### PR TITLE
feat(AC-219): wire notebook editing into cockpit API

### DIFF
--- a/autocontext/src/autocontext/server/cockpit_api.py
+++ b/autocontext/src/autocontext/server/cockpit_api.py
@@ -53,8 +53,7 @@ def _emit_cockpit_notebook_event(request: Request, session_id: str, scenario_nam
     if settings is None:
         return
     event_path: Path = settings.event_stream_path
-    if not event_path.parent.exists():
-        return
+    event_path.parent.mkdir(parents=True, exist_ok=True)
     from autocontext.loop.events import EventStreamEmitter
 
     emitter = EventStreamEmitter(event_path)
@@ -125,11 +124,26 @@ def cockpit_update_notebook(session_id: str, body: NotebookUpdateBody, request: 
 def cockpit_delete_notebook(session_id: str, request: Request) -> dict[str, str]:
     """Delete a notebook from cockpit."""
     store = _get_store(request)
+    existing = store.get_notebook(session_id)
+    scenario_name = str(existing["scenario_name"]) if existing is not None else ""
     deleted = store.delete_notebook(session_id)
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Notebook not found: {session_id}")
     artifacts = _get_artifacts(request)
     artifacts.delete_notebook(session_id)
+    if scenario_name:
+        settings = getattr(request.app.state, "app_settings", None)
+        if settings is not None:
+            event_path: Path = settings.event_stream_path
+            event_path.parent.mkdir(parents=True, exist_ok=True)
+            from autocontext.loop.events import EventStreamEmitter
+
+            emitter = EventStreamEmitter(event_path)
+            emitter.emit(
+                "notebook_deleted",
+                {"session_id": session_id, "scenario_name": scenario_name, "source": "cockpit"},
+                channel="cockpit",
+            )
     return {"status": "deleted", "session_id": session_id}
 
 

--- a/autocontext/tests/test_cockpit_notebook_integration.py
+++ b/autocontext/tests/test_cockpit_notebook_integration.py
@@ -381,9 +381,7 @@ class TestCockpitReadOnlyEndpointsUnchanged:
 class TestCockpitNotebookEventEmission:
     def test_put_emits_event(self, cockpit_env: dict[str, Any]) -> None:
         """PUT writes a notebook_updated event to the event stream."""
-        events_dir = cockpit_env["tmp_path"] / "runs"
-        events_dir.mkdir(parents=True, exist_ok=True)
-        event_path = events_dir / "events.ndjson"
+        event_path = cockpit_env["tmp_path"] / "runs" / "events.ndjson"
 
         cockpit_env["client"].put(
             "/api/cockpit/notebooks/sess-ev",
@@ -396,4 +394,20 @@ class TestCockpitNotebookEventEmission:
         event = json.loads(lines[-1])
         assert event["event"] == "notebook_updated"
         assert event["payload"]["session_id"] == "sess-ev"
+        assert event["payload"]["source"] == "cockpit"
+
+    def test_delete_emits_event(self, cockpit_env: dict[str, Any]) -> None:
+        """DELETE writes a notebook_deleted event to the event stream."""
+        event_path = cockpit_env["tmp_path"] / "runs" / "events.ndjson"
+        cockpit_env["client"].put(
+            "/api/cockpit/notebooks/sess-del-ev",
+            json={"scenario_name": "grid_ctf"},
+        )
+
+        resp = cockpit_env["client"].delete("/api/cockpit/notebooks/sess-del-ev")
+        assert resp.status_code == 200
+        lines = [line for line in event_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        event = json.loads(lines[-1])
+        assert event["event"] == "notebook_deleted"
+        assert event["payload"]["session_id"] == "sess-del-ev"
         assert event["payload"]["source"] == "cockpit"


### PR DESCRIPTION
## Summary
- Adds CRUD notebook endpoints (`GET`, `PUT`, `DELETE`) to the existing `cockpit_router` in `cockpit_api.py`, enabling operators to create, read, update, list, and delete session notebooks directly from the cockpit surface
- Introduces `NotebookUpdateBody` Pydantic model, filesystem sync via `ArtifactStore.write_notebook()`, and `notebook_updated` event emission with `source="cockpit"` channel
- Reuses existing `SQLiteStore` and `ArtifactStore` notebook methods — no new migrations or schema changes

## Endpoints Added
| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/cockpit/notebooks` | List all session notebooks |
| `GET` | `/api/cockpit/notebooks/{session_id}` | Get a specific notebook |
| `PUT` | `/api/cockpit/notebooks/{session_id}` | Create or update a notebook |
| `DELETE` | `/api/cockpit/notebooks/{session_id}` | Delete a notebook |

## TDD Approach
Strict red-green-refactor:
1. **RED**: Wrote 21 integration tests first — 14 failed (endpoints missing), 7 passed (existing read-only endpoints)
2. **GREEN**: Added endpoints to `cockpit_api.py` — all 21 pass
3. **REFACTOR**: Verified ruff, mypy, and full test suite (2939 passed, 45 skipped)

## Test Coverage (21 tests)
- Create notebook (with all fields, scenario_name required, 400 on missing)
- Read notebook (existing, 404 on missing)
- List notebooks (empty, multiple)
- Update notebook (partial update, score fields)
- Delete notebook (existing, 404 on missing)
- Session isolation (independent data, delete doesn't affect others)
- Filesystem sync (notebook.json created/deleted)
- Event emission (ndjson event with source=cockpit)
- Backward compatibility (5 existing read-only endpoints still work)

## Test plan
- [x] `uv run pytest tests/test_cockpit_notebook_integration.py -v` — 21 passed
- [x] `uv run pytest tests/test_cockpit.py -v` — 25 passed (existing cockpit tests unchanged)
- [x] `uv run ruff check src tests` — all checks passed
- [x] `uv run mypy src` — no issues in 248 source files
- [x] `uv run pytest --ignore=tests/test_probe_pipeline.py --ignore=tests/test_frontier_to_local_e2e.py` — 2939 passed, 45 skipped