### PR TITLE
fix: support broader solve families end to end

### DIFF
--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import re
 import threading
 import time
 import uuid
@@ -11,15 +13,24 @@ from pathlib import Path
 from typing import Any, Protocol, cast
 
 from autocontext.agents.types import LlmFn
+from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.config.settings import AppSettings
+from autocontext.execution.improvement_loop import ImprovementLoop
 from autocontext.knowledge.export import SkillPackage, export_skill_package
 from autocontext.mcp.tools import MtsToolContext
+from autocontext.scenarios import SCENARIO_REGISTRY
+from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
+from autocontext.scenarios.artifact_editing import Artifact, ArtifactEditingInterface
+from autocontext.storage.sqlite_store import SQLiteStore
 
 logger = logging.getLogger(__name__)
 
 
 class _NamedScenario(Protocol):
     name: str
+
+
+_FAMILY_HEADER_RE = re.compile(r"^\s*\*{0,2}family\*{0,2}:\s*(?P<body>.+?)\s*$", re.IGNORECASE | re.MULTILINE)
 
 
 @dataclass
@@ -41,6 +52,292 @@ class SolveScenarioBuildResult:
     family_name: str
 
 
+@dataclass(slots=True)
+class SolveExecutionSummary:
+    run_id: str
+    generations_executed: int
+    best_score: float
+
+
+class ArtifactEditingTaskAdapter(AgentTaskInterface):
+    """Adapt artifact-editing scenarios onto the task-bearing execution loop."""
+
+    def __init__(self, scenario: ArtifactEditingInterface) -> None:
+        self._scenario = scenario
+        self.name = getattr(scenario, "name", scenario.__class__.__name__)
+
+    def describe_task(self) -> str:
+        return self._scenario.describe_task()
+
+    def get_rubric(self) -> str:
+        return self._scenario.get_rubric()
+
+    def initial_state(self, seed: int | None = None) -> dict:
+        return {
+            "original_artifacts": [artifact.to_dict() for artifact in self._scenario.initial_artifacts(seed)],
+        }
+
+    def get_task_prompt(self, state: dict) -> str:
+        return self._scenario.get_edit_prompt(self._original_artifacts(state))
+
+    def evaluate_output(
+        self,
+        output: str,
+        state: dict,
+        reference_context: str | None = None,
+        required_concepts: list[str] | None = None,
+        calibration_examples: list[dict] | None = None,
+        pinned_dimensions: list[str] | None = None,
+    ) -> AgentTaskResult:
+        del reference_context, required_concepts, calibration_examples, pinned_dimensions
+        original = self._original_artifacts(state)
+        try:
+            edited = self._parse_edited_artifacts(output, original)
+        except Exception as exc:
+            return AgentTaskResult(
+                score=0.0,
+                reasoning=f"Edited artifact JSON parse failed: {exc}",
+                dimension_scores={},
+            )
+
+        result = self._scenario.evaluate_edits(original, edited)
+        reasoning = result.reasoning
+        if result.validation.errors:
+            reasoning = f"{reasoning} Validation errors: {'; '.join(result.validation.errors)}"
+        return AgentTaskResult(
+            score=result.score,
+            reasoning=reasoning,
+            dimension_scores=result.dimension_scores,
+        )
+
+    def _original_artifacts(self, state: dict) -> list[Artifact]:
+        payload = state.get("original_artifacts")
+        if isinstance(payload, list):
+            try:
+                return [Artifact.from_dict(cast(dict[str, Any], item)) for item in payload]
+            except Exception:
+                logger.debug("failed to restore original artifacts from state", exc_info=True)
+        return self._scenario.initial_artifacts()
+
+    def _parse_edited_artifacts(self, output: str, original: list[Artifact]) -> list[Artifact]:
+        text = output.strip()
+        json_start = text.find("{")
+        json_end = text.rfind("}")
+        if json_start == -1 or json_end == -1 or json_end <= json_start:
+            raise ValueError("output does not contain an edited-artifact JSON object")
+        payload = json.loads(text[json_start : json_end + 1])
+        artifact_payloads = payload.get("artifacts") if isinstance(payload, dict) else None
+        if not isinstance(artifact_payloads, list):
+            raise ValueError("output JSON must contain an 'artifacts' list")
+
+        original_by_path = {artifact.path: artifact for artifact in original}
+        edited_by_path: dict[str, Artifact] = {}
+        for item in artifact_payloads:
+            if not isinstance(item, dict):
+                raise ValueError("edited artifacts must be objects")
+            path = str(item.get("path", "")).strip()
+            content = item.get("content")
+            if not path or not isinstance(content, str):
+                raise ValueError("each edited artifact must include string path and content fields")
+            original_artifact = original_by_path.get(path)
+            content_type = item.get("content_type")
+            metadata = item.get("metadata")
+            edited_by_path[path] = Artifact(
+                path=path,
+                content=content,
+                content_type=(
+                    str(content_type)
+                    if isinstance(content_type, str) and content_type.strip()
+                    else (original_artifact.content_type if original_artifact is not None else "text")
+                ),
+                metadata=(
+                    cast(dict[str, Any], metadata)
+                    if isinstance(metadata, dict)
+                    else (original_artifact.metadata if original_artifact is not None else {})
+                ),
+            )
+        for artifact in original:
+            edited_by_path.setdefault(artifact.path, artifact)
+        if not edited_by_path:
+            raise ValueError("edited artifact set must not be empty")
+        return list(edited_by_path.values())
+
+
+def _resolve_family_hint(description: str):
+    from autocontext.scenarios.families import get_family, list_families
+
+    match = _FAMILY_HEADER_RE.search(description)
+    if match is None:
+        return None
+
+    supported = {family.name: family for family in list_families()}
+    raw_hint = match.group("body")
+    for token in re.split(r"[/,|]", raw_hint):
+        normalized = re.sub(r"[^a-z0-9_\-\s]", " ", token.lower()).strip()
+        candidate = normalized.replace("-", "_").replace(" ", "_")
+        if candidate in supported:
+            return get_family(candidate)
+    return None
+
+
+def _resolve_requested_scenario_family(description: str):
+    from autocontext.scenarios.custom.family_classifier import classify_scenario_family, route_to_family
+
+    hinted_family = _resolve_family_hint(description)
+    if hinted_family is not None:
+        return hinted_family
+    classification = classify_scenario_family(description)
+    return route_to_family(classification)
+
+
+class SolveScenarioExecutor:
+    """Execute created solve scenarios through the correct family-aware runtime surface."""
+
+    def __init__(self, settings: AppSettings, *, migrations_dir: Path | None = None) -> None:
+        self._settings = settings
+        self._migrations_dir = migrations_dir or Path(__file__).resolve().parents[2] / "migrations"
+
+    def execute(
+        self,
+        *,
+        scenario_name: str,
+        family_name: str,
+        generations: int,
+    ) -> SolveExecutionSummary:
+        scenario = self._scenario(scenario_name)
+        if isinstance(scenario, AgentTaskInterface):
+            return self._run_task_like_scenario(
+                scenario_name=scenario_name,
+                scenario_type="agent_task",
+                task=scenario,
+                max_rounds=generations,
+            )
+        if isinstance(scenario, ArtifactEditingInterface):
+            return self._run_task_like_scenario(
+                scenario_name=scenario_name,
+                scenario_type="artifact_editing",
+                task=ArtifactEditingTaskAdapter(scenario),
+                max_rounds=generations,
+            )
+        if family_name in {"agent_task", "artifact_editing"}:
+            raise TypeError(
+                f"Solve created family '{family_name}' for scenario '{scenario_name}', "
+                "but the generated class does not expose the expected execution interface"
+            )
+
+        from autocontext.loop.generation_runner import GenerationRunner
+
+        runner = GenerationRunner(self._settings)
+        runner.migrate(self._migrations_dir)
+        run_id = f"solve_{scenario_name}_{uuid.uuid4().hex[:8]}"
+        summary = runner.run(scenario_name, generations, run_id)
+        return SolveExecutionSummary(
+            run_id=summary.run_id,
+            generations_executed=summary.generations_executed,
+            best_score=summary.best_score,
+        )
+
+    def _scenario(self, scenario_name: str) -> Any:
+        cls = SCENARIO_REGISTRY.get(scenario_name)
+        if cls is None:
+            from autocontext.scenarios.custom.registry import load_all_custom_scenarios
+
+            custom = load_all_custom_scenarios(self._settings.knowledge_root)
+            if custom:
+                SCENARIO_REGISTRY.update(custom)
+            cls = SCENARIO_REGISTRY.get(scenario_name)
+        if cls is None:
+            supported = ", ".join(sorted(SCENARIO_REGISTRY.keys()))
+            raise ValueError(f"Unknown scenario '{scenario_name}'. Supported: {supported}")
+        return cls()
+
+    def _run_task_like_scenario(
+        self,
+        *,
+        scenario_name: str,
+        scenario_type: str,
+        task: AgentTaskInterface,
+        max_rounds: int,
+    ) -> SolveExecutionSummary:
+        sqlite = SQLiteStore(self._settings.db_path)
+        sqlite.migrate(self._migrations_dir)
+        provider, provider_model = resolve_role_runtime(
+            self._settings,
+            role="competitor",
+            scenario_name=scenario_name,
+            sqlite=sqlite,
+        )
+        state = task.prepare_context(task.initial_state())
+        context_errors = task.validate_context(state)
+        if context_errors:
+            raise ValueError(f"Context validation failed: {'; '.join(context_errors)}")
+        prompt = task.get_task_prompt(state)
+        initial_output = provider.complete(
+            system_prompt="Complete the task precisely.",
+            user_prompt=prompt,
+            model=provider_model,
+        ).text
+
+        loop = ImprovementLoop(task=task, max_rounds=max_rounds)
+        active_run_id = f"solve_{scenario_name}_{uuid.uuid4().hex[:8]}"
+        sqlite.create_run(
+            active_run_id,
+            scenario_name,
+            1,
+            scenario_type,
+            agent_provider=self._settings.agent_provider,
+        )
+        sqlite.upsert_generation(
+            active_run_id,
+            1,
+            mean_score=0.0,
+            best_score=0.0,
+            elo=0.0,
+            wins=0,
+            losses=0,
+            gate_decision="running",
+            status="running",
+        )
+        sqlite.append_agent_output(active_run_id, 1, "competitor_initial", initial_output)
+
+        try:
+            result = loop.run(initial_output=initial_output, state=state)
+        except Exception:
+            sqlite.upsert_generation(
+                active_run_id,
+                1,
+                mean_score=0.0,
+                best_score=0.0,
+                elo=0.0,
+                wins=0,
+                losses=0,
+                gate_decision="failed",
+                status="failed",
+            )
+            sqlite.mark_run_failed(active_run_id)
+            raise
+
+        sqlite.append_agent_output(active_run_id, 1, "competitor", result.best_output)
+        sqlite.upsert_generation(
+            active_run_id,
+            1,
+            mean_score=result.best_score,
+            best_score=result.best_score,
+            elo=0.0,
+            wins=0,
+            losses=0,
+            gate_decision=result.termination_reason,
+            status="completed",
+            duration_seconds=(result.duration_ms / 1000.0) if result.duration_ms is not None else None,
+        )
+        sqlite.mark_run_completed(active_run_id)
+        return SolveExecutionSummary(
+            run_id=active_run_id,
+            generations_executed=result.total_rounds,
+            best_score=result.best_score,
+        )
+
+
 class SolveScenarioBuilder:
     """Create solve scenarios through the correct family-specific pipeline."""
 
