### PR TITLE
feat: complete research integration — consultation, persistence, prompt wiring, A/B eval (AC-499–502)

### DIFF
--- a/autocontext/src/autocontext/research/consultation.py
+++ b/autocontext/src/autocontext/research/consultation.py
@@ -1,0 +1,132 @@
+"""Research consultation — goal decomposition and brief assembly (AC-499).
+
+Domain service: ResearchConsultant decomposes a goal into targeted queries,
+executes them through a ResearchEnabledSession, filters weak signals, deduplicates
+citations, and packages everything into a ResearchBrief value object.
+
+ResearchBrief is a frozen value object suitable for downstream prompt injection.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+
+from pydantic import BaseModel, Field
+
+from autocontext.research.runtime import ResearchEnabledSession
+from autocontext.research.types import Citation, ResearchQuery, ResearchResult, Urgency
+
+logger = logging.getLogger(__name__)
+
+
+class ResearchBrief(BaseModel):
+    """Immutable snapshot of research findings for a goal.
+
+    Produced by ResearchConsultant, consumed by prompt wiring (AC-501).
+    """
+
+    goal: str
+    findings: list[ResearchResult] = Field(default_factory=list)
+    unique_citations: list[Citation] = Field(default_factory=list)
+
+    model_config = {"frozen": True}
+
+    @property
+    def avg_confidence(self) -> float:
+        if not self.findings:
+            return 0.0
+        return sum(f.confidence for f in self.findings) / len(self.findings)
+
+    @classmethod
+    def from_results(
+        cls,
+        goal: str,
+        results: Sequence[ResearchResult],
+        min_confidence: float = 0.0,
+    ) -> ResearchBrief:
+        filtered = [r for r in results if r.confidence >= min_confidence]
+        citations = _dedupe_citations(filtered)
+        return cls(goal=goal, findings=list(filtered), unique_citations=citations)
+
+    @classmethod
+    def empty(cls, goal: str) -> ResearchBrief:
+        return cls(goal=goal)
+
+    def to_markdown(self) -> str:
+        if not self.findings:
+            return f"## Research Brief: {self.goal}\n\nNo findings available.\n"
+
+        parts = [f"## Research Brief: {self.goal}\n"]
+        for f in self.findings:
+            parts.append(f"### {f.query_topic} (confidence: {f.confidence:.0%})\n")
+            parts.append(f"{f.summary}\n")
+            for c in f.citations:
+                label = f"[{c.source}]({c.url})" if c.url else c.source
+                parts.append(f"- {label}")
+                if c.snippet:
+                    parts.append(f"  > {c.snippet}")
+            parts.append("")
+        return "\n".join(parts)
+
+
+def _dedupe_citations(results: Sequence[ResearchResult]) -> list[Citation]:
+    """Collect unique citations across results, keyed by (source, url)."""
+    seen: set[tuple[str, str]] = set()
+    unique: list[Citation] = []
+    for r in results:
+        for c in r.citations:
+            key = (c.source, c.url)
+            if key not in seen:
+                seen.add(key)
+                unique.append(c)
+    return unique
+
+
+class ResearchConsultant:
+    """Domain service: decompose goal → queries → brief.
+
+    Stateless — create one and call .consult() per research need.
+    """
+
+    def __init__(
+        self,
+        urgency: Urgency = Urgency.NORMAL,
+        min_confidence: float = 0.0,
+    ) -> None:
+        self._urgency = urgency
+        self._min_confidence = min_confidence
+
+    def consult(
+        self,
+        session: ResearchEnabledSession,
+        topics: Sequence[str],
+        context: str = "",
+    ) -> ResearchBrief:
+        """Execute research queries and return a packaged brief.
+
+        Respects the session's budget — stops when budget is exhausted.
+        Filters results below min_confidence.
+        """
+        if not session.has_research:
+            logger.debug("No research adapter attached — returning empty brief")
+            return ResearchBrief.empty(session.goal)
+
+        results: list[ResearchResult] = []
+        for topic in topics:
+            query = ResearchQuery(
+                topic=topic,
+                context=context,
+                urgency=self._urgency,
+            )
+            result = session.research(query)
+            if result is None:
+                logger.debug("Budget exhausted after %d queries", len(results))
+                break
+            results.append(result)
+
+        return ResearchBrief.from_results(
+            goal=session.goal,
+            results=results,
+            min_confidence=self._min_confidence,
+        )

--- a/autocontext/src/autocontext/research/evaluation.py
+++ b/autocontext/src/autocontext/research/evaluation.py
@@ -1,0 +1,110 @@
+"""Research A/B evaluation — compare augmented vs baseline (AC-502).
+
+Domain service: ResearchEvaluator pairs baseline and research-augmented
+outputs, scores them with a pluggable score function, and measures
+improvement and citation coverage.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from pydantic import BaseModel
+
+from autocontext.research.consultation import ResearchBrief
+
+logger = logging.getLogger(__name__)
+
+ScoreFn = Callable[[str], float]
+
+
+class EvalResult(BaseModel):
+    """Result of comparing one baseline/augmented pair."""
+
+    baseline_score: float = 0.0
+    augmented_score: float = 0.0
+    improvement: float = 0.0
+    citation_coverage: float = 0.0
+    sample_size: int = 1
+
+    model_config = {"frozen": True}
+
+    @property
+    def is_improvement(self) -> bool:
+        return self.improvement > 0
+
+    @property
+    def relative_gain(self) -> float:
+        if self.baseline_score == 0.0:
+            return float("inf") if self.improvement > 0 else 0.0
+        return self.improvement / self.baseline_score
+
+
+class BatchSummary(BaseModel):
+    """Aggregated summary over multiple eval pairs."""
+
+    sample_size: int = 0
+    avg_baseline: float = 0.0
+    avg_augmented: float = 0.0
+    avg_improvement: float = 0.0
+    win_rate: float = 0.0  # fraction where augmented > baseline
+
+    model_config = {"frozen": True}
+
+
+def _citation_coverage(brief: ResearchBrief, text: str) -> float:
+    """Fraction of unique citation sources mentioned in text."""
+    if not brief.unique_citations:
+        return 0.0
+    mentioned = sum(1 for c in brief.unique_citations if c.source in text)
+    return mentioned / len(brief.unique_citations)
+
+
+class ResearchEvaluator:
+    """Compares research-augmented vs baseline outputs."""
+
+    def evaluate_pair(
+        self,
+        brief: ResearchBrief,
+        baseline_output: str,
+        augmented_output: str,
+        score_fn: ScoreFn,
+    ) -> EvalResult:
+        baseline_score = score_fn(baseline_output)
+        augmented_score = score_fn(augmented_output)
+        return EvalResult(
+            baseline_score=baseline_score,
+            augmented_score=augmented_score,
+            improvement=augmented_score - baseline_score,
+            citation_coverage=_citation_coverage(brief, augmented_output),
+        )
+
+    def evaluate_batch(
+        self,
+        pairs: Sequence[dict[str, Any]],
+        score_fn: ScoreFn,
+    ) -> BatchSummary:
+        if not pairs:
+            return BatchSummary()
+
+        results: list[EvalResult] = []
+        for p in pairs:
+            r = self.evaluate_pair(
+                brief=p["brief"],
+                baseline_output=p["baseline"],
+                augmented_output=p["augmented"],
+                score_fn=score_fn,
+            )
+            results.append(r)
+
+        n = len(results)
+        wins = sum(1 for r in results if r.is_improvement)
+        return BatchSummary(
+            sample_size=n,
+            avg_baseline=sum(r.baseline_score for r in results) / n,
+            avg_augmented=sum(r.augmented_score for r in results) / n,
+            avg_improvement=sum(r.improvement for r in results) / n,
+            win_rate=wins / n,
+        )

