### PR TITLE
feat(ac-570): raise claude-cli timeout default to 300s + add invocation timing logs

### DIFF
--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -569,7 +569,7 @@ class AppSettings(BaseModel):
     notebook_enabled: bool = Field(default=True, description="Enable session notebook feature")
     # Claude Code CLI runtime (AC-317)
     claude_model: str = Field(default="sonnet", description="Claude CLI model alias")
-    claude_timeout: float = Field(default=120.0, ge=1.0, description="Claude CLI execution timeout")
+    claude_timeout: float = Field(default=300.0, ge=1.0, description="Claude CLI execution timeout")
     claude_tools: str | None = Field(default=None, description="Claude CLI tools override")
     claude_permission_mode: str = Field(default="bypassPermissions", description="Claude CLI permission mode")
     claude_session_persistence: bool = Field(default=False, description="Persist Claude CLI sessions across turns")

--- a/autocontext/src/autocontext/runtimes/claude_cli.py
+++ b/autocontext/src/autocontext/runtimes/claude_cli.py
@@ -28,7 +28,7 @@ class ClaudeCLIConfig:
     permission_mode: str = "bypassPermissions"
     session_persistence: bool = False
     session_id: str | None = None  # Set to maintain context across rounds
-    timeout: float = 120.0
+    timeout: float = 300.0
     system_prompt: str | None = None
     append_system_prompt: str | None = None
     extra_args: list[str] = field(default_factory=list)

--- a/autocontext/src/autocontext/runtimes/claude_cli.py
+++ b/autocontext/src/autocontext/runtimes/claude_cli.py
@@ -10,6 +10,7 @@ import json
 import logging
 import shutil
 import subprocess
+import time
 import uuid
 from dataclasses import dataclass, field
 
@@ -135,8 +136,13 @@ class ClaudeCLIRuntime(AgentRuntime):
 
     def _invoke(self, prompt: str, args: list[str]) -> AgentOutput:
         """Execute claude -p and parse the JSON result."""
-        logger.info("invoking claude CLI: %s", " ".join(args[:6]) + "...")
+        logger.info(
+            "claude-cli invoke: model=%s timeout=%ds",
+            self._config.model,
+            int(self._config.timeout),
+        )
 
