### PR TITLE
fix: stabilize long-horizon solve execution

### DIFF
--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -30,6 +30,10 @@ from autocontext.config import load_settings
 from autocontext.config.presets import VALID_PRESET_NAMES
 from autocontext.config.settings import AppSettings
 from autocontext.execution.improvement_loop import ImprovementLoop
+from autocontext.execution.task_runtime_budget import (
+    TASK_LIKE_EXECUTION_SYSTEM_PROMPT,
+    resolve_task_like_completion_max_tokens,
+)
 from autocontext.loop.generation_runner import GenerationRunner
 from autocontext.providers.base import ProviderError
 from autocontext.scenarios import SCENARIO_REGISTRY
@@ -242,11 +246,13 @@ def _run_agent_task(
     if context_errors:
         raise ValueError(f"Context validation failed: {'; '.join(context_errors)}")
     prompt = task.get_task_prompt(state)
+    initial_completion_max_tokens = resolve_task_like_completion_max_tokens(state, prompt)
 
     initial_output = provider.complete(
-        system_prompt="Complete the task precisely.",
+        system_prompt=TASK_LIKE_EXECUTION_SYSTEM_PROMPT,
         user_prompt=prompt,
         model=provider_model,
+        max_tokens=initial_completion_max_tokens,
     ).text
 
     loop = ImprovementLoop(task=task, max_rounds=max_rounds)

--- a/autocontext/src/autocontext/cli_role_runtime.py
+++ b/autocontext/src/autocontext/cli_role_runtime.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from autocontext.agents.orchestrator import AgentOrchestrator
 from autocontext.config.settings import AppSettings
+from autocontext.providers.base import CompletionResult, LLMProvider
 from autocontext.storage import SQLiteStore, artifact_store_from_settings
 
 if TYPE_CHECKING:
@@ -30,25 +31,40 @@ def _role_default_model(settings: AppSettings, role: str) -> str:
     return role_models.get(role) or settings.agent_default_model
 
 
+class _RoleRuntimeProvider(LLMProvider):
+    def __init__(self, client: LanguageModelClient, resolved_model: str, *, role: str) -> None:
+        self._client = client
+        self._resolved_model = resolved_model
+        self._role = role
+
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+    ) -> CompletionResult:
+        response = self._client.generate(
+            model=model or self._resolved_model,
+            prompt=f"{system_prompt}\n\n{user_prompt}" if system_prompt else user_prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            role=self._role,
+        )
+        return CompletionResult(text=response.text, model=model or self._resolved_model)
+
+    def default_model(self) -> str:
+        return self._resolved_model
+
+
 def _wrap_role_client_as_provider(
     client: LanguageModelClient,
     resolved_model: str,
     *,
     role: str,
 ) -> tuple[LLMProvider, str]:
-    from autocontext.providers.callable_wrapper import CallableProvider
-
-    def _llm_fn(system_prompt: str, user_prompt: str) -> str:
-        response = client.generate(
-            model=resolved_model,
-            prompt=f"{system_prompt}\n\n{user_prompt}" if system_prompt else user_prompt,
-            max_tokens=4096,
-            temperature=0.0,
-            role=role,
-        )
-        return response.text
-
-    return CallableProvider(_llm_fn, model_name=resolved_model), resolved_model
+    return _RoleRuntimeProvider(client, resolved_model, role=role), resolved_model
 
 
 def resolve_role_runtime(

--- a/autocontext/src/autocontext/execution/task_runtime_budget.py
+++ b/autocontext/src/autocontext/execution/task_runtime_budget.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+TASK_LIKE_EXECUTION_SYSTEM_PROMPT = (
+    "Complete the task precisely. Return only the required answer. Be concise and stop once the task requirements are satisfied."
+)
+
+_TASK_LIKE_COMPLETION_MAX_TOKENS: dict[str, int] = {
+    "free_text": 1600,
+    "json_schema": 2200,
+    "code": 2600,
+}
+_DEFAULT_TASK_LIKE_COMPLETION_MAX_TOKENS = 1800
+
+
+def resolve_task_like_completion_max_tokens(state: dict, prompt: str) -> int:
+    """Return a bounded response budget for task-like initial completions.
+
+    Solve-created agent-task scenarios can ask for large structured outputs. Letting
+    the runtime default to a very large completion budget increases latency and can
+    trigger live Pi timeouts for roadmap-style prompts. This helper centralizes a
+    tighter, output-format-aware cap for the first completion.
+    """
+    del prompt
+    output_format = state.get("output_format")
+    if isinstance(output_format, str):
+        normalized = output_format.strip().lower()
+        if normalized in _TASK_LIKE_COMPLETION_MAX_TOKENS:
+            return _TASK_LIKE_COMPLETION_MAX_TOKENS[normalized]
+    return _DEFAULT_TASK_LIKE_COMPLETION_MAX_TOKENS

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -338,12 +338,13 @@ def _complete_task_like_initial_output(
     attempts = 3
     for attempt in range(1, attempts + 1):
         try:
-            return provider.complete(
+            result = provider.complete(
                 system_prompt=TASK_LIKE_EXECUTION_SYSTEM_PROMPT,
                 user_prompt=prompt,
                 model=provider_model,
                 max_tokens=initial_completion_max_tokens,
-            ).text
+            )
+            return cast(str, result.text)
         except Exception as exc:
             if not _is_timeout_like_error(exc) or attempt == attempts:
                 raise

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -16,6 +16,10 @@ from autocontext.agents.types import LlmFn
 from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.config.settings import AppSettings
 from autocontext.execution.improvement_loop import ImprovementLoop
+from autocontext.execution.task_runtime_budget import (
+    TASK_LIKE_EXECUTION_SYSTEM_PROMPT,
+    resolve_task_like_completion_max_tokens,
+)
 from autocontext.knowledge.export import SkillPackage, export_skill_package
 from autocontext.mcp.tools import MtsToolContext
 from autocontext.scenarios import SCENARIO_REGISTRY
@@ -319,6 +323,39 @@ def _build_solve_description_brief(description: str) -> str:
     return brief or description.strip()
 
 
+def _is_timeout_like_error(exc: Exception) -> bool:
+    return "timeout" in str(exc).lower()
+
+
+def _complete_task_like_initial_output(
+    *,
+    provider: Any,
+    provider_model: str,
+    state: dict,
+    prompt: str,
+) -> str:
+    initial_completion_max_tokens = resolve_task_like_completion_max_tokens(state, prompt)
+    attempts = 3
+    for attempt in range(1, attempts + 1):
+        try:
+            return provider.complete(
+                system_prompt=TASK_LIKE_EXECUTION_SYSTEM_PROMPT,
+                user_prompt=prompt,
+                model=provider_model,
+                max_tokens=initial_completion_max_tokens,
+            ).text
+        except Exception as exc:
+            if not _is_timeout_like_error(exc) or attempt == attempts:
+                raise
+            logger.warning(
+                "task-like initial completion timed out on attempt %d/%d; retrying",
+                attempt,
+                attempts,
+                exc_info=True,
+            )
+    raise RuntimeError("unreachable task-like completion retry state")
+
+
 def _normalize_family_hint_token(token: str) -> str:
     normalized = re.sub(r"[^a-z0-9_\-\s]", " ", token.lower()).strip()
     return normalized.replace("-", "_").replace(" ", "_")
@@ -483,11 +520,12 @@ class SolveScenarioExecutor:
             if context_errors:
                 raise ValueError(f"Context validation failed: {'; '.join(context_errors)}")
             prompt = budgeted_task.get_task_prompt(state)
-            initial_output = provider.complete(
-                system_prompt="Complete the task precisely.",
-                user_prompt=prompt,
-                model=provider_model,
-            ).text
+            initial_output = _complete_task_like_initial_output(
+                provider=provider,
+                provider_model=provider_model,
+                state=state,
+                prompt=prompt,
+            )
             budget.check("initial generation")
             sqlite.append_agent_output(active_run_id, 1, "competitor_initial", initial_output)
 

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_spec.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_spec.py
@@ -4,6 +4,8 @@ import json
 from dataclasses import dataclass, replace
 from typing import Any
 
+_SAMPLE_INPUT_COMPACT_THRESHOLD_CHARS = 1000
+
 
 @dataclass(slots=True)
 class AgentTaskSpec:
@@ -27,6 +29,8 @@ class AgentTaskSpec:
 
 
 def _compact_json_string(value: str) -> str:
+    if len(value) < _SAMPLE_INPUT_COMPACT_THRESHOLD_CHARS:
+        return value
     stripped = value.strip()
     if not stripped:
         return value

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_spec.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_spec.py
@@ -26,6 +26,19 @@ class AgentTaskSpec:
     sample_input: str | None = None  # Sample input data for data-dependent tasks
 
 
+def _compact_json_string(value: str) -> str:
+    stripped = value.strip()
+    if not stripped:
+        return value
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return value
+    if not isinstance(parsed, dict | list):
+        return value
+    return json.dumps(parsed, separators=(",", ":"), ensure_ascii=False)
+
+
 def _serialize_agent_task_text_payload(value: Any) -> str | None:
     if value is None:
         return None
@@ -122,5 +135,9 @@ def normalize_agent_task_runtime_fields(spec: AgentTaskSpec) -> AgentTaskSpec:
         max_rounds=_normalize_max_rounds(spec.max_rounds),
         quality_threshold=_normalize_quality_threshold(spec.quality_threshold),
         revision_prompt=_serialize_agent_task_text_payload(spec.revision_prompt),
-        sample_input=_serialize_agent_task_text_payload(spec.sample_input),
+        sample_input=(
+            _compact_json_string(spec.sample_input)
+            if isinstance(spec.sample_input, str)
+            else _serialize_agent_task_text_payload(spec.sample_input)
+        ),
     )

--- a/autocontext/tests/test_agent_task_pipeline.py
+++ b/autocontext/tests/test_agent_task_pipeline.py
@@ -301,20 +301,29 @@ class TestDesignAgentTask:
 
         assert spec.quality_threshold == 0.9
 
-    def test_parse_spec_compacts_json_string_sample_input(self) -> None:
+    def test_parse_spec_compacts_large_json_string_sample_input(self) -> None:
+        sample_input = {
+            "current_generation": 12,
+            "metrics": {"success_rate": 0.31, "cost": 0.92},
+            "roadmap": [
+                {
+                    "step": i,
+                    "goal": f"Stabilize generation {i}",
+                    "notes": "Preserve enough execution detail for long-horizon solve planning.",
+                }
+                for i in range(20)
+            ],
+        }
         spec_data = {
             "task_prompt": "Plan the next milestone.",
             "judge_rubric": "Evaluate milestone quality.",
-            "sample_input": json.dumps(
-                {"current_generation": 12, "metrics": {"success_rate": 0.31, "cost": 0.92}},
-                indent=2,
-            ),
+            "sample_input": json.dumps(sample_input, indent=2),
         }
         raw = f"{SPEC_START}\n{json.dumps(spec_data, indent=2)}\n{SPEC_END}"
 
         spec = parse_agent_task_spec(raw)
 
-        assert spec.sample_input == '{"current_generation":12,"metrics":{"success_rate":0.31,"cost":0.92}}'
+        assert spec.sample_input == json.dumps(sample_input, separators=(",", ":"), ensure_ascii=False)
 
     def test_design_agent_task_with_mock(self) -> None:
         response_text = _mock_llm_response(SAMPLE_SPEC)

--- a/autocontext/tests/test_agent_task_pipeline.py
+++ b/autocontext/tests/test_agent_task_pipeline.py
@@ -301,6 +301,21 @@ class TestDesignAgentTask:
 
         assert spec.quality_threshold == 0.9
 
+    def test_parse_spec_compacts_json_string_sample_input(self) -> None:
+        spec_data = {
+            "task_prompt": "Plan the next milestone.",
+            "judge_rubric": "Evaluate milestone quality.",
+            "sample_input": json.dumps(
+                {"current_generation": 12, "metrics": {"success_rate": 0.31, "cost": 0.92}},
+                indent=2,
+            ),
+        }
+        raw = f"{SPEC_START}\n{json.dumps(spec_data, indent=2)}\n{SPEC_END}"
+
+        spec = parse_agent_task_spec(raw)
+
+        assert spec.sample_input == '{"current_generation":12,"metrics":{"success_rate":0.31,"cost":0.92}}'
+
     def test_design_agent_task_with_mock(self) -> None:
         response_text = _mock_llm_response(SAMPLE_SPEC)
 

--- a/autocontext/tests/test_cli_solve_runtime.py
+++ b/autocontext/tests/test_cli_solve_runtime.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from autocontext.cli import app
+from autocontext.cli_role_runtime import _wrap_role_client_as_provider
 from autocontext.config.settings import AppSettings
 from autocontext.knowledge.export import SkillPackage
 from autocontext.knowledge.solver import SolveJob
@@ -73,6 +74,27 @@ def _settings(tmp_path: Path, **overrides: object) -> AppSettings:
         pi_timeout=float(overrides.get("pi_timeout", 300.0)),
         generation_time_budget_seconds=int(overrides.get("generation_time_budget_seconds", 0)),
     )
