### PR TITLE
fix: resolve saved custom scenarios by name

### DIFF
--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -154,6 +154,8 @@ uv run autoctx mcp-serve
 uv run autoctx wait <condition_id> --json
 ```
 
+Saved custom scenarios under `knowledge/_custom_scenarios/` can be rerun and benchmarked by name once their `spec.json` has been persisted, so the `new-scenario` / `solve` workflow lines up with the named `run` and `benchmark` surfaces.
+
 Useful variants:
 
 ```bash

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -174,6 +174,13 @@ class GenerationRunner:
     def _scenario(self, scenario_name: str) -> ScenarioInterface:
         cls = SCENARIO_REGISTRY.get(scenario_name)
         if cls is None:
+            from autocontext.scenarios.custom.registry import load_all_custom_scenarios
+
+            custom = load_all_custom_scenarios(self.settings.knowledge_root)
+            if custom:
+                SCENARIO_REGISTRY.update(custom)
+            cls = SCENARIO_REGISTRY.get(scenario_name)
+        if cls is None:
             supported = ", ".join(sorted(SCENARIO_REGISTRY.keys()))
             raise ValueError(f"Unknown scenario '{scenario_name}'. Supported: {supported}")
         return cast(ScenarioInterface, cls())

--- a/autocontext/src/autocontext/scenarios/custom/registry.py
+++ b/autocontext/src/autocontext/scenarios/custom/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import logging
 import sys
 from pathlib import Path
@@ -38,15 +39,47 @@ def _load_agent_task_class(custom_dir: Path, name: str) -> type[Any]:
 
     for attr_name in dir(mod):
         attr = getattr(mod, attr_name)
-        if (
-            isinstance(attr, type)
-            and issubclass(attr, AgentTaskInterface)
-            and attr is not AgentTaskInterface
-        ):
+        if isinstance(attr, type) and issubclass(attr, AgentTaskInterface) and attr is not AgentTaskInterface:
             attr = patch_legacy_generated_evaluate_output(attr, source_path)
             return patch_legacy_generated_revise_output(attr, source_path)
 
     raise ImportError(f"no AgentTaskInterface subclass found in {module_name}")
+
+
+def _read_persisted_marker(entry: Path) -> str:
+    type_file = entry / "scenario_type.txt"
+    if type_file.exists():
+        return type_file.read_text().strip()
+
+    spec_file = entry / "spec.json"
+    if spec_file.exists():
+        try:
+            raw = json.loads(spec_file.read_text(encoding="utf-8"))
+        except Exception:
+            return "parametric"
+        marker = raw.get("scenario_type") or raw.get("scenarioType")
+        if isinstance(marker, str) and marker.strip():
+            return marker.strip()
+
+    return "parametric"
+
+
+def _materialize_parametric_scenario_source(custom_dir: Path, name: str) -> None:
+    from autocontext.scenarios.custom.codegen import generate_scenario_class
+    from autocontext.scenarios.custom.spec import ScenarioSpec
+
+    scenario_dir = custom_dir / name
+    spec = ScenarioSpec.load(scenario_dir)
+    if spec.name != name:
+        spec.name = name
+
+    source_path = scenario_dir / "scenario.py"
+    if not source_path.exists():
+        source_path.write_text(generate_scenario_class(spec), encoding="utf-8")
+
+    type_file = scenario_dir / "scenario_type.txt"
+    if not type_file.exists():
+        type_file.write_text("parametric", encoding="utf-8")
 
 
 def _load_family_class(custom_dir: Path, name: str, marker: str) -> type[Any]:
@@ -58,12 +91,14 @@ def _load_family_class(custom_dir: Path, name: str, marker: str) -> type[Any]:
             raise FileNotFoundError(f"agent task source not found: {agent_task_file}")
         return _load_agent_task_class(custom_dir, name)
 
+    if marker == "parametric":
+        _materialize_parametric_scenario_source(custom_dir, name)
+
     cls = load_custom_scenario(custom_dir, name, family.interface_class)
     detected = detect_family(cls())
     if detected is None or detected.name != family.name:
         raise ImportError(
-            f"loaded scenario '{name}' as family '{detected.name if detected else 'unknown'}', "
-            f"expected '{family.name}'"
+            f"loaded scenario '{name}' as family '{detected.name if detected else 'unknown'}', expected '{family.name}'"
         )
     return cls
 
@@ -79,8 +114,7 @@ def load_all_custom_scenarios(knowledge_root: Path) -> dict[str, type[Any]]:
             continue
         name = entry.name
 
-        type_file = entry / "scenario_type.txt"
-        marker = type_file.read_text().strip() if type_file.exists() else "parametric"
+        marker = _read_persisted_marker(entry)
         try:
             cls = _load_family_class(custom_dir, name, marker)
             loaded[name] = cls

