### PR TITLE
feat: add campaign CLI subcommands (AC-533)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ autocontext runs LLM agents through structured scenarios, evaluates their output
 ## What's New
 
 - All 11 scenario families executable in both Python and TypeScript
-- TypeScript campaign API and MCP surfaces shipped for multi-mission coordination
+- TypeScript campaign CLI, API, and MCP surfaces shipped for multi-mission coordination
 - Provider expansion: Gemini, Mistral, Groq, OpenRouter, and Azure OpenAI
 - Evidence and privacy hardening with TruffleHog integration and redaction
 - Session-runtime parity across Python and TypeScript surfaces
@@ -49,7 +49,7 @@ The product model centers on a few stable ideas:
 - `Scenario`: a reusable environment or evaluation context with stable rules and scoring
 - `Task`: a prompt-centric unit of work that can be evaluated directly or embedded elsewhere
 - `Mission`: a long-running goal advanced step by step until a verifier says it is done
-- `Campaign`: a planned grouping of missions under long-term goals; today it has partial TypeScript API/MCP support but is not yet a top-level CLI workflow or Python package surface
+- `Campaign`: a planned grouping of missions under long-term goals; today it has partial TypeScript CLI/API/MCP support but is not yet a Python package surface
 - `Run`: a concrete execution instance of a scenario or task
 - `Verifier`: the runtime check that decides whether a mission, step, or output is acceptable
 - `Knowledge`: validated lessons that should carry forward across runs
@@ -75,10 +75,11 @@ Strategies are then evaluated through scenario execution, staged validation, and
 | `investigate` | Evidence-driven diagnosis with hypotheses and confidence scoring                    |
 | `analyze`     | Inspect or compare runs, simulations, investigations, or missions after the fact    |
 | `mission`     | Verifier-driven goal advanced step by step with checkpoints and completion criteria |
+| `campaign`    | Coordinate multiple missions with budget tracking, dependencies, and progress aggregation |
 | `train`       | Distill stable exported data into a cheaper local runtime                           |
 | `replay`      | Inspect what happened before deciding what knowledge should persist                 |
 
-`campaign` now has partial TypeScript API/MCP support for multi-mission coordination, but it is not yet a top-level CLI workflow in either package.
+`campaign` now ships as a TypeScript CLI/API/MCP workflow for multi-mission coordination. The Python package still does not expose a campaign control-plane surface.
 
 ## Choose An Entry Point
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -42,7 +42,7 @@ Some newer operator-facing surfaces are currently TypeScript-first:
 - `autoctx analyze`
 - the interactive terminal UI via `npx autoctx tui`
 
-`campaign` currently lives in that same bucket: it has partial TypeScript API/MCP support, but the Python package does not expose a campaign control-plane workflow yet.
+`campaign` currently lives in that same bucket: it has partial TypeScript CLI/API/MCP support, but the Python package does not expose a campaign control-plane workflow yet.
 
 ## Quick Start
 

--- a/autocontext/assets/whats_new.txt
+++ b/autocontext/assets/whats_new.txt
@@ -1,5 +1,5 @@
 All 11 scenario families executable in both Python and TypeScript
-TypeScript campaign API and MCP surfaces shipped for multi-mission coordination
+TypeScript campaign CLI, API, and MCP surfaces shipped for multi-mission coordination
 Provider expansion: Gemini, Mistral, Groq, OpenRouter, and Azure OpenAI
 Evidence and privacy hardening with TruffleHog integration and redaction
 Session-runtime parity across Python and TypeScript surfaces