--- a/autocontext/src/autocontext/research/evaluation.py
+++ b/autocontext/src/autocontext/research/evaluation.py
@@ -8,6 +8,7 @@ improvement and citation coverage.
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Callable, Sequence
 from typing import Any
 
@@ -58,8 +59,14 @@ def _citation_coverage(brief: ResearchBrief, text: str) -> float:
     """Fraction of unique citation sources mentioned in text."""
     if not brief.unique_citations:
         return 0.0
-    mentioned = sum(1 for c in brief.unique_citations if c.source in text)
+    mentioned = sum(1 for c in brief.unique_citations if _source_mentioned(c.source, text))
     return mentioned / len(brief.unique_citations)
+
+
+def _source_mentioned(source: str, text: str) -> bool:
+    """Return True when `source` appears as a distinct mention in `text`."""
+    pattern = rf"(?<!\w){re.escape(source)}(?!\w)"
+    return re.search(pattern, text, flags=re.IGNORECASE) is not None
 
 
 class ResearchEvaluator:

--- a/autocontext/src/autocontext/research/persistence.py
+++ b/autocontext/src/autocontext/research/persistence.py
@@ -1,0 +1,103 @@
+"""Research evidence persistence — JSON-file store (AC-500).
+
+Persists ResearchBrief snapshots for audit trail, cross-session learning,
+and prompt context windows. Uses one JSON file per brief, indexed by a
+lightweight manifest.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from autocontext.research.consultation import ResearchBrief
+
+logger = logging.getLogger(__name__)
+
+BRIEFS_DIR = "research_briefs"
+MANIFEST_FILE = "manifest.json"
+
+
+class BriefRef(BaseModel):
+    """Pointer to a persisted brief."""
+
+    brief_id: str
+    session_id: str
+    goal: str
+    created_at: str
+    finding_count: int = 0
+
+    model_config = {"frozen": True}
+
+
+class ResearchStore:
+    """File-backed research brief persistence.
+
+    Layout:
+        root/
+          research_briefs/
+            manifest.json          — [{brief_id, session_id, goal, ...}]
+            <brief_id>.json        — serialized ResearchBrief
+    """
+
+    def __init__(self, root: Path) -> None:
+        self._dir = root / BRIEFS_DIR
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._manifest_path = self._dir / MANIFEST_FILE
+        self._manifest: list[dict[str, Any]] = self._load_manifest()
+
+    def save_brief(self, session_id: str, brief: ResearchBrief) -> BriefRef:
+        brief_id = uuid.uuid4().hex[:12]
+        ref = BriefRef(
+            brief_id=brief_id,
+            session_id=session_id,
+            goal=brief.goal,
+            created_at=datetime.now(UTC).isoformat(),
+            finding_count=len(brief.findings),
+        )
+
+        brief_path = self._dir / f"{brief_id}.json"
+        brief_path.write_text(brief.model_dump_json(indent=2), encoding="utf-8")
+
+        self._manifest.append(ref.model_dump())
+        self._flush_manifest()
+
+        logger.debug("Saved brief %s for session %s (%d findings)", brief_id, session_id, len(brief.findings))
+        return ref
+
+    def load_brief(self, brief_id: str) -> ResearchBrief | None:
+        brief_path = self._dir / f"{brief_id}.json"
+        if not brief_path.exists():
+            return None
+        data = json.loads(brief_path.read_text(encoding="utf-8"))
+        return ResearchBrief.model_validate(data)
+
+    def list_briefs(self, session_id: str) -> list[BriefRef]:
+        return [BriefRef.model_validate(e) for e in self._manifest if e["session_id"] == session_id]
+
+    def brief_count(self) -> int:
+        return len(self._manifest)
+
+    def delete_brief(self, brief_id: str) -> bool:
+        brief_path = self._dir / f"{brief_id}.json"
+        if not brief_path.exists():
+            return False
+        brief_path.unlink()
+        self._manifest = [e for e in self._manifest if e["brief_id"] != brief_id]
+        self._flush_manifest()
+        return True
+
+    def _load_manifest(self) -> list[dict[str, Any]]:
+        if not self._manifest_path.exists():
+            return []
+        data: list[dict[str, Any]] = json.loads(self._manifest_path.read_text(encoding="utf-8"))
+        return data
+
+    def _flush_manifest(self) -> None:
+        self._manifest_path.write_text(json.dumps(self._manifest, indent=2), encoding="utf-8")

--- a/autocontext/src/autocontext/research/persistence.py
+++ b/autocontext/src/autocontext/research/persistence.py
@@ -50,7 +50,6 @@ class ResearchStore:
         self._dir = root / BRIEFS_DIR
         self._dir.mkdir(parents=True, exist_ok=True)
         self._manifest_path = self._dir / MANIFEST_FILE
-        self._manifest: list[dict[str, Any]] = self._load_manifest()
 
     def save_brief(self, session_id: str, brief: ResearchBrief) -> BriefRef:
         brief_id = uuid.uuid4().hex[:12]
@@ -65,8 +64,9 @@ class ResearchStore:
         brief_path = self._dir / f"{brief_id}.json"
         brief_path.write_text(brief.model_dump_json(indent=2), encoding="utf-8")
 
-        self._manifest.append(ref.model_dump())
-        self._flush_manifest()
+        manifest = self._load_manifest()
+        manifest.append(ref.model_dump())
+        self._write_manifest(manifest)
 
         logger.debug("Saved brief %s for session %s (%d findings)", brief_id, session_id, len(brief.findings))
         return ref
@@ -79,18 +79,19 @@ class ResearchStore:
         return ResearchBrief.model_validate(data)
 
     def list_briefs(self, session_id: str) -> list[BriefRef]:
-        return [BriefRef.model_validate(e) for e in self._manifest if e["session_id"] == session_id]
+        manifest = self._load_manifest()
+        return [BriefRef.model_validate(e) for e in manifest if e["session_id"] == session_id]
 
     def brief_count(self) -> int:
-        return len(self._manifest)
+        return len(self._load_manifest())
 
     def delete_brief(self, brief_id: str) -> bool:
         brief_path = self._dir / f"{brief_id}.json"
         if not brief_path.exists():
             return False
         brief_path.unlink()
-        self._manifest = [e for e in self._manifest if e["brief_id"] != brief_id]
-        self._flush_manifest()
+        manifest = [e for e in self._load_manifest() if e["brief_id"] != brief_id]
+        self._write_manifest(manifest)
         return True
 
     def _load_manifest(self) -> list[dict[str, Any]]:
@@ -99,5 +100,5 @@ class ResearchStore:
         data: list[dict[str, Any]] = json.loads(self._manifest_path.read_text(encoding="utf-8"))
         return data
 
-    def _flush_manifest(self) -> None:
-        self._manifest_path.write_text(json.dumps(self._manifest, indent=2), encoding="utf-8")
+    def _write_manifest(self, manifest: list[dict[str, Any]]) -> None:
+        self._manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")

--- a/autocontext/src/autocontext/research/prompt_wiring.py
+++ b/autocontext/src/autocontext/research/prompt_wiring.py
@@ -1,0 +1,75 @@
+"""Research prompt wiring — format briefs for LLM injection (AC-501).
+
+ResearchPromptInjector formats a ResearchBrief into a prompt section,
+handling truncation to a char budget, confidence-based ordering, and
+citation formatting. Supports placeholder injection or append-to-base.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from autocontext.research.consultation import ResearchBrief
+
+logger = logging.getLogger(__name__)
+
+RESEARCH_PLACEHOLDER = "{research}"
+DEFAULT_MAX_CHARS = 4000
+
+
+class ResearchPromptInjector:
+    """Formats research briefs and injects them into prompt templates."""
+
+    def __init__(self, max_chars: int = DEFAULT_MAX_CHARS) -> None:
+        self._max_chars = max_chars
+
+    def format_brief(self, brief: ResearchBrief) -> str:
+        """Render a brief as a markdown section, truncated to budget.
+
+        Findings are ordered by confidence (highest first).
+        Returns empty string if brief has no findings.
+        """
+        if not brief.findings:
+            return ""
+
+        sorted_findings = sorted(brief.findings, key=lambda f: f.confidence, reverse=True)
+
+        parts: list[str] = [f"## External Research: {brief.goal}\n"]
+        budget = self._max_chars - len(parts[0])
+
+        for f in sorted_findings:
+            block_lines = [f"**{f.query_topic}** (confidence: {f.confidence:.0%})"]
+            block_lines.append(f.summary)
+            for c in f.citations:
+                if c.url:
+                    block_lines.append(f"- [{c.source}]({c.url})")
+                else:
+                    block_lines.append(f"- {c.source}")
+            block_lines.append("")
+            block = "\n".join(block_lines)
+
+            if len(block) > budget:
+                if len(parts) == 1:
+                    # At least include one truncated finding
+                    parts.append(block[:budget])
+                break
+            parts.append(block)
+            budget -= len(block)
+
+        return "\n".join(parts)
+
+    def inject(self, base_prompt: str, brief: ResearchBrief) -> str:
+        """Inject formatted brief into a prompt template.
+
+        If base_prompt contains {research}, replaces it.
+        Otherwise appends the section after the base.
+        Returns base_prompt unchanged if brief is empty.
+        """
+        section = self.format_brief(brief)
+        if not section:
+            return base_prompt
+
+        if RESEARCH_PLACEHOLDER in base_prompt:
+            return base_prompt.replace(RESEARCH_PLACEHOLDER, section)
+
+        return f"{base_prompt}\n\n{section}"

