### PR TITLE
feat: SampleStateGenerator, HarnessTester, and HarnessSynthesizer (MTS-146, MTS-148, MTS-147)

### DIFF
--- a/mts/src/mts/execution/harness_synthesizer.py
+++ b/mts/src/mts/execution/harness_synthesizer.py
@@ -91,7 +91,7 @@ class HarnessSynthesizer:
 
         failure_log: list[str] = []
         best_source = ""
-        best_accuracy = 0.0
+        best_accuracy = -1.0
         current_source = ""
 
         for iteration in range(1, self._max_iterations + 1):
@@ -107,7 +107,12 @@ class HarnessSynthesizer:
                 current_source = extracted
 
             # ── Test ──────────────────────────────────────────────────────
-            report = self._tester.test_harness(current_source, sample_states)
+            report = self._tester.test_harness(
+                current_source,
+                sample_states,
+                scenario=self._scenario,
+                required_functions=target_functions,
+            )
 
             LOGGER.info(
                 "synthesis iteration %d: accuracy=%.2f (%d/%d passed)",
@@ -194,12 +199,14 @@ class HarnessSynthesizer:
             "test failures. Return ONLY valid Python code with no imports. "
             "Only safe builtins are available."
         )
+        func_specs = "\n".join(f"- {fn}" for fn in target_functions)
         user_prompt = (
             f"The following harness code for '{self._scenario.name}' has failures:\n\n"
             f"```python\n{current_source}\n```\n\n"
             f"Test failures:\n{failure_context}\n\n"
             f"Scenario rules:\n{self._scenario.describe_rules()}\n\n"
             f"Strategy interface:\n{self._scenario.describe_strategy_interface()}\n\n"
+            f"Required functions:\n{func_specs}\n\n"
             "Fix the code and return ONLY the corrected Python code."
         )
         result = self._provider.complete(

--- a/mts/src/mts/execution/harness_tester.py
+++ b/mts/src/mts/execution/harness_tester.py
@@ -7,6 +7,7 @@ collecting structured failure reports suitable for LLM-driven refinement.
 from __future__ import annotations
 
 import ast
+import json
 import logging
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -70,7 +71,14 @@ class HarnessTester:
         self._timeout_per_test = timeout_per_test
         self._max_failures_reported = max_failures_reported
 
-    def test_harness(self, harness_source: str, sample_states: list[SampleState]) -> HarnessTestReport:
+    def test_harness(
+        self,
+        harness_source: str,
+        sample_states: list[SampleState],
+        *,
+        scenario: Any | None = None,
+        required_functions: list[str] | None = None,
+    ) -> HarnessTestReport:
         """Run *harness_source* against every state and return a structured report."""
         t0 = time.monotonic()
 
@@ -133,6 +141,28 @@ class HarnessTester:
         fn_enumerate = namespace.get("enumerate_legal_actions")
         fn_is_legal = namespace.get("is_legal_action")
         fn_validate = namespace.get("validate_strategy")
+        callables: dict[str, Any] = {
+            "enumerate_legal_actions": fn_enumerate if callable(fn_enumerate) else None,
+            "is_legal_action": fn_is_legal if callable(fn_is_legal) else None,
+            "validate_strategy": fn_validate if callable(fn_validate) else None,
+        }
+
+        missing = [name for name in (required_functions or []) if callables.get(name) is None]
+        if missing:
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            failures = self._make_blanket_failures(
+                sample_states,
+                "missing_function",
+                f"missing required harness function(s): {', '.join(missing)}",
+            )
+            return HarnessTestReport(
+                total_tests=len(sample_states),
+                passed=0,
+                failed=len(sample_states),
+                accuracy=0.0,
+                failures=failures,
+                execution_time_ms=elapsed_ms,
+            )
 
         # ── Run tests in parallel ────────────────────────────────────────
         all_failures: list[HarnessTestFailure] = []
@@ -143,9 +173,10 @@ class HarnessTester:
             pool.submit(
                 _test_single_state,
                 sample,
-                fn_enumerate=fn_enumerate if callable(fn_enumerate) else None,
-                fn_is_legal=fn_is_legal if callable(fn_is_legal) else None,
-                fn_validate=fn_validate if callable(fn_validate) else None,
+                fn_enumerate=callables["enumerate_legal_actions"],
+                fn_is_legal=callables["is_legal_action"],
+                fn_validate=callables["validate_strategy"],
+                scenario=scenario,
             ): sample
             for sample in sample_states
         }
