### PR TITLE
fix: normalize structured agent-task prompt payloads

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/agent_task_codegen.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_codegen.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import re
 import textwrap
 
-from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+from autocontext.scenarios.custom.agent_task_spec import (
+    AgentTaskSpec,
+    normalize_agent_task_runtime_fields,
+)
 
 
 def _class_name(name: str) -> str:
@@ -25,6 +28,8 @@ def generate_agent_task_class(spec: AgentTaskSpec, name: str = "custom_agent_tas
     Returns:
         Python source code string.
     """
+    spec = normalize_agent_task_runtime_fields(spec)
+
     cls_name = _class_name(name)
     safe_name = _safe_identifier(name)
 

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
@@ -4,7 +4,10 @@ import json
 import re
 
 from autocontext.agents.types import LlmFn
-from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+from autocontext.scenarios.custom.agent_task_spec import (
+    AgentTaskSpec,
+    normalize_agent_task_runtime_fields,
+)
 
 SPEC_START = "<!-- AGENT_TASK_SPEC_START -->"
 SPEC_END = "<!-- AGENT_TASK_SPEC_END -->"
@@ -79,7 +82,7 @@ AGENT_TASK_DESIGNER_SYSTEM = (
     "```\n\n"
     "## Rules\n\n"
     "- `task_prompt` must be clear, detailed, and self-contained\n"
-    "- `task_prompt` must be FULLY self-contained: never say \"you will be provided with...\" or reference "
+    '- `task_prompt` must be FULLY self-contained: never say "you will be provided with..." or reference '
     "external data without including it. If the task depends on input data, populate `sample_input` with "
     "realistic example data and embed it directly in the prompt\n"
     "- `sample_input` (optional, null if not needed) — realistic sample input data for data-dependent tasks. "
@@ -119,22 +122,24 @@ def parse_agent_task_spec(text: str) -> AgentTaskSpec:
         raise ValueError("response does not contain AGENT_TASK_SPEC delimiters")
     raw = match.group(1).strip()
     data = json.loads(raw)
-    return AgentTaskSpec(
-        task_prompt=data["task_prompt"],
-        judge_rubric=data["judge_rubric"],
-        output_format=data.get("output_format", "free_text"),
-        judge_model=data.get("judge_model", ""),
-        difficulty_tiers=data.get("difficulty_tiers"),
-        reference_context=data.get("reference_context"),
-        reference_sources=data.get("reference_sources"),
-        required_concepts=data.get("required_concepts"),
-        calibration_examples=data.get("calibration_examples"),
-        context_preparation=data.get("context_preparation"),
-        required_context_keys=data.get("required_context_keys"),
-        max_rounds=data.get("max_rounds", 1),
-        quality_threshold=data.get("quality_threshold", 0.9),
-        revision_prompt=data.get("revision_prompt"),
-        sample_input=data.get("sample_input"),
+    return normalize_agent_task_runtime_fields(
+        AgentTaskSpec(
+            task_prompt=data["task_prompt"],
+            judge_rubric=data["judge_rubric"],
+            output_format=data.get("output_format", "free_text"),
+            judge_model=data.get("judge_model", ""),
+            difficulty_tiers=data.get("difficulty_tiers"),
+            reference_context=data.get("reference_context"),
+            reference_sources=data.get("reference_sources"),
+            required_concepts=data.get("required_concepts"),
+            calibration_examples=data.get("calibration_examples"),
+            context_preparation=data.get("context_preparation"),
+            required_context_keys=data.get("required_context_keys"),
+            max_rounds=data.get("max_rounds", 1),
+            quality_threshold=data.get("quality_threshold", 0.9),
+            revision_prompt=data.get("revision_prompt"),
+            sample_input=data.get("sample_input"),
+        )
     )
 
 

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_spec.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_spec.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+from dataclasses import dataclass, replace
+from typing import Any
 
 
 @dataclass(slots=True)
@@ -22,3 +24,29 @@ class AgentTaskSpec:
     quality_threshold: float = 0.9  # Stop improving when score >= this
     revision_prompt: str | None = None  # Instructions for how to revise output
     sample_input: str | None = None  # Sample input data for data-dependent tasks
+
+
+def _serialize_agent_task_text_payload(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict | list):
+        return json.dumps(value, indent=2)
+    return str(value)
+
+
+def normalize_agent_task_runtime_fields(spec: AgentTaskSpec) -> AgentTaskSpec:
+    """Coerce structured prompt-adjacent fields into runtime-safe strings.
+
+    LLM-designed agent-task specs occasionally return structured JSON for fields
+    like sample_input. The generated runtime embeds those fields into prompts via
+    string concatenation, so we normalize them once at the spec boundary.
+    """
+    return replace(
+        spec,
+        reference_context=_serialize_agent_task_text_payload(spec.reference_context),
+        context_preparation=_serialize_agent_task_text_payload(spec.context_preparation),
+        revision_prompt=_serialize_agent_task_text_payload(spec.revision_prompt),
+        sample_input=_serialize_agent_task_text_payload(spec.sample_input),
+    )

--- a/autocontext/src/autocontext/scenarios/custom/family_pipeline.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_pipeline.py
@@ -220,7 +220,10 @@ class AgentTaskPipeline(FamilyPipeline):
         return {"task_prompt", "judge_rubric"}
 
     def validate_spec(self, spec: dict[str, Any]) -> list[str]:
-        from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+        from autocontext.scenarios.custom.agent_task_spec import (
+            AgentTaskSpec,
+            normalize_agent_task_runtime_fields,
+        )
         from autocontext.scenarios.custom.agent_task_validator import validate_spec
 
         errors = _check_required_fields(spec, self.required_spec_fields())
@@ -228,7 +231,7 @@ class AgentTaskPipeline(FamilyPipeline):
             return errors
 
         try:
-            spec_obj = AgentTaskSpec(**spec)
+            spec_obj = normalize_agent_task_runtime_fields(AgentTaskSpec(**spec))
         except TypeError as exc:
             return [f"invalid agent_task spec: {exc}"]
         return validate_spec(spec_obj)

--- a/autocontext/tests/test_agent_task_pipeline.py
+++ b/autocontext/tests/test_agent_task_pipeline.py
@@ -123,8 +123,7 @@ def _mock_investigation_response() -> str:
         "environment_description": "Mock service environment with logs and dashboards.",
         "initial_state_description": "An outage is active and only partial evidence is visible.",
         "evidence_pool_description": (
-            "Logs implicate the auth service, metrics show latency spikes, "
-            "and a cron-job entry is a red herring."
+            "Logs implicate the auth service, metrics show latency spikes, and a cron-job entry is a red herring."
         ),
         "diagnosis_target": "A bad auth deployment exhausted the database connection pool.",
         "success_criteria": [
@@ -464,6 +463,22 @@ class TestSampleInput:
         spec = parse_agent_task_spec(raw)
         assert spec.sample_input == "Service X went down at 3am."
 
+    def test_parse_structured_sample_input_serializes_json(self) -> None:
+        data = {
+            "task_prompt": "Analyze this clinical trial brief",
+            "judge_rubric": "Check completeness",
+            "sample_input": {
+                "indication": "oncology",
+                "phase": "II",
+                "jurisdiction": "FDA",
+            },
+        }
+        raw = f"{SPEC_START}\n{json.dumps(data)}\n{SPEC_END}"
+        spec = parse_agent_task_spec(raw)
+        assert isinstance(spec.sample_input, str)
+        assert '"indication": "oncology"' in spec.sample_input
+        assert '"phase": "II"' in spec.sample_input
+
     def test_sample_input_defaults_to_none(self) -> None:
         data = {
             "task_prompt": "Do something",
@@ -512,6 +527,60 @@ class TestAgentTaskCreator:
                 assert (scenario_dir / "agent_task_spec.json").exists()
                 assert (scenario_dir / "scenario_type.txt").exists()
                 assert (scenario_dir / "scenario_type.txt").read_text() == "agent_task"
+            finally:
+                SCENARIO_REGISTRY.pop(registered_name, None)
+
+    def test_end_to_end_with_structured_sample_input(self) -> None:
+        spec_data = {
+            "task_prompt": "Design a Phase II trial protocol from the study brief.",
+            "judge_rubric": "Evaluate protocol rigor and regulatory alignment.",
+            "output_format": "free_text",
+            "sample_input": {
+                "indication": "oncology",
+                "phase": "II",
+                "jurisdiction": "FDA",
+                "budget": "moderate",
+            },
+            "calibration_examples": [
+                {
+                    "human_score": 0.3,
+                    "human_notes": "Missing endpoint rationale.",
+                    "agent_output": "Use a generic protocol.",
+                },
+                {
+                    "human_score": 0.9,
+                    "human_notes": "Well scoped, justified, and safety-aware.",
+                    "agent_output": "Use a randomized protocol with clear endpoints.",
+                },
+            ],
+        }
+        response_text = f"Here is the spec:\n{SPEC_START}\n{json.dumps(spec_data, indent=2)}\n{SPEC_END}\n"
+
+        def mock_llm(system: str, user: str) -> str:
+            return response_text
+
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        with tempfile.TemporaryDirectory() as tmp:
+            creator = AgentTaskCreator(
+                llm_fn=mock_llm,
+                knowledge_root=Path(tmp),
+            )
+            from unittest.mock import patch
+
+            from autocontext.scenarios.families import get_family
+
+            with patch(
+                "autocontext.scenarios.custom.agent_task_creator.route_to_family",
+                return_value=get_family("agent_task"),
+            ):
+                instance = creator.create("Design a clinical trial protocol for oncology")
+            registered_name = creator.derive_name("Design a clinical trial protocol for oncology")
+
+            try:
+                prompt = instance.get_task_prompt({})
+                assert '"indication": "oncology"' in prompt
+                assert "## Input Data" in prompt
             finally:
                 SCENARIO_REGISTRY.pop(registered_name, None)
 
@@ -632,12 +701,8 @@ class TestAgentTaskCreator:
                 llm_fn=mock_llm,
                 knowledge_root=Path(tmp),
             )
-            instance = creator.create(
-                "Create a transactional workflow with compensation and side effects"
-            )
-            registered_name = creator.derive_name(
-                "Create a transactional workflow with compensation and side effects"
-            )
+            instance = creator.create("Create a transactional workflow with compensation and side effects")
+            registered_name = creator.derive_name("Create a transactional workflow with compensation and side effects")
             try:
                 from autocontext.scenarios.world_state import WorldState
 
@@ -652,9 +717,7 @@ class TestAgentTaskCreator:
                 _result, next_state = instance.execute_step(initial_state, first_step)
                 next_world_state = WorldState.from_dict(next_state["_world_state"])
                 step_entity = next(
-                    entity
-                    for entity in next_world_state.entities
-                    if entity.entity_id == f"step:{first_step.name}"
+                    entity for entity in next_world_state.entities if entity.entity_id == f"step:{first_step.name}"
                 )
                 assert step_entity.status == "completed"
                 assert next_state["world_state_deltas"]
@@ -758,6 +821,23 @@ class TestSampleInputWiring:
         assert '{"users"' in prompt
         assert "Analyze the following data" in prompt
 
+    def test_structured_sample_input_survives_execution_validation(self) -> None:
+        from autocontext.scenarios.custom.agent_task_codegen import generate_agent_task_class
+        from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+
+        spec = AgentTaskSpec(
+            task_prompt="Design a clinical trial protocol from the provided study brief.",
+            judge_rubric="Evaluate statistical rigor and regulatory alignment",
+            sample_input={
+                "indication": "oncology",
+                "phase": "II",
+                "jurisdiction": "FDA",
+            },  # type: ignore[arg-type]
+        )
+        source = generate_agent_task_class(spec, name="clinical_trial_protocol")
+        errors = validate_execution(source)
+        assert errors == []
+
     def test_sample_input_in_initial_state(self) -> None:
         from autocontext.scenarios.custom.agent_task_codegen import generate_agent_task_class
         from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
@@ -844,11 +924,11 @@ class TestValidatorExternalDataReference:
 
         spec = AgentTaskSpec(
             task_prompt=(
-                'Based on the data below:\n\n'
-                '```json\n'
+                "Based on the data below:\n\n"
+                "```json\n"
                 '{"gdp_growth": 2.1, "inflation": 3.5, "unemployment": 4.2}\n'
-                '```\n\n'
-                'Provide an economic outlook assessment.'
+                "```\n\n"
+                "Provide an economic outlook assessment."
             ),
             judge_rubric="Evaluate economic analysis quality",
         )

--- a/autocontext/tests/test_agent_task_pipeline.py
+++ b/autocontext/tests/test_agent_task_pipeline.py
@@ -25,6 +25,7 @@ from autocontext.scenarios.custom.artifact_editing_designer import (
     ARTIFACT_SPEC_END,
     ARTIFACT_SPEC_START,
 )
+from autocontext.scenarios.custom.family_pipeline import validate_for_family
 from autocontext.scenarios.custom.investigation_designer import (
     INVESTIGATION_SPEC_END,
     INVESTIGATION_SPEC_START,
@@ -372,6 +373,20 @@ class TestValidateSpec:
             reference_sources=["https://example.com/docs"],
         )
         errors = validate_spec(spec)
+        assert errors == []
+
+    def test_family_pipeline_normalizes_structured_runtime_fields(self) -> None:
+        errors = validate_for_family(
+            "agent_task",
+            {
+                "task_prompt": "Summarize the prepared evidence.",
+                "judge_rubric": "Evaluate completeness and grounding.",
+                "reference_context": {"facts": ["alpha", "beta"]},
+                "context_preparation": {"steps": ["load evidence"]},
+                "revision_prompt": ["Add missing facts"],
+                "sample_input": {"case_id": "case-123"},
+            },
+        )
         assert errors == []
 
     def test_empty_judge_model_is_valid(self) -> None:


### PR DESCRIPTION
## Summary

- normalize structured agent-task prompt-adjacent payloads like embedded input data before they reach generated runtime code
- harden both the parser and codegen boundary so dict/list payloads become JSON strings instead of crashing prompt assembly
- add regression coverage for parser normalization, execution validation, and the end-to-end creator path with structured embedded input data

## Root cause

During the post-AC-562 live investigation of the AC-272-style solve path, Python surfaced this failure:

```text
execution validation failed: get_task_prompt() raised: can only concatenate str (not "dict") to str; evaluate_output() raised: can only concatenate str (not "dict") to str
```

The underlying problem was that agent-task designer output could legitimately contain structured JSON for embedded input data, but the generated runtime embedded that field directly into prompt concatenation:

```python
prompt += "\n\n## Input Data\n" + self._sample_input
```

If that payload was a dict, generated scenarios failed during execution validation and never reached solve execution.

## Fix

- added runtime-safe normalization in `agent_task_spec.py`
  - `normalize_agent_task_runtime_fields(...)`
  - structured dict/list payloads now serialize to pretty JSON strings
- updated `parse_agent_task_spec(...)` to normalize prompt-adjacent runtime fields at the parse boundary
- updated `generate_agent_task_class(...)` to normalize again defensively for manually-constructed specs
- added regression tests covering:
  - parsing structured embedded input data
  - generated execution validation with structured embedded input data
  - end-to-end creator flow with structured embedded input data

## Verification

- [x] `cd autocontext && uv run pytest tests/test_agent_task_pipeline.py -k 'parse_structured_sample_input or structured_sample_input_survives_execution_validation or end_to_end_with_structured_sample_input' -x --tb=short`
- [x] `cd autocontext && uv run pytest tests/test_agent_task_pipeline.py tests/test_context_preparation.py tests/test_revise_output_fix.py tests/test_knowledge_solver.py -k 'agent_task or sample_input or context_preparation or revise_output or solve' -x --tb=short`
- [x] `cd autocontext && uv run ruff check src/autocontext/scenarios/custom/agent_task_spec.py src/autocontext/scenarios/custom/agent_task_designer.py src/autocontext/scenarios/custom/agent_task_codegen.py tests/test_agent_task_pipeline.py`

## Manual validation

### Direct structured-payload command path

Generated a task class from a spec whose embedded input data was a dict and confirmed it now validates and renders prompt input data correctly:

- artifact: `/tmp/py-agent-task-structured-manual-nVHBrW/result.json`

Observed result:

- `errors: []`
- prompt includes `## Input Data`
- prompt includes serialized oncology JSON
- `initial_state().get("sample_input")` is a `str`

### End-to-end creator path with structured input payload

Exercised `AgentTaskCreator` with a mocked designer response containing structured embedded input data:

- artifact: `/tmp/py-agent-task-creator-manual-3G1Jx9/result.json`

Observed result:

- scenario persisted successfully
- prompt contains serialized oncology JSON
- generated `agent_task.py` file exists

### Representative live AC-272-style rerun

I also retried the broader live solve path that originally uncovered this bug:

- stderr: `/tmp/py-agent-task-bug-live-9BYh0W/stderr.log`

That run is still blocked by the separate AC-562 timeout bucket (`pi CLI timed out after 600s`) before it reaches the old dict/string crash site. So the targeted bug validation for this PR relies on the deterministic regression tests plus the direct command-path/manual validations above.
