### PR TITLE
refactor: extract generation attempt workflow facade

### DIFF
--- a/ts/src/loop/generation-attempt-workflow.ts
+++ b/ts/src/loop/generation-attempt-workflow.ts
@@ -1,0 +1,128 @@
+import type { TournamentOpts, TournamentResult } from "../execution/tournament.js";
+import type { CompletionResult } from "../types/index.js";
+import {
+  awaitGenerationCompetitorResult,
+  awaitGenerationTournamentResult,
+  finalizeGenerationAttemptDecision,
+  type GenerationAttemptOrchestration,
+} from "./generation-attempt-orchestrator.js";
+import type { GenerationGateDecision } from "./generation-attempt-state.js";
+import {
+  buildGenerationAttemptCandidate,
+  createTournamentExecutionPlan,
+  parseCompetitorStrategyResult,
+} from "./generation-execution-step.js";
+import {
+  executeRoleCompletionSideEffect,
+  executeTournamentSideEffect,
+  type GenerationLoopEventSequenceItem,
+} from "./generation-side-effect-coordinator.js";
+
+export interface GenerationAttemptWorkflow {
+  attemptOrchestration: GenerationAttemptOrchestration;
+  runId: string;
+  generation: number;
+  competitorPrompt: string;
+  seedBase: number;
+  matchesPerGeneration: number;
+  currentElo: number;
+  executeCompetitor: () => Promise<CompletionResult>;
+  beforeTournament?: () => Promise<void>;
+  executeTournament: (input: {
+    strategy: Record<string, unknown>;
+    tournamentOptions: TournamentOpts;
+  }) => TournamentResult;
+  decideGate: (input: {
+    attemptOrchestration: GenerationAttemptOrchestration;
+    tournamentResult: TournamentResult;
+  }) => {
+    gateDecision: GenerationGateDecision;
+    delta: number;
+    threshold: number;
+  };
+}
+
+export function createGenerationAttemptWorkflow(
+  workflow: GenerationAttemptWorkflow,
+): GenerationAttemptWorkflow {
+  return workflow;
+}
+
+export async function runGenerationAttemptWorkflow(
+  workflow: GenerationAttemptWorkflow,
+): Promise<{
+  attemptOrchestration: GenerationAttemptOrchestration;
+  competitorResult: CompletionResult;
+  tournamentResult: TournamentResult;
+  attempt: ReturnType<typeof buildGenerationAttemptCandidate>;
+  events: GenerationLoopEventSequenceItem[];
+}> {
+  let attemptOrchestration = awaitGenerationCompetitorResult(
+    workflow.attemptOrchestration,
+  );
+
+  const competitorCompletion = await executeRoleCompletionSideEffect({
+    role: "competitor",
+    execute: workflow.executeCompetitor,
+  });
+  const competitorResult = competitorCompletion.result;
+  const strategy = parseCompetitorStrategyResult(competitorResult.text);
+
+  attemptOrchestration = awaitGenerationTournamentResult(attemptOrchestration);
+  await workflow.beforeTournament?.();
+
+  const tournamentPlan = createTournamentExecutionPlan({
+    generation: workflow.generation,
+    seedBase: workflow.seedBase,
+    matchesPerGeneration: workflow.matchesPerGeneration,
+    currentElo: workflow.currentElo,
+  });
+  const tournamentExecution = executeTournamentSideEffect({
+    runId: workflow.runId,
+    generation: workflow.generation,
+    scheduledMatches: workflow.matchesPerGeneration,
+    executionPlan: tournamentPlan,
+    strategy,
+    executeTournament: workflow.executeTournament,
+  });
+
+  const gateDecision = workflow.decideGate({
+    attemptOrchestration,
+    tournamentResult: tournamentExecution.tournamentResult,
+  });
+  const attempt = buildGenerationAttemptCandidate({
+    competitorPrompt: workflow.competitorPrompt,
+    competitorResultText: competitorResult.text,
+    strategy,
+    tournamentResult: tournamentExecution.tournamentResult,
+    gateDecision: gateDecision.gateDecision,
+  });
+  attemptOrchestration = finalizeGenerationAttemptDecision(
+    attemptOrchestration,
+    {
+      runId: workflow.runId,
+      generation: workflow.generation,
+      attempt,
+      delta: gateDecision.delta,
+      threshold: gateDecision.threshold,
+    },
+  );
+
+  return {
+    attemptOrchestration,
+    competitorResult,
+    tournamentResult: tournamentExecution.tournamentResult,
+    attempt,
+    events: [
+      {
+        event: "role_completed",
+        payload: competitorCompletion.roleCompletedPayload,
+      },
+      ...tournamentExecution.events,
+      {
+        event: "gate_decided",
+        payload: attemptOrchestration.events.gateDecided!,
+      },
+    ],
+  };
+}

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -37,22 +37,9 @@ import {
   buildCuratorPrompt,
   buildSupportPrompt,
 } from "./generation-prompts.js";
