### PR TITLE
[codex] publish npm package as autoctx

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@greyhaven/autoctx",
+  "name": "autoctx",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@greyhaven/autoctx",
+      "name": "autoctx",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@greyhaven/autoctx",
+  "name": "autoctx",
   "version": "0.1.0",
   "description": "AutoContext — always-on agent evaluation harness",
   "type": "module",

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @greyhaven/autoctx — AutoContext TypeScript toolkit.
+ * autoctx — AutoContext TypeScript toolkit.
  */
 
 // Core types


### PR DESCRIPTION
## Summary
This PR renames the TypeScript package from the scoped `@greyhaven/autoctx` name to the unscoped `autoctx` package name that is actually owned by this maintainer account on npm.

## Why this matters
The previous npm publish attempt failed because the package metadata still targeted the `@greyhaven` scope, while the publish token only has ownership for the existing unscoped `autoctx` package. Leaving the scoped name in place would keep npm publication blocked even though the package itself is otherwise buildable and ready.

## What changed
The package name in `ts/package.json` and `ts/package-lock.json` now matches the unscoped npm package name, and the TypeScript entrypoint banner comment was updated to match. No runtime behavior changed.

## Validation
I ran:
- `npm_config_cache=/tmp/releaseprep/.npm-cache npm run build`
- `npm_config_cache=/tmp/releaseprep/.npm-cache npm pack --dry-run`
