### PR TITLE
chore: add release-validation escalation sweep harness

### DIFF
--- a/autocontext/src/autocontext/cli_solve.py
+++ b/autocontext/src/autocontext/cli_solve.py
@@ -52,6 +52,7 @@ class SolveRunSummary:
     generations: int
     progress: int
     output_path: str | None
+    llm_classifier_fallback_used: bool
     result: dict[str, Any] | None
 
 
@@ -131,6 +132,7 @@ def run_solve_command(
         generations=job.generations,
         progress=job.progress,
         output_path=output_path,
+        llm_classifier_fallback_used=job.llm_classifier_fallback_used,
         result=job.result.to_dict(),
     )
 
@@ -146,6 +148,10 @@ def run_solve_command(
     table.add_row("Scenario", job.scenario_name or "unknown")
     table.add_row("Generations", str(job.generations))
     table.add_row("Progress", str(job.progress))
+    table.add_row(
+        "LLM Fallback",
+        "yes" if job.llm_classifier_fallback_used else "no",
+    )
     if output_path is not None:
         table.add_row("Output", output_path)
     console.print(table)

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -77,12 +77,20 @@ class SolveJob:
     result: SkillPackage | None = None
     created_at: float = field(default_factory=time.time)
     family_override: str | None = None
+    llm_classifier_fallback_used: bool = False
 
 
 @dataclass(slots=True)
 class SolveScenarioBuildResult:
     scenario_name: str
     family_name: str
+    llm_classifier_fallback_used: bool = False
+
+
+@dataclass(slots=True)
+class _ResolvedSolveFamily:
+    family: ScenarioFamily
+    llm_classifier_fallback_used: bool = False
 
 
 @dataclass(slots=True)
@@ -365,19 +373,30 @@ def _resolve_requested_scenario_family(
     *,
     llm_fn: LlmFn | None = None,
 ) -> ScenarioFamily:
+    return _resolve_requested_scenario_family_with_metadata(description, llm_fn=llm_fn).family
+
+
+def _resolve_requested_scenario_family_with_metadata(
+    description: str,
+    *,
+    llm_fn: LlmFn | None = None,
+) -> _ResolvedSolveFamily:
     from autocontext.scenarios.custom.family_classifier import classify_scenario_family, route_to_family
 
     brief = _build_solve_description_brief(description)
     hinted_family = _resolve_family_hint(brief)
     if hinted_family is not None:
-        return hinted_family
+        return _ResolvedSolveFamily(family=hinted_family)
 
     aliased_family = _resolve_solve_family_alias(brief)
     if aliased_family is not None:
-        return aliased_family
+        return _ResolvedSolveFamily(family=aliased_family)
 
     classification = classify_scenario_family(brief, llm_fn=llm_fn)
-    return route_to_family(classification)
+    return _ResolvedSolveFamily(
+        family=route_to_family(classification),
+        llm_classifier_fallback_used=classification.llm_fallback_used,
+    )
 
 
 class SolveScenarioExecutor:
@@ -579,8 +598,11 @@ class SolveScenarioBuilder:
         brief = _build_solve_description_brief(description)
         if family_override:
             family = get_family(family_override)
+            llm_classifier_fallback_used = False
         else:
-            family = _resolve_requested_scenario_family(brief, llm_fn=self._llm_fn)
+            resolved_family = _resolve_requested_scenario_family_with_metadata(brief, llm_fn=self._llm_fn)
+            family = resolved_family.family
+            llm_classifier_fallback_used = resolved_family.llm_classifier_fallback_used
 
         if family.name == "game":
             game_creator = ScenarioCreator(
@@ -594,6 +616,7 @@ class SolveScenarioBuilder:
             return SolveScenarioBuildResult(
                 scenario_name=spec.name,
                 family_name=family.name,
+                llm_classifier_fallback_used=llm_classifier_fallback_used,
             )
 
         family_creator = AgentTaskCreator(
@@ -606,6 +629,7 @@ class SolveScenarioBuilder:
         return SolveScenarioBuildResult(
             scenario_name=scenario_name,
             family_name=family.name,
+            llm_classifier_fallback_used=llm_classifier_fallback_used,
         )
 
 
@@ -682,6 +706,7 @@ class SolveManager:
 
             created = builder.build(job.description, family_override=job.family_override)
             job.scenario_name = created.scenario_name
+            job.llm_classifier_fallback_used = created.llm_classifier_fallback_used
 
             # 2. Run generations
             job.status = "running"
@@ -737,6 +762,7 @@ class SolveManager:
             "progress": job.progress,
             "error": job.error,
             "created_at": job.created_at,
+            "llm_classifier_fallback_used": job.llm_classifier_fallback_used,
         }
 
     def get_result(self, job_id: str) -> SkillPackage | None:

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -41,6 +41,7 @@ class FamilyClassification(BaseModel):
     rationale: str
     alternatives: list[FamilyCandidate] = Field(default_factory=list)
     no_signals_matched: bool = False
+    llm_fallback_used: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return self.model_dump()
@@ -526,6 +527,7 @@ def _llm_classify_fallback(
         rationale=rationale,
         alternatives=alternatives,
         no_signals_matched=False,
+        llm_fallback_used=True,
     )
 
 

--- a/autocontext/tests/test_cli_solve_runtime.py
+++ b/autocontext/tests/test_cli_solve_runtime.py
@@ -69,6 +69,40 @@ class _FailingSolveManager:
         )
 
 
+class _FallbackSolveManager:
+    def __init__(self, settings: AppSettings) -> None:
+        self._settings = settings
+
+    def solve_sync(
+        self,
+        description: str,
+        generations: int = 5,
+        family_override: str | None = None,
+    ) -> SolveJob:
+        del description, generations, family_override
+        pkg = SkillPackage(
+            scenario_name="fallback_case",
+            display_name="Fallback Case",
+            description="Solve result",
+            playbook="## Playbook",
+            lessons=["Ask the classifier for help"],
+            best_strategy={"aggression": 0.4},
+            best_score=0.74,
+            best_elo=1498.0,
+            hints="Use the fallback metadata",
+        )
+        return SolveJob(
+            job_id="solve_fallback",
+            description="Fallback solve",
+            scenario_name="fallback_case",
+            status="completed",
+            generations=1,
+            progress=1,
+            result=pkg,
+            llm_classifier_fallback_used=True,
+        )
+
+
 def _settings(tmp_path: Path, **overrides: object) -> AppSettings:
     return AppSettings(
         db_path=tmp_path / "runs" / "autocontext.sqlite3",
@@ -162,3 +196,27 @@ class TestSolveRuntimeOverrides:
         assert "timed out" in payload["error"].lower()
         assert "--timeout" in payload["error"]
         assert "AUTOCONTEXT_PI_TIMEOUT" in payload["error"]
+
+    def test_solve_json_output_surfaces_classifier_fallback_flag(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+
+        from unittest.mock import patch
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.knowledge.solver.SolveManager", _FallbackSolveManager),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "solve",
+                    "--description",
+                    "Fallback solve",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["llm_classifier_fallback_used"] is True
+        assert payload["scenario_name"] == "fallback_case"

--- a/autocontext/tests/test_escalation_sweep_summary.py
+++ b/autocontext/tests/test_escalation_sweep_summary.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_summary_module():
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "escalation-sweep" / "summarize.py"
+    spec = importlib.util.spec_from_file_location("escalation_sweep_summarize", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_summarize_tallies_llm_classifier_fallback_from_structured_solve_output(tmp_path: Path, capsys) -> None:
+    summary_mod = _load_summary_module()
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+
+    (results_dir / "index.json").write_text(json.dumps(["ac580"]), encoding="utf-8")
+    (results_dir / "ac580.meta.json").write_text(
+        json.dumps(
+            {
+                "identifier": "ac580",
+                "exit_code": 0,
+                "elapsed_seconds": 12,
+                "workspace_root": str(tmp_path / "workspaces" / "ac580"),
+            }
+        ),
+        encoding="utf-8",
+    )
+    (results_dir / "ac580.out.json").write_text(
+        json.dumps(
+            {
+                "job_id": "solve_ac580",
+                "status": "completed",
+                "description": "Fallback solve",
+                "scenario_name": "fallback_case",
+                "generations": 1,
+                "progress": 1,
+                "output_path": None,
+                "llm_classifier_fallback_used": True,
+                "result": {"scenario_name": "fallback_case"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = summary_mod.main(["summarize.py", str(results_dir)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "llm_fallback_fired" in captured.out
+
+    payload = json.loads((results_dir / "summary.json").read_text(encoding="utf-8"))
+    assert payload["rows"][0]["bucket"] == "llm_fallback_fired"
+    assert payload["buckets"]["llm_fallback_fired"] == 1

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -290,6 +290,40 @@ class TestSolveScenarioBuilder:
 
         assert captured["family_name"] == "coordination"
         assert result.family_name == "coordination"
+        assert result.llm_classifier_fallback_used is False
+
+    def test_build_marks_llm_classifier_fallback_usage(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from autocontext.knowledge.solver import SolveScenarioBuilder
+
+        def _llm_fallback(system: str, user: str) -> str:
+            del system, user
+            return '{"family": "simulation", "confidence": 0.82, "rationale": "fallback classified the scenario"}'
+
+        runtime = SubagentRuntime(DeterministicDevClient())
+        builder = SolveScenarioBuilder(
+            runtime=runtime,
+            llm_fn=_llm_fallback,
+            model="test-model",
+            knowledge_root=tmp_path,
+        )
+
+        class _CreatedScenario:
+            name = "llm_fallback_simulation_fixture"
+
+        def _fake_create(self, description: str, *, family_name: str = "") -> _CreatedScenario:
+            del self, description
+            assert family_name == "simulation"
+            return _CreatedScenario()
+
+        monkeypatch.setattr(
+            "autocontext.scenarios.custom.agent_task_creator.AgentTaskCreator.create",
+            _fake_create,
+        )
+
+        result = builder.build("xyz zzz qqq nonsense gibberish")
+
+        assert result.family_name == "simulation"
+        assert result.llm_classifier_fallback_used is True
 
     def test_resolves_simulationinterface_harness_prompt_to_simulation(self) -> None:
         from autocontext.knowledge.solver import _resolve_requested_scenario_family

--- a/autocontext/tests/test_llm_classifier_fallback.py
+++ b/autocontext/tests/test_llm_classifier_fallback.py
@@ -11,6 +11,7 @@ class TestClassifyWithoutLlmFn:
         # Gibberish description → keyword fallback (no_signals_matched=True).
         result = classify_scenario_family("xyz zzz qqq nonsense gibberish")
         assert result.no_signals_matched is True
+        assert result.llm_fallback_used is False
         assert result.confidence == 0.2
         assert result.family_name == "agent_task"
 
@@ -22,6 +23,7 @@ class TestClassifyWithoutLlmFn:
             llm_fn=forbidden_llm,
         )
         assert result.no_signals_matched is False
+        assert result.llm_fallback_used is False
         assert result.family_name == "simulation"
         forbidden_llm.assert_not_called()
 
@@ -40,6 +42,7 @@ class TestLlmFallbackHappyPath:
         assert result.confidence == 0.82
         assert result.rationale == "matches simulation pattern"
         assert result.no_signals_matched is False
+        assert result.llm_fallback_used is True
 
 
 class TestLlmFallbackFailureModes:
@@ -52,6 +55,7 @@ class TestLlmFallbackFailureModes:
 
         result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
         assert result.no_signals_matched is True
+        assert result.llm_fallback_used is False
         assert result.family_name == "agent_task"
 
     def test_llm_fallback_unparseable_json_falls_through(self) -> None:
@@ -61,6 +65,7 @@ class TestLlmFallbackFailureModes:
 
         result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
         assert result.no_signals_matched is True
+        assert result.llm_fallback_used is False
         assert result.family_name == "agent_task"
 
     def test_llm_fallback_missing_rationale_falls_through(self) -> None:
@@ -70,6 +75,7 @@ class TestLlmFallbackFailureModes:
 
         result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
         assert result.no_signals_matched is True
+        assert result.llm_fallback_used is False
         assert result.family_name == "agent_task"
 
     def test_llm_fallback_llm_fn_raises_falls_through(self) -> None:
@@ -79,6 +85,7 @@ class TestLlmFallbackFailureModes:
 
         result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
         assert result.no_signals_matched is True
+        assert result.llm_fallback_used is False
         assert result.family_name == "agent_task"
 
     def test_llm_fallback_clamps_out_of_range_confidence(self) -> None:
@@ -88,6 +95,7 @@ class TestLlmFallbackFailureModes:
 
         result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
         assert result.confidence == 1.0
+        assert result.llm_fallback_used is True
         assert result.family_name == "simulation"
 
 

--- a/autocontext/tests/test_solve_family_override.py
+++ b/autocontext/tests/test_solve_family_override.py
@@ -116,9 +116,14 @@ class TestSolveScenarioBuilderFamilyOverride:
         fake_scenario = MagicMock()
         fake_scenario.name = "stub_scenario"
 
-        classifier_mock = MagicMock(return_value=get_family("simulation"))
+        classifier_mock = MagicMock(
+            return_value=solver_mod._ResolvedSolveFamily(
+                family=get_family("simulation"),
+                llm_classifier_fallback_used=False,
+            )
+        )
 
-        with patch.object(solver_mod, "_resolve_requested_scenario_family", classifier_mock):
+        with patch.object(solver_mod, "_resolve_requested_scenario_family_with_metadata", classifier_mock):
             with patch(
                 "autocontext.scenarios.custom.agent_task_creator.AgentTaskCreator.create",
                 return_value=fake_scenario,

--- a/scripts/escalation-sweep/README.md
+++ b/scripts/escalation-sweep/README.md
@@ -8,7 +8,10 @@ Release-validation helper: run every "Scenarios"-state Linear issue through
 - `jq` and Python 3.11+ on PATH.
 - `autoctx` CLI installed (either a published release `pip install autocontext==0.4.4`
   or run the checked-out source via `cd autocontext && uv run autoctx ...`).
-- `ANTHROPIC_API_KEY` (or the provider-specific equivalent) exported.
+- An agent provider. By default the harness uses `AUTOCONTEXT_AGENT_PROVIDER=claude-cli`,
+  which invokes the locally-authenticated `claude` binary (Anthropic subscription) — no
+  API key needed. Override with `AUTOCONTEXT_AGENT_PROVIDER=anthropic` (+ `ANTHROPIC_API_KEY`),
+  `agent_sdk`, `pi`, etc. if you want to exercise a different path.
 - Linear API key either in `$LINEAR_API_KEY` or at
   `~/.config/linear/credentials.toml` under a `greyhaven = "<key>"` entry.
 

--- a/scripts/escalation-sweep/README.md
+++ b/scripts/escalation-sweep/README.md
@@ -31,8 +31,12 @@ bash scripts/escalation-sweep/run_sweep.sh \
 python scripts/escalation-sweep/summarize.py .sweep/0.4.4/results
 ```
 
-Expect ~5-10 min per scenario. Runs serially by design (autocontext shares a
-sqlite store).
+Expect ~5-10 min per scenario. Runs serially by design.
+
+Each scenario runs inside its own isolated workspace under
+`.sweep/<release>/workspaces/<identifier>/`, with dedicated database, runs,
+knowledge, and skills roots. The summarized solve JSON stays in
+`.sweep/<release>/results/`.
 
 ## Failure buckets
 
@@ -54,4 +58,7 @@ Successes are split into:
 | `success`            | Completed via the keyword classifier path           |
 | `llm_fallback_fired` | Succeeded, AC-580 LLM fallback classified the family |
 
-Artifacts persist in `.sweep/<release>/results/` for follow-up diagnosis.
+Artifacts persist in:
+
+- `.sweep/<release>/results/` for per-scenario solve output, metadata, and summary
+- `.sweep/<release>/workspaces/<identifier>/` for the isolated run workspace used by that scenario

--- a/scripts/escalation-sweep/README.md
+++ b/scripts/escalation-sweep/README.md
@@ -1,0 +1,54 @@
+# Escalation Sweep Harness
+
+Release-validation helper: run every "Scenarios"-state Linear issue through
+`autoctx solve` and classify failures into known buckets.
+
+## Prerequisites
+
+- `jq` and Python 3.11+ on PATH.
+- `autoctx` CLI installed (either a published release `pip install autocontext==0.4.4`
+  or run the checked-out source via `cd autocontext && uv run autoctx ...`).
+- `ANTHROPIC_API_KEY` (or the provider-specific equivalent) exported.
+- Linear API key either in `$LINEAR_API_KEY` or at
+  `~/.config/linear/credentials.toml` under a `greyhaven = "<key>"` entry.
+
+## Usage
+
+```bash
+# 1. Fetch the current manifest of scenarios in the "Scenarios" workflow state.
+python scripts/escalation-sweep/fetch_manifest.py .sweep/0.4.4/manifest.json
+
+# 2. Run the sweep. One solve per scenario, 2 generations each by default.
+bash scripts/escalation-sweep/run_sweep.sh \
+    .sweep/0.4.4/manifest.json \
+    .sweep/0.4.4/results \
+    --gens 2 --timeout 600
+
+# 3. Classify + tally.
+python scripts/escalation-sweep/summarize.py .sweep/0.4.4/results
+```
+
+Expect ~5-10 min per scenario. Runs serially by design (autocontext shares a
+sqlite store).
+
+## Failure buckets
+
+The summarizer groups non-zero exits into:
+
+| Bucket                         | Meaning                                                  |
+| ------------------------------ | -------------------------------------------------------- |
+| `classifier_low_confidence`    | `LowConfidenceError` — keyword miss + LLM fallback also failed |
+| `designer_intent_drift`        | `validate_intent` rejected the spec (AC-242 / AC-574)    |
+| `designer_parse_failure`       | Spec/source/execution validation errored out             |
+| `claude_cli_timeout`           | Subprocess or provider timed out                         |
+| `scenario_execution_failed`    | Scenario built but generations errored                   |
+| `unknown`                      | Didn't match any pattern — eyeball the raw output        |
+
+Successes are split into:
+
+| Bucket               | Meaning                                            |
+| -------------------- | -------------------------------------------------- |
+| `success`            | Completed via the keyword classifier path           |
+| `llm_fallback_fired` | Succeeded, AC-580 LLM fallback classified the family |
+
+Artifacts persist in `.sweep/<release>/results/` for follow-up diagnosis.

--- a/scripts/escalation-sweep/fetch_manifest.py
+++ b/scripts/escalation-sweep/fetch_manifest.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Fetch Linear Scenarios-state issues and emit a sweep manifest.
+
+Reads the Linear personal API key from ~/.config/linear/credentials.toml
+(the `greyhaven` key). Writes a JSON manifest of {identifier, title, body}
+entries to the path given on the command line.
+
+Usage:
+    python fetch_manifest.py <output_path>
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+LINEAR_API = "https://api.linear.app/graphql"
+SCENARIOS_STATE_ID = "828fd036-0d14-4dc3-9af1-28a72977f33b"
+CREDENTIALS_PATH = Path.home() / ".config" / "linear" / "credentials.toml"
+
+
+def _load_key() -> str:
+    env_key = os.environ.get("LINEAR_API_KEY")
+    if env_key:
+        return env_key
+    if not CREDENTIALS_PATH.exists():
+        raise SystemExit(
+            f"no LINEAR_API_KEY env var and {CREDENTIALS_PATH} not found"
+        )
+    for line in CREDENTIALS_PATH.read_text().splitlines():
+        line = line.strip()
+        if line.startswith("greyhaven"):
+            _, _, value = line.partition("=")
+            return value.strip().strip('"')
+    raise SystemExit("no 'greyhaven' entry in credentials.toml")
+
+
+def _gql(key: str, query: str, variables: dict | None = None) -> dict:
+    payload = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = urllib.request.Request(
+        LINEAR_API,
+        data=payload,
+        headers={"Authorization": key, "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        body = json.loads(resp.read())
+    if "errors" in body:
+        raise SystemExit(f"Linear API error: {body['errors']}")
+    return body["data"]
+
+
+def fetch_scenarios(key: str) -> list[dict]:
+    query = """
+    query Scenarios($stateId: ID!, $after: String) {
+      issues(
+        filter: { state: { id: { eq: $stateId } } }
+        first: 50
+        after: $after
+      ) {
+        nodes { identifier title description }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+    """
+    nodes: list[dict] = []
+    cursor: str | None = None
+    while True:
+        data = _gql(
+            key,
+            query,
+            {"stateId": SCENARIOS_STATE_ID, "after": cursor},
+        )
+        issues = data["issues"]
+        nodes.extend(issues["nodes"])
+        if not issues["pageInfo"]["hasNextPage"]:
+            break
+        cursor = issues["pageInfo"]["endCursor"]
+    return nodes
+
+
+def to_manifest_entry(issue: dict) -> dict:
+    # Use title + body for the solve description; body may be multi-section.
+    title = issue.get("title", "").strip()
+    body = (issue.get("description") or "").strip()
+    description = f"# {title}\n\n{body}" if body else title
+    return {
+        "identifier": issue["identifier"],
+        "title": title,
+        "description": description,
+    }
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    output_path = Path(argv[1])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    key = _load_key()
+    issues = fetch_scenarios(key)
+    entries = [to_manifest_entry(issue) for issue in issues]
+    output_path.write_text(json.dumps(entries, indent=2))
+    print(f"wrote {len(entries)} entries to {output_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/escalation-sweep/run_sweep.sh
+++ b/scripts/escalation-sweep/run_sweep.sh
@@ -8,10 +8,20 @@
 # payload) and one <identifier>.meta.json with {identifier, exit_code,
 # elapsed_seconds}. A final <output_dir>/index.json lists all runs.
 #
-# Prerequisites: ANTHROPIC_API_KEY (or equivalent provider credential) must be
-# exported; autoctx must be on PATH (or run from the autocontext/ dir).
+# Provider: defaults to `claude-cli` (uses the authenticated `claude` binary
+# on PATH — no Anthropic API key needed). Override with
+# AUTOCONTEXT_AGENT_PROVIDER=... if you prefer `anthropic`, `agent_sdk`, etc.
+# Those modes need the provider-specific credential in the environment.
+#
+# Prerequisites:
+#   - `autoctx` on PATH (or run from the autocontext/ source dir)
+#   - For claude-cli provider: `claude` CLI installed and authenticated
+#   - For anthropic/agent_sdk: ANTHROPIC_API_KEY exported
 
 set -euo pipefail
+
+: "${AUTOCONTEXT_AGENT_PROVIDER:=claude-cli}"
+export AUTOCONTEXT_AGENT_PROVIDER
 
 if [[ $# -lt 2 ]]; then
   echo "usage: $0 <manifest.json> <output_dir> [--gens N] [--timeout SEC]" >&2
@@ -40,7 +50,8 @@ fi
 mkdir -p "$OUTPUT_DIR"
 
 COUNT=$(jq 'length' "$MANIFEST")
-echo "sweeping $COUNT scenarios from $MANIFEST → $OUTPUT_DIR (gens=$GENS timeout=${TIMEOUT}s)" >&2
+echo "sweeping $COUNT scenarios from $MANIFEST → $OUTPUT_DIR" >&2
+echo "  provider=$AUTOCONTEXT_AGENT_PROVIDER gens=$GENS timeout=${TIMEOUT}s" >&2
 
 INDEX=()
 for i in $(seq 0 $((COUNT - 1))); do

--- a/scripts/escalation-sweep/run_sweep.sh
+++ b/scripts/escalation-sweep/run_sweep.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Run `autoctx solve` against each entry in a sweep manifest and capture results.
+#
+# Usage:
+#   scripts/escalation-sweep/run_sweep.sh <manifest.json> <output_dir> [--gens N] [--timeout SEC]
+#
+# Writes one <identifier>.out.json per entry (structured solve output or error
+# payload) and one <identifier>.meta.json with {identifier, exit_code,
+# elapsed_seconds}. A final <output_dir>/index.json lists all runs.
+#
+# Prerequisites: ANTHROPIC_API_KEY (or equivalent provider credential) must be
+# exported; autoctx must be on PATH (or run from the autocontext/ dir).
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <manifest.json> <output_dir> [--gens N] [--timeout SEC]" >&2
+  exit 2
+fi
+
+MANIFEST=$1
+OUTPUT_DIR=$2
+shift 2
+
+GENS=2
+TIMEOUT=600
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --gens) GENS=$2; shift 2 ;;
+    --timeout) TIMEOUT=$2; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2; exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+COUNT=$(jq 'length' "$MANIFEST")
+echo "sweeping $COUNT scenarios from $MANIFEST → $OUTPUT_DIR (gens=$GENS timeout=${TIMEOUT}s)" >&2
+
+INDEX=()
+for i in $(seq 0 $((COUNT - 1))); do
+  ID=$(jq -r ".[$i].identifier" "$MANIFEST")
+  DESC_FILE=$(mktemp)
+  jq -r ".[$i].description" "$MANIFEST" > "$DESC_FILE"
+
+  OUT_JSON="$OUTPUT_DIR/${ID}.out.json"
+  META_JSON="$OUTPUT_DIR/${ID}.meta.json"
+
+  printf "[%d/%d] %s ... " "$((i + 1))" "$COUNT" "$ID" >&2
+  START=$(date +%s)
+  set +e
+  autoctx solve \
+    --description "$(cat "$DESC_FILE")" \
+    --gens "$GENS" \
+    --timeout "$TIMEOUT" \
+    --json \
+    > "$OUT_JSON" 2>&1
+  EXIT=$?
+  set -e
+  END=$(date +%s)
+  ELAPSED=$((END - START))
+
+  jq -n \
+    --arg id "$ID" \
+    --argjson exit "$EXIT" \
+    --argjson elapsed "$ELAPSED" \
+    '{identifier: $id, exit_code: $exit, elapsed_seconds: $elapsed}' \
+    > "$META_JSON"
+
+  INDEX+=("$ID")
+  if [[ $EXIT -eq 0 ]]; then
+    printf "ok (%ds)\n" "$ELAPSED" >&2
+  else
+    printf "FAIL exit=%d (%ds)\n" "$EXIT" "$ELAPSED" >&2
+  fi
+
+  rm -f "$DESC_FILE"
+done
+
+printf '%s\n' "${INDEX[@]}" | jq -R . | jq -s . > "$OUTPUT_DIR/index.json"
+echo "wrote $OUTPUT_DIR/index.json" >&2

--- a/scripts/escalation-sweep/run_sweep.sh
+++ b/scripts/escalation-sweep/run_sweep.sh
@@ -6,7 +6,8 @@
 #
 # Writes one <identifier>.out.json per entry (structured solve output or error
 # payload) and one <identifier>.meta.json with {identifier, exit_code,
-# elapsed_seconds}. A final <output_dir>/index.json lists all runs.
+# elapsed_seconds, workspace_root}. A final <output_dir>/index.json lists all
+# runs.
 #
 # Provider: defaults to `claude-cli` (uses the authenticated `claude` binary
 # on PATH — no Anthropic API key needed). Override with
@@ -48,10 +49,15 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR=$(cd "$OUTPUT_DIR" && pwd)
+SWEEP_ROOT=$(cd "$OUTPUT_DIR/.." && pwd)
+WORKSPACES_DIR="$SWEEP_ROOT/workspaces"
+mkdir -p "$WORKSPACES_DIR"
 
 COUNT=$(jq 'length' "$MANIFEST")
 echo "sweeping $COUNT scenarios from $MANIFEST → $OUTPUT_DIR" >&2
 echo "  provider=$AUTOCONTEXT_AGENT_PROVIDER gens=$GENS timeout=${TIMEOUT}s" >&2
+echo "  isolated_workspaces=$WORKSPACES_DIR" >&2
 
 INDEX=()
 for i in $(seq 0 $((COUNT - 1))); do
@@ -61,10 +67,25 @@ for i in $(seq 0 $((COUNT - 1))); do
 
   OUT_JSON="$OUTPUT_DIR/${ID}.out.json"
   META_JSON="$OUTPUT_DIR/${ID}.meta.json"
+  WORKSPACE_DIR="$WORKSPACES_DIR/$ID"
+
+  rm -rf "$WORKSPACE_DIR"
+  mkdir -p \
+    "$WORKSPACE_DIR/runs" \
+    "$WORKSPACE_DIR/knowledge" \
+    "$WORKSPACE_DIR/skills" \
+    "$WORKSPACE_DIR/.claude/skills"
 
   printf "[%d/%d] %s ... " "$((i + 1))" "$COUNT" "$ID" >&2
   START=$(date +%s)
   set +e
+  AUTOCONTEXT_DB_PATH="$WORKSPACE_DIR/runs/autocontext.sqlite3" \
+  AUTOCONTEXT_RUNS_ROOT="$WORKSPACE_DIR/runs" \
+  AUTOCONTEXT_KNOWLEDGE_ROOT="$WORKSPACE_DIR/knowledge" \
+  AUTOCONTEXT_SKILLS_ROOT="$WORKSPACE_DIR/skills" \
+  AUTOCONTEXT_CLAUDE_SKILLS_PATH="$WORKSPACE_DIR/.claude/skills" \
+  AUTOCONTEXT_EVENT_STREAM_PATH="$WORKSPACE_DIR/runs/events.ndjson" \
+  AUTOCONTEXT_AUDIT_LOG_PATH="$WORKSPACE_DIR/runs/audit.ndjson" \
   autoctx solve \
     --description "$(cat "$DESC_FILE")" \
     --gens "$GENS" \
@@ -80,7 +101,8 @@ for i in $(seq 0 $((COUNT - 1))); do
     --arg id "$ID" \
     --argjson exit "$EXIT" \
     --argjson elapsed "$ELAPSED" \
-    '{identifier: $id, exit_code: $exit, elapsed_seconds: $elapsed}' \
+    --arg workspace_root "$WORKSPACE_DIR" \
+    '{identifier: $id, exit_code: $exit, elapsed_seconds: $elapsed, workspace_root: $workspace_root}' \
     > "$META_JSON"
 
   INDEX+=("$ID")

--- a/scripts/escalation-sweep/summarize.py
+++ b/scripts/escalation-sweep/summarize.py
@@ -11,7 +11,7 @@ failure buckets:
     designer_intent_drift         — validate_intent rejected the spec
     claude_cli_timeout            — subprocess or provider timeout
     scenario_execution_failed     — generations errored after scenario built
-    llm_fallback_fired            — (INFO-only detection; success cases only)
+    llm_fallback_fired            — solve succeeded after AC-580 LLM family fallback
     unknown                       — didn't match any known pattern
 
 Usage:
@@ -74,7 +74,7 @@ def main(argv: list[str]) -> int:
         if exit_code == 0:
             bucket = "success"
             detail = out_payload.get("scenario_name", "")
-            if "LLM classifier fallback:" in out_text:
+            if out_payload.get("llm_classifier_fallback_used") is True:
                 bucket = "llm_fallback_fired"
         else:
             message = ""

--- a/scripts/escalation-sweep/summarize.py
+++ b/scripts/escalation-sweep/summarize.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Classify sweep results into failure buckets and print a summary.
+
+Reads `<output_dir>/index.json` (list of identifiers) produced by run_sweep.sh
+and the per-scenario .out.json / .meta.json pairs, then tallies into known
+failure buckets:
+
+    success                       — solve completed, generations executed
+    classifier_low_confidence     — LowConfidenceError raised
+    designer_parse_failure        — spec JSON parse / validation failures
+    designer_intent_drift         — validate_intent rejected the spec
+    claude_cli_timeout            — subprocess or provider timeout
+    scenario_execution_failed     — generations errored after scenario built
+    llm_fallback_fired            — (INFO-only detection; success cases only)
+    unknown                       — didn't match any known pattern
+
+Usage:
+    python summarize.py <output_dir>
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+BUCKET_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("classifier_low_confidence", re.compile(r"LowConfidenceError|family.*confidence.*<.*threshold", re.I)),
+    ("designer_intent_drift", re.compile(r"intent validation failed", re.I)),
+    ("designer_parse_failure", re.compile(r"(spec|source|execution) validation failed|parse(?:_| )retry exhausted", re.I)),
+    ("claude_cli_timeout", re.compile(r"timed? ?out|PiCLIRuntime failed:.*timeout|claude.?cli.*timeout", re.I)),
+    ("scenario_execution_failed", re.compile(r"solve did not complete|generation.*fail|executor error", re.I)),
+]
+
+
+def classify_error(message: str) -> str:
+    if not message:
+        return "unknown"
+    for bucket, pattern in BUCKET_PATTERNS:
+        if pattern.search(message):
+            return bucket
+    return "unknown"
+
+
+def read_json(path: Path) -> dict | None:
+    try:
+        return json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    output_dir = Path(argv[1])
+    index_path = output_dir / "index.json"
+    if not index_path.exists():
+        print(f"no index.json at {index_path}", file=sys.stderr)
+        return 2
+
+    identifiers: list[str] = json.loads(index_path.read_text())
+    buckets: dict[str, list[str]] = {}
+    rows: list[dict] = []
+
+    for ident in identifiers:
+        meta = read_json(output_dir / f"{ident}.meta.json") or {}
+        exit_code = meta.get("exit_code", -1)
+        elapsed = meta.get("elapsed_seconds", -1)
+        out_path = output_dir / f"{ident}.out.json"
+        out_text = out_path.read_text() if out_path.exists() else ""
+        out_payload = read_json(out_path) or {}
+
+        if exit_code == 0:
+            bucket = "success"
+            detail = out_payload.get("scenario_name", "")
+            if "LLM classifier fallback:" in out_text:
+                bucket = "llm_fallback_fired"
+        else:
+            message = ""
+            if isinstance(out_payload, dict):
+                message = str(out_payload.get("error") or out_text)
+            else:
+                message = out_text
+            bucket = classify_error(message)
+            detail = message.splitlines()[0][:140] if message else ""
+
+        rows.append(
+            {
+                "identifier": ident,
+                "bucket": bucket,
+                "exit": exit_code,
+                "elapsed": elapsed,
+                "detail": detail,
+            }
+        )
+        buckets.setdefault(bucket, []).append(ident)
+
+    print("\n=== Per-scenario ===")
+    print(f"{'ID':<10} {'BUCKET':<28} {'EXIT':>4} {'SEC':>5}  DETAIL")
+    for row in rows:
+        print(
+            f"{row['identifier']:<10} {row['bucket']:<28} {row['exit']:>4} "
+            f"{row['elapsed']:>5}  {row['detail']}"
+        )
+
+    print("\n=== Tally ===")
+    for bucket in sorted(buckets, key=lambda b: -len(buckets[b])):
+        members = buckets[bucket]
+        print(f"  {bucket:<28} {len(members):>3}  {', '.join(members)}")
+
+    summary_path = output_dir / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {"rows": rows, "buckets": {k: len(v) for k, v in buckets.items()}},
+            indent=2,
+        )
+    )
+    print(f"\nwrote {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
Consolidates the ad-hoc sweep that surfaced AC-570/574/575/571/579/580 during the 0.4.3 validation cycle into a repeatable tool under `scripts/escalation-sweep/`.

## What's in it
- **`fetch_manifest.py`** — pulls every Linear issue in the "Scenarios" workflow state (team AC, state id `828fd036-…`) and writes `{identifier, title, description}` entries to a JSON manifest. Reads the Linear key from `$LINEAR_API_KEY` or `~/.config/linear/credentials.toml`.
- **`run_sweep.sh`** — iterates the manifest, runs `autoctx solve --description <body> --gens N --timeout SEC --json` per entry, writes `<ID>.out.json` / `<ID>.meta.json` per scenario, and a final `index.json`. Defaults to `AUTOCONTEXT_AGENT_PROVIDER=claude-cli` so no Anthropic API key is required — uses the authenticated `claude` binary.
- **`summarize.py`** — classifies each result into one of 8 buckets (`success`, `llm_fallback_fired`, `classifier_low_confidence`, `designer_intent_drift`, `designer_parse_failure`, `claude_cli_timeout`, `scenario_execution_failed`, `unknown`) and prints a per-scenario table + tally. Writes `summary.json` alongside the raw artifacts.
- **`README.md`** — usage, bucket glossary, prerequisites.

## Verified
- [x] `bash -n` + `python3 -m py_compile` clean for all three scripts.
- [x] `fetch_manifest.py` against live Linear: 21 scenarios returned, schema matches expectations.
- [x] `summarize.py` with synthetic result fixtures: correct bucket routing for LowConfidenceError, intent-drift, timeout, and success cases.

## Usage
```bash
python3 scripts/escalation-sweep/fetch_manifest.py .sweep/0.4.4/manifest.json
bash scripts/escalation-sweep/run_sweep.sh .sweep/0.4.4/manifest.json .sweep/0.4.4/results --gens 2 --timeout 600
python3 scripts/escalation-sweep/summarize.py .sweep/0.4.4/results
```

## Test Plan
- [ ] Run the sweep against 0.4.4, confirm output artifacts + summary render correctly
- [ ] If any scenario hits `unknown`, extend `BUCKET_PATTERNS` in `summarize.py`