### PR TITLE
feat(AC-251, AC-253): operator-in-the-loop and multi-agent coordination scenario families

### DIFF
--- a/autocontext/src/autocontext/scenarios/coordination.py
+++ b/autocontext/src/autocontext/scenarios/coordination.py
@@ -1,0 +1,145 @@
+"""Multi-agent coordination scenario family (AC-253).
+
+Scenarios where multiple worker agents coordinate under partial context,
+hand off information, and merge outputs. Evaluated on duplication avoidance,
+handoff quality, merge quality, and final outcome quality.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+from autocontext.scenarios.simulation import SimulationInterface
+
+
+@dataclass(slots=True)
+class WorkerContext:
+    """Partial context assigned to a worker agent."""
+
+    worker_id: str
+    role: str
+    context_partition: dict[str, Any]  # what this worker can see
+    visible_data: list[str]  # keys/sections visible to this worker
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "worker_id": self.worker_id,
+            "role": self.role,
+            "context_partition": self.context_partition,
+            "visible_data": self.visible_data,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> WorkerContext:
+        return cls(
+            worker_id=data["worker_id"],
+            role=data["role"],
+            context_partition=data.get("context_partition", {}),
+            visible_data=data.get("visible_data", []),
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass(slots=True)
+class HandoffRecord:
+    """A record of information passed between workers."""
+
+    from_worker: str
+    to_worker: str
+    content: str
+    quality: float  # 0.0–1.0
+    step: int
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "from_worker": self.from_worker,
+            "to_worker": self.to_worker,
+            "content": self.content,
+            "quality": self.quality,
+            "step": self.step,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> HandoffRecord:
+        return cls(
+            from_worker=data["from_worker"],
+            to_worker=data["to_worker"],
+            content=data["content"],
+            quality=data["quality"],
+            step=data["step"],
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass(slots=True)
+class CoordinationResult:
+    """Evaluation result for multi-agent coordination."""
+
+    score: float
+    reasoning: str
+    dimension_scores: dict[str, float]
+    workers_used: int
+    handoffs_completed: int
+    duplication_rate: float  # 0.0–1.0 (lower is better)
+    merge_conflicts: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "reasoning": self.reasoning,
+            "dimension_scores": self.dimension_scores,
+            "workers_used": self.workers_used,
+            "handoffs_completed": self.handoffs_completed,
+            "duplication_rate": self.duplication_rate,
+            "merge_conflicts": self.merge_conflicts,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CoordinationResult:
+        return cls(
+            score=data["score"],
+            reasoning=data["reasoning"],
+            dimension_scores=data["dimension_scores"],
+            workers_used=data["workers_used"],
+            handoffs_completed=data["handoffs_completed"],
+            duplication_rate=data["duplication_rate"],
+            merge_conflicts=data["merge_conflicts"],
+        )
+
+
+class CoordinationInterface(SimulationInterface):
+    """ABC for multi-agent coordination scenarios.
+
+    Extends SimulationInterface with worker context management,
+    handoff tracking, output merging, and coordination evaluation.
+    """
+
+    @abstractmethod
+    def get_worker_contexts(self, state: dict[str, Any]) -> list[WorkerContext]:
+        """Return the partial contexts for all workers."""
+
+    @abstractmethod
+    def get_handoff_log(self, state: dict[str, Any]) -> list[HandoffRecord]:
+        """Return all handoff records so far."""
+
+    @abstractmethod
+    def record_handoff(
+        self, state: dict[str, Any], handoff: HandoffRecord
+    ) -> dict[str, Any]:
+        """Record an information handoff between workers. Returns new state."""
+
+    @abstractmethod
+    def merge_outputs(
+        self, state: dict[str, Any], worker_outputs: dict[str, str]
+    ) -> dict[str, Any]:
+        """Merge outputs from multiple workers. Returns new state."""
+
+    @abstractmethod
+    def evaluate_coordination(self, state: dict[str, Any]) -> CoordinationResult:
+        """Evaluate coordination quality across all dimensions."""

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from autocontext.scenarios.agent_task import AgentTaskInterface
 from autocontext.scenarios.artifact_editing import ArtifactEditingInterface
 from autocontext.scenarios.base import ScenarioInterface
+from autocontext.scenarios.coordination import CoordinationInterface
 from autocontext.scenarios.custom.agent_task_codegen import generate_agent_task_class
 from autocontext.scenarios.custom.agent_task_designer import design_agent_task
 from autocontext.scenarios.custom.agent_task_validator import (
@@ -19,6 +20,7 @@ from autocontext.scenarios.custom.agent_task_validator import (
     validate_intent,
 )
 from autocontext.scenarios.custom.artifact_editing_creator import ArtifactEditingCreator
+from autocontext.scenarios.custom.coordination_creator import CoordinationCreator
 from autocontext.scenarios.custom.family_classifier import (
     classify_scenario_family,
     route_to_family,
@@ -29,6 +31,7 @@ from autocontext.scenarios.custom.family_pipeline import (
 )
 from autocontext.scenarios.custom.investigation_creator import InvestigationCreator
 from autocontext.scenarios.custom.negotiation_creator import NegotiationCreator
+from autocontext.scenarios.custom.operator_loop_creator import OperatorLoopCreator
 from autocontext.scenarios.custom.registry import CUSTOM_SCENARIOS_DIR
 from autocontext.scenarios.custom.schema_evolution_creator import SchemaEvolutionCreator
 from autocontext.scenarios.custom.simulation_creator import SimulationCreator
@@ -37,6 +40,7 @@ from autocontext.scenarios.custom.workflow_creator import WorkflowCreator
 from autocontext.scenarios.families import get_family_marker
 from autocontext.scenarios.investigation import InvestigationInterface
 from autocontext.scenarios.negotiation import NegotiationInterface
+from autocontext.scenarios.operator_loop import OperatorLoopInterface
 from autocontext.scenarios.schema_evolution import SchemaEvolutionInterface
 from autocontext.scenarios.tool_fragility import ToolFragilityInterface
 from autocontext.scenarios.workflow import WorkflowInterface
@@ -87,7 +91,8 @@ class AgentTaskCreator:
         AgentTaskInterface | ScenarioInterface | ArtifactEditingInterface
         | InvestigationInterface | WorkflowInterface
         | SchemaEvolutionInterface | ToolFragilityInterface
-        | NegotiationInterface
+        | NegotiationInterface | OperatorLoopInterface
+        | CoordinationInterface
     ):
         """Run the full pipeline: design → validate → codegen → validate → load → register.
 
@@ -118,6 +123,12 @@ class AgentTaskCreator:
         if family.name == "negotiation":
             logger.info("routing description to negotiation creator")
             return NegotiationCreator(self.llm_fn, self.knowledge_root).create(description, name=name)
