### PR TITLE
fix: stabilize python geopolitical simulate runtime

### DIFF
--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -43,6 +43,8 @@ from autocontext.util.json_io import read_json
 
 logger = logging.getLogger(__name__)
 
+_SIMULATION_PI_TIMEOUT_FLOOR_SECONDS = 600.0
+
 if TYPE_CHECKING:
     from autocontext.providers.base import LLMProvider
     from autocontext.training.runner import TrainingConfig, TrainingResult
@@ -189,13 +191,22 @@ def _is_agent_task(scenario_name: str) -> bool:
     return issubclass(family.interface_class, AgentTaskInterface)
 
 
+def _settings_for_simulation_runtime(settings: AppSettings) -> AppSettings:
+    if float(settings.pi_timeout) >= _SIMULATION_PI_TIMEOUT_FLOOR_SECONDS:
+        return settings
+    return settings.model_copy(update={"pi_timeout": _SIMULATION_PI_TIMEOUT_FLOOR_SECONDS})
+
+
 def _resolve_simulation_runtime(settings: AppSettings) -> tuple[LLMProvider, str]:
     """Resolve the architect-style runtime used for simulation spec generation.
 
     Simulations are authoring/spec-generation tasks, so they should follow the
     configured architect runtime surface rather than the judge provider.
+    Live Pi-backed simulation design can exceed the default CLI timeout for
+    stress scenarios, so use the same kind of internal timeout floor applied in
+    other long-running authoring flows.
     """
-    return _resolve_role_runtime(settings, role="architect")
+    return _resolve_role_runtime(_settings_for_simulation_runtime(settings), role="architect")
 
 
 def _resolve_role_runtime(

--- a/autocontext/src/autocontext/simulation/engine.py
+++ b/autocontext/src/autocontext/simulation/engine.py
@@ -20,6 +20,7 @@ from autocontext.agents.types import LlmFn
 from autocontext.simulation.helpers import (
     aggregate_contract_signal_counts,
     apply_behavioral_contract,
+    design_structured_family_spec,
     find_scenario_class,
     infer_family,
 )
@@ -300,17 +301,9 @@ class SimulationEngine:
     # ------------------------------------------------------------------
 
     def _build_spec(self, description: str, family: str) -> dict[str, Any]:
-        if family == "operator_loop":
-            from autocontext.scenarios.custom.generic_creator import spec_to_plain_data
-            from autocontext.scenarios.custom.operator_loop_designer import design_operator_loop
-
-            try:
-                designed = design_operator_loop(description, self.llm_fn)
-                plain = spec_to_plain_data(designed)
-                if isinstance(plain, dict):
-                    return plain
-            except Exception:
-                logger.debug("simulation.engine: operator_loop designer fallback", exc_info=True)
+        structured_spec = design_structured_family_spec(description, family, self.llm_fn)
+        if structured_spec is not None:
+            return structured_spec
 
         system = (
             f"You are a simulation designer. Produce a {family} spec as JSON.\n"

--- a/autocontext/src/autocontext/simulation/helpers.py
+++ b/autocontext/src/autocontext/simulation/helpers.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import inspect
+import logging
 import re
 import types
-from typing import Any
+from typing import Any, cast
+
+from autocontext.agents.types import LlmFn
+
+logger = logging.getLogger(__name__)
 
 # Only explicit human-oversight / clarification semantics should short-circuit to
 # operator_loop here. Broader escalation language belongs to the family classifier,
@@ -71,6 +76,34 @@ def infer_family(description: str) -> str:
         return "operator_loop" if family == "operator_loop" else "simulation"
     except Exception:
         return "simulation"
+
+
+def design_structured_family_spec(description: str, family: str, llm_fn: LlmFn) -> dict[str, Any] | None:
+    from autocontext.scenarios.custom.generic_creator import spec_to_plain_data
+
+    if family == "operator_loop":
+        from autocontext.scenarios.custom.operator_loop_designer import design_operator_loop
+
+        try:
+            plain = spec_to_plain_data(design_operator_loop(description, llm_fn))
+        except Exception:
+            logger.debug("simulation.helpers: operator_loop designer fallback", exc_info=True)
+        else:
+            if isinstance(plain, dict):
+                return cast(dict[str, Any], plain)
+
+    if family == "simulation":
+        from autocontext.scenarios.custom.simulation_designer import design_simulation
+
+        try:
+            plain = spec_to_plain_data(design_simulation(description, llm_fn))
+        except Exception:
+            logger.debug("simulation.helpers: simulation designer fallback", exc_info=True)
+        else:
+            if isinstance(plain, dict):
+                return cast(dict[str, Any], plain)
+
+    return None
 
 
 def aggregate_contract_signal_counts(results: list[dict[str, Any]]) -> dict[str, int]:

--- a/autocontext/tests/test_cli_simulate_runtime.py
+++ b/autocontext/tests/test_cli_simulate_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import patch
 
 from typer.testing import CliRunner
@@ -27,13 +28,15 @@ class _RecordingClient:
         temperature: float,
         role: str = "",
     ) -> SimpleNamespace:
-        self.calls.append({
-            "model": model,
-            "prompt": prompt,
-            "max_tokens": max_tokens,
-            "temperature": temperature,
-            "role": role,
-        })
+        self.calls.append(
+            {
+                "model": model,
+                "prompt": prompt,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "role": role,
+            }
+        )
         return SimpleNamespace(text=self._text)
 
 
@@ -65,13 +68,15 @@ class _FakeOrchestrator:
         is_plateau: bool = False,
         scenario_name: str = "",
     ) -> tuple[_RecordingClient, str]:
-        self.calls.append({
-            "role": role,
-            "generation": generation,
-            "retry_count": retry_count,
-            "is_plateau": is_plateau,
-            "scenario_name": scenario_name,
-        })
+        self.calls.append(
+            {
+                "role": role,
+                "generation": generation,
+                "retry_count": retry_count,
+                "is_plateau": is_plateau,
+                "scenario_name": scenario_name,
+            }
+        )
         return self._client, self._model
 
 
@@ -88,6 +93,7 @@ def _settings(tmp_path: Path, **overrides: object) -> AppSettings:
         model_architect=str(overrides.get("model_architect", "claude-opus-4-6")),
         agent_default_model=str(overrides.get("agent_default_model", "gpt-4o")),
         pi_model=str(overrides.get("pi_model", "")),
+        pi_timeout=float(cast(float | int | str, overrides.get("pi_timeout", 300.0))),
     )
 
 
@@ -118,20 +124,47 @@ class TestSimulateRuntimeResolution:
         payload = json.loads(result.stdout)
         assert payload["provider_text"] == '{"spec": "from-runtime"}'
         mock_from_settings.assert_called_once()
-        assert orchestrator.calls == [{
-            "role": "architect",
-            "generation": 1,
-            "retry_count": 0,
-            "is_plateau": False,
-            "scenario_name": "",
-        }]
-        assert client.calls == [{
-            "model": "pi-architect",
-            "prompt": "architect-system\n\narchitect-user",
-            "max_tokens": 4096,
-            "temperature": 0.0,
-            "role": "architect",
-        }]
+        assert orchestrator.calls == [
+            {
+                "role": "architect",
+                "generation": 1,
+                "retry_count": 0,
+                "is_plateau": False,
+                "scenario_name": "",
+            }
+        ]
+        assert client.calls == [
+            {
+                "model": "pi-architect",
+                "prompt": "architect-system\n\narchitect-user",
+                "max_tokens": 4096,
+                "temperature": 0.0,
+                "role": "architect",
+            }
+        ]
+
+    def test_simulate_raises_pi_timeout_floor_for_architect_runtime(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path, agent_provider="pi", architect_provider="pi", pi_timeout=300.0)
+        client = _RecordingClient(text='{"spec": "from-runtime"}')
+        orchestrator = _FakeOrchestrator(client, "pi-architect")
+        captured_settings: list[AppSettings] = []
+
+        def _capture_from_settings(current: AppSettings, **_: object) -> _FakeOrchestrator:
+            captured_settings.append(current)
+            return orchestrator
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._sqlite_from_settings", return_value=object()),
+            patch("autocontext.cli._artifacts_from_settings", return_value=object()),
+            patch("autocontext.cli.AgentOrchestrator.from_settings", side_effect=_capture_from_settings),
+            patch("autocontext.simulation.engine.SimulationEngine", _FakeSimulationEngine),
+        ):
+            result = runner.invoke(app, ["simulate", "--description", "runtime test", "--json"])
+
+        assert result.exit_code == 0, result.output
+        assert len(captured_settings) == 1
+        assert captured_settings[0].pi_timeout == 600.0
 
     def test_simulate_provider_flag_overrides_architect_runtime(self, tmp_path: Path) -> None:
         settings = _settings(tmp_path, agent_provider="anthropic", architect_provider="pi")

