### PR TITLE
feat: constraint-oriented prompt reframing for all agent roles

### DIFF
--- a/mts/src/mts/agents/curator.py
+++ b/mts/src/mts/agents/curator.py
@@ -73,6 +73,21 @@ def parse_curator_lesson_result(content: str) -> CuratorLessonResult:
     )
 
 
+_CURATOR_ASSESSMENT_CONSTRAINT = (
+    "Constraints:\n"
+    "- Do NOT accept a playbook that removes validated high-scoring strategies\n"
+    "- Do NOT reject a playbook without comparing specific coverage gaps\n"
+    "- Do NOT merge without preserving the highest-scoring strategy components\n\n"
+)
+
+_CURATOR_CONSOLIDATION_CONSTRAINT = (
+    "Constraints:\n"
+    "- Do NOT remove lessons that are supported by score improvements\n"
+    "- Do NOT merge semantically distinct lessons into a single vague bullet\n"
+    "- Do NOT keep lessons that directly contradict each other without resolution\n\n"
+)
+
+
 class KnowledgeCurator:
     def __init__(self, runtime: SubagentRuntime, model: str):
         self.runtime = runtime
@@ -84,10 +99,13 @@ class KnowledgeCurator:
         proposed_playbook: str,
         score_trajectory: str,
         recent_analysis: str,
+        constraint_mode: bool = False,
     ) -> tuple[CuratorPlaybookDecision, RoleExecution]:
         """Compare current vs proposed playbook. Return accept/reject/merge decision."""
+        constraint_preamble = _CURATOR_ASSESSMENT_CONSTRAINT if constraint_mode else ""
         prompt = (
-            "You are a curator assessing playbook quality. Compare the CURRENT and PROPOSED playbooks.\n\n"
+            constraint_preamble
+            + "You are a curator assessing playbook quality. Compare the CURRENT and PROPOSED playbooks.\n\n"
             "Score both on: coverage, specificity, actionability (1-10 each).\n"
             "Decide: accept (proposed is better), reject (current is better), or merge (combine best parts).\n\n"
             f"CURRENT PLAYBOOK:\n{current_playbook}\n\n"
@@ -121,11 +139,14 @@ class KnowledgeCurator:
         existing_lessons: list[str],
         max_lessons: int,
         score_trajectory: str,
+        constraint_mode: bool = False,
     ) -> tuple[CuratorLessonResult, RoleExecution]:
         """Deduplicate semantically, rank by evidence, cap at max_lessons."""
         lessons_text = "\n".join(existing_lessons)
