### PR TITLE
release: bump packages to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-Changes in this section are on the branch/repo after `0.4.2` and are not part of the last published release until the next version is cut.
+Changes in this section are on the branch/repo after `0.4.3` and are not part of the last published release until the next version is cut.
+
+## [0.4.3] - 2026-04-17
+
+### Fixed
+
+- Hardened Pi-backed solve/runtime execution so Pi RPC waits for assistant completion, honors model/context-file options consistently, and solve runs enforce timeout budgets.
+- Preserved generated-scenario family behavior across solve, export, TypeScript `new-scenario`, and `improve` flows, including empty-action family specs and improve calls without an initial output.
+- Made custom scenario loading resilient and diagnosable: malformed specs no longer block registry discovery, spec-only directories surface actionable diagnostics, import-time missing files keep their real reason, and non-agent family specs can auto-materialize Python `scenario.py` sources.
+- Normalized structured agent-task prompt payloads before validation and code generation, so JSON-like sample inputs, reference context, preparation instructions, and revision prompts no longer crash generated runtimes.
+
+### Changed
+
+- Python and TypeScript package metadata are bumped to `0.4.3`.
 
 ## [0.4.2] - 2026-04-16
 
@@ -199,6 +212,7 @@ Changes in this section are on the branch/repo after `0.4.2` and are not part of
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
+[0.4.3]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.2...py-v0.4.3
 [0.4.2]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.1...py-v0.4.2
 [0.4.1]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.0...py-v0.4.1
 [0.4.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.3.7...py-v0.4.0

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ autocontext runs LLM agents through structured scenarios, evaluates their output
 <!-- autocontext-whats-new:start -->
 ## What's New
 
-- All 11 scenario families executable in both Python and TypeScript
-- TypeScript campaign CLI, API, and MCP surfaces shipped for multi-mission coordination
-- Provider expansion: Gemini, Mistral, Groq, OpenRouter, and Azure OpenAI
-- Evidence and privacy hardening with TruffleHog integration and redaction
-- Session-runtime parity across Python and TypeScript surfaces
+- Pi RPC and solve runtime budgets hardened for longer live-agent runs
+- Custom scenario registry diagnostics and spec-to-scenario auto-materialization
+- Structured agent-task JSON payloads now validate and render safely
+- TypeScript new-scenario and improve fallbacks preserve family semantics
+- Generated scenario solve/export paths keep family-specific signals intact
 <!-- autocontext-whats-new:end -->
 
 ## What actually is autocontext?
@@ -211,7 +211,7 @@ The repo publishes two installable packages with different scopes:
 
 - Python package: `pip install autocontext`
 - TypeScript package: `npm install autoctx`
-- Current release line: `autocontext==0.4.2` and `autoctx@0.4.2`
+- Current release line: `autocontext==0.4.3` and `autoctx@0.4.3`
 
 Important:
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -10,7 +10,7 @@ The intended use is to hand the harness a real task in plain language, let it so
 pip install autocontext
 ```
 
-The current PyPI release line is `autocontext==0.4.2`.
+The current PyPI release line is `autocontext==0.4.3`.
 The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
 
 ## Working Directory

--- a/autocontext/assets/whats_new.txt
+++ b/autocontext/assets/whats_new.txt
@@ -1,5 +1,5 @@
-All 11 scenario families executable in both Python and TypeScript
-TypeScript campaign CLI, API, and MCP surfaces shipped for multi-mission coordination
-Provider expansion: Gemini, Mistral, Groq, OpenRouter, and Azure OpenAI
-Evidence and privacy hardening with TruffleHog integration and redaction
-Session-runtime parity across Python and TypeScript surfaces
+Pi RPC and solve runtime budgets hardened for longer live-agent runs
+Custom scenario registry diagnostics and spec-to-scenario auto-materialization
+Structured agent-task JSON payloads now validate and render safely
+TypeScript new-scenario and improve fallbacks preserve family semantics
+Generated scenario solve/export paths keep family-specific signals intact

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autocontext"
-version = "0.4.2"
+version = "0.4.3"
 description = "autocontext control plane for iterative strategy evolution."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/autocontext/src/autocontext/__init__.py
+++ b/autocontext/src/autocontext/__init__.py
@@ -4,4 +4,4 @@ from autocontext.sdk import AutoContext
 
 __all__ = ["AutoContext", "__version__"]
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/autocontext/uv.lock
+++ b/autocontext/uv.lock
@@ -72,7 +72,7 @@ wheels = [
 
 [[package]]
 name = "autocontext"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/ts/README.md
+++ b/ts/README.md
@@ -25,7 +25,7 @@ Need the canonical product/runtime vocabulary first? Start with [docs/concept-mo
 npm install autoctx
 ```
 
-The current npm release line is `autoctx@0.4.2`.
+The current npm release line is `autoctx@0.4.3`.
 Important: use `autoctx`, not `autocontext`.
 `autocontext` on npm is a different package and not this project.
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoctx",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoctx",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoctx",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",

--- a/ts/src/scenarios/materialize-result-support.ts
+++ b/ts/src/scenarios/materialize-result-support.ts
@@ -1,6 +1,6 @@
 import type { ScenarioFamilyName } from "./families.js";
 
-const SUPPORTED_MATERIALIZE_FAMILIES: ScenarioFamilyName[] = [
+const SUPPORTED_MATERIALIZE_FAMILIES = [
   "game",
   "agent_task",
   "simulation",
@@ -12,11 +12,16 @@ const SUPPORTED_MATERIALIZE_FAMILIES: ScenarioFamilyName[] = [
   "tool_fragility",
   "operator_loop",
   "coordination",
-];
+] satisfies readonly ScenarioFamilyName[];
+
+function isSupportedMaterializeFamily(family: string): family is ScenarioFamilyName {
+  const supportedFamilies: readonly string[] = SUPPORTED_MATERIALIZE_FAMILIES;
+  return supportedFamilies.includes(family);
+}
 
 export function coerceMaterializeFamily(family: string): ScenarioFamilyName {
-  if (SUPPORTED_MATERIALIZE_FAMILIES.includes(family as ScenarioFamilyName)) {
-    return family as ScenarioFamilyName;
+  if (isSupportedMaterializeFamily(family)) {
+    return family;
   }
   return "agent_task";
 }

--- a/ts/tests/mission-cli.test.ts
+++ b/ts/tests/mission-cli.test.ts
@@ -196,7 +196,7 @@ describe("autoctx mission lifecycle", () => {
 
     const { stdout } = runCli(["mission", "status", "--id", id], { cwd: dir });
     expect(JSON.parse(stdout).status).toBe("paused");
-  });
+  }, 15000);
 
   it("resume sets status back to active", () => {
     const { stdout: created } = runCli(["mission", "create", "--name", "T", "--goal", "g"], { cwd: dir });
@@ -207,7 +207,7 @@ describe("autoctx mission lifecycle", () => {
 
     const { stdout } = runCli(["mission", "status", "--id", id], { cwd: dir });
     expect(JSON.parse(stdout).status).toBe("active");
-  });
+  }, 15000);
 
   it("cancel sets status to canceled", () => {
     const { stdout: created } = runCli(["mission", "create", "--name", "T", "--goal", "g"], { cwd: dir });
@@ -217,13 +217,13 @@ describe("autoctx mission lifecycle", () => {
 
     const { stdout } = runCli(["mission", "status", "--id", id], { cwd: dir });
     expect(JSON.parse(stdout).status).toBe("canceled");
-  });
+  }, 15000);
 
   it("returns an error for nonexistent mission IDs", () => {
     const { stderr, exitCode } = runCli(["mission", "pause", "--id", "mission-does-not-exist"], { cwd: dir });
     expect(exitCode).toBe(1);
     expect(stderr).toContain("Mission not found: mission-does-not-exist");
-  });
+  }, 15000);
 });
 
 describe("autoctx mission run and artifacts", () => {


### PR DESCRIPTION
## Summary
- Bump Python and TypeScript packages to 0.4.3
- Update CHANGELOG and synced README What's New surfaces
- Reduce TS assertion budget debt by replacing materialization family casts with a type guard
- Align slow mission CLI lifecycle test timeouts with neighboring subprocess integration tests

## Verification
- uv run ruff check src tests
- uv run mypy src
- uv run pytest tests/test_banner_sync.py -q
- uv build
- npm run lint
- npm run build
- npm test
- npm pack --dry-run