@@ -58,13 +355,10 @@ class SolveScenarioBuilder:
         self._knowledge_root = knowledge_root
 
     def build(self, description: str) -> SolveScenarioBuildResult:
-        from autocontext.scenarios import SCENARIO_REGISTRY
         from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
         from autocontext.scenarios.custom.creator import ScenarioCreator
-        from autocontext.scenarios.custom.family_classifier import classify_scenario_family, route_to_family
 
-        classification = classify_scenario_family(description)
-        family = route_to_family(classification)
+        family = _resolve_requested_scenario_family(description)
 
         if family.name == "game":
             game_creator = ScenarioCreator(
@@ -84,7 +378,7 @@ class SolveScenarioBuilder:
             llm_fn=self._llm_fn,
             knowledge_root=self._knowledge_root,
         )
-        scenario = family_creator.create(description)
+        scenario = family_creator.create(description, family_name=family.name)
         scenario_name = str(cast(_NamedScenario, scenario).name)
         SCENARIO_REGISTRY[scenario_name] = scenario.__class__
         return SolveScenarioBuildResult(
@@ -159,12 +453,12 @@ class SolveManager:
 
             # 2. Run generations
             job.status = "running"
-            from autocontext.loop.generation_runner import GenerationRunner
-
-            runner = GenerationRunner(self._settings)
-            runner.migrate(self._migrations_dir)
-            run_id = f"solve_{created.scenario_name}_{uuid.uuid4().hex[:8]}"
-            summary = runner.run(created.scenario_name, job.generations, run_id)
+            executor = SolveScenarioExecutor(self._settings, migrations_dir=self._migrations_dir)
+            summary = executor.execute(
+                scenario_name=created.scenario_name,
+                family_name=created.family_name,
+                generations=job.generations,
+            )
             job.progress = summary.generations_executed
 
             # 3. Export skill package

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -10,7 +10,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from autocontext.agents.types import LlmFn
 from autocontext.cli_role_runtime import resolve_role_runtime
@@ -21,7 +21,11 @@ from autocontext.mcp.tools import MtsToolContext
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
 from autocontext.scenarios.artifact_editing import Artifact, ArtifactEditingInterface
+from autocontext.storage import artifact_store_from_settings
 from autocontext.storage.sqlite_store import SQLiteStore
+
+if TYPE_CHECKING:
+    from autocontext.scenarios.families import ScenarioFamily
 
 logger = logging.getLogger(__name__)
 
@@ -156,14 +160,10 @@ class ArtifactEditingTaskAdapter(AgentTaskInterface):
                     else (original_artifact.metadata if original_artifact is not None else {})
                 ),
             )
