### PR TITLE
fix: allow ts improve without initial output

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -83,6 +83,7 @@ autoctx train --scenario support_triage --dataset data.jsonl --backend cuda
 # Evaluation
 autoctx judge -p <prompt> -o <output> -r <rubric>
 autoctx judge --scenario my_saved_task -o <output>
+autoctx improve -p <prompt> -r <rubric> [-n rounds]
 autoctx improve -p <prompt> -o <output> -r <rubric> [-n rounds]
 autoctx improve --scenario my_saved_task [-o <output>]
 autoctx repl --scenario my_saved_task

--- a/ts/src/cli/improve-command-workflow.ts
+++ b/ts/src/cli/improve-command-workflow.ts
@@ -5,7 +5,7 @@ Usage: autoctx improve [options]
 Options:
   -s, --scenario <name>   Use a saved custom scenario (provides prompt + rubric)
   -p, --prompt <text>     Task prompt
-  -o, --output <text>     Initial agent output to improve
+  -o, --output <text>     Initial agent output to improve (optional; generated if omitted)
   -r, --rubric <text>     Evaluation rubric/criteria
   -n, --rounds N          Maximum improvement rounds (default: 5)
   -t, --threshold N       Quality threshold to stop early (default: 0.9)
@@ -17,8 +17,9 @@ Options:
 Provide either --scenario or both --prompt and --rubric.
 
 Examples:
+  autoctx improve -p "Write a summary" -r "Score clarity" -n 3
   autoctx improve -p "Write a summary" -o "Draft here" -r "Score clarity" -n 3
