### PR TITLE
fix: add judge timeout overrides for cli runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,11 @@ Run with Claude CLI:
 cd autocontext
 AUTOCONTEXT_AGENT_PROVIDER=claude-cli \
 AUTOCONTEXT_CLAUDE_MODEL=sonnet \
+AUTOCONTEXT_CLAUDE_TIMEOUT=300 \
 uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
 ```
+
+For longer `autoctx judge` / `autoctx improve` prompts on `claude-cli`, use `--timeout <seconds>` or set `AUTOCONTEXT_CLAUDE_TIMEOUT`.
 
 Run with Codex CLI:
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -81,8 +81,11 @@ Run with Claude CLI (`claude -p` via a local authenticated Claude Code runtime):
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=claude-cli \
 AUTOCONTEXT_CLAUDE_MODEL=sonnet \
+AUTOCONTEXT_CLAUDE_TIMEOUT=300 \
 uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
 ```
+
+For longer `autoctx judge` / `autoctx improve` prompts on `claude-cli`, use `--timeout <seconds>` or set `AUTOCONTEXT_CLAUDE_TIMEOUT`.
 
 Run with Codex CLI (`codex exec` via a local authenticated Codex runtime):
 

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -294,6 +294,8 @@ Key environment variables:
 | `AUTOCONTEXT_JUDGE_API_KEY` | API key for the judge provider |
 | `AUTOCONTEXT_JUDGE_BASE_URL` | Base URL for OpenAI-compatible judge endpoints |
 | `AUTOCONTEXT_JUDGE_MODEL` | Override judge model name |
+| `AUTOCONTEXT_CLAUDE_MODEL` | Claude CLI model alias (default: `sonnet`) |
+| `AUTOCONTEXT_CLAUDE_TIMEOUT` | Claude CLI execution timeout in seconds (default: 120) |
 | `AUTOCONTEXT_MODEL_COMPETITOR` | Override competitor agent model |
 | `AUTOCONTEXT_DB_PATH` | SQLite database path |
 | `AUTOCONTEXT_PI_COMMAND` | Path to Pi CLI binary (default: `pi`) |

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -10,7 +10,7 @@ import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import typer
 import uvicorn
@@ -23,6 +23,7 @@ from autocontext.config.presets import VALID_PRESET_NAMES
 from autocontext.config.settings import AppSettings
 from autocontext.execution.improvement_loop import ImprovementLoop
 from autocontext.loop.generation_runner import GenerationRunner
+from autocontext.providers.base import ProviderError
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.agent_task import AgentTaskInterface
 from autocontext.storage import ArtifactStore, SQLiteStore, artifact_store_from_settings
@@ -161,6 +162,83 @@ def _check_json_exit(result: dict[str, Any]) -> None:
     """Raise SystemExit(1) if JSON result has status=failed (AC-520)."""
     if isinstance(result, dict) and result.get("status") == "failed":
         raise SystemExit(1)
