### PR TITLE
feat(AC-190): normalized cross-scenario progress and cost-efficiency reporting

### DIFF
--- a/autocontext/src/autocontext/knowledge/normalized_metrics.py
+++ b/autocontext/src/autocontext/knowledge/normalized_metrics.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from autocontext.harness.core.types import RoleUsage
+from autocontext.harness.cost.calculator import CostCalculator
+
 
 def _safe_float(val: Any, default: float = 0.0) -> float:  # noqa: ANN401
     try:
@@ -249,7 +252,18 @@ def compute_cost_efficiency(
 
     tokens_per_advance = total_tokens // advances if advances > 0 else 0
 
+    calculator = CostCalculator()
     total_cost = consultation_cost
+    for metric in role_metrics:
+        record = calculator.from_usage(
+            RoleUsage(
+                input_tokens=_safe_int(metric.get("input_tokens")),
+                output_tokens=_safe_int(metric.get("output_tokens")),
+                latency_ms=_safe_int(metric.get("latency_ms")),
+                model=str(metric.get("model") or "_default"),
+            )
+        )
+        total_cost += record.total_cost
 
     cost_per_advance = total_cost / advances if advances > 0 else 0.0
 
@@ -269,7 +283,7 @@ def compute_cost_efficiency(
         total_input_tokens=total_in,
         total_output_tokens=total_out,
         total_tokens=total_tokens,
-        total_cost_usd=total_cost,
+        total_cost_usd=round(total_cost, 6),
         tokens_per_advance=tokens_per_advance,
         cost_per_advance=round(cost_per_advance, 4),
         tokens_per_score_point=tokens_per_score_point,

--- a/autocontext/src/autocontext/knowledge/normalized_metrics.py
+++ b/autocontext/src/autocontext/knowledge/normalized_metrics.py
@@ -1,0 +1,310 @@
+"""AC-190: Normalized cross-scenario progress and cost-efficiency reporting.
+
+Maps native scenario scores to a consistent [0, 1] reporting scale and
+computes cost-efficiency metrics (tokens per advance, cost per score point).
+Purely for operator review — not used for backpressure or gating decisions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _safe_float(val: Any, default: float = 0.0) -> float:  # noqa: ANN401
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_int(val: Any, default: int = 0) -> int:  # noqa: ANN401
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# NormalizedProgress
+# ---------------------------------------------------------------------------
+
+@dataclass(slots=True)
+class NormalizedProgress:
+    """A score mapped to a consistent [0, 1] reporting scale."""
+
+    raw_score: float
+    normalized_score: float
+    score_floor: float = 0.0
+    score_ceiling: float = 1.0
+    pct_of_ceiling: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "raw_score": self.raw_score,
+            "normalized_score": self.normalized_score,
+            "score_floor": self.score_floor,
+            "score_ceiling": self.score_ceiling,
+            "pct_of_ceiling": self.pct_of_ceiling,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> NormalizedProgress:
+        return cls(
+            raw_score=_safe_float(data.get("raw_score")),
+            normalized_score=_safe_float(data.get("normalized_score")),
+            score_floor=_safe_float(data.get("score_floor")),
+            score_ceiling=_safe_float(data.get("score_ceiling", 1.0), 1.0),
+            pct_of_ceiling=_safe_float(data.get("pct_of_ceiling")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# CostEfficiency
+# ---------------------------------------------------------------------------
+
+@dataclass(slots=True)
+class CostEfficiency:
+    """Token and cost efficiency metrics for a run."""
+
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_tokens: int = 0
+    total_cost_usd: float = 0.0
+    tokens_per_advance: int = 0
+    cost_per_advance: float = 0.0
+    tokens_per_score_point: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "total_tokens": self.total_tokens,
+            "total_cost_usd": self.total_cost_usd,
+            "tokens_per_advance": self.tokens_per_advance,
+            "cost_per_advance": self.cost_per_advance,
+            "tokens_per_score_point": self.tokens_per_score_point,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CostEfficiency:
+        return cls(
+            total_input_tokens=_safe_int(data.get("total_input_tokens")),
+            total_output_tokens=_safe_int(data.get("total_output_tokens")),
+            total_tokens=_safe_int(data.get("total_tokens")),
+            total_cost_usd=_safe_float(data.get("total_cost_usd")),
+            tokens_per_advance=_safe_int(data.get("tokens_per_advance")),
+            cost_per_advance=_safe_float(data.get("cost_per_advance")),
+            tokens_per_score_point=_safe_int(data.get("tokens_per_score_point")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# ScenarioNormalizer
+# ---------------------------------------------------------------------------
+
+class ScenarioNormalizer:
+    """Maps native scenario scores to [0, 1] range."""
+
+    def __init__(self, score_floor: float = 0.0, score_ceiling: float = 1.0) -> None:
+        self.score_floor = score_floor
+        self.score_ceiling = score_ceiling
+
+    def normalize(self, raw_score: float) -> NormalizedProgress:
+        span = self.score_ceiling - self.score_floor
+        if span <= 0:
+            return NormalizedProgress(
+                raw_score=raw_score,
+                normalized_score=0.0,
+                score_floor=self.score_floor,
+                score_ceiling=self.score_ceiling,
+                pct_of_ceiling=0.0,
+            )
+        clamped = max(self.score_floor, min(raw_score, self.score_ceiling))
+        normalized = (clamped - self.score_floor) / span
+        return NormalizedProgress(
+            raw_score=raw_score,
+            normalized_score=normalized,
+            score_floor=self.score_floor,
+            score_ceiling=self.score_ceiling,
+            pct_of_ceiling=round(normalized * 100, 2),
+        )
+
+
+# ---------------------------------------------------------------------------
+# RunProgressReport
+# ---------------------------------------------------------------------------
+
+@dataclass(slots=True)
+class RunProgressReport:
+    """Per-run normalized progress and cost-efficiency report."""
+
+    run_id: str
+    scenario: str
+    total_generations: int
+    advances: int
+    rollbacks: int
+    retries: int
+    progress: NormalizedProgress
+    cost: CostEfficiency
+    annotations: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "scenario": self.scenario,
+            "total_generations": self.total_generations,
+            "advances": self.advances,
+            "rollbacks": self.rollbacks,
+            "retries": self.retries,
+            "progress": self.progress.to_dict(),
+            "cost": self.cost.to_dict(),
+            "annotations": self.annotations,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunProgressReport:
+        return cls(
+            run_id=str(data.get("run_id", "")),
+            scenario=str(data.get("scenario", "")),
+            total_generations=_safe_int(data.get("total_generations")),
+            advances=_safe_int(data.get("advances")),
+            rollbacks=_safe_int(data.get("rollbacks")),
+            retries=_safe_int(data.get("retries")),
+            progress=NormalizedProgress.from_dict(data.get("progress", {})),
+            cost=CostEfficiency.from_dict(data.get("cost", {})),
+            annotations=dict(data.get("annotations", {})),
+        )
+
+    def to_markdown(self) -> str:
+        lines = [
+            f"# Progress Report: {self.run_id}",
+            f"**Scenario:** {self.scenario} | **Generations:** {self.total_generations}",
+            "",
+            "## Progress",
+            f"- Score: {self.progress.raw_score:.4f} ({self.progress.pct_of_ceiling}% of ceiling)",
+            f"- Normalized: {self.progress.normalized_score:.4f}",
+            f"- Score range: [{self.progress.score_floor}, {self.progress.score_ceiling}]",
+            "",
+            "## Gate Decisions",
+            f"- Advances: {self.advances}",
+            f"- Rollbacks: {self.rollbacks}",
+            f"- Retries: {self.retries}",
+            "",
+            "## Cost Efficiency",
+            f"- Total tokens: {self.cost.total_tokens:,}",
+            f"- Input / Output: {self.cost.total_input_tokens:,} / {self.cost.total_output_tokens:,}",
+            f"- Total cost: ${self.cost.total_cost_usd:.4f}",
+        ]
+        if self.cost.tokens_per_advance:
+            lines.append(f"- Tokens per advance: {self.cost.tokens_per_advance:,}")
+        if self.cost.cost_per_advance:
+            lines.append(f"- Cost per advance: ${self.cost.cost_per_advance:.4f}")
+        if self.cost.tokens_per_score_point:
+            lines.append(f"- Tokens per score point: {self.cost.tokens_per_score_point:,}")
+        lines.append("")
+
+        if self.annotations:
+            lines.append("## Annotations")
+            for key, val in self.annotations.items():
+                lines.append(f"- **{key}**: {val}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+def compute_normalized_progress(
+    trajectory: list[dict[str, Any]],
+    *,
+    normalizer: ScenarioNormalizer | None = None,
+) -> NormalizedProgress:
+    """Compute normalized progress from trajectory rows."""
+    if normalizer is None:
+        normalizer = ScenarioNormalizer()
+    if not trajectory:
+        return normalizer.normalize(0.0)
+    last_best = _safe_float(trajectory[-1].get("best_score", 0))
+    return normalizer.normalize(last_best)
+
+
+def compute_cost_efficiency(
+    *,
+    role_metrics: list[dict[str, Any]],
+    trajectory: list[dict[str, Any]],
+    consultation_cost: float = 0.0,
+) -> CostEfficiency:
+    """Compute cost-efficiency metrics from role metrics and trajectory."""
+    total_in = sum(_safe_int(m.get("input_tokens")) for m in role_metrics)
+    total_out = sum(_safe_int(m.get("output_tokens")) for m in role_metrics)
+    total_tokens = total_in + total_out
+
+    advances = sum(
+        1 for row in trajectory
+        if str(row.get("gate_decision", "")) == "advance"
+    )
+
+    tokens_per_advance = total_tokens // advances if advances > 0 else 0
+
+    total_cost = consultation_cost
+
+    cost_per_advance = total_cost / advances if advances > 0 else 0.0
+
+    # Net score gain from trajectory
+    if len(trajectory) >= 1:
+        first_score = _safe_float(trajectory[0].get("best_score", 0))
+        first_delta = _safe_float(trajectory[0].get("delta", 0))
+        start_score = first_score - first_delta
+        last_score = _safe_float(trajectory[-1].get("best_score", 0))
+        net_gain = last_score - start_score
+    else:
+        net_gain = 0.0
+
+    tokens_per_score_point = int(total_tokens / net_gain) if net_gain > 0 else 0
+
+    return CostEfficiency(
+        total_input_tokens=total_in,
+        total_output_tokens=total_out,
+        total_tokens=total_tokens,
+        total_cost_usd=total_cost,
+        tokens_per_advance=tokens_per_advance,
+        cost_per_advance=round(cost_per_advance, 4),
+        tokens_per_score_point=tokens_per_score_point,
+    )
+
+
+def generate_run_progress_report(
+    *,
+    run_id: str,
+    scenario: str,
+    trajectory: list[dict[str, Any]],
+    role_metrics: list[dict[str, Any]],
+    normalizer: ScenarioNormalizer | None = None,
+    consultation_cost: float = 0.0,
+) -> RunProgressReport:
+    """Generate a RunProgressReport from raw trajectory and role metrics data."""
+    progress = compute_normalized_progress(trajectory, normalizer=normalizer)
+    cost = compute_cost_efficiency(
+        role_metrics=role_metrics,
+        trajectory=trajectory,
+        consultation_cost=consultation_cost,
+    )
+
+    gate_counts: dict[str, int] = {}
+    for row in trajectory:
+        decision = str(row.get("gate_decision", "unknown"))
+        gate_counts[decision] = gate_counts.get(decision, 0) + 1
+
+    return RunProgressReport(
+        run_id=run_id,
+        scenario=scenario,
+        total_generations=len(trajectory),
+        advances=gate_counts.get("advance", 0),
+        rollbacks=gate_counts.get("rollback", 0),
+        retries=gate_counts.get("retry", 0),
+        progress=progress,
+        cost=cost,
+    )

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -14,6 +14,7 @@ from autocontext.execution.executors import LocalExecutor, PrimeIntellectExecuto
 from autocontext.harness.meta_optimizer import MetaOptimizer
 from autocontext.integrations.primeintellect import PrimeIntellectClient
 from autocontext.knowledge.mutation_log import MutationEntry
+from autocontext.knowledge.normalized_metrics import generate_run_progress_report
 from autocontext.knowledge.report import generate_session_report
 from autocontext.knowledge.trajectory import ScoreTrajectoryBuilder
 from autocontext.knowledge.weakness import WeaknessAnalyzer
@@ -214,6 +215,20 @@ class GenerationRunner:
         )
         self.artifacts.write_weakness_report(scenario_name, run_id, report)
 
+    def _generate_progress_report(self, run_id: str, scenario_name: str) -> None:
+        """Generate and persist a normalized progress report for a completed run."""
+        trajectory_rows = self.sqlite.get_generation_trajectory(run_id)
+        role_metrics = self.sqlite.get_agent_role_metrics(run_id)
+        consultation_cost = self.sqlite.get_total_consultation_cost(run_id)
+        report = generate_run_progress_report(
+            run_id=run_id,
+            scenario=scenario_name,
+            trajectory=trajectory_rows,
+            role_metrics=role_metrics,
+            consultation_cost=consultation_cost,
+        )
+        self.artifacts.write_progress_report(scenario_name, run_id, report)
+
     def run(self, scenario_name: str, generations: int, run_id: str | None = None) -> RunSummary:
         scenario = self._scenario(scenario_name)
         active_run_id = run_id or f"run_{uuid.uuid4().hex[:12]}"
@@ -406,6 +421,10 @@ class GenerationRunner:
             self._generate_weakness_report(active_run_id, scenario_name)
         except Exception:
             LOGGER.warning("failed to generate weakness report for run %s", active_run_id, exc_info=True)
+        try:
+            self._generate_progress_report(active_run_id, scenario_name)
+        except Exception:
+            LOGGER.warning("failed to generate progress report for run %s", active_run_id, exc_info=True)
 
         # Snapshot knowledge for cross-run inheritance
         if self.settings.cross_run_inheritance and not self.settings.ablation_no_feedback:

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -268,6 +268,7 @@ def stage_knowledge_setup(
     skills_context = "" if ablation else artifacts.read_skills(ctx.scenario_name)
     recent_analysis = "" if ablation else artifacts.read_latest_advance_analysis(ctx.scenario_name, ctx.generation)
     weakness_reports = "" if ablation else artifacts.read_latest_weakness_reports_markdown(ctx.scenario_name)
+    progress_reports = "" if ablation else artifacts.read_latest_progress_reports_markdown(ctx.scenario_name)
     score_trajectory = "" if ablation else trajectory_builder.build_trajectory(ctx.run_id)
     strategy_registry = "" if ablation else trajectory_builder.build_strategy_registry(ctx.run_id)
 
@@ -319,6 +320,12 @@ def stage_knowledge_setup(
             f"{experiment_log}\n\nRecent weakness reports:\n{weakness_reports}".strip()
             if experiment_log
             else f"Recent weakness reports:\n{weakness_reports}"
+        )
+    if progress_reports:
+        experiment_log = (
+            f"{experiment_log}\n\nRecent progress reports:\n{progress_reports}".strip()
+            if experiment_log
+            else f"Recent progress reports:\n{progress_reports}"
         )
 
     summary_text = f"best score so far: {ctx.previous_best:.4f}"

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -717,6 +717,57 @@ class ArtifactStore:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
 
+    # --- Normalized progress reports (AC-190) ---------------------------------
+
+    def _progress_report_dir(self, scenario_name: str) -> Path:
+        return self.knowledge_root / scenario_name / "progress_reports"
+
+    def write_progress_report(self, scenario_name: str, run_id: str, report: object) -> None:
+        """Persist a RunProgressReport as JSON."""
+        pr_dir = self._progress_report_dir(scenario_name)
+        pr_dir.mkdir(parents=True, exist_ok=True)
+        path = pr_dir / f"{run_id}.json"
+        self.write_json(path, report.to_dict())  # type: ignore[attr-defined]
+
+    def read_progress_report(self, scenario_name: str, run_id: str) -> object | None:
+        """Read a RunProgressReport, or None if missing."""
+        from autocontext.knowledge.normalized_metrics import RunProgressReport
+
+        path = self._progress_report_dir(scenario_name) / f"{run_id}.json"
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return RunProgressReport.from_dict(data)
+
+    def read_latest_progress_reports(
+        self, scenario_name: str, max_reports: int = 2,
+    ) -> list[object]:
+        """Read most recent progress reports for a scenario."""
+        from autocontext.knowledge.normalized_metrics import RunProgressReport
+
+        pr_dir = self._progress_report_dir(scenario_name)
+        if not pr_dir.exists():
+            return []
+        files = sorted(pr_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+        reports: list[object] = []
+        for path in files[:max_reports]:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            reports.append(RunProgressReport.from_dict(data))
+        return reports
+
+    def read_latest_progress_reports_markdown(self, scenario_name: str, max_reports: int = 2) -> str:
+        """Read recent progress reports and concatenate them as markdown."""
+        from autocontext.knowledge.normalized_metrics import RunProgressReport
+
+        reports = self.read_latest_progress_reports(scenario_name, max_reports=max_reports)
+        if not reports:
+            return ""
+        parts: list[str] = []
+        for report in reports:
+            if isinstance(report, RunProgressReport):
+                parts.append(report.to_markdown())
+        return "\n\n".join(parts)
+
     # --- Weakness reports (AC-196) -------------------------------------------
 
     def _weakness_dir(self, scenario_name: str) -> Path:

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -363,6 +363,21 @@ class SQLiteStore:
             ).fetchall()
             return [dict(row) for row in rows]
 
+    def get_agent_role_metrics(self, run_id: str) -> list[dict[str, Any]]:
+        """Return agent role metrics for a run, ordered by generation and row id."""
+        with self.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT generation_index, role, model, input_tokens, output_tokens,
+                       latency_ms, subagent_id, status
+                FROM agent_role_metrics
+                WHERE run_id = ?
+                ORDER BY generation_index, rowid
+                """,
+                (run_id,),
+            ).fetchall()
+            return [dict(row) for row in rows]
+
     def get_generation_trajectory(self, run_id: str) -> list[dict[str, Any]]:
         """Return generation trajectory with score deltas."""
         with self.connect() as conn:

--- a/autocontext/tests/test_generation_stages.py
+++ b/autocontext/tests/test_generation_stages.py
@@ -186,6 +186,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_skills.return_value = ""
         artifacts.read_mutation_replay.return_value = ""
         artifacts.read_latest_weakness_reports_markdown.return_value = ""
+        artifacts.read_latest_progress_reports_markdown.return_value = ""
         artifacts.read_latest_advance_analysis.return_value = ""
         artifacts.read_progress.return_value = None
         trajectory = MagicMock()
@@ -203,6 +204,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_skills.return_value = ""
         artifacts.read_mutation_replay.return_value = ""
         artifacts.read_latest_weakness_reports_markdown.return_value = ""
+        artifacts.read_latest_progress_reports_markdown.return_value = ""
         artifacts.read_latest_advance_analysis.return_value = ""
         artifacts.read_progress.return_value = None
         trajectory = MagicMock()
@@ -229,6 +231,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_skills.return_value = ""
         artifacts.read_mutation_replay.return_value = "Context mutations since last checkpoint:\n- gen 2: playbook_updated"
         artifacts.read_latest_weakness_reports_markdown.return_value = ""
+        artifacts.read_latest_progress_reports_markdown.return_value = ""
         artifacts.read_latest_advance_analysis.return_value = ""
         artifacts.read_progress.return_value = None
         trajectory = MagicMock()
@@ -253,6 +256,7 @@ class TestStageKnowledgeSetup:
             "## [HIGH] dead_end_pattern\n"
             "Repeated rollbacks detected"
         )
