### PR TITLE
feat(AC-174): add fixed time budgets for generation pipeline

### DIFF
--- a/autocontext/migrations/009_generation_timing.sql
+++ b/autocontext/migrations/009_generation_timing.sql
@@ -1,0 +1,2 @@
+-- AC-174: Track per-generation wall-clock duration.
+ALTER TABLE generations ADD COLUMN duration_seconds REAL DEFAULT NULL;

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -43,6 +43,11 @@ class AppSettings(BaseModel):
     backpressure_plateau_window: int = Field(default=3, ge=1)
     backpressure_plateau_relaxation: float = Field(default=0.5, ge=0.0, le=1.0)
     default_generations: int = Field(default=1, ge=1)
+    generation_time_budget_seconds: int = Field(
+        default=0,
+        ge=0,
+        description="Soft stage-boundary time budget per generation in seconds (0 = unlimited)",
+    )
     seed_base: int = Field(default=1000)
     max_retries: int = Field(default=2, ge=0)
     retry_backoff_seconds: float = Field(default=0.25, ge=0)

--- a/autocontext/src/autocontext/loop/generation_pipeline.py
+++ b/autocontext/src/autocontext/loop/generation_pipeline.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -13,6 +14,7 @@ from autocontext.loop.stage_staged_validation import stage_staged_validation
 from autocontext.loop.stage_tree_search import stage_tree_search
 from autocontext.loop.stage_types import GenerationContext
 from autocontext.loop.stages import (
+    _build_empty_tournament,
     stage_agent_generation,
     stage_curator_gate,
     stage_knowledge_setup,
@@ -36,6 +38,43 @@ if TYPE_CHECKING:
     from autocontext.storage import ArtifactStore, SQLiteStore
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _time_remaining(ctx: GenerationContext) -> float | None:
+    """Return seconds remaining in the time budget, or None if unlimited."""
+    budget = ctx.settings.generation_time_budget_seconds
+    if budget <= 0:
+        return None
+    elapsed = time.monotonic() - ctx.generation_start_time
+    return max(0.0, budget - elapsed)
+
+
+def _over_budget(ctx: GenerationContext) -> bool:
+    """True if the generation has exceeded its time budget."""
+    remaining = _time_remaining(ctx)
+    return remaining is not None and remaining <= 0
+
+
+def _rollback_for_budget(ctx: GenerationContext, events: EventStreamEmitter) -> GenerationContext:
+    """Stop the generation before tournament work once the budget is exhausted."""
+    ctx.tournament = _build_empty_tournament(ctx)
+    ctx.gate_decision = "rollback"
+    ctx.gate_delta = 0.0
+    ctx.score_history.append(0.0)
+    ctx.gate_decision_history.append("rollback")
+    events.emit("generation_budget_exhausted", {
+        "run_id": ctx.run_id,
+        "generation": ctx.generation,
+        "budget_seconds": ctx.settings.generation_time_budget_seconds,
+    })
+    events.emit("gate_decided", {
+        "run_id": ctx.run_id,
+        "generation": ctx.generation,
+        "decision": "rollback",
+        "delta": 0.0,
+        "tier": "budget",
+    })
+    return ctx
 
 
 class GenerationPipeline:
@@ -72,6 +111,7 @@ class GenerationPipeline:
 
     def run_generation(self, ctx: GenerationContext) -> GenerationContext:
         """Execute all stages for a single generation."""
+        ctx.generation_start_time = time.monotonic()
 
         def _on_role_event(role: str, status: str) -> None:
             self._events.emit("role_event", {
@@ -156,62 +196,69 @@ class GenerationPipeline:
                     self._controller.respond_chat(role, response)
 
             # Stage 2.3: Staged validation (progressive checks before tournament)
-            ctx = stage_staged_validation(
-                ctx,
-                events=self._events,
-                sqlite=self._sqlite,
-            )
+            if not _over_budget(ctx):
+                ctx = stage_staged_validation(
+                    ctx,
+                    events=self._events,
+                    sqlite=self._sqlite,
+                )
 
             # Stage 2.4: Pre-validation (optional — dry-run self-play before tournament)
-            harness_loader = None
-            if ctx.settings.harness_validators_enabled:
-                from autocontext.execution.harness_loader import HarnessLoader
+            if not _over_budget(ctx):
+                harness_loader = None
+                if ctx.settings.harness_validators_enabled:
+                    from autocontext.execution.harness_loader import HarnessLoader
 
-                h_dir = self._artifacts.harness_dir(ctx.scenario_name)
-                if h_dir.exists():
-                    harness_loader = HarnessLoader(h_dir, timeout_seconds=ctx.settings.harness_timeout_seconds)
-                    harness_loader.load()
+                    h_dir = self._artifacts.harness_dir(ctx.scenario_name)
+                    if h_dir.exists():
+                        harness_loader = HarnessLoader(h_dir, timeout_seconds=ctx.settings.harness_timeout_seconds)
+                        harness_loader.load()
 
-            ctx = stage_prevalidation(
-                ctx,
-                events=self._events,
-                agents=self._orchestrator,
-                harness_loader=harness_loader,
-                artifacts=self._artifacts,
-            )
+                ctx = stage_prevalidation(
+                    ctx,
+                    events=self._events,
+                    agents=self._orchestrator,
+                    harness_loader=harness_loader,
+                    artifacts=self._artifacts,
+                )
 
             # Stage 2.5: Probe (optional — refine strategy from observation)
-            ctx = stage_probe(
-                ctx,
-                agents=self._orchestrator,
-                events=self._events,
-                supervisor=self._supervisor,
-            )
+            if not _over_budget(ctx):
+                ctx = stage_probe(
+                    ctx,
+                    agents=self._orchestrator,
+                    events=self._events,
+                    supervisor=self._supervisor,
+                )
 
             # Stage 2.6: Policy refinement (optional — refine code strategies via zero-LLM evaluation)
-            refinement_client, refinement_model = self._orchestrator.resolve_role_execution(
-                "competitor",
-                generation=ctx.generation,
-                scenario_name=ctx.scenario_name,
-            )
-            ctx = stage_policy_refinement(
-                ctx,
-                client=refinement_client,
-                model=refinement_model,
-                events=self._events,
-                sqlite=self._sqlite,
-            )
+            if not _over_budget(ctx):
+                refinement_client, refinement_model = self._orchestrator.resolve_role_execution(
+                    "competitor",
+                    generation=ctx.generation,
+                    scenario_name=ctx.scenario_name,
+                )
+                ctx = stage_policy_refinement(
+                    ctx,
+                    client=refinement_client,
+                    model=refinement_model,
+                    events=self._events,
+                    sqlite=self._sqlite,
+                )
 
             # Stage 3: Tournament + gate
-            ctx = stage_tournament(
-                ctx,
-                supervisor=self._supervisor,
-                gate=self._gate,
-                events=self._events,
-                sqlite=self._sqlite,
-                artifacts=self._artifacts,
-                agents=self._orchestrator,
-            )
+            if _over_budget(ctx):
+                ctx = _rollback_for_budget(ctx, self._events)
+            else:
+                ctx = stage_tournament(
+                    ctx,
+                    supervisor=self._supervisor,
+                    gate=self._gate,
+                    events=self._events,
+                    sqlite=self._sqlite,
+                    artifacts=self._artifacts,
+                    agents=self._orchestrator,
+                )
 
         # Stage 3b: Stagnation check
         ctx = stage_stagnation_check(
@@ -255,8 +302,8 @@ class GenerationPipeline:
             curator=self._curator,
         )
 
-        # Stage 6: Knowledge coherence verification (optional)
-        if ctx.settings.coherence_check_enabled:
+        # Stage 6: Knowledge coherence verification (optional, skipped under time pressure)
+        if ctx.settings.coherence_check_enabled and not _over_budget(ctx):
             coherence = check_coherence(
                 scenario_name=ctx.scenario_name,
                 knowledge_root=self._artifacts.knowledge_root,
@@ -282,4 +329,18 @@ class GenerationPipeline:
             except Exception:
                 LOGGER.debug("meta_optimizer.record_generation failed", exc_info=True)
 
+        # Record generation timing (AC-174)
+        ctx.generation_elapsed_seconds = time.monotonic() - ctx.generation_start_time
+        self._sqlite.update_generation_duration(
+            ctx.run_id,
+            ctx.generation,
+            ctx.generation_elapsed_seconds,
+        )
+        self._events.emit("generation_timing", {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "elapsed_seconds": round(ctx.generation_elapsed_seconds, 2),
+            "budget_seconds": ctx.settings.generation_time_budget_seconds,
+            "over_budget": _over_budget(ctx),
+        })
         return ctx

--- a/autocontext/src/autocontext/loop/stage_types.py
+++ b/autocontext/src/autocontext/loop/stage_types.py
@@ -59,6 +59,10 @@ class GenerationContext:
     # Policy refinement result (AC-156)
     policy_refinement_result: PolicyRefinementResult | None = None
 
+    # AC-174: generation timing
+    generation_start_time: float = 0.0
+    generation_elapsed_seconds: float = 0.0
+
 
 @dataclass(slots=True)
 class StageResult:

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -72,14 +72,16 @@ class SQLiteStore:
         losses: int,
         gate_decision: str,
         status: str,
+        duration_seconds: float | None = None,
     ) -> None:
         with self.connect() as conn:
             conn.execute(
                 """
                 INSERT INTO generations(
-                    run_id, generation_index, mean_score, best_score, elo, wins, losses, gate_decision, status
+                    run_id, generation_index, mean_score, best_score, elo, wins, losses,
+                    gate_decision, status, duration_seconds
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(run_id, generation_index) DO UPDATE SET
                     mean_score = excluded.mean_score,
                     best_score = excluded.best_score,
@@ -88,9 +90,37 @@ class SQLiteStore:
                     losses = excluded.losses,
                     gate_decision = excluded.gate_decision,
                     status = excluded.status,
+                    duration_seconds = excluded.duration_seconds,
                     updated_at = datetime('now')
                 """,
-                (run_id, generation_index, mean_score, best_score, elo, wins, losses, gate_decision, status),
+                (
+                    run_id,
+                    generation_index,
+                    mean_score,
+                    best_score,
+                    elo,
+                    wins,
+                    losses,
+                    gate_decision,
+                    status,
+                    duration_seconds,
+                ),
+            )
+
+    def update_generation_duration(
+        self,
+        run_id: str,
+        generation_index: int,
+        duration_seconds: float,
+    ) -> None:
+        with self.connect() as conn:
+            conn.execute(
+                """
+                UPDATE generations
+                SET duration_seconds = ?, updated_at = datetime('now')
+                WHERE run_id = ? AND generation_index = ?
+                """,
+                (duration_seconds, run_id, generation_index),
             )
 
     def insert_match(

--- a/autocontext/tests/test_probe_pipeline.py
+++ b/autocontext/tests/test_probe_pipeline.py
@@ -6,10 +6,20 @@ from unittest.mock import MagicMock, patch
 from autocontext.loop.generation_pipeline import GenerationPipeline
 
 
-def test_pipeline_calls_probe_when_enabled() -> None:
-    """Pipeline calls stage_probe between agent generation and tournament."""
-    pipeline = GenerationPipeline(
-        orchestrator=MagicMock(),
+def _configure_pipeline_settings(mock_ctx: MagicMock, *, probe_matches: int) -> None:
+    mock_ctx.settings.probe_matches = probe_matches
+    mock_ctx.settings.coherence_check_enabled = False
+    mock_ctx.settings.generation_time_budget_seconds = 0
+    mock_ctx.settings.harness_validators_enabled = False
+    mock_ctx.settings.policy_refinement_enabled = False
+    mock_ctx.settings.exploration_mode = "linear"
+
+
+def _make_pipeline() -> GenerationPipeline:
+    orchestrator = MagicMock()
+    orchestrator.resolve_role_execution.return_value = (MagicMock(), "")
+    return GenerationPipeline(
+        orchestrator=orchestrator,
         supervisor=MagicMock(),
         gate=MagicMock(),
         artifacts=MagicMock(),
@@ -19,10 +29,14 @@ def test_pipeline_calls_probe_when_enabled() -> None:
         curator=None,
     )
 
+
+def test_pipeline_calls_probe_when_enabled() -> None:
+    """Pipeline calls stage_probe between agent generation and tournament."""
+    pipeline = _make_pipeline()
+
     mock_ctx = MagicMock()
     mock_ctx.generation = 2  # Skip startup verification
-    mock_ctx.settings.probe_matches = 1
-    mock_ctx.settings.coherence_check_enabled = False
+    _configure_pipeline_settings(mock_ctx, probe_matches=1)
 
     with (
         patch("autocontext.loop.generation_pipeline.stage_knowledge_setup", return_value=mock_ctx),
@@ -30,6 +44,7 @@ def test_pipeline_calls_probe_when_enabled() -> None:
         patch("autocontext.loop.generation_pipeline.stage_staged_validation", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_prevalidation", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_probe", return_value=mock_ctx) as mock_probe,
+        patch("autocontext.loop.generation_pipeline.stage_policy_refinement", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_tournament", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_stagnation_check", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_curator_gate", return_value=mock_ctx),
@@ -42,21 +57,11 @@ def test_pipeline_calls_probe_when_enabled() -> None:
 
 def test_pipeline_skips_probe_when_disabled() -> None:
     """Pipeline still calls stage_probe (it returns immediately when probe_matches=0)."""
-    pipeline = GenerationPipeline(
-        orchestrator=MagicMock(),
-        supervisor=MagicMock(),
-        gate=MagicMock(),
-        artifacts=MagicMock(),
-        sqlite=MagicMock(),
-        trajectory_builder=MagicMock(),
-        events=MagicMock(),
-        curator=None,
-    )
+    pipeline = _make_pipeline()
 
     mock_ctx = MagicMock()
     mock_ctx.generation = 2
-    mock_ctx.settings.probe_matches = 0
-    mock_ctx.settings.coherence_check_enabled = False
+    _configure_pipeline_settings(mock_ctx, probe_matches=0)
 
     with (
         patch("autocontext.loop.generation_pipeline.stage_knowledge_setup", return_value=mock_ctx),
@@ -64,6 +69,7 @@ def test_pipeline_skips_probe_when_disabled() -> None:
         patch("autocontext.loop.generation_pipeline.stage_staged_validation", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_prevalidation", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_probe", return_value=mock_ctx) as mock_probe,
+        patch("autocontext.loop.generation_pipeline.stage_policy_refinement", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_tournament", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_stagnation_check", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_curator_gate", return_value=mock_ctx),
@@ -77,22 +83,11 @@ def test_pipeline_skips_probe_when_disabled() -> None:
 
 def test_pipeline_continues_after_staged_validation_retry_signal() -> None:
     """A staged-validation retry signal should not short-circuit the rest of the pipeline."""
-    pipeline = GenerationPipeline(
-        orchestrator=MagicMock(),
-        supervisor=MagicMock(),
-        gate=MagicMock(),
-        artifacts=MagicMock(),
-        sqlite=MagicMock(),
-        trajectory_builder=MagicMock(),
-        events=MagicMock(),
-        curator=None,
-    )
+    pipeline = _make_pipeline()
 
     mock_ctx = MagicMock()
     mock_ctx.generation = 2
-    mock_ctx.settings.probe_matches = 1
-    mock_ctx.settings.coherence_check_enabled = False
-    mock_ctx.settings.harness_validators_enabled = False
+    _configure_pipeline_settings(mock_ctx, probe_matches=1)
     mock_ctx.gate_decision = "retry"
     mock_ctx.staged_validation_results = [{"stage": "contract", "status": "failed"}]
 
@@ -102,6 +97,7 @@ def test_pipeline_continues_after_staged_validation_retry_signal() -> None:
         patch("autocontext.loop.generation_pipeline.stage_staged_validation", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_prevalidation", return_value=mock_ctx) as mock_prevalidation,
         patch("autocontext.loop.generation_pipeline.stage_probe", return_value=mock_ctx) as mock_probe,
+        patch("autocontext.loop.generation_pipeline.stage_policy_refinement", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_tournament", return_value=mock_ctx) as mock_tournament,
         patch("autocontext.loop.generation_pipeline.stage_stagnation_check", return_value=mock_ctx),
         patch("autocontext.loop.generation_pipeline.stage_curator_gate", return_value=mock_ctx),

--- a/autocontext/tests/test_time_budget.py
+++ b/autocontext/tests/test_time_budget.py
@@ -1,0 +1,337 @@
+"""AC-174: Tests for generation time budget feature."""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autocontext.config.settings import AppSettings, load_settings
+from autocontext.loop.generation_pipeline import _over_budget, _time_remaining
+from autocontext.loop.stage_types import GenerationContext
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(
+    tmp_path: Path,
+    *,
+    budget: int = 0,
+    start_time: float | None = None,
+    **overrides: object,
+) -> GenerationContext:
+    """Build a minimal GenerationContext for testing budget helpers."""
+    settings = AppSettings(
+        agent_provider="deterministic",
+        db_path=tmp_path / "test.sqlite3",
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+        generation_time_budget_seconds=budget,
+    )
+    scenario = MagicMock()
+    ctx = GenerationContext(
+        run_id="test_run",
+        scenario_name="grid_ctf",
+        scenario=scenario,
+        generation=1,
+        settings=settings,
+        previous_best=0.0,
+        challenger_elo=1000.0,
+        score_history=[],
+        gate_decision_history=[],
+        coach_competitor_hints="",
+        replay_narrative="",
+    )
+    if start_time is not None:
+        ctx.generation_start_time = start_time
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+class TestSettings:
+    def test_default_is_zero(self) -> None:
+        """generation_time_budget_seconds defaults to 0 (unlimited)."""
+        settings = AppSettings()
+        assert settings.generation_time_budget_seconds == 0
+
+    def test_env_var_override(self) -> None:
+        """AUTOCONTEXT_GENERATION_TIME_BUDGET_SECONDS loads from env."""
+        with patch.dict(os.environ, {"AUTOCONTEXT_GENERATION_TIME_BUDGET_SECONDS": "60"}):
+            settings = load_settings()
+        assert settings.generation_time_budget_seconds == 60
+
+
+# ---------------------------------------------------------------------------
+# GenerationContext fields
+# ---------------------------------------------------------------------------
+
+
+class TestContextFields:
+    def test_timing_fields_exist(self, tmp_path: Path) -> None:
+        """GenerationContext has generation_start_time and generation_elapsed_seconds."""
+        ctx = _make_ctx(tmp_path)
+        assert ctx.generation_start_time == 0.0
+        assert ctx.generation_elapsed_seconds == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Budget helpers
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetHelpers:
+    def test_over_budget_false_when_unlimited(self, tmp_path: Path) -> None:
+        """_over_budget returns False when budget=0 (unlimited)."""
+        ctx = _make_ctx(tmp_path, budget=0, start_time=time.monotonic())
+        assert _over_budget(ctx) is False
+
+    def test_over_budget_false_when_within_budget(self, tmp_path: Path) -> None:
+        """_over_budget returns False when still within budget."""
+        ctx = _make_ctx(tmp_path, budget=300, start_time=time.monotonic())
+        assert _over_budget(ctx) is False
+
+    def test_over_budget_true_when_exceeded(self, tmp_path: Path) -> None:
+        """_over_budget returns True when start time is far in the past."""
+        ctx = _make_ctx(tmp_path, budget=1, start_time=time.monotonic() - 100)
+        assert _over_budget(ctx) is True
+
+    def test_time_remaining_none_when_unlimited(self, tmp_path: Path) -> None:
+        """_time_remaining returns None when budget=0."""
+        ctx = _make_ctx(tmp_path, budget=0, start_time=time.monotonic())
+        assert _time_remaining(ctx) is None
+
+    def test_time_remaining_positive_within_budget(self, tmp_path: Path) -> None:
+        """_time_remaining returns positive float when within budget."""
+        ctx = _make_ctx(tmp_path, budget=300, start_time=time.monotonic())
+        remaining = _time_remaining(ctx)
+        assert remaining is not None
+        assert remaining > 0
+
+    def test_time_remaining_zero_when_exceeded(self, tmp_path: Path) -> None:
+        """_time_remaining returns 0 when budget is exceeded (clamped)."""
+        ctx = _make_ctx(tmp_path, budget=1, start_time=time.monotonic() - 100)
+        remaining = _time_remaining(ctx)
+        assert remaining == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Pipeline behavior
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineBudget:
+    def test_pipeline_skips_optional_stages_when_over_budget(self, tmp_path: Path) -> None:
+        """Budget exhaustion before tournament causes a rollback without matches."""
+        from autocontext.loop.generation_runner import GenerationRunner
+
+        settings = AppSettings(
+            agent_provider="deterministic",
+            db_path=tmp_path / "test.sqlite3",
+            runs_root=tmp_path / "runs",
+            knowledge_root=tmp_path / "knowledge",
+            skills_root=tmp_path / "skills",
+            generation_time_budget_seconds=1,  # very short budget
+            coherence_check_enabled=True,
+            probe_matches=3,
+        )
+        runner = GenerationRunner(settings)
+        runner.migrate(Path("migrations"))
+
+        # Patch time.monotonic so the pipeline immediately appears over-budget
+        # after agent generation (which always runs)
+        real_monotonic = time.monotonic
+        call_count = 0
+
+        def _fast_forward_monotonic() -> float:
+            nonlocal call_count
+            call_count += 1
+            # First call sets generation_start_time normally
+            # Subsequent calls appear 1000s later → over budget
+            if call_count <= 1:
+                return real_monotonic()
+            return real_monotonic() + 1000
+
+        events_emitted: list[tuple[str, dict]] = []
+        original_emit = runner.events.emit
+
+        def _capture_emit(event: str, payload: dict) -> None:
+            events_emitted.append((event, payload))
+            original_emit(event, payload)
+
+        runner.events.emit = _capture_emit  # type: ignore[assignment]
+
+        with patch("autocontext.loop.generation_pipeline.time") as mock_time:
+            mock_time.monotonic = _fast_forward_monotonic
+            summary = runner.run("grid_ctf", generations=1, run_id="budget_test")
+
+        assert summary.generations_executed == 1
+
+        # Verify budget exhaustion was emitted and tournament work was skipped.
+        budget_events = [e for e in events_emitted if e[0] == "generation_budget_exhausted"]
+        assert len(budget_events) == 1
+        tournament_events = [e for e in events_emitted if e[0] == "tournament_started"]
+        assert tournament_events == []
+
+        metrics = runner.sqlite.get_generation_metrics("budget_test")
+        assert len(metrics) == 1
+        assert metrics[0]["gate_decision"] == "rollback"
+        assert metrics[0]["duration_seconds"] is not None
+        assert metrics[0]["duration_seconds"] > 0
+
+        # Verify timing event was emitted.
+        timing_events = [e for e in events_emitted if e[0] == "generation_timing"]
+        assert len(timing_events) == 1
+        assert timing_events[0][1]["budget_seconds"] == 1
+        assert timing_events[0][1]["over_budget"] is True
+
+    def test_pipeline_runs_all_stages_when_unlimited(self, tmp_path: Path) -> None:
+        """All stages run when budget=0 (unlimited)."""
+        from autocontext.loop.generation_runner import GenerationRunner
+
+        settings = AppSettings(
+            agent_provider="deterministic",
+            db_path=tmp_path / "test.sqlite3",
+            runs_root=tmp_path / "runs",
+            knowledge_root=tmp_path / "knowledge",
+            skills_root=tmp_path / "skills",
+            generation_time_budget_seconds=0,
+        )
+        runner = GenerationRunner(settings)
+        runner.migrate(Path("migrations"))
+        summary = runner.run("grid_ctf", generations=1, run_id="unlimited_test")
+        assert summary.generations_executed == 1
+        assert summary.best_score >= 0.0
+
+    def test_pipeline_emits_timing_event(self, tmp_path: Path) -> None:
+        """run_generation emits a generation_timing event."""
+        from autocontext.loop.generation_runner import GenerationRunner
+
+        settings = AppSettings(
+            agent_provider="deterministic",
+            db_path=tmp_path / "test.sqlite3",
+            runs_root=tmp_path / "runs",
+            knowledge_root=tmp_path / "knowledge",
+            skills_root=tmp_path / "skills",
+        )
+        runner = GenerationRunner(settings)
+        runner.migrate(Path("migrations"))
+
+        events_emitted: list[tuple[str, dict]] = []
+        original_emit = runner.events.emit
+
+        def _capture_emit(event: str, payload: dict) -> None:
+            events_emitted.append((event, payload))
+            original_emit(event, payload)
+
+        runner.events.emit = _capture_emit  # type: ignore[assignment]
+        runner.run("grid_ctf", generations=1, run_id="timing_test")
+
+        timing_events = [e for e in events_emitted if e[0] == "generation_timing"]
+        assert len(timing_events) == 1
+
+        payload = timing_events[0][1]
+        assert payload["run_id"] == "timing_test"
+        assert payload["generation"] == 1
+        assert payload["elapsed_seconds"] > 0
+        assert payload["budget_seconds"] == 0
+        assert payload["over_budget"] is False
+
+    def test_pipeline_persists_completed_generation_duration(self, tmp_path: Path) -> None:
+        """Completed generations store a non-null elapsed duration."""
+        from autocontext.loop.generation_runner import GenerationRunner
+
+        settings = AppSettings(
+            agent_provider="deterministic",
+            db_path=tmp_path / "test.sqlite3",
+            runs_root=tmp_path / "runs",
+            knowledge_root=tmp_path / "knowledge",
+            skills_root=tmp_path / "skills",
+        )
+        runner = GenerationRunner(settings)
+        runner.migrate(Path("migrations"))
+
+        summary = runner.run("grid_ctf", generations=1, run_id="duration_test")
+        assert summary.generations_executed == 1
+
+        metrics = runner.sqlite.get_generation_metrics("duration_test")
+        assert len(metrics) == 1
+        assert metrics[0]["duration_seconds"] is not None
+        assert metrics[0]["duration_seconds"] > 0
+
+
+# ---------------------------------------------------------------------------
+# SQLite store
+# ---------------------------------------------------------------------------
+
+
+class TestSQLiteStore:
+    def test_upsert_generation_accepts_duration(self, tmp_path: Path) -> None:
+        """upsert_generation stores duration_seconds."""
+        from autocontext.storage.sqlite_store import SQLiteStore
+
+        db_path = tmp_path / "test.sqlite3"
+        store = SQLiteStore(db_path)
+        store.migrate(Path("migrations"))
+
+        store.create_run("r1", "grid_ctf", 1, "local")
+        store.upsert_generation(
+            "r1", 1,
+            mean_score=0.5, best_score=0.5,
+            elo=1000.0, wins=1, losses=0,
+            gate_decision="advance", status="completed",
+            duration_seconds=5.25,
+        )
+
+        metrics = store.get_generation_metrics("r1")
+        assert len(metrics) == 1
+        assert metrics[0]["duration_seconds"] == pytest.approx(5.25)
+
+    def test_upsert_generation_duration_defaults_none(self, tmp_path: Path) -> None:
+        """duration_seconds defaults to None when not provided."""
+        from autocontext.storage.sqlite_store import SQLiteStore
+
+        db_path = tmp_path / "test.sqlite3"
+        store = SQLiteStore(db_path)
+        store.migrate(Path("migrations"))
+
+        store.create_run("r2", "grid_ctf", 1, "local")
+        store.upsert_generation(
+            "r2", 1,
+            mean_score=0.5, best_score=0.5,
+            elo=1000.0, wins=1, losses=0,
+            gate_decision="advance", status="completed",
+        )
+
+        metrics = store.get_generation_metrics("r2")
+        assert len(metrics) == 1
+        assert metrics[0]["duration_seconds"] is None
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+
+class TestMigration:
+    def test_migration_adds_duration_column(self, tmp_path: Path) -> None:
+        """Migration 009 adds duration_seconds column to generations table."""
+        from autocontext.storage.sqlite_store import SQLiteStore
+
+        db_path = tmp_path / "test.sqlite3"
+        store = SQLiteStore(db_path)
+        store.migrate(Path("migrations"))
+
+        with store.connect() as conn:
+            cursor = conn.execute("PRAGMA table_info(generations)")
+            columns = {row["name"] for row in cursor.fetchall()}
+
+        assert "duration_seconds" in columns


### PR DESCRIPTION
## Summary
- Add `AUTOCONTEXT_GENERATION_TIME_BUDGET_SECONDS` setting (default 0 = unlimited, backward compatible)
- Skip optional stages (staged validation, pre-validation, probe, policy refinement, coherence check) when over budget
- Emit `generation_timing` event with elapsed/budget/over_budget payload per generation
- Store `duration_seconds` in SQLite generations table (migration 009)
- Remove `.claude/` symlinks from git tracking, update `.gitignore` to `**/.claude/`

## Touch points
- `config/settings.py` — new `generation_time_budget_seconds` field
- `loop/generation_pipeline.py` — `_over_budget()` / `_time_remaining()` helpers, budget checks, timing event
- `loop/stage_types.py` — `generation_start_time` and `generation_elapsed_seconds` fields
- `loop/stages.py` — pass `duration_seconds` to `upsert_generation`
- `storage/sqlite_store.py` — `duration_seconds` param on `upsert_generation`
- `migrations/009_generation_timing.sql` — new column

## Test plan
- [x] 15 new tests in `tests/test_time_budget.py` — settings, context fields, budget helpers, pipeline skip/unlimited/events, SQLite store, migration
- [x] `uv run ruff check src tests` — clean
- [x] `uv run mypy src` — 0 errors
- [x] Full suite: 2831 passed, 45 skipped