### PR TITLE
fix: bootstrap list on fresh workspaces

### DIFF
--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -528,7 +528,7 @@ def list_runs(
     """List recent runs."""
 
     settings = load_settings()
-    store = SQLiteStore(settings.db_path)
+    store = _sqlite_from_settings(settings)
     rows = store.list_runs(limit=20)
 
     if json_output:
@@ -562,13 +562,8 @@ def status(
     """Show generation status for a run."""
 
     settings = load_settings()
-    store = SQLiteStore(settings.db_path)
-    with store.connect() as conn:
-        rows = conn.execute(
-            "SELECT generation_index, mean_score, best_score, elo, wins, losses, gate_decision, status "
-            "FROM generations WHERE run_id = ? ORDER BY generation_index ASC",
-            (run_id,),
-        ).fetchall()
+    store = _sqlite_from_settings(settings)
+    rows = store.run_status(run_id)
 
     if json_output:
         generations = []

--- a/autocontext/tests/test_cli_json.py
+++ b/autocontext/tests/test_cli_json.py
@@ -177,6 +177,17 @@ class TestListJson:
         data = json.loads(result.output.strip())
         assert data == []
 
+    def test_list_json_bootstraps_fresh_workspace(self, tmp_path: Path) -> None:
+        """list --json should not crash when the workspace DB has never been initialized."""
+        settings = _make_settings(tmp_path)
+
+        with patch("autocontext.cli.load_settings", return_value=settings):
+            result = runner.invoke(app, ["list", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output.strip())
+        assert data == []
+
     def test_list_json_populated(self, tmp_path: Path) -> None:
         """list --json with seeded runs should return list of dicts."""
         settings = _make_settings(tmp_path)
@@ -259,6 +270,17 @@ class TestStatusJson:
         data = json.loads(result.output.strip())
         assert data["run_id"] == "run-empty"
         assert data["generations"] == []
+
+    def test_status_json_bootstraps_fresh_workspace(self, tmp_path: Path) -> None:
+        """status --json should not crash before the workspace DB is initialized."""
+        settings = _make_settings(tmp_path)
+
+        with patch("autocontext.cli.load_settings", return_value=settings):
+            result = runner.invoke(app, ["status", "missing-run", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output.strip())
+        assert data == {"run_id": "missing-run", "generations": []}
 
     def test_status_json_is_valid_json(self, tmp_path: Path) -> None:
         """status --json output should be parseable as JSON without error."""


### PR DESCRIPTION
## Summary

This PR fixes AC-554 by making Python run-catalog read commands bootstrap cleanly on a brand-new workspace instead of crashing on missing SQLite tables. `autoctx list` and `autoctx status` now go through the shared SQLite bootstrap path, so a fresh workspace behaves like an empty catalog rather than raising `OperationalError: no such table: runs`.

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/cli.py tests/test_cli_json.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_cli_json.py tests/test_sqlite_store_bootstrap.py tests/test_service_layer.py -k 'list or status or bootstrap' -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Automated results:
- `21 passed, 24 deselected`

Manual / live verification:
- `AUTOCONTEXT_DB_PATH=/tmp/.../runs/autocontext.sqlite3 uv run autoctx list --json`
  - returned `[]`
- `AUTOCONTEXT_DB_PATH=/tmp/.../runs/autocontext.sqlite3 uv run autoctx status missing-run --json`
  - returned `{"run_id":"missing-run","generations":[]}`
- confirmed no `OperationalError: no such table: runs` on a fresh workspace

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- The fix is intentionally scoped to the Python CLI read path for fresh-workspace introspection.
- `autocontext/src/autocontext/cli.py`
  - `list` now uses `_sqlite_from_settings(settings)` instead of a raw `SQLiteStore(settings.db_path)` path
  - `status` now uses the same bootstrap helper and the shared `store.run_status(...)` query service instead of ad hoc SQL
- Added regression coverage in `autocontext/tests/test_cli_json.py` for both fresh-workspace `list --json` and `status --json` behavior.
- No breaking changes expected.
