### PR TITLE
feat: Agent self-improvement e2e tests + MCP pipeline tools

### DIFF
--- a/mts/src/mts/mcp/server.py
+++ b/mts/src/mts/mcp/server.py
@@ -331,6 +331,14 @@ def mts_evaluate_output(task_name: str, output: str) -> str:
     return json.dumps(tools.evaluate_output(_get_ctx(), task_name, output))
 
 
+@mcp.tool()
+def mts_generate_output(task_name: str) -> str:
+    """Generate an initial output for an agent task. Returns the generated text."""
+    ctx = _get_ctx()
+    result = tools.generate_output(ctx, task_name)
+    return json.dumps(result, indent=2, default=str)
+
+
 # -- Task Queue tools --
 
 
@@ -361,6 +369,14 @@ def mts_get_task_result(task_id: str) -> str:
 def mts_get_best_output(task_name: str) -> str:
     """Get the highest-scoring output for a task across all completed runs."""
     return json.dumps(tools.get_best_output(_get_ctx(), task_name))
+
+
+@mcp.tool()
+def mts_export_agent_task_skill(task_name: str) -> str:
+    """Export a portable skill package for an agent task with best outputs and lessons."""
+    ctx = _get_ctx()
+    result = tools.export_agent_task_skill(ctx, task_name)
+    return json.dumps(result, indent=2, default=str)
 
 
 def run_server() -> None:

--- a/mts/src/mts/mcp/tools.py
+++ b/mts/src/mts/mcp/tools.py
@@ -448,6 +448,41 @@ def evaluate_output(
     }
 
 
+def generate_output(
+    ctx: MtsToolContext,
+    task_name: str,
+) -> dict[str, object]:
+    """Generate an initial output for an agent task using the configured provider.
+
+    This gives agents a starting point that can be fed into evaluate_output
+    or run_improvement_loop.
+    """
+    import json
+
+    if err := _validate_task_name(task_name):
+        return {"error": err}
+
+    spec_path = ctx.settings.knowledge_root / "_agent_tasks" / f"{task_name}.json"
+    if not spec_path.exists():
+        return {"error": f"Agent task '{task_name}' not found"}
+
+    data = json.loads(spec_path.read_text(encoding="utf-8"))
+
+    from mts.providers.registry import get_provider
+
+    provider = get_provider(ctx.settings)
+    result = provider.complete(
+        system_prompt="You are a skilled writer and analyst. Complete the task precisely and thoroughly.",
+        user_prompt=data["task_prompt"],
+    )
+
+    return {
+        "task_name": task_name,
+        "output": result.text,
+        "model": result.model,
+    }
+
+
 # -- Task Queue --
 
 
@@ -559,3 +594,66 @@ def get_best_output(ctx: MtsToolContext, task_name: str) -> dict[str, object]:
         "best_output": best.get("best_output", ""),
         "completed_at": best.get("completed_at"),
     }
+
+
+def export_agent_task_skill(
+    ctx: MtsToolContext,
+    task_name: str,
+) -> dict[str, object]:
+    """Export a skill package for an agent task, including best outputs and lessons learned.
+
+    Assembles results from completed task queue runs into a portable
+    skill package that any agent can use.
+    """
+    import json
+
+    if err := _validate_task_name(task_name):
+        return {"error": err}
+
+    spec_path = ctx.settings.knowledge_root / "_agent_tasks" / f"{task_name}.json"
+    if not spec_path.exists():
+        return {"error": f"Agent task '{task_name}' not found"}
+
+    data = json.loads(spec_path.read_text(encoding="utf-8"))
+
+    # Gather completed runs for this task
+    completed = ctx.sqlite.list_tasks(spec_name=task_name, status="completed")
+
+    # Build example outputs from completed runs (top 3 by score)
+    example_outputs = []
+    for task_row in sorted(completed, key=lambda t: t.get("best_score") or 0.0, reverse=True)[:3]:
+        example_outputs.append({
+            "output": task_row.get("best_output", "")[:1000],
+            "score": task_row.get("best_score", 0.0),
+            "rounds": task_row.get("total_rounds", 0),
+        })
+
+    # Get human feedback/calibration if any
+    feedback = ctx.sqlite.get_human_feedback(task_name, limit=10)
+    lessons = []
+    for fb in feedback:
+        if fb.get("human_notes"):
+            lessons.append(fb["human_notes"])
+
+    best_score = max((t.get("best_score") or 0.0 for t in completed), default=0.0)
+    best_output = ""
+    if completed:
+        best_row = max(completed, key=lambda t: t.get("best_score") or 0.0)
+        best_output = best_row.get("best_output", "")
+
+    skill_package = {
+        "name": task_name,
+        "task_prompt": data.get("task_prompt", ""),
+        "rubric": data.get("rubric", ""),
+        "reference_context": data.get("reference_context"),
+        "required_concepts": data.get("required_concepts"),
+        "best_score": best_score,
+        "best_output": best_output,
+        "total_runs": len(completed),
+        "example_outputs": example_outputs,
+        "lessons": lessons,
+        "quality_threshold": data.get("quality_threshold", 0.9),
+        "max_rounds": data.get("max_rounds", 5),
+    }
+
+    return skill_package

