### PR TITLE
feat: typed role handoff contracts for structured agent output parsing

### DIFF
--- a/mts/src/mts/agents/contracts.py
+++ b/mts/src/mts/agents/contracts.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class CompetitorOutput:
+    raw_text: str
+    strategy: dict[str, Any]
+    reasoning: str
+    is_code_strategy: bool = False
+
+
+@dataclass(slots=True)
+class AnalystOutput:
+    raw_markdown: str
+    findings: list[str] = field(default_factory=list)
+    root_causes: list[str] = field(default_factory=list)
+    recommendations: list[str] = field(default_factory=list)
+    parse_success: bool = True
+
+
+@dataclass(slots=True)
+class CoachOutput:
+    raw_markdown: str
+    playbook: str = ""
+    lessons: str = ""
+    hints: str = ""
+    parse_success: bool = True
+
+
+@dataclass(slots=True)
+class ArchitectOutput:
+    raw_markdown: str
+    tool_specs: list[dict[str, Any]] = field(default_factory=list)
+    changelog_entry: str = ""
+    parse_success: bool = True

--- a/mts/src/mts/agents/orchestrator.py
+++ b/mts/src/mts/agents/orchestrator.py
@@ -11,6 +11,7 @@ from mts.agents.coach import CoachRunner, parse_coach_sections
 from mts.agents.competitor import CompetitorRunner
 from mts.agents.curator import KnowledgeCurator
 from mts.agents.llm_client import AnthropicClient, DeterministicDevClient, LanguageModelClient
+from mts.agents.parsers import parse_analyst_output, parse_architect_output, parse_coach_output, parse_competitor_output
 from mts.agents.subagent_runtime import SubagentRuntime
 from mts.agents.translator import StrategyTranslator
 from mts.agents.types import AgentOutputs, RoleExecution
@@ -143,6 +144,15 @@ class AgentOrchestrator:
 
         tools = parse_architect_tool_specs(architect_exec.content)
         coach_playbook, coach_lessons, coach_hints = parse_coach_sections(coach_exec.content)
