### PR TITLE
fix: detectGeneratedDimensions false positive on underscore-compound terms (MTS-57)

### DIFF
--- a/mts/src/mts/execution/judge.py
+++ b/mts/src/mts/execution/judge.py
@@ -50,7 +50,12 @@ def _detect_generated_dimensions(dimension_keys: list[str], rubric: str) -> bool
     rubric_words.discard("")
 
     for key in dimension_keys:
-        fragments = [f for f in key.lower().split("_") if f]
+        key_lower = key.lower()
+        # Exact match — the key itself appears in the rubric as-is
+        if key_lower in rubric_words:
+            continue
+        # Fragment match — any underscore-delimited part appears
+        fragments = [f for f in key_lower.split("_") if f]
         if not any(frag in rubric_words for frag in fragments):
             return True
     return False

--- a/mts/tests/test_judge.py
+++ b/mts/tests/test_judge.py
@@ -150,6 +150,18 @@ class TestDetectGeneratedDimensions:
             "Check code quality carefully",
         ) is False
 
+    def test_underscore_compound_rubric_term_exact_match(self) -> None:
+        assert _detect_generated_dimensions(
+            ["technical_accuracy", "clarity", "completeness"],
+            "Evaluate on three dimensions: technical_accuracy, clarity, completeness",
+        ) is False
+
+    def test_underscore_compound_rubric_term_inline(self) -> None:
+        assert _detect_generated_dimensions(
+            ["code_quality"],
+            "Score the code_quality of the submission",
+        ) is False
+
 
 class TestDimensionsWereGenerated:
     def test_generated_true_when_dims_not_in_rubric(self) -> None:

--- a/ts/src/judge/index.ts
+++ b/ts/src/judge/index.ts
@@ -39,7 +39,11 @@ export function detectGeneratedDimensions(
   const rubricWords = new Set(rubricLower.split(/\W+/).filter(Boolean));
 
   for (const key of dimensionKeys) {
-    const fragments = key.toLowerCase().split("_").filter(Boolean);
+    const keyLower = key.toLowerCase();
+    // Exact match — the key itself appears in the rubric as-is
+    if (rubricWords.has(keyLower)) continue;
+    // Fragment match — any underscore-delimited part appears
+    const fragments = keyLower.split("_").filter(Boolean);
     const anyMatch = fragments.some((frag) => rubricWords.has(frag));
     if (!anyMatch) return true;
   }

--- a/ts/tests/judge.test.ts
+++ b/ts/tests/judge.test.ts
@@ -32,6 +32,24 @@ describe("detectGeneratedDimensions", () => {
       detectGeneratedDimensions(["Code_Quality"], "Check code quality carefully"),
     ).toBe(false);
   });
+
+  it("returns false when key exactly matches underscore-compound rubric term", () => {
+    expect(
+      detectGeneratedDimensions(
+        ["technical_accuracy", "clarity", "completeness"],
+        "Evaluate on three dimensions: technical_accuracy, clarity, completeness",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when rubric uses underscored terms inline", () => {
+    expect(
+      detectGeneratedDimensions(
+        ["code_quality"],
+        "Score the code_quality of the submission",
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("LLMJudge", () => {


### PR DESCRIPTION
## Summary
- Fixes `detectGeneratedDimensions` false positive when dimension keys exactly match underscore-compound rubric terms (e.g. `technical_accuracy`)
- Root cause: `\W+` split keeps underscored terms as single tokens in rubric word set, so fragment-only matching misses them
- Adds exact-match check before fragment analysis in both TypeScript and Python implementations

## Changes
- `ts/src/judge/index.ts` — add `rubricWords.has(keyLower)` check before fragment split
- `mts/src/mts/execution/judge.py` — same fix for `_detect_generated_dimensions()`
- `ts/tests/judge.test.ts` — 2 new tests for underscore-compound rubric terms
- `mts/tests/test_judge.py` — 2 new tests for underscore-compound rubric terms

## Test plan
- [x] TS: `npx vitest run tests/judge.test.ts` — 13 passed
- [x] Python: `uv run pytest tests/test_judge.py` — 26 passed
- [x] `npx tsc --noEmit` clean
- [x] `uv run ruff check` + `uv run mypy` clean

Closes MTS-57