### PR TITLE
AC-545 — model-routing actuator + TS runtime helper + ProductionTrace routing field

### DIFF
--- a/autocontext/src/autocontext/production_traces/contract/json_schemas/production-trace.schema.json
+++ b/autocontext/src/autocontext/production_traces/contract/json_schemas/production-trace.schema.json
@@ -57,6 +57,27 @@
       "type": "array",
       "items": { "$ref": "https://autocontext.dev/schema/production-traces/redaction-marker.json" }
     },
+    "routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chosen", "reason", "evaluatedAt"],
+      "properties": {
+        "chosen": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["provider", "model"],
+          "properties": {
+            "provider": { "type": "string", "minLength": 1 },
+            "model": { "type": "string", "minLength": 1 },
+            "endpoint": { "type": "string" }
+          }
+        },
+        "matchedRouteId": { "type": "string", "minLength": 1 },
+        "reason": { "enum": ["default", "matched-route", "fallback"] },
+        "fallbackReason": { "enum": ["budget-exceeded", "latency-breached", "provider-error", "no-match"] },
+        "evaluatedAt": { "type": "string", "format": "date-time" }
+      }
+    },
     "metadata": { "type": "object" }
   }
 }

--- a/autocontext/src/autocontext/production_traces/contract/models.py
+++ b/autocontext/src/autocontext/production_traces/contract/models.py
@@ -112,6 +112,29 @@ class TraceLinks(BaseModel):
     trainingRecordIds: list[TrainingRecordId] | None = None
 
 