-  autoctx improve -s my_task -o "Initial draft" --threshold 0.95
+  autoctx improve -s my_task --threshold 0.95
 
 See also: judge, queue, run`;
 
@@ -91,10 +92,7 @@ export function getImproveUsageExitCode(
   values: Pick<ImproveCommandValues, "help" | "scenario" | "prompt" | "rubric" | "output" | "rlm">,
 ): 0 | 1 | null {
   if (values.help) return 0;
-  if (
-    (!values.scenario && (!values.prompt || !values.rubric)) ||
-    (!values.output && !values.rlm && !values.scenario)
-  ) {
+  if (!values.scenario && (!values.prompt || !values.rubric)) {
     return 1;
   }
   return null;
@@ -131,9 +129,7 @@ export function planImproveCommand(
     rlmConfig: {
       enabled: values.rlm ?? false,
       model: values["rlm-model"],
-      ...(values["rlm-turns"]
-        ? { maxTurns: Number.parseInt(values["rlm-turns"], 10) }
-        : {}),
+      ...(values["rlm-turns"] ? { maxTurns: Number.parseInt(values["rlm-turns"], 10) } : {}),
       ...(values["rlm-max-tokens"]
         ? { maxTokensPerTurn: Number.parseInt(values["rlm-max-tokens"], 10) }
         : {}),
@@ -155,7 +151,10 @@ export function planImproveCommand(
 
 export async function executeImproveCommandWorkflow<
   TTask extends {
-    generateOutput(args: { referenceContext?: string; requiredConcepts?: string[] }): Promise<string>;
+    generateOutput(args: {
+      referenceContext?: string;
+      requiredConcepts?: string[];
+    }): Promise<string>;
     getRlmSessions(): unknown[];
   },
   TLoop extends {
@@ -236,9 +235,7 @@ export function renderImproveResult(
           score: round.score,
           dimensionScores: round.dimensionScores,
           reasoning:
-            round.reasoning.length > 200
-              ? `${round.reasoning.slice(0, 200)}...`
-              : round.reasoning,
+            round.reasoning.length > 200 ? `${round.reasoning.slice(0, 200)}...` : round.reasoning,
           isRevision: round.isRevision,
           judgeFailed: round.judgeFailed,
         }),

--- a/ts/tests/cli.test.ts
+++ b/ts/tests/cli.test.ts
@@ -4,12 +4,15 @@ import { join } from "node:path";
 
 const CLI = join(import.meta.dirname, "..", "src", "cli", "index.ts");
 
-function runCli(args: string[]): { stdout: string; exitCode: number } {
+function runCli(
+  args: string[],
+  envOverrides: Record<string, string> = {},
+): { stdout: string; exitCode: number } {
   try {
     const stdout = execFileSync("npx", ["tsx", CLI, ...args], {
       encoding: "utf8",
       timeout: 5000,
-      env: { ...process.env, NODE_NO_WARNINGS: "1" },
+      env: { ...process.env, NODE_NO_WARNINGS: "1", ...envOverrides },
     });
     return { stdout, exitCode: 0 };
   } catch (err: unknown) {
@@ -63,6 +66,28 @@ describe("CLI", () => {
   it("improve requires args", () => {
     const { exitCode } = runCli(["improve"]);
     expect(exitCode).toBe(1);
+  });
+
+  it("improve generates an initial draft when prompt and rubric are provided without output", () => {
+    const { stdout, exitCode } = runCli(
+      [
+        "improve",
+        "-p",
+        "Write a haiku about distributed systems",
+        "-r",
+        "Score syllable_accuracy_5_7_5, technical_relevance, and imagery_creativity 0-1 each.",
+        "-n",
+        "2",
+        "-t",
+        "0.8",
+      ],
+      { AUTOCONTEXT_AGENT_PROVIDER: "deterministic" },
+    );
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({
+      bestOutput: expect.any(String),
+      totalRounds: expect.any(Number),
+    });
   });
 
   it("queue --help shows RLM flags", () => {

--- a/ts/tests/improve-command-workflow.test.ts
+++ b/ts/tests/improve-command-workflow.test.ts
@@ -40,6 +40,19 @@ describe("improve command workflow", () => {
     ).toBe(1);
   });
 
+  it("accepts prompt and rubric without requiring an initial output", () => {
+    expect(
+      getImproveUsageExitCode({
+        help: false,
+        scenario: undefined,
+        prompt: "Write a haiku about distributed systems",
+        rubric: "Score syllable accuracy and relevance",
+        output: undefined,
+        rlm: false,
+      }),
+    ).toBeNull();
+  });
+
   it("plans improve command inputs from saved scenario defaults", () => {
     const parsePositiveInteger = vi.fn((raw: string) => Number.parseInt(raw, 10));
     expect(


### PR DESCRIPTION
## Summary

- fix the TypeScript `improve` CLI usage gate so `--prompt` + `--rubric` works without requiring `--output`
- keep the improvement workflow on its intended domain path where the task generates the initial draft when no output is supplied
- add regression coverage at both the workflow and CLI layers
- update TypeScript help/examples so the optional initial output behavior is explicit

## Root cause

The `getImproveUsageExitCode(...)` gate treated missing `--output` as invalid for non-scenario improve calls, even though `executeImproveCommandWorkflow(...)` already supports generating the initial output via `task.generateOutput(...)` when `initialOutput` is absent.

That mismatch caused the CLI to print help text and exit before the improvement loop could run.

## Changes

- `ts/src/cli/improve-command-workflow.ts`
  - removed the incorrect `--output` requirement from usage validation
  - clarified help text so `--output` is documented as optional
  - added help examples that show no-output improve usage
- `ts/tests/improve-command-workflow.test.ts`
  - added regression coverage for prompt+rubric without output
- `ts/tests/cli.test.ts`
  - added a CLI regression test that runs `improve` without output using the deterministic provider
- `ts/README.md`
  - updated the evaluation command examples to show improve without an initial output

## Verification

- [x] `cd ts && npx vitest run tests/improve-command-workflow.test.ts tests/cli.test.ts tests/integration-improvement.test.ts`
- [x] `cd ts && npm run lint`
- [x] `cd ts && npm run build`

## Live validation

Reproduced the original AC-558 command shape against live `pi` without `--output` and confirmed it now runs successfully:

```bash
AUTOCONTEXT_AGENT_PROVIDER=pi \
AUTOCONTEXT_PI_COMMAND=pi \
node dist/cli/index.js improve \
  -p "Write a haiku about distributed systems" \
  -r "Score syllable_accuracy_5_7_5, technical_relevance, and imagery_creativity 0-1 each." \
  -n 3 -t 0.8
```

Artifacts:
- result: `/tmp/ac558-live-pi-OyGt06/result.json`
- stderr: `/tmp/ac558-live-pi-OyGt06/stderr.log`

Observed result:
- exit code `0`
- `totalRounds: 2`
- `metThreshold: true`
- `bestScore: 0.97`

## Notes

This is intentionally a minimal fix: the improvement loop already had the right domain behavior, so the change removes the incorrect CLI-front-door constraint instead of redesigning the workflow internals.