+        artifacts.read_latest_progress_reports_markdown.return_value = ""
         artifacts.read_latest_advance_analysis.return_value = ""
         artifacts.read_progress.return_value = None
         trajectory = MagicMock()
@@ -266,6 +270,32 @@ class TestStageKnowledgeSetup:
         assert result.prompts is not None
         assert "Recent weakness reports:" in result.prompts.competitor
         assert "dead_end_pattern" in result.prompts.competitor
+
+    def test_includes_recent_progress_reports_in_prompt_context(self) -> None:
+        artifacts = MagicMock()
+        artifacts.read_playbook.return_value = ""
+        artifacts.read_tool_context.return_value = ""
+        artifacts.read_skills.return_value = ""
+        artifacts.read_mutation_replay.return_value = ""
+        artifacts.read_latest_weakness_reports_markdown.return_value = ""
+        artifacts.read_latest_progress_reports_markdown.return_value = (
+            "# Progress Report: run_2\n"
+            "- Total cost: $0.0240\n"
+            "- Tokens per advance: 3,400"
+        )
+        artifacts.read_latest_advance_analysis.return_value = ""
+        artifacts.read_progress.return_value = None
+        trajectory = MagicMock()
+        trajectory.build_trajectory.return_value = ""
+        trajectory.build_strategy_registry.return_value = ""
+        trajectory.build_experiment_log.return_value = ""
+        ctx = _make_ctx()
+
+        result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
+
+        assert result.prompts is not None
+        assert "Recent progress reports:" in result.prompts.competitor
+        assert "Tokens per advance" in result.prompts.competitor
 
 
 # ---------- TestStageAgentGeneration ----------

