### PR TITLE
feat(AC-243): simulation-style scenario contract for action-trace evaluation

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from autocontext.scenarios.agent_task import AgentTaskInterface
+from autocontext.scenarios.base import ScenarioInterface
 from autocontext.scenarios.custom.agent_task_codegen import generate_agent_task_class
 from autocontext.scenarios.custom.agent_task_designer import design_agent_task
 from autocontext.scenarios.custom.agent_task_validator import (
@@ -18,6 +19,10 @@ from autocontext.scenarios.custom.agent_task_validator import (
     validate_syntax,
 )
 from autocontext.scenarios.custom.registry import CUSTOM_SCENARIOS_DIR
+from autocontext.scenarios.custom.simulation_creator import (
+    SimulationCreator,
+    should_use_simulation_family,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,12 +63,17 @@ class AgentTaskCreator:
         name_words = unique[:3] if len(unique) >= 3 else unique[:2] if unique else ["custom"]
         return "_".join(name_words)
 
-    def create(self, description: str) -> AgentTaskInterface:
+    def create(self, description: str) -> AgentTaskInterface | ScenarioInterface:
         """Run the full pipeline: design → validate → codegen → validate → load → register.
 
         Returns:
-            An instance of the generated AgentTaskInterface subclass.
+            An instance of the generated scenario family implementation.
         """
+        name = self.derive_name(description)
+        if should_use_simulation_family(description):
+            logger.info("routing description to simulation creator")
+            return SimulationCreator(self.llm_fn, self.knowledge_root).create(description, name=name)
+
         # 1. Design
         logger.info("designing agent task from description")
         spec = design_agent_task(description, self.llm_fn)
@@ -79,7 +89,6 @@ class AgentTaskCreator:
             raise ValueError(f"intent validation failed: {'; '.join(intent_errors)}")
 
         # 3. Derive name and generate code
-        name = self.derive_name(description)
         logger.info("generating code for agent task '%s'", name)
         source = generate_agent_task_class(spec, name=name)
 

--- a/autocontext/src/autocontext/scenarios/custom/simulation_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/simulation_codegen.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import re
+
+from autocontext.scenarios.custom.simulation_spec import SimulationSpec
+
+
+def _class_name(name: str) -> str:
+    parts = re.split(r"[^a-zA-Z0-9]+", name)
+    return "".join(part.capitalize() for part in parts if part) + "Simulation"
+
+
+def generate_simulation_class(spec: SimulationSpec, name: str) -> str:
+    class_name = _class_name(name)
+    action_specs = ",\n".join(
+        "            ActionSpec("
+        f"name={action.name!r}, "
+        f"description={action.description!r}, "
+        f"parameters={action.parameters!r}, "
+        f"preconditions={action.preconditions!r}, "
+        f"effects={action.effects!r})"
+        for action in spec.actions
+    )
+    required_actions = [action.name for action in spec.actions]
+    return f'''from __future__ import annotations
+
+from typing import Any
+
+from autocontext.scenarios.simulation import (
+    Action,
+    ActionResult,
+    ActionSpec,
+    ActionTrace,
+    EnvironmentSpec,
+    SimulationInterface,
+    SimulationResult,
+)
+
+
+class {class_name}(SimulationInterface):
+    name = {name!r}
+
+    def describe_scenario(self) -> str:
+        return {spec.description!r}
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name={name!r},
+            description={spec.environment_description!r},
+            available_actions=[
+{action_specs}
+            ],
+            initial_state_description={spec.initial_state_description!r},
+            success_criteria={spec.success_criteria!r},
+            failure_modes={spec.failure_modes!r},
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {{
+            "seed": seed or 0,
+            "step": 0,
+            "completed_actions": [],
+            "failed_actions": [],
+            "timeline": [],
+            "terminal": False,
+        }}
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        completed = set(state.get("completed_actions", []))
+        return [spec for spec in self.describe_environment().available_actions if spec.name not in completed]
+
+    def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+        specs = {{spec.name: spec for spec in self.describe_environment().available_actions}}
+        spec = specs.get(action.name)
+        if spec is None:
+            return False, f"unknown action: {{action.name}}"
+        completed = set(state.get("completed_actions", []))
+        for requirement in spec.preconditions:
+            if requirement not in completed:
+                return False, f"precondition not met for {{action.name}}: {{requirement}}"
+        return True, ""
+
+    def execute_action(self, state: dict[str, Any], action: Action) -> tuple[ActionResult, dict[str, Any]]:
+        valid, reason = self.validate_action(state, action)
+        next_state = dict(state)
+        next_state["timeline"] = list(state.get("timeline", []))
+        if not valid:
+            next_state["failed_actions"] = [*state.get("failed_actions", []), action.name]
+            return ActionResult(success=False, output="", state_changes={{}}, error=reason), next_state
+        next_state["completed_actions"] = [*state.get("completed_actions", []), action.name]
+        next_state["timeline"].append({{"action": action.name, "parameters": action.parameters}})
+        return (
+            ActionResult(
+                success=True,
+                output=f"executed {{action.name}}",
+                state_changes={{
+                    "completed_actions": list(next_state["completed_actions"])
+                }},
+                side_effects=[action.name],
+            ),
+            next_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        required = set({required_actions!r})
+        completed = set(state.get("completed_actions", []))
+        return required.issubset(completed) or state.get("step", 0) >= {spec.max_steps}
+
+    def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+        required = set({required_actions!r})
+        completed = set(final_state.get("completed_actions", []))
+        completion = len(required & completed) / len(required) if required else 1.0
+        ordering = trace.success_rate
+        failures = sum(1 for record in trace.records if not record.result.success)
+        recovery = 1.0 if failures == 0 else max(0.2, 1.0 - (failures / max(len(trace.records), 1)))
+        score = round((completion * 0.5) + (ordering * 0.3) + (recovery * 0.2), 4)
+        return SimulationResult(
+            score=score,
+            reasoning=f"Completed {{len(completed)}} of {{len(required)}} required actions.",
+            dimension_scores={{
+                "completion": round(completion, 4),
+                "ordering": round(ordering, 4),
+                "recovery": round(recovery, 4),
+            }},
+            workflow_complete=required.issubset(completed),
+            actions_taken=len(trace.records),
+            actions_successful=sum(1 for record in trace.records if record.result.success),
+            recovery_attempts=failures,
+            rollback_quality=1.0 if failures == 0 else recovery,
+        )
+
+    def get_rubric(self) -> str:
+        return "Evaluate on completion, correct dependency ordering, and recovery quality."
+
+    def max_steps(self) -> int:
+        return {spec.max_steps}
+'''

--- a/autocontext/src/autocontext/scenarios/custom/simulation_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/simulation_creator.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from pathlib import Path
+
+from autocontext.scenarios.base import ScenarioInterface
+from autocontext.scenarios.custom.loader import load_custom_scenario
+from autocontext.scenarios.custom.registry import CUSTOM_SCENARIOS_DIR
+from autocontext.scenarios.custom.simulation_codegen import generate_simulation_class
+from autocontext.scenarios.custom.simulation_designer import design_simulation
+from autocontext.scenarios.custom.simulation_spec import SimulationSpec
+
+logger = logging.getLogger(__name__)
+
+
+def should_use_simulation_family(description: str) -> bool:
+    lowered = description.lower()
+    keywords = (
+        "stateful", "simulation", "workflow", "orchestration", "api",
+        "rollback", "retry", "cancellation", "transaction", "debug",
+        "diagnos", "evidence", "side effect",
+    )
+    return any(keyword in lowered for keyword in keywords)
+
+
+def validate_simulation_spec(spec: SimulationSpec) -> list[str]:
+    errors: list[str] = []
+    if not spec.description.strip():
+        errors.append("description is required")
+    if not spec.environment_description.strip():
+        errors.append("environment_description is required")
+    if len(spec.actions) < 2:
+        errors.append("simulation must define at least two actions")
+    names = [action.name for action in spec.actions]
+    if len(names) != len(set(names)):
+        errors.append("action names must be unique")
+    if spec.max_steps <= 0:
+        errors.append("max_steps must be positive")
+    return errors
+
+
+class SimulationCreator:
+    def __init__(self, llm_fn: Callable[[str, str], str], knowledge_root: Path) -> None:
+        self.llm_fn = llm_fn
+        self.knowledge_root = knowledge_root
+
+    def create(self, description: str, name: str) -> ScenarioInterface:
+        spec = design_simulation(description, self.llm_fn)
+        errors = validate_simulation_spec(spec)
+        if errors:
+            raise ValueError(f"simulation spec validation failed: {'; '.join(errors)}")
+
+        custom_dir = self.knowledge_root / CUSTOM_SCENARIOS_DIR
+        scenario_dir = custom_dir / name
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+
+        (scenario_dir / "scenario.py").write_text(generate_simulation_class(spec, name=name), encoding="utf-8")
+        (scenario_dir / "spec.json").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "scenario_type": "simulation",
+                    "description": spec.description,
+                    "environment_description": spec.environment_description,
+                    "initial_state_description": spec.initial_state_description,
+                    "success_criteria": spec.success_criteria,
+                    "failure_modes": spec.failure_modes,
+                    "max_steps": spec.max_steps,
+                    "actions": [
+                        {
+                            "name": action.name,
+                            "description": action.description,
+                            "parameters": action.parameters,
+                            "preconditions": action.preconditions,
+                            "effects": action.effects,
+                        }
+                        for action in spec.actions
+                    ],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        (scenario_dir / "scenario_type.txt").write_text("simulation", encoding="utf-8")
+
+        cls = load_custom_scenario(custom_dir, name)
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        SCENARIO_REGISTRY[name] = cls
+        logger.info("registered simulation scenario '%s'", name)
+        return cls()

--- a/autocontext/src/autocontext/scenarios/custom/simulation_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/simulation_designer.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+
+from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel, SimulationSpec
+
+SIM_SPEC_START = "<!-- SIMULATION_SPEC_START -->"
+SIM_SPEC_END = "<!-- SIMULATION_SPEC_END -->"
+
+_EXAMPLE_SPEC = {
+    "description": "Recover a multi-step API workflow after a mid-flow cancellation.",
+    "environment_description": "Mock booking system with flight, hotel, and transport dependencies.",
+    "initial_state_description": "No bookings yet. APIs are healthy. Cancellation can occur mid-flow.",
+    "success_criteria": [
+        "flight, hotel, and transport are all booked consistently",
+        "if a booking fails mid-flow, the agent either compensates or rolls back cleanly",
+    ],
+    "failure_modes": ["flight cancellation", "booking dependency mismatch", "partial side effects left behind"],
+    "max_steps": 8,
+    "actions": [
+        {
+            "name": "book_flight",
+            "description": "Reserve a flight that satisfies user constraints.",
+            "parameters": {"flight_id": "string"},
+            "preconditions": [],
+            "effects": ["flight_reserved"],
+        },
+        {
+            "name": "book_hotel",
+            "description": "Reserve a hotel matched to the trip dates.",
+            "parameters": {"hotel_id": "string"},
+            "preconditions": ["book_flight"],
+            "effects": ["hotel_reserved"],
+        },
+    ],
+}
+
+SIMULATION_DESIGNER_SYSTEM = (
+    "You are a scenario designer for autocontext. "
+    "Given a natural-language request for a stateful or action-trace task, "
+    "produce a SimulationSpec JSON wrapped in delimiters.\n\n"
+    f"{SIM_SPEC_START}\n{{ ... }}\n{SIM_SPEC_END}\n\n"
+    "Schema:\n"
+    "{\n"
+    '  "description": "human readable scenario summary",\n'
+    '  "environment_description": "what the mock environment models",\n'
+    '  "initial_state_description": "starting state narrative",\n'
+    '  "success_criteria": ["condition 1", "condition 2"],\n'
+    '  "failure_modes": ["failure 1"],\n'
+    '  "max_steps": 8,\n'
+    '  "actions": [\n'
+    "    {\n"
+    '      "name": "action_name",\n'
+    '      "description": "what the action does",\n'
+    '      "parameters": {"param": "type"},\n'
+    '      "preconditions": ["previous_action_name"],\n'
+    '      "effects": ["effect description"]\n'
+    "    }\n"
+    "  ]\n"
+    "}\n\n"
+    "Rules:\n"
+    "- model the task as an environment with explicit actions and dependencies\n"
+    "- use action names that are short, stable, and snake_case\n"
+    "- use preconditions to represent valid ordering constraints\n"
+    "- include failure modes and at least two success criteria\n"
+    "- keep the action set minimal but sufficient to complete and recover the workflow\n\n"
+    f"Example:\n{SIM_SPEC_START}\n{json.dumps(_EXAMPLE_SPEC, indent=2)}\n{SIM_SPEC_END}\n"
+)
+
+
+def parse_simulation_spec(text: str) -> SimulationSpec:
+    pattern = re.escape(SIM_SPEC_START) + r"\s*(.*?)\s*" + re.escape(SIM_SPEC_END)
+    match = re.search(pattern, text, re.DOTALL)
+    if not match:
+        raise ValueError("response does not contain SIMULATION_SPEC delimiters")
+    data = json.loads(match.group(1).strip())
+    return SimulationSpec(
+        description=data["description"],
+        environment_description=data["environment_description"],
+        initial_state_description=data["initial_state_description"],
+        success_criteria=data["success_criteria"],
+        failure_modes=data.get("failure_modes", []),
+        actions=[
+            SimulationActionSpecModel(
+                name=raw["name"],
+                description=raw["description"],
+                parameters=raw.get("parameters", {}),
+                preconditions=raw.get("preconditions", []),
+                effects=raw.get("effects", []),
+            )
+            for raw in data["actions"]
+        ],
+        max_steps=data.get("max_steps", 10),
+    )
+
+
+def design_simulation(description: str, llm_fn: Callable[[str, str], str]) -> SimulationSpec:
+    return parse_simulation_spec(llm_fn(SIMULATION_DESIGNER_SYSTEM, f"User description:\n{description}"))

--- a/autocontext/src/autocontext/scenarios/custom/simulation_spec.py
+++ b/autocontext/src/autocontext/scenarios/custom/simulation_spec.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class SimulationActionSpecModel:
+    name: str
+    description: str
+    parameters: dict[str, str]
+    preconditions: list[str] = field(default_factory=list)
+    effects: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class SimulationSpec:
+    description: str
+    environment_description: str
+    initial_state_description: str
+    success_criteria: list[str]
+    failure_modes: list[str]
+    actions: list[SimulationActionSpecModel]
+    max_steps: int = 10

--- a/autocontext/src/autocontext/scenarios/simulation.py
+++ b/autocontext/src/autocontext/scenarios/simulation.py
@@ -1,15 +1,18 @@
 """Simulation-style scenario contract for action-trace evaluation (AC-243).
 
-Defines the third scenario type: agents interact with mock environments
-and are evaluated on their action traces (sequence correctness, recovery
-behavior, rollback quality) rather than prose output.
+Simulation scenarios are real first-class scenarios: they register in the same
+registry, execute through the normal run loop, and are judged from action
+traces and terminal state rather than prose quality alone.
 """
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
+
+from autocontext.scenarios.base import Observation, Result, ScenarioInterface
 
 
 @dataclass(slots=True)
@@ -169,16 +172,8 @@ class SimulationResult:
         )
 
 
-class SimulationInterface(ABC):
-    """Contract for simulation-style scenarios with action-trace evaluation.
-
-    The third scenario type in AutoContext. Agents interact with a mock
-    environment (APIs, filesystem, state machines) and are judged on their
-    action traces — sequence correctness, recovery behavior, rollback quality,
-    and dependency ordering — rather than prose quality alone.
-    """
-
-    name: str
+class SimulationInterface(ScenarioInterface):
+    """Scenario contract for action-trace evaluation."""
 
     @abstractmethod
     def describe_scenario(self) -> str:
@@ -201,7 +196,7 @@ class SimulationInterface(ABC):
         """Execute an action, returning result and new state."""
 
     @abstractmethod
-    def is_terminal(self, state: dict[str, Any]) -> bool:
+    def is_terminal(self, state: Mapping[str, Any]) -> bool:
         """Check if the simulation has ended."""
 
     @abstractmethod
@@ -217,9 +212,187 @@ class SimulationInterface(ABC):
         return True, ""
 
     def max_steps(self) -> int:
-        """Maximum number of steps before forced termination."""
         return 50
 
     def inject_fault(self, state: dict[str, Any], step: int) -> dict[str, Any]:
-        """Optionally inject faults to test recovery. Default: no-op."""
         return state
+
+    def describe_rules(self) -> str:
+        env = self.describe_environment()
+        action_lines = "\n".join(f"- {action.name}: {action.description}" for action in env.available_actions)
+        criteria = "\n".join(f"- {criterion}" for criterion in env.success_criteria)
+        failure_modes = (
+            "\n".join(f"- {failure}" for failure in env.failure_modes)
+            if env.failure_modes
+            else "- none explicitly modeled"
+        )
+        return (
+            f"{self.describe_scenario()}\n\n"
+            f"Environment: {env.description}\n"
+            f"Initial state: {env.initial_state_description}\n\n"
+            f"Available actions:\n{action_lines}\n\n"
+            f"Success criteria:\n{criteria}\n\n"
+            f"Known failure modes:\n{failure_modes}"
+        )
+
+    def describe_strategy_interface(self) -> str:
+        action_names = ", ".join(action.name for action in self.describe_environment().available_actions)
+        return (
+            "Return JSON with an ordered action plan:\n"
+            "{\n"
+            '  "actions": [\n'
+            '    {"name": "action_name", "parameters": {...}, "reasoning": "why this step now"}\n'
+            "  ]\n"
+            "}\n\n"
+            f"Allowed action names: {action_names}\n"
+            "The order matters. Use parameters required by the chosen action."
+        )
+
+    def describe_evaluation_criteria(self) -> str:
+        return self.get_rubric()
+
+    def get_observation(self, state: Mapping[str, Any], player_id: str) -> Observation:
+        available_actions = self.get_available_actions(dict(state))
+        action_names = ", ".join(action.name for action in available_actions) or "none"
+        trace = state.get("_simulation_trace", {"records": []})
+        prior_steps = 0
+        if isinstance(trace, dict) and isinstance(trace.get("records"), list):
+            prior_steps = len(trace["records"])
+        return Observation(
+            narrative=(
+                f"{player_id} is operating in a simulation environment. "
+                f"Step={state.get('step', 0)}. Prior actions={prior_steps}. "
+                f"Available actions: {action_names}."
+            ),
+            state=dict(state),
+            constraints=[f"max_steps={self.max_steps()}"],
+        )
+
+    def validate_actions(self, state: Mapping[str, Any], player_id: str, actions: Mapping[str, Any]) -> tuple[bool, str]:
+        del player_id
+        plan = actions.get("actions")
+        if not isinstance(plan, list) or not plan:
+            return False, "strategy must contain a non-empty 'actions' list"
+        available_names = {spec.name for spec in self.get_available_actions(dict(state))}
+        for idx, raw_action in enumerate(plan):
+            if not isinstance(raw_action, Mapping):
+                return False, f"action {idx} must be an object"
+            name = raw_action.get("name")
+            if not isinstance(name, str) or not name:
+                return False, f"action {idx} is missing a valid name"
+            if name not in available_names:
+                return False, f"action {idx} references unknown action '{name}'"
+            params = raw_action.get("parameters", {})
+            if not isinstance(params, Mapping):
+                return False, f"action {idx} parameters must be an object"
+            reasoning = raw_action.get("reasoning", "")
+            if reasoning is not None and not isinstance(reasoning, str):
+                return False, f"action {idx} reasoning must be a string"
+        return True, "ok"
+
+    def _coerce_action(self, raw_action: Mapping[str, Any]) -> Action:
+        return Action(
+            name=str(raw_action["name"]),
+            parameters=dict(raw_action.get("parameters", {})),
+            reasoning=str(raw_action.get("reasoning", "") or ""),
+        )
+
+    def _execute_plan(self, state: dict[str, Any], actions: Mapping[str, Any]) -> tuple[dict[str, Any], ActionTrace]:
+        current_state = dict(state)
+        records: list[ActionRecord] = []
+        plan = actions.get("actions", [])
+        if not isinstance(plan, list):
+            return current_state, ActionTrace(records=[])
+        for idx, raw_action in enumerate(plan[: self.max_steps()]):
+            if not isinstance(raw_action, Mapping):
+                continue
+            current_state = self.inject_fault(current_state, idx)
+            action = self._coerce_action(raw_action)
+            state_before = dict(current_state)
+            is_valid, reason = self.validate_action(current_state, action)
+            if not is_valid:
+                result = ActionResult(success=False, output="", state_changes={}, error=reason)
+                next_state = dict(current_state)
+            else:
+                result, next_state = self.execute_action(current_state, action)
+            records.append(
+                ActionRecord(
+                    step=idx,
+                    action=action,
+                    result=result,
+                    state_before=state_before,
+                    state_after=dict(next_state),
+                )
+            )
+            current_state = dict(next_state)
+            current_state["step"] = idx + 1
+            if self.is_terminal(current_state):
+                break
+        trace = ActionTrace(records=records)
+        current_state["_simulation_trace"] = trace.to_dict()
+        current_state["terminal"] = self.is_terminal(current_state) or len(records) >= self.max_steps()
+        return current_state, trace
+
+    def step(self, state: Mapping[str, Any], actions: Mapping[str, Any]) -> dict[str, Any]:
+        final_state, _trace = self._execute_plan(dict(state), actions)
+        return final_state
+
+    def get_result(self, state: Mapping[str, Any]) -> Result:
+        trace_data = state.get("_simulation_trace", {"records": []})
+        trace = ActionTrace.from_dict(trace_data) if isinstance(trace_data, dict) else ActionTrace(records=[])
+        final_state = dict(state)
+        sim_result = self.evaluate_trace(trace, final_state)
+        return Result(
+            score=sim_result.score,
+            winner="challenger" if sim_result.score >= 0.5 else "incumbent",
+            summary=sim_result.reasoning,
+            replay=trace.to_dict()["records"],
+            metrics={
+                **sim_result.dimension_scores,
+                "workflow_complete": 1.0 if sim_result.workflow_complete else 0.0,
+                "actions_taken": float(sim_result.actions_taken),
+                "actions_successful": float(sim_result.actions_successful),
+                "recovery_attempts": float(sim_result.recovery_attempts),
+                "rollback_quality": sim_result.rollback_quality,
+            },
+        )
+
+    def replay_to_narrative(self, replay: list[dict[str, Any]]) -> str:
+        if not replay:
+            return "No simulation actions were recorded."
+        rendered = []
+        for record in replay:
+            action = record.get("action", {})
+            result = record.get("result", {})
+            rendered.append(f"{action.get('name', 'unknown')} -> {'ok' if result.get('success') else 'failed'}")
+        return " | ".join(rendered)
+
+    def render_frame(self, state: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            "scenario": self.name,
+            "state": dict(state),
+            "available_actions": [
+                {
+                    "name": action.name,
+                    "description": action.description,
+                    "parameters": action.parameters,
+                }
+                for action in self.get_available_actions(dict(state))
+            ],
+        }
+
+    def execute_match(self, strategy: Mapping[str, Any], seed: int) -> Result:
+        state = self.initial_state(seed=seed)
+        valid, reason = self.validate_actions(state, "challenger", strategy)
+        if not valid:
+            return Result(
+                score=0.0,
+                winner="incumbent",
+                summary="simulation plan rejected during validation",
+                replay=[{"event": "validation_failed", "reason": reason}],
+                metrics={"valid": 0.0},
+                validation_errors=[reason],
+            )
+        next_state, trace = self._execute_plan(state, strategy)
+        next_state["_simulation_trace"] = trace.to_dict()
+        return self.get_result(next_state)

--- a/autocontext/src/autocontext/scenarios/simulation.py
+++ b/autocontext/src/autocontext/scenarios/simulation.py
@@ -1,0 +1,225 @@
+"""Simulation-style scenario contract for action-trace evaluation (AC-243).
+
+Defines the third scenario type: agents interact with mock environments
+and are evaluated on their action traces (sequence correctness, recovery
+behavior, rollback quality) rather than prose output.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class ActionSpec:
+    """Describes an available action in the simulation environment."""
+
+    name: str
+    description: str
+    parameters: dict[str, str]
+    preconditions: list[str] = field(default_factory=list)
+    effects: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class Action:
+    """An action submitted by the agent."""
+
+    name: str
+    parameters: dict[str, Any]
+    reasoning: str = ""
+
+
+@dataclass(slots=True)
+class ActionResult:
+    """Result of executing a single action."""
+
+    success: bool
+    output: str
+    state_changes: dict[str, Any]
+    error: str = ""
+    side_effects: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ActionRecord:
+    """A single entry in the action trace."""
+
+    step: int
+    action: Action
+    result: ActionResult
+    state_before: dict[str, Any]
+    state_after: dict[str, Any]
+
+
+@dataclass(slots=True)
+class ActionTrace:
+    """Complete record of all actions taken during a simulation."""
+
+    records: list[ActionRecord]
+
+    @property
+    def actions(self) -> list[Action]:
+        return [r.action for r in self.records]
+
+    @property
+    def success_rate(self) -> float:
+        if not self.records:
+            return 0.0
+        return sum(1 for r in self.records if r.result.success) / len(self.records)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "records": [
+                {
+                    "step": r.step,
+                    "action": {"name": r.action.name, "parameters": r.action.parameters, "reasoning": r.action.reasoning},
+                    "result": {
+                        "success": r.result.success,
+                        "output": r.result.output,
+                        "state_changes": r.result.state_changes,
+                        "error": r.result.error,
+                        "side_effects": r.result.side_effects,
+                    },
+                    "state_before": r.state_before,
+                    "state_after": r.state_after,
+                }
+                for r in self.records
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ActionTrace:
+        records = []
+        for rec in data["records"]:
+            action = Action(
+                name=rec["action"]["name"],
+                parameters=rec["action"]["parameters"],
+                reasoning=rec["action"].get("reasoning", ""),
+            )
+            result = ActionResult(
+                success=rec["result"]["success"],
+                output=rec["result"]["output"],
+                state_changes=rec["result"]["state_changes"],
+                error=rec["result"].get("error", ""),
+                side_effects=rec["result"].get("side_effects", []),
+            )
+            records.append(
+                ActionRecord(
+                    step=rec["step"],
+                    action=action,
+                    result=result,
+                    state_before=rec["state_before"],
+                    state_after=rec["state_after"],
+                )
+            )
+        return cls(records=records)
+
+
+@dataclass(slots=True)
+class EnvironmentSpec:
+    """Describes the simulation environment."""
+
+    name: str
+    description: str
+    available_actions: list[ActionSpec]
+    initial_state_description: str
+    success_criteria: list[str]
+    failure_modes: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class SimulationResult:
+    """Result of evaluating a complete simulation trace."""
+
+    score: float
+    reasoning: str
+    dimension_scores: dict[str, float]
+    workflow_complete: bool
+    actions_taken: int
+    actions_successful: int
+    recovery_attempts: int = 0
+    rollback_quality: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "reasoning": self.reasoning,
+            "dimension_scores": self.dimension_scores,
+            "workflow_complete": self.workflow_complete,
+            "actions_taken": self.actions_taken,
+            "actions_successful": self.actions_successful,
+            "recovery_attempts": self.recovery_attempts,
+            "rollback_quality": self.rollback_quality,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SimulationResult:
+        return cls(
+            score=data["score"],
+            reasoning=data["reasoning"],
+            dimension_scores=data["dimension_scores"],
+            workflow_complete=data["workflow_complete"],
+            actions_taken=data["actions_taken"],
+            actions_successful=data["actions_successful"],
+            recovery_attempts=data.get("recovery_attempts", 0),
+            rollback_quality=data.get("rollback_quality", 0.0),
+        )
+
+
+class SimulationInterface(ABC):
+    """Contract for simulation-style scenarios with action-trace evaluation.
+
+    The third scenario type in AutoContext. Agents interact with a mock
+    environment (APIs, filesystem, state machines) and are judged on their
+    action traces — sequence correctness, recovery behavior, rollback quality,
+    and dependency ordering — rather than prose quality alone.
+    """
+
+    name: str
+
+    @abstractmethod
+    def describe_scenario(self) -> str:
+        """Return a human-readable scenario description."""
+
+    @abstractmethod
+    def describe_environment(self) -> EnvironmentSpec:
+        """Return the environment specification."""
+
+    @abstractmethod
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        """Create deterministic initial state."""
+
+    @abstractmethod
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        """Return actions available in the current state."""
+
+    @abstractmethod
+    def execute_action(self, state: dict[str, Any], action: Action) -> tuple[ActionResult, dict[str, Any]]:
+        """Execute an action, returning result and new state."""
+
+    @abstractmethod
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        """Check if the simulation has ended."""
+
+    @abstractmethod
+    def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+        """Evaluate the complete action trace."""
+
+    @abstractmethod
+    def get_rubric(self) -> str:
+        """Return evaluation rubric for the simulation."""
+
+    def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+        """Validate an action before execution. Default: always valid."""
+        return True, ""
+
+    def max_steps(self) -> int:
+        """Maximum number of steps before forced termination."""
+        return 50
+
+    def inject_fault(self, state: dict[str, Any], step: int) -> dict[str, Any]:
+        """Optionally inject faults to test recovery. Default: no-op."""
+        return state

--- a/autocontext/tests/test_agent_task_pipeline.py
+++ b/autocontext/tests/test_agent_task_pipeline.py
@@ -20,6 +20,8 @@ from autocontext.scenarios.custom.agent_task_validator import (
     validate_spec,
     validate_syntax,
 )
+from autocontext.scenarios.custom.simulation_designer import SIM_SPEC_END, SIM_SPEC_START
+from autocontext.scenarios.simulation import SimulationInterface
 
 # --- Fixtures ---
 
@@ -50,6 +52,34 @@ def _mock_llm_response(spec: AgentTaskSpec) -> str:
     if spec.required_concepts is not None:
         data["required_concepts"] = spec.required_concepts
     return f"Here is the spec:\n{SPEC_START}\n{json.dumps(data, indent=2)}\n{SPEC_END}\n"
+
+
+def _mock_simulation_response() -> str:
+    data = {
+        "description": "Recover a multi-step API workflow.",
+        "environment_description": "Mock API orchestration environment.",
+        "initial_state_description": "No calls completed.",
+        "success_criteria": ["all required actions complete", "invalid order is recovered"],
+        "failure_modes": ["dependency mismatch", "partial side effects"],
+        "max_steps": 6,
+        "actions": [
+            {
+                "name": "book_flight",
+                "description": "Reserve a flight.",
+                "parameters": {"flight_id": "string"},
+                "preconditions": [],
+                "effects": ["flight_reserved"],
+            },
+            {
+                "name": "book_hotel",
+                "description": "Reserve a hotel.",
+                "parameters": {"hotel_id": "string"},
+                "preconditions": ["book_flight"],
+                "effects": ["hotel_reserved"],
+            },
+        ],
+    }
+    return f"{SIM_SPEC_START}\n{json.dumps(data, indent=2)}\n{SIM_SPEC_END}\n"
 
 
 # --- Tests ---
@@ -341,6 +371,40 @@ class TestAgentTaskCreator:
                 assert (scenario_dir / "agent_task_spec.json").exists()
                 assert (scenario_dir / "scenario_type.txt").exists()
                 assert (scenario_dir / "scenario_type.txt").read_text() == "agent_task"
+            finally:
+                SCENARIO_REGISTRY.pop(registered_name, None)
+
+    def test_routes_simulation_like_requests_to_simulation_creator(self) -> None:
+        response_text = _mock_simulation_response()
+
+        def mock_llm(system: str, user: str) -> str:
+            return response_text
+
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        with tempfile.TemporaryDirectory() as tmp:
+            creator = AgentTaskCreator(
+                llm_fn=mock_llm,
+                knowledge_root=Path(tmp),
+            )
+            instance = creator.create("Build a stateful API orchestration workflow with rollback")
+            registered_name = creator.derive_name("Build a stateful API orchestration workflow with rollback")
+            try:
+                assert isinstance(instance, SimulationInterface)
+                result = instance.execute_match(
+                    {
+                        "actions": [
+                            {"name": "book_flight", "parameters": {"flight_id": "F1"}},
+                            {"name": "book_hotel", "parameters": {"hotel_id": "H1"}},
+                        ]
+                    },
+                    seed=0,
+                )
+                assert result.score > 0.5
+                scenario_dir = Path(tmp) / "_custom_scenarios" / registered_name
+                assert (scenario_dir / "scenario.py").exists()
+                assert (scenario_dir / "spec.json").exists()
+                assert (scenario_dir / "scenario_type.txt").read_text() == "simulation"
             finally:
                 SCENARIO_REGISTRY.pop(registered_name, None)
 

--- a/autocontext/tests/test_simulation_contract.py
+++ b/autocontext/tests/test_simulation_contract.py
@@ -590,17 +590,17 @@ class TestRegistryCompatibility:
             del SCENARIO_REGISTRY["_test_mock_sim"]
 
     def test_detection_via_hasattr(self) -> None:
-        """Simulation scenarios are detected via hasattr guards."""
+        """Simulation scenarios expose both simulation and base scenario hooks."""
         sim = _MockSimulation()
         # Simulation-specific methods
         assert hasattr(sim, "evaluate_trace")
         assert hasattr(sim, "execute_action")
         assert hasattr(sim, "describe_environment")
         assert hasattr(sim, "get_available_actions")
-        # Should NOT have game-scenario-specific methods
-        assert not hasattr(sim, "execute_match")
-        assert not hasattr(sim, "validate_actions")
-        assert not hasattr(sim, "step")
+        # And now intentionally support the standard run-loop execution path.
+        assert hasattr(sim, "execute_match")
+        assert hasattr(sim, "validate_actions")
+        assert hasattr(sim, "step")
         # Should NOT have agent-task-specific methods
         assert not hasattr(sim, "evaluate_output")
         assert not hasattr(sim, "get_task_prompt")

--- a/autocontext/tests/test_simulation_contract.py
+++ b/autocontext/tests/test_simulation_contract.py
@@ -1,0 +1,619 @@
+"""Tests for AC-243: Simulation-style scenario contract for action-trace evaluation.
+
+Defines and validates the SimulationInterface ABC and its supporting data models
+(ActionSpec, Action, ActionResult, ActionRecord, ActionTrace, EnvironmentSpec,
+SimulationResult) for scenarios where agents interact with mock environments
+and are judged on action traces rather than prose quality.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from autocontext.scenarios.simulation import (
+    Action,
+    ActionRecord,
+    ActionResult,
+    ActionSpec,
+    ActionTrace,
+    EnvironmentSpec,
+    SimulationInterface,
+    SimulationResult,
+)
+
+# ---------------------------------------------------------------------------
+# Data model construction
+# ---------------------------------------------------------------------------
+
+
+class TestActionSpec:
+    def test_construction(self) -> None:
+        spec = ActionSpec(
+            name="api_call",
+            description="Call an API endpoint",
+            parameters={"url": "string", "method": "string"},
+        )
+        assert spec.name == "api_call"
+        assert spec.description == "Call an API endpoint"
+        assert spec.parameters == {"url": "string", "method": "string"}
+        assert spec.preconditions == []
+        assert spec.effects == []
+
+    def test_with_preconditions_and_effects(self) -> None:
+        spec = ActionSpec(
+            name="deploy",
+            description="Deploy service",
+            parameters={"service": "string"},
+            preconditions=["service_built", "tests_passing"],
+            effects=["service_deployed"],
+        )
+        assert spec.preconditions == ["service_built", "tests_passing"]
+        assert spec.effects == ["service_deployed"]
+
+
+class TestAction:
+    def test_construction(self) -> None:
+        action = Action(name="api_call", parameters={"url": "/users", "method": "GET"})
+        assert action.name == "api_call"
+        assert action.parameters == {"url": "/users", "method": "GET"}
+        assert action.reasoning == ""
+
+    def test_with_reasoning(self) -> None:
+        action = Action(
+            name="rollback",
+            parameters={"version": "v1.2"},
+            reasoning="Deployment failed, rolling back to stable version",
+        )
+        assert action.reasoning == "Deployment failed, rolling back to stable version"
+
+
+class TestActionResult:
+    def test_success(self) -> None:
+        result = ActionResult(
+            success=True,
+            output='{"status": "ok"}',
+            state_changes={"deployed": True},
+        )
+        assert result.success is True
+        assert result.error == ""
+        assert result.side_effects == []
+
+    def test_failure(self) -> None:
+        result = ActionResult(
+            success=False,
+            output="",
+            state_changes={},
+            error="Connection timeout",
+            side_effects=["partial_write"],
+        )
+        assert result.success is False
+        assert result.error == "Connection timeout"
+        assert result.side_effects == ["partial_write"]
+
+
+class TestActionRecord:
+    def test_construction(self) -> None:
+        record = ActionRecord(
+            step=0,
+            action=Action(name="check_status", parameters={}),
+            result=ActionResult(success=True, output="ok", state_changes={}),
+            state_before={"service_up": False},
+            state_after={"service_up": True},
+        )
+        assert record.step == 0
+        assert record.action.name == "check_status"
+        assert record.result.success is True
+        assert record.state_before == {"service_up": False}
+        assert record.state_after == {"service_up": True}
+
+
+# ---------------------------------------------------------------------------
+# ActionTrace
+# ---------------------------------------------------------------------------
+
+
+class TestActionTrace:
+    def _make_trace(self, n: int = 3, failures: int = 0) -> ActionTrace:
+        records = []
+        for i in range(n):
+            success = i >= failures  # first `failures` records fail
+            records.append(
+                ActionRecord(
+                    step=i,
+                    action=Action(name=f"step_{i}", parameters={"i": i}),
+                    result=ActionResult(
+                        success=success,
+                        output=f"result_{i}",
+                        state_changes={"step": i},
+                        error="" if success else "failed",
+                    ),
+                    state_before={"step": i - 1 if i > 0 else -1},
+                    state_after={"step": i},
+                )
+            )
+        return ActionTrace(records=records)
+
+    def test_actions_property(self) -> None:
+        trace = self._make_trace(3)
+        actions = trace.actions
+        assert len(actions) == 3
+        assert [a.name for a in actions] == ["step_0", "step_1", "step_2"]
+
+    def test_success_rate_all_pass(self) -> None:
+        trace = self._make_trace(4, failures=0)
+        assert trace.success_rate == 1.0
+
+    def test_success_rate_some_fail(self) -> None:
+        trace = self._make_trace(4, failures=2)
+        assert trace.success_rate == 0.5
+
+    def test_success_rate_empty(self) -> None:
+        trace = ActionTrace(records=[])
+        assert trace.success_rate == 0.0
+
+    def test_to_dict_from_dict_roundtrip(self) -> None:
+        trace = self._make_trace(2, failures=1)
+        data = trace.to_dict()
+        restored = ActionTrace.from_dict(data)
+        assert len(restored.records) == 2
+        assert restored.records[0].action.name == "step_0"
+        assert restored.records[0].result.success is False
+        assert restored.records[1].result.success is True
+        assert restored.success_rate == trace.success_rate
+
+    def test_to_dict_structure(self) -> None:
+        trace = self._make_trace(1)
+        data = trace.to_dict()
+        assert "records" in data
+        assert len(data["records"]) == 1
+        rec = data["records"][0]
+        assert "step" in rec
+        assert "action" in rec
+        assert "result" in rec
+        assert "state_before" in rec
+        assert "state_after" in rec
+
+
+# ---------------------------------------------------------------------------
+# EnvironmentSpec
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentSpec:
+    def test_construction(self) -> None:
+        env = EnvironmentSpec(
+            name="api_orchestration",
+            description="Orchestrate microservice API calls",
+            available_actions=[
+                ActionSpec(name="call", description="Call endpoint", parameters={"url": "str"}),
+            ],
+            initial_state_description="All services healthy",
+            success_criteria=["all endpoints responding", "data consistent"],
+        )
+        assert env.name == "api_orchestration"
+        assert len(env.available_actions) == 1
+        assert len(env.success_criteria) == 2
+        assert env.failure_modes == []
+
+    def test_with_failure_modes(self) -> None:
+        env = EnvironmentSpec(
+            name="deployment",
+            description="Deploy services",
+            available_actions=[],
+            initial_state_description="Clean state",
+            success_criteria=["deployed"],
+            failure_modes=["timeout", "dependency_conflict", "rollback_failure"],
+        )
+        assert len(env.failure_modes) == 3
+
+
+# ---------------------------------------------------------------------------
+# SimulationResult
+# ---------------------------------------------------------------------------
+
+
+class TestSimulationResult:
+    def test_construction(self) -> None:
+        result = SimulationResult(
+            score=0.85,
+            reasoning="Good workflow completion with minor ordering issues",
+            dimension_scores={
+                "completion": 0.95,
+                "ordering": 0.75,
+                "recovery": 0.85,
+            },
+            workflow_complete=True,
+            actions_taken=10,
+            actions_successful=9,
+        )
+        assert result.score == 0.85
+        assert result.workflow_complete is True
+        assert result.actions_taken == 10
+        assert result.recovery_attempts == 0
+        assert result.rollback_quality == 0.0
+
+    def test_to_dict_from_dict_roundtrip(self) -> None:
+        result = SimulationResult(
+            score=0.7,
+            reasoning="Partial completion",
+            dimension_scores={"completion": 0.6, "recovery": 0.8},
+            workflow_complete=False,
+            actions_taken=5,
+            actions_successful=3,
+            recovery_attempts=2,
+            rollback_quality=0.6,
+        )
+        data = result.to_dict()
+        restored = SimulationResult.from_dict(data)
+        assert restored.score == result.score
+        assert restored.reasoning == result.reasoning
+        assert restored.dimension_scores == result.dimension_scores
+        assert restored.workflow_complete == result.workflow_complete
+        assert restored.recovery_attempts == result.recovery_attempts
+        assert restored.rollback_quality == result.rollback_quality
+
+
+# ---------------------------------------------------------------------------
+# SimulationInterface ABC
+# ---------------------------------------------------------------------------
+
+
+class _MockSimulation(SimulationInterface):
+    """Concrete test implementation of SimulationInterface."""
+
+    name = "mock_sim"
+
+    def __init__(self) -> None:
+        self._fault_steps: set[int] = set()
+
+    def describe_scenario(self) -> str:
+        return "Mock simulation for testing"
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name="mock_env",
+            description="A mock environment",
+            available_actions=[
+                ActionSpec(name="ping", description="Ping a service", parameters={"target": "str"}),
+                ActionSpec(name="deploy", description="Deploy", parameters={"service": "str"}),
+            ],
+            initial_state_description="Clean state",
+            success_criteria=["all_deployed"],
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {"seed": seed or 0, "deployed": [], "step": 0, "errors": []}
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        actions = [
+            ActionSpec(name="ping", description="Ping", parameters={"target": "str"}),
+            ActionSpec(name="deploy", description="Deploy", parameters={"service": "str"}),
+        ]
+        if state.get("errors"):
+            actions.append(ActionSpec(name="rollback", description="Rollback", parameters={}))
+        return actions
+
+    def execute_action(self, state: dict[str, Any], action: Action) -> tuple[ActionResult, dict[str, Any]]:
+        new_state = {**state, "step": state["step"] + 1}
+        if action.name == "ping":
+            return ActionResult(success=True, output="pong", state_changes={}), new_state
+        if action.name == "deploy":
+            service = action.parameters.get("service", "unknown")
+            new_state["deployed"] = [*state.get("deployed", []), service]
+            return (
+                ActionResult(success=True, output=f"deployed {service}", state_changes={"deployed": service}),
+                new_state,
+            )
+        if action.name == "rollback":
+            new_state["deployed"] = []
+            new_state["errors"] = []
+            return ActionResult(success=True, output="rolled back", state_changes={"deployed": []}), new_state
+        return (
+            ActionResult(success=False, output="", state_changes={}, error=f"unknown action: {action.name}"),
+            new_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        return len(state.get("deployed", [])) >= 2 or state.get("step", 0) >= 10
+
+    def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+        deployed = final_state.get("deployed", [])
+        complete = len(deployed) >= 2
+        completion_score = min(len(deployed) / 2, 1.0)
+        ordering_score = 1.0 if trace.success_rate == 1.0 else 0.5
+        recovery_score = 1.0
+        for rec in trace.records:
+            if not rec.result.success and rec.action.name != "rollback":
+                # Check if next action was a recovery
+                next_idx = rec.step + 1
+                if next_idx < len(trace.records) and trace.records[next_idx].action.name == "rollback":
+                    recovery_score = 0.8
+                else:
+                    recovery_score = 0.3
+
+        score = completion_score * 0.5 + ordering_score * 0.3 + recovery_score * 0.2
+        return SimulationResult(
+            score=score,
+            reasoning=f"Deployed {len(deployed)} services",
+            dimension_scores={"completion": completion_score, "ordering": ordering_score, "recovery": recovery_score},
+            workflow_complete=complete,
+            actions_taken=len(trace.records),
+            actions_successful=sum(1 for r in trace.records if r.result.success),
+            recovery_attempts=sum(1 for r in trace.records if r.action.name == "rollback"),
+            rollback_quality=1.0 if not final_state.get("errors") else 0.0,
+        )
+
+    def get_rubric(self) -> str:
+        return (
+            "Evaluate on: workflow completion (50%), action ordering (30%), "
+            "error recovery (20%)"
+        )
+
+    def inject_fault(self, state: dict[str, Any], step: int) -> dict[str, Any]:
+        if step in self._fault_steps:
+            return {**state, "errors": [*state.get("errors", []), f"fault_at_step_{step}"]}
+        return state
+
+
+class TestSimulationInterfaceABC:
+    def test_cannot_instantiate_abc(self) -> None:
+        with pytest.raises(TypeError, match="abstract"):
+            SimulationInterface()  # type: ignore[abstract]
+
+    def test_concrete_subclass_instantiates(self) -> None:
+        sim = _MockSimulation()
+        assert sim.name == "mock_sim"
+
+    def test_describe_scenario(self) -> None:
+        sim = _MockSimulation()
+        assert "Mock simulation" in sim.describe_scenario()
+
+    def test_describe_environment(self) -> None:
+        sim = _MockSimulation()
+        env = sim.describe_environment()
+        assert isinstance(env, EnvironmentSpec)
+        assert env.name == "mock_env"
+        assert len(env.available_actions) == 2
+
+    def test_initial_state(self) -> None:
+        sim = _MockSimulation()
+        state = sim.initial_state(seed=42)
+        assert state["seed"] == 42
+        assert state["deployed"] == []
+        assert state["step"] == 0
+
+    def test_get_available_actions(self) -> None:
+        sim = _MockSimulation()
+        state = sim.initial_state()
+        actions = sim.get_available_actions(state)
+        assert len(actions) == 2
+        assert {a.name for a in actions} == {"ping", "deploy"}
+
+    def test_get_available_actions_with_errors(self) -> None:
+        sim = _MockSimulation()
+        state = {"errors": ["something_broke"], "deployed": []}
+        actions = sim.get_available_actions(state)
+        assert {a.name for a in actions} == {"ping", "deploy", "rollback"}
+
+    def test_execute_action(self) -> None:
+        sim = _MockSimulation()
+        state = sim.initial_state()
+        result, new_state = sim.execute_action(state, Action(name="ping", parameters={"target": "svc_a"}))
+        assert result.success is True
+        assert result.output == "pong"
+        assert new_state["step"] == 1
+
+    def test_execute_deploy(self) -> None:
+        sim = _MockSimulation()
+        state = sim.initial_state()
+        result, new_state = sim.execute_action(state, Action(name="deploy", parameters={"service": "svc_a"}))
+        assert result.success is True
+        assert "svc_a" in new_state["deployed"]
+
+    def test_execute_unknown_action(self) -> None:
+        sim = _MockSimulation()
+        state = sim.initial_state()
+        result, new_state = sim.execute_action(state, Action(name="explode", parameters={}))
+        assert result.success is False
+        assert "unknown action" in result.error
+
+    def test_is_terminal_false(self) -> None:
+        sim = _MockSimulation()
+        state = sim.initial_state()
+        assert sim.is_terminal(state) is False
+
+    def test_is_terminal_after_deployments(self) -> None:
+        sim = _MockSimulation()
+        state = {"deployed": ["svc_a", "svc_b"], "step": 2}
+        assert sim.is_terminal(state) is True
+
+    def test_is_terminal_after_max_steps(self) -> None:
+        sim = _MockSimulation()
+        state = {"deployed": [], "step": 10}
+        assert sim.is_terminal(state) is True
+
+    def test_get_rubric(self) -> None:
+        sim = _MockSimulation()
+        rubric = sim.get_rubric()
+        assert "completion" in rubric
+        assert "ordering" in rubric
+        assert "recovery" in rubric
+
+
+# ---------------------------------------------------------------------------
+# End-to-end simulation run
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndSimulation:
+    def test_successful_workflow(self) -> None:
+        """Agent deploys two services successfully."""
+        sim = _MockSimulation()
+        state = sim.initial_state(seed=1)
+        records: list[ActionRecord] = []
+
+        actions_to_take = [
+            Action(name="ping", parameters={"target": "svc_a"}),
+            Action(name="deploy", parameters={"service": "svc_a"}),
+            Action(name="deploy", parameters={"service": "svc_b"}),
+        ]
+
+        for i, action in enumerate(actions_to_take):
+            state_before = dict(state)
+            result, state = sim.execute_action(state, action)
+            records.append(ActionRecord(
+                step=i, action=action, result=result,
+                state_before=state_before, state_after=dict(state),
+            ))
+            if sim.is_terminal(state):
+                break
+
+        trace = ActionTrace(records=records)
+        sim_result = sim.evaluate_trace(trace, state)
+
+        assert sim_result.workflow_complete is True
+        assert sim_result.score > 0.8
+        assert sim_result.actions_taken == 3
+        assert sim_result.actions_successful == 3
+        assert sim_result.dimension_scores["completion"] == 1.0
+
+    def test_workflow_with_recovery(self) -> None:
+        """Agent encounters an error and rolls back."""
+        sim = _MockSimulation()
+        state = sim.initial_state()
+        records: list[ActionRecord] = []
+
+        # Force an error via unknown action, then recover
+        actions_to_take = [
+            Action(name="explode", parameters={}),  # fails
+            Action(name="rollback", parameters={}),  # recovery
+            Action(name="deploy", parameters={"service": "svc_a"}),
+            Action(name="deploy", parameters={"service": "svc_b"}),
+        ]
+
+        for i, action in enumerate(actions_to_take):
+            state_before = dict(state)
+            result, state = sim.execute_action(state, action)
+            records.append(ActionRecord(
+                step=i, action=action, result=result,
+                state_before=state_before, state_after=dict(state),
+            ))
+            if sim.is_terminal(state):
+                break
+
+        trace = ActionTrace(records=records)
+        sim_result = sim.evaluate_trace(trace, state)
+
+        assert sim_result.workflow_complete is True
+        assert sim_result.recovery_attempts >= 1
+        assert sim_result.actions_taken == 4
+        # Score should be lower than perfect due to the failure
+        assert sim_result.score < 1.0
+
+    def test_incomplete_workflow(self) -> None:
+        """Agent only deploys one service."""
+        sim = _MockSimulation()
+        state = sim.initial_state()
+        records: list[ActionRecord] = []
+
+        action = Action(name="deploy", parameters={"service": "svc_a"})
+        state_before = dict(state)
+        result, state = sim.execute_action(state, action)
+        records.append(ActionRecord(
+            step=0, action=action, result=result,
+            state_before=state_before, state_after=dict(state),
+        ))
+
+        trace = ActionTrace(records=records)
+        sim_result = sim.evaluate_trace(trace, state)
+
+        assert sim_result.workflow_complete is False
+        assert sim_result.dimension_scores["completion"] == 0.5
+        assert sim_result.score < 0.8
+
+
+# ---------------------------------------------------------------------------
+# Default methods
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultMethods:
+    def test_validate_action_default(self) -> None:
+        sim = _MockSimulation()
+        valid, reason = sim.validate_action({}, Action(name="anything", parameters={}))
+        assert valid is True
+        assert reason == ""
+
+    def test_max_steps_default(self) -> None:
+        sim = _MockSimulation()
+        assert sim.max_steps() == 50
+
+    def test_inject_fault_default_noop(self) -> None:
+        """Default inject_fault returns state unchanged."""
+        sim = _MockSimulation()
+        state = {"key": "value"}
+        assert sim.inject_fault(state, 0) == state
+
+    def test_inject_fault_override(self) -> None:
+        """Mock's inject_fault adds errors for configured steps."""
+        sim = _MockSimulation()
+        sim._fault_steps = {2, 5}
+        state = {"errors": []}
+        modified = sim.inject_fault(state, 2)
+        assert len(modified["errors"]) == 1
+        assert "fault_at_step_2" in modified["errors"][0]
+        # Step 3 should not inject
+        unmodified = sim.inject_fault(state, 3)
+        assert unmodified == state
+
+
+# ---------------------------------------------------------------------------
+# Registry compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryCompatibility:
+    def test_can_store_in_scenario_registry(self) -> None:
+        """SimulationInterface subclass can be stored in SCENARIO_REGISTRY."""
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        SCENARIO_REGISTRY["_test_mock_sim"] = _MockSimulation  # type: ignore[assignment]
+        try:
+            assert "_test_mock_sim" in SCENARIO_REGISTRY
+            cls = SCENARIO_REGISTRY["_test_mock_sim"]
+            instance = cls()
+            assert hasattr(instance, "evaluate_trace")
+            assert hasattr(instance, "execute_action")
+        finally:
+            del SCENARIO_REGISTRY["_test_mock_sim"]
+
+    def test_detection_via_hasattr(self) -> None:
+        """Simulation scenarios are detected via hasattr guards."""
+        sim = _MockSimulation()
+        # Simulation-specific methods
+        assert hasattr(sim, "evaluate_trace")
+        assert hasattr(sim, "execute_action")
+        assert hasattr(sim, "describe_environment")
+        assert hasattr(sim, "get_available_actions")
+        # Should NOT have game-scenario-specific methods
+        assert not hasattr(sim, "execute_match")
+        assert not hasattr(sim, "validate_actions")
+        assert not hasattr(sim, "step")
+        # Should NOT have agent-task-specific methods
+        assert not hasattr(sim, "evaluate_output")
+        assert not hasattr(sim, "get_task_prompt")
+
+    def test_has_rubric_like_agent_task(self) -> None:
+        """Simulation scenarios share get_rubric() for knowledge compatibility."""
+        sim = _MockSimulation()
+        assert hasattr(sim, "get_rubric")
+        assert isinstance(sim.get_rubric(), str)
+
+    def test_has_initial_state_like_both_interfaces(self) -> None:
+        """initial_state() is shared across all scenario types."""
+        sim = _MockSimulation()
+        assert hasattr(sim, "initial_state")
+        state = sim.initial_state()
+        assert isinstance(state, dict)

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -71,17 +71,35 @@ export { ClaudeCLIRuntime, createSessionRuntime } from "./runtimes/index.js";
 export type { ClaudeCLIConfig } from "./runtimes/index.js";
 
 // Scenarios
-export type { AgentTaskSpec, AgentTaskFactoryOpts, AgentTaskCreatorOpts } from "./scenarios/index.js";
+export type {
+  AgentTaskSpec,
+  AgentTaskFactoryOpts,
+  AgentTaskCreatorOpts,
+  CreatedScenario,
+  SimulationCreatorOpts,
+  SimulationScenarioHandle,
+  SimulationSpec,
+  SimulationActionSpec,
+} from "./scenarios/index.js";
 export {
   AgentTaskSpecSchema,
   parseRawSpec,
   parseAgentTaskSpec,
   designAgentTask,
+  SimulationSpecSchema,
+  SimulationActionSpecSchema,
+  parseRawSimulationSpec,
+  parseSimulationSpec,
+  designSimulation,
   validateSpec,
   createAgentTask,
   AgentTaskCreator,
+  SimulationCreator,
+  shouldUseSimulationFamily,
   SPEC_START,
   SPEC_END,
+  SIM_SPEC_START,
+  SIM_SPEC_END,
 } from "./scenarios/index.js";
 
 // Knowledge / Skill Export

--- a/ts/src/scenarios/agent-task-creator.ts
+++ b/ts/src/scenarios/agent-task-creator.ts
@@ -13,12 +13,21 @@ import type { AgentTaskSpec } from "./agent-task-spec.js";
 import { designAgentTask } from "./agent-task-designer.js";
 import { validateIntent, validateSpec } from "./agent-task-validator.js";
 import { createAgentTask } from "./agent-task-factory.js";
+import {
+  type SimulationScenarioHandle,
+  shouldUseSimulationFamily,
+  SimulationCreator,
+} from "./simulation-creator.js";
 
 export interface AgentTaskCreatorOpts {
   provider: LLMProvider;
   model?: string;
   knowledgeRoot: string;
 }
+
+export type CreatedScenario =
+  | (AgentTaskInterface & { readonly name: string; readonly spec: AgentTaskSpec; readonly family?: "agent_task" })
+  | SimulationScenarioHandle;
 
 export class AgentTaskCreator {
   private provider: LLMProvider;
@@ -70,7 +79,16 @@ export class AgentTaskCreator {
   /**
    * Run the full pipeline: design → validate → create → save.
    */
-  async create(description: string): Promise<AgentTaskInterface & { readonly name: string; readonly spec: AgentTaskSpec }> {
+  async create(description: string): Promise<CreatedScenario> {
+    const name = this.deriveName(description);
+    if (shouldUseSimulationFamily(description)) {
+      return new SimulationCreator({
+        provider: this.provider,
+        model: this.model,
+        knowledgeRoot: this.knowledgeRoot,
+      }).create(description, name);
+    }
+
     // 1. Design spec via LLM
     const llmFn = async (system: string, user: string): Promise<string> => {
       const result = await this.provider.complete({
@@ -95,7 +113,6 @@ export class AgentTaskCreator {
     }
 
     // 3. Derive name and create task
-    const name = this.deriveName(description);
     const task = createAgentTask({ spec, name, provider: this.provider });
 
     // 4. Save to disk

--- a/ts/src/scenarios/index.ts
+++ b/ts/src/scenarios/index.ts
@@ -5,4 +5,15 @@ export { validateSpec } from "./agent-task-validator.js";
 export { createAgentTask } from "./agent-task-factory.js";
 export type { AgentTaskFactoryOpts } from "./agent-task-factory.js";
 export { AgentTaskCreator } from "./agent-task-creator.js";
-export type { AgentTaskCreatorOpts } from "./agent-task-creator.js";
+export type { AgentTaskCreatorOpts, CreatedScenario } from "./agent-task-creator.js";
+export {
+  SIM_SPEC_START,
+  SIM_SPEC_END,
+  SIMULATION_DESIGNER_SYSTEM,
+  parseSimulationSpec,
+  designSimulation,
+} from "./simulation-designer.js";
+export { SimulationCreator, shouldUseSimulationFamily } from "./simulation-creator.js";
+export type { SimulationCreatorOpts, SimulationScenarioHandle } from "./simulation-creator.js";
+export type { SimulationSpec, SimulationActionSpec } from "./simulation-spec.js";
+export { SimulationSpecSchema, SimulationActionSpecSchema, parseRawSimulationSpec } from "./simulation-spec.js";

--- a/ts/src/scenarios/simulation-creator.ts
+++ b/ts/src/scenarios/simulation-creator.ts
@@ -1,0 +1,199 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { LLMProvider } from "../types/index.js";
+import type { SimulationSpec } from "./simulation-spec.js";
+import { designSimulation } from "./simulation-designer.js";
+
+export interface SimulationCreatorOpts {
+  provider: LLMProvider;
+  model?: string;
+  knowledgeRoot: string;
+}
+
+export interface SimulationScenarioHandle {
+  family: "simulation";
+  name: string;
+  spec: SimulationSpec;
+}
+
+export function shouldUseSimulationFamily(description: string): boolean {
+  const lowered = description.toLowerCase();
+  return [
+    "stateful",
+    "simulation",
+    "workflow",
+    "orchestration",
+    "api",
+    "rollback",
+    "retry",
+    "cancellation",
+    "transaction",
+    "debug",
+    "diagnos",
+    "evidence",
+    "side effect",
+  ].some((keyword) => lowered.includes(keyword));
+}
+
+function validateSimulationSpec(spec: SimulationSpec): string[] {
+  const errors: string[] = [];
+  if (spec.actions.length < 2) errors.push("simulation must define at least two actions");
+  const names = spec.actions.map((action) => action.name);
+  if (new Set(names).size !== names.length) errors.push("action names must be unique");
+  if (spec.maxSteps <= 0) errors.push("maxSteps must be positive");
+  return errors;
+}
+
+function className(name: string): string {
+  return name.split(/[^a-zA-Z0-9]+/).filter(Boolean).map((part) => part[0]!.toUpperCase() + part.slice(1)).join("") + "Simulation";
+}
+
+function generateScenarioSource(spec: SimulationSpec, name: string): string {
+  const actions = spec.actions
+    .map((action) => `            ActionSpec(name=${JSON.stringify(action.name)}, description=${JSON.stringify(action.description)}, parameters=${JSON.stringify(action.parameters)}, preconditions=${JSON.stringify(action.preconditions)}, effects=${JSON.stringify(action.effects)})`)
+    .join(",\n");
+  const requiredActions = JSON.stringify(spec.actions.map((action) => action.name));
+  return `from __future__ import annotations
+
+from typing import Any
+
+from autocontext.scenarios.simulation import Action, ActionResult, ActionSpec, ActionTrace, EnvironmentSpec, SimulationInterface, SimulationResult
+
+
+class ${className(name)}(SimulationInterface):
+    name = ${JSON.stringify(name)}
+
+    def describe_scenario(self) -> str:
+        return ${JSON.stringify(spec.description)}
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name=${JSON.stringify(name)},
+            description=${JSON.stringify(spec.environmentDescription)},
+            available_actions=[
+${actions}
+            ],
+            initial_state_description=${JSON.stringify(spec.initialStateDescription)},
+            success_criteria=${JSON.stringify(spec.successCriteria)},
+            failure_modes=${JSON.stringify(spec.failureModes)},
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {"seed": seed or 0, "step": 0, "completed_actions": [], "failed_actions": [], "timeline": [], "terminal": False}
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        completed = set(state.get("completed_actions", []))
+        return [spec for spec in self.describe_environment().available_actions if spec.name not in completed]
+
+    def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+        specs = {spec.name: spec for spec in self.describe_environment().available_actions}
+        spec = specs.get(action.name)
+        if spec is None:
+            return False, f"unknown action: {action.name}"
+        completed = set(state.get("completed_actions", []))
+        for requirement in spec.preconditions:
+            if requirement not in completed:
+                return False, f"precondition not met for {action.name}: {requirement}"
+        return True, ""
+
+    def execute_action(self, state: dict[str, Any], action: Action) -> tuple[ActionResult, dict[str, Any]]:
+        valid, reason = self.validate_action(state, action)
+        next_state = dict(state)
+        next_state["timeline"] = list(state.get("timeline", []))
+        if not valid:
+            next_state["failed_actions"] = [*state.get("failed_actions", []), action.name]
+            return ActionResult(success=False, output="", state_changes={}, error=reason), next_state
+        next_state["completed_actions"] = [*state.get("completed_actions", []), action.name]
+        next_state["timeline"].append({"action": action.name, "parameters": action.parameters})
+        return (
+            ActionResult(success=True, output=f"executed {action.name}", state_changes={"completed_actions": list(next_state["completed_actions"])}, side_effects=[action.name]),
+            next_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        required = set(${requiredActions})
+        completed = set(state.get("completed_actions", []))
+        return required.issubset(completed) or state.get("step", 0) >= ${spec.maxSteps}
+
+    def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+        required = set(${requiredActions})
+        completed = set(final_state.get("completed_actions", []))
+        completion = len(required & completed) / len(required) if required else 1.0
+        ordering = trace.success_rate
+        failures = sum(1 for record in trace.records if not record.result.success)
+        recovery = 1.0 if failures == 0 else max(0.2, 1.0 - (failures / max(len(trace.records), 1)))
+        score = round((completion * 0.5) + (ordering * 0.3) + (recovery * 0.2), 4)
+        return SimulationResult(
+            score=score,
+            reasoning=f"Completed {len(completed)} of {len(required)} required actions.",
+            dimension_scores={"completion": round(completion, 4), "ordering": round(ordering, 4), "recovery": round(recovery, 4)},
+            workflow_complete=required.issubset(completed),
+            actions_taken=len(trace.records),
+            actions_successful=sum(1 for record in trace.records if record.result.success),
+            recovery_attempts=failures,
+            rollback_quality=1.0 if failures == 0 else recovery,
+        )
+
+    def get_rubric(self) -> str:
+        return "Evaluate on completion, correct dependency ordering, and recovery quality."
+
+    def max_steps(self) -> int:
+        return ${spec.maxSteps}
+`;
+}
+
+export class SimulationCreator {
+  private provider: LLMProvider;
+  private model: string;
+  private knowledgeRoot: string;
+
+  constructor(opts: SimulationCreatorOpts) {
+    this.provider = opts.provider;
+    this.model = opts.model ?? opts.provider.defaultModel();
+    this.knowledgeRoot = opts.knowledgeRoot;
+  }
+
+  async create(description: string, name: string): Promise<SimulationScenarioHandle> {
+    const llmFn = async (system: string, user: string): Promise<string> => {
+      const result = await this.provider.complete({
+        systemPrompt: system,
+        userPrompt: user,
+        model: this.model,
+      });
+      return result.text;
+    };
+    const spec = await designSimulation(description, llmFn);
+    const errors = validateSimulationSpec(spec);
+    if (errors.length > 0) {
+      throw new Error(`simulation spec validation failed: ${errors.join("; ")}`);
+    }
+
+    const customDir = join(this.knowledgeRoot, "_custom_scenarios");
+    const scenarioDir = join(customDir, name);
+    if (!existsSync(scenarioDir)) mkdirSync(scenarioDir, { recursive: true });
+
+    writeFileSync(join(scenarioDir, "scenario.py"), generateScenarioSource(spec, name), "utf-8");
+    writeFileSync(join(scenarioDir, "scenario_type.txt"), "simulation", "utf-8");
+    writeFileSync(
+      join(scenarioDir, "spec.json"),
+      JSON.stringify(
+        {
+          name,
+          scenario_type: "simulation",
+          description: spec.description,
+          environment_description: spec.environmentDescription,
+          initial_state_description: spec.initialStateDescription,
+          success_criteria: spec.successCriteria,
+          failure_modes: spec.failureModes,
+          max_steps: spec.maxSteps,
+          actions: spec.actions,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    return { family: "simulation", name, spec };
+  }
+}

--- a/ts/src/scenarios/simulation-designer.ts
+++ b/ts/src/scenarios/simulation-designer.ts
@@ -1,0 +1,91 @@
+import type { SimulationSpec } from "./simulation-spec.js";
+import { parseRawSimulationSpec } from "./simulation-spec.js";
+
+export const SIM_SPEC_START = "<!-- SIMULATION_SPEC_START -->";
+export const SIM_SPEC_END = "<!-- SIMULATION_SPEC_END -->";
+
+const EXAMPLE_SPEC = {
+  description: "Recover a multi-step API workflow after a mid-flow cancellation.",
+  environment_description: "Mock booking system with dependent flight, hotel, and transport steps.",
+  initial_state_description: "No bookings exist yet. A flight cancellation may occur mid-flow.",
+  success_criteria: [
+    "all required bookings are completed consistently",
+    "partial side effects are rolled back or compensated cleanly",
+  ],
+  failure_modes: ["flight cancellation", "dependency mismatch", "partial side effects"],
+  max_steps: 8,
+  actions: [
+    {
+      name: "book_flight",
+      description: "Reserve a flight matching the request.",
+      parameters: { flight_id: "string" },
+      preconditions: [],
+      effects: ["flight_reserved"],
+    },
+    {
+      name: "book_hotel",
+      description: "Reserve a hotel after the flight exists.",
+      parameters: { hotel_id: "string" },
+      preconditions: ["book_flight"],
+      effects: ["hotel_reserved"],
+    },
+  ],
+};
+
+export const SIMULATION_DESIGNER_SYSTEM = `You are a scenario designer for autocontext.
+Given a natural-language request for a stateful or action-trace task, produce a SimulationSpec JSON.
+
+Wrap the output in delimiters:
+${SIM_SPEC_START}
+{ ... }
+${SIM_SPEC_END}
+
+Schema:
+{
+  "description": "human readable scenario summary",
+  "environment_description": "what the mock environment models",
+  "initial_state_description": "starting state narrative",
+  "success_criteria": ["criterion 1", "criterion 2"],
+  "failure_modes": ["failure mode"],
+  "max_steps": 8,
+  "actions": [
+    {
+      "name": "snake_case_action",
+      "description": "what the action does",
+      "parameters": {"param": "type"},
+      "preconditions": ["prior_action"],
+      "effects": ["effect"]
+    }
+  ]
+}
+
+Rules:
+- model the task as a mock environment with explicit actions
+- use preconditions to encode dependency ordering
+- include at least two success criteria
+- keep the action set minimal but sufficient to complete and recover the workflow
+
+Example:
+${SIM_SPEC_START}
+${JSON.stringify(EXAMPLE_SPEC, null, 2)}
+${SIM_SPEC_END}
+`;
+
+export function parseSimulationSpec(text: string): SimulationSpec {
+  const startIdx = text.indexOf(SIM_SPEC_START);
+  const endIdx = text.indexOf(SIM_SPEC_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
+    throw new Error("response does not contain SIMULATION_SPEC delimiters");
+  }
+  const raw = text.slice(startIdx + SIM_SPEC_START.length, endIdx).trim();
+  return parseRawSimulationSpec(JSON.parse(raw) as Record<string, unknown>);
+}
+
+export async function designSimulation(
+  description: string,
+  llmFn: (system: string, user: string) => Promise<string>,
+): Promise<SimulationSpec> {
+  return parseSimulationSpec(
+    await llmFn(SIMULATION_DESIGNER_SYSTEM, `User description:\n${description}`),
+  );
+}

--- a/ts/src/scenarios/simulation-spec.ts
+++ b/ts/src/scenarios/simulation-spec.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+export const SimulationActionSpecSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+  parameters: z.record(z.string()).default({}),
+  preconditions: z.array(z.string()).default([]),
+  effects: z.array(z.string()).default([]),
+});
+
+export const SimulationSpecSchema = z.object({
+  description: z.string().min(1),
+  environmentDescription: z.string().min(1),
+  initialStateDescription: z.string().min(1),
+  successCriteria: z.array(z.string()).min(2),
+  failureModes: z.array(z.string()).default([]),
+  actions: z.array(SimulationActionSpecSchema).min(2),
+  maxSteps: z.number().int().positive().default(10),
+});
+
+export type SimulationActionSpec = z.infer<typeof SimulationActionSpecSchema>;
+export type SimulationSpec = z.infer<typeof SimulationSpecSchema>;
+
+export function parseRawSimulationSpec(data: Record<string, unknown>): SimulationSpec {
+  return SimulationSpecSchema.parse({
+    description: data.description,
+    environmentDescription: data.environment_description,
+    initialStateDescription: data.initial_state_description,
+    successCriteria: data.success_criteria,
+    failureModes: data.failure_modes ?? [],
+    actions: data.actions,
+    maxSteps: data.max_steps ?? 10,
+  });
+}

--- a/ts/tests/agent-task-pipeline.test.ts
+++ b/ts/tests/agent-task-pipeline.test.ts
@@ -11,6 +11,10 @@ import {
   SPEC_START,
   SPEC_END,
 } from "../src/scenarios/agent-task-designer.js";
+import {
+  SIM_SPEC_END,
+  SIM_SPEC_START,
+} from "../src/scenarios/simulation-designer.js";
 import { validateIntent, validateSpec } from "../src/scenarios/agent-task-validator.js";
 import { createAgentTask } from "../src/scenarios/agent-task-factory.js";
 import { AgentTaskCreator } from "../src/scenarios/agent-task-creator.js";
@@ -38,6 +42,34 @@ function mockLlmResponse(spec: AgentTaskSpec): string {
     judge_model: spec.judgeModel,
   };
   return `Here is the spec:\n${SPEC_START}\n${JSON.stringify(data, null, 2)}\n${SPEC_END}\n`;
+}
+
+function mockSimulationResponse(): string {
+  const data = {
+    description: "Recover a multi-step API workflow.",
+    environment_description: "Mock API orchestration environment.",
+    initial_state_description: "No calls completed.",
+    success_criteria: ["all required actions complete", "invalid order is recovered"],
+    failure_modes: ["dependency mismatch", "partial side effects"],
+    max_steps: 6,
+    actions: [
+      {
+        name: "book_flight",
+        description: "Reserve a flight.",
+        parameters: { flight_id: "string" },
+        preconditions: [],
+        effects: ["flight_reserved"],
+      },
+      {
+        name: "book_hotel",
+        description: "Reserve a hotel.",
+        parameters: { hotel_id: "string" },
+        preconditions: ["book_flight"],
+        effects: ["hotel_reserved"],
+      },
+    ],
+  };
+  return `${SIM_SPEC_START}\n${JSON.stringify(data, null, 2)}\n${SIM_SPEC_END}\n`;
 }
 
 function makeMockProvider(response = "mock output"): LLMProvider {
@@ -332,6 +364,21 @@ describe("AgentTaskCreator", () => {
     await expect(
       creator.create("Root cause analysis of server crashes with red herrings"),
     ).rejects.toThrow("intent validation failed");
+  });
+
+  it("routes simulation-like descriptions into a simulation scenario scaffold", async () => {
+    const provider = makeMockProvider(mockSimulationResponse());
+    const tmpDir = mkdtempSync(join(tmpdir(), "autocontext-creator-sim-"));
+    const creator = new AgentTaskCreator({ provider, knowledgeRoot: tmpDir });
+
+    const scenario = await creator.create("Build a stateful API orchestration workflow with rollback");
+    expect("family" in scenario && scenario.family).toBe("simulation");
+
+    const name = creator.deriveName("Build a stateful API orchestration workflow with rollback");
+    const scenarioDir = join(tmpDir, "_custom_scenarios", name);
+    expect(existsSync(join(scenarioDir, "scenario.py"))).toBe(true);
+    expect(existsSync(join(scenarioDir, "spec.json"))).toBe(true);
+    expect(readFileSync(join(scenarioDir, "scenario_type.txt"), "utf-8")).toBe("simulation");
   });
 });
 


### PR DESCRIPTION
## Summary
- Introduces `SimulationInterface` ABC as the third scenario type alongside `ScenarioInterface` (games) and `AgentTaskInterface` (tasks)
- Agents interact with mock environments (APIs, filesystem, state machines) and are judged on action traces — sequence correctness, recovery behavior, rollback quality, dependency ordering — rather than prose quality
- Data models: `ActionSpec`, `Action`, `ActionResult`, `ActionRecord`, `ActionTrace`, `EnvironmentSpec`, `SimulationResult` with full `to_dict`/`from_dict` serialization
- ABC defines 8 abstract methods + 3 optional hooks (`validate_action`, `max_steps`, `inject_fault`)
- Compatible with `SCENARIO_REGISTRY` via `hasattr` detection (distinct from both game and agent-task interfaces)

## Test plan
- [x] 42 tests in `test_simulation_contract.py` covering:
  - Data model construction and defaults
  - ActionTrace computed properties (success_rate, actions)
  - ActionTrace/SimulationResult serialization roundtrips
  - ABC enforcement (cannot instantiate directly)
  - Concrete mock implementation end-to-end (successful workflow, recovery, incomplete)
  - Default method behavior (validate_action, max_steps, inject_fault)
  - Registry compatibility and hasattr detection
- [x] Ruff clean
- [x] Mypy clean
- [x] Full suite: 3399 passed, 46 skipped