### PR TITLE
feat(AC-250): negotiation and adversarial hidden-state scenario family

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -28,6 +28,7 @@ from autocontext.scenarios.custom.family_pipeline import (
     validate_source_for_family,
 )
 from autocontext.scenarios.custom.investigation_creator import InvestigationCreator
+from autocontext.scenarios.custom.negotiation_creator import NegotiationCreator
 from autocontext.scenarios.custom.registry import CUSTOM_SCENARIOS_DIR
 from autocontext.scenarios.custom.schema_evolution_creator import SchemaEvolutionCreator
 from autocontext.scenarios.custom.simulation_creator import SimulationCreator
@@ -35,6 +36,7 @@ from autocontext.scenarios.custom.tool_fragility_creator import ToolFragilityCre
 from autocontext.scenarios.custom.workflow_creator import WorkflowCreator
 from autocontext.scenarios.families import get_family_marker
 from autocontext.scenarios.investigation import InvestigationInterface
+from autocontext.scenarios.negotiation import NegotiationInterface
 from autocontext.scenarios.schema_evolution import SchemaEvolutionInterface
 from autocontext.scenarios.tool_fragility import ToolFragilityInterface
 from autocontext.scenarios.workflow import WorkflowInterface
@@ -85,6 +87,7 @@ class AgentTaskCreator:
         AgentTaskInterface | ScenarioInterface | ArtifactEditingInterface
         | InvestigationInterface | WorkflowInterface
         | SchemaEvolutionInterface | ToolFragilityInterface
