### PR TITLE
feat(AC-283): rubric calibration — human anchors, judge variance, alignment

### DIFF
--- a/autocontext/src/autocontext/execution/rubric_calibration.py
+++ b/autocontext/src/autocontext/execution/rubric_calibration.py
@@ -19,8 +19,12 @@ from __future__ import annotations
 
 import math
 import statistics
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any
+
+from autocontext.execution.judge import LLMJudge
+from autocontext.providers.base import LLMProvider
 
 
 @dataclass(slots=True)
@@ -193,15 +197,20 @@ def compute_alignment(
     judge_scores: list[float],
 ) -> AlignmentResult:
     """Compute alignment between human and judge scores."""
-    if not human_scores or not judge_scores:
+    if not human_scores and not judge_scores:
         return AlignmentResult(
             mean_absolute_error=0.0, bias=0.0, correlation=0.0,
             num_pairs=0, per_anchor_errors=[],
         )
 
-    n = min(len(human_scores), len(judge_scores))
-    hs = human_scores[:n]
-    js = judge_scores[:n]
+    if len(human_scores) != len(judge_scores):
+        raise ValueError(
+            "human_scores and judge_scores must have the same length; "
+            f"got {len(human_scores)} and {len(judge_scores)}",
+        )
+
+    hs = human_scores
+    js = judge_scores
 
     errors = [abs(j - h) for h, j in zip(hs, js, strict=True)]
     biases = [j - h for h, j in zip(hs, js, strict=True)]
@@ -214,7 +223,7 @@ def compute_alignment(
         mean_absolute_error=mae,
         bias=bias,
         correlation=corr,
-        num_pairs=n,
+        num_pairs=len(hs),
         per_anchor_errors=[round(e, 6) for e in errors],
     )
 
@@ -227,6 +236,39 @@ class AlignmentTolerance:
     max_mean_absolute_error: float
     max_bias: float
     min_correlation: float
+
+    @classmethod
+    def default_for_domain(cls, domain: str) -> AlignmentTolerance:
+        """Default domain tolerances for phase-1 within-domain calibration."""
+        normalized = domain.lower()
+        if any(token in normalized for token in ["drug", "interaction", "l19"]):
+            return cls(
+                domain=domain,
+                max_mean_absolute_error=0.12,
+                max_bias=0.08,
+                min_correlation=0.85,
+            )
+        if any(token in normalized for token in ["clinical", "trial", "protocol", "l16"]):
+            return cls(
+                domain=domain,
+                max_mean_absolute_error=0.15,
+                max_bias=0.10,
+                min_correlation=0.80,
+            )
+        return cls(
+            domain=domain,
+            max_mean_absolute_error=0.15,
+            max_bias=0.10,
+            min_correlation=0.80,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "domain": self.domain,
+            "max_mean_absolute_error": self.max_mean_absolute_error,
+            "max_bias": self.max_bias,
+            "min_correlation": self.min_correlation,
+        }
 
     def check(self, alignment: AlignmentResult) -> dict[str, Any]:
         """Check alignment against tolerance thresholds."""
@@ -298,3 +340,136 @@ class CalibrationReport:
             calibrated=data.get("calibrated", False),
             metadata=data.get("metadata", {}),
         )
+
+
+def _score_band_for_score(score: float) -> str:
+    if score < 0.4:
+        return "poor"
+    if score < 0.7:
+        return "fair"
+    if score < 0.9:
+        return "good"
+    return "excellent"
+
+
+def calibration_set_from_examples(
+    domain: str,
+    examples: Iterable[dict[str, Any]],
+) -> CalibrationSet:
+    """Build a calibration set from persisted human-feedback examples."""
+    anchors: list[CalibrationAnchor] = []
+    for idx, example in enumerate(examples):
+        human_score = example.get("human_score")
+        if human_score is None:
+            continue
+        score = float(human_score)
+        anchors.append(
+            CalibrationAnchor(
+                anchor_id=str(example.get("id", idx)),
+                domain=domain,
+                output_text=str(example.get("agent_output", "")),
+                human_score=score,
+                score_band=str(example.get("score_band") or _score_band_for_score(score)),
+                human_notes=str(example.get("human_notes", "")),
+                metadata={
+                    "created_at": example.get("created_at"),
+                    "generation_id": example.get("generation_id"),
+                },
+            ),
+        )
+    return CalibrationSet(
+        domain=domain,
+        anchors=anchors,
+        metadata={
+            "source": "human_feedback",
+            "cross_domain_normalization": "explicit second phase",
+        },
+    )
+
+
+def _aggregate_variance(results: list[JudgeVarianceResult]) -> JudgeVarianceResult:
+    """Aggregate per-anchor repeatability into one domain-level summary."""
+    if not results:
+        return JudgeVarianceResult(mean=0.0, variance=0.0, std_dev=0.0, range=0.0, num_samples=0)
+
+    return JudgeVarianceResult(
+        mean=round(statistics.mean(r.mean for r in results), 6),
+        variance=round(statistics.mean(r.variance for r in results), 6),
+        std_dev=round(statistics.mean(r.std_dev for r in results), 6),
+        range=round(max(r.range for r in results), 6),
+        num_samples=sum(r.num_samples for r in results),
+    )
+
+
+def run_judge_calibration(
+    *,
+    domain: str,
+    task_prompt: str,
+    rubric: str,
+    provider: LLMProvider,
+    model: str,
+    calibration_examples: list[dict[str, Any]],
+    reference_context: str | None = None,
+    required_concepts: list[str] | None = None,
+    repeat_judgments: int = 3,
+    tolerance: AlignmentTolerance | None = None,
+) -> CalibrationReport | None:
+    """Run live rubric calibration against stored human anchors."""
+    calibration_set = calibration_set_from_examples(domain, calibration_examples)
+    if len(calibration_set.anchors) < 2:
+        return None
+
+    tolerance = tolerance or AlignmentTolerance.default_for_domain(domain)
+    judge = LLMJudge(
+        model=model or provider.default_model(),
+        rubric=rubric,
+        provider=provider,
+        samples=1,
+        temperature=0.0,
+    )
+
+    human_scores: list[float] = []
+    judge_means: list[float] = []
+    per_anchor_variance: dict[str, dict[str, Any]] = {}
+
+    for anchor in calibration_set.anchors:
+        leave_one_out = [
+            example
+            for example in calibration_examples
+            if str(example.get("id")) != anchor.anchor_id
+        ]
+        repeated_scores: list[float] = []
+        for _ in range(max(1, repeat_judgments)):
+            result = judge.evaluate(
+                task_prompt=task_prompt,
+                agent_output=anchor.output_text,
+                reference_context=reference_context,
+                required_concepts=required_concepts,
+                calibration_examples=leave_one_out if leave_one_out else None,
+            )
+            repeated_scores.append(result.score)
+
+        variance = measure_judge_variance(repeated_scores)
+        per_anchor_variance[anchor.anchor_id] = variance.to_dict()
+        human_scores.append(anchor.human_score)
+        judge_means.append(variance.mean)
+
+    alignment = compute_alignment(human_scores, judge_means)
+    aggregate_variance = _aggregate_variance(
+        [JudgeVarianceResult.from_dict(data) for data in per_anchor_variance.values()],
+    )
+    tolerance_check = tolerance.check(alignment)
+
+    return CalibrationReport(
+        domain=domain,
+        num_anchors=len(calibration_set.anchors),
+        alignment=alignment,
+        variance=aggregate_variance,
+        calibrated=tolerance_check["passes"],
+        metadata={
+            "tolerance": tolerance.to_dict(),
+            "tolerance_check": tolerance_check,
+            "per_anchor_variance": per_anchor_variance,
+            "cross_domain_normalization": "explicit second phase",
+        },
+    )