@@ -283,6 +314,7 @@ def _test_single_state(
     fn_enumerate: Any | None,
     fn_is_legal: Any | None,
     fn_validate: Any | None,
+    scenario: Any | None,
 ) -> HarnessTestFailure | None:
     """Test all available harness functions against a single sample state.
 
@@ -355,7 +387,38 @@ def _test_single_state(
     # Test validate_strategy doesn't crash (no ground truth needed)
     if fn_validate is not None:
         try:
-            fn_validate(state, None)
+            strategy = _example_strategy_from_sample(sample, scenario)
+            if strategy is None:
+                if scenario is None and sample.expected_legal_actions is None:
+                    return None
+                return HarnessTestFailure(
+                    state=state,
+                    function_name="validate_strategy",
+                    expected="a valid example strategy",
+                    actual=None,
+                    error="could not derive an example strategy from sample state",
+                    state_description=sample.description,
+                )
+            result = fn_validate(strategy, scenario)
+            if not _validation_result_is_valid(result):
+                return HarnessTestFailure(
+                    state=state,
+                    function_name="validate_strategy",
+                    expected="tuple[bool, list[str]]",
+                    actual=result,
+                    error="validate_strategy returned an invalid result shape",
+                    state_description=sample.description,
+                )
+            passed, errors = result
+            if not passed:
+                return HarnessTestFailure(
+                    state=state,
+                    function_name="validate_strategy",
+                    expected=True,
+                    actual=result,
+                    error=f"rejected derived valid strategy: {errors}",
+                    state_description=sample.description,
+                )
         except Exception as exc:
             return HarnessTestFailure(
                 state=state,
@@ -375,6 +438,70 @@ def _actions_match(expected: list[dict[str, Any]], actual: Any) -> bool:
         return False
     if len(expected) != len(actual):
         return False
-    expected_keys = sorted(str(a.get("action", a)) for a in expected)
-    actual_keys = sorted(str(a.get("action", a)) for a in actual)
+    expected_keys = sorted(json.dumps(_normalize_action(a), sort_keys=True) for a in expected)
+    actual_keys = sorted(json.dumps(_normalize_action(a), sort_keys=True) for a in actual)
     return expected_keys == actual_keys
+
+
+def _normalize_action(value: Any) -> Any:
+    """Normalize nested action descriptors for stable equality checks."""
+    if isinstance(value, dict):
+        return {key: _normalize_action(val) for key, val in sorted(value.items())}
+    if isinstance(value, list):
+        return [_normalize_action(item) for item in value]
+    return value
+
+
+def _validation_result_is_valid(result: Any) -> bool:
+    """Check the validate_strategy return contract."""
+    return (
+        isinstance(result, tuple)
+        and len(result) == 2
+        and isinstance(result[0], bool)
+        and isinstance(result[1], list)
+        and all(isinstance(item, str) for item in result[1])
+    )
+
+
+def _example_strategy_from_sample(sample: SampleState, scenario: Any | None) -> dict[str, Any] | None:
+    """Derive a valid example strategy from the sample's legal-action metadata."""
+    legal_actions = sample.expected_legal_actions
+    if legal_actions is None and scenario is not None:
+        enumerate_fn = getattr(scenario, "enumerate_legal_actions", None)
+        if callable(enumerate_fn):
+            enumerated = enumerate_fn(sample.state)
+            if isinstance(enumerated, list):
+                legal_actions = enumerated
+    if not legal_actions:
+        return None
+
+    if all(isinstance(action, dict) and action.get("type") == "continuous" and "range" in action for action in legal_actions):
+        low_strategy: dict[str, Any] = {}
+        midpoint_strategy: dict[str, Any] = {}
+        for action in legal_actions:
+            low, high = action["range"]
+            low_strategy[str(action["action"])] = round(float(low), 4)
+            midpoint = (float(low) + float(high)) / 2.0
+            midpoint_strategy[str(action["action"])] = round(midpoint, 4)
+        for candidate in (midpoint_strategy, low_strategy):
+            if _strategy_is_valid(sample, scenario, candidate):
+                return candidate
+        return None
+
+    first_action = legal_actions[0]
+    if isinstance(first_action, dict):
+        candidate = dict(first_action)
+        if _strategy_is_valid(sample, scenario, candidate):
+            return candidate
+    return None
+
+
+def _strategy_is_valid(sample: SampleState, scenario: Any | None, strategy: dict[str, Any]) -> bool:
+    """Check whether the example strategy satisfies the scenario contract when available."""
+    if scenario is None:
+        return True
+    validate_fn = getattr(scenario, "validate_actions", None)
+    if not callable(validate_fn):
+        return True
+    valid, _ = validate_fn(sample.state, "harness_tester", strategy)
+    return bool(valid)

