### PR TITLE
refactor: extract generation lifecycle workflow

### DIFF
--- a/ts/src/loop/generation-lifecycle-workflow.ts
+++ b/ts/src/loop/generation-lifecycle-workflow.ts
@@ -1,0 +1,121 @@
+import {
+  createGenerationAttemptOrchestration,
+  type GenerationAttemptOrchestration,
+} from "./generation-attempt-orchestrator.js";
+import type { GenerationAttempt } from "./generation-attempt-state.js";
+import {
+  finalizeGenerationCycle,
+  getActiveGenerationPhase,
+  startNextGeneration,
+  type GenerationLoopOrchestration,
+} from "./generation-loop-orchestrator.js";
+import {
+  canContinueGenerationPhase,
+  getFinalizedGenerationPhaseAttempt,
+  type GenerationPhaseState,
+} from "./generation-phase-state.js";
+import type { GenerationLoopEventSequenceItem } from "./generation-side-effect-coordinator.js";
+
+export interface GenerationLifecycleWorkflow {
+  orchestration: GenerationLoopOrchestration;
+  curatorEnabled: boolean;
+  maxRetries: number;
+  runAttempt: (input: {
+    attemptOrchestration: GenerationAttemptOrchestration;
+    runId: string;
+    generation: number;
+  }) => Promise<{
+    attemptOrchestration: GenerationAttemptOrchestration;
+    events: GenerationLoopEventSequenceItem[];
+  }>;
+}
+
+export interface GenerationLifecycleWorkflowResult {
+  orchestration: GenerationLoopOrchestration;
+  attemptOrchestration: GenerationAttemptOrchestration;
+  phaseState: GenerationPhaseState;
+  generation: number;
+  finalizedAttempt: GenerationAttempt;
+  events: GenerationLoopEventSequenceItem[];
+}
+
+export function createGenerationLifecycleWorkflow(
+  workflow: GenerationLifecycleWorkflow,
+): GenerationLifecycleWorkflow {
+  return workflow;
+}
+
+export async function runGenerationLifecycleWorkflow(
+  workflow: GenerationLifecycleWorkflow,
+): Promise<GenerationLifecycleWorkflowResult> {
+  let orchestration = startNextGeneration(
+    workflow.orchestration,
+    workflow.curatorEnabled,
+  );
+  let phaseState = getActiveGenerationPhase(orchestration);
+  let attemptOrchestration = createGenerationAttemptOrchestration(
+    orchestration,
+    phaseState,
+  );
+  const generation = phaseState.generation;
+  const events: GenerationLoopEventSequenceItem[] = [
+    {
+      event: "generation_started",
+      payload: orchestration.events.generationStarted!,
+    },
+    {
+      event: "agents_started",
+      payload: orchestration.events.agentsStarted!,
+    },
+  ];
+
+  while (canContinueGenerationPhase(phaseState, workflow.maxRetries)) {
+    const attemptResult = await workflow.runAttempt({
+      attemptOrchestration,
+      runId: orchestration.runState.runId,
+      generation,
+    });
+    attemptOrchestration = attemptResult.attemptOrchestration;
+    phaseState = attemptOrchestration.phaseState;
+    orchestration = attemptOrchestration.orchestration;
+    events.push(...attemptResult.events);
+  }
+
+  return {
+    orchestration,
+    attemptOrchestration,
+    phaseState,
+    generation,
+    finalizedAttempt: getFinalizedGenerationPhaseAttempt(phaseState),
+    events,
+  };
+}
+
+export function completeGenerationLifecycleWorkflow(
+  workflow: GenerationLifecycleWorkflowResult,
+): GenerationLifecycleWorkflowResult {
+  const orchestration = finalizeGenerationCycle(
+    workflow.orchestration,
+    workflow.phaseState,
+    {
+      runId: workflow.orchestration.runState.runId,
+      generation: workflow.generation,
+      meanScore: workflow.finalizedAttempt.tournamentResult.meanScore,
+      bestScore: workflow.finalizedAttempt.tournamentResult.bestScore,
+      elo: workflow.finalizedAttempt.tournamentResult.elo,
+      gateDecision: workflow.finalizedAttempt.gateDecision,
+    },
+  );
+
+  return {
+    ...workflow,
+    orchestration,
+    events: [
+      ...workflow.events,
+      {
+        event: "generation_completed",
+        payload: orchestration.events.generationCompleted!,
+      },
+    ],
+  };
+}

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -37,25 +37,22 @@ import {
   buildCuratorPrompt,
   buildSupportPrompt,
 } from "./generation-prompts.js";
