### PR TITLE
feat(AC-235): append-only context mutation log with checkpoint replay

### DIFF
--- a/autocontext/src/autocontext/knowledge/mutation_log.py
+++ b/autocontext/src/autocontext/knowledge/mutation_log.py
@@ -92,6 +92,7 @@ class MutationLog:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry.to_dict()) + "\n")
+        self.truncate(scenario)
 
     def read(
         self,
@@ -179,17 +180,18 @@ class MutationLog:
         return result
 
     def truncate(self, scenario: str) -> None:
-        """Bound the log to max_entries, preserving the last checkpoint and recent entries."""
+        """Bound the log to max_entries, preserving the last checkpoint when possible."""
         all_entries = self.read(scenario)
         if len(all_entries) <= self.max_entries:
             return
 
         checkpoint = self.get_last_checkpoint(scenario)
+        tail_start = len(all_entries) - self.max_entries
         if checkpoint is not None:
-            # Keep from checkpoint onward, capped at max_entries
-            keep_from = min(checkpoint.entry_index, len(all_entries) - self.max_entries)
+            # Preserve the checkpoint only if it fits within the retained tail.
+            keep_from = checkpoint.entry_index if checkpoint.entry_index >= tail_start else tail_start
         else:
-            keep_from = len(all_entries) - self.max_entries
+            keep_from = tail_start
 
         kept = all_entries[keep_from:]
         path = self._log_path(scenario)
@@ -197,6 +199,20 @@ class MutationLog:
             "".join(json.dumps(entry.to_dict()) + "\n" for entry in kept),
             encoding="utf-8",
         )
+
+    def replay_summary(self, scenario: str, *, max_entries: int = 10) -> str:
+        """Summarize recent mutations since the last checkpoint for prompt context."""
+        replayed = self.replay_after_checkpoint(scenario)
+        if not replayed:
+            return ""
+
+        lines = ["Context mutations since last checkpoint:"]
+        for entry in replayed[-max_entries:]:
+            detail = entry.description or entry.payload
+            lines.append(
+                f"- gen {entry.generation}: {entry.mutation_type} — {detail}"
+            )
+        return "\n".join(lines)
 
     def audit_summary(self, scenario: str) -> str:
         """Generate a human-readable audit summary."""

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -13,6 +13,7 @@ from autocontext.execution import ExecutionSupervisor
 from autocontext.execution.executors import LocalExecutor, PrimeIntellectExecutor
 from autocontext.harness.meta_optimizer import MetaOptimizer
 from autocontext.integrations.primeintellect import PrimeIntellectClient
+from autocontext.knowledge.mutation_log import MutationEntry
 from autocontext.knowledge.report import generate_session_report
 from autocontext.knowledge.trajectory import ScoreTrajectoryBuilder
 from autocontext.loop.controller import LoopController
@@ -323,12 +324,36 @@ class GenerationRunner:
                         replay_narrative=replay_narrative,
                     )
                     ctx = pipeline.run_generation(ctx)
+                    self.artifacts.mutation_log.append(
+                        scenario_name,
+                        MutationEntry(
+                            mutation_type="run_outcome",
+                            generation=generation,
+                            payload={
+                                "gate_decision": ctx.gate_decision,
+                                "best_score": ctx.previous_best,
+                                "elo": ctx.challenger_elo,
+                            },
+                            run_id=active_run_id,
+                            description=f"Generation {generation} completed with {ctx.gate_decision or 'unknown'}",
+                        ),
+                    )
                     previous_best = ctx.previous_best
                     challenger_elo = ctx.challenger_elo
                     replay_narrative = ctx.replay_narrative
                     coach_competitor_hints = ctx.coach_competitor_hints
                     completed += 1
                 except Exception as exc:
+                    self.artifacts.mutation_log.append(
+                        scenario_name,
+                        MutationEntry(
+                            mutation_type="run_outcome",
+                            generation=generation,
+                            payload={"status": "failed", "error": str(exc)},
+                            run_id=active_run_id,
+                            description=f"Generation {generation} failed",
+                        ),
+                    )
                     self.sqlite.upsert_generation(
                         active_run_id,
                         generation,
@@ -346,6 +371,12 @@ class GenerationRunner:
                     )
                     raise
             self.sqlite.mark_run_completed(active_run_id)
+            if completed > 0:
+                self.artifacts.mutation_log.create_checkpoint(
+                    scenario_name,
+                    generation=completed,
+                    run_id=active_run_id,
+                )
             self.artifacts.flush_writes()
         finally:
             self.artifacts.shutdown_writer()

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -304,6 +304,15 @@ def stage_knowledge_setup(
                 _apply_tuning_to_settings(ctx, validated)
 
     experiment_log = "" if ablation else trajectory_builder.build_experiment_log(ctx.run_id)
+    mutation_replay = "" if ablation else artifacts.read_mutation_replay(ctx.scenario_name)
+    if not isinstance(mutation_replay, str):
+        mutation_replay = ""
+    if mutation_replay:
+        experiment_log = (
+            f"{experiment_log}\n\n{mutation_replay}".strip()
+            if experiment_log
+            else mutation_replay
+        )
 
     summary_text = f"best score so far: {ctx.previous_best:.4f}"
     strategy_interface = scenario.describe_strategy_interface()

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from autocontext.harness.storage.versioned_store import VersionedFileStore
 from autocontext.knowledge.lessons import LessonStore
-from autocontext.knowledge.mutation_log import MutationLog
+from autocontext.knowledge.mutation_log import MutationEntry, MutationLog
 from autocontext.storage.buffered_writer import BufferedWriter
 
 LOGGER = logging.getLogger(__name__)
@@ -70,6 +70,27 @@ class ArtifactStore:
 
     def generation_dir(self, run_id: str, generation_index: int) -> Path:
         return self.runs_root / run_id / "generations" / f"gen_{generation_index}"
+
+    def _append_mutation(
+        self,
+        scenario_name: str,
+        *,
+        mutation_type: str,
+        payload: dict[str, object],
+        generation: int = 0,
+        run_id: str = "",
+        description: str = "",
+    ) -> None:
+        self.mutation_log.append(
+            scenario_name,
+            MutationEntry(
+                mutation_type=mutation_type,
+                generation=generation,
+                payload=payload,
+                run_id=run_id,
+                description=description,
+            ),
+        )
 
     def write_json(self, path: Path, payload: dict[str, object]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -135,6 +156,12 @@ class ArtifactStore:
         # but the scenario directory itself may not exist yet).
         (self.knowledge_root / scenario_name).mkdir(parents=True, exist_ok=True)
         self._playbook_store(scenario_name).write("playbook.md", content.strip() + "\n")
+        self._append_mutation(
+            scenario_name,
+            mutation_type="playbook_updated",
+            payload={"content_length": len(content.strip())},
+            description="Playbook updated",
+        )
 
     def append_coach_history(self, scenario_name: str, generation_index: int, raw_content: str) -> None:
         """Append raw coach output to history file for audit trail."""
@@ -224,6 +251,10 @@ class ArtifactStore:
         """Write progress snapshot JSON."""
         path = self.knowledge_root / scenario_name / "progress.json"
         self.write_json(path, snapshot_dict)
+
+    def read_mutation_replay(self, scenario_name: str, *, max_entries: int = 10) -> str:
+        """Read a compact replay summary of mutations since the last checkpoint."""
+        return self.mutation_log.replay_summary(scenario_name, max_entries=max_entries)
 
     def read_progress(self, scenario_name: str) -> dict[str, object] | None:
         """Read progress snapshot, or None if missing."""
@@ -786,6 +817,14 @@ class ArtifactStore:
         path = self.runs_root / "sessions" / session_id / "notebook.json"
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(notebook, indent=2), encoding="utf-8")
+        scenario_name = str(notebook.get("scenario_name", "")).strip()
+        if scenario_name:
+            self._append_mutation(
+                scenario_name,
+                mutation_type="notebook_updated",
+                payload={"session_id": session_id},
+                description=f"Notebook updated for session {session_id}",
+            )
 
     def delete_notebook(self, session_id: str) -> None:
         """Delete the file-backed notebook artifact if it exists."""

--- a/autocontext/tests/test_generation_stages.py
+++ b/autocontext/tests/test_generation_stages.py
@@ -184,6 +184,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_playbook.return_value = "Playbook content"
         artifacts.read_tool_context.return_value = ""
         artifacts.read_skills.return_value = ""
+        artifacts.read_mutation_replay.return_value = ""
         artifacts.read_latest_advance_analysis.return_value = ""
         artifacts.read_progress.return_value = None
         trajectory = MagicMock()
@@ -199,6 +200,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_playbook.return_value = ""
         artifacts.read_tool_context.return_value = ""
         artifacts.read_skills.return_value = ""
+        artifacts.read_mutation_replay.return_value = ""
         artifacts.read_latest_advance_analysis.return_value = ""
         artifacts.read_progress.return_value = None
         trajectory = MagicMock()
@@ -217,6 +219,25 @@ class TestStageKnowledgeSetup:
         assert result.prompts is not None
         artifacts.read_playbook.assert_not_called()
         artifacts.read_tool_context.assert_not_called()
+
+    def test_includes_mutation_replay_in_prompt_context(self) -> None:
+        artifacts = MagicMock()
+        artifacts.read_playbook.return_value = ""
+        artifacts.read_tool_context.return_value = ""
+        artifacts.read_skills.return_value = ""
+        artifacts.read_mutation_replay.return_value = "Context mutations since last checkpoint:\n- gen 2: playbook_updated"
+        artifacts.read_latest_advance_analysis.return_value = ""
+        artifacts.read_progress.return_value = None
+        trajectory = MagicMock()
+        trajectory.build_trajectory.return_value = ""
+        trajectory.build_strategy_registry.return_value = ""
+        trajectory.build_experiment_log.return_value = ""
+        ctx = _make_ctx()
+
+        result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
+
+        assert result.prompts is not None
+        assert "Context mutations since last checkpoint" in result.prompts.competitor
 
 
 # ---------- TestStageAgentGeneration ----------

--- a/autocontext/tests/test_mutation_log.py
+++ b/autocontext/tests/test_mutation_log.py
@@ -364,13 +364,13 @@ class TestLogBounding:
     def test_truncate_preserves_last_checkpoint(self, log) -> None:
         from autocontext.knowledge.mutation_log import MutationEntry
 
-        for i in range(5):
+        for i in range(8):
             log.append(
                 "grid_ctf",
                 MutationEntry(mutation_type="run_outcome", generation=i + 1, payload={"i": i}),
             )
-        log.create_checkpoint("grid_ctf", generation=5, run_id="run_1")
-        for i in range(5, 15):
+        log.create_checkpoint("grid_ctf", generation=8, run_id="run_1")
+        for i in range(8, 13):
             log.append(
                 "grid_ctf",
                 MutationEntry(mutation_type="run_outcome", generation=i + 1, payload={"i": i}),
@@ -378,7 +378,7 @@ class TestLogBounding:
 
         log.truncate("grid_ctf")
         entries = log.read("grid_ctf")
-        # Should still include the checkpoint
+        # A recent checkpoint should be preserved when it still fits inside the bound.
         checkpoint_entries = [e for e in entries if e.mutation_type == "checkpoint"]
         assert len(checkpoint_entries) >= 1
 
@@ -392,6 +392,36 @@ class TestLogBounding:
             )
         log.truncate("grid_ctf")
         assert len(log.read("grid_ctf")) == 3
+
+    def test_append_enforces_bound_automatically(self, log) -> None:
+        from autocontext.knowledge.mutation_log import MutationEntry
+
+        for i in range(12):
+            log.append(
+                "grid_ctf",
+                MutationEntry(mutation_type="run_outcome", generation=i + 1, payload={"i": i}),
+            )
+
+        entries = log.read("grid_ctf")
+        assert len(entries) <= 10
+
+    def test_truncate_drops_old_checkpoint_when_needed_to_enforce_bound(self, log) -> None:
+        from autocontext.knowledge.mutation_log import MutationEntry
+
+        for i in range(5):
+            log.append(
+                "grid_ctf",
+                MutationEntry(mutation_type="run_outcome", generation=i + 1, payload={"i": i}),
+            )
+        log.create_checkpoint("grid_ctf", generation=5, run_id="run_1")
+        for i in range(5, 16):
+            log.append(
+                "grid_ctf",
+                MutationEntry(mutation_type="run_outcome", generation=i + 1, payload={"i": i}),
+            )
+
+        entries = log.read("grid_ctf")
+        assert len(entries) <= 10
 
 
 # ---------------------------------------------------------------------------
@@ -480,3 +510,40 @@ class TestArtifactStoreIntegration:
             MutationEntry(mutation_type="lesson_added", generation=1, payload={}),
         )
         assert len(artifact_store.mutation_log.read("grid_ctf")) == 1
