### PR TITLE
fix: preserve operator-loop family through solve

### DIFF
--- a/autocontext/src/autocontext/agents/feedback_loops.py
+++ b/autocontext/src/autocontext/agents/feedback_loops.py
@@ -19,7 +19,7 @@ import json
 import statistics
 from typing import Any
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 # ---------------------------------------------------------------------------
 # AC-336: Analyst quality scoring
@@ -40,19 +40,23 @@ class AnalystRating(BaseModel):
     def overall(self) -> float:
         return round(statistics.mean([self.actionability, self.specificity, self.correctness]), 2)
 
+    @field_validator("rationale", mode="before")
+    @classmethod
+    def _coerce_rationale(cls, value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value
+        if isinstance(value, dict | list):
+            return json.dumps(value, sort_keys=True)
+        return str(value)
+
     def to_dict(self) -> dict[str, Any]:
         return self.model_dump()
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> AnalystRating:
-        payload = dict(data)
-        rationale = payload.get("rationale", "")
-        if not isinstance(rationale, str):
-            if isinstance(rationale, dict | list):
-                payload["rationale"] = json.dumps(rationale, sort_keys=True)
-            else:
-                payload["rationale"] = str(rationale)
-        return cls.model_validate(payload)
+        return cls.model_validate(data)
 
 
 def format_analyst_feedback(rating: AnalystRating | None) -> str:

--- a/autocontext/src/autocontext/agents/feedback_loops.py
+++ b/autocontext/src/autocontext/agents/feedback_loops.py
@@ -15,6 +15,7 @@ Key types:
 
 from __future__ import annotations
 
+import json
 import statistics
 from typing import Any
 
@@ -44,7 +45,14 @@ class AnalystRating(BaseModel):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> AnalystRating:
-        return cls.model_validate(data)
+        payload = dict(data)
+        rationale = payload.get("rationale", "")
+        if not isinstance(rationale, str):
+            if isinstance(rationale, dict | list):
+                payload["rationale"] = json.dumps(rationale, sort_keys=True)
+            else:
+                payload["rationale"] = str(rationale)
+        return cls.model_validate(payload)
 
 
 def format_analyst_feedback(rating: AnalystRating | None) -> str:
@@ -90,8 +98,7 @@ class ToolUsageTracker:
     def __init__(self, known_tools: list[str]) -> None:
         self._tools = known_tools
         self._records: dict[str, ToolUsageRecord] = {
-            name: ToolUsageRecord(tool_name=name, used_in_gens=[], last_used=0, total_refs=0)
-            for name in known_tools
+            name: ToolUsageRecord(tool_name=name, used_in_gens=[], last_used=0, total_refs=0) for name in known_tools
         }
 
     def record_generation(self, generation: int, strategy_text: str) -> None:
@@ -110,10 +117,7 @@ class ToolUsageTracker:
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "records": {
-                name: record.to_dict()
-                for name, record in sorted(self._records.items())
-            },
+            "records": {name: record.to_dict() for name, record in sorted(self._records.items())},
         }
 
     @classmethod

--- a/autocontext/src/autocontext/agents/translator.py
+++ b/autocontext/src/autocontext/agents/translator.py
@@ -12,6 +12,7 @@ from autocontext.agents.translator_simplification import extract_strategy_determ
 from autocontext.agents.types import RoleExecution
 from autocontext.harness.core.output_parser import strip_json_fences as _harness_strip_fences
 from autocontext.harness.core.types import RoleUsage
+from autocontext.strategy_interface import is_action_plan_interface
 
 
 class StrategyTranslator:
@@ -38,20 +39,25 @@ class StrategyTranslator:
             )
             return deterministic, execution
 
+        action_plan_interface = is_action_plan_interface(strategy_interface)
         prompt = (
             "Extract the strategy from the following competitor analysis as a JSON object.\n\n"
             f"Strategy interface (expected format):\n{strategy_interface}\n\n"
             f"Competitor output:\n{raw_output}\n\n"
             "Return ONLY a valid JSON object with no markdown fences or explanation. "
-            "Map any abbreviated or alternative field names "
-            "to match the strategy interface. Include only numeric values."
+            "Map any abbreviated or alternative field names to match the strategy interface. "
+            + (
+                "Preserve strings, arrays, and nested objects exactly as needed by the strategy interface."
+                if action_plan_interface
+                else "Include only numeric values."
+            )
         )
         execution = self.runtime.run_task(
             SubagentTask(
                 role="translator",
                 model=self.model,
                 prompt=prompt,
-                max_tokens=200,
+                max_tokens=400 if action_plan_interface else 200,
                 temperature=0.0,
             )
         )
