### PR TITLE
feat: stagnation detection and fresh start mechanism

### DIFF
--- a/mts/src/mts/config/settings.py
+++ b/mts/src/mts/config/settings.py
@@ -107,6 +107,22 @@ class AppSettings(BaseModel):
     # Notification settings
     notify_webhook_url: str | None = Field(default=None)
     notify_on: str = Field(default="threshold_met,failure")
+    # Stagnation detection
+    stagnation_reset_enabled: bool = Field(
+        default=False, description="Enable stagnation detection and fresh start",
+    )
+    stagnation_rollback_threshold: int = Field(
+        default=5, ge=1, description="Consecutive rollbacks before fresh start",
+    )
+    stagnation_plateau_window: int = Field(
+        default=5, ge=2, description="Window size for score plateau detection",
+    )
+    stagnation_plateau_epsilon: float = Field(
+        default=0.01, ge=0.0, description="Max variance for plateau detection",
+    )
+    stagnation_distill_top_lessons: int = Field(
+        default=5, ge=1, description="Top lessons to retain in fresh start",
+    )
 
 
 def load_settings() -> AppSettings:
@@ -195,4 +211,9 @@ def load_settings() -> AppSettings:
         judge_api_key=os.getenv("MTS_JUDGE_API_KEY"),
         notify_webhook_url=os.getenv("MTS_NOTIFY_WEBHOOK_URL"),
         notify_on=os.getenv("MTS_NOTIFY_ON", "threshold_met,failure"),
+        stagnation_reset_enabled=os.getenv("MTS_STAGNATION_RESET_ENABLED", "false").lower() == "true",
+        stagnation_rollback_threshold=int(os.getenv("MTS_STAGNATION_ROLLBACK_THRESHOLD", "5")),
+        stagnation_plateau_window=int(os.getenv("MTS_STAGNATION_PLATEAU_WINDOW", "5")),
+        stagnation_plateau_epsilon=float(os.getenv("MTS_STAGNATION_PLATEAU_EPSILON", "0.01")),
+        stagnation_distill_top_lessons=int(os.getenv("MTS_STAGNATION_DISTILL_TOP_LESSONS", "5")),
     )

--- a/mts/src/mts/knowledge/fresh_start.py
+++ b/mts/src/mts/knowledge/fresh_start.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from mts.storage.artifacts import ArtifactStore
+
+LOGGER = logging.getLogger(__name__)
+
+
+def execute_fresh_start(
+    artifacts: ArtifactStore,
+    scenario_name: str,
+    current_strategy: dict[str, Any],
+    lessons: list[str],
+    top_n: int = 5,
+) -> str:
+    """Execute a fresh start: archive playbook, write distilled version, clear hints.
+
+    Returns the fresh-start competitor hint text.
+    """
+    # 1. Read top lessons
+    top_lessons = lessons[:top_n]
+    lessons_block = (
+        "\n".join(f"- {line.lstrip('- ')}" for line in top_lessons)
+        if top_lessons
+        else "- No prior lessons"
+    )
+
+    # 2. Build distilled playbook
+    strategy_summary = json.dumps(current_strategy, indent=2, sort_keys=True)[:500]
+    distilled = (
+        "# Fresh Start Playbook\n\n"
+        "Previous approach stagnated. Starting fresh with distilled knowledge.\n\n"
+        "## Retained Lessons\n\n"
+        f"{lessons_block}\n\n"
+        "## Best Strategy Reference\n\n"
+        f"```json\n{strategy_summary}\n```\n\n"
+        "## Directive\n\n"
+        "Explore fundamentally different approaches. Do not repeat rolled-back strategies.\n"
+    )
+
+    # 3. Archive current playbook and write distilled (write_playbook auto-archives)
+    artifacts.write_playbook(scenario_name, distilled)
+
+    # 4. Clear hints
+    artifacts.write_hints(scenario_name, "")
+
+    # 5. Build fresh-start competitor hint
+    hint = (
+        "FRESH START: Previous strategy evolution has stagnated. "
+        "You must explore a fundamentally different approach. "
+        "Do not repeat parameter combinations from rolled-back strategies. "
+        "Focus on the retained lessons above and try novel parameter ranges."
+    )
+
+    LOGGER.info("fresh start executed for scenario %s", scenario_name)
+    return hint

