### PR TITLE
feat(AC-248): artifact-editing scenario family with artifact-based evaluation

### DIFF
--- a/autocontext/src/autocontext/openclaw/models.py
+++ b/autocontext/src/autocontext/openclaw/models.py
@@ -11,7 +11,7 @@ class ScenarioInfo(BaseModel):
 
     name: str
     display_name: str
-    scenario_type: Literal["game", "agent_task", "simulation"]
+    scenario_type: Literal["game", "agent_task", "simulation", "artifact_editing"]
     description: str
     strategy_interface: str = ""
 

--- a/autocontext/src/autocontext/openclaw/skill.py
+++ b/autocontext/src/autocontext/openclaw/skill.py
@@ -73,11 +73,11 @@ def _build_scenario_info(name: str) -> ScenarioInfo:
         if hasattr(instance, "describe_strategy_interface")
         else ""
     )
-    if family.name == "agent_task":
+    if family.name in {"agent_task", "artifact_editing"}:
         description = instance.describe_task()[:500] if hasattr(instance, "describe_task") else ""
     else:
         description = instance.describe_rules()[:500] if hasattr(instance, "describe_rules") else ""
-    scenario_type = cast(Literal["game", "agent_task", "simulation"], family.name)
+    scenario_type = cast(Literal["game", "agent_task", "simulation", "artifact_editing"], family.name)
     return ScenarioInfo(
         name=name,
         display_name=name.replace("_", " ").title(),

--- a/autocontext/src/autocontext/scenarios/artifact_editing.py
+++ b/autocontext/src/autocontext/scenarios/artifact_editing.py
@@ -1,0 +1,196 @@
+"""Artifact-editing scenario family with artifact-based evaluation (AC-248).
+
+Scenarios where agents modify real artifacts (files, configs, schemas,
+structured outputs) and are judged on the resulting artifact state and
+validation pipeline outcomes, not just prose quality.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class Artifact:
+    """A versioned artifact that can be edited."""
+
+    path: str
+    content: str
+    content_type: str  # e.g., "yaml", "json", "python", "text"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "content": self.content,
+            "content_type": self.content_type,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Artifact:
+        return cls(
+            path=data["path"],
+            content=data["content"],
+            content_type=data["content_type"],
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass(slots=True)
+class ArtifactDiff:
+    """Records a change to an artifact."""
+
+    path: str
+    operation: str  # "create", "modify", "delete"
+    before: str | None
+    after: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "operation": self.operation,
+            "before": self.before,
+            "after": self.after,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ArtifactDiff:
+        return cls(
+            path=data["path"],
+            operation=data["operation"],
+            before=data.get("before"),
+            after=data.get("after"),
+        )
+
+
+@dataclass(slots=True)
+class ArtifactValidationResult:
+    """Result of validating an artifact's state."""
+
+    valid: bool
+    errors: list[str]
+    warnings: list[str]
+
+
+@dataclass(slots=True)
+class ArtifactEditingResult:
+    """Result of evaluating an artifact-editing scenario."""
+
+    score: float
+    reasoning: str
+    dimension_scores: dict[str, float]
+    diffs: list[ArtifactDiff]
+    validation: ArtifactValidationResult
+    artifacts_modified: int
+    artifacts_valid: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "reasoning": self.reasoning,
+            "dimension_scores": self.dimension_scores,
+            "diffs": [d.to_dict() for d in self.diffs],
+            "validation": {
+                "valid": self.validation.valid,
+                "errors": self.validation.errors,
+                "warnings": self.validation.warnings,
+            },
+            "artifacts_modified": self.artifacts_modified,
+            "artifacts_valid": self.artifacts_valid,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ArtifactEditingResult:
+        val_data = data["validation"]
+        return cls(
+            score=data["score"],
+            reasoning=data["reasoning"],
+            dimension_scores=data["dimension_scores"],
+            diffs=[ArtifactDiff.from_dict(d) for d in data["diffs"]],
+            validation=ArtifactValidationResult(
+                valid=val_data["valid"],
+                errors=val_data["errors"],
+                warnings=val_data.get("warnings", []),
+            ),
+            artifacts_modified=data["artifacts_modified"],
+            artifacts_valid=data["artifacts_valid"],
+        )
+
+
+class ArtifactEditingInterface(ABC):
+    """Contract for artifact-editing scenarios.
+
+    Agents modify real artifacts (files, configs, schemas) and are
+    evaluated on the resulting artifact state and validation outcomes.
+    """
+
+    name: str
+
+    @abstractmethod
+    def describe_task(self) -> str:
+        """Return a human-readable description of the editing task."""
+
+    @abstractmethod
+    def get_rubric(self) -> str:
+        """Return the evaluation rubric."""
+
+    @abstractmethod
+    def initial_artifacts(self, seed: int | None = None) -> list[Artifact]:
+        """Return the initial set of artifacts to be edited."""
+
+    @abstractmethod
+    def get_edit_prompt(self, artifacts: list[Artifact]) -> str:
+        """Return the editing prompt given the current artifacts."""
+
+    @abstractmethod
+    def validate_artifact(self, artifact: Artifact) -> ArtifactValidationResult:
+        """Validate a single artifact's state."""
+
+    @abstractmethod
+    def evaluate_edits(
+        self,
+        original: list[Artifact],
+        edited: list[Artifact],
+    ) -> ArtifactEditingResult:
+        """Evaluate the full set of edits."""
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        """Return initial state for registry compatibility."""
+        artifacts = self.initial_artifacts(seed)
+        return {"artifacts": [a.to_dict() for a in artifacts], "seed": seed or 0}
+
+    def compute_diffs(
+        self,
+        original: list[Artifact],
+        edited: list[Artifact],
+    ) -> list[ArtifactDiff]:
+        """Compute diffs between original and edited artifact sets."""
+        original_by_path = {a.path: a for a in original}
+        edited_by_path = {a.path: a for a in edited}
+
+        diffs: list[ArtifactDiff] = []
+
+        # Modifications and deletions
+        for path, orig in original_by_path.items():
+            if path in edited_by_path:
+                ed = edited_by_path[path]
+                if orig.content != ed.content:
+                    diffs.append(ArtifactDiff(
+                        path=path, operation="modify", before=orig.content, after=ed.content,
+                    ))
+            else:
+                diffs.append(ArtifactDiff(
+                    path=path, operation="delete", before=orig.content, after=None,
+                ))
+
+        # Creations
+        for path, ed in edited_by_path.items():
+            if path not in original_by_path:
+                diffs.append(ArtifactDiff(
+                    path=path, operation="create", before=None, after=ed.content,
+                ))
+
+        return diffs

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -10,6 +10,7 @@ from dataclasses import asdict
 from pathlib import Path
 
 from autocontext.scenarios.agent_task import AgentTaskInterface
+from autocontext.scenarios.artifact_editing import ArtifactEditingInterface
 from autocontext.scenarios.base import ScenarioInterface
 from autocontext.scenarios.custom.agent_task_codegen import generate_agent_task_class
 from autocontext.scenarios.custom.agent_task_designer import design_agent_task
@@ -17,6 +18,7 @@ from autocontext.scenarios.custom.agent_task_validator import (
     validate_execution,
     validate_intent,
 )
+from autocontext.scenarios.custom.artifact_editing_creator import ArtifactEditingCreator
 from autocontext.scenarios.custom.family_classifier import (
     classify_scenario_family,
     route_to_family,
@@ -68,7 +70,10 @@ class AgentTaskCreator:
         name_words = unique[:3] if len(unique) >= 3 else unique[:2] if unique else ["custom"]
         return "_".join(name_words)
 
-    def create(self, description: str) -> AgentTaskInterface | ScenarioInterface:
+    def create(
+        self,
+        description: str,
+    ) -> AgentTaskInterface | ScenarioInterface | ArtifactEditingInterface:
         """Run the full pipeline: design → validate → codegen → validate → load → register.
 
         Returns:
@@ -80,6 +85,9 @@ class AgentTaskCreator:
         if family.name == "simulation":
             logger.info("routing description to simulation creator")
             return SimulationCreator(self.llm_fn, self.knowledge_root).create(description, name=name)
+        if family.name == "artifact_editing":
+            logger.info("routing description to artifact-editing creator")
+            return ArtifactEditingCreator(self.llm_fn, self.knowledge_root).create(description, name=name)
         if family.name != "agent_task":
             raise ValueError(
                 f"Scenario family '{family.name}' is not yet supported for custom scaffolding"

--- a/autocontext/src/autocontext/scenarios/custom/artifact_editing_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/artifact_editing_codegen.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import re
+
+from autocontext.scenarios.custom.artifact_editing_spec import ArtifactEditingSpec
+
+
+def _class_name(name: str) -> str:
+    parts = re.split(r"[^a-zA-Z0-9]+", name)
+    return "".join(part.capitalize() for part in parts if part) + "ArtifactEditing"
+
+
+def generate_artifact_editing_class(spec: ArtifactEditingSpec, name: str) -> str:
+    class_name = _class_name(name)
+    artifacts = ",\n".join(
+        "            Artifact("
+        f"path={artifact.path!r}, "
+        f"content={artifact.content!r}, "
+        f"content_type={artifact.content_type!r}, "
+        f"metadata={artifact.metadata!r})"
+        for artifact in spec.artifacts
+    )
+    return f'''from __future__ import annotations
+
+import json
+import re
+
+from autocontext.scenarios.artifact_editing import (
+    Artifact,
+    ArtifactEditingInterface,
+    ArtifactEditingResult,
+    ArtifactValidationResult,
+)
+
+
+class {class_name}(ArtifactEditingInterface):
+    name = {name!r}
+    _validation_rules = {spec.validation_rules!r}
+
+    def describe_task(self) -> str:
+        return {spec.task_description!r}
+
+    def get_rubric(self) -> str:
+        return {spec.rubric!r}
+
+    def initial_artifacts(self, seed: int | None = None) -> list[Artifact]:
+        return [
+{artifacts}
+        ]
+
+    def get_edit_prompt(self, artifacts: list[Artifact]) -> str:
+        rendered = json.dumps([artifact.to_dict() for artifact in artifacts], indent=2)
+        rules = "\\n".join(f"- {{rule}}" for rule in self._validation_rules)
+        return (
+            f"{{self.describe_task()}}\\n\\n"
+            f"Artifacts:\\n{{rendered}}\\n\\n"
+            f"Validation rules:\\n{{rules}}\\n\\n"
+            'Return JSON with shape {{"artifacts": [{{"path": "...", "content": "...", "content_type": "..."}}]}} '
+            "containing the full edited artifact set."
+        )
+
+    def _rules_for_path(self, path: str) -> list[str]:
+        relevant: list[str] = []
+        for rule in self._validation_rules:
+            if " must " in rule:
+                prefix, _ = rule.split(" must ", 1)
+                if "/" in prefix and prefix.strip() != path:
+                    continue
+            relevant.append(rule)
+        return relevant
+
+    def _extract_snippets(self, rule: str) -> list[str]:
+        return [match[0] or match[1] for match in re.findall(r'"([^"]+)"|\\'([^\\']+)\\'', rule)]
+
+    def validate_artifact(self, artifact: Artifact) -> ArtifactValidationResult:
+        errors: list[str] = []
+        warnings: list[str] = []
+        if not artifact.content.strip():
+            errors.append(f"{{artifact.path}} must not be empty")
+        for rule in self._rules_for_path(artifact.path):
+            snippets = self._extract_snippets(rule)
+            if not snippets:
+                continue
+            if "must not contain" in rule:
+                for snippet in snippets:
+                    if snippet in artifact.content:
+                        errors.append(f"{{artifact.path}} violates rule: {{rule}}")
+            else:
+                for snippet in snippets:
+                    if snippet not in artifact.content:
+                        errors.append(f"{{artifact.path}} violates rule: {{rule}}")
+        return ArtifactValidationResult(valid=not errors, errors=errors, warnings=warnings)
+
+    def evaluate_edits(self, original: list[Artifact], edited: list[Artifact]) -> ArtifactEditingResult:
+        diffs = self.compute_diffs(original, edited)
+        validations = [self.validate_artifact(artifact) for artifact in edited]
+        valid_count = sum(1 for result in validations if result.valid)
+        error_count = sum(len(result.errors) for result in validations)
+        correctness = valid_count / max(len(edited), 1)
+        change_score = 1.0 if diffs else 0.0
+        baseline = max(len(original), 1)
+        precision = 1.0 if len(diffs) <= baseline else max(0.2, 1.0 - ((len(diffs) - baseline) / baseline) * 0.2)
+        score = round((correctness * 0.7) + (change_score * 0.15) + (precision * 0.15), 4)
+        return ArtifactEditingResult(
+            score=score,
+            reasoning=f"Validated {{valid_count}} of {{len(edited)}} artifacts with {{len(diffs)}} tracked edits.",
+            dimension_scores={{
+                "correctness": round(correctness, 4),
+                "change_completeness": round(change_score, 4),
+                "precision": round(precision, 4),
+            }},
+            diffs=diffs,
+            validation=ArtifactValidationResult(
+                valid=error_count == 0,
+                errors=[error for result in validations for error in result.errors],
+                warnings=[warning for result in validations for warning in result.warnings],
+            ),
+            artifacts_modified=len(diffs),
+            artifacts_valid=valid_count,
+        )
+'''

--- a/autocontext/src/autocontext/scenarios/custom/artifact_editing_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/artifact_editing_creator.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import asdict
+from pathlib import Path
+from typing import cast
+
+from autocontext.scenarios.artifact_editing import ArtifactEditingInterface
+from autocontext.scenarios.custom.artifact_editing_codegen import generate_artifact_editing_class
+from autocontext.scenarios.custom.artifact_editing_designer import design_artifact_editing
+from autocontext.scenarios.custom.family_pipeline import (
+    validate_for_family,
+    validate_source_for_family,
+)
+from autocontext.scenarios.custom.loader import load_custom_scenario
+from autocontext.scenarios.custom.registry import CUSTOM_SCENARIOS_DIR
+from autocontext.scenarios.families import get_family_marker
+
+logger = logging.getLogger(__name__)
+
+
+class ArtifactEditingCreator:
+    def __init__(self, llm_fn: Callable[[str, str], str], knowledge_root: Path) -> None:
+        self.llm_fn = llm_fn
+        self.knowledge_root = knowledge_root
+
+    def create(self, description: str, name: str) -> ArtifactEditingInterface:
+        spec = design_artifact_editing(description, self.llm_fn)
+        errors = validate_for_family("artifact_editing", asdict(spec))
+        if errors:
+            raise ValueError(f"artifact-editing spec validation failed: {'; '.join(errors)}")
+
+        custom_dir = self.knowledge_root / CUSTOM_SCENARIOS_DIR
+        scenario_dir = custom_dir / name
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+
+        source = generate_artifact_editing_class(spec, name=name)
+        source_errors = validate_source_for_family("artifact_editing", source)
+        if source_errors:
+            raise ValueError(
+                f"artifact-editing source validation failed: {'; '.join(source_errors)}"
+            )
+
+        (scenario_dir / "scenario.py").write_text(source, encoding="utf-8")
+        (scenario_dir / "spec.json").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "scenario_type": get_family_marker("artifact_editing"),
+                    "task_description": spec.task_description,
+                    "rubric": spec.rubric,
+                    "validation_rules": spec.validation_rules,
+                    "artifacts": [
+                        {
+                            "path": artifact.path,
+                            "content": artifact.content,
+                            "content_type": artifact.content_type,
+                            "metadata": artifact.metadata,
+                        }
+                        for artifact in spec.artifacts
+                    ],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        (scenario_dir / "scenario_type.txt").write_text(
+            get_family_marker("artifact_editing"),
+            encoding="utf-8",
+        )
+
+        cls = load_custom_scenario(custom_dir, name, ArtifactEditingInterface)
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        SCENARIO_REGISTRY[name] = cls
+        logger.info("registered artifact-editing scenario '%s'", name)
+        return cast(ArtifactEditingInterface, cls())

--- a/autocontext/src/autocontext/scenarios/custom/artifact_editing_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/artifact_editing_designer.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+
+from autocontext.scenarios.custom.artifact_editing_spec import (
+    ArtifactEditingSpec,
+    ArtifactSpecModel,
+)
+
+ARTIFACT_SPEC_START = "<!-- ARTIFACT_EDITING_SPEC_START -->"
+ARTIFACT_SPEC_END = "<!-- ARTIFACT_EDITING_SPEC_END -->"
+
+_EXAMPLE_SPEC = {
+    "task_description": "Update a YAML service config to add a database section without changing unrelated settings.",
+    "rubric": "Evaluate correctness of the edited artifacts, satisfaction of validation rules, and minimal unnecessary changes.",
+    "validation_rules": [
+        'config/app.yaml must contain "database:"',
+        'config/app.yaml must contain "host:"',
+        'config/app.yaml must contain "port:"',
+    ],
+    "artifacts": [
+        {
+            "path": "config/app.yaml",
+            "content": "app:\n  name: myapp\n  port: 8080\n",
+            "content_type": "yaml",
+        }
+    ],
+}
+
+ARTIFACT_EDITING_DESIGNER_SYSTEM = (
+    "You are a scenario designer for autocontext. "
+    "Given a natural-language request for an artifact-editing task, produce an "
+    "ArtifactEditingSpec JSON wrapped in delimiters.\n\n"
+    f"{ARTIFACT_SPEC_START}\n{{ ... }}\n{ARTIFACT_SPEC_END}\n\n"
+    "Schema:\n"
+    "{\n"
+    '  "task_description": "what the agent should change in the artifacts",\n'
+    '  "rubric": "how the final edited artifacts should be judged",\n'
+    '  "validation_rules": ["path/to/file must contain \\"snippet\\""],\n'
+    '  "artifacts": [\n'
+    "    {\n"
+    '      "path": "config/app.yaml",\n'
+    '      "content": "current file contents",\n'
+    '      "content_type": "yaml"\n'
+    "    }\n"
+    "  ]\n"
+    "}\n\n"
+    "Rules:\n"
+    "- model the task around editing concrete artifacts, not writing prose about them\n"
+    "- include at least one artifact with realistic initial content\n"
+    "- express validation rules as path-scoped must-contain or must-not-contain checks when possible\n"
+    "- keep the rubric focused on artifact correctness, validator success, and precision of edits\n\n"
+    f"Example:\n{ARTIFACT_SPEC_START}\n{json.dumps(_EXAMPLE_SPEC, indent=2)}\n{ARTIFACT_SPEC_END}\n"
+)
+
+
+def parse_artifact_editing_spec(text: str) -> ArtifactEditingSpec:
+    pattern = re.escape(ARTIFACT_SPEC_START) + r"\s*(.*?)\s*" + re.escape(ARTIFACT_SPEC_END)
+    match = re.search(pattern, text, re.DOTALL)
+    if not match:
+        raise ValueError("response does not contain ARTIFACT_EDITING_SPEC delimiters")
+    data = json.loads(match.group(1).strip())
+    return ArtifactEditingSpec(
+        task_description=data["task_description"],
+        rubric=data["rubric"],
+        validation_rules=data["validation_rules"],
+        artifacts=[
+            ArtifactSpecModel(
+                path=raw["path"],
+                content=raw["content"],
+                content_type=raw["content_type"],
+                metadata=raw.get("metadata", {}),
+            )
+            for raw in data["artifacts"]
+        ],
+    )
+
+
+def design_artifact_editing(description: str, llm_fn: Callable[[str, str], str]) -> ArtifactEditingSpec:
+    response = llm_fn(ARTIFACT_EDITING_DESIGNER_SYSTEM, f"User description:\n{description}")
+    return parse_artifact_editing_spec(response)

--- a/autocontext/src/autocontext/scenarios/custom/artifact_editing_spec.py
+++ b/autocontext/src/autocontext/scenarios/custom/artifact_editing_spec.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class ArtifactSpecModel:
+    path: str
+    content: str
+    content_type: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ArtifactEditingSpec:
+    task_description: str
+    rubric: str
+    validation_rules: list[str]
+    artifacts: list[ArtifactSpecModel]

--- a/autocontext/src/autocontext/scenarios/custom/creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/creator.py
@@ -103,7 +103,7 @@ class ScenarioCreator:
         scenario_file.write_text(source, encoding="utf-8")
         spec.save(scenario_dir)
 
-        scenario_class = load_custom_scenario(custom_dir, spec.name)
+        scenario_class = load_custom_scenario(custom_dir, spec.name, ScenarioInterface)
 
         exec_errors = validate_by_execution(scenario_class, spec, seeds=3)
         if exec_errors:

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -181,10 +181,38 @@ _GAME_SIGNALS: dict[str, float] = {
     "player": 1.0,
 }
 
+_ARTIFACT_EDITING_SIGNALS: dict[str, float] = {
+    "edit file": 2.0,
+    "modify file": 2.0,
+    "update config": 2.0,
+    "configuration": 1.5,
+    "config file": 1.5,
+    "yaml": 1.5,
+    "json": 1.0,
+    "schema": 1.5,
+    "migration": 1.5,
+    "manifest": 1.5,
+    "patch": 1.0,
+    "refactor config": 2.0,
+    "fix config": 2.0,
+    "artifact": 1.5,
+    "file edit": 2.0,
+    "rewrite": 1.0,
+    "update policy": 1.5,
+    "change file": 1.5,
+    "modify yaml": 2.0,
+    "modify json": 2.0,
+    "config repair": 2.0,
+    "repair schema": 2.0,
+    "sql migration": 2.0,
+    "dockerfile": 1.5,
+}
+
 _FAMILY_SIGNAL_GROUPS: dict[str, dict[str, float]] = {
     "simulation": _SIMULATION_SIGNALS,
     "agent_task": _AGENT_TASK_SIGNALS,
     "game": _GAME_SIGNALS,
+    "artifact_editing": _ARTIFACT_EDITING_SIGNALS,
 }
 
 _DEFAULT_FAMILY_NAME = "agent_task"

--- a/autocontext/src/autocontext/scenarios/custom/family_pipeline.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_pipeline.py
@@ -321,7 +321,14 @@ class ArtifactEditingPipeline(FamilyPipeline):
         return {"task_description", "artifacts", "validation_rules", "rubric"}
 
     def validate_spec(self, spec: dict[str, Any]) -> list[str]:
+        from autocontext.scenarios.custom.artifact_editing_spec import (
+            ArtifactEditingSpec,
+            ArtifactSpecModel,
+        )
+
         errors = _check_required_fields(spec, self.required_spec_fields())
+        if errors:
+            return errors
 
         artifacts = spec.get("artifacts")
         if isinstance(artifacts, list):
@@ -342,6 +349,27 @@ class ArtifactEditingPipeline(FamilyPipeline):
         rules = spec.get("validation_rules")
         if isinstance(rules, list) and len(rules) == 0:
             errors.append("validation_rules must not be empty")
+
+        if errors:
+            return errors
+
+        try:
+            ArtifactEditingSpec(
+                task_description=str(spec["task_description"]),
+                rubric=str(spec["rubric"]),
+                validation_rules=[str(rule) for rule in spec["validation_rules"]],
+                artifacts=[
+                    ArtifactSpecModel(
+                        path=str(artifact["path"]),
+                        content=str(artifact["content"]),
+                        content_type=str(artifact["content_type"]),
+                        metadata=artifact.get("metadata", {}) if isinstance(artifact, dict) else {},
+                    )
+                    for artifact in spec["artifacts"]
+                ],
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            return [f"invalid artifact_editing spec: {exc}"]
 
         return errors
 

--- a/autocontext/src/autocontext/scenarios/custom/family_pipeline.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_pipeline.py
@@ -310,6 +310,59 @@ class SimulationPipeline(FamilyPipeline):
         )
 
 
+class ArtifactEditingPipeline(FamilyPipeline):
+    """Pipeline for artifact_editing family scenarios."""
+
+    @property
+    def family_name(self) -> str:
+        return "artifact_editing"
+
+    def required_spec_fields(self) -> set[str]:
+        return {"task_description", "artifacts", "validation_rules", "rubric"}
+
+    def validate_spec(self, spec: dict[str, Any]) -> list[str]:
+        errors = _check_required_fields(spec, self.required_spec_fields())
+
+        artifacts = spec.get("artifacts")
+        if isinstance(artifacts, list):
+            if len(artifacts) == 0:
+                errors.append("artifacts must not be empty")
+            else:
+                for i, artifact in enumerate(artifacts):
+                    if not isinstance(artifact, dict):
+                        errors.append(f"artifacts[{i}] must be a dict")
+                    else:
+                        if "path" not in artifact:
+                            errors.append(f"artifacts[{i}] missing 'path'")
+                        if "content" not in artifact:
+                            errors.append(f"artifacts[{i}] missing 'content'")
+                        if "content_type" not in artifact:
+                            errors.append(f"artifacts[{i}] missing 'content_type'")
+
+        rules = spec.get("validation_rules")
+        if isinstance(rules, list) and len(rules) == 0:
+            errors.append("validation_rules must not be empty")
+
+        return errors
+
+    def validate_source(self, source: str) -> list[str]:
+        return _check_source_for_class(source, "ArtifactEditingInterface")
+
+    def validate_contract(self, source: str) -> list[str]:
+        return _check_required_methods(
+            source,
+            "ArtifactEditingInterface",
+            {
+                "describe_task",
+                "get_rubric",
+                "initial_artifacts",
+                "get_edit_prompt",
+                "validate_artifact",
+                "evaluate_edits",
+            },
+        )
+
+
 # ---------------------------------------------------------------------------
 # Built-in pipeline registration
 # ---------------------------------------------------------------------------
@@ -317,6 +370,7 @@ class SimulationPipeline(FamilyPipeline):
 def _register_builtins() -> None:
     register_pipeline(AgentTaskPipeline())
     register_pipeline(SimulationPipeline())
+    register_pipeline(ArtifactEditingPipeline())
 
 
 _register_builtins()

--- a/autocontext/src/autocontext/scenarios/custom/loader.py
+++ b/autocontext/src/autocontext/scenarios/custom/loader.py
@@ -5,8 +5,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from autocontext.scenarios.base import ScenarioInterface
 
-def load_custom_scenario(custom_dir: Path, name: str, interface_class: type[Any]) -> type[Any]:
+
+def load_custom_scenario(
+    custom_dir: Path,
+    name: str,
+    interface_class: type[Any] = ScenarioInterface,
+) -> type[Any]:
     module_name = f"autocontext.scenarios.custom.generated.{name}"
 
     if module_name in sys.modules:

--- a/autocontext/src/autocontext/scenarios/custom/loader.py
+++ b/autocontext/src/autocontext/scenarios/custom/loader.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from typing import Any
 
-from autocontext.scenarios.base import ScenarioInterface
 
-
-def load_custom_scenario(custom_dir: Path, name: str) -> type[ScenarioInterface]:
+def load_custom_scenario(custom_dir: Path, name: str, interface_class: type[Any]) -> type[Any]:
     module_name = f"autocontext.scenarios.custom.generated.{name}"
 
     if module_name in sys.modules:
@@ -29,10 +28,12 @@ def load_custom_scenario(custom_dir: Path, name: str) -> type[ScenarioInterface]
         attr = getattr(mod, attr_name)
         if (
             isinstance(attr, type)
-            and issubclass(attr, ScenarioInterface)
-            and attr is not ScenarioInterface
+            and issubclass(attr, interface_class)
+            and attr is not interface_class
             and getattr(attr, "name", None) == name
         ):
-            return attr  # type: ignore[return-value]
+            return attr
 
-    raise ImportError(f"no ScenarioInterface subclass with name='{name}' found in {module_name}")
+    raise ImportError(
+        f"no {interface_class.__name__} subclass with name='{name}' found in {module_name}"
+    )

--- a/autocontext/src/autocontext/scenarios/custom/registry.py
+++ b/autocontext/src/autocontext/scenarios/custom/registry.py
@@ -53,7 +53,7 @@ def _load_family_class(custom_dir: Path, name: str, marker: str) -> type[Any]:
             raise FileNotFoundError(f"agent task source not found: {agent_task_file}")
         return _load_agent_task_class(custom_dir, name)
 
-    cls = load_custom_scenario(custom_dir, name)
+    cls = load_custom_scenario(custom_dir, name, family.interface_class)
     detected = detect_family(cls())
     if detected is None or detected.name != family.name:
         raise ImportError(

--- a/autocontext/src/autocontext/scenarios/custom/simulation_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/simulation_creator.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import asdict
 from pathlib import Path
+from typing import cast
 
 from autocontext.scenarios.base import ScenarioInterface
 from autocontext.scenarios.custom.family_pipeline import (
@@ -17,6 +18,7 @@ from autocontext.scenarios.custom.simulation_codegen import generate_simulation_
 from autocontext.scenarios.custom.simulation_designer import design_simulation
 from autocontext.scenarios.custom.simulation_spec import SimulationSpec
 from autocontext.scenarios.families import get_family_marker
+from autocontext.scenarios.simulation import SimulationInterface
 
 logger = logging.getLogger(__name__)
 
@@ -84,9 +86,9 @@ class SimulationCreator:
         )
         (scenario_dir / "scenario_type.txt").write_text(get_family_marker("simulation"), encoding="utf-8")
 
-        cls = load_custom_scenario(custom_dir, name)
+        cls = load_custom_scenario(custom_dir, name, SimulationInterface)
         from autocontext.scenarios import SCENARIO_REGISTRY
 
         SCENARIO_REGISTRY[name] = cls
         logger.info("registered simulation scenario '%s'", name)
-        return cls()
+        return cast(ScenarioInterface, cls())

--- a/autocontext/src/autocontext/scenarios/families.py
+++ b/autocontext/src/autocontext/scenarios/families.py
@@ -100,6 +100,7 @@ def _inheritance_depth(cls: type) -> int:
 
 def _register_builtins() -> None:
     from autocontext.scenarios.agent_task import AgentTaskInterface
+    from autocontext.scenarios.artifact_editing import ArtifactEditingInterface
     from autocontext.scenarios.base import ScenarioInterface
     from autocontext.scenarios.simulation import SimulationInterface
 
@@ -133,6 +134,16 @@ def _register_builtins() -> None:
         scenario_type_marker="simulation",
         capabilities=["fault_injection", "action_validation", "playbook", "tournament"],
         supports_playbook=True,
+    ))
+
+    register_family(ScenarioFamily(
+        name="artifact_editing",
+        description="Artifact-state-evaluated scenarios where agents modify files, configs, and schemas",
+        interface_class=ArtifactEditingInterface,
+        evaluation_mode="artifact_validation",
+        output_modes=["artifact_diff"],
+        scenario_type_marker="artifact_editing",
+        capabilities=["artifact_lineage", "diff_tracking", "validation_pipeline"],
     ))
 
 

--- a/autocontext/tests/test_agent_task_pipeline.py
+++ b/autocontext/tests/test_agent_task_pipeline.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from autocontext.scenarios.artifact_editing import ArtifactEditingInterface
 from autocontext.scenarios.custom.agent_task_codegen import generate_agent_task_class
 from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
 from autocontext.scenarios.custom.agent_task_designer import (
@@ -19,6 +20,10 @@ from autocontext.scenarios.custom.agent_task_validator import (
     validate_execution,
     validate_spec,
     validate_syntax,
+)
+from autocontext.scenarios.custom.artifact_editing_designer import (
+    ARTIFACT_SPEC_END,
+    ARTIFACT_SPEC_START,
 )
 from autocontext.scenarios.custom.simulation_designer import SIM_SPEC_END, SIM_SPEC_START
 from autocontext.scenarios.simulation import SimulationInterface
@@ -80,6 +85,26 @@ def _mock_simulation_response() -> str:
         ],
     }
     return f"{SIM_SPEC_START}\n{json.dumps(data, indent=2)}\n{SIM_SPEC_END}\n"
+
+
+def _mock_artifact_editing_response() -> str:
+    data = {
+        "task_description": "Update a YAML config to add a database section.",
+        "rubric": "Evaluate artifact correctness, validator success, and minimal unnecessary changes.",
+        "validation_rules": [
+            'config/app.yaml must contain "database:"',
+            'config/app.yaml must contain "host:"',
+            'config/app.yaml must contain "port:"',
+        ],
+        "artifacts": [
+            {
+                "path": "config/app.yaml",
+                "content": "app:\n  name: myapp\n  port: 8080\n",
+                "content_type": "yaml",
+            },
+        ],
+    }
+    return f"{ARTIFACT_SPEC_START}\n{json.dumps(data, indent=2)}\n{ARTIFACT_SPEC_END}\n"
 
 
 # --- Tests ---
@@ -421,6 +446,33 @@ class TestAgentTaskCreator:
             )
             with pytest.raises(ValueError, match="not yet supported for custom scaffolding"):
                 creator.create("Create a competitive two-player board game tournament")
+
+    def test_routes_artifact_editing_requests_to_artifact_creator(self) -> None:
+        response_text = _mock_artifact_editing_response()
+
+        def mock_llm(system: str, user: str) -> str:
+            return response_text
+
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        with tempfile.TemporaryDirectory() as tmp:
+            creator = AgentTaskCreator(
+                llm_fn=mock_llm,
+                knowledge_root=Path(tmp),
+            )
+            instance = creator.create("Edit a YAML config file to add a database section")
+            registered_name = creator.derive_name("Edit a YAML config file to add a database section")
+            try:
+                assert isinstance(instance, ArtifactEditingInterface)
+                artifacts = instance.initial_artifacts()
+                assert artifacts[0].path == "config/app.yaml"
+                assert "database section" in instance.describe_task().lower()
+                scenario_dir = Path(tmp) / "_custom_scenarios" / registered_name
+                assert (scenario_dir / "scenario.py").exists()
+                assert (scenario_dir / "spec.json").exists()
+                assert (scenario_dir / "scenario_type.txt").read_text() == "artifact_editing"
+            finally:
+                SCENARIO_REGISTRY.pop(registered_name, None)
 
     def test_end_to_end_with_reference_context(self) -> None:
         spec = AgentTaskSpec(

--- a/autocontext/tests/test_artifact_editing.py
+++ b/autocontext/tests/test_artifact_editing.py
@@ -1,0 +1,477 @@
+"""Tests for AC-248: Artifact-editing scenario family with artifact-based evaluation.
+
+Validates the ArtifactEditingInterface ABC, supporting data models
+(Artifact, ArtifactDiff, ArtifactValidationResult, ArtifactEditingResult),
+family/pipeline registration, and end-to-end artifact editing scenarios.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from autocontext.scenarios.artifact_editing import (
+    Artifact,
+    ArtifactDiff,
+    ArtifactEditingInterface,
+    ArtifactEditingResult,
+    ArtifactValidationResult,
+)
+
+# ---------------------------------------------------------------------------
+# Data model construction
+# ---------------------------------------------------------------------------
+
+
+class TestArtifact:
+    def test_construction(self) -> None:
+        artifact = Artifact(
+            path="config/app.yaml",
+            content="key: value",
+            content_type="yaml",
+        )
+        assert artifact.path == "config/app.yaml"
+        assert artifact.content == "key: value"
+        assert artifact.content_type == "yaml"
+        assert artifact.metadata == {}
+
+    def test_with_metadata(self) -> None:
+        artifact = Artifact(
+            path="schema.json",
+            content='{"type": "object"}',
+            content_type="json",
+            metadata={"version": "2.0", "schema_id": "users"},
+        )
+        assert artifact.metadata["version"] == "2.0"
+
+    def test_to_dict_from_dict(self) -> None:
+        artifact = Artifact(
+            path="main.py",
+            content="print('hello')",
+            content_type="python",
+            metadata={"lines": 1},
+        )
+        data = artifact.to_dict()
+        restored = Artifact.from_dict(data)
+        assert restored.path == artifact.path
+        assert restored.content == artifact.content
+        assert restored.content_type == artifact.content_type
+        assert restored.metadata == artifact.metadata
+
+
+class TestArtifactDiff:
+    def test_modify_operation(self) -> None:
+        diff = ArtifactDiff(
+            path="config.yaml",
+            operation="modify",
+            before="key: old",
+            after="key: new",
+        )
+        assert diff.operation == "modify"
+        assert diff.before == "key: old"
+        assert diff.after == "key: new"
+
+    def test_create_operation(self) -> None:
+        diff = ArtifactDiff(
+            path="new_file.txt",
+            operation="create",
+            before=None,
+            after="new content",
+        )
+        assert diff.before is None
+        assert diff.after == "new content"
+
+    def test_delete_operation(self) -> None:
+        diff = ArtifactDiff(
+            path="old_file.txt",
+            operation="delete",
+            before="old content",
+            after=None,
+        )
+        assert diff.before == "old content"
+        assert diff.after is None
+
+    def test_to_dict_from_dict(self) -> None:
+        diff = ArtifactDiff(path="f.txt", operation="modify", before="a", after="b")
+        data = diff.to_dict()
+        restored = ArtifactDiff.from_dict(data)
+        assert restored.path == diff.path
+        assert restored.operation == diff.operation
+        assert restored.before == diff.before
+        assert restored.after == diff.after
+
+
+class TestArtifactValidationResult:
+    def test_valid(self) -> None:
+        result = ArtifactValidationResult(valid=True, errors=[], warnings=[])
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_invalid(self) -> None:
+        result = ArtifactValidationResult(
+            valid=False,
+            errors=["missing required key 'name'"],
+            warnings=["deprecated field 'legacy_id'"],
+        )
+        assert result.valid is False
+        assert len(result.errors) == 1
+        assert len(result.warnings) == 1
+
+
+class TestArtifactEditingResult:
+    def test_construction(self) -> None:
+        result = ArtifactEditingResult(
+            score=0.85,
+            reasoning="Correctly modified config, minor precision issue",
+            dimension_scores={"correctness": 0.95, "precision": 0.75},
+            diffs=[ArtifactDiff(path="f.txt", operation="modify", before="a", after="b")],
+            validation=ArtifactValidationResult(valid=True, errors=[], warnings=[]),
+            artifacts_modified=1,
+            artifacts_valid=1,
+        )
+        assert result.score == 0.85
+        assert result.artifacts_modified == 1
+        assert len(result.diffs) == 1
+
+    def test_to_dict_from_dict(self) -> None:
+        result = ArtifactEditingResult(
+            score=0.7,
+            reasoning="Partial",
+            dimension_scores={"correctness": 0.6},
+            diffs=[
+                ArtifactDiff(path="a.txt", operation="modify", before="x", after="y"),
+                ArtifactDiff(path="b.txt", operation="create", before=None, after="new"),
+            ],
+            validation=ArtifactValidationResult(valid=False, errors=["bad"], warnings=[]),
+            artifacts_modified=2,
+            artifacts_valid=1,
+        )
+        data = result.to_dict()
+        restored = ArtifactEditingResult.from_dict(data)
+        assert restored.score == result.score
+        assert restored.reasoning == result.reasoning
+        assert len(restored.diffs) == 2
+        assert restored.validation.valid is False
+        assert restored.artifacts_modified == 2
+
+
+# ---------------------------------------------------------------------------
+# ArtifactEditingInterface ABC
+# ---------------------------------------------------------------------------
+
+
+class _MockArtifactEditor(ArtifactEditingInterface):
+    """Concrete test implementation for artifact editing."""
+
+    name = "mock_editor"
+
+    def describe_task(self) -> str:
+        return "Fix the YAML config by adding a missing 'database' section"
+
+    def get_rubric(self) -> str:
+        return "Evaluate: correctness of YAML structure, completeness of required fields, minimal changes"
+
+    def initial_artifacts(self, seed: int | None = None) -> list[Artifact]:
+        return [
+            Artifact(
+                path="config/app.yaml",
+                content="app:\n  name: myapp\n  port: 8080\n",
+                content_type="yaml",
+            ),
+        ]
+
+    def get_edit_prompt(self, artifacts: list[Artifact]) -> str:
+        paths = ", ".join(a.path for a in artifacts)
+        return f"Add a 'database' section with host, port, and name fields to: {paths}"
+
+    def validate_artifact(self, artifact: Artifact) -> ArtifactValidationResult:
+        errors: list[str] = []
+        warnings: list[str] = []
+        if artifact.content_type == "yaml":
+            if "database:" not in artifact.content:
+                errors.append("missing 'database' section")
+            if "host:" not in artifact.content:
+                errors.append("missing 'host' field in database section")
+        return ArtifactValidationResult(valid=len(errors) == 0, errors=errors, warnings=warnings)
+
+    def evaluate_edits(
+        self,
+        original: list[Artifact],
+        edited: list[Artifact],
+    ) -> ArtifactEditingResult:
+        diffs = self.compute_diffs(original, edited)
+
+        all_valid = True
+        total_errors: list[str] = []
+        for artifact in edited:
+            vr = self.validate_artifact(artifact)
+            if not vr.valid:
+                all_valid = False
+                total_errors.extend(vr.errors)
+
+        correctness = 1.0 if all_valid else max(0.0, 1.0 - len(total_errors) * 0.3)
+        precision = 1.0 if len(diffs) <= 1 else max(0.0, 1.0 - (len(diffs) - 1) * 0.1)
+        score = correctness * 0.7 + precision * 0.3
+
+        return ArtifactEditingResult(
+            score=score,
+            reasoning=f"{'All' if all_valid else 'Not all'} artifacts valid, {len(diffs)} changes made",
+            dimension_scores={"correctness": correctness, "precision": precision},
+            diffs=diffs,
+            validation=ArtifactValidationResult(valid=all_valid, errors=total_errors, warnings=[]),
+            artifacts_modified=len(diffs),
+            artifacts_valid=sum(1 for a in edited if self.validate_artifact(a).valid),
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        artifacts = self.initial_artifacts(seed)
+        return {"artifacts": [a.to_dict() for a in artifacts], "seed": seed or 0}
+
+
+class TestArtifactEditingInterfaceABC:
+    def test_cannot_instantiate_abc(self) -> None:
+        with pytest.raises(TypeError, match="abstract"):
+            ArtifactEditingInterface()  # type: ignore[abstract]
+
+    def test_concrete_subclass_instantiates(self) -> None:
+        editor = _MockArtifactEditor()
+        assert editor.name == "mock_editor"
+
+    def test_describe_task(self) -> None:
+        editor = _MockArtifactEditor()
+        assert "YAML" in editor.describe_task()
+
+    def test_get_rubric(self) -> None:
+        editor = _MockArtifactEditor()
+        rubric = editor.get_rubric()
+        assert "correctness" in rubric
+
+    def test_initial_artifacts(self) -> None:
+        editor = _MockArtifactEditor()
+        artifacts = editor.initial_artifacts()
+        assert len(artifacts) == 1
+        assert artifacts[0].path == "config/app.yaml"
+        assert artifacts[0].content_type == "yaml"
+
+    def test_get_edit_prompt(self) -> None:
+        editor = _MockArtifactEditor()
+        artifacts = editor.initial_artifacts()
+        prompt = editor.get_edit_prompt(artifacts)
+        assert "database" in prompt
+        assert "config/app.yaml" in prompt
+
+    def test_validate_artifact_invalid(self) -> None:
+        editor = _MockArtifactEditor()
+        artifact = Artifact(path="config.yaml", content="app:\n  name: test\n", content_type="yaml")
+        result = editor.validate_artifact(artifact)
+        assert result.valid is False
+        assert any("database" in e for e in result.errors)
+
+    def test_validate_artifact_valid(self) -> None:
+        editor = _MockArtifactEditor()
+        artifact = Artifact(
+            path="config.yaml",
+            content="app:\n  name: test\ndatabase:\n  host: localhost\n  port: 5432\n",
+            content_type="yaml",
+        )
+        result = editor.validate_artifact(artifact)
+        assert result.valid is True
+
+    def test_initial_state(self) -> None:
+        editor = _MockArtifactEditor()
+        state = editor.initial_state(seed=42)
+        assert "artifacts" in state
+        assert isinstance(state["artifacts"], list)
+
+
+# ---------------------------------------------------------------------------
+# Default compute_diffs
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDiffs:
+    def test_modification_detected(self) -> None:
+        editor = _MockArtifactEditor()
+        original = [Artifact(path="f.txt", content="old", content_type="text")]
+        edited = [Artifact(path="f.txt", content="new", content_type="text")]
+        diffs = editor.compute_diffs(original, edited)
+        assert len(diffs) == 1
+        assert diffs[0].operation == "modify"
+        assert diffs[0].before == "old"
+        assert diffs[0].after == "new"
+
+    def test_no_change_produces_no_diff(self) -> None:
+        editor = _MockArtifactEditor()
+        original = [Artifact(path="f.txt", content="same", content_type="text")]
+        edited = [Artifact(path="f.txt", content="same", content_type="text")]
+        diffs = editor.compute_diffs(original, edited)
+        assert diffs == []
+
+    def test_create_detected(self) -> None:
+        editor = _MockArtifactEditor()
+        original = [Artifact(path="a.txt", content="a", content_type="text")]
+        edited = [
+            Artifact(path="a.txt", content="a", content_type="text"),
+            Artifact(path="b.txt", content="b", content_type="text"),
+        ]
+        diffs = editor.compute_diffs(original, edited)
+        creates = [d for d in diffs if d.operation == "create"]
+        assert len(creates) == 1
+        assert creates[0].path == "b.txt"
+
+    def test_delete_detected(self) -> None:
+        editor = _MockArtifactEditor()
+        original = [
+            Artifact(path="a.txt", content="a", content_type="text"),
+            Artifact(path="b.txt", content="b", content_type="text"),
+        ]
+        edited = [Artifact(path="a.txt", content="a", content_type="text")]
+        diffs = editor.compute_diffs(original, edited)
+        deletes = [d for d in diffs if d.operation == "delete"]
+        assert len(deletes) == 1
+        assert deletes[0].path == "b.txt"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end evaluation
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndEvaluation:
+    def test_correct_edit(self) -> None:
+        editor = _MockArtifactEditor()
+        original = editor.initial_artifacts()
+        edited = [
+            Artifact(
+                path="config/app.yaml",
+                content="app:\n  name: myapp\n  port: 8080\ndatabase:\n  host: localhost\n  port: 5432\n  name: mydb\n",
+                content_type="yaml",
+            ),
+        ]
+        result = editor.evaluate_edits(original, edited)
+        assert result.score > 0.8
+        assert result.validation.valid is True
+        assert result.artifacts_valid == 1
+        assert result.dimension_scores["correctness"] == 1.0
+
+    def test_wrong_edit(self) -> None:
+        """Edit that doesn't add the required database section."""
+        editor = _MockArtifactEditor()
+        original = editor.initial_artifacts()
+        edited = [
+            Artifact(
+                path="config/app.yaml",
+                content="app:\n  name: myapp\n  port: 9090\n",
+                content_type="yaml",
+            ),
+        ]
+        result = editor.evaluate_edits(original, edited)
+        assert result.validation.valid is False
+        assert result.score < 0.8
+        assert result.dimension_scores["correctness"] < 1.0
+
+    def test_invalid_artifact_state(self) -> None:
+        """Edit produces structurally invalid artifact."""
+        editor = _MockArtifactEditor()
+        original = editor.initial_artifacts()
+        edited = [
+            Artifact(
+                path="config/app.yaml",
+                content="",  # Empty config
+                content_type="yaml",
+            ),
+        ]
+        result = editor.evaluate_edits(original, edited)
+        assert result.validation.valid is False
+        assert result.artifacts_valid == 0
+
+
+# ---------------------------------------------------------------------------
+# Family registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestFamilyRegistration:
+    def test_artifact_editing_family_registered(self) -> None:
+        from autocontext.scenarios.families import get_family
+
+        family = get_family("artifact_editing")
+        assert family.name == "artifact_editing"
+        assert family.evaluation_mode == "artifact_validation"
+
+    def test_artifact_editing_scenario_type_marker(self) -> None:
+        from autocontext.scenarios.families import get_family
+
+        family = get_family("artifact_editing")
+        assert family.scenario_type_marker == "artifact_editing"
+
+    def test_detect_family_for_instance(self) -> None:
+        from autocontext.scenarios.families import detect_family
+
+        editor = _MockArtifactEditor()
+        family = detect_family(editor)
+        assert family is not None
+        assert family.name == "artifact_editing"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineRegistration:
+    def test_pipeline_registered(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import has_pipeline
+
+        assert has_pipeline("artifact_editing") is True
+
+    def test_pipeline_spec_validation_valid(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        spec: dict[str, Any] = {
+            "task_description": "Fix the config file",
+            "artifacts": [
+                {"path": "config.yaml", "content": "key: val", "content_type": "yaml"},
+            ],
+            "validation_rules": ["must contain 'database' section"],
+            "rubric": "Evaluate correctness and precision",
+        }
+        errors = validate_for_family("artifact_editing", spec)
+        assert errors == []
+
+    def test_pipeline_spec_validation_missing_fields(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        spec: dict[str, Any] = {"task_description": "Fix something"}
+        errors = validate_for_family("artifact_editing", spec)
+        assert len(errors) > 0
+        assert any("artifacts" in e for e in errors)
+
+    def test_pipeline_source_validation(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+
+        source = '''
+from autocontext.scenarios.artifact_editing import ArtifactEditingInterface
+
+class MyEditor(ArtifactEditingInterface):
+    name = "my_editor"
+    def describe_task(self): return "task"
+    def get_rubric(self): return "rubric"
+    def initial_artifacts(self, seed=None): return []
+    def get_edit_prompt(self, artifacts): return "edit"
+    def validate_artifact(self, artifact): pass
+    def evaluate_edits(self, original, edited): pass
+'''
+        errors = validate_source_for_family("artifact_editing", source)
+        assert errors == []
+
+    def test_pipeline_source_wrong_base_class(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+
+        source = '''
+class NotAnEditor:
+    pass
+'''
+        errors = validate_source_for_family("artifact_editing", source)
+        assert any("ArtifactEditingInterface" in e for e in errors)

--- a/autocontext/tests/test_family_classifier.py
+++ b/autocontext/tests/test_family_classifier.py
@@ -120,6 +120,20 @@ class TestClassifySimulation:
         assert result.family_name == "simulation"
 
 
+class TestClassifyArtifactEditing:
+    def test_config_editing(self) -> None:
+        result = classify_scenario_family(
+            "Create a task where the agent must edit a YAML config file to add a missing database section"
+        )
+        assert result.family_name == "artifact_editing"
+
+    def test_schema_migration(self) -> None:
+        result = classify_scenario_family(
+            "Build an artifact editing scenario that updates a JSON schema and repairs a broken SQL migration"
+        )
+        assert result.family_name == "artifact_editing"
+
+
 # ---------------------------------------------------------------------------
 # classify_scenario_family — agent_task signals
 # ---------------------------------------------------------------------------

--- a/ts/src/scenarios/agent-task-creator.ts
+++ b/ts/src/scenarios/agent-task-creator.ts
@@ -13,6 +13,10 @@ import type { AgentTaskSpec } from "./agent-task-spec.js";
 import { designAgentTask } from "./agent-task-designer.js";
 import { validateIntent } from "./agent-task-validator.js";
 import { createAgentTask } from "./agent-task-factory.js";
+import {
+  type ArtifactEditingScenarioHandle,
+  ArtifactEditingCreator,
+} from "./artifact-editing-creator.js";
 import { classifyScenarioFamily, routeToFamily } from "./family-classifier.js";
 import { validateForFamily } from "./family-pipeline.js";
 import { getScenarioTypeMarker } from "./families.js";
@@ -29,6 +33,7 @@ export interface AgentTaskCreatorOpts {
 
 export type CreatedScenario =
   | (AgentTaskInterface & { readonly name: string; readonly spec: AgentTaskSpec; readonly family?: "agent_task" })
+  | ArtifactEditingScenarioHandle
   | SimulationScenarioHandle;
 
 export class AgentTaskCreator {
@@ -86,6 +91,13 @@ export class AgentTaskCreator {
     const family = routeToFamily(classifyScenarioFamily(description));
     if (family === "simulation") {
       return new SimulationCreator({
+        provider: this.provider,
+        model: this.model,
+        knowledgeRoot: this.knowledgeRoot,
+      }).create(description, name);
+    }
+    if (family === "artifact_editing") {
+      return new ArtifactEditingCreator({
         provider: this.provider,
         model: this.model,
         knowledgeRoot: this.knowledgeRoot,

--- a/ts/src/scenarios/artifact-editing-creator.ts
+++ b/ts/src/scenarios/artifact-editing-creator.ts
@@ -1,0 +1,180 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { LLMProvider } from "../types/index.js";
+import type { ArtifactEditingSpec } from "./artifact-editing-spec.js";
+import { designArtifactEditing } from "./artifact-editing-designer.js";
+import { validateForFamily } from "./family-pipeline.js";
+import { getScenarioTypeMarker } from "./families.js";
+
+export interface ArtifactEditingCreatorOpts {
+  provider: LLMProvider;
+  model?: string;
+  knowledgeRoot: string;
+}
+
+export interface ArtifactEditingScenarioHandle {
+  family: "artifact_editing";
+  name: string;
+  spec: ArtifactEditingSpec;
+}
+
+function className(name: string): string {
+  return name
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join("") + "ArtifactEditing";
+}
+
+function generateScenarioSource(spec: ArtifactEditingSpec, name: string): string {
+  const artifacts = spec.artifacts
+    .map((artifact) => `            Artifact(path=${JSON.stringify(artifact.path)}, content=${JSON.stringify(artifact.content)}, content_type=${JSON.stringify(artifact.contentType)}, metadata=${JSON.stringify(artifact.metadata)})`)
+    .join(",\n");
+  return `from __future__ import annotations
+
+import json
+import re
+
+from autocontext.scenarios.artifact_editing import Artifact, ArtifactEditingInterface, ArtifactEditingResult, ArtifactValidationResult
+
+
+class ${className(name)}(ArtifactEditingInterface):
+    name = ${JSON.stringify(name)}
+    _validation_rules = ${JSON.stringify(spec.validationRules)}
+
+    def describe_task(self) -> str:
+        return ${JSON.stringify(spec.taskDescription)}
+
+    def get_rubric(self) -> str:
+        return ${JSON.stringify(spec.rubric)}
+
+    def initial_artifacts(self, seed: int | None = None) -> list[Artifact]:
+        return [
+${artifacts}
+        ]
+
+    def get_edit_prompt(self, artifacts: list[Artifact]) -> str:
+        rendered = json.dumps([artifact.to_dict() for artifact in artifacts], indent=2)
+        rules = "\\n".join(f"- {rule}" for rule in self._validation_rules)
+        return (
+            f"{self.describe_task()}\\n\\n"
+            f"Artifacts:\\n{rendered}\\n\\n"
+            f"Validation rules:\\n{rules}\\n\\n"
+            'Return JSON with shape {"artifacts": [{"path": "...", "content": "...", "content_type": "..."}]} containing the full edited artifact set.'
+        )
+
+    def _rules_for_path(self, path: str) -> list[str]:
+        relevant: list[str] = []
+        for rule in self._validation_rules:
+            if " must " in rule:
+                prefix, _ = rule.split(" must ", 1)
+                if "/" in prefix and prefix.strip() != path:
+                    continue
+            relevant.append(rule)
+        return relevant
+
+    def _extract_snippets(self, rule: str) -> list[str]:
+        return [match[0] or match[1] for match in re.findall(r'"([^"]+)"|\\'([^\\']+)\\'', rule)]
+
+    def validate_artifact(self, artifact: Artifact) -> ArtifactValidationResult:
+        errors: list[str] = []
+        warnings: list[str] = []
+        if not artifact.content.strip():
+            errors.append(f"{artifact.path} must not be empty")
+        for rule in self._rules_for_path(artifact.path):
+            snippets = self._extract_snippets(rule)
+            if not snippets:
+                continue
+            if "must not contain" in rule:
+                for snippet in snippets:
+                    if snippet in artifact.content:
+                        errors.append(f"{artifact.path} violates rule: {rule}")
+            else:
+                for snippet in snippets:
+                    if snippet not in artifact.content:
+                        errors.append(f"{artifact.path} violates rule: {rule}")
+        return ArtifactValidationResult(valid=not errors, errors=errors, warnings=warnings)
+
+    def evaluate_edits(self, original: list[Artifact], edited: list[Artifact]) -> ArtifactEditingResult:
+        diffs = self.compute_diffs(original, edited)
+        validations = [self.validate_artifact(artifact) for artifact in edited]
+        valid_count = sum(1 for result in validations if result.valid)
+        error_count = sum(len(result.errors) for result in validations)
+        correctness = valid_count / max(len(edited), 1)
+        change_score = 1.0 if diffs else 0.0
+        baseline = max(len(original), 1)
+        precision = 1.0 if len(diffs) <= baseline else max(0.2, 1.0 - ((len(diffs) - baseline) / baseline) * 0.2)
+        score = round((correctness * 0.7) + (change_score * 0.15) + (precision * 0.15), 4)
+        return ArtifactEditingResult(
+            score=score,
+            reasoning=f"Validated {valid_count} of {len(edited)} artifacts with {len(diffs)} tracked edits.",
+            dimension_scores={"correctness": round(correctness, 4), "change_completeness": round(change_score, 4), "precision": round(precision, 4)},
+            diffs=diffs,
+            validation=ArtifactValidationResult(
+                valid=error_count == 0,
+                errors=[error for result in validations for error in result.errors],
+                warnings=[warning for result in validations for warning in result.warnings],
+            ),
+            artifacts_modified=len(diffs),
+            artifacts_valid=valid_count,
+        )
+`;
+}
+
+export class ArtifactEditingCreator {
+  private provider: LLMProvider;
+  private model: string;
+  private knowledgeRoot: string;
+
+  constructor(opts: ArtifactEditingCreatorOpts) {
+    this.provider = opts.provider;
+    this.model = opts.model ?? opts.provider.defaultModel();
+    this.knowledgeRoot = opts.knowledgeRoot;
+  }
+
+  async create(description: string, name: string): Promise<ArtifactEditingScenarioHandle> {
+    const llmFn = async (system: string, user: string): Promise<string> => {
+      const result = await this.provider.complete({
+        systemPrompt: system,
+        userPrompt: user,
+        model: this.model,
+      });
+      return result.text;
+    };
+    const spec = await designArtifactEditing(description, llmFn);
+    const errors = validateForFamily("artifact_editing", spec);
+    if (errors.length > 0) {
+      throw new Error(`artifact-editing spec validation failed: ${errors.join("; ")}`);
+    }
+
+    const customDir = join(this.knowledgeRoot, "_custom_scenarios");
+    const scenarioDir = join(customDir, name);
+    if (!existsSync(scenarioDir)) mkdirSync(scenarioDir, { recursive: true });
+
+    writeFileSync(join(scenarioDir, "scenario.py"), generateScenarioSource(spec, name), "utf-8");
+    writeFileSync(join(scenarioDir, "scenario_type.txt"), getScenarioTypeMarker("artifact_editing"), "utf-8");
+    writeFileSync(
+      join(scenarioDir, "spec.json"),
+      JSON.stringify(
+        {
+          name,
+          scenario_type: getScenarioTypeMarker("artifact_editing"),
+          task_description: spec.taskDescription,
+          rubric: spec.rubric,
+          validation_rules: spec.validationRules,
+          artifacts: spec.artifacts.map((artifact) => ({
+            path: artifact.path,
+            content: artifact.content,
+            content_type: artifact.contentType,
+            metadata: artifact.metadata,
+          })),
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    return { family: "artifact_editing", name, spec };
+  }
+}

--- a/ts/src/scenarios/artifact-editing-designer.ts
+++ b/ts/src/scenarios/artifact-editing-designer.ts
@@ -1,0 +1,76 @@
+import type { ArtifactEditingSpec } from "./artifact-editing-spec.js";
+import { parseRawArtifactEditingSpec } from "./artifact-editing-spec.js";
+
+export const ARTIFACT_SPEC_START = "<!-- ARTIFACT_EDITING_SPEC_START -->";
+export const ARTIFACT_SPEC_END = "<!-- ARTIFACT_EDITING_SPEC_END -->";
+
+const EXAMPLE_SPEC = {
+  task_description: "Update a YAML service config to add a database section without changing unrelated settings.",
+  rubric:
+    "Evaluate correctness of the edited artifacts, satisfaction of validation rules, and minimal unnecessary changes.",
+  validation_rules: [
+    'config/app.yaml must contain "database:"',
+    'config/app.yaml must contain "host:"',
+    'config/app.yaml must contain "port:"',
+  ],
+  artifacts: [
+    {
+      path: "config/app.yaml",
+      content: "app:\n  name: myapp\n  port: 8080\n",
+      content_type: "yaml",
+    },
+  ],
+};
+
+export const ARTIFACT_EDITING_DESIGNER_SYSTEM = `You are a scenario designer for autocontext.
+Given a natural-language request for an artifact-editing task, produce an ArtifactEditingSpec JSON.
+
+Wrap the output in delimiters:
+${ARTIFACT_SPEC_START}
+{ ... }
+${ARTIFACT_SPEC_END}
+
+Schema:
+{
+  "task_description": "what the agent should change in the artifacts",
+  "rubric": "how the final edited artifacts should be judged",
+  "validation_rules": ["path/to/file must contain \\"snippet\\""],
+  "artifacts": [
+    {
+      "path": "config/app.yaml",
+      "content": "current file contents",
+      "content_type": "yaml"
+    }
+  ]
+}
+
+Rules:
+- model the task around editing concrete artifacts, not writing prose about them
+- include at least one artifact with realistic initial content
+- express validation rules as path-scoped must-contain or must-not-contain checks when possible
+- keep the rubric focused on artifact correctness, validator success, and precision of edits
+
+Example:
+${ARTIFACT_SPEC_START}
+${JSON.stringify(EXAMPLE_SPEC, null, 2)}
+${ARTIFACT_SPEC_END}
+`;
+
+export function parseArtifactEditingSpec(text: string): ArtifactEditingSpec {
+  const startIdx = text.indexOf(ARTIFACT_SPEC_START);
+  const endIdx = text.indexOf(ARTIFACT_SPEC_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
+    throw new Error("response does not contain ARTIFACT_EDITING_SPEC delimiters");
+  }
+  const raw = text.slice(startIdx + ARTIFACT_SPEC_START.length, endIdx).trim();
+  return parseRawArtifactEditingSpec(JSON.parse(raw) as Record<string, unknown>);
+}
+
+export async function designArtifactEditing(
+  description: string,
+  llmFn: (system: string, user: string) => Promise<string>,
+): Promise<ArtifactEditingSpec> {
+  return parseArtifactEditingSpec(
+    await llmFn(ARTIFACT_EDITING_DESIGNER_SYSTEM, `User description:\n${description}`),
+  );
+}

--- a/ts/src/scenarios/artifact-editing-spec.ts
+++ b/ts/src/scenarios/artifact-editing-spec.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+export const ArtifactSpecSchema = z.object({
+  path: z.string().min(1),
+  content: z.string(),
+  contentType: z.string().min(1),
+  metadata: z.record(z.unknown()).default({}),
+});
+
+export const ArtifactEditingSpecSchema = z.object({
+  taskDescription: z.string().min(1),
+  rubric: z.string().min(1),
+  validationRules: z.array(z.string().min(1)).min(1),
+  artifacts: z.array(ArtifactSpecSchema).min(1),
+});
+
+export type ArtifactSpec = z.infer<typeof ArtifactSpecSchema>;
+export type ArtifactEditingSpec = z.infer<typeof ArtifactEditingSpecSchema>;
+
+export function parseRawArtifactEditingSpec(data: Record<string, unknown>): ArtifactEditingSpec {
+  return ArtifactEditingSpecSchema.parse({
+    taskDescription: data.task_description,
+    rubric: data.rubric,
+    validationRules: data.validation_rules,
+    artifacts: Array.isArray(data.artifacts)
+      ? data.artifacts.map((artifact) => {
+          const raw = artifact as Record<string, unknown>;
+          return {
+            path: raw.path,
+            content: raw.content,
+            contentType: raw.content_type,
+            metadata: raw.metadata ?? {},
+          };
+        })
+      : data.artifacts,
+  });
+}

--- a/ts/src/scenarios/families.ts
+++ b/ts/src/scenarios/families.ts
@@ -1,9 +1,10 @@
-export type ScenarioFamilyName = "game" | "agent_task" | "simulation";
+export type ScenarioFamilyName = "game" | "agent_task" | "simulation" | "artifact_editing";
 
 export const SCENARIO_TYPE_MARKERS: Record<ScenarioFamilyName, string> = {
   game: "parametric",
   agent_task: "agent_task",
   simulation: "simulation",
+  artifact_editing: "artifact_editing",
 };
 
 export function getScenarioTypeMarker(family: ScenarioFamilyName): string {

--- a/ts/src/scenarios/family-classifier.ts
+++ b/ts/src/scenarios/family-classifier.ts
@@ -117,10 +117,38 @@ const GAME_SIGNALS: Record<string, number> = {
   player: 1.0,
 };
 
+const ARTIFACT_EDITING_SIGNALS: Record<string, number> = {
+  "edit file": 2.0,
+  "modify file": 2.0,
+  "update config": 2.0,
+  configuration: 1.5,
+  "config file": 1.5,
+  yaml: 1.5,
+  json: 1.0,
+  schema: 1.5,
+  migration: 1.5,
+  manifest: 1.5,
+  patch: 1.0,
+  "refactor config": 2.0,
+  "fix config": 2.0,
+  artifact: 1.5,
+  "file edit": 2.0,
+  rewrite: 1.0,
+  "update policy": 1.5,
+  "change file": 1.5,
+  "modify yaml": 2.0,
+  "modify json": 2.0,
+  "config repair": 2.0,
+  "repair schema": 2.0,
+  "sql migration": 2.0,
+  dockerfile: 1.5,
+};
+
 const FAMILY_SIGNAL_GROUPS: Record<ScenarioFamilyName, Record<string, number>> = {
   game: GAME_SIGNALS,
   agent_task: AGENT_TASK_SIGNALS,
   simulation: SIMULATION_SIGNALS,
+  artifact_editing: ARTIFACT_EDITING_SIGNALS,
 };
 
 const DEFAULT_FAMILY_NAME: ScenarioFamilyName = "agent_task";

--- a/ts/src/scenarios/family-pipeline.ts
+++ b/ts/src/scenarios/family-pipeline.ts
@@ -1,4 +1,5 @@
 import type { AgentTaskSpec } from "./agent-task-spec.js";
+import { ArtifactEditingSpecSchema, type ArtifactEditingSpec } from "./artifact-editing-spec.js";
 import { validateSpec as validateAgentTaskSpec } from "./agent-task-validator.js";
 import { type ScenarioFamilyName } from "./families.js";
 import { SimulationSpecSchema, type SimulationSpec } from "./simulation-spec.js";
@@ -41,9 +42,23 @@ const simulationPipeline: FamilyPipeline<SimulationSpec> = {
   },
 };
 
+const artifactEditingPipeline: FamilyPipeline<ArtifactEditingSpec> = {
+  familyName: "artifact_editing",
+  validateSpec(spec: ArtifactEditingSpec): string[] {
+    const result = ArtifactEditingSpecSchema.safeParse(spec);
+    if (!result.success) {
+      return result.error.issues.map(
+        (issue) => `${issue.path.join(".")}: ${issue.message}`,
+      );
+    }
+    return [];
+  },
+};
+
 const PIPELINE_REGISTRY = {
   agent_task: agentTaskPipeline,
   simulation: simulationPipeline,
+  artifact_editing: artifactEditingPipeline,
 } as const;
 
 export function hasPipeline(family: string): family is keyof typeof PIPELINE_REGISTRY {
@@ -59,7 +74,7 @@ export function getPipeline(family: string): (typeof PIPELINE_REGISTRY)[keyof ty
 
 export function validateForFamily(
   family: string,
-  spec: AgentTaskSpec | SimulationSpec,
+  spec: AgentTaskSpec | SimulationSpec | ArtifactEditingSpec,
 ): string[] {
   const pipeline = getPipeline(family);
   return pipeline.validateSpec(spec as never);

--- a/ts/src/scenarios/index.ts
+++ b/ts/src/scenarios/index.ts
@@ -1,5 +1,16 @@
 export type { AgentTaskSpec } from "./agent-task-spec.js";
 export { AgentTaskSpecSchema, parseRawSpec } from "./agent-task-spec.js";
+export type { ArtifactEditingSpec, ArtifactSpec } from "./artifact-editing-spec.js";
+export { ArtifactEditingSpecSchema, ArtifactSpecSchema, parseRawArtifactEditingSpec } from "./artifact-editing-spec.js";
+export {
+  ARTIFACT_SPEC_START,
+  ARTIFACT_SPEC_END,
+  ARTIFACT_EDITING_DESIGNER_SYSTEM,
+  parseArtifactEditingSpec,
+  designArtifactEditing,
+} from "./artifact-editing-designer.js";
+export { ArtifactEditingCreator } from "./artifact-editing-creator.js";
+export type { ArtifactEditingCreatorOpts, ArtifactEditingScenarioHandle } from "./artifact-editing-creator.js";
 export { parseAgentTaskSpec, designAgentTask, SPEC_START, SPEC_END, AGENT_TASK_DESIGNER_SYSTEM } from "./agent-task-designer.js";
 export { validateSpec } from "./agent-task-validator.js";
 export { createAgentTask } from "./agent-task-factory.js";

--- a/ts/tests/agent-task-pipeline.test.ts
+++ b/ts/tests/agent-task-pipeline.test.ts
@@ -12,6 +12,10 @@ import {
   SPEC_END,
 } from "../src/scenarios/agent-task-designer.js";
 import {
+  ARTIFACT_SPEC_END,
+  ARTIFACT_SPEC_START,
+} from "../src/scenarios/artifact-editing-designer.js";
+import {
   SIM_SPEC_END,
   SIM_SPEC_START,
 } from "../src/scenarios/simulation-designer.js";
@@ -74,6 +78,26 @@ function mockSimulationResponse(): string {
     ],
   };
   return `${SIM_SPEC_START}\n${JSON.stringify(data, null, 2)}\n${SIM_SPEC_END}\n`;
+}
+
+function mockArtifactEditingResponse(): string {
+  const data = {
+    task_description: "Update a YAML config to add a database section.",
+    rubric: "Evaluate artifact correctness, validator success, and minimal unnecessary changes.",
+    validation_rules: [
+      'config/app.yaml must contain "database:"',
+      'config/app.yaml must contain "host:"',
+      'config/app.yaml must contain "port:"',
+    ],
+    artifacts: [
+      {
+        path: "config/app.yaml",
+        content: "app:\n  name: myapp\n  port: 8080\n",
+        content_type: "yaml",
+      },
+    ],
+  };
+  return `${ARTIFACT_SPEC_START}\n${JSON.stringify(data, null, 2)}\n${ARTIFACT_SPEC_END}\n`;
 }
 
 function makeMockProvider(response = "mock output"): LLMProvider {
@@ -218,6 +242,26 @@ describe("FamilyPipeline", () => {
       ],
     };
     expect(validateForFamily("simulation", spec)).toEqual([]);
+  });
+
+  it("validates artifact-editing specs through the family pipeline", () => {
+    const spec = {
+      taskDescription: "Update a YAML config to add a database section.",
+      rubric: "Evaluate artifact correctness, validator success, and minimal unnecessary changes.",
+      validationRules: [
+        'config/app.yaml must contain "database:"',
+        'config/app.yaml must contain "host:"',
+      ],
+      artifacts: [
+        {
+          path: "config/app.yaml",
+          content: "app:\n  name: myapp\n  port: 8080\n",
+          contentType: "yaml",
+          metadata: {},
+        },
+      ],
+    };
+    expect(validateForFamily("artifact_editing", spec)).toEqual([]);
   });
 
   it("rejects unsupported families instead of collapsing silently", () => {
@@ -423,6 +467,21 @@ describe("AgentTaskCreator", () => {
     expect(readFileSync(join(scenarioDir, "scenario_type.txt"), "utf-8")).toBe(getScenarioTypeMarker("simulation"));
   });
 
+  it("routes artifact-editing descriptions into an artifact-editing scaffold", async () => {
+    const provider = makeMockProvider(mockArtifactEditingResponse());
+    const tmpDir = mkdtempSync(join(tmpdir(), "autocontext-creator-artifact-"));
+    const creator = new AgentTaskCreator({ provider, knowledgeRoot: tmpDir });
+
+    const scenario = await creator.create("Edit a YAML config file to add a database section");
+    expect("family" in scenario && scenario.family).toBe("artifact_editing");
+
+    const name = creator.deriveName("Edit a YAML config file to add a database section");
+    const scenarioDir = join(tmpDir, "_custom_scenarios", name);
+    expect(existsSync(join(scenarioDir, "scenario.py"))).toBe(true);
+    expect(existsSync(join(scenarioDir, "spec.json"))).toBe(true);
+    expect(readFileSync(join(scenarioDir, "scenario_type.txt"), "utf-8")).toBe(getScenarioTypeMarker("artifact_editing"));
+  });
+
   it("rejects classified-but-unsupported game families", async () => {
     const provider = makeMockProvider(mockLlmResponse(SAMPLE_SPEC));
     const tmpDir = mkdtempSync(join(tmpdir(), "autocontext-creator-game-"));
@@ -432,6 +491,12 @@ describe("AgentTaskCreator", () => {
     await expect(
       creator.create("Create a competitive two-player board game"),
     ).rejects.toThrow("not yet supported for custom scaffolding");
+  });
+
+  it("classifies artifact-editing descriptions into the artifact_editing family", () => {
+    expect(
+      classifyScenarioFamily("Edit a YAML config file to add a database section").familyName,
+    ).toBe("artifact_editing");
   });
 });
 


### PR DESCRIPTION
## Summary
- Introduces `ArtifactEditingInterface` ABC as the fourth scenario family (alongside game, agent_task, simulation)
- Agents modify real artifacts (files, configs, schemas, structured outputs) and are evaluated on resulting artifact state and validation pipeline outcomes
- Data models: `Artifact`, `ArtifactDiff` (create/modify/delete), `ArtifactValidationResult`, `ArtifactEditingResult` with full serialization
- Default `compute_diffs()` detects create, modify, and delete operations by path comparison
- Registered as `"artifact_editing"` in `FAMILY_REGISTRY` (evaluation_mode: `artifact_validation`)
- `ArtifactEditingPipeline` registered in `PIPELINE_REGISTRY` with spec validation for `task_description`, `artifacts`, `validation_rules`, `rubric`

## Test plan
- [x] 35 tests in `test_artifact_editing.py` covering:
  - Data model construction and serialization roundtrips (Artifact, ArtifactDiff, ArtifactValidationResult, ArtifactEditingResult)
  - ABC enforcement + concrete mock implementation
  - Default `compute_diffs()`: modify, create, delete, no-change detection
  - End-to-end evaluation: correct edit, wrong edit, invalid artifact state
  - Family registry: registered, correct marker, `detect_family()` works
  - Pipeline registry: registered, spec validation (valid + missing fields), source validation (valid + wrong base class)
- [x] Ruff clean
- [x] Mypy clean
- [x] Full suite: 3537 passed, 46 skipped