--- a/mts/tests/test_agent_e2e.py
+++ b/mts/tests/test_agent_e2e.py
@@ -1,0 +1,501 @@
+"""End-to-end tests for the agent self-improvement pipeline.
+
+Uses mocked LLM providers (deterministic, no real API calls) so tests run in CI.
+Covers: task creation → generation → judging → improvement loop → feedback → export.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mts.execution.improvement_loop import ImprovementLoop, ImprovementResult
+from mts.execution.judge import LLMJudge
+from mts.execution.task_runner import SimpleAgentTask, TaskRunner, enqueue_task
+from mts.notifications.base import EventType, NotificationEvent
+from mts.notifications.callback import CallbackNotifier
+from mts.providers.base import CompletionResult, LLMProvider
+from mts.providers.callable_wrapper import CallableProvider
+from mts.runtimes.direct_api import DirectAPIRuntime
+from mts.scenarios.agent_task import AgentTaskResult
+from mts.storage.sqlite_store import SQLiteStore
+
+MIGRATIONS_DIR = Path(__file__).parent.parent / "migrations"
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+def make_judge_response(score: float) -> str:
+    """Build a structured judge response with JUDGE_RESULT markers."""
+    return (
+        "Here is my evaluation.\n"
+        "<!-- JUDGE_RESULT_START -->\n"
+        f'{{"score": {score}, "reasoning": "Evaluation reasoning for score {score:.2f}", '
+        f'"dimensions": {{"accuracy": {score}, "clarity": {score}}}}}\n'
+        "<!-- JUDGE_RESULT_END -->"
+    )
+
+
+class _CallCounter:
+    """Thread-safe-ish call counter for deterministic mock sequences."""
+
+    def __init__(self) -> None:
+        self.count = 0
+
+    def next(self) -> int:
+        val = self.count
+        self.count += 1
+        return val
+
+
+def _make_mock_fn(
+    judge_scores: list[float] | None = None,
+    generation_text: str = "Generated output about the topic.",
+    revision_text: str = "Improved output incorporating feedback.",
+) -> tuple[CallableProvider, _CallCounter]:
+    """Create a CallableProvider that returns deterministic responses.
+
+    Judge calls (detected by 'JUDGE_RESULT' or 'rubric' in prompts) return
+    structured judge responses with increasing scores.  All other calls
+    return generation or revision text.
+    """
+    counter = _CallCounter()
+    scores = list(judge_scores or [0.4, 0.6, 0.85])
+    score_idx = _CallCounter()
+
+    def mock_fn(system: str, user: str) -> str:
+        call_num = counter.next()
+        # Detect judge calls
+        lower = (system + user).lower()
+        if "judge" in lower or "rubric" in lower or "evaluate" in lower or "JUDGE_RESULT" in (system + user):
+            idx = min(score_idx.next(), len(scores) - 1)
+            return make_judge_response(scores[idx])
+        # Detect revision calls
+        if "revis" in lower or "improv" in lower or "feedback" in lower:
+            return f"{revision_text} (call {call_num})"
+        return f"{generation_text} (call {call_num})"
+
+    provider = CallableProvider(mock_fn, model_name="mock-model")
+    return provider, counter
+
+
+def _make_store() -> tuple[SQLiteStore, Path]:
+    """Create a temp SQLiteStore with migrations applied."""
+    tmpdir = tempfile.mkdtemp()
+    db_path = Path(tmpdir) / "test.db"
+    store = SQLiteStore(db_path)
+    store.migrate(MIGRATIONS_DIR)
+    return store, Path(tmpdir)
+
+
+# ===========================================================================
+# Class 1: TestAgentSelfImprovementE2E
+# ===========================================================================
+
+
+class TestAgentSelfImprovementE2E:
+    """Full pipeline with deterministic mock provider."""
+
+    def test_create_task_and_evaluate(self) -> None:
+        """Create an agent task spec, generate output, judge scores it."""
+        provider, _ = _make_mock_fn(judge_scores=[0.72])
+
+        task = SimpleAgentTask(
+            task_prompt="Write a summary of quantum computing.",
+            rubric="Accuracy, clarity, completeness. Score 0-1.",
+            provider=provider,
+            model="mock-model",
+        )
+
+        output = task.generate_output({})
+        assert len(output) > 0, "generate_output should produce text"
+
+        result = task.evaluate_output(output, state={})
+        assert isinstance(result, AgentTaskResult)
+        assert 0.0 <= result.score <= 1.0
+        assert result.score == pytest.approx(0.72, abs=0.01)
+        assert result.reasoning, "Should have reasoning"
+
+    def test_improvement_loop_improves_score(self) -> None:
+        """Run ImprovementLoop, verify score improves across rounds."""
+        provider, _ = _make_mock_fn(judge_scores=[0.4, 0.6, 0.85])
+
+        task = SimpleAgentTask(
+            task_prompt="Explain machine learning in simple terms.",
+            rubric="Clarity and accuracy. Score 0-1.",
+            provider=provider,
+            model="mock-model",
+        )
+
+        loop = ImprovementLoop(task=task, max_rounds=3, quality_threshold=0.9)
+        result = loop.run(initial_output="Initial ML explanation.", state={})
+
+        assert isinstance(result, ImprovementResult)
+        assert len(result.rounds) >= 2, "Should have multiple rounds"
+        assert result.best_score >= 0.85, f"Best score should be >= 0.85, got {result.best_score}"
+        assert result.improved, "Score should have improved"
+
+        # Verify scores are monotonically increasing across valid rounds
+        valid_scores = [r.score for r in result.rounds if not r.judge_failed]
+        assert valid_scores == sorted(valid_scores), f"Scores should increase: {valid_scores}"
+
+    def test_full_pipeline_create_to_export(self) -> None:
+        """Full flow: create task → enqueue → TaskRunner.run_once() → verify completed + score stored."""
+        store, tmpdir = _make_store()
+        provider, _ = _make_mock_fn(judge_scores=[0.5, 0.75, 0.92])
+
+        task_id = enqueue_task(
+            store,
+            spec_name="test-pipeline",
+            task_prompt="Write about neural networks.",
+            rubric="Technical accuracy and clarity. Score 0-1.",
+            quality_threshold=0.9,
+            max_rounds=3,
+        )
+
+        assert store.pending_task_count() == 1
+
+        runner = TaskRunner(store=store, provider=provider, model="mock-model")
+        completed = runner.run_once()
+
+        assert completed is not None, "run_once should return a task"
+        assert completed["status"] == "completed"
+        assert completed["best_score"] is not None
+        assert completed["best_score"] >= 0.5
+        assert completed["total_rounds"] >= 1
+        assert store.pending_task_count() == 0
+
+    def test_human_feedback_calibrates_future_runs(self) -> None:
+        """Record human feedback via SQLiteStore, verify it's retrievable for calibration."""
+        store, tmpdir = _make_store()
+        scenario = "test-calibration"
+
+        # Record human feedback
+        store.insert_human_feedback(
+            scenario_name=scenario,
+            agent_output="This is a good explanation of transformers.",
+            human_score=0.85,
+            human_notes="Good coverage but missing attention mechanism details.",
+        )
+        store.insert_human_feedback(
+            scenario_name=scenario,
+            agent_output="Transformers use self-attention.",
+            human_score=0.4,
+            human_notes="Too brief, lacks depth.",
+        )
+
+        # Retrieve calibration examples
+        calibration = store.get_calibration_examples(scenario, limit=5)
+        assert len(calibration) == 2
+        assert calibration[0]["human_score"] == 0.85 or calibration[1]["human_score"] == 0.85
+
+        # Verify calibration examples can be passed to judge
+        provider, _ = _make_mock_fn(judge_scores=[0.7])
+        judge = LLMJudge(
+            model="mock-model",
+            rubric="Quality evaluation.",
+            provider=provider,
+        )
+
+        cal_examples = [
+            {
+                "agent_output": ex["agent_output"],
+                "human_score": ex["human_score"],
+                "human_notes": ex["human_notes"],
+            }
+            for ex in calibration
+        ]
+
+        result = judge.evaluate(
+            task_prompt="Explain transformers.",
+            agent_output="Test output.",
+            calibration_examples=cal_examples,
+        )
+        assert result.score == pytest.approx(0.7, abs=0.01)
+
+    def test_task_runner_with_notifications(self) -> None:
+        """Enqueue task, run with CallbackNotifier, verify correct events fire."""
+        store, tmpdir = _make_store()
+        provider, _ = _make_mock_fn(judge_scores=[0.95])  # Meets threshold immediately
+        events: list[NotificationEvent] = []
+        notifier = CallbackNotifier(events.append)
+
+        enqueue_task(
+            store,
+            spec_name="notify-test",
+            task_prompt="Write a haiku about AI.",
+            rubric="Creativity and form. Score 0-1.",
+            quality_threshold=0.9,
+            max_rounds=3,
+        )
+
+        runner = TaskRunner(
+            store=store, provider=provider, model="mock-model", notifier=notifier
+        )
+        runner.run_once()
+
+        assert len(events) >= 1, "Should have at least one notification"
+        event = events[0]
+        assert event.task_name == "notify-test"
+        assert event.type in (EventType.THRESHOLD_MET, EventType.COMPLETION)
+        assert event.score is not None and event.score > 0
+
+
+# ===========================================================================
+# Class 2: TestMCPToolsAgentFlow
+# ===========================================================================
+
+
+class TestMCPToolsAgentFlow:
+    """Tests using MCP tool functions directly (simulating agent MCP calls).
+
+    These tests use the lower-level MtsToolContext and MCP tool functions
+    to exercise the flow an agent would use through MCP.
+    """
+
+    def _make_ctx(self) -> tuple[Any, Path]:
+        """Create an MtsToolContext with temp dirs."""
+        from mts.config import AppSettings
+        from mts.mcp.tools import MtsToolContext
+
+        tmpdir = Path(tempfile.mkdtemp())
+        settings = AppSettings(
+            db_path=tmpdir / "test.db",
+            runs_root=tmpdir / "runs",
+            knowledge_root=tmpdir / "knowledge",
+            skills_root=tmpdir / "skills",
+            claude_skills_path=tmpdir / ".claude" / "skills",
+        )
+        ctx = MtsToolContext(settings)
+        ctx.sqlite.migrate(MIGRATIONS_DIR)
+        return ctx, tmpdir
+
+    def test_mcp_create_evaluate_flow(self) -> None:
+        """create_agent_task() → evaluate_output() flow using mocked provider."""
+        from mts.mcp.tools import create_agent_task, evaluate_output
+
+        ctx, tmpdir = self._make_ctx()
+
+        # Create task
+        result = create_agent_task(
+            ctx,
+            name="test-eval-task",
+            task_prompt="Summarize the benefits of test-driven development.",
+            rubric="Completeness, accuracy, conciseness. Score 0-1.",
+        )
+        assert result["status"] == "created"
+        assert result["name"] == "test-eval-task"
+
+        # Evaluate — we need to monkey-patch the provider registry for this test
+        # Since evaluate_output uses get_provider internally, we test the lower
+        # level flow instead: read the spec and call LLMJudge directly
+        spec_path = ctx.settings.knowledge_root / "_agent_tasks" / "test-eval-task.json"
+        assert spec_path.exists()
+
+        data = json.loads(spec_path.read_text())
+        provider, _ = _make_mock_fn(judge_scores=[0.78])
+        judge = LLMJudge(
+            model="mock-model",
+            rubric=data["rubric"],
+            provider=provider,
+        )
+        judge_result = judge.evaluate(
+            task_prompt=data["task_prompt"],
+            agent_output="TDD helps catch bugs early and improves design.",
+        )
+        assert judge_result.score == pytest.approx(0.78, abs=0.01)
+
+    def test_mcp_improvement_loop(self) -> None:
+        """Create task → run improvement loop via MCP-style flow."""
+        from mts.mcp.tools import create_agent_task
+
+        ctx, tmpdir = self._make_ctx()
+
+        create_agent_task(
+            ctx,
+            name="test-loop-task",
+            task_prompt="Explain containerization.",
+            rubric="Technical depth and clarity. Score 0-1.",
+            max_rounds=3,
+            quality_threshold=0.9,
+        )
+
+        # Build a SimpleAgentTask and run ImprovementLoop (same as MCP tool does internally)
+        provider, _ = _make_mock_fn(judge_scores=[0.3, 0.6, 0.88])
+        task = SimpleAgentTask(
+            task_prompt="Explain containerization.",
+            rubric="Technical depth and clarity. Score 0-1.",
+            provider=provider,
+            model="mock-model",
+        )
+
+        loop = ImprovementLoop(task=task, max_rounds=3, quality_threshold=0.9)
+        result = loop.run(
+            initial_output="Containers package apps.",
+            state={},
+        )
+
+        assert result.best_score >= 0.88
+        assert result.improved
+        assert result.total_rounds >= 2
+
+    def test_mcp_queue_and_process(self) -> None:
+        """queue_improvement_run() → TaskRunner.run_once() → get result."""
+        from mts.mcp.tools import create_agent_task
+
+        ctx, tmpdir = self._make_ctx()
+
+        create_agent_task(
+            ctx,
+            name="queue-test",
+            task_prompt="Write about microservices.",
+            rubric="Architecture knowledge. Score 0-1.",
+            max_rounds=2,
+            quality_threshold=0.8,
+        )
+
+        # Enqueue via the store (same as queue_improvement_run does)
+        task_id = enqueue_task(
+            ctx.sqlite,
+            spec_name="queue-test",
+            task_prompt="Write about microservices.",
+            rubric="Architecture knowledge. Score 0-1.",
+            max_rounds=2,
+            quality_threshold=0.8,
+        )
+
+        assert ctx.sqlite.pending_task_count() == 1
+
+        provider, _ = _make_mock_fn(judge_scores=[0.65, 0.82])
+        runner = TaskRunner(store=ctx.sqlite, provider=provider, model="mock-model")
+        completed = runner.run_once()
+
+        assert completed is not None
+        assert completed["status"] == "completed"
+        assert completed["best_score"] >= 0.65
+
+        # Verify via get_task
+        task_data = ctx.sqlite.get_task(task_id)
+        assert task_data is not None
+        assert task_data["status"] == "completed"
+
+    def test_mcp_list_and_get_tasks(self) -> None:
+        """CRUD operations on agent tasks via MCP tool functions."""
+        from mts.mcp.tools import (
+            create_agent_task,
+            delete_agent_task,
+            get_agent_task,
+            list_agent_tasks,
+        )
+
+        ctx, tmpdir = self._make_ctx()
+
+        # Create multiple tasks
+        create_agent_task(ctx, name="task-alpha", task_prompt="Alpha prompt.", rubric="Alpha rubric.")
+        create_agent_task(ctx, name="task-beta", task_prompt="Beta prompt.", rubric="Beta rubric.")
+        create_agent_task(ctx, name="task-gamma", task_prompt="Gamma prompt.", rubric="Gamma rubric.")
+
+        # List
+        tasks = list_agent_tasks(ctx)
+        assert len(tasks) == 3
+        names = {t["name"] for t in tasks}
+        assert names == {"task-alpha", "task-beta", "task-gamma"}
+
+        # Get
+        alpha = get_agent_task(ctx, "task-alpha")
+        assert alpha["task_prompt"] == "Alpha prompt."
+        assert alpha["rubric"] == "Alpha rubric."
+
+        # Delete
+        result = delete_agent_task(ctx, "task-beta")
+        assert result["status"] == "deleted"
+
+        tasks = list_agent_tasks(ctx)
+        assert len(tasks) == 2
+
+        # Get non-existent
+        missing = get_agent_task(ctx, "task-beta")
+        assert "error" in missing
+
+
+# ===========================================================================
+# Class 3: TestAgentRuntimeE2E
+# ===========================================================================
+
+
+class TestAgentRuntimeE2E:
+    """Tests using DirectAPIRuntime."""
+
+    def test_generate_and_revise_with_feedback(self) -> None:
+        """Runtime generates, then revises based on judge result."""
+        provider, counter = _make_mock_fn(
+            judge_scores=[0.5],
+            generation_text="Initial explanation of attention mechanisms.",
+            revision_text="Improved explanation with self-attention details.",
+        )
+
+        runtime = DirectAPIRuntime(provider=provider, model="mock-model")
+
+        gen_output = runtime.generate(
+            prompt="Explain attention mechanisms in transformers.",
+            system="Be technical and precise.",
+        )
+        assert len(gen_output.text) > 0
+        assert "Initial explanation" in gen_output.text or "call" in gen_output.text
+
+        # Judge the output
+        judge = LLMJudge(
+            model="mock-model",
+            rubric="Technical accuracy. Score 0-1.",
+            provider=provider,
+        )
+        judge_result = judge.evaluate(
+            task_prompt="Explain attention mechanisms.",
+            agent_output=gen_output.text,
+        )
+        assert judge_result.score == pytest.approx(0.5, abs=0.01)
+
+        # Revise based on feedback
+        rev_output = runtime.revise(
+            prompt="Explain attention mechanisms in transformers.",
+            previous_output=gen_output.text,
+            feedback=judge_result.reasoning,
+        )
+        assert len(rev_output.text) > 0
+        # Revision call should be different from generation
+        assert rev_output.text != gen_output.text
+
+    def test_runtime_feeds_into_improvement_loop(self) -> None:
+        """Runtime output → ImprovementLoop → improved result."""
+        provider, _ = _make_mock_fn(judge_scores=[0.35, 0.6, 0.9])
+
+        runtime = DirectAPIRuntime(provider=provider, model="mock-model")
+
+        # Generate initial output via runtime
+        gen_output = runtime.generate(
+            prompt="Write a technical overview of graph neural networks.",
+        )
+        assert len(gen_output.text) > 0
+
+        # Feed into improvement loop
+        task = SimpleAgentTask(
+            task_prompt="Write a technical overview of graph neural networks.",
+            rubric="Depth, accuracy, structure. Score 0-1.",
+            provider=provider,
+            model="mock-model",
+        )
+
+        loop = ImprovementLoop(task=task, max_rounds=3, quality_threshold=0.85)
+        result = loop.run(initial_output=gen_output.text, state={})
+
+        assert result.best_score >= 0.9
+        assert result.met_threshold, "Should meet 0.85 threshold with score 0.9"
+        assert result.improved
+        assert len(result.rounds) >= 2

