### PR TITLE
fix: stabilize python solve scenario generation

### DIFF
--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -35,6 +35,28 @@ class _NamedScenario(Protocol):
 
 
 _FAMILY_HEADER_RE = re.compile(r"^\s*\*{0,2}family\*{0,2}:\s*(?P<body>.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+_SOLVE_DESCRIPTION_SKIP_SECTIONS = frozenset(
+    {
+        "Why This Matters",
+        "What This Tests",
+        "Implementation Guidance",
+        "Acceptance",
+        "Why existing scenarios don't cover this",
+        "Dependencies",
+    }
+)
+_SOLVE_DESCRIPTION_SKIP_LINE_PREFIXES = (
+    "**Priority:**",
+    "**Generations to signal:**",
+)
+_SOLVE_FAMILY_ALIASES = {
+    "meta_learning": "agent_task",
+}
+_SIMULATION_INTERFACE_HINT_RE = re.compile(
+    r"\bsimulationinterface\b.*\bworldstate\b|\bworldstate\b.*\bsimulationinterface\b",
+    re.IGNORECASE | re.DOTALL,
+)
+_AGENT_TASK_INTERFACE_HINT_RE = re.compile(r"\bagent[- ]task evaluation\b", re.IGNORECASE)
 
 
 @dataclass
@@ -267,6 +289,34 @@ class _BudgetedAgentTask(AgentTaskInterface):
         return result
 
 
+def _build_solve_description_brief(description: str) -> str:
+    lines: list[str] = []
+    skipping_section = False
+    for raw_line in description.splitlines():
+        heading_match = re.match(r"^\s*#{2,6}\s+(.+?)\s*$", raw_line)
+        if heading_match is not None:
+            title = heading_match.group(1).strip()
+            skipping_section = title in _SOLVE_DESCRIPTION_SKIP_SECTIONS
+            if not skipping_section:
+                lines.append(raw_line)
+            continue
+
+        stripped = raw_line.strip()
+        if stripped.startswith(_SOLVE_DESCRIPTION_SKIP_LINE_PREFIXES):
+            continue
+        if not skipping_section:
+            lines.append(raw_line)
+
+    brief = "\n".join(lines).strip()
+    brief = re.sub(r"\n{3,}", "\n\n", brief)
+    return brief or description.strip()
+
+
+def _normalize_family_hint_token(token: str) -> str:
+    normalized = re.sub(r"[^a-z0-9_\-\s]", " ", token.lower()).strip()
+    return normalized.replace("-", "_").replace(" ", "_")
+
+
 def _resolve_family_hint(description: str) -> ScenarioFamily | None:
     from autocontext.scenarios.families import get_family, list_families
 
@@ -277,20 +327,43 @@ def _resolve_family_hint(description: str) -> ScenarioFamily | None:
     supported = {family.name: family for family in list_families()}
     raw_hint = match.group("body")
     for token in re.split(r"[/,|]", raw_hint):
-        normalized = re.sub(r"[^a-z0-9_\-\s]", " ", token.lower()).strip()
-        candidate = normalized.replace("-", "_").replace(" ", "_")
+        candidate = _normalize_family_hint_token(token)
         if candidate in supported:
             return get_family(candidate)
+    return None
+
+
+def _resolve_solve_family_alias(description: str) -> ScenarioFamily | None:
+    from autocontext.scenarios.families import get_family
+
+    match = _FAMILY_HEADER_RE.search(description)
+    if match is not None:
+        for token in re.split(r"[/,|]", match.group("body")):
+            candidate = _normalize_family_hint_token(token)
+            aliased = _SOLVE_FAMILY_ALIASES.get(candidate)
+            if aliased is not None:
+                return get_family(aliased)
+
+    if _SIMULATION_INTERFACE_HINT_RE.search(description):
+        return get_family("simulation")
+    if _AGENT_TASK_INTERFACE_HINT_RE.search(description):
+        return get_family("agent_task")
     return None
 
 
 def _resolve_requested_scenario_family(description: str) -> ScenarioFamily:
     from autocontext.scenarios.custom.family_classifier import classify_scenario_family, route_to_family
 
-    hinted_family = _resolve_family_hint(description)
+    brief = _build_solve_description_brief(description)
+    hinted_family = _resolve_family_hint(brief)
     if hinted_family is not None:
         return hinted_family
-    classification = classify_scenario_family(description)
+
+    aliased_family = _resolve_solve_family_alias(brief)
+    if aliased_family is not None:
+        return aliased_family
+
+    classification = classify_scenario_family(brief)
     return route_to_family(classification)
 
 
@@ -484,7 +557,8 @@ class SolveScenarioBuilder:
         from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
         from autocontext.scenarios.custom.creator import ScenarioCreator
 
-        family = _resolve_requested_scenario_family(description)
+        brief = _build_solve_description_brief(description)
+        family = _resolve_requested_scenario_family(brief)
 
         if family.name == "game":
             game_creator = ScenarioCreator(
@@ -492,7 +566,7 @@ class SolveScenarioBuilder:
                 model=self._model,
                 knowledge_root=self._knowledge_root,
             )
-            spec = game_creator.generate_spec(description)
+            spec = game_creator.generate_spec(brief)
             build = game_creator.build_and_validate(spec)
             SCENARIO_REGISTRY[spec.name] = build.scenario_class
             return SolveScenarioBuildResult(
@@ -504,7 +578,7 @@ class SolveScenarioBuilder:
             llm_fn=self._llm_fn,
             knowledge_root=self._knowledge_root,
         )