--- a/autocontext/tests/test_custom_scenario_name_resolution.py
+++ b/autocontext/tests/test_custom_scenario_name_resolution.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from autocontext.config.settings import AppSettings
+from autocontext.loop.generation_runner import GenerationRunner
+from autocontext.scenarios.custom.registry import load_all_custom_scenarios
+
+
+def _settings(tmp_path: Path, knowledge_root: Path) -> AppSettings:
+    return AppSettings(
+        db_path=tmp_path / "runs" / "autocontext.sqlite3",
+        runs_root=tmp_path / "runs",
+        knowledge_root=knowledge_root,
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / ".claude" / "skills",
+        agent_provider="deterministic",
+        judge_provider="anthropic",
+        anthropic_api_key="test-key",
+    )
+
+
+def _write_parametric_custom_spec(knowledge_root: Path, name: str = "linear_outage_escalation") -> Path:
+    scenario_dir = knowledge_root / "_custom_scenarios" / name
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+    (scenario_dir / "spec.json").write_text(
+        json.dumps(
+            {
+                "name": name,
+                "display_name": "Linear Outage Escalation",
+                "description": "Escalate likely Linear outages while avoiding unnecessary paging.",
+                "strategy_interface_description": (
+                    "Return JSON with clarification_threshold and escalation_bias floats in [0,1]."
+                ),
+                "evaluation_criteria": "Reward correct outage escalation timing.",
+                "strategy_params": [
+                    {
+                        "name": "clarification_threshold",
+                        "description": "How much clarification to gather before escalating.",
+                        "min_value": 0.0,
+                        "max_value": 1.0,
+                        "default": 0.4,
+                    },
+                    {
+                        "name": "escalation_bias",
+                        "description": "How quickly to escalate a likely outage.",
+                        "min_value": 0.0,
+                        "max_value": 1.0,
+                        "default": 0.6,
+                    },
+                ],
+                "constraints": [
+                    {
+                        "expression": "clarification_threshold + escalation_bias",
+                        "operator": "<=",
+                        "threshold": 1.5,
+                        "description": "Do not over-index on both clarification and escalation.",
+                    }
+                ],
+                "environment_variables": [
+                    {
+                        "name": "incident_severity",
+                        "description": "Severity of the underlying outage.",
+                        "low": 0.2,
+                        "high": 0.95,
+                    }
+                ],
+                "scoring_components": [
+                    {
+                        "name": "outage_capture",
+                        "description": "Ability to escalate real outages quickly.",
+                        "formula_terms": {
+                            "clarification_threshold": -0.1,
+                            "escalation_bias": 0.7,
+                        },
+                        "noise_range": [0.0, 0.0],
+                    }
+                ],
+                "final_score_weights": {"outage_capture": 1.0},
+                "win_threshold": 0.5,
+                "observation_constraints": [
+                    "Ask targeted questions when ambiguity is high.",
+                ],
+                "scenario_type": "parametric",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return scenario_dir
+
+
+class TestCustomScenarioNameResolution:
+    def test_load_all_custom_scenarios_materializes_spec_only_parametric_scenario(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        scenario_dir = _write_parametric_custom_spec(knowledge_root)
+
+        loaded = load_all_custom_scenarios(knowledge_root)
+
+        assert "linear_outage_escalation" in loaded
+        scenario_cls = loaded["linear_outage_escalation"]
+        scenario = scenario_cls()
+        assert scenario.name == "linear_outage_escalation"
+        assert (scenario_dir / "scenario.py").is_file()
+
+        result = scenario.execute_match(
+            {
+                "clarification_threshold": 0.4,
+                "escalation_bias": 0.6,
+            },
+            seed=0,
+        )
+        assert result.validation_errors == []
+        assert 0.0 <= result.score <= 1.0
+        assert "Linear Outage Escalation" in result.summary
+
+    def test_generation_runner_reload_resolves_saved_parametric_scenario_by_name(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        _write_parametric_custom_spec(knowledge_root)
+
+        runner = GenerationRunner.__new__(GenerationRunner)
+        runner.settings = _settings(tmp_path, knowledge_root)
+
+        with patch.dict("autocontext.loop.generation_runner.SCENARIO_REGISTRY", {}, clear=True):
+            scenario = GenerationRunner._scenario(runner, "linear_outage_escalation")
+
+        result = scenario.execute_match(
+            {
+                "clarification_threshold": 0.35,
+                "escalation_bias": 0.65,
+            },
+            seed=1,
+        )
+        assert scenario.name == "linear_outage_escalation"
+        assert result.validation_errors == []
+        assert result.score > 0.0

--- a/ts/README.md
+++ b/ts/README.md
@@ -193,7 +193,7 @@ Credential resolution order is:
 
 `autoctx replay` writes the selected generation and available generations to `stderr` before printing the replay JSON payload. `autoctx export-training-data` writes progress updates to `stderr` while keeping JSONL records on `stdout`.
 
-Saved custom agent-task scenarios under `knowledge/_custom_scenarios/` can be referenced by name in `judge`, `improve`, `repl`, and `queue`. That lets a saved scenario spec become directly usable from the TS CLI without retyping its prompt and rubric.
+Saved custom scenarios under `knowledge/_custom_scenarios/` can be reused directly from the TS CLI. Saved parametric scenarios can now be targeted by name in `run` and `benchmark`, while saved agent-task scenarios remain directly usable in `judge`, `improve`, `repl`, and `queue` without retyping their prompt and rubric.
 
 ## MCP Tools (40+)
 

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -479,7 +479,6 @@ async function cmdRun(dbPath: string): Promise<void> {
     executeRunCommandWorkflow,
     planRunCommand,
     renderRunResult,
-    resolveRunScenario,
     RUN_HELP_TEXT,
   } = await import("./run-command-workflow.js");
 
@@ -495,6 +494,7 @@ async function cmdRun(dbPath: string): Promise<void> {
     await import("../scenarios/family-interfaces.js");
   const { loadSettings } = await import("../config/index.js");
   const { buildRoleProviderBundle } = await import("../providers/index.js");
+  const { resolveRunnableScenarioClass } = await import("./runnable-scenario-resolution.js");
 
   const settings = loadSettings();
   let plan;
@@ -521,7 +521,11 @@ async function cmdRun(dbPath: string): Promise<void> {
 
   let ScenarioClass;
   try {
-    ScenarioClass = resolveRunScenario(plan.scenarioName, SCENARIO_REGISTRY);
+    ScenarioClass = resolveRunnableScenarioClass({
+      scenarioName: plan.scenarioName,
+      builtinScenarios: SCENARIO_REGISTRY,
+      knowledgeRoot: resolve(settings.knowledgeRoot),
+    });
   } catch (error) {
     console.error(errorMessage(error));
     process.exit(1);
@@ -1154,15 +1158,22 @@ async function cmdBenchmark(dbPath: string): Promise<void> {
     await import("../scenarios/family-interfaces.js");
   const { loadSettings } = await import("../config/index.js");
   const { buildRoleProviderBundle } = await import("../providers/index.js");
+  const { resolveRunnableScenarioClass } = await import("./runnable-scenario-resolution.js");
 
   const plan = await planBenchmarkCommand(values, resolveScenarioOption);
-  const ScenarioClass = SCENARIO_REGISTRY[plan.scenarioName];
-  if (!ScenarioClass) {
-    console.error(`Unknown scenario: ${plan.scenarioName}`);
-    process.exit(1);
-  }
 
   const settings = loadSettings();
+  let ScenarioClass;
+  try {
+    ScenarioClass = resolveRunnableScenarioClass({
+      scenarioName: plan.scenarioName,
+      builtinScenarios: SCENARIO_REGISTRY,
+      knowledgeRoot: resolve(settings.knowledgeRoot),
+    });
+  } catch (error) {
+    console.error(errorMessage(error));
+    process.exit(1);
+  }
   const providerBundle = buildRoleProviderBundle(
     settings,
     plan.providerType ? { providerType: plan.providerType } : {},

--- a/ts/src/cli/runnable-scenario-resolution.ts
+++ b/ts/src/cli/runnable-scenario-resolution.ts
@@ -1,0 +1,51 @@
+import { join } from "node:path";
+
+import type { ScenarioInterface } from "../scenarios/game-interface.js";
+import type { CustomScenarioEntry } from "../scenarios/custom-loader.js";
+import { loadCustomScenarios } from "../scenarios/custom-loader.js";
+import { createPersistedParametricScenarioClass } from "../scenarios/persisted-parametric-scenario.js";
+
+type ScenarioClass = new () => ScenarioInterface;
+
+function listAvailableScenarioNames(
+  builtinScenarios: Record<string, ScenarioClass>,
+  customScenarios: Map<string, CustomScenarioEntry>,
+): string {
+  return [...new Set([...Object.keys(builtinScenarios), ...customScenarios.keys()])]
+    .sort()
+    .join(", ");
+}
+
+export function resolveRunnableScenarioClass(opts: {
+  scenarioName: string;
+  builtinScenarios: Record<string, ScenarioClass>;
+  knowledgeRoot: string;
+  loadPersistedCustomScenarios?: (customDir: string) => Map<string, CustomScenarioEntry>;
+  createParametricScenarioClass?: typeof createPersistedParametricScenarioClass;
+}): ScenarioClass {
+  const builtin = opts.builtinScenarios[opts.scenarioName];
+  if (builtin) {
+    return builtin;
+  }
+
+  const customDir = join(opts.knowledgeRoot, "_custom_scenarios");
+  const customScenarios = (opts.loadPersistedCustomScenarios ?? loadCustomScenarios)(customDir);
+  const entry = customScenarios.get(opts.scenarioName);
+  if (!entry) {
+    throw new Error(
+      `Unknown scenario: ${opts.scenarioName}. Available: ${listAvailableScenarioNames(opts.builtinScenarios, customScenarios)}`,
+    );
+  }
+
+  if (entry.type === "parametric") {
+    return (opts.createParametricScenarioClass ?? createPersistedParametricScenarioClass)(
+      opts.scenarioName,
+      entry.spec,
+    );
+  }
+
+  throw new Error(
+    `Scenario '${opts.scenarioName}' is a saved custom ${entry.type} scenario. ` +
+      "Run and benchmark currently support built-in scenarios and saved parametric scenarios by name.",
+  );
+}

--- a/ts/src/scenarios/custom-loader.ts
+++ b/ts/src/scenarios/custom-loader.ts
@@ -5,6 +5,7 @@
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import type { ScenarioFamilyName } from "./families.js";
 import type { AgentTaskInterface, LLMProvider } from "../types/index.js";
 import { createAgentTask } from "./agent-task-factory.js";
 import { parseRawSpec, type AgentTaskSpec } from "./agent-task-spec.js";
@@ -41,7 +42,9 @@ function normalizeAgentTaskSpec(spec: Record<string, unknown>): AgentTaskSpec {
       referenceContext: (spec.referenceContext as string | null | undefined) ?? undefined,
       referenceSources: (spec.referenceSources as string[] | null | undefined) ?? undefined,
       requiredConcepts: (spec.requiredConcepts as string[] | null | undefined) ?? undefined,
-      calibrationExamples: (spec.calibrationExamples as Array<Record<string, unknown>> | null | undefined) ?? undefined,
+      calibrationExamples:
+        (spec.calibrationExamples as Array<Record<string, unknown>> | null | undefined) ??
+        undefined,
       contextPreparation: (spec.contextPreparation as string | null | undefined) ?? undefined,
       requiredContextKeys: (spec.requiredContextKeys as string[] | null | undefined) ?? undefined,
       maxRounds: Number(spec.maxRounds ?? 1),
@@ -71,6 +74,72 @@ export function renderAgentTaskPrompt(spec: AgentTaskSpec): string {
   return prompt;
 }
 
+function inferScenarioTypeFromSpec(spec: Record<string, unknown>): string {
+  const declaredType = spec.scenario_type ?? spec.scenarioType;
+  if (typeof declaredType === "string" && declaredType.trim().length > 0) {
+    return declaredType.trim();
+  }
+
+  const hasParametricShape =
+    Array.isArray(spec.strategy_params ?? spec.strategyParams) ||
+    Array.isArray(spec.environment_variables ?? spec.environmentVariables) ||
+    Array.isArray(spec.scoring_components ?? spec.scoringComponents);
+  if (hasParametricShape) {
+    return "parametric";
+  }
+
+  return "agent_task";
+}
+
+function readPersistedScenarioType(entryPath: string): string {
+  const typePath = join(entryPath, "scenario_type.txt");
+  if (existsSync(typePath)) {
+    try {
+      const stored = readFileSync(typePath, "utf-8").trim();
+      if (stored.length > 0) {
+        return stored;
+      }
+    } catch {
+      return "agent_task";
+    }
+  }
+
+  const candidateSpecPaths = [
+    join(entryPath, "spec.json"),
+    join(entryPath, "agent_task_spec.json"),
+  ];
+  for (const specPath of candidateSpecPaths) {
+    if (!existsSync(specPath)) {
+      continue;
+    }
+    try {
+      const raw = JSON.parse(readFileSync(specPath, "utf-8")) as Record<string, unknown>;
+      return inferScenarioTypeFromSpec(raw);
+    } catch {
+      continue;
+    }
+  }
+
+  return "agent_task";
+}
+
+function scenarioTypeToFamily(type: string): ScenarioFamilyName | null {
+  const TYPE_TO_FAMILY: Record<string, ScenarioFamilyName> = {
+    parametric: "game",
+    agent_task: "agent_task",
+    simulation: "simulation",
+    artifact_editing: "artifact_editing",
+    investigation: "investigation",
+    workflow: "workflow",
+    schema_evolution: "schema_evolution",
+    tool_fragility: "tool_fragility",
+    negotiation: "negotiation",
+    operator_loop: "operator_loop",
+    coordination: "coordination",
+  };
+  return TYPE_TO_FAMILY[type] ?? null;
+}
+
 /**
  * Scan a custom scenarios directory and load spec.json entries.
  * Returns a Map of name → entry for each valid custom scenario found.
@@ -95,37 +164,27 @@ export function loadCustomScenarios(customDir: string): Map<string, CustomScenar
       continue;
     }
 
-    // Read scenario type (default to agent_task)
-    const typePath = join(entryPath, "scenario_type.txt");
-    let scenarioType = "agent_task";
-    if (existsSync(typePath)) {
-      try {
-        scenarioType = readFileSync(typePath, "utf-8").trim();
-      } catch {
-        scenarioType = "agent_task";
-      }
-    }
+    const scenarioType = readPersistedScenarioType(entryPath);
     const specPath = join(entryPath, "spec.json");
     const agentTaskSpecPath = join(entryPath, "agent_task_spec.json");
     if (
-      !existsSync(specPath)
-      && !(scenarioType === "agent_task" && existsSync(agentTaskSpecPath))
+      !existsSync(specPath) &&
+      !(scenarioType === "agent_task" && existsSync(agentTaskSpecPath))
     ) {
       continue;
     }
 
     // Read spec
     try {
-      const specSourcePath = scenarioType === "agent_task" && existsSync(agentTaskSpecPath)
-        ? agentTaskSpecPath
-        : specPath;
+      const specSourcePath =
+        scenarioType === "agent_task" && existsSync(agentTaskSpecPath)
+          ? agentTaskSpecPath
+          : specPath;
       const specRaw = readFileSync(specSourcePath, "utf-8");
       const rawSpec = JSON.parse(specRaw) as Record<string, unknown>;
-      const spec = scenarioType === "agent_task"
-        ? normalizeAgentTaskSpec(rawSpec)
-        : rawSpec;
+      const spec = scenarioType === "agent_task" ? normalizeAgentTaskSpec(rawSpec) : rawSpec;
       const hasGenSource = existsSync(join(entryPath, "scenario.js"));
-      const family = readScenarioFamily(entryPath);
+      const family = readScenarioFamily(entryPath) ?? scenarioTypeToFamily(scenarioType);
       loaded.set(name, {
         name,
         type: scenarioType,
@@ -195,8 +254,8 @@ export function resolveCustomJudgeScenario(
   const spec = entry.spec as Record<string, unknown>;
   const hasPrompt = typeof spec.taskPrompt === "string" && spec.taskPrompt.trim().length > 0;
   const hasRubric =
-    (typeof spec.judgeRubric === "string" && spec.judgeRubric.trim().length > 0)
-    || (typeof spec.rubric === "string" && spec.rubric.trim().length > 0);
+    (typeof spec.judgeRubric === "string" && spec.judgeRubric.trim().length > 0) ||
+    (typeof spec.rubric === "string" && spec.rubric.trim().length > 0);
   if (!hasPrompt || !hasRubric) {
     return null;
   }

--- a/ts/src/scenarios/persisted-parametric-scenario.ts
+++ b/ts/src/scenarios/persisted-parametric-scenario.ts
@@ -181,6 +181,19 @@ function normalizeObservationConstraints(raw: Record<string, unknown>): string[]
   return items.filter((item): item is string => typeof item === "string");
 }
 
+function normalizeFinalScoreWeights(raw: Record<string, unknown>): Record<string, number> {
+  const items = raw.final_score_weights ?? raw.finalScoreWeights;
+  if (!items || typeof items !== "object") {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(items as Record<string, unknown>).map(([key, value]) => [
+      key,
+      readNumber(value, 0),
+    ]),
+  );
+}
+
 export function normalizePersistedParametricScenarioSpec(
   name: string,
   raw: Record<string, unknown>,
@@ -197,14 +210,7 @@ export function normalizePersistedParametricScenarioSpec(
     constraints: normalizeConstraints(raw),
     environmentVariables: normalizeEnvironmentVariables(raw),
     scoringComponents: normalizeScoringComponents(raw),
-    finalScoreWeights:
-      raw.final_score_weights && typeof raw.final_score_weights === "object"
-        ? Object.fromEntries(
-            Object.entries(raw.final_score_weights as Record<string, unknown>).map(
-              ([key, value]) => [key, readNumber(value, 0)],
-            ),
-          )
-        : {},
+    finalScoreWeights: normalizeFinalScoreWeights(raw),
     winThreshold: readNumber(raw.win_threshold ?? raw.winThreshold, 0.55),
     observationConstraints: normalizeObservationConstraints(raw),
   };

--- a/ts/src/scenarios/persisted-parametric-scenario.ts
+++ b/ts/src/scenarios/persisted-parametric-scenario.ts
@@ -1,0 +1,453 @@
+import type {
+  LegalAction,
+  Observation,
+  Result,
+  ScenarioInterface,
+  ScoringDimension,
+} from "./game-interface.js";
+import { ResultSchema } from "./game-interface.js";
+
+interface ParametricStrategyParam {
+  name: string;
+  description: string;
+  minValue: number;
+  maxValue: number;
+  defaultValue: number;
+}
+
+interface ParametricConstraint {
+  expression: string;
+  operator: "<=" | ">=" | "<" | ">" | "==";
+  threshold: number;
+  description: string;
+}
+
+interface ParametricEnvironmentVariable {
+  name: string;
+  description: string;
+  low: number;
+  high: number;
+}
+
+interface ParametricScoringComponent {
+  name: string;
+  description: string;
+  formulaTerms: Record<string, number>;
+  noiseRange: [number, number];
+}
+
+export interface PersistedParametricScenarioSpec {
+  name: string;
+  displayName: string;
+  description: string;
+  strategyInterfaceDescription: string;
+  evaluationCriteria: string;
+  strategyParams: ParametricStrategyParam[];
+  constraints: ParametricConstraint[];
+  environmentVariables: ParametricEnvironmentVariable[];
+  scoringComponents: ParametricScoringComponent[];
+  finalScoreWeights: Record<string, number>;
+  winThreshold: number;
+  observationConstraints: string[];
+}
+
+function createRng(seed: number): () => number {
+  let s = seed | 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function rngUniform(rng: () => number, lo: number, hi: number): number {
+  return lo + rng() * (hi - lo);
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function round3(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function round4(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+function readString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function readNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function normalizeConstraintOperator(value: unknown): ParametricConstraint["operator"] {
+  return value === ">=" || value === "<" || value === ">" || value === "==" ? value : "<=";
+}
+
+function normalizeStrategyParams(raw: Record<string, unknown>): ParametricStrategyParam[] {
+  const items = raw.strategy_params ?? raw.strategyParams;
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items
+    .filter((item): item is Record<string, unknown> => !!item && typeof item === "object")
+    .map((item) => ({
+      name: readString(item.name),
+      description: readString(item.description),
+      minValue: readNumber(item.min_value ?? item.minValue, 0),
+      maxValue: readNumber(item.max_value ?? item.maxValue, 1),
+      defaultValue: readNumber(item.default ?? item.defaultValue, 0.5),
+    }))
+    .filter((item) => item.name.length > 0);
+}
+
+function normalizeConstraints(raw: Record<string, unknown>): ParametricConstraint[] {
+  const items = raw.constraints;
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items
+    .filter((item): item is Record<string, unknown> => !!item && typeof item === "object")
+    .map((item) => ({
+      expression: readString(item.expression),
+      operator: normalizeConstraintOperator(item.operator),
+      threshold: readNumber(item.threshold, 0),
+      description: readString(item.description),
+    }))
+    .filter((item) => item.expression.length > 0);
+}
+
+function normalizeEnvironmentVariables(
+  raw: Record<string, unknown>,
+): ParametricEnvironmentVariable[] {
+  const items = raw.environment_variables ?? raw.environmentVariables;
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items
+    .filter((item): item is Record<string, unknown> => !!item && typeof item === "object")
+    .map((item) => ({
+      name: readString(item.name),
+      description: readString(item.description),
+      low: readNumber(item.low, 0),
+      high: readNumber(item.high, 1),
+    }))
+    .filter((item) => item.name.length > 0);
+}
+
+function normalizeScoringComponents(raw: Record<string, unknown>): ParametricScoringComponent[] {
+  const items = raw.scoring_components ?? raw.scoringComponents;
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items
+    .filter((item): item is Record<string, unknown> => !!item && typeof item === "object")
+    .map((item) => {
+      const rawNoise = item.noise_range ?? item.noiseRange;
+      const noiseRange: [number, number] =
+        Array.isArray(rawNoise) && rawNoise.length >= 2
+          ? [readNumber(rawNoise[0], 0), readNumber(rawNoise[1], 0)]
+          : [0, 0];
+      const rawFormulaTerms = item.formula_terms ?? item.formulaTerms;
+      const formulaTerms =
+        rawFormulaTerms && typeof rawFormulaTerms === "object"
+          ? Object.fromEntries(
+              Object.entries(rawFormulaTerms as Record<string, unknown>).map(([key, value]) => [
+                key,
+                readNumber(value, 0),
+              ]),
+            )
+          : {};
+      return {
+        name: readString(item.name),
+        description: readString(item.description),
+        formulaTerms,
+        noiseRange,
+      };
+    })
+    .filter((item) => item.name.length > 0);
+}
+
+function normalizeObservationConstraints(raw: Record<string, unknown>): string[] {
+  const items = raw.observation_constraints ?? raw.observationConstraints;
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items.filter((item): item is string => typeof item === "string");
+}
+
+export function normalizePersistedParametricScenarioSpec(
+  name: string,
+  raw: Record<string, unknown>,
+): PersistedParametricScenarioSpec {
+  return {
+    name,
+    displayName: readString(raw.display_name ?? raw.displayName, name),
+    description: readString(raw.description),
+    strategyInterfaceDescription: readString(
+      raw.strategy_interface_description ?? raw.strategyInterfaceDescription,
+    ),
+    evaluationCriteria: readString(raw.evaluation_criteria ?? raw.evaluationCriteria),
+    strategyParams: normalizeStrategyParams(raw),
+    constraints: normalizeConstraints(raw),
+    environmentVariables: normalizeEnvironmentVariables(raw),
+    scoringComponents: normalizeScoringComponents(raw),
+    finalScoreWeights:
+      raw.final_score_weights && typeof raw.final_score_weights === "object"
+        ? Object.fromEntries(
+            Object.entries(raw.final_score_weights as Record<string, unknown>).map(
+              ([key, value]) => [key, readNumber(value, 0)],
+            ),
+          )
+        : {},
+    winThreshold: readNumber(raw.win_threshold ?? raw.winThreshold, 0.55),
+    observationConstraints: normalizeObservationConstraints(raw),
+  };
+}
+
+function evaluateConstraintExpression(expression: string, parsed: Record<string, number>): number {
+  const parts = expression.split(/(\+|-)/);
+  let total = 0;
+  let sign = 1;
+  for (const part of parts) {
+    const token = part.trim();
+    if (!token) {
+      continue;
+    }
+    if (token === "+") {
+      sign = 1;
+      continue;
+    }
+    if (token === "-") {
+      sign = -1;
+      continue;
+    }
+    total += sign * (parsed[token] ?? 0);
+  }
+  return total;
+}
+
+function evaluateConstraint(
+  operator: ParametricConstraint["operator"],
+  value: number,
+  threshold: number,
+): boolean {
+  switch (operator) {
+    case ">=":
+      return value >= threshold;
+    case "<":
+      return value < threshold;
+    case ">":
+      return value > threshold;
+    case "==":
+      return value === threshold;
+    default:
+      return value <= threshold;
+  }
+}
+
+export class PersistedParametricScenario implements ScenarioInterface {
+  readonly name: string;
+  readonly #spec: PersistedParametricScenarioSpec;
+
+  constructor(name: string, rawSpec: Record<string, unknown>) {
+    this.name = name;
+    this.#spec = normalizePersistedParametricScenarioSpec(name, rawSpec);
+  }
+
+  describeRules(): string {
+    return this.#spec.description;
+  }
+
+  describeStrategyInterface(): string {
+    return this.#spec.strategyInterfaceDescription;
+  }
+
+  describeEvaluationCriteria(): string {
+    return this.#spec.evaluationCriteria;
+  }
+
+  initialState(seed = 0): Record<string, unknown> {
+    const rng = createRng(seed);
+    const state: Record<string, unknown> = {
+      seed,
+      terminal: false,
+      timeline: [],
+    };
+    for (const envVar of this.#spec.environmentVariables) {
+      state[envVar.name] = round3(rngUniform(rng, envVar.low, envVar.high));
+    }
+    return state;
+  }
+
+  getObservation(state: Record<string, unknown>, playerId: string): Observation {
+    const visibleState = Object.fromEntries(
+      this.#spec.environmentVariables.map((envVar) => [envVar.name, state[envVar.name]]),
+    );
+    return {
+      narrative: `${playerId} observes: ${Object.entries(visibleState)
+        .map(([key, value]) => `${key}=${String(value)}`)
+        .join(", ")}`,
+      state: visibleState,
+      constraints: [...this.#spec.observationConstraints],
+    };
+  }
+
+  validateActions(
+    _state: Record<string, unknown>,
+    _playerId: string,
+    actions: Record<string, unknown>,
+  ): [boolean, string] {
+    const parsed: Record<string, number> = {};
+    for (const param of this.#spec.strategyParams) {
+      const value = actions[param.name];
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        return [false, `missing or invalid field: ${param.name}`];
+      }
+      if (value < param.minValue || value > param.maxValue) {
+        return [false, `${param.name} must be in [${param.minValue},${param.maxValue}]`];
+      }
+      parsed[param.name] = value;
+    }
+
+    for (const constraint of this.#spec.constraints) {
+      const value = evaluateConstraintExpression(constraint.expression, parsed);
+      if (!evaluateConstraint(constraint.operator, value, constraint.threshold)) {
+        return [false, constraint.description];
+      }
+    }
+
+    return [true, "ok"];
+  }
+
+  step(state: Record<string, unknown>, actions: Record<string, unknown>): Record<string, unknown> {
+    const parsed = Object.fromEntries(
+      this.#spec.strategyParams.map((param) => [
+        param.name,
+        Number(actions[param.name] ?? param.defaultValue),
+      ]),
+    );
+    const rng = createRng(Number(state.seed ?? 0));
+    const metrics = Object.fromEntries(
+      this.#spec.scoringComponents.map((component) => {
+        const base = Object.entries(component.formulaTerms).reduce(
+          (sum, [paramName, coefficient]) => sum + coefficient * Number(parsed[paramName] ?? 0),
+          0,
+        );
+        const noise = rngUniform(rng, component.noiseRange[0], component.noiseRange[1]);
+        return [component.name, round4(clamp01(base + noise))];
+      }),
+    ) as Record<string, number>;
+
+    const score = round4(
+      clamp01(
+        Object.entries(metrics).reduce(
+          (sum, [metricName, value]) =>
+            sum + (this.#spec.finalScoreWeights[metricName] ?? 0) * value,
+          0,
+        ),
+      ),
+    );
+
+    const timeline = [...((state.timeline as Array<Record<string, unknown>> | undefined) ?? [])];
+    timeline.push({ event: "turn_complete", ...metrics });
+
+    return {
+      ...state,
+      terminal: true,
+      score,
+      metrics,
+      timeline,
+    };
+  }
+
+  isTerminal(state: Record<string, unknown>): boolean {
+    return Boolean(state.terminal);
+  }
+
+  getResult(state: Record<string, unknown>): Result {
+    const score = Number(state.score ?? 0);
+    const metrics = (state.metrics ?? {}) as Record<string, number>;
+    const replay = [...((state.timeline as Array<Record<string, unknown>>) ?? [])];
+    return ResultSchema.parse({
+      score,
+      winner: score >= this.#spec.winThreshold ? "challenger" : "incumbent",
+      summary: `${this.#spec.displayName} score ${score.toFixed(4)}`,
+      replay,
+      metrics: Object.fromEntries(
+        Object.entries(metrics).map(([key, value]) => [key, Number(value)]),
+      ),
+    });
+  }
+
+  replayToNarrative(replay: Array<Record<string, unknown>>): string {
+    if (!replay.length) {
+      return "No replay events were captured.";
+    }
+    const event = replay[replay.length - 1];
+    const dimensionText = this.#spec.scoringComponents
+      .map((component) => `${component.name} ${Number(event[component.name] ?? 0).toFixed(2)}`)
+      .join(", ");
+    return `${this.#spec.displayName}: ${dimensionText}`;
+  }
+
+  renderFrame(state: Record<string, unknown>): Record<string, unknown> {
+    return {
+      scenario: this.name,
+      score: Number(state.score ?? 0),
+      metrics: state.metrics ?? {},
+    };
+  }
+
+  enumerateLegalActions(state: Record<string, unknown>): LegalAction[] | null {
+    if (this.isTerminal(state)) {
+      return [];
+    }
+    return this.#spec.strategyParams.map((param) => ({
+      action: param.name,
+      description: param.description,
+      type: "continuous",
+      range: [param.minValue, param.maxValue] as [number, number],
+    }));
+  }
+
+  scoringDimensions(): ScoringDimension[] | null {
+    return this.#spec.scoringComponents.map((component) => ({
+      name: component.name,
+      weight: this.#spec.finalScoreWeights[component.name] ?? 0,
+      description: component.description,
+    }));
+  }
+
+  executeMatch(strategy: Record<string, unknown>, seed: number): Result {
+    const state = this.initialState(seed);
+    const [valid, reason] = this.validateActions(state, "challenger", strategy);
+    if (!valid) {
+      return ResultSchema.parse({
+        score: 0,
+        winner: "incumbent",
+        summary: "strategy rejected during validation",
+        replay: [{ event: "validation_failed", reason }],
+        metrics: { valid: 0 },
+        validationErrors: [reason],
+      });
+    }
+    return this.getResult(this.step(state, strategy));
+  }
+}
+
+export function createPersistedParametricScenarioClass(
+  name: string,
+  rawSpec: Record<string, unknown>,
+): new () => ScenarioInterface {
+  return class PersistedCustomParametricScenario extends PersistedParametricScenario {
+    constructor() {
+      super(name, rawSpec);
+    }
+  };
+}

--- a/ts/tests/persisted-parametric-scenario.test.ts
+++ b/ts/tests/persisted-parametric-scenario.test.ts
@@ -178,6 +178,54 @@ describe("persisted parametric scenario", () => {
     expect(result.summary).toContain("Linear Outage Escalation");
   });
 
+  it("preserves camelCase finalScoreWeights when scoring saved TS-style specs", () => {
+    const ScenarioClass = createPersistedParametricScenarioClass("camel_weighted_scenario", {
+      name: "camel_weighted_scenario",
+      displayName: "Camel Weighted Scenario",
+      description: "Score a TS-style parametric spec with camelCase keys.",
+      strategyInterfaceDescription: "Return JSON with signal in [0,1].",
+      evaluationCriteria: "Reward higher signal.",
+      strategyParams: [
+        {
+          name: "signal",
+          description: "Signal strength.",
+          minValue: 0,
+          maxValue: 1,
+          defaultValue: 0.5,
+        },
+      ],
+      constraints: [],
+      environmentVariables: [],
+      scoringComponents: [
+        {
+          name: "coverage",
+          description: "Coverage from signal.",
+          formulaTerms: {
+            signal: 1,
+          },
+          noiseRange: [0, 0],
+        },
+      ],
+      finalScoreWeights: {
+        coverage: 1,
+      },
+      winThreshold: 0.5,
+      observationConstraints: [],
+    });
+
+    const scenario = new ScenarioClass();
+    const result = scenario.executeMatch({ signal: 0.75 }, 1);
+
+    expect(result.score).toBe(0.75);
+    expect(scenario.scoringDimensions()).toEqual([
+      {
+        name: "coverage",
+        weight: 1,
+        description: "Coverage from signal.",
+      },
+    ]);
+  });
+
   it("resolves saved parametric scenarios by name for run and benchmark", () => {
     const dir = makeTempDir();
     tempDirs.push(dir);

--- a/ts/tests/persisted-parametric-scenario.test.ts
+++ b/ts/tests/persisted-parametric-scenario.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { resolveRunnableScenarioClass } from "../src/cli/runnable-scenario-resolution.js";
+import { loadCustomScenarios } from "../src/scenarios/custom-loader.js";
+import { createPersistedParametricScenarioClass } from "../src/scenarios/persisted-parametric-scenario.js";
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "ac551-parametric-"));
+}
+
+function writeSavedParametricScenario(
+  knowledgeRoot: string,
+  name = "linear_outage_escalation",
+): void {
+  const scenarioDir = join(knowledgeRoot, "_custom_scenarios", name);
+  mkdirSync(scenarioDir, { recursive: true });
+  writeFileSync(
+    join(scenarioDir, "spec.json"),
+    JSON.stringify(
+      {
+        name,
+        display_name: "Linear Outage Escalation",
+        description: "Escalate likely Linear outages while avoiding unnecessary paging.",
+        strategy_interface_description:
+          "Return JSON with clarification_threshold and escalation_bias floats in [0,1].",
+        evaluation_criteria: "Reward correct outage escalation timing.",
+        strategy_params: [
+          {
+            name: "clarification_threshold",
+            description: "How much clarification to gather before escalating.",
+            min_value: 0,
+            max_value: 1,
+            default: 0.4,
+          },
+          {
+            name: "escalation_bias",
+            description: "How quickly to escalate a likely outage.",
+            min_value: 0,
+            max_value: 1,
+            default: 0.6,
+          },
+        ],
+        constraints: [
+          {
+            expression: "clarification_threshold + escalation_bias",
+            operator: "<=",
+            threshold: 1.5,
+            description: "Do not over-index on both clarification and escalation.",
+          },
+        ],
+        environment_variables: [
+          {
+            name: "incident_severity",
+            description: "Severity of the outage.",
+            low: 0.2,
+            high: 0.95,
+          },
+        ],
+        scoring_components: [
+          {
+            name: "outage_capture",
+            description: "Ability to escalate real outages quickly.",
+            formula_terms: {
+              clarification_threshold: -0.1,
+              escalation_bias: 0.7,
+            },
+            noise_range: [0, 0],
+          },
+        ],
+        final_score_weights: {
+          outage_capture: 1,
+        },
+        win_threshold: 0.5,
+        observation_constraints: ["Ask targeted questions when ambiguity is high."],
+        scenario_type: "parametric",
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+}
+
+describe("persisted parametric scenario", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("infers the parametric type from spec metadata when scenario_type.txt is missing", () => {
+    const dir = makeTempDir();
+    tempDirs.push(dir);
+    const knowledgeRoot = join(dir, "knowledge");
+    writeSavedParametricScenario(knowledgeRoot);
+
+    const loaded = loadCustomScenarios(join(knowledgeRoot, "_custom_scenarios"));
+    const entry = loaded.get("linear_outage_escalation");
+
+    expect(entry?.type).toBe("parametric");
+  });
+
+  it("creates a runnable scenario class from a saved parametric spec", () => {
+    const ScenarioClass = createPersistedParametricScenarioClass("linear_outage_escalation", {
+      name: "linear_outage_escalation",
+      display_name: "Linear Outage Escalation",
+      description: "Escalate likely Linear outages while avoiding unnecessary paging.",
+      strategy_interface_description:
+        "Return JSON with clarification_threshold and escalation_bias floats in [0,1].",
+      evaluation_criteria: "Reward correct outage escalation timing.",
+      strategy_params: [
+        {
+          name: "clarification_threshold",
+          description: "How much clarification to gather before escalating.",
+          min_value: 0,
+          max_value: 1,
+          default: 0.4,
+        },
+        {
+          name: "escalation_bias",
+          description: "How quickly to escalate a likely outage.",
+          min_value: 0,
+          max_value: 1,
+          default: 0.6,
+        },
+      ],
+      constraints: [
+        {
+          expression: "clarification_threshold + escalation_bias",
+          operator: "<=",
+          threshold: 1.5,
+          description: "Do not over-index on both clarification and escalation.",
+        },
+      ],
+      environment_variables: [
+        {
+          name: "incident_severity",
+          description: "Severity of the outage.",
+          low: 0.2,
+          high: 0.95,
+        },
+      ],
+      scoring_components: [
+        {
+          name: "outage_capture",
+          description: "Ability to escalate real outages quickly.",
+          formula_terms: {
+            clarification_threshold: -0.1,
+            escalation_bias: 0.7,
+          },
+          noise_range: [0, 0],
+        },
+      ],
+      final_score_weights: {
+        outage_capture: 1,
+      },
+      win_threshold: 0.5,
+      observation_constraints: ["Ask targeted questions when ambiguity is high."],
+    });
+
+    const scenario = new ScenarioClass();
+    const result = scenario.executeMatch(
+      {
+        clarification_threshold: 0.35,
+        escalation_bias: 0.65,
+      },
+      1,
+    );
+
+    expect(scenario.name).toBe("linear_outage_escalation");
+    expect(result.validationErrors).toEqual([]);
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.summary).toContain("Linear Outage Escalation");
+  });
+
+  it("resolves saved parametric scenarios by name for run and benchmark", () => {
+    const dir = makeTempDir();
+    tempDirs.push(dir);
+    const knowledgeRoot = join(dir, "knowledge");
+    writeSavedParametricScenario(knowledgeRoot);
+
+    const ScenarioClass = resolveRunnableScenarioClass({
+      scenarioName: "linear_outage_escalation",
+      builtinScenarios: {},
+      knowledgeRoot,
+    });
+
+    const scenario = new ScenarioClass();
+    const result = scenario.executeMatch(
+      {
+        clarification_threshold: 0.4,
+        escalation_bias: 0.6,
+      },
+      0,
+    );
+
+    expect(scenario.name).toBe("linear_outage_escalation");
+    expect(result.validationErrors).toEqual([]);
+    expect(result.score).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- fix AC-551 by letting both Python and TypeScript resolve saved custom scenarios under `knowledge/_custom_scenarios/<name>` when `run` and `benchmark` are invoked by name
- materialize spec-only persisted parametric scenarios back into runnable classes instead of requiring the built-in registry to know about them ahead of time
- add regression coverage and README updates so the saved-scenario workflow now matches the natural-language creation/solve workflow

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [x] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check ...`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest ...`
- [x] `cd ts && npm run lint`
- [x] `cd ts && npm test`
- [x] additional manual verification described below

### Automated

#### Python
- `cd autocontext && uv run pytest tests/test_custom_scenario_name_resolution.py -x --tb=short`
  - `2 passed`
- `cd autocontext && uv run pytest tests/test_custom_scenario_name_resolution.py tests/test_scenario_dispatch.py tests/test_new_scenario_cli.py tests/test_revise_output_fix.py -x --tb=short`
  - `34 passed`
- `cd autocontext && uv run ruff check src/autocontext/scenarios/custom/registry.py src/autocontext/loop/generation_runner.py tests/test_custom_scenario_name_resolution.py`

#### TypeScript
- `cd ts && npm test -- persisted-parametric-scenario.test.ts run-command-workflow.test.ts benchmark-command-workflow.test.ts`
  - `14 passed`
- `cd ts && npm test -- persisted-parametric-scenario.test.ts auto-discover-custom.test.ts run-command-workflow.test.ts benchmark-command-workflow.test.ts run-custom-scenario-registry.test.ts run-start-workflow.test.ts run-environment-catalog.test.ts`
  - `28 passed`
- `cd ts && npm run lint`
- `cd ts && npm run build`

### Manual / Live

#### Python live rerun
Workspace: `/tmp/ac551-py-live-gfJp70`

- `AUTOCONTEXT_AGENT_PROVIDER=pi AUTOCONTEXT_JUDGE_PROVIDER=pi ... uv run python -m autocontext.cli run --scenario linear_outage_escalation --gens 1 --json`
  - succeeded with `scenario: "linear_outage_escalation"`
- `AUTOCONTEXT_AGENT_PROVIDER=pi AUTOCONTEXT_JUDGE_PROVIDER=pi ... uv run python -m autocontext.cli benchmark --scenario linear_outage_escalation --runs 1`
  - succeeded with `mean_score=0.5091`

#### TypeScript live rerun
Workspace: `/tmp/ac551-ts-live-KHLNdX`

- `AUTOCONTEXT_AGENT_PROVIDER=pi ... node dist/cli/index.js run --scenario linear_outage_escalation --gens 1 --json`
  - succeeded and resolved the saved custom scenario by name
- `AUTOCONTEXT_AGENT_PROVIDER=pi ... node dist/cli/index.js benchmark --scenario linear_outage_escalation --runs 1 --gens 1 --json`
  - succeeded and resolved the saved custom scenario by name

## Docs And Release Impact

- [ ] no user-facing docs changes needed
- [x] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- Python now reloads persisted custom scenarios on registry miss and can materialize spec-only `parametric` scenarios into runnable `scenario.py` files.
- TypeScript now uses a shared runnable-scenario resolver for both `run` and `benchmark`, plus a generic persisted-parametric adapter for saved specs.
- This PR is scoped to **named reruns of saved custom scenarios**. It does not change the separate family-routing work tracked under AC-549.