--- a/autocontext/tests/test_simulate_command.py
+++ b/autocontext/tests/test_simulate_command.py
@@ -18,18 +18,20 @@ def tmp_knowledge(tmp_path: Path) -> Path:
 
 def _mock_llm_fn(spec_json: str | None = None):
     """Return a callable that mimics llm_fn(system, user) -> str."""
-    default = json.dumps({
-        "description": "Test simulation",
-        "environment_description": "Test env",
-        "initial_state_description": "Start state",
-        "success_criteria": ["complete all steps"],
-        "failure_modes": ["timeout"],
-        "max_steps": 10,
-        "actions": [
-            {"name": "step_a", "description": "First", "parameters": {}, "preconditions": [], "effects": ["a_done"]},
-            {"name": "step_b", "description": "Second", "parameters": {}, "preconditions": ["step_a"], "effects": ["b_done"]},
-        ],
-    })
+    default = json.dumps(
+        {
+            "description": "Test simulation",
+            "environment_description": "Test env",
+            "initial_state_description": "Start state",
+            "success_criteria": ["complete all steps"],
+            "failure_modes": ["timeout"],
+            "max_steps": 10,
+            "actions": [
+                {"name": "step_a", "description": "First", "parameters": {}, "preconditions": [], "effects": ["a_done"]},
+                {"name": "step_b", "description": "Second", "parameters": {}, "preconditions": ["step_a"], "effects": ["b_done"]},
+            ],
+        }
+    )
 
     def llm_fn(system: str, user: str) -> str:
         return spec_json or default
@@ -148,31 +150,33 @@ class TestSimulationEngine:
     def test_tolerates_postconditions_in_llm_generated_actions(self, tmp_knowledge: Path) -> None:
         from autocontext.simulation.engine import SimulationEngine
 
-        spec_json = json.dumps({
-            "description": "Postconditions simulation",
-            "environment_description": "Test env",
-            "initial_state_description": "Start state",
-            "success_criteria": [{"condition": "complete", "description": "complete all steps"}],
-            "failure_modes": [{"condition": "timeout", "description": "run timed out"}],
-            "max_steps": 10,
-            "actions": [
-                {
-                    "name": "step_a",
-                    "description": "First",
-                    "parameters": {},
-                    "preconditions": [],
-                    "postconditions": ["a_done"],
-                    "steps": [{"action": "observe", "condition": "always"}],
-                },
-                {
-                    "name": "step_b",
-                    "description": "Second",
-                    "parameters": {},
-                    "preconditions": ["step_a"],
-                    "effects": ["b_done"],
-                },
-            ],
-        })
+        spec_json = json.dumps(
+            {
+                "description": "Postconditions simulation",
+                "environment_description": "Test env",
+                "initial_state_description": "Start state",
+                "success_criteria": [{"condition": "complete", "description": "complete all steps"}],
+                "failure_modes": [{"condition": "timeout", "description": "run timed out"}],
+                "max_steps": 10,
+                "actions": [
+                    {
+                        "name": "step_a",
+                        "description": "First",
+                        "parameters": {},
+                        "preconditions": [],
+                        "postconditions": ["a_done"],
+                        "steps": [{"action": "observe", "condition": "always"}],
+                    },
+                    {
+                        "name": "step_b",
+                        "description": "Second",
+                        "parameters": {},
+                        "preconditions": ["step_a"],
+                        "effects": ["b_done"],
+                    },
+                ],
+            }
+        )
 
         engine = SimulationEngine(llm_fn=_mock_llm_fn(spec_json), knowledge_root=tmp_knowledge)
         result = engine.run(description="Simulation with postconditions")
