### PR TITLE
fix: let simulate accept provider override

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ The Python package exposes the full `autoctx` control-plane CLI for scenario exe
 - Hand the harness a task in plain language: `uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3`
 - Run and improve a saved scenario: `uv run autoctx run --scenario support_triage --gens 3`
 - Inspect or replay outputs: `uv run autoctx list`, `uv run autoctx status <run_id>`
+- Override the simulation provider per call: `uv run autoctx simulate -d "simulate deploying a web service with rollback" --provider claude-cli`
 - Scaffold a custom scenario: `uv run autoctx new-scenario --template prompt-optimization --name my-task`
 - Export training data: `uv run autoctx export-training-data --scenario support_triage --all-runs --output training/support_triage.jsonl`
 - Train a local model: `uv run autoctx train --scenario support_triage --data training/support_triage.jsonl --time-budget 300`

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -103,7 +103,7 @@ AUTOCONTEXT_PI_COMMAND=pi \
 uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
 ```
 
-`autoctx simulate` now follows the effective architect-role runtime surface, so `AUTOCONTEXT_ARCHITECT_PROVIDER` and other role-routing overrides apply to live simulation generation as well.
+`autoctx simulate` now follows the effective architect-role runtime surface, so `AUTOCONTEXT_ARCHITECT_PROVIDER`, other role-routing overrides, and per-call `--provider <name>` overrides all apply to live simulation generation.
 
 Run with Pi RPC (remote Pi agent via HTTP):
 
@@ -143,6 +143,7 @@ uv run autoctx mcp-serve
 ```bash
 uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
 uv run autoctx simulate --description "simulate deploying a web service with rollback"
+uv run autoctx simulate --description "simulate deploying a web service with rollback" --provider claude-cli
 uv run autoctx simulate --replay deploy_sim --variables threshold=0.9
 uv run autoctx list
 uv run autoctx status <run_id>

