### PR TITLE
fix: restore geopolitical simulate family routing

### DIFF
--- a/autocontext/src/autocontext/simulation/helpers.py
+++ b/autocontext/src/autocontext/simulation/helpers.py
@@ -7,10 +7,13 @@ import re
 import types
 from typing import Any
 
+# Only explicit human-oversight / clarification semantics should short-circuit to
+# operator_loop here. Broader escalation language belongs to the family classifier,
+# which can still route geopolitical and statecraft prompts to simulation.
 _OPERATOR_LOOP_FAMILY_TRIGGERS = re.compile(
     r"operator|human[- .]?in[- .]?the[- .]?loop|clarif|approval.required|"
-    r"ambiguous|incomplete.input|ask.*question|missing.information|gather.more.info|"
-    r"when.to.escalat|over-escalat|under-escalat|triage.judgment"
+    r"ambiguous.support|incomplete input|ask.*question|missing.information|gather.more.info|"
+    r"when.to.escalat|triage.judgment"
 )
 
 

--- a/autocontext/src/autocontext/simulation/helpers.py
+++ b/autocontext/src/autocontext/simulation/helpers.py
@@ -12,8 +12,12 @@ from typing import Any
 # which can still route geopolitical and statecraft prompts to simulation.
 _OPERATOR_LOOP_FAMILY_TRIGGERS = re.compile(
     r"operator|human[- .]?in[- .]?the[- .]?loop|clarif|approval.required|"
-    r"ambiguous.support|incomplete input|ask.*question|missing.information|gather.more.info|"
-    r"when.to.escalat|triage.judgment"
+    r"ambiguous.support|incomplete input|ask.*question|missing.information|gather.more.info"
+)
+
+_STATECRAFT_SIMULATION_CONTEXT = re.compile(
+    r"geopolit|statecraft|national security|international crisis|international confrontation|"
+    r"crisis wargame|hybrid warfare|military movements|cyber-kinetic"
 )
 
 
@@ -62,6 +66,8 @@ def infer_family(description: str) -> str:
         )
 
         family = route_to_family(classify_scenario_family(description), 0.15).name
+        if family == "operator_loop" and _STATECRAFT_SIMULATION_CONTEXT.search(text_lower):
+            return "simulation"
         return "operator_loop" if family == "operator_loop" else "simulation"
     except Exception:
         return "simulation"

--- a/autocontext/tests/test_simulation_helpers.py
+++ b/autocontext/tests/test_simulation_helpers.py
@@ -13,6 +13,17 @@ class TestInferFamily:
         )
         assert family == "simulation"
 
+    def test_routes_ac276_geopolitical_stress_prompt_to_simulation(self) -> None:
+        family = infer_family(
+            "Harness Stress Test: geopolitical crisis wargame — multi-lever statecraft under hidden "
+            "information and escalation dynamics. Build and run a geopolitical crisis simulation where "
+            "the agent manages an escalating international crisis using NegotiationInterface + WorldState. "
+            "Scenario seeds include Baltic hybrid warfare with ambiguous military movements and a "
+            "cyber-kinetic infrastructure attack with attribution ambiguity. Early generations "
+            "over-escalate or under-respond; later generations calibrate."
+        )
+        assert family == "simulation"
+
     def test_keeps_explicit_operator_loop_prompts_on_operator_loop(self) -> None:
         family = infer_family(
             "Simulate when an agent should escalate to a human operator, request clarification, "

--- a/autocontext/tests/test_simulation_helpers.py
+++ b/autocontext/tests/test_simulation_helpers.py
@@ -24,6 +24,20 @@ class TestInferFamily:
         )
         assert family == "simulation"
 
+    def test_routes_compact_geopolitical_wargame_with_escalation_terms_to_simulation(self) -> None:
+        family = infer_family(
+            "Build a geopolitical crisis wargame with ambiguous military movements "
+            "and over-escalation dynamics"
+        )
+        assert family == "simulation"
+
+    def test_routes_statecraft_when_to_escalate_prompt_to_simulation(self) -> None:
+        family = infer_family(
+            "Simulate when to escalate diplomatic pressure during an international crisis "
+            "with national security tradeoffs"
+        )
+        assert family == "simulation"
+
     def test_keeps_explicit_operator_loop_prompts_on_operator_loop(self) -> None:
         family = infer_family(
             "Simulate when an agent should escalate to a human operator, request clarification, "


### PR DESCRIPTION
## Summary

- tighten the Python simulate operator-loop fast path so broader geopolitical/statecraft prompts no longer collapse into `operator_loop`
- add regression coverage for the representative AC-276-style geopolitical stress prompt

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/simulation/helpers.py tests/test_simulation_helpers.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_simulation_helpers.py -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Additional verification:
- `cd autocontext && uv run pytest tests/test_family_classifier.py tests/test_simulation_helpers.py tests/test_operator_loop_unsupported.py tests/test_negotiation.py tests/test_simulate_command.py -k 'family or infer_family or negotiation or operator_loop or simulation' -x --tb=short`
  - `93 passed, 9 deselected`
- live pi-backed representative repro before fix:
  - `/tmp/ac565-live-repro-xNqiCB/stdout.log`
  - observed `family: "operator_loop"`
- live pi-backed representative rerun after fix with a higher Pi timeout:
  - `/tmp/ac565-live-fix-timeout-0nNwRp/stdout.log`
  - observed `family: "simulation"`, `status: "completed"`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this fix stays inside the Python simulate family-boundary helper and preserves the DDD distinction between:
  - explicit human-oversight / clarification prompts → `operator_loop`
  - broader escalation/statecraft prompts → `simulation`
- no TypeScript changes are included here