### PR TITLE
feat: remote mission bridge with delegated approval relay (AC-514)

### DIFF
--- a/autocontext/src/autocontext/session/remote_bridge.py
+++ b/autocontext/src/autocontext/session/remote_bridge.py
@@ -1,0 +1,138 @@
+"""Remote mission bridge with delegated approval relay (AC-514).
+
+Domain concepts:
+- RemoteSession: one connected observer or controller
+- SessionRole: viewer (read-only) or controller (can approve/control)
+- ApprovalRequest: delegated approval with status tracking
+- RemoteBridge: aggregate managing connections and approval relay
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class SessionRole(StrEnum):
+    VIEWER = "viewer"
+    CONTROLLER = "controller"
+
+
+class RemoteSession(BaseModel):
+    """One connected remote observer or controller."""
+
+    remote_session_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:12])
+    session_id: str
+    operator: str
+    role: SessionRole
+    connected_at: str = Field(default_factory=_now)
+
+    @classmethod
+    def create(cls, session_id: str, operator: str, role: SessionRole) -> RemoteSession:
+        return cls(session_id=session_id, operator=operator, role=role)
+
+    @property
+    def can_approve(self) -> bool:
+        return self.role == SessionRole.CONTROLLER
+
+    @property
+    def can_control(self) -> bool:
+        return self.role == SessionRole.CONTROLLER
+
+
+class ApprovalRequest(BaseModel):
+    """A delegated approval with status tracking and audit."""
+
+    request_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:12])
+    action: str
+    context: str = ""
+    status: str = "pending"  # pending, approved, denied, timed_out, canceled
+    decided_by: str = ""
+    denial_reason: str = ""
+    created_at: str = Field(default_factory=_now)
+    decided_at: str = ""
+
+    @classmethod
+    def create(cls, action: str, context: str = "") -> ApprovalRequest:
+        return cls(action=action, context=context)
+
+    def approve(self, by: str) -> None:
+        self.status = "approved"
+        self.decided_by = by
+        self.decided_at = _now()
+
+    def deny(self, by: str, reason: str = "") -> None:
+        self.status = "denied"
+        self.decided_by = by
+        self.denial_reason = reason
+        self.decided_at = _now()
+
+    def timeout(self) -> None:
+        self.status = "timed_out"
+        self.decided_at = _now()
+
+    def cancel(self) -> None:
+        self.status = "canceled"
+        self.decided_at = _now()
+
+
+class RemoteBridge:
+    """Manages remote sessions and approval relay for a mission.
+
+    Enforces role-based access: viewers observe, controllers approve.
+    """
+
+    def __init__(self, mission_id: str) -> None:
+        self.mission_id = mission_id
+        self._sessions: dict[str, RemoteSession] = {}
+        self._approvals: dict[str, ApprovalRequest] = {}
+
+    def connect(self, operator: str, role: SessionRole) -> RemoteSession:
+        session = RemoteSession.create(
+            session_id=self.mission_id, operator=operator, role=role,
+        )
+        self._sessions[session.remote_session_id] = session
+        return session
+
+    def disconnect(self, remote_session_id: str) -> None:
+        self._sessions.pop(remote_session_id, None)
+
+    @property
+    def connected_sessions(self) -> list[RemoteSession]:
+        return list(self._sessions.values())
+
+    def request_approval(self, action: str, context: str = "") -> ApprovalRequest:
+        req = ApprovalRequest.create(action=action, context=context)
+        self._approvals[req.request_id] = req
+        return req
+
+    @property
+    def pending_approvals(self) -> list[ApprovalRequest]:
+        return [a for a in self._approvals.values() if a.status == "pending"]
+
+    def respond(self, request_id: str, approved: bool, by: str, reason: str = "") -> None:
+        """Respond to an approval request. Only controllers may respond."""
+        # Check operator role
+        operator_session = next(
+            (s for s in self._sessions.values() if s.operator == by), None
+        )
+        if operator_session is not None and operator_session.role == SessionRole.VIEWER:
+            msg = f"Operator '{by}' is a viewer and cannot respond to approvals"
+            raise PermissionError(msg)
+
+        req = self._approvals.get(request_id)
+        if req is None:
+            msg = f"Approval request '{request_id}' not found"
+            raise KeyError(msg)
+
+        if approved:
+            req.approve(by=by)
+        else:
+            req.deny(by=by, reason=reason)

--- a/autocontext/src/autocontext/session/remote_bridge.py
+++ b/autocontext/src/autocontext/session/remote_bridge.py
@@ -64,23 +64,32 @@ class ApprovalRequest(BaseModel):
         return cls(action=action, context=context)
 
     def approve(self, by: str) -> None:
+        self._require_pending(action="approve request")
         self.status = "approved"
         self.decided_by = by
         self.decided_at = _now()
 
     def deny(self, by: str, reason: str = "") -> None:
+        self._require_pending(action="deny request")
         self.status = "denied"
         self.decided_by = by
         self.denial_reason = reason
         self.decided_at = _now()
 
     def timeout(self) -> None:
+        self._require_pending(action="time out request")
         self.status = "timed_out"
         self.decided_at = _now()
 
     def cancel(self) -> None:
+        self._require_pending(action="cancel request")
         self.status = "canceled"
         self.decided_at = _now()
+
+    def _require_pending(self, action: str) -> None:
+        if self.status != "pending":
+            msg = f"Cannot {action} once status={self.status}"
+            raise ValueError(msg)
 
 
 class RemoteBridge:
@@ -123,7 +132,10 @@ class RemoteBridge:
         operator_session = next(
             (s for s in self._sessions.values() if s.operator == by), None
         )
-        if operator_session is not None and operator_session.role == SessionRole.VIEWER:
+        if operator_session is None:
+            msg = f"Operator '{by}' is not connected and cannot respond to approvals"
+            raise PermissionError(msg)
+        if operator_session.role != SessionRole.CONTROLLER:
             msg = f"Operator '{by}' is a viewer and cannot respond to approvals"
             raise PermissionError(msg)
 

--- a/autocontext/tests/test_remote_bridge.py
+++ b/autocontext/tests/test_remote_bridge.py
@@ -1,0 +1,131 @@
+"""Tests for remote mission bridge (AC-514).
+
+DDD: RemoteBridge manages observation and approval relay.
+RemoteSession tracks one connected observer/controller.
+ApprovalRequest models delegated approval flow.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestRemoteSession:
+    """A connected remote observer or controller."""
+
+    def test_create_viewer(self) -> None:
+        from autocontext.session.remote_bridge import RemoteSession, SessionRole
+
+        session = RemoteSession.create(
+            session_id="s1", operator="alice", role=SessionRole.VIEWER
+        )
+        assert session.operator == "alice"
+        assert session.role == SessionRole.VIEWER
+        assert not session.can_approve
+
+    def test_create_controller(self) -> None:
+        from autocontext.session.remote_bridge import RemoteSession, SessionRole
+
+        session = RemoteSession.create(
+            session_id="s1", operator="bob", role=SessionRole.CONTROLLER
+        )
+        assert session.can_approve
+
+    def test_viewer_cannot_approve(self) -> None:
+        from autocontext.session.remote_bridge import RemoteSession, SessionRole
+
+        session = RemoteSession.create(
+            session_id="s1", operator="alice", role=SessionRole.VIEWER
+        )
+        assert not session.can_approve
+        assert not session.can_control
+
+
+class TestApprovalRequest:
+    """Delegated approval with timeout and audit."""
+
+    def test_create_request(self) -> None:
+        from autocontext.session.remote_bridge import ApprovalRequest
+
+        req = ApprovalRequest.create(
+            action="deploy to production",
+            context="All tests pass, ready to deploy",
+        )
+        assert req.request_id
+        assert req.action == "deploy to production"
+        assert req.status == "pending"
+
+    def test_approve(self) -> None:
+        from autocontext.session.remote_bridge import ApprovalRequest
+
+        req = ApprovalRequest.create(action="deploy")
+        req.approve(by="bob")
+        assert req.status == "approved"
+        assert req.decided_by == "bob"
+
+    def test_deny(self) -> None:
+        from autocontext.session.remote_bridge import ApprovalRequest
+
+        req = ApprovalRequest.create(action="deploy")
+        req.deny(by="alice", reason="Not ready")
+        assert req.status == "denied"
+        assert req.denial_reason == "Not ready"
+
+    def test_timeout(self) -> None:
+        from autocontext.session.remote_bridge import ApprovalRequest
+
+        req = ApprovalRequest.create(action="deploy")
+        req.timeout()
+        assert req.status == "timed_out"
+
+
+class TestRemoteBridge:
+    """Bridge manages remote sessions and approval relay."""
+
+    def test_connect_observer(self) -> None:
+        from autocontext.session.remote_bridge import RemoteBridge, SessionRole
+
+        bridge = RemoteBridge(mission_id="m1")
+        session = bridge.connect(operator="alice", role=SessionRole.VIEWER)
+        assert len(bridge.connected_sessions) == 1
+        assert not session.can_approve
+
+    def test_request_approval_routed_to_controllers(self) -> None:
+        from autocontext.session.remote_bridge import RemoteBridge, SessionRole
+
+        bridge = RemoteBridge(mission_id="m1")
+        bridge.connect(operator="alice", role=SessionRole.VIEWER)
+        bridge.connect(operator="bob", role=SessionRole.CONTROLLER)
+
+        req = bridge.request_approval(action="deploy", context="ready")
+        assert req.status == "pending"
+        assert len(bridge.pending_approvals) == 1
+
+    def test_respond_to_approval(self) -> None:
+        from autocontext.session.remote_bridge import RemoteBridge, SessionRole
+
+        bridge = RemoteBridge(mission_id="m1")
+        bridge.connect(operator="bob", role=SessionRole.CONTROLLER)
+        req = bridge.request_approval(action="deploy", context="ready")
+
+        bridge.respond(req.request_id, approved=True, by="bob")
+        assert req.status == "approved"
+        assert len(bridge.pending_approvals) == 0
+
+    def test_viewer_cannot_respond(self) -> None:
+        from autocontext.session.remote_bridge import RemoteBridge, SessionRole
+
+        bridge = RemoteBridge(mission_id="m1")
+        bridge.connect(operator="alice", role=SessionRole.VIEWER)
+        req = bridge.request_approval(action="deploy", context="ready")
+
+        with pytest.raises(PermissionError, match="viewer"):
+            bridge.respond(req.request_id, approved=True, by="alice")
+
+    def test_disconnect(self) -> None:
+        from autocontext.session.remote_bridge import RemoteBridge, SessionRole
+
+        bridge = RemoteBridge(mission_id="m1")
+        session = bridge.connect(operator="alice", role=SessionRole.VIEWER)
+        bridge.disconnect(session.remote_session_id)
+        assert len(bridge.connected_sessions) == 0

