### PR TITLE
feat(ac-574): retry-with-feedback loop when validate_intent catches designer drift

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -13,7 +13,9 @@ from autocontext.scenarios.artifact_editing import ArtifactEditingInterface
 from autocontext.scenarios.base import ScenarioInterface
 from autocontext.scenarios.coordination import CoordinationInterface
 from autocontext.scenarios.custom.agent_task_codegen import generate_agent_task_class
-from autocontext.scenarios.custom.agent_task_designer import design_agent_task
+from autocontext.scenarios.custom.agent_task_designer import (
+    design_validated_agent_task,
+)
 from autocontext.scenarios.custom.agent_task_revision import (
     patch_legacy_generated_evaluate_output,
     patch_legacy_generated_revise_output,
@@ -99,11 +101,7 @@ class AgentTaskCreator:
 
         # 1. Design
         logger.info("designing agent task from description")
-        try:
-            spec = design_agent_task(description, self.llm_fn)
-        except Exception:
-            logger.warning("agent task design failed on first attempt; retrying once", exc_info=True)
-            spec = design_agent_task(description, self.llm_fn)
+        spec = design_validated_agent_task(description, self.llm_fn)
 
         # 1.5 Auto-heal: generate synthetic sample_input if needed (AC-309)
         from autocontext.scenarios.custom.spec_auto_heal import (

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 
 from autocontext.agents.types import LlmFn
@@ -8,6 +9,8 @@ from autocontext.scenarios.custom.agent_task_spec import (
     AgentTaskSpec,
     normalize_agent_task_runtime_fields,
 )
+
+logger = logging.getLogger(__name__)
 
 SPEC_START = "<!-- AGENT_TASK_SPEC_START -->"
 SPEC_END = "<!-- AGENT_TASK_SPEC_END -->"
@@ -136,7 +139,7 @@ def design_validated_agent_task(
     """Design an agent task spec, retrying with validator feedback if intent drifts.
 
     On each attempt:
-    - Call ``design_agent_task(description, llm_fn)``
+    - Call the designer (``design_agent_task`` for attempt 0, correction prompt otherwise)
     - Run ``validate_intent(description, spec)``
     - If empty → return spec
     - If errors and attempts remaining → build a correction prompt, loop
@@ -150,11 +153,66 @@ def design_validated_agent_task(
     # Local import to avoid a cycle (validator imports designer symbols in the other file).
     from autocontext.scenarios.custom.agent_task_validator import validate_intent
 
-    spec = design_agent_task(description, llm_fn)
-    errors = validate_intent(description, spec)
-    if not errors:
-        return spec
-    # Stub — Task 5 will implement the actual retry loop. This preserves the
-    # original single-attempt error shape so the happy-path test passes while
-    # leaving the retry behaviour undefined (which later RED tests will drive).
-    raise ValueError(f"intent validation failed: {'; '.join(errors)}")
+    total_attempts = max_retries + 1
+    errors_per_attempt: list[list[str]] = []
+    last_spec: AgentTaskSpec | None = None
+
+    for attempt in range(total_attempts):
+        if attempt == 0:
+            spec = design_agent_task(description, llm_fn)
+        else:
+            assert last_spec is not None  # prior loop iteration sets this
+            user_prompt = _build_correction_prompt(
+                description=description,
+                failed_spec=last_spec,
+                errors=errors_per_attempt[-1],
+            )
+            response = llm_fn(AGENT_TASK_DESIGNER_SYSTEM, user_prompt)
+            spec = parse_agent_task_spec(response)
+
+        errors = validate_intent(description, spec)
+        if not errors:
+            return spec
+
+        errors_per_attempt.append(errors)
+        last_spec = spec
+
+        if attempt < total_attempts - 1:
+            logger.warning(
+                "intent validation failed on attempt %d/%d: %s; retrying with correction prompt",
+                attempt + 1,
+                total_attempts,
+                "; ".join(errors),
+            )
+
+    raise ValueError(
+        f"intent validation failed after {total_attempts} attempts. "
+        f"Errors per attempt: {errors_per_attempt}"
+    )
+
+
+def _build_correction_prompt(
+    *,
+    description: str,
+    failed_spec: AgentTaskSpec,
+    errors: list[str],
+) -> str:
+    """Build the retry user prompt that feeds validator errors back to the LLM."""
+    prompt_excerpt = failed_spec.task_prompt[:200]
+    ellipsis = "..." if len(failed_spec.task_prompt) > 200 else ""
+    error_bullets = "\n".join(f"- {e}" for e in errors)
+    return (
+        "Your previous attempt generated a spec that failed intent validation.\n\n"
+        f"User description:\n{description}\n\n"
+        "Previous spec (key fields):\n"
+        f"  output_format: {failed_spec.output_format}\n"
+        f"  task_prompt: {prompt_excerpt}{ellipsis}\n\n"
+        "Validation errors:\n"
+        f"{error_bullets}\n\n"
+        "Please regenerate a corrected AgentTaskSpec that addresses these errors.\n\n"
+        "Hints:\n"
+        "- If the description implies writing/analysis/evaluation output, use output_format='free_text'\n"
+        "- If the description implies structured data output, use output_format='json_schema'\n"
+        "- Only use output_format='code' when the agent is asked to produce runnable source code\n"
+        "- The task_prompt and judge_rubric must reflect the same domain and output shape as the description"
+    )

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
@@ -140,15 +140,16 @@ def design_validated_agent_task(
 
     On each attempt:
     - Call the designer (``design_agent_task`` for attempt 0, correction prompt otherwise)
+    - If the response cannot be parsed, retry with parse feedback when attempts remain
     - Run ``validate_intent(description, spec)``
     - If empty → return spec
     - If errors and attempts remaining → build a correction prompt, loop
-    - If errors and attempts exhausted → raise ValueError with all attempts' errors
+    - If failures exhaust attempts → raise ValueError with all attempts' errors
 
     Total attempts = ``max_retries + 1``. Default ``max_retries=2`` (3 attempts total).
 
     Raises:
-        ValueError: when intent validation still fails after max_retries + 1 attempts.
+        ValueError: when design or intent validation still fails after max_retries + 1 attempts.
     """
     # Local import to avoid a cycle (validator imports designer symbols in the other file).
     from autocontext.scenarios.custom.agent_task_validator import validate_intent
@@ -158,17 +159,39 @@ def design_validated_agent_task(
     last_spec: AgentTaskSpec | None = None
 
     for attempt in range(total_attempts):
-        if attempt == 0:
-            spec = design_agent_task(description, llm_fn)
-        else:
-            assert last_spec is not None  # prior loop iteration sets this
-            user_prompt = _build_correction_prompt(
-                description=description,
-                failed_spec=last_spec,
-                errors=errors_per_attempt[-1],
-            )
-            response = llm_fn(AGENT_TASK_DESIGNER_SYSTEM, user_prompt)
-            spec = parse_agent_task_spec(response)
+        try:
+            if attempt == 0:
+                spec = design_agent_task(description, llm_fn)
+            elif last_spec is None:
+                user_prompt = _build_parse_failure_retry_prompt(
+                    description=description,
+                    errors=errors_per_attempt[-1],
+                )
+                response = llm_fn(AGENT_TASK_DESIGNER_SYSTEM, user_prompt)
+                spec = parse_agent_task_spec(response)
+            else:
+                user_prompt = _build_correction_prompt(
+                    description=description,
+                    failed_spec=last_spec,
+                    errors=errors_per_attempt[-1],
+                )
+                response = llm_fn(AGENT_TASK_DESIGNER_SYSTEM, user_prompt)
+                spec = parse_agent_task_spec(response)
+        except Exception as exc:
+            errors = [f"designer response could not be parsed: {exc}"]
+            errors_per_attempt.append(errors)
+            if attempt < total_attempts - 1:
+                logger.warning(
+                    "agent task design failed on attempt %d/%d; retrying with correction prompt",
+                    attempt + 1,
+                    total_attempts,
+                    exc_info=True,
+                )
+                continue
+            raise ValueError(
+                f"agent task design failed after {total_attempts} attempts. "
+                f"Errors per attempt: {errors_per_attempt}"
+            ) from exc
 
         errors = validate_intent(description, spec)
         if not errors:
@@ -188,6 +211,23 @@ def design_validated_agent_task(
     raise ValueError(
         f"intent validation failed after {total_attempts} attempts. "
         f"Errors per attempt: {errors_per_attempt}"
+    )
+
+
+def _build_parse_failure_retry_prompt(
+    *,
+    description: str,
+    errors: list[str],
+) -> str:
+    """Build a retry prompt for malformed or unparsable designer output."""
+    error_bullets = "\n".join(f"- {e}" for e in errors)
+    return (
+        "Your previous attempt could not be parsed into an AgentTaskSpec.\n\n"
+        f"User description:\n{description}\n\n"
+        "Parse errors:\n"
+        f"{error_bullets}\n\n"
+        "Please regenerate a corrected AgentTaskSpec as valid JSON wrapped in the "
+        f"{SPEC_START} and {SPEC_END} delimiters."
     )
 
 

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
@@ -125,3 +125,36 @@ def design_agent_task(description: str, llm_fn: LlmFn) -> AgentTaskSpec:
     user_prompt = f"User description:\n{description}"
     response = llm_fn(AGENT_TASK_DESIGNER_SYSTEM, user_prompt)
     return parse_agent_task_spec(response)
+
+
+def design_validated_agent_task(
+    description: str,
+    llm_fn: LlmFn,
+    *,
+    max_retries: int = 2,
+) -> AgentTaskSpec:
+    """Design an agent task spec, retrying with validator feedback if intent drifts.
+
+    On each attempt:
+    - Call ``design_agent_task(description, llm_fn)``
+    - Run ``validate_intent(description, spec)``
+    - If empty → return spec
+    - If errors and attempts remaining → build a correction prompt, loop
+    - If errors and attempts exhausted → raise ValueError with all attempts' errors
+
+    Total attempts = ``max_retries + 1``. Default ``max_retries=2`` (3 attempts total).
+
+    Raises:
+        ValueError: when intent validation still fails after max_retries + 1 attempts.
+    """
+    # Local import to avoid a cycle (validator imports designer symbols in the other file).
+    from autocontext.scenarios.custom.agent_task_validator import validate_intent
+
+    spec = design_agent_task(description, llm_fn)
+    errors = validate_intent(description, spec)
+    if not errors:
+        return spec
+    # Stub — Task 5 will implement the actual retry loop. This preserves the
+    # original single-attempt error shape so the happy-path test passes while
+    # leaving the retry behaviour undefined (which later RED tests will drive).
+    raise ValueError(f"intent validation failed: {'; '.join(errors)}")

--- a/autocontext/tests/test_agent_task_creator_retry.py
+++ b/autocontext/tests/test_agent_task_creator_retry.py
@@ -9,7 +9,6 @@ from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
 from autocontext.scenarios.custom.agent_task_designer import SPEC_END, SPEC_START
 from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
 
-
 _VALID_TEXT_SPEC = AgentTaskSpec(
     task_prompt="Write a haiku about distributed systems.",
     judge_rubric="Score syllable accuracy, relevance, imagery 0-1 each.",

--- a/autocontext/tests/test_agent_task_creator_retry.py
+++ b/autocontext/tests/test_agent_task_creator_retry.py
@@ -77,3 +77,22 @@ class TestAgentTaskCreatorRetry:
         assert len(persisted_files) == 1, (
             f"expected one persisted agent_task.py, got {persisted_files}"
         )
+
+    def test_creator_retries_on_unparseable_designer_response(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Malformed first responses should still get a second design attempt."""
+        llm_fn = _scripted_llm_fn([
+            "not delimited json",
+            _spec_response(_VALID_TEXT_SPEC),
+        ])
+
+        creator = AgentTaskCreator(llm_fn=llm_fn, knowledge_root=tmp_path)
+
+        scenario_instance = creator.create("Write a haiku about distributed systems.")
+
+        assert len(llm_fn.calls) == 2  # type: ignore[attr-defined]
+        assert scenario_instance is not None
+        persisted_files = list((tmp_path / "_custom_scenarios").rglob("agent_task.py"))
+        assert len(persisted_files) == 1

--- a/autocontext/tests/test_agent_task_creator_retry.py
+++ b/autocontext/tests/test_agent_task_creator_retry.py
@@ -1,0 +1,80 @@
+"""AC-574 — end-to-end: ScenarioCreator.create() retries on intent drift."""
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
+from autocontext.scenarios.custom.agent_task_designer import SPEC_END, SPEC_START
+from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+
+
+_VALID_TEXT_SPEC = AgentTaskSpec(
+    task_prompt="Write a haiku about distributed systems.",
+    judge_rubric="Score syllable accuracy, relevance, imagery 0-1 each.",
+    output_format="free_text",
+    judge_model="",
+)
+
+_INVALID_CODE_SPEC = AgentTaskSpec(
+    task_prompt="Implement a Python function that writes a haiku.",
+    judge_rubric="Score code quality, tests, documentation 0-1 each.",
+    output_format="code",
+    judge_model="",
+)
+
+
+def _spec_response(spec: AgentTaskSpec) -> str:
+    data = {
+        "task_prompt": spec.task_prompt,
+        "judge_rubric": spec.judge_rubric,
+        "output_format": spec.output_format,
+        "judge_model": spec.judge_model,
+    }
+    return f"prefix\n{SPEC_START}\n{json.dumps(data)}\n{SPEC_END}\nsuffix"
+
+
+def _scripted_llm_fn(responses: list[str]) -> Callable[[str, str], str]:
+    calls: list[tuple[str, str]] = []
+
+    def fn(system: str, user: str) -> str:
+        if not responses:
+            raise AssertionError("llm_fn called more times than responses available")
+        calls.append((system, user))
+        return responses.pop(0)
+
+    fn.calls = calls  # type: ignore[attr-defined]
+    return fn
+
+
+class TestAgentTaskCreatorRetry:
+    def test_creator_retries_on_intent_drift_and_succeeds(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """ScenarioCreator.create() must use the retry-capable designer.
+
+        First LLM call returns code-format spec for a text description
+        (triggers validate_intent drift). Second call returns valid spec.
+        Creator must succeed, not raise.
+        """
+        llm_fn = _scripted_llm_fn([
+            _spec_response(_INVALID_CODE_SPEC),
+            _spec_response(_VALID_TEXT_SPEC),
+        ])
+
+        creator = AgentTaskCreator(llm_fn=llm_fn, knowledge_root=tmp_path)
+
+        scenario_instance = creator.create("Write a haiku about distributed systems.")
+
+        # Proves the retry happened at the creator layer.
+        assert len(llm_fn.calls) == 2  # type: ignore[attr-defined]
+        # Proves creator returned a live instance (second attempt's spec was
+        # codegenned, loaded, and instantiated successfully).
+        assert scenario_instance is not None
+        # A persisted agent_task.py exists for the returned scenario.
+        persisted_files = list((tmp_path / "_custom_scenarios").rglob("agent_task.py"))
+        assert len(persisted_files) == 1, (
+            f"expected one persisted agent_task.py, got {persisted_files}"
+        )

--- a/autocontext/tests/test_agent_task_designer_retry.py
+++ b/autocontext/tests/test_agent_task_designer_retry.py
@@ -1,0 +1,78 @@
+"""AC-574 — retry-with-feedback loop when validate_intent catches designer drift."""
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+
+import pytest
+
+from autocontext.scenarios.custom.agent_task_designer import (
+    SPEC_END,
+    SPEC_START,
+    design_validated_agent_task,
+)
+from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+
+
+# --- Fixtures ---
+
+_VALID_TEXT_SPEC = AgentTaskSpec(
+    task_prompt="Write a haiku about distributed systems.",
+    judge_rubric="Score syllable accuracy (5-7-5), relevance, and imagery 0-1 each.",
+    output_format="free_text",
+    judge_model="",
+)
+
+_INVALID_CODE_FOR_TEXT_DESCRIPTION = AgentTaskSpec(
+    task_prompt="Implement a Python function that writes a haiku.",
+    judge_rubric="Score code quality, test coverage, and documentation.",
+    output_format="code",  # triggers format-mismatch against text description
+    judge_model="",
+)
+
+_TEXT_DESCRIPTION = "Write a haiku about distributed systems."
+
+
+def _spec_response(spec: AgentTaskSpec) -> str:
+    """Build the LLM response format expected by parse_agent_task_spec."""
+    data = {
+        "task_prompt": spec.task_prompt,
+        "judge_rubric": spec.judge_rubric,
+        "output_format": spec.output_format,
+        "judge_model": spec.judge_model,
+    }
+    return f"prefix\n{SPEC_START}\n{json.dumps(data)}\n{SPEC_END}\nsuffix"
+
+
+def _scripted_llm_fn(
+    responses: list[str],
+) -> Callable[[str, str], str]:
+    """Returns an llm_fn stub that yields each response in order and records calls."""
+    calls: list[tuple[str, str]] = []
+
+    def fn(system: str, user: str) -> str:
+        if not responses:
+            raise AssertionError(
+                f"llm_fn called more times than responses available; "
+                f"previous calls: {len(calls)}"
+            )
+        calls.append((system, user))
+        return responses.pop(0)
+
+    fn.calls = calls  # type: ignore[attr-defined]
+    return fn
+
+
+# --- Tests ---
+
+
+class TestDesignValidatedAgentTask:
+    def test_happy_path_no_retry_on_valid_spec(self) -> None:
+        llm_fn = _scripted_llm_fn([_spec_response(_VALID_TEXT_SPEC)])
+
+        spec = design_validated_agent_task(_TEXT_DESCRIPTION, llm_fn)
+
+        assert spec.task_prompt == _VALID_TEXT_SPEC.task_prompt
+        assert spec.output_format == "free_text"
+        assert len(llm_fn.calls) == 1  # type: ignore[attr-defined]

--- a/autocontext/tests/test_agent_task_designer_retry.py
+++ b/autocontext/tests/test_agent_task_designer_retry.py
@@ -14,7 +14,6 @@ from autocontext.scenarios.custom.agent_task_designer import (
 )
 from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
 
-
 # --- Fixtures ---
 
 _VALID_TEXT_SPEC = AgentTaskSpec(

--- a/autocontext/tests/test_agent_task_designer_retry.py
+++ b/autocontext/tests/test_agent_task_designer_retry.py
@@ -101,3 +101,65 @@ class TestDesignValidatedAgentTask:
             f"expected one retry warning, got {[r.message for r in warnings]}"
         )
         assert "attempt 1" in warnings[0].getMessage()
+
+    def test_raises_after_max_retries_exhausted(self) -> None:
+        # All 3 attempts return the invalid spec.
+        llm_fn = _scripted_llm_fn([
+            _spec_response(_INVALID_CODE_FOR_TEXT_DESCRIPTION),
+            _spec_response(_INVALID_CODE_FOR_TEXT_DESCRIPTION),
+            _spec_response(_INVALID_CODE_FOR_TEXT_DESCRIPTION),
+        ])
+
+        with pytest.raises(ValueError) as excinfo:
+            design_validated_agent_task(_TEXT_DESCRIPTION, llm_fn, max_retries=2)
+
+        message = str(excinfo.value)
+        assert "intent validation failed after 3 attempts" in message
+        assert "format mismatch" in message  # validator's error text present
+        assert len(llm_fn.calls) == 3  # type: ignore[attr-defined]
+
+    def test_retry_correction_prompt_contains_validator_errors(self) -> None:
+        llm_fn = _scripted_llm_fn([
+            _spec_response(_INVALID_CODE_FOR_TEXT_DESCRIPTION),
+            _spec_response(_VALID_TEXT_SPEC),
+        ])
+
+        design_validated_agent_task(_TEXT_DESCRIPTION, llm_fn)
+
+        assert len(llm_fn.calls) == 2  # type: ignore[attr-defined]
+        _system, retry_user_prompt = llm_fn.calls[1]  # type: ignore[attr-defined]
+
+        assert "Please regenerate" in retry_user_prompt
+        assert "Validation errors" in retry_user_prompt
+        assert "format mismatch" in retry_user_prompt
+        # The original description must still be present so the LLM has task context.
+        assert _TEXT_DESCRIPTION in retry_user_prompt
+        # Hints block should be present.
+        assert "output_format='free_text'" in retry_user_prompt
+
+    def test_max_retries_zero_makes_exactly_one_attempt(self) -> None:
+        llm_fn = _scripted_llm_fn([
+            _spec_response(_INVALID_CODE_FOR_TEXT_DESCRIPTION),
+        ])
+
+        with pytest.raises(ValueError) as excinfo:
+            design_validated_agent_task(_TEXT_DESCRIPTION, llm_fn, max_retries=0)
+
+        assert "intent validation failed after 1 attempts" in str(excinfo.value)
+        assert len(llm_fn.calls) == 1  # type: ignore[attr-defined]
+
+    def test_max_retries_three_allows_four_total_attempts(self) -> None:
+        # First 3 invalid, 4th valid.
+        llm_fn = _scripted_llm_fn([
+            _spec_response(_INVALID_CODE_FOR_TEXT_DESCRIPTION),
+            _spec_response(_INVALID_CODE_FOR_TEXT_DESCRIPTION),
+            _spec_response(_INVALID_CODE_FOR_TEXT_DESCRIPTION),
+            _spec_response(_VALID_TEXT_SPEC),
+        ])
+
+        spec = design_validated_agent_task(
+            _TEXT_DESCRIPTION, llm_fn, max_retries=3
+        )
+
+        assert spec.output_format == "free_text"
+        assert len(llm_fn.calls) == 4  # type: ignore[attr-defined]

--- a/autocontext/tests/test_agent_task_designer_retry.py
+++ b/autocontext/tests/test_agent_task_designer_retry.py
@@ -101,6 +101,21 @@ class TestDesignValidatedAgentTask:
         )
         assert "attempt 1" in warnings[0].getMessage()
 
+    def test_retries_after_unparseable_designer_response(self) -> None:
+        llm_fn = _scripted_llm_fn([
+            "not delimited json",
+            _spec_response(_VALID_TEXT_SPEC),
+        ])
+
+        spec = design_validated_agent_task(_TEXT_DESCRIPTION, llm_fn)
+
+        assert spec.output_format == "free_text"
+        assert len(llm_fn.calls) == 2  # type: ignore[attr-defined]
+        _system, retry_user_prompt = llm_fn.calls[1]  # type: ignore[attr-defined]
+        assert "could not be parsed" in retry_user_prompt
+        assert SPEC_START in retry_user_prompt
+        assert _TEXT_DESCRIPTION in retry_user_prompt
+
     def test_raises_after_max_retries_exhausted(self) -> None:
         # All 3 attempts return the invalid spec.
         llm_fn = _scripted_llm_fn([
@@ -115,6 +130,21 @@ class TestDesignValidatedAgentTask:
         message = str(excinfo.value)
         assert "intent validation failed after 3 attempts" in message
         assert "format mismatch" in message  # validator's error text present
+        assert len(llm_fn.calls) == 3  # type: ignore[attr-defined]
+
+    def test_raises_after_parse_retries_exhausted(self) -> None:
+        llm_fn = _scripted_llm_fn([
+            "not delimited json",
+            "still not delimited json",
+            "also not delimited json",
+        ])
+
+        with pytest.raises(ValueError) as excinfo:
+            design_validated_agent_task(_TEXT_DESCRIPTION, llm_fn, max_retries=2)
+
+        message = str(excinfo.value)
+        assert "agent task design failed after 3 attempts" in message
+        assert "response does not contain AGENT_TASK_SPEC delimiters" in message
         assert len(llm_fn.calls) == 3  # type: ignore[attr-defined]
 
     def test_retry_correction_prompt_contains_validator_errors(self) -> None:

--- a/autocontext/tests/test_agent_task_designer_retry.py
+++ b/autocontext/tests/test_agent_task_designer_retry.py
@@ -76,3 +76,28 @@ class TestDesignValidatedAgentTask:
         assert spec.task_prompt == _VALID_TEXT_SPEC.task_prompt
         assert spec.output_format == "free_text"
         assert len(llm_fn.calls) == 1  # type: ignore[attr-defined]
+
+    def test_retries_once_then_succeeds(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # First attempt: invalid (code format for a text description).
+        # Second attempt: valid.
+        llm_fn = _scripted_llm_fn([
+            _spec_response(_INVALID_CODE_FOR_TEXT_DESCRIPTION),
+            _spec_response(_VALID_TEXT_SPEC),
+        ])
+
+        with caplog.at_level(
+            logging.WARNING, logger="autocontext.scenarios.custom.agent_task_designer"
+        ):
+            spec = design_validated_agent_task(_TEXT_DESCRIPTION, llm_fn)
+
+        assert spec.output_format == "free_text"
+        assert len(llm_fn.calls) == 2  # type: ignore[attr-defined]
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, (
+            f"expected one retry warning, got {[r.message for r in warnings]}"
+        )
+        assert "attempt 1" in warnings[0].getMessage()

--- a/autocontext/tests/test_intent_validation.py
+++ b/autocontext/tests/test_intent_validation.py
@@ -311,7 +311,7 @@ class TestCreatorIntentValidation:
 
         with (
             patch(
-                "autocontext.scenarios.custom.agent_task_creator.design_agent_task",
+                "autocontext.scenarios.custom.agent_task_creator.design_validated_agent_task",
                 return_value=bad_spec,
             ),
             patch(


### PR DESCRIPTION
Closes AC-574.

## What changed

- New function `design_validated_agent_task(description, llm_fn, max_retries=2)` in `agent_task_designer.py` wraps `design_agent_task` with a retry-on-intent-drift loop.
- On each retry, the LLM receives a correction prompt naming the validator's errors and hints (text vs code vs json format mapping).
- `ScenarioCreator.create()` now calls `design_validated_agent_task` instead of `design_agent_task` directly. The post-design `validate_intent` guard at line 115 stays as defense-in-depth.
- WARNING log per retry at `autocontext.scenarios.custom.agent_task_designer` so operators see which drift patterns are surfacing in production.

## Why

On 0.4.3, AC-268 (rubric drift) and AC-272 (clinical trial) escalation prompts hit `ValueError: intent validation failed …` from the LLM designer generating specs with wrong `output_format`. One bad spec killed the solve job with no chance for the LLM to self-correct. This PR gives the designer a bounded retry budget (2 retries = 3 attempts total) and feeds the validator's error back into the retry prompt so the LLM can fix the drift.

## Non-goals in this PR

- Non-parametric families (simulation, artifact_editing, …) — tracked in AC-575.
- Changes to `validate_intent` itself — it's correct, just lacked a retry partner.
- Configurable `max_retries` via CLI or env var — hardcoded default is fine until evidence demands a knob.

## Tests

6 unit tests in `tests/test_agent_task_designer_retry.py`:

- `test_happy_path_no_retry_on_valid_spec`
- `test_retries_once_then_succeeds` (+ WARNING log assertion)
- `test_raises_after_max_retries_exhausted`
- `test_retry_correction_prompt_contains_validator_errors`
- `test_max_retries_zero_makes_exactly_one_attempt`
- `test_max_retries_three_allows_four_total_attempts`

1 end-to-end test in `tests/test_agent_task_creator_retry.py`:

- `test_creator_retries_on_intent_drift_and_succeeds`

1 pre-existing test updated: `test_intent_validation.py::test_creator_calls_validate_intent` — patches `design_validated_agent_task` instead of `design_agent_task` now that the creator routes through the retry wrapper.

Full suite: **5373 passed**, ruff + mypy clean.

## Linear

- AC-574 (closes this)
- AC-571 (original misfiled issue, correction comment added; AC-574 is the real follow-up)
- AC-575 (sibling: non-parametric designer JSON parse — separate PR)