### PR TITLE
ci: update workflows for Node 24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
       run:
         working-directory: autocontext
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install
@@ -39,12 +39,12 @@ jobs:
       run:
         working-directory: autocontext
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install
@@ -53,7 +53,7 @@ jobs:
         run: uv run pytest --cov=src/autocontext --cov-report=html:htmlcov -m "not live"
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: autocontext/htmlcov/
@@ -66,12 +66,12 @@ jobs:
       run:
         working-directory: autocontext
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install
@@ -103,12 +103,12 @@ jobs:
       AUTOCONTEXT_PRIMEINTELLECT_API_KEY: ${{ secrets.AUTOCONTEXT_PRIMEINTELLECT_API_KEY }}
       AUTOCONTEXT_ANTHROPIC_API_KEY: ${{ secrets.AUTOCONTEXT_ANTHROPIC_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,18 +20,18 @@ jobs:
       run:
         working-directory: autocontext
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Build Python package
         run: uv build
       - name: Upload Python dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: python-dist
           path: autocontext/dist/*
@@ -46,7 +46,7 @@ jobs:
       id-token: write
     steps:
       - name: Download Python dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: python-dist
           path: dist
@@ -65,8 +65,8 @@ jobs:
       run:
         working-directory: ts
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary
- update CI and publish workflows to newer GitHub Action majors that support the Node 24 runner migration
- upgrade checkout, setup-python, setup-node, setup-uv, and artifact actions
- close the remaining Node 20 deprecation gap called out by GitHub Actions

## Scope
- .github/workflows/ci.yml
- .github/workflows/publish.yml