### PR TITLE
feat(ac-563/C): auto-materialize scenario.py from spec.json for all families

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/creator_registry.py
+++ b/autocontext/src/autocontext/scenarios/custom/creator_registry.py
@@ -18,6 +18,7 @@ class FamilyCreatorConfig:
     designer_fn_path: str  # module:function for lazy import
     codegen_fn_path: str  # module:function for lazy import
     interface_class_path: str  # module:class for lazy import
+    spec_class_path: str  # module:class for the family-specific spec dataclass
 
 
 def _lazy_import(dotted_path: str) -> Any:
@@ -37,54 +38,63 @@ FAMILY_CONFIGS: dict[str, FamilyCreatorConfig] = {
         designer_fn_path="autocontext.scenarios.custom.simulation_designer:design_simulation",
         codegen_fn_path="autocontext.scenarios.custom.simulation_codegen:generate_simulation_class",
         interface_class_path="autocontext.scenarios.simulation:SimulationInterface",
+        spec_class_path="autocontext.scenarios.custom.simulation_spec:SimulationSpec",
     ),
     "artifact_editing": FamilyCreatorConfig(
         family="artifact_editing",
         designer_fn_path="autocontext.scenarios.custom.artifact_editing_designer:design_artifact_editing",
         codegen_fn_path="autocontext.scenarios.custom.artifact_editing_codegen:generate_artifact_editing_class",
         interface_class_path="autocontext.scenarios.artifact_editing:ArtifactEditingInterface",
+        spec_class_path="autocontext.scenarios.custom.artifact_editing_spec:ArtifactEditingSpec",
     ),
     "investigation": FamilyCreatorConfig(
         family="investigation",
         designer_fn_path="autocontext.scenarios.custom.investigation_designer:design_investigation",
         codegen_fn_path="autocontext.scenarios.custom.investigation_codegen:generate_investigation_class",
         interface_class_path="autocontext.scenarios.investigation:InvestigationInterface",
+        spec_class_path="autocontext.scenarios.custom.investigation_spec:InvestigationSpec",
     ),
     "workflow": FamilyCreatorConfig(
         family="workflow",
         designer_fn_path="autocontext.scenarios.custom.workflow_designer:design_workflow",
         codegen_fn_path="autocontext.scenarios.custom.workflow_codegen:generate_workflow_class",
         interface_class_path="autocontext.scenarios.workflow:WorkflowInterface",
+        spec_class_path="autocontext.scenarios.custom.workflow_spec:WorkflowSpec",
     ),
     "schema_evolution": FamilyCreatorConfig(
         family="schema_evolution",
         designer_fn_path="autocontext.scenarios.custom.schema_evolution_designer:design_schema_evolution",
         codegen_fn_path="autocontext.scenarios.custom.schema_evolution_codegen:generate_schema_evolution_class",
         interface_class_path="autocontext.scenarios.schema_evolution:SchemaEvolutionInterface",
+        spec_class_path="autocontext.scenarios.custom.schema_evolution_spec:SchemaEvolutionSpec",
     ),
     "tool_fragility": FamilyCreatorConfig(
         family="tool_fragility",
         designer_fn_path="autocontext.scenarios.custom.tool_fragility_designer:design_tool_fragility",
         codegen_fn_path="autocontext.scenarios.custom.tool_fragility_codegen:generate_tool_fragility_class",
         interface_class_path="autocontext.scenarios.tool_fragility:ToolFragilityInterface",
+        spec_class_path="autocontext.scenarios.custom.tool_fragility_spec:ToolFragilitySpec",
     ),
     "negotiation": FamilyCreatorConfig(
         family="negotiation",
         designer_fn_path="autocontext.scenarios.custom.negotiation_designer:design_negotiation",
         codegen_fn_path="autocontext.scenarios.custom.negotiation_codegen:generate_negotiation_class",
         interface_class_path="autocontext.scenarios.negotiation:NegotiationInterface",
+        spec_class_path="autocontext.scenarios.custom.negotiation_spec:NegotiationSpec",
     ),
     "operator_loop": FamilyCreatorConfig(
         family="operator_loop",
         designer_fn_path="autocontext.scenarios.custom.operator_loop_designer:design_operator_loop",
         codegen_fn_path="autocontext.scenarios.custom.operator_loop_codegen:generate_operator_loop_class",
         interface_class_path="autocontext.scenarios.operator_loop:OperatorLoopInterface",
+        spec_class_path="autocontext.scenarios.custom.operator_loop_spec:OperatorLoopSpec",
     ),
     "coordination": FamilyCreatorConfig(
         family="coordination",
         designer_fn_path="autocontext.scenarios.custom.coordination_designer:design_coordination",
         codegen_fn_path="autocontext.scenarios.custom.coordination_codegen:generate_coordination_class",
         interface_class_path="autocontext.scenarios.coordination:CoordinationInterface",
+        spec_class_path="autocontext.scenarios.custom.coordination_spec:CoordinationSpec",
     ),
 }
 