+        constraint_preamble = _CURATOR_CONSOLIDATION_CONSTRAINT if constraint_mode else ""
         prompt = (
-            "You are a curator consolidating operational lessons. "
+            constraint_preamble
+            + "You are a curator consolidating operational lessons. "
             f"Reduce {len(existing_lessons)} lessons to at most {max_lessons}.\n\n"
             "Deduplicate semantically similar lessons. Rank by evidence strength.\n"
             "Remove outdated or contradicted lessons.\n\n"

--- a/mts/src/mts/agents/orchestrator.py
+++ b/mts/src/mts/agents/orchestrator.py
@@ -263,20 +263,37 @@ class AgentOrchestrator:
         assert self._rlm_loader is not None
         settings = self.settings
 
-        # Select worker class and prompt templates based on rlm_backend
+        # Select worker class and prompt templates based on rlm_backend and constraint_mode
+        use_constraints = settings.constraint_prompts_enabled
         if settings.rlm_backend == "monty":
             from mts.harness.repl.monty_worker import MontyReplWorker
-            from mts.rlm.prompts import ANALYST_MONTY_RLM_SYSTEM, ARCHITECT_MONTY_RLM_SYSTEM
 
-            analyst_system_tpl = ANALYST_MONTY_RLM_SYSTEM
-            architect_system_tpl = ARCHITECT_MONTY_RLM_SYSTEM
+            if use_constraints:
+                from mts.rlm.prompts import (
+                    ANALYST_MONTY_RLM_SYSTEM_CONSTRAINED,
+                    ARCHITECT_MONTY_RLM_SYSTEM_CONSTRAINED,
+                )
+                analyst_system_tpl = ANALYST_MONTY_RLM_SYSTEM_CONSTRAINED
+                architect_system_tpl = ARCHITECT_MONTY_RLM_SYSTEM_CONSTRAINED
+            else:
+                from mts.rlm.prompts import ANALYST_MONTY_RLM_SYSTEM, ARCHITECT_MONTY_RLM_SYSTEM
+                analyst_system_tpl = ANALYST_MONTY_RLM_SYSTEM
+                architect_system_tpl = ARCHITECT_MONTY_RLM_SYSTEM
             worker_cls: type = MontyReplWorker
         else:
-            from mts.rlm.prompts import ANALYST_RLM_SYSTEM, ARCHITECT_RLM_SYSTEM
             from mts.rlm.repl_worker import ReplWorker
 
-            analyst_system_tpl = ANALYST_RLM_SYSTEM
-            architect_system_tpl = ARCHITECT_RLM_SYSTEM
+            if use_constraints:
+                from mts.rlm.prompts import (
+                    ANALYST_RLM_SYSTEM_CONSTRAINED,
+                    ARCHITECT_RLM_SYSTEM_CONSTRAINED,
+                )
+                analyst_system_tpl = ANALYST_RLM_SYSTEM_CONSTRAINED
+                architect_system_tpl = ARCHITECT_RLM_SYSTEM_CONSTRAINED
+            else:
+                from mts.rlm.prompts import ANALYST_RLM_SYSTEM, ARCHITECT_RLM_SYSTEM
+                analyst_system_tpl = ANALYST_RLM_SYSTEM
+                architect_system_tpl = ARCHITECT_RLM_SYSTEM
             worker_cls = ReplWorker
 
         # Reset deterministic client turn counter if applicable

--- a/mts/src/mts/config/settings.py
+++ b/mts/src/mts/config/settings.py
@@ -125,6 +125,8 @@ class AppSettings(BaseModel):
     )
     # Progress JSON
     progress_json_enabled: bool = Field(default=True, description="Inject structured progress JSON into prompts")
+    # Constraint prompts
+    constraint_prompts_enabled: bool = Field(default=True, description="Append constraint suffixes to role prompts")
 
 
 def load_settings() -> AppSettings:
@@ -219,4 +221,5 @@ def load_settings() -> AppSettings:
         stagnation_plateau_epsilon=float(os.getenv("MTS_STAGNATION_PLATEAU_EPSILON", "0.01")),
         stagnation_distill_top_lessons=int(os.getenv("MTS_STAGNATION_DISTILL_TOP_LESSONS", "5")),
         progress_json_enabled=os.getenv("MTS_PROGRESS_JSON_ENABLED", "true").lower() == "true",
+        constraint_prompts_enabled=os.getenv("MTS_CONSTRAINT_PROMPTS_ENABLED", "true").lower() == "true",
     )

--- a/mts/src/mts/loop/stages.py
+++ b/mts/src/mts/loop/stages.py
@@ -72,6 +72,7 @@ def stage_knowledge_setup(
         score_trajectory=score_trajectory,
         strategy_registry=strategy_registry,
         progress_json=progress_json_str,
+        constraint_mode=ctx.settings.constraint_prompts_enabled,
     )
 
     ctx.prompts = prompts
