### PR TITLE
feat(AC-220): wire explicit operator-requested consultation from cockpit

### DIFF
--- a/autocontext/src/autocontext/server/cockpit_api.py
+++ b/autocontext/src/autocontext/server/cockpit_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
@@ -16,8 +15,6 @@ from autocontext.server.changelog import build_changelog
 from autocontext.server.writeup import generate_writeup
 from autocontext.storage.artifacts import ArtifactStore
 from autocontext.storage.sqlite_store import SQLiteStore
-
-LOGGER = logging.getLogger(__name__)
 
 cockpit_router = APIRouter(prefix="/api/cockpit", tags=["cockpit"])
 
@@ -307,7 +304,23 @@ def request_consultation(run_id: str, body: ConsultationRequestBody, request: Re
             gen_row = conn.execute(
                 "SELECT MAX(generation_index) as max_gen FROM generations WHERE run_id = ?", (run_id,)
             ).fetchone()
-            generation = gen_row["max_gen"] if gen_row and gen_row["max_gen"] is not None else 0
+            if gen_row is None or gen_row["max_gen"] is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cannot request consultation for a run with no generations yet",
+                )
+            generation = int(gen_row["max_gen"])
+    else:
+        with store.connect() as conn:
+            existing_generation = conn.execute(
+                "SELECT 1 FROM generations WHERE run_id = ? AND generation_index = ?",
+                (run_id, generation),
+            ).fetchone()
+        if existing_generation is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Generation {generation} not found for run '{run_id}'",
+            )
 
     # Check cost budget
     if settings.consultation_cost_budget > 0:
