### PR TITLE
fix(AC-241): auto-wire provider into generated agent-task evaluate_output

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/agent_task_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_codegen.py
@@ -43,8 +43,8 @@ def generate_agent_task_class(spec: AgentTaskSpec, name: str = "custom_agent_tas
     source = textwrap.dedent(f'''\
         from __future__ import annotations
 
-        from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
         from autocontext.execution.judge import LLMJudge
+        from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
 
 
         class {cls_name}(AgentTaskInterface):
@@ -80,13 +80,15 @@ def generate_agent_task_class(spec: AgentTaskSpec, name: str = "custom_agent_tas
                 calibration_examples: list[dict] | None = None,
                 pinned_dimensions: list[str] | None = None,
             ) -> AgentTaskResult:
-                def llm_fn(system: str, user: str) -> str:
-                    raise NotImplementedError("llm_fn must be injected at runtime")
+                from autocontext.config import load_settings
+                from autocontext.providers.registry import get_provider
 
+                settings = load_settings()
+                provider = get_provider(settings)
                 judge = LLMJudge(
                     model=self._judge_model,
                     rubric=self._rubric,
-                    llm_fn=llm_fn,
+                    provider=provider,
                 )
                 # Use passed-in context or fall back to class defaults
                 ref_ctx = reference_context or self._reference_context
@@ -143,7 +145,6 @@ def generate_agent_task_class(spec: AgentTaskSpec, name: str = "custom_agent_tas
             ) -> str:
                 if not self._revision_prompt and self._max_rounds <= 1:
                     return output
-                # Default revision: return original (llm_fn must be injected at runtime)
                 return output
     ''')
     return source

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_codegen.py
@@ -85,8 +85,9 @@ def generate_agent_task_class(spec: AgentTaskSpec, name: str = "custom_agent_tas
 
                 settings = load_settings()
                 provider = get_provider(settings)
+                effective_model = self._judge_model or settings.judge_model or provider.default_model()
                 judge = LLMJudge(
-                    model=self._judge_model,
+                    model=effective_model,
                     rubric=self._rubric,
                     provider=provider,
                 )
@@ -94,7 +95,7 @@ def generate_agent_task_class(spec: AgentTaskSpec, name: str = "custom_agent_tas
                 ref_ctx = reference_context or self._reference_context
                 req_con = required_concepts or self._required_concepts
                 result = judge.evaluate(
-                    self._task_prompt,
+                    self.get_task_prompt(state),
                     output,
                     reference_context=ref_ctx,
                     required_concepts=req_con,

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
@@ -55,7 +55,7 @@ _EXAMPLE_SPEC = {
 AGENT_TASK_DESIGNER_SYSTEM = (
     "You are a scenario designer for AutoContext, an agent evaluation system. "
     "Given a natural language description, produce an AgentTaskSpec JSON "
-    "that defines a task prompt, evaluation rubric, output format, and judge model.\n\n"
+    "that defines a task prompt, evaluation rubric, output format, and optional judge model.\n\n"
     f"The output must be valid JSON wrapped in delimiters:\n"
     f"{SPEC_START}\n{{ ... }}\n{SPEC_END}\n\n"
     "## AgentTaskSpec Schema\n\n"
@@ -87,7 +87,7 @@ AGENT_TASK_DESIGNER_SYSTEM = (
     "(e.g. an outage report, a code snippet, a dataset)\n"
     "- `judge_rubric` must list specific evaluation dimensions with criteria\n"
     "- `output_format` must be one of: free_text, json_schema, code\n"
-    "- `judge_model` should be a valid model identifier\n"
+    "- `judge_model` is optional; use an empty string to fall back to the configured judge/default provider model\n"
     "- `reference_context` (optional) — authoritative domain knowledge the judge should use to verify factual accuracy. "
     "Include this when the task requires domain-specific knowledge that the judge LLM may not have. "
     "When provided, the judge will score factual_accuracy as a mandatory dimension.\n"

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_validator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_validator.py
@@ -107,6 +107,13 @@ def validate_execution(source: str) -> list[str]:
     """Validate by importing and instantiating the generated class."""
     errors: list[str] = []
 
+    # Reject unresolved llm_fn placeholder — it always fails at runtime (AC-241).
+    if "llm_fn must be injected at runtime" in source:
+        errors.append(
+            "evaluate_output contains unresolved llm_fn placeholder; "
+            "use get_provider(load_settings()) instead"
+        )
+
     with tempfile.TemporaryDirectory() as tmp:
         mod_path = Path(tmp) / "agent_task_mod.py"
         mod_path.write_text(source, encoding="utf-8")

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_validator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_validator.py
@@ -5,6 +5,7 @@ import importlib.util
 import sys
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
 
@@ -106,13 +107,18 @@ def validate_syntax(source: str) -> list[str]:
 def validate_execution(source: str) -> list[str]:
     """Validate by importing and instantiating the generated class."""
     errors: list[str] = []
-
-    # Reject unresolved llm_fn placeholder — it always fails at runtime (AC-241).
-    if "llm_fn must be injected at runtime" in source:
-        errors.append(
-            "evaluate_output contains unresolved llm_fn placeholder; "
-            "use get_provider(load_settings()) instead"
-        )
+    try:
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "LLMJudge":
+                if any(keyword.arg == "llm_fn" for keyword in node.keywords):
+                    errors.append(
+                        "evaluate_output uses legacy llm_fn wiring; use provider= with runtime provider resolution"
+                    )
+                    break
+    except SyntaxError:
+        # Syntax issues are handled by validate_syntax().
+        pass
 
     with tempfile.TemporaryDirectory() as tmp:
         mod_path = Path(tmp) / "agent_task_mod.py"
@@ -189,5 +195,27 @@ def validate_execution(source: str) -> list[str]:
                 errors.append("validate_context() must return a list")
         except Exception as exc:
             errors.append(f"validate_context() raised: {exc}")
+
+        try:
+            mock_settings = MagicMock()
+            mock_settings.judge_model = "configured-judge-model"
+            mock_provider = MagicMock()
+            mock_provider.default_model.return_value = "provider-default-model"
+            mock_result = MagicMock()
+            mock_result.score = 0.5
+            mock_result.reasoning = "validator smoke test"
+            mock_result.dimension_scores = {}
+            mock_result.internal_retries = 0
+
+            with (
+                patch("autocontext.config.load_settings", return_value=mock_settings),
+                patch("autocontext.providers.registry.get_provider", return_value=mock_provider),
+                patch("autocontext.execution.judge.LLMJudge.evaluate", return_value=mock_result),
+            ):
+                eval_result = instance.evaluate_output("validator smoke output", prepared)
+                if not hasattr(eval_result, "score"):
+                    errors.append("evaluate_output() did not return an AgentTaskResult-like object")
+        except Exception as exc:
+            errors.append(f"evaluate_output() raised: {exc}")
 
     return errors

--- a/autocontext/tests/test_eval_provider_wiring.py
+++ b/autocontext/tests/test_eval_provider_wiring.py
@@ -41,6 +41,12 @@ class TestCodegenNoPlaceholder:
         assert "provider=provider" in source
         assert "llm_fn=" not in source
 
+    def test_generated_code_resolves_model_from_settings_when_empty(self) -> None:
+        """Generated evaluate_output should fall back to runtime judge model resolution."""
+        source = generate_agent_task_class(SAMPLE_SPEC, name="haiku_task")
+        assert "settings.judge_model" in source
+        assert "provider.default_model()" in source
+
     def test_generated_code_syntax_valid(self) -> None:
         source = generate_agent_task_class(SAMPLE_SPEC, name="haiku_task")
         errors = validate_syntax(source)
@@ -116,6 +122,28 @@ class TestGeneratedEvaluateOutput:
             result = instance.evaluate_output("some output", {})
             assert result.score == 0.5
 
+    def test_evaluate_output_uses_runtime_judge_model_when_spec_model_empty(self) -> None:
+        """Empty judge_model should fall back to configured settings judge model."""
+        instance = self._build_instance()
+
+        mock_provider = MagicMock()
+        mock_provider.default_model.return_value = "provider-fallback-model"
+        mock_result = MagicMock()
+        mock_result.score = 0.6
+        mock_result.reasoning = "OK"
+        mock_result.dimension_scores = {}
+        mock_result.internal_retries = 0
+
+        with (
+            patch("autocontext.config.load_settings", return_value=MagicMock(judge_model="runtime-judge-model")),
+            patch("autocontext.providers.registry.get_provider", return_value=mock_provider),
+            patch("autocontext.execution.judge.LLMJudge.evaluate", return_value=mock_result),
+            patch("autocontext.execution.judge.LLMJudge.__init__", return_value=None) as mock_init,
+        ):
+            result = instance.evaluate_output("some output", {})
+            assert result.score == 0.6
+            assert mock_init.call_args.kwargs["model"] == "runtime-judge-model"
+
     def test_evaluate_output_passes_reference_context(self) -> None:
         """Reference context should be forwarded to the judge."""
         spec = AgentTaskSpec(
@@ -182,7 +210,7 @@ class TestGeneratedEvaluateOutput:
 
 class TestValidatorCatchesPlaceholder:
     def test_validator_rejects_llm_fn_placeholder(self) -> None:
-        """validate_execution should catch the broken llm_fn placeholder."""
+        """validate_execution should fail by exercising the broken eval path."""
         # Hand-craft source with the old broken pattern
         broken_source = '''\
 from __future__ import annotations
@@ -215,7 +243,7 @@ class BrokenAgentTask(AgentTaskInterface):
         return self._task_prompt
 '''
         errors = validate_execution(broken_source)
-        assert any("llm_fn" in e or "provider" in e for e in errors), (
+        assert any("evaluate_output()" in e or "llm_fn" in e for e in errors), (
             f"Expected validation error about llm_fn placeholder, got: {errors}"
         )
 

--- a/autocontext/tests/test_eval_provider_wiring.py
+++ b/autocontext/tests/test_eval_provider_wiring.py
@@ -1,0 +1,233 @@
+"""Tests for AC-241: Fix generated agent-task eval provider wiring.
+
+Ensures generated agent-task scenarios auto-wire the provider into
+evaluate_output instead of using a broken llm_fn placeholder.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from autocontext.scenarios.custom.agent_task_codegen import generate_agent_task_class
+from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+from autocontext.scenarios.custom.agent_task_validator import validate_execution, validate_syntax
+
+# A minimal valid spec for testing.
+SAMPLE_SPEC = AgentTaskSpec(
+    task_prompt="Write a haiku about testing.",
+    judge_rubric="Evaluate haiku quality: 5-7-5 syllable structure.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Codegen: generated code must not contain placeholder llm_fn
+# ---------------------------------------------------------------------------
+
+class TestCodegenNoPlaceholder:
+    def test_generated_code_does_not_contain_llm_fn_placeholder(self) -> None:
+        """The broken 'llm_fn must be injected at runtime' pattern must be gone."""
+        source = generate_agent_task_class(SAMPLE_SPEC, name="haiku_task")
+        assert "llm_fn must be injected at runtime" not in source
+
+    def test_generated_code_uses_provider(self) -> None:
+        """Generated evaluate_output should use get_provider / load_settings."""
+        source = generate_agent_task_class(SAMPLE_SPEC, name="haiku_task")
+        assert "get_provider" in source
+        assert "load_settings" in source
+
+    def test_generated_code_passes_provider_to_judge(self) -> None:
+        """LLMJudge should receive provider=, not llm_fn=."""
+        source = generate_agent_task_class(SAMPLE_SPEC, name="haiku_task")
+        assert "provider=provider" in source
+        assert "llm_fn=" not in source
+
+    def test_generated_code_syntax_valid(self) -> None:
+        source = generate_agent_task_class(SAMPLE_SPEC, name="haiku_task")
+        errors = validate_syntax(source)
+        assert errors == [], f"Syntax errors: {errors}"
+
+    def test_generated_code_execution_valid(self) -> None:
+        source = generate_agent_task_class(SAMPLE_SPEC, name="haiku_task")
+        errors = validate_execution(source)
+        assert errors == [], f"Execution errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Generated evaluate_output calls provider correctly
+# ---------------------------------------------------------------------------
+
+class TestGeneratedEvaluateOutput:
+    def _build_instance(self, spec: AgentTaskSpec | None = None, name: str = "test_task") -> object:
+        """Generate, compile, and instantiate a generated agent task."""
+        source = generate_agent_task_class(spec or SAMPLE_SPEC, name=name)
+        ns: dict = {}
+        exec(compile(source, "<test>", "exec"), ns)  # noqa: S102
+        cls_name = name.split("_")
+        pascal = "".join(p.capitalize() for p in cls_name) + "AgentTask"
+        return ns[pascal]()
+
+    def test_evaluate_output_calls_provider(self) -> None:
+        """evaluate_output should call get_provider and pass it to LLMJudge."""
+        instance = self._build_instance()
+
+        mock_provider = MagicMock()
+        mock_result = MagicMock()
+        mock_result.score = 0.8
+        mock_result.reasoning = "Good"
+        mock_result.dimension_scores = {}
+        mock_result.internal_retries = 0
+
+        with (
+            patch(
+                "autocontext.config.load_settings",
+                return_value=MagicMock(),
+            ) as mock_load,
+            patch(
+                "autocontext.providers.registry.get_provider",
+                return_value=mock_provider,
+            ) as mock_get,
+            patch(
+                "autocontext.execution.judge.LLMJudge.evaluate",
+                return_value=mock_result,
+            ),
+        ):
+            result = instance.evaluate_output("test output", {})
+            mock_load.assert_called_once()
+            mock_get.assert_called_once()
+            assert result.score == 0.8
+
+    def test_evaluate_output_no_not_implemented_error(self) -> None:
+        """evaluate_output must not raise NotImplementedError."""
+        instance = self._build_instance()
+
+        mock_provider = MagicMock()
+        mock_result = MagicMock()
+        mock_result.score = 0.5
+        mock_result.reasoning = "OK"
+        mock_result.dimension_scores = {}
+        mock_result.internal_retries = 0
+
+        with (
+            patch("autocontext.config.load_settings", return_value=MagicMock()),
+            patch("autocontext.providers.registry.get_provider", return_value=mock_provider),
+            patch("autocontext.execution.judge.LLMJudge.evaluate", return_value=mock_result),
+        ):
+            # This should NOT raise NotImplementedError
+            result = instance.evaluate_output("some output", {})
+            assert result.score == 0.5
+
+    def test_evaluate_output_passes_reference_context(self) -> None:
+        """Reference context should be forwarded to the judge."""
+        spec = AgentTaskSpec(
+            task_prompt="Write about RLMs.",
+            judge_rubric="Check accuracy",
+            reference_context="RLM = Recursive Language Model",
+            required_concepts=["context folding"],
+        )
+        instance = self._build_instance(spec, name="rlm_task")
+
+        mock_provider = MagicMock()
+        mock_result = MagicMock()
+        mock_result.score = 0.9
+        mock_result.reasoning = "Accurate"
+        mock_result.dimension_scores = {}
+        mock_result.internal_retries = 0
+
+        with (
+            patch("autocontext.config.load_settings", return_value=MagicMock()),
+            patch("autocontext.providers.registry.get_provider", return_value=mock_provider),
+            patch("autocontext.execution.judge.LLMJudge.evaluate", return_value=mock_result) as mock_eval,
+        ):
+            instance.evaluate_output(
+                "test output", {},
+                reference_context="Custom ref",
+                required_concepts=["custom concept"],
+            )
+            # Verify judge.evaluate was called with the passed-in context
+            call_kwargs = mock_eval.call_args
+            assert call_kwargs.kwargs.get("reference_context") == "Custom ref"
+            assert call_kwargs.kwargs.get("required_concepts") == ["custom concept"]
+
+    def test_evaluate_output_falls_back_to_class_defaults(self) -> None:
+        """When no ref context is passed, fall back to class defaults."""
+        spec = AgentTaskSpec(
+            task_prompt="Write about RLMs.",
+            judge_rubric="Check accuracy",
+            reference_context="Default ref context",
+            required_concepts=["default concept"],
+        )
+        instance = self._build_instance(spec, name="default_task")
+
+        mock_provider = MagicMock()
+        mock_result = MagicMock()
+        mock_result.score = 0.7
+        mock_result.reasoning = "OK"
+        mock_result.dimension_scores = {}
+        mock_result.internal_retries = 0
+
+        with (
+            patch("autocontext.config.load_settings", return_value=MagicMock()),
+            patch("autocontext.providers.registry.get_provider", return_value=mock_provider),
+            patch("autocontext.execution.judge.LLMJudge.evaluate", return_value=mock_result) as mock_eval,
+        ):
+            instance.evaluate_output("test output", {})
+            call_kwargs = mock_eval.call_args
+            assert call_kwargs.kwargs.get("reference_context") == "Default ref context"
+            assert call_kwargs.kwargs.get("required_concepts") == ["default concept"]
+
+
+# ---------------------------------------------------------------------------
+# Validator catches placeholder pattern
+# ---------------------------------------------------------------------------
+
+class TestValidatorCatchesPlaceholder:
+    def test_validator_rejects_llm_fn_placeholder(self) -> None:
+        """validate_execution should catch the broken llm_fn placeholder."""
+        # Hand-craft source with the old broken pattern
+        broken_source = '''\
+from __future__ import annotations
+from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
+from autocontext.execution.judge import LLMJudge
+
+class BrokenAgentTask(AgentTaskInterface):
+    name = "broken"
+    _task_prompt = "test"
+    _rubric = "test"
+    _judge_model = "test-model"
+
+    def get_task_prompt(self, state: dict) -> str:
+        return self._task_prompt
+
+    def evaluate_output(self, output: str, state: dict, **kwargs) -> AgentTaskResult:
+        def llm_fn(system: str, user: str) -> str:
+            raise NotImplementedError("llm_fn must be injected at runtime")
+        judge = LLMJudge(model=self._judge_model, rubric=self._rubric, llm_fn=llm_fn)
+        result = judge.evaluate(self._task_prompt, output)
+        return AgentTaskResult(score=result.score, reasoning=result.reasoning)
+
+    def get_rubric(self) -> str:
+        return self._rubric
+
+    def initial_state(self, seed: int | None = None) -> dict:
+        return {}
+
+    def describe_task(self) -> str:
+        return self._task_prompt
+'''
+        errors = validate_execution(broken_source)
+        assert any("llm_fn" in e or "provider" in e for e in errors), (
+            f"Expected validation error about llm_fn placeholder, got: {errors}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Revise_output comment is cleaned up too
+# ---------------------------------------------------------------------------
+
+class TestReviseOutputCleaned:
+    def test_revise_output_no_llm_fn_comment(self) -> None:
+        """The revise_output method should not reference llm_fn in comments."""
+        source = generate_agent_task_class(SAMPLE_SPEC, name="clean_task")
+        # The old comment "llm_fn must be injected at runtime" in revise_output
+        # should be removed or rewritten
+        assert source.count("llm_fn") == 0


### PR DESCRIPTION
## Summary
- Replaces the broken `llm_fn` placeholder in generated `evaluate_output` with proper `get_provider(load_settings())` wiring — matching the pattern already used by `TemplateAgentTask`
- Uses lazy imports inside `evaluate_output` for robustness with dynamically loaded modules
- Adds validator check in `validate_execution()` to reject the `llm_fn` placeholder early (before scaffolding hangs)
- Removes the stale `llm_fn` comment from `revise_output`

## Root cause
`agent_task_codegen.py` generated code with `def llm_fn(...): raise NotImplementedError(...)` passed to `LLMJudge(llm_fn=llm_fn)`. When `evaluate_output` was called, the judge tried to use this placeholder and crashed with `NotImplementedError`, causing scaffolding timeouts.

## Test plan
- [x] 11 new tests in `tests/test_eval_provider_wiring.py`
- [x] Generated code no longer contains `llm_fn` placeholder
- [x] Generated code uses `get_provider`/`load_settings` with lazy imports
- [x] Generated code passes `provider=provider` to `LLMJudge` (not `llm_fn=`)
- [x] `evaluate_output` correctly calls provider (mocked)
- [x] Reference context / required concepts pass-through works
- [x] Class default fallback works
- [x] Validator rejects old placeholder pattern
- [x] All 42 existing `test_agent_task_pipeline.py` tests pass
- [x] Ruff clean, mypy clean, full suite passes