### PR TITLE
feat: derived progress digests for operator surfaces (AC-512)

### DIFF
--- a/autocontext/src/autocontext/session/progress_digest.py
+++ b/autocontext/src/autocontext/session/progress_digest.py
@@ -1,0 +1,127 @@
+"""Derived progress digests for operator surfaces (AC-512).
+
+Domain concepts:
+- WorkerDigest: compact status of one active worker
+- ProgressDigest: aggregate summary derived from coordinator/session state
+- Designed for operator re-entry: what's happening, what changed, what's next
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from autocontext.session.coordinator import Coordinator, Worker
+    from autocontext.session.types import Session
+
+
+class WorkerDigest(BaseModel):
+    """Compact operator-facing status of one worker."""
+
+    worker_id: str
+    role: str
+    status: str
+    current_action: str
+    last_result: str = ""
+
+    @classmethod
+    def from_worker(cls, worker: Worker) -> WorkerDigest:
+        return cls(
+            worker_id=worker.worker_id,
+            role=worker.role,
+            status=worker.status.value,
+            current_action=worker.task[:200],
+            last_result=worker.result[:200] if worker.result else "",
+        )
+
+    model_config = {"frozen": True}
+
+
+class ProgressDigest(BaseModel):
+    """Aggregate operator-facing summary.
+
+    Derived from coordinator and/or session state — never persisted
+    as primary data, always recomputable from source signals.
+    """
+
+    goal: str = ""
+    summary: str = ""
+    active_count: int = 0
+    completed_count: int = 0
+    failed_count: int = 0
+    turn_count: int = 0
+    worker_digests: list[WorkerDigest] = Field(default_factory=list)
+    recent_changes: list[str] = Field(default_factory=list)
+
+    @classmethod
+    def from_coordinator(
+        cls,
+        coordinator: Coordinator,
+        max_recent_events: int = 10,
+    ) -> ProgressDigest:
+        """Build digest from coordinator state and events."""
+        from autocontext.session.coordinator import WorkerStatus
+
+        worker_digests = [WorkerDigest.from_worker(w) for w in coordinator.workers]
+        active = [w for w in coordinator.workers if w.is_active]
+        completed = [w for w in coordinator.workers if w.status == WorkerStatus.COMPLETED]
+        failed = [w for w in coordinator.workers if w.status == WorkerStatus.FAILED]
+
+        # Build short summary
+        parts: list[str] = []
+        if not coordinator.workers:
+            parts.append("Idle — no workers delegated yet.")
+        else:
+            if active:
+                tasks = ", ".join(w.task[:50] for w in active[:3])
+                parts.append(f"{len(active)} active: {tasks}")
+            if completed:
+                parts.append(f"{len(completed)} completed")
+            if failed:
+                parts.append(f"{len(failed)} failed")
+        summary = ". ".join(parts)[:300]
+
+        # Recent changes from event stream
+        recent = []
+        for event in coordinator.events[-max_recent_events:]:
+            label = event.event_type.value.replace("_", " ")
+            recent.append(f"{label}: {_compact_payload(event.payload)}")
+
+        return cls(
+            goal=coordinator.goal,
+            summary=summary,
+            active_count=len(active),
+            completed_count=len(completed),
+            failed_count=len(failed),
+            worker_digests=worker_digests,
+            recent_changes=recent,
+        )
+
+    @classmethod
+    def from_session(cls, session: Session) -> ProgressDigest:
+        """Build digest from a plain session (no coordinator)."""
+        return cls(
+            goal=session.goal,
+            summary=f"Session with {len(session.turns)} turn(s).",
+            turn_count=len(session.turns),
+        )
+
+    @classmethod
+    def empty(cls) -> ProgressDigest:
+        """Safe fallback when no signal is available."""
+        return cls(summary="No active work.")
+
+    model_config = {"frozen": True}
+
+
+def _compact_payload(payload: dict[str, Any]) -> str:
+    """Render event payload as a short string."""
+    parts = []
+    for k, v in payload.items():
+        if k == "coordinator_id":
+            continue
+        sv = str(v)[:60]
+        parts.append(f"{k}={sv}")
+    return ", ".join(parts[:4])

--- a/autocontext/src/autocontext/session/progress_digest.py
+++ b/autocontext/src/autocontext/session/progress_digest.py
@@ -51,6 +51,7 @@ class ProgressDigest(BaseModel):
     active_count: int = 0
     completed_count: int = 0
     failed_count: int = 0
+    redirected_count: int = 0
     turn_count: int = 0
     worker_digests: list[WorkerDigest] = Field(default_factory=list)
     recent_changes: list[str] = Field(default_factory=list)
@@ -68,6 +69,7 @@ class ProgressDigest(BaseModel):
         active = [w for w in coordinator.workers if w.is_active]
         completed = [w for w in coordinator.workers if w.status == WorkerStatus.COMPLETED]
         failed = [w for w in coordinator.workers if w.status == WorkerStatus.FAILED]
+        redirected = [w for w in coordinator.workers if w.status == WorkerStatus.REDIRECTED]
 
         # Build short summary
         parts: list[str] = []
@@ -81,6 +83,8 @@ class ProgressDigest(BaseModel):
                 parts.append(f"{len(completed)} completed")
             if failed:
                 parts.append(f"{len(failed)} failed")
+            if redirected:
+                parts.append(f"{len(redirected)} redirected")
         summary = ". ".join(parts)[:300]
 
         # Recent changes from event stream
@@ -95,6 +99,7 @@ class ProgressDigest(BaseModel):
             active_count=len(active),
             completed_count=len(completed),
             failed_count=len(failed),
+            redirected_count=len(redirected),
             worker_digests=worker_digests,
             recent_changes=recent,
         )

--- a/autocontext/tests/test_progress_digests.py
+++ b/autocontext/tests/test_progress_digests.py
@@ -1,0 +1,113 @@
+"""Tests for derived progress digests (AC-512).
+
+DDD: DigestBuilder derives compact operator-facing summaries from
+session events, coordinator state, and heartbeat signals.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestWorkerDigest:
+    """Compact status of one active worker."""
+
+    def test_create_from_worker(self) -> None:
+        from autocontext.session.coordinator import Worker
+        from autocontext.session.progress_digest import WorkerDigest
+
+        worker = Worker.create(task="Research auth libraries", role="researcher")
+        worker.start()
+        digest = WorkerDigest.from_worker(worker)
+        assert digest.worker_id == worker.worker_id
+        assert digest.role == "researcher"
+        assert digest.current_action == "Research auth libraries"
+        assert digest.status == "running"
+
+    def test_completed_worker_digest(self) -> None:
+        from autocontext.session.coordinator import Worker
+        from autocontext.session.progress_digest import WorkerDigest
+
+        worker = Worker.create(task="t1", role="r1")
+        worker.start()
+        worker.complete(result="Found 3 options")
+        digest = WorkerDigest.from_worker(worker)
+        assert digest.status == "completed"
+        assert "Found 3 options" in digest.last_result
+
+
+class TestProgressDigest:
+    """Aggregate summary: active workers, recent changes, next step."""
+
+    def test_build_from_coordinator(self) -> None:
+        from autocontext.session.coordinator import Coordinator
+        from autocontext.session.progress_digest import ProgressDigest
+
+        coord = Coordinator.create(session_id="s1", goal="Build API")
+        w1 = coord.delegate(task="Research auth", role="researcher")
+        w2 = coord.delegate(task="Research DB", role="researcher")
+        w1.start()
+        w2.start()
+        w1.complete(result="OAuth2 recommended")
+
+        digest = ProgressDigest.from_coordinator(coord)
+        assert digest.goal == "Build API"
+        assert digest.active_count == 1
+        assert digest.completed_count == 1
+        assert len(digest.worker_digests) == 2
+
+    def test_digest_summary_is_short(self) -> None:
+        from autocontext.session.coordinator import Coordinator
+        from autocontext.session.progress_digest import ProgressDigest
+
+        coord = Coordinator.create(session_id="s1", goal="test")
+        w = coord.delegate(task="long task name " * 20, role="r1")
+        w.start()
+
+        digest = ProgressDigest.from_coordinator(coord)
+        assert len(digest.summary) <= 300  # skimmable, not a wall of text
+
+    def test_empty_coordinator_digest(self) -> None:
+        from autocontext.session.coordinator import Coordinator
+        from autocontext.session.progress_digest import ProgressDigest
+
+        coord = Coordinator.create(session_id="s1", goal="test")
+        digest = ProgressDigest.from_coordinator(coord)
+        assert digest.active_count == 0
+        assert "no workers" in digest.summary.lower() or "idle" in digest.summary.lower()
+
+    def test_recent_changes_from_events(self) -> None:
+        from autocontext.session.coordinator import Coordinator
+        from autocontext.session.progress_digest import ProgressDigest
+
+        coord = Coordinator.create(session_id="s1", goal="test")
+        w = coord.delegate(task="t1", role="r1")
+        w.start()
+        coord.complete_worker(w.worker_id, result="done")
+
+        digest = ProgressDigest.from_coordinator(coord, max_recent_events=5)
+        assert len(digest.recent_changes) > 0
+
+
+class TestDigestDegradation:
+    """Digests degrade gracefully with insufficient signal."""
+
+    def test_digest_from_session_without_coordinator(self) -> None:
+        from autocontext.session.progress_digest import ProgressDigest
+        from autocontext.session.types import Session
+
+        session = Session.create(goal="Simple task")
+        session.submit_turn(prompt="do something", role="competitor")
+
+        digest = ProgressDigest.from_session(session)
+        assert digest.goal == "Simple task"
+        assert digest.active_count == 0  # no coordinator
+        assert digest.turn_count == 1
+
+    def test_digest_never_crashes(self) -> None:
+        from autocontext.session.progress_digest import ProgressDigest
+
+        # Empty inputs
+        digest = ProgressDigest.empty()
+        assert digest.summary
+        assert digest.active_count == 0

