### PR TITLE
fix: penalize contradictory rubric judge escapes

### DIFF
--- a/autocontext/src/autocontext/execution/judge.py
+++ b/autocontext/src/autocontext/execution/judge.py
@@ -53,6 +53,7 @@ _RESULT_START = "<!-- JUDGE_RESULT_START -->"
 _RESULT_END = "<!-- JUDGE_RESULT_END -->"
 
 DEFAULT_FACTUAL_CONFIDENCE = 0.5
+_CONTRADICTION_SCORE_CAP = 0.25
 
 
 def _detect_generated_dimensions(dimension_keys: list[str], rubric: str) -> bool:
@@ -78,6 +79,65 @@ def _detect_generated_dimensions(dimension_keys: list[str], rubric: str) -> bool
         if not any(frag in rubric_words for frag in fragments):
             return True
     return False
+
+
+def _looks_like_dual_section_escape(agent_output: str) -> bool:
+    lower = agent_output.lower()
+    child_markers = (
+        "for a five-year-old",
+        "for five-year-olds",
+        "for kids",
+        "for a child",
+        "child version",
+        "beginner version",
+    )
+    advanced_markers = (
+        "graduate seminar",
+        "graduate-level",
+        "technical treatment",
+        "advanced treatment",
+        "for experts",
+        "formal treatment",
+    )
+    heading_count = len(re.findall(r"(?m)^\s{0,3}#{1,6}\s+", agent_output))
+    has_child_section = any(marker in lower for marker in child_markers)
+    has_advanced_section = any(marker in lower for marker in advanced_markers)
+    return (has_child_section and has_advanced_section) or (
+        heading_count >= 2 and has_child_section and ("graduate" in lower or "technical" in lower)
+    )
+
+
+def _apply_same_span_contradiction_guardrail(
+    rubric: str,
+    agent_output: str,
+    score: float,
+    reasoning: str,
+    dimension_scores: dict[str, float],
+) -> tuple[float, str, dict[str, float]]:
+    coherence = check_rubric_coherence(rubric)
+    has_same_span_conflict = any(
+        "graduate-level depth and child-level accessibility" in warning for warning in coherence.warnings
+    )
+    if not has_same_span_conflict or score < 0.75:
+        return score, reasoning, dimension_scores
+
+    high_dimensions = [value for value in dimension_scores.values() if value >= 0.75]
+    dual_section_escape = _looks_like_dual_section_escape(agent_output)
+    if len(high_dimensions) < 2 and not dual_section_escape:
+        return score, reasoning, dimension_scores
+
+    escape_note = (
+        "The response appears to satisfy them in separate sections instead of one coherent span"
+        if dual_section_escape
+        else "No single span can satisfy both incompatible demands at a high score simultaneously"
+    )
+    capped_reasoning = (
+        f"{reasoning}\n\n"
+        "Rubric contradiction guardrail: this rubric asks for incompatible same-span qualities. "
+        f"{escape_note}, so the score was capped."
+    )
+    capped_dimensions = {key: min(value, _CONTRADICTION_SCORE_CAP) for key, value in dimension_scores.items()}
+    return min(score, _CONTRADICTION_SCORE_CAP), capped_reasoning, capped_dimensions
 
 
 class LLMJudge:
@@ -138,8 +198,7 @@ class LLMJudge:
     ) -> JudgeResult:
         """Evaluate agent output by calling the provider N times and averaging."""
         system_prompt = (
-            "You are an expert judge evaluating an AI agent's output. "
-            "Evaluate the output against the provided rubric. "
+            "You are an expert judge evaluating an AI agent's output. Evaluate the output against the provided rubric. "
         )
         if reference_context:
             system_prompt += (
@@ -156,7 +215,11 @@ class LLMJudge:
             'containing JSON: {"score": 0.0-1.0, "reasoning": "...", "dimensions": {"dim1": 0.0-1.0, ...}}'
         )
         user_prompt = self._build_judge_prompt(
-            task_prompt, agent_output, reference_context, required_concepts, calibration_examples,
+            task_prompt,
+            agent_output,
+            reference_context,
+            required_concepts,
+            calibration_examples,
             pinned_dimensions,
         )
 