-        for artifact in original:
-            edited_by_path.setdefault(artifact.path, artifact)
-        if not edited_by_path:
-            raise ValueError("edited artifact set must not be empty")
         return list(edited_by_path.values())
 
 
-def _resolve_family_hint(description: str):
+def _resolve_family_hint(description: str) -> ScenarioFamily | None:
     from autocontext.scenarios.families import get_family, list_families
 
     match = _FAMILY_HEADER_RE.search(description)
@@ -180,7 +180,7 @@ def _resolve_family_hint(description: str):
     return None
 
 
-def _resolve_requested_scenario_family(description: str):
+def _resolve_requested_scenario_family(description: str) -> ScenarioFamily:
     from autocontext.scenarios.custom.family_classifier import classify_scenario_family, route_to_family
 
     hinted_family = _resolve_family_hint(description)
@@ -331,6 +331,19 @@ class SolveScenarioExecutor:
             duration_seconds=(result.duration_ms / 1000.0) if result.duration_ms is not None else None,
         )
         sqlite.mark_run_completed(active_run_id)
+        if self._settings.cross_run_inheritance and not self._settings.ablation_no_feedback:
+            artifacts = artifact_store_from_settings(self._settings)
+            playbook_hash = artifacts.snapshot_knowledge(scenario_name, active_run_id)
+            sqlite.save_knowledge_snapshot(
+                scenario=scenario_name,
+                run_id=active_run_id,
+                best_score=result.best_score,
+                best_elo=1500.0,
+                playbook_hash=playbook_hash,
+                agent_provider=self._settings.agent_provider,
+                rlm_enabled=self._settings.rlm_enabled,
+                scoring_backend=self._settings.scoring_backend,
+            )
         return SolveExecutionSummary(
             run_id=active_run_id,
             generations_executed=result.total_rounds,

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -34,7 +34,7 @@ from autocontext.scenarios.custom.family_pipeline import (
 from autocontext.scenarios.custom.naming import STOP_WORDS as SHARED_STOP_WORDS
 from autocontext.scenarios.custom.naming import derive_name as shared_derive_name
 from autocontext.scenarios.custom.registry import CUSTOM_SCENARIOS_DIR
-from autocontext.scenarios.families import get_family_marker
+from autocontext.scenarios.families import get_family, get_family_marker
 from autocontext.scenarios.investigation import InvestigationInterface
 from autocontext.scenarios.negotiation import NegotiationInterface
 from autocontext.scenarios.operator_loop import OperatorLoopInterface
@@ -65,11 +65,19 @@ class AgentTaskCreator:
     def create(
         self,
         description: str,
+        *,
+        family_name: str = "",
     ) -> (
-        AgentTaskInterface | ScenarioInterface | ArtifactEditingInterface
-        | InvestigationInterface | WorkflowInterface
-        | SchemaEvolutionInterface | ToolFragilityInterface
-        | NegotiationInterface | OperatorLoopInterface | CoordinationInterface
+        AgentTaskInterface
+        | ScenarioInterface
+        | ArtifactEditingInterface
+        | InvestigationInterface
+        | WorkflowInterface
+        | SchemaEvolutionInterface
+        | ToolFragilityInterface
+        | NegotiationInterface
+        | OperatorLoopInterface
+        | CoordinationInterface
     ):
         """Run the full pipeline: design → validate → codegen → validate → load → register.
 
@@ -77,16 +85,17 @@ class AgentTaskCreator:
             An instance of the generated scenario family implementation.
         """
         name = self.derive_name(description)
-        classification = classify_scenario_family(description)
-        family = route_to_family(classification)
+        if family_name:
+            family = get_family(family_name)
+        else:
+            classification = classify_scenario_family(description)
+            family = route_to_family(classification)
         if family.name in FAMILY_CONFIGS:
             logger.info("routing description to %s creator", family.name)
             creator = create_for_family(family.name, self.llm_fn, self.knowledge_root)
             return creator.create(description, name=name)
         if family.name != "agent_task":
-            raise ValueError(
-                f"Scenario family '{family.name}' is not yet supported for custom scaffolding"
-            )
+            raise ValueError(f"Scenario family '{family.name}' is not yet supported for custom scaffolding")
 
         # 1. Design
         logger.info("designing agent task from description")
@@ -166,6 +175,7 @@ class AgentTaskCreator:
         # 7. Load and register
         cls = self._load_agent_task(custom_dir, name)
         from autocontext.scenarios import SCENARIO_REGISTRY
+
         SCENARIO_REGISTRY[name] = cls
         logger.info("registered agent task '%s'", name)
 
@@ -188,11 +198,7 @@ class AgentTaskCreator:
 
         for attr_name in dir(mod):
             attr = getattr(mod, attr_name)
-            if (
-                isinstance(attr, type)
-                and issubclass(attr, AgentTaskInterface)
-                and attr is not AgentTaskInterface
-            ):
+            if isinstance(attr, type) and issubclass(attr, AgentTaskInterface) and attr is not AgentTaskInterface:
                 attr = patch_legacy_generated_evaluate_output(attr, source_path)
                 return patch_legacy_generated_revise_output(attr, source_path)
 

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -3,11 +3,22 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from autocontext.agents.llm_client import DeterministicDevClient
 from autocontext.agents.subagent_runtime import SubagentRuntime
+from autocontext.config.settings import AppSettings
 from autocontext.scenarios import SCENARIO_REGISTRY
+from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
+from autocontext.scenarios.artifact_editing import (
+    Artifact,
+    ArtifactEditingInterface,
+    ArtifactEditingResult,
+    ArtifactValidationResult,
+)
 from autocontext.scenarios.custom.operator_loop_designer import OPERATOR_LOOP_SPEC_END, OPERATOR_LOOP_SPEC_START
 from autocontext.scenarios.families import detect_family
+from autocontext.storage.sqlite_store import SQLiteStore
 
 
 def _operator_loop_llm(system: str, user: str) -> str:
@@ -48,6 +59,86 @@ def _operator_loop_llm(system: str, user: str) -> str:
         ],
     }
     return f"{OPERATOR_LOOP_SPEC_START}\n{json.dumps(spec)}\n{OPERATOR_LOOP_SPEC_END}"
