### PR TITLE
feat: external research adapter contract and domain types (AC-497)

### DIFF
--- a/autocontext/src/autocontext/research/types.py
+++ b/autocontext/src/autocontext/research/types.py
@@ -33,7 +33,7 @@ class ResearchQuery(BaseModel):
     topic: str
     context: str = ""
     urgency: Urgency = Urgency.NORMAL
-    max_results: int = 5
+    max_results: int = Field(default=5, ge=1)
     constraints: list[str] = Field(default_factory=list)
     scenario_family: str = ""
     metadata: dict[str, Any] = Field(default_factory=dict)
@@ -46,7 +46,7 @@ class Citation(BaseModel):
 
     source: str
     url: str = ""
-    relevance: float = 0.0  # 0.0–1.0
+    relevance: float = Field(default=0.0, ge=0.0, le=1.0)
     snippet: str = ""
     retrieved_at: str = ""
 
@@ -59,7 +59,7 @@ class ResearchResult(BaseModel):
     query_topic: str
     summary: str
     citations: list[Citation] = Field(default_factory=list)
-    confidence: float = 0.0  # 0.0–1.0, how confident the result is
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     @property
@@ -89,9 +89,9 @@ class ResearchConfig(BaseModel):
 
     enabled: bool = False
     adapter_name: str = ""  # e.g. "perplexity", "exa", "internal"
-    max_queries_per_session: int = 20
-    max_queries_per_turn: int = 3
+    max_queries_per_session: int = Field(default=20, ge=0)
+    max_queries_per_turn: int = Field(default=3, ge=0)
     require_citations: bool = True
-    min_confidence: float = 0.3
+    min_confidence: float = Field(default=0.3, ge=0.0, le=1.0)
 
     model_config = {"frozen": True}

