### PR TITLE
feat: ArtifactStore harness CRUD methods (MTS-73)

### DIFF
--- a/mts/src/mts/storage/artifacts.py
+++ b/mts/src/mts/storage/artifacts.py
@@ -261,17 +261,27 @@ class ArtifactStore:
             created.append(label)
         return created
 
+    @staticmethod
+    def _validate_harness_name(name: str) -> str:
+        """Validate harness module name and prevent path traversal."""
+        candidate = name.strip()
+        if not re.fullmatch(r"[a-zA-Z_][a-zA-Z0-9_]*", candidate):
+            raise ValueError(f"invalid harness name: {name!r}")
+        return candidate
+
     def write_harness(self, scenario_name: str, name: str, source: str) -> Path:
         """Write a single harness file to knowledge/<scenario>/harness/<name>.py."""
+        safe_name = self._validate_harness_name(name)
         h_dir = self.harness_dir(scenario_name)
         h_dir.mkdir(parents=True, exist_ok=True)
-        target = h_dir / f"{name}.py"
+        target = h_dir / f"{safe_name}.py"
         target.write_text(source, encoding="utf-8")
         return target
 
     def read_harness(self, scenario_name: str, name: str) -> str | None:
         """Read a harness file by name, or None if not found."""
-        target = self.harness_dir(scenario_name) / f"{name}.py"
+        safe_name = self._validate_harness_name(name)
+        target = self.harness_dir(scenario_name) / f"{safe_name}.py"
         if not target.exists():
             return None
         return target.read_text(encoding="utf-8")

--- a/mts/tests/test_artifact_harness.py
+++ b/mts/tests/test_artifact_harness.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from mts.storage.artifacts import ArtifactStore
 
 
@@ -59,6 +61,11 @@ class TestWriteHarness:
         assert isinstance(path, Path)
         assert path.parent.name == "harness"
 
+    def test_write_rejects_invalid_name(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with pytest.raises(ValueError, match="invalid harness name"):
+            store.write_harness("grid_ctf", "../escape", "pass")
+
 
 # ---------------------------------------------------------------------------
 # read_harness
@@ -79,6 +86,11 @@ class TestReadHarness:
     def test_read_missing_scenario_returns_none(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
         assert store.read_harness("no_scenario", "anything") is None
+
+    def test_read_rejects_invalid_name(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with pytest.raises(ValueError, match="invalid harness name"):
+            store.read_harness("grid_ctf", "../../etc/passwd")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds three CRUD methods to `ArtifactStore` for individual harness file operations:
  - `write_harness(scenario, name, source) -> Path` — write a single harness file, creating directory lazily
  - `read_harness(scenario, name) -> str | None` — read a harness file by name, or None if missing
  - `list_harness(scenario) -> list[str]` — list harness file stems, sorted, excluding `_archive/` and non-.py files
- These complement the existing batch `persist_harness()` (AST validation + archiving) and `read_harness_context()` methods
- Foundational for P5 (Action Filter Mode) and P6 (Harness Persistence) features

## Test plan
- [x] 18 new tests in `test_artifact_harness.py` covering all CRUD operations
- [x] Full regression: 1779 passed, 26 skipped
- [x] Ruff lint clean
- [x] Mypy clean