### PR TITLE
fix: restore ts family-aware scenario materialization

### DIFF
--- a/ts/src/scenarios/coordination-designer.ts
+++ b/ts/src/scenarios/coordination-designer.ts
@@ -1,6 +1,7 @@
 import type { CoordinationSpec } from "./coordination-spec.js";
 import { parseRawCoordinationSpec } from "./coordination-spec.js";
 import { healSpec } from "./spec-auto-heal.js";
+import { parseDelimitedJsonObject } from "./llm-json-response.js";
 
 export const COORDINATION_SPEC_START = "<!-- COORDINATION_SPEC_START -->";
 export const COORDINATION_SPEC_END = "<!-- COORDINATION_SPEC_END -->";
@@ -80,14 +81,16 @@ ${COORDINATION_SPEC_END}
 `;
 
 export function parseCoordinationSpec(text: string): CoordinationSpec {
-  const startIdx = text.indexOf(COORDINATION_SPEC_START);
-  const endIdx = text.indexOf(COORDINATION_SPEC_END);
-  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
-    throw new Error("response does not contain COORDINATION_SPEC delimiters");
-  }
-  const raw = text.slice(startIdx + COORDINATION_SPEC_START.length, endIdx).trim();
   return parseRawCoordinationSpec(
-    healSpec(JSON.parse(raw) as Record<string, unknown>, "coordination"),
+    healSpec(
+      parseDelimitedJsonObject({
+        text,
+        startDelimiter: COORDINATION_SPEC_START,
+        endDelimiter: COORDINATION_SPEC_END,
+        missingDelimiterLabel: "COORDINATION_SPEC",
+      }),
+      "coordination",
+    ),
   );
 }
 

--- a/ts/src/scenarios/family-classifier-signals.ts
+++ b/ts/src/scenarios/family-classifier-signals.ts
@@ -163,6 +163,8 @@ const SCHEMA_EVOLUTION_SIGNALS: Record<string, number> = {
   "schema evolv": 2.0,
   "schema evolution": 2.0,
   "schema-evolution": 2.0,
+  schemaevolutioninterface: 2.5,
+  schemamutation: 2.5,
   "stale context": 2.0,
   "schema migration": 2.0,
   "breaking change": 2.0,

--- a/ts/src/scenarios/investigation-designer.ts
+++ b/ts/src/scenarios/investigation-designer.ts
@@ -1,6 +1,7 @@
 import type { InvestigationSpec } from "./investigation-spec.js";
 import { parseRawInvestigationSpec } from "./investigation-spec.js";
 import { healSpec } from "./spec-auto-heal.js";
+import { parseDelimitedJsonObject } from "./llm-json-response.js";
 
 export const INVESTIGATION_SPEC_START = "<!-- INVESTIGATION_SPEC_START -->";
 export const INVESTIGATION_SPEC_END = "<!-- INVESTIGATION_SPEC_END -->";
@@ -86,14 +87,16 @@ ${INVESTIGATION_SPEC_END}
 `;
 
 export function parseInvestigationSpec(text: string): InvestigationSpec {
-  const startIdx = text.indexOf(INVESTIGATION_SPEC_START);
-  const endIdx = text.indexOf(INVESTIGATION_SPEC_END);
-  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
-    throw new Error("response does not contain INVESTIGATION_SPEC delimiters");
-  }
-  const raw = text.slice(startIdx + INVESTIGATION_SPEC_START.length, endIdx).trim();
   return parseRawInvestigationSpec(
-    healSpec(JSON.parse(raw) as Record<string, unknown>, "investigation"),
+    healSpec(
+      parseDelimitedJsonObject({
+        text,
+        startDelimiter: INVESTIGATION_SPEC_START,
+        endDelimiter: INVESTIGATION_SPEC_END,
+        missingDelimiterLabel: "INVESTIGATION_SPEC",
+      }),
+      "investigation",
+    ),
   );
 }
 