@@ -187,30 +191,32 @@ class TestSimulationEngine:
     def test_structured_preconditions_keep_action_dependencies(self, tmp_knowledge: Path) -> None:
         from autocontext.simulation.engine import SimulationEngine
 
-        spec_json = json.dumps({
-            "description": "Structured precondition simulation",
-            "environment_description": "Test env",
-            "initial_state_description": "Start state",
-            "success_criteria": ["complete all steps"],
-            "failure_modes": ["timeout"],
-            "max_steps": 10,
-            "actions": [
-                {
-                    "name": "step_a",
-                    "description": "First",
-                    "parameters": {},
-                    "preconditions": [],
-                    "effects": ["a_done"],
-                },
-                {
-                    "name": "step_b",
-                    "description": "Second",
-                    "parameters": {},
-                    "preconditions": [{"action": "step_a", "description": "after step a"}],
-                    "effects": ["b_done"],
-                },
-            ],
-        })
+        spec_json = json.dumps(
+            {
+                "description": "Structured precondition simulation",
+                "environment_description": "Test env",
+                "initial_state_description": "Start state",
+                "success_criteria": ["complete all steps"],
+                "failure_modes": ["timeout"],
+                "max_steps": 10,
+                "actions": [
+                    {
+                        "name": "step_a",
+                        "description": "First",
+                        "parameters": {},
+                        "preconditions": [],
+                        "effects": ["a_done"],
+                    },
+                    {
+                        "name": "step_b",
+                        "description": "Second",
+                        "parameters": {},
+                        "preconditions": [{"action": "step_a", "description": "after step a"}],
+                        "effects": ["b_done"],
+                    },
+                ],
+            }
+        )
 
         engine = SimulationEngine(llm_fn=_mock_llm_fn(spec_json), knowledge_root=tmp_knowledge)
         result = engine.run(description="Simulation with structured preconditions")
@@ -218,34 +224,79 @@ class TestSimulationEngine:
         assert result["status"] == "completed"
         assert result["summary"]["reasoning"] == "Completed 2 of 2 required actions."
 
+    def test_simulation_run_uses_family_designer_for_simulation_family(self, tmp_knowledge: Path) -> None:
+        from autocontext.scenarios.custom.simulation_designer import SIM_SPEC_END, SIM_SPEC_START
+        from autocontext.simulation.engine import SimulationEngine
+
+        simulation_spec = {
+            "description": "Geopolitical crisis simulation with doctrine-based escalation management.",
+            "environment_description": "NegotiationInterface plus WorldState across allied and adversary actors.",
+            "initial_state_description": "A maritime dispute is escalating under hidden information.",
+            "success_criteria": ["contain escalation", "preserve alliance coherence"],
+            "failure_modes": ["catastrophic escalation"],
+            "max_steps": 8,
+            "actions": [
+                {
+                    "name": "diplomatic_demarche",
+                    "description": "Deliver a formal warning to the adversary.",
+                    "parameters": {},
+                    "preconditions": [],
+                    "effects": ["warning_issued"],
+                },
+                {
+                    "name": "alliance_consultation",
+                    "description": "Coordinate with allies before coercive measures.",
+                    "parameters": {},
+                    "preconditions": ["diplomatic_demarche"],
+                    "effects": ["allies_aligned"],
+                },
+            ],
+        }
+        prompt_capture: dict[str, str] = {}
+
+        def simulation_llm(system: str, user: str) -> str:
+            prompt_capture["system"] = system
+            prompt_capture["user"] = user
+            return f"{SIM_SPEC_START}\n{json.dumps(simulation_spec)}\n{SIM_SPEC_END}"
+
+        engine = SimulationEngine(llm_fn=simulation_llm, knowledge_root=tmp_knowledge)
+        result = engine.run(description="Simulate a geopolitical crisis wargame with hidden adversary thresholds")
+
+        assert "SimulationSpec JSON wrapped in delimiters" in prompt_capture["system"]
+        assert result["family"] == "simulation"
+        assert result["status"] == "completed"
+        assert result["summary"]["reasoning"] == "Completed 2 of 2 required actions."
+
     def test_operator_loop_run_prefers_safe_autonomy_over_unnecessary_escalation(self, tmp_knowledge: Path) -> None:
         from autocontext.simulation.engine import SimulationEngine
 
