### PR TITLE
fix: wire scenario_rules and current_strategy to RLM context loaders

### DIFF
--- a/mts/src/mts/agents/orchestrator.py
+++ b/mts/src/mts/agents/orchestrator.py
@@ -116,6 +116,8 @@ class AgentOrchestrator:
         scenario_name: str = "",
         strategy_interface: str = "",
         on_role_event: Callable[[str, str], None] | None = None,
+        scenario_rules: str = "",
+        current_strategy: dict[str, Any] | None = None,
     ) -> AgentOutputs:
         # Feature-gated pipeline codepath (skips RLM path when active)
         if self.settings.use_pipeline_engine and not (
@@ -142,6 +144,8 @@ class AgentOrchestrator:
             raw_text, competitor_exec = self._run_rlm_competitor(
                 run_id, scenario_name, generation_index,
                 strategy_interface=strategy_interface,
+                scenario_rules=scenario_rules,
+                current_strategy=current_strategy,
             )
             _notify("competitor", "completed")
         else:
@@ -168,6 +172,7 @@ class AgentOrchestrator:
             _notify("architect", "started")
             analyst_exec, architect_exec = self._run_rlm_roles(
                 run_id, scenario_name, generation_index, strategy, architect_prompt,
+                scenario_rules=scenario_rules,
             )
             _notify("analyst", "completed")
             _notify("architect", "completed")
@@ -308,6 +313,8 @@ class AgentOrchestrator:
         generation_index: int,
         *,
         strategy_interface: str = "",
+        scenario_rules: str = "",
+        current_strategy: dict[str, Any] | None = None,
     ) -> tuple[str, RoleExecution]:
         """Run the Competitor via an RLM REPL session.
 
@@ -350,6 +357,8 @@ class AgentOrchestrator:
         competitor_ctx = self._rlm_loader.load_for_competitor(
             run_id, scenario_name, generation_index,
             strategy_interface=strategy_interface,
+            scenario_rules=scenario_rules,
+            current_strategy=current_strategy,
         )
         competitor_ns = dict(competitor_ctx.variables)
         competitor_ns["llm_batch"] = make_llm_batch(self.client, settings.rlm_sub_model)
@@ -384,6 +393,8 @@ class AgentOrchestrator:
         generation_index: int,
         strategy: dict[str, Any],
         architect_prompt: str,
+        *,
+        scenario_rules: str = "",
     ) -> tuple[RoleExecution, RoleExecution]:
         """Run Analyst and Architect via RLM sessions.
 
@@ -436,6 +447,7 @@ class AgentOrchestrator:
         # --- Analyst ---
         analyst_ctx = self._rlm_loader.load_for_analyst(
             run_id, scenario_name, generation_index,
+            scenario_rules=scenario_rules,
             current_strategy=strategy,
         )
         analyst_ns = dict(analyst_ctx.variables)
@@ -467,6 +479,7 @@ class AgentOrchestrator:
         # --- Architect ---
         architect_ctx = self._rlm_loader.load_for_architect(
             run_id, scenario_name, generation_index,
+            scenario_rules=scenario_rules,
         )
         architect_ns = dict(architect_ctx.variables)
         architect_ns["llm_batch"] = make_llm_batch(self.client, settings.rlm_sub_model)

--- a/mts/src/mts/loop/stages.py
+++ b/mts/src/mts/loop/stages.py
@@ -162,6 +162,8 @@ def stage_agent_generation(
         scenario_name=ctx.scenario_name,
         strategy_interface=ctx.strategy_interface,
         on_role_event=on_role_event,
+        scenario_rules=ctx.scenario.describe_rules(),
+        current_strategy=ctx.current_strategy or None,
     )
 
     if "__code__" not in outputs.strategy:

--- a/mts/tests/test_rlm_competitor.py
+++ b/mts/tests/test_rlm_competitor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -501,3 +502,105 @@ class TestOrchestratorCompetitorRlm:
         # The competitor execution should still be present.
         roles = [r.role for r in outputs.role_executions]
         assert "competitor" in roles