@@ -239,9 +302,17 @@ class LLMJudge:
                 avg_dims["factual_confidence"] = DEFAULT_FACTUAL_CONFIDENCE
 
         combined_reasoning = "\n---\n".join(reasonings)
+        avg_score, combined_reasoning, avg_dims = _apply_same_span_contradiction_guardrail(
+            self.rubric,
+            agent_output,
+            avg_score,
+            combined_reasoning,
+            avg_dims,
+        )
 
         dimensions_were_generated = _detect_generated_dimensions(
-            list(avg_dims.keys()), self.rubric,
+            list(avg_dims.keys()),
+            self.rubric,
         )
 
         return JudgeResult(
@@ -268,14 +339,10 @@ class LLMJudge:
             f"## Rubric\n{self.rubric}\n",
         ]
         if reference_context:
-            parts.append(
-                f"\n## Reference Context (Authoritative)\n{reference_context}\n"
-            )
+            parts.append(f"\n## Reference Context (Authoritative)\n{reference_context}\n")
         if required_concepts:
             concepts_list = ", ".join(required_concepts)
-            parts.append(
-                f"\n## Required Concepts\nThe output MUST correctly address these concepts: {concepts_list}\n"
-            )
+            parts.append(f"\n## Required Concepts\nThe output MUST correctly address these concepts: {concepts_list}\n")
         if calibration_examples:
             cal_lines = ["\n## Calibration Examples (Human-Scored)\n"]
             cal_lines.append(
@@ -286,11 +353,7 @@ class LLMJudge:
                 score = ex.get("human_score", "N/A")
                 notes = ex.get("human_notes", "")
                 output_snippet = ex.get("agent_output", "")[:200]
-                cal_lines.append(
-                    f"**Example {i}** — Score: {score}\n"
-                    f"Human notes: {notes}\n"
-                    f"Output snippet: {output_snippet}...\n"
-                )
+                cal_lines.append(f"**Example {i}** — Score: {score}\nHuman notes: {notes}\nOutput snippet: {output_snippet}...\n")
             parts.append("\n".join(cal_lines))
         if pinned_dimensions:
             dim_list = ", ".join(pinned_dimensions)
@@ -400,9 +463,9 @@ class LLMJudge:
         """Strategy 4: Extract score from plain text patterns."""
         # Match patterns like "Score: 0.85" or "Overall score: 0.9"
         patterns = [
-            r'(?:overall\s+)?score[:\s]+([01](?:\.\d+)?)',
+            r"(?:overall\s+)?score[:\s]+([01](?:\.\d+)?)",
             r'"score"\s*:\s*([01](?:\.\d+)?)',
-            r'(\d\.\d+)\s*/\s*1\.0',
+            r"(\d\.\d+)\s*/\s*1\.0",
         ]
         for pat in patterns:
             match = re.search(pat, response, re.IGNORECASE)
@@ -419,7 +482,8 @@ class LLMJudge:
 
     @staticmethod
     def _extract_from_dict(
-        data: dict, method: ParseMethod,
+        data: dict,
+        method: ParseMethod,
     ) -> tuple[float, str, dict[str, float], ParseMethod]:
         """Extract score, reasoning, dimensions, and parse method from a parsed dict."""
         score = float(data.get("score", 0.0))

--- a/autocontext/src/autocontext/execution/rubric_coherence.py
+++ b/autocontext/src/autocontext/execution/rubric_coherence.py
@@ -16,6 +16,22 @@ def _has_pattern(lower: str, patterns: tuple[str, ...]) -> bool:
     return any(re.search(pattern, lower) for pattern in patterns)
 
 
+def _allows_separate_depth_and_accessibility(lower: str) -> bool:
+    separate_surface_patterns = (
+        r"\b(?:two|2)\s+(?:separate\s+)?(?:sections|parts|versions|explanations)\b",
+        r"\bseparate\s+(?:sections|parts|versions|explanations|audiences)\b",
+    )
+    if _has_pattern(lower, separate_surface_patterns):
+        return True
+
+    advanced_unit = r"(?:advanced|expert|graduate|technical)\s+(?:section|version|treatment|explanation)"
+    beginner_unit = r"(?:beginner|child|kid|layperson)\s+(?:section|version|explanation)"
+    return bool(
+        re.search(rf"\b{advanced_unit}\b.*\b{beginner_unit}\b", lower)
+        or re.search(rf"\b{beginner_unit}\b.*\b{advanced_unit}\b", lower)
+    )
+
+
 def check_rubric_coherence(rubric: str) -> RubricCoherenceResult:
     """Check a rubric for potential coherence issues.
 
@@ -56,7 +72,11 @@ def check_rubric_coherence(rubric: str) -> RubricCoherenceResult:
         r"\blayperson\b",
         r"\baccessible to a child\b",
     )
-    if _has_pattern(lower, depth_patterns) and _has_pattern(lower, child_accessibility_patterns):
+    if (
+        _has_pattern(lower, depth_patterns)
+        and _has_pattern(lower, child_accessibility_patterns)
+        and not _allows_separate_depth_and_accessibility(lower)
+    ):
         warnings.append("Potentially contradictory criteria: graduate-level depth and child-level accessibility both appear")
 
     # Check for overly vague criteria

--- a/autocontext/src/autocontext/execution/rubric_coherence.py
+++ b/autocontext/src/autocontext/execution/rubric_coherence.py
@@ -12,11 +12,16 @@ class RubricCoherenceResult:
     is_coherent: bool = True
 
 
+def _has_pattern(lower: str, patterns: tuple[str, ...]) -> bool:
+    return any(re.search(pattern, lower) for pattern in patterns)
+
+
 def check_rubric_coherence(rubric: str) -> RubricCoherenceResult:
     """Check a rubric for potential coherence issues.
 
-    Detects contradictory adjective pairs, overly vague criteria,
-    and underspecified rubrics. Returns warnings (non-blocking).
+    Detects contradictory adjective pairs, same-span audience/depth conflicts,
+    overly vague criteria, and underspecified rubrics. Returns warnings
+    (non-blocking).
     """
     warnings: list[str] = []
 
@@ -32,6 +37,27 @@ def check_rubric_coherence(rubric: str) -> RubricCoherenceResult:
     for a, b in contradictions:
         if re.search(rf"\b{a}\b", lower) and re.search(rf"\b{b}\b", lower):
             warnings.append(f'Potentially contradictory criteria: "{a}" and "{b}" both appear')
+
+    depth_patterns = (
+        r"\bgraduate\b",
+        r"\bgraduate-level\b",
+        r"\bseminar depth\b",
+        r"\badvanced\b",
+        r"\bexpert\b",
+        r"\btechnical depth\b",
+        r"\brigorous\b",
+    )
+    child_accessibility_patterns = (
+        r"\b5-year-old\b",
+        r"\bfive-year-old\b",
+        r"\bchild\b",
+        r"\bkid\b",
+        r"\bbeginner\b",
+        r"\blayperson\b",
+        r"\baccessible to a child\b",
+    )
+    if _has_pattern(lower, depth_patterns) and _has_pattern(lower, child_accessibility_patterns):
+        warnings.append("Potentially contradictory criteria: graduate-level depth and child-level accessibility both appear")
 
     # Check for overly vague criteria
     vague_matches = re.findall(r"\b(good|nice|appropriate|adequate|proper)\b", lower)

--- a/autocontext/tests/test_judge.py
+++ b/autocontext/tests/test_judge.py
@@ -127,6 +127,29 @@ class TestLLMJudge:
         assert result.parse_method == "plaintext"
         assert result.score == 0.8
 
+    def test_contradictory_rubric_caps_dual_section_escape(self) -> None:
+        resp = (
+            '<!-- JUDGE_RESULT_START -->{"score": 0.96, "reasoning": "Both sections satisfy their target audience.", '
+            '"dimensions": {"technical_depth": 0.97, "child_accessibility": 0.95}}<!-- JUDGE_RESULT_END -->'
+        )
+        judge = LLMJudge(
+            model="test",
+            rubric=(
+                "Must be at graduate physics seminar depth AND accessible to a 5-year-old. "
+                "Score technical_depth and child_accessibility 0-1 each."
+            ),
+            llm_fn=make_mock_llm(resp),
+        )
+        result = judge.evaluate(
+            "Explain quantum entanglement",
+            "## For a Five-Year-Old\nImagine two magic coins.\n\n"
+            "## Graduate Seminar Treatment\nConsider Hilbert spaces, Bell inequalities, and Schmidt decomposition.",
+        )
+        assert result.score <= 0.25
+        assert result.dimension_scores["technical_depth"] <= 0.25
+        assert result.dimension_scores["child_accessibility"] <= 0.25
+        assert "separate sections" in result.reasoning.lower()
+
 
 class TestDetectGeneratedDimensions:
     def test_empty_keys(self) -> None:

--- a/autocontext/tests/test_judge.py
+++ b/autocontext/tests/test_judge.py
@@ -150,6 +150,30 @@ class TestLLMJudge:
         assert result.dimension_scores["child_accessibility"] <= 0.25
         assert "separate sections" in result.reasoning.lower()
 
+    def test_contradiction_guardrail_allows_explicit_two_section_rubric(self) -> None:
+        resp = (
+            '<!-- JUDGE_RESULT_START -->{"score": 0.96, "reasoning": "Meets both requested sections.", '
+            '"dimensions": {"advanced_section": 0.96, "beginner_section": 0.95}}<!-- JUDGE_RESULT_END -->'
+        )
+        judge = LLMJudge(
+            model="test",
+            rubric=(
+                "Provide two separate sections: an advanced treatment for experts and "
+                "a beginner explanation for newcomers. Score advanced_section and "
+                "beginner_section 0-1 each."
+            ),
+            llm_fn=make_mock_llm(resp),
+        )
+        result = judge.evaluate(
+            "Explain quantum entanglement",
+            "## Beginner explanation\nImagine two magic coins.\n\n"
+            "## Advanced treatment for experts\nConsider Hilbert spaces and Bell inequalities.",
+        )
+        assert result.score == 0.96
+        assert result.dimension_scores["advanced_section"] == 0.96
+        assert result.dimension_scores["beginner_section"] == 0.95
+        assert "guardrail" not in result.reasoning.lower()
+
 
 class TestDetectGeneratedDimensions:
     def test_empty_keys(self) -> None:

--- a/autocontext/tests/test_rubric_coherence.py
+++ b/autocontext/tests/test_rubric_coherence.py
@@ -52,3 +52,12 @@ def test_detects_multiple_contradictory_pairs() -> None:
     assert not result.is_coherent
     contradiction_warnings = [w for w in result.warnings if "contradictory" in w]
     assert len(contradiction_warnings) >= 2
+
+
+def test_detects_same_span_depth_vs_child_accessibility_conflict() -> None:
+    result = check_rubric_coherence(
+        "Must be at graduate physics seminar depth AND accessible to a 5-year-old. "
+        "Score technical_depth and child_accessibility 0-1 each."
+    )
+    assert not result.is_coherent
+    assert any("graduate-level depth" in warning for warning in result.warnings)

--- a/autocontext/tests/test_rubric_coherence.py
+++ b/autocontext/tests/test_rubric_coherence.py
@@ -61,3 +61,13 @@ def test_detects_same_span_depth_vs_child_accessibility_conflict() -> None:
     )
     assert not result.is_coherent
     assert any("graduate-level depth" in warning for warning in result.warnings)
+
+
+def test_allows_explicit_multi_section_depth_and_beginner_rubric() -> None:
+    result = check_rubric_coherence(
+        "Provide two separate sections: an advanced treatment for experts and "
+        "a beginner explanation for newcomers. Score advanced_section and "
+        "beginner_section 0-1 each."
+    )
+    assert result.is_coherent
+    assert result.warnings == []

--- a/autocontext/tests/test_task_runner.py
+++ b/autocontext/tests/test_task_runner.py
@@ -188,6 +188,29 @@ class TestSimpleAgentTask:
         result = task.evaluate_output("my output", {})
         assert result.score == 0.85
 
+    def test_evaluate_output_penalizes_dual_section_escape_for_contradictory_rubric(self):
+        provider = _MockProvider([
+            '<!-- JUDGE_RESULT_START -->\n'
+            '{"score": 0.96, "reasoning": "Both sections satisfy their target audience.", '
+            '"dimensions": {"technical_depth": 0.97, "child_accessibility": 0.95}}\n'
+            '<!-- JUDGE_RESULT_END -->'
+        ])
+        task = SimpleAgentTask(
+            task_prompt="Explain quantum entanglement",
+            rubric=(
+                "Must be at graduate physics seminar depth AND accessible to a 5-year-old. "
+                "Score technical_depth and child_accessibility 0-1 each."
+            ),
+            provider=provider,
+        )
+        result = task.evaluate_output(
+            "## For a Five-Year-Old\nImagine two magic coins.\n\n"
+            "## Graduate Seminar Treatment\nConsider Hilbert spaces and Bell inequalities.",
+            {},
+        )
+        assert result.score <= 0.25
+        assert "separate sections" in result.reasoning.lower()
+
     def test_revise_output(self):
         provider = _MockProvider([_judge_response(0.5, "needs work"), "Revised content"])
         task = SimpleAgentTask(task_prompt="Write something", rubric="Quality", provider=provider)


### PR DESCRIPTION
## Summary

This PR fixes AC-552 by making the Python judge fail closed on contradictory same-span rubrics instead of rewarding section-splitting escape hatches. When a rubric simultaneously demands graduate-seminar technical depth and 5-year-old accessibility, the judge now detects the contradiction, penalizes implausibly high dual-pass scores, and keeps the improve loop below threshold.

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/execution/judge.py src/autocontext/execution/rubric_coherence.py tests/test_rubric_coherence.py tests/test_judge.py tests/test_task_runner.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_rubric_coherence.py tests/test_judge.py tests/test_task_runner.py -k 'contradictory or same_span or dual_section_escape' -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Additional automated coverage:
- `cd autocontext && uv run pytest tests/test_rubric_coherence.py tests/test_judge.py tests/test_task_runner.py tests/test_improvement_loop.py tests/test_cli_agent_task.py tests/test_providers.py -k 'judge or improve or task_runner or rubric or contradictory or threshold' -x --tb=short`
  - `144 passed, 24 deselected`

Manual / live verification:
- `cd autocontext && uv run autoctx improve -p "Explain quantum entanglement" -r "Must be at graduate physics seminar depth AND accessible to a 5-year-old. Score technical_depth and child_accessibility 0-1 each." -n 2 -t 0.9 --provider claude-cli --json`
  - result on this branch: `best_score: 0.28`, `met_threshold: false`
- `cd autocontext && uv run autoctx judge ... --provider claude-cli --json` against a deliberately split dual-section answer
  - result on this branch: `score: 0.42`
  - `technical_depth` was capped to `0.25`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- AC-552 / AC-49 reopen: the fix stays in the Python judge bounded context rather than loosening improve thresholds downstream.
- `rubric_coherence.py` now flags the graduate-depth vs child-accessibility contradiction explicitly.
- `judge.py` adds a contradiction guardrail that caps implausibly high scores when the model appears to satisfy incompatible demands in separate sections instead of one coherent span.
- Added regression coverage in `tests/test_rubric_coherence.py`, `tests/test_judge.py`, and `tests/test_task_runner.py`.
- This PR is intentionally scoped to the Python path because the issue evidence was on Python judge/improve behavior.
