### PR TITLE
feat: environment snapshot + evidence workspace (AC-503, AC-504)

### DIFF
--- a/autocontext/src/autocontext/bootstrap/__init__.py
+++ b/autocontext/src/autocontext/bootstrap/__init__.py
@@ -1,0 +1,18 @@
+"""Environment snapshot bootstrapping (AC-503)."""
+
+from __future__ import annotations
+
+from autocontext.bootstrap.collector import collect_snapshot
+from autocontext.bootstrap.redactor import RedactionConfig, redact_snapshot
+from autocontext.bootstrap.renderer import render_full_json, render_prompt_section
+from autocontext.bootstrap.snapshot import EnvironmentSnapshot, PackageInfo
+
+__all__ = [
+    "EnvironmentSnapshot",
+    "PackageInfo",
+    "collect_snapshot",
+    "RedactionConfig",
+    "redact_snapshot",
+    "render_prompt_section",
+    "render_full_json",
+]

--- a/autocontext/src/autocontext/bootstrap/collector.py
+++ b/autocontext/src/autocontext/bootstrap/collector.py
@@ -1,0 +1,282 @@
+"""Environment snapshot collector (AC-503).
+
+Gathers environment info via stdlib only. Each helper catches all exceptions
+and returns sensible defaults — the collector never raises.
+"""
+
+from __future__ import annotations
+
+import datetime
+import importlib.metadata
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from autocontext.bootstrap.snapshot import EnvironmentSnapshot, PackageInfo
+
+_SUBPROCESS_TIMEOUT = 0.5  # seconds
+_MAX_NOTABLE_FILES = 50
+_KNOWN_LOCKFILES = frozenset(
+    {
+        "poetry.lock",
+        "Pipfile.lock",
+        "uv.lock",
+        "pdm.lock",
+        "conda-lock.yml",
+        "package-lock.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "bun.lock",
+        "Gemfile.lock",
+        "Cargo.lock",
+        "go.sum",
+        "composer.lock",
+    }
+)
+_RUNTIME_CHECKS = {
+    "node": ["node", "--version"],
+    "go": ["go", "version"],
+    "ruby": ["ruby", "--version"],
+    "java": ["java", "-version"],
+    "rustc": ["rustc", "--version"],
+    "cargo": ["cargo", "--version"],
+    "deno": ["deno", "--version"],
+    "bun": ["bun", "--version"],
+}
+
+
+def collect_snapshot() -> EnvironmentSnapshot:
+    """Collect full environment snapshot. Never raises."""
+    core = _collect_core()
+    runtimes = _collect_runtimes()
+    packages = _collect_packages()
+    fs = _collect_filesystem(core["working_directory"])
+    git = _collect_git()
+    system = _collect_system()
+
+    return EnvironmentSnapshot(
+        **core,
+        **runtimes,
+        **packages,
+        **fs,
+        **git,
+        **system,
+        collected_at=datetime.datetime.now(datetime.UTC).isoformat(),
+    )
+
+
+def _collect_core() -> dict[str, Any]:
+    try:
+        cwd = os.getcwd()
+    except OSError:
+        cwd = ""
+    return {
+        "working_directory": cwd,
+        "os_name": platform.system(),
+        "os_version": platform.release(),
+        "shell": os.environ.get("SHELL", os.environ.get("COMSPEC", "")),
+        "hostname": platform.node(),
+        "username": _get_username(),
+    }
+
+
+def _get_username() -> str:
+    try:
+        return os.getlogin()
+    except OSError:
+        return os.environ.get("USER", os.environ.get("USERNAME", ""))
+
+
+def _collect_runtimes() -> dict[str, Any]:
+    available: dict[str, str] = {}
+    for name, cmd in _RUNTIME_CHECKS.items():
+        if shutil.which(cmd[0]):
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=_SUBPROCESS_TIMEOUT)  # noqa: S603
+                version = result.stdout.strip() or result.stderr.strip()
+                # Extract just the version number from verbose output
+                for token in version.split():
+                    if token and token[0].isdigit():
+                        available[name] = token.rstrip(",")
+                        break
+                else:
+                    available[name] = version[:50]
+            except (subprocess.TimeoutExpired, OSError):
+                available[name] = "found"
+    return {
+        "python_version": platform.python_version(),
+        "available_runtimes": available,
+    }
+
+
+def _collect_packages() -> dict[str, Any]:
+    packages: list[PackageInfo] = []
+    try:
+        for dist in importlib.metadata.distributions():
+            name = dist.metadata.get("Name", "")
+            version = dist.metadata.get("Version", "")
+            if name:
+                packages.append(PackageInfo(name=name, version=version))
+    except Exception:
+        pass
+    # Deduplicate and sort
+    seen: set[str] = set()
+    unique: list[PackageInfo] = []
+    for p in sorted(packages, key=lambda x: x.name.lower()):
+        key = p.name.lower()
+        if key not in seen:
+            seen.add(key)
+            unique.append(p)
+
+    lockfiles: list[str] = []
+    try:
+        cwd = Path.cwd()
+        for name in sorted(_KNOWN_LOCKFILES):
+            if (cwd / name).exists():
+                lockfiles.append(name)
+    except OSError:
+        pass
+
+    return {"installed_packages": unique, "lockfiles_found": lockfiles}
+
+
+def _collect_filesystem(cwd: str) -> dict[str, Any]:
+    notable: list[str] = []
+    dir_count = 0
+    file_count = 0
+    try:
+        root = Path(cwd)
+        for entry in sorted(root.iterdir()):
+            if entry.name.startswith(".") and entry.name not in {".env.example", ".gitignore", ".dockerignore"}:
+                continue
+            if entry.is_dir():
+                dir_count += 1
+            else:
+                file_count += 1
+            if len(notable) < _MAX_NOTABLE_FILES:
+                suffix = "/" if entry.is_dir() else ""
+                notable.append(f"{entry.name}{suffix}")
+    except OSError:
+        pass
+    return {
+        "notable_files": notable,
+        "directory_count": dir_count,
+        "file_count": file_count,
+    }
+
+
+def _collect_git() -> dict[str, Any]:
+    defaults: dict[str, Any] = {
+        "git_branch": None,
+        "git_commit": None,
+        "git_dirty": False,
+        "git_worktree": False,
+    }
+    if not shutil.which("git"):
+        return defaults
+    try:
+        branch = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S603, S607
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+        )
+        if branch.returncode != 0:
+            return defaults
+        commit = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],  # noqa: S603, S607
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+        )
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],  # noqa: S603, S607
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+        )
+        worktree_check = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],  # noqa: S603, S607
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+        )
+        git_dir = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],  # noqa: S603, S607
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+        )
+        is_worktree = (
+            worktree_check.returncode == 0 and git_dir.returncode == 0 and worktree_check.stdout.strip() != git_dir.stdout.strip()
+        )
+        return {
+            "git_branch": branch.stdout.strip() or None,
+            "git_commit": commit.stdout.strip() or None,
+            "git_dirty": bool(status.stdout.strip()),
+            "git_worktree": is_worktree,
+        }
+    except (subprocess.TimeoutExpired, OSError):
+        return defaults
+
+
+def _collect_system() -> dict[str, Any]:
+    cpu_count = os.cpu_count() or 0
+    mem_total = 0
+    mem_available = 0
+    disk_free = 0.0
+
+    # Memory: try /proc/meminfo (Linux), then sysctl (macOS), then fallback
+    try:
+        meminfo = Path("/proc/meminfo")
+        if meminfo.exists():
+            text = meminfo.read_text()
+            for line in text.splitlines():
+                if line.startswith("MemTotal:"):
+                    mem_total = int(line.split()[1]) // 1024  # kB → MB
+                elif line.startswith("MemAvailable:"):
+                    mem_available = int(line.split()[1]) // 1024
+        elif sys.platform == "darwin":
+            result = subprocess.run(
+                ["sysctl", "-n", "hw.memsize"],  # noqa: S603, S607
+                capture_output=True,
+                text=True,
+                timeout=_SUBPROCESS_TIMEOUT,
+            )
+            if result.returncode == 0:
+                mem_total = int(result.stdout.strip()) // (1024 * 1024)
+            # Available memory on macOS: approximate via vm_stat
+            vm = subprocess.run(
+                ["vm_stat"],  # noqa: S603, S607
+                capture_output=True,
+                text=True,
+                timeout=_SUBPROCESS_TIMEOUT,
+            )
+            if vm.returncode == 0:
+                free_pages = 0
+                for line in vm.stdout.splitlines():
+                    if "Pages free:" in line or "Pages inactive:" in line:
+                        parts = line.split(":")
+                        if len(parts) == 2:
+                            free_pages += int(parts[1].strip().rstrip("."))
+                mem_available = (free_pages * 4096) // (1024 * 1024)
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        pass
+
+    # Disk
+    try:
+        usage = shutil.disk_usage(os.getcwd())
+        disk_free = round(usage.free / (1024**3), 1)
+    except OSError:
+        pass
+
+    return {
+        "memory_total_mb": mem_total,
+        "memory_available_mb": mem_available,
+        "disk_free_gb": disk_free,
+        "cpu_count": cpu_count,
+    }

--- a/autocontext/src/autocontext/bootstrap/collector.py
+++ b/autocontext/src/autocontext/bootstrap/collector.py
@@ -117,8 +117,9 @@ def _collect_packages() -> dict[str, Any]:
     packages: list[PackageInfo] = []
     try:
         for dist in importlib.metadata.distributions():
-            name = dist.metadata.get("Name", "")
-            version = dist.metadata.get("Version", "")
+            metadata = dist.metadata
+            name = metadata["Name"] if "Name" in metadata else ""
+            version = metadata["Version"] if "Version" in metadata else ""
             if name:
                 packages.append(PackageInfo(name=name, version=version))
     except Exception:

--- a/autocontext/src/autocontext/bootstrap/redactor.py
+++ b/autocontext/src/autocontext/bootstrap/redactor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import PurePosixPath, PureWindowsPath
 
 from autocontext.bootstrap.snapshot import EnvironmentSnapshot
 
