### PR TITLE
feat(P4): add tree search settings (MTS-77)

### DIFF
--- a/mts/src/mts/config/settings.py
+++ b/mts/src/mts/config/settings.py
@@ -185,6 +185,13 @@ class AppSettings(BaseModel):
     rapid_gens: int = Field(
         default=0, ge=0, description="Auto-transition from rapid to linear after N gens (0=manual)",
     )
+    # Tree search (P4, activates when exploration_mode="tree")
+    tree_max_hypotheses: int = Field(
+        default=8, ge=1, description="Max concurrent strategy variants in tree search",
+    )
+    tree_sampling_temperature: float = Field(
+        default=1.0, gt=0.0, description="Thompson sampling temperature for tree search",
+    )
     # Session reports (AR-5)
     session_reports_enabled: bool = Field(
         default=True, description="Generate cross-session summary reports",
@@ -351,6 +358,10 @@ def load_settings() -> AppSettings:
         protocol_enabled=_get_bool("protocol_enabled", "MTS_PROTOCOL_ENABLED", "false"),
         exploration_mode=cast(Literal["linear", "rapid", "tree"], _get("exploration_mode", "MTS_EXPLORATION_MODE", "linear")),
         rapid_gens=int(_get("rapid_gens", "MTS_RAPID_GENS", "0")),
+        tree_max_hypotheses=int(_get("tree_max_hypotheses", "MTS_TREE_MAX_HYPOTHESES", "8")),
+        tree_sampling_temperature=float(
+            _get("tree_sampling_temperature", "MTS_TREE_SAMPLING_TEMPERATURE", "1.0"),
+        ),
         session_reports_enabled=_get_bool("session_reports_enabled", "MTS_SESSION_REPORTS_ENABLED", "true"),
         config_adaptive_enabled=_get_bool("config_adaptive_enabled", "MTS_CONFIG_ADAPTIVE_ENABLED", "false"),
     )

--- a/mts/tests/test_config_adaptive.py
+++ b/mts/tests/test_config_adaptive.py
@@ -33,6 +33,37 @@ class TestConfigAdaptiveSettings:
 
 
 # ---------------------------------------------------------------------------
+# TestTreeSearchSettings
+# ---------------------------------------------------------------------------
+
+
+class TestTreeSearchSettings:
+    def test_tree_max_hypotheses_defaults_to_8(self) -> None:
+        settings = AppSettings()
+        assert settings.tree_max_hypotheses == 8
+
+    def test_tree_sampling_temperature_defaults_to_1(self) -> None:
+        settings = AppSettings()
+        assert settings.tree_sampling_temperature == 1.0
+
+    def test_load_settings_reads_tree_search_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MTS_TREE_MAX_HYPOTHESES", "12")
+        monkeypatch.setenv("MTS_TREE_SAMPLING_TEMPERATURE", "0.5")
+        monkeypatch.setenv("MTS_AGENT_PROVIDER", "deterministic")
+        settings = load_settings()
+        assert settings.tree_max_hypotheses == 12
+        assert settings.tree_sampling_temperature == 0.5
+
+    def test_tree_max_hypotheses_minimum_1(self) -> None:
+        with pytest.raises(ValueError):
+            AppSettings(tree_max_hypotheses=0)
+
+    def test_tree_sampling_temperature_must_be_positive(self) -> None:
+        with pytest.raises(ValueError):
+            AppSettings(tree_sampling_temperature=0.0)
+
+
+# ---------------------------------------------------------------------------
 # TestTuningConfig
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `tree_max_hypotheses` (default 8, ge=1) and `tree_sampling_temperature` (default 1.0, gt=0.0) to AppSettings
- Wire `MTS_TREE_MAX_HYPOTHESES` and `MTS_TREE_SAMPLING_TEMPERATURE` env vars in `load_settings()`
- Tree search activates via existing `exploration_mode="tree"` (AR-4), no separate enable flag needed
- 5 unit tests for defaults, env overrides, and validation bounds

## Test plan
- [x] `pytest tests/test_config_adaptive.py::TestTreeSearchSettings -v` — 5 passed
- [x] ruff + mypy clean