### PR TITLE
refactor: extract generation execution step coordination

### DIFF
--- a/ts/src/loop/generation-execution-step.ts
+++ b/ts/src/loop/generation-execution-step.ts
@@ -1,0 +1,48 @@
+import type { GenerationAttempt } from "./generation-attempt-state.js";
+
+export const DEFAULT_COMPETITOR_STRATEGY = {
+  aggression: 0.5,
+  defense: 0.5,
+  path_bias: 0.5,
+} as const;
+
+export function parseCompetitorStrategyResult(
+  competitorResultText: string,
+): Record<string, unknown> {
+  try {
+    return JSON.parse(competitorResultText) as Record<string, unknown>;
+  } catch {
+    return { ...DEFAULT_COMPETITOR_STRATEGY };
+  }
+}
+
+export function createTournamentExecutionPlan(opts: {
+  generation: number;
+  seedBase: number;
+  matchesPerGeneration: number;
+  currentElo: number;
+}): {
+  seedForGeneration: number;
+  tournamentOptions: {
+    matchCount: number;
+    seedBase: number;
+    initialElo: number;
+  };
+} {
+  const seedForGeneration = opts.seedBase + (opts.generation - 1) * opts.matchesPerGeneration;
+
+  return {
+    seedForGeneration,
+    tournamentOptions: {
+      matchCount: opts.matchesPerGeneration,
+      seedBase: seedForGeneration,
+      initialElo: opts.currentElo,
+    },
+  };
+}
+
+export function buildGenerationAttemptCandidate(
+  attempt: GenerationAttempt,
+): GenerationAttempt {
+  return attempt;
+}

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -43,6 +43,11 @@ import {
   createGenerationAttemptOrchestration,
   finalizeGenerationAttemptDecision,
 } from "./generation-attempt-orchestrator.js";
