### PR TITLE
fix: harden ts new-scenario generic family fallback

### DIFF
--- a/ts/src/cli/new-scenario-family-resolution.ts
+++ b/ts/src/cli/new-scenario-family-resolution.ts
@@ -1,9 +1,12 @@
+import {
+  countScenarioFamilySpecificFields,
+  fallbackCodegenFamilyToAgentTask,
+} from "../scenarios/scenario-family-fallback.js";
+
 export function countImportedScenarioFamilySpecificFields(
   specFields: Record<string, unknown>,
 ): number {
-  return Object.keys(specFields).filter(
-    (key) => key !== "taskPrompt" && key !== "rubric" && key !== "description",
-  ).length;
+  return countScenarioFamilySpecificFields(specFields);
 }
 
 export function resolveImportedScenarioFamily(opts: {
@@ -29,13 +32,7 @@ export function resolveImportedScenarioFamily(opts: {
       throw new Error(`Error: family must be one of ${opts.validFamilies.join(", ")}`);
     }
 
-    const familySpecificFieldCount = countImportedScenarioFamilySpecificFields(specFields);
-    family =
-      requestedFamily !== "agent_task" &&
-      requestedFamily !== "game" &&
-      familySpecificFieldCount === 0
-        ? "agent_task"
-        : requestedFamily;
+    family = fallbackCodegenFamilyToAgentTask(requestedFamily, specFields);
   }
 
   return {

--- a/ts/src/scenarios/scenario-creator.ts
+++ b/ts/src/scenarios/scenario-creator.ts
@@ -9,6 +9,7 @@ import type { CoordinationSpec } from "./coordination-spec.js";
 import { classifyScenarioFamily, routeToFamily } from "./family-classifier.js";
 import { SCENARIO_TYPE_MARKERS, type ScenarioFamilyName } from "./families.js";
 import { designInvestigation } from "./investigation-designer.js";
+import { fallbackCodegenFamilyToAgentTask } from "./scenario-family-fallback.js";
 import type { InvestigationSpec } from "./investigation-spec.js";
 import { designNegotiation } from "./negotiation-designer.js";
 import type { NegotiationSpec } from "./negotiation-spec.js";
@@ -403,11 +404,15 @@ async function createGenericScenarioFromDescription(
   if (!spec.rubric) spec.rubric = "Evaluate the quality of the response.";
   if (!spec.description) spec.description = `Custom scenario: ${description}`;
   const name = typeof spec.name === "string" && spec.name.trim() ? spec.name.trim() : defaultName;
-  const family =
+  const resolvedFamily =
     typeof spec.family === "string" && isScenarioFamilyName(spec.family)
       ? spec.family
       : defaultFamily;
   const { name: _ignoredName, family: _ignoredFamily, ...specFields } = spec;
+  const family = fallbackCodegenFamilyToAgentTask(
+    resolvedFamily,
+    specFields as Record<string, unknown>,
+  );
 
   return {
     name,

--- a/ts/src/scenarios/scenario-family-fallback.ts
+++ b/ts/src/scenarios/scenario-family-fallback.ts
@@ -4,6 +4,10 @@ export function countScenarioFamilySpecificFields(specFields: Record<string, unk
   return Object.keys(specFields).filter((key) => !CORE_SCENARIO_FIELDS.has(key)).length;
 }
 
+function familySpecificFieldNames(specFields: Record<string, unknown>): string[] {
+  return Object.keys(specFields).filter((key) => !CORE_SCENARIO_FIELDS.has(key));
+}
+
 export function fallbackCodegenFamilyToAgentTask(
   family: string,
   specFields: Record<string, unknown>,
@@ -12,12 +16,18 @@ export function fallbackCodegenFamilyToAgentTask(
     return family;
   }
 
-  if (countScenarioFamilySpecificFields(specFields) === 0) {
+  const familySpecificFields = familySpecificFieldNames(specFields);
+  if (familySpecificFields.length === 0) {
     return "agent_task";
   }
 
   const actions = specFields.actions;
-  if (Array.isArray(actions) && actions.length === 0) {
+  if (
+    familySpecificFields.length === 1 &&
+    familySpecificFields[0] === "actions" &&
+    Array.isArray(actions) &&
+    actions.length === 0
+  ) {
     return "agent_task";
   }
 

--- a/ts/src/scenarios/scenario-family-fallback.ts
+++ b/ts/src/scenarios/scenario-family-fallback.ts
@@ -1,0 +1,25 @@
+const CORE_SCENARIO_FIELDS = new Set(["taskPrompt", "rubric", "description"]);
+
+export function countScenarioFamilySpecificFields(specFields: Record<string, unknown>): number {
+  return Object.keys(specFields).filter((key) => !CORE_SCENARIO_FIELDS.has(key)).length;
+}
+
+export function fallbackCodegenFamilyToAgentTask(
+  family: string,
+  specFields: Record<string, unknown>,
+): string {
+  if (family === "agent_task" || family === "game") {
+    return family;
+  }
+
+  if (countScenarioFamilySpecificFields(specFields) === 0) {
+    return "agent_task";
+  }
+
+  const actions = specFields.actions;
+  if (Array.isArray(actions) && actions.length === 0) {
+    return "agent_task";
+  }
+
+  return family;
+}

--- a/ts/tests/new-scenario-created-materialization.test.ts
+++ b/ts/tests/new-scenario-created-materialization.test.ts
@@ -1,10 +1,21 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { executeCreatedScenarioMaterialization } from "../src/cli/new-scenario-created-materialization.js";
+import { materializeScenario } from "../src/scenarios/materialize.js";
+import { createScenarioFromDescription } from "../src/scenarios/scenario-creator.js";
 
 describe("new-scenario created materialization", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("routes prepared materialization directly instead of through an extra execution wrapper", () => {
     const cliDir = join(import.meta.dirname, "..", "src", "cli");
     const source = readFileSync(join(cliDir, "new-scenario-created-materialization.ts"), "utf-8");
@@ -58,5 +69,46 @@ describe("new-scenario created materialization", () => {
       },
       knowledgeRoot: "/tmp/knowledge",
     });
+  });
+
+  it("materializes a core-only simulation fallback as an agent_task instead of failing codegen", async () => {
+    const knowledgeRoot = mkdtempSync(join(tmpdir(), "ac559-new-scenario-"));
+    tempDirs.push(knowledgeRoot);
+
+    const provider = {
+      defaultModel: () => "mock-model",
+      complete: vi.fn(async ({ systemPrompt }: { systemPrompt?: string }) => {
+        const bareFallback = {
+          family: "simulation",
+          name: "paperclip_test",
+          taskPrompt: "Write a memo that resists optimizing for the visible metric.",
+          rubric: "Reward usefulness to the real audience over metric gaming.",
+          description: "A core-only fallback payload without simulation actions.",
+        };
+
+        return {
+          text: JSON.stringify(bareFallback),
+          model: "mock-model",
+          usage: { inputTokens: 0, outputTokens: 0 },
+        };
+      }),
+    };
+
+    const created = await createScenarioFromDescription(
+      "Create a paperclip-test simulation where the model can exploit a visible metric instead of serving the real task objective.",
+      provider as never,
+    );
+
+    const materialized = await materializeScenario({
+      name: created.name,
+      family: created.family as never,
+      spec: created.spec,
+      knowledgeRoot,
+    });
+
+    expect(created.family).toBe("agent_task");
+    expect(materialized.persisted).toBe(true);
+    expect(materialized.generatedSource).toBe(false);
+    expect(materialized.errors).toEqual([]);
   });
 });

--- a/ts/tests/new-scenario-family-resolution.test.ts
+++ b/ts/tests/new-scenario-family-resolution.test.ts
@@ -77,6 +77,36 @@ describe("new-scenario family resolution", () => {
       family: "agent_task",
     });
 
+    expect(
+      resolveImportedScenarioFamily({
+        spec: {
+          name: "workflow_with_missing_actions",
+          family: "workflow",
+          taskPrompt: "Run the checkout workflow.",
+          rubric: "Verify compensation and side-effect handling.",
+          description: "A workflow import whose actions need repair.",
+          workflow_steps: [
+            {
+              name: "charge_card",
+              description: "Charge the customer",
+              idempotent: false,
+              reversible: true,
+              compensation: "refund_card",
+            },
+          ],
+          success_criteria: ["Complete the checkout", "Rollback failed charges"],
+          actions: [],
+        },
+        description: "A workflow import whose actions need repair.",
+        taskPrompt: "Run the checkout workflow.",
+        detectScenarioFamily: () => "workflow",
+        isScenarioFamilyName: (value: string) => ["agent_task", "workflow"].includes(value),
+        validFamilies: ["agent_task", "workflow"],
+      }),
+    ).toMatchObject({
+      family: "workflow",
+    });
+
     expect(() =>
       resolveImportedScenarioFamily({
         spec: {

--- a/ts/tests/new-scenario-family-resolution.test.ts
+++ b/ts/tests/new-scenario-family-resolution.test.ts
@@ -57,6 +57,26 @@ describe("new-scenario family resolution", () => {
       family: "workflow",
     });
 
+    expect(
+      resolveImportedScenarioFamily({
+        spec: {
+          name: "simulation_saved_task",
+          family: "simulation",
+          taskPrompt: "Handle the crisis response.",
+          rubric: "Keep the system stable.",
+          description: "A simulation import with no initial actions.",
+          actions: [],
+        },
+        description: "A simulation import with no initial actions.",
+        taskPrompt: "Handle the crisis response.",
+        detectScenarioFamily: () => "simulation",
+        isScenarioFamilyName: (value: string) => ["agent_task", "simulation"].includes(value),
+        validFamilies: ["agent_task", "simulation"],
+      }),
+    ).toMatchObject({
+      family: "agent_task",
+    });
+
     expect(() =>
       resolveImportedScenarioFamily({
         spec: {

--- a/ts/tests/scenario-creator-family-aware.test.ts
+++ b/ts/tests/scenario-creator-family-aware.test.ts
@@ -92,4 +92,46 @@ describe("createScenarioFromDescription family-aware routing", () => {
       max_escalations: 2,
     });
   });
+
+  it("falls back to agent_task when family-aware simulation creation degrades to a core-only generic spec", async () => {
+    const provider = {
+      defaultModel: () => "mock-model",
+      complete: vi.fn(async ({ systemPrompt }: { systemPrompt?: string }) => {
+        if (systemPrompt?.includes("produce a SimulationSpec JSON")) {
+          return {
+            text: JSON.stringify({
+              family: "simulation",
+              name: "geopolitical_crisis_simulation",
+              taskPrompt: "Coordinate the crisis response.",
+              rubric: "Prioritize de-escalation and clear reasoning.",
+              description: "A bare fallback payload without simulation actions.",
+            }),
+            model: "mock-model",
+            usage: { inputTokens: 0, outputTokens: 0 },
+          };
+        }
+
+        return {
+          text: JSON.stringify({
+            family: "simulation",
+            name: "geopolitical_crisis_simulation",
+            taskPrompt: "Coordinate the crisis response.",
+            rubric: "Prioritize de-escalation and clear reasoning.",
+            description: "A bare fallback payload without simulation actions.",
+          }),
+          model: "mock-model",
+          usage: { inputTokens: 0, outputTokens: 0 },
+        };
+      }),
+    };
+
+    const created = await createScenarioFromDescription(
+      "Create a geopolitical crisis simulation where a national security advisor manages an escalating international crisis using diplomatic, economic, military, intelligence, public communication, alliance, UN, and cyber actions under hidden adversary intentions and escalation thresholds.",
+      provider as never,
+    );
+
+    expect(created.family).toBe("agent_task");
+    expect(created.spec.taskPrompt).toBe("Coordinate the crisis response.");
+    expect(created.spec).not.toHaveProperty("actions");
+  });
 });


### PR DESCRIPTION
## Summary

- harden the TypeScript `new-scenario` fallback path so core-only generic specs do not keep simulation/workflow-style families and flow into codegen with no executable action surface
- add a shared scenario-family fallback helper and reuse it from both generic creation and imported-spec normalization to keep the fallback semantics DRY
- fall back to `agent_task` when a non-game codegen family only has core prompt fields, or when it explicitly carries an empty `actions` array
- add regression coverage for family-aware creation fallback, created-scenario materialization, and imported-family resolution
- live-validate representative AC-559 prompts that previously failed with `getAvailableActions must return at least one action for initial state`

## Root cause

The generic fallback path in `createScenarioFromDescription(...)` could preserve a codegen family like `simulation` even when the fallback payload only contained:

- `name`
- `family`
- `taskPrompt`
- `rubric`
- `description`

That meant the CLI tried to materialize a simulation-like family with no meaningful action surface, and codegen validation later failed with:

```text
getAvailableActions must return at least one action for initial state
```

## Fix

- added `ts/src/scenarios/scenario-family-fallback.ts`
  - `countScenarioFamilySpecificFields(...)`
  - `fallbackCodegenFamilyToAgentTask(...)`
- updated `ts/src/scenarios/scenario-creator.ts`
  - generic fallback creation now downgrades bare codegen-family payloads to `agent_task`
- updated `ts/src/cli/new-scenario-family-resolution.ts`
  - imported-spec normalization now reuses the same fallback helper
- added tests that lock the AC-559 behavior in both creation and materialization surfaces

## Verification

- [x] `cd ts && npm test -- scenario-creator-family-aware.test.ts new-scenario-created-materialization.test.ts new-scenario-command-workflow.test.ts new-scenario-normalization-workflow.test.ts new-scenario-family-resolution.test.ts new-scenario-import-workflow.test.ts new-scenario-broader-family-materialization.test.ts new-scenario-materialization-execution.test.ts materialize-codegen-planning.test.ts execution-validator.test.ts`
- [x] `cd ts && npm run lint`
- [x] `cd ts && npm run build`

## Live validation

### AC-383

Previously in the AC-559 bucket this prompt could fail in `new-scenario` with the empty-initial-actions signature.

Now it succeeds and persists as a runnable `agent_task` fallback:

- result: `/tmp/ac559-live-ac383-vwSCNQ/result.json`
- persisted spec: `/tmp/ac559-live-ac383-vwSCNQ/knowledge/_custom_scenarios/paperclip_test/spec.json`

Key result:

- `family: "agent_task"`
- `scenario_type: "agent_task"`
- `persisted: true`

### AC-277

Previously this prompt failed repeatedly in the representative `0.4.2` validation pass.

Now it succeeds and persists as a runnable `agent_task` fallback:

- result: `/tmp/ac559-live-ac277-Sg9GVc/result.json`
- persisted spec: `/tmp/ac559-live-ac277-Sg9GVc/knowledge/_custom_scenarios/adaptive_portfolio_regime_change/spec.json`

Key result:

- `family: "agent_task"`
- `scenario_type: "agent_task"`
- `persisted: true`

## Notes

- this change intentionally prefers a runnable `agent_task` fallback over a broken simulation-like family when the generic fallback payload lacks executable scenario structure
- it does not claim to preserve full family fidelity after a family-aware designer fails; it hardens the CLI so the user gets a usable saved scenario instead of a late codegen validation crash
