### PR TITLE
feat(AC-196): weakness reports for recurring failure pattern analysis

### DIFF
--- a/autocontext/src/autocontext/knowledge/weakness.py
+++ b/autocontext/src/autocontext/knowledge/weakness.py
@@ -21,7 +21,6 @@ WEAKNESS_CATEGORIES = frozenset({
     "match_variance",
     "stagnation_risk",
     "dead_end_pattern",
-    "strategy_repetition",
 })
 
 

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -16,6 +16,7 @@ from autocontext.integrations.primeintellect import PrimeIntellectClient
 from autocontext.knowledge.mutation_log import MutationEntry
 from autocontext.knowledge.report import generate_session_report
 from autocontext.knowledge.trajectory import ScoreTrajectoryBuilder
+from autocontext.knowledge.weakness import WeaknessAnalyzer
 from autocontext.loop.controller import LoopController
 from autocontext.loop.events import EventStreamEmitter
 from autocontext.scenarios import SCENARIO_REGISTRY
@@ -199,6 +200,19 @@ class GenerationRunner:
         )
         markdown = report.to_markdown()
         self.artifacts.write_session_report(scenario_name, run_id, markdown)
+
+    def _generate_weakness_report(self, run_id: str, scenario_name: str) -> None:
+        """Generate and persist a weakness report for a completed run."""
+        trajectory_rows = self.sqlite.get_generation_trajectory(run_id)
+        match_rows = self.sqlite.get_matches_for_run(run_id)
+        analyzer = WeaknessAnalyzer()
+        report = analyzer.analyze(
+            run_id=run_id,
+            scenario=scenario_name,
+            trajectory=trajectory_rows,
+            match_data=match_rows,
+        )
+        self.artifacts.write_weakness_report(scenario_name, run_id, report)
 
     def run(self, scenario_name: str, generations: int, run_id: str | None = None) -> RunSummary:
         scenario = self._scenario(scenario_name)
@@ -388,6 +402,10 @@ class GenerationRunner:
                 self._generate_session_report(active_run_id, scenario_name, duration)
             except Exception:
                 LOGGER.warning("failed to generate session report for run %s", active_run_id, exc_info=True)