+
+
+class _StubProviderResponse:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _StubProvider:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def complete(self, system_prompt: str, user_prompt: str, model: str = "") -> _StubProviderResponse:
+        del system_prompt, user_prompt, model
+        return _StubProviderResponse(self._text)
+
+    def default_model(self) -> str:
+        return "test-model"
+
+
+class _SolveAgentTask(AgentTaskInterface):
+    name = "solve_agent_task_fixture"
+
+    def get_task_prompt(self, state: dict) -> str:
+        del state
+        return "Reply with exactly: improved draft"
+
+    def evaluate_output(self, output: str, state: dict, **kwargs: object) -> AgentTaskResult:
+        del state, kwargs
+        score = 1.0 if output.strip() == "improved draft" else 0.2
+        return AgentTaskResult(
+            score=score,
+            reasoning="matched expected task output" if score == 1.0 else "output mismatch",
+            dimension_scores={"quality": score},
+        )
+
+    def get_rubric(self) -> str:
+        return "Score exact_match 0-1."
+
+    def initial_state(self, seed: int | None = None) -> dict:
+        del seed
+        return {}
+
+    def describe_task(self) -> str:
+        return "Return the expected draft text."
+
+
+class _SolveArtifactEditing(ArtifactEditingInterface):
+    name = "solve_artifact_editing_fixture"
+
+    def describe_task(self) -> str:
+        return "Update the YAML artifact so foo is set to new."
+
+    def get_rubric(self) -> str:
+        return "Reward valid edits that change only the target field."
+
+    def initial_artifacts(self, seed: int | None = None) -> list[Artifact]:
+        del seed
+        return [Artifact(path="config.yaml", content="foo: old\n", content_type="yaml", metadata={})]
+
+    def get_edit_prompt(self, artifacts: list[Artifact]) -> str:
+        del artifacts
+        return "Return JSON with an artifacts array containing the full edited artifact set."
+
+    def validate_artifact(self, artifact: Artifact) -> ArtifactValidationResult:
+        errors = [] if artifact.content.strip() == "foo: new" else ["config.yaml did not update foo"]
+        return ArtifactValidationResult(valid=not errors, errors=errors, warnings=[])
+
+    def evaluate_edits(self, original: list[Artifact], edited: list[Artifact]) -> ArtifactEditingResult:
+        del original
+        validation = self.validate_artifact(edited[0])
+        score = 1.0 if validation.valid else 0.0
+        return ArtifactEditingResult(
+            score=score,
+            reasoning="artifact updated" if validation.valid else "artifact invalid",
+            dimension_scores={"correctness": score},
+            diffs=self.compute_diffs(self.initial_artifacts(), edited),
+            validation=validation,
+            artifacts_modified=1 if score else 0,
+            artifacts_valid=1 if score else 0,
+        )
 
 
 class TestSolveScenarioBuilder:
@@ -95,3 +186,200 @@ class TestSolveScenarioBuilder:
         assert result.family_name == "game"
         assert spec_payload["scenario_type"] == "parametric"
         assert detect_family(scenario).name == "game"
+
+    def test_prefers_supported_family_hint_from_proposal_metadata(self) -> None:
+        from autocontext.knowledge.solver import _resolve_requested_scenario_family
+
+        family = _resolve_requested_scenario_family(
+            "Scenario Proposal: peer_review_panel — multi-role adversarial coordination\n\n"
+            "## Scenario Proposal\n\n"
+            "**Family:** coordination / adversarial_self_play\n"
+            "**Priority:** Week 4\n\n"
+            "### Description\n\n"
+            "Three instances (Author, Critic A, Critic B) collaborate. Author produces artifact, "
+            "Critic A finds weaknesses, Critic B defends and challenges objections."
+        )
+
+        assert family.name == "coordination"
+
+    def test_passes_supported_family_hint_into_creator(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from autocontext.knowledge.solver import SolveScenarioBuilder
+
+        runtime = SubagentRuntime(DeterministicDevClient())
+        builder = SolveScenarioBuilder(
+            runtime=runtime,
+            llm_fn=_operator_loop_llm,
+            model="test-model",
+            knowledge_root=tmp_path,
+        )
+        captured: dict[str, str] = {}
+
+        class _CreatedScenario:
+            name = "peer_review_panel_fixture"
+
+        def _fake_create(self, description: str, *, family_name: str = "") -> _CreatedScenario:
+            del self, description
+            captured["family_name"] = family_name
+            return _CreatedScenario()
+
+        monkeypatch.setattr(
+            "autocontext.scenarios.custom.agent_task_creator.AgentTaskCreator.create",
+            _fake_create,
+        )
+
+        result = builder.build(
+            "Scenario Proposal: peer_review_panel — multi-role adversarial coordination\n\n"
+            "## Scenario Proposal\n\n"
+            "**Family:** coordination / adversarial_self_play\n"
+            "**Priority:** Week 4\n\n"
+            "### Description\n\n"
+            "Three instances (Author, Critic A, Critic B) collaborate. Author produces artifact, "
+            "Critic A finds weaknesses, Critic B defends and challenges objections."
+        )
+
+        assert captured["family_name"] == "coordination"
+        assert result.family_name == "coordination"
+
+
+class TestSolveScenarioExecutor:
+    def test_runs_agent_task_scenarios_through_task_loop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from autocontext.knowledge.solver import SolveScenarioExecutor
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+        )
+        scenario_name = "solve_agent_task_execution"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        SCENARIO_REGISTRY[scenario_name] = _SolveAgentTask
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.resolve_role_runtime",
+            lambda settings, **kwargs: (_StubProvider("improved draft"), "test-model"),
+        )
+
+        try:
+            executor = SolveScenarioExecutor(settings)
+            summary = executor.execute(
+                scenario_name=scenario_name,
+                family_name="agent_task",
+                generations=1,
+            )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        sqlite = SQLiteStore(settings.db_path)
+        sqlite.migrate(Path(__file__).resolve().parents[1] / "migrations")
+
+        assert summary.generations_executed == 1
+        assert summary.best_score == 1.0
+        assert sqlite.count_completed_runs(scenario_name) == 1
+
+    def test_runs_artifact_editing_scenarios_through_task_loop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from autocontext.knowledge.solver import SolveScenarioExecutor
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+        )
+        scenario_name = "solve_artifact_editing_execution"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        SCENARIO_REGISTRY[scenario_name] = _SolveArtifactEditing
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.resolve_role_runtime",
+            lambda settings, **kwargs: (
+                _StubProvider(
+                    json.dumps(
+                        {
+                            "artifacts": [
+                                {
+                                    "path": "config.yaml",
+                                    "content": "foo: new\n",
+                                    "content_type": "yaml",
+                                }
+                            ]
+                        }
+                    )
+                ),
+                "test-model",
+            ),
+        )
+
+        try:
+            executor = SolveScenarioExecutor(settings)
+            summary = executor.execute(
+                scenario_name=scenario_name,
+                family_name="artifact_editing",
+                generations=1,
+            )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        sqlite = SQLiteStore(settings.db_path)
+        sqlite.migrate(Path(__file__).resolve().parents[1] / "migrations")
+
+        assert summary.generations_executed == 1
+        assert summary.best_score == 1.0
+        assert sqlite.count_completed_runs(scenario_name) == 1
+
+
+class TestSolveManager:
+    def test_run_job_uses_family_aware_executor(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from autocontext.knowledge.export import SkillPackage
+        from autocontext.knowledge.solver import (
+            SolveExecutionSummary,
+            SolveJob,
+            SolveManager,
+            SolveScenarioBuildResult,
+        )
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+        )
+        manager = SolveManager(settings)
+        created = SolveScenarioBuildResult(
+            scenario_name="solve_agent_task_execution",
+            family_name="agent_task",
+        )
+
+        class _FakeBuilder:
+            def build(self, description: str) -> SolveScenarioBuildResult:
+                del description
+                return created
+
+        fake_package = SkillPackage(
+            scenario_name=created.scenario_name,
+            display_name="Solve Agent Task Execution",
+            description="fixture",
+            playbook="",
+            lessons=[],
+            best_strategy=None,
+            best_score=1.0,
+            best_elo=1500.0,
+            hints="",
+            harness={},
+        )
+
+        monkeypatch.setattr(manager, "_build_creator", lambda: _FakeBuilder())
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.SolveScenarioExecutor.execute",
+            lambda self, **kwargs: SolveExecutionSummary(
+                run_id="solve_fixture",
+                generations_executed=3,
+                best_score=0.9,
+            ),
+        )
+        monkeypatch.setattr("autocontext.knowledge.solver.export_skill_package", lambda ctx, name: fake_package)
+
+        job = SolveJob(job_id="solve_fixture_job", description="fixture", generations=3)
+        manager._run_job(job)
+
+        assert job.status == "completed"
+        assert job.progress == 3
+        assert job.result == fake_package

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -8,6 +8,8 @@ import pytest
 from autocontext.agents.llm_client import DeterministicDevClient
 from autocontext.agents.subagent_runtime import SubagentRuntime
 from autocontext.config.settings import AppSettings