--- a/mts/src/mts/knowledge/stagnation.py
+++ b/mts/src/mts/knowledge/stagnation.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class StagnationReport:
+    is_stagnated: bool
+    trigger: str  # "none", "consecutive_rollbacks", "score_plateau"
+    detail: str
+
+    @staticmethod
+    def no_stagnation() -> StagnationReport:
+        return StagnationReport(is_stagnated=False, trigger="none", detail="")
+
+
+class StagnationDetector:
+    def __init__(
+        self,
+        rollback_threshold: int = 5,
+        plateau_window: int = 5,
+        plateau_epsilon: float = 0.01,
+    ) -> None:
+        self.rollback_threshold = rollback_threshold
+        self.plateau_window = plateau_window
+        self.plateau_epsilon = plateau_epsilon
+
+    def detect(
+        self,
+        gate_history: list[str],
+        score_history: list[float],
+    ) -> StagnationReport:
+        # Check consecutive rollbacks from end
+        consecutive_rollbacks = 0
+        for decision in reversed(gate_history):
+            if decision == "rollback":
+                consecutive_rollbacks += 1
+            else:
+                break
+
+        if consecutive_rollbacks >= self.rollback_threshold:
+            return StagnationReport(
+                is_stagnated=True,
+                trigger="consecutive_rollbacks",
+                detail=f"{consecutive_rollbacks} consecutive rollbacks",
+            )
+
+        # Check score plateau
+        if len(score_history) >= self.plateau_window:
+            window = score_history[-self.plateau_window:]
+            mean = sum(window) / len(window)
+            variance = sum((s - mean) ** 2 for s in window) / len(window)
+            if variance < self.plateau_epsilon:
+                return StagnationReport(
+                    is_stagnated=True,
+                    trigger="score_plateau",
+                    detail=(
+                        f"score variance {variance:.6f} < epsilon {self.plateau_epsilon}"
+                        f" over last {self.plateau_window} gens"
+                    ),
+                )
+
+        return StagnationReport.no_stagnation()

--- a/mts/src/mts/loop/generation_pipeline.py
+++ b/mts/src/mts/loop/generation_pipeline.py
@@ -11,6 +11,7 @@ from mts.loop.stages import (
     stage_curator_gate,
     stage_knowledge_setup,
     stage_persistence,
+    stage_stagnation_check,
     stage_tournament,
 )
 
@@ -119,6 +120,13 @@ class GenerationPipeline:
             sqlite=self._sqlite,
             artifacts=self._artifacts,
             agents=self._orchestrator,
+        )
+
+        # Stage 3b: Stagnation check
+        ctx = stage_stagnation_check(
+            ctx,
+            artifacts=self._artifacts,
+            events=self._events,
         )
 
         # Hook: Controller gate override

--- a/mts/src/mts/loop/stage_types.py
+++ b/mts/src/mts/loop/stage_types.py
@@ -43,6 +43,7 @@ class GenerationContext:
     attempt: int = 0
     strategy_interface: str = ""
     tool_context: str = ""
+    fresh_start_triggered: bool = False
 
 
 @dataclass(slots=True)