-        scenario = family_creator.create(description, family_name=family.name)
+        scenario = family_creator.create(brief, family_name=family.name)
         scenario_name = str(cast(_NamedScenario, scenario).name)
         SCENARIO_REGISTRY[scenario_name] = scenario.__class__
         return SolveScenarioBuildResult(
@@ -518,7 +592,7 @@ def _llm_fn_from_client(client: Any, model: str) -> LlmFn:
         response = client.generate(
             model=model,
             prompt=f"{system}\n\n{user}",
-            max_tokens=3000,
+            max_tokens=1800,
             temperature=0.3,
             role="scenario_designer",
         )
@@ -605,11 +679,12 @@ class SolveManager:
 
             client = build_client_from_settings(self._settings)
             runtime = SubagentRuntime(client)
-            llm_fn = _llm_fn_from_client(client, self._settings.model_architect)
+            designer_model = self._settings.model_translator or self._settings.model_architect
+            llm_fn = _llm_fn_from_client(client, designer_model)
             return SolveScenarioBuilder(
                 runtime=runtime,
                 llm_fn=llm_fn,
-                model=self._settings.model_architect,
+                model=designer_model,
                 knowledge_root=self._settings.knowledge_root,
             )
         except Exception:

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -99,12 +99,20 @@ class AgentTaskCreator:
 
         # 1. Design
         logger.info("designing agent task from description")
-        spec = design_agent_task(description, self.llm_fn)
+        try:
+            spec = design_agent_task(description, self.llm_fn)
+        except Exception:
+            logger.warning("agent task design failed on first attempt; retrying once", exc_info=True)
+            spec = design_agent_task(description, self.llm_fn)
 
         # 1.5 Auto-heal: generate synthetic sample_input if needed (AC-309)
-        from autocontext.scenarios.custom.spec_auto_heal import heal_spec_sample_input
+        from autocontext.scenarios.custom.spec_auto_heal import (
+            heal_spec_runtime_context_requirements,
+            heal_spec_sample_input,
+        )
 
         spec = heal_spec_sample_input(spec, description=description)
+        spec = heal_spec_runtime_context_requirements(spec)
 
         # 2. Validate spec
         spec_errors = validate_for_family("agent_task", asdict(spec))

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
@@ -63,9 +63,11 @@ AGENT_TASK_DESIGNER_SYSTEM = (
     '- "task_prompt": self-contained prompt for the evaluated agent\n'
     '- "judge_rubric": explicit scoring dimensions and criteria\n'
     '- "output_format": one of free_text, json_schema, or code\n\n'
+    '- "calibration_examples": MUST include at least 2 calibration examples '
+    "with human_score, human_notes, and agent_output fields\n\n"
     "Optional fields (use null or omit when unnecessary): judge_model, difficulty_tiers, "
     "reference_context, reference_sources, required_concepts, sample_input, "
-    "context_preparation, required_context_keys, calibration_examples, max_rounds, "
+    "context_preparation, required_context_keys, max_rounds, "
     "quality_threshold, revision_prompt.\n\n"
     "Rules:\n"
     "- Keep the task executable from the prompt, sample_input, reference_context, "

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
@@ -56,61 +56,28 @@ _EXAMPLE_SPEC = {
 }
 
 AGENT_TASK_DESIGNER_SYSTEM = (
-    "You are a scenario designer for autocontext, an agent evaluation system. "
-    "Given a natural language description, produce an AgentTaskSpec JSON "
-    "that defines a task prompt, evaluation rubric, output format, and optional judge model.\n\n"
-    f"The output must be valid JSON wrapped in delimiters:\n"
+    "You design AgentTaskSpec JSON for autocontext. "
+    "Return only one JSON object wrapped in the required delimiters.\n\n"
     f"{SPEC_START}\n{{ ... }}\n{SPEC_END}\n\n"
-    "## AgentTaskSpec Schema\n\n"
-    "```json\n"
-    "{\n"
-    '  "task_prompt": "The full prompt given to the agent being evaluated",\n'
-    '  "judge_rubric": "Detailed rubric for the LLM judge to score the output",\n'
-    '  "output_format": "free_text | json_schema | code",\n'
-    '  "judge_model": "",\n'
-    '  "difficulty_tiers": null,\n'
-    '  "reference_context": "Authoritative domain knowledge for judging factual accuracy (optional, null if not needed)",\n'
-    '  "reference_sources": ["list of source URLs or references (optional)"],\n'
-    '  "required_concepts": ["key concepts the output must correctly address (optional)"],\n'
-    '  "sample_input": "Realistic sample input data for data-dependent tasks (optional, null if not needed)",\n'
-    '  "context_preparation": "Instructions for gathering context before generation (optional, null if not needed)",\n'
-    '  "required_context_keys": ["state keys that must be present after context preparation (optional)"],\n'
-    '  "max_rounds": 1,\n'
-    '  "quality_threshold": 0.9,\n'
-    '  "revision_prompt": "Instructions for revising output based on judge feedback (optional)"\n'
-    "}\n"
-    "```\n\n"
-    "## Rules\n\n"
-    "- `task_prompt` must be clear, detailed, and self-contained\n"
-    '- `task_prompt` must be FULLY self-contained: never say "you will be provided with..." or reference '
-    "external data without including it. If the task depends on input data, populate `sample_input` with "
-    "realistic example data and embed it directly in the prompt\n"
-    "- `sample_input` (optional, null if not needed) — realistic sample input data for data-dependent tasks. "
-    "Populate this whenever the task requires the agent to process specific input "
-    "(e.g. an outage report, a code snippet, a dataset)\n"
-    "- `judge_rubric` must list specific evaluation dimensions with criteria\n"
-    "- `output_format` must be one of: free_text, json_schema, code\n"
-    "- `judge_model` is optional; use an empty string to fall back to the configured judge/default provider model\n"
-    "- `reference_context` (optional) — authoritative domain knowledge the judge should use to verify factual accuracy. "
-    "Include this when the task requires domain-specific knowledge that the judge LLM may not have. "
-    "When provided, the judge will score factual_accuracy as a mandatory dimension.\n"
-    "- `reference_sources` (optional) — list of source URLs or citations for the reference context\n"
-    "- `required_concepts` (optional) — key concepts the output must correctly address\n"
-    "- `context_preparation` (optional) — instructions for gathering/loading context before the agent generates output. "
-    "Use this when the task requires research, document loading, or other preparation steps.\n"
-    "- `required_context_keys` (optional) — state dictionary keys that must be present after context preparation. "
-    "Used to validate that preparation completed successfully.\n"
-    "- `calibration_examples` — You MUST include at least 2 calibration examples: one low-quality output "
-    "(~0.3 score) and one high-quality output (~0.9 score). Each example must have `human_score`, "
-    "`human_notes`, and `agent_output` fields. These anchor the judge's scoring scale and are critical "
-    "for consistent evaluation.\n"
-    "- `max_rounds` (optional, default 1) — maximum improvement rounds. Set >1 to enable iterative refinement.\n"
-    "- `quality_threshold` (optional, default 0.9) — stop improving when score >= this value.\n"
-    "- `revision_prompt` (optional) — instructions for how the agent should revise its output based on judge feedback.\n\n"
-    f"## Example\n\n{SPEC_START}\n"
-    f"{json.dumps(_EXAMPLE_SPEC, indent=2)}\n"
-    f"{SPEC_END}\n\n"
-    "Now design an agent task scenario for the user's description.\n"
+    "Required fields:\n"
+    '- "task_prompt": self-contained prompt for the evaluated agent\n'
+    '- "judge_rubric": explicit scoring dimensions and criteria\n'
+    '- "output_format": one of free_text, json_schema, or code\n\n'
+    "Optional fields (use null or omit when unnecessary): judge_model, difficulty_tiers, "
+    "reference_context, reference_sources, required_concepts, sample_input, "
+    "context_preparation, required_context_keys, calibration_examples, max_rounds, "
+    "quality_threshold, revision_prompt.\n\n"
+    "Rules:\n"
+    "- Keep the task executable from the prompt, sample_input, reference_context, "
+    "and reference_sources alone whenever possible.\n"
+    "- If the task depends on concrete input data, include realistic sample_input and make the prompt self-contained.\n"
+    "- Use context_preparation and required_context_keys only when the task truly "
+    "needs extra runtime-loaded context; otherwise set them to null.\n"
+    "- Do not invent impossible external loaders or unsatisfied state keys.\n"
+    "- Prefer concise, domain-specific rubrics over generic prose-quality language.\n"
+    "- For structured tasks, output_format should usually be json_schema.\n"
+    "- If iterative refinement is useful, set max_rounds > 1 and provide a revision_prompt.\n\n"
+    "Produce the smallest complete AgentTaskSpec that faithfully captures the user description.\n"
 )
 
 

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_validator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_validator.py
@@ -16,72 +16,262 @@ logger = logging.getLogger(__name__)
 _VALID_OUTPUT_FORMATS = {"free_text", "json_schema", "code"}
 
 # Words too common to signal domain intent.
-_INTENT_STOP_WORDS = frozenset({
-    "a", "an", "the", "and", "or", "of", "for", "to", "in", "on", "at", "by",
-    "is", "are", "was", "be", "do", "does", "it", "we", "they", "i", "you",
-    "that", "can", "should", "could", "would", "will", "must", "with", "which",
-    "what", "how", "task", "agent", "system", "create", "build", "write", "make",
-    "good", "well", "very", "just", "also", "clear", "structured", "want", "need",
-})
+_INTENT_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "and",
+        "or",
+        "of",
+        "for",
+        "to",
+        "in",
+        "on",
+        "at",
+        "by",
+        "is",
+        "are",
+        "was",
+        "be",
+        "do",
+        "does",
+        "it",
+        "we",
+        "they",
+        "i",
+        "you",
+        "that",
+        "can",
+        "should",
+        "could",
+        "would",
+        "will",
+        "must",
+        "with",
+        "which",
+        "what",
+        "how",
+        "task",
+        "agent",
+        "system",
+        "create",
+        "build",
+        "write",
+        "make",
+        "good",
+        "well",
+        "very",
+        "just",
+        "also",
+        "clear",
+        "structured",
+        "want",
+        "need",
+    }
+)
 
 # Task-family keyword clusters — if description keywords fall in one cluster
 # but the spec's keywords fall in a different one, that signals drift.
 _TASK_FAMILIES: dict[str, frozenset[str]] = {
-    "code": frozenset({
-        "code", "coding", "python", "function", "algorithm", "program", "debug",
-        "debugging", "syntax", "compile", "runtime", "api", "endpoint", "scraper",
-        "refactor", "test", "tests", "testing", "unittest", "bug", "bugs",
-        "implementation", "implement", "software", "developer", "class", "method",
-    }),
-    "writing": frozenset({
-        "essay", "article", "blog", "write", "writing", "prose", "paragraph",
-        "narrative", "story", "fiction", "poetry", "haiku", "poem", "literary",
-        "persuasive", "rhetoric", "composition", "draft", "editorial", "recipe",
-        "cookbook", "cooking", "ingredients", "frosting", "cake", "baking",
-    }),
-    "analysis": frozenset({
-        "analysis", "analyze", "diagnostic", "diagnose", "investigate", "root",
-        "cause", "debugging", "logs", "monitoring", "crash", "error", "incident",
-        "forensic", "audit", "trace", "profiling", "performance", "bottleneck",
-    }),
-    "data": frozenset({
-        "data", "dataset", "classification", "classifier", "sentiment", "nlp",
-        "machine", "learning", "model", "training", "prediction", "regression",
-        "clustering", "neural", "deep", "statistics", "statistical", "inference",
-    }),
-    "design": frozenset({
-        "architecture", "design", "pattern", "microservices", "distributed",
-        "scalability", "infrastructure", "devops", "deployment", "kubernetes",
-        "docker", "cloud", "aws", "system", "systems",
-    }),
+    "code": frozenset(
+        {
+            "code",
+            "coding",
+            "python",
+            "algorithm",
+            "program",
+            "debug",
+            "debugging",
+            "syntax",
+            "compile",
+            "runtime",
+            "api",
+            "scraper",
+            "refactor",
+            "testing",
+            "unittest",
+            "bug",
+            "bugs",
+            "implement",
+            "software",
+            "developer",
+        }
+    ),
+    "writing": frozenset(
+        {
+            "essay",
+            "article",
+            "blog",
+            "write",
+            "writing",
+            "prose",
+            "paragraph",
+            "narrative",
+            "story",
+            "fiction",
+            "poetry",
+            "haiku",
+            "poem",
+            "literary",
+            "persuasive",
+            "rhetoric",
+            "composition",
+            "draft",
+            "editorial",
+            "recipe",
+            "cookbook",
+            "cooking",
+            "ingredients",
+            "frosting",
+            "cake",
+            "baking",
+        }
+    ),
+    "analysis": frozenset(
+        {
+            "analysis",
+            "analyze",
+            "diagnostic",
+            "diagnose",
+            "investigate",
+            "root",
+            "cause",
+            "debugging",
+            "logs",
+            "monitoring",
+            "crash",
+            "error",
+            "incident",
+            "forensic",
+            "audit",
+            "trace",
+            "profiling",
+            "performance",
+            "bottleneck",
+        }
+    ),
+    "data": frozenset(
+        {
+            "data",
+            "dataset",
+            "classification",
+            "classifier",
+            "sentiment",
+            "nlp",
+            "machine",
+            "prediction",
+            "regression",
+            "clustering",
+            "neural",
+            "deep",
+            "statistics",
+            "statistical",
+            "inference",
+        }
+    ),
+    "design": frozenset(
+        {
+            "architecture",
+            "design",
+            "pattern",
+            "microservices",
+            "distributed",
+            "scalability",
+            "infrastructure",
+            "devops",
+            "deployment",
+            "kubernetes",
+            "docker",
+            "cloud",
+            "aws",
+            "system",
+            "systems",
+        }
+    ),
 }
 
 # Signals that the description is asking for code generation output.
