### PR TITLE
refactor: extract generation tournament event sequencing

### DIFF
--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -37,13 +37,13 @@ import {
   buildCuratorPrompt,
   buildSupportPrompt,
 } from "./generation-prompts.js";
-import { buildTournamentCompletedPayload } from "./generation-event-coordinator.js";
 import {
   awaitGenerationCompetitorResult,
   awaitGenerationTournamentResult,
   createGenerationAttemptOrchestration,
   finalizeGenerationAttemptDecision,
 } from "./generation-attempt-orchestrator.js";
+import { buildGenerationTournamentEventSequence } from "./generation-tournament-event-sequencing.js";
 import { GenerationJournal } from "./generation-journal.js";
 import {
   completeGenerationLoopRun,
@@ -246,25 +246,15 @@ export class GenerationRunner {
             seedBase: seedForGen,
             initialElo: this.#runState.currentElo,
           });
-          this.emit("tournament_started", {
-            run_id: runId,
-            generation: gen,
-            matches: this.#matchesPerGeneration,
-          });
           const tournamentResult = tournament.run(strategy);
-          tournamentResult.matches.forEach((match, matchIndex) => {
-            this.emit("match_completed", {
-              run_id: runId,
-              generation: gen,
-              match_index: matchIndex,
-              score: match.score,
-              winner: match.winner ?? "",
-            });
-          });
-          this.emit(
-            "tournament_completed",
-            buildTournamentCompletedPayload(runId, gen, tournamentResult),
-          );
+          for (const event of buildGenerationTournamentEventSequence({
+            runId,
+            generation: gen,
+            scheduledMatches: this.#matchesPerGeneration,
+            tournamentResult,
+          })) {
+            this.emit(event.event, event.payload);
+          }
 
           // Step 3: Backpressure gate
           const decision = this.#gate.evaluate(

--- a/ts/src/loop/generation-tournament-event-sequencing.ts
+++ b/ts/src/loop/generation-tournament-event-sequencing.ts
@@ -1,0 +1,67 @@
+import type { TournamentResult } from "../execution/tournament.js";
+import { buildTournamentCompletedPayload } from "./generation-event-coordinator.js";
+
+export interface GenerationLoopEventSequenceItem {
+  event: string;
+  payload: Record<string, unknown>;
+}
+
+export function buildGenerationTournamentEventSequence(opts: {
+  runId: string;
+  generation: number;
+  scheduledMatches: number;
+  tournamentResult: TournamentResult;
+}): GenerationLoopEventSequenceItem[] {
+  return [
+    buildTournamentStartedEvent(opts.runId, opts.generation, opts.scheduledMatches),
+    ...opts.tournamentResult.matches.map((match, matchIndex) =>
+      buildMatchCompletedEvent(opts.runId, opts.generation, matchIndex, match.score, match.winner),
+    ),
+    buildTournamentCompletedEvent(opts.runId, opts.generation, opts.tournamentResult),
+  ];
+}
+
+function buildTournamentStartedEvent(
+  runId: string,
+  generation: number,
+  scheduledMatches: number,
+): GenerationLoopEventSequenceItem {
+  return {
+    event: "tournament_started",
+    payload: {
+      run_id: runId,
+      generation,
+      matches: scheduledMatches,
+    },
+  };
+}
+
+function buildMatchCompletedEvent(
+  runId: string,
+  generation: number,
+  matchIndex: number,
+  score: number,
+  winner: string | null,
+): GenerationLoopEventSequenceItem {
+  return {
+    event: "match_completed",
+    payload: {
+      run_id: runId,
+      generation,
+      match_index: matchIndex,
+      score,
+      winner: winner ?? "",
+    },
+  };
+}
+
+function buildTournamentCompletedEvent(
+  runId: string,
+  generation: number,
+  tournamentResult: TournamentResult,
+): GenerationLoopEventSequenceItem {
+  return {
+    event: "tournament_completed",
+    payload: buildTournamentCompletedPayload(runId, generation, tournamentResult),
+  };
+}

