### PR TITLE
feat: compact action labels for timelines and event feeds (AC-513)

### DIFF
--- a/autocontext/src/autocontext/session/action_labels.py
+++ b/autocontext/src/autocontext/session/action_labels.py
@@ -11,6 +11,9 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
+from autocontext.session.coordinator import CoordinatorEventType
+from autocontext.session.types import SessionEventType
+
 if TYPE_CHECKING:
     from autocontext.session.coordinator import Coordinator, CoordinatorEvent
     from autocontext.session.types import SessionEvent
@@ -18,8 +21,11 @@ if TYPE_CHECKING:
 _MAX_LABEL_LEN = 120
 
 _FAILURE_EVENT_TYPES = frozenset({
-    "worker_failed", "turn_failed", "turn_interrupted",
-    "session_failed", "session_canceled",
+    CoordinatorEventType.WORKER_FAILED.value,
+    SessionEventType.TURN_FAILED.value,
+    SessionEventType.TURN_INTERRUPTED.value,
+    SessionEventType.SESSION_FAILED.value,
+    SessionEventType.SESSION_CANCELED.value,
 })
 
 _EVENT_LABEL_MAP: dict[str, str] = {
@@ -87,6 +93,7 @@ def label_from_event(event: CoordinatorEvent | SessionEvent) -> ActionLabel:
             detail_parts.append(f"{key}={str(val)[:40]}")
 
     if detail_parts:
+        # Keep labels glanceable in narrow timeline views rather than dumping every payload field.
         detail = ", ".join(detail_parts[:3])
         text = f"{base}: {detail}"
     else:

--- a/autocontext/src/autocontext/session/action_labels.py
+++ b/autocontext/src/autocontext/session/action_labels.py
@@ -1,0 +1,105 @@
+"""Compact action labels for timelines and event feeds (AC-513).
+
+Domain concept: ActionLabel is a value object — a short, scannable
+description of what just happened. Derived from events, not stored
+as primary data.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from autocontext.session.coordinator import Coordinator, CoordinatorEvent
+    from autocontext.session.types import SessionEvent
+
+_MAX_LABEL_LEN = 120
+
+_FAILURE_EVENT_TYPES = frozenset({
+    "worker_failed", "turn_failed", "turn_interrupted",
+    "session_failed", "session_canceled",
+})
+
+_EVENT_LABEL_MAP: dict[str, str] = {
+    "coordinator_created": "Coordinator started",
+    "worker_delegated": "Worker delegated",
+    "worker_started": "Worker started",
+    "worker_completed": "Worker completed",
+    "worker_failed": "Worker failed",
+    "worker_redirected": "Worker redirected",
+    "fan_out": "Fan-out dispatched",
+    "fan_in": "Fan-in collected",
+    "session_created": "Session started",
+    "session_paused": "Session paused",
+    "session_resumed": "Session resumed",
+    "session_completed": "Session completed",
+    "session_failed": "Session failed",
+    "session_canceled": "Session canceled",
+    "turn_submitted": "Turn submitted",
+    "turn_completed": "Turn completed",
+    "turn_interrupted": "Turn interrupted",
+    "turn_failed": "Turn failed",
+}
+
+
+class ActionLabel(BaseModel):
+    """Short, scannable description for timeline/event display.
+
+    Categories: action, tool, failure, noop, info
+    """
+
+    text: str
+    category: str = "action"
+
+    @classmethod
+    def create(cls, text: str, category: str = "action") -> ActionLabel:
+        truncated = _truncate(text)
+        return cls(text=truncated, category=category)
+
+    @classmethod
+    def noop(cls, reason: str = "No changes") -> ActionLabel:
+        return cls(text=_truncate(reason), category="noop")
+
+    model_config = {"frozen": True}
+
+
+def _truncate(text: str) -> str:
+    """Truncate to _MAX_LABEL_LEN with ellipsis."""
+    text = text.strip().replace("\n", " ")
+    if len(text) <= _MAX_LABEL_LEN:
+        return text
+    return text[: _MAX_LABEL_LEN - 1] + "…"
+
+
+def label_from_event(event: CoordinatorEvent | SessionEvent) -> ActionLabel:
+    """Derive a compact label from a coordinator or session event."""
+    event_type = event.event_type.value
+    base = _EVENT_LABEL_MAP.get(event_type, event_type.replace("_", " ").title())
+
+    # Enrich with payload details
+    payload = event.payload
+    detail_parts: list[str] = []
+    for key in ("task", "role", "reason", "error", "worker_id", "turn_id"):
+        val = payload.get(key)
+        if val:
+            detail_parts.append(f"{key}={str(val)[:40]}")
+
+    if detail_parts:
+        detail = ", ".join(detail_parts[:3])
+        text = f"{base}: {detail}"
+    else:
+        text = base
+
+    category = "failure" if event_type in _FAILURE_EVENT_TYPES else "action"
+    return ActionLabel.create(text, category=category)
+
+
+def labels_from_coordinator(
+    coordinator: Coordinator,
+    max_labels: int = 20,
+) -> list[ActionLabel]:
+    """Generate labels from the coordinator's recent events."""
+    events = coordinator.events[-max_labels:]
+    return [label_from_event(e) for e in events]

--- a/autocontext/tests/test_action_labels.py
+++ b/autocontext/tests/test_action_labels.py
@@ -1,0 +1,105 @@
+"""Tests for compact action labels (AC-513).
+
+DDD: ActionLabel is a value object — a short, scannable description
+derived from events, tool calls, and step outcomes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestActionLabel:
+    """ActionLabel value object for timeline/event display."""
+
+    def test_create_from_text(self) -> None:
+        from autocontext.session.action_labels import ActionLabel
+
+        label = ActionLabel.create("Wrote unit tests for auth module")
+        assert label.text == "Wrote unit tests for auth module"
+        assert label.category == "action"
+
+    def test_truncates_long_text(self) -> None:
+        from autocontext.session.action_labels import ActionLabel
+
+        label = ActionLabel.create("x" * 500)
+        assert len(label.text) <= 120
+        assert label.text.endswith("…")
+
+    def test_category_tagging(self) -> None:
+        from autocontext.session.action_labels import ActionLabel
+
+        assert ActionLabel.create("Ran tests", category="tool").category == "tool"
+        assert ActionLabel.create("Error: timeout", category="failure").category == "failure"
+
+    def test_noop_label(self) -> None:
+        from autocontext.session.action_labels import ActionLabel
+
+        label = ActionLabel.noop("No changes needed")
+        assert label.category == "noop"
+
+
+class TestLabelFromEvent:
+    """Labels derived from coordinator/session events."""
+
+    def test_from_coordinator_event(self) -> None:
+        from autocontext.session.action_labels import label_from_event
+        from autocontext.session.coordinator import CoordinatorEvent, CoordinatorEventType
+
+        event = CoordinatorEvent(
+            event_type=CoordinatorEventType.WORKER_COMPLETED,
+            payload={"worker_id": "w1", "coordinator_id": "c1"},
+        )
+        label = label_from_event(event)
+        assert "completed" in label.text.lower()
+        assert label.category == "action"
+
+    def test_from_session_event(self) -> None:
+        from autocontext.session.action_labels import label_from_event
+        from autocontext.session.types import SessionEvent, SessionEventType
+
+        event = SessionEvent(
+            event_type=SessionEventType.TURN_COMPLETED,
+            payload={"session_id": "s1", "turn_id": "t1", "tokens_used": 150},
+        )
+        label = label_from_event(event)
+        assert label.text
+        assert label.category == "action"
+
+    def test_failure_event_gets_failure_category(self) -> None:
+        from autocontext.session.action_labels import label_from_event
+        from autocontext.session.coordinator import CoordinatorEvent, CoordinatorEventType
+
+        event = CoordinatorEvent(
+            event_type=CoordinatorEventType.WORKER_FAILED,
+            payload={"worker_id": "w1", "error": "timeout"},
+        )
+        label = label_from_event(event)
+        assert label.category == "failure"
+
+
+class TestLabelBatch:
+    """Batch labeling for timeline display."""
+
+    def test_label_batch_from_coordinator(self) -> None:
+        from autocontext.session.action_labels import labels_from_coordinator
+        from autocontext.session.coordinator import Coordinator
+
+        coord = Coordinator.create(session_id="s1", goal="test")
+        w = coord.delegate(task="Research auth", role="researcher")
+        w.start()
+        coord.complete_worker(w.worker_id, result="done")
+
+        labels = labels_from_coordinator(coord, max_labels=10)
+        assert len(labels) >= 2  # at least delegated + completed
+
+    def test_max_labels_respected(self) -> None:
+        from autocontext.session.action_labels import labels_from_coordinator
+        from autocontext.session.coordinator import Coordinator
+
+        coord = Coordinator.create(session_id="s1", goal="test")
+        for i in range(20):
+            coord.delegate(task=f"task-{i}", role="r1")
+
+        labels = labels_from_coordinator(coord, max_labels=5)
+        assert len(labels) <= 5

--- a/autocontext/tests/test_action_labels.py
+++ b/autocontext/tests/test_action_labels.py
@@ -6,8 +6,6 @@ derived from events, tool calls, and step outcomes.
 
 from __future__ import annotations
 
-import pytest
-
 
 class TestActionLabel:
     """ActionLabel value object for timeline/event display."""
@@ -91,7 +89,14 @@ class TestLabelBatch:
         coord.complete_worker(w.worker_id, result="done")
 
         labels = labels_from_coordinator(coord, max_labels=10)
-        assert len(labels) >= 2  # at least delegated + completed
+        assert len(labels) == len(coord.events) == 3
+        assert labels[0].text == "Coordinator started"
+        assert labels[1].text.startswith("Worker delegated:")
+        assert "task=Research auth" in labels[1].text
+        assert "role=researcher" in labels[1].text
+        assert "worker_id=" in labels[1].text
+        assert labels[2].text.startswith("Worker completed:")
+        assert "worker_id=" in labels[2].text
 
     def test_max_labels_respected(self) -> None:
         from autocontext.session.action_labels import labels_from_coordinator
@@ -102,4 +107,5 @@ class TestLabelBatch:
             coord.delegate(task=f"task-{i}", role="r1")
 
         labels = labels_from_coordinator(coord, max_labels=5)
-        assert len(labels) <= 5
+        assert len(labels) == 5
+        assert all(label.text.startswith("Worker delegated") for label in labels)


### PR DESCRIPTION
Adds ActionLabel value object — short, scannable descriptions (≤120 chars) derived from coordinator/session events. Labels auto-categorize as action/failure/noop with payload enrichment. Batch generation via labels_from_coordinator(). 9 TDD tests. Resolves AC-513.