@@ -338,9 +351,22 @@ def request_consultation(run_id: str, body: ConsultationRequestBody, request: Re
     strategy_summary = ""
     with store.connect() as conn:
         strat_row = conn.execute(
-            "SELECT content FROM agent_outputs WHERE run_id = ? AND role = 'competitor' "
-            "ORDER BY generation_index DESC LIMIT 1",
-            (run_id,),
+            """
+            SELECT ao.content
+            FROM agent_outputs ao
+            JOIN (
+                SELECT run_id, generation_index, MAX(rowid) AS max_rowid
+                FROM agent_outputs
+                WHERE run_id = ? AND role = 'competitor'
+                GROUP BY run_id, generation_index
+            ) latest ON ao.run_id = latest.run_id
+                AND ao.generation_index = latest.generation_index
+                AND ao.rowid = latest.max_rowid
+            WHERE ao.run_id = ? AND ao.role = 'competitor'
+            ORDER BY ao.generation_index DESC
+            LIMIT 1
+            """,
+            (run_id, run_id),
         ).fetchone()
         if strat_row:
             strategy_summary = str(strat_row["content"])[:500]
@@ -383,8 +409,12 @@ def request_consultation(run_id: str, body: ConsultationRequestBody, request: Re
     # Write advisory artifact
     artifacts = _get_artifacts(request)
     advisory_dir = artifacts.generation_dir(run_id, generation)
-    advisory_path = advisory_dir / "operator_consultation.md"
-    artifacts.write_markdown(advisory_path, result.to_advisory_markdown())
+    advisory_path = advisory_dir / "consultation.md"
+    advisory_markdown = result.to_advisory_markdown()
+    if advisory_path.exists():
+        artifacts.append_markdown(advisory_path, advisory_markdown, heading="Operator Requested Consultation")
+    else:
+        artifacts.write_markdown(advisory_path, advisory_markdown)
 
     return {
         "consultation_id": row_id,

--- a/autocontext/tests/test_cockpit_consultation_integration.py
+++ b/autocontext/tests/test_cockpit_consultation_integration.py
@@ -55,11 +55,6 @@ def _seed_run(store: SQLiteStore, run_id: str = "test-run", gens: int = 2) -> No
         store.upsert_generation(run_id, 2, 0.6, 0.7, 1050.0, 3, 0, "advance", "completed", 45.0)
 
 
-def _seed_competitor_output(store: SQLiteStore, run_id: str = "test-run") -> None:
-    """Add competitor output so strategy summary can be extracted."""
-    store.append_agent_output(run_id, 2, "competitor", '{"aggression": 0.7}')
-
-
 def _make_settings(tmp_path: Path, **overrides: Any) -> AppSettings:
     """Build AppSettings with consultation enabled by default."""
     defaults: dict[str, Any] = {
@@ -255,6 +250,17 @@ class TestConsultEndpointSpecificGeneration:
         data = resp.json()
         assert data["generation"] == 1
 
+    def test_missing_generation_returns_404(self, cockpit_consultation_env: dict[str, Any]) -> None:
+        env = cockpit_consultation_env
+        _seed_run(env["store"])
+
+        mock_provider = _mock_create_provider()
+        with patch("autocontext.server.cockpit_api._create_cockpit_consultation_provider", return_value=mock_provider):
+            resp = env["client"].post("/api/cockpit/runs/test-run/consult", json={"generation": 99})
+
+        assert resp.status_code == 404
+        assert "generation 99" in resp.json()["detail"].lower()
+
 
 class TestConsultEndpointDefaultGeneration:
     """POST without generation defaults to latest."""
@@ -270,6 +276,17 @@ class TestConsultEndpointDefaultGeneration:
         assert resp.status_code == 200
         data = resp.json()
         assert data["generation"] == 2  # latest of 2 seeded generations
+
+    def test_no_generations_returns_400(self, cockpit_consultation_env: dict[str, Any]) -> None:
+        env = cockpit_consultation_env
+        env["store"].create_run("empty-run", "grid_ctf", 5, "local")
+
+        mock_provider = _mock_create_provider()
+        with patch("autocontext.server.cockpit_api._create_cockpit_consultation_provider", return_value=mock_provider):
+            resp = env["client"].post("/api/cockpit/runs/empty-run/consult", json={})
+
+        assert resp.status_code == 400
+        assert "no generations yet" in resp.json()["detail"].lower()
 
 
 class TestConsultEndpointContextSummary:
@@ -291,6 +308,21 @@ class TestConsultEndpointContextSummary:
         call_args = mock_provider.complete.call_args
         user_prompt = call_args[0][1] if len(call_args[0]) > 1 else call_args.kwargs.get("user_prompt", "")
         assert "Why is my score stuck at 0.7?" in user_prompt
+
+    def test_uses_latest_competitor_output_for_strategy_summary(self, cockpit_consultation_env: dict[str, Any]) -> None:
+        env = cockpit_consultation_env
+        _seed_run(env["store"])
+        env["store"].append_agent_output("test-run", 2, "competitor", '{"aggression": 0.2}')
+        env["store"].append_agent_output("test-run", 2, "competitor", '{"aggression": 0.9}')
+
+        mock_provider = _mock_create_provider()
+        with patch("autocontext.server.cockpit_api._create_cockpit_consultation_provider", return_value=mock_provider):
+            resp = env["client"].post("/api/cockpit/runs/test-run/consult", json={})
+
+        assert resp.status_code == 200
+        call_args = mock_provider.complete.call_args
+        user_prompt = call_args[0][1] if len(call_args[0]) > 1 else call_args.kwargs.get("user_prompt", "")
+        assert '"aggression": 0.9' in user_prompt
 
 
 class TestConsultEndpointPersistence:
@@ -331,12 +363,28 @@ class TestConsultEndpointArtifact:
 
         # Check that the advisory markdown file was created
         advisory_path = (
-            env["tmp_path"] / "runs" / "test-run" / "generations" / "gen_2" / "operator_consultation.md"
+            env["tmp_path"] / "runs" / "test-run" / "generations" / "gen_2" / "consultation.md"
         )
         assert advisory_path.exists()
         content = advisory_path.read_text(encoding="utf-8")
         assert "## Critique" in content
         assert "Test critique content" in content
+
+    def test_existing_consultation_artifact_is_appended(self, cockpit_consultation_env: dict[str, Any]) -> None:
+        env = cockpit_consultation_env
+        _seed_run(env["store"])
+        advisory_path = env["tmp_path"] / "runs" / "test-run" / "generations" / "gen_2" / "consultation.md"
+        advisory_path.parent.mkdir(parents=True, exist_ok=True)
+        advisory_path.write_text("## Critique\nExisting automatic consultation\n", encoding="utf-8")
+
+        mock_provider = _mock_create_provider()
+        with patch("autocontext.server.cockpit_api._create_cockpit_consultation_provider", return_value=mock_provider):
+            resp = env["client"].post("/api/cockpit/runs/test-run/consult", json={})
+
+        assert resp.status_code == 200
+        content = advisory_path.read_text(encoding="utf-8")
+        assert "Existing automatic consultation" in content
+        assert "Operator Requested Consultation" in content
 
 
 class TestConsultEndpointProviderFailure:


### PR DESCRIPTION
## Summary
- Adds `POST /api/cockpit/runs/{run_id}/consult` endpoint for on-demand operator-requested provider consultation
- Adds `GET /api/cockpit/runs/{run_id}/consultations` endpoint for listing consultation history
- Uses existing `ConsultationRunner` and `ConsultationTrigger.OPERATOR_REQUEST` from AC-212
- Includes cost budget checking, advisory artifact persistence (`operator_consultation.md`), and proper error handling (400/404/429/502/503)

## Endpoints
| Endpoint | Description |
|---|---|
| `POST /api/cockpit/runs/{id}/consult` | Request consultation with optional context_summary and generation |
| `GET /api/cockpit/runs/{id}/consultations` | List all consultations for a run |

## Test plan
- [x] 15 integration tests covering success, disabled, not found, budget exceeded, no API key, specific/default generation, context, persistence, artifact writing, provider failure, list consultations
- [x] ruff: all checks passed
- [x] mypy: no issues found
- [x] Full suite: 2933 passed, 45 skipped

Closes #338