+import {
+  buildGenerationAttemptCandidate,
+  createTournamentExecutionPlan,
+  parseCompetitorStrategyResult,
+} from "./generation-execution-step.js";
 import { buildGenerationTournamentEventSequence } from "./generation-tournament-event-sequencing.js";
 import { GenerationJournal } from "./generation-journal.js";
 import {
@@ -228,24 +233,23 @@ export class GenerationRunner {
           const competitorResult = await this.completeRole("competitor", competitorPrompt);
           this.emitRoleCompleted("competitor", competitorStartedAt, competitorResult.usage);
 
-          let strategy: Record<string, unknown>;
-          try {
-            strategy = JSON.parse(competitorResult.text);
-          } catch {
-            strategy = { aggression: 0.5, defense: 0.5, path_bias: 0.5 };
-          }
+          const strategy = parseCompetitorStrategyResult(competitorResult.text);
 
           // Step 2: Run tournament
           await this.#controller?.waitIfPaused();
           attemptOrchestration = awaitGenerationTournamentResult(attemptOrchestration);
           phaseState = attemptOrchestration.phaseState;
           orchestration = attemptOrchestration.orchestration;
-          const seedForGen = this.#seedBase + (gen - 1) * this.#matchesPerGeneration;
-          const tournament = new TournamentRunner(this.#scenario, {
-            matchCount: this.#matchesPerGeneration,
-            seedBase: seedForGen,
-            initialElo: this.#runState.currentElo,
+          const tournamentPlan = createTournamentExecutionPlan({
+            generation: gen,
+            seedBase: this.#seedBase,
+            matchesPerGeneration: this.#matchesPerGeneration,
+            currentElo: this.#runState.currentElo,
           });
+          const tournament = new TournamentRunner(
+            this.#scenario,
+            tournamentPlan.tournamentOptions,
+          );
           const tournamentResult = tournament.run(strategy);
           for (const event of buildGenerationTournamentEventSequence({
             runId,
@@ -264,13 +268,13 @@ export class GenerationRunner {
             this.#maxRetries,
           );
           const gateDecision = this.#controller?.takeGateOverride() as GenerationAttempt["gateDecision"] | null ?? decision.decision;
-          const attempt: GenerationAttempt = {
+          const attempt: GenerationAttempt = buildGenerationAttemptCandidate({
             competitorPrompt,
             competitorResultText: competitorResult.text,
             strategy,
             tournamentResult,
             gateDecision,
-          };
+          });
           attemptOrchestration = finalizeGenerationAttemptDecision(
             attemptOrchestration,
             {

--- a/ts/tests/generation-execution-step.test.ts
+++ b/ts/tests/generation-execution-step.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGenerationAttemptCandidate,
+  createTournamentExecutionPlan,
+  DEFAULT_COMPETITOR_STRATEGY,
+  parseCompetitorStrategyResult,
+} from "../src/loop/generation-execution-step.js";
+
+describe("generation execution step", () => {
+  it("parses competitor strategy JSON when valid", () => {
+    expect(
+      parseCompetitorStrategyResult('{"aggression":0.8,"defense":0.4,"path_bias":0.2}'),
+    ).toEqual({
+      aggression: 0.8,
+      defense: 0.4,
+      path_bias: 0.2,
+    });
+  });
+
+  it("falls back to the default strategy when competitor output is invalid", () => {
+    expect(parseCompetitorStrategyResult("not-json")).toEqual(
+      DEFAULT_COMPETITOR_STRATEGY,
+    );
+  });
+
+  it("creates tournament execution plan from generation context", () => {
+    expect(
+      createTournamentExecutionPlan({
+        generation: 3,
+        seedBase: 1000,
+        matchesPerGeneration: 4,
+        currentElo: 1075,
+      }),
+    ).toEqual({
+      seedForGeneration: 1008,
+      tournamentOptions: {
+        matchCount: 4,
+        seedBase: 1008,
+        initialElo: 1075,
+      },
+    });
+  });
+
+  it("builds a generation attempt candidate from execution outputs", () => {
+    const tournamentResult = {
+      matches: [],
+      meanScore: 0.66,
+      bestScore: 0.71,
+      wins: 2,
+      losses: 1,
+      elo: 1033,
+    };
+
+    expect(
+      buildGenerationAttemptCandidate({
+        competitorPrompt: "prompt",
+        competitorResultText: '{"aggression":0.6}',
+        strategy: { aggression: 0.6 },
+        tournamentResult,
+        gateDecision: "advance",
+      }),
+    ).toEqual({
+      competitorPrompt: "prompt",
+      competitorResultText: '{"aggression":0.6}',
+      strategy: { aggression: 0.6 },
+      tournamentResult,
+      gateDecision: "advance",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract the remaining pure execution-step bookkeeping for a generation attempt into a dedicated helper module
- centralize competitor strategy parsing, tournament execution plan creation, and attempt candidate assembly
- keep runtime behavior stable while shrinking imperative execution setup logic in `GenerationRunner`

## TDD / DDD / DRY framing
This continues the GenerationRunner orchestration track after #672.

Bounded context extracted:
- **Generation Execution Step Coordination** — pure setup and assembly logic for competitor output parsing, tournament execution inputs, and attempt candidate creation inside one generation attempt

Test-first work:
- added execution-step tests first
- implemented a pure execution-step helper
- rewired `GenerationRunner` to delegate strategy parsing, tournament plan creation, and attempt candidate assembly

## Changes
### New module
- `ts/src/loop/generation-execution-step.ts`
  - `DEFAULT_COMPETITOR_STRATEGY`
  - `parseCompetitorStrategyResult`
  - `createTournamentExecutionPlan`
  - `buildGenerationAttemptCandidate`

### Runner integration
- `ts/src/loop/generation-runner.ts`
  - now delegates pure execution-step setup logic to the extracted helper

### New tests
- `ts/tests/generation-execution-step.test.ts`

## Validation
- `cd ts && npx vitest run tests/generation-execution-step.test.ts tests/generation-tournament-event-sequencing.test.ts tests/generation-attempt-orchestrator.test.ts tests/generation-loop-orchestrator.test.ts tests/generation-event-coordinator.test.ts tests/generation-cycle-state.test.ts tests/generation-phase-state.test.ts tests/generation-attempt-state.test.ts tests/generation-run-state.test.ts tests/generation-recovery.test.ts tests/generation-journal.test.ts tests/generation-loop.test.ts tests/generation-runner-prompts.test.ts`
- `cd ts && npm run lint`

## Follow-up
The next incremental step would be a higher-level provider/tournament side-effect coordinator that wraps provider completion timing plus tournament execution invocation behind a single boundary, further reducing the imperative body of `GenerationRunner` before any fuller state-machine facade.
