### PR TITLE
feat: add HarnessMode enum setting (MTS-83)

### DIFF
--- a/mts/src/mts/config/settings.py
+++ b/mts/src/mts/config/settings.py
@@ -1,12 +1,25 @@
 from __future__ import annotations
 
+import logging
 import os
+from enum import StrEnum
 from pathlib import Path
 from typing import Literal, cast
 
 from pydantic import BaseModel, Field
 
 from mts.config.presets import apply_preset
+
+LOGGER = logging.getLogger(__name__)
+
+
+class HarnessMode(StrEnum):
+    """How the harness interacts with strategy execution."""
+
+    NONE = "none"        # No harness intervention (existing behavior)
+    FILTER = "filter"    # Enumerate valid moves, LLM selects by index
+    VERIFY = "verify"    # LLM proposes, code validates, retry on invalid
+    POLICY = "policy"    # Pure code strategy (alias for CODE_STRATEGIES_ENABLED)
 
 
 class AppSettings(BaseModel):
@@ -134,6 +147,9 @@ class AppSettings(BaseModel):
     )
     harness_timeout_seconds: float = Field(
         default=5.0, ge=0.5, le=60.0, description="Timeout for harness code execution",
+    )
+    harness_mode: HarnessMode = Field(
+        default=HarnessMode.NONE, description="Harness interaction mode: none, filter, verify, policy",
     )
     # Probe matches (Phase 4)
     probe_matches: int = Field(default=0, ge=0, description="Probe matches before full tournament (0=disabled)")
@@ -316,6 +332,7 @@ def load_settings() -> AppSettings:
         harness_timeout_seconds=float(
             _get("harness_timeout_seconds", "MTS_HARNESS_TIMEOUT_SECONDS", "5.0"),
         ),
+        harness_mode=HarnessMode(_get("harness_mode", "MTS_HARNESS_MODE", "none")),
         probe_matches=int(_get("probe_matches", "MTS_PROBE_MATCHES", "0")),
         ecosystem_convergence_enabled=_get_bool(
             "ecosystem_convergence_enabled", "MTS_ECOSYSTEM_CONVERGENCE_ENABLED", "false",
@@ -337,3 +354,20 @@ def load_settings() -> AppSettings:
         session_reports_enabled=_get_bool("session_reports_enabled", "MTS_SESSION_REPORTS_ENABLED", "true"),
         config_adaptive_enabled=_get_bool("config_adaptive_enabled", "MTS_CONFIG_ADAPTIVE_ENABLED", "false"),
     )
+
+
+def validate_harness_mode(settings: AppSettings) -> AppSettings:
+    """Validate harness_mode against dependent settings, falling back to NONE if invalid."""
+    mode = settings.harness_mode
+    if mode in (HarnessMode.FILTER, HarnessMode.VERIFY) and not settings.harness_validators_enabled:
+        LOGGER.warning(
+            "harness_mode=%s requires harness_validators_enabled=true; falling back to 'none'",
+            mode.value,
+        )
+        settings = settings.model_copy(update={"harness_mode": HarnessMode.NONE})
+    if mode == HarnessMode.POLICY and not settings.code_strategies_enabled:
+        LOGGER.warning(
+            "harness_mode=policy implies code_strategies_enabled=true; enabling it",
+        )
+        settings = settings.model_copy(update={"code_strategies_enabled": True})
+    return settings

