### PR TITLE
fix: restore queue add task-prompt compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 Changes in this section are on the branch/repo after `0.4.1` and are not part of the last published release until the next version is cut.
 
+### Fixed
+
+- Restored Python `autoctx queue add --task-prompt ... --rubric ...` compatibility for prompt-backed queued tasks, including direct ad hoc queueing without a saved spec name.
+
 ## [0.4.1] - 2026-04-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 autocontext runs LLM agents through structured scenarios, evaluates their outputs, and accumulates the knowledge that improved results — so repeated runs get better, not just different. Point the harness at a real task in plain language, let it work the problem, and then inspect the traces, reports, artifacts, datasets, playbooks, and optional distilled model it produces.
 
 <!-- autocontext-whats-new:start -->
-
 ## What's New
 
 - All 11 scenario families executable in both Python and TypeScript

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 autocontext runs LLM agents through structured scenarios, evaluates their outputs, and accumulates the knowledge that improved results — so repeated runs get better, not just different. Point the harness at a real task in plain language, let it work the problem, and then inspect the traces, reports, artifacts, datasets, playbooks, and optional distilled model it produces.
 
 <!-- autocontext-whats-new:start -->
+
 ## What's New
 
 - All 11 scenario families executable in both Python and TypeScript
@@ -239,6 +240,7 @@ The Python package exposes the full `autoctx` control-plane CLI for scenario exe
 - Run and improve a saved scenario: `uv run autoctx run --scenario support_triage --gens 3`
 - Inspect or replay outputs: `uv run autoctx list`, `uv run autoctx status <run_id>`
 - Run an investigation from Python: `uv run autoctx investigate -d "why did conversion drop after Tuesday's release"`
+- Enqueue an ad hoc queued task from Python: `uv run autoctx queue add --task-prompt "Write a 1-line fact about primes" --rubric "correct" --threshold 0.8 --rounds 2`
 - Override the simulation provider per call: `uv run autoctx simulate -d "simulate deploying a web service with rollback" --provider claude-cli`
 - Scaffold a custom scenario: `uv run autoctx new-scenario --template prompt-optimization --name my-task`
 - Export training data: `uv run autoctx export-training-data --scenario support_triage --all-runs --output training/support_triage.jsonl`

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -147,6 +147,7 @@ uv run autoctx solve --description "improve customer-support replies for billing
 uv run autoctx simulate --description "simulate deploying a web service with rollback"
 uv run autoctx simulate --description "simulate deploying a web service with rollback" --provider claude-cli
 uv run autoctx investigate --description "why did conversion drop after Tuesday's release"
+uv run autoctx queue add --task-prompt "Write a 1-line fact about primes" --rubric "correct" --threshold 0.8 --rounds 2
 uv run autoctx simulate --replay deploy_sim --variables threshold=0.9
 uv run autoctx list
 uv run autoctx status <run_id>

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -19,6 +19,7 @@ from rich.table import Table
 
 from autocontext.agents.orchestrator import AgentOrchestrator
 from autocontext.cli_investigate import run_investigate_command
