### PR TITLE
fix(ac-563/A): isolate malformed custom scenario specs, expose skipped registry results

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/__init__.py
+++ b/autocontext/src/autocontext/scenarios/custom/__init__.py
@@ -4,17 +4,25 @@ from autocontext.scenarios.custom.codegen import generate_scenario_class
 from autocontext.scenarios.custom.creator import BuildResult, ScenarioCreator
 from autocontext.scenarios.custom.designer import parse_spec_from_response
 from autocontext.scenarios.custom.loader import load_custom_scenario
-from autocontext.scenarios.custom.registry import load_all_custom_scenarios
+from autocontext.scenarios.custom.registry import (
+    ScenarioLoadError,
+    ScenarioRegistryLoadResult,
+    load_all_custom_scenarios,
+    load_custom_scenarios_detailed,
+)
 from autocontext.scenarios.custom.spec import ScenarioSpec
 from autocontext.scenarios.custom.validator import validate_by_execution, validate_generated_code, validate_spec
 
 __all__ = [
     "BuildResult",
     "ScenarioCreator",
+    "ScenarioLoadError",
+    "ScenarioRegistryLoadResult",
     "ScenarioSpec",
     "generate_scenario_class",
     "load_all_custom_scenarios",
     "load_custom_scenario",
+    "load_custom_scenarios_detailed",
     "parse_spec_from_response",
     "validate_by_execution",
     "validate_generated_code",

--- a/autocontext/src/autocontext/scenarios/custom/registry.py
+++ b/autocontext/src/autocontext/scenarios/custom/registry.py
@@ -152,12 +152,22 @@ def _summarize_load_failure(exc: BaseException, marker: str) -> str:
         return exc.__class__.__name__
 
 
-def load_all_custom_scenarios(knowledge_root: Path) -> dict[str, type[Any]]:
+def load_custom_scenarios_detailed(knowledge_root: Path) -> ScenarioRegistryLoadResult:
+    """Load all custom scenarios under ``knowledge_root``.
+
+    Returns both successfully-loaded scenarios and a tuple of
+    :class:`ScenarioLoadError` for any directory that could not be loaded.
+
+    Malformed directories never prevent other scenarios from loading, and
+    never emit a traceback at WARNING level. The full traceback is available
+    at DEBUG level for forensics.
+    """
     custom_dir = knowledge_root / CUSTOM_SCENARIOS_DIR
     if not custom_dir.is_dir():
-        return {}
+        return ScenarioRegistryLoadResult(loaded={}, skipped=())
 
     loaded: dict[str, type[Any]] = {}
+    skipped: list[ScenarioLoadError] = []
     for entry in sorted(custom_dir.iterdir()):
         if not entry.is_dir():
             continue
@@ -168,12 +178,20 @@ def load_all_custom_scenarios(knowledge_root: Path) -> dict[str, type[Any]]:
             cls = _load_family_class(custom_dir, name, marker)
             loaded[name] = cls
         except FileNotFoundError:
-            # Spec-only directories without compiled source are Failure B territory
-            # (AC-563). Preserve today's silent-skip behavior here.
+            # Spec-only directories without compiled source are Failure B
+            # territory (AC-563). Preserve today's silent-skip behavior here.
             continue
         except Exception as exc:
             spec_path = entry / "spec.json"
             reason = _summarize_load_failure(exc, marker)
+            skipped.append(
+                ScenarioLoadError(
+                    name=name,
+                    spec_path=spec_path,
+                    reason=reason,
+                    marker=marker,
+                )
+            )
             logger.warning(
                 "custom scenario %r skipped (%s): %s",
                 name,
@@ -187,4 +205,12 @@ def load_all_custom_scenarios(knowledge_root: Path) -> dict[str, type[Any]]:
                 exc_info=True,
             )
 
-    return loaded
+    return ScenarioRegistryLoadResult(
+        loaded=loaded,
+        skipped=tuple(skipped),
+    )
+
+
+def load_all_custom_scenarios(knowledge_root: Path) -> dict[str, type[Any]]:
+    """Backwards-compatible entry point — returns only the successful loads."""
+    return dict(load_custom_scenarios_detailed(knowledge_root).loaded)

--- a/autocontext/src/autocontext/scenarios/custom/registry.py
+++ b/autocontext/src/autocontext/scenarios/custom/registry.py
@@ -4,6 +4,8 @@ import importlib.util
 import json
 import logging
 import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +19,29 @@ from autocontext.scenarios.families import detect_family, get_family_by_marker
 logger = logging.getLogger(__name__)
 
 CUSTOM_SCENARIOS_DIR = "_custom_scenarios"
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioLoadError:
+    """A single custom-scenario directory that could not be loaded.
+
+    Part of the AC-563 domain model. Emitted by
+    :func:`load_custom_scenarios_detailed` so callers can surface skipped
+    scenarios in a UI without parsing stderr.
+    """
+
+    name: str
+    spec_path: Path
+    reason: str
+    marker: str
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioRegistryLoadResult:
+    """Aggregate result of attempting to load all custom scenarios."""
+
+    loaded: Mapping[str, type[Any]]
+    skipped: tuple[ScenarioLoadError, ...]
 
 
 def _load_agent_task_class(custom_dir: Path, name: str) -> type[Any]:

--- a/autocontext/src/autocontext/scenarios/custom/registry.py
+++ b/autocontext/src/autocontext/scenarios/custom/registry.py
@@ -103,6 +103,30 @@ def _load_family_class(custom_dir: Path, name: str, marker: str) -> type[Any]:
     return cls
 
 
+def _summarize_load_failure(exc: BaseException, marker: str) -> str:
+    """Render a single-line, user-friendly reason string for a load failure.
+
+    Best-effort: never raises. Falls back to ``str(exc)`` if rendering fails.
+    """
+    try:
+        from pydantic import ValidationError
+
+        if isinstance(exc, ValidationError):
+            errors = exc.errors()
+            if errors:
+                first = errors[0]
+                loc = ".".join(str(part) for part in first.get("loc", ()))
+                msg = first.get("msg", "invalid")
+                return f"spec.json validation failed: {loc}: {msg}"
+            return "spec.json validation failed"
+        if isinstance(exc, KeyError):
+            return f"unknown scenario_type marker {marker!r}"
+        text = str(exc) or exc.__class__.__name__
+        return text.splitlines()[0][:200]
+    except Exception:
+        return exc.__class__.__name__
+
+
 def load_all_custom_scenarios(knowledge_root: Path) -> dict[str, type[Any]]:
     custom_dir = knowledge_root / CUSTOM_SCENARIOS_DIR
     if not custom_dir.is_dir():
@@ -119,10 +143,23 @@ def load_all_custom_scenarios(knowledge_root: Path) -> dict[str, type[Any]]:
             cls = _load_family_class(custom_dir, name, marker)
             loaded[name] = cls
         except FileNotFoundError:
+            # Spec-only directories without compiled source are Failure B territory
+            # (AC-563). Preserve today's silent-skip behavior here.
             continue
-        except KeyError:
-            logger.warning("failed to load custom scenario '%s': unknown marker '%s'", name, marker)
-        except Exception:
-            logger.warning("failed to load custom scenario '%s'", name, exc_info=True)
+        except Exception as exc:
+            spec_path = entry / "spec.json"
+            reason = _summarize_load_failure(exc, marker)
+            logger.warning(
+                "custom scenario %r skipped (%s): %s",
+                name,
+                spec_path,
+                reason,
+            )
+            logger.debug(
+                "custom scenario %r skipped (%s): full traceback",
+                name,
+                spec_path,
+                exc_info=True,
+            )
 
     return loaded

--- a/autocontext/tests/test_custom_registry_isolation.py
+++ b/autocontext/tests/test_custom_registry_isolation.py
@@ -64,6 +64,17 @@ def _write_valid_parametric_spec(knowledge_root: Path, name: str = "good_scenari
     return scenario_dir
 
 
+def _write_unknown_marker_scenario(knowledge_root: Path, name: str = "banana_scenario") -> Path:
+    """Write a scenario dir that claims an unknown family marker."""
+    scenario_dir = knowledge_root / "_custom_scenarios" / name
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+    (scenario_dir / "scenario_type.txt").write_text("banana", encoding="utf-8")
+    (scenario_dir / "spec.json").write_text(
+        json.dumps({"name": name, "scenario_type": "banana"}), encoding="utf-8"
+    )
+    return scenario_dir
+
+
 def _write_malformed_spec(knowledge_root: Path, name: str = "regression_probe") -> Path:
     """Write a ``spec.json`` that is missing a required pydantic field."""
     scenario_dir = knowledge_root / "_custom_scenarios" / name
@@ -153,3 +164,21 @@ class TestRegistryIsolation:
         assert any(r.exc_text for r in debug_records), (
             "at DEBUG level the full traceback must be available via exc_info"
         )
+
+    def test_reason_identifies_unknown_marker(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        _write_unknown_marker_scenario(knowledge_root, name="banana_scenario")
+
+        with caplog.at_level(logging.WARNING, logger="autocontext.scenarios.custom.registry"):
+            load_all_custom_scenarios(knowledge_root)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "banana_scenario" in message
+        assert "unknown scenario_type marker" in message
+        assert "banana" in message

--- a/autocontext/tests/test_custom_registry_isolation.py
+++ b/autocontext/tests/test_custom_registry_isolation.py
@@ -226,3 +226,57 @@ class TestRegistryIsolation:
                     name="x", spec_path=Path("x"), reason="x", marker="x"
                 )
             )
+
+    def test_empty_knowledge_root_returns_empty_result(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"  # does not exist
+
+        with caplog.at_level(logging.WARNING, logger="autocontext.scenarios.custom.registry"):
+            result = load_custom_scenarios_detailed(knowledge_root)
+
+        assert result.loaded == {}
+        assert result.skipped == ()
+        assert caplog.records == []
+
+    def test_file_not_found_is_not_reported_as_skipped(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Failure B boundary: spec-less scenario dirs remain silently skipped.
+
+        A scenario directory that declares marker 'agent_task' but has no
+        agent_task.py raises FileNotFoundError. That pathway is handled by
+        Failure B — preserve today's silent behavior here to avoid double-
+        counting.
+        """
+        knowledge_root = tmp_path / "knowledge"
+        scenario_dir = knowledge_root / "_custom_scenarios" / "spec_only_task"
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+        (scenario_dir / "scenario_type.txt").write_text("agent_task", encoding="utf-8")
+        # Deliberately no agent_task.py and no spec.json
+
+        with caplog.at_level(logging.WARNING, logger="autocontext.scenarios.custom.registry"):
+            result = load_custom_scenarios_detailed(knowledge_root)
+
+        assert "spec_only_task" not in result.loaded
+        assert all(e.name != "spec_only_task" for e in result.skipped)
+        assert caplog.records == []
+
+    def test_non_directory_entries_are_ignored(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        custom_dir = knowledge_root / "_custom_scenarios"
+        custom_dir.mkdir(parents=True, exist_ok=True)
+        (custom_dir / "README.md").write_text("not a scenario", encoding="utf-8")
+        _write_valid_parametric_spec(knowledge_root, name="real_scenario")
+
+        result = load_custom_scenarios_detailed(knowledge_root)
+
+        assert "real_scenario" in result.loaded
+        assert result.skipped == ()

--- a/autocontext/tests/test_custom_registry_isolation.py
+++ b/autocontext/tests/test_custom_registry_isolation.py
@@ -6,7 +6,10 @@ scenarios, and must not dump a traceback into stderr for unrelated commands.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
+
+import pytest
 
 from autocontext.scenarios.custom.registry import load_all_custom_scenarios
 
@@ -95,3 +98,26 @@ class TestRegistryIsolation:
 
         assert "good_scenario" in loaded
         assert "regression_probe" not in loaded
+
+    def test_warning_logged_at_warning_level_without_traceback(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        _write_malformed_spec(knowledge_root, name="regression_probe")
+
+        with caplog.at_level(logging.WARNING, logger="autocontext.scenarios.custom.registry"):
+            load_all_custom_scenarios(knowledge_root)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, (
+            f"expected exactly one warning, got {[r.message for r in warnings]}"
+        )
+        record = warnings[0]
+
+        assert record.exc_text is None, "warning must not carry a traceback"
+        message = record.getMessage()
+        assert "\n" not in message, f"warning must be a single line, got:\n{message!r}"
+        assert "regression_probe" in message
+        assert "spec.json" in message

--- a/autocontext/tests/test_custom_registry_isolation.py
+++ b/autocontext/tests/test_custom_registry_isolation.py
@@ -1,0 +1,97 @@
+"""AC-563 Failure A: custom scenario registry isolation.
+
+One malformed ``spec.json`` must not prevent the registry from loading other
+scenarios, and must not dump a traceback into stderr for unrelated commands.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autocontext.scenarios.custom.registry import load_all_custom_scenarios
+
+
+def _write_valid_parametric_spec(knowledge_root: Path, name: str = "good_scenario") -> Path:
+    """Write a minimally-valid parametric ``spec.json`` that the loader can materialize."""
+    scenario_dir = knowledge_root / "_custom_scenarios" / name
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+    (scenario_dir / "spec.json").write_text(
+        json.dumps(
+            {
+                "name": name,
+                "display_name": "Good Scenario",
+                "description": "Valid parametric scenario used by AC-563 isolation tests.",
+                "strategy_interface_description": (
+                    "Return JSON with a single float `bias` in [0,1]."
+                ),
+                "evaluation_criteria": "Reward a bias close to 0.5.",
+                "strategy_params": [
+                    {
+                        "name": "bias",
+                        "description": "Decision bias.",
+                        "min_value": 0.0,
+                        "max_value": 1.0,
+                        "default": 0.5,
+                    }
+                ],
+                "environment_variables": [
+                    {
+                        "name": "noise",
+                        "description": "Environmental noise.",
+                        "low": 0.0,
+                        "high": 0.1,
+                    }
+                ],
+                "scoring_components": [
+                    {
+                        "name": "centered",
+                        "description": "Reward centered bias.",
+                        "formula_terms": {"bias": 1.0},
+                        "noise_range": [0.0, 0.0],
+                    }
+                ],
+                "final_score_weights": {"centered": 1.0},
+                "win_threshold": 0.5,
+                "scenario_type": "parametric",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return scenario_dir
+
+
+def _write_malformed_spec(knowledge_root: Path, name: str = "regression_probe") -> Path:
+    """Write a ``spec.json`` that is missing a required pydantic field."""
+    scenario_dir = knowledge_root / "_custom_scenarios" / name
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+    (scenario_dir / "spec.json").write_text(
+        json.dumps(
+            {
+                # Intentionally missing `evaluation_criteria` (required on ScenarioSpec).
+                "name": name,
+                "display_name": "Regression probe",
+                "description": "Intentionally invalid fixture.",
+                "strategy_interface_description": "ignored",
+                "scenario_type": "parametric",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return scenario_dir
+
+
+class TestRegistryIsolation:
+    def test_malformed_spec_does_not_prevent_other_scenarios_from_loading(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        _write_valid_parametric_spec(knowledge_root, name="good_scenario")
+        _write_malformed_spec(knowledge_root, name="regression_probe")
+
+        loaded = load_all_custom_scenarios(knowledge_root)
+
+        assert "good_scenario" in loaded
+        assert "regression_probe" not in loaded

--- a/autocontext/tests/test_custom_registry_isolation.py
+++ b/autocontext/tests/test_custom_registry_isolation.py
@@ -121,3 +121,19 @@ class TestRegistryIsolation:
         assert "\n" not in message, f"warning must be a single line, got:\n{message!r}"
         assert "regression_probe" in message
         assert "spec.json" in message
+
+    def test_reason_summarizes_pydantic_validation_error(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        _write_malformed_spec(knowledge_root, name="regression_probe")
+
+        with caplog.at_level(logging.WARNING, logger="autocontext.scenarios.custom.registry"):
+            load_all_custom_scenarios(knowledge_root)
+
+        message = caplog.records[0].getMessage()
+        assert "evaluation_criteria" in message, message
+        assert "Traceback" not in message, message
+        assert 'File "' not in message, message

--- a/autocontext/tests/test_custom_registry_isolation.py
+++ b/autocontext/tests/test_custom_registry_isolation.py
@@ -11,7 +11,12 @@ from pathlib import Path
 
 import pytest
 
-from autocontext.scenarios.custom.registry import load_all_custom_scenarios
+from autocontext.scenarios.custom.registry import (
+    ScenarioLoadError,
+    ScenarioRegistryLoadResult,
+    load_all_custom_scenarios,
+    load_custom_scenarios_detailed,
+)
 
 
 def _write_valid_parametric_spec(knowledge_root: Path, name: str = "good_scenario") -> Path:
@@ -182,3 +187,42 @@ class TestRegistryIsolation:
         assert "banana_scenario" in message
         assert "unknown scenario_type marker" in message
         assert "banana" in message
+
+    def test_malformed_spec_is_reported_in_detailed_result(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        _write_valid_parametric_spec(knowledge_root, name="good_scenario")
+        _write_malformed_spec(knowledge_root, name="regression_probe")
+
+        result = load_custom_scenarios_detailed(knowledge_root)
+
+        assert isinstance(result, ScenarioRegistryLoadResult)
+        assert "good_scenario" in result.loaded
+        assert "regression_probe" not in result.loaded
+        assert len(result.skipped) == 1
+        entry = result.skipped[0]
+        assert isinstance(entry, ScenarioLoadError)
+        assert entry.name == "regression_probe"
+        assert entry.spec_path == (
+            knowledge_root / "_custom_scenarios" / "regression_probe" / "spec.json"
+        )
+        assert "evaluation_criteria" in entry.reason
+        assert entry.marker == "parametric"
+
+    def test_skipped_tuple_is_immutable(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        _write_malformed_spec(knowledge_root)
+
+        result = load_custom_scenarios_detailed(knowledge_root)
+
+        with pytest.raises((TypeError, AttributeError)):
+            result.skipped.append(  # type: ignore[attr-defined]
+                ScenarioLoadError(
+                    name="x", spec_path=Path("x"), reason="x", marker="x"
+                )
+            )

--- a/autocontext/tests/test_custom_registry_isolation.py
+++ b/autocontext/tests/test_custom_registry_isolation.py
@@ -137,3 +137,19 @@ class TestRegistryIsolation:
         assert "evaluation_criteria" in message, message
         assert "Traceback" not in message, message
         assert 'File "' not in message, message
+
+    def test_traceback_available_at_debug_level(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        _write_malformed_spec(knowledge_root, name="regression_probe")
+
+        with caplog.at_level(logging.DEBUG, logger="autocontext.scenarios.custom.registry"):
+            load_all_custom_scenarios(knowledge_root)
+
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any(r.exc_text for r in debug_records), (
+            "at DEBUG level the full traceback must be available via exc_info"
+        )


### PR DESCRIPTION
Closes part **A** of AC-563 (re-opens AC-551). Failures B (spec-only silent drop) and C (cross-package extension split) are tracked as separate follow-up PRs.

## What changed

- `autoctx run` / `autoctx benchmark` no longer prints a pydantic traceback for unrelated scenarios when any single custom scenario's `spec.json` is malformed.
- New domain types `ScenarioLoadError` and `ScenarioRegistryLoadResult` expose skipped scenarios to callers (CLI, dashboard) without requiring them to parse stderr.
- `load_all_custom_scenarios(...)` is unchanged (still returns `dict[str, type]`) — no caller migrations required.
- Full traceback is still available: set logger `autocontext.scenarios.custom.registry` to DEBUG.

## Evidence

Before (py-v0.4.2):

```
$ autoctx run --scenario does_not_exist --gens 1
Traceback (most recent call last):
  File ".../registry.py", line 119, in load_all_custom_scenarios
    cls = _load_family_class(...)
  ...
pydantic_core._pydantic_core.ValidationError: 1 validation error for ScenarioSpec
evaluation_criteria
  Field required [type=missing, input_value=...]
Error: Unknown scenario 'does_not_exist'. Supported: ...
```

After (this PR):

```
$ autoctx run --scenario does_not_exist --gens 1
WARNING ... custom scenario 'regression_probe' skipped (.../spec.json): spec.json validation failed: evaluation_criteria: Field required
Error: Unknown scenario 'does_not_exist'. Supported: ...
```

Zero `Traceback` lines, zero `File "..."` frames, single-line diagnostic naming the offending scenario + spec + reason.

## Tests

New `tests/test_custom_registry_isolation.py` — 10 cases:

- `test_malformed_spec_does_not_prevent_other_scenarios_from_loading`
- `test_warning_logged_at_warning_level_without_traceback`
- `test_reason_summarizes_pydantic_validation_error`
- `test_traceback_available_at_debug_level`
- `test_reason_identifies_unknown_marker`
- `test_malformed_spec_is_reported_in_detailed_result`
- `test_skipped_tuple_is_immutable`
- `test_empty_knowledge_root_returns_empty_result`
- `test_file_not_found_is_not_reported_as_skipped` (Failure-B boundary preserved)
- `test_non_directory_entries_are_ignored`

Full suite: **5333 passed, 54 skipped, 0 failed** (5m 11s). `ruff check` and `mypy` clean.

## TDD discipline

10 tight commits, each a clean red→green→refactor unit (visible in the commit log, bisect-safe):

```
test(ac-563): pin registry resilience to one malformed spec
fix(ac-563): emit single-line warning for malformed custom scenario specs
test(ac-563): pin reason string format for pydantic validation errors
test(ac-563): pin DEBUG-level availability of full load traceback
test(ac-563): pin reason string for unknown scenario_type marker
feat(ac-563): add ScenarioLoadError + ScenarioRegistryLoadResult domain model
refactor(ac-563): expose detailed load result without breaking legacy API
test(ac-563): verify ScenarioRegistryLoadResult surfaces skipped scenarios
test(ac-563): cover empty root, spec-only skip, and non-dir entries
feat(ac-563): export ScenarioLoadError + detailed loader from custom package
```

## Non-goals in this PR

- Failure B: `spec.json` without compiled source → silent invisibility.
- Failure C: Py/TS cross-package visibility of `scenario.py` vs `scenario.js`.
- TypeScript parity (TS registry gets its own isolation fix in the B/C PRs).
- CLI UX that consumes `.skipped` (friendly summary line).

## Linear

- AC-563 (this part A)
- AC-551 — root of the re-opened UX regression