### PR TITLE
feat(AC-255, AC-256): aggregate run facets, signal extraction, and pattern clustering

### DIFF
--- a/autocontext/src/autocontext/analytics/__init__.py
+++ b/autocontext/src/autocontext/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Aggregate analytics for cross-run facets, signal extraction, and pattern clustering."""

--- a/autocontext/src/autocontext/analytics/clustering.py
+++ b/autocontext/src/autocontext/analytics/clustering.py
@@ -1,0 +1,199 @@
+"""Pattern clustering across runs (AC-256).
+
+Groups similar friction and delight signals across RunFacets,
+supporting sequence-level pattern detection and queryable clusters.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+from autocontext.analytics.facets import RunFacet
+
+
+@dataclass(slots=True)
+class EventPattern:
+    """A recurring event or sequence pattern across runs."""
+
+    pattern_id: str
+    pattern_type: str  # single_event, sequence, motif
+    description: str
+    event_sequence: list[str]
+    frequency: int
+    run_ids: list[str]
+    confidence: float
+    evidence: list[dict[str, Any]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pattern_id": self.pattern_id,
+            "pattern_type": self.pattern_type,
+            "description": self.description,
+            "event_sequence": self.event_sequence,
+            "frequency": self.frequency,
+            "run_ids": self.run_ids,
+            "confidence": self.confidence,
+            "evidence": self.evidence,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EventPattern:
+        return cls(
+            pattern_id=data["pattern_id"],
+            pattern_type=data["pattern_type"],
+            description=data["description"],
+            event_sequence=data.get("event_sequence", []),
+            frequency=data.get("frequency", 0),
+            run_ids=data.get("run_ids", []),
+            confidence=data.get("confidence", 0.0),
+            evidence=data.get("evidence", []),
+        )
+
+
+@dataclass(slots=True)
+class FacetCluster:
+    """A group of similar friction or delight signals across runs."""
+
+    cluster_id: str
+    label: str
+    category: str  # friction or delight
+    signal_types: list[str]
+    run_ids: list[str]
+    frequency: int
+    recurrence_rate: float
+    confidence: float
+    evidence_summary: str
+    supporting_events: list[dict[str, Any]]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cluster_id": self.cluster_id,
+            "label": self.label,
+            "category": self.category,
+            "signal_types": self.signal_types,
+            "run_ids": self.run_ids,
+            "frequency": self.frequency,
+            "recurrence_rate": self.recurrence_rate,
+            "confidence": self.confidence,
+            "evidence_summary": self.evidence_summary,
+            "supporting_events": self.supporting_events,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FacetCluster:
+        return cls(
+            cluster_id=data["cluster_id"],
+            label=data["label"],
+            category=data["category"],
+            signal_types=data.get("signal_types", []),
+            run_ids=data.get("run_ids", []),
+            frequency=data.get("frequency", 0),
+            recurrence_rate=data.get("recurrence_rate", 0.0),
+            confidence=data.get("confidence", 0.0),
+            evidence_summary=data.get("evidence_summary", ""),
+            supporting_events=data.get("supporting_events", []),
+            metadata=data.get("metadata", {}),
+        )
+
+
+class PatternClusterer:
+    """Groups similar friction/delight patterns across runs."""
+
+    def cluster_friction(self, facets: list[RunFacet]) -> list[FacetCluster]:
+        """Cluster friction signals by signal_type across facets."""
+        if not facets:
+            return []
+        return self._cluster_signals(facets, "friction")
+
+    def cluster_delight(self, facets: list[RunFacet]) -> list[FacetCluster]:
+        """Cluster delight signals by signal_type across facets."""
+        if not facets:
+            return []
+        return self._cluster_signals(facets, "delight")
+
+    def _cluster_signals(
+        self, facets: list[RunFacet], category: str
+    ) -> list[FacetCluster]:
+        # Group signals by type across all facets
+        type_to_runs: dict[str, set[str]] = defaultdict(set)
+        type_to_evidence: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        type_to_facets: dict[str, list[RunFacet]] = defaultdict(list)
+
+        for facet in facets:
+            signals = (
+                facet.friction_signals if category == "friction"
+                else facet.delight_signals
+            )
+            seen_types: set[str] = set()
+            for signal in signals:
+                st = signal.signal_type
+                type_to_runs[st].add(facet.run_id)
+                type_to_evidence[st].append({
+                    "run_id": facet.run_id,
+                    "generation_index": signal.generation_index,
+                    "description": signal.description,
+                })
+                if st not in seen_types:
+                    seen_types.add(st)
+                    type_to_facets[st].append(facet)
+
+        total_runs = len(facets)
+        clusters: list[FacetCluster] = []
+
+        for signal_type, run_ids in type_to_runs.items():
+            frequency = len(run_ids)
+            recurrence_rate = frequency / total_runs if total_runs > 0 else 0.0
+            confidence = min(1.0, recurrence_rate + 0.1 * frequency)
+
+            clusters.append(FacetCluster(
+                cluster_id=f"clust-{uuid.uuid4().hex[:8]}",
+                label=f"Recurring {signal_type}",
+                category=category,
+                signal_types=[signal_type],
+                run_ids=sorted(run_ids),
+                frequency=frequency,
+                recurrence_rate=round(recurrence_rate, 4),
+                confidence=round(confidence, 4),
+                evidence_summary=f"{frequency} of {total_runs} runs exhibited {signal_type}",
+                supporting_events=type_to_evidence[signal_type][:5],
+                metadata={
+                    "scenarios": sorted({
+                        f.scenario for f in type_to_facets[signal_type]
+                    }),
+                    "providers": sorted({
+                        f.agent_provider for f in type_to_facets[signal_type]
+                    }),
+                },
+            ))
+
+        return sorted(clusters, key=lambda c: c.frequency, reverse=True)
+
+    def query_clusters(
+        self,
+        clusters: list[FacetCluster],
+        scenario: str | None = None,
+        agent_provider: str | None = None,
+        scenario_family: str | None = None,
+    ) -> list[FacetCluster]:
+        """Filter clusters by metadata dimensions."""
+        results: list[FacetCluster] = []
+        for cluster in clusters:
+            if scenario is not None:
+                scenarios = cluster.metadata.get("scenarios", [])
+                if scenario not in scenarios:
+                    continue
+            if agent_provider is not None:
+                providers = cluster.metadata.get("providers", [])
+                if agent_provider not in providers:
+                    continue
+            if scenario_family is not None:
+                families = cluster.metadata.get("scenario_families", [])
+                if scenario_family not in families:
+                    continue
+            results.append(cluster)
+        return results

--- a/autocontext/src/autocontext/analytics/clustering.py
+++ b/autocontext/src/autocontext/analytics/clustering.py
@@ -165,6 +165,10 @@ class PatternClusterer:
                     "scenarios": sorted({
                         f.scenario for f in type_to_facets[signal_type]
                     }),
+                    "scenario_families": sorted({
+                        f.scenario_family for f in type_to_facets[signal_type]
+                        if f.scenario_family
+                    }),
                     "providers": sorted({
                         f.agent_provider for f in type_to_facets[signal_type]
                     }),

--- a/autocontext/src/autocontext/analytics/extractor.py
+++ b/autocontext/src/autocontext/analytics/extractor.py
@@ -1,0 +1,177 @@
+"""Facet extraction from completed run data (AC-255).
+
+Processes run metadata from SQLiteStore + ArtifactStore into structured
+RunFacet instances with friction/delight signal detection.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from autocontext.analytics.facets import (
+    DelightSignal,
+    FrictionSignal,
+    RunFacet,
+)
+
+
+class FacetExtractor:
+    """Extracts structured facets from completed run data."""
+
+    def extract(self, data: dict[str, Any]) -> RunFacet:
+        """Build a RunFacet from run data dict.
+
+        Expects keys: run, generations, role_metrics,
+        staged_validations, consultations, recovery.
+        """
+        run = data["run"]
+        generations = data.get("generations", [])
+        role_metrics = data.get("role_metrics", [])
+        staged_validations = data.get("staged_validations", [])
+        consultations = data.get("consultations", [])
+        recovery = data.get("recovery", [])
+
+        # Gate decision counts
+        advances = sum(1 for g in generations if g.get("gate_decision") == "advance")
+        retries = sum(1 for g in generations if g.get("gate_decision") == "retry")
+        rollbacks = sum(1 for g in generations if g.get("gate_decision") == "rollback")
+
+        # Best score/elo
+        best_score = max((g.get("best_score", 0.0) for g in generations), default=0.0)
+        best_elo = max((g.get("elo", 0.0) for g in generations), default=0.0)
+
+        # Duration
+        total_duration = sum(g.get("duration_seconds", 0.0) for g in generations)
+
+        # Token totals
+        total_tokens = sum(
+            m.get("input_tokens", 0) + m.get("output_tokens", 0)
+            for m in role_metrics
+        )
+
+        # Validation failures
+        validation_failures = sum(
+            1 for v in staged_validations if v.get("status") == "failed"
+        )
+
+        # Consultations
+        consultation_count = len(consultations)
+        consultation_cost = sum(c.get("cost_usd", 0.0) for c in consultations)
+
+        # Scenario family detection (best-effort from run metadata)
+        scenario_family = run.get("scenario_family", "")
+
+        # Signal extraction
+        friction_signals = self._extract_friction(
+            generations, staged_validations, recovery
+        )
+        delight_signals = self._extract_delight(generations)
+
+        return RunFacet(
+            run_id=run["run_id"],
+            scenario=run.get("scenario", ""),
+            scenario_family=scenario_family,
+            agent_provider=run.get("agent_provider", ""),
+            executor_mode=run.get("executor_mode", ""),
+            total_generations=len(generations),
+            advances=advances,
+            retries=retries,
+            rollbacks=rollbacks,
+            best_score=best_score,
+            best_elo=best_elo,
+            total_duration_seconds=total_duration,
+            total_tokens=total_tokens,
+            total_cost_usd=0.0,  # computed from provider pricing if available
+            tool_invocations=0,
+            validation_failures=validation_failures,
+            consultation_count=consultation_count,
+            consultation_cost_usd=consultation_cost,
+            friction_signals=friction_signals,
+            delight_signals=delight_signals,
+            events=[],
+            metadata=run.get("metadata", {}),
+            created_at=datetime.now(UTC).isoformat(),
+        )
+
+    def _extract_friction(
+        self,
+        generations: list[dict[str, Any]],
+        staged_validations: list[dict[str, Any]],
+        recovery: list[dict[str, Any]],
+    ) -> list[FrictionSignal]:
+        signals: list[FrictionSignal] = []
+
+        # Validation failures
+        for v in staged_validations:
+            if v.get("status") == "failed":
+                signals.append(FrictionSignal(
+                    signal_type="validation_failure",
+                    severity="medium",
+                    generation_index=v.get("generation_index", 0),
+                    description=f"Validation failure in stage '{v.get('stage_name', 'unknown')}': "
+                                f"{v.get('error', 'unknown error')}",
+                    evidence=[f"staged_validation:{v.get('stage_name', '')}"],
+                ))
+
+        # Retry loops
+        for r in recovery:
+            if r.get("decision") == "retry":
+                signals.append(FrictionSignal(
+                    signal_type="retry_loop",
+                    severity="low",
+                    generation_index=r.get("generation_index", 0),
+                    description=f"Retry at generation {r.get('generation_index', '?')}: "
+                                f"{r.get('reason', 'unknown')}",
+                    evidence=[f"recovery:{r.get('generation_index', '')}"],
+                ))
+
+        # Rollbacks
+        for g in generations:
+            if g.get("gate_decision") == "rollback":
+                signals.append(FrictionSignal(
+                    signal_type="rollback",
+                    severity="high",
+                    generation_index=g.get("generation_index", 0),
+                    description=f"Rollback at generation {g.get('generation_index', '?')}",
+                    evidence=[f"generation:{g.get('generation_index', '')}"],
+                    recoverable=True,
+                ))
+
+        return signals
+
+    def _extract_delight(
+        self,
+        generations: list[dict[str, Any]],
+    ) -> list[DelightSignal]:
+        signals: list[DelightSignal] = []
+
+        for g in generations:
+            gen_idx = g.get("generation_index", 0)
+
+            # Fast advance: first attempt advances
+            if g.get("gate_decision") == "advance":
+                signals.append(DelightSignal(
+                    signal_type="fast_advance",
+                    generation_index=gen_idx,
+                    description=f"Advanced at generation {gen_idx}",
+                    evidence=[f"generation:{gen_idx}"],
+                ))
+
+        # Strong improvement: large score jumps between consecutive generations
+        for i in range(1, len(generations)):
+            prev_score = generations[i - 1].get("best_score", 0.0)
+            curr_score = generations[i].get("best_score", 0.0)
+            if curr_score - prev_score >= 0.2:
+                signals.append(DelightSignal(
+                    signal_type="strong_improvement",
+                    generation_index=generations[i].get("generation_index", i),
+                    description=f"Score improved by {curr_score - prev_score:.2f} "
+                                f"({prev_score:.2f} → {curr_score:.2f})",
+                    evidence=[
+                        f"generation:{generations[i - 1].get('generation_index', i - 1)}",
+                        f"generation:{generations[i].get('generation_index', i)}",
+                    ],
+                ))
+
+        return signals

--- a/autocontext/src/autocontext/analytics/facets.py
+++ b/autocontext/src/autocontext/analytics/facets.py
@@ -1,0 +1,216 @@
+"""Canonical aggregate facet and run-event schema for completed runs (AC-255).
+
+Defines the structured event model for cross-run signal extraction:
+- RunEvent: categorized events within a run
+- FrictionSignal: detected friction patterns
+- DelightSignal: detected delight/efficiency patterns
+- RunFacet: aggregate structured metadata for a completed run
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class RunEvent:
+    """A categorized event within a run.
+
+    Categories: observation, action, tool_invocation, validation,
+    retry, cancellation, evidence_chain, dependency.
+    """
+
+    event_id: str
+    run_id: str
+    category: str
+    event_type: str
+    timestamp: str
+    generation_index: int
+    payload: dict[str, Any]
+    severity: str = "info"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "run_id": self.run_id,
+            "category": self.category,
+            "event_type": self.event_type,
+            "timestamp": self.timestamp,
+            "generation_index": self.generation_index,
+            "payload": self.payload,
+            "severity": self.severity,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunEvent:
+        return cls(
+            event_id=data["event_id"],
+            run_id=data["run_id"],
+            category=data["category"],
+            event_type=data["event_type"],
+            timestamp=data["timestamp"],
+            generation_index=data["generation_index"],
+            payload=data.get("payload", {}),
+            severity=data.get("severity", "info"),
+        )
+
+
+@dataclass(slots=True)
+class FrictionSignal:
+    """A detected friction pattern in a run.
+
+    Signal types: validation_failure, retry_loop, backpressure,
+    stale_context, tool_failure, dependency_error, rollback.
+    """
+
+    signal_type: str
+    severity: str
+    generation_index: int
+    description: str
+    evidence: list[str]
+    recoverable: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "signal_type": self.signal_type,
+            "severity": self.severity,
+            "generation_index": self.generation_index,
+            "description": self.description,
+            "evidence": self.evidence,
+            "recoverable": self.recoverable,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FrictionSignal:
+        return cls(
+            signal_type=data["signal_type"],
+            severity=data["severity"],
+            generation_index=data["generation_index"],
+            description=data["description"],
+            evidence=data.get("evidence", []),
+            recoverable=data.get("recoverable", True),
+        )
+
+
+@dataclass(slots=True)
+class DelightSignal:
+    """A detected delight/efficiency pattern in a run.
+
+    Signal types: fast_advance, clean_recovery, efficient_tool_use,
+    strong_improvement.
+    """
+
+    signal_type: str
+    generation_index: int
+    description: str
+    evidence: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "signal_type": self.signal_type,
+            "generation_index": self.generation_index,
+            "description": self.description,
+            "evidence": self.evidence,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DelightSignal:
+        return cls(
+            signal_type=data["signal_type"],
+            generation_index=data["generation_index"],
+            description=data["description"],
+            evidence=data.get("evidence", []),
+        )
+
+
+@dataclass(slots=True)
+class RunFacet:
+    """Aggregate structured metadata for a completed run.
+
+    Contains non-PII metadata about scenario family, provider/runtime,
+    token counts, validation failures, friction/delight signals, and events.
+    """
+
+    run_id: str
+    scenario: str
+    scenario_family: str
+    agent_provider: str
+    executor_mode: str
+    total_generations: int
+    advances: int
+    retries: int
+    rollbacks: int
+    best_score: float
+    best_elo: float
+    total_duration_seconds: float
+    total_tokens: int
+    total_cost_usd: float
+    tool_invocations: int
+    validation_failures: int
+    consultation_count: int
+    consultation_cost_usd: float
+    friction_signals: list[FrictionSignal]
+    delight_signals: list[DelightSignal]
+    events: list[RunEvent]
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "scenario": self.scenario,
+            "scenario_family": self.scenario_family,
+            "agent_provider": self.agent_provider,
+            "executor_mode": self.executor_mode,
+            "total_generations": self.total_generations,
+            "advances": self.advances,
+            "retries": self.retries,
+            "rollbacks": self.rollbacks,
+            "best_score": self.best_score,
+            "best_elo": self.best_elo,
+            "total_duration_seconds": self.total_duration_seconds,
+            "total_tokens": self.total_tokens,
+            "total_cost_usd": self.total_cost_usd,
+            "tool_invocations": self.tool_invocations,
+            "validation_failures": self.validation_failures,
+            "consultation_count": self.consultation_count,
+            "consultation_cost_usd": self.consultation_cost_usd,
+            "friction_signals": [s.to_dict() for s in self.friction_signals],
+            "delight_signals": [s.to_dict() for s in self.delight_signals],
+            "events": [e.to_dict() for e in self.events],
+            "metadata": self.metadata,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunFacet:
+        return cls(
+            run_id=data["run_id"],
+            scenario=data["scenario"],
+            scenario_family=data["scenario_family"],
+            agent_provider=data["agent_provider"],
+            executor_mode=data["executor_mode"],
+            total_generations=data["total_generations"],
+            advances=data["advances"],
+            retries=data["retries"],
+            rollbacks=data["rollbacks"],
+            best_score=data["best_score"],
+            best_elo=data["best_elo"],
+            total_duration_seconds=data["total_duration_seconds"],
+            total_tokens=data["total_tokens"],
+            total_cost_usd=data["total_cost_usd"],
+            tool_invocations=data["tool_invocations"],
+            validation_failures=data["validation_failures"],
+            consultation_count=data["consultation_count"],
+            consultation_cost_usd=data["consultation_cost_usd"],
+            friction_signals=[
+                FrictionSignal.from_dict(s) for s in data.get("friction_signals", [])
+            ],
+            delight_signals=[
+                DelightSignal.from_dict(s) for s in data.get("delight_signals", [])
+            ],
+            events=[RunEvent.from_dict(e) for e in data.get("events", [])],
+            metadata=data.get("metadata", {}),
+            created_at=data.get("created_at", ""),
+        )

--- a/autocontext/src/autocontext/analytics/store.py
+++ b/autocontext/src/autocontext/analytics/store.py
@@ -1,0 +1,69 @@
+"""Facet persistence and querying (AC-255).
+
+Stores RunFacet instances as JSON files in a structured directory,
+supporting listing and filtering by scenario, provider, etc.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from autocontext.analytics.facets import RunFacet
+
+_FACETS_DIR = "facets"
+
+
+class FacetStore:
+    """Persists and queries RunFacet instances."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root / _FACETS_DIR
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def persist(self, facet: RunFacet) -> Path:
+        """Persist a RunFacet as a JSON file. Returns the file path."""
+        path = self.root / f"{facet.run_id}.json"
+        path.write_text(
+            json.dumps(facet.to_dict(), indent=2),
+            encoding="utf-8",
+        )
+        return path
+
+    def load(self, run_id: str) -> RunFacet | None:
+        """Load a RunFacet by run_id. Returns None if not found."""
+        path = self.root / f"{run_id}.json"
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return RunFacet.from_dict(data)
+
+    def list_facets(self, scenario: str | None = None) -> list[RunFacet]:
+        """List all persisted facets, optionally filtered by scenario."""
+        facets: list[RunFacet] = []
+        for path in sorted(self.root.glob("*.json")):
+            data = json.loads(path.read_text(encoding="utf-8"))
+            facet = RunFacet.from_dict(data)
+            if scenario is not None and facet.scenario != scenario:
+                continue
+            facets.append(facet)
+        return facets
+
+    def query(self, **filters: Any) -> list[RunFacet]:
+        """Query facets by arbitrary field filters.
+
+        Supported filters: scenario, scenario_family, agent_provider,
+        executor_mode.
+        """
+        facets = self.list_facets()
+        results: list[RunFacet] = []
+        for facet in facets:
+            match = True
+            for key, value in filters.items():
+                if getattr(facet, key, None) != value:
+                    match = False
+                    break
+            if match:
+                results.append(facet)
+        return results

--- a/autocontext/src/autocontext/analytics/taxonomy.py
+++ b/autocontext/src/autocontext/analytics/taxonomy.py
@@ -1,0 +1,185 @@
+"""Evolving facet taxonomy (AC-256).
+
+Manages a taxonomy of facet categories that can grow as new recurring
+patterns are discovered by the clustering engine.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from autocontext.analytics.clustering import FacetCluster
+
+
+@dataclass(slots=True)
+class TaxonomyEntry:
+    """An entry in the evolving facet taxonomy."""
+
+    entry_id: str
+    name: str
+    parent_category: str  # friction, delight, neutral
+    description: str
+    is_system_defined: bool
+    source_cluster_id: str | None
+    created_at: str
+    recurrence_count: int
+    confidence: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entry_id": self.entry_id,
+            "name": self.name,
+            "parent_category": self.parent_category,
+            "description": self.description,
+            "is_system_defined": self.is_system_defined,
+            "source_cluster_id": self.source_cluster_id,
+            "created_at": self.created_at,
+            "recurrence_count": self.recurrence_count,
+            "confidence": self.confidence,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TaxonomyEntry:
+        return cls(
+            entry_id=data["entry_id"],
+            name=data["name"],
+            parent_category=data["parent_category"],
+            description=data["description"],
+            is_system_defined=data.get("is_system_defined", False),
+            source_cluster_id=data.get("source_cluster_id"),
+            created_at=data.get("created_at", ""),
+            recurrence_count=data.get("recurrence_count", 0),
+            confidence=data.get("confidence", 0.0),
+        )
+
+
+# Built-in taxonomy entries
+_BUILTIN_FRICTION: list[tuple[str, str]] = [
+    ("validation_failure", "Validation stage failures in generated code or strategies"),
+    ("retry_loop", "Backpressure gate triggered a retry"),
+    ("rollback", "Backpressure gate triggered a rollback to previous generation"),
+    ("stale_context", "Agent operated on stale or invalidated context"),
+    ("tool_failure", "Tool invocation failed or returned unexpected results"),
+    ("dependency_error", "Dependency ordering error in action execution"),
+]
+
+_BUILTIN_DELIGHT: list[tuple[str, str]] = [
+    ("fast_advance", "Generation advanced on first attempt"),
+    ("clean_recovery", "Recovered cleanly after a rollback or retry"),
+    ("efficient_tool_use", "Effective tool usage with minimal overhead"),
+    ("strong_improvement", "Large score improvement between generations"),
+]
+
+
+def _make_builtins() -> list[TaxonomyEntry]:
+    entries: list[TaxonomyEntry] = []
+    now = datetime.now(UTC).isoformat()
+    for name, desc in _BUILTIN_FRICTION:
+        entries.append(TaxonomyEntry(
+            entry_id=f"builtin-friction-{name}",
+            name=name,
+            parent_category="friction",
+            description=desc,
+            is_system_defined=True,
+            source_cluster_id=None,
+            created_at=now,
+            recurrence_count=0,
+            confidence=1.0,
+        ))
+    for name, desc in _BUILTIN_DELIGHT:
+        entries.append(TaxonomyEntry(
+            entry_id=f"builtin-delight-{name}",
+            name=name,
+            parent_category="delight",
+            description=desc,
+            is_system_defined=True,
+            source_cluster_id=None,
+            created_at=now,
+            recurrence_count=0,
+            confidence=1.0,
+        ))
+    return entries
+
+
+class FacetTaxonomy:
+    """Evolving taxonomy of facet categories."""
+
+    def __init__(self) -> None:
+        self._entries: list[TaxonomyEntry] = _make_builtins()
+
+    def get_entries(self) -> list[TaxonomyEntry]:
+        """Return all taxonomy entries."""
+        return list(self._entries)
+
+    def add_entry(self, entry: TaxonomyEntry) -> None:
+        """Add a new taxonomy entry."""
+        self._entries.append(entry)
+
+    def _has_name(self, name: str) -> bool:
+        return any(e.name == name for e in self._entries)
+
+    def propose_from_cluster(
+        self,
+        cluster: FacetCluster,
+        min_confidence: float = 0.6,
+    ) -> TaxonomyEntry | None:
+        """Propose a new taxonomy entry from a cluster.
+
+        Returns None if the cluster's confidence is below the threshold
+        or if the signal type already exists in the taxonomy.
+        """
+        if cluster.confidence < min_confidence:
+            return None
+
+        # Use the primary signal type as the entry name
+        name = cluster.signal_types[0] if cluster.signal_types else cluster.label
+        if self._has_name(name):
+            return None
+
+        return TaxonomyEntry(
+            entry_id=f"evolved-{uuid.uuid4().hex[:8]}",
+            name=name,
+            parent_category=cluster.category,
+            description=cluster.evidence_summary,
+            is_system_defined=False,
+            source_cluster_id=cluster.cluster_id,
+            created_at=datetime.now(UTC).isoformat(),
+            recurrence_count=cluster.frequency,
+            confidence=cluster.confidence,
+        )
+
+    def evolve(
+        self,
+        clusters: list[FacetCluster],
+        min_confidence: float = 0.6,
+    ) -> list[TaxonomyEntry]:
+        """Evolve the taxonomy by proposing entries from clusters.
+
+        Returns the list of newly added entries.
+        """
+        new_entries: list[TaxonomyEntry] = []
+        for cluster in clusters:
+            proposed = self.propose_from_cluster(cluster, min_confidence)
+            if proposed is not None:
+                self.add_entry(proposed)
+                new_entries.append(proposed)
+        return new_entries
+
+    def save(self, path: Path) -> None:
+        """Persist the taxonomy to a JSON file."""
+        data = [e.to_dict() for e in self._entries]
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Path) -> FacetTaxonomy:
+        """Load a taxonomy from a JSON file."""
+        taxonomy = cls()
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            taxonomy._entries = [TaxonomyEntry.from_dict(d) for d in data]
+        return taxonomy

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import time
 import uuid
@@ -8,6 +9,10 @@ from pathlib import Path
 from typing import cast
 
 from autocontext.agents import AgentOrchestrator
+from autocontext.analytics.clustering import PatternClusterer
+from autocontext.analytics.extractor import FacetExtractor
+from autocontext.analytics.store import FacetStore
+from autocontext.analytics.taxonomy import FacetTaxonomy
 from autocontext.backpressure import BackpressureGate, TrendAwareGate
 from autocontext.config import AppSettings
 from autocontext.execution import ExecutionSupervisor
@@ -23,6 +28,7 @@ from autocontext.loop.controller import LoopController
 from autocontext.loop.events import EventStreamEmitter
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.base import ScenarioInterface
+from autocontext.scenarios.families import detect_family
 from autocontext.storage import ArtifactStore, SQLiteStore
 
 LOGGER = logging.getLogger(__name__)
@@ -230,6 +236,64 @@ class GenerationRunner:
         )
         self.artifacts.write_progress_report(scenario_name, run_id, report)
 
+    def _generate_aggregate_analytics(
+        self,
+        run_id: str,
+        scenario_name: str,
+        scenario: ScenarioInterface,
+    ) -> None:
+        """Extract and persist aggregate run facets, then update clusters/taxonomy."""
+        family = detect_family(scenario)
+        run_payload = {
+            "run_id": run_id,
+            "scenario": scenario_name,
+            "scenario_family": family.name if family is not None else "",
+            "agent_provider": self.settings.agent_provider,
+            "executor_mode": self.settings.executor_mode,
+            "metadata": {
+                "exploration_mode": self.settings.exploration_mode,
+                "rlm_enabled": self.settings.rlm_enabled,
+            },
+        }
+        generation_rows = self.sqlite.get_generation_metrics(run_id)
+        role_metrics = self.sqlite.get_agent_role_metrics(run_id)
+        staged_validations = self.sqlite.get_staged_validation_results_for_run(run_id)
+        consultations = self.sqlite.get_consultations_for_run(run_id)
+        recovery = self.sqlite.get_recovery_markers_for_run(run_id)
+
+        facet = FacetExtractor().extract({
+            "run": run_payload,
+            "generations": generation_rows,
+            "role_metrics": role_metrics,
+            "staged_validations": staged_validations,
+            "consultations": consultations,
+            "recovery": recovery,
+        })
+
+        facet_store = FacetStore(self.settings.knowledge_root)
+        facet_store.persist(facet)
+
+        all_facets = facet_store.list_facets()
+        clusterer = PatternClusterer()
+        friction_clusters = clusterer.cluster_friction(all_facets)
+        delight_clusters = clusterer.cluster_delight(all_facets)
+
+        analytics_root = self.settings.knowledge_root / "analytics"
+        analytics_root.mkdir(parents=True, exist_ok=True)
+        (analytics_root / "friction_clusters.json").write_text(
+            json.dumps([cluster.to_dict() for cluster in friction_clusters], indent=2),
+            encoding="utf-8",
+        )
+        (analytics_root / "delight_clusters.json").write_text(
+            json.dumps([cluster.to_dict() for cluster in delight_clusters], indent=2),
+            encoding="utf-8",
+        )
+
+        taxonomy_path = analytics_root / "taxonomy.json"
+        taxonomy = FacetTaxonomy.load(taxonomy_path)
+        taxonomy.evolve([*friction_clusters, *delight_clusters])
+        taxonomy.save(taxonomy_path)
+
     def run(self, scenario_name: str, generations: int, run_id: str | None = None) -> RunSummary:
         scenario = self._scenario(scenario_name)
         active_run_id = run_id or f"run_{uuid.uuid4().hex[:12]}"
@@ -426,6 +490,10 @@ class GenerationRunner:
             self._generate_progress_report(active_run_id, scenario_name)
         except Exception:
             LOGGER.warning("failed to generate progress report for run %s", active_run_id, exc_info=True)
+        try:
+            self._generate_aggregate_analytics(active_run_id, scenario_name, scenario)
+        except Exception:
+            LOGGER.warning("failed to generate aggregate analytics for run %s", active_run_id, exc_info=True)
 
         # Snapshot knowledge for cross-run inheritance
         if self.settings.cross_run_inheritance and not self.settings.ablation_no_feedback:

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -192,6 +192,20 @@ class SQLiteStore:
             ).fetchall()
             return [dict(r) for r in rows]
 
+    def get_staged_validation_results_for_run(self, run_id: str) -> list[dict[str, Any]]:
+        """Retrieve all staged validation results for a run, ordered by generation and stage."""
+        with self.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT generation_index, stage_order, stage_name, status, duration_ms, error, error_code
+                FROM staged_validation_results
+                WHERE run_id = ?
+                ORDER BY generation_index, stage_order
+                """,
+                (run_id,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
     def append_agent_output(self, run_id: str, generation_index: int, role: str, content: str) -> None:
         self.append_generation_agent_activity(
             run_id,
@@ -344,6 +358,20 @@ class SQLiteStore:
                 """,
                 (run_id, generation_index, decision, reason, retry_count),
             )
+
+    def get_recovery_markers_for_run(self, run_id: str) -> list[dict[str, Any]]:
+        """Return recovery markers for a run, ordered by generation."""
+        with self.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT generation_index, decision, reason, retry_count
+                FROM generation_recovery
+                WHERE run_id = ?
+                ORDER BY generation_index, rowid
+                """,
+                (run_id,),
+            ).fetchall()
+            return [dict(row) for row in rows]
 
     def get_matches_for_run(self, run_id: str) -> list[dict[str, Any]]:
         """Return all match records for a run, ordered by generation and seed."""

--- a/autocontext/tests/test_aggregate_facets.py
+++ b/autocontext/tests/test_aggregate_facets.py
@@ -1,0 +1,1012 @@
+"""Tests for AC-255 + AC-256: aggregate run facets, signal extraction, and pattern clustering.
+
+Full vertical-slice tests:
+- AC-255: RunEvent, FrictionSignal, DelightSignal, RunFacet data models
+- AC-255: FacetExtractor — builds facets from completed run data
+- AC-255: FacetStore — persist/load/query facets
+- AC-256: EventPattern, FacetCluster, TaxonomyEntry data models
+- AC-256: PatternClusterer — groups similar patterns across runs
+- AC-256: FacetTaxonomy — evolving category taxonomy
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ===========================================================================
+# AC-255: RunEvent data model
+# ===========================================================================
+
+
+class TestRunEvent:
+    def test_construction(self) -> None:
+        from autocontext.analytics.facets import RunEvent
+
+        event = RunEvent(
+            event_id="ev-1",
+            run_id="run-1",
+            category="validation",
+            event_type="validation_failure",
+            timestamp="2026-03-14T12:00:00Z",
+            generation_index=2,
+            payload={"stage": "syntax", "error": "parse error"},
+            severity="error",
+        )
+        assert event.event_id == "ev-1"
+        assert event.category == "validation"
+        assert event.severity == "error"
+        assert event.payload["stage"] == "syntax"
+
+    def test_roundtrip(self) -> None:
+        from autocontext.analytics.facets import RunEvent
+
+        event = RunEvent(
+            event_id="ev-2",
+            run_id="run-1",
+            category="action",
+            event_type="tool_call",
+            timestamp="2026-03-14T12:01:00Z",
+            generation_index=1,
+            payload={"tool": "search"},
+        )
+        d = event.to_dict()
+        restored = RunEvent.from_dict(d)
+        assert restored.event_id == event.event_id
+        assert restored.category == event.category
+        assert restored.payload == event.payload
+        assert restored.severity == "info"  # default
+
+    def test_defaults(self) -> None:
+        from autocontext.analytics.facets import RunEvent
+
+        event = RunEvent(
+            event_id="ev-3",
+            run_id="run-1",
+            category="observation",
+            event_type="score_change",
+            timestamp="2026-03-14T12:02:00Z",
+            generation_index=0,
+            payload={},
+        )
+        assert event.severity == "info"
+
+
+# ===========================================================================
+# AC-255: FrictionSignal data model
+# ===========================================================================
+
+
+class TestFrictionSignal:
+    def test_construction(self) -> None:
+        from autocontext.analytics.facets import FrictionSignal
+
+        signal = FrictionSignal(
+            signal_type="validation_failure",
+            severity="high",
+            generation_index=3,
+            description="Repeated parse failures in validation stage",
+            evidence=["ev-1", "ev-2"],
+            recoverable=True,
+        )
+        assert signal.signal_type == "validation_failure"
+        assert signal.severity == "high"
+        assert len(signal.evidence) == 2
+
+    def test_roundtrip(self) -> None:
+        from autocontext.analytics.facets import FrictionSignal
+
+        signal = FrictionSignal(
+            signal_type="retry_loop",
+            severity="medium",
+            generation_index=1,
+            description="Retry loop detected",
+            evidence=["ev-3"],
+        )
+        d = signal.to_dict()
+        restored = FrictionSignal.from_dict(d)
+        assert restored.signal_type == signal.signal_type
+        assert restored.evidence == signal.evidence
+        assert restored.recoverable is True  # default
+
+
+# ===========================================================================
+# AC-255: DelightSignal data model
+# ===========================================================================
+
+
+class TestDelightSignal:
+    def test_construction(self) -> None:
+        from autocontext.analytics.facets import DelightSignal
+
+        signal = DelightSignal(
+            signal_type="fast_advance",
+            generation_index=1,
+            description="Advanced on first attempt with high score",
+            evidence=["ev-4"],
+        )
+        assert signal.signal_type == "fast_advance"
+        assert signal.generation_index == 1
+
+    def test_roundtrip(self) -> None:
+        from autocontext.analytics.facets import DelightSignal
+
+        signal = DelightSignal(
+            signal_type="clean_recovery",
+            generation_index=2,
+            description="Recovered cleanly after rollback",
+            evidence=["ev-5", "ev-6"],
+        )
+        d = signal.to_dict()
+        restored = DelightSignal.from_dict(d)
+        assert restored.signal_type == signal.signal_type
+        assert restored.evidence == signal.evidence
+
+
+# ===========================================================================
+# AC-255: RunFacet data model
+# ===========================================================================
+
+
+class TestRunFacet:
+    def test_construction(self) -> None:
+        from autocontext.analytics.facets import DelightSignal, FrictionSignal, RunFacet
+
+        facet = RunFacet(
+            run_id="run-1",
+            scenario="grid_ctf",
+            scenario_family="game",
+            agent_provider="anthropic",
+            executor_mode="local",
+            total_generations=5,
+            advances=3,
+            retries=1,
+            rollbacks=1,
+            best_score=0.85,
+            best_elo=1200.0,
+            total_duration_seconds=120.5,
+            total_tokens=50000,
+            total_cost_usd=0.25,
+            tool_invocations=10,
+            validation_failures=2,
+            consultation_count=1,
+            consultation_cost_usd=0.01,
+            friction_signals=[
+                FrictionSignal(
+                    signal_type="validation_failure",
+                    severity="medium",
+                    generation_index=2,
+                    description="Parse failure",
+                    evidence=["ev-1"],
+                ),
+            ],
+            delight_signals=[
+                DelightSignal(
+                    signal_type="fast_advance",
+                    generation_index=1,
+                    description="Quick advance",
+                    evidence=["ev-2"],
+                ),
+            ],
+            events=[],
+            metadata={"rlm_enabled": False},
+            created_at="2026-03-14T12:00:00Z",
+        )
+        assert facet.run_id == "run-1"
+        assert facet.scenario_family == "game"
+        assert facet.advances == 3
+        assert len(facet.friction_signals) == 1
+        assert len(facet.delight_signals) == 1
+
+    def test_roundtrip(self) -> None:
+        from autocontext.analytics.facets import RunFacet
+
+        facet = RunFacet(
+            run_id="run-2",
+            scenario="othello",
+            scenario_family="game",
+            agent_provider="deterministic",
+            executor_mode="local",
+            total_generations=3,
+            advances=2,
+            retries=1,
+            rollbacks=0,
+            best_score=0.6,
+            best_elo=1100.0,
+            total_duration_seconds=45.0,
+            total_tokens=20000,
+            total_cost_usd=0.10,
+            tool_invocations=5,
+            validation_failures=0,
+            consultation_count=0,
+            consultation_cost_usd=0.0,
+            friction_signals=[],
+            delight_signals=[],
+            events=[],
+            metadata={},
+            created_at="2026-03-14T13:00:00Z",
+        )
+        d = facet.to_dict()
+        restored = RunFacet.from_dict(d)
+        assert restored.run_id == facet.run_id
+        assert restored.scenario == facet.scenario
+        assert restored.best_score == facet.best_score
+        assert restored.total_tokens == facet.total_tokens
+
+
+# ===========================================================================
+# AC-255: FacetExtractor
+# ===========================================================================
+
+
+class TestFacetExtractor:
+    def _make_run_data(self) -> dict[str, Any]:
+        """Build mock data matching what SQLiteStore + ArtifactStore return."""
+        return {
+            "run": {
+                "run_id": "test-run",
+                "scenario": "grid_ctf",
+                "agent_provider": "deterministic",
+                "executor_mode": "local",
+                "status": "completed",
+            },
+            "generations": [
+                {
+                    "generation_index": 1,
+                    "mean_score": 0.3,
+                    "best_score": 0.4,
+                    "elo": 1050.0,
+                    "gate_decision": "advance",
+                    "duration_seconds": 10.0,
+                },
+                {
+                    "generation_index": 2,
+                    "mean_score": 0.5,
+                    "best_score": 0.6,
+                    "elo": 1100.0,
+                    "gate_decision": "retry",
+                    "duration_seconds": 15.0,
+                },
+                {
+                    "generation_index": 3,
+                    "mean_score": 0.7,
+                    "best_score": 0.8,
+                    "elo": 1150.0,
+                    "gate_decision": "advance",
+                    "duration_seconds": 20.0,
+                },
+            ],
+            "role_metrics": [
+                {
+                    "role": "competitor",
+                    "input_tokens": 5000,
+                    "output_tokens": 2000,
+                    "generation_index": 1,
+                },
+                {
+                    "role": "analyst",
+                    "input_tokens": 4000,
+                    "output_tokens": 1500,
+                    "generation_index": 1,
+                },
+                {
+                    "role": "competitor",
+                    "input_tokens": 6000,
+                    "output_tokens": 2500,
+                    "generation_index": 2,
+                },
+            ],
+            "staged_validations": [
+                {
+                    "generation_index": 2,
+                    "stage_name": "syntax",
+                    "status": "failed",
+                    "error": "parse error",
+                },
+            ],
+            "consultations": [
+                {
+                    "generation_index": 2,
+                    "cost_usd": 0.005,
+                    "trigger": "score_stall",
+                },
+            ],
+            "recovery": [
+                {"generation_index": 2, "decision": "retry", "reason": "low score"},
+            ],
+        }
+
+    def test_extract_basic_facet(self) -> None:
+        from autocontext.analytics.extractor import FacetExtractor
+
+        data = self._make_run_data()
+        extractor = FacetExtractor()
+        facet = extractor.extract(data)
+
+        assert facet.run_id == "test-run"
+        assert facet.scenario == "grid_ctf"
+        assert facet.total_generations == 3
+        assert facet.advances == 2
+        assert facet.retries == 1
+        assert facet.rollbacks == 0
+        assert facet.best_score == 0.8
+        assert facet.best_elo == 1150.0
+
+    def test_extract_token_totals(self) -> None:
+        from autocontext.analytics.extractor import FacetExtractor
+
+        data = self._make_run_data()
+        extractor = FacetExtractor()
+        facet = extractor.extract(data)
+
+        # 5000+2000 + 4000+1500 + 6000+2500 = 21000
+        assert facet.total_tokens == 21000
+
+    def test_extract_friction_signals(self) -> None:
+        from autocontext.analytics.extractor import FacetExtractor
+
+        data = self._make_run_data()
+        extractor = FacetExtractor()
+        facet = extractor.extract(data)
+
+        # Should detect validation_failure and retry friction
+        friction_types = {s.signal_type for s in facet.friction_signals}
+        assert "validation_failure" in friction_types
+
+    def test_extract_delight_signals(self) -> None:
+        from autocontext.analytics.extractor import FacetExtractor
+
+        data = self._make_run_data()
+        extractor = FacetExtractor()
+        facet = extractor.extract(data)
+
+        # Should detect fast_advance (gen 1 advanced)
+        delight_types = {s.signal_type for s in facet.delight_signals}
+        assert "fast_advance" in delight_types
+
+    def test_extract_duration(self) -> None:
+        from autocontext.analytics.extractor import FacetExtractor
+
+        data = self._make_run_data()
+        extractor = FacetExtractor()
+        facet = extractor.extract(data)
+
+        # 10 + 15 + 20 = 45
+        assert facet.total_duration_seconds == 45.0
+
+    def test_extract_consultation_count(self) -> None:
+        from autocontext.analytics.extractor import FacetExtractor
+
+        data = self._make_run_data()
+        extractor = FacetExtractor()
+        facet = extractor.extract(data)
+
+        assert facet.consultation_count == 1
+        assert facet.consultation_cost_usd == 0.005
+
+    def test_extract_empty_run(self) -> None:
+        from autocontext.analytics.extractor import FacetExtractor
+
+        data = {
+            "run": {
+                "run_id": "empty-run",
+                "scenario": "test",
+                "agent_provider": "deterministic",
+                "executor_mode": "local",
+                "status": "completed",
+            },
+            "generations": [],
+            "role_metrics": [],
+            "staged_validations": [],
+            "consultations": [],
+            "recovery": [],
+        }
+        extractor = FacetExtractor()
+        facet = extractor.extract(data)
+
+        assert facet.total_generations == 0
+        assert facet.best_score == 0.0
+        assert facet.friction_signals == []
+        assert facet.delight_signals == []
+
+
+# ===========================================================================
+# AC-255: FacetStore
+# ===========================================================================
+
+
+class TestFacetStore:
+    def _make_facet(self, run_id: str = "run-1", scenario: str = "grid_ctf") -> Any:
+        from autocontext.analytics.facets import RunFacet
+
+        return RunFacet(
+            run_id=run_id,
+            scenario=scenario,
+            scenario_family="game",
+            agent_provider="deterministic",
+            executor_mode="local",
+            total_generations=3,
+            advances=2,
+            retries=1,
+            rollbacks=0,
+            best_score=0.7,
+            best_elo=1100.0,
+            total_duration_seconds=45.0,
+            total_tokens=20000,
+            total_cost_usd=0.10,
+            tool_invocations=5,
+            validation_failures=1,
+            consultation_count=0,
+            consultation_cost_usd=0.0,
+            friction_signals=[],
+            delight_signals=[],
+            events=[],
+            metadata={},
+            created_at="2026-03-14T12:00:00Z",
+        )
+
+    def test_persist_and_load(self, tmp_path: Path) -> None:
+        from autocontext.analytics.store import FacetStore
+
+        store = FacetStore(tmp_path)
+        facet = self._make_facet()
+        path = store.persist(facet)
+
+        assert path.exists()
+        loaded = store.load("run-1")
+        assert loaded is not None
+        assert loaded.run_id == "run-1"
+        assert loaded.best_score == 0.7
+
+    def test_load_missing_returns_none(self, tmp_path: Path) -> None:
+        from autocontext.analytics.store import FacetStore
+
+        store = FacetStore(tmp_path)
+        result = store.load("nonexistent")
+        assert result is None
+
+    def test_list_facets_all(self, tmp_path: Path) -> None:
+        from autocontext.analytics.store import FacetStore
+
+        store = FacetStore(tmp_path)
+        store.persist(self._make_facet("run-1", "grid_ctf"))
+        store.persist(self._make_facet("run-2", "othello"))
+        store.persist(self._make_facet("run-3", "grid_ctf"))
+
+        all_facets = store.list_facets()
+        assert len(all_facets) == 3
+
+    def test_list_facets_by_scenario(self, tmp_path: Path) -> None:
+        from autocontext.analytics.store import FacetStore
+
+        store = FacetStore(tmp_path)
+        store.persist(self._make_facet("run-1", "grid_ctf"))
+        store.persist(self._make_facet("run-2", "othello"))
+        store.persist(self._make_facet("run-3", "grid_ctf"))
+
+        ctf_facets = store.list_facets(scenario="grid_ctf")
+        assert len(ctf_facets) == 2
+        assert all(f.scenario == "grid_ctf" for f in ctf_facets)
+
+    def test_query_by_provider(self, tmp_path: Path) -> None:
+        from autocontext.analytics.facets import RunFacet
+        from autocontext.analytics.store import FacetStore
+
+        store = FacetStore(tmp_path)
+
+        facet_anthropic = RunFacet(
+            run_id="run-a",
+            scenario="grid_ctf",
+            scenario_family="game",
+            agent_provider="anthropic",
+            executor_mode="local",
+            total_generations=3,
+            advances=2, retries=1, rollbacks=0,
+            best_score=0.8, best_elo=1200.0,
+            total_duration_seconds=60.0,
+            total_tokens=30000, total_cost_usd=0.15,
+            tool_invocations=8, validation_failures=0,
+            consultation_count=0, consultation_cost_usd=0.0,
+            friction_signals=[], delight_signals=[], events=[],
+            metadata={}, created_at="2026-03-14T12:00:00Z",
+        )
+        store.persist(facet_anthropic)
+        store.persist(self._make_facet("run-b", "grid_ctf"))
+
+        results = store.query(agent_provider="anthropic")
+        assert len(results) == 1
+        assert results[0].agent_provider == "anthropic"
+
+
+# ===========================================================================
+# AC-256: EventPattern data model
+# ===========================================================================
+
+
+class TestEventPattern:
+    def test_construction(self) -> None:
+        from autocontext.analytics.clustering import EventPattern
+
+        pattern = EventPattern(
+            pattern_id="pat-1",
+            pattern_type="sequence",
+            description="Retry then alternate tool then success",
+            event_sequence=["retry", "tool_switch", "advance"],
+            frequency=5,
+            run_ids=["run-1", "run-2", "run-3", "run-4", "run-5"],
+            confidence=0.75,
+            evidence=[{"run_id": "run-1", "gen": 2}],
+        )
+        assert pattern.pattern_id == "pat-1"
+        assert pattern.frequency == 5
+        assert len(pattern.event_sequence) == 3
+
+    def test_roundtrip(self) -> None:
+        from autocontext.analytics.clustering import EventPattern
+
+        pattern = EventPattern(
+            pattern_id="pat-2",
+            pattern_type="single_event",
+            description="test",
+            event_sequence=["retry"],
+            frequency=3,
+            run_ids=["r1", "r2", "r3"],
+            confidence=0.6,
+            evidence=[],
+        )
+        d = pattern.to_dict()
+        restored = EventPattern.from_dict(d)
+        assert restored.pattern_id == pattern.pattern_id
+        assert restored.event_sequence == pattern.event_sequence
+
+
+# ===========================================================================
+# AC-256: FacetCluster data model
+# ===========================================================================
+
+
+class TestFacetCluster:
+    def test_construction(self) -> None:
+        from autocontext.analytics.clustering import FacetCluster
+
+        cluster = FacetCluster(
+            cluster_id="clust-1",
+            label="Repeated validation failures",
+            category="friction",
+            signal_types=["validation_failure"],
+            run_ids=["run-1", "run-2", "run-3"],
+            frequency=3,
+            recurrence_rate=0.6,
+            confidence=0.8,
+            evidence_summary="3 of 5 runs showed validation failures",
+            supporting_events=[{"run_id": "run-1", "gen": 2}],
+            metadata={"scenario_family": "game"},
+        )
+        assert cluster.cluster_id == "clust-1"
+        assert cluster.category == "friction"
+        assert cluster.recurrence_rate == 0.6
+
+    def test_roundtrip(self) -> None:
+        from autocontext.analytics.clustering import FacetCluster
+
+        cluster = FacetCluster(
+            cluster_id="clust-2",
+            label="test",
+            category="delight",
+            signal_types=["fast_advance"],
+            run_ids=["r1"],
+            frequency=1,
+            recurrence_rate=0.2,
+            confidence=0.5,
+            evidence_summary="",
+            supporting_events=[],
+            metadata={},
+        )
+        d = cluster.to_dict()
+        restored = FacetCluster.from_dict(d)
+        assert restored.cluster_id == cluster.cluster_id
+        assert restored.category == cluster.category
+
+
+# ===========================================================================
+# AC-256: TaxonomyEntry data model
+# ===========================================================================
+
+
+class TestTaxonomyEntry:
+    def test_construction(self) -> None:
+        from autocontext.analytics.taxonomy import TaxonomyEntry
+
+        entry = TaxonomyEntry(
+            entry_id="tax-1",
+            name="validation_failure",
+            parent_category="friction",
+            description="Repeated validation failures in generated code",
+            is_system_defined=True,
+            source_cluster_id=None,
+            created_at="2026-03-14T12:00:00Z",
+            recurrence_count=10,
+            confidence=1.0,
+        )
+        assert entry.name == "validation_failure"
+        assert entry.is_system_defined is True
+        assert entry.source_cluster_id is None
+
+    def test_roundtrip(self) -> None:
+        from autocontext.analytics.taxonomy import TaxonomyEntry
+
+        entry = TaxonomyEntry(
+            entry_id="tax-2",
+            name="dependency_misordering",
+            parent_category="friction",
+            description="Discovered pattern",
+            is_system_defined=False,
+            source_cluster_id="clust-5",
+            created_at="2026-03-14T13:00:00Z",
+            recurrence_count=4,
+            confidence=0.7,
+        )
+        d = entry.to_dict()
+        restored = TaxonomyEntry.from_dict(d)
+        assert restored.entry_id == entry.entry_id
+        assert restored.source_cluster_id == "clust-5"
+        assert restored.is_system_defined is False
+
+
+# ===========================================================================
+# AC-256: PatternClusterer
+# ===========================================================================
+
+
+class TestPatternClusterer:
+    def _make_facets(self) -> list[Any]:
+        from autocontext.analytics.facets import (
+            DelightSignal,
+            FrictionSignal,
+            RunFacet,
+        )
+
+        return [
+            RunFacet(
+                run_id="run-1",
+                scenario="grid_ctf",
+                scenario_family="game",
+                agent_provider="deterministic",
+                executor_mode="local",
+                total_generations=5,
+                advances=3, retries=1, rollbacks=1,
+                best_score=0.7, best_elo=1100.0,
+                total_duration_seconds=60.0,
+                total_tokens=30000, total_cost_usd=0.15,
+                tool_invocations=5, validation_failures=2,
+                consultation_count=1, consultation_cost_usd=0.01,
+                friction_signals=[
+                    FrictionSignal(
+                        signal_type="validation_failure",
+                        severity="medium",
+                        generation_index=2,
+                        description="Parse failure in gen 2",
+                        evidence=["ev-1"],
+                    ),
+                    FrictionSignal(
+                        signal_type="retry_loop",
+                        severity="low",
+                        generation_index=3,
+                        description="Retried gen 3",
+                        evidence=["ev-2"],
+                    ),
+                ],
+                delight_signals=[
+                    DelightSignal(
+                        signal_type="fast_advance",
+                        generation_index=1,
+                        description="Quick gen 1",
+                        evidence=["ev-3"],
+                    ),
+                ],
+                events=[], metadata={},
+                created_at="2026-03-14T12:00:00Z",
+            ),
+            RunFacet(
+                run_id="run-2",
+                scenario="grid_ctf",
+                scenario_family="game",
+                agent_provider="deterministic",
+                executor_mode="local",
+                total_generations=4,
+                advances=2, retries=2, rollbacks=0,
+                best_score=0.65, best_elo=1080.0,
+                total_duration_seconds=50.0,
+                total_tokens=25000, total_cost_usd=0.12,
+                tool_invocations=4, validation_failures=3,
+                consultation_count=0, consultation_cost_usd=0.0,
+                friction_signals=[
+                    FrictionSignal(
+                        signal_type="validation_failure",
+                        severity="high",
+                        generation_index=1,
+                        description="Parse failure in gen 1",
+                        evidence=["ev-4"],
+                    ),
+                ],
+                delight_signals=[],
+                events=[], metadata={},
+                created_at="2026-03-14T13:00:00Z",
+            ),
+            RunFacet(
+                run_id="run-3",
+                scenario="othello",
+                scenario_family="game",
+                agent_provider="anthropic",
+                executor_mode="local",
+                total_generations=3,
+                advances=3, retries=0, rollbacks=0,
+                best_score=0.9, best_elo=1300.0,
+                total_duration_seconds=30.0,
+                total_tokens=15000, total_cost_usd=0.08,
+                tool_invocations=3, validation_failures=0,
+                consultation_count=0, consultation_cost_usd=0.0,
+                friction_signals=[],
+                delight_signals=[
+                    DelightSignal(
+                        signal_type="fast_advance",
+                        generation_index=1,
+                        description="Clean run",
+                        evidence=["ev-5"],
+                    ),
+                    DelightSignal(
+                        signal_type="strong_improvement",
+                        generation_index=2,
+                        description="Big jump",
+                        evidence=["ev-6"],
+                    ),
+                ],
+                events=[], metadata={},
+                created_at="2026-03-14T14:00:00Z",
+            ),
+        ]
+
+    def test_cluster_friction(self) -> None:
+        from autocontext.analytics.clustering import PatternClusterer
+
+        facets = self._make_facets()
+        clusterer = PatternClusterer()
+        clusters = clusterer.cluster_friction(facets)
+
+        # Should group validation_failure signals from run-1 and run-2
+        assert len(clusters) > 0
+        vf_cluster = next(
+            (c for c in clusters if "validation_failure" in c.signal_types), None
+        )
+        assert vf_cluster is not None
+        assert vf_cluster.category == "friction"
+        assert vf_cluster.frequency >= 2
+
+    def test_cluster_delight(self) -> None:
+        from autocontext.analytics.clustering import PatternClusterer
+
+        facets = self._make_facets()
+        clusterer = PatternClusterer()
+        clusters = clusterer.cluster_delight(facets)
+
+        assert len(clusters) > 0
+        fa_cluster = next(
+            (c for c in clusters if "fast_advance" in c.signal_types), None
+        )
+        assert fa_cluster is not None
+        assert fa_cluster.category == "delight"
+        assert fa_cluster.frequency >= 2
+
+    def test_cluster_recurrence_rate(self) -> None:
+        from autocontext.analytics.clustering import PatternClusterer
+
+        facets = self._make_facets()
+        clusterer = PatternClusterer()
+        clusters = clusterer.cluster_friction(facets)
+
+        # validation_failure appears in 2 of 3 runs = 0.667
+        vf_cluster = next(
+            (c for c in clusters if "validation_failure" in c.signal_types), None
+        )
+        assert vf_cluster is not None
+        assert vf_cluster.recurrence_rate == pytest.approx(2 / 3, abs=0.01)
+
+    def test_query_clusters_by_scenario(self) -> None:
+        from autocontext.analytics.clustering import PatternClusterer
+
+        facets = self._make_facets()
+        clusterer = PatternClusterer()
+        clusters = clusterer.cluster_friction(facets)
+
+        filtered = clusterer.query_clusters(
+            clusters, scenario="grid_ctf"
+        )
+        # All friction clusters should involve grid_ctf runs
+        for cluster in filtered:
+            assert any(
+                rid in ["run-1", "run-2"]
+                for rid in cluster.run_ids
+            )
+
+    def test_query_clusters_by_provider(self) -> None:
+        from autocontext.analytics.clustering import PatternClusterer
+
+        facets = self._make_facets()
+        clusterer = PatternClusterer()
+        clusters = clusterer.cluster_delight(facets)
+
+        filtered = clusterer.query_clusters(
+            clusters, agent_provider="anthropic"
+        )
+        for cluster in filtered:
+            assert "run-3" in cluster.run_ids
+
+    def test_empty_facets(self) -> None:
+        from autocontext.analytics.clustering import PatternClusterer
+
+        clusterer = PatternClusterer()
+        assert clusterer.cluster_friction([]) == []
+        assert clusterer.cluster_delight([]) == []
+
+
+# ===========================================================================
+# AC-256: FacetTaxonomy
+# ===========================================================================
+
+
+class TestFacetTaxonomy:
+    def test_builtin_entries(self) -> None:
+        from autocontext.analytics.taxonomy import FacetTaxonomy
+
+        taxonomy = FacetTaxonomy()
+        entries = taxonomy.get_entries()
+        # Should have built-in friction/delight categories
+        assert len(entries) > 0
+        names = {e.name for e in entries}
+        assert "validation_failure" in names
+        assert "fast_advance" in names
+
+    def test_add_entry(self) -> None:
+        from autocontext.analytics.taxonomy import FacetTaxonomy, TaxonomyEntry
+
+        taxonomy = FacetTaxonomy()
+        initial_count = len(taxonomy.get_entries())
+
+        entry = TaxonomyEntry(
+            entry_id="tax-custom",
+            name="dependency_misordering",
+            parent_category="friction",
+            description="Actions taken in wrong dependency order",
+            is_system_defined=False,
+            source_cluster_id="clust-99",
+            created_at="2026-03-14T12:00:00Z",
+            recurrence_count=3,
+            confidence=0.7,
+        )
+        taxonomy.add_entry(entry)
+        assert len(taxonomy.get_entries()) == initial_count + 1
+
+    def test_propose_from_cluster(self) -> None:
+        from autocontext.analytics.clustering import FacetCluster
+        from autocontext.analytics.taxonomy import FacetTaxonomy
+
+        taxonomy = FacetTaxonomy()
+        cluster = FacetCluster(
+            cluster_id="clust-new",
+            label="Repeated cancellation cascades",
+            category="friction",
+            signal_types=["cancellation_cascade"],
+            run_ids=["r1", "r2", "r3", "r4"],
+            frequency=4,
+            recurrence_rate=0.8,
+            confidence=0.85,
+            evidence_summary="4 of 5 runs had cancellation cascades",
+            supporting_events=[],
+            metadata={},
+        )
+
+        proposed = taxonomy.propose_from_cluster(cluster, min_confidence=0.6)
+        assert proposed is not None
+        assert proposed.name == "cancellation_cascade"
+        assert proposed.is_system_defined is False
+        assert proposed.source_cluster_id == "clust-new"
+
+    def test_propose_low_confidence_returns_none(self) -> None:
+        from autocontext.analytics.clustering import FacetCluster
+        from autocontext.analytics.taxonomy import FacetTaxonomy
+
+        taxonomy = FacetTaxonomy()
+        cluster = FacetCluster(
+            cluster_id="clust-weak",
+            label="Weak pattern",
+            category="friction",
+            signal_types=["unknown_type"],
+            run_ids=["r1"],
+            frequency=1,
+            recurrence_rate=0.1,
+            confidence=0.3,
+            evidence_summary="Only 1 run",
+            supporting_events=[],
+            metadata={},
+        )
+
+        proposed = taxonomy.propose_from_cluster(cluster, min_confidence=0.6)
+        assert proposed is None
+
+    def test_evolve_adds_new_categories(self) -> None:
+        from autocontext.analytics.clustering import FacetCluster
+        from autocontext.analytics.taxonomy import FacetTaxonomy
+
+        taxonomy = FacetTaxonomy()
+        initial_count = len(taxonomy.get_entries())
+
+        clusters = [
+            FacetCluster(
+                cluster_id="clust-a",
+                label="Cancellation cascade",
+                category="friction",
+                signal_types=["cancellation_cascade"],
+                run_ids=["r1", "r2", "r3"],
+                frequency=3,
+                recurrence_rate=0.6,
+                confidence=0.75,
+                evidence_summary="3 runs showed cascading cancellations",
+                supporting_events=[],
+                metadata={},
+            ),
+        ]
+        new_entries = taxonomy.evolve(clusters, min_confidence=0.6)
+        assert len(new_entries) == 1
+        assert len(taxonomy.get_entries()) == initial_count + 1
+
+    def test_evolve_skips_existing(self) -> None:
+        from autocontext.analytics.clustering import FacetCluster
+        from autocontext.analytics.taxonomy import FacetTaxonomy
+
+        taxonomy = FacetTaxonomy()
+
+        # Try to evolve with a cluster that maps to an existing category
+        clusters = [
+            FacetCluster(
+                cluster_id="clust-dup",
+                label="Validation failures",
+                category="friction",
+                signal_types=["validation_failure"],
+                run_ids=["r1", "r2"],
+                frequency=2,
+                recurrence_rate=0.5,
+                confidence=0.9,
+                evidence_summary="Already known",
+                supporting_events=[],
+                metadata={},
+            ),
+        ]
+        initial_count = len(taxonomy.get_entries())
+        new_entries = taxonomy.evolve(clusters, min_confidence=0.6)
+        assert len(new_entries) == 0
+        assert len(taxonomy.get_entries()) == initial_count
+
+    def test_persist_and_load(self, tmp_path: Path) -> None:
+        from autocontext.analytics.taxonomy import FacetTaxonomy, TaxonomyEntry
+
+        taxonomy = FacetTaxonomy()
+        taxonomy.add_entry(TaxonomyEntry(
+            entry_id="tax-persist",
+            name="custom_category",
+            parent_category="friction",
+            description="A custom category",
+            is_system_defined=False,
+            source_cluster_id=None,
+            created_at="2026-03-14T12:00:00Z",
+            recurrence_count=1,
+            confidence=0.5,
+        ))
+
+        path = tmp_path / "taxonomy.json"
+        taxonomy.save(path)
+
+        loaded = FacetTaxonomy.load(path)
+        names = {e.name for e in loaded.get_entries()}
+        assert "custom_category" in names

--- a/autocontext/tests/test_aggregate_facets.py
+++ b/autocontext/tests/test_aggregate_facets.py
@@ -843,6 +843,20 @@ class TestPatternClusterer:
         for cluster in filtered:
             assert "run-3" in cluster.run_ids
 
+    def test_query_clusters_by_scenario_family(self) -> None:
+        from autocontext.analytics.clustering import PatternClusterer
+
+        facets = self._make_facets()
+        clusterer = PatternClusterer()
+        clusters = clusterer.cluster_friction(facets)
+
+        filtered = clusterer.query_clusters(
+            clusters, scenario_family="game"
+        )
+        assert filtered
+        for cluster in filtered:
+            assert "game" in cluster.metadata.get("scenario_families", [])
+
     def test_empty_facets(self) -> None:
         from autocontext.analytics.clustering import PatternClusterer
 

--- a/autocontext/tests/test_session_report_wiring.py
+++ b/autocontext/tests/test_session_report_wiring.py
@@ -266,6 +266,75 @@ class TestProgressReportWiring:
         assert report.cost.total_cost_usd > 0
 
 
+class TestAggregateAnalyticsWiring:
+    """Aggregate facets and clustering are generated from the live run completion path."""
+
+    def test_aggregate_analytics_persisted_on_run_completion(self, tmp_path: Path) -> None:
+        settings = _make_settings(tmp_path, session_reports_enabled=False)
+        runner, mocks = _make_runner_with_mocks(settings)
+
+        mocks["sqlite"].get_generation_metrics.return_value = [
+            {
+                "generation_index": 1,
+                "mean_score": 0.3,
+                "best_score": 0.4,
+                "elo": 1020.0,
+                "gate_decision": "advance",
+                "status": "completed",
+                "duration_seconds": 12.0,
+            },
+            {
+                "generation_index": 2,
+                "mean_score": 0.5,
+                "best_score": 0.6,
+                "elo": 1080.0,
+                "gate_decision": "retry",
+                "status": "completed",
+                "duration_seconds": 14.0,
+            },
+        ]
+        mocks["sqlite"].get_agent_role_metrics.return_value = [
+            {
+                "generation_index": 1,
+                "role": "competitor",
+                "model": "claude-sonnet-4-5-20250929",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "latency_ms": 100,
+                "subagent_id": "competitor",
+                "status": "success",
+            }
+        ]
+        mocks["sqlite"].get_staged_validation_results_for_run.return_value = [
+            {
+                "generation_index": 2,
+                "stage_order": 1,
+                "stage_name": "syntax",
+                "status": "failed",
+                "duration_ms": 10,
+                "error": "parse error",
+                "error_code": "parse",
+            }
+        ]
+        mocks["sqlite"].get_consultations_for_run.return_value = []
+        mocks["sqlite"].get_recovery_markers_for_run.return_value = [
+            {
+                "generation_index": 2,
+                "decision": "retry",
+                "reason": "validator failed",
+                "retry_count": 1,
+            }
+        ]
+        mocks["artifacts"].tools_dir.return_value = MagicMock(exists=MagicMock(return_value=True))
+
+        _run_with_pipeline_mock(runner, mocks, "grid_ctf", 2, "test_aggregate")
+
+        assert (tmp_path / "knowledge" / "facets" / "test_aggregate.json").exists()
+        assert (tmp_path / "knowledge" / "analytics" / "friction_clusters.json").exists()
+        assert (tmp_path / "knowledge" / "analytics" / "delight_clusters.json").exists()
+        assert (tmp_path / "knowledge" / "analytics" / "taxonomy.json").exists()
+
+
 class TestSessionReportEmptyTrajectory:
     """Handles empty trajectory (0 completed generations) gracefully."""
 


### PR DESCRIPTION
## Summary
- **AC-255**: Adds canonical aggregate facet and run-event schema for completed runs. Extracts non-PII metadata (scenario family, provider, token counts, validation failures, gate decisions) into structured `RunFacet` instances with friction/delight signal detection. Persists to queryable JSON store.
- **AC-256**: Adds cross-run pattern clustering engine that groups similar friction and delight signals, computes recurrence rates/confidence, and supports evolving facet taxonomy. New categories can emerge from high-confidence clusters without manual definition.

## New Package: `src/autocontext/analytics/`
| Module | Purpose |
|--------|---------|
| `facets.py` | RunEvent, FrictionSignal, DelightSignal, RunFacet data models |
| `extractor.py` | FacetExtractor — processes run data into structured facets |
| `store.py` | FacetStore — persist/load/query facets as JSON |
| `clustering.py` | EventPattern, FacetCluster, PatternClusterer |
| `taxonomy.py` | TaxonomyEntry, FacetTaxonomy with builtin + evolving categories |

## Signal Types
**Friction**: validation_failure, retry_loop, rollback, stale_context, tool_failure, dependency_error
**Delight**: fast_advance, clean_recovery, efficient_tool_use, strong_improvement

## Test plan
- [x] 40 dedicated tests in `test_aggregate_facets.py`
- [x] Full suite: 3738 passed, 46 skipped, 0 failed
- [x] Ruff clean, mypy clean