--- a/mts/src/mts/loop/stages.py
+++ b/mts/src/mts/loop/stages.py
@@ -307,6 +307,54 @@ def stage_tournament(
     return ctx
 
 
+def stage_stagnation_check(
+    ctx: GenerationContext,
+    *,
+    artifacts: ArtifactStore,
+    events: EventStreamEmitter,
+) -> GenerationContext:
+    """Stage 3b: Check for stagnation and trigger fresh start if needed."""
+    if not ctx.settings.stagnation_reset_enabled:
+        return ctx
+    if ctx.settings.ablation_no_feedback:
+        return ctx
+
+    from mts.knowledge.stagnation import StagnationDetector
+
+    detector = StagnationDetector(
+        rollback_threshold=ctx.settings.stagnation_rollback_threshold,
+        plateau_window=ctx.settings.stagnation_plateau_window,
+        plateau_epsilon=ctx.settings.stagnation_plateau_epsilon,
+    )
+    report = detector.detect(ctx.gate_decision_history, ctx.score_history)
+
+    if not report.is_stagnated:
+        return ctx
+
+    from mts.knowledge.fresh_start import execute_fresh_start
+
+    lessons = artifacts.read_skill_lessons_raw(ctx.scenario_name)
+    hint = execute_fresh_start(
+        artifacts=artifacts,
+        scenario_name=ctx.scenario_name,
+        current_strategy=ctx.current_strategy,
+        lessons=lessons,
+        top_n=ctx.settings.stagnation_distill_top_lessons,
+    )
+
+    ctx.coach_competitor_hints = hint
+    ctx.fresh_start_triggered = True
+
+    events.emit("fresh_start", {
+        "run_id": ctx.run_id,
+        "generation": ctx.generation,
+        "trigger": report.trigger,
+        "detail": report.detail,
+    })
+
+    return ctx
+
+
 def stage_curator_gate(
     ctx: GenerationContext,
     *,

--- a/mts/tests/test_stagnation.py
+++ b/mts/tests/test_stagnation.py
@@ -1,0 +1,302 @@
+"""Tests for stagnation detection and fresh start."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from mts.config.settings import AppSettings
+from mts.knowledge.fresh_start import execute_fresh_start
+from mts.knowledge.stagnation import StagnationDetector, StagnationReport
+from mts.loop.stage_types import GenerationContext
+from mts.loop.stages import stage_stagnation_check
+from mts.storage.artifacts import ArtifactStore
+
+# ---------------------------------------------------------------------------
+# StagnationDetector tests
+# ---------------------------------------------------------------------------
+
+
+class TestStagnationDetector:
+    def test_consecutive_rollbacks_at_threshold_triggers(self) -> None:
+        detector = StagnationDetector(rollback_threshold=3)
+        report = detector.detect(
+            gate_history=["advance", "rollback", "rollback", "rollback"],
+            score_history=[0.5, 0.4, 0.4, 0.4],
+        )
+        assert report.is_stagnated is True
+        assert report.trigger == "consecutive_rollbacks"
+        assert "3 consecutive rollbacks" in report.detail
+
+    def test_consecutive_rollbacks_below_threshold(self) -> None:
+        detector = StagnationDetector(rollback_threshold=5)
+        report = detector.detect(
+            gate_history=["rollback", "rollback", "rollback"],
+            score_history=[0.4, 0.4, 0.4],
+        )
+        assert report.is_stagnated is False
+        assert report.trigger == "none"
+
+    def test_score_plateau_triggers(self) -> None:
+        detector = StagnationDetector(plateau_window=3, plateau_epsilon=0.01)
+        report = detector.detect(
+            gate_history=["advance", "advance", "advance"],
+            score_history=[0.5, 0.5, 0.5],
+        )
+        assert report.is_stagnated is True
+        assert report.trigger == "score_plateau"
+        assert "variance" in report.detail
+
+    def test_score_plateau_high_variance_no_trigger(self) -> None:
+        detector = StagnationDetector(plateau_window=3, plateau_epsilon=0.001)
+        report = detector.detect(
+            gate_history=["advance", "advance", "advance"],
+            score_history=[0.3, 0.5, 0.7],
+        )
+        assert report.is_stagnated is False
+
+    def test_insufficient_history_no_stagnation(self) -> None:
+        detector = StagnationDetector(plateau_window=5, rollback_threshold=5)
+        report = detector.detect(
+            gate_history=["advance"],
+            score_history=[0.5],
+        )
+        assert report.is_stagnated is False
+
+    def test_interleaved_advance_rollback_resets_count(self) -> None:
+        detector = StagnationDetector(rollback_threshold=3, plateau_window=10)
+        report = detector.detect(
+            gate_history=["rollback", "rollback", "advance", "rollback", "rollback"],
+            score_history=[0.2, 0.3, 0.8, 0.1, 0.6],
+        )
+        assert report.is_stagnated is False
+
+    def test_empty_history_no_stagnation(self) -> None:
+        detector = StagnationDetector()
+        report = detector.detect(gate_history=[], score_history=[])
+        assert report.is_stagnated is False
+        assert report.trigger == "none"
+
+    def test_exact_epsilon_boundary_no_trigger(self) -> None:
+        """Variance exactly equal to epsilon should NOT trigger (strictly less than)."""
+        detector = StagnationDetector(plateau_window=2, plateau_epsilon=0.01)
+        # Two scores: 0.0 and 0.2 => mean=0.1, var = ((0.0-0.1)^2+(0.2-0.1)^2)/2 = 0.01
+        report = detector.detect(
+            gate_history=["advance", "advance"],
+            score_history=[0.0, 0.2],
+        )
+        assert report.is_stagnated is False
+
+
+class TestStagnationReportNoStagnation:
+    def test_static_factory(self) -> None:
+        report = StagnationReport.no_stagnation()
+        assert report.is_stagnated is False
+        assert report.trigger == "none"
+        assert report.detail == ""
+
+
+# ---------------------------------------------------------------------------
+# execute_fresh_start tests
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteFreshStart:
+    def test_archives_playbook_and_writes_distilled(self, tmp_path: object) -> None:
+        artifacts = ArtifactStore(
+            runs_root=tmp_path / "runs",  # type: ignore[operator]
+            knowledge_root=tmp_path / "knowledge",  # type: ignore[operator]
+            skills_root=tmp_path / "skills",  # type: ignore[operator]
+            claude_skills_path=tmp_path / ".claude" / "skills",  # type: ignore[operator]
+        )
+        scenario = "test_scenario"
+        # Seed a playbook
+        artifacts.write_playbook(scenario, "Original playbook content")
+        hint = execute_fresh_start(
+            artifacts=artifacts,
+            scenario_name=scenario,
+            current_strategy={"param_a": 1, "param_b": 2},
+            lessons=["lesson one", "lesson two"],
+            top_n=5,
+        )
+        # Playbook should now be the distilled version
+        playbook = artifacts.read_playbook(scenario)
+        assert "Fresh Start Playbook" in playbook
+        assert "lesson one" in playbook
+        assert "lesson two" in playbook
+        assert "param_a" in playbook
+        assert isinstance(hint, str)
+
+    def test_clears_hints(self, tmp_path: object) -> None:
+        artifacts = ArtifactStore(
+            runs_root=tmp_path / "runs",  # type: ignore[operator]
+            knowledge_root=tmp_path / "knowledge",  # type: ignore[operator]
+            skills_root=tmp_path / "skills",  # type: ignore[operator]
+            claude_skills_path=tmp_path / ".claude" / "skills",  # type: ignore[operator]
+        )
+        scenario = "test_scenario"
+        artifacts.write_playbook(scenario, "playbook")
+        artifacts.write_hints(scenario, "some hints")
+        execute_fresh_start(
+            artifacts=artifacts,
+            scenario_name=scenario,
+            current_strategy={},
+            lessons=[],
+        )
+        hints = artifacts.read_hints(scenario)
+        assert hints.strip() == ""
+
+    def test_retains_top_n_lessons(self, tmp_path: object) -> None:
+        artifacts = ArtifactStore(
+            runs_root=tmp_path / "runs",  # type: ignore[operator]
+            knowledge_root=tmp_path / "knowledge",  # type: ignore[operator]
+            skills_root=tmp_path / "skills",  # type: ignore[operator]
+            claude_skills_path=tmp_path / ".claude" / "skills",  # type: ignore[operator]
+        )
+        scenario = "test_scenario"
+        artifacts.write_playbook(scenario, "playbook")
+        lessons = [f"lesson {i}" for i in range(10)]
+        execute_fresh_start(
+            artifacts=artifacts,
+            scenario_name=scenario,
+            current_strategy={},
+            lessons=lessons,
+            top_n=3,
+        )
+        playbook = artifacts.read_playbook(scenario)
+        assert "lesson 0" in playbook
+        assert "lesson 2" in playbook
+        assert "lesson 3" not in playbook
+
+    def test_returns_fresh_start_hint(self, tmp_path: object) -> None:
+        artifacts = ArtifactStore(
+            runs_root=tmp_path / "runs",  # type: ignore[operator]
+            knowledge_root=tmp_path / "knowledge",  # type: ignore[operator]
+            skills_root=tmp_path / "skills",  # type: ignore[operator]
+            claude_skills_path=tmp_path / ".claude" / "skills",  # type: ignore[operator]
+        )
+        scenario = "test_scenario"
+        artifacts.write_playbook(scenario, "playbook")
+        hint = execute_fresh_start(
+            artifacts=artifacts,
+            scenario_name=scenario,
+            current_strategy={},
+            lessons=[],
+        )
+        assert "FRESH START" in hint
+        assert "fundamentally different" in hint
+
+    def test_handles_empty_lessons(self, tmp_path: object) -> None:
+        artifacts = ArtifactStore(
+            runs_root=tmp_path / "runs",  # type: ignore[operator]
+            knowledge_root=tmp_path / "knowledge",  # type: ignore[operator]
+            skills_root=tmp_path / "skills",  # type: ignore[operator]
+            claude_skills_path=tmp_path / ".claude" / "skills",  # type: ignore[operator]
+        )
+        scenario = "test_scenario"
+        artifacts.write_playbook(scenario, "playbook")
+        execute_fresh_start(
+            artifacts=artifacts,
+            scenario_name=scenario,
+            current_strategy={},
+            lessons=[],
+        )
+        playbook = artifacts.read_playbook(scenario)
+        assert "No prior lessons" in playbook
+
+
+# ---------------------------------------------------------------------------
+# stage_stagnation_check tests
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(
+    tmp_path: object,
+    *,
+    stagnation_reset_enabled: bool = True,
+    ablation_no_feedback: bool = False,
+    gate_history: list[str] | None = None,
+    score_history: list[float] | None = None,
+    rollback_threshold: int = 3,
+    plateau_window: int = 5,
+    plateau_epsilon: float = 0.01,
+) -> GenerationContext:
+    """Build a minimal GenerationContext for stage testing."""
+    settings = AppSettings(
+        stagnation_reset_enabled=stagnation_reset_enabled,
+        ablation_no_feedback=ablation_no_feedback,
+        stagnation_rollback_threshold=rollback_threshold,
+        stagnation_plateau_window=plateau_window,
+        stagnation_plateau_epsilon=plateau_epsilon,
+        knowledge_root=tmp_path / "knowledge",  # type: ignore[operator]
+        skills_root=tmp_path / "skills",  # type: ignore[operator]
+        runs_root=tmp_path / "runs",  # type: ignore[operator]
+        claude_skills_path=tmp_path / ".claude" / "skills",  # type: ignore[operator]
+    )
+    scenario = MagicMock()
+    return GenerationContext(
+        run_id="test_run",
+        scenario_name="test_scenario",
+        scenario=scenario,
+        generation=5,
+        settings=settings,
+        previous_best=0.5,
+        challenger_elo=1500.0,
+        score_history=score_history if score_history is not None else [],
+        gate_decision_history=gate_history if gate_history is not None else [],
+        coach_competitor_hints="original hints",
+        replay_narrative="",
+        current_strategy={"param": 42},
+    )
+
+
+class TestStageStagnationCheck:
+    def test_noop_when_disabled(self, tmp_path: object) -> None:
+        ctx = _make_ctx(tmp_path, stagnation_reset_enabled=False)
+        artifacts = ArtifactStore(
+            runs_root=tmp_path / "runs",  # type: ignore[operator]
+            knowledge_root=tmp_path / "knowledge",  # type: ignore[operator]
+            skills_root=tmp_path / "skills",  # type: ignore[operator]
+            claude_skills_path=tmp_path / ".claude" / "skills",  # type: ignore[operator]
+        )
+        events = MagicMock()
+        result = stage_stagnation_check(ctx, artifacts=artifacts, events=events)
+        assert result.fresh_start_triggered is False
+        assert result.coach_competitor_hints == "original hints"
+        events.emit.assert_not_called()
+
+    def test_noop_on_ablation(self, tmp_path: object) -> None:
+        ctx = _make_ctx(tmp_path, ablation_no_feedback=True)
+        artifacts = ArtifactStore(
+            runs_root=tmp_path / "runs",  # type: ignore[operator]
+            knowledge_root=tmp_path / "knowledge",  # type: ignore[operator]
+            skills_root=tmp_path / "skills",  # type: ignore[operator]
+            claude_skills_path=tmp_path / ".claude" / "skills",  # type: ignore[operator]
+        )
+        events = MagicMock()
+        result = stage_stagnation_check(ctx, artifacts=artifacts, events=events)
+        assert result.fresh_start_triggered is False
+        events.emit.assert_not_called()
+
+    def test_triggers_on_consecutive_rollbacks(self, tmp_path: object) -> None:
+        ctx = _make_ctx(
+            tmp_path,
+            gate_history=["rollback", "rollback", "rollback"],
+            score_history=[0.4, 0.4, 0.4],
+            rollback_threshold=3,
+        )
+        artifacts = ArtifactStore(
+            runs_root=tmp_path / "runs",  # type: ignore[operator]
+            knowledge_root=tmp_path / "knowledge",  # type: ignore[operator]
+            skills_root=tmp_path / "skills",  # type: ignore[operator]
+            claude_skills_path=tmp_path / ".claude" / "skills",  # type: ignore[operator]
+        )
+        # Seed a playbook so write_playbook can archive it
+        artifacts.write_playbook("test_scenario", "old playbook")
+        events = MagicMock()
+        result = stage_stagnation_check(ctx, artifacts=artifacts, events=events)
+        assert result.fresh_start_triggered is True
+        assert "FRESH START" in result.coach_competitor_hints
+        events.emit.assert_called_once()
+        call_args = events.emit.call_args
+        assert call_args[0][0] == "fresh_start"
+        assert call_args[0][1]["trigger"] == "consecutive_rollbacks"


### PR DESCRIPTION
## Summary
- Add `StagnationDetector` that triggers on consecutive rollbacks or score plateaus
- `execute_fresh_start()` archives the playbook and starts fresh with distilled knowledge
- New pipeline stage `stage_stagnation_check` between tournament and curator gate
- Disabled by default (`MTS_STAGNATION_RESET_ENABLED=false`)

## Changes
- **New**: `mts/src/mts/knowledge/stagnation.py` — `StagnationDetector` + `StagnationReport`
- **New**: `mts/src/mts/knowledge/fresh_start.py` — `execute_fresh_start()`
- **Modified**: `mts/src/mts/config/settings.py` — 5 stagnation settings
- **Modified**: `mts/src/mts/loop/stage_types.py` — `fresh_start_triggered` on `GenerationContext`
- **Modified**: `mts/src/mts/loop/stages.py` — `stage_stagnation_check()` function
- **Modified**: `mts/src/mts/loop/generation_pipeline.py` — wired as Stage 3b
- **New**: `mts/tests/test_stagnation.py` — 17 tests

## Test plan
- [x] StagnationDetector: consecutive rollbacks, plateau, insufficient history, interleaved decisions
- [x] execute_fresh_start: archives playbook, writes distilled, clears hints, retains lessons
- [x] stage_stagnation_check: noop when disabled, noop on ablation, triggers correctly
- [x] Full test suite: 1215 passed, 21 skipped, ruff/mypy clean