### PR TITLE
feat(AC-232): add OpenAI-compatible provider support to the TypeScript CLI

### DIFF
--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -74,72 +74,17 @@ async function main(): Promise<void> {
 }
 
 async function getProvider() {
-  // Dynamic import to avoid loading heavy deps for --help
-  const { ProviderError } = await import("../types/index.js");
+  const { resolveProviderConfig, createProvider } = await import("../providers/index.js");
 
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    console.error("ANTHROPIC_API_KEY environment variable required");
+  try {
+    const config = resolveProviderConfig();
+    const provider = createProvider(config);
+    const model = provider.defaultModel();
+    return { provider, model };
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
-
-  const model = process.env.AUTOCONTEXT_MODEL ?? "claude-sonnet-4-20250514";
-
-  // Simple fetch-based Anthropic provider
-  const provider = {
-    name: "anthropic-cli",
-    defaultModel: () => model,
-    complete: async (opts: {
-      systemPrompt: string;
-      userPrompt: string;
-      model?: string;
-      temperature?: number;
-      maxTokens?: number;
-    }) => {
-      const res = await fetch("https://api.anthropic.com/v1/messages", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-api-key": apiKey,
-          "anthropic-version": "2023-06-01",
-        },
-        body: JSON.stringify({
-          model: opts.model ?? model,
-          max_tokens: opts.maxTokens ?? 4096,
-          temperature: opts.temperature ?? 0,
-          system: opts.systemPrompt,
-          messages: [{ role: "user", content: opts.userPrompt }],
-        }),
-      });
-
-      if (!res.ok) {
-        const body = await res.text();
-        throw new ProviderError(`Anthropic API error ${res.status}: ${body.slice(0, 200)}`);
-      }
-
-      const data = (await res.json()) as {
-        content: Array<{ type: string; text: string }>;
-        model: string;
-        usage: { input_tokens: number; output_tokens: number };
-      };
-
-      const text = data.content
-        .filter((c) => c.type === "text")
-        .map((c) => c.text)
-        .join("");
-
-      return {
-        text,
-        model: data.model,
-        usage: {
-          input: data.usage.input_tokens,
-          output: data.usage.output_tokens,
-        },
-      };
-    },
-  };
-
-  return { provider, model };
 }
 
 async function cmdJudge(_dbPath: string): Promise<void> {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -30,6 +30,20 @@ export {
   ProviderError,
 } from "./types/index.js";
 
+// Providers
+export {
+  createAnthropicProvider,
+  createOpenAICompatibleProvider,
+  createProvider,
+  resolveProviderConfig,
+} from "./providers/index.js";
+export type {
+  AnthropicProviderOpts,
+  OpenAICompatibleProviderOpts,
+  CreateProviderOpts,
+  ProviderConfig,
+} from "./providers/index.js";
+
 // Judge
 export { LLMJudge, parseJudgeResponse } from "./judge/index.js";
 export type { LLMJudgeOpts, ParsedJudge } from "./judge/index.js";

--- a/ts/src/providers/index.ts
+++ b/ts/src/providers/index.ts
@@ -1,0 +1,230 @@
+/**
+ * Provider module — pluggable LLM provider construction.
+ *
+ * Supports Anthropic, OpenAI-compatible (OpenAI, OpenRouter, vLLM, Ollama).
+ * Uses native fetch() — no external SDK dependency required.
+ */
+
+import { ProviderError } from "../types/index.js";
+import type { CompletionResult, LLMProvider } from "../types/index.js";
+
+// ---------------------------------------------------------------------------
+// Anthropic Provider
+// ---------------------------------------------------------------------------
+
+export interface AnthropicProviderOpts {
+  apiKey: string;
+  model?: string;
+}
+
+export function createAnthropicProvider(opts: AnthropicProviderOpts): LLMProvider {
+  const defaultModel = opts.model ?? "claude-sonnet-4-20250514";
+
+  return {
+    name: "anthropic",
+    defaultModel: () => defaultModel,
+    complete: async (callOpts) => {
+      const res = await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": opts.apiKey,
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify({
+          model: callOpts.model ?? defaultModel,
+          max_tokens: callOpts.maxTokens ?? 4096,
+          temperature: callOpts.temperature ?? 0,
+          system: callOpts.systemPrompt,
+          messages: [{ role: "user", content: callOpts.userPrompt }],
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        throw new ProviderError(`Anthropic API error ${res.status}: ${body.slice(0, 200)}`);
+      }
+
+      const data = (await res.json()) as {
+        content: Array<{ type: string; text: string }>;
+        model: string;
+        usage: { input_tokens: number; output_tokens: number };
+      };
+
+      const text = data.content
+        .filter((c) => c.type === "text")
+        .map((c) => c.text)
+        .join("");
+
+      return {
+        text,
+        model: data.model,
+        usage: { input: data.usage.input_tokens, output: data.usage.output_tokens },
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI-Compatible Provider
+// ---------------------------------------------------------------------------
+
+export interface OpenAICompatibleProviderOpts {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+}
+
+export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpts): LLMProvider {
+  const defaultModel = opts.model ?? "gpt-4o";
+  const baseUrl = (opts.baseUrl ?? "https://api.openai.com/v1").replace(/\/+$/, "");
+  const apiKey = opts.apiKey ?? "";
+
+  return {
+    name: "openai-compatible",
+    defaultModel: () => defaultModel,
+    complete: async (callOpts) => {
+      const res = await fetch(`${baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: callOpts.model ?? defaultModel,
+          max_tokens: callOpts.maxTokens ?? 4096,
+          temperature: callOpts.temperature ?? 0,
+          messages: [
+            { role: "system", content: callOpts.systemPrompt },
+            { role: "user", content: callOpts.userPrompt },
+          ],
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        throw new ProviderError(`OpenAI API error ${res.status}: ${body.slice(0, 200)}`);
+      }
+
+      const data = (await res.json()) as {
+        choices: Array<{ message: { content: string } }>;
+        model: string;
+        usage: { prompt_tokens: number; completion_tokens: number };
+      };
+
+      const text = data.choices[0]?.message?.content ?? "";
+      return {
+        text,
+        model: data.model,
+        usage: { input: data.usage.prompt_tokens, output: data.usage.completion_tokens },
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface CreateProviderOpts {
+  providerType: string;
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+}
+
+export function createProvider(opts: CreateProviderOpts): LLMProvider {
+  const type = opts.providerType.toLowerCase().trim();
+
+  if (type === "anthropic") {
+    return createAnthropicProvider({
+      apiKey: opts.apiKey ?? "",
+      model: opts.model,
+    });
+  }
+
+  if (type === "openai" || type === "openai-compatible") {
+    return createOpenAICompatibleProvider({
+      apiKey: opts.apiKey,
+      baseUrl: opts.baseUrl,
+      model: opts.model,
+    });
+  }
+
+  if (type === "ollama") {
+    return createOpenAICompatibleProvider({
+      apiKey: "ollama",
+      baseUrl: opts.baseUrl ?? "http://localhost:11434/v1",
+      model: opts.model ?? "llama3.1",
+    });
+  }
+
+  if (type === "vllm") {
+    return createOpenAICompatibleProvider({
+      apiKey: opts.apiKey ?? "no-key",
+      baseUrl: opts.baseUrl ?? "http://localhost:8000/v1",
+      model: opts.model ?? "default",
+    });
+  }
+
+  throw new ProviderError(
+    `Unknown provider type: ${JSON.stringify(type)}. Supported: anthropic, openai, openai-compatible, ollama, vllm`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Environment-based config resolution (for CLI)
+// ---------------------------------------------------------------------------
+
+export interface ProviderConfig {
+  providerType: string;
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+}
+
+export function resolveProviderConfig(): ProviderConfig {
+  const providerType = process.env.AUTOCONTEXT_PROVIDER ?? "anthropic";
+  const model = process.env.AUTOCONTEXT_MODEL;
+  const baseUrl = process.env.AUTOCONTEXT_BASE_URL;
+  const genericKey = process.env.AUTOCONTEXT_API_KEY;
+
+  const type = providerType.toLowerCase().trim();
+
+  if (type === "anthropic") {
+    const apiKey = genericKey ?? process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new ProviderError(
+        "ANTHROPIC_API_KEY environment variable required (or set AUTOCONTEXT_API_KEY)",
+      );
+    }
+    return { providerType: type, apiKey, model, baseUrl };
+  }
+
+  if (type === "ollama") {
+    return {
+      providerType: type,
+      apiKey: genericKey ?? "ollama",
+      baseUrl: baseUrl ?? "http://localhost:11434/v1",
+      model: model ?? "llama3.1",
+    };
+  }
+
+  if (type === "vllm") {
+    return {
+      providerType: type,
+      apiKey: genericKey ?? "no-key",
+      baseUrl: baseUrl ?? "http://localhost:8000/v1",
+      model: model ?? "default",
+    };
+  }
+
+  // openai, openai-compatible, and other generic types
+  const apiKey = genericKey ?? process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new ProviderError(
+      "API key required: set AUTOCONTEXT_API_KEY or OPENAI_API_KEY",
+    );
+  }
+  return { providerType: type, apiKey, baseUrl, model };
+}

--- a/ts/tests/providers.test.ts
+++ b/ts/tests/providers.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Tests for AC-232: OpenAI-compatible provider support in the TypeScript CLI.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// 1. Anthropic Provider
+// ---------------------------------------------------------------------------
+
+describe("AnthropicProvider", () => {
+  it("should implement LLMProvider interface", async () => {
+    const { createAnthropicProvider } = await import("../src/providers/index.js");
+    const provider = createAnthropicProvider({ apiKey: "test-key" });
+    expect(provider.name).toBe("anthropic");
+    expect(typeof provider.defaultModel).toBe("function");
+    expect(typeof provider.complete).toBe("function");
+  });
+
+  it("should use default model when none specified", async () => {
+    const { createAnthropicProvider } = await import("../src/providers/index.js");
+    const provider = createAnthropicProvider({ apiKey: "test-key" });
+    expect(provider.defaultModel()).toBe("claude-sonnet-4-20250514");
+  });
+
+  it("should use custom model when specified", async () => {
+    const { createAnthropicProvider } = await import("../src/providers/index.js");
+    const provider = createAnthropicProvider({ apiKey: "test-key", model: "claude-haiku-4-5-20251001" });
+    expect(provider.defaultModel()).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("should call Anthropic API with correct headers", async () => {
+    const { createAnthropicProvider } = await import("../src/providers/index.js");
+    const provider = createAnthropicProvider({ apiKey: "sk-ant-test" });
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "Hello" }],
+        model: "claude-sonnet-4-20250514",
+        usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await provider.complete({ systemPrompt: "system", userPrompt: "hello" });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.anthropic.com/v1/messages");
+    expect(opts.headers["x-api-key"]).toBe("sk-ant-test");
+    expect(opts.headers["anthropic-version"]).toBe("2023-06-01");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should parse Anthropic response correctly", async () => {
+    const { createAnthropicProvider } = await import("../src/providers/index.js");
+    const provider = createAnthropicProvider({ apiKey: "test-key" });
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "Test response" }],
+        model: "claude-sonnet-4-20250514",
+        usage: { input_tokens: 15, output_tokens: 8 },
+      }),
+    }));
+
+    const result = await provider.complete({ systemPrompt: "sys", userPrompt: "test" });
+    expect(result.text).toBe("Test response");
+    expect(result.model).toBe("claude-sonnet-4-20250514");
+    expect(result.usage).toEqual({ input: 15, output: 8 });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should throw ProviderError on API failure", async () => {
+    const { createAnthropicProvider } = await import("../src/providers/index.js");
+    const provider = createAnthropicProvider({ apiKey: "test-key" });
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => "Unauthorized",
+    }));
+
+    await expect(
+      provider.complete({ systemPrompt: "sys", userPrompt: "test" }),
+    ).rejects.toThrow("Anthropic API error 401");
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. OpenAI-Compatible Provider
+// ---------------------------------------------------------------------------
+
+describe("OpenAICompatibleProvider", () => {
+  it("should implement LLMProvider interface", async () => {
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
+    const provider = createOpenAICompatibleProvider({ apiKey: "test-key" });
+    expect(provider.name).toBe("openai-compatible");
+    expect(typeof provider.defaultModel).toBe("function");
+    expect(typeof provider.complete).toBe("function");
+  });
+
+  it("should use default model gpt-4o when none specified", async () => {
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
+    const provider = createOpenAICompatibleProvider({ apiKey: "test-key" });
+    expect(provider.defaultModel()).toBe("gpt-4o");
+  });
+
+  it("should use custom model and base URL", async () => {
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
+    const provider = createOpenAICompatibleProvider({
+      apiKey: "test-key",
+      model: "llama3.1",
+      baseUrl: "http://localhost:11434/v1",
+    });
+    expect(provider.defaultModel()).toBe("llama3.1");
+  });
+
+  it("should call OpenAI chat completions endpoint", async () => {
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
+    const provider = createOpenAICompatibleProvider({
+      apiKey: "sk-test",
+      baseUrl: "https://api.openai.com/v1",
+    });
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "Hello from GPT" } }],
+        model: "gpt-4o",
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await provider.complete({ systemPrompt: "system", userPrompt: "hello" });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.openai.com/v1/chat/completions");
+    const body = JSON.parse(opts.body);
+    expect(body.messages).toEqual([
+      { role: "system", content: "system" },
+      { role: "user", content: "hello" },
+    ]);
+    expect(opts.headers["Authorization"]).toBe("Bearer sk-test");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should parse OpenAI response correctly", async () => {
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
+    const provider = createOpenAICompatibleProvider({ apiKey: "test-key" });
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "GPT response" } }],
+        model: "gpt-4o",
+        usage: { prompt_tokens: 20, completion_tokens: 10 },
+      }),
+    }));
+
+    const result = await provider.complete({ systemPrompt: "sys", userPrompt: "test" });
+    expect(result.text).toBe("GPT response");
+    expect(result.model).toBe("gpt-4o");
+    expect(result.usage).toEqual({ input: 20, output: 10 });
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should throw ProviderError on API failure", async () => {
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
+    const provider = createOpenAICompatibleProvider({ apiKey: "test-key" });
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => "Rate limited",
+    }));
+
+    await expect(
+      provider.complete({ systemPrompt: "sys", userPrompt: "test" }),
+    ).rejects.toThrow("OpenAI API error 429");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should default base URL to OpenAI when not specified", async () => {
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
+    const provider = createOpenAICompatibleProvider({ apiKey: "sk-test" });
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "ok" } }],
+        model: "gpt-4o",
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await provider.complete({ systemPrompt: "s", userPrompt: "u" });
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://api.openai.com/v1/chat/completions");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should strip trailing slash from base URL", async () => {
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
+    const provider = createOpenAICompatibleProvider({
+      apiKey: "sk-test",
+      baseUrl: "http://localhost:8000/v1/",
+    });
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "ok" } }],
+        model: "local",
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await provider.complete({ systemPrompt: "s", userPrompt: "u" });
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe("http://localhost:8000/v1/chat/completions");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("should pass model override from complete() opts", async () => {
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
+    const provider = createOpenAICompatibleProvider({
+      apiKey: "test-key",
+      model: "gpt-4o",
+    });
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "ok" } }],
+        model: "gpt-4o-mini",
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await provider.complete({ systemPrompt: "s", userPrompt: "u", model: "gpt-4o-mini" });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.model).toBe("gpt-4o-mini");
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Provider Factory
+// ---------------------------------------------------------------------------
+
+describe("createProvider", () => {
+  it("should create anthropic provider by default", async () => {
+    const { createProvider } = await import("../src/providers/index.js");
+    const provider = createProvider({ providerType: "anthropic", apiKey: "test-key" });
+    expect(provider.name).toBe("anthropic");
+  });
+
+  it("should create openai-compatible provider", async () => {
+    const { createProvider } = await import("../src/providers/index.js");
+    const provider = createProvider({
+      providerType: "openai-compatible",
+      apiKey: "test-key",
+      baseUrl: "https://api.openai.com/v1",
+    });
+    expect(provider.name).toBe("openai-compatible");
+  });
+
+  it("should create openai provider (alias for openai-compatible)", async () => {
+    const { createProvider } = await import("../src/providers/index.js");
+    const provider = createProvider({ providerType: "openai", apiKey: "test-key" });
+    expect(provider.name).toBe("openai-compatible");
+  });
+
+  it("should create ollama provider with default base URL", async () => {
+    const { createProvider } = await import("../src/providers/index.js");
+    const provider = createProvider({ providerType: "ollama" });
+    expect(provider.name).toBe("openai-compatible");
+    expect(provider.defaultModel()).toBe("llama3.1");
+  });
+
+  it("should create vllm provider with default base URL", async () => {
+    const { createProvider } = await import("../src/providers/index.js");
+    const provider = createProvider({ providerType: "vllm" });
+    expect(provider.name).toBe("openai-compatible");
+    expect(provider.defaultModel()).toBe("default");
+  });
+
+  it("should throw ProviderError for unknown type", async () => {
+    const { createProvider } = await import("../src/providers/index.js");
+    expect(() => createProvider({ providerType: "unknown" as any })).toThrow("Unknown provider type");
+  });
+
+  it("should pass model through to provider", async () => {
+    const { createProvider } = await import("../src/providers/index.js");
+    const provider = createProvider({
+      providerType: "openai-compatible",
+      apiKey: "k",
+      model: "my-custom-model",
+    });
+    expect(provider.defaultModel()).toBe("my-custom-model");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. CLI getProvider integration (env var routing)
+// ---------------------------------------------------------------------------
+
+describe("CLI provider routing", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Reset env for each test
+    delete process.env.AUTOCONTEXT_PROVIDER;
+    delete process.env.AUTOCONTEXT_BASE_URL;
+    delete process.env.AUTOCONTEXT_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.AUTOCONTEXT_MODEL;
+  });
+
+  afterEach(() => {
+    // Restore original env
+    process.env = { ...originalEnv };
+  });
+
+  it("should default to anthropic when AUTOCONTEXT_PROVIDER is unset", async () => {
+    const { resolveProviderConfig } = await import("../src/providers/index.js");
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+
+    const config = resolveProviderConfig();
+    expect(config.providerType).toBe("anthropic");
+    expect(config.apiKey).toBe("sk-ant-test");
+  });
+
+  it("should use AUTOCONTEXT_PROVIDER to select openai-compatible", async () => {
+    const { resolveProviderConfig } = await import("../src/providers/index.js");
+    process.env.AUTOCONTEXT_PROVIDER = "openai-compatible";
+    process.env.OPENAI_API_KEY = "sk-openai-test";
+
+    const config = resolveProviderConfig();
+    expect(config.providerType).toBe("openai-compatible");
+    expect(config.apiKey).toBe("sk-openai-test");
+  });
+
+  it("should prefer AUTOCONTEXT_API_KEY over provider-specific keys", async () => {
+    const { resolveProviderConfig } = await import("../src/providers/index.js");
+    process.env.AUTOCONTEXT_PROVIDER = "openai";
+    process.env.AUTOCONTEXT_API_KEY = "generic-key";
+    process.env.OPENAI_API_KEY = "specific-key";
+
+    const config = resolveProviderConfig();
+    expect(config.apiKey).toBe("generic-key");
+  });
+
+  it("should use AUTOCONTEXT_BASE_URL for custom endpoints", async () => {
+    const { resolveProviderConfig } = await import("../src/providers/index.js");
+    process.env.AUTOCONTEXT_PROVIDER = "openai-compatible";
+    process.env.AUTOCONTEXT_BASE_URL = "https://openrouter.ai/api/v1";
+    process.env.AUTOCONTEXT_API_KEY = "key";
+
+    const config = resolveProviderConfig();
+    expect(config.baseUrl).toBe("https://openrouter.ai/api/v1");
+  });
+
+  it("should use AUTOCONTEXT_MODEL for model override", async () => {
+    const { resolveProviderConfig } = await import("../src/providers/index.js");
+    process.env.AUTOCONTEXT_PROVIDER = "openai";
+    process.env.AUTOCONTEXT_MODEL = "gpt-4o-mini";
+    process.env.OPENAI_API_KEY = "key";
+
+    const config = resolveProviderConfig();
+    expect(config.model).toBe("gpt-4o-mini");
+  });
+
+  it("should error when anthropic selected but no API key", async () => {
+    const { resolveProviderConfig } = await import("../src/providers/index.js");
+    process.env.AUTOCONTEXT_PROVIDER = "anthropic";
+
+    expect(() => resolveProviderConfig()).toThrow("ANTHROPIC_API_KEY");
+  });
+
+  it("should error when openai selected but no API key", async () => {
+    const { resolveProviderConfig } = await import("../src/providers/index.js");
+    process.env.AUTOCONTEXT_PROVIDER = "openai";
+
+    expect(() => resolveProviderConfig()).toThrow("API key");
+  });
+
+  it("should not require API key for ollama", async () => {
+    const { resolveProviderConfig } = await import("../src/providers/index.js");
+    process.env.AUTOCONTEXT_PROVIDER = "ollama";
+
+    const config = resolveProviderConfig();
+    expect(config.providerType).toBe("ollama");
+  });
+});


### PR DESCRIPTION
## Summary
- New `ts/src/providers/` module with `createAnthropicProvider()`, `createOpenAICompatibleProvider()`, `createProvider()` factory, and `resolveProviderConfig()` for env-based routing
- Supports `anthropic`, `openai`, `openai-compatible`, `ollama`, `vllm` provider types
- CLI `getProvider()` now reads `AUTOCONTEXT_PROVIDER`, `AUTOCONTEXT_BASE_URL`, `AUTOCONTEXT_API_KEY` env vars
- Anthropic remains the default provider; no new npm dependencies (uses native `fetch`)
- All providers implement the existing `LLMProvider` interface — downstream judge/improve/serve paths work unchanged

## Environment Variables
| Variable | Description | Default |
|----------|-------------|---------|
| `AUTOCONTEXT_PROVIDER` | Provider type | `anthropic` |
| `AUTOCONTEXT_API_KEY` | Generic API key (overrides provider-specific) | — |
| `AUTOCONTEXT_BASE_URL` | Custom endpoint URL | provider default |
| `AUTOCONTEXT_MODEL` | Model override | provider default |
| `ANTHROPIC_API_KEY` | Anthropic-specific key | — |
| `OPENAI_API_KEY` | OpenAI-specific key | — |

## Test plan
- [x] 30 tests in `tests/providers.test.ts` covering Anthropic provider, OpenAI-compatible provider, factory, and CLI env routing
- [x] `tsc --noEmit` clean
- [x] Full suite: 392 passed (29 files), 1 pre-existing failure in smoke-judge.test.ts (MTS→AutoContext rename artifact)