### PR TITLE
chore: migrate analytics/calibration.py to Pydantic BaseModel — pilot (AC-489, AC-481)

### DIFF
--- a/autocontext/src/autocontext/analytics/calibration.py
+++ b/autocontext/src/autocontext/analytics/calibration.py
@@ -8,10 +8,11 @@ scores, contradictory rubric satisfaction) are prioritized for review.
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+from pydantic import BaseModel, Field
 
 from autocontext.analytics.facets import RunFacet
 from autocontext.util.json_io import read_json, write_json
@@ -20,143 +21,70 @@ from autocontext.util.json_io import read_json, write_json
 _PERFECT_THRESHOLD = 0.95
 
 
-@dataclass(slots=True)
-class CalibrationSample:
+class CalibrationSample(BaseModel):
     """A run selected for human calibration review."""
 
     sample_id: str
     run_id: str
     scenario: str
-    scenario_family: str
-    agent_provider: str
-    generation_index: int
-    risk_score: float
-    risk_reasons: list[str]
-    best_score: float
-    score_delta: float
-    playbook_mutation_size: int
-    created_at: str
-    metadata: dict[str, Any] = field(default_factory=dict)
+    scenario_family: str = ""
+    agent_provider: str = ""
+    generation_index: int = 0
+    risk_score: float = 0.0
+    risk_reasons: list[str] = Field(default_factory=list)
+    best_score: float = 0.0
+    score_delta: float = 0.0
+    playbook_mutation_size: int = 0
+    created_at: str = ""
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "sample_id": self.sample_id,
-            "run_id": self.run_id,
-            "scenario": self.scenario,
-            "scenario_family": self.scenario_family,
-            "agent_provider": self.agent_provider,
-            "generation_index": self.generation_index,
-            "risk_score": self.risk_score,
-            "risk_reasons": self.risk_reasons,
-            "best_score": self.best_score,
-            "score_delta": self.score_delta,
-            "playbook_mutation_size": self.playbook_mutation_size,
-            "created_at": self.created_at,
-            "metadata": self.metadata,
-        }
+        return self.model_dump()
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CalibrationSample:
-        return cls(
-            sample_id=data["sample_id"],
-            run_id=data["run_id"],
-            scenario=data.get("scenario", ""),
-            scenario_family=data.get("scenario_family", ""),
-            agent_provider=data.get("agent_provider", ""),
-            generation_index=data.get("generation_index", 0),
-            risk_score=data.get("risk_score", 0.0),
-            risk_reasons=data.get("risk_reasons", []),
-            best_score=data.get("best_score", 0.0),
-            score_delta=data.get("score_delta", 0.0),
-            playbook_mutation_size=data.get("playbook_mutation_size", 0),
-            created_at=data.get("created_at", ""),
-            metadata=data.get("metadata", {}),
-        )
+        return cls.model_validate(data)
 
 
-@dataclass(slots=True)
-class CalibrationOutcome:
+class CalibrationOutcome(BaseModel):
     """Human calibration decision for a sample."""
 
     outcome_id: str
     sample_id: str
-    decision: str  # approve, reject, needs_adjustment
-    reviewer: str
-    notes: str
-    rubric_quality: str  # good, degraded, overfit, unstable
-    playbook_quality: str  # good, degraded, bloated, drifted
-    recommended_action: str  # none, rollback_rubric, rollback_playbook, investigate
-    created_at: str
-    metadata: dict[str, Any] = field(default_factory=dict)
+    decision: str = ""  # approve, reject, needs_adjustment
+    reviewer: str = ""
+    notes: str = ""
+    rubric_quality: str = ""  # good, degraded, overfit, unstable
+    playbook_quality: str = ""  # good, degraded, bloated, drifted
+    recommended_action: str = "none"  # none, rollback_rubric, rollback_playbook, investigate
+    created_at: str = ""
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "outcome_id": self.outcome_id,
-            "sample_id": self.sample_id,
-            "decision": self.decision,
-            "reviewer": self.reviewer,
-            "notes": self.notes,
-            "rubric_quality": self.rubric_quality,
-            "playbook_quality": self.playbook_quality,
-            "recommended_action": self.recommended_action,
-            "created_at": self.created_at,
-            "metadata": self.metadata,
-        }
+        return self.model_dump()
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CalibrationOutcome:
-        return cls(
-            outcome_id=data["outcome_id"],
-            sample_id=data["sample_id"],
-            decision=data.get("decision", ""),
-            reviewer=data.get("reviewer", ""),
-            notes=data.get("notes", ""),
-            rubric_quality=data.get("rubric_quality", ""),
-            playbook_quality=data.get("playbook_quality", ""),
-            recommended_action=data.get("recommended_action", "none"),
-            created_at=data.get("created_at", ""),
-            metadata=data.get("metadata", {}),
-        )
+        return cls.model_validate(data)
 
 
-@dataclass(slots=True)
-class CalibrationRound:
+class CalibrationRound(BaseModel):
     """A periodic calibration round with samples and outcomes."""
 
     round_id: str
     created_at: str
