### PR TITLE
ci: update npm trusted publishing and bump 0.1.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,10 +68,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: npm ci
+      - name: Show npm version
+        run: npm --version
       - name: Build package
         run: npm run build
       - name: Publish to npm

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autoctx"
-version = "0.1.1"
+version = "0.1.2"
 description = "autocontext control plane for iterative strategy evolution."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoctx",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoctx",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoctx",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- update the npm publish job to use Node 24 for current trusted publishing requirements
- print the npm version in the workflow for easier diagnostics
- bump the Python and npm package versions to 0.1.2 for a clean synchronized release

## Why
- PyPI 0.1.1 already published successfully
- npm 0.1.1 failed during trusted publishing
- the next clean release should be 0.1.2 on both registries