### PR TITLE
chore: release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-Changes in this section are on the branch/repo after `0.4.0` and are not part of the last published release until the next version is cut.
+Changes in this section are on the branch/repo after `0.4.1` and are not part of the last published release until the next version is cut.
+
+## [0.4.1] - 2026-04-14
+
+### Fixed
+
+- Restored operator-loop escalation accounting when explicit escalation actions also mention clarification, so generated Python scenarios preserve both escalation and clarification signals.
+- Preserved operator-loop family routing through Python solve creation and replay-safe feedback validation without violating the Pydantic serialization convention.
+- Routed TypeScript `new-scenario` operator-loop requests through the dedicated family designer and allowed generated operator-loop scenarios to execute through the solve codegen path.
+- Python and TypeScript package metadata are bumped to `0.4.1`.
 
 ## [0.4.0] - 2026-04-14
 
@@ -177,6 +186,7 @@ Changes in this section are on the branch/repo after `0.4.0` and are not part of
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
+[0.4.1]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.0...py-v0.4.1
 [0.4.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.3.7...py-v0.4.0
 [0.3.7]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.3.6...py-v0.3.7
 [0.3.6]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.3.5...py-v0.3.6

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The repo publishes two installable packages with different scopes:
 
 - Python package: `pip install autocontext`
 - TypeScript package: `npm install autoctx`
-- Current release line: `autocontext==0.4.0` and `autoctx@0.4.0`
+- Current release line: `autocontext==0.4.1` and `autoctx@0.4.1`
 
 Important:
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -10,7 +10,7 @@ The intended use is to hand the harness a real task in plain language, let it so
 pip install autocontext
 ```
 
-The current PyPI release line is `autocontext==0.4.0`.
+The current PyPI release line is `autocontext==0.4.1`.
 The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
 
 ## Working Directory

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autocontext"
-version = "0.4.0"
+version = "0.4.1"
 description = "autocontext control plane for iterative strategy evolution."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/autocontext/src/autocontext/__init__.py
+++ b/autocontext/src/autocontext/__init__.py
@@ -4,4 +4,4 @@ from autocontext.sdk import AutoContext
 
 __all__ = ["AutoContext", "__version__"]
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/autocontext/uv.lock
+++ b/autocontext/uv.lock
@@ -72,7 +72,7 @@ wheels = [
 
 [[package]]
 name = "autocontext"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/ts/README.md
+++ b/ts/README.md
@@ -25,7 +25,7 @@ Need the canonical product/runtime vocabulary first? Start with [docs/concept-mo
 npm install autoctx
 ```
 
-The current npm release line is `autoctx@0.4.0`.
+The current npm release line is `autoctx@0.4.1`.
 Important: use `autoctx`, not `autocontext`.
 `autocontext` on npm is a different package and not this project.
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoctx",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoctx",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoctx",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump Python and TypeScript packages to 0.4.1
- update release lines in README files
- add the 0.4.1 changelog entry

## Verification
- uv build
- npm run build
- npm pack --dry-run
- python import version check