### PR TITLE
AC-538: expose Claude CLI and Codex as first-class live providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 autocontext runs LLM agents through structured scenarios, evaluates their outputs, and accumulates the knowledge that improved results — so repeated runs get better, not just different. Point the harness at a real task in plain language, let it work the problem, and then inspect the traces, reports, artifacts, datasets, playbooks, and optional distilled model it produces.
 
 <!-- autocontext-whats-new:start -->
-
 ## What's New
 
 - All 11 scenario families executable in both Python and TypeScript

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 autocontext runs LLM agents through structured scenarios, evaluates their outputs, and accumulates the knowledge that improved results — so repeated runs get better, not just different. Point the harness at a real task in plain language, let it work the problem, and then inspect the traces, reports, artifacts, datasets, playbooks, and optional distilled model it produces.
 
 <!-- autocontext-whats-new:start -->
+
 ## What's New
 
 - All 11 scenario families executable in both Python and TypeScript
@@ -172,6 +173,24 @@ uv run autoctx solve --description "improve customer-support replies for billing
 ```
 
 `ANTHROPIC_API_KEY` is the preferred Anthropic credential env var. `AUTOCONTEXT_ANTHROPIC_API_KEY` remains supported as a compatibility alias.
+
+Run with Claude CLI:
+
+```bash
+cd autocontext
+AUTOCONTEXT_AGENT_PROVIDER=claude-cli \
+AUTOCONTEXT_CLAUDE_MODEL=sonnet \
+uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+```
+
+Run with Codex CLI:
+
+```bash
+cd autocontext
+AUTOCONTEXT_AGENT_PROVIDER=codex \
+AUTOCONTEXT_CODEX_MODEL=o4-mini \
+uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+```
 
 Start the API server:
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -76,6 +76,22 @@ uv run autoctx solve --description "improve customer-support replies for billing
 
 `ANTHROPIC_API_KEY` is the preferred Anthropic credential env var. `AUTOCONTEXT_ANTHROPIC_API_KEY` remains supported as a compatibility alias.
 
+Run with Claude CLI (`claude -p` via a local authenticated Claude Code runtime):
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=claude-cli \
+AUTOCONTEXT_CLAUDE_MODEL=sonnet \
+uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+```
+
+Run with Codex CLI (`codex exec` via a local authenticated Codex runtime):
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=codex \
+AUTOCONTEXT_CODEX_MODEL=o4-mini \
+uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+```
+
 Run with Pi CLI (local Pi agent runtime):
 
 ```bash

--- a/autocontext/src/autocontext/agents/llm_client.py
+++ b/autocontext/src/autocontext/agents/llm_client.py
@@ -568,6 +568,30 @@ def build_client_from_settings(
             model=settings.agent_default_model,
         )
         return ProviderBridgeClient(provider, use_provider_default_model=True)
+    if settings.agent_provider == "claude-cli":
+        from autocontext.agents.provider_bridge import RuntimeBridgeClient
+        from autocontext.runtimes.claude_cli import ClaudeCLIConfig, ClaudeCLIRuntime
+
+        config = ClaudeCLIConfig(
+            model=settings.claude_model,
+            tools=settings.claude_tools,
+            permission_mode=settings.claude_permission_mode,
+            session_persistence=settings.claude_session_persistence,
+            timeout=settings.claude_timeout,
+        )
+        return RuntimeBridgeClient(ClaudeCLIRuntime(config))
+    if settings.agent_provider == "codex":
+        from autocontext.agents.provider_bridge import RuntimeBridgeClient
+        from autocontext.runtimes.codex_cli import CodexCLIConfig, CodexCLIRuntime
+
+        config = CodexCLIConfig(
+            model=settings.codex_model,
+            approval_mode=settings.codex_approval_mode,
+            timeout=settings.codex_timeout,
+            workspace=settings.codex_workspace,
+            quiet=settings.codex_quiet,
+        )
+        return RuntimeBridgeClient(CodexCLIRuntime(config))
     if settings.agent_provider == "pi":
         from autocontext.agents.provider_bridge import RuntimeBridgeClient
         from autocontext.providers.scenario_routing import resolve_pi_model

