### PR TITLE
feat: research runtime plumbing — connect adapter to session (AC-498)

### DIFF
--- a/autocontext/src/autocontext/research/runtime.py
+++ b/autocontext/src/autocontext/research/runtime.py
@@ -1,0 +1,102 @@
+"""Research runtime plumbing — connects adapter to session (AC-498).
+
+ResearchEnabledSession extends the session model with:
+- Optional research adapter attachment
+- Per-session query budget enforcement
+- Research event emission
+- Accumulated research history for prompt injection
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from autocontext.research.types import ResearchAdapter, ResearchConfig, ResearchQuery, ResearchResult
+
+logger = logging.getLogger(__name__)
+
+
+class _ResearchEvent:
+    """Lightweight event for research activity tracking."""
+
+    __slots__ = ("eventId", "eventType", "timestamp", "payload")
+
+    def __init__(self, event_type: str, payload: dict[str, Any]) -> None:
+        self.eventId = uuid.uuid4().hex[:12]
+        self.eventType = event_type
+        self.timestamp = datetime.now(UTC).isoformat()
+        self.payload = payload
+
+
+class ResearchEnabledSession:
+    """Session with optional research capabilities.
+
+    Wraps research adapter with budget enforcement and history tracking.
+    Create via ResearchEnabledSession.create().
+    """
+
+    def __init__(
+        self,
+        goal: str,
+        research_adapter: ResearchAdapter | None = None,
+        research_config: ResearchConfig | None = None,
+    ) -> None:
+        self.session_id = uuid.uuid4().hex[:16]
+        self.goal = goal
+        self._adapter = research_adapter
+        self._config = research_config or ResearchConfig(enabled=research_adapter is not None)
+        self._query_count = 0
+        self._history: list[ResearchResult] = []
+        self.events: list[_ResearchEvent] = []
+
+        self.events.append(_ResearchEvent("session_created", {"goal": goal}))
+
+    @classmethod
+    def create(
+        cls,
+        goal: str,
+        research_adapter: ResearchAdapter | None = None,
+        research_config: ResearchConfig | None = None,
+    ) -> ResearchEnabledSession:
+        return cls(goal=goal, research_adapter=research_adapter, research_config=research_config)
+
+    @property
+    def has_research(self) -> bool:
+        return self._adapter is not None
+
+    @property
+    def research_queries_used(self) -> int:
+        return self._query_count
+
+    @property
+    def research_history(self) -> list[ResearchResult]:
+        return list(self._history)
+
+    def research(self, query: ResearchQuery) -> ResearchResult | None:
+        """Execute a research query if adapter is available and budget allows.
+
+        Returns None if:
+        - No adapter attached
+        - Query budget exhausted
+        """
+        if self._adapter is None:
+            return None
+
+        if self._query_count >= self._config.max_queries_per_session:
+            logger.debug("research budget exhausted (%d/%d)", self._query_count, self._config.max_queries_per_session)
+            return None
+
+        result = self._adapter.search(query)
+        self._query_count += 1
+        self._history.append(result)
+
+        self.events.append(_ResearchEvent("research_requested", {
+            "topic": query.topic,
+            "confidence": result.confidence,
+            "citations": len(result.citations),
+        }))
+
+        return result

--- a/autocontext/src/autocontext/research/types.py
+++ b/autocontext/src/autocontext/research/types.py
@@ -1,0 +1,97 @@
+"""External research adapter contract and domain types (AC-497).
+
+Domain concepts:
+- ResearchQuery: what we're asking (topic, context, urgency, constraints)
+- Citation: provenance tracking for a single source
+- ResearchResult: what comes back (summary, citations, confidence)
+- ResearchAdapter: Protocol for pluggable research backends
+- ResearchConfig: opt-in settings surface
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+
+class Urgency(StrEnum):
+    """How urgently research is needed."""
+
+    LOW = "low"        # Background enrichment, no rush
+    NORMAL = "normal"  # Standard research request
+    HIGH = "high"      # Blocking on this for next decision
+
+
+class ResearchQuery(BaseModel):
+    """What we're asking the research backend.
+
+    Carries enough context for the adapter to scope the search.
+    """
+
+    topic: str
+    context: str = ""
+    urgency: Urgency = Urgency.NORMAL
+    max_results: int = 5
+    constraints: list[str] = Field(default_factory=list)
+    scenario_family: str = ""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {"frozen": True}
+
+
+class Citation(BaseModel):
+    """One source with provenance tracking."""
+
+    source: str
+    url: str = ""
+    relevance: float = 0.0  # 0.0–1.0
+    snippet: str = ""
+    retrieved_at: str = ""
+
+    model_config = {"frozen": True}
+
+
+class ResearchResult(BaseModel):
+    """What the research backend returns."""
+
+    query_topic: str
+    summary: str
+    citations: list[Citation] = Field(default_factory=list)
+    confidence: float = 0.0  # 0.0–1.0, how confident the result is
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def has_citations(self) -> bool:
+        return len(self.citations) > 0
+
+    model_config = {"frozen": True}
+
+
+@runtime_checkable
+class ResearchAdapter(Protocol):
+    """Protocol for pluggable external research backends.
+
+    Implementors: Perplexity, Exa, Google Scholar, internal doc search, etc.
+    """
+
+    def search(self, query: ResearchQuery) -> ResearchResult:
+        """Execute a research query and return structured results."""
+        ...
+
+
+class ResearchConfig(BaseModel):
+    """Opt-in settings for external research integration.
+
+    Disabled by default — must be explicitly enabled per workspace.
+    """
+
+    enabled: bool = False
+    adapter_name: str = ""  # e.g. "perplexity", "exa", "internal"
+    max_queries_per_session: int = 20
+    max_queries_per_turn: int = 3
+    require_citations: bool = True
+    min_confidence: float = 0.3
+
+    model_config = {"frozen": True}

