### PR TITLE
feat(ac-575): parse-retry wrapper for all custom scenario designers

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
@@ -125,9 +125,15 @@ def design_agent_task(description: str, llm_fn: LlmFn) -> AgentTaskSpec:
     Returns:
         Parsed AgentTaskSpec.
     """
-    user_prompt = f"User description:\n{description}"
-    response = llm_fn(AGENT_TASK_DESIGNER_SYSTEM, user_prompt)
-    return parse_agent_task_spec(response)
+    from autocontext.scenarios.custom.designer_retry import design_with_parse_retry
+
+    return design_with_parse_retry(
+        llm_fn=llm_fn,
+        system_prompt=AGENT_TASK_DESIGNER_SYSTEM,
+        user_prompt=f"User description:\n{description}",
+        parser=parse_agent_task_spec,
+        delimiter_hint=f"{SPEC_START} ... {SPEC_END}",
+    )
 
 
 def design_validated_agent_task(

--- a/autocontext/src/autocontext/scenarios/custom/artifact_editing_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/artifact_editing_designer.py
@@ -79,5 +79,12 @@ def parse_artifact_editing_spec(text: str) -> ArtifactEditingSpec:
 
 
 def design_artifact_editing(description: str, llm_fn: LlmFn) -> ArtifactEditingSpec:
-    response = llm_fn(ARTIFACT_EDITING_DESIGNER_SYSTEM, f"User description:\n{description}")
-    return parse_artifact_editing_spec(response)
+    from autocontext.scenarios.custom.designer_retry import design_with_parse_retry
+
+    return design_with_parse_retry(
+        llm_fn=llm_fn,
+        system_prompt=ARTIFACT_EDITING_DESIGNER_SYSTEM,
+        user_prompt=f"User description:\n{description}",
+        parser=parse_artifact_editing_spec,
+        delimiter_hint=f"{ARTIFACT_SPEC_START} ... {ARTIFACT_SPEC_END}",
+    )

--- a/autocontext/src/autocontext/scenarios/custom/coordination_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/coordination_designer.py
@@ -104,6 +104,12 @@ def parse_coordination_spec(text: str) -> CoordinationSpec:
 def design_coordination(
     description: str, llm_fn: LlmFn
 ) -> CoordinationSpec:
-    return parse_coordination_spec(
-        llm_fn(COORDINATION_DESIGNER_SYSTEM, f"User description:\n{description}")
+    from autocontext.scenarios.custom.designer_retry import design_with_parse_retry
+
+    return design_with_parse_retry(
+        llm_fn=llm_fn,
+        system_prompt=COORDINATION_DESIGNER_SYSTEM,
+        user_prompt=f"User description:\n{description}",
+        parser=parse_coordination_spec,
+        delimiter_hint=f"{COORDINATION_SPEC_START} ... {COORDINATION_SPEC_END}",
     )

--- a/autocontext/src/autocontext/scenarios/custom/designer_retry.py
+++ b/autocontext/src/autocontext/scenarios/custom/designer_retry.py
@@ -1,0 +1,102 @@
+"""AC-575 — shared parse-retry helper for custom scenario designers.
+
+All ``design_X`` entry points under ``autocontext.scenarios.custom`` share the
+same shape: call ``llm_fn(system, user)``, then pass the response through
+``parse_X_spec``. When the LLM emits a response with an empty or malformed
+JSON body between the expected delimiters, the parser raises
+``JSONDecodeError`` or ``ValueError`` and the solve job dies.
+
+This helper wraps the call/parse pair with a bounded retry loop. On parse
+failure it regenerates with a correction prompt naming the validator error
+and the expected delimiter shape.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from typing import TypeVar
+
+from autocontext.agents.types import LlmFn
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def design_with_parse_retry(
+    *,
+    llm_fn: LlmFn,
+    system_prompt: str,
+    user_prompt: str,
+    parser: Callable[[str], T],
+    delimiter_hint: str,
+    max_retries: int = 2,
+) -> T:
+    """Call ``llm_fn`` and ``parser``, retrying on parse failures.
+
+    On each attempt:
+    - Call ``llm_fn(system_prompt, effective_user_prompt)``
+    - Call ``parser(response)``
+    - If parser returns a value → return it
+    - If parser raises ``JSONDecodeError`` or ``ValueError`` → build correction
+      prompt, loop
+    - If exhausted → raise ``ValueError`` with all attempts' errors
+
+    Total attempts = ``max_retries + 1``. Default ``max_retries=2`` (3 attempts).
+
+    ``delimiter_hint`` is embedded verbatim in the correction prompt so the LLM
+    sees which token pair to wrap its JSON in.
+
+    Raises:
+        ValueError: when parse still fails after ``max_retries + 1`` attempts.
+    """
+    total_attempts = max_retries + 1
+    errors: list[str] = []
+    effective_user_prompt = user_prompt
+
+    for attempt in range(total_attempts):
+        response = llm_fn(system_prompt, effective_user_prompt)
+        try:
+            return parser(response)
+        except (json.JSONDecodeError, ValueError) as exc:
+            error_text = f"{type(exc).__name__}: {exc}"
+            errors.append(error_text)
+
+            if attempt < total_attempts - 1:
+                logger.warning(
+                    "designer parse failed on attempt %d/%d: %s; retrying with correction prompt",
+                    attempt + 1,
+                    total_attempts,
+                    error_text,
+                )
+                effective_user_prompt = _build_correction_prompt(
+                    original_user_prompt=user_prompt,
+                    error_message=error_text,
+                    delimiter_hint=delimiter_hint,
+                )
+
+    raise ValueError(
+        f"designer parse failed after {total_attempts} attempts. "
+        f"Errors per attempt: {errors}"
+    )
+
+
+def _build_correction_prompt(
+    *,
+    original_user_prompt: str,
+    error_message: str,
+    delimiter_hint: str,
+) -> str:
+    """Build the retry user prompt after a parse failure."""
+    return (
+        "Your previous response could not be parsed as valid JSON.\n\n"
+        "Original request:\n"
+        f"{original_user_prompt}\n\n"
+        f"Parse error: {error_message}\n\n"
+        "Please regenerate your response. The JSON block MUST be:\n"
+        f"- wrapped in the specified delimiters: {delimiter_hint}\n"
+        "- non-empty between the delimiters\n"
+        "- valid JSON (no trailing commas, properly quoted keys, escaped newlines in strings)\n"
+        "- match the schema from the system prompt exactly"
+    )