--- a/ts/src/scenarios/llm-json-response.ts
+++ b/ts/src/scenarios/llm-json-response.ts
@@ -1,0 +1,43 @@
+export function parseJsonObjectFromResponse(text: string): Record<string, unknown> | null {
+  const trimmed = text.trim();
+
+  try {
+    return JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    // continue
+  }
+
+  const jsonStart = trimmed.indexOf("{");
+  const jsonEnd = trimmed.lastIndexOf("}");
+  if (jsonStart !== -1 && jsonEnd > jsonStart) {
+    try {
+      return JSON.parse(trimmed.slice(jsonStart, jsonEnd + 1)) as Record<string, unknown>;
+    } catch {
+      // continue
+    }
+  }
+
+  return null;
+}
+
+export function parseDelimitedJsonObject(opts: {
+  text: string;
+  startDelimiter: string;
+  endDelimiter: string;
+  missingDelimiterLabel: string;
+}): Record<string, unknown> {
+  const { text, startDelimiter, endDelimiter, missingDelimiterLabel } = opts;
+  const startIdx = text.indexOf(startDelimiter);
+  const endIdx = text.indexOf(endDelimiter);
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const raw = text.slice(startIdx + startDelimiter.length, endIdx).trim();
+    return JSON.parse(raw) as Record<string, unknown>;
+  }
+
+  const parsed = parseJsonObjectFromResponse(text);
+  if (parsed) {
+    return parsed;
+  }
+
+  throw new Error(`response does not contain ${missingDelimiterLabel} delimiters`);
+}

--- a/ts/src/scenarios/negotiation-designer.ts
+++ b/ts/src/scenarios/negotiation-designer.ts
@@ -1,6 +1,7 @@
 import type { NegotiationSpec } from "./negotiation-spec.js";
 import { parseRawNegotiationSpec } from "./negotiation-spec.js";
 import { healSpec } from "./spec-auto-heal.js";
+import { parseDelimitedJsonObject } from "./llm-json-response.js";
 
 export const NEGOTIATION_SPEC_START = "<!-- NEGOTIATION_SPEC_START -->";
 export const NEGOTIATION_SPEC_END = "<!-- NEGOTIATION_SPEC_END -->";
@@ -91,14 +92,16 @@ ${NEGOTIATION_SPEC_END}
 `;
 
 export function parseNegotiationSpec(text: string): NegotiationSpec {
-  const startIdx = text.indexOf(NEGOTIATION_SPEC_START);
-  const endIdx = text.indexOf(NEGOTIATION_SPEC_END);
-  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
-    throw new Error("response does not contain NEGOTIATION_SPEC delimiters");
-  }
-  const raw = text.slice(startIdx + NEGOTIATION_SPEC_START.length, endIdx).trim();
   return parseRawNegotiationSpec(
-    healSpec(JSON.parse(raw) as Record<string, unknown>, "negotiation"),
+    healSpec(
+      parseDelimitedJsonObject({
+        text,
+        startDelimiter: NEGOTIATION_SPEC_START,
+        endDelimiter: NEGOTIATION_SPEC_END,
+        missingDelimiterLabel: "NEGOTIATION_SPEC",
+      }),
+      "negotiation",
+    ),
   );
 }
 

--- a/ts/src/scenarios/operator-loop-designer.ts
+++ b/ts/src/scenarios/operator-loop-designer.ts
@@ -1,6 +1,7 @@
 import type { OperatorLoopSpec } from "./operator-loop-spec.js";
 import { parseRawOperatorLoopSpec } from "./operator-loop-spec.js";
 import { healSpec } from "./spec-auto-heal.js";
+import { parseDelimitedJsonObject } from "./llm-json-response.js";
 
 export const OPERATOR_LOOP_SPEC_START = "<!-- OPERATOR_LOOP_SPEC_START -->";
 export const OPERATOR_LOOP_SPEC_END = "<!-- OPERATOR_LOOP_SPEC_END -->";
@@ -41,14 +42,16 @@ Rules:
 `;
 
 export function parseOperatorLoopSpec(text: string): OperatorLoopSpec {
-  const startIdx = text.indexOf(OPERATOR_LOOP_SPEC_START);
-  const endIdx = text.indexOf(OPERATOR_LOOP_SPEC_END);
-  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
-    throw new Error("response does not contain OPERATOR_LOOP_SPEC delimiters");
-  }
-  const raw = text.slice(startIdx + OPERATOR_LOOP_SPEC_START.length, endIdx).trim();
   return parseRawOperatorLoopSpec(
-    healSpec(JSON.parse(raw) as Record<string, unknown>, "operator_loop"),
+    healSpec(
+      parseDelimitedJsonObject({
+        text,
+        startDelimiter: OPERATOR_LOOP_SPEC_START,
+        endDelimiter: OPERATOR_LOOP_SPEC_END,
+        missingDelimiterLabel: "OPERATOR_LOOP_SPEC",
+      }),
+      "operator_loop",
+    ),
   );
 }
 

