### PR TITLE
fix: Address TS audit findings

### DIFF
--- a/ts/src/execution/task-runner.ts
+++ b/ts/src/execution/task-runner.ts
@@ -4,6 +4,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { z } from "zod";
 import type {
   LLMProvider,
   AgentTaskInterface,
@@ -26,9 +27,22 @@ export interface TaskConfig {
   revisionPrompt?: string;
 }
 
+const TaskConfigSchema = z.object({
+  max_rounds: z.number().int().positive().optional(),
+  quality_threshold: z.number().min(0).max(1).optional(),
+  reference_context: z.string().optional(),
+  required_concepts: z.array(z.string()).optional(),
+  calibration_examples: z.array(z.record(z.unknown())).optional(),
+  initial_output: z.string().optional(),
+  rubric: z.string().optional(),
+  task_prompt: z.string().optional(),
+  revision_prompt: z.string().optional(),
+}).passthrough();
+
 function parseTaskConfig(json: string | null): TaskConfig {
   if (!json) return { maxRounds: 5, qualityThreshold: 0.9 };
-  const d = JSON.parse(json);
+  const raw = JSON.parse(json);
+  const d = TaskConfigSchema.parse(raw);
   return {
     maxRounds: d.max_rounds ?? 5,
     qualityThreshold: d.quality_threshold ?? 0.9,
@@ -232,7 +246,7 @@ export class TaskRunner {
         serializeResult(result),
       );
     } catch (err) {
-      const msg = err instanceof Error ? err.stack ?? err.message : String(err);
+      const msg = err instanceof Error ? err.message : String(err);
       this.store.failTask(task.id, msg);
     }
   }

--- a/ts/src/runtimes/claude-cli.ts
+++ b/ts/src/runtimes/claude-cli.ts
@@ -111,6 +111,11 @@ export class ClaudeCLIRuntime implements AgentRuntime {
       args.push("--json-schema", JSON.stringify(schema));
     }
     if (this.config.extraArgs) {
+      for (const arg of this.config.extraArgs) {
+        if (typeof arg !== "string") {
+          throw new Error(`extraArgs must be strings, got ${typeof arg}`);
+        }
+      }
       args.push(...this.config.extraArgs);
     }
 

--- a/ts/src/storage/index.ts
+++ b/ts/src/storage/index.ts
@@ -36,13 +36,27 @@ export class SQLiteStore {
   }
 
   migrate(migrationsDir: string): void {
+    this.db.exec(
+      `CREATE TABLE IF NOT EXISTS schema_version (
+         filename TEXT PRIMARY KEY,
+         applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+       )`,
+    );
+
+    const applied = new Set(
+      (this.db.prepare("SELECT filename FROM schema_version").all() as Array<{ filename: string }>)
+        .map(r => r.filename),
+    );
+
     const files = readdirSync(migrationsDir)
       .filter(f => f.endsWith(".sql"))
       .sort();
 
     for (const file of files) {
+      if (applied.has(file)) continue;
       const sql = readFileSync(join(migrationsDir, file), "utf8");
       this.db.exec(sql);
+      this.db.prepare("INSERT INTO schema_version(filename) VALUES (?)").run(file);
     }
   }
 

--- a/ts/tests/storage.test.ts
+++ b/ts/tests/storage.test.ts
@@ -91,4 +91,12 @@ describe("SQLiteStore", () => {
     expect(store.dequeueTask()!.id).toBe("now");
     expect(store.dequeueTask()).toBeNull();
   });
+
+  it("migrate is idempotent with version tracking", () => {
+    // Running migrate again should not throw (migrations already applied)
+    store.migrate(MIGRATIONS_DIR);
+    // Store still works
+    store.enqueueTask("t1", "s");
+    expect(store.dequeueTask()!.id).toBe("t1");
+  });
 });

--- a/ts/tests/task-runner.test.ts
+++ b/ts/tests/task-runner.test.ts
@@ -95,6 +95,19 @@ describe("TaskRunner", () => {
     expect(result).not.toBeNull();
     expect(result!.status).toBe("failed");
     expect(result!.error).toContain("API down");
+    // Verify no stack trace in error (only message stored)
+    expect(result!.error).not.toContain("\n    at ");
+  });
+
+  it("rejects invalid config via Zod validation", async () => {
+    const store = createStore();
+    const provider = makeMockProvider();
+    // max_rounds must be a positive integer, not a string
+    store.enqueueTask("bad", "test_spec", 0, { max_rounds: "not_a_number" });
+    const runner = new TaskRunner({ store, provider });
+    const result = await runner.runOnce();
+    expect(result!.status).toBe("failed");
+    expect(result!.error).toContain("Expected number");
   });
 });
 


### PR DESCRIPTION
Fixes all 4 non-blocking audit findings from PR #35 review:

1. **extraArgs validation** — Rejects non-string values in `ClaudeCLIConfig.extraArgs` at runtime
2. **Zod validation for parseTaskConfig** — `JSON.parse` output now validated through a Zod schema; malformed config fails fast with clear errors
3. **Migration version tracking** — New `schema_version` table tracks applied migrations; `migrate()` is now idempotent (safe to call multiple times)
4. **Stack trace sanitization** — Only `err.message` stored in DB error column, not full stack traces

**Tests:** 67 passed (+2 new — Zod rejection test, idempotent migration test)