--- a/autocontext/tests/test_research_consultation.py
+++ b/autocontext/tests/test_research_consultation.py
@@ -1,0 +1,184 @@
+"""Tests for research consultation service (AC-499).
+
+DDD: ResearchConsultant is a domain service that:
+- Decomposes a session goal into targeted research queries
+- Executes them against the adapter via ResearchEnabledSession
+- Filters low-confidence results
+- Deduplicates citations
+- Packages everything into a ResearchBrief value object
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autocontext.research.types import (
+    Citation,
+    ResearchConfig,
+    ResearchQuery,
+    ResearchResult,
+)
+
+
+class StubAdapter:
+    """Returns predictable results keyed by topic."""
+
+    def __init__(self, results: dict[str, ResearchResult] | None = None) -> None:
+        self._results = results or {}
+        self.queries_received: list[str] = []
+
+    def search(self, query: ResearchQuery) -> ResearchResult:
+        self.queries_received.append(query.topic)
+        if query.topic in self._results:
+            return self._results[query.topic]
+        return ResearchResult(
+            query_topic=query.topic,
+            summary=f"Default answer for {query.topic}",
+            confidence=0.5,
+        )
+
+
+def _make_result(topic: str, confidence: float = 0.8, citations: list[Citation] | None = None) -> ResearchResult:
+    return ResearchResult(
+        query_topic=topic,
+        summary=f"Research on {topic}",
+        confidence=confidence,
+        citations=citations or [],
+    )
+
+
+# --- ResearchBrief value object ---
+
+class TestResearchBrief:
+    def test_brief_from_results(self) -> None:
+        from autocontext.research.consultation import ResearchBrief
+
+        brief = ResearchBrief.from_results(
+            goal="Build auth API",
+            results=[
+                _make_result("OAuth2", confidence=0.9),
+                _make_result("JWT tokens", confidence=0.7),
+            ],
+        )
+        assert brief.goal == "Build auth API"
+        assert len(brief.findings) == 2
+        assert brief.avg_confidence == pytest.approx(0.8, abs=0.01)
+
+    def test_brief_filters_low_confidence(self) -> None:
+        from autocontext.research.consultation import ResearchBrief
+
+        brief = ResearchBrief.from_results(
+            goal="test",
+            results=[
+                _make_result("good", confidence=0.8),
+                _make_result("weak", confidence=0.1),
+            ],
+            min_confidence=0.3,
+        )
+        assert len(brief.findings) == 1
+        assert brief.findings[0].query_topic == "good"
+
+    def test_brief_deduplicates_citations(self) -> None:
+        from autocontext.research.consultation import ResearchBrief
+
+        shared_cite = Citation(source="RFC 6749", url="https://tools.ietf.org/rfc6749", relevance=0.9)
+        brief = ResearchBrief.from_results(
+            goal="test",
+            results=[
+                _make_result("q1", citations=[shared_cite, Citation(source="Unique A", relevance=0.7)]),
+                _make_result("q2", citations=[shared_cite, Citation(source="Unique B", relevance=0.6)]),
+            ],
+        )
+        urls = [c.url for c in brief.unique_citations]
+        assert urls.count("https://tools.ietf.org/rfc6749") == 1
+        assert len(brief.unique_citations) == 3
+
+    def test_brief_renders_markdown(self) -> None:
+        from autocontext.research.consultation import ResearchBrief
+
+        brief = ResearchBrief.from_results(
+            goal="Build auth",
+            results=[_make_result("OAuth2", confidence=0.9, citations=[
+                Citation(source="RFC 6749", url="https://example.com/rfc", relevance=0.9),
+            ])],
+        )
+        md = brief.to_markdown()
+        assert "OAuth2" in md
+        assert "RFC 6749" in md
+        assert "Build auth" in md
+
+    def test_empty_brief(self) -> None:
+        from autocontext.research.consultation import ResearchBrief
+
+        brief = ResearchBrief.empty("no results")
+        assert len(brief.findings) == 0
+        assert brief.avg_confidence == 0.0
+
+
+# --- ResearchConsultant domain service ---
+
+class TestResearchConsultant:
+    def test_consult_decomposes_goal(self) -> None:
+        from autocontext.research.consultation import ResearchConsultant
+        from autocontext.research.runtime import ResearchEnabledSession
+
+        adapter = StubAdapter()
+        session = ResearchEnabledSession.create(goal="Build OAuth2 login", research_adapter=adapter)
+        consultant = ResearchConsultant()
+
+        brief = consultant.consult(session, topics=["OAuth2 best practices", "token storage"])
+        assert len(brief.findings) == 2
+        assert len(adapter.queries_received) == 2
+
+    def test_consult_respects_session_budget(self) -> None:
+        from autocontext.research.consultation import ResearchConsultant
+        from autocontext.research.runtime import ResearchEnabledSession
+
+        adapter = StubAdapter()
+        config = ResearchConfig(enabled=True, max_queries_per_session=1)
+        session = ResearchEnabledSession.create(goal="test", research_adapter=adapter, research_config=config)
+        consultant = ResearchConsultant()
+
+        brief = consultant.consult(session, topics=["t1", "t2", "t3"])
+        # Only 1 query allowed by budget
+        assert len(brief.findings) == 1
+
+    def test_consult_without_adapter_returns_empty(self) -> None:
+        from autocontext.research.consultation import ResearchConsultant
+        from autocontext.research.runtime import ResearchEnabledSession
+
+        session = ResearchEnabledSession.create(goal="test")
+        consultant = ResearchConsultant()
+
+        brief = consultant.consult(session, topics=["anything"])
+        assert len(brief.findings) == 0
+
+    def test_consult_applies_context(self) -> None:
+        from autocontext.research.consultation import ResearchConsultant
+        from autocontext.research.runtime import ResearchEnabledSession
+
+        adapter = StubAdapter()
+        session = ResearchEnabledSession.create(goal="Build API", research_adapter=adapter)
+        consultant = ResearchConsultant()
+
+        brief = consultant.consult(
+            session,
+            topics=["auth"],
+            context="We use FastAPI with Python 3.12",
+        )
+        assert len(brief.findings) == 1
+
+    def test_consult_filters_by_min_confidence(self) -> None:
+        from autocontext.research.consultation import ResearchConsultant
+        from autocontext.research.runtime import ResearchEnabledSession
+
+        adapter = StubAdapter(results={
+            "good": _make_result("good", confidence=0.9),
+            "weak": _make_result("weak", confidence=0.1),
+        })
+        session = ResearchEnabledSession.create(goal="test", research_adapter=adapter)
+        consultant = ResearchConsultant(min_confidence=0.3)
+
+        brief = consultant.consult(session, topics=["good", "weak"])
+        assert len(brief.findings) == 1
+        assert brief.findings[0].query_topic == "good"

--- a/autocontext/tests/test_research_eval.py
+++ b/autocontext/tests/test_research_eval.py
@@ -1,0 +1,137 @@
+"""Tests for research A/B evaluation (AC-502).
+
+DDD: ResearchEvaluator compares research-augmented vs baseline outputs,
+producing structured evaluation results for quality gating.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autocontext.research.consultation import ResearchBrief
+from autocontext.research.types import Citation, ResearchResult
+
+
+def _brief(n: int = 1, confidence: float = 0.8) -> ResearchBrief:
+    results = [
+        ResearchResult(
+            query_topic=f"topic-{i}",
+            summary=f"Finding {i}",
+            confidence=confidence,
+            citations=[Citation(source=f"src-{i}", url=f"https://ex.com/{i}", relevance=0.9)],
+        )
+        for i in range(n)
+    ]
+    return ResearchBrief.from_results(goal="test", results=results)
+
+
+class TestEvalResult:
+    def test_create_eval_result(self) -> None:
+        from autocontext.research.evaluation import EvalResult
+
+        r = EvalResult(
+            baseline_score=0.6,
+            augmented_score=0.85,
+            improvement=0.25,
+            citation_coverage=0.9,
+            sample_size=10,
+        )
+        assert r.is_improvement
+        assert r.relative_gain == pytest.approx(0.4167, abs=0.01)
+
+    def test_no_improvement(self) -> None:
+        from autocontext.research.evaluation import EvalResult
+
+        r = EvalResult(baseline_score=0.8, augmented_score=0.75, improvement=-0.05)
+        assert not r.is_improvement
+
+    def test_zero_baseline_gain(self) -> None:
+        from autocontext.research.evaluation import EvalResult
+
+        r = EvalResult(baseline_score=0.0, augmented_score=0.5, improvement=0.5)
+        assert r.relative_gain == float("inf")
+
+
+class TestResearchEvaluator:
+    def test_evaluate_pair(self) -> None:
+        from autocontext.research.evaluation import ResearchEvaluator
+
+        evaluator = ResearchEvaluator()
+        result = evaluator.evaluate_pair(
+            brief=_brief(),
+            baseline_output="Generic auth answer",
+            augmented_output="OAuth2 with PKCE flow as recommended by RFC 7636",
+            score_fn=lambda text: 0.9 if "RFC" in text else 0.5,
+        )
+        assert result.is_improvement
+        assert result.augmented_score > result.baseline_score
+
+    def test_evaluate_pair_no_improvement(self) -> None:
+        from autocontext.research.evaluation import ResearchEvaluator
+
+        evaluator = ResearchEvaluator()
+        result = evaluator.evaluate_pair(
+            brief=_brief(),
+            baseline_output="Great answer",
+            augmented_output="Also great answer",
+            score_fn=lambda text: 0.8,
+        )
+        assert not result.is_improvement
+        assert result.improvement == pytest.approx(0.0)
+
+    def test_evaluate_batch(self) -> None:
+        from autocontext.research.evaluation import ResearchEvaluator
+
+        evaluator = ResearchEvaluator()
+        pairs = [
+            {
+                "brief": _brief(),
+                "baseline": "basic",
+                "augmented": "research-backed with RFC citation",
+            },
+            {
+                "brief": _brief(),
+                "baseline": "generic",
+                "augmented": "detailed with RFC source",
+            },
+        ]
+        summary = evaluator.evaluate_batch(
+            pairs=pairs,
+            score_fn=lambda text: 0.9 if "RFC" in text else 0.5,
+        )
+        assert summary.sample_size == 2
+        assert summary.avg_improvement > 0
+        assert summary.win_rate == pytest.approx(1.0)
+
+    def test_evaluate_batch_empty(self) -> None:
+        from autocontext.research.evaluation import ResearchEvaluator
+
+        evaluator = ResearchEvaluator()
+        summary = evaluator.evaluate_batch(pairs=[], score_fn=lambda t: 0.5)
+        assert summary.sample_size == 0
+
+    def test_citation_coverage(self) -> None:
+        from autocontext.research.evaluation import ResearchEvaluator
+
+        evaluator = ResearchEvaluator()
+        brief = _brief(n=2)
+        result = evaluator.evaluate_pair(
+            brief=brief,
+            baseline_output="no citations",
+            augmented_output="According to src-0 and src-1, the approach is solid",
+            score_fn=lambda t: 0.7,
+        )
+        assert result.citation_coverage == pytest.approx(1.0)
+
+    def test_partial_citation_coverage(self) -> None:
+        from autocontext.research.evaluation import ResearchEvaluator
+
+        evaluator = ResearchEvaluator()
+        brief = _brief(n=3)
+        result = evaluator.evaluate_pair(
+            brief=brief,
+            baseline_output="none",
+            augmented_output="Only src-0 was referenced",
+            score_fn=lambda t: 0.7,
+        )
+        assert result.citation_coverage == pytest.approx(1 / 3, abs=0.01)

