### PR TITLE
feat(AC-252, AC-254): schema-evolution and tool-fragility scenario families

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -29,10 +29,14 @@ from autocontext.scenarios.custom.family_pipeline import (
 )
 from autocontext.scenarios.custom.investigation_creator import InvestigationCreator
 from autocontext.scenarios.custom.registry import CUSTOM_SCENARIOS_DIR
+from autocontext.scenarios.custom.schema_evolution_creator import SchemaEvolutionCreator
 from autocontext.scenarios.custom.simulation_creator import SimulationCreator
+from autocontext.scenarios.custom.tool_fragility_creator import ToolFragilityCreator
 from autocontext.scenarios.custom.workflow_creator import WorkflowCreator
 from autocontext.scenarios.families import get_family_marker
 from autocontext.scenarios.investigation import InvestigationInterface
+from autocontext.scenarios.schema_evolution import SchemaEvolutionInterface
+from autocontext.scenarios.tool_fragility import ToolFragilityInterface
 from autocontext.scenarios.workflow import WorkflowInterface
 
 logger = logging.getLogger(__name__)
@@ -77,7 +81,11 @@ class AgentTaskCreator:
     def create(
         self,
         description: str,
-    ) -> AgentTaskInterface | ScenarioInterface | ArtifactEditingInterface | InvestigationInterface | WorkflowInterface:
+    ) -> (
+        AgentTaskInterface | ScenarioInterface | ArtifactEditingInterface
+        | InvestigationInterface | WorkflowInterface
+        | SchemaEvolutionInterface | ToolFragilityInterface
+    ):
         """Run the full pipeline: design → validate → codegen → validate → load → register.
 
         Returns:
@@ -98,6 +106,12 @@ class AgentTaskCreator:
         if family.name == "workflow":
             logger.info("routing description to workflow creator")
             return WorkflowCreator(self.llm_fn, self.knowledge_root).create(description, name=name)
+        if family.name == "schema_evolution":
+            logger.info("routing description to schema-evolution creator")
+            return SchemaEvolutionCreator(self.llm_fn, self.knowledge_root).create(description, name=name)
+        if family.name == "tool_fragility":
+            logger.info("routing description to tool-fragility creator")
+            return ToolFragilityCreator(self.llm_fn, self.knowledge_root).create(description, name=name)
         if family.name != "agent_task":
             raise ValueError(
                 f"Scenario family '{family.name}' is not yet supported for custom scaffolding"

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -239,6 +239,40 @@ _WORKFLOW_SIGNALS: dict[str, float] = {
     "multi-step transaction": 2.0,
 }
 
+_SCHEMA_EVOLUTION_SIGNALS: dict[str, float] = {
+    "schema evolv": 2.0,
+    "schema evolution": 2.0,
+    "stale context": 2.0,
+    "schema migration": 2.0,
+    "breaking change": 2.0,
+    "schema version": 2.0,
+    "field removed": 1.5,
+    "field added": 1.5,
+    "field renamed": 1.5,
+    "context invalidat": 2.0,
+    "stale assumption": 2.0,
+    "data model change": 1.5,
+    "schema drift": 1.5,
+    "backwards compat": 1.5,
+}
+
+_TOOL_FRAGILITY_SIGNALS: dict[str, float] = {
+    "tool drift": 2.0,
+    "api contract": 2.0,
+    "tool fragility": 2.0,
+    "environment drift": 2.0,
+    "broken tool": 2.0,
+    "tool version": 1.5,
+    "api change": 1.5,
+    "response format change": 2.0,
+    "tool adapt": 1.5,
+    "tool break": 1.5,
+    "contract drift": 2.0,
+    "endpoint deprecat": 1.5,
+    "api deprecat": 1.5,
+    "tool failure": 1.5,
+}
+
 _FAMILY_SIGNAL_GROUPS: dict[str, dict[str, float]] = {
     "simulation": _SIMULATION_SIGNALS,
     "agent_task": _AGENT_TASK_SIGNALS,
@@ -246,6 +280,8 @@ _FAMILY_SIGNAL_GROUPS: dict[str, dict[str, float]] = {
     "artifact_editing": _ARTIFACT_EDITING_SIGNALS,
     "investigation": _INVESTIGATION_SIGNALS,
     "workflow": _WORKFLOW_SIGNALS,
+    "schema_evolution": _SCHEMA_EVOLUTION_SIGNALS,
+    "tool_fragility": _TOOL_FRAGILITY_SIGNALS,
 }
 
 _DEFAULT_FAMILY_NAME = "agent_task"

--- a/autocontext/src/autocontext/scenarios/custom/family_pipeline.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_pipeline.py
@@ -525,6 +525,152 @@ class WorkflowPipeline(FamilyPipeline):
         )
 
 
+class SchemaEvolutionPipeline(FamilyPipeline):
+    """Pipeline for schema_evolution family scenarios."""
+
+    @property
+    def family_name(self) -> str:
+        return "schema_evolution"
+
+    def required_spec_fields(self) -> set[str]:
+        return {
+            "description",
+            "environment_description",
+            "initial_state_description",
+            "mutations",
+            "success_criteria",
+            "actions",
+        }
+
+    def validate_spec(self, spec: dict[str, Any]) -> list[str]:
+        errors = _check_required_fields(spec, self.required_spec_fields())
+
+        mutations = spec.get("mutations")
+        if isinstance(mutations, list):
+            if len(mutations) == 0:
+                errors.append("mutations must not be empty")
+            else:
+                for i, mutation in enumerate(mutations):
+                    if not isinstance(mutation, dict):
+                        errors.append(f"mutations[{i}] must be a dict")
+                    elif "version" not in mutation:
+                        errors.append(f"mutations[{i}] missing 'version'")
+
+        actions = spec.get("actions")
+        if isinstance(actions, list):
+            if len(actions) == 0:
+                errors.append("actions must not be empty")
+            else:
+                for i, action in enumerate(actions):
+                    if not isinstance(action, dict):
+                        errors.append(f"actions[{i}] must be a dict")
+                    elif "name" not in action:
+                        errors.append(f"actions[{i}] missing 'name'")
+
+        criteria = spec.get("success_criteria")
+        if isinstance(criteria, list) and len(criteria) == 0:
+            errors.append("success_criteria must not be empty")
+
+        return errors
+
+    def validate_source(self, source: str) -> list[str]:
+        return _check_source_for_class(source, "SchemaEvolutionInterface")
+
+    def validate_contract(self, source: str) -> list[str]:
+        return _check_required_methods(
+            source,
+            "SchemaEvolutionInterface",
+            {
+                "describe_scenario",
+                "describe_environment",
+                "initial_state",
+                "get_available_actions",
+                "execute_action",
+                "is_terminal",
+                "evaluate_trace",
+                "get_rubric",
+                "get_schema_version",
+                "get_mutation_log",
+                "apply_mutation",
+                "check_context_validity",
+                "evaluate_adaptation",
+            },
+        )
+
+
+class ToolFragilityPipeline(FamilyPipeline):
+    """Pipeline for tool_fragility family scenarios."""
+
+    @property
+    def family_name(self) -> str:
+        return "tool_fragility"
+
+    def required_spec_fields(self) -> set[str]:
+        return {
+            "description",
+            "environment_description",
+            "initial_state_description",
+            "tool_contracts",
+            "success_criteria",
+            "actions",
+        }
+
+    def validate_spec(self, spec: dict[str, Any]) -> list[str]:
+        errors = _check_required_fields(spec, self.required_spec_fields())
+
+        tool_contracts = spec.get("tool_contracts")
+        if isinstance(tool_contracts, list):
+            if len(tool_contracts) == 0:
+                errors.append("tool_contracts must not be empty")
+            else:
+                for i, tc in enumerate(tool_contracts):
+                    if not isinstance(tc, dict):
+                        errors.append(f"tool_contracts[{i}] must be a dict")
+                    elif "tool_name" not in tc:
+                        errors.append(f"tool_contracts[{i}] missing 'tool_name'")
+
+        actions = spec.get("actions")
+        if isinstance(actions, list):
+            if len(actions) == 0:
+                errors.append("actions must not be empty")
+            else:
+                for i, action in enumerate(actions):
+                    if not isinstance(action, dict):
+                        errors.append(f"actions[{i}] must be a dict")
+                    elif "name" not in action:
+                        errors.append(f"actions[{i}] missing 'name'")
+
+        criteria = spec.get("success_criteria")
+        if isinstance(criteria, list) and len(criteria) == 0:
+            errors.append("success_criteria must not be empty")
+
+        return errors
+
+    def validate_source(self, source: str) -> list[str]:
+        return _check_source_for_class(source, "ToolFragilityInterface")
+
+    def validate_contract(self, source: str) -> list[str]:
+        return _check_required_methods(
+            source,
+            "ToolFragilityInterface",
+            {
+                "describe_scenario",
+                "describe_environment",
+                "initial_state",
+                "get_available_actions",
+                "execute_action",
+                "is_terminal",
+                "evaluate_trace",
+                "get_rubric",
+                "get_tool_contracts",
+                "get_drift_log",
+                "inject_drift",
+                "attribute_failure",
+                "evaluate_fragility",
+            },
+        )
+
+
 # ---------------------------------------------------------------------------
 # Built-in pipeline registration
 # ---------------------------------------------------------------------------
@@ -535,6 +681,8 @@ def _register_builtins() -> None:
     register_pipeline(ArtifactEditingPipeline())
     register_pipeline(InvestigationPipeline())
     register_pipeline(WorkflowPipeline())
+    register_pipeline(SchemaEvolutionPipeline())
+    register_pipeline(ToolFragilityPipeline())
 
 
 _register_builtins()

--- a/autocontext/src/autocontext/scenarios/custom/schema_evolution_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/schema_evolution_codegen.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import re
+
+from autocontext.scenarios.custom.schema_evolution_spec import SchemaEvolutionSpec
+
+
+def _class_name(name: str) -> str:
+    parts = re.split(r"[^a-zA-Z0-9]+", name)
+    return "".join(part.capitalize() for part in parts if part) + "SchemaEvolution"
+
+
+def generate_schema_evolution_class(spec: SchemaEvolutionSpec, name: str) -> str:
+    class_name = _class_name(name)
+    action_specs = ",\n".join(
+        "            ActionSpec("
+        f"name={action.name!r}, "
+        f"description={action.description!r}, "
+        f"parameters={action.parameters!r}, "
+        f"preconditions={action.preconditions!r}, "
+        f"effects={action.effects!r})"
+        for action in spec.actions
+    )
+    mutations_repr = [
+        {
+            "version": m.version,
+            "description": m.description,
+            "fields_added": m.fields_added,
+            "fields_removed": m.fields_removed,
+            "fields_modified": m.fields_modified,
+            "breaking": m.breaking,
+        }
+        for m in spec.mutations
+    ]
+    required_actions = [action.name for action in spec.actions]
+    return f'''from __future__ import annotations
+
+from typing import Any
+
+from autocontext.scenarios.schema_evolution import (
+    ContextValidity,
+    SchemaEvolutionInterface,
+    SchemaEvolutionResult,
+    SchemaMutation,
+)
+from autocontext.scenarios.simulation import (
+    Action,
+    ActionResult,
+    ActionSpec,
+    ActionTrace,
+    EnvironmentSpec,
+    SimulationResult,
+)
+
+
+class {class_name}(SchemaEvolutionInterface):
+    name = {name!r}
+    _mutations_spec = {mutations_repr!r}
+
+    def describe_scenario(self) -> str:
+        return {spec.description!r}
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name={name!r},
+            description={spec.environment_description!r},
+            available_actions=[
+{action_specs}
+            ],
+            initial_state_description={spec.initial_state_description!r},
+            success_criteria={spec.success_criteria!r},
+            failure_modes={spec.failure_modes!r},
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {{
+            "seed": seed or 0,
+            "step": 0,
+            "schema_version": 1,
+            "mutations_applied": [],
+            "completed_actions": [],
+            "failed_actions": [],
+            "assumptions_checked": [],
+            "stale_detected": 0,
+            "stale_missed": 0,
+            "recovery_taken": 0,
+            "recovery_successful": 0,
+        }}
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        completed = set(state.get("completed_actions", []))
+        return [s for s in self.describe_environment().available_actions if s.name not in completed]
+
+    def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+        specs = {{s.name: s for s in self.describe_environment().available_actions}}
+        spec = specs.get(action.name)
+        if spec is None:
+            return False, f"unknown action: {{action.name}}"
+        completed = set(state.get("completed_actions", []))
+        for req in spec.preconditions:
+            if req not in completed:
+                return False, f"precondition not met for {{action.name}}: {{req}}"
+        return True, ""
+
+    def execute_action(self, state: dict[str, Any], action: Action) -> tuple[ActionResult, dict[str, Any]]:
+        valid, reason = self.validate_action(state, action)
+        next_state = dict(state)
+        if not valid:
+            next_state["failed_actions"] = [*state.get("failed_actions", []), action.name]
+            return ActionResult(success=False, output="", state_changes={{}}, error=reason), next_state
+
+        next_state["completed_actions"] = [*state.get("completed_actions", []), action.name]
+
+        # Apply pending mutations based on step progression
+        pending = [m for m in self._mutations_spec if m["version"] > state.get("schema_version", 1)]
+        if pending:
+            m = pending[0]
+            mutation = SchemaMutation(
+                version=m["version"], description=m["description"],
+                fields_added=m["fields_added"], fields_removed=m["fields_removed"],
+                fields_modified=m["fields_modified"], breaking=m["breaking"],
+            )
+            next_state = self.apply_mutation(next_state, mutation)
+
+        return (
+            ActionResult(
+                success=True,
+                output=f"executed {{action.name}} (schema v{{next_state.get('schema_version', 1)}})",
+                state_changes={{"schema_version": next_state.get("schema_version", 1)}},
+            ),
+            next_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        required = set({required_actions!r})
+        completed = set(state.get("completed_actions", []))
+        max_version = max((m["version"] for m in self._mutations_spec), default=1)
+        return (
+            required.issubset(completed)
+            or state.get("schema_version", 1) >= max_version
+            or state.get("step", 0) >= {spec.max_steps}
+        )
+
+    def get_schema_version(self, state: dict[str, Any]) -> int:
+        return state.get("schema_version", 1)
+
+    def get_mutation_log(self, state: dict[str, Any]) -> list[SchemaMutation]:
+        return [SchemaMutation.from_dict(m) for m in state.get("mutations_applied", [])]
+
+    def apply_mutation(self, state: dict[str, Any], mutation: SchemaMutation) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["schema_version"] = mutation.version
+        next_state["mutations_applied"] = [*state.get("mutations_applied", []), mutation.to_dict()]
+        return next_state
+
+    def check_context_validity(
+        self, state: dict[str, Any], assumptions: list[str]
+    ) -> list[ContextValidity]:
+        version = state.get("schema_version", 1)
+        removed_fields: set[str] = set()
+        for m in state.get("mutations_applied", []):
+            removed_fields.update(m.get("fields_removed", []))
+
+        results: list[ContextValidity] = []
+        for assumption in assumptions:
+            invalidated = any(field in assumption.lower() for field in removed_fields)
+            results.append(ContextValidity(
+                assumption=assumption,
+                still_valid=not invalidated,
+                invalidated_by_version=version if invalidated else None,
+            ))
+        return results
+
+    def evaluate_adaptation(self, state: dict[str, Any]) -> SchemaEvolutionResult:
+        mutations_applied = len(state.get("mutations_applied", []))
+        stale_detected = state.get("stale_detected", 0)
+        stale_missed = state.get("stale_missed", 0)
+        recovery_taken = state.get("recovery_taken", 0)
+        recovery_successful = state.get("recovery_successful", 0)
+        detection_rate = stale_detected / max(stale_detected + stale_missed, 1)
+        recovery_rate = recovery_successful / max(recovery_taken, 1)
+        score = round(detection_rate * 0.6 + recovery_rate * 0.4, 4)
+        return SchemaEvolutionResult(
+            score=score,
+            reasoning=f"Detected {{stale_detected}}/{{stale_detected + stale_missed}} stale assumptions.",
+            dimension_scores={{"detection": round(detection_rate, 4), "recovery": round(recovery_rate, 4)}},
+            mutations_applied=mutations_applied,
+            stale_assumptions_detected=stale_detected,
+            stale_assumptions_missed=stale_missed,
+            recovery_actions_taken=recovery_taken,
+            recovery_actions_successful=recovery_successful,
+        )
+
+    def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+        adaptation = self.evaluate_adaptation(final_state)
+        action_success = trace.success_rate
+        score = round(adaptation.score * 0.7 + action_success * 0.3, 4)
+        return SimulationResult(
+            score=score,
+            reasoning=adaptation.reasoning,
+            dimension_scores={{
+                "detection": adaptation.dimension_scores.get("detection", 0.0),
+                "recovery": adaptation.dimension_scores.get("recovery", 0.0),
+                "action_success": round(action_success, 4),
+            }},
+            workflow_complete=adaptation.stale_assumptions_missed == 0,
+            actions_taken=len(trace.records),
+            actions_successful=sum(1 for r in trace.records if r.result.success),
+            recovery_attempts=adaptation.recovery_actions_taken,
+            rollback_quality=adaptation.dimension_scores.get("recovery", 0.0),
+        )
+
+    def get_rubric(self) -> str:
+        return "Evaluate on stale-assumption detection, adaptation to schema changes, and recovery quality."
+
+    def max_steps(self) -> int:
+        return {spec.max_steps}
+'''

--- a/autocontext/src/autocontext/scenarios/custom/schema_evolution_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/schema_evolution_creator.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import asdict
+from pathlib import Path
+from typing import cast
+
+from autocontext.scenarios.base import ScenarioInterface
+from autocontext.scenarios.custom.family_pipeline import (
+    validate_for_family,
+    validate_source_for_family,
+)
+from autocontext.scenarios.custom.loader import load_custom_scenario
+from autocontext.scenarios.custom.registry import CUSTOM_SCENARIOS_DIR
+from autocontext.scenarios.custom.schema_evolution_codegen import (
+    generate_schema_evolution_class,
+)
+from autocontext.scenarios.custom.schema_evolution_designer import design_schema_evolution
+from autocontext.scenarios.families import get_family_marker
+from autocontext.scenarios.schema_evolution import SchemaEvolutionInterface
+
+logger = logging.getLogger(__name__)
+
+
+class SchemaEvolutionCreator:
+    def __init__(self, llm_fn: Callable[[str, str], str], knowledge_root: Path) -> None:
+        self.llm_fn = llm_fn
+        self.knowledge_root = knowledge_root
+
+    def create(self, description: str, name: str) -> ScenarioInterface:
+        spec = design_schema_evolution(description, self.llm_fn)
+        errors = validate_for_family("schema_evolution", asdict(spec))
+        if errors:
+            raise ValueError(f"schema_evolution spec validation failed: {'; '.join(errors)}")
+
+        custom_dir = self.knowledge_root / CUSTOM_SCENARIOS_DIR
+        scenario_dir = custom_dir / name
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+
+        source = generate_schema_evolution_class(spec, name=name)
+        source_errors = validate_source_for_family("schema_evolution", source)
+        if source_errors:
+            raise ValueError(
+                f"schema_evolution source validation failed: {'; '.join(source_errors)}"
+            )
+
+        (scenario_dir / "scenario.py").write_text(source, encoding="utf-8")
+        (scenario_dir / "spec.json").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "scenario_type": get_family_marker("schema_evolution"),
+                    "description": spec.description,
+                    "environment_description": spec.environment_description,
+                    "initial_state_description": spec.initial_state_description,
+                    "mutations": [asdict(m) for m in spec.mutations],
+                    "success_criteria": spec.success_criteria,
+                    "failure_modes": spec.failure_modes,
+                    "max_steps": spec.max_steps,
+                    "actions": [
+                        {
+                            "name": action.name,
+                            "description": action.description,
+                            "parameters": action.parameters,
+                            "preconditions": action.preconditions,
+                            "effects": action.effects,
+                        }
+                        for action in spec.actions
+                    ],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        (scenario_dir / "scenario_type.txt").write_text(
+            get_family_marker("schema_evolution"),
+            encoding="utf-8",
+        )
+
+        cls = load_custom_scenario(custom_dir, name, SchemaEvolutionInterface)
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        SCENARIO_REGISTRY[name] = cls
+        logger.info("registered schema_evolution scenario '%s'", name)
+        return cast(ScenarioInterface, cls())

--- a/autocontext/src/autocontext/scenarios/custom/schema_evolution_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/schema_evolution_designer.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+
+from autocontext.scenarios.custom.schema_evolution_spec import (
+    SchemaEvolutionMutationModel,
+    SchemaEvolutionSpec,
+)
+from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+
+SCHEMA_EVOLUTION_SPEC_START = "<!-- SCHEMA_EVOLUTION_SPEC_START -->"
+SCHEMA_EVOLUTION_SPEC_END = "<!-- SCHEMA_EVOLUTION_SPEC_END -->"
+
+_EXAMPLE_SPEC = {
+    "description": "API schema evolves from v1 to v3 during a data migration task.",
+    "environment_description": "REST API backend with versioned schemas.",
+    "initial_state_description": "v1 schema is active; all endpoints respond with v1 format.",
+    "mutations": [
+        {
+            "version": 2,
+            "description": "Add 'priority' field to task objects.",
+            "breaking": False,
+            "fields_added": ["priority"],
+            "fields_removed": [],
+            "fields_modified": {},
+        },
+        {
+            "version": 3,
+            "description": "Rename 'status' to 'state' and remove 'legacy_id'.",
+            "breaking": True,
+            "fields_added": ["state"],
+            "fields_removed": ["status", "legacy_id"],
+            "fields_modified": {},
+        },
+    ],
+    "success_criteria": [
+        "detect each schema version change",
+        "discard stale assumptions about removed fields",
+    ],
+    "failure_modes": ["using removed fields after mutation", "caching stale schema"],
+    "max_steps": 8,
+    "actions": [
+        {
+            "name": "query_api",
+            "description": "Query an API endpoint and observe the response schema.",
+            "parameters": {"endpoint": "string"},
+            "preconditions": [],
+            "effects": ["schema_observed"],
+        },
+        {
+            "name": "validate_schema",
+            "description": "Check whether the current schema matches expectations.",
+            "parameters": {},
+            "preconditions": ["query_api"],
+            "effects": ["schema_validated"],
+        },
+    ],
+}
+
+SCHEMA_EVOLUTION_DESIGNER_SYSTEM = (
+    "You are a scenario designer for autocontext. "
+    "Given a natural-language request for a schema-evolution or stale-context scenario, "
+    "produce a SchemaEvolutionSpec JSON wrapped in delimiters.\n\n"
+    f"{SCHEMA_EVOLUTION_SPEC_START}\n{{ ... }}\n{SCHEMA_EVOLUTION_SPEC_END}\n\n"
+    "Schema:\n"
+    "{\n"
+    '  "description": "scenario summary",\n'
+    '  "environment_description": "what system has evolving schemas",\n'
+    '  "initial_state_description": "starting state with initial schema version",\n'
+    '  "mutations": [\n'
+    "    {\n"
+    '      "version": 2,\n'
+    '      "description": "what changed",\n'
+    '      "breaking": true,\n'
+    '      "fields_added": ["field"],\n'
+    '      "fields_removed": ["field"],\n'
+    '      "fields_modified": {"field": "old_type -> new_type"}\n'
+    "    }\n"
+    "  ],\n"
+    '  "success_criteria": ["criterion"],\n'
+    '  "failure_modes": ["failure mode"],\n'
+    '  "max_steps": 8,\n'
+    '  "actions": [\n'
+    "    {\n"
+    '      "name": "snake_case",\n'
+    '      "description": "what the action does",\n'
+    '      "parameters": {"param": "type"},\n'
+    '      "preconditions": [],\n'
+    '      "effects": ["effect"]\n'
+    "    }\n"
+    "  ]\n"
+    "}\n\n"
+    "Rules:\n"
+    "- include at least one breaking mutation\n"
+    "- model the scenario around detecting and adapting to schema changes\n"
+    "- include at least two actions and two mutations\n\n"
+    f"Example:\n{SCHEMA_EVOLUTION_SPEC_START}\n{json.dumps(_EXAMPLE_SPEC, indent=2)}\n{SCHEMA_EVOLUTION_SPEC_END}\n"
+)
+
+
+def parse_schema_evolution_spec(text: str) -> SchemaEvolutionSpec:
+    pattern = re.escape(SCHEMA_EVOLUTION_SPEC_START) + r"\s*(.*?)\s*" + re.escape(SCHEMA_EVOLUTION_SPEC_END)
+    match = re.search(pattern, text, re.DOTALL)
+    if not match:
+        raise ValueError("response does not contain SCHEMA_EVOLUTION_SPEC delimiters")
+    data = json.loads(match.group(1).strip())
+    return SchemaEvolutionSpec(
+        description=data["description"],
+        environment_description=data["environment_description"],
+        initial_state_description=data["initial_state_description"],
+        mutations=[
+            SchemaEvolutionMutationModel(
+                version=m["version"],
+                description=m["description"],
+                breaking=m["breaking"],
+                fields_added=m.get("fields_added", []),
+                fields_removed=m.get("fields_removed", []),
+                fields_modified=m.get("fields_modified", {}),
+            )
+            for m in data["mutations"]
+        ],
+        success_criteria=data["success_criteria"],
+        failure_modes=data.get("failure_modes", []),
+        actions=[
+            SimulationActionSpecModel(
+                name=raw["name"],
+                description=raw["description"],
+                parameters=raw.get("parameters", {}),
+                preconditions=raw.get("preconditions", []),
+                effects=raw.get("effects", []),
+            )
+            for raw in data["actions"]
+        ],
+        max_steps=data.get("max_steps", 10),
+    )
+
+
+def design_schema_evolution(description: str, llm_fn: Callable[[str, str], str]) -> SchemaEvolutionSpec:
+    return parse_schema_evolution_spec(
+        llm_fn(SCHEMA_EVOLUTION_DESIGNER_SYSTEM, f"User description:\n{description}")
+    )

--- a/autocontext/src/autocontext/scenarios/custom/schema_evolution_spec.py
+++ b/autocontext/src/autocontext/scenarios/custom/schema_evolution_spec.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+
+
+@dataclass(slots=True)
+class SchemaEvolutionMutationModel:
+    version: int
+    description: str
+    breaking: bool
+    fields_added: list[str] = field(default_factory=list)
+    fields_removed: list[str] = field(default_factory=list)
+    fields_modified: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class SchemaEvolutionSpec:
+    description: str
+    environment_description: str
+    initial_state_description: str
+    mutations: list[SchemaEvolutionMutationModel]
+    success_criteria: list[str]
+    failure_modes: list[str]
+    actions: list[SimulationActionSpecModel]
+    max_steps: int = 10

--- a/autocontext/src/autocontext/scenarios/custom/tool_fragility_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/tool_fragility_codegen.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import re
+
+from autocontext.scenarios.custom.tool_fragility_spec import ToolFragilitySpec
+
+
+def _class_name(name: str) -> str:
+    parts = re.split(r"[^a-zA-Z0-9]+", name)
+    return "".join(part.capitalize() for part in parts if part) + "ToolFragility"
+
+
+def generate_tool_fragility_class(spec: ToolFragilitySpec, name: str) -> str:
+    class_name = _class_name(name)
+    action_specs = ",\n".join(
+        "            ActionSpec("
+        f"name={action.name!r}, "
+        f"description={action.description!r}, "
+        f"parameters={action.parameters!r}, "
+        f"preconditions={action.preconditions!r}, "
+        f"effects={action.effects!r})"
+        for action in spec.actions
+    )
+    tool_contracts_repr = [
+        {
+            "tool_name": tc.tool_name,
+            "version": tc.version,
+            "description": tc.description,
+        }
+        for tc in spec.tool_contracts
+    ]
+    required_actions = [action.name for action in spec.actions]
+    return f'''from __future__ import annotations
+
+from typing import Any
+
+from autocontext.scenarios.simulation import (
+    Action,
+    ActionResult,
+    ActionSpec,
+    ActionTrace,
+    EnvironmentSpec,
+    SimulationResult,
+)
+from autocontext.scenarios.tool_fragility import (
+    FailureAttribution,
+    ToolContract,
+    ToolDrift,
+    ToolFragilityInterface,
+    ToolFragilityResult,
+)
+
+
+class {class_name}(ToolFragilityInterface):
+    name = {name!r}
+    _tool_contracts_spec = {tool_contracts_repr!r}
+
+    def describe_scenario(self) -> str:
+        return {spec.description!r}
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name={name!r},
+            description={spec.environment_description!r},
+            available_actions=[
+{action_specs}
+            ],
+            initial_state_description={spec.initial_state_description!r},
+            success_criteria={spec.success_criteria!r},
+            failure_modes={spec.failure_modes!r},
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {{
+            "seed": seed or 0,
+            "step": 0,
+            "tool_versions": {{tc["tool_name"]: tc["version"] for tc in self._tool_contracts_spec}},
+            "drifts_applied": [],
+            "completed_actions": [],
+            "failed_actions": [],
+            "drifts_detected": 0,
+            "drifts_adapted": 0,
+            "wasted_attempts": 0,
+            "failure_attributions": [],
+        }}
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        completed = set(state.get("completed_actions", []))
+        return [s for s in self.describe_environment().available_actions if s.name not in completed]
+
+    def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+        specs = {{s.name: s for s in self.describe_environment().available_actions}}
+        spec = specs.get(action.name)
+        if spec is None:
+            return False, f"unknown action: {{action.name}}"
+        completed = set(state.get("completed_actions", []))
+        for req in spec.preconditions:
+            if req not in completed:
+                return False, f"precondition not met for {{action.name}}: {{req}}"
+        return True, ""
+
+    def execute_action(self, state: dict[str, Any], action: Action) -> tuple[ActionResult, dict[str, Any]]:
+        valid, reason = self.validate_action(state, action)
+        next_state = dict(state)
+        if not valid:
+            next_state["failed_actions"] = [*state.get("failed_actions", []), action.name]
+            next_state["wasted_attempts"] = state.get("wasted_attempts", 0) + 1
+            return ActionResult(success=False, output="", state_changes={{}}, error=reason), next_state
+
+        next_state["completed_actions"] = [*state.get("completed_actions", []), action.name]
+        return (
+            ActionResult(
+                success=True,
+                output=f"executed {{action.name}}",
+                state_changes={{"completed_actions": list(next_state["completed_actions"])}},
+            ),
+            next_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        required = set({required_actions!r})
+        completed = set(state.get("completed_actions", []))
+        return required.issubset(completed) or state.get("step", 0) >= {spec.max_steps}
+
+    def get_tool_contracts(self, state: dict[str, Any]) -> list[ToolContract]:
+        versions = state.get("tool_versions", {{}})
+        return [
+            ToolContract(
+                tool_name=tc["tool_name"],
+                version=versions.get(tc["tool_name"], tc["version"]),
+                input_schema={{}},
+                output_schema={{}},
+                description=tc["description"],
+            )
+            for tc in self._tool_contracts_spec
+        ]
+
+    def get_drift_log(self, state: dict[str, Any]) -> list[ToolDrift]:
+        return [ToolDrift.from_dict(d) for d in state.get("drifts_applied", [])]
+
+    def inject_drift(self, state: dict[str, Any], drift: ToolDrift) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["drifts_applied"] = [*state.get("drifts_applied", []), drift.to_dict()]
+        tv = dict(state.get("tool_versions", {{}}))
+        tv[drift.tool_name] = drift.to_version
+        next_state["tool_versions"] = tv
+        return next_state
+
+    def attribute_failure(
+        self, state: dict[str, Any], step: int, error: str
+    ) -> FailureAttribution:
+        drifts = state.get("drifts_applied", [])
+        if drifts:
+            return FailureAttribution(
+                step=step, failure_class="tool_failure",
+                description=error, tool_name=drifts[-1].get("tool_name", "unknown"),
+                recoverable=True,
+            )
+        return FailureAttribution(
+            step=step, failure_class="routing_failure",
+            description=error, tool_name="unknown",
+            recoverable=True,
+        )
+
+    def evaluate_fragility(self, state: dict[str, Any]) -> ToolFragilityResult:
+        drifts_injected = len(state.get("drifts_applied", []))
+        detected = state.get("drifts_detected", 0)
+        adapted = state.get("drifts_adapted", 0)
+        wasted = state.get("wasted_attempts", 0)
+        adaptation_rate = adapted / max(drifts_injected, 1)
+        waste_penalty = min(wasted * 0.1, 0.5)
+        score = round(max(0.0, adaptation_rate - waste_penalty), 4)
+        return ToolFragilityResult(
+            score=score,
+            reasoning=f"Adapted to {{adapted}}/{{drifts_injected}} drifts with {{wasted}} wasted attempts.",
+            dimension_scores={{"adaptation": round(adaptation_rate, 4), "waste_avoidance": round(1.0 - waste_penalty, 4)}},
+            drifts_injected=drifts_injected,
+            drifts_detected=detected,
+            drifts_adapted=adapted,
+            wasted_attempts=wasted,
+            failure_attributions=[
+                FailureAttribution.from_dict(fa) for fa in state.get("failure_attributions", [])
+            ],
+        )
+
+    def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+        fragility = self.evaluate_fragility(final_state)
+        action_success = trace.success_rate
+        score = round(fragility.score * 0.7 + action_success * 0.3, 4)
+        return SimulationResult(
+            score=score,
+            reasoning=fragility.reasoning,
+            dimension_scores={{
+                "adaptation": fragility.dimension_scores.get("adaptation", 0.0),
+                "waste_avoidance": fragility.dimension_scores.get("waste_avoidance", 0.0),
+                "action_success": round(action_success, 4),
+            }},
+            workflow_complete=fragility.drifts_adapted == fragility.drifts_injected,
+            actions_taken=len(trace.records),
+            actions_successful=sum(1 for r in trace.records if r.result.success),
+            recovery_attempts=fragility.wasted_attempts,
+            rollback_quality=fragility.dimension_scores.get("waste_avoidance", 0.0),
+        )
+
+    def get_rubric(self) -> str:
+        return "Evaluate on drift detection, tool adaptation quality, and wasted attempt minimization."
+
+    def max_steps(self) -> int:
+        return {spec.max_steps}
+'''

--- a/autocontext/src/autocontext/scenarios/custom/tool_fragility_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/tool_fragility_creator.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import asdict
+from pathlib import Path
+from typing import cast
+
+from autocontext.scenarios.base import ScenarioInterface
+from autocontext.scenarios.custom.family_pipeline import (
+    validate_for_family,
+    validate_source_for_family,
+)
+from autocontext.scenarios.custom.loader import load_custom_scenario
+from autocontext.scenarios.custom.registry import CUSTOM_SCENARIOS_DIR
+from autocontext.scenarios.custom.tool_fragility_codegen import (
+    generate_tool_fragility_class,
+)
+from autocontext.scenarios.custom.tool_fragility_designer import design_tool_fragility
+from autocontext.scenarios.families import get_family_marker
+from autocontext.scenarios.tool_fragility import ToolFragilityInterface
+
+logger = logging.getLogger(__name__)
+
+
+class ToolFragilityCreator:
+    def __init__(self, llm_fn: Callable[[str, str], str], knowledge_root: Path) -> None:
+        self.llm_fn = llm_fn
+        self.knowledge_root = knowledge_root
+
+    def create(self, description: str, name: str) -> ScenarioInterface:
+        spec = design_tool_fragility(description, self.llm_fn)
+        errors = validate_for_family("tool_fragility", asdict(spec))
+        if errors:
+            raise ValueError(f"tool_fragility spec validation failed: {'; '.join(errors)}")
+
+        custom_dir = self.knowledge_root / CUSTOM_SCENARIOS_DIR
+        scenario_dir = custom_dir / name
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+
+        source = generate_tool_fragility_class(spec, name=name)
+        source_errors = validate_source_for_family("tool_fragility", source)
+        if source_errors:
+            raise ValueError(
+                f"tool_fragility source validation failed: {'; '.join(source_errors)}"
+            )
+
+        (scenario_dir / "scenario.py").write_text(source, encoding="utf-8")
+        (scenario_dir / "spec.json").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "scenario_type": get_family_marker("tool_fragility"),
+                    "description": spec.description,
+                    "environment_description": spec.environment_description,
+                    "initial_state_description": spec.initial_state_description,
+                    "tool_contracts": [asdict(tc) for tc in spec.tool_contracts],
+                    "success_criteria": spec.success_criteria,
+                    "failure_modes": spec.failure_modes,
+                    "max_steps": spec.max_steps,
+                    "actions": [
+                        {
+                            "name": action.name,
+                            "description": action.description,
+                            "parameters": action.parameters,
+                            "preconditions": action.preconditions,
+                            "effects": action.effects,
+                        }
+                        for action in spec.actions
+                    ],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        (scenario_dir / "scenario_type.txt").write_text(
+            get_family_marker("tool_fragility"),
+            encoding="utf-8",
+        )
+
+        cls = load_custom_scenario(custom_dir, name, ToolFragilityInterface)
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        SCENARIO_REGISTRY[name] = cls
+        logger.info("registered tool_fragility scenario '%s'", name)
+        return cast(ScenarioInterface, cls())

--- a/autocontext/src/autocontext/scenarios/custom/tool_fragility_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/tool_fragility_designer.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+
+from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+from autocontext.scenarios.custom.tool_fragility_spec import (
+    ToolContractSpecModel,
+    ToolFragilitySpec,
+)
+
+TOOL_FRAGILITY_SPEC_START = "<!-- TOOL_FRAGILITY_SPEC_START -->"
+TOOL_FRAGILITY_SPEC_END = "<!-- TOOL_FRAGILITY_SPEC_END -->"
+
+_EXAMPLE_SPEC = {
+    "description": "API contracts drift during a data processing pipeline.",
+    "environment_description": "Microservice architecture with versioned API contracts.",
+    "initial_state_description": "All tools at v1; pipeline runs successfully.",
+    "tool_contracts": [
+        {"tool_name": "search_api", "version": 1, "description": "Search endpoint returning flat list."},
+        {"tool_name": "transform_api", "version": 1, "description": "Data transformation endpoint."},
+    ],
+    "success_criteria": [
+        "complete the pipeline despite tool changes",
+        "detect and adapt to changed response formats",
+    ],
+    "failure_modes": ["using stale response format", "selecting wrong tool"],
+    "max_steps": 10,
+    "actions": [
+        {
+            "name": "call_search",
+            "description": "Call the search API with a query.",
+            "parameters": {"query": "string"},
+            "preconditions": [],
+            "effects": ["search_results_obtained"],
+        },
+        {
+            "name": "call_transform",
+            "description": "Transform data using the transformation API.",
+            "parameters": {"data": "string"},
+            "preconditions": ["call_search"],
+            "effects": ["data_transformed"],
+        },
+    ],
+}
+
+TOOL_FRAGILITY_DESIGNER_SYSTEM = (
+    "You are a scenario designer for autocontext. "
+    "Given a natural-language request for a tool-fragility or environment-drift scenario, "
+    "produce a ToolFragilitySpec JSON wrapped in delimiters.\n\n"
+    f"{TOOL_FRAGILITY_SPEC_START}\n{{ ... }}\n{TOOL_FRAGILITY_SPEC_END}\n\n"
+    "Schema:\n"
+    "{\n"
+    '  "description": "scenario summary",\n'
+    '  "environment_description": "what system has drifting tools",\n'
+    '  "initial_state_description": "starting state with stable tools",\n'
+    '  "tool_contracts": [\n'
+    "    {\n"
+    '      "tool_name": "api_name",\n'
+    '      "version": 1,\n'
+    '      "description": "what this tool does"\n'
+    "    }\n"
+    "  ],\n"
+    '  "success_criteria": ["criterion"],\n'
+    '  "failure_modes": ["failure mode"],\n'
+    '  "max_steps": 10,\n'
+    '  "actions": [\n'
+    "    {\n"
+    '      "name": "snake_case",\n'
+    '      "description": "what the action does",\n'
+    '      "parameters": {"param": "type"},\n'
+    '      "preconditions": [],\n'
+    '      "effects": ["effect"]\n'
+    "    }\n"
+    "  ]\n"
+    "}\n\n"
+    "Rules:\n"
+    "- include at least two tool contracts\n"
+    "- model the scenario around adapting to changed tool behavior\n"
+    "- include at least two actions\n\n"
+    f"Example:\n{TOOL_FRAGILITY_SPEC_START}\n{json.dumps(_EXAMPLE_SPEC, indent=2)}\n{TOOL_FRAGILITY_SPEC_END}\n"
+)
+
+
+def parse_tool_fragility_spec(text: str) -> ToolFragilitySpec:
+    pattern = re.escape(TOOL_FRAGILITY_SPEC_START) + r"\s*(.*?)\s*" + re.escape(TOOL_FRAGILITY_SPEC_END)
+    match = re.search(pattern, text, re.DOTALL)
+    if not match:
+        raise ValueError("response does not contain TOOL_FRAGILITY_SPEC delimiters")
+    data = json.loads(match.group(1).strip())
+    return ToolFragilitySpec(
+        description=data["description"],
+        environment_description=data["environment_description"],
+        initial_state_description=data["initial_state_description"],
+        tool_contracts=[
+            ToolContractSpecModel(
+                tool_name=tc["tool_name"],
+                version=tc["version"],
+                description=tc["description"],
+            )
+            for tc in data["tool_contracts"]
+        ],
+        success_criteria=data["success_criteria"],
+        failure_modes=data.get("failure_modes", []),
+        actions=[
+            SimulationActionSpecModel(
+                name=raw["name"],
+                description=raw["description"],
+                parameters=raw.get("parameters", {}),
+                preconditions=raw.get("preconditions", []),
+                effects=raw.get("effects", []),
+            )
+            for raw in data["actions"]
+        ],
+        max_steps=data.get("max_steps", 10),
+    )
+
+
+def design_tool_fragility(description: str, llm_fn: Callable[[str, str], str]) -> ToolFragilitySpec:
+    return parse_tool_fragility_spec(
+        llm_fn(TOOL_FRAGILITY_DESIGNER_SYSTEM, f"User description:\n{description}")
+    )

--- a/autocontext/src/autocontext/scenarios/custom/tool_fragility_spec.py
+++ b/autocontext/src/autocontext/scenarios/custom/tool_fragility_spec.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+
+
+@dataclass(slots=True)
+class ToolContractSpecModel:
+    tool_name: str
+    version: int
+    description: str
+
+
+@dataclass(slots=True)
+class ToolFragilitySpec:
+    description: str
+    environment_description: str
+    initial_state_description: str
+    tool_contracts: list[ToolContractSpecModel]
+    success_criteria: list[str]
+    failure_modes: list[str]
+    actions: list[SimulationActionSpecModel]
+    max_steps: int = 10

--- a/autocontext/src/autocontext/scenarios/families.py
+++ b/autocontext/src/autocontext/scenarios/families.py
@@ -103,7 +103,9 @@ def _register_builtins() -> None:
     from autocontext.scenarios.artifact_editing import ArtifactEditingInterface
     from autocontext.scenarios.base import ScenarioInterface
     from autocontext.scenarios.investigation import InvestigationInterface
+    from autocontext.scenarios.schema_evolution import SchemaEvolutionInterface
     from autocontext.scenarios.simulation import SimulationInterface
+    from autocontext.scenarios.tool_fragility import ToolFragilityInterface
     from autocontext.scenarios.workflow import WorkflowInterface
 
     register_family(ScenarioFamily(
@@ -166,6 +168,26 @@ def _register_builtins() -> None:
         output_modes=["action_trace"],
         scenario_type_marker="workflow",
         capabilities=["compensation", "retry", "side_effect_tracking", "rollback"],
+    ))
+
+    register_family(ScenarioFamily(
+        name="schema_evolution",
+        description="Schema-evolution scenarios where state changes mid-run and agents must detect stale context",
+        interface_class=SchemaEvolutionInterface,
+        evaluation_mode="schema_adaptation",
+        output_modes=["action_trace"],
+        scenario_type_marker="schema_evolution",
+        capabilities=["stale_detection", "schema_migration", "context_invalidation"],
+    ))
+
+    register_family(ScenarioFamily(
+        name="tool_fragility",
+        description="Tool-fragility scenarios where APIs drift and agents must adapt to changed tool behaviour",
+        interface_class=ToolFragilityInterface,
+        evaluation_mode="drift_adaptation",
+        output_modes=["action_trace"],
+        scenario_type_marker="tool_fragility",
+        capabilities=["drift_detection", "failure_attribution", "tool_adaptation"],
     ))
 
 

--- a/autocontext/src/autocontext/scenarios/schema_evolution.py
+++ b/autocontext/src/autocontext/scenarios/schema_evolution.py
@@ -1,0 +1,144 @@
+"""Schema-evolution scenario family with stale-context evaluation (AC-252).
+
+Scenarios where schemas, upstream state, or constraints change mid-run
+or between generations. Agents must detect invalidated assumptions,
+discard stale context, and adapt. Evaluated on stale-assumption detection
+rate, recovery quality, and mutation adaptation.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+from autocontext.scenarios.simulation import SimulationInterface
+
+
+@dataclass(slots=True)
+class SchemaMutation:
+    """A single schema or state mutation applied to the environment."""
+
+    version: int
+    description: str
+    fields_added: list[str]
+    fields_removed: list[str]
+    fields_modified: dict[str, str]  # field_name -> "old_type -> new_type"
+    breaking: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "description": self.description,
+            "fields_added": self.fields_added,
+            "fields_removed": self.fields_removed,
+            "fields_modified": self.fields_modified,
+            "breaking": self.breaking,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SchemaMutation:
+        return cls(
+            version=data["version"],
+            description=data["description"],
+            fields_added=data.get("fields_added", []),
+            fields_removed=data.get("fields_removed", []),
+            fields_modified=data.get("fields_modified", {}),
+            breaking=data["breaking"],
+        )
+
+
+@dataclass(slots=True)
+class ContextValidity:
+    """Whether a prior assumption is still valid after mutations."""
+
+    assumption: str
+    still_valid: bool
+    invalidated_by_version: int | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "assumption": self.assumption,
+            "still_valid": self.still_valid,
+            "invalidated_by_version": self.invalidated_by_version,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ContextValidity:
+        return cls(
+            assumption=data["assumption"],
+            still_valid=data["still_valid"],
+            invalidated_by_version=data.get("invalidated_by_version"),
+        )
+
+
+@dataclass(slots=True)
+class SchemaEvolutionResult:
+    """Result of evaluating a schema-evolution scenario."""
+
+    score: float
+    reasoning: str
+    dimension_scores: dict[str, float]
+    mutations_applied: int
+    stale_assumptions_detected: int
+    stale_assumptions_missed: int
+    recovery_actions_taken: int
+    recovery_actions_successful: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "reasoning": self.reasoning,
+            "dimension_scores": self.dimension_scores,
+            "mutations_applied": self.mutations_applied,
+            "stale_assumptions_detected": self.stale_assumptions_detected,
+            "stale_assumptions_missed": self.stale_assumptions_missed,
+            "recovery_actions_taken": self.recovery_actions_taken,
+            "recovery_actions_successful": self.recovery_actions_successful,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SchemaEvolutionResult:
+        return cls(
+            score=data["score"],
+            reasoning=data["reasoning"],
+            dimension_scores=data["dimension_scores"],
+            mutations_applied=data["mutations_applied"],
+            stale_assumptions_detected=data["stale_assumptions_detected"],
+            stale_assumptions_missed=data["stale_assumptions_missed"],
+            recovery_actions_taken=data["recovery_actions_taken"],
+            recovery_actions_successful=data["recovery_actions_successful"],
+        )
+
+
+class SchemaEvolutionInterface(SimulationInterface):
+    """Contract for schema-evolution / stale-context scenarios.
+
+    Extends SimulationInterface with schema versioning, mutation tracking,
+    context validity checking, and adaptation evaluation. Agents are judged
+    on detecting and discarding stale assumptions after schema changes.
+    """
+
+    @abstractmethod
+    def get_schema_version(self, state: dict[str, Any]) -> int:
+        """Return the current schema version from state."""
+
+    @abstractmethod
+    def get_mutation_log(self, state: dict[str, Any]) -> list[SchemaMutation]:
+        """Return the log of mutations applied so far."""
+
+    @abstractmethod
+    def apply_mutation(
+        self, state: dict[str, Any], mutation: SchemaMutation
+    ) -> dict[str, Any]:
+        """Apply a schema mutation and return the updated state."""
+
+    @abstractmethod
+    def check_context_validity(
+        self, state: dict[str, Any], assumptions: list[str]
+    ) -> list[ContextValidity]:
+        """Check which prior assumptions are still valid after mutations."""
+
+    @abstractmethod
+    def evaluate_adaptation(self, state: dict[str, Any]) -> SchemaEvolutionResult:
+        """Evaluate how well the agent adapted to schema changes."""