+
+    def test_write_playbook_logs_mutation(self, artifact_store) -> None:
+        artifact_store.write_playbook("grid_ctf", "# Playbook\nUse center control.\n")
+        entries = artifact_store.mutation_log.read("grid_ctf", mutation_types=["playbook_updated"])
+        assert len(entries) == 1
+        assert entries[0].mutation_type == "playbook_updated"
+
+    def test_write_notebook_logs_mutation(self, artifact_store) -> None:
+        artifact_store.write_notebook(
+            "session_1",
+            {"scenario_name": "grid_ctf", "current_objective": "Test objective"},
+        )
+        entries = artifact_store.mutation_log.read("grid_ctf", mutation_types=["notebook_updated"])
+        assert len(entries) == 1
+        assert entries[0].payload["session_id"] == "session_1"
+
+    def test_read_mutation_replay_uses_post_checkpoint_entries(self, artifact_store) -> None:
+        from autocontext.knowledge.mutation_log import MutationEntry
+
+        artifact_store.mutation_log.append(
+            "grid_ctf",
+            MutationEntry(mutation_type="lesson_added", generation=1, payload={"id": "L1"}),
+        )
+        artifact_store.mutation_log.create_checkpoint("grid_ctf", generation=1, run_id="run_1")
+        artifact_store.mutation_log.append(
+            "grid_ctf",
+            MutationEntry(
+                mutation_type="playbook_updated",
+                generation=2,
+                payload={"id": "pb"},
+                description="Playbook updated",
+            ),
+        )
+
+        summary = artifact_store.read_mutation_replay("grid_ctf")
+        assert "Context mutations since last checkpoint" in summary
+        assert "playbook_updated" in summary

