### PR TITLE
feat(ac-579): add --family CLI override to autoctx solve

### DIFF
--- a/autocontext/src/autocontext/cli_solve.py
+++ b/autocontext/src/autocontext/cli_solve.py
@@ -23,6 +23,24 @@ if TYPE_CHECKING:
     from rich.console import Console
 
 
+def _validate_family_override(family_name: str | None) -> None:
+    """Validate the --family flag value. Raises typer.Exit(1) on unknown.
+
+    Empty string and None both mean "not provided" → no raise.
+    """
+    from autocontext.scenarios.families import list_families
+
+    if not family_name:
+        return
+    known = {f.name for f in list_families()}
+    if family_name not in known:
+        typer.echo(
+            f"unknown --family {family_name!r}. Valid: {sorted(known)}",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+
 @dataclass(slots=True)
 class SolveRunSummary:
     """Result summary for solve-on-demand via the CLI."""

--- a/autocontext/src/autocontext/cli_solve.py
+++ b/autocontext/src/autocontext/cli_solve.py
@@ -71,6 +71,7 @@ def run_solve_command(
     load_settings_fn: Callable[[], AppSettings],
     write_json_stdout: Callable[[object], None],
     write_json_stderr: Callable[[str], None],
+    family_override: str | None = None,
 ) -> None:
     """Create a scenario on demand, run it, and export the solved package."""
     from autocontext.knowledge.solver import SolveManager
@@ -83,7 +84,11 @@ def run_solve_command(
     manager = SolveManager(settings)
 
     try:
-        job = manager.solve_sync(description=description, generations=gens)
+        job = manager.solve_sync(
+            description=description,
+            generations=gens,
+            family_override=family_override or None,
+        )
     except KeyboardInterrupt:
         if json_output:
             write_json_stderr("solve interrupted")
@@ -170,7 +175,13 @@ def register_solve_command(
         ),
         output: str = typer.Option("", "--output", help="Optional JSON file path for the solved package"),
         json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
+        family: str = typer.Option(
+            "",
+            "--family",
+            help="Force a specific scenario family, bypassing the keyword classifier",
+        ),
     ) -> None:
+        _validate_family_override(family)
         run_solve_command(
             description=description,
             gens=gens,
@@ -182,4 +193,5 @@ def register_solve_command(
             load_settings_fn=_cli_attr(dependency_module, "load_settings"),
             write_json_stdout=_cli_attr(dependency_module, "_write_json_stdout"),
             write_json_stderr=_cli_attr(dependency_module, "_write_json_stderr"),
+            family_override=family or None,
         )

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -562,12 +562,21 @@ class SolveScenarioBuilder:
         self._model = model
         self._knowledge_root = knowledge_root
 
-    def build(self, description: str) -> SolveScenarioBuildResult:
+    def build(
+        self,
+        description: str,
+        *,
+        family_override: str | None = None,
+    ) -> SolveScenarioBuildResult:
         from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
         from autocontext.scenarios.custom.creator import ScenarioCreator
+        from autocontext.scenarios.families import get_family
 
         brief = _build_solve_description_brief(description)
-        family = _resolve_requested_scenario_family(brief)
+        if family_override:
+            family = get_family(family_override)
+        else:
+            family = _resolve_requested_scenario_family(brief)
 
         if family.name == "game":
             game_creator = ScenarioCreator(
@@ -667,7 +676,7 @@ class SolveManager:
                 job.error = "Scenario creation pipeline unavailable (no API key or unsupported provider)"
                 return
 
-            created = builder.build(job.description)
+            created = builder.build(job.description, family_override=job.family_override)
             job.scenario_name = created.scenario_name
 
             # 2. Run generations

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -76,6 +76,7 @@ class SolveJob:
     error: str | None = None
     result: SkillPackage | None = None
     created_at: float = field(default_factory=time.time)
+    family_override: str | None = None
 
 
 @dataclass(slots=True)
@@ -633,13 +634,23 @@ class SolveManager:
         thread.start()
         return job_id
 
-    def solve_sync(self, description: str, generations: int = 5) -> SolveJob:
-        """Run solve-on-demand synchronously in the current process."""
+    def solve_sync(
+        self,
+        description: str,
+        generations: int = 5,
+        family_override: str | None = None,
+    ) -> SolveJob:
+        """Run solve-on-demand synchronously in the current process.
+
+        If ``family_override`` is provided, the scenario family classifier is
+        bypassed and the solver routes directly to the named family's pipeline.
+        """
         job_id = f"solve_{uuid.uuid4().hex[:8]}"
         job = SolveJob(
             job_id=job_id,
             description=description,
             generations=generations,
+            family_override=family_override,
         )
         self._jobs[job_id] = job
         self._run_job(job)

--- a/autocontext/tests/test_cli_solve_runtime.py
+++ b/autocontext/tests/test_cli_solve_runtime.py
@@ -19,8 +19,13 @@ class _CapturingSolveManager:
     def __init__(self, settings: AppSettings) -> None:
         type(self).last_settings = settings
 
-    def solve_sync(self, description: str, generations: int = 5) -> SolveJob:
-        del description, generations
+    def solve_sync(
+        self,
+        description: str,
+        generations: int = 5,
+        family_override: str | None = None,
+    ) -> SolveJob:
+        del description, generations, family_override
         pkg = SkillPackage(
             scenario_name="grid_ctf",
             display_name="Grid Ctf",
@@ -47,8 +52,13 @@ class _FailingSolveManager:
     def __init__(self, settings: AppSettings) -> None:
         self._settings = settings
 
-    def solve_sync(self, description: str, generations: int = 5) -> SolveJob:
-        del description, generations
+    def solve_sync(
+        self,
+        description: str,
+        generations: int = 5,
+        family_override: str | None = None,
+    ) -> SolveJob:
+        del description, generations, family_override
         return SolveJob(
             job_id="solve_fail",
             description="Broken solve",

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -669,8 +669,13 @@ class TestSolveManager:
         )
 
         class _FakeBuilder:
-            def build(self, description: str) -> SolveScenarioBuildResult:
-                del description
+            def build(
+                self,
+                description: str,
+                *,
+                family_override: str | None = None,
+            ) -> SolveScenarioBuildResult:
+                del description, family_override
                 return created
 
         fake_package = SkillPackage(

--- a/autocontext/tests/test_solve_family_override.py
+++ b/autocontext/tests/test_solve_family_override.py
@@ -1,0 +1,27 @@
+"""AC-579 — --family CLI override for autoctx solve."""
+from __future__ import annotations
+
+import pytest
+import typer
+
+from autocontext.cli_solve import _validate_family_override
+from autocontext.scenarios.families import list_families
+
+
+class TestValidateFamilyOverride:
+    def test_empty_string_is_accepted(self) -> None:
+        # Empty string means "--family not provided"; no raise.
+        _validate_family_override("")
+
+    def test_none_is_accepted(self) -> None:
+        # None is also treated as "not provided".
+        _validate_family_override(None)
+
+    def test_unknown_family_raises_typer_exit(self) -> None:
+        with pytest.raises(typer.Exit) as excinfo:
+            _validate_family_override("not_a_real_family")
+        assert excinfo.value.exit_code == 1
+
+    @pytest.mark.parametrize("family_name", [f.name for f in list_families()])
+    def test_all_registered_families_are_accepted(self, family_name: str) -> None:
+        _validate_family_override(family_name)

--- a/autocontext/tests/test_solve_family_override.py
+++ b/autocontext/tests/test_solve_family_override.py
@@ -25,3 +25,43 @@ class TestValidateFamilyOverride:
     @pytest.mark.parametrize("family_name", [f.name for f in list_families()])
     def test_all_registered_families_are_accepted(self, family_name: str) -> None:
         _validate_family_override(family_name)
+
+
+class TestSolveJobFamilyOverride:
+    def test_solve_sync_defaults_family_override_to_none(self, tmp_path) -> None:
+        from unittest.mock import patch
+
+        from autocontext.config.settings import AppSettings
+        from autocontext.knowledge.solver import SolveJob, SolveManager
+
+        settings = AppSettings(knowledge_root=tmp_path / "knowledge")
+        manager = SolveManager(settings)
+
+        captured: dict[str, SolveJob] = {}
+
+        def capture_and_return(job: SolveJob) -> None:
+            captured["job"] = job
+
+        with patch.object(manager, "_run_job", side_effect=capture_and_return):
+            manager.solve_sync(description="x")
+
+        assert captured["job"].family_override is None
+
+    def test_solve_sync_stores_family_override_on_job(self, tmp_path) -> None:
+        from unittest.mock import patch
+
+        from autocontext.config.settings import AppSettings
+        from autocontext.knowledge.solver import SolveJob, SolveManager
+
+        settings = AppSettings(knowledge_root=tmp_path / "knowledge")
+        manager = SolveManager(settings)
+
+        captured: dict[str, SolveJob] = {}
+
+        def capture_and_return(job: SolveJob) -> None:
+            captured["job"] = job
+
+        with patch.object(manager, "_run_job", side_effect=capture_and_return):
+            manager.solve_sync(description="x", family_override="simulation")
+
+        assert captured["job"].family_override == "simulation"

--- a/autocontext/tests/test_solve_family_override.py
+++ b/autocontext/tests/test_solve_family_override.py
@@ -65,3 +65,65 @@ class TestSolveJobFamilyOverride:
             manager.solve_sync(description="x", family_override="simulation")
 
         assert captured["job"].family_override == "simulation"
+
+
+class TestSolveScenarioBuilderFamilyOverride:
+    """Builder.build routes via family_override when provided, else via classifier."""
+
+    def _make_builder(self, tmp_path):
+        from autocontext.knowledge.solver import SolveScenarioBuilder
+
+        def stub_llm_fn(system: str, user: str) -> str:
+            return ""
+
+        return SolveScenarioBuilder(
+            runtime=object(),
+            llm_fn=stub_llm_fn,
+            model="stub-model",
+            knowledge_root=tmp_path / "knowledge",
+        )
+
+    def test_build_skips_classifier_when_family_override_provided(self, tmp_path) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from autocontext.knowledge import solver as solver_mod
+
+        builder = self._make_builder(tmp_path)
+
+        def explode(_desc: str):
+            raise AssertionError("classifier must not be called when family_override is provided")
+
+        fake_scenario = MagicMock()
+        fake_scenario.name = "stub_scenario"
+
+        with patch.object(solver_mod, "_resolve_requested_scenario_family", side_effect=explode):
+            with patch(
+                "autocontext.scenarios.custom.agent_task_creator.AgentTaskCreator.create",
+                return_value=fake_scenario,
+            ):
+                result = builder.build("anything at all", family_override="simulation")
+
+        assert result.family_name == "simulation"
+
+    def test_build_uses_classifier_when_no_override(self, tmp_path) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from autocontext.knowledge import solver as solver_mod
+        from autocontext.scenarios.families import get_family
+
+        builder = self._make_builder(tmp_path)
+
+        fake_scenario = MagicMock()
+        fake_scenario.name = "stub_scenario"
+
+        classifier_mock = MagicMock(return_value=get_family("simulation"))
+
+        with patch.object(solver_mod, "_resolve_requested_scenario_family", classifier_mock):
+            with patch(
+                "autocontext.scenarios.custom.agent_task_creator.AgentTaskCreator.create",
+                return_value=fake_scenario,
+            ):
+                result = builder.build("please classify me")
+
+        classifier_mock.assert_called_once_with("please classify me")
+        assert result.family_name == "simulation"

--- a/autocontext/tests/test_solve_family_override.py
+++ b/autocontext/tests/test_solve_family_override.py
@@ -127,3 +127,96 @@ class TestSolveScenarioBuilderFamilyOverride:
 
         classifier_mock.assert_called_once_with("please classify me")
         assert result.family_name == "simulation"
+
+
+class TestRunSolveCommandFamilyOverride:
+    """--family flag is threaded from the CLI through to SolveManager.solve_sync."""
+
+    def test_run_solve_command_forwards_family_override(self, tmp_path) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from rich.console import Console
+
+        from autocontext.cli_solve import run_solve_command
+        from autocontext.config.settings import AppSettings
+        from autocontext.knowledge.export import SkillPackage
+
+        settings = AppSettings(knowledge_root=tmp_path / "knowledge")
+
+        fake_result = MagicMock(spec=SkillPackage)
+        fake_result.to_dict.return_value = {"stub": True}
+
+        fake_job = MagicMock()
+        fake_job.status = "completed"
+        fake_job.result = fake_result
+        fake_job.job_id = "job_1"
+        fake_job.description = "x"
+        fake_job.scenario_name = "stub_scn"
+        fake_job.generations = 1
+        fake_job.progress = 1
+        fake_job.error = None
+
+        with patch("autocontext.knowledge.solver.SolveManager") as manager_cls:
+            manager_cls.return_value.solve_sync.return_value = fake_job
+            run_solve_command(
+                description="x",
+                gens=1,
+                timeout=None,
+                generation_time_budget=None,
+                output="",
+                json_output=True,
+                console=Console(quiet=True),
+                load_settings_fn=lambda: settings,
+                write_json_stdout=lambda _payload: None,
+                write_json_stderr=lambda _msg: None,
+                family_override="simulation",
+            )
+            manager_cls.return_value.solve_sync.assert_called_once_with(
+                description="x",
+                generations=1,
+                family_override="simulation",
+            )
+
+    def test_run_solve_command_defaults_family_override_to_none(self, tmp_path) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from rich.console import Console
+
+        from autocontext.cli_solve import run_solve_command
+        from autocontext.config.settings import AppSettings
+        from autocontext.knowledge.export import SkillPackage
+
+        settings = AppSettings(knowledge_root=tmp_path / "knowledge")
+
+        fake_result = MagicMock(spec=SkillPackage)
+        fake_result.to_dict.return_value = {"stub": True}
+
+        fake_job = MagicMock()
+        fake_job.status = "completed"
+        fake_job.result = fake_result
+        fake_job.job_id = "job_1"
+        fake_job.description = "x"
+        fake_job.scenario_name = "stub_scn"
+        fake_job.generations = 1
+        fake_job.progress = 1
+        fake_job.error = None
+
+        with patch("autocontext.knowledge.solver.SolveManager") as manager_cls:
+            manager_cls.return_value.solve_sync.return_value = fake_job
+            run_solve_command(
+                description="x",
+                gens=1,
+                timeout=None,
+                generation_time_budget=None,
+                output="",
+                json_output=True,
+                console=Console(quiet=True),
+                load_settings_fn=lambda: settings,
+                write_json_stdout=lambda _payload: None,
+                write_json_stderr=lambda _msg: None,
+            )
+            manager_cls.return_value.solve_sync.assert_called_once_with(
+                description="x",
+                generations=1,
+                family_override=None,
+            )


### PR DESCRIPTION
## Summary
- Adds optional `--family <name>` flag to `autoctx solve` that bypasses the keyword classifier and routes the description directly to the named scenario family's pipeline.
- Complements AC-571 (vocabulary expansion) as the "level 2" escape hatch in the long-term classifier sustainability plan (design: docs/superpowers/specs/2026-04-20-ac579-family-cli-override-design.md). AC-580 (LLM fallback classifier) ships separately.

## Plumbing
- `_validate_family_override` helper in `cli_solve.py` validates against `list_families()`; unknown → typer.Exit(1) with a "Valid: …" message on stderr.
- `--family` threads through `solve` command → `run_solve_command(family_override=…)` → `SolveManager.solve_sync(family_override=…)` → `SolveJob.family_override` → `SolveScenarioBuilder.build(description, family_override=…)`.
- Builder uses `get_family(family_override)` and skips `_resolve_requested_scenario_family` entirely when override is set. Classifier, fallback behavior, and `**Family:** X` header parsing are unchanged for the default path.

## Behavior
```bash
autoctx solve --description "..."                            # classifier runs (unchanged)
autoctx solve --description "..." --family simulation        # bypasses classifier → simulation pipeline
autoctx solve --description "..." --family unknown_name      # exits 1 with valid-names hint
```

## Test Plan
- [x] `uv run pytest autocontext/tests/test_solve_family_override.py` — 20 new tests covering validator, SolveJob/solve_sync plumbing, builder override bypass vs. classifier path, and run_solve_command forwarding.
- [x] `uv run pytest` — 5419 passed, 54 skipped.
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run mypy src` — clean.
- [x] Manual CLI probe: `autoctx solve --description "x" --family not_a_real_family` exits 1, prints valid names; `--help` shows new flag.

## Linked
- Linear: AC-579
- Related: AC-571 (vocabulary expansion, merged #728), AC-580 (LLM fallback classifier, pending)