### PR TITLE
feat(ac-571): classifier observability + finance vocabulary expansion

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -52,10 +52,34 @@ class LowConfidenceError(Exception):
     def __init__(self, classification: FamilyClassification, min_confidence: float) -> None:
         self.classification = classification
         self.min_confidence = min_confidence
-        super().__init__(
-            f"Family classification confidence {classification.confidence:.2f} "
-            f"is below threshold {min_confidence:.2f} for family '{classification.family_name}'"
+        super().__init__(self._build_message(classification, min_confidence))
+
+    @staticmethod
+    def _build_message(
+        classification: FamilyClassification, min_confidence: float
+    ) -> str:
+        conf = classification.confidence
+        thr = min_confidence
+        family = classification.family_name
+
+        if classification.no_signals_matched:
+            return (
+                f"Family classification confidence {conf:.2f} < threshold {thr:.2f}: "
+                f"no family keywords matched in description (fell back to {family}). "
+                f"Consider rephrasing with domain keywords."
+            )
+
+        base = (
+            f"Family classification confidence {conf:.2f} < threshold {thr:.2f} "
+            f"for family {family!r}."
         )
+        if classification.alternatives:
+            top_two = classification.alternatives[:2]
+            alts_str = ", ".join(
+                f"{a.family_name}={a.confidence:.2f}" for a in top_two
+            )
+            return f"{base} Top alternatives: {alts_str}."
+        return base
 
 
 # ---------------------------------------------------------------------------

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -36,6 +36,7 @@ class FamilyClassification(BaseModel):
     confidence: float
     rationale: str
     alternatives: list[FamilyCandidate] = Field(default_factory=list)
+    no_signals_matched: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return self.model_dump()
@@ -457,6 +458,7 @@ def classify_scenario_family(description: str) -> FamilyClassification:
             confidence=0.2,
             rationale=f"No strong signals detected; defaulting to {default_family}",
             alternatives=alternatives,
+            no_signals_matched=True,
         )
 
     # Normalize to confidences

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -214,6 +214,16 @@ _AGENT_TASK_SIGNALS: dict[str, float] = {
     "sort": 0.5,
     "data analysis": 1.0,
     "customer review": 1.0,
+    # AC-571: finance / quant domain keywords
+    "portfolio": 2.0,
+    "macroeconomic": 2.0,
+    "regime change": 2.0,
+    "rebalance": 1.5,
+    "volatility": 1.5,
+    "allocation": 1.0,
+    "quantitative": 1.0,
+    "investment": 1.0,
+    "financial": 1.0,
 }
 
 # Game: competitive, two-player, tournament, Elo

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -7,6 +7,7 @@ rationale. Routes into the correct family-specific generator.
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from typing import Any
@@ -14,6 +15,8 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from autocontext.scenarios.families import ScenarioFamily, get_family, list_families
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Data models
@@ -529,5 +532,13 @@ def route_to_family(
     Raises KeyError if family_name is not in the registry.
     """
     if classification.confidence < min_confidence:
+        logger.warning(
+            "route_to_family rejecting classification: family=%r confidence=%.2f threshold=%.2f rationale=%r alternatives=%s",
+            classification.family_name,
+            classification.confidence,
+            min_confidence,
+            classification.rationale,
+            [(a.family_name, a.confidence) for a in classification.alternatives],
+        )
         raise LowConfidenceError(classification, min_confidence)
     return get_family(classification.family_name)

--- a/autocontext/tests/test_classifier_observability.py
+++ b/autocontext/tests/test_classifier_observability.py
@@ -13,7 +13,6 @@ from autocontext.scenarios.custom.family_classifier import (
     route_to_family,
 )
 
-
 # --- Fixtures ---
 
 _AC277_PROMPT = (

--- a/autocontext/tests/test_classifier_observability.py
+++ b/autocontext/tests/test_classifier_observability.py
@@ -129,3 +129,49 @@ class TestVocabularyExpansion:
         assert c.no_signals_matched is False, (
             f"keyword {keyword!r} did not match any signal (got {c.rationale!r})"
         )
+
+
+class TestRouteToFamilyWarningLog:
+    def test_emits_warning_before_raising(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        c = FamilyClassification(
+            family_name="agent_task",
+            confidence=0.2,
+            rationale="No strong signals detected; defaulting to agent_task",
+            alternatives=[],
+            no_signals_matched=True,
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="autocontext.scenarios.custom.family_classifier"
+        ):
+            with pytest.raises(LowConfidenceError):
+                route_to_family(c, min_confidence=0.3)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "route_to_family rejecting" in msg
+        assert "agent_task" in msg
+        assert "0.20" in msg
+        assert "0.30" in msg
+
+    def test_emits_no_warning_on_happy_path(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        c = FamilyClassification(
+            family_name="agent_task",
+            confidence=0.9,
+            rationale="matched: haiku",
+            alternatives=[],
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="autocontext.scenarios.custom.family_classifier"
+        ):
+            family = route_to_family(c, min_confidence=0.3)
+
+        assert family.name == "agent_task"
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings == []

--- a/autocontext/tests/test_classifier_observability.py
+++ b/autocontext/tests/test_classifier_observability.py
@@ -111,3 +111,21 @@ class TestLowConfidenceErrorMessage:
         assert "0.30" in msg
         # No dangling "Top alternatives:" with empty content
         assert not msg.rstrip().endswith("Top alternatives:")
+
+
+class TestVocabularyExpansion:
+    def test_ac277_portfolio_prompt_classifies_above_threshold(self) -> None:
+        c = classify_scenario_family(_AC277_PROMPT)
+        assert c.confidence >= 0.30
+        assert c.family_name == "agent_task"
+        assert c.no_signals_matched is False
+
+    @pytest.mark.parametrize("keyword", _NEW_AGENT_TASK_KEYWORDS)
+    def test_each_new_keyword_individually_triggers_non_fallback(
+        self, keyword: str
+    ) -> None:
+        # Minimal prompt carrying only the keyword.
+        c = classify_scenario_family(f"build something about {keyword}")
+        assert c.no_signals_matched is False, (
+            f"keyword {keyword!r} did not match any signal (got {c.rationale!r})"
+        )

--- a/autocontext/tests/test_classifier_observability.py
+++ b/autocontext/tests/test_classifier_observability.py
@@ -57,3 +57,57 @@ class TestFamilyClassificationFlag:
         # "haiku" is in _AGENT_TASK_SIGNALS with weight 1.5.
         c = classify_scenario_family("write a haiku about rivers")
         assert c.no_signals_matched is False
+
+
+class TestLowConfidenceErrorMessage:
+    def test_message_for_no_signals_fallback(self) -> None:
+        c = FamilyClassification(
+            family_name="agent_task",
+            confidence=0.2,
+            rationale="No strong signals detected; defaulting to agent_task",
+            alternatives=[],
+            no_signals_matched=True,
+        )
+        exc = LowConfidenceError(c, 0.3)
+        msg = str(exc)
+
+        assert "0.20" in msg
+        assert "0.30" in msg
+        assert "no family keywords matched" in msg
+        assert "Consider rephrasing" in msg
+        assert "agent_task" in msg
+
+    def test_message_for_tied_alternatives(self) -> None:
+        c = FamilyClassification(
+            family_name="agent_task",
+            confidence=0.25,
+            rationale="matched: evaluat",
+            alternatives=[
+                FamilyCandidate(family_name="simulation", confidence=0.22, rationale="r1"),
+                FamilyCandidate(family_name="negotiation", confidence=0.18, rationale="r2"),
+            ],
+            no_signals_matched=False,
+        )
+        exc = LowConfidenceError(c, 0.3)
+        msg = str(exc)
+
+        assert "Top alternatives" in msg
+        assert "simulation" in msg
+        assert "0.22" in msg
+        assert "negotiation" in msg
+        assert "0.18" in msg
+
+    def test_message_degrades_cleanly_with_zero_alternatives(self) -> None:
+        c = FamilyClassification(
+            family_name="agent_task",
+            confidence=0.25,
+            rationale="matched: something",
+            alternatives=[],
+            no_signals_matched=False,
+        )
+        # Must not raise IndexError or produce a trailing "Top alternatives:" with empty list.
+        msg = str(LowConfidenceError(c, 0.3))
+        assert "0.25" in msg
+        assert "0.30" in msg
+        # No dangling "Top alternatives:" with empty content
+        assert not msg.rstrip().endswith("Top alternatives:")

--- a/autocontext/tests/test_classifier_observability.py
+++ b/autocontext/tests/test_classifier_observability.py
@@ -1,0 +1,59 @@
+"""AC-571 — classifier observability + targeted vocabulary expansion."""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from autocontext.scenarios.custom.family_classifier import (
+    FamilyCandidate,
+    FamilyClassification,
+    LowConfidenceError,
+    classify_scenario_family,
+    route_to_family,
+)
+
+
+# --- Fixtures ---
+
+_AC277_PROMPT = (
+    "Build a financial portfolio construction scenario where the agent must build "
+    "and manage portfolios across macroeconomic regime changes, accumulating "
+    "quantitative investment heuristics."
+)
+
+_NEW_AGENT_TASK_KEYWORDS = [
+    "portfolio",
+    "macroeconomic",
+    "regime change",
+    "rebalance",
+    "volatility",
+    "allocation",
+    "quantitative",
+    "investment",
+    "financial",
+]
+
+
+# --- Tests ---
+
+
+class TestFamilyClassificationFlag:
+    def test_defaults_no_signals_matched_false(self) -> None:
+        c = FamilyClassification(
+            family_name="agent_task",
+            confidence=1.0,
+            rationale="matched: some_keyword",
+        )
+        assert c.no_signals_matched is False
+
+    def test_classify_sets_no_signals_matched_true_when_no_keywords_match(self) -> None:
+        # A totally noise-word description with no registered signals.
+        c = classify_scenario_family("xyz plop qux widget")
+        assert c.no_signals_matched is True
+        assert c.confidence == pytest.approx(0.2)
+
+    def test_classify_sets_no_signals_matched_false_when_any_keyword_matches(self) -> None:
+        # "haiku" is in _AGENT_TASK_SIGNALS with weight 1.5.
+        c = classify_scenario_family("write a haiku about rivers")
+        assert c.no_signals_matched is False


### PR DESCRIPTION
Closes AC-571 (rescoped from its original filing).

## What changed

- `FamilyClassification` gains `no_signals_matched: bool = False`, set to `True` in the `total == 0` fallback branch of `classify_scenario_family`.
- `LowConfidenceError.__str__` now emits two distinct messages:
  - **Fallback case** (`no_signals_matched=True`): `"Family classification confidence 0.20 < threshold 0.30: no family keywords matched in description (fell back to agent_task). Consider rephrasing with domain keywords."`
  - **Tied-alternatives case** (`no_signals_matched=False`): `"Family classification confidence 0.25 < threshold 0.30 for family 'agent_task'. Top alternatives: simulation=0.22, negotiation=0.18."`
- `route_to_family` emits a WARNING log with the full classification (family, confidence, threshold, rationale, alternatives) before raising `LowConfidenceError`.
- `_AGENT_TASK_SIGNALS` adds 9 finance/quant-domain keywords: `portfolio`, `macroeconomic`, `regime change`, `rebalance`, `volatility`, `allocation`, `quantitative`, `investment`, `financial`.

## Why

On 0.4.3, **AC-277** (portfolio regime change) was the only remaining Scenarios-state prompt blocked by the classifier — it matched zero registered keywords and fell into the `confidence=0.2` fallback path. AC-575's designer retries unblock AC-269/AC-276, AC-574 unblocks AC-268/AC-272, AC-570 unblocks AC-275. This PR takes AC-277 from fail to pass, closing the 0.4.3 Scenarios sweep at 9/9.

Verified via direct probe: AC-277 now classifies at `agent_task @ 1.00` matching `portfolio, macroeconomic, regime change`.

## Tests

18 new test cases in `tests/test_classifier_observability.py`:

- `TestFamilyClassificationFlag` — 3 tests pinning the flag
- `TestLowConfidenceErrorMessage` — 3 tests pinning both message templates + zero-alts degradation
- `TestVocabularyExpansion` — 1 AC-277 test + 9 parametrized per-keyword regression guards
- `TestRouteToFamilyWarningLog` — 2 tests (WARNING on low-confidence, silent on happy path)

Full suite: **5399 passed**, ruff + mypy clean.

## Non-goals

- LLM fallback classifier when keywords don't match (YAGNI).
- `--family` CLI override flag (separate UX decision).
- Threshold tuning (0.30 stays).
- TS classifier parity (separate follow-up if needed).

## Linear

- AC-571 (closes this)
- AC-570 / AC-574 / AC-575 — sibling Py-parity fixes. Together these four PRs take the 0.4.3 Scenarios sweep from 3/9 to 9/9.