### PR TITLE
fix: add solve timeout and budget controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 autocontext runs LLM agents through structured scenarios, evaluates their outputs, and accumulates the knowledge that improved results — so repeated runs get better, not just different. Point the harness at a real task in plain language, let it work the problem, and then inspect the traces, reports, artifacts, datasets, playbooks, and optional distilled model it produces.
 
 <!-- autocontext-whats-new:start -->
-
 ## What's New
 
 - All 11 scenario families executable in both Python and TypeScript

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 autocontext runs LLM agents through structured scenarios, evaluates their outputs, and accumulates the knowledge that improved results — so repeated runs get better, not just different. Point the harness at a real task in plain language, let it work the problem, and then inspect the traces, reports, artifacts, datasets, playbooks, and optional distilled model it produces.
 
 <!-- autocontext-whats-new:start -->
+
 ## What's New
 
 - All 11 scenario families executable in both Python and TypeScript
@@ -183,7 +184,7 @@ AUTOCONTEXT_CLAUDE_TIMEOUT=300 \
 uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
 ```
 
-For longer `autoctx judge` / `autoctx improve` prompts on `claude-cli`, use `--timeout <seconds>` or set `AUTOCONTEXT_CLAUDE_TIMEOUT`.
+For longer live prompts, `autoctx solve`, `autoctx judge`, and `autoctx improve` all accept `--timeout <seconds>`. `autoctx solve` also accepts `--generation-time-budget <seconds>` to cap per-generation solve runtime. You can still use provider env vars such as `AUTOCONTEXT_CLAUDE_TIMEOUT` or `AUTOCONTEXT_PI_TIMEOUT`.
 
 Run with Codex CLI:
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -85,7 +85,7 @@ AUTOCONTEXT_CLAUDE_TIMEOUT=300 \
 uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
 ```
 