--- a/autocontext/tests/test_research_runtime.py
+++ b/autocontext/tests/test_research_runtime.py
@@ -1,0 +1,106 @@
+"""Tests for research runtime plumbing (AC-498).
+
+DDD: ResearchSession extends Session with research capabilities.
+Research is gated by config and tracked at session level.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class StubAdapter:
+    """Stub that satisfies ResearchAdapter protocol."""
+
+    def __init__(self, response: str = "Stub result") -> None:
+        self._response = response
+        self.call_count = 0
+
+    def search(self, query: "ResearchQuery") -> "ResearchResult":
+        from autocontext.research.types import ResearchResult
+        self.call_count += 1
+        return ResearchResult(
+            query_topic=query.topic,
+            summary=self._response,
+            confidence=0.8,
+        )
+
+
+class TestResearchEnabledSession:
+    """Session with research adapter attached."""
+
+    def test_session_accepts_research_adapter(self) -> None:
+        from autocontext.research.runtime import ResearchEnabledSession
+
+        adapter = StubAdapter()
+        session = ResearchEnabledSession.create(
+            goal="Build API", research_adapter=adapter
+        )
+        assert session.has_research
+        assert session.research_queries_used == 0
+
+    def test_session_without_adapter(self) -> None:
+        from autocontext.research.runtime import ResearchEnabledSession
+
+        session = ResearchEnabledSession.create(goal="Build API")
+        assert not session.has_research
+
+    def test_research_query_during_session(self) -> None:
+        from autocontext.research.runtime import ResearchEnabledSession
+        from autocontext.research.types import ResearchQuery
+
+        adapter = StubAdapter("OAuth2 is best for APIs")
+        session = ResearchEnabledSession.create(goal="test", research_adapter=adapter)
+
+        result = session.research(ResearchQuery(topic="auth best practices"))
+        assert result is not None
+        assert "OAuth2" in result.summary
+        assert session.research_queries_used == 1
+        assert adapter.call_count == 1
+
+    def test_research_without_adapter_returns_none(self) -> None:
+        from autocontext.research.runtime import ResearchEnabledSession
+        from autocontext.research.types import ResearchQuery
+
+        session = ResearchEnabledSession.create(goal="test")
+        result = session.research(ResearchQuery(topic="anything"))
+        assert result is None
+
+    def test_research_respects_budget(self) -> None:
+        from autocontext.research.runtime import ResearchEnabledSession
+        from autocontext.research.types import ResearchConfig, ResearchQuery
+
+        adapter = StubAdapter()
+        config = ResearchConfig(enabled=True, max_queries_per_session=2)
+        session = ResearchEnabledSession.create(
+            goal="test", research_adapter=adapter, research_config=config
+        )
+
+        session.research(ResearchQuery(topic="q1"))
+        session.research(ResearchQuery(topic="q2"))
+        result = session.research(ResearchQuery(topic="q3"))
+        assert result is None  # budget exhausted
+        assert session.research_queries_used == 2
+
+    def test_research_events_emitted(self) -> None:
+        from autocontext.research.runtime import ResearchEnabledSession
+        from autocontext.research.types import ResearchQuery
+
+        adapter = StubAdapter()
+        session = ResearchEnabledSession.create(goal="test", research_adapter=adapter)
+        session.research(ResearchQuery(topic="auth"))
+
+        event_types = [e.eventType for e in session.events]
+        assert "research_requested" in event_types
+
+    def test_research_results_accumulated(self) -> None:
+        from autocontext.research.runtime import ResearchEnabledSession
+        from autocontext.research.types import ResearchQuery
+
+        adapter = StubAdapter()
+        session = ResearchEnabledSession.create(goal="test", research_adapter=adapter)
+        session.research(ResearchQuery(topic="q1"))
+        session.research(ResearchQuery(topic="q2"))
+
+        assert len(session.research_history) == 2
+        assert session.research_history[0].query_topic == "q1"


### PR DESCRIPTION
Adds ResearchEnabledSession connecting the ResearchAdapter protocol to the session runtime. Optional adapter attachment, per-session budget, event emission, research history accumulation. Graceful None return when unavailable. 7 TDD tests. Resolves AC-498.