### PR TITLE
feat: harness mutation surface — typed specs, parser, store, gate, applier (AC-505)

### DIFF
--- a/autocontext/src/autocontext/harness/mutations/__init__.py
+++ b/autocontext/src/autocontext/harness/mutations/__init__.py
@@ -1,0 +1,18 @@
+"""Harness mutation surface (AC-505)."""
+
+from autocontext.harness.mutations.applier import apply_mutations, get_active_completion_checks
+from autocontext.harness.mutations.gate import GateResult, evaluate_mutation
+from autocontext.harness.mutations.parser import parse_mutations
+from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+from autocontext.harness.mutations.store import MutationStore
+
+__all__ = [
+    "GateResult",
+    "HarnessMutation",
+    "MutationStore",
+    "MutationType",
+    "apply_mutations",
+    "evaluate_mutation",
+    "get_active_completion_checks",
+    "parse_mutations",
+]

--- a/autocontext/src/autocontext/harness/mutations/applier.py
+++ b/autocontext/src/autocontext/harness/mutations/applier.py
@@ -1,0 +1,34 @@
+"""Apply active mutations to prompt assembly (AC-505)."""
+
+from __future__ import annotations
+
+from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+
+def apply_mutations(
+    prompts: dict[str, str],
+    mutations: list[HarnessMutation],
+) -> dict[str, str]:
+    """Apply active prompt_fragment mutations to role prompts.
+
+    Returns a new dict with modified prompts. Non-prompt mutation types
+    (context_policy, completion_check, tool_instruction) are handled
+    by their respective consumers, not here.
+    """
+    result = dict(prompts)
+
+    for mutation in mutations:
+        if not mutation.active:
+            continue
+        if mutation.mutation_type != MutationType.PROMPT_FRAGMENT:
+            continue
+        role = mutation.target_role
+        if role and role in result:
+            result[role] = f"{result[role]}\n\n{mutation.content}"
+
+    return result
+
+
+def get_active_completion_checks(mutations: list[HarnessMutation]) -> list[str]:
+    """Extract active completion check content strings."""
+    return [m.content for m in mutations if m.active and m.mutation_type == MutationType.COMPLETION_CHECK]

--- a/autocontext/src/autocontext/harness/mutations/gate.py
+++ b/autocontext/src/autocontext/harness/mutations/gate.py
@@ -1,0 +1,37 @@
+"""Mutation gate — evaluate before promotion (AC-505)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from autocontext.harness.mutations.spec import HarnessMutation
+
+_MAX_CONTENT_LENGTH = 10_000
+
+
+@dataclass(slots=True)
+class GateResult:
+    """Outcome of evaluating a mutation for promotion."""
+
+    approved: bool
+    reason: str
+
+
+def evaluate_mutation(mutation: HarnessMutation) -> GateResult:
+    """Evaluate whether a mutation should be promoted.
+
+    Current rules (extensible):
+    - Content must not be empty
+    - Content must not exceed max length
+    - Type must be valid (enforced by enum)
+    """
+    if not mutation.content.strip():
+        return GateResult(approved=False, reason="Empty mutation content")
+
+    if len(mutation.content) > _MAX_CONTENT_LENGTH:
+        return GateResult(
+            approved=False,
+            reason=f"Content exceeds max length ({len(mutation.content)} > {_MAX_CONTENT_LENGTH})",
+        )
+
+    return GateResult(approved=True, reason=f"Approved: {mutation.mutation_type.value}")

--- a/autocontext/src/autocontext/harness/mutations/gate.py
+++ b/autocontext/src/autocontext/harness/mutations/gate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from autocontext.harness.mutations.spec import HarnessMutation
+from autocontext.harness.mutations.spec import HarnessMutation, MutationType
 
 _MAX_CONTENT_LENGTH = 10_000
 
@@ -33,5 +33,14 @@ def evaluate_mutation(mutation: HarnessMutation) -> GateResult:
             approved=False,
             reason=f"Content exceeds max length ({len(mutation.content)} > {_MAX_CONTENT_LENGTH})",
         )
+
+    if mutation.mutation_type == MutationType.PROMPT_FRAGMENT and not mutation.target_role.strip():
+        return GateResult(approved=False, reason="prompt_fragment requires target_role")
+
+    if mutation.mutation_type == MutationType.CONTEXT_POLICY and not mutation.component.strip():
+        return GateResult(approved=False, reason="context_policy requires component")
+
+    if mutation.mutation_type == MutationType.TOOL_INSTRUCTION and not mutation.tool_name.strip():
+        return GateResult(approved=False, reason="tool_instruction requires tool_name")
 
     return GateResult(approved=True, reason=f"Approved: {mutation.mutation_type.value}")

--- a/autocontext/src/autocontext/harness/mutations/parser.py
+++ b/autocontext/src/autocontext/harness/mutations/parser.py
@@ -1,0 +1,62 @@
+"""Parse harness mutations from architect output (AC-505)."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+logger = logging.getLogger(__name__)
+
+_MUTATIONS_START = "<!-- MUTATIONS_START -->"
+_MUTATIONS_END = "<!-- MUTATIONS_END -->"
+
+_VALID_TYPES = {t.value for t in MutationType}
+
+
+def parse_mutations(content: str) -> list[HarnessMutation]:
+    """Extract mutation specs from architect output between delimited markers."""
+    start = content.find(_MUTATIONS_START)
+    end = content.find(_MUTATIONS_END)
+    if start == -1 or end == -1 or end <= start:
+        return []
+
+    body = content[start + len(_MUTATIONS_START) : end].strip()
+    try:
+        decoded = json.loads(body)
+    except json.JSONDecodeError:
+        logger.debug("failed to parse mutations JSON")
+        return []
+
+    if not isinstance(decoded, dict):
+        return []
+
+    raw_mutations = decoded.get("mutations", [])
+    if not isinstance(raw_mutations, list):
+        return []
+
+    mutations: list[HarnessMutation] = []
+    for raw in raw_mutations:
+        if not isinstance(raw, dict):
+            continue
+        mutation_type = raw.get("type", "")
+        if mutation_type not in _VALID_TYPES:
+            continue
+        if not raw.get("content"):
+            continue
+        try:
+            mutations.append(
+                HarnessMutation(
+                    mutation_type=MutationType(mutation_type),
+                    content=raw.get("content", ""),
+                    rationale=raw.get("rationale", ""),
+                    target_role=raw.get("target_role", ""),
+                    component=raw.get("component", ""),
+                    tool_name=raw.get("tool_name", ""),
+                )
+            )
+        except (ValueError, KeyError):
+            continue
+
+    return mutations