-_CODE_INTENT_SIGNALS = frozenset({
-    "code", "function", "class", "algorithm", "program", "implement",
-    "script", "python", "javascript", "typescript", "java", "rust", "go",
-    "generate code", "write code", "coding", "scraper", "web scraper",
-})
+_CODE_INTENT_SIGNALS = frozenset(
+    {
+        "code",
+        "function",
+        "class",
+        "algorithm",
+        "program",
+        "implement",
+        "script",
+        "python",
+        "javascript",
+        "typescript",
+        "java",
+        "rust",
+        "go",
+        "generate code",
+        "write code",
+        "coding",
+        "scraper",
+        "web scraper",
+    }
+)
 
 # Counter-signals: when present alongside code keywords, the task is about
 # evaluating/reviewing code (text output), not generating code.
-_CODE_EVALUATION_SIGNALS = frozenset({
-    "evaluate", "review", "assess", "analyze", "analyse", "audit", "quality",
-    "correctness", "diagnostic", "diagnose", "critique", "score", "grade",
-})
+_CODE_EVALUATION_SIGNALS = frozenset(
+    {
+        "evaluate",
+        "review",
+        "assess",
+        "analyze",
+        "analyse",
+        "audit",
+        "quality",
+        "correctness",
+        "diagnostic",
+        "diagnose",
+        "critique",
+        "score",
+        "grade",
+    }
+)
 
 # Signals that the description is asking for text/writing output.
