### PR TITLE
[codex] tighten docs and package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,45 @@
 # AutoContext
 
-AutoContext is a harness for improving agent behavior over repeated runs. It combines scenario execution, staged validation, knowledge accumulation, optional distillation, and OpenClaw-facing APIs so a task can move from frontier-model exploration toward cheaper local execution.
+AutoContext is a closed-loop system for improving agent behavior over repeated runs.
 
-## Before You Start
+It executes tasks, evaluates outcomes, updates persistent knowledge, and optionally distills successful behavior into cheaper local runtimes. The goal is to move from frontier-model exploration toward validated, reusable, lower-cost execution.
 
-- The Python application lives in `autocontext/`.
-- The main CLI is `autoctx`.
-- Most `uv`, `pytest`, `ruff`, and `mypy` commands should be run from `autocontext/`.
-- Environment variables use the `AUTOCONTEXT_` prefix.
+## Why It Exists
 
-## Repo Layout
+Most agent systems start every run cold. They do not reliably carry forward what worked, what failed, and what should change next.
 
-- `autocontext/`: Python package, CLI, API server, dashboard, training loop
-- `ts/`: TypeScript package and MCP-compatible tooling
-- `tui/`: interactive terminal UI
-- `infra/`: Docker, Fly.io, and bootstrap scripts
-- `docs/`: design notes and historical implementation plans
+AutoContext adds that missing feedback loop:
+
+- run the task
+- analyze what happened
+- persist validated lessons
+- use those lessons in the next run
+- optionally train and route to local models when the task is stable enough
+
+## How It Works
+
+Each generation runs through a structured multi-agent loop:
+
+- `competitor` proposes a strategy or artifact for the task
+- `analyst` explains what happened and why
+- `coach` turns that analysis into playbook updates and future hints
+- `architect` proposes tools, harness improvements, or structural changes
+- `curator` gates what knowledge is allowed to persist
+
+Strategies are then evaluated through scenario execution, staged validation, and gating. Weak changes are rolled back. Successful changes accumulate into reusable knowledge.
+
+## Core Capabilities
+
+- Persistent playbooks, hints, tools, reports, and progress snapshots across runs
+- Staged validation, harness synthesis, and harness-aware execution
+- Frontier-to-local distillation with MLX on Apple Silicon
+- Runtime routing across Anthropic, OpenAI-compatible backends, Ollama, vLLM, MLX, and Pi-based runtimes
+- OpenClaw-facing APIs and agent integration surfaces
+- CLI, API server, dashboard, and TypeScript/TUI surfaces for operators and external agents
 
 ## Quick Start
+
+The Python application lives in `autocontext/`, and most `uv`, `pytest`, `ruff`, and `mypy` commands should be run from there.
 
 ```bash
 cd autocontext
@@ -31,7 +53,16 @@ AUTOCONTEXT_AGENT_PROVIDER=deterministic uv run autoctx run \
   --run-id quickstart
 ```
 
-That command creates a local run, writes artifacts under `runs/` and `knowledge/`, and works without external API keys.
+That creates a local run, writes artifacts under `runs/` and `knowledge/`, and works without external API keys.
+
+Run with Anthropic:
+
+```bash
+cd autocontext
+AUTOCONTEXT_AGENT_PROVIDER=anthropic \
+AUTOCONTEXT_ANTHROPIC_API_KEY=your-key \
+uv run autoctx run --scenario grid_ctf --gens 3
+```
 
 Start the API server and dashboard:
 
@@ -42,46 +73,33 @@ uv run autoctx serve --host 127.0.0.1 --port 8000
 
 Then open `http://127.0.0.1:8000`.
 
-## Main Workflows
+## Common Workflows
 
 - Run the generation loop: `uv run autoctx run --scenario grid_ctf --gens 3`
 - Inspect runs: `uv run autoctx list`, `uv run autoctx status <run_id>`
 - Export training data: `uv run autoctx export-training-data --scenario grid_ctf --all-runs --output training/grid_ctf.jsonl`
-- Launch training: `uv run autoctx train --scenario grid_ctf --data training/grid_ctf.jsonl --time-budget 300`
-- Start MCP server: `uv run autoctx mcp-serve`
+- Train a local model: `uv run autoctx train --scenario grid_ctf --data training/grid_ctf.jsonl --time-budget 300`
+- Start the API server: `uv run autoctx serve --host 127.0.0.1 --port 8000`
+- Start the MCP server: `uv run autoctx mcp-serve`
 
-## Other Packages
+MLX training is host-only on Apple Silicon macOS. If you want a sandboxed OpenClaw agent to trigger training, use the file-based host watcher flow documented in [autocontext/docs/mlx-training.md](autocontext/docs/mlx-training.md).
 
-TypeScript package:
+## Repository Layout
 
