### PR TITLE
feat(P4): create HypothesisTree with Thompson sampling (MTS-78)

### DIFF
--- a/mts/src/mts/loop/hypothesis_tree.py
+++ b/mts/src/mts/loop/hypothesis_tree.py
@@ -53,7 +53,8 @@ class HypothesisTree:
         self.nodes[node_id] = node
 
         if len(self.nodes) > self.max_hypotheses:
-            self.prune()
+            # Keep the newly-added node for at least one refinement cycle.
+            self.prune(protected_ids={node_id})
 
         return node
 
@@ -97,12 +98,22 @@ class HypothesisTree:
         node.elo = elo
         node.refinement_count += 1
 
-    def prune(self) -> list[HypothesisNode]:
-        """Remove lowest-Elo nodes to stay within max_hypotheses. Returns removed nodes."""
+    def prune(self, protected_ids: set[str] | None = None) -> list[HypothesisNode]:
+        """Remove lowest-Elo nodes to stay within max_hypotheses.
+
+        `protected_ids` can be used to keep specific nodes (for example a newly
+        added hypothesis) from immediate pruning.
+        """
         if len(self.nodes) <= self.max_hypotheses:
             return []
-        sorted_nodes = sorted(self.nodes.values(), key=lambda n: n.elo)
+
+        protected = protected_ids or set()
+        candidates = [n for n in self.nodes.values() if n.id not in protected]
         to_remove = len(self.nodes) - self.max_hypotheses
+        if len(candidates) < to_remove:
+            raise ValueError("Not enough non-protected nodes to prune")
+
+        sorted_nodes = sorted(candidates, key=lambda n: n.elo)
         removed = sorted_nodes[:to_remove]
         for node in removed:
             del self.nodes[node.id]

--- a/mts/tests/test_hypothesis_tree.py
+++ b/mts/tests/test_hypothesis_tree.py
@@ -39,6 +39,19 @@ class TestHypothesisTreeAdd:
         # Lowest Elo (nodes[0]) should be pruned
         assert nodes[0].id not in tree.nodes
 
+    def test_add_preserves_new_node_when_existing_elos_are_higher(self) -> None:
+        tree = HypothesisTree(max_hypotheses=3)
+        nodes = []
+        for i, elo in enumerate([1600.0, 1650.0, 1700.0]):
+            n = tree.add({"v": i})
+            tree.update(n.id, [0.8], elo=elo)
+            nodes.append(n)
+
+        new_node = tree.add({"v": 99})
+        assert tree.size() == 3
+        assert new_node.id in tree.nodes
+        assert nodes[0].id not in tree.nodes
+
 
 class TestHypothesisTreeSelect:
     def test_select_single_node(self) -> None:
@@ -131,6 +144,14 @@ class TestHypothesisTreePrune:
         removed = tree.prune()
         assert removed == []
         assert tree.size() == 2
+
+    def test_prune_raises_when_protected_ids_block_removal(self) -> None:
+        tree = HypothesisTree(max_hypotheses=2)
+        n1 = tree.add({"v": 1})
+        n2 = tree.add({"v": 2})
+        tree.max_hypotheses = 1
+        with pytest.raises(ValueError, match="Not enough non-protected nodes"):
+            tree.prune(protected_ids={n1.id, n2.id})
 
 
 class TestHypothesisTreeBest:


### PR DESCRIPTION
## Summary
- New `HypothesisTree` class in `loop/hypothesis_tree.py` for multi-hypothesis strategy search
- `HypothesisNode` dataclass: id, strategy, parent_id, scores, elo, generation, refinement_count
- `add()` — insert hypothesis with optional parent (tree structure), auto-prune past limit
- `select(rng)` — Thompson sampling via Beta distributions fitted to score history relative to median
- `update()` — accumulate match scores and Elo
- `prune()` — remove lowest-Elo nodes to respect max_hypotheses
- `best()` — return highest-Elo node
- `converged()` — detect when all hypotheses have similar Elo
- Temperature parameter scales sampling variance (higher = more exploration)
- No external dependencies (stdlib `random`, `math`, `uuid`)

## Test plan
- [x] `pytest tests/test_hypothesis_tree.py -v` — 20 passed
- [x] ruff + mypy clean