### PR TITLE
feat: blob store abstraction with local + HF Bucket backends (AC-518 Phase 1)

### DIFF
--- a/autocontext/src/autocontext/blobstore/__init__.py
+++ b/autocontext/src/autocontext/blobstore/__init__.py
@@ -1,0 +1,15 @@
+"""Deduplicated bucket-backed blob store (AC-518)."""
+
+from __future__ import annotations
+
+from autocontext.blobstore.factory import create_blob_store
+from autocontext.blobstore.ref import BlobRef
+from autocontext.blobstore.registry import BlobRegistry
+from autocontext.blobstore.store import BlobStore
+
+__all__ = [
+    "BlobRef",
+    "BlobRegistry",
+    "BlobStore",
+    "create_blob_store",
+]

--- a/autocontext/src/autocontext/blobstore/factory.py
+++ b/autocontext/src/autocontext/blobstore/factory.py
@@ -1,0 +1,38 @@
+"""BlobStore factory (AC-518)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.blobstore.store import BlobStore
+
+
+def create_blob_store(
+    backend: str,
+    root: str = "",
+    repo_id: str = "",
+    cache_dir: str = "",
+    **kwargs: object,
+) -> BlobStore:
+    """Create a BlobStore backend from configuration.
+
+    Args:
+        backend: "local" or "hf_bucket"
+        root: Root directory for local backend
+        repo_id: HF repo ID for hf_bucket backend
+        cache_dir: Local cache directory for hf_bucket backend
+    """
+    if backend == "local":
+        from autocontext.blobstore.local import LocalBlobStore
+
+        return LocalBlobStore(root=Path(root))
+
+    if backend == "hf_bucket":
+        from autocontext.blobstore.hf_bucket import HfBucketStore
+
+        return HfBucketStore(
+            repo_id=repo_id,
+            cache_dir=Path(cache_dir) if cache_dir else Path(root) / ".hf_cache",
+        )
+
+    raise ValueError(f"Unknown blob store backend: {backend!r}. Available: 'local', 'hf_bucket'")

--- a/autocontext/src/autocontext/blobstore/hf_bucket.py
+++ b/autocontext/src/autocontext/blobstore/hf_bucket.py
@@ -7,14 +7,16 @@ directory for hydrated blobs.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import subprocess
 from pathlib import Path
 from typing import Any
 
-from autocontext.blobstore.store import BlobStore
+from autocontext.blobstore.store import BlobStore, normalize_blob_key, prefix_matches, resolve_blob_path
 
 logger = logging.getLogger(__name__)
+_INDEX_KEY = ".autocontext/blob_index.json"
 
 
 class HfBucketStore(BlobStore):
@@ -27,8 +29,9 @@ class HfBucketStore(BlobStore):
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
     def put(self, key: str, data: bytes) -> str:
+        normalized_key = normalize_blob_key(key)
         # Write to local cache first, then upload
-        cache_path = self.cache_dir / key
+        cache_path = resolve_blob_path(self.cache_dir, normalized_key)
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_bytes(data)
         digest = "sha256:" + hashlib.sha256(data).hexdigest()
@@ -39,18 +42,30 @@ class HfBucketStore(BlobStore):
                 "upload",
                 self.repo_id,
                 str(cache_path),
-                key,
+                normalized_key,
                 "--repo-type",
                 self.repo_type,
             ]
         )
+        index = self._load_index()[1]
+        index[normalized_key] = {
+            "size_bytes": len(data),
+            "digest": digest,
+            "content_type": _guess_content_type(normalized_key),
+        }
+        self._save_index(index)
         return digest
 
     def get(self, key: str) -> bytes | None:
+        normalized_key = normalize_blob_key(key)
         # Try cache first
-        cache_path = self.cache_dir / key
+        cache_path = resolve_blob_path(self.cache_dir, normalized_key)
         if cache_path.is_file():
             return cache_path.read_bytes()
+
+        index_available, index = self._load_index()
+        if index_available and normalized_key not in index:
+            return None
 
         # Download from remote
         try:
@@ -60,7 +75,7 @@ class HfBucketStore(BlobStore):
                     "huggingface-cli",
                     "download",
                     self.repo_id,
-                    key,
+                    normalized_key,
                     "--repo-type",
                     self.repo_type,
                     "--local-dir",
@@ -74,37 +89,119 @@ class HfBucketStore(BlobStore):
         return None
 
     def head(self, key: str) -> dict[str, Any] | None:
-        cache_path = self.cache_dir / key
+        normalized_key = normalize_blob_key(key)
+        cache_path = resolve_blob_path(self.cache_dir, normalized_key)
         if cache_path.is_file():
             data = cache_path.read_bytes()
             return {
                 "size_bytes": len(data),
                 "digest": "sha256:" + hashlib.sha256(data).hexdigest(),
-                "content_type": "application/octet-stream",
+                "content_type": _guess_content_type(normalized_key),
             }
+        index_available, index = self._load_index()
+        if index_available:
+            metadata = index.get(normalized_key)
+            if metadata is not None:
+                return dict(metadata)
         return None
 
     def list_prefix(self, prefix: str) -> list[str]:
-        # List from local cache; remote listing would need HF API
+        index_available, index = self._load_index()
+        if index_available:
+            return sorted(key for key in index if prefix_matches(key, prefix))
+
+        # Fall back to local cache listing if index is unavailable.
         try:
-            base = self.cache_dir / prefix
+            base = self.cache_dir / prefix.replace("\\", "/")
             parent = base.parent if not base.is_dir() else base
             if not parent.is_dir():
                 return []
             return [
-                str(p.relative_to(self.cache_dir))
+                p.relative_to(self.cache_dir).as_posix()
                 for p in sorted(parent.rglob("*"))
-                if p.is_file() and str(p.relative_to(self.cache_dir)).startswith(prefix)
+                if p.is_file() and prefix_matches(p.relative_to(self.cache_dir).as_posix(), prefix)
             ]
         except Exception:
             return []
 
     def delete(self, key: str) -> bool:
-        cache_path = self.cache_dir / key
+        normalized_key = normalize_blob_key(key)
+        cache_path = resolve_blob_path(self.cache_dir, normalized_key)
+        index_available, index = self._load_index()
+        existed = normalized_key in index if index_available else False
+        if index_available and normalized_key in index:
+            del index[normalized_key]
+            self._save_index(index)
+        self._delete_remote_file(normalized_key)
         if cache_path.is_file():
             cache_path.unlink()
-            return True
-        return False
+            existed = True
+        return existed
+
+    def _load_index(self) -> tuple[bool, dict[str, dict[str, Any]]]:
+        index_path = resolve_blob_path(self.cache_dir, _INDEX_KEY)
+        if not index_path.is_file():
+            try:
+                self._run_hf_command(
+                    [
+                        "huggingface-cli",
+                        "download",
+                        self.repo_id,
+                        _INDEX_KEY,
+                        "--repo-type",
+                        self.repo_type,
+                        "--local-dir",
+                        str(index_path.parent),
+                    ]
+                )
+            except (RuntimeError, OSError):
+                return False, {}
+        if not index_path.is_file():
+            return False, {}
+        try:
+            data = json.loads(index_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            logger.warning("failed to parse HF blob index for %s", self.repo_id)
+            return False, {}
+        if not isinstance(data, dict):
+            return False, {}
+        index: dict[str, dict[str, Any]] = {}
+        for key, metadata in data.items():
+            if isinstance(key, str) and isinstance(metadata, dict):
+                index[key] = dict(metadata)
+        return True, index
+
+    def _save_index(self, index: dict[str, dict[str, Any]]) -> None:
+        index_path = resolve_blob_path(self.cache_dir, _INDEX_KEY)
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        index_path.write_text(json.dumps(index, indent=2, sort_keys=True), encoding="utf-8")
+        self._run_hf_command(
+            [
+                "huggingface-cli",
+                "upload",
+                self.repo_id,
+                str(index_path),
+                _INDEX_KEY,
+                "--repo-type",
+                self.repo_type,
+            ]
+        )
+
+    def _delete_remote_file(self, key: str) -> None:
+        try:
+            self._run_hf_command(
+                [
+                    "huggingface-cli",
+                    "repo-files",
+                    "delete",
+                    self.repo_id,
+                    key,
+                    "--repo-type",
+                    self.repo_type,
+                ]
+            )
+        except RuntimeError:
+            logger.info("remote delete not available for %s in %s", key, self.repo_id)
 
     def _run_hf_command(self, cmd: list[str]) -> str:
         result = subprocess.run(
@@ -116,3 +213,15 @@ class HfBucketStore(BlobStore):
         if result.returncode != 0:
             raise RuntimeError(f"HF command failed: {result.stderr.strip()}")
         return result.stdout.strip()
+
+
+def _guess_content_type(key: str) -> str:
+    if key.endswith(".json"):
+        return "application/json"
+    if key.endswith(".ndjson"):
+        return "application/x-ndjson"
+    if key.endswith(".md"):
+        return "text/markdown"
+    if key.endswith(".txt"):
+        return "text/plain"
+    return "application/octet-stream"

--- a/autocontext/src/autocontext/blobstore/hf_bucket.py
+++ b/autocontext/src/autocontext/blobstore/hf_bucket.py
@@ -1,0 +1,118 @@
+"""Hugging Face Bucket blob store backend (AC-518).
+
+Wraps ``huggingface-cli`` for upload/download. Uses a local cache
+directory for hydrated blobs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from autocontext.blobstore.store import BlobStore
+
+logger = logging.getLogger(__name__)
+
+
+class HfBucketStore(BlobStore):
+    """HF Buckets backend using huggingface-cli."""
+
+    def __init__(self, repo_id: str, cache_dir: Path, repo_type: str = "dataset") -> None:
+        self.repo_id = repo_id
+        self.cache_dir = cache_dir
+        self.repo_type = repo_type
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def put(self, key: str, data: bytes) -> str:
+        # Write to local cache first, then upload
+        cache_path = self.cache_dir / key
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(data)
+        digest = "sha256:" + hashlib.sha256(data).hexdigest()
+
+        self._run_hf_command(
+            [
+                "huggingface-cli",
+                "upload",
+                self.repo_id,
+                str(cache_path),
+                key,
+                "--repo-type",
+                self.repo_type,
+            ]
+        )
+        return digest
+
+    def get(self, key: str) -> bytes | None:
+        # Try cache first
+        cache_path = self.cache_dir / key
+        if cache_path.is_file():
+            return cache_path.read_bytes()
+
+        # Download from remote
+        try:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            self._run_hf_command(
+                [
+                    "huggingface-cli",
+                    "download",
+                    self.repo_id,
+                    key,
+                    "--repo-type",
+                    self.repo_type,
+                    "--local-dir",
+                    str(cache_path.parent),
+                ]
+            )
+            if cache_path.is_file():
+                return cache_path.read_bytes()
+        except (RuntimeError, OSError):
+            pass
+        return None
+
+    def head(self, key: str) -> dict[str, Any] | None:
+        cache_path = self.cache_dir / key
+        if cache_path.is_file():
+            data = cache_path.read_bytes()
+            return {
+                "size_bytes": len(data),
+                "digest": "sha256:" + hashlib.sha256(data).hexdigest(),
+                "content_type": "application/octet-stream",
+            }
+        return None
+
+    def list_prefix(self, prefix: str) -> list[str]:
+        # List from local cache; remote listing would need HF API
+        try:
+            base = self.cache_dir / prefix
+            parent = base.parent if not base.is_dir() else base
+            if not parent.is_dir():
+                return []
+            return [
+                str(p.relative_to(self.cache_dir))
+                for p in sorted(parent.rglob("*"))
+                if p.is_file() and str(p.relative_to(self.cache_dir)).startswith(prefix)
+            ]
+        except Exception:
+            return []
+
+    def delete(self, key: str) -> bool:
+        cache_path = self.cache_dir / key
+        if cache_path.is_file():
+            cache_path.unlink()
+            return True
+        return False
+
+    def _run_hf_command(self, cmd: list[str]) -> str:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"HF command failed: {result.stderr.strip()}")
+        return result.stdout.strip()