--- a/autocontext/src/autocontext/concepts.py
+++ b/autocontext/src/autocontext/concepts.py
@@ -32,7 +32,7 @@ _CONCEPT_MODEL: dict[str, Any] = {
             "description": (
                 "A planned grouping of missions, runs, and scenarios used to "
                 "coordinate broader work over time. Partial support exists "
-                "today through TypeScript API/MCP surfaces; the Python "
+                "today through TypeScript CLI/API/MCP surfaces; the Python "
                 "package does not expose campaign workflows yet."
             ),
             "status": "partial",

--- a/docs/concept-model.md
+++ b/docs/concept-model.md
@@ -14,7 +14,7 @@ The repo already has strong runtime primitives, but the vocabulary is not yet un
 - `Task` means at least three different things today: an agent-task spec, a queued evaluation job, and a generic prompt.
 - `Scenario` is sometimes a simulation environment and sometimes the saved wrapper around an agent task.
 - `Mission` exists as a real TypeScript control-plane concept, but not yet as a shared repo-wide one.
-- `Campaign` now has partial TypeScript API/MCP support, but it is not yet a shared CLI workflow or Python package surface.
+- `Campaign` now has partial TypeScript CLI/API/MCP support, but it is not yet a Python package surface.
 - `solve`, `sandbox`, `replay`, `playbook`, and `artifacts` are often presented like peer concepts even though they are better understood as operations or runtime outputs.
 
 ## Canonical Layers
@@ -28,7 +28,7 @@ These are the nouns we should prefer in docs, APIs, and product copy when descri
 | `Scenario` | A reusable environment, simulation, or evaluation context with stable rules and scoring. | Implemented across Python, TypeScript, CLI, MCP, API/TUI surfaces, and docs. |
 | `Task` | A user-authored unit of work or prompt-centric objective that can be evaluated directly or embedded inside another surface. | Implemented, but overloaded. |
 | `Mission` | A long-running goal advanced step by step until a verifier says it is complete. | Implemented in TypeScript CLI/MCP/API/TUI surfaces. |
-| `Campaign` | A planned grouping of missions, runs, and/or scenarios used to coordinate broader work over time. | Partially implemented through TypeScript API/MCP surfaces. Not yet a shared CLI workflow or Python package surface. |
+| `Campaign` | A planned grouping of missions, runs, and/or scenarios used to coordinate broader work over time. | Partially implemented through TypeScript CLI/API/MCP surfaces. Not yet a Python package surface. |
 
 ### Runtime concepts
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -240,7 +240,7 @@ The TypeScript package includes the current 0.3.x operator-facing surfaces:
 - `mission`
 - `train` as a validation plus executor-hook surface
 
-`campaign` now has partial TypeScript API and MCP support for multi-mission coordination, but it is not yet a shipped first-class CLI workflow.
+`campaign` now ships as a first-class TypeScript CLI/API/MCP workflow for multi-mission coordination.
 
 For end-to-end local MLX/CUDA training, the Python package is still the canonical out-of-the-box runtime.
 

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -16,6 +16,7 @@ import { parseArgs } from "node:util";
 import { resolve, join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { emitEngineResult } from "./emit-engine-result.js";
+import type { CampaignStatus } from "../mission/campaign.js";
 
 function getMigrationsDir(): string {
   const thisDir = dirname(fileURLToPath(import.meta.url));
@@ -41,6 +42,7 @@ Commands:
   logout           Clear stored provider credentials
   providers        List all known providers with auth status (JSON)
   models           List available models for authenticated providers (JSON)
+  campaign         Manage multi-mission campaigns
   tui              Start interactive TUI (WebSocket server + Ink UI)
   judge            One-shot evaluation of output against a rubric
   improve          Run multi-round improvement loop
@@ -2194,6 +2196,7 @@ async function cmdCapabilities(): Promise<void> {
       "providers",
       "models",
       "mission",
+      "campaign",
       "tui",
       "judge",
       "improve",
@@ -2816,9 +2819,55 @@ See also: mission, run`);
     const id = requireIdArg(
       `Usage: autoctx campaign ${action} --id <campaign-id>`,
     );
-    requireCampaign(id);
+    const campaign = requireCampaign(id);
+    if (action === "pause" && campaign.status !== "active") {
+      console.error(`Cannot pause campaign in status: ${campaign.status}`);
+      process.exit(1);
+    }
+    if (action === "resume" && campaign.status !== "paused") {
+      console.error(`Cannot resume campaign in status: ${campaign.status}`);
+      process.exit(1);
+    }
+    if (
+      action === "cancel" &&
+      campaign.status !== "active" &&
+      campaign.status !== "paused"
+    ) {
+      console.error(`Cannot cancel campaign in status: ${campaign.status}`);
+      process.exit(1);
+    }
     manager[action](id);
     console.log(JSON.stringify(manager.get(id), null, 2));
+  }
+
+  function parseCampaignPositiveInteger(
+    raw: string | undefined,
+    label: string,
+  ): number {
+    try {
+      return parsePositiveInteger(raw, label);
+    } catch (error) {
+      console.error(formatFatalCliError(error));
+      process.exit(1);
+    }
+  }
+
+  function parseCampaignStatus(raw: string | undefined): CampaignStatus | undefined {
+    if (!raw) return undefined;
+    const allowed: CampaignStatus[] = [
+      "active",
+      "paused",
+      "completed",
+      "failed",
+      "canceled",
+    ];
+    if (!allowed.includes(raw as CampaignStatus)) {
+      console.error(
+        `Error: --status must be one of ${allowed.join(", ")}`,
+      );
+      process.exit(1);
+    }
+    return raw as CampaignStatus;
   }
 
   try {
@@ -2843,10 +2892,20 @@ See also: mission, run`);
           values["max-missions"] || values["max-steps"]
             ? {
                 ...(values["max-missions"]
-                  ? { maxMissions: parseInt(values["max-missions"], 10) }
+                  ? {
+                      maxMissions: parseCampaignPositiveInteger(
+                        values["max-missions"],
+                        "--max-missions",
+                      ),
+                    }
                   : {}),
                 ...(values["max-steps"]
-                  ? { maxTotalSteps: parseInt(values["max-steps"], 10) }
+                  ? {
+                      maxTotalSteps: parseCampaignPositiveInteger(
+                        values["max-steps"],
+                        "--max-steps",
+                      ),
+                    }
                   : {}),
               }
             : undefined;
@@ -2875,8 +2934,7 @@ See also: mission, run`);
           args: process.argv.slice(4),
           options: { status: { type: "string" } },
         });
-        type CampaignStatusParam = Parameters<typeof manager.list>[0];
-        const campaigns = manager.list(values.status as CampaignStatusParam);
+        const campaigns = manager.list(parseCampaignStatus(values.status));
         console.log(JSON.stringify(campaigns, null, 2));
         break;
       }
@@ -2899,7 +2957,12 @@ See also: mission, run`);
         requireCampaign(values.id);
         manager.addMission(values.id, values["mission-id"], {
           ...(values.priority
-            ? { priority: parseInt(values.priority, 10) }
+            ? {
+                priority: parseCampaignPositiveInteger(
+                  values.priority,
+                  "--priority",
+                ),
+              }
             : {}),
           ...(values["depends-on"]
             ? { dependsOn: [values["depends-on"]] }

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -117,6 +117,9 @@ async function main(): Promise<void> {
     case "mission":
       await cmdMission(await getDbPath());
       break;
+    case "campaign":
+      await cmdCampaign(await getDbPath());
+      break;
     case "run":
       await cmdRun(await getDbPath());
       break;
@@ -2748,6 +2751,197 @@ See also: run, improve, judge`);
     }
   } finally {
     manager.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// campaign command (AC-533)
+// ---------------------------------------------------------------------------
+
+async function cmdCampaign(dbPath: string): Promise<void> {
+  const subcommand = process.argv[3];
+  const { MissionManager } = await import("../mission/manager.js");
+  const { CampaignManager } = await import("../mission/campaign.js");
+
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    console.log(`autoctx campaign — Manage multi-mission campaigns
+
+Subcommands:
+  create       Create a new campaign
+  status       Show campaign details with progress
+  list         List all campaigns
+  add-mission  Add a mission to a campaign
+  progress     Show campaign progress and budget usage
+  pause        Pause an active campaign
+  resume       Resume a paused campaign
+  cancel       Cancel a campaign
+
+Examples:
+  autoctx campaign create --name "Q2 Goals" --goal "Ship OAuth and billing"
+  autoctx campaign create --name "Budgeted" --goal "Test" --max-missions 5 --max-steps 50
+  autoctx campaign list --status active
+  autoctx campaign status --id <campaign-id>
+  autoctx campaign add-mission --id <campaign-id> --mission-id <mission-id>
+  autoctx campaign progress --id <campaign-id>
+
+See also: mission, run`);
+    process.exit(0);
+  }
+
+  const missionManager = new MissionManager(dbPath);
+  const manager = new CampaignManager(missionManager);
+
+  function requireCampaign(id: string) {
+    const campaign = manager.get(id);
+    if (!campaign) {
+      console.error(`Campaign not found: ${id}`);
+      process.exit(1);
+    }
+    return campaign;
+  }
+
+  function requireIdArg(usage: string): string {
+    const { values } = parseArgs({
+      args: process.argv.slice(4),
+      options: { id: { type: "string" } },
+    });
+    if (!values.id) {
+      console.error(usage);
+      process.exit(1);
+    }
+    return values.id;
+  }
+
+  function lifecycleAction(action: "pause" | "resume" | "cancel"): void {
+    const id = requireIdArg(
+      `Usage: autoctx campaign ${action} --id <campaign-id>`,
+    );
+    requireCampaign(id);
+    manager[action](id);
+    console.log(JSON.stringify(manager.get(id), null, 2));
+  }
+
+  try {
+    switch (subcommand) {
+      case "create": {
+        const { values } = parseArgs({
+          args: process.argv.slice(4),
+          options: {
+            name: { type: "string" },
+            goal: { type: "string" },
+            "max-missions": { type: "string" },
+            "max-steps": { type: "string" },
+          },
+        });
+        if (!values.name || !values.goal) {
+          console.error(
+            "Usage: autoctx campaign create --name <name> --goal <goal> [--max-missions N] [--max-steps N]",
+          );
+          process.exit(1);
+        }
+        const budget =
+          values["max-missions"] || values["max-steps"]
+            ? {
+                ...(values["max-missions"]
+                  ? { maxMissions: parseInt(values["max-missions"], 10) }
+                  : {}),
+                ...(values["max-steps"]
+                  ? { maxTotalSteps: parseInt(values["max-steps"], 10) }
+                  : {}),
+              }
+            : undefined;
+        const id = manager.create({
+          name: values.name,
+          goal: values.goal,
+          budget,
+        });
+        console.log(JSON.stringify(manager.get(id), null, 2));
+        break;
+      }
+      case "status": {
+        const id = requireIdArg(
+          "Usage: autoctx campaign status --id <campaign-id>",
+        );
+        const campaign = requireCampaign(id);
+        const progress = manager.progress(id);
+        const missions = manager.missions(id);
+        console.log(
+          JSON.stringify({ ...campaign, progress, missions }, null, 2),
+        );
+        break;
+      }
+      case "list": {
+        const { values } = parseArgs({
+          args: process.argv.slice(4),
+          options: { status: { type: "string" } },
+        });
+        type CampaignStatusParam = Parameters<typeof manager.list>[0];
+        const campaigns = manager.list(values.status as CampaignStatusParam);
+        console.log(JSON.stringify(campaigns, null, 2));
+        break;
+      }
+      case "add-mission": {
+        const { values } = parseArgs({
+          args: process.argv.slice(4),
+          options: {
+            id: { type: "string" },
+            "mission-id": { type: "string" },
+            priority: { type: "string" },
+            "depends-on": { type: "string" },
+          },
+        });
+        if (!values.id || !values["mission-id"]) {
+          console.error(
+            "Usage: autoctx campaign add-mission --id <campaign-id> --mission-id <mission-id> [--priority N] [--depends-on <id>]",
+          );
+          process.exit(1);
+        }
+        requireCampaign(values.id);
+        manager.addMission(values.id, values["mission-id"], {
+          ...(values.priority
+            ? { priority: parseInt(values.priority, 10) }
+            : {}),
+          ...(values["depends-on"]
+            ? { dependsOn: [values["depends-on"]] }
+            : {}),
+        });
+        console.log(
+          JSON.stringify(
+            {
+              ok: true,
+              campaignId: values.id,
+              missionId: values["mission-id"],
+            },
+            null,
+            2,
+          ),
+        );
+        break;
+      }
+      case "progress": {
+        const id = requireIdArg(
+          "Usage: autoctx campaign progress --id <campaign-id>",
+        );
+        requireCampaign(id);
+        const progress = manager.progress(id);
+        const budgetUsage = manager.budgetUsage(id);
+        console.log(JSON.stringify({ ...progress, budgetUsage }, null, 2));
+        break;
+      }
+      case "pause":
+      case "resume":
+      case "cancel":
+        lifecycleAction(subcommand);
+        break;
+      default:
+        console.error(
+          `Unknown campaign subcommand: ${subcommand}. Run 'autoctx campaign --help'.`,
+        );
+        process.exit(1);
+    }
+  } finally {
+    manager.close();
+    missionManager.close();
   }
 }
 

--- a/ts/src/concepts/model.ts
+++ b/ts/src/concepts/model.ts
@@ -58,7 +58,7 @@ const CONCEPT_MODEL: ConceptModel = {
     {
       name: "Campaign",
       description:
-        "A planned grouping of missions, runs, and scenarios used to coordinate broader work over time. Partial support exists today through TypeScript API/MCP surfaces; there is not yet a top-level campaign CLI workflow.",
+        "A planned grouping of missions, runs, and scenarios used to coordinate broader work over time. Partial support exists today through TypeScript CLI/API/MCP surfaces; there is not yet a Python package campaign workflow.",
       status: "partial",
     },
   ],

--- a/ts/src/mission/campaign.ts
+++ b/ts/src/mission/campaign.ts
@@ -79,6 +79,21 @@ function isTerminalCampaignStatus(status: CampaignStatus): boolean {
   return status === "completed" || status === "failed" || status === "canceled";
 }
 
+function assertLifecycleTransitionAllowed(
+  current: CampaignStatus,
+  next: CampaignStatus,
+): void {
+  if (next === "paused" && current !== "active") {
+    throw new Error(`Cannot pause campaign in status: ${current}`);
+  }
+  if (next === "active" && current !== "paused") {
+    throw new Error(`Cannot resume campaign in status: ${current}`);
+  }
+  if (next === "canceled" && current !== "active" && current !== "paused") {
+    throw new Error(`Cannot cancel campaign in status: ${current}`);
+  }
+}
+
 function missionCountsAsFailure(status: MissionStatus): boolean {
   return status === "failed" || status === "verifier_failed" || status === "budget_exhausted";
 }
@@ -463,6 +478,7 @@ export class CampaignManager {
   private setStatus(campaignId: string, status: CampaignStatus): void {
     const campaign = this.store.getCampaign(campaignId);
     if (!campaign) throw new Error(`Campaign not found: ${campaignId}`);
+    assertLifecycleTransitionAllowed(campaign.status, status);
     this.store.setStatus(campaignId, status);
   }
 }

--- a/ts/tests/campaign-cli.test.ts
+++ b/ts/tests/campaign-cli.test.ts
@@ -77,6 +77,16 @@ function setupProjectDir(): string {
 // ---------------------------------------------------------------------------
 
 describe("autoctx campaign --help", () => {
+  it("appears in top-level help and capabilities", () => {
+    const help = runCli(["--help"]);
+    expect(help.exitCode).toBe(0);
+    expect(help.stdout).toContain("campaign");
+
+    const capabilities = runCli(["capabilities"]);
+    expect(capabilities.exitCode).toBe(0);
+    expect(JSON.parse(capabilities.stdout).commands).toContain("campaign");
+  });
+
   it("shows campaign subcommands", () => {
     const { stdout, exitCode } = runCli(["campaign", "--help"]);
     expect(exitCode).toBe(0);
@@ -151,6 +161,24 @@ describe("autoctx campaign create", () => {
     expect(stderr).toContain("--name");
     expect(stderr).toContain("--goal");
   });
+
+  it("rejects invalid numeric budget flags", () => {
+    const { exitCode, stderr } = runCli(
+      [
+        "campaign",
+        "create",
+        "--name",
+        "Bad",
+        "--goal",
+        "g",
+        "--max-missions",
+        "oops",
+      ],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--max-missions must be a positive integer");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -223,6 +251,15 @@ describe("autoctx campaign list", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.length).toBe(1);
     expect(parsed[0].name).toBe("B");
+  });
+
+  it("rejects invalid status filters", () => {
+    const { exitCode, stderr } = runCli(
+      ["campaign", "list", "--status", "mystery"],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--status must be one of");
   });
 });
 
@@ -320,6 +357,36 @@ describe("autoctx campaign add-mission and progress", () => {
     const status = JSON.parse(statusOut);
     expect(status.missions.length).toBe(2);
   });
+
+  it("rejects invalid priority values", () => {
+    const { stdout: cOut } = runCli(
+      ["campaign", "create", "--name", "C", "--goal", "g"],
+      { cwd: dir },
+    );
+    const campaignId = JSON.parse(cOut).id;
+
+    const { stdout: mOut } = runCli(
+      ["mission", "create", "--name", "M1", "--goal", "mg"],
+      { cwd: dir },
+    );
+    const missionId = JSON.parse(mOut).id;
+
+    const { exitCode, stderr } = runCli(
+      [
+        "campaign",
+        "add-mission",
+        "--id",
+        campaignId,
+        "--mission-id",
+        missionId,
+        "--priority",
+        "bogus",
+      ],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--priority must be a positive integer");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -373,6 +440,25 @@ describe("autoctx campaign lifecycle", () => {
     const { id } = JSON.parse(created);
 
     runCli(["campaign", "cancel", "--id", id], { cwd: dir });
+
+    const { stdout } = runCli(["campaign", "status", "--id", id], { cwd: dir });
+    expect(JSON.parse(stdout).status).toBe("canceled");
+  });
+
+  it("does not allow canceled campaigns to resume", () => {
+    const { stdout: created } = runCli(
+      ["campaign", "create", "--name", "T", "--goal", "g"],
+      { cwd: dir },
+    );
+    const { id } = JSON.parse(created);
+
+    runCli(["campaign", "cancel", "--id", id], { cwd: dir });
+    const { exitCode, stderr } = runCli(["campaign", "resume", "--id", id], {
+      cwd: dir,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Cannot resume campaign in status: canceled");
 
     const { stdout } = runCli(["campaign", "status", "--id", id], { cwd: dir });
     expect(JSON.parse(stdout).status).toBe("canceled");

--- a/ts/tests/campaign-cli.test.ts
+++ b/ts/tests/campaign-cli.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Tests for AC-533: Campaign CLI subcommands.
+ *
+ * CLI: autoctx campaign create/status/list/add-mission/progress/pause/resume/cancel
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const CLI = join(import.meta.dirname, "..", "src", "cli", "index.ts");
+
+const SANITIZED_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "AUTOCONTEXT_API_KEY",
+  "AUTOCONTEXT_AGENT_API_KEY",
+  "AUTOCONTEXT_PROVIDER",
+  "AUTOCONTEXT_AGENT_PROVIDER",
+  "AUTOCONTEXT_DB_PATH",
+  "AUTOCONTEXT_RUNS_ROOT",
+  "AUTOCONTEXT_KNOWLEDGE_ROOT",
+  "AUTOCONTEXT_CONFIG_DIR",
+  "AUTOCONTEXT_AGENT_DEFAULT_MODEL",
+  "AUTOCONTEXT_MODEL",
+];
+
+function buildEnv(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, NODE_NO_WARNINGS: "1" };
+  for (const k of SANITIZED_KEYS) delete env[k];
+  return { ...env, ...overrides };
+}
+
+function runCli(
+  args: string[],
+  opts: { cwd?: string; env?: Record<string, string> } = {},
+): { stdout: string; stderr: string; exitCode: number } {
+  const r = spawnSync("npx", ["tsx", CLI, ...args], {
+    encoding: "utf8",
+    timeout: 15000,
+    cwd: opts.cwd,
+    env: buildEnv(opts.env),
+  });
+  return {
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? "",
+    exitCode: r.status ?? 1,
+  };
+}
+
+function setupProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ac-campaign-cli-"));
+  mkdirSync(join(dir, "runs"), { recursive: true });
+  mkdirSync(join(dir, "knowledge"), { recursive: true });
+  writeFileSync(
+    join(dir, ".autoctx.json"),
+    JSON.stringify(
+      {
+        default_scenario: "grid_ctf",
+        provider: "deterministic",
+        gens: 1,
+        runs_dir: "./runs",
+        knowledge_dir: "./knowledge",
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// CLI: autoctx campaign --help
+// ---------------------------------------------------------------------------
+
+describe("autoctx campaign --help", () => {
+  it("shows campaign subcommands", () => {
+    const { stdout, exitCode } = runCli(["campaign", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("create");
+    expect(stdout).toContain("status");
+    expect(stdout).toContain("list");
+    expect(stdout).toContain("add-mission");
+    expect(stdout).toContain("progress");
+    expect(stdout).toContain("pause");
+    expect(stdout).toContain("resume");
+    expect(stdout).toContain("cancel");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI: campaign create + status
+// ---------------------------------------------------------------------------
+
+describe("autoctx campaign create", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = setupProjectDir();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("creates a campaign and returns its ID", () => {
+    const { stdout, exitCode } = runCli(
+      [
+        "campaign",
+        "create",
+        "--name",
+        "Q2 Goals",
+        "--goal",
+        "Ship OAuth and billing",
+      ],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.id).toBeTruthy();
+    expect(parsed.name).toBe("Q2 Goals");
+    expect(parsed.status).toBe("active");
+  });
+
+  it("creates a campaign with budget constraints", () => {
+    const { stdout, exitCode } = runCli(
+      [
+        "campaign",
+        "create",
+        "--name",
+        "Budgeted",
+        "--goal",
+        "Test budget",
+        "--max-missions",
+        "5",
+        "--max-steps",
+        "50",
+      ],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.id).toBeTruthy();
+    expect(parsed.status).toBe("active");
+  });
+
+  it("requires name and goal", () => {
+    const { exitCode, stderr } = runCli(["campaign", "create"], { cwd: dir });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--name");
+    expect(stderr).toContain("--goal");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI: campaign status
+// ---------------------------------------------------------------------------
+
+describe("autoctx campaign status", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = setupProjectDir();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns campaign details with progress", () => {
+    const { stdout: created } = runCli(
+      ["campaign", "create", "--name", "Test", "--goal", "Do thing"],
+      { cwd: dir },
+    );
+    const { id } = JSON.parse(created);
+
+    const { stdout, exitCode } = runCli(["campaign", "status", "--id", id], {
+      cwd: dir,
+    });
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.name).toBe("Test");
+    expect(parsed.status).toBe("active");
+    expect(parsed.progress).toBeDefined();
+    expect(parsed.progress.totalMissions).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI: campaign list
+// ---------------------------------------------------------------------------
+
+describe("autoctx campaign list", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = setupProjectDir();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("lists all campaigns as JSON", () => {
+    runCli(["campaign", "create", "--name", "A", "--goal", "g1"], { cwd: dir });
+    runCli(["campaign", "create", "--name", "B", "--goal", "g2"], { cwd: dir });
+
+    const { stdout, exitCode } = runCli(["campaign", "list"], { cwd: dir });
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.length).toBe(2);
+  });
+
+  it("filters by status", () => {
+    const { stdout: r1 } = runCli(
+      ["campaign", "create", "--name", "A", "--goal", "g1"],
+      { cwd: dir },
+    );
+    runCli(["campaign", "create", "--name", "B", "--goal", "g2"], { cwd: dir });
+    const { id } = JSON.parse(r1);
+    runCli(["campaign", "pause", "--id", id], { cwd: dir });
+
+    const { stdout } = runCli(["campaign", "list", "--status", "active"], {
+      cwd: dir,
+    });
+    const parsed = JSON.parse(stdout);
+    expect(parsed.length).toBe(1);
+    expect(parsed[0].name).toBe("B");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI: campaign add-mission + progress
+// ---------------------------------------------------------------------------
+
+describe("autoctx campaign add-mission and progress", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = setupProjectDir();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("adds a mission to a campaign", () => {
+    const { stdout: cOut } = runCli(
+      ["campaign", "create", "--name", "C", "--goal", "g"],
+      { cwd: dir },
+    );
+    const campaignId = JSON.parse(cOut).id;
+
+    const { stdout: mOut } = runCli(
+      ["mission", "create", "--name", "M1", "--goal", "mg"],
+      { cwd: dir },
+    );
+    const missionId = JSON.parse(mOut).id;
+
+    const { exitCode } = runCli(
+      [
+        "campaign",
+        "add-mission",
+        "--id",
+        campaignId,
+        "--mission-id",
+        missionId,
+      ],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(0);
+
+    const { stdout: progressOut } = runCli(
+      ["campaign", "progress", "--id", campaignId],
+      { cwd: dir },
+    );
+    const progress = JSON.parse(progressOut);
+    expect(progress.totalMissions).toBe(1);
+  });
+
+  it("adds a mission with priority and dependencies", () => {
+    const { stdout: cOut } = runCli(
+      ["campaign", "create", "--name", "C", "--goal", "g"],
+      { cwd: dir },
+    );
+    const campaignId = JSON.parse(cOut).id;
+
+    const { stdout: m1Out } = runCli(
+      ["mission", "create", "--name", "M1", "--goal", "mg1"],
+      { cwd: dir },
+    );
+    const m1Id = JSON.parse(m1Out).id;
+
+    const { stdout: m2Out } = runCli(
+      ["mission", "create", "--name", "M2", "--goal", "mg2"],
+      { cwd: dir },
+    );
+    const m2Id = JSON.parse(m2Out).id;
+
+    runCli(
+      ["campaign", "add-mission", "--id", campaignId, "--mission-id", m1Id],
+      { cwd: dir },
+    );
+    const { exitCode } = runCli(
+      [
+        "campaign",
+        "add-mission",
+        "--id",
+        campaignId,
+        "--mission-id",
+        m2Id,
+        "--priority",
+        "10",
+        "--depends-on",
+        m1Id,
+      ],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(0);
+
+    const { stdout: statusOut } = runCli(
+      ["campaign", "status", "--id", campaignId],
+      { cwd: dir },
+    );
+    const status = JSON.parse(statusOut);
+    expect(status.missions.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI: campaign pause/resume/cancel
+// ---------------------------------------------------------------------------
+
+describe("autoctx campaign lifecycle", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = setupProjectDir();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("pause sets status to paused", () => {
+    const { stdout: created } = runCli(
+      ["campaign", "create", "--name", "T", "--goal", "g"],
+      { cwd: dir },
+    );
+    const { id } = JSON.parse(created);
+
+    const { exitCode } = runCli(["campaign", "pause", "--id", id], {
+      cwd: dir,
+    });
+    expect(exitCode).toBe(0);
+
+    const { stdout } = runCli(["campaign", "status", "--id", id], { cwd: dir });
+    expect(JSON.parse(stdout).status).toBe("paused");
+  });
+
+  it("resume sets status back to active", () => {
+    const { stdout: created } = runCli(
+      ["campaign", "create", "--name", "T", "--goal", "g"],
+      { cwd: dir },
+    );
+    const { id } = JSON.parse(created);
+
+    runCli(["campaign", "pause", "--id", id], { cwd: dir });
+    runCli(["campaign", "resume", "--id", id], { cwd: dir });
+
+    const { stdout } = runCli(["campaign", "status", "--id", id], { cwd: dir });
+    expect(JSON.parse(stdout).status).toBe("active");
+  });
+
+  it("cancel sets status to canceled", () => {
+    const { stdout: created } = runCli(
+      ["campaign", "create", "--name", "T", "--goal", "g"],
+      { cwd: dir },
+    );
+    const { id } = JSON.parse(created);
+
+    runCli(["campaign", "cancel", "--id", id], { cwd: dir });
+
+    const { stdout } = runCli(["campaign", "status", "--id", id], { cwd: dir });
+    expect(JSON.parse(stdout).status).toBe("canceled");
+  });
+
+  it("returns an error for nonexistent campaign IDs", () => {
+    const { stderr, exitCode } = runCli(
+      ["campaign", "status", "--id", "nonexistent-id"],
+      { cwd: dir },
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Campaign not found");
+  });
+});

--- a/ts/tests/campaign.test.ts
+++ b/ts/tests/campaign.test.ts
@@ -100,6 +100,17 @@ describe("campaign lifecycle", () => {
     campaignManager.cancel(id);
     expect(campaignManager.get(id)!.status).toBe("canceled");
   });
+
+  it("does not allow terminal campaigns to resume", () => {
+    const id = campaignManager.create({ name: "Terminal", goal: "Stay terminal" });
+
+    campaignManager.cancel(id);
+
+    expect(() => campaignManager.resume(id)).toThrow(
+      "Cannot resume campaign in status: canceled",
+    );
+    expect(campaignManager.get(id)!.status).toBe("canceled");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Wires `CampaignManager` into the `autoctx` CLI with full subcommand support, closing the CLI gap identified in AC-533.

- `autoctx campaign create --name <name> --goal <goal> [--max-missions N] [--max-steps N]`
- `autoctx campaign status --id <id>` — details with progress and mission list
- `autoctx campaign list [--status <status>]`
- `autoctx campaign add-mission --id <id> --mission-id <mid> [--priority N] [--depends-on <id>]`
- `autoctx campaign progress --id <id>` — progress and budget usage
- `autoctx campaign pause/resume/cancel --id <id>`

### DRY patterns

- `requireCampaign(id)` — get + null check + exit, mirrors `requireMission`
- `requireIdArg(usage)` — parseArgs for `--id` with usage message
- `lifecycleAction(action)` — collapses identical pause/resume/cancel handling

## Test plan

- [x] 13 campaign CLI tests pass (create, budget, validation, status, list, filter, add-mission, priority/deps, pause, resume, cancel, error)
- [x] 12 mission CLI tests pass (no regressions)

Closes AC-533 (CLI portion — API and MCP shipped in #639)