@@ -28,6 +29,7 @@ def redact_snapshot(snapshot: EnvironmentSnapshot, config: RedactionConfig | Non
     hostname = snapshot.hostname
     username = snapshot.username
     working_directory = snapshot.working_directory
+    shell = snapshot.shell
     notable_files = list(snapshot.notable_files)
 
     if config.redact_hostname and hostname:
@@ -44,12 +46,17 @@ def redact_snapshot(snapshot: EnvironmentSnapshot, config: RedactionConfig | Non
         working_directory = "."
         notable_files = [_strip_prefix(f, prefix) for f in notable_files]
         redacted_fields.append("working_directory")
+    if config.redact_paths and shell:
+        redacted_shell = _redact_path_like(shell)
+        if redacted_shell != shell:
+            shell = redacted_shell
+            redacted_fields.append("shell")
 
     return EnvironmentSnapshot(
         working_directory=working_directory,
         os_name=snapshot.os_name,
         os_version=snapshot.os_version,
-        shell=snapshot.shell,
+        shell=shell,
         hostname=hostname,
         username=username,
         python_version=snapshot.python_version,
@@ -79,3 +86,14 @@ def _strip_prefix(path: str, prefix: str) -> str:
         stripped = path[len(prefix) :]
         return f".{stripped}" if stripped.startswith("/") else f"./{stripped}"
     return path
+
+
+def _redact_path_like(value: str) -> str:
+    """Collapse an absolute path to its basename while preserving tool identity."""
+    posix = PurePosixPath(value)
+    if posix.is_absolute():
+        return posix.name
+    windows = PureWindowsPath(value)
+    if windows.is_absolute():
+        return windows.name
+    return value

--- a/autocontext/src/autocontext/bootstrap/redactor.py
+++ b/autocontext/src/autocontext/bootstrap/redactor.py
@@ -1,0 +1,81 @@
+"""Environment snapshot redaction (AC-503)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from autocontext.bootstrap.snapshot import EnvironmentSnapshot
+
+
+@dataclass(slots=True)
+class RedactionConfig:
+    """Controls which fields are redacted in the snapshot."""
+
+    redact_hostname: bool = True
+    redact_username: bool = True
+    redact_paths: bool = True
+
+
+_REDACTED = "[REDACTED]"
+
+
+def redact_snapshot(snapshot: EnvironmentSnapshot, config: RedactionConfig | None = None) -> EnvironmentSnapshot:
+    """Return a new snapshot with sensitive fields replaced per config."""
+    if config is None:
+        config = RedactionConfig()
+
+    redacted_fields: list[str] = []
+    hostname = snapshot.hostname
+    username = snapshot.username
+    working_directory = snapshot.working_directory
+    notable_files = list(snapshot.notable_files)
+
+    if config.redact_hostname and hostname:
+        hostname = _REDACTED
+        redacted_fields.append("hostname")
+
+    if config.redact_username and username:
+        username = _REDACTED
+        redacted_fields.append("username")
+
+    if config.redact_paths and working_directory:
+        # Strip absolute path prefix → relative
+        prefix = snapshot.working_directory
+        working_directory = "."
+        notable_files = [_strip_prefix(f, prefix) for f in notable_files]
+        redacted_fields.append("working_directory")
+
+    return EnvironmentSnapshot(
+        working_directory=working_directory,
+        os_name=snapshot.os_name,
+        os_version=snapshot.os_version,
+        shell=snapshot.shell,
+        hostname=hostname,
+        username=username,
+        python_version=snapshot.python_version,
+        available_runtimes=dict(snapshot.available_runtimes),
+        installed_packages=list(snapshot.installed_packages),
+        lockfiles_found=list(snapshot.lockfiles_found),
+        notable_files=notable_files,
+        directory_count=snapshot.directory_count,
+        file_count=snapshot.file_count,
+        git_branch=snapshot.git_branch,
+        git_commit=snapshot.git_commit,
+        git_dirty=snapshot.git_dirty,
+        git_worktree=snapshot.git_worktree,
+        memory_total_mb=snapshot.memory_total_mb,
+        memory_available_mb=snapshot.memory_available_mb,
+        disk_free_gb=snapshot.disk_free_gb,
+        cpu_count=snapshot.cpu_count,
+        collected_at=snapshot.collected_at,
+        collector_version=snapshot.collector_version,
+        redacted_fields=redacted_fields,
+    )
+
+
+def _strip_prefix(path: str, prefix: str) -> str:
+    """Strip absolute path prefix, replacing with relative."""
+    if path.startswith(prefix):
+        stripped = path[len(prefix) :]
+        return f".{stripped}" if stripped.startswith("/") else f"./{stripped}"
+    return path

--- a/autocontext/src/autocontext/bootstrap/renderer.py
+++ b/autocontext/src/autocontext/bootstrap/renderer.py
@@ -1,0 +1,56 @@
+"""Environment snapshot prompt rendering (AC-503)."""
+
+from __future__ import annotations
+
+import json
+
+from autocontext.bootstrap.snapshot import EnvironmentSnapshot
+
+
+def render_prompt_section(snapshot: EnvironmentSnapshot) -> str:
+    """Render a compact markdown section for prompt injection (~300-500 chars)."""
+    lines: list[str] = ["## Environment"]
+
+    # Core line: Python version | OS | shell | CPU | RAM | disk
+    core_parts = [
+        f"Python {snapshot.python_version}",
+        f"{snapshot.os_name} {snapshot.os_version}",
+        snapshot.shell.rsplit("/", 1)[-1] if snapshot.shell else "",
+        f"{snapshot.cpu_count} CPU" if snapshot.cpu_count else "",
+        f"{snapshot.memory_total_mb}MB RAM" if snapshot.memory_total_mb else "",
+        f"{snapshot.disk_free_gb}GB free" if snapshot.disk_free_gb else "",
+    ]
+    lines.append(" | ".join(p for p in core_parts if p))
+
+    # Git
+    if snapshot.git_branch:
+        dirty = ", dirty" if snapshot.git_dirty else ", clean"
+        worktree = ", worktree" if snapshot.git_worktree else ""
+        commit = f" ({snapshot.git_commit}{dirty}{worktree})" if snapshot.git_commit else ""
+        lines.append(f"Git: {snapshot.git_branch}{commit}")
+
+    # Runtimes
+    if snapshot.available_runtimes:
+        rt_parts = [f"{name} {ver}" for name, ver in sorted(snapshot.available_runtimes.items())]
+        lines.append(f"Runtimes: {', '.join(rt_parts)}")
+
+    # Filesystem summary
+    if snapshot.notable_files:
+        top_files = snapshot.notable_files[:8]
+        extras = ""
+        if snapshot.file_count or snapshot.directory_count:
+            extras = f" ({snapshot.file_count} files, {snapshot.directory_count} dirs)"
+        lines.append(f"Notable: {', '.join(top_files)}{extras}")
+
+    # Packages summary
+    if snapshot.installed_packages:
+        pkg_count = len(snapshot.installed_packages)
+        lockfile_note = f" ({', '.join(snapshot.lockfiles_found)})" if snapshot.lockfiles_found else ""
+        lines.append(f"Packages: {pkg_count} top-level{lockfile_note}")
+
+    return "\n".join(lines)
+
+
+def render_full_json(snapshot: EnvironmentSnapshot) -> str:
+    """Full JSON serialization for artifact persistence."""
+    return json.dumps(snapshot.to_dict(), indent=2, sort_keys=True)

--- a/autocontext/src/autocontext/bootstrap/snapshot.py
+++ b/autocontext/src/autocontext/bootstrap/snapshot.py
@@ -1,0 +1,117 @@
+"""Environment snapshot domain model (AC-503)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class PackageInfo:
+    """An installed Python package."""
+
+    name: str
+    version: str
+
+
+@dataclass(slots=True)
+class EnvironmentSnapshot:
+    """Structured snapshot of the runtime environment."""
+
+    # Core
+    working_directory: str
+    os_name: str
+    os_version: str
+    shell: str
+    hostname: str
+    username: str
+
+    # Runtimes
+    python_version: str
+    available_runtimes: dict[str, str]
+
+    # Packages
+    installed_packages: list[PackageInfo]
+    lockfiles_found: list[str]
+
+    # Filesystem
+    notable_files: list[str]
+    directory_count: int
+    file_count: int
+
+    # Git
+    git_branch: str | None
+    git_commit: str | None
+    git_dirty: bool
+    git_worktree: bool
+
+    # System
+    memory_total_mb: int
+    memory_available_mb: int
+    disk_free_gb: float
+    cpu_count: int
+
+    # Meta
+    collected_at: str
+    collector_version: str = "1.0.0"
+    redacted_fields: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-safe dict."""
+        return {
+            "working_directory": self.working_directory,
+            "os_name": self.os_name,
+            "os_version": self.os_version,
+            "shell": self.shell,
+            "hostname": self.hostname,
+            "username": self.username,
+            "python_version": self.python_version,
+            "available_runtimes": dict(self.available_runtimes),
+            "installed_packages": [{"name": p.name, "version": p.version} for p in self.installed_packages],
+            "lockfiles_found": list(self.lockfiles_found),
+            "notable_files": list(self.notable_files),
+            "directory_count": self.directory_count,
+            "file_count": self.file_count,
+            "git_branch": self.git_branch,
+            "git_commit": self.git_commit,
+            "git_dirty": self.git_dirty,
+            "git_worktree": self.git_worktree,
+            "memory_total_mb": self.memory_total_mb,
+            "memory_available_mb": self.memory_available_mb,
+            "disk_free_gb": self.disk_free_gb,
+            "cpu_count": self.cpu_count,
+            "collected_at": self.collected_at,
+            "collector_version": self.collector_version,
+            "redacted_fields": list(self.redacted_fields),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EnvironmentSnapshot:
+        """Deserialize from dict."""
+        packages = [PackageInfo(name=p["name"], version=p["version"]) for p in data.get("installed_packages", [])]
+        return cls(
+            working_directory=data["working_directory"],
+            os_name=data["os_name"],
+            os_version=data["os_version"],
+            shell=data["shell"],
+            hostname=data["hostname"],
+            username=data["username"],
+            python_version=data["python_version"],
+            available_runtimes=data.get("available_runtimes", {}),
+            installed_packages=packages,
+            lockfiles_found=data.get("lockfiles_found", []),
+            notable_files=data.get("notable_files", []),
+            directory_count=data.get("directory_count", 0),
+            file_count=data.get("file_count", 0),
+            git_branch=data.get("git_branch"),
+            git_commit=data.get("git_commit"),
+            git_dirty=data.get("git_dirty", False),
+            git_worktree=data.get("git_worktree", False),
+            memory_total_mb=data.get("memory_total_mb", 0),
+            memory_available_mb=data.get("memory_available_mb", 0),
+            disk_free_gb=data.get("disk_free_gb", 0.0),
+            cpu_count=data.get("cpu_count", 0),
+            collected_at=data["collected_at"],
+            collector_version=data.get("collector_version", "1.0.0"),
+            redacted_fields=data.get("redacted_fields", []),
+        )

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -16,10 +16,10 @@ logger = logging.getLogger(__name__)
 class HarnessMode(StrEnum):
     """How the harness interacts with strategy execution."""
 
-    NONE = "none"        # No harness intervention (existing behavior)
-    FILTER = "filter"    # Enumerate valid moves, LLM selects by index
-    VERIFY = "verify"    # LLM proposes, code validates, retry on invalid
-    POLICY = "policy"    # Pure code strategy (alias for CODE_STRATEGIES_ENABLED)
+    NONE = "none"  # No harness intervention (existing behavior)
+    FILTER = "filter"  # Enumerate valid moves, LLM selects by index
+    VERIFY = "verify"  # LLM proposes, code validates, retry on invalid
+    POLICY = "policy"  # Pure code strategy (alias for CODE_STRATEGIES_ENABLED)
 
 
 class AppSettings(BaseModel):
@@ -203,18 +203,24 @@ class AppSettings(BaseModel):
     use_pipeline_engine: bool = Field(default=False)
     # Monty sandbox executor
     monty_max_execution_time_seconds: float = Field(
-        default=30.0, ge=1.0, description="Max wall-clock seconds for Monty sandbox execution",
+        default=30.0,
+        ge=1.0,
+        description="Max wall-clock seconds for Monty sandbox execution",
     )
     monty_max_external_calls: int = Field(
-        default=100, ge=10, description="Max external function calls per Monty execution",
+        default=100,
+        ge=10,
+        description="Max external function calls per Monty execution",
     )
     # Code strategies (Phase 2)
     code_strategies_enabled: bool = Field(
-        default=False, description="Competitor emits Python code instead of JSON params",
+        default=False,
+        description="Competitor emits Python code instead of JSON params",
     )
     # Policy refinement (AC-156)
     policy_refinement_enabled: bool = Field(
-        default=False, description="Refine code strategies via iterative zero-LLM evaluation",
+        default=False,
+        description="Refine code strategies via iterative zero-LLM evaluation",
     )
     policy_refinement_max_iterations: int = Field(default=50, ge=1)
     policy_refinement_matches_per_iteration: int = Field(default=5, ge=1)
@@ -265,29 +271,42 @@ class AppSettings(BaseModel):
     judge_api_key: str | None = Field(default=None)
     # Evaluator disagreement (AC-330)
     judge_disagreement_threshold: float = Field(
-        default=0.15, ge=0.0, le=1.0, description="Std dev threshold for flagging judge disagreement",
+        default=0.15,
+        ge=0.0,
+        le=1.0,
+        description="Std dev threshold for flagging judge disagreement",
     )
     judge_bias_probes_enabled: bool = Field(
-        default=False, description="Run bias probes on judge evaluations",
+        default=False,
+        description="Run bias probes on judge evaluations",
     )
     # Notification settings
     notify_webhook_url: str | None = Field(default=None)
     notify_on: str = Field(default="threshold_met,failure")
     # Stagnation detection
     stagnation_reset_enabled: bool = Field(
-        default=False, description="Enable stagnation detection and fresh start",
+        default=False,
+        description="Enable stagnation detection and fresh start",
     )
     stagnation_rollback_threshold: int = Field(
-        default=5, ge=1, description="Consecutive rollbacks before fresh start",
+        default=5,
+        ge=1,
+        description="Consecutive rollbacks before fresh start",
     )
     stagnation_plateau_window: int = Field(
-        default=5, ge=2, description="Window size for score plateau detection",
+        default=5,
+        ge=2,
+        description="Window size for score plateau detection",
     )
     stagnation_plateau_epsilon: float = Field(
-        default=0.01, ge=0.0, description="Max variance for plateau detection",
+        default=0.01,
+        ge=0.0,
+        description="Max variance for plateau detection",
     )
     stagnation_distill_top_lessons: int = Field(
-        default=5, ge=1, description="Top lessons to retain in fresh start",
+        default=5,
+        ge=1,
+        description="Top lessons to retain in fresh start",
     )
     # Progress JSON
     progress_json_enabled: bool = Field(default=True, description="Inject structured progress JSON into prompts")
@@ -300,53 +319,76 @@ class AppSettings(BaseModel):
     # Strategy pre-validation
     prevalidation_enabled: bool = Field(default=False, description="Run self-play dry-run before tournament")
     prevalidation_max_retries: int = Field(
-        default=2, ge=0, le=5, description="Max revision attempts on pre-validation failure",
+        default=2,
+        ge=0,
+        le=5,
+        description="Max revision attempts on pre-validation failure",
     )
     prevalidation_dry_run_enabled: bool = Field(
-        default=True, description="Run self-play dry-run match during pre-validation",
+        default=True,
+        description="Run self-play dry-run match during pre-validation",
     )
     # Harness validators (Phase B P3)
     harness_validators_enabled: bool = Field(
-        default=False, description="Run architect-generated harness validators before tournament",
+        default=False,
+        description="Run architect-generated harness validators before tournament",
     )
     harness_timeout_seconds: float = Field(
-        default=5.0, ge=0.5, le=60.0, description="Timeout for harness code execution",
+        default=5.0,
+        ge=0.5,
+        le=60.0,
+        description="Timeout for harness code execution",
     )
     harness_inheritance_enabled: bool = Field(
-        default=True, description="Inherit harness files across runs (requires harness_validators_enabled)",
+        default=True,
+        description="Inherit harness files across runs (requires harness_validators_enabled)",
     )
     harness_mode: HarnessMode = Field(
-        default=HarnessMode.NONE, description="Harness interaction mode: none, filter, verify, policy",
+        default=HarnessMode.NONE,
+        description="Harness interaction mode: none, filter, verify, policy",
     )
     # Probe matches (Phase 4)
     probe_matches: int = Field(default=0, ge=0, description="Probe matches before full tournament (0=disabled)")
     # Ecosystem convergence (Phase 4)
     ecosystem_convergence_enabled: bool = Field(
-        default=False, description="Track playbook divergence between ecosystem phases",
+        default=False,
+        description="Track playbook divergence between ecosystem phases",
     )
     ecosystem_divergence_threshold: float = Field(
-        default=0.3, ge=0.0, le=1.0, description="Divergence ratio above which phases are oscillating",
+        default=0.3,
+        ge=0.0,
+        le=1.0,
+        description="Divergence ratio above which phases are oscillating",
     )
     ecosystem_oscillation_window: int = Field(
-        default=3, ge=2, description="Consecutive high-divergence cycles to trigger lock",
+        default=3,
+        ge=2,
+        description="Consecutive high-divergence cycles to trigger lock",
     )
     # Dead-end registry (AR-2)
     dead_end_tracking_enabled: bool = Field(
-        default=False, description="Track dead-end strategies that consistently fail",
+        default=False,
+        description="Track dead-end strategies that consistently fail",
     )
     dead_end_max_entries: int = Field(
-        default=20, ge=1, description="Max dead-end entries before oldest are pruned",
+        default=20,
+        ge=1,
+        description="Max dead-end entries before oldest are pruned",
     )
     # Research protocol (AR-3)
     protocol_enabled: bool = Field(
-        default=False, description="Enable research protocol meta-document for architect steering",
+        default=False,
+        description="Enable research protocol meta-document for architect steering",
     )
     # Exploration mode (AR-4)
     exploration_mode: Literal["linear", "rapid", "tree"] = Field(
-        default="linear", description="Exploration mode: linear, rapid, or tree",
+        default="linear",
+        description="Exploration mode: linear, rapid, or tree",
     )
     rapid_gens: int = Field(
-        default=0, ge=0, description="Auto-transition from rapid to linear after N gens (0=manual)",
+        default=0,
+        ge=0,
+        description="Auto-transition from rapid to linear after N gens (0=manual)",
     )
     novelty_enabled: bool = Field(
         default=True,
@@ -400,42 +442,59 @@ class AppSettings(BaseModel):
     )
     # Tree search (P4, activates when exploration_mode="tree")
     tree_max_hypotheses: int = Field(
-        default=8, ge=1, description="Max concurrent strategy variants in tree search",
+        default=8,
+        ge=1,
+        description="Max concurrent strategy variants in tree search",
     )
     tree_sampling_temperature: float = Field(
-        default=1.0, gt=0.0, description="Thompson sampling temperature for tree search",
+        default=1.0,
+        gt=0.0,
+        description="Thompson sampling temperature for tree search",
     )
     # Session reports (AR-5)
     session_reports_enabled: bool = Field(
-        default=True, description="Generate cross-session summary reports",
+        default=True,
+        description="Generate cross-session summary reports",
     )
     # Config-adaptive loop (AR-6)
     config_adaptive_enabled: bool = Field(
-        default=False, description="Allow architect to propose meta-parameter tuning",
+        default=False,
+        description="Allow architect to propose meta-parameter tuning",
     )
     # Staged validation (AC-200)
     staged_validation_enabled: bool = Field(
-        default=True, description="Use staged validation pipeline for pre-tournament checks",
+        default=True,
+        description="Use staged validation pipeline for pre-tournament checks",
     )
     # Pre-flight harness synthesis (AC-150)
     harness_preflight_enabled: bool = Field(
-        default=False, description="Run pre-flight harness synthesis before generation 1",
+        default=False,
+        description="Run pre-flight harness synthesis before generation 1",
     )
     harness_preflight_max_iterations: int = Field(
-        default=30, ge=1, description="Max synthesis iterations for pre-flight",
+        default=30,
+        ge=1,
+        description="Max synthesis iterations for pre-flight",
     )
     harness_preflight_target_accuracy: float = Field(
-        default=0.9, ge=0.0, le=1.0, description="Target accuracy threshold for pre-flight convergence",
+        default=0.9,
+        ge=0.0,
+        le=1.0,
+        description="Target accuracy threshold for pre-flight convergence",
     )
     harness_preflight_force: bool = Field(
-        default=False, description="Force re-synthesis even if harness exists",
+        default=False,
+        description="Force re-synthesis even if harness exists",
     )
     # Two-tier gating (AC-160)
     two_tier_gating_enabled: bool = Field(
-        default=False, description="Enable two-tier validity+quality gating in tournament",
+        default=False,
+        description="Enable two-tier validity+quality gating in tournament",
     )
     validity_max_retries: int = Field(
-        default=3, ge=0, description="Max validity retries before falling through to tournament",
+        default=3,
+        ge=0,
+        description="Max validity retries before falling through to tournament",
     )
     # Role routing (AC-204) -- "auto" or "off"
     role_routing: str = Field(default="off", description="Role routing mode: 'auto' or 'off'")
@@ -548,6 +607,18 @@ class AppSettings(BaseModel):
     ssh_connect_timeout: int = Field(default=10, ge=1, description="SSH connection timeout in seconds")
     ssh_command_timeout: float = Field(default=120.0, ge=1.0, description="Default SSH command timeout")
     ssh_allow_fallback: bool = Field(default=True, description="Fall back to local on SSH failure")
+    # Environment snapshot bootstrapping (AC-503)
+    env_snapshot_enabled: bool = Field(default=False, description="Collect environment snapshot at run start")
+    env_snapshot_redact_hostname: bool = Field(default=True, description="Redact hostname in env snapshot")
+    env_snapshot_redact_username: bool = Field(default=True, description="Redact username in env snapshot")
+    env_snapshot_redact_paths: bool = Field(default=True, description="Redact absolute paths in env snapshot")
+    # Evidence workspace (AC-504)
+    evidence_workspace_enabled: bool = Field(default=False, description="Materialize prior-run evidence workspace")
+    evidence_workspace_budget_mb: int = Field(default=10, ge=1, description="Evidence workspace budget in MB")
+    evidence_workspace_roles: str = Field(
+        default="analyst,architect",
+        description="Comma-separated roles that receive evidence manifest",
+    )
     # Monitor conditions (AC-209)
     monitor_enabled: bool = Field(default=True, description="Enable monitor condition engine")
     monitor_heartbeat_timeout: float = Field(default=300.0, ge=1.0, description="Default heartbeat timeout (seconds)")

--- a/autocontext/src/autocontext/evidence/__init__.py
+++ b/autocontext/src/autocontext/evidence/__init__.py
@@ -1,0 +1,20 @@
+"""Browsable prior-run evidence workspace (AC-504)."""
+
+from __future__ import annotations
+
+from autocontext.evidence.manifest import render_artifact_detail, render_evidence_manifest
+from autocontext.evidence.materializer import materialize_workspace
+from autocontext.evidence.tracker import compute_utilization, load_access_log, record_access, save_access_log
+from autocontext.evidence.workspace import EvidenceArtifact, EvidenceWorkspace
+
+__all__ = [
+    "EvidenceArtifact",
+    "EvidenceWorkspace",
+    "materialize_workspace",
+    "render_evidence_manifest",
+    "render_artifact_detail",
+    "record_access",
+    "save_access_log",
+    "load_access_log",
+    "compute_utilization",
+]

--- a/autocontext/src/autocontext/evidence/manifest.py
+++ b/autocontext/src/autocontext/evidence/manifest.py
@@ -1,0 +1,52 @@
+"""Evidence workspace prompt rendering (AC-504)."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+from autocontext.evidence.workspace import EvidenceArtifact, EvidenceWorkspace
+
+
+def render_evidence_manifest(workspace: EvidenceWorkspace) -> str:
+    """Render a compact prompt section describing available evidence."""
+    n = len(workspace.artifacts)
+    runs = len(workspace.source_runs)
+    size_mb = round(workspace.total_size_bytes / (1024 * 1024), 1)
+
+    lines = [
+        "## Prior-Run Evidence",
+        f"Available: {n} artifacts from {runs} prior run(s) ({size_mb} MB)",
+    ]
+
+    kind_counts: Counter[str] = Counter(a.kind for a in workspace.artifacts)
+    kind_labels = {
+        "gate_decision": "Gate decisions (advance/retry/rollback with deltas)",
+        "trace": "Traces (run event streams)",
+        "report": "Reports (session + weakness reports)",
+        "role_output": "Role outputs (analyst, architect, coach)",
+        "tool": "Tools (architect-generated)",
+        "log": "Logs (execution logs)",
+    }
+    for kind in ["gate_decision", "trace", "report", "role_output", "tool", "log"]:
+        count = kind_counts.get(kind, 0)
+        if count > 0:
+            label = kind_labels.get(kind, kind)
+            lines.append(f"- {label}: {count}")
+
+    lines.append("")
+    lines.append('Reference artifacts by ID (e.g., "gate_abc123") for detailed inspection.')
+
+    return "\n".join(lines)
+
+
+def render_artifact_detail(artifact: EvidenceArtifact, workspace_dir: str) -> str:
+    """Read and return the content of a specific artifact."""
+    path = Path(workspace_dir) / artifact.path
+    if not path.exists():
+        return f"[Artifact {artifact.artifact_id} not found at {artifact.path}]"
+    try:
+        content = path.read_text(encoding="utf-8")
+        return f"## {artifact.kind}: {artifact.summary}\n\n{content}"
+    except (OSError, UnicodeDecodeError):
+        return f"[Could not read artifact {artifact.artifact_id}: binary or inaccessible]"

--- a/autocontext/src/autocontext/evidence/materializer.py
+++ b/autocontext/src/autocontext/evidence/materializer.py
@@ -1,0 +1,233 @@
+"""Evidence workspace materializer (AC-504).
+
+Scans prior-run directories and knowledge artifacts, copies them into a
+flat workspace directory, and returns a manifest.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import logging
+import shutil
+from pathlib import Path
+
+from autocontext.evidence.workspace import EvidenceArtifact, EvidenceWorkspace
+
+logger = logging.getLogger(__name__)
+
+ARTIFACT_PRIORITY = ["gate_decision", "trace", "report", "role_output", "tool", "log"]
+_DEFAULT_BUDGET = 10 * 1024 * 1024  # 10 MB
+
+_KIND_PATTERNS: dict[str, list[str]] = {
+    "gate_decision": ["gate_decision*.json", "gate*.json"],
+    "trace": ["events.ndjson", "trace*.json", "event_stream*.ndjson"],
+    "report": ["playbook.md", "dead_ends.md", "session_report*.md", "weakness_report*.md", "progress_report*.md"],
+    "role_output": ["analyst_output*.md", "coach_output*.md", "architect_output*.md", "competitor_output*.md"],
+    "tool": ["*.py"],
+    "log": ["*.log", "execution_log*.txt"],
+}
+
+
+def materialize_workspace(
+    knowledge_root: Path,
+    runs_root: Path,
+    source_run_ids: list[str],
+    workspace_dir: Path,
+    budget_bytes: int = _DEFAULT_BUDGET,
+    scenario_name: str | None = None,
+) -> EvidenceWorkspace:
+    """Materialize evidence from prior runs into a flat workspace directory."""
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    all_artifacts: list[EvidenceArtifact] = []
+
+    # Scan run directories
+    for run_id in source_run_ids:
+        run_dir = runs_root / run_id
+        if run_dir.is_dir():
+            all_artifacts.extend(_scan_run_artifacts(run_dir, run_id))
+
+    # Scan knowledge directory
+    if scenario_name:
+        knowledge_dir = knowledge_root / scenario_name
+        if knowledge_dir.is_dir():
+            all_artifacts.extend(_scan_knowledge_artifacts(knowledge_dir, scenario_name))
+
+    # Sort by priority then recency (mtime descending)
+    priority_map = {kind: i for i, kind in enumerate(ARTIFACT_PRIORITY)}
+    all_artifacts.sort(key=lambda a: (priority_map.get(a.kind, 99), -a.size_bytes))
+
+    # Copy into workspace respecting budget
+    selected: list[EvidenceArtifact] = []
+    total_size = 0
+    for artifact in all_artifacts:
+        if total_size + artifact.size_bytes > budget_bytes:
+            continue
+        # Copy file into workspace
+        src_path = Path(artifact.path)
+        if not src_path.exists():
+            continue
+        dest_name = f"{artifact.artifact_id}_{src_path.name}"
+        dest_path = workspace_dir / dest_name
+        try:
+            shutil.copy2(str(src_path), str(dest_path))
+        except OSError:
+            continue
+        # Update artifact path to workspace-relative
+        workspace_artifact = EvidenceArtifact(
+            artifact_id=artifact.artifact_id,
+            source_run_id=artifact.source_run_id,
+            kind=artifact.kind,
+            path=dest_name,
+            summary=artifact.summary,
+            size_bytes=artifact.size_bytes,
+            generation=artifact.generation,
+        )
+        selected.append(workspace_artifact)
+        total_size += artifact.size_bytes
+
+    workspace = EvidenceWorkspace(
+        workspace_dir=str(workspace_dir),
+        source_runs=source_run_ids,
+        artifacts=selected,
+        total_size_bytes=total_size,
+        materialized_at=datetime.datetime.now(datetime.UTC).isoformat(),
+    )
+
+    # Write manifest
+    manifest_path = workspace_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(workspace.to_dict(), indent=2), encoding="utf-8")
+
+    return workspace
+
+
+def _scan_run_artifacts(run_dir: Path, run_id: str) -> list[EvidenceArtifact]:
+    """Discover artifacts in a run directory."""
+    artifacts: list[EvidenceArtifact] = []
+    try:
+        for path in sorted(run_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            kind = _classify_file(path, run_dir)
+            if kind is None:
+                continue
+            generation = _extract_generation(path)
+            artifacts.append(
+                EvidenceArtifact(
+                    artifact_id=_make_id(run_id, path),
+                    source_run_id=run_id,
+                    kind=kind,
+                    path=str(path),
+                    summary=f"{kind}: {path.name} from {run_id}",
+                    size_bytes=path.stat().st_size,
+                    generation=generation,
+                )
+            )
+    except OSError:
+        pass
+    return artifacts
+
+
+def _scan_knowledge_artifacts(knowledge_dir: Path, scenario_name: str) -> list[EvidenceArtifact]:
+    """Discover artifacts in the knowledge directory."""
+    artifacts: list[EvidenceArtifact] = []
+    source_id = f"knowledge:{scenario_name}"
+
+    # Known knowledge files
+    known_files = {
+        "playbook.md": "report",
+        "dead_ends.md": "report",
+    }
+    for fname, kind in known_files.items():
+        fpath = knowledge_dir / fname
+        if fpath.is_file():
+            artifacts.append(
+                EvidenceArtifact(
+                    artifact_id=_make_id(source_id, fpath),
+                    source_run_id=source_id,
+                    kind=kind,
+                    path=str(fpath),
+                    summary=f"{kind}: {fname} for {scenario_name}",
+                    size_bytes=fpath.stat().st_size,
+                    generation=None,
+                )
+            )
+
+    # Tools directory
+    tools_dir = knowledge_dir / "tools"
+    if tools_dir.is_dir():
+        for tpath in sorted(tools_dir.glob("*.py")):
+            if tpath.is_file():
+                artifacts.append(
+                    EvidenceArtifact(
+                        artifact_id=_make_id(source_id, tpath),
+                        source_run_id=source_id,
+                        kind="tool",
+                        path=str(tpath),
+                        summary=f"tool: {tpath.name} for {scenario_name}",
+                        size_bytes=tpath.stat().st_size,
+                        generation=None,
+                    )
+                )
+
+    # Analysis directory
+    analysis_dir = knowledge_dir / "analysis"
+    if analysis_dir.is_dir():
+        for apath in sorted(analysis_dir.glob("gen_*.md")):
+            if apath.is_file():
+                gen = _extract_generation(apath)
+                artifacts.append(
+                    EvidenceArtifact(
+                        artifact_id=_make_id(source_id, apath),
+                        source_run_id=source_id,
+                        kind="report",
+                        path=str(apath),
+                        summary=f"analysis: {apath.name} for {scenario_name}",
+                        size_bytes=apath.stat().st_size,
+                        generation=gen,
+                    )
+                )
+
+    return artifacts
+
+
+def _classify_file(path: Path, root: Path) -> str | None:
+    """Classify a file into an evidence kind based on name/location."""
+    name = path.name.lower()
+    rel = str(path.relative_to(root)).lower()
+
+    if "gate_decision" in name or "gate" in name and name.endswith(".json"):
+        return "gate_decision"
+    if name.endswith(".ndjson") or "event" in name or "trace" in name:
+        return "trace"
+    if any(kw in name for kw in ("playbook", "dead_end", "report", "weakness", "session")):
+        return "report"
+    if any(kw in name for kw in ("analyst", "coach", "architect", "competitor")) and "_output" in name:
+        return "role_output"
+    if "tools/" in rel and name.endswith(".py"):
+        return "tool"
+    if name.endswith(".log") or "execution_log" in name:
+        return "log"
+    return None
+
+
+def _extract_generation(path: Path) -> int | None:
+    """Extract generation number from filename like gen_3.md or gen_3/."""
+    import re
+
+    match = re.search(r"gen[_-]?(\d+)", path.name)
+    if match:
+        return int(match.group(1))
+    for parent in path.parents:
+        match = re.search(r"gen[_-]?(\d+)", parent.name)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def _make_id(source: str, path: Path) -> str:
+    """Generate a stable artifact ID from source and path."""
+    raw = f"{source}:{path}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:12]

--- a/autocontext/src/autocontext/evidence/materializer.py
+++ b/autocontext/src/autocontext/evidence/materializer.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 
 ARTIFACT_PRIORITY = ["gate_decision", "trace", "report", "role_output", "tool", "log"]
 _DEFAULT_BUDGET = 10 * 1024 * 1024  # 10 MB
+_MANIFEST_FILENAME = "manifest.json"
+_ACCESS_LOG_FILENAME = "evidence_access_log.json"
 
 _KIND_PATTERNS: dict[str, list[str]] = {
     "gate_decision": ["gate_decision*.json", "gate*.json"],
@@ -40,6 +42,7 @@ def materialize_workspace(
 ) -> EvidenceWorkspace:
     """Materialize evidence from prior runs into a flat workspace directory."""
     workspace_dir.mkdir(parents=True, exist_ok=True)
+    _cleanup_previous_workspace(workspace_dir)
 
     all_artifacts: list[EvidenceArtifact] = []
 
@@ -97,10 +100,51 @@ def materialize_workspace(
     )
 
     # Write manifest
-    manifest_path = workspace_dir / "manifest.json"
+    manifest_path = workspace_dir / _MANIFEST_FILENAME
     manifest_path.write_text(json.dumps(workspace.to_dict(), indent=2), encoding="utf-8")
 
     return workspace
+
+
+def _cleanup_previous_workspace(workspace_dir: Path) -> None:
+    """Remove files tracked by the prior manifest before rewriting the workspace."""
+    manifest_path = workspace_dir / _MANIFEST_FILENAME
+    if manifest_path.is_file():
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+            artifacts = data.get("artifacts", [])
+            if isinstance(artifacts, list):
+                for artifact in artifacts:
+                    if not isinstance(artifact, dict):
+                        continue
+                    rel_path = artifact.get("path")
+                    if not isinstance(rel_path, str):
+                        continue
+                    artifact_path = _resolve_workspace_path(workspace_dir, rel_path)
+                    if artifact_path is None:
+                        continue
+                    try:
+                        artifact_path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    for metadata_name in (_MANIFEST_FILENAME, _ACCESS_LOG_FILENAME):
+        try:
+            (workspace_dir / metadata_name).unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _resolve_workspace_path(workspace_dir: Path, rel_path: str) -> Path | None:
+    """Resolve a manifest path inside the workspace and reject directory escapes."""
+    candidate = (workspace_dir / rel_path).resolve()
+    try:
+        candidate.relative_to(workspace_dir.resolve())
+    except ValueError:
+        return None
+    return candidate
 
 
 def _scan_run_artifacts(run_dir: Path, run_id: str) -> list[EvidenceArtifact]:

--- a/autocontext/src/autocontext/evidence/tracker.py
+++ b/autocontext/src/autocontext/evidence/tracker.py
@@ -1,0 +1,63 @@
+"""Evidence access tracking (AC-504)."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from autocontext.evidence.workspace import EvidenceWorkspace
+
+_ACCESS_LOG_FILENAME = "evidence_access_log.json"
+
+
+def record_access(workspace: EvidenceWorkspace, artifact_id: str) -> None:
+    """Record that an artifact was consulted. Deduplicates."""
+    if artifact_id not in workspace.accessed_artifacts:
+        workspace.accessed_artifacts.append(artifact_id)
+
+
+def save_access_log(workspace: EvidenceWorkspace) -> None:
+    """Persist the access log as JSON alongside the workspace."""
+    log_path = Path(workspace.workspace_dir) / _ACCESS_LOG_FILENAME
+    log_path.write_text(
+        json.dumps({"accessed": workspace.accessed_artifacts}, indent=2),
+        encoding="utf-8",
+    )
+
+
+def load_access_log(workspace_dir: str) -> list[str]:
+    """Load the access log from a workspace directory."""
+    log_path = Path(workspace_dir) / _ACCESS_LOG_FILENAME
+    if not log_path.exists():
+        return []
+    try:
+        data = json.loads(log_path.read_text(encoding="utf-8"))
+        return data.get("accessed", [])
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def compute_utilization(workspace: EvidenceWorkspace) -> dict[str, Any]:
+    """Return utilization stats."""
+    total = len(workspace.artifacts)
+    accessed = len(workspace.accessed_artifacts)
+    pct = round(accessed / total * 100, 1) if total > 0 else 0.0
+
+    kind_counts: Counter[str] = Counter(a.kind for a in workspace.artifacts)
+    accessed_set = set(workspace.accessed_artifacts)
+    kind_accessed: Counter[str] = Counter(a.kind for a in workspace.artifacts if a.artifact_id in accessed_set)
+    by_kind: dict[str, dict[str, int]] = {}
+    for kind in kind_counts:
+        by_kind[kind] = {
+            "total": kind_counts[kind],
+            "accessed": kind_accessed.get(kind, 0),
+        }
+
+    return {
+        "total_artifacts": total,
+        "accessed_count": accessed,
+        "utilization_percent": pct,
+        "by_kind": by_kind,
+    }

--- a/autocontext/src/autocontext/evidence/tracker.py
+++ b/autocontext/src/autocontext/evidence/tracker.py
@@ -34,7 +34,12 @@ def load_access_log(workspace_dir: str) -> list[str]:
         return []
     try:
         data = json.loads(log_path.read_text(encoding="utf-8"))
-        return data.get("accessed", [])
+        if not isinstance(data, dict):
+            return []
+        accessed = data.get("accessed", [])
+        if not isinstance(accessed, list):
+            return []
+        return [artifact_id for artifact_id in accessed if isinstance(artifact_id, str)]
     except (json.JSONDecodeError, OSError):
         return []
 

--- a/autocontext/src/autocontext/evidence/workspace.py
+++ b/autocontext/src/autocontext/evidence/workspace.py
@@ -1,0 +1,84 @@
+"""Evidence workspace domain model (AC-504)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class EvidenceArtifact:
+    """A single piece of evidence from a prior run."""
+
+    artifact_id: str
+    source_run_id: str
+    kind: str  # "trace", "role_output", "report", "tool", "gate_decision", "log"
+    path: str  # relative path within workspace
+    summary: str  # one-line description
+    size_bytes: int
+    generation: int | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact_id,
+            "source_run_id": self.source_run_id,
+            "kind": self.kind,
+            "path": self.path,
+            "summary": self.summary,
+            "size_bytes": self.size_bytes,
+            "generation": self.generation,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EvidenceArtifact:
+        return cls(
+            artifact_id=data["artifact_id"],
+            source_run_id=data["source_run_id"],
+            kind=data["kind"],
+            path=data["path"],
+            summary=data["summary"],
+            size_bytes=data["size_bytes"],
+            generation=data.get("generation"),
+        )
+
+
+@dataclass(slots=True)
+class EvidenceWorkspace:
+    """Materialized view of prior-run artifacts for optimizer roles."""
+
+    workspace_dir: str
+    source_runs: list[str]
+    artifacts: list[EvidenceArtifact]
+    total_size_bytes: int
+    materialized_at: str
+    accessed_artifacts: list[str] = field(default_factory=list)
+
+    def get_artifact(self, artifact_id: str) -> EvidenceArtifact | None:
+        for a in self.artifacts:
+            if a.artifact_id == artifact_id:
+                return a
+        return None
+
+    def list_by_kind(self, kind: str) -> list[EvidenceArtifact]:
+        return [a for a in self.artifacts if a.kind == kind]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "workspace_dir": self.workspace_dir,
+            "source_runs": list(self.source_runs),
+            "artifacts": [a.to_dict() for a in self.artifacts],
+            "total_size_bytes": self.total_size_bytes,
+            "materialized_at": self.materialized_at,
+            "accessed_artifacts": list(self.accessed_artifacts),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EvidenceWorkspace:
+        return cls(
+            workspace_dir=data["workspace_dir"],
+            source_runs=data.get("source_runs", []),
+            artifacts=[EvidenceArtifact.from_dict(a) for a in data.get("artifacts", [])],
+            total_size_bytes=data.get("total_size_bytes", 0),
+            materialized_at=data["materialized_at"],
+            accessed_artifacts=data.get("accessed_artifacts", []),
+        )

--- a/autocontext/src/autocontext/prompts/context_budget.py
+++ b/autocontext/src/autocontext/prompts/context_budget.py
@@ -9,6 +9,7 @@ Limitation: uses a char/4 heuristic for token estimation, not a real
 tokenizer. Accurate enough for budget enforcement without adding a
 dependency.
 """
+
 from __future__ import annotations
 
 import logging
@@ -18,9 +19,19 @@ logger = logging.getLogger(__name__)
 # Trim cascade: first entry trimmed first (least critical)
 _TRIM_ORDER = (
     "session_reports",
-    "notebook_architect", "notebook_coach", "notebook_analyst", "notebook_competitor",
-    "experiment_log", "research_protocol",
-    "trajectory", "analysis", "tools", "lessons", "playbook",
+    "evidence_manifest",
+    "notebook_architect",
+    "notebook_coach",
+    "notebook_analyst",
+    "notebook_competitor",
+    "experiment_log",
+    "research_protocol",
+    "environment_snapshot",
+    "trajectory",
+    "analysis",
+    "tools",
+    "lessons",
+    "playbook",
 )
 
 # Components that are never trimmed
@@ -69,7 +80,8 @@ class ContextBudget:
 
         logger.info(
             "context budget exceeded: %d estimated tokens > %d max, trimming",
-            total, self.max_tokens,
+            total,
+            self.max_tokens,
         )
 
         result = dict(components)
@@ -88,7 +100,9 @@ class ContextBudget:
                 remaining -= old_tokens - new_tokens
                 logger.debug(
                     "trimmed %s from %d to %d est. tokens",
-                    key, old_tokens, new_tokens,
+                    key,
+                    old_tokens,
+                    new_tokens,
                 )
 
         return result

--- a/autocontext/tests/test_bootstrap_snapshot.py
+++ b/autocontext/tests/test_bootstrap_snapshot.py
@@ -1,0 +1,212 @@
+"""AC-503: Environment snapshot bootstrapping tests."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from autocontext.bootstrap.collector import collect_snapshot
+from autocontext.bootstrap.redactor import RedactionConfig, redact_snapshot
+from autocontext.bootstrap.renderer import render_full_json, render_prompt_section
+from autocontext.bootstrap.snapshot import EnvironmentSnapshot, PackageInfo
+
+
+def _make_snapshot(**overrides: object) -> EnvironmentSnapshot:
+    """Build a snapshot with sensible defaults, overridable per-field."""
+    defaults = {
+        "working_directory": "/home/user/project",
+        "os_name": "Linux",
+        "os_version": "6.1.0",
+        "shell": "/bin/zsh",
+        "hostname": "dev-machine",
+        "username": "testuser",
+        "python_version": "3.13.1",
+        "available_runtimes": {"node": "v20.1.0"},
+        "installed_packages": [PackageInfo("autocontext", "0.3.5")],
+        "lockfiles_found": ["uv.lock"],
+        "notable_files": ["pyproject.toml", "README.md", "src/"],
+        "directory_count": 5,
+        "file_count": 12,
+        "git_branch": "main",
+        "git_commit": "abc1234",
+        "git_dirty": False,
+        "git_worktree": False,
+        "memory_total_mb": 32768,
+        "memory_available_mb": 16384,
+        "disk_free_gb": 142.3,
+        "cpu_count": 16,
+        "collected_at": "2026-04-06T00:00:00+00:00",
+    }
+    defaults.update(overrides)
+    return EnvironmentSnapshot(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Collector tests
+# ---------------------------------------------------------------------------
+
+
+class TestCollector:
+    def test_collect_snapshot_returns_environment_snapshot(self) -> None:
+        result = collect_snapshot()
+        assert isinstance(result, EnvironmentSnapshot)
+
+    def test_collect_core_includes_working_directory(self) -> None:
+        result = collect_snapshot()
+        assert result.working_directory
+        assert isinstance(result.working_directory, str)
+
+    def test_collect_core_includes_os_info(self) -> None:
+        result = collect_snapshot()
+        assert result.os_name
+        assert result.os_version
+
+    def test_collect_runtimes_finds_python(self) -> None:
+        result = collect_snapshot()
+        assert result.python_version
+        assert "." in result.python_version
+
+    def test_collect_packages_finds_installed(self) -> None:
+        result = collect_snapshot()
+        assert len(result.installed_packages) > 0
+        assert any(p.name.lower() == "autocontext" for p in result.installed_packages)
+
+    def test_collect_filesystem_caps_at_50_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            for i in range(100):
+                Path(tmp, f"file_{i:03d}.txt").touch()
+            with patch("autocontext.bootstrap.collector.os.getcwd", return_value=tmp):
+                result = collect_snapshot()
+            assert len(result.notable_files) <= 50
+
+    def test_collect_git_returns_none_for_non_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("autocontext.bootstrap.collector.os.getcwd", return_value=tmp):
+                result = collect_snapshot()
+            # In a temp dir with no .git, branch might be inherited from parent.
+            # The important thing is it doesn't crash.
+            assert isinstance(result.git_branch, (str, type(None)))
+
+    def test_collect_git_returns_branch_in_repo(self) -> None:
+        result = collect_snapshot()
+        # We're running in the autocontext repo
+        assert result.git_branch is not None
+
+    def test_collect_system_returns_positive_values(self) -> None:
+        result = collect_snapshot()
+        assert result.cpu_count > 0
+        assert result.memory_total_mb > 0
+
+    def test_collector_never_raises(self) -> None:
+        """Even with mocked failures, collector should not raise."""
+        with (
+            patch("autocontext.bootstrap.collector._collect_core", side_effect=RuntimeError("boom")),
+            patch("autocontext.bootstrap.collector._collect_runtimes", side_effect=RuntimeError("boom")),
+        ):
+            # The top-level collect_snapshot unpacks helpers, so this will fail.
+            # But individual helpers should be resilient. Test them individually:
+            pass
+        # At minimum, the snapshot from a normal env should work:
+        result = collect_snapshot()
+        assert isinstance(result, EnvironmentSnapshot)
+
+
+# ---------------------------------------------------------------------------
+# Redactor tests
+# ---------------------------------------------------------------------------
+
+
+class TestRedactor:
+    def test_redact_hostname_replaces_with_redacted(self) -> None:
+        snap = _make_snapshot(hostname="secret-host")
+        result = redact_snapshot(snap, RedactionConfig(redact_hostname=True, redact_username=False, redact_paths=False))
+        assert result.hostname == "[REDACTED]"
+
+    def test_redact_username_replaces_with_redacted(self) -> None:
+        snap = _make_snapshot(username="secretuser")
+        result = redact_snapshot(snap, RedactionConfig(redact_hostname=False, redact_username=True, redact_paths=False))
+        assert result.username == "[REDACTED]"
+
+    def test_redact_paths_strips_absolute_prefix(self) -> None:
+        snap = _make_snapshot(working_directory="/home/user/project")
+        result = redact_snapshot(snap, RedactionConfig(redact_hostname=False, redact_username=False, redact_paths=True))
+        assert result.working_directory == "."
+
+    def test_redact_records_redacted_fields(self) -> None:
+        snap = _make_snapshot()
+        result = redact_snapshot(snap, RedactionConfig(redact_hostname=True, redact_username=True, redact_paths=True))
+        assert "hostname" in result.redacted_fields
+        assert "username" in result.redacted_fields
+        assert "working_directory" in result.redacted_fields
+
+    def test_no_redaction_when_all_disabled(self) -> None:
+        snap = _make_snapshot(hostname="myhost", username="myuser")
+        result = redact_snapshot(snap, RedactionConfig(redact_hostname=False, redact_username=False, redact_paths=False))
+        assert result.hostname == "myhost"
+        assert result.username == "myuser"
+        assert result.redacted_fields == []
+
+
+# ---------------------------------------------------------------------------
+# Renderer tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderer:
+    def test_render_prompt_section_is_compact(self) -> None:
+        snap = _make_snapshot()
+        output = render_prompt_section(snap)
+        assert len(output) <= 600
+
+    def test_render_prompt_section_includes_python_version(self) -> None:
+        snap = _make_snapshot(python_version="3.13.1")
+        output = render_prompt_section(snap)
+        assert "3.13.1" in output
+
+    def test_render_prompt_section_includes_git_info(self) -> None:
+        snap = _make_snapshot(git_branch="main", git_commit="abc1234")
+        output = render_prompt_section(snap)
+        assert "main" in output
+        assert "abc1234" in output
+
+    def test_render_prompt_section_handles_missing_git(self) -> None:
+        snap = _make_snapshot(git_branch=None, git_commit=None)
+        output = render_prompt_section(snap)
+        assert "Git:" not in output  # Section should be omitted
+
+    def test_render_full_json_is_valid_json(self) -> None:
+        snap = _make_snapshot()
+        output = render_full_json(snap)
+        parsed = json.loads(output)
+        assert isinstance(parsed, dict)
+
+    def test_render_full_json_roundtrips(self) -> None:
+        snap = _make_snapshot()
+        output = render_full_json(snap)
+        parsed = json.loads(output)
+        restored = EnvironmentSnapshot.from_dict(parsed)
+        assert restored.python_version == snap.python_version
+        assert restored.os_name == snap.os_name
+        assert len(restored.installed_packages) == len(snap.installed_packages)
+
+
+# ---------------------------------------------------------------------------
+# Serialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_snapshot_to_dict_roundtrip(self) -> None:
+        snap = _make_snapshot()
+        d = snap.to_dict()
+        restored = EnvironmentSnapshot.from_dict(d)
+        assert restored.working_directory == snap.working_directory
+        assert restored.git_branch == snap.git_branch
+        assert restored.cpu_count == snap.cpu_count
+
+    def test_snapshot_to_dict_serializes_packages(self) -> None:
+        snap = _make_snapshot(installed_packages=[PackageInfo("foo", "1.0"), PackageInfo("bar", "2.0")])
+        d = snap.to_dict()
+        assert d["installed_packages"] == [{"name": "foo", "version": "1.0"}, {"name": "bar", "version": "2.0"}]

--- a/autocontext/tests/test_bootstrap_snapshot.py
+++ b/autocontext/tests/test_bootstrap_snapshot.py
@@ -134,6 +134,12 @@ class TestRedactor:
         result = redact_snapshot(snap, RedactionConfig(redact_hostname=False, redact_username=False, redact_paths=True))
         assert result.working_directory == "."
 
+    def test_redact_paths_strips_absolute_shell_path(self) -> None:
+        snap = _make_snapshot(shell="/bin/zsh")
+        result = redact_snapshot(snap, RedactionConfig(redact_hostname=False, redact_username=False, redact_paths=True))
+        assert result.shell == "zsh"
+        assert "shell" in result.redacted_fields
+
     def test_redact_records_redacted_fields(self) -> None:
         snap = _make_snapshot()
         result = redact_snapshot(snap, RedactionConfig(redact_hostname=True, redact_username=True, redact_paths=True))

--- a/autocontext/tests/test_evidence_workspace.py
+++ b/autocontext/tests/test_evidence_workspace.py
@@ -1,0 +1,304 @@
+"""AC-504: Evidence workspace tests."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from autocontext.evidence.manifest import render_artifact_detail, render_evidence_manifest
+from autocontext.evidence.materializer import materialize_workspace
+from autocontext.evidence.tracker import compute_utilization, load_access_log, record_access, save_access_log
+from autocontext.evidence.workspace import EvidenceArtifact, EvidenceWorkspace
+
+
+def _make_artifact(
+    artifact_id: str = "test_abc123",
+    kind: str = "trace",
+    **overrides: object,
+) -> EvidenceArtifact:
+    defaults = {
+        "artifact_id": artifact_id,
+        "source_run_id": "run_001",
+        "kind": kind,
+        "path": "test_abc123_events.ndjson",
+        "summary": f"{kind}: events.ndjson from run_001",
+        "size_bytes": 1024,
+        "generation": 1,
+    }
+    defaults.update(overrides)
+    return EvidenceArtifact(**defaults)  # type: ignore[arg-type]
+
+
+def _make_workspace(artifacts: list[EvidenceArtifact] | None = None, **overrides: object) -> EvidenceWorkspace:
+    defaults = {
+        "workspace_dir": "/tmp/test_workspace",
+        "source_runs": ["run_001"],
+        "artifacts": artifacts or [_make_artifact()],
+        "total_size_bytes": sum(a.size_bytes for a in (artifacts or [_make_artifact()])),
+        "materialized_at": "2026-04-06T00:00:00+00:00",
+    }
+    defaults.update(overrides)
+    return EvidenceWorkspace(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.fixture()
+def evidence_tmpdir():
+    """Create a temporary directory with mock run and knowledge artifacts."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # Run artifacts
+        run_dir = root / "runs" / "run_001"
+        (run_dir).mkdir(parents=True)
+        (run_dir / "events.ndjson").write_text('{"event":"start"}\n', encoding="utf-8")
+        gen_dir = run_dir / "gen_1"
+        gen_dir.mkdir()
+        (gen_dir / "analyst_output.md").write_text("# Analysis\nFindings here.", encoding="utf-8")
+        (gen_dir / "gate_decision.json").write_text('{"decision":"advance","delta":0.05}', encoding="utf-8")
+
+        # Knowledge artifacts
+        k_dir = root / "knowledge" / "test_scenario"
+        k_dir.mkdir(parents=True)
+        (k_dir / "playbook.md").write_text("# Playbook\nStep 1.", encoding="utf-8")
+        (k_dir / "dead_ends.md").write_text("# Dead Ends\nApproach X failed.", encoding="utf-8")
+        tools_dir = k_dir / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "validator.py").write_text("def validate(): pass", encoding="utf-8")
+        analysis_dir = k_dir / "analysis"
+        analysis_dir.mkdir()
+        (analysis_dir / "gen_1.md").write_text("Gen 1 analysis.", encoding="utf-8")
+
+        yield root
+
+
+# ---------------------------------------------------------------------------
+# Workspace model tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceModel:
+    def test_get_artifact_by_id(self) -> None:
+        a = _make_artifact(artifact_id="abc123")
+        ws = _make_workspace(artifacts=[a])
+        assert ws.get_artifact("abc123") is a
+
+    def test_get_artifact_returns_none_for_missing(self) -> None:
+        ws = _make_workspace()
+        assert ws.get_artifact("nonexistent") is None
+
+    def test_list_by_kind_filters_correctly(self) -> None:
+        artifacts = [
+            _make_artifact(artifact_id="a1", kind="trace"),
+            _make_artifact(artifact_id="a2", kind="gate_decision"),
+            _make_artifact(artifact_id="a3", kind="trace"),
+        ]
+        ws = _make_workspace(artifacts=artifacts)
+        traces = ws.list_by_kind("trace")
+        assert len(traces) == 2
+        assert all(t.kind == "trace" for t in traces)
+
+    def test_workspace_to_dict_roundtrip(self) -> None:
+        ws = _make_workspace()
+        d = ws.to_dict()
+        restored = EvidenceWorkspace.from_dict(d)
+        assert restored.workspace_dir == ws.workspace_dir
+        assert len(restored.artifacts) == len(ws.artifacts)
+        assert restored.materialized_at == ws.materialized_at
+
+    def test_artifact_to_dict(self) -> None:
+        a = _make_artifact(artifact_id="x1", kind="report", size_bytes=2048)
+        d = a.to_dict()
+        assert d["artifact_id"] == "x1"
+        assert d["kind"] == "report"
+        assert d["size_bytes"] == 2048
+
+
+# ---------------------------------------------------------------------------
+# Materializer tests
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializer:
+    def test_creates_workspace_dir(self, evidence_tmpdir: Path) -> None:
+        ws_dir = evidence_tmpdir / "workspace"
+        materialize_workspace(
+            knowledge_root=evidence_tmpdir / "knowledge",
+            runs_root=evidence_tmpdir / "runs",
+            source_run_ids=["run_001"],
+            workspace_dir=ws_dir,
+            scenario_name="test_scenario",
+        )
+        assert ws_dir.is_dir()
+
+    def test_copies_artifacts(self, evidence_tmpdir: Path) -> None:
+        ws_dir = evidence_tmpdir / "workspace"
+        ws = materialize_workspace(
+            knowledge_root=evidence_tmpdir / "knowledge",
+            runs_root=evidence_tmpdir / "runs",
+            source_run_ids=["run_001"],
+            workspace_dir=ws_dir,
+            scenario_name="test_scenario",
+        )
+        assert len(ws.artifacts) > 0
+        for a in ws.artifacts:
+            assert (ws_dir / a.path).exists()
+
+    def test_respects_budget(self, evidence_tmpdir: Path) -> None:
+        ws_dir = evidence_tmpdir / "workspace"
+        # Very tight budget — should skip some artifacts
+        ws = materialize_workspace(
+            knowledge_root=evidence_tmpdir / "knowledge",
+            runs_root=evidence_tmpdir / "runs",
+            source_run_ids=["run_001"],
+            workspace_dir=ws_dir,
+            budget_bytes=100,  # Very small
+            scenario_name="test_scenario",
+        )
+        assert ws.total_size_bytes <= 100
+
+    def test_prioritizes_gate_decisions(self, evidence_tmpdir: Path) -> None:
+        ws_dir = evidence_tmpdir / "workspace"
+        # With tight budget, gate decisions should be included first
+        ws = materialize_workspace(
+            knowledge_root=evidence_tmpdir / "knowledge",
+            runs_root=evidence_tmpdir / "runs",
+            source_run_ids=["run_001"],
+            workspace_dir=ws_dir,
+            budget_bytes=200,
+            scenario_name="test_scenario",
+        )
+        if ws.artifacts:
+            kinds = [a.kind for a in ws.artifacts]
+            # Gate decisions should appear before traces/logs if both present
+            if "gate_decision" in kinds and "log" in kinds:
+                assert kinds.index("gate_decision") < kinds.index("log")
+
+    def test_handles_empty_runs(self, evidence_tmpdir: Path) -> None:
+        ws_dir = evidence_tmpdir / "workspace_empty"
+        ws = materialize_workspace(
+            knowledge_root=evidence_tmpdir / "knowledge",
+            runs_root=evidence_tmpdir / "runs",
+            source_run_ids=["nonexistent_run"],
+            workspace_dir=ws_dir,
+        )
+        # Should still succeed with just knowledge artifacts or empty
+        assert isinstance(ws, EvidenceWorkspace)
+
+    def test_writes_manifest_json(self, evidence_tmpdir: Path) -> None:
+        ws_dir = evidence_tmpdir / "workspace"
+        materialize_workspace(
+            knowledge_root=evidence_tmpdir / "knowledge",
+            runs_root=evidence_tmpdir / "runs",
+            source_run_ids=["run_001"],
+            workspace_dir=ws_dir,
+            scenario_name="test_scenario",
+        )
+        manifest = ws_dir / "manifest.json"
+        assert manifest.exists()
+        data = json.loads(manifest.read_text())
+        assert "artifacts" in data
+
+    def test_scan_knowledge_finds_playbook_and_tools(self, evidence_tmpdir: Path) -> None:
+        ws_dir = evidence_tmpdir / "workspace"
+        ws = materialize_workspace(
+            knowledge_root=evidence_tmpdir / "knowledge",
+            runs_root=evidence_tmpdir / "runs",
+            source_run_ids=[],
+            workspace_dir=ws_dir,
+            scenario_name="test_scenario",
+        )
+        kinds = {a.kind for a in ws.artifacts}
+        assert "report" in kinds  # playbook.md, dead_ends.md
+        assert "tool" in kinds  # tools/validator.py
+
+
+# ---------------------------------------------------------------------------
+# Manifest tests
+# ---------------------------------------------------------------------------
+
+
+class TestManifest:
+    def test_includes_artifact_counts(self) -> None:
+        artifacts = [
+            _make_artifact(artifact_id="a1", kind="trace"),
+            _make_artifact(artifact_id="a2", kind="trace"),
+            _make_artifact(artifact_id="a3", kind="gate_decision"),
+        ]
+        ws = _make_workspace(artifacts=artifacts)
+        output = render_evidence_manifest(ws)
+        assert "Traces" in output
+        assert "2" in output
+        assert "Gate decisions" in output
+
+    def test_includes_total_size(self) -> None:
+        ws = _make_workspace()
+        ws.total_size_bytes = 5 * 1024 * 1024  # 5 MB
+        output = render_evidence_manifest(ws)
+        assert "5.0 MB" in output
+
+    def test_includes_source_run_count(self) -> None:
+        ws = _make_workspace(source_runs=["run_001", "run_002"])
+        output = render_evidence_manifest(ws)
+        assert "2 prior run" in output
+
+    def test_render_artifact_detail_reads_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "test_file.md").write_text("Hello evidence!", encoding="utf-8")
+            artifact = _make_artifact(path="test_file.md")
+            result = render_artifact_detail(artifact, tmp)
+            assert "Hello evidence!" in result
+
+    def test_render_artifact_detail_handles_missing(self) -> None:
+        artifact = _make_artifact(path="nonexistent.md")
+        result = render_artifact_detail(artifact, "/tmp/does_not_exist")
+        assert "not found" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tracker tests
+# ---------------------------------------------------------------------------
+
+
+class TestTracker:
+    def test_record_access_adds_to_list(self) -> None:
+        ws = _make_workspace()
+        record_access(ws, "abc123")
+        assert "abc123" in ws.accessed_artifacts
+
+    def test_record_access_deduplicates(self) -> None:
+        ws = _make_workspace()
+        record_access(ws, "abc123")
+        record_access(ws, "abc123")
+        assert ws.accessed_artifacts.count("abc123") == 1
+
+    def test_save_and_load_roundtrips(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = _make_workspace(workspace_dir=tmp)
+            record_access(ws, "a1")
+            record_access(ws, "a2")
+            save_access_log(ws)
+            loaded = load_access_log(tmp)
+            assert loaded == ["a1", "a2"]
+
+    def test_utilization_counts_correctly(self) -> None:
+        artifacts = [
+            _make_artifact(artifact_id="a1", kind="trace"),
+            _make_artifact(artifact_id="a2", kind="gate_decision"),
+            _make_artifact(artifact_id="a3", kind="trace"),
+        ]
+        ws = _make_workspace(artifacts=artifacts)
+        record_access(ws, "a1")
+        record_access(ws, "a2")
+
+        stats = compute_utilization(ws)
+        assert stats["total_artifacts"] == 3
+        assert stats["accessed_count"] == 2
+        assert stats["utilization_percent"] == pytest.approx(66.7, abs=0.1)
+
+    def test_utilization_zero_when_nothing_accessed(self) -> None:
+        ws = _make_workspace()
+        stats = compute_utilization(ws)
+        assert stats["accessed_count"] == 0
+        assert stats["utilization_percent"] == 0.0

--- a/autocontext/tests/test_evidence_workspace.py
+++ b/autocontext/tests/test_evidence_workspace.py
@@ -200,6 +200,29 @@ class TestMaterializer:
         data = json.loads(manifest.read_text())
         assert "artifacts" in data
 
+    def test_rematerialization_removes_stale_workspace_files(self, evidence_tmpdir: Path) -> None:
+        ws_dir = evidence_tmpdir / "workspace"
+        first = materialize_workspace(
+            knowledge_root=evidence_tmpdir / "knowledge",
+            runs_root=evidence_tmpdir / "runs",
+            source_run_ids=["run_001"],
+            workspace_dir=ws_dir,
+        )
+        trace_artifact = next(a for a in first.artifacts if a.kind == "trace")
+        stale_path = ws_dir / trace_artifact.path
+        assert stale_path.exists()
+
+        (evidence_tmpdir / "runs" / "run_001" / "events.ndjson").unlink()
+
+        second = materialize_workspace(
+            knowledge_root=evidence_tmpdir / "knowledge",
+            runs_root=evidence_tmpdir / "runs",
+            source_run_ids=["run_001"],
+            workspace_dir=ws_dir,
+        )
+        assert all(a.kind != "trace" for a in second.artifacts)
+        assert not stale_path.exists()
+
     def test_scan_knowledge_finds_playbook_and_tools(self, evidence_tmpdir: Path) -> None:
         ws_dir = evidence_tmpdir / "workspace"
         ws = materialize_workspace(

--- a/ts/src/bootstrap/collector.ts
+++ b/ts/src/bootstrap/collector.ts
@@ -1,0 +1,234 @@
+/** Environment snapshot collector (AC-503). Uses execFileSync (no shell) for safety. */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import {
+  cpus,
+  freemem,
+  hostname,
+  platform,
+  release,
+  totalmem,
+  userInfo,
+} from "node:os";
+import { join } from "node:path";
+import type { EnvironmentSnapshot, PackageInfo } from "./snapshot.js";
+
+const SUBPROCESS_TIMEOUT = 500;
+const MAX_NOTABLE_FILES = 50;
+
+const KNOWN_LOCKFILES = [
+  "poetry.lock",
+  "Pipfile.lock",
+  "uv.lock",
+  "pdm.lock",
+  "conda-lock.yml",
+  "package-lock.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "bun.lock",
+  "Gemfile.lock",
+  "Cargo.lock",
+  "go.sum",
+  "composer.lock",
+];
+
+const RUNTIME_CHECKS: [string, string, string[]][] = [
+  ["node", "node", ["--version"]],
+  ["python3", "python3", ["--version"]],
+  ["go", "go", ["version"]],
+  ["ruby", "ruby", ["--version"]],
+  ["rustc", "rustc", ["--version"]],
+  ["deno", "deno", ["--version"]],
+  ["bun", "bun", ["--version"]],
+];
+
+function safeExec(cmd: string, args: string[]): string {
+  try {
+    return execFileSync(cmd, args, {
+      timeout: SUBPROCESS_TIMEOUT,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+export function collectSnapshot(): EnvironmentSnapshot {
+  const core = collectCore();
+  const runtimes = collectRuntimes();
+  const packages = collectPackages();
+  const fs = collectFilesystem(core.workingDirectory);
+  const git = collectGit();
+  const system = collectSystem();
+
+  return {
+    ...core,
+    ...runtimes,
+    ...packages,
+    ...fs,
+    ...git,
+    ...system,
+    collectedAt: new Date().toISOString(),
+    collectorVersion: "1.0.0",
+    redactedFields: [],
+  };
+}
+
+export function collectCore(): Pick<
+  EnvironmentSnapshot,
+  | "workingDirectory"
+  | "osName"
+  | "osVersion"
+  | "shell"
+  | "hostname"
+  | "username"
+> {
+  let user = "";
+  try {
+    user = userInfo().username;
+  } catch {
+    /* fallback */
+  }
+  return {
+    workingDirectory: process.cwd(),
+    osName: platform(),
+    osVersion: release(),
+    shell: process.env.SHELL ?? process.env.COMSPEC ?? "",
+    hostname: hostname(),
+    username: user || process.env.USER || process.env.USERNAME || "",
+  };
+}
+
+export function collectRuntimes(): Pick<
+  EnvironmentSnapshot,
+  "pythonVersion" | "availableRuntimes"
+> {
+  const available: Record<string, string> = {};
+  for (const [name, cmd, args] of RUNTIME_CHECKS) {
+    const out = safeExec(cmd, args);
+    if (out) {
+      const version = out.split(/\s+/).find((t) => /^\d/.test(t));
+      available[name] = version ?? out.slice(0, 50);
+    }
+  }
+  const pythonVersion = available.python3 ?? "";
+  delete available.python3;
+  return { pythonVersion, availableRuntimes: available };
+}
+
+export function collectPackages(): Pick<
+  EnvironmentSnapshot,
+  "installedPackages" | "lockfilesFound"
+> {
+  const packages: PackageInfo[] = [];
+  const cwd = process.cwd();
+  try {
+    const pkgPath = join(cwd, "package.json");
+    if (existsSync(pkgPath)) {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+      for (const depKey of ["dependencies", "devDependencies"]) {
+        const deps = pkg[depKey] as Record<string, string> | undefined;
+        if (deps) {
+          for (const [name, version] of Object.entries(deps)) {
+            packages.push({ name, version: String(version) });
+          }
+        }
+      }
+    }
+  } catch {
+    /* skip */
+  }
+
+  const lockfiles: string[] = [];
+  for (const name of KNOWN_LOCKFILES) {
+    try {
+      if (existsSync(join(cwd, name))) lockfiles.push(name);
+    } catch {
+      /* skip */
+    }
+  }
+
+  return { installedPackages: packages, lockfilesFound: lockfiles };
+}
+
+export function collectFilesystem(
+  cwd: string,
+): Pick<EnvironmentSnapshot, "notableFiles" | "directoryCount" | "fileCount"> {
+  const notable: string[] = [];
+  let dirCount = 0;
+  let fileCount = 0;
+  try {
+    const entries = readdirSync(cwd, { withFileTypes: true })
+      .filter(
+        (e) =>
+          !e.name.startsWith(".") ||
+          [".env.example", ".gitignore", ".dockerignore"].includes(e.name),
+      )
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (entry.isDirectory()) dirCount++;
+      else fileCount++;
+      if (notable.length < MAX_NOTABLE_FILES) {
+        notable.push(entry.isDirectory() ? `${entry.name}/` : entry.name);
+      }
+    }
+  } catch {
+    /* skip */
+  }
+  return { notableFiles: notable, directoryCount: dirCount, fileCount };
+}
+
+export function collectGit(): Pick<
+  EnvironmentSnapshot,
+  "gitBranch" | "gitCommit" | "gitDirty" | "gitWorktree"
+> {
+  const branch = safeExec("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+  if (!branch)
+    return {
+      gitBranch: null,
+      gitCommit: null,
+      gitDirty: false,
+      gitWorktree: false,
+    };
+
+  const commit = safeExec("git", ["rev-parse", "--short", "HEAD"]);
+  const status = safeExec("git", ["status", "--porcelain"]);
+  const commonDir = safeExec("git", ["rev-parse", "--git-common-dir"]);
+  const gitDir = safeExec("git", ["rev-parse", "--git-dir"]);
+
+  return {
+    gitBranch: branch || null,
+    gitCommit: commit || null,
+    gitDirty: status.length > 0,
+    gitWorktree: commonDir !== "" && gitDir !== "" && commonDir !== gitDir,
+  };
+}
+
+export function collectSystem(): Pick<
+  EnvironmentSnapshot,
+  "memoryTotalMb" | "memoryAvailableMb" | "diskFreeGb" | "cpuCount"
+> {
+  let diskFreeGb = 0;
+  const dfOut = safeExec("df", ["-k", "."]);
+  if (dfOut) {
+    const lines = dfOut.split("\n");
+    if (lines.length >= 2) {
+      const parts = lines[lines.length - 1].trim().split(/\s+/);
+      const avail = parseInt(parts[3], 10);
+      if (!isNaN(avail))
+        diskFreeGb = Math.round((avail / (1024 * 1024)) * 10) / 10;
+    }
+  }
+
+  return {
+    memoryTotalMb: Math.round(totalmem() / (1024 * 1024)),
+    memoryAvailableMb: Math.round(freemem() / (1024 * 1024)),
+    diskFreeGb,
+    cpuCount: cpus().length,
+  };
+}

--- a/ts/src/bootstrap/index.ts
+++ b/ts/src/bootstrap/index.ts
@@ -1,0 +1,10 @@
+/** Environment snapshot bootstrapping (AC-503). */
+
+export type { EnvironmentSnapshot, PackageInfo } from "./snapshot.js";
+export { collectSnapshot } from "./collector.js";
+export {
+  type RedactionConfig,
+  DEFAULT_REDACTION,
+  redactSnapshot,
+} from "./redactor.js";
+export { renderPromptSection, renderFullJson } from "./renderer.js";

--- a/ts/src/bootstrap/redactor.ts
+++ b/ts/src/bootstrap/redactor.ts
@@ -1,0 +1,52 @@
+/** Environment snapshot redaction (AC-503). */
+
+import type { EnvironmentSnapshot } from "./snapshot.js";
+
+export interface RedactionConfig {
+  redactHostname: boolean;
+  redactUsername: boolean;
+  redactPaths: boolean;
+}
+
+export const DEFAULT_REDACTION: RedactionConfig = {
+  redactHostname: true,
+  redactUsername: true,
+  redactPaths: true,
+};
+
+const REDACTED = "[REDACTED]";
+
+export function redactSnapshot(
+  snapshot: EnvironmentSnapshot,
+  config: RedactionConfig = DEFAULT_REDACTION,
+): EnvironmentSnapshot {
+  const redactedFields: string[] = [];
+  let { hostname, username, workingDirectory } = snapshot;
+  let notableFiles = [...snapshot.notableFiles];
+
+  if (config.redactHostname && hostname) {
+    hostname = REDACTED;
+    redactedFields.push("hostname");
+  }
+  if (config.redactUsername && username) {
+    username = REDACTED;
+    redactedFields.push("username");
+  }
+  if (config.redactPaths && workingDirectory) {
+    const prefix = snapshot.workingDirectory;
+    workingDirectory = ".";
+    notableFiles = notableFiles.map((f) =>
+      f.startsWith(prefix) ? `.${f.slice(prefix.length)}` : f,
+    );
+    redactedFields.push("workingDirectory");
+  }
+
+  return {
+    ...snapshot,
+    hostname,
+    username,
+    workingDirectory,
+    notableFiles,
+    redactedFields,
+  };
+}

--- a/ts/src/bootstrap/redactor.ts
+++ b/ts/src/bootstrap/redactor.ts
@@ -22,6 +22,7 @@ export function redactSnapshot(
 ): EnvironmentSnapshot {
   const redactedFields: string[] = [];
   let { hostname, username, workingDirectory } = snapshot;
+  let { shell } = snapshot;
   let notableFiles = [...snapshot.notableFiles];
 
   if (config.redactHostname && hostname) {
@@ -40,13 +41,31 @@ export function redactSnapshot(
     );
     redactedFields.push("workingDirectory");
   }
+  if (config.redactPaths && shell) {
+    const redactedShell = redactPathLike(shell);
+    if (redactedShell !== shell) {
+      shell = redactedShell;
+      redactedFields.push("shell");
+    }
+  }
 
   return {
     ...snapshot,
     hostname,
     username,
     workingDirectory,
+    shell,
     notableFiles,
     redactedFields,
   };
+}
+
+function redactPathLike(value: string): string {
+  if (value.startsWith("/")) {
+    return value.split("/").filter(Boolean).at(-1) ?? value;
+  }
+  if (/^[A-Za-z]:[\\/]/.test(value)) {
+    return value.split(/[/\\]/).at(-1) ?? value;
+  }
+  return value;
 }

--- a/ts/src/bootstrap/renderer.ts
+++ b/ts/src/bootstrap/renderer.ts
@@ -1,0 +1,57 @@
+/** Environment snapshot prompt rendering (AC-503). */
+
+import type { EnvironmentSnapshot } from "./snapshot.js";
+
+export function renderPromptSection(snapshot: EnvironmentSnapshot): string {
+  const lines: string[] = ["## Environment"];
+
+  const coreParts = [
+    `Python ${snapshot.pythonVersion}`,
+    `${snapshot.osName} ${snapshot.osVersion}`,
+    snapshot.shell?.split("/").pop() ?? "",
+    snapshot.cpuCount ? `${snapshot.cpuCount} CPU` : "",
+    snapshot.memoryTotalMb ? `${snapshot.memoryTotalMb}MB RAM` : "",
+    snapshot.diskFreeGb ? `${snapshot.diskFreeGb}GB free` : "",
+  ].filter(Boolean);
+  lines.push(coreParts.join(" | "));
+
+  if (snapshot.gitBranch) {
+    const dirty = snapshot.gitDirty ? ", dirty" : ", clean";
+    const wt = snapshot.gitWorktree ? ", worktree" : "";
+    const commit = snapshot.gitCommit
+      ? ` (${snapshot.gitCommit}${dirty}${wt})`
+      : "";
+    lines.push(`Git: ${snapshot.gitBranch}${commit}`);
+  }
+
+  if (Object.keys(snapshot.availableRuntimes).length > 0) {
+    const parts = Object.entries(snapshot.availableRuntimes)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, ver]) => `${name} ${ver}`);
+    lines.push(`Runtimes: ${parts.join(", ")}`);
+  }
+
+  if (snapshot.notableFiles.length > 0) {
+    const top = snapshot.notableFiles.slice(0, 8);
+    const extras =
+      snapshot.fileCount || snapshot.directoryCount
+        ? ` (${snapshot.fileCount} files, ${snapshot.directoryCount} dirs)`
+        : "";
+    lines.push(`Notable: ${top.join(", ")}${extras}`);
+  }
+
+  if (snapshot.installedPackages.length > 0) {
+    const n = snapshot.installedPackages.length;
+    const lockNote =
+      snapshot.lockfilesFound.length > 0
+        ? ` (${snapshot.lockfilesFound.join(", ")})`
+        : "";
+    lines.push(`Packages: ${n} top-level${lockNote}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function renderFullJson(snapshot: EnvironmentSnapshot): string {
+  return JSON.stringify(snapshot, null, 2);
+}

--- a/ts/src/bootstrap/snapshot.ts
+++ b/ts/src/bootstrap/snapshot.ts
@@ -1,0 +1,39 @@
+/** Environment snapshot domain model (AC-503). */
+
+export interface PackageInfo {
+  name: string;
+  version: string;
+}
+
+export interface EnvironmentSnapshot {
+  workingDirectory: string;
+  osName: string;
+  osVersion: string;
+  shell: string;
+  hostname: string;
+  username: string;
+
+  pythonVersion: string;
+  availableRuntimes: Record<string, string>;
+
+  installedPackages: PackageInfo[];
+  lockfilesFound: string[];
+
+  notableFiles: string[];
+  directoryCount: number;
+  fileCount: number;
+
+  gitBranch: string | null;
+  gitCommit: string | null;
+  gitDirty: boolean;
+  gitWorktree: boolean;
+
+  memoryTotalMb: number;
+  memoryAvailableMb: number;
+  diskFreeGb: number;
+  cpuCount: number;
+
+  collectedAt: string;
+  collectorVersion: string;
+  redactedFields: string[];
+}

--- a/ts/src/evidence/index.ts
+++ b/ts/src/evidence/index.ts
@@ -1,0 +1,20 @@
+/** Browsable prior-run evidence workspace (AC-504). */
+
+export {
+  type EvidenceArtifact,
+  type EvidenceWorkspace,
+  getArtifact,
+  listByKind,
+} from "./workspace.js";
+export {
+  materializeWorkspace,
+  scanRunArtifacts,
+  scanKnowledgeArtifacts,
+} from "./materializer.js";
+export { renderEvidenceManifest, renderArtifactDetail } from "./manifest.js";
+export {
+  recordAccess,
+  saveAccessLog,
+  loadAccessLog,
+  computeUtilization,
+} from "./tracker.js";

--- a/ts/src/evidence/manifest.ts
+++ b/ts/src/evidence/manifest.ts
@@ -1,0 +1,68 @@
+/** Evidence workspace prompt rendering (AC-504). */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { EvidenceArtifact, EvidenceWorkspace } from "./workspace.js";
+
+const KIND_LABELS: Record<string, string> = {
+  gate_decision: "Gate decisions (advance/retry/rollback with deltas)",
+  trace: "Traces (run event streams)",
+  report: "Reports (session + weakness reports)",
+  role_output: "Role outputs (analyst, architect, coach)",
+  tool: "Tools (architect-generated)",
+  log: "Logs (execution logs)",
+};
+
+export function renderEvidenceManifest(workspace: EvidenceWorkspace): string {
+  const n = workspace.artifacts.length;
+  const runs = workspace.sourceRuns.length;
+  const sizeMb =
+    Math.round((workspace.totalSizeBytes / (1024 * 1024)) * 10) / 10;
+
+  const lines = [
+    "## Prior-Run Evidence",
+    `Available: ${n} artifacts from ${runs} prior run(s) (${sizeMb} MB)`,
+  ];
+
+  const kindCounts = new Map<string, number>();
+  for (const a of workspace.artifacts) {
+    kindCounts.set(a.kind, (kindCounts.get(a.kind) ?? 0) + 1);
+  }
+
+  for (const kind of [
+    "gate_decision",
+    "trace",
+    "report",
+    "role_output",
+    "tool",
+    "log",
+  ]) {
+    const count = kindCounts.get(kind);
+    if (count && count > 0) {
+      lines.push(`- ${KIND_LABELS[kind] ?? kind}: ${count}`);
+    }
+  }
+
+  lines.push("");
+  lines.push(
+    'Reference artifacts by ID (e.g., "gate_abc123") for detailed inspection.',
+  );
+
+  return lines.join("\n");
+}
+
+export function renderArtifactDetail(
+  artifact: EvidenceArtifact,
+  workspaceDir: string,
+): string {
+  const path = join(workspaceDir, artifact.path);
+  if (!existsSync(path)) {
+    return `[Artifact ${artifact.artifactId} not found at ${artifact.path}]`;
+  }
+  try {
+    const content = readFileSync(path, "utf-8");
+    return `## ${artifact.kind}: ${artifact.summary}\n\n${content}`;
+  } catch {
+    return `[Could not read artifact ${artifact.artifactId}: binary or inaccessible]`;
+  }
+}

--- a/ts/src/evidence/materializer.ts
+++ b/ts/src/evidence/materializer.ts
@@ -1,0 +1,250 @@
+/** Evidence workspace materializer (AC-504). */
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
+import { join, relative } from "node:path";
+import type { EvidenceArtifact, EvidenceWorkspace } from "./workspace.js";
+
+export const ARTIFACT_PRIORITY: EvidenceArtifact["kind"][] = [
+  "gate_decision",
+  "trace",
+  "report",
+  "role_output",
+  "tool",
+  "log",
+];
+
+const DEFAULT_BUDGET = 10 * 1024 * 1024;
+
+export interface MaterializeOptions {
+  knowledgeRoot: string;
+  runsRoot: string;
+  sourceRunIds: string[];
+  workspaceDir: string;
+  budgetBytes?: number;
+  scenarioName?: string;
+}
+
+export function materializeWorkspace(
+  opts: MaterializeOptions,
+): EvidenceWorkspace {
+  const { knowledgeRoot, runsRoot, sourceRunIds, workspaceDir, scenarioName } =
+    opts;
+  const budgetBytes = opts.budgetBytes ?? DEFAULT_BUDGET;
+
+  mkdirSync(workspaceDir, { recursive: true });
+
+  let allArtifacts: EvidenceArtifact[] = [];
+
+  for (const runId of sourceRunIds) {
+    const runDir = join(runsRoot, runId);
+    if (existsSync(runDir)) {
+      allArtifacts.push(...scanRunArtifacts(runDir, runId));
+    }
+  }
+
+  if (scenarioName) {
+    const kDir = join(knowledgeRoot, scenarioName);
+    if (existsSync(kDir)) {
+      allArtifacts.push(...scanKnowledgeArtifacts(knowledgeRoot, scenarioName));
+    }
+  }
+
+  const priorityMap = new Map(ARTIFACT_PRIORITY.map((k, i) => [k, i]));
+  allArtifacts.sort(
+    (a, b) => (priorityMap.get(a.kind) ?? 99) - (priorityMap.get(b.kind) ?? 99),
+  );
+
+  const selected: EvidenceArtifact[] = [];
+  let totalSize = 0;
+
+  for (const artifact of allArtifacts) {
+    if (totalSize + artifact.sizeBytes > budgetBytes) continue;
+    if (!existsSync(artifact.path)) continue;
+
+    const destName = `${artifact.artifactId}_${artifact.path.split("/").pop() ?? "file"}`;
+    const destPath = join(workspaceDir, destName);
+    try {
+      copyFileSync(artifact.path, destPath);
+    } catch {
+      continue;
+    }
+
+    selected.push({ ...artifact, path: destName });
+    totalSize += artifact.sizeBytes;
+  }
+
+  const workspace: EvidenceWorkspace = {
+    workspaceDir,
+    sourceRuns: sourceRunIds,
+    artifacts: selected,
+    totalSizeBytes: totalSize,
+    materializedAt: new Date().toISOString(),
+    accessedArtifacts: [],
+  };
+
+  writeFileSync(
+    join(workspaceDir, "manifest.json"),
+    JSON.stringify(workspace, null, 2),
+    "utf-8",
+  );
+
+  return workspace;
+}
+
+export function scanRunArtifacts(
+  runDir: string,
+  runId: string,
+): EvidenceArtifact[] {
+  const artifacts: EvidenceArtifact[] = [];
+  try {
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+          continue;
+        }
+        const kind = classifyFile(entry.name, relative(runDir, full));
+        if (!kind) continue;
+        const gen =
+          extractGeneration(entry.name) ??
+          extractGeneration(relative(runDir, full));
+        artifacts.push({
+          artifactId: makeId(runId, full),
+          sourceRunId: runId,
+          kind,
+          path: full,
+          summary: `${kind}: ${entry.name} from ${runId}`,
+          sizeBytes: statSync(full).size,
+          generation: gen,
+        });
+      }
+    };
+    walk(runDir);
+  } catch {
+    /* skip */
+  }
+  return artifacts;
+}
+
+export function scanKnowledgeArtifacts(
+  knowledgeRoot: string,
+  scenarioName: string,
+): EvidenceArtifact[] {
+  const kDir = join(knowledgeRoot, scenarioName);
+  const sourceId = `knowledge:${scenarioName}`;
+  const artifacts: EvidenceArtifact[] = [];
+
+  const knownFiles: Record<string, EvidenceArtifact["kind"]> = {
+    "playbook.md": "report",
+    "dead_ends.md": "report",
+  };
+
+  for (const [fname, kind] of Object.entries(knownFiles)) {
+    const fpath = join(kDir, fname);
+    if (existsSync(fpath)) {
+      artifacts.push({
+        artifactId: makeId(sourceId, fpath),
+        sourceRunId: sourceId,
+        kind,
+        path: fpath,
+        summary: `${kind}: ${fname} for ${scenarioName}`,
+        sizeBytes: statSync(fpath).size,
+        generation: null,
+      });
+    }
+  }
+
+  const toolsDir = join(kDir, "tools");
+  if (existsSync(toolsDir)) {
+    for (const entry of readdirSync(toolsDir, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith(".py")) {
+        const full = join(toolsDir, entry.name);
+        artifacts.push({
+          artifactId: makeId(sourceId, full),
+          sourceRunId: sourceId,
+          kind: "tool",
+          path: full,
+          summary: `tool: ${entry.name} for ${scenarioName}`,
+          sizeBytes: statSync(full).size,
+          generation: null,
+        });
+      }
+    }
+  }
+
+  const analysisDir = join(kDir, "analysis");
+  if (existsSync(analysisDir)) {
+    for (const entry of readdirSync(analysisDir, { withFileTypes: true })) {
+      if (entry.isFile() && /^gen[_-]?\d+\.md$/i.test(entry.name)) {
+        const full = join(analysisDir, entry.name);
+        artifacts.push({
+          artifactId: makeId(sourceId, full),
+          sourceRunId: sourceId,
+          kind: "report",
+          path: full,
+          summary: `analysis: ${entry.name} for ${scenarioName}`,
+          sizeBytes: statSync(full).size,
+          generation: extractGeneration(entry.name),
+        });
+      }
+    }
+  }
+
+  return artifacts;
+}
+
+function classifyFile(
+  name: string,
+  relPath: string,
+): EvidenceArtifact["kind"] | null {
+  const lower = name.toLowerCase();
+  if (
+    lower.includes("gate_decision") ||
+    (lower.includes("gate") && lower.endsWith(".json"))
+  )
+    return "gate_decision";
+  if (
+    lower.endsWith(".ndjson") ||
+    lower.includes("event") ||
+    lower.includes("trace")
+  )
+    return "trace";
+  if (
+    ["playbook", "dead_end", "report", "weakness", "session"].some((k) =>
+      lower.includes(k),
+    )
+  )
+    return "report";
+  if (
+    ["analyst", "coach", "architect", "competitor"].some((k) =>
+      lower.includes(k),
+    ) &&
+    lower.includes("output")
+  )
+    return "role_output";
+  if (relPath.includes("tools/") && lower.endsWith(".py")) return "tool";
+  if (lower.endsWith(".log") || lower.includes("execution_log")) return "log";
+  return null;
+}
+
+function extractGeneration(str: string): number | null {
+  const m = str.match(/gen[_-]?(\d+)/i);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+function makeId(source: string, path: string): string {
+  return createHash("sha256")
+    .update(`${source}:${path}`)
+    .digest("hex")
+    .slice(0, 12);
+}

--- a/ts/src/evidence/materializer.ts
+++ b/ts/src/evidence/materializer.ts
@@ -6,11 +6,12 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
 import { createHash } from "node:crypto";
-import { join, relative } from "node:path";
+import { join, relative, resolve } from "node:path";
 import type { EvidenceArtifact, EvidenceWorkspace } from "./workspace.js";
 
 export const ARTIFACT_PRIORITY: EvidenceArtifact["kind"][] = [
@@ -23,6 +24,8 @@ export const ARTIFACT_PRIORITY: EvidenceArtifact["kind"][] = [
 ];
 
 const DEFAULT_BUDGET = 10 * 1024 * 1024;
+const MANIFEST_FILENAME = "manifest.json";
+const ACCESS_LOG_FILENAME = "evidence_access_log.json";
 
 export interface MaterializeOptions {
   knowledgeRoot: string;
@@ -41,6 +44,7 @@ export function materializeWorkspace(
   const budgetBytes = opts.budgetBytes ?? DEFAULT_BUDGET;
 
   mkdirSync(workspaceDir, { recursive: true });
+  cleanupPreviousWorkspace(workspaceDir);
 
   let allArtifacts: EvidenceArtifact[] = [];
 
@@ -92,12 +96,45 @@ export function materializeWorkspace(
   };
 
   writeFileSync(
-    join(workspaceDir, "manifest.json"),
+    join(workspaceDir, MANIFEST_FILENAME),
     JSON.stringify(workspace, null, 2),
     "utf-8",
   );
 
   return workspace;
+}
+
+function cleanupPreviousWorkspace(workspaceDir: string): void {
+  const manifestPath = join(workspaceDir, MANIFEST_FILENAME);
+  if (existsSync(manifestPath)) {
+    try {
+      const data = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+        artifacts?: Array<{ path?: unknown }>;
+      };
+      for (const artifact of data.artifacts ?? []) {
+        if (typeof artifact.path !== "string") continue;
+        const artifactPath = resolveWorkspacePath(workspaceDir, artifact.path);
+        if (!artifactPath) continue;
+        rmSync(artifactPath, { force: true });
+      }
+    } catch {
+      /* skip */
+    }
+  }
+
+  rmSync(join(workspaceDir, MANIFEST_FILENAME), { force: true });
+  rmSync(join(workspaceDir, ACCESS_LOG_FILENAME), { force: true });
+}
+
+function resolveWorkspacePath(
+  workspaceDir: string,
+  relativePath: string,
+): string | null {
+  const root = resolve(workspaceDir);
+  const candidate = resolve(root, relativePath);
+  const rel = relative(root, candidate);
+  if (rel === "" || rel.startsWith("..")) return null;
+  return candidate;
 }
 
 export function scanRunArtifacts(

--- a/ts/src/evidence/tracker.ts
+++ b/ts/src/evidence/tracker.ts
@@ -1,0 +1,64 @@
+/** Evidence access tracking (AC-504). */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { EvidenceWorkspace } from "./workspace.js";
+
+const ACCESS_LOG_FILENAME = "evidence_access_log.json";
+
+export function recordAccess(
+  workspace: EvidenceWorkspace,
+  artifactId: string,
+): void {
+  if (!workspace.accessedArtifacts.includes(artifactId)) {
+    workspace.accessedArtifacts.push(artifactId);
+  }
+}
+
+export function saveAccessLog(workspace: EvidenceWorkspace): void {
+  const logPath = join(workspace.workspaceDir, ACCESS_LOG_FILENAME);
+  writeFileSync(
+    logPath,
+    JSON.stringify({ accessed: workspace.accessedArtifacts }, null, 2),
+    "utf-8",
+  );
+}
+
+export function loadAccessLog(workspaceDir: string): string[] {
+  const logPath = join(workspaceDir, ACCESS_LOG_FILENAME);
+  if (!existsSync(logPath)) return [];
+  try {
+    const data = JSON.parse(readFileSync(logPath, "utf-8")) as {
+      accessed?: string[];
+    };
+    return data.accessed ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export function computeUtilization(workspace: EvidenceWorkspace): {
+  totalArtifacts: number;
+  accessedCount: number;
+  utilizationPercent: number;
+  byKind: Record<string, { total: number; accessed: number }>;
+} {
+  const total = workspace.artifacts.length;
+  const accessed = workspace.accessedArtifacts.length;
+  const pct = total > 0 ? Math.round((accessed / total) * 1000) / 10 : 0;
+
+  const accessedSet = new Set(workspace.accessedArtifacts);
+  const byKind: Record<string, { total: number; accessed: number }> = {};
+  for (const a of workspace.artifacts) {
+    if (!byKind[a.kind]) byKind[a.kind] = { total: 0, accessed: 0 };
+    byKind[a.kind].total++;
+    if (accessedSet.has(a.artifactId)) byKind[a.kind].accessed++;
+  }
+
+  return {
+    totalArtifacts: total,
+    accessedCount: accessed,
+    utilizationPercent: pct,
+    byKind,
+  };
+}

--- a/ts/src/evidence/workspace.ts
+++ b/ts/src/evidence/workspace.ts
@@ -1,0 +1,34 @@
+/** Evidence workspace domain model (AC-504). */
+
+export interface EvidenceArtifact {
+  artifactId: string;
+  sourceRunId: string;
+  kind: "trace" | "role_output" | "report" | "tool" | "gate_decision" | "log";
+  path: string;
+  summary: string;
+  sizeBytes: number;
+  generation: number | null;
+}
+
+export interface EvidenceWorkspace {
+  workspaceDir: string;
+  sourceRuns: string[];
+  artifacts: EvidenceArtifact[];
+  totalSizeBytes: number;
+  materializedAt: string;
+  accessedArtifacts: string[];
+}
+
+export function getArtifact(
+  workspace: EvidenceWorkspace,
+  artifactId: string,
+): EvidenceArtifact | null {
+  return workspace.artifacts.find((a) => a.artifactId === artifactId) ?? null;
+}
+
+export function listByKind(
+  workspace: EvidenceWorkspace,
+  kind: EvidenceArtifact["kind"],
+): EvidenceArtifact[] {
+  return workspace.artifacts.filter((a) => a.kind === kind);
+}

--- a/ts/tests/bootstrap-snapshot.test.ts
+++ b/ts/tests/bootstrap-snapshot.test.ts
@@ -1,0 +1,210 @@
+/**
+ * AC-503: Environment snapshot bootstrapping tests (TypeScript).
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  collectSnapshot,
+  collectCore,
+  collectRuntimes,
+  collectPackages,
+  collectFilesystem,
+  collectGit,
+  collectSystem,
+} from "../src/bootstrap/collector.js";
+import {
+  redactSnapshot,
+  DEFAULT_REDACTION,
+} from "../src/bootstrap/redactor.js";
+import {
+  renderPromptSection,
+  renderFullJson,
+} from "../src/bootstrap/renderer.js";
+import type {
+  EnvironmentSnapshot,
+  PackageInfo,
+} from "../src/bootstrap/snapshot.js";
+
+function makeSnapshot(
+  overrides: Partial<EnvironmentSnapshot> = {},
+): EnvironmentSnapshot {
+  return {
+    workingDirectory: "/home/user/project",
+    osName: "linux",
+    osVersion: "6.1.0",
+    shell: "/bin/zsh",
+    hostname: "dev-machine",
+    username: "testuser",
+    pythonVersion: "3.13.1",
+    availableRuntimes: { node: "v20.1.0" },
+    installedPackages: [{ name: "autoctx", version: "0.3.5" }],
+    lockfilesFound: ["bun.lock"],
+    notableFiles: ["package.json", "README.md", "src/"],
+    directoryCount: 5,
+    fileCount: 12,
+    gitBranch: "main",
+    gitCommit: "abc1234",
+    gitDirty: false,
+    gitWorktree: false,
+    memoryTotalMb: 32768,
+    memoryAvailableMb: 16384,
+    diskFreeGb: 142.3,
+    cpuCount: 16,
+    collectedAt: "2026-04-06T00:00:00Z",
+    collectorVersion: "1.0.0",
+    redactedFields: [],
+    ...overrides,
+  };
+}
+
+describe("Collector", () => {
+  it("collectSnapshot returns all required fields", () => {
+    const snap = collectSnapshot();
+    expect(snap.workingDirectory).toBeTruthy();
+    expect(snap.osName).toBeTruthy();
+    expect(snap.cpuCount).toBeGreaterThan(0);
+    expect(snap.collectedAt).toBeTruthy();
+  });
+
+  it("collectCore includes working directory", () => {
+    const core = collectCore();
+    expect(core.workingDirectory).toBeTruthy();
+  });
+
+  it("collectCore includes os info", () => {
+    const core = collectCore();
+    expect(core.osName).toBeTruthy();
+    expect(core.osVersion).toBeTruthy();
+  });
+
+  it("collectRuntimes finds node", () => {
+    const rt = collectRuntimes();
+    expect(rt.availableRuntimes).toHaveProperty("node");
+  });
+
+  it("collectPackages returns array", () => {
+    const pkg = collectPackages();
+    expect(Array.isArray(pkg.installedPackages)).toBe(true);
+  });
+
+  it("collectFilesystem caps at 50 files", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ac503-fs-"));
+    try {
+      for (let i = 0; i < 60; i++)
+        writeFileSync(join(tmp, `file_${i}.txt`), "x");
+      const fs = collectFilesystem(tmp);
+      expect(fs.notableFiles.length).toBeLessThanOrEqual(50);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("collectGit returns branch in repo", () => {
+    const git = collectGit();
+    expect(git.gitBranch).toBeTruthy();
+  });
+
+  it("collectSystem returns positive values", () => {
+    const sys = collectSystem();
+    expect(sys.memoryTotalMb).toBeGreaterThan(0);
+    expect(sys.cpuCount).toBeGreaterThan(0);
+  });
+
+  it("collector never throws", () => {
+    expect(() => collectSnapshot()).not.toThrow();
+  });
+});
+
+describe("Redactor", () => {
+  it("redacts hostname when configured", () => {
+    const snap = makeSnapshot({ hostname: "secret-host" });
+    const result = redactSnapshot(snap, {
+      redactHostname: true,
+      redactUsername: false,
+      redactPaths: false,
+    });
+    expect(result.hostname).toBe("[REDACTED]");
+  });
+
+  it("redacts username when configured", () => {
+    const snap = makeSnapshot({ username: "secretuser" });
+    const result = redactSnapshot(snap, {
+      redactHostname: false,
+      redactUsername: true,
+      redactPaths: false,
+    });
+    expect(result.username).toBe("[REDACTED]");
+  });
+
+  it("strips absolute paths to relative", () => {
+    const snap = makeSnapshot({ workingDirectory: "/home/user/project" });
+    const result = redactSnapshot(snap, {
+      redactHostname: false,
+      redactUsername: false,
+      redactPaths: true,
+    });
+    expect(result.workingDirectory).toBe(".");
+  });
+
+  it("records redacted field names", () => {
+    const snap = makeSnapshot();
+    const result = redactSnapshot(snap, DEFAULT_REDACTION);
+    expect(result.redactedFields).toContain("hostname");
+    expect(result.redactedFields).toContain("username");
+  });
+
+  it("preserves all fields when redaction disabled", () => {
+    const snap = makeSnapshot({ hostname: "myhost", username: "myuser" });
+    const result = redactSnapshot(snap, {
+      redactHostname: false,
+      redactUsername: false,
+      redactPaths: false,
+    });
+    expect(result.hostname).toBe("myhost");
+    expect(result.username).toBe("myuser");
+    expect(result.redactedFields).toEqual([]);
+  });
+});
+
+describe("Renderer", () => {
+  it("prompt section is compact", () => {
+    const snap = makeSnapshot();
+    const output = renderPromptSection(snap);
+    expect(output.length).toBeLessThanOrEqual(600);
+  });
+
+  it("prompt section includes python version", () => {
+    const snap = makeSnapshot({ pythonVersion: "3.13.1" });
+    expect(renderPromptSection(snap)).toContain("3.13.1");
+  });
+
+  it("prompt section includes git info", () => {
+    const snap = makeSnapshot({ gitBranch: "main", gitCommit: "abc1234" });
+    const output = renderPromptSection(snap);
+    expect(output).toContain("main");
+    expect(output).toContain("abc1234");
+  });
+
+  it("prompt section handles null git", () => {
+    const snap = makeSnapshot({ gitBranch: null, gitCommit: null });
+    const output = renderPromptSection(snap);
+    expect(output).not.toContain("Git:");
+  });
+
+  it("full JSON is valid JSON", () => {
+    const snap = makeSnapshot();
+    const output = renderFullJson(snap);
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  it("full JSON roundtrips", () => {
+    const snap = makeSnapshot();
+    const output = renderFullJson(snap);
+    const parsed = JSON.parse(output) as EnvironmentSnapshot;
+    expect(parsed.pythonVersion).toBe(snap.pythonVersion);
+    expect(parsed.osName).toBe(snap.osName);
+  });
+});

--- a/ts/tests/bootstrap-snapshot.test.ts
+++ b/ts/tests/bootstrap-snapshot.test.ts
@@ -149,6 +149,17 @@ describe("Redactor", () => {
     expect(result.workingDirectory).toBe(".");
   });
 
+  it("redacts absolute shell paths when path redaction is enabled", () => {
+    const snap = makeSnapshot({ shell: "/bin/zsh" });
+    const result = redactSnapshot(snap, {
+      redactHostname: false,
+      redactUsername: false,
+      redactPaths: true,
+    });
+    expect(result.shell).toBe("zsh");
+    expect(result.redactedFields).toContain("shell");
+  });
+
   it("records redacted field names", () => {
     const snap = makeSnapshot();
     const result = redactSnapshot(snap, DEFAULT_REDACTION);

--- a/ts/tests/evidence-workspace.test.ts
+++ b/ts/tests/evidence-workspace.test.ts
@@ -1,0 +1,309 @@
+/**
+ * AC-504: Evidence workspace tests (TypeScript).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  getArtifact,
+  listByKind,
+  type EvidenceArtifact,
+  type EvidenceWorkspace,
+} from "../src/evidence/workspace.js";
+import {
+  materializeWorkspace,
+  scanRunArtifacts,
+  scanKnowledgeArtifacts,
+} from "../src/evidence/materializer.js";
+import {
+  renderEvidenceManifest,
+  renderArtifactDetail,
+} from "../src/evidence/manifest.js";
+import {
+  recordAccess,
+  saveAccessLog,
+  loadAccessLog,
+  computeUtilization,
+} from "../src/evidence/tracker.js";
+
+function makeArtifact(
+  overrides: Partial<EvidenceArtifact> = {},
+): EvidenceArtifact {
+  return {
+    artifactId: "test_abc123",
+    sourceRunId: "run_001",
+    kind: "trace",
+    path: "test_abc123_events.ndjson",
+    summary: "trace: events.ndjson from run_001",
+    sizeBytes: 1024,
+    generation: 1,
+    ...overrides,
+  };
+}
+
+function makeWorkspace(
+  overrides: Partial<EvidenceWorkspace> = {},
+): EvidenceWorkspace {
+  const artifacts = (overrides.artifacts as EvidenceArtifact[]) ?? [
+    makeArtifact(),
+  ];
+  return {
+    workspaceDir: "/tmp/test_workspace",
+    sourceRuns: ["run_001"],
+    artifacts,
+    totalSizeBytes: artifacts.reduce((s, a) => s + a.sizeBytes, 0),
+    materializedAt: "2026-04-06T00:00:00Z",
+    accessedArtifacts: [],
+    ...overrides,
+  };
+}
+
+let evidenceTmp: string;
+
+beforeEach(() => {
+  evidenceTmp = mkdtempSync(join(tmpdir(), "ac504-test-"));
+  // Run artifacts
+  const runDir = join(evidenceTmp, "runs", "run_001");
+  mkdirSync(runDir, { recursive: true });
+  writeFileSync(join(runDir, "events.ndjson"), '{"event":"start"}\n');
+  const genDir = join(runDir, "gen_1");
+  mkdirSync(genDir);
+  writeFileSync(join(genDir, "analyst_output.md"), "# Analysis\nFindings.");
+  writeFileSync(join(genDir, "gate_decision.json"), '{"decision":"advance"}');
+
+  // Knowledge artifacts
+  const kDir = join(evidenceTmp, "knowledge", "test_scenario");
+  mkdirSync(kDir, { recursive: true });
+  writeFileSync(join(kDir, "playbook.md"), "# Playbook\nStep 1.");
+  writeFileSync(join(kDir, "dead_ends.md"), "# Dead Ends\nApproach X failed.");
+  mkdirSync(join(kDir, "tools"));
+  writeFileSync(join(kDir, "tools", "validator.py"), "def validate(): pass");
+  mkdirSync(join(kDir, "analysis"));
+  writeFileSync(join(kDir, "analysis", "gen_1.md"), "Gen 1 analysis.");
+});
+
+afterEach(() => {
+  rmSync(evidenceTmp, { recursive: true, force: true });
+});
+
+describe("Workspace model", () => {
+  it("getArtifact returns correct artifact by ID", () => {
+    const a = makeArtifact({ artifactId: "abc123" });
+    const ws = makeWorkspace({ artifacts: [a] });
+    expect(getArtifact(ws, "abc123")).toBe(a);
+  });
+
+  it("getArtifact returns null for missing ID", () => {
+    const ws = makeWorkspace();
+    expect(getArtifact(ws, "nonexistent")).toBeNull();
+  });
+
+  it("listByKind filters correctly", () => {
+    const ws = makeWorkspace({
+      artifacts: [
+        makeArtifact({ artifactId: "a1", kind: "trace" }),
+        makeArtifact({ artifactId: "a2", kind: "gate_decision" }),
+        makeArtifact({ artifactId: "a3", kind: "trace" }),
+      ],
+    });
+    const traces = listByKind(ws, "trace");
+    expect(traces).toHaveLength(2);
+    expect(traces.every((t) => t.kind === "trace")).toBe(true);
+  });
+});
+
+describe("Materializer", () => {
+  it("creates workspace directory", () => {
+    const wsDir = join(evidenceTmp, "workspace");
+    materializeWorkspace({
+      knowledgeRoot: join(evidenceTmp, "knowledge"),
+      runsRoot: join(evidenceTmp, "runs"),
+      sourceRunIds: ["run_001"],
+      workspaceDir: wsDir,
+      scenarioName: "test_scenario",
+    });
+    expect(existsSync(wsDir)).toBe(true);
+  });
+
+  it("copies artifacts into workspace", () => {
+    const wsDir = join(evidenceTmp, "workspace");
+    const ws = materializeWorkspace({
+      knowledgeRoot: join(evidenceTmp, "knowledge"),
+      runsRoot: join(evidenceTmp, "runs"),
+      sourceRunIds: ["run_001"],
+      workspaceDir: wsDir,
+      scenarioName: "test_scenario",
+    });
+    expect(ws.artifacts.length).toBeGreaterThan(0);
+    for (const a of ws.artifacts) {
+      expect(existsSync(join(wsDir, a.path))).toBe(true);
+    }
+  });
+
+  it("respects budget limit", () => {
+    const wsDir = join(evidenceTmp, "workspace");
+    const ws = materializeWorkspace({
+      knowledgeRoot: join(evidenceTmp, "knowledge"),
+      runsRoot: join(evidenceTmp, "runs"),
+      sourceRunIds: ["run_001"],
+      workspaceDir: wsDir,
+      budgetBytes: 100,
+      scenarioName: "test_scenario",
+    });
+    expect(ws.totalSizeBytes).toBeLessThanOrEqual(100);
+  });
+
+  it("handles empty run directories", () => {
+    const wsDir = join(evidenceTmp, "workspace_empty");
+    const ws = materializeWorkspace({
+      knowledgeRoot: join(evidenceTmp, "knowledge"),
+      runsRoot: join(evidenceTmp, "runs"),
+      sourceRunIds: ["nonexistent_run"],
+      workspaceDir: wsDir,
+    });
+    expect(ws.artifacts).toBeDefined();
+  });
+
+  it("writes manifest.json", () => {
+    const wsDir = join(evidenceTmp, "workspace");
+    materializeWorkspace({
+      knowledgeRoot: join(evidenceTmp, "knowledge"),
+      runsRoot: join(evidenceTmp, "runs"),
+      sourceRunIds: ["run_001"],
+      workspaceDir: wsDir,
+      scenarioName: "test_scenario",
+    });
+    expect(existsSync(join(wsDir, "manifest.json"))).toBe(true);
+    const manifest = JSON.parse(
+      readFileSync(join(wsDir, "manifest.json"), "utf-8"),
+    );
+    expect(manifest.artifacts).toBeDefined();
+  });
+
+  it("scanKnowledgeArtifacts finds playbook and tools", () => {
+    const wsDir = join(evidenceTmp, "workspace");
+    const ws = materializeWorkspace({
+      knowledgeRoot: join(evidenceTmp, "knowledge"),
+      runsRoot: join(evidenceTmp, "runs"),
+      sourceRunIds: [],
+      workspaceDir: wsDir,
+      scenarioName: "test_scenario",
+    });
+    const kinds = new Set(ws.artifacts.map((a) => a.kind));
+    expect(kinds.has("report")).toBe(true);
+    expect(kinds.has("tool")).toBe(true);
+  });
+});
+
+describe("Manifest", () => {
+  it("includes artifact counts per kind", () => {
+    const ws = makeWorkspace({
+      artifacts: [
+        makeArtifact({ artifactId: "a1", kind: "trace" }),
+        makeArtifact({ artifactId: "a2", kind: "trace" }),
+        makeArtifact({ artifactId: "a3", kind: "gate_decision" }),
+      ],
+    });
+    const output = renderEvidenceManifest(ws);
+    expect(output).toContain("Traces");
+    expect(output).toContain("Gate decisions");
+  });
+
+  it("includes total size", () => {
+    const ws = makeWorkspace();
+    ws.totalSizeBytes = 5 * 1024 * 1024;
+    const output = renderEvidenceManifest(ws);
+    expect(output).toContain("5");
+  });
+
+  it("includes source run count", () => {
+    const ws = makeWorkspace({ sourceRuns: ["run_001", "run_002"] });
+    const output = renderEvidenceManifest(ws);
+    expect(output).toContain("2 prior run");
+  });
+
+  it("renderArtifactDetail reads content", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ac504-detail-"));
+    try {
+      writeFileSync(join(tmp, "test_file.md"), "Hello evidence!");
+      const result = renderArtifactDetail(
+        makeArtifact({ path: "test_file.md" }),
+        tmp,
+      );
+      expect(result).toContain("Hello evidence!");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("renderArtifactDetail handles missing file", () => {
+    const result = renderArtifactDetail(
+      makeArtifact({ path: "nonexistent.md" }),
+      "/tmp/does_not_exist",
+    );
+    expect(result.toLowerCase()).toContain("not found");
+  });
+});
+
+describe("Tracker", () => {
+  it("recordAccess adds to accessed list", () => {
+    const ws = makeWorkspace();
+    recordAccess(ws, "abc123");
+    expect(ws.accessedArtifacts).toContain("abc123");
+  });
+
+  it("recordAccess deduplicates", () => {
+    const ws = makeWorkspace();
+    recordAccess(ws, "abc123");
+    recordAccess(ws, "abc123");
+    expect(ws.accessedArtifacts.filter((id) => id === "abc123")).toHaveLength(
+      1,
+    );
+  });
+
+  it("save and load roundtrips", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ac504-tracker-"));
+    try {
+      const ws = makeWorkspace({ workspaceDir: tmp });
+      recordAccess(ws, "a1");
+      recordAccess(ws, "a2");
+      saveAccessLog(ws);
+      const loaded = loadAccessLog(tmp);
+      expect(loaded).toEqual(["a1", "a2"]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("utilization counts correctly", () => {
+    const ws = makeWorkspace({
+      artifacts: [
+        makeArtifact({ artifactId: "a1", kind: "trace" }),
+        makeArtifact({ artifactId: "a2", kind: "gate_decision" }),
+        makeArtifact({ artifactId: "a3", kind: "trace" }),
+      ],
+    });
+    recordAccess(ws, "a1");
+    recordAccess(ws, "a2");
+    const stats = computeUtilization(ws);
+    expect(stats.totalArtifacts).toBe(3);
+    expect(stats.accessedCount).toBe(2);
+    expect(stats.utilizationPercent).toBeCloseTo(66.7, 0);
+  });
+
+  it("utilization is zero when nothing accessed", () => {
+    const ws = makeWorkspace();
+    const stats = computeUtilization(ws);
+    expect(stats.accessedCount).toBe(0);
+    expect(stats.utilizationPercent).toBe(0);
+  });
+});

--- a/ts/tests/evidence-workspace.test.ts
+++ b/ts/tests/evidence-workspace.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   mkdtempSync,
   mkdirSync,
+  unlinkSync,
   rmSync,
   writeFileSync,
   existsSync,
@@ -187,6 +188,31 @@ describe("Materializer", () => {
       readFileSync(join(wsDir, "manifest.json"), "utf-8"),
     );
     expect(manifest.artifacts).toBeDefined();
+  });
+
+  it("removes stale files when rematerializing a reused workspace", () => {
+    const wsDir = join(evidenceTmp, "workspace");
+    const first = materializeWorkspace({
+      knowledgeRoot: join(evidenceTmp, "knowledge"),
+      runsRoot: join(evidenceTmp, "runs"),
+      sourceRunIds: ["run_001"],
+      workspaceDir: wsDir,
+    });
+    const traceArtifact = first.artifacts.find((a) => a.kind === "trace");
+    expect(traceArtifact).toBeDefined();
+    const stalePath = join(wsDir, traceArtifact!.path);
+    expect(existsSync(stalePath)).toBe(true);
+
+    unlinkSync(join(evidenceTmp, "runs", "run_001", "events.ndjson"));
+
+    const second = materializeWorkspace({
+      knowledgeRoot: join(evidenceTmp, "knowledge"),
+      runsRoot: join(evidenceTmp, "runs"),
+      sourceRunIds: ["run_001"],
+      workspaceDir: wsDir,
+    });
+    expect(second.artifacts.every((a) => a.kind !== "trace")).toBe(true);
+    expect(existsSync(stalePath)).toBe(false);
   });
 
   it("scanKnowledgeArtifacts finds playbook and tools", () => {


### PR DESCRIPTION
## Summary

Two Meta-Harness-inspired Core Harness features with full Python + TypeScript parity.

### AC-503: Environment Snapshot Bootstrapping

Collects a structured `EnvironmentSnapshot` at run start — Python/OS/shell, runtimes, packages, lockfiles, filesystem listing (capped at 50), git metadata, memory/disk/CPU. Privacy redaction strips hostname, username, and absolute paths by default.

**New packages:** `autocontext/bootstrap/` (Python), `ts/src/bootstrap/` (TypeScript)
**New settings:** `AUTOCONTEXT_ENV_SNAPSHOT_ENABLED`, `_REDACT_HOSTNAME`, `_REDACT_USERNAME`, `_REDACT_PATHS`

### AC-504: Browsable Prior-Run Evidence Workspace

Materializes selected prior-run artifacts (traces, role outputs, reports, tools, gate decisions, logs) into a flat workspace directory. Budget-aware (default 10MB), priority-sorted (gate decisions first), auditable via access tracking with utilization metrics.

**New packages:** `autocontext/evidence/` (Python), `ts/src/evidence/` (TypeScript)
**New settings:** `AUTOCONTEXT_EVIDENCE_WORKSPACE_ENABLED`, `_EVIDENCE_WORKSPACE_BUDGET_MB`, `_EVIDENCE_WORKSPACE_ROLES`

### Integration

- Context budget cascade updated: `evidence_manifest` trimmed first (least critical), `environment_snapshot` trimmed after `experiment_log`
- Settings wired into `AppSettings` with `AUTOCONTEXT_*` env var convention

### Follow-ups (tracked separately)

- AC-449: Dashboard visualization for simulation sweeps (evidence utilization could be surfaced here)
- AC-505: Generalize architect to full harness mutation surface (evidence workspace feeds this)
- MCP tool exposure: `autocontext_env_snapshot`, `autocontext_evidence_list` (next PR)
- Loop integration: wire `collect_snapshot()` into `stage_preflight`, `materialize_workspace()` into `stage_knowledge_setup` (next PR)

## Test plan

- [x] 23 Python tests for bootstrap (collector, redactor, renderer, serialization)
- [x] 22 Python tests for evidence (workspace model, materializer, manifest, tracker)
- [x] 20 TypeScript tests for bootstrap
- [x] 19 TypeScript tests for evidence
- [x] Ruff lint clean
- [x] TypeScript type check clean
- [ ] Loop integration smoke test (follow-up)