--- a/autocontext/src/autocontext/execution/rubric_calibration.py
+++ b/autocontext/src/autocontext/execution/rubric_calibration.py
@@ -1,0 +1,300 @@
+"""Rubric calibration — human anchors, judge variance, and alignment (AC-283).
+
+Infrastructure for validating LLM-generated rubrics against human baselines.
+Measures judge repeatability, computes alignment between human and LLM scores,
+and defines per-domain tolerance thresholds.
+
+Key types:
+- CalibrationAnchor: a human-scored output with score band and notes
+- CalibrationSet: collection of anchors for one domain
+- JudgeVarianceResult: variance metrics from repeat-judging same output
+- AlignmentResult: alignment between human and judge scores
+- AlignmentTolerance: per-domain tolerance thresholds
+- CalibrationReport: aggregate calibration report
+- measure_judge_variance(): compute variance from repeated scores
+- compute_alignment(): compute correlation, bias, MAE from score pairs
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class CalibrationAnchor:
+    """A human-scored output serving as calibration reference."""
+
+    anchor_id: str
+    domain: str
+    output_text: str
+    human_score: float
+    score_band: str  # poor, fair, good, excellent
+    human_notes: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "anchor_id": self.anchor_id,
+            "domain": self.domain,
+            "output_text": self.output_text,
+            "human_score": self.human_score,
+            "score_band": self.score_band,
+            "human_notes": self.human_notes,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CalibrationAnchor:
+        return cls(
+            anchor_id=data["anchor_id"],
+            domain=data.get("domain", ""),
+            output_text=data.get("output_text", ""),
+            human_score=data.get("human_score", 0.0),
+            score_band=data.get("score_band", ""),
+            human_notes=data.get("human_notes", ""),
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass(slots=True)
+class CalibrationSet:
+    """Collection of calibration anchors for one domain."""
+
+    domain: str
+    anchors: list[CalibrationAnchor]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def score_bands(self) -> dict[str, list[CalibrationAnchor]]:
+        """Group anchors by score band."""
+        bands: dict[str, list[CalibrationAnchor]] = {}
+        for anchor in self.anchors:
+            bands.setdefault(anchor.score_band, []).append(anchor)
+        return bands
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "domain": self.domain,
+            "anchors": [a.to_dict() for a in self.anchors],
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CalibrationSet:
+        return cls(
+            domain=data["domain"],
+            anchors=[CalibrationAnchor.from_dict(a) for a in data.get("anchors", [])],
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass(slots=True)
+class JudgeVarianceResult:
+    """Variance metrics from repeat-judging the same output."""
+
+    mean: float
+    variance: float
+    std_dev: float
+    range: float
+    num_samples: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mean": self.mean,
+            "variance": self.variance,
+            "std_dev": self.std_dev,
+            "range": self.range,
+            "num_samples": self.num_samples,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> JudgeVarianceResult:
+        return cls(
+            mean=data.get("mean", 0.0),
+            variance=data.get("variance", 0.0),
+            std_dev=data.get("std_dev", 0.0),
+            range=data.get("range", 0.0),
+            num_samples=data.get("num_samples", 0),
+        )
+
+
+def measure_judge_variance(scores: list[float]) -> JudgeVarianceResult:
+    """Compute variance metrics from repeated judge scores on the same output."""
+    if not scores:
+        return JudgeVarianceResult(mean=0.0, variance=0.0, std_dev=0.0, range=0.0, num_samples=0)
+
+    mean = statistics.mean(scores)
+    var = statistics.pvariance(scores) if len(scores) > 1 else 0.0
+    std = math.sqrt(var)
+    score_range = round(max(scores) - min(scores), 6)
+
+    return JudgeVarianceResult(
+        mean=round(mean, 6),
+        variance=round(var, 6),
+        std_dev=round(std, 6),
+        range=score_range,
+        num_samples=len(scores),
+    )
+
+
+@dataclass(slots=True)
+class AlignmentResult:
+    """Alignment between human scores and judge scores."""
+
+    mean_absolute_error: float
+    bias: float  # positive = judge overestimates
+    correlation: float
+    num_pairs: int
+    per_anchor_errors: list[float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mean_absolute_error": self.mean_absolute_error,
+            "bias": self.bias,
+            "correlation": self.correlation,
+            "num_pairs": self.num_pairs,
+            "per_anchor_errors": self.per_anchor_errors,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AlignmentResult:
+        return cls(
+            mean_absolute_error=data.get("mean_absolute_error", 0.0),
+            bias=data.get("bias", 0.0),
+            correlation=data.get("correlation", 0.0),
+            num_pairs=data.get("num_pairs", 0),
+            per_anchor_errors=data.get("per_anchor_errors", []),
+        )
+
+
+def _pearson_correlation(xs: list[float], ys: list[float]) -> float:
+    """Compute Pearson correlation coefficient."""
+    n = len(xs)
+    if n < 2:
+        return 0.0
+
+    mean_x = statistics.mean(xs)
+    mean_y = statistics.mean(ys)
+
+    numerator = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys, strict=True))
+    denom_x = math.sqrt(sum((x - mean_x) ** 2 for x in xs))
+    denom_y = math.sqrt(sum((y - mean_y) ** 2 for y in ys))
+
+    if denom_x == 0 or denom_y == 0:
+        return 0.0
+
+    return numerator / (denom_x * denom_y)
+
+
+def compute_alignment(
+    human_scores: list[float],
+    judge_scores: list[float],
+) -> AlignmentResult:
+    """Compute alignment between human and judge scores."""
+    if not human_scores or not judge_scores:
+        return AlignmentResult(
+            mean_absolute_error=0.0, bias=0.0, correlation=0.0,
+            num_pairs=0, per_anchor_errors=[],
+        )
+
+    n = min(len(human_scores), len(judge_scores))
+    hs = human_scores[:n]
+    js = judge_scores[:n]
+
+    errors = [abs(j - h) for h, j in zip(hs, js, strict=True)]
+    biases = [j - h for h, j in zip(hs, js, strict=True)]
+
+    mae = round(statistics.mean(errors), 6)
+    bias = round(statistics.mean(biases), 6)
+    corr = round(_pearson_correlation(hs, js), 4)
+
+    return AlignmentResult(
+        mean_absolute_error=mae,
+        bias=bias,
+        correlation=corr,
+        num_pairs=n,
+        per_anchor_errors=[round(e, 6) for e in errors],
+    )
+
+
+@dataclass(slots=True)
+class AlignmentTolerance:
+    """Per-domain tolerance thresholds for acceptable alignment."""
+
+    domain: str
+    max_mean_absolute_error: float
+    max_bias: float
+    min_correlation: float
+
+    def check(self, alignment: AlignmentResult) -> dict[str, Any]:
+        """Check alignment against tolerance thresholds."""
+        violations: list[str] = []
+
+        if alignment.mean_absolute_error > self.max_mean_absolute_error:
+            violations.append(
+                f"mean_absolute_error {alignment.mean_absolute_error:.4f} "
+                f"> max {self.max_mean_absolute_error:.4f}"
+            )
+        if abs(alignment.bias) > self.max_bias:
+            violations.append(
+                f"bias {alignment.bias:.4f} > max {self.max_bias:.4f}"
+            )
+        if alignment.correlation < self.min_correlation and alignment.num_pairs >= 3:
+            violations.append(
+                f"correlation {alignment.correlation:.4f} "
+                f"< min {self.min_correlation:.4f}"
+            )
+
+        return {
+            "passes": len(violations) == 0,
+            "violations": violations,
+            "domain": self.domain,
+        }
+
+
+@dataclass(slots=True)
+class CalibrationReport:
+    """Aggregate calibration report for one domain."""
+
+    domain: str
+    num_anchors: int
+    alignment: AlignmentResult
+    variance: JudgeVarianceResult
+    calibrated: bool
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def summary(self) -> str:
+        lines = [
+            f"Calibration Report: {self.domain}",
+            f"Anchors: {self.num_anchors}",
+            f"MAE: {self.alignment.mean_absolute_error:.4f}",
+            f"Bias: {self.alignment.bias:+.4f}",
+            f"Correlation: {self.alignment.correlation:.4f}",
+            f"Judge variance (std): {self.variance.std_dev:.4f}",
+            f"Judge variance (range): {self.variance.range:.4f}",
+            f"Calibrated: {'yes' if self.calibrated else 'no'}",
+        ]
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "domain": self.domain,
+            "num_anchors": self.num_anchors,
+            "alignment": self.alignment.to_dict(),
+            "variance": self.variance.to_dict(),
+            "calibrated": self.calibrated,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CalibrationReport:
+        return cls(
+            domain=data["domain"],
+            num_anchors=data.get("num_anchors", 0),
+            alignment=AlignmentResult.from_dict(data.get("alignment", {})),
+            variance=JudgeVarianceResult.from_dict(data.get("variance", {})),
+            calibrated=data.get("calibrated", False),
+            metadata=data.get("metadata", {}),
+        )

--- a/autocontext/src/autocontext/execution/task_runner.py
+++ b/autocontext/src/autocontext/execution/task_runner.py
@@ -30,6 +30,7 @@ from autocontext.execution.objective_verification import (
     ObjectiveVerificationConfig,
     run_objective_verification,
 )
+from autocontext.execution.rubric_calibration import run_judge_calibration
 from autocontext.providers.base import LLMProvider
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
 from autocontext.storage.sqlite_store import SQLiteStore
@@ -78,6 +79,7 @@ class TaskConfig:
 def _serialize_result(
     result: ImprovementResult,
     objective_verification: dict[str, Any] | None = None,
+    rubric_calibration: dict[str, Any] | None = None,
 ) -> str:
     """Serialize an ImprovementResult to JSON."""
     rounds = []
@@ -102,6 +104,8 @@ def _serialize_result(
         data["judge_calls"] = result.judge_calls
     if objective_verification is not None:
         data["objective_verification"] = objective_verification
+    if rubric_calibration is not None:
+        data["rubric_calibration"] = rubric_calibration
     return json.dumps(data)
 
 
@@ -109,6 +113,7 @@ def _serialize_evolution_result(
     trajectory: AgentTaskTrajectory,
     generation_results: list[ImprovementResult],
     objective_verification: dict[str, Any] | None = None,
+    rubric_calibration: dict[str, Any] | None = None,
 ) -> str:
     """Serialize a multi-generation AgentTask evolution run to JSON."""
     final_rounds: list[dict[str, object]] = []
@@ -147,6 +152,8 @@ def _serialize_evolution_result(
     }
     if objective_verification is not None:
         data["objective_verification"] = objective_verification
+    if rubric_calibration is not None:
+        data["rubric_calibration"] = rubric_calibration
     return json.dumps(data)
 
 
@@ -166,6 +173,32 @@ def _build_objective_payload(
         rubric_score=rubric_score,
         config=verification_config,
     )
+
+
+def _build_rubric_calibration_payload(
+    *,
+    store: SQLiteStore,
+    spec_name: str,
+    task_prompt: str,
+    rubric: str,
+    provider: LLMProvider,
+    model: str,
+    reference_context: str | None = None,
+    required_concepts: list[str] | None = None,
+) -> dict[str, Any] | None:
+    """Run live rubric calibration against stored human feedback anchors."""
+    calibration_examples = store.get_calibration_examples(spec_name, limit=5)
+    report = run_judge_calibration(
+        domain=spec_name,
+        task_prompt=task_prompt,
+        rubric=rubric,
+        provider=provider,
+        model=model or provider.default_model(),
+        calibration_examples=calibration_examples,
+        reference_context=reference_context,
+        required_concepts=required_concepts,
+    )
+    return report.to_dict() if report is not None else None
 
 
 class SimpleAgentTask(AgentTaskInterface):
@@ -427,6 +460,16 @@ class TaskRunner:
                     result.best_score,
                     config,
                 )
+                rubric_calibration = _build_rubric_calibration_payload(
+                    store=self.store,
+                    spec_name=spec_name,
+                    task_prompt=agent_task.get_task_prompt({}),
+                    rubric=agent_task.get_rubric(),
+                    provider=self.provider,
+                    model=self.model,
+                    reference_context=config.reference_context,
+                    required_concepts=config.required_concepts,
+                )
 
                 self.store.complete_task(
                     task_id=task_id,
@@ -434,7 +477,11 @@ class TaskRunner:
                     best_output=result.best_output,
                     total_rounds=result.total_rounds,
                     met_threshold=result.met_threshold,
-                    result_json=_serialize_result(result, objective_payload),
+                    result_json=_serialize_result(
+                        result,
+                        objective_payload,
+                        rubric_calibration,
+                    ),
                 )
 
             logger.info(
@@ -519,6 +566,16 @@ class TaskRunner:
         best_score = state.best_score
         best_output = state.best_output
         objective_payload = _build_objective_payload(best_output, best_score, config)
+        rubric_calibration = _build_rubric_calibration_payload(
+            store=self.store,
+            spec_name=spec_name,
+            task_prompt=agent_task.get_task_prompt({}),
+            rubric=agent_task.get_rubric(),
+            provider=self.provider,
+            model=self.model,
+            reference_context=config.reference_context,
+            required_concepts=config.required_concepts,
+        )
 
         self.store.complete_task(
             task_id=task_id,
@@ -530,6 +587,7 @@ class TaskRunner:
                 trajectory,
                 ordered_results,
                 objective_payload,
+                rubric_calibration,
             ),
         )
 

--- a/autocontext/src/autocontext/mcp/tools.py
+++ b/autocontext/src/autocontext/mcp/tools.py
@@ -270,6 +270,8 @@ def run_improvement_loop(
         return {"error": f"'{scenario_name}' is not an agent task scenario. Improvement loops require agent task scenarios."}
 
     from autocontext.execution.improvement_loop import ImprovementLoop
+    from autocontext.execution.rubric_calibration import run_judge_calibration
+    from autocontext.providers.registry import get_provider
 
     calibration = ctx.sqlite.get_calibration_examples(scenario_name, limit=5)
 
@@ -296,7 +298,22 @@ def run_improvement_loop(
         for r in result.rounds
     ]
 
-    return {
+    rubric_calibration: dict[str, object] | None = None
+    if len(calibration) >= 2:
+        provider = get_provider(ctx.settings)
+        report = run_judge_calibration(
+            domain=scenario_name,
+            task_prompt=task.get_task_prompt(task.initial_state()),
+            rubric=task.get_rubric(),
+            provider=provider,
+            model=ctx.settings.judge_model,
+            calibration_examples=calibration,
+            reference_context=reference_context,
+            required_concepts=required_concepts,
+        )
+        rubric_calibration = report.to_dict() if report is not None else None
+
+    payload: dict[str, object] = {
         "scenario_name": scenario_name,
         "total_rounds": result.total_rounds,
         "met_threshold": result.met_threshold,
@@ -306,6 +323,9 @@ def run_improvement_loop(
         "rounds": rounds_summary,
         "best_output_preview": result.best_output[:500],
     }
+    if rubric_calibration is not None:
+        payload["rubric_calibration"] = rubric_calibration
+    return payload
 
 
 # -- Agent Task Management --
@@ -436,6 +456,7 @@ def evaluate_output(
         ObjectiveVerificationConfig,
         run_objective_verification,
     )
+    from autocontext.execution.rubric_calibration import run_judge_calibration
     from autocontext.providers.registry import get_provider
 
     provider = get_provider(ctx.settings)
@@ -472,6 +493,19 @@ def evaluate_output(
                 rubric_score=result.score,
                 config=config,
             )
+    if len(calibration) >= 2:
+        report = run_judge_calibration(
+            domain=task_name,
+            task_prompt=data["task_prompt"],
+            rubric=data["rubric"],
+            provider=provider,
+            model=ctx.settings.judge_model,
+            calibration_examples=calibration,
+            reference_context=data.get("reference_context"),
+            required_concepts=data.get("required_concepts"),
+        )
+        if report is not None:
+            payload["rubric_calibration"] = report.to_dict()
     return payload
 
 
@@ -610,6 +644,8 @@ def get_task_result(ctx: MtsToolContext, task_id: str) -> dict[str, object]:
                     result["generations"] = payload["generations"]
                 if "objective_verification" in payload:
                     result["objective_verification"] = payload["objective_verification"]
+                if "rubric_calibration" in payload:
+                    result["rubric_calibration"] = payload["rubric_calibration"]
             except (json.JSONDecodeError, AttributeError):
                 result["rounds"] = []
     elif task["status"] == "failed":

--- a/autocontext/tests/test_mcp_agent_tasks.py
+++ b/autocontext/tests/test_mcp_agent_tasks.py
@@ -182,6 +182,38 @@ class TestEvaluateOutput:
         assert result["objective_verification"]["oracle_result"]["found_count"] == 1
         assert result["objective_verification"]["comparison"]["rubric_score"] == 0.9
 
+    def test_evaluates_with_rubric_calibration(self, ctx, monkeypatch):
+        create_agent_task(
+            ctx,
+            "calibrated-task",
+            "Find serious drug interactions.",
+            "Clinical accuracy",
+        )
+        ctx.sqlite.insert_human_feedback(
+            scenario_name="calibrated-task",
+            agent_output="Warfarin and aspirin increase bleeding risk.",
+            human_score=0.82,
+            human_notes="Strong anchor with correct interaction.",
+        )
+        ctx.sqlite.insert_human_feedback(
+            scenario_name="calibrated-task",
+            agent_output="Simvastatin and clarithromycin increase myopathy risk.",
+            human_score=0.87,
+            human_notes="Also correct and clinically relevant.",
+        )
+
+        from autocontext.providers import registry
+        monkeypatch.setattr(registry, "get_provider", lambda s: _MockProvider(_judge_response(0.88)))
+
+        result = evaluate_output(
+            ctx,
+            "calibrated-task",
+            "1. Warfarin + Aspirin: high severity bleeding interaction.",
+        )
+        assert result["score"] == 0.88
+        assert result["rubric_calibration"]["num_anchors"] == 2
+        assert result["rubric_calibration"]["alignment"]["num_pairs"] == 2
+
 
 # ---------------------------------------------------------------------------
 # Queue tools
@@ -303,6 +335,36 @@ class TestQueueTools:
         result = get_task_result(ctx, "t2")
         assert result["objective_verification"]["oracle_result"]["found_count"] == 1
         assert result["objective_verification"]["comparison"]["rubric_score"] == 0.84
+
+    def test_get_task_result_surfaces_rubric_calibration(self, ctx):
+        create_agent_task(ctx, "calibrated-run", "prompt", "rubric")
+        ctx.sqlite.enqueue_task(
+            "t3",
+            "calibrated-run",
+            config={"task_prompt": "prompt", "rubric": "rubric"},
+        )
+        ctx.sqlite.dequeue_task()
+        ctx.sqlite.complete_task(
+            "t3",
+            best_score=0.86,
+            best_output="Warfarin + Aspirin is high risk.",
+            total_rounds=1,
+            met_threshold=False,
+            result_json=json.dumps({
+                "rounds": [{"round_number": 1, "score": 0.86, "reasoning": "ok"}],
+                "rubric_calibration": {
+                    "domain": "calibrated-run",
+                    "num_anchors": 2,
+                    "alignment": {"num_pairs": 2, "mean_absolute_error": 0.03},
+                    "variance": {"std_dev": 0.0},
+                    "calibrated": True,
+                },
+            }),
+        )
+
+        result = get_task_result(ctx, "t3")
+        assert result["rubric_calibration"]["num_anchors"] == 2
+        assert result["rubric_calibration"]["calibrated"] is True
 
 
 class TestGetBestOutput:

--- a/autocontext/tests/test_rubric_calibration.py
+++ b/autocontext/tests/test_rubric_calibration.py
@@ -1,0 +1,311 @@
+"""Tests for AC-283: rubric calibration — human anchors, judge variance, alignment.
+
+Covers: CalibrationAnchor, CalibrationSet, measure_judge_variance,
+compute_alignment, AlignmentTolerance, CalibrationReport.
+"""
+
+from __future__ import annotations
+
+# ===========================================================================
+# CalibrationAnchor
+# ===========================================================================
+
+
+class TestCalibrationAnchor:
+    def test_construction(self) -> None:
+        from autocontext.execution.rubric_calibration import CalibrationAnchor
+
+        anchor = CalibrationAnchor(
+            anchor_id="a-1",
+            domain="clinical_trial",
+            output_text="A detailed clinical trial protocol...",
+            human_score=0.82,
+            score_band="good",
+            human_notes="Thorough but missing secondary endpoints",
+        )
+        assert anchor.human_score == 0.82
+        assert anchor.score_band == "good"
+
+    def test_roundtrip(self) -> None:
+        from autocontext.execution.rubric_calibration import CalibrationAnchor
+
+        anchor = CalibrationAnchor(
+            anchor_id="a-2",
+            domain="drug_interaction",
+            output_text="Output text",
+            human_score=0.45,
+            score_band="poor",
+            human_notes="Missed critical interactions",
+        )
+        d = anchor.to_dict()
+        restored = CalibrationAnchor.from_dict(d)
+        assert restored.anchor_id == "a-2"
+        assert restored.human_score == 0.45
+
+
+# ===========================================================================
+# CalibrationSet
+# ===========================================================================
+
+
+class TestCalibrationSet:
+    def test_construction(self) -> None:
+        from autocontext.execution.rubric_calibration import (
+            CalibrationAnchor,
+            CalibrationSet,
+        )
+
+        anchors = [
+            CalibrationAnchor("a-1", "clinical_trial", "Poor output", 0.30, "poor", "Very weak"),
+            CalibrationAnchor("a-2", "clinical_trial", "OK output", 0.60, "fair", "Adequate"),
+            CalibrationAnchor("a-3", "clinical_trial", "Good output", 0.85, "good", "Solid work"),
+        ]
+        cal_set = CalibrationSet(domain="clinical_trial", anchors=anchors)
+        assert cal_set.domain == "clinical_trial"
+        assert len(cal_set.anchors) == 3
+
+    def test_score_bands(self) -> None:
+        from autocontext.execution.rubric_calibration import (
+            CalibrationAnchor,
+            CalibrationSet,
+        )
+
+        anchors = [
+            CalibrationAnchor("a-1", "test", "output", 0.30, "poor", ""),
+            CalibrationAnchor("a-2", "test", "output", 0.60, "fair", ""),
+            CalibrationAnchor("a-3", "test", "output", 0.85, "good", ""),
+            CalibrationAnchor("a-4", "test", "output", 0.95, "excellent", ""),
+        ]
+        cal_set = CalibrationSet(domain="test", anchors=anchors)
+        bands = cal_set.score_bands()
+        assert "poor" in bands
+        assert "excellent" in bands
+
+    def test_roundtrip(self) -> None:
+        from autocontext.execution.rubric_calibration import (
+            CalibrationAnchor,
+            CalibrationSet,
+        )
+
+        cal_set = CalibrationSet(
+            domain="test",
+            anchors=[CalibrationAnchor("a-1", "test", "out", 0.5, "fair", "ok")],
+        )
+        d = cal_set.to_dict()
+        restored = CalibrationSet.from_dict(d)
+        assert restored.domain == "test"
+        assert len(restored.anchors) == 1
+
+
+# ===========================================================================
+# measure_judge_variance
+# ===========================================================================
+
+
+class TestMeasureJudgeVariance:
+    def test_identical_scores_zero_variance(self) -> None:
+        from autocontext.execution.rubric_calibration import measure_judge_variance
+
+        result = measure_judge_variance([0.75, 0.75, 0.75, 0.75, 0.75])
+        assert result.variance == 0.0
+        assert result.std_dev == 0.0
+        assert result.range == 0.0
+
+    def test_varying_scores(self) -> None:
+        from autocontext.execution.rubric_calibration import measure_judge_variance
+
+        result = measure_judge_variance([0.70, 0.75, 0.80, 0.72, 0.78])
+        assert result.variance > 0
+        assert result.std_dev > 0
+        assert result.mean > 0.7
+        assert result.range == 0.10
+
+    def test_single_score(self) -> None:
+        from autocontext.execution.rubric_calibration import measure_judge_variance
+
+        result = measure_judge_variance([0.80])
+        assert result.variance == 0.0
+        assert result.mean == 0.80
+
+    def test_empty_scores(self) -> None:
+        from autocontext.execution.rubric_calibration import measure_judge_variance
+
+        result = measure_judge_variance([])
+        assert result.mean == 0.0
+        assert result.num_samples == 0
+
+
+# ===========================================================================
+# compute_alignment
+# ===========================================================================
+
+
+class TestComputeAlignment:
+    def test_perfect_alignment(self) -> None:
+        from autocontext.execution.rubric_calibration import compute_alignment
+
+        human_scores = [0.3, 0.5, 0.7, 0.9]
+        judge_scores = [0.3, 0.5, 0.7, 0.9]
+        result = compute_alignment(human_scores, judge_scores)
+        assert result.mean_absolute_error == 0.0
+        assert result.bias == 0.0
+        assert result.correlation >= 0.99
+
+    def test_systematic_overestimation(self) -> None:
+        from autocontext.execution.rubric_calibration import compute_alignment
+
+        human_scores = [0.3, 0.5, 0.7]
+        judge_scores = [0.5, 0.7, 0.9]
+        result = compute_alignment(human_scores, judge_scores)
+        assert result.bias > 0  # judge scores higher than human
+        assert result.mean_absolute_error > 0
+
+    def test_high_correlation_with_offset(self) -> None:
+        from autocontext.execution.rubric_calibration import compute_alignment
+
+        human_scores = [0.2, 0.4, 0.6, 0.8]
+        judge_scores = [0.3, 0.5, 0.7, 0.9]  # +0.1 systematic offset
+        result = compute_alignment(human_scores, judge_scores)
+        assert result.correlation >= 0.99  # Perfect correlation despite offset
+        assert abs(result.bias - 0.1) < 0.01  # Bias is ~0.1
+
+    def test_no_correlation(self) -> None:
+        from autocontext.execution.rubric_calibration import compute_alignment
+
+        human_scores = [0.2, 0.8, 0.4, 0.6]
+        judge_scores = [0.7, 0.3, 0.9, 0.1]
+        result = compute_alignment(human_scores, judge_scores)
+        assert result.correlation < 0.5
+
+    def test_empty_scores(self) -> None:
+        from autocontext.execution.rubric_calibration import compute_alignment
+
+        result = compute_alignment([], [])
+        assert result.mean_absolute_error == 0.0
+        assert result.num_pairs == 0
+
+
+# ===========================================================================
+# AlignmentTolerance
+# ===========================================================================
+
+
+class TestAlignmentTolerance:
+    def test_construction(self) -> None:
+        from autocontext.execution.rubric_calibration import AlignmentTolerance
+
+        tol = AlignmentTolerance(
+            domain="clinical_trial",
+            max_mean_absolute_error=0.15,
+            max_bias=0.10,
+            min_correlation=0.80,
+        )
+        assert tol.max_mean_absolute_error == 0.15
+
+    def test_check_passes(self) -> None:
+        from autocontext.execution.rubric_calibration import (
+            AlignmentResult,
+            AlignmentTolerance,
+        )
+
+        tol = AlignmentTolerance("test", 0.15, 0.10, 0.80)
+        alignment = AlignmentResult(
+            mean_absolute_error=0.08,
+            bias=0.05,
+            correlation=0.92,
+            num_pairs=5,
+            per_anchor_errors=[0.05, 0.10, 0.08, 0.12, 0.05],
+        )
+        check = tol.check(alignment)
+        assert check["passes"] is True
+
+    def test_check_fails_on_mae(self) -> None:
+        from autocontext.execution.rubric_calibration import (
+            AlignmentResult,
+            AlignmentTolerance,
+        )
+
+        tol = AlignmentTolerance("test", 0.10, 0.10, 0.80)
+        alignment = AlignmentResult(
+            mean_absolute_error=0.20,
+            bias=0.05,
+            correlation=0.90,
+            num_pairs=3,
+            per_anchor_errors=[0.15, 0.25, 0.20],
+        )
+        check = tol.check(alignment)
+        assert check["passes"] is False
+        assert "mean_absolute_error" in str(check["violations"])
+
+
+# ===========================================================================
+# CalibrationReport
+# ===========================================================================
+
+
+class TestCalibrationReport:
+    def test_construction(self) -> None:
+        from autocontext.execution.rubric_calibration import (
+            AlignmentResult,
+            CalibrationReport,
+            JudgeVarianceResult,
+        )
+
+        report = CalibrationReport(
+            domain="clinical_trial",
+            num_anchors=3,
+            alignment=AlignmentResult(
+                mean_absolute_error=0.10,
+                bias=0.05,
+                correlation=0.90,
+                num_pairs=3,
+                per_anchor_errors=[0.08, 0.12, 0.10],
+            ),
+            variance=JudgeVarianceResult(
+                mean=0.75,
+                variance=0.001,
+                std_dev=0.032,
+                range=0.08,
+                num_samples=5,
+            ),
+            calibrated=True,
+        )
+        assert report.calibrated is True
+        assert report.num_anchors == 3
+
+    def test_summary(self) -> None:
+        from autocontext.execution.rubric_calibration import (
+            AlignmentResult,
+            CalibrationReport,
+            JudgeVarianceResult,
+        )
+
+        report = CalibrationReport(
+            domain="drug_interaction",
+            num_anchors=4,
+            alignment=AlignmentResult(0.12, 0.08, 0.88, 4, [0.10, 0.15, 0.08, 0.15]),
+            variance=JudgeVarianceResult(0.72, 0.002, 0.045, 0.10, 5),
+            calibrated=False,
+        )
+        summary = report.summary()
+        assert "drug_interaction" in summary
+        assert "0.12" in summary or "mae" in summary.lower()
+
+    def test_roundtrip(self) -> None:
+        from autocontext.execution.rubric_calibration import (
+            AlignmentResult,
+            CalibrationReport,
+            JudgeVarianceResult,
+        )
+
+        report = CalibrationReport(
+            domain="test",
+            num_anchors=2,
+            alignment=AlignmentResult(0.1, 0.05, 0.9, 2, [0.1, 0.1]),
+            variance=JudgeVarianceResult(0.7, 0.001, 0.03, 0.05, 3),
+            calibrated=True,
+        )
+        d = report.to_dict()
+        restored = CalibrationReport.from_dict(d)
+        assert restored.domain == "test"
+        assert restored.calibrated is True

--- a/autocontext/tests/test_rubric_calibration.py
+++ b/autocontext/tests/test_rubric_calibration.py
@@ -6,6 +6,32 @@ compute_alignment, AlignmentTolerance, CalibrationReport.
 
 from __future__ import annotations
 
+import pytest
+
+from autocontext.providers.base import CompletionResult, LLMProvider
+
+
+class _MockJudgeProvider(LLMProvider):
+    def __init__(self, response: str) -> None:
+        self._response = response
+
+    def complete(self, system_prompt, user_prompt, model=None, temperature=0.0, max_tokens=4096):
+        return CompletionResult(text=self._response, model=model or "mock-judge")
+
+    def default_model(self):
+        return "mock-judge"
+
+
+def _judge_response(score: float, reasoning: str = "aligned") -> str:
+    import json
+
+    payload = {
+        "score": score,
+        "reasoning": reasoning,
+        "dimensions": {"quality": score},
+    }
+    return f"<!-- JUDGE_RESULT_START -->\n{json.dumps(payload)}\n<!-- JUDGE_RESULT_END -->"
+
 # ===========================================================================
 # CalibrationAnchor
 # ===========================================================================
@@ -184,6 +210,12 @@ class TestComputeAlignment:
         assert result.mean_absolute_error == 0.0
         assert result.num_pairs == 0
 
+    def test_rejects_mismatched_anchor_sets(self) -> None:
+        from autocontext.execution.rubric_calibration import compute_alignment
+
+        with pytest.raises(ValueError, match="same length"):
+            compute_alignment([0.4, 0.7, 0.9], [0.4, 0.7])
+
 
 # ===========================================================================
 # AlignmentTolerance
@@ -309,3 +341,38 @@ class TestCalibrationReport:
         restored = CalibrationReport.from_dict(d)
         assert restored.domain == "test"
         assert restored.calibrated is True
+
+
+class TestRunJudgeCalibration:
+    def test_builds_live_report_from_human_feedback_examples(self) -> None:
+        from autocontext.execution.rubric_calibration import run_judge_calibration
+
+        provider = _MockJudgeProvider(_judge_response(0.82))
+        report = run_judge_calibration(
+            domain="l19-drug-interactions",
+            task_prompt="Find clinically relevant drug interactions.",
+            rubric="Clinical accuracy and recall",
+            provider=provider,
+            model="mock-judge",
+            calibration_examples=[
+                {
+                    "id": 1,
+                    "agent_output": "Warfarin and aspirin cause bleeding risk.",
+                    "human_score": 0.8,
+                    "human_notes": "Correct high-severity interaction.",
+                    "created_at": "2026-03-16T00:00:00Z",
+                },
+                {
+                    "id": 2,
+                    "agent_output": "Simvastatin and clarithromycin raise myopathy risk.",
+                    "human_score": 0.84,
+                    "human_notes": "Also correct and clinically relevant.",
+                    "created_at": "2026-03-16T00:01:00Z",
+                },
+            ],
+        )
+
+        assert report is not None
+        assert report.num_anchors == 2
+        assert report.alignment.num_pairs == 2
+        assert "per_anchor_variance" in report.metadata

--- a/autocontext/tests/test_task_runner.py
+++ b/autocontext/tests/test_task_runner.py
@@ -444,6 +444,39 @@ class TestEnqueueFunction:
         assert payload["objective_verification"]["oracle_result"]["false_positive_count"] >= 1
         assert payload["objective_verification"]["comparison"]["rubric_score"] == 0.82
 
+    def test_run_once_persists_rubric_calibration(self, store):
+        store.insert_human_feedback(
+            scenario_name="l19-drug-interactions",
+            agent_output="Warfarin and aspirin increase bleeding risk.",
+            human_score=0.82,
+            human_notes="Correctly identifies the critical interaction.",
+        )
+        store.insert_human_feedback(
+            scenario_name="l19-drug-interactions",
+            agent_output="Simvastatin with clarithromycin increases myopathy risk.",
+            human_score=0.86,
+            human_notes="Correct interaction with clear severity explanation.",
+        )
+
+        provider = _MockProvider([
+            "1. Warfarin + Aspirin: high severity bleeding interaction.",
+            *[_judge_response(0.84, "aligned with anchors")] * 8,
+        ])
+        config = {
+            "task_prompt": "Find clinically relevant drug interactions.",
+            "rubric": "Clinical accuracy and recall",
+            "max_rounds": 1,
+        }
+        store.enqueue_task("t3", "l19-drug-interactions", config=config)
+
+        runner = TaskRunner(store=store, provider=provider)
+        result = runner.run_once()
+
+        assert result is not None
+        payload = json.loads(result["result_json"])
+        assert payload["rubric_calibration"]["num_anchors"] == 2
+        assert payload["rubric_calibration"]["alignment"]["num_pairs"] == 2
+
 
 # ---------------------------------------------------------------------------
 # Serialization


### PR DESCRIPTION
## Summary
- **AC-283**: Infrastructure for validating LLM-generated rubrics against human baselines — measures judge repeatability, computes alignment, and defines per-domain tolerance thresholds

## New Module
| Module | Purpose |
|--------|---------|
| `execution/rubric_calibration.py` | CalibrationAnchor, CalibrationSet, measure_judge_variance(), compute_alignment(), AlignmentTolerance, CalibrationReport |

## Key Design Decisions
- **Domain-agnostic** — CalibrationAnchor and CalibrationSet work for any domain; human scores + score bands provide ground truth
- **Judge variance** — `measure_judge_variance()` computes mean/variance/std_dev/range from repeated scores on identical output; detects unreliable judges before trusting scores
- **Alignment** — `compute_alignment()` computes Pearson correlation, MAE, and systematic bias; positive bias = judge overestimates human expectations
- **AlignmentTolerance** — per-domain thresholds (max MAE, max bias, min correlation) with `check()` that returns pass/fail + violations list
- **CalibrationReport** — aggregate domain report with `calibrated` flag

## Metrics Computed
| Metric | Purpose |
|--------|---------|
| Pearson correlation | Do human and judge scores rank outputs the same way? |
| Mean absolute error | How far are judge scores from human scores on average? |
| Bias | Does the judge systematically over- or under-estimate? |
| Judge std_dev | How much does the judge vary on identical output? |
| Score range | Max - min across repeated judgments |

## Test plan
- [x] 20 tests in `test_rubric_calibration.py`
- [x] CalibrationAnchor: construction, roundtrip
- [x] CalibrationSet: construction, score_bands, roundtrip
- [x] measure_judge_variance: identical (zero), varying, single, empty
- [x] compute_alignment: perfect, systematic overestimation, high correlation with offset, no correlation, empty
- [x] AlignmentTolerance: check passes, check fails on MAE
- [x] CalibrationReport: construction, summary, roundtrip
- [x] ruff clean, mypy clean, full suite 4219 passed