### PR TITLE
fix: stabilize solve agent-task design timeouts

### DIFF
--- a/autocontext/src/autocontext/knowledge/solve_design.py
+++ b/autocontext/src/autocontext/knowledge/solve_design.py
@@ -1,0 +1,123 @@
+"""Helpers for solve-on-demand scenario design prompts."""
+
+from __future__ import annotations
+
+import re
+
+from autocontext.config.settings import AppSettings
+
+_SOLVE_DESCRIPTION_SKIP_SECTIONS = frozenset(
+    {
+        "Why This Matters",
+        "What This Tests",
+        "Implementation Guidance",
+        "Acceptance",
+        "Why existing scenarios don't cover this",
+        "Dependencies",
+    }
+)
+_SOLVE_DESCRIPTION_SKIP_LINE_PREFIXES = (
+    "**Priority:**",
+    "**Generations to signal:**",
+)
+_SOLVE_INLINE_EXAMPLE_PAREN_RE = re.compile(
+    r"\(\s*(?:e\.g\.,?|eg,?|for example,?)[^)]*\)",
+    re.IGNORECASE,
+)
+_SOLVE_AGENT_TASK_DESIGN_KEEP_SECTIONS = frozenset(
+    {
+        "Objective",
+        "Description",
+        "Scenario Design",
+        "Evaluation Dimensions",
+        "Success Criteria",
+    }
+)
+_SOLVE_AGENT_TASK_DESIGN_MAX_CHARS = 1000
+_SOLVE_AGENT_TASK_DESIGN_MAX_SECTION_LINES = 5
+_SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS = 600.0
+
+
+def _build_solve_description_brief(description: str) -> str:
+    lines: list[str] = []
+    skipping_section = False
+    for raw_line in description.splitlines():
+        heading_match = re.match(r"^\s*#{2,6}\s+(.+?)\s*$", raw_line)
+        if heading_match is not None:
+            title = heading_match.group(1).strip()
+            skipping_section = title in _SOLVE_DESCRIPTION_SKIP_SECTIONS
+            if not skipping_section:
+                lines.append(raw_line)
+            continue
+
+        stripped = raw_line.strip()
+        if stripped.startswith(_SOLVE_DESCRIPTION_SKIP_LINE_PREFIXES):
+            continue
+        if not skipping_section:
+            lines.append(raw_line)
+
+    brief = "\n".join(lines).strip()
+    brief = _SOLVE_INLINE_EXAMPLE_PAREN_RE.sub("", brief)
+    brief = re.sub(r"\n{3,}", "\n\n", brief)
+    brief = re.sub(r"[ \t]{2,}", " ", brief)
+    return brief or description.strip()
+
+
+def _build_solve_agent_task_design_brief(description: str) -> str:
+    brief = _build_solve_description_brief(description)
+    if len(brief) <= _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS:
+        return brief
+
+    lines: list[str] = []
+    current_section: str | None = None
+    current_section_lines = 0
+    title_captured = False
+
+    for raw_line in brief.splitlines():
+        heading_match = re.match(r"^\s*#{2,6}\s+(.+?)\s*$", raw_line)
+        if heading_match is not None:
+            title = heading_match.group(1).strip()
+            if title in _SOLVE_AGENT_TASK_DESIGN_KEEP_SECTIONS:
+                current_section = title
+                current_section_lines = 0
+                if lines and lines[-1] != "":
+                    lines.append("")
+                lines.append(raw_line)
+                lines.append("")
+            else:
+                current_section = None
+            continue
+
+        stripped = raw_line.strip()
+        if not title_captured and stripped:
+            lines.append(raw_line)
+            title_captured = True
+            continue
+        if current_section is None:
+            continue
+        if not stripped:
+            if lines and lines[-1] != "":
+                lines.append("")
+            continue
+        if stripped.startswith("```"):
+            continue
+        if current_section_lines >= _SOLVE_AGENT_TASK_DESIGN_MAX_SECTION_LINES:
+            continue
+        lines.append(raw_line)
+        current_section_lines += 1
+
+    compact = "\n".join(lines).strip()
+    compact = re.sub(r"\n{3,}", "\n\n", compact)
+    while len(compact) > _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS and "\n\n" in compact:
+        compact = compact.rsplit("\n\n", 1)[0].strip()
+    if len(compact) > _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS:
+        compact = compact[:_SOLVE_AGENT_TASK_DESIGN_MAX_CHARS].rsplit("\n", 1)[0].strip()
+    return compact or brief[:_SOLVE_AGENT_TASK_DESIGN_MAX_CHARS].strip()
+
+
+def _settings_for_solve_creator(settings: AppSettings) -> AppSettings:
+    if settings.agent_provider not in {"pi", "pi-rpc"}:
+        return settings
+    if float(settings.pi_timeout) >= _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS:
+        return settings
+    return settings.model_copy(update={"pi_timeout": _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS})

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -21,10 +21,19 @@ from autocontext.execution.task_runtime_budget import (
     resolve_task_like_completion_max_tokens,
 )
 from autocontext.knowledge.export import SkillPackage, export_skill_package