-import {
-  awaitGenerationCompetitorResult,
-  awaitGenerationTournamentResult,
-  createGenerationAttemptOrchestration,
-  finalizeGenerationAttemptDecision,
-} from "./generation-attempt-orchestrator.js";
-import {
-  buildGenerationAttemptCandidate,
-  createTournamentExecutionPlan,
-  parseCompetitorStrategyResult,
-} from "./generation-execution-step.js";
-import {
-  buildRoleCompletedPayload,
-  executeRoleCompletionSideEffect,
-  executeTournamentSideEffect,
-} from "./generation-side-effect-coordinator.js";
+import { createGenerationAttemptOrchestration } from "./generation-attempt-orchestrator.js";
+import { createGenerationAttemptWorkflow, runGenerationAttemptWorkflow } from "./generation-attempt-workflow.js";
+import { buildRoleCompletedPayload } from "./generation-side-effect-coordinator.js";
 import { GenerationJournal } from "./generation-journal.js";
 import {
   completeGenerationLoopRun,
@@ -227,75 +214,45 @@ export class GenerationRunner {
         // Retry loop for this generation
         while (canContinueGenerationPhase(phaseState, this.#maxRetries)) {
           await this.#controller?.waitIfPaused();
-          attemptOrchestration = awaitGenerationCompetitorResult(attemptOrchestration);
-          phaseState = attemptOrchestration.phaseState;
-          orchestration = attemptOrchestration.orchestration;
           const competitorPrompt = this.buildCompetitorPrompt(runId);
-
-          // Step 1: Get strategy from provider (competitor role)
-          const competitorCompletion = await executeRoleCompletionSideEffect({
-            role: "competitor",
-            execute: () => this.completeRole("competitor", competitorPrompt),
-          });
-          const competitorResult = competitorCompletion.result;
-          this.emit("role_completed", competitorCompletion.roleCompletedPayload);
-
-          const strategy = parseCompetitorStrategyResult(competitorResult.text);
-
-          // Step 2: Run tournament
-          await this.#controller?.waitIfPaused();
-          attemptOrchestration = awaitGenerationTournamentResult(attemptOrchestration);
-          phaseState = attemptOrchestration.phaseState;
-          orchestration = attemptOrchestration.orchestration;
-          const tournamentPlan = createTournamentExecutionPlan({
-            generation: gen,
-            seedBase: this.#seedBase,
-            matchesPerGeneration: this.#matchesPerGeneration,
-            currentElo: this.#runState.currentElo,
-          });
-          const tournamentExecution = executeTournamentSideEffect({
-            runId,
-            generation: gen,
-            scheduledMatches: this.#matchesPerGeneration,
-            executionPlan: tournamentPlan,
-            strategy,
-            executeTournament: ({ strategy: nextStrategy, tournamentOptions }) =>
-              new TournamentRunner(this.#scenario, tournamentOptions).run(nextStrategy),
-          });
-          const tournamentResult = tournamentExecution.tournamentResult;
-          for (const event of tournamentExecution.events) {
-            this.emit(event.event, event.payload);
-          }
-
-          // Step 3: Backpressure gate
-          const decision = this.#gate.evaluate(
-            orchestration.cycleState.previousBestOverall,
-            tournamentResult.bestScore,
-            phaseState.attemptState.retryCount,
-            this.#maxRetries,
-          );
-          const gateDecision = this.#controller?.takeGateOverride() as GenerationAttempt["gateDecision"] | null ?? decision.decision;
-          const attempt: GenerationAttempt = buildGenerationAttemptCandidate({
-            competitorPrompt,
-            competitorResultText: competitorResult.text,
-            strategy,
-            tournamentResult,
-            gateDecision,
-          });
-          attemptOrchestration = finalizeGenerationAttemptDecision(
-            attemptOrchestration,
-            {
+          const workflowResult = await runGenerationAttemptWorkflow(
+            createGenerationAttemptWorkflow({
+              attemptOrchestration,
               runId,
               generation: gen,
-              attempt,
-              delta: decision.delta,
-              threshold: decision.threshold,
-            },
+              competitorPrompt,
+              seedBase: this.#seedBase,
+              matchesPerGeneration: this.#matchesPerGeneration,
+              currentElo: this.#runState.currentElo,
+              executeCompetitor: () => this.completeRole("competitor", competitorPrompt),
+              beforeTournament: async () => {
+                await this.#controller?.waitIfPaused();
+              },
+              executeTournament: ({ strategy: nextStrategy, tournamentOptions }) =>
+                new TournamentRunner(this.#scenario, tournamentOptions).run(nextStrategy),
+              decideGate: ({ attemptOrchestration: currentAttemptOrchestration, tournamentResult }) => {
+                const decision = this.#gate.evaluate(
+                  currentAttemptOrchestration.orchestration.cycleState.previousBestOverall,
+                  tournamentResult.bestScore,
+                  currentAttemptOrchestration.phaseState.attemptState.retryCount,
+                  this.#maxRetries,
+                );
+                const gateDecision = this.#controller?.takeGateOverride() as GenerationAttempt["gateDecision"] | null ?? decision.decision;
+                return {
+                  gateDecision,
+                  delta: decision.delta,
+                  threshold: decision.threshold,
+                };
+              },
+            }),
           );
+          attemptOrchestration = workflowResult.attemptOrchestration;
           phaseState = attemptOrchestration.phaseState;
           orchestration = attemptOrchestration.orchestration;
           this.#runState = orchestration.runState;
-          this.emit("gate_decided", attemptOrchestration.events.gateDecided!);
+          for (const event of workflowResult.events) {
+            this.emit(event.event, event.payload);
+          }
         }
 
         const finalizedAttempt = getFinalizedGenerationPhaseAttempt(phaseState);

--- a/ts/tests/generation-attempt-workflow.test.ts
+++ b/ts/tests/generation-attempt-workflow.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import type { TournamentOpts } from "../src/execution/tournament.js";
+import type { CompletionResult } from "../src/types/index.js";
+import {
+  createGenerationAttemptWorkflow,
+  runGenerationAttemptWorkflow,
+} from "../src/loop/generation-attempt-workflow.js";
+import type { GenerationLoopEventSequenceItem } from "../src/loop/generation-side-effect-coordinator.js";
+import {
+  createGenerationLoopOrchestration,
+  getActiveGenerationPhase,
+  startNextGeneration,
+} from "../src/loop/generation-loop-orchestrator.js";
+
+describe("generation attempt workflow", () => {
+  function createStartedWorkflow() {
+    const orchestration = startNextGeneration(
+      createGenerationLoopOrchestration({
+        runId: "run-1",
+        scenarioName: "grid_ctf",
+        targetGenerations: 2,
+        startedAtMs: 100,
+      }),
+      false,
+    );
+
+    return createGenerationAttemptWorkflow({
+      attemptOrchestration: {
+        orchestration,
+        phaseState: getActiveGenerationPhase(orchestration),
+        events: {},
+      },
+      runId: "run-1",
+      generation: 1,
+      competitorPrompt: "prompt",
+      seedBase: 1000,
+      matchesPerGeneration: 2,
+      currentElo: 1000,
+      executeCompetitor: async (): Promise<CompletionResult> => ({
+        text: '{"aggression":0.7}',
+        model: "test-model",
+        usage: { inputTokens: 3, output_tokens: 4 },
+      }),
+      executeTournament: ({
+        strategy,
+        tournamentOptions,
+      }: {
+        strategy: Record<string, unknown>;
+        tournamentOptions: TournamentOpts;
+      }) => ({
+        matches: [
+          {
+            seed: tournamentOptions.seedBase,
+            score: Number(strategy.aggression ?? 0),
+            winner: "challenger",
+            passedValidation: true,
+            validationErrors: [],
+            replay: [],
+          },
+        ],
+        meanScore: Number(strategy.aggression ?? 0),
+        bestScore: Number(strategy.aggression ?? 0),
+        wins: 1,
+        losses: 0,
+        elo: 1015,
+      }),
+      decideGate: () => ({
+        gateDecision: "retry",
+        delta: 0.001,
+        threshold: 0.005,
+      }),
+    });
+  }
+
+  it("runs a retrying attempt workflow and preserves run score state", async () => {
+    const workflow = await runGenerationAttemptWorkflow(createStartedWorkflow());
+
+    expect(workflow.attemptOrchestration.phaseState.phase).toBe("gate_decided");
+    expect(workflow.attemptOrchestration.orchestration.runState.bestScore).toBe(0);
+    expect(
+      workflow.events.map((event: GenerationLoopEventSequenceItem) => event.event),
+    ).toEqual([
+      "role_completed",
+      "tournament_started",
+      "match_completed",
+      "tournament_completed",
+      "gate_decided",
+    ]);
+    expect(workflow.events.at(-1)?.payload).toEqual({
+      run_id: "run-1",
+      generation: 1,
+      decision: "retry",
+      delta: 0.001,
+      threshold: 0.005,
+    });
+  });
+
+  it("runs an advancing attempt workflow and records run progress", async () => {
+    const workflow = await runGenerationAttemptWorkflow(
+      createGenerationAttemptWorkflow({
+        ...createStartedWorkflow(),
+        decideGate: () => ({
+          gateDecision: "advance",
+          delta: 0.2,
+          threshold: 0.005,
+        }),
+      }),
+    );
+
+    expect(workflow.attemptOrchestration.phaseState.phase).toBe("finalized");
+    expect(workflow.attemptOrchestration.orchestration.runState.bestScore).toBe(0.7);
+    expect(workflow.attemptOrchestration.orchestration.runState.currentElo).toBe(1015);
+    expect(workflow.attempt.tournamentResult.bestScore).toBe(0.7);
+    expect(
+      workflow.events.map((event: GenerationLoopEventSequenceItem) => event.event),
+    ).toEqual([
+      "role_completed",
+      "tournament_started",
+      "match_completed",
+      "tournament_completed",
+      "gate_decided",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- extract the remaining inner generation-attempt workflow from `GenerationRunner` into a focused facade
- compose attempt orchestration, execution-step setup, side-effect coordination, and gate-decision handling behind one explicit workflow surface
- keep runtime behavior stable while further reducing imperative loop logic in the runner

## TDD / DDD / DRY framing
This continues the GenerationRunner architectural extraction track after #674.

Bounded context extracted:
- **Generation Attempt Workflow** — the end-to-end workflow for a single generation attempt, from competitor completion through tournament execution and gate decision finalization

Test-first work:
- added generation attempt workflow tests first
- implemented the workflow facade module
- rewired `GenerationRunner` to delegate the inner attempt workflow to the facade

## Changes
### New module
- `ts/src/loop/generation-attempt-workflow.ts`
  - `createGenerationAttemptWorkflow`
  - `runGenerationAttemptWorkflow`

### Runner integration
- `ts/src/loop/generation-runner.ts`
  - now delegates the inner attempt workflow to the extracted facade
  - keeps generation-level orchestration and post-attempt responsibilities in the runner

### New tests
- `ts/tests/generation-attempt-workflow.test.ts`

## Validation
- `cd ts && npx vitest run tests/generation-attempt-workflow.test.ts tests/generation-side-effect-coordinator.test.ts tests/generation-execution-step.test.ts tests/generation-tournament-event-sequencing.test.ts tests/generation-attempt-orchestrator.test.ts tests/generation-loop-orchestrator.test.ts tests/generation-event-coordinator.test.ts tests/generation-cycle-state.test.ts tests/generation-phase-state.test.ts tests/generation-attempt-state.test.ts tests/generation-run-state.test.ts tests/generation-recovery.test.ts tests/generation-journal.test.ts tests/generation-loop.test.ts tests/generation-runner-prompts.test.ts`
- `cd ts && npm run lint`

## Follow-up
At this point the remaining `GenerationRunner` body is mostly generation-level composition and post-attempt work. The next step is likely a review/decision point rather than another mandatory extraction: either stop here, or add one final event-driven facade only if review shows the remaining composition layer is still too imperative.