--- a/autocontext/src/autocontext/blobstore/local.py
+++ b/autocontext/src/autocontext/blobstore/local.py
@@ -7,7 +7,7 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-from autocontext.blobstore.store import BlobStore
+from autocontext.blobstore.store import BlobStore, prefix_matches, resolve_blob_path
 
 
 class LocalBlobStore(BlobStore):
@@ -25,19 +25,19 @@ class LocalBlobStore(BlobStore):
 
     def put(self, key: str, data: bytes) -> str:
         digest = _sha256(data)
-        path = self.root / key
+        path = resolve_blob_path(self.root, key)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(data)
         return digest
 
     def get(self, key: str) -> bytes | None:
-        path = self.root / key
+        path = resolve_blob_path(self.root, key)
         if not path.is_file():
             return None
         return path.read_bytes()
 
     def head(self, key: str) -> dict[str, Any] | None:
-        path = self.root / key
+        path = resolve_blob_path(self.root, key)
         if not path.is_file():
             return None
         data = path.read_bytes()
@@ -48,33 +48,33 @@ class LocalBlobStore(BlobStore):
         }
 
     def list_prefix(self, prefix: str) -> list[str]:
-        prefix_path = self.root / prefix
+        prefix_path = self.root / prefix.replace("\\", "/")
         base = prefix_path.parent if not prefix_path.is_dir() else prefix_path
         if not base.is_dir():
             return []
         results: list[str] = []
         for path in sorted(base.rglob("*")):
             if path.is_file():