+
+        # Parse typed contracts
+        competitor_typed = parse_competitor_output(
+            raw_text, strategy, is_code_strategy=self.settings.code_strategies_enabled,
+        )
+        analyst_typed = parse_analyst_output(analyst_exec.content)
+        coach_typed = parse_coach_output(coach_exec.content)
+        architect_typed = parse_architect_output(architect_exec.content)
+
         return AgentOutputs(
             strategy=strategy,
             analysis_markdown=analyst_exec.content,
@@ -153,6 +163,10 @@ class AgentOrchestrator:
             architect_markdown=architect_exec.content,
             architect_tools=tools,
             role_executions=[competitor_exec, translator_exec, analyst_exec, coach_exec, architect_exec],
+            competitor_output=competitor_typed,
+            analyst_output=analyst_typed,
+            coach_output=coach_typed,
+            architect_output=architect_typed,
         )
 
     def _run_via_pipeline(
@@ -201,6 +215,14 @@ class AgentOrchestrator:
         tools = parse_architect_tool_specs(results["architect"].content)
         coach_playbook, coach_lessons, coach_hints = parse_coach_sections(results["coach"].content)
 
+        competitor_typed = parse_competitor_output(
+            results["competitor"].content, strategy,
+            is_code_strategy=self.settings.code_strategies_enabled,
+        )
+        analyst_typed = parse_analyst_output(results["analyst"].content)
+        coach_typed = parse_coach_output(results["coach"].content)
+        architect_typed = parse_architect_output(results["architect"].content)
+
         return AgentOutputs(
             strategy=strategy,
             analysis_markdown=results["analyst"].content,
@@ -213,6 +235,10 @@ class AgentOrchestrator:
             role_executions=[
                 results[r] for r in ["competitor", "translator", "analyst", "coach", "architect"]
             ],
+            competitor_output=competitor_typed,
+            analyst_output=analyst_typed,
+            coach_output=coach_typed,
+            architect_output=architect_typed,
         )
 
     def _enrich_coach_prompt(self, base_prompt: str, analyst_content: str) -> str:

--- a/mts/src/mts/agents/parsers.py
+++ b/mts/src/mts/agents/parsers.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from mts.agents.architect import parse_architect_tool_specs
+from mts.agents.coach import parse_coach_sections
+from mts.agents.contracts import AnalystOutput, ArchitectOutput, CoachOutput, CompetitorOutput
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _extract_section_bullets(markdown: str, heading: str) -> list[str]:
+    """Extract bullet points under a markdown heading.
+
+    Looks for lines starting with '- ' under a ## heading matching the text.
+    Stops at the next heading of equal or higher level.
+    """
+    bullets: list[str] = []
+    pattern = re.compile(rf"^##\s+{re.escape(heading)}\s*$", re.MULTILINE)
+    match = pattern.search(markdown)
+    if not match:
+        return bullets
+
+    after = markdown[match.end():]
+    for line in after.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## ") or stripped.startswith("# "):
+            break
+        if stripped.startswith("- "):
+            bullets.append(stripped[2:].strip())
+
+    return bullets
+
+
+def parse_competitor_output(
+    raw_text: str,
+    strategy: dict[str, Any],
+    is_code_strategy: bool = False,
+) -> CompetitorOutput:
+    """Parse competitor output into typed contract."""
+    return CompetitorOutput(
+        raw_text=raw_text,
+        strategy=strategy,
+        reasoning=raw_text.strip(),
+        is_code_strategy=is_code_strategy,
+    )
+
+
+def parse_analyst_output(raw_markdown: str) -> AnalystOutput:
+    """Parse analyst markdown into typed contract."""
+    try:
+        findings = _extract_section_bullets(raw_markdown, "Findings")
+        root_causes = _extract_section_bullets(raw_markdown, "Root Causes")
+        recommendations = _extract_section_bullets(raw_markdown, "Actionable Recommendations")
+        return AnalystOutput(
+            raw_markdown=raw_markdown,
+            findings=findings,
+            root_causes=root_causes,
+            recommendations=recommendations,
+            parse_success=True,
+        )
+    except Exception:
+        LOGGER.warning("failed to parse analyst output", exc_info=True)
+        return AnalystOutput(raw_markdown=raw_markdown, parse_success=False)
+
+
+def parse_coach_output(raw_markdown: str) -> CoachOutput:
+    """Parse coach markdown into typed contract."""
+    try:
+        playbook, lessons, hints = parse_coach_sections(raw_markdown)
+        return CoachOutput(
+            raw_markdown=raw_markdown,
+            playbook=playbook,
+            lessons=lessons,
+            hints=hints,
+            parse_success=True,
+        )
+    except Exception:
+        LOGGER.warning("failed to parse coach output", exc_info=True)
+        return CoachOutput(raw_markdown=raw_markdown, parse_success=False)
+
+
+def parse_architect_output(raw_markdown: str) -> ArchitectOutput:
+    """Parse architect markdown into typed contract."""
+    try:
+        tool_specs = parse_architect_tool_specs(raw_markdown)
+        return ArchitectOutput(
+            raw_markdown=raw_markdown,
+            tool_specs=tool_specs,
+            parse_success=True,
+        )
+    except Exception:
+        LOGGER.warning("failed to parse architect output", exc_info=True)
+        return ArchitectOutput(raw_markdown=raw_markdown, parse_success=False)

--- a/mts/src/mts/agents/types.py
+++ b/mts/src/mts/agents/types.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mts.harness.core.types import RoleExecution, RoleUsage
+
+if TYPE_CHECKING:
+    from mts.agents.contracts import AnalystOutput, ArchitectOutput, CoachOutput, CompetitorOutput
 
 
 @dataclass(slots=True)
@@ -17,6 +20,10 @@ class AgentOutputs:
     architect_markdown: str
     architect_tools: list[dict[str, Any]]
     role_executions: list[RoleExecution]
+    competitor_output: CompetitorOutput | None = None
+    analyst_output: AnalystOutput | None = None
+    coach_output: CoachOutput | None = None
+    architect_output: ArchitectOutput | None = None
 
 
 __all__ = ["RoleUsage", "RoleExecution", "AgentOutputs"]

--- a/mts/tests/test_typed_contracts.py
+++ b/mts/tests/test_typed_contracts.py
@@ -1,0 +1,247 @@
+"""Tests for typed role handoff contracts and parsers."""
+
+from __future__ import annotations
+
+from mts.agents.contracts import AnalystOutput, ArchitectOutput, CoachOutput, CompetitorOutput
+from mts.agents.parsers import (
+    _extract_section_bullets,
+    parse_analyst_output,
+    parse_architect_output,
+    parse_coach_output,
+    parse_competitor_output,
+)
+from mts.agents.types import AgentOutputs
+from mts.harness.core.types import RoleExecution, RoleUsage
+
+# ---------- Contract construction ----------
+
+
+def test_competitor_output_defaults() -> None:
+    out = CompetitorOutput(raw_text="hello", strategy={"a": 1}, reasoning="my reasoning")
+    assert out.raw_text == "hello"
+    assert out.strategy == {"a": 1}
+    assert out.reasoning == "my reasoning"
+    assert out.is_code_strategy is False
+
+
+def test_analyst_output_defaults() -> None:
+    out = AnalystOutput(raw_markdown="# Analysis")
+    assert out.raw_markdown == "# Analysis"
+    assert out.findings == []
+    assert out.root_causes == []
+    assert out.recommendations == []
+    assert out.parse_success is True
+
+
+def test_coach_output_defaults() -> None:
+    out = CoachOutput(raw_markdown="# Coach")
+    assert out.raw_markdown == "# Coach"
+    assert out.playbook == ""
+    assert out.lessons == ""
+    assert out.hints == ""
+    assert out.parse_success is True
+
+
+def test_architect_output_defaults() -> None:
+    out = ArchitectOutput(raw_markdown="# Architect")
+    assert out.raw_markdown == "# Architect"
+    assert out.tool_specs == []
+    assert out.changelog_entry == ""
+    assert out.parse_success is True
+
+
+# ---------- _extract_section_bullets ----------
+
+
+def test_extract_bullets_single_heading() -> None:
+    md = "## Findings\n- First finding\n- Second finding\n"
+    bullets = _extract_section_bullets(md, "Findings")
+    assert bullets == ["First finding", "Second finding"]
+
+
+def test_extract_bullets_no_matching_heading() -> None:
+    md = "## Other Section\n- Some bullet\n"
+    bullets = _extract_section_bullets(md, "Findings")
+    assert bullets == []
+
+
+def test_extract_bullets_stops_at_next_heading() -> None:
+    md = "## Findings\n- Finding one\n## Root Causes\n- Cause one\n"
+    bullets = _extract_section_bullets(md, "Findings")
+    assert bullets == ["Finding one"]
+
+
+def test_extract_bullets_no_bullets_under_heading() -> None:
+    md = "## Findings\nJust some text, no bullets.\n"
+    bullets = _extract_section_bullets(md, "Findings")
+    assert bullets == []
+
+
+# ---------- parse_competitor_output ----------
+
+
+def test_parse_competitor_basic() -> None:
+    out = parse_competitor_output("raw strategy text", {"x": 1})
+    assert out.raw_text == "raw strategy text"
+    assert out.strategy == {"x": 1}
+    assert out.is_code_strategy is False
+
+
+def test_parse_competitor_code_strategy() -> None:
+    out = parse_competitor_output("```python\ncode\n```", {"__code__": "code"}, is_code_strategy=True)
+    assert out.is_code_strategy is True
+    assert out.strategy == {"__code__": "code"}
+
+
+# ---------- parse_analyst_output ----------
+
+
+def test_parse_analyst_well_formed() -> None:
+    md = (
+        "## Findings\n- Finding A\n- Finding B\n"
+        "## Root Causes\n- Cause X\n"
+        "## Actionable Recommendations\n- Do Y\n- Do Z\n"
+    )
+    out = parse_analyst_output(md)
+    assert out.parse_success is True
+    assert out.findings == ["Finding A", "Finding B"]
+    assert out.root_causes == ["Cause X"]
+    assert out.recommendations == ["Do Y", "Do Z"]
+    assert out.raw_markdown == md
+
+
+def test_parse_analyst_missing_sections() -> None:
+    md = "Some unstructured analyst output without headings."
+    out = parse_analyst_output(md)
+    assert out.parse_success is True
+    assert out.findings == []
+    assert out.root_causes == []
+    assert out.recommendations == []
+
+
+def test_parse_analyst_failure() -> None:
+    """Force a parse failure by making _extract_section_bullets raise."""
+    import mts.agents.parsers as parsers_mod
+
+    original = parsers_mod._extract_section_bullets
+
+    def _raise(md: str, heading: str) -> list[str]:
+        raise RuntimeError("boom")
+
+    parsers_mod._extract_section_bullets = _raise  # type: ignore[assignment]
+    try:
+        out = parse_analyst_output("any markdown")
+        assert out.parse_success is False
+        assert out.raw_markdown == "any markdown"
+    finally:
+        parsers_mod._extract_section_bullets = original  # type: ignore[assignment]
+
+
+# ---------- parse_coach_output ----------
+
+
+def test_parse_coach_well_formed() -> None:
+    md = (
+        "<!-- PLAYBOOK_START -->\nPlaybook content\n<!-- PLAYBOOK_END -->\n"
+        "<!-- LESSONS_START -->\nLesson 1\n<!-- LESSONS_END -->\n"
+        "<!-- COMPETITOR_HINTS_START -->\nHint A\n<!-- COMPETITOR_HINTS_END -->\n"
+    )
+    out = parse_coach_output(md)
+    assert out.parse_success is True
+    assert out.playbook == "Playbook content"
+    assert out.lessons == "Lesson 1"
+    assert out.hints == "Hint A"
+
+
+def test_parse_coach_missing_markers() -> None:
+    md = "Just a raw playbook without any markers."
+    out = parse_coach_output(md)
+    assert out.parse_success is True
+    assert out.playbook == md.strip()
+    assert out.lessons == ""
+    assert out.hints == ""
+
+
+def test_parse_coach_failure() -> None:
+    """Force a parse failure by making parse_coach_sections raise."""
+    import mts.agents.parsers as parsers_mod
+
+    original = parsers_mod.parse_coach_sections
+
+    def _raise(content: str) -> tuple[str, str, str]:
+        raise RuntimeError("boom")
+
+    parsers_mod.parse_coach_sections = _raise  # type: ignore[assignment]
+    try:
+        out = parse_coach_output("any markdown")
+        assert out.parse_success is False
+        assert out.raw_markdown == "any markdown"
+    finally:
+        parsers_mod.parse_coach_sections = original  # type: ignore[assignment]
+
+
+# ---------- parse_architect_output ----------
+
+
+def test_parse_architect_with_tools() -> None:
+    md = (
+        "Some analysis.\n"
+        '```json\n{"tools": [{"name": "t1", "description": "desc", "code": "pass"}]}\n```\n'
+    )
+    out = parse_architect_output(md)
+    assert out.parse_success is True
+    assert len(out.tool_specs) == 1
+    assert out.tool_specs[0]["name"] == "t1"
+
+
+def test_parse_architect_no_json_block() -> None:
+    md = "Architect output without any JSON."
+    out = parse_architect_output(md)
+    assert out.parse_success is True
+    assert out.tool_specs == []
+
+
+# ---------- AgentOutputs integration ----------
+
+
+def test_agent_outputs_with_typed_fields() -> None:
+    """Verify typed fields are consistent with string fields on AgentOutputs."""
+    coach_md = (
+        "<!-- PLAYBOOK_START -->\nMy playbook\n<!-- PLAYBOOK_END -->\n"
+        "<!-- LESSONS_START -->\nLesson\n<!-- LESSONS_END -->\n"
+        "<!-- COMPETITOR_HINTS_START -->\nHint\n<!-- COMPETITOR_HINTS_END -->\n"
+    )
+
+    competitor_typed = parse_competitor_output("raw", {"s": 1})
+    analyst_typed = parse_analyst_output("## Findings\n- F1\n")
+    coach_typed = parse_coach_output(coach_md)
+    architect_typed = parse_architect_output("no tools")
+
+    usage = RoleUsage(input_tokens=0, output_tokens=0, latency_ms=0, model="m")
+    exec_ = RoleExecution(role="test", content="c", usage=usage, subagent_id="sa", status="ok")
+    outputs = AgentOutputs(
+        strategy={"s": 1},
+        analysis_markdown="## Findings\n- F1\n",
+        coach_markdown=coach_md,
+        coach_playbook="My playbook",
+        coach_lessons="Lesson",
+        coach_competitor_hints="Hint",
+        architect_markdown="no tools",
+        architect_tools=[],
+        role_executions=[exec_] * 5,
+        competitor_output=competitor_typed,
+        analyst_output=analyst_typed,
+        coach_output=coach_typed,
+        architect_output=architect_typed,
+    )
+
+    assert outputs.competitor_output is not None
+    assert outputs.competitor_output.strategy == outputs.strategy
+    assert outputs.analyst_output is not None
+    assert outputs.analyst_output.findings == ["F1"]
+    assert outputs.coach_output is not None
+    assert outputs.coach_output.playbook == outputs.coach_playbook
+    assert outputs.coach_output.lessons == outputs.coach_lessons
+    assert outputs.coach_output.hints == outputs.coach_competitor_hints
+    assert outputs.architect_output is not None
+    assert outputs.architect_output.tool_specs == outputs.architect_tools


### PR DESCRIPTION
## Summary
- Add `CompetitorOutput`, `AnalystOutput`, `CoachOutput`, `ArchitectOutput` typed dataclasses
- Dedicated parsers extract structured data from raw role outputs
- `AgentOutputs` gains optional typed fields alongside existing string fields for backward compatibility

## Changes
- **New**: `mts/src/mts/agents/contracts.py` — 4 typed dataclass contracts
- **New**: `mts/src/mts/agents/parsers.py` — `parse_*_output()` functions + `_extract_section_bullets()` helper
- **Modified**: `mts/src/mts/agents/types.py` — 4 optional typed fields on `AgentOutputs`
- **Modified**: `mts/src/mts/agents/orchestrator.py` — populated in both `run_generation()` and `_run_via_pipeline()`
- **New**: `mts/tests/test_typed_contracts.py` — 19 tests

## Test plan
- [x] Contract construction and defaults
- [x] Each parser with well-formed and missing-marker input
- [x] `_extract_section_bullets` with single/multiple headings
- [x] AgentOutputs typed fields populated and consistent with string fields
- [x] Parse failure sets `parse_success=False`
- [x] Full test suite: 1215 passed, 21 skipped, ruff/mypy clean