--- a/autocontext/src/autocontext/scenarios/custom/registry.py
+++ b/autocontext/src/autocontext/scenarios/custom/registry.py
@@ -116,8 +116,12 @@ def _load_family_class(custom_dir: Path, name: str, marker: str) -> type[Any]:
             raise FileNotFoundError(f"agent task source not found: {agent_task_file}")
         return _load_agent_task_class(custom_dir, name)
 
-    if marker == "parametric":
-        _materialize_parametric_scenario_source(custom_dir, name)
+    source_path = custom_dir / name / "scenario.py"
+    if not source_path.exists():
+        if marker == "parametric":
+            _materialize_parametric_scenario_source(custom_dir, name)
+        else:
+            _auto_materialize_family_source(custom_dir, name, family.name)
 
     cls = load_custom_scenario(custom_dir, name, family.interface_class)
     detected = detect_family(cls())
@@ -160,6 +164,73 @@ def _summarize_load_failure(exc: BaseException, marker: str) -> str:
         return text.splitlines()[0][:200]
     except Exception:
         return exc.__class__.__name__
+
+
+def _reconstruct_family_spec(spec_cls: type, raw: dict[str, Any]) -> Any:
+    """Reconstruct a family spec dataclass from a plain JSON dict.
+
+    Handles nested pydantic BaseModels (via ``model_validate``) and nested
+    dataclasses (recursive). Best-effort: raises on missing required fields.
+    """
+    import dataclasses
+    import typing
+
+    from pydantic import BaseModel
+
+    hints = typing.get_type_hints(spec_cls)
+    kwargs: dict[str, Any] = {}
+    for f in dataclasses.fields(spec_cls):
+        if f.name not in raw:
+            if f.default is not dataclasses.MISSING:
+                continue
+            if f.default_factory is not dataclasses.MISSING:
+                continue
+            raise ValueError(f"missing required field '{f.name}' for {spec_cls.__name__}")
+        value = raw[f.name]
+        hint = hints.get(f.name)
+        origin = typing.get_origin(hint)
+        args = typing.get_args(hint)
+        if origin is list and args and isinstance(value, list):
+            elem_type = args[0]
+            if isinstance(elem_type, type) and issubclass(elem_type, BaseModel):
+                value = [elem_type.model_validate(item) if isinstance(item, dict) else item for item in value]
+            elif dataclasses.is_dataclass(elem_type):
+                value = [_reconstruct_family_spec(elem_type, item) if isinstance(item, dict) else item for item in value]
+        kwargs[f.name] = value
+    return spec_cls(**kwargs)
+
+
+def _auto_materialize_family_source(custom_dir: Path, name: str, family_name: str) -> None:
+    """Auto-generate ``scenario.py`` from ``spec.json`` for any registered family.
+
+    Uses ``FAMILY_CONFIGS`` from ``creator_registry`` to find the spec class and
+    codegen function. Falls through (raises) if reconstruction or codegen fails
+    — callers handle failures via the Failure A/B diagnostic handlers.
+    """
+    from autocontext.scenarios.custom.creator_registry import FAMILY_CONFIGS, _lazy_import
+
+    config = FAMILY_CONFIGS.get(family_name)
+    if config is None:
+        raise FileNotFoundError(f"no FAMILY_CONFIGS entry for family '{family_name}'")
+
+    scenario_dir = custom_dir / name
+    spec_path = scenario_dir / "spec.json"
+    raw = json.loads(spec_path.read_text(encoding="utf-8"))
+
+    spec_cls = _lazy_import(config.spec_class_path)
+    spec = _reconstruct_family_spec(spec_cls, raw)
+
+    codegen_fn = _lazy_import(config.codegen_fn_path)
+    source = codegen_fn(spec, name=name)
+
+    source_path = scenario_dir / "scenario.py"
+    source_path.write_text(source, encoding="utf-8")
+
+    type_file = scenario_dir / "scenario_type.txt"
+    if not type_file.exists():
+        type_file.write_text(family_name, encoding="utf-8")
+
+    logger.info("auto-materialized scenario.py for '%s' (family=%s)", name, family_name)
 
 
 def load_custom_scenarios_detailed(knowledge_root: Path) -> ScenarioRegistryLoadResult:

--- a/autocontext/src/autocontext/scenarios/custom/registry.py
+++ b/autocontext/src/autocontext/scenarios/custom/registry.py
@@ -194,7 +194,7 @@ def _reconstruct_family_spec(spec_cls: type, raw: dict[str, Any]) -> Any:
             elem_type = args[0]
             if isinstance(elem_type, type) and issubclass(elem_type, BaseModel):
                 value = [elem_type.model_validate(item) if isinstance(item, dict) else item for item in value]
-            elif dataclasses.is_dataclass(elem_type):
+            elif isinstance(elem_type, type) and dataclasses.is_dataclass(elem_type):
                 value = [_reconstruct_family_spec(elem_type, item) if isinstance(item, dict) else item for item in value]
         kwargs[f.name] = value
     return spec_cls(**kwargs)

--- a/autocontext/tests/test_custom_registry_isolation.py
+++ b/autocontext/tests/test_custom_registry_isolation.py
@@ -121,6 +121,48 @@ def _write_agent_task_with_import_file_not_found(
     return scenario_dir
 
 
+def _write_ts_simulation_spec(knowledge_root: Path, name: str = "ts_simulation") -> Path:
+    """Write a scenario dir that mimics TS new-scenario output for a simulation family."""
+    scenario_dir = knowledge_root / "_custom_scenarios" / name
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+    (scenario_dir / "scenario_type.txt").write_text("simulation", encoding="utf-8")
+    (scenario_dir / "scenario.js").write_text("// TS generated source", encoding="utf-8")
+    (scenario_dir / "spec.json").write_text(
+        json.dumps(
+            {
+                "name": name,
+                "scenario_type": "simulation",
+                "family": "simulation",
+                "description": "A test simulation created by TS.",
+                "environment_description": "A simulated environment with two variables.",
+                "initial_state_description": "Both variables start at zero.",
+                "success_criteria": ["Variable A reaches 10"],
+                "failure_modes": ["Variable A goes negative"],
+                "actions": [
+                    {
+                        "name": "increment_a",
+                        "description": "Add 1 to variable A",
+                        "parameters": {},
+                        "preconditions": ["Variable A is below 10"],
+                        "effects": ["Variable A increases by 1"],
+                    },
+                    {
+                        "name": "reset_a",
+                        "description": "Reset variable A to zero",
+                        "parameters": {},
+                        "preconditions": [],
+                        "effects": ["Variable A becomes 0"],
+                    },
+                ],
+                "max_steps": 5,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return scenario_dir
+
+
 def _write_malformed_spec(knowledge_root: Path, name: str = "regression_probe") -> Path:
     """Write a ``spec.json`` that is missing a required pydantic field."""
     scenario_dir = knowledge_root / "_custom_scenarios" / name
@@ -398,3 +440,17 @@ class TestRegistryIsolation:
         assert any(r.exc_text for r in debug_records), (
             "import-time FileNotFoundError should retain DEBUG traceback"
         )
+
+    def test_ts_created_simulation_auto_materializes(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        scenario_dir = _write_ts_simulation_spec(knowledge_root, name="ts_simulation")
+
+        loaded = load_all_custom_scenarios(knowledge_root)
+
+        assert "ts_simulation" in loaded, (
+            f"expected ts_simulation in loaded, got {list(loaded.keys())}"
+        )
+        assert (scenario_dir / "scenario.py").is_file(), "scenario.py should have been generated"

--- a/autocontext/tests/test_custom_registry_isolation.py
+++ b/autocontext/tests/test_custom_registry_isolation.py
@@ -14,6 +14,7 @@ import pytest
 from autocontext.scenarios.custom.registry import (
     ScenarioLoadError,
     ScenarioRegistryLoadResult,
+    _reconstruct_family_spec,
     load_all_custom_scenarios,
     load_custom_scenarios_detailed,
 )
@@ -152,6 +153,43 @@ def _write_ts_simulation_spec(knowledge_root: Path, name: str = "ts_simulation")
                         "parameters": {},
                         "preconditions": [],
                         "effects": ["Variable A becomes 0"],
+                    },
+                ],
+                "max_steps": 5,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return scenario_dir
+
+
+def _write_ts_investigation_spec(knowledge_root: Path, name: str = "ts_investigation") -> Path:
+    """Write a scenario dir that mimics TS new-scenario output for investigation family."""
+    scenario_dir = knowledge_root / "_custom_scenarios" / name
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+    (scenario_dir / "scenario_type.txt").write_text("investigation", encoding="utf-8")
+    (scenario_dir / "scenario.js").write_text("// TS generated source", encoding="utf-8")
+    (scenario_dir / "spec.json").write_text(
+        json.dumps(
+            {
+                "name": name,
+                "scenario_type": "investigation",
+                "family": "investigation",
+                "description": "A test investigation created by TS.",
+                "environment_description": "A system with intermittent failures.",
+                "initial_state_description": "System is in degraded state.",
+                "evidence_pool_description": "Logs, metrics, and traces are available.",
+                "diagnosis_target": "Identify the root cause of the degraded state.",
+                "success_criteria": ["Root cause correctly identified"],
+                "failure_modes": ["Wrong diagnosis accepted"],
+                "actions": [
+                    {
+                        "name": "check_logs",
+                        "description": "Review system logs",
+                        "parameters": {},
+                        "preconditions": [],
+                        "effects": ["Log entries revealed"],
                     },
                 ],
                 "max_steps": 5,
@@ -454,3 +492,103 @@ class TestRegistryIsolation:
             f"expected ts_simulation in loaded, got {list(loaded.keys())}"
         )
         assert (scenario_dir / "scenario.py").is_file(), "scenario.py should have been generated"
+
+    def test_ts_created_investigation_auto_materializes(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        scenario_dir = _write_ts_investigation_spec(knowledge_root, name="ts_investigation")
+
+        loaded = load_all_custom_scenarios(knowledge_root)
+
+        assert "ts_investigation" in loaded
+        assert (scenario_dir / "scenario.py").is_file()
+
+    def test_auto_materialize_falls_back_on_bad_family_spec(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """spec.json exists for simulation family but is missing required fields."""
+        knowledge_root = tmp_path / "knowledge"
+        scenario_dir = knowledge_root / "_custom_scenarios" / "bad_sim"
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+        (scenario_dir / "scenario_type.txt").write_text("simulation", encoding="utf-8")
+        (scenario_dir / "spec.json").write_text(
+            json.dumps(
+                {
+                    "name": "bad_sim",
+                    "scenario_type": "simulation",
+                    # Missing required simulation fields: environment_description, actions, etc.
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        result = load_custom_scenarios_detailed(knowledge_root)
+
+        assert "bad_sim" not in result.loaded
+        assert len(result.skipped) == 1
+        assert result.skipped[0].name == "bad_sim"
+
+    def test_parametric_auto_materialize_still_works(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Existing parametric path must still work — regression guard for the refactor."""
+        knowledge_root = tmp_path / "knowledge"
+        scenario_dir = _write_valid_parametric_spec(knowledge_root, name="parametric_regression")
+
+        loaded = load_all_custom_scenarios(knowledge_root)
+
+        assert "parametric_regression" in loaded
+        assert (scenario_dir / "scenario.py").is_file()
+        scenario = loaded["parametric_regression"]()
+        assert scenario.name == "parametric_regression"
+
+    def test_reconstruct_handles_nested_pydantic_models(self) -> None:
+        from autocontext.scenarios.custom.simulation_spec import SimulationSpec
+
+        raw = {
+            "description": "test",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "success_criteria": ["win"],
+            "failure_modes": ["lose"],
+            "actions": [
+                {
+                    "name": "act1",
+                    "description": "do thing",
+                    "parameters": {},
+                    "preconditions": ["ready"],
+                    "effects": ["done"],
+                },
+            ],
+            "max_steps": 3,
+        }
+
+        spec = _reconstruct_family_spec(SimulationSpec, raw)
+
+        assert isinstance(spec, SimulationSpec)
+        assert spec.description == "test"
+        assert len(spec.actions) == 1
+        assert spec.actions[0].name == "act1"
+        assert spec.max_steps == 3
+
+    def test_reconstruct_handles_missing_optional_fields(self) -> None:
+        from autocontext.scenarios.custom.simulation_spec import SimulationSpec
+
+        raw = {
+            "description": "test",
+            "environment_description": "env",
+            "initial_state_description": "init",
+            "success_criteria": ["win"],
+            "failure_modes": ["lose"],
+            "actions": [],
+            # max_steps omitted — has default of 10
+        }
+
+        spec = _reconstruct_family_spec(SimulationSpec, raw)
+
+        assert spec.max_steps == 10


### PR DESCRIPTION
Closes part **C** of AC-563 (completes the issue). Builds on PRs #707 (A) and #709 (B).

## What changed

- Any `_custom_scenarios/` directory with a valid `spec.json` now auto-generates `scenario.py` at Py load time — regardless of which package created the scenario.
- A TS-created scenario (with `spec.json` + `scenario.js`) is now loadable and runnable from Py. The `.js` file is irrelevant to Py; it generates its own `.py` from the spec.
- Uses the existing `FAMILY_CONFIGS` codegen infrastructure — no new codegen, no TS coupling.
- New generic `_reconstruct_family_spec` handles all 9 non-parametric family specs via dataclass introspection + pydantic `model_validate` for nested types.
- If auto-materialization fails (bad spec, missing fields), falls through to the existing Failure A/B diagnostic handlers — `.skipped` with a reason.
- Added `spec_class_path` to `FamilyCreatorConfig` so the registry can lazy-import and reconstruct typed spec objects.

## Tests

6 new tests in `tests/test_custom_registry_isolation.py` (total now 19):

- `test_ts_created_simulation_auto_materializes`
- `test_ts_created_investigation_auto_materializes`
- `test_auto_materialize_falls_back_on_bad_family_spec`
- `test_parametric_auto_materialize_still_works` (regression guard)
- `test_reconstruct_handles_nested_pydantic_models`
- `test_reconstruct_handles_missing_optional_fields`

Full suite: **5342 passed, 54 skipped, 0 failed**. ruff + mypy clean.

## Linear

- AC-563 (part C — completes the issue)