--- a/autocontext/src/autocontext/research/types.py
+++ b/autocontext/src/autocontext/research/types.py
@@ -1,0 +1,97 @@
+"""External research adapter contract and domain types (AC-497).
+
+Domain concepts:
+- ResearchQuery: what we're asking (topic, context, urgency, constraints)
+- Citation: provenance tracking for a single source
+- ResearchResult: what comes back (summary, citations, confidence)
+- ResearchAdapter: Protocol for pluggable research backends
+- ResearchConfig: opt-in settings surface
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+
+class Urgency(StrEnum):
+    """How urgently research is needed."""
+
+    LOW = "low"        # Background enrichment, no rush
+    NORMAL = "normal"  # Standard research request
+    HIGH = "high"      # Blocking on this for next decision
+
+
+class ResearchQuery(BaseModel):
+    """What we're asking the research backend.
+
+    Carries enough context for the adapter to scope the search.
+    """
+
+    topic: str
+    context: str = ""
+    urgency: Urgency = Urgency.NORMAL
+    max_results: int = 5
+    constraints: list[str] = Field(default_factory=list)
+    scenario_family: str = ""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {"frozen": True}
+
+
+class Citation(BaseModel):
+    """One source with provenance tracking."""
+
+    source: str
+    url: str = ""
+    relevance: float = 0.0  # 0.0–1.0
+    snippet: str = ""
+    retrieved_at: str = ""
+
+    model_config = {"frozen": True}
+
+
+class ResearchResult(BaseModel):
+    """What the research backend returns."""
+
+    query_topic: str
+    summary: str
+    citations: list[Citation] = Field(default_factory=list)
+    confidence: float = 0.0  # 0.0–1.0, how confident the result is
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def has_citations(self) -> bool:
+        return len(self.citations) > 0
+
+    model_config = {"frozen": True}
+
+
+@runtime_checkable
+class ResearchAdapter(Protocol):
+    """Protocol for pluggable external research backends.
+
+    Implementors: Perplexity, Exa, Google Scholar, internal doc search, etc.
+    """
+
+    def search(self, query: ResearchQuery) -> ResearchResult:
+        """Execute a research query and return structured results."""
+        ...
+
+
+class ResearchConfig(BaseModel):
+    """Opt-in settings for external research integration.
+
+    Disabled by default — must be explicitly enabled per workspace.
+    """
+
+    enabled: bool = False
+    adapter_name: str = ""  # e.g. "perplexity", "exa", "internal"
+    max_queries_per_session: int = 20
+    max_queries_per_turn: int = 3
+    require_citations: bool = True
+    min_confidence: float = 0.3
+
+    model_config = {"frozen": True}

--- a/autocontext/tests/test_research_adapter.py
+++ b/autocontext/tests/test_research_adapter.py
@@ -29,6 +29,12 @@ class TestResearchQuery:
         q = ResearchQuery(topic="test", urgency=Urgency.HIGH)
         assert q.urgency == Urgency.HIGH
 
+    def test_rejects_non_positive_max_results(self) -> None:
+        from autocontext.research.types import ResearchQuery
+
+        with pytest.raises(ValueError):
+            ResearchQuery(topic="test", max_results=0)
+
 
 class TestResearchResult:
     """Result value object — what comes back with citations."""
@@ -56,6 +62,12 @@ class TestResearchResult:
         assert not result.has_citations
         assert result.confidence == 0.0
 
+    def test_rejects_out_of_range_confidence(self) -> None:
+        from autocontext.research.types import ResearchResult
+
+        with pytest.raises(ValueError):
+            ResearchResult(query_topic="OAuth2", summary="summary", confidence=1.5)
+
 
 class TestCitation:
     """Citation tracks provenance."""
@@ -73,6 +85,12 @@ class TestCitation:
         cite = Citation(source="Internal docs")
         assert cite.url == ""
         assert cite.relevance == 0.0
+
+    def test_rejects_out_of_range_relevance(self) -> None:
+        from autocontext.research.types import Citation
+
+        with pytest.raises(ValueError):
+            Citation(source="Internal docs", relevance=2.0)
 
 
 class TestResearchAdapter:
@@ -115,3 +133,15 @@ class TestResearchConfig:
 
         config = ResearchConfig(enabled=True, max_queries_per_session=10)
         assert config.max_queries_per_session == 10
+
+    def test_rejects_negative_query_limits(self) -> None:
+        from autocontext.research.types import ResearchConfig
+
+        with pytest.raises(ValueError):
+            ResearchConfig(max_queries_per_turn=-1)
+
+    def test_rejects_out_of_range_min_confidence(self) -> None:
+        from autocontext.research.types import ResearchConfig
+
+        with pytest.raises(ValueError):
+            ResearchConfig(min_confidence=2.0)

--- a/autocontext/tests/test_research_adapter.py
+++ b/autocontext/tests/test_research_adapter.py
@@ -1,0 +1,117 @@
+"""Tests for external research adapter contract (AC-497).
+
+DDD: ResearchAdapter is a Protocol for pluggable research backends.
+ResearchQuery/ResearchResult are the domain value objects.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestResearchQuery:
+    """Query value object — what we're asking."""
+
+    def test_create_query(self) -> None:
+        from autocontext.research.types import ResearchQuery
+
+        query = ResearchQuery(
+            topic="OAuth2 best practices for Python APIs",
+            context="Building a FastAPI service with JWT auth",
+            max_results=5,
+        )
+        assert query.topic
+        assert query.max_results == 5
+
+    def test_urgency_levels(self) -> None:
+        from autocontext.research.types import ResearchQuery, Urgency
+
+        q = ResearchQuery(topic="test", urgency=Urgency.HIGH)
+        assert q.urgency == Urgency.HIGH
+
+
+class TestResearchResult:
+    """Result value object — what comes back with citations."""
+
+    def test_create_result(self) -> None:
+        from autocontext.research.types import Citation, ResearchResult
+
+        result = ResearchResult(
+            query_topic="OAuth2",
+            summary="Use PKCE flow for public clients",
+            citations=[
+                Citation(source="RFC 7636", url="https://tools.ietf.org/html/rfc7636", relevance=0.95),
+                Citation(source="OWASP Guide", url="https://owasp.org/auth", relevance=0.85),
+            ],
+            confidence=0.9,
+        )
+        assert len(result.citations) == 2
+        assert result.confidence == 0.9
+        assert result.has_citations
+
+    def test_empty_result(self) -> None:
+        from autocontext.research.types import ResearchResult
+
+        result = ResearchResult(query_topic="obscure topic", summary="No results found")
+        assert not result.has_citations
+        assert result.confidence == 0.0
+
+
+class TestCitation:
+    """Citation tracks provenance."""
+
+    def test_citation_fields(self) -> None:
+        from autocontext.research.types import Citation
+
+        cite = Citation(source="RFC 7636", url="https://example.com", relevance=0.9)
+        assert cite.source == "RFC 7636"
+        assert cite.relevance == 0.9
+
+    def test_citation_without_url(self) -> None:
+        from autocontext.research.types import Citation
+
+        cite = Citation(source="Internal docs")
+        assert cite.url == ""
+        assert cite.relevance == 0.0
+
+
+class TestResearchAdapter:
+    """Protocol — pluggable research backends."""
+
+    def test_stub_adapter_satisfies_protocol(self) -> None:
+        from autocontext.research.types import ResearchAdapter, ResearchQuery, ResearchResult
+
+        class StubAdapter:
+            def search(self, query: ResearchQuery) -> ResearchResult:
+                return ResearchResult(
+                    query_topic=query.topic,
+                    summary=f"Stub result for: {query.topic}",
+                    confidence=0.5,
+                )
+
+        adapter: ResearchAdapter = StubAdapter()
+        result = adapter.search(ResearchQuery(topic="test"))
+        assert result.summary.startswith("Stub result")
+
+
+class TestResearchConfig:
+    """Opt-in settings surface."""
+
+    def test_default_disabled(self) -> None:
+        from autocontext.research.types import ResearchConfig
+
+        config = ResearchConfig()
+        assert not config.enabled
+
+    def test_enable_with_adapter(self) -> None:
+        from autocontext.research.types import ResearchConfig
+
+        config = ResearchConfig(enabled=True, adapter_name="perplexity")
+        assert config.enabled
+        assert config.adapter_name == "perplexity"
+
+    def test_max_queries_per_session(self) -> None:
+        from autocontext.research.types import ResearchConfig
+
+        config = ResearchConfig(enabled=True, max_queries_per_session=10)
+        assert config.max_queries_per_session == 10


### PR DESCRIPTION
Introduces research/ bounded context with ResearchQuery, Citation, ResearchResult, ResearchAdapter Protocol, and ResearchConfig. Disabled by default, Protocol-based pluggable backends, citation provenance tracking. 10 TDD tests. Resolves AC-497.