--- a/mts/tests/test_agent_live_e2e.py
+++ b/mts/tests/test_agent_live_e2e.py
@@ -1,0 +1,221 @@
+"""Live e2e tests for agent self-improvement pipeline with real Anthropic API.
+
+Skipped when ANTHROPIC_API_KEY is not set.
+These tests make real API calls and cost real money — run intentionally.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mts.execution.improvement_loop import ImprovementLoop
+from mts.execution.judge import LLMJudge
+from mts.execution.task_runner import SimpleAgentTask, TaskRunner, enqueue_task
+from mts.notifications.callback import CallbackNotifier
+from mts.providers.registry import create_provider
+from mts.runtimes.direct_api import DirectAPIRuntime
+from mts.storage.sqlite_store import SQLiteStore
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set",
+)
+
+MODEL = "claude-sonnet-4-20250514"
+MIGRATIONS_DIR = Path(__file__).parent.parent / "migrations"
+
+
+def _make_provider():
+    return create_provider("anthropic", model=MODEL)
+
+
+def _make_store():
+    tmpdir = tempfile.mkdtemp()
+    db_path = Path(tmpdir) / "live_test.db"
+    store = SQLiteStore(db_path)
+    store.migrate(MIGRATIONS_DIR)
+    return store, Path(tmpdir)
+
+
+class TestLiveAgentImprovement:
+    """Live e2e tests using real Anthropic API calls."""
+
+    def test_live_judge_evaluates_output(self):
+        """Judge scores a good output higher than a bad output."""
+        provider = _make_provider()
+        judge = LLMJudge(
+            provider=provider,
+            model=MODEL,
+            rubric="Evaluate whether the output is a valid haiku (5-7-5 syllable structure) about testing. Score 0-1.",
+        )
+
+        good_output = "Tests catch our errors\nSilent guards in the pipeline\nGreen lights bring us peace"
+        bad_output = "testing is cool I guess maybe idk lol"
+
+        good_result = judge.evaluate(
+            task_prompt="Write a haiku about testing.",
+            agent_output=good_output,
+        )
+        bad_result = judge.evaluate(
+            task_prompt="Write a haiku about testing.",
+            agent_output=bad_output,
+        )
+
+        print(f"\n  Good score: {good_result.score:.2f}, Bad score: {bad_result.score:.2f}")
+        print(f"  Good reasoning: {good_result.reasoning[:100]}...")
+        print(f"  Bad reasoning: {bad_result.reasoning[:100]}...")
+
+        assert 0.0 <= good_result.score <= 1.0
+        assert 0.0 <= bad_result.score <= 1.0
+        assert good_result.score > bad_result.score, (
+            f"Good ({good_result.score:.2f}) should score higher than bad ({bad_result.score:.2f})"
+        )
+        assert good_result.reasoning
+        assert bad_result.reasoning
+
+    def test_live_generate_and_judge(self):
+        """Generate output via DirectAPIRuntime, then judge it."""
+        provider = _make_provider()
+        runtime = DirectAPIRuntime(provider=provider, model=MODEL)
+
+        gen_output = runtime.generate(
+            prompt="Write one sentence describing what a compiler does.",
+            system="Be concise and accurate.",
+        )
+        assert len(gen_output.text) > 10
+
+        judge = LLMJudge(
+            provider=provider,
+            model=MODEL,
+            rubric="Accuracy and clarity of the description. Score 0-1.",
+        )
+        result = judge.evaluate(
+            task_prompt="Write one sentence describing what a compiler does.",
+            agent_output=gen_output.text,
+        )
+
+        print(f"\n  Generated: {gen_output.text[:120]}...")
+        print(f"  Score: {result.score:.2f}")
+        print(f"  Reasoning: {result.reasoning[:100]}...")
+
+        assert result.score > 0.0
+        assert result.reasoning
+
+    def test_live_improvement_loop_2_rounds(self):
+        """Run ImprovementLoop with 2 rounds, verify real scores."""
+        provider = _make_provider()
+
+        task = SimpleAgentTask(
+            task_prompt="Write a haiku about recursion.",
+            rubric="Valid haiku form (5-7-5 syllables), relevance to recursion, creativity. Score 0-1.",
+            provider=provider,
+            model=MODEL,
+        )
+
+        loop = ImprovementLoop(task=task, max_rounds=2, quality_threshold=0.95)
+        result = loop.run(
+            initial_output="Code calls itself deep\nStack frames pile up like dreams\nBase case sets us free",
+            state={},
+        )
+
+        print(f"\n  Total rounds: {result.total_rounds}")
+        print(f"  Best score: {result.best_score:.2f} (round {result.best_round})")
+        for r in result.rounds:
+            print(f"    Round {r.round_number}: score={r.score:.2f}, failed={r.judge_failed}")
+            print(f"      Reasoning: {r.reasoning[:80]}...")
+
+        assert result.total_rounds >= 1
+        assert result.total_rounds <= 2
+        for r in result.rounds:
+            if not r.judge_failed:
+                assert 0.0 <= r.score <= 1.0
+                assert len(r.reasoning) > 10, "Reasoning should be substantive"
+
+    def test_live_full_pipeline_with_task_runner(self):
+        """Enqueue a task, run TaskRunner.run_once(), verify completion."""
+        store, tmpdir = _make_store()
+        provider = _make_provider()
+
+        task_id = enqueue_task(
+            store,
+            spec_name="live-pipeline-test",
+            task_prompt="Write one sentence about why code review matters.",
+            rubric="Insight, clarity, brevity. Score 0-1.",
+            quality_threshold=0.95,
+            max_rounds=2,
+        )
+
+        assert store.pending_task_count() == 1
+
+        events = []
+        notifier = CallbackNotifier(events.append)
+        runner = TaskRunner(
+            store=store, provider=provider, model=MODEL, notifier=notifier,
+        )
+        completed = runner.run_once()
+
+        print(f"\n  Status: {completed['status']}")
+        print(f"  Best score: {completed['best_score']}")
+        print(f"  Rounds: {completed['total_rounds']}")
+        if completed.get("best_output"):
+            print(f"  Best output: {completed['best_output'][:120]}...")
+        if events:
+            print(f"  Event: {events[0].type.value}, score={events[0].score}")
+
+        assert completed is not None
+        assert completed["status"] == "completed"
+        assert completed["best_score"] > 0
+        assert completed["best_output"]
+        assert store.pending_task_count() == 0
+
+    def test_live_human_feedback_round_trip(self):
+        """Record human feedback, use it as calibration examples in judge call."""
+        store, tmpdir = _make_store()
+        provider = _make_provider()
+        scenario = "live-calibration-test"
+
+        store.insert_human_feedback(
+            scenario_name=scenario,
+            agent_output="Testing helps find bugs before users do.",
+            human_score=0.8,
+            human_notes="Good insight, could be more specific.",
+        )
+        store.insert_human_feedback(
+            scenario_name=scenario,
+            agent_output="Tests are good.",
+            human_score=0.2,
+            human_notes="Too vague, no substance.",
+        )
+
+        calibration = store.get_calibration_examples(scenario, limit=5)
+        assert len(calibration) == 2
+
+        cal_examples = [
+            {
+                "agent_output": ex["agent_output"],
+                "human_score": ex["human_score"],
+                "human_notes": ex["human_notes"],
+            }
+            for ex in calibration
+        ]
+
+        judge = LLMJudge(
+            provider=provider,
+            model=MODEL,
+            rubric="Clarity and insight about software testing. Score 0-1.",
+        )
+
+        result = judge.evaluate(
+            task_prompt="Write one sentence about the value of testing.",
+            agent_output="Automated tests act as a safety net, catching regressions before they reach production.",
+            calibration_examples=cal_examples,
+        )
+
+        print(f"\n  Score with calibration: {result.score:.2f}")
+        print(f"  Reasoning: {result.reasoning[:100]}...")
+
+        assert 0.0 <= result.score <= 1.0
+        assert result.reasoning

--- a/ts/tests/agent-e2e.test.ts
+++ b/ts/tests/agent-e2e.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Agent Self-Improvement E2E tests.
+ *
+ * Exercises the full MTS pipeline: task creation → judge evaluation →
+ * improvement loop → task queue → skill export, all with mock providers.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import type {
+  LLMProvider,
+  CompletionResult,
+  AgentTaskInterface,
+  AgentTaskResult,
+} from "../src/types/index.js";
+import { ImprovementLoop } from "../src/execution/improvement-loop.js";
+import {
+  TaskRunner,
+  SimpleAgentTask,
+  enqueueTask,
+} from "../src/execution/task-runner.js";
+import { JudgeExecutor } from "../src/execution/judge-executor.js";
+import { LLMJudge } from "../src/judge/index.js";
+import { parseJudgeResponse } from "../src/judge/parse.js";
+import { SQLiteStore } from "../src/storage/index.js";
+import { createAgentTask } from "../src/scenarios/agent-task-factory.js";
+import type { AgentTaskSpec } from "../src/scenarios/agent-task-spec.js";
+import {
+  SkillPackage,
+  exportAgentTaskSkill,
+} from "../src/knowledge/skill-package.js";
+import { DirectAPIRuntime } from "../src/runtimes/direct-api.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MIGRATIONS_DIR = join(import.meta.dirname ?? ".", "..", "migrations");
+
+function makeJudgeResponse(score: number, dims?: Record<string, number>): string {
+  return (
+    `Evaluation:\n<!-- JUDGE_RESULT_START -->\n` +
+    JSON.stringify({
+      score,
+      reasoning: `test reasoning (score=${score})`,
+      dimensions: dims ?? { accuracy: score },
+    }) +
+    `\n<!-- JUDGE_RESULT_END -->`
+  );
+}
+
+/**
+ * Build a mock LLMProvider.
+ *
+ * - `judgeScores`: successive scores returned for judge calls (cycles).
+ * - `generationText`: text returned for non-judge completions.
+ */
+function makeMockProvider(opts?: {
+  judgeScores?: number[];
+  generationText?: string;
+}): LLMProvider & { callCount: number } {
+  const scores = opts?.judgeScores ?? [0.7];
+  const genText = opts?.generationText ?? "Generated output.";
+  let idx = 0;
+
+  const provider: LLMProvider & { callCount: number } = {
+    name: "mock",
+    callCount: 0,
+    defaultModel: () => "mock-model",
+    complete: async (args): Promise<CompletionResult> => {
+      provider.callCount++;
+      const isJudge =
+        args.systemPrompt.includes("expert judge") ||
+        args.userPrompt.includes("JUDGE_RESULT");
+
+      if (isJudge) {
+        const score = scores[Math.min(idx, scores.length - 1)];
+        idx++;
+        return {
+          text: makeJudgeResponse(score),
+          model: "mock-model",
+          usage: {},
+        };
+      }
+      // Generation / revision call
+      return {
+        text: `${genText} [call ${provider.callCount}]`,
+        model: "mock-model",
+        usage: {},
+      };
+    },
+  };
+  return provider;
+}
+
+function createTempStore(): { store: SQLiteStore; tmpDir: string } {
+  const tmpDir = mkdtempSync(join(tmpdir(), "mts-e2e-"));
+  const store = new SQLiteStore(join(tmpDir, "test.db"));
+  store.migrate(MIGRATIONS_DIR);
+  return { store, tmpDir };
+}
+
+// ---------------------------------------------------------------------------
+// Agent Self-Improvement E2E
+// ---------------------------------------------------------------------------
+
+describe("Agent Self-Improvement E2E", () => {
+  let tmpDir: string;
+  let store: SQLiteStore;
+
+  beforeEach(() => {
+    const s = createTempStore();
+    tmpDir = s.tmpDir;
+    store = s.store;
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates task, evaluates output, and scores it", async () => {
+    const provider = makeMockProvider({ judgeScores: [0.72] });
+
+    const spec: AgentTaskSpec = {
+      taskPrompt: "Write a short essay about AI safety.",
+      judgeRubric: "Evaluate clarity, accuracy, and depth on a 0–1 scale.",
+      outputFormat: "free_text",
+      judgeModel: "mock-model",
+      maxRounds: 1,
+      qualityThreshold: 0.9,
+    };
+
+    const task = createAgentTask({ spec, name: "ai_safety_essay", provider });
+    const state = task.initialState();
+    expect(state.taskName).toBe("ai_safety_essay");
+
+    const result = await task.evaluateOutput("AI safety is important because…", state);
+    expect(result.score).toBeCloseTo(0.72, 1);
+    expect(result.reasoning).toContain("test reasoning");
+    expect(result.dimensionScores).toHaveProperty("accuracy");
+  });
+
+  it("improvement loop improves score across rounds", async () => {
+    const provider = makeMockProvider({
+      judgeScores: [0.4, 0.6, 0.85],
+      generationText: "Revised output",
+    });
+
+    const task = new SimpleAgentTask(
+      "Summarize quantum computing in 100 words.",
+      "Evaluate accuracy and conciseness.",
+      provider,
+      "mock-model",
+    );
+
+    const loop = new ImprovementLoop({
+      task,
+      maxRounds: 5,
+      qualityThreshold: 0.9,
+    });
+
+    const result = await loop.run({
+      initialOutput: "Quantum computing uses qubits.",
+      state: {},
+    });
+
+    expect(result.rounds.length).toBeGreaterThanOrEqual(3);
+    expect(result.bestScore).toBeCloseTo(0.85, 1);
+    // Scores should be non-decreasing among valid rounds
+    const validScores = result.rounds
+      .filter((r) => !r.judgeFailed)
+      .map((r) => r.score);
+    for (let i = 1; i < validScores.length; i++) {
+      expect(validScores[i]).toBeGreaterThanOrEqual(validScores[i - 1]);
+    }
+  });
+
+  it("full pipeline: create → queue → run → export", async () => {
+    const provider = makeMockProvider({
+      judgeScores: [0.92],
+      generationText: "Excellent summary of distributed systems.",
+    });
+
+    // 1. Enqueue
+    const taskId = enqueueTask(store, "distributed_systems", {
+      taskPrompt: "Write about distributed consensus algorithms.",
+      rubric: "Evaluate correctness and depth.",
+      maxRounds: 2,
+      qualityThreshold: 0.9,
+    });
+    expect(store.pendingTaskCount()).toBe(1);
+
+    // 2. Run via TaskRunner
+    const runner = new TaskRunner({ store, provider, model: "mock-model" });
+    const completed = await runner.runOnce();
+
+    expect(completed).not.toBeNull();
+    expect(completed!.status).toBe("completed");
+    expect(completed!.best_score).toBeGreaterThanOrEqual(0.9);
+    expect(completed!.met_threshold).toBe(1); // SQLite stores as 1/0
+    expect(store.pendingTaskCount()).toBe(0);
+
+    // 3. Export as skill
+    const skill = exportAgentTaskSkill({
+      scenarioName: "distributed_systems",
+      taskPrompt: "Write about distributed consensus algorithms.",
+      judgeRubric: "Evaluate correctness and depth.",
+      outputFormat: "free_text",
+      playbook: "Focus on Raft and Paxos.",
+      lessons: ["Clarity matters.", "Include examples."],
+      bestOutputs: [
+        {
+          output: completed!.best_output!,
+          score: completed!.best_score!,
+          reasoning: "Solid coverage.",
+        },
+      ],
+    });
+
+    expect(skill.scenarioName).toBe("distributed_systems");
+    expect(skill.bestScore).toBeGreaterThanOrEqual(0.9);
+    const md = skill.toSkillMarkdown();
+    expect(md).toContain("distributed consensus");
+    expect(md).toContain("Clarity matters.");
+  });
+
+  it("human feedback calibrates future evaluations", () => {
+    // Store feedback
+    store.insertHumanFeedback(
+      "code_review",
+      "def foo(): pass",
+      0.3,
+      "Too trivial, no error handling",
+    );
+    store.insertHumanFeedback(
+      "code_review",
+      "def foo():\n  try:\n    ...\n  except Exception as e:\n    log(e)",
+      0.8,
+      "Good error handling pattern",
+    );
+    store.insertHumanFeedback("code_review", "print('hello')", 0.1, "Not a function");
+
+    // Retrieve calibration examples (most recently inserted first by rowid/created_at)
+    const examples = store.getCalibrationExamples("code_review", 5);
+    expect(examples.length).toBe(3);
+    // All scores present
+    const scores = examples.map((e) => e.human_score).sort();
+    expect(scores).toEqual([0.1, 0.3, 0.8]);
+
+    // Verify they can be fed as calibration
+    const calibration = examples.map((e) => ({
+      agent_output: e.agent_output,
+      human_score: e.human_score,
+      human_notes: e.human_notes,
+    }));
+    expect(calibration).toHaveLength(3);
+    expect(calibration[0]).toHaveProperty("human_score");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MCP Tool Flow E2E (testing underlying functions, not transport)
+// ---------------------------------------------------------------------------
+
+describe("MCP Tool Flow E2E", () => {
+  let tmpDir: string;
+  let store: SQLiteStore;
+
+  beforeEach(() => {
+    const s = createTempStore();
+    tmpDir = s.tmpDir;
+    store = s.store;
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("evaluate → improve → export flow", async () => {
+    const provider = makeMockProvider({
+      judgeScores: [0.55, 0.78, 0.91],
+      generationText: "Improved version",
+    });
+
+    // Step 1: One-shot evaluate (mirrors evaluate_output MCP tool)
+    const judge = new LLMJudge({
+      provider,
+      model: "mock-model",
+      rubric: "Evaluate quality on 0–1 scale.",
+    });
+    const evalResult = await judge.evaluate({
+      taskPrompt: "Write about microservices.",
+      agentOutput: "Microservices are small services.",
+    });
+    expect(evalResult.score).toBeCloseTo(0.55, 1);
+
+    // Step 2: Run improvement loop (mirrors run_improvement_loop MCP tool)
+    const task = new SimpleAgentTask(
+      "Write about microservices.",
+      "Evaluate quality on 0–1 scale.",
+      provider,
+      "mock-model",
+    );
+    const loop = new ImprovementLoop({
+      task,
+      maxRounds: 5,
+      qualityThreshold: 0.9,
+    });
+    const loopResult = await loop.run({
+      initialOutput: "Microservices are small services.",
+      state: {},
+    });
+    expect(loopResult.metThreshold).toBe(true);
+    expect(loopResult.bestScore).toBeGreaterThanOrEqual(0.9);
+
+    // Step 3: Queue task (mirrors queue_task MCP tool)
+    const taskId = enqueueTask(store, "microservices_essay", {
+      taskPrompt: "Write about microservices.",
+      rubric: "Evaluate quality.",
+      initialOutput: loopResult.bestOutput,
+      maxRounds: 1,
+      qualityThreshold: 0.85,
+    });
+    const queued = store.getTask(taskId);
+    expect(queued).not.toBeNull();
+    expect(queued!.status).toBe("pending");
+
+    // Step 4: Export
+    const skill = exportAgentTaskSkill({
+      scenarioName: "microservices",
+      taskPrompt: "Write about microservices.",
+      judgeRubric: "Evaluate quality.",
+      outputFormat: "free_text",
+      playbook: "Cover decomposition, communication, and deployment.",
+      lessons: ["Keep services focused.", "Use async messaging."],
+      bestOutputs: [
+        {
+          output: loopResult.bestOutput,
+          score: loopResult.bestScore,
+          reasoning: "Good coverage.",
+        },
+      ],
+    });
+    const dict = skill.toDict();
+    expect(dict.scenario_name).toBe("microservices");
+    expect(dict.task_prompt).toBe("Write about microservices.");
+    expect(dict.best_score).toBeGreaterThanOrEqual(0.9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Agent Runtime E2E
+// ---------------------------------------------------------------------------
+
+describe("Agent Runtime E2E", () => {
+  it("generates and revises with mock provider", async () => {
+    const provider = makeMockProvider({ generationText: "Initial draft" });
+    const runtime = new DirectAPIRuntime(provider, "mock-model");
+
+    // Generate
+    const gen = await runtime.generate({
+      prompt: "Explain event sourcing.",
+    });
+    expect(gen.text).toContain("Initial draft");
+
+    // Revise
+    const rev = await runtime.revise({
+      prompt: "Explain event sourcing.",
+      previousOutput: gen.text,
+      feedback: "Add more examples and clarify terminology.",
+    });
+    expect(rev.text).toContain("Initial draft");
+    // Revision should be a distinct call
+    expect(provider.callCount).toBe(2);
+  });
+
+  it("runtime output feeds into improvement loop", async () => {
+    const provider = makeMockProvider({
+      judgeScores: [0.5, 0.88],
+      generationText: "Runtime output about event sourcing",
+    });
+    const runtime = new DirectAPIRuntime(provider, "mock-model");
+
+    // Generate initial output via runtime
+    const gen = await runtime.generate({
+      prompt: "Explain event sourcing patterns.",
+    });
+
+    // Feed into improvement loop
+    const task = new SimpleAgentTask(
+      "Explain event sourcing patterns.",
+      "Evaluate depth and accuracy.",
+      provider,
+      "mock-model",
+    );
+    const loop = new ImprovementLoop({
+      task,
+      maxRounds: 3,
+      qualityThreshold: 0.85,
+    });
+    const result = await loop.run({
+      initialOutput: gen.text,
+      state: {},
+    });
+
+    expect(result.rounds.length).toBeGreaterThanOrEqual(2);
+    expect(result.bestScore).toBeGreaterThanOrEqual(0.85);
+    // First round used runtime output
+    expect(result.rounds[0].output).toContain("Runtime output");
+  });
+
+  it("JudgeExecutor handles context validation", async () => {
+    const provider = makeMockProvider({ judgeScores: [0.75] });
+
+    const spec: AgentTaskSpec = {
+      taskPrompt: "Analyze data.",
+      judgeRubric: "Check completeness.",
+      outputFormat: "free_text",
+      judgeModel: "mock-model",
+      maxRounds: 1,
+      qualityThreshold: 0.9,
+      requiredContextKeys: ["dataset"],
+    };
+
+    const task = createAgentTask({ spec, name: "data_analysis", provider });
+    const executor = new JudgeExecutor(task);
+
+    // Missing required context key → score 0
+    const failResult = await executor.execute("Analysis results...", {});
+    expect(failResult.score).toBe(0);
+    expect(failResult.reasoning).toContain("Context validation failed");
+
+    // With required key → normal evaluation
+    const okResult = await executor.execute("Analysis results...", {
+      dataset: "test_data.csv",
+    });
+    expect(okResult.score).toBeCloseTo(0.75, 1);
+  });
+});


### PR DESCRIPTION
## What

E2E test suites covering the full agent self-improvement pipeline — how an agent uses MTS to improve itself.

## Changes

### New test files
- **`mts/tests/test_agent_e2e.py`** — 11 tests with mocked providers (CI-safe, 0.22s)
  - `TestAgentSelfImprovementE2E`: create task → judge → improvement loop → human feedback → notifications
  - `TestMCPToolsAgentFlow`: MCP tool CRUD + evaluate + queue + process
  - `TestAgentRuntimeE2E`: DirectAPIRuntime generate → revise → feed into loop

- **`mts/tests/test_agent_live_e2e.py`** — Live Anthropic API tests (skipped when `ANTHROPIC_API_KEY` not set)
  - Real judge evaluation, 2-round improvement loops, full task runner pipeline

- **`ts/tests/agent-e2e.test.ts`** — 8 Vitest tests with mocked providers
  - Mirrors the Python e2e coverage for the TS port

### MCP tool additions (closes agent pipeline gaps)
- **`generate_output`** — Generate an initial attempt for an agent task via MCP
- **`export_agent_task_skill`** — Export a portable skill package from MCP-created agent tasks

These two tools close the loop so an agent can do the full pipeline through MCP:
`create_agent_task` → `generate_output` → `evaluate_output` → `run_improvement_loop` → `export_agent_task_skill`

## Test results
- Python mocked: 11/11 ✅ (0.22s)
- TypeScript: 8/8 ✅ (12ms)
- Live API: running (skipped in CI without key)