-                rel = str(path.relative_to(self.root))
-                if rel.startswith(prefix):
+                rel = path.relative_to(self.root).as_posix()
+                if prefix_matches(rel, prefix):
                     results.append(rel)
         return results
 
     def delete(self, key: str) -> bool:
-        path = self.root / key
+        path = resolve_blob_path(self.root, key)
         if not path.is_file():
             return False
         path.unlink()
         return True
 
     def put_file(self, key: str, path: Path) -> str:
-        dest = self.root / key
+        dest = resolve_blob_path(self.root, key)
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(str(path), str(dest))
         return _sha256(dest.read_bytes())
 
     def get_file(self, key: str, dest: Path) -> bool:
-        src = self.root / key
+        src = resolve_blob_path(self.root, key)
         if not src.is_file():
             return False
         dest.parent.mkdir(parents=True, exist_ok=True)

--- a/autocontext/src/autocontext/blobstore/local.py
+++ b/autocontext/src/autocontext/blobstore/local.py
@@ -1,0 +1,98 @@
+"""Local filesystem blob store — content-addressed by SHA256 (AC-518)."""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from pathlib import Path
+from typing import Any
+
+from autocontext.blobstore.store import BlobStore
+
+
+class LocalBlobStore(BlobStore):
+    """Content-addressed local filesystem backend.
+
+    Blobs are stored at ``root/<key>`` and their SHA256 digest is
+    computed on write. The same content stored under different keys
+    will have the same digest but occupy separate files (simplicity
+    over dedup for the local backend).
+    """
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def put(self, key: str, data: bytes) -> str:
+        digest = _sha256(data)
+        path = self.root / key
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+        return digest
+
+    def get(self, key: str) -> bytes | None:
+        path = self.root / key
+        if not path.is_file():
+            return None
+        return path.read_bytes()
+
+    def head(self, key: str) -> dict[str, Any] | None:
+        path = self.root / key
+        if not path.is_file():
+            return None
+        data = path.read_bytes()
+        return {
+            "size_bytes": len(data),
+            "digest": _sha256(data),
+            "content_type": _guess_content_type(key),
+        }
+
+    def list_prefix(self, prefix: str) -> list[str]:
+        prefix_path = self.root / prefix
+        base = prefix_path.parent if not prefix_path.is_dir() else prefix_path
+        if not base.is_dir():
+            return []
+        results: list[str] = []
+        for path in sorted(base.rglob("*")):
+            if path.is_file():
+                rel = str(path.relative_to(self.root))
+                if rel.startswith(prefix):
+                    results.append(rel)
+        return results
+
+    def delete(self, key: str) -> bool:
+        path = self.root / key
+        if not path.is_file():
+            return False
+        path.unlink()
+        return True
+
+    def put_file(self, key: str, path: Path) -> str:
+        dest = self.root / key
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(path), str(dest))
+        return _sha256(dest.read_bytes())
+
+    def get_file(self, key: str, dest: Path) -> bool:
+        src = self.root / key
+        if not src.is_file():
+            return False
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(src), str(dest))
+        return True
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _guess_content_type(key: str) -> str:
+    if key.endswith(".json"):
+        return "application/json"
+    if key.endswith(".ndjson"):
+        return "application/x-ndjson"
+    if key.endswith(".md"):
+        return "text/markdown"
+    if key.endswith(".txt"):
+        return "text/plain"
+    return "application/octet-stream"

