### PR TITLE
feat(P4): add competitor refinement prompt for tree search (MTS-79)

### DIFF
--- a/mts/src/mts/agents/competitor.py
+++ b/mts/src/mts/agents/competitor.py
@@ -32,3 +32,7 @@ class CompetitorRunner:
         """Re-run competitor with revision feedback appended."""
         combined = f"{original_prompt}\n\n--- REVISION REQUIRED ---\n{revision_prompt}"
         return self.run(combined, tool_context=tool_context)
+
+    def refine_strategy(self, refinement_prompt: str, tool_context: str = "") -> tuple[str, RoleExecution]:
+        """Refine an existing strategy given match feedback (tree search)."""
+        return self.run(refinement_prompt, tool_context=tool_context)

--- a/mts/src/mts/loop/refinement_prompt.py
+++ b/mts/src/mts/loop/refinement_prompt.py
@@ -1,0 +1,50 @@
+"""Refinement prompt for tree search mode (MTS-79)."""
+
+from __future__ import annotations
+
+
+def build_refinement_prompt(
+    scenario_rules: str,
+    strategy_interface: str,
+    evaluation_criteria: str,
+    parent_strategy: str,
+    match_feedback: str,
+    current_playbook: str = "",
+    score_trajectory: str = "",
+    operational_lessons: str = "",
+) -> str:
+    """Build a prompt for refining an existing strategy (tree search mode).
+
+    Unlike the initial competitor prompt, this asks the LLM to improve an
+    existing strategy based on match results rather than generating from scratch.
+    """
+    playbook_block = (
+        f"Current playbook:\n{current_playbook}\n\n"
+        if current_playbook
+        else ""
+    )
+    trajectory_block = (
+        f"Score trajectory:\n{score_trajectory}\n\n"
+        if score_trajectory
+        else ""
+    )
+    lessons_block = (
+        f"Operational lessons:\n{operational_lessons}\n\n"
+        if operational_lessons
+        else ""
+    )
+    return (
+        f"Scenario rules:\n{scenario_rules}\n\n"
+        f"Strategy interface:\n{strategy_interface}\n\n"
+        f"Evaluation criteria:\n{evaluation_criteria}\n\n"
+        f"{playbook_block}"
+        f"{trajectory_block}"
+        f"{lessons_block}"
+        "--- STRATEGY REFINEMENT ---\n\n"
+        "You are refining an existing strategy, not creating one from scratch.\n\n"
+        f"Current strategy to refine:\n<strategy>\n{parent_strategy}\n</strategy>\n\n"
+        f"Recent match results for this strategy:\n<match_feedback>\n{match_feedback}\n</match_feedback>\n\n"
+        "Produce an improved version that addresses the weaknesses shown in the results.\n"
+        "Keep what works, fix what doesn't.\n"
+        "Describe your reasoning for each change, then provide the refined strategy."
+    )