--- a/autocontext/src/autocontext/harness/mutations/spec.py
+++ b/autocontext/src/autocontext/harness/mutations/spec.py
@@ -1,0 +1,57 @@
+"""Typed harness mutation specs (AC-505)."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class MutationType(StrEnum):
+    PROMPT_FRAGMENT = "prompt_fragment"
+    CONTEXT_POLICY = "context_policy"
+    COMPLETION_CHECK = "completion_check"
+    TOOL_INSTRUCTION = "tool_instruction"
+
+
+@dataclass(slots=True)
+class HarnessMutation:
+    """A typed mutation to a harness component."""
+
+    mutation_type: MutationType
+    content: str = ""
+    rationale: str = ""
+    target_role: str = ""  # for prompt_fragment
+    component: str = ""  # for context_policy
+    tool_name: str = ""  # for tool_instruction
+    mutation_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    generation: int = 0
+    active: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mutation_id": self.mutation_id,
+            "type": self.mutation_type.value,
+            "content": self.content,
+            "rationale": self.rationale,
+            "target_role": self.target_role,
+            "component": self.component,
+            "tool_name": self.tool_name,
+            "generation": self.generation,
+            "active": self.active,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> HarnessMutation:
+        return cls(
+            mutation_type=MutationType(data["type"]),
+            content=data.get("content", ""),
+            rationale=data.get("rationale", ""),
+            target_role=data.get("target_role", ""),
+            component=data.get("component", ""),
+            tool_name=data.get("tool_name", ""),
+            mutation_id=data.get("mutation_id", uuid.uuid4().hex[:12]),
+            generation=data.get("generation", 0),
+            active=data.get("active", True),
+        )

--- a/autocontext/src/autocontext/harness/mutations/store.py
+++ b/autocontext/src/autocontext/harness/mutations/store.py
@@ -6,6 +6,7 @@ import json
 import logging
 from pathlib import Path
 
+from autocontext.blobstore.store import resolve_blob_path
 from autocontext.harness.mutations.spec import HarnessMutation
 
 logger = logging.getLogger(__name__)
@@ -20,9 +21,12 @@ class MutationStore:
     def __init__(self, root: Path) -> None:
         self.root = root
 
+    def _scenario_dir(self, scenario_name: str) -> Path:
+        return resolve_blob_path(self.root, scenario_name)
+
     def save(self, scenario_name: str, mutations: list[HarnessMutation]) -> None:
         """Save mutations, preserving previous version."""
-        scenario_dir = self.root / scenario_name
+        scenario_dir = self._scenario_dir(scenario_name)
         scenario_dir.mkdir(parents=True, exist_ok=True)
         mutations_path = scenario_dir / _MUTATIONS_FILENAME
 
@@ -40,7 +44,7 @@ class MutationStore:
 
     def load(self, scenario_name: str) -> list[HarnessMutation]:
         """Load current mutations for a scenario."""
-        mutations_path = self.root / scenario_name / _MUTATIONS_FILENAME
+        mutations_path = self._scenario_dir(scenario_name) / _MUTATIONS_FILENAME
         if not mutations_path.exists():
             return []
         try:
@@ -51,27 +55,29 @@ class MutationStore:
 
     def list_versions(self, scenario_name: str) -> list[str]:
         """List available version files."""
-        versions_dir = self.root / scenario_name / _VERSIONS_DIR
+        scenario_dir = self._scenario_dir(scenario_name)
+        versions_dir = scenario_dir / _VERSIONS_DIR
         if not versions_dir.is_dir():
-            current = self.root / scenario_name / _MUTATIONS_FILENAME
+            current = scenario_dir / _MUTATIONS_FILENAME
             return [str(current)] if current.exists() else []
         versions = sorted(versions_dir.glob("mutations_v*.json"))
         result = [str(v) for v in versions]
-        current = self.root / scenario_name / _MUTATIONS_FILENAME
+        current = scenario_dir / _MUTATIONS_FILENAME
         if current.exists():
             result.append(str(current))
         return result
 
     def rollback(self, scenario_name: str) -> bool:
         """Rollback to the previous version. Returns True if successful."""
-        versions_dir = self.root / scenario_name / _VERSIONS_DIR
+        scenario_dir = self._scenario_dir(scenario_name)
+        versions_dir = scenario_dir / _VERSIONS_DIR
         if not versions_dir.is_dir():
             return False
         versions = sorted(versions_dir.glob("mutations_v*.json"))
         if not versions:
             return False
         latest_archive = versions[-1]
-        current = self.root / scenario_name / _MUTATIONS_FILENAME
+        current = scenario_dir / _MUTATIONS_FILENAME
         current.write_text(latest_archive.read_text(encoding="utf-8"), encoding="utf-8")
         latest_archive.unlink()
         return True

--- a/autocontext/src/autocontext/harness/mutations/store.py
+++ b/autocontext/src/autocontext/harness/mutations/store.py
@@ -1,0 +1,77 @@
+"""Versioned mutation persistence (AC-505)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from autocontext.harness.mutations.spec import HarnessMutation
+
+logger = logging.getLogger(__name__)
+
+_MUTATIONS_FILENAME = "mutations.json"
+_VERSIONS_DIR = "mutation_versions"
+
+
+class MutationStore:
+    """Version and persist harness mutations as JSON artifacts."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def save(self, scenario_name: str, mutations: list[HarnessMutation]) -> None:
+        """Save mutations, preserving previous version."""
+        scenario_dir = self.root / scenario_name
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+        mutations_path = scenario_dir / _MUTATIONS_FILENAME
+
+        # Archive current version
+        if mutations_path.exists():
+            versions_dir = scenario_dir / _VERSIONS_DIR
+            versions_dir.mkdir(exist_ok=True)
+            version_num = len(list(versions_dir.glob("mutations_v*.json"))) + 1
+            archive_path = versions_dir / f"mutations_v{version_num}.json"
+            archive_path.write_text(mutations_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+        # Write current
+        data = [m.to_dict() for m in mutations]
+        mutations_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    def load(self, scenario_name: str) -> list[HarnessMutation]:
+        """Load current mutations for a scenario."""
+        mutations_path = self.root / scenario_name / _MUTATIONS_FILENAME
+        if not mutations_path.exists():
+            return []
+        try:
+            data = json.loads(mutations_path.read_text(encoding="utf-8"))
+            return [HarnessMutation.from_dict(d) for d in data]
+        except (json.JSONDecodeError, KeyError, ValueError):
+            return []
+
+    def list_versions(self, scenario_name: str) -> list[str]:
+        """List available version files."""
+        versions_dir = self.root / scenario_name / _VERSIONS_DIR
+        if not versions_dir.is_dir():
+            current = self.root / scenario_name / _MUTATIONS_FILENAME
+            return [str(current)] if current.exists() else []
+        versions = sorted(versions_dir.glob("mutations_v*.json"))
+        result = [str(v) for v in versions]
+        current = self.root / scenario_name / _MUTATIONS_FILENAME
+        if current.exists():
+            result.append(str(current))
+        return result
+
+    def rollback(self, scenario_name: str) -> bool:
+        """Rollback to the previous version. Returns True if successful."""
+        versions_dir = self.root / scenario_name / _VERSIONS_DIR
+        if not versions_dir.is_dir():
+            return False
+        versions = sorted(versions_dir.glob("mutations_v*.json"))
+        if not versions:
+            return False
+        latest_archive = versions[-1]
+        current = self.root / scenario_name / _MUTATIONS_FILENAME
+        current.write_text(latest_archive.read_text(encoding="utf-8"), encoding="utf-8")
+        latest_archive.unlink()
+        return True

--- a/autocontext/src/autocontext/loop/stage_helpers/harness_mutations.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/harness_mutations.py
@@ -74,7 +74,12 @@ def apply_harness_mutations_to_prompts(
         checklist = "Active completion checks:\n" + "\n".join(f"- {check}" for check in checks)
         prompt_map["competitor"] = f"{prompt_map['competitor']}\n\n{checklist}"
 
-    return dataclasses.replace(prompts, **prompt_map)
+    if dataclasses.is_dataclass(prompts):
+        return dataclasses.replace(prompts, **prompt_map)
+
+    for role, prompt in prompt_map.items():
+        setattr(prompts, role, prompt)
+    return prompts
 
 
 def persist_approved_harness_mutations(

--- a/autocontext/src/autocontext/loop/stage_helpers/harness_mutations.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/harness_mutations.py
@@ -1,0 +1,129 @@
+"""Helpers for wiring harness mutations into live generation stages."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from autocontext.harness.mutations import (
+    HarnessMutation,
+    MutationType,
+    apply_mutations,
+    evaluate_mutation,
+    get_active_completion_checks,
+)
+from autocontext.prompts.templates import PromptBundle
+
+if TYPE_CHECKING:
+    from autocontext.storage import ArtifactStore
+
+_PROMPT_ROLES = ("competitor", "analyst", "coach", "architect")
+
+
+def load_active_harness_mutations(
+    artifacts: ArtifactStore,
+    scenario_name: str,
+) -> list[HarnessMutation]:
+    """Load only active, typed mutations for a scenario."""
+    loaded = artifacts.load_harness_mutations(scenario_name)
+    if not isinstance(loaded, list):
+        return []
+    return [mutation for mutation in loaded if isinstance(mutation, HarnessMutation) and mutation.active]
+
+
+def render_context_policy_block(mutations: list[HarnessMutation]) -> str:
+    """Render prompt-facing context policy notes."""
+    lines = [
+        f"- {mutation.component}: {mutation.content}"
+        for mutation in mutations
+        if mutation.active
+        and mutation.mutation_type == MutationType.CONTEXT_POLICY
+        and mutation.component
+        and mutation.content.strip()
+    ]
+    if not lines:
+        return ""
+    return "Active context policies:\n" + "\n".join(lines)
+
+
+def render_tool_instruction_block(mutations: list[HarnessMutation]) -> str:
+    """Render prompt-facing tool instructions."""
+    lines = [
+        f"- {mutation.tool_name}: {mutation.content}"
+        for mutation in mutations
+        if mutation.active
+        and mutation.mutation_type == MutationType.TOOL_INSTRUCTION
+        and mutation.tool_name
+        and mutation.content.strip()
+    ]
+    if not lines:
+        return ""
+    return "Tool-specific instructions:\n" + "\n".join(lines)
+
+
+def apply_harness_mutations_to_prompts(
+    prompts: PromptBundle,
+    mutations: list[HarnessMutation],
+) -> PromptBundle:
+    """Apply active prompt fragments and completion checks to the live prompt bundle."""
+    prompt_map = {role: getattr(prompts, role) for role in _PROMPT_ROLES}
+    prompt_map = apply_mutations(prompt_map, mutations)
+
+    checks = get_active_completion_checks(mutations)
+    if checks:
+        checklist = "Active completion checks:\n" + "\n".join(f"- {check}" for check in checks)
+        prompt_map["competitor"] = f"{prompt_map['competitor']}\n\n{checklist}"
+
+    return dataclasses.replace(prompts, **prompt_map)
+
+
+def persist_approved_harness_mutations(
+    artifacts: ArtifactStore,
+    scenario_name: str,
+    *,
+    generation: int,
+    run_id: str,
+    proposed: list[HarnessMutation],
+) -> list[HarnessMutation]:
+    """Gate, deduplicate, and persist approved harness mutations."""
+    if not proposed:
+        return []
+
+    existing = load_active_harness_mutations(artifacts, scenario_name)
+    merged = list(existing)
+    existing_keys = {_mutation_identity(mutation) for mutation in merged}
+    approved_additions: list[HarnessMutation] = []
+
+    for mutation in proposed:
+        if not isinstance(mutation, HarnessMutation):
+            continue
+        result = evaluate_mutation(mutation)
+        if not result.approved:
+            continue
+        mutation.generation = generation
+        identity = _mutation_identity(mutation)
+        if identity in existing_keys:
+            continue
+        merged.append(mutation)
+        existing_keys.add(identity)
+        approved_additions.append(mutation)
+
+    if approved_additions:
+        artifacts.save_harness_mutations(
+            scenario_name,
+            merged,
+            generation=generation,
+            run_id=run_id,
+        )
+
+    return approved_additions
+
+
+def _mutation_identity(mutation: HarnessMutation) -> tuple[str, str, str, str, str]:
+    return (
+        mutation.mutation_type.value,
+        mutation.content.strip(),
+        mutation.target_role.strip(),
+        mutation.component.strip(),
+        mutation.tool_name.strip(),
+    )

