### PR TITLE
fix(ac-563/B): report unmaterialized custom scenarios with remediation hint

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/registry.py
+++ b/autocontext/src/autocontext/scenarios/custom/registry.py
@@ -128,6 +128,12 @@ def _load_family_class(custom_dir: Path, name: str, marker: str) -> type[Any]:
     return cls
 
 
+def _expected_compiled_source_path(entry: Path, marker: str) -> Path:
+    if marker == "agent_task":
+        return entry / "agent_task.py"
+    return entry / "scenario.py"
+
+
 def _summarize_load_failure(exc: BaseException, marker: str) -> str:
     """Render a single-line, user-friendly reason string for a load failure.
 
@@ -146,6 +152,10 @@ def _summarize_load_failure(exc: BaseException, marker: str) -> str:
             return "spec.json validation failed"
         if isinstance(exc, KeyError):
             return f"unknown scenario_type marker {marker!r}"
+        if isinstance(exc, FileNotFoundError):
+            missing = getattr(exc, "filename", None)
+            if missing:
+                return f"file not found: {Path(missing).name}"
         text = str(exc) or exc.__class__.__name__
         return text.splitlines()[0][:200]
     except Exception:
@@ -177,9 +187,12 @@ def load_custom_scenarios_detailed(knowledge_root: Path) -> ScenarioRegistryLoad
         try:
             cls = _load_family_class(custom_dir, name, marker)
             loaded[name] = cls
-        except FileNotFoundError:
+        except FileNotFoundError as exc:
             spec_path = entry / "spec.json"
-            if spec_path.exists():
+            expected_source = _expected_compiled_source_path(entry, marker)
+            if not spec_path.exists() and not expected_source.exists():
+                continue
+            if spec_path.exists() and not expected_source.exists():
                 reason = (
                     f"has spec.json but no compiled source for this package"
                     f" — run autoctx new-scenario --from-spec {spec_path} to materialize"
@@ -199,7 +212,27 @@ def load_custom_scenarios_detailed(knowledge_root: Path) -> ScenarioRegistryLoad
                     reason,
                 )
             else:
-                continue
+                reason = _summarize_load_failure(exc, marker)
+                skipped.append(
+                    ScenarioLoadError(
+                        name=name,
+                        spec_path=spec_path,
+                        reason=reason,
+                        marker=marker,
+                    )
+                )
+                logger.warning(
+                    "custom scenario %r skipped (%s): %s",
+                    name,
+                    spec_path,
+                    reason,
+                )
+                logger.debug(
+                    "custom scenario %r skipped (%s): full traceback",
+                    name,
+                    spec_path,
+                    exc_info=True,
+                )
         except Exception as exc:
             spec_path = entry / "spec.json"
             reason = _summarize_load_failure(exc, marker)

--- a/autocontext/src/autocontext/scenarios/custom/registry.py
+++ b/autocontext/src/autocontext/scenarios/custom/registry.py
@@ -178,9 +178,28 @@ def load_custom_scenarios_detailed(knowledge_root: Path) -> ScenarioRegistryLoad
             cls = _load_family_class(custom_dir, name, marker)
             loaded[name] = cls
         except FileNotFoundError:
-            # Spec-only directories without compiled source are Failure B
-            # territory (AC-563). Preserve today's silent-skip behavior here.
-            continue
+            spec_path = entry / "spec.json"
+            if spec_path.exists():
+                reason = (
+                    f"has spec.json but no compiled source for this package"
+                    f" — run autoctx new-scenario --from-spec {spec_path} to materialize"
+                )
+                skipped.append(
+                    ScenarioLoadError(
+                        name=name,
+                        spec_path=spec_path,
+                        reason=reason,
+                        marker=marker,
+                    )
+                )
+                logger.warning(
+                    "custom scenario %r skipped (%s): %s",
+                    name,
+                    spec_path,
+                    reason,
+                )
+            else:
+                continue
         except Exception as exc:
             spec_path = entry / "spec.json"
             reason = _summarize_load_failure(exc, marker)

--- a/autocontext/tests/test_custom_registry_isolation.py
+++ b/autocontext/tests/test_custom_registry_isolation.py
@@ -318,3 +318,39 @@ class TestRegistryIsolation:
         assert entry.name == "spec_only_task"
         assert "spec.json" in entry.reason
         assert "no compiled source" in entry.reason
+
+    def test_spec_only_dir_emits_warning(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        _write_spec_only_agent_task(knowledge_root, name="spec_only_task")
+
+        with caplog.at_level(logging.WARNING, logger="autocontext.scenarios.custom.registry"):
+            load_custom_scenarios_detailed(knowledge_root)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "spec_only_task" in message
+        assert "spec.json" in message
+        assert "no compiled source" in message
+        assert "new-scenario --from-spec" in message
+        assert "\n" not in message
+
+    def test_truly_empty_dir_remains_silent(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        empty_dir = knowledge_root / "_custom_scenarios" / "empty_scenario"
+        empty_dir.mkdir(parents=True, exist_ok=True)
+
+        with caplog.at_level(logging.WARNING, logger="autocontext.scenarios.custom.registry"):
+            result = load_custom_scenarios_detailed(knowledge_root)
+
+        assert "empty_scenario" not in result.loaded
+        assert all(e.name != "empty_scenario" for e in result.skipped)
+        assert caplog.records == []

--- a/autocontext/tests/test_custom_registry_isolation.py
+++ b/autocontext/tests/test_custom_registry_isolation.py
@@ -102,6 +102,25 @@ def _write_spec_only_agent_task(knowledge_root: Path, name: str = "spec_only_tas
     return scenario_dir
 
 
+def _write_agent_task_with_import_file_not_found(
+    knowledge_root: Path,
+    name: str = "broken_import_task",
+) -> Path:
+    """Write an agent_task source that raises FileNotFoundError while importing."""
+    scenario_dir = knowledge_root / "_custom_scenarios" / name
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+    (scenario_dir / "scenario_type.txt").write_text("agent_task", encoding="utf-8")
+    (scenario_dir / "spec.json").write_text(
+        json.dumps({"name": name, "scenario_type": "agent_task"}), encoding="utf-8"
+    )
+    (scenario_dir / "agent_task.py").write_text(
+        "from pathlib import Path\n"
+        "Path(__file__).with_name('missing-data.txt').read_text(encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    return scenario_dir
+
+
 def _write_malformed_spec(knowledge_root: Path, name: str = "regression_probe") -> Path:
     """Write a ``spec.json`` that is missing a required pydantic field."""
     scenario_dir = knowledge_root / "_custom_scenarios" / name
@@ -354,3 +373,28 @@ class TestRegistryIsolation:
         assert "empty_scenario" not in result.loaded
         assert all(e.name != "empty_scenario" for e in result.skipped)
         assert caplog.records == []
+
+    def test_import_file_not_found_uses_real_failure_reason(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        _write_agent_task_with_import_file_not_found(
+            knowledge_root, name="broken_import_task"
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="autocontext.scenarios.custom.registry"):
+            result = load_custom_scenarios_detailed(knowledge_root)
+
+        assert "broken_import_task" not in result.loaded
+        assert len(result.skipped) == 1
+        entry = result.skipped[0]
+        assert entry.name == "broken_import_task"
+        assert "missing-data.txt" in entry.reason
+        assert "no compiled source" not in entry.reason
+
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any(r.exc_text for r in debug_records), (
+            "import-time FileNotFoundError should retain DEBUG traceback"
+        )

--- a/autocontext/tests/test_custom_registry_isolation.py
+++ b/autocontext/tests/test_custom_registry_isolation.py
@@ -80,6 +80,28 @@ def _write_unknown_marker_scenario(knowledge_root: Path, name: str = "banana_sce
     return scenario_dir
 
 
+def _write_spec_only_agent_task(knowledge_root: Path, name: str = "spec_only_task") -> Path:
+    """Write a scenario dir with spec.json and agent_task marker but no agent_task.py."""
+    scenario_dir = knowledge_root / "_custom_scenarios" / name
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+    (scenario_dir / "scenario_type.txt").write_text("agent_task", encoding="utf-8")
+    (scenario_dir / "spec.json").write_text(
+        json.dumps(
+            {
+                "name": name,
+                "display_name": "Spec Only Task",
+                "description": "Has spec but no compiled source.",
+                "strategy_interface_description": "ignored",
+                "evaluation_criteria": "ignored",
+                "scenario_type": "agent_task",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return scenario_dir
+
+
 def _write_malformed_spec(knowledge_root: Path, name: str = "regression_probe") -> Path:
     """Write a ``spec.json`` that is missing a required pydantic field."""
     scenario_dir = knowledge_root / "_custom_scenarios" / name
@@ -280,3 +302,19 @@ class TestRegistryIsolation:
 
         assert "real_scenario" in result.loaded
         assert result.skipped == ()
+
+    def test_spec_only_dir_reported_in_skipped(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        _write_spec_only_agent_task(knowledge_root, name="spec_only_task")
+
+        result = load_custom_scenarios_detailed(knowledge_root)
+
+        assert "spec_only_task" not in result.loaded
+        assert len(result.skipped) == 1
+        entry = result.skipped[0]
+        assert entry.name == "spec_only_task"
+        assert "spec.json" in entry.reason
+        assert "no compiled source" in entry.reason


### PR DESCRIPTION
Closes part **B** of AC-563. Builds on PR #707 (Failure A).

## What changed

- `_custom_scenarios/` directories that have `spec.json` but no compiled source (`scenario.py` / `agent_task.py`) now appear in `.skipped` with a reason string that tells the user exactly how to materialize:

```
custom scenario 'my_task' skipped (.../spec.json): has spec.json but no compiled source for this package — run autoctx new-scenario --from-spec .../spec.json to materialize
```

- Truly empty directories (no `spec.json` at all) remain silently skipped — no noise for detritus dirs.

## Tests

3 new tests in `tests/test_custom_registry_isolation.py` (total now 13):

- `test_spec_only_dir_reported_in_skipped`
- `test_spec_only_dir_emits_warning`
- `test_truly_empty_dir_remains_silent`

Full suite: **5336 passed, 54 skipped, 0 failed**.

## Non-goals

- Failure C: cross-package `scenario.py` vs `scenario.js` visibility.
- Auto-materializing on the user's behalf.
- TypeScript parity.

## Linear

- AC-563 (part B)