### PR TITLE
ci: add concurrency group to cancel stale CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `concurrency` group (`ci-${{ github.ref }}`) with `cancel-in-progress: true` to the CI workflow
- When multiple commits are pushed rapidly to a PR branch, in-progress runs are cancelled in favor of the latest

## Test plan
- [ ] Push two commits in quick succession to a PR branch and verify the first run is cancelled