--- a/mts/src/mts/execution/sample_states.py
+++ b/mts/src/mts/execution/sample_states.py
@@ -141,6 +141,9 @@ class SampleStateGenerator:
                 break
 
             actions = self._random_actions(state, rng)
+            if actions is None:
+                LOGGER.debug("no valid actions generated during simulation for seed %d", seed)
+                break
             try:
                 state = self._scenario.step(state, actions)
             except Exception:
@@ -151,20 +154,47 @@ class SampleStateGenerator:
 
         return states
 
-    def _random_actions(self, state: dict[str, Any], rng: random.Random) -> dict[str, Any]:
+    def _random_actions(self, state: dict[str, Any], rng: random.Random) -> dict[str, Any] | None:
         """Generate random valid actions for the current state."""
         legal = self._scenario.enumerate_legal_actions(state)
         if legal is not None and len(legal) > 0:
             # Check if continuous parameter space
             if all(a.get("type") == "continuous" and "range" in a for a in legal):
-                actions: dict[str, Any] = {}
+                baseline: dict[str, Any] = {}
                 for a in legal:
-                    low, high = a["range"]
-                    actions[str(a["action"])] = round(rng.uniform(float(low), float(high)), 4)
-                return actions
+                    low, _ = a["range"]
+                    baseline[str(a["action"])] = round(float(low), 4)
+                if self._is_valid_action(state, baseline):
+                    return baseline
+
+                for _ in range(32):
+                    actions: dict[str, Any] = {}
+                    for a in legal:
+                        low, high = a["range"]
+                        actions[str(a["action"])] = round(rng.uniform(float(low), float(high)), 4)
+                    if self._is_valid_action(state, actions):
+                        return actions
+                return None
             # Discrete: pick one
-            choice = rng.choice(legal)
-            return dict(choice)
+            choices = list(legal)
+            rng.shuffle(choices)
+            for choice in choices:
+                candidate = dict(choice)
+                if self._is_valid_action(state, candidate):
+                    return candidate
+            return None
 
         # Fallback: try a simple strategy with random values
-        return {"value": round(rng.random(), 4)}
+        candidate = {"value": round(rng.random(), 4)}
+        if self._is_valid_action(state, candidate):
+            return candidate
+        return None
+
+    def _is_valid_action(self, state: dict[str, Any], actions: dict[str, Any]) -> bool:
+        """Return whether the scenario accepts the candidate action mapping."""
+        try:
+            valid, _ = self._scenario.validate_actions(state, "generator", actions)
+        except Exception:
+            LOGGER.debug("validate_actions failed during sampling", exc_info=True)
+            return False
+        return valid

--- a/mts/tests/test_harness_synthesizer.py
+++ b/mts/tests/test_harness_synthesizer.py
@@ -300,6 +300,19 @@ class TestHarnessSynthesizerTargetFunctions:
         result = synth.synthesize(states)
         assert result.converged
 