--- a/autocontext/src/autocontext/agents/llm_client.py
+++ b/autocontext/src/autocontext/agents/llm_client.py
@@ -626,6 +626,7 @@ def build_client_from_settings(
 
         rpc_config = PiRPCConfig(
             pi_command=settings.pi_command,
+            timeout=settings.pi_timeout,
             session_persistence=settings.pi_rpc_session_persistence,
         )
         return RuntimeBridgeClient(PiRPCRuntime(rpc_config))

--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -336,6 +336,7 @@ def create_role_client(
 
         rpc_config = PiRPCConfig(
             pi_command=settings.pi_command,
+            timeout=settings.pi_timeout,
             session_persistence=settings.pi_rpc_session_persistence,
         )
         return RuntimeBridgeClient(PiRPCRuntime(rpc_config))

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -221,16 +221,6 @@ def _wrap_role_client_as_provider(
     return CallableProvider(_llm_fn, model_name=resolved_model), resolved_model
 
 
-def _apply_simulation_runtime_overrides(
-    settings: AppSettings,
-    *,
-    provider_name: str = "",
-) -> AppSettings:
-    if not provider_name:
-        return settings
-    return settings.model_copy(update={"agent_provider": provider_name, "architect_provider": provider_name})
-
-
 def _resolve_simulation_runtime(settings: AppSettings) -> tuple[LLMProvider, str]:
     """Resolve the architect-style runtime used for simulation spec generation.
 
@@ -1110,10 +1100,11 @@ def simulate(
     """Run a plain-language simulation with sweeps and analysis."""
     from autocontext.simulation.engine import SimulationEngine
 
-    settings = _apply_simulation_runtime_overrides(
-        load_settings(),
-        provider_name=provider_override,
-    )
+    settings = load_settings()
+    if provider_override:
+        settings = settings.model_copy(
+            update={"agent_provider": provider_override, "architect_provider": provider_override},
+        )
 
     if bool(compare_left) != bool(compare_right):
         console.print("[red]--compare-left and --compare-right must be provided together[/red]")

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -221,6 +221,16 @@ def _wrap_role_client_as_provider(
     return CallableProvider(_llm_fn, model_name=resolved_model), resolved_model
 
 
+def _apply_simulation_runtime_overrides(
+    settings: AppSettings,
+    *,
+    provider_name: str = "",
+) -> AppSettings:
+    if not provider_name:
+        return settings
+    return settings.model_copy(update={"agent_provider": provider_name, "architect_provider": provider_name})
+
+
 def _resolve_simulation_runtime(settings: AppSettings) -> tuple[LLMProvider, str]:
     """Resolve the architect-style runtime used for simulation spec generation.
 
@@ -1091,6 +1101,7 @@ def simulate(
     compare_right: str = typer.Option("", "--compare-right", help="Right simulation for comparison"),
     export_id: str = typer.Option("", "--export", help="Export a saved simulation"),
     export_format: str = typer.Option("json", "--format", help="Export format: json, markdown, csv"),
+    provider_override: str = typer.Option("", "--provider", help="Provider override"),
     runs: int = typer.Option(1, "--runs", min=1, help="Number of runs"),
     max_steps: int = typer.Option(0, "--max-steps", help="Max steps per run (0 = auto)"),
     save_as: str = typer.Option("", "--save-as", help="Name for saved simulation"),
@@ -1099,7 +1110,10 @@ def simulate(
     """Run a plain-language simulation with sweeps and analysis."""
     from autocontext.simulation.engine import SimulationEngine
 
-    settings = load_settings()
+    settings = _apply_simulation_runtime_overrides(
+        load_settings(),
+        provider_name=provider_override,
+    )
 
     if bool(compare_left) != bool(compare_right):
         console.print("[red]--compare-left and --compare-right must be provided together[/red]")

--- a/autocontext/tests/test_cli_simulate_runtime.py
+++ b/autocontext/tests/test_cli_simulate_runtime.py
@@ -133,6 +133,35 @@ class TestSimulateRuntimeResolution:
             "role": "architect",
         }]
 
+    def test_simulate_provider_flag_overrides_architect_runtime(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path, agent_provider="anthropic", architect_provider="pi")
+        client = _RecordingClient(text='{"spec": "provider-override"}')
+        orchestrator = _FakeOrchestrator(client, "claude-cli-architect")
+        captured_settings: list[AppSettings] = []
+
+        def _capture_from_settings(current: AppSettings, **_: object) -> _FakeOrchestrator:
+            captured_settings.append(current)
+            return orchestrator
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._sqlite_from_settings", return_value=object()),
+            patch("autocontext.cli._artifacts_from_settings", return_value=object()),
+            patch("autocontext.cli.AgentOrchestrator.from_settings", side_effect=_capture_from_settings),
+            patch("autocontext.simulation.engine.SimulationEngine", _FakeSimulationEngine),
+        ):
+            result = runner.invoke(
+                app,
+                ["simulate", "--description", "provider override test", "--provider", "claude-cli", "--json"],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["provider_text"] == '{"spec": "provider-override"}'
+        assert len(captured_settings) == 1
+        assert captured_settings[0].architect_provider == "claude-cli"
+        assert captured_settings[0].agent_provider == "claude-cli"
+
     def test_simulate_uses_resolved_architect_model(self, tmp_path: Path) -> None:
         settings = _settings(
             tmp_path,

--- a/autocontext/tests/test_pi_provider_surface.py
+++ b/autocontext/tests/test_pi_provider_surface.py
@@ -118,9 +118,10 @@ class TestPiRPCProvider:
         assert isinstance(client, RuntimeBridgeClient)
 
     def test_pi_rpc_passes_config_from_settings(self) -> None:
-        """Pi RPC config should use settings values for session_persistence."""
+        """Pi RPC config should use settings values for runtime config."""
         settings = _settings(
             agent_provider="pi-rpc",
+            pi_timeout=90.0,
             pi_rpc_session_persistence=False,
         )
         with patch("autocontext.runtimes.pi_rpc.PiRPCRuntime") as MockRuntime:
@@ -128,6 +129,7 @@ class TestPiRPCProvider:
             build_client_from_settings(settings)
         call_args = MockRuntime.call_args
         config = call_args[0][0] if call_args[0] else call_args[1].get("config")
+        assert config.timeout == 90.0
         assert config.session_persistence is False
         assert config.pi_command == "pi"
 

--- a/autocontext/tests/test_pi_rpc.py
+++ b/autocontext/tests/test_pi_rpc.py
@@ -142,8 +142,10 @@ def test_revise_success() -> None:
 
 def test_create_role_client_pi_rpc() -> None:
     """create_role_client('pi-rpc') should return a RuntimeBridgeClient."""
-    settings = AppSettings()
+    settings = AppSettings(pi_timeout=240.0)
     with patch("autocontext.runtimes.pi_rpc.PiRPCRuntime") as MockRuntime:
         MockRuntime.return_value = MagicMock()
         client = create_role_client("pi-rpc", settings)
     assert isinstance(client, RuntimeBridgeClient)
+    config = MockRuntime.call_args.args[0]
+    assert config.timeout == 240.0


### PR DESCRIPTION
## Summary

This PR makes Python `autoctx simulate` accept a per-call `--provider` override,
bringing it into parity with sibling prompt-style CLI surfaces. Simulation
provider overrides now route through the architect-runtime path instead of
failing at CLI parsing. Fixes AC-555.

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [x] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/cli.py tests/test_cli_simulate_runtime.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_cli_simulate_runtime.py tests/test_per_role_provider.py -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

### Manual verification

- Reproduced the original failure:
  - `uv run autoctx simulate ... --provider claude-cli`
  - prior behavior: `No such option: --provider`
- Verified live success after the fix:
  - `uv run autoctx simulate -d "simulate a deploy pipeline with 3 stages: build, test, deploy. Add a rollback path if any stage fails." --provider claude-cli --json`
  - completed successfully with `status: "completed"`

## Docs And Release Impact

- [ ] no user-facing docs changes needed
- [x] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- `simulate` already resolves through the architect runtime surface via the orchestrator.
- The important nuance is that the per-call override must update both `agent_provider`
  and `architect_provider`; setting only the architect role was not sufficient because
  `AgentOrchestrator.from_settings(...)` still constructs a base client from the top-level
  provider settings.
- Added regression coverage for the provider override path in
  `autocontext/tests/test_cli_simulate_runtime.py`.
- Updated root and package READMEs with the new `simulate --provider <name>` usage.