-        operator_loop_spec = json.dumps({
-            "description": "Escalation-first deployment review with ambiguous prerequisites",
-            "environment_description": "A deployment requires human confirmation before release.",
-            "initial_state_description": "The rollout is blocked until the review is complete.",
-            "escalation_policy": {"escalation_threshold": "medium", "max_escalations": 5},
-            "success_criteria": ["review completed", "release approved safely"],
-            "failure_modes": ["unsafe autonomous release"],
-            "max_steps": 5,
-            "actions": [
-                {
-                    "name": "release_to_prod",
-                    "description": "Attempt production release",
-                    "parameters": {},
-                    "preconditions": ["operator_review_complete"],
-                    "effects": ["released"],
-                },
-                {
-                    "name": "operator_review_complete",
-                    "description": "Record operator review",
-                    "parameters": {},
-                    "preconditions": [],
-                    "effects": ["reviewed"],
-                },
-            ],
-        })
+        operator_loop_spec = json.dumps(
+            {
+                "description": "Escalation-first deployment review with ambiguous prerequisites",
+                "environment_description": "A deployment requires human confirmation before release.",
+                "initial_state_description": "The rollout is blocked until the review is complete.",
+                "escalation_policy": {"escalation_threshold": "medium", "max_escalations": 5},
+                "success_criteria": ["review completed", "release approved safely"],
+                "failure_modes": ["unsafe autonomous release"],
+                "max_steps": 5,
+                "actions": [
+                    {
+                        "name": "release_to_prod",
+                        "description": "Attempt production release",
+                        "parameters": {},
+                        "preconditions": ["operator_review_complete"],
+                        "effects": ["released"],
+                    },
+                    {
+                        "name": "operator_review_complete",
+                        "description": "Record operator review",
+                        "parameters": {},
+                        "preconditions": [],
+                        "effects": ["reviewed"],
+                    },
+                ],
+            }
+        )
 
         engine = SimulationEngine(llm_fn=_mock_llm_fn(operator_loop_spec), knowledge_root=tmp_knowledge)
         result = engine.run(description="Simulate an operator escalation for an ambiguous production release")
@@ -294,11 +345,7 @@ class TestSimulationEngine:
         def operator_loop_llm(system: str, user: str) -> str:
             prompt_capture["system"] = system
             prompt_capture["user"] = user