+from autocontext.knowledge.solve_design import (
+    _build_solve_agent_task_design_brief,
+    _build_solve_description_brief,
+    _settings_for_solve_creator,
+)
 from autocontext.mcp.tools import MtsToolContext
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
 from autocontext.scenarios.artifact_editing import Artifact, ArtifactEditingInterface
+from autocontext.scenarios.custom.agent_task_designer import (
+    RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+    SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+)
 from autocontext.storage import artifact_store_from_settings
 from autocontext.storage.sqlite_store import SQLiteStore
 
@@ -39,20 +48,6 @@ class _NamedScenario(Protocol):
 
 
 _FAMILY_HEADER_RE = re.compile(r"^\s*\*{0,2}family\*{0,2}:\s*(?P<body>.+?)\s*$", re.IGNORECASE | re.MULTILINE)
-_SOLVE_DESCRIPTION_SKIP_SECTIONS = frozenset(
-    {
-        "Why This Matters",
-        "What This Tests",
-        "Implementation Guidance",
-        "Acceptance",
-        "Why existing scenarios don't cover this",
-        "Dependencies",
-    }
-)
-_SOLVE_DESCRIPTION_SKIP_LINE_PREFIXES = (
-    "**Priority:**",
-    "**Generations to signal:**",
-)
 _SOLVE_FAMILY_ALIASES = {
     "meta_learning": "agent_task",
     "capability_bootstrapping": "agent_task",
@@ -62,12 +57,6 @@ _SIMULATION_INTERFACE_HINT_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 _AGENT_TASK_INTERFACE_HINT_RE = re.compile(r"\bagent[- ]task evaluation\b", re.IGNORECASE)
-_SOLVE_INLINE_EXAMPLE_PAREN_RE = re.compile(
-    r"\(\s*(?:e\.g\.,?|eg,?|for example,?)[^)]*\)",
-    re.IGNORECASE,
-)
-
-
 @dataclass
 class SolveJob:
     job_id: str
@@ -296,31 +285,6 @@ class _BudgetedAgentTask(AgentTaskInterface):
         result = self._task.verify_facts(output, state)
         self._budget.check("fact verification")
         return result
-
-
-def _build_solve_description_brief(description: str) -> str:
-    lines: list[str] = []
-    skipping_section = False
-    for raw_line in description.splitlines():
-        heading_match = re.match(r"^\s*#{2,6}\s+(.+?)\s*$", raw_line)
-        if heading_match is not None:
-            title = heading_match.group(1).strip()
-            skipping_section = title in _SOLVE_DESCRIPTION_SKIP_SECTIONS
-            if not skipping_section:
-                lines.append(raw_line)
-            continue
-
-        stripped = raw_line.strip()
-        if stripped.startswith(_SOLVE_DESCRIPTION_SKIP_LINE_PREFIXES):
-            continue
-        if not skipping_section:
-            lines.append(raw_line)
-
-    brief = "\n".join(lines).strip()
-    brief = _SOLVE_INLINE_EXAMPLE_PAREN_RE.sub("", brief)
-    brief = re.sub(r"\n{3,}", "\n\n", brief)
-    brief = re.sub(r"[ \t]{2,}", " ", brief)
-    return brief or description.strip()
 
 
 def _is_timeout_like_error(exc: Exception) -> bool:
@@ -623,6 +587,9 @@ class SolveScenarioBuilder:
         family_creator = AgentTaskCreator(
             llm_fn=self._llm_fn,
             knowledge_root=self._knowledge_root,
+            designer_system_prompt=SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+            retry_designer_system_prompt=RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+            description_transform=_build_solve_agent_task_design_brief,
         )
         scenario = family_creator.create(brief, family_name=family.name)
         scenario_name = str(cast(_NamedScenario, scenario).name)
@@ -638,8 +605,8 @@ def _llm_fn_from_client(client: Any, model: str) -> LlmFn:
         response = client.generate(
             model=model,
             prompt=f"{system}\n\n{user}",
-            max_tokens=1800,
-            temperature=0.3,
+            max_tokens=1200,
+            temperature=0.2,
             role="scenario_designer",
         )
         response_text: object = getattr(response, "text", "")
@@ -723,7 +690,8 @@ class SolveManager:
             from autocontext.agents.llm_client import build_client_from_settings
             from autocontext.agents.subagent_runtime import SubagentRuntime
 
-            client = build_client_from_settings(self._settings)
+            creator_settings = _settings_for_solve_creator(self._settings)
+            client = build_client_from_settings(creator_settings)
             runtime = SubagentRuntime(client)
             designer_model = self._settings.model_translator or self._settings.model_architect
             llm_fn = _llm_fn_from_client(client, designer_model)

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import logging
 import sys
+from collections.abc import Callable
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -13,7 +14,10 @@ from autocontext.scenarios.artifact_editing import ArtifactEditingInterface
 from autocontext.scenarios.base import ScenarioInterface
 from autocontext.scenarios.coordination import CoordinationInterface
 from autocontext.scenarios.custom.agent_task_codegen import generate_agent_task_class
-from autocontext.scenarios.custom.agent_task_designer import design_agent_task
+from autocontext.scenarios.custom.agent_task_designer import (
+    AGENT_TASK_DESIGNER_SYSTEM,
+    design_agent_task,
+)
 from autocontext.scenarios.custom.agent_task_revision import (
     patch_legacy_generated_evaluate_output,
     patch_legacy_generated_revise_output,
@@ -46,6 +50,10 @@ from autocontext.util.json_io import write_json
 logger = logging.getLogger(__name__)
 
 
+def _is_timeout_like_error(exc: Exception) -> bool:
+    return "timeout" in str(exc).lower()
+
+
 class AgentTaskCreator:
     """Orchestrates the full agent task creation pipeline."""
 
@@ -53,9 +61,16 @@ class AgentTaskCreator:
         self,
         llm_fn: LlmFn,
         knowledge_root: Path,
+        *,
+        designer_system_prompt: str = AGENT_TASK_DESIGNER_SYSTEM,
+        retry_designer_system_prompt: str | None = None,
+        description_transform: Callable[[str], str] | None = None,
     ) -> None:
         self.llm_fn = llm_fn
         self.knowledge_root = knowledge_root
+        self._designer_system_prompt = designer_system_prompt
+        self._retry_designer_system_prompt = retry_designer_system_prompt
+        self._description_transform = description_transform
 
     STOP_WORDS = SHARED_STOP_WORDS
 
@@ -99,11 +114,25 @@ class AgentTaskCreator:
 
         # 1. Design
         logger.info("designing agent task from description")
+        design_description = self._description_transform(description) if self._description_transform is not None else description
         try:
-            spec = design_agent_task(description, self.llm_fn)
-        except Exception:
+            spec = design_agent_task(
+                design_description,
+                self.llm_fn,
+                system_prompt=self._designer_system_prompt,
+            )
+        except Exception as exc:
+            retry_system_prompt = (
+                self._retry_designer_system_prompt
+                if _is_timeout_like_error(exc) and self._retry_designer_system_prompt is not None
+                else self._designer_system_prompt
+            )
             logger.warning("agent task design failed on first attempt; retrying once", exc_info=True)
-            spec = design_agent_task(description, self.llm_fn)
+            spec = design_agent_task(
+                design_description,
+                self.llm_fn,
+                system_prompt=retry_system_prompt,
+            )
 
         # 1.5 Auto-heal: generate synthetic sample_input if needed (AC-309)
         from autocontext.scenarios.custom.spec_auto_heal import (

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
@@ -82,6 +82,48 @@ AGENT_TASK_DESIGNER_SYSTEM = (
     "Produce the smallest complete AgentTaskSpec that faithfully captures the user description.\n"
 )
 
+SOLVE_AGENT_TASK_DESIGNER_SYSTEM = (
+    "You design the smallest viable AgentTaskSpec JSON for autocontext solve-on-demand. "
+    "Return only one JSON object wrapped in the required delimiters.\n\n"
+    f"{SPEC_START}\n{{ ... }}\n{SPEC_END}\n\n"
+    "Required fields:\n"
+    '- "task_prompt": self-contained prompt for the evaluated agent\n'
+    '- "judge_rubric": concise scoring dimensions and criteria\n'
+    '- "output_format": one of free_text, json_schema, or code\n'
+    '- "calibration_examples": MUST include at least 2 calibration examples '
+    "with human_score, human_notes, and agent_output fields\n\n"
+    "Optional fields are allowed only when they materially change execution or evaluation: "
+    "judge_model, difficulty_tiers, reference_context, reference_sources, required_concepts, "
+    "sample_input, context_preparation, required_context_keys, max_rounds, quality_threshold, "
+    "revision_prompt. Omit unnecessary fields instead of filling them with prose.\n\n"
+    "Solve-specific rules:\n"
+    "- Keep the spec lean and execution-ready.\n"
+    "- Prefer a single structured output contract over long nested examples.\n"
+    "- Keep task_prompt under 550 characters whenever possible.\n"
+    "- Keep judge_rubric under 900 characters whenever possible.\n"
+    "- Keep sample_input under 800 characters whenever possible.\n"
+    "- Prefer compact sample_input that summarizes telemetry or state instead of "
+    "repeating long arrays or verbose examples when possible.\n"
+    "- Keep required_concepts short and focused; omit them if the prompt and rubric already carry the needed intent.\n"
+    "- Use context_preparation and required_context_keys only when absolutely necessary.\n"
+    "- Do not invent impossible external loaders or unsatisfied state keys.\n"
+    "- For structured tasks, prefer json_schema.\n"
+    "- If iterative refinement is useful, set max_rounds > 1 and provide a compact revision_prompt.\n\n"
+    "Produce the smallest complete AgentTaskSpec that faithfully captures the user description.\n"
+)
+
+RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM = (
+    "Design the smallest viable AgentTaskSpec JSON for autocontext solve-on-demand. "
+    "Return only one JSON object wrapped in the required delimiters.\n\n"
+    f"{SPEC_START}\n{{ ... }}\n{SPEC_END}\n\n"
+    "Required fields: task_prompt, judge_rubric, output_format, and calibration_examples with "
+    "at least 2 examples containing human_score, human_notes, and agent_output. "
+    "Keep task_prompt under 550 characters, judge_rubric under 900 characters, and "
+    "sample_input under 800 characters whenever possible. Prefer compact sample_input that summarizes telemetry "
+    "or state instead of repeating long arrays. Prefer 3-5 short evidence items and 1-3 short actions. "
+    "Omit optional fields unless they are essential for execution or evaluation. Prefer json_schema for structured tasks.\n"
+)
+
 
 def parse_agent_task_spec(text: str) -> AgentTaskSpec:
     """Parse an AgentTaskSpec from LLM response text."""
@@ -112,16 +154,22 @@ def parse_agent_task_spec(text: str) -> AgentTaskSpec:
     )
 
 
-def design_agent_task(description: str, llm_fn: LlmFn) -> AgentTaskSpec:
+def design_agent_task(
+    description: str,
+    llm_fn: LlmFn,
+    *,
+    system_prompt: str = AGENT_TASK_DESIGNER_SYSTEM,
+) -> AgentTaskSpec:
     """Design an agent task spec from a natural language description.
 
     Args:
         description: Natural language description of the task.
         llm_fn: Callable(system_prompt, user_prompt) -> response text.
+        system_prompt: Designer instructions used for the LLM call.
 
     Returns:
         Parsed AgentTaskSpec.
     """
     user_prompt = f"User description:\n{description}"
-    response = llm_fn(AGENT_TASK_DESIGNER_SYSTEM, user_prompt)
+    response = llm_fn(system_prompt, user_prompt)
     return parse_agent_task_spec(response)

--- a/autocontext/tests/test_agent_task_pipeline.py
+++ b/autocontext/tests/test_agent_task_pipeline.py
@@ -335,6 +335,25 @@ class TestDesignAgentTask:
         assert spec.task_prompt == SAMPLE_SPEC.task_prompt
         assert spec.output_format == "free_text"
 
+    def test_design_agent_task_uses_overridden_system_prompt(self) -> None:
+        response_text = _mock_llm_response(SAMPLE_SPEC)
+        captured: dict[str, str] = {}
+
+        def mock_llm(system: str, user: str) -> str:
+            captured["system"] = system
+            captured["user"] = user
+            return response_text
+
+        spec = design_agent_task(
+            "Write a haiku about testing",
+            mock_llm,
+            system_prompt="custom solve designer prompt",
+        )
+
+        assert spec.task_prompt == SAMPLE_SPEC.task_prompt
+        assert captured["system"] == "custom solve designer prompt"
+        assert captured["user"].startswith("User description:\nWrite a haiku")
+
 
 class TestGenerateAgentTaskClass:
     def test_produces_valid_python(self) -> None:
@@ -713,6 +732,35 @@ class TestAgentTaskCreator:
             try:
                 assert instance.get_rubric() == SAMPLE_SPEC.judge_rubric
                 assert attempts["count"] == 2
+            finally:
+                SCENARIO_REGISTRY.pop(registered_name, None)
+
+    def test_retries_agent_task_design_with_retry_system_prompt_after_timeout(self) -> None:
+        response_text = _mock_llm_response(SAMPLE_SPEC)
+        seen_system_prompts: list[str] = []
+
+        def mock_llm(system: str, user: str) -> str:
+            del user
+            seen_system_prompts.append(system)
+            if len(seen_system_prompts) == 1:
+                raise RuntimeError("PiCLIRuntime failed: timeout")
+            return response_text
+
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        with tempfile.TemporaryDirectory() as tmp:
+            creator = AgentTaskCreator(
+                llm_fn=mock_llm,
+                knowledge_root=Path(tmp),
+                designer_system_prompt="primary designer prompt",
+                retry_designer_system_prompt="fallback designer prompt",
+            )
+            instance = creator.create("Write a haiku about testing software")
+            registered_name = creator.derive_name("Write a haiku about testing software")
+
+            try:
+                assert instance.get_rubric() == SAMPLE_SPEC.judge_rubric
+                assert seen_system_prompts == ["primary designer prompt", "fallback designer prompt"]
             finally:
                 SCENARIO_REGISTRY.pop(registered_name, None)
 

--- a/autocontext/tests/test_designer_calibration.py
+++ b/autocontext/tests/test_designer_calibration.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from autocontext.scenarios.custom.agent_task_designer import (
     _EXAMPLE_SPEC,
     AGENT_TASK_DESIGNER_SYSTEM,
+    RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+    SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
 )
 
 
@@ -18,6 +20,12 @@ def test_example_spec_has_calibration_examples() -> None:
 def test_prompt_requires_calibration() -> None:
     """System prompt must state calibration examples are mandatory."""
     assert "MUST include at least 2 calibration" in AGENT_TASK_DESIGNER_SYSTEM
+
+
+def test_solve_prompts_require_calibration() -> None:
+    """Solve-specific designer prompts must preserve the calibration contract."""
+    assert "MUST include at least 2 calibration" in SOLVE_AGENT_TASK_DESIGNER_SYSTEM
+    assert "calibration_examples with at least 2 examples" in RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM
 
 
 def test_calibration_examples_have_required_fields() -> None:

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -414,8 +414,77 @@ class TestSolveScenarioBuilder:
         assert "Objective" in captured["description"]
         assert "Scenario Design" in captured["description"]
 
+    def test_build_uses_compact_designer_prompt_for_agent_task_solves(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from autocontext.knowledge.solve_design import _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS
+        from autocontext.knowledge.solver import (
+            SolveScenarioBuilder,
+        )
+        from autocontext.scenarios.custom.agent_task_designer import (
+            RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+            SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+        )
+
+        runtime = SubagentRuntime(DeterministicDevClient())
+        builder = SolveScenarioBuilder(
+            runtime=runtime,
+            llm_fn=_operator_loop_llm,
+            model="test-model",
+            knowledge_root=tmp_path,
+        )
+        captured: dict[str, str] = {}
+
+        class _CreatedScenario:
+            name = "stress_test_rubric_fixture"
+
+        def _fake_create(self, description: str, *, family_name: str = "") -> _CreatedScenario:
+            del family_name
+            captured["description"] = description
+            captured["designer_system_prompt"] = self._designer_system_prompt
+            captured["retry_designer_system_prompt"] = self._retry_designer_system_prompt
+            transformed = self._description_transform(description) if self._description_transform is not None else description
+            captured["transformed_description"] = transformed
+            return _CreatedScenario()
+
+        monkeypatch.setattr(
+            "autocontext.scenarios.custom.agent_task_creator.AgentTaskCreator.create",
+            _fake_create,
+        )
+
+        builder.build(
+            "Harness Stress Test: rubric drift detection — long-horizon evaluation quality monitoring\n\n"
+            "## Objective\n\n"
+            "Run a scenario long enough (10+ generations) that rubric drift becomes measurable, then "
+            "validate that the analytics stack correctly detects and reports evaluation quality degradation.\n\n"
+            "## Scenario Design\n\n"
+            "* Use any stable scenario (grid_ctf or a custom agent-task)\n"
+            "* Run 10+ generations with live Anthropic provider\n"
+            "* Use analytics/rubric_drift.py, analytics/calibration.py, analytics/correlation.py, "
+            "analytics/timeline_inspector.py, and analytics/trace_reporter.py\n"
+            "* Capture concrete commands, artifacts, and metrics\n"
+            "* Report cross-module consistency\n\n"
+            "## Evaluation Dimensions\n\n"
+            "* Rubric drift coefficient\n"
+            "* Calibration error\n"
+            "* Inter-dimension correlation matrix health\n"
+            "* Score distribution entropy across generations\n"
+            "* Stagnation detection accuracy\n\n"
+            "## Success Criteria\n\n"
+            "* 10+ generation run completes without crashes\n"
+            "* Analytics modules produce non-trivial output\n"
+            "* Timeline inspector identifies at least one inflection point or trend\n"
+            "* All analytics outputs are internally consistent\n"
+        )
+
+        assert captured["designer_system_prompt"] == SOLVE_AGENT_TASK_DESIGNER_SYSTEM
+        assert captured["retry_designer_system_prompt"] == RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM
+        assert len(captured["transformed_description"]) <= _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS
+        assert len(captured["transformed_description"]) < len(captured["description"])
+        assert "## Scenario Design" in captured["transformed_description"]
+
     def test_build_strips_inline_example_parentheticals_before_creation(self) -> None:
-        from autocontext.knowledge.solver import _build_solve_description_brief
+        from autocontext.knowledge.solve_design import _build_solve_description_brief
 
         brief = _build_solve_description_brief(
             "## Scenario Proposal\n\n"
@@ -431,6 +500,48 @@ class TestSolveScenarioBuilder:
         assert "essay-quality metric" not in brief
         assert "e.g." not in brief
         assert "gaming the metric" in brief
+
+    def test_build_solve_agent_task_design_brief_compacts_long_structured_descriptions(self) -> None:
+        from autocontext.knowledge.solve_design import (
+            _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS,
+            _build_solve_agent_task_design_brief,
+            _build_solve_description_brief,
+        )
+
+        description = (
+            "Harness Stress Test: rubric drift detection — long-horizon evaluation quality monitoring\n\n"
+            "## Objective\n\n"
+            "Run a scenario long enough (10+ generations) that rubric drift becomes measurable, then "
+            "validate that the analytics stack correctly detects and reports evaluation quality degradation.\n\n"
+            "## Scenario Design\n\n"
+            "* Use any stable scenario (grid_ctf or a custom agent-task)\n"
+            "* Run 10+ generations with live Anthropic provider\n"
+            "* Use analytics/rubric_drift.py, analytics/calibration.py, analytics/correlation.py, "
+            "analytics/timeline_inspector.py, and analytics/trace_reporter.py\n"
+            "* Capture concrete commands, artifacts, and metrics\n"
+            "* Report cross-module consistency\n\n"
+            "## Evaluation Dimensions\n\n"
+            "* Rubric drift coefficient\n"
+            "* Calibration error\n"
+            "* Inter-dimension correlation matrix health\n"
+            "* Score distribution entropy across generations\n"
+            "* Stagnation detection accuracy\n\n"
+            "## Success Criteria\n\n"
+            "* 10+ generation run completes without crashes\n"
+            "* Analytics modules produce non-trivial output\n"
+            "* Timeline inspector identifies at least one inflection point or trend\n"
+            "* All analytics outputs are internally consistent\n"
+        )
+
+        brief = _build_solve_description_brief(description)
+        compact = _build_solve_agent_task_design_brief(description)
+
+        assert len(brief) > _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS
+        assert len(compact) <= _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS
+        assert len(compact) < len(brief)
+        assert "## Objective" in compact
+        assert "## Scenario Design" in compact
+        assert "analytics/rubric_drift.py" in compact
 
 
 class TestSolveLLMFn:
@@ -452,7 +563,8 @@ class TestSolveLLMFn:
 
         assert result == "ok"
         assert captured["model"] == "architect-model"
-        assert captured["max_tokens"] == 1800
+        assert captured["max_tokens"] == 1200
+        assert captured["temperature"] == 0.2
         assert captured["role"] == "scenario_designer"
 
     def test_build_creator_prefers_translator_model_for_solve_design(
@@ -489,6 +601,47 @@ class TestSolveLLMFn:
 
         assert builder is not None
         assert builder._model == "translator-sonnet"
+
+    def test_build_creator_raises_pi_timeout_floor_for_solve_design(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solve_design import _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS
+        from autocontext.knowledge.solver import SolveManager
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            agent_provider="pi",
+            pi_timeout=300.0,
+        )
+        manager = SolveManager(settings)
+        captured: dict[str, float] = {}
+
+        class _Client:
+            pass
+
+        class _Runtime:
+            def __init__(self, client: object) -> None:
+                self.client = client
+
+        def _fake_build_client(settings: AppSettings) -> _Client:
+            captured["pi_timeout"] = float(settings.pi_timeout)
+            return _Client()
+
+        monkeypatch.setattr(
+            "autocontext.agents.llm_client.build_client_from_settings",
+            _fake_build_client,
+        )
+        monkeypatch.setattr(
+            "autocontext.agents.subagent_runtime.SubagentRuntime",
+            _Runtime,
+        )
+
+        builder = manager._build_creator()
+
+        assert builder is not None
+        assert captured["pi_timeout"] == _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS
 
 
 class TestSolveScenarioExecutor:


### PR DESCRIPTION
## Summary

- stabilize Python `solve` scenario design for the AC-268 / rubric-drift stress prompt by introducing a solve-specific compact AgentTask designer path
- add a tighter solve-design timeout floor for live Pi-backed creator calls so scenario creation is not constrained by the normal 300s CLI default
- keep the fix bounded to solve-time agent-task design while leaving a separately filed follow-up bucket (`AC-584`) for the residual post-creation execution flake on the generated scenario

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run pytest tests/test_agent_task_pipeline.py tests/test_knowledge_solver.py tests/test_cli_solve_runtime.py tests/test_intent_validation.py tests/test_auto_sample_input.py tests/test_time_budget.py -k 'solve or agent_task or overridden_system_prompt or compact_designer_prompt or design_brief_compacts or retry_system_prompt or timeout_floor' -x --tb=short`
- [x] `cd autocontext && uv run ruff check src/autocontext/scenarios/custom/agent_task_designer.py src/autocontext/scenarios/custom/agent_task_creator.py src/autocontext/knowledge/solver.py tests/test_agent_task_pipeline.py tests/test_knowledge_solver.py`
- [ ] `cd autocontext && uv run mypy ...`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Additional verification:
- failing-first red check against the pre-fix AC-573 commit with the new regression tests copied in:
  - log: `/tmp/ac576-red-log-XXXXXX.txt`
  - representative failure: `TypeError: design_agent_task() got an unexpected keyword argument 'system_prompt'`
- focused green checks after implementation:
  - `cd autocontext && uv run pytest tests/test_agent_task_pipeline.py tests/test_knowledge_solver.py -k 'retry_system_prompt or timeout_floor or compact_designer_prompt or design_brief_compacts or uses_tighter_solve_designer_token_budget or overridden_system_prompt' -x --tb=short`
  - `6 passed`
- broader targeted Python suite:
  - `94 passed, 50 deselected`
- live creation-only validation for the AC-268 solve creator boundary:
  - root: `/tmp/ac576-create-only3-ITX27f`
  - result: `3 / 3` successful `SolveScenarioBuilder.build(...)` runs under live Pi
  - representative success artifacts:
    - `/tmp/ac576-create-only3-ITX27f/run-1/stdout.log`
    - `/tmp/ac576-create-only3-ITX27f/run-2/stdout.log`
    - `/tmp/ac576-create-only3-ITX27f/run-3/stdout.log`
- residual live follow-up discovered during full solve validation:
  - roots: `/tmp/ac576-live-MkK2NX`, `/tmp/ac576-live3-ywNHXG`
  - creation now succeeds often enough to materialize `stress_test_rubric`, but a separate execution flake remains in `_complete_task_like_initial_output(...)`
  - follow-up issue filed: `AC-584`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- `AgentTaskCreator` now supports:
  - solve-specific designer prompt overrides
  - retry-specific designer prompt overrides for timeout retries
  - description transforms for bounded-context prompt compaction
- `SolveScenarioBuilder` now routes solve-created `agent_task` designs through:
  - `_build_solve_agent_task_design_brief(...)`
  - `SOLVE_AGENT_TASK_DESIGNER_SYSTEM`
  - `RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM`
- `SolveManager._build_creator()` now applies a solve-creator Pi timeout floor of `600s` so live solve design calls are not limited by the normal default Pi CLI timeout
- this PR is stacked on top of AC-573 / PR #725
- residual execution flake after creation is tracked separately in `AC-584` to keep this PR bounded to the scenario-design timeout regression
