### PR TITLE
fix: align provider surfaces — KNOWN_PROVIDERS, factory, README (AC-522)

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -14,7 +14,7 @@ Need the canonical product/runtime vocabulary first? Start with [docs/concept-mo
 - **Knowledge system**: versioned playbooks, score trajectories, session reports, dead-end tracking
 - **Interactive server**: HTTP API, WebSocket control plane, bundled Ink TUI
 - **MCP control plane**: 40+ tools covering scenarios, runs, knowledge, evaluation, feedback, solve, sandbox, and export
-- **Provider routing**: Anthropic, OpenAI-compatible, Ollama, vLLM, Hermes, Pi, Pi-RPC, deterministic
+- **Provider routing**: Anthropic, OpenAI-compatible, Gemini, Mistral, Groq, OpenRouter, Azure OpenAI, Ollama, vLLM, Hermes, Pi, Pi-RPC, deterministic
 - **Evaluation**: one-shot judging, multi-round improvement loops, REPL-loop sessions
 - **Package management**: strategy package export/import, training data export
 - **Training hook surface**: dataset validation and executor-backed `train` entry point

--- a/ts/README.md
+++ b/ts/README.md
@@ -127,7 +127,7 @@ AUTOCONTEXT_AGENT_PROVIDER=pi autoctx run --scenario support_triage --json
 AUTOCONTEXT_AGENT_PROVIDER=deterministic autoctx run --scenario support_triage --json
 ```
 
-Supported providers: `anthropic`, `openai`, `openai-compatible`, `ollama`, `vllm`, `hermes`, `pi`, `pi-rpc`, `deterministic`.
+Supported providers: `anthropic`, `openai`, `openai-compatible`, `gemini`, `mistral`, `groq`, `openrouter`, `azure-openai`, `ollama`, `vllm`, `hermes`, `pi`, `pi-rpc`, `deterministic`.
 
 `autoctx simulate` and `autoctx investigate` require a configured provider for spec generation. If you want synthetic placeholder behavior for CI/testing, select the deterministic provider explicitly instead of relying on implicit fallback.
 

--- a/ts/src/config/credentials.ts
+++ b/ts/src/config/credentials.ts
@@ -176,6 +176,10 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
   { id: "azure-openai", displayName: "Azure OpenAI", envVar: "AZURE_OPENAI_API_KEY", requiresKey: true },
   { id: "ollama", displayName: "Ollama", defaultBaseUrl: "http://localhost:11434", requiresKey: false },
   { id: "vllm", displayName: "vLLM", defaultBaseUrl: "http://localhost:8000", requiresKey: false },
+  { id: "hermes", displayName: "Hermes Gateway", defaultBaseUrl: "http://localhost:8080", requiresKey: false },
+  { id: "openai-compatible", displayName: "OpenAI-Compatible", requiresKey: true },
+  { id: "pi", displayName: "Pi (CLI)", requiresKey: false },
+  { id: "pi-rpc", displayName: "Pi (RPC)", requiresKey: false },
   { id: "deterministic", displayName: "Deterministic (testing)", requiresKey: false },
 ];
 

--- a/ts/src/providers/index.ts
+++ b/ts/src/providers/index.ts
@@ -209,12 +209,29 @@ export function createProvider(opts: CreateProviderOpts): LLMProvider {
     return new RuntimeBridgeProvider(runtime as any, opts.model ?? "pi-rpc-default");
   }
 
+  // OpenAI-compatible providers with per-service defaults
+  const OPENAI_COMPATIBLE_DEFAULTS: Record<string, { baseUrl: string; envVar: string }> = {
+    gemini: { baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai", envVar: "GEMINI_API_KEY" },
+    mistral: { baseUrl: "https://api.mistral.ai/v1", envVar: "MISTRAL_API_KEY" },
+    groq: { baseUrl: "https://api.groq.com/openai/v1", envVar: "GROQ_API_KEY" },
+    openrouter: { baseUrl: "https://openrouter.ai/api/v1", envVar: "OPENROUTER_API_KEY" },
+    "azure-openai": { baseUrl: opts.baseUrl ?? "", envVar: "AZURE_OPENAI_API_KEY" },
+  };
+  const compat = OPENAI_COMPATIBLE_DEFAULTS[type];
+  if (compat) {
+    return createOpenAICompatibleProvider({
+      apiKey: opts.apiKey ?? process.env[compat.envVar] ?? "",
+      baseUrl: opts.baseUrl ?? compat.baseUrl,
+      model: opts.model,
+    });
+  }
+
   if (type === "deterministic") {
     return new DeterministicProvider();
   }
 
   throw new ProviderError(
-    `Unknown provider type: ${JSON.stringify(type)}. Supported: anthropic, openai, openai-compatible, ollama, vllm, hermes, pi, pi-rpc, deterministic`,
+    `Unknown provider type: ${JSON.stringify(type)}. Supported: anthropic, openai, openai-compatible, ollama, vllm, hermes, gemini, mistral, groq, openrouter, azure-openai, pi, pi-rpc, deterministic`,
   );
 }
 

--- a/ts/src/providers/index.ts
+++ b/ts/src/providers/index.ts
@@ -7,7 +7,7 @@
 
 import { ProviderError } from "../types/index.js";
 import type { CompletionResult, LLMProvider } from "../types/index.js";
-import { loadPersistedCredentials, loadProjectConfig } from "../config/index.js";
+import { getKnownProvider, loadPersistedCredentials, loadProjectConfig } from "../config/index.js";
 import { DeterministicProvider } from "./deterministic.js";
 import { PiCLIRuntime, PiCLIConfig } from "../runtimes/pi-cli.js";
 import { PiRPCRuntime, PiRPCConfig } from "../runtimes/pi-rpc.js";
@@ -127,6 +127,37 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
   };
 }
 
+const OPENAI_COMPATIBLE_PROVIDER_DEFAULTS: Record<string, {
+  baseUrl?: string;
+  envVar: string;
+  defaultModel: string;
+}> = {
+  gemini: {
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+    envVar: "GEMINI_API_KEY",
+    defaultModel: "gemini-2.5-pro",
+  },
+  mistral: {
+    baseUrl: "https://api.mistral.ai/v1",
+    envVar: "MISTRAL_API_KEY",
+    defaultModel: "mistral-large-latest",
+  },
+  groq: {
+    baseUrl: "https://api.groq.com/openai/v1",
+    envVar: "GROQ_API_KEY",
+    defaultModel: "llama-3.3-70b-versatile",
+  },
+  openrouter: {
+    baseUrl: "https://openrouter.ai/api/v1",
+    envVar: "OPENROUTER_API_KEY",
+    defaultModel: "anthropic/claude-sonnet-4",
+  },
+  "azure-openai": {
+    envVar: "AZURE_OPENAI_API_KEY",
+    defaultModel: "gpt-4o",
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
@@ -210,19 +241,12 @@ export function createProvider(opts: CreateProviderOpts): LLMProvider {
   }
 
   // OpenAI-compatible providers with per-service defaults
-  const OPENAI_COMPATIBLE_DEFAULTS: Record<string, { baseUrl: string; envVar: string }> = {
-    gemini: { baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai", envVar: "GEMINI_API_KEY" },
-    mistral: { baseUrl: "https://api.mistral.ai/v1", envVar: "MISTRAL_API_KEY" },
-    groq: { baseUrl: "https://api.groq.com/openai/v1", envVar: "GROQ_API_KEY" },
-    openrouter: { baseUrl: "https://openrouter.ai/api/v1", envVar: "OPENROUTER_API_KEY" },
-    "azure-openai": { baseUrl: opts.baseUrl ?? "", envVar: "AZURE_OPENAI_API_KEY" },
-  };
-  const compat = OPENAI_COMPATIBLE_DEFAULTS[type];
+  const compat = OPENAI_COMPATIBLE_PROVIDER_DEFAULTS[type];
   if (compat) {
     return createOpenAICompatibleProvider({
       apiKey: opts.apiKey ?? process.env[compat.envVar] ?? "",
       baseUrl: opts.baseUrl ?? compat.baseUrl,
-      model: opts.model,
+      model: opts.model ?? compat.defaultModel,
     });
   }
 
@@ -338,11 +362,29 @@ export function resolveProviderConfig(
     return { providerType: type, apiKey: genericKey, baseUrl, model };
   }
 
-  // openai, openai-compatible, and other generic types
-  const apiKey = genericKey ?? process.env.OPENAI_API_KEY;
+  const providerSpecificEnvVar =
+    OPENAI_COMPATIBLE_PROVIDER_DEFAULTS[type]?.envVar ??
+    getKnownProvider(type)?.envVar;
+  const providerSpecificKey = providerSpecificEnvVar
+    ? process.env[providerSpecificEnvVar]
+    : undefined;
+  const openaiFallbackKey =
+    type === "openai" || type === "openai-compatible"
+      ? process.env.OPENAI_API_KEY
+      : undefined;
+  const apiKey = genericKey ?? providerSpecificKey ?? openaiFallbackKey;
   if (!apiKey) {
+    const keyVars = [
+      "AUTOCONTEXT_API_KEY",
+      "AUTOCONTEXT_AGENT_API_KEY",
+    ];
+    if (providerSpecificEnvVar) {
+      keyVars.push(providerSpecificEnvVar);
+    } else if (type === "openai" || type === "openai-compatible") {
+      keyVars.push("OPENAI_API_KEY");
+    }
     throw new ProviderError(
-      "API key required: set AUTOCONTEXT_API_KEY, AUTOCONTEXT_AGENT_API_KEY, or OPENAI_API_KEY",
+      `API key required: set ${keyVars.join(", or ")}`,
     );
   }
   return { providerType: type, apiKey, baseUrl, model };

--- a/ts/tests/provider-routing.test.ts
+++ b/ts/tests/provider-routing.test.ts
@@ -11,6 +11,16 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PROVIDER_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "MISTRAL_API_KEY",
+  "GROQ_API_KEY",
+  "OPENROUTER_API_KEY",
+  "AZURE_OPENAI_API_KEY",
+] as const;
+
 function makeTempDir(): string {
   return mkdtempSync(join(tmpdir(), "ac-provider-routing-"));
 }
@@ -19,7 +29,7 @@ const savedEnv: Record<string, string | undefined> = {};
 
 function restoreProviderEnv(): void {
   for (const key of Object.keys(process.env)) {
-    if (key.startsWith("AUTOCONTEXT_") || key === "ANTHROPIC_API_KEY" || key === "OPENAI_API_KEY") {
+    if (key.startsWith("AUTOCONTEXT_") || PROVIDER_ENV_KEYS.includes(key as typeof PROVIDER_ENV_KEYS[number])) {
       if (key in savedEnv) {
         process.env[key] = savedEnv[key];
       } else {
@@ -31,7 +41,7 @@ function restoreProviderEnv(): void {
 
 function saveAndClearProviderEnv(): void {
   for (const key of Object.keys(process.env)) {
-    if (key.startsWith("AUTOCONTEXT_") || key === "ANTHROPIC_API_KEY" || key === "OPENAI_API_KEY") {
+    if (key.startsWith("AUTOCONTEXT_") || PROVIDER_ENV_KEYS.includes(key as typeof PROVIDER_ENV_KEYS[number])) {
       savedEnv[key] = process.env[key];
       delete process.env[key];
     }
@@ -134,6 +144,27 @@ describe("resolveProviderConfig env var alignment", () => {
     const { resolveProviderConfig } = await import("../src/providers/index.js");
     const config = resolveProviderConfig();
     expect(config.providerType).toBe("hermes");
+  });
+
+  it("uses provider-specific API key env vars for new compat providers", async () => {
+    const { resolveProviderConfig } = await import("../src/providers/index.js");
+    const providerEnvPairs = [
+      ["gemini", "GEMINI_API_KEY", "gem-key"],
+      ["mistral", "MISTRAL_API_KEY", "mistral-key"],
+      ["groq", "GROQ_API_KEY", "groq-key"],
+      ["openrouter", "OPENROUTER_API_KEY", "openrouter-key"],
+      ["azure-openai", "AZURE_OPENAI_API_KEY", "azure-key"],
+    ] as const;
+
+    for (const [providerType, envVar, apiKey] of providerEnvPairs) {
+      saveAndClearProviderEnv();
+      process.env.AUTOCONTEXT_AGENT_PROVIDER = providerType;
+      process.env[envVar] = apiKey;
+
+      const config = resolveProviderConfig();
+      expect(config.providerType).toBe(providerType);
+      expect(config.apiKey).toBe(apiKey);
+    }
   });
 });
 

--- a/ts/tests/provider-surface-consistency.test.ts
+++ b/ts/tests/provider-surface-consistency.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for AC-522: Provider surface consistency.
+ *
+ * KNOWN_PROVIDERS (credentials.ts), createProvider() factory,
+ * and README must all agree on which providers exist.
+ */
+
+import { describe, expect, it } from "vitest";
+
+describe("Provider surface consistency", () => {
+  it("KNOWN_PROVIDERS includes all createProvider factory types", async () => {
+    const { KNOWN_PROVIDERS } = await import("../src/config/credentials.js");
+    const knownIds = new Set(KNOWN_PROVIDERS.map((p: { id: string }) => p.id));
+
+    // These are all types that createProvider() can handle
+    const factoryTypes = [
+      "anthropic",
+      "openai",
+      "openai-compatible",
+      "ollama",
+      "vllm",
+      "hermes",
+      "pi",
+      "pi-rpc",
+      "deterministic",
+    ];
+
+    for (const type of factoryTypes) {
+      expect(knownIds.has(type), `KNOWN_PROVIDERS missing factory type: ${type}`).toBe(true);
+    }
+  });
+
+  it("createProvider() handles all KNOWN_PROVIDERS ids", async () => {
+    const { KNOWN_PROVIDERS } = await import("../src/config/credentials.js");
+    const { createProvider } = await import("../src/providers/index.js");
+
+    // Every KNOWN_PROVIDER id should be accepted by createProvider without throwing "Unknown provider"
+    // We can't fully construct all (missing API keys), but the factory should recognize the type
+    const knownIds = KNOWN_PROVIDERS.map((p: { id: string }) => p.id);
+
+    for (const id of knownIds) {
+      // For key-requiring providers, createProvider may throw on missing key,
+      // but should NOT throw "Unknown provider type"
+      try {
+        createProvider({ providerType: id });
+      } catch (e: any) {
+        expect(e.message).not.toContain("Unknown provider type");
+      }
+    }
+  });
+
+  it("KNOWN_PROVIDERS has entries for pi, pi-rpc, hermes", async () => {
+    const { KNOWN_PROVIDERS } = await import("../src/config/credentials.js");
+    const ids = KNOWN_PROVIDERS.map((p: { id: string }) => p.id);
+
+    expect(ids).toContain("pi");
+    expect(ids).toContain("pi-rpc");
+    expect(ids).toContain("hermes");
+  });
+
+  it("KNOWN_PROVIDERS has at least 13 entries (all providers)", async () => {
+    const { KNOWN_PROVIDERS } = await import("../src/config/credentials.js");
+    expect(KNOWN_PROVIDERS.length).toBeGreaterThanOrEqual(13);
+  });
+});

--- a/ts/tests/provider-surface-consistency.test.ts
+++ b/ts/tests/provider-surface-consistency.test.ts
@@ -5,27 +5,40 @@
  * and README must all agree on which providers exist.
  */
 
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
+
+const EXPECTED_PROVIDER_IDS = [
+  "anthropic",
+  "openai",
+  "openai-compatible",
+  "gemini",
+  "mistral",
+  "groq",
+  "openrouter",
+  "azure-openai",
+  "ollama",
+  "vllm",
+  "hermes",
+  "pi",
+  "pi-rpc",
+  "deterministic",
+] as const;
+
+function readSupportedProvidersFromReadme(): string[] {
+  const readme = readFileSync(new URL("../README.md", import.meta.url), "utf8");
+  const match = readme.match(/^Supported providers:\s+(.+)$/m);
+  expect(match, "README missing supported providers line").not.toBeNull();
+  return [...match![1].matchAll(/`([^`]+)`/g)].map((entry) => entry[1]);
+}
 
 describe("Provider surface consistency", () => {
   it("KNOWN_PROVIDERS includes all createProvider factory types", async () => {
     const { KNOWN_PROVIDERS } = await import("../src/config/credentials.js");
     const knownIds = new Set(KNOWN_PROVIDERS.map((p: { id: string }) => p.id));
 
-    // These are all types that createProvider() can handle
-    const factoryTypes = [
-      "anthropic",
-      "openai",
-      "openai-compatible",
-      "ollama",
-      "vllm",
-      "hermes",
-      "pi",
-      "pi-rpc",
-      "deterministic",
-    ];
-
-    for (const type of factoryTypes) {
+    for (const type of EXPECTED_PROVIDER_IDS) {
       expect(knownIds.has(type), `KNOWN_PROVIDERS missing factory type: ${type}`).toBe(true);
     }
   });
@@ -49,6 +62,16 @@ describe("Provider surface consistency", () => {
     }
   });
 
+  it("new compat providers use provider-specific default models", async () => {
+    const { createProvider } = await import("../src/providers/index.js");
+
+    expect(createProvider({ providerType: "gemini", apiKey: "gem-key" }).defaultModel()).toBe("gemini-2.5-pro");
+    expect(createProvider({ providerType: "mistral", apiKey: "mistral-key" }).defaultModel()).toBe("mistral-large-latest");
+    expect(createProvider({ providerType: "groq", apiKey: "groq-key" }).defaultModel()).toBe("llama-3.3-70b-versatile");
+    expect(createProvider({ providerType: "openrouter", apiKey: "openrouter-key" }).defaultModel()).toBe("anthropic/claude-sonnet-4");
+    expect(createProvider({ providerType: "azure-openai", apiKey: "azure-key", baseUrl: "https://azure.example.com/openai/v1" }).defaultModel()).toBe("gpt-4o");
+  });
+
   it("KNOWN_PROVIDERS has entries for pi, pi-rpc, hermes", async () => {
     const { KNOWN_PROVIDERS } = await import("../src/config/credentials.js");
     const ids = KNOWN_PROVIDERS.map((p: { id: string }) => p.id);
@@ -58,8 +81,14 @@ describe("Provider surface consistency", () => {
     expect(ids).toContain("hermes");
   });
 
-  it("KNOWN_PROVIDERS has at least 13 entries (all providers)", async () => {
+  it("KNOWN_PROVIDERS has all expected provider entries", async () => {
     const { KNOWN_PROVIDERS } = await import("../src/config/credentials.js");
-    expect(KNOWN_PROVIDERS.length).toBeGreaterThanOrEqual(13);
+    const ids = KNOWN_PROVIDERS.map((p: { id: string }) => p.id).sort();
+    expect(ids).toEqual([...EXPECTED_PROVIDER_IDS].sort());
+  });
+
+  it("README supported providers line matches the runtime provider surface", () => {
+    const readmeIds = readSupportedProvidersFromReadme().sort();
+    expect(readmeIds).toEqual([...EXPECTED_PROVIDER_IDS].sort());
   });
 });


### PR DESCRIPTION
Aligns all three provider surfaces: KNOWN_PROVIDERS (10→14 entries), createProvider() factory (added gemini/mistral/groq/openrouter/azure-openai via OpenAI-compatible defaults), and README. 4 TDD consistency tests added. Resolves AC-522.