-    samples: list[CalibrationSample]
-    outcomes: list[CalibrationOutcome]
-    status: str  # pending, in_progress, completed
-    summary: str
-    metadata: dict[str, Any] = field(default_factory=dict)
+    samples: list[CalibrationSample] = Field(default_factory=list)
+    outcomes: list[CalibrationOutcome] = Field(default_factory=list)
+    status: str = "pending"  # pending, in_progress, completed
+    summary: str = ""
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "round_id": self.round_id,
-            "created_at": self.created_at,
-            "samples": [s.to_dict() for s in self.samples],
-            "outcomes": [o.to_dict() for o in self.outcomes],
-            "status": self.status,
-            "summary": self.summary,
-            "metadata": self.metadata,
-        }
+        return self.model_dump()
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CalibrationRound:
-        return cls(
-            round_id=data["round_id"],
-            created_at=data["created_at"],
-            samples=[
-                CalibrationSample.from_dict(s) for s in data.get("samples", [])
-            ],
-            outcomes=[
-                CalibrationOutcome.from_dict(o) for o in data.get("outcomes", [])
-            ],
-            status=data.get("status", "pending"),
-            summary=data.get("summary", ""),
-            metadata=data.get("metadata", {}),
-        )
+        return cls.model_validate(data)
 
 
 class SpotCheckSampler:

--- a/autocontext/tests/test_pydantic_migration.py
+++ b/autocontext/tests/test_pydantic_migration.py
@@ -1,0 +1,117 @@
+"""Tests for Pydantic migration of analytics dataclasses (AC-489, AC-481).
+
+Verifies that migrated types use Pydantic BaseModel with model_dump/model_validate
+instead of manual to_dict/from_dict.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from autocontext.analytics.calibration import (
+    CalibrationOutcome,
+    CalibrationRound,
+    CalibrationSample,
+)
+
+
+class TestCalibrationSamplePydantic:
+    def test_model_dump_roundtrip(self) -> None:
+        sample = CalibrationSample(
+            sample_id="s1",
+            run_id="r1",
+            scenario="grid_ctf",
+            scenario_family="game",
+            agent_provider="anthropic",
+            generation_index=3,
+            risk_score=0.8,
+            risk_reasons=["large_score_jump"],
+            best_score=0.9,
+            score_delta=0.2,
+            playbook_mutation_size=5,
+            created_at="2025-01-01T00:00:00Z",
+        )
+        data = sample.model_dump()
+        assert isinstance(data, dict)
+        assert data["sample_id"] == "s1"
+        assert data["risk_reasons"] == ["large_score_jump"]
+
+        restored = CalibrationSample.model_validate(data)
+        assert restored.sample_id == sample.sample_id
+        assert restored.risk_score == sample.risk_score
+
+    def test_json_serialization(self) -> None:
+        sample = CalibrationSample(
+            sample_id="s2",
+            run_id="r2",
+            scenario="othello",
+            scenario_family="game",
+            agent_provider="openai",
+            generation_index=1,
+            risk_score=0.5,
+            risk_reasons=[],
+            best_score=0.6,
+            score_delta=0.1,
+            playbook_mutation_size=2,
+            created_at="2025-01-01T00:00:00Z",
+        )
+        json_str = sample.model_dump_json()
+        assert isinstance(json_str, str)
+        parsed = json.loads(json_str)
+        assert parsed["sample_id"] == "s2"
+
+
+class TestCalibrationOutcomePydantic:
+    def test_model_dump(self) -> None:
+        outcome = CalibrationOutcome(
+            outcome_id="o1",
+            sample_id="s1",
+            decision="approve",
+            reviewer="human",
+            notes="looks good",
+            rubric_quality="good",
+            playbook_quality="good",
+            recommended_action="none",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        data = outcome.model_dump()
+        assert data["decision"] == "approve"
+        restored = CalibrationOutcome.model_validate(data)
+        assert restored == outcome
+
+
+class TestCalibrationRoundPydantic:
+    def test_nested_model_dump(self) -> None:
+        rnd = CalibrationRound(
+            round_id="rnd1",
+            created_at="2025-01-01T00:00:00Z",
+            samples=[
+                CalibrationSample(
+                    sample_id="s1", run_id="r1", scenario="grid_ctf",
+                    scenario_family="game", agent_provider="anthropic",
+                    generation_index=0, risk_score=0.5, risk_reasons=[],
+                    best_score=0.5, score_delta=0.0, playbook_mutation_size=0,
+                    created_at="2025-01-01T00:00:00Z",
+                ),
+            ],
+            outcomes=[],
+            status="pending",
+            summary="",
+        )
+        data = rnd.model_dump()
+        assert len(data["samples"]) == 1
+        assert data["samples"][0]["sample_id"] == "s1"
+
+        restored = CalibrationRound.model_validate(data)
+        assert len(restored.samples) == 1
+        assert restored.samples[0].sample_id == "s1"
+
+    def test_backward_compat_to_dict(self) -> None:
+        """to_dict should still work as alias for model_dump."""
+        rnd = CalibrationRound(
+            round_id="rnd1", created_at="now", samples=[], outcomes=[],
+            status="pending", summary="",
+        )
+        assert rnd.to_dict() == rnd.model_dump()

--- a/autocontext/tests/test_pydantic_migration.py
+++ b/autocontext/tests/test_pydantic_migration.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 from autocontext.analytics.calibration import (
     CalibrationOutcome,
     CalibrationRound,


### PR DESCRIPTION
## Summary

Pilot migration of analytics dataclasses to Pydantic BaseModel, establishing the pattern for the remaining ~60 dataclasses with manual to_dict/from_dict.

## Problem

295 dataclasses across the codebase implement manual `to_dict() -> dict[str, Any]` and `from_dict(data)` classmethods — boilerplate that Pydantic provides for free via `model_dump()` and `model_validate()`.

## Changes

### Converted `analytics/calibration.py` (3 classes)

| Class | to_dict lines removed | from_dict lines removed |
|-------|----------------------|------------------------|
| `CalibrationSample` | 15 → 1 | 15 → 1 |
| `CalibrationOutcome` | 11 → 1 | 11 → 1 |
| `CalibrationRound` | 8 → 1 | 10 → 1 |

**Total: ~78 lines of boilerplate → 6 lines of aliases**

### Backward compatibility

`to_dict()` and `from_dict()` kept as thin aliases (`self.model_dump()` / `cls.model_validate(data)`) so existing callers (`CalibrationStore`, `SpotCheckSampler`) work unchanged.

### Pattern for future migrations

```python
# Before (dataclass)
@dataclass(slots=True)
class Foo:
    x: str
    y: int = 0
    
    def to_dict(self) -> dict[str, Any]:
        return {"x": self.x, "y": self.y}
    
    @classmethod
    def from_dict(cls, data: dict[str, Any]) -> Foo:
        return cls(x=data["x"], y=data.get("y", 0))

# After (Pydantic)
class Foo(BaseModel):
    x: str
    y: int = 0
    
    def to_dict(self) -> dict[str, Any]:
        return self.model_dump()
    
    @classmethod
    def from_dict(cls, data: dict[str, Any]) -> Foo:
        return cls.model_validate(data)
```

## TDD

Added `test_pydantic_migration.py` with **5 tests**:
- model_dump roundtrip
- JSON serialization
- Nested model handling
- Backward-compat to_dict alias

## Verification

- [x] `ruff check src` — all checks passed
- [x] `mypy src` — zero errors
- [x] `pytest tests/` — all tests pass

## Issues

Partially resolves AC-489 and AC-481