--- a/autocontext/src/autocontext/scenarios/tool_fragility.py
+++ b/autocontext/src/autocontext/scenarios/tool_fragility.py
@@ -1,0 +1,189 @@
+"""Tool-fragility scenario family with environment-drift evaluation (AC-254).
+
+Scenarios where tools, APIs, or environment contracts drift while the core
+task stays the same. Agents must detect broken tools, changed interfaces,
+and degraded environments. Evaluation separates routing, instruction,
+runtime/tool, and stale-context failures.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+from autocontext.scenarios.simulation import SimulationInterface
+
+FAILURE_CLASSES = frozenset({
+    "routing_failure",
+    "stale_instruction_failure",
+    "tool_failure",
+    "stale_context_failure",
+})
+
+
+@dataclass(slots=True)
+class ToolContract:
+    """Describes a tool/API contract at a specific version."""
+
+    tool_name: str
+    version: int
+    input_schema: dict[str, str]
+    output_schema: dict[str, str]
+    description: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_name": self.tool_name,
+            "version": self.version,
+            "input_schema": self.input_schema,
+            "output_schema": self.output_schema,
+            "description": self.description,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ToolContract:
+        return cls(
+            tool_name=data["tool_name"],
+            version=data["version"],
+            input_schema=data.get("input_schema", {}),
+            output_schema=data.get("output_schema", {}),
+            description=data["description"],
+        )
+
+
+@dataclass(slots=True)
+class ToolDrift:
+    """Records a change in a tool's contract."""
+
+    tool_name: str
+    from_version: int
+    to_version: int
+    description: str
+    drift_type: str  # "schema_change", "additive_change", "removal", "behavior_change"
+    breaking: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_name": self.tool_name,
+            "from_version": self.from_version,
+            "to_version": self.to_version,
+            "description": self.description,
+            "drift_type": self.drift_type,
+            "breaking": self.breaking,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ToolDrift:
+        return cls(
+            tool_name=data["tool_name"],
+            from_version=data["from_version"],
+            to_version=data["to_version"],
+            description=data["description"],
+            drift_type=data["drift_type"],
+            breaking=data["breaking"],
+        )
+
+
+@dataclass(slots=True)
+class FailureAttribution:
+    """Attributes a failure to a specific class."""
+
+    step: int
+    failure_class: str  # one of FAILURE_CLASSES
+    description: str
+    tool_name: str
+    recoverable: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step": self.step,
+            "failure_class": self.failure_class,
+            "description": self.description,
+            "tool_name": self.tool_name,
+            "recoverable": self.recoverable,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FailureAttribution:
+        return cls(
+            step=data["step"],
+            failure_class=data["failure_class"],
+            description=data["description"],
+            tool_name=data["tool_name"],
+            recoverable=data["recoverable"],
+        )
+
+
+@dataclass(slots=True)
+class ToolFragilityResult:
+    """Result of evaluating a tool-fragility scenario."""
+
+    score: float
+    reasoning: str
+    dimension_scores: dict[str, float]
+    drifts_injected: int
+    drifts_detected: int
+    drifts_adapted: int
+    wasted_attempts: int
+    failure_attributions: list[FailureAttribution]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "reasoning": self.reasoning,
+            "dimension_scores": self.dimension_scores,
+            "drifts_injected": self.drifts_injected,
+            "drifts_detected": self.drifts_detected,
+            "drifts_adapted": self.drifts_adapted,
+            "wasted_attempts": self.wasted_attempts,
+            "failure_attributions": [fa.to_dict() for fa in self.failure_attributions],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ToolFragilityResult:
+        return cls(
+            score=data["score"],
+            reasoning=data["reasoning"],
+            dimension_scores=data["dimension_scores"],
+            drifts_injected=data["drifts_injected"],
+            drifts_detected=data["drifts_detected"],
+            drifts_adapted=data["drifts_adapted"],
+            wasted_attempts=data["wasted_attempts"],
+            failure_attributions=[
+                FailureAttribution.from_dict(fa) for fa in data["failure_attributions"]
+            ],
+        )
+
+
+class ToolFragilityInterface(SimulationInterface):
+    """Contract for tool-fragility / environment-drift scenarios.
+
+    Extends SimulationInterface with tool contract management, drift injection,
+    failure attribution, and fragility evaluation. Agents are judged on
+    adaptation quality and wasted attempts when tools change.
+    """
+
+    @abstractmethod
+    def get_tool_contracts(self, state: dict[str, Any]) -> list[ToolContract]:
+        """Return current tool contracts in the environment."""
+
+    @abstractmethod
+    def get_drift_log(self, state: dict[str, Any]) -> list[ToolDrift]:
+        """Return the log of tool drifts applied so far."""
+
+    @abstractmethod
+    def inject_drift(
+        self, state: dict[str, Any], drift: ToolDrift
+    ) -> dict[str, Any]:
+        """Inject a tool drift and return the updated state."""
+
+    @abstractmethod
+    def attribute_failure(
+        self, state: dict[str, Any], step: int, error: str
+    ) -> FailureAttribution:
+        """Attribute a failure to a specific class."""
+
+    @abstractmethod
+    def evaluate_fragility(self, state: dict[str, Any]) -> ToolFragilityResult:
+        """Evaluate how well the agent adapted to tool/environment changes."""

