### PR TITLE
feat(ac-580): LLM classifier fallback when no keyword signals matched

### DIFF
--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -360,7 +360,11 @@ def _resolve_solve_family_alias(description: str) -> ScenarioFamily | None:
     return None
 
 
-def _resolve_requested_scenario_family(description: str) -> ScenarioFamily:
+def _resolve_requested_scenario_family(
+    description: str,
+    *,
+    llm_fn: LlmFn | None = None,
+) -> ScenarioFamily:
     from autocontext.scenarios.custom.family_classifier import classify_scenario_family, route_to_family
 
     brief = _build_solve_description_brief(description)
@@ -372,7 +376,7 @@ def _resolve_requested_scenario_family(description: str) -> ScenarioFamily:
     if aliased_family is not None:
         return aliased_family
 
-    classification = classify_scenario_family(brief)
+    classification = classify_scenario_family(brief, llm_fn=llm_fn)
     return route_to_family(classification)
 
 
@@ -576,7 +580,7 @@ class SolveScenarioBuilder:
         if family_override:
             family = get_family(family_override)
         else:
-            family = _resolve_requested_scenario_family(brief)
+            family = _resolve_requested_scenario_family(brief, llm_fn=self._llm_fn)
 
         if family.name == "game":
             game_creator = ScenarioCreator(

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -90,7 +90,7 @@ class AgentTaskCreator:
         if family_name:
             family = get_family(family_name)
         else:
-            classification = classify_scenario_family(description)
+            classification = classify_scenario_family(description, llm_fn=self.llm_fn)
             family = route_to_family(classification)
         if family.name in FAMILY_CONFIGS:
             logger.info("routing description to %s creator", family.name)

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from autocontext.agents.types import LlmFn
 from autocontext.scenarios.families import ScenarioFamily, get_family, list_families
 
 logger = logging.getLogger(__name__)
@@ -454,14 +455,24 @@ def _build_rationale(matched: list[str], family_name: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def classify_scenario_family(description: str) -> FamilyClassification:
+def classify_scenario_family(
+    description: str,
+    *,
+    llm_fn: LlmFn | None = None,
+) -> FamilyClassification:
     """Classify a natural-language description into a scenario family.
 
     Returns a FamilyClassification with the top choice, confidence,
     rationale, and ranked alternatives.
 
+    When ``llm_fn`` is provided and the keyword classifier matches no signals,
+    a single structured LLM call is made to pick a family before returning the
+    keyword fallback (AC-580). If the LLM call fails for any reason, the
+    keyword fallback is returned unchanged.
+
     Raises ValueError if description is empty/whitespace.
     """
+    del llm_fn  # Parameter is accepted but unused in this task; wired in next.
     if not description or not description.strip():
         raise ValueError("description must be non-empty")
 

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -451,6 +451,85 @@ def _build_rationale(matched: list[str], family_name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# LLM fallback (AC-580)
+# ---------------------------------------------------------------------------
+
+
+_LLM_FALLBACK_SYSTEM_PROMPT = (
+    "You classify a natural-language scenario description into one of the "
+    "registered scenario families. Respond with a single JSON object on one line: "
+    '{{"family": "<name>", "confidence": <0.0-1.0>, "rationale": "<short explanation>"}}. '
+    "The family name MUST be one of: {family_list}. Do not invent new family names."
+)
+
+
+def _llm_classify_fallback(
+    description: str,
+    registered_families: list[str],
+    llm_fn: LlmFn,
+) -> FamilyClassification | None:
+    """Single structured LLM call to classify a description. Returns None on any failure."""
+    import json
+
+    family_list = ", ".join(registered_families)
+    system = _LLM_FALLBACK_SYSTEM_PROMPT.format(family_list=family_list)
+
+    try:
+        raw = llm_fn(system, description)
+    except Exception as exc:  # noqa: BLE001 - fallback must tolerate any provider failure
+        logger.warning("LLM classifier fallback failed: llm_fn raised %s", exc)
+        return None
+
+    json_start = raw.find("{")
+    json_end = raw.rfind("}")
+    if json_start == -1 or json_end == -1 or json_end <= json_start:
+        logger.warning("LLM classifier fallback failed: no JSON object in response")
+        return None
+
+    try:
+        payload = json.loads(raw[json_start : json_end + 1])
+    except json.JSONDecodeError as exc:
+        logger.warning("LLM classifier fallback failed: JSON decode error %s", exc)
+        return None
+
+    family = payload.get("family") if isinstance(payload, dict) else None
+    confidence = payload.get("confidence") if isinstance(payload, dict) else None
+    rationale = payload.get("rationale") if isinstance(payload, dict) else None
+
+    if not isinstance(family, str) or family not in registered_families:
+        logger.warning("LLM classifier fallback failed: family %r not registered", family)
+        return None
+    if not isinstance(rationale, str) or not rationale.strip():
+        logger.warning("LLM classifier fallback failed: missing rationale")
+        return None
+    try:
+        conf_value = float(confidence)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        logger.warning("LLM classifier fallback failed: confidence %r not numeric", confidence)
+        return None
+
+    clamped = max(0.0, min(1.0, conf_value))
+    logger.info("LLM classifier fallback: family=%s confidence=%.2f", family, clamped)
+
+    alternatives = [
+        FamilyCandidate(
+            family_name=other,
+            confidence=0.0,
+            rationale="LLM fallback selected a different family",
+        )
+        for other in registered_families
+        if other != family
+    ]
+    return FamilyClassification(
+        family_name=family,
+        confidence=round(clamped, 4),
+        rationale=rationale,
+        alternatives=alternatives,
+        no_signals_matched=False,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -472,7 +551,6 @@ def classify_scenario_family(
 
     Raises ValueError if description is empty/whitespace.
     """
-    del llm_fn  # Parameter is accepted but unused in this task; wired in next.
     if not description or not description.strip():
         raise ValueError("description must be non-empty")
 
@@ -490,6 +568,10 @@ def classify_scenario_family(
 
     total = sum(raw_scores.values())
     if total == 0:
+        if llm_fn is not None:
+            llm_result = _llm_classify_fallback(description, registered_families, llm_fn)
+            if llm_result is not None:
+                return llm_result
         # No signals matched — default to agent_task with low confidence if available.
         default_family = _DEFAULT_FAMILY_NAME if _DEFAULT_FAMILY_NAME in registered_families else registered_families[0]
         alternatives = [

--- a/autocontext/tests/test_llm_classifier_fallback.py
+++ b/autocontext/tests/test_llm_classifier_fallback.py
@@ -89,3 +89,40 @@ class TestLlmFallbackFailureModes:
         result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
         assert result.confidence == 1.0
         assert result.family_name == "simulation"
+
+
+class TestResolveRequestedScenarioFamilyThreadsLlmFn:
+    def test_resolve_requested_scenario_family_threads_llm_fn(self) -> None:
+        from unittest.mock import patch
+
+        from autocontext.knowledge import solver as solver_mod
+        from autocontext.scenarios.custom.family_classifier import FamilyClassification
+        from autocontext.scenarios.families import get_family
+
+        def stub_llm(system: str, user: str) -> str:
+            del system, user
+            return '{"family": "simulation", "confidence": 0.9, "rationale": "r"}'
+
+        captured: dict = {}
+
+        def fake_classify(description: str, *, llm_fn=None) -> FamilyClassification:
+            del description
+            captured["llm_fn"] = llm_fn
+            return FamilyClassification(
+                family_name="simulation",
+                confidence=0.9,
+                rationale="r",
+                no_signals_matched=False,
+            )
+
+        with patch.object(solver_mod, "_resolve_family_hint", return_value=None):
+            with patch(
+                "autocontext.scenarios.custom.family_classifier.classify_scenario_family",
+                side_effect=fake_classify,
+            ):
+                family = solver_mod._resolve_requested_scenario_family(
+                    "xyz zzz qqq", llm_fn=stub_llm
+                )
+
+        assert captured["llm_fn"] is stub_llm
+        assert family is get_family("simulation")

--- a/autocontext/tests/test_llm_classifier_fallback.py
+++ b/autocontext/tests/test_llm_classifier_fallback.py
@@ -40,3 +40,52 @@ class TestLlmFallbackHappyPath:
         assert result.confidence == 0.82
         assert result.rationale == "matches simulation pattern"
         assert result.no_signals_matched is False
+
+
+class TestLlmFallbackFailureModes:
+    """Any failure in the LLM path must fall through to the keyword fallback."""
+
+    def test_llm_fallback_unknown_family_falls_through(self) -> None:
+        def stub_llm(system: str, user: str) -> str:
+            del system, user
+            return '{"family": "bogus_family", "confidence": 0.9, "rationale": "r"}'
+
+        result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
+        assert result.no_signals_matched is True
+        assert result.family_name == "agent_task"
+
+    def test_llm_fallback_unparseable_json_falls_through(self) -> None:
+        def stub_llm(system: str, user: str) -> str:
+            del system, user
+            return "not json at all"
+
+        result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
+        assert result.no_signals_matched is True
+        assert result.family_name == "agent_task"
+
+    def test_llm_fallback_missing_rationale_falls_through(self) -> None:
+        def stub_llm(system: str, user: str) -> str:
+            del system, user
+            return '{"family": "simulation", "confidence": 0.9}'
+
+        result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
+        assert result.no_signals_matched is True
+        assert result.family_name == "agent_task"
+
+    def test_llm_fallback_llm_fn_raises_falls_through(self) -> None:
+        def stub_llm(system: str, user: str) -> str:
+            del system, user
+            raise RuntimeError("boom")
+
+        result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
+        assert result.no_signals_matched is True
+        assert result.family_name == "agent_task"
+
+    def test_llm_fallback_clamps_out_of_range_confidence(self) -> None:
+        def stub_llm(system: str, user: str) -> str:
+            del system, user
+            return '{"family": "simulation", "confidence": 1.5, "rationale": "overshoot"}'
+
+        result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
+        assert result.confidence == 1.0
+        assert result.family_name == "simulation"

--- a/autocontext/tests/test_llm_classifier_fallback.py
+++ b/autocontext/tests/test_llm_classifier_fallback.py
@@ -1,0 +1,26 @@
+"""AC-580 — LLM classifier fallback when no keyword signals matched."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from autocontext.scenarios.custom.family_classifier import classify_scenario_family
+
+
+class TestClassifyWithoutLlmFn:
+    def test_classify_without_llm_fn_preserves_keyword_only_behavior(self) -> None:
+        # Gibberish description → keyword fallback (no_signals_matched=True).
+        result = classify_scenario_family("xyz zzz qqq nonsense gibberish")
+        assert result.no_signals_matched is True
+        assert result.confidence == 0.2
+        assert result.family_name == "agent_task"
+
+    def test_classify_with_keyword_match_skips_llm_fn(self) -> None:
+        # When keywords match, llm_fn must not be invoked.
+        forbidden_llm = MagicMock(side_effect=AssertionError("must not be called"))
+        result = classify_scenario_family(
+            "Build a simulation of a deployment pipeline with rollback and failover",
+            llm_fn=forbidden_llm,
+        )
+        assert result.no_signals_matched is False
+        assert result.family_name == "simulation"
+        forbidden_llm.assert_not_called()

--- a/autocontext/tests/test_llm_classifier_fallback.py
+++ b/autocontext/tests/test_llm_classifier_fallback.py
@@ -24,3 +24,19 @@ class TestClassifyWithoutLlmFn:
         assert result.no_signals_matched is False
         assert result.family_name == "simulation"
         forbidden_llm.assert_not_called()
+
+
+class TestLlmFallbackHappyPath:
+    def test_llm_fallback_happy_path_returns_llm_family(self) -> None:
+        def stub_llm(system: str, user: str) -> str:
+            del system, user
+            return '{"family": "simulation", "confidence": 0.82, "rationale": "matches simulation pattern"}'
+
+        result = classify_scenario_family(
+            "xyz zzz qqq nonsense gibberish",
+            llm_fn=stub_llm,
+        )
+        assert result.family_name == "simulation"
+        assert result.confidence == 0.82
+        assert result.rationale == "matches simulation pattern"
+        assert result.no_signals_matched is False

--- a/autocontext/tests/test_solve_family_override.py
+++ b/autocontext/tests/test_solve_family_override.py
@@ -125,7 +125,10 @@ class TestSolveScenarioBuilderFamilyOverride:
             ):
                 result = builder.build("please classify me")
 
-        classifier_mock.assert_called_once_with("please classify me")
+        classifier_mock.assert_called_once()
+        args, kwargs = classifier_mock.call_args
+        assert args == ("please classify me",)
+        assert kwargs["llm_fn"]("", "") == ""
         assert result.family_name == "simulation"
 
 


### PR DESCRIPTION
## Summary
- When the keyword classifier returns \`no_signals_matched=True\` (total keyword score = 0), make one structured LLM call to classify the description into a registered family before returning the keyword fallback.
- Complements AC-571 (vocabulary expansion, #728) and AC-579 (\`--family\` override, #731). Together they form "level 1+2+3" of the long-term classifier sustainability plan. Caching (AC-581) and vocab mining (AC-582) are filed separately.

## Design
Spec: \`docs/superpowers/specs/2026-04-20-ac580-llm-classifier-fallback-design.md\` (local).

- \`classify_scenario_family\` gains a keyword-only \`llm_fn: LlmFn | None = None\` parameter. Default \`None\` preserves every existing caller unchanged.
- New \`_llm_classify_fallback(description, registered_families, llm_fn)\` helper: one call, JSON prompt contract \`{family, confidence, rationale}\`, validates family is registered, clamps confidence to \`[0, 1]\`, returns \`None\` on any failure.
- Inside \`classify_scenario_family\`, when \`total == 0\` and \`llm_fn\` is provided, the fallback fires before the keyword default. On \`None\` return, we fall through to the existing keyword fallback.
- Two caller sites updated to thread their \`llm_fn\` through:
  1. \`knowledge/solver.py::_resolve_requested_scenario_family\` (\`SolveScenarioBuilder.build\` passes \`self._llm_fn\`)
  2. \`scenarios/custom/agent_task_creator.py::AgentTaskCreator.create\` (passes \`self.llm_fn\`)

## Failure modes (all fall through to keyword fallback)
- \`llm_fn\` raises → logged, \`None\`
- Response has no JSON object → logged, \`None\`
- JSON decode error → logged, \`None\`
- Family not in registered list → logged, \`None\`
- Missing / non-string rationale → logged, \`None\`
- Non-numeric confidence → logged, \`None\`
- Out-of-range confidence → clamped to \`[0, 1]\`

## Observability
- INFO \`"LLM classifier fallback: family=%s confidence=%.2f"\` on success
- WARNING \`"LLM classifier fallback failed: %s"\` with the specific reason on failure
- LLM rationale stored verbatim in \`FamilyClassification.rationale\`

## Test Plan
- [x] \`uv run pytest autocontext/tests/test_llm_classifier_fallback.py\` — 9 new tests (regression no-op, keyword-skip, happy path, unknown family, unparseable JSON, missing rationale, exception, clamp, caller threading).
- [x] \`uv run pytest\` — **5434 passed, 54 skipped**.
- [x] \`uv run ruff check src tests\` — clean.
- [x] \`uv run mypy src\` — clean (451 files).

## Linked
- Linear: AC-580
- Related: AC-571 (#728 merged), AC-579 (#731 open), AC-581 / AC-582 (filed for caching + mining)