--- a/autocontext/src/autocontext/loop/stage_tree_search.py
+++ b/autocontext/src/autocontext/loop/stage_tree_search.py
@@ -13,9 +13,11 @@ from autocontext.agents.types import AgentOutputs
 from autocontext.harness.evaluation.runner import EvaluationRunner
 from autocontext.harness.evaluation.scenario_evaluator import ScenarioEvaluator
 from autocontext.harness.evaluation.types import EvaluationLimits as HarnessLimits
+from autocontext.harness.mutations.parser import parse_mutations
 from autocontext.knowledge.rapid_gate import rapid_gate
 from autocontext.loop.hypothesis_tree import HypothesisTree
 from autocontext.loop.refinement_prompt import build_refinement_prompt
+from autocontext.loop.stage_helpers.harness_mutations import persist_approved_harness_mutations
 from autocontext.loop.stage_types import GenerationContext
 
 if TYPE_CHECKING:
@@ -309,6 +311,13 @@ def stage_tree_search(
     created_tools = artifacts.persist_tools(ctx.scenario_name, ctx.generation, tools)
     if settings.harness_validators_enabled and harness_specs:
         artifacts.persist_harness(ctx.scenario_name, ctx.generation, harness_specs)
+    persist_approved_harness_mutations(
+        artifacts,
+        ctx.scenario_name,
+        generation=ctx.generation,
+        run_id=ctx.run_id,
+        proposed=parse_mutations(architect_exec.content),
+    )
 
     ctx.dag_changes = parse_dag_changes(architect_exec.content)
 

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -16,6 +16,7 @@ from autocontext.harness.evaluation.runner import EvaluationRunner
 from autocontext.harness.evaluation.scenario_evaluator import ScenarioEvaluator
 from autocontext.harness.evaluation.types import EvaluationLimits as HarnessLimits
 from autocontext.harness.evaluation.types import EvaluationResult
+from autocontext.harness.mutations.parser import parse_mutations
 from autocontext.harness.pipeline.holdout import HoldoutResult
 from autocontext.harness.pipeline.trend_gate import TrendAwareGate
 from autocontext.harness.pipeline.validity_gate import ValidityGate
@@ -83,6 +84,13 @@ from autocontext.loop.stage_helpers.freshness import (
     _filter_notebook_by_freshness,
     _load_fresh_hint_context,
     _load_fresh_skill_context,
+)
+from autocontext.loop.stage_helpers.harness_mutations import (
+    apply_harness_mutations_to_prompts,
+    load_active_harness_mutations,
+    persist_approved_harness_mutations,
+    render_context_policy_block,
+    render_tool_instruction_block,
 )
 from autocontext.loop.stage_helpers.persistence_helpers import (
     _apply_tuning_to_settings,
@@ -358,6 +366,7 @@ def stage_knowledge_setup(
     strategy_interface = scenario.describe_strategy_interface()
     evidence_manifest = ""
     notebook_contexts: dict[str, str] | None = None
+    active_harness_mutations = [] if ablation else load_active_harness_mutations(artifacts, ctx.scenario_name)
     if not ablation:
         raw_notebook = artifacts.read_notebook(ctx.run_id)
         if isinstance(raw_notebook, dict):
@@ -380,6 +389,12 @@ def stage_knowledge_setup(
                 if experiment_log
                 else freshness_block
             )
+    tool_instruction_block = render_tool_instruction_block(active_harness_mutations)
+    if tool_instruction_block:
+        tool_context = f"{tool_context}\n\n{tool_instruction_block}".strip() if tool_context else tool_instruction_block
+    context_policy_block = render_context_policy_block(active_harness_mutations)
+    if context_policy_block:
+        experiment_log = f"{experiment_log}\n\n{context_policy_block}".strip() if experiment_log else context_policy_block
     if not ablation and ctx.settings.evidence_workspace_enabled:
         try:
             evidence_manifest = _materialize_evidence_manifest(ctx, artifacts=artifacts)
@@ -414,6 +429,7 @@ def stage_knowledge_setup(
         environment_snapshot="" if ablation else ctx.environment_snapshot,
         evidence_manifest=evidence_manifest,
     )
+    prompts = apply_harness_mutations_to_prompts(prompts, active_harness_mutations)
 
     ctx.applied_competitor_hints = "" if ablation else coach_hints_for_prompt
     ctx.prompts = prompts
@@ -517,6 +533,13 @@ def stage_agent_generation(
     # Persist harness validators if enabled
     if ctx.settings.harness_validators_enabled and outputs.architect_harness_specs:
         artifacts.persist_harness(ctx.scenario_name, ctx.generation, outputs.architect_harness_specs)
+    persist_approved_harness_mutations(
+        artifacts,
+        ctx.scenario_name,
+        generation=ctx.generation,
+        run_id=ctx.run_id,
+        proposed=parse_mutations(outputs.architect_markdown),
+    )
 
     # Parse DAG change directives from architect output
     ctx.dag_changes = parse_dag_changes(outputs.architect_markdown)

--- a/autocontext/src/autocontext/prompts/templates.py
+++ b/autocontext/src/autocontext/prompts/templates.py
@@ -241,7 +241,18 @@ def build_prompt_bundle(
             '{"harness":[{"name":"<snake_case>","description":"<text>",'
             '"code":"def validate_strategy(strategy, scenario):\\n    ..."}]}\n'
             "<!-- HARNESS_END -->\n\n"
-            "If no harness validators, omit the HARNESS markers entirely."
+            "If no harness validators, omit the HARNESS markers entirely.\n\n"
+            "Additionally, you may propose harness mutations — lightweight prompt, "
+            "context, completion, or tool-usage adjustments that carry forward to future generations. "
+            "Wrap mutation specs between markers:\n\n"
+            "<!-- MUTATIONS_START -->\n"
+            '{"mutations":[{"type":"prompt_fragment","target_role":"<competitor|analyst|coach|architect>",'
+            '"content":"<text>","rationale":"<why>"},{"type":"context_policy","component":"<component>",'
+            '"content":"<policy>","rationale":"<why>"},{"type":"completion_check","content":"<check>",'
+            '"rationale":"<why>"},{"type":"tool_instruction","tool_name":"<tool_name>",'
+            '"content":"<instruction>","rationale":"<why>"}]}\n'
+            "<!-- MUTATIONS_END -->\n\n"
+            "If no harness mutations, omit the MUTATIONS markers entirely."
         ),
     )
 

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -17,6 +17,8 @@ from autocontext.agents.feedback_loops import (
 )
 from autocontext.agents.hint_feedback import HintFeedback
 from autocontext.analytics.credit_assignment import CreditAssignmentRecord
+from autocontext.harness.mutations.spec import HarnessMutation
+from autocontext.harness.mutations.store import MutationStore
 from autocontext.harness.storage.versioned_store import VersionedFileStore
 from autocontext.knowledge.hint_volume import HintManager, HintVolumePolicy
 from autocontext.knowledge.lessons import LessonStore
@@ -73,6 +75,13 @@ class ArtifactStore:
                 skills_root=self.skills_root,
             )
         return self._lesson_store
+
+    @property
+    def harness_mutation_store(self) -> MutationStore:
+        """Lazily create a MutationStore for harness mutation state."""
+        if not hasattr(self, "_harness_mutation_store"):
+            self._harness_mutation_store = MutationStore(root=self.knowledge_root)
+        return self._harness_mutation_store
 
     def _playbook_store(self, scenario_name: str) -> VersionedFileStore:
         """Lazily create a per-scenario VersionedFileStore with legacy naming."""
@@ -315,6 +324,34 @@ class ArtifactStore:
     def read_mutation_replay(self, scenario_name: str, *, max_entries: int = 10) -> str:
         """Read a compact replay summary of mutations since the last checkpoint."""
         return self.mutation_log.replay_summary(scenario_name, max_entries=max_entries)
+
+    def load_harness_mutations(self, scenario_name: str) -> list[HarnessMutation]:
+        """Load persisted harness mutations for a scenario."""
+        return self.harness_mutation_store.load(scenario_name)
+
+    def save_harness_mutations(
+        self,
+        scenario_name: str,
+        mutations: list[HarnessMutation],
+        *,
+        generation: int = 0,
+        run_id: str = "",
+    ) -> None:
+        """Persist harness mutations and log the update in the mutation audit trail."""
+        self.harness_mutation_store.save(scenario_name, mutations)
+        self._append_mutation(
+            scenario_name,
+            mutation_type="harness_mutations_updated",
+            payload={
+                "count": len(mutations),
+                "active_count": sum(1 for mutation in mutations if mutation.active),
+                "mutation_ids": [mutation.mutation_id for mutation in mutations],
+                "types": [mutation.mutation_type.value for mutation in mutations],
+            },
+            generation=generation,
+            run_id=run_id,
+            description="Harness mutations updated",
+        )
 
     def read_progress(self, scenario_name: str) -> dict[str, Any] | None:
         """Read progress snapshot, or None if missing."""

--- a/autocontext/tests/test_generation_stages.py
+++ b/autocontext/tests/test_generation_stages.py
@@ -302,6 +302,56 @@ class TestStageKnowledgeSetup:
         assert "Recent progress reports:" in result.prompts.competitor
         assert "Tokens per advance" in result.prompts.competitor
 
+    def test_applies_active_harness_mutations_to_live_prompts(self) -> None:
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        artifacts = MagicMock()
+        artifacts.read_playbook.return_value = ""
+        artifacts.read_tool_context.return_value = "Existing tool context"
+        artifacts.read_skills.return_value = ""
+        artifacts.read_mutation_replay.return_value = ""
+        artifacts.read_latest_weakness_reports_markdown.return_value = ""
+        artifacts.read_latest_progress_reports_markdown.return_value = ""
+        artifacts.read_latest_advance_analysis.return_value = ""
+        artifacts.read_progress.return_value = None
+        artifacts.load_harness_mutations.return_value = [
+            HarnessMutation(
+                mutation_type=MutationType.PROMPT_FRAGMENT,
+                target_role="competitor",
+                content="Always verify edge cases before finalizing.",
+            ),
+            HarnessMutation(
+                mutation_type=MutationType.COMPLETION_CHECK,
+                content="Return valid JSON strategy output.",
+            ),
+            HarnessMutation(
+                mutation_type=MutationType.CONTEXT_POLICY,
+                component="trajectory",
+                content="prefer latest 5 entries",
+            ),
+            HarnessMutation(
+                mutation_type=MutationType.TOOL_INSTRUCTION,
+                tool_name="path_optimizer",
+                content="Prefer this tool for route selection.",
+            ),
+        ]
+        trajectory = MagicMock()
+        trajectory.build_trajectory.return_value = ""
+        trajectory.build_strategy_registry.return_value = ""
+        trajectory.build_experiment_log.return_value = ""
+        ctx = _make_ctx()
+
+        result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
+
+        assert result.prompts is not None
+        assert "Always verify edge cases before finalizing." in result.prompts.competitor
+        assert "Active completion checks" in result.prompts.competitor
+        assert "Return valid JSON strategy output." in result.prompts.competitor
+        assert "Tool-specific instructions" in result.prompts.competitor
+        assert "path_optimizer" in result.prompts.competitor
+        assert "Active context policies" in result.prompts.competitor
+        assert "prefer latest 5 entries" in result.prompts.competitor
+
     def test_includes_role_specific_notebook_context_in_live_prompt_bundle(self) -> None:
         artifacts = MagicMock()
         artifacts.read_playbook.return_value = ""
@@ -782,6 +832,59 @@ class TestStageAgentGeneration:
         written_tracker = artifacts.write_tool_usage_tracker.call_args.args[1]
         assert isinstance(written_tracker, ToolUsageTracker)
         assert written_tracker.get_stats()["cluster_evaluator"].total_refs == 1
+
+    def test_persists_approved_harness_mutations_from_architect_output(self) -> None:
+        scenario = _make_scenario_mock()
+        ctx = _make_ctx(settings=_make_settings(), scenario=scenario)
+
+        from autocontext.prompts.templates import build_prompt_bundle
+
+        ctx.prompts = build_prompt_bundle(
+            scenario_rules="Test",
+            strategy_interface='{"aggression": float}',
+            evaluation_criteria="Score",
+            previous_summary="best: 0.0",
+            observation=scenario.get_observation(None, "challenger"),
+            current_playbook="",
+            available_tools="",
+        )
+        ctx.strategy_interface = '{"aggression": float}'
+
+        outputs = AgentOutputs(
+            strategy={"aggression": 0.5},
+            analysis_markdown="analysis",
+            coach_markdown="coach",
+            coach_playbook="playbook",
+            coach_lessons="",
+            coach_competitor_hints="",
+            architect_markdown=(
+                "## Tool Proposals\n\nNone.\n\n"
+                "<!-- MUTATIONS_START -->\n"
+                '{"mutations":[{"type":"prompt_fragment","target_role":"competitor",'
+                '"content":"Check edge cases","rationale":"rollback trend"}]}\n'
+                "<!-- MUTATIONS_END -->"
+            ),
+            architect_tools=[],
+            role_executions=[],
+        )
+        orchestrator = MagicMock()
+        orchestrator.run_generation.return_value = outputs
+        artifacts = MagicMock()
+        artifacts.persist_tools.return_value = []
+        artifacts.load_harness_mutations.return_value = []
+        sqlite = MagicMock()
+
+        stage_agent_generation(ctx, orchestrator=orchestrator, artifacts=artifacts, sqlite=sqlite)
+
+        artifacts.save_harness_mutations.assert_called_once()
+        call = artifacts.save_harness_mutations.call_args
+        assert call.args[0] == ctx.scenario_name
+        saved = call.args[1]
+        assert len(saved) == 1
+        assert saved[0].target_role == "competitor"
+        assert saved[0].content == "Check edge cases"
+        assert call.kwargs["generation"] == ctx.generation
+        assert call.kwargs["run_id"] == ctx.run_id
 
     def test_multi_basin_branching_selects_best_candidate_in_live_path(self) -> None:
         from autocontext.prompts.templates import build_prompt_bundle

--- a/autocontext/tests/test_harness_mutations.py
+++ b/autocontext/tests/test_harness_mutations.py
@@ -1,0 +1,304 @@
+"""AC-505: Harness mutation surface tests.
+
+Tests typed mutation specs, parsing from architect output, versioned
+persistence, gate evaluation, and prompt-assembly application.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Mutation spec model
+# ---------------------------------------------------------------------------
+
+
+class TestMutationSpec:
+    def test_create_prompt_fragment(self) -> None:
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        m = HarnessMutation(
+            mutation_type=MutationType.PROMPT_FRAGMENT,
+            target_role="competitor",
+            content="Always verify edge cases before submitting",
+            rationale="Edge cases caused 3 consecutive rollbacks",
+        )
+        assert m.mutation_type == MutationType.PROMPT_FRAGMENT
+        assert m.target_role == "competitor"
+
+    def test_create_context_policy(self) -> None:
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        m = HarnessMutation(
+            mutation_type=MutationType.CONTEXT_POLICY,
+            component="trajectory",
+            content="include_last_5",
+            rationale="Full trajectory too verbose",
+        )
+        assert m.mutation_type == MutationType.CONTEXT_POLICY
+        assert m.component == "trajectory"
+
+    def test_create_completion_check(self) -> None:
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        m = HarnessMutation(
+            mutation_type=MutationType.COMPLETION_CHECK,
+            content="Verify output contains valid JSON strategy",
+            rationale="Invalid JSON caused 5 parse failures",
+        )
+        assert m.mutation_type == MutationType.COMPLETION_CHECK
+
+    def test_create_tool_instruction(self) -> None:
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        m = HarnessMutation(
+            mutation_type=MutationType.TOOL_INSTRUCTION,
+            tool_name="score_calculator",
+            content="When using score_calculator, always pass normalized values",
+            rationale="Raw values caused score overflow",
+        )
+        assert m.mutation_type == MutationType.TOOL_INSTRUCTION
+
+    def test_to_dict_roundtrip(self) -> None:
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        m = HarnessMutation(
+            mutation_type=MutationType.PROMPT_FRAGMENT,
+            target_role="analyst",
+            content="Focus on root causes, not symptoms",
+            rationale="Shallow analysis",
+        )
+        d = m.to_dict()
+        restored = HarnessMutation.from_dict(d)
+        assert restored.mutation_type == m.mutation_type
+        assert restored.target_role == m.target_role
+        assert restored.content == m.content
+
+    def test_mutation_has_id(self) -> None:
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        m = HarnessMutation(
+            mutation_type=MutationType.PROMPT_FRAGMENT,
+            content="test",
+        )
+        assert m.mutation_id
+        assert isinstance(m.mutation_id, str)
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+class TestMutationParser:
+    def test_parse_mutations_from_architect_output(self) -> None:
+        from autocontext.harness.mutations.parser import parse_mutations
+
+        content = """Here is my analysis.
+
+<!-- MUTATIONS_START -->
+{"mutations": [
+  {"type": "prompt_fragment", "target_role": "competitor", "content": "Check edge cases", "rationale": "rollbacks"},
+  {"type": "completion_check", "content": "Verify JSON output", "rationale": "parse failures"}
+]}
+<!-- MUTATIONS_END -->
+
+Other text here."""
+
+        mutations = parse_mutations(content)
+        assert len(mutations) == 2
+        assert mutations[0].mutation_type.value == "prompt_fragment"
+        assert mutations[1].mutation_type.value == "completion_check"
+
+    def test_parse_returns_empty_for_no_markers(self) -> None:
+        from autocontext.harness.mutations.parser import parse_mutations
+
+        assert parse_mutations("No mutations here.") == []
+
+    def test_parse_handles_malformed_json(self) -> None:
+        from autocontext.harness.mutations.parser import parse_mutations
+
+        content = "<!-- MUTATIONS_START -->\nnot json\n<!-- MUTATIONS_END -->"
+        assert parse_mutations(content) == []
+
+    def test_parse_skips_invalid_entries(self) -> None:
+        from autocontext.harness.mutations.parser import parse_mutations
+
+        content = """<!-- MUTATIONS_START -->
+{"mutations": [
+  {"type": "prompt_fragment", "content": "valid", "rationale": "ok"},
+  {"type": "bogus_type", "content": "invalid"},
+  {"content": "missing type"}
+]}
+<!-- MUTATIONS_END -->"""
+
+        mutations = parse_mutations(content)
+        assert len(mutations) == 1  # only the valid one
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class TestMutationStore:
+    def test_save_and_load(self) -> None:
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+        from autocontext.harness.mutations.store import MutationStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = MutationStore(root=Path(tmp))
+            m = HarnessMutation(
+                mutation_type=MutationType.PROMPT_FRAGMENT,
+                content="test mutation",
+                rationale="testing",
+            )
+            store.save("test_scenario", [m])
+            loaded = store.load("test_scenario")
+            assert len(loaded) == 1
+            assert loaded[0].content == "test mutation"
+
+    def test_load_returns_empty_for_missing(self) -> None:
+        from autocontext.harness.mutations.store import MutationStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = MutationStore(root=Path(tmp))
+            assert store.load("nonexistent") == []
+
+    def test_versions_are_preserved(self) -> None:
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+        from autocontext.harness.mutations.store import MutationStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = MutationStore(root=Path(tmp))
+            m1 = HarnessMutation(mutation_type=MutationType.PROMPT_FRAGMENT, content="v1")
+            store.save("s", [m1])
+            m2 = HarnessMutation(mutation_type=MutationType.PROMPT_FRAGMENT, content="v2")
+            store.save("s", [m2])
+            versions = store.list_versions("s")
+            assert len(versions) >= 2
+
+    def test_rollback_restores_previous(self) -> None:
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+        from autocontext.harness.mutations.store import MutationStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = MutationStore(root=Path(tmp))
+            m1 = HarnessMutation(mutation_type=MutationType.PROMPT_FRAGMENT, content="original")
+            store.save("s", [m1])
+            m2 = HarnessMutation(mutation_type=MutationType.PROMPT_FRAGMENT, content="updated")
+            store.save("s", [m2])
+            store.rollback("s")
+            loaded = store.load("s")
+            assert loaded[0].content == "original"
+
+
+# ---------------------------------------------------------------------------
+# Gate
+# ---------------------------------------------------------------------------
+
+
+class TestMutationGate:
+    def test_approve_valid_mutation(self) -> None:
+        from autocontext.harness.mutations.gate import evaluate_mutation
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        m = HarnessMutation(
+            mutation_type=MutationType.PROMPT_FRAGMENT,
+            target_role="competitor",
+            content="Focus on defense parameters",
+            rationale="Low defense scores",
+        )
+        result = evaluate_mutation(m)
+        assert result.approved
+        assert result.reason
+
+    def test_reject_empty_content(self) -> None:
+        from autocontext.harness.mutations.gate import evaluate_mutation
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        m = HarnessMutation(
+            mutation_type=MutationType.PROMPT_FRAGMENT,
+            content="",
+            rationale="empty",
+        )
+        result = evaluate_mutation(m)
+        assert not result.approved
+
+    def test_reject_oversized_content(self) -> None:
+        from autocontext.harness.mutations.gate import evaluate_mutation
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        m = HarnessMutation(
+            mutation_type=MutationType.PROMPT_FRAGMENT,
+            content="x" * 10_001,
+            rationale="huge",
+        )
+        result = evaluate_mutation(m)
+        assert not result.approved
+
+
+# ---------------------------------------------------------------------------
+# Applier
+# ---------------------------------------------------------------------------
+
+
+class TestMutationApplier:
+    def test_apply_prompt_fragment_to_role(self) -> None:
+        from autocontext.harness.mutations.applier import apply_mutations
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        mutations = [
+            HarnessMutation(
+                mutation_type=MutationType.PROMPT_FRAGMENT,
+                target_role="competitor",
+                content="Always check edge cases",
+            ),
+        ]
+        base_prompts = {"competitor": "Base prompt.", "analyst": "Analyst base."}
+        result = apply_mutations(base_prompts, mutations)
+        assert "Always check edge cases" in result["competitor"]
+        assert result["analyst"] == "Analyst base."  # unchanged
+
+    def test_apply_multiple_fragments(self) -> None:
+        from autocontext.harness.mutations.applier import apply_mutations
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        mutations = [
+            HarnessMutation(mutation_type=MutationType.PROMPT_FRAGMENT, target_role="analyst", content="Fragment 1"),
+            HarnessMutation(mutation_type=MutationType.PROMPT_FRAGMENT, target_role="analyst", content="Fragment 2"),
+        ]
+        result = apply_mutations({"analyst": "Base."}, mutations)
+        assert "Fragment 1" in result["analyst"]
+        assert "Fragment 2" in result["analyst"]
+
+    def test_apply_skips_non_prompt_mutations(self) -> None:
+        from autocontext.harness.mutations.applier import apply_mutations
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        mutations = [
+            HarnessMutation(mutation_type=MutationType.COMPLETION_CHECK, content="check JSON"),
+            HarnessMutation(mutation_type=MutationType.CONTEXT_POLICY, content="include_last_5"),
+        ]
+        result = apply_mutations({"competitor": "Base."}, mutations)
+        assert result["competitor"] == "Base."  # non-prompt mutations don't modify prompts
+
+    def test_apply_empty_mutations(self) -> None:
+        from autocontext.harness.mutations.applier import apply_mutations
+
+        result = apply_mutations({"competitor": "Base."}, [])
+        assert result["competitor"] == "Base."
+
+    def test_get_active_completion_checks(self) -> None:
+        from autocontext.harness.mutations.applier import get_active_completion_checks
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        mutations = [
+            HarnessMutation(mutation_type=MutationType.PROMPT_FRAGMENT, content="prompt"),
+            HarnessMutation(mutation_type=MutationType.COMPLETION_CHECK, content="Check A"),
+            HarnessMutation(mutation_type=MutationType.COMPLETION_CHECK, content="Check B"),
+        ]
+        checks = get_active_completion_checks(mutations)
+        assert len(checks) == 2
+        assert checks[0] == "Check A"

--- a/autocontext/tests/test_harness_mutations.py
+++ b/autocontext/tests/test_harness_mutations.py
@@ -193,6 +193,20 @@ class TestMutationStore:
             loaded = store.load("s")
             assert loaded[0].content == "original"
 
+    def test_rejects_scenario_path_escape(self) -> None:
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+        from autocontext.harness.mutations.store import MutationStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            store = MutationStore(root=Path(tmp))
+            mutation = HarnessMutation(mutation_type=MutationType.PROMPT_FRAGMENT, content="safe")
+            try:
+                store.save("../escape", [mutation])
+            except ValueError as exc:
+                assert "invalid blob key" in str(exc)
+            else:
+                raise AssertionError("expected path-escape scenario name to be rejected")
+
 
 # ---------------------------------------------------------------------------
 # Gate
@@ -237,6 +251,42 @@ class TestMutationGate:
         )
         result = evaluate_mutation(m)
         assert not result.approved
+
+    def test_reject_prompt_fragment_without_target_role(self) -> None:
+        from autocontext.harness.mutations.gate import evaluate_mutation
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        m = HarnessMutation(
+            mutation_type=MutationType.PROMPT_FRAGMENT,
+            content="Always check edge cases",
+        )
+        result = evaluate_mutation(m)
+        assert not result.approved
+        assert "target_role" in result.reason
+
+    def test_reject_context_policy_without_component(self) -> None:
+        from autocontext.harness.mutations.gate import evaluate_mutation
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        m = HarnessMutation(
+            mutation_type=MutationType.CONTEXT_POLICY,
+            content="include_last_5",
+        )
+        result = evaluate_mutation(m)
+        assert not result.approved
+        assert "component" in result.reason
+
+    def test_reject_tool_instruction_without_tool_name(self) -> None:
+        from autocontext.harness.mutations.gate import evaluate_mutation
+        from autocontext.harness.mutations.spec import HarnessMutation, MutationType
+
+        m = HarnessMutation(
+            mutation_type=MutationType.TOOL_INSTRUCTION,
+            content="Use normalized values",
+        )
+        result = evaluate_mutation(m)
+        assert not result.approved
+        assert "tool_name" in result.reason
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extends the architect role from tools/validators/tuning to a full harness mutation surface, inspired by Meta-Harness's TerminalBench work on searching over system prompts, tool definitions, and completion-checking logic.

### Four mutation types

| Type | Purpose | Example |
|---|---|---|
| `prompt_fragment` | Inject text into a role's prompt | "Always verify edge cases before submitting" |
| `context_policy` | Control what context is included/excluded | "include_last_5" for trajectory |
| `completion_check` | Add output validation checklist items | "Verify output contains valid JSON" |
| `tool_instruction` | Modify how a tool is described/used | "When using score_calculator, pass normalized values" |

### New `harness/mutations/` package (5 modules)

| Module | Purpose |
|---|---|
| `spec.py` | `HarnessMutation` dataclass + `MutationType` enum |
| `parser.py` | Extract from `<!-- MUTATIONS_START/END -->` markers in architect output |
| `store.py` | Versioned JSON persistence with rollback |
| `gate.py` | Evaluate mutations before promotion (empty/oversized rejected) |
| `applier.py` | Apply prompt_fragment mutations to role prompts; extract completion checks |

### Follow-ups

- Wire `parse_mutations` into architect output parser (`agents/parsers.py`)
- Wire `apply_mutations` into prompt assembly (`prompts/templates.py`)
- Add mutation visibility to `autoctx status` and operator dashboard
- TS parity

## Test plan

- [x] 22 tests: spec model (6), parser (4), store (4), gate (3), applier (5)
- [x] Ruff lint clean
- [x] All existing tests unaffected