### PR TITLE
chore(AC-237): normalize user-facing branding to lowercase autocontext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AutoContext is an iterative strategy generation and evaluation system. It runs a multi-agent loop where LLM agents collaboratively evolve strategies for pluggable scenarios, scoring them through tournament matches (game scenarios) or LLM judge evaluation (agent task scenarios) with Elo-based progression gating.
+autocontext is an iterative strategy generation and evaluation system. It runs a multi-agent loop where LLM agents collaboratively evolve strategies for pluggable scenarios, scoring them through tournament matches (game scenarios) or LLM judge evaluation (agent task scenarios) with Elo-based progression gating.
 
 ## Repository Layout
 
@@ -35,7 +35,7 @@ autocontext/                  # Python package root (pyproject.toml lives here)
   knowledge/                  # Runtime-generated: per-scenario playbooks, analysis, tools, hints, snapshots
   skills/                     # Runtime-generated: operational skill notes per scenario
   runs/                       # Runtime-generated: SQLite DB, event stream, generation artifacts
-ts/                           # TypeScript port of AutoContext modules
+ts/                           # TypeScript port of autocontext modules
   src/                        # Source code (types, judge, storage, execution, runtimes, scenarios, knowledge, mcp, cli)
   tests/                      # Vitest tests (119 tests)
   migrations/                 # Shared SQLite migration SQL (cross-compatible with Python)
@@ -187,7 +187,7 @@ GitHub Actions (`.github/workflows/ci.yml`) runs: ruff check, mypy, pytest, dete
 
 ## TypeScript Port (`ts/`)
 
-A TypeScript port of AutoContext modules under `ts/`, published as `@greyhaven/autoctx`. ESM-only, strict TypeScript, Node.js >=18.
+A TypeScript port of autocontext modules under `ts/`, published as `autoctx`. ESM-only, strict TypeScript, Node.js >=18.
 
 ```bash
 cd ts

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Our Standard
 
-We want AutoContext to be a professional, constructive project for contributors, users, and maintainers. Participants are expected to communicate clearly, stay respectful, and keep technical disagreement focused on the work.
+We want autocontext to be a professional, constructive project for contributors, users, and maintainers. Participants are expected to communicate clearly, stay respectful, and keep technical disagreement focused on the work.
 
 Examples of behavior that contribute to a positive environment:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AutoContext
+# autocontext
 
-AutoContext is a closed-loop system for improving agent behavior over repeated runs.
+autocontext is a closed-loop system for improving agent behavior over repeated runs.
 
 It executes tasks, evaluates outcomes, updates persistent knowledge, and optionally distills successful behavior into cheaper local runtimes. The goal is to move from frontier-model exploration toward validated, reusable, lower-cost execution.
 
@@ -8,7 +8,7 @@ It executes tasks, evaluates outcomes, updates persistent knowledge, and optiona
 
 Most agent systems start every run cold. They do not reliably carry forward what worked, what failed, and what should change next.
 
-AutoContext adds that missing feedback loop:
+autocontext adds that missing feedback loop:
 
 - run the task
 - analyze what happened

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -1,6 +1,6 @@
-# AutoContext
+# autocontext
 
-AutoContext is a control plane for improving agent behavior over repeated runs. It combines multi-agent candidate generation, staged validation, scenario execution, knowledge accumulation, optional local distillation, and OpenClaw-facing APIs.
+autocontext is a control plane for improving agent behavior over repeated runs. It combines multi-agent candidate generation, staged validation, scenario execution, knowledge accumulation, optional local distillation, and OpenClaw-facing APIs.
 
 ## Working Directory
 
@@ -155,7 +155,7 @@ uv run --directory autocontext python scripts/generate_protocol.py
 
 ## OpenClaw / ClawHub
 
-AutoContext exposes:
+autocontext exposes:
 
 - artifact contracts for harnesses, policies, and distilled models
 - REST and MCP operations for evaluate, validate, publish, import, and discover

--- a/autocontext/dashboard/index.html
+++ b/autocontext/dashboard/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>AutoContext Dashboard</title>
+    <title>autocontext Dashboard</title>
     <style>
       body { font-family: Arial, sans-serif; margin: 0; padding: 16px; background: #0f172a; color: #e2e8f0; }
       h1, h2 { margin: 0 0 12px 0; }
@@ -17,7 +17,7 @@
     </style>
   </head>
   <body>
-    <h1>AutoContext Dashboard</h1>
+    <h1>autocontext Dashboard</h1>
     <div class="row">
       <div class="card">
         <h2>Runs</h2>

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -1,6 +1,6 @@
 # External Agent Integration Guide
 
-AutoContext provides three integration surfaces for external agents: the `autoctx` CLI, an MCP server, and a Python SDK. This guide covers them in order of recommended usage.
+autocontext provides three integration surfaces for external agents: the `autoctx` CLI, an MCP server, and a Python SDK. This guide covers them in order of recommended usage.
 
 ## Why CLI-First
 
@@ -190,7 +190,7 @@ Without `--json`, errors appear as formatted Rich console output on stderr.
 
 ### Provider Configuration
 
-Configure which LLM provider AutoContext uses via environment variables:
+Configure which LLM provider autocontext uses via environment variables:
 
 ```bash
 # Anthropic (default)