-_TEXT_INTENT_SIGNALS = frozenset({
-    "essay", "article", "blog", "story", "write about", "persuasive",
-    "narrative", "poem", "haiku", "report", "documentation", "recipe",
-})
+_TEXT_INTENT_SIGNALS = frozenset(
+    {
+        "essay",
+        "article",
+        "blog",
+        "story",
+        "write about",
+        "persuasive",
+        "narrative",
+        "poem",
+        "haiku",
+        "report",
+        "documentation",
+        "recipe",
+    }
+)
 
 # Signals that the description is asking for a structured JSON-shaped output.
-_JSON_INTENT_SIGNALS = frozenset({
-    "json", "json schema", "structured output", "structured response",
-    "return a schema", "return schema", "fields", "field names", "key value",
-    "key-value", "object with", "array of", "machine readable", "machine-readable",
-})
+_JSON_INTENT_SIGNALS = frozenset(
+    {
+        "json",
+        "json schema",
+        "structured output",
+        "structured response",
+        "return a schema",
+        "return schema",
+        "fields",
+        "field names",
+        "key value",
+        "key-value",
+        "object with",
+        "array of",
+        "machine readable",
+        "machine-readable",
+    }
+)
 
 # Patterns that ALWAYS indicate external data (future/passive voice referring
 # to data the system must supply).
@@ -111,7 +301,7 @@ def _has_inline_data_after(prompt: str, pattern: str) -> bool:
     idx = prompt.lower().find(pattern)
     if idx < 0:
         return False
-    after = prompt[idx + len(pattern):].strip()
+    after = prompt[idx + len(pattern) :].strip()
     if not after:
         return False
 
@@ -130,7 +320,7 @@ def _has_inline_data_after(prompt: str, pattern: str) -> bool:
 
     match = _INLINE_BLOCK_RE.match(after)
     if match is not None:
-        payload = after[match.end():].strip()
+        payload = after[match.end() :].strip()
         if len(payload) >= _INLINE_DATA_MIN_CHARS:
             return True
 
@@ -147,12 +337,18 @@ def _detect_task_family(keywords: set[str]) -> str | None:
     """Return the best-matching task family for a set of keywords, or None."""
     best_family: str | None = None
     best_overlap = 0
