### PR TITLE
docs: Agent task case study — reference context validation

### DIFF
--- a/mts/docs/agent-task-case-study.md
+++ b/mts/docs/agent-task-case-study.md
@@ -1,0 +1,139 @@
+# Case Study: How Reference Context Catches Domain-Specific Errors
+
+MTS's agent task evaluation uses an LLM-as-judge to score agent outputs. This case study documents a real experiment that exposed a critical gap in judge-only evaluation — and how reference context, human feedback calibration, and context preparation fix it.
+
+## The Setup
+
+We used MTS to evaluate LinkedIn posts about **RLMs (Recursive Language Models)** — a specific architecture for context folding via persistent Python REPLs and sub-LLM delegation, introduced by Alex Zhang (Oct 2025) and researched by Prime Intellect.
+
+The agent produced 3 well-written posts. Good voice, good structure, technically substantive. One problem: every post treated "RLM" as "Reasoning Language Models" — generic o1/o3-style chain-of-thought reasoning. The posts were confidently, completely wrong about the core topic.
+
+## The Experiment
+
+We ran each post through `LLMJudge.evaluate()` under three conditions:
+
+1. **No reference context** — vague task prompt ("Write about RLMs"), rubric checks voice/depth/accuracy/engagement
+2. **With reference context** — same prompt, but `reference_context` and `required_concepts` provided
+3. **With calibration** — reference context plus `calibration_examples` from human feedback
+
+### Results
+
+```
+Post                         No Context   + Ref Context   + Calibration
+----------------------------------------------------------------------
+Post 1: Agent Autonomy            0.85           0.20           0.15
+Post 2: Token Efficiency          0.85           0.20           0.25
+Post 3: Contrarian Take           0.85           0.10           0.10
+----------------------------------------------------------------------
+AVERAGE                           0.85           0.17           0.17
+```
+
+### Factual Accuracy Dimension
+
+```
+Post                         No Context   + Ref Context   + Calibration
+----------------------------------------------------------------------
+Post 1: Agent Autonomy            0.80           0.00           0.00
+Post 2: Token Efficiency          0.90           0.10           0.10
+Post 3: Contrarian Take           0.90           0.00           0.00
+----------------------------------------------------------------------
+AVERAGE                           0.87           0.03           0.03
+```
+
+## What Happened
+
+**Without reference context**, the judge scored 0.85 average. It called the posts "strong" with "solid understanding." The judge had no domain knowledge to contradict the agent's confident misuse of the term — the posts *sounded* right.
+
+**With reference context**, scores dropped to 0.17. The judge immediately identified the fundamental error: the posts describe generic reasoning models, not Recursive Language Models. Factual accuracy went from 0.87 to 0.03.
+
+**With calibration examples**, scores were nearly identical to reference-only (0.17). This makes sense for a binary error (wrong definition). Calibration adds more value for subtler quality distinctions where the "right" answer isn't black-and-white.
+
+## Why This Matters
+
+LLM judges are good at evaluating style, structure, and general coherence. They are **bad at catching domain-specific factual errors** unless given ground truth to evaluate against.
+
+This isn't a niche problem. Any task where:
+- The agent writes about a specific technology, company, or concept
+- Domain knowledge is required to distinguish correct from plausible-sounding-but-wrong
+- The judge LLM might not have up-to-date information
+
+...will hit this failure mode without reference context.
+
+## Features Used
+
+### Reference Context (`AgentTaskSpec.reference_context`)
+
+Authoritative domain knowledge injected into the judge prompt. When present, `LLMJudge` adds a mandatory `factual_accuracy` dimension and instructs the judge to score against the reference.
+
+```python
+spec = AgentTaskSpec(
+    task_prompt="Write about RLMs...",
+    judge_rubric="Evaluate accuracy, voice, depth, engagement",
+    reference_context="RLM = Recursive Language Model. A context folding architecture...",
+    required_concepts=[
+        "Context folding (not chain-of-thought)",
+        "Persistent Python REPL",
+        "Sub-LLM delegation",
+    ],
+)
+```
+
+### Calibration Examples (`LLMJudge.evaluate(calibration_examples=...)`)
+
+Human-scored examples injected into the judge prompt. Teaches the judge what score levels mean in practice.
+
+```python
+result = judge.evaluate(
+    task_prompt, agent_output,
+    reference_context=spec.reference_context,
+    required_concepts=spec.required_concepts,
+    calibration_examples=[
+        {
+            "human_score": 0.15,
+            "human_notes": "Wrong definition of RLM. Treats it as reasoning models.",
+            "agent_output": "Reasoning Language Models change the mechanics...",
+        },
+        {
+            "human_score": 0.85,
+            "human_notes": "Accurate. Describes context folding and sub-LLM delegation.",
+            "agent_output": "The breakthrough in RLMs isn't reasoning — it's context management...",
+        },
+    ],
+)
+```
+
+### Context Preparation (`AgentTaskInterface.prepare_context()`)
+
+Tasks can define a preparation stage that runs before generation. This is where research, document loading, and context validation happen — ensuring the agent has accurate information before it writes.
+
+```python
+class MyTask(AgentTaskInterface):
+    def prepare_context(self, state: dict) -> dict:
+        state["reference_context"] = load_reference_docs()
+        state["sources"] = fetch_source_urls()
+        return state
+
+    def validate_context(self, state: dict) -> list[str]:
+        errors = []
+        if "reference_context" not in state:
+            errors.append("missing reference context")
+        return errors
+```
+
+## Key Takeaway
+
+If your agent task requires domain knowledge, **always provide reference context**. The judge cannot evaluate what it doesn't know. A 0.68-point scoring swing on the same content — from "great" to "fundamentally wrong" — demonstrates that style-only evaluation is insufficient for factual tasks.
+
+## Reproducing This Experiment
+
+The experiment scripts are in the repo root:
+
+- `rlm_experiment.py` — detailed task prompt (judge has hints)
+- `rlm_experiment_v2.py` — vague task prompt (fair baseline, starker results)
+
+Run with:
+```bash
+ANTHROPIC_API_KEY=sk-... mts/.venv/bin/python rlm_experiment_v2.py
+```
+
+Results are saved to `content/research/rlm-experiment-v2-results.json`.

