### PR TITLE
fix: restore schema-evolution solve routing confidence

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -61,13 +61,56 @@ class LowConfidenceError(Exception):
 # Keyword signal groups per family
 # ---------------------------------------------------------------------------
 
-_STOP_WORDS = frozenset({
-    "a", "an", "the", "and", "or", "of", "for", "to", "in", "on", "at", "by",
-    "is", "are", "was", "be", "do", "does", "it", "we", "they", "i", "you",
-    "that", "can", "should", "could", "would", "will", "must", "with", "which",
-    "what", "how", "where", "when", "about", "create", "build", "make",
-    "new", "need", "want", "scenario", "test", "testing",
-})
+_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "and",
+        "or",
+        "of",
+        "for",
+        "to",
+        "in",
+        "on",
+        "at",
+        "by",
+        "is",
+        "are",
+        "was",
+        "be",
+        "do",
+        "does",
+        "it",
+        "we",
+        "they",
+        "i",
+        "you",
+        "that",
+        "can",
+        "should",
+        "could",
+        "would",
+        "will",
+        "must",
+        "with",
+        "which",
+        "what",
+        "how",
+        "where",
+        "when",
+        "about",
+        "create",
+        "build",
+        "make",
+        "new",
+        "need",
+        "want",
+        "scenario",
+        "test",
+        "testing",
+    }
+)
 
 # Simulation: stateful interaction with environment, action traces
 _SIMULATION_SIGNALS: dict[str, float] = {
@@ -234,13 +277,21 @@ _WORKFLOW_SIGNALS: dict[str, float] = {
 _SCHEMA_EVOLUTION_SIGNALS: dict[str, float] = {
     "schema evolv": 2.0,
     "schema evolution": 2.0,
+    "schema-evolution": 2.0,
+    "schemaevolutioninterface": 2.5,
+    "schemamutation": 2.5,
     "stale context": 2.0,
+    "stale-assumption": 2.0,
     "schema migration": 2.0,
+    "knowledge migration": 2.0,
     "breaking change": 2.0,
+    "breaking mutation": 2.0,
     "schema version": 2.0,
     "field removed": 1.5,
     "field added": 1.5,
     "field renamed": 1.5,
+    "field type": 1.5,
+    "required field": 1.5,
     "context invalidat": 2.0,
     "stale assumption": 2.0,
     "data model change": 1.5,
@@ -391,11 +442,7 @@ def classify_scenario_family(description: str) -> FamilyClassification:
     total = sum(raw_scores.values())
     if total == 0:
         # No signals matched — default to agent_task with low confidence if available.
-        default_family = (
-            _DEFAULT_FAMILY_NAME
-            if _DEFAULT_FAMILY_NAME in registered_families
-            else registered_families[0]
-        )
+        default_family = _DEFAULT_FAMILY_NAME if _DEFAULT_FAMILY_NAME in registered_families else registered_families[0]
         alternatives = [
             FamilyCandidate(
                 family_name=family_name,

--- a/autocontext/tests/test_family_classifier.py
+++ b/autocontext/tests/test_family_classifier.py
@@ -92,8 +92,7 @@ class TestFamilyClassification:
 class TestClassifySimulation:
     def test_api_orchestration(self) -> None:
         result = classify_scenario_family(
-            "Build a scenario where an agent orchestrates API calls across microservices "
-            "and must handle failures with rollback"
+            "Build a scenario where an agent orchestrates API calls across microservices and must handle failures with rollback"
         )
         assert result.family_name == "simulation"
         assert result.confidence >= 0.5
@@ -162,6 +161,25 @@ class TestClassifyWorkflow:
         assert result.family_name == "workflow"
 
 
+class TestClassifySchemaEvolution:
+    def test_schema_evolution_stress_prompt_confidently_routes_to_schema_evolution(self) -> None:
+        result = classify_scenario_family(
+            "Harness Stress Test: schema evolution under pressure — mid-run mutation and knowledge migration\n\n"
+            "## Objective\n\n"
+            "Test whether AutoContext handles mid-run schema changes gracefully — adapting strategies, "
+            "migrating knowledge, and preserving persisted state integrity when the rules change.\n\n"
+            "## Scenario Design\n\n"
+            "Use SchemaEvolutionInterface with SchemaMutation. Start with a stable schema with five "
+            "required fields. Apply a breaking mutation mid-run that adds two new required fields, "
+            "removes one existing field, and modifies the type of one field.\n\n"
+            "## Evaluation Dimensions\n\n"
+            "Stale-assumption detection rate. Recovery quality — Elo trajectory post-mutation. "
+            "Knowledge migration completeness. Persisted state integrity. Adaptation speed."
+        )
+        assert result.family_name == "schema_evolution"
+        assert result.confidence >= 0.3
+
+
 # ---------------------------------------------------------------------------
 # classify_scenario_family — agent_task signals
 # ---------------------------------------------------------------------------
@@ -169,27 +187,19 @@ class TestClassifyWorkflow:
 
 class TestClassifyAgentTask:
     def test_essay_writing(self) -> None:
-        result = classify_scenario_family(
-            "Evaluate an agent's ability to write a persuasive essay about climate change"
-        )
+        result = classify_scenario_family("Evaluate an agent's ability to write a persuasive essay about climate change")
         assert result.family_name == "agent_task"
 
     def test_code_generation(self) -> None:
-        result = classify_scenario_family(
-            "Generate a Python function that sorts a list of dictionaries by multiple keys"
-        )
+        result = classify_scenario_family("Generate a Python function that sorts a list of dictionaries by multiple keys")
         assert result.family_name == "agent_task"
 
     def test_content_summarization(self) -> None:
-        result = classify_scenario_family(
-            "Summarize a long research paper into a concise abstract"
-        )
+        result = classify_scenario_family("Summarize a long research paper into a concise abstract")
         assert result.family_name == "agent_task"
 
     def test_data_analysis_report(self) -> None:
-        result = classify_scenario_family(
-            "Analyze a dataset of customer reviews and produce a sentiment report"
-        )
+        result = classify_scenario_family("Analyze a dataset of customer reviews and produce a sentiment report")
         assert result.family_name == "agent_task"
 
 
@@ -200,9 +210,7 @@ class TestClassifyAgentTask:
 
 class TestClassifyGame:
     def test_board_game(self) -> None:
-        result = classify_scenario_family(
-            "Create a competitive board game where two players compete for territory control"
-        )
+        result = classify_scenario_family("Create a competitive board game where two players compete for territory control")
         assert result.family_name == "game"
 
     def test_strategy_tournament(self) -> None:
@@ -213,9 +221,7 @@ class TestClassifyGame:
         assert result.family_name == "game"
 
     def test_capture_the_flag(self) -> None:
-        result = classify_scenario_family(
-            "Build a capture the flag grid game where opponents navigate a maze"
-        )
+        result = classify_scenario_family("Build a capture the flag grid game where opponents navigate a maze")
         assert result.family_name == "game"
 
 
@@ -226,26 +232,20 @@ class TestClassifyGame:
 
 class TestClassificationAlternatives:
     def test_alternatives_are_ranked_by_confidence(self) -> None:
-        result = classify_scenario_family(
-            "Build a deployment pipeline simulation where the agent must deploy services"
-        )
+        result = classify_scenario_family("Build a deployment pipeline simulation where the agent must deploy services")
         if result.alternatives:
             confidences = [a.confidence for a in result.alternatives]
             assert confidences == sorted(confidences, reverse=True)
 
     def test_alternatives_cover_other_families(self) -> None:
-        result = classify_scenario_family(
-            "Write an essay about the history of computing"
-        )
+        result = classify_scenario_family("Write an essay about the history of computing")
         alt_names = {a.family_name for a in result.alternatives}
         # Alternatives should include families other than the top choice
         assert result.family_name not in alt_names
 
     def test_all_families_represented(self) -> None:
         """Top choice + alternatives should cover all registered families."""
-        result = classify_scenario_family(
-            "Create a scenario for testing API orchestration with rollback"
-        )
+        result = classify_scenario_family("Create a scenario for testing API orchestration with rollback")
         all_names = {result.family_name} | {a.family_name for a in result.alternatives}
         assert all_names == {family.name for family in list_families()}
 
@@ -290,12 +290,8 @@ class TestClassifyEdgeCases:
 
     def test_ambiguous_description_has_lower_confidence(self) -> None:
         """A vague description should produce lower confidence than a clear one."""
-        clear = classify_scenario_family(
-            "Build a competitive two-player board game tournament"
-        )
-        vague = classify_scenario_family(
-            "Do something interesting with data"
-        )
+        clear = classify_scenario_family("Build a competitive two-player board game tournament")
+        vague = classify_scenario_family("Do something interesting with data")
         assert clear.confidence > vague.confidence
 
 
@@ -391,17 +387,13 @@ class TestEndToEnd:
         assert family.evaluation_mode == "trace_evaluation"
 
     def test_agent_task_request_routes_correctly(self) -> None:
-        classification = classify_scenario_family(
-            "Write a persuasive blog post about sustainable energy"
-        )
+        classification = classify_scenario_family("Write a persuasive blog post about sustainable energy")
         family = route_to_family(classification)
         assert family.name == "agent_task"
         assert family.evaluation_mode == "llm_judge"
 
     def test_game_request_routes_correctly(self) -> None:
-        classification = classify_scenario_family(
-            "Design a competitive two-player strategy game with territory control"
-        )
+        classification = classify_scenario_family("Design a competitive two-player strategy game with territory control")
         family = route_to_family(classification)
         assert family.name == "game"
         assert family.evaluation_mode == "tournament"

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -234,6 +234,25 @@ class TestSolveScenarioBuilder:
 
         assert family.name == "coordination"
 
+    def test_resolves_schema_evolution_family_for_ac269_stress_prompt(self) -> None:
+        from autocontext.knowledge.solver import _resolve_requested_scenario_family
+
+        family = _resolve_requested_scenario_family(
+            "Harness Stress Test: schema evolution under pressure — mid-run mutation and knowledge migration\n\n"
+            "## Objective\n\n"
+            "Test whether AutoContext handles mid-run schema changes gracefully — adapting strategies, "
+            "migrating knowledge, and preserving persisted state integrity when the rules change.\n\n"
+            "## Scenario Design\n\n"
+            "Use SchemaEvolutionInterface with SchemaMutation. Start with a stable schema with five "
+            "required fields. Apply a breaking mutation mid-run that adds two new required fields, "
+            "removes one existing field, and modifies the type of one field.\n\n"
+            "## Evaluation Dimensions\n\n"
+            "Stale-assumption detection rate. Recovery quality — Elo trajectory post-mutation. "
+            "Knowledge migration completeness. Persisted state integrity. Adaptation speed."
+        )
+
+        assert family.name == "schema_evolution"
+
     def test_passes_supported_family_hint_into_creator(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from autocontext.knowledge.solver import SolveScenarioBuilder
 


### PR DESCRIPTION
## Summary

- strengthen Python schema-evolution family signals so AC-269-style stress prompts resolve confidently through `solve`
- add regression coverage for both family classification and solve family resolution on representative schema-evolution prompts

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/scenarios/custom/family_classifier.py tests/test_family_classifier.py tests/test_knowledge_solver.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_family_classifier.py tests/test_knowledge_solver.py -k 'schema_evolution or ac269' -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Additional verification:
- `cd autocontext && uv run pytest tests/test_family_classifier.py tests/test_knowledge_solver.py tests/test_scenario_families.py tests/test_artifact_editing.py -k 'schema or solve or family' -x --tb=short`
  - `71 passed, 38 deselected`
- live pi-backed rerun of the representative `AC-269` prompt now completes successfully
  - artifact root: `/tmp/ac564-live-E8NpNm`
  - stdout: `/tmp/ac564-live-E8NpNm/stdout.log`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this fix stays inside the Python family-classifier bounded context and uses explicit schema-evolution domain language already present in the representative prompts (`SchemaEvolutionInterface`, `SchemaMutation`, `knowledge migration`, `required field`)
- no TypeScript changes are included here; the 0.4.3 TypeScript family-fidelity bucket is being tracked separately in AC-566