### PR TITLE
AC-560: align Pi runtimes with subprocess RPC

### DIFF
--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -107,12 +107,18 @@ uv run autoctx solve --description "improve customer-support replies for billing
 
 `autoctx investigate` now ships as a first-class Python CLI surface as well. It uses the architect runtime for investigation-spec synthesis and the analyst runtime for hypothesis generation, so role-routing overrides apply there too.
 
-Run with Pi RPC (remote Pi agent via HTTP):
+Run with Pi RPC (local Pi subprocess using `pi --mode rpc` JSONL):
 
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=pi-rpc \
-AUTOCONTEXT_PI_RPC_ENDPOINT=http://localhost:3284 \
+AUTOCONTEXT_PI_COMMAND=pi \
 uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+```
+
+For deterministic evals where Pi should ignore repo-local `AGENTS.md` / `CLAUDE.md`, add:
+
+```bash
+AUTOCONTEXT_PI_NO_CONTEXT_FILES=true
 ```
 
 Run with Hermes (via OpenAI-compatible gateway):

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -32,6 +32,7 @@ autoctx train --scenario grid_ctf --data data.jsonl --json
 ```
 
 **Contract:**
+
 - **stdout** receives the JSON payload (one JSON object per line).
 - **stderr** receives errors in the format `{"error": "description"}`.
 - **Exit code 0** means the command succeeded. The JSON payload is on stdout.