--- a/ts/src/scenarios/scenario-creator.ts
+++ b/ts/src/scenarios/scenario-creator.ts
@@ -57,6 +57,30 @@ type SimulationLikeCreatedSpecInput = {
   extras?: Record<string, unknown>;
 };
 
+const FAMILY_HEADER_REGEX = /^\*\*Family:\*\*\s*(.+)$/im;
+
+function resolveScenarioFamilyHint(description: string): ScenarioFamilyName | null {
+  const match = FAMILY_HEADER_REGEX.exec(description);
+  if (!match) {
+    return null;
+  }
+
+  const rawHint = match[1] ?? "";
+  for (const token of rawHint.split(/[\/,|]/)) {
+    const candidate = token
+      .toLowerCase()
+      .replace(/[^a-z0-9_\-\s]/g, " ")
+      .trim()
+      .replace(/-/g, "_")
+      .replace(/\s+/g, "_");
+    if (isScenarioFamilyName(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
 /**
  * Derive a snake_case scenario name from a description.
  */
@@ -86,6 +110,12 @@ export function deriveScenarioName(description: string): string {
  */
 export function detectScenarioFamily(description: string): ScenarioFamilyName {
   if (!description.trim()) return "agent_task";
+
+  const hintedFamily = resolveScenarioFamilyHint(description);
+  if (hintedFamily) {
+    return hintedFamily === "game" ? "agent_task" : hintedFamily;
+  }
+
   try {
     const family = routeToFamily(classifyScenarioFamily(description), 0.15);
     return family === "game" ? "agent_task" : family;

--- a/ts/src/scenarios/scenario-revision-execution.ts
+++ b/ts/src/scenarios/scenario-revision-execution.ts
@@ -1,4 +1,5 @@
 import type { LLMProvider } from "../types/index.js";
+import { parseJsonObjectFromResponse } from "./llm-json-response.js";
 import { normalizeScenarioRevisionSpec } from "./revision-spec-normalizer.js";
 
 export interface ExecuteScenarioRevisionOpts {
@@ -16,27 +17,7 @@ export interface ExecutedScenarioRevisionResult {
   error?: string;
 }
 
-export function parseJsonFromLLMResponse(text: string): Record<string, unknown> | null {
-  const trimmed = text.trim();
-
-  try {
-    return JSON.parse(trimmed);
-  } catch {
-    // continue
-  }
-
-  const jsonStart = trimmed.indexOf("{");
-  const jsonEnd = trimmed.lastIndexOf("}");
-  if (jsonStart !== -1 && jsonEnd > jsonStart) {
-    try {
-      return JSON.parse(trimmed.slice(jsonStart, jsonEnd + 1));
-    } catch {
-      // continue
-    }
-  }
-
-  return null;
-}
+export const parseJsonFromLLMResponse = parseJsonObjectFromResponse;
 
 export async function executeScenarioRevision(
   opts: ExecuteScenarioRevisionOpts,

--- a/ts/src/scenarios/schema-evolution-designer.ts
+++ b/ts/src/scenarios/schema-evolution-designer.ts
@@ -1,6 +1,7 @@
 import type { SchemaEvolutionSpec } from "./schema-evolution-spec.js";
 import { parseRawSchemaEvolutionSpec } from "./schema-evolution-spec.js";
 import { healSpec } from "./spec-auto-heal.js";
+import { parseDelimitedJsonObject } from "./llm-json-response.js";
 
 export const SCHEMA_EVOLUTION_SPEC_START = "<!-- SCHEMA_EVOLUTION_SPEC_START -->";
 export const SCHEMA_EVOLUTION_SPEC_END = "<!-- SCHEMA_EVOLUTION_SPEC_END -->";
@@ -100,14 +101,16 @@ ${SCHEMA_EVOLUTION_SPEC_END}
 `;
 
 export function parseSchemaEvolutionSpec(text: string): SchemaEvolutionSpec {
-  const startIdx = text.indexOf(SCHEMA_EVOLUTION_SPEC_START);
-  const endIdx = text.indexOf(SCHEMA_EVOLUTION_SPEC_END);
-  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
-    throw new Error("response does not contain SCHEMA_EVOLUTION_SPEC delimiters");
-  }
-  const raw = text.slice(startIdx + SCHEMA_EVOLUTION_SPEC_START.length, endIdx).trim();
   return parseRawSchemaEvolutionSpec(
-    healSpec(JSON.parse(raw) as Record<string, unknown>, "schema_evolution"),
+    healSpec(
+      parseDelimitedJsonObject({
+        text,
+        startDelimiter: SCHEMA_EVOLUTION_SPEC_START,
+        endDelimiter: SCHEMA_EVOLUTION_SPEC_END,
+        missingDelimiterLabel: "SCHEMA_EVOLUTION_SPEC",
+      }),
+      "schema_evolution",
+    ),
   );
 }
 

--- a/ts/src/scenarios/simulation-designer.ts
+++ b/ts/src/scenarios/simulation-designer.ts
@@ -1,6 +1,7 @@
 import type { SimulationSpec } from "./simulation-spec.js";
 import { parseRawSimulationSpec } from "./simulation-spec.js";
 import { healSpec } from "./spec-auto-heal.js";
+import { parseDelimitedJsonObject } from "./llm-json-response.js";
 
 export const SIM_SPEC_START = "<!-- SIMULATION_SPEC_START -->";
 export const SIM_SPEC_END = "<!-- SIMULATION_SPEC_END -->";
@@ -73,14 +74,16 @@ ${SIM_SPEC_END}
 `;
 
 export function parseSimulationSpec(text: string): SimulationSpec {
-  const startIdx = text.indexOf(SIM_SPEC_START);
-  const endIdx = text.indexOf(SIM_SPEC_END);
-  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
-    throw new Error("response does not contain SIMULATION_SPEC delimiters");
-  }
-  const raw = text.slice(startIdx + SIM_SPEC_START.length, endIdx).trim();
   return parseRawSimulationSpec(
-    healSpec(JSON.parse(raw) as Record<string, unknown>, "simulation"),
+    healSpec(
+      parseDelimitedJsonObject({
+        text,
+        startDelimiter: SIM_SPEC_START,
+        endDelimiter: SIM_SPEC_END,
+        missingDelimiterLabel: "SIMULATION_SPEC",
+      }),
+      "simulation",
+    ),
   );
 }
 

--- a/ts/src/scenarios/workflow-designer.ts
+++ b/ts/src/scenarios/workflow-designer.ts
@@ -1,6 +1,7 @@
 import type { WorkflowSpec } from "./workflow-spec.js";
 import { parseRawWorkflowSpec } from "./workflow-spec.js";
 import { healSpec } from "./spec-auto-heal.js";
+import { parseDelimitedJsonObject } from "./llm-json-response.js";
 
 export const WORKFLOW_SPEC_START = "<!-- WORKFLOW_SPEC_START -->";
 export const WORKFLOW_SPEC_END = "<!-- WORKFLOW_SPEC_END -->";
@@ -112,14 +113,16 @@ ${WORKFLOW_SPEC_END}
 `;
 
 export function parseWorkflowSpec(text: string): WorkflowSpec {
-  const startIdx = text.indexOf(WORKFLOW_SPEC_START);
-  const endIdx = text.indexOf(WORKFLOW_SPEC_END);
-  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
-    throw new Error("response does not contain WORKFLOW_SPEC delimiters");
-  }
-  const raw = text.slice(startIdx + WORKFLOW_SPEC_START.length, endIdx).trim();
   return parseRawWorkflowSpec(
-    healSpec(JSON.parse(raw) as Record<string, unknown>, "workflow"),
+    healSpec(
+      parseDelimitedJsonObject({
+        text,
+        startDelimiter: WORKFLOW_SPEC_START,
+        endDelimiter: WORKFLOW_SPEC_END,
+        missingDelimiterLabel: "WORKFLOW_SPEC",
+      }),
+      "workflow",
+    ),
   );
 }
 

--- a/ts/tests/scenario-creator-family-aware.test.ts
+++ b/ts/tests/scenario-creator-family-aware.test.ts
@@ -93,6 +93,172 @@ describe("createScenarioFromDescription family-aware routing", () => {
     });
   });
 
+  it("keeps simulation family when the simulation designer returns raw JSON without delimiters", async () => {
+    const simulationSpec = {
+      description: "Geopolitical crisis management under hidden adversary intentions",
+      environment_description:
+        "A multi-actor international crisis with military posture shifts, alliance politics, economic pressure, and cyber disruptions.",
+      initial_state_description:
+        "A confrontation is intensifying and allied governments are asking for coordination.",
+      success_criteria: [
+        "Stabilize the confrontation without uncontrolled escalation.",
+        "Sequence diplomatic, economic, military, and cyber actions coherently.",
+      ],
+      failure_modes: [
+        "Escalate the crisis through poorly coordinated signaling.",
+        "Ignore hidden adversary intentions and misread the confrontation.",
+      ],
+      max_steps: 10,
+      actions: [
+        {
+          name: "update_intelligence_picture",
+          description: "Refresh the intelligence picture.",
+          parameters: { collection_focus: "string" },
+          preconditions: [],
+          effects: ["intelligence_picture_updated"],
+        },
+        {
+          name: "open_backchannel_contact",
+          description: "Open a diplomatic off-ramp.",
+          parameters: { counterpart: "string" },
+          preconditions: ["update_intelligence_picture"],
+          effects: ["backchannel_opened"],
+        },
+      ],
+    };
+
+    const provider = {
+      defaultModel: () => "mock-model",
+      complete: vi.fn(async ({ systemPrompt }: { systemPrompt?: string }) => {
+        if (systemPrompt?.includes("produce a SimulationSpec JSON")) {
+          return {
+            text: JSON.stringify(simulationSpec),
+            model: "mock-model",
+            usage: { inputTokens: 0, outputTokens: 0 },
+          };
+        }
+
+        return {
+          text: JSON.stringify({
+            family: "simulation",
+            name: "geopolitical_crisis_simulation",
+            taskPrompt: "Coordinate the crisis response.",
+            rubric: "Prioritize de-escalation and clear reasoning.",
+            description: "A bare fallback payload without simulation actions.",
+          }),
+          model: "mock-model",
+          usage: { inputTokens: 0, outputTokens: 0 },
+        };
+      }),
+    };
+
+    const created = await createScenarioFromDescription(
+      "Create a geopolitical crisis simulation where a national security advisor manages an escalating international crisis using diplomatic, economic, military, intelligence, public communication, alliance, UN, and cyber actions under hidden adversary intentions and escalation thresholds.",
+      provider as never,
+    );
+
+    expect(created.family).toBe("simulation");
+    expect(created.spec.description).toBe(simulationSpec.description);
+    expect(created.spec.actions).toEqual([
+      expect.objectContaining({ name: "update_intelligence_picture" }),
+      expect.objectContaining({ name: "open_backchannel_contact" }),
+    ]);
+  });
+
+  it("keeps schema_evolution family when the designer returns raw JSON without delimiters", async () => {
+    const schemaEvolutionSpec = {
+      description: "Portfolio adaptation across changing market regimes",
+      environment_description:
+        "A market simulation with macro indicators, portfolio exposures, and regime shocks.",
+      initial_state_description:
+        "A balanced portfolio is deployed before a breaking regime mutation hits.",
+      mutations: [
+        {
+          version: 2,
+          description: "Interest-rate regime flips bond-equity correlations.",
+          breaking: true,
+          fields_added: ["yield_curve_slope"],
+          fields_removed: ["low_vol_assumption"],
+          fields_modified: { duration_risk: "low -> elevated" },
+        },
+        {
+          version: 3,
+          description: "Crisis regime pushes cross-asset correlations toward one.",
+          breaking: true,
+          fields_added: ["liquidity_stress"],
+          fields_removed: ["stable_correlation_matrix"],
+          fields_modified: { volatility_regime: "moderate -> crisis" },
+        },
+      ],
+      success_criteria: [
+        "Adjust allocations before drawdown becomes severe.",
+        "Restore risk-adjusted performance after each regime mutation.",
+      ],
+      failure_modes: [
+        "Hold stale allocations after a regime break.",
+        "Recover too slowly after crisis volatility spikes.",
+      ],
+      max_steps: 9,
+      actions: [
+        {
+          name: "assess_regime_signals",
+          description: "Review macro and volatility signals to classify the current regime.",
+          parameters: { signal_window: "string" },
+          preconditions: [],
+          effects: ["regime_assessed"],
+        },
+        {
+          name: "rebalance_portfolio",
+          description: "Adjust the portfolio to align with the current regime outlook.",
+          parameters: { allocation_model: "string" },
+          preconditions: ["assess_regime_signals"],
+          effects: ["portfolio_rebalanced"],
+        },
+      ],
+    };
+
+    const provider = {
+      defaultModel: () => "mock-model",
+      complete: vi.fn(async ({ systemPrompt }: { systemPrompt?: string }) => {
+        if (systemPrompt?.includes("produce a SchemaEvolutionSpec JSON")) {
+          return {
+            text: JSON.stringify(schemaEvolutionSpec),
+            model: "mock-model",
+            usage: { inputTokens: 0, outputTokens: 0 },
+          };
+        }
+
+        return {
+          text: JSON.stringify({
+            family: "schema_evolution",
+            name: "portfolio_regime_shift",
+            taskPrompt: "Manage allocations across regime shifts.",
+            rubric: "Track recovery after breaking mutations.",
+            description: "A bare fallback payload without schema-evolution actions.",
+          }),
+          model: "mock-model",
+          usage: { inputTokens: 0, outputTokens: 0 },
+        };
+      }),
+    };
+
+    const created = await createScenarioFromDescription(
+      "Build and run a 10-generation portfolio construction simulation using SchemaEvolutionInterface and WorldState. Each generation, the agent receives macro indicators, volatility metrics, geopolitical signals, and the current portfolio. After generation 3 apply a breaking SchemaMutation for a rate-hike regime, and after generation 6 apply a breaking SchemaMutation for a crisis regime. The agent should maintain and evolve a playbook of regime-specific investment heuristics across mutations.",
+      provider as never,
+    );
+
+    expect(created.family).toBe("schema_evolution");
+    expect(created.spec.description).toBe(schemaEvolutionSpec.description);
+    expect(created.spec.mutations).toEqual([
+      expect.objectContaining({ version: 2, breaking: true }),
+      expect.objectContaining({ version: 3, breaking: true }),
+    ]);
+    expect(created.spec.actions).toEqual([
+      expect.objectContaining({ name: "assess_regime_signals" }),
+      expect.objectContaining({ name: "rebalance_portfolio" }),
+    ]);
+  });
+
   it("falls back to agent_task when family-aware simulation creation degrades to a core-only generic spec", async () => {
     const provider = {
       defaultModel: () => "mock-model",

--- a/ts/tests/unified-classifier.test.ts
+++ b/ts/tests/unified-classifier.test.ts
@@ -96,6 +96,20 @@ describe("detectScenarioFamily routes all custom-scenario families (AC-437)", ()
     expect(family).toBe("schema_evolution");
   });
 
+  it("routes the AC-277 portfolio regime-change stress prompt to schema_evolution", () => {
+    const family = detectScenarioFamily(
+      "Build and run a 10-generation portfolio construction simulation using SchemaEvolutionInterface and WorldState. Each generation, the agent receives macro indicators, volatility metrics, geopolitical signals, and the current portfolio. After generation 3 apply a breaking SchemaMutation for a rate-hike regime, and after generation 6 apply a breaking SchemaMutation for a crisis regime. The agent should maintain and evolve a playbook of regime-specific investment heuristics across mutations.",
+    );
+    expect(family).toBe("schema_evolution");
+  });
+
+  it("prefers a supported Family header from scenario proposal metadata", () => {
+    const family = detectScenarioFamily(
+      "## Scenario Proposal\n\n**Family:** coordination / adversarial_self_play\n\n### Description\n\nThree instances collaborate in role rotation to critique and revise the same artifact.",
+    );
+    expect(family).toBe("coordination");
+  });
+
   it("routes tool_fragility descriptions correctly", () => {
     const family = detectScenarioFamily(
       "Test agent behavior when tool drift causes API contract changes requiring adaptation",


### PR DESCRIPTION
## Summary

- restore TypeScript family-aware `new-scenario` materialization when designers return raw JSON instead of delimiter-wrapped JSON
- strengthen broader family detection so schema-evolution prompts and supported `**Family:** ...` scenario-proposal headers keep their richer family semantics instead of collapsing into `agent_task`

## Surfaces Touched

- [ ] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [ ] `cd autocontext && uv run ruff check ...`
- [ ] `cd autocontext && uv run mypy ...`
- [ ] `cd autocontext && uv run pytest ...`
- [x] `cd ts && npm run lint`
- [x] `cd ts && npm test`
- [x] additional manual verification described below

Additional verification:
- `cd ts && npx vitest run tests/unified-classifier.test.ts tests/scenario-creator-family-aware.test.ts`
  - `41 passed`
- `cd ts && npx vitest run tests/unified-classifier.test.ts tests/scenario-creator-family-aware.test.ts tests/new-scenario-broader-family-materialization.test.ts tests/new-scenario-command-workflow.test.ts tests/new-scenario-created-materialization.test.ts tests/new-scenario-family-resolution.test.ts tests/new-scenario-normalization-workflow.test.ts tests/new-scenario-materialization-execution.test.ts tests/materialize-codegen-planning.test.ts tests/execution-validator.test.ts`
  - `81 passed`
- live pi-backed representative reruns:
  - `/tmp/ac566-live-fzz0AO/AC-269/stdout.log` → `family: "schema_evolution"`, `generatedSource: true`
  - `/tmp/ac566-live-fzz0AO/AC-276/stdout.log` → `family: "simulation"`, `generatedSource: true`
  - `/tmp/ac566-live-fzz0AO/AC-277/stdout.log` → `family: "schema_evolution"`, `generatedSource: true`
- live current-scenario proposal rerun:
  - `/tmp/ac566-live-current-1Egyn9/stdout.log` → `family: "coordination"`, `generatedSource: true`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- adds a shared DRY JSON-response helper at `ts/src/scenarios/llm-json-response.ts`
- family-aware designers now accept either delimiter-wrapped JSON or raw JSON object responses, reducing silent fallback into generic `agent_task`
- `detectScenarioFamily(...)` now honors a supported `**Family:** ...` header before weighted classification, mirroring the domain intent already encoded in scenario proposals
- unsupported proposal families still fall back to the weighted classifier / existing safety paths