### PR TITLE
refactor: extract generation attempt orchestration

### DIFF
--- a/ts/src/loop/generation-attempt-orchestrator.ts
+++ b/ts/src/loop/generation-attempt-orchestrator.ts
@@ -1,0 +1,108 @@
+import type { GenerationAttempt } from "./generation-attempt-state.js";
+import { buildGateDecidedPayload } from "./generation-event-coordinator.js";
+import {
+  recordAdvancedGenerationResult,
+  type GenerationLoopOrchestration,
+} from "./generation-loop-orchestrator.js";
+import {
+  applyGenerationPhaseDecision,
+  didAdvanceGenerationPhase,
+  markAwaitingCompetitorResult,
+  markAwaitingTournamentResult,
+  type GenerationPhaseState,
+} from "./generation-phase-state.js";
+import { updateGenerationCyclePhase } from "./generation-cycle-state.js";
+
+export interface GenerationAttemptOrchestration {
+  orchestration: GenerationLoopOrchestration;
+  phaseState: GenerationPhaseState;
+  events: {
+    gateDecided?: Record<string, unknown>;
+  };
+}
+
+export function createGenerationAttemptOrchestration(
+  orchestration: GenerationLoopOrchestration,
+  phaseState: GenerationPhaseState,
+): GenerationAttemptOrchestration {
+  return {
+    orchestration,
+    phaseState,
+    events: {},
+  };
+}
+
+export function awaitGenerationCompetitorResult(
+  attemptOrchestration: GenerationAttemptOrchestration,
+): GenerationAttemptOrchestration {
+  return withPhaseState(
+    attemptOrchestration,
+    markAwaitingCompetitorResult(attemptOrchestration.phaseState),
+  );
+}
+
+export function awaitGenerationTournamentResult(
+  attemptOrchestration: GenerationAttemptOrchestration,
+): GenerationAttemptOrchestration {
+  return withPhaseState(
+    attemptOrchestration,
+    markAwaitingTournamentResult(attemptOrchestration.phaseState),
+  );
+}
+
+export function finalizeGenerationAttemptDecision(
+  attemptOrchestration: GenerationAttemptOrchestration,
+  opts: {
+    runId: string;
+    generation: number;
+    attempt: GenerationAttempt;
+    delta: number;
+    threshold: number;
+  },
+): GenerationAttemptOrchestration {
+  let next = withPhaseState(
+    attemptOrchestration,
+    applyGenerationPhaseDecision(attemptOrchestration.phaseState, opts.attempt),
+  );
+
+  if (didAdvanceGenerationPhase(next.phaseState)) {
+    next = {
+      ...next,
+      orchestration: recordAdvancedGenerationResult(next.orchestration, {
+        generation: opts.generation,
+        bestScore: opts.attempt.tournamentResult.bestScore,
+        elo: opts.attempt.tournamentResult.elo,
+      }),
+    };
+  }
+
+  return {
+    ...next,
+    events: {
+      gateDecided: buildGateDecidedPayload(
+        opts.runId,
+        opts.generation,
+        opts.attempt.gateDecision,
+        opts.delta,
+        opts.threshold,
+      ),
+    },
+  };
+}
+
+function withPhaseState(
+  attemptOrchestration: GenerationAttemptOrchestration,
+  phaseState: GenerationPhaseState,
+): GenerationAttemptOrchestration {
+  return {
+    ...attemptOrchestration,
+    phaseState,
+    orchestration: {
+      ...attemptOrchestration.orchestration,
+      cycleState: updateGenerationCyclePhase(
+        attemptOrchestration.orchestration.cycleState,
+        phaseState,
+      ),
+    },
+  };
+}

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -37,10 +37,13 @@ import {
   buildCuratorPrompt,
   buildSupportPrompt,
 } from "./generation-prompts.js";
