### PR TITLE
fix: alias capability bootstrapping solve proposals

### DIFF
--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -51,6 +51,7 @@ _SOLVE_DESCRIPTION_SKIP_LINE_PREFIXES = (
 )
 _SOLVE_FAMILY_ALIASES = {
     "meta_learning": "agent_task",
+    "capability_bootstrapping": "agent_task",
 }
 _SIMULATION_INTERFACE_HINT_RE = re.compile(
     r"\bsimulationinterface\b.*\bworldstate\b|\bworldstate\b.*\bsimulationinterface\b",

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -334,6 +334,22 @@ class TestSolveScenarioBuilder:
 
         assert family.name == "agent_task"
 
+    def test_resolves_capability_bootstrapping_proposal_to_agent_task(self) -> None:
+        from autocontext.knowledge.solver import _resolve_requested_scenario_family
+
+        family = _resolve_requested_scenario_family(
+            "## Scenario Proposal\n\n"
+            "**Family:** capability_bootstrapping\n"
+            "**Priority:** Week 2\n"
+            "**Generations to signal:** 15-30\n\n"
+            "### Description\n\n"
+            "Given a problem it cannot solve directly, the system must design a tool "
+            "(function/algorithm/sub-procedure), then use that tool to solve the problem. "
+            "Scores both tool quality and downstream problem-solving success.\n"
+        )
+
+        assert family.name == "agent_task"
+
     def test_build_strips_nonessential_solve_sections_before_creation(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Replaces closed PR #718 after restacking onto current main.\n\n## Summary\n- Alias capability_bootstrapping solve proposal headers to agent_task\n- Add regression coverage for capability bootstrapping proposal routing\n\n## Verification\n- uv run pytest tests/test_knowledge_solver.py -q\n- uv run ruff check src tests\n- uv run mypy src\n- uv run pytest -q