--- a/mts/tests/test_harness_mode.py
+++ b/mts/tests/test_harness_mode.py
@@ -1,0 +1,130 @@
+"""Tests for HarnessMode enum and validation (MTS-83)."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from mts.config.settings import AppSettings, HarnessMode, load_settings, validate_harness_mode
+
+# ---------------------------------------------------------------------------
+# HarnessMode enum
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessMode:
+    def test_enum_values(self) -> None:
+        assert HarnessMode.NONE == "none"
+        assert HarnessMode.FILTER == "filter"
+        assert HarnessMode.VERIFY == "verify"
+        assert HarnessMode.POLICY == "policy"
+
+    def test_enum_from_string(self) -> None:
+        assert HarnessMode("none") is HarnessMode.NONE
+        assert HarnessMode("filter") is HarnessMode.FILTER
+        assert HarnessMode("verify") is HarnessMode.VERIFY
+        assert HarnessMode("policy") is HarnessMode.POLICY
+
+
+# ---------------------------------------------------------------------------
+# AppSettings defaults
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessModeSettings:
+    def test_default_is_none(self) -> None:
+        settings = AppSettings()
+        assert settings.harness_mode is HarnessMode.NONE
+
+    def test_explicit_mode(self) -> None:
+        settings = AppSettings(harness_mode=HarnessMode.FILTER)
+        assert settings.harness_mode is HarnessMode.FILTER
+
+    def test_env_var_parsing(self) -> None:
+        with patch.dict("os.environ", {"MTS_HARNESS_MODE": "verify"}):
+            settings = load_settings()
+            assert settings.harness_mode is HarnessMode.VERIFY
+
+    def test_env_var_filter(self) -> None:
+        with patch.dict("os.environ", {"MTS_HARNESS_MODE": "filter"}):
+            settings = load_settings()
+            assert settings.harness_mode is HarnessMode.FILTER
+
+    def test_env_var_policy(self) -> None:
+        with patch.dict("os.environ", {"MTS_HARNESS_MODE": "policy"}):
+            settings = load_settings()
+            assert settings.harness_mode is HarnessMode.POLICY
+
+    def test_env_var_none(self) -> None:
+        with patch.dict("os.environ", {"MTS_HARNESS_MODE": "none"}):
+            settings = load_settings()
+            assert settings.harness_mode is HarnessMode.NONE
+
+
+# ---------------------------------------------------------------------------
+# validate_harness_mode
+# ---------------------------------------------------------------------------
+
+
+class TestValidateHarnessMode:
+    def test_none_passes_through(self) -> None:
+        settings = AppSettings(harness_mode=HarnessMode.NONE)
+        result = validate_harness_mode(settings)
+        assert result.harness_mode is HarnessMode.NONE
+
+    def test_filter_without_validators_falls_back(self) -> None:
+        settings = AppSettings(
+            harness_mode=HarnessMode.FILTER,
+            harness_validators_enabled=False,
+        )
+        result = validate_harness_mode(settings)
+        assert result.harness_mode is HarnessMode.NONE
+
+    def test_filter_with_validators_ok(self) -> None:
+        settings = AppSettings(
+            harness_mode=HarnessMode.FILTER,
+            harness_validators_enabled=True,
+        )
+        result = validate_harness_mode(settings)
+        assert result.harness_mode is HarnessMode.FILTER
+
+    def test_verify_without_validators_falls_back(self) -> None:
+        settings = AppSettings(
+            harness_mode=HarnessMode.VERIFY,
+            harness_validators_enabled=False,
+        )
+        result = validate_harness_mode(settings)
+        assert result.harness_mode is HarnessMode.NONE
+
+    def test_verify_with_validators_ok(self) -> None:
+        settings = AppSettings(
+            harness_mode=HarnessMode.VERIFY,
+            harness_validators_enabled=True,
+        )
+        result = validate_harness_mode(settings)
+        assert result.harness_mode is HarnessMode.VERIFY
+
+    def test_policy_enables_code_strategies(self) -> None:
+        settings = AppSettings(
+            harness_mode=HarnessMode.POLICY,
+            code_strategies_enabled=False,
+        )
+        result = validate_harness_mode(settings)
+        assert result.harness_mode is HarnessMode.POLICY
+        assert result.code_strategies_enabled is True
+
+    def test_policy_with_code_strategies_already_on(self) -> None:
+        settings = AppSettings(
+            harness_mode=HarnessMode.POLICY,
+            code_strategies_enabled=True,
+        )
+        result = validate_harness_mode(settings)
+        assert result.harness_mode is HarnessMode.POLICY
+        assert result.code_strategies_enabled is True
+
+    def test_validate_does_not_mutate_original(self) -> None:
+        settings = AppSettings(
+            harness_mode=HarnessMode.FILTER,
+            harness_validators_enabled=False,
+        )
+        result = validate_harness_mode(settings)
+        assert settings.harness_mode is HarnessMode.FILTER  # original unchanged
+        assert result.harness_mode is HarnessMode.NONE  # new copy modified


### PR DESCRIPTION
## Summary
- Adds `HarnessMode` StrEnum with four modes: `none`, `filter`, `verify`, `policy`
- New `MTS_HARNESS_MODE` env var (default `none`) controls harness interaction with strategy execution
- `validate_harness_mode()` enforces dependency constraints:
  - `filter`/`verify` require `harness_validators_enabled=true` — falls back to `none` with warning if not set
  - `policy` implies `code_strategies_enabled=true` — auto-enables it with warning
- Foundation for P5 Action Filter Mode (MTS-84 through MTS-89)

## Test plan
- [x] 16 tests in `test_harness_mode.py` covering enum values, env var parsing, all validation paths
- [x] Full regression: 1777 passed, 26 skipped
- [x] Ruff lint clean
- [x] Mypy clean