--- a/mts/tests/test_refinement_prompt.py
+++ b/mts/tests/test_refinement_prompt.py
@@ -1,0 +1,116 @@
+"""Tests for competitor refinement prompt (MTS-79)."""
+
+from __future__ import annotations
+
+import json
+
+from mts.loop.refinement_prompt import build_refinement_prompt
+
+
+def _build(**kwargs):  # type: ignore[no-untyped-def]
+    return build_refinement_prompt(**kwargs)
+
+
+class TestBuildRefinementPrompt:
+    def test_includes_parent_strategy(self) -> None:
+        strategy = json.dumps({"flag_x": 3, "flag_y": 4})
+        prompt = _build(
+            scenario_rules="Grid CTF rules",
+            strategy_interface="flag_x: int, flag_y: int",
+            evaluation_criteria="maximize score",
+            parent_strategy=strategy,
+            match_feedback="Lost 3/5 matches",
+        )
+        assert "<strategy>" in prompt
+        assert strategy in prompt
+
+    def test_includes_match_feedback(self) -> None:
+        prompt = _build(
+            scenario_rules="rules",
+            strategy_interface="interface",
+            evaluation_criteria="criteria",
+            parent_strategy="{}",
+            match_feedback="Score: 0.3, errors: illegal move at turn 5",
+        )
+        assert "<match_feedback>" in prompt
+        assert "illegal move at turn 5" in prompt
+
+    def test_includes_scenario_context(self) -> None:
+        prompt = _build(
+            scenario_rules="Grid CTF: capture the flag",
+            strategy_interface="flag_x: int",
+            evaluation_criteria="maximize wins",
+            parent_strategy="{}",
+            match_feedback="feedback",
+        )
+        assert "Grid CTF: capture the flag" in prompt
+        assert "flag_x: int" in prompt
+        assert "maximize wins" in prompt
+
+    def test_refinement_not_creation(self) -> None:
+        prompt = _build(
+            scenario_rules="rules",
+            strategy_interface="interface",
+            evaluation_criteria="criteria",
+            parent_strategy="{}",
+            match_feedback="feedback",
+        )
+        assert "STRATEGY REFINEMENT" in prompt
+        assert "not creating one from scratch" in prompt
+        assert "Keep what works" in prompt
+
+    def test_optional_playbook_included(self) -> None:
+        prompt = _build(
+            scenario_rules="rules",
+            strategy_interface="interface",
+            evaluation_criteria="criteria",
+            parent_strategy="{}",
+            match_feedback="feedback",
+            current_playbook="Use balanced approach",
+        )
+        assert "Use balanced approach" in prompt
+
+    def test_optional_playbook_omitted_when_empty(self) -> None:
+        prompt = _build(
+            scenario_rules="rules",
+            strategy_interface="interface",
+            evaluation_criteria="criteria",
+            parent_strategy="{}",
+            match_feedback="feedback",
+            current_playbook="",
+        )
+        assert "Current playbook:" not in prompt
+
+    def test_optional_trajectory_included(self) -> None:
+        prompt = _build(
+            scenario_rules="rules",
+            strategy_interface="interface",
+            evaluation_criteria="criteria",
+            parent_strategy="{}",
+            match_feedback="feedback",
+            score_trajectory="Gen1: 0.3, Gen2: 0.5",
+        )
+        assert "Gen1: 0.3, Gen2: 0.5" in prompt
+
+    def test_optional_lessons_included(self) -> None:
+        prompt = _build(
+            scenario_rules="rules",
+            strategy_interface="interface",
+            evaluation_criteria="criteria",
+            parent_strategy="{}",
+            match_feedback="feedback",
+            operational_lessons="- High aggression works in early game",
+        )
+        assert "High aggression works in early game" in prompt
+
+    def test_works_with_code_strategy(self) -> None:
+        code_strategy = "if state['turn'] < 5:\n    result = {'flag_x': 3}\nelse:\n    result = {'flag_x': 7}"
+        prompt = _build(
+            scenario_rules="rules",
+            strategy_interface="interface",
+            evaluation_criteria="criteria",
+            parent_strategy=code_strategy,
+            match_feedback="Score: 0.6",
+        )
+        assert "if state['turn'] < 5:" in prompt
+        assert "result = {'flag_x': 3}" in prompt


### PR DESCRIPTION
## Summary
- New `build_refinement_prompt()` in `loop/refinement_prompt.py` — constructs prompts for refining existing strategies based on match feedback
- Includes parent strategy in `<strategy>` tags and match feedback in `<match_feedback>` tags
- Supports optional playbook, trajectory, and operational lessons context
- Works with both JSON and code strategies
- Adds `refine_strategy()` method to `CompetitorRunner`
- Placed in `loop/` package to avoid the existing `prompts` ↔ `agents` circular import

## Test plan
- [x] `pytest tests/test_refinement_prompt.py -v` — 9 passed
- [x] ruff + mypy clean