+from autocontext.knowledge.export import export_skill_package
+from autocontext.mcp.tools import MtsToolContext
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
 from autocontext.scenarios.artifact_editing import (
@@ -264,6 +266,7 @@ class TestSolveScenarioExecutor:
                 family_name="agent_task",
                 generations=1,
             )
+            package = export_skill_package(MtsToolContext(settings), scenario_name)
         finally:
             if previous is None:
                 SCENARIO_REGISTRY.pop(scenario_name, None)
@@ -275,7 +278,35 @@ class TestSolveScenarioExecutor:
 
         assert summary.generations_executed == 1
         assert summary.best_score == 1.0
+        assert package.best_score == 1.0
+        assert package.metadata["has_snapshot"] is True
         assert sqlite.count_completed_runs(scenario_name) == 1
+
+    def test_artifact_editing_adapter_preserves_omitted_artifact_deletions(self) -> None:
+        from autocontext.knowledge.solver import ArtifactEditingTaskAdapter
+
+        adapter = ArtifactEditingTaskAdapter(_SolveArtifactEditing())
+        original = [
+            Artifact(path="config.yaml", content="foo: old\n", content_type="yaml", metadata={}),
+            Artifact(path="legacy.yaml", content="delete: true\n", content_type="yaml", metadata={}),
+        ]
+
+        edited = adapter._parse_edited_artifacts(
+            json.dumps(
+                {
+                    "artifacts": [
+                        {
+                            "path": "config.yaml",
+                            "content": "foo: new\n",
+                            "content_type": "yaml",
+                        }
+                    ]
+                }
+            ),
+            original,
+        )
+
+        assert [artifact.path for artifact in edited] == ["config.yaml"]
 
     def test_runs_artifact_editing_scenarios_through_task_loop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from autocontext.knowledge.solver import SolveScenarioExecutor


