### PR TITLE
fix: add investigate surface and generation fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 autocontext runs LLM agents through structured scenarios, evaluates their outputs, and accumulates the knowledge that improved results — so repeated runs get better, not just different. Point the harness at a real task in plain language, let it work the problem, and then inspect the traces, reports, artifacts, datasets, playbooks, and optional distilled model it produces.
 
 <!-- autocontext-whats-new:start -->
-
 ## What's New
 
 - All 11 scenario families executable in both Python and TypeScript

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 autocontext runs LLM agents through structured scenarios, evaluates their outputs, and accumulates the knowledge that improved results — so repeated runs get better, not just different. Point the harness at a real task in plain language, let it work the problem, and then inspect the traces, reports, artifacts, datasets, playbooks, and optional distilled model it produces.
 
 <!-- autocontext-whats-new:start -->
+
 ## What's New
 
 - All 11 scenario families executable in both Python and TypeScript
@@ -238,6 +239,7 @@ The Python package exposes the full `autoctx` control-plane CLI for scenario exe
 - Hand the harness a task in plain language: `uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3`
 - Run and improve a saved scenario: `uv run autoctx run --scenario support_triage --gens 3`
 - Inspect or replay outputs: `uv run autoctx list`, `uv run autoctx status <run_id>`
+- Run an investigation from Python: `uv run autoctx investigate -d "why did conversion drop after Tuesday's release"`
 - Override the simulation provider per call: `uv run autoctx simulate -d "simulate deploying a web service with rollback" --provider claude-cli`
 - Scaffold a custom scenario: `uv run autoctx new-scenario --template prompt-optimization --name my-task`
 - Export training data: `uv run autoctx export-training-data --scenario support_triage --all-runs --output training/support_triage.jsonl`
@@ -248,7 +250,6 @@ The Python package exposes the full `autoctx` control-plane CLI for scenario exe
 Representative TypeScript operator workflows:
 
 - Run a simulation: `npx autoctx simulate -d "simulate deploying a web service with rollback"`
-- Run an investigation: `npx autoctx investigate -d "why did conversion drop after Tuesday's release"`
 - Analyze an artifact: `npx autoctx analyze --id deploy_sim --type simulation`
 - Operate a mission: `npx autoctx mission create --name "Ship login" --goal "Implement OAuth"`
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -32,13 +32,13 @@ The Python package is the full control-plane surface in this repo. It currently 
 
 - generation-loop execution via `autoctx run`
 - plain-language simulation via `autoctx simulate`
+- plain-language investigation via `autoctx investigate`
 - local training workflows via `autoctx export-training-data` and `autoctx train`
 - scenario creation and materialization via `autoctx new-scenario`
 - HTTP API and MCP server surfaces via `autoctx serve` and `autoctx mcp-serve`
 
 Some newer operator-facing surfaces are currently TypeScript-first:
 
-- `autoctx investigate`
 - `autoctx analyze`
 - the interactive terminal UI via `npx autoctx tui`
 
@@ -105,6 +105,8 @@ uv run autoctx solve --description "improve customer-support replies for billing
 
 `autoctx simulate` now follows the effective architect-role runtime surface, so `AUTOCONTEXT_ARCHITECT_PROVIDER`, other role-routing overrides, and per-call `--provider <name>` overrides all apply to live simulation generation.
 