+import { buildTournamentCompletedPayload } from "./generation-event-coordinator.js";
 import {
-  buildGateDecidedPayload,
-  buildTournamentCompletedPayload,
-} from "./generation-event-coordinator.js";
+  awaitGenerationCompetitorResult,
+  awaitGenerationTournamentResult,
+  createGenerationAttemptOrchestration,
+  finalizeGenerationAttemptDecision,
+} from "./generation-attempt-orchestrator.js";
 import { GenerationJournal } from "./generation-journal.js";
 import {
   completeGenerationLoopRun,
@@ -48,30 +51,18 @@ import {
   failGenerationLoopRun,
   finalizeGenerationCycle,
   getActiveGenerationPhase,
-  recordAdvancedGenerationResult,
   startNextGeneration,
 } from "./generation-loop-orchestrator.js";
 import { GenerationRecovery } from "./generation-recovery.js";
+import { hasRemainingGenerationCycles } from "./generation-cycle-state.js";
 import {
-  hasRemainingGenerationCycles,
-  updateGenerationCyclePhase,
-} from "./generation-cycle-state.js";
-import {
-  applyGenerationPhaseDecision,
   canContinueGenerationPhase,
-  didAdvanceGenerationPhase,
   getFinalizedGenerationPhaseAttempt,
-  markAwaitingCompetitorResult,
-  markAwaitingTournamentResult,
   type GenerationAttempt,
 } from "./generation-phase-state.js";
 import {
-  completeGenerationRun,
   consumeFreshStartHint,
-  createGenerationRunState,
-  failGenerationRun,
   queueFreshStartHint,
-  recordGenerationResult,
   type GenerationRunState,
 } from "./generation-run-state.js";
 import { join } from "node:path";
@@ -219,10 +210,17 @@ export class GenerationRunner {
         this.emit("generation_started", orchestration.events.generationStarted!);
         this.emit("agents_started", orchestration.events.agentsStarted!);
 
+        let attemptOrchestration = createGenerationAttemptOrchestration(
+          orchestration,
+          phaseState,
+        );
+
         // Retry loop for this generation
         while (canContinueGenerationPhase(phaseState, this.#maxRetries)) {
           await this.#controller?.waitIfPaused();
-          phaseState = markAwaitingCompetitorResult(phaseState);
+          attemptOrchestration = awaitGenerationCompetitorResult(attemptOrchestration);
+          phaseState = attemptOrchestration.phaseState;
+          orchestration = attemptOrchestration.orchestration;
           const competitorPrompt = this.buildCompetitorPrompt(runId);
 
           // Step 1: Get strategy from provider (competitor role)
@@ -239,7 +237,9 @@ export class GenerationRunner {
 
           // Step 2: Run tournament
           await this.#controller?.waitIfPaused();
-          phaseState = markAwaitingTournamentResult(phaseState);
+          attemptOrchestration = awaitGenerationTournamentResult(attemptOrchestration);
+          phaseState = attemptOrchestration.phaseState;
+          orchestration = attemptOrchestration.orchestration;
           const seedForGen = this.#seedBase + (gen - 1) * this.#matchesPerGeneration;
           const tournament = new TournamentRunner(this.#scenario, {
             matchCount: this.#matchesPerGeneration,
@@ -281,31 +281,20 @@ export class GenerationRunner {
             tournamentResult,
             gateDecision,
           };
-          this.emit(
-            "gate_decided",
-            buildGateDecidedPayload(
+          attemptOrchestration = finalizeGenerationAttemptDecision(
+            attemptOrchestration,
+            {
               runId,
-              gen,
-              gateDecision,
-              decision.delta,
-              decision.threshold,
-            ),
-          );
-
-          phaseState = applyGenerationPhaseDecision(phaseState, attempt);
-          orchestration = {
-            ...orchestration,
-            cycleState: updateGenerationCyclePhase(orchestration.cycleState, phaseState),
-          };
-
-          if (didAdvanceGenerationPhase(phaseState)) {
-            orchestration = recordAdvancedGenerationResult(orchestration, {
               generation: gen,
-              bestScore: tournamentResult.bestScore,
-              elo: tournamentResult.elo,
-            });
-            this.#runState = orchestration.runState;
-          }
+              attempt,
+              delta: decision.delta,
+              threshold: decision.threshold,
+            },
+          );
+          phaseState = attemptOrchestration.phaseState;
+          orchestration = attemptOrchestration.orchestration;
+          this.#runState = orchestration.runState;
+          this.emit("gate_decided", attemptOrchestration.events.gateDecided!);
         }
 
         const finalizedAttempt = getFinalizedGenerationPhaseAttempt(phaseState);

--- a/ts/tests/generation-attempt-orchestrator.test.ts
+++ b/ts/tests/generation-attempt-orchestrator.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import type { GenerationAttempt } from "../src/loop/generation-attempt-state.js";
+import {
+  awaitGenerationCompetitorResult,
+  awaitGenerationTournamentResult,
+  createGenerationAttemptOrchestration,
+  finalizeGenerationAttemptDecision,
+} from "../src/loop/generation-attempt-orchestrator.js";
+import {
+  createGenerationLoopOrchestration,
+  getActiveGenerationPhase,
+  startNextGeneration,
+} from "../src/loop/generation-loop-orchestrator.js";
+
+function makeAttempt(
+  gateDecision: GenerationAttempt["gateDecision"],
+  bestScore: number,
+  elo = 1000 + bestScore * 100,
+): GenerationAttempt {
+  return {
+    competitorPrompt: "prompt",
+    competitorResultText: '{"aggression":0.5}',
+    strategy: { aggression: 0.5 },
+    tournamentResult: {
+      matches: [],
+      meanScore: bestScore,
+      bestScore,
+      wins: 1,
+      losses: 0,
+      elo,
+    },
+    gateDecision,
+  };
+}
+
+describe("generation attempt orchestrator", () => {
+  function createStartedAttemptOrchestration() {
+    const orchestration = startNextGeneration(
+      createGenerationLoopOrchestration({
+        runId: "run-1",
+        scenarioName: "grid_ctf",
+        targetGenerations: 2,
+        startedAtMs: 100,
+      }),
+      false,
+    );
+
+    return createGenerationAttemptOrchestration(
+      orchestration,
+      getActiveGenerationPhase(orchestration),
+    );
+  }
+
+  it("marks the active generation as awaiting competitor result", () => {
+    const attemptOrchestration = awaitGenerationCompetitorResult(
+      createStartedAttemptOrchestration(),
+    );
+
+    expect(attemptOrchestration.phaseState.phase).toBe("awaiting_competitor_result");
+    expect(
+      attemptOrchestration.orchestration.cycleState.activeGeneration?.phase,
+    ).toBe("awaiting_competitor_result");
+  });
+
+  it("marks the active generation as awaiting tournament result", () => {
+    const attemptOrchestration = awaitGenerationTournamentResult(
+      awaitGenerationCompetitorResult(createStartedAttemptOrchestration()),
+    );
+
+    expect(attemptOrchestration.phaseState.phase).toBe("awaiting_tournament_result");
+    expect(
+      attemptOrchestration.orchestration.cycleState.activeGeneration?.phase,
+    ).toBe("awaiting_tournament_result");
+  });
+
+  it("applies retry decisions without advancing run results", () => {
+    const attemptOrchestration = finalizeGenerationAttemptDecision(
+      awaitGenerationTournamentResult(
+        awaitGenerationCompetitorResult(createStartedAttemptOrchestration()),
+      ),
+      {
+        runId: "run-1",
+        generation: 1,
+        attempt: makeAttempt("retry", 0.51, 1020),
+        delta: 0.001,
+        threshold: 0.005,
+      },
+    );
+
+    expect(attemptOrchestration.phaseState.phase).toBe("gate_decided");
+    expect(attemptOrchestration.phaseState.attemptState.retryCount).toBe(1);
+    expect(attemptOrchestration.orchestration.runState.bestScore).toBe(0);
+    expect(attemptOrchestration.events.gateDecided).toEqual({
+      run_id: "run-1",
+      generation: 1,
+      decision: "retry",
+      delta: 0.001,
+      threshold: 0.005,
+    });
+  });
+
+  it("applies advance decisions and records generation results", () => {
+    const attemptOrchestration = finalizeGenerationAttemptDecision(
+      awaitGenerationTournamentResult(
+        awaitGenerationCompetitorResult(createStartedAttemptOrchestration()),
+      ),
+      {
+        runId: "run-1",
+        generation: 1,
+        attempt: makeAttempt("advance", 0.72, 1088),
+        delta: 0.22,
+        threshold: 0.005,
+      },
+    );
+
+    expect(attemptOrchestration.phaseState.phase).toBe("finalized");
+    expect(attemptOrchestration.orchestration.runState.bestScore).toBe(0.72);
+    expect(attemptOrchestration.orchestration.runState.currentElo).toBe(1088);
+    expect(attemptOrchestration.events.gateDecided).toEqual({
+      run_id: "run-1",
+      generation: 1,
+      decision: "advance",
+      delta: 0.22,
+      threshold: 0.005,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract the per-attempt control-flow surface inside each generation into a dedicated orchestration helper
- coordinate active phase updates, gate decision payload emission, and advanced-result propagation through a pure module
- keep runtime behavior stable while reducing inline attempt bookkeeping in `GenerationRunner`

## TDD / DDD / DRY framing
This continues the GenerationRunner state-model track after #670.

Bounded context extracted:
- **Generation Attempt Orchestration** — competitor/tournament/gate phase coordination for a single attempt within a generation

Test-first work:
- added attempt orchestration tests first
- implemented a pure attempt orchestration helper
- rewired `GenerationRunner` to delegate attempt-phase updates and gate bookkeeping

## Changes
### New module
- `ts/src/loop/generation-attempt-orchestrator.ts`
  - `createGenerationAttemptOrchestration`
  - `awaitGenerationCompetitorResult`
  - `awaitGenerationTournamentResult`
  - `finalizeGenerationAttemptDecision`

### Runner integration
- `ts/src/loop/generation-runner.ts`
  - now delegates per-attempt phase transitions and gate-decision bookkeeping to the extracted module

### New tests
- `ts/tests/generation-attempt-orchestrator.test.ts`

## Validation
- `cd ts && npx vitest run tests/generation-attempt-orchestrator.test.ts tests/generation-loop-orchestrator.test.ts tests/generation-event-coordinator.test.ts tests/generation-cycle-state.test.ts tests/generation-phase-state.test.ts tests/generation-attempt-state.test.ts tests/generation-run-state.test.ts tests/generation-recovery.test.ts tests/generation-journal.test.ts tests/generation-loop.test.ts tests/generation-runner-prompts.test.ts`
- `cd ts && npm run lint`

## Follow-up
The next incremental step would be consolidating the remaining inline tournament/match event sequencing behind a more explicit event-driven transition API, further shrinking the imperative body of `GenerationRunner` without a risky whole-loop rewrite.
