### PR TITLE
AC-535: restore operator-loop escalation generation in simulate

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/operator_loop_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/operator_loop_codegen.py
@@ -108,6 +108,42 @@ class {class_name}(OperatorLoopInterface):
                 return False, f"precondition not met for {{action.name}}: {{requirement}}"
         return True, ""
 
+    def _action_description(self, action_name: str) -> str:
+        specs = {{spec.name: spec for spec in self.describe_environment().available_actions}}
+        spec = specs.get(action_name)
+        return spec.description if spec is not None else action_name
+
+    def _is_explicit_escalation_action(self, action: Action) -> bool:
+        action_name = action.name.lower()
+        if action_name.startswith((
+            "escalate_",
+            "handoff_",
+            "defer_",
+            "consult_operator",
+            "consult_human",
+            "page_operator",
+        )):
+            return True
+        description = self._action_description(action.name).lower()
+        return any(phrase in description for phrase in (
+            "escalate to a human operator",
+            "escalate to the operator",
+            "hand off to a human operator",
+            "defer to a human operator",
+            "page the operator",
+            "consult the operator",
+        ))
+
+    def _is_explicit_clarification_action(self, action: Action) -> bool:
+        haystack = f"{{action.name}} {{self._action_description(action.name)}}".lower()
+        return any(keyword in haystack for keyword in (
+            "clarif",
+            "ask_question",
+            "request_information",
+            "request_more_info",
+            "missing_information",
+        ))
+
     def execute_action(self, state: dict[str, Any], action: Action) -> tuple[ActionResult, dict[str, Any]]:
         valid, reason = self.validate_action(state, action)
         next_state = dict(state)
@@ -115,6 +151,8 @@ class {class_name}(OperatorLoopInterface):
         next_state["timeline"] = list(state.get("timeline", []))
         next_state["completed_actions"] = list(state.get("completed_actions", []))
         next_state["failed_actions"] = list(state.get("failed_actions", []))
+        next_state["escalation_log"] = list(state.get("escalation_log", []))
+        next_state["clarification_log"] = list(state.get("clarification_log", []))
 
         if not valid:
             next_state["failed_actions"].append(action.name)
@@ -125,8 +163,40 @@ class {class_name}(OperatorLoopInterface):
             return ActionResult(success=False, output="", state_changes={{}}, error=reason), next_state
 
         next_state["completed_actions"].append(action.name)