--- a/autocontext/tests/test_normalized_metrics.py
+++ b/autocontext/tests/test_normalized_metrics.py
@@ -204,9 +204,9 @@ class TestComputeCostEfficiency:
 
     def test_basic_computation(self) -> None:
         role_metrics = [
-            {"input_tokens": 1000, "output_tokens": 500},
-            {"input_tokens": 2000, "output_tokens": 1000},
-            {"input_tokens": 1500, "output_tokens": 800},
+            {"model": "claude-sonnet-4-5-20250929", "input_tokens": 1000, "output_tokens": 500},
+            {"model": "claude-sonnet-4-5-20250929", "input_tokens": 2000, "output_tokens": 1000},
+            {"model": "claude-sonnet-4-5-20250929", "input_tokens": 1500, "output_tokens": 800},
         ]
         trajectory = [
             {"generation_index": 0, "best_score": 0.3, "delta": 0.3, "gate_decision": "advance"},
@@ -219,10 +219,11 @@ class TestComputeCostEfficiency:
         assert result.total_tokens == 6800
         # 2 advances, so tokens_per_advance = 6800 / 2 = 3400
         assert result.tokens_per_advance == 3400
+        assert result.total_cost_usd == pytest.approx(0.048)
 
     def test_no_advances(self) -> None:
         """When no advances, tokens_per_advance should be 0."""
-        role_metrics = [{"input_tokens": 1000, "output_tokens": 500}]
+        role_metrics = [{"model": "claude-sonnet-4-5-20250929", "input_tokens": 1000, "output_tokens": 500}]
         trajectory = [
             {"generation_index": 0, "best_score": 0.3, "delta": 0.0, "gate_decision": "rollback"},
         ]
@@ -232,7 +233,7 @@ class TestComputeCostEfficiency:
     def test_tokens_per_score_point(self) -> None:
         """Tokens per net score point gained."""
         role_metrics = [
-            {"input_tokens": 5000, "output_tokens": 2000},
+            {"model": "claude-sonnet-4-5-20250929", "input_tokens": 5000, "output_tokens": 2000},
         ]
         trajectory = [
             {"generation_index": 0, "best_score": 0.2, "delta": 0.2, "gate_decision": "advance"},
@@ -249,7 +250,7 @@ class TestComputeCostEfficiency:
 
     def test_no_score_gain(self) -> None:
         """When no score improvement, tokens_per_score_point = 0."""
-        role_metrics = [{"input_tokens": 1000, "output_tokens": 500}]
+        role_metrics = [{"model": "claude-sonnet-4-5-20250929", "input_tokens": 1000, "output_tokens": 500}]
         trajectory = [
             {"generation_index": 0, "best_score": 0.5, "delta": 0.0, "gate_decision": "rollback"},
         ]
@@ -263,6 +264,23 @@ class TestComputeCostEfficiency:
             consultation_cost=0.05,
         )
         assert result.total_cost_usd == pytest.approx(0.05)
+
+    def test_role_cost_and_consultation_cost_are_combined(self) -> None:
+        result = compute_cost_efficiency(
+            role_metrics=[
+                {
+                    "model": "claude-sonnet-4-5-20250929",
+                    "input_tokens": 1000,
+                    "output_tokens": 1000,
+                    "latency_ms": 10,
+                }
+            ],
+            trajectory=[
+                {"generation_index": 0, "best_score": 0.4, "delta": 0.4, "gate_decision": "advance"},
+            ],
+            consultation_cost=0.01,
+        )
+        assert result.total_cost_usd == pytest.approx(0.028)
 
 
 # ---------------------------------------------------------------------------
@@ -425,10 +443,10 @@ class TestGenerateRunProgressReport:
             trajectory=[
                 {"generation_index": 0, "best_score": 0.5, "delta": 0.5, "gate_decision": "advance"},
             ],
-            role_metrics=[{"input_tokens": 1000, "output_tokens": 500}],
+            role_metrics=[{"model": "claude-sonnet-4-5-20250929", "input_tokens": 1000, "output_tokens": 500}],
             consultation_cost=0.10,
         )