+    tied_best = False
     for family, family_words in _TASK_FAMILIES.items():
         overlap = len(keywords & family_words)
         if overlap > best_overlap:
             best_overlap = overlap
             best_family = family
-    return best_family if best_overlap >= 1 else None
+            tied_best = False
+        elif overlap == best_overlap and overlap > 0:
+            tied_best = True
+    if best_overlap < 1 or tied_best:
+        return None
+    return best_family
 
 
 def _fuzzy_overlap(a: set[str], b: set[str], min_prefix: int = 4) -> set[str]:
@@ -200,8 +396,7 @@ def validate_intent(
     spec_family = _detect_task_family(spec_keywords)
     if desc_family and spec_family and desc_family != spec_family:
         errors.append(
-            f"intent mismatch: description suggests '{desc_family}' task family "
-            f"but generated spec resembles '{spec_family}'"
+            f"intent mismatch: description suggests '{desc_family}' task family but generated spec resembles '{spec_family}'"
         )
 
     # --- 2. Keyword overlap ---
@@ -209,10 +404,7 @@ def validate_intent(
         overlap = _fuzzy_overlap(desc_keywords, spec_keywords)
         overlap_ratio = len(overlap) / len(desc_keywords) if desc_keywords else 1.0
         if overlap_ratio == 0 and len(desc_keywords) >= 2:
-            errors.append(
-                "intent drift: no domain keywords from the description appear "
-                "in the generated task prompt or rubric"
-            )
+            errors.append("intent drift: no domain keywords from the description appear in the generated task prompt or rubric")
 
     # --- 3. Output format compatibility ---
     desc_signals_code = any(sig in desc_lower for sig in _CODE_INTENT_SIGNALS)
@@ -223,19 +415,12 @@ def validate_intent(
     # Only flag code→free_text mismatch when the description asks for code
     # *generation*, not code *evaluation/review* (which produces text output).
     if desc_signals_code and not desc_signals_text and not desc_signals_code_eval and spec.output_format == "free_text":
-        errors.append(
-            "format mismatch: description implies code output but "
-            "spec uses output_format='free_text'"
-        )
+        errors.append("format mismatch: description implies code output but spec uses output_format='free_text'")
     if desc_signals_text and not desc_signals_code and spec.output_format == "code":
-        errors.append(
-            "format mismatch: description implies text output but "
-            "spec uses output_format='code'"
-        )
+        errors.append("format mismatch: description implies text output but spec uses output_format='code'")
     if desc_signals_json and spec.output_format != "json_schema":
         errors.append(
-            "format mismatch: description implies structured JSON output but "
-            f"spec uses output_format='{spec.output_format}'"
+            f"format mismatch: description implies structured JSON output but spec uses output_format='{spec.output_format}'"
         )
 
     return errors
@@ -252,9 +437,7 @@ def validate_spec(spec: AgentTaskSpec) -> list[str]:
         errors.append("judge_rubric must not be empty")
 
     if spec.output_format not in _VALID_OUTPUT_FORMATS:
-        errors.append(
-            f"output_format '{spec.output_format}' not in {_VALID_OUTPUT_FORMATS}"
-        )
+        errors.append(f"output_format '{spec.output_format}' not in {_VALID_OUTPUT_FORMATS}")
 
     if spec.reference_context is not None and not spec.reference_context.strip():
         errors.append("reference_context, if provided, must not be empty")
@@ -344,9 +527,7 @@ def validate_execution(source: str) -> list[str]:
         for node in ast.walk(tree):
             if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "LLMJudge":
                 if any(keyword.arg == "llm_fn" for keyword in node.keywords):
-                    errors.append(
-                        "evaluate_output uses legacy llm_fn wiring; use provider= with runtime provider resolution"
-                    )
+                    errors.append("evaluate_output uses legacy llm_fn wiring; use provider= with runtime provider resolution")
                     break
     except SyntaxError:
         # Syntax issues are handled by validate_syntax().
@@ -379,11 +560,7 @@ def validate_execution(source: str) -> list[str]:
         found_cls = None
         for attr_name in dir(mod):
             attr = getattr(mod, attr_name)
-            if (
-                isinstance(attr, type)
-                and issubclass(attr, AgentTaskInterface)
-                and attr is not AgentTaskInterface
-            ):
+            if isinstance(attr, type) and issubclass(attr, AgentTaskInterface) and attr is not AgentTaskInterface:
                 found_cls = attr
                 break
 

--- a/autocontext/src/autocontext/scenarios/custom/spec_auto_heal.py
+++ b/autocontext/src/autocontext/scenarios/custom/spec_auto_heal.py
@@ -25,6 +25,17 @@ from autocontext.scenarios.custom.agent_task_validator import (
     _has_inline_data_after,
 )
 
+_AUTOMATIC_RUNTIME_CONTEXT_KEYS = frozenset(
+    {
+        "task_name",
+        "output_format",
+        "sample_input",
+        "context_preparation",
+        "reference_context",
+        "reference_sources",
+    }
+)
+
 
 def needs_sample_input(spec: AgentTaskSpec) -> bool:
     """Detect when a spec needs auto-generated sample_input.
@@ -109,3 +120,27 @@ def heal_spec_sample_input(
 
     synthetic = generate_synthetic_sample_input(spec.task_prompt, description)
     return replace(spec, sample_input=synthetic)
+
+
+def heal_spec_runtime_context_requirements(spec: AgentTaskSpec) -> AgentTaskSpec:
+    """Drop runtime context keys the generated agent-task surface cannot hydrate.
+
+    Generated agent-task classes can automatically provide only a small fixed set
+    of state keys during solve/improve execution. If the LLM designer invents
+    additional required context keys such as `patient_case` or
+    `judge_ground_truth_interactions`, the task becomes impossible to execute.
+    In that case, keep only satisfiable keys and clear context-preparation
+    instructions when nothing executable remains.
+    """
+    if not spec.required_context_keys:
+        return spec
+
+    supported_keys = [key for key in spec.required_context_keys if key in _AUTOMATIC_RUNTIME_CONTEXT_KEYS]
+    if len(supported_keys) == len(spec.required_context_keys):
+        return spec
+
+    return replace(
+        spec,
+        context_preparation=(spec.context_preparation if supported_keys else None),
+        required_context_keys=(supported_keys or None),
+    )

--- a/autocontext/tests/test_agent_task_pipeline.py
+++ b/autocontext/tests/test_agent_task_pipeline.py
@@ -599,6 +599,61 @@ class TestAgentTaskCreator:
             finally:
                 SCENARIO_REGISTRY.pop(registered_name, None)
 
+    def test_retries_agent_task_design_after_timeout(self) -> None:
+        attempts = {"count": 0}
+        response_text = _mock_llm_response(SAMPLE_SPEC)
+
+        def mock_llm(system: str, user: str) -> str:
+            del system, user
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise RuntimeError("PiCLIRuntime failed: timeout")
+            return response_text
+
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        with tempfile.TemporaryDirectory() as tmp:
+            creator = AgentTaskCreator(
+                llm_fn=mock_llm,
+                knowledge_root=Path(tmp),
+            )
+            instance = creator.create("Write a haiku about testing software")
+            registered_name = creator.derive_name("Write a haiku about testing software")
+
+            try:
+                assert instance.get_rubric() == SAMPLE_SPEC.judge_rubric
+                assert attempts["count"] == 2
+            finally:
+                SCENARIO_REGISTRY.pop(registered_name, None)
+
+    def test_retries_agent_task_design_after_parse_failure(self) -> None:
+        attempts = {"count": 0}
+        invalid_response = f'{SPEC_START}\n{{\n  "task_prompt": }}\n{SPEC_END}\n'
+        response_text = _mock_llm_response(SAMPLE_SPEC)
+
+        def mock_llm(system: str, user: str) -> str:
+            del system, user
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                return invalid_response
+            return response_text
+
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        with tempfile.TemporaryDirectory() as tmp:
+            creator = AgentTaskCreator(
+                llm_fn=mock_llm,
+                knowledge_root=Path(tmp),
+            )
+            instance = creator.create("Write a haiku about testing software")
+            registered_name = creator.derive_name("Write a haiku about testing software")
+
+            try:
+                assert instance.get_rubric() == SAMPLE_SPEC.judge_rubric
+                assert attempts["count"] == 2
+            finally:
+                SCENARIO_REGISTRY.pop(registered_name, None)
+
     def test_routes_simulation_like_requests_to_simulation_creator(self) -> None:
         response_text = _mock_simulation_response()
 

--- a/autocontext/tests/test_auto_sample_input.py
+++ b/autocontext/tests/test_auto_sample_input.py
@@ -77,8 +77,7 @@ class TestNeedsSampleInput:
 
         spec = AgentTaskSpec(
             task_prompt=(
-                "Analyze the following customer complaint and explain the refund "
-                "exposure, escalation path, and contractual risk."
+                "Analyze the following customer complaint and explain the refund exposure, escalation path, and contractual risk."
             ),
             judge_rubric="Evaluate analysis",
         )
@@ -142,6 +141,44 @@ class TestHealSpecSampleInput:
         healed = heal_spec_sample_input(spec, description="Analyze customer data")
         assert healed.sample_input is not None
         assert len(healed.sample_input) > 0
+
+    def test_drops_unreachable_runtime_context_requirements(self) -> None:
+        from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+        from autocontext.scenarios.custom.spec_auto_heal import heal_spec_runtime_context_requirements
+
+        spec = AgentTaskSpec(
+            task_prompt="Assess a medication interaction case.",
+            judge_rubric="Evaluate accuracy.",
+            sample_input='{"case_id": "poly_07"}',
+            context_preparation="Load patient_case, judge_ground_truth_interactions, and prior_playbook_patterns.",
+            required_context_keys=[
+                "patient_case",
+                "judge_ground_truth_interactions",
+                "prior_playbook_patterns",
+            ],
+        )
+
+        healed = heal_spec_runtime_context_requirements(spec)
+
+        assert healed.context_preparation is None
+        assert healed.required_context_keys is None
+
+    def test_preserves_runtime_supported_context_requirements(self) -> None:
+        from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+        from autocontext.scenarios.custom.spec_auto_heal import heal_spec_runtime_context_requirements
+
+        spec = AgentTaskSpec(
+            task_prompt="Summarize the reference document.",
+            judge_rubric="Evaluate faithfulness.",
+            context_preparation="Load the reference document into state.",
+            reference_context="Reference facts.",
+            required_context_keys=["reference_context"],
+        )
+
+        healed = heal_spec_runtime_context_requirements(spec)
+
+        assert healed.context_preparation == "Load the reference document into state."
+        assert healed.required_context_keys == ["reference_context"]
 
     def test_does_not_overwrite_existing(self) -> None:
         from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec

--- a/autocontext/tests/test_intent_validation.py
+++ b/autocontext/tests/test_intent_validation.py
@@ -15,6 +15,7 @@ from autocontext.scenarios.custom.agent_task_validator import validate_intent
 # Task-family keyword extraction
 # ---------------------------------------------------------------------------
 
+
 class TestIntentKeywordOverlap:
     def test_matching_intent_passes(self) -> None:
         """A spec about Python code quality should pass for a code quality description."""
@@ -61,10 +62,60 @@ class TestIntentKeywordOverlap:
         )
         assert errors == []
 
+    def test_biomedical_agent_task_prompt_does_not_false_positive_as_code(self) -> None:
+        """Biomedical evaluation prompts should not drift just because they mention kidney function."""
+        errors = validate_intent(
+            user_description=(
+                "Build and run a pharmacological reasoning scenario where the agent predicts "
+                "drug interaction risks.\n\n"
+                "Use agent-task evaluation with structured output:\n"
+                "* Agent receives: patient profile (age, weight, conditions, current medications, "
+                "liver/kidney function), proposed new medication\n"
+                "* Agent must produce: interaction risk assessment with mechanism explanation, "
+                "severity rating, clinical recommendation\n"
+                "* Evaluation dimensions: interaction identification accuracy, mechanism explanation "
+                "quality, severity rating accuracy, clinical recommendation quality"
+            ),
+            spec=AgentTaskSpec(
+                task_prompt=(
+                    "Assess the proposed medication against the patient profile, identify clinically "
+                    "meaningful drug interactions, explain the mechanism, assign a severity rating, "
+                    "and recommend the safest next step."
+                ),
+                judge_rubric=(
+                    "Score interaction identification accuracy, mechanism explanation quality, "
+                    "severity rating accuracy, and clinical recommendation quality."
+                ),
+                output_format="json_schema",
+            ),
+        )
+        assert errors == []
+
+    def test_meta_learning_summary_prompt_does_not_false_positive_as_data_task(self) -> None:
+        """Meta-learning prompts should not be rejected just because they mention learning or self-models."""
+        errors = validate_intent(
+            user_description=(
+                "The system's own generation history is fed back as input. It must produce a compressed summary of what it "
+                "has learned, then use that summary as the only context for the next generation."
+            ),
+            spec=AgentTaskSpec(
+                task_prompt=(
+                    "Summarize the most important lessons from the prior generations into a compact memory note that can guide "
+                    "the next attempt without access to the raw history."
+                ),
+                judge_rubric=(
+                    "Score whether the summary preserves actionable lessons, compresses redundant detail, and supports strong "
+                    "next-generation performance."
+                ),
+            ),
+        )
+        assert errors == []
+
 
 # ---------------------------------------------------------------------------
 # Rubric-prompt coherence
 # ---------------------------------------------------------------------------
+
 
 class TestRubricPromptCoherence:
     def test_coherent_rubric_passes(self) -> None:
@@ -93,6 +144,7 @@ class TestRubricPromptCoherence:
 # ---------------------------------------------------------------------------
 # Output format compatibility
 # ---------------------------------------------------------------------------
+
 
 class TestOutputFormatCompatibility:
     def test_code_format_for_code_task(self) -> None:
@@ -163,6 +215,7 @@ class TestOutputFormatCompatibility:
 # Name coherence (derived name vs spec content)
 # ---------------------------------------------------------------------------
 
+
 class TestNameCoherence:
     def test_derived_name_preserves_domain_concepts(self) -> None:
         """Key domain terms from the description should appear in the spec."""
@@ -193,6 +246,7 @@ class TestNameCoherence:
 # ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
+
 
 class TestEdgeCases:
     def test_empty_description_passes(self) -> None:
@@ -236,6 +290,7 @@ class TestEdgeCases:
 # ---------------------------------------------------------------------------
 # Integration with AgentTaskCreator
 # ---------------------------------------------------------------------------
+
 
 class TestCreatorIntentValidation:
     def test_creator_calls_validate_intent(self) -> None:

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -291,6 +291,155 @@ class TestSolveScenarioBuilder:
         assert captured["family_name"] == "coordination"
         assert result.family_name == "coordination"
 
+    def test_resolves_simulationinterface_harness_prompt_to_simulation(self) -> None:
+        from autocontext.knowledge.solver import _resolve_requested_scenario_family
+
+        family = _resolve_requested_scenario_family(
+            "## Objective\n\n"
+            "Build and run a biomedical scenario where the agent designs Phase II/III "
+            "clinical trial protocols, accumulating regulatory and statistical design "
+            "heuristics across generations.\n\n"
+            "## Scenario Design\n\n"
+            "Use `SimulationInterface` + `WorldState`:\n\n"
+            "* Agent receives: disease indication, drug mechanism of action, target "
+            "population demographics, regulatory jurisdiction (FDA/EMA), budget constraints\n"
+            "* Agent must produce: primary/secondary endpoints, sample size with power "
+            "calculation rationale, inclusion/exclusion criteria, randomization scheme, "
+            "safety monitoring plan\n"
+            "* WorldState tracks: regulatory precedent database, statistical design "
+            "parameters, ethical review requirements\n"
+            "* Multiple seeds across indications: oncology, cardiovascular, rare disease, "
+            "neurodegenerative\n"
+            "* Evaluation against real protocol standards (ICH-GCP E6, FDA guidance "
+            "documents)\n"
+        )
+
+        assert family.name == "simulation"
+
+    def test_resolves_meta_learning_proposal_to_agent_task(self) -> None:
+        from autocontext.knowledge.solver import _resolve_requested_scenario_family
+
+        family = _resolve_requested_scenario_family(
+            "## Scenario Proposal\n\n"
+            "**Family:** meta_learning\n"
+            "**Priority:** Week 1 (standalone)\n"
+            "**Generations to signal:** 20-40\n\n"
+            "### Description\n\n"
+            "The system's own generation history is fed back as input. It must produce "
+            "a compressed summary of what it has learned, then use that summary as the "
+            "only context for the next generation (raw history is dropped). Tests whether "
+            "the system can maintain useful meta-knowledge under compression and develop "
+            "a stable self-model.\n"
+        )
+
+        assert family.name == "agent_task"
+
+    def test_build_strips_nonessential_solve_sections_before_creation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from autocontext.knowledge.solver import SolveScenarioBuilder
+
+        runtime = SubagentRuntime(DeterministicDevClient())
+        builder = SolveScenarioBuilder(
+            runtime=runtime,
+            llm_fn=_operator_loop_llm,
+            model="test-model",
+            knowledge_root=tmp_path,
+        )
+        captured: dict[str, str] = {}
+
+        class _CreatedScenario:
+            name = "clinical_trial_protocol_fixture"
+
+        def _fake_create(self, description: str, *, family_name: str = "") -> _CreatedScenario:
+            del self, family_name
+            captured["description"] = description
+            return _CreatedScenario()
+
+        monkeypatch.setattr(
+            "autocontext.scenarios.custom.agent_task_creator.AgentTaskCreator.create",
+            _fake_create,
+        )
+
+        builder.build(
+            "## Objective\n\n"
+            "Build and run a biomedical scenario where the agent designs Phase II/III "
+            "clinical trial protocols, accumulating regulatory and statistical design "
+            "heuristics across generations.\n\n"
+            "## Why This Matters\n\n"
+            "Clinical trial protocol design is high value.\n\n"
+            "## Scenario Design\n\n"
+            "Use agent-task evaluation with structured output.\n\n"
+            "## Implementation Guidance\n\n"
+            "Build a concrete SimulationInterface subclass for clinical trial protocol design.\n\n"
+            "## Acceptance\n\n"
+            "- [ ] 10+ generations show score improvement\n"
+        )
+
+        assert "Why This Matters" not in captured["description"]
+        assert "Implementation Guidance" not in captured["description"]
+        assert "Acceptance" not in captured["description"]
+        assert "Objective" in captured["description"]
+        assert "Scenario Design" in captured["description"]
+
+
+class TestSolveLLMFn:
+    def test_uses_tighter_solve_designer_token_budget(self) -> None:
+        from autocontext.knowledge.solver import _llm_fn_from_client
+
+        captured: dict[str, object] = {}
+
+        class _Response:
+            text = "ok"
+
+        class _Client:
+            def generate(self, **kwargs: object) -> _Response:
+                captured.update(kwargs)
+                return _Response()
+
+        llm_fn = _llm_fn_from_client(_Client(), "architect-model")
+        result = llm_fn("system prompt", "user prompt")
+
+        assert result == "ok"
+        assert captured["model"] == "architect-model"
+        assert captured["max_tokens"] == 1800
+        assert captured["role"] == "scenario_designer"
+
+    def test_build_creator_prefers_translator_model_for_solve_design(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solver import SolveManager
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            model_architect="architect-opus",
+            model_translator="translator-sonnet",
+        )
+        manager = SolveManager(settings)
+
+        class _Client:
+            pass
+
+        class _Runtime:
+            def __init__(self, client: object) -> None:
+                self.client = client
+
+        monkeypatch.setattr(
+            "autocontext.agents.llm_client.build_client_from_settings",
+            lambda settings: _Client(),
+        )
+        monkeypatch.setattr(
+            "autocontext.agents.subagent_runtime.SubagentRuntime",
+            _Runtime,
+        )
+
+        builder = manager._build_creator()
+
+        assert builder is not None
+        assert builder._model == "translator-sonnet"
+
 
 class TestSolveScenarioExecutor:
     def test_runs_agent_task_scenarios_through_task_loop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- stabilize Python `solve` scenario creation for broader current-scenario prompts tracked in AC-567
- reduce creator drift by stripping noisy proposal sections before routing, honoring supported/aliased family hints, and tightening the solve designer runtime path
- harden generated agent-task creation with one retry on transient designer failures plus auto-healing of impossible runtime context requirements

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/knowledge/solver.py src/autocontext/scenarios/custom/agent_task_validator.py src/autocontext/scenarios/custom/spec_auto_heal.py src/autocontext/scenarios/custom/agent_task_creator.py src/autocontext/scenarios/custom/agent_task_designer.py tests/test_knowledge_solver.py tests/test_intent_validation.py tests/test_auto_sample_input.py tests/test_agent_task_pipeline.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_agent_task_pipeline.py tests/test_auto_sample_input.py tests/test_knowledge_solver.py tests/test_cli_solve_runtime.py tests/test_time_budget.py tests/test_intent_validation.py tests/test_family_classifier.py tests/test_scenario_families.py tests/test_artifact_editing.py tests/test_context_preparation.py -k 'solve or budget or intent or family or artifact or context or sample_input or retries_agent_task_design' -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Additional verification:
- targeted regression checks:
  - `cd autocontext && uv run pytest tests/test_agent_task_pipeline.py -k 'retries_agent_task_design_after_timeout or retries_agent_task_design_after_parse_failure' -x --tb=short`
  - `2 passed`
- broader targeted Python suite:
  - `203 passed, 46 deselected`
- live pi-backed default-timeout reruns:
  - root: `/tmp/ac567-live-final-jQyqFN`
  - `AC-272` → `stress_test_trial` → `/tmp/ac567-live-final-jQyqFN/AC-272/stdout.log`
  - `AC-275` → `stress_test_drug` → `/tmp/ac567-live-final-jQyqFN/AC-275/stdout.log`
  - `AC-384` → `proposal_summarizer_self` → `/tmp/ac567-live-final-jQyqFN/AC-384/stdout.log`
  - `AC-389` → `proposal_prompt_meta` → `/tmp/ac567-live-final-jQyqFN/AC-389/stdout.log`
  - all four representative prompts now complete with exit code `0` under default live `pi` settings

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- `solver.py` now builds a shorter solve brief before family routing / creation, aliases unsupported solve hints like `meta_learning` to `agent_task`, treats `SimulationInterface` + `WorldState` prompts as simulation requests, lowers solve designer token budget, and prefers the translator model for solve design when available
- `agent_task_validator.py` removes overly generic family-signal keywords and returns `None` on weak/tied task-family matches to avoid false-positive drift checks for biomedical and meta-learning prompts
- `spec_auto_heal.py` now drops generated `required_context_keys` / `context_preparation` requirements that the runtime cannot actually hydrate
- `agent_task_creator.py` retries one transient agent-task design failure before surfacing the error, which was enough to recover live `pi` design retries seen in AC-567
