### PR TITLE
fix: consolidate duplicate tuning bounds (MTS-136)

### DIFF
--- a/mts/src/mts/config/tuning_bounds.py
+++ b/mts/src/mts/config/tuning_bounds.py
@@ -1,0 +1,64 @@
+"""Canonical tuning bounds for meta-parameter validation.
+
+Both the AR-3 research protocol (protocol.py) and AR-6 architect tuning
+proposals (tuning.py) reference these bounds.  Two tiers exist:
+
+* **architect** — tighter bounds for automated architect proposals that
+  are applied without human review.
+* **protocol** — wider bounds for research protocol overrides that
+  represent deliberate experimental exploration.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ParamBounds:
+    """Bounds for a single tunable parameter."""
+
+    param_type: type  # int or float
+    architect_min: float
+    architect_max: float
+    protocol_min: float
+    protocol_max: float
+
+
+# Canonical definition — single source of truth
+TUNING_PARAMS: dict[str, ParamBounds] = {
+    "backpressure_min_delta": ParamBounds(
+        param_type=float,
+        architect_min=0.0, architect_max=0.05,
+        protocol_min=0.0, protocol_max=1.0,
+    ),
+    "matches_per_generation": ParamBounds(
+        param_type=int,
+        architect_min=1, architect_max=10,
+        protocol_min=1, protocol_max=20,
+    ),
+    "rlm_max_turns": ParamBounds(
+        param_type=int,
+        architect_min=3, architect_max=50,
+        protocol_min=1, protocol_max=50,
+    ),
+    "architect_every_n_gens": ParamBounds(
+        param_type=int,
+        architect_min=1, architect_max=10,
+        protocol_min=1, protocol_max=10,
+    ),
+    "probe_matches": ParamBounds(
+        param_type=int,
+        architect_min=0, architect_max=5,
+        protocol_min=0, protocol_max=10,
+    ),
+}
+
+
+def architect_bounds() -> dict[str, tuple[float, float]]:
+    """Return (min, max) tuples for architect-tier validation."""
+    return {k: (p.architect_min, p.architect_max) for k, p in TUNING_PARAMS.items()}
+
+
+def protocol_bounds() -> dict[str, tuple[type, float, float]]:
+    """Return (type, min, max) tuples for protocol-tier validation."""
+    return {k: (p.param_type, p.protocol_min, p.protocol_max) for k, p in TUNING_PARAMS.items()}

--- a/mts/src/mts/knowledge/protocol.py
+++ b/mts/src/mts/knowledge/protocol.py
@@ -4,13 +4,11 @@ import json
 import re
 from dataclasses import dataclass, field
 
-# Allowed tuning override keys and their validation ranges
-TUNING_ALLOWED_KEYS: dict[str, tuple[type, float | int, float | int]] = {
-    "backpressure_min_delta": (float, 0.0, 1.0),
-    "matches_per_generation": (int, 1, 20),
-    "rlm_max_turns": (int, 1, 50),
-    "probe_matches": (int, 0, 10),
-}
+from mts.config.tuning_bounds import protocol_bounds
+
+# Protocol-tier bounds: wider ranges for deliberate experimental exploration.
+# Derived from the canonical definition in config/tuning_bounds.py.
+TUNING_ALLOWED_KEYS: dict[str, tuple[type, float | int, float | int]] = protocol_bounds()
 
 
 @dataclass(slots=True)

--- a/mts/src/mts/knowledge/tuning.py
+++ b/mts/src/mts/knowledge/tuning.py
@@ -5,14 +5,11 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-# Hard bounds for tunable parameters
-TUNING_BOUNDS: dict[str, tuple[float, float]] = {
-    "matches_per_generation": (1, 10),
-    "backpressure_min_delta": (0.0, 0.05),
-    "rlm_max_turns": (3, 50),
-    "architect_every_n_gens": (1, 10),
-    "probe_matches": (0, 5),
-}
+from mts.config.tuning_bounds import architect_bounds
+
+# Architect-tier bounds: tighter ranges for automated proposals.
+# Derived from the canonical definition in config/tuning_bounds.py.
+TUNING_BOUNDS: dict[str, tuple[float, float]] = architect_bounds()
 
 
 @dataclass(slots=True)

--- a/mts/tests/test_config_adaptive.py
+++ b/mts/tests/test_config_adaptive.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import pytest
 
 from mts.config.settings import AppSettings, load_settings
+from mts.config.tuning_bounds import TUNING_PARAMS, architect_bounds, protocol_bounds
 from mts.knowledge.tuning import (
+    TUNING_BOUNDS,
     TuningConfig,
     compute_meta_parameter_stats,
     format_meta_stats,
@@ -218,3 +220,38 @@ class TestFormatMetaStats:
         assert "Average gate delta: 0.0123" in output
         assert "RLM utilization: 0%" in output
         assert "last 8 gens" in output
+
+
+# ---------------------------------------------------------------------------
+# TestCanonicalTuningBounds
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalTuningBounds:
+    """Verify both tiers derive from the single canonical source."""
+
+    def test_tuning_bounds_matches_architect_bounds(self) -> None:
+        assert TUNING_BOUNDS == architect_bounds()
+
+    def test_protocol_and_architect_share_same_keys(self) -> None:
+        assert set(architect_bounds().keys()) == set(protocol_bounds().keys())
+
+    def test_architect_bounds_within_protocol_bounds(self) -> None:
+        """Architect bounds should be equal or tighter than protocol bounds."""
+        for key, param in TUNING_PARAMS.items():
+            assert param.architect_min >= param.protocol_min, (
+                f"{key}: architect_min ({param.architect_min}) < protocol_min ({param.protocol_min})"
+            )
+            assert param.architect_max <= param.protocol_max, (
+                f"{key}: architect_max ({param.architect_max}) > protocol_max ({param.protocol_max})"
+            )
+
+    def test_all_tuning_params_have_valid_ranges(self) -> None:
+        for key, param in TUNING_PARAMS.items():
+            assert param.architect_min <= param.architect_max, f"{key}: architect min > max"
+            assert param.protocol_min <= param.protocol_max, f"{key}: protocol min > max"
+
+    def test_architect_every_n_gens_in_protocol_bounds(self) -> None:
+        """architect_every_n_gens was missing from protocol — now present."""
+        pb = protocol_bounds()
+        assert "architect_every_n_gens" in pb


### PR DESCRIPTION
## Summary
- Introduces `config/tuning_bounds.py` as the single canonical source for all tunable parameter bounds
- `ParamBounds` dataclass holds both architect-tier (tight, automated) and protocol-tier (wide, experimental) ranges
- Refactors `protocol.py` and `tuning.py` to derive bounds via `protocol_bounds()` / `architect_bounds()` helpers, eliminating independent hardcoded dicts that could silently drift
- Adds 5 canonical consistency tests verifying both tiers derive from the same source and architect bounds are always within protocol bounds

## Test plan
- [x] All 20 `test_config_adaptive.py` tests pass (including 5 new canonical tests)
- [x] All 33 related protocol/tuning tests pass
- [x] Full regression suite: 1763 passed, 26 skipped
- [x] Ruff lint clean
- [x] Mypy clean