### PR TITLE
refactor: finish execution-surface cleanup and encapsulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,11 @@ __pycache__/
 # Node
 node_modules/
 
-# Claude Code / superpowers workflow artifacts
+# Local agent / superpowers workflow artifacts
 .claude/projects/
+.pi/
+.pi-lens/
+/superpowers/
 docs/superpowers/
 
 # OS/editor

--- a/ts/.gitignore
+++ b/ts/.gitignore
@@ -1,3 +1,8 @@
 node_modules/
 dist/
 *.tsbuildinfo
+
+# Local agent / superpowers workflow artifacts
+.pi/
+.pi-lens/
+/superpowers/

--- a/ts/src/agents/orchestrator.ts
+++ b/ts/src/agents/orchestrator.ts
@@ -13,12 +13,7 @@ import {
   parseCoachOutput,
   parseCompetitorOutput,
 } from "./roles.js";
-import type {
-  AnalystOutput,
-  ArchitectOutput,
-  CoachOutput,
-  CompetitorOutput,
-} from "./roles.js";
+import type { AnalystOutput, ArchitectOutput, CoachOutput, CompetitorOutput } from "./roles.js";
 
 export interface GenerationPrompts {
   competitorPrompt: string;
@@ -40,31 +35,31 @@ export interface AgentOrchestratorOpts {
 }
 
 export class AgentOrchestrator {
-  private provider: LLMProvider;
-  private roleProviders: Partial<Record<GenerationRole, LLMProvider>>;
-  private roleModels: Partial<Record<GenerationRole, string>>;
+  #provider: LLMProvider;
+  #roleProviders: Partial<Record<GenerationRole, LLMProvider>>;
+  #roleModels: Partial<Record<GenerationRole, string>>;
 
   constructor(provider: LLMProvider, opts: AgentOrchestratorOpts = {}) {
-    this.provider = provider;
-    this.roleProviders = opts.roleProviders ?? {};
-    this.roleModels = opts.roleModels ?? {};
+    this.#provider = provider;
+    this.#roleProviders = opts.roleProviders ?? {};
+    this.#roleModels = opts.roleModels ?? {};
   }
 
-  private providerForRole(role: GenerationRole): LLMProvider {
-    return this.roleProviders[role] ?? this.provider;
+  #providerForRole(role: GenerationRole): LLMProvider {
+    return this.#roleProviders[role] ?? this.#provider;
   }
 
-  private completeRole(role: GenerationRole, userPrompt: string) {
-    return this.providerForRole(role).complete({
+  #completeRole(role: GenerationRole, userPrompt: string) {
+    return this.#providerForRole(role).complete({
       systemPrompt: "",
       userPrompt,
-      model: this.roleModels[role],
+      model: this.#roleModels[role],
     });
   }
 
   async runGeneration(prompts: GenerationPrompts): Promise<GenerationResult> {
     // Phase 1: Competitor
-    const competitorResult = await this.completeRole("competitor", prompts.competitorPrompt);
+    const competitorResult = await this.#completeRole("competitor", prompts.competitorPrompt);
     let strategy: Record<string, unknown> = {};
     try {
       strategy = JSON.parse(competitorResult.text);
@@ -75,10 +70,10 @@ export class AgentOrchestrator {
 
     // Phase 2: Analyst, Coach, Architect in parallel
     const [analystResult, coachResult, architectResult] = await Promise.all([
-      this.completeRole("analyst", prompts.analystPrompt),
-      this.completeRole("coach", prompts.coachPrompt),
+      this.#completeRole("analyst", prompts.analystPrompt),
+      this.#completeRole("coach", prompts.coachPrompt),
       prompts.architectPrompt
-        ? this.completeRole("architect", prompts.architectPrompt)
+        ? this.#completeRole("architect", prompts.architectPrompt)
         : Promise.resolve({ text: "", usage: {} }),
     ]);
 

--- a/ts/src/execution/action-filter-contracts.ts
+++ b/ts/src/execution/action-filter-contracts.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const ActionDictSchema = z
+  .object({
+    action: z.string(),
+    description: z.string(),
+    type: z.string().optional(),
+    range: z.tuple([z.number(), z.number()]).optional(),
+    row: z.number().optional(),
+    col: z.number().optional(),
+  })
+  .passthrough();
+
+export type ActionDict = z.infer<typeof ActionDictSchema>;
+
+export interface ScenarioLike {
+  enumerateLegalActions(state: Record<string, unknown>): ActionDict[] | null;
+  validateActions(
+    state: Record<string, unknown>,
+    playerId: string,
+    actions: Record<string, unknown>,
+  ): [boolean, string];
+}
+
+export interface HarnessLoaderLike {
+  validators: Array<{
+    enumerate_legal_actions?: (state: Record<string, unknown>) => ActionDict[];
+  }>;
+}

--- a/ts/src/execution/action-filter-discovery-workflow.ts
+++ b/ts/src/execution/action-filter-discovery-workflow.ts
@@ -1,0 +1,40 @@
+import type {
+  ActionDict,
+  HarnessLoaderLike,
+  ScenarioLike,
+} from "./action-filter-contracts.js";
+
+export function getHarnessActions(
+  harnessLoader: HarnessLoaderLike | null,
+  state: Record<string, unknown>,
+): ActionDict[] | null {
+  if (!harnessLoader) {
+    return null;
+  }
+  for (const validator of harnessLoader.validators) {
+    if (typeof validator.enumerate_legal_actions !== "function") {
+      continue;
+    }
+    try {
+      const result = validator.enumerate_legal_actions(state);
+      if (Array.isArray(result)) {
+        return result;
+      }
+    } catch {
+      // ignore failing validator and continue to the next one
+    }
+  }
+  return null;
+}
+
+export function getLegalActions(
+  scenario: ScenarioLike,
+  state: Record<string, unknown>,
+  harnessLoader: HarnessLoaderLike | null,
+): ActionDict[] | null {
+  const result = scenario.enumerateLegalActions(state);
+  if (result !== null) {
+    return result;
+  }
+  return getHarnessActions(harnessLoader, state);
+}

--- a/ts/src/execution/action-filter-prompt-workflow.ts
+++ b/ts/src/execution/action-filter-prompt-workflow.ts
@@ -1,0 +1,59 @@
+import type { ActionDict } from "./action-filter-contracts.js";
+
+export function isContinuousParamSpace(actions: ActionDict[]): boolean {
+  if (actions.length === 0) {
+    return false;
+  }
+  return actions.every((action) => {
+    if (action.type !== "continuous") {
+      return false;
+    }
+    if (!action.range || action.range.length !== 2) {
+      return false;
+    }
+    const [low, high] = action.range;
+    return typeof low === "number" && typeof high === "number";
+  });
+}
+
+export function formatActionPrompt(actions: ActionDict[]): string {
+  if (actions.length === 0) {
+    return "No actions available.";
+  }
+  if (isContinuousParamSpace(actions)) {
+    const lines: string[] = ["Provide a JSON object with all strategy parameters:"];
+    const example: Record<string, number> = {};
+    for (const action of actions) {
+      const name = action.action;
+      const description = action.description ?? "";
+      const [low, high] = action.range!;
+      lines.push(`- ${name}: ${description} (range [${low}, ${high}])`);
+      example[name] = Number(((low + high) / 2).toFixed(3));
+    }
+    lines.push(`Example: ${JSON.stringify(example)}`);
+    lines.push("Respond with JSON only.");
+    return lines.join("\n");
+  }
+
+  const lines: string[] = ["Available actions:"];
+  for (let index = 0; index < actions.length; index++) {
+    const action = actions[index];
+    const name = action.action ?? `action_${index + 1}`;
+    const description = action.description ?? "";
+    let extra = "";
+    if (action.type === "continuous" && action.range) {
+      extra = ` (continuous [${action.range[0]}, ${action.range[1]}])`;
+    } else if (action.row !== undefined && action.col !== undefined) {
+      extra = ` (row ${action.row}, col ${action.col})`;
+    }
+
+    let line = `${index + 1}. ${name}`;
+    if (description) {
+      line += ` — ${description}`;
+    }
+    line += extra;
+    lines.push(line);
+  }
+  lines.push("Select an action by number:");
+  return lines.join("\n");
+}

--- a/ts/src/execution/action-filter-selection-workflow.ts
+++ b/ts/src/execution/action-filter-selection-workflow.ts
@@ -1,0 +1,84 @@
+import type { ActionDict } from "./action-filter-contracts.js";
+import { isContinuousParamSpace } from "./action-filter-prompt-workflow.js";
+
+export function extractJsonObject(response: string): Record<string, unknown> | null {
+  const candidates: string[] = [];
+  const fenced = response.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/i);
+  if (fenced?.[1]) {
+    candidates.push(fenced[1]);
+  }
+  const start = response.indexOf("{");
+  const end = response.lastIndexOf("}");
+  if (start !== -1 && end > start) {
+    candidates.push(response.slice(start, end + 1));
+  }
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // continue
+    }
+  }
+  return null;
+}
+
+export function parseContinuousSelection(
+  response: string,
+  actions: ActionDict[],
+): Record<string, number> | null {
+  const payload = extractJsonObject(response);
+  if (!payload) {
+    return null;
+  }
+
+  const strategy: Record<string, number> = {};
+  for (const action of actions) {
+    const key = action.action;
+    if (!(key in payload)) {
+      return null;
+    }
+    const raw = payload[key];
+    if (typeof raw !== "number" || Number.isNaN(raw)) {
+      return null;
+    }
+    const [low, high] = action.range!;
+    if (raw < low || raw > high) {
+      return null;
+    }
+    strategy[key] = raw;
+  }
+  return strategy;
+}
+
+export function parseActionSelection(
+  response: string,
+  actions: ActionDict[],
+): Record<string, unknown> | ActionDict | null {
+  if (actions.length === 0) {
+    return null;
+  }
+
+  if (isContinuousParamSpace(actions)) {
+    return parseContinuousSelection(response, actions);
+  }
+
+  const match = response.trim().match(/\b(\d+)\b/);
+  if (match) {
+    const index = Number.parseInt(match[1], 10);
+    if (index >= 1 && index <= actions.length) {
+      return actions[index - 1];
+    }
+  }
+
+  const normalizedResponse = response.trim().toLowerCase();
+  for (const action of actions) {
+    if (action.action && normalizedResponse.includes(action.action.toLowerCase())) {
+      return action;
+    }
+  }
+
+  return null;
+}

--- a/ts/src/execution/action-filter-verification-workflow.ts
+++ b/ts/src/execution/action-filter-verification-workflow.ts
@@ -1,0 +1,26 @@
+import type {
+  ActionDict,
+  ScenarioLike,
+} from "./action-filter-contracts.js";
+import { formatActionPrompt } from "./action-filter-prompt-workflow.js";
+
+export function verifyAction(
+  scenario: ScenarioLike,
+  state: Record<string, unknown>,
+  playerId: string,
+  proposed: Record<string, unknown>,
+): [boolean, string] {
+  return scenario.validateActions(state, playerId, proposed);
+}
+
+export function getVerifyFeedback(
+  reason: string,
+  legalActions: ActionDict[] | null,
+): string {
+  const parts: string[] = [`Invalid action: ${reason}`];
+  if (legalActions) {
+    parts.push(formatActionPrompt(legalActions));
+  }
+  parts.push("Please try again.");
+  return parts.join("\n");
+}

--- a/ts/src/execution/action-filter.ts
+++ b/ts/src/execution/action-filter.ts
@@ -7,254 +7,51 @@
  * harness validates).
  */
 
-import { z } from "zod";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export const ActionDictSchema = z
-  .object({
-    action: z.string(),
-    description: z.string(),
-    type: z.string().optional(),
-    range: z.tuple([z.number(), z.number()]).optional(),
-    row: z.number().optional(),
-    col: z.number().optional(),
-  })
-  .passthrough();
-
-export type ActionDict = z.infer<typeof ActionDictSchema>;
-
-/**
- * Minimal scenario interface for the ActionFilterHarness.
- * Mirrors the Python ScenarioInterface methods used by the harness.
- */
-export interface ScenarioLike {
-  enumerateLegalActions(state: Record<string, unknown>): ActionDict[] | null;
-  validateActions(
-    state: Record<string, unknown>,
-    playerId: string,
-    actions: Record<string, unknown>,
-  ): [boolean, string];
-}
-
-/**
- * Optional harness loader interface — used as fallback when the scenario
- * does not support enumerate_legal_actions.
- */
-export interface HarnessLoaderLike {
-  validators: Array<{
-    enumerate_legal_actions?: (state: Record<string, unknown>) => ActionDict[];
-  }>;
-}
-
-// ---------------------------------------------------------------------------
-// ActionFilterHarness
-// ---------------------------------------------------------------------------
+export {
+  ActionDictSchema,
+  type ActionDict,
+  type HarnessLoaderLike,
+  type ScenarioLike,
+} from "./action-filter-contracts.js";
+import type { ActionDict, HarnessLoaderLike, ScenarioLike } from "./action-filter-contracts.js";
+import { getLegalActions } from "./action-filter-discovery-workflow.js";
+import { formatActionPrompt } from "./action-filter-prompt-workflow.js";
+import { parseActionSelection } from "./action-filter-selection-workflow.js";
+import { getVerifyFeedback, verifyAction } from "./action-filter-verification-workflow.js";
 
 export class ActionFilterHarness {
-  private readonly scenario: ScenarioLike;
-  private readonly harnessLoader: HarnessLoaderLike | null;
+  readonly #scenario: ScenarioLike;
+  readonly #harnessLoader: HarnessLoaderLike | null;
 
-  constructor(
-    scenario: ScenarioLike,
-    harnessLoader: HarnessLoaderLike | null = null,
-  ) {
-    this.scenario = scenario;
-    this.harnessLoader = harnessLoader;
+  constructor(scenario: ScenarioLike, harnessLoader: HarnessLoaderLike | null = null) {
+    this.#scenario = scenario;
+    this.#harnessLoader = harnessLoader;
   }
 
-  /**
-   * Get legal actions, preferring the scenario method over harness loader.
-   * Returns null if enumeration is not supported by either source.
-   */
   getLegalActions(state: Record<string, unknown>): ActionDict[] | null {
-    const result = this.scenario.enumerateLegalActions(state);
-    if (result !== null) {
-      return result;
-    }
-    if (this.harnessLoader) {
-      return this.getHarnessActions(state);
-    }
-    return null;
+    return getLegalActions(this.#scenario, state, this.#harnessLoader);
   }
 
-  /**
-   * Format actions as a numbered list for LLM selection.
-   */
   formatActionPrompt(actions: ActionDict[]): string {
-    if (actions.length === 0) {
-      return "No actions available.";
-    }
-    if (this.isContinuousParamSpace(actions)) {
-      const lines: string[] = ["Provide a JSON object with all strategy parameters:"];
-      const example: Record<string, number> = {};
-      for (const action of actions) {
-        const name = action.action;
-        const desc = action.description ?? "";
-        const [low, high] = action.range!;
-        lines.push(`- ${name}: ${desc} (range [${low}, ${high}])`);
-        example[name] = Number(((low + high) / 2).toFixed(3));
-      }
-      lines.push(`Example: ${JSON.stringify(example)}`);
-      lines.push("Respond with JSON only.");
-      return lines.join("\n");
-    }
-    const lines: string[] = ["Available actions:"];
-    for (let i = 0; i < actions.length; i++) {
-      const action = actions[i];
-      const name = action.action ?? `action_${i + 1}`;
-      const desc = action.description ?? "";
-      let extra = "";
-      if (action.type === "continuous" && action.range) {
-        extra = ` (continuous [${action.range[0]}, ${action.range[1]}])`;
-      } else if (action.row !== undefined && action.col !== undefined) {
-        extra = ` (row ${action.row}, col ${action.col})`;
-      }
-      let line = `${i + 1}. ${name}`;
-      if (desc) {
-        line += ` — ${desc}`;
-      }
-      line += extra;
-      lines.push(line);
-    }
-    lines.push("Select an action by number:");
-    return lines.join("\n");
+    return formatActionPrompt(actions);
   }
 
-  /**
-   * Parse LLM response to extract the selected action.
-   * Handles numeric index and action name matching.
-   * Returns null if no match found.
-   */
   parseActionSelection(
     response: string,
     actions: ActionDict[],
   ): Record<string, unknown> | ActionDict | null {
-    if (actions.length === 0) {
-      return null;
-    }
-
-    if (this.isContinuousParamSpace(actions)) {
-      return this.parseContinuousSelection(response, actions);
-    }
-
-    // Try numeric index first
-    const match = response.trim().match(/\b(\d+)\b/);
-    if (match) {
-      const idx = parseInt(match[1], 10);
-      if (idx >= 1 && idx <= actions.length) {
-        return actions[idx - 1];
-      }
-    }
-
-    // Try action name match
-    const lower = response.trim().toLowerCase();
-    for (const action of actions) {
-      if (action.action && lower.includes(action.action.toLowerCase())) {
-        return action;
-      }
-    }
-
-    return null;
+    return parseActionSelection(response, actions);
   }
 
-  /**
-   * Verify a proposed action using validateActions.
-   * In verify mode, the LLM proposes freely and we check validity.
-   */
   verifyAction(
     state: Record<string, unknown>,
     playerId: string,
     proposed: Record<string, unknown>,
   ): [boolean, string] {
-    return this.scenario.validateActions(state, playerId, proposed);
+    return verifyAction(this.#scenario, state, playerId, proposed);
   }
 
-  /**
-   * Build feedback string for verify mode retries.
-   * Includes the rejection reason and available legal actions if enumerable.
-   */
-  getVerifyFeedback(
-    reason: string,
-    state: Record<string, unknown>,
-  ): string {
-    const parts: string[] = [`Invalid action: ${reason}`];
-    const legal = this.getLegalActions(state);
-    if (legal) {
-      parts.push(this.formatActionPrompt(legal));
-    }
-    parts.push("Please try again.");
-    return parts.join("\n");
-  }
-
-  private getHarnessActions(
-    state: Record<string, unknown>,
-  ): ActionDict[] | null {
-    if (!this.harnessLoader) return null;
-    for (const v of this.harnessLoader.validators) {
-      if (typeof v.enumerate_legal_actions === "function") {
-        try {
-          const result = v.enumerate_legal_actions(state);
-          if (Array.isArray(result)) {
-            return result;
-          }
-        } catch {
-          // harness enumerate_legal_actions failed, try next
-        }
-      }
-    }
-    return null;
-  }
-
-  private isContinuousParamSpace(actions: ActionDict[]): boolean {
-    if (actions.length === 0) return false;
-    return actions.every((action) => {
-      if (action.type !== "continuous") return false;
-      if (!action.range || action.range.length !== 2) return false;
-      const [low, high] = action.range;
-      return typeof low === "number" && typeof high === "number";
-    });
-  }
-
-  private parseContinuousSelection(
-    response: string,
-    actions: ActionDict[],
-  ): Record<string, number> | null {
-    const payload = this.extractJsonObject(response);
-    if (!payload) return null;
-
-    const strategy: Record<string, number> = {};
-    for (const action of actions) {
-      const key = action.action;
-      if (!(key in payload)) return null;
-      const raw = payload[key];
-      if (typeof raw !== "number" || Number.isNaN(raw)) return null;
-      const [low, high] = action.range!;
-      if (raw < low || raw > high) return null;
-      strategy[key] = raw;
-    }
-    return strategy;
-  }
-
-  private extractJsonObject(response: string): Record<string, unknown> | null {
-    const candidates: string[] = [];
-    const fenced = response.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/i);
-    if (fenced?.[1]) candidates.push(fenced[1]);
-    const start = response.indexOf("{");
-    const end = response.lastIndexOf("}");
-    if (start !== -1 && end > start) candidates.push(response.slice(start, end + 1));
-    for (const candidate of candidates) {
-      try {
-        const parsed = JSON.parse(candidate);
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-          return parsed as Record<string, unknown>;
-        }
-      } catch {
-        // continue
-      }
-    }
-    return null;
+  getVerifyFeedback(reason: string, state: Record<string, unknown>): string {
+    return getVerifyFeedback(reason, this.getLegalActions(state));
   }
 }

--- a/ts/src/execution/improvement-loop-detection.ts
+++ b/ts/src/execution/improvement-loop-detection.ts
@@ -1,0 +1,23 @@
+import type { RoundResult } from "../types/index.js";
+
+export const PARSE_FAILURE_MARKERS = [
+  "no parseable score found",
+  "missing JUDGE_RESULT markers",
+  "invalid JSON",
+  "Failed to parse judge response",
+] as const;
+
+export function isParseFailure(score: number, reasoning: string): boolean {
+  if (score > 0) {
+    return false;
+  }
+  return PARSE_FAILURE_MARKERS.some((marker) => reasoning.includes(marker));
+}
+
+export function isImproved(rounds: RoundResult[]): boolean {
+  const validRounds = rounds.filter((round) => !round.judgeFailed);
+  if (validRounds.length < 2) {
+    return false;
+  }
+  return validRounds[validRounds.length - 1].score > validRounds[0].score;
+}

--- a/ts/src/execution/improvement-loop-policy.ts
+++ b/ts/src/execution/improvement-loop-policy.ts
@@ -1,0 +1,164 @@
+import type { AgentTaskResult, RoundResult } from "../types/index.js";
+
+export const PLATEAU_EPSILON = 0.01;
+export const NEAR_THRESHOLD_MARGIN = 0.02;
+export const PLATEAU_PATIENCE = 2;
+export const DIMENSION_DELTA_THRESHOLD = 0.05;
+
+export function updateDimensionTrajectory(
+  dimensionTrajectory: Record<string, number[]>,
+  dimensionScores: Record<string, number>,
+): void {
+  for (const [dimension, score] of Object.entries(dimensionScores)) {
+    if (!(dimension in dimensionTrajectory)) {
+      dimensionTrajectory[dimension] = [];
+    }
+    dimensionTrajectory[dimension].push(score);
+  }
+}
+
+export function applyScoreDeltaPolicy(opts: {
+  score: number;
+  prevValidScore: number | null;
+  maxScoreDelta: number;
+  capScoreJumps: boolean;
+  roundNum: number;
+}): { effectiveScore: number; warning?: string } {
+  if (opts.prevValidScore === null) {
+    return { effectiveScore: opts.score };
+  }
+
+  const delta = Math.abs(opts.score - opts.prevValidScore);
+  if (delta <= opts.maxScoreDelta) {
+    return { effectiveScore: opts.score };
+  }
+
+  const warning =
+    `Score jump of ${delta.toFixed(3)} exceeds maxScoreDelta ${opts.maxScoreDelta} ` +
+    `(round ${opts.roundNum}: ${opts.prevValidScore.toFixed(3)} -> ${opts.score.toFixed(3)})`;
+
+  if (!opts.capScoreJumps) {
+    return { effectiveScore: opts.score, warning };
+  }
+
+  return {
+    effectiveScore: Math.max(
+      0,
+      opts.score > opts.prevValidScore
+        ? opts.prevValidScore + opts.maxScoreDelta
+        : opts.prevValidScore - opts.maxScoreDelta,
+    ),
+    warning,
+  };
+}
+
+export function evaluatePlateauState(opts: {
+  prevValidScore: number | null;
+  score: number;
+  plateauCount: number;
+  roundNum: number;
+  minRounds: number;
+}): { plateauCount: number; shouldStop: boolean } {
+  if (
+    opts.prevValidScore !== null
+    && Math.abs(opts.score - opts.prevValidScore) < PLATEAU_EPSILON
+  ) {
+    const plateauCount = opts.plateauCount + 1;
+    return {
+      plateauCount,
+      shouldStop: plateauCount >= PLATEAU_PATIENCE && opts.roundNum >= opts.minRounds,
+    };
+  }
+
+  return { plateauCount: 0, shouldStop: false };
+}
+
+export function evaluateThresholdState(opts: {
+  effectiveScore: number;
+  qualityThreshold: number;
+  roundNum: number;
+  minRounds: number;
+  maxRounds: number;
+  thresholdMetRound: number | null;
+  dimensionScores: Record<string, number>;
+  dimensionThreshold: number | null;
+}): {
+  metThreshold: boolean;
+  shouldStop: boolean;
+  thresholdMetRound: number | null;
+} {
+  let dimensionsSatisfied = true;
+  if (opts.dimensionThreshold !== null && Object.keys(opts.dimensionScores).length > 0) {
+    dimensionsSatisfied = Object.values(opts.dimensionScores).every(
+      (score) => score >= opts.dimensionThreshold!,
+    );
+  }
+
+  if (
+    opts.effectiveScore >= opts.qualityThreshold
+    && opts.roundNum >= opts.minRounds
+    && dimensionsSatisfied
+  ) {
+    const nearThreshold = opts.effectiveScore < opts.qualityThreshold + NEAR_THRESHOLD_MARGIN;
+
+    if (opts.thresholdMetRound !== null) {
+      return {
+        metThreshold: true,
+        shouldStop: true,
+        thresholdMetRound: opts.thresholdMetRound,
+      };
+    }
+
+    if (nearThreshold && opts.roundNum < opts.maxRounds) {
+      return {
+        metThreshold: false,
+        shouldStop: false,
+        thresholdMetRound: opts.roundNum,
+      };
+    }
+
+    return {
+      metThreshold: true,
+      shouldStop: true,
+      thresholdMetRound: opts.roundNum,
+    };
+  }
+
+  return {
+    metThreshold: false,
+    shouldStop: false,
+    thresholdMetRound: null,
+  };
+}
+
+export function buildRevisionFeedbackResult(opts: {
+  result: AgentTaskResult;
+  previousValidRound?: RoundResult;
+}): AgentTaskResult {
+  if (Object.keys(opts.result.dimensionScores).length === 0) {
+    return opts.result;
+  }
+
+  const previousDimensions = opts.previousValidRound?.dimensionScores ?? {};
+  const dimensionLines: string[] = [];
+
+  for (const [dimension, score] of Object.entries(opts.result.dimensionScores).sort()) {
+    let line = `  - ${dimension}: ${score.toFixed(2)}`;
+    if (dimension in previousDimensions) {
+      const delta = score - previousDimensions[dimension];
+      if (delta < -DIMENSION_DELTA_THRESHOLD) {
+        line += ` (REGRESSION from ${previousDimensions[dimension].toFixed(2)} -- preserve this dimension)`;
+      } else if (delta > DIMENSION_DELTA_THRESHOLD) {
+        line += ` (improved from ${previousDimensions[dimension].toFixed(2)})`;
+      }
+    }
+    dimensionLines.push(line);
+  }
+
+  return {
+    score: opts.result.score,
+    reasoning: `${opts.result.reasoning}\n\nDimension Scores:\n${dimensionLines.join("\n")}`,
+    dimensionScores: opts.result.dimensionScores,
+    internalRetries: opts.result.internalRetries,
+  };
+}

--- a/ts/src/execution/improvement-loop-result.ts
+++ b/ts/src/execution/improvement-loop-result.ts
@@ -1,0 +1,81 @@
+import type {
+  AgentTaskResult,
+  ImprovementResult,
+  RoundResult,
+} from "../types/index.js";
+
+function findWorstDimension(dimensionScores: Record<string, number>): {
+  worstDimension: string | undefined;
+  worstDimensionScore: number | undefined;
+} {
+  const entries = Object.entries(dimensionScores);
+  if (entries.length === 0) {
+    return { worstDimension: undefined, worstDimensionScore: undefined };
+  }
+
+  let [worstDimension, worstDimensionScore] = entries[0];
+  for (let index = 1; index < entries.length; index += 1) {
+    const [dimension, score] = entries[index];
+    if (score < worstDimensionScore) {
+      worstDimension = dimension;
+      worstDimensionScore = score;
+    }
+  }
+
+  return { worstDimension, worstDimensionScore };
+}
+
+export function buildRoundResult(opts: {
+  roundNumber: number;
+  output: string;
+  result: AgentTaskResult;
+  judgeFailed: boolean;
+  roundDurationMs: number;
+}): RoundResult {
+  const worstDimension = opts.judgeFailed
+    ? { worstDimension: undefined, worstDimensionScore: undefined }
+    : findWorstDimension(opts.result.dimensionScores);
+
+  return {
+    roundNumber: opts.roundNumber,
+    output: opts.output,
+    score: opts.result.score,
+    reasoning: opts.result.reasoning,
+    dimensionScores: opts.result.dimensionScores,
+    isRevision: opts.roundNumber > 1,
+    judgeFailed: opts.judgeFailed,
+    worstDimension: worstDimension.worstDimension,
+    worstDimensionScore: worstDimension.worstDimensionScore,
+    roundDurationMs: opts.roundDurationMs,
+  };
+}
+
+export function buildImprovementResult(opts: {
+  rounds: RoundResult[];
+  bestOutput: string;
+  bestScore: number;
+  bestRound: number;
+  totalRounds?: number;
+  metThreshold: boolean;
+  judgeFailures: number;
+  terminationReason: ImprovementResult["terminationReason"];
+  dimensionTrajectory: Record<string, number[]>;
+  totalInternalRetries: number;
+  durationMs: number;
+  judgeCalls: number;
+}): ImprovementResult {
+  return {
+    rounds: opts.rounds,
+    bestOutput: opts.bestOutput,
+    bestScore: opts.bestScore,
+    bestRound: opts.bestRound,
+    totalRounds: opts.totalRounds ?? opts.rounds.length,
+    metThreshold: opts.metThreshold,
+    judgeFailures: opts.judgeFailures,
+    terminationReason: opts.terminationReason,
+    dimensionTrajectory: opts.dimensionTrajectory,
+    totalInternalRetries: opts.totalInternalRetries,
+    durationMs: opts.durationMs,
+    judgeCalls: opts.judgeCalls,
+  };
+}

--- a/ts/src/execution/improvement-loop.ts
+++ b/ts/src/execution/improvement-loop.ts
@@ -3,36 +3,19 @@
  * Port of autocontext/src/autocontext/execution/improvement_loop.py
  */
 
-import type {
-  AgentTaskInterface,
-  AgentTaskResult,
-  RoundResult,
-  ImprovementResult,
-} from "../types/index.js";
+import type { AgentTaskInterface, AgentTaskResult, ImprovementResult } from "../types/index.js";
 import { cleanRevisionOutput } from "./output-cleaner.js";
+import { isImproved, isParseFailure } from "./improvement-loop-detection.js";
+import {
+  applyScoreDeltaPolicy,
+  buildRevisionFeedbackResult,
+  evaluatePlateauState,
+  evaluateThresholdState,
+  updateDimensionTrajectory,
+} from "./improvement-loop-policy.js";
+import { buildImprovementResult, buildRoundResult } from "./improvement-loop-result.js";
 
-const PARSE_FAILURE_MARKERS = [
-  "no parseable score found",
-  "missing JUDGE_RESULT markers",
-  "invalid JSON",
-  "Failed to parse judge response",
-] as const;
-
-const PLATEAU_EPSILON = 0.01;
-const NEAR_THRESHOLD_MARGIN = 0.02;
-const PLATEAU_PATIENCE = 2;
-const DIMENSION_DELTA_THRESHOLD = 0.05;
-
-export function isParseFailure(score: number, reasoning: string): boolean {
-  if (score > 0) return false;
-  return PARSE_FAILURE_MARKERS.some((m) => reasoning.includes(m));
-}
-
-export function isImproved(rounds: RoundResult[]): boolean {
-  const valid = rounds.filter((r) => !r.judgeFailed);
-  if (valid.length < 2) return false;
-  return valid[valid.length - 1].score > valid[0].score;
-}
+export { isImproved, isParseFailure } from "./improvement-loop-detection.js";
 
 export interface ImprovementLoopOpts {
   task: AgentTaskInterface;
@@ -45,22 +28,22 @@ export interface ImprovementLoopOpts {
 }
 
 export class ImprovementLoop {
-  private task: AgentTaskInterface;
-  private maxRounds: number;
-  private qualityThreshold: number;
-  private minRounds: number;
-  private maxScoreDelta: number;
-  private capScoreJumps: boolean;
-  private dimensionThreshold: number | null;
+  #task: AgentTaskInterface;
+  #maxRounds: number;
+  #qualityThreshold: number;
+  #minRounds: number;
+  #maxScoreDelta: number;
+  #capScoreJumps: boolean;
+  #dimensionThreshold: number | null;
 
   constructor(opts: ImprovementLoopOpts) {
-    this.task = opts.task;
-    this.maxRounds = Math.max(1, opts.maxRounds ?? 5);
-    this.qualityThreshold = opts.qualityThreshold ?? 0.9;
-    this.minRounds = Math.max(1, opts.minRounds ?? 1);
-    this.maxScoreDelta = opts.maxScoreDelta ?? 0.5;
-    this.capScoreJumps = opts.capScoreJumps ?? false;
-    this.dimensionThreshold = opts.dimensionThreshold ?? null;
+    this.#task = opts.task;
+    this.#maxRounds = Math.max(1, opts.maxRounds ?? 5);
+    this.#qualityThreshold = opts.qualityThreshold ?? 0.9;
+    this.#minRounds = Math.max(1, opts.minRounds ?? 1);
+    this.#maxScoreDelta = opts.maxScoreDelta ?? 0.5;
+    this.#capScoreJumps = opts.capScoreJumps ?? false;
+    this.#dimensionThreshold = opts.dimensionThreshold ?? null;
   }
 
   async run(opts: {
@@ -72,144 +55,99 @@ export class ImprovementLoop {
   }): Promise<ImprovementResult> {
     const loopStart = performance.now();
     let judgeCalls = 0;
-    const rounds: RoundResult[] = [];
+    const rounds = [] as ReturnType<typeof buildRoundResult>[];
     let currentOutput = opts.initialOutput;
     let bestOutput = opts.initialOutput;
     let bestScore = 0;
     let bestRound = 1;
     let judgeFailures = 0;
-    let lastGoodResult: RoundResult | null = null;
+    let lastGoodResult: ReturnType<typeof buildRoundResult> | null = null;
     let consecutiveFailures = 0;
     const maxConsecutiveFailures = 3;
     let totalInternalRetries = 0;
     let terminationReason: ImprovementResult["terminationReason"] = "max_rounds";
     const dimensionTrajectory: Record<string, number[]> = {};
     let thresholdMetRound: number | null = null;
-
-    // Dimension pinning: lock dimension names after first successful evaluation
     let pinnedDimensions: string[] | undefined;
-
-    // Plateau detection state
     let prevValidScore: number | null = null;
     let plateauCount = 0;
 
-    for (let roundNum = 1; roundNum <= this.maxRounds; roundNum++) {
+    for (let roundNum = 1; roundNum <= this.#maxRounds; roundNum++) {
       const roundStart = performance.now();
-      const result = await this.task.evaluateOutput(currentOutput, opts.state, {
+      const result = await this.#task.evaluateOutput(currentOutput, opts.state, {
         referenceContext: opts.referenceContext,
         requiredConcepts: opts.requiredConcepts,
         calibrationExamples: opts.calibrationExamples,
         pinnedDimensions,
       });
-      judgeCalls++;
+      judgeCalls += 1;
       const roundMs = Math.round(performance.now() - roundStart);
       totalInternalRetries += result.internalRetries ?? 0;
 
       const failed = isParseFailure(result.score, result.reasoning);
-
-      const roundResult: RoundResult = {
+      const roundResult = buildRoundResult({
         roundNumber: roundNum,
         output: currentOutput,
-        score: result.score,
-        reasoning: result.reasoning,
-        dimensionScores: result.dimensionScores,
-        isRevision: roundNum > 1,
+        result,
         judgeFailed: failed,
-        worstDimension: undefined,
-        worstDimensionScore: undefined,
         roundDurationMs: roundMs,
-      };
+      });
       rounds.push(roundResult);
 
       if (failed) {
-        judgeFailures++;
-        consecutiveFailures++;
-        thresholdMetRound = null; // Reset stability tracking on parse failure
+        judgeFailures += 1;
+        consecutiveFailures += 1;
+        thresholdMetRound = null;
 
         if (consecutiveFailures >= maxConsecutiveFailures) {
           terminationReason = "consecutive_failures";
           break;
         }
 
-        if (roundNum < this.maxRounds) {
-          if (lastGoodResult && this.task.reviseOutput) {
-            const feedbackResult: AgentTaskResult = {
-              score: lastGoodResult.score,
-              reasoning: lastGoodResult.reasoning,
-              dimensionScores: lastGoodResult.dimensionScores,
-              internalRetries: 0,
-            };
-            const revised = await this.task.reviseOutput(
-              currentOutput,
-              feedbackResult,
-              opts.state,
-            );
-            const cleaned = cleanRevisionOutput(revised);
-            if (cleaned !== currentOutput) currentOutput = cleaned;
+        if (roundNum < this.#maxRounds && lastGoodResult && this.#task.reviseOutput) {
+          const feedbackResult: AgentTaskResult = {
+            score: lastGoodResult.score,
+            reasoning: lastGoodResult.reasoning,
+            dimensionScores: lastGoodResult.dimensionScores,
+            internalRetries: 0,
+          };
+          const revised = await this.#task.reviseOutput(currentOutput, feedbackResult, opts.state);
+          const cleaned = cleanRevisionOutput(revised);
+          if (cleaned !== currentOutput) {
+            currentOutput = cleaned;
           }
-          // else: no prior feedback, just re-judge next round
         }
         continue;
       }
 
-      // Successful evaluation
       consecutiveFailures = 0;
+      const previousValidRound = lastGoodResult;
       lastGoodResult = roundResult;
 
-      // Compute worst dimension for this round
-      const dimEntries = Object.entries(result.dimensionScores);
-      if (dimEntries.length > 0) {
-        let worstDim = dimEntries[0][0];
-        let worstScore = dimEntries[0][1];
-        for (let i = 1; i < dimEntries.length; i++) {
-          const [dim, dimScore] = dimEntries[i];
-          if (dimScore < worstScore) {
-            worstDim = dim;
-            worstScore = dimScore;
-          }
-        }
-        roundResult.worstDimension = worstDim;
-        roundResult.worstDimensionScore = worstScore;
-      }
-
-      // Pin dimension names after first successful evaluation
       if (pinnedDimensions === undefined && Object.keys(result.dimensionScores).length > 0) {
         pinnedDimensions = Object.keys(result.dimensionScores).sort();
       }
 
-      // Build dimension trajectory from valid rounds
-      for (const [dim, dimScore] of Object.entries(result.dimensionScores)) {
-        if (!(dim in dimensionTrajectory)) {
-          dimensionTrajectory[dim] = [];
-        }
-        dimensionTrajectory[dim].push(dimScore);
+      updateDimensionTrajectory(dimensionTrajectory, result.dimensionScores);
+
+      const scoreDeltaPolicy = applyScoreDeltaPolicy({
+        score: result.score,
+        prevValidScore,
+        maxScoreDelta: this.#maxScoreDelta,
+        capScoreJumps: this.#capScoreJumps,
+        roundNum,
+      });
+      if (scoreDeltaPolicy.warning) {
+        console.warn(scoreDeltaPolicy.warning);
       }
+      let effectiveScore = scoreDeltaPolicy.effectiveScore;
 
-      let effectiveScore = result.score;
-
-      // Max score delta warning + optional cap
-      if (prevValidScore !== null) {
-        const delta = Math.abs(result.score - prevValidScore);
-        if (delta > this.maxScoreDelta) {
-          console.warn(
-            `Score jump of ${delta.toFixed(3)} exceeds maxScoreDelta ${this.maxScoreDelta} ` +
-            `(round ${roundNum}: ${prevValidScore.toFixed(3)} -> ${result.score.toFixed(3)})`,
-          );
-          if (this.capScoreJumps) {
-            effectiveScore = Math.max(0, result.score > prevValidScore
-              ? prevValidScore + this.maxScoreDelta
-              : prevValidScore - this.maxScoreDelta);
-          }
-        }
-      }
-
-      // Reference verification hook — apply score penalty if facts unverified
-      if (effectiveScore > 0 && this.task.verifyFacts) {
-        const verifyResult = await this.task.verifyFacts(currentOutput, opts.state);
+      if (effectiveScore > 0 && this.#task.verifyFacts) {
+        const verifyResult = await this.#task.verifyFacts(currentOutput, opts.state);
         if (verifyResult && !verifyResult.verified) {
           const issues = verifyResult.issues ?? [];
           if (issues.length > 0) {
-            roundResult.reasoning += " | Fact-check issues: " + issues.join("; ");
+            roundResult.reasoning += ` | Fact-check issues: ${issues.join("; ")}`;
           }
           effectiveScore = Math.max(0, effectiveScore * 0.9);
           roundResult.score = effectiveScore;
@@ -222,109 +160,58 @@ export class ImprovementLoop {
         bestRound = roundNum;
       }
 
-      // Plateau detection (only after minRounds satisfied)
-      if (prevValidScore !== null && Math.abs(result.score - prevValidScore) < PLATEAU_EPSILON) {
-        plateauCount++;
-        if (plateauCount >= PLATEAU_PATIENCE && roundNum >= this.minRounds) {
-          terminationReason = "plateau_stall";
-          break;
-        }
-      } else {
-        plateauCount = 0;
+      const plateauState = evaluatePlateauState({
+        prevValidScore,
+        score: result.score,
+        plateauCount,
+        roundNum,
+        minRounds: this.#minRounds,
+      });
+      plateauCount = plateauState.plateauCount;
+      if (plateauState.shouldStop) {
+        terminationReason = "plateau_stall";
+        break;
       }
       prevValidScore = result.score;
 
-      // Dimension threshold gate: all dimensions must meet minimum
-      let dimsOk = true;
-      if (this.dimensionThreshold !== null && Object.keys(result.dimensionScores).length > 0) {
-        dimsOk = Object.values(result.dimensionScores).every(
-          (v) => v >= this.dimensionThreshold!,
-        );
+      const thresholdState = evaluateThresholdState({
+        effectiveScore,
+        qualityThreshold: this.#qualityThreshold,
+        roundNum,
+        minRounds: this.#minRounds,
+        maxRounds: this.#maxRounds,
+        thresholdMetRound,
+        dimensionScores: result.dimensionScores,
+        dimensionThreshold: this.#dimensionThreshold,
+      });
+      thresholdMetRound = thresholdState.thresholdMetRound;
+      if (thresholdState.shouldStop) {
+        terminationReason = "threshold_met";
+        return buildImprovementResult({
+          rounds,
+          bestOutput,
+          bestScore,
+          bestRound,
+          totalRounds: roundNum,
+          metThreshold: thresholdState.metThreshold,
+          judgeFailures,
+          terminationReason,
+          dimensionTrajectory,
+          totalInternalRetries,
+          durationMs: Math.round(performance.now() - loopStart),
+          judgeCalls,
+        });
       }
 
-      if (effectiveScore >= this.qualityThreshold && roundNum >= this.minRounds && dimsOk) {
-        const nearThreshold =
-          effectiveScore < this.qualityThreshold + NEAR_THRESHOLD_MARGIN;
-
-        if (thresholdMetRound !== null) {
-          // Threshold was met on a previous round too — confirmed stable
-          terminationReason = "threshold_met";
-          const durationMs = Math.round(performance.now() - loopStart);
-          return {
-            rounds,
-            bestOutput,
-            bestScore,
-            bestRound,
-            totalRounds: roundNum,
-            metThreshold: true,
-            judgeFailures,
-            terminationReason,
-            dimensionTrajectory,
-            totalInternalRetries,
-            durationMs,
-            judgeCalls,
-          };
-        }
-
-        if (nearThreshold && roundNum < this.maxRounds) {
-          // Score barely meets threshold — continue to confirm stability
-          thresholdMetRound = roundNum;
-        } else {
-          // Clearly above threshold — stop immediately
-          terminationReason = "threshold_met";
-          const durationMs = Math.round(performance.now() - loopStart);
-          return {
-            rounds,
-            bestOutput,
-            bestScore,
-            bestRound,
-            totalRounds: roundNum,
-            metThreshold: true,
-            judgeFailures,
-            terminationReason,
-            dimensionTrajectory,
-            totalInternalRetries,
-            durationMs,
-            judgeCalls,
-          };
-        }
-      } else {
-        // Score dropped below threshold after previously meeting it
-        thresholdMetRound = null;
-      }
-
-      if (roundNum < this.maxRounds && this.task.reviseOutput) {
-        // Enrich feedback with dimension scores + regression warnings (AC-41)
-        let revisionResult: AgentTaskResult = result;
-        if (Object.keys(result.dimensionScores).length > 0 && roundNum > 1) {
-          const prevValid = rounds.slice(0, -1).filter((r) => !r.judgeFailed);
-          const prevDims = prevValid.length > 0 ? prevValid[prevValid.length - 1].dimensionScores : {};
-          const dimLines: string[] = [];
-          for (const [dim, dscore] of Object.entries(result.dimensionScores).sort()) {
-            let line = `  - ${dim}: ${dscore.toFixed(2)}`;
-            if (dim in prevDims) {
-              const delta = dscore - prevDims[dim];
-              if (delta < -DIMENSION_DELTA_THRESHOLD) {
-                line += ` (REGRESSION from ${prevDims[dim].toFixed(2)} -- preserve this dimension)`;
-              } else if (delta > DIMENSION_DELTA_THRESHOLD) {
-                line += ` (improved from ${prevDims[dim].toFixed(2)})`;
-              }
-            }
-            dimLines.push(line);
-          }
-          const dimAnnotation = "\n\nDimension Scores:\n" + dimLines.join("\n");
-          revisionResult = {
-            score: result.score,
-            reasoning: result.reasoning + dimAnnotation,
-            dimensionScores: result.dimensionScores,
-            internalRetries: result.internalRetries,
-          };
-        }
-        const revised = await this.task.reviseOutput(
-          currentOutput,
-          revisionResult,
-          opts.state,
-        );
+      if (roundNum < this.#maxRounds && this.#task.reviseOutput) {
+        const revisionFeedback =
+          roundNum > 1
+            ? buildRevisionFeedbackResult({
+                result,
+                previousValidRound: previousValidRound ?? undefined,
+              })
+            : result;
+        const revised = await this.#task.reviseOutput(currentOutput, revisionFeedback, opts.state);
         const cleaned = cleanRevisionOutput(revised);
         if (cleaned === currentOutput) {
           terminationReason = "unchanged_output";
@@ -334,20 +221,18 @@ export class ImprovementLoop {
       }
     }
 
-    const durationMs = Math.round(performance.now() - loopStart);
-    return {
+    return buildImprovementResult({
       rounds,
       bestOutput,
       bestScore,
       bestRound,
-      totalRounds: rounds.length,
       metThreshold: false,
       judgeFailures,
       terminationReason,
       dimensionTrajectory,
       totalInternalRetries,
-      durationMs,
+      durationMs: Math.round(performance.now() - loopStart),
       judgeCalls,
-    };
+    });
   }
 }

--- a/ts/src/execution/sandbox.ts
+++ b/ts/src/execution/sandbox.ts
@@ -27,24 +27,24 @@ export interface Sandbox {
 }
 
 export class SandboxManager {
-  private provider: LLMProvider;
-  private store: SQLiteStore;
-  private runsRoot: string;
-  private knowledgeRoot: string;
-  private maxSandboxes: number;
-  private sandboxes = new Map<string, Sandbox>();
+  #provider: LLMProvider;
+  #store: SQLiteStore;
+  #runsRoot: string;
+  #knowledgeRoot: string;
+  #maxSandboxes: number;
+  #sandboxes = new Map<string, Sandbox>();
 
   constructor(opts: SandboxManagerOpts) {
-    this.provider = opts.provider;
-    this.store = opts.store;
-    this.runsRoot = opts.runsRoot;
-    this.knowledgeRoot = opts.knowledgeRoot;
-    this.maxSandboxes = opts.maxSandboxes ?? 10;
+    this.#provider = opts.provider;
+    this.#store = opts.store;
+    this.#runsRoot = opts.runsRoot;
+    this.#knowledgeRoot = opts.knowledgeRoot;
+    this.#maxSandboxes = opts.maxSandboxes ?? 10;
   }
 
   create(scenarioName: string, userId = "anonymous"): Sandbox {
-    if (this.sandboxes.size >= this.maxSandboxes) {
-      throw new Error(`Maximum sandbox limit (${this.maxSandboxes}) reached`);
+    if (this.#sandboxes.size >= this.#maxSandboxes) {
+      throw new Error(`Maximum sandbox limit (${this.#maxSandboxes}) reached`);
     }
     if (!(scenarioName in SCENARIO_REGISTRY)) {
       const supported = Object.keys(SCENARIO_REGISTRY).sort().join(", ");
@@ -58,20 +58,20 @@ export class SandboxManager {
       createdAt: new Date().toISOString(),
       status: "active",
     };
-    this.sandboxes.set(sandboxId, sandbox);
+    this.#sandboxes.set(sandboxId, sandbox);
     return sandbox;
   }
 
   getStatus(sandboxId: string): Sandbox | null {
-    return this.sandboxes.get(sandboxId) ?? null;
+    return this.#sandboxes.get(sandboxId) ?? null;
   }
 
   list(): Sandbox[] {
-    return [...this.sandboxes.values()].filter((s) => s.status !== "destroyed");
+    return [...this.#sandboxes.values()].filter((s) => s.status !== "destroyed");
   }
 
   async run(sandboxId: string, generations = 1): Promise<Record<string, unknown>> {
-    const sandbox = this.sandboxes.get(sandboxId);
+    const sandbox = this.#sandboxes.get(sandboxId);
     if (!sandbox) throw new Error(`Sandbox ${sandboxId} not found`);
     if (sandbox.status === "destroyed") throw new Error(`Sandbox ${sandboxId} is destroyed`);
 
@@ -87,11 +87,11 @@ export class SandboxManager {
       assertFamilyContract(scenario, "game", `scenario '${sandbox.scenarioName}'`);
 
       const runner = new GenerationRunner({
-        provider: this.provider,
+        provider: this.#provider,
         scenario,
-        store: this.store,
-        runsRoot: this.runsRoot,
-        knowledgeRoot: this.knowledgeRoot,
+        store: this.#store,
+        runsRoot: this.#runsRoot,
+        knowledgeRoot: this.#knowledgeRoot,
         matchesPerGeneration: 2,
       });
 
@@ -105,19 +105,22 @@ export class SandboxManager {
   }
 
   readPlaybook(sandboxId: string): string {
-    const sandbox = this.sandboxes.get(sandboxId);
+    const sandbox = this.#sandboxes.get(sandboxId);
     if (!sandbox) {
       throw new Error(`Sandbox ${sandboxId} not found`);
     }
-    const artifacts = new ArtifactStore({ runsRoot: this.runsRoot, knowledgeRoot: this.knowledgeRoot });
+    const artifacts = new ArtifactStore({
+      runsRoot: this.#runsRoot,
+      knowledgeRoot: this.#knowledgeRoot,
+    });
     return artifacts.readPlaybook(sandbox.scenarioName);
   }
 
   destroy(sandboxId: string): boolean {
-    const sandbox = this.sandboxes.get(sandboxId);
+    const sandbox = this.#sandboxes.get(sandboxId);
     if (!sandbox) return false;
     sandbox.status = "destroyed";
-    this.sandboxes.delete(sandboxId);
+    this.#sandboxes.delete(sandboxId);
     return true;
   }
 }

--- a/ts/src/execution/simple-agent-task-workflow.ts
+++ b/ts/src/execution/simple-agent-task-workflow.ts
@@ -1,0 +1,177 @@
+import { LLMJudge } from "../judge/llm-judge.js";
+import type { AgentTaskResult, LLMProvider } from "../types/index.js";
+import type { JudgeInterface } from "../judge/delegated.js";
+import type { RlmSessionRecord, RlmTaskConfig } from "../rlm/types.js";
+import { runAgentTaskRlmSession } from "../rlm/agent-task.js";
+
+export interface EvaluateSimpleAgentTaskOpts {
+  taskPrompt: string;
+  rubric: string;
+  provider: LLMProvider;
+  model: string;
+  output: string;
+  judgeOverride?: JudgeInterface;
+  referenceContext?: string;
+  requiredConcepts?: string[];
+  calibrationExamples?: Array<Record<string, unknown>>;
+  pinnedDimensions?: string[];
+}
+
+export async function evaluateSimpleAgentTaskOutput(
+  opts: EvaluateSimpleAgentTaskOpts,
+): Promise<AgentTaskResult> {
+  const judge = opts.judgeOverride ?? new LLMJudge({
+    provider: opts.provider,
+    model: opts.model,
+    rubric: opts.rubric,
+  });
+  const result = await judge.evaluate({
+    taskPrompt: opts.taskPrompt,
+    agentOutput: opts.output,
+    referenceContext: opts.referenceContext,
+    requiredConcepts: opts.requiredConcepts,
+    calibrationExamples: opts.calibrationExamples,
+    pinnedDimensions: opts.pinnedDimensions,
+  });
+  return {
+    score: result.score,
+    reasoning: result.reasoning,
+    dimensionScores: result.dimensionScores,
+    internalRetries: result.internalRetries ?? 0,
+  };
+}
+
+export async function runSimpleAgentTaskRlm(opts: {
+  provider: LLMProvider;
+  model: string;
+  config: RlmTaskConfig | null;
+  phase: "generate" | "revise";
+  taskPrompt: string;
+  rubric: string;
+  sessions: RlmSessionRecord[];
+  revisionPrompt?: string;
+  currentOutput?: string;
+  judgeResult?: AgentTaskResult;
+  referenceContext?: string;
+  requiredConcepts?: string[];
+}): Promise<string | null> {
+  if (!opts.config) {
+    return null;
+  }
+  const record = await runAgentTaskRlmSession({
+    provider: opts.provider,
+    model: opts.model,
+    config: opts.config,
+    phase: opts.phase,
+    taskPrompt: opts.taskPrompt,
+    rubric: opts.rubric,
+    currentOutput: opts.currentOutput,
+    judgeResult: opts.judgeResult,
+    referenceContext: opts.referenceContext,
+    requiredConcepts: opts.requiredConcepts,
+    revisionPrompt: opts.revisionPrompt,
+  });
+  opts.sessions.push(record);
+  const content = record.content.trim();
+  return content.length > 0 ? content : null;
+}
+
+export async function generateSimpleAgentTaskOutput(opts: {
+  provider: LLMProvider;
+  model: string;
+  taskPrompt: string;
+  rubric: string;
+  rlmConfig: RlmTaskConfig | null;
+  rlmSessions: RlmSessionRecord[];
+  referenceContext?: string;
+  requiredConcepts?: string[];
+}): Promise<string> {
+  const rlmOutput = await runSimpleAgentTaskRlm({
+    provider: opts.provider,
+    model: opts.model,
+    config: opts.rlmConfig,
+    phase: "generate",
+    taskPrompt: opts.taskPrompt,
+    rubric: opts.rubric,
+    sessions: opts.rlmSessions,
+    referenceContext: opts.referenceContext,
+    requiredConcepts: opts.requiredConcepts,
+  });
+  if (rlmOutput) {
+    return rlmOutput;
+  }
+
+  const result = await opts.provider.complete({
+    systemPrompt: "You are a skilled writer and analyst. Complete the task precisely.",
+    userPrompt: opts.taskPrompt,
+    model: opts.model,
+  });
+  return result.text;
+}
+
+export function buildSimpleAgentTaskRevisionPrompt(opts: {
+  revisionPrompt?: string;
+  output: string;
+  judgeResult: AgentTaskResult;
+  taskPrompt: string;
+}): string {
+  const instruction = opts.revisionPrompt
+    ?? "Revise the following output based on the judge's feedback. Maintain what works, fix what doesn't.";
+
+  return (
+    `${instruction}\n\n` +
+    `## Original Output\n${opts.output}\n\n` +
+    `## Judge Score: ${opts.judgeResult.score.toFixed(2)}\n` +
+    `## Judge Feedback\n${opts.judgeResult.reasoning}\n\n` +
+    `## Task\n${opts.taskPrompt}\n\n` +
+    "Produce an improved version:"
+  );
+}
+
+export async function reviseSimpleAgentTaskOutput(opts: {
+  provider: LLMProvider;
+  model: string;
+  taskPrompt: string;
+  rubric: string;
+  revisionPrompt?: string;
+  output: string;
+  judgeResult: AgentTaskResult;
+  rlmConfig: RlmTaskConfig | null;
+  rlmSessions: RlmSessionRecord[];
+  referenceContext?: string;
+  requiredConcepts?: string[];
+}): Promise<string> {
+  const rlmOutput = await runSimpleAgentTaskRlm({
+    provider: opts.provider,
+    model: opts.model,
+    config: opts.rlmConfig,
+    phase: "revise",
+    taskPrompt: opts.taskPrompt,
+    rubric: opts.rubric,
+    sessions: opts.rlmSessions,
+    revisionPrompt: opts.revisionPrompt,
+    currentOutput: opts.output,
+    judgeResult: opts.judgeResult,
+    referenceContext: opts.referenceContext,
+    requiredConcepts: opts.requiredConcepts,
+  });
+  if (rlmOutput) {
+    return rlmOutput;
+  }
+
+  const result = await opts.provider.complete({
+    systemPrompt:
+      "You are revising content based on expert feedback. Improve the output. " +
+      "IMPORTANT: Return ONLY the revised content. Do NOT include analysis, " +
+      "explanations, headers like '## Revised Output', or self-assessment. " +
+      "Just output the improved version directly.",
+    userPrompt: buildSimpleAgentTaskRevisionPrompt({
+      revisionPrompt: opts.revisionPrompt,
+      output: opts.output,
+      judgeResult: opts.judgeResult,
+      taskPrompt: opts.taskPrompt,
+    }),
+    model: opts.model,
+  });
+  return result.text;
+}

--- a/ts/src/execution/task-processing-workflow.ts
+++ b/ts/src/execution/task-processing-workflow.ts
@@ -1,0 +1,192 @@
+import { ImprovementLoop } from "./improvement-loop.js";
+import { SequentialDelegatedJudge, type JudgeInterface } from "../judge/delegated.js";
+import { renderAgentTaskPrompt, resolveCustomAgentTask } from "../scenarios/custom-loader.js";
+import type { LLMProvider, AgentTaskInterface, ImprovementResult } from "../types/index.js";
+import type { SQLiteStore, TaskQueueRow } from "../storage/index.js";
+import type { TaskConfig } from "./task-runner-config.js";
+import { parseTaskConfig, serializeTaskResult } from "./task-runner-config.js";
+import type { RlmSessionRecord, RlmTaskConfig } from "../rlm/types.js";
+
+interface SavedTaskSpec {
+  judgeRubric?: string;
+  referenceContext?: string;
+  requiredConcepts?: string[];
+  calibrationExamples?: Array<Record<string, unknown>>;
+  maxRounds?: number;
+  qualityThreshold?: number;
+  revisionPrompt?: string;
+}
+
+interface SavedTaskLike {
+  spec: SavedTaskSpec;
+}
+
+export interface QueuedTaskExecutionPlan {
+  taskPrompt: string;
+  rubric: string;
+  referenceContext?: string;
+  requiredConcepts?: string[];
+  calibrationExamples?: Array<Record<string, unknown>>;
+  maxRounds: number;
+  qualityThreshold: number;
+  minRounds: number;
+  revisionPrompt?: string;
+  initialOutput?: string;
+  rlm?: RlmTaskConfig;
+  delegatedJudge?: JudgeInterface;
+}
+
+interface WorkflowAgentTask extends AgentTaskInterface {
+  generateOutput(context?: { referenceContext?: string; requiredConcepts?: string[] }): Promise<string>;
+  getRlmSessions(): RlmSessionRecord[];
+}
+
+interface ImprovementLoopLike {
+  run(opts: {
+    initialOutput: string;
+    state: Record<string, unknown>;
+    referenceContext?: string;
+    requiredConcepts?: string[];
+    calibrationExamples?: Array<Record<string, unknown>>;
+  }): Promise<ImprovementResult>;
+}
+
+interface TaskProcessingInternals {
+  parseTaskConfig: typeof parseTaskConfig;
+  resolveSavedTask(knowledgeRoot: string, specName: string): SavedTaskLike | null;
+  renderSavedTaskPrompt(spec: SavedTaskSpec): string;
+  createDelegatedJudge: typeof SequentialDelegatedJudge;
+  createAgentTask(opts: {
+    taskPrompt: string;
+    rubric: string;
+    provider: LLMProvider;
+    model: string;
+    revisionPrompt?: string;
+    rlm?: RlmTaskConfig;
+    delegatedJudge?: JudgeInterface;
+  }): WorkflowAgentTask;
+  createImprovementLoop(opts: {
+    task: WorkflowAgentTask;
+    maxRounds: number;
+    qualityThreshold: number;
+    minRounds: number;
+  }): ImprovementLoopLike;
+  serializeTaskResult: typeof serializeTaskResult;
+}
+
+const defaultInternals: TaskProcessingInternals = {
+  parseTaskConfig,
+  resolveSavedTask: (knowledgeRoot, specName) =>
+    resolveCustomAgentTask(knowledgeRoot, specName) as unknown as SavedTaskLike | null,
+  renderSavedTaskPrompt: (spec) => renderAgentTaskPrompt(spec as Parameters<typeof renderAgentTaskPrompt>[0]),
+  createDelegatedJudge: SequentialDelegatedJudge,
+  createAgentTask: () => {
+    throw new Error("createAgentTask must be provided");
+  },
+  createImprovementLoop: (opts) => new ImprovementLoop(opts),
+  serializeTaskResult,
+};
+
+export function buildQueuedTaskExecutionPlan(opts: {
+  task: Pick<TaskQueueRow, "spec_name" | "config_json">;
+  knowledgeRoot?: string;
+  internals?: Partial<TaskProcessingInternals>;
+}): QueuedTaskExecutionPlan {
+  const internals: TaskProcessingInternals = {
+    ...defaultInternals,
+    ...opts.internals,
+  };
+  const config = internals.parseTaskConfig(opts.task.config_json);
+  const savedTask = opts.knowledgeRoot
+    ? internals.resolveSavedTask(opts.knowledgeRoot, opts.task.spec_name)
+    : null;
+
+  const taskPrompt = config.taskPrompt
+    ?? (savedTask ? internals.renderSavedTaskPrompt(savedTask.spec) : undefined)
+    ?? `Complete the task: ${opts.task.spec_name}`;
+  const rubric = config.rubric
+    ?? savedTask?.spec.judgeRubric
+    ?? "Evaluate quality, accuracy, and completeness on a 0-1 scale.";
+
+  return {
+    taskPrompt,
+    rubric,
+    referenceContext: config.referenceContext ?? savedTask?.spec.referenceContext ?? undefined,
+    requiredConcepts: config.requiredConcepts ?? savedTask?.spec.requiredConcepts ?? undefined,
+    calibrationExamples: config.calibrationExamples ?? savedTask?.spec.calibrationExamples ?? undefined,
+    maxRounds: config.maxRounds ?? savedTask?.spec.maxRounds ?? 5,
+    qualityThreshold: config.qualityThreshold ?? savedTask?.spec.qualityThreshold ?? 0.9,
+    minRounds: config.minRounds ?? 1,
+    revisionPrompt: config.revisionPrompt ?? savedTask?.spec.revisionPrompt ?? undefined,
+    initialOutput: config.initialOutput,
+    rlm: config.rlm,
+    delegatedJudge: config.delegatedResults?.length
+      ? new internals.createDelegatedJudge(config.delegatedResults, rubric)
+      : undefined,
+  };
+}
+
+export async function executeQueuedTaskWorkflow(opts: {
+  store: SQLiteStore;
+  task: TaskQueueRow;
+  provider: LLMProvider;
+  model: string;
+  knowledgeRoot?: string;
+  internals?: Partial<TaskProcessingInternals>;
+}): Promise<void> {
+  const internals: TaskProcessingInternals = {
+    ...defaultInternals,
+    ...opts.internals,
+  };
+
+  try {
+    const plan = buildQueuedTaskExecutionPlan({
+      task: opts.task,
+      knowledgeRoot: opts.knowledgeRoot,
+      internals,
+    });
+
+    const agentTask = internals.createAgentTask({
+      taskPrompt: plan.taskPrompt,
+      rubric: plan.rubric,
+      provider: opts.provider,
+      model: opts.model,
+      revisionPrompt: plan.revisionPrompt,
+      rlm: plan.rlm,
+      delegatedJudge: plan.delegatedJudge,
+    });
+
+    let initialOutput = plan.initialOutput;
+    if (!initialOutput) {
+      initialOutput = await agentTask.generateOutput({
+        referenceContext: plan.referenceContext,
+        requiredConcepts: plan.requiredConcepts,
+      });
+    }
+
+    const result = await internals.createImprovementLoop({
+      task: agentTask,
+      maxRounds: plan.maxRounds,
+      qualityThreshold: plan.qualityThreshold,
+      minRounds: plan.minRounds,
+    }).run({
+      initialOutput,
+      state: agentTask.initialState(),
+      referenceContext: plan.referenceContext,
+      requiredConcepts: plan.requiredConcepts,
+      calibrationExamples: plan.calibrationExamples,
+    });
+
+    opts.store.completeTask(
+      opts.task.id,
+      result.bestScore,
+      result.bestOutput,
+      result.totalRounds,
+      result.metThreshold,
+      internals.serializeTaskResult(result, agentTask.getRlmSessions()),
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    opts.store.failTask(opts.task.id, message);
+  }
+}

--- a/ts/src/execution/task-runner-config.ts
+++ b/ts/src/execution/task-runner-config.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+
+import type { ImprovementResult } from "../types/index.js";
+import type { DelegatedResult } from "../judge/delegated.js";
+import {
+  RlmTaskConfigSchema,
+  type RlmSessionRecord,
+  type RlmTaskConfig,
+} from "../rlm/types.js";
+import type { SQLiteStore } from "../storage/index.js";
+
+export interface TaskConfig {
+  maxRounds?: number;
+  qualityThreshold?: number;
+  minRounds?: number;
+  referenceContext?: string;
+  requiredConcepts?: string[];
+  calibrationExamples?: Array<Record<string, unknown>>;
+  initialOutput?: string;
+  rubric?: string;
+  taskPrompt?: string;
+  revisionPrompt?: string;
+  delegatedResults?: DelegatedResult[];
+  rlm?: RlmTaskConfig;
+}
+
+export interface EnqueueTaskRequest {
+  taskPrompt?: string;
+  rubric?: string;
+  referenceContext?: string;
+  requiredConcepts?: string[];
+  maxRounds?: number;
+  qualityThreshold?: number;
+  minRounds?: number;
+  initialOutput?: string;
+  delegatedResults?: DelegatedResult[];
+  priority?: number;
+  rlmEnabled?: boolean;
+  rlmModel?: string;
+  rlmMaxTurns?: number;
+  rlmMaxTokensPerTurn?: number;
+  rlmTemperature?: number;
+  rlmMaxStdoutChars?: number;
+  rlmCodeTimeoutMs?: number;
+  rlmMemoryLimitMb?: number;
+}
+
+const DelegatedResultSchema = z.object({
+  score: z.number().min(0).max(1),
+  reasoning: z.string(),
+  dimension_scores: z.record(z.number().min(0).max(1)).optional(),
+  dimensionScores: z.record(z.number().min(0).max(1)).optional(),
+}).passthrough();
+
+const TaskConfigSchema = z.object({
+  max_rounds: z.number().int().positive().optional(),
+  quality_threshold: z.number().min(0).max(1).optional(),
+  min_rounds: z.number().int().positive().optional(),
+  reference_context: z.string().optional(),
+  required_concepts: z.array(z.string()).optional(),
+  calibration_examples: z.array(z.record(z.unknown())).optional(),
+  initial_output: z.string().optional(),
+  rubric: z.string().optional(),
+  task_prompt: z.string().optional(),
+  revision_prompt: z.string().optional(),
+  delegated_results: z.array(DelegatedResultSchema).optional(),
+  rlm_enabled: z.boolean().optional(),
+  rlm_model: z.string().optional(),
+  rlm_max_turns: z.number().int().positive().optional(),
+  rlm_max_tokens_per_turn: z.number().int().positive().optional(),
+  rlm_temperature: z.number().min(0).max(2).optional(),
+  rlm_max_stdout_chars: z.number().int().positive().optional(),
+  rlm_code_timeout_ms: z.number().int().positive().optional(),
+  rlm_memory_limit_mb: z.number().int().positive().optional(),
+}).passthrough();
+
+export function resolveRlmConfig(raw: Partial<RlmTaskConfig> | null | undefined): RlmTaskConfig | null {
+  if (!raw?.enabled) return null;
+  return RlmTaskConfigSchema.parse(raw);
+}
+
+export function parseTaskConfig(json: string | null): TaskConfig {
+  if (!json) return {};
+  const raw = JSON.parse(json) as Record<string, unknown>;
+  const parsed = TaskConfigSchema.parse(raw);
+  return {
+    maxRounds: parsed.max_rounds,
+    qualityThreshold: parsed.quality_threshold,
+    minRounds: parsed.min_rounds,
+    referenceContext: parsed.reference_context,
+    requiredConcepts: parsed.required_concepts,
+    calibrationExamples: parsed.calibration_examples,
+    initialOutput: parsed.initial_output,
+    rubric: parsed.rubric,
+    taskPrompt: parsed.task_prompt,
+    revisionPrompt: parsed.revision_prompt,
+    delegatedResults: parsed.delegated_results?.map((result) => ({
+      score: result.score,
+      reasoning: result.reasoning,
+      dimensionScores: result.dimension_scores ?? result.dimensionScores ?? {},
+    })),
+    rlm: resolveRlmConfig({
+      enabled: parsed.rlm_enabled ?? false,
+      model: parsed.rlm_model,
+      maxTurns: parsed.rlm_max_turns,
+      maxTokensPerTurn: parsed.rlm_max_tokens_per_turn,
+      temperature: parsed.rlm_temperature,
+      maxStdoutChars: parsed.rlm_max_stdout_chars,
+      codeTimeoutMs: parsed.rlm_code_timeout_ms,
+      memoryLimitMb: parsed.rlm_memory_limit_mb,
+    }) ?? undefined,
+  };
+}
+
+export function serializeTaskResult(
+  result: ImprovementResult,
+  rlmSessions?: RlmSessionRecord[],
+): string {
+  return JSON.stringify({
+    rounds: result.rounds.map((round) => ({
+      round_number: round.roundNumber,
+      score: round.score,
+      reasoning: round.reasoning,
+      dimension_scores: round.dimensionScores,
+      is_revision: round.isRevision,
+    })),
+    best_score: result.bestScore,
+    best_round: result.bestRound,
+    total_rounds: result.totalRounds,
+    met_threshold: result.metThreshold,
+    ...(result.durationMs != null ? { duration_ms: result.durationMs } : {}),
+    ...(result.judgeCalls ? { judge_calls: result.judgeCalls } : {}),
+    ...(rlmSessions && rlmSessions.length > 0 ? { rlm_sessions: rlmSessions } : {}),
+  });
+}
+
+export function buildEnqueueTaskConfig(opts?: EnqueueTaskRequest): Record<string, unknown> | undefined {
+  const config: Record<string, unknown> = {};
+  if (opts?.maxRounds != null) config.max_rounds = opts.maxRounds;
+  if (opts?.qualityThreshold != null) config.quality_threshold = opts.qualityThreshold;
+  if (opts?.minRounds != null) config.min_rounds = opts.minRounds;
+  if (opts?.taskPrompt) config.task_prompt = opts.taskPrompt;
+  if (opts?.rubric) config.rubric = opts.rubric;
+  if (opts?.referenceContext) config.reference_context = opts.referenceContext;
+  if (opts?.requiredConcepts) config.required_concepts = opts.requiredConcepts;
+  if (opts?.initialOutput) config.initial_output = opts.initialOutput;
+  if (opts?.delegatedResults?.length) {
+    config.delegated_results = opts.delegatedResults.map((result) => ({
+      score: result.score,
+      reasoning: result.reasoning,
+      dimension_scores: result.dimensionScores ?? {},
+    }));
+  }
+  if (opts?.rlmEnabled != null) config.rlm_enabled = opts.rlmEnabled;
+  if (opts?.rlmModel) config.rlm_model = opts.rlmModel;
+  if (opts?.rlmMaxTurns != null) config.rlm_max_turns = opts.rlmMaxTurns;
+  if (opts?.rlmMaxTokensPerTurn != null) config.rlm_max_tokens_per_turn = opts.rlmMaxTokensPerTurn;
+  if (opts?.rlmTemperature != null) config.rlm_temperature = opts.rlmTemperature;
+  if (opts?.rlmMaxStdoutChars != null) config.rlm_max_stdout_chars = opts.rlmMaxStdoutChars;
+  if (opts?.rlmCodeTimeoutMs != null) config.rlm_code_timeout_ms = opts.rlmCodeTimeoutMs;
+  if (opts?.rlmMemoryLimitMb != null) config.rlm_memory_limit_mb = opts.rlmMemoryLimitMb;
+  return Object.keys(config).length > 0 ? config : undefined;
+}
+
+export function enqueueConfiguredTask(
+  store: SQLiteStore,
+  specName: string,
+  opts?: EnqueueTaskRequest,
+): string {
+  const taskId = randomUUID();
+  store.enqueueTask(
+    taskId,
+    specName,
+    opts?.priority ?? 0,
+    buildEnqueueTaskConfig(opts),
+  );
+  return taskId;
+}

--- a/ts/src/execution/task-runner-loop-workflow.ts
+++ b/ts/src/execution/task-runner-loop-workflow.ts
@@ -1,0 +1,20 @@
+import type { TaskQueueRow, SQLiteStore } from "../storage/index.js";
+
+export function buildTaskRunnerModel(defaultModel: string, explicitModel?: string): string {
+  return explicitModel || defaultModel;
+}
+
+export function dequeueTaskBatch(
+  store: SQLiteStore,
+  maxTasks: number,
+): TaskQueueRow[] {
+  const tasks: TaskQueueRow[] = [];
+  for (let index = 0; index < maxTasks; index++) {
+    const task = store.dequeueTask();
+    if (!task) {
+      break;
+    }
+    tasks.push(task);
+  }
+  return tasks;
+}

--- a/ts/src/execution/task-runner.ts
+++ b/ts/src/execution/task-runner.ts
@@ -3,145 +3,51 @@
  * Port of autocontext/src/autocontext/execution/task_runner.py
  */
 
-import { randomUUID } from "node:crypto";
-import { z } from "zod";
 import type {
   LLMProvider,
   AgentTaskInterface,
   AgentTaskResult,
-  ImprovementResult,
 } from "../types/index.js";
-import { ImprovementLoop } from "./improvement-loop.js";
-import { LLMJudge } from "../judge/llm-judge.js";
-import { SequentialDelegatedJudge, type DelegatedResult, type JudgeInterface } from "../judge/delegated.js";
+import { type DelegatedResult, type JudgeInterface } from "../judge/delegated.js";
 import type { SQLiteStore, TaskQueueRow } from "../storage/index.js";
 import { assertFamilyContract } from "../scenarios/family-interfaces.js";
-import { renderAgentTaskPrompt, resolveCustomAgentTask } from "../scenarios/custom-loader.js";
 import {
-  RlmTaskConfigSchema,
   type RlmSessionRecord,
   type RlmTaskConfig,
 } from "../rlm/types.js";
-import { runAgentTaskRlmSession } from "../rlm/agent-task.js";
+import {
+  enqueueConfiguredTask,
+  resolveRlmConfig,
+  type EnqueueTaskRequest,
+} from "./task-runner-config.js";
+import type { TaskConfig } from "./task-runner-config.js";
+import { executeQueuedTaskWorkflow } from "./task-processing-workflow.js";
+import {
+  evaluateSimpleAgentTaskOutput,
+  generateSimpleAgentTaskOutput,
+  reviseSimpleAgentTaskOutput,
+} from "./simple-agent-task-workflow.js";
+import {
+  buildTaskRunnerModel,
+  dequeueTaskBatch,
+} from "./task-runner-loop-workflow.js";
 
-export interface TaskConfig {
-  maxRounds?: number;
-  qualityThreshold?: number;
-  minRounds?: number;
-  referenceContext?: string;
-  requiredConcepts?: string[];
-  calibrationExamples?: Array<Record<string, unknown>>;
-  initialOutput?: string;
-  rubric?: string;
-  taskPrompt?: string;
-  revisionPrompt?: string;
-  delegatedResults?: DelegatedResult[];
-  rlm?: RlmTaskConfig;
-}
-
-const DelegatedResultSchema = z.object({
-  score: z.number().min(0).max(1),
-  reasoning: z.string(),
-  dimension_scores: z.record(z.number().min(0).max(1)).optional(),
-  dimensionScores: z.record(z.number().min(0).max(1)).optional(),
-}).passthrough();
-
-const TaskConfigSchema = z.object({
-  max_rounds: z.number().int().positive().optional(),
-  quality_threshold: z.number().min(0).max(1).optional(),
-  min_rounds: z.number().int().positive().optional(),
-  reference_context: z.string().optional(),
-  required_concepts: z.array(z.string()).optional(),
-  calibration_examples: z.array(z.record(z.unknown())).optional(),
-  initial_output: z.string().optional(),
-  rubric: z.string().optional(),
-  task_prompt: z.string().optional(),
-  revision_prompt: z.string().optional(),
-  delegated_results: z.array(DelegatedResultSchema).optional(),
-  rlm_enabled: z.boolean().optional(),
-  rlm_model: z.string().optional(),
-  rlm_max_turns: z.number().int().positive().optional(),
-  rlm_max_tokens_per_turn: z.number().int().positive().optional(),
-  rlm_temperature: z.number().min(0).max(2).optional(),
-  rlm_max_stdout_chars: z.number().int().positive().optional(),
-  rlm_code_timeout_ms: z.number().int().positive().optional(),
-  rlm_memory_limit_mb: z.number().int().positive().optional(),
-}).passthrough();
-
-function resolveRlmConfig(raw: Partial<RlmTaskConfig> | null | undefined): RlmTaskConfig | null {
-  if (!raw?.enabled) return null;
-  return RlmTaskConfigSchema.parse(raw);
-}
-
-function parseTaskConfig(json: string | null): TaskConfig {
-  if (!json) return {};
-  const raw = JSON.parse(json);
-  const d = TaskConfigSchema.parse(raw);
-  return {
-    maxRounds: d.max_rounds,
-    qualityThreshold: d.quality_threshold,
-    minRounds: d.min_rounds,
-    referenceContext: d.reference_context,
-    requiredConcepts: d.required_concepts,
-    calibrationExamples: d.calibration_examples,
-    initialOutput: d.initial_output,
-    rubric: d.rubric,
-    taskPrompt: d.task_prompt,
-    revisionPrompt: d.revision_prompt,
-    delegatedResults: d.delegated_results?.map((result) => ({
-      score: result.score,
-      reasoning: result.reasoning,
-      dimensionScores: result.dimension_scores ?? result.dimensionScores ?? {},
-    })),
-    rlm: resolveRlmConfig({
-      enabled: d.rlm_enabled ?? false,
-      model: d.rlm_model,
-      maxTurns: d.rlm_max_turns,
-      maxTokensPerTurn: d.rlm_max_tokens_per_turn,
-      temperature: d.rlm_temperature,
-      maxStdoutChars: d.rlm_max_stdout_chars,
-      codeTimeoutMs: d.rlm_code_timeout_ms,
-      memoryLimitMb: d.rlm_memory_limit_mb,
-    }) ?? undefined,
-  };
-}
-
-function serializeResult(
-  result: ImprovementResult,
-  rlmSessions?: RlmSessionRecord[],
-): string {
-  return JSON.stringify({
-    rounds: result.rounds.map((r) => ({
-      round_number: r.roundNumber,
-      score: r.score,
-      reasoning: r.reasoning,
-      dimension_scores: r.dimensionScores,
-      is_revision: r.isRevision,
-    })),
-    best_score: result.bestScore,
-    best_round: result.bestRound,
-    total_rounds: result.totalRounds,
-    met_threshold: result.metThreshold,
-    ...(result.durationMs != null ? { duration_ms: result.durationMs } : {}),
-    ...(result.judgeCalls ? { judge_calls: result.judgeCalls } : {}),
-    ...(rlmSessions && rlmSessions.length > 0 ? { rlm_sessions: rlmSessions } : {}),
-  });
-}
+export type { TaskConfig } from "./task-runner-config.js";
 
 /**
  * A simple agent task built from queue config.
  */
 export class SimpleAgentTask implements AgentTaskInterface {
-  private taskPrompt: string;
-  private rubric: string;
-  private provider: LLMProvider;
-  private model: string;
-  private revisionPrompt?: string;
-  private readonly rlmConfig: RlmTaskConfig | null;
-  private readonly rlmSessions: RlmSessionRecord[] = [];
-  private lastReferenceContext?: string;
-  private lastRequiredConcepts?: string[];
-  private readonly judgeOverride?: JudgeInterface;
+  #taskPrompt: string;
+  #rubric: string;
+  #provider: LLMProvider;
+  #model: string;
+  #revisionPrompt?: string;
+  readonly #rlmConfig: RlmTaskConfig | null;
+  readonly #rlmSessions: RlmSessionRecord[] = [];
+  #lastReferenceContext?: string;
+  #lastRequiredConcepts?: string[];
+  readonly #judgeOverride?: JudgeInterface;
 
   constructor(
     taskPrompt: string,
@@ -152,22 +58,22 @@ export class SimpleAgentTask implements AgentTaskInterface {
     rlmConfig?: Partial<RlmTaskConfig> | null,
     judgeOverride?: JudgeInterface,
   ) {
-    this.taskPrompt = taskPrompt;
-    this.rubric = rubric;
-    this.provider = provider;
-    this.model = model || provider.defaultModel();
-    this.revisionPrompt = revisionPrompt;
-    this.rlmConfig = resolveRlmConfig(rlmConfig);
-    this.judgeOverride = judgeOverride;
+    this.#taskPrompt = taskPrompt;
+    this.#rubric = rubric;
+    this.#provider = provider;
+    this.#model = model || provider.defaultModel();
+    this.#revisionPrompt = revisionPrompt;
+    this.#rlmConfig = resolveRlmConfig(rlmConfig);
+    this.#judgeOverride = judgeOverride;
     assertFamilyContract(this, "agent_task", "SimpleAgentTask");
   }
 
   getTaskPrompt(): string {
-    return this.taskPrompt;
+    return this.#taskPrompt;
   }
 
   getRubric(): string {
-    return this.rubric;
+    return this.#rubric;
   }
 
   initialState(): Record<string, unknown> {
@@ -175,7 +81,7 @@ export class SimpleAgentTask implements AgentTaskInterface {
   }
 
   describeTask(): string {
-    return this.taskPrompt;
+    return this.#taskPrompt;
   }
 
   async evaluateOutput(
@@ -188,75 +94,40 @@ export class SimpleAgentTask implements AgentTaskInterface {
       pinnedDimensions?: string[];
     },
   ): Promise<AgentTaskResult> {
-    this.lastReferenceContext = opts?.referenceContext;
-    this.lastRequiredConcepts = opts?.requiredConcepts;
-    const judge = this.judgeOverride ?? new LLMJudge({
-      provider: this.provider,
-      model: this.model,
-      rubric: this.rubric,
-    });
-    const result = await judge.evaluate({
-      taskPrompt: this.taskPrompt,
-      agentOutput: output,
+    this.#lastReferenceContext = opts?.referenceContext;
+    this.#lastRequiredConcepts = opts?.requiredConcepts;
+    return evaluateSimpleAgentTaskOutput({
+      taskPrompt: this.#taskPrompt,
+      rubric: this.#rubric,
+      provider: this.#provider,
+      model: this.#model,
+      output,
+      judgeOverride: this.#judgeOverride,
       referenceContext: opts?.referenceContext,
       requiredConcepts: opts?.requiredConcepts,
       calibrationExamples: opts?.calibrationExamples,
       pinnedDimensions: opts?.pinnedDimensions,
     });
-    return {
-      score: result.score,
-      reasoning: result.reasoning,
-      dimensionScores: result.dimensionScores,
-      internalRetries: result.internalRetries ?? 0,
-    };
   }
 
   getRlmSessions(): RlmSessionRecord[] {
-    return this.rlmSessions.slice();
-  }
-
-  private async runRlm(phase: "generate" | "revise", opts: {
-    currentOutput?: string;
-    judgeResult?: AgentTaskResult;
-    referenceContext?: string;
-    requiredConcepts?: string[];
-  }): Promise<string | null> {
-    if (!this.rlmConfig) return null;
-    const record = await runAgentTaskRlmSession({
-      provider: this.provider,
-      model: this.model,
-      config: this.rlmConfig,
-      phase,
-      taskPrompt: this.taskPrompt,
-      rubric: this.rubric,
-      currentOutput: opts.currentOutput,
-      judgeResult: opts.judgeResult,
-      referenceContext: opts.referenceContext,
-      requiredConcepts: opts.requiredConcepts,
-      revisionPrompt: this.revisionPrompt,
-    });
-    this.rlmSessions.push(record);
-    const content = record.content.trim();
-    return content.length > 0 ? content : null;
+    return this.#rlmSessions.slice();
   }
 
   async generateOutput(context?: {
     referenceContext?: string;
     requiredConcepts?: string[];
   }): Promise<string> {
-    const rlmOutput = await this.runRlm("generate", {
+    return generateSimpleAgentTaskOutput({
+      provider: this.#provider,
+      model: this.#model,
+      taskPrompt: this.#taskPrompt,
+      rubric: this.#rubric,
+      rlmConfig: this.#rlmConfig,
+      rlmSessions: this.#rlmSessions,
       referenceContext: context?.referenceContext,
       requiredConcepts: context?.requiredConcepts,
     });
-    if (rlmOutput) return rlmOutput;
-
-    const result = await this.provider.complete({
-      systemPrompt:
-        "You are a skilled writer and analyst. Complete the task precisely.",
-      userPrompt: this.taskPrompt,
-      model: this.model,
-    });
-    return result.text;
   }
 
   async reviseOutput(
@@ -264,36 +135,19 @@ export class SimpleAgentTask implements AgentTaskInterface {
     judgeResult: AgentTaskResult,
     _state: Record<string, unknown>,
   ): Promise<string> {
-    const rlmOutput = await this.runRlm("revise", {
-      currentOutput: output,
+    return reviseSimpleAgentTaskOutput({
+      provider: this.#provider,
+      model: this.#model,
+      taskPrompt: this.#taskPrompt,
+      rubric: this.#rubric,
+      revisionPrompt: this.#revisionPrompt,
+      output,
       judgeResult,
-      referenceContext: this.lastReferenceContext,
-      requiredConcepts: this.lastRequiredConcepts,
+      rlmConfig: this.#rlmConfig,
+      rlmSessions: this.#rlmSessions,
+      referenceContext: this.#lastReferenceContext,
+      requiredConcepts: this.#lastRequiredConcepts,
     });
-    if (rlmOutput) return rlmOutput;
-
-    const instruction =
-      this.revisionPrompt ??
-      "Revise the following output based on the judge's feedback. Maintain what works, fix what doesn't.";
-
-    const prompt =
-      `${instruction}\n\n` +
-      `## Original Output\n${output}\n\n` +
-      `## Judge Score: ${judgeResult.score.toFixed(2)}\n` +
-      `## Judge Feedback\n${judgeResult.reasoning}\n\n` +
-      `## Task\n${this.taskPrompt}\n\n` +
-      "Produce an improved version:";
-
-    const result = await this.provider.complete({
-      systemPrompt:
-        "You are revising content based on expert feedback. Improve the output. " +
-        "IMPORTANT: Return ONLY the revised content. Do NOT include analysis, " +
-        "explanations, headers like '## Revised Output', or self-assessment. " +
-        "Just output the improved version directly.",
-      userPrompt: prompt,
-      model: this.model,
-    });
-    return result.text;
   }
 }
 
@@ -308,183 +162,86 @@ export interface TaskRunnerOpts {
 }
 
 export class TaskRunner {
-  private store: SQLiteStore;
-  private provider: LLMProvider;
-  private model: string;
-  private knowledgeRoot?: string;
-  private pollInterval: number;
-  private maxConsecutiveEmpty: number;
-  private concurrency: number;
-  private _shutdown = false;
-  private _tasksProcessed = 0;
+  #store: SQLiteStore;
+  #provider: LLMProvider;
+  #model: string;
+  #knowledgeRoot?: string;
+  #pollInterval: number;
+  #maxConsecutiveEmpty: number;
+  #concurrency: number;
+  #shutdown = false;
+  #tasksProcessed = 0;
 
   constructor(opts: TaskRunnerOpts) {
-    this.store = opts.store;
-    this.provider = opts.provider;
-    this.model = opts.model || opts.provider.defaultModel();
-    this.knowledgeRoot = opts.knowledgeRoot;
-    this.pollInterval = opts.pollInterval ?? 60;
-    this.maxConsecutiveEmpty = opts.maxConsecutiveEmpty ?? 0;
-    this.concurrency = Math.max(1, opts.concurrency ?? 1);
+    this.#store = opts.store;
+    this.#provider = opts.provider;
+    this.#model = buildTaskRunnerModel(opts.provider.defaultModel(), opts.model);
+    this.#knowledgeRoot = opts.knowledgeRoot;
+    this.#pollInterval = opts.pollInterval ?? 60;
+    this.#maxConsecutiveEmpty = opts.maxConsecutiveEmpty ?? 0;
+    this.#concurrency = Math.max(1, opts.concurrency ?? 1);
   }
 
   get tasksProcessed(): number {
-    return this._tasksProcessed;
+    return this.#tasksProcessed;
   }
 
   async runOnce(): Promise<TaskQueueRow | null> {
-    const task = this.store.dequeueTask();
+    const task = this.#store.dequeueTask();
     if (!task) return null;
-    await this.processTask(task);
-    this._tasksProcessed++;
-    return this.store.getTask(task.id) ?? null;
+    await this.#processTask(task);
+    this.#tasksProcessed++;
+    return this.#store.getTask(task.id) ?? null;
   }
 
   async runBatch(limit?: number): Promise<number> {
-    const maxTasks = limit ?? this.concurrency;
-    const tasks: TaskQueueRow[] = [];
-    for (let i = 0; i < maxTasks; i++) {
-      const task = this.store.dequeueTask();
-      if (!task) break;
-      tasks.push(task);
-    }
+    const maxTasks = limit ?? this.#concurrency;
+    const tasks = dequeueTaskBatch(this.#store, maxTasks);
     if (tasks.length === 0) return 0;
 
-    await Promise.all(tasks.map((task) => this.processTask(task)));
-    this._tasksProcessed += tasks.length;
+    await Promise.all(tasks.map((task) => this.#processTask(task)));
+    this.#tasksProcessed += tasks.length;
     return tasks.length;
   }
 
   shutdown(): void {
-    this._shutdown = true;
+    this.#shutdown = true;
   }
 
-  private async processTask(task: TaskQueueRow): Promise<void> {
-    try {
-      const config = parseTaskConfig(task.config_json);
-      const savedTask = this.knowledgeRoot
-        ? resolveCustomAgentTask(this.knowledgeRoot, task.spec_name)
-        : null;
-      const taskPrompt = config.taskPrompt
-        ?? (savedTask ? renderAgentTaskPrompt(savedTask.spec) : undefined)
-        ?? `Complete the task: ${task.spec_name}`;
-      const rubric = config.rubric
-        ?? savedTask?.spec.judgeRubric
-        ?? "Evaluate quality, accuracy, and completeness on a 0-1 scale.";
-      const referenceContext = config.referenceContext ?? savedTask?.spec.referenceContext ?? undefined;
-      const requiredConcepts = config.requiredConcepts ?? savedTask?.spec.requiredConcepts ?? undefined;
-      const calibrationExamples = config.calibrationExamples ?? savedTask?.spec.calibrationExamples ?? undefined;
-      const maxRounds = config.maxRounds ?? savedTask?.spec.maxRounds ?? 5;
-      const qualityThreshold = config.qualityThreshold ?? savedTask?.spec.qualityThreshold ?? 0.9;
-      const minRounds = config.minRounds ?? 1;
-      const revisionPrompt = config.revisionPrompt ?? savedTask?.spec.revisionPrompt ?? undefined;
-      const delegatedJudge = config.delegatedResults?.length
-        ? new SequentialDelegatedJudge(config.delegatedResults, rubric)
-        : undefined;
-
-      const agentTask = new SimpleAgentTask(
-        taskPrompt,
-        rubric,
-        this.provider,
-        this.model,
-        revisionPrompt,
-        config.rlm,
-        delegatedJudge,
-      );
-
-      let initialOutput = config.initialOutput;
-      if (!initialOutput) {
-        initialOutput = await agentTask.generateOutput({
-          referenceContext,
-          requiredConcepts,
-        });
-      }
-
-      const loop = new ImprovementLoop({
-        task: agentTask,
-        maxRounds,
-        qualityThreshold,
-        minRounds,
-      });
-
-      const result = await loop.run({
-        initialOutput,
-        state: agentTask.initialState(),
-        referenceContext,
-        requiredConcepts,
-        calibrationExamples,
-      });
-
-      this.store.completeTask(
-        task.id,
-        result.bestScore,
-        result.bestOutput,
-        result.totalRounds,
-        result.metThreshold,
-        serializeResult(result, agentTask.getRlmSessions()),
-      );
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.store.failTask(task.id, msg);
-    }
+  async #processTask(task: TaskQueueRow): Promise<void> {
+    await executeQueuedTaskWorkflow({
+      store: this.#store,
+      task,
+      provider: this.#provider,
+      model: this.#model,
+      knowledgeRoot: this.#knowledgeRoot,
+      internals: {
+        createAgentTask: ({
+          taskPrompt,
+          rubric,
+          provider,
+          model,
+          revisionPrompt,
+          rlm,
+          delegatedJudge,
+        }) => new SimpleAgentTask(
+          taskPrompt,
+          rubric,
+          provider,
+          model,
+          revisionPrompt,
+          rlm,
+          delegatedJudge,
+        ),
+      },
+    });
   }
 }
 
 export function enqueueTask(
   store: SQLiteStore,
   specName: string,
-  opts?: {
-    taskPrompt?: string;
-    rubric?: string;
-    referenceContext?: string;
-    requiredConcepts?: string[];
-    maxRounds?: number;
-    qualityThreshold?: number;
-    minRounds?: number;
-    initialOutput?: string;
-    delegatedResults?: DelegatedResult[];
-    priority?: number;
-    rlmEnabled?: boolean;
-    rlmModel?: string;
-    rlmMaxTurns?: number;
-    rlmMaxTokensPerTurn?: number;
-    rlmTemperature?: number;
-    rlmMaxStdoutChars?: number;
-    rlmCodeTimeoutMs?: number;
-    rlmMemoryLimitMb?: number;
-  },
+  opts?: EnqueueTaskRequest,
 ): string {
-  const taskId = randomUUID();
-  const config: Record<string, unknown> = {};
-  if (opts?.maxRounds != null) config.max_rounds = opts.maxRounds;
-  if (opts?.qualityThreshold != null) config.quality_threshold = opts.qualityThreshold;
-  if (opts?.minRounds != null) config.min_rounds = opts.minRounds;
-  if (opts?.taskPrompt) config.task_prompt = opts.taskPrompt;
-  if (opts?.rubric) config.rubric = opts.rubric;
-  if (opts?.referenceContext) config.reference_context = opts.referenceContext;
-  if (opts?.requiredConcepts) config.required_concepts = opts.requiredConcepts;
-  if (opts?.initialOutput) config.initial_output = opts.initialOutput;
-  if (opts?.delegatedResults?.length) {
-    config.delegated_results = opts.delegatedResults.map((result) => ({
-      score: result.score,
-      reasoning: result.reasoning,
-      dimension_scores: result.dimensionScores ?? {},
-    }));
-  }
-  if (opts?.rlmEnabled != null) config.rlm_enabled = opts.rlmEnabled;
-  if (opts?.rlmModel) config.rlm_model = opts.rlmModel;
-  if (opts?.rlmMaxTurns != null) config.rlm_max_turns = opts.rlmMaxTurns;
-  if (opts?.rlmMaxTokensPerTurn != null) config.rlm_max_tokens_per_turn = opts.rlmMaxTokensPerTurn;
-  if (opts?.rlmTemperature != null) config.rlm_temperature = opts.rlmTemperature;
-  if (opts?.rlmMaxStdoutChars != null) config.rlm_max_stdout_chars = opts.rlmMaxStdoutChars;
-  if (opts?.rlmCodeTimeoutMs != null) config.rlm_code_timeout_ms = opts.rlmCodeTimeoutMs;
-  if (opts?.rlmMemoryLimitMb != null) config.rlm_memory_limit_mb = opts.rlmMemoryLimitMb;
-
-  store.enqueueTask(
-    taskId,
-    specName,
-    opts?.priority ?? 0,
-    Object.keys(config).length > 0 ? config : undefined,
-  );
-  return taskId;
+  return enqueueConfiguredTask(store, specName, opts);
 }

--- a/ts/src/mcp/sandbox-tools.ts
+++ b/ts/src/mcp/sandbox-tools.ts
@@ -1,0 +1,113 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+interface SandboxToolResult {
+  content: Array<{ type: "text"; text: string }>;
+}
+
+interface SandboxToolServer {
+  tool(
+    name: string,
+    description: string,
+    schema: Record<string, unknown>,
+    handler: (args: Record<string, unknown>) => Promise<SandboxToolResult> | SandboxToolResult,
+  ): void;
+}
+
+type SandboxToolRegistrar = McpServer | SandboxToolServer;
+
+interface SandboxManagerLike {
+  create(scenarioName: string, userId?: string): unknown;
+  run(sandboxId: string, generations?: number): Promise<unknown>;
+  getStatus(sandboxId: string): unknown | null;
+  readPlaybook(sandboxId: string): string;
+  list(): unknown[];
+  destroy(sandboxId: string): boolean;
+}
+
+function jsonContent(payload: unknown): SandboxToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+export function buildSandboxNotFoundPayload(sandboxId: string): Record<string, string> {
+  return { error: `Sandbox '${sandboxId}' not found` };
+}
+
+export function registerSandboxTools(
+  server: SandboxToolRegistrar,
+  opts: { sandboxManager: SandboxManagerLike },
+): void {
+  const { sandboxManager } = opts;
+  const toolServer = server as SandboxToolServer;
+
+  toolServer.tool(
+    "sandbox_create",
+    "Create an isolated sandbox for scenario execution",
+    { scenario: z.string(), userId: z.string().default("anonymous") },
+    async (args) => jsonContent(
+      sandboxManager.create(String(args.scenario), String(args.userId ?? "anonymous")),
+    ),
+  );
+
+  toolServer.tool(
+    "sandbox_run",
+    "Run generation(s) in a sandbox",
+    { sandboxId: z.string(), generations: z.number().int().default(1) },
+    async (args) => jsonContent(
+      await sandboxManager.run(String(args.sandboxId), Number(args.generations ?? 1)),
+    ),
+  );
+
+  toolServer.tool(
+    "sandbox_status",
+    "Get sandbox status",
+    { sandboxId: z.string() },
+    async (args) => {
+      const sandboxId = String(args.sandboxId);
+      return jsonContent(
+        sandboxManager.getStatus(sandboxId) ?? buildSandboxNotFoundPayload(sandboxId),
+      );
+    },
+  );
+
+  toolServer.tool(
+    "sandbox_playbook",
+    "Read the current playbook for a sandbox",
+    { sandboxId: z.string() },
+    async (args) => ({
+      content: [
+        {
+          type: "text",
+          text: sandboxManager.readPlaybook(String(args.sandboxId)),
+        },
+      ],
+    }),
+  );
+
+  toolServer.tool(
+    "sandbox_list",
+    "List active sandboxes",
+    {},
+    async () => jsonContent(sandboxManager.list()),
+  );
+
+  toolServer.tool(
+    "sandbox_destroy",
+    "Destroy a sandbox and clean up its data",
+    { sandboxId: z.string() },
+    async (args) => {
+      const sandboxId = String(args.sandboxId);
+      return jsonContent({
+        destroyed: sandboxManager.destroy(sandboxId),
+        sandboxId,
+      });
+    },
+  );
+}

--- a/ts/src/mcp/server.ts
+++ b/ts/src/mcp/server.ts
@@ -22,6 +22,7 @@ import { runAgentTaskRlmSession } from "../rlm/agent-task.js";
 import { assertFamilyContract } from "../scenarios/family-interfaces.js";
 import { registerCampaignTools } from "./campaign-tools.js";
 import { registerMissionTools } from "./mission-tools.js";
+import { registerSandboxTools } from "./sandbox-tools.js";
 
 export interface MtsServerOpts {
   store: SQLiteStore;
@@ -893,71 +894,7 @@ export function createMcpServer(opts: MtsServerOpts): McpServer {
     },
   );
 
-  // -- sandbox_create (AC-370) --
-  server.tool(
-    "sandbox_create",
-    "Create an isolated sandbox for scenario execution",
-    { scenario: z.string(), userId: z.string().default("anonymous") },
-    async (args) => {
-      const sb = sandboxManager.create(args.scenario, args.userId);
-      return { content: [{ type: "text" as const, text: JSON.stringify(sb, null, 2) }] };
-    },
-  );
-
-  // -- sandbox_run (AC-370) --
-  server.tool(
-    "sandbox_run",
-    "Run generation(s) in a sandbox",
-    { sandboxId: z.string(), generations: z.number().int().default(1) },
-    async (args) => {
-      const result = await sandboxManager.run(args.sandboxId, args.generations);
-      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
-    },
-  );
-
-  // -- sandbox_status (AC-370) --
-  server.tool(
-    "sandbox_status",
-    "Get sandbox status",
-    { sandboxId: z.string() },
-    async (args) => {
-      const sandbox = sandboxManager.getStatus(args.sandboxId);
-      if (!sandbox) {
-        return { content: [{ type: "text" as const, text: JSON.stringify({ error: `Sandbox '${args.sandboxId}' not found` }) }] };
-      }
-      return { content: [{ type: "text" as const, text: JSON.stringify(sandbox, null, 2) }] };
-    },
-  );
-
-  // -- sandbox_playbook (AC-370) --
-  server.tool(
-    "sandbox_playbook",
-    "Read the current playbook for a sandbox",
-    { sandboxId: z.string() },
-    async (args) => {
-      return { content: [{ type: "text" as const, text: sandboxManager.readPlaybook(args.sandboxId) }] };
-    },
-  );
-
-  // -- sandbox_list (AC-370) --
-  server.tool(
-    "sandbox_list",
-    "List active sandboxes",
-    {},
-    async () => {
-      return { content: [{ type: "text" as const, text: JSON.stringify(sandboxManager.list(), null, 2) }] };
-    },
-  );
-
-  // -- sandbox_destroy (AC-370) --
-  server.tool(
-    "sandbox_destroy",
-    "Destroy a sandbox and clean up its data",
-    { sandboxId: z.string() },
-    async (args) => {
-      return { content: [{ type: "text" as const, text: JSON.stringify({ destroyed: sandboxManager.destroy(args.sandboxId), sandboxId: args.sandboxId }) }] };
-    },
-  );
+  registerSandboxTools(server, { sandboxManager });
 
   // -- create_agent_task (AC-370) --
   server.tool(

--- a/ts/tests/action-filter-workflows.test.ts
+++ b/ts/tests/action-filter-workflows.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  ActionDict,
+  HarnessLoaderLike,
+  ScenarioLike,
+} from "../src/execution/action-filter.js";
+import {
+  getHarnessActions,
+  getLegalActions,
+} from "../src/execution/action-filter-discovery-workflow.js";
+import {
+  formatActionPrompt,
+  isContinuousParamSpace,
+} from "../src/execution/action-filter-prompt-workflow.js";
+import {
+  extractJsonObject,
+  parseActionSelection,
+} from "../src/execution/action-filter-selection-workflow.js";
+import { getVerifyFeedback } from "../src/execution/action-filter-verification-workflow.js";
+
+function buildScenario(actions: ActionDict[] | null): ScenarioLike {
+  return {
+    enumerateLegalActions: vi.fn().mockReturnValue(actions),
+    validateActions: vi.fn().mockReturnValue([true, "ok"]),
+  };
+}
+
+describe("action filter workflows", () => {
+  it("discovers legal actions from scenario first, then harness validators", () => {
+    const scenarioActions = [{ action: "move", description: "Move forward" }];
+    const scenario = buildScenario(scenarioActions);
+    const loader: HarnessLoaderLike = {
+      validators: [
+        {
+          enumerate_legal_actions: vi.fn().mockReturnValue([
+            { action: "fallback", description: "Harness fallback" },
+          ]),
+        },
+      ],
+    };
+
+    expect(getLegalActions(scenario, {}, loader)).toEqual(scenarioActions);
+
+    const fallbackScenario = buildScenario(null);
+    expect(getLegalActions(fallbackScenario, {}, loader)).toEqual([
+      { action: "fallback", description: "Harness fallback" },
+    ]);
+    expect(getHarnessActions(null, {})).toBeNull();
+  });
+
+  it("formats discrete and continuous action prompts", () => {
+    expect(
+      formatActionPrompt([
+        { action: "capture_flag", description: "Capture", row: 1, col: 5 },
+      ]),
+    ).toContain("1. capture_flag — Capture (row 1, col 5)");
+
+    const continuous = [
+      { action: "aggression", description: "Tune aggression", type: "continuous", range: [0, 1] },
+      { action: "defense", description: "Tune defense", type: "continuous", range: [0, 1] },
+    ] satisfies ActionDict[];
+
+    expect(isContinuousParamSpace(continuous)).toBe(true);
+    const prompt = formatActionPrompt(continuous);
+    expect(prompt).toContain("Provide a JSON object with all strategy parameters:");
+    expect(prompt).toContain('"aggression":0.5');
+    expect(prompt).toContain("Respond with JSON only.");
+  });
+
+  it("parses indexed, named, and JSON continuous selections", () => {
+    const actions = [
+      { action: "move_up", description: "Move up" },
+      { action: "move_down", description: "Move down" },
+    ] satisfies ActionDict[];
+
+    expect(parseActionSelection("2", actions)).toEqual(actions[1]);
+    expect(parseActionSelection("I choose move_up", actions)).toEqual(actions[0]);
+
+    const continuous = [
+      { action: "aggression", description: "x", type: "continuous", range: [0, 1] },
+      { action: "defense", description: "y", type: "continuous", range: [0, 1] },
+    ] satisfies ActionDict[];
+    expect(
+      parseActionSelection("```json\n{\"aggression\":0.6,\"defense\":0.4}\n```", continuous),
+    ).toEqual({ aggression: 0.6, defense: 0.4 });
+    expect(extractJsonObject("prefix {\"a\":1} suffix")).toEqual({ a: 1 });
+    expect(parseActionSelection('{"aggression":2,"defense":0.4}', continuous)).toBeNull();
+  });
+
+  it("builds verification feedback with prompt text when legal actions exist", () => {
+    expect(getVerifyFeedback("bad move", null)).toBe("Invalid action: bad move\nPlease try again.");
+    const feedback = getVerifyFeedback("bad move", [
+      { action: "move_up", description: "Move up" },
+    ]);
+    expect(feedback).toContain("Invalid action: bad move");
+    expect(feedback).toContain("Available actions:");
+    expect(feedback).toContain("Please try again.");
+  });
+});

--- a/ts/tests/action-filter.test.ts
+++ b/ts/tests/action-filter.test.ts
@@ -1,8 +1,7 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it, expect, vi } from "vitest";
-import {
-  ActionFilterHarness,
-  ActionDictSchema,
-} from "../src/execution/action-filter.js";
+import { ActionFilterHarness, ActionDictSchema } from "../src/execution/action-filter.js";
 import type {
   ActionDict,
   ScenarioLike,
@@ -22,14 +21,16 @@ function mockScenario(
 ): ScenarioLike {
   return {
     enumerateLegalActions: vi.fn().mockReturnValue(actions),
-    validateActions: vi.fn().mockImplementation(
-      (_state: Record<string, unknown>, _pid: string, acts: Record<string, unknown>) => {
-        if (acts.action === "move_up" || acts.action === "move_down") {
-          return [true, "ok"] as [boolean, string];
-        }
-        return [false, "invalid action"] as [boolean, string];
-      },
-    ),
+    validateActions: vi
+      .fn()
+      .mockImplementation(
+        (_state: Record<string, unknown>, _pid: string, acts: Record<string, unknown>) => {
+          if (acts.action === "move_up" || acts.action === "move_down") {
+            return [true, "ok"] as [boolean, string];
+          }
+          return [false, "invalid action"] as [boolean, string];
+        },
+      ),
   };
 }
 
@@ -43,6 +44,20 @@ function noEnumerateScenario(): ScenarioLike {
 // ---------------------------------------------------------------------------
 // getLegalActions
 // ---------------------------------------------------------------------------
+
+describe("ActionFilterHarness encapsulation", () => {
+  it("uses real #private fields for harness state", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "src", "execution", "action-filter.ts"),
+      "utf-8",
+    );
+
+    expect(source).toContain("#scenario");
+    expect(source).toContain("#harnessLoader");
+    expect(source).not.toContain("private readonly scenario:");
+    expect(source).not.toContain("private readonly harnessLoader:");
+  });
+});
 
 describe("ActionFilterHarness — getLegalActions", () => {
   it("returns scenario actions", () => {
@@ -65,7 +80,11 @@ describe("ActionFilterHarness — getLegalActions", () => {
   it("falls back to harness loader", () => {
     const loader: HarnessLoaderLike = {
       validators: [
-        { enumerate_legal_actions: vi.fn().mockReturnValue([{ action: "from_harness", description: "harness" }]) },
+        {
+          enumerate_legal_actions: vi
+            .fn()
+            .mockReturnValue([{ action: "from_harness", description: "harness" }]),
+        },
       ],
     };
     const h = new ActionFilterHarness(noEnumerateScenario(), loader);
@@ -77,7 +96,11 @@ describe("ActionFilterHarness — getLegalActions", () => {
   it("prefers scenario over harness", () => {
     const loader: HarnessLoaderLike = {
       validators: [
-        { enumerate_legal_actions: vi.fn().mockReturnValue([{ action: "harness", description: "x" }]) },
+        {
+          enumerate_legal_actions: vi
+            .fn()
+            .mockReturnValue([{ action: "harness", description: "x" }]),
+        },
       ],
     };
     const h = new ActionFilterHarness(mockScenario(), loader);

--- a/ts/tests/agent-orchestration.test.ts
+++ b/ts/tests/agent-orchestration.test.ts
@@ -86,7 +86,8 @@ describe("Output parsing", () => {
 
   it("parseArchitectOutput extracts tool specs from JSON", async () => {
     const { parseArchitectOutput } = await import("../src/agents/roles.js");
-    const md = 'Here are tools:\n```json\n{"tools": [{"name": "validator", "description": "validates", "code": "def f(): pass"}]}\n```';
+    const md =
+      'Here are tools:\n```json\n{"tools": [{"name": "validator", "description": "validates", "code": "def f(): pass"}]}\n```';
     const output = parseArchitectOutput(md);
     expect(output.toolSpecs).toHaveLength(1);
     expect(output.toolSpecs[0].name).toBe("validator");
@@ -197,7 +198,10 @@ describe("RetryProvider", () => {
     const inner = {
       name: "test",
       defaultModel: () => "model",
-      complete: async () => { calls++; return { text: "ok", usage: {} }; },
+      complete: async () => {
+        calls++;
+        return { text: "ok", usage: {} };
+      },
     };
     const provider = new RetryProvider(inner as any, { maxRetries: 3 });
     const result = await provider.complete({ systemPrompt: "", userPrompt: "test" });
@@ -228,10 +232,14 @@ describe("RetryProvider", () => {
     const inner = {
       name: "test",
       defaultModel: () => "model",
-      complete: async () => { throw new Error("permanent"); },
+      complete: async () => {
+        throw new Error("permanent");
+      },
     };
     const provider = new RetryProvider(inner as any, { maxRetries: 2, baseDelay: 0 });
-    await expect(provider.complete({ systemPrompt: "", userPrompt: "test" })).rejects.toThrow("permanent");
+    await expect(provider.complete({ systemPrompt: "", userPrompt: "test" })).rejects.toThrow(
+      "permanent",
+    );
   });
 });
 
@@ -250,7 +258,9 @@ describe("ModelRouter", () => {
     const { ModelRouter, TierConfig } = await import("../src/agents/model-router.js");
     const config = new TierConfig({ enabled: false });
     const router = new ModelRouter(config);
-    expect(router.select("competitor", { generation: 1, retryCount: 0, isPlateau: false })).toBeNull();
+    expect(
+      router.select("competitor", { generation: 1, retryCount: 0, isPlateau: false }),
+    ).toBeNull();
   });
 
   it("routes competitor to haiku for early generations", async () => {
@@ -318,7 +328,7 @@ describe("CodexCLIRuntime", () => {
     const runtime = new CodexCLIRuntime();
     // Access internal parser for testing
     const result = runtime.parseOutput(
-      '{"type": "item.message", "content": [{"text": "hello world"}]}\n'
+      '{"type": "item.message", "content": [{"text": "hello world"}]}\n',
     );
     expect(result.text).toBe("hello world");
   });
@@ -362,6 +372,27 @@ describe("CodexCLIRuntime", () => {
 // ---------------------------------------------------------------------------
 // Task 18: Agent Orchestrator
 // ---------------------------------------------------------------------------
+
+describe("AgentOrchestrator encapsulation", () => {
+  it("uses real #private fields and helpers for role-routing internals", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "src", "agents", "orchestrator.ts"),
+      "utf-8",
+    );
+
+    expect(source).toContain("#provider");
+    expect(source).toContain("#roleProviders");
+    expect(source).toContain("#roleModels");
+    expect(source).toContain("#providerForRole");
+    expect(source).toContain("#completeRole");
+    expect(source).not.toContain("private provider:");
+    expect(source).not.toContain("private roleProviders:");
+    expect(source).not.toContain("private roleModels:");
+  });
+});
 
 describe("AgentOrchestrator", () => {
   it("exports AgentOrchestrator", async () => {
@@ -480,7 +511,10 @@ describe("AgentOrchestrator", () => {
       roleProviders: {
         competitor: providerFor("competitor", '{"aggression": 0.9}') as any,
         analyst: providerFor("analyst", "## Findings\n- Strong opening") as any,
-        coach: providerFor("coach", "<!-- PLAYBOOK_START -->\nplaybook\n<!-- PLAYBOOK_END -->") as any,
+        coach: providerFor(
+          "coach",
+          "<!-- PLAYBOOK_START -->\nplaybook\n<!-- PLAYBOOK_END -->",
+        ) as any,
         architect: providerFor("architect", "No tools needed.") as any,
       },
       roleModels: {

--- a/ts/tests/improvement-loop-policy-workflow.test.ts
+++ b/ts/tests/improvement-loop-policy-workflow.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyScoreDeltaPolicy,
+  buildRevisionFeedbackResult,
+  evaluatePlateauState,
+  evaluateThresholdState,
+} from "../src/execution/improvement-loop-policy.js";
+
+describe("improvement loop policy workflow", () => {
+  it("caps large score jumps, tracks plateau state, and evaluates threshold stability", () => {
+    expect(applyScoreDeltaPolicy({
+      score: 0.9,
+      prevValidScore: 0.2,
+      maxScoreDelta: 0.3,
+      capScoreJumps: true,
+      roundNum: 2,
+    })).toEqual({
+      effectiveScore: 0.5,
+      warning: "Score jump of 0.700 exceeds maxScoreDelta 0.3 (round 2: 0.200 -> 0.900)",
+    });
+
+    expect(evaluatePlateauState({
+      prevValidScore: 0.5,
+      score: 0.505,
+      plateauCount: 1,
+      roundNum: 3,
+      minRounds: 1,
+    })).toEqual({ plateauCount: 2, shouldStop: true });
+
+    expect(evaluateThresholdState({
+      effectiveScore: 0.91,
+      qualityThreshold: 0.9,
+      roundNum: 1,
+      minRounds: 1,
+      maxRounds: 5,
+      thresholdMetRound: null,
+      dimensionScores: {},
+      dimensionThreshold: null,
+    })).toEqual({
+      metThreshold: false,
+      shouldStop: false,
+      thresholdMetRound: 1,
+    });
+  });
+
+  it("adds dimension annotations with regression and improvement notes", () => {
+    const revisionFeedback = buildRevisionFeedbackResult({
+      result: {
+        score: 0.8,
+        reasoning: "Needs improvement",
+        dimensionScores: { clarity: 0.7, accuracy: 0.6 },
+        internalRetries: 1,
+      },
+      previousValidRound: {
+        roundNumber: 1,
+        output: "draft",
+        score: 0.75,
+        reasoning: "prior",
+        dimensionScores: { clarity: 0.8, accuracy: 0.4 },
+        isRevision: false,
+        judgeFailed: false,
+      },
+    });
+
+    expect(revisionFeedback.reasoning).toContain("Dimension Scores:");
+    expect(revisionFeedback.reasoning).toContain("clarity: 0.70 (REGRESSION from 0.80 -- preserve this dimension)");
+    expect(revisionFeedback.reasoning).toContain("accuracy: 0.60 (improved from 0.40)");
+  });
+});

--- a/ts/tests/improvement-loop-result-workflow.test.ts
+++ b/ts/tests/improvement-loop-result-workflow.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildImprovementResult,
+  buildRoundResult,
+} from "../src/execution/improvement-loop-result.js";
+
+describe("improvement loop result workflow", () => {
+  it("builds round results with worst-dimension tracking", () => {
+    expect(buildRoundResult({
+      roundNumber: 2,
+      output: "revised draft",
+      result: {
+        score: 0.82,
+        reasoning: "Better",
+        dimensionScores: { clarity: 0.9, accuracy: 0.7, depth: 0.8 },
+        internalRetries: 0,
+      },
+      judgeFailed: false,
+      roundDurationMs: 12,
+    })).toMatchObject({
+      roundNumber: 2,
+      isRevision: true,
+      worstDimension: "accuracy",
+      worstDimensionScore: 0.7,
+      roundDurationMs: 12,
+    });
+  });
+
+  it("assembles final improvement loop results", () => {
+    const rounds = [buildRoundResult({
+      roundNumber: 1,
+      output: "draft",
+      result: {
+        score: 0.6,
+        reasoning: "ok",
+        dimensionScores: {},
+        internalRetries: 0,
+      },
+      judgeFailed: false,
+      roundDurationMs: 5,
+    })];
+
+    expect(buildImprovementResult({
+      rounds,
+      bestOutput: "draft",
+      bestScore: 0.6,
+      bestRound: 1,
+      metThreshold: false,
+      judgeFailures: 0,
+      terminationReason: "max_rounds",
+      dimensionTrajectory: {},
+      totalInternalRetries: 0,
+      durationMs: 20,
+      judgeCalls: 1,
+    })).toEqual({
+      rounds,
+      bestOutput: "draft",
+      bestScore: 0.6,
+      bestRound: 1,
+      totalRounds: 1,
+      metThreshold: false,
+      judgeFailures: 0,
+      terminationReason: "max_rounds",
+      dimensionTrajectory: {},
+      totalInternalRetries: 0,
+      durationMs: 20,
+      judgeCalls: 1,
+    });
+  });
+});

--- a/ts/tests/remove-hardcoded-models.test.ts
+++ b/ts/tests/remove-hardcoded-models.test.ts
@@ -67,19 +67,14 @@ describe("AgentTaskDesigner defaults", () => {
   it("should have empty judge_model in EXAMPLE_SPEC", async () => {
     // The EXAMPLE_SPEC is embedded in the system prompt. Check the prompt doesn't
     // use "claude-sonnet-4-20250514" as the judge_model default.
-    const { AGENT_TASK_DESIGNER_SYSTEM } = await import(
-      "../src/scenarios/agent-task-designer.js"
-    );
+    const { AGENT_TASK_DESIGNER_SYSTEM } = await import("../src/scenarios/agent-task-designer.js");
     // The system prompt should not contain the hardcoded model as a default
-    expect(AGENT_TASK_DESIGNER_SYSTEM).not.toContain(
-      '"judge_model": "claude-sonnet-4-20250514"',
-    );
+    expect(AGENT_TASK_DESIGNER_SYSTEM).not.toContain('"judge_model": "claude-sonnet-4-20250514"');
   });
 
   it("should parse spec without judge_model to empty string", async () => {
-    const { SPEC_START, SPEC_END, parseAgentTaskSpec } = await import(
-      "../src/scenarios/agent-task-designer.js"
-    );
+    const { SPEC_START, SPEC_END, parseAgentTaskSpec } =
+      await import("../src/scenarios/agent-task-designer.js");
     const raw = JSON.stringify({
       task_prompt: "test",
       judge_rubric: "rubric",
@@ -96,20 +91,49 @@ describe("AgentTaskDesigner defaults", () => {
 
 describe("AgentTaskCreator defaults", () => {
   it("should default model to empty string", async () => {
-    const { AgentTaskCreator } = await import(
-      "../src/scenarios/agent-task-creator.js"
-    );
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const { tmpdir } = await import("node:os");
+    const { AgentTaskCreator } = await import("../src/scenarios/agent-task-creator.js");
+    const { SPEC_END, SPEC_START } = await import("../src/scenarios/agent-task-designer.js");
+
     const provider = {
       name: "test",
       defaultModel: () => "test-model",
-      complete: vi.fn(),
+      complete: vi.fn().mockResolvedValue({
+        text:
+          `${SPEC_START}\n` +
+          JSON.stringify(
+            {
+              task_prompt: "Write a haiku about testing software.",
+              judge_rubric: "Evaluate format, relevance, and creativity.",
+              output_format: "free_text",
+              judge_model: "",
+              max_rounds: 1,
+              quality_threshold: 0.9,
+            },
+            null,
+            2,
+          ) +
+          `\n${SPEC_END}`,
+        usage: {},
+      }),
     };
-    const creator = new AgentTaskCreator({
-      provider,
-      knowledgeRoot: "/tmp/test",
-    });
-    // Access private field via casting
-    expect((creator as any).model).toBe("");
+
+    const dir = mkdtempSync(join(tmpdir(), "autoctx-agent-task-creator-default-model-"));
+    try {
+      const creator = new AgentTaskCreator({
+        provider,
+        knowledgeRoot: dir,
+      });
+
+      await creator.create("Write a haiku about testing software.");
+
+      expect(provider.complete).toHaveBeenCalled();
+      expect(provider.complete.mock.calls[0]?.[0]?.model).toBe("");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -119,32 +143,71 @@ describe("AgentTaskCreator defaults", () => {
 
 describe("SimpleAgentTask defaults", () => {
   it("should fall back to provider.defaultModel() when model omitted", async () => {
-    const { SimpleAgentTask } = await import(
-      "../src/execution/task-runner.js"
-    );
+    const { SimpleAgentTask } = await import("../src/execution/task-runner.js");
     const provider = {
       name: "test",
       defaultModel: () => "test-model",
-      complete: vi.fn(),
+      complete: vi.fn().mockResolvedValue({ text: "generated", usage: {} }),
     };
     const task = new SimpleAgentTask("prompt", "rubric", provider);
-    // AC-298: model should fall back to provider default, not empty string
-    expect((task as any).model).toBe("test-model");
+
+    await task.generateOutput();
+
+    expect(provider.complete).toHaveBeenCalled();
+    expect(provider.complete.mock.calls[0]?.[0]?.model).toBe("test-model");
   });
 });
 
 describe("TaskRunner defaults", () => {
   it("should fall back to provider.defaultModel() when model omitted", async () => {
-    const { TaskRunner } = await import("../src/execution/task-runner.js");
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const { tmpdir } = await import("node:os");
+    const { SQLiteStore } = await import("../src/storage/index.js");
+    const { TaskRunner, enqueueTask } = await import("../src/execution/task-runner.js");
+
+    const dir = mkdtempSync(join(tmpdir(), "autoctx-runner-default-model-"));
+    const store = new SQLiteStore(join(dir, "test.db"));
+    store.migrate(join(import.meta.dirname, "..", "migrations"));
+
     const provider = {
       name: "test",
       defaultModel: () => "test-model",
-      complete: vi.fn(),
+      complete: vi
+        .fn()
+        .mockImplementation(async (opts: { systemPrompt: string; model: string }) => {
+          if (opts.systemPrompt.includes("judge")) {
+            return {
+              text:
+                "<!-- JUDGE_RESULT_START -->\n{" +
+                '\"score\":0.9,\"reasoning\":\"ok\",\"dimensions\":{\"quality\":0.9}}' +
+                "\n<!-- JUDGE_RESULT_END -->",
+              usage: {},
+            };
+          }
+          return { text: "draft", usage: {} };
+        }),
     };
-    const store = {} as any;
-    const runner = new TaskRunner({ store, provider });
-    // AC-298: model should fall back to provider default, not empty string
-    expect((runner as any).model).toBe("test-model");
+
+    try {
+      enqueueTask(store, "test-spec", {
+        taskPrompt: "prompt",
+        rubric: "rubric",
+        initialOutput: "draft",
+        maxRounds: 1,
+      });
+
+      const runner = new TaskRunner({ store, provider });
+      await runner.runOnce();
+
+      expect(provider.complete).toHaveBeenCalled();
+      expect(provider.complete.mock.calls.every(([call]) => call.model === "test-model")).toBe(
+        true,
+      );
+    } finally {
+      store.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -176,9 +239,7 @@ describe("MCP server defaults", () => {
 
 describe("Provider empty model fallback", () => {
   it("Anthropic provider should use default when model is empty", async () => {
-    const { createAnthropicProvider } = await import(
-      "../src/providers/index.js"
-    );
+    const { createAnthropicProvider } = await import("../src/providers/index.js");
     const provider = createAnthropicProvider({ apiKey: "test" });
 
     const mockFetch = vi.fn().mockResolvedValue({
@@ -205,9 +266,7 @@ describe("Provider empty model fallback", () => {
   });
 
   it("OpenAI-compatible provider should use default when model is empty", async () => {
-    const { createOpenAICompatibleProvider } = await import(
-      "../src/providers/index.js"
-    );
+    const { createOpenAICompatibleProvider } = await import("../src/providers/index.js");
     const provider = createOpenAICompatibleProvider({
       apiKey: "test",
       model: "gpt-4o",
@@ -257,12 +316,8 @@ describe("No hardcoded Anthropic model in scaffold TS files", () => {
     it(`${filepath} should not hardcode Anthropic model`, async () => {
       const { readFileSync } = await import("node:fs");
       const { join } = await import("node:path");
-      const content = readFileSync(
-        join(import.meta.dirname, "..", filepath),
-        "utf-8",
-      );
-      const count = (content.match(new RegExp(HARDCODED_MODEL, "g")) || [])
-        .length;
+      const content = readFileSync(join(import.meta.dirname, "..", filepath), "utf-8");
+      const count = (content.match(new RegExp(HARDCODED_MODEL, "g")) || []).length;
       expect(count).toBe(0);
     });
   }

--- a/ts/tests/sandbox-manager.test.ts
+++ b/ts/tests/sandbox-manager.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { SandboxManager } from "../src/execution/sandbox.js";
+
+const PROVIDER_STUB = {
+  name: "test-provider",
+  defaultModel: () => "test-model",
+  complete: async () => ({ text: "{}", usage: {} }),
+};
+
+describe("SandboxManager encapsulation", () => {
+  it("uses real #private fields for internal sandbox state", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "src", "execution", "sandbox.ts"),
+      "utf-8",
+    );
+
+    expect(source).toContain("#provider");
+    expect(source).toContain("#store");
+    expect(source).toContain("#runsRoot");
+    expect(source).toContain("#knowledgeRoot");
+    expect(source).toContain("#maxSandboxes");
+    expect(source).toContain("#sandboxes");
+    expect(source).not.toContain("private provider:");
+    expect(source).not.toContain("private store:");
+    expect(source).not.toContain("private runsRoot:");
+    expect(source).not.toContain("private knowledgeRoot:");
+    expect(source).not.toContain("private maxSandboxes:");
+  });
+});
+
+describe("SandboxManager", () => {
+  it("creates, lists, reports, and destroys sandboxes", () => {
+    const manager = new SandboxManager({
+      provider: PROVIDER_STUB,
+      store: {} as never,
+      runsRoot: "/tmp/runs",
+      knowledgeRoot: "/tmp/knowledge",
+      maxSandboxes: 2,
+    });
+
+    const created = manager.create("grid_ctf", "test-user");
+
+    expect(created.scenarioName).toBe("grid_ctf");
+    expect(created.userId).toBe("test-user");
+    expect(created.status).toBe("active");
+    expect(manager.getStatus(created.sandboxId)).toEqual(created);
+    expect(manager.list()).toEqual([created]);
+
+    expect(manager.destroy(created.sandboxId)).toBe(true);
+    expect(manager.getStatus(created.sandboxId)).toBeNull();
+    expect(manager.list()).toEqual([]);
+  });
+
+  it("rejects unknown scenarios and enforces the configured sandbox limit", () => {
+    const manager = new SandboxManager({
+      provider: PROVIDER_STUB,
+      store: {} as never,
+      runsRoot: "/tmp/runs",
+      knowledgeRoot: "/tmp/knowledge",
+      maxSandboxes: 1,
+    });
+
+    expect(() => manager.create("missing_scenario")).toThrow(/Unknown scenario/);
+
+    manager.create("grid_ctf", "user-a");
+    expect(() => manager.create("grid_ctf", "user-b")).toThrow(/Maximum sandbox limit/);
+  });
+});

--- a/ts/tests/sandbox-tools.test.ts
+++ b/ts/tests/sandbox-tools.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildSandboxNotFoundPayload,
+  registerSandboxTools,
+} from "../src/mcp/sandbox-tools.js";
+
+function createFakeServer() {
+  const registeredTools: Record<
+    string,
+    {
+      description: string;
+      schema: Record<string, unknown>;
+      handler: (args: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text: string }> }>;
+    }
+  > = {};
+
+  return {
+    registeredTools,
+    tool(
+      name: string,
+      description: string,
+      schema: Record<string, unknown>,
+      handler: (args: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text: string }> }>,
+    ) {
+      registeredTools[name] = { description, schema, handler };
+    },
+  };
+}
+
+describe("sandbox MCP tools", () => {
+  it("creates, runs, lists, reads playbooks, and destroys sandboxes", async () => {
+    const server = createFakeServer();
+    const manager = {
+      create: vi.fn(() => ({
+        sandboxId: "sb-1",
+        scenarioName: "grid_ctf",
+        userId: "test-user",
+        status: "active",
+      })),
+      run: vi.fn(async () => ({ runId: "run-1", bestScore: 0.91, elo: 1112 })),
+      getStatus: vi.fn(() => ({
+        sandboxId: "sb-1",
+        scenarioName: "grid_ctf",
+        userId: "test-user",
+        status: "active",
+      })),
+      readPlaybook: vi.fn(() => "## Strategy Updates\n"),
+      list: vi.fn(() => [{ sandboxId: "sb-1" }]),
+      destroy: vi.fn(() => true),
+    };
+
+    registerSandboxTools(server, {
+      sandboxManager: manager,
+    });
+
+    const created = await server.registeredTools.sandbox_create.handler({
+      scenario: "grid_ctf",
+      userId: "test-user",
+    });
+    expect(JSON.parse(created.content[0].text)).toEqual({
+      sandboxId: "sb-1",
+      scenarioName: "grid_ctf",
+      userId: "test-user",
+      status: "active",
+    });
+
+    const status = await server.registeredTools.sandbox_status.handler({ sandboxId: "sb-1" });
+    expect(JSON.parse(status.content[0].text)).toEqual({
+      sandboxId: "sb-1",
+      scenarioName: "grid_ctf",
+      userId: "test-user",
+      status: "active",
+    });
+
+    const listed = await server.registeredTools.sandbox_list.handler({});
+    expect(JSON.parse(listed.content[0].text)).toEqual([{ sandboxId: "sb-1" }]);
+
+    const run = await server.registeredTools.sandbox_run.handler({
+      sandboxId: "sb-1",
+      generations: 2,
+    });
+    expect(manager.run).toHaveBeenCalledWith("sb-1", 2);
+    expect(JSON.parse(run.content[0].text)).toEqual({
+      runId: "run-1",
+      bestScore: 0.91,
+      elo: 1112,
+    });
+
+    const playbook = await server.registeredTools.sandbox_playbook.handler({ sandboxId: "sb-1" });
+    expect(playbook.content[0].text).toBe("## Strategy Updates\n");
+
+    const destroyed = await server.registeredTools.sandbox_destroy.handler({ sandboxId: "sb-1" });
+    expect(JSON.parse(destroyed.content[0].text)).toEqual({
+      destroyed: true,
+      sandboxId: "sb-1",
+    });
+  });
+
+  it("returns stable not-found payloads for sandbox status", async () => {
+    const server = createFakeServer();
+
+    registerSandboxTools(server, {
+      sandboxManager: {
+        create: vi.fn(),
+        run: vi.fn(),
+        getStatus: vi.fn(() => null),
+        readPlaybook: vi.fn(),
+        list: vi.fn(() => []),
+        destroy: vi.fn(() => false),
+      },
+    });
+
+    const result = await server.registeredTools.sandbox_status.handler({
+      sandboxId: "missing-sb",
+    });
+
+    expect(JSON.parse(result.content[0].text)).toEqual(
+      buildSandboxNotFoundPayload("missing-sb"),
+    );
+  });
+});

--- a/ts/tests/task-processing-workflow.test.ts
+++ b/ts/tests/task-processing-workflow.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildQueuedTaskExecutionPlan,
+  executeQueuedTaskWorkflow,
+} from "../src/execution/task-processing-workflow.js";
+
+describe("task processing workflow", () => {
+  it("merges explicit queue config, saved task defaults, and fallback defaults", () => {
+    const plan = buildQueuedTaskExecutionPlan({
+      task: {
+        spec_name: "saved-task",
+        config_json: JSON.stringify({
+          task_prompt: "Queued prompt",
+          min_rounds: 3,
+          delegated_results: [{ score: 0.8, reasoning: "delegated" }],
+        }),
+      },
+      knowledgeRoot: "/knowledge",
+      internals: {
+        resolveSavedTask: () => ({
+          spec: {
+            judgeRubric: "Saved rubric",
+            referenceContext: "Saved context",
+            requiredConcepts: ["clarity"],
+            maxRounds: 7,
+            qualityThreshold: 0.95,
+            revisionPrompt: "Saved revision",
+          },
+        }),
+        createDelegatedJudge: vi.fn(() => ({ tag: "judge" })) as never,
+      },
+    });
+
+    expect(plan).toMatchObject({
+      taskPrompt: "Queued prompt",
+      rubric: "Saved rubric",
+      referenceContext: "Saved context",
+      requiredConcepts: ["clarity"],
+      maxRounds: 7,
+      qualityThreshold: 0.95,
+      minRounds: 3,
+      revisionPrompt: "Saved revision",
+    });
+    expect(plan.delegatedJudge).toEqual({ tag: "judge" });
+  });
+
+  it("completes tasks through injected agent/loop workflows", async () => {
+    const completeTask = vi.fn();
+    const failTask = vi.fn();
+    const generateOutput = vi.fn(async () => "generated output");
+    const run = vi.fn(async () => ({
+      rounds: [],
+      bestOutput: "best output",
+      bestScore: 0.92,
+      bestRound: 2,
+      totalRounds: 2,
+      metThreshold: true,
+      judgeFailures: 0,
+      terminationReason: "threshold_met",
+      dimensionTrajectory: {},
+      totalInternalRetries: 0,
+      durationMs: 10,
+      judgeCalls: 2,
+    }));
+
+    await executeQueuedTaskWorkflow({
+      store: { completeTask, failTask } as never,
+      task: {
+        id: "task-1",
+        spec_name: "queued-spec",
+        config_json: JSON.stringify({ task_prompt: "Prompt" }),
+      } as never,
+      provider: { complete: vi.fn(), defaultModel: () => "mock", name: "mock" } as never,
+      model: "mock-model",
+      internals: {
+        createAgentTask: vi.fn(() => ({
+          initialState: () => ({ seed: 1 }),
+          generateOutput,
+          getRlmSessions: () => [{ phase: "generate", content: "generated output" }],
+        })) as never,
+        createImprovementLoop: vi.fn(() => ({ run })) as never,
+        serializeTaskResult: vi.fn(() => "serialized-result"),
+      },
+    });
+
+    expect(generateOutput).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledWith({
+      initialOutput: "generated output",
+      state: { seed: 1 },
+      referenceContext: undefined,
+      requiredConcepts: undefined,
+      calibrationExamples: undefined,
+    });
+    expect(completeTask).toHaveBeenCalledWith(
+      "task-1",
+      0.92,
+      "best output",
+      2,
+      true,
+      "serialized-result",
+    );
+    expect(failTask).not.toHaveBeenCalled();
+  });
+
+  it("fails tasks with message-only errors when planning or execution throws", async () => {
+    const completeTask = vi.fn();
+    const failTask = vi.fn();
+
+    await executeQueuedTaskWorkflow({
+      store: { completeTask, failTask } as never,
+      task: {
+        id: "task-2",
+        spec_name: "queued-spec",
+        config_json: JSON.stringify({ task_prompt: "Prompt" }),
+      } as never,
+      provider: { complete: vi.fn(), defaultModel: () => "mock", name: "mock" } as never,
+      model: "mock-model",
+      internals: {
+        createAgentTask: vi.fn(() => {
+          throw new Error("workflow exploded");
+        }) as never,
+      },
+    });
+
+    expect(completeTask).not.toHaveBeenCalled();
+    expect(failTask).toHaveBeenCalledWith("task-2", "workflow exploded");
+  });
+});

--- a/ts/tests/task-runner-config-workflow.test.ts
+++ b/ts/tests/task-runner-config-workflow.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEnqueueTaskConfig,
+  parseTaskConfig,
+  serializeTaskResult,
+} from "../src/execution/task-runner-config.js";
+
+describe("task runner config workflow", () => {
+  it("parses queue config JSON into runtime config", () => {
+    expect(
+      parseTaskConfig(JSON.stringify({
+        max_rounds: 4,
+        quality_threshold: 0.85,
+        min_rounds: 2,
+        task_prompt: "Write a summary",
+        rubric: "Be clear",
+        delegated_results: [{
+          score: 0.8,
+          reasoning: "delegated",
+          dimension_scores: { clarity: 0.8 },
+        }],
+        rlm_enabled: true,
+        rlm_max_turns: 3,
+      })),
+    ).toMatchObject({
+      maxRounds: 4,
+      qualityThreshold: 0.85,
+      minRounds: 2,
+      taskPrompt: "Write a summary",
+      rubric: "Be clear",
+      delegatedResults: [{
+        score: 0.8,
+        reasoning: "delegated",
+        dimensionScores: { clarity: 0.8 },
+      }],
+      rlm: {
+        enabled: true,
+        maxTurns: 3,
+      },
+    });
+  });
+
+  it("serializes completed task results with optional RLM sessions", () => {
+    const payload = JSON.parse(serializeTaskResult({
+      rounds: [{
+        roundNumber: 1,
+        output: "draft",
+        score: 0.7,
+        reasoning: "good",
+        dimensionScores: { quality: 0.7 },
+        isRevision: false,
+        judgeFailed: false,
+      }],
+      bestOutput: "best",
+      bestScore: 0.9,
+      bestRound: 1,
+      totalRounds: 1,
+      metThreshold: true,
+      judgeFailures: 0,
+      terminationReason: "threshold_met",
+      dimensionTrajectory: {},
+      totalInternalRetries: 0,
+      durationMs: 12,
+      judgeCalls: 1,
+    }, [{ phase: "generate", content: "draft" } as never]));
+
+    expect(payload.best_score).toBe(0.9);
+    expect(payload.duration_ms).toBe(12);
+    expect(payload.judge_calls).toBe(1);
+    expect(payload.rlm_sessions).toEqual([{ phase: "generate", content: "draft" }]);
+  });
+
+  it("builds snake_case enqueue config fields only for provided values", () => {
+    expect(buildEnqueueTaskConfig({
+      taskPrompt: "Prompt",
+      minRounds: 3,
+      rlmEnabled: true,
+      rlmModel: "claude",
+    })).toEqual({
+      task_prompt: "Prompt",
+      min_rounds: 3,
+      rlm_enabled: true,
+      rlm_model: "claude",
+    });
+
+    expect(buildEnqueueTaskConfig()).toBeUndefined();
+  });
+});

--- a/ts/tests/task-runner-workflows.test.ts
+++ b/ts/tests/task-runner-workflows.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildSimpleAgentTaskRevisionPrompt,
+  evaluateSimpleAgentTaskOutput,
+} from "../src/execution/simple-agent-task-workflow.js";
+import {
+  buildTaskRunnerModel,
+  dequeueTaskBatch,
+} from "../src/execution/task-runner-loop-workflow.js";
+
+describe("task runner workflows", () => {
+  it("builds task runner model defaults and dequeues up to the requested batch size", () => {
+    expect(buildTaskRunnerModel("provider-default")).toBe("provider-default");
+    expect(buildTaskRunnerModel("provider-default", "explicit-model")).toBe("explicit-model");
+
+    const dequeued = [{ id: "t1" }, { id: "t2" }, null] as const;
+    let index = 0;
+    const store = {
+      dequeueTask: vi.fn(() => dequeued[index++] ?? null),
+    } as never;
+
+    expect(dequeueTaskBatch(store, 5)).toEqual([{ id: "t1" }, { id: "t2" }]);
+  });
+
+  it("builds revision prompts and normalizes judge results", async () => {
+    const prompt = buildSimpleAgentTaskRevisionPrompt({
+      output: "Draft answer",
+      judgeResult: { score: 0.45, reasoning: "Need more detail", dimensionScores: {}, internalRetries: 0 },
+      taskPrompt: "Summarize the outage",
+      revisionPrompt: "Add owner and severity.",
+    });
+
+    expect(prompt).toContain("Add owner and severity.");
+    expect(prompt).toContain("## Judge Score: 0.45");
+    expect(prompt).toContain("Summarize the outage");
+
+    const result = await evaluateSimpleAgentTaskOutput({
+      taskPrompt: "Summarize the outage",
+      rubric: "Be complete",
+      provider: {
+        name: "unused",
+        defaultModel: () => "unused",
+        complete: vi.fn(),
+      } as never,
+      model: "mock-model",
+      output: "Answer",
+      judgeOverride: {
+        evaluate: vi.fn(async () => ({
+          score: 0.9,
+          reasoning: "Great",
+          dimensionScores: { quality: 0.9 },
+          internalRetries: 0,
+        })),
+      } as never,
+    });
+
+    expect(result).toEqual({
+      score: 0.9,
+      reasoning: "Great",
+      dimensionScores: { quality: 0.9 },
+      internalRetries: 0,
+    });
+  });
+});

--- a/ts/tests/task-runner.test.ts
+++ b/ts/tests/task-runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { SQLiteStore } from "../src/storage/index.js";
@@ -93,6 +93,21 @@ describe("enqueueTask", () => {
     enqueueTask(store, "high", { priority: 10 });
     const task = store.dequeueTask();
     expect(task!.spec_name).toBe("high");
+  });
+});
+
+describe("TaskRunner encapsulation", () => {
+  it("uses real #private fields for runner and simple task internals", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "src", "execution", "task-runner.ts"),
+      "utf-8",
+    );
+
+    expect(source).toContain("#taskPrompt");
+    expect(source).toContain("#store");
+    expect(source).toContain("#tasksProcessed");
+    expect(source).not.toContain("private taskPrompt:");
+    expect(source).not.toContain("private store:");
   });
 });
 
@@ -345,10 +360,14 @@ describe("SimpleAgentTask", () => {
       { enabled: true, maxTurns: 2 },
     );
 
-    await task.evaluateOutput("Original draft", {}, {
-      referenceContext: "Trusted facts",
-      requiredConcepts: ["clarity"],
-    });
+    await task.evaluateOutput(
+      "Original draft",
+      {},
+      {
+        referenceContext: "Trusted facts",
+        requiredConcepts: ["clarity"],
+      },
+    );
 
     const revised = await task.reviseOutput(
       "Original draft",


### PR DESCRIPTION
## Summary
- finish the review-aligned execution/core cleanup slice
- migrate the remaining safe execution-adjacent internals to real `#private` where appropriate
- extract focused action-filter, improvement-loop, task-runner, and sandbox helper workflows
- add focused execution-surface tests and keep the repo-level ignore updates with this low-risk cleanup slice

## Testing
- npm run lint
- focused execution bundles during implementation, including:
  - `tests/action-filter*.test.ts`
  - `tests/task-runner*.test.ts`
  - `tests/sandbox*.test.ts`
  - `tests/remove-hardcoded-models.test.ts`

## Notes
- This is PR 1/6 in the reviewer-friendly TypeScript cleanup split.
- Subsequent PRs are isolated onto separate main-based branches for smaller review surfaces.