@@ -225,7 +225,7 @@ Key environment variables:
 
 ### Concrete CLI-First Integration Example
 
-An external agent integrating with AutoContext via CLI:
+An external agent integrating with autocontext via CLI:
 
 ```bash
 #!/usr/bin/env bash
@@ -268,7 +268,7 @@ Use MCP when your agent framework specifically requires a tool-catalog protocol 
 
 - Your agent runtime expects MCP tool discovery and invocation
 - You need interactive, stateful tool sessions (e.g., sandbox create/run/destroy)
-- You want to expose AutoContext as a tool provider in a multi-tool agent
+- You want to expose autocontext as a tool provider in a multi-tool agent
 
 ### When to Prefer CLI
 

--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AutoContext's `autoctx train` command uses [MLX](https://github.com/ml-explore/mlx) to fine-tune local models from exported run data. MLX requires direct access to Apple's Metal GPU framework, which means training must run on the macOS host, not inside a Docker sandbox.
+autocontext's `autoctx train` command uses [MLX](https://github.com/ml-explore/mlx) to fine-tune local models from exported run data. MLX requires direct access to Apple's Metal GPU framework, which means training must run on the macOS host, not inside a Docker sandbox.
 
 Docker containers on macOS run inside a Linux VM and cannot access Metal. The MLX Python package may install on Linux aarch64, but training cannot complete without a Metal-capable Apple Silicon host. Host-side Python environments also cannot be executed directly from the sandbox when they point to macOS-native binaries.
 

--- a/autocontext/docs/sandbox.md
+++ b/autocontext/docs/sandbox.md
@@ -1,6 +1,6 @@
 # Sandbox Modes
 
-AutoContext supports three execution modes for game scenarios, plus judge-based evaluation for agent tasks:
+autocontext supports three execution modes for game scenarios, plus judge-based evaluation for agent tasks:
 
 - `local` executor: runs strategies in a process pool with timeout controls, and applies memory limits in the subprocess path.
 - `primeintellect` executor: runs strategies remotely via PrimeIntellect sandbox lifecycle (create/wait/execute/delete).

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "autoctx"
 version = "0.1.0"
-description = "AutoContext control plane for iterative strategy evolution."
+description = "autocontext control plane for iterative strategy evolution."
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"

--- a/autocontext/src/autocontext/artifacts/models.py
+++ b/autocontext/src/autocontext/artifacts/models.py
@@ -1,6 +1,6 @@
 """Portable artifact schemas for the OpenClaw/ClawHub contract.
 
-Defines Pydantic models for the three artifact types exchanged between AutoContext
+Defines Pydantic models for the three artifact types exchanged between autocontext
 and external systems: harnesses, code policies, and distilled local models.
 Each artifact carries provenance, versioning, and scenario compatibility
 metadata so consumers can discover and validate artifacts portably.
@@ -17,10 +17,10 @@ from pydantic import BaseModel, Field
 class ArtifactProvenance(BaseModel):
     """Tracks which run, generation, and settings produced an artifact."""
 
-    run_id: str = Field(..., min_length=1, description="AutoContext run that produced this artifact")
+    run_id: str = Field(..., min_length=1, description="autocontext run that produced this artifact")
     generation: int = Field(..., ge=0, description="Generation index within the run")
     scenario: str = Field(..., min_length=1, description="Scenario the artifact was produced for")
-    settings: dict[str, Any] = Field(default_factory=dict, description="Relevant AutoContext settings at creation time")
+    settings: dict[str, Any] = Field(default_factory=dict, description="Relevant autocontext settings at creation time")
 
 
 class _ArtifactBase(BaseModel):
@@ -39,7 +39,7 @@ class _ArtifactBase(BaseModel):
 class HarnessArtifact(_ArtifactBase):
     """A validation harness — source code that checks strategy correctness.
 
-    Harnesses are synthesized by AutoContext and can be published to ClawHub so that
+    Harnesses are synthesized by autocontext and can be published to ClawHub so that
     other agents can validate strategies against known constraints.
     """
 
@@ -52,7 +52,7 @@ class HarnessArtifact(_ArtifactBase):
 class PolicyArtifact(_ArtifactBase):
     """A code policy — executable strategy logic for a scenario.
 
-    Policies are the distilled output of AutoContext strategy evolution runs.
+    Policies are the distilled output of autocontext strategy evolution runs.
     They can be shared via ClawHub for benchmarking or warm-starting.
     """
 
@@ -63,10 +63,10 @@ class PolicyArtifact(_ArtifactBase):
 
 
 class DistilledModelArtifact(_ArtifactBase):
-    """A distilled local model — a smaller model trained on AutoContext data.
+    """A distilled local model — a smaller model trained on autocontext data.
 
     These are neural network checkpoints produced by knowledge distillation
-    from AutoContext strategy evolution trajectories.
+    from autocontext strategy evolution trajectories.
     """
 
     artifact_type: Literal["distilled_model"] = Field(default="distilled_model", frozen=True)

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -46,7 +46,7 @@ class AgentTaskRunSummary:
     met_threshold: bool
     termination_reason: str
 
-app = typer.Typer(help="AutoContext control-plane CLI")
+app = typer.Typer(help="autocontext control-plane CLI")
 console = Console()
 
 _PRESET_HELP = f"Apply a named preset ({', '.join(sorted(VALID_PRESET_NAMES))}). Overrides AUTOCONTEXT_PRESET env var."
@@ -356,7 +356,7 @@ def run(
         if json_output:
             _write_json_stdout(dataclasses.asdict(summary))
         else:
-            table = Table(title="AutoContext Run Summary")
+            table = Table(title="autocontext Run Summary")
             table.add_column("Run ID")
             table.add_column("Scenario")
             table.add_column("Generations")
@@ -655,7 +655,7 @@ def ab_test(
     gens: int = typer.Option(3, "--gens", min=1, help="Generations per run"),
     seed: int = typer.Option(42, "--seed", help="Random seed for condition ordering"),
 ) -> None:
-    """Run paired A/B test comparing two AutoContext configurations."""
+    """Run paired A/B test comparing two autocontext configurations."""
     from autocontext.evaluation.ab_runner import ABTestConfig, ABTestRunner
     from autocontext.evaluation.ab_stats import mcnemar_test
 
@@ -721,7 +721,7 @@ def ab_test(
 
 @app.command("mcp-serve")
 def mcp_serve() -> None:
-    """Start AutoContext MCP server on stdio for Claude Code integration."""
+    """Start autocontext MCP server on stdio for Claude Code integration."""
 
     try:
         from autocontext.mcp.server import run_server

--- a/autocontext/src/autocontext/knowledge/export.py
+++ b/autocontext/src/autocontext/knowledge/export.py
@@ -317,7 +317,7 @@ def _scenario_description(scenario: object) -> str:
 
 
 def _clean_lessons(raw_bullets: list[str]) -> list[str]:
-    """Strip AutoContext-internal noise from lesson bullets, keeping prescriptive rules."""
+    """Strip autocontext-internal noise from lesson bullets, keeping prescriptive rules."""
     cleaned: list[str] = []
     for bullet in raw_bullets:
         text = bullet.strip()

--- a/autocontext/src/autocontext/knowledge/package.py
+++ b/autocontext/src/autocontext/knowledge/package.py
@@ -38,7 +38,7 @@ class ConflictPolicy(StrEnum):
 class PackageMetadata(BaseModel):
     """Provenance and compatibility metadata for a strategy package."""
 
-    mts_version: str = Field(default="", description="AutoContext version that created this package")
+    mts_version: str = Field(default="", description="autocontext version that created this package")
     source_run_id: str | None = Field(default=None, description="Run that produced the best strategy")
     created_at: str = Field(
         default_factory=lambda: datetime.now(UTC).isoformat(),

--- a/autocontext/src/autocontext/mcp/server.py
+++ b/autocontext/src/autocontext/mcp/server.py
@@ -1,4 +1,4 @@
-"""AutoContext MCP server -- exposes scenario, knowledge, and run tools via stdio."""
+"""autocontext MCP server -- exposes scenario, knowledge, and run tools via stdio."""
 
 from __future__ import annotations
 

--- a/autocontext/src/autocontext/mcp/tools.py
+++ b/autocontext/src/autocontext/mcp/tools.py
@@ -1,4 +1,4 @@
-"""MCP tool implementations — thin wrappers around existing AutoContext infrastructure."""
+"""MCP tool implementations — thin wrappers around existing autocontext infrastructure."""
 
 from __future__ import annotations
 
@@ -1072,10 +1072,10 @@ def import_package(
 
 
 def get_capabilities() -> dict[str, object]:
-    """Return capability metadata for this AutoContext instance.
+    """Return capability metadata for this autocontext instance.
 
     Lists all available OpenClaw operations and their descriptions,
-    enabling clients to discover what this AutoContext instance can do.
+    enabling clients to discover what this autocontext instance can do.
     """
     return {
         "version": _OPENCLAW_VERSION,
@@ -1157,7 +1157,7 @@ def skill_scenario_artifact_lookup(ctx: MtsToolContext, scenario_name: str) -> l
 
 
 def skill_manifest(ctx: MtsToolContext) -> dict[str, object]:
-    """Return the ClawHub skill manifest for this AutoContext instance."""
+    """Return the ClawHub skill manifest for this autocontext instance."""
     from autocontext.openclaw.skill import MtsSkillWrapper
 
     return MtsSkillWrapper(ctx).manifest().model_dump()

--- a/autocontext/src/autocontext/notifications/__init__.py
+++ b/autocontext/src/autocontext/notifications/__init__.py
@@ -1,4 +1,4 @@
-"""Notification system for AutoContext task results."""
+"""Notification system for autocontext task results."""
 
 from autocontext.notifications.base import EventType, NotificationEvent, Notifier
 from autocontext.notifications.callback import CallbackNotifier

--- a/autocontext/src/autocontext/notifications/slack.py
+++ b/autocontext/src/autocontext/notifications/slack.py
@@ -49,7 +49,7 @@ class SlackWebhookNotifier(Notifier):
             EventType.FAILURE: "❌",
         }.get(event.type, "📌")
 
-        header = f"{emoji} *AutoContext: {event.task_name}*"
+        header = f"{emoji} *autocontext: {event.task_name}*"
         blocks: list[dict] = [
             {"type": "section", "text": {"type": "mrkdwn", "text": header}},
             {"type": "section", "text": {"type": "mrkdwn", "text": event.summary}},

--- a/autocontext/src/autocontext/notifications/stdout.py
+++ b/autocontext/src/autocontext/notifications/stdout.py
@@ -19,8 +19,8 @@ class StdoutNotifier(Notifier):
         try:
             msg = event.summary
             if self._use_logger:
-                logger.info("AutoContext notification: %s", msg)
+                logger.info("autocontext notification: %s", msg)
             else:
-                print(f"[AutoContext] {msg}")
+                print(f"[autocontext] {msg}")
         except Exception:
             pass  # Fire and forget

--- a/autocontext/src/autocontext/openclaw/agent_adapter.py
+++ b/autocontext/src/autocontext/openclaw/agent_adapter.py
@@ -1,4 +1,4 @@
-"""OpenClaw agent adapter for running agents inside the AutoContext harness (AC-193).
+"""OpenClaw agent adapter for running agents inside the autocontext harness (AC-193).
 
 Provides:
 - OpenClawAgentProtocol: structural typing for OpenClaw-compatible agents
@@ -47,7 +47,7 @@ class OpenClawExecutionTrace:
     """Structured capture of an OpenClaw agent execution.
 
     Maps the raw trace dict from an OpenClaw agent into typed fields
-    for AutoContext evaluation records.
+    for autocontext evaluation records.
     """
 
     output: str
@@ -88,7 +88,7 @@ class OpenClawExecutionTrace:
         )
 
     def to_role_usage(self) -> RoleUsage:
-        """Convert trace usage into AutoContext RoleUsage."""
+        """Convert trace usage into autocontext RoleUsage."""
         return RoleUsage(
             input_tokens=self.input_tokens,
             output_tokens=self.output_tokens,
@@ -97,7 +97,7 @@ class OpenClawExecutionTrace:
         )
 
     def to_evaluation_summary(self) -> dict[str, Any]:
-        """Build a summary dict suitable for AutoContext evaluation records."""
+        """Build a summary dict suitable for autocontext evaluation records."""
         return {
             "steps": len(self.steps),
             "tool_calls": len(self.tool_calls),
@@ -107,7 +107,7 @@ class OpenClawExecutionTrace:
         }
 
     def to_role_execution(self, role: str) -> RoleExecution:
-        """Convert trace into an AutoContext RoleExecution record."""
+        """Convert trace into an autocontext RoleExecution record."""
         return RoleExecution(
             role=role,
             content=self.output,
@@ -122,7 +122,7 @@ class OpenClawAgentProtocol(Protocol):
     """Structural typing protocol for OpenClaw-compatible agents.
 
     Any object with an `execute` method matching this signature can be
-    used as an OpenClaw agent inside the AutoContext harness.
+    used as an OpenClaw agent inside the autocontext harness.
     """
 
     def execute(
@@ -161,7 +161,7 @@ class OpenClawClient(LanguageModelClient):
         temperature: float,
         role: str = "",
     ) -> ModelResponse:
-        """Execute the OpenClaw agent and return an AutoContext ModelResponse."""
+        """Execute the OpenClaw agent and return an autocontext ModelResponse."""
         trace_dict = self._execute_with_retry(
             prompt=prompt,
             model=model,

--- a/autocontext/src/autocontext/openclaw/discovery.py
+++ b/autocontext/src/autocontext/openclaw/discovery.py
@@ -1,6 +1,6 @@
 """Discovery and capability advertisement for ClawHub (AC-195).
 
-Allows external clients to discover what AutoContext can serve for a scenario:
+Allows external clients to discover what autocontext can serve for a scenario:
 scenario-to-artifact lookup, capability advertisement, runtime health,
 and client-friendly summaries for ClawHub UX.
 """

--- a/autocontext/src/autocontext/openclaw/models.py
+++ b/autocontext/src/autocontext/openclaw/models.py
@@ -21,7 +21,7 @@ class SkillManifest(BaseModel):
 
     name: str = Field(default="autocontext")
     version: str = Field(default="")
-    description: str = Field(default="AutoContext iterative strategy evolution and evaluation system")
+    description: str = Field(default="autocontext iterative strategy evolution and evaluation system")
     capabilities: list[str] = Field(default_factory=lambda: [
         "scenario_evaluation",
         "strategy_validation",

--- a/autocontext/src/autocontext/openclaw/skill.py
+++ b/autocontext/src/autocontext/openclaw/skill.py
@@ -1,4 +1,4 @@
-"""ClawHub skill wrapper — high-level interface for AutoContext (AC-192)."""
+"""ClawHub skill wrapper — high-level interface for autocontext (AC-192)."""
 from __future__ import annotations
 
 import re
@@ -144,7 +144,7 @@ def _rank_scenarios(
 
 
 class MtsSkillWrapper:
-    """High-level ClawHub skill interface for AutoContext.
+    """High-level ClawHub skill interface for autocontext.
 
     Wraps the low-level MCP tool functions into cohesive workflows
     that external agents can invoke through ClawHub discovery.

--- a/autocontext/src/autocontext/server/__init__.py
+++ b/autocontext/src/autocontext/server/__init__.py
@@ -1,1 +1,1 @@
-"""AutoContext server package for dashboard and stream APIs."""
+"""autocontext server package for dashboard and stream APIs."""

--- a/autocontext/src/autocontext/server/app.py
+++ b/autocontext/src/autocontext/server/app.py
@@ -107,7 +107,7 @@ def create_app(
     run_manager: RunManager | None = None,
 ) -> FastAPI:
     """Factory that creates the FastAPI app, optionally wired to a LoopController."""
-    application = FastAPI(title="AutoContext Dashboard API", version="0.1.0")
+    application = FastAPI(title="autocontext Dashboard API", version="0.1.0")
     application.include_router(cockpit_router)
     application.include_router(knowledge_router)
     application.include_router(notebook_router)

--- a/autocontext/src/autocontext/server/openclaw_api.py
+++ b/autocontext/src/autocontext/server/openclaw_api.py
@@ -188,7 +188,7 @@ def update_distill_job_endpoint(
 
 @router.get("/capabilities")
 def capabilities_endpoint() -> dict[str, Any]:
-    """Return capability metadata for this AutoContext instance."""
+    """Return capability metadata for this autocontext instance."""
     from autocontext.mcp.tools import get_capabilities
 
     return get_capabilities()  # type: ignore[return-value]
@@ -246,7 +246,7 @@ def discovery_scenario_artifacts_endpoint(
 def skill_manifest_endpoint(
     ctx: Annotated[MtsToolContext, Depends(get_openclaw_ctx)],
 ) -> dict[str, Any]:
-    """Return the ClawHub skill manifest for this AutoContext instance."""
+    """Return the ClawHub skill manifest for this autocontext instance."""
     from autocontext.mcp.tools import skill_manifest
 
     return skill_manifest(ctx)  # type: ignore[return-value]

--- a/autocontext/src/autocontext/server/protocol.py
+++ b/autocontext/src/autocontext/server/protocol.py
@@ -1,4 +1,4 @@
-"""WebSocket protocol models for the AutoContext TUI <-> Server boundary.
+"""WebSocket protocol models for the autocontext TUI <-> Server boundary.
 
 This module is the single source of truth for the protocol. All message types
 that flow over ``/ws/interactive`` are defined here as Pydantic models.

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -173,7 +173,7 @@ class ArtifactStore:
         return self.skills_root / f"{scenario_name.replace('_', '-')}-ops"
 
     def read_skills(self, scenario_name: str) -> str:
-        """Read operational lessons for injection into AutoContext agent prompts.
+        """Read operational lessons for injection into autocontext agent prompts.
 
         Extracts only the ``## Operational Lessons`` section from SKILL.md.
         The playbook is already injected separately via ``current_playbook``
@@ -533,7 +533,7 @@ class ArtifactStore:
         skill_content = (
             f"---\nname: {kebab}-ops\ndescription: {desc}\n---\n\n"
             f"# {title} Operational Knowledge\n\n"
-            "Accumulated knowledge from AutoContext strategy evolution.\n\n"
+            "Accumulated knowledge from autocontext strategy evolution.\n\n"
             "## Operational Lessons\n\n"
             "Prescriptive rules derived from what worked and what failed:\n\n"
             f"{lessons_block}\n\n"

--- a/autocontext/src/autocontext/training/__init__.py
+++ b/autocontext/src/autocontext/training/__init__.py
@@ -1,4 +1,4 @@
-"""AutoContext training package — optional MLX-based distillation and autoresearch."""
+"""autocontext training package — optional MLX-based distillation and autoresearch."""
 from __future__ import annotations
 
 from autocontext.training.types import MatchRecord, TrainingRecord

--- a/autocontext/src/autocontext/training/autoresearch/program.py
+++ b/autocontext/src/autocontext/training/autoresearch/program.py
@@ -20,7 +20,7 @@ def render_program(
     Parameters
     ----------
     scenario:
-        Name of the AutoContext scenario (e.g. ``grid_ctf``).
+        Name of the autocontext scenario (e.g. ``grid_ctf``).
     strategy_schema:
         JSON schema or description of the strategy interface.
     playbook_summary:

--- a/autocontext/tests/test_notifications.py
+++ b/autocontext/tests/test_notifications.py
@@ -52,7 +52,7 @@ class TestStdoutNotifier:
         e = NotificationEvent(type=EventType.COMPLETION, task_name="test", score=0.80, round_count=2)
         n.notify(e)
         captured = capsys.readouterr()
-        assert "[AutoContext]" in captured.out
+        assert "[autocontext]" in captured.out
         assert "test" in captured.out
 
     def test_logger_mode(self):

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autoctx",
   "version": "0.1.0",
-  "description": "AutoContext — always-on agent evaluation harness",
+  "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * AutoContext CLI — command-line interface for the evaluation harness.
+ * autocontext CLI — command-line interface for the evaluation harness.
  *
  * Commands:
  *   autoctx judge     — one-shot evaluation

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * autoctx — AutoContext TypeScript toolkit.
+ * autoctx — autocontext TypeScript toolkit.
  */
 
 // Core types

--- a/ts/src/knowledge/skill-package.ts
+++ b/ts/src/knowledge/skill-package.ts
@@ -226,7 +226,7 @@ export function exportAgentTaskSkill(opts: {
 }
 
 /**
- * Clean lesson bullets: strip AutoContext-internal noise, keeping prescriptive rules.
+ * Clean lesson bullets: strip autocontext-internal noise, keeping prescriptive rules.
  */
 export function cleanLessons(rawBullets: string[]): string[] {
   const cleaned: string[] = [];

--- a/ts/src/mcp/server.ts
+++ b/ts/src/mcp/server.ts
@@ -1,5 +1,5 @@
 /**
- * MCP server for AutoContext — agent task evaluation tools.
+ * MCP server for autocontext — agent task evaluation tools.
  * Port of autocontext/src/autocontext/mcp/tools.py (agent task subset).
  */
 

--- a/ts/src/storage/index.ts
+++ b/ts/src/storage/index.ts
@@ -1,5 +1,5 @@
 /**
- * SQLite storage for AutoContext task queue.
+ * SQLite storage for autocontext task queue.
  * Uses better-sqlite3 for synchronous access (same as Python's sqlite3).
  */
 

--- a/ts/src/types/index.ts
+++ b/ts/src/types/index.ts
@@ -1,5 +1,5 @@
 /**
- * Core types for AutoContext — mirrors Python dataclasses with Zod validation.
+ * Core types for autocontext — mirrors Python dataclasses with Zod validation.
  */
 
 import { z } from "zod";


### PR DESCRIPTION
## Summary
- normalize user-facing branding and prose from AutoContext to autocontext
- update docs, dashboard strings, CLI/help text, OpenClaw/MCP/server descriptions, and package metadata
- leave code-level SDK identifiers like the Python AutoContext class unchanged

## Scope
- README and docs prose
- dashboard and notification strings
- package metadata descriptions
- product-facing docstrings and descriptions

## Non-goals
- renaming Python class identifiers or import paths
- broad code or API symbol churn

## Validation
- uv run pytest tests/test_integration_docs.py tests/test_notifications.py tests/test_smoke_judge.py
- git diff --check