+`autoctx investigate` now ships as a first-class Python CLI surface as well. It uses the architect runtime for investigation-spec synthesis and the analyst runtime for hypothesis generation, so role-routing overrides apply there too.
+
 Run with Pi RPC (remote Pi agent via HTTP):
 
 ```bash
@@ -144,6 +146,7 @@ uv run autoctx mcp-serve
 uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
 uv run autoctx simulate --description "simulate deploying a web service with rollback"
 uv run autoctx simulate --description "simulate deploying a web service with rollback" --provider claude-cli
+uv run autoctx investigate --description "why did conversion drop after Tuesday's release"
 uv run autoctx simulate --replay deploy_sim --variables threshold=0.9
 uv run autoctx list
 uv run autoctx status <run_id>
@@ -265,7 +268,7 @@ autocontext exposes:
 - [Agent integration guide](docs/agent-integration.md) — CLI-first integration for external agents, MCP fallback, JSON output reference
 - [Sandbox modes](docs/sandbox.md)
 - [MLX host training](docs/mlx-training.md)
-- [TypeScript package guide](../ts/README.md) — `investigate`, `analyze`, and interactive TUI surfaces
+- [TypeScript package guide](../ts/README.md) — `analyze`, mission control, and interactive TUI surfaces
 - [Demo data notes](demo_data/README.md)
 - [Copy-paste examples](../examples/README.md)
 - [Change history](../CHANGELOG.md)

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -221,36 +221,61 @@ def _wrap_role_client_as_provider(
     return CallableProvider(_llm_fn, model_name=resolved_model), resolved_model
 
 
+def _role_default_model(settings: AppSettings, role: str) -> str:
+    role_models = {
+        "competitor": settings.model_competitor,
+        "analyst": settings.model_analyst,
+        "architect": settings.model_architect,
+        "coach": settings.model_coach,
+        "curator": settings.model_curator,
+        "translator": settings.model_translator,
+    }
+    return role_models.get(role) or settings.agent_default_model
+
+
+def _resolve_role_runtime(
+    settings: AppSettings,
+    *,
+    role: str,
+    scenario_name: str = "",
+) -> tuple[LLMProvider, str]:
+    sqlite = _sqlite_from_settings(settings)
+    artifacts = _artifacts_from_settings(settings)
+    orchestrator = AgentOrchestrator.from_settings(settings, artifacts=artifacts, sqlite=sqlite)
+    client, model = orchestrator.resolve_role_execution(
+        role,
+        generation=1,
+        scenario_name=scenario_name,
+    )
+    resolved_model = model or _role_default_model(settings, role)
+    return _wrap_role_client_as_provider(client, resolved_model, role=role)
+
+
 def _resolve_simulation_runtime(settings: AppSettings) -> tuple[LLMProvider, str]:
     """Resolve the architect-style runtime used for simulation spec generation.
 
     Simulations are authoring/spec-generation tasks, so they should follow the
     configured architect runtime surface rather than the judge provider.
     """
-    sqlite = _sqlite_from_settings(settings)
-    artifacts = _artifacts_from_settings(settings)
-    orchestrator = AgentOrchestrator.from_settings(settings, artifacts=artifacts, sqlite=sqlite)
-    client, model = orchestrator.resolve_role_execution(
-        "architect",
-        generation=1,
-        scenario_name="",
-    )
-    resolved_model = model or settings.model_architect or settings.agent_default_model
-    return _wrap_role_client_as_provider(client, resolved_model, role="architect")
+    return _resolve_role_runtime(settings, role="architect")
+
+
+def _resolve_investigation_runtime(
+    settings: AppSettings,
+    *,
+    role: str,
+) -> tuple[LLMProvider, str]:
+    """Resolve investigation runtimes through role routing.
+
+    Investigation spec synthesis is an architect-style authoring task, while
+    hypothesis generation is an analyst-style interpretation task.
+    """
+    return _resolve_role_runtime(settings, role=role)
 
 
 def _resolve_agent_task_runtime(settings: AppSettings, scenario_name: str) -> tuple[LLMProvider, str]:
     """Resolve the effective competitor runtime for direct agent-task execution."""
-    sqlite = _sqlite_from_settings(settings)
-    artifacts = _artifacts_from_settings(settings)
-    orchestrator = AgentOrchestrator.from_settings(settings, artifacts=artifacts, sqlite=sqlite)
-    client, model = orchestrator.resolve_role_execution(
-        "competitor",
-        generation=1,
-        scenario_name=scenario_name,
-    )
-    resolved_model = model or settings.model_competitor or settings.agent_default_model
-    return _wrap_role_client_as_provider(client, resolved_model, role="competitor")
+    return _resolve_role_runtime(settings, role="competitor", scenario_name=scenario_name)
 
 
 def _run_agent_task(
@@ -1230,6 +1255,83 @@ def simulate(
         for w in result.get("warnings", []):
             console.print(f"  ⚠ {w}")
         console.print(f"\nArtifacts: {result['artifacts']['scenario_dir']}")
+
+
+@app.command()
+def investigate(
+    description: str = typer.Option("", "--description", "-d", help="Plain-language problem to investigate"),
+    max_steps: int = typer.Option(8, "--max-steps", min=1, help="Maximum investigation steps"),
+    hypotheses: int = typer.Option(5, "--hypotheses", min=1, help="Maximum hypotheses to generate"),
+    save_as: str = typer.Option("", "--save-as", help="Name for the saved investigation"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """Run a plain-language investigation with evidence and hypotheses."""
+    from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
+
+    if not description:
+        message = "--description is required. Run 'autoctx investigate --help' for usage."
+        if json_output:
+            _write_json_stderr(message)
+        else:
+            console.print(f"[red]{message}[/red]")
+        raise typer.Exit(code=1)
+
+    settings = load_settings()
+    spec_provider, spec_model = _resolve_investigation_runtime(settings, role="architect")
+    analysis_provider, analysis_model = _resolve_investigation_runtime(settings, role="analyst")
+
+    def _spec_llm_fn(system: str, user: str) -> str:
+        result = spec_provider.complete(system, user, model=spec_model)
+        return result.text
+
+    def _analysis_llm_fn(system: str, user: str) -> str:
+        result = analysis_provider.complete(system, user, model=analysis_model)
+        return result.text
+
+    engine = InvestigationEngine(
+        spec_llm_fn=_spec_llm_fn,
+        analysis_llm_fn=_analysis_llm_fn,
+        knowledge_root=settings.knowledge_root,
+    )
+    result = engine.run(
+        InvestigationRequest(
+            description=description,
+            max_steps=max_steps,
+            max_hypotheses=hypotheses,
+            save_as=save_as or None,
+        )
+    )
+    payload = result.to_dict()
+
+    if json_output:
+        _write_json_stdout(payload)
+        _check_json_exit(payload)
+        return
+
+    if result.status == "failed":
+        console.print(f"[red]Investigation failed:[/red] {result.error or 'unknown error'}")
+        raise typer.Exit(code=1)
+
+    console.print(f"[bold]Investigation:[/bold] {result.name}")
+    console.print(f"Question: {result.question}")
+    console.print("\n[dim]Hypotheses:[/dim]")
+    for hypothesis in result.hypotheses:
+        icon = "✓" if hypothesis.status == "supported" else "✗" if hypothesis.status == "contradicted" else "?"
+        console.print(
+            f"  {icon} {hypothesis.statement} "
+            f"(confidence: {hypothesis.confidence:.2f}, {hypothesis.status})"
+        )
+    console.print(f"\nConclusion: {result.conclusion.best_explanation}")
+    console.print(f"Confidence: {result.conclusion.confidence:.2f}")
+    if result.unknowns:
+        console.print("\n[dim]Unknowns:[/dim]")
+        for unknown in result.unknowns:
+            console.print(f"  - {unknown}")
+    if result.recommended_next_steps:
+        console.print("\n[dim]Next steps:[/dim]")
+        for step in result.recommended_next_steps:
+            console.print(f"  → {step}")
+    console.print(f"\nArtifacts: {result.artifacts.investigation_dir}")
 
 
 @app.command()

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -18,6 +18,8 @@ from rich.console import Console
 from rich.table import Table
 
 from autocontext.agents.orchestrator import AgentOrchestrator
+from autocontext.cli_investigate import run_investigate_command
+from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.cli_runtime_overrides import (
     apply_judge_runtime_overrides,
     format_runtime_provider_error,
@@ -36,7 +38,6 @@ from autocontext.util.json_io import read_json, write_json
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from autocontext.agents.llm_client import LanguageModelClient
     from autocontext.providers.base import LLMProvider
     from autocontext.training.runner import TrainingConfig, TrainingResult
 
@@ -195,62 +196,6 @@ def _is_agent_task(scenario_name: str) -> bool:
     return issubclass(family.interface_class, AgentTaskInterface)
 
 
-def _wrap_role_client_as_provider(
-    client: LanguageModelClient,
-    resolved_model: str,
-    *,
-    role: str,
-) -> tuple[LLMProvider, str]:
-    """Adapt a resolved LanguageModelClient into an LLMProvider-compatible callable.
-
-    This keeps prompt-only workflows like simulate aligned with the same runtime
-    bridge used by role-driven execution without duplicating the generate() glue.
-    """
-    from autocontext.providers.callable_wrapper import CallableProvider
-
-    def _llm_fn(system_prompt: str, user_prompt: str) -> str:
-        response = client.generate(
-            model=resolved_model,
-            prompt=f"{system_prompt}\n\n{user_prompt}" if system_prompt else user_prompt,
-            max_tokens=4096,
-            temperature=0.0,
-            role=role,
-        )
-        return response.text
-
-    return CallableProvider(_llm_fn, model_name=resolved_model), resolved_model
-
-
-def _role_default_model(settings: AppSettings, role: str) -> str:
-    role_models = {
-        "competitor": settings.model_competitor,
-        "analyst": settings.model_analyst,
-        "architect": settings.model_architect,
-        "coach": settings.model_coach,
-        "curator": settings.model_curator,
-        "translator": settings.model_translator,
-    }
-    return role_models.get(role) or settings.agent_default_model
-
-
-def _resolve_role_runtime(
-    settings: AppSettings,
-    *,
-    role: str,
-    scenario_name: str = "",
-) -> tuple[LLMProvider, str]:
-    sqlite = _sqlite_from_settings(settings)
-    artifacts = _artifacts_from_settings(settings)
-    orchestrator = AgentOrchestrator.from_settings(settings, artifacts=artifacts, sqlite=sqlite)
-    client, model = orchestrator.resolve_role_execution(
-        role,
-        generation=1,
-        scenario_name=scenario_name,
-    )
-    resolved_model = model or _role_default_model(settings, role)
-    return _wrap_role_client_as_provider(client, resolved_model, role=role)
-
-
 def _resolve_simulation_runtime(settings: AppSettings) -> tuple[LLMProvider, str]:
     """Resolve the architect-style runtime used for simulation spec generation.
 
@@ -260,16 +205,27 @@ def _resolve_simulation_runtime(settings: AppSettings) -> tuple[LLMProvider, str
     return _resolve_role_runtime(settings, role="architect")
 
 
+def _resolve_role_runtime(
+    settings: AppSettings,
+    *,
+    role: str,
+    scenario_name: str = "",
+) -> tuple[LLMProvider, str]:
+    return resolve_role_runtime(
+        settings,
+        role=role,
+        scenario_name=scenario_name,
+        sqlite=_sqlite_from_settings(settings),
+        artifacts=_artifacts_from_settings(settings),
+        orchestrator_cls=AgentOrchestrator,
+    )
+
+
 def _resolve_investigation_runtime(
     settings: AppSettings,
     *,
     role: str,
 ) -> tuple[LLMProvider, str]:
-    """Resolve investigation runtimes through role routing.
-
-    Investigation spec synthesis is an architect-style authoring task, while
-    hypothesis generation is an analyst-style interpretation task.
-    """
     return _resolve_role_runtime(settings, role=role)
 
 
@@ -1266,72 +1222,19 @@ def investigate(
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
     """Run a plain-language investigation with evidence and hypotheses."""
-    from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
-
-    if not description:
-        message = "--description is required. Run 'autoctx investigate --help' for usage."
-        if json_output:
-            _write_json_stderr(message)
-        else:
-            console.print(f"[red]{message}[/red]")
-        raise typer.Exit(code=1)
-
-    settings = load_settings()
-    spec_provider, spec_model = _resolve_investigation_runtime(settings, role="architect")
-    analysis_provider, analysis_model = _resolve_investigation_runtime(settings, role="analyst")
-
-    def _spec_llm_fn(system: str, user: str) -> str:
-        result = spec_provider.complete(system, user, model=spec_model)
-        return result.text
-
-    def _analysis_llm_fn(system: str, user: str) -> str:
-        result = analysis_provider.complete(system, user, model=analysis_model)
-        return result.text
-
-    engine = InvestigationEngine(
-        spec_llm_fn=_spec_llm_fn,
-        analysis_llm_fn=_analysis_llm_fn,
-        knowledge_root=settings.knowledge_root,
+    run_investigate_command(
+        description=description,
+        max_steps=max_steps,
+        hypotheses=hypotheses,
+        save_as=save_as,
+        json_output=json_output,
+        console=console,
+        load_settings_fn=load_settings,
+        resolve_investigation_runtime=_resolve_investigation_runtime,
+        write_json_stdout=_write_json_stdout,
+        write_json_stderr=_write_json_stderr,
+        check_json_exit=_check_json_exit,
     )
-    result = engine.run(
-        InvestigationRequest(
-            description=description,
-            max_steps=max_steps,
-            max_hypotheses=hypotheses,
-            save_as=save_as or None,
-        )
-    )
-    payload = result.to_dict()
-
-    if json_output:
-        _write_json_stdout(payload)
-        _check_json_exit(payload)
-        return
-
-    if result.status == "failed":
-        console.print(f"[red]Investigation failed:[/red] {result.error or 'unknown error'}")
-        raise typer.Exit(code=1)
-
-    console.print(f"[bold]Investigation:[/bold] {result.name}")
-    console.print(f"Question: {result.question}")
-    console.print("\n[dim]Hypotheses:[/dim]")
-    for hypothesis in result.hypotheses:
-        icon = "✓" if hypothesis.status == "supported" else "✗" if hypothesis.status == "contradicted" else "?"
-        console.print(
-            f"  {icon} {hypothesis.statement} "
-            f"(confidence: {hypothesis.confidence:.2f}, {hypothesis.status})"
-        )
-    console.print(f"\nConclusion: {result.conclusion.best_explanation}")
-    console.print(f"Confidence: {result.conclusion.confidence:.2f}")
-    if result.unknowns:
-        console.print("\n[dim]Unknowns:[/dim]")
-        for unknown in result.unknowns:
-            console.print(f"  - {unknown}")
-    if result.recommended_next_steps:
-        console.print("\n[dim]Next steps:[/dim]")
-        for step in result.recommended_next_steps:
-            console.print(f"  → {step}")
-    console.print(f"\nArtifacts: {result.artifacts.investigation_dir}")
 
 
 @app.command()

--- a/autocontext/src/autocontext/cli_investigate.py
+++ b/autocontext/src/autocontext/cli_investigate.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Protocol
+
+import typer
+
+from autocontext.config.settings import AppSettings
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+    from autocontext.providers.base import LLMProvider
+
+
+class InvestigationRuntimeResolver(Protocol):
+    def __call__(self, settings: AppSettings, *, role: str) -> tuple[LLMProvider, str]: ...
+
+
+def run_investigate_command(
+    *,
+    description: str,
+    max_steps: int,
+    hypotheses: int,
+    save_as: str,
+    json_output: bool,
+    console: Console,
+    load_settings_fn: Callable[[], AppSettings],
+    resolve_investigation_runtime: InvestigationRuntimeResolver,
+    write_json_stdout: Callable[[object], None],
+    write_json_stderr: Callable[[str], None],
+    check_json_exit: Callable[[dict[str, Any]], None],
+) -> None:
+    from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
+
+    if not description:
+        message = "--description is required. Run 'autoctx investigate --help' for usage."
+        if json_output:
+            write_json_stderr(message)
+        else:
+            console.print(f"[red]{message}[/red]")
+        raise typer.Exit(code=1)
+
+    settings = load_settings_fn()
+    spec_provider, spec_model = resolve_investigation_runtime(settings, role="architect")
+    analysis_provider, analysis_model = resolve_investigation_runtime(settings, role="analyst")
+
+    def _spec_llm_fn(system: str, user: str) -> str:
+        result = spec_provider.complete(system, user, model=spec_model)
+        return result.text
+
+    def _analysis_llm_fn(system: str, user: str) -> str:
+        result = analysis_provider.complete(system, user, model=analysis_model)
+        return result.text
+
+    engine = InvestigationEngine(
+        spec_llm_fn=_spec_llm_fn,
+        analysis_llm_fn=_analysis_llm_fn,
+        knowledge_root=settings.knowledge_root,
+    )
+    result = engine.run(
+        InvestigationRequest(
+            description=description,
+            max_steps=max_steps,
+            max_hypotheses=hypotheses,
+            save_as=save_as or None,
+        )
+    )
+    payload = result.to_dict()
+
+    if json_output:
+        write_json_stdout(payload)
+        check_json_exit(payload)
+        return
+
+    if result.status == "failed":
+        console.print(f"[red]Investigation failed:[/red] {result.error or 'unknown error'}")
+        raise typer.Exit(code=1)
+
+    console.print(f"[bold]Investigation:[/bold] {result.name}")
+    console.print(f"Question: {result.question}")
+    console.print("\n[dim]Hypotheses:[/dim]")
+    for hypothesis in result.hypotheses:
+        icon = "\u2713" if hypothesis.status == "supported" else "\u2717" if hypothesis.status == "contradicted" else "?"
+        console.print(
+            f"  {icon} {hypothesis.statement} "
+            f"(confidence: {hypothesis.confidence:.2f}, {hypothesis.status})"
+        )
+    console.print(f"\nConclusion: {result.conclusion.best_explanation}")
+    console.print(f"Confidence: {result.conclusion.confidence:.2f}")
+    if result.unknowns:
+        console.print("\n[dim]Unknowns:[/dim]")
+        for unknown in result.unknowns:
+            console.print(f"  - {unknown}")
+    if result.recommended_next_steps:
+        console.print("\n[dim]Next steps:[/dim]")
+        for step in result.recommended_next_steps:
+            console.print(f"  \u2192 {step}")
+    console.print(f"\nArtifacts: {result.artifacts.investigation_dir}")

--- a/autocontext/src/autocontext/cli_role_runtime.py
+++ b/autocontext/src/autocontext/cli_role_runtime.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from autocontext.agents.orchestrator import AgentOrchestrator
+from autocontext.config.settings import AppSettings
+from autocontext.storage import SQLiteStore, artifact_store_from_settings
+
+if TYPE_CHECKING:
+    from autocontext.agents.llm_client import LanguageModelClient
+    from autocontext.providers.base import LLMProvider
+
+
+def _sqlite_from_settings(settings: AppSettings) -> SQLiteStore:
+    sqlite = SQLiteStore(settings.db_path)
+    sqlite.migrate(Path(__file__).resolve().parents[2] / "migrations")
+    return sqlite
+
+
+def _role_default_model(settings: AppSettings, role: str) -> str:
+    role_models = {
+        "competitor": settings.model_competitor,
+        "analyst": settings.model_analyst,
+        "architect": settings.model_architect,
+        "coach": settings.model_coach,
+        "curator": settings.model_curator,
+        "translator": settings.model_translator,
+    }
+    return role_models.get(role) or settings.agent_default_model
+
+
+def _wrap_role_client_as_provider(
+    client: LanguageModelClient,
+    resolved_model: str,
+    *,
+    role: str,
+) -> tuple[LLMProvider, str]:
+    from autocontext.providers.callable_wrapper import CallableProvider
+
+    def _llm_fn(system_prompt: str, user_prompt: str) -> str:
+        response = client.generate(
+            model=resolved_model,
+            prompt=f"{system_prompt}\n\n{user_prompt}" if system_prompt else user_prompt,
+            max_tokens=4096,
+            temperature=0.0,
+            role=role,
+        )
+        return response.text
+
+    return CallableProvider(_llm_fn, model_name=resolved_model), resolved_model
+
+
+def resolve_role_runtime(
+    settings: AppSettings,
+    *,
+    role: str,
+    scenario_name: str = "",
+    sqlite: Any | None = None,
+    artifacts: Any | None = None,
+    orchestrator_cls: Any = AgentOrchestrator,
+) -> tuple[LLMProvider, str]:
+    resolved_sqlite = sqlite if sqlite is not None else _sqlite_from_settings(settings)
+    resolved_artifacts = (
+        artifacts
+        if artifacts is not None
+        else artifact_store_from_settings(
+            settings,
+            enable_buffered_writes=True,
+        )
+    )
+    orchestrator = orchestrator_cls.from_settings(settings, artifacts=resolved_artifacts, sqlite=resolved_sqlite)
+    client, model = orchestrator.resolve_role_execution(
+        role,
+        generation=1,
+        scenario_name=scenario_name,
+    )
+    resolved_model = model or _role_default_model(settings, role)
+    return _wrap_role_client_as_provider(client, resolved_model, role=role)

--- a/autocontext/src/autocontext/investigation/__init__.py
+++ b/autocontext/src/autocontext/investigation/__init__.py
@@ -1,0 +1,27 @@
+from autocontext.investigation.engine import (
+    InvestigationArtifacts,
+    InvestigationConclusion,
+    InvestigationEngine,
+    InvestigationEvidence,
+    InvestigationHypothesis,
+    InvestigationRequest,
+    InvestigationResult,
+    derive_investigation_name,
+    generate_investigation_id,
+    normalize_positive_integer,
+    parse_investigation_json,
+)
+
+__all__ = [
+    "InvestigationArtifacts",
+    "InvestigationConclusion",
+    "InvestigationEngine",
+    "InvestigationEvidence",
+    "InvestigationHypothesis",
+    "InvestigationRequest",
+    "InvestigationResult",
+    "derive_investigation_name",
+    "generate_investigation_id",
+    "normalize_positive_integer",
+    "parse_investigation_json",
+]

--- a/autocontext/src/autocontext/investigation/engine.py
+++ b/autocontext/src/autocontext/investigation/engine.py
@@ -1,0 +1,615 @@
+from __future__ import annotations
+
+import dataclasses
+import importlib.util
+import json
+import re
+import sys
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from autocontext.agents.types import LlmFn
+from autocontext.scenarios.custom.family_pipeline import validate_for_family, validate_source_for_family
+from autocontext.scenarios.custom.investigation_codegen import generate_investigation_class
+from autocontext.scenarios.custom.investigation_spec import InvestigationSpec
+from autocontext.scenarios.custom.simulation_spec import SimulationActionSpecModel
+from autocontext.scenarios.families import get_family_marker
+from autocontext.scenarios.investigation import EvidenceItem
+from autocontext.scenarios.simulation import Action
+from autocontext.simulation.helpers import find_scenario_class
+from autocontext.util.json_io import write_json
+
+
+@dataclass(slots=True)
+class InvestigationRequest:
+    description: str
+    max_steps: int | None = None
+    max_hypotheses: int | None = None
+    save_as: str | None = None
+
+
+@dataclass(slots=True)
+class InvestigationHypothesis:
+    id: str
+    statement: str
+    status: str
+    confidence: float
+
+
+@dataclass(slots=True)
+class InvestigationEvidence:
+    id: str
+    kind: str
+    source: str
+    summary: str
+    supports: list[str] = field(default_factory=list)
+    contradicts: list[str] = field(default_factory=list)
+    is_red_herring: bool = False
+
+
+@dataclass(slots=True)
+class InvestigationConclusion:
+    best_explanation: str
+    confidence: float
+    limitations: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class InvestigationArtifacts:
+    investigation_dir: str
+    report_path: str | None = None
+
+
+@dataclass(slots=True)
+class InvestigationResult:
+    id: str
+    name: str
+    family: str
+    status: str
+    description: str
+    question: str
+    hypotheses: list[InvestigationHypothesis]
+    evidence: list[InvestigationEvidence]
+    conclusion: InvestigationConclusion
+    unknowns: list[str]
+    recommended_next_steps: list[str]
+    steps_executed: int
+    artifacts: InvestigationArtifacts
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> InvestigationResult:
+        hypotheses = [InvestigationHypothesis(**item) for item in data.get("hypotheses", [])]
+        evidence = [InvestigationEvidence(**item) for item in data.get("evidence", [])]
+        conclusion = InvestigationConclusion(**data.get("conclusion", {}))
+        artifacts = InvestigationArtifacts(**data.get("artifacts", {}))
+        return cls(
+            id=str(data.get("id", "")),
+            name=str(data.get("name", "")),
+            family=str(data.get("family", "investigation")),
+            status=str(data.get("status", "failed")),
+            description=str(data.get("description", "")),
+            question=str(data.get("question", "")),
+            hypotheses=hypotheses,
+            evidence=evidence,
+            conclusion=conclusion,
+            unknowns=[str(item) for item in data.get("unknowns", [])],
+            recommended_next_steps=[str(item) for item in data.get("recommended_next_steps", [])],
+            steps_executed=int(data.get("steps_executed", 0)),
+            artifacts=artifacts,
+            error=str(data["error"]) if data.get("error") is not None else None,
+        )
+
+
+@dataclass(slots=True)
+class _ExecutedInvestigation:
+    steps_executed: int
+    collected_evidence: list[EvidenceItem]
+    final_state: dict[str, Any]
+
+
+def derive_investigation_name(description: str) -> str:
+    words = re.sub(r"[^a-z0-9\s]", " ", description.lower()).split()
+    return "_".join(word for word in words if len(word) > 2)[:80] or "investigation"
+
+
+def generate_investigation_id() -> str:
+    return f"inv_{uuid.uuid4().hex[:12]}"
+
+
+def normalize_positive_integer(value: int | None) -> int | None:
+    if value is None or value <= 0:
+        return None
+    return int(value)
+
+
+def parse_investigation_json(text: str) -> dict[str, Any] | None:
+    trimmed = text.strip()
+    candidates = [trimmed]
+
+    fenced = re.search(r"```(?:json)?\s*(\{[\s\S]*\})\s*```", trimmed, re.IGNORECASE)
+    if fenced:
+        candidates.append(fenced.group(1).strip())
+
+    start = trimmed.find("{")
+    end = trimmed.rfind("}")
+    if start != -1 and end > start:
+        candidates.append(trimmed[start : end + 1])
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def _build_investigation_spec_prompt(description: str) -> tuple[str, str]:
+    system_prompt = (
+        "You are an investigation designer. Given a problem description, produce an investigation spec as JSON.\n\n"
+        "Required fields:\n"
+        "- description: investigation summary\n"
+        "- environment_description: system/context being investigated\n"
+        "- initial_state_description: what is known at the start\n"
+        "- evidence_pool_description: what evidence sources are available, including any red herring\n"
+        "- diagnosis_target: the root cause or diagnosis we are trying to determine\n"
+        "- success_criteria: array of strings\n"
+        "- failure_modes: array of strings\n"
+        "- max_steps: positive integer\n"
+        "- actions: array of {name, description, parameters, preconditions, effects}\n"
+        "- when preconditions represent ordering, reference prior action names instead of environmental access assumptions\n\n"
+        "Output ONLY the JSON object, no markdown fences."
+    )
+    return system_prompt, f"Investigation: {description}"
+
+
+def _build_hypothesis_prompt(
+    *,
+    description: str,
+    execution: _ExecutedInvestigation,
+    max_hypotheses: int | None,
+) -> tuple[str, str]:
+    system_prompt = (
+        "You are a diagnostic analyst. Given an investigation description and collected evidence, generate hypotheses. "
+        "Output JSON with this shape:\n"
+        "{\n"
+        '  "question": "The specific question being investigated",\n'
+        '  "hypotheses": [\n'
+        '    { "statement": "Hypothesis text", "confidence": 0.0 }\n'
+        "  ]\n"
+        "}\n"
+        "Output ONLY the JSON object."
+    )
+    evidence = ", ".join(item.content for item in execution.collected_evidence) or "none yet"
+    user_prompt = (
+        f"Investigation: {description}\n"
+        f"Evidence collected: {evidence}\n"
+        f"Steps taken: {execution.steps_executed}\n"
+        f"Maximum hypotheses: {max_hypotheses or 5}"
+    )
+    return system_prompt, user_prompt
+
+
+def _spec_from_dict(data: dict[str, Any]) -> InvestigationSpec:
+    errors = validate_for_family("investigation", data)
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    actions = [
+        SimulationActionSpecModel(
+            name=str(raw["name"]),
+            description=str(raw["description"]),
+            parameters=raw.get("parameters", {}) if isinstance(raw, dict) else {},
+            preconditions=raw.get("preconditions", []) if isinstance(raw, dict) else [],
+            effects=raw.get("effects", []) if isinstance(raw, dict) else [],
+        )
+        for raw in data.get("actions", [])
+        if isinstance(raw, dict)
+    ]
+    return InvestigationSpec(
+        description=str(data["description"]),
+        environment_description=str(data["environment_description"]),
+        initial_state_description=str(data["initial_state_description"]),
+        evidence_pool_description=str(data["evidence_pool_description"]),
+        diagnosis_target=str(data["diagnosis_target"]),
+        success_criteria=[str(item) for item in data.get("success_criteria", [])],
+        failure_modes=[str(item) for item in data.get("failure_modes", [])],
+        actions=actions,
+        max_steps=int(data.get("max_steps", 10)),
+    )
+
+
+def _persist_investigation_artifacts(
+    knowledge_root: Path,
+    name: str,
+    spec: dict[str, Any],
+    source: str,
+) -> Path:
+    investigation_dir = knowledge_root / "_investigations" / name
+    investigation_dir.mkdir(parents=True, exist_ok=True)
+    write_json(investigation_dir / "spec.json", {"name": name, "family": "investigation", **spec})
+    (investigation_dir / "scenario.py").write_text(source, encoding="utf-8")
+    (investigation_dir / "scenario_type.txt").write_text(get_family_marker("investigation"), encoding="utf-8")
+    return investigation_dir
+
+
+def _execute_generated_investigation(
+    *,
+    source: str,
+    name: str,
+    max_steps: int | None,
+) -> _ExecutedInvestigation:
+    mod_name = f"autocontext._investigation_gen.{name}_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_loader(mod_name, loader=None)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    exec(source, module.__dict__)  # noqa: S102
+    sys.modules[mod_name] = module
+
+    scenario_class = find_scenario_class(module)
+    if scenario_class is None:
+        raise ValueError("No investigation scenario class found")
+
+    instance = scenario_class()
+    state = instance.initial_state(42)
+    limit = max_steps or getattr(instance, "max_steps", lambda: 8)()
+    steps = 0
+
+    while steps < limit:
+        if instance.is_terminal(state):
+            break
+        actions = instance.get_available_actions(state)
+        if not actions:
+            break
+
+        next_action: Action | None = None
+        for candidate in actions:
+            action = Action(name=candidate.name, parameters={})
+            valid, _reason = instance.validate_action(state, action)
+            if valid:
+                next_action = action
+                break
+        if next_action is None:
+            break
+
+        result, next_state = instance.execute_action(state, next_action)
+        state = next_state
+        if result.success:
+            steps += 1
+        else:
+            break
+
+    evidence_pool = {item.id: item for item in instance.get_evidence_pool(state)}
+    collected_ids = [str(item) for item in state.get("collected_evidence_ids", [])]
+    collected = [evidence_pool[item_id] for item_id in collected_ids if item_id in evidence_pool]
+    return _ExecutedInvestigation(
+        steps_executed=steps,
+        collected_evidence=collected,
+        final_state=state,
+    )
+
+
+def _normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9\s]", " ", text.lower())).strip()
+
+
+def _tokenize(text: str) -> list[str]:
+    stopwords = {
+        "a",
+        "an",
+        "and",
+        "the",
+        "to",
+        "of",
+        "for",
+        "in",
+        "on",
+        "at",
+        "by",
+        "with",
+        "after",
+        "before",
+        "from",
+        "our",
+        "your",
+        "their",
+        "is",
+        "was",
+        "were",
+        "be",
+        "this",
+        "that",
+    }
+    return [token for token in _normalize_text(text).split(" ") if len(token) > 1 and token not in stopwords]
+
+
+def _similarity_score(left: str, right: str) -> float:
+    left_tokens = set(_tokenize(left))
+    right_tokens = set(_tokenize(right))
+    if not left_tokens or not right_tokens:
+        return 0.0
+    matches = sum(1 for token in left_tokens if token in right_tokens)
+    return matches / max(len(left_tokens), len(right_tokens))
+
+
+def _build_evidence(execution: _ExecutedInvestigation) -> list[InvestigationEvidence]:
+    return [
+        InvestigationEvidence(
+            id=item.id,
+            kind="red_herring" if item.is_red_herring else "observation",
+            source=item.source,
+            summary=item.content,
+            is_red_herring=item.is_red_herring,
+        )
+        for item in execution.collected_evidence
+    ]
+
+
+def _parse_hypotheses(
+    *,
+    text: str,
+    description: str,
+    max_hypotheses: int | None,
+) -> tuple[str, list[dict[str, Any]]]:
+    parsed = parse_investigation_json(text)
+    if not parsed or not isinstance(parsed.get("hypotheses"), list):
+        return description, [
+            {"statement": f"Investigate: {description}", "confidence": 0.5},
+        ][: normalize_positive_integer(max_hypotheses) or 1]
+
+    hypotheses = []
+    for raw in parsed["hypotheses"]:
+        if not isinstance(raw, dict) or not isinstance(raw.get("statement"), str):
+            continue
+        confidence = raw.get("confidence")
+        if not isinstance(confidence, (int, float)):
+            confidence = 0.5
+        hypotheses.append(
+            {
+                "statement": str(raw["statement"]),
+                "confidence": max(0.0, min(1.0, float(confidence))),
+            }
+        )
+
+    limit = normalize_positive_integer(max_hypotheses)
+    if limit is not None:
+        hypotheses = hypotheses[:limit]
+    return str(parsed.get("question") or description), hypotheses
+
+
+def _evaluate_hypotheses(
+    *,
+    hypotheses: list[dict[str, Any]],
+    evidence: list[InvestigationEvidence],
+    diagnosis_target: str,
+) -> tuple[list[InvestigationHypothesis], list[InvestigationEvidence]]:
+    annotated_evidence = [
+        InvestigationEvidence(
+            id=item.id,
+            kind=item.kind,
+            source=item.source,
+            summary=item.summary,
+            supports=list(item.supports),
+            contradicts=list(item.contradicts),
+            is_red_herring=item.is_red_herring,
+        )
+        for item in evidence
+    ]
+    normalized_target = _normalize_text(diagnosis_target)
+    evaluated: list[InvestigationHypothesis] = []
+
+    for index, hypothesis in enumerate(hypotheses):
+        hypothesis_id = f"h{index}"
+        statement = str(hypothesis.get("statement", ""))
+        confidence = float(hypothesis.get("confidence", 0.5))
+        matches_target = bool(normalized_target) and _similarity_score(statement, normalized_target) >= 0.34
+        supporting = 0.0
+        contradicting = 0.0
+
+        for item in annotated_evidence:
+            overlap = _similarity_score(statement, item.summary)
+            related = overlap >= 0.34
+            if item.is_red_herring:
+                if related:
+                    item.contradicts.append(hypothesis_id)
+                    contradicting += overlap
+            elif related or matches_target:
+                item.supports.append(hypothesis_id)
+                supporting += max(overlap, 0.5 if matches_target else 0.0)
+
+        status = "unresolved"
+        if supporting > contradicting and supporting > 0:
+            status = "supported"
+        elif contradicting > supporting and contradicting > 0:
+            status = "contradicted"
+
+        evaluated.append(
+            InvestigationHypothesis(
+                id=hypothesis_id,
+                statement=statement,
+                status=status,
+                confidence=max(0.0, min(1.0, confidence)),
+            )
+        )
+
+    return evaluated, annotated_evidence
+
+
+def _build_conclusion(
+    hypotheses: list[InvestigationHypothesis],
+    evidence: list[InvestigationEvidence],
+) -> InvestigationConclusion:
+    supported = sorted(
+        [hypothesis for hypothesis in hypotheses if hypothesis.status == "supported"],
+        key=lambda item: item.confidence,
+        reverse=True,
+    )
+    best = supported[0] if supported else None
+    limitations: list[str] = []
+    red_herrings = sum(1 for item in evidence if item.is_red_herring)
+    if red_herrings:
+        limitations.append(f"{red_herrings} potential red herring(s) in evidence pool")
+    if any(hypothesis.status == "unresolved" for hypothesis in hypotheses):
+        limitations.append("Some hypotheses remain unresolved")
+    limitations.append("Investigation based on generated scenario — not live system data")
+    return InvestigationConclusion(
+        best_explanation=best.statement if best else "No hypothesis received sufficient support",
+        confidence=best.confidence if best else 0.0,
+        limitations=limitations,
+    )
+
+
+def _identify_unknowns(
+    hypotheses: list[InvestigationHypothesis],
+    evidence: list[InvestigationEvidence],
+) -> list[str]:
+    unknowns = [
+        f'Hypothesis "{hypothesis.statement}" needs more evidence'
+        for hypothesis in hypotheses
+        if hypothesis.status == "unresolved"
+    ]
+    if len(evidence) < 3:
+        unknowns.append("Limited evidence collected — more data sources needed")
+    return unknowns
+
+
+def _recommend_next_steps(
+    hypotheses: list[InvestigationHypothesis],
+    unknowns: list[str],
+) -> list[str]:
+    steps: list[str] = []
+    supported = [hypothesis for hypothesis in hypotheses if hypothesis.status == "supported"]
+    if supported:
+        steps.append(f'Verify leading hypothesis: "{supported[0].statement}"')
+    for hypothesis in [item for item in hypotheses if item.status == "unresolved"][:2]:
+        steps.append(f'Gather evidence for: "{hypothesis.statement}"')
+    if unknowns:
+        steps.append("Address identified unknowns before concluding")
+    return steps
+
+
+def _build_failed_result(
+    *,
+    investigation_id: str,
+    name: str,
+    request: InvestigationRequest,
+    errors: list[str],
+) -> InvestigationResult:
+    return InvestigationResult(
+        id=investigation_id,
+        name=name,
+        family="investigation",
+        status="failed",
+        description=request.description,
+        question=request.description,
+        hypotheses=[],
+        evidence=[],
+        conclusion=InvestigationConclusion(best_explanation="", confidence=0.0, limitations=errors),
+        unknowns=[],
+        recommended_next_steps=[],
+        steps_executed=0,
+        artifacts=InvestigationArtifacts(investigation_dir=""),
+        error="; ".join(errors),
+    )
+
+
+class InvestigationEngine:
+    def __init__(
+        self,
+        *,
+        spec_llm_fn: LlmFn,
+        knowledge_root: Path,
+        analysis_llm_fn: LlmFn | None = None,
+    ) -> None:
+        self._spec_llm_fn = spec_llm_fn
+        self._analysis_llm_fn = analysis_llm_fn or spec_llm_fn
+        self._knowledge_root = knowledge_root
+
+    def run(self, request: InvestigationRequest) -> InvestigationResult:
+        investigation_id = generate_investigation_id()
+        name = request.save_as or derive_investigation_name(request.description)
+
+        try:
+            spec_system, spec_user = _build_investigation_spec_prompt(request.description)
+            raw_spec = parse_investigation_json(self._spec_llm_fn(spec_system, spec_user))
+            if raw_spec is None:
+                raise ValueError("Investigation spec generation did not return valid JSON")
+
+            spec = _spec_from_dict(raw_spec)
+            source = generate_investigation_class(spec, name)
+            source_errors = validate_source_for_family("investigation", source)
+            if source_errors:
+                raise ValueError("; ".join(source_errors))
+
+            investigation_dir = _persist_investigation_artifacts(
+                self._knowledge_root,
+                name,
+                raw_spec,
+                source,
+            )
+            execution = _execute_generated_investigation(
+                source=source,
+                name=name,
+                max_steps=request.max_steps,
+            )
+
+            hypothesis_system, hypothesis_user = _build_hypothesis_prompt(
+                description=request.description,
+                execution=execution,
+                max_hypotheses=request.max_hypotheses,
+            )
+            question, raw_hypotheses = _parse_hypotheses(
+                text=self._analysis_llm_fn(hypothesis_system, hypothesis_user),
+                description=request.description,
+                max_hypotheses=request.max_hypotheses,
+            )
+
+            evidence = _build_evidence(execution)
+            hypotheses, annotated_evidence = _evaluate_hypotheses(
+                hypotheses=raw_hypotheses,
+                evidence=evidence,
+                diagnosis_target=spec.diagnosis_target,
+            )
+            conclusion = _build_conclusion(hypotheses, annotated_evidence)
+            unknowns = _identify_unknowns(hypotheses, annotated_evidence)
+            next_steps = _recommend_next_steps(hypotheses, unknowns)
+            report_path = investigation_dir / "report.json"
+
+            result = InvestigationResult(
+                id=investigation_id,
+                name=name,
+                family="investigation",
+                status="completed",
+                description=request.description,
+                question=question,
+                hypotheses=hypotheses,
+                evidence=annotated_evidence,
+                conclusion=conclusion,
+                unknowns=unknowns,
+                recommended_next_steps=next_steps,
+                steps_executed=execution.steps_executed,
+                artifacts=InvestigationArtifacts(
+                    investigation_dir=str(investigation_dir),
+                    report_path=str(report_path),
+                ),
+            )
+            write_json(report_path, result.to_dict())
+            return result
+        except Exception as exc:
+            return _build_failed_result(
+                investigation_id=investigation_id,
+                name=name,
+                request=request,
+                errors=[str(exc)],
+            )

--- a/autocontext/src/autocontext/scenarios/custom/investigation_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/investigation_codegen.py
@@ -45,7 +45,7 @@ def generate_investigation_class(spec: InvestigationSpec, name: str) -> str:
         },
     ]
     required_actions = [action.name for action in spec.actions]
-    return f'''from __future__ import annotations
+    return f"""from __future__ import annotations
 
 from typing import Any
 
@@ -106,9 +106,19 @@ class {class_name}(InvestigationInterface):
         if spec is None:
             return False, f"unknown action: {{action.name}}"
         completed = set(state.get("completed_actions", []))
+        known_actions = set(specs)
         for requirement in spec.preconditions:
-            if requirement not in completed:
-                return False, f"precondition not met for {{action.name}}: {{requirement}}"
+            normalized_requirement = requirement.strip().lower()
+            referenced_action = next(
+                (
+                    name
+                    for name in known_actions
+                    if name.lower() == normalized_requirement or name.lower() in normalized_requirement
+                ),
+                None,
+            )
+            if referenced_action and referenced_action not in completed:
+                return False, f"precondition not met for {{action.name}}: {{referenced_action}}"
         return True, ""
 
     def _ordered_evidence(self) -> list[EvidenceItem]:
@@ -240,4 +250,4 @@ class {class_name}(InvestigationInterface):
 
     def max_steps(self) -> int:
         return {spec.max_steps}
-'''
+"""

--- a/autocontext/tests/test_cli_investigate.py
+++ b/autocontext/tests/test_cli_investigate.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _make_settings(tmp_path: Path):
+    from autocontext.config.settings import AppSettings
+
+    return AppSettings(
+        db_path=tmp_path / "runs" / "autocontext.sqlite3",
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / ".claude" / "skills",
+        event_stream_path=tmp_path / "events.ndjson",
+    )
+
+
+def _completed_payload() -> dict[str, object]:
+    return {
+        "id": "inv_123",
+        "name": "checkout_rca",
+        "family": "investigation",
+        "status": "completed",
+        "description": "why did checkout fail",
+        "question": "Why did checkout fail?",
+        "hypotheses": [
+            {"id": "h0", "statement": "Config regression", "status": "supported", "confidence": 0.74},
+        ],
+        "evidence": [
+            {
+                "id": "e0",
+                "kind": "observation",
+                "source": "scenario execution",
+                "summary": "Primary evidence",
+                "supports": ["h0"],
+                "contradicts": [],
+                "is_red_herring": False,
+            }
+        ],
+        "conclusion": {
+            "best_explanation": "Config regression",
+            "confidence": 0.74,
+            "limitations": [],
+        },
+        "unknowns": [],
+        "recommended_next_steps": ["Inspect rollout diff"],
+        "steps_executed": 3,
+        "artifacts": {
+            "investigation_dir": "/tmp/investigations/checkout_rca",
+            "report_path": "/tmp/investigations/checkout_rca/report.json",
+        },
+    }
+
+
+class _FakeInvestigationEngine:
+    def __init__(self, **_: object) -> None:
+        pass
+
+    def run(self, _request):  # noqa: ANN001
+        from autocontext.investigation.engine import InvestigationResult
+
+        return InvestigationResult.from_dict(_completed_payload())
+
+
+class _FailingInvestigationEngine:
+    def __init__(self, **_: object) -> None:
+        pass
+
+    def run(self, _request):  # noqa: ANN001
+        from autocontext.investigation.engine import InvestigationResult
+
+        payload = _completed_payload()
+        payload.update({"status": "failed", "error": "spec generation did not return valid JSON"})
+        return InvestigationResult.from_dict(payload)
+
+
+class TestInvestigateCli:
+    def test_help_exists(self) -> None:
+        result = runner.invoke(app, ["investigate", "--help"])
+        help_text = _strip_ansi(result.output)
+
+        assert result.exit_code == 0, result.output
+        assert "investigate" in help_text.lower()
+        assert "--description" in help_text
+        assert "--hypotheses" in help_text
+
+    def test_json_success(self, tmp_path: Path) -> None:
+        settings = _make_settings(tmp_path)
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._resolve_investigation_runtime", return_value=(object(), "mock-model")),
+            patch("autocontext.investigation.engine.InvestigationEngine", _FakeInvestigationEngine),
+        ):
+            result = runner.invoke(app, ["investigate", "-d", "why did checkout fail", "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output.strip())
+        assert payload["status"] == "completed"
+        assert payload["family"] == "investigation"
+        assert payload["name"] == "checkout_rca"
+
+    def test_json_failure_writes_to_stderr(self, tmp_path: Path) -> None:
+        settings = _make_settings(tmp_path)
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._resolve_investigation_runtime", return_value=(object(), "mock-model")),
+            patch("autocontext.investigation.engine.InvestigationEngine", _FailingInvestigationEngine),
+        ):
+            result = runner.invoke(app, ["investigate", "-d", "broken investigation", "--json"])
+
+        assert result.exit_code == 1
+        payload = json.loads(result.output.strip())
+        assert payload["status"] == "failed"
+        assert payload["error"] == "spec generation did not return valid JSON"

--- a/autocontext/tests/test_investigation_engine.py
+++ b/autocontext/tests/test_investigation_engine.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _spec_response() -> str:
+    return json.dumps(
+        {
+            "description": "Investigate checkout errors",
+            "environment_description": "Production checkout stack",
+            "initial_state_description": "Customers report intermittent 500s during checkout",
+            "evidence_pool_description": "Application logs, deployment metadata, and a misleading cron alert",
+            "diagnosis_target": "A config regression in the checkout service",
+            "success_criteria": ["identify the root cause", "avoid the red herring"],
+            "failure_modes": ["follow the cron alert", "stop before enough evidence is gathered"],
+            "max_steps": 4,
+            "actions": [
+                {
+                    "name": "inspect_logs",
+                    "description": "Inspect logs",
+                    "parameters": {},
+                    "preconditions": [],
+                    "effects": ["log_evidence_collected"],
+                },
+                {
+                    "name": "review_deploy",
+                    "description": "Review deploy metadata",
+                    "parameters": {},
+                    "preconditions": [],
+                    "effects": ["deploy_evidence_collected"],
+                },
+                {
+                    "name": "record_diagnosis",
+                    "description": "Record final diagnosis",
+                    "parameters": {"diagnosis": "string"},
+                    "preconditions": ["inspect_logs"],
+                    "effects": ["diagnosis_recorded"],
+                },
+            ],
+        }
+    )
+
+
+def _hypothesis_response() -> str:
+    return json.dumps(
+        {
+            "question": "What caused the checkout errors?",
+            "hypotheses": [
+                {
+                    "statement": "A config regression in the checkout service",
+                    "confidence": 0.82,
+                },
+                {"statement": "The cron alert caused the outage", "confidence": 0.21},
+            ],
+        }
+    )
+
+
+class TestInvestigationEngine:
+    def test_runs_from_plain_language_description(self, tmp_path: Path) -> None:
+        from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
+
+        calls: list[tuple[str, str]] = []
+
+        def spec_llm(system: str, user: str) -> str:
+            calls.append((system, user))
+            return _spec_response()
+
+        def analysis_llm(system: str, user: str) -> str:
+            calls.append((system, user))
+            return _hypothesis_response()
+
+        engine = InvestigationEngine(
+            spec_llm_fn=spec_llm,
+            analysis_llm_fn=analysis_llm,
+            knowledge_root=tmp_path,
+        )
+
+        result = engine.run(InvestigationRequest(description="Investigate checkout errors"))
+
+        assert result.status == "completed"
+        assert result.family == "investigation"
+        assert result.question == "What caused the checkout errors?"
+        assert len(result.hypotheses) == 2
+        assert len(result.evidence) >= 1
+        assert result.artifacts.investigation_dir.endswith(result.name)
+        assert (tmp_path / "_investigations" / result.name / "spec.json").exists()
+        assert (tmp_path / "_investigations" / result.name / "report.json").exists()
+        assert len(calls) == 2
+
+    def test_parses_wrapped_and_fenced_spec_json(self, tmp_path: Path) -> None:
+        from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
+
+        wrapped = "Here's the investigation spec:\n```json\n" + _spec_response() + "\n```\nUse this to continue."
+
+        engine = InvestigationEngine(
+            spec_llm_fn=lambda *_: wrapped,
+            analysis_llm_fn=lambda *_: _hypothesis_response(),
+            knowledge_root=tmp_path,
+        )
+
+        result = engine.run(InvestigationRequest(description="Investigate checkout errors"))
+
+        assert result.status == "completed"
+        assert result.description == "Investigate checkout errors"
+
+    def test_skips_blocked_actions_until_a_valid_investigation_step_is_available(self, tmp_path: Path) -> None:
+        from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
+
+        blocked_first = json.dumps(
+            {
+                "description": "Investigate checkout errors",
+                "environment_description": "Production checkout stack",
+                "initial_state_description": "Customers report intermittent 500s during checkout",
+                "evidence_pool_description": "Application logs and a misleading cron alert",
+                "diagnosis_target": "A config regression in the checkout service",
+                "success_criteria": ["identify the root cause", "avoid the red herring"],
+                "failure_modes": ["follow the cron alert"],
+                "max_steps": 4,
+                "actions": [
+                    {
+                        "name": "record_diagnosis",
+                        "description": "Record final diagnosis",
+                        "parameters": {"diagnosis": "string"},
+                        "preconditions": ["inspect_logs has been completed"],
+                        "effects": ["diagnosis_recorded"],
+                    },
+                    {
+                        "name": "inspect_logs",
+                        "description": "Inspect logs",
+                        "parameters": {},
+                        "preconditions": [],
+                        "effects": ["log_evidence_collected"],
+                    },
+                ],
+            }
+        )
+
+        engine = InvestigationEngine(
+            spec_llm_fn=lambda *_: blocked_first,
+            analysis_llm_fn=lambda *_: _hypothesis_response(),
+            knowledge_root=tmp_path,
+        )
+
+        result = engine.run(InvestigationRequest(description="Investigate checkout errors"))
+
+        assert result.status == "completed"
+        assert result.steps_executed >= 1
+        assert len(result.evidence) >= 1
+
+    def test_treats_environmental_preconditions_as_advisory_context(self, tmp_path: Path) -> None:
+        from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
+
+        advisory_preconditions = json.dumps(
+            {
+                "description": "Investigate checkout errors",
+                "environment_description": "Production checkout stack",
+                "initial_state_description": "Customers report intermittent 500s during checkout",
+                "evidence_pool_description": "Application logs and a misleading cron alert",
+                "diagnosis_target": "A config regression in the checkout service",
+                "success_criteria": ["identify the root cause", "avoid the red herring"],
+                "failure_modes": ["follow the cron alert"],
+                "max_steps": 4,
+                "actions": [
+                    {
+                        "name": "inspect_logs",
+                        "description": "Inspect logs",
+                        "parameters": {},
+                        "preconditions": ["Log aggregation system is accessible"],
+                        "effects": ["log_evidence_collected"],
+                    },
+                    {
+                        "name": "record_diagnosis",
+                        "description": "Record final diagnosis",
+                        "parameters": {"diagnosis": "string"},
+                        "preconditions": ["inspect_logs"],
+                        "effects": ["diagnosis_recorded"],
+                    },
+                ],
+            }
+        )
+
+        engine = InvestigationEngine(
+            spec_llm_fn=lambda *_: advisory_preconditions,
+            analysis_llm_fn=lambda *_: _hypothesis_response(),
+            knowledge_root=tmp_path,
+        )
+
+        result = engine.run(InvestigationRequest(description="Investigate checkout errors"))
+
+        assert result.status == "completed"
+        assert result.steps_executed >= 1
+        assert len(result.evidence) >= 1
+
+    def test_returns_failed_result_when_spec_generation_is_not_json(self, tmp_path: Path) -> None:
+        from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
+
+        engine = InvestigationEngine(
+            spec_llm_fn=lambda *_: "not json at all",
+            analysis_llm_fn=lambda *_: _hypothesis_response(),
+            knowledge_root=tmp_path,
+        )
+
+        result = engine.run(InvestigationRequest(description="Investigate checkout errors"))
+
+        assert result.status == "failed"
+        assert "valid JSON" in (result.error or "")

--- a/ts/src/investigation/investigation-generation-workflow.ts
+++ b/ts/src/investigation/investigation-generation-workflow.ts
@@ -1,3 +1,5 @@
+import { designInvestigation } from "../scenarios/investigation-designer.js";
+import type { InvestigationSpec } from "../scenarios/investigation-spec.js";
 import type { LLMProvider } from "../types/index.js";
 import {
   buildFallbackInvestigationHypothesisSet,
@@ -19,19 +21,39 @@ export interface InvestigationHypothesisSet {
   question: string;
 }
 
+function serializeDesignedInvestigationSpec(spec: InvestigationSpec): Record<string, unknown> {
+  return {
+    description: spec.description,
+    environment_description: spec.environmentDescription,
+    initial_state_description: spec.initialStateDescription,
+    evidence_pool_description: spec.evidencePoolDescription,
+    diagnosis_target: spec.diagnosisTarget,
+    success_criteria: spec.successCriteria,
+    failure_modes: spec.failureModes,
+    actions: spec.actions,
+    max_steps: spec.maxSteps,
+  };
+}
+
 export async function buildInvestigationSpec(opts: {
   provider: LLMProvider;
   description: string;
 }): Promise<Record<string, unknown>> {
-  const result = await opts.provider.complete(
-    buildInvestigationSpecPrompt(opts.description),
-  );
+  const result = await opts.provider.complete(buildInvestigationSpecPrompt(opts.description));
 
   const parsed = parseInvestigationSpecResponse(result.text);
-  if (!parsed) {
-    throw new Error("Investigation spec generation did not return valid JSON");
+  if (parsed) {
+    return parsed;
   }
-  return parsed;
+
+  const designed = await designInvestigation(opts.description, async (system, user) => {
+    const fallback = await opts.provider.complete({
+      systemPrompt: system,
+      userPrompt: user,
+    });
+    return fallback.text;
+  });
+  return serializeDesignedInvestigationSpec(designed);
 }
 
 export async function generateInvestigationHypotheses(opts: {

--- a/ts/tests/investigation-engine-helpers.test.ts
+++ b/ts/tests/investigation-engine-helpers.test.ts
@@ -13,8 +13,13 @@ import {
 
 describe("investigation engine helpers", () => {
   it("derives stable names and parses wrapped JSON payloads", () => {
-    expect(deriveInvestigationName("Why did checkout fail after Tuesday's deploy?")).toBe("why_did_checkout_fail");
-    expect(parseInvestigationJson("before {\"a\":1} after")).toEqual({ a: 1 });
+    expect(deriveInvestigationName("Why did checkout fail after Tuesday's deploy?")).toBe(
+      "why_did_checkout_fail",
+    );
+    expect(parseInvestigationJson('before {"a":1} after')).toEqual({ a: 1 });
+    expect(
+      parseInvestigationJson('Here is the spec:\n```json\n{"a":1,"b":2}\n```\nUse it.'),
+    ).toEqual({ a: 1, b: 2 });
     expect(parseInvestigationJson("not json")).toBeNull();
   });
 
@@ -39,12 +44,14 @@ describe("investigation engine helpers", () => {
       expect(existsSync(join(artifactDir, "scenario_type.txt"))).toBe(true);
       expect(readFileSync(join(artifactDir, "spec.json"), "utf-8")).toContain("checkout_rca");
 
-      expect(buildFailedInvestigationResult(
-        "inv-1",
-        "checkout_rca",
-        { description: "Investigate checkout regression" },
-        ["spec invalid", "provider failed"],
-      )).toMatchObject({
+      expect(
+        buildFailedInvestigationResult(
+          "inv-1",
+          "checkout_rca",
+          { description: "Investigate checkout regression" },
+          ["spec invalid", "provider failed"],
+        ),
+      ).toMatchObject({
         id: "inv-1",
         name: "checkout_rca",
         status: "failed",

--- a/ts/tests/investigation-generation-parsing.test.ts
+++ b/ts/tests/investigation-generation-parsing.test.ts
@@ -22,6 +22,23 @@ describe("investigation generation parsing", () => {
     });
   });
 
+  it("parses investigation spec responses wrapped in prose and fenced JSON", () => {
+    expect(
+      parseInvestigationSpecResponse(
+        "I found the investigation spec below.\n```json\n" +
+          JSON.stringify({
+            description: "Investigate anomaly",
+            evidence_pool: [],
+            correct_diagnosis: "config drift",
+          }) +
+          "\n```\nThis should help.",
+      ),
+    ).toMatchObject({
+      description: "Investigate anomaly",
+      correct_diagnosis: "config drift",
+    });
+  });
+
   it("normalizes parsed hypothesis responses and applies limits", () => {
     expect(
       parseInvestigationHypothesisResponse({

--- a/ts/tests/investigation-generation-workflow.test.ts
+++ b/ts/tests/investigation-generation-workflow.test.ts
@@ -9,7 +9,9 @@ import type { LLMProvider } from "../src/types/index.js";
 function mockProvider(responses: string[]): LLMProvider {
   let callIndex = 0;
   return {
-    complete: async () => ({ text: responses[callIndex++] ?? responses[responses.length - 1] ?? "{}" }),
+    complete: async () => ({
+      text: responses[callIndex++] ?? responses[responses.length - 1] ?? "{}",
+    }),
     defaultModel: () => "test-model",
   } as unknown as LLMProvider;
 }
@@ -31,6 +33,50 @@ describe("investigation generation workflow", () => {
     ).resolves.toMatchObject({
       description: "Investigate anomaly",
       correct_diagnosis: "config drift",
+    });
+  });
+
+  it("falls back to the investigation designer prompt when strict JSON parsing fails", async () => {
+    await expect(
+      buildInvestigationSpec({
+        provider: mockProvider([
+          "not json",
+          [
+            "<!-- INVESTIGATION_SPEC_START -->",
+            JSON.stringify({
+              description: "Investigate anomaly",
+              environment_description: "Production environment",
+              initial_state_description: "Anomaly detected",
+              evidence_pool_description: "System logs and a red herring cron alert",
+              diagnosis_target: "config drift",
+              success_criteria: ["identify root cause", "avoid the red herring"],
+              failure_modes: ["follow the cron alert"],
+              max_steps: 6,
+              actions: [
+                {
+                  name: "inspect_logs",
+                  description: "Inspect logs",
+                  parameters: {},
+                  preconditions: [],
+                  effects: ["log_evidence_collected"],
+                },
+                {
+                  name: "record_diagnosis",
+                  description: "Record diagnosis",
+                  parameters: { diagnosis: "string" },
+                  preconditions: ["inspect_logs"],
+                  effects: ["diagnosis_recorded"],
+                },
+              ],
+            }),
+            "<!-- INVESTIGATION_SPEC_END -->",
+          ].join("\n"),
+        ]),
+        description: "Investigate anomaly",
+      }),
+    ).resolves.toMatchObject({
+      description: "Investigate anomaly",
+      diagnosis_target: "config drift",
     });
   });
 


### PR DESCRIPTION
## Summary

- add a first-class Python `autoctx investigate` CLI surface with architect/analyst role-runtime routing
- introduce the Python investigation engine and TDD coverage for CLI/help, JSON output, wrapped JSON parsing, and blocked-step execution
- harden investigation execution/codegen so advisory environment preconditions do not deadlock runs while action-name dependencies still gate correctly
- add a TypeScript fallback from strict JSON parsing to the existing investigation designer path when live spec generation returns wrapped prose

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [x] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/investigation/engine.py src/autocontext/scenarios/custom/investigation_codegen.py src/autocontext/cli.py tests/test_investigation_engine.py tests/test_cli_investigate.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_investigation_engine.py tests/test_cli_investigate.py tests/test_investigation_workflow.py tests/test_cli_json.py -k 'investigate or investigation' -x --tb=short`
- [x] `cd ts && npm run lint`
- [x] `cd ts && npm test -- investigate.test.ts investigate-command-workflow.test.ts investigation-engine-helpers.test.ts investigation-generation-parsing.test.ts investigation-generation-workflow.test.ts cli-emit-engine-result.test.ts`
- [x] additional manual verification described below

### Manual verification

- Python live investigate rerun via `claude-cli` completed successfully with execution progress restored (`steps_executed: 8`):
  - `/tmp/ac556-py-final-5JTobq/result.json`
- TypeScript live investigate rerun via `claude-cli` completed successfully after the fallback path change:
  - `/tmp/ac556-ts-final-1Lf1iS/result.json`

## Docs And Release Impact

- [ ] no user-facing docs changes needed
- [x] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- AC-556 covered two concrete gaps:
  - Python had no `autoctx investigate` CLI surface at all
  - TypeScript investigate spec generation was still fragile when the model wrapped JSON in prose/fences
- Python investigation execution now skips blocked first actions and treats environment-access preconditions as advisory context, which avoids zero-step completed runs on richer live prompts.
- TypeScript now falls back to the investigation designer contract instead of failing immediately on a strict JSON parse miss.