+        start = time.monotonic()
         try:
             result = subprocess.run(
                 args,
@@ -151,6 +157,13 @@ class ClaudeCLIRuntime(AgentRuntime):
         except FileNotFoundError:
             logger.error("claude CLI not found. Install Claude Code first.")
             return AgentOutput(text="", metadata={"error": "claude_not_found"})
+
+        elapsed = time.monotonic() - start
+        logger.debug(
+            "claude-cli completed in %.1fs (budget %ds)",
+            elapsed,
+            int(self._config.timeout),
+        )
 
         if result.returncode != 0:
             logger.warning("claude CLI exited with code %d: %s", result.returncode, result.stderr[:200])

--- a/autocontext/tests/test_claude_cli_timeout.py
+++ b/autocontext/tests/test_claude_cli_timeout.py
@@ -19,3 +19,7 @@ class TestClaudeTimeoutDefaults:
     def test_app_settings_claude_timeout_default_is_300s(self) -> None:
         settings = AppSettings()
         assert settings.claude_timeout == 300.0
+
+    def test_claude_cli_config_default_is_300s(self) -> None:
+        cfg = ClaudeCLIConfig()
+        assert cfg.timeout == 300.0

--- a/autocontext/tests/test_claude_cli_timeout.py
+++ b/autocontext/tests/test_claude_cli_timeout.py
@@ -1,0 +1,21 @@
+"""AC-570 — claude-cli timeout defaults and observability.
+
+Pins the raised default (300s) and the existing override paths
+(--timeout flag, AUTOCONTEXT_CLAUDE_TIMEOUT env var).
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from autocontext.config.settings import AppSettings, load_settings
+from autocontext.runtimes.claude_cli import ClaudeCLIConfig, ClaudeCLIRuntime
+
+
+class TestClaudeTimeoutDefaults:
+    def test_app_settings_claude_timeout_default_is_300s(self) -> None:
+        settings = AppSettings()
+        assert settings.claude_timeout == 300.0

--- a/autocontext/tests/test_claude_cli_timeout.py
+++ b/autocontext/tests/test_claude_cli_timeout.py
@@ -45,3 +45,35 @@ class TestClaudeTimeoutDefaults:
         )
 
         assert resolved.claude_timeout == 90.0
+
+
+class TestClaudeCLIRuntimeObservability:
+    def test_runtime_logs_invoke_with_timeout_and_model(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Each claude-cli invocation emits one INFO log naming the model and timeout."""
+        completed = subprocess.CompletedProcess(
+            args=["claude"],
+            returncode=0,
+            stdout='{"type":"result","subtype":"success","is_error":false,'
+                   '"result":"ok","total_cost_usd":0.0,"session_id":"t","duration_ms":1}',
+            stderr="",
+        )
+
+        runtime = ClaudeCLIRuntime(ClaudeCLIConfig(model="sonnet", timeout=300.0))
+
+        with caplog.at_level(logging.INFO, logger="autocontext.runtimes.claude_cli"):
+            with patch("subprocess.run", return_value=completed):
+                runtime.generate(prompt="probe")
+
+        invoke_records = [
+            r for r in caplog.records
+            if r.levelno == logging.INFO and "claude-cli invoke" in r.getMessage()
+        ]
+        assert len(invoke_records) == 1, (
+            f"expected one invoke INFO record, got {[r.message for r in caplog.records]}"
+        )
+        message = invoke_records[0].getMessage()
+        assert "model=sonnet" in message
+        assert "timeout=300s" in message

--- a/autocontext/tests/test_claude_cli_timeout.py
+++ b/autocontext/tests/test_claude_cli_timeout.py
@@ -33,3 +33,15 @@ class TestClaudeTimeoutDefaults:
         settings = load_settings()
 
         assert settings.claude_timeout == 45.0
+
+    def test_cli_timeout_flag_overrides_default_for_claude_cli(self) -> None:
+        """--timeout flag routes through apply_judge_runtime_overrides and wins
+        over the default for CLI-backed providers."""
+        from autocontext.cli_runtime_overrides import apply_judge_runtime_overrides
+
+        base = AppSettings()  # claude_timeout defaults to 300
+        resolved = apply_judge_runtime_overrides(
+            base, provider_name="claude-cli", timeout=90.0
+        )
+
+        assert resolved.claude_timeout == 90.0

--- a/autocontext/tests/test_claude_cli_timeout.py
+++ b/autocontext/tests/test_claude_cli_timeout.py
@@ -23,3 +23,13 @@ class TestClaudeTimeoutDefaults:
     def test_claude_cli_config_default_is_300s(self) -> None:
         cfg = ClaudeCLIConfig()
         assert cfg.timeout == 300.0
+
+    def test_env_var_overrides_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AUTOCONTEXT_CLAUDE_TIMEOUT has always overridden the default; pin it."""
+        monkeypatch.setenv("AUTOCONTEXT_CLAUDE_TIMEOUT", "45")
+
+        settings = load_settings()
+
+        assert settings.claude_timeout == 45.0

--- a/autocontext/tests/test_per_role_provider.py
+++ b/autocontext/tests/test_per_role_provider.py
@@ -93,7 +93,7 @@ class TestPerRoleConfigFields:
 
         settings = AppSettings()
         assert settings.claude_model == "sonnet"
-        assert settings.claude_timeout == 120.0
+        assert settings.claude_timeout == 300.0
         assert settings.claude_tools is None
         assert settings.claude_permission_mode == "bypassPermissions"
         assert settings.claude_session_persistence is False


### PR DESCRIPTION
Closes AC-570. Supersedes the timeout half of AC-553.

## What changed

- `AppSettings.claude_timeout` default: 120.0 → **300.0** (`config/settings.py:572`).
- `ClaudeCLIConfig.timeout` dataclass default: 120.0 → **300.0** (`runtimes/claude_cli.py:31`). Kept in sync with the Pydantic field so ad-hoc `ClaudeCLIConfig()` instantiations don't regress to 120s.
- `ClaudeCLIRuntime._invoke()` now emits an INFO log on every invocation with model + timeout, and a DEBUG log with elapsed time on success. No behavior change; purely observability.

## What did NOT change

The `--timeout` flag on `autoctx improve` / `autoctx judge` / `autoctx solve` and the `AUTOCONTEXT_CLAUDE_TIMEOUT` env var were already wired up correctly in 0.4.3 — contrary to my original AC-570 filing. This PR adds regression-guard tests pinning both paths so future refactors can't silently break them.

## Why 300s

Observed latencies in the 0.4.3 escalation suite:

| Surface | Typical elapsed |
|---|---|
| judge (structured scoring) | 5–15s |
| improve round (creative) | 20–40s |
| improve round (reasoning-heavy) | 60–180s |
| solve / new-scenario (multi-step LLM design) | 30–120s |

300s covers the 99th percentile with margin. The timeout is a failure-mode detector, not a latency budget — real hangs surface within seconds; multi-minute elapsed just means the model is thinking.

## Tests

5 new tests in `autocontext/tests/test_claude_cli_timeout.py`:
- `test_app_settings_claude_timeout_default_is_300s` — pins the Pydantic default
- `test_claude_cli_config_default_is_300s` — pins the dataclass default
- `test_env_var_overrides_default` — regression guard for `AUTOCONTEXT_CLAUDE_TIMEOUT`
- `test_cli_timeout_flag_overrides_default_for_claude_cli` — regression guard for `--timeout` flag path
- `test_runtime_logs_invoke_with_timeout_and_model` — pins the new INFO log format

1 existing test updated: `test_per_role_provider.py:96` (bumped expected default from 120.0 to 300.0).

Full suite: **5366 passed**, ruff + mypy clean.

## Linear

- AC-570 (closes this)
- AC-553 (original issue, supersedes the timeout half)