@@ -397,6 +398,7 @@ def stage_curator_gate(
         proposed_playbook=ctx.outputs.coach_playbook,
         score_trajectory=curator_trajectory,
         recent_analysis=curator_analysis,
+        constraint_mode=ctx.settings.constraint_prompts_enabled,
     )
 
     sqlite.append_agent_output(
@@ -528,6 +530,7 @@ def stage_persistence(
             consolidation_trajectory = trajectory_builder.build_trajectory(run_id)
             lesson_result, lesson_exec = curator.consolidate_lessons(
                 existing_lessons, settings.skill_max_lessons, consolidation_trajectory,
+                constraint_mode=settings.constraint_prompts_enabled,
             )
             artifacts.replace_skill_lessons(scenario_name, lesson_result.consolidated_lessons)
             sqlite.append_agent_output(

--- a/mts/src/mts/prompts/templates.py
+++ b/mts/src/mts/prompts/templates.py
@@ -13,6 +13,40 @@ class PromptBundle:
     architect: str
 
 
+_COMPETITOR_CONSTRAINT_SUFFIX = (
+    "\n\nConstraints:\n"
+    "- Do NOT repeat any strategy from the registry that resulted in rollback\n"
+    "- Do NOT set parameters outside the valid ranges defined in the strategy interface\n"
+    "- Do NOT omit reasoning for each parameter choice\n"
+    "- Do NOT ignore patterns identified in the score trajectory\n"
+    "- Do NOT propose a strategy without considering the evaluation criteria"
+)
+
+_ANALYST_CONSTRAINT_SUFFIX = (
+    "\n\nConstraints:\n"
+    "- Do NOT report findings without supporting evidence from match data\n"
+    "- Do NOT omit root cause analysis for score regressions\n"
+    "- Do NOT repeat recommendations already addressed in the current playbook\n"
+    "- Do NOT provide vague recommendations — each must specify concrete parameter changes"
+)
+
+_COACH_CONSTRAINT_SUFFIX = (
+    "\n\nConstraints:\n"
+    "- Do NOT remove working strategies from the playbook without justification\n"
+    "- Do NOT omit the required structural markers (PLAYBOOK, LESSONS, COMPETITOR_HINTS START/END)\n"
+    "- Do NOT contradict lessons that have been validated across multiple generations\n"
+    "- Do NOT provide hints that repeat previously rolled-back approaches"
+)
+
+_ARCHITECT_CONSTRAINT_SUFFIX = (
+    "\n\nConstraints:\n"
+    "- Do NOT propose tools that duplicate existing tool functionality\n"
+    "- Do NOT generate code with syntax errors or undefined dependencies\n"
+    "- Do NOT remove or break existing tools without archiving them first\n"
+    "- Do NOT propose changes without an impact hypothesis"
+)
+
+
 def build_prompt_bundle(
     scenario_rules: str,
     strategy_interface: str,
@@ -28,6 +62,7 @@ def build_prompt_bundle(
     score_trajectory: str = "",
     strategy_registry: str = "",
     progress_json: str = "",
+    constraint_mode: bool = False,
 ) -> PromptBundle:
     lessons_block = (
         f"Operational lessons (from prior generations):\n{operational_lessons}\n\n"
@@ -81,18 +116,23 @@ def build_prompt_bundle(
         if coach_competitor_hints
         else ""
     )
+    competitor_constraint = _COMPETITOR_CONSTRAINT_SUFFIX if constraint_mode else ""
+    analyst_constraint = _ANALYST_CONSTRAINT_SUFFIX if constraint_mode else ""
+    coach_constraint = _COACH_CONSTRAINT_SUFFIX if constraint_mode else ""
+    architect_constraint = _ARCHITECT_CONSTRAINT_SUFFIX if constraint_mode else ""
     return PromptBundle(
         competitor=base_context
         + hints_block
-        + (
-            "Describe your strategy reasoning and recommend specific parameter values."
-        ),
+        + competitor_constraint
+        + "Describe your strategy reasoning and recommend specific parameter values.",
         analyst=base_context
+        + analyst_constraint
         + (
             "Analyze strengths/failures and return markdown with sections: "
             "Findings, Root Causes, Actionable Recommendations."
         ),
         coach=base_context
+        + coach_constraint
         + (
             "You are the playbook coach. Produce THREE structured sections:\n\n"
             "1. A COMPLETE replacement playbook between markers. Consolidate all prior guidance, "
@@ -113,6 +153,7 @@ def build_prompt_bundle(
             "<!-- COMPETITOR_HINTS_END -->"
         ),
         architect=base_context
+        + architect_constraint
         + (
             "Propose infrastructure/tooling improvements in markdown with sections: "
             "Observed Bottlenecks, Tool Proposals, Impact Hypothesis. "

--- a/mts/src/mts/rlm/prompts.py
+++ b/mts/src/mts/rlm/prompts.py
@@ -177,6 +177,22 @@ If no new tools are needed, use an empty tools array.
 Start by examining existing tool code and correlating with performance metrics.
 """
 
+_RLM_ANALYST_CONSTRAINT = (
+    "\n## Constraints\n"
+    "- Do NOT report findings without supporting evidence from match data\n"
+    "- Do NOT omit root cause analysis for score regressions\n"
+    "- Do NOT repeat recommendations already addressed in the current playbook\n"
+    "- Do NOT provide vague recommendations — each must specify concrete parameter changes\n"
+)
+
+_RLM_ARCHITECT_CONSTRAINT = (
+    "\n## Constraints\n"
+    "- Do NOT propose tools that duplicate existing tool functionality\n"
+    "- Do NOT generate code with syntax errors or undefined dependencies\n"
+    "- Do NOT remove or break existing tools without archiving them first\n"
+    "- Do NOT propose changes without an impact hypothesis\n"
+)
+
 ANALYST_RLM_SYSTEM = RLM_SCAFFOLDING_PREAMBLE + """\
 You are the Analyst agent in an iterative strategy evolution system. Your job is to
 analyze match replays, score distributions, and strategic patterns to produce actionable
@@ -221,3 +237,18 @@ If no new tools are needed, use an empty tools array.
 
 Start by examining existing tool code and correlating with performance metrics.
 """
+
+
+def _insert_rlm_constraint(base: str, constraint: str) -> str:
+    """Insert constraint block before '## Important rules' in RLM prompts."""
+    marker = "## Important rules"
+    idx = base.find(marker)
+    if idx == -1:
+        return base + constraint
+    return base[:idx] + constraint.lstrip("\n") + "\n" + base[idx:]
+
+
+ANALYST_RLM_SYSTEM_CONSTRAINED = _insert_rlm_constraint(ANALYST_RLM_SYSTEM, _RLM_ANALYST_CONSTRAINT)
+ARCHITECT_RLM_SYSTEM_CONSTRAINED = _insert_rlm_constraint(ARCHITECT_RLM_SYSTEM, _RLM_ARCHITECT_CONSTRAINT)
+ANALYST_MONTY_RLM_SYSTEM_CONSTRAINED = _insert_rlm_constraint(ANALYST_MONTY_RLM_SYSTEM, _RLM_ANALYST_CONSTRAINT)
+ARCHITECT_MONTY_RLM_SYSTEM_CONSTRAINED = _insert_rlm_constraint(ARCHITECT_MONTY_RLM_SYSTEM, _RLM_ARCHITECT_CONSTRAINT)

--- a/mts/tests/test_constraint_prompts.py
+++ b/mts/tests/test_constraint_prompts.py
@@ -1,0 +1,280 @@
+"""Tests for constraint-oriented prompt reframing (PR 2)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mts.agents.curator import (
+    _CURATOR_ASSESSMENT_CONSTRAINT,
+    _CURATOR_CONSOLIDATION_CONSTRAINT,
+    KnowledgeCurator,
+)
+from mts.config.settings import AppSettings
+from mts.prompts.templates import (
+    _ANALYST_CONSTRAINT_SUFFIX,
+    _ARCHITECT_CONSTRAINT_SUFFIX,
+    _COACH_CONSTRAINT_SUFFIX,
+    _COMPETITOR_CONSTRAINT_SUFFIX,
+    build_prompt_bundle,
+)
+from mts.rlm.prompts import (
+    _RLM_ANALYST_CONSTRAINT,
+    _RLM_ARCHITECT_CONSTRAINT,
+    ANALYST_MONTY_RLM_SYSTEM,
+    ANALYST_MONTY_RLM_SYSTEM_CONSTRAINED,
+    ANALYST_RLM_SYSTEM,
+    ANALYST_RLM_SYSTEM_CONSTRAINED,
+    ARCHITECT_MONTY_RLM_SYSTEM,
+    ARCHITECT_MONTY_RLM_SYSTEM_CONSTRAINED,
+    ARCHITECT_RLM_SYSTEM,
+    ARCHITECT_RLM_SYSTEM_CONSTRAINED,
+)
+from mts.scenarios.base import Observation
+
+
+def _make_observation() -> Observation:
+    return Observation(
+        narrative="test narrative",
+        state={"key": "value"},
+        constraints=["test constraint"],
+    )
+
+
+def _make_bundle(constraint_mode: bool = False) -> object:
+    return build_prompt_bundle(
+        scenario_rules="rules",
+        strategy_interface="interface",
+        evaluation_criteria="criteria",
+        previous_summary="summary",
+        observation=_make_observation(),
+        current_playbook="playbook",
+        available_tools="tools",
+        constraint_mode=constraint_mode,
+    )
+
+
+# --- Constraint suffix constants ---
+
+
+class TestConstraintSuffixConstants:
+    def test_competitor_constraint_contains_do_not(self) -> None:
+        assert "Do NOT" in _COMPETITOR_CONSTRAINT_SUFFIX
+
+    def test_analyst_constraint_contains_do_not(self) -> None:
+        assert "Do NOT" in _ANALYST_CONSTRAINT_SUFFIX
+
+    def test_coach_constraint_contains_do_not(self) -> None:
+        assert "Do NOT" in _COACH_CONSTRAINT_SUFFIX
+
+    def test_architect_constraint_contains_do_not(self) -> None:
+        assert "Do NOT" in _ARCHITECT_CONSTRAINT_SUFFIX
+
+
+# --- build_prompt_bundle with constraint_mode ---
+
+
+class TestBuildPromptBundleConstraints:
+    def test_constraint_mode_true_injects_competitor_constraint(self) -> None:
+        bundle = _make_bundle(constraint_mode=True)
+        assert "Do NOT repeat any strategy from the registry" in bundle.competitor
+
+    def test_constraint_mode_true_injects_analyst_constraint(self) -> None:
+        bundle = _make_bundle(constraint_mode=True)
+        assert "Do NOT report findings without supporting evidence" in bundle.analyst
+
+    def test_constraint_mode_true_injects_coach_constraint(self) -> None:
+        bundle = _make_bundle(constraint_mode=True)
+        assert "Do NOT remove working strategies" in bundle.coach
+
+    def test_constraint_mode_true_injects_architect_constraint(self) -> None:
+        bundle = _make_bundle(constraint_mode=True)
+        assert "Do NOT propose tools that duplicate" in bundle.architect
+
+    def test_constraint_mode_false_no_constraint_text(self) -> None:
+        bundle = _make_bundle(constraint_mode=False)
+        assert "Do NOT repeat any strategy from the registry" not in bundle.competitor
+        assert "Do NOT report findings without supporting evidence" not in bundle.analyst
+        assert "Do NOT remove working strategies" not in bundle.coach
+        assert "Do NOT propose tools that duplicate" not in bundle.architect
+
+    def test_constraint_mode_default_is_false(self) -> None:
+        bundle = build_prompt_bundle(
+            scenario_rules="rules",
+            strategy_interface="interface",
+            evaluation_criteria="criteria",
+            previous_summary="summary",
+            observation=_make_observation(),
+            current_playbook="playbook",
+            available_tools="tools",
+        )
+        assert "Do NOT repeat any strategy from the registry" not in bundle.competitor
+
+    def test_coach_constraint_preserves_structural_markers(self) -> None:
+        bundle = _make_bundle(constraint_mode=True)
+        assert "<!-- PLAYBOOK_START -->" in bundle.coach
+        assert "<!-- PLAYBOOK_END -->" in bundle.coach
+        assert "<!-- LESSONS_START -->" in bundle.coach
+        assert "<!-- LESSONS_END -->" in bundle.coach
+        assert "<!-- COMPETITOR_HINTS_START -->" in bundle.coach
+        assert "<!-- COMPETITOR_HINTS_END -->" in bundle.coach
+
+    def test_constraint_before_role_instruction(self) -> None:
+        bundle = _make_bundle(constraint_mode=True)
+        # Competitor: constraint should appear before "Describe your strategy"
+        constraint_pos = bundle.competitor.find("Do NOT repeat any strategy")
+        instruction_pos = bundle.competitor.find("Describe your strategy reasoning")
+        assert constraint_pos < instruction_pos
+        # Analyst: constraint before "Analyze strengths"
+        constraint_pos = bundle.analyst.find("Do NOT report findings")
+        instruction_pos = bundle.analyst.find("Analyze strengths/failures")
+        assert constraint_pos < instruction_pos
+
+    def test_constraint_mode_false_matches_no_arg(self) -> None:
+        bundle_default = build_prompt_bundle(
+            scenario_rules="rules",
+            strategy_interface="interface",
+            evaluation_criteria="criteria",
+            previous_summary="summary",
+            observation=_make_observation(),
+            current_playbook="playbook",
+            available_tools="tools",
+        )
+        bundle_explicit = _make_bundle(constraint_mode=False)
+        assert bundle_default.competitor == bundle_explicit.competitor
+        assert bundle_default.analyst == bundle_explicit.analyst
+        assert bundle_default.coach == bundle_explicit.coach
+        assert bundle_default.architect == bundle_explicit.architect
+
+
+# --- RLM constrained variants ---
+
+
+class TestRlmConstrainedPrompts:
+    def test_rlm_analyst_constrained_contains_constraint(self) -> None:
+        assert "Do NOT report findings without supporting evidence" in ANALYST_RLM_SYSTEM_CONSTRAINED
+
+    def test_rlm_architect_constrained_contains_constraint(self) -> None:
+        assert "Do NOT propose tools that duplicate" in ARCHITECT_RLM_SYSTEM_CONSTRAINED
+
+    def test_monty_analyst_constrained_contains_constraint(self) -> None:
+        assert "Do NOT report findings without supporting evidence" in ANALYST_MONTY_RLM_SYSTEM_CONSTRAINED
+
+    def test_monty_architect_constrained_contains_constraint(self) -> None:
+        assert "Do NOT propose tools that duplicate" in ARCHITECT_MONTY_RLM_SYSTEM_CONSTRAINED
+
+    def test_unconstrained_does_not_have_constraint(self) -> None:
+        assert "Do NOT report findings without supporting evidence" not in ANALYST_RLM_SYSTEM
+        assert "Do NOT propose tools that duplicate" not in ARCHITECT_RLM_SYSTEM
+        assert "Do NOT report findings without supporting evidence" not in ANALYST_MONTY_RLM_SYSTEM
+        assert "Do NOT propose tools that duplicate" not in ARCHITECT_MONTY_RLM_SYSTEM
+
+    def test_constrained_still_has_important_rules(self) -> None:
+        assert "## Important rules" in ANALYST_RLM_SYSTEM_CONSTRAINED
+        assert "## Important rules" in ARCHITECT_RLM_SYSTEM_CONSTRAINED
+
+    def test_constraint_before_important_rules(self) -> None:
+        constraint_pos = ANALYST_RLM_SYSTEM_CONSTRAINED.find("## Constraints")
+        rules_pos = ANALYST_RLM_SYSTEM_CONSTRAINED.find("## Important rules")
+        assert constraint_pos < rules_pos
+
+    def test_rlm_constraint_constants(self) -> None:
+        assert "Do NOT" in _RLM_ANALYST_CONSTRAINT
+        assert "Do NOT" in _RLM_ARCHITECT_CONSTRAINT
+
+
+# --- Curator constraint_mode ---
+
+
+class TestCuratorConstraints:
+    def test_assess_playbook_quality_with_constraints(self) -> None:
+        runtime = MagicMock()
+        exec_result = MagicMock()
+        exec_result.content = "<!-- CURATOR_DECISION: accept -->\n<!-- CURATOR_SCORE: 8 -->"
+        runtime.run_task.return_value = exec_result
+
+        curator = KnowledgeCurator(runtime, "test-model")
+        decision, _ = curator.assess_playbook_quality(
+            current_playbook="current",
+            proposed_playbook="proposed",
+            score_trajectory="trajectory",
+            recent_analysis="analysis",
+            constraint_mode=True,
+        )
+
+        call_args = runtime.run_task.call_args[0][0]
+        assert "Do NOT accept a playbook that removes validated" in call_args.prompt
+
+    def test_assess_playbook_quality_without_constraints(self) -> None:
+        runtime = MagicMock()
+        exec_result = MagicMock()
+        exec_result.content = "<!-- CURATOR_DECISION: accept -->\n<!-- CURATOR_SCORE: 8 -->"
+        runtime.run_task.return_value = exec_result
+
+        curator = KnowledgeCurator(runtime, "test-model")
+        decision, _ = curator.assess_playbook_quality(
+            current_playbook="current",
+            proposed_playbook="proposed",
+            score_trajectory="trajectory",
+            recent_analysis="analysis",
+            constraint_mode=False,
+        )
+
+        call_args = runtime.run_task.call_args[0][0]
+        assert "Do NOT accept a playbook that removes validated" not in call_args.prompt
+
+    def test_consolidate_lessons_with_constraints(self) -> None:
+        runtime = MagicMock()
+        exec_result = MagicMock()
+        exec_result.content = (
+            "<!-- CONSOLIDATED_LESSONS_START -->\n- lesson 1\n<!-- CONSOLIDATED_LESSONS_END -->\n"
+            "<!-- LESSONS_REMOVED: 1 -->"
+        )
+        runtime.run_task.return_value = exec_result
+
+        curator = KnowledgeCurator(runtime, "test-model")
+        result, _ = curator.consolidate_lessons(
+            existing_lessons=["- lesson 1", "- lesson 2"],
+            max_lessons=1,
+            score_trajectory="trajectory",
+            constraint_mode=True,
+        )
+
+        call_args = runtime.run_task.call_args[0][0]
+        assert "Do NOT remove lessons that are supported by score" in call_args.prompt
+
+    def test_consolidate_lessons_without_constraints(self) -> None:
+        runtime = MagicMock()
+        exec_result = MagicMock()
+        exec_result.content = (
+            "<!-- CONSOLIDATED_LESSONS_START -->\n- lesson 1\n<!-- CONSOLIDATED_LESSONS_END -->\n"
+            "<!-- LESSONS_REMOVED: 1 -->"
+        )
+        runtime.run_task.return_value = exec_result
+
+        curator = KnowledgeCurator(runtime, "test-model")
+        result, _ = curator.consolidate_lessons(
+            existing_lessons=["- lesson 1", "- lesson 2"],
+            max_lessons=1,
+            score_trajectory="trajectory",
+            constraint_mode=False,
+        )
+
+        call_args = runtime.run_task.call_args[0][0]
+        assert "Do NOT remove lessons that are supported by score" not in call_args.prompt
+
+    def test_curator_constraint_constants(self) -> None:
+        assert "Do NOT" in _CURATOR_ASSESSMENT_CONSTRAINT
+        assert "Do NOT" in _CURATOR_CONSOLIDATION_CONSTRAINT
+
+
+# --- Settings ---
+
+
+class TestConstraintSettings:
+    def test_default_constraint_prompts_enabled(self) -> None:
+        settings = AppSettings()
+        assert settings.constraint_prompts_enabled is True
+
+    def test_constraint_prompts_disabled(self) -> None:
+        settings = AppSettings(constraint_prompts_enabled=False)
+        assert settings.constraint_prompts_enabled is False


### PR DESCRIPTION
## Summary
- Add per-role constraint suffixes ("Do NOT...") to all agent prompts, reducing common failure modes
- Includes RLM prompt variants and curator constraint modes
- Controlled by `MTS_CONSTRAINT_PROMPTS_ENABLED` (default: `true`)

## Changes
- **Modified**: `mts/src/mts/prompts/templates.py` — 4 constraint suffix constants + `constraint_mode` param
- **Modified**: `mts/src/mts/rlm/prompts.py` — RLM constraint variants + `_insert_rlm_constraint()` helper
- **Modified**: `mts/src/mts/agents/curator.py` — `constraint_mode` on `assess_playbook_quality()` and `consolidate_lessons()`
- **Modified**: `mts/src/mts/agents/orchestrator.py` — constrained RLM prompt selection
- **Modified**: `mts/src/mts/loop/stages.py` — passes `constraint_mode` through to all callsites
- **Modified**: `mts/src/mts/config/settings.py` — `constraint_prompts_enabled` setting
- **New**: `mts/tests/test_constraint_prompts.py` — 28 tests

## Test plan
- [x] Each role's constraint suffix contains "Do NOT"
- [x] Coach constraints preserve structural markers (PLAYBOOK_START/END)
- [x] `constraint_mode=False` produces identical output to current behavior
- [x] RLM constrained variants validated
- [x] Curator constraint mode validated
- [x] Full test suite: 1224 passed, 21 skipped, ruff/mypy clean