### PR TITLE
feat: Skill export + agent task markdown rendering (TS)

### DIFF
--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -65,6 +65,10 @@ export {
   SPEC_END,
 } from "./scenarios/index.js";
 
+// Knowledge / Skill Export
+export { SkillPackage, exportAgentTaskSkill, cleanLessons } from "./knowledge/index.js";
+export type { SkillPackageData } from "./knowledge/index.js";
+
 // MCP
 export { createMcpServer, startServer } from "./mcp/server.js";
 export type { MtsServerOpts } from "./mcp/server.js";

--- a/ts/src/knowledge/index.ts
+++ b/ts/src/knowledge/index.ts
@@ -1,0 +1,2 @@
+export { SkillPackage, exportAgentTaskSkill, cleanLessons } from "./skill-package.js";
+export type { SkillPackageData } from "./skill-package.js";

--- a/ts/src/knowledge/skill-package.ts
+++ b/ts/src/knowledge/skill-package.ts
@@ -1,0 +1,228 @@
+/**
+ * SkillPackage — portable knowledge packages for external agents.
+ * Port of mts/src/mts/knowledge/export.py
+ */
+
+export interface SkillPackageData {
+  scenarioName: string;
+  displayName: string;
+  description: string;
+  playbook: string;
+  lessons: string[];
+  bestStrategy: Record<string, unknown> | null;
+  bestScore: number;
+  bestElo: number;
+  hints: string;
+  metadata?: Record<string, unknown>;
+  // Agent task fields
+  taskPrompt?: string | null;
+  judgeRubric?: string | null;
+  exampleOutputs?: Array<{ output: string; score: number; reasoning: string }> | null;
+  outputFormat?: string | null;
+  referenceContext?: string | null;
+  contextPreparation?: string | null;
+  maxRounds?: number | null;
+  qualityThreshold?: number | null;
+}
+
+// Noise patterns for cleaning lesson bullets
+const ROLLBACK_RE = /^-\s*Generation\s+\d+\s+ROLLBACK\b/i;
+const RAW_JSON_RE = /\{"[a-z_]+"\s*:\s*[\d.]+/;
+const SCORE_PARENS_RE = /\(score=[0-9.]+,\s*delta=[0-9.+-]+,\s*threshold=[0-9.]+\)/g;
+
+export class SkillPackage {
+  readonly scenarioName: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly playbook: string;
+  readonly lessons: string[];
+  readonly bestStrategy: Record<string, unknown> | null;
+  readonly bestScore: number;
+  readonly bestElo: number;
+  readonly hints: string;
+  readonly metadata: Record<string, unknown>;
+  readonly taskPrompt: string | null;
+  readonly judgeRubric: string | null;
+  readonly exampleOutputs: Array<{ output: string; score: number; reasoning: string }> | null;
+  readonly outputFormat: string | null;
+  readonly referenceContext: string | null;
+  readonly contextPreparation: string | null;
+  readonly maxRounds: number | null;
+  readonly qualityThreshold: number | null;
+
+  constructor(data: SkillPackageData) {
+    this.scenarioName = data.scenarioName;
+    this.displayName = data.displayName;
+    this.description = data.description;
+    this.playbook = data.playbook;
+    this.lessons = data.lessons;
+    this.bestStrategy = data.bestStrategy;
+    this.bestScore = data.bestScore;
+    this.bestElo = data.bestElo;
+    this.hints = data.hints;
+    this.metadata = data.metadata ?? {};
+    this.taskPrompt = data.taskPrompt ?? null;
+    this.judgeRubric = data.judgeRubric ?? null;
+    this.exampleOutputs = data.exampleOutputs ?? null;
+    this.outputFormat = data.outputFormat ?? null;
+    this.referenceContext = data.referenceContext ?? null;
+    this.contextPreparation = data.contextPreparation ?? null;
+    this.maxRounds = data.maxRounds ?? null;
+    this.qualityThreshold = data.qualityThreshold ?? null;
+  }
+
+  toDict(): Record<string, unknown> {
+    const d: Record<string, unknown> = {
+      scenario_name: this.scenarioName,
+      display_name: this.displayName,
+      description: this.description,
+      playbook: this.playbook,
+      lessons: this.lessons,
+      best_strategy: this.bestStrategy,
+      best_score: this.bestScore,
+      best_elo: this.bestElo,
+      hints: this.hints,
+      metadata: this.metadata,
+    };
+    if (this.taskPrompt != null) d.task_prompt = this.taskPrompt;
+    if (this.judgeRubric != null) d.judge_rubric = this.judgeRubric;
+    if (this.exampleOutputs != null) d.example_outputs = this.exampleOutputs;
+    if (this.outputFormat != null) d.output_format = this.outputFormat;
+    if (this.referenceContext != null) d.reference_context = this.referenceContext;
+    if (this.contextPreparation != null) d.context_preparation = this.contextPreparation;
+    if (this.maxRounds != null && this.maxRounds > 1) d.max_rounds = this.maxRounds;
+    if (this.qualityThreshold != null) d.quality_threshold = this.qualityThreshold;
+    return d;
+  }
+
+  toSkillMarkdown(): string {
+    const lessonsBlock = this.lessons.length > 0
+      ? this.lessons.map((l) => `- ${l}`).join("\n")
+      : "No lessons yet.";
+
+    if (this.taskPrompt != null) {
+      return this._renderAgentTaskMarkdown(lessonsBlock);
+    }
+
+    let strategyBlock = "";
+    if (this.bestStrategy) {
+      strategyBlock =
+        `\n## Best Known Strategy\n\n` +
+        `\`\`\`json\n${JSON.stringify(this.bestStrategy, null, 2)}\n\`\`\`\n` +
+        `\nBest score: ${this.bestScore.toFixed(4)} | Best Elo: ${this.bestElo.toFixed(1)}\n`;
+    }
+
+    return (
+      `---\nname: ${this.scenarioName.replace(/_/g, "-")}-knowledge\n` +
+      `description: ${this.description.slice(0, 200)}\n---\n\n` +
+      `# ${this.displayName}\n\n` +
+      `${this.description}\n\n` +
+      `## Operational Lessons\n\n` +
+      `${lessonsBlock}\n` +
+      `${strategyBlock}\n` +
+      `## Playbook\n\n` +
+      `${this.playbook}\n`
+    );
+  }
+
+  private _renderAgentTaskMarkdown(lessonsBlock: string): string {
+    const parts: string[] = [
+      `---\nname: ${this.scenarioName.replace(/_/g, "-")}-knowledge\n` +
+        `description: ${this.description.slice(0, 200)}\n---\n\n` +
+        `# ${this.displayName}\n\n` +
+        `${this.description}\n\n` +
+        `## Task\n\n` +
+        `${this.taskPrompt}\n`,
+    ];
+
+    if (this.judgeRubric) {
+      parts.push(`\n## Evaluation Criteria\n\n${this.judgeRubric}\n`);
+    }
+
+    if (this.contextPreparation) {
+      parts.push(`\n## Context Preparation\n\n${this.contextPreparation}\n`);
+    }
+
+    if (this.referenceContext) {
+      parts.push(`\n## Reference Context\n\n${this.referenceContext}\n`);
+    }
+
+    if (this.exampleOutputs && this.exampleOutputs.length > 0) {
+      parts.push("\n## Example Outputs\n");
+      for (const [i, ex] of this.exampleOutputs.slice(0, 3).entries()) {
+        parts.push(
+          `\n<details>\n<summary>Example ${i + 1} (score: ${ex.score.toFixed(2)})</summary>\n\n` +
+            `**Output:**\n\n${ex.output}\n\n` +
+            `**Reasoning:** ${ex.reasoning}\n\n` +
+            `</details>\n`,
+        );
+      }
+    }
+
+    parts.push(`\n## Operational Lessons\n\n${lessonsBlock}\n`);
+
+    if (this.bestStrategy) {
+      parts.push(
+        `\n## Best Known Strategy\n\n` +
+          `\`\`\`\n${JSON.stringify(this.bestStrategy, null, 2)}\n\`\`\`\n` +
+          `\nBest score: ${this.bestScore.toFixed(4)} | Best Elo: ${this.bestElo.toFixed(1)}\n`,
+      );
+    }
+
+    parts.push(`\n## Playbook\n\n${this.playbook}\n`);
+
+    return parts.join("");
+  }
+}
+
+/**
+ * Convenience builder for agent-task skill packages.
+ */
+export function exportAgentTaskSkill(opts: {
+  scenarioName: string;
+  taskPrompt: string;
+  judgeRubric: string;
+  outputFormat: string;
+  playbook: string;
+  lessons: string[];
+  bestOutputs: Array<{ output: string; score: number; reasoning: string }>;
+  hints?: string;
+  referenceContext?: string;
+  contextPreparation?: string;
+}): SkillPackage {
+  const displayName = opts.scenarioName.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  return new SkillPackage({
+    scenarioName: opts.scenarioName,
+    displayName,
+    description: `Agent task: ${displayName}`,
+    playbook: opts.playbook,
+    lessons: opts.lessons,
+    bestStrategy: null,
+    bestScore: opts.bestOutputs.length > 0 ? opts.bestOutputs[0].score : 0.0,
+    bestElo: 1500.0,
+    hints: opts.hints ?? "",
+    taskPrompt: opts.taskPrompt,
+    judgeRubric: opts.judgeRubric,
+    exampleOutputs: opts.bestOutputs.length > 0 ? opts.bestOutputs : null,
+    outputFormat: opts.outputFormat,
+    referenceContext: opts.referenceContext ?? null,
+    contextPreparation: opts.contextPreparation ?? null,
+  });
+}
+
+/**
+ * Clean lesson bullets: strip MTS-internal noise, keeping prescriptive rules.
+ */
+export function cleanLessons(rawBullets: string[]): string[] {
+  const cleaned: string[] = [];
+  for (const bullet of rawBullets) {
+    const text = bullet.trim();
+    if (!text) continue;
+    let content = text.startsWith("- ") ? text.slice(2) : text;
+    if (ROLLBACK_RE.test(text)) continue;
+    if (RAW_JSON_RE.test(content) && content.trim().startsWith("{")) continue;
+    content = content.replace(SCORE_PARENS_RE, "").trim();
+    if (content) cleaned.push(content);
+  }
+  return cleaned;
+}

--- a/ts/tests/skill-export.test.ts
+++ b/ts/tests/skill-export.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import { SkillPackage, exportAgentTaskSkill, cleanLessons } from "../src/knowledge/index.js";
+import type { SkillPackageData } from "../src/knowledge/index.js";
+
+function makeExampleOutputs() {
+  return [
+    { output: "Great answer", score: 0.95, reasoning: "Thorough and accurate" },
+    { output: "Okay answer", score: 0.70, reasoning: "Partially correct" },
+    { output: "Weak answer", score: 0.30, reasoning: "Missing key points" },
+  ];
+}
+
+function makeAgentTaskPackage(overrides?: Partial<SkillPackageData>): SkillPackage {
+  return new SkillPackage({
+    scenarioName: "test_task",
+    displayName: "Test Task",
+    description: "A test agent task",
+    playbook: "Follow the rubric.",
+    lessons: ["Be concise", "Cite sources"],
+    bestStrategy: { approach: "structured" },
+    bestScore: 0.85,
+    bestElo: 1600.0,
+    hints: "Focus on clarity",
+    taskPrompt: "Write a summary of the article.",
+    judgeRubric: "Score based on accuracy and completeness.",
+    exampleOutputs: makeExampleOutputs(),
+    outputFormat: "free_text",
+    ...overrides,
+  });
+}
+
+describe("SkillPackage — Agent Task Markdown", () => {
+  it("includes task section", () => {
+    const md = makeAgentTaskPackage().toSkillMarkdown();
+    expect(md).toContain("## Task");
+    expect(md).toContain("Write a summary of the article.");
+  });
+
+  it("includes evaluation criteria", () => {
+    const md = makeAgentTaskPackage().toSkillMarkdown();
+    expect(md).toContain("## Evaluation Criteria");
+    expect(md).toContain("Score based on accuracy and completeness.");
+  });
+
+  it("includes example outputs with details blocks", () => {
+    const md = makeAgentTaskPackage().toSkillMarkdown();
+    expect(md).toContain("## Example Outputs");
+    expect(md).toContain("<details>");
+    expect(md).toContain("<summary>");
+    expect(md).toContain("</details>");
+    expect(md).toContain("Great answer");
+    expect(md).toContain("score: 0.95");
+    expect(md).toContain("**Reasoning:**");
+    expect(md).toContain("Thorough and accurate");
+  });
+
+  it("limits to three examples", () => {
+    const outputs = [
+      ...makeExampleOutputs(),
+      { output: "Fourth", score: 0.10, reasoning: "Bad" },
+    ];
+    const md = makeAgentTaskPackage({ exampleOutputs: outputs }).toSkillMarkdown();
+    expect(md).toContain("Weak answer");
+    expect(md).not.toContain("Fourth");
+  });
+
+  it("uses text code block (not json) for strategy", () => {
+    const md = makeAgentTaskPackage().toSkillMarkdown();
+    expect(md).toContain("```\n{");
+    expect(md).not.toContain("```json");
+  });
+
+  it("includes playbook", () => {
+    const md = makeAgentTaskPackage().toSkillMarkdown();
+    expect(md).toContain("## Playbook");
+    expect(md).toContain("Follow the rubric.");
+  });
+
+  it("includes operational lessons", () => {
+    const md = makeAgentTaskPackage().toSkillMarkdown();
+    expect(md).toContain("## Operational Lessons");
+    expect(md).toContain("- Be concise");
+    expect(md).toContain("- Cite sources");
+  });
+
+  it("includes reference context when present", () => {
+    const md = makeAgentTaskPackage({ referenceContext: "Domain knowledge" }).toSkillMarkdown();
+    expect(md).toContain("## Reference Context");
+    expect(md).toContain("Domain knowledge");
+  });
+
+  it("includes context preparation when present", () => {
+    const md = makeAgentTaskPackage({ contextPreparation: "Load documents" }).toSkillMarkdown();
+    expect(md).toContain("## Context Preparation");
+    expect(md).toContain("Load documents");
+  });
+
+  it("omits optional sections when not present", () => {
+    const md = makeAgentTaskPackage({
+      referenceContext: null,
+      contextPreparation: null,
+      exampleOutputs: null,
+    }).toSkillMarkdown();
+    expect(md).not.toContain("## Reference Context");
+    expect(md).not.toContain("## Context Preparation");
+    expect(md).not.toContain("## Example Outputs");
+  });
+});
+
+describe("SkillPackage — Game Scenario Markdown", () => {
+  it("renders without agent task sections", () => {
+    const pkg = new SkillPackage({
+      scenarioName: "grid_ctf",
+      displayName: "Grid CTF",
+      description: "Capture the flag on a grid",
+      playbook: "Move toward the flag.",
+      lessons: ["Avoid corners"],
+      bestStrategy: { x: 1, y: 2 },
+      bestScore: 0.9,
+      bestElo: 1700,
+      hints: "Think ahead",
+    });
+    const md = pkg.toSkillMarkdown();
+    expect(md).toContain("# Grid CTF");
+    expect(md).toContain("## Playbook");
+    expect(md).toContain("```json");
+    expect(md).not.toContain("## Task");
+    expect(md).not.toContain("## Evaluation Criteria");
+  });
+});
+
+describe("SkillPackage — toDict", () => {
+  it("serializes core fields", () => {
+    const d = makeAgentTaskPackage().toDict();
+    expect(d.scenario_name).toBe("test_task");
+    expect(d.task_prompt).toBe("Write a summary of the article.");
+    expect(d.judge_rubric).toBe("Score based on accuracy and completeness.");
+    expect(d.example_outputs).toHaveLength(3);
+  });
+
+  it("omits null optional fields", () => {
+    const d = makeAgentTaskPackage({
+      taskPrompt: null,
+      judgeRubric: null,
+      referenceContext: null,
+    }).toDict();
+    expect("task_prompt" in d).toBe(false);
+    expect("judge_rubric" in d).toBe(false);
+    expect("reference_context" in d).toBe(false);
+  });
+});
+
+describe("exportAgentTaskSkill", () => {
+  it("creates package from opts", () => {
+    const pkg = exportAgentTaskSkill({
+      scenarioName: "summary_task",
+      taskPrompt: "Summarize this",
+      judgeRubric: "Check completeness",
+      outputFormat: "free_text",
+      playbook: "Read carefully, then summarize.",
+      lessons: ["Keep it short"],
+      bestOutputs: [{ output: "Good summary", score: 0.9, reasoning: "Concise" }],
+    });
+    expect(pkg.scenarioName).toBe("summary_task");
+    expect(pkg.displayName).toBe("Summary Task");
+    expect(pkg.bestScore).toBe(0.9);
+    expect(pkg.taskPrompt).toBe("Summarize this");
+    const md = pkg.toSkillMarkdown();
+    expect(md).toContain("## Task");
+  });
+
+  it("handles empty bestOutputs", () => {
+    const pkg = exportAgentTaskSkill({
+      scenarioName: "empty_task",
+      taskPrompt: "Do something",
+      judgeRubric: "Check it",
+      outputFormat: "free_text",
+      playbook: "Try your best.",
+      lessons: [],
+      bestOutputs: [],
+    });
+    expect(pkg.bestScore).toBe(0.0);
+    expect(pkg.exampleOutputs).toBeNull();
+  });
+});
+
+describe("cleanLessons", () => {
+  it("strips rollback lines", () => {
+    const result = cleanLessons([
+      "- Generation 3 ROLLBACK — score dropped",
+      "- Keep outputs concise",
+    ]);
+    expect(result).toEqual(["Keep outputs concise"]);
+  });
+
+  it("strips raw JSON blobs", () => {
+    const result = cleanLessons([
+      '{"param_a": 0.5, "param_b": 0.3}',
+      "Use structured format",
+    ]);
+    expect(result).toEqual(["Use structured format"]);
+  });
+
+  it("strips score parentheticals", () => {
+    const result = cleanLessons([
+      "- Improved accuracy (score=0.85, delta=+0.10, threshold=0.90)",
+    ]);
+    expect(result).toEqual(["Improved accuracy"]);
+  });
+
+  it("removes empty entries", () => {
+    const result = cleanLessons(["", "  ", "Valid lesson"]);
+    expect(result).toEqual(["Valid lesson"]);
+  });
+});


### PR DESCRIPTION
## PR 3 of 3: Playbook Generator — Skill Export

Completes the playbook generator pipeline by porting the skill export layer to TypeScript.

### New modules (`ts/src/knowledge/`)

| File | Purpose |
|------|---------|
| `skill-package.ts` | `SkillPackage` class with `toDict()` and `toSkillMarkdown()` |
| `index.ts` | Barrel exports |

### Key features
- **Dual markdown rendering**: Game scenarios get ```json``` strategy blocks; agent tasks get task prompt, evaluation criteria, example outputs in `<details>` blocks
- **`exportAgentTaskSkill()`** — convenience builder for agent task packages
- **`cleanLessons()`** — strips MTS-internal noise (rollback lines, raw JSON, score parentheticals) from lesson bullets
- Example outputs capped at 3 in markdown rendering (matches Python)

### Tests
- 19 new tests covering markdown rendering, toDict, builder, lesson cleaning
- **86 total tests passing** across 10 test files

### Full pipeline now available in TS
With PRs #40 + #41 + this one merged, the complete flow works:
1. `AgentTaskCreator.create('describe your task')` → generates scenario from NL
2. `ImprovementLoop.run()` → iterates with LLM judge scoring
3. `exportAgentTaskSkill()` → produces portable SKILL.md playbook