### PR TITLE
refactor: extract generation side-effect coordination

### DIFF
--- a/ts/src/loop/generation-execution-step.ts
+++ b/ts/src/loop/generation-execution-step.ts
@@ -16,19 +16,21 @@ export function parseCompetitorStrategyResult(
   }
 }
 
-export function createTournamentExecutionPlan(opts: {
-  generation: number;
-  seedBase: number;
-  matchesPerGeneration: number;
-  currentElo: number;
-}): {
+export interface TournamentExecutionPlan {
   seedForGeneration: number;
   tournamentOptions: {
     matchCount: number;
     seedBase: number;
     initialElo: number;
   };
-} {
+}
+
+export function createTournamentExecutionPlan(opts: {
+  generation: number;
+  seedBase: number;
+  matchesPerGeneration: number;
+  currentElo: number;
+}): TournamentExecutionPlan {
   const seedForGeneration = opts.seedBase + (opts.generation - 1) * opts.matchesPerGeneration;
 
   return {

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -48,7 +48,11 @@ import {
   createTournamentExecutionPlan,
   parseCompetitorStrategyResult,
 } from "./generation-execution-step.js";
-import { buildGenerationTournamentEventSequence } from "./generation-tournament-event-sequencing.js";
+import {
+  buildRoleCompletedPayload,
+  executeRoleCompletionSideEffect,
+  executeTournamentSideEffect,
+} from "./generation-side-effect-coordinator.js";
 import { GenerationJournal } from "./generation-journal.js";
 import {
   completeGenerationLoopRun,
@@ -229,9 +233,12 @@ export class GenerationRunner {
           const competitorPrompt = this.buildCompetitorPrompt(runId);
 
           // Step 1: Get strategy from provider (competitor role)
-          const competitorStartedAt = Date.now();
-          const competitorResult = await this.completeRole("competitor", competitorPrompt);
-          this.emitRoleCompleted("competitor", competitorStartedAt, competitorResult.usage);
+          const competitorCompletion = await executeRoleCompletionSideEffect({
+            role: "competitor",
+            execute: () => this.completeRole("competitor", competitorPrompt),
+          });
+          const competitorResult = competitorCompletion.result;
+          this.emit("role_completed", competitorCompletion.roleCompletedPayload);
 
           const strategy = parseCompetitorStrategyResult(competitorResult.text);
 
@@ -246,17 +253,17 @@ export class GenerationRunner {
             matchesPerGeneration: this.#matchesPerGeneration,
             currentElo: this.#runState.currentElo,
           });
-          const tournament = new TournamentRunner(
-            this.#scenario,
-            tournamentPlan.tournamentOptions,
-          );
-          const tournamentResult = tournament.run(strategy);
-          for (const event of buildGenerationTournamentEventSequence({
+          const tournamentExecution = executeTournamentSideEffect({
             runId,
             generation: gen,
             scheduledMatches: this.#matchesPerGeneration,
-            tournamentResult,
-          })) {
+            executionPlan: tournamentPlan,
+            strategy,
+            executeTournament: ({ strategy: nextStrategy, tournamentOptions }) =>
+              new TournamentRunner(this.#scenario, tournamentOptions).run(nextStrategy),
+          });
+          const tournamentResult = tournamentExecution.tournamentResult;
+          for (const event of tournamentExecution.events) {
             this.emit(event.event, event.payload);
           }
 
@@ -648,13 +655,10 @@ export class GenerationRunner {
     startedAt: number,
     usage: Record<string, number>,
   ): void {
-    const inputTokens = usage.input_tokens ?? usage.inputTokens ?? 0;
-    const outputTokens = usage.output_tokens ?? usage.outputTokens ?? 0;
-    this.emit("role_completed", {
-      role,
-      latency_ms: Date.now() - startedAt,
-      tokens: inputTokens + outputTokens,
-    });
+    this.emit(
+      "role_completed",
+      buildRoleCompletedPayload(role, Date.now() - startedAt, usage),
+    );
   }
 }
 

--- a/ts/src/loop/generation-side-effect-coordinator.ts
+++ b/ts/src/loop/generation-side-effect-coordinator.ts
@@ -1,0 +1,78 @@
+import type { TournamentOpts, TournamentResult } from "../execution/tournament.js";
+import type { CompletionResult } from "../types/index.js";
+import type { GenerationRole } from "../providers/index.js";
+import type { TournamentExecutionPlan } from "./generation-execution-step.js";
+import {
+  buildGenerationTournamentEventSequence,
+  type GenerationLoopEventSequenceItem,
+} from "./generation-tournament-event-sequencing.js";
+
+export type { GenerationLoopEventSequenceItem };
+
+export function buildRoleCompletedPayload(
+  role: "competitor" | "analyst" | "coach" | "curator",
+  latencyMs: number,
+  usage: Record<string, number>,
+): Record<string, unknown> {
+  const inputTokens = usage.input_tokens ?? usage.inputTokens ?? 0;
+  const outputTokens = usage.output_tokens ?? usage.outputTokens ?? 0;
+
+  return {
+    role,
+    latency_ms: latencyMs,
+    tokens: inputTokens + outputTokens,
+  };
+}
+
+export async function executeRoleCompletionSideEffect(opts: {
+  role: "competitor" | "analyst" | "coach" | "curator";
+  execute: () => Promise<CompletionResult>;
+  now?: () => number;
+}): Promise<{
+  result: CompletionResult;
+  roleCompletedPayload: Record<string, unknown>;
+}> {
+  const now = opts.now ?? Date.now;
+  const startedAt = now();
+  const result = await opts.execute();
+  const finishedAt = now();
+
+  return {
+    result,
+    roleCompletedPayload: buildRoleCompletedPayload(
+      opts.role,
+      finishedAt - startedAt,
+      result.usage,
+    ),
+  };
+}
+
+export function executeTournamentSideEffect(opts: {
+  runId: string;
+  generation: number;
+  scheduledMatches: number;
+  executionPlan: TournamentExecutionPlan;
+  strategy: Record<string, unknown>;
+  executeTournament: (input: {
+    strategy: Record<string, unknown>;
+    tournamentOptions: TournamentOpts;
+  }) => TournamentResult;
+}): {
+  tournamentResult: TournamentResult;
+  events: GenerationLoopEventSequenceItem[];
+} {
+  const tournamentResult = opts.executeTournament({
+    strategy: opts.strategy,
+    tournamentOptions: opts.executionPlan.tournamentOptions,
+  });
+
+  return {
+    tournamentResult,
+    events: buildGenerationTournamentEventSequence({
+      runId: opts.runId,
+      generation: opts.generation,
+      scheduledMatches: opts.scheduledMatches,
+      tournamentResult,
+    }),
+  };
+}

--- a/ts/tests/generation-side-effect-coordinator.test.ts
+++ b/ts/tests/generation-side-effect-coordinator.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import type { TournamentOpts } from "../src/execution/tournament.js";
+import {
+  buildRoleCompletedPayload,
+  executeRoleCompletionSideEffect,
+  executeTournamentSideEffect,
+  type GenerationLoopEventSequenceItem,
+} from "../src/loop/generation-side-effect-coordinator.js";
+import type { TournamentExecutionPlan } from "../src/loop/generation-execution-step.js";
+
+describe("generation side-effect coordinator", () => {
+  it("builds role completion payloads from mixed usage token formats", () => {
+    expect(
+      buildRoleCompletedPayload("competitor", 125, {
+        input_tokens: 2,
+        outputTokens: 5,
+      }),
+    ).toEqual({
+      role: "competitor",
+      latency_ms: 125,
+      tokens: 7,
+    });
+  });
+
+  it("executes role completion and reports timing metadata", async () => {
+    const marks = [1000, 1145];
+
+    const completed = await executeRoleCompletionSideEffect({
+      role: "competitor",
+      execute: async () => ({
+        text: '{"aggression":0.7}',
+        model: "test-model",
+        usage: { inputTokens: 3, output_tokens: 4 },
+      }),
+      now: () => marks.shift() ?? 1145,
+    });
+
+    expect(completed.result.text).toBe('{"aggression":0.7}');
+    expect(completed.roleCompletedPayload).toEqual({
+      role: "competitor",
+      latency_ms: 145,
+      tokens: 7,
+    });
+  });
+
+  it("executes tournament side effects using the prepared execution plan", () => {
+    const executionPlan: TournamentExecutionPlan = {
+      seedForGeneration: 1006,
+      tournamentOptions: {
+        matchCount: 3,
+        seedBase: 1006,
+        initialElo: 1040,
+      },
+    };
+    const strategy = { aggression: 0.6 };
+    const calls: Array<Record<string, unknown>> = [];
+
+    const tournament = executeTournamentSideEffect({
+      runId: "run-1",
+      generation: 2,
+      scheduledMatches: 3,
+      executionPlan,
+      strategy,
+      executeTournament: ({
+        strategy: nextStrategy,
+        tournamentOptions,
+      }: {
+        strategy: Record<string, unknown>;
+        tournamentOptions: TournamentOpts;
+      }) => {
+        calls.push({ strategy: nextStrategy, tournamentOptions });
+        return {
+          matches: [
+            {
+              seed: 1006,
+              score: 0.75,
+              winner: "challenger",
+              passedValidation: true,
+              validationErrors: [],
+              replay: [],
+            },
+          ],
+          meanScore: 0.75,
+          bestScore: 0.75,
+          wins: 1,
+          losses: 0,
+          elo: 1060,
+        };
+      },
+    });
+
+    expect(calls).toEqual([
+      {
+        strategy,
+        tournamentOptions: executionPlan.tournamentOptions,
+      },
+    ]);
+    expect(tournament.tournamentResult.bestScore).toBe(0.75);
+    expect(tournament.events.map((event: GenerationLoopEventSequenceItem) => event.event)).toEqual([
+      "tournament_started",
+      "match_completed",
+      "tournament_completed",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- extract provider-completion and tournament-execution side-effect wiring for generation attempts into a dedicated coordinator module
- centralize role completion payload shaping, provider timing metadata, and tournament execution/event sequencing handoff behind a single boundary
- keep runtime behavior stable while further shrinking the imperative body of `GenerationRunner`

## TDD / DDD / DRY framing
This continues the GenerationRunner orchestration track after #673.

Bounded context extracted:
- **Generation Side-Effect Coordination** — provider completion timing, role-completion payload shaping, and tournament execution handoff for a single generation attempt

Test-first work:
- added side-effect coordinator tests first
- implemented the side-effect coordinator module
- rewired `GenerationRunner` to delegate competitor completion and tournament execution side-effect wiring

## Changes
### New module
- `ts/src/loop/generation-side-effect-coordinator.ts`
  - `buildRoleCompletedPayload`
  - `executeRoleCompletionSideEffect`
  - `executeTournamentSideEffect`

### Supporting type cleanup
- `ts/src/loop/generation-execution-step.ts`
  - exports `TournamentExecutionPlan`

### Runner integration
- `ts/src/loop/generation-runner.ts`
  - now delegates competitor completion timing/payload handling to the side-effect coordinator
  - now delegates tournament execution/event handoff to the side-effect coordinator
  - reuses the shared role-completed payload builder for other role completions

### New tests
- `ts/tests/generation-side-effect-coordinator.test.ts`

## Validation
- `cd ts && npx vitest run tests/generation-side-effect-coordinator.test.ts tests/generation-execution-step.test.ts tests/generation-tournament-event-sequencing.test.ts tests/generation-attempt-orchestrator.test.ts tests/generation-loop-orchestrator.test.ts tests/generation-event-coordinator.test.ts tests/generation-cycle-state.test.ts tests/generation-phase-state.test.ts tests/generation-attempt-state.test.ts tests/generation-run-state.test.ts tests/generation-recovery.test.ts tests/generation-journal.test.ts tests/generation-loop.test.ts tests/generation-runner-prompts.test.ts`
- `cd ts && npm run lint`

## Follow-up
The next incremental step would be deciding whether `GenerationRunner` still merits a fuller event-driven facade now that run orchestration, attempt orchestration, tournament sequencing, execution-step setup, and side-effect coordination are separated into explicit modules.