--- a/autocontext/src/autocontext/blobstore/ref.py
+++ b/autocontext/src/autocontext/blobstore/ref.py
@@ -1,0 +1,52 @@
+"""BlobRef — structured artifact locator (AC-518)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(slots=True)
+class BlobRef:
+    """Reference to a blob artifact with optional local and remote locations."""
+
+    kind: str  # "trace", "checkpoint", "report", "model", "export", ...
+    digest: str  # "sha256:<hex>"
+    size_bytes: int
+    local_path: str = ""
+    remote_uri: str = ""  # e.g. "hf://org/repo/blobs/key"
+    content_type: str = ""
+    created_at: str = ""
+    retention_class: str = ""  # "ephemeral", "durable", "archive"
+
+    @property
+    def is_hydrated(self) -> bool:
+        """True if the blob is available locally."""
+        return bool(self.local_path) and Path(self.local_path).exists()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "digest": self.digest,
+            "size_bytes": self.size_bytes,
+            "local_path": self.local_path,
+            "remote_uri": self.remote_uri,
+            "content_type": self.content_type,
+            "created_at": self.created_at,
+            "retention_class": self.retention_class,
+            "is_hydrated": self.is_hydrated,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BlobRef:
+        return cls(
+            kind=data.get("kind", ""),
+            digest=data.get("digest", ""),
+            size_bytes=data.get("size_bytes", 0),
+            local_path=data.get("local_path", ""),
+            remote_uri=data.get("remote_uri", ""),
+            content_type=data.get("content_type", ""),
+            created_at=data.get("created_at", ""),
+            retention_class=data.get("retention_class", ""),
+        )

--- a/autocontext/src/autocontext/blobstore/registry.py
+++ b/autocontext/src/autocontext/blobstore/registry.py
@@ -1,0 +1,45 @@
+"""BlobRegistry — tracks BlobRefs by run + artifact name (AC-518)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from autocontext.blobstore.ref import BlobRef
+
+
+class BlobRegistry:
+    """In-memory registry of BlobRefs, persistable to JSON."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, dict[str, BlobRef]] = {}  # run_id → {name → ref}
+
+    def register(self, run_id: str, name: str, ref: BlobRef) -> None:
+        if run_id not in self._entries:
+            self._entries[run_id] = {}
+        self._entries[run_id][name] = ref
+
+    def lookup(self, run_id: str, name: str) -> BlobRef | None:
+        return self._entries.get(run_id, {}).get(name)
+
+    def list_for_run(self, run_id: str) -> list[BlobRef]:
+        return list(self._entries.get(run_id, {}).values())
+
+    def save(self, path: Path) -> None:
+        data: dict[str, Any] = {}
+        for run_id, entries in self._entries.items():
+            data[run_id] = {name: ref.to_dict() for name, ref in entries.items()}
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Path) -> BlobRegistry:
+        registry = cls()
+        if not path.is_file():
+            return registry
+        data = json.loads(path.read_text(encoding="utf-8"))
+        for run_id, entries in data.items():
+            for name, ref_dict in entries.items():
+                registry.register(run_id, name, BlobRef.from_dict(ref_dict))
+        return registry

--- a/autocontext/src/autocontext/blobstore/store.py
+++ b/autocontext/src/autocontext/blobstore/store.py
@@ -1,0 +1,49 @@
+"""BlobStore abstract base class (AC-518).
+
+Backend-agnostic interface for large artifact storage. Implementations
+must handle put/get/head/list/delete of opaque byte blobs keyed by
+string paths.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+
+class BlobStore(ABC):
+    """Abstract blob storage backend."""
+
+    @abstractmethod
+    def put(self, key: str, data: bytes) -> str:
+        """Store bytes at key. Returns digest string (e.g. 'sha256:...')."""
+
+    @abstractmethod
+    def get(self, key: str) -> bytes | None:
+        """Retrieve bytes by key. Returns None if not found."""
+
+    @abstractmethod
+    def head(self, key: str) -> dict[str, Any] | None:
+        """Return metadata (size_bytes, digest, content_type) or None."""
+
+    @abstractmethod
+    def list_prefix(self, prefix: str) -> list[str]:
+        """List all keys matching a prefix."""
+
+    @abstractmethod
+    def delete(self, key: str) -> bool:
+        """Delete a key. Returns True if deleted, False if not found."""
+
+    def put_file(self, key: str, path: Path) -> str:
+        """Store a file at key. Default: read and delegate to put()."""
+        return self.put(key, path.read_bytes())
+
+    def get_file(self, key: str, dest: Path) -> bool:
+        """Retrieve a blob to a file. Returns True on success."""
+        data = self.get(key)
+        if data is None:
+            return False
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+        return True

