### PR TITLE
feat: RetryProvider with exponential backoff (MTS-15)

### DIFF
--- a/mts/src/mts/providers/__init__.py
+++ b/mts/src/mts/providers/__init__.py
@@ -5,10 +5,12 @@ Supports Anthropic, OpenAI, and any OpenAI-compatible endpoint (vLLM, Ollama, et
 
 from mts.providers.base import LLMProvider, ProviderError
 from mts.providers.registry import create_provider, get_provider
+from mts.providers.retry import RetryProvider
 
 __all__ = [
     "LLMProvider",
     "ProviderError",
+    "RetryProvider",
     "get_provider",
     "create_provider",
 ]

--- a/mts/src/mts/providers/retry.py
+++ b/mts/src/mts/providers/retry.py
@@ -1,0 +1,113 @@
+"""Retry wrapper for LLM providers with exponential backoff.
+
+Handles transient errors (rate limits, timeouts, server errors)
+by retrying with configurable backoff. Wraps any LLMProvider.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from mts.providers.base import CompletionResult, LLMProvider, ProviderError
+
+logger = logging.getLogger(__name__)
+
+
+# Exceptions considered transient and worth retrying.
+_TRANSIENT_SUBSTRINGS = frozenset({
+    "rate limit",
+    "rate_limit",
+    "429",
+    "timeout",
+    "timed out",
+    "server error",
+    "500",
+    "502",
+    "503",
+    "504",
+    "overloaded",
+    "capacity",
+    "connection",
+    "temporarily unavailable",
+})
+
+
+def _is_transient(error: Exception) -> bool:
+    """Check if an error looks transient based on message content."""
+    msg = str(error).lower()
+    return any(sub in msg for sub in _TRANSIENT_SUBSTRINGS)
+
+
+class RetryProvider(LLMProvider):
+    """Wraps an LLMProvider with retry logic and exponential backoff.
+
+    Args:
+        provider: The underlying LLM provider to wrap.
+        max_retries: Maximum number of retry attempts (0 = no retries).
+        base_delay: Initial delay in seconds before first retry.
+        max_delay: Maximum delay cap in seconds.
+        backoff_factor: Multiplier applied to delay after each retry.
+        retry_all: If True, retry all ProviderErrors (not just transient).
+    """
+
+    def __init__(
+        self,
+        provider: LLMProvider,
+        max_retries: int = 3,
+        base_delay: float = 1.0,
+        max_delay: float = 60.0,
+        backoff_factor: float = 2.0,
+        retry_all: bool = False,
+    ) -> None:
+        self._provider = provider
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.backoff_factor = backoff_factor
+        self.retry_all = retry_all
+
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+    ) -> CompletionResult:
+        """Call the underlying provider with retry on transient errors."""
+        last_error: Exception | None = None
+        delay = self.base_delay
+
+        for attempt in range(1 + self.max_retries):
+            try:
+                return self._provider.complete(
+                    system_prompt, user_prompt,
+                    model=model, temperature=temperature, max_tokens=max_tokens,
+                )
+            except ProviderError as e:
+                last_error = e
+                if attempt == self.max_retries:
+                    break
+                if not self.retry_all and not _is_transient(e):
+                    logger.warning(
+                        "non-transient provider error (attempt %d), not retrying: %s",
+                        attempt + 1, e,
+                    )
+                    break
+
+                logger.warning(
+                    "transient provider error (attempt %d/%d), retrying in %.1fs: %s",
+                    attempt + 1, 1 + self.max_retries, delay, e,
+                )
+                time.sleep(delay)
+                delay = min(delay * self.backoff_factor, self.max_delay)
+
+        raise last_error  # type: ignore[misc]
+
+    def default_model(self) -> str:
+        return self._provider.default_model()
+
+    @property
+    def name(self) -> str:
+        return f"Retry({self._provider.name})"

--- a/mts/tests/test_retry_provider.py
+++ b/mts/tests/test_retry_provider.py
@@ -1,0 +1,157 @@
+"""Tests for RetryProvider — provider error recovery (MTS-15)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from mts.providers.base import CompletionResult, LLMProvider, ProviderError
+from mts.providers.retry import RetryProvider, _is_transient
+
+
+class FakeProvider(LLMProvider):
+    """Provider that fails N times then succeeds."""
+
+    def __init__(self, fail_count: int = 0, error_msg: str = "rate limit exceeded"):
+        self._fail_count = fail_count
+        self._error_msg = error_msg
+        self.call_count = 0
+
+    def complete(self, system_prompt, user_prompt, **kwargs) -> CompletionResult:
+        self.call_count += 1
+        if self.call_count <= self._fail_count:
+            raise ProviderError(self._error_msg)
+        return CompletionResult(text="success", model="fake")
+
+    def default_model(self) -> str:
+        return "fake-model"
+
+
+class TestIsTransient:
+    def test_rate_limit(self):
+        assert _is_transient(ProviderError("Rate limit exceeded"))
+
+    def test_429(self):
+        assert _is_transient(ProviderError("HTTP 429 Too Many Requests"))
+
+    def test_timeout(self):
+        assert _is_transient(ProviderError("Request timed out"))
+
+    def test_server_error_500(self):
+        assert _is_transient(ProviderError("500 Internal Server Error"))
+
+    def test_502(self):
+        assert _is_transient(ProviderError("502 Bad Gateway"))
+
+    def test_503(self):
+        assert _is_transient(ProviderError("503 Service Temporarily Unavailable"))
+
+    def test_overloaded(self):
+        assert _is_transient(ProviderError("API is overloaded"))
+
+    def test_connection(self):
+        assert _is_transient(ProviderError("Connection reset by peer"))
+
+    def test_not_transient(self):
+        assert not _is_transient(ProviderError("Invalid API key"))
+
+    def test_not_transient_auth(self):
+        assert not _is_transient(ProviderError("Authentication failed"))
+
+
+class TestRetryProvider:
+    def test_success_no_retry(self):
+        inner = FakeProvider(fail_count=0)
+        provider = RetryProvider(inner, max_retries=3, base_delay=0.001)
+        result = provider.complete("sys", "user")
+        assert result.text == "success"
+        assert inner.call_count == 1
+
+    def test_retry_on_transient_error(self):
+        inner = FakeProvider(fail_count=2, error_msg="rate limit exceeded")
+        provider = RetryProvider(inner, max_retries=3, base_delay=0.001)
+        result = provider.complete("sys", "user")
+        assert result.text == "success"
+        assert inner.call_count == 3  # 2 failures + 1 success
+
+    def test_exhaust_retries(self):
+        inner = FakeProvider(fail_count=10, error_msg="rate limit exceeded")
+        provider = RetryProvider(inner, max_retries=2, base_delay=0.001)
+        with pytest.raises(ProviderError, match="rate limit"):
+            provider.complete("sys", "user")
+        assert inner.call_count == 3  # 1 initial + 2 retries
+
+    def test_no_retry_on_non_transient(self):
+        inner = FakeProvider(fail_count=5, error_msg="Invalid API key")
+        provider = RetryProvider(inner, max_retries=3, base_delay=0.001)
+        with pytest.raises(ProviderError, match="Invalid API key"):
+            provider.complete("sys", "user")
+        assert inner.call_count == 1  # No retries
+
+    def test_retry_all_flag(self):
+        inner = FakeProvider(fail_count=2, error_msg="Invalid API key")
+        provider = RetryProvider(inner, max_retries=3, base_delay=0.001, retry_all=True)
+        result = provider.complete("sys", "user")
+        assert result.text == "success"
+        assert inner.call_count == 3
+
+    def test_backoff_increases_delay(self):
+        inner = FakeProvider(fail_count=3, error_msg="timeout")
+        provider = RetryProvider(
+            inner, max_retries=3, base_delay=0.01,
+            backoff_factor=2.0, max_delay=10.0,
+        )
+        start = time.monotonic()
+        result = provider.complete("sys", "user")
+        elapsed = time.monotonic() - start
+        assert result.text == "success"
+        # base=0.01, then 0.02, then 0.04 = 0.07s minimum
+        assert elapsed >= 0.05
+
+    def test_max_delay_cap(self):
+        inner = FakeProvider(fail_count=3, error_msg="timeout")
+        provider = RetryProvider(
+            inner, max_retries=3, base_delay=0.01,
+            backoff_factor=100.0, max_delay=0.02,
+        )
+        start = time.monotonic()
+        provider.complete("sys", "user")
+        elapsed = time.monotonic() - start
+        # Should be capped: 0.01 + 0.02 + 0.02 = 0.05s max
+        assert elapsed < 0.2
+
+    def test_zero_retries(self):
+        inner = FakeProvider(fail_count=1, error_msg="timeout")
+        provider = RetryProvider(inner, max_retries=0, base_delay=0.001)
+        with pytest.raises(ProviderError):
+            provider.complete("sys", "user")
+        assert inner.call_count == 1
+
+    def test_default_model_delegates(self):
+        inner = FakeProvider()
+        provider = RetryProvider(inner)
+        assert provider.default_model() == "fake-model"
+
+    def test_name_wraps(self):
+        inner = FakeProvider()
+        provider = RetryProvider(inner)
+        assert "Retry" in provider.name
+        assert "FakeProvider" in provider.name
+
+    def test_passes_kwargs(self):
+        """Ensure model, temperature, max_tokens are forwarded."""
+        calls = []
+
+        class TrackingProvider(LLMProvider):
+            def complete(self, system_prompt, user_prompt, **kwargs):
+                calls.append(kwargs)
+                return CompletionResult(text="ok", model="t")
+            def default_model(self):
+                return "t"
+
+        provider = RetryProvider(TrackingProvider(), max_retries=0)
+        provider.complete("s", "u", model="custom", temperature=0.5, max_tokens=100)
+        assert calls[0]["model"] == "custom"
+        assert calls[0]["temperature"] == 0.5
+        assert calls[0]["max_tokens"] == 100


### PR DESCRIPTION
Closes MTS-15.

## Problem
Provider errors (rate limits, timeouts, server errors) during improvement loops or task runs cause immediate failure with no recovery.

## Solution
`RetryProvider` — a wrapper around any `LLMProvider` that adds retry with exponential backoff:

```python
from mts.providers import RetryProvider, get_provider

inner = get_provider(settings)
provider = RetryProvider(inner, max_retries=3, base_delay=1.0)
```

| Behavior | Detail |
|----------|--------|
| Transient errors | Rate limits, timeouts, 5xx → retry with backoff |
| Non-transient errors | Auth failures, invalid key → fail immediately |
| Backoff | Exponential: base × factor^attempt, capped at max_delay |
| `retry_all=True` | Override to retry everything |
| Delegation | `default_model()`, `name` pass through to wrapped provider |

## Testing
21 new tests covering: transient detection (10 error types), retry logic, backoff timing, max_delay cap, zero retries, kwarg forwarding, delegation.