--- a/autocontext/src/autocontext/scenarios/custom/designer_retry.py
+++ b/autocontext/src/autocontext/scenarios/custom/designer_retry.py
@@ -3,8 +3,9 @@
 All ``design_X`` entry points under ``autocontext.scenarios.custom`` share the
 same shape: call ``llm_fn(system, user)``, then pass the response through
 ``parse_X_spec``. When the LLM emits a response with an empty or malformed
-JSON body between the expected delimiters, the parser raises
-``JSONDecodeError`` or ``ValueError`` and the solve job dies.
+JSON body between the expected delimiters, or syntactically valid JSON that is
+missing required schema fields, the parser raises a parse/schema exception and
+the solve job dies.
 
 This helper wraps the call/parse pair with a bounded retry loop. On parse
 failure it regenerates with a correction prompt naming the validator error
@@ -22,6 +23,7 @@ from autocontext.agents.types import LlmFn
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+_PARSER_RETRY_EXCEPTIONS = (json.JSONDecodeError, ValueError, KeyError, TypeError)
 
 
 def design_with_parse_retry(
@@ -39,8 +41,7 @@ def design_with_parse_retry(
     - Call ``llm_fn(system_prompt, effective_user_prompt)``
     - Call ``parser(response)``
     - If parser returns a value → return it
-    - If parser raises ``JSONDecodeError`` or ``ValueError`` → build correction
-      prompt, loop
+    - If parser raises a parse/schema exception → build correction prompt, loop
     - If exhausted → raise ``ValueError`` with all attempts' errors
 
     Total attempts = ``max_retries + 1``. Default ``max_retries=2`` (3 attempts).
@@ -59,7 +60,7 @@ def design_with_parse_retry(
         response = llm_fn(system_prompt, effective_user_prompt)
         try:
             return parser(response)
-        except (json.JSONDecodeError, ValueError) as exc:
+        except _PARSER_RETRY_EXCEPTIONS as exc:
             error_text = f"{type(exc).__name__}: {exc}"
             errors.append(error_text)
 

--- a/autocontext/src/autocontext/scenarios/custom/investigation_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/investigation_designer.py
@@ -114,6 +114,12 @@ def parse_investigation_spec(text: str) -> InvestigationSpec:
 
 
 def design_investigation(description: str, llm_fn: LlmFn) -> InvestigationSpec:
-    return parse_investigation_spec(
-        llm_fn(INVESTIGATION_DESIGNER_SYSTEM, f"User description:\n{description}")
+    from autocontext.scenarios.custom.designer_retry import design_with_parse_retry
+
+    return design_with_parse_retry(
+        llm_fn=llm_fn,
+        system_prompt=INVESTIGATION_DESIGNER_SYSTEM,
+        user_prompt=f"User description:\n{description}",
+        parser=parse_investigation_spec,
+        delimiter_hint=f"{INVESTIGATION_SPEC_START} ... {INVESTIGATION_SPEC_END}",
     )

--- a/autocontext/src/autocontext/scenarios/custom/negotiation_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/negotiation_designer.py
@@ -123,6 +123,12 @@ def parse_negotiation_spec(text: str) -> NegotiationSpec:
 def design_negotiation(
     description: str, llm_fn: LlmFn
 ) -> NegotiationSpec:
-    return parse_negotiation_spec(
-        llm_fn(NEGOTIATION_DESIGNER_SYSTEM, f"User description:\n{description}")
+    from autocontext.scenarios.custom.designer_retry import design_with_parse_retry
+
+    return design_with_parse_retry(
+        llm_fn=llm_fn,
+        system_prompt=NEGOTIATION_DESIGNER_SYSTEM,
+        user_prompt=f"User description:\n{description}",
+        parser=parse_negotiation_spec,
+        delimiter_hint=f"{NEGOTIATION_SPEC_START} ... {NEGOTIATION_SPEC_END}",
     )

--- a/autocontext/src/autocontext/scenarios/custom/operator_loop_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/operator_loop_designer.py
@@ -67,4 +67,12 @@ def parse_operator_loop_spec(text: str) -> OperatorLoopSpec:
 
 
 def design_operator_loop(description: str, llm_fn: LlmFn) -> OperatorLoopSpec:
-    return parse_operator_loop_spec(llm_fn(OPERATOR_LOOP_DESIGNER_SYSTEM, f"User description:\n{description}"))
+    from autocontext.scenarios.custom.designer_retry import design_with_parse_retry
+
+    return design_with_parse_retry(
+        llm_fn=llm_fn,
+        system_prompt=OPERATOR_LOOP_DESIGNER_SYSTEM,
+        user_prompt=f"User description:\n{description}",
+        parser=parse_operator_loop_spec,
+        delimiter_hint=f"{OPERATOR_LOOP_SPEC_START} ... {OPERATOR_LOOP_SPEC_END}",
+    )

--- a/autocontext/src/autocontext/scenarios/custom/schema_evolution_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/schema_evolution_designer.py
@@ -138,6 +138,12 @@ def parse_schema_evolution_spec(text: str) -> SchemaEvolutionSpec:
 
 
 def design_schema_evolution(description: str, llm_fn: LlmFn) -> SchemaEvolutionSpec:
-    return parse_schema_evolution_spec(
-        llm_fn(SCHEMA_EVOLUTION_DESIGNER_SYSTEM, f"User description:\n{description}")
+    from autocontext.scenarios.custom.designer_retry import design_with_parse_retry
+
+    return design_with_parse_retry(
+        llm_fn=llm_fn,
+        system_prompt=SCHEMA_EVOLUTION_DESIGNER_SYSTEM,
+        user_prompt=f"User description:\n{description}",
+        parser=parse_schema_evolution_spec,
+        delimiter_hint=f"{SCHEMA_EVOLUTION_SPEC_START} ... {SCHEMA_EVOLUTION_SPEC_END}",
     )

--- a/autocontext/src/autocontext/scenarios/custom/simulation_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/simulation_designer.py
@@ -97,4 +97,12 @@ def parse_simulation_spec(text: str) -> SimulationSpec:
 
 
 def design_simulation(description: str, llm_fn: LlmFn) -> SimulationSpec:
-    return parse_simulation_spec(llm_fn(SIMULATION_DESIGNER_SYSTEM, f"User description:\n{description}"))
+    from autocontext.scenarios.custom.designer_retry import design_with_parse_retry
+
+    return design_with_parse_retry(
+        llm_fn=llm_fn,
+        system_prompt=SIMULATION_DESIGNER_SYSTEM,
+        user_prompt=f"User description:\n{description}",
+        parser=parse_simulation_spec,
+        delimiter_hint=f"{SIM_SPEC_START} ... {SIM_SPEC_END}",
+    )

--- a/autocontext/src/autocontext/scenarios/custom/tool_fragility_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/tool_fragility_designer.py
@@ -118,6 +118,12 @@ def parse_tool_fragility_spec(text: str) -> ToolFragilitySpec:
 
 
 def design_tool_fragility(description: str, llm_fn: LlmFn) -> ToolFragilitySpec:
-    return parse_tool_fragility_spec(
-        llm_fn(TOOL_FRAGILITY_DESIGNER_SYSTEM, f"User description:\n{description}")
+    from autocontext.scenarios.custom.designer_retry import design_with_parse_retry
+
+    return design_with_parse_retry(
+        llm_fn=llm_fn,
+        system_prompt=TOOL_FRAGILITY_DESIGNER_SYSTEM,
+        user_prompt=f"User description:\n{description}",
+        parser=parse_tool_fragility_spec,
+        delimiter_hint=f"{TOOL_FRAGILITY_SPEC_START} ... {TOOL_FRAGILITY_SPEC_END}",
     )

--- a/autocontext/src/autocontext/scenarios/custom/workflow_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/workflow_designer.py
@@ -149,6 +149,12 @@ def parse_workflow_spec(text: str) -> WorkflowSpec:
 
 
 def design_workflow(description: str, llm_fn: LlmFn) -> WorkflowSpec:
-    return parse_workflow_spec(
-        llm_fn(WORKFLOW_DESIGNER_SYSTEM, f"User description:\n{description}")
+    from autocontext.scenarios.custom.designer_retry import design_with_parse_retry
+
+    return design_with_parse_retry(
+        llm_fn=llm_fn,
+        system_prompt=WORKFLOW_DESIGNER_SYSTEM,
+        user_prompt=f"User description:\n{description}",
+        parser=parse_workflow_spec,
+        delimiter_hint=f"{WORKFLOW_SPEC_START} ... {WORKFLOW_SPEC_END}",
     )

--- a/autocontext/tests/test_agent_task_designer_retry.py
+++ b/autocontext/tests/test_agent_task_designer_retry.py
@@ -116,6 +116,22 @@ class TestDesignValidatedAgentTask:
         assert SPEC_START in retry_user_prompt
         assert _TEXT_DESCRIPTION in retry_user_prompt
 
+    def test_retries_after_unparseable_intent_correction_response(self) -> None:
+        llm_fn = _scripted_llm_fn([
+            _spec_response(_INVALID_CODE_FOR_TEXT_DESCRIPTION),
+            "not delimited json",
+            _spec_response(_VALID_TEXT_SPEC),
+        ])
+
+        spec = design_validated_agent_task(_TEXT_DESCRIPTION, llm_fn, max_retries=2)
+
+        assert spec.output_format == "free_text"
+        assert len(llm_fn.calls) == 3  # type: ignore[attr-defined]
+        _system, retry_user_prompt = llm_fn.calls[2]  # type: ignore[attr-defined]
+        assert "could not be parsed" in retry_user_prompt
+        assert "Validation errors" in retry_user_prompt
+        assert _TEXT_DESCRIPTION in retry_user_prompt
+
     def test_raises_after_max_retries_exhausted(self) -> None:
         # All 3 attempts return the invalid spec.
         llm_fn = _scripted_llm_fn([

--- a/autocontext/tests/test_designer_parse_retry.py
+++ b/autocontext/tests/test_designer_parse_retry.py
@@ -47,6 +47,12 @@ def _strict_dict_parser(text: str) -> dict[str, Any]:
     return json.loads(text)
 
 
+def _required_field_parser(text: str) -> dict[str, Any]:
+    """Parser that mirrors real spec parsers raising KeyError on missing fields."""
+    data = _strict_dict_parser(text)
+    return {"required": data["required"]}
+
+
 # --- Tests ---
 
 
@@ -108,6 +114,25 @@ class TestDesignWithParseRetry:
         )
 
         assert result == {"ok": True}
+        assert len(llm_fn.calls) == 2  # type: ignore[attr-defined]
+
+    def test_retries_once_on_missing_required_field_then_succeeds(self) -> None:
+        # First attempt is syntactically valid JSON but misses required schema fields.
+        # Second attempt returns a schema-complete value.
+        llm_fn = _scripted_llm_fn([
+            json.dumps({"other": True}),
+            json.dumps({"required": "ok"}),
+        ])
+
+        result = design_with_parse_retry(
+            llm_fn=llm_fn,
+            system_prompt=_SYSTEM,
+            user_prompt=_USER,
+            parser=_required_field_parser,
+            delimiter_hint=_DELIMITERS,
+        )
+
+        assert result == {"required": "ok"}
         assert len(llm_fn.calls) == 2  # type: ignore[attr-defined]
 
     def test_raises_after_max_retries_exhausted(self) -> None:

--- a/autocontext/tests/test_designer_parse_retry.py
+++ b/autocontext/tests/test_designer_parse_retry.py
@@ -10,7 +10,6 @@ import pytest
 
 from autocontext.scenarios.custom.designer_retry import design_with_parse_retry
 
-
 # --- Shared fixtures ---
 
 def _scripted_llm_fn(responses: list[str]) -> Callable[[str, str], str]:

--- a/autocontext/tests/test_designer_parse_retry.py
+++ b/autocontext/tests/test_designer_parse_retry.py
@@ -65,3 +65,100 @@ class TestDesignWithParseRetry:
 
         assert result == {"ok": True}
         assert len(llm_fn.calls) == 1  # type: ignore[attr-defined]
+
+    def test_retries_once_on_json_decode_error_then_succeeds(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # First attempt returns empty (JSONDecodeError).
+        # Second attempt returns valid JSON.
+        llm_fn = _scripted_llm_fn(["", json.dumps({"ok": True})])
+
+        with caplog.at_level(
+            logging.WARNING, logger="autocontext.scenarios.custom.designer_retry"
+        ):
+            result = design_with_parse_retry(
+                llm_fn=llm_fn,
+                system_prompt=_SYSTEM,
+                user_prompt=_USER,
+                parser=_strict_dict_parser,
+                delimiter_hint=_DELIMITERS,
+            )
+
+        assert result == {"ok": True}
+        assert len(llm_fn.calls) == 2  # type: ignore[attr-defined]
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "attempt 1/3" in warnings[0].getMessage()
+
+    def test_retries_once_on_value_error_then_succeeds(self) -> None:
+        # First attempt returns prose (no JSON object; ValueError).
+        # Second attempt returns valid JSON.
+        llm_fn = _scripted_llm_fn([
+            "I am just prose with no JSON.",
+            json.dumps({"ok": True}),
+        ])
+
+        result = design_with_parse_retry(
+            llm_fn=llm_fn,
+            system_prompt=_SYSTEM,
+            user_prompt=_USER,
+            parser=_strict_dict_parser,
+            delimiter_hint=_DELIMITERS,
+        )
+
+        assert result == {"ok": True}
+        assert len(llm_fn.calls) == 2  # type: ignore[attr-defined]
+
+    def test_raises_after_max_retries_exhausted(self) -> None:
+        llm_fn = _scripted_llm_fn(["", "", ""])
+
+        with pytest.raises(ValueError) as excinfo:
+            design_with_parse_retry(
+                llm_fn=llm_fn,
+                system_prompt=_SYSTEM,
+                user_prompt=_USER,
+                parser=_strict_dict_parser,
+                delimiter_hint=_DELIMITERS,
+                max_retries=2,
+            )
+
+        message = str(excinfo.value)
+        assert "designer parse failed after 3 attempts" in message
+        assert "JSONDecodeError" in message or "ValueError" in message
+        assert len(llm_fn.calls) == 3  # type: ignore[attr-defined]
+
+    def test_correction_prompt_contains_delimiter_hint_and_original_user_prompt(
+        self,
+    ) -> None:
+        llm_fn = _scripted_llm_fn(["", json.dumps({"ok": True})])
+
+        design_with_parse_retry(
+            llm_fn=llm_fn,
+            system_prompt=_SYSTEM,
+            user_prompt=_USER,
+            parser=_strict_dict_parser,
+            delimiter_hint=_DELIMITERS,
+        )
+
+        _system, retry_user_prompt = llm_fn.calls[1]  # type: ignore[attr-defined]
+        assert _DELIMITERS in retry_user_prompt
+        assert _USER in retry_user_prompt
+        assert "non-empty between the delimiters" in retry_user_prompt
+
+    def test_max_retries_zero_makes_exactly_one_attempt(self) -> None:
+        llm_fn = _scripted_llm_fn([""])
+
+        with pytest.raises(ValueError) as excinfo:
+            design_with_parse_retry(
+                llm_fn=llm_fn,
+                system_prompt=_SYSTEM,
+                user_prompt=_USER,
+                parser=_strict_dict_parser,
+                delimiter_hint=_DELIMITERS,
+                max_retries=0,
+            )
+
+        assert "designer parse failed after 1 attempts" in str(excinfo.value)
+        assert len(llm_fn.calls) == 1  # type: ignore[attr-defined]

--- a/autocontext/tests/test_designer_parse_retry.py
+++ b/autocontext/tests/test_designer_parse_retry.py
@@ -1,0 +1,67 @@
+"""AC-575 — shared parse-retry helper for custom scenario designers."""
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from autocontext.scenarios.custom.designer_retry import design_with_parse_retry
+
+
+# --- Shared fixtures ---
+
+def _scripted_llm_fn(responses: list[str]) -> Callable[[str, str], str]:
+    calls: list[tuple[str, str]] = []
+
+    def fn(system: str, user: str) -> str:
+        if not responses:
+            raise AssertionError(
+                f"llm_fn called more times than responses available; "
+                f"previous calls: {len(calls)}"
+            )
+        calls.append((system, user))
+        return responses.pop(0)
+
+    fn.calls = calls  # type: ignore[attr-defined]
+    return fn
+
+
+_SYSTEM = "You are a test designer."
+_USER = "User description:\nWrite something."
+_DELIMITERS = "<!-- TEST_SPEC_START --> ... <!-- TEST_SPEC_END -->"
+
+
+def _strict_dict_parser(text: str) -> dict[str, Any]:
+    """Parser that expects a JSON dict; raises on empty or malformed input.
+
+    Mirrors the failure shape of real parse_X_spec: ValueError on missing
+    delimiter, JSONDecodeError on empty/malformed JSON body.
+    """
+    text = text.strip()
+    if not text:
+        raise ValueError("empty response")
+    if not text.startswith("{"):
+        raise ValueError("response does not start with JSON object")
+    return json.loads(text)
+
+
+# --- Tests ---
+
+
+class TestDesignWithParseRetry:
+    def test_happy_path_returns_parser_value_on_first_attempt(self) -> None:
+        llm_fn = _scripted_llm_fn([json.dumps({"ok": True})])
+
+        result = design_with_parse_retry(
+            llm_fn=llm_fn,
+            system_prompt=_SYSTEM,
+            user_prompt=_USER,
+            parser=_strict_dict_parser,
+            delimiter_hint=_DELIMITERS,
+        )
+
+        assert result == {"ok": True}
+        assert len(llm_fn.calls) == 1  # type: ignore[attr-defined]

--- a/autocontext/tests/test_designer_parse_retry_integration.py
+++ b/autocontext/tests/test_designer_parse_retry_integration.py
@@ -66,6 +66,14 @@ def _empty_sim_response() -> str:
     return f"prefix\n{SIM_SPEC_START}\n{SIM_SPEC_END}\nsuffix"
 
 
+def _missing_required_sim_response() -> str:
+    return (
+        f"prefix\n{SIM_SPEC_START}\n"
+        f"{json.dumps({'description': 'A schema-incomplete simulation'})}\n"
+        f"{SIM_SPEC_END}\nsuffix"
+    )
+
+
 def _valid_sim_response() -> str:
     return (
         f"prefix\n{SIM_SPEC_START}\n{json.dumps(_VALID_SIMULATION_JSON)}\n{SIM_SPEC_END}\nsuffix"
@@ -87,6 +95,18 @@ class TestDesignerParseRetryIntegration:
         """AC-276 repro: first response has empty content between SIM delimiters,
         second response has valid JSON. design_simulation must succeed."""
         llm_fn = _scripted_llm_fn([_empty_sim_response(), _valid_sim_response()])
+
+        spec = design_simulation("A test description.", llm_fn)
+
+        assert spec.description == _VALID_SIMULATION_JSON["description"]
+        assert len(llm_fn.calls) == 2  # type: ignore[attr-defined]
+
+    def test_design_simulation_retries_on_missing_required_schema_fields(self) -> None:
+        """Syntactically valid but schema-incomplete JSON should retry too."""
+        llm_fn = _scripted_llm_fn([
+            _missing_required_sim_response(),
+            _valid_sim_response(),
+        ])
 
         spec = design_simulation("A test description.", llm_fn)
 

--- a/autocontext/tests/test_designer_parse_retry_integration.py
+++ b/autocontext/tests/test_designer_parse_retry_integration.py
@@ -1,0 +1,104 @@
+"""AC-575 — end-to-end: design_simulation and design_artifact_editing recover from empty LLM body."""
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+from autocontext.scenarios.custom.artifact_editing_designer import (
+    ARTIFACT_SPEC_END,
+    ARTIFACT_SPEC_START,
+    design_artifact_editing,
+)
+from autocontext.scenarios.custom.simulation_designer import (
+    SIM_SPEC_END,
+    SIM_SPEC_START,
+    design_simulation,
+)
+
+
+def _scripted_llm_fn(responses: list[str]) -> Callable[[str, str], str]:
+    calls: list[tuple[str, str]] = []
+
+    def fn(system: str, user: str) -> str:
+        if not responses:
+            raise AssertionError("llm_fn called more times than responses available")
+        calls.append((system, user))
+        return responses.pop(0)
+
+    fn.calls = calls  # type: ignore[attr-defined]
+    return fn
+
+
+_VALID_SIMULATION_JSON = {
+    "description": "A test simulation",
+    "environment_description": "An environment with two variables",
+    "initial_state_description": "Both start at zero",
+    "success_criteria": ["Variable A reaches 10"],
+    "failure_modes": ["Variable A goes negative"],
+    "actions": [
+        {
+            "name": "increment_a",
+            "description": "Add 1 to variable A",
+            "parameters": {},
+            "preconditions": [],
+            "effects": ["Variable A increases by 1"],
+        }
+    ],
+    "max_steps": 5,
+}
+
+_VALID_ARTIFACT_EDITING_JSON = {
+    "task_description": "Edit a config file to enable debug mode.",
+    "rubric": "Score correctness and minimal side effects.",
+    "validation_rules": ["debug = true is set"],
+    "artifacts": [
+        {
+            "path": "app.yaml",
+            "content": "debug: false\nport: 8080\n",
+            "content_type": "yaml",
+            "metadata": {},
+        }
+    ],
+}
+
+
+def _empty_sim_response() -> str:
+    return f"prefix\n{SIM_SPEC_START}\n{SIM_SPEC_END}\nsuffix"
+
+
+def _valid_sim_response() -> str:
+    return (
+        f"prefix\n{SIM_SPEC_START}\n{json.dumps(_VALID_SIMULATION_JSON)}\n{SIM_SPEC_END}\nsuffix"
+    )
+
+
+def _empty_artifact_response() -> str:
+    return f"prefix\n{ARTIFACT_SPEC_START}\n{ARTIFACT_SPEC_END}\nsuffix"
+
+
+def _valid_artifact_response() -> str:
+    return (
+        f"prefix\n{ARTIFACT_SPEC_START}\n{json.dumps(_VALID_ARTIFACT_EDITING_JSON)}\n{ARTIFACT_SPEC_END}\nsuffix"
+    )
+
+
+class TestDesignerParseRetryIntegration:
+    def test_design_simulation_retries_on_empty_spec_block(self) -> None:
+        """AC-276 repro: first response has empty content between SIM delimiters,
+        second response has valid JSON. design_simulation must succeed."""
+        llm_fn = _scripted_llm_fn([_empty_sim_response(), _valid_sim_response()])
+
+        spec = design_simulation("A test description.", llm_fn)
+
+        assert spec.description == _VALID_SIMULATION_JSON["description"]
+        assert len(llm_fn.calls) == 2  # type: ignore[attr-defined]
+
+    def test_design_artifact_editing_retries_on_empty_spec_block(self) -> None:
+        """AC-269 repro: first response has empty content between ARTIFACT delimiters,
+        second response has valid JSON. design_artifact_editing must succeed."""
+        llm_fn = _scripted_llm_fn([_empty_artifact_response(), _valid_artifact_response()])
+
+        spec = design_artifact_editing("A test description.", llm_fn)
+
+        assert spec.task_description == _VALID_ARTIFACT_EDITING_JSON["task_description"]
+        assert len(llm_fn.calls) == 2  # type: ignore[attr-defined]


### PR DESCRIPTION
Closes AC-575. Unblocks AC-269 and AC-276 in the 0.4.3 escalation suite.

## What changed

- New module `autocontext/scenarios/custom/designer_retry.py` exposes `design_with_parse_retry(llm_fn, system_prompt, user_prompt, parser, delimiter_hint, max_retries=2)`.
- All 10 `design_X` entry points refactored to delegate to the helper.
- On `JSONDecodeError` or `ValueError` from the parser, the helper retries with a correction prompt that includes the original user prompt, the parse error, and the expected delimiter shape. WARNING log emitted per retry.
- For `agent_task`, the parse retry nests naturally under AC-574's `design_validated_agent_task` intent retry: first get a parseable spec, then validate intent.

## Why

On 0.4.3, AC-269 (schema evolution → artifact_editing designer) and AC-276 (geopolitical → simulation designer) failed with `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` — the LLM emitted the delimiters with empty content between them. No retry, no correction, solve job died. This PR gives every designer a bounded retry budget (2 retries = 3 attempts) so transient LLM mishaps self-correct.

## Tests

6 unit tests in `tests/test_designer_parse_retry.py`:

- `test_happy_path_returns_parser_value_on_first_attempt`
- `test_retries_once_on_json_decode_error_then_succeeds` (+ WARNING log assertion)
- `test_retries_once_on_value_error_then_succeeds`
- `test_raises_after_max_retries_exhausted`
- `test_correction_prompt_contains_delimiter_hint_and_original_user_prompt`
- `test_max_retries_zero_makes_exactly_one_attempt`

2 integration tests in `tests/test_designer_parse_retry_integration.py`:

- `test_design_simulation_retries_on_empty_spec_block` (AC-276 repro)
- `test_design_artifact_editing_retries_on_empty_spec_block` (AC-269 repro)

Full suite: **5381 passed**, ruff + mypy clean.

## Non-goals

- Fence-tolerant JSON extraction inside `parse_X_spec` (deferred — observed failures are empty-content, not misplaced-JSON).
- TS designers (separate follow-up if needed).
- Generic retry infrastructure unifying AC-574's intent retry + AC-575's parse retry (YAGNI until a third retry flavor appears).

## Linear

- AC-575 (closes this)
- AC-574 (sibling intent-validation retry; composes naturally for agent_task)
- AC-571 (original misfiled issue)