@@ -78,10 +84,7 @@ class StrategyTranslator:
         }
         if interface_keys:
             return all(key in interface_keys for key in keys)
-        return all(
-            re.search(rf"\b{re.escape(key)}\b", strategy_interface) is not None
-            for key in keys
-        )
+        return all(re.search(rf"\b{re.escape(key)}\b", strategy_interface) is not None for key in keys)
 
     def translate_code(self, raw_output: str) -> tuple[dict[str, Any], RoleExecution]:
         """Extract executable Python code from competitor output.

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 from autocontext.agents.types import LlmFn
 from autocontext.config.settings import AppSettings
@@ -16,6 +16,10 @@ from autocontext.knowledge.export import SkillPackage, export_skill_package
 from autocontext.mcp.tools import MtsToolContext
 
 logger = logging.getLogger(__name__)
+
+
+class _NamedScenario(Protocol):
+    name: str
 
 
 @dataclass
@@ -63,25 +67,25 @@ class SolveScenarioBuilder:
         family = route_to_family(classification)
 
         if family.name == "game":
-            creator = ScenarioCreator(
+            game_creator = ScenarioCreator(
                 runtime=self._runtime,
                 model=self._model,
                 knowledge_root=self._knowledge_root,
             )
-            spec = creator.generate_spec(description)
-            build = creator.build_and_validate(spec)
+            spec = game_creator.generate_spec(description)
+            build = game_creator.build_and_validate(spec)
             SCENARIO_REGISTRY[spec.name] = build.scenario_class
             return SolveScenarioBuildResult(
                 scenario_name=spec.name,
                 family_name=family.name,
             )
 
-        creator = AgentTaskCreator(
+        family_creator = AgentTaskCreator(
             llm_fn=self._llm_fn,
             knowledge_root=self._knowledge_root,
         )
-        scenario = creator.create(description)
-        scenario_name = str(cast(Any, scenario).name)
+        scenario = family_creator.create(description)
+        scenario_name = str(cast(_NamedScenario, scenario).name)
         SCENARIO_REGISTRY[scenario_name] = scenario.__class__
         return SolveScenarioBuildResult(
             scenario_name=scenario_name,
@@ -98,7 +102,10 @@ def _llm_fn_from_client(client: Any, model: str) -> LlmFn:
             temperature=0.3,
             role="scenario_designer",
         )
-        return response.text.strip()
+        response_text: object = getattr(response, "text", "")
+        if not isinstance(response_text, str):
+            response_text = str(response_text)
+        return response_text.strip()
 
     return llm_fn
 

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -8,8 +8,9 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+from autocontext.agents.types import LlmFn
 from autocontext.config.settings import AppSettings
 from autocontext.knowledge.export import SkillPackage, export_skill_package
 from autocontext.mcp.tools import MtsToolContext
@@ -28,6 +29,78 @@ class SolveJob:
     error: str | None = None
     result: SkillPackage | None = None
     created_at: float = field(default_factory=time.time)
+
+
+@dataclass(slots=True)
+class SolveScenarioBuildResult:
+    scenario_name: str
+    family_name: str
+
+
+class SolveScenarioBuilder:
+    """Create solve scenarios through the correct family-specific pipeline."""
+
+    def __init__(
+        self,
+        *,
+        runtime: Any,
+        llm_fn: LlmFn,
+        model: str,
+        knowledge_root: Path,
+    ) -> None:
+        self._runtime = runtime
+        self._llm_fn = llm_fn
+        self._model = model
+        self._knowledge_root = knowledge_root
+
+    def build(self, description: str) -> SolveScenarioBuildResult:
+        from autocontext.scenarios import SCENARIO_REGISTRY
+        from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
+        from autocontext.scenarios.custom.creator import ScenarioCreator
+        from autocontext.scenarios.custom.family_classifier import classify_scenario_family, route_to_family
+
+        classification = classify_scenario_family(description)
+        family = route_to_family(classification)
+
+        if family.name == "game":
+            creator = ScenarioCreator(
+                runtime=self._runtime,
+                model=self._model,
+                knowledge_root=self._knowledge_root,
+            )
+            spec = creator.generate_spec(description)
+            build = creator.build_and_validate(spec)
+            SCENARIO_REGISTRY[spec.name] = build.scenario_class
+            return SolveScenarioBuildResult(
+                scenario_name=spec.name,
+                family_name=family.name,
+            )
+
+        creator = AgentTaskCreator(
+            llm_fn=self._llm_fn,
+            knowledge_root=self._knowledge_root,
+        )
+        scenario = creator.create(description)
+        scenario_name = str(cast(Any, scenario).name)
+        SCENARIO_REGISTRY[scenario_name] = scenario.__class__
+        return SolveScenarioBuildResult(
+            scenario_name=scenario_name,
+            family_name=family.name,
+        )
+
+
+def _llm_fn_from_client(client: Any, model: str) -> LlmFn:
+    def llm_fn(system: str, user: str) -> str:
+        response = client.generate(
+            model=model,
+            prompt=f"{system}\n\n{user}",
+            max_tokens=3000,
+            temperature=0.3,
+            role="scenario_designer",
+        )
+        return response.text.strip()
+
+    return llm_fn
 
 
 class SolveManager:
@@ -68,19 +141,14 @@ class SolveManager:
         try:
             # 1. Create scenario
             job.status = "creating_scenario"
-            creator = self._build_creator()
-            if creator is None:
+            builder = self._build_creator()
+            if builder is None:
                 job.status = "failed"
-                job.error = "ScenarioCreator unavailable (no API key or unsupported provider)"
+                job.error = "Scenario creation pipeline unavailable (no API key or unsupported provider)"
                 return
 
-            spec = creator.generate_spec(job.description)
-            build = creator.build_and_validate(spec)
-
-            from autocontext.scenarios import SCENARIO_REGISTRY
-
-            SCENARIO_REGISTRY[spec.name] = build.scenario_class
-            job.scenario_name = spec.name
+            created = builder.build(job.description)
+            job.scenario_name = created.scenario_name
 
             # 2. Run generations
             job.status = "running"
@@ -88,13 +156,13 @@ class SolveManager:
 
             runner = GenerationRunner(self._settings)
             runner.migrate(self._migrations_dir)
-            run_id = f"solve_{spec.name}_{uuid.uuid4().hex[:8]}"
-            summary = runner.run(spec.name, job.generations, run_id)
+            run_id = f"solve_{created.scenario_name}_{uuid.uuid4().hex[:8]}"
+            summary = runner.run(created.scenario_name, job.generations, run_id)
             job.progress = summary.generations_executed
 
             # 3. Export skill package
             ctx = MtsToolContext(self._settings)
-            job.result = export_skill_package(ctx, spec.name)
+            job.result = export_skill_package(ctx, created.scenario_name)
             job.status = "completed"
 
         except Exception as exc:
@@ -102,22 +170,23 @@ class SolveManager:
             job.status = "failed"
             job.error = str(exc)
 
-    def _build_creator(self) -> Any:
-        """Build a ScenarioCreator following the same pattern as server/app.py."""
+    def _build_creator(self) -> SolveScenarioBuilder | None:
+        """Build a family-aware solve scenario creator."""
         try:
             from autocontext.agents.llm_client import build_client_from_settings
             from autocontext.agents.subagent_runtime import SubagentRuntime
-            from autocontext.scenarios.custom.creator import ScenarioCreator
 
             client = build_client_from_settings(self._settings)
             runtime = SubagentRuntime(client)
-            return ScenarioCreator(
+            llm_fn = _llm_fn_from_client(client, self._settings.model_architect)
+            return SolveScenarioBuilder(
                 runtime=runtime,
+                llm_fn=llm_fn,
                 model=self._settings.model_architect,
                 knowledge_root=self._settings.knowledge_root,
             )
         except Exception:
-            logger.warning("failed to build ScenarioCreator for solve job", exc_info=True)
+            logger.warning("failed to build solve scenario creator", exc_info=True)
             return None
 
     def get_status(self, job_id: str) -> dict[str, Any]:

--- a/autocontext/src/autocontext/prompts/templates.py
+++ b/autocontext/src/autocontext/prompts/templates.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from autocontext.prompts.context_budget import ContextBudget
 from autocontext.scenarios.base import Observation
+from autocontext.strategy_interface import is_action_plan_interface
 
 
 @dataclass(frozen=True)
@@ -183,12 +184,15 @@ def build_prompt_bundle(
     analyst_nb = f"Session notebook context:\n{_nb['analyst']}\n\n" if _nb.get("analyst") else ""
     coach_nb = f"Session notebook context:\n{_nb['coach']}\n\n" if _nb.get("coach") else ""
     architect_nb = f"Session notebook context:\n{_nb['architect']}\n\n" if _nb.get("architect") else ""
+    competitor_task = (
+        "Return ONLY a JSON object that matches the strategy interface. "
+        "Encode your reasoning inside each action's `reasoning` field and do not add prose outside the JSON."
+        if is_action_plan_interface(strategy_interface)
+        else "Describe your strategy reasoning and recommend specific parameter values."
+    )
+
     return PromptBundle(
-        competitor=base_context
-        + hints_block
-        + competitor_nb
-        + competitor_constraint
-        + "Describe your strategy reasoning and recommend specific parameter values.",
+        competitor=base_context + hints_block + competitor_nb + competitor_constraint + competitor_task,
         analyst=base_context
         + evidence_block
         + analyst_feedback_block

--- a/autocontext/src/autocontext/runtimes/pi_cli.py
+++ b/autocontext/src/autocontext/runtimes/pi_cli.py
@@ -151,6 +151,8 @@ class PiCLIRuntime(AgentRuntime):
             try:
                 data = json.loads(raw)
                 text = data.get("result", data.get("output", ""))
+                if not isinstance(text, str) or not text.strip():
+                    text = json.dumps(data)
                 return AgentOutput(
                     text=text,
                     cost_usd=data.get("cost_usd", 0.0),

--- a/autocontext/src/autocontext/strategy_interface.py
+++ b/autocontext/src/autocontext/strategy_interface.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+
+def is_action_plan_interface(strategy_interface: str) -> bool:
+    """Return True when the strategy interface expects structured action plans.
+
+    Simulation-style families describe strategies as ordered plans with an
+    `actions` array, nested parameters, and allowed action names. Game-style
+    scenarios instead expose flat numeric parameter dictionaries.
+    """
+    lowered = strategy_interface.lower()
+    return (
+        '"actions"' in strategy_interface
+        or "`actions`" in strategy_interface
+        or "ordered action plan" in lowered
+        or "allowed action names" in lowered
+    )

--- a/autocontext/tests/test_family_aware_strategy_prompts.py
+++ b/autocontext/tests/test_family_aware_strategy_prompts.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from autocontext.prompts.templates import build_prompt_bundle
+from autocontext.scenarios.base import Observation
+
+NUMERIC_INTERFACE = "Return JSON object with `aggression`, `defense`, and `path_bias` as floats in [0,1]."
+ACTION_PLAN_INTERFACE = (
+    "Return JSON with an ordered action plan:\n"
+    "{\n"
+    '  "actions": [\n'
+    '    {"name": "action_name", "parameters": {...}, "reasoning": "why this step now"}\n'
+    "  ]\n"
+    "}\n\n"
+    "Allowed action names: review_request, escalate_to_human_operator, continue_with_operator_guidance"
+)
+
+
+def _build_bundle(strategy_interface: str):
+    return build_prompt_bundle(
+        scenario_rules="Rules",
+        strategy_interface=strategy_interface,
+        evaluation_criteria="Criteria",
+        previous_summary="Prev",
+        observation=Observation(narrative="obs", state={}, constraints=[]),
+        current_playbook="Playbook",
+        available_tools="",
+    )
+
+
+class TestFamilyAwareCompetitorPrompt:
+    def test_uses_action_plan_language_for_simulation_style_interfaces(self) -> None:
+        bundle = _build_bundle(ACTION_PLAN_INTERFACE)
+
+        assert "Return ONLY a JSON object" in bundle.competitor
+        assert "reasoning` field" in bundle.competitor
+        assert "parameter values" not in bundle.competitor
+
+    def test_keeps_parameter_language_for_numeric_interfaces(self) -> None:
+        bundle = _build_bundle(NUMERIC_INTERFACE)
+
+        assert "parameter values" in bundle.competitor

--- a/autocontext/tests/test_feedback_loops.py
+++ b/autocontext/tests/test_feedback_loops.py
@@ -44,6 +44,25 @@ class TestAnalystRating:
         assert restored.specificity == 4
         assert restored.generation == 3
 
+    def test_from_dict_coerces_structured_rationale_to_string(self) -> None:
+        from autocontext.agents.feedback_loops import AnalystRating
+
+        restored = AnalystRating.from_dict(
+            {
+                "actionability": 4,
+                "specificity": 4,
+                "correctness": 4,
+                "rationale": {
+                    "actionability": "Concrete next steps.",
+                    "correctness": "Aligned with evidence.",
+                },
+                "generation": 2,
+            }
+        )
+
+        assert "Concrete next steps." in restored.rationale
+        assert restored.generation == 2
+
 
 # ===========================================================================
 # AC-336: format_analyst_feedback
@@ -55,7 +74,9 @@ class TestFormatAnalystFeedback:
         from autocontext.agents.feedback_loops import AnalystRating, format_analyst_feedback
 
         rating = AnalystRating(
-            actionability=2, specificity=2, correctness=4,
+            actionability=2,
+            specificity=2,
+            correctness=4,
             rationale="Findings were too vague to act on.",
             generation=4,
         )
@@ -68,7 +89,9 @@ class TestFormatAnalystFeedback:
         from autocontext.agents.feedback_loops import AnalystRating, format_analyst_feedback
 
         rating = AnalystRating(
-            actionability=5, specificity=5, correctness=5,
+            actionability=5,
+            specificity=5,
+            correctness=5,
             rationale="Excellent analysis with concrete evidence.",
             generation=7,
         )
@@ -121,7 +144,7 @@ class TestToolUsageTracker:
         tracker = ToolUsageTracker(known_tools=["cluster_evaluator", "move_predictor", "path_optimizer"])
         tracker.record_generation(
             generation=3,
-            strategy_text='Using cluster_evaluator to analyze positions and path_optimizer for routing.',
+            strategy_text="Using cluster_evaluator to analyze positions and path_optimizer for routing.",
         )
 
         stats = tracker.get_stats()

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autocontext.agents.llm_client import DeterministicDevClient
+from autocontext.agents.subagent_runtime import SubagentRuntime
+from autocontext.scenarios import SCENARIO_REGISTRY
+from autocontext.scenarios.custom.operator_loop_designer import OPERATOR_LOOP_SPEC_END, OPERATOR_LOOP_SPEC_START
+from autocontext.scenarios.families import detect_family
+
+
+def _operator_loop_llm(system: str, user: str) -> str:
+    del system, user
+    spec = {
+        "description": "A support queue where high-risk actions require operator escalation.",
+        "environment_description": "The agent triages support requests and can defer risky actions to a human operator.",
+        "initial_state_description": "A new request is waiting for triage.",
+        "escalation_policy": {"escalation_threshold": "high", "max_escalations": 2},
+        "success_criteria": [
+            "routine issues are handled safely",
+            "high-risk actions are escalated to a human operator",
+        ],
+        "failure_modes": ["unsafe autonomous handling"],
+        "max_steps": 5,
+        "actions": [
+            {
+                "name": "review_request",
+                "description": "Assess the request and available evidence.",
+                "parameters": {},
+                "preconditions": [],
+                "effects": ["request_reviewed"],
+            },
+            {
+                "name": "escalate_to_human_operator",
+                "description": "Escalate the risky request to a human operator.",
+                "parameters": {},
+                "preconditions": ["review_request"],
+                "effects": ["operator_guidance_available"],
+            },
+            {
+                "name": "continue_with_operator_guidance",
+                "description": "Resume handling after operator guidance is received.",
+                "parameters": {},
+                "preconditions": ["escalate_to_human_operator"],
+                "effects": ["request_resolved"],
+            },
+        ],
+    }
+    return f"{OPERATOR_LOOP_SPEC_START}\n{json.dumps(spec)}\n{OPERATOR_LOOP_SPEC_END}"
+
+
+class TestSolveScenarioBuilder:
+    def test_routes_operator_loop_descriptions_to_operator_loop_creator(self, tmp_path: Path) -> None:
+        from autocontext.knowledge.solver import SolveScenarioBuilder
+
+        runtime = SubagentRuntime(DeterministicDevClient())
+        builder = SolveScenarioBuilder(
+            runtime=runtime,
+            llm_fn=_operator_loop_llm,
+            model="test-model",
+            knowledge_root=tmp_path,
+        )
+
+        result = builder.build(
+            "Create and solve an operator-loop escalation scenario for an autonomous support agent "
+            "that escalates high-risk account actions to a human operator."
+        )
+
+        scenario_dir = tmp_path / "_custom_scenarios" / result.scenario_name
+        spec_payload = json.loads((scenario_dir / "spec.json").read_text(encoding="utf-8"))
+        scenario = SCENARIO_REGISTRY[result.scenario_name]()
+
+        assert result.family_name == "operator_loop"
+        assert spec_payload["scenario_type"] == "operator_loop"
+        assert detect_family(scenario).name == "operator_loop"
+
+    def test_keeps_legacy_game_creator_for_game_descriptions(self, tmp_path: Path) -> None:
+        from autocontext.knowledge.solver import SolveScenarioBuilder
+
+        runtime = SubagentRuntime(DeterministicDevClient())
+        builder = SolveScenarioBuilder(
+            runtime=runtime,
+            llm_fn=_operator_loop_llm,
+            model="test-model",
+            knowledge_root=tmp_path,
+        )
+
+        result = builder.build("Create and solve a resource management game about balancing mining and defense.")
+
+        scenario_dir = tmp_path / "_custom_scenarios" / result.scenario_name
+        spec_payload = json.loads((scenario_dir / "spec.json").read_text(encoding="utf-8"))
+        scenario = SCENARIO_REGISTRY[result.scenario_name]()
+
+        assert result.family_name == "game"
+        assert spec_payload["scenario_type"] == "parametric"
+        assert detect_family(scenario).name == "game"

--- a/autocontext/tests/test_pi_cli_runtime.py
+++ b/autocontext/tests/test_pi_cli_runtime.py
@@ -84,6 +84,27 @@ def test_generate_raw_text_fallback() -> None:
     assert output.model == "pi"
 
 
+def test_generate_json_object_without_result_serializes_full_payload() -> None:
+    runtime = PiCLIRuntime(PiCLIConfig())
+    raw_payload = {
+        "actions": [
+            {"name": "review_request", "parameters": {}, "reasoning": "Start with intake."},
+        ],
+    }
+    mock_result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps(raw_payload),
+        stderr="",
+    )
+
+    with patch("subprocess.run", return_value=mock_result), patch("shutil.which", return_value="/usr/bin/pi"):
+        output = runtime.generate("test prompt")
+
+    assert json.loads(output.text) == raw_payload
+    assert output.metadata["raw_json"] == raw_payload
+
+
 def test_generate_json_output_disabled() -> None:
     runtime = PiCLIRuntime(PiCLIConfig(json_output=False))
     mock_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="raw output\n", stderr="")

--- a/autocontext/tests/test_strategy_translator.py
+++ b/autocontext/tests/test_strategy_translator.py
@@ -23,13 +23,18 @@ def _make_runtime(response_text: str) -> MagicMock:
     return runtime
 
 
-OTHELLO_INTERFACE = (
-    "Return JSON object with `mobility_weight`, `corner_weight`, and `stability_weight` "
-    "as floats in [0,1]."
-)
+OTHELLO_INTERFACE = "Return JSON object with `mobility_weight`, `corner_weight`, and `stability_weight` as floats in [0,1]."
 
-GRID_CTF_INTERFACE = (
-    "Return JSON object with `aggression`, `defense`, and `path_bias` as floats in [0,1]."
+GRID_CTF_INTERFACE = "Return JSON object with `aggression`, `defense`, and `path_bias` as floats in [0,1]."
+
+ACTION_PLAN_INTERFACE = (
+    "Return JSON with an ordered action plan:\n"
+    "{\n"
+    '  "actions": [\n'
+    '    {"name": "action_name", "parameters": {...}, "reasoning": "why this step now"}\n'
+    "  ]\n"
+    "}\n\n"
+    "Allowed action names: review_request, escalate_to_human_operator, continue_with_operator_guidance"
 )
 
 
@@ -174,3 +179,21 @@ class TestStrategyTranslator:
         assert result == {"mobility_weight": 0.25, "corner_weight": 0.6, "stability_weight": 0.15}
         assert execution.subagent_id == "translator-abc123"
         runtime.run_task.assert_called_once()
+
+    def test_translate_action_plan_prompt_allows_nested_non_numeric_values(self) -> None:
+        raw_json = '{"actions": [{"name": "review_request", "parameters": {}, "reasoning": "Start with intake."}]}'
+        runtime = _make_runtime(raw_json)
+        translator = StrategyTranslator(runtime, model="test-model")
+
+        result, _ = translator.translate(
+            raw_output="Review the request, then escalate if needed.",
+            strategy_interface=ACTION_PLAN_INTERFACE,
+        )
+
+        prompt = runtime.run_task.call_args[0][0].prompt
+        task = runtime.run_task.call_args[0][0]
+
+        assert result["actions"][0]["name"] == "review_request"
+        assert "Include only numeric values" not in prompt
+        assert "Preserve strings, arrays, and nested objects" in prompt
+        assert task.max_tokens == 400


### PR DESCRIPTION
## Summary

This PR fixes AC-536 by preserving the canonical `operator_loop` family through the Python `autoctx solve` flow instead of drifting into the legacy parametric/game path. It also hardens the live Pi-backed solve pipeline so action-plan outputs and structured curator feedback survive downstream parsing during real runtime execution.

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/knowledge/solver.py src/autocontext/strategy_interface.py src/autocontext/prompts/templates.py src/autocontext/agents/translator.py src/autocontext/agents/feedback_loops.py src/autocontext/runtimes/pi_cli.py tests/test_knowledge_solver.py tests/test_family_aware_strategy_prompts.py tests/test_strategy_translator.py tests/test_feedback_loops.py tests/test_pi_cli_runtime.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_knowledge_solver.py tests/test_feedback_loops.py tests/test_pi_cli_runtime.py tests/test_strategy_translator.py tests/test_family_aware_strategy_prompts.py tests/test_scenario_creator.py tests/test_operator_loop_coordination.py tests/test_detect_family_prefers_explicit.py tests/test_cli_json.py -k 'solve or operator_loop or detect_family or creator or translator or prompt or feedback or pi' -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

### Manual verification

Live Pi-backed canonical solve rerun:

- Workspace: `/tmp/autoctx-py-ac536-fix5-7i3Frk`
- Command: `AUTOCONTEXT_AGENT_PROVIDER=pi AUTOCONTEXT_JUDGE_PROVIDER=pi ... autoctx solve --description "Create and solve an operator-loop escalation scenario ..." --gens 1 --json`
- Result: `status: "completed"`
- Verified generated spec persisted as `scenario_type: "operator_loop"`
- Verified analytics writeup metadata persisted as `scenario_family: "operator_loop"`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

### Implementation details

- Added a family-aware solve builder in `autocontext/src/autocontext/knowledge/solver.py` so `game` descriptions continue to use the legacy `ScenarioCreator`, while non-game families such as `operator_loop` route through `AgentTaskCreator`.
- Added `autocontext/src/autocontext/strategy_interface.py` plus prompt/translator coverage so action-plan scenarios use ordered action plans instead of numeric parameter language.
- Hardened `autocontext/src/autocontext/runtimes/pi_cli.py` to preserve top-level structured Pi JSON payloads that do not come back through the older `result`/`output` fields.
- Hardened `autocontext/src/autocontext/agents/feedback_loops.py` so structured curator `rationale` payloads fail soft instead of aborting the solve pipeline.

### Follow-up / limitations

- This PR is intentionally Python-only.
- `mypy` was not part of the focused validation pass for this fix.
- The original AC-536 failure mode is cleared by the live rerun artifacts:
  - `/tmp/autoctx-py-ac536-fix5-7i3Frk/result.json`
  - `/tmp/autoctx-py-ac536-fix5-7i3Frk/knowledge/_custom_scenarios/solve_operator_loop/spec.json`
  - `/tmp/autoctx-py-ac536-fix5-7i3Frk/knowledge/analytics/writeups/writeup-1652c8f6.json`