--- a/autocontext/tests/test_progress_digests.py
+++ b/autocontext/tests/test_progress_digests.py
@@ -6,8 +6,6 @@ session events, coordinator state, and heartbeat signals.
 
 from __future__ import annotations
 
-import pytest
-
 
 class TestWorkerDigest:
     """Compact status of one active worker."""
@@ -87,6 +85,21 @@ class TestProgressDigest:
 
         digest = ProgressDigest.from_coordinator(coord, max_recent_events=5)
         assert len(digest.recent_changes) > 0
+
+    def test_redirected_workers_still_appear_in_digest_summary(self) -> None:
+        from autocontext.session.coordinator import Coordinator
+        from autocontext.session.progress_digest import ProgressDigest
+
+        coord = Coordinator.create(session_id="s1", goal="test")
+        w = coord.delegate(task="t1", role="r1")
+        w.start()
+        coord.stop_worker(w.worker_id, reason="dead end")
+
+        digest = ProgressDigest.from_coordinator(coord)
+        assert digest.redirected_count == 1
+        assert "redirected" in digest.summary.lower()
+        assert len(digest.worker_digests) == 1
+        assert digest.worker_digests[0].status == "redirected"
 
 
 class TestDigestDegradation:


### PR DESCRIPTION
## Summary

Adds derived progress digests — compact, operator-facing summaries derived from coordinator and session state. Designed for fast re-entry: "what's happening, what changed, what's next" in a few seconds.