-For longer `autoctx judge` / `autoctx improve` prompts on `claude-cli`, use `--timeout <seconds>` or set `AUTOCONTEXT_CLAUDE_TIMEOUT`.
+For longer live prompts, `autoctx solve`, `autoctx judge`, and `autoctx improve` all accept `--timeout <seconds>`. `autoctx solve` also accepts `--generation-time-budget <seconds>` to cap per-generation solve runtime. You can still use provider env vars such as `AUTOCONTEXT_CLAUDE_TIMEOUT` or `AUTOCONTEXT_PI_TIMEOUT`.
 
 Run with Codex CLI (`codex exec` via a local authenticated Codex runtime):
 

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -506,7 +506,7 @@ autoctx solve \
   --json | jq .
 ```
 
-`autoctx solve` is a synchronous CLI wrapper around the solve-on-demand pipeline. Use the server or MCP solve APIs if you need background job submission and later result retrieval from a long-lived process.
+`autoctx solve` is a synchronous CLI wrapper around the solve-on-demand pipeline. Use `--timeout <seconds>` when richer live prompts need a longer provider runtime window, and `--generation-time-budget <seconds>` when you want to cap per-generation solve runtime. Use the server or MCP solve APIs if you need background job submission and later result retrieval from a long-lived process.
 
 #### When to use which integration path
 

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -23,7 +23,9 @@ from autocontext.cli_queue import register_queue_command
 from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.cli_runtime_overrides import (
     apply_judge_runtime_overrides,
+    apply_solve_runtime_overrides,
     format_runtime_provider_error,
+    solve_primary_runtime_provider,
 )
 from autocontext.config import load_settings
 from autocontext.config.presets import VALID_PRESET_NAMES
@@ -68,6 +70,7 @@ class SolveRunSummary:
     progress: int
     output_path: str | None
     result: dict[str, Any] | None
+
 
 app = typer.Typer(help="autocontext control-plane CLI", invoke_without_command=True)
 console = Console()
@@ -550,16 +553,18 @@ def status(
     if json_output:
         generations = []
         for row in rows:
-            generations.append({
-                "generation": row["generation_index"],
-                "mean_score": row["mean_score"],
-                "best_score": row["best_score"],
-                "elo": row["elo"],
-                "wins": row["wins"],
-                "losses": row["losses"],
-                "gate_decision": row["gate_decision"],
-                "status": row["status"],
-            })
+            generations.append(
+                {
+                    "generation": row["generation_index"],
+                    "mean_score": row["mean_score"],
+                    "best_score": row["best_score"],
+                    "elo": row["elo"],
+                    "wins": row["wins"],
+                    "losses": row["losses"],
+                    "gate_decision": row["gate_decision"],
+                    "status": row["status"],
+                }
+            )
         sys.stdout.write(json.dumps({"run_id": run_id, "generations": generations}) + "\n")
     else:
         table = Table(title=f"Run Status: {run_id}")
@@ -692,10 +697,14 @@ def tui(
 def ab_test(
     scenario: str = typer.Option("grid_ctf", "--scenario", help="Scenario to test"),
     baseline: str = typer.Option(
-        "AUTOCONTEXT_RLM_ENABLED=false", "--baseline", help="Comma-separated KEY=VALUE env overrides for baseline",
+        "AUTOCONTEXT_RLM_ENABLED=false",
+        "--baseline",
+        help="Comma-separated KEY=VALUE env overrides for baseline",
     ),
     treatment: str = typer.Option(
-        "AUTOCONTEXT_RLM_ENABLED=true", "--treatment", help="Comma-separated KEY=VALUE env overrides for treatment",
+        "AUTOCONTEXT_RLM_ENABLED=true",
+        "--treatment",
+        help="Comma-separated KEY=VALUE env overrides for treatment",
     ),
     runs: int = typer.Option(5, "--runs", min=1, help="Runs per condition"),
     gens: int = typer.Option(3, "--gens", min=1, help="Generations per run"),
@@ -833,15 +842,17 @@ def train(
         raise typer.Exit(code=1) from exc
 
     if json_output:
-        _write_json_stdout({
-            "scenario": result.scenario,
-            "total_experiments": result.total_experiments,
-            "kept_count": result.kept_count,
-            "discarded_count": result.discarded_count,
-            "best_score": result.best_score,
-            "checkpoint_path": str(result.checkpoint_path) if result.checkpoint_path else None,
-            "published_model_id": result.published_model_id,
-        })
+        _write_json_stdout(
+            {
+                "scenario": result.scenario,
+                "total_experiments": result.total_experiments,
+                "kept_count": result.kept_count,
+                "discarded_count": result.discarded_count,
+                "best_score": result.best_score,
+                "checkpoint_path": str(result.checkpoint_path) if result.checkpoint_path else None,
+                "published_model_id": result.published_model_id,
+            }
+        )
     else:
         # Summary
         table = Table(title="Training Summary")
@@ -1012,6 +1023,7 @@ def export_cmd(
     """Export a portable strategy package for a scenario."""
     from autocontext.knowledge.export import export_strategy_package
     from autocontext.mcp.tools import MtsToolContext
+
     settings = load_settings()
     resolved_db = Path(db_path) if db_path is not None else settings.db_path
     resolved_runs, resolved_knowledge, resolved_skills, resolved_claude = _resolve_export_artifact_roots(
@@ -1051,13 +1063,15 @@ def export_cmd(
     pkg.to_file(output_path)
 
     if json_output:
-        _write_json_stdout({
-            "scenario": scenario,
-            "output_path": str(output_path),
-            "best_score": pkg.best_score,
-            "lessons_count": len(pkg.lessons),
-            "harness_count": len(pkg.harness),
-        })
+        _write_json_stdout(
+            {
+                "scenario": scenario,
+                "output_path": str(output_path),
+                "best_score": pkg.best_score,
+                "lessons_count": len(pkg.lessons),
+                "harness_count": len(pkg.harness),
+            }
+        )
     else:
         console.print(f"[green]Exported {scenario} package to {output_path}[/green]")
         console.print(f"[dim]best_score={pkg.best_score:.4f} lessons={len(pkg.lessons)} harness={len(pkg.harness)}[/dim]")
@@ -1133,6 +1147,7 @@ def simulate(
     # Export mode
     if export_id:
         from autocontext.simulation.export import export_simulation
+
         result = export_simulation(id=export_id, knowledge_root=settings.knowledge_root, format=export_format)
         if json_output:
             _write_json_stdout(result)
@@ -1242,13 +1257,29 @@ def investigate(
 def solve(
     description: str = typer.Option(..., "--description", help="Natural-language scenario/problem description"),
     gens: int = typer.Option(5, "--gens", min=1, max=50, help="Generations to run for the solve"),
+    timeout: float | None = typer.Option(
+        None,
+        "--timeout",
+        min=1.0,
+        help="Provider timeout override in seconds for solve creation/execution runtimes",
+    ),
+    generation_time_budget: int | None = typer.Option(
+        None,
+        "--generation-time-budget",
+        min=0,
+        help="Soft per-generation time budget in seconds for solve runs (0 = unlimited)",
+    ),
     output: str = typer.Option("", "--output", help="Optional JSON file path for the solved package"),
     json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
 ) -> None:
     """Create a scenario on demand, run it, and export the solved package."""
     from autocontext.knowledge.solver import SolveManager
 
-    settings = load_settings()
+    settings = apply_solve_runtime_overrides(
+        load_settings(),
+        timeout=timeout,
+        generation_time_budget_seconds=generation_time_budget,
+    )
     manager = SolveManager(settings)
 
     try:
@@ -1269,6 +1300,12 @@ def solve(
 
     if job.status != "completed" or job.result is None:
         message = job.error or "solve did not complete successfully"
+        if "timeout" in message.lower():
+            message = format_runtime_provider_error(
+                ProviderError(message),
+                provider_name=solve_primary_runtime_provider(settings),
+                settings=settings,
+            )
         if json_output:
             _write_json_stderr(message)
         else:
@@ -1323,6 +1360,7 @@ def import_package_cmd(
 ) -> None:
     """Import a strategy package into scenario knowledge."""
     from autocontext.knowledge.package import ConflictPolicy, StrategyPackage, import_strategy_package
+
     pkg_path = Path(package_file)
     if not pkg_path.exists():
         if json_output:
@@ -1368,15 +1406,17 @@ def import_package_cmd(
     result = import_strategy_package(artifacts, pkg, sqlite=sqlite, conflict_policy=policy)
 
     if json_output:
-        _write_json_stdout({
-            "scenario_name": result.scenario_name,
-            "playbook_written": result.playbook_written,
-            "hints_written": result.hints_written,
-            "skill_written": result.skill_written,
-            "harness_written": result.harness_written,
-            "harness_skipped": result.harness_skipped,
-            "conflict_policy": result.conflict_policy,
-        })
+        _write_json_stdout(
+            {
+                "scenario_name": result.scenario_name,
+                "playbook_written": result.playbook_written,
+                "hints_written": result.hints_written,
+                "skill_written": result.skill_written,
+                "harness_written": result.harness_written,
+                "harness_skipped": result.harness_skipped,
+                "conflict_policy": result.conflict_policy,
+            }
+        )
     else:
         table = Table(title=f"Import: {result.scenario_name}")
         table.add_column("Item", style="bold")
@@ -1425,21 +1465,25 @@ def wait(
 
     if fired:
         if json_output:
-            _write_json_stdout({
-                "fired": True,
-                "condition_id": condition_id,
-                "alert": alert,
-            })
+            _write_json_stdout(
+                {
+                    "fired": True,
+                    "condition_id": condition_id,
+                    "alert": alert,
+                }
+            )
         else:
             detail = alert.get("detail", "") if alert else ""
             console.print(f"[green]Alert fired:[/green] {detail}")
     else:
         if json_output:
-            _write_json_stdout({
-                "fired": False,
-                "condition_id": condition_id,
-                "timeout_seconds": timeout,
-            })
+            _write_json_stdout(
+                {
+                    "fired": False,
+                    "condition_id": condition_id,
+                    "timeout_seconds": timeout,
+                }
+            )
         else:
             console.print(f"[yellow]Timed out after {timeout}s waiting for condition {condition_id}[/yellow]")
         raise typer.Exit(code=1)
@@ -1494,11 +1538,13 @@ def judge(
         )
 
     if json_output:
-        _write_json_stdout({
-            "score": result.score,
-            "reasoning": result.reasoning,
-            "dimension_scores": result.dimension_scores,
-        })
+        _write_json_stdout(
+            {
+                "score": result.score,
+                "reasoning": result.reasoning,
+                "dimension_scores": result.dimension_scores,
+            }
+        )
     else:
         console.print(f"[bold]Score:[/bold] {result.score:.4f}")
         console.print(f"[bold]Reasoning:[/bold] {result.reasoning}")
@@ -1560,17 +1606,20 @@ def improve(
         )
 
     if json_output:
-        _write_json_stdout({
-            "best_score": result.best_score,
-            "best_round": result.best_round,
-            "total_rounds": result.total_rounds,
-            "met_threshold": result.met_threshold,
-            "best_output": result.best_output,
-        })
+        _write_json_stdout(
+            {
+                "best_score": result.best_score,
+                "best_round": result.best_round,
+                "total_rounds": result.total_rounds,
+                "met_threshold": result.met_threshold,
+                "best_output": result.best_output,
+            }
+        )
     else:
         console.print(f"[bold]Best score:[/bold] {result.best_score:.4f} (round {result.best_round})")
         console.print(f"[bold]Rounds:[/bold] {result.total_rounds}")
         console.print(f"[bold]Met threshold:[/bold] {result.met_threshold}")
+
 
 register_queue_command(app, console=console)
 

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -23,10 +23,9 @@ from autocontext.cli_queue import register_queue_command
 from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.cli_runtime_overrides import (
     apply_judge_runtime_overrides,
-    apply_solve_runtime_overrides,
     format_runtime_provider_error,
-    solve_primary_runtime_provider,
 )
+from autocontext.cli_solve import register_solve_command
 from autocontext.config import load_settings
 from autocontext.config.presets import VALID_PRESET_NAMES
 from autocontext.config.settings import AppSettings
@@ -36,7 +35,7 @@ from autocontext.providers.base import ProviderError
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.agent_task import AgentTaskInterface
 from autocontext.storage import ArtifactStore, SQLiteStore, artifact_store_from_settings
-from autocontext.util.json_io import read_json, write_json
+from autocontext.util.json_io import read_json
 
 logger = logging.getLogger(__name__)
 
@@ -56,20 +55,6 @@ class AgentTaskRunSummary:
     total_rounds: int
     met_threshold: bool
     termination_reason: str
-
-
-@dataclass(slots=True)
-class SolveRunSummary:
-    """Result summary for solve-on-demand via the CLI."""
-
-    job_id: str
-    status: str
-    description: str
-    scenario_name: str | None
-    generations: int
-    progress: int
-    output_path: str | None
-    result: dict[str, Any] | None
 
 
 app = typer.Typer(help="autocontext control-plane CLI", invoke_without_command=True)
@@ -1253,100 +1238,6 @@ def investigate(
     )
 
 
-@app.command()
-def solve(
-    description: str = typer.Option(..., "--description", help="Natural-language scenario/problem description"),
-    gens: int = typer.Option(5, "--gens", min=1, max=50, help="Generations to run for the solve"),
-    timeout: float | None = typer.Option(
-        None,
-        "--timeout",
-        min=1.0,
-        help="Provider timeout override in seconds for solve creation/execution runtimes",
-    ),
-    generation_time_budget: int | None = typer.Option(
-        None,
-        "--generation-time-budget",
-        min=0,
-        help="Soft per-generation time budget in seconds for solve runs (0 = unlimited)",
-    ),
-    output: str = typer.Option("", "--output", help="Optional JSON file path for the solved package"),
-    json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
-) -> None:
-    """Create a scenario on demand, run it, and export the solved package."""
-    from autocontext.knowledge.solver import SolveManager
-
-    settings = apply_solve_runtime_overrides(
-        load_settings(),
-        timeout=timeout,
-        generation_time_budget_seconds=generation_time_budget,
-    )
-    manager = SolveManager(settings)
-
-    try:
-        job = manager.solve_sync(description=description, generations=gens)
-    except KeyboardInterrupt:
-        if json_output:
-            _write_json_stderr("solve interrupted")
-        else:
-            console.print("[red]Solve interrupted[/red]")
-        raise typer.Exit(code=1) from None
-    except Exception as exc:
-        logger.debug("cli: caught Exception", exc_info=True)
-        if json_output:
-            _write_json_stderr(str(exc))
-        else:
-            console.print(f"[red]Solve failed:[/red] {exc}")
-        raise typer.Exit(code=1) from None
-
-    if job.status != "completed" or job.result is None:
-        message = job.error or "solve did not complete successfully"
-        if "timeout" in message.lower():
-            message = format_runtime_provider_error(
-                ProviderError(message),
-                provider_name=solve_primary_runtime_provider(settings),
-                settings=settings,
-            )
-        if json_output:
-            _write_json_stderr(message)
-        else:
-            console.print(f"[red]Solve failed:[/red] {message}")
-        raise typer.Exit(code=1)
-
-    output_path: str | None = None
-    if output:
-        output_file = Path(output)
-        output_file.parent.mkdir(parents=True, exist_ok=True)
-        write_json(output_file, job.result.to_dict())
-        output_path = str(output_file)
-
-    summary = SolveRunSummary(
-        job_id=job.job_id,
-        status=job.status,
-        description=job.description,
-        scenario_name=job.scenario_name,
-        generations=job.generations,
-        progress=job.progress,
-        output_path=output_path,
-        result=job.result.to_dict(),
-    )
-
-    if json_output:
-        _write_json_stdout(dataclasses.asdict(summary))
-        return
-
-    table = Table(title="Solve Result")
-    table.add_column("Field")
-    table.add_column("Value")
-    table.add_row("Job ID", job.job_id)
-    table.add_row("Status", job.status)
-    table.add_row("Scenario", job.scenario_name or "unknown")
-    table.add_row("Generations", str(job.generations))
-    table.add_row("Progress", str(job.progress))
-    if output_path is not None:
-        table.add_row("Output", output_path)
-    console.print(table)
-
-
 @app.command("import-package")
 def import_package_cmd(
     package_file: str = typer.Argument(..., help="Path to the strategy package JSON file"),
@@ -1621,6 +1512,7 @@ def improve(
         console.print(f"[bold]Met threshold:[/bold] {result.met_threshold}")
 
 
+register_solve_command(app, console=console)
 register_queue_command(app, console=console)
 
 

--- a/autocontext/src/autocontext/cli_runtime_overrides.py
+++ b/autocontext/src/autocontext/cli_runtime_overrides.py
@@ -5,6 +5,13 @@ from typing import Any
 from autocontext.config.settings import AppSettings
 from autocontext.providers.base import ProviderError
 
+_SOLVE_RUNTIME_PROVIDER_FIELDS = (
+    "agent_provider",
+    "architect_provider",
+    "analyst_provider",
+    "competitor_provider",
+)
+
 
 def runtime_timeout_field_for_provider(provider_name: str) -> str | None:
     provider = provider_name.strip().lower()
@@ -15,6 +22,40 @@ def runtime_timeout_field_for_provider(provider_name: str) -> str | None:
     if provider in {"pi", "pi-rpc"}:
         return "pi_timeout"
     return None
+
+
+def _apply_timeout_overrides(
+    updates: dict[str, Any],
+    *,
+    provider_names: list[str],
+    timeout: float | None,
+) -> None:
+    if timeout is None:
+        return
+    for provider_name in provider_names:
+        timeout_field = runtime_timeout_field_for_provider(provider_name)
+        if timeout_field is not None:
+            updates[timeout_field] = timeout
+
+
+def solve_runtime_provider_names(settings: AppSettings) -> list[str]:
+    providers: list[str] = []
+    for field_name in _SOLVE_RUNTIME_PROVIDER_FIELDS:
+        value = getattr(settings, field_name, "")
+        if not isinstance(value, str):
+            continue
+        normalized = value.strip().lower()
+        if normalized and normalized not in providers:
+            providers.append(normalized)
+    return providers
+
+
+def solve_primary_runtime_provider(settings: AppSettings) -> str:
+    provider_names = solve_runtime_provider_names(settings)
+    for provider_name in provider_names:
+        if runtime_timeout_field_for_provider(provider_name) is not None:
+            return provider_name
+    return settings.agent_provider.strip().lower()
 
 
 def apply_judge_runtime_overrides(
@@ -31,10 +72,31 @@ def apply_judge_runtime_overrides(
         updates["judge_model"] = model
 
     resolved_provider = (provider_name or settings.judge_provider).strip().lower()
-    timeout_field = runtime_timeout_field_for_provider(resolved_provider)
-    if timeout is not None and timeout_field:
-        updates[timeout_field] = timeout
+    _apply_timeout_overrides(
+        updates,
+        provider_names=[resolved_provider],
+        timeout=timeout,
+    )
 
+    if not updates:
+        return settings
+    return settings.model_copy(update=updates)
+
+
+def apply_solve_runtime_overrides(
+    settings: AppSettings,
+    *,
+    timeout: float | None = None,
+    generation_time_budget_seconds: int | None = None,
+) -> AppSettings:
+    updates: dict[str, Any] = {}
+    _apply_timeout_overrides(
+        updates,
+        provider_names=solve_runtime_provider_names(settings),
+        timeout=timeout,
+    )
+    if generation_time_budget_seconds is not None:
+        updates["generation_time_budget_seconds"] = generation_time_budget_seconds
     if not updates:
         return settings
     return settings.model_copy(update=updates)

--- a/autocontext/src/autocontext/cli_solve.py
+++ b/autocontext/src/autocontext/cli_solve.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import dataclasses
+import importlib
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import typer
+from rich.table import Table
+
+from autocontext.cli_runtime_overrides import (
+    apply_solve_runtime_overrides,
+    format_runtime_provider_error,
+    solve_primary_runtime_provider,
+)
+from autocontext.config.settings import AppSettings
+from autocontext.providers.base import ProviderError
+from autocontext.util.json_io import write_json
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+@dataclass(slots=True)
+class SolveRunSummary:
+    """Result summary for solve-on-demand via the CLI."""
+
+    job_id: str
+    status: str
+    description: str
+    scenario_name: str | None
+    generations: int
+    progress: int
+    output_path: str | None
+    result: dict[str, Any] | None
+
+
+def _cli_attr(dependency_module: str, name: str) -> Any:
+    return getattr(importlib.import_module(dependency_module), name)
+
+
+def run_solve_command(
+    *,
+    description: str,
+    gens: int,
+    timeout: float | None,
+    generation_time_budget: int | None,
+    output: str,
+    json_output: bool,
+    console: Console,
+    load_settings_fn: Callable[[], AppSettings],
+    write_json_stdout: Callable[[object], None],
+    write_json_stderr: Callable[[str], None],
+) -> None:
+    """Create a scenario on demand, run it, and export the solved package."""
+    from autocontext.knowledge.solver import SolveManager
+
+    settings = apply_solve_runtime_overrides(
+        load_settings_fn(),
+        timeout=timeout,
+        generation_time_budget_seconds=generation_time_budget,
+    )
+    manager = SolveManager(settings)
+
+    try:
+        job = manager.solve_sync(description=description, generations=gens)
+    except KeyboardInterrupt:
+        if json_output:
+            write_json_stderr("solve interrupted")
+        else:
+            console.print("[red]Solve interrupted[/red]")
+        raise typer.Exit(code=1) from None
+    except Exception as exc:
+        if json_output:
+            write_json_stderr(str(exc))
+        else:
+            console.print(f"[red]Solve failed:[/red] {exc}")
+        raise typer.Exit(code=1) from None
+
+    if job.status != "completed" or job.result is None:
+        message = job.error or "solve did not complete successfully"
+        if "timeout" in message.lower():
+            message = format_runtime_provider_error(
+                ProviderError(message),
+                provider_name=solve_primary_runtime_provider(settings),
+                settings=settings,
+            )
+        if json_output:
+            write_json_stderr(message)
+        else:
+            console.print(f"[red]Solve failed:[/red] {message}")
+        raise typer.Exit(code=1)
+
+    output_path: str | None = None
+    if output:
+        output_file = Path(output)
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        write_json(output_file, job.result.to_dict())
+        output_path = str(output_file)
+
+    summary = SolveRunSummary(
+        job_id=job.job_id,
+        status=job.status,
+        description=job.description,
+        scenario_name=job.scenario_name,
+        generations=job.generations,
+        progress=job.progress,
+        output_path=output_path,
+        result=job.result.to_dict(),
+    )
+
+    if json_output:
+        write_json_stdout(dataclasses.asdict(summary))
+        return
+
+    table = Table(title="Solve Result")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("Job ID", job.job_id)
+    table.add_row("Status", job.status)
+    table.add_row("Scenario", job.scenario_name or "unknown")
+    table.add_row("Generations", str(job.generations))
+    table.add_row("Progress", str(job.progress))
+    if output_path is not None:
+        table.add_row("Output", output_path)
+    console.print(table)
+
+
+def register_solve_command(
+    app: typer.Typer,
+    *,
+    console: Console,
+    dependency_module: str = "autocontext.cli",
+) -> None:
+    @app.command()
+    def solve(
+        description: str = typer.Option(..., "--description", help="Natural-language scenario/problem description"),
+        gens: int = typer.Option(5, "--gens", min=1, max=50, help="Generations to run for the solve"),
+        timeout: float | None = typer.Option(
+            None,
+            "--timeout",
+            min=1.0,
+            help="Provider timeout override in seconds for solve creation/execution runtimes",
+        ),
+        generation_time_budget: int | None = typer.Option(
+            None,
+            "--generation-time-budget",
+            min=0,
+            help="Soft per-generation time budget in seconds for solve runs (0 = unlimited)",
+        ),
+        output: str = typer.Option("", "--output", help="Optional JSON file path for the solved package"),
+        json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
+    ) -> None:
+        run_solve_command(
+            description=description,
+            gens=gens,
+            timeout=timeout,
+            generation_time_budget=generation_time_budget,
+            output=output,
+            json_output=json_output,
+            console=console,
+            load_settings_fn=_cli_attr(dependency_module, "load_settings"),
+            write_json_stdout=_cli_attr(dependency_module, "_write_json_stdout"),
+            write_json_stderr=_cli_attr(dependency_module, "_write_json_stderr"),
+        )

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -163,6 +163,110 @@ class ArtifactEditingTaskAdapter(AgentTaskInterface):
         return list(edited_by_path.values())
 
 
+@dataclass(slots=True)
+class _SolveGenerationBudget:
+    scenario_name: str
+    budget_seconds: int
+    started_at: float = field(default_factory=lambda: time.monotonic())
+
+    def elapsed_seconds(self) -> float:
+        return max(0.0, time.monotonic() - self.started_at)
+
+    def check(self, phase: str) -> None:
+        if self.budget_seconds <= 0:
+            return
+        elapsed = self.elapsed_seconds()
+        if elapsed >= self.budget_seconds:
+            raise TimeoutError(
+                f"Solve generation time budget exceeded during {phase} "
+                f"after {elapsed:.2f}s for scenario '{self.scenario_name}' "
+                f"(budget {self.budget_seconds}s)"
+            )
+
+
+class _BudgetedAgentTask(AgentTaskInterface):
+    """Add solve generation budget checks around an AgentTaskInterface."""
+
+    def __init__(self, task: AgentTaskInterface, budget: _SolveGenerationBudget) -> None:
+        self._task = task
+        self._budget = budget
+        self.name = getattr(task, "name", task.__class__.__name__)
+
+    def get_task_prompt(self, state: dict) -> str:
+        self._budget.check("task prompt")
+        prompt = self._task.get_task_prompt(state)
+        self._budget.check("task prompt")
+        return prompt
+
+    def evaluate_output(
+        self,
+        output: str,
+        state: dict,
+        reference_context: str | None = None,
+        required_concepts: list[str] | None = None,
+        calibration_examples: list[dict] | None = None,
+        pinned_dimensions: list[str] | None = None,
+    ) -> AgentTaskResult:
+        self._budget.check("evaluation")
+        result = self._task.evaluate_output(
+            output,
+            state,
+            reference_context=reference_context,
+            required_concepts=required_concepts,
+            calibration_examples=calibration_examples,
+            pinned_dimensions=pinned_dimensions,
+        )
+        self._budget.check("evaluation")
+        return result
+
+    def get_rubric(self) -> str:
+        self._budget.check("rubric")
+        rubric = self._task.get_rubric()
+        self._budget.check("rubric")
+        return rubric
+
+    def initial_state(self, seed: int | None = None) -> dict:
+        self._budget.check("initial state")
+        state = self._task.initial_state(seed)
+        self._budget.check("initial state")
+        return state
+
+    def describe_task(self) -> str:
+        self._budget.check("task description")
+        description = self._task.describe_task()
+        self._budget.check("task description")
+        return description
+
+    def prepare_context(self, state: dict) -> dict:
+        self._budget.check("context preparation")
+        prepared = self._task.prepare_context(state)
+        self._budget.check("context preparation")
+        return prepared
+
+    def validate_context(self, state: dict) -> list[str]:
+        self._budget.check("context validation")
+        errors = self._task.validate_context(state)
+        self._budget.check("context validation")
+        return errors
+
+    def revise_output(
+        self,
+        output: str,
+        judge_result: AgentTaskResult,
+        state: dict,
+    ) -> str:
+        self._budget.check("revision")
+        revised = self._task.revise_output(output, judge_result, state)
+        self._budget.check("revision")
+        return revised
+
+    def verify_facts(self, output: str, state: dict) -> dict | None:
+        self._budget.check("fact verification")
+        result = self._task.verify_facts(output, state)
+        self._budget.check("fact verification")
+        return result
+
+
 def _resolve_family_hint(description: str) -> ScenarioFamily | None:
     from autocontext.scenarios.families import get_family, list_families
 
@@ -261,24 +365,6 @@ class SolveScenarioExecutor:
     ) -> SolveExecutionSummary:
         sqlite = SQLiteStore(self._settings.db_path)
         sqlite.migrate(self._migrations_dir)
-        provider, provider_model = resolve_role_runtime(
-            self._settings,
-            role="competitor",
-            scenario_name=scenario_name,
-            sqlite=sqlite,
-        )
-        state = task.prepare_context(task.initial_state())
-        context_errors = task.validate_context(state)
-        if context_errors:
-            raise ValueError(f"Context validation failed: {'; '.join(context_errors)}")
-        prompt = task.get_task_prompt(state)
-        initial_output = provider.complete(
-            system_prompt="Complete the task precisely.",
-            user_prompt=prompt,
-            model=provider_model,
-        ).text
-
-        loop = ImprovementLoop(task=task, max_rounds=max_rounds)
         active_run_id = f"solve_{scenario_name}_{uuid.uuid4().hex[:8]}"
         sqlite.create_run(
             active_run_id,
@@ -298,10 +384,36 @@ class SolveScenarioExecutor:
             gate_decision="running",
             status="running",
         )
-        sqlite.append_agent_output(active_run_id, 1, "competitor_initial", initial_output)
+        budget = _SolveGenerationBudget(
+            scenario_name=scenario_name,
+            budget_seconds=self._settings.generation_time_budget_seconds,
+        )
 
         try:
+            provider, provider_model = resolve_role_runtime(
+                self._settings,
+                role="competitor",
+                scenario_name=scenario_name,
+                sqlite=sqlite,
+            )
+            budget.check("runtime resolution")
+            budgeted_task = _BudgetedAgentTask(task, budget)
+            state = budgeted_task.prepare_context(budgeted_task.initial_state())
+            context_errors = budgeted_task.validate_context(state)
+            if context_errors:
+                raise ValueError(f"Context validation failed: {'; '.join(context_errors)}")
+            prompt = budgeted_task.get_task_prompt(state)
+            initial_output = provider.complete(
+                system_prompt="Complete the task precisely.",
+                user_prompt=prompt,
+                model=provider_model,
+            ).text
+            budget.check("initial generation")
+            sqlite.append_agent_output(active_run_id, 1, "competitor_initial", initial_output)
+
+            loop = ImprovementLoop(task=budgeted_task, max_rounds=max_rounds)
             result = loop.run(initial_output=initial_output, state=state)
+            budget.check("improvement loop")
         except Exception:
             sqlite.upsert_generation(
                 active_run_id,
@@ -313,6 +425,7 @@ class SolveScenarioExecutor:
                 losses=0,
                 gate_decision="failed",
                 status="failed",
+                duration_seconds=budget.elapsed_seconds(),
             )
             sqlite.mark_run_failed(active_run_id)
             raise

--- a/autocontext/tests/test_cli_solve_runtime.py
+++ b/autocontext/tests/test_cli_solve_runtime.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+from autocontext.config.settings import AppSettings
+from autocontext.knowledge.export import SkillPackage
+from autocontext.knowledge.solver import SolveJob
+
+runner = CliRunner()
+
+
+class _CapturingSolveManager:
+    last_settings: AppSettings | None = None
+
+    def __init__(self, settings: AppSettings) -> None:
+        type(self).last_settings = settings
+
+    def solve_sync(self, description: str, generations: int = 5) -> SolveJob:
+        del description, generations
+        pkg = SkillPackage(
+            scenario_name="grid_ctf",
+            display_name="Grid Ctf",
+            description="Solve result",
+            playbook="## Playbook",
+            lessons=["Scout lanes"],
+            best_strategy={"aggression": 0.6},
+            best_score=0.81,
+            best_elo=1512.0,
+            hints="Protect home base",
+        )
+        return SolveJob(
+            job_id="solve_1234",
+            description="Design a strategy",
+            scenario_name="grid_ctf",
+            status="completed",
+            generations=1,
+            progress=1,
+            result=pkg,
+        )
+
+
+class _FailingSolveManager:
+    def __init__(self, settings: AppSettings) -> None:
+        self._settings = settings
+
+    def solve_sync(self, description: str, generations: int = 5) -> SolveJob:
+        del description, generations
+        return SolveJob(
+            job_id="solve_fail",
+            description="Broken solve",
+            status="failed",
+            generations=1,
+            progress=0,
+            error="PiCLIRuntime failed: timeout",
+        )
+
+
+def _settings(tmp_path: Path, **overrides: object) -> AppSettings:
+    return AppSettings(
+        db_path=tmp_path / "runs" / "autocontext.sqlite3",
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / ".claude" / "skills",
+        agent_provider=str(overrides.get("agent_provider", "pi")),
+        architect_provider=str(overrides.get("architect_provider", "")),
+        analyst_provider=str(overrides.get("analyst_provider", "")),
+        competitor_provider=str(overrides.get("competitor_provider", "")),
+        pi_timeout=float(overrides.get("pi_timeout", 300.0)),
+        generation_time_budget_seconds=int(overrides.get("generation_time_budget_seconds", 0)),
+    )
+
+
+class TestSolveRuntimeOverrides:
+    def test_solve_timeout_override_updates_runtime_settings(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+
+        from unittest.mock import patch
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.knowledge.solver.SolveManager", _CapturingSolveManager),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "solve",
+                    "--description",
+                    "Design a strategy",
+                    "--timeout",
+                    "600",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert _CapturingSolveManager.last_settings is not None
+        assert _CapturingSolveManager.last_settings.pi_timeout == 600.0
+
+    def test_solve_generation_time_budget_override_updates_settings(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+
+        from unittest.mock import patch
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.knowledge.solver.SolveManager", _CapturingSolveManager),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "solve",
+                    "--description",
+                    "Design a strategy",
+                    "--generation-time-budget",
+                    "120",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert _CapturingSolveManager.last_settings is not None
+        assert _CapturingSolveManager.last_settings.generation_time_budget_seconds == 120
+
+    def test_solve_timeout_error_mentions_timeout_override(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path, pi_timeout=600.0)
+
+        from unittest.mock import patch
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.knowledge.solver.SolveManager", _FailingSolveManager),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "solve",
+                    "--description",
+                    "Broken solve",
+                    "--timeout",
+                    "600",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stderr)
+        assert "timed out" in payload["error"].lower()
+        assert "--timeout" in payload["error"]
+        assert "AUTOCONTEXT_PI_TIMEOUT" in payload["error"]

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -143,6 +143,36 @@ class _SolveArtifactEditing(ArtifactEditingInterface):
         )
 
 
+class _BudgetExhaustingAgentTask(AgentTaskInterface):
+    name = "solve_budget_exhausting_fixture"
+
+    def __init__(self, clock: dict[str, float]) -> None:
+        self._clock = clock
+
+    def get_task_prompt(self, state: dict) -> str:
+        del state
+        return "Reply with exactly: improved draft"
+
+    def evaluate_output(self, output: str, state: dict, **kwargs: object) -> AgentTaskResult:
+        del output, state, kwargs
+        self._clock["now"] = 2.0
+        return AgentTaskResult(
+            score=1.0,
+            reasoning="budget should expire after evaluation",
+            dimension_scores={"quality": 1.0},
+        )
+
+    def get_rubric(self) -> str:
+        return "Score exact_match 0-1."
+
+    def initial_state(self, seed: int | None = None) -> dict:
+        del seed
+        return {}
+
+    def describe_task(self) -> str:
+        return "Return the expected draft text."
+
+
 class TestSolveScenarioBuilder:
     def test_routes_operator_loop_descriptions_to_operator_loop_creator(self, tmp_path: Path) -> None:
         from autocontext.knowledge.solver import SolveScenarioBuilder
@@ -357,6 +387,47 @@ class TestSolveScenarioExecutor:
         assert summary.generations_executed == 1
         assert summary.best_score == 1.0
         assert sqlite.count_completed_runs(scenario_name) == 1
+
+    def test_task_like_executor_marks_run_failed_when_budget_expires(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solver import SolveScenarioExecutor
+
+        clock = {"now": 0.0}
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+            generation_time_budget_seconds=1,
+        )
+        scenario_name = "solve_budget_exhausting_execution"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        SCENARIO_REGISTRY[scenario_name] = lambda: _BudgetExhaustingAgentTask(clock)
+        monkeypatch.setattr("autocontext.knowledge.solver.time.monotonic", lambda: clock["now"])
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.resolve_role_runtime",
+            lambda settings, **kwargs: (_StubProvider("improved draft"), "test-model"),
+        )
+
+        try:
+            executor = SolveScenarioExecutor(settings)
+            with pytest.raises(TimeoutError, match="time budget exceeded"):
+                executor.execute(
+                    scenario_name=scenario_name,
+                    family_name="agent_task",
+                    generations=1,
+                )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        sqlite = SQLiteStore(settings.db_path)
+        sqlite.migrate(Path(__file__).resolve().parents[1] / "migrations")
+
+        assert sqlite.count_completed_runs(scenario_name) == 0
 
 
 class TestSolveManager:


### PR DESCRIPTION
## Summary

- add `--timeout` to `autoctx solve` so richer live solve prompts can override provider runtime limits just like other Python CLI surfaces
- add `--generation-time-budget` to `autoctx solve` so long-running solve generations can be capped without relying only on environment variables
- route solve settings through a new `apply_solve_runtime_overrides(...)` helper that reuses the shared runtime-timeout field mapping while covering solve-relevant role providers
- format solve timeout failures with operator-facing guidance that points to `--timeout` and provider env vars such as `AUTOCONTEXT_PI_TIMEOUT`
- document the new solve controls in both READMEs and the agent integration guide
- add focused CLI regression coverage for solve timeout and generation-budget overrides

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [x] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/cli.py src/autocontext/cli_runtime_overrides.py tests/test_cli_solve_runtime.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_cli_solve_runtime.py -x --tb=short`
- [x] `cd autocontext && uv run pytest tests/test_cli_solve_runtime.py tests/test_cli_json.py tests/test_knowledge_solver.py tests/test_time_budget.py -k 'solve or budget or timeout' -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

### Manual verification

- live representative AC-562 prompt that previously timed out at 300s now completes with `--timeout 600`:
  - `/tmp/ac562-live-ac383-Z9pw6P/result.json`
- live solve timeout failures now surface actionable guidance with `--timeout` / `AUTOCONTEXT_PI_TIMEOUT` instead of a bare runtime error:
  - `/tmp/ac562-live-timeout-msg-sJpuAP/stderr.log`
- live solve accepts `--generation-time-budget` together with `--timeout` on a stateful solve flow:
  - `/tmp/ac562-live-sim-budget-rtCGlO/result.json`

## Docs And Release Impact

- [ ] no user-facing docs changes needed
- [x] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this addresses the AC-562 operator-control gap by exposing solve-local timeout and per-generation budget controls; it does not attempt to fix unrelated scenario-creation or validation failures that may still surface once a longer timeout lets execution progress further
- one live AC-272 rerun with the new flags advanced past the original timeout but surfaced a different execution-validation failure instead of the old timeout path:
  - `/tmp/ac562-live-ac272-o8Wd8I/stderr.log`