+        try:
+            self._generate_weakness_report(active_run_id, scenario_name)
+        except Exception:
+            LOGGER.warning("failed to generate weakness report for run %s", active_run_id, exc_info=True)
 
         # Snapshot knowledge for cross-run inheritance
         if self.settings.cross_run_inheritance and not self.settings.ablation_no_feedback:

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -267,6 +267,7 @@ def stage_knowledge_setup(
     tool_context = "" if ablation else artifacts.read_tool_context(ctx.scenario_name)
     skills_context = "" if ablation else artifacts.read_skills(ctx.scenario_name)
     recent_analysis = "" if ablation else artifacts.read_latest_advance_analysis(ctx.scenario_name, ctx.generation)
+    weakness_reports = "" if ablation else artifacts.read_latest_weakness_reports_markdown(ctx.scenario_name)
     score_trajectory = "" if ablation else trajectory_builder.build_trajectory(ctx.run_id)
     strategy_registry = "" if ablation else trajectory_builder.build_strategy_registry(ctx.run_id)
 
@@ -312,6 +313,12 @@ def stage_knowledge_setup(
             f"{experiment_log}\n\n{mutation_replay}".strip()
             if experiment_log
             else mutation_replay
+        )
+    if weakness_reports:
+        experiment_log = (
+            f"{experiment_log}\n\nRecent weakness reports:\n{weakness_reports}".strip()
+            if experiment_log
+            else f"Recent weakness reports:\n{weakness_reports}"
         )
 
     summary_text = f"best score so far: {ctx.previous_best:.4f}"

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -755,6 +755,19 @@ class ArtifactStore:
             reports.append(WeaknessReport.from_dict(data))
         return reports
 
+    def read_latest_weakness_reports_markdown(self, scenario_name: str, max_reports: int = 2) -> str:
+        """Read recent weakness reports and concatenate them as markdown."""
+        from autocontext.knowledge.weakness import WeaknessReport
+
+        reports = self.read_latest_weakness_reports(scenario_name, max_reports=max_reports)
+        if not reports:
+            return ""
+        markdown_parts: list[str] = []
+        for report in reports:
+            if isinstance(report, WeaknessReport):
+                markdown_parts.append(report.to_markdown())
+        return "\n\n".join(markdown_parts)
+
     def read_latest_session_reports(self, scenario_name: str, max_reports: int = 2) -> str:
         """Read the most recent session reports, concatenated."""
         reports_dir = self.knowledge_root / scenario_name / "reports"

--- a/autocontext/tests/test_generation_stages.py
+++ b/autocontext/tests/test_generation_stages.py
@@ -185,6 +185,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_tool_context.return_value = ""
         artifacts.read_skills.return_value = ""
         artifacts.read_mutation_replay.return_value = ""
+        artifacts.read_latest_weakness_reports_markdown.return_value = ""
         artifacts.read_latest_advance_analysis.return_value = ""
         artifacts.read_progress.return_value = None
         trajectory = MagicMock()
@@ -201,6 +202,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_tool_context.return_value = ""
         artifacts.read_skills.return_value = ""
         artifacts.read_mutation_replay.return_value = ""
+        artifacts.read_latest_weakness_reports_markdown.return_value = ""
         artifacts.read_latest_advance_analysis.return_value = ""
         artifacts.read_progress.return_value = None
         trajectory = MagicMock()
@@ -226,6 +228,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_tool_context.return_value = ""
         artifacts.read_skills.return_value = ""
         artifacts.read_mutation_replay.return_value = "Context mutations since last checkpoint:\n- gen 2: playbook_updated"
+        artifacts.read_latest_weakness_reports_markdown.return_value = ""
         artifacts.read_latest_advance_analysis.return_value = ""
         artifacts.read_progress.return_value = None
         trajectory = MagicMock()
@@ -238,6 +241,31 @@ class TestStageKnowledgeSetup:
 
         assert result.prompts is not None
         assert "Context mutations since last checkpoint" in result.prompts.competitor
+
+    def test_includes_recent_weakness_reports_in_prompt_context(self) -> None:
+        artifacts = MagicMock()
+        artifacts.read_playbook.return_value = ""
+        artifacts.read_tool_context.return_value = ""
+        artifacts.read_skills.return_value = ""
+        artifacts.read_mutation_replay.return_value = ""
+        artifacts.read_latest_weakness_reports_markdown.return_value = (
+            "# Weakness Report: run_1\n"
+            "## [HIGH] dead_end_pattern\n"
+            "Repeated rollbacks detected"
+        )
+        artifacts.read_latest_advance_analysis.return_value = ""
+        artifacts.read_progress.return_value = None
+        trajectory = MagicMock()
+        trajectory.build_trajectory.return_value = ""
+        trajectory.build_strategy_registry.return_value = ""
+        trajectory.build_experiment_log.return_value = ""
+        ctx = _make_ctx()
+
+        result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
+
+        assert result.prompts is not None
+        assert "Recent weakness reports:" in result.prompts.competitor
+        assert "dead_end_pattern" in result.prompts.competitor
 
 
 # ---------- TestStageAgentGeneration ----------

--- a/autocontext/tests/test_session_report_wiring.py
+++ b/autocontext/tests/test_session_report_wiring.py
@@ -189,6 +189,41 @@ class TestSessionReportPersistence:
         assert len(call_args[0][2]) > 0
 
 
+class TestWeaknessReportWiring:
+    """Weakness reports are generated from the live run completion path."""
+
+    def test_weakness_report_generated_on_run_completion(self, tmp_path: Path) -> None:
+        settings = _make_settings(tmp_path, session_reports_enabled=False)
+        runner, mocks = _make_runner_with_mocks(settings)
+
+        trajectory_rows = [
+            {"generation_index": 1, "best_score": 0.3, "elo": 1000, "delta": 0.0, "gate_decision": "advance"},
+            {"generation_index": 2, "best_score": 0.1, "elo": 980, "delta": -0.2, "gate_decision": "rollback"},
+            {"generation_index": 3, "best_score": 0.2, "elo": 990, "delta": 0.1, "gate_decision": "advance"},
+            {"generation_index": 4, "best_score": 0.05, "elo": 960, "delta": -0.15, "gate_decision": "rollback"},
+            {"generation_index": 5, "best_score": 0.04, "elo": 950, "delta": -0.01, "gate_decision": "rollback"},
+        ]
+        match_rows = [
+            {"generation_index": 2, "score": 0.1, "passed_validation": False, "validation_errors": '["bad action"]'},
+            {"generation_index": 4, "score": 0.05, "passed_validation": False, "validation_errors": '["bad action"]'},
+        ]
+        mocks["sqlite"].get_generation_trajectory.return_value = trajectory_rows
+        mocks["sqlite"].get_matches_for_run.return_value = match_rows
+        mocks["artifacts"].tools_dir.return_value = MagicMock(exists=MagicMock(return_value=True))
+
+        _run_with_pipeline_mock(runner, mocks, "grid_ctf", 5, "test_weakness")
+
+        mocks["artifacts"].write_weakness_report.assert_called_once()
+        call_args = mocks["artifacts"].write_weakness_report.call_args
+        assert call_args[0][0] == "grid_ctf"
+        assert call_args[0][1] == "test_weakness"
+        report = call_args[0][2]
+        assert report.run_id == "test_weakness"
+        assert report.scenario == "grid_ctf"
+        assert report.total_generations == 5
+        assert report.weaknesses
+
+
 class TestSessionReportEmptyTrajectory:
     """Handles empty trajectory (0 completed generations) gracefully."""
 

--- a/autocontext/tests/test_weakness_reports.py
+++ b/autocontext/tests/test_weakness_reports.py
@@ -3,7 +3,7 @@
 Verifies:
 1. Weakness and WeaknessReport dataclass construction and serialization.
 2. WeaknessAnalyzer detects score regressions, validation failures, match variance,
-   strategy repetition, stagnation risk, and dead-end patterns.
+   stagnation risk, and dead-end patterns.
 3. WeaknessReport markdown rendering for operator visibility.
 4. Integration with ArtifactStore for persistence.
 """
@@ -505,3 +505,26 @@ class TestArtifactStoreWeaknessIntegration:
 
         latest = artifact_store.read_latest_weakness_reports("grid_ctf", max_reports=2)
         assert len(latest) == 2
+
+    def test_read_latest_weakness_reports_markdown(self, artifact_store) -> None:
+        from autocontext.knowledge.weakness import Weakness, WeaknessReport
+
+        report = WeaknessReport(
+            run_id="run_md",
+            scenario="grid_ctf",
+            total_generations=4,
+            weaknesses=[
+                Weakness(
+                    category="dead_end_pattern",
+                    severity="high",
+                    affected_generations=[2, 4],
+                    description="Repeated rollbacks detected",
+                    evidence={"rollback_ratio": 0.5},
+                ),
+            ],
+        )
+        artifact_store.write_weakness_report("grid_ctf", "run_md", report)
+
+        markdown = artifact_store.read_latest_weakness_reports_markdown("grid_ctf")
+        assert "# Weakness Report: run_md" in markdown
+        assert "dead_end_pattern" in markdown


### PR DESCRIPTION
## Summary
- Adds `knowledge/weakness.py` with `Weakness`, `WeaknessReport`, and `WeaknessAnalyzer` for Phase 1 weakness analysis
- Detects 5 failure pattern categories from generation trajectory and match data:
  - **Score regression** — rollbacks with negative deltas
  - **Validation failure** — recurring validation errors across matches
  - **Match variance** — unstable strategies with high score spread
  - **Stagnation risk** — consecutive rollback streaks
  - **Dead-end pattern** — high rollback ratio across a run
- Human-readable markdown reports with severity classification
- `ArtifactStore` integration for persistence/retrieval as JSON

Closes AC-196 (Phase 1)

## What changed
| File | Change |
|------|--------|
| `src/autocontext/knowledge/weakness.py` | New — `Weakness`, `WeaknessReport`, `WeaknessAnalyzer` |
| `src/autocontext/storage/artifacts.py` | Add `write_weakness_report`, `read_weakness_report`, `read_latest_weakness_reports` |
| `tests/test_weakness_reports.py` | New — 26 tests |

## Test plan
- [x] 26 new tests covering dataclass construction/serialization, all 5 analyzer detectors, edge cases, markdown rendering, ArtifactStore persistence
- [x] Full suite: 3284 passed, 46 skipped, 0 failures
- [x] Ruff clean, mypy clean