+
+
+class TestRoleRuntimeProvider:
+    def test_wrap_role_runtime_provider_forwards_max_tokens(self) -> None:
+        captured: dict[str, object] = {}
+
+        class _Response:
+            text = "ok"
+
+        class _Client:
+            def generate(self, **kwargs: object) -> _Response:
+                captured.update(kwargs)
+                return _Response()
+
+        provider, model = _wrap_role_client_as_provider(_Client(), "test-model", role="competitor")
+        result = provider.complete("system", "user", model=model, temperature=0.2, max_tokens=1234)
+
+        assert result.text == "ok"
+        assert captured["max_tokens"] == 1234
+        assert captured["temperature"] == 0.2
+        assert captured["role"] == "competitor"
 
 
 class TestSolveRuntimeOverrides:

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -71,9 +71,25 @@ class _StubProviderResponse:
 class _StubProvider:
     def __init__(self, text: str) -> None:
         self._text = text
+        self.calls: list[dict[str, object]] = []
 
-    def complete(self, system_prompt: str, user_prompt: str, model: str = "") -> _StubProviderResponse:
-        del system_prompt, user_prompt, model
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str = "",
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+    ) -> _StubProviderResponse:
+        self.calls.append(
+            {
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "model": model,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            }
+        )
         return _StubProviderResponse(self._text)
 
     def default_model(self) -> str:
@@ -589,6 +605,107 @@ class TestSolveScenarioExecutor:
         assert summary.generations_executed == 1
         assert summary.best_score == 1.0
         assert sqlite.count_completed_runs(scenario_name) == 1
+
+    def test_task_like_executor_uses_output_format_completion_budget(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solver import SolveScenarioExecutor
+
+        class _JsonSolveAgentTask(_SolveAgentTask):
+            def initial_state(self, seed: int | None = None) -> dict:
+                del seed
+                return {"output_format": "json_schema"}
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+        )
+        scenario_name = "solve_json_task_execution"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        provider = _StubProvider("improved draft")
+        SCENARIO_REGISTRY[scenario_name] = _JsonSolveAgentTask
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.resolve_role_runtime",
+            lambda settings, **kwargs: (provider, "test-model"),
+        )
+
+        try:
+            executor = SolveScenarioExecutor(settings)
+            summary = executor.execute(
+                scenario_name=scenario_name,
+                family_name="agent_task",
+                generations=1,
+            )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        assert summary.best_score == 1.0
+        assert provider.calls[0]["max_tokens"] == 2200
+        assert "Be concise" in str(provider.calls[0]["system_prompt"])
+
+    def test_task_like_executor_retries_timeout_once(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solver import SolveScenarioExecutor
+
+        class _FlakyTimeoutProvider(_StubProvider):
+            def __init__(self) -> None:
+                super().__init__("improved draft")
+                self._attempt = 0
+
+            def complete(
+                self,
+                system_prompt: str,
+                user_prompt: str,
+                model: str = "",
+                temperature: float = 0.0,
+                max_tokens: int = 4096,
+            ) -> _StubProviderResponse:
+                self._attempt += 1
+                if self._attempt == 1:
+                    raise RuntimeError("PiCLIRuntime failed: timeout")
+                return super().complete(
+                    system_prompt,
+                    user_prompt,
+                    model=model,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+        )
+        scenario_name = "solve_retry_timeout_execution"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        provider = _FlakyTimeoutProvider()
+        SCENARIO_REGISTRY[scenario_name] = _SolveAgentTask
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.resolve_role_runtime",
+            lambda settings, **kwargs: (provider, "test-model"),
+        )
+
+        try:
+            summary = SolveScenarioExecutor(settings).execute(
+                scenario_name=scenario_name,
+                family_name="agent_task",
+                generations=1,
+            )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        assert summary.best_score == 1.0
+        assert provider._attempt == 2
 
     def test_task_like_executor_marks_run_failed_when_budget_expires(
         self,


### PR DESCRIPTION
## Summary

- stabilize flaky Python `solve` execution for the `AC-391` / `strategy_cartographer` current-scenario path
- add a shared task-like runtime budget policy so solve-created and directly run agent tasks use a tighter initial completion budget plus a concise execution prompt
- retry transient timeout-like failures during the first task-like completion and compact JSON sample-input payloads to reduce prompt bloat for large long-horizon planning scenarios

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/cli_role_runtime.py src/autocontext/knowledge/solver.py src/autocontext/execution/task_runtime_budget.py src/autocontext/cli.py src/autocontext/scenarios/custom/agent_task_spec.py tests/test_knowledge_solver.py tests/test_cli_solve_runtime.py tests/test_agent_task_pipeline.py`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest tests/test_knowledge_solver.py tests/test_cli_solve_runtime.py tests/test_agent_task_pipeline.py tests/test_auto_sample_input.py tests/test_intent_validation.py tests/test_time_budget.py -k 'output_format_completion_budget or wrap_role_runtime_provider_forwards_max_tokens or retries_timeout_once or compacts_json_string_sample_input or structured_quality_threshold or structured_judge_rubric or inline_example_parentheticals or meta_learning or capability_bootstrapping or solve' -x --tb=short`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Additional verification:
- failing-first runtime tests:
  - `cd autocontext && uv run pytest tests/test_knowledge_solver.py tests/test_cli_solve_runtime.py -k 'output_format_completion_budget or wrap_role_runtime_provider_forwards_max_tokens or retries_timeout_once' -x --tb=short`
  - `3 passed`
- focused sample-input compaction checks:
  - `cd autocontext && uv run pytest tests/test_agent_task_pipeline.py -k 'structured_quality_threshold or compacts_json_string_sample_input' -x --tb=short`
  - `2 passed`
- broader targeted Python suite:
  - `27 passed, 112 deselected`
- flaky repro before fix:
  - `/tmp/ac573-repro-43FzjL`
  - `run-1` and `run-4` failed with initial task execution timeout
- post-fix live burn-in:
  - `/tmp/ac573-live-fixed6-l0mCLT`
  - `4 / 4` successful `AC-391` solves
  - representative success: `/tmp/ac573-live-fixed6-l0mCLT/run-1/stdout.log`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- adds `src/autocontext/execution/task_runtime_budget.py` as the shared bounded context for task-like initial completion policy
- `cli_role_runtime` now uses a dedicated role-runtime provider that forwards per-call `max_tokens` / `temperature` to the underlying client instead of silently ignoring them
- `solver` now retries timeout-like failures during the initial task-like completion and uses the shared runtime budget helper
- `cli.py` uses the same shared task-like runtime budget helper so direct agent-task execution stays aligned with solve behavior
- `agent_task_spec` now compacts JSON-string `sample_input` payloads to reduce prompt size for large scenario inputs like long-horizon planning
- this PR is stacked on top of AC-572 / PR #723 because the long-horizon execution flake only surfaced after the earlier current-scenario solve fixes landed