--- a/autocontext/tests/test_schema_evolution_tool_fragility.py
+++ b/autocontext/tests/test_schema_evolution_tool_fragility.py
@@ -1,0 +1,1270 @@
+"""Tests for AC-252 + AC-254: Schema-evolution and tool-fragility scenario families.
+
+AC-252: SchemaEvolutionInterface — schemas/state change mid-run, agent must
+detect stale context and adapt. Scores stale-assumption detection and recovery.
+
+AC-254: ToolFragilityInterface — tools/APIs drift while task stays the same.
+Separates routing, instruction, runtime/tool, and stale-context failures.
+Scores adaptation quality and wasted attempts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ===========================================================================
+# AC-252: Schema-evolution data models
+# ===========================================================================
+
+
+class TestSchemaMutation:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.schema_evolution import SchemaMutation
+
+        m = SchemaMutation(
+            version=2,
+            description="Add 'priority' field to task schema",
+            fields_added=["priority"],
+            fields_removed=[],
+            fields_modified={},
+            breaking=False,
+        )
+        assert m.version == 2
+        assert m.fields_added == ["priority"]
+        assert m.breaking is False
+
+    def test_breaking_change(self) -> None:
+        from autocontext.scenarios.schema_evolution import SchemaMutation
+
+        m = SchemaMutation(
+            version=3,
+            description="Rename 'status' to 'state'",
+            fields_added=["state"],
+            fields_removed=["status"],
+            fields_modified={},
+            breaking=True,
+        )
+        assert m.breaking is True
+        assert "status" in m.fields_removed
+
+    def test_to_dict_from_dict(self) -> None:
+        from autocontext.scenarios.schema_evolution import SchemaMutation
+
+        m = SchemaMutation(
+            version=2,
+            description="desc",
+            fields_added=["x"],
+            fields_removed=["y"],
+            fields_modified={"z": "int -> str"},
+            breaking=True,
+        )
+        data = m.to_dict()
+        restored = SchemaMutation.from_dict(data)
+        assert restored.version == m.version
+        assert restored.fields_added == m.fields_added
+        assert restored.fields_modified == m.fields_modified
+        assert restored.breaking == m.breaking
+
+
+class TestContextValidity:
+    def test_valid(self) -> None:
+        from autocontext.scenarios.schema_evolution import ContextValidity
+
+        cv = ContextValidity(
+            assumption="status field exists",
+            still_valid=True,
+            invalidated_by_version=None,
+        )
+        assert cv.still_valid is True
+        assert cv.invalidated_by_version is None
+
+    def test_invalid(self) -> None:
+        from autocontext.scenarios.schema_evolution import ContextValidity
+
+        cv = ContextValidity(
+            assumption="status field exists",
+            still_valid=False,
+            invalidated_by_version=3,
+        )
+        assert cv.still_valid is False
+        assert cv.invalidated_by_version == 3
+
+    def test_to_dict_from_dict(self) -> None:
+        from autocontext.scenarios.schema_evolution import ContextValidity
+
+        cv = ContextValidity(
+            assumption="field X exists",
+            still_valid=False,
+            invalidated_by_version=2,
+        )
+        data = cv.to_dict()
+        restored = ContextValidity.from_dict(data)
+        assert restored.assumption == cv.assumption
+        assert restored.still_valid is False
+        assert restored.invalidated_by_version == 2
+
+
+class TestSchemaEvolutionResult:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.schema_evolution import SchemaEvolutionResult
+
+        r = SchemaEvolutionResult(
+            score=0.8,
+            reasoning="Good adaptation",
+            dimension_scores={"detection": 0.9, "recovery": 0.7},
+            mutations_applied=3,
+            stale_assumptions_detected=2,
+            stale_assumptions_missed=1,
+            recovery_actions_taken=2,
+            recovery_actions_successful=2,
+        )
+        assert r.score == 0.8
+        assert r.stale_assumptions_detected == 2
+        assert r.stale_assumptions_missed == 1
+
+    def test_to_dict_from_dict(self) -> None:
+        from autocontext.scenarios.schema_evolution import SchemaEvolutionResult
+
+        r = SchemaEvolutionResult(
+            score=0.6,
+            reasoning="Partial",
+            dimension_scores={"detection": 0.5},
+            mutations_applied=2,
+            stale_assumptions_detected=1,
+            stale_assumptions_missed=2,
+            recovery_actions_taken=1,
+            recovery_actions_successful=0,
+        )
+        data = r.to_dict()
+        restored = SchemaEvolutionResult.from_dict(data)
+        assert restored.score == r.score
+        assert restored.mutations_applied == 2
+        assert restored.stale_assumptions_missed == 2
+
+
+# ===========================================================================
+# AC-252: SchemaEvolutionInterface ABC
+# ===========================================================================
+
+
+class TestSchemaEvolutionInterfaceABC:
+    def test_cannot_instantiate_abc(self) -> None:
+        from autocontext.scenarios.schema_evolution import SchemaEvolutionInterface
+
+        with pytest.raises(TypeError, match="abstract"):
+            SchemaEvolutionInterface()  # type: ignore[abstract]
+
+    def test_concrete_subclass_instantiates(self) -> None:
+        mock = self._make_mock()
+        assert mock.name == "mock_schema_evo"
+
+    def test_describe_scenario(self) -> None:
+        mock = self._make_mock()
+        assert isinstance(mock.describe_scenario(), str)
+
+    def test_get_schema_version(self) -> None:
+        mock = self._make_mock()
+        state = mock.initial_state()
+        version = mock.get_schema_version(state)
+        assert isinstance(version, int)
+        assert version >= 1
+
+    def test_get_mutation_log(self) -> None:
+        from autocontext.scenarios.schema_evolution import SchemaMutation
+
+        mock = self._make_mock()
+        state = mock.initial_state()
+        log = mock.get_mutation_log(state)
+        assert isinstance(log, list)
+        assert all(isinstance(m, SchemaMutation) for m in log)
+
+    def test_apply_mutation(self) -> None:
+        from autocontext.scenarios.schema_evolution import SchemaMutation
+
+        mock = self._make_mock()
+        state = mock.initial_state()
+        mutation = SchemaMutation(
+            version=2, description="add field",
+            fields_added=["priority"], fields_removed=[],
+            fields_modified={}, breaking=False,
+        )
+        new_state = mock.apply_mutation(state, mutation)
+        assert isinstance(new_state, dict)
+        assert mock.get_schema_version(new_state) == 2
+
+    def test_check_context_validity(self) -> None:
+        from autocontext.scenarios.schema_evolution import ContextValidity
+
+        mock = self._make_mock()
+        state = mock.initial_state()
+        results = mock.check_context_validity(state, ["status field exists"])
+        assert isinstance(results, list)
+        assert all(isinstance(cv, ContextValidity) for cv in results)
+
+    def test_evaluate_adaptation(self) -> None:
+        from autocontext.scenarios.schema_evolution import SchemaEvolutionResult
+
+        mock = self._make_mock()
+        state = mock.initial_state()
+        result = mock.evaluate_adaptation(state)
+        assert isinstance(result, SchemaEvolutionResult)
+        assert 0.0 <= result.score <= 1.0
+
+    def test_initial_state(self) -> None:
+        mock = self._make_mock()
+        state = mock.initial_state(seed=42)
+        assert isinstance(state, dict)
+
+    def _make_mock(self) -> Any:
+        from autocontext.scenarios.schema_evolution import (
+            ContextValidity,
+            SchemaEvolutionInterface,
+            SchemaEvolutionResult,
+            SchemaMutation,
+        )
+        from autocontext.scenarios.simulation import ActionResult, ActionSpec, EnvironmentSpec
+
+        class _M(SchemaEvolutionInterface):
+            name = "mock_schema_evo"
+
+            def describe_scenario(self) -> str:
+                return "Schema changes mid-run"
+
+            def describe_environment(self) -> EnvironmentSpec:
+                return EnvironmentSpec(
+                    name="mock_schema_evo", description="evolving schema",
+                    available_actions=[ActionSpec(name="query", description="query data", parameters={})],
+                    initial_state_description="v1 schema", success_criteria=["adapted to v3"],
+                )
+
+            def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+                return {"schema_version": 1, "mutations": [], "seed": seed or 0}
+
+            def get_available_actions(self, state: dict[str, Any]) -> list:
+                return self.describe_environment().available_actions
+
+            def execute_action(self, state: dict[str, Any], action: Any) -> tuple:
+                return ActionResult(success=True, output="ok", state_changes={}), state
+
+            def is_terminal(self, state: Any) -> bool:
+                return state.get("schema_version", 1) >= 3
+
+            def evaluate_trace(self, trace: Any, final_state: dict[str, Any]) -> Any:
+                from autocontext.scenarios.simulation import SimulationResult
+
+                return SimulationResult(
+                    score=1.0, reasoning="ok", dimension_scores={},
+                    workflow_complete=True, actions_taken=0, actions_successful=0,
+                )
+
+            def get_rubric(self) -> str:
+                return "Stale detection, adaptation quality"
+
+            def get_schema_version(self, state: dict[str, Any]) -> int:
+                return state.get("schema_version", 1)
+
+            def get_mutation_log(self, state: dict[str, Any]) -> list[SchemaMutation]:
+                return [
+                    SchemaMutation(
+                        version=2, description="add priority",
+                        fields_added=["priority"], fields_removed=[],
+                        fields_modified={}, breaking=False,
+                    ),
+                ]
+
+            def apply_mutation(self, state: dict[str, Any], mutation: SchemaMutation) -> dict[str, Any]:
+                new_state = dict(state)
+                new_state["schema_version"] = mutation.version
+                new_state.setdefault("mutations", []).append(mutation.to_dict())
+                return new_state
+
+            def check_context_validity(
+                self, state: dict[str, Any], assumptions: list[str]
+            ) -> list[ContextValidity]:
+                return [
+                    ContextValidity(
+                        assumption=a,
+                        still_valid=state.get("schema_version", 1) < 2,
+                        invalidated_by_version=2 if state.get("schema_version", 1) >= 2 else None,
+                    )
+                    for a in assumptions
+                ]
+
+            def evaluate_adaptation(self, state: dict[str, Any]) -> SchemaEvolutionResult:
+                return SchemaEvolutionResult(
+                    score=0.85, reasoning="Good", dimension_scores={"detection": 0.9},
+                    mutations_applied=2, stale_assumptions_detected=2,
+                    stale_assumptions_missed=0, recovery_actions_taken=2,
+                    recovery_actions_successful=2,
+                )
+
+        return _M()
+
+
+# ===========================================================================
+# AC-254: Tool-fragility data models
+# ===========================================================================
+
+
+class TestToolContract:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.tool_fragility import ToolContract
+
+        tc = ToolContract(
+            tool_name="search_api",
+            version=1,
+            input_schema={"query": "str"},
+            output_schema={"results": "list[str]"},
+            description="Search endpoint",
+        )
+        assert tc.tool_name == "search_api"
+        assert tc.version == 1
+
+    def test_to_dict_from_dict(self) -> None:
+        from autocontext.scenarios.tool_fragility import ToolContract
+
+        tc = ToolContract(
+            tool_name="api",
+            version=2,
+            input_schema={"q": "str"},
+            output_schema={"data": "list"},
+            description="API v2",
+        )
+        data = tc.to_dict()
+        restored = ToolContract.from_dict(data)
+        assert restored.tool_name == tc.tool_name
+        assert restored.version == tc.version
+        assert restored.input_schema == tc.input_schema
+
+
+class TestToolDrift:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.tool_fragility import ToolDrift
+
+        td = ToolDrift(
+            tool_name="search_api",
+            from_version=1,
+            to_version=2,
+            description="Response format changed from list to paginated",
+            drift_type="schema_change",
+            breaking=True,
+        )
+        assert td.drift_type == "schema_change"
+        assert td.breaking is True
+
+    def test_non_breaking_drift(self) -> None:
+        from autocontext.scenarios.tool_fragility import ToolDrift
+
+        td = ToolDrift(
+            tool_name="cache",
+            from_version=1,
+            to_version=2,
+            description="Added optional TTL parameter",
+            drift_type="additive_change",
+            breaking=False,
+        )
+        assert td.breaking is False
+
+    def test_to_dict_from_dict(self) -> None:
+        from autocontext.scenarios.tool_fragility import ToolDrift
+
+        td = ToolDrift(
+            tool_name="api",
+            from_version=1,
+            to_version=2,
+            description="changed",
+            drift_type="schema_change",
+            breaking=True,
+        )
+        data = td.to_dict()
+        restored = ToolDrift.from_dict(data)
+        assert restored.tool_name == td.tool_name
+        assert restored.drift_type == td.drift_type
+        assert restored.breaking is True
+
+
+class TestFailureAttribution:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.tool_fragility import FailureAttribution
+
+        fa = FailureAttribution(
+            step=3,
+            failure_class="tool_failure",
+            description="API returned unexpected schema",
+            tool_name="search_api",
+            recoverable=True,
+        )
+        assert fa.failure_class == "tool_failure"
+        assert fa.recoverable is True
+
+    def test_valid_failure_classes(self) -> None:
+        from autocontext.scenarios.tool_fragility import FAILURE_CLASSES, FailureAttribution
+
+        for fc in FAILURE_CLASSES:
+            fa = FailureAttribution(
+                step=1, failure_class=fc, description="test",
+                tool_name="t", recoverable=True,
+            )
+            assert fa.failure_class == fc
+
+    def test_to_dict_from_dict(self) -> None:
+        from autocontext.scenarios.tool_fragility import FailureAttribution
+
+        fa = FailureAttribution(
+            step=5, failure_class="routing_failure",
+            description="Wrong tool selected", tool_name="api",
+            recoverable=False,
+        )
+        data = fa.to_dict()
+        restored = FailureAttribution.from_dict(data)
+        assert restored.failure_class == fa.failure_class
+        assert restored.recoverable is False
+
+
+class TestToolFragilityResult:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.tool_fragility import ToolFragilityResult
+
+        r = ToolFragilityResult(
+            score=0.7,
+            reasoning="Adapted to most drifts",
+            dimension_scores={"adaptation": 0.8, "waste_avoidance": 0.6},
+            drifts_injected=3,
+            drifts_detected=2,
+            drifts_adapted=2,
+            wasted_attempts=1,
+            failure_attributions=[],
+        )
+        assert r.score == 0.7
+        assert r.drifts_detected == 2
+        assert r.wasted_attempts == 1
+
+    def test_to_dict_from_dict(self) -> None:
+        from autocontext.scenarios.tool_fragility import FailureAttribution, ToolFragilityResult
+
+        r = ToolFragilityResult(
+            score=0.5,
+            reasoning="Poor",
+            dimension_scores={"adaptation": 0.3},
+            drifts_injected=4,
+            drifts_detected=1,
+            drifts_adapted=1,
+            wasted_attempts=3,
+            failure_attributions=[
+                FailureAttribution(
+                    step=2, failure_class="tool_failure",
+                    description="Schema mismatch", tool_name="api",
+                    recoverable=True,
+                ),
+            ],
+        )
+        data = r.to_dict()
+        restored = ToolFragilityResult.from_dict(data)
+        assert restored.score == r.score
+        assert restored.wasted_attempts == 3
+        assert len(restored.failure_attributions) == 1
+        assert restored.failure_attributions[0].failure_class == "tool_failure"
+
+
+# ===========================================================================
+# AC-254: ToolFragilityInterface ABC
+# ===========================================================================
+
+
+class TestToolFragilityInterfaceABC:
+    def test_cannot_instantiate_abc(self) -> None:
+        from autocontext.scenarios.tool_fragility import ToolFragilityInterface
+
+        with pytest.raises(TypeError, match="abstract"):
+            ToolFragilityInterface()  # type: ignore[abstract]
+
+    def test_concrete_subclass_instantiates(self) -> None:
+        mock = self._make_mock()
+        assert mock.name == "mock_tool_fragility"
+
+    def test_describe_scenario(self) -> None:
+        mock = self._make_mock()
+        assert isinstance(mock.describe_scenario(), str)
+
+    def test_get_tool_contracts(self) -> None:
+        from autocontext.scenarios.tool_fragility import ToolContract
+
+        mock = self._make_mock()
+        state = mock.initial_state()
+        contracts = mock.get_tool_contracts(state)
+        assert isinstance(contracts, list)
+        assert len(contracts) >= 1
+        assert all(isinstance(c, ToolContract) for c in contracts)
+
+    def test_get_drift_log(self) -> None:
+        from autocontext.scenarios.tool_fragility import ToolDrift
+
+        mock = self._make_mock()
+        state = mock.initial_state()
+        log = mock.get_drift_log(state)
+        assert isinstance(log, list)
+        assert all(isinstance(d, ToolDrift) for d in log)
+
+    def test_inject_drift(self) -> None:
+        from autocontext.scenarios.tool_fragility import ToolDrift
+
+        mock = self._make_mock()
+        state = mock.initial_state()
+        drift = ToolDrift(
+            tool_name="search_api", from_version=1, to_version=2,
+            description="Schema changed", drift_type="schema_change", breaking=True,
+        )
+        new_state = mock.inject_drift(state, drift)
+        assert isinstance(new_state, dict)
+
+    def test_attribute_failure(self) -> None:
+        from autocontext.scenarios.tool_fragility import FailureAttribution
+
+        mock = self._make_mock()
+        state = mock.initial_state()
+        attr = mock.attribute_failure(state, step=1, error="Schema mismatch")
+        assert isinstance(attr, FailureAttribution)
+        assert attr.failure_class in {
+            "routing_failure", "stale_instruction_failure",
+            "tool_failure", "stale_context_failure",
+        }
+
+    def test_evaluate_fragility(self) -> None:
+        from autocontext.scenarios.tool_fragility import ToolFragilityResult
+
+        mock = self._make_mock()
+        state = mock.initial_state()
+        result = mock.evaluate_fragility(state)
+        assert isinstance(result, ToolFragilityResult)
+        assert 0.0 <= result.score <= 1.0
+
+    def test_initial_state(self) -> None:
+        mock = self._make_mock()
+        state = mock.initial_state(seed=42)
+        assert isinstance(state, dict)
+
+    def _make_mock(self) -> Any:
+        from autocontext.scenarios.simulation import ActionResult, ActionSpec, EnvironmentSpec
+        from autocontext.scenarios.tool_fragility import (
+            FailureAttribution,
+            ToolContract,
+            ToolDrift,
+            ToolFragilityInterface,
+            ToolFragilityResult,
+        )
+
+        class _M(ToolFragilityInterface):
+            name = "mock_tool_fragility"
+
+            def describe_scenario(self) -> str:
+                return "Tools drift while task stays the same"
+
+            def describe_environment(self) -> EnvironmentSpec:
+                return EnvironmentSpec(
+                    name="mock_tool_fragility", description="drifting tools",
+                    available_actions=[ActionSpec(name="call_api", description="call API", parameters={})],
+                    initial_state_description="stable tools", success_criteria=["task completed"],
+                )
+
+            def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+                return {"tool_versions": {"search_api": 1}, "drifts": [], "seed": seed or 0}
+
+            def get_available_actions(self, state: dict[str, Any]) -> list:
+                return self.describe_environment().available_actions
+
+            def execute_action(self, state: dict[str, Any], action: Any) -> tuple:
+                return ActionResult(success=True, output="ok", state_changes={}), state
+
+            def is_terminal(self, state: Any) -> bool:
+                return False
+
+            def evaluate_trace(self, trace: Any, final_state: dict[str, Any]) -> Any:
+                from autocontext.scenarios.simulation import SimulationResult
+
+                return SimulationResult(
+                    score=1.0, reasoning="ok", dimension_scores={},
+                    workflow_complete=True, actions_taken=0, actions_successful=0,
+                )
+
+            def get_rubric(self) -> str:
+                return "Adaptation quality, waste avoidance"
+
+            def get_tool_contracts(self, state: dict[str, Any]) -> list[ToolContract]:
+                return [
+                    ToolContract(
+                        tool_name="search_api", version=1,
+                        input_schema={"query": "str"},
+                        output_schema={"results": "list"},
+                        description="Search API",
+                    ),
+                ]
+
+            def get_drift_log(self, state: dict[str, Any]) -> list[ToolDrift]:
+                return [
+                    ToolDrift(
+                        tool_name="search_api", from_version=1, to_version=2,
+                        description="Paginated response", drift_type="schema_change",
+                        breaking=True,
+                    ),
+                ]
+
+            def inject_drift(self, state: dict[str, Any], drift: ToolDrift) -> dict[str, Any]:
+                new_state = dict(state)
+                new_state.setdefault("drifts", []).append(drift.to_dict())
+                tv = dict(new_state.get("tool_versions", {}))
+                tv[drift.tool_name] = drift.to_version
+                new_state["tool_versions"] = tv
+                return new_state
+
+            def attribute_failure(
+                self, state: dict[str, Any], step: int, error: str
+            ) -> FailureAttribution:
+                return FailureAttribution(
+                    step=step, failure_class="tool_failure",
+                    description=error, tool_name="search_api",
+                    recoverable=True,
+                )
+
+            def evaluate_fragility(self, state: dict[str, Any]) -> ToolFragilityResult:
+                return ToolFragilityResult(
+                    score=0.75, reasoning="Adapted to most drifts",
+                    dimension_scores={"adaptation": 0.8},
+                    drifts_injected=2, drifts_detected=2, drifts_adapted=1,
+                    wasted_attempts=1, failure_attributions=[],
+                )
+
+        return _M()
+
+
+# ===========================================================================
+# Family registry integration
+# ===========================================================================
+
+
+class TestFamilyRegistration:
+    def test_schema_evolution_family_registered(self) -> None:
+        from autocontext.scenarios.families import get_family
+
+        family = get_family("schema_evolution")
+        assert family.name == "schema_evolution"
+        assert family.evaluation_mode == "schema_adaptation"
+
+    def test_schema_evolution_scenario_type_marker(self) -> None:
+        from autocontext.scenarios.families import get_family
+
+        family = get_family("schema_evolution")
+        assert family.scenario_type_marker == "schema_evolution"
+
+    def test_tool_fragility_family_registered(self) -> None:
+        from autocontext.scenarios.families import get_family
+
+        family = get_family("tool_fragility")
+        assert family.name == "tool_fragility"
+        assert family.evaluation_mode == "drift_adaptation"
+
+    def test_tool_fragility_scenario_type_marker(self) -> None:
+        from autocontext.scenarios.families import get_family
+
+        family = get_family("tool_fragility")
+        assert family.scenario_type_marker == "tool_fragility"
+
+    def test_detect_family_schema_evolution(self) -> None:
+        from autocontext.scenarios.families import detect_family
+
+        mock = TestSchemaEvolutionInterfaceABC()._make_mock()
+        family = detect_family(mock)
+        assert family is not None
+        assert family.name == "schema_evolution"
+
+    def test_detect_family_tool_fragility(self) -> None:
+        from autocontext.scenarios.families import detect_family
+
+        mock = TestToolFragilityInterfaceABC()._make_mock()
+        family = detect_family(mock)
+        assert family is not None
+        assert family.name == "tool_fragility"
+
+
+# ===========================================================================
+# Pipeline registry integration
+# ===========================================================================
+
+
+class TestSchemaEvolutionPipeline:
+    def test_pipeline_registered(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import has_pipeline
+
+        assert has_pipeline("schema_evolution") is True
+
+    def test_pipeline_spec_validation_valid(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        spec: dict[str, Any] = {
+            "description": "Schema changes during API migration",
+            "environment_description": "REST API backend",
+            "initial_state_description": "v1 schema active",
+            "mutations": [
+                {"version": 2, "description": "add priority field", "breaking": False},
+            ],
+            "success_criteria": ["Agent adapts to all schema versions"],
+            "actions": [{"name": "query_api"}],
+        }
+        errors = validate_for_family("schema_evolution", spec)
+        assert errors == []
+
+    def test_pipeline_spec_validation_missing_fields(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        spec: dict[str, Any] = {"description": "Schema changes"}
+        errors = validate_for_family("schema_evolution", spec)
+        assert len(errors) > 0
+        assert any("mutations" in e for e in errors)
+
+    def test_pipeline_spec_empty_mutations(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        spec: dict[str, Any] = {
+            "description": "Schema changes",
+            "environment_description": "backend",
+            "initial_state_description": "v1",
+            "mutations": [],
+            "success_criteria": ["adapted"],
+            "actions": [{"name": "query"}],
+        }
+        errors = validate_for_family("schema_evolution", spec)
+        assert any("mutations" in e and "empty" in e for e in errors)
+
+    def test_pipeline_source_validation(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+
+        source = '''
+from autocontext.scenarios.schema_evolution import SchemaEvolutionInterface
+
+class MyEvo(SchemaEvolutionInterface):
+    name = "my_evo"
+    def describe_scenario(self): return "scenario"
+    def describe_environment(self): pass
+    def initial_state(self, seed=None): return {}
+    def get_available_actions(self, state): return []
+    def execute_action(self, state, action): pass
+    def is_terminal(self, state): return False
+    def evaluate_trace(self, trace, final_state): pass
+    def get_rubric(self): return "rubric"
+    def get_schema_version(self, state): return 1
+    def get_mutation_log(self, state): return []
+    def apply_mutation(self, state, mutation): return state
+    def check_context_validity(self, state, assumptions): return []
+    def evaluate_adaptation(self, state): pass
+'''
+        errors = validate_source_for_family("schema_evolution", source)
+        assert errors == []
+
+    def test_pipeline_source_wrong_base_class(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+
+        source = '''
+class NotASchemaEvo:
+    pass
+'''
+        errors = validate_source_for_family("schema_evolution", source)
+        assert any("SchemaEvolutionInterface" in e for e in errors)
+
+
+class TestToolFragilityPipeline:
+    def test_pipeline_registered(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import has_pipeline
+
+        assert has_pipeline("tool_fragility") is True
+
+    def test_pipeline_spec_validation_valid(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        spec: dict[str, Any] = {
+            "description": "API contracts drift during migration",
+            "environment_description": "Microservice architecture",
+            "initial_state_description": "All tools stable at v1",
+            "tool_contracts": [
+                {"tool_name": "search_api", "version": 1, "description": "Search endpoint"},
+            ],
+            "success_criteria": ["Agent completes task despite tool changes"],
+            "actions": [{"name": "call_search"}],
+        }
+        errors = validate_for_family("tool_fragility", spec)
+        assert errors == []
+
+    def test_pipeline_spec_validation_missing_fields(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        spec: dict[str, Any] = {"description": "Tools drift"}
+        errors = validate_for_family("tool_fragility", spec)
+        assert len(errors) > 0
+        assert any("tool_contracts" in e for e in errors)
+
+    def test_pipeline_spec_empty_tool_contracts(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        spec: dict[str, Any] = {
+            "description": "Tools drift",
+            "environment_description": "microservices",
+            "initial_state_description": "stable",
+            "tool_contracts": [],
+            "success_criteria": ["adapted"],
+            "actions": [{"name": "call"}],
+        }
+        errors = validate_for_family("tool_fragility", spec)
+        assert any("tool_contracts" in e and "empty" in e for e in errors)
+
+    def test_pipeline_source_validation(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+
+        source = '''
+from autocontext.scenarios.tool_fragility import ToolFragilityInterface
+
+class MyFrag(ToolFragilityInterface):
+    name = "my_frag"
+    def describe_scenario(self): return "scenario"
+    def describe_environment(self): pass
+    def initial_state(self, seed=None): return {}
+    def get_available_actions(self, state): return []
+    def execute_action(self, state, action): pass
+    def is_terminal(self, state): return False
+    def evaluate_trace(self, trace, final_state): pass
+    def get_rubric(self): return "rubric"
+    def get_tool_contracts(self, state): return []
+    def get_drift_log(self, state): return []
+    def inject_drift(self, state, drift): return state
+    def attribute_failure(self, state, step, error): pass
+    def evaluate_fragility(self, state): pass
+'''
+        errors = validate_source_for_family("tool_fragility", source)
+        assert errors == []
+
+    def test_pipeline_source_wrong_base_class(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+
+        source = '''
+class NotAToolFragility:
+    pass
+'''
+        errors = validate_source_for_family("tool_fragility", source)
+        assert any("ToolFragilityInterface" in e for e in errors)
+
+
+# ===========================================================================
+# Cross-family mismatch
+# ===========================================================================
+
+
+# ===========================================================================
+# Classifier routing (hot path: classify)
+# ===========================================================================
+
+
+class TestClassifierRouting:
+    def test_classify_schema_evolution_description(self) -> None:
+        from autocontext.scenarios.custom.family_classifier import classify_scenario_family
+
+        result = classify_scenario_family(
+            "Schema changes mid-run and the agent must detect stale context and adapt to the new version"
+        )
+        assert result.family_name == "schema_evolution"
+        assert result.confidence > 0.3
+
+    def test_classify_tool_fragility_description(self) -> None:
+        from autocontext.scenarios.custom.family_classifier import classify_scenario_family
+
+        result = classify_scenario_family(
+            "API contract drift where tools change their response schema while the core task stays the same"
+        )
+        assert result.family_name == "tool_fragility"
+        assert result.confidence > 0.3
+
+    def test_route_schema_evolution(self) -> None:
+        from autocontext.scenarios.custom.family_classifier import classify_scenario_family, route_to_family
+
+        classification = classify_scenario_family(
+            "Detect stale context after a schema evolution with breaking change and field removed"
+        )
+        family = route_to_family(classification)
+        assert family.name == "schema_evolution"
+
+    def test_route_tool_fragility(self) -> None:
+        from autocontext.scenarios.custom.family_classifier import classify_scenario_family, route_to_family
+
+        classification = classify_scenario_family(
+            "Tool contract drift where the API response format changes between runs"
+        )
+        family = route_to_family(classification)
+        assert family.name == "tool_fragility"
+
+
+# ===========================================================================
+# Designer/spec parsing (hot path: design)
+# ===========================================================================
+
+
+class TestSchemaEvolutionDesigner:
+    def test_parse_spec(self) -> None:
+        from autocontext.scenarios.custom.schema_evolution_designer import (
+            SCHEMA_EVOLUTION_SPEC_END,
+            SCHEMA_EVOLUTION_SPEC_START,
+            parse_schema_evolution_spec,
+        )
+
+        raw = f"""{SCHEMA_EVOLUTION_SPEC_START}
+{{
+    "description": "API schema evolves",
+    "environment_description": "REST backend",
+    "initial_state_description": "v1 active",
+    "mutations": [
+        {{
+            "version": 2, "description": "add field",
+            "breaking": false, "fields_added": ["priority"],
+            "fields_removed": [], "fields_modified": {{}}
+        }}
+    ],
+    "success_criteria": ["adapted"],
+    "failure_modes": ["stale cache"],
+    "max_steps": 6,
+    "actions": [
+        {{
+            "name": "query_api", "description": "query endpoint",
+            "parameters": {{"endpoint": "string"}},
+            "preconditions": [], "effects": ["data_fetched"]
+        }}
+    ]
+}}
+{SCHEMA_EVOLUTION_SPEC_END}"""
+        spec = parse_schema_evolution_spec(raw)
+        assert spec.description == "API schema evolves"
+        assert len(spec.mutations) == 1
+        assert spec.mutations[0].version == 2
+
+    def test_design_fn_calls_llm(self) -> None:
+        import json
+
+        from autocontext.scenarios.custom.schema_evolution_designer import (
+            SCHEMA_EVOLUTION_SPEC_END,
+            SCHEMA_EVOLUTION_SPEC_START,
+            design_schema_evolution,
+        )
+
+        fake_spec = {
+            "description": "test",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "mutations": [{
+                "version": 2, "description": "add field", "breaking": False,
+                "fields_added": ["x"], "fields_removed": [], "fields_modified": {},
+            }],
+            "success_criteria": ["ok"],
+            "failure_modes": [],
+            "max_steps": 5,
+            "actions": [{"name": "query", "description": "q", "parameters": {}, "preconditions": [], "effects": []}],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return f"{SCHEMA_EVOLUTION_SPEC_START}\n{json.dumps(fake_spec)}\n{SCHEMA_EVOLUTION_SPEC_END}"
+
+        spec = design_schema_evolution("test description", fake_llm)
+        assert spec.description == "test"
+
+
+class TestToolFragilityDesigner:
+    def test_parse_spec(self) -> None:
+        from autocontext.scenarios.custom.tool_fragility_designer import (
+            TOOL_FRAGILITY_SPEC_END,
+            TOOL_FRAGILITY_SPEC_START,
+            parse_tool_fragility_spec,
+        )
+
+        raw = f"""{TOOL_FRAGILITY_SPEC_START}
+{{
+    "description": "API contracts drift",
+    "environment_description": "microservices",
+    "initial_state_description": "stable",
+    "tool_contracts": [
+        {{"tool_name": "search_api", "version": 1, "description": "Search endpoint"}}
+    ],
+    "success_criteria": ["adapted"],
+    "failure_modes": ["wrong tool selected"],
+    "max_steps": 8,
+    "actions": [
+        {{"name": "call_search", "description": "call search API", "parameters": {{}}, "preconditions": [], "effects": []}}
+    ]
+}}
+{TOOL_FRAGILITY_SPEC_END}"""
+        spec = parse_tool_fragility_spec(raw)
+        assert spec.description == "API contracts drift"
+        assert len(spec.tool_contracts) == 1
+        assert spec.tool_contracts[0].tool_name == "search_api"
+
+    def test_design_fn_calls_llm(self) -> None:
+        import json
+
+        from autocontext.scenarios.custom.tool_fragility_designer import (
+            TOOL_FRAGILITY_SPEC_END,
+            TOOL_FRAGILITY_SPEC_START,
+            design_tool_fragility,
+        )
+
+        fake_spec = {
+            "description": "test",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "tool_contracts": [{"tool_name": "api", "version": 1, "description": "d"}],
+            "success_criteria": ["ok"],
+            "failure_modes": [],
+            "max_steps": 5,
+            "actions": [{"name": "call", "description": "c", "parameters": {}, "preconditions": [], "effects": []}],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return f"{TOOL_FRAGILITY_SPEC_START}\n{json.dumps(fake_spec)}\n{TOOL_FRAGILITY_SPEC_END}"
+
+        spec = design_tool_fragility("test description", fake_llm)
+        assert spec.description == "test"
+
+
+# ===========================================================================
+# Codegen (hot path: generate source)
+# ===========================================================================
+
+
+class TestSchemaEvolutionCodegen:
+    def test_generate_class(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+        from autocontext.scenarios.custom.schema_evolution_codegen import generate_schema_evolution_class
+        from autocontext.scenarios.custom.schema_evolution_spec import SchemaEvolutionMutationModel, SchemaEvolutionSpec
+        from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+
+        spec = SchemaEvolutionSpec(
+            description="API schema evolves",
+            environment_description="REST backend",
+            initial_state_description="v1 active",
+            mutations=[
+                SchemaEvolutionMutationModel(
+                    version=2, description="add priority", breaking=False,
+                    fields_added=["priority"], fields_removed=[], fields_modified={},
+                ),
+            ],
+            success_criteria=["adapted"],
+            failure_modes=["stale cache"],
+            actions=[SimulationActionSpecModel(name="query", description="query endpoint", parameters={"endpoint": "string"})],
+            max_steps=6,
+        )
+        source = generate_schema_evolution_class(spec, "test_evo")
+        errors = validate_source_for_family("schema_evolution", source)
+        assert errors == [], f"Generated source has errors: {errors}"
+
+
+class TestToolFragilityCodegen:
+    def test_generate_class(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+        from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+        from autocontext.scenarios.custom.tool_fragility_codegen import generate_tool_fragility_class
+        from autocontext.scenarios.custom.tool_fragility_spec import ToolContractSpecModel, ToolFragilitySpec
+
+        spec = ToolFragilitySpec(
+            description="API contracts drift",
+            environment_description="microservices",
+            initial_state_description="stable",
+            tool_contracts=[
+                ToolContractSpecModel(tool_name="search_api", version=1, description="Search endpoint"),
+            ],
+            success_criteria=["adapted"],
+            failure_modes=["wrong tool"],
+            actions=[SimulationActionSpecModel(name="call", description="call API", parameters={})],
+            max_steps=8,
+        )
+        source = generate_tool_fragility_class(spec, "test_frag")
+        errors = validate_source_for_family("tool_fragility", source)
+        assert errors == [], f"Generated source has errors: {errors}"
+
+
+# ===========================================================================
+# Creator end-to-end (hot path: create → persist → load → register)
+# ===========================================================================
+
+
+class TestSchemaEvolutionCreator:
+    def test_create_and_persist(self, tmp_path: Path) -> None:
+        import json
+
+        from autocontext.scenarios.custom.schema_evolution_creator import SchemaEvolutionCreator
+        from autocontext.scenarios.custom.schema_evolution_designer import (
+            SCHEMA_EVOLUTION_SPEC_END,
+            SCHEMA_EVOLUTION_SPEC_START,
+        )
+        from autocontext.scenarios.schema_evolution import SchemaEvolutionInterface
+
+        fake_spec = {
+            "description": "test schema evo",
+            "environment_description": "env",
+            "initial_state_description": "v1",
+            "mutations": [{
+                "version": 2, "description": "add x", "breaking": False,
+                "fields_added": ["x"], "fields_removed": [], "fields_modified": {},
+            }],
+            "success_criteria": ["adapted"],
+            "failure_modes": [],
+            "max_steps": 5,
+            "actions": [{"name": "query", "description": "q", "parameters": {}, "preconditions": [], "effects": []}],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return f"{SCHEMA_EVOLUTION_SPEC_START}\n{json.dumps(fake_spec)}\n{SCHEMA_EVOLUTION_SPEC_END}"
+
+        creator = SchemaEvolutionCreator(fake_llm, tmp_path)
+        scenario = creator.create("test schema evo", name="test_schema_evo_scenario")
+
+        assert isinstance(scenario, SchemaEvolutionInterface)
+        scenario_dir = tmp_path / "_custom_scenarios" / "test_schema_evo_scenario"
+        assert (scenario_dir / "scenario.py").exists()
+        assert (scenario_dir / "spec.json").exists()
+        assert (scenario_dir / "scenario_type.txt").exists()
+        assert (scenario_dir / "scenario_type.txt").read_text().strip() == "schema_evolution"
+
+
+class TestToolFragilityCreator:
+    def test_create_and_persist(self, tmp_path: Path) -> None:
+        import json
+
+        from autocontext.scenarios.custom.tool_fragility_creator import ToolFragilityCreator
+        from autocontext.scenarios.custom.tool_fragility_designer import (
+            TOOL_FRAGILITY_SPEC_END,
+            TOOL_FRAGILITY_SPEC_START,
+        )
+        from autocontext.scenarios.tool_fragility import ToolFragilityInterface
+
+        fake_spec = {
+            "description": "test tool frag",
+            "environment_description": "env",
+            "initial_state_description": "stable",
+            "tool_contracts": [{"tool_name": "api", "version": 1, "description": "d"}],
+            "success_criteria": ["adapted"],
+            "failure_modes": [],
+            "max_steps": 5,
+            "actions": [{"name": "call", "description": "c", "parameters": {}, "preconditions": [], "effects": []}],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return f"{TOOL_FRAGILITY_SPEC_START}\n{json.dumps(fake_spec)}\n{TOOL_FRAGILITY_SPEC_END}"
+
+        creator = ToolFragilityCreator(fake_llm, tmp_path)
+        scenario = creator.create("test tool frag", name="test_tool_frag_scenario")
+
+        assert isinstance(scenario, ToolFragilityInterface)
+        scenario_dir = tmp_path / "_custom_scenarios" / "test_tool_frag_scenario"
+        assert (scenario_dir / "scenario.py").exists()
+        assert (scenario_dir / "spec.json").exists()
+        assert (scenario_dir / "scenario_type.txt").exists()
+        assert (scenario_dir / "scenario_type.txt").read_text().strip() == "tool_fragility"
+
+
+# ===========================================================================
+# Router dispatch from AgentTaskCreator (hot path: routing)
+# ===========================================================================
+
+
+class TestAgentTaskCreatorRouting:
+    def test_routes_to_schema_evolution(self, tmp_path: Path) -> None:
+        import json
+
+        from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
+        from autocontext.scenarios.custom.schema_evolution_designer import (
+            SCHEMA_EVOLUTION_SPEC_END,
+            SCHEMA_EVOLUTION_SPEC_START,
+        )
+        from autocontext.scenarios.schema_evolution import SchemaEvolutionInterface
+
+        fake_spec = {
+            "description": "schema evo routing test",
+            "environment_description": "env",
+            "initial_state_description": "v1",
+            "mutations": [{
+                "version": 2, "description": "add x", "breaking": False,
+                "fields_added": ["x"], "fields_removed": [], "fields_modified": {},
+            }],
+            "success_criteria": ["adapted"],
+            "failure_modes": [],
+            "max_steps": 5,
+            "actions": [{"name": "query", "description": "q", "parameters": {}, "preconditions": [], "effects": []}],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return f"{SCHEMA_EVOLUTION_SPEC_START}\n{json.dumps(fake_spec)}\n{SCHEMA_EVOLUTION_SPEC_END}"
+
+        creator = AgentTaskCreator(fake_llm, tmp_path)
+        scenario = creator.create(
+            "Schema mutation scenario where the database schema changes mid-run and the agent must detect stale assumptions"
+        )
+        assert isinstance(scenario, SchemaEvolutionInterface)
+
+    def test_routes_to_tool_fragility(self, tmp_path: Path) -> None:
+        import json
+
+        from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
+        from autocontext.scenarios.custom.tool_fragility_designer import (
+            TOOL_FRAGILITY_SPEC_END,
+            TOOL_FRAGILITY_SPEC_START,
+        )
+        from autocontext.scenarios.tool_fragility import ToolFragilityInterface
+
+        fake_spec = {
+            "description": "tool frag routing test",
+            "environment_description": "env",
+            "initial_state_description": "stable",
+            "tool_contracts": [{"tool_name": "api", "version": 1, "description": "d"}],
+            "success_criteria": ["adapted"],
+            "failure_modes": [],
+            "max_steps": 5,
+            "actions": [{"name": "call", "description": "c", "parameters": {}, "preconditions": [], "effects": []}],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return f"{TOOL_FRAGILITY_SPEC_START}\n{json.dumps(fake_spec)}\n{TOOL_FRAGILITY_SPEC_END}"
+
+        creator = AgentTaskCreator(fake_llm, tmp_path)
+        scenario = creator.create(
+            "Tool contract drift scenario where the API response schema changes while the core task remains the same"
+        )
+        assert isinstance(scenario, ToolFragilityInterface)
+
+
+# ===========================================================================
+# Cross-family mismatch
+# ===========================================================================
+
+
+class TestCrossFamilyMismatch:
+    def test_schema_evo_spec_through_tool_fragility_pipeline(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        evo_spec: dict[str, Any] = {
+            "description": "Schema changes",
+            "environment_description": "backend",
+            "initial_state_description": "v1",
+            "mutations": [{"version": 2, "description": "change", "breaking": False}],
+            "success_criteria": ["adapted"],
+            "actions": [{"name": "query"}],
+        }
+        errors = validate_for_family("tool_fragility", evo_spec)
+        assert len(errors) > 0, "Schema-evo spec should fail tool-fragility validation"
+
+    def test_tool_fragility_spec_through_schema_evo_pipeline(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        frag_spec: dict[str, Any] = {
+            "description": "Tools drift",
+            "environment_description": "microservices",
+            "initial_state_description": "stable",
+            "tool_contracts": [{"tool_name": "api", "version": 1, "description": "d"}],
+            "success_criteria": ["adapted"],
+            "actions": [{"name": "call"}],
+        }
+        errors = validate_for_family("schema_evolution", frag_spec)
+        assert len(errors) > 0, "Tool-fragility spec should fail schema-evo validation"

--- a/ts/src/scenarios/agent-task-creator.ts
+++ b/ts/src/scenarios/agent-task-creator.ts
@@ -25,9 +25,17 @@ import {
   InvestigationCreator,
 } from "./investigation-creator.js";
 import {
+  type SchemaEvolutionScenarioHandle,
+  SchemaEvolutionCreator,
+} from "./schema-evolution-creator.js";
+import {
   type SimulationScenarioHandle,
   SimulationCreator,
 } from "./simulation-creator.js";
+import {
+  type ToolFragilityScenarioHandle,
+  ToolFragilityCreator,
+} from "./tool-fragility-creator.js";
 import {
   type WorkflowScenarioHandle,
   WorkflowCreator,
@@ -43,7 +51,9 @@ export type CreatedScenario =
   | (AgentTaskInterface & { readonly name: string; readonly spec: AgentTaskSpec; readonly family?: "agent_task" })
   | ArtifactEditingScenarioHandle
   | InvestigationScenarioHandle
+  | SchemaEvolutionScenarioHandle
   | SimulationScenarioHandle
+  | ToolFragilityScenarioHandle
   | WorkflowScenarioHandle;
 
 export class AgentTaskCreator {
@@ -122,6 +132,20 @@ export class AgentTaskCreator {
     }
     if (family === "workflow") {
       return new WorkflowCreator({
+        provider: this.provider,
+        model: this.model,
+        knowledgeRoot: this.knowledgeRoot,
+      }).create(description, name);
+    }
+    if (family === "schema_evolution") {
+      return new SchemaEvolutionCreator({
+        provider: this.provider,
+        model: this.model,
+        knowledgeRoot: this.knowledgeRoot,
+      }).create(description, name);
+    }
+    if (family === "tool_fragility") {
+      return new ToolFragilityCreator({
         provider: this.provider,
         model: this.model,
         knowledgeRoot: this.knowledgeRoot,

--- a/ts/src/scenarios/families.ts
+++ b/ts/src/scenarios/families.ts
@@ -4,7 +4,9 @@ export type ScenarioFamilyName =
   | "simulation"
   | "artifact_editing"
   | "investigation"
-  | "workflow";
+  | "workflow"
+  | "schema_evolution"
+  | "tool_fragility";
 
 export const SCENARIO_TYPE_MARKERS: Record<ScenarioFamilyName, string> = {
   game: "parametric",
@@ -13,6 +15,8 @@ export const SCENARIO_TYPE_MARKERS: Record<ScenarioFamilyName, string> = {
   artifact_editing: "artifact_editing",
   investigation: "investigation",
   workflow: "workflow",
+  schema_evolution: "schema_evolution",
+  tool_fragility: "tool_fragility",
 };
 
 export function getScenarioTypeMarker(family: ScenarioFamilyName): string {

--- a/ts/src/scenarios/family-classifier.ts
+++ b/ts/src/scenarios/family-classifier.ts
@@ -175,6 +175,40 @@ const WORKFLOW_SIGNALS: Record<string, number> = {
   "multi-step transaction": 2.0,
 };
 
+const SCHEMA_EVOLUTION_SIGNALS: Record<string, number> = {
+  "schema evolv": 2.0,
+  "schema evolution": 2.0,
+  "stale context": 2.0,
+  "schema migration": 2.0,
+  "breaking change": 2.0,
+  "schema version": 2.0,
+  "field removed": 1.5,
+  "field added": 1.5,
+  "field renamed": 1.5,
+  "context invalidat": 2.0,
+  "stale assumption": 2.0,
+  "data model change": 1.5,
+  "schema drift": 1.5,
+  "backwards compat": 1.5,
+};
+
+const TOOL_FRAGILITY_SIGNALS: Record<string, number> = {
+  "tool drift": 2.0,
+  "api contract": 2.0,
+  "tool fragility": 2.0,
+  "environment drift": 2.0,
+  "broken tool": 2.0,
+  "tool version": 1.5,
+  "api change": 1.5,
+  "response format change": 2.0,
+  "tool adapt": 1.5,
+  "tool break": 1.5,
+  "contract drift": 2.0,
+  "endpoint deprecat": 1.5,
+  "api deprecat": 1.5,
+  "tool failure": 1.5,
+};
+
 const FAMILY_SIGNAL_GROUPS: Record<ScenarioFamilyName, Record<string, number>> = {
   game: GAME_SIGNALS,
   agent_task: AGENT_TASK_SIGNALS,
@@ -182,6 +216,8 @@ const FAMILY_SIGNAL_GROUPS: Record<ScenarioFamilyName, Record<string, number>> =
   artifact_editing: ARTIFACT_EDITING_SIGNALS,
   investigation: INVESTIGATION_SIGNALS,
   workflow: WORKFLOW_SIGNALS,
+  schema_evolution: SCHEMA_EVOLUTION_SIGNALS,
+  tool_fragility: TOOL_FRAGILITY_SIGNALS,
 };
 
 const DEFAULT_FAMILY_NAME: ScenarioFamilyName = "agent_task";

--- a/ts/src/scenarios/family-pipeline.ts
+++ b/ts/src/scenarios/family-pipeline.ts
@@ -3,7 +3,9 @@ import { ArtifactEditingSpecSchema, type ArtifactEditingSpec } from "./artifact-
 import { validateSpec as validateAgentTaskSpec } from "./agent-task-validator.js";
 import { type ScenarioFamilyName } from "./families.js";
 import { InvestigationSpecSchema, type InvestigationSpec } from "./investigation-spec.js";
+import { SchemaEvolutionSpecSchema, type SchemaEvolutionSpec } from "./schema-evolution-spec.js";
 import { SimulationSpecSchema, type SimulationSpec } from "./simulation-spec.js";
+import { ToolFragilitySpecSchema, type ToolFragilitySpec } from "./tool-fragility-spec.js";
 import { WorkflowSpecSchema, type WorkflowSpec } from "./workflow-spec.js";
 
 export interface FamilyPipeline<TSpec> {
@@ -83,12 +85,40 @@ const workflowPipeline: FamilyPipeline<WorkflowSpec> = {
   },
 };
 
+const schemaEvolutionPipeline: FamilyPipeline<SchemaEvolutionSpec> = {
+  familyName: "schema_evolution",
+  validateSpec(spec: SchemaEvolutionSpec): string[] {
+    const result = SchemaEvolutionSpecSchema.safeParse(spec);
+    if (!result.success) {
+      return result.error.issues.map(
+        (issue) => `${issue.path.join(".")}: ${issue.message}`,
+      );
+    }
+    return [];
+  },
+};
+
+const toolFragilityPipeline: FamilyPipeline<ToolFragilitySpec> = {
+  familyName: "tool_fragility",
+  validateSpec(spec: ToolFragilitySpec): string[] {
+    const result = ToolFragilitySpecSchema.safeParse(spec);
+    if (!result.success) {
+      return result.error.issues.map(
+        (issue) => `${issue.path.join(".")}: ${issue.message}`,
+      );
+    }
+    return [];
+  },
+};
+
 const PIPELINE_REGISTRY = {
   agent_task: agentTaskPipeline,
   simulation: simulationPipeline,
   artifact_editing: artifactEditingPipeline,
   investigation: investigationPipeline,
   workflow: workflowPipeline,
+  schema_evolution: schemaEvolutionPipeline,
+  tool_fragility: toolFragilityPipeline,
 } as const;
 
 export function hasPipeline(family: string): family is keyof typeof PIPELINE_REGISTRY {
@@ -104,7 +134,14 @@ export function getPipeline(family: string): (typeof PIPELINE_REGISTRY)[keyof ty
 
 export function validateForFamily(
   family: string,
-  spec: AgentTaskSpec | SimulationSpec | ArtifactEditingSpec | InvestigationSpec | WorkflowSpec,
+  spec:
+    | AgentTaskSpec
+    | SimulationSpec
+    | ArtifactEditingSpec
+    | InvestigationSpec
+    | WorkflowSpec
+    | SchemaEvolutionSpec
+    | ToolFragilitySpec,
 ): string[] {
   const pipeline = getPipeline(family);
   return pipeline.validateSpec(spec as never);

--- a/ts/src/scenarios/schema-evolution-creator.ts
+++ b/ts/src/scenarios/schema-evolution-creator.ts
@@ -1,0 +1,269 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { LLMProvider } from "../types/index.js";
+import { validateForFamily } from "./family-pipeline.js";
+import { getScenarioTypeMarker } from "./families.js";
+import type { SchemaEvolutionSpec } from "./schema-evolution-spec.js";
+import { designSchemaEvolution } from "./schema-evolution-designer.js";
+
+export interface SchemaEvolutionCreatorOpts {
+  provider: LLMProvider;
+  model?: string;
+  knowledgeRoot: string;
+}
+
+export interface SchemaEvolutionScenarioHandle {
+  family: "schema_evolution";
+  name: string;
+  spec: SchemaEvolutionSpec;
+}
+
+function className(name: string): string {
+  return name
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join("") + "SchemaEvolution";
+}
+
+function generateScenarioSource(spec: SchemaEvolutionSpec, name: string): string {
+  const actions = spec.actions
+    .map((action) => `            ActionSpec(name=${JSON.stringify(action.name)}, description=${JSON.stringify(action.description)}, parameters=${JSON.stringify(action.parameters)}, preconditions=${JSON.stringify(action.preconditions)}, effects=${JSON.stringify(action.effects)})`)
+    .join(",\n");
+  const mutations = JSON.stringify(
+    spec.mutations.map((mutation) => ({
+      version: mutation.version,
+      description: mutation.description,
+      fields_added: mutation.fieldsAdded,
+      fields_removed: mutation.fieldsRemoved,
+      fields_modified: mutation.fieldsModified,
+      breaking: mutation.breaking,
+    })),
+  );
+  const requiredActions = JSON.stringify(spec.actions.map((action) => action.name));
+  return `from __future__ import annotations
+
+from typing import Any
+
+from autocontext.scenarios.schema_evolution import ContextValidity, SchemaEvolutionInterface, SchemaEvolutionResult, SchemaMutation
+from autocontext.scenarios.simulation import Action, ActionResult, ActionSpec, ActionTrace, EnvironmentSpec, SimulationResult
+
+
+class ${className(name)}(SchemaEvolutionInterface):
+    name = ${JSON.stringify(name)}
+    _mutations_spec = ${mutations}
+
+    def describe_scenario(self) -> str:
+        return ${JSON.stringify(spec.description)}
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name=${JSON.stringify(name)},
+            description=${JSON.stringify(spec.environmentDescription)},
+            available_actions=[
+${actions}
+            ],
+            initial_state_description=${JSON.stringify(spec.initialStateDescription)},
+            success_criteria=${JSON.stringify(spec.successCriteria)},
+            failure_modes=${JSON.stringify(spec.failureModes)},
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {
+            "seed": seed or 0,
+            "step": 0,
+            "schema_version": 1,
+            "mutations_applied": [],
+            "completed_actions": [],
+            "failed_actions": [],
+            "assumptions_checked": [],
+            "stale_detected": 0,
+            "stale_missed": 0,
+            "recovery_taken": 0,
+            "recovery_successful": 0,
+        }
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        completed = set(state.get("completed_actions", []))
+        return [s for s in self.describe_environment().available_actions if s.name not in completed]
+
+    def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+        specs = {s.name: s for s in self.describe_environment().available_actions}
+        spec = specs.get(action.name)
+        if spec is None:
+            return False, f"unknown action: {action.name}"
+        completed = set(state.get("completed_actions", []))
+        for req in spec.preconditions:
+            if req not in completed:
+                return False, f"precondition not met for {action.name}: {req}"
+        return True, ""
+
+    def execute_action(self, state: dict[str, Any], action: Action) -> tuple[ActionResult, dict[str, Any]]:
+        valid, reason = self.validate_action(state, action)
+        next_state = dict(state)
+        if not valid:
+            next_state["failed_actions"] = [*state.get("failed_actions", []), action.name]
+            return ActionResult(success=False, output="", state_changes={}, error=reason), next_state
+
+        next_state["completed_actions"] = [*state.get("completed_actions", []), action.name]
+        pending = [m for m in self._mutations_spec if m["version"] > state.get("schema_version", 1)]
+        if pending:
+            m = pending[0]
+            mutation = SchemaMutation(
+                version=m["version"],
+                description=m["description"],
+                fields_added=m["fields_added"],
+                fields_removed=m["fields_removed"],
+                fields_modified=m["fields_modified"],
+                breaking=m["breaking"],
+            )
+            next_state = self.apply_mutation(next_state, mutation)
+
+        return (
+            ActionResult(
+                success=True,
+                output=f"executed {action.name} (schema v{next_state.get('schema_version', 1)})",
+                state_changes={"schema_version": next_state.get("schema_version", 1)},
+            ),
+            next_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        required = set(${requiredActions})
+        completed = set(state.get("completed_actions", []))
+        max_version = max((m["version"] for m in self._mutations_spec), default=1)
+        return required.issubset(completed) or state.get("schema_version", 1) >= max_version or state.get("step", 0) >= ${spec.maxSteps}
+
+    def get_schema_version(self, state: dict[str, Any]) -> int:
+        return state.get("schema_version", 1)
+
+    def get_mutation_log(self, state: dict[str, Any]) -> list[SchemaMutation]:
+        return [SchemaMutation.from_dict(m) for m in state.get("mutations_applied", [])]
+
+    def apply_mutation(self, state: dict[str, Any], mutation: SchemaMutation) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["schema_version"] = mutation.version
+        next_state["mutations_applied"] = [*state.get("mutations_applied", []), mutation.to_dict()]
+        return next_state
+
+    def check_context_validity(self, state: dict[str, Any], assumptions: list[str]) -> list[ContextValidity]:
+        version = state.get("schema_version", 1)
+        removed_fields: set[str] = set()
+        for mutation in state.get("mutations_applied", []):
+            removed_fields.update(mutation.get("fields_removed", []))
+        results: list[ContextValidity] = []
+        for assumption in assumptions:
+            invalidated = any(field in assumption.lower() for field in removed_fields)
+            results.append(ContextValidity(
+                assumption=assumption,
+                still_valid=not invalidated,
+                invalidated_by_version=version if invalidated else None,
+            ))
+        return results
+
+    def evaluate_adaptation(self, state: dict[str, Any]) -> SchemaEvolutionResult:
+        mutations_applied = len(state.get("mutations_applied", []))
+        stale_detected = state.get("stale_detected", 0)
+        stale_missed = state.get("stale_missed", 0)
+        recovery_taken = state.get("recovery_taken", 0)
+        recovery_successful = state.get("recovery_successful", 0)
+        detection_rate = stale_detected / max(stale_detected + stale_missed, 1)
+        recovery_rate = recovery_successful / max(recovery_taken, 1)
+        score = round(detection_rate * 0.6 + recovery_rate * 0.4, 4)
+        return SchemaEvolutionResult(
+            score=score,
+            reasoning=f"Detected {stale_detected}/{stale_detected + stale_missed} stale assumptions.",
+            dimension_scores={"detection": round(detection_rate, 4), "recovery": round(recovery_rate, 4)},
+            mutations_applied=mutations_applied,
+            stale_assumptions_detected=stale_detected,
+            stale_assumptions_missed=stale_missed,
+            recovery_actions_taken=recovery_taken,
+            recovery_actions_successful=recovery_successful,
+        )
+
+    def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+        adaptation = self.evaluate_adaptation(final_state)
+        action_success = trace.success_rate
+        score = round(adaptation.score * 0.7 + action_success * 0.3, 4)
+        return SimulationResult(
+            score=score,
+            reasoning=adaptation.reasoning,
+            dimension_scores={"detection": adaptation.dimension_scores.get("detection", 0.0), "recovery": adaptation.dimension_scores.get("recovery", 0.0), "action_success": round(action_success, 4)},
+            workflow_complete=adaptation.stale_assumptions_missed == 0,
+            actions_taken=len(trace.records),
+            actions_successful=sum(1 for record in trace.records if record.result.success),
+            recovery_attempts=adaptation.recovery_actions_taken,
+            rollback_quality=adaptation.dimension_scores.get("recovery", 0.0),
+        )
+
+    def get_rubric(self) -> str:
+        return "Evaluate on stale-assumption detection, adaptation to schema changes, and recovery quality."
+
+    def max_steps(self) -> int:
+        return ${spec.maxSteps}
+`;
+}
+
+export class SchemaEvolutionCreator {
+  private provider: LLMProvider;
+  private model: string;
+  private knowledgeRoot: string;
+
+  constructor(opts: SchemaEvolutionCreatorOpts) {
+    this.provider = opts.provider;
+    this.model = opts.model ?? opts.provider.defaultModel();
+    this.knowledgeRoot = opts.knowledgeRoot;
+  }
+
+  async create(description: string, name: string): Promise<SchemaEvolutionScenarioHandle> {
+    const llmFn = async (system: string, user: string): Promise<string> => {
+      const result = await this.provider.complete({
+        systemPrompt: system,
+        userPrompt: user,
+        model: this.model,
+      });
+      return result.text;
+    };
+    const spec = await designSchemaEvolution(description, llmFn);
+    const errors = validateForFamily("schema_evolution", spec);
+    if (errors.length > 0) {
+      throw new Error(`schema_evolution spec validation failed: ${errors.join("; ")}`);
+    }
+
+    const customDir = join(this.knowledgeRoot, "_custom_scenarios");
+    const scenarioDir = join(customDir, name);
+    if (!existsSync(scenarioDir)) mkdirSync(scenarioDir, { recursive: true });
+
+    writeFileSync(join(scenarioDir, "scenario.py"), generateScenarioSource(spec, name), "utf-8");
+    writeFileSync(join(scenarioDir, "scenario_type.txt"), getScenarioTypeMarker("schema_evolution"), "utf-8");
+    writeFileSync(
+      join(scenarioDir, "spec.json"),
+      JSON.stringify(
+        {
+          name,
+          scenario_type: getScenarioTypeMarker("schema_evolution"),
+          description: spec.description,
+          environment_description: spec.environmentDescription,
+          initial_state_description: spec.initialStateDescription,
+          mutations: spec.mutations.map((mutation) => ({
+            version: mutation.version,
+            description: mutation.description,
+            breaking: mutation.breaking,
+            fields_added: mutation.fieldsAdded,
+            fields_removed: mutation.fieldsRemoved,
+            fields_modified: mutation.fieldsModified,
+          })),
+          success_criteria: spec.successCriteria,
+          failure_modes: spec.failureModes,
+          max_steps: spec.maxSteps,
+          actions: spec.actions,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    return { family: "schema_evolution", name, spec };
+  }
+}

--- a/ts/src/scenarios/schema-evolution-designer.ts
+++ b/ts/src/scenarios/schema-evolution-designer.ts
@@ -1,0 +1,118 @@
+import type { SchemaEvolutionSpec } from "./schema-evolution-spec.js";
+import { parseRawSchemaEvolutionSpec } from "./schema-evolution-spec.js";
+
+export const SCHEMA_EVOLUTION_SPEC_START = "<!-- SCHEMA_EVOLUTION_SPEC_START -->";
+export const SCHEMA_EVOLUTION_SPEC_END = "<!-- SCHEMA_EVOLUTION_SPEC_END -->";
+
+const EXAMPLE_SPEC = {
+  description: "API schema evolves from v1 to v3 during a data migration task.",
+  environment_description: "REST API backend with versioned schemas.",
+  initial_state_description: "v1 schema is active; all endpoints respond with v1 format.",
+  mutations: [
+    {
+      version: 2,
+      description: "Add 'priority' field to task objects.",
+      breaking: false,
+      fields_added: ["priority"],
+      fields_removed: [],
+      fields_modified: {},
+    },
+    {
+      version: 3,
+      description: "Rename 'status' to 'state' and remove 'legacy_id'.",
+      breaking: true,
+      fields_added: ["state"],
+      fields_removed: ["status", "legacy_id"],
+      fields_modified: {},
+    },
+  ],
+  success_criteria: [
+    "detect each schema version change",
+    "discard stale assumptions about removed fields",
+  ],
+  failure_modes: ["using removed fields after mutation", "caching stale schema"],
+  max_steps: 8,
+  actions: [
+    {
+      name: "query_api",
+      description: "Query an API endpoint and observe the response schema.",
+      parameters: { endpoint: "string" },
+      preconditions: [],
+      effects: ["schema_observed"],
+    },
+    {
+      name: "validate_schema",
+      description: "Check whether the current schema matches expectations.",
+      parameters: {},
+      preconditions: ["query_api"],
+      effects: ["schema_validated"],
+    },
+  ],
+};
+
+export const SCHEMA_EVOLUTION_DESIGNER_SYSTEM = `You are a scenario designer for autocontext.
+Given a natural-language request for a schema-evolution or stale-context scenario, produce a SchemaEvolutionSpec JSON.
+
+Wrap the output in delimiters:
+${SCHEMA_EVOLUTION_SPEC_START}
+{ ... }
+${SCHEMA_EVOLUTION_SPEC_END}
+
+Schema:
+{
+  "description": "scenario summary",
+  "environment_description": "what system has evolving schemas",
+  "initial_state_description": "starting state with initial schema version",
+  "mutations": [
+    {
+      "version": 2,
+      "description": "what changed",
+      "breaking": true,
+      "fields_added": ["field"],
+      "fields_removed": ["field"],
+      "fields_modified": {"field": "old_type -> new_type"}
+    }
+  ],
+  "success_criteria": ["criterion"],
+  "failure_modes": ["failure mode"],
+  "max_steps": 8,
+  "actions": [
+    {
+      "name": "snake_case",
+      "description": "what the action does",
+      "parameters": {"param": "type"},
+      "preconditions": [],
+      "effects": ["effect"]
+    }
+  ]
+}
+
+Rules:
+- include at least one breaking mutation
+- model the scenario around detecting and adapting to schema changes
+- include at least two actions and two mutations
+
+Example:
+${SCHEMA_EVOLUTION_SPEC_START}
+${JSON.stringify(EXAMPLE_SPEC, null, 2)}
+${SCHEMA_EVOLUTION_SPEC_END}
+`;
+
+export function parseSchemaEvolutionSpec(text: string): SchemaEvolutionSpec {
+  const startIdx = text.indexOf(SCHEMA_EVOLUTION_SPEC_START);
+  const endIdx = text.indexOf(SCHEMA_EVOLUTION_SPEC_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
+    throw new Error("response does not contain SCHEMA_EVOLUTION_SPEC delimiters");
+  }
+  const raw = text.slice(startIdx + SCHEMA_EVOLUTION_SPEC_START.length, endIdx).trim();
+  return parseRawSchemaEvolutionSpec(JSON.parse(raw) as Record<string, unknown>);
+}
+
+export async function designSchemaEvolution(
+  description: string,
+  llmFn: (system: string, user: string) => Promise<string>,
+): Promise<SchemaEvolutionSpec> {
+  return parseSchemaEvolutionSpec(
+    await llmFn(SCHEMA_EVOLUTION_DESIGNER_SYSTEM, `User description:\n${description}`),
+  );
+}

--- a/ts/src/scenarios/schema-evolution-spec.ts
+++ b/ts/src/scenarios/schema-evolution-spec.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { SimulationActionSpecSchema } from "./simulation-spec.js";
+
+export const SchemaEvolutionMutationSchema = z.object({
+  version: z.number().int().positive(),
+  description: z.string().min(1),
+  breaking: z.boolean(),
+  fieldsAdded: z.array(z.string().min(1)).default([]),
+  fieldsRemoved: z.array(z.string().min(1)).default([]),
+  fieldsModified: z.record(z.string()).default({}),
+});
+
+export const SchemaEvolutionSpecSchema = z.object({
+  description: z.string().min(1),
+  environmentDescription: z.string().min(1),
+  initialStateDescription: z.string().min(1),
+  mutations: z.array(SchemaEvolutionMutationSchema).min(2),
+  successCriteria: z.array(z.string().min(1)).min(1),
+  failureModes: z.array(z.string().min(1)).default([]),
+  actions: z.array(SimulationActionSpecSchema).min(2),
+  maxSteps: z.number().int().positive().default(10),
+});
+
+export type SchemaEvolutionMutation = z.infer<typeof SchemaEvolutionMutationSchema>;
+export type SchemaEvolutionSpec = z.infer<typeof SchemaEvolutionSpecSchema>;
+
+export function parseRawSchemaEvolutionSpec(data: Record<string, unknown>): SchemaEvolutionSpec {
+  return SchemaEvolutionSpecSchema.parse({
+    description: data.description,
+    environmentDescription: data.environment_description,
+    initialStateDescription: data.initial_state_description,
+    mutations: Array.isArray(data.mutations)
+      ? data.mutations.map((mutation) => {
+          const raw = mutation as Record<string, unknown>;
+          return {
+            version: raw.version,
+            description: raw.description,
+            breaking: raw.breaking,
+            fieldsAdded: raw.fields_added ?? [],
+            fieldsRemoved: raw.fields_removed ?? [],
+            fieldsModified: raw.fields_modified ?? {},
+          };
+        })
+      : data.mutations,
+    successCriteria: data.success_criteria,
+    failureModes: data.failure_modes ?? [],
+    actions: data.actions,
+    maxSteps: data.max_steps ?? 10,
+  });
+}

--- a/ts/src/scenarios/tool-fragility-creator.ts
+++ b/ts/src/scenarios/tool-fragility-creator.ts
@@ -1,0 +1,251 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { LLMProvider } from "../types/index.js";
+import { validateForFamily } from "./family-pipeline.js";
+import { getScenarioTypeMarker } from "./families.js";
+import type { ToolFragilitySpec } from "./tool-fragility-spec.js";
+import { designToolFragility } from "./tool-fragility-designer.js";
+
+export interface ToolFragilityCreatorOpts {
+  provider: LLMProvider;
+  model?: string;
+  knowledgeRoot: string;
+}
+
+export interface ToolFragilityScenarioHandle {
+  family: "tool_fragility";
+  name: string;
+  spec: ToolFragilitySpec;
+}
+
+function className(name: string): string {
+  return name
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join("") + "ToolFragility";
+}
+
+function generateScenarioSource(spec: ToolFragilitySpec, name: string): string {
+  const actions = spec.actions
+    .map((action) => `            ActionSpec(name=${JSON.stringify(action.name)}, description=${JSON.stringify(action.description)}, parameters=${JSON.stringify(action.parameters)}, preconditions=${JSON.stringify(action.preconditions)}, effects=${JSON.stringify(action.effects)})`)
+    .join(",\n");
+  const toolContracts = JSON.stringify(
+    spec.toolContracts.map((toolContract) => ({
+      tool_name: toolContract.toolName,
+      version: toolContract.version,
+      description: toolContract.description,
+    })),
+  );
+  const requiredActions = JSON.stringify(spec.actions.map((action) => action.name));
+  return `from __future__ import annotations
+
+from typing import Any
+
+from autocontext.scenarios.simulation import Action, ActionResult, ActionSpec, ActionTrace, EnvironmentSpec, SimulationResult
+from autocontext.scenarios.tool_fragility import FailureAttribution, ToolContract, ToolDrift, ToolFragilityInterface, ToolFragilityResult
+
+
+class ${className(name)}(ToolFragilityInterface):
+    name = ${JSON.stringify(name)}
+    _tool_contracts_spec = ${toolContracts}
+
+    def describe_scenario(self) -> str:
+        return ${JSON.stringify(spec.description)}
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name=${JSON.stringify(name)},
+            description=${JSON.stringify(spec.environmentDescription)},
+            available_actions=[
+${actions}
+            ],
+            initial_state_description=${JSON.stringify(spec.initialStateDescription)},
+            success_criteria=${JSON.stringify(spec.successCriteria)},
+            failure_modes=${JSON.stringify(spec.failureModes)},
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {
+            "seed": seed or 0,
+            "step": 0,
+            "tool_versions": {tc["tool_name"]: tc["version"] for tc in self._tool_contracts_spec},
+            "drifts_applied": [],
+            "completed_actions": [],
+            "failed_actions": [],
+            "drifts_detected": 0,
+            "drifts_adapted": 0,
+            "wasted_attempts": 0,
+            "failure_attributions": [],
+        }
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        completed = set(state.get("completed_actions", []))
+        return [s for s in self.describe_environment().available_actions if s.name not in completed]
+
+    def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+        specs = {s.name: s for s in self.describe_environment().available_actions}
+        spec = specs.get(action.name)
+        if spec is None:
+            return False, f"unknown action: {action.name}"
+        completed = set(state.get("completed_actions", []))
+        for req in spec.preconditions:
+            if req not in completed:
+                return False, f"precondition not met for {action.name}: {req}"
+        return True, ""
+
+    def execute_action(self, state: dict[str, Any], action: Action) -> tuple[ActionResult, dict[str, Any]]:
+        valid, reason = self.validate_action(state, action)
+        next_state = dict(state)
+        if not valid:
+            next_state["failed_actions"] = [*state.get("failed_actions", []), action.name]
+            next_state["wasted_attempts"] = state.get("wasted_attempts", 0) + 1
+            return ActionResult(success=False, output="", state_changes={}, error=reason), next_state
+
+        next_state["completed_actions"] = [*state.get("completed_actions", []), action.name]
+        return (
+            ActionResult(
+                success=True,
+                output=f"executed {action.name}",
+                state_changes={"completed_actions": list(next_state["completed_actions"])},
+            ),
+            next_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        required = set(${requiredActions})
+        completed = set(state.get("completed_actions", []))
+        return required.issubset(completed) or state.get("step", 0) >= ${spec.maxSteps}
+
+    def get_tool_contracts(self, state: dict[str, Any]) -> list[ToolContract]:
+        versions = state.get("tool_versions", {})
+        return [
+            ToolContract(
+                tool_name=tc["tool_name"],
+                version=versions.get(tc["tool_name"], tc["version"]),
+                input_schema={},
+                output_schema={},
+                description=tc["description"],
+            )
+            for tc in self._tool_contracts_spec
+        ]
+
+    def get_drift_log(self, state: dict[str, Any]) -> list[ToolDrift]:
+        return [ToolDrift.from_dict(drift) for drift in state.get("drifts_applied", [])]
+
+    def inject_drift(self, state: dict[str, Any], drift: ToolDrift) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["drifts_applied"] = [*state.get("drifts_applied", []), drift.to_dict()]
+        tool_versions = dict(state.get("tool_versions", {}))
+        tool_versions[drift.tool_name] = drift.to_version
+        next_state["tool_versions"] = tool_versions
+        return next_state
+
+    def attribute_failure(self, state: dict[str, Any], step: int, error: str) -> FailureAttribution:
+        drifts = state.get("drifts_applied", [])
+        if drifts:
+            return FailureAttribution(step=step, failure_class="tool_failure", description=error, tool_name=drifts[-1].get("tool_name", "unknown"), recoverable=True)
+        return FailureAttribution(step=step, failure_class="routing_failure", description=error, tool_name="unknown", recoverable=True)
+
+    def evaluate_fragility(self, state: dict[str, Any]) -> ToolFragilityResult:
+        drifts_injected = len(state.get("drifts_applied", []))
+        detected = state.get("drifts_detected", 0)
+        adapted = state.get("drifts_adapted", 0)
+        wasted = state.get("wasted_attempts", 0)
+        adaptation_rate = adapted / max(drifts_injected, 1)
+        waste_penalty = min(wasted * 0.1, 0.5)
+        score = round(max(0.0, adaptation_rate - waste_penalty), 4)
+        return ToolFragilityResult(
+            score=score,
+            reasoning=f"Adapted to {adapted}/{drifts_injected} drifts with {wasted} wasted attempts.",
+            dimension_scores={"adaptation": round(adaptation_rate, 4), "waste_avoidance": round(1.0 - waste_penalty, 4)},
+            drifts_injected=drifts_injected,
+            drifts_detected=detected,
+            drifts_adapted=adapted,
+            wasted_attempts=wasted,
+            failure_attributions=[FailureAttribution.from_dict(failure) for failure in state.get("failure_attributions", [])],
+        )
+
+    def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+        fragility = self.evaluate_fragility(final_state)
+        action_success = trace.success_rate
+        score = round(fragility.score * 0.7 + action_success * 0.3, 4)
+        return SimulationResult(
+            score=score,
+            reasoning=fragility.reasoning,
+            dimension_scores={"adaptation": fragility.dimension_scores.get("adaptation", 0.0), "waste_avoidance": fragility.dimension_scores.get("waste_avoidance", 0.0), "action_success": round(action_success, 4)},
+            workflow_complete=fragility.drifts_adapted == fragility.drifts_injected,
+            actions_taken=len(trace.records),
+            actions_successful=sum(1 for record in trace.records if record.result.success),
+            recovery_attempts=fragility.wasted_attempts,
+            rollback_quality=fragility.dimension_scores.get("waste_avoidance", 0.0),
+        )
+
+    def get_rubric(self) -> str:
+        return "Evaluate on drift detection, tool adaptation quality, and wasted attempt minimization."
+
+    def max_steps(self) -> int:
+        return ${spec.maxSteps}
+`;
+}
+
+export class ToolFragilityCreator {
+  private provider: LLMProvider;
+  private model: string;
+  private knowledgeRoot: string;
+
+  constructor(opts: ToolFragilityCreatorOpts) {
+    this.provider = opts.provider;
+    this.model = opts.model ?? opts.provider.defaultModel();
+    this.knowledgeRoot = opts.knowledgeRoot;
+  }
+
+  async create(description: string, name: string): Promise<ToolFragilityScenarioHandle> {
+    const llmFn = async (system: string, user: string): Promise<string> => {
+      const result = await this.provider.complete({
+        systemPrompt: system,
+        userPrompt: user,
+        model: this.model,
+      });
+      return result.text;
+    };
+    const spec = await designToolFragility(description, llmFn);
+    const errors = validateForFamily("tool_fragility", spec);
+    if (errors.length > 0) {
+      throw new Error(`tool_fragility spec validation failed: ${errors.join("; ")}`);
+    }
+
+    const customDir = join(this.knowledgeRoot, "_custom_scenarios");
+    const scenarioDir = join(customDir, name);
+    if (!existsSync(scenarioDir)) mkdirSync(scenarioDir, { recursive: true });
+
+    writeFileSync(join(scenarioDir, "scenario.py"), generateScenarioSource(spec, name), "utf-8");
+    writeFileSync(join(scenarioDir, "scenario_type.txt"), getScenarioTypeMarker("tool_fragility"), "utf-8");
+    writeFileSync(
+      join(scenarioDir, "spec.json"),
+      JSON.stringify(
+        {
+          name,
+          scenario_type: getScenarioTypeMarker("tool_fragility"),
+          description: spec.description,
+          environment_description: spec.environmentDescription,
+          initial_state_description: spec.initialStateDescription,
+          tool_contracts: spec.toolContracts.map((toolContract) => ({
+            tool_name: toolContract.toolName,
+            version: toolContract.version,
+            description: toolContract.description,
+          })),
+          success_criteria: spec.successCriteria,
+          failure_modes: spec.failureModes,
+          max_steps: spec.maxSteps,
+          actions: spec.actions,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    return { family: "tool_fragility", name, spec };
+  }
+}

--- a/ts/src/scenarios/tool-fragility-designer.ts
+++ b/ts/src/scenarios/tool-fragility-designer.ts
@@ -1,0 +1,101 @@
+import type { ToolFragilitySpec } from "./tool-fragility-spec.js";
+import { parseRawToolFragilitySpec } from "./tool-fragility-spec.js";
+
+export const TOOL_FRAGILITY_SPEC_START = "<!-- TOOL_FRAGILITY_SPEC_START -->";
+export const TOOL_FRAGILITY_SPEC_END = "<!-- TOOL_FRAGILITY_SPEC_END -->";
+
+const EXAMPLE_SPEC = {
+  description: "API contracts drift during a data processing pipeline.",
+  environment_description: "Microservice architecture with versioned API contracts.",
+  initial_state_description: "All tools at v1; pipeline runs successfully.",
+  tool_contracts: [
+    { tool_name: "search_api", version: 1, description: "Search endpoint returning flat list." },
+    { tool_name: "transform_api", version: 1, description: "Data transformation endpoint." },
+  ],
+  success_criteria: [
+    "complete the pipeline despite tool changes",
+    "detect and adapt to changed response formats",
+  ],
+  failure_modes: ["using stale response format", "selecting wrong tool"],
+  max_steps: 10,
+  actions: [
+    {
+      name: "call_search",
+      description: "Call the search API with a query.",
+      parameters: { query: "string" },
+      preconditions: [],
+      effects: ["search_results_obtained"],
+    },
+    {
+      name: "call_transform",
+      description: "Transform data using the transformation API.",
+      parameters: { data: "string" },
+      preconditions: ["call_search"],
+      effects: ["data_transformed"],
+    },
+  ],
+};
+
+export const TOOL_FRAGILITY_DESIGNER_SYSTEM = `You are a scenario designer for autocontext.
+Given a natural-language request for a tool-fragility or environment-drift scenario, produce a ToolFragilitySpec JSON.
+
+Wrap the output in delimiters:
+${TOOL_FRAGILITY_SPEC_START}
+{ ... }
+${TOOL_FRAGILITY_SPEC_END}
+
+Schema:
+{
+  "description": "scenario summary",
+  "environment_description": "what system has drifting tools",
+  "initial_state_description": "starting state with stable tools",
+  "tool_contracts": [
+    {
+      "tool_name": "api_name",
+      "version": 1,
+      "description": "what this tool does"
+    }
+  ],
+  "success_criteria": ["criterion"],
+  "failure_modes": ["failure mode"],
+  "max_steps": 10,
+  "actions": [
+    {
+      "name": "snake_case",
+      "description": "what the action does",
+      "parameters": {"param": "type"},
+      "preconditions": [],
+      "effects": ["effect"]
+    }
+  ]
+}
+
+Rules:
+- include at least two tool contracts
+- model the scenario around adapting to changed tool behavior
+- include at least two actions
+
+Example:
+${TOOL_FRAGILITY_SPEC_START}
+${JSON.stringify(EXAMPLE_SPEC, null, 2)}
+${TOOL_FRAGILITY_SPEC_END}
+`;
+
+export function parseToolFragilitySpec(text: string): ToolFragilitySpec {
+  const startIdx = text.indexOf(TOOL_FRAGILITY_SPEC_START);
+  const endIdx = text.indexOf(TOOL_FRAGILITY_SPEC_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
+    throw new Error("response does not contain TOOL_FRAGILITY_SPEC delimiters");
+  }
+  const raw = text.slice(startIdx + TOOL_FRAGILITY_SPEC_START.length, endIdx).trim();
+  return parseRawToolFragilitySpec(JSON.parse(raw) as Record<string, unknown>);
+}
+
+export async function designToolFragility(
+  description: string,
+  llmFn: (system: string, user: string) => Promise<string>,
+): Promise<ToolFragilitySpec> {
+  return parseToolFragilitySpec(
+    await llmFn(TOOL_FRAGILITY_DESIGNER_SYSTEM, `User description:\n${description}`),
+  );
+}

--- a/ts/src/scenarios/tool-fragility-spec.ts
+++ b/ts/src/scenarios/tool-fragility-spec.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { SimulationActionSpecSchema } from "./simulation-spec.js";
+
+export const ToolContractSpecSchema = z.object({
+  toolName: z.string().min(1),
+  version: z.number().int().positive(),
+  description: z.string().min(1),
+});
+
+export const ToolFragilitySpecSchema = z.object({
+  description: z.string().min(1),
+  environmentDescription: z.string().min(1),
+  initialStateDescription: z.string().min(1),
+  toolContracts: z.array(ToolContractSpecSchema).min(2),
+  successCriteria: z.array(z.string().min(1)).min(1),
+  failureModes: z.array(z.string().min(1)).default([]),
+  actions: z.array(SimulationActionSpecSchema).min(2),
+  maxSteps: z.number().int().positive().default(10),
+});
+
+export type ToolContractSpec = z.infer<typeof ToolContractSpecSchema>;
+export type ToolFragilitySpec = z.infer<typeof ToolFragilitySpecSchema>;
+
+export function parseRawToolFragilitySpec(data: Record<string, unknown>): ToolFragilitySpec {
+  return ToolFragilitySpecSchema.parse({
+    description: data.description,
+    environmentDescription: data.environment_description,
+    initialStateDescription: data.initial_state_description,
+    toolContracts: Array.isArray(data.tool_contracts)
+      ? data.tool_contracts.map((toolContract) => {
+          const raw = toolContract as Record<string, unknown>;
+          return {
+            toolName: raw.tool_name,
+            version: raw.version,
+            description: raw.description,
+          };
+        })
+      : data.tool_contracts,
+    successCriteria: data.success_criteria,
+    failureModes: data.failure_modes ?? [],
+    actions: data.actions,
+    maxSteps: data.max_steps ?? 10,
+  });
+}

--- a/ts/tests/agent-task-pipeline.test.ts
+++ b/ts/tests/agent-task-pipeline.test.ts
@@ -20,9 +20,17 @@ import {
   INVESTIGATION_SPEC_START,
 } from "../src/scenarios/investigation-designer.js";
 import {
+  SCHEMA_EVOLUTION_SPEC_END,
+  SCHEMA_EVOLUTION_SPEC_START,
+} from "../src/scenarios/schema-evolution-designer.js";
+import {
   SIM_SPEC_END,
   SIM_SPEC_START,
 } from "../src/scenarios/simulation-designer.js";
+import {
+  TOOL_FRAGILITY_SPEC_END,
+  TOOL_FRAGILITY_SPEC_START,
+} from "../src/scenarios/tool-fragility-designer.js";
 import {
   WORKFLOW_SPEC_END,
   WORKFLOW_SPEC_START,
@@ -35,7 +43,9 @@ import { createAgentTask } from "../src/scenarios/agent-task-factory.js";
 import { AgentTaskCreator } from "../src/scenarios/agent-task-creator.js";
 import type { AgentTaskSpec } from "../src/scenarios/agent-task-spec.js";
 import type { InvestigationSpec } from "../src/scenarios/investigation-spec.js";
+import type { SchemaEvolutionSpec } from "../src/scenarios/schema-evolution-spec.js";
 import type { SimulationSpec } from "../src/scenarios/simulation-spec.js";
+import type { ToolFragilitySpec } from "../src/scenarios/tool-fragility-spec.js";
 import type { WorkflowSpec } from "../src/scenarios/workflow-spec.js";
 import type { LLMProvider, CompletionResult } from "../src/types/index.js";
 import { AgentTaskResultSchema } from "../src/types/index.js";
@@ -209,6 +219,84 @@ function mockWorkflowResponse(): string {
     ],
   };
   return `${WORKFLOW_SPEC_START}\n${JSON.stringify(data, null, 2)}\n${WORKFLOW_SPEC_END}\n`;
+}
+
+function mockSchemaEvolutionResponse(): string {
+  const data = {
+    description: "Adapt to schema changes during a data migration.",
+    environment_description: "Versioned API environment with evolving fields.",
+    initial_state_description: "Version 1 schema is currently active.",
+    mutations: [
+      {
+        version: 2,
+        description: "Add a priority field.",
+        breaking: false,
+        fields_added: ["priority"],
+        fields_removed: [],
+        fields_modified: {},
+      },
+      {
+        version: 3,
+        description: "Rename status to state and remove legacy_id.",
+        breaking: true,
+        fields_added: ["state"],
+        fields_removed: ["status", "legacy_id"],
+        fields_modified: {},
+      },
+    ],
+    success_criteria: ["detect schema changes", "discard stale assumptions"],
+    failure_modes: ["using removed fields"],
+    max_steps: 8,
+    actions: [
+      {
+        name: "query_api",
+        description: "Query the current schema.",
+        parameters: { endpoint: "string" },
+        preconditions: [],
+        effects: ["schema_observed"],
+      },
+      {
+        name: "validate_schema",
+        description: "Validate assumptions against the schema.",
+        parameters: {},
+        preconditions: ["query_api"],
+        effects: ["schema_validated"],
+      },
+    ],
+  };
+  return `${SCHEMA_EVOLUTION_SPEC_START}\n${JSON.stringify(data, null, 2)}\n${SCHEMA_EVOLUTION_SPEC_END}\n`;
+}
+
+function mockToolFragilityResponse(): string {
+  const data = {
+    description: "Adapt to tool contract drift in a pipeline.",
+    environment_description: "Versioned services with unstable response formats.",
+    initial_state_description: "All tools initially operate at stable version 1.",
+    tool_contracts: [
+      { tool_name: "search_api", version: 1, description: "Search endpoint returning a flat list." },
+      { tool_name: "transform_api", version: 1, description: "Data transform endpoint." },
+    ],
+    success_criteria: ["detect tool drift", "adapt without wasted attempts"],
+    failure_modes: ["using stale response format"],
+    max_steps: 8,
+    actions: [
+      {
+        name: "call_search",
+        description: "Call the search API.",
+        parameters: { query: "string" },
+        preconditions: [],
+        effects: ["search_results_obtained"],
+      },
+      {
+        name: "call_transform",
+        description: "Call the transform API.",
+        parameters: { data: "string" },
+        preconditions: ["call_search"],
+        effects: ["data_transformed"],
+      },
+    ],
+  };
+  return `${TOOL_FRAGILITY_SPEC_START}\n${JSON.stringify(data, null, 2)}\n${TOOL_FRAGILITY_SPEC_END}\n`;
 }
 
 function makeMockProvider(response = "mock output"): LLMProvider {
@@ -412,6 +500,46 @@ describe("FamilyPipeline", () => {
       ],
     };
     expect(validateForFamily("workflow", spec)).toEqual([]);
+  });
+
+  it("validates schema-evolution specs through the family pipeline", () => {
+    const spec: SchemaEvolutionSpec = {
+      description: "Adapt to schema evolution.",
+      environmentDescription: "Versioned API environment.",
+      initialStateDescription: "Schema v1 is active.",
+      mutations: [
+        { version: 2, description: "Add priority.", breaking: false, fieldsAdded: ["priority"], fieldsRemoved: [], fieldsModified: {} },
+        { version: 3, description: "Rename status.", breaking: true, fieldsAdded: ["state"], fieldsRemoved: ["status"], fieldsModified: {} },
+      ],
+      successCriteria: ["detect changes"],
+      failureModes: ["using removed fields"],
+      maxSteps: 8,
+      actions: [
+        { name: "query_api", description: "Query schema", parameters: { endpoint: "string" }, preconditions: [], effects: ["schema_observed"] },
+        { name: "validate_schema", description: "Validate schema", parameters: {}, preconditions: ["query_api"], effects: ["schema_validated"] },
+      ],
+    };
+    expect(validateForFamily("schema_evolution", spec)).toEqual([]);
+  });
+
+  it("validates tool-fragility specs through the family pipeline", () => {
+    const spec: ToolFragilitySpec = {
+      description: "Adapt to tool drift.",
+      environmentDescription: "Versioned service environment.",
+      initialStateDescription: "Tools are on v1.",
+      toolContracts: [
+        { toolName: "search_api", version: 1, description: "Search API" },
+        { toolName: "transform_api", version: 1, description: "Transform API" },
+      ],
+      successCriteria: ["detect drift"],
+      failureModes: ["using stale responses"],
+      maxSteps: 8,
+      actions: [
+        { name: "call_search", description: "Call search", parameters: { query: "string" }, preconditions: [], effects: ["search_results"] },
+        { name: "call_transform", description: "Call transform", parameters: { data: "string" }, preconditions: ["call_search"], effects: ["transform_complete"] },
+      ],
+    };
+    expect(validateForFamily("tool_fragility", spec)).toEqual([]);
   });
 
   it("rejects unsupported families instead of collapsing silently", () => {
@@ -662,6 +790,36 @@ describe("AgentTaskCreator", () => {
     expect(readFileSync(join(scenarioDir, "scenario_type.txt"), "utf-8")).toBe(getScenarioTypeMarker("workflow"));
   });
 
+  it("routes schema-evolution descriptions into a schema-evolution scaffold", async () => {
+    const provider = makeMockProvider(mockSchemaEvolutionResponse());
+    const tmpDir = mkdtempSync(join(tmpdir(), "autocontext-creator-schema-"));
+    const creator = new AgentTaskCreator({ provider, knowledgeRoot: tmpDir });
+
+    const scenario = await creator.create("Create a schema evolution scenario with stale context after breaking field changes");
+    expect("family" in scenario && scenario.family).toBe("schema_evolution");
+
+    const name = creator.deriveName("Create a schema evolution scenario with stale context after breaking field changes");
+    const scenarioDir = join(tmpDir, "_custom_scenarios", name);
+    expect(existsSync(join(scenarioDir, "scenario.py"))).toBe(true);
+    expect(existsSync(join(scenarioDir, "spec.json"))).toBe(true);
+    expect(readFileSync(join(scenarioDir, "scenario_type.txt"), "utf-8")).toBe(getScenarioTypeMarker("schema_evolution"));
+  });
+
+  it("routes tool-fragility descriptions into a tool-fragility scaffold", async () => {
+    const provider = makeMockProvider(mockToolFragilityResponse());
+    const tmpDir = mkdtempSync(join(tmpdir(), "autocontext-creator-tool-"));
+    const creator = new AgentTaskCreator({ provider, knowledgeRoot: tmpDir });
+
+    const scenario = await creator.create("Create a tool fragility scenario with API contract drift and environment changes");
+    expect("family" in scenario && scenario.family).toBe("tool_fragility");
+
+    const name = creator.deriveName("Create a tool fragility scenario with API contract drift and environment changes");
+    const scenarioDir = join(tmpDir, "_custom_scenarios", name);
+    expect(existsSync(join(scenarioDir, "scenario.py"))).toBe(true);
+    expect(existsSync(join(scenarioDir, "spec.json"))).toBe(true);
+    expect(readFileSync(join(scenarioDir, "scenario_type.txt"), "utf-8")).toBe(getScenarioTypeMarker("tool_fragility"));
+  });
+
   it("rejects classified-but-unsupported game families", async () => {
     const provider = makeMockProvider(mockLlmResponse(SAMPLE_SPEC));
     const tmpDir = mkdtempSync(join(tmpdir(), "autocontext-creator-game-"));
@@ -689,6 +847,18 @@ describe("AgentTaskCreator", () => {
     expect(
       classifyScenarioFamily("Create a transactional workflow with compensation and side effects").familyName,
     ).toBe("workflow");
+  });
+
+  it("classifies schema-evolution descriptions into the schema_evolution family", () => {
+    expect(
+      classifyScenarioFamily("Create a schema evolution scenario with stale context after breaking field changes").familyName,
+    ).toBe("schema_evolution");
+  });
+
+  it("classifies tool-fragility descriptions into the tool_fragility family", () => {
+    expect(
+      classifyScenarioFamily("Create a tool fragility scenario with API contract drift and environment changes").familyName,
+    ).toBe("tool_fragility");
   });
 });
 


### PR DESCRIPTION
## Summary
- **AC-252**: Adds `schema_evolution` scenario family — schemas/state change mid-run, agents must detect stale context, discard invalidated assumptions, and adapt
- **AC-254**: Adds `tool_fragility` scenario family — tools/APIs drift while the core task stays the same, with failure attribution across routing/instruction/tool/stale-context categories

Both families are full vertical slices wired end-to-end: classify → create → persist → load → run.

### New modules
| Module | Purpose |
|--------|---------|
| `scenarios/schema_evolution.py` | Interface + data models (SchemaMutation, ContextValidity, SchemaEvolutionResult) |
| `scenarios/tool_fragility.py` | Interface + data models (ToolContract, ToolDrift, FailureAttribution, ToolFragilityResult) |
| `custom/schema_evolution_{spec,designer,codegen,creator}.py` | Creation pipeline for schema_evolution |
| `custom/tool_fragility_{spec,designer,codegen,creator}.py` | Creation pipeline for tool_fragility |

### Integration wiring
- `families.py` — registered both families with markers
- `family_pipeline.py` — SchemaEvolutionPipeline + ToolFragilityPipeline with spec/source/contract validation
- `family_classifier.py` — signal dicts for natural-language routing
- `agent_task_creator.py` — routing branches for both creators

## Test plan
- [x] 70 tests in `test_schema_evolution_tool_fragility.py`
- [x] Data model construction + serialization roundtrip (both families)
- [x] ABC enforcement (cannot instantiate, concrete subclass works)
- [x] Family registry integration (registered, marker, detect_family)
- [x] Pipeline registry (spec validation, source validation, contract checking)
- [x] Classifier routing (both families resolve from natural-language)
- [x] Designer/codegen (spec parsing, LLM-driven design, source generation)
- [x] Creator end-to-end (create → persist → load → register)
- [x] AgentTaskCreator dispatch (routes to both new families)
- [x] Cross-family mismatch tests
- [x] Full suite: 3670 passed, 46 skipped
- [x] ruff + mypy clean