+
+
+def _runtime_timeout_field_for_provider(provider_name: str) -> str | None:
+    provider = provider_name.strip().lower()
+    if provider == "claude-cli":
+        return "claude_timeout"
+    if provider == "codex":
+        return "codex_timeout"
+    if provider in {"pi", "pi-rpc"}:
+        return "pi_timeout"
+    return None
+
+
+def _apply_judge_runtime_overrides(
+    settings: AppSettings,
+    *,
+    provider_name: str = "",
+    model: str = "",
+    timeout: float | None = None,
+) -> AppSettings:
+    updates: dict[str, Any] = {}
+    if provider_name:
+        updates["judge_provider"] = provider_name
+    if model:
+        updates["judge_model"] = model
+
+    resolved_provider = (provider_name or settings.judge_provider).strip().lower()
+    timeout_field = _runtime_timeout_field_for_provider(resolved_provider)
+    if timeout is not None and timeout_field:
+        updates[timeout_field] = timeout
+
+    if not updates:
+        return settings
+    return settings.model_copy(update=updates)
+
+
+def _format_runtime_provider_error(
+    exc: ProviderError,
+    *,
+    provider_name: str,
+    settings: AppSettings,
+) -> str:
+    message = str(exc)
+    if "timeout" not in message.lower():
+        return message
+
+    provider = provider_name.strip().lower()
+    timeout_help = {
+        "claude-cli": ("Claude CLI", settings.claude_timeout, "AUTOCONTEXT_CLAUDE_TIMEOUT"),
+        "codex": ("Codex CLI", settings.codex_timeout, "AUTOCONTEXT_CODEX_TIMEOUT"),
+        "pi": ("Pi CLI", settings.pi_timeout, "AUTOCONTEXT_PI_TIMEOUT"),
+        "pi-rpc": ("Pi RPC", settings.pi_timeout, "AUTOCONTEXT_PI_TIMEOUT"),
+    }
+    help_details = timeout_help.get(provider)
+    if help_details is None:
+        return message
+
+    label, configured_timeout, env_var = help_details
+    return (
+        f"{label} timed out after {configured_timeout:.0f}s. "
+        f"Retry with --timeout <seconds> or set {env_var}. Original error: {message}"
+    )
+
+
+def _exit_provider_error(
+    exc: ProviderError,
+    *,
+    provider_name: str,
+    settings: AppSettings,
+    json_output: bool,
+) -> NoReturn:
+    message = _format_runtime_provider_error(exc, provider_name=provider_name, settings=settings)
+    if json_output:
+        _write_json_stderr(message)
+    else:
+        console.print(f"[red]{message}[/red]")
+    raise typer.Exit(code=1) from exc
 
 
 def _is_agent_task(scenario_name: str) -> bool:
@@ -1431,25 +1509,41 @@ def judge(
     rubric: str = typer.Option(..., "--rubric", "-r", help="Evaluation rubric"),
     provider: str = typer.Option("", "--provider", help="Provider override"),
     model: str = typer.Option("", "--model", help="Model override"),
+    timeout: float | None = typer.Option(
+        None,
+        "--timeout",
+        min=1.0,
+        help="Override runtime timeout in seconds for CLI-backed providers",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
 ) -> None:
     """One-shot evaluation of agent output against a rubric."""
     from autocontext.execution.judge import LLMJudge
 
-    settings = load_settings()
-    if provider:
-        settings = settings.model_copy(update={"judge_provider": provider})
-    if model:
-        settings = settings.model_copy(update={"judge_model": model})
-
-    from autocontext.providers.registry import get_provider
-    judge_provider = get_provider(settings)
-    llm_judge = LLMJudge(
-        provider=judge_provider,
-        model=settings.judge_model,
-        rubric=rubric,
+    settings = _apply_judge_runtime_overrides(
+        load_settings(),
+        provider_name=provider,
+        model=model,
+        timeout=timeout,
     )
-    result = llm_judge.evaluate(task_prompt=task_prompt, agent_output=output)
+
+    try:
+        from autocontext.providers.registry import get_provider
+
+        judge_provider = get_provider(settings)
+        llm_judge = LLMJudge(
+            provider=judge_provider,
+            model=settings.judge_model,
+            rubric=rubric,
+        )
+        result = llm_judge.evaluate(task_prompt=task_prompt, agent_output=output)
+    except ProviderError as exc:
+        _exit_provider_error(
+            exc,
+            provider_name=settings.judge_provider,
+            settings=settings,
+            json_output=json_output,
+        )
 
     if json_output:
         _write_json_stdout({
@@ -1470,6 +1564,12 @@ def improve(
     max_rounds: int = typer.Option(5, "--rounds", "-n", help="Maximum improvement rounds"),
     threshold: float = typer.Option(0.9, "--threshold", "-t", help="Quality threshold to stop"),
     provider_override: str = typer.Option("", "--provider", help="Provider override"),
+    timeout: float | None = typer.Option(
+        None,
+        "--timeout",
+        min=1.0,
+        help="Override runtime timeout in seconds for CLI-backed providers",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
 ) -> None:
     """Run multi-round improvement loop on agent output.
@@ -1481,25 +1581,35 @@ def improve(
     from autocontext.execution.task_runner import SimpleAgentTask
     from autocontext.providers.registry import get_provider as get_judge_provider
 
-    settings = load_settings()
-    if provider_override:
-        settings = settings.model_copy(update={"judge_provider": provider_override})
+    settings = _apply_judge_runtime_overrides(
+        load_settings(),
+        provider_name=provider_override,
+        timeout=timeout,
+    )
 
-    provider = get_judge_provider(settings)
-    task = SimpleAgentTask(
-        task_prompt=task_prompt,
-        rubric=rubric,
-        provider=provider,
-        model=settings.judge_model,
-    )
-    state = task.initial_state()
-    loop = ImprovementLoop(
-        task=task,
-        max_rounds=max_rounds,
-        quality_threshold=threshold,
-    )
-    starting_output = initial_output or task.generate_output(state)
-    result = loop.run(initial_output=starting_output, state=state)
+    try:
+        provider = get_judge_provider(settings)
+        task = SimpleAgentTask(
+            task_prompt=task_prompt,
+            rubric=rubric,
+            provider=provider,
+            model=settings.judge_model,
+        )
+        state = task.initial_state()
+        loop = ImprovementLoop(
+            task=task,
+            max_rounds=max_rounds,
+            quality_threshold=threshold,
+        )
+        starting_output = initial_output or task.generate_output(state)
+        result = loop.run(initial_output=starting_output, state=state)
+    except ProviderError as exc:
+        _exit_provider_error(
+            exc,
+            provider_name=settings.judge_provider,
+            settings=settings,
+            json_output=json_output,
+        )
 
     if json_output:
         _write_json_stdout({

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -18,6 +18,10 @@ from rich.console import Console
 from rich.table import Table
 
 from autocontext.agents.orchestrator import AgentOrchestrator
+from autocontext.cli_runtime_overrides import (
+    apply_judge_runtime_overrides,
+    format_runtime_provider_error,
+)
 from autocontext.config import load_settings
 from autocontext.config.presets import VALID_PRESET_NAMES
 from autocontext.config.settings import AppSettings
@@ -164,68 +168,6 @@ def _check_json_exit(result: dict[str, Any]) -> None:
         raise SystemExit(1)
 
 
-def _runtime_timeout_field_for_provider(provider_name: str) -> str | None:
-    provider = provider_name.strip().lower()
-    if provider == "claude-cli":
-        return "claude_timeout"
-    if provider == "codex":
-        return "codex_timeout"
-    if provider in {"pi", "pi-rpc"}:
-        return "pi_timeout"
-    return None
-
-
-def _apply_judge_runtime_overrides(
-    settings: AppSettings,
-    *,
-    provider_name: str = "",
-    model: str = "",
-    timeout: float | None = None,
-) -> AppSettings:
-    updates: dict[str, Any] = {}
-    if provider_name:
-        updates["judge_provider"] = provider_name
-    if model:
-        updates["judge_model"] = model
-
-    resolved_provider = (provider_name or settings.judge_provider).strip().lower()
-    timeout_field = _runtime_timeout_field_for_provider(resolved_provider)
-    if timeout is not None and timeout_field:
-        updates[timeout_field] = timeout
-
-    if not updates:
-        return settings
-    return settings.model_copy(update=updates)
-
-
-def _format_runtime_provider_error(
-    exc: ProviderError,
-    *,
-    provider_name: str,
-    settings: AppSettings,
-) -> str:
-    message = str(exc)
-    if "timeout" not in message.lower():
-        return message
-
-    provider = provider_name.strip().lower()
-    timeout_help = {
-        "claude-cli": ("Claude CLI", settings.claude_timeout, "AUTOCONTEXT_CLAUDE_TIMEOUT"),
-        "codex": ("Codex CLI", settings.codex_timeout, "AUTOCONTEXT_CODEX_TIMEOUT"),
-        "pi": ("Pi CLI", settings.pi_timeout, "AUTOCONTEXT_PI_TIMEOUT"),
-        "pi-rpc": ("Pi RPC", settings.pi_timeout, "AUTOCONTEXT_PI_TIMEOUT"),
-    }
-    help_details = timeout_help.get(provider)
-    if help_details is None:
-        return message
-
-    label, configured_timeout, env_var = help_details
-    return (
-        f"{label} timed out after {configured_timeout:.0f}s. "
-        f"Retry with --timeout <seconds> or set {env_var}. Original error: {message}"
-    )
-
-
 def _exit_provider_error(
     exc: ProviderError,
     *,
@@ -233,7 +175,7 @@ def _exit_provider_error(
     settings: AppSettings,
     json_output: bool,
 ) -> NoReturn:
-    message = _format_runtime_provider_error(exc, provider_name=provider_name, settings=settings)
+    message = format_runtime_provider_error(exc, provider_name=provider_name, settings=settings)
     if json_output:
         _write_json_stderr(message)
     else:
@@ -1520,7 +1462,7 @@ def judge(
     """One-shot evaluation of agent output against a rubric."""
     from autocontext.execution.judge import LLMJudge
 
-    settings = _apply_judge_runtime_overrides(
+    settings = apply_judge_runtime_overrides(
         load_settings(),
         provider_name=provider,
         model=model,
@@ -1581,7 +1523,7 @@ def improve(
     from autocontext.execution.task_runner import SimpleAgentTask
     from autocontext.providers.registry import get_provider as get_judge_provider
 
-    settings = _apply_judge_runtime_overrides(
+    settings = apply_judge_runtime_overrides(
         load_settings(),
         provider_name=provider_override,
         timeout=timeout,

--- a/autocontext/src/autocontext/cli_runtime_overrides.py
+++ b/autocontext/src/autocontext/cli_runtime_overrides.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any
+
+from autocontext.config.settings import AppSettings
+from autocontext.providers.base import ProviderError
+
+
+def runtime_timeout_field_for_provider(provider_name: str) -> str | None:
+    provider = provider_name.strip().lower()
+    if provider == "claude-cli":
+        return "claude_timeout"
+    if provider == "codex":
+        return "codex_timeout"
+    if provider in {"pi", "pi-rpc"}:
+        return "pi_timeout"
+    return None
+
+
+def apply_judge_runtime_overrides(
+    settings: AppSettings,
+    *,
+    provider_name: str = "",
+    model: str = "",
+    timeout: float | None = None,
+) -> AppSettings:
+    updates: dict[str, Any] = {}
+    if provider_name:
+        updates["judge_provider"] = provider_name
+    if model:
+        updates["judge_model"] = model
+
+    resolved_provider = (provider_name or settings.judge_provider).strip().lower()
+    timeout_field = runtime_timeout_field_for_provider(resolved_provider)
+    if timeout is not None and timeout_field:
+        updates[timeout_field] = timeout
+
+    if not updates:
+        return settings
+    return settings.model_copy(update=updates)
+
+
+def format_runtime_provider_error(
+    exc: ProviderError,
+    *,
+    provider_name: str,
+    settings: AppSettings,
+) -> str:
+    message = str(exc)
+    if "timeout" not in message.lower():
+        return message
+
+    provider = provider_name.strip().lower()
+    timeout_help = {
+        "claude-cli": ("Claude CLI", settings.claude_timeout, "AUTOCONTEXT_CLAUDE_TIMEOUT"),
+        "codex": ("Codex CLI", settings.codex_timeout, "AUTOCONTEXT_CODEX_TIMEOUT"),
+        "pi": ("Pi CLI", settings.pi_timeout, "AUTOCONTEXT_PI_TIMEOUT"),
+        "pi-rpc": ("Pi RPC", settings.pi_timeout, "AUTOCONTEXT_PI_TIMEOUT"),
+    }
+    help_details = timeout_help.get(provider)
+    if help_details is None:
+        return message
+
+    label, configured_timeout, env_var = help_details
+    return (
+        f"{label} timed out after {configured_timeout:.0f}s. "
+        f"Retry with --timeout <seconds> or set {env_var}. Original error: {message}"
+    )

--- a/autocontext/src/autocontext/providers/registry.py
+++ b/autocontext/src/autocontext/providers/registry.py
@@ -160,6 +160,7 @@ def get_provider(settings: AppSettings) -> LLMProvider:
         pi_rpc_runtime = PiRPCRuntime(PiRPCConfig(
             pi_command=settings.pi_command,
             model=settings.pi_model or settings.judge_model,
+            timeout=settings.pi_timeout,
             session_persistence=settings.pi_rpc_session_persistence,
         ))
         return RuntimeBridgeProvider(

--- a/autocontext/tests/test_cli_runtime_timeout_overrides.py
+++ b/autocontext/tests/test_cli_runtime_timeout_overrides.py
@@ -8,8 +8,10 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from autocontext.cli import app
+from autocontext.cli_runtime_overrides import apply_judge_runtime_overrides
 from autocontext.config.settings import AppSettings
 from autocontext.providers.base import CompletionResult, ProviderError
+from autocontext.providers.registry import get_provider
 
 runner = CliRunner()
 
@@ -195,3 +197,13 @@ class TestImproveRuntimeTimeoutOverrides:
         assert "timed out" in payload["error"].lower()
         assert "--timeout" in payload["error"]
         assert "AUTOCONTEXT_CLAUDE_TIMEOUT" in payload["error"]
+
+
+class TestPiRpcRuntimeTimeoutOverrides:
+    def test_pi_rpc_provider_uses_runtime_timeout_override(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path).model_copy(update={"judge_provider": "pi-rpc"})
+        overridden = apply_judge_runtime_overrides(settings, timeout=300.0)
+
+        provider = get_provider(overridden)
+
+        assert provider._runtime._config.timeout == 300.0  # type: ignore[attr-defined]

--- a/autocontext/tests/test_cli_runtime_timeout_overrides.py
+++ b/autocontext/tests/test_cli_runtime_timeout_overrides.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+from autocontext.config.settings import AppSettings
+from autocontext.providers.base import CompletionResult, ProviderError
+
+runner = CliRunner()
+
+
+class _RecordingProvider:
+    def __init__(self, text: str = "generated output") -> None:
+        self._text = text
+        self.calls: list[dict[str, object]] = []
+
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        **_: object,
+    ) -> CompletionResult:
+        self.calls.append(
+            {
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "model": model,
+            }
+        )
+        return CompletionResult(text=self._text, model=model)
+
+    def default_model(self) -> str:
+        return "recording-model"
+
+
+class _TimeoutProvider:
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        **_: object,
+    ) -> CompletionResult:
+        del system_prompt, user_prompt, model
+        raise ProviderError("ClaudeCLIRuntime failed: timeout")
+
+    def default_model(self) -> str:
+        return "claude-cli"
+
+
+class _FakeLoopResult:
+    def __init__(self) -> None:
+        self.best_score = 0.91
+        self.best_round = 1
+        self.total_rounds = 1
+        self.met_threshold = True
+        self.best_output = "generated output"
+
+
+class _FakeJudge:
+    def __init__(self, *, provider, model: str, rubric: str, **_: object) -> None:
+        self.provider = provider
+        self.model = model
+        self.rubric = rubric
+
+    def evaluate(self, *, task_prompt: str, agent_output: str, **_: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            score=0.82,
+            reasoning=f"judged {task_prompt} -> {agent_output}",
+            dimension_scores={"quality": 0.82},
+        )
+
+
+def _settings(tmp_path: Path) -> AppSettings:
+    return AppSettings(
+        db_path=tmp_path / "runs" / "autocontext.sqlite3",
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / ".claude" / "skills",
+        judge_provider="anthropic",
+        judge_model="judge-default",
+        claude_model="sonnet",
+        claude_timeout=120.0,
+    )
+
+
+class TestJudgeRuntimeTimeoutOverrides:
+    def test_judge_applies_timeout_override_to_claude_cli_provider(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+        captured: dict[str, AppSettings] = {}
+
+        def _fake_get_provider(current: AppSettings) -> _RecordingProvider:
+            captured["settings"] = current
+            return _RecordingProvider()
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.providers.registry.get_provider", side_effect=_fake_get_provider),
+            patch("autocontext.execution.judge.LLMJudge", _FakeJudge),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "judge",
+                    "-p",
+                    "Explain entanglement",
+                    "-o",
+                    "output",
+                    "-r",
+                    "Score quality 0-1.",
+                    "--provider",
+                    "claude-cli",
+                    "--timeout",
+                    "300",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["score"] == 0.82
+        assert captured["settings"].judge_provider == "claude-cli"
+        assert captured["settings"].claude_timeout == 300.0
+
+
+class TestImproveRuntimeTimeoutOverrides:
+    def test_improve_applies_timeout_override_to_claude_cli_provider(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+        captured: dict[str, AppSettings] = {}
+        provider = _RecordingProvider()
+
+        def _fake_get_provider(current: AppSettings) -> _RecordingProvider:
+            captured["settings"] = current
+            return provider
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.providers.registry.get_provider", side_effect=_fake_get_provider),
+            patch("autocontext.execution.improvement_loop.ImprovementLoop") as mock_loop,
+        ):
+            mock_loop.return_value.run.return_value = _FakeLoopResult()
+            result = runner.invoke(
+                app,
+                [
+                    "improve",
+                    "-p",
+                    "Draft a trial design",
+                    "-r",
+                    "Score rigor 0-1.",
+                    "--provider",
+                    "claude-cli",
+                    "--timeout",
+                    "300",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["best_score"] == 0.91
+        assert captured["settings"].judge_provider == "claude-cli"
+        assert captured["settings"].claude_timeout == 300.0
+        assert provider.calls[0]["user_prompt"] == "Draft a trial design"
+
+    def test_improve_timeout_error_mentions_timeout_override(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.providers.registry.get_provider", return_value=_TimeoutProvider()),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "improve",
+                    "-p",
+                    "List 5 peer-reviewed studies with DOIs",
+                    "-r",
+                    "Score factual_accuracy 0-1.",
+                    "--provider",
+                    "claude-cli",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stderr)
+        assert "timed out" in payload["error"].lower()
+        assert "--timeout" in payload["error"]
+        assert "AUTOCONTEXT_CLAUDE_TIMEOUT" in payload["error"]


### PR DESCRIPTION
## Summary

This PR fixes AC-553 by adding explicit runtime timeout overrides to the Python `autoctx judge` and `autoctx improve` commands when they run through CLI-backed judge providers like `claude-cli`. It also replaces the previous opaque timeout traceback with a clean operator-facing error that points users to `--timeout <seconds>` or `AUTOCONTEXT_CLAUDE_TIMEOUT`.

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [x] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/cli.py tests/test_cli_runtime_timeout_overrides.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_cli_runtime_timeout_overrides.py -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Additional automated coverage:
- `cd autocontext && uv run pytest tests/test_cli_runtime_timeout_overrides.py tests/test_runtimes.py tests/test_per_role_provider.py tests/test_task_runner.py tests/test_cli_agent_task.py -k 'timeout or provider or improve or judge or generate_output or runtime' -x --tb=short`
  - `64 passed, 55 deselected`

Manual / live verification:
- `cd autocontext && uv run autoctx improve -p "Reply with exactly OK." -r "Score exact_match 0-1." -n 1 -t 0.9 --provider claude-cli --timeout 300 --json`
  - command succeeds with the new `--timeout` flag accepted
- `cd autocontext && uv run autoctx improve -p "Design a Phase II clinical trial for a novel SGLT2 inhibitor in T2D patients." -r "Score statistical_rigor, regulatory_fit, ethics 0-1." -n 1 -t 0.9 --provider claude-cli --timeout 300 --json`
  - AC-553-style complex prompt completed successfully
- `cd autocontext && uv run autoctx improve -p "List 5 specific peer-reviewed studies from 2023 showing effects of caffeine on prefrontal cortex activity in adolescents, with DOIs." -r "Score factual_accuracy, citation_completeness, relevance. 0-1 each." -n 1 -t 0.9 --provider claude-cli --timeout 1 --json`
  - timeout failure now returns a clean hint mentioning both `--timeout` and `AUTOCONTEXT_CLAUDE_TIMEOUT`

## Docs And Release Impact

- [ ] no user-facing docs changes needed
- [x] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- AC-553 is scoped to the Python CLI bounded context for judge/improve runtime timeout handling.
- `autocontext/src/autocontext/cli.py` now applies provider/model/timeout overrides through a shared helper before resolving the judge provider.
- Timeout-related `ProviderError`s are translated into user-facing CLI errors instead of raw internal tracebacks.
- Added focused regression coverage in `autocontext/tests/test_cli_runtime_timeout_overrides.py`.
- Updated `README.md`, `autocontext/README.md`, and `autocontext/docs/agent-integration.md` to document `AUTOCONTEXT_CLAUDE_TIMEOUT` and the `--timeout` guidance.