--- a/autocontext/tests/test_remote_bridge.py
+++ b/autocontext/tests/test_remote_bridge.py
@@ -78,6 +78,15 @@ class TestApprovalRequest:
         req.timeout()
         assert req.status == "timed_out"
 
+    def test_decision_is_terminal(self) -> None:
+        from autocontext.session.remote_bridge import ApprovalRequest
+
+        req = ApprovalRequest.create(action="deploy")
+        req.approve(by="bob")
+
+        with pytest.raises(ValueError, match="status=approved"):
+            req.deny(by="bob", reason="changed my mind")
+
 
 class TestRemoteBridge:
     """Bridge manages remote sessions and approval relay."""
@@ -121,6 +130,16 @@ class TestRemoteBridge:
 
         with pytest.raises(PermissionError, match="viewer"):
             bridge.respond(req.request_id, approved=True, by="alice")
+
+    def test_unconnected_operator_cannot_respond(self) -> None:
+        from autocontext.session.remote_bridge import RemoteBridge, SessionRole
+
+        bridge = RemoteBridge(mission_id="m1")
+        bridge.connect(operator="alice", role=SessionRole.VIEWER)
+        req = bridge.request_approval(action="deploy", context="ready")
+
+        with pytest.raises(PermissionError, match="not connected"):
+            bridge.respond(req.request_id, approved=True, by="mallory")
 
     def test_disconnect(self) -> None:
         from autocontext.session.remote_bridge import RemoteBridge, SessionRole


### PR DESCRIPTION
Adds RemoteBridge aggregate with RemoteSession (viewer/controller roles), ApprovalRequest (pending→approved/denied/timed_out), and role-based access control. Viewers observe, controllers approve. 12 TDD tests. Resolves AC-514.