+from autocontext.cli_queue import run_queue_command
 from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.cli_runtime_overrides import (
     apply_judge_runtime_overrides,
@@ -1574,24 +1575,42 @@ def improve(
 
 @app.command()
 def queue(
-    spec: str = typer.Option(..., "--spec", "-s", help="Task spec name"),
+    action: str = typer.Argument("add"),
+    spec: str = typer.Option("", "--spec", "-s", help="Task spec name"),
+    task_prompt: str = typer.Option("", "--task-prompt", "--prompt", "-p", help="The queued task prompt"),
+    rubric: str = typer.Option("", "--rubric", "-r", help="Evaluation rubric"),
+    max_rounds: int = typer.Option(5, "--rounds", "-n", min=1, help="Maximum improvement rounds"),
+    threshold: float = typer.Option(0.9, "--threshold", "-t", help="Quality threshold to stop"),
+    min_rounds: int = typer.Option(1, "--min-rounds", min=1, help="Minimum rounds before threshold stops"),
     priority: int = typer.Option(0, "--priority", help="Task priority"),
+    provider: str = typer.Option(
+        "",
+        "--provider",
+        help="Provider override accepted for queue-script compatibility; queued execution still follows the worker provider",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
 ) -> None:
     """Add a task to the background runner queue."""
     from autocontext.execution.task_runner import enqueue_task
 
-    settings = load_settings()
-    store = _sqlite_from_settings(settings)
-    migrations_dir = Path(__file__).resolve().parents[2] / "migrations"
-    store.migrate(migrations_dir)
-
-    task_id = enqueue_task(store=store, spec_name=spec, priority=priority)
-
-    if json_output:
-        _write_json_stdout({"task_id": task_id, "spec_name": spec, "status": "queued"})
-    else:
-        console.print(f"Queued task {task_id} for spec '{spec}' (priority {priority})")
+    run_queue_command(
+        action=action,
+        spec=spec,
+        task_prompt=task_prompt,
+        rubric=rubric,
+        max_rounds=max_rounds,
+        threshold=threshold,
+        min_rounds=min_rounds,
+        priority=priority,
+        provider=provider,
+        json_output=json_output,
+        console=console,
+        load_settings_fn=load_settings,
+        sqlite_from_settings=_sqlite_from_settings,
+        enqueue_task_fn=enqueue_task,
+        write_json_stdout=_write_json_stdout,
+        write_json_stderr=_write_json_stderr,
+    )
 
 
 if __name__ == "__main__":

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -19,7 +19,7 @@ from rich.table import Table
 
 from autocontext.agents.orchestrator import AgentOrchestrator
 from autocontext.cli_investigate import run_investigate_command
-from autocontext.cli_queue import run_queue_command
+from autocontext.cli_queue import register_queue_command
 from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.cli_runtime_overrides import (
     apply_judge_runtime_overrides,
@@ -1572,45 +1572,7 @@ def improve(
         console.print(f"[bold]Rounds:[/bold] {result.total_rounds}")
         console.print(f"[bold]Met threshold:[/bold] {result.met_threshold}")
 
-
-@app.command()
-def queue(
-    action: str = typer.Argument("add"),
-    spec: str = typer.Option("", "--spec", "-s", help="Task spec name"),
-    task_prompt: str = typer.Option("", "--task-prompt", "--prompt", "-p", help="The queued task prompt"),
-    rubric: str = typer.Option("", "--rubric", "-r", help="Evaluation rubric"),
-    max_rounds: int = typer.Option(5, "--rounds", "-n", min=1, help="Maximum improvement rounds"),
-    threshold: float = typer.Option(0.9, "--threshold", "-t", help="Quality threshold to stop"),
-    min_rounds: int = typer.Option(1, "--min-rounds", min=1, help="Minimum rounds before threshold stops"),
-    priority: int = typer.Option(0, "--priority", help="Task priority"),
-    provider: str = typer.Option(
-        "",
-        "--provider",
-        help="Provider override accepted for queue-script compatibility; queued execution still follows the worker provider",
-    ),
-    json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
-) -> None:
-    """Add a task to the background runner queue."""
-    from autocontext.execution.task_runner import enqueue_task
-
-    run_queue_command(
-        action=action,
-        spec=spec,
-        task_prompt=task_prompt,
-        rubric=rubric,
-        max_rounds=max_rounds,
-        threshold=threshold,
-        min_rounds=min_rounds,
-        priority=priority,
-        provider=provider,
-        json_output=json_output,
-        console=console,
-        load_settings_fn=load_settings,
-        sqlite_from_settings=_sqlite_from_settings,
-        enqueue_task_fn=enqueue_task,
-        write_json_stdout=_write_json_stdout,
-        write_json_stderr=_write_json_stderr,
-    )
+register_queue_command(app, console=console)
 
 
 if __name__ == "__main__":

--- a/autocontext/src/autocontext/cli_queue.py
+++ b/autocontext/src/autocontext/cli_queue.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import importlib
 import re
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import typer
 
@@ -26,6 +27,10 @@ class QueueEnqueuer(Protocol):
         min_rounds: int = 1,
         priority: int = 0,
     ) -> str: ...
+
+
+def _cli_attr(dependency_module: str, name: str) -> Any:
+    return getattr(importlib.import_module(dependency_module), name)
 
 
 def derive_queue_spec_name(task_prompt: str) -> str:
@@ -121,3 +126,45 @@ def run_queue_command(
         write_json_stdout(payload)
     else:
         console.print(f"Queued task {task_id} for spec '{resolved_spec_name}' (priority {priority})")
+
+
+def register_queue_command(
+    app: typer.Typer,
+    *,
+    console: Console,
+    dependency_module: str = "autocontext.cli",
+) -> None:
+    @app.command()
+    def queue(
+        action: str = typer.Argument("add"),
+        spec: str = typer.Option("", "--spec", "-s", help="Task spec name"),
+        task_prompt: str = typer.Option("", "--task-prompt", "--prompt", "-p", help="The queued task prompt"),
+        rubric: str = typer.Option("", "--rubric", "-r", help="Evaluation rubric"),
+        max_rounds: int = typer.Option(5, "--rounds", "-n", min=1, help="Maximum improvement rounds"),
+        threshold: float = typer.Option(0.9, "--threshold", "-t", help="Quality threshold to stop"),
+        min_rounds: int = typer.Option(1, "--min-rounds", min=1, help="Minimum rounds before threshold stops"),
+        priority: int = typer.Option(0, "--priority", help="Task priority"),
+        provider: str = typer.Option("", "--provider", help="Provider override accepted for queue-script compatibility"),
+        json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
+    ) -> None:
+        """Add a task to the background runner queue."""
+        from autocontext.execution.task_runner import enqueue_task
+
+        run_queue_command(
+            action=action,
+            spec=spec,
+            task_prompt=task_prompt,
+            rubric=rubric,
+            max_rounds=max_rounds,
+            threshold=threshold,
+            min_rounds=min_rounds,
+            priority=priority,
+            provider=provider,
+            json_output=json_output,
+            console=console,
+            load_settings_fn=_cli_attr(dependency_module, "load_settings"),
+            sqlite_from_settings=_cli_attr(dependency_module, "_sqlite_from_settings"),
+            enqueue_task_fn=enqueue_task,
+            write_json_stdout=_cli_attr(dependency_module, "_write_json_stdout"),
+            write_json_stderr=_cli_attr(dependency_module, "_write_json_stderr"),
+        )

--- a/autocontext/src/autocontext/cli_queue.py
+++ b/autocontext/src/autocontext/cli_queue.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Protocol
+
+import typer
+
+from autocontext.config.settings import AppSettings
+from autocontext.storage.sqlite_store import SQLiteStore
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+class QueueEnqueuer(Protocol):
+    def __call__(
+        self,
+        *,
+        store: SQLiteStore,
+        spec_name: str,
+        task_prompt: str | None = None,
+        rubric: str | None = None,
+        max_rounds: int = 5,
+        quality_threshold: float = 0.9,
+        min_rounds: int = 1,
+        priority: int = 0,
+    ) -> str: ...
+
+
+def derive_queue_spec_name(task_prompt: str) -> str:
+    words = re.sub(r"[^a-z0-9\s]", " ", task_prompt.lower()).split()
+    return ("_".join(words)[:80] or "queue_task").strip("_") or "queue_task"
+
+
+def resolve_queue_spec_name(spec: str, task_prompt: str) -> str:
+    cleaned_spec = spec.strip()
+    if cleaned_spec:
+        return cleaned_spec
+
+    cleaned_prompt = task_prompt.strip()
+    if cleaned_prompt:
+        return derive_queue_spec_name(cleaned_prompt)
+
+    raise ValueError("Either --spec or --task-prompt is required.")
+
+
+def run_queue_command(
+    *,
+    action: str,
+    spec: str,
+    task_prompt: str,
+    rubric: str,
+    max_rounds: int,
+    threshold: float,
+    min_rounds: int,
+    priority: int,
+    provider: str,
+    json_output: bool,
+    console: Console,
+    load_settings_fn: Callable[[], AppSettings],
+    sqlite_from_settings: Callable[[AppSettings], SQLiteStore],
+    enqueue_task_fn: QueueEnqueuer,
+    write_json_stdout: Callable[[object], None],
+    write_json_stderr: Callable[[str], None],
+) -> None:
+    normalized_action = (action or "add").strip().lower()
+    if normalized_action != "add":
+        message = f"Unsupported queue action '{action}'. Only 'add' is supported."
+        if json_output:
+            write_json_stderr(message)
+        else:
+            console.print(f"[red]{message}[/red]")
+        raise typer.Exit(code=1)
+
+    try:
+        resolved_spec_name = resolve_queue_spec_name(spec, task_prompt)
+    except ValueError as exc:
+        if json_output:
+            write_json_stderr(str(exc))
+        else:
+            console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    _provider_override = provider.strip()
+
+    settings = load_settings_fn()
+    store = sqlite_from_settings(settings)
+
+    has_direct_task_payload = bool(task_prompt.strip() or rubric.strip())
+    if not has_direct_task_payload and max_rounds == 5 and threshold == 0.9 and min_rounds == 1:
+        task_id = enqueue_task_fn(
+            store=store,
+            spec_name=resolved_spec_name,
+            priority=priority,
+        )
+    elif min_rounds == 1:
+        task_id = enqueue_task_fn(
+            store=store,
+            spec_name=resolved_spec_name,
+            task_prompt=task_prompt.strip() or None,
+            rubric=rubric.strip() or None,
+            max_rounds=max_rounds,
+            quality_threshold=threshold,
+            priority=priority,
+        )
+    else:
+        task_id = enqueue_task_fn(
+            store=store,
+            spec_name=resolved_spec_name,
+            task_prompt=task_prompt.strip() or None,
+            rubric=rubric.strip() or None,
+            max_rounds=max_rounds,
+            quality_threshold=threshold,
+            min_rounds=min_rounds,
+            priority=priority,
+        )
+
+    payload = {"task_id": task_id, "spec_name": resolved_spec_name, "status": "queued"}
+    if json_output:
+        write_json_stdout(payload)
+    else:
+        console.print(f"Queued task {task_id} for spec '{resolved_spec_name}' (priority {priority})")

--- a/autocontext/tests/test_cli_backport.py
+++ b/autocontext/tests/test_cli_backport.py
@@ -23,11 +23,13 @@ class _FakeProvider:
         self.calls: list[dict[str, str]] = []
 
     def complete(self, system_prompt: str, user_prompt: str, model: str) -> SimpleNamespace:
-        self.calls.append({
-            "system_prompt": system_prompt,
-            "user_prompt": user_prompt,
-            "model": model,
-        })
+        self.calls.append(
+            {
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "model": model,
+            }
+        )
         return SimpleNamespace(text=self._outputs.pop(0))
 
     def default_model(self) -> str:
@@ -48,12 +50,18 @@ class TestJudgeCommand:
 
     def test_judge_missing_provider_gives_clear_error(self) -> None:
         """Judge without API key should give a clear error, not a stack trace."""
-        result = runner.invoke(app, [
-            "judge",
-            "--task-prompt", "Write a haiku",
-            "--output", "Test output",
-            "--rubric", "Score it",
-        ])
+        result = runner.invoke(
+            app,
+            [
+                "judge",
+                "--task-prompt",
+                "Write a haiku",
+                "--output",
+                "Test output",
+                "--rubric",
+                "Score it",
+            ],
+        )
         # Should fail cleanly (no API key configured)
         assert result.exit_code != 0
 
@@ -95,13 +103,19 @@ class TestImproveCommand:
             patch("autocontext.execution.task_runner.evaluate_evaluator_guardrail", return_value=None),
         ):
             mock_judge_cls.return_value.evaluate.side_effect = judge_results
-            result = runner.invoke(app, [
-                "improve",
-                "--task-prompt", "Write a haiku",
-                "--rubric", "Score quality",
-                "--rounds", "2",
-                "--json",
-            ])
+            result = runner.invoke(
+                app,
+                [
+                    "improve",
+                    "--task-prompt",
+                    "Write a haiku",
+                    "--rubric",
+                    "Score quality",
+                    "--rounds",
+                    "2",
+                    "--json",
+                ],
+            )
 
         assert result.exit_code == 0
         payload = json.loads(result.stdout)
@@ -116,12 +130,14 @@ class TestQueueCommand:
         result = runner.invoke(app, ["queue", "--help"])
         assert result.exit_code == 0
         assert "--spec" in result.stdout or "-s" in result.stdout
+        assert "--task-prompt" in result.stdout or "-p" in result.stdout
+        assert "--rounds" in result.stdout or "-n" in result.stdout
 
-    def test_queue_requires_spec(self) -> None:
+    def test_queue_requires_spec_or_task_prompt(self) -> None:
         result = runner.invoke(app, ["queue"])
         assert result.exit_code != 0
 
-    def test_queue_uses_task_runner_helper(self) -> None:
+    def test_queue_uses_task_runner_helper_for_saved_spec(self) -> None:
         settings = MagicMock()
         store = MagicMock()
 
@@ -139,3 +155,46 @@ class TestQueueCommand:
             "status": "queued",
         }
         mock_enqueue.assert_called_once_with(store=store, spec_name="demo-task", priority=2)
+
+    def test_queue_add_accepts_direct_task_prompt_aliases(self) -> None:
+        settings = MagicMock()
+        store = MagicMock()
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._sqlite_from_settings", return_value=store),
+            patch("autocontext.execution.task_runner.enqueue_task", return_value="task-456") as mock_enqueue,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "queue",
+                    "add",
+                    "--task-prompt",
+                    "Write a 1-line fact about primes",
+                    "--rubric",
+                    "correct",
+                    "--threshold",
+                    "0.8",
+                    "--rounds",
+                    "2",
+                    "--provider",
+                    "claude-cli",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["task_id"] == "task-456"
+        assert payload["status"] == "queued"
+        assert payload["spec_name"] == "write_a_1_line_fact_about_primes"
+        mock_enqueue.assert_called_once_with(
+            store=store,
+            spec_name="write_a_1_line_fact_about_primes",
+            task_prompt="Write a 1-line fact about primes",
+            rubric="correct",
+            quality_threshold=0.8,
+            max_rounds=2,
+            priority=0,
+        )


### PR DESCRIPTION
## Summary

- restore Python `autoctx queue add --task-prompt ... --rubric ...` compatibility for prompt-backed queued tasks
- add a dedicated queue CLI workflow helper so prompt-backed queueing can derive a stable spec name when `--spec` is omitted
- accept `--provider` again on `queue add` for script compatibility while keeping queued execution bound to the worker provider/runtime
- update docs and changelog to reflect the restored queue surface

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [x] Docs or examples
- [x] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/cli.py src/autocontext/cli_queue.py tests/test_cli_backport.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_cli_backport.py tests/test_task_runner.py -k 'queue or backport' -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

### Manual verification

- exact AC-557 command shape now queues successfully:
  - `AUTOCONTEXT_DB_PATH=/tmp/... AUTOCONTEXT_JUDGE_PROVIDER=claude-cli uv run autoctx queue add --task-prompt "Write a 1-line fact about primes" --rubric "Score correctness 0-1." --threshold 0.8 --rounds 2 --provider claude-cli --json`
  - artifact: `/tmp/ac557-live-queue-Zagdj4/queue.json`
- the queued task then completed through the real SQLite-backed task runner path using `claude-cli`
  - artifact: `/tmp/ac557-live-queue-Zagdj4/run_once.json`
  - observed result: `status: "completed"`, `best_score: 0.95`

## Docs And Release Impact

- [ ] no user-facing docs changes needed
- [x] updated relevant README/docs/examples
- [x] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this restores the queue enqueue surface referenced by AC-34/L6 concurrency smoke without requiring callers to switch immediately to a different flag shape
- when `--spec` is omitted for prompt-backed queue requests, Python now derives a stable spec name from the task prompt (for example `Write a 1-line fact about primes` → `write_a_1_line_fact_about_primes`)
- `--provider` is accepted again for queue-script compatibility, but actual queued execution still follows the worker's configured provider/runtime