+
+    def test_orchestrator_passes_scenario_rules_and_strategy(
+        self, tmp_artifacts: Any, tmp_sqlite: Any, seeded_artifacts: Any,
+    ) -> None:
+        """scenario_rules and current_strategy reach the context loader."""
+        from mts.agents.orchestrator import AgentOrchestrator
+        from mts.prompts.templates import PromptBundle
+
+        settings = AppSettings(
+            agent_provider="deterministic",
+            rlm_enabled=True,
+            rlm_competitor_enabled=True,
+            rlm_max_turns=5,
+            curator_enabled=False,
+        )
+        orch = AgentOrchestrator(
+            client=DeterministicDevClient(),
+            settings=settings,
+            artifacts=seeded_artifacts,
+            sqlite=tmp_sqlite,
+        )
+        prompts = PromptBundle(
+            competitor="Describe your strategy.",
+            analyst="Analyze.",
+            coach="Coach.",
+            architect="Propose.",
+        )
+
+        captured_kwargs: dict[str, Any] = {}
+        original_load = orch._rlm_loader.load_for_competitor  # type: ignore[union-attr]
+
+        def _spy_load(*args: Any, **kwargs: Any) -> Any:
+            captured_kwargs.update(kwargs)
+            return original_load(*args, **kwargs)
+
+        with patch.object(orch._rlm_loader, "load_for_competitor", side_effect=_spy_load):  # type: ignore[union-attr]
+            orch.run_generation(
+                prompts,
+                generation_index=1,
+                run_id="test_run",
+                scenario_name="grid_ctf",
+                scenario_rules="Capture the flag on a 5x5 grid.",
+                current_strategy={"aggression": 0.5},
+            )
+
+        assert captured_kwargs.get("scenario_rules") == "Capture the flag on a 5x5 grid."
+        assert captured_kwargs.get("current_strategy") == {"aggression": 0.5}
+
+    def test_orchestrator_passes_scenario_rules_to_analyst_and_architect(
+        self, tmp_artifacts: Any, tmp_sqlite: Any, seeded_artifacts: Any,
+    ) -> None:
+        """scenario_rules reaches the analyst and architect context loaders."""
+        from mts.agents.orchestrator import AgentOrchestrator
+        from mts.prompts.templates import PromptBundle
+
+        settings = AppSettings(
+            agent_provider="deterministic",
+            rlm_enabled=True,
+            rlm_competitor_enabled=False,  # Use normal competitor path
+            rlm_max_turns=5,
+            curator_enabled=False,
+        )
+        orch = AgentOrchestrator(
+            client=DeterministicDevClient(),
+            settings=settings,
+            artifacts=seeded_artifacts,
+            sqlite=tmp_sqlite,
+        )
+        prompts = PromptBundle(
+            competitor="Describe your strategy.",
+            analyst="Analyze.",
+            coach="Coach.",
+            architect="Propose.",
+        )
+
+        analyst_kwargs: dict[str, Any] = {}
+        architect_kwargs: dict[str, Any] = {}
+        original_analyst = orch._rlm_loader.load_for_analyst  # type: ignore[union-attr]
+        original_architect = orch._rlm_loader.load_for_architect  # type: ignore[union-attr]
+
+        def _spy_analyst(*args: Any, **kwargs: Any) -> Any:
+            analyst_kwargs.update(kwargs)
+            return original_analyst(*args, **kwargs)
+
+        def _spy_architect(*args: Any, **kwargs: Any) -> Any:
+            architect_kwargs.update(kwargs)
+            return original_architect(*args, **kwargs)
+
+        with (
+            patch.object(orch._rlm_loader, "load_for_analyst", side_effect=_spy_analyst),  # type: ignore[union-attr]
+            patch.object(orch._rlm_loader, "load_for_architect", side_effect=_spy_architect),  # type: ignore[union-attr]
+        ):
+            orch.run_generation(
+                prompts,
+                generation_index=1,
+                run_id="test_run",
+                scenario_name="grid_ctf",
+                scenario_rules="Capture the flag on a 5x5 grid.",
+            )
+
+        assert analyst_kwargs.get("scenario_rules") == "Capture the flag on a 5x5 grid."
+        assert architect_kwargs.get("scenario_rules") == "Capture the flag on a 5x5 grid."


### PR DESCRIPTION
## Summary

- **MTS-137**: `_run_rlm_competitor` called `load_for_competitor()` without passing `scenario_rules` or `current_strategy`, leaving the REPL session without essential scenario context
- Same issue affected `_run_rlm_roles` — analyst and architect loaders also lacked `scenario_rules`
- Added `scenario_rules` and `current_strategy` params to `run_generation()`, threaded through to all three RLM context loaders
- `stage_agent_generation` now passes `ctx.scenario.describe_rules()` and `ctx.current_strategy`

## Files changed

- `src/mts/agents/orchestrator.py` — added params to `run_generation`, `_run_rlm_competitor`, `_run_rlm_roles`; passed them to all `load_for_*` calls
- `src/mts/loop/stages.py` — pass `scenario_rules` and `current_strategy` from generation context
- `tests/test_rlm_competitor.py` — 2 new tests verifying context wiring via spy patches

## Test plan

- [x] `uv run pytest tests/test_rlm_competitor.py -v` — 22 passed
- [x] `uv run ruff check` — clean
- [x] `uv run mypy` — clean  
- [x] Full suite: 1763 passed, 26 skipped, 0 failed