-        next_state["autonomous_actions"] = state.get("autonomous_actions", 0) + 1
-        next_state["timeline"].append({{"action": action.name, "parameters": action.parameters}})
+
+        if self._is_explicit_clarification_action(action):
+            next_state["clarification_log"].append({{
+                "question": self._action_description(action.name),
+                "context": f"Clarification requested via {{action.name}}",
+                "urgency": "medium",
+                "metadata": {{"source": "explicit_action", "action": action.name}},
+            }})
+            next_state["timeline"].append({{
+                "type": "clarification",
+                "action": action.name,
+                "question": self._action_description(action.name),
+                "urgency": "medium",
+            }})
+        elif self._is_explicit_escalation_action(action):
+            next_state["escalation_log"].append({{
+                "step": next_state["step"],
+                "reason": f"Executed escalation action {{action.name}}",
+                "severity": state.get("escalation_policy", {{}}).get("escalation_threshold", "medium"),
+                "context": self._action_description(action.name),
+                "was_necessary": True,
+                "metadata": {{"source": "explicit_action", "action": action.name}},
+            }})
+            next_state["timeline"].append({{
+                "type": "escalation",
+                "action": action.name,
+                "reason": f"Executed escalation action {{action.name}}",
+                "severity": state.get("escalation_policy", {{}}).get("escalation_threshold", "medium"),
+                "was_necessary": True,
+            }})
+        else:
+            next_state["autonomous_actions"] = state.get("autonomous_actions", 0) + 1
+            next_state["timeline"].append({{"action": action.name, "parameters": action.parameters}})
+
         return (
             ActionResult(
                 success=True,

--- a/autocontext/src/autocontext/scenarios/custom/operator_loop_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/operator_loop_codegen.py
@@ -164,20 +164,10 @@ class {class_name}(OperatorLoopInterface):
 
         next_state["completed_actions"].append(action.name)
 
-        if self._is_explicit_clarification_action(action):
-            next_state["clarification_log"].append({{
-                "question": self._action_description(action.name),
-                "context": f"Clarification requested via {{action.name}}",
-                "urgency": "medium",
-                "metadata": {{"source": "explicit_action", "action": action.name}},
-            }})
-            next_state["timeline"].append({{
-                "type": "clarification",
-                "action": action.name,
-                "question": self._action_description(action.name),
-                "urgency": "medium",
-            }})
-        elif self._is_explicit_escalation_action(action):
+        is_escalation = self._is_explicit_escalation_action(action)
+        is_clarification = self._is_explicit_clarification_action(action)
+
+        if is_escalation:
             next_state["escalation_log"].append({{
                 "step": next_state["step"],
                 "reason": f"Executed escalation action {{action.name}}",
@@ -193,7 +183,22 @@ class {class_name}(OperatorLoopInterface):
                 "severity": state.get("escalation_policy", {{}}).get("escalation_threshold", "medium"),
                 "was_necessary": True,
             }})
-        else:
+
+        if is_clarification:
+            next_state["clarification_log"].append({{
+                "question": self._action_description(action.name),
+                "context": f"Clarification requested via {{action.name}}",
+                "urgency": "medium",
+                "metadata": {{"source": "explicit_action", "action": action.name}},
+            }})
+            next_state["timeline"].append({{
+                "type": "clarification",
+                "action": action.name,
+                "question": self._action_description(action.name),
+                "urgency": "medium",
+            }})
+
+        if not is_escalation and not is_clarification:
             next_state["autonomous_actions"] = state.get("autonomous_actions", 0) + 1
             next_state["timeline"].append({{"action": action.name, "parameters": action.parameters}})
 

--- a/autocontext/src/autocontext/scenarios/custom/operator_loop_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/operator_loop_designer.py
@@ -32,15 +32,15 @@ OPERATOR_LOOP_DESIGNER_SYSTEM = (
     "- keep the scenario neutral and capability-oriented\n"
     "- do not anchor the scenario to a canned domain, action set, or scoring pattern\n"
     "- avoid prescriptive examples that imply a preferred escalation workflow\n"
+    "- if the request requires escalation, include an explicit escalation action whose name begins with escalate_\n"
+    "- if work continues after operator input, include a follow-up action "
+    "whose preconditions reference the escalation action name\n"
+    "- preconditions must reference prior action names, not effect labels\n"
 )
 
 
 def parse_operator_loop_spec(text: str) -> OperatorLoopSpec:
-    pattern = (
-        re.escape(OPERATOR_LOOP_SPEC_START)
-        + r"\s*(.*?)\s*"
-        + re.escape(OPERATOR_LOOP_SPEC_END)
-    )
+    pattern = re.escape(OPERATOR_LOOP_SPEC_START) + r"\s*(.*?)\s*" + re.escape(OPERATOR_LOOP_SPEC_END)
     match = re.search(pattern, text, re.DOTALL)
     if not match:
         raise ValueError("response does not contain OPERATOR_LOOP_SPEC delimiters")
@@ -66,9 +66,5 @@ def parse_operator_loop_spec(text: str) -> OperatorLoopSpec:
     )
 
 
-def design_operator_loop(
-    description: str, llm_fn: LlmFn
-) -> OperatorLoopSpec:
-    return parse_operator_loop_spec(
-        llm_fn(OPERATOR_LOOP_DESIGNER_SYSTEM, f"User description:\n{description}")
-    )
+def design_operator_loop(description: str, llm_fn: LlmFn) -> OperatorLoopSpec:
+    return parse_operator_loop_spec(llm_fn(OPERATOR_LOOP_DESIGNER_SYSTEM, f"User description:\n{description}"))

--- a/autocontext/src/autocontext/simulation/engine.py
+++ b/autocontext/src/autocontext/simulation/engine.py
@@ -300,6 +300,18 @@ class SimulationEngine:
     # ------------------------------------------------------------------
 
     def _build_spec(self, description: str, family: str) -> dict[str, Any]:
+        if family == "operator_loop":
+            from autocontext.scenarios.custom.generic_creator import spec_to_plain_data
+            from autocontext.scenarios.custom.operator_loop_designer import design_operator_loop
+
+            try:
+                designed = design_operator_loop(description, self.llm_fn)
+                plain = spec_to_plain_data(designed)
+                if isinstance(plain, dict):
+                    return plain
+            except Exception:
+                logger.debug("simulation.engine: operator_loop designer fallback", exc_info=True)
+
         system = (
             f"You are a simulation designer. Produce a {family} spec as JSON.\n"
             "Required: description, environment_description, initial_state_description, "
@@ -337,6 +349,7 @@ class SimulationEngine:
             from autocontext.scenarios.custom.operator_loop_codegen import generate_operator_loop_class
             from autocontext.scenarios.custom.operator_loop_spec import OperatorLoopSpec
             from autocontext.scenarios.custom.simulation_spec import parse_simulation_actions
+
             ol_spec = OperatorLoopSpec(
                 description=spec.get("description", ""),
                 environment_description=spec.get("environment_description", ""),
@@ -351,6 +364,7 @@ class SimulationEngine:
         else:
             from autocontext.scenarios.custom.simulation_codegen import generate_simulation_class
             from autocontext.scenarios.custom.simulation_spec import SimulationSpec, parse_simulation_actions
+
             sim_spec = SimulationSpec(
                 description=spec.get("description", ""),
                 environment_description=spec.get("environment_description", ""),
@@ -456,8 +470,6 @@ class SimulationEngine:
         limit = max_steps or getattr(instance, "max_steps", lambda: 20)()
         records: list[dict[str, Any]] = []
         step_num = 0
-        escalation_count = 0
-        clarification_count = 0
 
         for _ in range(limit):
             if instance.is_terminal(state):
@@ -482,8 +494,6 @@ class SimulationEngine:
 
             if action_to_run is None and blocked_action is not None:
                 state = self._operator_loop_intervene(instance, state, blocked_action, blocked_reason)
-                escalation_count += 1
-                clarification_count += 1
                 continue
 
             if action_to_run is None:
@@ -519,8 +529,8 @@ class SimulationEngine:
             "score": round(eval_result.score, 4),
             "reasoning": eval_result.reasoning,
             "dimension_scores": eval_result.dimension_scores,
-            "escalation_count": escalation_count,
-            "clarification_count": clarification_count,
+            "escalation_count": len(instance.get_escalation_log(state)),
+            "clarification_count": len(instance.get_clarification_log(state)),
         }
 
     def _operator_loop_intervene(

--- a/autocontext/tests/test_simulate_command.py
+++ b/autocontext/tests/test_simulate_command.py
@@ -257,6 +257,64 @@ class TestSimulationEngine:
         assert "Clarifications: 0" in result["summary"]["reasoning"]
         assert "Missed escalations: 0" in result["summary"]["reasoning"]
 
+    def test_operator_loop_run_uses_family_designer_and_counts_explicit_escalation_actions(
+        self,
+        tmp_knowledge: Path,
+    ) -> None:
+        from autocontext.scenarios.custom.operator_loop_designer import OPERATOR_LOOP_SPEC_END, OPERATOR_LOOP_SPEC_START
+        from autocontext.simulation.engine import SimulationEngine
+
+        operator_loop_spec = {
+            "description": "Support escalation requiring operator guidance before a response is sent.",
+            "environment_description": "A support agent must defer to a human operator before replying.",
+            "initial_state_description": "The customer is waiting on a high-risk account action.",
+            "escalation_policy": {"escalation_threshold": "high", "max_escalations": 3},
+            "success_criteria": ["human operator consulted", "response sent with operator guidance"],
+            "failure_modes": ["responding without operator approval"],
+            "max_steps": 4,
+            "actions": [
+                {
+                    "name": "escalate_to_human_operator",
+                    "description": "Escalate the case to a human operator for approval and guidance.",
+                    "parameters": {},
+                    "preconditions": [],
+                    "effects": ["operator_guidance_ready"],
+                },
+                {
+                    "name": "continue_with_operator_guidance",
+                    "description": "Continue handling the case after the operator responds.",
+                    "parameters": {},
+                    "preconditions": ["escalate_to_human_operator"],
+                    "effects": ["case_resolved"],
+                },
+            ],
+        }
+        prompt_capture: dict[str, str] = {}
+
+        def operator_loop_llm(system: str, user: str) -> str:
+            prompt_capture["system"] = system
+            prompt_capture["user"] = user
+            return (
+                f"{OPERATOR_LOOP_SPEC_START}\n"
+                f"{json.dumps(operator_loop_spec)}\n"
+                f"{OPERATOR_LOOP_SPEC_END}"
+            )
+
+        engine = SimulationEngine(llm_fn=operator_loop_llm, knowledge_root=tmp_knowledge)
+        result = engine.run(
+            description=(
+                "simulate a customer support escalation where the AI agent must escalate "
+                "to a human operator, wait for operator input, then continue with the operator's guidance"
+            )
+        )
+
+        assert "OperatorLoopSpec JSON" in prompt_capture["system"]
+        assert result["family"] == "operator_loop"
+        assert result["status"] == "completed"
+        assert result["summary"]["escalation_count"] == 1
+        assert "Escalations: 1" in result["summary"]["reasoning"]
+        assert result.get("missing_signals") is None
+
     def test_operator_loop_multi_run_preserves_contract_signal_counts(self, tmp_knowledge: Path) -> None:
         from autocontext.simulation.engine import SimulationEngine
 

--- a/autocontext/tests/test_simulate_command.py
+++ b/autocontext/tests/test_simulate_command.py
@@ -315,6 +315,58 @@ class TestSimulationEngine:
         assert "Escalations: 1" in result["summary"]["reasoning"]
         assert result.get("missing_signals") is None
 
+    def test_operator_loop_escalation_for_clarification_records_both_signals(
+        self,
+        tmp_knowledge: Path,
+    ) -> None:
+        from autocontext.scenarios.custom.operator_loop_designer import OPERATOR_LOOP_SPEC_END, OPERATOR_LOOP_SPEC_START
+        from autocontext.simulation.engine import SimulationEngine
+
+        operator_loop_spec = {
+            "description": "Support escalation requiring operator clarification before a response is sent.",
+            "environment_description": "A support agent must defer to a human operator for clarification.",
+            "initial_state_description": "The customer request is high-risk and ambiguous.",
+            "escalation_policy": {"escalation_threshold": "high", "max_escalations": 3},
+            "success_criteria": ["human operator clarified the request", "response sent with operator guidance"],
+            "failure_modes": ["responding without operator clarification"],
+            "max_steps": 4,
+            "actions": [
+                {
+                    "name": "escalate_for_clarification",
+                    "description": "Escalate to the human operator for clarification and guidance.",
+                    "parameters": {},
+                    "preconditions": [],
+                    "effects": ["operator_clarified"],
+                },
+                {
+                    "name": "continue_with_operator_guidance",
+                    "description": "Continue handling the case after the operator responds.",
+                    "parameters": {},
+                    "preconditions": ["escalate_for_clarification"],
+                    "effects": ["case_resolved"],
+                },
+            ],
+        }
+
+        def operator_loop_llm(system: str, user: str) -> str:
+            return f"{OPERATOR_LOOP_SPEC_START}\n{json.dumps(operator_loop_spec)}\n{OPERATOR_LOOP_SPEC_END}"
+
+        engine = SimulationEngine(llm_fn=operator_loop_llm, knowledge_root=tmp_knowledge)
+        result = engine.run(
+            description=(
+                "simulate a support case that must escalate to a human operator "
+                "for clarification before responding"
+            )
+        )
+
+        assert result["family"] == "operator_loop"
+        assert result["status"] == "completed"
+        assert result["summary"]["escalation_count"] == 1
+        assert result["summary"]["clarification_count"] == 1
+        assert "Escalations: 1" in result["summary"]["reasoning"]
+        assert "Clarifications: 1" in result["summary"]["reasoning"]
+        assert result.get("missing_signals") is None
+
     def test_operator_loop_multi_run_preserves_contract_signal_counts(self, tmp_knowledge: Path) -> None:
         from autocontext.simulation.engine import SimulationEngine
 


### PR DESCRIPTION
## Summary

This PR restores the Python `autoctx simulate` operator-loop path for the canonical escalation regression tracked in AC-535. It routes operator-loop simulations through the family-specific designer prompt, preserves explicit escalation actions in generated scenarios, and adds a regression test covering the live failure shape. Fixes AC-535.

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/simulation/engine.py src/autocontext/scenarios/custom/operator_loop_codegen.py src/autocontext/scenarios/custom/operator_loop_designer.py tests/test_simulate_command.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_simulate_command.py tests/test_operator_loop_coordination.py tests/test_operator_loop_unsupported.py tests/test_scenario_behavioral_contract.py -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

### Manual / live verification

Live Pi-backed canonical repro rerun:

```bash
AUTOCONTEXT_AGENT_PROVIDER=pi \
AUTOCONTEXT_JUDGE_PROVIDER=pi \
AUTOCONTEXT_PI_COMMAND=pi \
AUTOCONTEXT_PI_TIMEOUT=300 \
./.venv/bin/autoctx simulate \
  --description "simulate a customer support escalation where the AI agent must escalate to a human operator, wait for operator input, then continue with the operator's guidance" \
  --save-as ac535_py_sim_fix \
  --json
```

Observed result in `/tmp/autoctx-py-ac535-fix2-qEYrs0/result.json`:

```json
{
  "family": "operator_loop",
  "status": "completed",
  "summary": {
    "score": 0.82,
    "escalation_count": 1,
    "clarification_count": 1,
    "reasoning": "Escalations: 1 (1 necessary, 0 unnecessary). Missed escalations: 0. Autonomous actions: 4. Clarifications: 1."
  }
}
```

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

### Implementation details

- `autocontext/src/autocontext/simulation/engine.py:302` now uses the operator-loop designer when the inferred family is `operator_loop`, instead of always falling back to the generic simulation JSON prompt.
- `autocontext/src/autocontext/simulation/engine.py:461` now reports escalation and clarification counts from the scenario state itself, so explicit operator-loop actions are reflected in the run summary.
- `autocontext/src/autocontext/scenarios/custom/operator_loop_codegen.py:116` teaches generated scenarios to recognize explicit escalation and clarification actions and record them in the operator-loop logs during execution.
- `autocontext/src/autocontext/scenarios/custom/operator_loop_designer.py:35` nudges spec generation toward explicit `escalate_...` actions and action-name-based preconditions for escalation workflows.
- `autocontext/tests/test_simulate_command.py:260` adds a regression test for the canonical escalation/wait/continue path.

### Scope / limitations

- No API or config surface changes.
- No TypeScript changes in this PR.
- The behavioral contract remains unchanged and still fail-closes if escalation is absent.
