### PR TITLE
fix: preserve schema-evolution simulate routing

### DIFF
--- a/autocontext/src/autocontext/simulation/engine.py
+++ b/autocontext/src/autocontext/simulation/engine.py
@@ -20,8 +20,11 @@ from autocontext.agents.types import LlmFn
 from autocontext.simulation.helpers import (
     aggregate_contract_signal_counts,
     apply_behavioral_contract,
+    build_json_spec_prompt,
     design_structured_family_spec,
+    fallback_spec_for_family,
     find_scenario_class,
+    generate_source_for_family,
     infer_family,
 )
 from autocontext.util.json_io import read_json, write_json
@@ -305,13 +308,7 @@ class SimulationEngine:
         if structured_spec is not None:
             return structured_spec
 
-        system = (
-            f"You are a simulation designer. Produce a {family} spec as JSON.\n"
-            "Required: description, environment_description, initial_state_description, "
-            "success_criteria, failure_modes, max_steps, actions.\n"
-            "Output ONLY JSON."
-        )
-        text = self.llm_fn(system, f"Simulate: {description}")
+        text = self.llm_fn(build_json_spec_prompt(family), f"Simulate: {description}")
         try:
             trimmed = text.strip()
             start = trimmed.index("{")
@@ -322,15 +319,7 @@ class SimulationEngine:
         except (ValueError, json.JSONDecodeError):
             logger.debug("simulation.engine: suppressed ValueError, json.JSONDecodeError)", exc_info=True)
 
-        return {
-            "description": description,
-            "environment_description": "Simulated environment",
-            "initial_state_description": "Initial state",
-            "success_criteria": ["achieve objective"],
-            "failure_modes": ["timeout"],
-            "max_steps": 10,
-            "actions": [{"name": "act", "description": "Take action", "parameters": {}, "preconditions": [], "effects": []}],
-        }
+        return fallback_spec_for_family(description, family)
 
     def _normalize_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
         from autocontext.scenarios.custom.simulation_spec import normalize_simulation_spec_dict
@@ -338,36 +327,7 @@ class SimulationEngine:
         return normalize_simulation_spec_dict(spec)
 
     def _generate_source(self, spec: dict[str, Any], name: str, family: str) -> str:
-        if family == "operator_loop":
-            from autocontext.scenarios.custom.operator_loop_codegen import generate_operator_loop_class
-            from autocontext.scenarios.custom.operator_loop_spec import OperatorLoopSpec
-            from autocontext.scenarios.custom.simulation_spec import parse_simulation_actions
-
-            ol_spec = OperatorLoopSpec(
-                description=spec.get("description", ""),
-                environment_description=spec.get("environment_description", ""),
-                initial_state_description=spec.get("initial_state_description", ""),
-                escalation_policy=spec.get("escalation_policy", {"escalation_threshold": "medium", "max_escalations": 5}),
-                success_criteria=spec.get("success_criteria", []),
-                failure_modes=spec.get("failure_modes", []),
-                actions=parse_simulation_actions(spec.get("actions", [])),
-                max_steps=spec.get("max_steps", 10),
-            )
-            return generate_operator_loop_class(ol_spec, name)
-        else:
-            from autocontext.scenarios.custom.simulation_codegen import generate_simulation_class
-            from autocontext.scenarios.custom.simulation_spec import SimulationSpec, parse_simulation_actions
-
-            sim_spec = SimulationSpec(
-                description=spec.get("description", ""),
-                environment_description=spec.get("environment_description", ""),
-                initial_state_description=spec.get("initial_state_description", ""),
-                success_criteria=spec.get("success_criteria", []),
-                failure_modes=spec.get("failure_modes", []),
-                actions=parse_simulation_actions(spec.get("actions", [])),
-                max_steps=spec.get("max_steps", 10),
-            )
-            return generate_simulation_class(sim_spec, name)
+        return generate_source_for_family(spec, name, family)
 
     def _persist(
         self,

--- a/autocontext/src/autocontext/simulation/helpers.py
+++ b/autocontext/src/autocontext/simulation/helpers.py
@@ -73,7 +73,9 @@ def infer_family(description: str) -> str:
         family = route_to_family(classify_scenario_family(description), 0.15).name
         if family == "operator_loop" and _STATECRAFT_SIMULATION_CONTEXT.search(text_lower):
             return "simulation"
-        return "operator_loop" if family == "operator_loop" else "simulation"
+        if family in {"operator_loop", "schema_evolution"}:
+            return family
+        return "simulation"
     except Exception:
         return "simulation"
 
@@ -92,6 +94,17 @@ def design_structured_family_spec(description: str, family: str, llm_fn: LlmFn) 
             if isinstance(plain, dict):
                 return cast(dict[str, Any], plain)
 
+    if family == "schema_evolution":
+        from autocontext.scenarios.custom.schema_evolution_designer import design_schema_evolution
+
+        try:
+            plain = spec_to_plain_data(design_schema_evolution(description, llm_fn))
+        except Exception:
+            logger.debug("simulation.helpers: schema_evolution designer fallback", exc_info=True)
+        else:
+            if isinstance(plain, dict):
+                return cast(dict[str, Any], plain)
+
     if family == "simulation":
         from autocontext.scenarios.custom.simulation_designer import design_simulation
 
@@ -104,6 +117,135 @@ def design_structured_family_spec(description: str, family: str, llm_fn: LlmFn) 
                 return cast(dict[str, Any], plain)
 
     return None
+
+
+def build_json_spec_prompt(family: str) -> str:
+    if family == "schema_evolution":
+        return (
+            "You are a schema-evolution designer. Produce a schema_evolution spec as JSON.\n"
+            "Required: description, environment_description, initial_state_description, mutations, "
+            "success_criteria, failure_modes, max_steps, actions.\n"
+            "Output ONLY JSON."
+        )
+
+    return (
+        f"You are a simulation designer. Produce a {family} spec as JSON.\n"
+        "Required: description, environment_description, initial_state_description, "
+        "success_criteria, failure_modes, max_steps, actions.\n"
+        "Output ONLY JSON."
+    )
+
+
+def fallback_spec_for_family(description: str, family: str) -> dict[str, Any]:
+    if family == "schema_evolution":
+        return {
+            "description": description,
+            "environment_description": "Versioned system with evolving schema.",
+            "initial_state_description": "Schema v1 is active.",
+            "mutations": [
+                {
+                    "version": 2,
+                    "description": "Add a new required field.",
+                    "breaking": True,
+                    "fields_added": ["new_field"],
+                    "fields_removed": [],
+                    "fields_modified": {},
+                }
+            ],
+            "success_criteria": ["detect schema change", "adapt to new version"],
+            "failure_modes": ["stale assumptions after mutation"],
+            "max_steps": 10,
+            "actions": [
+                {
+                    "name": "observe_schema",
+                    "description": "Observe the current schema.",
+                    "parameters": {},
+                    "preconditions": [],
+                    "effects": ["schema_observed"],
+                },
+                {
+                    "name": "adapt_to_mutation",
+                    "description": "Adapt once the schema changes.",
+                    "parameters": {},
+                    "preconditions": ["observe_schema"],
+                    "effects": ["schema_adapted"],
+                },
+            ],
+        }
+
+    return {
+        "description": description,
+        "environment_description": "Simulated environment",
+        "initial_state_description": "Initial state",
+        "success_criteria": ["achieve objective"],
+        "failure_modes": ["timeout"],
+        "max_steps": 10,
+        "actions": [{"name": "act", "description": "Take action", "parameters": {}, "preconditions": [], "effects": []}],
+    }
+
+
+def generate_source_for_family(spec: dict[str, Any], name: str, family: str) -> str:
+    from autocontext.scenarios.custom.simulation_spec import parse_simulation_actions
+
+    if family == "operator_loop":
+        from autocontext.scenarios.custom.operator_loop_codegen import generate_operator_loop_class
+        from autocontext.scenarios.custom.operator_loop_spec import OperatorLoopSpec
+
+        ol_spec = OperatorLoopSpec(
+            description=spec.get("description", ""),
+            environment_description=spec.get("environment_description", ""),
+            initial_state_description=spec.get("initial_state_description", ""),
+            escalation_policy=spec.get("escalation_policy", {"escalation_threshold": "medium", "max_escalations": 5}),
+            success_criteria=spec.get("success_criteria", []),
+            failure_modes=spec.get("failure_modes", []),
+            actions=parse_simulation_actions(spec.get("actions", [])),
+            max_steps=spec.get("max_steps", 10),
+        )
+        return generate_operator_loop_class(ol_spec, name)
+
+    if family == "schema_evolution":
+        from autocontext.scenarios.custom.schema_evolution_codegen import generate_schema_evolution_class
+        from autocontext.scenarios.custom.schema_evolution_spec import (
+            SchemaEvolutionMutationModel,
+            SchemaEvolutionSpec,
+        )
+
+        schema_spec = SchemaEvolutionSpec(
+            description=spec.get("description", ""),
+            environment_description=spec.get("environment_description", ""),
+            initial_state_description=spec.get("initial_state_description", ""),
+            mutations=[
+                SchemaEvolutionMutationModel(
+                    version=int(mutation.get("version", 1)),
+                    description=str(mutation.get("description", "")),
+                    breaking=bool(mutation.get("breaking", False)),
+                    fields_added=list(mutation.get("fields_added", [])),
+                    fields_removed=list(mutation.get("fields_removed", [])),
+                    fields_modified=dict(mutation.get("fields_modified", {})),
+                )
+                for mutation in spec.get("mutations", [])
+                if isinstance(mutation, dict)
+            ],
+            success_criteria=spec.get("success_criteria", []),
+            failure_modes=spec.get("failure_modes", []),
+            actions=parse_simulation_actions(spec.get("actions", [])),
+            max_steps=spec.get("max_steps", 10),
+        )
+        return generate_schema_evolution_class(schema_spec, name)
+
+    from autocontext.scenarios.custom.simulation_codegen import generate_simulation_class
+    from autocontext.scenarios.custom.simulation_spec import SimulationSpec
+
+    sim_spec = SimulationSpec(
+        description=spec.get("description", ""),
+        environment_description=spec.get("environment_description", ""),
+        initial_state_description=spec.get("initial_state_description", ""),
+        success_criteria=spec.get("success_criteria", []),
+        failure_modes=spec.get("failure_modes", []),
+        actions=parse_simulation_actions(spec.get("actions", [])),
+        max_steps=spec.get("max_steps", 10),
+    )
+    return generate_simulation_class(sim_spec, name)
 
 
 def aggregate_contract_signal_counts(results: list[dict[str, Any]]) -> dict[str, int]:

--- a/autocontext/tests/test_simulate_command.py
+++ b/autocontext/tests/test_simulate_command.py
@@ -267,6 +267,67 @@ class TestSimulationEngine:
         assert result["status"] == "completed"
         assert result["summary"]["reasoning"] == "Completed 2 of 2 required actions."
 
+    def test_simulation_run_uses_schema_evolution_designer_for_schema_evolution_family(self, tmp_knowledge: Path) -> None:
+        from autocontext.scenarios.custom.schema_evolution_designer import (
+            SCHEMA_EVOLUTION_SPEC_END,
+            SCHEMA_EVOLUTION_SPEC_START,
+        )
+        from autocontext.simulation.engine import SimulationEngine
+
+        schema_evolution_spec = {
+            "description": "Portfolio adapts across breaking macro regime mutations.",
+            "environment_description": "SchemaEvolutionInterface plus WorldState for portfolio construction.",
+            "initial_state_description": "Low-vol regime with bond hedge assumptions still valid.",
+            "mutations": [
+                {
+                    "version": 2,
+                    "description": "Rate-hike regime flips stock-bond correlation.",
+                    "breaking": True,
+                    "fields_added": ["real_yield"],
+                    "fields_removed": ["bond_hedge_assumption"],
+                    "fields_modified": {"regime_assessment": "string -> object"},
+                }
+            ],
+            "success_criteria": ["detect mutation", "adapt allocation"],
+            "failure_modes": ["stale hedging assumptions"],
+            "max_steps": 6,
+            "actions": [
+                {
+                    "name": "observe_market_state",
+                    "description": "Observe the current market schema.",
+                    "parameters": {},
+                    "preconditions": [],
+                    "effects": ["schema_observed"],
+                },
+                {
+                    "name": "detect_schema_mutation",
+                    "description": "Detect whether the regime schema changed.",
+                    "parameters": {},
+                    "preconditions": ["observe_market_state"],
+                    "effects": ["mutation_detected"],
+                },
+            ],
+        }
+        prompt_capture: dict[str, str] = {}
+
+        def schema_evolution_llm(system: str, user: str) -> str:
+            prompt_capture["system"] = system
+            prompt_capture["user"] = user
+            return f"{SCHEMA_EVOLUTION_SPEC_START}\n{json.dumps(schema_evolution_spec)}\n{SCHEMA_EVOLUTION_SPEC_END}"
+
+        engine = SimulationEngine(llm_fn=schema_evolution_llm, knowledge_root=tmp_knowledge)
+        result = engine.run(
+            description=(
+                "Simulate portfolio construction under regime change where SchemaEvolutionInterface and "
+                "SchemaMutation drive adaptation across rate-hike and crisis regimes"
+            )
+        )
+
+        assert "SchemaEvolutionSpec JSON wrapped in delimiters" in prompt_capture["system"]
+        assert result["family"] == "schema_evolution"
+        assert result["status"] == "completed"
+        assert result["summary"]["reasoning"] == "Detected 0/0 stale assumptions."
+
     def test_operator_loop_run_prefers_safe_autonomy_over_unnecessary_escalation(self, tmp_knowledge: Path) -> None:
         from autocontext.simulation.engine import SimulationEngine
 

--- a/autocontext/tests/test_simulation_helpers.py
+++ b/autocontext/tests/test_simulation_helpers.py
@@ -26,17 +26,24 @@ class TestInferFamily:
 
     def test_routes_compact_geopolitical_wargame_with_escalation_terms_to_simulation(self) -> None:
         family = infer_family(
-            "Build a geopolitical crisis wargame with ambiguous military movements "
-            "and over-escalation dynamics"
+            "Build a geopolitical crisis wargame with ambiguous military movements and over-escalation dynamics"
         )
         assert family == "simulation"
 
     def test_routes_statecraft_when_to_escalate_prompt_to_simulation(self) -> None:
         family = infer_family(
-            "Simulate when to escalate diplomatic pressure during an international crisis "
-            "with national security tradeoffs"
+            "Simulate when to escalate diplomatic pressure during an international crisis with national security tradeoffs"
         )
         assert family == "simulation"
+
+    def test_routes_ac277_regime_change_prompt_to_schema_evolution(self) -> None:
+        family = infer_family(
+            "Harness Stress Test: portfolio construction under regime change — quantitative adaptation "
+            "with schema evolution. Use SchemaEvolutionInterface + WorldState with mid-run "
+            "SchemaMutation events so the agent must discard stale assumptions about bonds hedging "
+            "equities and adapt allocations across low-vol, rising-rate, and crisis regimes."
+        )
+        assert family == "schema_evolution"
 
     def test_keeps_explicit_operator_loop_prompts_on_operator_loop(self) -> None:
         family = infer_family(


### PR DESCRIPTION
## Summary

- preserve AC-277’s intended `schema_evolution` family on the Python `simulate` path instead of collapsing it into generic `simulation`
- add schema-evolution family support to `SimulationEngine` spec generation and source generation so simulate can materialize `SchemaEvolutionInterface` scenarios directly
- add regression coverage for AC-277 family inference and schema-evolution designer usage in the simulate engine

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run pytest tests/test_simulation_helpers.py tests/test_simulate_command.py -k 'ac277_regime_change_prompt_to_schema_evolution or schema_evolution_designer_for_schema_evolution_family' -x --tb=short`
- [x] `cd autocontext && uv run pytest tests/test_simulation_helpers.py tests/test_simulate_command.py tests/test_schema_evolution_tool_fragility.py tests/test_cli_simulate_runtime.py tests/test_cli_json.py tests/test_cli_error_output.py -x --tb=short`
- [x] `cd autocontext && uv run ruff check src/autocontext/simulation/helpers.py src/autocontext/simulation/engine.py tests/test_simulation_helpers.py tests/test_simulate_command.py`
- [ ] `cd autocontext && uv run mypy src`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Additional verification:
- failing-first red check against the stacked AC-577 base commit `36f23e8f` with the new regression tests copied in:
  - `/tmp/ac578-red-log-XXXXXX.txt`
  - representative red: `assert 'simulation' == 'schema_evolution'`
- fresh pre-fix live validation on the AC-577 base before this PR:
  - `/tmp/ac578-repro-1rs31c`
  - result: `3 / 3` runs completed, but AC-277 still materialized as `family: "simulation"` instead of the scenario’s intended schema-evolution family
- post-fix live validation root:
  - `/tmp/ac578-live-DlAxRk`
  - result: `4 / 4` successful default-timeout live `autoctx simulate` runs for AC-277
  - representative artifacts:
    - `/tmp/ac578-live-DlAxRk/run-1/stdout.log`
    - `/tmp/ac578-live-DlAxRk/run-1/knowledge/_simulations/harn/spec.json`
    - `/tmp/ac578-live-DlAxRk/run-1/knowledge/_simulations/harn/scenario_type.txt`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- by the time AC-578 was taken on top of AC-577, the strict timeout symptom no longer reproduced in fresh live reruns; the stacked AC-577 runtime work had already mitigated that part of the failure surface
- this PR closes the remaining domain-fidelity gap for the same AC-277 prompt by preserving `schema_evolution` instead of flattening it to generic `simulation`
- `SimulationEngine` now has explicit schema-evolution design/codegen support, while still preserving the generic simulation fallback for other families
- this PR is stacked on top of AC-577 / PR #734