## Domain Model (DDD)

### `WorkerDigest` (value object)
Compact status of one worker, derived from `Worker` entity:
```python
WorkerDigest.from_worker(worker)
→ {worker_id, role, status, current_action, last_result}
```

### `ProgressDigest` (value object)
Aggregate summary derived from runtime state:
```python
digest = ProgressDigest.from_coordinator(coord)
digest.summary       # "2 active: Research auth, Research DB. 1 completed"
digest.active_count  # 2
digest.recent_changes  # ["worker delegated: task=Research auth", ...]
```

Factory methods:
- `from_coordinator()` — full worker-aware digest with events
- `from_session()` — lightweight turn-count-only digest
- `empty()` — safe fallback for no signal

## Key Design Rules

1. **Derived, never primary** — always recomputable from persisted signals
2. **Skimmable** — summary capped at 300 chars
3. **Degrades safely** — empty coordinator → "idle", no coordinator → turn count, no signal → default

## TDD

8 tests: worker digest creation, coordinator digest, summary length cap, empty state, recent changes from events, session-only fallback, safe degradation.

## Session Package — 8 modules, 85 TDD tests

| Module | Tests |
|--------|-------|
| `types.py` | 12 |
| `context_pressure.py` | 13 |
| `supervisor.py` | 13 |
| `coordinator.py` | 15 |
| `memory_consolidation.py` | 13 |
| `skill_registry.py` | 11 |
| `progress_digest.py` | 8 |
| **Total** | **85** |

## Verification

- [x] `ruff check src` — all checks passed
- [x] `mypy src` — zero errors
- [x] `pytest tests/` — all tests pass

## Issue

Resolves AC-512