-```bash
-cd ts
-npm install
-npm run lint
-npm test
-```
+- `autocontext/`: Python package, CLI, API server, dashboard, training loop
+- `ts/`: TypeScript package and CLI/MCP-compatible tooling
+- `tui/`: interactive terminal UI
+- `infra/`: Docker, Fly.io, and bootstrap scripts
+- `docs/`: higher-level repo notes
 
-TUI:
-
-```bash
-cd tui
-npm install
-npm test
-```
-
-Bootstrap script:
-
-```bash
-bash infra/scripts/bootstrap.sh
-```
-
-## Where To Look
+## Where To Look Next
 
 - Package and CLI guide: [autocontext/README.md](autocontext/README.md)
 - Contributor setup: [CONTRIBUTING.md](CONTRIBUTING.md)
-- Sandbox/executor notes: [autocontext/docs/sandbox.md](autocontext/docs/sandbox.md)
+- MLX host training and OpenClaw bridge: [autocontext/docs/mlx-training.md](autocontext/docs/mlx-training.md)
+- Sandbox and executor notes: [autocontext/docs/sandbox.md](autocontext/docs/sandbox.md)
 - License: [LICENSE](LICENSE)
 
-## Release Note
+## Note
 
-This repo has been renamed from `MTS` to `AutoContext`. Historical planning docs may still use the older name or issue identifiers.
+This repo was previously named `MTS`. Some historical references may still use the older name or issue prefixes.

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -100,7 +100,11 @@ uv run autoctx train \
   --time-budget 300
 ```
 
+MLX training is host-only. It must run on an Apple Silicon macOS machine with Metal access. It will not run correctly inside a Docker sandbox on macOS.
+
 If you only want to inspect generated training data first, export without training and open the JSONL directly.
+
+For host setup details and OpenClaw automation via a file-based watcher bridge, see [docs/mlx-training.md](docs/mlx-training.md).
 
 ## Configuration
 
@@ -161,5 +165,6 @@ AutoContext exposes:
 ## Additional Docs
 
 - [Sandbox modes](docs/sandbox.md)
+- [MLX host training](docs/mlx-training.md)
 - [Demo data notes](demo_data/README.md)
 - [Repository overview](../README.md)

--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -1,0 +1,295 @@
+# MLX Host Training Setup (Apple Silicon)
+
+## Overview
+
+AutoContext's `autoctx train` command uses [MLX](https://github.com/ml-explore/mlx) to fine-tune local models from exported run data. MLX requires direct access to Apple's Metal GPU framework, which means training must run on the macOS host, not inside a Docker sandbox.
+
+Docker containers on macOS run inside a Linux VM and cannot access Metal. The MLX Python package may install on Linux aarch64, but training cannot complete without a Metal-capable Apple Silicon host. Host-side Python environments also cannot be executed directly from the sandbox when they point to macOS-native binaries.
+
+## Prerequisites
+
+| Component | Version | Install |
+|-----------|---------|---------|
+| Apple Silicon Mac | M1/M2/M3/M4 | - |
+| macOS | Tahoe (26.x) or later | - |
+| Homebrew | Latest | [brew.sh](https://brew.sh) |
+| Python | 3.12+ | `brew install python@3.12` |
+| uv | 0.10+ | `brew install uv` |
+
+The package requires Python 3.11+, but Homebrew Python 3.12 is the safest host setup for MLX on Apple Silicon.
+
+## Installation
+
+### 1. Install Python and uv
+
+```bash
+brew install python@3.12
+brew install uv
+```
+
+### 2. Sync the MLX dependency group
+
+From the `autocontext/` directory:
+
+```bash
+cd <project-root>/autocontext
+uv sync --group dev --extra mlx
+```
+
+This installs the MLX-specific extras:
+
+- `mlx>=0.30.0`
+- `rustbpe>=0.1.0`
+- `tiktoken>=0.11.0`
+- `safetensors>=0.4.0`
+
+## Running Training
+
+Export JSONL data from completed runs:
+
+```bash
+cd <project-root>/autocontext
+uv run autoctx export-training-data \
+  --scenario grid_ctf \
+  --all-runs \
+  --output training/grid_ctf.jsonl
+```
+
+Run training on the host:
+
+```bash
+cd <project-root>/autocontext
+uv run autoctx train \
+  --scenario grid_ctf \
+  --data /absolute/path/to/training/grid_ctf.jsonl \
+  --time-budget 300
+```
+
+Use absolute paths for `--data`. The CLI resolves relative paths from the current working directory, which may differ from the location that originally produced the training data.
+
+The training loop writes its workspace under `runs/train_<scenario>/` and produces a checkpoint bundle that `MLXProvider` can load for local inference.
+
+## Automating Host Training for Sandboxed Agents
+
+For sandboxed agents, especially OpenClaw agents running in Docker, the cleanest low-risk approach is a file-based host-training bridge.
+
+### Why a File Bridge
+
+- the sandbox cannot access Metal directly
+- you do not need to expose a network service
+- you do not need to grant broad host exec permissions to the sandbox
+- the agent can request training asynchronously and poll for results through the shared workspace
+
+### How It Works
+
+1. The agent writes `request-*.json` into a watched directory.
+2. A host-side `launchd` agent notices the file and runs a watcher script.
+3. The watcher script invokes `uv run autoctx train` on the host.
+4. The watcher writes `<request>-result.json` back to the same directory.
+5. The agent polls for the result file and then loads the produced local artifact.
+
+## Request Format
+
+The agent writes a request file such as `request-123.json`:
+
+```json
+{
+  "scenario": "grid_ctf",
+  "data": "/absolute/path/to/training-data.jsonl",
+  "time_budget": 60
+}
+```
+
+## Result Format
+
+Successful run:
+
+```json
+{
+  "status": "success",
+  "scenario": "grid_ctf",
+  "timestamp": "2026-03-12T02:49:33Z"
+}
+```
+
+Failure:
+
+```json
+{
+  "status": "error",
+  "exit_code": 1,
+  "scenario": "grid_ctf",
+  "timestamp": "2026-03-12T02:49:33Z"
+}
+```
+
+## Reference Watcher Script
+
+Save as `~/.openclaw/scripts/autocontext-train-watcher.sh`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+REQUEST_DIR="$HOME/.openclaw/workspace/autocontext/runs/train-requests"
+AUTOCTX_DIR="$HOME/.openclaw/workspace/autocontext/autocontext"
+LOG="/tmp/autocontext-train-watcher.log"
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) watcher triggered" >> "$LOG"
+
+for req in "$REQUEST_DIR"/request-*.json; do
+  [ -f "$req" ] || continue
+  [[ "$req" == *-result.json ]] && continue
+  [ -s "$req" ] || { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) skipping empty file: $req" >> "$LOG"; continue; }
+
+  BASENAME="$(basename "$req" .json)"
+  RESULT_FILE="$REQUEST_DIR/${BASENAME}-result.json"
+
+  [ -f "$RESULT_FILE" ] && continue
+
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) processing $req" >> "$LOG"
+
+  SCENARIO=$(python3.12 -c "import json,sys; print(json.load(open(sys.argv[1]))['scenario'])" "$req" 2>/dev/null || echo "")
+  DATA_PATH=$(python3.12 -c "import json,sys; print(json.load(open(sys.argv[1]))['data'])" "$req" 2>/dev/null || echo "")
+  TIME_BUDGET=$(python3.12 -c "import json,sys; print(json.load(open(sys.argv[1])).get('time_budget', 60))" "$req" 2>/dev/null || echo "60")
+
+  if [ -z "$SCENARIO" ] || [ -z "$DATA_PATH" ]; then
+    echo "{\"status\":\"error\",\"message\":\"missing scenario or data in request\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$RESULT_FILE"
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) error: missing fields in $req" >> "$LOG"
+    continue
+  fi
+
+  cd "$AUTOCTX_DIR"
+  if /opt/homebrew/bin/uv run autoctx train --scenario "$SCENARIO" --data "$DATA_PATH" --time-budget "$TIME_BUDGET" >> "$LOG" 2>&1; then
+    echo "{\"status\":\"success\",\"scenario\":\"$SCENARIO\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$RESULT_FILE"
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) training complete for $SCENARIO" >> "$LOG"
+  else
+    EXIT_CODE=$?
+    echo "{\"status\":\"error\",\"exit_code\":$EXIT_CODE,\"scenario\":\"$SCENARIO\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$RESULT_FILE"
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) training failed ($EXIT_CODE) for $SCENARIO" >> "$LOG"
+  fi
+done
+```
+
+Make it executable:
+
+```bash
+chmod 755 ~/.openclaw/scripts/autocontext-train-watcher.sh
+```
+
+## Reference `launchd` Plist
+
+Save as `~/Library/LaunchAgents/com.autocontext.train-watcher.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.autocontext.train-watcher</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/cirdan/.openclaw/scripts/autocontext-train-watcher.sh</string>
+  </array>
+  <key>WatchPaths</key>
+  <array>
+    <string>/Users/cirdan/.openclaw/workspace/autocontext/runs/train-requests</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/tmp/autocontext-train-watcher-stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/autocontext-train-watcher-stderr.log</string>
+</dict>
+</plist>
+```
+
+Update the example paths to match your home directory and shared workspace path.
+
+Load the agent:
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.autocontext.train-watcher.plist
+launchctl list com.autocontext.train-watcher
+```
+
+## Bridge Test
+
+Write a request:
+
+```bash
+echo '{"scenario": "grid_ctf", "data": "/absolute/path/to/training-data.jsonl", "time_budget": 60}' > ~/.openclaw/workspace/autocontext/runs/train-requests/request-test.json
+```
+
+Check logs and result:
+
+```bash
+cat /tmp/autocontext-train-watcher.log
+cat ~/.openclaw/workspace/autocontext/runs/train-requests/request-test-result.json
+```
+
+Clean up:
+
+```bash
+rm ~/.openclaw/workspace/autocontext/runs/train-requests/request-test*.json
+```
+
+## Alternative Approaches
+
+### Gateway Exec
+
+OpenClaw's host-exec gateway is cleaner in principle, but today it routes all exec traffic to the host rather than only the training command. That is too broad for Slack-style sandboxed agents and makes normal sandbox behavior awkward.
+
+### HTTP Bridge
+
+A localhost HTTP bridge is possible, but it adds a service boundary and local networking complexity without giving much over the file-based trigger model.
+
+## Troubleshooting
+
+### `MLX is required`
+
+You are either running inside Docker or you have not synced the MLX extra on the host:
+
+```bash
+uv sync --group dev --extra mlx
+```
+
+### Python version errors
+
+Install Homebrew Python and verify it:
+
+```bash
+brew install python@3.12
+python3.12 --version
+```
+
+### Metal runtime failures
+
+MLX requires Apple Silicon and a Metal-capable macOS host. Intel Macs are not supported.
+
+### Watcher does not trigger
+
+Check:
+
+```bash
+launchctl list com.autocontext.train-watcher
+```
+
+Also verify that:
+- the watched directory exists
+- request files match `request-*.json`
+- the script is executable
+
+### Permission errors on workspace files
+
+If the sandbox created the exported data with restrictive permissions:
+
+```bash
+chmod -R u+rw ~/.openclaw/workspace/autocontext/runs/
+```

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -7,7 +7,20 @@ name = "autoctx"
 version = "0.1.0"
 description = "AutoContext control plane for iterative strategy evolution."
 readme = "README.md"
+license = { text = "Apache-2.0" }
 requires-python = ">=3.11"
+keywords = ["agents", "evaluation", "harness", "llm", "optimization", "autocontext"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 dependencies = [
   "anthropic>=0.66.0",
   "fastapi>=0.116.1",
@@ -39,6 +52,12 @@ dev = [
 
 [project.scripts]
 autoctx = "autocontext.cli:app"
+
+[project.urls]
+Homepage = "https://github.com/greyhaven-ai/autocontext"
+Repository = "https://github.com/greyhaven-ai/autocontext"
+Issues = "https://github.com/greyhaven-ai/autocontext/issues"
+Documentation = "https://github.com/greyhaven-ai/autocontext/tree/main/autocontext/docs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/autocontext"]

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@greyhaven/autoctx",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "better-sqlite3": "^11.0.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "migrations"
+  ],
   "bin": {
     "autoctx": "dist/cli/index.js"
   },
@@ -23,7 +27,18 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/greyhaven-ai/autocontext.git"
+  },
+  "homepage": "https://github.com/greyhaven-ai/autocontext/tree/main/ts",
+  "bugs": {
+    "url": "https://github.com/greyhaven-ai/autocontext/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## Summary
This PR prepares the repo for public package distribution by tightening the GitHub landing page, documenting host-only MLX training for Apple Silicon, and aligning Python and TypeScript package metadata with the repository's Apache-2.0 licensing and public package publishing targets.

## Why this matters
The repo is now close to open source and package publication, but the top-level docs were still more implementation-oriented than product-oriented, MLX host-training requirements were undocumented for external users and agents, and package metadata still had stale licensing and registry details. Without this cleanup, new users would have a harder time understanding the project, and package consumers would receive inconsistent package metadata.

## What changed
The top-level README now presents AutoContext as a closed-loop agent-improvement system, explains the multi-agent optimization loop, highlights the core capabilities, and points users to the key operational docs. The Python package README now calls out that MLX training must run on a Metal-capable Apple Silicon host and links to the new MLX host-training guide.

A new `autocontext/docs/mlx-training.md` guide documents host-side MLX setup, the `autoctx train` workflow, and a file-based OpenClaw bridge for sandboxed agents that need to trigger host-side training. On the packaging side, the Python package metadata now includes the Apache-2.0 license, classifiers, keywords, and project URLs. The TypeScript package metadata now also reflects Apache-2.0, includes repository/homepage/bugs links, declares public publish access, and narrows the published file set.

## Validation
I ran:
- `git diff --check`
- a TOML parse sanity check for `autocontext/pyproject.toml`
- a JSON/package metadata sanity check for `ts/package.json`