--- a/rlm_experiment.py
+++ b/rlm_experiment.py
@@ -1,0 +1,240 @@
+"""RLM Experiment: Before/After validation of reference context + calibration features.
+
+Runs the LLMJudge on the 3 baseline RLM posts:
+1. WITHOUT reference context (simulates old behavior)
+2. WITH reference context + required concepts (new behavior)
+3. WITH reference context + calibration examples (full new behavior)
+
+Shows whether the judge catches the fundamental factual error:
+posts treat "RLM" as generic reasoning models, when RLM actually means
+Recursive Language Models (context folding via sub-LLM delegation).
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, "mts/src")
+
+from mts.execution.judge import LLMJudge
+
+# --- Config ---
+import anthropic
+
+client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+
+
+def llm_fn(system: str, user: str) -> str:
+    response = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=2000,
+        system=system,
+        messages=[{"role": "user", "content": user}],
+    )
+    return response.content[0].text
+
+
+# --- Posts ---
+POSTS = {
+    "Post 1: Agent Autonomy": """The reason most AI agents fail isn't intelligence — it's brittleness.
+
+Give a standard LLM-based agent a multi-step task and watch what happens. It generates a plan, executes it linearly, and the moment something unexpected occurs, it either hallucinates a recovery or stalls. There's no real feedback loop. No course correction. Just token prediction on rails.
+
+Reasoning Language Models change the mechanics here in a way that matters. By training with reinforcement learning on iterative reasoning chains, RLMs don't just produce answers — they evaluate, backtrack, and refine. That's not a philosophical distinction. It's an architectural one.
+
+What this means practically: agents built on RLMs can attempt a subtask, assess whether the result actually satisfies the goal, and try a different approach if it doesn't. That loop — act, evaluate, revise — is the difference between an agent that can handle a 3-step workflow and one that can handle a 30-step workflow without a human checking every intermediate output.
+
+We've been building agent systems at Grey Haven for clients in industries where the tasks aren't neat and predictable. Insurance workflows. Manufacturing diagnostics. The kind of work where edge cases are the norm, not the exception. In those environments, an agent that can reason about its own failures is worth ten that can't.
+
+The real shift isn't "smarter AI." It's AI that degrades gracefully instead of catastrophically. That's what makes agents actually deployable.""",
+
+    "Post 2: Token Efficiency": """Here's a cost problem nobody talks about enough: most production AI systems burn tokens on retries.
+
+Your agent calls an LLM, gets a mediocre result, runs a validation check, fails, and calls the LLM again with a longer prompt that includes the failed attempt plus correction instructions. Repeat. Each retry doubles your token spend and latency. We've seen pipelines where 60% of total token cost comes from retry loops and prompt stuffing to compensate for first-pass failures.
+
+RLMs offer a different path. Because the reasoning and self-correction happen inside the model's own inference process, you're paying for one (longer) generation instead of three or four round trips. The model thinks harder on one pass rather than thinking cheaply multiple times.
+
+The math is counterintuitive. RLM inference costs more per call — sometimes 3-5x the tokens of a standard completion. But if that single call replaces a chain of prompt → validate → re-prompt → validate → re-prompt, total cost drops. In our testing, tasks that previously required an average of 2.8 LLM calls to reach acceptable quality needed 1.1 calls with a reasoning model. Net token spend fell roughly 40%.
+
+This matters most for high-volume production workloads where you're already paying for orchestration layers, validation logic, and retry infrastructure. RLMs don't just save tokens — they simplify your architecture. Less code to maintain, fewer failure modes, faster end-to-end latency.
+
+The cheapest token is the one you never have to send.""",
+
+    "Post 3: Contrarian Take": """Most of the conversation around Reasoning Language Models assumes the bottleneck in AI is reasoning quality. I think that's wrong.
+
+The bottleneck is knowing *when* to reason.
+
+RLMs are genuinely better at complex multi-step problems. No argument there. But the vast majority of real-world AI tasks don't need extended reasoning. They need fast pattern matching, reliable formatting, and consistent execution. Deploying a reasoning model to extract invoice line items is like hiring a PhD mathematician to do your bookkeeping. It'll work, but you're paying for capability you don't need, and it'll be slower.
+
+The harder problem — the one nobody's building good tooling for yet — is routing. Deciding at inference time whether a given input needs 10 tokens of thought or 10,000. The models themselves aren't good at this. They'll happily burn through a long chain-of-thought on a question that deserved a one-line answer.
+
+What I'd actually watch for isn't better reasoning models. It's better orchestration that knows when to invoke them. A system that routes simple extractions to a fast, cheap model and escalates genuine ambiguity to an RLM — that's where the production value is.
+
+The teams that will get the most out of RLMs are the ones that use them sparingly. Not as a default, but as an escalation path. The rest will end up with slower, more expensive systems and a vague sense that reasoning models were overhyped.
+
+They weren't. They were just over-applied.""",
+}
+
+TASK_PROMPT = (
+    "Write a LinkedIn post about Recursive Language Models (RLMs) for a technical "
+    "but accessible audience. The post should demonstrate understanding of what RLMs "
+    "actually are — specifically the context folding architecture using persistent "
+    "Python REPLs and sub-LLM delegation, as introduced by Alex Zhang (Oct 2025) "
+    "and researched by Prime Intellect."
+)
+
+RUBRIC = (
+    "Evaluate on: (1) Factual accuracy — does the post correctly describe what RLMs are? "
+    "(2) Voice — direct, opinionated, no hype language. "
+    "(3) Technical depth — accessible but substantive. "
+    "(4) Engagement — would this perform well on LinkedIn?"
+)
+
+REFERENCE_CONTEXT = """RLM (Recursive Language Model) is a specific architecture for context folding — recursively compressing and reshaping an agent's own context to prevent context rot and keep ultra-long, multi-step rollouts cheap and reliable.
+
+Key facts:
+- RLM is NOT "Reasoning Language Models" or generic chain-of-thought reasoning
+- RLM allows an LLM to use a persistent Python REPL to inspect and transform its input data
+- The model calls sub-LLMs (fresh instances of itself) from within the REPL
+- Sub-LLM calls can be parallelized via llm_batch
+- The RLM answers via a Python variable (answer["content"] + answer["ready"])
+- Introduced by Alex Zhang, October 2025
+- Paper: https://arxiv.org/abs/2512.24601
+- Prime Intellect is a major research backer
+- The key innovation is the model managing its own context window as a first-class capability
+- It's about context management and recursive delegation, not just "reasoning harder"
+"""
+
+REQUIRED_CONCEPTS = [
+    "Context folding (not just chain-of-thought reasoning)",
+    "Persistent Python REPL for context manipulation",
+    "Sub-LLM delegation",
+    "Alex Zhang / Prime Intellect origin",
+    "RLM = Recursive Language Model (not Reasoning Language Model)",
+]
+
+CALIBRATION_EXAMPLES = [
+    {
+        "human_score": 0.15,
+        "human_notes": (
+            "Fundamentally misunderstands the topic. Treats 'RLM' as 'Reasoning Language Models' "
+            "(generic o1/o3-style chain-of-thought) when it actually means 'Recursive Language Models' — "
+            "a specific context folding architecture using Python REPLs and sub-LLM delegation. "
+            "Every claim in the post is about reasoning models in general, not RLMs specifically. "
+            "Good voice and structure, but the content is about the wrong thing entirely."
+        ),
+        "agent_output": "Reasoning Language Models change the mechanics here...",
+    },
+    {
+        "human_score": 0.85,
+        "human_notes": (
+            "Accurately describes RLM as a context folding architecture. Mentions Python REPL, "
+            "sub-LLM delegation, and Prime Intellect. Good voice — direct, no hype. "
+            "Could be more specific about the paper and experimental results."
+        ),
+        "agent_output": "The real breakthrough in RLMs isn't reasoning — it's context management...",
+    },
+]
+
+
+def run_experiment():
+    print("=" * 80)
+    print("RLM EXPERIMENT: Before/After Validation")
+    print("=" * 80)
+    print()
+
+    results = {}
+
+    for post_name, post_text in POSTS.items():
+        print(f"\n{'=' * 60}")
+        print(f"  {post_name}")
+        print(f"{'=' * 60}")
+
+        # --- Run 1: No reference context (old behavior) ---
+        print("\n  [1/3] Judge WITHOUT reference context...")
+        judge_no_ctx = LLMJudge(
+            model="claude-sonnet-4-20250514",
+            rubric=RUBRIC,
+            llm_fn=llm_fn,
+        )
+        result_no_ctx = judge_no_ctx.evaluate(TASK_PROMPT, post_text)
+        print(f"        Score: {result_no_ctx.score:.2f}")
+        print(f"        Dimensions: {result_no_ctx.dimension_scores}")
+        print(f"        Reasoning: {result_no_ctx.reasoning[:200]}...")
+
+        # --- Run 2: With reference context + required concepts ---
+        print("\n  [2/3] Judge WITH reference context...")
+        judge_with_ctx = LLMJudge(
+            model="claude-sonnet-4-20250514",
+            rubric=RUBRIC,
+            llm_fn=llm_fn,
+        )
+        result_with_ctx = judge_with_ctx.evaluate(
+            TASK_PROMPT,
+            post_text,
+            reference_context=REFERENCE_CONTEXT,
+            required_concepts=REQUIRED_CONCEPTS,
+        )
+        print(f"        Score: {result_with_ctx.score:.2f}")
+        print(f"        Dimensions: {result_with_ctx.dimension_scores}")
+        print(f"        Reasoning: {result_with_ctx.reasoning[:200]}...")
+
+        # --- Run 3: With reference context + calibration examples ---
+        print("\n  [3/3] Judge WITH reference context + calibration...")
+        judge_full = LLMJudge(
+            model="claude-sonnet-4-20250514",
+            rubric=RUBRIC,
+            llm_fn=llm_fn,
+        )
+        result_full = judge_full.evaluate(
+            TASK_PROMPT,
+            post_text,
+            reference_context=REFERENCE_CONTEXT,
+            required_concepts=REQUIRED_CONCEPTS,
+            calibration_examples=CALIBRATION_EXAMPLES,
+        )
+        print(f"        Score: {result_full.score:.2f}")
+        print(f"        Dimensions: {result_full.dimension_scores}")
+        print(f"        Reasoning: {result_full.reasoning[:200]}...")
+
+        results[post_name] = {
+            "no_context": {
+                "score": result_no_ctx.score,
+                "dimensions": result_no_ctx.dimension_scores,
+                "reasoning": result_no_ctx.reasoning,
+            },
+            "with_context": {
+                "score": result_with_ctx.score,
+                "dimensions": result_with_ctx.dimension_scores,
+                "reasoning": result_with_ctx.reasoning,
+            },
+            "full": {
+                "score": result_full.score,
+                "dimensions": result_full.dimension_scores,
+                "reasoning": result_full.reasoning,
+            },
+        }
+
+    # --- Summary ---
+    print("\n\n" + "=" * 80)
+    print("SUMMARY")
+    print("=" * 80)
+    print(f"\n{'Post':<30} {'No Context':>12} {'+ Ref Context':>14} {'+ Calibration':>14} {'Delta':>8}")
+    print("-" * 80)
+    for post_name, r in results.items():
+        no_ctx = r["no_context"]["score"]
+        with_ctx = r["with_context"]["score"]
+        full = r["full"]["score"]
+        delta = no_ctx - full
+        print(f"{post_name:<30} {no_ctx:>12.2f} {with_ctx:>14.2f} {full:>14.2f} {delta:>+8.2f}")
+
+    # Save results
+    with open("/workspace/content/research/rlm-experiment-results.json", "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nFull results saved to /workspace/content/research/rlm-experiment-results.json")
+
+    return results
+
+
+if __name__ == "__main__":
+    run_experiment()

