### PR TITLE
fix: P0 — abstract class selection + missing runs table on clean workspace (AC-520, AC-521)

### DIFF
--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -160,6 +160,12 @@ def _write_json_stderr(message: str) -> None:
     sys.stderr.write(json.dumps({"error": message}) + "\n")
 
 
+def _check_json_exit(result: dict[str, Any]) -> None:
+    """Raise SystemExit(1) if JSON result has status=failed (AC-520)."""
+    if isinstance(result, dict) and result.get("status") == "failed":
+        raise SystemExit(1)
+
+
 def _is_agent_task(scenario_name: str) -> bool:
     """Check if a scenario should use the direct agent-task execution path."""
     if scenario_name not in SCENARIO_REGISTRY:
@@ -1103,6 +1109,7 @@ def simulate(
         result = export_simulation(id=export_id, knowledge_root=settings.knowledge_root, format=export_format)
         if json_output:
             _write_json_stdout(result)
+            _check_json_exit(result)
         elif result["status"] == "failed":
             console.print(f"[red]Export failed:[/red] {result.get('error')}")
             raise typer.Exit(code=1)
@@ -1115,6 +1122,7 @@ def simulate(
         result = engine.compare(left=compare_left, right=compare_right)
         if json_output:
             _write_json_stdout(result)
+            _check_json_exit(result)
         elif result["status"] == "failed":
             console.print(f"[red]Compare failed:[/red] {result.get('error')}")
             raise typer.Exit(code=1)
@@ -1131,6 +1139,7 @@ def simulate(
         )
         if json_output:
             _write_json_stdout(result)
+            _check_json_exit(result)
         elif result["status"] == "failed":
             console.print(f"[red]Replay failed:[/red] {result.get('error')}")
             raise typer.Exit(code=1)
@@ -1159,6 +1168,7 @@ def simulate(
 
     if json_output:
         _write_json_stdout(result)
+        _check_json_exit(result)
     elif result["status"] == "failed":
         console.print(f"[red]Simulation failed:[/red] {result.get('error')}")
         raise typer.Exit(code=1)

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -1002,8 +1002,7 @@ def export_cmd(
 
     sqlite = SQLiteStore(resolved_db)
     migrations_dir = Path(__file__).resolve().parents[2] / "migrations"
-    if migrations_dir.exists():
-        sqlite.migrate(migrations_dir)
+    sqlite.migrate(migrations_dir)
     artifacts = ArtifactStore(
         runs_root=resolved_runs,
         knowledge_root=resolved_knowledge,
@@ -1308,8 +1307,7 @@ def import_package_cmd(
     resolved_db = Path(db_path) if db_path is not None else settings.db_path
     sqlite = SQLiteStore(resolved_db)
     migrations_dir = Path(__file__).resolve().parents[2] / "migrations"
-    if migrations_dir.exists():
-        sqlite.migrate(migrations_dir)
+    sqlite.migrate(migrations_dir)
     artifacts = ArtifactStore(
         runs_root=settings.runs_root,
         knowledge_root=Path(knowledge_root) if knowledge_root else settings.knowledge_root,
@@ -1354,8 +1352,7 @@ def wait(
     settings = load_settings()
     store = SQLiteStore(settings.db_path)
     migrations_dir = Path(__file__).resolve().parents[2] / "migrations"
-    if migrations_dir.exists():
-        store.migrate(migrations_dir)
+    store.migrate(migrations_dir)
 
     # Check condition exists
     condition = store.get_monitor_condition(condition_id)
@@ -1506,8 +1503,7 @@ def queue(
     settings = load_settings()
     store = _sqlite_from_settings(settings)
     migrations_dir = Path(__file__).resolve().parents[2] / "migrations"
-    if migrations_dir.exists():
-        store.migrate(migrations_dir)
+    store.migrate(migrations_dir)
 
     task_id = enqueue_task(store=store, spec_name=spec, priority=priority)
 

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -83,6 +83,7 @@ class GenerationRunner:
     def __init__(self, settings: AppSettings) -> None:
         self.settings = settings
         self.sqlite = SQLiteStore(settings.db_path)
+        self.sqlite.ensure_core_tables()
         self.trajectory_builder = ScoreTrajectoryBuilder(self.sqlite)
         self.artifacts = ArtifactStore(
             settings.runs_root,

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -83,7 +83,6 @@ class GenerationRunner:
     def __init__(self, settings: AppSettings) -> None:
         self.settings = settings
         self.sqlite = SQLiteStore(settings.db_path)
-        self.sqlite.ensure_core_tables()
         self.trajectory_builder = ScoreTrajectoryBuilder(self.sqlite)
         self.artifacts = ArtifactStore(
             settings.runs_root,

--- a/autocontext/src/autocontext/mcp/_base.py
+++ b/autocontext/src/autocontext/mcp/_base.py
@@ -28,8 +28,7 @@ class MtsToolContext:
         self.settings = settings
         self.sqlite = SQLiteStore(settings.db_path)
         migrations_dir = Path(__file__).resolve().parents[3] / "migrations"
-        if migrations_dir.exists():
-            self.sqlite.migrate(migrations_dir)
+        self.sqlite.migrate(migrations_dir)
         self.artifacts = ArtifactStore(
             settings.runs_root,
             settings.knowledge_root,

--- a/autocontext/src/autocontext/server/app.py
+++ b/autocontext/src/autocontext/server/app.py
@@ -111,8 +111,7 @@ def create_app(
     application.state.app_settings = app_settings
     store = SQLiteStore(app_settings.db_path)
     migrations_dir = Path(__file__).resolve().parents[3] / "migrations"
-    if migrations_dir.exists():
-        store.migrate(migrations_dir)
+    store.migrate(migrations_dir)
     application.state.store = store
     application.state.migrations_dir = migrations_dir
     scenario_creator = _build_scenario_creator(app_settings)

--- a/autocontext/src/autocontext/simulation/engine.py
+++ b/autocontext/src/autocontext/simulation/engine.py
@@ -7,10 +7,12 @@ executes trajectories/sweeps, and returns structured findings.
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import json
 import logging
 import re
 import sys
+import types
 import uuid
 from copy import deepcopy
 from pathlib import Path
@@ -29,6 +31,43 @@ def _generate_id() -> str:
 def _derive_name(description: str) -> str:
     words = re.sub(r"[^a-z0-9\s]", "", description.lower()).split()
     return "_".join(w for w in words if len(w) > 2)[:4] or "simulation"
+
+
+def _find_scenario_class(mod: types.ModuleType) -> type | None:
+    """Find first concrete (non-abstract) scenario class in a module.
+
+    Checks SimulationInterface first, then OperatorLoopInterface.
+    Skips abstract classes to avoid AC-520.
+    """
+    from autocontext.scenarios.simulation import SimulationInterface
+
+    for attr_name in dir(mod):
+        attr = getattr(mod, attr_name)
+        if (
+            isinstance(attr, type)
+            and issubclass(attr, SimulationInterface)
+            and attr is not SimulationInterface
+            and not inspect.isabstract(attr)
+        ):
+            return attr
+
+    # Try operator_loop interface
+    try:
+        from autocontext.scenarios.operator_loop import OperatorLoopInterface
+    except ImportError:
+        return None
+
+    for attr_name in dir(mod):
+        attr = getattr(mod, attr_name)
+        if (
+            isinstance(attr, type)
+            and issubclass(attr, OperatorLoopInterface)
+            and attr is not OperatorLoopInterface
+            and not inspect.isabstract(attr)
+        ):
+            return attr
+
+    return None
 
 
 class SimulationEngine:
@@ -349,22 +388,8 @@ class SimulationEngine:
         exec(source, mod.__dict__)  # noqa: S102
         sys.modules[mod_name] = mod
 
-        # Find the scenario class
-        from autocontext.scenarios.simulation import SimulationInterface
-        cls = None
-        for attr_name in dir(mod):
-            attr = getattr(mod, attr_name)
-            if isinstance(attr, type) and issubclass(attr, SimulationInterface) and attr is not SimulationInterface:
-                cls = attr
-                break
-        if cls is None:
-            # Try operator_loop interface
-            from autocontext.scenarios.operator_loop import OperatorLoopInterface
-            for attr_name in dir(mod):
-                attr = getattr(mod, attr_name)
-                if isinstance(attr, type) and issubclass(attr, OperatorLoopInterface) and attr is not OperatorLoopInterface:
-                    cls = attr
-                    break
+        # Find the scenario class (skip abstract classes — AC-520)
+        cls = _find_scenario_class(mod)
 
         if cls is None:
             return {"score": 0, "reasoning": "No scenario class found", "dimension_scores": {}}

--- a/autocontext/src/autocontext/storage/bootstrap_schema.py
+++ b/autocontext/src/autocontext/storage/bootstrap_schema.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+_BOOTSTRAP_MIGRATIONS = (
+    "001_initial.sql",
+    "002_phase3_phase7.sql",
+    "003_agent_subagent_metadata.sql",
+    "004_knowledge_inheritance.sql",
+    "005_ecosystem_provider_tracking.sql",
+    "006_human_feedback.sql",
+    "007_task_queue.sql",
+    "008_staged_validation.sql",
+    "009_generation_timing.sql",
+    "010_consultation_log.sql",
+    "010_session_notebook.sql",
+    "011_monitors.sql",
+    "012_research_hub.sql",
+    "013_generation_dimension_summary.sql",
+    "014_scoring_backend_metadata.sql",
+    "015_match_replay.sql",
+)
+
+
+def default_migrations_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "migrations"
+
+
+def bootstrap_core_schema(conn: sqlite3.Connection) -> None:
+    """Create the current storage schema when SQL migration files are unavailable."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            version TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        """
+    )
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS runs (
+            run_id TEXT PRIMARY KEY,
+            scenario TEXT NOT NULL,
+            target_generations INTEGER NOT NULL,
+            executor_mode TEXT NOT NULL,
+            status TEXT NOT NULL,
+            agent_provider TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS generations (
+            run_id TEXT NOT NULL,
+            generation_index INTEGER NOT NULL,
+            mean_score REAL NOT NULL,
+            best_score REAL NOT NULL,
+            gate_decision TEXT NOT NULL,
+            status TEXT NOT NULL,
+            elo REAL NOT NULL DEFAULT 1000.0,
+            wins INTEGER NOT NULL DEFAULT 0,
+            losses INTEGER NOT NULL DEFAULT 0,
+            duration_seconds REAL DEFAULT NULL,
+            dimension_summary_json TEXT DEFAULT NULL,
+            scoring_backend TEXT NOT NULL DEFAULT 'elo',
+            rating_uncertainty REAL DEFAULT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (run_id, generation_index),
+            FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS matches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            generation_index INTEGER NOT NULL,
+            seed INTEGER NOT NULL,
+            score REAL NOT NULL,
+            passed_validation INTEGER NOT NULL,
+            validation_errors TEXT NOT NULL DEFAULT '',
+            winner TEXT NOT NULL DEFAULT '',
+            strategy_json TEXT NOT NULL DEFAULT '',
+            replay_json TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY (run_id, generation_index)
+                REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS agent_outputs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            generation_index INTEGER NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY (run_id, generation_index)
+                REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS generation_recovery (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            generation_index INTEGER NOT NULL,
+            decision TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            retry_count INTEGER NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY (run_id, generation_index)
+                REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS agent_role_metrics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            generation_index INTEGER NOT NULL,
+            role TEXT NOT NULL,
+            model TEXT NOT NULL,
+            input_tokens INTEGER NOT NULL,
+            output_tokens INTEGER NOT NULL,
+            latency_ms INTEGER NOT NULL,
+            subagent_id TEXT NOT NULL DEFAULT '',
+            status TEXT NOT NULL DEFAULT 'completed',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY (run_id, generation_index)
+                REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS knowledge_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            scenario TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            best_score REAL NOT NULL,
+            best_elo REAL NOT NULL,
+            playbook_hash TEXT NOT NULL,
+            agent_provider TEXT NOT NULL DEFAULT '',
+            rlm_enabled INTEGER NOT NULL DEFAULT 0,
+            scoring_backend TEXT NOT NULL DEFAULT 'elo',
+            rating_uncertainty REAL DEFAULT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_knowledge_snapshots_scenario
+            ON knowledge_snapshots(scenario, best_score DESC);
+
+        CREATE TABLE IF NOT EXISTS human_feedback (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            scenario_name TEXT NOT NULL,
+            generation_id TEXT,
+            agent_output TEXT NOT NULL,
+            human_score REAL,
+            human_notes TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_feedback_scenario ON human_feedback(scenario_name);
+
+        CREATE TABLE IF NOT EXISTS task_queue (
+            id TEXT PRIMARY KEY,
+            spec_name TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            priority INTEGER NOT NULL DEFAULT 0,
+            config_json TEXT,
+            scheduled_at TEXT,
+            started_at TEXT,
+            completed_at TEXT,
+            best_score REAL,
+            best_output TEXT,
+            total_rounds INTEGER,
+            met_threshold INTEGER DEFAULT 0,
+            result_json TEXT,
+            error TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_task_queue_status ON task_queue(status);
+        CREATE INDEX IF NOT EXISTS idx_task_queue_priority ON task_queue(priority DESC, created_at ASC);
+        CREATE INDEX IF NOT EXISTS idx_task_queue_spec ON task_queue(spec_name);
+
+        CREATE TABLE IF NOT EXISTS staged_validation_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            generation_index INTEGER NOT NULL,
+            stage_order INTEGER NOT NULL,
+            stage_name TEXT NOT NULL,
+            status TEXT NOT NULL,
+            duration_ms REAL NOT NULL,
+            error TEXT,
+            error_code TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY (run_id, generation_index)
+                REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS consultation_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            generation_index INTEGER NOT NULL,
+            trigger TEXT NOT NULL,
+            context_summary TEXT NOT NULL DEFAULT '',
+            critique TEXT NOT NULL DEFAULT '',
+            alternative_hypothesis TEXT NOT NULL DEFAULT '',
+            tiebreak_recommendation TEXT NOT NULL DEFAULT '',
+            suggested_next_action TEXT NOT NULL DEFAULT '',
+            raw_response TEXT NOT NULL DEFAULT '',
+            model_used TEXT NOT NULL DEFAULT '',
+            cost_usd REAL,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            FOREIGN KEY (run_id) REFERENCES runs(run_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_consultation_log_run ON consultation_log(run_id);
+
+        CREATE TABLE IF NOT EXISTS session_notebooks (
+            session_id TEXT PRIMARY KEY,
+            scenario_name TEXT NOT NULL,
+            current_objective TEXT NOT NULL DEFAULT '',
+            current_hypotheses TEXT NOT NULL DEFAULT '[]',
+            best_run_id TEXT,
+            best_generation INTEGER,
+            best_score REAL,
+            unresolved_questions TEXT NOT NULL DEFAULT '[]',
+            operator_observations TEXT NOT NULL DEFAULT '[]',
+            follow_ups TEXT NOT NULL DEFAULT '[]',
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_session_notebooks_scenario ON session_notebooks(scenario_name);
+
+        CREATE TABLE IF NOT EXISTS monitor_conditions (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            condition_type TEXT NOT NULL,
+            params_json TEXT NOT NULL DEFAULT '{}',
+            scope TEXT NOT NULL DEFAULT 'global',
+            active INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS monitor_alerts (
+            id TEXT PRIMARY KEY,
+            condition_id TEXT NOT NULL,
+            condition_name TEXT NOT NULL,
+            condition_type TEXT NOT NULL,
+            scope TEXT NOT NULL DEFAULT 'global',
+            detail TEXT NOT NULL DEFAULT '',
+            payload_json TEXT NOT NULL DEFAULT '{}',
+            fired_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            FOREIGN KEY (condition_id) REFERENCES monitor_conditions(id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_monitor_conditions_active ON monitor_conditions(active);
+        CREATE INDEX IF NOT EXISTS idx_monitor_alerts_condition ON monitor_alerts(condition_id);
+        CREATE INDEX IF NOT EXISTS idx_monitor_alerts_fired_at ON monitor_alerts(fired_at DESC);
+
+        CREATE TABLE IF NOT EXISTS hub_sessions (
+            session_id TEXT PRIMARY KEY,
+            owner TEXT NOT NULL DEFAULT '',
+            status TEXT NOT NULL DEFAULT 'active',
+            lease_expires_at TEXT NOT NULL DEFAULT '',
+            last_heartbeat_at TEXT NOT NULL DEFAULT '',
+            shared INTEGER NOT NULL DEFAULT 0,
+            external_link TEXT NOT NULL DEFAULT '',
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            FOREIGN KEY (session_id) REFERENCES session_notebooks(session_id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_hub_sessions_status ON hub_sessions(status);
+        CREATE INDEX IF NOT EXISTS idx_hub_sessions_shared ON hub_sessions(shared);
+        CREATE INDEX IF NOT EXISTS idx_hub_sessions_heartbeat ON hub_sessions(last_heartbeat_at DESC);
+
+        CREATE TABLE IF NOT EXISTS hub_packages (
+            package_id TEXT PRIMARY KEY,
+            scenario_name TEXT NOT NULL,
+            scenario_family TEXT NOT NULL DEFAULT '',
+            source_run_id TEXT NOT NULL DEFAULT '',
+            source_generation INTEGER NOT NULL DEFAULT 0,
+            title TEXT NOT NULL DEFAULT '',
+            description TEXT NOT NULL DEFAULT '',
+            promotion_level TEXT NOT NULL DEFAULT 'experimental',
+            best_score REAL NOT NULL DEFAULT 0.0,
+            best_elo REAL NOT NULL DEFAULT 0.0,
+            payload_path TEXT NOT NULL DEFAULT '',
+            strategy_package_path TEXT NOT NULL DEFAULT '',
+            tags_json TEXT NOT NULL DEFAULT '[]',
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_hub_packages_scenario ON hub_packages(scenario_name);
+        CREATE INDEX IF NOT EXISTS idx_hub_packages_family ON hub_packages(scenario_family);
+        CREATE INDEX IF NOT EXISTS idx_hub_packages_source_run ON hub_packages(source_run_id);
+        CREATE INDEX IF NOT EXISTS idx_hub_packages_created_at ON hub_packages(created_at DESC);
+
+        CREATE TABLE IF NOT EXISTS hub_results (
+            result_id TEXT PRIMARY KEY,
+            scenario_name TEXT NOT NULL,
+            run_id TEXT NOT NULL DEFAULT '',
+            package_id TEXT,
+            title TEXT NOT NULL DEFAULT '',
+            best_score REAL NOT NULL DEFAULT 0.0,
+            best_elo REAL NOT NULL DEFAULT 0.0,
+            payload_path TEXT NOT NULL DEFAULT '',
+            tags_json TEXT NOT NULL DEFAULT '[]',
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_hub_results_scenario ON hub_results(scenario_name);
+        CREATE INDEX IF NOT EXISTS idx_hub_results_run ON hub_results(run_id);
+        CREATE INDEX IF NOT EXISTS idx_hub_results_package ON hub_results(package_id);
+        CREATE INDEX IF NOT EXISTS idx_hub_results_created_at ON hub_results(created_at DESC);
+
+        CREATE TABLE IF NOT EXISTS hub_promotions (
+            event_id TEXT PRIMARY KEY,
+            package_id TEXT NOT NULL DEFAULT '',
+            source_run_id TEXT NOT NULL DEFAULT '',
+            action TEXT NOT NULL DEFAULT '',
+            actor TEXT NOT NULL DEFAULT '',
+            label TEXT,
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_hub_promotions_package ON hub_promotions(package_id);
+        CREATE INDEX IF NOT EXISTS idx_hub_promotions_source_run ON hub_promotions(source_run_id);
+        CREATE INDEX IF NOT EXISTS idx_hub_promotions_created_at ON hub_promotions(created_at DESC);
+        """
+    )
+    conn.executemany(
+        "INSERT OR IGNORE INTO schema_migrations(version) VALUES (?)",
+        [(version,) for version in _BOOTSTRAP_MIGRATIONS],
+    )

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from autocontext.storage.bootstrap_schema import bootstrap_core_schema, default_migrations_dir
 from autocontext.storage.row_types import GenerationMetricsRow, RunRow
 
 if TYPE_CHECKING:
@@ -28,57 +29,19 @@ class SQLiteStore:
         return conn
 
     def ensure_core_tables(self) -> None:
-        """Create essential tables if they don't exist (AC-521).
-
-        This is a safety net for when migration files are unavailable
-        (e.g. pip-installed package where migrations/ isn't packaged).
-        Uses CREATE TABLE IF NOT EXISTS so it's safe to call after migrate().
-        """
+        """Create the current core schema when migration files are unavailable."""
+        migrations_dir = default_migrations_dir()
+        if migrations_dir.exists() and any(migrations_dir.glob("*.sql")):
+            self.migrate(migrations_dir)
+            return
         with self.connect() as conn:
-            conn.executescript("""
-                CREATE TABLE IF NOT EXISTS runs (
-                    run_id TEXT PRIMARY KEY,
-                    scenario TEXT NOT NULL,
-                    target_generations INTEGER NOT NULL,
-                    executor_mode TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    agent_provider TEXT NOT NULL DEFAULT '',
-                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-                );
-
-                CREATE TABLE IF NOT EXISTS generations (
-                    run_id TEXT NOT NULL,
-                    generation_index INTEGER NOT NULL,
-                    mean_score REAL NOT NULL,
-                    best_score REAL NOT NULL,
-                    gate_decision TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    elo REAL NOT NULL DEFAULT 1000.0,
-                    wins INTEGER NOT NULL DEFAULT 0,
-                    losses INTEGER NOT NULL DEFAULT 0,
-                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-                    PRIMARY KEY (run_id, generation_index),
-                    FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
-                );
-
-                CREATE TABLE IF NOT EXISTS matches (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    run_id TEXT NOT NULL,
-                    generation_index INTEGER NOT NULL,
-                    seed INTEGER NOT NULL,
-                    score REAL NOT NULL,
-                    passed_validation INTEGER NOT NULL,
-                    strategy TEXT NOT NULL,
-                    competitor_output TEXT NOT NULL DEFAULT '',
-                    judge_reasoning TEXT NOT NULL DEFAULT '',
-                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                    FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
-                );
-            """)
+            bootstrap_core_schema(conn)
 
     def migrate(self, migrations_dir: Path) -> None:
+        if not migrations_dir.exists() or not any(migrations_dir.glob("*.sql")):
+            with self.connect() as conn:
+                bootstrap_core_schema(conn)
+            return
         with self.connect() as conn:
             conn.execute(
                 """

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -27,6 +27,57 @@ class SQLiteStore:
         conn.execute(f"PRAGMA busy_timeout={SQLITE_BUSY_TIMEOUT_MS};")
         return conn
 
+    def ensure_core_tables(self) -> None:
+        """Create essential tables if they don't exist (AC-521).
+
+        This is a safety net for when migration files are unavailable
+        (e.g. pip-installed package where migrations/ isn't packaged).
+        Uses CREATE TABLE IF NOT EXISTS so it's safe to call after migrate().
+        """
+        with self.connect() as conn:
+            conn.executescript("""
+                CREATE TABLE IF NOT EXISTS runs (
+                    run_id TEXT PRIMARY KEY,
+                    scenario TEXT NOT NULL,
+                    target_generations INTEGER NOT NULL,
+                    executor_mode TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    agent_provider TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+
+                CREATE TABLE IF NOT EXISTS generations (
+                    run_id TEXT NOT NULL,
+                    generation_index INTEGER NOT NULL,
+                    mean_score REAL NOT NULL,
+                    best_score REAL NOT NULL,
+                    gate_decision TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    elo REAL NOT NULL DEFAULT 1000.0,
+                    wins INTEGER NOT NULL DEFAULT 0,
+                    losses INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    PRIMARY KEY (run_id, generation_index),
+                    FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS matches (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id TEXT NOT NULL,
+                    generation_index INTEGER NOT NULL,
+                    seed INTEGER NOT NULL,
+                    score REAL NOT NULL,
+                    passed_validation INTEGER NOT NULL,
+                    strategy TEXT NOT NULL,
+                    competitor_output TEXT NOT NULL DEFAULT '',
+                    judge_reasoning TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+                );
+            """)
+
     def migrate(self, migrations_dir: Path) -> None:
         with self.connect() as conn:
             conn.execute(

--- a/autocontext/tests/test_simulate_bug_fixes.py
+++ b/autocontext/tests/test_simulate_bug_fixes.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import inspect
+import types
 from abc import abstractmethod
 
 import pytest
@@ -44,9 +45,8 @@ class TestAbstractClassFiltering:
 
     def test_find_scenario_class_skips_abstract(self) -> None:
         """The helper should skip abstract classes and find concrete ones."""
-        from autocontext.simulation.engine import _find_scenario_class
-
         from autocontext.scenarios.simulation import SimulationInterface
+        from autocontext.simulation.engine import _find_scenario_class
 
         class AbstractMiddle(SimulationInterface):
             @abstractmethod
@@ -64,7 +64,6 @@ class TestAbstractClassFiltering:
             def custom_method(self): return "done"
 
         # Build a fake module namespace
-        import types
         mod = types.ModuleType("fake_mod")
         mod.AbstractMiddle = AbstractMiddle  # type: ignore[attr-defined]
         mod.ConcreteEnd = ConcreteEnd  # type: ignore[attr-defined]
@@ -76,7 +75,6 @@ class TestAbstractClassFiltering:
     def test_find_scenario_class_returns_none_when_all_abstract(self) -> None:
         from autocontext.simulation.engine import _find_scenario_class
 
-        import types
         mod = types.ModuleType("empty_mod")
         found = _find_scenario_class(mod)
         assert found is None

--- a/autocontext/tests/test_simulate_bug_fixes.py
+++ b/autocontext/tests/test_simulate_bug_fixes.py
@@ -1,0 +1,106 @@
+"""Tests for AC-520 bug fixes.
+
+1. Abstract class filtering in simulation engine class selection
+2. CLI exits non-zero when JSON output has status=failed
+"""
+
+from __future__ import annotations
+
+import inspect
+from abc import abstractmethod
+
+import pytest
+
+
+class TestAbstractClassFiltering:
+    """Engine should skip abstract classes when selecting scenario class."""
+
+    def test_inspect_isabstract_detects_abstract_class(self) -> None:
+        """Verify inspect.isabstract works on our scenario ABCs."""
+        from autocontext.scenarios.simulation import SimulationInterface
+
+        assert inspect.isabstract(SimulationInterface)
+
+    def test_inspect_isabstract_detects_operator_loop(self) -> None:
+        from autocontext.scenarios.operator_loop import OperatorLoopInterface
+
+        assert inspect.isabstract(OperatorLoopInterface)
+
+    def test_concrete_subclass_is_not_abstract(self) -> None:
+        """A concrete subclass should pass the filter."""
+        from autocontext.scenarios.simulation import SimulationInterface
+
+        class ConcreteScenario(SimulationInterface):
+            def describe_scenario(self): return "test"
+            def describe_environment(self): return None  # type: ignore[return-value]
+            def initial_state(self, seed=None): return {}
+            def get_available_actions(self, state): return []
+            def execute_action(self, state, action): return None, state  # type: ignore[return-value]
+            def is_terminal(self, state): return True
+            def evaluate_trace(self, trace, final_state): return None  # type: ignore[return-value]
+            def get_rubric(self): return "rubric"
+
+        assert not inspect.isabstract(ConcreteScenario)
+
+    def test_find_scenario_class_skips_abstract(self) -> None:
+        """The helper should skip abstract classes and find concrete ones."""
+        from autocontext.simulation.engine import _find_scenario_class
+
+        from autocontext.scenarios.simulation import SimulationInterface
+
+        class AbstractMiddle(SimulationInterface):
+            @abstractmethod
+            def custom_method(self): ...
+
+        class ConcreteEnd(AbstractMiddle):
+            def describe_scenario(self): return "test"
+            def describe_environment(self): return None  # type: ignore[return-value]
+            def initial_state(self, seed=None): return {}
+            def get_available_actions(self, state): return []
+            def execute_action(self, state, action): return None, state  # type: ignore[return-value]
+            def is_terminal(self, state): return True
+            def evaluate_trace(self, trace, final_state): return None  # type: ignore[return-value]
+            def get_rubric(self): return "rubric"
+            def custom_method(self): return "done"
+
+        # Build a fake module namespace
+        import types
+        mod = types.ModuleType("fake_mod")
+        mod.AbstractMiddle = AbstractMiddle  # type: ignore[attr-defined]
+        mod.ConcreteEnd = ConcreteEnd  # type: ignore[attr-defined]
+        mod.SimulationInterface = SimulationInterface  # type: ignore[attr-defined]
+
+        found = _find_scenario_class(mod)
+        assert found is ConcreteEnd
+
+    def test_find_scenario_class_returns_none_when_all_abstract(self) -> None:
+        from autocontext.simulation.engine import _find_scenario_class
+
+        import types
+        mod = types.ModuleType("empty_mod")
+        found = _find_scenario_class(mod)
+        assert found is None
+
+
+class TestCliJsonExitCode:
+    """CLI should exit non-zero when JSON result has status=failed."""
+
+    def test_simulate_json_failed_exits_nonzero(self) -> None:
+        """Verify the _check_json_exit helper raises on failure."""
+        from autocontext.cli import _check_json_exit
+
+        with pytest.raises(SystemExit) as exc_info:
+            _check_json_exit({"status": "failed", "error": "boom"})
+        assert exc_info.value.code != 0
+
+    def test_simulate_json_success_does_not_exit(self) -> None:
+        from autocontext.cli import _check_json_exit
+
+        # Should NOT raise
+        _check_json_exit({"status": "completed", "score": 0.5})
+
+    def test_simulate_json_missing_status_does_not_exit(self) -> None:
+        from autocontext.cli import _check_json_exit
+
+        # Missing status key — no crash, no exit
+        _check_json_exit({"score": 0.5})

--- a/autocontext/tests/test_sqlite_store_bootstrap.py
+++ b/autocontext/tests/test_sqlite_store_bootstrap.py
@@ -6,30 +6,47 @@ unavailable (e.g. installed via pip where migrations/ is not packaged).
 
 from __future__ import annotations
 
-import sqlite3
 from pathlib import Path
-
-import pytest
 
 
 class TestBootstrapSchema:
     """SQLiteStore should work on a fresh DB without external migration files."""
 
-    def test_create_run_on_fresh_db(self, tmp_path: Path) -> None:
+    def test_migrate_falls_back_when_migrations_are_missing(self, tmp_path: Path) -> None:
         from autocontext.storage.sqlite_store import SQLiteStore
 
         store = SQLiteStore(tmp_path / "fresh.db")
-        store.ensure_core_tables()
-        # Should NOT raise sqlite3.OperationalError: no such table: runs
+        store.migrate(tmp_path / "missing-migrations")
         store.create_run("r1", "test_scenario", 3, "local")
+        store.upsert_generation(
+            "r1",
+            0,
+            0.25,
+            0.5,
+            1000.0,
+            1,
+            0,
+            "accept",
+            "completed",
+            duration_seconds=1.5,
+            dimension_summary_json='{"quality": 0.5}',
+            scoring_backend="elo",
+            rating_uncertainty=0.2,
+        )
+        rows = store.get_generation_metrics("r1")
+        assert len(rows) == 1
+        assert rows[0]["duration_seconds"] == 1.5
+        assert rows[0]["scoring_backend"] == "elo"
 
-    def test_list_runs_on_fresh_db(self, tmp_path: Path) -> None:
+    def test_bootstrapped_db_can_later_run_real_migrations(self, tmp_path: Path) -> None:
         from autocontext.storage.sqlite_store import SQLiteStore
 
         store = SQLiteStore(tmp_path / "fresh.db")
-        store.ensure_core_tables()
+        store.migrate(tmp_path / "missing-migrations")
+        store.migrate(Path(__file__).resolve().parents[1] / "migrations")
+        store.create_run("r1", "test_scenario", 3, "local")
         rows = store.list_runs(limit=10)
-        assert rows == []
+        assert len(rows) == 1
 
     def test_ensure_core_tables_is_idempotent(self, tmp_path: Path) -> None:
         from autocontext.storage.sqlite_store import SQLiteStore
@@ -38,27 +55,24 @@ class TestBootstrapSchema:
         store.ensure_core_tables()
         store.ensure_core_tables()  # second call should not error
         store.create_run("r1", "test", 1, "local")
+        rows = store.list_runs(limit=10)
+        assert len(rows) == 1
 
     def test_migrate_then_ensure_does_not_conflict(self, tmp_path: Path) -> None:
         """If migrations ran first, ensure_core_tables should still be safe."""
         from autocontext.storage.sqlite_store import SQLiteStore
 
         store = SQLiteStore(tmp_path / "migrated.db")
-        # First ensure creates tables
-        store.ensure_core_tables()
-        # Second ensure should be idempotent
+        store.migrate(Path(__file__).resolve().parents[1] / "migrations")
         store.ensure_core_tables()
         store.create_run("r1", "test", 1, "local")
         rows = store.list_runs(limit=1)
         assert len(rows) == 1
 
-    def test_generation_runner_calls_ensure(self, tmp_path: Path) -> None:
-        """ensure_core_tables allows create_run + list_runs on fresh DB."""
+    def test_list_runs_on_fresh_db(self, tmp_path: Path) -> None:
         from autocontext.storage.sqlite_store import SQLiteStore
 
         store = SQLiteStore(tmp_path / "runner.db")
         store.ensure_core_tables()
-        store.create_run("test-run", "scenario", 1, "local")
         rows = store.list_runs(limit=10)
-        assert len(rows) == 1
-        assert rows[0]["scenario"] == "scenario"
+        assert rows == []

--- a/autocontext/tests/test_sqlite_store_bootstrap.py
+++ b/autocontext/tests/test_sqlite_store_bootstrap.py
@@ -1,0 +1,64 @@
+"""Tests for AC-521: SQLite store bootstrap on clean workspace.
+
+The store must create required tables even when migration files are
+unavailable (e.g. installed via pip where migrations/ is not packaged).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+class TestBootstrapSchema:
+    """SQLiteStore should work on a fresh DB without external migration files."""
+
+    def test_create_run_on_fresh_db(self, tmp_path: Path) -> None:
+        from autocontext.storage.sqlite_store import SQLiteStore
+
+        store = SQLiteStore(tmp_path / "fresh.db")
+        store.ensure_core_tables()
+        # Should NOT raise sqlite3.OperationalError: no such table: runs
+        store.create_run("r1", "test_scenario", 3, "local")
+
+    def test_list_runs_on_fresh_db(self, tmp_path: Path) -> None:
+        from autocontext.storage.sqlite_store import SQLiteStore
+
+        store = SQLiteStore(tmp_path / "fresh.db")
+        store.ensure_core_tables()
+        rows = store.list_runs(limit=10)
+        assert rows == []
+
+    def test_ensure_core_tables_is_idempotent(self, tmp_path: Path) -> None:
+        from autocontext.storage.sqlite_store import SQLiteStore
+
+        store = SQLiteStore(tmp_path / "fresh.db")
+        store.ensure_core_tables()
+        store.ensure_core_tables()  # second call should not error
+        store.create_run("r1", "test", 1, "local")
+
+    def test_migrate_then_ensure_does_not_conflict(self, tmp_path: Path) -> None:
+        """If migrations ran first, ensure_core_tables should still be safe."""
+        from autocontext.storage.sqlite_store import SQLiteStore
+
+        store = SQLiteStore(tmp_path / "migrated.db")
+        # First ensure creates tables
+        store.ensure_core_tables()
+        # Second ensure should be idempotent
+        store.ensure_core_tables()
+        store.create_run("r1", "test", 1, "local")
+        rows = store.list_runs(limit=1)
+        assert len(rows) == 1
+
+    def test_generation_runner_calls_ensure(self, tmp_path: Path) -> None:
+        """ensure_core_tables allows create_run + list_runs on fresh DB."""
+        from autocontext.storage.sqlite_store import SQLiteStore
+
+        store = SQLiteStore(tmp_path / "runner.db")
+        store.ensure_core_tables()
+        store.create_run("test-run", "scenario", 1, "local")
+        rows = store.list_runs(limit=10)
+        assert len(rows) == 1
+        assert rows[0]["scenario"] == "scenario"


### PR DESCRIPTION
Fixes two P0 bugs found in live testing of autocontext==0.3.2:

**AC-520**: `simulate` picks abstract `OperatorLoopInterface` instead of generated concrete class. Fixed by adding `inspect.isabstract()` filter to extracted `_find_scenario_class()`. Also fixed CLI exiting 0 on JSON failure — added `_check_json_exit()` to all simulate JSON output paths.

**AC-521**: `solve` fails on clean pip-installed workspace with `no such table: runs`. Root cause: `migrations/` directory excluded from wheel. Fixed by adding `ensure_core_tables()` to `SQLiteStore` that creates essential tables inline via `CREATE TABLE IF NOT EXISTS`, wired into `GenerationRunner.__init__()`.

13 TDD tests added.