--- a/ts/tests/generation-tournament-event-sequencing.test.ts
+++ b/ts/tests/generation-tournament-event-sequencing.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGenerationTournamentEventSequence } from "../src/loop/generation-tournament-event-sequencing.js";
+
+describe("generation tournament event sequencing", () => {
+  it("builds tournament lifecycle events in emission order", () => {
+    const events = buildGenerationTournamentEventSequence({
+      runId: "run-1",
+      generation: 2,
+      scheduledMatches: 3,
+      tournamentResult: {
+        matches: [
+          {
+            seed: 100,
+            score: 0.4,
+            winner: "challenger",
+            passedValidation: true,
+            validationErrors: [],
+            replay: [],
+          },
+          {
+            seed: 101,
+            score: 0.7,
+            winner: null,
+            passedValidation: true,
+            validationErrors: [],
+            replay: [],
+          },
+        ],
+        meanScore: 0.55,
+        bestScore: 0.7,
+        wins: 1,
+        losses: 1,
+        elo: 1042,
+      },
+    });
+
+    expect(events).toEqual([
+      {
+        event: "tournament_started",
+        payload: {
+          run_id: "run-1",
+          generation: 2,
+          matches: 3,
+        },
+      },
+      {
+        event: "match_completed",
+        payload: {
+          run_id: "run-1",
+          generation: 2,
+          match_index: 0,
+          score: 0.4,
+          winner: "challenger",
+        },
+      },
+      {
+        event: "match_completed",
+        payload: {
+          run_id: "run-1",
+          generation: 2,
+          match_index: 1,
+          score: 0.7,
+          winner: "",
+        },
+      },
+      {
+        event: "tournament_completed",
+        payload: {
+          run_id: "run-1",
+          generation: 2,
+          mean_score: 0.55,
+          best_score: 0.7,
+          wins: 1,
+          losses: 1,
+        },
+      },
+    ]);
+  });
+
+  it("still emits start and completion events when no matches are present", () => {
+    const events = buildGenerationTournamentEventSequence({
+      runId: "run-2",
+      generation: 1,
+      scheduledMatches: 0,
+      tournamentResult: {
+        matches: [],
+        meanScore: 0,
+        bestScore: 0,
+        wins: 0,
+        losses: 0,
+        elo: 1000,
+      },
+    });
+
+    expect(events).toEqual([
+      {
+        event: "tournament_started",
+        payload: {
+          run_id: "run-2",
+          generation: 1,
+          matches: 0,
+        },
+      },
+      {
+        event: "tournament_completed",
+        payload: {
+          run_id: "run-2",
+          generation: 1,
+          mean_score: 0,
+          best_score: 0,
+          wins: 0,
+          losses: 0,
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- extract tournament and match event sequencing from `GenerationRunner` into a dedicated pure helper module
- centralize tournament_started, match_completed, and tournament_completed event construction in one bounded surface
- keep runtime behavior stable while reducing inline event sequencing logic in the runner

## TDD / DDD / DRY framing
This continues the GenerationRunner state-model/event-sequencing track after #671.

Bounded context extracted:
- **Generation Tournament Event Sequencing** — event ordering and payload shaping for tournament lifecycle emissions within a generation attempt

Test-first work:
- added tournament event sequencing tests first
- implemented a pure event-sequencing helper
- rewired `GenerationRunner` to emit the returned event sequence

## Changes
### New module
- `ts/src/loop/generation-tournament-event-sequencing.ts`
  - `buildGenerationTournamentEventSequence`

### Runner integration
- `ts/src/loop/generation-runner.ts`
  - now delegates tournament lifecycle event sequence construction to the extracted helper

### New tests
- `ts/tests/generation-tournament-event-sequencing.test.ts`

## Validation
- `cd ts && npx vitest run tests/generation-tournament-event-sequencing.test.ts tests/generation-attempt-orchestrator.test.ts tests/generation-loop-orchestrator.test.ts tests/generation-event-coordinator.test.ts tests/generation-cycle-state.test.ts tests/generation-phase-state.test.ts tests/generation-attempt-state.test.ts tests/generation-run-state.test.ts tests/generation-recovery.test.ts tests/generation-journal.test.ts tests/generation-loop.test.ts tests/generation-runner-prompts.test.ts`
- `cd ts && npm run lint`

## Follow-up
The next incremental step would be extracting the remaining inline provider/tournament execution choreography behind a more explicit run-step coordinator, so `GenerationRunner` mostly composes orchestrators plus side-effect boundaries.