+        if family.name == "operator_loop":
+            logger.info("routing description to operator-loop creator")
+            return OperatorLoopCreator(self.llm_fn, self.knowledge_root).create(description, name=name)
+        if family.name == "coordination":
+            logger.info("routing description to coordination creator")
+            return CoordinationCreator(self.llm_fn, self.knowledge_root).create(description, name=name)
         if family.name != "agent_task":
             raise ValueError(
                 f"Scenario family '{family.name}' is not yet supported for custom scaffolding"

--- a/autocontext/src/autocontext/scenarios/custom/coordination_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/coordination_codegen.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import re
+
+from autocontext.scenarios.custom.coordination_spec import CoordinationSpec
+
+
+def _class_name(name: str) -> str:
+    parts = re.split(r"[^a-zA-Z0-9]+", name)
+    return "".join(part.capitalize() for part in parts if part) + "Coordination"
+
+
+def generate_coordination_class(spec: CoordinationSpec, name: str) -> str:
+    class_name = _class_name(name)
+    action_specs = ",\n".join(
+        "            ActionSpec("
+        f"name={action.name!r}, "
+        f"description={action.description!r}, "
+        f"parameters={action.parameters!r}, "
+        f"preconditions={action.preconditions!r}, "
+        f"effects={action.effects!r})"
+        for action in spec.actions
+    )
+    required_actions = [action.name for action in spec.actions]
+    return f'''from __future__ import annotations
+
+from typing import Any
+
+from autocontext.scenarios.coordination import (
+    CoordinationInterface,
+    CoordinationResult,
+    HandoffRecord,
+    WorkerContext,
+)
+from autocontext.scenarios.simulation import (
+    Action,
+    ActionResult,
+    ActionSpec,
+    ActionTrace,
+    EnvironmentSpec,
+    SimulationResult,
+)
+
+
+class {class_name}(CoordinationInterface):
+    name = {name!r}
+    _workers_spec = {spec.workers!r}
+
+    def describe_scenario(self) -> str:
+        return {spec.description!r}
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name={name!r},
+            description={spec.environment_description!r},
+            available_actions=[
+{action_specs}
+            ],
+            initial_state_description={spec.initial_state_description!r},
+            success_criteria={spec.success_criteria!r},
+            failure_modes={spec.failure_modes!r},
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {{
+            "seed": seed or 0,
+            "step": 0,
+            "completed_actions": [],
+            "failed_actions": [],
+            "handoffs": [],
+            "worker_outputs": {{}},
+            "merged": False,
+            "merge_conflicts": 0,
+        }}
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        completed = set(state.get("completed_actions", []))
+        return [
+            s for s in self.describe_environment().available_actions
+            if s.name not in completed
+        ]
+
+    def validate_action(
+        self, state: dict[str, Any], action: Action
+    ) -> tuple[bool, str]:
+        specs = {{
+            s.name: s for s in self.describe_environment().available_actions
+        }}
+        spec = specs.get(action.name)
+        if spec is None:
+            return False, f"unknown action: {{action.name}}"
+        completed = set(state.get("completed_actions", []))
+        for req in spec.preconditions:
+            if req not in completed:
+                return False, f"precondition not met for {{action.name}}: {{req}}"
+        return True, ""
+
+    def execute_action(
+        self, state: dict[str, Any], action: Action
+    ) -> tuple[ActionResult, dict[str, Any]]:
+        valid, reason = self.validate_action(state, action)
+        next_state = dict(state)
+        if not valid:
+            next_state["failed_actions"] = [
+                *state.get("failed_actions", []), action.name
+            ]
+            return (
+                ActionResult(
+                    success=False, output="", state_changes={{}}, error=reason
+                ),
+                next_state,
+            )
+
+        next_state["completed_actions"] = [
+            *state.get("completed_actions", []), action.name
+        ]
+        next_state["step"] = state.get("step", 0) + 1
+        return (
+            ActionResult(
+                success=True,
+                output=f"executed {{action.name}}",
+                state_changes={{
+                    "completed_actions": list(next_state["completed_actions"])
+                }},
+            ),
+            next_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        required = set({required_actions!r})
+        completed = set(state.get("completed_actions", []))
+        return (
+            required.issubset(completed)
+            or state.get("merged", False)
+            or state.get("step", 0) >= {spec.max_steps}
+        )
+
+    def get_worker_contexts(
+        self, state: dict[str, Any]
+    ) -> list[WorkerContext]:
+        return [
+            WorkerContext(
+                worker_id=w["worker_id"],
+                role=w.get("role", "worker"),
+                context_partition={{}},
+                visible_data=[],
+            )
+            for w in self._workers_spec
+        ]
+
+    def get_handoff_log(
+        self, state: dict[str, Any]
+    ) -> list[HandoffRecord]:
+        return [
+            HandoffRecord.from_dict(h) for h in state.get("handoffs", [])
+        ]
+
+    def record_handoff(
+        self, state: dict[str, Any], handoff: HandoffRecord
+    ) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["handoffs"] = [
+            *state.get("handoffs", []), handoff.to_dict()
+        ]
+        return next_state
+
+    def merge_outputs(
+        self, state: dict[str, Any], worker_outputs: dict[str, str]
+    ) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["worker_outputs"] = worker_outputs
+        next_state["merged"] = True
+        # Detect duplication (simple: any two outputs identical)
+        values = list(worker_outputs.values())
+        conflicts = 0
+        for i, v1 in enumerate(values):
+            for v2 in values[i + 1:]:
+                if v1 == v2 and v1:
+                    conflicts += 1
+        next_state["merge_conflicts"] = conflicts
+        return next_state
+
+    def evaluate_coordination(
+        self, state: dict[str, Any]
+    ) -> CoordinationResult:
+        handoffs = state.get("handoffs", [])
+        worker_outputs = state.get("worker_outputs", {{}})
+        workers_used = len(worker_outputs) or len(self._workers_spec)
+        merge_conflicts = state.get("merge_conflicts", 0)
+
+        # Duplication rate
+        values = list(worker_outputs.values())
+        if len(values) > 1:
+            unique = len(set(v for v in values if v))
+            total = len([v for v in values if v])
+            duplication_rate = (
+                1.0 - (unique / max(total, 1)) if total > 0 else 0.0
+            )
+        else:
+            duplication_rate = 0.0
+
+        # Handoff quality (average quality)
+        if handoffs:
+            avg_handoff = sum(
+                h.get("quality", 0.5) for h in handoffs
+            ) / len(handoffs)
+        else:
+            avg_handoff = 0.5
+
+        # Merge quality: fewer conflicts is better
+        merge_quality = max(0.0, 1.0 - merge_conflicts * 0.2)
+
+        # Outcome quality: completed actions ratio
+        completed = len(state.get("completed_actions", []))
+        failed = len(state.get("failed_actions", []))
+        outcome_quality = completed / max(completed + failed, 1)
+
+        dup_avoidance = max(0.0, 1.0 - duplication_rate)
+        score = round(
+            dup_avoidance * 0.25
+            + avg_handoff * 0.25
+            + merge_quality * 0.25
+            + outcome_quality * 0.25,
+            4,
+        )
+
+        return CoordinationResult(
+            score=score,
+            reasoning=(
+                f"{{workers_used}} workers, {{len(handoffs)}} handoffs, "
+                f"duplication rate {{duplication_rate:.2f}}, "
+                f"{{merge_conflicts}} merge conflicts."
+            ),
+            dimension_scores={{
+                "duplication_avoidance": round(dup_avoidance, 4),
+                "handoff_quality": round(avg_handoff, 4),
+                "merge_quality": round(merge_quality, 4),
+                "outcome_quality": round(outcome_quality, 4),
+            }},
+            workers_used=workers_used,
+            handoffs_completed=len(handoffs),
+            duplication_rate=round(duplication_rate, 4),
+            merge_conflicts=merge_conflicts,
+        )
+
+    def evaluate_trace(
+        self, trace: ActionTrace, final_state: dict[str, Any]
+    ) -> SimulationResult:
+        coord = self.evaluate_coordination(final_state)
+        action_success = trace.success_rate
+        score = round(coord.score * 0.7 + action_success * 0.3, 4)
+        return SimulationResult(
+            score=score,
+            reasoning=coord.reasoning,
+            dimension_scores={{
+                "duplication_avoidance": coord.dimension_scores.get(
+                    "duplication_avoidance", 0.0
+                ),
+                "handoff_quality": coord.dimension_scores.get(
+                    "handoff_quality", 0.0
+                ),
+                "merge_quality": coord.dimension_scores.get(
+                    "merge_quality", 0.0
+                ),
+                "outcome_quality": coord.dimension_scores.get(
+                    "outcome_quality", 0.0
+                ),
+                "action_success": round(action_success, 4),
+            }},
+            workflow_complete=final_state.get("merged", False),
+            actions_taken=len(trace.records),
+            actions_successful=sum(
+                1 for r in trace.records if r.result.success
+            ),
+            recovery_attempts=coord.merge_conflicts,
+            rollback_quality=coord.dimension_scores.get(
+                "merge_quality", 0.0
+            ),
+        )
+
+    def get_rubric(self) -> str:
+        return (
+            "Evaluate on duplication avoidance, handoff quality, "
+            "merge quality, and overall outcome quality."
+        )
+
+    def max_steps(self) -> int:
+        return {spec.max_steps}
+'''

--- a/autocontext/src/autocontext/scenarios/custom/coordination_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/coordination_creator.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import asdict
+from pathlib import Path
+from typing import cast
+
+from autocontext.scenarios.base import ScenarioInterface
+from autocontext.scenarios.coordination import CoordinationInterface
+from autocontext.scenarios.custom.coordination_codegen import (
+    generate_coordination_class,
+)
+from autocontext.scenarios.custom.coordination_designer import design_coordination
+from autocontext.scenarios.custom.family_pipeline import (
+    validate_for_family,
+    validate_source_for_family,
+)
+from autocontext.scenarios.custom.loader import load_custom_scenario
+from autocontext.scenarios.custom.registry import CUSTOM_SCENARIOS_DIR
+from autocontext.scenarios.families import get_family_marker
+
+logger = logging.getLogger(__name__)
+
+
+class CoordinationCreator:
+    def __init__(self, llm_fn: Callable[[str, str], str], knowledge_root: Path) -> None:
+        self.llm_fn = llm_fn
+        self.knowledge_root = knowledge_root
+
+    def create(self, description: str, name: str) -> ScenarioInterface:
+        spec = design_coordination(description, self.llm_fn)
+        errors = validate_for_family("coordination", asdict(spec))
+        if errors:
+            raise ValueError(f"coordination spec validation failed: {'; '.join(errors)}")
+
+        custom_dir = self.knowledge_root / CUSTOM_SCENARIOS_DIR
+        scenario_dir = custom_dir / name
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+
+        source = generate_coordination_class(spec, name=name)
+        source_errors = validate_source_for_family("coordination", source)
+        if source_errors:
+            raise ValueError(
+                f"coordination source validation failed: {'; '.join(source_errors)}"
+            )
+
+        (scenario_dir / "scenario.py").write_text(source, encoding="utf-8")
+        (scenario_dir / "spec.json").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "scenario_type": get_family_marker("coordination"),
+                    "description": spec.description,
+                    "environment_description": spec.environment_description,
+                    "initial_state_description": spec.initial_state_description,
+                    "workers": spec.workers,
+                    "success_criteria": spec.success_criteria,
+                    "failure_modes": spec.failure_modes,
+                    "max_steps": spec.max_steps,
+                    "actions": [
+                        {
+                            "name": action.name,
+                            "description": action.description,
+                            "parameters": action.parameters,
+                            "preconditions": action.preconditions,
+                            "effects": action.effects,
+                        }
+                        for action in spec.actions
+                    ],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        (scenario_dir / "scenario_type.txt").write_text(
+            get_family_marker("coordination"),
+            encoding="utf-8",
+        )
+
+        cls = load_custom_scenario(custom_dir, name, CoordinationInterface)
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        SCENARIO_REGISTRY[name] = cls
+        logger.info("registered coordination scenario '%s'", name)
+        return cast(ScenarioInterface, cls())

--- a/autocontext/src/autocontext/scenarios/custom/coordination_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/coordination_designer.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+
+from autocontext.scenarios.custom.coordination_spec import CoordinationSpec
+from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+
+COORDINATION_SPEC_START = "<!-- COORDINATION_SPEC_START -->"
+COORDINATION_SPEC_END = "<!-- COORDINATION_SPEC_END -->"
+
+_EXAMPLE_SPEC = {
+    "description": "Multi-agent research report writing.",
+    "environment_description": "Research team with partial information.",
+    "initial_state_description": "Task partitioned across workers.",
+    "workers": [
+        {"worker_id": "researcher", "role": "data gatherer"},
+        {"worker_id": "writer", "role": "report writer"},
+    ],
+    "success_criteria": [
+        "coherent merged report",
+        "minimal duplication across sections",
+    ],
+    "failure_modes": [
+        "duplicate content across workers",
+        "lost information during handoff",
+    ],
+    "max_steps": 10,
+    "actions": [
+        {
+            "name": "research",
+            "description": "Gather data on assigned topic.",
+            "parameters": {"topic": "string"},
+            "preconditions": [],
+            "effects": ["data_gathered"],
+        },
+        {
+            "name": "write_section",
+            "description": "Write a report section.",
+            "parameters": {"section": "string"},
+            "preconditions": ["research"],
+            "effects": ["section_written"],
+        },
+    ],
+}
+
+COORDINATION_DESIGNER_SYSTEM = (
+    "You are a scenario designer for autocontext. "
+    "Given a natural-language request for a multi-agent coordination scenario, "
+    "produce a CoordinationSpec JSON wrapped in delimiters.\n\n"
+    f"{COORDINATION_SPEC_START}\n{{ ... }}\n{COORDINATION_SPEC_END}\n\n"
+    "Schema:\n"
+    "{\n"
+    '  "description": "scenario summary",\n'
+    '  "environment_description": "team context",\n'
+    '  "initial_state_description": "starting state",\n'
+    '  "workers": [{"worker_id": "name", "role": "role"}],\n'
+    '  "success_criteria": ["criterion"],\n'
+    '  "failure_modes": ["failure mode"],\n'
+    '  "max_steps": 10,\n'
+    '  "actions": [{"name": "snake_case", "description": "...", '
+    '"parameters": {}, "preconditions": [], "effects": []}]\n'
+    "}\n\n"
+    "Rules:\n"
+    "- include at least two workers with distinct roles\n"
+    "- workers do not share full context by default\n"
+    "- include at least two actions\n\n"
+    f"Example:\n{COORDINATION_SPEC_START}\n{json.dumps(_EXAMPLE_SPEC, indent=2)}\n{COORDINATION_SPEC_END}\n"
+)
+
+
+def parse_coordination_spec(text: str) -> CoordinationSpec:
+    pattern = (
+        re.escape(COORDINATION_SPEC_START)
+        + r"\s*(.*?)\s*"
+        + re.escape(COORDINATION_SPEC_END)
+    )
+    match = re.search(pattern, text, re.DOTALL)
+    if not match:
+        raise ValueError("response does not contain COORDINATION_SPEC delimiters")
+    data = json.loads(match.group(1).strip())
+    return CoordinationSpec(
+        description=data["description"],
+        environment_description=data["environment_description"],
+        initial_state_description=data["initial_state_description"],
+        workers=data["workers"],
+        success_criteria=data["success_criteria"],
+        failure_modes=data.get("failure_modes", []),
+        actions=[
+            SimulationActionSpecModel(
+                name=raw["name"],
+                description=raw["description"],
+                parameters=raw.get("parameters", {}),
+                preconditions=raw.get("preconditions", []),
+                effects=raw.get("effects", []),
+            )
+            for raw in data["actions"]
+        ],
+        max_steps=data.get("max_steps", 10),
+    )
+
+
+def design_coordination(
+    description: str, llm_fn: Callable[[str, str], str]
+) -> CoordinationSpec:
+    return parse_coordination_spec(
+        llm_fn(COORDINATION_DESIGNER_SYSTEM, f"User description:\n{description}")
+    )

--- a/autocontext/src/autocontext/scenarios/custom/coordination_spec.py
+++ b/autocontext/src/autocontext/scenarios/custom/coordination_spec.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+
+
+@dataclass(slots=True)
+class CoordinationSpec:
+    """Spec for a multi-agent coordination scenario."""
+
+    description: str
+    environment_description: str
+    initial_state_description: str
+    workers: list[dict[str, Any]]  # [{worker_id, role, ...}]
+    success_criteria: list[str]
+    failure_modes: list[str]
+    actions: list[SimulationActionSpecModel]
+    max_steps: int = 10

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -291,6 +291,42 @@ _NEGOTIATION_SIGNALS: dict[str, float] = {
     "offer accept": 1.5,
 }
 
+_OPERATOR_LOOP_SIGNALS: dict[str, float] = {
+    "escalat": 2.0,  # escalate, escalation
+    "clarification": 2.0,
+    "operator": 1.5,
+    "human-in-the-loop": 2.0,
+    "human in the loop": 2.0,
+    "judgment": 1.5,
+    "over-escalat": 2.0,
+    "under-escalat": 2.0,
+    "consult": 1.5,
+    "approval required": 1.5,
+    "ask for help": 1.5,
+    "when to escalate": 2.0,
+    "triage judgment": 2.0,
+    "autonomous vs": 1.5,
+    "operator loop": 2.0,
+}
+
+_COORDINATION_SIGNALS: dict[str, float] = {
+    "coordinat": 2.0,  # coordinate, coordination
+    "multi-agent": 2.0,
+    "multi agent": 2.0,
+    "worker": 1.5,
+    "handoff": 2.0,
+    "hand-off": 2.0,
+    "partial context": 2.0,
+    "merge output": 2.0,
+    "merge result": 2.0,
+    "duplication": 1.5,
+    "parallel worker": 2.0,
+    "context partition": 2.0,
+    "split work": 1.5,
+    "divide and conquer": 1.5,
+    "task decompos": 1.5,
+}
+
 _FAMILY_SIGNAL_GROUPS: dict[str, dict[str, float]] = {
     "simulation": _SIMULATION_SIGNALS,
     "agent_task": _AGENT_TASK_SIGNALS,
@@ -301,6 +337,8 @@ _FAMILY_SIGNAL_GROUPS: dict[str, dict[str, float]] = {
     "schema_evolution": _SCHEMA_EVOLUTION_SIGNALS,
     "tool_fragility": _TOOL_FRAGILITY_SIGNALS,
     "negotiation": _NEGOTIATION_SIGNALS,
+    "operator_loop": _OPERATOR_LOOP_SIGNALS,
+    "coordination": _COORDINATION_SIGNALS,
 }
 
 _DEFAULT_FAMILY_NAME = "agent_task"

--- a/autocontext/src/autocontext/scenarios/custom/family_pipeline.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_pipeline.py
@@ -746,6 +746,159 @@ class NegotiationPipeline(FamilyPipeline):
         )
 
 
+class OperatorLoopPipeline(FamilyPipeline):
+    """Pipeline for operator_loop family scenarios."""
+
+    @property
+    def family_name(self) -> str:
+        return "operator_loop"
+
+    def required_spec_fields(self) -> set[str]:
+        return {
+            "description",
+            "environment_description",
+            "initial_state_description",
+            "escalation_policy",
+            "success_criteria",
+            "actions",
+        }
+
+    def validate_spec(self, spec: dict[str, Any]) -> list[str]:
+        errors = _check_required_fields(spec, self.required_spec_fields())
+
+        ep = spec.get("escalation_policy")
+        if isinstance(ep, dict):
+            for key in ("escalation_threshold", "max_escalations"):
+                if key not in ep:
+                    errors.append(f"escalation_policy missing '{key}'")
+        elif ep is not None:
+            errors.append("escalation_policy must be a dict")
+
+        actions = spec.get("actions")
+        if isinstance(actions, list):
+            if len(actions) == 0:
+                errors.append("actions must not be empty")
+            else:
+                for i, action in enumerate(actions):
+                    if not isinstance(action, dict):
+                        errors.append(f"actions[{i}] must be a dict")
+                    elif "name" not in action:
+                        errors.append(f"actions[{i}] missing 'name'")
+
+        criteria = spec.get("success_criteria")
+        if isinstance(criteria, list) and len(criteria) == 0:
+            errors.append("success_criteria must not be empty")
+
+        max_steps = spec.get("max_steps")
+        if max_steps is not None and (not isinstance(max_steps, int) or max_steps <= 0):
+            errors.append("max_steps must be a positive integer")
+
+        return errors
+
+    def validate_source(self, source: str) -> list[str]:
+        return _check_source_for_class(source, "OperatorLoopInterface")
+
+    def validate_contract(self, source: str) -> list[str]:
+        return _check_required_methods(
+            source,
+            "OperatorLoopInterface",
+            {
+                "describe_scenario",
+                "describe_environment",
+                "initial_state",
+                "get_available_actions",
+                "execute_action",
+                "is_terminal",
+                "evaluate_trace",
+                "get_rubric",
+                "get_escalation_log",
+                "get_clarification_log",
+                "escalate",
+                "request_clarification",
+                "evaluate_judgment",
+            },
+        )
+
+
+class CoordinationPipeline(FamilyPipeline):
+    """Pipeline for coordination family scenarios."""
+
+    @property
+    def family_name(self) -> str:
+        return "coordination"
+
+    def required_spec_fields(self) -> set[str]:
+        return {
+            "description",
+            "environment_description",
+            "initial_state_description",
+            "workers",
+            "success_criteria",
+            "actions",
+        }
+
+    def validate_spec(self, spec: dict[str, Any]) -> list[str]:
+        errors = _check_required_fields(spec, self.required_spec_fields())
+
+        workers = spec.get("workers")
+        if isinstance(workers, list):
+            if len(workers) == 0:
+                errors.append("workers must not be empty")
+            else:
+                for i, worker in enumerate(workers):
+                    if not isinstance(worker, dict):
+                        errors.append(f"workers[{i}] must be a dict")
+                    elif "worker_id" not in worker:
+                        errors.append(f"workers[{i}] missing 'worker_id'")
+        elif workers is not None:
+            errors.append("workers must be a list")
+
+        actions = spec.get("actions")
+        if isinstance(actions, list):
+            if len(actions) == 0:
+                errors.append("actions must not be empty")
+            else:
+                for i, action in enumerate(actions):
+                    if not isinstance(action, dict):
+                        errors.append(f"actions[{i}] must be a dict")
+                    elif "name" not in action:
+                        errors.append(f"actions[{i}] missing 'name'")
+
+        criteria = spec.get("success_criteria")
+        if isinstance(criteria, list) and len(criteria) == 0:
+            errors.append("success_criteria must not be empty")
+
+        max_steps = spec.get("max_steps")
+        if max_steps is not None and (not isinstance(max_steps, int) or max_steps <= 0):
+            errors.append("max_steps must be a positive integer")
+
+        return errors
+
+    def validate_source(self, source: str) -> list[str]:
+        return _check_source_for_class(source, "CoordinationInterface")
+
+    def validate_contract(self, source: str) -> list[str]:
+        return _check_required_methods(
+            source,
+            "CoordinationInterface",
+            {
+                "describe_scenario",
+                "describe_environment",
+                "initial_state",
+                "get_available_actions",
+                "execute_action",
+                "is_terminal",
+                "evaluate_trace",
+                "get_rubric",
+                "get_worker_contexts",
+                "get_handoff_log",
+                "record_handoff",
+                "merge_outputs",
+                "evaluate_coordination",
+            },
+        )
+
+
 # ---------------------------------------------------------------------------
 # Built-in pipeline registration
 # ---------------------------------------------------------------------------
@@ -759,6 +912,8 @@ def _register_builtins() -> None:
     register_pipeline(SchemaEvolutionPipeline())
     register_pipeline(ToolFragilityPipeline())
     register_pipeline(NegotiationPipeline())
+    register_pipeline(OperatorLoopPipeline())
+    register_pipeline(CoordinationPipeline())
 
 
 _register_builtins()

--- a/autocontext/src/autocontext/scenarios/custom/operator_loop_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/operator_loop_codegen.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import re
+
+from autocontext.scenarios.custom.operator_loop_spec import OperatorLoopSpec
+
+
+def _class_name(name: str) -> str:
+    parts = re.split(r"[^a-zA-Z0-9]+", name)
+    return "".join(part.capitalize() for part in parts if part) + "OperatorLoop"
+
+
+def generate_operator_loop_class(spec: OperatorLoopSpec, name: str) -> str:
+    class_name = _class_name(name)
+    action_specs = ",\n".join(
+        "            ActionSpec("
+        f"name={action.name!r}, "
+        f"description={action.description!r}, "
+        f"parameters={action.parameters!r}, "
+        f"preconditions={action.preconditions!r}, "
+        f"effects={action.effects!r})"
+        for action in spec.actions
+    )
+    required_actions = [action.name for action in spec.actions]
+    return f'''from __future__ import annotations
+
+from typing import Any
+
+from autocontext.scenarios.operator_loop import (
+    ClarificationRequest,
+    EscalationEvent,
+    OperatorLoopInterface,
+    OperatorLoopResult,
+)
+from autocontext.scenarios.simulation import (
+    Action,
+    ActionResult,
+    ActionSpec,
+    ActionTrace,
+    EnvironmentSpec,
+    SimulationResult,
+)
+
+
+class {class_name}(OperatorLoopInterface):
+    name = {name!r}
+    _escalation_policy = {spec.escalation_policy!r}
+
+    def describe_scenario(self) -> str:
+        return {spec.description!r}
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name={name!r},
+            description={spec.environment_description!r},
+            available_actions=[
+{action_specs}
+            ],
+            initial_state_description={spec.initial_state_description!r},
+            success_criteria={spec.success_criteria!r},
+            failure_modes={spec.failure_modes!r},
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {{
+            "seed": seed or 0,
+            "step": 0,
+            "completed_actions": [],
+            "failed_actions": [],
+            "escalations": [],
+            "clarifications": [],
+            "necessary_escalation_steps": [],
+        }}
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        completed = set(state.get("completed_actions", []))
+        return [
+            s for s in self.describe_environment().available_actions
+            if s.name not in completed
+        ]
+
+    def validate_action(
+        self, state: dict[str, Any], action: Action
+    ) -> tuple[bool, str]:
+        specs = {{
+            s.name: s for s in self.describe_environment().available_actions
+        }}
+        spec = specs.get(action.name)
+        if spec is None:
+            return False, f"unknown action: {{action.name}}"
+        completed = set(state.get("completed_actions", []))
+        for req in spec.preconditions:
+            if req not in completed:
+                return False, f"precondition not met for {{action.name}}: {{req}}"
+        return True, ""
+
+    def execute_action(
+        self, state: dict[str, Any], action: Action
+    ) -> tuple[ActionResult, dict[str, Any]]:
+        valid, reason = self.validate_action(state, action)
+        next_state = dict(state)
+        if not valid:
+            next_state["failed_actions"] = [
+                *state.get("failed_actions", []), action.name
+            ]
+            return (
+                ActionResult(
+                    success=False, output="", state_changes={{}}, error=reason
+                ),
+                next_state,
+            )
+
+        next_state["completed_actions"] = [
+            *state.get("completed_actions", []), action.name
+        ]
+        next_state["step"] = state.get("step", 0) + 1
+        return (
+            ActionResult(
+                success=True,
+                output=f"executed {{action.name}}",
+                state_changes={{
+                    "completed_actions": list(next_state["completed_actions"])
+                }},
+            ),
+            next_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        required = set({required_actions!r})
+        completed = set(state.get("completed_actions", []))
+        return (
+            required.issubset(completed)
+            or state.get("step", 0) >= {spec.max_steps}
+        )
+
+    def get_escalation_log(
+        self, state: dict[str, Any]
+    ) -> list[EscalationEvent]:
+        return [
+            EscalationEvent.from_dict(e)
+            for e in state.get("escalations", [])
+        ]
+
+    def get_clarification_log(
+        self, state: dict[str, Any]
+    ) -> list[ClarificationRequest]:
+        return [
+            ClarificationRequest.from_dict(c)
+            for c in state.get("clarifications", [])
+        ]
+
+    def escalate(
+        self, state: dict[str, Any], event: EscalationEvent
+    ) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["escalations"] = [
+            *state.get("escalations", []), event.to_dict()
+        ]
+        return next_state
+
+    def request_clarification(
+        self, state: dict[str, Any], request: ClarificationRequest
+    ) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["clarifications"] = [
+            *state.get("clarifications", []), request.to_dict()
+        ]
+        return next_state
+
+    def evaluate_judgment(
+        self, state: dict[str, Any]
+    ) -> OperatorLoopResult:
+        escalations = state.get("escalations", [])
+        clarifications = state.get("clarifications", [])
+        total_actions = len(state.get("completed_actions", []))
+        necessary_steps = set(state.get("necessary_escalation_steps", []))
+
+        necessary = sum(
+            1 for e in escalations if e.get("was_necessary", False)
+        )
+        unnecessary = len(escalations) - necessary
+        missed = len(necessary_steps - {{
+            e.get("step", -1) for e in escalations
+        }})
+
+        # Action quality: completed actions without failures
+        failed = len(state.get("failed_actions", []))
+        action_quality = (
+            total_actions / max(total_actions + failed, 1)
+        )
+
+        # Escalation judgment: penalize both over and under
+        if escalations or necessary_steps:
+            over_penalty = unnecessary * 0.15
+            under_penalty = missed * 0.2
+            judgment = max(0.0, 1.0 - over_penalty - under_penalty)
+        else:
+            judgment = 1.0
+
+        score = round(action_quality * 0.4 + judgment * 0.6, 4)
+
+        return OperatorLoopResult(
+            score=score,
+            reasoning=(
+                f"{{total_actions}} actions, {{len(escalations)}} escalations "
+                f"({{necessary}} necessary, {{unnecessary}} unnecessary), "
+                f"{{missed}} missed escalations."
+            ),
+            dimension_scores={{
+                "action_quality": round(action_quality, 4),
+                "escalation_judgment": round(judgment, 4),
+            }},
+            total_actions=total_actions,
+            escalations=len(escalations),
+            necessary_escalations=necessary,
+            unnecessary_escalations=unnecessary,
+            missed_escalations=missed,
+            clarifications_requested=len(clarifications),
+        )
+
+    def evaluate_trace(
+        self, trace: ActionTrace, final_state: dict[str, Any]
+    ) -> SimulationResult:
+        judgment = self.evaluate_judgment(final_state)
+        action_success = trace.success_rate
+        score = round(judgment.score * 0.7 + action_success * 0.3, 4)
+        return SimulationResult(
+            score=score,
+            reasoning=judgment.reasoning,
+            dimension_scores={{
+                "action_quality": judgment.dimension_scores.get(
+                    "action_quality", 0.0
+                ),
+                "escalation_judgment": judgment.dimension_scores.get(
+                    "escalation_judgment", 0.0
+                ),
+                "action_success": round(action_success, 4),
+            }},
+            workflow_complete=self.is_terminal(final_state),
+            actions_taken=len(trace.records),
+            actions_successful=sum(
+                1 for r in trace.records if r.result.success
+            ),
+            recovery_attempts=judgment.unnecessary_escalations,
+            rollback_quality=judgment.dimension_scores.get(
+                "escalation_judgment", 0.0
+            ),
+        )
+
+    def get_rubric(self) -> str:
+        return (
+            "Evaluate on action completion quality, "
+            "escalation judgment (avoiding both over- and under-escalation), "
+            "and appropriate use of clarification requests."
+        )
+
+    def max_steps(self) -> int:
+        return {spec.max_steps}
+'''

--- a/autocontext/src/autocontext/scenarios/custom/operator_loop_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/operator_loop_creator.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import asdict
+from pathlib import Path
+from typing import cast
+
+from autocontext.scenarios.base import ScenarioInterface
+from autocontext.scenarios.custom.family_pipeline import (
+    validate_for_family,
+    validate_source_for_family,
+)
+from autocontext.scenarios.custom.loader import load_custom_scenario
+from autocontext.scenarios.custom.operator_loop_codegen import (
+    generate_operator_loop_class,
+)
+from autocontext.scenarios.custom.operator_loop_designer import design_operator_loop
+from autocontext.scenarios.custom.registry import CUSTOM_SCENARIOS_DIR
+from autocontext.scenarios.families import get_family_marker
+from autocontext.scenarios.operator_loop import OperatorLoopInterface
+
+logger = logging.getLogger(__name__)
+
+
+class OperatorLoopCreator:
+    def __init__(self, llm_fn: Callable[[str, str], str], knowledge_root: Path) -> None:
+        self.llm_fn = llm_fn
+        self.knowledge_root = knowledge_root
+
+    def create(self, description: str, name: str) -> ScenarioInterface:
+        spec = design_operator_loop(description, self.llm_fn)
+        errors = validate_for_family("operator_loop", asdict(spec))
+        if errors:
+            raise ValueError(f"operator_loop spec validation failed: {'; '.join(errors)}")
+
+        custom_dir = self.knowledge_root / CUSTOM_SCENARIOS_DIR
+        scenario_dir = custom_dir / name
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+
+        source = generate_operator_loop_class(spec, name=name)
+        source_errors = validate_source_for_family("operator_loop", source)
+        if source_errors:
+            raise ValueError(
+                f"operator_loop source validation failed: {'; '.join(source_errors)}"
+            )
+
+        (scenario_dir / "scenario.py").write_text(source, encoding="utf-8")
+        (scenario_dir / "spec.json").write_text(
+            json.dumps(
+                {
+                    "name": name,
+                    "scenario_type": get_family_marker("operator_loop"),
+                    "description": spec.description,
+                    "environment_description": spec.environment_description,
+                    "initial_state_description": spec.initial_state_description,
+                    "escalation_policy": spec.escalation_policy,
+                    "success_criteria": spec.success_criteria,
+                    "failure_modes": spec.failure_modes,
+                    "max_steps": spec.max_steps,
+                    "actions": [
+                        {
+                            "name": action.name,
+                            "description": action.description,
+                            "parameters": action.parameters,
+                            "preconditions": action.preconditions,
+                            "effects": action.effects,
+                        }
+                        for action in spec.actions
+                    ],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        (scenario_dir / "scenario_type.txt").write_text(
+            get_family_marker("operator_loop"),
+            encoding="utf-8",
+        )
+
+        cls = load_custom_scenario(custom_dir, name, OperatorLoopInterface)
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        SCENARIO_REGISTRY[name] = cls
+        logger.info("registered operator_loop scenario '%s'", name)
+        return cast(ScenarioInterface, cls())

--- a/autocontext/src/autocontext/scenarios/custom/operator_loop_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/operator_loop_designer.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+
+from autocontext.scenarios.custom.operator_loop_spec import OperatorLoopSpec
+from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+
+OPERATOR_LOOP_SPEC_START = "<!-- OPERATOR_LOOP_SPEC_START -->"
+OPERATOR_LOOP_SPEC_END = "<!-- OPERATOR_LOOP_SPEC_END -->"
+
+_EXAMPLE_SPEC = {
+    "description": "Customer support triage with escalation policy.",
+    "environment_description": "Help desk system with tiered support.",
+    "initial_state_description": "Ticket received, agent begins triage.",
+    "escalation_policy": {
+        "escalation_threshold": "high",
+        "max_escalations": 3,
+    },
+    "success_criteria": [
+        "resolve issue or correctly escalate",
+        "minimize unnecessary escalations",
+    ],
+    "failure_modes": [
+        "over-escalation (escalating trivial issues)",
+        "under-escalation (failing to escalate critical issues)",
+    ],
+    "max_steps": 10,
+    "actions": [
+        {
+            "name": "respond",
+            "description": "Reply to the customer directly.",
+            "parameters": {"message": "string"},
+            "preconditions": [],
+            "effects": ["response_sent"],
+        },
+        {
+            "name": "escalate_ticket",
+            "description": "Escalate to a human operator.",
+            "parameters": {"reason": "string"},
+            "preconditions": [],
+            "effects": ["escalated"],
+        },
+    ],
+}
+
+OPERATOR_LOOP_DESIGNER_SYSTEM = (
+    "You are a scenario designer for autocontext. "
+    "Given a natural-language request for an operator-in-the-loop scenario, "
+    "produce an OperatorLoopSpec JSON wrapped in delimiters.\n\n"
+    f"{OPERATOR_LOOP_SPEC_START}\n{{ ... }}\n{OPERATOR_LOOP_SPEC_END}\n\n"
+    "Schema:\n"
+    "{\n"
+    '  "description": "scenario summary",\n'
+    '  "environment_description": "system context",\n'
+    '  "initial_state_description": "starting state",\n'
+    '  "escalation_policy": {"escalation_threshold": "level", "max_escalations": N},\n'
+    '  "success_criteria": ["criterion"],\n'
+    '  "failure_modes": ["failure mode"],\n'
+    '  "max_steps": 10,\n'
+    '  "actions": [{"name": "snake_case", "description": "...", '
+    '"parameters": {}, "preconditions": [], "effects": []}]\n'
+    "}\n\n"
+    "Rules:\n"
+    "- escalation_policy must include escalation_threshold and max_escalations\n"
+    "- include at least one action that acts and one that escalates\n"
+    "- failure_modes should include both over-escalation and under-escalation\n\n"
+    f"Example:\n{OPERATOR_LOOP_SPEC_START}\n{json.dumps(_EXAMPLE_SPEC, indent=2)}\n{OPERATOR_LOOP_SPEC_END}\n"
+)
+
+
+def parse_operator_loop_spec(text: str) -> OperatorLoopSpec:
+    pattern = (
+        re.escape(OPERATOR_LOOP_SPEC_START)
+        + r"\s*(.*?)\s*"
+        + re.escape(OPERATOR_LOOP_SPEC_END)
+    )
+    match = re.search(pattern, text, re.DOTALL)
+    if not match:
+        raise ValueError("response does not contain OPERATOR_LOOP_SPEC delimiters")
+    data = json.loads(match.group(1).strip())
+    return OperatorLoopSpec(
+        description=data["description"],
+        environment_description=data["environment_description"],
+        initial_state_description=data["initial_state_description"],
+        escalation_policy=data["escalation_policy"],
+        success_criteria=data["success_criteria"],
+        failure_modes=data.get("failure_modes", []),
+        actions=[
+            SimulationActionSpecModel(
+                name=raw["name"],
+                description=raw["description"],
+                parameters=raw.get("parameters", {}),
+                preconditions=raw.get("preconditions", []),
+                effects=raw.get("effects", []),
+            )
+            for raw in data["actions"]
+        ],
+        max_steps=data.get("max_steps", 10),
+    )
+
+
+def design_operator_loop(
+    description: str, llm_fn: Callable[[str, str], str]
+) -> OperatorLoopSpec:
+    return parse_operator_loop_spec(
+        llm_fn(OPERATOR_LOOP_DESIGNER_SYSTEM, f"User description:\n{description}")
+    )

--- a/autocontext/src/autocontext/scenarios/custom/operator_loop_spec.py
+++ b/autocontext/src/autocontext/scenarios/custom/operator_loop_spec.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+
+
+@dataclass(slots=True)
+class OperatorLoopSpec:
+    """Spec for an operator-in-the-loop scenario."""
+
+    description: str
+    environment_description: str
+    initial_state_description: str
+    escalation_policy: dict[str, Any]
+    success_criteria: list[str]
+    failure_modes: list[str]
+    actions: list[SimulationActionSpecModel]
+    max_steps: int = 10

--- a/autocontext/src/autocontext/scenarios/families.py
+++ b/autocontext/src/autocontext/scenarios/families.py
@@ -102,8 +102,10 @@ def _register_builtins() -> None:
     from autocontext.scenarios.agent_task import AgentTaskInterface
     from autocontext.scenarios.artifact_editing import ArtifactEditingInterface
     from autocontext.scenarios.base import ScenarioInterface
+    from autocontext.scenarios.coordination import CoordinationInterface
     from autocontext.scenarios.investigation import InvestigationInterface
     from autocontext.scenarios.negotiation import NegotiationInterface
+    from autocontext.scenarios.operator_loop import OperatorLoopInterface
     from autocontext.scenarios.schema_evolution import SchemaEvolutionInterface
     from autocontext.scenarios.simulation import SimulationInterface
     from autocontext.scenarios.tool_fragility import ToolFragilityInterface
@@ -199,6 +201,26 @@ def _register_builtins() -> None:
         output_modes=["action_trace"],
         scenario_type_marker="tool_fragility",
         capabilities=["drift_detection", "failure_attribution", "tool_adaptation"],
+    ))
+
+    register_family(ScenarioFamily(
+        name="operator_loop",
+        description="Operator-in-the-loop scenarios testing escalation and clarification judgment",
+        interface_class=OperatorLoopInterface,
+        evaluation_mode="judgment_evaluation",
+        output_modes=["action_trace"],
+        scenario_type_marker="operator_loop",
+        capabilities=["escalation", "clarification", "judgment_scoring"],
+    ))
+
+    register_family(ScenarioFamily(
+        name="coordination",
+        description="Multi-agent coordination scenarios with partial context, handoff, and merge",
+        interface_class=CoordinationInterface,
+        evaluation_mode="coordination_evaluation",
+        output_modes=["action_trace"],
+        scenario_type_marker="coordination",
+        capabilities=["partial_context", "handoff", "merge", "duplication_detection"],
     ))
 
 

--- a/autocontext/src/autocontext/scenarios/operator_loop.py
+++ b/autocontext/src/autocontext/scenarios/operator_loop.py
@@ -1,0 +1,147 @@
+"""Operator-in-the-loop scenario family (AC-251).
+
+Scenarios where agents must decide when to act autonomously vs when to
+escalate, request clarification, or consult an operator. Evaluated on
+judgment quality: correct deferrals, unnecessary escalations, and missed
+escalations are scored separately.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+from autocontext.scenarios.simulation import SimulationInterface
+
+
+@dataclass(slots=True)
+class ClarificationRequest:
+    """A clarification request from the agent to the operator."""
+
+    question: str
+    context: str
+    urgency: str  # "low", "medium", "high"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "question": self.question,
+            "context": self.context,
+            "urgency": self.urgency,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ClarificationRequest:
+        return cls(
+            question=data["question"],
+            context=data["context"],
+            urgency=data["urgency"],
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass(slots=True)
+class EscalationEvent:
+    """A record of an escalation to the operator."""
+
+    step: int
+    reason: str
+    severity: str  # "low", "medium", "high", "critical"
+    context: str
+    was_necessary: bool  # ground truth for evaluation
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step": self.step,
+            "reason": self.reason,
+            "severity": self.severity,
+            "context": self.context,
+            "was_necessary": self.was_necessary,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EscalationEvent:
+        return cls(
+            step=data["step"],
+            reason=data["reason"],
+            severity=data["severity"],
+            context=data["context"],
+            was_necessary=data["was_necessary"],
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass(slots=True)
+class OperatorLoopResult:
+    """Evaluation result for operator-in-the-loop judgment."""
+
+    score: float
+    reasoning: str
+    dimension_scores: dict[str, float]
+    total_actions: int
+    escalations: int
+    necessary_escalations: int
+    unnecessary_escalations: int
+    missed_escalations: int
+    clarifications_requested: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "reasoning": self.reasoning,
+            "dimension_scores": self.dimension_scores,
+            "total_actions": self.total_actions,
+            "escalations": self.escalations,
+            "necessary_escalations": self.necessary_escalations,
+            "unnecessary_escalations": self.unnecessary_escalations,
+            "missed_escalations": self.missed_escalations,
+            "clarifications_requested": self.clarifications_requested,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> OperatorLoopResult:
+        return cls(
+            score=data["score"],
+            reasoning=data["reasoning"],
+            dimension_scores=data["dimension_scores"],
+            total_actions=data["total_actions"],
+            escalations=data["escalations"],
+            necessary_escalations=data["necessary_escalations"],
+            unnecessary_escalations=data["unnecessary_escalations"],
+            missed_escalations=data["missed_escalations"],
+            clarifications_requested=data["clarifications_requested"],
+        )
+
+
+class OperatorLoopInterface(SimulationInterface):
+    """ABC for operator-in-the-loop scenarios.
+
+    Extends SimulationInterface with escalation, clarification, and
+    judgment evaluation methods.
+    """
+
+    @abstractmethod
+    def get_escalation_log(self, state: dict[str, Any]) -> list[EscalationEvent]:
+        """Return all escalation events so far."""
+
+    @abstractmethod
+    def get_clarification_log(self, state: dict[str, Any]) -> list[ClarificationRequest]:
+        """Return all clarification requests so far."""
+
+    @abstractmethod
+    def escalate(self, state: dict[str, Any], event: EscalationEvent) -> dict[str, Any]:
+        """Record an escalation event. Returns new state."""
+
+    @abstractmethod
+    def request_clarification(
+        self, state: dict[str, Any], request: ClarificationRequest
+    ) -> dict[str, Any]:
+        """Record a clarification request. Returns new state."""
+
+    @abstractmethod
+    def evaluate_judgment(self, state: dict[str, Any]) -> OperatorLoopResult:
+        """Evaluate the agent's escalation/clarification judgment."""

--- a/autocontext/tests/test_operator_loop_coordination.py
+++ b/autocontext/tests/test_operator_loop_coordination.py
@@ -1,0 +1,1015 @@
+"""Tests for AC-251 + AC-253: operator-in-the-loop and multi-agent coordination families.
+
+Full vertical-slice tests for both families:
+- Data models
+- Interface ABCs
+- Family registry
+- Pipeline registry
+- Classifier routing
+- Designer/codegen
+- Creator (create → persist → load → register)
+- AgentTaskCreator routing
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ===========================================================================
+# AC-251: Operator-in-the-loop data models
+# ===========================================================================
+
+
+class TestClarificationRequest:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.operator_loop import ClarificationRequest
+
+        req = ClarificationRequest(
+            question="What format should the output be in?",
+            context="Processing customer data",
+            urgency="medium",
+        )
+        assert req.question == "What format should the output be in?"
+        assert req.urgency == "medium"
+
+    def test_roundtrip(self) -> None:
+        from autocontext.scenarios.operator_loop import ClarificationRequest
+
+        req = ClarificationRequest(
+            question="q", context="c", urgency="low",
+        )
+        d = req.to_dict()
+        restored = ClarificationRequest.from_dict(d)
+        assert restored.question == req.question
+        assert restored.context == req.context
+        assert restored.urgency == req.urgency
+
+
+class TestEscalationEvent:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.operator_loop import EscalationEvent
+
+        event = EscalationEvent(
+            step=3,
+            reason="Ambiguous requirements",
+            severity="high",
+            context="Customer request unclear",
+            was_necessary=True,
+        )
+        assert event.step == 3
+        assert event.severity == "high"
+        assert event.was_necessary is True
+
+    def test_roundtrip(self) -> None:
+        from autocontext.scenarios.operator_loop import EscalationEvent
+
+        event = EscalationEvent(
+            step=1, reason="r", severity="low",
+            context="c", was_necessary=False,
+        )
+        d = event.to_dict()
+        restored = EscalationEvent.from_dict(d)
+        assert restored.step == event.step
+        assert restored.was_necessary == event.was_necessary
+
+
+class TestOperatorLoopResult:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.operator_loop import OperatorLoopResult
+
+        result = OperatorLoopResult(
+            score=0.7,
+            reasoning="Good judgment on when to escalate",
+            dimension_scores={
+                "action_quality": 0.8,
+                "escalation_judgment": 0.7,
+            },
+            total_actions=10,
+            escalations=2,
+            necessary_escalations=1,
+            unnecessary_escalations=1,
+            missed_escalations=0,
+            clarifications_requested=3,
+        )
+        assert result.score == 0.7
+        assert result.escalations == 2
+        assert result.unnecessary_escalations == 1
+
+    def test_roundtrip(self) -> None:
+        from autocontext.scenarios.operator_loop import OperatorLoopResult
+
+        result = OperatorLoopResult(
+            score=0.5, reasoning="ok",
+            dimension_scores={"action_quality": 0.5},
+            total_actions=5, escalations=1,
+            necessary_escalations=1, unnecessary_escalations=0,
+            missed_escalations=0, clarifications_requested=1,
+        )
+        d = result.to_dict()
+        restored = OperatorLoopResult.from_dict(d)
+        assert restored.score == result.score
+        assert restored.escalations == result.escalations
+
+
+# ===========================================================================
+# AC-251: OperatorLoopInterface ABC
+# ===========================================================================
+
+
+class TestOperatorLoopInterface:
+    def test_cannot_instantiate(self) -> None:
+        from autocontext.scenarios.operator_loop import OperatorLoopInterface
+
+        with pytest.raises(TypeError):
+            OperatorLoopInterface()  # type: ignore[abstract]
+
+    def test_concrete_subclass(self) -> None:
+        from autocontext.scenarios.operator_loop import (
+            ClarificationRequest,
+            EscalationEvent,
+            OperatorLoopInterface,
+            OperatorLoopResult,
+        )
+        from autocontext.scenarios.simulation import (
+            Action,
+            ActionResult,
+            ActionSpec,
+            ActionTrace,
+            EnvironmentSpec,
+            SimulationResult,
+        )
+
+        class Stub(OperatorLoopInterface):
+            name = "stub_op_loop"
+
+            def describe_scenario(self) -> str:
+                return "stub"
+
+            def describe_environment(self) -> EnvironmentSpec:
+                return EnvironmentSpec(
+                    name="stub", description="stub",
+                    available_actions=[], initial_state_description="stub",
+                    success_criteria=[], failure_modes=[],
+                )
+
+            def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+                return {}
+
+            def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+                return []
+
+            def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+                return True, ""
+
+            def execute_action(
+                self, state: dict[str, Any], action: Action
+            ) -> tuple[ActionResult, dict[str, Any]]:
+                return ActionResult(success=True, output="", state_changes={}), state
+
+            def is_terminal(self, state: dict[str, Any]) -> bool:
+                return True
+
+            def evaluate_trace(
+                self, trace: ActionTrace, final_state: dict[str, Any]
+            ) -> SimulationResult:
+                return SimulationResult(
+                    score=0.0, reasoning="", dimension_scores={},
+                    workflow_complete=True, actions_taken=0, actions_successful=0,
+                )
+
+            def get_rubric(self) -> str:
+                return ""
+
+            def max_steps(self) -> int:
+                return 5
+
+            def get_escalation_log(self, state: dict[str, Any]) -> list[EscalationEvent]:
+                return []
+
+            def get_clarification_log(self, state: dict[str, Any]) -> list[ClarificationRequest]:
+                return []
+
+            def escalate(
+                self, state: dict[str, Any], event: EscalationEvent
+            ) -> dict[str, Any]:
+                return state
+
+            def request_clarification(
+                self, state: dict[str, Any], request: ClarificationRequest
+            ) -> dict[str, Any]:
+                return state
+
+            def evaluate_judgment(self, state: dict[str, Any]) -> OperatorLoopResult:
+                return OperatorLoopResult(
+                    score=0.5, reasoning="", dimension_scores={},
+                    total_actions=0, escalations=0,
+                    necessary_escalations=0, unnecessary_escalations=0,
+                    missed_escalations=0, clarifications_requested=0,
+                )
+
+        stub = Stub()
+        assert stub.name == "stub_op_loop"
+        assert stub.get_escalation_log({}) == []
+        result = stub.evaluate_judgment({})
+        assert isinstance(result, OperatorLoopResult)
+
+
+# ===========================================================================
+# AC-253: Multi-agent coordination data models
+# ===========================================================================
+
+
+class TestWorkerContext:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.coordination import WorkerContext
+
+        ctx = WorkerContext(
+            worker_id="w1",
+            role="researcher",
+            context_partition={"visible_docs": ["doc1", "doc2"]},
+            visible_data=["section_a"],
+        )
+        assert ctx.worker_id == "w1"
+        assert ctx.role == "researcher"
+        assert len(ctx.visible_data) == 1
+
+    def test_roundtrip(self) -> None:
+        from autocontext.scenarios.coordination import WorkerContext
+
+        ctx = WorkerContext(
+            worker_id="w2", role="writer",
+            context_partition={"topic": "x"},
+            visible_data=["a", "b"],
+        )
+        d = ctx.to_dict()
+        restored = WorkerContext.from_dict(d)
+        assert restored.worker_id == ctx.worker_id
+        assert restored.visible_data == ctx.visible_data
+
+
+class TestHandoffRecord:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.coordination import HandoffRecord
+
+        handoff = HandoffRecord(
+            from_worker="w1",
+            to_worker="w2",
+            content="Research findings on topic X",
+            quality=0.8,
+            step=2,
+        )
+        assert handoff.from_worker == "w1"
+        assert handoff.quality == 0.8
+
+    def test_roundtrip(self) -> None:
+        from autocontext.scenarios.coordination import HandoffRecord
+
+        handoff = HandoffRecord(
+            from_worker="a", to_worker="b",
+            content="data", quality=0.5, step=1,
+        )
+        d = handoff.to_dict()
+        restored = HandoffRecord.from_dict(d)
+        assert restored.from_worker == handoff.from_worker
+        assert restored.quality == handoff.quality
+
+
+class TestCoordinationResult:
+    def test_construction(self) -> None:
+        from autocontext.scenarios.coordination import CoordinationResult
+
+        result = CoordinationResult(
+            score=0.75,
+            reasoning="Good coordination",
+            dimension_scores={
+                "duplication_avoidance": 0.8,
+                "handoff_quality": 0.7,
+                "merge_quality": 0.8,
+                "outcome_quality": 0.7,
+            },
+            workers_used=3,
+            handoffs_completed=4,
+            duplication_rate=0.1,
+            merge_conflicts=1,
+        )
+        assert result.score == 0.75
+        assert result.workers_used == 3
+        assert result.duplication_rate == 0.1
+
+    def test_roundtrip(self) -> None:
+        from autocontext.scenarios.coordination import CoordinationResult
+
+        result = CoordinationResult(
+            score=0.6, reasoning="ok", dimension_scores={},
+            workers_used=2, handoffs_completed=1,
+            duplication_rate=0.2, merge_conflicts=0,
+        )
+        d = result.to_dict()
+        restored = CoordinationResult.from_dict(d)
+        assert restored.score == result.score
+        assert restored.workers_used == result.workers_used
+
+
+# ===========================================================================
+# AC-253: CoordinationInterface ABC
+# ===========================================================================
+
+
+class TestCoordinationInterface:
+    def test_cannot_instantiate(self) -> None:
+        from autocontext.scenarios.coordination import CoordinationInterface
+
+        with pytest.raises(TypeError):
+            CoordinationInterface()  # type: ignore[abstract]
+
+    def test_concrete_subclass(self) -> None:
+        from autocontext.scenarios.coordination import (
+            CoordinationInterface,
+            CoordinationResult,
+            HandoffRecord,
+            WorkerContext,
+        )
+        from autocontext.scenarios.simulation import (
+            Action,
+            ActionResult,
+            ActionSpec,
+            ActionTrace,
+            EnvironmentSpec,
+            SimulationResult,
+        )
+
+        class Stub(CoordinationInterface):
+            name = "stub_coord"
+
+            def describe_scenario(self) -> str:
+                return "stub"
+
+            def describe_environment(self) -> EnvironmentSpec:
+                return EnvironmentSpec(
+                    name="stub", description="stub",
+                    available_actions=[], initial_state_description="stub",
+                    success_criteria=[], failure_modes=[],
+                )
+
+            def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+                return {}
+
+            def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+                return []
+
+            def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+                return True, ""
+
+            def execute_action(
+                self, state: dict[str, Any], action: Action
+            ) -> tuple[ActionResult, dict[str, Any]]:
+                return ActionResult(success=True, output="", state_changes={}), state
+
+            def is_terminal(self, state: dict[str, Any]) -> bool:
+                return True
+
+            def evaluate_trace(
+                self, trace: ActionTrace, final_state: dict[str, Any]
+            ) -> SimulationResult:
+                return SimulationResult(
+                    score=0.0, reasoning="", dimension_scores={},
+                    workflow_complete=True, actions_taken=0, actions_successful=0,
+                )
+
+            def get_rubric(self) -> str:
+                return ""
+
+            def max_steps(self) -> int:
+                return 5
+
+            def get_worker_contexts(self, state: dict[str, Any]) -> list[WorkerContext]:
+                return []
+
+            def get_handoff_log(self, state: dict[str, Any]) -> list[HandoffRecord]:
+                return []
+
+            def record_handoff(
+                self, state: dict[str, Any], handoff: HandoffRecord
+            ) -> dict[str, Any]:
+                return state
+
+            def merge_outputs(
+                self, state: dict[str, Any], worker_outputs: dict[str, str]
+            ) -> dict[str, Any]:
+                return state
+
+            def evaluate_coordination(self, state: dict[str, Any]) -> CoordinationResult:
+                return CoordinationResult(
+                    score=0.5, reasoning="", dimension_scores={},
+                    workers_used=0, handoffs_completed=0,
+                    duplication_rate=0.0, merge_conflicts=0,
+                )
+
+        stub = Stub()
+        assert stub.name == "stub_coord"
+        assert stub.get_worker_contexts({}) == []
+        result = stub.evaluate_coordination({})
+        assert isinstance(result, CoordinationResult)
+
+
+# ===========================================================================
+# Family registry integration — both families
+# ===========================================================================
+
+
+class TestFamilyRegistration:
+    def test_operator_loop_registered(self) -> None:
+        from autocontext.scenarios.families import FAMILY_REGISTRY
+
+        assert "operator_loop" in FAMILY_REGISTRY
+
+    def test_coordination_registered(self) -> None:
+        from autocontext.scenarios.families import FAMILY_REGISTRY
+
+        assert "coordination" in FAMILY_REGISTRY
+
+    def test_operator_loop_marker(self) -> None:
+        from autocontext.scenarios.families import get_family_marker
+
+        assert get_family_marker("operator_loop") == "operator_loop"
+
+    def test_coordination_marker(self) -> None:
+        from autocontext.scenarios.families import get_family_marker
+
+        assert get_family_marker("coordination") == "coordination"
+
+    def test_detect_operator_loop(self) -> None:
+        from autocontext.scenarios.families import detect_family
+        from autocontext.scenarios.operator_loop import OperatorLoopInterface
+        from autocontext.scenarios.simulation import (
+            Action,
+            ActionResult,
+            ActionSpec,
+            ActionTrace,
+            EnvironmentSpec,
+            SimulationResult,
+        )
+
+        class Mini(OperatorLoopInterface):
+            name = "mini_op"
+
+            def describe_scenario(self) -> str:
+                return ""
+
+            def describe_environment(self) -> EnvironmentSpec:
+                return EnvironmentSpec(
+                    name="", description="", available_actions=[],
+                    initial_state_description="", success_criteria=[], failure_modes=[],
+                )
+
+            def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+                return {}
+
+            def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+                return []
+
+            def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+                return True, ""
+
+            def execute_action(
+                self, state: dict[str, Any], action: Action
+            ) -> tuple[ActionResult, dict[str, Any]]:
+                return ActionResult(success=True, output="", state_changes={}), state
+
+            def is_terminal(self, state: dict[str, Any]) -> bool:
+                return True
+
+            def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+                return SimulationResult(
+                    score=0.0, reasoning="", dimension_scores={},
+                    workflow_complete=False, actions_taken=0, actions_successful=0,
+                )
+
+            def get_rubric(self) -> str:
+                return ""
+
+            def max_steps(self) -> int:
+                return 1
+
+            def get_escalation_log(self, state: dict[str, Any]) -> list:
+                return []
+
+            def get_clarification_log(self, state: dict[str, Any]) -> list:
+                return []
+
+            def escalate(self, state: dict[str, Any], event: Any) -> dict[str, Any]:
+                return state
+
+            def request_clarification(self, state: dict[str, Any], request: Any) -> dict[str, Any]:
+                return state
+
+            def evaluate_judgment(self, state: dict[str, Any]) -> Any:
+                from autocontext.scenarios.operator_loop import OperatorLoopResult
+                return OperatorLoopResult(
+                    score=0.0, reasoning="", dimension_scores={},
+                    total_actions=0, escalations=0, necessary_escalations=0,
+                    unnecessary_escalations=0, missed_escalations=0,
+                    clarifications_requested=0,
+                )
+
+        family = detect_family(Mini())
+        assert family is not None
+        assert family.name == "operator_loop"
+
+
+# ===========================================================================
+# Pipeline registry — both families
+# ===========================================================================
+
+
+class TestPipelineRegistration:
+    def test_operator_loop_pipeline_registered(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import PIPELINE_REGISTRY
+
+        assert "operator_loop" in PIPELINE_REGISTRY
+
+    def test_coordination_pipeline_registered(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import PIPELINE_REGISTRY
+
+        assert "coordination" in PIPELINE_REGISTRY
+
+    def test_operator_loop_spec_valid(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        spec = {
+            "description": "Customer support escalation",
+            "environment_description": "Support system",
+            "initial_state_description": "Ticket received",
+            "escalation_policy": {
+                "escalation_threshold": "high",
+                "max_escalations": 3,
+            },
+            "success_criteria": ["resolve or correctly escalate"],
+            "failure_modes": ["over-escalation"],
+            "actions": [{"name": "respond", "description": "d"}],
+        }
+        errors = validate_for_family("operator_loop", spec)
+        assert errors == []
+
+    def test_coordination_spec_valid(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        spec = {
+            "description": "Multi-agent report writing",
+            "environment_description": "Research team",
+            "initial_state_description": "Task assigned to workers",
+            "workers": [
+                {"worker_id": "w1", "role": "researcher"},
+                {"worker_id": "w2", "role": "writer"},
+            ],
+            "success_criteria": ["coherent merged report"],
+            "failure_modes": ["duplication"],
+            "actions": [{"name": "research", "description": "d"}],
+        }
+        errors = validate_for_family("coordination", spec)
+        assert errors == []
+
+    def test_operator_loop_spec_missing_fields(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        errors = validate_for_family("operator_loop", {"description": "x"})
+        assert len(errors) > 0
+
+    def test_coordination_spec_missing_fields(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_for_family
+
+        errors = validate_for_family("coordination", {"description": "x"})
+        assert len(errors) > 0
+
+
+# ===========================================================================
+# Classifier routing
+# ===========================================================================
+
+
+class TestClassifierRouting:
+    def test_route_operator_loop(self) -> None:
+        from autocontext.scenarios.custom.family_classifier import (
+            classify_scenario_family,
+            route_to_family,
+        )
+
+        classification = classify_scenario_family(
+            "Agent must decide when to escalate to an operator and "
+            "when to request clarification before acting autonomously"
+        )
+        family = route_to_family(classification)
+        assert family.name == "operator_loop"
+
+    def test_route_coordination(self) -> None:
+        from autocontext.scenarios.custom.family_classifier import (
+            classify_scenario_family,
+            route_to_family,
+        )
+
+        classification = classify_scenario_family(
+            "Multiple worker agents coordinate under partial context "
+            "with handoff and merge of outputs"
+        )
+        family = route_to_family(classification)
+        assert family.name == "coordination"
+
+
+# ===========================================================================
+# Designer/spec parsing
+# ===========================================================================
+
+
+class TestOperatorLoopDesigner:
+    def test_parse_spec(self) -> None:
+        from autocontext.scenarios.custom.operator_loop_designer import (
+            OPERATOR_LOOP_SPEC_END,
+            OPERATOR_LOOP_SPEC_START,
+            parse_operator_loop_spec,
+        )
+
+        raw = f"""{OPERATOR_LOOP_SPEC_START}
+{{
+    "description": "Support triage",
+    "environment_description": "Help desk",
+    "initial_state_description": "Ticket open",
+    "escalation_policy": {{
+        "escalation_threshold": "high",
+        "max_escalations": 3
+    }},
+    "success_criteria": ["resolve or escalate correctly"],
+    "failure_modes": ["over-escalation"],
+    "max_steps": 8,
+    "actions": [
+        {{
+            "name": "respond", "description": "reply to customer",
+            "parameters": {{}}, "preconditions": [], "effects": ["replied"]
+        }},
+        {{
+            "name": "escalate_ticket", "description": "escalate to human",
+            "parameters": {{}}, "preconditions": [], "effects": ["escalated"]
+        }}
+    ]
+}}
+{OPERATOR_LOOP_SPEC_END}"""
+        spec = parse_operator_loop_spec(raw)
+        assert spec.description == "Support triage"
+        assert spec.escalation_policy["max_escalations"] == 3
+        assert len(spec.actions) == 2
+
+    def test_design_fn_calls_llm(self) -> None:
+        import json
+
+        from autocontext.scenarios.custom.operator_loop_designer import (
+            OPERATOR_LOOP_SPEC_END,
+            OPERATOR_LOOP_SPEC_START,
+            design_operator_loop,
+        )
+
+        fake_spec = {
+            "description": "test",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "escalation_policy": {
+                "escalation_threshold": "medium",
+                "max_escalations": 2,
+            },
+            "success_criteria": ["ok"],
+            "failure_modes": [],
+            "max_steps": 6,
+            "actions": [
+                {
+                    "name": "act", "description": "a",
+                    "parameters": {}, "preconditions": [], "effects": [],
+                }
+            ],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return (
+                f"{OPERATOR_LOOP_SPEC_START}\n"
+                f"{json.dumps(fake_spec)}\n"
+                f"{OPERATOR_LOOP_SPEC_END}"
+            )
+
+        spec = design_operator_loop("test", fake_llm)
+        assert spec.description == "test"
+
+
+class TestCoordinationDesigner:
+    def test_parse_spec(self) -> None:
+        from autocontext.scenarios.custom.coordination_designer import (
+            COORDINATION_SPEC_END,
+            COORDINATION_SPEC_START,
+            parse_coordination_spec,
+        )
+
+        raw = f"""{COORDINATION_SPEC_START}
+{{
+    "description": "Team report",
+    "environment_description": "Research team",
+    "initial_state_description": "Tasks assigned",
+    "workers": [
+        {{"worker_id": "w1", "role": "researcher"}},
+        {{"worker_id": "w2", "role": "writer"}}
+    ],
+    "success_criteria": ["merged report"],
+    "failure_modes": ["duplication"],
+    "max_steps": 10,
+    "actions": [
+        {{
+            "name": "research", "description": "gather data",
+            "parameters": {{}}, "preconditions": [], "effects": ["data_gathered"]
+        }},
+        {{
+            "name": "write", "description": "write section",
+            "parameters": {{}}, "preconditions": ["research"],
+            "effects": ["section_written"]
+        }}
+    ]
+}}
+{COORDINATION_SPEC_END}"""
+        spec = parse_coordination_spec(raw)
+        assert spec.description == "Team report"
+        assert len(spec.workers) == 2
+        assert spec.workers[0]["worker_id"] == "w1"
+
+    def test_design_fn_calls_llm(self) -> None:
+        import json
+
+        from autocontext.scenarios.custom.coordination_designer import (
+            COORDINATION_SPEC_END,
+            COORDINATION_SPEC_START,
+            design_coordination,
+        )
+
+        fake_spec = {
+            "description": "test",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "workers": [{"worker_id": "w1", "role": "r"}],
+            "success_criteria": ["ok"],
+            "failure_modes": [],
+            "max_steps": 6,
+            "actions": [
+                {
+                    "name": "work", "description": "w",
+                    "parameters": {}, "preconditions": [], "effects": [],
+                }
+            ],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return (
+                f"{COORDINATION_SPEC_START}\n"
+                f"{json.dumps(fake_spec)}\n"
+                f"{COORDINATION_SPEC_END}"
+            )
+
+        spec = design_coordination("test", fake_llm)
+        assert spec.description == "test"
+
+
+# ===========================================================================
+# Codegen
+# ===========================================================================
+
+
+class TestOperatorLoopCodegen:
+    def test_generate_class(self) -> None:
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+        from autocontext.scenarios.custom.operator_loop_codegen import generate_operator_loop_class
+        from autocontext.scenarios.custom.operator_loop_spec import OperatorLoopSpec
+        from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+
+        spec = OperatorLoopSpec(
+            description="test",
+            environment_description="env",
+            initial_state_description="init",
+            escalation_policy={"escalation_threshold": "high", "max_escalations": 3},
+            success_criteria=["done"],
+            failure_modes=[],
+            actions=[
+                SimulationActionSpecModel(
+                    name="act", description="a", parameters={},
+                    preconditions=[], effects=[],
+                ),
+            ],
+        )
+        source = generate_operator_loop_class(spec, name="test_op")
+        errors = validate_source_for_family("operator_loop", source)
+        assert errors == [], f"validation errors: {errors}"
+
+
+class TestCoordinationCodegen:
+    def test_generate_class(self) -> None:
+        from autocontext.scenarios.custom.coordination_codegen import generate_coordination_class
+        from autocontext.scenarios.custom.coordination_spec import CoordinationSpec
+        from autocontext.scenarios.custom.family_pipeline import validate_source_for_family
+        from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+
+        spec = CoordinationSpec(
+            description="test",
+            environment_description="env",
+            initial_state_description="init",
+            workers=[{"worker_id": "w1", "role": "r"}],
+            success_criteria=["done"],
+            failure_modes=[],
+            actions=[
+                SimulationActionSpecModel(
+                    name="work", description="w", parameters={},
+                    preconditions=[], effects=[],
+                ),
+            ],
+        )
+        source = generate_coordination_class(spec, name="test_coord")
+        errors = validate_source_for_family("coordination", source)
+        assert errors == [], f"validation errors: {errors}"
+
+
+# ===========================================================================
+# Creator end-to-end
+# ===========================================================================
+
+
+class TestOperatorLoopCreator:
+    def test_create_and_persist(self, tmp_path: Path) -> None:
+        import json
+
+        from autocontext.scenarios.custom.operator_loop_creator import OperatorLoopCreator
+        from autocontext.scenarios.custom.operator_loop_designer import (
+            OPERATOR_LOOP_SPEC_END,
+            OPERATOR_LOOP_SPEC_START,
+        )
+        from autocontext.scenarios.operator_loop import OperatorLoopInterface
+
+        fake_spec = {
+            "description": "test",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "escalation_policy": {
+                "escalation_threshold": "medium",
+                "max_escalations": 2,
+            },
+            "success_criteria": ["done"],
+            "failure_modes": [],
+            "max_steps": 6,
+            "actions": [
+                {
+                    "name": "act", "description": "a",
+                    "parameters": {}, "preconditions": [], "effects": [],
+                }
+            ],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return (
+                f"{OPERATOR_LOOP_SPEC_START}\n"
+                f"{json.dumps(fake_spec)}\n"
+                f"{OPERATOR_LOOP_SPEC_END}"
+            )
+
+        creator = OperatorLoopCreator(fake_llm, tmp_path)
+        scenario = creator.create("test", name="test_op_creator")
+        assert isinstance(scenario, OperatorLoopInterface)
+
+        scenario_dir = tmp_path / "_custom_scenarios" / "test_op_creator"
+        assert (scenario_dir / "scenario.py").exists()
+        assert (scenario_dir / "spec.json").exists()
+        assert (scenario_dir / "scenario_type.txt").read_text().strip() == "operator_loop"
+
+
+class TestCoordinationCreator:
+    def test_create_and_persist(self, tmp_path: Path) -> None:
+        import json
+
+        from autocontext.scenarios.coordination import CoordinationInterface
+        from autocontext.scenarios.custom.coordination_creator import CoordinationCreator
+        from autocontext.scenarios.custom.coordination_designer import (
+            COORDINATION_SPEC_END,
+            COORDINATION_SPEC_START,
+        )
+
+        fake_spec = {
+            "description": "test",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "workers": [{"worker_id": "w1", "role": "r"}],
+            "success_criteria": ["done"],
+            "failure_modes": [],
+            "max_steps": 6,
+            "actions": [
+                {
+                    "name": "work", "description": "w",
+                    "parameters": {}, "preconditions": [], "effects": [],
+                }
+            ],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return (
+                f"{COORDINATION_SPEC_START}\n"
+                f"{json.dumps(fake_spec)}\n"
+                f"{COORDINATION_SPEC_END}"
+            )
+
+        creator = CoordinationCreator(fake_llm, tmp_path)
+        scenario = creator.create("test", name="test_coord_creator")
+        assert isinstance(scenario, CoordinationInterface)
+
+        scenario_dir = tmp_path / "_custom_scenarios" / "test_coord_creator"
+        assert (scenario_dir / "scenario.py").exists()
+        assert (scenario_dir / "scenario_type.txt").read_text().strip() == "coordination"
+
+
+# ===========================================================================
+# AgentTaskCreator routing
+# ===========================================================================
+
+
+class TestAgentTaskCreatorRouting:
+    def test_routes_to_operator_loop(self, tmp_path: Path) -> None:
+        import json
+
+        from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
+        from autocontext.scenarios.custom.operator_loop_designer import (
+            OPERATOR_LOOP_SPEC_END,
+            OPERATOR_LOOP_SPEC_START,
+        )
+        from autocontext.scenarios.operator_loop import OperatorLoopInterface
+
+        fake_spec = {
+            "description": "routing test",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "escalation_policy": {
+                "escalation_threshold": "high",
+                "max_escalations": 2,
+            },
+            "success_criteria": ["done"],
+            "failure_modes": [],
+            "max_steps": 6,
+            "actions": [
+                {
+                    "name": "act", "description": "a",
+                    "parameters": {}, "preconditions": [], "effects": [],
+                }
+            ],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return (
+                f"{OPERATOR_LOOP_SPEC_START}\n"
+                f"{json.dumps(fake_spec)}\n"
+                f"{OPERATOR_LOOP_SPEC_END}"
+            )
+
+        creator = AgentTaskCreator(fake_llm, tmp_path)
+        scenario = creator.create(
+            "An operator-in-the-loop scenario where the agent must "
+            "decide when to escalate and when to request clarification"
+        )
+        assert isinstance(scenario, OperatorLoopInterface)
+
+    def test_routes_to_coordination(self, tmp_path: Path) -> None:
+        import json
+
+        from autocontext.scenarios.coordination import CoordinationInterface
+        from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
+        from autocontext.scenarios.custom.coordination_designer import (
+            COORDINATION_SPEC_END,
+            COORDINATION_SPEC_START,
+        )
+
+        fake_spec = {
+            "description": "routing test",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "workers": [{"worker_id": "w1", "role": "r"}],
+            "success_criteria": ["done"],
+            "failure_modes": [],
+            "max_steps": 6,
+            "actions": [
+                {
+                    "name": "work", "description": "w",
+                    "parameters": {}, "preconditions": [], "effects": [],
+                }
+            ],
+        }
+
+        def fake_llm(system: str, user: str) -> str:
+            return (
+                f"{COORDINATION_SPEC_START}\n"
+                f"{json.dumps(fake_spec)}\n"
+                f"{COORDINATION_SPEC_END}"
+            )
+
+        creator = AgentTaskCreator(fake_llm, tmp_path)
+        scenario = creator.create(
+            "Multi-agent coordination where worker agents have partial context "
+            "and must handoff information and merge outputs"
+        )
+        assert isinstance(scenario, CoordinationInterface)

--- a/ts/src/scenarios/agent-task-creator.ts
+++ b/ts/src/scenarios/agent-task-creator.ts
@@ -17,6 +17,10 @@ import {
   type ArtifactEditingScenarioHandle,
   ArtifactEditingCreator,
 } from "./artifact-editing-creator.js";
+import {
+  type CoordinationScenarioHandle,
+  CoordinationCreator,
+} from "./coordination-creator.js";
 import { classifyScenarioFamily, routeToFamily } from "./family-classifier.js";
 import { validateForFamily } from "./family-pipeline.js";
 import { getScenarioTypeMarker } from "./families.js";
@@ -28,6 +32,10 @@ import {
   type NegotiationScenarioHandle,
   NegotiationCreator,
 } from "./negotiation-creator.js";
+import {
+  type OperatorLoopScenarioHandle,
+  OperatorLoopCreator,
+} from "./operator-loop-creator.js";
 import {
   type SchemaEvolutionScenarioHandle,
   SchemaEvolutionCreator,
@@ -54,8 +62,10 @@ export interface AgentTaskCreatorOpts {
 export type CreatedScenario =
   | (AgentTaskInterface & { readonly name: string; readonly spec: AgentTaskSpec; readonly family?: "agent_task" })
   | ArtifactEditingScenarioHandle
+  | CoordinationScenarioHandle
   | InvestigationScenarioHandle
   | NegotiationScenarioHandle
+  | OperatorLoopScenarioHandle
   | SchemaEvolutionScenarioHandle
   | SimulationScenarioHandle
   | ToolFragilityScenarioHandle
@@ -158,6 +168,20 @@ export class AgentTaskCreator {
     }
     if (family === "negotiation") {
       return new NegotiationCreator({
+        provider: this.provider,
+        model: this.model,
+        knowledgeRoot: this.knowledgeRoot,
+      }).create(description, name);
+    }
+    if (family === "operator_loop") {
+      return new OperatorLoopCreator({
+        provider: this.provider,
+        model: this.model,
+        knowledgeRoot: this.knowledgeRoot,
+      }).create(description, name);
+    }
+    if (family === "coordination") {
+      return new CoordinationCreator({
         provider: this.provider,
         model: this.model,
         knowledgeRoot: this.knowledgeRoot,

--- a/ts/src/scenarios/coordination-creator.ts
+++ b/ts/src/scenarios/coordination-creator.ts
@@ -1,0 +1,230 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { LLMProvider } from "../types/index.js";
+import { validateForFamily } from "./family-pipeline.js";
+import { getScenarioTypeMarker } from "./families.js";
+import type { CoordinationSpec } from "./coordination-spec.js";
+import { designCoordination } from "./coordination-designer.js";
+
+export interface CoordinationCreatorOpts {
+  provider: LLMProvider;
+  model?: string;
+  knowledgeRoot: string;
+}
+
+export interface CoordinationScenarioHandle {
+  family: "coordination";
+  name: string;
+  spec: CoordinationSpec;
+}
+
+function className(name: string): string {
+  return name
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join("") + "Coordination";
+}
+
+function generateScenarioSource(spec: CoordinationSpec, name: string): string {
+  const actions = spec.actions
+    .map((action) => `            ActionSpec(name=${JSON.stringify(action.name)}, description=${JSON.stringify(action.description)}, parameters=${JSON.stringify(action.parameters)}, preconditions=${JSON.stringify(action.preconditions)}, effects=${JSON.stringify(action.effects)})`)
+    .join(",\n");
+  const requiredActions = JSON.stringify(spec.actions.map((action) => action.name));
+  const workers = JSON.stringify(spec.workers.map((worker) => ({ worker_id: worker.workerId, role: worker.role })));
+  return `from __future__ import annotations
+
+from typing import Any
+
+from autocontext.scenarios.coordination import CoordinationInterface, CoordinationResult, HandoffRecord, WorkerContext
+from autocontext.scenarios.simulation import Action, ActionResult, ActionSpec, ActionTrace, EnvironmentSpec, SimulationResult
+
+
+class ${className(name)}(CoordinationInterface):
+    name = ${JSON.stringify(name)}
+    _workers_spec = ${workers}
+
+    def describe_scenario(self) -> str:
+        return ${JSON.stringify(spec.description)}
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name=${JSON.stringify(name)},
+            description=${JSON.stringify(spec.environmentDescription)},
+            available_actions=[
+${actions}
+            ],
+            initial_state_description=${JSON.stringify(spec.initialStateDescription)},
+            success_criteria=${JSON.stringify(spec.successCriteria)},
+            failure_modes=${JSON.stringify(spec.failureModes)},
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {"seed": seed or 0, "step": 0, "completed_actions": [], "failed_actions": [], "handoffs": [], "worker_outputs": {}, "merged": False, "merge_conflicts": 0}
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        completed = set(state.get("completed_actions", []))
+        return [spec for spec in self.describe_environment().available_actions if spec.name not in completed]
+
+    def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+        specs = {spec.name: spec for spec in self.describe_environment().available_actions}
+        spec = specs.get(action.name)
+        if spec is None:
+            return False, f"unknown action: {action.name}"
+        completed = set(state.get("completed_actions", []))
+        for requirement in spec.preconditions:
+            if requirement not in completed:
+                return False, f"precondition not met for {action.name}: {requirement}"
+        return True, ""
+
+    def execute_action(self, state: dict[str, Any], action: Action) -> tuple[ActionResult, dict[str, Any]]:
+        valid, reason = self.validate_action(state, action)
+        next_state = dict(state)
+        if not valid:
+            next_state["failed_actions"] = [*state.get("failed_actions", []), action.name]
+            return ActionResult(success=False, output="", state_changes={}, error=reason), next_state
+        next_state["completed_actions"] = [*state.get("completed_actions", []), action.name]
+        next_state["step"] = state.get("step", 0) + 1
+        return (
+            ActionResult(success=True, output=f"executed {action.name}", state_changes={"completed_actions": list(next_state["completed_actions"])}),
+            next_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        required = set(${requiredActions})
+        completed = set(state.get("completed_actions", []))
+        return required.issubset(completed) or state.get("merged", False) or state.get("step", 0) >= ${spec.maxSteps}
+
+    def get_worker_contexts(self, state: dict[str, Any]) -> list[WorkerContext]:
+        del state
+        return [WorkerContext(worker_id=worker["worker_id"], role=worker.get("role", "worker"), context_partition={}, visible_data=[]) for worker in self._workers_spec]
+
+    def get_handoff_log(self, state: dict[str, Any]) -> list[HandoffRecord]:
+        return [HandoffRecord.from_dict(handoff) for handoff in state.get("handoffs", [])]
+
+    def record_handoff(self, state: dict[str, Any], handoff: HandoffRecord) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["handoffs"] = [*state.get("handoffs", []), handoff.to_dict()]
+        return next_state
+
+    def merge_outputs(self, state: dict[str, Any], worker_outputs: dict[str, str]) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["worker_outputs"] = worker_outputs
+        next_state["merged"] = True
+        values = list(worker_outputs.values())
+        conflicts = 0
+        for index, value in enumerate(values):
+            for other in values[index + 1:]:
+                if value == other and value:
+                    conflicts += 1
+        next_state["merge_conflicts"] = conflicts
+        return next_state
+
+    def evaluate_coordination(self, state: dict[str, Any]) -> CoordinationResult:
+        handoffs = state.get("handoffs", [])
+        worker_outputs = state.get("worker_outputs", {})
+        workers_used = len(worker_outputs) or len(self._workers_spec)
+        merge_conflicts = state.get("merge_conflicts", 0)
+        values = list(worker_outputs.values())
+        if len(values) > 1:
+            unique = len(set(value for value in values if value))
+            total = len([value for value in values if value])
+            duplication_rate = 1.0 - (unique / max(total, 1)) if total > 0 else 0.0
+        else:
+            duplication_rate = 0.0
+        avg_handoff = (sum(handoff.get("quality", 0.5) for handoff in handoffs) / len(handoffs)) if handoffs else 0.5
+        merge_quality = max(0.0, 1.0 - merge_conflicts * 0.2)
+        completed = len(state.get("completed_actions", []))
+        failed = len(state.get("failed_actions", []))
+        outcome_quality = completed / max(completed + failed, 1)
+        duplication_avoidance = max(0.0, 1.0 - duplication_rate)
+        score = round(duplication_avoidance * 0.25 + avg_handoff * 0.25 + merge_quality * 0.25 + outcome_quality * 0.25, 4)
+        return CoordinationResult(
+            score=score,
+            reasoning=f"{workers_used} workers, {len(handoffs)} handoffs, duplication rate {duplication_rate:.2f}, {merge_conflicts} merge conflicts.",
+            dimension_scores={"duplication_avoidance": round(duplication_avoidance, 4), "handoff_quality": round(avg_handoff, 4), "merge_quality": round(merge_quality, 4), "outcome_quality": round(outcome_quality, 4)},
+            workers_used=workers_used,
+            handoffs_completed=len(handoffs),
+            duplication_rate=round(duplication_rate, 4),
+            merge_conflicts=merge_conflicts,
+        )
+
+    def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+        coordination = self.evaluate_coordination(final_state)
+        action_success = trace.success_rate
+        score = round(coordination.score * 0.7 + action_success * 0.3, 4)
+        return SimulationResult(
+            score=score,
+            reasoning=coordination.reasoning,
+            dimension_scores={"duplication_avoidance": coordination.dimension_scores.get("duplication_avoidance", 0.0), "handoff_quality": coordination.dimension_scores.get("handoff_quality", 0.0), "merge_quality": coordination.dimension_scores.get("merge_quality", 0.0), "outcome_quality": coordination.dimension_scores.get("outcome_quality", 0.0), "action_success": round(action_success, 4)},
+            workflow_complete=final_state.get("merged", False),
+            actions_taken=len(trace.records),
+            actions_successful=sum(1 for record in trace.records if record.result.success),
+            recovery_attempts=coordination.merge_conflicts,
+            rollback_quality=coordination.dimension_scores.get("merge_quality", 0.0),
+        )
+
+    def get_rubric(self) -> str:
+        return "Evaluate on duplication avoidance, handoff quality, merge quality, and overall outcome quality."
+
+    def max_steps(self) -> int:
+        return ${spec.maxSteps}
+`;
+}
+
+export class CoordinationCreator {
+  private provider: LLMProvider;
+  private model: string;
+  private knowledgeRoot: string;
+
+  constructor(opts: CoordinationCreatorOpts) {
+    this.provider = opts.provider;
+    this.model = opts.model ?? opts.provider.defaultModel();
+    this.knowledgeRoot = opts.knowledgeRoot;
+  }
+
+  async create(description: string, name: string): Promise<CoordinationScenarioHandle> {
+    const llmFn = async (system: string, user: string): Promise<string> => {
+      const result = await this.provider.complete({
+        systemPrompt: system,
+        userPrompt: user,
+        model: this.model,
+      });
+      return result.text;
+    };
+    const spec = await designCoordination(description, llmFn);
+    const errors = validateForFamily("coordination", spec);
+    if (errors.length > 0) {
+      throw new Error(`coordination spec validation failed: ${errors.join("; ")}`);
+    }
+
+    const customDir = join(this.knowledgeRoot, "_custom_scenarios");
+    const scenarioDir = join(customDir, name);
+    if (!existsSync(scenarioDir)) mkdirSync(scenarioDir, { recursive: true });
+
+    writeFileSync(join(scenarioDir, "scenario.py"), generateScenarioSource(spec, name), "utf-8");
+    writeFileSync(join(scenarioDir, "scenario_type.txt"), getScenarioTypeMarker("coordination"), "utf-8");
+    writeFileSync(
+      join(scenarioDir, "spec.json"),
+      JSON.stringify(
+        {
+          name,
+          scenario_type: getScenarioTypeMarker("coordination"),
+          description: spec.description,
+          environment_description: spec.environmentDescription,
+          initial_state_description: spec.initialStateDescription,
+          workers: spec.workers.map((worker) => ({ worker_id: worker.workerId, role: worker.role })),
+          success_criteria: spec.successCriteria,
+          failure_modes: spec.failureModes,
+          max_steps: spec.maxSteps,
+          actions: spec.actions,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    return { family: "coordination", name, spec };
+  }
+}

--- a/ts/src/scenarios/coordination-designer.ts
+++ b/ts/src/scenarios/coordination-designer.ts
@@ -1,0 +1,98 @@
+import type { CoordinationSpec } from "./coordination-spec.js";
+import { parseRawCoordinationSpec } from "./coordination-spec.js";
+
+export const COORDINATION_SPEC_START = "<!-- COORDINATION_SPEC_START -->";
+export const COORDINATION_SPEC_END = "<!-- COORDINATION_SPEC_END -->";
+
+const EXAMPLE_SPEC = {
+  description: "Multi-agent research report writing.",
+  environment_description: "Research team with partial information.",
+  initial_state_description: "Task partitioned across workers.",
+  workers: [
+    { worker_id: "researcher", role: "data gatherer" },
+    { worker_id: "writer", role: "report writer" },
+  ],
+  success_criteria: [
+    "coherent merged report",
+    "minimal duplication across sections",
+  ],
+  failure_modes: [
+    "duplicate content across workers",
+    "lost information during handoff",
+  ],
+  max_steps: 10,
+  actions: [
+    {
+      name: "research",
+      description: "Gather data on assigned topic.",
+      parameters: { topic: "string" },
+      preconditions: [],
+      effects: ["data_gathered"],
+    },
+    {
+      name: "write_section",
+      description: "Write a report section.",
+      parameters: { section: "string" },
+      preconditions: ["research"],
+      effects: ["section_written"],
+    },
+  ],
+};
+
+export const COORDINATION_DESIGNER_SYSTEM = `You are a scenario designer for autocontext.
+Given a natural-language request for a multi-agent coordination scenario, produce a CoordinationSpec JSON.
+
+Wrap the output in delimiters:
+${COORDINATION_SPEC_START}
+{ ... }
+${COORDINATION_SPEC_END}
+
+Schema:
+{
+  "description": "scenario summary",
+  "environment_description": "team context",
+  "initial_state_description": "starting state",
+  "workers": [{"worker_id": "name", "role": "role"}],
+  "success_criteria": ["criterion"],
+  "failure_modes": ["failure mode"],
+  "max_steps": 10,
+  "actions": [
+    {
+      "name": "snake_case",
+      "description": "what the action does",
+      "parameters": {"param": "type"},
+      "preconditions": [],
+      "effects": ["effect"]
+    }
+  ]
+}
+
+Rules:
+- include at least two workers with distinct roles
+- workers do not share full context by default
+- include at least two actions
+
+Example:
+${COORDINATION_SPEC_START}
+${JSON.stringify(EXAMPLE_SPEC, null, 2)}
+${COORDINATION_SPEC_END}
+`;
+
+export function parseCoordinationSpec(text: string): CoordinationSpec {
+  const startIdx = text.indexOf(COORDINATION_SPEC_START);
+  const endIdx = text.indexOf(COORDINATION_SPEC_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
+    throw new Error("response does not contain COORDINATION_SPEC delimiters");
+  }
+  const raw = text.slice(startIdx + COORDINATION_SPEC_START.length, endIdx).trim();
+  return parseRawCoordinationSpec(JSON.parse(raw) as Record<string, unknown>);
+}
+
+export async function designCoordination(
+  description: string,
+  llmFn: (system: string, user: string) => Promise<string>,
+): Promise<CoordinationSpec> {
+  return parseCoordinationSpec(
+    await llmFn(COORDINATION_DESIGNER_SYSTEM, `User description:\n${description}`),
+  );
+}

--- a/ts/src/scenarios/coordination-spec.ts
+++ b/ts/src/scenarios/coordination-spec.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { SimulationActionSpecSchema } from "./simulation-spec.js";
+
+export const WorkerSpecSchema = z.object({
+  workerId: z.string().min(1),
+  role: z.string().min(1),
+});
+
+export const CoordinationSpecSchema = z.object({
+  description: z.string().min(1),
+  environmentDescription: z.string().min(1),
+  initialStateDescription: z.string().min(1),
+  workers: z.array(WorkerSpecSchema).min(2),
+  successCriteria: z.array(z.string().min(1)).min(1),
+  failureModes: z.array(z.string().min(1)).default([]),
+  actions: z.array(SimulationActionSpecSchema).min(2),
+  maxSteps: z.number().int().positive().default(10),
+});
+
+export type WorkerSpec = z.infer<typeof WorkerSpecSchema>;
+export type CoordinationSpec = z.infer<typeof CoordinationSpecSchema>;
+
+export function parseRawCoordinationSpec(data: Record<string, unknown>): CoordinationSpec {
+  return CoordinationSpecSchema.parse({
+    description: data.description,
+    environmentDescription: data.environment_description,
+    initialStateDescription: data.initial_state_description,
+    workers: Array.isArray(data.workers)
+      ? data.workers.map((worker) => {
+          const raw = worker as Record<string, unknown>;
+          return {
+            workerId: raw.worker_id,
+            role: raw.role,
+          };
+        })
+      : data.workers,
+    successCriteria: data.success_criteria,
+    failureModes: data.failure_modes ?? [],
+    actions: data.actions,
+    maxSteps: data.max_steps ?? 10,
+  });
+}

--- a/ts/src/scenarios/families.ts
+++ b/ts/src/scenarios/families.ts
@@ -7,7 +7,9 @@ export type ScenarioFamilyName =
   | "workflow"
   | "schema_evolution"
   | "tool_fragility"
-  | "negotiation";
+  | "negotiation"
+  | "operator_loop"
+  | "coordination";
 
 export const SCENARIO_TYPE_MARKERS: Record<ScenarioFamilyName, string> = {
   game: "parametric",
@@ -19,6 +21,8 @@ export const SCENARIO_TYPE_MARKERS: Record<ScenarioFamilyName, string> = {
   schema_evolution: "schema_evolution",
   tool_fragility: "tool_fragility",
   negotiation: "negotiation",
+  operator_loop: "operator_loop",
+  coordination: "coordination",
 };
 
 export function getScenarioTypeMarker(family: ScenarioFamilyName): string {

--- a/ts/src/scenarios/family-classifier.ts
+++ b/ts/src/scenarios/family-classifier.ts
@@ -226,6 +226,34 @@ const NEGOTIATION_SIGNALS: Record<string, number> = {
   concession: 1.0,
 };
 
+const OPERATOR_LOOP_SIGNALS: Record<string, number> = {
+  escalat: 2.0,
+  operator: 1.5,
+  clarification: 1.5,
+  "human in the loop": 2.0,
+  "human-in-the-loop": 2.0,
+  "over-escalat": 2.0,
+  "under-escalat": 2.0,
+  triage: 1.0,
+  "when to escalate": 2.0,
+  "operator loop": 2.0,
+};
+
+const COORDINATION_SIGNALS: Record<string, number> = {
+  coordinat: 2.0,
+  handoff: 2.0,
+  "multi-agent": 2.0,
+  "multi agent": 2.0,
+  worker: 1.5,
+  merge: 1.5,
+  duplication: 1.5,
+  parallel: 1.0,
+  teammate: 1.0,
+  collaborator: 1.0,
+  "role split": 1.5,
+  "partial context": 2.0,
+};
+
 const FAMILY_SIGNAL_GROUPS: Record<ScenarioFamilyName, Record<string, number>> = {
   game: GAME_SIGNALS,
   agent_task: AGENT_TASK_SIGNALS,
@@ -236,6 +264,8 @@ const FAMILY_SIGNAL_GROUPS: Record<ScenarioFamilyName, Record<string, number>> =
   schema_evolution: SCHEMA_EVOLUTION_SIGNALS,
   tool_fragility: TOOL_FRAGILITY_SIGNALS,
   negotiation: NEGOTIATION_SIGNALS,
+  operator_loop: OPERATOR_LOOP_SIGNALS,
+  coordination: COORDINATION_SIGNALS,
 };
 
 const DEFAULT_FAMILY_NAME: ScenarioFamilyName = "agent_task";

--- a/ts/src/scenarios/family-pipeline.ts
+++ b/ts/src/scenarios/family-pipeline.ts
@@ -1,9 +1,11 @@
 import type { AgentTaskSpec } from "./agent-task-spec.js";
 import { ArtifactEditingSpecSchema, type ArtifactEditingSpec } from "./artifact-editing-spec.js";
 import { validateSpec as validateAgentTaskSpec } from "./agent-task-validator.js";
+import { CoordinationSpecSchema, type CoordinationSpec } from "./coordination-spec.js";
 import { type ScenarioFamilyName } from "./families.js";
 import { InvestigationSpecSchema, type InvestigationSpec } from "./investigation-spec.js";
 import { NegotiationSpecSchema, type NegotiationSpec } from "./negotiation-spec.js";
+import { OperatorLoopSpecSchema, type OperatorLoopSpec } from "./operator-loop-spec.js";
 import { SchemaEvolutionSpecSchema, type SchemaEvolutionSpec } from "./schema-evolution-spec.js";
 import { SimulationSpecSchema, type SimulationSpec } from "./simulation-spec.js";
 import { ToolFragilitySpecSchema, type ToolFragilitySpec } from "./tool-fragility-spec.js";
@@ -125,6 +127,32 @@ const negotiationPipeline: FamilyPipeline<NegotiationSpec> = {
   },
 };
 
+const operatorLoopPipeline: FamilyPipeline<OperatorLoopSpec> = {
+  familyName: "operator_loop",
+  validateSpec(spec: OperatorLoopSpec): string[] {
+    const result = OperatorLoopSpecSchema.safeParse(spec);
+    if (!result.success) {
+      return result.error.issues.map(
+        (issue) => `${issue.path.join(".")}: ${issue.message}`,
+      );
+    }
+    return [];
+  },
+};
+
+const coordinationPipeline: FamilyPipeline<CoordinationSpec> = {
+  familyName: "coordination",
+  validateSpec(spec: CoordinationSpec): string[] {
+    const result = CoordinationSpecSchema.safeParse(spec);
+    if (!result.success) {
+      return result.error.issues.map(
+        (issue) => `${issue.path.join(".")}: ${issue.message}`,
+      );
+    }
+    return [];
+  },
+};
+
 const PIPELINE_REGISTRY = {
   agent_task: agentTaskPipeline,
   simulation: simulationPipeline,
@@ -134,6 +162,8 @@ const PIPELINE_REGISTRY = {
   schema_evolution: schemaEvolutionPipeline,
   tool_fragility: toolFragilityPipeline,
   negotiation: negotiationPipeline,
+  operator_loop: operatorLoopPipeline,
+  coordination: coordinationPipeline,
 } as const;
 
 export function hasPipeline(family: string): family is keyof typeof PIPELINE_REGISTRY {
@@ -157,7 +187,9 @@ export function validateForFamily(
     | WorkflowSpec
     | SchemaEvolutionSpec
     | ToolFragilitySpec
-    | NegotiationSpec,
+    | NegotiationSpec
+    | OperatorLoopSpec
+    | CoordinationSpec,
 ): string[] {
   const pipeline = getPipeline(family);
   return pipeline.validateSpec(spec as never);

--- a/ts/src/scenarios/operator-loop-creator.ts
+++ b/ts/src/scenarios/operator-loop-creator.ts
@@ -1,0 +1,227 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { LLMProvider } from "../types/index.js";
+import { validateForFamily } from "./family-pipeline.js";
+import { getScenarioTypeMarker } from "./families.js";
+import type { OperatorLoopSpec } from "./operator-loop-spec.js";
+import { designOperatorLoop } from "./operator-loop-designer.js";
+
+export interface OperatorLoopCreatorOpts {
+  provider: LLMProvider;
+  model?: string;
+  knowledgeRoot: string;
+}
+
+export interface OperatorLoopScenarioHandle {
+  family: "operator_loop";
+  name: string;
+  spec: OperatorLoopSpec;
+}
+
+function className(name: string): string {
+  return name
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join("") + "OperatorLoop";
+}
+
+function generateScenarioSource(spec: OperatorLoopSpec, name: string): string {
+  const actions = spec.actions
+    .map((action) => `            ActionSpec(name=${JSON.stringify(action.name)}, description=${JSON.stringify(action.description)}, parameters=${JSON.stringify(action.parameters)}, preconditions=${JSON.stringify(action.preconditions)}, effects=${JSON.stringify(action.effects)})`)
+    .join(",\n");
+  const requiredActions = JSON.stringify(spec.actions.map((action) => action.name));
+  const escalationPolicy = JSON.stringify({
+    escalation_threshold: spec.escalationPolicy.escalationThreshold,
+    max_escalations: spec.escalationPolicy.maxEscalations,
+  });
+  return `from __future__ import annotations
+
+from typing import Any
+
+from autocontext.scenarios.operator_loop import ClarificationRequest, EscalationEvent, OperatorLoopInterface, OperatorLoopResult
+from autocontext.scenarios.simulation import Action, ActionResult, ActionSpec, ActionTrace, EnvironmentSpec, SimulationResult
+
+
+class ${className(name)}(OperatorLoopInterface):
+    name = ${JSON.stringify(name)}
+    _escalation_policy = ${escalationPolicy}
+
+    def describe_scenario(self) -> str:
+        return ${JSON.stringify(spec.description)}
+
+    def describe_environment(self) -> EnvironmentSpec:
+        return EnvironmentSpec(
+            name=${JSON.stringify(name)},
+            description=${JSON.stringify(spec.environmentDescription)},
+            available_actions=[
+${actions}
+            ],
+            initial_state_description=${JSON.stringify(spec.initialStateDescription)},
+            success_criteria=${JSON.stringify(spec.successCriteria)},
+            failure_modes=${JSON.stringify(spec.failureModes)},
+        )
+
+    def initial_state(self, seed: int | None = None) -> dict[str, Any]:
+        return {"seed": seed or 0, "step": 0, "completed_actions": [], "failed_actions": [], "escalations": [], "clarifications": [], "necessary_escalation_steps": []}
+
+    def get_available_actions(self, state: dict[str, Any]) -> list[ActionSpec]:
+        completed = set(state.get("completed_actions", []))
+        return [spec for spec in self.describe_environment().available_actions if spec.name not in completed]
+
+    def validate_action(self, state: dict[str, Any], action: Action) -> tuple[bool, str]:
+        specs = {spec.name: spec for spec in self.describe_environment().available_actions}
+        spec = specs.get(action.name)
+        if spec is None:
+            return False, f"unknown action: {action.name}"
+        completed = set(state.get("completed_actions", []))
+        for requirement in spec.preconditions:
+            if requirement not in completed:
+                return False, f"precondition not met for {action.name}: {requirement}"
+        return True, ""
+
+    def execute_action(self, state: dict[str, Any], action: Action) -> tuple[ActionResult, dict[str, Any]]:
+        valid, reason = self.validate_action(state, action)
+        next_state = dict(state)
+        if not valid:
+            next_state["failed_actions"] = [*state.get("failed_actions", []), action.name]
+            return ActionResult(success=False, output="", state_changes={}, error=reason), next_state
+        next_state["completed_actions"] = [*state.get("completed_actions", []), action.name]
+        next_state["step"] = state.get("step", 0) + 1
+        return (
+            ActionResult(success=True, output=f"executed {action.name}", state_changes={"completed_actions": list(next_state["completed_actions"])}),
+            next_state,
+        )
+
+    def is_terminal(self, state: dict[str, Any]) -> bool:
+        required = set(${requiredActions})
+        completed = set(state.get("completed_actions", []))
+        return required.issubset(completed) or state.get("step", 0) >= ${spec.maxSteps}
+
+    def get_escalation_log(self, state: dict[str, Any]) -> list[EscalationEvent]:
+        return [EscalationEvent.from_dict(event) for event in state.get("escalations", [])]
+
+    def get_clarification_log(self, state: dict[str, Any]) -> list[ClarificationRequest]:
+        return [ClarificationRequest.from_dict(request) for request in state.get("clarifications", [])]
+
+    def escalate(self, state: dict[str, Any], event: EscalationEvent) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["escalations"] = [*state.get("escalations", []), event.to_dict()]
+        return next_state
+
+    def request_clarification(self, state: dict[str, Any], request: ClarificationRequest) -> dict[str, Any]:
+        next_state = dict(state)
+        next_state["clarifications"] = [*state.get("clarifications", []), request.to_dict()]
+        return next_state
+
+    def evaluate_judgment(self, state: dict[str, Any]) -> OperatorLoopResult:
+        escalations = state.get("escalations", [])
+        clarifications = state.get("clarifications", [])
+        total_actions = len(state.get("completed_actions", []))
+        necessary_steps = set(state.get("necessary_escalation_steps", []))
+        necessary = sum(1 for event in escalations if event.get("was_necessary", False))
+        unnecessary = len(escalations) - necessary
+        missed = len(necessary_steps - {event.get("step", -1) for event in escalations})
+        failed = len(state.get("failed_actions", []))
+        action_quality = total_actions / max(total_actions + failed, 1)
+        if escalations or necessary_steps:
+            over_penalty = unnecessary * 0.15
+            under_penalty = missed * 0.2
+            judgment = max(0.0, 1.0 - over_penalty - under_penalty)
+        else:
+            judgment = 1.0
+        score = round(action_quality * 0.4 + judgment * 0.6, 4)
+        return OperatorLoopResult(
+            score=score,
+            reasoning=f"{total_actions} actions, {len(escalations)} escalations ({necessary} necessary, {unnecessary} unnecessary), {missed} missed escalations.",
+            dimension_scores={"action_quality": round(action_quality, 4), "escalation_judgment": round(judgment, 4)},
+            total_actions=total_actions,
+            escalations=len(escalations),
+            necessary_escalations=necessary,
+            unnecessary_escalations=unnecessary,
+            missed_escalations=missed,
+            clarifications_requested=len(clarifications),
+        )
+
+    def evaluate_trace(self, trace: ActionTrace, final_state: dict[str, Any]) -> SimulationResult:
+        judgment = self.evaluate_judgment(final_state)
+        action_success = trace.success_rate
+        score = round(judgment.score * 0.7 + action_success * 0.3, 4)
+        return SimulationResult(
+            score=score,
+            reasoning=judgment.reasoning,
+            dimension_scores={"action_quality": judgment.dimension_scores.get("action_quality", 0.0), "escalation_judgment": judgment.dimension_scores.get("escalation_judgment", 0.0), "action_success": round(action_success, 4)},
+            workflow_complete=self.is_terminal(final_state),
+            actions_taken=len(trace.records),
+            actions_successful=sum(1 for record in trace.records if record.result.success),
+            recovery_attempts=judgment.unnecessary_escalations,
+            rollback_quality=judgment.dimension_scores.get("escalation_judgment", 0.0),
+        )
+
+    def get_rubric(self) -> str:
+        return "Evaluate on action completion quality, escalation judgment (avoiding both over- and under-escalation), and appropriate use of clarification requests."
+
+    def max_steps(self) -> int:
+        return ${spec.maxSteps}
+`;
+}
+
+export class OperatorLoopCreator {
+  private provider: LLMProvider;
+  private model: string;
+  private knowledgeRoot: string;
+
+  constructor(opts: OperatorLoopCreatorOpts) {
+    this.provider = opts.provider;
+    this.model = opts.model ?? opts.provider.defaultModel();
+    this.knowledgeRoot = opts.knowledgeRoot;
+  }
+
+  async create(description: string, name: string): Promise<OperatorLoopScenarioHandle> {
+    const llmFn = async (system: string, user: string): Promise<string> => {
+      const result = await this.provider.complete({
+        systemPrompt: system,
+        userPrompt: user,
+        model: this.model,
+      });
+      return result.text;
+    };
+    const spec = await designOperatorLoop(description, llmFn);
+    const errors = validateForFamily("operator_loop", spec);
+    if (errors.length > 0) {
+      throw new Error(`operator_loop spec validation failed: ${errors.join("; ")}`);
+    }
+
+    const customDir = join(this.knowledgeRoot, "_custom_scenarios");
+    const scenarioDir = join(customDir, name);
+    if (!existsSync(scenarioDir)) mkdirSync(scenarioDir, { recursive: true });
+
+    writeFileSync(join(scenarioDir, "scenario.py"), generateScenarioSource(spec, name), "utf-8");
+    writeFileSync(join(scenarioDir, "scenario_type.txt"), getScenarioTypeMarker("operator_loop"), "utf-8");
+    writeFileSync(
+      join(scenarioDir, "spec.json"),
+      JSON.stringify(
+        {
+          name,
+          scenario_type: getScenarioTypeMarker("operator_loop"),
+          description: spec.description,
+          environment_description: spec.environmentDescription,
+          initial_state_description: spec.initialStateDescription,
+          escalation_policy: {
+            escalation_threshold: spec.escalationPolicy.escalationThreshold,
+            max_escalations: spec.escalationPolicy.maxEscalations,
+          },
+          success_criteria: spec.successCriteria,
+          failure_modes: spec.failureModes,
+          max_steps: spec.maxSteps,
+          actions: spec.actions,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    return { family: "operator_loop", name, spec };
+  }
+}

--- a/ts/src/scenarios/operator-loop-designer.ts
+++ b/ts/src/scenarios/operator-loop-designer.ts
@@ -1,0 +1,98 @@
+import type { OperatorLoopSpec } from "./operator-loop-spec.js";
+import { parseRawOperatorLoopSpec } from "./operator-loop-spec.js";
+
+export const OPERATOR_LOOP_SPEC_START = "<!-- OPERATOR_LOOP_SPEC_START -->";
+export const OPERATOR_LOOP_SPEC_END = "<!-- OPERATOR_LOOP_SPEC_END -->";
+
+const EXAMPLE_SPEC = {
+  description: "Customer support triage with escalation policy.",
+  environment_description: "Help desk system with tiered support.",
+  initial_state_description: "Ticket received, agent begins triage.",
+  escalation_policy: {
+    escalation_threshold: "high",
+    max_escalations: 3,
+  },
+  success_criteria: [
+    "resolve issue or correctly escalate",
+    "minimize unnecessary escalations",
+  ],
+  failure_modes: [
+    "over-escalation (escalating trivial issues)",
+    "under-escalation (failing to escalate critical issues)",
+  ],
+  max_steps: 10,
+  actions: [
+    {
+      name: "respond",
+      description: "Reply to the customer directly.",
+      parameters: { message: "string" },
+      preconditions: [],
+      effects: ["response_sent"],
+    },
+    {
+      name: "escalate_ticket",
+      description: "Escalate to a human operator.",
+      parameters: { reason: "string" },
+      preconditions: [],
+      effects: ["escalated"],
+    },
+  ],
+};
+
+export const OPERATOR_LOOP_DESIGNER_SYSTEM = `You are a scenario designer for autocontext.
+Given a natural-language request for an operator-in-the-loop scenario, produce an OperatorLoopSpec JSON.
+
+Wrap the output in delimiters:
+${OPERATOR_LOOP_SPEC_START}
+{ ... }
+${OPERATOR_LOOP_SPEC_END}
+
+Schema:
+{
+  "description": "scenario summary",
+  "environment_description": "system context",
+  "initial_state_description": "starting state",
+  "escalation_policy": {"escalation_threshold": "level", "max_escalations": 3},
+  "success_criteria": ["criterion"],
+  "failure_modes": ["failure mode"],
+  "max_steps": 10,
+  "actions": [
+    {
+      "name": "snake_case",
+      "description": "what the action does",
+      "parameters": {"param": "type"},
+      "preconditions": [],
+      "effects": ["effect"]
+    }
+  ]
+}
+
+Rules:
+- escalation_policy must include escalation_threshold and max_escalations
+- include at least one action that acts and one that escalates
+- failure_modes should include both over-escalation and under-escalation
+
+Example:
+${OPERATOR_LOOP_SPEC_START}
+${JSON.stringify(EXAMPLE_SPEC, null, 2)}
+${OPERATOR_LOOP_SPEC_END}
+`;
+
+export function parseOperatorLoopSpec(text: string): OperatorLoopSpec {
+  const startIdx = text.indexOf(OPERATOR_LOOP_SPEC_START);
+  const endIdx = text.indexOf(OPERATOR_LOOP_SPEC_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
+    throw new Error("response does not contain OPERATOR_LOOP_SPEC delimiters");
+  }
+  const raw = text.slice(startIdx + OPERATOR_LOOP_SPEC_START.length, endIdx).trim();
+  return parseRawOperatorLoopSpec(JSON.parse(raw) as Record<string, unknown>);
+}
+
+export async function designOperatorLoop(
+  description: string,
+  llmFn: (system: string, user: string) => Promise<string>,
+): Promise<OperatorLoopSpec> {
+  return parseOperatorLoopSpec(
+    await llmFn(OPERATOR_LOOP_DESIGNER_SYSTEM, `User description:\n${description}`),
+  );
+}

--- a/ts/src/scenarios/operator-loop-spec.ts
+++ b/ts/src/scenarios/operator-loop-spec.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { SimulationActionSpecSchema } from "./simulation-spec.js";
+
+export const EscalationPolicySchema = z.object({
+  escalationThreshold: z.string().min(1),
+  maxEscalations: z.number().int().positive(),
+});
+
+export const OperatorLoopSpecSchema = z.object({
+  description: z.string().min(1),
+  environmentDescription: z.string().min(1),
+  initialStateDescription: z.string().min(1),
+  escalationPolicy: EscalationPolicySchema,
+  successCriteria: z.array(z.string().min(1)).min(1),
+  failureModes: z.array(z.string().min(1)).default([]),
+  actions: z.array(SimulationActionSpecSchema).min(2),
+  maxSteps: z.number().int().positive().default(10),
+});
+
+export type EscalationPolicy = z.infer<typeof EscalationPolicySchema>;
+export type OperatorLoopSpec = z.infer<typeof OperatorLoopSpecSchema>;
+
+export function parseRawOperatorLoopSpec(data: Record<string, unknown>): OperatorLoopSpec {
+  const rawPolicy = data.escalation_policy as Record<string, unknown>;
+  return OperatorLoopSpecSchema.parse({
+    description: data.description,
+    environmentDescription: data.environment_description,
+    initialStateDescription: data.initial_state_description,
+    escalationPolicy: {
+      escalationThreshold: rawPolicy.escalation_threshold,
+      maxEscalations: rawPolicy.max_escalations,
+    },
+    successCriteria: data.success_criteria,
+    failureModes: data.failure_modes ?? [],
+    actions: data.actions,
+    maxSteps: data.max_steps ?? 10,
+  });
+}

--- a/ts/tests/agent-task-pipeline.test.ts
+++ b/ts/tests/agent-task-pipeline.test.ts
@@ -16,6 +16,10 @@ import {
   ARTIFACT_SPEC_START,
 } from "../src/scenarios/artifact-editing-designer.js";
 import {
+  COORDINATION_SPEC_END,
+  COORDINATION_SPEC_START,
+} from "../src/scenarios/coordination-designer.js";
+import {
   INVESTIGATION_SPEC_END,
   INVESTIGATION_SPEC_START,
 } from "../src/scenarios/investigation-designer.js";
@@ -23,6 +27,10 @@ import {
   NEGOTIATION_SPEC_END,
   NEGOTIATION_SPEC_START,
 } from "../src/scenarios/negotiation-designer.js";
+import {
+  OPERATOR_LOOP_SPEC_END,
+  OPERATOR_LOOP_SPEC_START,
+} from "../src/scenarios/operator-loop-designer.js";
 import {
   SCHEMA_EVOLUTION_SPEC_END,
   SCHEMA_EVOLUTION_SPEC_START,
@@ -46,8 +54,10 @@ import { validateIntent, validateSpec } from "../src/scenarios/agent-task-valida
 import { createAgentTask } from "../src/scenarios/agent-task-factory.js";
 import { AgentTaskCreator } from "../src/scenarios/agent-task-creator.js";
 import type { AgentTaskSpec } from "../src/scenarios/agent-task-spec.js";
+import type { CoordinationSpec } from "../src/scenarios/coordination-spec.js";
 import type { InvestigationSpec } from "../src/scenarios/investigation-spec.js";
 import type { NegotiationSpec } from "../src/scenarios/negotiation-spec.js";
+import type { OperatorLoopSpec } from "../src/scenarios/operator-loop-spec.js";
 import type { SchemaEvolutionSpec } from "../src/scenarios/schema-evolution-spec.js";
 import type { SimulationSpec } from "../src/scenarios/simulation-spec.js";
 import type { ToolFragilitySpec } from "../src/scenarios/tool-fragility-spec.js";
@@ -345,6 +355,70 @@ function mockNegotiationResponse(): string {
   return `${NEGOTIATION_SPEC_START}\n${JSON.stringify(data, null, 2)}\n${NEGOTIATION_SPEC_END}\n`;
 }
 
+function mockOperatorLoopResponse(): string {
+  const data = {
+    description: "Customer support triage with escalation policy.",
+    environment_description: "Help desk system with tiered support.",
+    initial_state_description: "Ticket received, agent begins triage.",
+    escalation_policy: {
+      escalation_threshold: "high",
+      max_escalations: 3,
+    },
+    success_criteria: ["resolve issue or correctly escalate", "minimize unnecessary escalations"],
+    failure_modes: ["over-escalation", "under-escalation"],
+    max_steps: 10,
+    actions: [
+      {
+        name: "respond",
+        description: "Reply to the customer directly.",
+        parameters: { message: "string" },
+        preconditions: [],
+        effects: ["response_sent"],
+      },
+      {
+        name: "escalate_ticket",
+        description: "Escalate to a human operator.",
+        parameters: { reason: "string" },
+        preconditions: [],
+        effects: ["escalated"],
+      },
+    ],
+  };
+  return `${OPERATOR_LOOP_SPEC_START}\n${JSON.stringify(data, null, 2)}\n${OPERATOR_LOOP_SPEC_END}\n`;
+}
+
+function mockCoordinationResponse(): string {
+  const data = {
+    description: "Multi-agent research report writing.",
+    environment_description: "Research team with partial information.",
+    initial_state_description: "Task partitioned across workers.",
+    workers: [
+      { worker_id: "researcher", role: "data gatherer" },
+      { worker_id: "writer", role: "report writer" },
+    ],
+    success_criteria: ["coherent merged report", "minimal duplication across sections"],
+    failure_modes: ["duplicate content across workers", "lost information during handoff"],
+    max_steps: 10,
+    actions: [
+      {
+        name: "research",
+        description: "Gather data on assigned topic.",
+        parameters: { topic: "string" },
+        preconditions: [],
+        effects: ["data_gathered"],
+      },
+      {
+        name: "write_section",
+        description: "Write a report section.",
+        parameters: { section: "string" },
+        preconditions: ["research"],
+        effects: ["section_written"],
+      },
+    ],
+  };
+  return `${COORDINATION_SPEC_START}\n${JSON.stringify(data, null, 2)}\n${COORDINATION_SPEC_END}\n`;
+}
+
 function makeMockProvider(response = "mock output"): LLMProvider {
   return {
     complete: async () => ({ text: response, model: "mock", usage: { inputTokens: 0, outputTokens: 0 } }) as CompletionResult,
@@ -609,6 +683,46 @@ describe("FamilyPipeline", () => {
       maxSteps: 10,
     };
     expect(validateForFamily("negotiation", spec)).toEqual([]);
+  });
+
+  it("validates operator-loop specs through the family pipeline", () => {
+    const spec: OperatorLoopSpec = {
+      description: "Support triage with escalation judgment.",
+      environmentDescription: "Help desk system.",
+      initialStateDescription: "A new ticket has arrived.",
+      escalationPolicy: {
+        escalationThreshold: "high",
+        maxEscalations: 3,
+      },
+      successCriteria: ["resolve or correctly escalate"],
+      failureModes: ["over-escalation", "under-escalation"],
+      actions: [
+        { name: "respond", description: "Reply to the customer", parameters: { message: "string" }, preconditions: [], effects: ["response_sent"] },
+        { name: "escalate_ticket", description: "Escalate to a human", parameters: { reason: "string" }, preconditions: [], effects: ["escalated"] },
+      ],
+      maxSteps: 10,
+    };
+    expect(validateForFamily("operator_loop", spec)).toEqual([]);
+  });
+
+  it("validates coordination specs through the family pipeline", () => {
+    const spec: CoordinationSpec = {
+      description: "Coordinate workers on a shared task.",
+      environmentDescription: "Research team with partial context.",
+      initialStateDescription: "Task is partitioned.",
+      workers: [
+        { workerId: "researcher", role: "data gatherer" },
+        { workerId: "writer", role: "report writer" },
+      ],
+      successCriteria: ["coherent merged output"],
+      failureModes: ["duplicate work"],
+      actions: [
+        { name: "research", description: "Gather data", parameters: { topic: "string" }, preconditions: [], effects: ["data_gathered"] },
+        { name: "write_section", description: "Write section", parameters: { section: "string" }, preconditions: ["research"], effects: ["section_written"] },
+      ],
+      maxSteps: 10,
+    };
+    expect(validateForFamily("coordination", spec)).toEqual([]);
   });
 
   it("rejects unsupported families instead of collapsing silently", () => {
@@ -904,6 +1018,36 @@ describe("AgentTaskCreator", () => {
     expect(readFileSync(join(scenarioDir, "scenario_type.txt"), "utf-8")).toBe(getScenarioTypeMarker("negotiation"));
   });
 
+  it("routes operator-loop descriptions into an operator-loop scaffold", async () => {
+    const provider = makeMockProvider(mockOperatorLoopResponse());
+    const tmpDir = mkdtempSync(join(tmpdir(), "autocontext-creator-operator-"));
+    const creator = new AgentTaskCreator({ provider, knowledgeRoot: tmpDir });
+
+    const scenario = await creator.create("Create an operator-in-the-loop scenario for support triage with escalation judgment");
+    expect("family" in scenario && scenario.family).toBe("operator_loop");
+
+    const name = creator.deriveName("Create an operator-in-the-loop scenario for support triage with escalation judgment");
+    const scenarioDir = join(tmpDir, "_custom_scenarios", name);
+    expect(existsSync(join(scenarioDir, "scenario.py"))).toBe(true);
+    expect(existsSync(join(scenarioDir, "spec.json"))).toBe(true);
+    expect(readFileSync(join(scenarioDir, "scenario_type.txt"), "utf-8")).toBe(getScenarioTypeMarker("operator_loop"));
+  });
+
+  it("routes coordination descriptions into a coordination scaffold", async () => {
+    const provider = makeMockProvider(mockCoordinationResponse());
+    const tmpDir = mkdtempSync(join(tmpdir(), "autocontext-creator-coordination-"));
+    const creator = new AgentTaskCreator({ provider, knowledgeRoot: tmpDir });
+
+    const scenario = await creator.create("Create a multi-agent coordination scenario with handoffs and partial context");
+    expect("family" in scenario && scenario.family).toBe("coordination");
+
+    const name = creator.deriveName("Create a multi-agent coordination scenario with handoffs and partial context");
+    const scenarioDir = join(tmpDir, "_custom_scenarios", name);
+    expect(existsSync(join(scenarioDir, "scenario.py"))).toBe(true);
+    expect(existsSync(join(scenarioDir, "spec.json"))).toBe(true);
+    expect(readFileSync(join(scenarioDir, "scenario_type.txt"), "utf-8")).toBe(getScenarioTypeMarker("coordination"));
+  });
+
   it("rejects classified-but-unsupported game families", async () => {
     const provider = makeMockProvider(mockLlmResponse(SAMPLE_SPEC));
     const tmpDir = mkdtempSync(join(tmpdir(), "autocontext-creator-game-"));
@@ -949,6 +1093,18 @@ describe("AgentTaskCreator", () => {
     expect(
       classifyScenarioFamily("Create a negotiation scenario with hidden BATNA, counteroffers, and adversarial preferences").familyName,
     ).toBe("negotiation");
+  });
+
+  it("classifies operator-loop descriptions into the operator_loop family", () => {
+    expect(
+      classifyScenarioFamily("Create an operator-in-the-loop scenario for support triage with escalation judgment").familyName,
+    ).toBe("operator_loop");
+  });
+
+  it("classifies coordination descriptions into the coordination family", () => {
+    expect(
+      classifyScenarioFamily("Create a multi-agent coordination scenario with handoffs and partial context").familyName,
+    ).toBe("coordination");
   });
 });
 


### PR DESCRIPTION
## Summary
- **AC-251**: Adds operator-in-the-loop scenario family with escalation/clarification/judgment evaluation — tests when agents should escalate vs act autonomously
- **AC-253**: Adds multi-agent coordination scenario family with worker context partitioning, handoff tracking, merge quality, and duplication detection

Both families include full vertical-slice pipelines: interface → spec → designer → codegen → creator → pipeline validation → classifier routing → AgentTaskCreator integration.

## Files Added (10 new modules)
- `scenarios/operator_loop.py` — OperatorLoopInterface ABC + ClarificationRequest, EscalationEvent, OperatorLoopResult
- `scenarios/coordination.py` — CoordinationInterface ABC + WorkerContext, HandoffRecord, CoordinationResult
- `scenarios/custom/{operator_loop,coordination}_{spec,designer,codegen,creator}.py` — full creation pipelines

## Files Modified (4 integration points)
- `families.py` — registered both families
- `family_pipeline.py` — OperatorLoopPipeline + CoordinationPipeline with contract validation
- `family_classifier.py` — signal dicts for keyword-based routing
- `agent_task_creator.py` — routing branches for both families

## Test plan
- [x] 39 dedicated tests in `test_operator_loop_coordination.py`
- [x] Full suite: 3737 passed, 46 skipped, 0 failed
- [x] Ruff clean, mypy clean