-            return (
-                f"{OPERATOR_LOOP_SPEC_START}\n"
-                f"{json.dumps(operator_loop_spec)}\n"
-                f"{OPERATOR_LOOP_SPEC_END}"
-            )
+            return f"{OPERATOR_LOOP_SPEC_START}\n{json.dumps(operator_loop_spec)}\n{OPERATOR_LOOP_SPEC_END}"
 
         engine = SimulationEngine(llm_fn=operator_loop_llm, knowledge_root=tmp_knowledge)
         result = engine.run(
@@ -353,10 +400,7 @@ class TestSimulationEngine:
 
         engine = SimulationEngine(llm_fn=operator_loop_llm, knowledge_root=tmp_knowledge)
         result = engine.run(
-            description=(
-                "simulate a support case that must escalate to a human operator "
-                "for clarification before responding"
-            )
+            description=("simulate a support case that must escalate to a human operator for clarification before responding")
         )
 
         assert result["family"] == "operator_loop"
@@ -471,10 +515,12 @@ class TestSimulateReplay:
         from autocontext.simulation.engine import SimulationEngine
 
         engine = SimulationEngine(llm_fn=_mock_llm_fn(), knowledge_root=tmp_knowledge)
-        results = iter([
-            _mock_operator_loop_result(score=0.9, escalations=1, clarifications=0),
-            _mock_operator_loop_result(score=0.8, escalations=0, clarifications=0),
-        ])
+        results = iter(
+            [
+                _mock_operator_loop_result(score=0.9, escalations=1, clarifications=0),
+                _mock_operator_loop_result(score=0.8, escalations=0, clarifications=0),
+            ]
+        )
         engine._execute_single = lambda source, name, seed, max_steps=None: next(results)  # type: ignore[method-assign]
 
         original = engine.run(


### PR DESCRIPTION
## Summary

- stabilize AC-577’s flaky Python `simulate` path for AC-276 by resolving simulation authoring through the dedicated simulation family designer before falling back to the generic JSON prompt
- add an internal Pi timeout floor for architect-role simulation spec generation so live stress simulations do not inherit the too-short default CLI timeout
- add regression coverage for both the simulation-family designer path and the simulate architect-runtime timeout floor

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run pytest tests/test_simulate_command.py tests/test_cli_simulate_runtime.py -k 'family_designer_for_simulation_family or raises_pi_timeout_floor_for_architect_runtime' -x --tb=short`
- [x] `cd autocontext && uv run pytest tests/test_simulate_command.py tests/test_cli_simulate_runtime.py tests/test_simulation_helpers.py tests/test_cli_json.py tests/test_cli_error_output.py -x --tb=short`
- [x] `cd autocontext && uv run ruff check src/autocontext/cli.py src/autocontext/simulation/engine.py tests/test_simulate_command.py tests/test_cli_simulate_runtime.py`
- [ ] `cd autocontext && uv run mypy src`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Additional verification:
- failing-first red checks against pre-fix AC-584 base commit `7cbee129`:
  - `/tmp/ac577-red-log-XXXXXX.txt`
    - representative red: simulation path still used the generic `"You are a simulation designer. Produce a simulation spec as JSON."` prompt instead of the family designer
  - `/tmp/ac577-red2-log-XXXXXX.txt`
    - representative red: `assert 300.0 == 600.0`
- fresh pre-fix live repro root on AC-577 branch before the fix:
  - `/tmp/ac577-repro-fMmhlQ`
  - result: `run-1` failed, `run-2` succeeded, `run-3` failed
- timeout-floor control on pre-fix code:
  - `/tmp/ac577-timeout600-vW9tT6`
  - result: `3 / 3` succeeded with `AUTOCONTEXT_PI_TIMEOUT=600`
- post-fix live validation root:
  - `/tmp/ac577-live-DWL9Bb`
  - result: `4 / 4` successful default-timeout live `autoctx simulate` runs for AC-276
  - representative success artifacts:
    - `/tmp/ac577-live-DWL9Bb/run-1/stdout.log`
    - `/tmp/ac577-live-DWL9Bb/run-1/knowledge/_simulations/harn/spec.json`
    - `/tmp/ac577-live-DWL9Bb/run-4/stdout.log`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- `SimulationEngine._build_spec(...)` now prefers `design_simulation(...)` for the simulation family, mirroring the existing family-aware operator-loop path and keeping simulation authoring inside the proper bounded context
- `cli._resolve_simulation_runtime(...)` now applies an internal Pi timeout floor of `600s` for architect-role simulation design, similar to other long-running live authoring flows
- the generic raw-JSON simulation prompt remains as a fallback if the family-specific designer fails, preserving backward compatibility for existing tests and non-delimited outputs
- this PR is stacked on top of AC-584 / PR #732