-import { createGenerationAttemptOrchestration } from "./generation-attempt-orchestrator.js";
 import { createGenerationAttemptWorkflow, runGenerationAttemptWorkflow } from "./generation-attempt-workflow.js";
+import {
+  completeGenerationLifecycleWorkflow,
+  createGenerationLifecycleWorkflow,
+  runGenerationLifecycleWorkflow,
+} from "./generation-lifecycle-workflow.js";
 import { buildRoleCompletedPayload } from "./generation-side-effect-coordinator.js";
 import { GenerationJournal } from "./generation-journal.js";
 import {
   completeGenerationLoopRun,
   createGenerationLoopOrchestration,
   failGenerationLoopRun,
-  finalizeGenerationCycle,
-  getActiveGenerationPhase,
-  startNextGeneration,
 } from "./generation-loop-orchestrator.js";
 import { GenerationRecovery } from "./generation-recovery.js";
 import { hasRemainingGenerationCycles } from "./generation-cycle-state.js";
-import {
-  canContinueGenerationPhase,
-  getFinalizedGenerationPhaseAttempt,
-  type GenerationAttempt,
-} from "./generation-phase-state.js";
+import { type GenerationAttempt } from "./generation-phase-state.js";
 import {
   consumeFreshStartHint,
   queueFreshStartHint,
@@ -200,75 +197,65 @@ export class GenerationRunner {
 
       while (hasRemainingGenerationCycles(orchestration.cycleState)) {
         await this.#controller?.waitIfPaused();
-        orchestration = startNextGeneration(orchestration, this.#curatorEnabled);
-        let phaseState = getActiveGenerationPhase(orchestration);
-        const gen = phaseState.generation;
-        this.emit("generation_started", orchestration.events.generationStarted!);
-        this.emit("agents_started", orchestration.events.agentsStarted!);
-
-        let attemptOrchestration = createGenerationAttemptOrchestration(
-          orchestration,
-          phaseState,
+        let lifecycle = await runGenerationLifecycleWorkflow(
+          createGenerationLifecycleWorkflow({
+            orchestration,
+            curatorEnabled: this.#curatorEnabled,
+            maxRetries: this.#maxRetries,
+            runAttempt: async ({ attemptOrchestration, generation }) => {
+              await this.#controller?.waitIfPaused();
+              const competitorPrompt = this.buildCompetitorPrompt(runId);
+              return runGenerationAttemptWorkflow(
+                createGenerationAttemptWorkflow({
+                  attemptOrchestration,
+                  runId,
+                  generation,
+                  competitorPrompt,
+                  seedBase: this.#seedBase,
+                  matchesPerGeneration: this.#matchesPerGeneration,
+                  currentElo: this.#runState!.currentElo,
+                  executeCompetitor: () => this.completeRole("competitor", competitorPrompt),
+                  beforeTournament: async () => {
+                    await this.#controller?.waitIfPaused();
+                  },
+                  executeTournament: ({ strategy: nextStrategy, tournamentOptions }) =>
+                    new TournamentRunner(this.#scenario, tournamentOptions).run(nextStrategy),
+                  decideGate: ({ attemptOrchestration: currentAttemptOrchestration, tournamentResult }) => {
+                    const decision = this.#gate.evaluate(
+                      currentAttemptOrchestration.orchestration.cycleState.previousBestOverall,
+                      tournamentResult.bestScore,
+                      currentAttemptOrchestration.phaseState.attemptState.retryCount,
+                      this.#maxRetries,
+                    );
+                    const gateDecision = this.#controller?.takeGateOverride() as GenerationAttempt["gateDecision"] | null ?? decision.decision;
+                    return {
+                      gateDecision,
+                      delta: decision.delta,
+                      threshold: decision.threshold,
+                    };
+                  },
+                }),
+              );
+            },
+          }),
         );
-
-        // Retry loop for this generation
-        while (canContinueGenerationPhase(phaseState, this.#maxRetries)) {
-          await this.#controller?.waitIfPaused();
-          const competitorPrompt = this.buildCompetitorPrompt(runId);
-          const workflowResult = await runGenerationAttemptWorkflow(
-            createGenerationAttemptWorkflow({
-              attemptOrchestration,
-              runId,
-              generation: gen,
-              competitorPrompt,
-              seedBase: this.#seedBase,
-              matchesPerGeneration: this.#matchesPerGeneration,
-              currentElo: this.#runState.currentElo,
-              executeCompetitor: () => this.completeRole("competitor", competitorPrompt),
-              beforeTournament: async () => {
-                await this.#controller?.waitIfPaused();
-              },
-              executeTournament: ({ strategy: nextStrategy, tournamentOptions }) =>
-                new TournamentRunner(this.#scenario, tournamentOptions).run(nextStrategy),
-              decideGate: ({ attemptOrchestration: currentAttemptOrchestration, tournamentResult }) => {
-                const decision = this.#gate.evaluate(
-                  currentAttemptOrchestration.orchestration.cycleState.previousBestOverall,
-                  tournamentResult.bestScore,
-                  currentAttemptOrchestration.phaseState.attemptState.retryCount,
-                  this.#maxRetries,
-                );
-                const gateDecision = this.#controller?.takeGateOverride() as GenerationAttempt["gateDecision"] | null ?? decision.decision;
-                return {
-                  gateDecision,
-                  delta: decision.delta,
-                  threshold: decision.threshold,
-                };
-              },
-            }),
-          );
-          attemptOrchestration = workflowResult.attemptOrchestration;
-          phaseState = attemptOrchestration.phaseState;
-          orchestration = attemptOrchestration.orchestration;
-          this.#runState = orchestration.runState;
-          for (const event of workflowResult.events) {
-            this.emit(event.event, event.payload);
-          }
+        orchestration = lifecycle.orchestration;
+        this.#runState = orchestration.runState;
+        for (const event of lifecycle.events) {
+          this.emit(event.event, event.payload);
         }
 
-        const finalizedAttempt = getFinalizedGenerationPhaseAttempt(phaseState);
-
-        this.#journal.persistGeneration(runId, gen, finalizedAttempt);
+        this.#journal.persistGeneration(runId, lifecycle.generation, lifecycle.finalizedAttempt);
         await this.#controller?.waitIfPaused();
-        await this.runSupportRoles(runId, gen, finalizedAttempt);
-        await this.applyAdvancedFeatures(runId, gen, finalizedAttempt, phaseState.previousBestForGeneration);
-        orchestration = finalizeGenerationCycle(orchestration, phaseState, {
+        await this.runSupportRoles(runId, lifecycle.generation, lifecycle.finalizedAttempt);
+        await this.applyAdvancedFeatures(
           runId,
-          generation: gen,
-          meanScore: finalizedAttempt.tournamentResult.meanScore,
-          bestScore: finalizedAttempt.tournamentResult.bestScore,
-          elo: finalizedAttempt.tournamentResult.elo,
-          gateDecision: finalizedAttempt.gateDecision,
-        });
+          lifecycle.generation,
+          lifecycle.finalizedAttempt,
+          lifecycle.phaseState.previousBestForGeneration,
+        );
+        lifecycle = completeGenerationLifecycleWorkflow(lifecycle);
+        orchestration = lifecycle.orchestration;
         this.emit("generation_completed", orchestration.events.generationCompleted!);
       }
 

--- a/ts/tests/generation-lifecycle-workflow.test.ts
+++ b/ts/tests/generation-lifecycle-workflow.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import type { GenerationAttempt } from "../src/loop/generation-attempt-state.js";
+import {
+  awaitGenerationCompetitorResult,
+  awaitGenerationTournamentResult,
+  finalizeGenerationAttemptDecision,
+} from "../src/loop/generation-attempt-orchestrator.js";
+import {
+  completeGenerationLifecycleWorkflow,
+  createGenerationLifecycleWorkflow,
+  runGenerationLifecycleWorkflow,
+  type GenerationLifecycleWorkflow,
+} from "../src/loop/generation-lifecycle-workflow.js";
+import {
+  createGenerationLoopOrchestration,
+  type GenerationLoopOrchestration,
+} from "../src/loop/generation-loop-orchestrator.js";
+import type { GenerationLoopEventSequenceItem } from "../src/loop/generation-side-effect-coordinator.js";
+
+function makeAttempt(
+  gateDecision: GenerationAttempt["gateDecision"],
+  bestScore: number,
+  elo = 1000 + bestScore * 100,
+): GenerationAttempt {
+  return {
+    competitorPrompt: "prompt",
+    competitorResultText: '{"aggression":0.5}',
+    strategy: { aggression: 0.5 },
+    tournamentResult: {
+      matches: [],
+      meanScore: bestScore,
+      bestScore,
+      wins: 1,
+      losses: 0,
+      elo,
+    },
+    gateDecision,
+  };
+}
+
+describe("generation lifecycle workflow", () => {
+  function createRunOrchestration(): GenerationLoopOrchestration {
+    return createGenerationLoopOrchestration({
+      runId: "run-1",
+      scenarioName: "grid_ctf",
+      targetGenerations: 2,
+      startedAtMs: 100,
+    });
+  }
+
+  it("runs generation attempts until one finalizes", async () => {
+    let attempts = 0;
+
+    const lifecycle = await runGenerationLifecycleWorkflow(
+      createGenerationLifecycleWorkflow({
+        orchestration: createRunOrchestration(),
+        curatorEnabled: false,
+        maxRetries: 1,
+        runAttempt: async ({
+          attemptOrchestration,
+          runId,
+          generation,
+        }: Parameters<GenerationLifecycleWorkflow["runAttempt"]>[0]) => {
+          attempts += 1;
+          const decision = attempts === 1 ? "retry" : "advance";
+          const score = attempts === 1 ? 0.51 : 0.72;
+          const next = finalizeGenerationAttemptDecision(
+            awaitGenerationTournamentResult(
+              awaitGenerationCompetitorResult(attemptOrchestration),
+            ),
+            {
+              runId,
+              generation,
+              attempt: makeAttempt(decision, score, attempts === 1 ? 1020 : 1088),
+              delta: attempts === 1 ? 0.001 : 0.2,
+              threshold: 0.005,
+            },
+          );
+
+          return {
+            attemptOrchestration: next,
+            events: [
+              {
+                event: "gate_decided",
+                payload: next.events.gateDecided!,
+              },
+            ],
+          };
+        },
+      }),
+    );
+
+    expect(attempts).toBe(2);
+    expect(lifecycle.generation).toBe(1);
+    expect(lifecycle.finalizedAttempt.gateDecision).toBe("advance");
+    expect(lifecycle.orchestration.runState.bestScore).toBe(0.72);
+    expect(
+      lifecycle.events.map((event: GenerationLoopEventSequenceItem) => event.event),
+    ).toEqual([
+      "generation_started",
+      "agents_started",
+      "gate_decided",
+      "gate_decided",
+    ]);
+  });
+
+  it("completes generation lifecycle with stable completion payloads", async () => {
+    const lifecycle = await runGenerationLifecycleWorkflow(
+      createGenerationLifecycleWorkflow({
+        orchestration: createRunOrchestration(),
+        curatorEnabled: true,
+        maxRetries: 0,
+        runAttempt: async ({
+          attemptOrchestration,
+          runId,
+          generation,
+        }: Parameters<GenerationLifecycleWorkflow["runAttempt"]>[0]) => {
+          const next = finalizeGenerationAttemptDecision(
+            awaitGenerationTournamentResult(
+              awaitGenerationCompetitorResult(attemptOrchestration),
+            ),
+            {
+              runId,
+              generation,
+              attempt: makeAttempt("advance", 0.68, 1068),
+              delta: 0.18,
+              threshold: 0.005,
+            },
+          );
+
+          return {
+            attemptOrchestration: next,
+            events: [],
+          };
+        },
+      }),
+    );
+    const completed = completeGenerationLifecycleWorkflow(lifecycle);
+
+    expect(completed.orchestration.cycleState.completedGenerations).toBe(1);
+    expect(completed.orchestration.events.generationCompleted).toEqual({
+      run_id: "run-1",
+      generation: 1,
+      mean_score: 0.68,
+      best_score: 0.68,
+      elo: 1068,
+      gate_decision: "advance",
+    });
+    expect(
+      completed.events.map((event: GenerationLoopEventSequenceItem) => event.event),
+    ).toEqual([
+      "generation_started",
+      "agents_started",
+      "generation_completed",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- extract the remaining generation-level workflow composition from `GenerationRunner` into a dedicated lifecycle facade
- coordinate generation start events, repeated attempt execution until finalization, and generation completion handoff through one explicit surface
- keep runtime behavior stable while reducing the remaining imperative composition inside the runner

## TDD / DDD / DRY framing
This continues the GenerationRunner architectural extraction track after #675.

Bounded context extracted:
- **Generation Lifecycle Workflow** — generation-level composition across start-of-generation events, repeated attempt workflow execution, finalized-attempt capture, and generation completion handoff

Test-first work:
- added generation lifecycle workflow tests first
- implemented the lifecycle workflow module
- rewired `GenerationRunner` to delegate generation-level attempt-loop composition to the facade

## Changes
### New module
- `ts/src/loop/generation-lifecycle-workflow.ts`
  - `createGenerationLifecycleWorkflow`
  - `runGenerationLifecycleWorkflow`
  - `completeGenerationLifecycleWorkflow`

### Runner integration
- `ts/src/loop/generation-runner.ts`
  - now delegates generation-level attempt-loop composition to the lifecycle workflow facade
  - retains post-attempt support-role and recovery responsibilities before emitting generation completion

### New tests
- `ts/tests/generation-lifecycle-workflow.test.ts`

## Validation
- `cd ts && npx vitest run tests/generation-lifecycle-workflow.test.ts tests/generation-attempt-workflow.test.ts tests/generation-side-effect-coordinator.test.ts tests/generation-execution-step.test.ts tests/generation-tournament-event-sequencing.test.ts tests/generation-attempt-orchestrator.test.ts tests/generation-loop-orchestrator.test.ts tests/generation-event-coordinator.test.ts tests/generation-cycle-state.test.ts tests/generation-phase-state.test.ts tests/generation-attempt-state.test.ts tests/generation-run-state.test.ts tests/generation-recovery.test.ts tests/generation-journal.test.ts tests/generation-loop.test.ts tests/generation-runner-prompts.test.ts`
- `cd ts && npm run lint`

## Follow-up
This likely marks the end of the low-risk GenerationRunner extraction sequence. The next step should probably be a review decision rather than another automatic split-out: either keep `GenerationRunner` as the remaining composition shell, or only add a final event-driven facade if review still finds the residual structure too imperative.