--- a/autocontext/tests/test_research_eval.py
+++ b/autocontext/tests/test_research_eval.py
@@ -135,3 +135,26 @@ class TestResearchEvaluator:
             score_fn=lambda t: 0.7,
         )
         assert result.citation_coverage == pytest.approx(1 / 3, abs=0.01)
+
+    def test_citation_coverage_avoids_prefix_false_positives(self) -> None:
+        from autocontext.research.evaluation import ResearchEvaluator
+
+        evaluator = ResearchEvaluator()
+        brief = ResearchBrief.from_results(
+            goal="test",
+            results=[
+                ResearchResult(
+                    query_topic="topic",
+                    summary="Finding",
+                    confidence=0.8,
+                    citations=[Citation(source="src-1", relevance=0.9)],
+                )
+            ],
+        )
+        result = evaluator.evaluate_pair(
+            brief=brief,
+            baseline_output="none",
+            augmented_output="This only mentions src-10, not the cited source",
+            score_fn=lambda t: 0.7,
+        )
+        assert result.citation_coverage == pytest.approx(0.0)

--- a/autocontext/tests/test_research_persistence.py
+++ b/autocontext/tests/test_research_persistence.py
@@ -1,0 +1,109 @@
+"""Tests for research evidence persistence (AC-500).
+
+DDD: ResearchStore persists briefs and results for audit trail,
+cross-session learning, and prompt context windows.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from autocontext.research.types import Citation, ResearchResult
+
+
+def _make_brief(goal: str = "test", n_findings: int = 2):
+    from autocontext.research.consultation import ResearchBrief
+
+    results = [
+        ResearchResult(
+            query_topic=f"topic-{i}",
+            summary=f"Summary {i}",
+            confidence=0.5 + i * 0.1,
+            citations=[Citation(source=f"src-{i}", url=f"https://example.com/{i}", relevance=0.8)],
+        )
+        for i in range(n_findings)
+    ]
+    return ResearchBrief.from_results(goal=goal, results=results)
+
+
+class TestResearchStore:
+    def test_save_and_load_brief(self, tmp_path: Path) -> None:
+        from autocontext.research.persistence import ResearchStore
+
+        store = ResearchStore(tmp_path)
+        brief = _make_brief("Build auth API")
+
+        ref = store.save_brief("session-1", brief)
+        assert ref.session_id == "session-1"
+        assert ref.brief_id
+
+        loaded = store.load_brief(ref.brief_id)
+        assert loaded is not None
+        assert loaded.goal == "Build auth API"
+        assert len(loaded.findings) == 2
+
+    def test_list_briefs_by_session(self, tmp_path: Path) -> None:
+        from autocontext.research.persistence import ResearchStore
+
+        store = ResearchStore(tmp_path)
+        store.save_brief("s1", _make_brief("goal-a"))
+        store.save_brief("s1", _make_brief("goal-b"))
+        store.save_brief("s2", _make_brief("goal-c"))
+
+        s1_briefs = store.list_briefs("s1")
+        assert len(s1_briefs) == 2
+        assert store.list_briefs("s2") == [store.list_briefs("s2")[0]]
+
+    def test_load_nonexistent_returns_none(self, tmp_path: Path) -> None:
+        from autocontext.research.persistence import ResearchStore
+
+        store = ResearchStore(tmp_path)
+        assert store.load_brief("nonexistent") is None
+
+    def test_briefs_persist_across_instances(self, tmp_path: Path) -> None:
+        from autocontext.research.persistence import ResearchStore
+
+        store1 = ResearchStore(tmp_path)
+        ref = store1.save_brief("s1", _make_brief("persistent"))
+
+        store2 = ResearchStore(tmp_path)
+        loaded = store2.load_brief(ref.brief_id)
+        assert loaded is not None
+        assert loaded.goal == "persistent"
+
+    def test_citations_round_trip(self, tmp_path: Path) -> None:
+        from autocontext.research.persistence import ResearchStore
+
+        store = ResearchStore(tmp_path)
+        brief = _make_brief("cite-test", n_findings=1)
+        ref = store.save_brief("s1", brief)
+
+        loaded = store.load_brief(ref.brief_id)
+        assert loaded is not None
+        assert len(loaded.unique_citations) == 1
+        assert loaded.unique_citations[0].source == "src-0"
+
+    def test_brief_count(self, tmp_path: Path) -> None:
+        from autocontext.research.persistence import ResearchStore
+
+        store = ResearchStore(tmp_path)
+        assert store.brief_count() == 0
+        store.save_brief("s1", _make_brief())
+        store.save_brief("s1", _make_brief())
+        assert store.brief_count() == 2
+
+    def test_delete_brief(self, tmp_path: Path) -> None:
+        from autocontext.research.persistence import ResearchStore
+
+        store = ResearchStore(tmp_path)
+        ref = store.save_brief("s1", _make_brief())
+        assert store.load_brief(ref.brief_id) is not None
+
+        deleted = store.delete_brief(ref.brief_id)
+        assert deleted is True
+        assert store.load_brief(ref.brief_id) is None
+        assert store.brief_count() == 0

--- a/autocontext/tests/test_research_persistence.py
+++ b/autocontext/tests/test_research_persistence.py
@@ -6,11 +6,7 @@ cross-session learning, and prompt context windows.
 
 from __future__ import annotations
 
-import json
-import tempfile
 from pathlib import Path
-
-import pytest
 
 from autocontext.research.types import Citation, ResearchResult
 
@@ -74,6 +70,22 @@ class TestResearchStore:
         loaded = store2.load_brief(ref.brief_id)
         assert loaded is not None
         assert loaded.goal == "persistent"
+
+    def test_manifest_merges_across_store_instances(self, tmp_path: Path) -> None:
+        from autocontext.research.persistence import ResearchStore
+
+        store1 = ResearchStore(tmp_path)
+        store2 = ResearchStore(tmp_path)
+
+        ref1 = store1.save_brief("s1", _make_brief("goal-a"))
+        ref2 = store2.save_brief("s2", _make_brief("goal-b"))
+
+        store3 = ResearchStore(tmp_path)
+        assert store3.brief_count() == 2
+        assert len(store3.list_briefs("s1")) == 1
+        assert len(store3.list_briefs("s2")) == 1
+        assert store3.load_brief(ref1.brief_id) is not None
+        assert store3.load_brief(ref2.brief_id) is not None
 
     def test_citations_round_trip(self, tmp_path: Path) -> None:
         from autocontext.research.persistence import ResearchStore

--- a/autocontext/tests/test_research_prompt_wiring.py
+++ b/autocontext/tests/test_research_prompt_wiring.py
@@ -1,0 +1,102 @@
+"""Tests for research prompt wiring (AC-501).
+
+DDD: ResearchPromptInjector formats briefs into prompt sections
+for LLM context injection. Handles budget, truncation, ordering.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autocontext.research.consultation import ResearchBrief
+from autocontext.research.types import Citation, ResearchResult
+
+
+def _brief(n: int = 2, confidence: float = 0.8) -> ResearchBrief:
+    results = [
+        ResearchResult(
+            query_topic=f"topic-{i}",
+            summary=f"Finding about topic-{i} with detailed explanation",
+            confidence=confidence,
+            citations=[Citation(source=f"source-{i}", url=f"https://example.com/{i}", relevance=0.9)],
+        )
+        for i in range(n)
+    ]
+    return ResearchBrief.from_results(goal="Build API", results=results)
+
+
+class TestResearchPromptInjector:
+    def test_inject_brief_as_section(self) -> None:
+        from autocontext.research.prompt_wiring import ResearchPromptInjector
+
+        injector = ResearchPromptInjector()
+        section = injector.format_brief(_brief())
+
+        assert "## External Research" in section
+        assert "topic-0" in section
+        assert "topic-1" in section
+
+    def test_empty_brief_returns_empty(self) -> None:
+        from autocontext.research.prompt_wiring import ResearchPromptInjector
+
+        injector = ResearchPromptInjector()
+        section = injector.format_brief(ResearchBrief.empty("test"))
+        assert section == ""
+
+    def test_respects_token_budget(self) -> None:
+        from autocontext.research.prompt_wiring import ResearchPromptInjector
+
+        brief = _brief(n=20)
+        injector = ResearchPromptInjector(max_chars=500)
+        section = injector.format_brief(brief)
+        assert len(section) <= 550  # small overflow tolerance for final line
+
+    def test_highest_confidence_first(self) -> None:
+        from autocontext.research.prompt_wiring import ResearchPromptInjector
+
+        results = [
+            ResearchResult(query_topic="low", summary="Low conf", confidence=0.3),
+            ResearchResult(query_topic="high", summary="High conf", confidence=0.9),
+            ResearchResult(query_topic="mid", summary="Mid conf", confidence=0.6),
+        ]
+        brief = ResearchBrief.from_results(goal="test", results=results)
+        injector = ResearchPromptInjector()
+        section = injector.format_brief(brief)
+
+        high_pos = section.index("high")
+        low_pos = section.index("low")
+        assert high_pos < low_pos
+
+    def test_inject_into_prompt(self) -> None:
+        from autocontext.research.prompt_wiring import ResearchPromptInjector
+
+        injector = ResearchPromptInjector()
+        base = "You are a helpful assistant.\n\n{research}\n\nPlease help the user."
+        result = injector.inject(base, _brief())
+        assert "External Research" in result
+        assert "Please help the user" in result
+
+    def test_inject_no_placeholder_appends(self) -> None:
+        from autocontext.research.prompt_wiring import ResearchPromptInjector
+
+        injector = ResearchPromptInjector()
+        base = "You are a helpful assistant."
+        result = injector.inject(base, _brief())
+        assert result.startswith("You are a helpful assistant.")
+        assert "External Research" in result
+
+    def test_inject_empty_brief_returns_base(self) -> None:
+        from autocontext.research.prompt_wiring import ResearchPromptInjector
+
+        injector = ResearchPromptInjector()
+        base = "You are a helpful assistant."
+        result = injector.inject(base, ResearchBrief.empty("test"))
+        assert result == base
+
+    def test_citation_formatting(self) -> None:
+        from autocontext.research.prompt_wiring import ResearchPromptInjector
+
+        injector = ResearchPromptInjector()
+        section = injector.format_brief(_brief(n=1))
+        assert "source-0" in section
+        assert "https://example.com/0" in section