+    def test_default_target_functions_reject_missing_callables(self) -> None:
+        harness_validate_only = textwrap.dedent("""\
+            def validate_strategy(strategy, scenario):
+                return True, []
+        """)
+        provider = MockProvider([harness_validate_only])
+        scenario = FakeScenario()
+        synth = HarnessSynthesizer(scenario, provider, max_iterations=1)
+        states = _make_states()
+        result = synth.synthesize(states)
+        assert not result.converged
+        assert result.accuracy == 0.0
+
     def test_custom_target_functions(self) -> None:
         """Can request just validate_strategy."""
         harness_validate_only = textwrap.dedent("""\

--- a/mts/tests/test_harness_tester.py
+++ b/mts/tests/test_harness_tester.py
@@ -70,6 +70,20 @@ BAD_HARNESS_IMPORT = textwrap.dedent("""\
         return True, []
 """)
 
+BAD_HARNESS_WRONG_METADATA = textwrap.dedent("""\
+    def validate_strategy(strategy, scenario):
+        return True, []
+
+    def enumerate_legal_actions(state):
+        return [
+            {"action": "up", "range": [9.0, 9.0]},
+            {"action": "down", "range": [9.0, 9.0]},
+        ]
+
+    def is_legal_action(state, action):
+        return action.get("action") in ("up", "down")
+""")
+
 
 # ── HarnessTestFailure dataclass ──────────────────────────────────────────────
 
@@ -175,6 +189,13 @@ class TestHarnessTesterBadHarness:
         assert report.failed == report.total_tests
         assert report.accuracy == 0.0
 
+    def test_action_metadata_mismatch_detected(self) -> None:
+        tester = HarnessTester()
+        states = _make_states(3)
+        report = tester.test_harness(BAD_HARNESS_WRONG_METADATA, states)
+        assert report.failed > 0
+        assert report.accuracy < 1.0
+
 
 # ── Max failures limit ────────────────────────────────────────────────────────
 
@@ -269,13 +290,33 @@ class TestHarnessTesterEdgeCases:
         assert report.passed == 1
 
     def test_harness_missing_function(self) -> None:
-        """Harness that lacks expected functions should report failures."""
+        """Missing required functions should report failures when requested."""
         harness = textwrap.dedent("""\
             def validate_strategy(strategy, scenario):
                 return True, []
         """)
         tester = HarnessTester()
         states = _make_states(3)
-        report = tester.test_harness(harness, states)
-        # Should still work — just can't test enumerate_legal_actions / is_legal_action
-        assert report.total_tests == 3
+        report = tester.test_harness(
+            harness,
+            states,
+            required_functions=["validate_strategy", "enumerate_legal_actions", "is_legal_action"],
+        )
+        assert report.failed == report.total_tests
+        assert report.accuracy == 0.0
+
+    def test_validate_strategy_receives_real_contract(self) -> None:
+        harness = textwrap.dedent("""\
+            def validate_strategy(strategy, scenario):
+                return strategy.get("action") == "up" and scenario is not None, []
+
+            def enumerate_legal_actions(state):
+                return [{"action": "up"}, {"action": "down"}]
+
+            def is_legal_action(state, action):
+                return action.get("action") in ("up", "down")
+        """)
+        tester = HarnessTester()
+        states = _make_states(1)
+        report = tester.test_harness(harness, states, scenario=object())
+        assert report.failed == 0

--- a/mts/tests/test_sample_states.py
+++ b/mts/tests/test_sample_states.py
@@ -1,6 +1,7 @@
 """Tests for SampleStateGenerator — diverse game state generation for harness testing."""
 from __future__ import annotations
 
+import random
 from collections.abc import Mapping
 from typing import Any
 
@@ -211,3 +212,17 @@ class TestSampleStateGeneratorRealScenarios:
         states = gen.generate_with_ground_truth()
         has_actions = [s for s in states if s.expected_legal_actions is not None]
         assert len(has_actions) > 0
+
+    def test_grid_ctf_random_actions_respect_constraints(self) -> None:
+        from mts.scenarios.grid_ctf import GridCtfScenario
+
+        scenario = GridCtfScenario()
+        gen = SampleStateGenerator(scenario, n_states=1)
+        rng = random.Random(7)
+        state = scenario.initial_state(seed=7)
+
+        for _ in range(25):
+            actions = gen._random_actions(state, rng)
+            assert actions is not None
+            valid, _ = scenario.validate_actions(state, "generator", actions)
+            assert valid


### PR DESCRIPTION
## Summary
- **MTS-146**: `SampleStateGenerator` — diverse game state generation via random self-play, early/mid/late phase classification, ground truth legal actions when available
- **MTS-148**: `HarnessTester` — parallel harness validation with ThreadPoolExecutor (10 workers), per-test timeout, max 5 diverse failure samples, AST safety reuse
- **MTS-147**: `HarnessSynthesizer` — iterative LLM refinement loop (generate → test → collect failures → refine), Haiku by default, max 30 iterations, writes to harness directory

## Implementation
- `execution/sample_states.py` — `SampleStateGenerator` + `SampleState`, caches generated states
- `execution/harness_tester.py` — `HarnessTester` + `HarnessTestFailure` + `HarnessTestReport`
- `execution/harness_synthesizer.py` — `HarnessSynthesizer` + `SynthesisResult`

## Test plan
- [x] 18 tests for SampleStateGenerator (mock + real grid_ctf/othello scenarios)
- [x] 20 tests for HarnessTester (good/bad harness, parallel, timeout, AST safety)
- [x] 14 tests for HarnessSynthesizer (mock LLM provider, convergence, output writing)
- [x] ruff clean, mypy clean (203 files), full suite passes

Closes MTS-146, MTS-148, MTS-147