### PR TITLE
fix: stabilize solve agent-task execution timeouts

### DIFF
--- a/autocontext/src/autocontext/execution/task_runtime_budget.py
+++ b/autocontext/src/autocontext/execution/task_runtime_budget.py
@@ -9,7 +9,18 @@ _TASK_LIKE_COMPLETION_MAX_TOKENS: dict[str, int] = {
     "json_schema": 2200,
     "code": 2600,
 }
+_COMPACT_JSON_SCHEMA_COMPLETION_MAX_TOKENS = 1200
+_COMPACT_JSON_SCHEMA_MAX_PROMPT_CHARS = 1600
 _DEFAULT_TASK_LIKE_COMPLETION_MAX_TOKENS = 1800
+
+
+def _uses_compact_json_schema_budget(prompt: str) -> bool:
+    normalized = prompt.lower()
+    if len(prompt) > _COMPACT_JSON_SCHEMA_MAX_PROMPT_CHARS:
+        return False
+    return "json" in normalized and (
+        "json only with keys" in normalized or "json object with keys" in normalized or "return json with {" in normalized
+    )
 
 
 def resolve_task_like_completion_max_tokens(state: dict, prompt: str) -> int:
@@ -20,10 +31,11 @@ def resolve_task_like_completion_max_tokens(state: dict, prompt: str) -> int:
     trigger live Pi timeouts for roadmap-style prompts. This helper centralizes a
     tighter, output-format-aware cap for the first completion.
     """
-    del prompt
     output_format = state.get("output_format")
     if isinstance(output_format, str):
         normalized = output_format.strip().lower()
+        if normalized == "json_schema" and _uses_compact_json_schema_budget(prompt):
+            return _COMPACT_JSON_SCHEMA_COMPLETION_MAX_TOKENS
         if normalized in _TASK_LIKE_COMPLETION_MAX_TOKENS:
             return _TASK_LIKE_COMPLETION_MAX_TOKENS[normalized]
     return _DEFAULT_TASK_LIKE_COMPLETION_MAX_TOKENS

--- a/autocontext/src/autocontext/knowledge/solve_design.py
+++ b/autocontext/src/autocontext/knowledge/solve_design.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 
 from autocontext.config.settings import AppSettings
+from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
 
 _SOLVE_DESCRIPTION_SKIP_SECTIONS = frozenset(
     {
@@ -36,6 +37,10 @@ _SOLVE_AGENT_TASK_DESIGN_KEEP_SECTIONS = frozenset(
 _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS = 1000
 _SOLVE_AGENT_TASK_DESIGN_MAX_SECTION_LINES = 5
 _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS = 600.0
+_SOLVE_RUNTIME_HEAVY_TASK_PROMPT_RE = re.compile(
+    r"\b(run|execute|inspect)\b.*\b(provider|repository|scenario|generations?|command|file|artifact)\b",
+    re.IGNORECASE,
+)
 
 
 def _build_solve_description_brief(description: str) -> str:
@@ -121,3 +126,14 @@ def _settings_for_solve_creator(settings: AppSettings) -> AppSettings:
     if float(settings.pi_timeout) >= _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS:
         return settings
     return settings.model_copy(update={"pi_timeout": _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS})
+
+
+def _solve_task_spec_needs_compact_retry(spec: AgentTaskSpec) -> bool:
+    if spec.output_format != "json_schema":
+        return False
+    if spec.sample_input not in {None, ""}:
+        return False
+    prompt = spec.task_prompt.strip()
+    if "if available" in prompt.lower():
+        return True
+    return bool(_SOLVE_RUNTIME_HEAVY_TASK_PROMPT_RE.search(prompt))

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -25,6 +25,7 @@ from autocontext.knowledge.solve_design import (
     _build_solve_agent_task_design_brief,
     _build_solve_description_brief,
     _settings_for_solve_creator,
+    _solve_task_spec_needs_compact_retry,
 )
 from autocontext.mcp.tools import MtsToolContext
 from autocontext.scenarios import SCENARIO_REGISTRY
@@ -57,6 +58,8 @@ _SIMULATION_INTERFACE_HINT_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 _AGENT_TASK_INTERFACE_HINT_RE = re.compile(r"\bagent[- ]task evaluation\b", re.IGNORECASE)
+
+
 @dataclass
 class SolveJob:
     job_id: str
@@ -473,7 +476,7 @@ class SolveScenarioExecutor:
 
         try:
             provider, provider_model = resolve_role_runtime(
-                self._settings,
+                _settings_for_solve_creator(self._settings),
                 role="competitor",
                 scenario_name=scenario_name,
                 sqlite=sqlite,
@@ -590,6 +593,7 @@ class SolveScenarioBuilder:
             designer_system_prompt=SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
             retry_designer_system_prompt=RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
             description_transform=_build_solve_agent_task_design_brief,
+            retry_spec_predicate=_solve_task_spec_needs_compact_retry,
         )
         scenario = family_creator.create(brief, family_name=family.name)
         scenario_name = str(cast(_NamedScenario, scenario).name)

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -65,12 +65,14 @@ class AgentTaskCreator:
         designer_system_prompt: str = AGENT_TASK_DESIGNER_SYSTEM,
         retry_designer_system_prompt: str | None = None,
         description_transform: Callable[[str], str] | None = None,
+        retry_spec_predicate: Callable[[Any], bool] | None = None,
     ) -> None:
         self.llm_fn = llm_fn
         self.knowledge_root = knowledge_root
         self._designer_system_prompt = designer_system_prompt
         self._retry_designer_system_prompt = retry_designer_system_prompt
         self._description_transform = description_transform
+        self._retry_spec_predicate = retry_spec_predicate
 
     STOP_WORDS = SHARED_STOP_WORDS
 
@@ -128,6 +130,15 @@ class AgentTaskCreator:
                 else self._designer_system_prompt
             )
             logger.warning("agent task design failed on first attempt; retrying once", exc_info=True)
+            spec = design_agent_task(
+                design_description,
+                self.llm_fn,
+                system_prompt=retry_system_prompt,
+            )
+
+        if self._retry_spec_predicate is not None and self._retry_spec_predicate(spec):
+            retry_system_prompt = self._retry_designer_system_prompt or self._designer_system_prompt
+            logger.warning("agent task design produced a retryable spec; retrying once with fallback prompt")
             spec = design_agent_task(
                 design_description,
                 self.llm_fn,

--- a/autocontext/tests/test_agent_task_pipeline.py
+++ b/autocontext/tests/test_agent_task_pipeline.py
@@ -764,6 +764,60 @@ class TestAgentTaskCreator:
             finally:
                 SCENARIO_REGISTRY.pop(registered_name, None)
 
+    def test_retries_agent_task_design_when_retry_spec_predicate_flags_spec(self) -> None:
+        compact_spec = AgentTaskSpec(
+            task_prompt="Inspect telemetry and return JSON only with keys drift_status, calibration_status, and summary.",
+            judge_rubric="Score contract fidelity and diagnosis quality.",
+            output_format="json_schema",
+            sample_input='{"score_entropy":0.18}',
+        )
+        seen_system_prompts: list[str] = []
+        responses = [
+            _mock_llm_response(
+                AgentTaskSpec(
+                    task_prompt=(
+                        "Run a stable eval (grid_ctf if available) for 10 generations with the live provider "
+                        "and inspect repository analytics artifacts."
+                    ),
+                    judge_rubric="Score whether the run completed and analytics were inspected.",
+                    output_format="json_schema",
+                )
+            ),
+            _mock_llm_response(compact_spec),
+        ]
+
+        def mock_llm(system: str, user: str) -> str:
+            del user
+            seen_system_prompts.append(system)
+            return responses.pop(0)
+
+        from autocontext.scenarios import SCENARIO_REGISTRY
+
+        with tempfile.TemporaryDirectory() as tmp:
+            creator = AgentTaskCreator(
+                llm_fn=mock_llm,
+                knowledge_root=Path(tmp),
+                designer_system_prompt="primary designer prompt",
+                retry_designer_system_prompt="fallback designer prompt",
+                retry_spec_predicate=lambda spec: spec.sample_input is None and spec.task_prompt.startswith("Run a stable eval"),
+            )
+            from unittest.mock import patch
+
+            from autocontext.scenarios.families import get_family
+
+            with patch(
+                "autocontext.scenarios.custom.agent_task_creator.route_to_family",
+                return_value=get_family("agent_task"),
+            ):
+                instance = creator.create("Analyze rubric drift telemetry")
+            registered_name = creator.derive_name("Analyze rubric drift telemetry")
+
+            try:
+                assert instance.get_rubric() == compact_spec.judge_rubric
+                assert seen_system_prompts == ["primary designer prompt", "fallback designer prompt"]
+            finally:
+                SCENARIO_REGISTRY.pop(registered_name, None)
+
     def test_retries_agent_task_design_after_parse_failure(self) -> None:
         attempts = {"count": 0}
         invalid_response = f'{SPEC_START}\n{{\n  "task_prompt": }}\n{SPEC_END}\n'

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -543,6 +543,28 @@ class TestSolveScenarioBuilder:
         assert "## Scenario Design" in compact
         assert "analytics/rubric_drift.py" in compact
 
+    def test_solve_task_spec_needs_compact_retry_for_runtime_heavy_specs(self) -> None:
+        from autocontext.knowledge.solve_design import _solve_task_spec_needs_compact_retry
+        from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+
+        heavy_spec = AgentTaskSpec(
+            task_prompt=(
+                "Run a stable eval (grid_ctf if available) for 10 generations with the live provider "
+                "and inspect repository analytics artifacts."
+            ),
+            judge_rubric="Score whether the run completed and analytics were inspected.",
+            output_format="json_schema",
+        )
+        compact_spec = AgentTaskSpec(
+            task_prompt="Inspect telemetry and return JSON only with keys drift_status, calibration_status, and summary.",
+            judge_rubric="Score contract fidelity and diagnosis quality.",
+            output_format="json_schema",
+            sample_input='{"score_entropy":0.18}',
+        )
+
+        assert _solve_task_spec_needs_compact_retry(heavy_spec) is True
+        assert _solve_task_spec_needs_compact_retry(compact_spec) is False
+
 
 class TestSolveLLMFn:
     def test_uses_tighter_solve_designer_token_budget(self) -> None:
@@ -641,6 +663,51 @@ class TestSolveLLMFn:
         builder = manager._build_creator()
 
         assert builder is not None
+        assert captured["pi_timeout"] == _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS
+
+    def test_task_like_executor_raises_pi_timeout_floor_for_solve_runtime(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solve_design import _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS
+        from autocontext.knowledge.solver import SolveScenarioExecutor
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+            agent_provider="pi",
+            pi_timeout=300.0,
+        )
+        scenario_name = "solve_runtime_timeout_floor"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        SCENARIO_REGISTRY[scenario_name] = _SolveAgentTask
+        provider = _StubProvider("improved draft")
+        captured: dict[str, float] = {}
+
+        def _fake_resolve_role_runtime(settings: AppSettings, **kwargs: object) -> tuple[_StubProvider, str]:
+            del kwargs
+            captured["pi_timeout"] = float(settings.pi_timeout)
+            return provider, "test-model"
+
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.resolve_role_runtime",
+            _fake_resolve_role_runtime,
+        )
+
+        try:
+            summary = SolveScenarioExecutor(settings).execute(
+                scenario_name=scenario_name,
+                family_name="agent_task",
+                generations=1,
+            )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        assert summary.best_score == 1.0
         assert captured["pi_timeout"] == _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS
 
 
@@ -771,6 +838,10 @@ class TestSolveScenarioExecutor:
                 del seed
                 return {"output_format": "json_schema"}
 
+            def get_task_prompt(self, state: dict) -> str:
+                del state
+                return "Return JSON with {summary, milestones, risks, evidence, roadmap}. " + "Long telemetry details. " * 120
+
         settings = AppSettings(
             knowledge_root=tmp_path / "knowledge",
             db_path=tmp_path / "runs.sqlite3",
@@ -800,6 +871,55 @@ class TestSolveScenarioExecutor:
         assert summary.best_score == 1.0
         assert provider.calls[0]["max_tokens"] == 2200
         assert "Be concise" in str(provider.calls[0]["system_prompt"])
+
+    def test_task_like_executor_uses_compact_json_schema_budget(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solver import SolveScenarioExecutor
+
+        class _CompactJsonSolveAgentTask(_SolveAgentTask):
+            def initial_state(self, seed: int | None = None) -> dict:
+                del seed
+                return {"output_format": "json_schema"}
+
+            def get_task_prompt(self, state: dict) -> str:
+                del state
+                return (
+                    "Inspect telemetry and return JSON only with keys drift_status, calibration_status, "
+                    "correlation_health, entropy_status, stagnation_status, evidence_gens, and summary."
+                )
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+            agent_provider="pi",
+            pi_timeout=300.0,
+        )
+        scenario_name = "solve_compact_json_task_execution"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        provider = _StubProvider("improved draft")
+        SCENARIO_REGISTRY[scenario_name] = _CompactJsonSolveAgentTask
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.resolve_role_runtime",
+            lambda settings, **kwargs: (provider, "test-model"),
+        )
+
+        try:
+            summary = SolveScenarioExecutor(settings).execute(
+                scenario_name=scenario_name,
+                family_name="agent_task",
+                generations=1,
+            )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        assert summary.best_score == 1.0
+        assert provider.calls[0]["max_tokens"] == 1200
 
     def test_task_like_executor_retries_timeout_once(
         self,


### PR DESCRIPTION
## Summary

- stabilize the residual AC-268 post-creation `solve` execution flake by applying the solve Pi timeout floor to task-like runtime resolution, not just solve-time scenario creation
- add a compact json-schema execution budget path for short structured telemetry-analysis prompts so solve-created agent tasks do not over-allocate completion budget
- retry solve-created agent-task design when the first spec is runtime-heavy (for example, it asks the evaluated agent to run repository/provider workflows instead of consuming embedded input data)

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run pytest tests/test_agent_task_pipeline.py tests/test_knowledge_solver.py tests/test_cli_solve_runtime.py tests/test_intent_validation.py tests/test_auto_sample_input.py tests/test_time_budget.py -k 'solve or agent_task or timeout_floor or compact_json_schema_budget or retry_spec_predicate or retry_system_prompt or compact_designer_prompt or design_brief_compacts' -x --tb=short`
- [x] `cd autocontext && uv run ruff check src/autocontext/scenarios/custom/agent_task_creator.py src/autocontext/execution/task_runtime_budget.py src/autocontext/knowledge/solver.py tests/test_agent_task_pipeline.py tests/test_knowledge_solver.py`
- [ ] `cd autocontext && uv run mypy ...`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Additional verification:
- failing-first red check against the pre-fix AC-576 commit with the new regression tests copied in:
  - log: `/tmp/ac584-red-log-XXXXXX.txt`
  - representative failure: `TypeError: AgentTaskCreator.__init__() got an unexpected keyword argument 'retry_spec_predicate'`
- focused green checks:
  - `cd autocontext && uv run pytest tests/test_knowledge_solver.py -k 'timeout_floor or compact_json_schema_budget or uses_output_format_completion_budget or retries_timeout_once' -x --tb=short`
  - `5 passed`
- broader targeted Python suite:
  - `98 passed, 50 deselected`
- live repro before fix:
  - `/tmp/ac584-live-zF2UBS`
  - `/tmp/ac584-live2-tSpN0R`
  - representative failure: `/tmp/ac584-live2-tSpN0R/run-1/stderr.log`
- post-fix live validation:
  - `/tmp/ac584-live3-v36XBt`
  - result: `3 / 3` successful live `autoctx solve` runs for AC-268
  - representative success:
    - `/tmp/ac584-live3-v36XBt/run-1/stdout.log`
    - `/tmp/ac584-live3-v36XBt/run-2/stdout.log`
    - `/tmp/ac584-live3-v36XBt/run-3/stdout.log`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- `AgentTaskCreator` now supports a `retry_spec_predicate` hook so solve can redesign runtime-heavy specs before materialization
- `SolveScenarioBuilder` uses solve-specific heavy-spec detection to retry prompts that ask the evaluated agent to run repository/provider workflows instead of consuming embedded telemetry
- `task_runtime_budget.py` now gives compact short-form json-schema tasks a smaller completion budget, while leaving larger structured outputs on the existing higher cap
- `SolveScenarioExecutor` now uses the same solve Pi timeout floor as the solve creator path, keeping creation and execution in the same bounded runtime policy
- this PR is stacked on top of AC-576 / PR #730