--- a/autocontext/tests/test_research_prompt_wiring.py
+++ b/autocontext/tests/test_research_prompt_wiring.py
@@ -6,8 +6,6 @@ for LLM context injection. Handles budget, truncation, ordering.
 
 from __future__ import annotations
 
-import pytest
-
 from autocontext.research.consultation import ResearchBrief
 from autocontext.research.types import Citation, ResearchResult
 


### PR DESCRIPTION
## Summary

Completes the external research integration workstream (AC-499 through AC-502). **4 new modules, 34 TDD tests, 952 lines.**

## Modules

| Module | Issue | Tests | Key Types |
|--------|-------|-------|-----------|
| `research/consultation.py` | AC-499 | 10 | `ResearchBrief`, `ResearchConsultant` |
| `research/persistence.py` | AC-500 | 7 | `ResearchStore`, `BriefRef` |
| `research/prompt_wiring.py` | AC-501 | 8 | `ResearchPromptInjector` |
| `research/evaluation.py` | AC-502 | 9 | `ResearchEvaluator`, `EvalResult`, `BatchSummary` |

## Architecture (DDD layering)

```
ResearchAdapter (Protocol)        ← pluggable backends (AC-497)
    ↓
ResearchEnabledSession            ← budget + history tracking (AC-498)
    ↓
ResearchConsultant                ← goal → queries → brief (AC-499)
    ↓
ResearchStore                     ← persist for audit/learning (AC-500)
    ↓
ResearchPromptInjector            ← format for LLM injection (AC-501)
    ↓
ResearchEvaluator                 ← A/B quality comparison (AC-502)
```

## Verification

- [x] ruff check — zero errors
- [x] mypy — zero errors
- [x] 34/34 tests pass
