### PR TITLE
fix: route geopolitical crisis prompts to simulation

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -104,6 +104,17 @@ _SIMULATION_SIGNALS: dict[str, float] = {
     "server log": 1.0,
     "root cause": 1.0,
     "investigat": 1.0,  # investigate, investigation
+    "geopolit": 2.0,
+    "national security": 2.0,
+    "diplomat": 1.5,
+    "public communication": 1.5,
+    "alliance": 1.5,
+    "multilateral": 1.5,
+    "international crisis": 2.0,
+    "international confrontation": 2.0,
+    "hidden adversary": 2.0,
+    "escalation threshold": 1.5,
+    "statecraft": 1.5,
 }
 
 # Agent task: evaluate output quality via LLM judge

--- a/autocontext/src/autocontext/simulation/helpers.py
+++ b/autocontext/src/autocontext/simulation/helpers.py
@@ -8,8 +8,9 @@ import types
 from typing import Any
 
 _OPERATOR_LOOP_FAMILY_TRIGGERS = re.compile(
-    r"escalat|operator|human.in.the.loop|clarif|ambiguous|"
-    r"incomplete.input|ask.*question|missing.information|gather.more.info"
+    r"operator|human[- .]?in[- .]?the[- .]?loop|clarif|approval.required|"
+    r"ask.*question|missing.information|gather.more.info|"
+    r"when.to.escalat|over-escalat|under-escalat|triage.judgment"
 )
 
 
@@ -46,9 +47,21 @@ def find_scenario_class(mod: types.ModuleType) -> type | None:
 
 
 def infer_family(description: str) -> str:
-    if _OPERATOR_LOOP_FAMILY_TRIGGERS.search(description.lower()):
+    text_lower = description.lower()
+
+    if _OPERATOR_LOOP_FAMILY_TRIGGERS.search(text_lower):
         return "operator_loop"
-    return "simulation"
+
+    try:
+        from autocontext.scenarios.custom.family_classifier import (
+            classify_scenario_family,
+            route_to_family,
+        )
+
+        family = route_to_family(classify_scenario_family(description), 0.15).name
+        return "operator_loop" if family == "operator_loop" else "simulation"
+    except Exception:
+        return "simulation"
 
 
 def aggregate_contract_signal_counts(results: list[dict[str, Any]]) -> dict[str, int]:

--- a/autocontext/src/autocontext/simulation/helpers.py
+++ b/autocontext/src/autocontext/simulation/helpers.py
@@ -9,7 +9,7 @@ from typing import Any
 
 _OPERATOR_LOOP_FAMILY_TRIGGERS = re.compile(
     r"operator|human[- .]?in[- .]?the[- .]?loop|clarif|approval.required|"
-    r"ask.*question|missing.information|gather.more.info|"
+    r"ambiguous|incomplete.input|ask.*question|missing.information|gather.more.info|"
     r"when.to.escalat|over-escalat|under-escalat|triage.judgment"
 )
 

--- a/autocontext/tests/test_family_classifier.py
+++ b/autocontext/tests/test_family_classifier.py
@@ -119,6 +119,16 @@ class TestClassifySimulation:
         )
         assert result.family_name == "simulation"
 
+    def test_geopolitical_crisis_routes_to_simulation(self) -> None:
+        result = classify_scenario_family(
+            "Create a geopolitical crisis simulation where a national security advisor manages "
+            "an escalating international confrontation using diplomatic, economic, military, "
+            "intelligence, public communication, alliance, UN, humanitarian, and cyber actions "
+            "under hidden adversary objectives and escalation thresholds."
+        )
+        assert result.family_name == "simulation"
+        assert result.confidence >= 0.3
+
 
 class TestClassifyArtifactEditing:
     def test_config_editing(self) -> None:

--- a/autocontext/tests/test_simulation_helpers.py
+++ b/autocontext/tests/test_simulation_helpers.py
@@ -19,3 +19,7 @@ class TestInferFamily:
             "and wait for approval before acting on ambiguous support tickets."
         )
         assert family == "operator_loop"
+
+    def test_routes_clarification_only_prompts_to_operator_loop(self) -> None:
+        assert infer_family("Handle requests with incomplete inputs before acting") == "operator_loop"
+        assert infer_family("Handle ambiguous support tickets safely before acting") == "operator_loop"