--- a/autocontext/src/autocontext/agents/llm_client.py
+++ b/autocontext/src/autocontext/agents/llm_client.py
@@ -572,26 +572,26 @@ def build_client_from_settings(
         from autocontext.agents.provider_bridge import RuntimeBridgeClient
         from autocontext.runtimes.claude_cli import ClaudeCLIConfig, ClaudeCLIRuntime
 
-        config = ClaudeCLIConfig(
+        claude_config = ClaudeCLIConfig(
             model=settings.claude_model,
             tools=settings.claude_tools,
             permission_mode=settings.claude_permission_mode,
             session_persistence=settings.claude_session_persistence,
             timeout=settings.claude_timeout,
         )
-        return RuntimeBridgeClient(ClaudeCLIRuntime(config))
+        return RuntimeBridgeClient(ClaudeCLIRuntime(claude_config))
     if settings.agent_provider == "codex":
         from autocontext.agents.provider_bridge import RuntimeBridgeClient
         from autocontext.runtimes.codex_cli import CodexCLIConfig, CodexCLIRuntime
 
-        config = CodexCLIConfig(
+        codex_config = CodexCLIConfig(
             model=settings.codex_model,
             approval_mode=settings.codex_approval_mode,
             timeout=settings.codex_timeout,
             workspace=settings.codex_workspace,
             quiet=settings.codex_quiet,
         )
-        return RuntimeBridgeClient(CodexCLIRuntime(config))
+        return RuntimeBridgeClient(CodexCLIRuntime(codex_config))
     if settings.agent_provider == "pi":
         from autocontext.agents.provider_bridge import RuntimeBridgeClient
         from autocontext.providers.scenario_routing import resolve_pi_model
@@ -613,13 +613,13 @@ def build_client_from_settings(
             if handoff is not None:
                 resolved_model = handoff.checkpoint_path
 
-        config = PiCLIConfig(
+        pi_config = PiCLIConfig(
             pi_command=settings.pi_command,
             timeout=settings.pi_timeout,
             workspace=settings.pi_workspace,
             model=resolved_model,
         )
-        return RuntimeBridgeClient(PiCLIRuntime(config))
+        return RuntimeBridgeClient(PiCLIRuntime(pi_config))
     if settings.agent_provider == "pi-rpc":
         from autocontext.agents.provider_bridge import RuntimeBridgeClient
         from autocontext.runtimes.pi_rpc import PiRPCConfig, PiRPCRuntime

--- a/autocontext/src/autocontext/providers/registry.py
+++ b/autocontext/src/autocontext/providers/registry.py
@@ -119,50 +119,53 @@ def get_provider(settings: AppSettings) -> LLMProvider:
         from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
         from autocontext.runtimes.claude_cli import ClaudeCLIConfig, ClaudeCLIRuntime
 
-        runtime = ClaudeCLIRuntime(ClaudeCLIConfig(
+        claude_runtime = ClaudeCLIRuntime(ClaudeCLIConfig(
             model=settings.claude_model,
             tools=settings.claude_tools,
             permission_mode=settings.claude_permission_mode,
             session_persistence=settings.claude_session_persistence,
             timeout=settings.claude_timeout,
         ))
-        return RuntimeBridgeProvider(runtime, default_model_name=settings.claude_model)
+        return RuntimeBridgeProvider(claude_runtime, default_model_name=settings.claude_model)
 
     if provider_type == "codex":
         from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
         from autocontext.runtimes.codex_cli import CodexCLIConfig, CodexCLIRuntime
 
-        runtime = CodexCLIRuntime(CodexCLIConfig(
+        codex_runtime = CodexCLIRuntime(CodexCLIConfig(
             model=settings.codex_model,
             approval_mode=settings.codex_approval_mode,
             timeout=settings.codex_timeout,
             workspace=settings.codex_workspace,
             quiet=settings.codex_quiet,
         ))
-        return RuntimeBridgeProvider(runtime, default_model_name=settings.codex_model)
+        return RuntimeBridgeProvider(codex_runtime, default_model_name=settings.codex_model)
 
     if provider_type == "pi":
         from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
         from autocontext.runtimes.pi_cli import PiCLIConfig, PiCLIRuntime
 
-        runtime = PiCLIRuntime(PiCLIConfig(
+        pi_runtime = PiCLIRuntime(PiCLIConfig(
             pi_command=settings.pi_command,
             timeout=settings.pi_timeout,
             workspace=settings.pi_workspace,
             model=settings.pi_model,
         ))
-        return RuntimeBridgeProvider(runtime, default_model_name=settings.pi_model or "pi-default")
+        return RuntimeBridgeProvider(pi_runtime, default_model_name=settings.pi_model or "pi-default")
 
     if provider_type == "pi-rpc":
         from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
         from autocontext.runtimes.pi_rpc import PiRPCConfig, PiRPCRuntime
 
-        runtime = PiRPCRuntime(PiRPCConfig(
+        pi_rpc_runtime = PiRPCRuntime(PiRPCConfig(
             pi_command=settings.pi_command,
             model=settings.pi_model or settings.judge_model,
             session_persistence=settings.pi_rpc_session_persistence,
         ))
-        return RuntimeBridgeProvider(runtime, default_model_name=settings.pi_model or settings.judge_model or "pi-rpc-default")
+        return RuntimeBridgeProvider(
+            pi_rpc_runtime,
+            default_model_name=settings.pi_model or settings.judge_model or "pi-rpc-default",
+        )
 
     # Use judge_api_key if set, otherwise fall back to provider-specific keys
     api_key = settings.judge_api_key

--- a/autocontext/src/autocontext/providers/registry.py
+++ b/autocontext/src/autocontext/providers/registry.py
@@ -99,7 +99,7 @@ def get_provider(settings: AppSettings) -> LLMProvider:
     ``settings.judge_api_key``. Falls back to provider-specific env vars
     (``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``) when ``judge_api_key`` is not set.
     """
-    provider_type = settings.judge_provider
+    provider_type = settings.judge_provider.lower().strip()
     base_url = settings.judge_base_url
 
     # MLX provider has its own construction path using mlx_* settings
@@ -114,6 +114,55 @@ def get_provider(settings: AppSettings) -> LLMProvider:
             temperature=settings.mlx_temperature,
             max_tokens=settings.mlx_max_tokens,
         )
+
+    if provider_type == "claude-cli":
+        from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
+        from autocontext.runtimes.claude_cli import ClaudeCLIConfig, ClaudeCLIRuntime
+
+        runtime = ClaudeCLIRuntime(ClaudeCLIConfig(
+            model=settings.claude_model,
+            tools=settings.claude_tools,
+            permission_mode=settings.claude_permission_mode,
+            session_persistence=settings.claude_session_persistence,
+            timeout=settings.claude_timeout,
+        ))
+        return RuntimeBridgeProvider(runtime, default_model_name=settings.claude_model)
+
+    if provider_type == "codex":
+        from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
+        from autocontext.runtimes.codex_cli import CodexCLIConfig, CodexCLIRuntime
+
+        runtime = CodexCLIRuntime(CodexCLIConfig(
+            model=settings.codex_model,
+            approval_mode=settings.codex_approval_mode,
+            timeout=settings.codex_timeout,
+            workspace=settings.codex_workspace,
+            quiet=settings.codex_quiet,
+        ))
+        return RuntimeBridgeProvider(runtime, default_model_name=settings.codex_model)
+
+    if provider_type == "pi":
+        from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
+        from autocontext.runtimes.pi_cli import PiCLIConfig, PiCLIRuntime
+
+        runtime = PiCLIRuntime(PiCLIConfig(
+            pi_command=settings.pi_command,
+            timeout=settings.pi_timeout,
+            workspace=settings.pi_workspace,
+            model=settings.pi_model,
+        ))
+        return RuntimeBridgeProvider(runtime, default_model_name=settings.pi_model or "pi-default")
+
+    if provider_type == "pi-rpc":
+        from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
+        from autocontext.runtimes.pi_rpc import PiRPCConfig, PiRPCRuntime
+
+        runtime = PiRPCRuntime(PiRPCConfig(
+            pi_command=settings.pi_command,
+            model=settings.pi_model or settings.judge_model,
+            session_persistence=settings.pi_rpc_session_persistence,
+        ))
+        return RuntimeBridgeProvider(runtime, default_model_name=settings.pi_model or settings.judge_model or "pi-rpc-default")
 
     # Use judge_api_key if set, otherwise fall back to provider-specific keys
     api_key = settings.judge_api_key

--- a/autocontext/src/autocontext/providers/runtime_bridge.py
+++ b/autocontext/src/autocontext/providers/runtime_bridge.py
@@ -1,0 +1,51 @@
+"""Bridge adapter: wrap an AgentRuntime as an LLMProvider.
+
+Used when provider-like surfaces (such as judge_provider) need to route through
+subscription-backed local CLIs instead of direct hosted APIs.
+"""
+
+from __future__ import annotations
+
+from autocontext.providers.base import CompletionResult, LLMProvider, ProviderError
+from autocontext.runtimes.base import AgentRuntime
+
+
+class RuntimeBridgeProvider(LLMProvider):
+    """Adapts an AgentRuntime to the LLMProvider interface."""
+
+    def __init__(self, runtime: AgentRuntime, default_model_name: str) -> None:
+        self._runtime = runtime
+        self._default_model_name = default_model_name
+
+    def default_model(self) -> str:
+        return self._default_model_name
+
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+    ) -> CompletionResult:
+        del temperature, max_tokens
+        output = self._runtime.generate(
+            prompt=user_prompt,
+            system=system_prompt or None,
+        )
+        error = output.metadata.get("error") if output.metadata else None
+        if error:
+            detail = ""
+            if output.metadata:
+                detail = str(output.metadata.get("detail") or output.metadata.get("stderr") or "")
+            raise ProviderError(f"{self._runtime.name} failed: {error}{f' ({detail})' if detail else ''}")
+        return CompletionResult(
+            text=output.text,
+            model=output.model or model or self._default_model_name,
+            cost_usd=output.cost_usd,
+            usage={},
+        )
+
+    @property
+    def name(self) -> str:
+        return "runtime-bridge"

--- a/autocontext/tests/test_subscription_cli_provider_surface.py
+++ b/autocontext/tests/test_subscription_cli_provider_surface.py
@@ -1,0 +1,97 @@
+"""Tests for first-class subscription-backed CLI provider surfaces.
+
+Verifies that Claude CLI and Codex can be selected through the same top-level
+live-provider paths that Pi already uses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from autocontext.agents.llm_client import build_client_from_settings
+from autocontext.config.settings import AppSettings
+from autocontext.providers.registry import get_provider
+
+
+def _settings(**overrides: object) -> AppSettings:
+    defaults = {
+        "agent_provider": "deterministic",
+        "knowledge_root": Path("/tmp/ac-test-knowledge"),
+    }
+    defaults.update(overrides)
+    return AppSettings(**defaults)  # type: ignore[arg-type]
+
+
+class TestTopLevelAgentProviderSurface:
+    def test_build_client_accepts_claude_cli_provider(self) -> None:
+        settings = _settings(agent_provider="claude-cli", claude_model="sonnet")
+        with patch("autocontext.runtimes.claude_cli.ClaudeCLIRuntime") as MockRuntime:
+            MockRuntime.return_value = MagicMock()
+            client = build_client_from_settings(settings)
+        assert client is not None
+
+    def test_build_client_accepts_codex_provider(self) -> None:
+        settings = _settings(agent_provider="codex", codex_model="o4-mini")
+        with patch("autocontext.runtimes.codex_cli.CodexCLIRuntime") as MockRuntime:
+            MockRuntime.return_value = MagicMock()
+            client = build_client_from_settings(settings)
+        assert client is not None
+
+    def test_claude_cli_settings_flow_into_runtime(self) -> None:
+        settings = _settings(
+            agent_provider="claude-cli",
+            claude_model="opus",
+            claude_timeout=75.0,
+            claude_tools="read,edit,bash",
+            claude_permission_mode="acceptEdits",
+            claude_session_persistence=True,
+        )
+        with patch("autocontext.runtimes.claude_cli.ClaudeCLIRuntime") as MockRuntime:
+            MockRuntime.return_value = MagicMock()
+            build_client_from_settings(settings)
+        call_args = MockRuntime.call_args
+        config = call_args[0][0] if call_args[0] else call_args[1].get("config")
+        assert config.model == "opus"
+        assert config.timeout == 75.0
+        assert config.tools == "read,edit,bash"
+        assert config.permission_mode == "acceptEdits"
+        assert config.session_persistence is True
+
+    def test_codex_settings_flow_into_runtime(self) -> None:
+        settings = _settings(
+            agent_provider="codex",
+            codex_model="o3",
+            codex_timeout=90.0,
+            codex_workspace="/tmp/codex-workspace",
+            codex_approval_mode="full-auto",
+            codex_quiet=True,
+        )
+        with patch("autocontext.runtimes.codex_cli.CodexCLIRuntime") as MockRuntime:
+            MockRuntime.return_value = MagicMock()
+            build_client_from_settings(settings)
+        call_args = MockRuntime.call_args
+        config = call_args[0][0] if call_args[0] else call_args[1].get("config")
+        assert config.model == "o3"
+        assert config.timeout == 90.0
+        assert config.workspace == "/tmp/codex-workspace"
+        assert config.approval_mode == "full-auto"
+        assert config.quiet is True
+
+
+class TestJudgeProviderSurface:
+    def test_get_provider_accepts_claude_cli(self) -> None:
+        settings = _settings(judge_provider="claude-cli", claude_model="sonnet")
+        with patch("autocontext.runtimes.claude_cli.ClaudeCLIRuntime") as MockRuntime:
+            MockRuntime.return_value = MagicMock()
+            provider = get_provider(settings)
+        assert provider.name == "runtime-bridge"
+        assert provider.default_model() == "sonnet"
+
+    def test_get_provider_accepts_codex(self) -> None:
+        settings = _settings(judge_provider="codex", codex_model="o4-mini")
+        with patch("autocontext.runtimes.codex_cli.CodexCLIRuntime") as MockRuntime:
+            MockRuntime.return_value = MagicMock()
+            provider = get_provider(settings)
+        assert provider.name == "runtime-bridge"
+        assert provider.default_model() == "o4-mini"

--- a/ts/README.md
+++ b/ts/README.md
@@ -128,6 +128,16 @@ AUTOCONTEXT_AGENT_PROVIDER=hermes \
 AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1 \
 autoctx run --scenario support_triage --json
 
+# Claude CLI (local authenticated Claude Code runtime)
+AUTOCONTEXT_AGENT_PROVIDER=claude-cli \
+AUTOCONTEXT_CLAUDE_MODEL=sonnet \
+autoctx run --scenario support_triage --json
+
+# Codex CLI (local authenticated Codex runtime)
+AUTOCONTEXT_AGENT_PROVIDER=codex \
+AUTOCONTEXT_CODEX_MODEL=o4-mini \
+autoctx run --scenario support_triage --json
+
 # Pi CLI
 AUTOCONTEXT_AGENT_PROVIDER=pi autoctx run --scenario support_triage --json
 
@@ -137,7 +147,7 @@ AUTOCONTEXT_AGENT_PROVIDER=deterministic autoctx run --scenario support_triage -
 
 `ANTHROPIC_API_KEY` is the preferred Anthropic credential env var. `AUTOCONTEXT_ANTHROPIC_API_KEY` remains supported as a compatibility alias.
 
-Supported providers: `anthropic`, `openai`, `openai-compatible`, `gemini`, `mistral`, `groq`, `openrouter`, `azure-openai`, `ollama`, `vllm`, `hermes`, `pi`, `pi-rpc`, `deterministic`.
+Supported providers: `anthropic`, `openai`, `openai-compatible`, `gemini`, `mistral`, `groq`, `openrouter`, `azure-openai`, `ollama`, `vllm`, `hermes`, `claude-cli`, `codex`, `pi`, `pi-rpc`, `deterministic`.
 
 `autoctx simulate` and `autoctx investigate` require a configured provider for spec generation. If you want synthetic placeholder behavior for CI/testing, select the deterministic provider explicitly instead of relying on implicit fallback.
 
@@ -153,6 +163,8 @@ Key environment variables:
 | `AUTOCONTEXT_ANALYST_API_KEY` / `AUTOCONTEXT_ANALYST_BASE_URL` | Optional analyst-specific credential/endpoint override |
 | `AUTOCONTEXT_COACH_API_KEY` / `AUTOCONTEXT_COACH_BASE_URL` | Optional coach-specific credential/endpoint override |
 | `AUTOCONTEXT_ARCHITECT_API_KEY` / `AUTOCONTEXT_ARCHITECT_BASE_URL` | Optional architect-specific credential/endpoint override |
+| `AUTOCONTEXT_CLAUDE_MODEL` | Claude CLI model alias override |
+| `AUTOCONTEXT_CODEX_MODEL` | Codex CLI model override |
 | `AUTOCONTEXT_CONFIG_DIR` | Override where `login` / `whoami` read saved credentials |
 | `AUTOCONTEXT_DB_PATH` | SQLite database path |
 

--- a/ts/src/config/app-settings-schema.ts
+++ b/ts/src/config/app-settings-schema.ts
@@ -94,6 +94,21 @@ export const AppSettingsSchema = z.object({
   openclawDistillSidecarFactory: z.string().default(""),
   openclawDistillSidecarCommand: z.string().default(""),
 
+  // Claude CLI runtime
+  claudeModel: z.string().default("sonnet"),
+  claudeFallbackModel: z.string().default("haiku"),
+  claudeTools: z.string().nullable().default(null),
+  claudePermissionMode: z.string().default("bypassPermissions"),
+  claudeSessionPersistence: z.boolean().default(false),
+  claudeTimeout: z.number().min(1).default(120.0),
+
+  // Codex CLI runtime
+  codexModel: z.string().default("o4-mini"),
+  codexTimeout: z.number().min(1).default(120.0),
+  codexWorkspace: z.string().default(""),
+  codexApprovalMode: z.string().default("full-auto"),
+  codexQuiet: z.boolean().default(false),
+
   // Pi CLI runtime
   piCommand: z.string().default("pi"),
   piTimeout: z.number().min(1).default(120.0),

--- a/ts/src/config/credential-provider-discovery.ts
+++ b/ts/src/config/credential-provider-discovery.ts
@@ -1,9 +1,6 @@
 import process from "node:process";
 
-import {
-  readCredentialStore,
-  type ProviderAuthStatus,
-} from "./credential-store.js";
+import { readCredentialStore, type ProviderAuthStatus } from "./credential-store.js";
 
 export interface KnownProvider {
   id: string;
@@ -15,17 +12,58 @@ export interface KnownProvider {
 }
 
 export const KNOWN_PROVIDERS: KnownProvider[] = [
-  { id: "anthropic", displayName: "Anthropic", keyPrefix: "sk-ant-", envVar: "ANTHROPIC_API_KEY", requiresKey: true },
-  { id: "openai", displayName: "OpenAI", keyPrefix: "sk-", envVar: "OPENAI_API_KEY", requiresKey: true },
-  { id: "gemini", displayName: "Google Gemini", keyPrefix: "AIza", envVar: "GEMINI_API_KEY", requiresKey: true },
+  {
+    id: "anthropic",
+    displayName: "Anthropic",
+    keyPrefix: "sk-ant-",
+    envVar: "ANTHROPIC_API_KEY",
+    requiresKey: true,
+  },
+  {
+    id: "openai",
+    displayName: "OpenAI",
+    keyPrefix: "sk-",
+    envVar: "OPENAI_API_KEY",
+    requiresKey: true,
+  },
+  {
+    id: "gemini",
+    displayName: "Google Gemini",
+    keyPrefix: "AIza",
+    envVar: "GEMINI_API_KEY",
+    requiresKey: true,
+  },
   { id: "mistral", displayName: "Mistral", envVar: "MISTRAL_API_KEY", requiresKey: true },
   { id: "groq", displayName: "Groq", keyPrefix: "gsk_", envVar: "GROQ_API_KEY", requiresKey: true },
-  { id: "openrouter", displayName: "OpenRouter", keyPrefix: "sk-or-", envVar: "OPENROUTER_API_KEY", requiresKey: true },
-  { id: "azure-openai", displayName: "Azure OpenAI", envVar: "AZURE_OPENAI_API_KEY", requiresKey: true },
-  { id: "ollama", displayName: "Ollama", defaultBaseUrl: "http://localhost:11434", requiresKey: false },
+  {
+    id: "openrouter",
+    displayName: "OpenRouter",
+    keyPrefix: "sk-or-",
+    envVar: "OPENROUTER_API_KEY",
+    requiresKey: true,
+  },
+  {
+    id: "azure-openai",
+    displayName: "Azure OpenAI",
+    envVar: "AZURE_OPENAI_API_KEY",
+    requiresKey: true,
+  },
+  {
+    id: "ollama",
+    displayName: "Ollama",
+    defaultBaseUrl: "http://localhost:11434",
+    requiresKey: false,
+  },
   { id: "vllm", displayName: "vLLM", defaultBaseUrl: "http://localhost:8000", requiresKey: false },
-  { id: "hermes", displayName: "Hermes Gateway", defaultBaseUrl: "http://localhost:8080", requiresKey: false },
+  {
+    id: "hermes",
+    displayName: "Hermes Gateway",
+    defaultBaseUrl: "http://localhost:8080",
+    requiresKey: false,
+  },
   { id: "openai-compatible", displayName: "OpenAI-Compatible", requiresKey: true },
+  { id: "claude-cli", displayName: "Claude CLI", requiresKey: false },
+  { id: "codex", displayName: "Codex CLI", requiresKey: false },
   { id: "pi", displayName: "Pi (CLI)", requiresKey: false },
   { id: "pi-rpc", displayName: "Pi (RPC)", requiresKey: false },
   { id: "deterministic", displayName: "Deterministic (testing)", requiresKey: false },
@@ -88,8 +126,8 @@ export function discoverAllProviders(configDir: string): DiscoveredProvider[] {
     discovered.push({
       provider: genericProvider,
       hasApiKey:
-        Boolean(getGenericEnvApiKey() ?? providerSpecificKey)
-        || Boolean(knownProvider && !knownProvider.requiresKey),
+        Boolean(getGenericEnvApiKey() ?? providerSpecificKey) ||
+        Boolean(knownProvider && !knownProvider.requiresKey),
       source: "env",
       ...(getGenericEnvModel() ? { model: getGenericEnvModel() } : {}),
       ...(getGenericEnvBaseUrl() ? { baseUrl: getGenericEnvBaseUrl() } : {}),

--- a/ts/src/providers/provider-config-resolution.ts
+++ b/ts/src/providers/provider-config-resolution.ts
@@ -106,26 +106,28 @@ export function resolveProviderConfig(
     };
   }
 
+  if (type === "claude-cli") {
+    return { providerType: type, model: model ?? process.env.AUTOCONTEXT_CLAUDE_MODEL ?? "sonnet" };
+  }
+
+  if (type === "codex") {
+    return { providerType: type, model: model ?? process.env.AUTOCONTEXT_CODEX_MODEL ?? "o4-mini" };
+  }
+
   if (type === "pi" || type === "pi-rpc") {
     return { providerType: type, apiKey: genericKey, baseUrl, model };
   }
 
   const providerSpecificEnvVar =
-    OPENAI_COMPATIBLE_PROVIDER_DEFAULTS[type]?.envVar ??
-    getKnownProvider(type)?.envVar;
+    OPENAI_COMPATIBLE_PROVIDER_DEFAULTS[type]?.envVar ?? getKnownProvider(type)?.envVar;
   const providerSpecificKey = providerSpecificEnvVar
     ? process.env[providerSpecificEnvVar]
     : undefined;
   const openaiFallbackKey =
-    type === "openai" || type === "openai-compatible"
-      ? process.env.OPENAI_API_KEY
-      : undefined;
+    type === "openai" || type === "openai-compatible" ? process.env.OPENAI_API_KEY : undefined;
   const apiKey = genericKey ?? providerSpecificKey ?? openaiFallbackKey;
   if (!apiKey) {
-    const keyVars = [
-      "AUTOCONTEXT_API_KEY",
-      "AUTOCONTEXT_AGENT_API_KEY",
-    ];
+    const keyVars = ["AUTOCONTEXT_API_KEY", "AUTOCONTEXT_AGENT_API_KEY"];
     if (providerSpecificEnvVar) {
       keyVars.push(providerSpecificEnvVar);
     } else if (type === "openai" || type === "openai-compatible") {

--- a/ts/src/providers/provider-factory.ts
+++ b/ts/src/providers/provider-factory.ts
@@ -1,6 +1,8 @@
 import { ProviderError } from "../types/index.js";
 import type { CompletionResult, LLMProvider } from "../types/index.js";
 import { DeterministicProvider } from "./deterministic.js";
+import { ClaudeCLIRuntime } from "../runtimes/claude-cli.js";
+import { CodexCLIRuntime, CodexCLIConfig } from "../runtimes/codex-cli.js";
 import { PiCLIRuntime, PiCLIConfig } from "../runtimes/pi-cli.js";
 import { PiRPCRuntime, PiRPCConfig } from "../runtimes/pi-rpc.js";
 import { RuntimeBridgeProvider } from "../agents/provider-bridge.js";
@@ -111,11 +113,14 @@ export function createOpenAICompatibleProvider(opts: OpenAICompatibleProviderOpt
   };
 }
 
-export const OPENAI_COMPATIBLE_PROVIDER_DEFAULTS: Record<string, {
-  baseUrl?: string;
-  envVar: string;
-  defaultModel: string;
-}> = {
+export const OPENAI_COMPATIBLE_PROVIDER_DEFAULTS: Record<
+  string,
+  {
+    baseUrl?: string;
+    envVar: string;
+    defaultModel: string;
+  }
+> = {
   gemini: {
     baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
     envVar: "GEMINI_API_KEY",
@@ -147,6 +152,17 @@ export interface CreateProviderOpts {
   apiKey?: string;
   baseUrl?: string;
   model?: string;
+  claudeModel?: string;
+  claudeFallbackModel?: string;
+  claudeTools?: string;
+  claudePermissionMode?: string;
+  claudeSessionPersistence?: boolean;
+  claudeTimeout?: number;
+  codexModel?: string;
+  codexApprovalMode?: string;
+  codexTimeout?: number;
+  codexWorkspace?: string;
+  codexQuiet?: boolean;
   piCommand?: string;
   piTimeout?: number;
   piWorkspace?: string;
@@ -168,6 +184,8 @@ export const SUPPORTED_PROVIDER_TYPES = [
   "groq",
   "openrouter",
   "azure-openai",
+  "claude-cli",
+  "codex",
   "pi",
   "pi-rpc",
   "deterministic",
@@ -216,23 +234,54 @@ export function createProvider(opts: CreateProviderOpts): LLMProvider {
     return { ...inner, name: "hermes-gateway" };
   }
 
+  if (type === "claude-cli") {
+    const resolvedModel = opts.claudeModel ?? opts.model;
+    const runtime = new ClaudeCLIRuntime({
+      model: resolvedModel,
+      fallbackModel: opts.claudeFallbackModel,
+      tools: opts.claudeTools,
+      permissionMode: opts.claudePermissionMode,
+      sessionPersistence: opts.claudeSessionPersistence,
+      timeout: opts.claudeTimeout ? opts.claudeTimeout * 1000 : undefined,
+    });
+    return new RuntimeBridgeProvider(runtime as never, resolvedModel ?? "sonnet");
+  }
+
+  if (type === "codex") {
+    const resolvedModel = opts.codexModel ?? opts.model;
+    const runtime = new CodexCLIRuntime(
+      new CodexCLIConfig({
+        model: resolvedModel,
+        approvalMode: opts.codexApprovalMode,
+        timeout: opts.codexTimeout,
+        workspace: opts.codexWorkspace,
+        quiet: opts.codexQuiet,
+      }),
+    );
+    return new RuntimeBridgeProvider(runtime as never, resolvedModel ?? "o4-mini");
+  }
+
   if (type === "pi") {
     const resolvedModel = opts.model ?? opts.piModel;
-    const runtime = new PiCLIRuntime(new PiCLIConfig({
-      piCommand: opts.piCommand,
-      timeout: opts.piTimeout,
-      workspace: opts.piWorkspace,
-      model: resolvedModel,
-    }));
+    const runtime = new PiCLIRuntime(
+      new PiCLIConfig({
+        piCommand: opts.piCommand,
+        timeout: opts.piTimeout,
+        workspace: opts.piWorkspace,
+        model: resolvedModel,
+      }),
+    );
     return new RuntimeBridgeProvider(runtime as never, resolvedModel ?? "pi-default");
   }
 
   if (type === "pi-rpc") {
-    const runtime = new PiRPCRuntime(new PiRPCConfig({
-      endpoint: opts.piRpcEndpoint ?? opts.baseUrl,
-      apiKey: opts.piRpcApiKey ?? opts.apiKey,
-      sessionPersistence: opts.piRpcSessionPersistence,
-    }));
+    const runtime = new PiRPCRuntime(
+      new PiRPCConfig({
+        endpoint: opts.piRpcEndpoint ?? opts.baseUrl,
+        apiKey: opts.piRpcApiKey ?? opts.apiKey,
+        sessionPersistence: opts.piRpcSessionPersistence,
+      }),
+    );
     return new RuntimeBridgeProvider(runtime as never, opts.model ?? "pi-rpc-default");
   }
 

--- a/ts/src/providers/role-provider-bundle.ts
+++ b/ts/src/providers/role-provider-bundle.ts
@@ -1,12 +1,6 @@
 import type { LLMProvider } from "../types/index.js";
-import {
-  createProvider,
-  type CreateProviderOpts,
-} from "./provider-factory.js";
-import {
-  resolveProviderConfig,
-  type ProviderConfig,
-} from "./provider-config-resolution.js";
+import { createProvider, type CreateProviderOpts } from "./provider-factory.js";
+import { resolveProviderConfig, type ProviderConfig } from "./provider-config-resolution.js";
 
 export type GenerationRole = "competitor" | "analyst" | "coach" | "architect" | "curator";
 
@@ -29,6 +23,17 @@ export interface RoleProviderSettings {
   modelCoach?: string;
   modelArchitect?: string;
   modelCurator?: string;
+  claudeModel?: string;
+  claudeFallbackModel?: string;
+  claudeTools?: string | null;
+  claudePermissionMode?: string;
+  claudeSessionPersistence?: boolean;
+  claudeTimeout?: number;
+  codexModel?: string;
+  codexApprovalMode?: string;
+  codexTimeout?: number;
+  codexWorkspace?: string;
+  codexQuiet?: boolean;
   piCommand?: string;
   piTimeout?: number;
   piWorkspace?: string;
@@ -51,6 +56,17 @@ export function withRuntimeSettings(
 ): CreateProviderOpts {
   return {
     ...config,
+    claudeModel: settings.claudeModel,
+    claudeFallbackModel: settings.claudeFallbackModel,
+    claudeTools: settings.claudeTools ?? undefined,
+    claudePermissionMode: settings.claudePermissionMode,
+    claudeSessionPersistence: settings.claudeSessionPersistence,
+    claudeTimeout: settings.claudeTimeout,
+    codexModel: settings.codexModel,
+    codexApprovalMode: settings.codexApprovalMode,
+    codexTimeout: settings.codexTimeout,
+    codexWorkspace: settings.codexWorkspace,
+    codexQuiet: settings.codexQuiet,
     piCommand: settings.piCommand,
     piTimeout: settings.piTimeout,
     piWorkspace: settings.piWorkspace,

--- a/ts/tests/package-parity.test.ts
+++ b/ts/tests/package-parity.test.ts
@@ -10,9 +10,9 @@ import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 
 const PACKAGE_ROOT = join(import.meta.dirname, "..");
-const PACKAGE_JSON = JSON.parse(
-  readFileSync(join(PACKAGE_ROOT, "package.json"), "utf-8"),
-) as { bin: { autoctx: string } };
+const PACKAGE_JSON = JSON.parse(readFileSync(join(PACKAGE_ROOT, "package.json"), "utf-8")) as {
+  bin: { autoctx: string };
+};
 let didBuild = false;
 
 function ensureBuiltPackage(): void {
@@ -33,7 +33,11 @@ function createConsumerWorkspace(): string {
   );
   mkdirSync(join(workspace, "node_modules"), { recursive: true });
   symlinkSync(PACKAGE_ROOT, join(workspace, "node_modules", "autoctx"), "dir");
-  writeFileSync(join(workspace, "package.json"), JSON.stringify({ name: "package-parity-fixture", type: "module" }), "utf-8");
+  writeFileSync(
+    join(workspace, "package.json"),
+    JSON.stringify({ name: "package-parity-fixture", type: "module" }),
+    "utf-8",
+  );
   return workspace;
 }
 
@@ -118,6 +122,8 @@ describe("README positioning", () => {
     const readme = readFileSync(join(import.meta.dirname, "..", "README.md"), "utf-8");
     expect(readme).toContain("anthropic");
     expect(readme).toContain("hermes");
+    expect(readme).toContain("claude-cli");
+    expect(readme).toContain("codex");
     expect(readme).toContain("pi");
     expect(readme).toContain("pi-rpc");
     expect(readme).toContain("deterministic");
@@ -140,10 +146,28 @@ describe("CLI help matches README", () => {
   it("lists all documented commands in help", () => {
     const help = runCli(["--help"]);
     const expected = [
-      "init", "capabilities", "login", "whoami", "logout",
-      "run", "list", "replay", "benchmark", "export", "export-training-data",
-      "import-package", "new-scenario", "tui", "judge", "improve", "repl",
-      "queue", "status", "serve", "mcp-serve", "version",
+      "init",
+      "capabilities",
+      "login",
+      "whoami",
+      "logout",
+      "run",
+      "list",
+      "replay",
+      "benchmark",
+      "export",
+      "export-training-data",
+      "import-package",
+      "new-scenario",
+      "tui",
+      "judge",
+      "improve",
+      "repl",
+      "queue",
+      "status",
+      "serve",
+      "mcp-serve",
+      "version",
     ];
     for (const cmd of expected) {
       expect(help).toContain(cmd);

--- a/ts/tests/pi-runtime.test.ts
+++ b/ts/tests/pi-runtime.test.ts
@@ -3,13 +3,15 @@
  */
 
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 
 vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
   execFileSync: vi.fn(),
 }));
 
 const execFileSyncMock = vi.mocked(execFileSync);
+void execFile;
 
 // ---------------------------------------------------------------------------
 // Pi config in AppSettingsSchema
@@ -74,7 +76,11 @@ describe("resolveProviderConfig Pi", () => {
 
   function saveAndClear(): void {
     for (const key of Object.keys(process.env)) {
-      if (key.startsWith("AUTOCONTEXT_") || key === "ANTHROPIC_API_KEY" || key === "OPENAI_API_KEY") {
+      if (
+        key.startsWith("AUTOCONTEXT_") ||
+        key === "ANTHROPIC_API_KEY" ||
+        key === "OPENAI_API_KEY"
+      ) {
         saved[key] = process.env[key];
         delete process.env[key];
       }
@@ -83,7 +89,11 @@ describe("resolveProviderConfig Pi", () => {
 
   afterEach(() => {
     for (const key of Object.keys(process.env)) {
-      if (key.startsWith("AUTOCONTEXT_") || key === "ANTHROPIC_API_KEY" || key === "OPENAI_API_KEY") {
+      if (
+        key.startsWith("AUTOCONTEXT_") ||
+        key === "ANTHROPIC_API_KEY" ||
+        key === "OPENAI_API_KEY"
+      ) {
         if (key in saved) {
           process.env[key] = saved[key];
         } else {

--- a/ts/tests/provider-factory-workflow.test.ts
+++ b/ts/tests/provider-factory-workflow.test.ts
@@ -1,19 +1,24 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  SUPPORTED_PROVIDER_TYPES,
-  createProvider,
-} from "../src/providers/provider-factory.js";
+import { SUPPORTED_PROVIDER_TYPES, createProvider } from "../src/providers/provider-factory.js";
 
 describe("provider factory workflow", () => {
   it("creates compat providers with their family defaults", () => {
-    expect(createProvider({ providerType: "gemini", apiKey: "gem-key" }).defaultModel()).toBe("gemini-2.5-pro");
-    expect(createProvider({ providerType: "mistral", apiKey: "mistral-key" }).defaultModel()).toBe("mistral-large-latest");
-    expect(createProvider({ providerType: "openrouter", apiKey: "router-key" }).defaultModel()).toBe("anthropic/claude-sonnet-4");
+    expect(createProvider({ providerType: "gemini", apiKey: "gem-key" }).defaultModel()).toBe(
+      "gemini-2.5-pro",
+    );
+    expect(createProvider({ providerType: "mistral", apiKey: "mistral-key" }).defaultModel()).toBe(
+      "mistral-large-latest",
+    );
+    expect(
+      createProvider({ providerType: "openrouter", apiKey: "router-key" }).defaultModel(),
+    ).toBe("anthropic/claude-sonnet-4");
   });
 
   it("creates runtime-backed and renamed provider families", () => {
     expect(createProvider({ providerType: "hermes" }).name).toBe("hermes-gateway");
+    expect(createProvider({ providerType: "claude-cli" }).name).toBe("runtime-bridge");
+    expect(createProvider({ providerType: "codex" }).name).toBe("runtime-bridge");
     expect(createProvider({ providerType: "pi" }).name).toBe("runtime-bridge");
     expect(createProvider({ providerType: "pi-rpc" }).name).toBe("runtime-bridge");
   });

--- a/ts/tests/provider-surface-consistency.test.ts
+++ b/ts/tests/provider-surface-consistency.test.ts
@@ -21,6 +21,8 @@ const EXPECTED_PROVIDER_IDS = [
   "ollama",
   "vllm",
   "hermes",
+  "claude-cli",
+  "codex",
   "pi",
   "pi-rpc",
   "deterministic",
@@ -65,20 +67,36 @@ describe("Provider surface consistency", () => {
   it("new compat providers use provider-specific default models", async () => {
     const { createProvider } = await import("../src/providers/index.js");
 
-    expect(createProvider({ providerType: "gemini", apiKey: "gem-key" }).defaultModel()).toBe("gemini-2.5-pro");
-    expect(createProvider({ providerType: "mistral", apiKey: "mistral-key" }).defaultModel()).toBe("mistral-large-latest");
-    expect(createProvider({ providerType: "groq", apiKey: "groq-key" }).defaultModel()).toBe("llama-3.3-70b-versatile");
-    expect(createProvider({ providerType: "openrouter", apiKey: "openrouter-key" }).defaultModel()).toBe("anthropic/claude-sonnet-4");
-    expect(createProvider({ providerType: "azure-openai", apiKey: "azure-key", baseUrl: "https://azure.example.com/openai/v1" }).defaultModel()).toBe("gpt-4o");
+    expect(createProvider({ providerType: "gemini", apiKey: "gem-key" }).defaultModel()).toBe(
+      "gemini-2.5-pro",
+    );
+    expect(createProvider({ providerType: "mistral", apiKey: "mistral-key" }).defaultModel()).toBe(
+      "mistral-large-latest",
+    );
+    expect(createProvider({ providerType: "groq", apiKey: "groq-key" }).defaultModel()).toBe(
+      "llama-3.3-70b-versatile",
+    );
+    expect(
+      createProvider({ providerType: "openrouter", apiKey: "openrouter-key" }).defaultModel(),
+    ).toBe("anthropic/claude-sonnet-4");
+    expect(
+      createProvider({
+        providerType: "azure-openai",
+        apiKey: "azure-key",
+        baseUrl: "https://azure.example.com/openai/v1",
+      }).defaultModel(),
+    ).toBe("gpt-4o");
   });
 
-  it("KNOWN_PROVIDERS has entries for pi, pi-rpc, hermes", async () => {
+  it("KNOWN_PROVIDERS has entries for subscription-backed CLI runtimes and gateway providers", async () => {
     const { KNOWN_PROVIDERS } = await import("../src/config/credentials.js");
     const ids = KNOWN_PROVIDERS.map((p: { id: string }) => p.id);
 
+    expect(ids).toContain("hermes");
+    expect(ids).toContain("claude-cli");
+    expect(ids).toContain("codex");
     expect(ids).toContain("pi");
     expect(ids).toContain("pi-rpc");
-    expect(ids).toContain("hermes");
   });
 
   it("KNOWN_PROVIDERS has all expected provider entries", async () => {

--- a/ts/tests/subscription-cli-runtime-provider.test.ts
+++ b/ts/tests/subscription-cli-runtime-provider.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { execFile, execFileSync } from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+  execFileSync: vi.fn(),
+}));
+
+const execFileMock = vi.mocked(execFile);
+const execFileSyncMock = vi.mocked(execFileSync);
+const kPromisifyCustom = Symbol.for("nodejs.util.promisify.custom");
+
+describe("subscription-backed CLI runtime provider parity", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    delete process.env.AUTOCONTEXT_AGENT_PROVIDER;
+  });
+
+  it("includes Claude CLI and Codex settings with defaults", async () => {
+    const { AppSettingsSchema } = await import("../src/config/index.js");
+    const settings = AppSettingsSchema.parse({});
+
+    expect(settings.claudeModel).toBe("sonnet");
+    expect(settings.claudeFallbackModel).toBe("haiku");
+    expect(settings.claudeTools).toBeNull();
+    expect(settings.claudePermissionMode).toBe("bypassPermissions");
+    expect(settings.claudeSessionPersistence).toBe(false);
+    expect(settings.claudeTimeout).toBe(120.0);
+
+    expect(settings.codexModel).toBe("o4-mini");
+    expect(settings.codexTimeout).toBe(120.0);
+    expect(settings.codexWorkspace).toBe("");
+    expect(settings.codexApprovalMode).toBe("full-auto");
+    expect(settings.codexQuiet).toBe(false);
+  });
+
+  it("supports claude-cli and codex provider types", async () => {
+    const { createProvider } = await import("../src/providers/index.js");
+
+    expect(createProvider({ providerType: "claude-cli" }).name).toBe("runtime-bridge");
+    expect(createProvider({ providerType: "codex" }).name).toBe("runtime-bridge");
+  });
+
+  it("resolves claude-cli and codex providers from env", async () => {
+    const { resolveProviderConfig } = await import("../src/providers/index.js");
+
+    process.env.AUTOCONTEXT_AGENT_PROVIDER = "claude-cli";
+    expect(resolveProviderConfig().providerType).toBe("claude-cli");
+
+    process.env.AUTOCONTEXT_AGENT_PROVIDER = "codex";
+    expect(resolveProviderConfig().providerType).toBe("codex");
+  });
+
+  it("createConfiguredProvider threads Claude CLI settings into the live provider", async () => {
+    execFileSyncMock.mockImplementation(((command: string) => {
+      if (command === "which") {
+        return "claude-local\n" as never;
+      }
+      return "" as never;
+    }) as unknown as typeof execFileSync);
+    execFileMock.mockImplementation(((
+      _file: string,
+      _args: readonly string[],
+      options: unknown,
+      callback?: unknown,
+    ) => {
+      const cb = (typeof options === "function" ? options : callback) as (
+        err: Error | null,
+        stdout: string,
+        stderr: string,
+      ) => void;
+      cb(
+        null,
+        JSON.stringify({
+          result: "claude output",
+          total_cost_usd: 0.01,
+          modelUsage: { sonnet: {} },
+        }),
+        "",
+      );
+      return {} as never;
+    }) as unknown as typeof execFile);
+    const execFileAsyncMock = vi.fn(async () => ({
+      stdout: JSON.stringify({
+        result: "claude output",
+        total_cost_usd: 0.01,
+        modelUsage: { sonnet: {} },
+      }),
+      stderr: "",
+    }));
+    Object.defineProperty(execFileMock, kPromisifyCustom, {
+      configurable: true,
+      value: execFileAsyncMock,
+    });
+
+    const { createConfiguredProvider } = await import("../src/providers/index.js");
+    const { provider } = createConfiguredProvider(
+      { providerType: "claude-cli" },
+      {
+        agentProvider: "claude-cli",
+        claudeModel: "sonnet",
+        claudeFallbackModel: "haiku",
+        claudeTools: "read,edit",
+        claudePermissionMode: "acceptEdits",
+        claudeSessionPersistence: true,
+        claudeTimeout: 33,
+      },
+    );
+
+    const result = await provider.complete({
+      systemPrompt: "system prompt",
+      userPrompt: "task prompt",
+    });
+
+    expect(result.text).toBe("claude output");
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      "claude-local",
+      [
+        "-p",
+        "--output-format",
+        "json",
+        "--model",
+        "sonnet",
+        "--fallback-model",
+        "haiku",
+        "--tools",
+        "read,edit",
+        "--permission-mode",
+        "acceptEdits",
+        "--system-prompt",
+        "system prompt",
+        "task prompt",
+      ],
+      expect.objectContaining({
+        timeout: 33_000,
+        encoding: "utf8",
+      }),
+    );
+  });
+
+  it("buildRoleProviderBundle threads Codex CLI settings into run providers", async () => {
+    execFileSyncMock.mockImplementation(((command: string, args?: readonly string[]) => {
+      if (command === "which") {
+        return "" as never;
+      }
+      expect(command).toBe("codex");
+      expect(args).toEqual([
+        "exec",
+        "--model",
+        "o3",
+        "--full-auto",
+        "--quiet",
+        "--cd",
+        "/tmp/codex-workspace",
+        "bundle task",
+      ]);
+      return "codex output" as never;
+    }) as unknown as typeof execFileSync);
+
+    const { buildRoleProviderBundle } = await import("../src/providers/index.js");
+    const bundle = buildRoleProviderBundle({
+      agentProvider: "codex",
+      codexModel: "o3",
+      codexTimeout: 12,
+      codexWorkspace: "/tmp/codex-workspace",
+      codexApprovalMode: "full-auto",
+      codexQuiet: true,
+    });
+
+    const result = await bundle.defaultProvider.complete({
+      systemPrompt: "",
+      userPrompt: "bundle task",
+    });
+
+    expect(result.text).toBe("codex output");
+    expect(execFileSyncMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

This PR exposes `claude-cli` and `codex` as first-class live provider options across the top-level Python and TypeScript surfaces, instead of requiring per-role bridge wiring or fallback paths. It also adds a runtime-bridge judge adapter in Python so judge flows can intentionally run through local subscription-backed CLIs, matching the existing Pi runtime pattern. Addresses AC-538.

## Motivation

Live runtime parity had drifted: Claude CLI and Codex runtime implementations already existed, but the public provider-selection surfaces did not expose them the way `pi` and `pi-rpc` were exposed. That made documented live execution inconsistent across packages and blocked clean end-to-end use of authenticated local CLI runtimes for agent and judge flows. AC-538 tracks restoring that parity.

## Implementation Details

### Python
- Added top-level `agent_provider` routing for `claude-cli` and `codex` in `autocontext/src/autocontext/agents/llm_client.py`.
- Added `autocontext/src/autocontext/providers/runtime_bridge.py` to adapt an `AgentRuntime` into an `LLMProvider` for provider-like surfaces.
- Extended `autocontext/src/autocontext/providers/registry.py` so `judge_provider` can explicitly use `claude-cli`, `codex`, `pi`, or `pi-rpc` via the same runtime-bridge model.
- Added `autocontext/tests/test_subscription_cli_provider_surface.py` to cover agent-provider and judge-provider parity for subscription-backed CLIs.

### TypeScript
- Extended provider creation in `ts/src/providers/provider-factory.ts` for `claude-cli` and `codex` runtime-backed providers.
- Threaded runtime-specific settings through `ts/src/providers/role-provider-bundle.ts` and `ts/src/providers/provider-config-resolution.ts`.
- Added config/discovery support in `ts/src/config/app-settings-schema.ts` and `ts/src/config/credential-provider-discovery.ts`.
- Added regression coverage in `ts/tests/subscription-cli-runtime-provider.test.ts` and updated parity/readme workflow tests.

### Docs
- Updated examples and supported-provider docs in `README.md`, `autocontext/README.md`, and `ts/README.md`.

## Testing

### Automated
- `cd autocontext && uv run pytest tests/test_subscription_cli_provider_surface.py tests/test_pi_provider_surface.py tests/test_per_role_provider.py tests/test_providers.py tests/test_codex_cli_runtime.py`
- `cd autocontext && uv run ruff check src/autocontext/agents/llm_client.py src/autocontext/providers/registry.py src/autocontext/providers/runtime_bridge.py tests/test_subscription_cli_provider_surface.py`
- `cd ts && npm test -- subscription-cli-runtime-provider.test.ts pi-runtime.test.ts provider-factory-workflow.test.ts provider-surface-consistency.test.ts package-parity.test.ts`
- `cd ts && npm run lint`
- `cd ts && npm run build`

### Manual / Live
- `claude -p 'Reply with the single word OK.' --output-format json`
- `cd autocontext && AUTOCONTEXT_JUDGE_PROVIDER=claude-cli AUTOCONTEXT_CLAUDE_MODEL=sonnet ./.venv/bin/autoctx judge -p 'Reply with OK.' -o 'OK' -r 'Return JSON with score 1.0 if the output exactly matches OK, otherwise 0.0, and explain briefly.'`

### Known Limitation
- `codex` is not installed in the validation environment used for this branch, so live Codex verification was not run here. The runtime wiring and automated tests are included.

## Checklist

- [x] Code follows existing project style
- [x] Types maintained across Python and TypeScript surfaces
- [x] Tests added/updated for provider parity
- [x] Documentation updated
- [x] No breaking changes intended
- [x] Linear issue referenced in description
- [ ] Full `mypy` suite run
- [ ] Full repository-wide test suite run

## Notes

- This restores provider-surface parity for local authenticated CLI runtimes without changing the existing direct API provider behavior.
- Follow-up live Codex smoke validation should be run on a machine with `codex` installed and authenticated.