+class Chosen(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    provider: Annotated[str, Field(min_length=1)]
+    model: Annotated[str, Field(min_length=1)]
+    endpoint: str | None = None
+
+
+class Routing(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    chosen: Chosen
+    matchedRouteId: Annotated[str | None, Field(min_length=1)] = None
+    reason: Literal['default', 'matched-route', 'fallback']
+    fallbackReason: (
+        Literal['budget-exceeded', 'latency-breached', 'provider-error', 'no-match']
+        | None
+    ) = None
+    evaluatedAt: AwareDatetime
+
+
 class UserIdHash(RootModel[str]):
     root: Annotated[str, Field(pattern='^[0-9a-f]{64}$')]
 
@@ -206,4 +229,5 @@ class ProductionTrace(BaseModel):
     feedbackRefs: list[FeedbackRef]
     links: Annotated[TraceLinks, Field(title='TraceLinks')]
     redactions: list[RedactionMarker]
+    routing: Routing | None = None
     metadata: dict[str, Any] | None = None

--- a/autocontext/src/autocontext/production_traces/emit.py
+++ b/autocontext/src/autocontext/production_traces/emit.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import datetime, timezone
-from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import Any
 
@@ -194,7 +195,7 @@ def _partition_date(traces: list[dict[str, Any]]) -> str:
             parsed = _parse_iso_utc(started)
             if parsed is not None:
                 return parsed.strftime("%Y-%m-%d")
-    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return datetime.now(UTC).strftime("%Y-%m-%d")
 
 
 def _parse_iso_utc(value: str) -> datetime | None:
@@ -205,8 +206,8 @@ def _parse_iso_utc(value: str) -> datetime | None:
     except ValueError:
         return None
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
 
 
 __all__ = ["TraceBatch", "build_trace", "write_jsonl"]

--- a/autocontext/tests/test_production_traces_emit.py
+++ b/autocontext/tests/test_production_traces_emit.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import os
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -20,7 +20,7 @@ ULID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
 
 
 def _timing(offset_seconds: int = 0) -> dict[str, Any]:
-    start = datetime(2026, 4, 17, 12, 0, offset_seconds, tzinfo=timezone.utc)
+    start = datetime(2026, 4, 17, 12, 0, offset_seconds, tzinfo=UTC)
     end = start + timedelta(seconds=1)
     return {
         "startedAt": start.isoformat().replace("+00:00", "Z"),

--- a/autocontext/tests/test_production_traces_hashing.py
+++ b/autocontext/tests/test_production_traces_hashing.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 import pytest
 
-
 # ---- hash_user_id / hash_session_id (pure functions, byte-compat with TS) ----
 
 

--- a/ts/package.json
+++ b/ts/package.json
@@ -27,6 +27,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./control-plane/runtime": {
+      "import": "./dist/control-plane/runtime/index.js",
+      "types": "./dist/control-plane/runtime/index.d.ts"
     }
   },
   "scripts": {

--- a/ts/src/control-plane/actuators/index.ts
+++ b/ts/src/control-plane/actuators/index.ts
@@ -1,5 +1,5 @@
 // Public surface of the autocontext control-plane actuators layer.
-// Importing this module registers all four concrete actuators as a side effect.
+// Importing this module registers all five concrete actuators as a side effect.
 //
 // Import discipline (§3.2): this module imports ONLY from contract/ (and its
 // own subtree) — never from registry/, promotion/, or emit/.
@@ -60,3 +60,33 @@ export {
 export type { FineTunedModelPayload } from "./fine-tuned-model/index.js";
 
 export { importLegacyModelRecords } from "./fine-tuned-model/legacy-adapter.js";
+
+export {
+  modelRoutingActuator,
+  modelRoutingRegistration,
+  ModelRoutingPayloadSchema,
+  RouteSchema,
+  MatchExpressionSchema,
+  MatchOperatorSchema,
+  ModelTargetSchema,
+  RolloutSchema,
+  BudgetGuardrailSchema,
+  LatencyGuardrailSchema,
+  ConfidenceGuardrailSchema,
+  FallbackEntrySchema,
+  FallbackReasonSchema,
+  MODEL_ROUTING_FILENAME,
+} from "./model-routing/index.js";
+export type {
+  ModelRoutingPayload,
+  ModelTarget,
+  MatchOperator,
+  MatchExpression,
+  Rollout,
+  BudgetGuardrail,
+  LatencyGuardrail,
+  ConfidenceGuardrail,
+  Route,
+  FallbackEntry,
+  FallbackReason,
+} from "./model-routing/index.js";

--- a/ts/src/control-plane/actuators/model-routing/applicator.ts
+++ b/ts/src/control-plane/actuators/model-routing/applicator.ts
@@ -1,0 +1,80 @@
+// model-routing actuator (AC-545) — writes a models.json payload file to
+// <scenarioDir>/routing/models/<artifactId>-model-routing.json.
+//
+// Rollback: content-revert — the baseline's payload content is written back to
+// the same resolved target. (Spec §4: model-routing is config data, not a
+// cascade-dependent artifact; content-revert is safe and symmetric.)
+//
+// DRY: wraps `_shared/single-file-applicator` + `_shared/content-revert-rollback`
+// + `_shared/unified-diff-emitter` (same pattern as prompt-patch / tool-policy).
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Actuator, WorkspaceLayoutArg } from "../registry.js";
+import type { Artifact, Patch } from "../../contract/types.js";
+import { applySingleFile } from "../_shared/single-file-applicator.js";
+import { emitUnifiedDiff } from "../_shared/unified-diff-emitter.js";
+import { contentRevertRollback } from "../_shared/content-revert-rollback.js";
+import {
+  ModelRoutingPayloadSchema,
+  MODEL_ROUTING_FILENAME,
+  type ModelRoutingPayload,
+} from "./schema.js";
+
+/**
+ * Subdirectory under the `routingSubdir` where model-routing configs land.
+ * Chosen to match `routing-rule`'s `routing/*.json` convention while keeping
+ * model-routing in a sibling `routing/models/` tree so the two actuator types
+ * don't collide on disk.
+ */
+const MODEL_ROUTING_SUBDIR = "models";
+
+function targetRelativePath(artifact: Artifact, layout: WorkspaceLayoutArg): string {
+  const scenarioDir = layout.scenarioDir(artifact.scenario, artifact.environmentTag);
+  return `${scenarioDir}/${layout.routingSubdir}/${MODEL_ROUTING_SUBDIR}/${artifact.id}-model-routing.json`;
+}
+
+export const modelRoutingActuator: Actuator<ModelRoutingPayload> = {
+  parsePayload(raw: unknown): ModelRoutingPayload {
+    return ModelRoutingPayloadSchema.parse(raw);
+  },
+
+  resolveTargetPath(artifact, layout): string {
+    return targetRelativePath(artifact, layout);
+  },
+
+  async apply({ artifact, payloadDir, workingTreeRoot, layout }): Promise<void> {
+    const rel = targetRelativePath(artifact, layout);
+    applySingleFile({
+      artifact,
+      payloadDir,
+      payloadFileName: MODEL_ROUTING_FILENAME,
+      resolvedTargetPath: join(workingTreeRoot, rel),
+    });
+  },
+
+  emitPatch({ artifact, payloadDir, workingTreeRoot, layout }): Patch {
+    const rel = targetRelativePath(artifact, layout);
+    const target = join(workingTreeRoot, rel);
+    const oldContent = existsSync(target) ? readFileSync(target, "utf-8") : "";
+    const newContent = readFileSync(join(payloadDir, MODEL_ROUTING_FILENAME), "utf-8");
+    return emitUnifiedDiff({ filePath: rel, oldContent, newContent });
+  },
+
+  async rollback({
+    candidate,
+    baseline,
+    baselinePayloadDir,
+    workingTreeRoot,
+    layout,
+  }): Promise<Patch | Patch[]> {
+    const rel = targetRelativePath(candidate, layout);
+    return contentRevertRollback({
+      candidate,
+      baseline,
+      baselinePayloadDir,
+      payloadFileName: MODEL_ROUTING_FILENAME,
+      resolvedTargetPath: join(workingTreeRoot, rel),
+    });
+  },
+};

--- a/ts/src/control-plane/actuators/model-routing/index.ts
+++ b/ts/src/control-plane/actuators/model-routing/index.ts
@@ -1,0 +1,46 @@
+// model-routing actuator (AC-545) — registers on module import.
+//
+// Target pattern: **/routing/models/*.json (sibling of routing-rule's
+// **/routing/*.json — the two actuators own distinct subtrees).
+
+import { registerActuator, type ActuatorRegistration } from "../registry.js";
+import { modelRoutingActuator } from "./applicator.js";
+import type { ModelRoutingPayload } from "./schema.js";
+
+export const modelRoutingRegistration: ActuatorRegistration<ModelRoutingPayload> = {
+  type: "model-routing",
+  rollback: { kind: "content-revert" },
+  allowedTargetPattern: "**/routing/models/*.json",
+  actuator: modelRoutingActuator,
+};
+
+registerActuator(modelRoutingRegistration);
+
+export { modelRoutingActuator } from "./applicator.js";
+export {
+  ModelRoutingPayloadSchema,
+  RouteSchema,
+  MatchExpressionSchema,
+  MatchOperatorSchema,
+  ModelTargetSchema,
+  RolloutSchema,
+  BudgetGuardrailSchema,
+  LatencyGuardrailSchema,
+  ConfidenceGuardrailSchema,
+  FallbackEntrySchema,
+  FallbackReasonSchema,
+  MODEL_ROUTING_FILENAME,
+} from "./schema.js";
+export type {
+  ModelRoutingPayload,
+  ModelTarget,
+  MatchOperator,
+  MatchExpression,
+  Rollout,
+  BudgetGuardrail,
+  LatencyGuardrail,
+  ConfidenceGuardrail,
+  Route,
+  FallbackEntry,
+  FallbackReason,
+} from "./schema.js";

--- a/ts/src/control-plane/actuators/model-routing/schema.ts
+++ b/ts/src/control-plane/actuators/model-routing/schema.ts
@@ -25,10 +25,8 @@ export const ModelTargetSchema = z
 
 /**
  * A per-field operator. The JSON Schema requires each operator object contain
- * exactly one of { equals, contains, default:true }, but JSON Schema cannot
- * enforce "exactly one" declaratively with additionalProperties:false and
- * optional keys. The runtime helper applies "exactly one" semantics: a
- * pathological {} is treated as non-matching.
+ * exactly one of { equals, contains, default:true }. The Zod echo enforces the
+ * same rule so invalid configs fail before registration/runtime.
  */
 export const MatchOperatorSchema = z
   .object({
@@ -36,9 +34,26 @@ export const MatchOperatorSchema = z
     contains: z.union([z.string(), z.array(z.unknown())]).optional(),
     default: z.literal(true).optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((op, ctx) => {
+    const set = [
+      op.equals !== undefined,
+      op.contains !== undefined,
+      op.default === true,
+    ].filter(Boolean).length;
+    if (set !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "match operator must set exactly one of equals, contains, or default:true",
+      });
+    }
+  });
 
-export const MatchExpressionSchema = z.record(z.string(), MatchOperatorSchema);
+export const MatchExpressionSchema = z
+  .record(z.string(), MatchOperatorSchema)
+  .refine((match) => Object.keys(match).length > 0, {
+    message: "match expression must include at least one condition",
+  });
 
 export const RolloutSchema = z
   .object({

--- a/ts/src/control-plane/actuators/model-routing/schema.ts
+++ b/ts/src/control-plane/actuators/model-routing/schema.ts
@@ -1,0 +1,121 @@
+// Payload schema for the model-routing actuator (AC-545, spec §4).
+//
+// The payload directory contains exactly one file:
+//   models.json — a top-level declarative config with a `default` model target,
+//                 ordered `routes[]`, and a `fallback[]` chain with guardrails.
+//
+// The canonical schema lives in
+//   control-plane/contract/json-schemas/model-routing-payload.schema.json
+// — this Zod schema is the TS echo used for type ergonomics (parsePayload and
+// the runtime helper both ingest the already-Zod-parsed tree). DDD note: field
+// names are taken verbatim from the spec (`default`, `routes`, `fallback`,
+// `match`, `rollout`, `budget`, `latency`, `confidence`, `cohortKey`).
+
+import { z } from "zod";
+
+// ---- Primitives ----
+
+export const ModelTargetSchema = z
+  .object({
+    provider: z.string().min(1),
+    model: z.string().min(1),
+    endpoint: z.string().nullable().optional(),
+  })
+  .strict();
+
+/**
+ * A per-field operator. The JSON Schema requires each operator object contain
+ * exactly one of { equals, contains, default:true }, but JSON Schema cannot
+ * enforce "exactly one" declaratively with additionalProperties:false and
+ * optional keys. The runtime helper applies "exactly one" semantics: a
+ * pathological {} is treated as non-matching.
+ */
+export const MatchOperatorSchema = z
+  .object({
+    equals: z.unknown().optional(),
+    contains: z.union([z.string(), z.array(z.unknown())]).optional(),
+    default: z.literal(true).optional(),
+  })
+  .strict();
+
+export const MatchExpressionSchema = z.record(z.string(), MatchOperatorSchema);
+
+export const RolloutSchema = z
+  .object({
+    percent: z.number().min(0).max(100),
+    cohortKey: z.string().min(1),
+  })
+  .strict();
+
+export const BudgetGuardrailSchema = z
+  .object({
+    maxCostUsdPerCall: z.number().min(0),
+  })
+  .strict();
+
+export const LatencyGuardrailSchema = z
+  .object({
+    maxP95Ms: z.number().min(0),
+  })
+  .strict();
+
+export const ConfidenceGuardrailSchema = z
+  .object({
+    minScore: z.number().min(0).max(1),
+  })
+  .strict();
+
+// ---- Aggregates ----
+
+export const RouteSchema = z
+  .object({
+    id: z.string().min(1),
+    match: MatchExpressionSchema,
+    target: ModelTargetSchema,
+    rollout: RolloutSchema.optional(),
+    budget: BudgetGuardrailSchema.optional(),
+    latency: LatencyGuardrailSchema.optional(),
+    confidence: ConfidenceGuardrailSchema.optional(),
+  })
+  .strict();
+
+export const FallbackReasonSchema = z.enum([
+  "budget-exceeded",
+  "latency-breached",
+  "provider-error",
+  "no-match",
+]);
+
+export const FallbackEntrySchema = z
+  .object({
+    provider: z.string().min(1),
+    model: z.string().min(1),
+    endpoint: z.string().nullable().optional(),
+    when: z.array(FallbackReasonSchema).optional(),
+  })
+  .strict();
+
+export const ModelRoutingPayloadSchema = z
+  .object({
+    schemaVersion: z.literal("1.0"),
+    default: ModelTargetSchema,
+    routes: z.array(RouteSchema),
+    fallback: z.array(FallbackEntrySchema),
+  })
+  .strict();
+
+// ---- Types ----
+
+export type ModelTarget = z.infer<typeof ModelTargetSchema>;
+export type MatchOperator = z.infer<typeof MatchOperatorSchema>;
+export type MatchExpression = z.infer<typeof MatchExpressionSchema>;
+export type Rollout = z.infer<typeof RolloutSchema>;
+export type BudgetGuardrail = z.infer<typeof BudgetGuardrailSchema>;
+export type LatencyGuardrail = z.infer<typeof LatencyGuardrailSchema>;
+export type ConfidenceGuardrail = z.infer<typeof ConfidenceGuardrailSchema>;
+export type Route = z.infer<typeof RouteSchema>;
+export type FallbackReason = z.infer<typeof FallbackReasonSchema>;
+export type FallbackEntry = z.infer<typeof FallbackEntrySchema>;
+export type ModelRoutingPayload = z.infer<typeof ModelRoutingPayloadSchema>;
+
+export const MODEL_ROUTING_FILENAME = "models.json";

--- a/ts/src/control-plane/actuators/registry.ts
+++ b/ts/src/control-plane/actuators/registry.ts
@@ -8,6 +8,7 @@
 //        tool-policy      → content-revert
 //        routing-rule     → cascade-set
 //        fine-tuned-model → pointer-flip
+//        model-routing    → content-revert
 //
 // A second call for an already-registered type throws — by design, there is one
 // canonical implementation per ActuatorType in a given process.
@@ -105,6 +106,7 @@ const MIN_ROLLBACK: Record<ActuatorType, RollbackStrategy["kind"]> = {
   "tool-policy": "content-revert",
   "routing-rule": "cascade-set",
   "fine-tuned-model": "pointer-flip",
+  "model-routing": "content-revert",
 };
 
 function meetsMinimum(type: ActuatorType, declared: RollbackStrategy["kind"]): boolean {

--- a/ts/src/control-plane/cli/candidate.ts
+++ b/ts/src/control-plane/cli/candidate.ts
@@ -32,6 +32,7 @@ const ACTUATOR_TYPES: readonly ActuatorType[] = [
   "tool-policy",
   "routing-rule",
   "fine-tuned-model",
+  "model-routing",
 ];
 
 export const CANDIDATE_HELP_TEXT = `autoctx candidate — manage control-plane candidate artifacts

--- a/ts/src/control-plane/contract/json-schemas/model-routing-payload.schema.json
+++ b/ts/src/control-plane/contract/json-schemas/model-routing-payload.schema.json
@@ -32,9 +32,15 @@
     "MatchExpression": {
       "description": "Mapping of dotted context paths to per-path operator objects. Each operator object may set exactly one of { equals, contains, default:true }.",
       "type": "object",
+      "minProperties": 1,
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
+        "oneOf": [
+          { "required": ["equals"] },
+          { "required": ["contains"] },
+          { "required": ["default"] }
+        ],
         "properties": {
           "equals": {},
           "contains": { "type": ["string", "array"] },

--- a/ts/src/control-plane/contract/json-schemas/model-routing-payload.schema.json
+++ b/ts/src/control-plane/contract/json-schemas/model-routing-payload.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://autocontext.dev/schema/model-routing-payload.json",
+  "title": "ModelRoutingPayload",
+  "description": "Declarative model-routing config shipped as the model-routing actuator's models.json payload file. Top-level shape: default model + ordered routes[] + fallback[] chain with guardrails for budget, latency, confidence, rollout%. Spec §4 (AC-545).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "default", "routes", "fallback"],
+  "properties": {
+    "schemaVersion": { "const": "1.0" },
+    "default": { "$ref": "#/$defs/ModelTarget" },
+    "routes": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Route" }
+    },
+    "fallback": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/FallbackEntry" }
+    }
+  },
+  "$defs": {
+    "ModelTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "model"],
+      "properties": {
+        "provider": { "type": "string", "minLength": 1 },
+        "model": { "type": "string", "minLength": 1 },
+        "endpoint": { "type": ["string", "null"] }
+      }
+    },
+    "MatchExpression": {
+      "description": "Mapping of dotted context paths to per-path operator objects. Each operator object may set exactly one of { equals, contains, default:true }.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "equals": {},
+          "contains": { "type": ["string", "array"] },
+          "default": { "const": true }
+        }
+      }
+    },
+    "Route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "match", "target"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "match": { "$ref": "#/$defs/MatchExpression" },
+        "target": { "$ref": "#/$defs/ModelTarget" },
+        "rollout": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["percent", "cohortKey"],
+          "properties": {
+            "percent": { "type": "number", "minimum": 0, "maximum": 100 },
+            "cohortKey": { "type": "string", "minLength": 1 }
+          }
+        },
+        "budget": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["maxCostUsdPerCall"],
+          "properties": {
+            "maxCostUsdPerCall": { "type": "number", "minimum": 0 }
+          }
+        },
+        "latency": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["maxP95Ms"],
+          "properties": {
+            "maxP95Ms": { "type": "number", "minimum": 0 }
+          }
+        },
+        "confidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["minScore"],
+          "properties": {
+            "minScore": { "type": "number", "minimum": 0, "maximum": 1 }
+          }
+        }
+      }
+    },
+    "FallbackEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "model"],
+      "properties": {
+        "provider": { "type": "string", "minLength": 1 },
+        "model": { "type": "string", "minLength": 1 },
+        "endpoint": { "type": ["string", "null"] },
+        "when": {
+          "type": "array",
+          "items": {
+            "enum": ["budget-exceeded", "latency-breached", "provider-error", "no-match"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/ts/src/control-plane/contract/json-schemas/shared-defs.schema.json
+++ b/ts/src/control-plane/contract/json-schemas/shared-defs.schema.json
@@ -28,7 +28,7 @@
       "pattern": "^[a-z0-9][a-z0-9_-]*$"
     },
     "ActuatorType": {
-      "enum": ["prompt-patch", "tool-policy", "routing-rule", "fine-tuned-model"]
+      "enum": ["prompt-patch", "tool-policy", "routing-rule", "fine-tuned-model", "model-routing"]
     },
     "ActivationState": {
       "enum": ["candidate", "shadow", "canary", "active", "disabled", "deprecated"]

--- a/ts/src/control-plane/contract/types.ts
+++ b/ts/src/control-plane/contract/types.ts
@@ -12,7 +12,8 @@ export type ActuatorType =
   | "prompt-patch"
   | "tool-policy"
   | "routing-rule"
-  | "fine-tuned-model";
+  | "fine-tuned-model"
+  | "model-routing";
 
 export type ActivationState =
   | "candidate"

--- a/ts/src/control-plane/emit/pr-body-renderer.ts
+++ b/ts/src/control-plane/emit/pr-body-renderer.ts
@@ -176,6 +176,8 @@ function rollbackForActuator(
       return { kind: "cascade-set", dependsOn: ["tool-policy"] };
     case "fine-tuned-model":
       return { kind: "pointer-flip" };
+    case "model-routing":
+      return { kind: "content-revert" };
   }
 }
 

--- a/ts/src/control-plane/runtime/index.ts
+++ b/ts/src/control-plane/runtime/index.ts
@@ -1,0 +1,15 @@
+// Public surface of the autocontext control-plane runtime helpers.
+//
+// v1 exposes only `chooseModel` (AC-545, spec §4). Import discipline: this
+// module sits in runtime/ and depends on contract/ + actuators/model-routing/
+// for config types. It does NOT import from emit/, registry/, promotion/, or
+// production-traces/. Callers that want to record a routing decision on a
+// ProductionTrace do so themselves — the router does not touch I/O.
+
+export { chooseModel } from "./model-router.js";
+export type {
+  ChooseModelInputs,
+  ModelDecision,
+  ModelDecisionReason,
+  ModelRouterContext,
+} from "./model-router.js";

--- a/ts/src/control-plane/runtime/model-router.ts
+++ b/ts/src/control-plane/runtime/model-router.ts
@@ -86,6 +86,13 @@ function lookupContextValue(path: string, ctx: ModelRouterContext): unknown {
  * require a defined context value.
  */
 function operatorMatches(op: MatchOperator, value: unknown): boolean {
+  const operatorCount = [
+    op.default === true,
+    op.equals !== undefined,
+    op.contains !== undefined,
+  ].filter(Boolean).length;
+  if (operatorCount !== 1) return false;
+
   if (op.default === true) return true;
   if (op.equals !== undefined) {
     return value === op.equals;
@@ -107,7 +114,9 @@ function operatorMatches(op: MatchOperator, value: unknown): boolean {
 
 /** All per-field operators in a MatchExpression must match (AND semantics). */
 function matchExpressionMatches(match: MatchExpression, ctx: ModelRouterContext): boolean {
-  for (const [path, op] of Object.entries(match)) {
+  const entries = Object.entries(match);
+  if (entries.length === 0) return false;
+  for (const [path, op] of entries) {
     const value = lookupContextValue(path, ctx);
     if (!operatorMatches(op, value)) return false;
   }

--- a/ts/src/control-plane/runtime/model-router.ts
+++ b/ts/src/control-plane/runtime/model-router.ts
@@ -1,0 +1,287 @@
+// chooseModel — pure runtime helper that consults a ModelRoutingPayload
+// (validated config) and returns a ModelDecision. Spec §4 (AC-545).
+//
+// Pure: no I/O, no clock, no random. `evaluatedAt` is injected as `nowIso` so
+// the output is reproducible in tests and audit logs.
+//
+// Import discipline: runtime/ imports from contract/ + actuators/model-routing/
+// (for the config types). It does NOT import from emit/, registry/, or
+// production-traces/. Trace emission is the caller's responsibility.
+//
+// DDD vocabulary (from spec §4, verbatim): `default`, `routes`, `fallback`,
+// `match`, `rollout`, `budget`, `latency`, `confidence`, `cohortKey`.
+
+import { createHash } from "node:crypto";
+import type {
+  FallbackEntry,
+  FallbackReason,
+  MatchExpression,
+  MatchOperator,
+  ModelRoutingPayload,
+  Route,
+} from "../actuators/model-routing/schema.js";
+
+// ---- Types ----
+
+/**
+ * Context inputs to the router. Field names mirror the spec's dotted path
+ * vocabulary — `env.taskType`, `session.sessionIdHash` — flattened into a
+ * single object for ergonomic call sites. The router maps dotted paths to
+ * these flat fields internally (see `lookupContextValue`).
+ */
+export interface ModelRouterContext {
+  readonly taskType?: string;
+  readonly tenant?: string;
+  readonly budgetRemainingUsd?: number;
+  readonly latencyBudgetMs?: number;
+  readonly sessionIdHash?: string;
+  readonly confidenceScore?: number;
+  readonly previousFailure?: "provider-error" | "latency-breached" | "budget-exceeded";
+}
+
+export interface ChooseModelInputs {
+  readonly config: ModelRoutingPayload;
+  readonly context: ModelRouterContext;
+}
+
+export type ModelDecisionReason = "default" | "matched-route" | "fallback";
+
+export interface ModelDecision {
+  readonly chosen: {
+    readonly provider: string;
+    readonly model: string;
+    readonly endpoint?: string;
+  };
+  readonly reason: ModelDecisionReason;
+  readonly matchedRouteId?: string;
+  readonly fallbackReason?: FallbackReason;
+  readonly evaluatedAt: string;
+}
+
+// ---- Helpers ----
+
+/**
+ * Map a dotted path (e.g. "env.taskType" or "session.sessionIdHash") to the
+ * corresponding field in the flat context. v1 supports a closed set of paths
+ * — unknown paths return `undefined` and the operator is considered non-
+ * matching. (This keeps semantics conservative and the surface small.)
+ */
+function lookupContextValue(path: string, ctx: ModelRouterContext): unknown {
+  switch (path) {
+    case "env.taskType":
+      return ctx.taskType;
+    case "env.tenant":
+      return ctx.tenant;
+    case "session.sessionIdHash":
+      return ctx.sessionIdHash;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Decide whether a per-field operator object matches the context value. The
+ * operator object may set exactly one of { equals, contains, default:true }.
+ * `default: true` matches any context (including undefined). Other operators
+ * require a defined context value.
+ */
+function operatorMatches(op: MatchOperator, value: unknown): boolean {
+  if (op.default === true) return true;
+  if (op.equals !== undefined) {
+    return value === op.equals;
+  }
+  if (op.contains !== undefined) {
+    if (typeof value !== "string") return false;
+    if (typeof op.contains === "string") {
+      return value.includes(op.contains);
+    }
+    // Array form: any element a string the value contains.
+    for (const needle of op.contains) {
+      if (typeof needle === "string" && value.includes(needle)) return true;
+    }
+    return false;
+  }
+  // No operator set — treat as non-matching (conservative).
+  return false;
+}
+
+/** All per-field operators in a MatchExpression must match (AND semantics). */
+function matchExpressionMatches(match: MatchExpression, ctx: ModelRouterContext): boolean {
+  for (const [path, op] of Object.entries(match)) {
+    const value = lookupContextValue(path, ctx);
+    if (!operatorMatches(op, value)) return false;
+  }
+  return true;
+}
+
+/**
+ * Rollout bucket check: `hash(cohortValue) mod 100 < percent`. The cohortKey
+ * is a dotted path into the context. Missing cohort value ⇒ route does not
+ * match (conservative — don't bucket unknown traffic).
+ */
+function rolloutMatches(
+  rollout: NonNullable<Route["rollout"]>,
+  ctx: ModelRouterContext,
+): boolean {
+  const cohortValue = lookupContextValue(rollout.cohortKey, ctx);
+  if (typeof cohortValue !== "string" || cohortValue.length === 0) {
+    return false;
+  }
+  if (rollout.percent >= 100) return true;
+  if (rollout.percent <= 0) return false;
+  const digest = createHash("sha256").update(cohortValue).digest();
+  const bucket = digest.readUInt32BE(0) % 100;
+  return bucket < rollout.percent;
+}
+
+/**
+ * Confidence guardrail: if the route declares a minScore, the context must
+ * provide a confidenceScore ≥ minScore for the route to be considered
+ * matching. Missing confidenceScore → skip (conservative).
+ */
+function confidenceMatches(route: Route, ctx: ModelRouterContext): boolean {
+  const conf = route.confidence;
+  if (conf === undefined) return true;
+  if (typeof ctx.confidenceScore !== "number") return false;
+  return ctx.confidenceScore >= conf.minScore;
+}
+
+/**
+ * Guardrail demotion: if the route matches but a budget/latency guardrail is
+ * violated, return the appropriate fallback reason. `undefined` means no
+ * demotion.
+ */
+function guardrailDemotion(
+  route: Route,
+  ctx: ModelRouterContext,
+): FallbackReason | undefined {
+  if (route.budget !== undefined) {
+    const remaining = ctx.budgetRemainingUsd;
+    if (typeof remaining === "number" && remaining < route.budget.maxCostUsdPerCall) {
+      return "budget-exceeded";
+    }
+  }
+  if (route.latency !== undefined) {
+    const budget = ctx.latencyBudgetMs;
+    if (typeof budget === "number" && budget < route.latency.maxP95Ms) {
+      return "latency-breached";
+    }
+  }
+  return undefined;
+}
+
+/** Map a `previousFailure` context value to the corresponding FallbackReason. */
+function previousFailureReason(ctx: ModelRouterContext): FallbackReason | undefined {
+  switch (ctx.previousFailure) {
+    case "provider-error":
+      return "provider-error";
+    case "latency-breached":
+      return "latency-breached";
+    case "budget-exceeded":
+      return "budget-exceeded";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Pick the first fallback whose `when` filter includes `reason` (or omits the
+ * filter entirely — an unconditional fallback). Returns undefined if the
+ * chain is exhausted.
+ */
+function pickFallback(
+  fallback: readonly FallbackEntry[],
+  reason: FallbackReason,
+): FallbackEntry | undefined {
+  for (const entry of fallback) {
+    if (entry.when === undefined || entry.when.length === 0) return entry;
+    if (entry.when.includes(reason)) return entry;
+  }
+  return undefined;
+}
+
+function toChosen(target: {
+  readonly provider: string;
+  readonly model: string;
+  readonly endpoint?: string | null;
+}): ModelDecision["chosen"] {
+  return target.endpoint !== undefined && target.endpoint !== null
+    ? { provider: target.provider, model: target.model, endpoint: target.endpoint }
+    : { provider: target.provider, model: target.model };
+}
+
+// ---- chooseModel ----
+
+/**
+ * Decide which model to use given a config, context, and a nowIso. Pure and
+ * deterministic: given the same inputs and the same nowIso, returns the same
+ * ModelDecision.
+ *
+ * Algorithm (spec §4):
+ *   1. Walk `config.routes` in declared order. For each route:
+ *      - check match expression (AND of per-field operators)
+ *      - check confidence guardrail (skip if below minScore)
+ *      - check rollout bucket (skip if cohort value missing or bucket ≥ percent)
+ *      If all pass, the route is a candidate.
+ *   2. If a candidate route is found:
+ *      - if `context.previousFailure` is set → demote to fallback with that reason
+ *      - else if a budget/latency guardrail is violated → demote to fallback
+ *      - else → return the route's target with reason=matched-route
+ *   3. If no route matches → return `config.default` with reason=default.
+ *
+ * Fallback resolution: walk `config.fallback` in order; first entry whose
+ * `when` filter includes the reason (or has no filter) wins. If the list is
+ * exhausted, fall back to `config.default` but keep the reason=fallback so
+ * audit logs reflect the demotion.
+ */
+export function chooseModel(inputs: ChooseModelInputs, nowIso: string): ModelDecision {
+  const { config, context } = inputs;
+
+  for (const route of config.routes) {
+    if (!matchExpressionMatches(route.match, context)) continue;
+    if (!confidenceMatches(route, context)) continue;
+    if (route.rollout !== undefined && !rolloutMatches(route.rollout, context)) continue;
+
+    // Route matched. Check for previousFailure short-circuit, then guardrails.
+    const prev = previousFailureReason(context);
+    if (prev !== undefined) {
+      return buildFallback(config, prev, route.id, nowIso);
+    }
+    const demotion = guardrailDemotion(route, context);
+    if (demotion !== undefined) {
+      return buildFallback(config, demotion, route.id, nowIso);
+    }
+
+    return {
+      chosen: toChosen(route.target),
+      reason: "matched-route",
+      matchedRouteId: route.id,
+      evaluatedAt: nowIso,
+    };
+  }
+
+  // No route matched → default path. previousFailure without a matched route
+  // does not trigger a fallback (there's nothing to fall back *from*).
+  return {
+    chosen: toChosen(config.default),
+    reason: "default",
+    evaluatedAt: nowIso,
+  };
+}
+
+function buildFallback(
+  config: ModelRoutingPayload,
+  reason: FallbackReason,
+  matchedRouteId: string,
+  nowIso: string,
+): ModelDecision {
+  const picked = pickFallback(config.fallback, reason);
+  const target = picked ?? config.default;
+  return {
+    chosen: toChosen(target),
+    reason: "fallback",
+    matchedRouteId,
+    fallbackReason: reason,
+    evaluatedAt: nowIso,
+  };
+}

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -477,3 +477,11 @@ export type {
   MissionVerifier,
 } from "./mission/index.js";
 
+// Control-plane runtime helpers
+export { chooseModel } from "./control-plane/runtime/index.js";
+export type {
+  ChooseModelInputs,
+  ModelDecision,
+  ModelDecisionReason,
+  ModelRouterContext,
+} from "./control-plane/runtime/index.js";

--- a/ts/src/production-traces/cli/build-dataset.ts
+++ b/ts/src/production-traces/cli/build-dataset.ts
@@ -308,7 +308,8 @@ async function buildRegistryRubricLookup(cwd: string): Promise<RubricLookup | nu
     | "tool-policy"
     | "routing-rule"
     | "fine-tuned-model"
-  )[] = ["prompt-patch", "tool-policy", "routing-rule", "fine-tuned-model"];
+    | "model-routing"
+  )[] = ["prompt-patch", "tool-policy", "routing-rule", "fine-tuned-model", "model-routing"];
 
   return async (scenarioId) => {
     try {

--- a/ts/src/production-traces/contract/factories.ts
+++ b/ts/src/production-traces/contract/factories.ts
@@ -12,6 +12,7 @@ import {
   type ToolCall,
   type TraceLinks,
   type TraceMessage,
+  type ProductionTraceRouting,
   type TraceSource,
   type UsageInfo,
 } from "./types.js";
@@ -31,6 +32,7 @@ export interface CreateProductionTraceInputs {
   readonly feedbackRefs?: readonly FeedbackRef[];
   readonly links?: TraceLinks;
   readonly redactions?: readonly RedactionMarker[];
+  readonly routing?: ProductionTraceRouting;
   readonly metadata?: Record<string, unknown>;
 }
 
@@ -59,6 +61,7 @@ export function createProductionTrace(inputs: CreateProductionTraceInputs): Prod
     feedbackRefs: inputs.feedbackRefs ?? [],
     links: inputs.links ?? {},
     redactions: inputs.redactions ?? [],
+    ...(inputs.routing !== undefined ? { routing: inputs.routing } : {}),
     ...(inputs.metadata !== undefined ? { metadata: inputs.metadata } : {}),
   };
   return trace;

--- a/ts/src/production-traces/contract/generated-types.ts
+++ b/ts/src/production-traces/contract/generated-types.ts
@@ -227,6 +227,17 @@ export interface ProductionTrace {
   feedbackRefs: FeedbackRef[];
   links: TraceLinks;
   redactions: RedactionMarker[];
+  routing?: {
+    chosen: {
+      provider: string;
+      model: string;
+      endpoint?: string;
+    };
+    matchedRouteId?: string;
+    reason: "default" | "matched-route" | "fallback";
+    fallbackReason?: "budget-exceeded" | "latency-breached" | "provider-error" | "no-match";
+    evaluatedAt: string;
+  };
   metadata?: {};
 }
 export interface TraceSource {

--- a/ts/src/production-traces/contract/json-schemas/production-trace.schema.json
+++ b/ts/src/production-traces/contract/json-schemas/production-trace.schema.json
@@ -57,6 +57,27 @@
       "type": "array",
       "items": { "$ref": "https://autocontext.dev/schema/production-traces/redaction-marker.json" }
     },
+    "routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chosen", "reason", "evaluatedAt"],
+      "properties": {
+        "chosen": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["provider", "model"],
+          "properties": {
+            "provider": { "type": "string", "minLength": 1 },
+            "model": { "type": "string", "minLength": 1 },
+            "endpoint": { "type": "string" }
+          }
+        },
+        "matchedRouteId": { "type": "string", "minLength": 1 },
+        "reason": { "enum": ["default", "matched-route", "fallback"] },
+        "fallbackReason": { "enum": ["budget-exceeded", "latency-breached", "provider-error", "no-match"] },
+        "evaluatedAt": { "type": "string", "format": "date-time" }
+      }
+    },
     "metadata": { "type": "object" }
   }
 }

--- a/ts/src/production-traces/contract/types.ts
+++ b/ts/src/production-traces/contract/types.ts
@@ -130,6 +130,29 @@ export type RedactionMarker = {
   readonly detectedAt: string;
 };
 
+
+// ---- Routing decision (AC-545) ----
+
+export type ModelRoutingDecisionReason = "default" | "matched-route" | "fallback";
+
+export type ModelRoutingFallbackReason =
+  | "budget-exceeded"
+  | "latency-breached"
+  | "provider-error"
+  | "no-match";
+
+export type ProductionTraceRouting = {
+  readonly chosen: {
+    readonly provider: string;
+    readonly model: string;
+    readonly endpoint?: string;
+  };
+  readonly matchedRouteId?: string;
+  readonly reason: ModelRoutingDecisionReason;
+  readonly fallbackReason?: ModelRoutingFallbackReason;
+  readonly evaluatedAt: string;
+};
+
 // ---- Aggregate root ----
 
 export type ProductionTrace = {
@@ -148,6 +171,7 @@ export type ProductionTrace = {
   readonly feedbackRefs: readonly FeedbackRef[];
   readonly links: TraceLinks;
   readonly redactions: readonly RedactionMarker[];
+  readonly routing?: ProductionTraceRouting;
   readonly metadata?: Record<string, unknown>;
 };
 

--- a/ts/tests/control-plane/actuators/model-routing/applicator.test.ts
+++ b/ts/tests/control-plane/actuators/model-routing/applicator.test.ts
@@ -97,6 +97,27 @@ describe("model-routing actuator — parsePayload", () => {
     expect(() => modelRoutingActuator.parsePayload(bad)).toThrow();
   });
 
+  test("rejects empty route match expressions", () => {
+    const bad = {
+      ...VALID_PAYLOAD,
+      routes: [{ ...VALID_PAYLOAD.routes[0]!, match: {} }],
+    };
+    expect(() => modelRoutingActuator.parsePayload(bad)).toThrow(/match expression/i);
+  });
+
+  test("rejects match operators with more than one operator", () => {
+    const bad = {
+      ...VALID_PAYLOAD,
+      routes: [
+        {
+          ...VALID_PAYLOAD.routes[0]!,
+          match: { "env.taskType": { default: true, equals: "checkout" } },
+        },
+      ],
+    };
+    expect(() => modelRoutingActuator.parsePayload(bad)).toThrow(/exactly one/i);
+  });
+
   test("rejects a rollout with percent > 100", () => {
     const bad = {
       ...VALID_PAYLOAD,

--- a/ts/tests/control-plane/actuators/model-routing/applicator.test.ts
+++ b/ts/tests/control-plane/actuators/model-routing/applicator.test.ts
@@ -1,0 +1,233 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { applyPatch } from "diff";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { modelRoutingActuator } from "../../../../src/control-plane/actuators/model-routing/applicator.js";
+import { hashDirectory } from "../../../../src/control-plane/registry/content-address.js";
+import { createArtifact } from "../../../../src/control-plane/contract/factories.js";
+import { defaultWorkspaceLayout } from "../../../../src/control-plane/emit/workspace-layout.js";
+import { parseContentHash } from "../../../../src/control-plane/contract/branded-ids.js";
+import type { Artifact, Provenance } from "../../../../src/control-plane/contract/types.js";
+import type { ModelRoutingPayload } from "../../../../src/control-plane/actuators/model-routing/schema.js";
+
+const prov: Provenance = {
+  authorType: "human",
+  authorId: "jay@greyhaven.ai",
+  parentArtifactIds: [],
+  createdAt: "2026-04-17T00:00:00.000Z",
+};
+
+const VALID_PAYLOAD: ModelRoutingPayload = {
+  schemaVersion: "1.0",
+  default: { provider: "anthropic", model: "claude-sonnet-4-5", endpoint: null },
+  routes: [
+    {
+      id: "checkout-specialized",
+      match: { "env.taskType": { equals: "checkout" } },
+      target: {
+        provider: "openai-compatible",
+        model: "finetuned-checkout-v3",
+        endpoint: "https://my-vllm/v1",
+      },
+      rollout: { percent: 25, cohortKey: "session.sessionIdHash" },
+      budget: { maxCostUsdPerCall: 0.02 },
+      latency: { maxP95Ms: 800 },
+      confidence: { minScore: 0.85 },
+    },
+  ],
+  fallback: [
+    {
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      when: ["budget-exceeded", "latency-breached", "provider-error"],
+    },
+  ],
+};
+
+function mkPayload(dir: string, payload: unknown): string {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "models.json"), JSON.stringify(payload, null, 2), "utf-8");
+  return dir;
+}
+
+function mkArtifact(payloadDir: string): Artifact {
+  return createArtifact({
+    actuatorType: "model-routing",
+    scenario: "grid_ctf",
+    payloadHash: hashDirectory(payloadDir),
+    provenance: prov,
+  });
+}
+
+describe("model-routing actuator — parsePayload", () => {
+  test("accepts a fully-populated spec §4 example", () => {
+    expect(modelRoutingActuator.parsePayload(VALID_PAYLOAD)).toBeTruthy();
+  });
+
+  test("accepts a minimal payload (default + empty routes + empty fallback)", () => {
+    expect(
+      modelRoutingActuator.parsePayload({
+        schemaVersion: "1.0",
+        default: { provider: "anthropic", model: "claude-sonnet-4-5" },
+        routes: [],
+        fallback: [],
+      }),
+    ).toBeTruthy();
+  });
+
+  test("rejects wrong schemaVersion", () => {
+    expect(() =>
+      modelRoutingActuator.parsePayload({ ...VALID_PAYLOAD, schemaVersion: "2.0" }),
+    ).toThrow();
+  });
+
+  test("rejects a route missing required id", () => {
+    const bad = {
+      ...VALID_PAYLOAD,
+      routes: [{ match: {}, target: { provider: "x", model: "y" } }],
+    };
+    expect(() => modelRoutingActuator.parsePayload(bad)).toThrow();
+  });
+
+  test("rejects a rollout with percent > 100", () => {
+    const bad = {
+      ...VALID_PAYLOAD,
+      routes: [
+        {
+          ...VALID_PAYLOAD.routes[0]!,
+          rollout: { percent: 150, cohortKey: "x" },
+        },
+      ],
+    };
+    expect(() => modelRoutingActuator.parsePayload(bad)).toThrow();
+  });
+
+  test("rejects additionalProperties (strict)", () => {
+    expect(() =>
+      modelRoutingActuator.parsePayload({ ...VALID_PAYLOAD, extraField: "nope" }),
+    ).toThrow();
+  });
+});
+
+describe("model-routing actuator — apply / emit / rollback", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "autocontext-model-routing-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("resolveTargetPath places models.json under <scenarioDir>/<routingSubdir>/models/", () => {
+    const layout = defaultWorkspaceLayout();
+    const payloadDir = mkPayload(join(tmp, "payload"), VALID_PAYLOAD);
+    const artifact = mkArtifact(payloadDir);
+    const target = modelRoutingActuator.resolveTargetPath(artifact, layout);
+    expect(target).toMatch(/routing\/models\//);
+    expect(target).toMatch(/\.json$/);
+    expect(target).toContain(artifact.id);
+  });
+
+  test("apply writes the models.json payload to the resolved target", async () => {
+    const layout = defaultWorkspaceLayout();
+    const payloadDir = mkPayload(join(tmp, "payload"), VALID_PAYLOAD);
+    const artifact = mkArtifact(payloadDir);
+    const wt = join(tmp, "wt");
+    mkdirSync(wt, { recursive: true });
+
+    await modelRoutingActuator.apply({
+      artifact,
+      payloadDir,
+      workingTreeRoot: wt,
+      layout,
+    });
+    const target = join(wt, modelRoutingActuator.resolveTargetPath(artifact, layout));
+    expect(existsSync(target)).toBe(true);
+    expect(JSON.parse(readFileSync(target, "utf-8"))).toEqual(VALID_PAYLOAD);
+  });
+
+  test("apply rejects when payload tree hash does not match artifact.payloadHash", async () => {
+    const layout = defaultWorkspaceLayout();
+    const payloadDir = mkPayload(join(tmp, "payload"), VALID_PAYLOAD);
+    const artifact = createArtifact({
+      actuatorType: "model-routing",
+      scenario: "grid_ctf",
+      payloadHash: parseContentHash("sha256:" + "0".repeat(64))!,
+      provenance: prov,
+    });
+    const wt = join(tmp, "wt");
+    mkdirSync(wt, { recursive: true });
+    await expect(
+      modelRoutingActuator.apply({
+        artifact,
+        payloadDir,
+        workingTreeRoot: wt,
+        layout,
+      }),
+    ).rejects.toThrow(/hash.*mismatch/i);
+  });
+
+  test("emitPatch roundtrips via diff.applyPatch", () => {
+    const layout = defaultWorkspaceLayout();
+    const payloadDir = mkPayload(join(tmp, "payload"), VALID_PAYLOAD);
+    const artifact = mkArtifact(payloadDir);
+    const wt = join(tmp, "wt");
+    mkdirSync(wt, { recursive: true });
+
+    const patch = modelRoutingActuator.emitPatch({
+      artifact,
+      payloadDir,
+      workingTreeRoot: wt,
+      layout,
+    });
+    expect(patch.operation).toBe("create");
+    expect(applyPatch("", patch.unifiedDiff)).toBe(patch.afterContent);
+  });
+
+  test("rollback content-reverts to the baseline payload", async () => {
+    const layout = defaultWorkspaceLayout();
+    const candDir = mkPayload(join(tmp, "cand"), {
+      ...VALID_PAYLOAD,
+      default: { provider: "anthropic", model: "claude-opus-4-5" },
+    });
+    const baseDir = mkPayload(join(tmp, "base"), VALID_PAYLOAD);
+    const candidate = mkArtifact(candDir);
+    const baseline = createArtifact({
+      actuatorType: "model-routing",
+      scenario: "grid_ctf",
+      payloadHash: hashDirectory(baseDir),
+      provenance: prov,
+    });
+    const wt = join(tmp, "wt");
+    mkdirSync(wt, { recursive: true });
+    await modelRoutingActuator.apply({
+      artifact: candidate,
+      payloadDir: candDir,
+      workingTreeRoot: wt,
+      layout,
+    });
+
+    const patches = await modelRoutingActuator.rollback({
+      candidate,
+      baseline,
+      candidatePayloadDir: candDir,
+      baselinePayloadDir: baseDir,
+      workingTreeRoot: wt,
+      layout,
+    });
+    const patch = Array.isArray(patches) ? patches[0]! : patches;
+    const target = join(wt, modelRoutingActuator.resolveTargetPath(candidate, layout));
+    expect(patch.afterContent).toBe(readFileSync(join(baseDir, "models.json"), "utf-8"));
+    expect(applyPatch(readFileSync(target, "utf-8"), patch.unifiedDiff)).toBe(patch.afterContent);
+  });
+});

--- a/ts/tests/control-plane/actuators/model-routing/registration.test.ts
+++ b/ts/tests/control-plane/actuators/model-routing/registration.test.ts
@@ -1,0 +1,47 @@
+// RED-phase TDD: this file references files that will exist once AC-545 lands.
+// The first green cycle is "actuator registers on import with the expected
+// rollback strategy and target pattern".
+
+import { describe, test, expect } from "vitest";
+import {
+  __resetActuatorRegistryForTests,
+  getActuator,
+  registerActuator,
+  type ActuatorRegistration,
+} from "../../../../src/control-plane/actuators/registry.js";
+import { modelRoutingRegistration } from "../../../../src/control-plane/actuators/model-routing/index.js";
+
+describe("model-routing actuator registration", () => {
+  test("declares content-revert rollback and a routing/models/*.json target pattern", () => {
+    expect(modelRoutingRegistration.type).toBe("model-routing");
+    expect(modelRoutingRegistration.rollback).toEqual({ kind: "content-revert" });
+    expect(modelRoutingRegistration.allowedTargetPattern).toMatch(/routing\/models/);
+    expect(modelRoutingRegistration.allowedTargetPattern).toMatch(/\.json$/);
+  });
+
+  test("is discoverable via getActuator after importing the module", () => {
+    expect(getActuator("model-routing")).not.toBeNull();
+  });
+
+  test("registry refuses a wrong-rollback registration for model-routing", () => {
+    __resetActuatorRegistryForTests();
+    const wrong: ActuatorRegistration<unknown> = {
+      type: "model-routing",
+      rollback: { kind: "pointer-flip" },
+      allowedTargetPattern: "**/routing/models/*.json",
+      actuator: modelRoutingRegistration.actuator,
+    };
+    expect(() => registerActuator(wrong)).toThrow(/content-revert/i);
+  });
+
+  test("registry refuses an empty allowedTargetPattern for model-routing", () => {
+    __resetActuatorRegistryForTests();
+    const wrong: ActuatorRegistration<unknown> = {
+      type: "model-routing",
+      rollback: { kind: "content-revert" },
+      allowedTargetPattern: "",
+      actuator: modelRoutingRegistration.actuator,
+    };
+    expect(() => registerActuator(wrong)).toThrow(/allowedTargetPattern/i);
+  });
+});

--- a/ts/tests/control-plane/runtime/model-router-cohort.test.ts
+++ b/ts/tests/control-plane/runtime/model-router-cohort.test.ts
@@ -1,0 +1,93 @@
+// Property test P-cohort (spec §4, AC-545 stated property test).
+//
+// For a fixed cohortKey value across many invocations with rollout percent N,
+// the "matches vs. doesn't match" answer is stable — same cohort always lands
+// in the same bucket. 100 runs.
+
+import { describe, test } from "vitest";
+import fc from "fast-check";
+import { chooseModel } from "../../../src/control-plane/runtime/model-router.js";
+import type { ModelRoutingPayload } from "../../../src/control-plane/actuators/model-routing/schema.js";
+
+const NOW = "2026-04-17T12:00:00.000Z";
+
+function configWithRollout(percent: number): ModelRoutingPayload {
+  return {
+    schemaVersion: "1.0",
+    default: { provider: "anthropic", model: "default-model", endpoint: null },
+    routes: [
+      {
+        id: "cohort-route",
+        match: { "env.taskType": { equals: "checkout" } },
+        target: { provider: "openai-compatible", model: "cohort-model" },
+        rollout: { percent, cohortKey: "session.sessionIdHash" },
+      },
+    ],
+    fallback: [],
+  };
+}
+
+describe("P-cohort — rollout bucketing is stable per cohort value", () => {
+  test("same cohort value → same decision across invocations (100 runs)", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1 }),
+        fc.integer({ min: 0, max: 100 }),
+        (sessionIdHash, percent) => {
+          const config = configWithRollout(percent);
+          const ctx = { taskType: "checkout", sessionIdHash };
+          const first = chooseModel({ config, context: ctx }, NOW);
+          const second = chooseModel({ config, context: ctx }, NOW);
+          const third = chooseModel({ config, context: ctx }, NOW);
+          const fourth = chooseModel({ config, context: ctx }, NOW);
+          return (
+            first.reason === second.reason
+            && second.reason === third.reason
+            && third.reason === fourth.reason
+            && first.matchedRouteId === fourth.matchedRouteId
+          );
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  test("percent:0 → never matches regardless of cohort value (100 runs)", () => {
+    const config = configWithRollout(0);
+    fc.assert(
+      fc.property(fc.string({ minLength: 1 }), (sessionIdHash) => {
+        const decision = chooseModel(
+          { config, context: { taskType: "checkout", sessionIdHash } },
+          NOW,
+        );
+        return decision.reason === "default";
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test("percent:100 → always matches when cohort value is provided (100 runs)", () => {
+    const config = configWithRollout(100);
+    fc.assert(
+      fc.property(fc.string({ minLength: 1 }), (sessionIdHash) => {
+        const decision = chooseModel(
+          { config, context: { taskType: "checkout", sessionIdHash } },
+          NOW,
+        );
+        return decision.reason === "matched-route";
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test("missing cohort value → never matches regardless of percent (100 runs)", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 100 }), (percent) => {
+        const config = configWithRollout(percent);
+        const decision = chooseModel({ config, context: { taskType: "checkout" } }, NOW);
+        return decision.reason === "default";
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/ts/tests/control-plane/runtime/model-router-determinism.test.ts
+++ b/ts/tests/control-plane/runtime/model-router-determinism.test.ts
@@ -1,0 +1,123 @@
+// Property test P-det (spec §4, AC-545 stated property test).
+//
+// Over a fast-check generator of (config, context) pairs, chooseModel returns
+// identical decisions when given identical inputs + same nowIso. 100 runs.
+
+import { describe, test } from "vitest";
+import fc from "fast-check";
+import { chooseModel } from "../../../src/control-plane/runtime/model-router.js";
+import type {
+  ChooseModelInputs,
+  ModelRouterContext,
+} from "../../../src/control-plane/runtime/model-router.js";
+import type { ModelRoutingPayload } from "../../../src/control-plane/actuators/model-routing/schema.js";
+
+const NOW = "2026-04-17T12:00:00.000Z";
+
+// Small arbitrary of model targets.
+const arbTarget = fc.record({
+  provider: fc.constantFrom("anthropic", "openai", "openai-compatible"),
+  model: fc.stringMatching(/^[a-z0-9-]+$/).filter((s) => s.length > 0 && s.length < 40),
+  endpoint: fc.option(fc.webUrl(), { nil: null }),
+});
+
+const arbMatch = fc.oneof(
+  fc.record({ "env.taskType": fc.record({ equals: fc.string() }) }),
+  fc.record({ "env.taskType": fc.record({ default: fc.constant(true as const) }) }),
+  fc.record({ "session.sessionIdHash": fc.record({ equals: fc.string() }) }),
+  fc.constant<Record<string, never>>({}),
+);
+
+const arbRoute = fc.record({
+  id: fc.stringMatching(/^[a-z][a-z0-9-]*$/).filter((s) => s.length > 0 && s.length < 30),
+  match: arbMatch,
+  target: arbTarget,
+  rollout: fc.option(
+    fc.record({
+      percent: fc.integer({ min: 0, max: 100 }),
+      cohortKey: fc.constantFrom("session.sessionIdHash", "env.tenant"),
+    }),
+    { nil: undefined },
+  ),
+  budget: fc.option(fc.record({ maxCostUsdPerCall: fc.double({ min: 0, max: 1, noNaN: true }) }), {
+    nil: undefined,
+  }),
+  latency: fc.option(fc.record({ maxP95Ms: fc.integer({ min: 0, max: 10000 }) }), {
+    nil: undefined,
+  }),
+  confidence: fc.option(
+    fc.record({ minScore: fc.double({ min: 0, max: 1, noNaN: true }) }),
+    { nil: undefined },
+  ),
+});
+
+const arbConfig = fc.record({
+  schemaVersion: fc.constant("1.0" as const),
+  default: arbTarget,
+  routes: fc.array(arbRoute, { maxLength: 5 }),
+  fallback: fc.array(
+    fc.record({
+      provider: fc.constantFrom("anthropic", "openai"),
+      model: fc.stringMatching(/^[a-z0-9-]+$/).filter((s) => s.length > 0 && s.length < 40),
+      when: fc.option(
+        fc.array(
+          fc.constantFrom("budget-exceeded", "latency-breached", "provider-error", "no-match"),
+        ),
+        { nil: undefined },
+      ),
+    }),
+    { maxLength: 5 },
+  ),
+});
+
+const arbContext = fc.record({
+  taskType: fc.option(fc.string(), { nil: undefined }),
+  tenant: fc.option(fc.string(), { nil: undefined }),
+  budgetRemainingUsd: fc.option(fc.double({ min: 0, max: 10, noNaN: true }), { nil: undefined }),
+  latencyBudgetMs: fc.option(fc.integer({ min: 0, max: 10000 }), { nil: undefined }),
+  sessionIdHash: fc.option(fc.string(), { nil: undefined }),
+  confidenceScore: fc.option(fc.double({ min: 0, max: 1, noNaN: true }), { nil: undefined }),
+  previousFailure: fc.option(
+    fc.constantFrom("provider-error", "latency-breached", "budget-exceeded"),
+    { nil: undefined },
+  ),
+});
+
+// fast-check's `.option(..., { nil: undefined })` yields T | undefined which
+// is structurally equivalent to optional fields; TS is happy via `as`.
+function toInputs(config: unknown, context: unknown): ChooseModelInputs {
+  return {
+    config: config as ModelRoutingPayload,
+    context: context as ModelRouterContext,
+  };
+}
+
+describe("P-det — chooseModel is deterministic", () => {
+  test("same inputs + same nowIso → identical ModelDecision (100 runs)", () => {
+    fc.assert(
+      fc.property(arbConfig, arbContext, (config, context) => {
+        const inputs = toInputs(config, context);
+        const a = chooseModel(inputs, NOW);
+        const b = chooseModel(inputs, NOW);
+        return JSON.stringify(a) === JSON.stringify(b);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test("evaluatedAt in the output is exactly the injected nowIso (100 runs)", () => {
+    fc.assert(
+      fc.property(
+        arbConfig,
+        arbContext,
+        fc.date({ min: new Date("2000-01-01"), max: new Date("2100-01-01"), noInvalidDate: true }),
+        (config, context, d) => {
+          const inputs = toInputs(config, context);
+          const nowIso = d.toISOString();
+          return chooseModel(inputs, nowIso).evaluatedAt === nowIso;
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/ts/tests/control-plane/runtime/model-router.test.ts
+++ b/ts/tests/control-plane/runtime/model-router.test.ts
@@ -1,0 +1,477 @@
+// Unit tests for chooseModel — the pure runtime helper that consults a
+// model-routing config and returns a ModelDecision. No I/O, clock injected
+// as nowIso. See spec §4 (AC-545).
+
+import { describe, test, expect } from "vitest";
+import { chooseModel } from "../../../src/control-plane/runtime/model-router.js";
+import type {
+  ChooseModelInputs,
+  ModelRouterContext,
+} from "../../../src/control-plane/runtime/model-router.js";
+import type { ModelRoutingPayload } from "../../../src/control-plane/actuators/model-routing/schema.js";
+
+const NOW = "2026-04-17T12:00:00.000Z";
+
+const DEFAULT_TARGET = {
+  provider: "anthropic",
+  model: "claude-sonnet-4-5",
+  endpoint: null,
+};
+
+function cfg(overrides: Partial<ModelRoutingPayload> = {}): ModelRoutingPayload {
+  return {
+    schemaVersion: "1.0",
+    default: DEFAULT_TARGET,
+    routes: [],
+    fallback: [],
+    ...overrides,
+  };
+}
+
+function choose(
+  config: ModelRoutingPayload,
+  context: ModelRouterContext,
+  nowIso: string = NOW,
+) {
+  const inputs: ChooseModelInputs = { config, context };
+  return chooseModel(inputs, nowIso);
+}
+
+describe("chooseModel — default path", () => {
+  test("no routes → default model with reason=default and evaluatedAt=nowIso", () => {
+    const decision = choose(cfg(), {});
+    expect(decision.chosen).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      endpoint: undefined,
+    });
+    expect(decision.reason).toBe("default");
+    expect(decision.matchedRouteId).toBeUndefined();
+    expect(decision.fallbackReason).toBeUndefined();
+    expect(decision.evaluatedAt).toBe(NOW);
+  });
+
+  test("evaluatedAt is the injected nowIso verbatim", () => {
+    const d = choose(cfg(), {}, "2099-12-31T23:59:59.000Z");
+    expect(d.evaluatedAt).toBe("2099-12-31T23:59:59.000Z");
+  });
+
+  test("default target preserves endpoint when set (string) and omits when null", () => {
+    const withEndpoint = choose(
+      cfg({
+        default: { provider: "openai-compatible", model: "m", endpoint: "https://ep/v1" },
+      }),
+      {},
+    );
+    expect(withEndpoint.chosen).toEqual({
+      provider: "openai-compatible",
+      model: "m",
+      endpoint: "https://ep/v1",
+    });
+  });
+});
+
+describe("chooseModel — first matching route wins", () => {
+  test("route with matching taskType wins over default", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m-checkout" },
+          },
+        ],
+      }),
+      { taskType: "checkout" },
+    );
+    expect(decision.reason).toBe("matched-route");
+    expect(decision.matchedRouteId).toBe("r1");
+    expect(decision.chosen.model).toBe("m-checkout");
+  });
+
+  test("first route wins when multiple match", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "first",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "first-model" },
+          },
+          {
+            id: "second",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "second-model" },
+          },
+        ],
+      }),
+      { taskType: "checkout" },
+    );
+    expect(decision.matchedRouteId).toBe("first");
+  });
+
+  test("default: true matches any context", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "catchall",
+            match: { "env.taskType": { default: true } },
+            target: { provider: "x", model: "y" },
+          },
+        ],
+      }),
+      {},
+    );
+    expect(decision.reason).toBe("matched-route");
+    expect(decision.matchedRouteId).toBe("catchall");
+  });
+
+  test("no-match reports reason=default (not fallback)", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.taskType": { equals: "other-task" } },
+            target: { provider: "o", model: "m" },
+          },
+        ],
+      }),
+      { taskType: "checkout" },
+    );
+    expect(decision.reason).toBe("default");
+  });
+});
+
+describe("chooseModel — contains operator", () => {
+  test("contains with a string needle matches substring", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "ck",
+            match: { "env.taskType": { contains: "check" } },
+            target: { provider: "o", model: "m" },
+          },
+        ],
+      }),
+      { taskType: "checkout-v2" },
+    );
+    expect(decision.matchedRouteId).toBe("ck");
+  });
+
+  test("contains with an array needle matches any element", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "multi",
+            match: { "env.taskType": { contains: ["login", "checkout"] } },
+            target: { provider: "o", model: "m" },
+          },
+        ],
+      }),
+      { taskType: "checkout" },
+    );
+    expect(decision.matchedRouteId).toBe("multi");
+  });
+});
+
+describe("chooseModel — guardrail demotions", () => {
+  test("budget exceeded → demotes matched route to fallback", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m" },
+            budget: { maxCostUsdPerCall: 0.01 },
+          },
+        ],
+        fallback: [{ provider: "anthropic", model: "claude-haiku-4-5" }],
+      }),
+      { taskType: "checkout", budgetRemainingUsd: 0.005 },
+    );
+    expect(decision.reason).toBe("fallback");
+    expect(decision.fallbackReason).toBe("budget-exceeded");
+    expect(decision.chosen.model).toBe("claude-haiku-4-5");
+  });
+
+  test("latency budget smaller than route max → demotes to fallback with latency-breached", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m" },
+            latency: { maxP95Ms: 800 },
+          },
+        ],
+        fallback: [{ provider: "anthropic", model: "claude-haiku-4-5" }],
+      }),
+      { taskType: "checkout", latencyBudgetMs: 500 },
+    );
+    expect(decision.reason).toBe("fallback");
+    expect(decision.fallbackReason).toBe("latency-breached");
+  });
+
+  test("confidence below minScore → route does not match (skip to next / default)", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "low-conf",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m" },
+            confidence: { minScore: 0.85 },
+          },
+        ],
+      }),
+      { taskType: "checkout", confidenceScore: 0.5 },
+    );
+    expect(decision.reason).toBe("default");
+  });
+
+  test("confidence above minScore → route matches normally", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "high-conf",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m" },
+            confidence: { minScore: 0.85 },
+          },
+        ],
+      }),
+      { taskType: "checkout", confidenceScore: 0.9 },
+    );
+    expect(decision.reason).toBe("matched-route");
+  });
+
+  test("no confidence context at all + confidence guardrail → skips route (conservative)", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m" },
+            confidence: { minScore: 0.85 },
+          },
+        ],
+      }),
+      { taskType: "checkout" },
+    );
+    expect(decision.reason).toBe("default");
+  });
+});
+
+describe("chooseModel — previousFailure short-circuit", () => {
+  test("previousFailure=provider-error while route matches → fallback", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m" },
+          },
+        ],
+        fallback: [{ provider: "anthropic", model: "claude-haiku-4-5" }],
+      }),
+      { taskType: "checkout", previousFailure: "provider-error" },
+    );
+    expect(decision.reason).toBe("fallback");
+    expect(decision.fallbackReason).toBe("provider-error");
+    expect(decision.chosen.model).toBe("claude-haiku-4-5");
+  });
+
+  test("previousFailure without a matched route → still returns default (nothing to fall back from)", () => {
+    const decision = choose(cfg({ fallback: [{ provider: "x", model: "y" }] }), {
+      previousFailure: "provider-error",
+    });
+    // No route matched, so there's nothing for previousFailure to demote from.
+    expect(decision.reason).toBe("default");
+  });
+});
+
+describe("chooseModel — rollout cohort hashing", () => {
+  test("percent:0 → route never matches, percent:100 → always matches", () => {
+    const d0 = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m" },
+            rollout: { percent: 0, cohortKey: "session.sessionIdHash" },
+          },
+        ],
+      }),
+      { taskType: "checkout", sessionIdHash: "abc-xyz" },
+    );
+    expect(d0.reason).toBe("default");
+
+    const d100 = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m" },
+            rollout: { percent: 100, cohortKey: "session.sessionIdHash" },
+          },
+        ],
+      }),
+      { taskType: "checkout", sessionIdHash: "abc-xyz" },
+    );
+    expect(d100.reason).toBe("matched-route");
+  });
+
+  test("missing cohort value → route does not match (conservative per spec §4)", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m" },
+            rollout: { percent: 100, cohortKey: "session.sessionIdHash" },
+          },
+        ],
+      }),
+      { taskType: "checkout" },
+    );
+    expect(decision.reason).toBe("default");
+  });
+
+  test("same cohort value lands in the same bucket across invocations", () => {
+    const config = cfg({
+      routes: [
+        {
+          id: "r1",
+          match: { "env.taskType": { equals: "checkout" } },
+          target: { provider: "o", model: "m" },
+          rollout: { percent: 50, cohortKey: "session.sessionIdHash" },
+        },
+      ],
+    });
+    const first = choose(config, { taskType: "checkout", sessionIdHash: "stable-hash" });
+    const second = choose(config, { taskType: "checkout", sessionIdHash: "stable-hash" });
+    expect(first.reason).toBe(second.reason);
+    expect(first.matchedRouteId).toBe(second.matchedRouteId);
+  });
+});
+
+describe("chooseModel — fallback chain order", () => {
+  test("first fallback with no `when` filter is used", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m" },
+            budget: { maxCostUsdPerCall: 0.01 },
+          },
+        ],
+        fallback: [
+          { provider: "a", model: "first" },
+          { provider: "a", model: "second" },
+        ],
+      }),
+      { taskType: "checkout", budgetRemainingUsd: 0 },
+    );
+    expect(decision.chosen.model).toBe("first");
+  });
+
+  test("fallback with `when` filter is skipped if reason not listed", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m" },
+            budget: { maxCostUsdPerCall: 0.01 },
+          },
+        ],
+        fallback: [
+          { provider: "a", model: "only-latency", when: ["latency-breached"] },
+          { provider: "a", model: "for-budget", when: ["budget-exceeded"] },
+        ],
+      }),
+      { taskType: "checkout", budgetRemainingUsd: 0 },
+    );
+    expect(decision.chosen.model).toBe("for-budget");
+    expect(decision.fallbackReason).toBe("budget-exceeded");
+  });
+
+  test("fallback list exhausted with no match → reason still fallback, chosen=default", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.taskType": { equals: "checkout" } },
+            target: { provider: "o", model: "m" },
+            budget: { maxCostUsdPerCall: 0.01 },
+          },
+        ],
+        fallback: [{ provider: "a", model: "not-this", when: ["latency-breached"] }],
+      }),
+      { taskType: "checkout", budgetRemainingUsd: 0 },
+    );
+    // No fallback with matching `when`; router falls all the way back to
+    // default, but the reason+fallbackReason still record the budget demotion.
+    expect(decision.reason).toBe("fallback");
+    expect(decision.fallbackReason).toBe("budget-exceeded");
+    expect(decision.chosen).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      endpoint: undefined,
+    });
+  });
+});
+
+describe("chooseModel — context lookup (dotted paths)", () => {
+  test("supports env.* and session.* paths", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: {
+              "env.taskType": { equals: "checkout" },
+              "session.sessionIdHash": { equals: "abc" },
+            },
+            target: { provider: "o", model: "m-combined" },
+          },
+        ],
+      }),
+      { taskType: "checkout", sessionIdHash: "abc" },
+    );
+    expect(decision.matchedRouteId).toBe("r1");
+  });
+
+  test("unknown dotted path → operator non-match → route skipped", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "r1",
+            match: { "env.not-a-real-field": { equals: "x" } },
+            target: { provider: "o", model: "m" },
+          },
+        ],
+      }),
+      { taskType: "checkout" },
+    );
+    expect(decision.reason).toBe("default");
+  });
+});

--- a/ts/tests/control-plane/runtime/model-router.test.ts
+++ b/ts/tests/control-plane/runtime/model-router.test.ts
@@ -143,6 +143,40 @@ describe("chooseModel — first matching route wins", () => {
     );
     expect(decision.reason).toBe("default");
   });
+
+  test("empty match expression is non-matching if unchecked config reaches runtime", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "bad-catchall",
+            match: {},
+            target: { provider: "o", model: "bad" },
+          },
+        ],
+      }),
+      { taskType: "checkout" },
+    );
+    expect(decision.reason).toBe("default");
+  });
+
+  test("multi-operator matcher is non-matching if unchecked config reaches runtime", () => {
+    const decision = choose(
+      cfg({
+        routes: [
+          {
+            id: "bad-multi-op",
+            match: {
+              "env.taskType": { default: true, equals: "checkout" },
+            },
+            target: { provider: "o", model: "bad" },
+          },
+        ],
+      }),
+      { taskType: "checkout" },
+    );
+    expect(decision.reason).toBe("default");
+  });
 });
 
 describe("chooseModel — contains operator", () => {

--- a/ts/tests/control-plane/runtime/trace-integration.test.ts
+++ b/ts/tests/control-plane/runtime/trace-integration.test.ts
@@ -1,0 +1,242 @@
+// Integration test: build a ProductionTrace with the new `routing` field set
+// from a ModelDecision. Validate via AJV and (when uv is available) via the
+// Python Pydantic validator — cross-runtime parity check for the additive
+// routing field (spec §4, AC-545).
+
+import { describe, test, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { chooseModel } from "../../../src/control-plane/runtime/model-router.js";
+import { createProductionTrace } from "../../../src/production-traces/contract/factories.js";
+import { validateProductionTrace } from "../../../src/production-traces/contract/validators.js";
+import type {
+  AppId,
+  EnvironmentTag,
+} from "../../../src/production-traces/contract/branded-ids.js";
+import type {
+  ModelRoutingDecisionReason,
+  ModelRoutingFallbackReason,
+  ProductionTraceRouting,
+} from "../../../src/production-traces/contract/types.js";
+import type { ModelRoutingPayload } from "../../../src/control-plane/actuators/model-routing/schema.js";
+
+const NOW = "2026-04-17T12:00:00.000Z";
+const TS_ROOT = resolve(__dirname, "..", "..", "..");
+const WORKTREE_ROOT = resolve(TS_ROOT, "..");
+const PY_CWD = resolve(WORKTREE_ROOT, "autocontext");
+
+type PythonResult = { valid: boolean; error?: string };
+
+function runPythonValidate(input: unknown): PythonResult {
+  const script = [
+    "import json, sys",
+    "from pydantic import ValidationError",
+    "from autocontext.production_traces import validate_production_trace",
+    "data = json.loads(sys.stdin.read())",
+    "try:",
+    "    trace = validate_production_trace(data)",
+    "    out = {'valid': True}",
+    "    print(json.dumps(out))",
+    "except ValidationError as e:",
+    "    print(json.dumps({'valid': False, 'error': str(e)}))",
+  ].join("\n");
+  const result = spawnSync("uv", ["run", "python", "-c", script], {
+    cwd: PY_CWD,
+    input: JSON.stringify(input),
+    encoding: "utf-8",
+    env: process.env,
+  });
+  if (result.status !== 0 && !result.stdout) {
+    throw new Error(`python validate exited ${result.status}: ${result.stderr}`);
+  }
+  const line = result.stdout.trim().split("\n").pop() ?? "{}";
+  return JSON.parse(line) as PythonResult;
+}
+
+function hasUv(): boolean {
+  const r = spawnSync("uv", ["--version"], { encoding: "utf-8" });
+  return r.status === 0;
+}
+
+const UV_AVAILABLE = hasUv();
+
+const ROUTING_CONFIG: ModelRoutingPayload = {
+  schemaVersion: "1.0",
+  default: { provider: "anthropic", model: "claude-sonnet-4-5", endpoint: null },
+  routes: [
+    {
+      id: "checkout-specialized",
+      match: { "env.taskType": { equals: "checkout" } },
+      target: {
+        provider: "openai-compatible",
+        model: "finetuned-checkout-v3",
+        endpoint: "https://my-vllm/v1",
+      },
+    },
+  ],
+  fallback: [{ provider: "anthropic", model: "claude-haiku-4-5" }],
+};
+
+function decisionToRoutingField(decision: {
+  chosen: { provider: string; model: string; endpoint?: string };
+  reason: ModelRoutingDecisionReason;
+  matchedRouteId?: string;
+  fallbackReason?: ModelRoutingFallbackReason;
+  evaluatedAt: string;
+}): ProductionTraceRouting {
+  return {
+    chosen: decision.chosen,
+    reason: decision.reason,
+    ...(decision.matchedRouteId !== undefined
+      ? { matchedRouteId: decision.matchedRouteId }
+      : {}),
+    ...(decision.fallbackReason !== undefined
+      ? { fallbackReason: decision.fallbackReason }
+      : {}),
+    evaluatedAt: decision.evaluatedAt,
+  };
+}
+
+function baseTrace(routing?: ProductionTraceRouting) {
+  return createProductionTrace({
+    source: { emitter: "sdk", sdk: { name: "ts", version: "0.4.3" } },
+    provider: { name: "anthropic" },
+    model: "claude-sonnet-4-5",
+    env: {
+      environmentTag: "production" as EnvironmentTag,
+      appId: "my-app" as AppId,
+    },
+    messages: [{ role: "user", content: "x", timestamp: NOW }],
+    timing: {
+      startedAt: NOW,
+      endedAt: "2026-04-17T12:00:01.000Z",
+      latencyMs: 1000,
+    },
+    usage: { tokensIn: 10, tokensOut: 5 },
+    ...(routing !== undefined ? { routing } : {}),
+  });
+}
+
+describe("ProductionTrace with routing field — TS AJV validation", () => {
+  test("trace without routing field validates (additive-optional, backward compatible)", () => {
+    const trace = baseTrace();
+    expect(validateProductionTrace(trace).valid).toBe(true);
+    expect(trace.routing).toBeUndefined();
+  });
+
+  test("trace with default-path routing decision validates", () => {
+    const decision = chooseModel({ config: ROUTING_CONFIG, context: {} }, NOW);
+    const trace = baseTrace(decisionToRoutingField(decision));
+    expect(validateProductionTrace(trace).valid).toBe(true);
+    expect(trace.routing?.reason).toBe("default");
+    expect(trace.routing?.chosen.model).toBe("claude-sonnet-4-5");
+    expect(trace.routing?.evaluatedAt).toBe(NOW);
+  });
+
+  test("trace with matched-route routing decision validates", () => {
+    const decision = chooseModel(
+      { config: ROUTING_CONFIG, context: { taskType: "checkout" } },
+      NOW,
+    );
+    const trace = baseTrace(decisionToRoutingField(decision));
+    expect(validateProductionTrace(trace).valid).toBe(true);
+    expect(trace.routing?.reason).toBe("matched-route");
+    expect(trace.routing?.matchedRouteId).toBe("checkout-specialized");
+    expect(trace.routing?.chosen.endpoint).toBe("https://my-vllm/v1");
+  });
+
+  test("AJV rejects routing field with unknown reason", () => {
+    const trace = baseTrace({
+      chosen: { provider: "x", model: "y" },
+      reason: "bogus-reason" as ModelRoutingDecisionReason,
+      evaluatedAt: NOW,
+    });
+    expect(validateProductionTrace(trace).valid).toBe(false);
+  });
+
+  test("AJV rejects routing.chosen missing required provider", () => {
+    const trace = {
+      ...baseTrace(),
+      routing: {
+        chosen: { model: "y" },
+        reason: "default" as const,
+        evaluatedAt: NOW,
+      },
+    };
+    expect(validateProductionTrace(trace).valid).toBe(false);
+  });
+
+  test("AJV rejects additional properties on routing (strict)", () => {
+    const trace = {
+      ...baseTrace(),
+      routing: {
+        chosen: { provider: "x", model: "y" },
+        reason: "default" as const,
+        evaluatedAt: NOW,
+        extra: "nope",
+      },
+    };
+    expect(validateProductionTrace(trace).valid).toBe(false);
+  });
+});
+
+const maybeDescribe = UV_AVAILABLE ? describe : describe.skip;
+
+maybeDescribe("ProductionTrace with routing field — cross-runtime (TS AJV vs Python Pydantic)", () => {
+  test("matched-route decision: accepted by both runtimes", () => {
+    const decision = chooseModel(
+      { config: ROUTING_CONFIG, context: { taskType: "checkout" } },
+      NOW,
+    );
+    const trace = baseTrace(decisionToRoutingField(decision));
+    const ts = validateProductionTrace(trace).valid;
+    const py = runPythonValidate(trace).valid;
+    expect(ts).toBe(true);
+    expect(py).toBe(true);
+  }, 30_000);
+
+  test("fallback decision with fallbackReason: accepted by both runtimes", () => {
+    const fallbackConfig: ModelRoutingPayload = {
+      ...ROUTING_CONFIG,
+      routes: [
+        {
+          id: "budget-bound",
+          match: { "env.taskType": { equals: "checkout" } },
+          target: { provider: "openai-compatible", model: "expensive" },
+          budget: { maxCostUsdPerCall: 0.02 },
+        },
+      ],
+    };
+    const decision = chooseModel(
+      {
+        config: fallbackConfig,
+        context: { taskType: "checkout", budgetRemainingUsd: 0.001 },
+      },
+      NOW,
+    );
+    expect(decision.reason).toBe("fallback");
+    expect(decision.fallbackReason).toBe("budget-exceeded");
+    const trace = baseTrace(decisionToRoutingField(decision));
+    expect(validateProductionTrace(trace).valid).toBe(true);
+    expect(runPythonValidate(trace).valid).toBe(true);
+  }, 30_000);
+
+  test("trace without routing field (backward compat) accepted by both runtimes", () => {
+    const trace = baseTrace();
+    expect(validateProductionTrace(trace).valid).toBe(true);
+    expect(runPythonValidate(trace).valid).toBe(true);
+  }, 30_000);
+
+  test("invalid routing.reason rejected by both runtimes", () => {
+    const trace = {
+      ...baseTrace(),
+      routing: {
+        chosen: { provider: "x", model: "y" },
+        reason: "not-a-reason",
+        evaluatedAt: NOW,
+      },
+    };
+    expect(validateProductionTrace(trace).valid).toBe(false);
+    expect(runPythonValidate(trace).valid).toBe(false);
+  }, 30_000);
+});

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -14,6 +14,7 @@ describe("package root exports", () => {
     expect(pkg.ModelStrategySelector).toBeDefined();
     expect(pkg.createMcpServer).toBeDefined();
     expect(pkg.MissionManager).toBeDefined();
+    expect(pkg.chooseModel).toBeDefined();
   });
 
   it("avoids package catalog barrel hops in ts/src/index.ts", () => {
@@ -23,5 +24,16 @@ describe("package root exports", () => {
     expect(indexSource).not.toContain('export * from "./package-execution-catalog.js";');
     expect(indexSource).not.toContain('export * from "./package-trace-training-catalog.js";');
     expect(indexSource).not.toContain('export * from "./package-platform-catalog.js";');
+  });
+
+  it("publishes the control-plane runtime subpath for chooseModel", () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(import.meta.dirname, "..", "package.json"), "utf-8"),
+    ) as { exports?: Record<string, { import?: string; types?: string }> };
+
+    expect(packageJson.exports?.["./control-plane/runtime"]).toEqual({
+      import: "./dist/control-plane/runtime/index.js",
+      types: "./dist/control-plane/runtime/index.d.ts",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds the 5th actuator type (`model-routing`) to Foundation B's registry, plus a pure-function TS runtime helper (`chooseModel`) that applications consult at inference time to pick between base models, fine-tuned models, local models, and fallback providers. Also extends Foundation A's `ProductionTrace` schema with an optional `routing` field so routing decisions can be recorded on the production calls they governed. Closes **AC-545**.

Design doc at `docs/superpowers/specs/2026-04-19-ac-545-model-routing-design.md` (gitignored per `docs/superpowers/` convention).

## ⚠️ PR dependency chain

**Base branch is `ac-539-foundation-a`** (Foundation A PR #727) — which is itself stacked on `ac-543-foundation-b` (Foundation B PR #720). AC-545 depends on **both** because:

1. The actuator type lands in Foundation B's registry (Layers 5+6 pattern) — needs #720
2. The ProductionTrace `routing` field lands in Foundation A's schema — needs #727

**Merge order:** #720 → main, then #727 rebased onto main → merged, then this PR rebased onto main → merged. Reviewers can review independently today; the dependency is about merge order, not review order.

## What this ships

### New actuator: `model-routing`

5th actuator type in Foundation B's registry, distinct from the existing `routing-rule`:
- `routing-rule` — tool/endpoint dispatch ("which tool to call")
- `model-routing` — model selection ("which LLM to route this call to")

Declarative config matches the issue's listed dimensions (task-cluster, tenant, rollout%, budget, latency target, confidence):

```json
{
  "schemaVersion": "1.0",
  "default": { "provider": "anthropic", "model": "claude-sonnet-4-5" },
  "routes": [{
    "id": "checkout-specialized",
    "match": { "env.taskType": { "equals": "checkout" } },
    "target": { "provider": "openai-compatible", "model": "ft-checkout-v3",
                "endpoint": "https://my-vllm/v1" },
    "rollout": { "percent": 25, "cohortKey": "session.sessionIdHash" },
    "budget": { "maxCostUsdPerCall": 0.02 },
    "latency": { "maxP95Ms": 800 },
    "confidence": { "minScore": 0.85 }
  }],
  "fallback": [{
    "provider": "anthropic", "model": "claude-haiku-4-5",
    "when": ["budget-exceeded", "latency-breached", "provider-error"]
  }]
}
```

Wraps Foundation B's `_shared/single-file-applicator` + `_shared/content-revert-rollback` (DRY). Target pattern `**/routing/models/*.json`. Rollback strategy `content-revert` (config-only artifact).

### Runtime library: `chooseModel`

```ts
import { chooseModel } from "autocontext/control-plane/runtime";

const decision = chooseModel({
  config: loadedRoutingConfig,
  context: { taskType, sessionIdHash, budgetRemainingUsd, latencyBudgetMs, previousFailure },
}, new Date().toISOString());
// decision.chosen = { provider, model, endpoint? }
// decision.reason = "default" | "matched-route" | "fallback"
```

**Pure function**, no I/O, no hidden clock — `evaluatedAt` is injected as `nowIso` for determinism. Rollout cohort assignment is stable: `bucket = sha256(cohortValue).readUInt32BE(0) % 100` — same cohort always lands in the same bucket across retries.

### Trace integration

Optional `routing` field on `ProductionTrace`:
```ts
type ProductionTraceRouting = {
  chosen: { provider: string; model: string; endpoint?: string };
  matchedRouteId?: string;
  reason: "default" | "matched-route" | "fallback";
  fallbackReason?: "budget-exceeded" | "latency-breached" | "provider-error" | "no-match";
  evaluatedAt: string;
};
```

Additive-optional: existing fixtures and Python Pydantic callers remain valid. No MINOR schema bump required; cross-runtime compat test P5 verifies equivalence with the new field included.

## Design decisions

- **5th actuator type, not an extension of `routing-rule`.** Different domain (model selection vs. tool dispatch); different schema; different runtime integration story. Coexist in the registry via the established `ActuatorType` enum extension pattern.
- **Flat route list with first-match-wins + explicit fallback chain**, over a tiered policy hierarchy. Matches the vocabulary of the existing `routing-rule` actuator and is easier to hand-author. Tiered hierarchy is a future option if complex-policy customers demand it.
- **Pure-function runtime helper, stateless.** Percentage rollout via hash-bucket (deterministic per cohort); no budget counters or tracked state. Stateful gateway is hosted-product territory.
- **`routing` field on `ProductionTrace`**, not a separate `RoutingDecisionTrace` document. Keeps emission pipeline unchanged; routing decision is data about the call, not a separate event.
- **`control-plane/runtime/` sub-context** for customer-facing runtime helpers. First resident: `chooseModel`. Second helper will prompt a top-level promotion if / when it lands.
- **Python runtime helper deferred** per scoping discussion (option b). Config file is language-agnostic; Python customers integrate by writing a thin wrapper against the same JSON config. Port when demand surfaces.

## Testing

- **~55 new TS tests** across actuator registration, applicator behavior, `chooseModel` unit tests, property tests P-det and P-cohort (100 runs each), cross-runtime trace-integration
- **P-det**: determinism — same inputs + same `nowIso` → same decision ✓
- **P-cohort**: cohort stability — hashed bucket assignment consistent across invocations ✓
- **Cross-runtime parity**: new `routing` field round-trips through AJV ↔ Pydantic via Foundation A's generator pipeline (Layer 4.5 mechanics unchanged — regenerated `models.py` accepts the additive field)
- **Full TS suite**: 3638 passing (+54 from 3584 baseline). 1 known `campaign-cli` flake (pre-existing, unrelated, passes in isolation)
- **Full Python suite**: 5430 passing, 54 skipped — baseline exact (routing field optional on Pydantic side, so existing fixtures remain valid)
- **Typecheck** (TS) and **mypy** (Python) both clean
- **Schema drift guard** `npm run check:schemas` exits 0

## Type-assertion budget

**No bump.** Zero new casts introduced. The actuator wrapping + schema-driven types kept the module cast-free.

## Deferred

- **Python runtime helper for `chooseModel`** — port when customer demand surfaces; config file is already language-agnostic.
- **Tiered policy hierarchy** — v1 is flat + explicit fallback chain; tiered is a future extension.
- **Gateway binary / proxy server** — hosted product territory.
- **Multi-region / multi-cluster routing semantics** — v1.5+.

## Test plan

- [ ] CI on this branch passes (expected 3638/3640 with known campaign-cli flakes)
- [ ] Review the 5th actuator type registration: `actuators/model-routing/{schema,applicator,index}.ts`
- [ ] Review the `chooseModel` decision algorithm + rollout cohort hashing: `runtime/model-router.ts`
- [ ] Review the ProductionTrace schema extension + regenerated Pydantic `models.py`
- [ ] Security review: AJV strict mode + `additionalProperties: false` on the new schema
- [ ] Verify no accidentally-tracked files under `ts/knowledge/` or `ts/runs/`