--- a/autocontext/tests/test_simulation_helpers.py
+++ b/autocontext/tests/test_simulation_helpers.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from autocontext.simulation.helpers import infer_family
+
+
+class TestInferFamily:
+    def test_routes_geopolitical_crisis_to_simulation(self) -> None:
+        family = infer_family(
+            "Simulate a geopolitical crisis where a national security advisor manages "
+            "an escalating international confrontation using diplomatic, economic, military, "
+            "intelligence, public communication, alliance, UN, humanitarian, and cyber actions "
+            "under hidden adversary objectives and escalation thresholds."
+        )
+        assert family == "simulation"
+
+    def test_keeps_explicit_operator_loop_prompts_on_operator_loop(self) -> None:
+        family = infer_family(
+            "Simulate when an agent should escalate to a human operator, request clarification, "
+            "and wait for approval before acting on ambiguous support tickets."
+        )
+        assert family == "operator_loop"

--- a/ts/src/scenarios/family-classifier-signals.ts
+++ b/ts/src/scenarios/family-classifier-signals.ts
@@ -34,6 +34,17 @@ const SIMULATION_SIGNALS: Record<string, number> = {
   "server log": 1.0,
   "root cause": 1.0,
   investigat: 1.0,
+  geopolit: 2.0,
+  "national security": 2.0,
+  diplomat: 1.5,
+  "public communication": 1.5,
+  alliance: 1.5,
+  multilateral: 1.5,
+  "international crisis": 2.0,
+  "international confrontation": 2.0,
+  "hidden adversary": 2.0,
+  "escalation threshold": 1.5,
+  statecraft: 1.5,
 };
 
 const AGENT_TASK_SIGNALS: Record<string, number> = {

--- a/ts/tests/new-scenario-broader-family-materialization.test.ts
+++ b/ts/tests/new-scenario-broader-family-materialization.test.ts
@@ -196,6 +196,68 @@ const STRESS_CASES: StressCase[] = [
     },
   },
   {
+    issueId: "AC-276",
+    prompt:
+      "Create a geopolitical crisis simulation where a national security advisor manages an escalating international crisis using diplomatic, economic, military, intelligence, public communication, alliance, UN, and cyber actions under hidden adversary intentions and escalation thresholds.",
+    expectedFamily: "simulation",
+    expectedPromptFragment: "produce a SimulationSpec JSON",
+    responseText: [
+      SIM_SPEC_START,
+      JSON.stringify(
+        {
+          description: "Geopolitical crisis management under hidden adversary intentions",
+          environment_description:
+            "A multi-actor international crisis with military posture shifts, alliance politics, economic pressure, cyber disruptions, public narratives, and uncertain escalation thresholds.",
+          initial_state_description:
+            "A cross-border confrontation is intensifying, allied governments are asking for coordination, adversary intentions are partially hidden, and each move can change escalation risk.",
+          success_criteria: [
+            "Stabilize the confrontation without triggering uncontrolled escalation.",
+            "Sequence diplomatic, economic, military, intelligence, and cyber actions coherently.",
+          ],
+          failure_modes: [
+            "Escalate the crisis through poorly coordinated signaling.",
+            "Ignore hidden adversary intentions and misread the confrontation.",
+          ],
+          max_steps: 10,
+          actions: [
+            {
+              name: "update_intelligence_picture",
+              description:
+                "Refresh the intelligence picture to estimate adversary intent, readiness, and escalation thresholds.",
+              parameters: { collection_focus: "string" },
+              preconditions: [],
+              effects: ["intelligence_picture_updated"],
+            },
+            {
+              name: "open_backchannel_contact",
+              description:
+                "Use diplomatic outreach to clarify intent, test red lines, and create de-escalation options.",
+              parameters: { counterpart: "string" },
+              preconditions: ["update_intelligence_picture"],
+              effects: ["backchannel_opened"],
+            },
+            {
+              name: "synchronize_allied_response",
+              description:
+                "Coordinate military, economic, and public messaging options with allies and multilateral partners.",
+              parameters: { coalition_goal: "string" },
+              preconditions: ["open_backchannel_contact"],
+              effects: ["allied_response_synchronized"],
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      SIM_SPEC_END,
+    ].join("\n"),
+    assertPersistedSpec: (spec) => {
+      expect(spec.scenario_type).toBe("simulation");
+      expect(Array.isArray(spec.actions)).toBe(true);
+      expect((spec.actions as unknown[]).length).toBeGreaterThanOrEqual(3);
+    },
+  },
+  {
     issueId: "AC-550-workflow",
     prompt:
       "Create a transactional workflow scenario with compensation and side effects across payment capture, inventory reservation, and customer notification.",

--- a/ts/tests/unified-classifier.test.ts
+++ b/ts/tests/unified-classifier.test.ts
@@ -50,6 +50,11 @@ describe("classifyScenarioFamily (sophisticated)", () => {
       expected: "operator_loop",
     },
     {
+      description:
+        "Create a geopolitical crisis simulation where a national security advisor manages an escalating international crisis using diplomatic, economic, military, intelligence, public communication, alliance, UN, and cyber actions under hidden adversary intentions and escalation thresholds.",
+      expected: "simulation",
+    },
+    {
       description: "Coordinate multiple agents with partial context doing handoffs and merges",
       expected: "coordination",
     },
@@ -110,6 +115,13 @@ describe("detectScenarioFamily routes all custom-scenario families (AC-437)", ()
       "Coordinate multiple agents with partial context doing handoffs and merge operations",
     );
     expect(family).toBe("coordination");
+  });
+
+  it("routes the AC-276 geopolitical crisis stress prompt to simulation", () => {
+    const family = detectScenarioFamily(
+      "Create a geopolitical crisis simulation where a national security advisor manages an escalating international crisis using diplomatic, economic, military, intelligence, public communication, alliance, UN, and cyber actions under hidden adversary intentions and escalation thresholds.",
+    );
+    expect(family).toBe("simulation");
   });
 
   // These 6 families already work — regression guard


### PR DESCRIPTION
## Summary

This PR fixes AC-549 by preventing geopolitical crisis / statecraft prompts from
collapsing into the narrower `operator_loop` family. Python `simulate` and
TypeScript `new-scenario` now route AC-276-style geopolitical crisis prompts to
`simulation`, while still preserving explicit operator-loop prompts as
`operator_loop`.

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/scenarios/custom/family_classifier.py src/autocontext/simulation/helpers.py tests/test_family_classifier.py tests/test_simulation_helpers.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_family_classifier.py tests/test_simulation_helpers.py tests/test_operator_loop_unsupported.py tests/test_negotiation.py tests/test_simulate_command.py -k 'family or infer_family or negotiation or operator_loop or simulation' -x --tb=short`
- [x] `cd ts && npm run lint`
- [x] `cd ts && npm test -- unified-classifier.test.ts scenario-creator-family-aware.test.ts new-scenario-broader-family-materialization.test.ts new-scenario-command-workflow.test.ts new-scenario-created-materialization.test.ts new-scenario-materialization-execution.test.ts agent-task-pipeline.test.ts materialize-codegen-planning.test.ts execution-validator.test.ts`
- [x] additional manual verification described below

### Manual verification

Python live rerun:
- `AUTOCONTEXT_AGENT_PROVIDER=pi AUTOCONTEXT_JUDGE_PROVIDER=pi AUTOCONTEXT_PI_COMMAND=pi uv run autoctx simulate --description "Simulate a geopolitical crisis where a national security advisor manages an escalating international confrontation using diplomatic, economic, military, intelligence, public communication, alliance, UN, humanitarian, and cyber actions under hidden adversary objectives and escalation thresholds." --runs 1 --json`
- artifact: `/tmp/ac549-py-live-dTitQj/result.json`
- result: `family: "simulation"`, `status: "completed"`

TypeScript live rerun:
- `AUTOCONTEXT_AGENT_PROVIDER=pi AUTOCONTEXT_KNOWLEDGE_ROOT=/tmp/ac549-ts-live3-7Ok2I5/knowledge node dist/cli/index.js new-scenario --description "Create a geopolitical crisis simulation where a national security advisor manages an escalating international crisis using diplomatic, economic, military, intelligence, public communication, alliance, UN, and cyber actions under hidden adversary intentions and escalation thresholds." --json`
- artifacts:
  - `/tmp/ac549-ts-live3-7Ok2I5/result.json`
  - `/tmp/ac549-ts-live3-7Ok2I5/knowledge/_custom_scenarios/create_geopolitical_crisis_simulation/spec.json`
- result: `family: "simulation"`, `persisted: true`, `generatedSource: true`, persisted `scenario_type: "simulation"`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- Python classifier now includes explicit geopolitical crisis / statecraft signals so broader crisis-management prompts outweigh generic escalation wording.
- Python `infer_family(...)` now keeps an explicit operator-loop fast path for true human-oversight prompts, then delegates broader routing to the weighted family classifier for simulation-vs-operator decisions.
- TypeScript classifier received matching geopolitical crisis signals for parity, plus regression coverage for AC-276-style `new-scenario` materialization.
- Scope is intentionally limited to routing fidelity; no scenario-family contract semantics or docs surfaces were changed.
- Fixes AC-549.