--- a/autocontext/src/autocontext/blobstore/store.py
+++ b/autocontext/src/autocontext/blobstore/store.py
@@ -8,7 +8,7 @@ string paths.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
 
@@ -47,3 +47,48 @@ class BlobStore(ABC):
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(data)
         return True
+
+
+def normalize_blob_key(key: str, *, allow_empty: bool = False) -> str:
+    """Normalize a blob key and reject absolute or escaping paths."""
+    if not key:
+        if allow_empty:
+            return ""
+        raise ValueError("blob key must not be empty")
+
+    for path_cls in (PurePosixPath, PureWindowsPath):
+        candidate = path_cls(key)
+        if candidate.is_absolute():
+            raise ValueError(f"invalid blob key: {key!r}")
+
+    normalized = key.replace("\\", "/")
+    parts = [part for part in PurePosixPath(normalized).parts if part not in ("", ".")]
+    if any(part == ".." for part in parts):
+        raise ValueError(f"invalid blob key: {key!r}")
+
+    joined = "/".join(parts)
+    if not joined and not allow_empty:
+        raise ValueError("blob key must not be empty")
+    return joined
+
+
+def resolve_blob_path(root: Path, key: str) -> Path:
+    """Resolve a normalized key under root and reject directory escapes."""
+    normalized = normalize_blob_key(key)
+    root_resolved = root.resolve()
+    candidate = (root / normalized).resolve()
+    try:
+        candidate.relative_to(root_resolved)
+    except ValueError as exc:
+        raise ValueError(f"invalid blob key: {key!r}") from exc
+    return candidate
+
+
+def prefix_matches(key: str, prefix: str) -> bool:
+    """Return True if a normalized key matches a normalized prefix."""
+    normalized_prefix = normalize_blob_key(prefix, allow_empty=True)
+    if not normalized_prefix:
+        return True
+    if prefix.endswith(("/", "\\")):
+        return key == normalized_prefix or key.startswith(normalized_prefix + "/")
+    return key.startswith(normalized_prefix)

--- a/autocontext/tests/test_blob_store.py
+++ b/autocontext/tests/test_blob_store.py
@@ -47,7 +47,6 @@ class TestBlobRef:
     def test_is_hydrated(self) -> None:
         from autocontext.blobstore.ref import BlobRef
 
-        ref = BlobRef(kind="trace", local_path="/tmp/exists.json", digest="sha256:x", size_bytes=10)
         # is_hydrated checks if local_path exists — use tmpfile for positive
         with tempfile.NamedTemporaryFile() as f:
             ref_with_file = BlobRef(kind="trace", local_path=f.name, digest="sha256:x", size_bytes=10)
@@ -157,6 +156,14 @@ class TestLocalBlobStore:
             d2 = store.put("key2", data)
             assert d1 == d2  # same content = same digest
 
+    def test_put_rejects_directory_escape(self) -> None:
+        from autocontext.blobstore.local import LocalBlobStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = LocalBlobStore(root=Path(tmp) / "root")
+            with pytest.raises(ValueError, match="invalid blob key"):
+                store.put("../escape.txt", b"x")
+
 
 # ---------------------------------------------------------------------------
 # HfBucketStore (mocked)
@@ -164,6 +171,30 @@ class TestLocalBlobStore:
 
 
 class TestHfBucketStore:
+    @staticmethod
+    def _fake_hf(remote: dict[str, bytes]):
+        def runner(cmd: list[str]) -> str:
+            if cmd[1] == "upload":
+                local_path = Path(cmd[3])
+                key = cmd[4]
+                remote[key] = local_path.read_bytes()
+                return ""
+            if cmd[1] == "download":
+                key = cmd[3]
+                local_dir = Path(cmd[cmd.index("--local-dir") + 1])
+                if key not in remote:
+                    raise RuntimeError("missing remote key")
+                local_dir.mkdir(parents=True, exist_ok=True)
+                (local_dir / Path(key).name).write_bytes(remote[key])
+                return ""
+            if cmd[1:3] == ["repo-files", "delete"]:
+                key = cmd[4]
+                remote.pop(key, None)
+                return ""
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        return runner
+
     def test_put_calls_hf_upload(self) -> None:
         from autocontext.blobstore.hf_bucket import HfBucketStore
 
@@ -172,7 +203,7 @@ class TestHfBucketStore:
             with patch.object(store, "_run_hf_command") as mock_hf:
                 mock_hf.return_value = ""
                 store.put("test/file.txt", b"hello")
-                mock_hf.assert_called_once()
+                assert mock_hf.call_count >= 2
 
     def test_get_calls_hf_download(self) -> None:
         from autocontext.blobstore.hf_bucket import HfBucketStore
@@ -194,6 +225,37 @@ class TestHfBucketStore:
             with patch.object(store, "_run_hf_command", side_effect=RuntimeError("no auth")):
                 keys = store.list_prefix("runs/")
                 assert keys == []
+
+    def test_head_uses_remote_index_for_fresh_instance(self) -> None:
+        from autocontext.blobstore.hf_bucket import HfBucketStore
+
+        remote: dict[str, bytes] = {}
+        with tempfile.TemporaryDirectory() as tmp:
+            first = HfBucketStore(repo_id="org/repo", cache_dir=Path(tmp) / "cache1")
+            second = HfBucketStore(repo_id="org/repo", cache_dir=Path(tmp) / "cache2")
+            runner = self._fake_hf(remote)
+            with patch.object(first, "_run_hf_command", side_effect=runner):
+                first.put("nested/remote.txt", b"remote data")
+            with patch.object(second, "_run_hf_command", side_effect=runner):
+                meta = second.head("nested/remote.txt")
+                assert meta is not None
+                assert meta["size_bytes"] == len(b"remote data")
+                assert second.list_prefix("nested/") == ["nested/remote.txt"]
+
+    def test_delete_uses_remote_index_for_uncached_key(self) -> None:
+        from autocontext.blobstore.hf_bucket import HfBucketStore
+
+        remote: dict[str, bytes] = {}
+        with tempfile.TemporaryDirectory() as tmp:
+            first = HfBucketStore(repo_id="org/repo", cache_dir=Path(tmp) / "cache1")
+            second = HfBucketStore(repo_id="org/repo", cache_dir=Path(tmp) / "cache2")
+            runner = self._fake_hf(remote)
+            with patch.object(first, "_run_hf_command", side_effect=runner):
+                first.put("nested/remote.txt", b"remote data")
+            with patch.object(second, "_run_hf_command", side_effect=runner):
+                assert second.delete("nested/remote.txt") is True
+                assert second.head("nested/remote.txt") is None
+                assert second.list_prefix("nested/") == []
 
 
 # ---------------------------------------------------------------------------