### PR DESCRIPTION
## Summary

- route `solve` through explicit family hints from Scenarios proposal metadata before falling back to generic family classification
- pass the resolved family into `AgentTaskCreator` so solve-created proposal prompts do not get reclassified and fail the original low-confidence gate again
- add a family-aware `SolveScenarioExecutor` so solve-created `agent_task` and `artifact_editing` scenarios run through task-like execution instead of the tournament `GenerationRunner` path that expected `seed_tools()`
- adapt artifact-editing scenarios onto the existing improvement-loop surface with a lightweight JSON artifact adapter
- add regression coverage for family-hint routing, agent-task solve execution, artifact-editing solve execution, and manager wiring

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/knowledge/solver.py src/autocontext/scenarios/custom/agent_task_creator.py tests/test_knowledge_solver.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_knowledge_solver.py -x --tb=short`
- [x] `cd autocontext && uv run pytest tests/test_knowledge_solver.py tests/test_cli_json.py tests/test_family_classifier.py tests/test_artifact_editing.py tests/test_scenario_families.py -k 'solve or artifact or family' -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

### Manual verification

- live `pi` AC-390 solve now completes instead of failing low-confidence family routing:
  - `/tmp/ac561-live-ac390-xVuc6u/result.json`
- live `pi` AC-392 solve now completes instead of crashing on missing `seed_tools` after creation:
  - `/tmp/ac561-live-ac392-0jx7CW/result.json`
- live `pi` AC-384 rerun completed through the solve path without the old `seed_tools` crash:
  - `/tmp/ac561-live-ac384-rerun2-4h7dtX/result.json`
- one other AC-384 rerun failed earlier with a clear intent-validation error instead of the old post-creation `seed_tools` crash:
  - `/tmp/ac561-live-ac384-T9Ys3d/stderr.log`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this change addresses the AC-561 bucket by fixing the family-support boundary in Python `solve`; it does not attempt to solve the separate AC-562 timeout bucket
- AC-384 still appears nondeterministic at creation time under live `pi`, but when creation succeeds the old post-creation crash path is cleared and failures now surface earlier and more clearly