--- a/rlm_experiment_v2.py
+++ b/rlm_experiment_v2.py
@@ -1,0 +1,201 @@
+"""RLM Experiment v2: Vague prompt to show starker before/after.
+
+The first run used a detailed prompt that mentioned "context folding" — giving
+the judge enough signal even without reference context. This run uses a vague
+prompt ("Write about RLMs") so the judge has NO domain knowledge without the
+reference context feature.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, "mts/src")
+
+from mts.execution.judge import LLMJudge
+
+import anthropic
+
+client = anthropic.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+
+
+def llm_fn(system: str, user: str) -> str:
+    response = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=2000,
+        system=system,
+        messages=[{"role": "user", "content": user}],
+    )
+    return response.content[0].text
+
+
+POSTS = {
+    "Post 1: Agent Autonomy": """The reason most AI agents fail isn't intelligence — it's brittleness.
+
+Give a standard LLM-based agent a multi-step task and watch what happens. It generates a plan, executes it linearly, and the moment something unexpected occurs, it either hallucinates a recovery or stalls. There's no real feedback loop. No course correction. Just token prediction on rails.
+
+Reasoning Language Models change the mechanics here in a way that matters. By training with reinforcement learning on iterative reasoning chains, RLMs don't just produce answers — they evaluate, backtrack, and refine. That's not a philosophical distinction. It's an architectural one.
+
+What this means practically: agents built on RLMs can attempt a subtask, assess whether the result actually satisfies the goal, and try a different approach if it doesn't. That loop — act, evaluate, revise — is the difference between an agent that can handle a 3-step workflow and one that can handle a 30-step workflow without a human checking every intermediate output.
+
+We've been building agent systems at Grey Haven for clients in industries where the tasks aren't neat and predictable. Insurance workflows. Manufacturing diagnostics. The kind of work where edge cases are the norm, not the exception. In those environments, an agent that can reason about its own failures is worth ten that can't.
+
+The real shift isn't "smarter AI." It's AI that degrades gracefully instead of catastrophically. That's what makes agents actually deployable.""",
+
+    "Post 2: Token Efficiency": """Here's a cost problem nobody talks about enough: most production AI systems burn tokens on retries.
+
+Your agent calls an LLM, gets a mediocre result, runs a validation check, fails, and calls the LLM again with a longer prompt that includes the failed attempt plus correction instructions. Repeat. Each retry doubles your token spend and latency. We've seen pipelines where 60% of total token cost comes from retry loops and prompt stuffing to compensate for first-pass failures.
+
+RLMs offer a different path. Because the reasoning and self-correction happen inside the model's own inference process, you're paying for one (longer) generation instead of three or four round trips. The model thinks harder on one pass rather than thinking cheaply multiple times.
+
+The math is counterintuitive. RLM inference costs more per call — sometimes 3-5x the tokens of a standard completion. But if that single call replaces a chain of prompt → validate → re-prompt → validate → re-prompt, total cost drops. In our testing, tasks that previously required an average of 2.8 LLM calls to reach acceptable quality needed 1.1 calls with a reasoning model. Net token spend fell roughly 40%.
+
+This matters most for high-volume production workloads where you're already paying for orchestration layers, validation logic, and retry infrastructure. RLMs don't just save tokens — they simplify your architecture. Less code to maintain, fewer failure modes, faster end-to-end latency.
+
+The cheapest token is the one you never have to send.""",
+
+    "Post 3: Contrarian Take": """Most of the conversation around Reasoning Language Models assumes the bottleneck in AI is reasoning quality. I think that's wrong.
+
+The bottleneck is knowing *when* to reason.
+
+RLMs are genuinely better at complex multi-step problems. No argument there. But the vast majority of real-world AI tasks don't need extended reasoning. They need fast pattern matching, reliable formatting, and consistent execution. Deploying a reasoning model to extract invoice line items is like hiring a PhD mathematician to do your bookkeeping. It'll work, but you're paying for capability you don't need, and it'll be slower.
+
+The harder problem — the one nobody's building good tooling for yet — is routing. Deciding at inference time whether a given input needs 10 tokens of thought or 10,000. The models themselves aren't good at this. They'll happily burn through a long chain-of-thought on a question that deserved a one-line answer.
+
+What I'd actually watch for isn't better reasoning models. It's better orchestration that knows when to invoke them. A system that routes simple extractions to a fast, cheap model and escalates genuine ambiguity to an RLM — that's where the production value is.
+
+The teams that will get the most out of RLMs are the ones that use them sparingly. Not as a default, but as an escalation path. The rest will end up with slower, more expensive systems and a vague sense that reasoning models were overhyped.
+
+They weren't. They were just over-applied.""",
+}
+
+# VAGUE prompt — no hints about what RLM actually means
+VAGUE_PROMPT = (
+    "Write a LinkedIn post about RLMs for a technical but accessible audience. "
+    "The post should demonstrate genuine understanding of the topic and provide "
+    "useful insight for practitioners."
+)
+
+VAGUE_RUBRIC = (
+    "Evaluate on: (1) Factual accuracy — does the post correctly describe the topic? "
+    "(2) Voice — direct, opinionated, no hype language. "
+    "(3) Technical depth — accessible but substantive. "
+    "(4) Engagement — would this perform well on LinkedIn?"
+)
+
+REFERENCE_CONTEXT = """RLM (Recursive Language Model) is a specific architecture for context folding — recursively compressing and reshaping an agent's own context to prevent context rot and keep ultra-long, multi-step rollouts cheap and reliable.
+
+Key facts:
+- RLM is NOT "Reasoning Language Models" or generic chain-of-thought reasoning
+- RLM allows an LLM to use a persistent Python REPL to inspect and transform its input data
+- The model calls sub-LLMs (fresh instances of itself) from within the REPL
+- Sub-LLM calls can be parallelized via llm_batch
+- The RLM answers via a Python variable (answer["content"] + answer["ready"])
+- Introduced by Alex Zhang, October 2025
+- Paper: https://arxiv.org/abs/2512.24601
+- Prime Intellect is a major research backer
+- The key innovation is the model managing its own context window as a first-class capability
+- It's about context management and recursive delegation, not just "reasoning harder"
+"""
+
+REQUIRED_CONCEPTS = [
+    "Context folding (not just chain-of-thought reasoning)",
+    "Persistent Python REPL for context manipulation",
+    "Sub-LLM delegation",
+    "Alex Zhang / Prime Intellect origin",
+    "RLM = Recursive Language Model (not Reasoning Language Model)",
+]
+
+CALIBRATION_EXAMPLES = [
+    {
+        "human_score": 0.15,
+        "human_notes": (
+            "Fundamentally misunderstands the topic. Treats 'RLM' as 'Reasoning Language Models' "
+            "(generic o1/o3-style chain-of-thought) when it actually means 'Recursive Language Models' — "
+            "a specific context folding architecture using Python REPLs and sub-LLM delegation. "
+            "Good voice and structure, but the content is about the wrong thing entirely."
+        ),
+        "agent_output": "Reasoning Language Models change the mechanics here...",
+    },
+    {
+        "human_score": 0.85,
+        "human_notes": (
+            "Accurately describes RLM as a context folding architecture. Mentions Python REPL, "
+            "sub-LLM delegation, and Prime Intellect. Good voice — direct, no hype."
+        ),
+        "agent_output": "The real breakthrough in RLMs isn't reasoning — it's context management...",
+    },
+]
+
+
+def run_experiment():
+    print("=" * 80)
+    print("RLM EXPERIMENT v2: Vague Prompt (fair baseline)")
+    print("=" * 80)
+
+    results = {}
+
+    for post_name, post_text in POSTS.items():
+        print(f"\n{'=' * 60}")
+        print(f"  {post_name}")
+        print(f"{'=' * 60}")
+
+        # --- Run 1: No reference context, vague prompt ---
+        print("\n  [1/3] Vague prompt, NO reference context...")
+        judge1 = LLMJudge(model="claude-sonnet-4-20250514", rubric=VAGUE_RUBRIC, llm_fn=llm_fn)
+        r1 = judge1.evaluate(VAGUE_PROMPT, post_text)
+        print(f"        Score: {r1.score:.2f}  |  Dims: {r1.dimension_scores}")
+        print(f"        Reasoning: {r1.reasoning[:250]}...")
+
+        # --- Run 2: Vague prompt + reference context ---
+        print("\n  [2/3] Vague prompt + reference context + required concepts...")
+        judge2 = LLMJudge(model="claude-sonnet-4-20250514", rubric=VAGUE_RUBRIC, llm_fn=llm_fn)
+        r2 = judge2.evaluate(
+            VAGUE_PROMPT, post_text,
+            reference_context=REFERENCE_CONTEXT,
+            required_concepts=REQUIRED_CONCEPTS,
+        )
+        print(f"        Score: {r2.score:.2f}  |  Dims: {r2.dimension_scores}")
+        print(f"        Reasoning: {r2.reasoning[:250]}...")
+
+        # --- Run 3: Full stack ---
+        print("\n  [3/3] Vague prompt + reference context + calibration...")
+        judge3 = LLMJudge(model="claude-sonnet-4-20250514", rubric=VAGUE_RUBRIC, llm_fn=llm_fn)
+        r3 = judge3.evaluate(
+            VAGUE_PROMPT, post_text,
+            reference_context=REFERENCE_CONTEXT,
+            required_concepts=REQUIRED_CONCEPTS,
+            calibration_examples=CALIBRATION_EXAMPLES,
+        )
+        print(f"        Score: {r3.score:.2f}  |  Dims: {r3.dimension_scores}")
+        print(f"        Reasoning: {r3.reasoning[:250]}...")
+
+        results[post_name] = {
+            "no_context": {"score": r1.score, "dimensions": r1.dimension_scores, "reasoning": r1.reasoning},
+            "with_context": {"score": r2.score, "dimensions": r2.dimension_scores, "reasoning": r2.reasoning},
+            "full": {"score": r3.score, "dimensions": r3.dimension_scores, "reasoning": r3.reasoning},
+        }
+
+    # Summary
+    print("\n\n" + "=" * 80)
+    print("SUMMARY — Vague Prompt Experiment")
+    print("=" * 80)
+    print(f"\n{'Post':<30} {'No Context':>12} {'+ Ref Ctx':>12} {'+ Calib':>12} {'Delta':>8}")
+    print("-" * 76)
+    for name, r in results.items():
+        s1, s2, s3 = r["no_context"]["score"], r["with_context"]["score"], r["full"]["score"]
+        print(f"{name:<30} {s1:>12.2f} {s2:>12.2f} {s3:>12.2f} {s1 - s3:>+8.2f}")
+
+    avg_no = sum(r["no_context"]["score"] for r in results.values()) / 3
+    avg_ctx = sum(r["with_context"]["score"] for r in results.values()) / 3
+    avg_full = sum(r["full"]["score"] for r in results.values()) / 3
+    print("-" * 76)
+    print(f"{'AVERAGE':<30} {avg_no:>12.2f} {avg_ctx:>12.2f} {avg_full:>12.2f} {avg_no - avg_full:>+8.2f}")
+
+    with open("/workspace/content/research/rlm-experiment-v2-results.json", "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nFull results saved to /workspace/content/research/rlm-experiment-v2-results.json")
+
+
+if __name__ == "__main__":
+    run_experiment()


### PR DESCRIPTION
Adds documentation for the RLM experiment that validated Gaps 1-4.

**The case study shows**: without reference context, the LLM judge scored factually wrong posts at 0.85 ('strong, demonstrates solid understanding'). With reference context, scores dropped to 0.17 — a 0.68-point swing on identical content.

**Files:**
- `mts/docs/agent-task-case-study.md` — full writeup with results tables, code examples, and key takeaways
- `rlm_experiment.py` — experiment script (detailed prompt)
- `rlm_experiment_v2.py` — experiment script (vague prompt, starker results)

Documents usage of `reference_context`, `required_concepts`, `calibration_examples`, and `prepare_context()`.