--- a/autocontext/tests/test_blob_store.py
+++ b/autocontext/tests/test_blob_store.py
@@ -1,0 +1,273 @@
+"""AC-518: Blob store abstraction tests.
+
+Tests the BlobStore ABC, BlobRef model, LocalBlobStore (content-addressed
+filesystem backend), HfBucketStore (mocked), BlobRegistry, and factory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# BlobRef model
+# ---------------------------------------------------------------------------
+
+
+class TestBlobRef:
+    def test_create_and_serialize(self) -> None:
+        from autocontext.blobstore.ref import BlobRef
+
+        ref = BlobRef(
+            kind="trace",
+            local_path="/tmp/run_001/events.ndjson",
+            remote_uri="hf://org/repo/blobs/abc123",
+            digest="sha256:abc123def456",
+            size_bytes=4096,
+            content_type="application/x-ndjson",
+        )
+        d = ref.to_dict()
+        assert d["kind"] == "trace"
+        assert d["digest"] == "sha256:abc123def456"
+        assert d["size_bytes"] == 4096
+
+    def test_roundtrip(self) -> None:
+        from autocontext.blobstore.ref import BlobRef
+
+        ref = BlobRef(kind="checkpoint", local_path="/tmp/ckpt.bin", digest="sha256:aaa", size_bytes=100)
+        restored = BlobRef.from_dict(ref.to_dict())
+        assert restored.kind == ref.kind
+        assert restored.digest == ref.digest
+        assert restored.size_bytes == ref.size_bytes
+
+    def test_is_hydrated(self) -> None:
+        from autocontext.blobstore.ref import BlobRef
+
+        ref = BlobRef(kind="trace", local_path="/tmp/exists.json", digest="sha256:x", size_bytes=10)
+        # is_hydrated checks if local_path exists — use tmpfile for positive
+        with tempfile.NamedTemporaryFile() as f:
+            ref_with_file = BlobRef(kind="trace", local_path=f.name, digest="sha256:x", size_bytes=10)
+            assert ref_with_file.is_hydrated
+
+    def test_not_hydrated_when_no_local_path(self) -> None:
+        from autocontext.blobstore.ref import BlobRef
+
+        ref = BlobRef(kind="trace", remote_uri="hf://org/repo/blobs/x", digest="sha256:x", size_bytes=10)
+        assert not ref.is_hydrated
+
+
+# ---------------------------------------------------------------------------
+# LocalBlobStore
+# ---------------------------------------------------------------------------
+
+
+class TestLocalBlobStore:
+    def test_put_and_get(self) -> None:
+        from autocontext.blobstore.local import LocalBlobStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = LocalBlobStore(root=Path(tmp))
+            key = "runs/run_001/events.ndjson"
+            data = b'{"event":"start"}\n'
+            store.put(key, data)
+
+            retrieved = store.get(key)
+            assert retrieved == data
+
+    def test_put_returns_digest(self) -> None:
+        from autocontext.blobstore.local import LocalBlobStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = LocalBlobStore(root=Path(tmp))
+            data = b"hello world"
+            digest = store.put("test/hello.txt", data)
+            expected = "sha256:" + hashlib.sha256(data).hexdigest()
+            assert digest == expected
+
+    def test_get_returns_none_for_missing(self) -> None:
+        from autocontext.blobstore.local import LocalBlobStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = LocalBlobStore(root=Path(tmp))
+            assert store.get("nonexistent/key") is None
+
+    def test_head(self) -> None:
+        from autocontext.blobstore.local import LocalBlobStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = LocalBlobStore(root=Path(tmp))
+            store.put("test/file.txt", b"content")
+            meta = store.head("test/file.txt")
+            assert meta is not None
+            assert meta["size_bytes"] == 7
+            assert meta["digest"].startswith("sha256:")
+
+    def test_head_returns_none_for_missing(self) -> None:
+        from autocontext.blobstore.local import LocalBlobStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = LocalBlobStore(root=Path(tmp))
+            assert store.head("missing") is None
+
+    def test_list_prefix(self) -> None:
+        from autocontext.blobstore.local import LocalBlobStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = LocalBlobStore(root=Path(tmp))
+            store.put("runs/r1/a.txt", b"a")
+            store.put("runs/r1/b.txt", b"b")
+            store.put("runs/r2/c.txt", b"c")
+            keys = store.list_prefix("runs/r1/")
+            assert sorted(keys) == ["runs/r1/a.txt", "runs/r1/b.txt"]
+
+    def test_delete(self) -> None:
+        from autocontext.blobstore.local import LocalBlobStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = LocalBlobStore(root=Path(tmp))
+            store.put("test/del.txt", b"delete me")
+            assert store.get("test/del.txt") is not None
+            store.delete("test/del.txt")
+            assert store.get("test/del.txt") is None
+
+    def test_put_file_and_get_file(self) -> None:
+        from autocontext.blobstore.local import LocalBlobStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = LocalBlobStore(root=Path(tmp))
+            src = Path(tmp) / "source.bin"
+            src.write_bytes(b"binary content here")
+            store.put_file("test/binary.bin", src)
+
+            dest = Path(tmp) / "dest.bin"
+            store.get_file("test/binary.bin", dest)
+            assert dest.read_bytes() == b"binary content here"
+
+    def test_content_addressed_dedup(self) -> None:
+        from autocontext.blobstore.local import LocalBlobStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = LocalBlobStore(root=Path(tmp))
+            data = b"same content"
+            d1 = store.put("key1", data)
+            d2 = store.put("key2", data)
+            assert d1 == d2  # same content = same digest
+
+
+# ---------------------------------------------------------------------------
+# HfBucketStore (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestHfBucketStore:
+    def test_put_calls_hf_upload(self) -> None:
+        from autocontext.blobstore.hf_bucket import HfBucketStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = HfBucketStore(repo_id="org/repo", cache_dir=Path(tmp))
+            with patch.object(store, "_run_hf_command") as mock_hf:
+                mock_hf.return_value = ""
+                store.put("test/file.txt", b"hello")
+                mock_hf.assert_called_once()
+
+    def test_get_calls_hf_download(self) -> None:
+        from autocontext.blobstore.hf_bucket import HfBucketStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = HfBucketStore(repo_id="org/repo", cache_dir=Path(tmp))
+            # Pre-populate cache so get doesn't need real download
+            cache_path = Path(tmp) / "test" / "file.txt"
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_path.write_bytes(b"cached content")
+            result = store.get("test/file.txt")
+            assert result == b"cached content"
+
+    def test_list_prefix_returns_empty_on_error(self) -> None:
+        from autocontext.blobstore.hf_bucket import HfBucketStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = HfBucketStore(repo_id="org/repo", cache_dir=Path(tmp))
+            with patch.object(store, "_run_hf_command", side_effect=RuntimeError("no auth")):
+                keys = store.list_prefix("runs/")
+                assert keys == []
+
+
+# ---------------------------------------------------------------------------
+# BlobRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestBlobRegistry:
+    def test_register_and_lookup(self) -> None:
+        from autocontext.blobstore.ref import BlobRef
+        from autocontext.blobstore.registry import BlobRegistry
+
+        registry = BlobRegistry()
+        ref = BlobRef(kind="trace", local_path="/tmp/events.ndjson", digest="sha256:abc", size_bytes=100)
+        registry.register("run_001", "events.ndjson", ref)
+        found = registry.lookup("run_001", "events.ndjson")
+        assert found is not None
+        assert found.digest == "sha256:abc"
+
+    def test_lookup_missing_returns_none(self) -> None:
+        from autocontext.blobstore.registry import BlobRegistry
+
+        registry = BlobRegistry()
+        assert registry.lookup("run_001", "missing") is None
+
+    def test_list_for_run(self) -> None:
+        from autocontext.blobstore.ref import BlobRef
+        from autocontext.blobstore.registry import BlobRegistry
+
+        registry = BlobRegistry()
+        registry.register("run_001", "a.txt", BlobRef(kind="trace", digest="sha256:a", size_bytes=10))
+        registry.register("run_001", "b.txt", BlobRef(kind="report", digest="sha256:b", size_bytes=20))
+        registry.register("run_002", "c.txt", BlobRef(kind="trace", digest="sha256:c", size_bytes=30))
+        refs = registry.list_for_run("run_001")
+        assert len(refs) == 2
+
+    def test_save_and_load(self) -> None:
+        from autocontext.blobstore.ref import BlobRef
+        from autocontext.blobstore.registry import BlobRegistry
+
+        with tempfile.TemporaryDirectory() as tmp:
+            registry = BlobRegistry()
+            registry.register("r1", "f.txt", BlobRef(kind="trace", digest="sha256:x", size_bytes=50))
+            path = Path(tmp) / "registry.json"
+            registry.save(path)
+
+            loaded = BlobRegistry.load(path)
+            assert loaded.lookup("r1", "f.txt") is not None
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+class TestFactory:
+    def test_creates_local_backend(self) -> None:
+        from autocontext.blobstore.factory import create_blob_store
+        from autocontext.blobstore.local import LocalBlobStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = create_blob_store(backend="local", root=tmp)
+            assert isinstance(store, LocalBlobStore)
+
+    def test_creates_hf_backend(self) -> None:
+        from autocontext.blobstore.factory import create_blob_store
+        from autocontext.blobstore.hf_bucket import HfBucketStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = create_blob_store(backend="hf_bucket", repo_id="org/repo", cache_dir=tmp)
+            assert isinstance(store, HfBucketStore)
+
+    def test_raises_for_unknown_backend(self) -> None:
+        from autocontext.blobstore.factory import create_blob_store
+
+        with pytest.raises(ValueError, match="Unknown"):
+            create_blob_store(backend="s3")


### PR DESCRIPTION
## Summary

Phase 1 of AC-518: introduces a backend-agnostic `BlobStore` abstraction for large mutable artifacts that don't belong in Git.

### Architecture

**Storage split:**
- SQLite → coordination, indexing, metadata
- Local filesystem → playbooks, hints, skills, versioned text knowledge
- **Blob store (new)** → run traces, checkpoints, training exports, model payloads, evidence packs

### New `blobstore/` package (6 modules)

| Module | Purpose |
|---|---|
| `store.py` | `BlobStore` ABC: `put`/`get`/`head`/`list_prefix`/`delete`/`put_file`/`get_file` |
| `ref.py` | `BlobRef`: structured locator with kind, digest, size, local_path, remote_uri, hydration status |
| `local.py` | `LocalBlobStore`: content-addressed filesystem backend (SHA256 on write) |
| `hf_bucket.py` | `HfBucketStore`: wraps `huggingface-cli` upload/download with local cache |
| `registry.py` | `BlobRegistry`: tracks BlobRefs by run_id + artifact name, JSON-persistable |
| `factory.py` | `create_blob_store(backend="local"\|"hf_bucket")` |

### Follow-up phases (separate PRs)

- **Phase 2**: Settings integration, artifact store wiring, `autoctx blob sync/status` CLI
- **Phase 3**: Remote-aware artifact publication, OpenClaw integration
- **Phase 4**: Train-in-bucket / publish-to-repo operator workflow

## Test plan

- [x] 23 tests: BlobRef model, LocalBlobStore CRUD (put/get/head/list/delete/put_file/get_file/dedup), HfBucketStore (mocked), BlobRegistry save/load, factory dispatch
- [x] Ruff lint clean
- [x] No external dependencies — stdlib + existing deps only