@@ -50,6 +51,7 @@ autoctx run --scenario my_agent_task --gens 3 --json
 ```
 
 JSON output shape:
+
 ```json
 {
   "run_id": "my_run",
@@ -67,6 +69,7 @@ autoctx status <run_id> --json
 ```
 
 JSON output shape:
+
 ```json
 {
   "run_id": "abc123",
@@ -92,6 +95,7 @@ autoctx list --json
 ```
 
 Returns an array of run summaries:
+
 ```json
 [
   {
@@ -157,6 +161,7 @@ autoctx export --scenario grid_ctf --output pkg.json --json
 ```
 
 JSON output shape:
+
 ```json
 {
   "scenario": "grid_ctf",
@@ -174,6 +179,7 @@ autoctx train --scenario grid_ctf --data training.jsonl --time-budget 300 --json
 ```
 
 JSON output shape:
+
 ```json
 {
   "scenario": "grid_ctf",
@@ -192,6 +198,7 @@ autoctx import-package --file grid_ctf_package.json --json
 ```
 
 JSON output shape:
+
 ```json
 {
   "scenario_name": "grid_ctf",
@@ -262,11 +269,13 @@ AUTOCONTEXT_PI_COMMAND=pi \
 AUTOCONTEXT_PI_TIMEOUT=120 \
 autoctx run --scenario my_task --json
 
-# Pi RPC (Pi agent via HTTP RPC — supports session persistence)
+# Pi RPC (Pi subprocess via `pi --mode rpc` JSONL)
 AUTOCONTEXT_AGENT_PROVIDER=pi-rpc \
-AUTOCONTEXT_PI_RPC_ENDPOINT=http://localhost:3284 \
-AUTOCONTEXT_PI_RPC_API_KEY=your-key \
+AUTOCONTEXT_PI_COMMAND=pi \
 autoctx run --scenario my_task --json
+
+# Optional: keep Pi deterministic by ignoring AGENTS.md / CLAUDE.md context files
+AUTOCONTEXT_PI_NO_CONTEXT_FILES=true
 
 # Role-scoped override: competitor uses a separate gateway/key
 AUTOCONTEXT_AGENT_PROVIDER=anthropic \
@@ -281,55 +290,62 @@ autoctx run --scenario my_task --json
 
 Key environment variables:
 
-| Variable | Purpose |
-|---|---|
-| `AUTOCONTEXT_AGENT_PROVIDER` | Agent provider: `anthropic`, `openai-compatible`, `ollama`, `vllm`, `pi`, `pi-rpc`, `deterministic` |
-| `AUTOCONTEXT_AGENT_API_KEY` | Global agent API key override (or use provider-native env vars such as `ANTHROPIC_API_KEY`) |
-| `AUTOCONTEXT_AGENT_BASE_URL` | Global base URL for OpenAI-compatible agent endpoints |
-| `AUTOCONTEXT_COMPETITOR_API_KEY` / `AUTOCONTEXT_COMPETITOR_BASE_URL` | Optional competitor-specific credential and endpoint override |
-| `AUTOCONTEXT_ANALYST_API_KEY` / `AUTOCONTEXT_ANALYST_BASE_URL` | Optional analyst-specific credential and endpoint override |
-| `AUTOCONTEXT_COACH_API_KEY` / `AUTOCONTEXT_COACH_BASE_URL` | Optional coach-specific credential and endpoint override |
-| `AUTOCONTEXT_ARCHITECT_API_KEY` / `AUTOCONTEXT_ARCHITECT_BASE_URL` | Optional architect-specific credential and endpoint override |
-| `AUTOCONTEXT_JUDGE_PROVIDER` | Judge provider (defaults to `anthropic`) |
-| `AUTOCONTEXT_JUDGE_API_KEY` | API key for the judge provider |
-| `AUTOCONTEXT_JUDGE_BASE_URL` | Base URL for OpenAI-compatible judge endpoints |
-| `AUTOCONTEXT_JUDGE_MODEL` | Override judge model name |
-| `AUTOCONTEXT_CLAUDE_MODEL` | Claude CLI model alias (default: `sonnet`) |
-| `AUTOCONTEXT_CLAUDE_TIMEOUT` | Claude CLI execution timeout in seconds (default: 120) |
-| `AUTOCONTEXT_MODEL_COMPETITOR` | Override competitor agent model |
-| `AUTOCONTEXT_DB_PATH` | SQLite database path |
-| `AUTOCONTEXT_PI_COMMAND` | Path to Pi CLI binary (default: `pi`) |
-| `AUTOCONTEXT_PI_TIMEOUT` | Pi CLI execution timeout in seconds (default: 120) |
-| `AUTOCONTEXT_PI_WORKSPACE` | Pi CLI working directory |
-| `AUTOCONTEXT_PI_MODEL` | Manual Pi model override (pins a specific checkpoint/path) |
-| `AUTOCONTEXT_PI_RPC_ENDPOINT` | Pi RPC server URL (default: `http://localhost:3284`) |
-| `AUTOCONTEXT_PI_RPC_API_KEY` | Pi RPC API key |
-| `AUTOCONTEXT_PI_RPC_SESSION_PERSISTENCE` | Persist Pi sessions across turns (default: `true`) |
+| Variable                                                             | Purpose                                                                                             |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `AUTOCONTEXT_AGENT_PROVIDER`                                         | Agent provider: `anthropic`, `openai-compatible`, `ollama`, `vllm`, `pi`, `pi-rpc`, `deterministic` |
+| `AUTOCONTEXT_AGENT_API_KEY`                                          | Global agent API key override (or use provider-native env vars such as `ANTHROPIC_API_KEY`)         |
+| `AUTOCONTEXT_AGENT_BASE_URL`                                         | Global base URL for OpenAI-compatible agent endpoints                                               |
+| `AUTOCONTEXT_COMPETITOR_API_KEY` / `AUTOCONTEXT_COMPETITOR_BASE_URL` | Optional competitor-specific credential and endpoint override                                       |
+| `AUTOCONTEXT_ANALYST_API_KEY` / `AUTOCONTEXT_ANALYST_BASE_URL`       | Optional analyst-specific credential and endpoint override                                          |
+| `AUTOCONTEXT_COACH_API_KEY` / `AUTOCONTEXT_COACH_BASE_URL`           | Optional coach-specific credential and endpoint override                                            |
+| `AUTOCONTEXT_ARCHITECT_API_KEY` / `AUTOCONTEXT_ARCHITECT_BASE_URL`   | Optional architect-specific credential and endpoint override                                        |
+| `AUTOCONTEXT_JUDGE_PROVIDER`                                         | Judge provider (defaults to `anthropic`)                                                            |
+| `AUTOCONTEXT_JUDGE_API_KEY`                                          | API key for the judge provider                                                                      |
+| `AUTOCONTEXT_JUDGE_BASE_URL`                                         | Base URL for OpenAI-compatible judge endpoints                                                      |
+| `AUTOCONTEXT_JUDGE_MODEL`                                            | Override judge model name                                                                           |
+| `AUTOCONTEXT_CLAUDE_MODEL`                                           | Claude CLI model alias (default: `sonnet`)                                                          |
+| `AUTOCONTEXT_CLAUDE_TIMEOUT`                                         | Claude CLI execution timeout in seconds (default: 120)                                              |
+| `AUTOCONTEXT_MODEL_COMPETITOR`                                       | Override competitor agent model                                                                     |
+| `AUTOCONTEXT_DB_PATH`                                                | SQLite database path                                                                                |
+| `AUTOCONTEXT_PI_COMMAND`                                             | Path to Pi CLI binary (default: `pi`)                                                               |
+| `AUTOCONTEXT_PI_TIMEOUT`                                             | Pi CLI execution timeout in seconds (default: 120)                                                  |
+| `AUTOCONTEXT_PI_WORKSPACE`                                           | Pi CLI working directory                                                                            |
+| `AUTOCONTEXT_PI_MODEL`                                               | Manual Pi model override (pins a specific checkpoint/path)                                          |
+| `AUTOCONTEXT_PI_NO_CONTEXT_FILES`                                    | Disable Pi context file loading (`AGENTS.md`, `CLAUDE.md`) for deterministic/eval-style runs        |
+| `AUTOCONTEXT_PI_RPC_ENDPOINT`                                        | Legacy compatibility field for older HTTP-based experiments; current Pi RPC runtime does not use it |
+| `AUTOCONTEXT_PI_RPC_API_KEY`                                         | Legacy compatibility field for older HTTP-based experiments; current Pi RPC runtime does not use it |
+| `AUTOCONTEXT_PI_RPC_SESSION_PERSISTENCE`                             | Toggle Pi session persistence when launching `pi --mode rpc` (default: `true`)                      |
 
 #### Pi CLI vs Pi RPC
 
 **Pi CLI** (`AUTOCONTEXT_AGENT_PROVIDER=pi`) invokes the `pi` binary in non-interactive `--print` mode for each agent turn. Best for:
+
 - Simple setups where Pi is installed locally
 - Stateless, one-shot agent executions
 - CI/testing environments
 
-**Pi RPC** (`AUTOCONTEXT_AGENT_PROVIDER=pi-rpc`) communicates with Pi via HTTP RPC. Best for:
-- Session persistence across multi-turn improvement loops
-- Branch-on-retry strategies (Pi creates branches for each retry)
-- Remote Pi instances running as a service
+**Pi RPC** (`AUTOCONTEXT_AGENT_PROVIDER=pi-rpc`) launches a local Pi subprocess in `--mode rpc` and exchanges LF-delimited JSONL over stdin/stdout. Best for:
+
+- Aligning autocontext with Pi's documented RPC protocol
+- Session-aware Pi runs when Pi session persistence is enabled
+- Local environments where the `pi` binary is available
 
 Both support **scenario-aware model handoff** when scenario context is available and no manual Pi model override is set. In that case, autocontext checks the distillation model registry for a scenario-specific checkpoint and routes to it automatically. If `AUTOCONTEXT_PI_MODEL` is set, that value is treated as a manual pin and used directly instead of consulting the registry. This enables the distill→deploy loop where a fine-tuned model is used for specific scenarios while still allowing operators to force a specific checkpoint when needed.
+
+Set `AUTOCONTEXT_PI_NO_CONTEXT_FILES=true` when you need Pi runs to ignore repository context files such as `AGENTS.md` and `CLAUDE.md`, which is especially useful for reproducible evaluations and other contamination-sensitive workflows.
 
 #### Hermes via OpenAI-Compatible Gateway
 
 Hermes exposes an OpenAI-compatible API server, so the fastest way to connect autocontext to Hermes is through the existing `openai-compatible` provider.
 
 **When to use the gateway path:**
+
 - You have a Hermes instance already running (local or remote)
 - You want the lowest-friction setup with standard chat-completions semantics
 - The OpenAI chat completions API surface is sufficient for your use case
 
 **Caveats:**
+
 - **Model naming**: Use the exact model name your Hermes server reports (e.g. `hermes-3-llama-3.1-8b`). Check `GET /v1/models` on your Hermes endpoint.
 - **Determinism**: Hermes temperature behavior may differ from OpenAI. Set `AUTOCONTEXT_JUDGE_TEMPERATURE=0.0` explicitly for reproducible evaluations.
 - **Memory/sessions**: The gateway path is stateless per-request. Hermes memory and tool configuration are server-side concerns, not managed by autocontext.
@@ -341,11 +357,13 @@ Hermes exposes an OpenAI-compatible API server, so the fastest way to connect au
 autocontext also supports Hermes directly through `AUTOCONTEXT_AGENT_PROVIDER=hermes`, which shells out to `hermes chat --query ...` instead of using the OpenAI-compatible gateway.
 
 **When to use the native runtime path:**
+
 - You want Hermes CLI behavior directly, including local SOUL/skill/tool configuration that Hermes applies in its own runtime
 - You want Hermes to run in a specific working directory via `AUTOCONTEXT_HERMES_WORKSPACE`
 - You want autocontext to call the local Hermes CLI without standing up a separate OpenAI-compatible server
 
 **Tradeoffs:**
+
 - **Still one-shot**: autocontext invokes Hermes in single-query mode. This is not the same thing as resuming a long-lived interactive Hermes chat session.
 - **CLI dependency**: The `hermes` binary must be installed and available on `PATH` (or configured via `AUTOCONTEXT_HERMES_COMMAND`).
 - **Endpoint overrides**: `AUTOCONTEXT_HERMES_BASE_URL` and `AUTOCONTEXT_HERMES_API_KEY` are forwarded into Hermes's provider env for custom OpenAI-compatible backends.
@@ -492,12 +510,12 @@ autoctx solve \
 
 #### When to use which integration path
 
-| Path | Best for | Complexity |
-|------|----------|-----------|
-| **CLI-first** (this section) | Hermes agents driving `autoctx` via shell commands | Lowest |
-| **OpenAI-compatible provider** | autocontext calling Hermes for agent/judge completions | Low |
-| **MCP server** | Tool-catalog agents (Claude Code, MCP clients) | Medium |
-| **Native Hermes runtime** | autocontext calling the local Hermes CLI with Hermes-side workspace/skill context | Highest |
+| Path                           | Best for                                                                          | Complexity |
+| ------------------------------ | --------------------------------------------------------------------------------- | ---------- |
+| **CLI-first** (this section)   | Hermes agents driving `autoctx` via shell commands                                | Lowest     |
+| **OpenAI-compatible provider** | autocontext calling Hermes for agent/judge completions                            | Low        |
+| **MCP server**                 | Tool-catalog agents (Claude Code, MCP clients)                                    | Medium     |
+| **Native Hermes runtime**      | autocontext calling the local Hermes CLI with Hermes-side workspace/skill context | Highest    |
 
 The CLI-first path is recommended for getting started. Move to the gateway or native provider paths when you want autocontext to call Hermes instead of Hermes calling autocontext.
 
@@ -574,6 +592,7 @@ Once the server is running, invoke tools via the MCP protocol:
 ```
 
 Response:
+
 ```json
 {
   "content": [
@@ -619,6 +638,7 @@ This starts the autocontext MCP server on stdio when Hermes connects.
 For safe Hermes exposure, consider allowing tools by category:
 
 **Read-only (safe for any operator):**
+
 - `mcp_autocontext_list_scenarios` — Browse available scenarios
 - `mcp_autocontext_describe_scenario` — Get scenario details, rules, strategy interface
 - `mcp_autocontext_read_playbook` — Read accumulated strategy playbook
@@ -631,12 +651,14 @@ For safe Hermes exposure, consider allowing tools by category:
 - `mcp_autocontext_list_solved` — List scenarios with exported knowledge
 
 **Evaluation (stateless, safe):**
+
 - `mcp_autocontext_evaluate_output` — One-shot judge evaluation
 - `mcp_autocontext_validate_strategy` — Validate strategy JSON against scenario constraints
 - `mcp_autocontext_run_match` — Run a single match (deterministic)
 - `mcp_autocontext_run_tournament` — Run N matches with Elo scoring
 
 **Write operations (require operator trust):**
+
 - `mcp_autocontext_run_replay` — Replay a generation
 - `mcp_autocontext_export_skill` — Export strategy package
 - `mcp_autocontext_solve_scenario` — Launch a solve job (long-running, creates artifacts)
@@ -647,51 +669,65 @@ For safe Hermes exposure, consider allowing tools by category:
 Once configured, a Hermes agent can drive the full autocontext loop:
 
 **1. Discover scenarios:**
+
 ```
 Use autocontext_list_scenarios to see what's available.
 ```
+
 → Returns JSON array of scenario names with descriptions.
 
 **2. Inspect a scenario:**
+
 ```
 Use autocontext_describe_scenario with scenario_name="grid_ctf".
 ```
+
 → Returns rules, strategy interface, evaluation criteria, and scoring dimensions.
 
 **3. Validate a strategy:**
+
 ```
 Use autocontext_validate_strategy with scenario_name="grid_ctf" and
 strategy='{"aggression": 0.6, "defense": 0.4, "path_bias": 0.5}'.
 ```
+
 → Returns `{"valid": true, "reason": "ok"}` or validation errors.
 
 **4. Run a tournament:**
+
 ```
 Use autocontext_run_tournament with scenario_name="grid_ctf",
 strategy='{"aggression": 0.6, "defense": 0.4, "path_bias": 0.5}',
 matches=5.
 ```
+
 → Returns mean/best scores, Elo, wins/losses.
 
 **5. Read the playbook:**
+
 ```
 Use autocontext_read_playbook with scenario_name="grid_ctf".
 ```
+
 → Returns the accumulated playbook markdown (or sentinel if none exists).
 
 **6. Export knowledge:**
+
 ```
 Use autocontext_export_skill with scenario_name="grid_ctf".
 ```
+
 → Returns a portable skill package with playbook, lessons, best strategy.
 
 **7. Install the exported skill into Hermes:**
+
 ```
 Take the result from autocontext_export_skill, read result.skill_markdown and
 result.suggested_filename, and write the markdown into your Hermes skill directory.
 ```
 
 For raw MCP clients, `autocontext_export_skill` returns structured JSON that now includes:
+
 - `skill_markdown` — the rendered `SKILL.md` contents
 - `suggested_filename` — the recommended install filename, such as `grid-ctf-knowledge.md`
 
@@ -711,19 +747,20 @@ After writing the file, restart Hermes or reload its skills so the new knowledge
 All tools use the `autocontext_` prefix (e.g., `autocontext_list_scenarios`). This is deliberate — it prevents collisions in multi-MCP-server setups. In Hermes, the prefix is visible in tool discovery and helps distinguish autocontext tools from other MCP servers.
 
 **Known rough edges:**
+
 - Tool names are verbose — Hermes agents may need explicit instruction to use the `autocontext_` prefix
 - `autocontext_solve_scenario` is long-running and returns a `job_id`; poll with `autocontext_solve_status`
 - Sandbox tools require explicit create/destroy lifecycle management
 
 #### MCP vs CLI-First for Hermes
 
-| Aspect | MCP | CLI-first |
-|--------|-----|-----------|
-| **Setup** | Config in `mcp_servers` | Set env vars |
-| **Tool discovery** | Automatic (Hermes sees all tools) | Manual (`autoctx --help`) |
-| **Output format** | Structured MCP responses | `--json` stdout |
-| **Long-running jobs** | Poll via `autocontext_solve_status` | Poll via `autoctx status` |
-| **Best for** | Hermes agents with MCP support | Hermes agents with shell access |
+| Aspect                | MCP                                 | CLI-first                       |
+| --------------------- | ----------------------------------- | ------------------------------- |
+| **Setup**             | Config in `mcp_servers`             | Set env vars                    |
+| **Tool discovery**    | Automatic (Hermes sees all tools)   | Manual (`autoctx --help`)       |
+| **Output format**     | Structured MCP responses            | `--json` stdout                 |
+| **Long-running jobs** | Poll via `autocontext_solve_status` | Poll via `autoctx status`       |
+| **Best for**          | Hermes agents with MCP support      | Hermes agents with shell access |
 
 Use MCP when Hermes has native MCP client support and you want automatic tool discovery. Use CLI-first when you want simpler debugging or are scripting a workflow.
 

--- a/autocontext/src/autocontext/agents/llm_client.py
+++ b/autocontext/src/autocontext/agents/llm_client.py
@@ -207,19 +207,19 @@ class DeterministicDevClient(LanguageModelClient):
         del max_tokens, temperature, role
         self._rlm_turn_counter += 1
         if self._rlm_turn_counter == 1:
-            text = '<code>\nprint(type(answer))\nprint(answer)\n</code>'
+            text = "<code>\nprint(type(answer))\nprint(answer)\n</code>"
         elif self._rlm_turn_counter == 2:
             text = (
                 "<code>\n"
-                "answer[\"content\"] = (\n"
-                "    \"## Findings\\n\\n\"\n"
-                "    \"- Strategy balances offense/defense.\\n\\n\"\n"
-                "    \"## Root Causes\\n\\n\"\n"
-                "    \"- Moderate aggressiveness.\\n\\n\"\n"
-                "    \"## Actionable Recommendations\\n\\n\"\n"
-                "    \"- Increase defensive weight.\"\n"
+                'answer["content"] = (\n'
+                '    "## Findings\\n\\n"\n'
+                '    "- Strategy balances offense/defense.\\n\\n"\n'
+                '    "## Root Causes\\n\\n"\n'
+                '    "- Moderate aggressiveness.\\n\\n"\n'
+                '    "## Actionable Recommendations\\n\\n"\n'
+                '    "- Increase defensive weight."\n'
                 ")\n"
-                "answer[\"ready\"] = True\n"
+                'answer["ready"] = True\n'
                 "</code>"
             )
         else:
@@ -359,35 +359,44 @@ class DeterministicDevClient(LanguageModelClient):
             "name": "resource_balance",
             "display_name": "Resource Balance",
             "description": (
-                "A resource management scenario where agents balance mining, "
-                "defense, and trade to maximize colony growth."
+                "A resource management scenario where agents balance mining, defense, and trade to maximize colony growth."
             ),
             "strategy_interface_description": (
                 "Return JSON object with keys `mining`, `defense`, and `trade`, all floats in [0,1]. "
                 "Constraint: mining + defense + trade <= 2.0."
             ),
             "evaluation_criteria": (
-                "Optimize colony growth through efficient resource "
-                "allocation across mining, defense, and trade."
+                "Optimize colony growth through efficient resource allocation across mining, defense, and trade."
             ),
             "strategy_params": [
                 {
-                    "name": "mining", "description": "Investment in resource extraction",
-                    "min_value": 0.0, "max_value": 1.0, "default": 0.5,
+                    "name": "mining",
+                    "description": "Investment in resource extraction",
+                    "min_value": 0.0,
+                    "max_value": 1.0,
+                    "default": 0.5,
                 },
                 {
-                    "name": "defense", "description": "Investment in colony protection",
-                    "min_value": 0.0, "max_value": 1.0, "default": 0.4,
+                    "name": "defense",
+                    "description": "Investment in colony protection",
+                    "min_value": 0.0,
+                    "max_value": 1.0,
+                    "default": 0.4,
                 },
                 {
-                    "name": "trade", "description": "Investment in trade routes",
-                    "min_value": 0.0, "max_value": 1.0, "default": 0.5,
+                    "name": "trade",
+                    "description": "Investment in trade routes",
+                    "min_value": 0.0,
+                    "max_value": 1.0,
+                    "default": 0.5,
                 },
             ],
             "constraints": [
                 {
-                    "expression": "mining + defense + trade", "operator": "<=",
-                    "threshold": 2.0, "description": "total allocation must be <= 2.0",
+                    "expression": "mining + defense + trade",
+                    "operator": "<=",
+                    "threshold": 2.0,
+                    "description": "total allocation must be <= 2.0",
                 },
             ],
             "environment_variables": [
@@ -536,8 +545,7 @@ def build_client_from_settings(
         )
         if not api_key:
             raise ValueError(
-                "AUTOCONTEXT_ANTHROPIC_API_KEY or ANTHROPIC_API_KEY is required "
-                "when AUTOCONTEXT_AGENT_PROVIDER=anthropic"
+                "AUTOCONTEXT_ANTHROPIC_API_KEY or ANTHROPIC_API_KEY is required when AUTOCONTEXT_AGENT_PROVIDER=anthropic"
             )
         return AnthropicClient(api_key=api_key)
     if settings.agent_provider == "deterministic":
@@ -618,6 +626,7 @@ def build_client_from_settings(
             timeout=settings.pi_timeout,
             workspace=settings.pi_workspace,
             model=resolved_model,
+            no_context_files=settings.pi_no_context_files,
         )
         return RuntimeBridgeClient(PiCLIRuntime(pi_config))
     if settings.agent_provider == "pi-rpc":
@@ -628,6 +637,7 @@ def build_client_from_settings(
             pi_command=settings.pi_command,
             timeout=settings.pi_timeout,
             session_persistence=settings.pi_rpc_session_persistence,
+            no_context_files=settings.pi_no_context_files,
         )
         return RuntimeBridgeClient(PiRPCRuntime(rpc_config))
     if settings.agent_provider == "hermes":

--- a/autocontext/src/autocontext/agents/llm_client.py
+++ b/autocontext/src/autocontext/agents/llm_client.py
@@ -635,6 +635,7 @@ def build_client_from_settings(
 
         rpc_config = PiRPCConfig(
             pi_command=settings.pi_command,
+            model=settings.pi_model,
             timeout=settings.pi_timeout,
             session_persistence=settings.pi_rpc_session_persistence,
             no_context_files=settings.pi_no_context_files,

--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -328,6 +328,7 @@ def create_role_client(
             timeout=settings.pi_timeout,
             workspace=settings.pi_workspace,
             model=resolved_model,
+            no_context_files=settings.pi_no_context_files,
         )
         return RuntimeBridgeClient(PiCLIRuntime(pi_config))
 
@@ -338,6 +339,7 @@ def create_role_client(
             pi_command=settings.pi_command,
             timeout=settings.pi_timeout,
             session_persistence=settings.pi_rpc_session_persistence,
+            no_context_files=settings.pi_no_context_files,
         )
         return RuntimeBridgeClient(PiRPCRuntime(rpc_config))
 

--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -337,6 +337,7 @@ def create_role_client(
 
         rpc_config = PiRPCConfig(
             pi_command=settings.pi_command,
+            model=settings.pi_model,
             timeout=settings.pi_timeout,
             session_persistence=settings.pi_rpc_session_persistence,
             no_context_files=settings.pi_no_context_files,

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -578,16 +578,29 @@ class AppSettings(BaseModel):
     pi_timeout: float = Field(default=PI_DEFAULT_TIMEOUT_SECONDS, ge=1.0, description="Pi execution timeout")
     pi_workspace: str = Field(default="", description="Pi workspace directory")
     pi_model: str = Field(default="", description="Pi model override")
+    pi_no_context_files: bool = Field(
+        default=False,
+        description="Disable Pi context file loading (e.g. AGENTS.md / CLAUDE.md) for deterministic runs",
+    )
     # Codex CLI runtime (AC-317)
     codex_model: str = Field(default="o4-mini", description="Codex CLI model")
     codex_timeout: float = Field(default=120.0, ge=1.0, description="Codex CLI execution timeout")
     codex_workspace: str = Field(default="", description="Codex CLI working directory")
     codex_approval_mode: str = Field(default="full-auto", description="Codex CLI approval mode")
     codex_quiet: bool = Field(default=False, description="Use Codex CLI quiet mode")
-    # Pi RPC spike (AC-225)
-    pi_rpc_endpoint: str = Field(default="", description="Pi RPC endpoint URL")
-    pi_rpc_api_key: str = Field(default="", description="Pi RPC API key")
-    pi_rpc_session_persistence: bool = Field(default=True, description="Persist Pi sessions across turns")
+    # Pi RPC runtime (subprocess JSONL; endpoint/api_key retained for backwards compatibility)
+    pi_rpc_endpoint: str = Field(
+        default="",
+        description="Legacy compatibility field for older HTTP-based Pi RPC experiments; current runtime ignores it",
+    )
+    pi_rpc_api_key: str = Field(
+        default="",
+        description="Legacy compatibility field for older HTTP-based Pi RPC experiments; current runtime ignores it",
+    )
+    pi_rpc_session_persistence: bool = Field(
+        default=True,
+        description="Persist Pi sessions across turns when launching pi --mode rpc",
+    )
     # Hermes CLI runtime (AC-351)
     hermes_command: str = Field(default="hermes", description="Path to Hermes CLI binary")
     hermes_model: str = Field(default="", description="Hermes model override")

--- a/autocontext/src/autocontext/providers/registry.py
+++ b/autocontext/src/autocontext/providers/registry.py
@@ -150,6 +150,7 @@ def get_provider(settings: AppSettings) -> LLMProvider:
             timeout=settings.pi_timeout,
             workspace=settings.pi_workspace,
             model=settings.pi_model,
+            no_context_files=settings.pi_no_context_files,
         ))
         return RuntimeBridgeProvider(pi_runtime, default_model_name=settings.pi_model or "pi-default")
 
@@ -162,6 +163,7 @@ def get_provider(settings: AppSettings) -> LLMProvider:
             model=settings.pi_model or settings.judge_model,
             timeout=settings.pi_timeout,
             session_persistence=settings.pi_rpc_session_persistence,
+            no_context_files=settings.pi_no_context_files,
         ))
         return RuntimeBridgeProvider(
             pi_rpc_runtime,

--- a/autocontext/src/autocontext/runtimes/pi_cli.py
+++ b/autocontext/src/autocontext/runtimes/pi_cli.py
@@ -29,6 +29,7 @@ class PiCLIConfig:
     timeout: float = PI_DEFAULT_TIMEOUT_SECONDS
     json_output: bool = True
     workspace: str = ""
+    no_context_files: bool = False
     extra_args: list[str] = field(default_factory=list)
 
 
@@ -90,6 +91,8 @@ class PiCLIRuntime(AgentRuntime):
 
         if self._config.model:
             args.extend(["--model", self._config.model])
+        if self._config.no_context_files:
+            args.append("--no-context-files")
 
         # NOTE: Pi does not have a --workspace CLI flag.
         # Workspace is passed as subprocess cwd instead (see _invoke).

--- a/autocontext/src/autocontext/runtimes/pi_rpc.py
+++ b/autocontext/src/autocontext/runtimes/pi_rpc.py
@@ -34,6 +34,7 @@ class PiRPCConfig:
     model: str = ""
     timeout: float = 120.0
     session_persistence: bool = True
+    no_context_files: bool = False
     branch_on_retry: bool = True
     extra_args: list[str] = field(default_factory=list)
 
@@ -60,6 +61,8 @@ class PiRPCRuntime(AgentRuntime):
         args = [pi, "--mode", "rpc"]
         if self._config.model:
             args.extend(["--model", self._config.model])
+        if self._config.no_context_files:
+            args.append("--no-context-files")
         if not self._config.session_persistence:
             args.append("--no-session")
         args.extend(self._config.extra_args)

--- a/autocontext/src/autocontext/runtimes/pi_rpc.py
+++ b/autocontext/src/autocontext/runtimes/pi_rpc.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 
 import json
 import logging
+import queue
 import shutil
 import subprocess
+import threading
+import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Any
@@ -90,6 +93,49 @@ class PiRPCRuntime(AgentRuntime):
             metadata["stdout"] = stdout[:500]
         return AgentOutput(text="", metadata=metadata)
 
+    def _read_stream(self, stream: Any, sink: queue.Queue[str | None]) -> None:
+        try:
+            for line in stream:
+                sink.put(line)
+        finally:
+            sink.put(None)
+
+    def _drain_queue(self, source: queue.Queue[str | None], lines: list[str]) -> None:
+        while True:
+            try:
+                line = source.get_nowait()
+            except queue.Empty:
+                return
+            if line is not None:
+                lines.append(line)
+
+    def _is_terminal_rpc_event(self, line: str) -> bool:
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            return False
+        if not isinstance(event, dict):
+            return False
+        if event.get("type") == "agent_end":
+            return True
+        return event.get("type") == "response" and event.get("success") is False
+
+    def _shutdown_process(self, process: subprocess.Popen[str]) -> None:
+        if process.stdin and not process.stdin.closed:
+            try:
+                process.stdin.close()
+            except OSError:
+                logger.debug("runtimes.pi_rpc: suppressed stdin close error", exc_info=True)
+        try:
+            process.wait(timeout=1.0)
+        except subprocess.TimeoutExpired:
+            process.terminate()
+            try:
+                process.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=1.0)
+
     def generate(
         self,
         prompt: str,
@@ -104,35 +150,87 @@ class PiRPCRuntime(AgentRuntime):
         command = self._build_prompt_command(full_prompt)
 
         args = self._build_args()
+        stdout_queue: queue.Queue[str | None] = queue.Queue()
+        stderr_queue: queue.Queue[str | None] = queue.Queue()
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
+        process: subprocess.Popen[str] | None = None
         try:
-            # Send the prompt command as JSONL on stdin, read response on stdout
+            # Keep stdin open after the prompt ack so Pi can stream the agent result.
             input_line = json.dumps(command) + "\n"
-            result = subprocess.run(
+            process = subprocess.Popen(
                 args,
-                input=input_line,
-                capture_output=True,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                timeout=self._config.timeout,
             )
+            if process.stdin is None or process.stdout is None or process.stderr is None:
+                return AgentOutput(text="", metadata={"error": "pi_rpc_pipe_unavailable"})
+
+            threading.Thread(target=self._read_stream, args=(process.stdout, stdout_queue), daemon=True).start()
+            threading.Thread(target=self._read_stream, args=(process.stderr, stderr_queue), daemon=True).start()
+
+            process.stdin.write(input_line)
+            process.stdin.flush()
+
+            deadline = time.monotonic() + self._config.timeout
+            saw_stdout_eof = False
+            terminal_seen = False
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise subprocess.TimeoutExpired(args, self._config.timeout)
+
+                try:
+                    line = stdout_queue.get(timeout=min(0.1, remaining))
+                except queue.Empty:
+                    self._drain_queue(stderr_queue, stderr_lines)
+                    if process.poll() is not None and saw_stdout_eof:
+                        break
+                    continue
+
+                if line is None:
+                    saw_stdout_eof = True
+                    if process.poll() is not None:
+                        break
+                    continue
+
+                stdout_lines.append(line)
+                if self._is_terminal_rpc_event(line):
+                    terminal_seen = True
+                    break
+
+            self._drain_queue(stderr_queue, stderr_lines)
+            if terminal_seen:
+                self._shutdown_process(process)
+            else:
+                process.wait(timeout=1.0)
         except subprocess.TimeoutExpired:
             logger.error("pi RPC timed out after %.0fs", self._config.timeout)
+            if process is not None:
+                process.kill()
+                process.wait(timeout=1.0)
             return AgentOutput(text="", metadata={"error": "timeout"})
         except FileNotFoundError:
             logger.error("pi CLI not found at %r", self._config.pi_command)
             return AgentOutput(text="", metadata={"error": "pi_not_found"})
 
-        if result.returncode != 0 and not result.stdout.strip():
-            logger.warning("pi RPC exited with code %d: %s", result.returncode, result.stderr[:200])
-            return self._nonzero_exit_output(result.returncode, result.stderr)
+        stdout = "".join(stdout_lines)
+        stderr = "".join(stderr_lines)
+        returncode = process.returncode if process is not None and process.returncode is not None else 0
+        if returncode != 0 and not stdout.strip():
+            logger.warning("pi RPC exited with code %d: %s", returncode, stderr[:200])
+            return self._nonzero_exit_output(returncode, stderr)
 
         output = self._parse_rpc_output(
-            result.stdout,
-            exit_code=result.returncode,
-            stderr=result.stderr,
+            stdout,
+            exit_code=returncode,
+            stderr=stderr,
         )
-        if result.returncode != 0 and not output.metadata.get("error"):
-            logger.warning("pi RPC exited with code %d: %s", result.returncode, result.stderr[:200])
-            return self._nonzero_exit_output(result.returncode, result.stderr, result.stdout)
+        if returncode != 0 and not output.metadata.get("error"):
+            logger.warning("pi RPC exited with code %d: %s", returncode, stderr[:200])
+            return self._nonzero_exit_output(returncode, stderr, stdout)
         return output
 
     def revise(
@@ -164,6 +262,7 @@ class PiRPCRuntime(AgentRuntime):
         Falls back to the last non-empty line if no structured events found.
         """
         text_parts: list[str] = []
+        saw_json_event = False
 
         for line in raw.strip().split("\n"):
             line = line.strip()
@@ -171,6 +270,7 @@ class PiRPCRuntime(AgentRuntime):
                 continue
             try:
                 event = json.loads(line)
+                saw_json_event = True
                 event_type = event.get("type", "")
 
                 # Collect assistant text from message_end or response events
@@ -216,4 +316,13 @@ class PiRPCRuntime(AgentRuntime):
 
         if exit_code != 0:
             return self._nonzero_exit_output(exit_code, stderr, raw.strip())
+        if saw_json_event:
+            return AgentOutput(
+                text="",
+                metadata={
+                    "error": "missing_assistant_response",
+                    "exit_code": exit_code,
+                    "stdout": raw.strip()[:500],
+                },
+            )
         return AgentOutput(text=raw.strip(), metadata={"exit_code": exit_code})

--- a/autocontext/tests/test_pi_cli_runtime.py
+++ b/autocontext/tests/test_pi_cli_runtime.py
@@ -28,6 +28,7 @@ def test_config_defaults() -> None:
     assert c.timeout == PI_DEFAULT_TIMEOUT_SECONDS
     assert c.json_output is True
     assert c.workspace == ""
+    assert c.no_context_files is False
     assert c.extra_args == []
 
 
@@ -50,6 +51,7 @@ def test_settings_pi_fields_exist() -> None:
     assert s.pi_timeout == PI_DEFAULT_TIMEOUT_SECONDS
     assert s.pi_workspace == ""
     assert s.pi_model == ""
+    assert s.pi_no_context_files is False
 
 
 # ---------------------------------------------------------------------------
@@ -198,11 +200,19 @@ def test_generate_binary_not_found() -> None:
 
 
 def test_build_args_includes_model_and_prompt() -> None:
-    runtime = PiCLIRuntime(PiCLIConfig(model="pi-turbo", workspace="/tmp/ws", extra_args=["--verbose"]))
+    runtime = PiCLIRuntime(
+        PiCLIConfig(
+            model="pi-turbo",
+            workspace="/tmp/ws",
+            no_context_files=True,
+            extra_args=["--verbose"],
+        )
+    )
     with patch("shutil.which", return_value="/usr/bin/pi"):
         args = runtime._build_args("test prompt")
     assert "--model" in args
     assert "pi-turbo" in args
+    assert "--no-context-files" in args
     assert "--verbose" in args
     assert "test prompt" in args
     # workspace is NOT a Pi flag — handled via cwd

--- a/autocontext/tests/test_pi_provider_surface.py
+++ b/autocontext/tests/test_pi_provider_surface.py
@@ -19,6 +19,7 @@ from autocontext.config.settings import AppSettings
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _settings(**overrides: object) -> AppSettings:
     """Build an AppSettings with sensible defaults and overrides."""
     defaults = {
@@ -32,6 +33,7 @@ def _settings(**overrides: object) -> AppSettings:
 # ---------------------------------------------------------------------------
 # Pi CLI happy path
 # ---------------------------------------------------------------------------
+
 
 class TestPiCLIProvider:
     def test_build_client_accepts_pi_provider(self) -> None:
@@ -49,6 +51,7 @@ class TestPiCLIProvider:
             MockRuntime.return_value = MagicMock()
             client = build_client_from_settings(settings)
         from autocontext.agents.provider_bridge import RuntimeBridgeClient
+
         assert isinstance(client, RuntimeBridgeClient)
 
     def test_pi_passes_config_from_settings(self) -> None:
@@ -59,6 +62,7 @@ class TestPiCLIProvider:
             pi_timeout=60.0,
             pi_workspace="/my/workspace",
             pi_model="local-model",
+            pi_no_context_files=True,
         )
         with patch("autocontext.runtimes.pi_cli.PiCLIRuntime") as MockRuntime:
             MockRuntime.return_value = MagicMock()
@@ -68,6 +72,7 @@ class TestPiCLIProvider:
         assert config.pi_command == "/usr/local/bin/pi"
         assert config.timeout == 60.0
         assert config.workspace == "/my/workspace"
+        assert config.no_context_files is True
 
     def test_pi_resolves_scenario_model_handoff(self) -> None:
         """Scenario-aware Pi clients should resolve the active checkpoint via the registry."""
@@ -93,6 +98,7 @@ class TestPiCLIProvider:
 # Pi RPC happy path
 # ---------------------------------------------------------------------------
 
+
 class TestPiRPCProvider:
     def test_build_client_accepts_pi_rpc_provider(self) -> None:
         """``AUTOCONTEXT_AGENT_PROVIDER=pi-rpc`` should construct a valid client."""
@@ -115,6 +121,7 @@ class TestPiRPCProvider:
             MockRuntime.return_value = MagicMock()
             client = build_client_from_settings(settings)
         from autocontext.agents.provider_bridge import RuntimeBridgeClient
+
         assert isinstance(client, RuntimeBridgeClient)
 
     def test_pi_rpc_passes_config_from_settings(self) -> None:
@@ -123,6 +130,7 @@ class TestPiRPCProvider:
             agent_provider="pi-rpc",
             pi_timeout=90.0,
             pi_rpc_session_persistence=False,
+            pi_no_context_files=True,
         )
         with patch("autocontext.runtimes.pi_rpc.PiRPCRuntime") as MockRuntime:
             MockRuntime.return_value = MagicMock()
@@ -131,12 +139,14 @@ class TestPiRPCProvider:
         config = call_args[0][0] if call_args[0] else call_args[1].get("config")
         assert config.timeout == 90.0
         assert config.session_persistence is False
+        assert config.no_context_files is True
         assert config.pi_command == "pi"
 
 
 # ---------------------------------------------------------------------------
 # Misconfiguration
 # ---------------------------------------------------------------------------
+
 
 class TestPiMisconfiguration:
     def test_unknown_provider_still_raises(self) -> None:

--- a/autocontext/tests/test_pi_provider_surface.py
+++ b/autocontext/tests/test_pi_provider_surface.py
@@ -14,6 +14,7 @@ import pytest
 
 from autocontext.agents.llm_client import build_client_from_settings
 from autocontext.config.settings import AppSettings
+from autocontext.providers.registry import get_provider
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -129,6 +130,7 @@ class TestPiRPCProvider:
         settings = _settings(
             agent_provider="pi-rpc",
             pi_timeout=90.0,
+            pi_model="local-rpc-model",
             pi_rpc_session_persistence=False,
             pi_no_context_files=True,
         )
@@ -138,9 +140,40 @@ class TestPiRPCProvider:
         call_args = MockRuntime.call_args
         config = call_args[0][0] if call_args[0] else call_args[1].get("config")
         assert config.timeout == 90.0
+        assert config.model == "local-rpc-model"
         assert config.session_persistence is False
         assert config.no_context_files is True
         assert config.pi_command == "pi"
+
+
+# ---------------------------------------------------------------------------
+# Judge/provider registry parity
+# ---------------------------------------------------------------------------
+
+
+class TestPiRegistryProvider:
+    def test_registry_pi_passes_no_context_files(self) -> None:
+        settings = _settings(
+            judge_provider="pi",
+            pi_model="local-model",
+            pi_no_context_files=True,
+        )
+        provider = get_provider(settings)
+        config = provider._runtime._config  # type: ignore[attr-defined]
+        assert config.model == "local-model"
+        assert config.no_context_files is True
+
+    def test_registry_pi_rpc_passes_model_and_no_context_files(self) -> None:
+        settings = _settings(
+            judge_provider="pi-rpc",
+            judge_model="judge-model",
+            pi_model="local-rpc-model",
+            pi_no_context_files=True,
+        )
+        provider = get_provider(settings)
+        config = provider._runtime._config  # type: ignore[attr-defined]
+        assert config.model == "local-rpc-model"
+        assert config.no_context_files is True
 
 
 # ---------------------------------------------------------------------------

--- a/autocontext/tests/test_pi_rpc.py
+++ b/autocontext/tests/test_pi_rpc.py
@@ -18,17 +18,20 @@ from autocontext.runtimes.pi_rpc import PiRPCConfig, PiRPCRuntime
 # PiRPCConfig defaults
 # ---------------------------------------------------------------------------
 
+
 def test_config_defaults() -> None:
     c = PiRPCConfig()
     assert c.pi_command == "pi"
     assert c.timeout == 120.0
     assert c.session_persistence is True
+    assert c.no_context_files is False
     assert c.branch_on_retry is True
 
 
 # ---------------------------------------------------------------------------
 # Settings fields
 # ---------------------------------------------------------------------------
+
 
 def test_settings_pi_rpc_fields() -> None:
     s = AppSettings()
@@ -40,6 +43,7 @@ def test_settings_pi_rpc_fields() -> None:
 # ---------------------------------------------------------------------------
 # PiRPCRuntime build_args
 # ---------------------------------------------------------------------------
+
 
 def test_build_args_includes_mode_rpc() -> None:
     runtime = PiRPCRuntime()
@@ -61,17 +65,26 @@ def test_build_args_no_session() -> None:
     assert "--no-session" in args
 
 
+def test_build_args_no_context_files() -> None:
+    runtime = PiRPCRuntime(PiRPCConfig(no_context_files=True))
+    args = runtime._build_args()
+    assert "--no-context-files" in args
+
+
 # ---------------------------------------------------------------------------
 # PiRPCRuntime.generate() — mocked subprocess
 # ---------------------------------------------------------------------------
 
+
 def test_generate_success() -> None:
     """generate() sends JSONL command and parses response."""
     runtime = PiRPCRuntime()
-    rpc_response = json.dumps({
-        "type": "agent_end",
-        "messages": [{"role": "assistant", "content": "Strategy analysis complete."}],
-    })
+    rpc_response = json.dumps(
+        {
+            "type": "agent_end",
+            "messages": [{"role": "assistant", "content": "Strategy analysis complete."}],
+        }
+    )
     completed = MagicMock(returncode=0, stdout=rpc_response + "\n", stderr="")
     with patch("subprocess.run", return_value=completed) as mock_run:
         output = runtime.generate("Analyze this strategy")
@@ -96,12 +109,14 @@ def test_generate_timeout() -> None:
 def test_generate_rpc_error_response() -> None:
     """generate() surfaces Pi RPC error responses as errors, not model text."""
     runtime = PiRPCRuntime()
-    rpc_response = json.dumps({
-        "type": "response",
-        "command": "prompt",
-        "success": False,
-        "error": "bad payload",
-    })
+    rpc_response = json.dumps(
+        {
+            "type": "response",
+            "command": "prompt",
+            "success": False,
+            "error": "bad payload",
+        }
+    )
     completed = MagicMock(returncode=0, stdout=rpc_response + "\n", stderr="")
     with patch("subprocess.run", return_value=completed):
         output = runtime.generate("test")
@@ -126,10 +141,12 @@ def test_generate_nonzero_exit_without_stdout() -> None:
 def test_revise_success() -> None:
     """revise() sends a revision prompt through generate()."""
     runtime = PiRPCRuntime()
-    rpc_response = json.dumps({
-        "type": "agent_end",
-        "messages": [{"role": "assistant", "content": "Revised output."}],
-    })
+    rpc_response = json.dumps(
+        {
+            "type": "agent_end",
+            "messages": [{"role": "assistant", "content": "Revised output."}],
+        }
+    )
     completed = MagicMock(returncode=0, stdout=rpc_response + "\n", stderr="")
     with patch("subprocess.run", return_value=completed):
         output = runtime.revise("original", "prev output", "feedback")
@@ -139,6 +156,7 @@ def test_revise_success() -> None:
 # ---------------------------------------------------------------------------
 # create_role_client integration
 # ---------------------------------------------------------------------------
+
 
 def test_create_role_client_pi_rpc() -> None:
     """create_role_client('pi-rpc') should return a RuntimeBridgeClient."""

--- a/autocontext/tests/test_pi_rpc.py
+++ b/autocontext/tests/test_pi_rpc.py
@@ -7,12 +7,56 @@ stdin/stdout with JSONL framing.
 
 from __future__ import annotations
 
+import io
 import json
 from unittest.mock import MagicMock, patch
 
 from autocontext.agents.provider_bridge import RuntimeBridgeClient, create_role_client
 from autocontext.config.settings import AppSettings
 from autocontext.runtimes.pi_rpc import PiRPCConfig, PiRPCRuntime
+
+
+class _FakeStdin:
+    def __init__(self) -> None:
+        self.value = ""
+        self.closed = False
+
+    def write(self, text: str) -> int:
+        self.value += text
+        return len(text)
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakePopen:
+    def __init__(self, stdout: str, stderr: str = "", returncode: int = 0, *, never_exits: bool = False) -> None:
+        self.stdin = _FakeStdin()
+        self.stdout = io.StringIO(stdout)
+        self.stderr = io.StringIO(stderr)
+        self.returncode = None if never_exits else returncode
+        self._returncode = returncode
+        self._never_exits = never_exits
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        if self.returncode is None:
+            self.returncode = self._returncode
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
 
 # ---------------------------------------------------------------------------
 # PiRPCConfig defaults
@@ -79,31 +123,37 @@ def test_build_args_no_context_files() -> None:
 def test_generate_success() -> None:
     """generate() sends JSONL command and parses response."""
     runtime = PiRPCRuntime()
-    rpc_response = json.dumps(
-        {
-            "type": "agent_end",
-            "messages": [{"role": "assistant", "content": "Strategy analysis complete."}],
-        }
+    rpc_response = "\n".join(
+        [
+            json.dumps({"type": "response", "command": "prompt", "success": True}),
+            json.dumps(
+                {
+                    "type": "agent_end",
+                    "messages": [{"role": "assistant", "content": "Strategy analysis complete."}],
+                }
+            ),
+        ]
     )
-    completed = MagicMock(returncode=0, stdout=rpc_response + "\n", stderr="")
-    with patch("subprocess.run", return_value=completed) as mock_run:
+    process = _FakePopen(rpc_response + "\n")
+    with patch("subprocess.Popen", return_value=process):
         output = runtime.generate("Analyze this strategy")
-    sent = json.loads(mock_run.call_args.kwargs["input"])
+    sent = json.loads(process.stdin.value)
     assert sent["message"] == "Analyze this strategy"
     assert "content" not in sent
+    assert process.stdin.closed is True
     assert output.text == "Strategy analysis complete."
     assert output.metadata["exit_code"] == 0
 
 
 def test_generate_timeout() -> None:
     """generate() handles subprocess timeout gracefully."""
-    import subprocess as sp
-
-    runtime = PiRPCRuntime()
-    with patch("subprocess.run", side_effect=sp.TimeoutExpired("pi", 120)):
+    runtime = PiRPCRuntime(PiRPCConfig(timeout=0.01))
+    process = _FakePopen("", never_exits=True)
+    with patch("subprocess.Popen", return_value=process):
         output = runtime.generate("test")
     assert output.text == ""
     assert output.metadata.get("error") == "timeout"
+    assert process.killed is True
 
 
 def test_generate_rpc_error_response() -> None:
@@ -117,8 +167,8 @@ def test_generate_rpc_error_response() -> None:
             "error": "bad payload",
         }
     )
-    completed = MagicMock(returncode=0, stdout=rpc_response + "\n", stderr="")
-    with patch("subprocess.run", return_value=completed):
+    process = _FakePopen(rpc_response + "\n")
+    with patch("subprocess.Popen", return_value=process):
         output = runtime.generate("test")
     assert output.text == ""
     assert output.metadata["error"] == "rpc_response_error"
@@ -129,13 +179,24 @@ def test_generate_rpc_error_response() -> None:
 def test_generate_nonzero_exit_without_stdout() -> None:
     """generate() surfaces transport/process failures when Pi exits non-zero."""
     runtime = PiRPCRuntime()
-    completed = MagicMock(returncode=2, stdout="", stderr="permission denied")
-    with patch("subprocess.run", return_value=completed):
+    process = _FakePopen("", stderr="permission denied", returncode=2)
+    with patch("subprocess.Popen", return_value=process):
         output = runtime.generate("test")
     assert output.text == ""
     assert output.metadata["error"] == "nonzero_exit"
     assert output.metadata["exit_code"] == 2
     assert output.metadata["stderr"] == "permission denied"
+
+
+def test_generate_prompt_ack_without_assistant_response_is_error() -> None:
+    """The prompt ack is not the final model response."""
+    runtime = PiRPCRuntime()
+    rpc_response = json.dumps({"type": "response", "command": "prompt", "success": True})
+    process = _FakePopen(rpc_response + "\n")
+    with patch("subprocess.Popen", return_value=process):
+        output = runtime.generate("test")
+    assert output.text == ""
+    assert output.metadata["error"] == "missing_assistant_response"
 
 
 def test_revise_success() -> None:
@@ -147,8 +208,8 @@ def test_revise_success() -> None:
             "messages": [{"role": "assistant", "content": "Revised output."}],
         }
     )
-    completed = MagicMock(returncode=0, stdout=rpc_response + "\n", stderr="")
-    with patch("subprocess.run", return_value=completed):
+    process = _FakePopen(rpc_response + "\n")
+    with patch("subprocess.Popen", return_value=process):
         output = runtime.revise("original", "prev output", "feedback")
     assert output.text == "Revised output."
 

--- a/autocontext/tests/test_pi_smoke.py
+++ b/autocontext/tests/test_pi_smoke.py
@@ -95,6 +95,7 @@ def _complete_smoke_generation(
 # Documented env var → load_settings → build_client round-trip
 # ---------------------------------------------------------------------------
 
+
 class TestPiEnvVarRoundTrip:
     """Verify the documented env var combinations load and produce valid clients."""
 
@@ -128,14 +129,16 @@ class TestPiEnvVarRoundTrip:
             client = build_client_from_settings(settings)
         assert isinstance(client, RuntimeBridgeClient)
 
-    def test_pi_workspace_and_model_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_pi_workspace_model_and_no_context_files_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Verify optional Pi env vars are preserved through load_settings."""
         monkeypatch.setenv("AUTOCONTEXT_AGENT_PROVIDER", "pi")
         monkeypatch.setenv("AUTOCONTEXT_PI_WORKSPACE", "/my/workspace")
         monkeypatch.setenv("AUTOCONTEXT_PI_MODEL", "distilled-v2")
+        monkeypatch.setenv("AUTOCONTEXT_PI_NO_CONTEXT_FILES", "true")
         settings = load_settings()
         assert settings.pi_workspace == "/my/workspace"
         assert settings.pi_model == "distilled-v2"
+        assert settings.pi_no_context_files is True
 
     def test_pi_rpc_session_persistence_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Verify PI_RPC_SESSION_PERSISTENCE coerces string to bool."""
@@ -148,6 +151,7 @@ class TestPiEnvVarRoundTrip:
 # ---------------------------------------------------------------------------
 # Scenario-aware Pi model handoff
 # ---------------------------------------------------------------------------
+
 
 class TestPiScenarioHandoff:
     """Verify scenario-aware routing through the public entrypoint."""
@@ -214,6 +218,7 @@ class TestPiScenarioHandoff:
 # Per-role Pi overrides through create_role_client
 # ---------------------------------------------------------------------------
 
+
 class TestPiRoleOverride:
     """Verify Pi works as a per-role provider override (competitor_provider=pi)."""
 
@@ -243,6 +248,7 @@ class TestPiRoleOverride:
 # ---------------------------------------------------------------------------
 # Live autoctx run smoke path
 # ---------------------------------------------------------------------------
+
 
 class TestPiRunSmoke:
     """Verify the documented Pi setup survives the real CLI/runner entrypoint."""
@@ -281,10 +287,7 @@ class TestPiRunSmoke:
         assert result.exit_code == 0, result.output
         assert "competitor" in resolved_clients
         assert "analyst" in resolved_clients
-        assert any(
-            call.kwargs.get("scenario") == "grid_ctf"
-            for call in mock_resolve.call_args_list
-        )
+        assert any(call.kwargs.get("scenario") == "grid_ctf" for call in mock_resolve.call_args_list)
         assert any(
             (call.args[0].model if call.args else call.kwargs["config"].model) == "/models/grid-ctf/pi-v4"
             for call in mock_runtime.call_args_list
@@ -333,6 +336,7 @@ class TestPiRunSmoke:
 # ---------------------------------------------------------------------------
 # Failure modes
 # ---------------------------------------------------------------------------
+
 
 class TestPiFailureModes:
     """Verify broken Pi setups produce intelligible errors."""

--- a/ts/src/config/app-settings-schema.ts
+++ b/ts/src/config/app-settings-schema.ts
@@ -114,8 +114,9 @@ export const AppSettingsSchema = z.object({
   piTimeout: z.number().min(1).default(120.0),
   piWorkspace: z.string().default(""),
   piModel: z.string().default(""),
+  piNoContextFiles: z.boolean().default(false),
 
-  // Pi RPC runtime
+  // Pi RPC runtime (subprocess JSONL; endpoint/apiKey retained for backwards-compatible config parsing)
   piRpcEndpoint: z.string().default(""),
   piRpcApiKey: z.string().default(""),
   piRpcSessionPersistence: z.boolean().default(true),

--- a/ts/src/providers/provider-factory.ts
+++ b/ts/src/providers/provider-factory.ts
@@ -167,6 +167,7 @@ export interface CreateProviderOpts {
   piTimeout?: number;
   piWorkspace?: string;
   piModel?: string;
+  piNoContextFiles?: boolean;
   piRpcEndpoint?: string;
   piRpcApiKey?: string;
   piRpcSessionPersistence?: boolean;
@@ -269,6 +270,7 @@ export function createProvider(opts: CreateProviderOpts): LLMProvider {
         timeout: opts.piTimeout,
         workspace: opts.piWorkspace,
         model: resolvedModel,
+        noContextFiles: opts.piNoContextFiles,
       }),
     );
     return new RuntimeBridgeProvider(runtime as never, resolvedModel ?? "pi-default");
@@ -277,9 +279,11 @@ export function createProvider(opts: CreateProviderOpts): LLMProvider {
   if (type === "pi-rpc") {
     const runtime = new PiRPCRuntime(
       new PiRPCConfig({
-        endpoint: opts.piRpcEndpoint ?? opts.baseUrl,
-        apiKey: opts.piRpcApiKey ?? opts.apiKey,
+        piCommand: opts.piCommand,
+        model: opts.model,
+        timeout: opts.piTimeout,
         sessionPersistence: opts.piRpcSessionPersistence,
+        noContextFiles: opts.piNoContextFiles,
       }),
     );
     return new RuntimeBridgeProvider(runtime as never, opts.model ?? "pi-rpc-default");

--- a/ts/src/providers/provider-factory.ts
+++ b/ts/src/providers/provider-factory.ts
@@ -277,16 +277,17 @@ export function createProvider(opts: CreateProviderOpts): LLMProvider {
   }
 
   if (type === "pi-rpc") {
+    const resolvedModel = opts.model ?? opts.piModel;
     const runtime = new PiRPCRuntime(
       new PiRPCConfig({
         piCommand: opts.piCommand,
-        model: opts.model,
+        model: resolvedModel,
         timeout: opts.piTimeout,
         sessionPersistence: opts.piRpcSessionPersistence,
         noContextFiles: opts.piNoContextFiles,
       }),
     );
-    return new RuntimeBridgeProvider(runtime as never, opts.model ?? "pi-rpc-default");
+    return new RuntimeBridgeProvider(runtime as never, resolvedModel ?? "pi-rpc-default");
   }
 
   const compat = OPENAI_COMPATIBLE_PROVIDER_DEFAULTS[type];

--- a/ts/src/providers/role-provider-bundle.ts
+++ b/ts/src/providers/role-provider-bundle.ts
@@ -38,6 +38,7 @@ export interface RoleProviderSettings {
   piTimeout?: number;
   piWorkspace?: string;
   piModel?: string;
+  piNoContextFiles?: boolean;
   piRpcEndpoint?: string;
   piRpcApiKey?: string;
   piRpcSessionPersistence?: boolean;
@@ -71,6 +72,7 @@ export function withRuntimeSettings(
     piTimeout: settings.piTimeout,
     piWorkspace: settings.piWorkspace,
     piModel: settings.piModel,
+    piNoContextFiles: settings.piNoContextFiles,
     piRpcEndpoint: settings.piRpcEndpoint,
     piRpcApiKey: settings.piRpcApiKey,
     piRpcSessionPersistence: settings.piRpcSessionPersistence,
@@ -98,18 +100,21 @@ function resolveRoleConfig(
   const model = normalizeOptionalOverride(roleConfig.model);
   const apiKey = normalizeOptionalOverride(roleConfig.apiKey);
   const baseUrl = normalizeOptionalOverride(roleConfig.baseUrl);
-  return resolveProviderConfig({
-    ...overrides,
-    providerType: providerType ?? defaultConfig.providerType,
-    model: model ?? defaultConfig.model,
-    apiKey: apiKey ?? overrides.apiKey,
-    baseUrl: baseUrl ?? overrides.baseUrl,
-  }, {
-    preferProviderOverride: Boolean(providerType),
-    preferModelOverride: Boolean(model),
-    preferApiKeyOverride: Boolean(apiKey),
-    preferBaseUrlOverride: Boolean(baseUrl),
-  });
+  return resolveProviderConfig(
+    {
+      ...overrides,
+      providerType: providerType ?? defaultConfig.providerType,
+      model: model ?? defaultConfig.model,
+      apiKey: apiKey ?? overrides.apiKey,
+      baseUrl: baseUrl ?? overrides.baseUrl,
+    },
+    {
+      preferProviderOverride: Boolean(providerType),
+      preferModelOverride: Boolean(model),
+      preferApiKeyOverride: Boolean(apiKey),
+      preferBaseUrlOverride: Boolean(baseUrl),
+    },
+  );
 }
 
 export function createConfiguredProvider(

--- a/ts/src/runtimes/pi-cli.ts
+++ b/ts/src/runtimes/pi-cli.ts
@@ -11,6 +11,7 @@ export interface PiCLIConfigOpts {
   model?: string;
   timeout?: number;
   workspace?: string;
+  noContextFiles?: boolean;
 }
 
 export class PiCLIConfig {
@@ -18,12 +19,14 @@ export class PiCLIConfig {
   readonly model: string;
   readonly timeout: number;
   readonly workspace: string;
+  readonly noContextFiles: boolean;
 
   constructor(opts: PiCLIConfigOpts = {}) {
     this.piCommand = opts.piCommand ?? "pi";
     this.model = opts.model ?? "";
     this.timeout = opts.timeout ?? 120.0;
     this.workspace = opts.workspace ?? "";
+    this.noContextFiles = opts.noContextFiles ?? false;
   }
 }
 
@@ -35,13 +38,8 @@ export class PiCLIRuntime {
     this.config = config ?? new PiCLIConfig();
   }
 
-  async generate(opts: {
-    prompt: string;
-    system?: string;
-  }): Promise<AgentOutput> {
-    const fullPrompt = opts.system
-      ? `${opts.system}\n\n${opts.prompt}`
-      : opts.prompt;
+  async generate(opts: { prompt: string; system?: string }): Promise<AgentOutput> {
+    const fullPrompt = opts.system ? `${opts.system}\n\n${opts.prompt}` : opts.prompt;
     return this.invoke(fullPrompt);
   }
 
@@ -66,20 +64,21 @@ export class PiCLIRuntime {
   }
 
   private invoke(prompt: string): AgentOutput {
-    const args = [this.config.piCommand, "--print"];
+    const args = ["--print"];
     if (this.config.model) {
       args.push("--model", this.config.model);
     }
-    if (this.config.workspace) {
-      args.push("--workspace", this.config.workspace);
+    if (this.config.noContextFiles) {
+      args.push("--no-context-files");
     }
 
     try {
-      const stdout = execFileSync(args[0], args.slice(1), {
+      const stdout = execFileSync(this.config.piCommand, args, {
         input: prompt,
         timeout: this.config.timeout * 1000,
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
+        cwd: this.config.workspace || undefined,
       });
       return this.parseOutput(stdout);
     } catch (err: unknown) {

--- a/ts/src/runtimes/pi-rpc.ts
+++ b/ts/src/runtimes/pi-rpc.ts
@@ -1,29 +1,36 @@
 /**
- * Pi RPC runtime — HTTP RPC communication with Pi (AC-361).
+ * Pi RPC runtime — subprocess stdin/stdout JSONL communication with Pi.
  * Mirrors Python's autocontext/runtimes/pi_rpc.py.
- * Supports session persistence and per-role isolation.
  */
 
+import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import type { AgentOutput } from "./base.js";
 
 export interface PiRPCConfigOpts {
-  endpoint?: string;
-  apiKey?: string;
+  piCommand?: string;
+  model?: string;
   timeout?: number;
   sessionPersistence?: boolean;
+  noContextFiles?: boolean;
+  extraArgs?: string[];
 }
 
 export class PiRPCConfig {
-  readonly endpoint: string;
-  readonly apiKey: string;
+  readonly piCommand: string;
+  readonly model: string;
   readonly timeout: number;
   readonly sessionPersistence: boolean;
+  readonly noContextFiles: boolean;
+  readonly extraArgs: string[];
 
   constructor(opts: PiRPCConfigOpts = {}) {
-    this.endpoint = opts.endpoint ?? "http://localhost:3284";
-    this.apiKey = opts.apiKey ?? "";
+    this.piCommand = opts.piCommand ?? "pi";
+    this.model = opts.model ?? "";
     this.timeout = opts.timeout ?? 120.0;
     this.sessionPersistence = opts.sessionPersistence ?? true;
+    this.noContextFiles = opts.noContextFiles ?? false;
+    this.extraArgs = [...(opts.extraArgs ?? [])];
   }
 }
 
@@ -40,48 +47,47 @@ export class PiRPCRuntime {
     return this._currentSessionId;
   }
 
-  async generate(opts: {
-    prompt: string;
-    system?: string;
-  }): Promise<AgentOutput> {
-    const payload: Record<string, unknown> = { prompt: opts.prompt };
-    if (opts.system) payload.system = opts.system;
-    if (this._currentSessionId && this.config.sessionPersistence) {
-      payload.session_id = this._currentSessionId;
-    }
+  async generate(opts: { prompt: string; system?: string }): Promise<AgentOutput> {
+    const fullPrompt = opts.system ? `${opts.system}\n\n${opts.prompt}` : opts.prompt;
+    const args = this.buildArgs();
+    const input = `${JSON.stringify(this.buildPromptCommand(fullPrompt))}\n`;
 
     try {
-      const headers: Record<string, string> = { "Content-Type": "application/json" };
-      if (this.config.apiKey) headers.Authorization = `Bearer ${this.config.apiKey}`;
-
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), this.config.timeout * 1000);
-
-      const res = await fetch(`${this.config.endpoint}/v1/generate`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(payload),
-        signal: controller.signal,
+      const stdout = execFileSync(this.config.piCommand, args, {
+        input,
+        timeout: this.config.timeout * 1000,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
       });
-      clearTimeout(timeout);
-
-      if (!res.ok) {
-        const body = await res.text();
-        return { text: "", metadata: { error: `HTTP ${res.status}: ${body.slice(0, 200)}` } };
-      }
-
-      const data = (await res.json()) as Record<string, unknown>;
-      if (data.session_id && typeof data.session_id === "string") {
-        this._currentSessionId = data.session_id;
-      }
-      const text = typeof data.text === "string" ? data.text : typeof data.response === "string" ? data.response : "";
-      return { text, metadata: { sessionId: this._currentSessionId } };
+      return this.parseOutput(stdout, 0, "");
     } catch (err: unknown) {
-      const error = err as { name?: string; message?: string };
-      if (error.name === "AbortError") {
+      const error = err as {
+        code?: string;
+        status?: number;
+        stdout?: string | Buffer;
+        stderr?: string | Buffer;
+        message?: string;
+      };
+      if (error.code === "ETIMEDOUT") {
         return { text: "", metadata: { error: "timeout" } };
       }
-      return { text: "", metadata: { error: error.message ?? "unknown" } };
+      if (error.code === "ENOENT") {
+        return { text: "", metadata: { error: "pi_not_found" } };
+      }
+
+      const stdout = this.normalizeOutput(error.stdout);
+      const stderr = this.normalizeOutput(error.stderr);
+      if (stdout.trim()) {
+        return this.parseOutput(stdout, error.status ?? 1, stderr);
+      }
+      return {
+        text: "",
+        metadata: {
+          error: "nonzero_exit",
+          exitCode: error.status ?? 1,
+          stderr: stderr || error.message || "unknown",
+        },
+      };
     }
   }
 
@@ -99,5 +105,163 @@ export class PiRPCRuntime {
         `Produce an improved version:`,
       ].join("\n\n"),
     });
+  }
+
+  private buildArgs(): string[] {
+    const args = ["--mode", "rpc"];
+    if (this.config.model) {
+      args.push("--model", this.config.model);
+    }
+    if (this.config.noContextFiles) {
+      args.push("--no-context-files");
+    }
+    if (!this.config.sessionPersistence) {
+      args.push("--no-session");
+    }
+    args.push(...this.config.extraArgs);
+    return args;
+  }
+
+  private buildPromptCommand(prompt: string): { type: string; id: string; message: string } {
+    return {
+      type: "prompt",
+      id: randomUUID().slice(0, 8),
+      message: prompt,
+    };
+  }
+
+  private parseOutput(raw: string, exitCode: number, stderr: string): AgentOutput {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return exitCode === 0
+        ? { text: "", metadata: { exitCode } }
+        : {
+            text: "",
+            metadata: {
+              error: "nonzero_exit",
+              exitCode,
+              stderr,
+            },
+          };
+    }
+
+    const textParts: string[] = [];
+
+    for (const line of trimmed.split("\n")) {
+      const record = line.trim();
+      if (!record) continue;
+
+      try {
+        const event = JSON.parse(record) as {
+          type?: string;
+          success?: boolean;
+          command?: string;
+          error?: unknown;
+          data?: { content?: unknown; session_id?: unknown; sessionId?: unknown };
+          message?: { content?: unknown };
+          messages?: Array<{ role?: string; content?: unknown }>;
+          session_id?: unknown;
+          sessionId?: unknown;
+        };
+        this.updateSessionId(event);
+
+        if (event.type === "response") {
+          if (event.success === false) {
+            return {
+              text: "",
+              metadata: {
+                error: "rpc_response_error",
+                rpcCommand: String(event.command ?? ""),
+                rpcMessage: String(event.error ?? "unknown"),
+                exitCode,
+                ...(stderr ? { stderr } : {}),
+              },
+            };
+          }
+
+          if (typeof event.data?.content === "string" && event.data.content) {
+            textParts.push(event.data.content);
+          }
+          continue;
+        }
+
+        if (event.type === "message_end") {
+          if (typeof event.message?.content === "string" && event.message.content) {
+            textParts.push(event.message.content);
+          }
+          continue;
+        }
+
+        if (event.type === "agent_end") {
+          for (const message of event.messages ?? []) {
+            if (
+              message.role === "assistant" &&
+              typeof message.content === "string" &&
+              message.content
+            ) {
+              textParts.push(message.content);
+            }
+          }
+        }
+      } catch {
+        if (textParts.length === 0) {
+          return exitCode === 0
+            ? { text: trimmed, metadata: { exitCode } }
+            : {
+                text: "",
+                metadata: {
+                  error: "nonzero_exit",
+                  exitCode,
+                  ...(stderr ? { stderr } : {}),
+                  stdout: trimmed,
+                },
+              };
+        }
+      }
+    }
+
+    if (textParts.length > 0) {
+      return {
+        text: textParts[textParts.length - 1] ?? "",
+        metadata: {
+          exitCode,
+          ...(this._currentSessionId ? { sessionId: this._currentSessionId } : {}),
+        },
+      };
+    }
+
+    return exitCode === 0
+      ? { text: trimmed, metadata: { exitCode } }
+      : {
+          text: "",
+          metadata: {
+            error: "nonzero_exit",
+            exitCode,
+            ...(stderr ? { stderr } : {}),
+            stdout: trimmed,
+          },
+        };
+  }
+
+  private updateSessionId(event: {
+    data?: { session_id?: unknown; sessionId?: unknown };
+    session_id?: unknown;
+    sessionId?: unknown;
+  }): void {
+    const candidate =
+      event.data?.session_id ?? event.data?.sessionId ?? event.session_id ?? event.sessionId;
+    if (typeof candidate === "string" && candidate) {
+      this._currentSessionId = candidate;
+    }
+  }
+
+  private normalizeOutput(value: string | Buffer | undefined): string {
+    if (typeof value === "string") {
+      return value;
+    }
+    if (value) {
+      return value.toString("utf-8");
+    }
+    return "";
   }
 }

--- a/ts/src/runtimes/pi-rpc.ts
+++ b/ts/src/runtimes/pi-rpc.ts
@@ -4,7 +4,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { execFileSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import type { AgentOutput } from "./base.js";
 
 export interface PiRPCConfigOpts {
@@ -52,43 +52,7 @@ export class PiRPCRuntime {
     const args = this.buildArgs();
     const input = `${JSON.stringify(this.buildPromptCommand(fullPrompt))}\n`;
 
-    try {
-      const stdout = execFileSync(this.config.piCommand, args, {
-        input,
-        timeout: this.config.timeout * 1000,
-        encoding: "utf-8",
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-      return this.parseOutput(stdout, 0, "");
-    } catch (err: unknown) {
-      const error = err as {
-        code?: string;
-        status?: number;
-        stdout?: string | Buffer;
-        stderr?: string | Buffer;
-        message?: string;
-      };
-      if (error.code === "ETIMEDOUT") {
-        return { text: "", metadata: { error: "timeout" } };
-      }
-      if (error.code === "ENOENT") {
-        return { text: "", metadata: { error: "pi_not_found" } };
-      }
-
-      const stdout = this.normalizeOutput(error.stdout);
-      const stderr = this.normalizeOutput(error.stderr);
-      if (stdout.trim()) {
-        return this.parseOutput(stdout, error.status ?? 1, stderr);
-      }
-      return {
-        text: "",
-        metadata: {
-          error: "nonzero_exit",
-          exitCode: error.status ?? 1,
-          stderr: stderr || error.message || "unknown",
-        },
-      };
-    }
+    return this.invokeRpc(args, input);
   }
 
   async revise(opts: {
@@ -130,6 +94,96 @@ export class PiRPCRuntime {
     };
   }
 
+  private invokeRpc(args: string[], input: string): Promise<AgentOutput> {
+    return new Promise((resolve) => {
+      const child = spawn(this.config.piCommand, args, {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      let stdoutBuffer = "";
+      let settled = false;
+
+      const cleanupTimer = (): NodeJS.Timeout =>
+        setTimeout(() => {
+          if (!child.killed && child.exitCode === null) {
+            child.kill();
+          }
+        }, 1_000);
+
+      const finish = (output: AgentOutput, endStdin = true): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        if (endStdin && child.stdin.writable && !child.stdin.destroyed) {
+          child.stdin.end();
+        }
+        cleanupTimer().unref();
+        resolve(output);
+      };
+
+      const timeout = setTimeout(() => {
+        if (!child.killed) {
+          child.kill();
+        }
+        finish({ text: "", metadata: { error: "timeout" } }, false);
+      }, this.config.timeout * 1000);
+
+      child.stdout.setEncoding("utf-8");
+      child.stderr.setEncoding("utf-8");
+
+      child.stdout.on("data", (chunk: string | Buffer) => {
+        stdoutBuffer += this.normalizeOutput(chunk);
+        let newlineIndex = stdoutBuffer.indexOf("\n");
+        while (newlineIndex >= 0) {
+          const line = stdoutBuffer.slice(0, newlineIndex);
+          stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+          stdout += `${line}\n`;
+          if (this.isTerminalRpcEvent(line)) {
+            finish(this.parseOutput(stdout, 0, stderr));
+            return;
+          }
+          newlineIndex = stdoutBuffer.indexOf("\n");
+        }
+      });
+
+      child.stderr.on("data", (chunk: string | Buffer) => {
+        stderr += this.normalizeOutput(chunk);
+      });
+
+      child.on("error", (err: NodeJS.ErrnoException) => {
+        if (err.code === "ENOENT") {
+          finish({ text: "", metadata: { error: "pi_not_found" } }, false);
+          return;
+        }
+        finish({ text: "", metadata: { error: err.message || "unknown" } }, false);
+      });
+
+      child.on("close", (code) => {
+        if (stdoutBuffer) {
+          stdout += stdoutBuffer;
+          stdoutBuffer = "";
+        }
+        finish(this.parseOutput(stdout, code ?? 1, stderr), false);
+      });
+
+      child.stdin.write(input);
+    });
+  }
+
+  private isTerminalRpcEvent(record: string): boolean {
+    try {
+      const event = JSON.parse(record) as {
+        type?: string;
+        success?: boolean;
+      };
+      if (event.type === "agent_end") return true;
+      return event.type === "response" && event.success === false;
+    } catch {
+      return false;
+    }
+  }
+
   private parseOutput(raw: string, exitCode: number, stderr: string): AgentOutput {
     const trimmed = raw.trim();
     if (!trimmed) {
@@ -146,6 +200,7 @@ export class PiRPCRuntime {
     }
 
     const textParts: string[] = [];
+    let sawJsonEvent = false;
 
     for (const line of trimmed.split("\n")) {
       const record = line.trim();
@@ -163,6 +218,7 @@ export class PiRPCRuntime {
           session_id?: unknown;
           sessionId?: unknown;
         };
+        sawJsonEvent = true;
         this.updateSessionId(event);
 
         if (event.type === "response") {
@@ -179,27 +235,28 @@ export class PiRPCRuntime {
             };
           }
 
-          if (typeof event.data?.content === "string" && event.data.content) {
-            textParts.push(event.data.content);
+          const content = this.extractTextContent(event.data?.content);
+          if (content) {
+            textParts.push(content);
           }
           continue;
         }
 
         if (event.type === "message_end") {
-          if (typeof event.message?.content === "string" && event.message.content) {
-            textParts.push(event.message.content);
+          const content = this.extractTextContent(event.message?.content);
+          if (content) {
+            textParts.push(content);
           }
           continue;
         }
 
         if (event.type === "agent_end") {
           for (const message of event.messages ?? []) {
-            if (
-              message.role === "assistant" &&
-              typeof message.content === "string" &&
-              message.content
-            ) {
-              textParts.push(message.content);
+            if (message.role === "assistant") {
+              const content = this.extractTextContent(message.content);
+              if (content) {
+                textParts.push(content);
+              }
             }
           }
         }
@@ -231,7 +288,16 @@ export class PiRPCRuntime {
     }
 
     return exitCode === 0
-      ? { text: trimmed, metadata: { exitCode } }
+      ? sawJsonEvent
+        ? {
+            text: "",
+            metadata: {
+              error: "missing_assistant_response",
+              exitCode,
+              stdout: trimmed,
+            },
+          }
+        : { text: trimmed, metadata: { exitCode } }
       : {
           text: "",
           metadata: {
@@ -241,6 +307,25 @@ export class PiRPCRuntime {
             stdout: trimmed,
           },
         };
+  }
+
+  private extractTextContent(content: unknown): string {
+    if (typeof content === "string") {
+      return content;
+    }
+    if (!Array.isArray(content)) {
+      return "";
+    }
+    return content
+      .map((part) => {
+        if (typeof part === "string") return part;
+        if (!part || typeof part !== "object") return "";
+        if ("text" in part && typeof part.text === "string") return part.text;
+        if ("content" in part && typeof part.content === "string") return part.content;
+        return "";
+      })
+      .filter(Boolean)
+      .join("");
   }
 
   private updateSessionId(event: {

--- a/ts/tests/pi-runtime.test.ts
+++ b/ts/tests/pi-runtime.test.ts
@@ -25,6 +25,7 @@ describe("Pi config in AppSettingsSchema", () => {
     expect(settings.piTimeout).toBe(120.0);
     expect(settings.piWorkspace).toBe("");
     expect(settings.piModel).toBe("");
+    expect(settings.piNoContextFiles).toBe(false);
   });
 
   it("includes Pi RPC settings with defaults", async () => {
@@ -165,6 +166,7 @@ describe("PiCLIRuntime", () => {
         piTimeout: 33,
         piWorkspace: "/tmp/pi-workspace",
         piModel: "pi-checkpoint",
+        piNoContextFiles: true,
       },
     );
 
@@ -176,15 +178,15 @@ describe("PiCLIRuntime", () => {
     expect(result.text).toBe("pi output");
     expect(execFileSyncMock).toHaveBeenCalledWith(
       "pi-local",
-      ["--print", "--model", "pi-checkpoint", "--workspace", "/tmp/pi-workspace"],
+      ["--print", "--model", "pi-checkpoint", "--no-context-files"],
       expect.objectContaining({
         input: "system prompt\n\ntask prompt",
         timeout: 33_000,
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
+        cwd: "/tmp/pi-workspace",
       }),
     );
-    expect(execFileSyncMock.mock.calls[0]?.[2]).not.toHaveProperty("cwd");
   });
 
   it("buildRoleProviderBundle threads Pi CLI settings into run providers", async () => {
@@ -198,6 +200,7 @@ describe("PiCLIRuntime", () => {
       piTimeout: 12,
       piWorkspace: "/tmp/pi-bundle-workspace",
       piModel: "pi-bundle-model",
+      piNoContextFiles: true,
     });
 
     const result = await bundle.defaultProvider.complete({
@@ -208,10 +211,11 @@ describe("PiCLIRuntime", () => {
     expect(result.text).toBe("bundle output");
     expect(execFileSyncMock).toHaveBeenCalledWith(
       "pi-bundle",
-      ["--print", "--model", "pi-bundle-model", "--workspace", "/tmp/pi-bundle-workspace"],
+      ["--print", "--model", "pi-bundle-model", "--no-context-files"],
       expect.objectContaining({
         input: "bundle task",
         timeout: 12_000,
+        cwd: "/tmp/pi-bundle-workspace",
       }),
     );
   });
@@ -230,8 +234,10 @@ describe("PiRPCRuntime", () => {
   it("has correct defaults", async () => {
     const { PiRPCConfig } = await import("../src/runtimes/pi-rpc.js");
     const config = new PiRPCConfig();
-    expect(config.endpoint).toBe("http://localhost:3284");
+    expect(config.piCommand).toBe("pi");
+    expect(config.timeout).toBe(120.0);
     expect(config.sessionPersistence).toBe(true);
+    expect(config.noContextFiles).toBe(false);
   });
 
   it("creates isolated sessions per role", async () => {
@@ -245,18 +251,18 @@ describe("PiRPCRuntime", () => {
     expect(rt2.currentSessionId).toBeNull();
   });
 
-  it("createConfiguredProvider uses Python-compatible Pi RPC endpoint and settings", async () => {
+  it("createConfiguredProvider uses subprocess Pi RPC JSONL instead of HTTP", async () => {
     vi.resetModules();
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ text: "first", session_id: "sess-1" }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ text: "second", session_id: "sess-2" }),
-      });
+    execFileSyncMock.mockReturnValue(
+      [
+        JSON.stringify({ type: "response", command: "prompt", success: true }),
+        JSON.stringify({
+          type: "agent_end",
+          messages: [{ role: "assistant", content: "first" }],
+        }),
+      ].join("\n") as never,
+    );
+    const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
     const { createConfiguredProvider } = await import("../src/providers/index.js");
@@ -264,40 +270,38 @@ describe("PiRPCRuntime", () => {
       { providerType: "pi-rpc" },
       {
         agentProvider: "pi-rpc",
+        piCommand: "pi-rpc-local",
+        piTimeout: 45,
         piRpcEndpoint: "http://rpc.local:3284",
         piRpcApiKey: "rpc-key",
         piRpcSessionPersistence: false,
+        piNoContextFiles: true,
       },
     );
 
-    const first = await provider.complete({
+    const result = await provider.complete({
       systemPrompt: "rpc system",
       userPrompt: "first prompt",
     });
-    const second = await provider.complete({
-      systemPrompt: "rpc system",
-      userPrompt: "second prompt",
-    });
 
-    expect(first.text).toBe("first");
-    expect(second.text).toBe("second");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://rpc.local:3284/v1/generate");
-    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer rpc-key",
-      },
+    expect(result.text).toBe("first");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "pi-rpc-local",
+      ["--mode", "rpc", "--no-context-files", "--no-session"],
+      expect.objectContaining({
+        timeout: 45_000,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }),
+    );
+
+    const input = String(execFileSyncMock.mock.calls[0]?.[2]?.input ?? "");
+    expect(JSON.parse(input.trim())).toMatchObject({
+      type: "prompt",
+      message: "rpc system\n\nfirst prompt",
     });
-    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
-      prompt: "first prompt",
-      system: "rpc system",
-    });
-    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toEqual({
-      prompt: "second prompt",
-      system: "rpc system",
-    });
+    expect(input.endsWith("\n")).toBe(true);
   });
 });
 

--- a/ts/tests/pi-runtime.test.ts
+++ b/ts/tests/pi-runtime.test.ts
@@ -3,15 +3,87 @@
  */
 
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { execFile, execFileSync } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { execFile, execFileSync, spawn } from "node:child_process";
 
 vi.mock("node:child_process", () => ({
   execFile: vi.fn(),
   execFileSync: vi.fn(),
+  spawn: vi.fn(),
 }));
 
 const execFileSyncMock = vi.mocked(execFileSync);
+const spawnMock = vi.mocked(spawn);
 void execFile;
+
+class FakeStream extends EventEmitter {
+  writable = true;
+  destroyed = false;
+  readonly chunks: string[] = [];
+
+  constructor(private readonly onWrite?: () => void) {
+    super();
+  }
+
+  setEncoding(_encoding: string): void {}
+
+  write(chunk: string): boolean {
+    this.chunks.push(chunk);
+    this.onWrite?.();
+    return true;
+  }
+
+  end(): void {
+    this.writable = false;
+    this.emit("finish");
+  }
+}
+
+function createFakeSpawnProcess(stdoutLines: string[], closeCode = 0): {
+  child: EventEmitter & {
+    stdin: FakeStream;
+    stdout: FakeStream;
+    stderr: FakeStream;
+    killed: boolean;
+    exitCode: number | null;
+    kill: () => void;
+  };
+  stdin: FakeStream;
+} {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: FakeStream;
+    stdout: FakeStream;
+    stderr: FakeStream;
+    killed: boolean;
+    exitCode: number | null;
+    kill: () => void;
+  };
+  let emitted = false;
+  const emitOutput = (): void => {
+    if (emitted) return;
+    emitted = true;
+    queueMicrotask(() => {
+      for (const line of stdoutLines) {
+        child.stdout.emit("data", `${line}\n`);
+      }
+      child.exitCode = closeCode;
+      child.emit("close", closeCode);
+    });
+  };
+  const stdin = new FakeStream(emitOutput);
+  child.stdin = stdin;
+  child.stdout = new FakeStream();
+  child.stderr = new FakeStream();
+  child.killed = false;
+  child.exitCode = null;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    child.exitCode = -9;
+    child.emit("close", -9);
+  });
+
+  return { child, stdin };
+}
 
 // ---------------------------------------------------------------------------
 // Pi config in AppSettingsSchema
@@ -253,15 +325,16 @@ describe("PiRPCRuntime", () => {
 
   it("createConfiguredProvider uses subprocess Pi RPC JSONL instead of HTTP", async () => {
     vi.resetModules();
-    execFileSyncMock.mockReturnValue(
+    const fakeProcess = createFakeSpawnProcess(
       [
         JSON.stringify({ type: "response", command: "prompt", success: true }),
         JSON.stringify({
           type: "agent_end",
           messages: [{ role: "assistant", content: "first" }],
         }),
-      ].join("\n") as never,
+      ],
     );
+    spawnMock.mockReturnValue(fakeProcess.child as never);
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
@@ -286,22 +359,69 @@ describe("PiRPCRuntime", () => {
 
     expect(result.text).toBe("first");
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(execFileSyncMock).toHaveBeenCalledWith(
+    expect(spawnMock).toHaveBeenCalledWith(
       "pi-rpc-local",
       ["--mode", "rpc", "--no-context-files", "--no-session"],
       expect.objectContaining({
-        timeout: 45_000,
-        encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
       }),
     );
 
-    const input = String(execFileSyncMock.mock.calls[0]?.[2]?.input ?? "");
+    const input = fakeProcess.stdin.chunks.join("");
     expect(JSON.parse(input.trim())).toMatchObject({
       type: "prompt",
       message: "rpc system\n\nfirst prompt",
     });
     expect(input.endsWith("\n")).toBe(true);
+    expect(fakeProcess.stdin.writable).toBe(false);
+  });
+
+  it("does not treat a prompt ack as the final assistant output", async () => {
+    vi.resetModules();
+    const fakeProcess = createFakeSpawnProcess([
+      JSON.stringify({ type: "response", command: "prompt", success: true }),
+    ]);
+    spawnMock.mockReturnValue(fakeProcess.child as never);
+
+    const { PiRPCRuntime, PiRPCConfig } = await import("../src/runtimes/pi-rpc.js");
+    const runtime = new PiRPCRuntime(new PiRPCConfig({ piCommand: "pi-rpc-local" }));
+    const result = await runtime.generate({ prompt: "first prompt" });
+
+    expect(result.text).toBe("");
+    expect(result.metadata?.error).toBe("missing_assistant_response");
+  });
+
+  it("pi-rpc uses piModel when no generic model override is set", async () => {
+    vi.resetModules();
+    const fakeProcess = createFakeSpawnProcess([
+      JSON.stringify({
+        type: "agent_end",
+        messages: [{ role: "assistant", content: "model output" }],
+      }),
+    ]);
+    spawnMock.mockReturnValue(fakeProcess.child as never);
+
+    const { createConfiguredProvider } = await import("../src/providers/index.js");
+    const { provider } = createConfiguredProvider(
+      { providerType: "pi-rpc" },
+      {
+        agentProvider: "pi-rpc",
+        piCommand: "pi-rpc-local",
+        piModel: "manual-pi-model",
+      },
+    );
+
+    await provider.complete({
+      systemPrompt: "",
+      userPrompt: "first prompt",
+    });
+
+    expect(provider.defaultModel()).toBe("manual-pi-model");
+    expect(spawnMock).toHaveBeenCalledWith(
+      "pi-rpc-local",
+      ["--mode", "rpc", "--model", "manual-pi-model"],
+      expect.any(Object),
+    );
   });
 });
 

--- a/ts/tests/settings-assembly-workflow.test.ts
+++ b/ts/tests/settings-assembly-workflow.test.ts
@@ -26,6 +26,7 @@ describe("settings assembly workflow", () => {
       env: {
         AUTOCONTEXT_AGENT_PROVIDER: "deterministic",
         AUTOCONTEXT_MODEL_ANALYST: "analyst-model",
+        AUTOCONTEXT_PI_NO_CONTEXT_FILES: "true",
       },
       defaults: getDefaultSettingsRecord(),
     });
@@ -38,7 +39,10 @@ describe("settings assembly workflow", () => {
       runsRoot: "/tmp/runs",
       dbPath: "/tmp/runs/db.sqlite3",
       defaultGenerations: 4,
+      piNoContextFiles: true,
     });
-    expect(parseAppSettings(input).agentProvider).toBe("deterministic");
+    const settings = parseAppSettings(input);
+    expect(settings.agentProvider).toBe("deterministic");
+    expect(settings.piNoContextFiles).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
This PR aligns autocontext's Pi integrations with Pi's documented subprocess behavior and adds a deterministic `--no-context-files` switch for eval-style runs. TypeScript Pi RPC now uses local `pi --mode rpc` JSONL instead of the old HTTP spike, Pi CLI uses subprocess `cwd` instead of an unsupported `--workspace` flag, and both the Python and TypeScript Pi surfaces can opt into `AUTOCONTEXT_PI_NO_CONTEXT_FILES=true`. Addresses AC-560.

## Motivation
The TypeScript Pi runtime had drifted from current Pi behavior: Pi RPC was still modeled as HTTP and Pi CLI was still passing a flag Pi does not support. That left the TS surface out of sync with the Python runtime and Pi docs, and made contamination-sensitive evals harder because repository context files such as `AGENTS.md` and `CLAUDE.md` could leak into runs.

## Implementation Details
- Replaced the TypeScript Pi RPC transport with subprocess JSONL prompt/response handling, session tracking, and runtime error normalization in [ts/src/runtimes/pi-rpc.ts:10](ts/src/runtimes/pi-rpc.ts#L10).
- Updated the TypeScript Pi CLI runtime to use subprocess `cwd` and optional `--no-context-files` argument handling in [ts/src/runtimes/pi-cli.ts:9](ts/src/runtimes/pi-cli.ts#L9).
- Routed the new Pi settings through provider construction so `pi-rpc` uses subprocess config and both Pi runtimes honor `piNoContextFiles` in [ts/src/providers/provider-factory.ts:265](ts/src/providers/provider-factory.ts#L265) and [ts/src/providers/role-provider-bundle.ts:7](ts/src/providers/role-provider-bundle.ts#L7).
- Added Python parity for `pi_no_context_files` and threaded it through role/client creation in [autocontext/src/autocontext/config/settings.py:576](autocontext/src/autocontext/config/settings.py#L576) and [autocontext/src/autocontext/agents/provider_bridge.py:326](autocontext/src/autocontext/agents/provider_bridge.py#L326).
- Updated operator-facing docs and examples to describe subprocess RPC, legacy compatibility fields, and deterministic Pi runs in [autocontext/docs/agent-integration.md:266](autocontext/docs/agent-integration.md#L266).

## Testing
### Automated Tests
- `cd ts && npx vitest run tests/pi-runtime.test.ts tests/settings-assembly-workflow.test.ts tests/provider-factory-workflow.test.ts tests/provider-surface-consistency.test.ts tests/role-provider-bundle-workflow.test.ts`
- `cd ts && npm run lint`
- `cd autocontext && uv run python -m pytest -q tests/test_pi_protocol_alignment.py tests/test_pi_cli_runtime.py tests/test_pi_rpc.py tests/test_pi_provider_surface.py tests/test_pi_smoke.py`
- `cd autocontext && uv run ruff check src/autocontext/config/settings.py src/autocontext/agents/provider_bridge.py src/autocontext/agents/llm_client.py src/autocontext/runtimes/pi_cli.py src/autocontext/runtimes/pi_rpc.py`

### Manual Validation
- Verified Pi CLI invocations use subprocess `cwd` rather than `--workspace`.
- Verified Pi RPC calls send JSONL prompt commands to `pi --mode rpc` and parse assistant output from Pi events.
- Verified `AUTOCONTEXT_PI_NO_CONTEXT_FILES=true` flows through both Pi CLI and Pi RPC code paths.

## Checklist
- [x] Code follows project style guidelines
- [x] Type hints added or maintained (Python) and types maintained (TypeScript)
- [x] Tests added/updated for the changed runtime surfaces
- [x] Documentation updated
- [x] No breaking changes expected for current Pi extension compatibility
- [x] Linear issue referenced (`AC-560`)
- [x] N/A: database migrations
- [x] N/A: multi-tenant isolation / RLS
