### PR TITLE
chore: release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-Changes in this section are on the branch/repo after `0.3.7` and are not part of the last published release until the next version is cut.
+Changes in this section are on the branch/repo after `0.4.0` and are not part of the last published release until the next version is cut.
+
+## [0.4.0] - 2026-04-14
+
+### Changed
+
+- Refactored the TypeScript platform foundation, analytics/trace/training, and control-plane integration surfaces into thinner workflow modules while preserving CLI, MCP, and package parity.
+- Hardened the extracted package-surface workflows around typed MCP tool boundaries, simulation dashboard report parsing, and deterministic simulation score normalization.
+- Python and TypeScript package metadata are bumped to `0.4.0`.
 
 ## [0.3.7] - 2026-04-08
 
@@ -164,6 +172,7 @@ Changes in this section are on the branch/repo after `0.3.7` and are not part of
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
+[0.4.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.3.7...py-v0.4.0
 [0.3.7]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.3.6...py-v0.3.7
 [0.3.6]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.3.5...py-v0.3.6
 [0.3.5]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.3.4...py-v0.3.5

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The repo publishes two installable packages with different scopes:
 
 - Python package: `pip install autocontext`
 - TypeScript package: `npm install autoctx`
-- Current release line: `autocontext==0.3.7` and `autoctx@0.3.7`
+- Current release line: `autocontext==0.4.0` and `autoctx@0.4.0`
 
 Important:
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -10,7 +10,7 @@ The intended use is to hand the harness a real task in plain language, let it so
 pip install autocontext
 ```
 
-The current PyPI release line is `autocontext==0.3.7`.
+The current PyPI release line is `autocontext==0.4.0`.
 The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
 
 ## Working Directory

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autocontext"
-version = "0.3.7"
+version = "0.4.0"
 description = "autocontext control plane for iterative strategy evolution."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/autocontext/src/autocontext/__init__.py
+++ b/autocontext/src/autocontext/__init__.py
@@ -4,4 +4,4 @@ from autocontext.sdk import AutoContext
 
 __all__ = ["AutoContext", "__version__"]
 
-__version__ = "0.2.0"
+__version__ = "0.4.0"

--- a/autocontext/uv.lock
+++ b/autocontext/uv.lock
@@ -72,7 +72,7 @@ wheels = [
 
 [[package]]
 name = "autocontext"
-version = "0.3.7"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -59,16 +59,16 @@ npm pack --dry-run
 
 ## 5. Sanity-Check Publishing Inputs
 
-- Confirm `.github/workflows/publish.yml` still matches the intended publish surfaces.
-- Treat `.github/workflows/publish.yml` as the only supported release workflow. Do not add a parallel publish path without updating the trusted publisher configuration first.
+- Confirm `.github/workflows/publish-python.yml` and `.github/workflows/publish-ts.yml` still match the intended publish surfaces.
+- Treat `.github/workflows/publish-python.yml` and `.github/workflows/publish-ts.yml` as the supported release workflows. Do not add a parallel publish path without updating the trusted publisher configuration first.
 - Confirm release notes in `CHANGELOG.md` reflect the tagged version.
 - Confirm any install commands in the READMEs still match the package names and binaries.
 
 ## 6. Publish
 
 - Merge the release prep to the intended branch.
-- Create and push a tag in the format `vX.Y.Z`.
-- Watch the tag-triggered GitHub Actions `publish` workflow for both PyPI and npm.
+- Create and push package-specific tags in the format `py-vX.Y.Z` and `ts-vX.Y.Z`.
+- Watch the tag-triggered GitHub Actions `publish-python` and `publish-ts` workflows for PyPI and npm.
 - Approve the `release` environment when the trusted publish jobs pause for deployment review.
 
 ## 7. Post-Release

--- a/ts/README.md
+++ b/ts/README.md
@@ -25,7 +25,7 @@ Need the canonical product/runtime vocabulary first? Start with [docs/concept-mo
 npm install autoctx
 ```
 
-The current npm release line is `autoctx@0.3.7`.
+The current npm release line is `autoctx@0.4.0`.
 Important: use `autoctx`, not `autocontext`.
 `autocontext` on npm is a different package and not this project.
 
@@ -232,7 +232,7 @@ const improved = await loop.run({ initialOutput: "We can help with that billing 
 
 ## TS / Python Scope
 
-The TypeScript package includes the current 0.3.x operator-facing surfaces:
+The TypeScript package includes the current 0.4.x operator-facing surfaces:
 
 - `simulate`
 - `investigate`

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoctx",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoctx",
-      "version": "0.3.7",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoctx",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump Python and TypeScript package metadata to 0.4.0
- update README release lines and CHANGELOG.md for 0.4.0
- align the release checklist with the split Python/TS publish workflows

## Validation
- cd autocontext && uv build
- cd ts && npm run lint
- cd ts && npm run build
- cd ts && npm test
- cd ts && npm_config_cache=/private/tmp/release040/.npm-cache npm pack --dry-run