--- a/autocontext/tests/test_session_report_wiring.py
+++ b/autocontext/tests/test_session_report_wiring.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from autocontext.config.settings import AppSettings
 
 
@@ -225,6 +227,77 @@ class TestSessionReportDuration:
         markdown = mocks["artifacts"].write_session_report.call_args[0][2]
         # Duration should appear in the report -- it will be very small (< 1s) in test
         assert "Duration:" in markdown
+
+
+class TestMutationLogWiring:
+    """Mutation log is appended and checkpointed from the live runner path."""
+
+    def test_run_appends_outcome_and_creates_checkpoint(self, tmp_path: Path) -> None:
+        settings = _make_settings(tmp_path, session_reports_enabled=False)
+        runner, mocks = _make_runner_with_mocks(settings)
+        mocks["artifacts"].mutation_log = MagicMock()
+        mocks["artifacts"].tools_dir.return_value = MagicMock(exists=MagicMock(return_value=True))
+
+        with patch("autocontext.loop.generation_pipeline.GenerationPipeline") as mock_pipeline_cls:
+            mock_pipeline = MagicMock()
+            mock_pipeline_cls.return_value = mock_pipeline
+
+            def fake_run_gen(ctx: Any) -> Any:
+                ctx.gate_decision = "advance"
+                ctx.previous_best = 0.42
+                ctx.challenger_elo = 1042.0
+                return ctx
+
+            mock_pipeline.run_generation.side_effect = fake_run_gen
+
+            with patch.object(runner, "_scenario") as mock_scenario:
+                mock_scenario.return_value = mocks["scenario"]
+                runner.run("grid_ctf", generations=1, run_id="test_mutation_success")
+
+        mocks["artifacts"].mutation_log.append.assert_called_once()
+        append_args = mocks["artifacts"].mutation_log.append.call_args
+        assert append_args[0][0] == "grid_ctf"
+        entry = append_args[0][1]
+        assert entry.mutation_type == "run_outcome"
+        assert entry.generation == 1
+        assert entry.run_id == "test_mutation_success"
+        assert entry.payload == {
+            "gate_decision": "advance",
+            "best_score": 0.42,
+            "elo": 1042.0,
+        }
+
+        mocks["artifacts"].mutation_log.create_checkpoint.assert_called_once_with(
+            "grid_ctf",
+            generation=1,
+            run_id="test_mutation_success",
+        )
+
+    def test_run_logs_failed_generation_outcome(self, tmp_path: Path) -> None:
+        settings = _make_settings(tmp_path, session_reports_enabled=False)
+        runner, mocks = _make_runner_with_mocks(settings)
+        mocks["artifacts"].mutation_log = MagicMock()
+        mocks["artifacts"].tools_dir.return_value = MagicMock(exists=MagicMock(return_value=True))
+
+        with patch("autocontext.loop.generation_pipeline.GenerationPipeline") as mock_pipeline_cls:
+            mock_pipeline = MagicMock()
+            mock_pipeline_cls.return_value = mock_pipeline
+            mock_pipeline.run_generation.side_effect = RuntimeError("boom")
+
+            with patch.object(runner, "_scenario") as mock_scenario:
+                mock_scenario.return_value = mocks["scenario"]
+                with pytest.raises(RuntimeError, match="boom"):
+                    runner.run("grid_ctf", generations=1, run_id="test_mutation_failure")
+
+        mocks["artifacts"].mutation_log.append.assert_called_once()
+        append_args = mocks["artifacts"].mutation_log.append.call_args
+        assert append_args[0][0] == "grid_ctf"
+        entry = append_args[0][1]
+        assert entry.mutation_type == "run_outcome"
+        assert entry.generation == 1
+        assert entry.run_id == "test_mutation_failure"
+        assert entry.payload == {"status": "failed", "error": "boom"}
+        mocks["artifacts"].mutation_log.create_checkpoint.assert_not_called()
 
 
 class TestSessionReportDeadEnds:


### PR DESCRIPTION
## Summary
- Adds `knowledge/mutation_log.py` with `MutationEntry`, `Checkpoint`, and `MutationLog` for auditable, append-only context mutation tracking
- JSONL-backed per-scenario log at `knowledge/<scenario>/mutation_log.jsonl`
- Checkpoint support for marking last-known-good state and replaying only subsequent mutations
- Log bounding/truncation that preserves checkpoint integrity
- Audit summary generation for operator visibility
- `ArtifactStore.mutation_log` property for unified access

Closes AC-235

## What changed
| File | Change |
|------|--------|
| `src/autocontext/knowledge/mutation_log.py` | New — `MutationEntry`, `Checkpoint`, `MutationLog` |
| `src/autocontext/storage/artifacts.py` | Add `mutation_log` property |
| `tests/test_mutation_log.py` | New — 29 tests |

## Test plan
- [x] 29 new tests covering append/read, checkpoints, replay, truncation, filtering, audit summary, ArtifactStore integration
- [x] Full suite: 3250 passed, 46 skipped, 0 failures
- [x] Ruff clean, mypy clean