+        | NegotiationInterface
     ):
         """Run the full pipeline: design → validate → codegen → validate → load → register.
 
@@ -112,6 +115,9 @@ class AgentTaskCreator:
         if family.name == "tool_fragility":
             logger.info("routing description to tool-fragility creator")
             return ToolFragilityCreator(self.llm_fn, self.knowledge_root).create(description, name=name)
+        if family.name == "negotiation":
+            logger.info("routing description to negotiation creator")
+            return NegotiationCreator(self.llm_fn, self.knowledge_root).create(description, name=name)
         if family.name != "agent_task":
             raise ValueError(
                 f"Scenario family '{family.name}' is not yet supported for custom scaffolding"

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -273,6 +273,24 @@ _TOOL_FRAGILITY_SIGNALS: dict[str, float] = {
     "tool failure": 1.5,
 }
 
+_NEGOTIATION_SIGNALS: dict[str, float] = {
+    "negotiat": 2.0,  # negotiate, negotiation
+    "hidden preference": 2.0,
+    "batna": 2.0,
+    "opponent model": 2.0,
+    "adversarial": 1.5,
+    "counter offer": 2.0,
+    "counter-offer": 2.0,
+    "bargain": 1.5,
+    "deal": 1.0,
+    "concession": 1.5,
+    "reservation value": 2.0,
+    "repeated round": 2.0,
+    "strategy adapt": 1.5,
+    "hidden state": 1.5,
+    "offer accept": 1.5,
+}
+
 _FAMILY_SIGNAL_GROUPS: dict[str, dict[str, float]] = {
     "simulation": _SIMULATION_SIGNALS,
     "agent_task": _AGENT_TASK_SIGNALS,
@@ -282,6 +300,7 @@ _FAMILY_SIGNAL_GROUPS: dict[str, dict[str, float]] = {
     "workflow": _WORKFLOW_SIGNALS,
     "schema_evolution": _SCHEMA_EVOLUTION_SIGNALS,
     "tool_fragility": _TOOL_FRAGILITY_SIGNALS,
+    "negotiation": _NEGOTIATION_SIGNALS,
 }
 
 _DEFAULT_FAMILY_NAME = "agent_task"

--- a/autocontext/src/autocontext/scenarios/custom/family_pipeline.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_pipeline.py
@@ -671,6 +671,81 @@ class ToolFragilityPipeline(FamilyPipeline):
         )
 
 
+class NegotiationPipeline(FamilyPipeline):
+    """Pipeline for negotiation family scenarios."""
+
+    @property
+    def family_name(self) -> str:
+        return "negotiation"
+
+    def required_spec_fields(self) -> set[str]:
+        return {
+            "description",
+            "environment_description",
+            "initial_state_description",
+            "hidden_preferences",
+            "max_rounds",
+            "success_criteria",
+            "actions",
+        }
+
+    def validate_spec(self, spec: dict[str, Any]) -> list[str]:
+        errors = _check_required_fields(spec, self.required_spec_fields())
+
+        hp = spec.get("hidden_preferences")
+        if isinstance(hp, dict):
+            for key in ("priorities", "reservation_value", "aspiration_value", "batna_description"):
+                if key not in hp:
+                    errors.append(f"hidden_preferences missing '{key}'")
+        elif hp is not None:
+            errors.append("hidden_preferences must be a dict")
+
+        actions = spec.get("actions")
+        if isinstance(actions, list):
+            if len(actions) == 0:
+                errors.append("actions must not be empty")
+            else:
+                for i, action in enumerate(actions):
+                    if not isinstance(action, dict):
+                        errors.append(f"actions[{i}] must be a dict")
+                    elif "name" not in action:
+                        errors.append(f"actions[{i}] missing 'name'")
+
+        criteria = spec.get("success_criteria")
+        if isinstance(criteria, list) and len(criteria) == 0:
+            errors.append("success_criteria must not be empty")
+
+        max_rounds = spec.get("max_rounds")
+        if max_rounds is not None and (not isinstance(max_rounds, int) or max_rounds <= 0):
+            errors.append("max_rounds must be a positive integer")
+
+        return errors
+
+    def validate_source(self, source: str) -> list[str]:
+        return _check_source_for_class(source, "NegotiationInterface")
+
+    def validate_contract(self, source: str) -> list[str]:
+        return _check_required_methods(
+            source,
+            "NegotiationInterface",
+            {
+                "describe_scenario",
+                "describe_environment",
+                "initial_state",
+                "get_available_actions",
+                "execute_action",
+                "is_terminal",
+                "evaluate_trace",
+                "get_rubric",
+                "get_hidden_preferences",
+                "get_rounds",
+                "get_opponent_model",
+                "update_opponent_model",
+                "evaluate_negotiation",
+            },
+        )
+
+
 # ---------------------------------------------------------------------------
 # Built-in pipeline registration
 # ---------------------------------------------------------------------------
@@ -683,6 +758,7 @@ def _register_builtins() -> None:
     register_pipeline(WorkflowPipeline())
     register_pipeline(SchemaEvolutionPipeline())
     register_pipeline(ToolFragilityPipeline())
+    register_pipeline(NegotiationPipeline())
 
 
 _register_builtins()

--- a/autocontext/src/autocontext/scenarios/custom/negotiation_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/negotiation_codegen.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import re
+
+from autocontext.scenarios.custom.negotiation_spec import NegotiationSpec
+
+
+def _class_name(name: str) -> str:
+    parts = re.split(r"[^a-zA-Z0-9]+", name)
+    return "".join(part.capitalize() for part in parts if part) + "Negotiation"
+
+
+def generate_negotiation_class(spec: NegotiationSpec, name: str) -> str:
+    class_name = _class_name(name)
+    action_specs = ",\n".join(
+        "            ActionSpec("
+        f"name={action.name!r}, "
+        f"description={action.description!r}, "
+        f"parameters={action.parameters!r}, "
+        f"preconditions={action.preconditions!r}, "
+        f"effects={action.effects!r})"
+        for action in spec.actions
+    )
+    required_actions = [action.name for action in spec.actions]
+    return f'''from __future__ import annotations
+
+from typing import Any
+
+from autocontext.scenarios.negotiation import (
+    HiddenPreferences,
+    NegotiationInterface,
+    NegotiationResult,
+    NegotiationRound,
+    OpponentModel,
+)
+from autocontext.scenarios.simulation import (
+    Action,
+    ActionResult,
+    ActionSpec,
+    ActionTrace,
+    EnvironmentSpec,
+    SimulationResult,
+)
+
+
+class {class_name}(NegotiationInterface):
+    name = {name!r}
+    _hidden_prefs_spec = {spec.hidden_preferences!r}
+
+    def describe_scenario(self) -> str:
+        return {spec.description!r}
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name={name!r},
+            description={spec.environment_description!r},
+            available_actions=[
+{action_specs}
+            ],
+            initial_state_description={spec.initial_state_description!r},
+            success_criteria={spec.success_criteria!r},
+            failure_modes={spec.failure_modes!r},
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {{
+            "seed": seed or 0,
+            "step": 0,
+            "round": 0,
+            "max_rounds": {spec.max_rounds},
+            "rounds": [],
+            "completed_actions": [],
+            "failed_actions": [],
+            "opponent_model": None,
+            "deal_value": None,
+            "deal_closed": False,
+        }}
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        completed = set(state.get("completed_actions", []))
+        return [
+            s for s in self.describe_environment().available_actions
+            if s.name not in completed
+        ]
+
+    def validate_action(
+        self, state: dict[str, Any], action: Action
+    ) -> tuple[bool, str]:
+        specs = {{
+            s.name: s for s in self.describe_environment().available_actions
+        }}
+        spec = specs.get(action.name)
+        if spec is None:
+            return False, f"unknown action: {{action.name}}"
+        completed = set(state.get("completed_actions", []))
+        for req in spec.preconditions:
+            if req not in completed:
+                return False, f"precondition not met for {{action.name}}: {{req}}"
+        return True, ""
+
+    def execute_action(
+        self, state: dict[str, Any], action: Action
+    ) -> tuple[ActionResult, dict[str, Any]]:
+        valid, reason = self.validate_action(state, action)
+        next_state = dict(state)
+        if not valid:
+            next_state["failed_actions"] = [
+                *state.get("failed_actions", []), action.name
+            ]
+            return (
+                ActionResult(
+                    success=False, output="", state_changes={{}}, error=reason
+                ),
+                next_state,
+            )
+
+        next_state["completed_actions"] = [
+            *state.get("completed_actions", []), action.name
+        ]
+        next_state["round"] = state.get("round", 0) + 1
+
+        # Record round
+        offer = action.parameters if action.parameters else {{}}
+        rnd = {{
+            "round_number": next_state["round"],
+            "offer": offer,
+            "counter_offer": None,
+            "accepted": action.name == "accept",
+            "agent_reasoning": action.parameters.get("reasoning", "")
+            if action.parameters else "",
+        }}
+        next_state["rounds"] = [*state.get("rounds", []), rnd]
+
+        if action.name == "accept":
+            next_state["deal_closed"] = True
+            # Compute simple deal value from round count
+            max_r = state.get("max_rounds", {spec.max_rounds})
+            rounds_used = next_state["round"]
+            prefs = self._hidden_prefs_spec
+            reservation = prefs.get("reservation_value", 0.0)
+            aspiration = prefs.get("aspiration_value", 100.0)
+            # More rounds used → closer to reservation; fewer → closer to aspiration
+            ratio = 1.0 - (rounds_used / max(max_r, 1))
+            next_state["deal_value"] = round(
+                reservation + ratio * (aspiration - reservation), 2
+            )
+
+        return (
+            ActionResult(
+                success=True,
+                output=f"executed {{action.name}} (round {{next_state['round']}})",
+                state_changes={{"round": next_state["round"]}},
+            ),
+            next_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        required = set({required_actions!r})
+        completed = set(state.get("completed_actions", []))
+        return (
+            state.get("deal_closed", False)
+            or required.issubset(completed)
+            or state.get("round", 0) >= state.get("max_rounds", {spec.max_rounds})
+            or state.get("step", 0) >= {spec.max_steps}
+        )
+
+    def get_hidden_preferences(
+        self, state: dict[str, Any]
+    ) -> HiddenPreferences:
+        return HiddenPreferences(
+            priorities=self._hidden_prefs_spec.get("priorities", {{}}),
+            reservation_value=self._hidden_prefs_spec.get(
+                "reservation_value", 0.0
+            ),
+            aspiration_value=self._hidden_prefs_spec.get(
+                "aspiration_value", 100.0
+            ),
+            batna_description=self._hidden_prefs_spec.get(
+                "batna_description", ""
+            ),
+        )
+
+    def get_rounds(self, state: dict[str, Any]) -> list[NegotiationRound]:
+        return [NegotiationRound.from_dict(r) for r in state.get("rounds", [])]
+
+    def get_opponent_model(
+        self, state: dict[str, Any]
+    ) -> OpponentModel | None:
+        om = state.get("opponent_model")
+        if om is None:
+            return None
+        return OpponentModel.from_dict(om)
+
+    def update_opponent_model(
+        self, state: dict[str, Any], model: OpponentModel
+    ) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["opponent_model"] = model.to_dict()
+        return next_state
+
+    def evaluate_negotiation(
+        self, state: dict[str, Any]
+    ) -> NegotiationResult:
+        prefs = self.get_hidden_preferences(state)
+        deal_value = state.get("deal_value") or 0.0
+        rounds_used = state.get("round", 0)
+        max_rounds = state.get("max_rounds", {spec.max_rounds})
+
+        # Deal quality: how much above reservation?
+        surplus = prefs.aspiration_value - prefs.reservation_value
+        if surplus > 0:
+            value_ratio = max(
+                0.0,
+                (deal_value - prefs.reservation_value) / surplus,
+            )
+        else:
+            value_ratio = 1.0 if deal_value >= prefs.reservation_value else 0.0
+
+        # Efficiency: fewer rounds → higher score
+        efficiency = 1.0 - (rounds_used / max(max_rounds, 1))
+
+        # Opponent modeling accuracy
+        om = self.get_opponent_model(state)
+        if om is not None:
+            # Compare inferred priorities to actual
+            actual = prefs.priorities
+            diffs = []
+            for dim, actual_w in actual.items():
+                inferred_w = om.inferred_priorities.get(dim, 0.0)
+                diffs.append(abs(actual_w - inferred_w))
+            model_accuracy = max(0.0, 1.0 - (sum(diffs) / max(len(diffs), 1)))
+        else:
+            model_accuracy = 0.0
+
+        # Adaptation: did the agent update its model?
+        adaptation = min(1.0, len(state.get("rounds", [])) * 0.2)
+
+        score = round(
+            value_ratio * 0.35
+            + model_accuracy * 0.25
+            + efficiency * 0.2
+            + adaptation * 0.2,
+            4,
+        )
+
+        return NegotiationResult(
+            score=score,
+            reasoning=(
+                f"Deal value {{deal_value}} "
+                f"({{rounds_used}}/{{max_rounds}} rounds). "
+                f"Model accuracy: {{model_accuracy:.2f}}."
+            ),
+            dimension_scores={{
+                "deal_quality": round(value_ratio, 4),
+                "opponent_modeling": round(model_accuracy, 4),
+                "efficiency": round(efficiency, 4),
+                "adaptation": round(adaptation, 4),
+            }},
+            deal_value=deal_value,
+            rounds_used=rounds_used,
+            max_rounds=max_rounds,
+            opponent_model_accuracy=round(model_accuracy, 4),
+            value_claimed_ratio=round(value_ratio, 4),
+        )
+
+    def evaluate_trace(
+        self, trace: ActionTrace, final_state: dict[str, Any]
+    ) -> SimulationResult:
+        neg_result = self.evaluate_negotiation(final_state)
+        action_success = trace.success_rate
+        score = round(neg_result.score * 0.7 + action_success * 0.3, 4)
+        return SimulationResult(
+            score=score,
+            reasoning=neg_result.reasoning,
+            dimension_scores={{
+                "deal_quality": neg_result.dimension_scores.get(
+                    "deal_quality", 0.0
+                ),
+                "opponent_modeling": neg_result.dimension_scores.get(
+                    "opponent_modeling", 0.0
+                ),
+                "efficiency": neg_result.dimension_scores.get(
+                    "efficiency", 0.0
+                ),
+                "adaptation": neg_result.dimension_scores.get(
+                    "adaptation", 0.0
+                ),
+                "action_success": round(action_success, 4),
+            }},
+            workflow_complete=final_state.get("deal_closed", False),
+            actions_taken=len(trace.records),
+            actions_successful=sum(
+                1 for r in trace.records if r.result.success
+            ),
+            recovery_attempts=len(final_state.get("failed_actions", [])),
+            rollback_quality=neg_result.dimension_scores.get(
+                "efficiency", 0.0
+            ),
+        )
+
+    def get_rubric(self) -> str:
+        return (
+            "Evaluate on deal quality relative to BATNA, "
+            "opponent modeling accuracy, negotiation efficiency, "
+            "and strategic adaptation across rounds."
+        )
+
+    def max_steps(self) -> int:
+        return {spec.max_steps}
+'''

--- a/autocontext/src/autocontext/scenarios/custom/negotiation_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/negotiation_creator.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import asdict
+from pathlib import Path
+from typing import cast
+
+from autocontext.scenarios.base import ScenarioInterface
+from autocontext.scenarios.custom.family_pipeline import (
+    validate_for_family,
+    validate_source_for_family,
+)
+from autocontext.scenarios.custom.loader import load_custom_scenario
+from autocontext.scenarios.custom.negotiation_codegen import (
+    generate_negotiation_class,
+)
+from autocontext.scenarios.custom.negotiation_designer import design_negotiation
+from autocontext.scenarios.custom.registry import CUSTOM_SCENARIOS_DIR
+from autocontext.scenarios.families import get_family_marker
+from autocontext.scenarios.negotiation import NegotiationInterface
+
+logger = logging.getLogger(__name__)
+
+
+class NegotiationCreator:
+    def __init__(self, llm_fn: Callable[[str, str], str], knowledge_root: Path) -> None:
+        self.llm_fn = llm_fn
+        self.knowledge_root = knowledge_root
+
+    def create(self, description: str, name: str) -> ScenarioInterface:
+        spec = design_negotiation(description, self.llm_fn)
+        errors = validate_for_family("negotiation", asdict(spec))
+        if errors:
+            raise ValueError(f"negotiation spec validation failed: {'; '.join(errors)}")
+
+        custom_dir = self.knowledge_root / CUSTOM_SCENARIOS_DIR
+        scenario_dir = custom_dir / name
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+
+        source = generate_negotiation_class(spec, name=name)
+        source_errors = validate_source_for_family("negotiation", source)
+        if source_errors:
+            raise ValueError(
+                f"negotiation source validation failed: {'; '.join(source_errors)}"
+            )
+
+        (scenario_dir / "scenario.py").write_text(source, encoding="utf-8")
+        (scenario_dir / "spec.json").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "scenario_type": get_family_marker("negotiation"),
+                    "description": spec.description,
+                    "environment_description": spec.environment_description,
+                    "initial_state_description": spec.initial_state_description,
+                    "hidden_preferences": spec.hidden_preferences,
+                    "max_rounds": spec.max_rounds,
+                    "success_criteria": spec.success_criteria,
+                    "failure_modes": spec.failure_modes,
+                    "max_steps": spec.max_steps,
+                    "actions": [
+                        {
+                            "name": action.name,
+                            "description": action.description,
+                            "parameters": action.parameters,
+                            "preconditions": action.preconditions,
+                            "effects": action.effects,
+                        }
+                        for action in spec.actions
+                    ],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        (scenario_dir / "scenario_type.txt").write_text(
+            get_family_marker("negotiation"),
+            encoding="utf-8",
+        )
+
+        cls = load_custom_scenario(custom_dir, name, NegotiationInterface)
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        SCENARIO_REGISTRY[name] = cls
+        logger.info("registered negotiation scenario '%s'", name)
+        return cast(ScenarioInterface, cls())

--- a/autocontext/src/autocontext/scenarios/custom/negotiation_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/negotiation_designer.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+
+from autocontext.scenarios.custom.negotiation_spec import NegotiationSpec
+from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+
+NEGOTIATION_SPEC_START = "<!-- NEGOTIATION_SPEC_START -->"
+NEGOTIATION_SPEC_END = "<!-- NEGOTIATION_SPEC_END -->"
+
+_EXAMPLE_SPEC = {
+    "description": "Contract price negotiation with hidden BATNA.",
+    "environment_description": "Buyer-seller negotiation over contract terms.",
+    "initial_state_description": "Both parties have opening positions; hidden preferences unknown.",
+    "hidden_preferences": {
+        "priorities": {"price": 0.6, "delivery_time": 0.3, "warranty": 0.1},
+        "reservation_value": 50.0,
+        "aspiration_value": 85.0,
+        "batna_description": "Switch to alternative vendor with longer lead time.",
+    },
+    "max_rounds": 5,
+    "success_criteria": [
+        "reach agreement above reservation value",
+        "accurately model opponent priorities by final round",
+    ],
+    "failure_modes": ["deadlock without agreement", "accept below BATNA"],
+    "actions": [
+        {
+            "name": "make_offer",
+            "description": "Propose contract terms to the opponent.",
+            "parameters": {"terms": "dict"},
+            "preconditions": [],
+            "effects": ["offer_on_table"],
+        },
+        {
+            "name": "counter_offer",
+            "description": "Respond with modified terms.",
+            "parameters": {"terms": "dict"},
+            "preconditions": ["make_offer"],
+            "effects": ["counter_on_table"],
+        },
+        {
+            "name": "accept",
+            "description": "Accept the current terms on the table.",
+            "parameters": {},
+            "preconditions": ["make_offer"],
+            "effects": ["deal_closed"],
+        },
+    ],
+}
+
+NEGOTIATION_DESIGNER_SYSTEM = (
+    "You are a scenario designer for autocontext. "
+    "Given a natural-language request for a negotiation or adversarial "
+    "hidden-state scenario, produce a NegotiationSpec JSON wrapped in delimiters.\n\n"
+    f"{NEGOTIATION_SPEC_START}\n{{ ... }}\n{NEGOTIATION_SPEC_END}\n\n"
+    "Schema:\n"
+    "{\n"
+    '  "description": "scenario summary",\n'
+    '  "environment_description": "negotiation context",\n'
+    '  "initial_state_description": "starting positions",\n'
+    '  "hidden_preferences": {\n'
+    '    "priorities": {"dimension": weight},\n'
+    '    "reservation_value": float,\n'
+    '    "aspiration_value": float,\n'
+    '    "batna_description": "string"\n'
+    "  },\n"
+    '  "max_rounds": 5,\n'
+    '  "success_criteria": ["criterion"],\n'
+    '  "failure_modes": ["failure mode"],\n'
+    '  "actions": [\n'
+    "    {\n"
+    '      "name": "snake_case",\n'
+    '      "description": "what the action does",\n'
+    '      "parameters": {"param": "type"},\n'
+    '      "preconditions": [],\n'
+    '      "effects": ["effect"]\n'
+    "    }\n"
+    "  ]\n"
+    "}\n\n"
+    "Rules:\n"
+    "- hidden_preferences must include priorities, reservation_value, aspiration_value, batna_description\n"
+    "- include at least two actions (e.g. make_offer + accept)\n"
+    "- max_rounds should be between 2 and 10\n\n"
+    f"Example:\n{NEGOTIATION_SPEC_START}\n{json.dumps(_EXAMPLE_SPEC, indent=2)}\n{NEGOTIATION_SPEC_END}\n"
+)
+
+
+def parse_negotiation_spec(text: str) -> NegotiationSpec:
+    pattern = (
+        re.escape(NEGOTIATION_SPEC_START)
+        + r"\s*(.*?)\s*"
+        + re.escape(NEGOTIATION_SPEC_END)
+    )
+    match = re.search(pattern, text, re.DOTALL)
+    if not match:
+        raise ValueError("response does not contain NEGOTIATION_SPEC delimiters")
+    data = json.loads(match.group(1).strip())
+    return NegotiationSpec(
+        description=data["description"],
+        environment_description=data["environment_description"],
+        initial_state_description=data["initial_state_description"],
+        hidden_preferences=data["hidden_preferences"],
+        max_rounds=data.get("max_rounds", 5),
+        success_criteria=data["success_criteria"],
+        failure_modes=data.get("failure_modes", []),
+        actions=[
+            SimulationActionSpecModel(
+                name=raw["name"],
+                description=raw["description"],
+                parameters=raw.get("parameters", {}),
+                preconditions=raw.get("preconditions", []),
+                effects=raw.get("effects", []),
+            )
+            for raw in data["actions"]
+        ],
+        max_steps=data.get("max_steps", 0),
+    )
+
+
+def design_negotiation(
+    description: str, llm_fn: Callable[[str, str], str]
+) -> NegotiationSpec:
+    return parse_negotiation_spec(
+        llm_fn(NEGOTIATION_DESIGNER_SYSTEM, f"User description:\n{description}")
+    )

--- a/autocontext/src/autocontext/scenarios/custom/negotiation_spec.py
+++ b/autocontext/src/autocontext/scenarios/custom/negotiation_spec.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+
+
+@dataclass(slots=True)
+class NegotiationSpec:
+    """Spec for a negotiation scenario."""
+
+    description: str
+    environment_description: str
+    initial_state_description: str
+    hidden_preferences: dict[str, Any]  # priorities, reservation, aspiration, batna
+    max_rounds: int
+    success_criteria: list[str]
+    failure_modes: list[str]
+    actions: list[SimulationActionSpecModel]
+    max_steps: int = 0  # auto-derived from max_rounds * 2 if not set
+
+    def __post_init__(self) -> None:
+        if self.max_steps <= 0:
+            self.max_steps = max(self.max_rounds * 2, 4)

--- a/autocontext/src/autocontext/scenarios/families.py
+++ b/autocontext/src/autocontext/scenarios/families.py
@@ -103,6 +103,7 @@ def _register_builtins() -> None:
     from autocontext.scenarios.artifact_editing import ArtifactEditingInterface
     from autocontext.scenarios.base import ScenarioInterface
     from autocontext.scenarios.investigation import InvestigationInterface
+    from autocontext.scenarios.negotiation import NegotiationInterface
     from autocontext.scenarios.schema_evolution import SchemaEvolutionInterface
     from autocontext.scenarios.simulation import SimulationInterface
     from autocontext.scenarios.tool_fragility import ToolFragilityInterface
@@ -168,6 +169,16 @@ def _register_builtins() -> None:
         output_modes=["action_trace"],
         scenario_type_marker="workflow",
         capabilities=["compensation", "retry", "side_effect_tracking", "rollback"],
+    ))
+
+    register_family(ScenarioFamily(
+        name="negotiation",
+        description="Negotiation scenarios with hidden preferences, BATNA constraints, and opponent modeling",
+        interface_class=NegotiationInterface,
+        evaluation_mode="negotiation_evaluation",
+        output_modes=["action_trace"],
+        scenario_type_marker="negotiation",
+        capabilities=["opponent_modeling", "hidden_state", "repeated_rounds", "adaptation"],
     ))
 
     register_family(ScenarioFamily(

--- a/autocontext/src/autocontext/scenarios/negotiation.py
+++ b/autocontext/src/autocontext/scenarios/negotiation.py
@@ -1,0 +1,179 @@
+"""Negotiation scenario family with adversarial hidden-state evaluation (AC-250).
+
+Negotiation scenarios where agents negotiate under hidden preferences,
+BATNA constraints, and repeated rounds. Evaluated on deal quality,
+opponent modeling accuracy, efficiency, and strategic adaptation.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+from autocontext.scenarios.simulation import SimulationInterface
+
+
+@dataclass(slots=True)
+class HiddenPreferences:
+    """The opponent's hidden negotiation parameters (ground truth)."""
+
+    priorities: dict[str, float]  # dimension → weight (0.0–1.0)
+    reservation_value: float  # minimum acceptable deal value
+    aspiration_value: float  # ideal deal value
+    batna_description: str  # best alternative to negotiated agreement
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "priorities": self.priorities,
+            "reservation_value": self.reservation_value,
+            "aspiration_value": self.aspiration_value,
+            "batna_description": self.batna_description,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> HiddenPreferences:
+        return cls(
+            priorities=data["priorities"],
+            reservation_value=data["reservation_value"],
+            aspiration_value=data["aspiration_value"],
+            batna_description=data["batna_description"],
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass(slots=True)
+class NegotiationRound:
+    """A single round of negotiation."""
+
+    round_number: int
+    offer: dict[str, Any]  # the agent's offer
+    counter_offer: dict[str, Any] | None  # opponent counter (None if accepted/final)
+    accepted: bool
+    agent_reasoning: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "round_number": self.round_number,
+            "offer": self.offer,
+            "counter_offer": self.counter_offer,
+            "accepted": self.accepted,
+            "agent_reasoning": self.agent_reasoning,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> NegotiationRound:
+        return cls(
+            round_number=data["round_number"],
+            offer=data["offer"],
+            counter_offer=data.get("counter_offer"),
+            accepted=data["accepted"],
+            agent_reasoning=data.get("agent_reasoning", ""),
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass(slots=True)
+class OpponentModel:
+    """The agent's inferred model of the opponent."""
+
+    inferred_priorities: dict[str, float]
+    inferred_reservation: float
+    strategy_hypothesis: str
+    confidence: float  # 0.0–1.0
+    adaptation_notes: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "inferred_priorities": self.inferred_priorities,
+            "inferred_reservation": self.inferred_reservation,
+            "strategy_hypothesis": self.strategy_hypothesis,
+            "confidence": self.confidence,
+            "adaptation_notes": self.adaptation_notes,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> OpponentModel:
+        return cls(
+            inferred_priorities=data["inferred_priorities"],
+            inferred_reservation=data["inferred_reservation"],
+            strategy_hypothesis=data["strategy_hypothesis"],
+            confidence=data["confidence"],
+            adaptation_notes=data.get("adaptation_notes", []),
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass(slots=True)
+class NegotiationResult:
+    """Evaluation result for a negotiation scenario."""
+
+    score: float
+    reasoning: str
+    dimension_scores: dict[str, float]  # deal_quality, opponent_modeling, efficiency, adaptation
+    deal_value: float
+    rounds_used: int
+    max_rounds: int
+    opponent_model_accuracy: float  # how close the inferred model was to ground truth
+    value_claimed_ratio: float  # fraction of available surplus claimed
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "reasoning": self.reasoning,
+            "dimension_scores": self.dimension_scores,
+            "deal_value": self.deal_value,
+            "rounds_used": self.rounds_used,
+            "max_rounds": self.max_rounds,
+            "opponent_model_accuracy": self.opponent_model_accuracy,
+            "value_claimed_ratio": self.value_claimed_ratio,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> NegotiationResult:
+        return cls(
+            score=data["score"],
+            reasoning=data["reasoning"],
+            dimension_scores=data["dimension_scores"],
+            deal_value=data["deal_value"],
+            rounds_used=data["rounds_used"],
+            max_rounds=data["max_rounds"],
+            opponent_model_accuracy=data["opponent_model_accuracy"],
+            value_claimed_ratio=data["value_claimed_ratio"],
+        )
+
+
+class NegotiationInterface(SimulationInterface):
+    """ABC for negotiation scenarios with hidden preferences and repeated rounds.
+
+    Extends SimulationInterface with negotiation-specific methods for
+    opponent modeling, round tracking, and deal quality evaluation.
+    """
+
+    @abstractmethod
+    def get_hidden_preferences(self, state: dict[str, Any]) -> HiddenPreferences:
+        """Return the opponent's hidden preferences (ground truth for evaluation)."""
+
+    @abstractmethod
+    def get_rounds(self, state: dict[str, Any]) -> list[NegotiationRound]:
+        """Return the negotiation rounds completed so far."""
+
+    @abstractmethod
+    def get_opponent_model(self, state: dict[str, Any]) -> OpponentModel | None:
+        """Return the agent's current inferred opponent model, if any."""
+
+    @abstractmethod
+    def update_opponent_model(
+        self, state: dict[str, Any], model: OpponentModel
+    ) -> dict[str, Any]:
+        """Update the opponent model in state. Returns new state."""
+
+    @abstractmethod
+    def evaluate_negotiation(self, state: dict[str, Any]) -> NegotiationResult:
+        """Evaluate the negotiation outcome with dimension scores."""

--- a/autocontext/tests/test_negotiation.py
+++ b/autocontext/tests/test_negotiation.py
@@ -1,0 +1,800 @@
+"""Tests for AC-250: negotiation and adversarial hidden-state scenario family.
+
+Full vertical-slice tests covering:
+- Data models (HiddenPreferences, NegotiationRound, OpponentModel, NegotiationResult)
+- NegotiationInterface ABC
+- Family registry integration
+- Pipeline registry integration
+- Classifier routing
+- Designer/codegen
+- Creator end-to-end (create → persist → load → register)
+- AgentTaskCreator routing dispatch
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ===========================================================================
+# Data models
+# ===========================================================================
+
+
+class TestHiddenPreferences:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.negotiation import HiddenPreferences
+
+        prefs = HiddenPreferences(
+            priorities={"price": 0.8, "delivery": 0.2},
+            reservation_value=50.0,
+            aspiration_value=90.0,
+            batna_description="Walk away and find another vendor",
+        )
+        assert prefs.priorities["price"] == 0.8
+        assert prefs.reservation_value == 50.0
+        assert prefs.aspiration_value == 90.0
+        assert prefs.batna_description == "Walk away and find another vendor"
+
+    def test_roundtrip(self) -> None:
+        from autocontext.scenarios.negotiation import HiddenPreferences
+
+        prefs = HiddenPreferences(
+            priorities={"price": 0.6, "quality": 0.4},
+            reservation_value=30.0,
+            aspiration_value=80.0,
+            batna_description="Use alternative supplier",
+        )
+        d = prefs.to_dict()
+        restored = HiddenPreferences.from_dict(d)
+        assert restored.priorities == prefs.priorities
+        assert restored.reservation_value == prefs.reservation_value
+        assert restored.aspiration_value == prefs.aspiration_value
+        assert restored.batna_description == prefs.batna_description
+
+    def test_defaults(self) -> None:
+        from autocontext.scenarios.negotiation import HiddenPreferences
+
+        prefs = HiddenPreferences(
+            priorities={},
+            reservation_value=0.0,
+            aspiration_value=100.0,
+            batna_description="",
+        )
+        assert prefs.metadata == {}
+
+
+class TestNegotiationRound:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.negotiation import NegotiationRound
+
+        rnd = NegotiationRound(
+            round_number=1,
+            offer={"price": 70, "delivery_days": 5},
+            counter_offer={"price": 80, "delivery_days": 3},
+            accepted=False,
+            agent_reasoning="Testing price sensitivity",
+        )
+        assert rnd.round_number == 1
+        assert rnd.offer["price"] == 70
+        assert rnd.counter_offer is not None
+        assert rnd.accepted is False
+
+    def test_roundtrip(self) -> None:
+        from autocontext.scenarios.negotiation import NegotiationRound
+
+        rnd = NegotiationRound(
+            round_number=2,
+            offer={"price": 75},
+            counter_offer=None,
+            accepted=True,
+            agent_reasoning="Final deal",
+        )
+        d = rnd.to_dict()
+        restored = NegotiationRound.from_dict(d)
+        assert restored.round_number == rnd.round_number
+        assert restored.offer == rnd.offer
+        assert restored.counter_offer is None
+        assert restored.accepted is True
+        assert restored.agent_reasoning == "Final deal"
+
+
+class TestOpponentModel:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.negotiation import OpponentModel
+
+        model = OpponentModel(
+            inferred_priorities={"price": 0.7, "quality": 0.3},
+            inferred_reservation=40.0,
+            strategy_hypothesis="Anchoring high then conceding gradually",
+            confidence=0.6,
+            adaptation_notes=["Noticed price sensitivity after round 2"],
+        )
+        assert model.inferred_priorities["price"] == 0.7
+        assert model.confidence == 0.6
+        assert len(model.adaptation_notes) == 1
+
+    def test_roundtrip(self) -> None:
+        from autocontext.scenarios.negotiation import OpponentModel
+
+        model = OpponentModel(
+            inferred_priorities={"speed": 0.9},
+            inferred_reservation=20.0,
+            strategy_hypothesis="Aggressive deadline pressure",
+            confidence=0.8,
+            adaptation_notes=[],
+        )
+        d = model.to_dict()
+        restored = OpponentModel.from_dict(d)
+        assert restored.inferred_priorities == model.inferred_priorities
+        assert restored.inferred_reservation == model.inferred_reservation
+        assert restored.strategy_hypothesis == model.strategy_hypothesis
+        assert restored.confidence == model.confidence
+
+
+class TestNegotiationResult:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.negotiation import NegotiationResult
+
+        result = NegotiationResult(
+            score=0.75,
+            reasoning="Good deal quality, decent opponent modeling",
+            dimension_scores={
+                "deal_quality": 0.8,
+                "opponent_modeling": 0.7,
+                "efficiency": 0.6,
+                "adaptation": 0.9,
+            },
+            deal_value=72.0,
+            rounds_used=3,
+            max_rounds=5,
+            opponent_model_accuracy=0.7,
+            value_claimed_ratio=0.65,
+        )
+        assert result.score == 0.75
+        assert result.dimension_scores["deal_quality"] == 0.8
+        assert result.deal_value == 72.0
+        assert result.rounds_used == 3
+        assert result.opponent_model_accuracy == 0.7
+
+    def test_roundtrip(self) -> None:
+        from autocontext.scenarios.negotiation import NegotiationResult
+
+        result = NegotiationResult(
+            score=0.5,
+            reasoning="Mediocre",
+            dimension_scores={"deal_quality": 0.5},
+            deal_value=50.0,
+            rounds_used=5,
+            max_rounds=5,
+            opponent_model_accuracy=0.3,
+            value_claimed_ratio=0.4,
+        )
+        d = result.to_dict()
+        restored = NegotiationResult.from_dict(d)
+        assert restored.score == result.score
+        assert restored.deal_value == result.deal_value
+        assert restored.rounds_used == result.rounds_used
+
+
+# ===========================================================================
+# NegotiationInterface ABC
+# ===========================================================================
+
+
+class TestNegotiationInterface:
+    def test_cannot_instantiate(self) -> None:
+        from autocontext.scenarios.negotiation import NegotiationInterface
+
+        with pytest.raises(TypeError):
+            NegotiationInterface()  # type: ignore[abstract]
+
+    def test_concrete_subclass(self) -> None:
+        from autocontext.scenarios.negotiation import (
+            HiddenPreferences,
+            NegotiationInterface,
+            NegotiationResult,
+            NegotiationRound,
+            OpponentModel,
+        )
+        from autocontext.scenarios.simulation import (
+            Action,
+            ActionResult,
+            ActionSpec,
+            ActionTrace,
+            EnvironmentSpec,
+            SimulationResult,
+        )
+
+        class Stub(NegotiationInterface):
+            name = "stub_negotiation"
+
+            def describe_scenario(self) -> str:
+                return "stub"
+
+            def describe_environment(self) -> EnvironmentSpec:
+                return EnvironmentSpec(
+                    name="stub",
+                    description="stub",
+                    available_actions=[],
+                    initial_state_description="stub",
+                    success_criteria=[],
+                    failure_modes=[],
+                )
+
+            def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+                return {"round": 0}
+
+            def get_available_actions(
+                self, state: dict[str, Any]
+            ) -> list[ActionSpec]:
+                return []
+
+            def validate_action(
+                self, state: dict[str, Any], action: Action
+            ) -> tuple[bool, str]:
+                return True, ""
+
+            def execute_action(
+                self, state: dict[str, Any], action: Action
+            ) -> tuple[ActionResult, dict[str, Any]]:
+                return ActionResult(
+                    success=True, output="ok", state_changes={}
+                ), state
+
+            def is_terminal(self, state: dict[str, Any]) -> bool:
+                return True
+
+            def evaluate_trace(
+                self, trace: ActionTrace, final_state: dict[str, Any]
+            ) -> SimulationResult:
+                return SimulationResult(
+                    score=1.0,
+                    reasoning="ok",
+                    dimension_scores={},
+                    workflow_complete=True,
+                    actions_taken=0,
+                    actions_successful=0,
+                )
+
+            def get_rubric(self) -> str:
+                return "rubric"
+
+            def max_steps(self) -> int:
+                return 5
+
+            def get_hidden_preferences(
+                self, state: dict[str, Any]
+            ) -> HiddenPreferences:
+                return HiddenPreferences(
+                    priorities={}, reservation_value=0.0,
+                    aspiration_value=100.0, batna_description="none",
+                )
+
+            def get_rounds(
+                self, state: dict[str, Any]
+            ) -> list[NegotiationRound]:
+                return []
+
+            def get_opponent_model(
+                self, state: dict[str, Any]
+            ) -> OpponentModel | None:
+                return None
+
+            def update_opponent_model(
+                self, state: dict[str, Any], model: OpponentModel
+            ) -> dict[str, Any]:
+                return state
+
+            def evaluate_negotiation(
+                self, state: dict[str, Any]
+            ) -> NegotiationResult:
+                return NegotiationResult(
+                    score=0.5, reasoning="stub", dimension_scores={},
+                    deal_value=50.0, rounds_used=0, max_rounds=5,
+                    opponent_model_accuracy=0.0, value_claimed_ratio=0.0,
+                )
+
+        stub = Stub()
+        assert stub.name == "stub_negotiation"
+        prefs = stub.get_hidden_preferences({"round": 0})
+        assert isinstance(prefs, HiddenPreferences)
+        rounds = stub.get_rounds({"round": 0})
+        assert isinstance(rounds, list)
+        assert stub.get_opponent_model({"round": 0}) is None
+        result = stub.evaluate_negotiation({"round": 0})
+        assert isinstance(result, NegotiationResult)
+        assert result.score == 0.5
+
+
+# ===========================================================================
+# Family registry integration
+# ===========================================================================
+
+
+class TestFamilyRegistration:
+    def test_family_registered(self) -> None:
+        from autocontext.scenarios.families import FAMILY_REGISTRY
+
+        assert "negotiation" in FAMILY_REGISTRY
+
+    def test_family_marker(self) -> None:
+        from autocontext.scenarios.families import get_family_marker
+
+        assert get_family_marker("negotiation") == "negotiation"
+
+    def test_detect_family(self) -> None:
+        """detect_family should resolve a NegotiationInterface instance."""
+        from autocontext.scenarios.families import detect_family
+        from autocontext.scenarios.negotiation import NegotiationInterface
+        from autocontext.scenarios.simulation import (
+            Action,
+            ActionResult,
+            ActionSpec,
+            ActionTrace,
+            EnvironmentSpec,
+            SimulationResult,
+        )
+
+        class MinimalNeg(NegotiationInterface):
+            name = "minimal_neg"
+
+            def describe_scenario(self) -> str:
+                return ""
+
+            def describe_environment(self) -> EnvironmentSpec:
+                return EnvironmentSpec(
+                    name="", description="", available_actions=[],
+                    initial_state_description="", success_criteria=[],
+                    failure_modes=[],
+                )
+
+            def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+                return {}
+
+            def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+                return []
+
+            def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+                return True, ""
+
+            def execute_action(
+                self, state: dict[str, Any], action: Action
+            ) -> tuple[ActionResult, dict[str, Any]]:
+                return ActionResult(success=True, output="", state_changes={}), state
+
+            def is_terminal(self, state: dict[str, Any]) -> bool:
+                return True
+
+            def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+                return SimulationResult(
+                    score=0.0, reasoning="", dimension_scores={},
+                    workflow_complete=False, actions_taken=0, actions_successful=0,
+                )
+
+            def get_rubric(self) -> str:
+                return ""
+
+            def max_steps(self) -> int:
+                return 1
+
+            def get_hidden_preferences(self, state: dict[str, Any]) -> Any:
+                from autocontext.scenarios.negotiation import HiddenPreferences
+                return HiddenPreferences(
+                    priorities={}, reservation_value=0.0,
+                    aspiration_value=0.0, batna_description="",
+                )
+
+            def get_rounds(self, state: dict[str, Any]) -> list:
+                return []
+
+            def get_opponent_model(self, state: dict[str, Any]) -> Any:
+                return None
+
+            def update_opponent_model(self, state: dict[str, Any], model: Any) -> dict[str, Any]:
+                return state
+
+            def evaluate_negotiation(self, state: dict[str, Any]) -> Any:
+                from autocontext.scenarios.negotiation import NegotiationResult
+                return NegotiationResult(
+                    score=0.0, reasoning="", dimension_scores={},
+                    deal_value=0.0, rounds_used=0, max_rounds=1,
+                    opponent_model_accuracy=0.0, value_claimed_ratio=0.0,
+                )
+
+        family = detect_family(MinimalNeg())
+        assert family is not None
+        assert family.name == "negotiation"
+
+
+# ===========================================================================
+# Pipeline registry integration
+# ===========================================================================
+
+
+class TestPipelineRegistration:
+    def test_pipeline_registered(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import PIPELINE_REGISTRY
+
+        assert "negotiation" in PIPELINE_REGISTRY
+
+    def test_spec_validation_valid(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        spec = {
+            "description": "Negotiate a contract",
+            "environment_description": "Two-party contract negotiation",
+            "initial_state_description": "Opening positions set",
+            "hidden_preferences": {
+                "priorities": {"price": 0.7},
+                "reservation_value": 40.0,
+                "aspiration_value": 90.0,
+                "batna_description": "Walk away",
+            },
+            "max_rounds": 5,
+            "success_criteria": ["reach agreement above reservation"],
+            "failure_modes": ["deadlock"],
+            "actions": [
+                {"name": "make_offer", "description": "d", "parameters": {},
+                 "preconditions": [], "effects": []}
+            ],
+        }
+        errors = validate_for_family("negotiation", spec)
+        assert errors == []
+
+    def test_spec_validation_missing_fields(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        errors = validate_for_family("negotiation", {"description": "x"})
+        assert len(errors) > 0
+
+    def test_source_validation(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+
+        bad_source = "class Foo:\n    pass\n"
+        errors = validate_source_for_family("negotiation", bad_source)
+        assert len(errors) > 0
+
+
+# ===========================================================================
+# Cross-family mismatch
+# ===========================================================================
+
+
+class TestCrossFamilyMismatch:
+    def test_negotiation_source_fails_tool_fragility_pipeline(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+
+        source = "class MyNeg(NegotiationInterface):\n    pass\n"
+        errors = validate_source_for_family("tool_fragility", source)
+        assert len(errors) > 0
+
+    def test_tool_fragility_source_fails_negotiation_pipeline(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+
+        source = "class MyFrag(ToolFragilityInterface):\n    pass\n"
+        errors = validate_source_for_family("negotiation", source)
+        assert len(errors) > 0
+
+
+# ===========================================================================
+# Classifier routing (hot path: classify → route)
+# ===========================================================================
+
+
+class TestClassifierRouting:
+    def test_route_negotiation(self) -> None:
+        from autocontext.scenarios.custom.family_classifier import (
+            classify_scenario_family,
+            route_to_family,
+        )
+
+        classification = classify_scenario_family(
+            "Negotiation scenario with hidden preferences where agents "
+            "model the opponent and adapt strategy across repeated rounds"
+        )
+        family = route_to_family(classification)
+        assert family.name == "negotiation"
+
+    def test_negotiate_keyword_matches(self) -> None:
+        from autocontext.scenarios.custom.family_classifier import classify_scenario_family
+
+        classification = classify_scenario_family(
+            "Negotiate a contract deal with BATNA constraints "
+            "and opponent modeling across multiple rounds"
+        )
+        assert classification.family_name == "negotiation"
+
+
+# ===========================================================================
+# Designer/spec parsing (hot path: design)
+# ===========================================================================
+
+
+class TestNegotiationDesigner:
+    def test_parse_spec(self) -> None:
+        from autocontext.scenarios.custom.negotiation_designer import (
+            NEGOTIATION_SPEC_END,
+            NEGOTIATION_SPEC_START,
+            parse_negotiation_spec,
+        )
+
+        raw = f"""{NEGOTIATION_SPEC_START}
+{{
+    "description": "Contract negotiation",
+    "environment_description": "Two parties",
+    "initial_state_description": "Opening bids",
+    "hidden_preferences": {{
+        "priorities": {{"price": 0.7, "quality": 0.3}},
+        "reservation_value": 40.0,
+        "aspiration_value": 85.0,
+        "batna_description": "Use alternative vendor"
+    }},
+    "max_rounds": 5,
+    "success_criteria": ["reach deal above reservation"],
+    "failure_modes": ["deadlock", "accept below BATNA"],
+    "actions": [
+        {{
+            "name": "make_offer", "description": "propose terms",
+            "parameters": {{"terms": "dict"}},
+            "preconditions": [], "effects": ["offer_made"]
+        }},
+        {{
+            "name": "accept", "description": "accept current terms",
+            "parameters": {{}},
+            "preconditions": ["make_offer"], "effects": ["deal_closed"]
+        }}
+    ]
+}}
+{NEGOTIATION_SPEC_END}"""
+        spec = parse_negotiation_spec(raw)
+        assert spec.description == "Contract negotiation"
+        assert spec.hidden_preferences["priorities"]["price"] == 0.7
+        assert spec.max_rounds == 5
+        assert len(spec.actions) == 2
+
+    def test_design_fn_calls_llm(self) -> None:
+        import json
+
+        from autocontext.scenarios.custom.negotiation_designer import (
+            NEGOTIATION_SPEC_END,
+            NEGOTIATION_SPEC_START,
+            design_negotiation,
+        )
+
+        fake_spec = {
+            "description": "test",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "hidden_preferences": {
+                "priorities": {"price": 0.5},
+                "reservation_value": 30.0,
+                "aspiration_value": 80.0,
+                "batna_description": "walk away",
+            },
+            "max_rounds": 3,
+            "success_criteria": ["ok"],
+            "failure_modes": [],
+            "actions": [
+                {
+                    "name": "offer", "description": "o",
+                    "parameters": {}, "preconditions": [], "effects": [],
+                }
+            ],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return (
+                f"{NEGOTIATION_SPEC_START}\n"
+                f"{json.dumps(fake_spec)}\n"
+                f"{NEGOTIATION_SPEC_END}"
+            )
+
+        spec = design_negotiation("test negotiation", fake_llm)
+        assert spec.description == "test"
+        assert spec.max_rounds == 3
+
+
+# ===========================================================================
+# Codegen (hot path: generate source)
+# ===========================================================================
+
+
+class TestNegotiationCodegen:
+    def test_generate_class(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import (
+            validate_source_for_family,
+        )
+        from autocontext.scenarios.custom.negotiation_codegen import (
+            generate_negotiation_class,
+        )
+        from autocontext.scenarios.custom.negotiation_spec import (
+            NegotiationSpec,
+        )
+        from autocontext.scenarios.custom.simulation_spec import (
+            SimulationActionSpecModel,
+        )
+
+        spec = NegotiationSpec(
+            description="test negotiation",
+            environment_description="env",
+            initial_state_description="init",
+            hidden_preferences={
+                "priorities": {"price": 0.6},
+                "reservation_value": 30.0,
+                "aspiration_value": 80.0,
+                "batna_description": "walk",
+            },
+            max_rounds=3,
+            success_criteria=["deal above reservation"],
+            failure_modes=["deadlock"],
+            actions=[
+                SimulationActionSpecModel(
+                    name="make_offer",
+                    description="propose terms",
+                    parameters={"terms": "dict"},
+                    preconditions=[],
+                    effects=["offer_made"],
+                ),
+                SimulationActionSpecModel(
+                    name="accept",
+                    description="accept terms",
+                    parameters={},
+                    preconditions=["make_offer"],
+                    effects=["deal_closed"],
+                ),
+            ],
+        )
+        source = generate_negotiation_class(spec, name="test_neg")
+        errors = validate_source_for_family("negotiation", source)
+        assert errors == [], f"validation errors: {errors}"
+
+    def test_generated_source_compiles(self) -> None:
+        from autocontext.scenarios.custom.negotiation_codegen import (
+            generate_negotiation_class,
+        )
+        from autocontext.scenarios.custom.negotiation_spec import (
+            NegotiationSpec,
+        )
+        from autocontext.scenarios.custom.simulation_spec import (
+            SimulationActionSpecModel,
+        )
+
+        spec = NegotiationSpec(
+            description="compile test",
+            environment_description="env",
+            initial_state_description="init",
+            hidden_preferences={
+                "priorities": {"speed": 0.5},
+                "reservation_value": 20.0,
+                "aspiration_value": 70.0,
+                "batna_description": "none",
+            },
+            max_rounds=2,
+            success_criteria=["ok"],
+            failure_modes=[],
+            actions=[
+                SimulationActionSpecModel(
+                    name="bid", description="bid", parameters={},
+                    preconditions=[], effects=["bid_done"],
+                ),
+            ],
+        )
+        source = generate_negotiation_class(spec, name="compile_test")
+        compile(source, "<test>", "exec")
+
+
+# ===========================================================================
+# Creator end-to-end (hot path: create → persist → load → register)
+# ===========================================================================
+
+
+class TestNegotiationCreator:
+    def test_create_and_persist(self, tmp_path: Path) -> None:
+        import json
+
+        from autocontext.scenarios.custom.negotiation_creator import (
+            NegotiationCreator,
+        )
+        from autocontext.scenarios.custom.negotiation_designer import (
+            NEGOTIATION_SPEC_END,
+            NEGOTIATION_SPEC_START,
+        )
+        from autocontext.scenarios.negotiation import NegotiationInterface
+
+        fake_spec = {
+            "description": "test creation",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "hidden_preferences": {
+                "priorities": {"p": 0.5},
+                "reservation_value": 25.0,
+                "aspiration_value": 75.0,
+                "batna_description": "leave",
+            },
+            "max_rounds": 3,
+            "success_criteria": ["done"],
+            "failure_modes": [],
+            "actions": [
+                {
+                    "name": "offer", "description": "o",
+                    "parameters": {}, "preconditions": [], "effects": [],
+                }
+            ],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return (
+                f"{NEGOTIATION_SPEC_START}\n"
+                f"{json.dumps(fake_spec)}\n"
+                f"{NEGOTIATION_SPEC_END}"
+            )
+
+        creator = NegotiationCreator(fake_llm, tmp_path)
+        scenario = creator.create("test negotiation", name="test_neg_creator")
+        assert isinstance(scenario, NegotiationInterface)
+
+        scenario_dir = tmp_path / "_custom_scenarios" / "test_neg_creator"
+        assert (scenario_dir / "scenario.py").exists()
+        assert (scenario_dir / "spec.json").exists()
+        assert (scenario_dir / "scenario_type.txt").exists()
+        assert (
+            (scenario_dir / "scenario_type.txt").read_text().strip()
+            == "negotiation"
+        )
+
+
+# ===========================================================================
+# Router dispatch from AgentTaskCreator (hot path: routing)
+# ===========================================================================
+
+
+class TestAgentTaskCreatorRouting:
+    def test_routes_to_negotiation(self, tmp_path: Path) -> None:
+        import json
+
+        from autocontext.scenarios.custom.agent_task_creator import (
+            AgentTaskCreator,
+        )
+        from autocontext.scenarios.custom.negotiation_designer import (
+            NEGOTIATION_SPEC_END,
+            NEGOTIATION_SPEC_START,
+        )
+        from autocontext.scenarios.negotiation import NegotiationInterface
+
+        fake_spec = {
+            "description": "routing test",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "hidden_preferences": {
+                "priorities": {"p": 0.5},
+                "reservation_value": 20.0,
+                "aspiration_value": 70.0,
+                "batna_description": "walk",
+            },
+            "max_rounds": 3,
+            "success_criteria": ["done"],
+            "failure_modes": [],
+            "actions": [
+                {
+                    "name": "offer", "description": "o",
+                    "parameters": {}, "preconditions": [], "effects": [],
+                }
+            ],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return (
+                f"{NEGOTIATION_SPEC_START}\n"
+                f"{json.dumps(fake_spec)}\n"
+                f"{NEGOTIATION_SPEC_END}"
+            )
+
+        creator = AgentTaskCreator(fake_llm, tmp_path)
+        scenario = creator.create(
+            "Negotiation scenario with hidden preferences "
+            "where agents model the opponent across repeated rounds"
+        )
+        assert isinstance(scenario, NegotiationInterface)

--- a/ts/src/scenarios/agent-task-creator.ts
+++ b/ts/src/scenarios/agent-task-creator.ts
@@ -25,6 +25,10 @@ import {
   InvestigationCreator,
 } from "./investigation-creator.js";
 import {
+  type NegotiationScenarioHandle,
+  NegotiationCreator,
+} from "./negotiation-creator.js";
+import {
   type SchemaEvolutionScenarioHandle,
   SchemaEvolutionCreator,
 } from "./schema-evolution-creator.js";
@@ -51,6 +55,7 @@ export type CreatedScenario =
   | (AgentTaskInterface & { readonly name: string; readonly spec: AgentTaskSpec; readonly family?: "agent_task" })
   | ArtifactEditingScenarioHandle
   | InvestigationScenarioHandle
+  | NegotiationScenarioHandle
   | SchemaEvolutionScenarioHandle
   | SimulationScenarioHandle
   | ToolFragilityScenarioHandle
@@ -146,6 +151,13 @@ export class AgentTaskCreator {
     }
     if (family === "tool_fragility") {
       return new ToolFragilityCreator({
+        provider: this.provider,
+        model: this.model,
+        knowledgeRoot: this.knowledgeRoot,
+      }).create(description, name);
+    }
+    if (family === "negotiation") {
+      return new NegotiationCreator({
         provider: this.provider,
         model: this.model,
         knowledgeRoot: this.knowledgeRoot,

--- a/ts/src/scenarios/families.ts
+++ b/ts/src/scenarios/families.ts
@@ -6,7 +6,8 @@ export type ScenarioFamilyName =
   | "investigation"
   | "workflow"
   | "schema_evolution"
-  | "tool_fragility";
+  | "tool_fragility"
+  | "negotiation";
 
 export const SCENARIO_TYPE_MARKERS: Record<ScenarioFamilyName, string> = {
   game: "parametric",
@@ -17,6 +18,7 @@ export const SCENARIO_TYPE_MARKERS: Record<ScenarioFamilyName, string> = {
   workflow: "workflow",
   schema_evolution: "schema_evolution",
   tool_fragility: "tool_fragility",
+  negotiation: "negotiation",
 };
 
 export function getScenarioTypeMarker(family: ScenarioFamilyName): string {

--- a/ts/src/scenarios/family-classifier.ts
+++ b/ts/src/scenarios/family-classifier.ts
@@ -209,6 +209,23 @@ const TOOL_FRAGILITY_SIGNALS: Record<string, number> = {
   "tool failure": 1.5,
 };
 
+const NEGOTIATION_SIGNALS: Record<string, number> = {
+  negotiat: 2.0,
+  adversarial: 1.5,
+  batna: 2.0,
+  "hidden preference": 2.0,
+  "reservation value": 1.5,
+  "aspiration value": 1.5,
+  counteroffer: 1.5,
+  "counter offer": 1.5,
+  "deal quality": 1.5,
+  "opponent modeling": 2.0,
+  anchoring: 1.0,
+  seller: 1.0,
+  buyer: 1.0,
+  concession: 1.0,
+};
+
 const FAMILY_SIGNAL_GROUPS: Record<ScenarioFamilyName, Record<string, number>> = {
   game: GAME_SIGNALS,
   agent_task: AGENT_TASK_SIGNALS,
@@ -218,6 +235,7 @@ const FAMILY_SIGNAL_GROUPS: Record<ScenarioFamilyName, Record<string, number>> =
   workflow: WORKFLOW_SIGNALS,
   schema_evolution: SCHEMA_EVOLUTION_SIGNALS,
   tool_fragility: TOOL_FRAGILITY_SIGNALS,
+  negotiation: NEGOTIATION_SIGNALS,
 };
 
 const DEFAULT_FAMILY_NAME: ScenarioFamilyName = "agent_task";

--- a/ts/src/scenarios/family-pipeline.ts
+++ b/ts/src/scenarios/family-pipeline.ts
@@ -3,6 +3,7 @@ import { ArtifactEditingSpecSchema, type ArtifactEditingSpec } from "./artifact-
 import { validateSpec as validateAgentTaskSpec } from "./agent-task-validator.js";
 import { type ScenarioFamilyName } from "./families.js";
 import { InvestigationSpecSchema, type InvestigationSpec } from "./investigation-spec.js";
+import { NegotiationSpecSchema, type NegotiationSpec } from "./negotiation-spec.js";
 import { SchemaEvolutionSpecSchema, type SchemaEvolutionSpec } from "./schema-evolution-spec.js";
 import { SimulationSpecSchema, type SimulationSpec } from "./simulation-spec.js";
 import { ToolFragilitySpecSchema, type ToolFragilitySpec } from "./tool-fragility-spec.js";
@@ -111,6 +112,19 @@ const toolFragilityPipeline: FamilyPipeline<ToolFragilitySpec> = {
   },
 };
 
+const negotiationPipeline: FamilyPipeline<NegotiationSpec> = {
+  familyName: "negotiation",
+  validateSpec(spec: NegotiationSpec): string[] {
+    const result = NegotiationSpecSchema.safeParse(spec);
+    if (!result.success) {
+      return result.error.issues.map(
+        (issue) => `${issue.path.join(".")}: ${issue.message}`,
+      );
+    }
+    return [];
+  },
+};
+
 const PIPELINE_REGISTRY = {
   agent_task: agentTaskPipeline,
   simulation: simulationPipeline,
@@ -119,6 +133,7 @@ const PIPELINE_REGISTRY = {
   workflow: workflowPipeline,
   schema_evolution: schemaEvolutionPipeline,
   tool_fragility: toolFragilityPipeline,
+  negotiation: negotiationPipeline,
 } as const;
 
 export function hasPipeline(family: string): family is keyof typeof PIPELINE_REGISTRY {
@@ -141,7 +156,8 @@ export function validateForFamily(
     | InvestigationSpec
     | WorkflowSpec
     | SchemaEvolutionSpec
-    | ToolFragilitySpec,
+    | ToolFragilitySpec
+    | NegotiationSpec,
 ): string[] {
   const pipeline = getPipeline(family);
   return pipeline.validateSpec(spec as never);

--- a/ts/src/scenarios/negotiation-creator.ts
+++ b/ts/src/scenarios/negotiation-creator.ts
@@ -1,0 +1,271 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { LLMProvider } from "../types/index.js";
+import { validateForFamily } from "./family-pipeline.js";
+import { getScenarioTypeMarker } from "./families.js";
+import type { NegotiationSpec } from "./negotiation-spec.js";
+import { designNegotiation } from "./negotiation-designer.js";
+
+export interface NegotiationCreatorOpts {
+  provider: LLMProvider;
+  model?: string;
+  knowledgeRoot: string;
+}
+
+export interface NegotiationScenarioHandle {
+  family: "negotiation";
+  name: string;
+  spec: NegotiationSpec;
+}
+
+function className(name: string): string {
+  return name
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join("") + "Negotiation";
+}
+
+function generateScenarioSource(spec: NegotiationSpec, name: string): string {
+  const actions = spec.actions
+    .map((action) => `            ActionSpec(name=${JSON.stringify(action.name)}, description=${JSON.stringify(action.description)}, parameters=${JSON.stringify(action.parameters)}, preconditions=${JSON.stringify(action.preconditions)}, effects=${JSON.stringify(action.effects)})`)
+    .join(",\n");
+  const requiredActions = JSON.stringify(spec.actions.map((action) => action.name));
+  const hiddenPrefs = JSON.stringify({
+    priorities: spec.hiddenPreferences.priorities,
+    reservation_value: spec.hiddenPreferences.reservationValue,
+    aspiration_value: spec.hiddenPreferences.aspirationValue,
+    batna_description: spec.hiddenPreferences.batnaDescription,
+  });
+  return `from __future__ import annotations
+
+from typing import Any
+
+from autocontext.scenarios.negotiation import HiddenPreferences, NegotiationInterface, NegotiationResult, NegotiationRound, OpponentModel
+from autocontext.scenarios.simulation import Action, ActionResult, ActionSpec, ActionTrace, EnvironmentSpec, SimulationResult
+
+
+class ${className(name)}(NegotiationInterface):
+    name = ${JSON.stringify(name)}
+    _hidden_prefs_spec = ${hiddenPrefs}
+
+    def describe_scenario(self) -> str:
+        return ${JSON.stringify(spec.description)}
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name=${JSON.stringify(name)},
+            description=${JSON.stringify(spec.environmentDescription)},
+            available_actions=[
+${actions}
+            ],
+            initial_state_description=${JSON.stringify(spec.initialStateDescription)},
+            success_criteria=${JSON.stringify(spec.successCriteria)},
+            failure_modes=${JSON.stringify(spec.failureModes)},
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {
+            "seed": seed or 0,
+            "step": 0,
+            "round": 0,
+            "max_rounds": ${spec.maxRounds},
+            "rounds": [],
+            "completed_actions": [],
+            "failed_actions": [],
+            "opponent_model": None,
+            "deal_value": None,
+            "deal_closed": False,
+        }
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        completed = set(state.get("completed_actions", []))
+        return [s for s in self.describe_environment().available_actions if s.name not in completed]
+
+    def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+        specs = {s.name: s for s in self.describe_environment().available_actions}
+        spec = specs.get(action.name)
+        if spec is None:
+            return False, f"unknown action: {action.name}"
+        completed = set(state.get("completed_actions", []))
+        for req in spec.preconditions:
+            if req not in completed:
+                return False, f"precondition not met for {action.name}: {req}"
+        return True, ""
+
+    def execute_action(self, state: dict[str, Any], action: Action) -> tuple[ActionResult, dict[str, Any]]:
+        valid, reason = self.validate_action(state, action)
+        next_state = dict(state)
+        if not valid:
+            next_state["failed_actions"] = [*state.get("failed_actions", []), action.name]
+            return ActionResult(success=False, output="", state_changes={}, error=reason), next_state
+
+        next_state["completed_actions"] = [*state.get("completed_actions", []), action.name]
+        next_state["round"] = state.get("round", 0) + 1
+        offer = action.parameters if action.parameters else {}
+        rnd = {
+            "round_number": next_state["round"],
+            "offer": offer,
+            "counter_offer": None,
+            "accepted": action.name == "accept",
+            "agent_reasoning": action.parameters.get("reasoning", "") if action.parameters else "",
+        }
+        next_state["rounds"] = [*state.get("rounds", []), rnd]
+
+        if action.name == "accept":
+            next_state["deal_closed"] = True
+            rounds_used = next_state["round"]
+            reservation = self._hidden_prefs_spec.get("reservation_value", 0.0)
+            aspiration = self._hidden_prefs_spec.get("aspiration_value", 100.0)
+            ratio = 1.0 - (rounds_used / max(state.get("max_rounds", ${spec.maxRounds}), 1))
+            next_state["deal_value"] = round(reservation + ratio * (aspiration - reservation), 2)
+
+        return (
+            ActionResult(
+                success=True,
+                output=f"executed {action.name} (round {next_state['round']})",
+                state_changes={"round": next_state["round"]},
+            ),
+            next_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        required = set(${requiredActions})
+        completed = set(state.get("completed_actions", []))
+        return state.get("deal_closed", False) or required.issubset(completed) or state.get("round", 0) >= state.get("max_rounds", ${spec.maxRounds}) or state.get("step", 0) >= ${spec.maxSteps}
+
+    def get_hidden_preferences(self, state: dict[str, Any]) -> HiddenPreferences:
+        del state
+        return HiddenPreferences(
+            priorities=self._hidden_prefs_spec.get("priorities", {}),
+            reservation_value=self._hidden_prefs_spec.get("reservation_value", 0.0),
+            aspiration_value=self._hidden_prefs_spec.get("aspiration_value", 100.0),
+            batna_description=self._hidden_prefs_spec.get("batna_description", ""),
+        )
+
+    def get_rounds(self, state: dict[str, Any]) -> list[NegotiationRound]:
+        return [NegotiationRound.from_dict(rnd) for rnd in state.get("rounds", [])]
+
+    def get_opponent_model(self, state: dict[str, Any]) -> OpponentModel | None:
+        raw = state.get("opponent_model")
+        if raw is None:
+            return None
+        return OpponentModel.from_dict(raw)
+
+    def update_opponent_model(self, state: dict[str, Any], model: OpponentModel) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["opponent_model"] = model.to_dict()
+        return next_state
+
+    def evaluate_negotiation(self, state: dict[str, Any]) -> NegotiationResult:
+        prefs = self.get_hidden_preferences(state)
+        deal_value = state.get("deal_value") or 0.0
+        rounds_used = state.get("round", 0)
+        max_rounds = state.get("max_rounds", ${spec.maxRounds})
+        surplus = prefs.aspiration_value - prefs.reservation_value
+        value_ratio = max(0.0, (deal_value - prefs.reservation_value) / surplus) if surplus > 0 else (1.0 if deal_value >= prefs.reservation_value else 0.0)
+        efficiency = 1.0 - (rounds_used / max(max_rounds, 1))
+        opponent_model = self.get_opponent_model(state)
+        if opponent_model is not None:
+            diffs = [abs(actual - opponent_model.inferred_priorities.get(dim, 0.0)) for dim, actual in prefs.priorities.items()]
+            model_accuracy = max(0.0, 1.0 - (sum(diffs) / max(len(diffs), 1)))
+        else:
+            model_accuracy = 0.0
+        adaptation = min(1.0, len(state.get("rounds", [])) * 0.2)
+        score = round(value_ratio * 0.35 + model_accuracy * 0.25 + efficiency * 0.2 + adaptation * 0.2, 4)
+        return NegotiationResult(
+            score=score,
+            reasoning=f"Deal value {deal_value} ({rounds_used}/{max_rounds} rounds). Model accuracy: {model_accuracy:.2f}.",
+            dimension_scores={"deal_quality": round(value_ratio, 4), "opponent_modeling": round(model_accuracy, 4), "efficiency": round(efficiency, 4), "adaptation": round(adaptation, 4)},
+            deal_value=deal_value,
+            rounds_used=rounds_used,
+            max_rounds=max_rounds,
+            opponent_model_accuracy=round(model_accuracy, 4),
+            value_claimed_ratio=round(value_ratio, 4),
+        )
+
+    def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+        negotiation = self.evaluate_negotiation(final_state)
+        action_success = trace.success_rate
+        score = round(negotiation.score * 0.7 + action_success * 0.3, 4)
+        return SimulationResult(
+            score=score,
+            reasoning=negotiation.reasoning,
+            dimension_scores={"deal_quality": negotiation.dimension_scores.get("deal_quality", 0.0), "opponent_modeling": negotiation.dimension_scores.get("opponent_modeling", 0.0), "efficiency": negotiation.dimension_scores.get("efficiency", 0.0), "adaptation": negotiation.dimension_scores.get("adaptation", 0.0), "action_success": round(action_success, 4)},
+            workflow_complete=final_state.get("deal_closed", False),
+            actions_taken=len(trace.records),
+            actions_successful=sum(1 for record in trace.records if record.result.success),
+            recovery_attempts=len(final_state.get("failed_actions", [])),
+            rollback_quality=negotiation.dimension_scores.get("efficiency", 0.0),
+        )
+
+    def get_rubric(self) -> str:
+        return "Evaluate on deal quality relative to BATNA, opponent modeling accuracy, negotiation efficiency, and strategic adaptation across rounds."
+
+    def max_steps(self) -> int:
+        return ${spec.maxSteps}
+`;
+}
+
+export class NegotiationCreator {
+  private provider: LLMProvider;
+  private model: string;
+  private knowledgeRoot: string;
+
+  constructor(opts: NegotiationCreatorOpts) {
+    this.provider = opts.provider;
+    this.model = opts.model ?? opts.provider.defaultModel();
+    this.knowledgeRoot = opts.knowledgeRoot;
+  }
+
+  async create(description: string, name: string): Promise<NegotiationScenarioHandle> {
+    const llmFn = async (system: string, user: string): Promise<string> => {
+      const result = await this.provider.complete({
+        systemPrompt: system,
+        userPrompt: user,
+        model: this.model,
+      });
+      return result.text;
+    };
+    const spec = await designNegotiation(description, llmFn);
+    const errors = validateForFamily("negotiation", spec);
+    if (errors.length > 0) {
+      throw new Error(`negotiation spec validation failed: ${errors.join("; ")}`);
+    }
+
+    const customDir = join(this.knowledgeRoot, "_custom_scenarios");
+    const scenarioDir = join(customDir, name);
+    if (!existsSync(scenarioDir)) mkdirSync(scenarioDir, { recursive: true });
+
+    writeFileSync(join(scenarioDir, "scenario.py"), generateScenarioSource(spec, name), "utf-8");
+    writeFileSync(join(scenarioDir, "scenario_type.txt"), getScenarioTypeMarker("negotiation"), "utf-8");
+    writeFileSync(
+      join(scenarioDir, "spec.json"),
+      JSON.stringify(
+        {
+          name,
+          scenario_type: getScenarioTypeMarker("negotiation"),
+          description: spec.description,
+          environment_description: spec.environmentDescription,
+          initial_state_description: spec.initialStateDescription,
+          hidden_preferences: {
+            priorities: spec.hiddenPreferences.priorities,
+            reservation_value: spec.hiddenPreferences.reservationValue,
+            aspiration_value: spec.hiddenPreferences.aspirationValue,
+            batna_description: spec.hiddenPreferences.batnaDescription,
+          },
+          max_rounds: spec.maxRounds,
+          success_criteria: spec.successCriteria,
+          failure_modes: spec.failureModes,
+          max_steps: spec.maxSteps,
+          actions: spec.actions,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    return { family: "negotiation", name, spec };
+  }
+}

--- a/ts/src/scenarios/negotiation-designer.ts
+++ b/ts/src/scenarios/negotiation-designer.ts
@@ -1,0 +1,109 @@
+import type { NegotiationSpec } from "./negotiation-spec.js";
+import { parseRawNegotiationSpec } from "./negotiation-spec.js";
+
+export const NEGOTIATION_SPEC_START = "<!-- NEGOTIATION_SPEC_START -->";
+export const NEGOTIATION_SPEC_END = "<!-- NEGOTIATION_SPEC_END -->";
+
+const EXAMPLE_SPEC = {
+  description: "Contract price negotiation with hidden BATNA.",
+  environment_description: "Buyer-seller negotiation over contract terms.",
+  initial_state_description: "Both parties have opening positions; hidden preferences unknown.",
+  hidden_preferences: {
+    priorities: { price: 0.6, delivery_time: 0.3, warranty: 0.1 },
+    reservation_value: 50.0,
+    aspiration_value: 85.0,
+    batna_description: "Switch to alternative vendor with longer lead time.",
+  },
+  max_rounds: 5,
+  success_criteria: [
+    "reach agreement above reservation value",
+    "accurately model opponent priorities by final round",
+  ],
+  failure_modes: ["deadlock without agreement", "accept below BATNA"],
+  actions: [
+    {
+      name: "make_offer",
+      description: "Propose contract terms to the opponent.",
+      parameters: { terms: "dict" },
+      preconditions: [],
+      effects: ["offer_on_table"],
+    },
+    {
+      name: "counter_offer",
+      description: "Respond with modified terms.",
+      parameters: { terms: "dict" },
+      preconditions: ["make_offer"],
+      effects: ["counter_on_table"],
+    },
+    {
+      name: "accept",
+      description: "Accept the current terms on the table.",
+      parameters: {},
+      preconditions: ["make_offer"],
+      effects: ["deal_closed"],
+    },
+  ],
+};
+
+export const NEGOTIATION_DESIGNER_SYSTEM = `You are a scenario designer for autocontext.
+Given a natural-language request for a negotiation or adversarial hidden-state scenario, produce a NegotiationSpec JSON.
+
+Wrap the output in delimiters:
+${NEGOTIATION_SPEC_START}
+{ ... }
+${NEGOTIATION_SPEC_END}
+
+Schema:
+{
+  "description": "scenario summary",
+  "environment_description": "negotiation context",
+  "initial_state_description": "starting positions",
+  "hidden_preferences": {
+    "priorities": {"dimension": weight},
+    "reservation_value": 50.0,
+    "aspiration_value": 85.0,
+    "batna_description": "string"
+  },
+  "max_rounds": 5,
+  "success_criteria": ["criterion"],
+  "failure_modes": ["failure mode"],
+  "actions": [
+    {
+      "name": "snake_case",
+      "description": "what the action does",
+      "parameters": {"param": "type"},
+      "preconditions": [],
+      "effects": ["effect"]
+    }
+  ]
+}
+
+Rules:
+- hidden_preferences must include priorities, reservation_value, aspiration_value, batna_description
+- include at least two actions
+- max_rounds should be between 2 and 10
+
+Example:
+${NEGOTIATION_SPEC_START}
+${JSON.stringify(EXAMPLE_SPEC, null, 2)}
+${NEGOTIATION_SPEC_END}
+`;
+
+export function parseNegotiationSpec(text: string): NegotiationSpec {
+  const startIdx = text.indexOf(NEGOTIATION_SPEC_START);
+  const endIdx = text.indexOf(NEGOTIATION_SPEC_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
+    throw new Error("response does not contain NEGOTIATION_SPEC delimiters");
+  }
+  const raw = text.slice(startIdx + NEGOTIATION_SPEC_START.length, endIdx).trim();
+  return parseRawNegotiationSpec(JSON.parse(raw) as Record<string, unknown>);
+}
+
+export async function designNegotiation(
+  description: string,
+  llmFn: (system: string, user: string) => Promise<string>,
+): Promise<NegotiationSpec> {
+  return parseNegotiationSpec(
+    await llmFn(NEGOTIATION_DESIGNER_SYSTEM, `User description:\n${description}`),
+  );
+}

--- a/ts/src/scenarios/negotiation-spec.ts
+++ b/ts/src/scenarios/negotiation-spec.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { SimulationActionSpecSchema } from "./simulation-spec.js";
+
+export const HiddenPreferencesSchema = z.object({
+  priorities: z.record(z.number()),
+  reservationValue: z.number(),
+  aspirationValue: z.number(),
+  batnaDescription: z.string().min(1),
+});
+
+export const NegotiationSpecSchema = z.object({
+  description: z.string().min(1),
+  environmentDescription: z.string().min(1),
+  initialStateDescription: z.string().min(1),
+  hiddenPreferences: HiddenPreferencesSchema,
+  maxRounds: z.number().int().min(2).max(10),
+  successCriteria: z.array(z.string().min(1)).min(1),
+  failureModes: z.array(z.string().min(1)).default([]),
+  actions: z.array(SimulationActionSpecSchema).min(2),
+  maxSteps: z.number().int().nonnegative().default(0),
+});
+
+export type HiddenPreferences = z.infer<typeof HiddenPreferencesSchema>;
+export type NegotiationSpec = z.infer<typeof NegotiationSpecSchema>;
+
+export function parseRawNegotiationSpec(data: Record<string, unknown>): NegotiationSpec {
+  const parsed = NegotiationSpecSchema.parse({
+    description: data.description,
+    environmentDescription: data.environment_description,
+    initialStateDescription: data.initial_state_description,
+    hiddenPreferences: (() => {
+      const raw = data.hidden_preferences as Record<string, unknown>;
+      return {
+        priorities: raw.priorities,
+        reservationValue: raw.reservation_value,
+        aspirationValue: raw.aspiration_value,
+        batnaDescription: raw.batna_description,
+      };
+    })(),
+    maxRounds: data.max_rounds,
+    successCriteria: data.success_criteria,
+    failureModes: data.failure_modes ?? [],
+    actions: data.actions,
+    maxSteps: data.max_steps ?? 0,
+  });
+  return {
+    ...parsed,
+    maxSteps: parsed.maxSteps > 0 ? parsed.maxSteps : Math.max(parsed.maxRounds * 2, 4),
+  };
+}

--- a/ts/tests/agent-task-pipeline.test.ts
+++ b/ts/tests/agent-task-pipeline.test.ts
@@ -20,6 +20,10 @@ import {
   INVESTIGATION_SPEC_START,
 } from "../src/scenarios/investigation-designer.js";
 import {
+  NEGOTIATION_SPEC_END,
+  NEGOTIATION_SPEC_START,
+} from "../src/scenarios/negotiation-designer.js";
+import {
   SCHEMA_EVOLUTION_SPEC_END,
   SCHEMA_EVOLUTION_SPEC_START,
 } from "../src/scenarios/schema-evolution-designer.js";
@@ -43,6 +47,7 @@ import { createAgentTask } from "../src/scenarios/agent-task-factory.js";
 import { AgentTaskCreator } from "../src/scenarios/agent-task-creator.js";
 import type { AgentTaskSpec } from "../src/scenarios/agent-task-spec.js";
 import type { InvestigationSpec } from "../src/scenarios/investigation-spec.js";
+import type { NegotiationSpec } from "../src/scenarios/negotiation-spec.js";
 import type { SchemaEvolutionSpec } from "../src/scenarios/schema-evolution-spec.js";
 import type { SimulationSpec } from "../src/scenarios/simulation-spec.js";
 import type { ToolFragilitySpec } from "../src/scenarios/tool-fragility-spec.js";
@@ -299,6 +304,47 @@ function mockToolFragilityResponse(): string {
   return `${TOOL_FRAGILITY_SPEC_START}\n${JSON.stringify(data, null, 2)}\n${TOOL_FRAGILITY_SPEC_END}\n`;
 }
 
+function mockNegotiationResponse(): string {
+  const data = {
+    description: "Negotiate a contract with hidden opponent preferences and BATNA constraints.",
+    environment_description: "Buyer-seller negotiation over price, timing, and warranty.",
+    initial_state_description: "Both sides have opening positions and hidden priorities.",
+    hidden_preferences: {
+      priorities: { price: 0.6, delivery_time: 0.3, warranty: 0.1 },
+      reservation_value: 50.0,
+      aspiration_value: 85.0,
+      batna_description: "Switch to a slower alternative vendor.",
+    },
+    max_rounds: 5,
+    success_criteria: ["reach agreement above reservation value", "model opponent priorities"],
+    failure_modes: ["deadlock without agreement"],
+    actions: [
+      {
+        name: "make_offer",
+        description: "Propose contract terms.",
+        parameters: { terms: "dict" },
+        preconditions: [],
+        effects: ["offer_on_table"],
+      },
+      {
+        name: "counter_offer",
+        description: "Respond with modified terms.",
+        parameters: { terms: "dict" },
+        preconditions: ["make_offer"],
+        effects: ["counter_on_table"],
+      },
+      {
+        name: "accept",
+        description: "Accept the current offer.",
+        parameters: {},
+        preconditions: ["make_offer"],
+        effects: ["deal_closed"],
+      },
+    ],
+  };
+  return `${NEGOTIATION_SPEC_START}\n${JSON.stringify(data, null, 2)}\n${NEGOTIATION_SPEC_END}\n`;
+}
+
 function makeMockProvider(response = "mock output"): LLMProvider {
   return {
     complete: async () => ({ text: response, model: "mock", usage: { inputTokens: 0, outputTokens: 0 } }) as CompletionResult,
@@ -540,6 +586,29 @@ describe("FamilyPipeline", () => {
       ],
     };
     expect(validateForFamily("tool_fragility", spec)).toEqual([]);
+  });
+
+  it("validates negotiation specs through the family pipeline", () => {
+    const spec: NegotiationSpec = {
+      description: "Negotiate a contract with hidden BATNA.",
+      environmentDescription: "Buyer-seller contract negotiation.",
+      initialStateDescription: "Both parties have opening positions.",
+      hiddenPreferences: {
+        priorities: { price: 0.6, delivery_time: 0.3, warranty: 0.1 },
+        reservationValue: 50.0,
+        aspirationValue: 85.0,
+        batnaDescription: "Switch to a slower alternative vendor.",
+      },
+      maxRounds: 5,
+      successCriteria: ["reach agreement", "model opponent priorities"],
+      failureModes: ["deadlock"],
+      actions: [
+        { name: "make_offer", description: "Make an offer", parameters: { terms: "dict" }, preconditions: [], effects: ["offer_on_table"] },
+        { name: "accept", description: "Accept an offer", parameters: {}, preconditions: ["make_offer"], effects: ["deal_closed"] },
+      ],
+      maxSteps: 10,
+    };
+    expect(validateForFamily("negotiation", spec)).toEqual([]);
   });
 
   it("rejects unsupported families instead of collapsing silently", () => {
@@ -820,6 +889,21 @@ describe("AgentTaskCreator", () => {
     expect(readFileSync(join(scenarioDir, "scenario_type.txt"), "utf-8")).toBe(getScenarioTypeMarker("tool_fragility"));
   });
 
+  it("routes negotiation descriptions into a negotiation scaffold", async () => {
+    const provider = makeMockProvider(mockNegotiationResponse());
+    const tmpDir = mkdtempSync(join(tmpdir(), "autocontext-creator-negotiation-"));
+    const creator = new AgentTaskCreator({ provider, knowledgeRoot: tmpDir });
+
+    const scenario = await creator.create("Create a negotiation scenario with hidden BATNA, counteroffers, and adversarial preferences");
+    expect("family" in scenario && scenario.family).toBe("negotiation");
+
+    const name = creator.deriveName("Create a negotiation scenario with hidden BATNA, counteroffers, and adversarial preferences");
+    const scenarioDir = join(tmpDir, "_custom_scenarios", name);
+    expect(existsSync(join(scenarioDir, "scenario.py"))).toBe(true);
+    expect(existsSync(join(scenarioDir, "spec.json"))).toBe(true);
+    expect(readFileSync(join(scenarioDir, "scenario_type.txt"), "utf-8")).toBe(getScenarioTypeMarker("negotiation"));
+  });
+
   it("rejects classified-but-unsupported game families", async () => {
     const provider = makeMockProvider(mockLlmResponse(SAMPLE_SPEC));
     const tmpDir = mkdtempSync(join(tmpdir(), "autocontext-creator-game-"));
@@ -859,6 +943,12 @@ describe("AgentTaskCreator", () => {
     expect(
       classifyScenarioFamily("Create a tool fragility scenario with API contract drift and environment changes").familyName,
     ).toBe("tool_fragility");
+  });
+
+  it("classifies negotiation descriptions into the negotiation family", () => {
+    expect(
+      classifyScenarioFamily("Create a negotiation scenario with hidden BATNA, counteroffers, and adversarial preferences").familyName,
+    ).toBe("negotiation");
   });
 });
 


### PR DESCRIPTION
## Summary
Adds the `negotiation` scenario family (AC-250) — negotiation under hidden preferences, BATNA constraints, and repeated rounds. Full vertical slice wired end-to-end: classify → create → persist → load → run.

### Data models
| Model | Purpose |
|-------|---------|
| `HiddenPreferences` | Opponent's hidden priorities, reservation/aspiration values, BATNA |
| `NegotiationRound` | Per-round offer/counter-offer tracking with acceptance state |
| `OpponentModel` | Agent's inferred opponent model (priorities, strategy, confidence) |
| `NegotiationResult` | Multi-dimension evaluation: deal_quality, opponent_modeling, efficiency, adaptation |

### Evaluation dimensions
- **Deal quality** — value claimed relative to BATNA/reservation
- **Opponent modeling** — accuracy of inferred priorities vs hidden ground truth
- **Efficiency** — fewer rounds to agreement = higher score
- **Adaptation** — strategic adjustments across rounds

### New modules
| Module | Purpose |
|--------|---------|
| `scenarios/negotiation.py` | Interface + data models |
| `custom/negotiation_{spec,designer,codegen,creator}.py` | Creation pipeline |

### Integration wiring
- `families.py` — registered with `negotiation_evaluation` mode
- `family_pipeline.py` — NegotiationPipeline with hidden_preferences validation
- `family_classifier.py` — signal dict (batna, opponent model, negotiate, etc.)
- `agent_task_creator.py` — routing branch for NegotiationCreator

## Test plan
- [x] 28 tests in `test_negotiation.py`
- [x] Data model construction + serialization roundtrip (all 4 models)
- [x] ABC enforcement (cannot instantiate, concrete subclass works)
- [x] Family registry integration (registered, marker, detect_family)
- [x] Pipeline registry (spec validation, source validation)
- [x] Classifier routing (negotiation signals resolve correctly)
- [x] Designer/codegen (spec parsing, LLM-driven design, source generation + compilation)
- [x] Creator end-to-end (create → persist → load → register)
- [x] AgentTaskCreator dispatch (routes to negotiation family)
- [x] Cross-family mismatch tests
- [x] Full suite: 3698 passed, 46 skipped
- [x] ruff + mypy clean