-        assert report.cost.total_cost_usd == pytest.approx(0.10)
+        assert report.cost.total_cost_usd == pytest.approx(0.1105)
 
 
 # ---------------------------------------------------------------------------

--- a/autocontext/tests/test_normalized_metrics.py
+++ b/autocontext/tests/test_normalized_metrics.py
@@ -1,0 +1,520 @@
+"""Tests for AC-190: Normalized cross-scenario progress and cost-efficiency reporting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autocontext.knowledge.normalized_metrics import (
+    CostEfficiency,
+    NormalizedProgress,
+    RunProgressReport,
+    ScenarioNormalizer,
+    compute_cost_efficiency,
+    compute_normalized_progress,
+    generate_run_progress_report,
+)
+
+# ---------------------------------------------------------------------------
+# NormalizedProgress dataclass
+# ---------------------------------------------------------------------------
+
+class TestNormalizedProgress:
+    def test_construction_defaults(self) -> None:
+        np = NormalizedProgress(raw_score=0.75, normalized_score=0.75, pct_of_ceiling=75.0)
+        assert np.raw_score == 0.75
+        assert np.normalized_score == 0.75
+        assert np.score_floor == 0.0
+        assert np.score_ceiling == 1.0
+        assert np.pct_of_ceiling == 75.0
+
+    def test_custom_floor_ceiling(self) -> None:
+        np = NormalizedProgress(
+            raw_score=500,
+            normalized_score=0.5,
+            score_floor=0,
+            score_ceiling=1000,
+            pct_of_ceiling=50.0,
+        )
+        assert np.raw_score == 500
+        assert np.normalized_score == 0.5
+        assert np.pct_of_ceiling == 50.0
+
+    def test_to_dict(self) -> None:
+        np = NormalizedProgress(raw_score=0.8, normalized_score=0.8, pct_of_ceiling=80.0)
+        d = np.to_dict()
+        assert d["raw_score"] == 0.8
+        assert d["normalized_score"] == 0.8
+        assert d["pct_of_ceiling"] == 80.0
+        assert "score_floor" in d
+        assert "score_ceiling" in d
+
+    def test_from_dict_roundtrip(self) -> None:
+        original = NormalizedProgress(
+            raw_score=0.65,
+            normalized_score=0.65,
+            score_floor=0.0,
+            score_ceiling=1.0,
+            pct_of_ceiling=65.0,
+        )
+        restored = NormalizedProgress.from_dict(original.to_dict())
+        assert restored.raw_score == original.raw_score
+        assert restored.normalized_score == original.normalized_score
+        assert restored.pct_of_ceiling == original.pct_of_ceiling
+
+
+# ---------------------------------------------------------------------------
+# CostEfficiency dataclass
+# ---------------------------------------------------------------------------
+
+class TestCostEfficiency:
+    def test_construction(self) -> None:
+        ce = CostEfficiency(
+            total_input_tokens=10000,
+            total_output_tokens=5000,
+            total_tokens=15000,
+            total_cost_usd=0.05,
+            tokens_per_advance=5000,
+            cost_per_advance=0.0167,
+            tokens_per_score_point=30000,
+        )
+        assert ce.total_tokens == 15000
+        assert ce.tokens_per_advance == 5000
+
+    def test_defaults(self) -> None:
+        ce = CostEfficiency()
+        assert ce.total_input_tokens == 0
+        assert ce.total_output_tokens == 0
+        assert ce.total_tokens == 0
+        assert ce.total_cost_usd == 0.0
+        assert ce.tokens_per_advance == 0
+        assert ce.cost_per_advance == 0.0
+        assert ce.tokens_per_score_point == 0
+
+    def test_to_dict(self) -> None:
+        ce = CostEfficiency(total_tokens=1000, total_cost_usd=0.01)
+        d = ce.to_dict()
+        assert d["total_tokens"] == 1000
+        assert d["total_cost_usd"] == 0.01
+
+    def test_from_dict_roundtrip(self) -> None:
+        original = CostEfficiency(
+            total_input_tokens=5000,
+            total_output_tokens=2000,
+            total_tokens=7000,
+            total_cost_usd=0.03,
+            tokens_per_advance=3500,
+            cost_per_advance=0.015,
+            tokens_per_score_point=14000,
+        )
+        restored = CostEfficiency.from_dict(original.to_dict())
+        assert restored.total_tokens == original.total_tokens
+        assert restored.cost_per_advance == original.cost_per_advance
+
+
+# ---------------------------------------------------------------------------
+# ScenarioNormalizer
+# ---------------------------------------------------------------------------
+
+class TestScenarioNormalizer:
+    def test_default_normalizer_maps_identity(self) -> None:
+        """Default normalizer uses floor=0, ceiling=1."""
+        normalizer = ScenarioNormalizer()
+        result = normalizer.normalize(0.75)
+        assert result.normalized_score == pytest.approx(0.75)
+        assert result.pct_of_ceiling == pytest.approx(75.0)
+
+    def test_custom_floor_ceiling(self) -> None:
+        """Score range [0, 64] maps to [0, 1]."""
+        normalizer = ScenarioNormalizer(score_floor=0, score_ceiling=64)
+        result = normalizer.normalize(32)
+        assert result.normalized_score == pytest.approx(0.5)
+        assert result.pct_of_ceiling == pytest.approx(50.0)
+        assert result.raw_score == 32
+
+    def test_floor_equals_ceiling(self) -> None:
+        """When floor equals ceiling, normalized score should be 0."""
+        normalizer = ScenarioNormalizer(score_floor=5, score_ceiling=5)
+        result = normalizer.normalize(5)
+        assert result.normalized_score == 0.0
+
+    def test_score_below_floor_clamps_to_zero(self) -> None:
+        normalizer = ScenarioNormalizer(score_floor=0, score_ceiling=100)
+        result = normalizer.normalize(-10)
+        assert result.normalized_score == 0.0
+
+    def test_score_above_ceiling_clamps_to_one(self) -> None:
+        normalizer = ScenarioNormalizer(score_floor=0, score_ceiling=100)
+        result = normalizer.normalize(150)
+        assert result.normalized_score == 1.0
+        assert result.pct_of_ceiling == 100.0
+
+    def test_negative_floor(self) -> None:
+        """Support negative floors (e.g., score range [-1, 1])."""
+        normalizer = ScenarioNormalizer(score_floor=-1, score_ceiling=1)
+        result = normalizer.normalize(0)
+        assert result.normalized_score == pytest.approx(0.5)
+
+    def test_preserves_raw_score(self) -> None:
+        normalizer = ScenarioNormalizer(score_floor=0, score_ceiling=10)
+        result = normalizer.normalize(7)
+        assert result.raw_score == 7
+
+
+# ---------------------------------------------------------------------------
+# compute_normalized_progress (from trajectory rows)
+# ---------------------------------------------------------------------------
+
+class TestComputeNormalizedProgress:
+    def test_empty_trajectory(self) -> None:
+        result = compute_normalized_progress([], normalizer=ScenarioNormalizer())
+        assert result.raw_score == 0.0
+        assert result.normalized_score == 0.0
+
+    def test_uses_last_best_score(self) -> None:
+        trajectory = [
+            {"generation_index": 0, "best_score": 0.3, "gate_decision": "advance"},
+            {"generation_index": 1, "best_score": 0.5, "gate_decision": "advance"},
+            {"generation_index": 2, "best_score": 0.8, "gate_decision": "advance"},
+        ]
+        result = compute_normalized_progress(trajectory, normalizer=ScenarioNormalizer())
+        assert result.raw_score == pytest.approx(0.8)
+        assert result.normalized_score == pytest.approx(0.8)
+
+    def test_custom_normalizer(self) -> None:
+        trajectory = [
+            {"generation_index": 0, "best_score": 32, "gate_decision": "advance"},
+        ]
+        normalizer = ScenarioNormalizer(score_floor=0, score_ceiling=64)
+        result = compute_normalized_progress(trajectory, normalizer=normalizer)
+        assert result.normalized_score == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# compute_cost_efficiency (from role metrics and trajectory)
+# ---------------------------------------------------------------------------
+
+class TestComputeCostEfficiency:
+    def test_empty_inputs(self) -> None:
+        result = compute_cost_efficiency(role_metrics=[], trajectory=[], consultation_cost=0.0)
+        assert result.total_tokens == 0
+        assert result.tokens_per_advance == 0
+        assert result.cost_per_advance == 0.0
+
+    def test_basic_computation(self) -> None:
+        role_metrics = [
+            {"input_tokens": 1000, "output_tokens": 500},
+            {"input_tokens": 2000, "output_tokens": 1000},
+            {"input_tokens": 1500, "output_tokens": 800},
+        ]
+        trajectory = [
+            {"generation_index": 0, "best_score": 0.3, "delta": 0.3, "gate_decision": "advance"},
+            {"generation_index": 1, "best_score": 0.3, "delta": 0.0, "gate_decision": "rollback"},
+            {"generation_index": 2, "best_score": 0.5, "delta": 0.2, "gate_decision": "advance"},
+        ]
+        result = compute_cost_efficiency(role_metrics=role_metrics, trajectory=trajectory)
+        assert result.total_input_tokens == 4500
+        assert result.total_output_tokens == 2300
+        assert result.total_tokens == 6800
+        # 2 advances, so tokens_per_advance = 6800 / 2 = 3400
+        assert result.tokens_per_advance == 3400
+
+    def test_no_advances(self) -> None:
+        """When no advances, tokens_per_advance should be 0."""
+        role_metrics = [{"input_tokens": 1000, "output_tokens": 500}]
+        trajectory = [
+            {"generation_index": 0, "best_score": 0.3, "delta": 0.0, "gate_decision": "rollback"},
+        ]
+        result = compute_cost_efficiency(role_metrics=role_metrics, trajectory=trajectory)
+        assert result.tokens_per_advance == 0
+
+    def test_tokens_per_score_point(self) -> None:
+        """Tokens per net score point gained."""
+        role_metrics = [
+            {"input_tokens": 5000, "output_tokens": 2000},
+        ]
+        trajectory = [
+            {"generation_index": 0, "best_score": 0.2, "delta": 0.2, "gate_decision": "advance"},
+            {"generation_index": 1, "best_score": 0.7, "delta": 0.5, "gate_decision": "advance"},
+        ]
+        result = compute_cost_efficiency(role_metrics=role_metrics, trajectory=trajectory)
+        # Net score gain = 0.7 (last best_score) - 0.0 (initial) = 0.7
+        # But computed from first.best_score and last.best_score delta
+        # total_tokens = 7000, net_gain = 0.7 - 0.2 + 0.2 = 0.7
+        # Actually first best_score = 0.2 so net = 0.7 - 0 = 0.7 (from trajectory start score)
+        assert result.total_tokens == 7000
+        # tokens_per_score_point = 7000 / 0.7 = 10000
+        assert result.tokens_per_score_point == 10000
+
+    def test_no_score_gain(self) -> None:
+        """When no score improvement, tokens_per_score_point = 0."""
+        role_metrics = [{"input_tokens": 1000, "output_tokens": 500}]
+        trajectory = [
+            {"generation_index": 0, "best_score": 0.5, "delta": 0.0, "gate_decision": "rollback"},
+        ]
+        result = compute_cost_efficiency(role_metrics=role_metrics, trajectory=trajectory)
+        assert result.tokens_per_score_point == 0
+
+    def test_consultation_cost_included(self) -> None:
+        result = compute_cost_efficiency(
+            role_metrics=[],
+            trajectory=[],
+            consultation_cost=0.05,
+        )
+        assert result.total_cost_usd == pytest.approx(0.05)
+
+
+# ---------------------------------------------------------------------------
+# RunProgressReport
+# ---------------------------------------------------------------------------
+
+class TestRunProgressReport:
+    def test_construction(self) -> None:
+        report = RunProgressReport(
+            run_id="run_1",
+            scenario="grid_ctf",
+            total_generations=5,
+            advances=3,
+            rollbacks=1,
+            retries=1,
+            progress=NormalizedProgress(raw_score=0.8, normalized_score=0.8, pct_of_ceiling=80.0),
+            cost=CostEfficiency(total_tokens=10000),
+        )
+        assert report.run_id == "run_1"
+        assert report.advances == 3
+
+    def test_to_dict(self) -> None:
+        report = RunProgressReport(
+            run_id="run_1",
+            scenario="grid_ctf",
+            total_generations=2,
+            advances=1,
+            rollbacks=1,
+            retries=0,
+            progress=NormalizedProgress(raw_score=0.5, normalized_score=0.5, pct_of_ceiling=50.0),
+            cost=CostEfficiency(total_tokens=5000),
+        )
+        d = report.to_dict()
+        assert d["run_id"] == "run_1"
+        assert d["scenario"] == "grid_ctf"
+        assert d["progress"]["normalized_score"] == 0.5
+        assert d["cost"]["total_tokens"] == 5000
+
+    def test_from_dict_roundtrip(self) -> None:
+        original = RunProgressReport(
+            run_id="r2",
+            scenario="othello",
+            total_generations=10,
+            advances=6,
+            rollbacks=3,
+            retries=1,
+            progress=NormalizedProgress(raw_score=0.9, normalized_score=0.9, pct_of_ceiling=90.0),
+            cost=CostEfficiency(total_tokens=20000, cost_per_advance=0.01),
+        )
+        restored = RunProgressReport.from_dict(original.to_dict())
+        assert restored.run_id == original.run_id
+        assert restored.advances == original.advances
+        assert restored.progress.normalized_score == original.progress.normalized_score
+        assert restored.cost.total_tokens == original.cost.total_tokens
+
+    def test_to_markdown(self) -> None:
+        report = RunProgressReport(
+            run_id="run_1",
+            scenario="grid_ctf",
+            total_generations=5,
+            advances=3,
+            rollbacks=1,
+            retries=1,
+            progress=NormalizedProgress(
+                raw_score=0.8,
+                normalized_score=0.8,
+                score_floor=0.0,
+                score_ceiling=1.0,
+                pct_of_ceiling=80.0,
+            ),
+            cost=CostEfficiency(
+                total_input_tokens=8000,
+                total_output_tokens=4000,
+                total_tokens=12000,
+                total_cost_usd=0.04,
+                tokens_per_advance=4000,
+                cost_per_advance=0.0133,
+                tokens_per_score_point=15000,
+            ),
+        )
+        md = report.to_markdown()
+        assert "run_1" in md
+        assert "grid_ctf" in md
+        assert "80.0%" in md
+        assert "12,000" in md or "12000" in md
+        assert "advance" in md.lower()
+
+    def test_to_markdown_zero_cost(self) -> None:
+        """Report with zero cost should still render cleanly."""
+        report = RunProgressReport(
+            run_id="r2",
+            scenario="othello",
+            total_generations=0,
+            advances=0,
+            rollbacks=0,
+            retries=0,
+            progress=NormalizedProgress(raw_score=0.0, normalized_score=0.0),
+            cost=CostEfficiency(),
+        )
+        md = report.to_markdown()
+        assert "othello" in md
+
+
+# ---------------------------------------------------------------------------
+# generate_run_progress_report (integration)
+# ---------------------------------------------------------------------------
+
+class TestGenerateRunProgressReport:
+    def test_empty_trajectory(self) -> None:
+        report = generate_run_progress_report(
+            run_id="run_empty",
+            scenario="grid_ctf",
+            trajectory=[],
+            role_metrics=[],
+        )
+        assert report.total_generations == 0
+        assert report.progress.normalized_score == 0.0
+        assert report.cost.total_tokens == 0
+
+    def test_basic_report(self) -> None:
+        trajectory = [
+            {"generation_index": 0, "best_score": 0.3, "delta": 0.3, "gate_decision": "advance"},
+            {"generation_index": 1, "best_score": 0.3, "delta": 0.0, "gate_decision": "rollback"},
+            {"generation_index": 2, "best_score": 0.6, "delta": 0.3, "gate_decision": "advance"},
+        ]
+        role_metrics = [
+            {"input_tokens": 1000, "output_tokens": 500},
+            {"input_tokens": 2000, "output_tokens": 1000},
+        ]
+        report = generate_run_progress_report(
+            run_id="run_basic",
+            scenario="grid_ctf",
+            trajectory=trajectory,
+            role_metrics=role_metrics,
+        )
+        assert report.total_generations == 3
+        assert report.advances == 2
+        assert report.rollbacks == 1
+        assert report.progress.raw_score == pytest.approx(0.6)
+        assert report.cost.total_tokens == 4500
+
+    def test_custom_normalizer(self) -> None:
+        trajectory = [
+            {"generation_index": 0, "best_score": 32, "delta": 32, "gate_decision": "advance"},
+        ]
+        normalizer = ScenarioNormalizer(score_floor=0, score_ceiling=64)
+        report = generate_run_progress_report(
+            run_id="custom",
+            scenario="othello",
+            trajectory=trajectory,
+            role_metrics=[],
+            normalizer=normalizer,
+        )
+        assert report.progress.normalized_score == pytest.approx(0.5)
+
+    def test_consultation_cost_included(self) -> None:
+        report = generate_run_progress_report(
+            run_id="consult",
+            scenario="grid_ctf",
+            trajectory=[
+                {"generation_index": 0, "best_score": 0.5, "delta": 0.5, "gate_decision": "advance"},
+            ],
+            role_metrics=[{"input_tokens": 1000, "output_tokens": 500}],
+            consultation_cost=0.10,
+        )
+        assert report.cost.total_cost_usd == pytest.approx(0.10)
+
+
+# ---------------------------------------------------------------------------
+# ArtifactStore integration
+# ---------------------------------------------------------------------------
+
+class TestArtifactStoreNormalizedMetrics:
+    @pytest.fixture()
+    def store(self, tmp_path: Path) -> object:
+        from autocontext.storage.artifacts import ArtifactStore
+
+        return ArtifactStore(
+            runs_root=tmp_path / "runs",
+            knowledge_root=tmp_path / "knowledge",
+            skills_root=tmp_path / "skills",
+            claude_skills_path=tmp_path / ".claude" / "skills",
+        )
+
+    def test_write_and_read_progress_report(self, store: object) -> None:
+        from autocontext.storage.artifacts import ArtifactStore
+
+        assert isinstance(store, ArtifactStore)
+
+        report = RunProgressReport(
+            run_id="run_1",
+            scenario="grid_ctf",
+            total_generations=5,
+            advances=3,
+            rollbacks=1,
+            retries=1,
+            progress=NormalizedProgress(raw_score=0.8, normalized_score=0.8, pct_of_ceiling=80.0),
+            cost=CostEfficiency(total_tokens=10000),
+        )
+        store.write_progress_report("grid_ctf", "run_1", report)
+        restored = store.read_progress_report("grid_ctf", "run_1")
+        assert restored is not None
+        assert isinstance(restored, RunProgressReport)
+        assert restored.run_id == "run_1"
+        assert restored.progress.normalized_score == pytest.approx(0.8)
+
+    def test_read_missing_progress_report(self, store: object) -> None:
+        from autocontext.storage.artifacts import ArtifactStore
+
+        assert isinstance(store, ArtifactStore)
+        result = store.read_progress_report("grid_ctf", "nonexistent")
+        assert result is None
+
+    def test_read_latest_progress_reports(self, store: object) -> None:
+        from autocontext.storage.artifacts import ArtifactStore
+
+        assert isinstance(store, ArtifactStore)
+        for i in range(3):
+            report = RunProgressReport(
+                run_id=f"run_{i}",
+                scenario="grid_ctf",
+                total_generations=i + 1,
+                advances=i,
+                rollbacks=0,
+                retries=0,
+                progress=NormalizedProgress(
+                    raw_score=0.2 * (i + 1),
+                    normalized_score=0.2 * (i + 1),
+                    pct_of_ceiling=20.0 * (i + 1),
+                ),
+                cost=CostEfficiency(total_tokens=1000 * (i + 1)),
+            )
+            store.write_progress_report("grid_ctf", f"run_{i}", report)
+
+        latest = store.read_latest_progress_reports("grid_ctf", max_reports=2)
+        assert len(latest) == 2
+
+    def test_progress_report_to_markdown(self, store: object) -> None:
+        from autocontext.storage.artifacts import ArtifactStore
+
+        assert isinstance(store, ArtifactStore)
+        report = RunProgressReport(
+            run_id="run_md",
+            scenario="grid_ctf",
+            total_generations=3,
+            advances=2,
+            rollbacks=1,
+            retries=0,
+            progress=NormalizedProgress(raw_score=0.6, normalized_score=0.6, pct_of_ceiling=60.0),
+            cost=CostEfficiency(total_tokens=5000, cost_per_advance=0.01),
+        )
+        store.write_progress_report("grid_ctf", "run_md", report)
+        md = store.read_latest_progress_reports_markdown("grid_ctf", max_reports=1)
+        assert "run_md" in md
+        assert "60.0%" in md

--- a/autocontext/tests/test_session_report_wiring.py
+++ b/autocontext/tests/test_session_report_wiring.py
@@ -56,6 +56,8 @@ def _make_runner_with_mocks(settings: AppSettings) -> tuple[Any, dict[str, Any]]
 
     # Default: no existing generations (not skipped for idempotency)
     runner.sqlite.generation_exists.return_value = False
+    runner.sqlite.get_agent_role_metrics.return_value = []
+    runner.sqlite.get_total_consultation_cost.return_value = 0.0
 
     # Default: scenario lookup succeeds
     scenario_mock = MagicMock()
@@ -222,6 +224,46 @@ class TestWeaknessReportWiring:
         assert report.scenario == "grid_ctf"
         assert report.total_generations == 5
         assert report.weaknesses
+
+
+class TestProgressReportWiring:
+    """Normalized progress reports are generated from the live run completion path."""
+
+    def test_progress_report_generated_on_run_completion(self, tmp_path: Path) -> None:
+        settings = _make_settings(tmp_path, session_reports_enabled=False)
+        runner, mocks = _make_runner_with_mocks(settings)
+
+        trajectory_rows = [
+            {"generation_index": 1, "best_score": 0.3, "elo": 1000, "delta": 0.3, "gate_decision": "advance"},
+            {"generation_index": 2, "best_score": 0.5, "elo": 1050, "delta": 0.2, "gate_decision": "advance"},
+        ]
+        role_metrics = [
+            {
+                "generation_index": 1,
+                "role": "competitor",
+                "model": "claude-sonnet-4-5-20250929",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "latency_ms": 100,
+                "subagent_id": "competitor",
+                "status": "success",
+            }
+        ]
+        mocks["sqlite"].get_generation_trajectory.return_value = trajectory_rows
+        mocks["sqlite"].get_agent_role_metrics.return_value = role_metrics
+        mocks["sqlite"].get_total_consultation_cost.return_value = 0.01
+        mocks["artifacts"].tools_dir.return_value = MagicMock(exists=MagicMock(return_value=True))
+
+        _run_with_pipeline_mock(runner, mocks, "grid_ctf", 2, "test_progress")
+
+        mocks["artifacts"].write_progress_report.assert_called_once()
+        call_args = mocks["artifacts"].write_progress_report.call_args
+        assert call_args[0][0] == "grid_ctf"
+        assert call_args[0][1] == "test_progress"
+        report = call_args[0][2]
+        assert report.run_id == "test_progress"
+        assert report.cost.total_tokens == 1500
+        assert report.cost.total_cost_usd > 0
 
 
 class TestSessionReportEmptyTrajectory:


### PR DESCRIPTION
## Summary
- Adds `NormalizedProgress`, `CostEfficiency`, `RunProgressReport` dataclasses and `ScenarioNormalizer` class in `knowledge/normalized_metrics.py`
- Maps native scenario scores to consistent [0, 1] reporting scale with configurable floor/ceiling per scenario
- Computes cost-efficiency metrics: tokens per advance, cost per advance, tokens per score point
- Integrates with `ArtifactStore` for persistence (`write_progress_report`, `read_progress_report`, `read_latest_progress_reports`, `read_latest_progress_reports_markdown`)
- All metrics are purely for operator review — not used for backpressure or gating decisions

## Test plan
- [x] 37 new tests in `tests/test_normalized_metrics.py`
- [x] NormalizedProgress construction, serialization, roundtrip
- [x] CostEfficiency construction, serialization, roundtrip
- [x] ScenarioNormalizer: default identity, custom floor/ceiling, clamping, negative floor
- [x] `compute_normalized_progress` from trajectory rows (empty, basic, custom normalizer)
- [x] `compute_cost_efficiency` from role metrics and trajectory (empty, basic, no advances, no score gain, consultation cost)
- [x] RunProgressReport construction, serialization, markdown rendering
- [x] `generate_run_progress_report` integration (empty, basic, custom normalizer, consultation cost)
- [x] ArtifactStore integration: write/read/latest/markdown
- [x] Ruff clean, mypy clean, full test suite passes