### PR TITLE
feat: add MTS_HARNESS_INHERITANCE_ENABLED setting (MTS-90)

### DIFF
--- a/mts/src/mts/config/settings.py
+++ b/mts/src/mts/config/settings.py
@@ -135,6 +135,9 @@ class AppSettings(BaseModel):
     harness_timeout_seconds: float = Field(
         default=5.0, ge=0.5, le=60.0, description="Timeout for harness code execution",
     )
+    harness_inheritance_enabled: bool = Field(
+        default=True, description="Inherit harness files across runs (requires harness_validators_enabled)",
+    )
     # Probe matches (Phase 4)
     probe_matches: int = Field(default=0, ge=0, description="Probe matches before full tournament (0=disabled)")
     # Ecosystem convergence (Phase 4)
@@ -315,6 +318,9 @@ def load_settings() -> AppSettings:
         ),
         harness_timeout_seconds=float(
             _get("harness_timeout_seconds", "MTS_HARNESS_TIMEOUT_SECONDS", "5.0"),
+        ),
+        harness_inheritance_enabled=_get_bool(
+            "harness_inheritance_enabled", "MTS_HARNESS_INHERITANCE_ENABLED", "true",
         ),
         probe_matches=int(_get("probe_matches", "MTS_PROBE_MATCHES", "0")),
         ecosystem_convergence_enabled=_get_bool(

--- a/mts/tests/test_config_adaptive.py
+++ b/mts/tests/test_config_adaptive.py
@@ -32,6 +32,24 @@ class TestConfigAdaptiveSettings:
         assert settings.config_adaptive_enabled is True
 
 
+class TestHarnessInheritanceSetting:
+    def test_default_is_true(self) -> None:
+        settings = AppSettings()
+        assert settings.harness_inheritance_enabled is True
+
+    def test_env_var_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MTS_HARNESS_INHERITANCE_ENABLED", "false")
+        monkeypatch.setenv("MTS_AGENT_PROVIDER", "deterministic")
+        settings = load_settings()
+        assert settings.harness_inheritance_enabled is False
+
+    def test_env_var_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MTS_HARNESS_INHERITANCE_ENABLED", "true")
+        monkeypatch.setenv("MTS_AGENT_PROVIDER", "deterministic")
+        settings = load_settings()
+        assert settings.harness_inheritance_enabled is True
+
+
 # ---------------------------------------------------------------------------
 # TestTuningConfig
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `harness_inheritance_enabled` field to `AppSettings` (default `True`)
- Wire `MTS_HARNESS_INHERITANCE_ENABLED` env var in `load_settings()`
- Only effective when `harness_validators_enabled` is also True
- 3 tests: default value, env var false override, env var true

## Test plan
- [x] `uv run ruff check` — clean
- [x] `uv run mypy` — clean
- [x] `uv run pytest tests/test_config_adaptive.py -v` — 18 passed
- [x] `uv run pytest` full suite — 1764 passed, 26 skipped