### PR TITLE
fix: normalize structured solve quality thresholds

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
@@ -63,9 +63,11 @@ AGENT_TASK_DESIGNER_SYSTEM = (
     '- "task_prompt": self-contained prompt for the evaluated agent\n'
     '- "judge_rubric": explicit scoring dimensions and criteria\n'
     '- "output_format": one of free_text, json_schema, or code\n\n'
+    '- "calibration_examples": MUST include at least 2 calibration examples '
+    "with human_score, human_notes, and agent_output fields\n\n"
     "Optional fields (use null or omit when unnecessary): judge_model, difficulty_tiers, "
     "reference_context, reference_sources, required_concepts, sample_input, "
-    "context_preparation, required_context_keys, calibration_examples, max_rounds, "
+    "context_preparation, required_context_keys, max_rounds, "
     "quality_threshold, revision_prompt.\n\n"
     "Rules:\n"
     "- Keep the task executable from the prompt, sample_input, reference_context, "

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_spec.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_spec.py
@@ -36,7 +36,28 @@ def _serialize_agent_task_text_payload(value: Any) -> str | None:
     return str(value)
 
 
-def _extract_numeric_scalar(value: Any) -> float | None:
+QUALITY_THRESHOLD_NUMERIC_KEYS = (
+    "minimum",
+    "min",
+    "threshold",
+    "target",
+    "required",
+    "value",
+)
+
+
+def _normalized_key(value: object) -> str:
+    return str(value).strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _matches_preferred_key(key: str, preferred: str) -> bool:
+    if key == preferred:
+        return True
+    parts = tuple(part for part in key.split("_") if part)
+    return preferred in parts
+
+
+def _extract_numeric_scalar(value: Any, *, preferred_keys: tuple[str, ...] = ()) -> float | None:
     if value is None or isinstance(value, bool):
         return None
     if isinstance(value, int | float):
@@ -47,14 +68,22 @@ def _extract_numeric_scalar(value: Any) -> float | None:
         except ValueError:
             return None
     if isinstance(value, dict):
+        normalized_items = [(_normalized_key(key), nested) for key, nested in value.items()]
+        for preferred in preferred_keys:
+            for key, nested in normalized_items:
+                if not _matches_preferred_key(key, preferred):
+                    continue
+                extracted = _extract_numeric_scalar(nested, preferred_keys=preferred_keys)
+                if extracted is not None:
+                    return extracted
         for nested in value.values():
-            extracted = _extract_numeric_scalar(nested)
+            extracted = _extract_numeric_scalar(nested, preferred_keys=preferred_keys)
             if extracted is not None:
                 return extracted
         return None
     if isinstance(value, list):
         for nested in value:
-            extracted = _extract_numeric_scalar(nested)
+            extracted = _extract_numeric_scalar(nested, preferred_keys=preferred_keys)
             if extracted is not None:
                 return extracted
         return None
@@ -69,9 +98,11 @@ def _normalize_max_rounds(value: Any) -> int:
 
 
 def _normalize_quality_threshold(value: Any) -> float:
-    extracted = _extract_numeric_scalar(value)
+    extracted = _extract_numeric_scalar(value, preferred_keys=QUALITY_THRESHOLD_NUMERIC_KEYS)
     if extracted is None:
         return 0.9
+    if 10.0 <= extracted <= 100.0:
+        return extracted / 100.0
     return extracted
 
 

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_spec.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_spec.py
@@ -36,6 +36,45 @@ def _serialize_agent_task_text_payload(value: Any) -> str | None:
     return str(value)
 
 
+def _extract_numeric_scalar(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    if isinstance(value, dict):
+        for nested in value.values():
+            extracted = _extract_numeric_scalar(nested)
+            if extracted is not None:
+                return extracted
+        return None
+    if isinstance(value, list):
+        for nested in value:
+            extracted = _extract_numeric_scalar(nested)
+            if extracted is not None:
+                return extracted
+        return None
+    return None
+
+
+def _normalize_max_rounds(value: Any) -> int:
+    extracted = _extract_numeric_scalar(value)
+    if extracted is None:
+        return 1
+    return max(1, int(extracted))
+
+
+def _normalize_quality_threshold(value: Any) -> float:
+    extracted = _extract_numeric_scalar(value)
+    if extracted is None:
+        return 0.9
+    return extracted
+
+
 def normalize_agent_task_runtime_fields(spec: AgentTaskSpec) -> AgentTaskSpec:
     """Coerce structured prompt-adjacent fields into runtime-safe strings.
 
@@ -49,6 +88,8 @@ def normalize_agent_task_runtime_fields(spec: AgentTaskSpec) -> AgentTaskSpec:
         judge_rubric=_serialize_agent_task_text_payload(spec.judge_rubric) or "",
         reference_context=_serialize_agent_task_text_payload(spec.reference_context),
         context_preparation=_serialize_agent_task_text_payload(spec.context_preparation),
+        max_rounds=_normalize_max_rounds(spec.max_rounds),
+        quality_threshold=_normalize_quality_threshold(spec.quality_threshold),
         revision_prompt=_serialize_agent_task_text_payload(spec.revision_prompt),
         sample_input=_serialize_agent_task_text_payload(spec.sample_input),
     )

--- a/autocontext/tests/test_agent_task_pipeline.py
+++ b/autocontext/tests/test_agent_task_pipeline.py
@@ -271,6 +271,36 @@ class TestDesignAgentTask:
         assert isinstance(spec.quality_threshold, float)
         assert spec.quality_threshold == 0.9
 
+    def test_parse_spec_prefers_minimum_quality_threshold_key(self) -> None:
+        spec_data = {
+            "task_prompt": "Transfer two reasoning patterns into a hybrid task.",
+            "judge_rubric": "Evaluate transfer quality.",
+            "quality_threshold": {
+                "stretch": 0.95,
+                "minimum": 0.9,
+            },
+        }
+        raw = f"{SPEC_START}\n{json.dumps(spec_data, indent=2)}\n{SPEC_END}"
+
+        spec = parse_agent_task_spec(raw)
+
+        assert spec.quality_threshold == 0.9
+
+    def test_parse_spec_normalizes_percentage_quality_threshold(self) -> None:
+        spec_data = {
+            "task_prompt": "Transfer two reasoning patterns into a hybrid task.",
+            "judge_rubric": "Evaluate transfer quality.",
+            "quality_threshold": {
+                "scale": "0-100",
+                "minimum": 90,
+            },
+        }
+        raw = f"{SPEC_START}\n{json.dumps(spec_data, indent=2)}\n{SPEC_END}"
+
+        spec = parse_agent_task_spec(raw)
+
+        assert spec.quality_threshold == 0.9
+
     def test_design_agent_task_with_mock(self) -> None:
         response_text = _mock_llm_response(SAMPLE_SPEC)
 

--- a/autocontext/tests/test_agent_task_pipeline.py
+++ b/autocontext/tests/test_agent_task_pipeline.py
@@ -255,6 +255,22 @@ class TestDesignAgentTask:
         assert '"true_goal_usefulness"' in spec.judge_rubric
         assert '"overall_rule"' in spec.judge_rubric
 
+    def test_parse_spec_normalizes_structured_quality_threshold(self) -> None:
+        spec_data = {
+            "task_prompt": "Transfer two reasoning patterns into a hybrid task.",
+            "judge_rubric": "Evaluate transfer quality.",
+            "quality_threshold": {
+                "minimum": 0.9,
+                "stretch": 0.95,
+            },
+        }
+        raw = f"{SPEC_START}\n{json.dumps(spec_data, indent=2)}\n{SPEC_END}"
+
+        spec = parse_agent_task_spec(raw)
+
+        assert isinstance(spec.quality_threshold, float)
+        assert spec.quality_threshold == 0.9
+
     def test_design_agent_task_with_mock(self) -> None:
         response_text = _mock_llm_response(SAMPLE_SPEC)
 


### PR DESCRIPTION
## Summary

- normalize structured numeric control fields in Python agent-task specs so `solve` no longer crashes when the designer returns a structured `quality_threshold`
- add focused regression coverage for structured `quality_threshold` payloads at the agent-task spec boundary
- keep the fix narrow and DRY by centralizing scalar extraction in `agent_task_spec.normalize_agent_task_runtime_fields(...)`

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/scenarios/custom/agent_task_spec.py tests/test_agent_task_pipeline.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_knowledge_solver.py tests/test_agent_task_pipeline.py tests/test_auto_sample_input.py tests/test_intent_validation.py tests/test_cli_solve_runtime.py tests/test_time_budget.py -k 'solve or structured_quality_threshold or structured_judge_rubric or inline_example_parentheticals or meta_learning or capability_bootstrapping or retries_agent_task_design or runtime_context' -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Additional verification:
- failing-first regression:
  - `cd autocontext && uv run pytest tests/test_agent_task_pipeline.py -k 'structured_quality_threshold or structured_judge_rubric' -x --tb=short`
  - before fix: `1 failed, 1 passed`
  - after fix: `2 passed`
- broader targeted Python suite:
  - `26 passed, 109 deselected`
- post-AC-569 discovery failure artifact:
  - `/tmp/post-ac569-discovery-ll73Rc/AC-386/stderr.log`
  - failure: `TypeError: '<' not supported between instances of 'float' and 'dict'`
- live pi-backed validation after fix:
  - burn-in root: `/tmp/ac572-live-fixed-mXfBUd`
  - results: `6 / 6` successful `AC-386` solves
  - representative success: `/tmp/ac572-live-fixed-mXfBUd/run-1/stdout.log`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- `agent_task_spec` now extracts numeric scalars from strings / nested structured payloads and normalizes them at the spec boundary before validation/runtime use
- this is the same bounded context as the recent structured `judge_rubric` / prompt-adjacent normalization work, so the change keeps the normalization logic centralized instead of spreading one-off guards through validators
- this PR is stacked on top of AC-569 / PR #721 because the AC-386 structured-threshold crash surfaced only after the earlier current-scenario fixes landed
