### PR TITLE
build: exclude .claude from Python packages

### DIFF
--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -59,6 +59,9 @@ Repository = "https://github.com/greyhaven-ai/autocontext"
 Issues = "https://github.com/greyhaven-ai/autocontext/issues"
 Documentation = "https://github.com/greyhaven-ai/autocontext/tree/main/autocontext/docs"
 
+[tool.hatch.build]
+exclude = [".claude", ".claude/**"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/autocontext"]
 


### PR DESCRIPTION
## Summary
- exclude .claude from Python sdists and wheels
- prevent tracked absolute skill symlinks from breaking release builds
- unblock trusted publishing for tagged releases

## Why
The first trusted publish run for v0.1.1 failed because Hatch tried to package tracked absolute symlinks under autocontext/.claude/skills.