### PR TITLE
feat: structured JSON progress snapshot for agent prompts

### DIFF
--- a/mts/src/mts/config/settings.py
+++ b/mts/src/mts/config/settings.py
@@ -123,6 +123,8 @@ class AppSettings(BaseModel):
     stagnation_distill_top_lessons: int = Field(
         default=5, ge=1, description="Top lessons to retain in fresh start",
     )
+    # Progress JSON
+    progress_json_enabled: bool = Field(default=True, description="Inject structured progress JSON into prompts")
 
 
 def load_settings() -> AppSettings:
@@ -216,4 +218,5 @@ def load_settings() -> AppSettings:
         stagnation_plateau_window=int(os.getenv("MTS_STAGNATION_PLATEAU_WINDOW", "5")),
         stagnation_plateau_epsilon=float(os.getenv("MTS_STAGNATION_PLATEAU_EPSILON", "0.01")),
         stagnation_distill_top_lessons=int(os.getenv("MTS_STAGNATION_DISTILL_TOP_LESSONS", "5")),
+        progress_json_enabled=os.getenv("MTS_PROGRESS_JSON_ENABLED", "true").lower() == "true",
     )

--- a/mts/src/mts/knowledge/progress.py
+++ b/mts/src/mts/knowledge/progress.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class ProgressSnapshot:
+    generation: int
+    best_score: float
+    best_elo: float
+    mean_score: float
+    last_advance_generation: int
+    stagnation_count: int
+    gate_history: list[str]
+    top_lessons: list[str]
+    blocked_approaches: list[str]
+    strategy_summary: dict[str, Any]
+    score_trend: list[float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProgressSnapshot:
+        return cls(**data)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+
+def build_progress_snapshot(
+    generation: int,
+    best_score: float,
+    best_elo: float,
+    mean_score: float,
+    gate_history: list[str],
+    score_history: list[float],
+    current_strategy: dict[str, Any],
+    lessons: list[str],
+) -> ProgressSnapshot:
+    last_advance_generation = 0
+    for i, decision in enumerate(gate_history):
+        if decision == "advance":
+            last_advance_generation = i + 1
+
+    stagnation_count = 0
+    for decision in reversed(gate_history):
+        if decision != "advance":
+            stagnation_count += 1
+        else:
+            break
+
+    return ProgressSnapshot(
+        generation=generation,
+        best_score=best_score,
+        best_elo=best_elo,
+        mean_score=mean_score,
+        last_advance_generation=last_advance_generation,
+        stagnation_count=stagnation_count,
+        gate_history=list(gate_history),
+        top_lessons=lessons[:5],
+        blocked_approaches=[],
+        strategy_summary=dict(current_strategy),
+        score_trend=score_history[-10:],
+    )

--- a/mts/src/mts/loop/stages.py
+++ b/mts/src/mts/loop/stages.py
@@ -48,6 +48,12 @@ def stage_knowledge_setup(
     score_trajectory = "" if ablation else trajectory_builder.build_trajectory(ctx.run_id)
     strategy_registry = "" if ablation else trajectory_builder.build_strategy_registry(ctx.run_id)
 
+    progress_json_str = ""
+    if not ablation and ctx.settings.progress_json_enabled:
+        progress_data = artifacts.read_progress(ctx.scenario_name)
+        if progress_data:
+            progress_json_str = json.dumps(progress_data, indent=2, sort_keys=True)
+
     summary_text = f"best score so far: {ctx.previous_best:.4f}"
     strategy_interface = scenario.describe_strategy_interface()
 
@@ -65,6 +71,7 @@ def stage_knowledge_setup(
         recent_analysis=recent_analysis,
         score_trajectory=score_trajectory,
         strategy_registry=strategy_registry,
+        progress_json=progress_json_str,
     )
 
     ctx.prompts = prompts
@@ -537,6 +544,22 @@ def stage_persistence(
     ctx.coach_competitor_hints = coach_competitor_hints
     if gate_decision == "advance" and coach_competitor_hints:
         artifacts.write_hints(scenario_name, coach_competitor_hints)
+
+    # 7b. Write progress snapshot
+    if ctx.settings.progress_json_enabled and not ctx.settings.ablation_no_feedback:
+        from mts.knowledge.progress import build_progress_snapshot
+        progress_lessons = artifacts.read_skill_lessons_raw(scenario_name)
+        snapshot = build_progress_snapshot(
+            generation=generation,
+            best_score=ctx.previous_best,
+            best_elo=ctx.challenger_elo,
+            mean_score=tournament.mean_score,
+            gate_history=ctx.gate_decision_history,
+            score_history=ctx.score_history,
+            current_strategy=ctx.current_strategy,
+            lessons=[lesson.lstrip("- ") for lesson in progress_lessons],
+        )
+        artifacts.write_progress(scenario_name, snapshot.to_dict())
 
     # 8. Emit generation_completed event
     events.emit("generation_completed", {

--- a/mts/src/mts/prompts/templates.py
+++ b/mts/src/mts/prompts/templates.py
@@ -27,6 +27,7 @@ def build_prompt_bundle(
     recent_analysis: str = "",
     score_trajectory: str = "",
     strategy_registry: str = "",
+    progress_json: str = "",
 ) -> PromptBundle:
     lessons_block = (
         f"Operational lessons (from prior generations):\n{operational_lessons}\n\n"
@@ -53,6 +54,11 @@ def build_prompt_bundle(
         if strategy_registry
         else ""
     )
+    progress_block = (
+        f"Progress snapshot:\n```json\n{progress_json}\n```\n\n"
+        if progress_json
+        else ""
+    )
     base_context = (
         f"Scenario rules:\n{scenario_rules}\n\n"
         f"Strategy interface:\n{strategy_interface}\n\n"
@@ -68,6 +74,7 @@ def build_prompt_bundle(
         f"Previous generation summary:\n{previous_summary}\n"
         f"{trajectory_block}"
         f"{registry_block}"
+        f"{progress_block}"
     )
     hints_block = (
         f"Coach hints for competitor:\n{coach_competitor_hints}\n\n"

--- a/mts/src/mts/storage/artifacts.py
+++ b/mts/src/mts/storage/artifacts.py
@@ -112,6 +112,18 @@ class ArtifactStore:
         path = self.knowledge_root / scenario_name / "hints.md"
         return path.read_text(encoding="utf-8") if path.exists() else ""
 
+    def write_progress(self, scenario_name: str, snapshot_dict: dict[str, object]) -> None:
+        """Write progress snapshot JSON."""
+        path = self.knowledge_root / scenario_name / "progress.json"
+        self.write_json(path, snapshot_dict)
+
+    def read_progress(self, scenario_name: str) -> dict[str, object] | None:
+        """Read progress snapshot, or None if missing."""
+        path = self.knowledge_root / scenario_name / "progress.json"
+        if not path.exists():
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
+
     def read_latest_advance_analysis(self, scenario_name: str, current_gen: int) -> str:
         """Read the most recent analysis from a generation before current_gen."""
         analysis_dir = self.knowledge_root / scenario_name / "analysis"

--- a/mts/tests/test_generation_stages.py
+++ b/mts/tests/test_generation_stages.py
@@ -184,6 +184,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_tool_context.return_value = ""
         artifacts.read_skills.return_value = ""
         artifacts.read_latest_advance_analysis.return_value = ""
+        artifacts.read_progress.return_value = None
         trajectory = MagicMock()
         trajectory.build_trajectory.return_value = ""
         trajectory.build_strategy_registry.return_value = ""
@@ -198,6 +199,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_tool_context.return_value = ""
         artifacts.read_skills.return_value = ""
         artifacts.read_latest_advance_analysis.return_value = ""
+        artifacts.read_progress.return_value = None
         trajectory = MagicMock()
         trajectory.build_trajectory.return_value = ""
         trajectory.build_strategy_registry.return_value = ""

--- a/mts/tests/test_progress_json.py
+++ b/mts/tests/test_progress_json.py
@@ -1,0 +1,270 @@
+"""Tests for structured progress JSON snapshot."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mts.knowledge.progress import ProgressSnapshot, build_progress_snapshot
+from mts.scenarios.base import Observation
+from mts.storage.artifacts import ArtifactStore
+
+# ── ProgressSnapshot dataclass ──────────────────────────────────────────
+
+
+class TestProgressSnapshot:
+    def test_to_dict_roundtrip(self) -> None:
+        snap = ProgressSnapshot(
+            generation=3,
+            best_score=0.75,
+            best_elo=1050.0,
+            mean_score=0.65,
+            last_advance_generation=2,
+            stagnation_count=1,
+            gate_history=["advance", "advance", "rollback"],
+            top_lessons=["lesson1", "lesson2"],
+            blocked_approaches=[],
+            strategy_summary={"aggression": 0.8},
+            score_trend=[0.5, 0.6, 0.75],
+        )
+        d = snap.to_dict()
+        restored = ProgressSnapshot.from_dict(d)
+        assert restored == snap
+
+    def test_to_json_valid(self) -> None:
+        snap = ProgressSnapshot(
+            generation=1,
+            best_score=0.5,
+            best_elo=1000.0,
+            mean_score=0.45,
+            last_advance_generation=1,
+            stagnation_count=0,
+            gate_history=["advance"],
+            top_lessons=[],
+            blocked_approaches=[],
+            strategy_summary={},
+            score_trend=[0.5],
+        )
+        parsed = json.loads(snap.to_json())
+        assert parsed["generation"] == 1
+        assert parsed["best_score"] == 0.5
+
+    def test_to_json_sorted_keys(self) -> None:
+        snap = ProgressSnapshot(
+            generation=1,
+            best_score=0.5,
+            best_elo=1000.0,
+            mean_score=0.45,
+            last_advance_generation=0,
+            stagnation_count=0,
+            gate_history=[],
+            top_lessons=[],
+            blocked_approaches=[],
+            strategy_summary={},
+            score_trend=[],
+        )
+        text = snap.to_json()
+        keys = list(json.loads(text).keys())
+        assert keys == sorted(keys)
+
+
+# ── build_progress_snapshot ─────────────────────────────────────────────
+
+
+class TestBuildProgressSnapshot:
+    def test_last_advance_generation(self) -> None:
+        snap = build_progress_snapshot(
+            generation=4,
+            best_score=0.8,
+            best_elo=1100.0,
+            mean_score=0.7,
+            gate_history=["advance", "rollback", "advance", "rollback"],
+            score_history=[0.5, 0.6, 0.8, 0.7],
+            current_strategy={"x": 1},
+            lessons=["a", "b", "c"],
+        )
+        assert snap.last_advance_generation == 3  # 3rd entry (index 2) is last advance
+
+    def test_stagnation_count_trailing_rollbacks(self) -> None:
+        snap = build_progress_snapshot(
+            generation=5,
+            best_score=0.6,
+            best_elo=1000.0,
+            mean_score=0.55,
+            gate_history=["advance", "rollback", "rollback", "rollback"],
+            score_history=[0.6, 0.5, 0.5, 0.5],
+            current_strategy={},
+            lessons=[],
+        )
+        assert snap.stagnation_count == 3
+
+    def test_stagnation_count_all_advance(self) -> None:
+        snap = build_progress_snapshot(
+            generation=3,
+            best_score=0.9,
+            best_elo=1200.0,
+            mean_score=0.85,
+            gate_history=["advance", "advance", "advance"],
+            score_history=[0.7, 0.8, 0.9],
+            current_strategy={},
+            lessons=[],
+        )
+        assert snap.stagnation_count == 0
+
+    def test_top_lessons_capped_at_5(self) -> None:
+        lessons = [f"lesson_{i}" for i in range(10)]
+        snap = build_progress_snapshot(
+            generation=1,
+            best_score=0.5,
+            best_elo=1000.0,
+            mean_score=0.45,
+            gate_history=["advance"],
+            score_history=[0.5],
+            current_strategy={},
+            lessons=lessons,
+        )
+        assert len(snap.top_lessons) == 5
+        assert snap.top_lessons == lessons[:5]
+
+    def test_score_trend_last_10(self) -> None:
+        scores = list(range(20))
+        snap = build_progress_snapshot(
+            generation=20,
+            best_score=19.0,
+            best_elo=1500.0,
+            mean_score=15.0,
+            gate_history=[],
+            score_history=[float(s) for s in scores],
+            current_strategy={},
+            lessons=[],
+        )
+        assert len(snap.score_trend) == 10
+        assert snap.score_trend == [float(s) for s in range(10, 20)]
+
+    def test_empty_gate_history(self) -> None:
+        snap = build_progress_snapshot(
+            generation=0,
+            best_score=0.0,
+            best_elo=1000.0,
+            mean_score=0.0,
+            gate_history=[],
+            score_history=[],
+            current_strategy={},
+            lessons=[],
+        )
+        assert snap.last_advance_generation == 0
+        assert snap.stagnation_count == 0
+
+    def test_strategy_summary_is_copy(self) -> None:
+        strategy = {"aggression": 0.5}
+        snap = build_progress_snapshot(
+            generation=1,
+            best_score=0.5,
+            best_elo=1000.0,
+            mean_score=0.5,
+            gate_history=[],
+            score_history=[0.5],
+            current_strategy=strategy,
+            lessons=[],
+        )
+        assert snap.strategy_summary == strategy
+        assert snap.strategy_summary is not strategy
+
+
+# ── ArtifactStore write/read progress ───────────────────────────────────
+
+
+class TestArtifactStoreProgress:
+    def _make_store(self, tmp_path: Path) -> ArtifactStore:
+        return ArtifactStore(
+            runs_root=tmp_path / "runs",
+            knowledge_root=tmp_path / "knowledge",
+            skills_root=tmp_path / "skills",
+            claude_skills_path=tmp_path / ".claude" / "skills",
+        )
+
+    def test_read_progress_missing(self, tmp_path: Path) -> None:
+        store = self._make_store(tmp_path)
+        assert store.read_progress("test_scenario") is None
+
+    def test_write_and_read_progress(self, tmp_path: Path) -> None:
+        store = self._make_store(tmp_path)
+        data: dict[str, object] = {"generation": 1, "best_score": 0.5}
+        store.write_progress("test_scenario", data)
+        result = store.read_progress("test_scenario")
+        assert result is not None
+        assert result["generation"] == 1
+        assert result["best_score"] == 0.5
+
+    def test_write_progress_creates_directory(self, tmp_path: Path) -> None:
+        store = self._make_store(tmp_path)
+        data: dict[str, object] = {"generation": 1}
+        store.write_progress("new_scenario", data)
+        path = tmp_path / "knowledge" / "new_scenario" / "progress.json"
+        assert path.exists()
+
+    def test_write_progress_overwrites(self, tmp_path: Path) -> None:
+        store = self._make_store(tmp_path)
+        store.write_progress("s1", {"generation": 1, "best_score": 0.3})
+        store.write_progress("s1", {"generation": 2, "best_score": 0.7})
+        result = store.read_progress("s1")
+        assert result is not None
+        assert result["generation"] == 2
+        assert result["best_score"] == 0.7
+
+
+# ── Prompt bundle injection ─────────────────────────────────────────────
+
+
+class TestPromptBundleProgressInjection:
+    def _obs(self) -> Observation:
+        return Observation(narrative="test", state={"key": "value"}, constraints=["c1"])
+
+    def test_progress_json_included_in_prompt(self) -> None:
+        from mts.prompts.templates import build_prompt_bundle
+
+        progress = json.dumps({"generation": 3, "best_score": 0.8}, indent=2, sort_keys=True)
+        bundle = build_prompt_bundle(
+            scenario_rules="rules",
+            strategy_interface="interface",
+            evaluation_criteria="criteria",
+            previous_summary="summary",
+            observation=self._obs(),
+            current_playbook="playbook",
+            available_tools="tools",
+            progress_json=progress,
+        )
+        assert "Progress snapshot:" in bundle.competitor
+        assert '"best_score": 0.8' in bundle.competitor
+        assert "Progress snapshot:" in bundle.analyst
+        assert "Progress snapshot:" in bundle.coach
+
+    def test_no_progress_json_when_empty(self) -> None:
+        from mts.prompts.templates import build_prompt_bundle
+
+        bundle = build_prompt_bundle(
+            scenario_rules="rules",
+            strategy_interface="interface",
+            evaluation_criteria="criteria",
+            previous_summary="summary",
+            observation=self._obs(),
+            current_playbook="playbook",
+            available_tools="tools",
+            progress_json="",
+        )
+        assert "Progress snapshot:" not in bundle.competitor
+        assert "Progress snapshot:" not in bundle.analyst
+
+    def test_progress_json_default_empty(self) -> None:
+        from mts.prompts.templates import build_prompt_bundle
+
+        bundle = build_prompt_bundle(
+            scenario_rules="rules",
+            strategy_interface="interface",
+            evaluation_criteria="criteria",
+            previous_summary="summary",
+            observation=self._obs(),
+            current_playbook="playbook",
+            available_tools="tools",
+        )
+        assert "Progress snapshot:" not in bundle.competitor


### PR DESCRIPTION
## Summary
- Add `ProgressSnapshot` dataclass capturing generation state (scores, gate history, stagnation count, top lessons, strategy summary)
- Inject snapshot as fenced JSON block into agent prompts via `build_prompt_bundle()`
- Controlled by `MTS_PROGRESS_JSON_ENABLED` (default: `true`)

## Changes
- **New**: `mts/src/mts/knowledge/progress.py` — `ProgressSnapshot` + `build_progress_snapshot()` factory
- **Modified**: `mts/src/mts/storage/artifacts.py` — `write_progress()` / `read_progress()` methods
- **Modified**: `mts/src/mts/prompts/templates.py` — `progress_json` param on `build_prompt_bundle()`
- **Modified**: `mts/src/mts/loop/stages.py` — read in `stage_knowledge_setup`, write in `stage_persistence`
- **Modified**: `mts/src/mts/config/settings.py` — `progress_json_enabled` setting
- **New**: `mts/tests/test_progress_json.py` — 17 tests

## Test plan
- [x] `build_progress_snapshot` field computation (stagnation count, last advance gen, lessons capping)
- [x] `to_dict` / `from_dict` roundtrip serialization
- [x] `write_progress` / `read_progress` with `tmp_path`
- [x] Prompt bundle injection (enabled vs disabled)
- [x] Full test suite: 1213 passed, 21 skipped, ruff/mypy clean