### PR TITLE
fix: stabilize python ecosystem rlm pi runs

### DIFF
--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -17,11 +17,16 @@ from autocontext.agents.curator import KnowledgeCurator
 from autocontext.agents.llm_client import LanguageModelClient, build_client_from_settings
 from autocontext.agents.model_router import ModelRouter, TierConfig
 from autocontext.agents.parsers import parse_analyst_output, parse_architect_output, parse_coach_output, parse_competitor_output
+from autocontext.agents.rlm_short_circuits import (
+    analyst_has_fresh_match_data,
+    build_analyst_no_data_execution,
+    build_architect_cadence_skip_execution,
+)
 from autocontext.agents.role_router import ProviderClass, RoleRouter, RoutingContext
 from autocontext.agents.skeptic import SkepticAgent
 from autocontext.agents.subagent_runtime import SubagentRuntime
 from autocontext.agents.translator import StrategyTranslator
-from autocontext.agents.types import AgentOutputs, RoleExecution, RoleUsage
+from autocontext.agents.types import AgentOutputs, RoleExecution
 from autocontext.config.settings import AppSettings
 from autocontext.execution.harness_coverage import HarnessCoverage
 from autocontext.harness.orchestration.dag import RoleDAG
@@ -936,36 +941,9 @@ class AgentOrchestrator:
             scenario_rules=scenario_rules,
             current_strategy=strategy,
         )
-        if not (
-            analyst_ctx.variables.get("replays")
-            or analyst_ctx.variables.get("metrics_history")
-            or analyst_ctx.variables.get("match_scores")
-        ):
-            analyst_exec = RoleExecution(
-                role="analyst",
-                content=(
-                    "## Findings\n"
-                    "- No fresh match data is available for this run yet; replays, metrics history, "
-                    "and match scores are empty.\n\n"
-                    "## Root Causes\n"
-                    "- The analyst RLM pass was skipped because there is no new scored evidence "
-                    "to analyze for this generation.\n"
-                    "- Only carry-forward guidance from the playbook, prior analyses, and "
-                    "operational lessons is available.\n\n"
-                    "## Actionable Recommendations\n"
-                    "- Freeze parameter deltas at `0.00` and reuse the currently validated "
-                    "baseline until fresh replay-backed data arrives.\n"
-                    "- Collect new scored runs before making additional strategic claims or "
-                    "branching changes."
-                ),
-                usage=RoleUsage(
-                    input_tokens=0,
-                    output_tokens=0,
-                    latency_ms=0,
-                    model=analyst_model or self.settings.model_analyst,
-                ),
-                subagent_id="analyst-no-data",
-                status="completed",
+        if not analyst_has_fresh_match_data(analyst_ctx.variables):
+            analyst_exec = build_analyst_no_data_execution(
+                analyst_model or self.settings.model_analyst,
             )
         else:
             analyst_exec, _ = self._run_single_rlm_session(
@@ -988,27 +966,8 @@ class AgentOrchestrator:
 
         # --- Architect ---
         if _ARCHITECT_CADENCE_SKIP in architect_prompt:
-            architect_exec = RoleExecution(
-                role="architect",
-                content=(
-                    "## Observed Bottlenecks\n"
-                    "- Architect cadence skip: no major intervention this generation.\n\n"
-                    "## Tool Proposals\n"
-                    "- None; return minimal status and an empty tools array.\n\n"
-                    "## Impact Hypothesis\n"
-                    "- Reduces live runtime overhead on off-cadence generations while preserving existing tool behavior.\n\n"
-                    "```json\n"
-                    '{"tools": []}\n'
-                    "```"
-                ),
-                usage=RoleUsage(
-                    input_tokens=0,
-                    output_tokens=0,
-                    latency_ms=0,
-                    model=architect_model or self.settings.model_architect,
-                ),
-                subagent_id="architect-skip",
-                status="completed",
+            architect_exec = build_architect_cadence_skip_execution(
+                architect_model or self.settings.model_architect,
             )
             return analyst_exec, architect_exec
 

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -21,7 +21,7 @@ from autocontext.agents.role_router import ProviderClass, RoleRouter, RoutingCon
 from autocontext.agents.skeptic import SkepticAgent
 from autocontext.agents.subagent_runtime import SubagentRuntime
 from autocontext.agents.translator import StrategyTranslator
-from autocontext.agents.types import AgentOutputs, RoleExecution
+from autocontext.agents.types import AgentOutputs, RoleExecution, RoleUsage
 from autocontext.config.settings import AppSettings
 from autocontext.execution.harness_coverage import HarnessCoverage
 from autocontext.harness.orchestration.dag import RoleDAG
@@ -936,14 +936,46 @@ class AgentOrchestrator:
             scenario_rules=scenario_rules,
             current_strategy=strategy,
         )
-        analyst_exec, _ = self._run_single_rlm_session(
-            role="analyst",
-            model=analyst_model or self.settings.model_analyst,
-            system_tpl=backend.analyst_tpl,
-            context=analyst_ctx,
-            worker_cls=backend.worker_cls,
-            client=analyst_client,
-        )
+        if not (
+            analyst_ctx.variables.get("replays")
+            or analyst_ctx.variables.get("metrics_history")
+            or analyst_ctx.variables.get("match_scores")
+        ):
+            analyst_exec = RoleExecution(
+                role="analyst",
+                content=(
+                    "## Findings\n"
+                    "- No fresh match data is available for this run yet; replays, metrics history, "
+                    "and match scores are empty.\n\n"
+                    "## Root Causes\n"
+                    "- The analyst RLM pass was skipped because there is no new scored evidence "
+                    "to analyze for this generation.\n"
+                    "- Only carry-forward guidance from the playbook, prior analyses, and "
+                    "operational lessons is available.\n\n"
+                    "## Actionable Recommendations\n"
+                    "- Freeze parameter deltas at `0.00` and reuse the currently validated "
+                    "baseline until fresh replay-backed data arrives.\n"
+                    "- Collect new scored runs before making additional strategic claims or "
+                    "branching changes."
+                ),
+                usage=RoleUsage(
+                    input_tokens=0,
+                    output_tokens=0,
+                    latency_ms=0,
+                    model=analyst_model or self.settings.model_analyst,
+                ),
+                subagent_id="analyst-no-data",
+                status="completed",
+            )
+        else:
+            analyst_exec, _ = self._run_single_rlm_session(
+                role="analyst",
+                model=analyst_model or self.settings.model_analyst,
+                system_tpl=backend.analyst_tpl,
+                context=analyst_ctx,
+                worker_cls=backend.worker_cls,
+                client=analyst_client,
+            )
 
         # Reset turn counter between roles for deterministic client
         architect_client, architect_model = self._resolve_role_execution(
@@ -955,6 +987,31 @@ class AgentOrchestrator:
             architect_client.reset_rlm_turns()
 
         # --- Architect ---
+        if _ARCHITECT_CADENCE_SKIP in architect_prompt:
+            architect_exec = RoleExecution(
+                role="architect",
+                content=(
+                    "## Observed Bottlenecks\n"
+                    "- Architect cadence skip: no major intervention this generation.\n\n"
+                    "## Tool Proposals\n"
+                    "- None; return minimal status and an empty tools array.\n\n"
+                    "## Impact Hypothesis\n"
+                    "- Reduces live runtime overhead on off-cadence generations while preserving existing tool behavior.\n\n"
+                    "```json\n"
+                    '{"tools": []}\n'
+                    "```"
+                ),
+                usage=RoleUsage(
+                    input_tokens=0,
+                    output_tokens=0,
+                    latency_ms=0,
+                    model=architect_model or self.settings.model_architect,
+                ),
+                subagent_id="architect-skip",
+                status="completed",
+            )
+            return analyst_exec, architect_exec
+
         architect_ctx = self._rlm_loader.load_for_architect(
             run_id,
             scenario_name,

--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -22,6 +22,10 @@ from autocontext.harness.core.types import ModelResponse, RoleUsage
 
 logger = logging.getLogger(__name__)
 
+_RUNTIME_MULTITURN_MAX_PROMPT_CHARS = 6000
+_RUNTIME_MULTITURN_MAX_MESSAGE_CHARS = 1000
+_RUNTIME_MULTITURN_MAX_USER_MESSAGES = 3
+
 if TYPE_CHECKING:
     from autocontext.config.settings import AppSettings
     from autocontext.providers.base import LLMProvider
@@ -71,6 +75,34 @@ class ProviderBridgeClient(LanguageModelClient):
         )
 
 
+def _truncate_runtime_multiturn_text(text: str, *, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    head = text[: limit // 2].rstrip()
+    tail = text[-(limit - len(head) - len("\n... [truncated] ...\n")) :].lstrip()
+    return f"{head}\n... [truncated] ...\n{tail}"
+
+
+def _build_runtime_multiturn_prompt(system: str, messages: list[dict[str, str]]) -> str:
+    user_messages = [m.get("content", "") for m in messages if m.get("role") == "user"]
+    if not user_messages:
+        return system
+
+    retained: list[str] = []
+    first_message = user_messages[0]
+    tail_messages = user_messages[1:][-_RUNTIME_MULTITURN_MAX_USER_MESSAGES + 1 :]
+    retained.append(first_message)
+    retained.extend(tail_messages)
+
+    sections = [system, "## Conversation state"]
+    for idx, message in enumerate(retained, start=1):
+        compact = _truncate_runtime_multiturn_text(message, limit=_RUNTIME_MULTITURN_MAX_MESSAGE_CHARS)
+        sections.append(f"### User message {idx}\n{compact}")
+
+    prompt = "\n\n".join(section for section in sections if section)
+    return _truncate_runtime_multiturn_text(prompt, limit=_RUNTIME_MULTITURN_MAX_PROMPT_CHARS)
+
+
 class RuntimeBridgeClient(LanguageModelClient):
     """Adapts an AgentRuntime to the LanguageModelClient interface.
 
@@ -109,6 +141,25 @@ class RuntimeBridgeClient(LanguageModelClient):
             metadata=dict(output.metadata),
         )
 
+    def generate_multiturn(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+        temperature: float,
+        role: str = "",
+    ) -> ModelResponse:
+        prompt = _build_runtime_multiturn_prompt(system, messages)
+        return self.generate(
+            model=model,
+            prompt=prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            role=role,
+        )
+
 
 def _role_setting(settings: AppSettings, role: str, suffix: str) -> str:
     if not role:
@@ -136,11 +187,7 @@ def _provider_api_key(provider_type: str, settings: AppSettings, *, role: str = 
     if role_api_key:
         return role_api_key
     if provider_type == "anthropic":
-        return (
-            settings.anthropic_api_key
-            or os.getenv("ANTHROPIC_API_KEY")
-            or os.getenv("AUTOCONTEXT_ANTHROPIC_API_KEY")
-        )
+        return settings.anthropic_api_key or os.getenv("ANTHROPIC_API_KEY") or os.getenv("AUTOCONTEXT_ANTHROPIC_API_KEY")
     if provider_type in ("openai", "openai-compatible"):
         return settings.agent_api_key or settings.judge_api_key or os.getenv("OPENAI_API_KEY")
     if provider_type == "vllm":

--- a/autocontext/src/autocontext/agents/rlm_short_circuits.py
+++ b/autocontext/src/autocontext/agents/rlm_short_circuits.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from autocontext.agents.types import RoleExecution, RoleUsage
+
+
+def analyst_has_fresh_match_data(variables: Mapping[str, Any]) -> bool:
+    return bool(
+        variables.get("replays")
+        or variables.get("metrics_history")
+        or variables.get("match_scores")
+    )
+
+
+def build_analyst_no_data_execution(model: str) -> RoleExecution:
+    return RoleExecution(
+        role="analyst",
+        content=(
+            "## Findings\n"
+            "- No fresh match data is available for this run yet; replays, metrics history, "
+            "and match scores are empty.\n\n"
+            "## Root Causes\n"
+            "- The analyst RLM pass was skipped because there is no new scored evidence "
+            "to analyze for this generation.\n"
+            "- Only carry-forward guidance from the playbook, prior analyses, and "
+            "operational lessons is available.\n\n"
+            "## Actionable Recommendations\n"
+            "- Freeze parameter deltas at `0.00` and reuse the currently validated "
+            "baseline until fresh replay-backed data arrives.\n"
+            "- Collect new scored runs before making additional strategic claims or "
+            "branching changes."
+        ),
+        usage=RoleUsage(
+            input_tokens=0,
+            output_tokens=0,
+            latency_ms=0,
+            model=model,
+        ),
+        subagent_id="analyst-no-data",
+        status="completed",
+    )
+
+
+def build_architect_cadence_skip_execution(model: str) -> RoleExecution:
+    return RoleExecution(
+        role="architect",
+        content=(
+            "## Observed Bottlenecks\n"
+            "- Architect cadence skip: no major intervention this generation.\n\n"
+            "## Tool Proposals\n"
+            "- None; return minimal status and an empty tools array.\n\n"
+            "## Impact Hypothesis\n"
+            "- Reduces live runtime overhead on off-cadence generations while preserving existing tool behavior.\n\n"
+            "```json\n"
+            '{"tools": []}\n'
+            "```"
+        ),
+        usage=RoleUsage(
+            input_tokens=0,
+            output_tokens=0,
+            latency_ms=0,
+            model=model,
+        ),
+        subagent_id="architect-skip",
+        status="completed",
+    )

--- a/autocontext/src/autocontext/harness/repl/session.py
+++ b/autocontext/src/autocontext/harness/repl/session.py
@@ -17,6 +17,15 @@ from autocontext.harness.repl.types import ExecutionRecord, ReplCommand, ReplWor
 logger = logging.getLogger(__name__)
 
 _CODE_PATTERN = re.compile(r"<code>(.*?)</code>", re.DOTALL)
+_REPL_FEEDBACK_MAX_CHARS = 1200
+
+
+def _compact_feedback_text(text: str, *, limit: int = _REPL_FEEDBACK_MAX_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    head = text[: limit // 2].rstrip()
+    tail = text[-(limit - len(head) - len("\n... [truncated] ...\n")) :].lstrip()
+    return f"{head}\n... [truncated] ...\n{tail}"
 
 
 def make_llm_batch(
@@ -123,24 +132,33 @@ class RlmSession:
                 code = code_match.group(1).strip()
                 result = self._worker.run_code(ReplCommand(code))
 
-                self.execution_history.append(ExecutionRecord(
-                    turn=turn,
-                    code=code,
-                    stdout=result.stdout,
-                    error=result.error,
-                    answer_ready=result.answer.get("ready", False),
-                ))
+                self.execution_history.append(
+                    ExecutionRecord(
+                        turn=turn,
+                        code=code,
+                        stdout=result.stdout,
+                        error=result.error,
+                        answer_ready=result.answer.get("ready", False),
+                    )
+                )
 
                 # Build user feedback message
                 parts: list[str] = []
                 if result.stdout:
-                    parts.append(f"[stdout]\n{result.stdout}")
+                    parts.append(f"[stdout]\n{_compact_feedback_text(result.stdout)}")
                 if result.error:
-                    parts.append(f"[error]\n{result.error}")
+                    parts.append(f"[error]\n{_compact_feedback_text(result.error)}")
                 if not parts:
                     parts.append("[no output]")
 
                 feedback = "\n\n".join(parts)
+                if turn >= 2 and not result.answer.get("ready", False):
+                    feedback += (
+                        "\n\n[finalization reminder]\n"
+                        "If you have enough evidence, finalize now by writing your markdown into "
+                        'answer["content"] and setting answer["ready"] = True instead of running '
+                        "more exploratory code."
+                    )
                 messages.append({"role": "user", "content": feedback})
 
                 if self._on_turn:
@@ -151,11 +169,13 @@ class RlmSession:
                     break
             else:
                 # Model didn't emit code — nudge it
-                messages.append({
-                    "role": "user",
-                    "content": "Please write code inside <code> tags to continue your analysis, "
-                    'or set answer["ready"] = True to finalize.',
-                })
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": "Please write code inside <code> tags to continue your analysis, "
+                        'or set answer["ready"] = True to finalize.',
+                    }
+                )
         else:
             status = "truncated"
             logger.warning("RLM %s hit max_turns=%d without finalizing", self._role, self._max_turns)

--- a/autocontext/src/autocontext/harness/repl/worker.py
+++ b/autocontext/src/autocontext/harness/repl/worker.py
@@ -20,9 +20,25 @@ _SAFE_MODULES = {
     "math": __import__("math"),
     "statistics": __import__("statistics"),
     "collections": __import__("collections"),
+    "pprint": __import__("pprint"),
     "re": __import__("re"),
     "time": __import__("time"),
 }
+
+
+def _safe_import(
+    name: str,
+    globals: dict[str, Any] | None = None,
+    locals: dict[str, Any] | None = None,
+    fromlist: tuple[str, ...] = (),
+    level: int = 0,
+) -> Any:
+    del globals, locals, fromlist, level
+    base_name = name.split(".", 1)[0]
+    module = _SAFE_MODULES.get(base_name)
+    if module is None:
+        raise ImportError(f"import of '{name}' is blocked")
+    return module
 
 
 def _peek(text: str, start: int = 0, length: int = 2000) -> str:
@@ -98,19 +114,21 @@ _TEXT_HELPERS: dict[str, Any] = {
     "chunk_by_headers": _chunk_by_headers,
 }
 
-_BLOCKED_NAMES = frozenset({
-    "open",
-    "os",
-    "sys",
-    "subprocess",
-    "importlib",
-    "__import__",
-    "eval",
-    "compile",
-    "breakpoint",
-    "exit",
-    "quit",
-})
+_BLOCKED_NAMES = frozenset(
+    {
+        "open",
+        "os",
+        "sys",
+        "subprocess",
+        "importlib",
+        "__import__",
+        "eval",
+        "compile",
+        "breakpoint",
+        "exit",
+        "quit",
+    }
+)
 
 
 class CodeTimeout(BaseException):
@@ -132,6 +150,7 @@ def _build_restricted_builtins() -> dict[str, Any]:
         if name in _BLOCKED_NAMES:
             continue
         safe[name] = getattr(_builtins, name)
+    safe["__import__"] = _safe_import
     return safe
 
 

--- a/autocontext/src/autocontext/rlm/context_loader.py
+++ b/autocontext/src/autocontext/rlm/context_loader.py
@@ -8,6 +8,15 @@ from autocontext.storage.artifacts import ArtifactStore
 from autocontext.storage.sqlite_store import SQLiteStore
 from autocontext.util.json_io import read_json
 
+_RLM_CONTEXT_TEXT_BLOB_MAX_CHARS = 2000
+
+
+def _truncate_context_text(text: str, *, limit: int = _RLM_CONTEXT_TEXT_BLOB_MAX_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    tail = text[-limit:]
+    return f"... [truncated to last {limit} chars] ...\n{tail}"
+
 
 class ContextLoader:
     """Loads run data into REPL namespace variables for RLM-enabled agents."""
@@ -37,12 +46,12 @@ class ContextLoader:
         variables["replays"] = self._load_replays(run_id, generation)
         variables["metrics_history"] = self._load_metrics_files(run_id, generation)
         variables["match_scores"] = self._sqlite.get_matches_for_run(run_id)
-        variables["playbook"] = self._artifacts.read_playbook(scenario_name)
+        variables["playbook"] = _truncate_context_text(self._artifacts.read_playbook(scenario_name))
         variables["scenario_rules"] = scenario_rules
         variables["strategy_interface"] = strategy_interface
         variables["current_strategy"] = current_strategy or {}
         variables["prior_analyses"] = self._load_prior_analyses(scenario_name, generation)
-        variables["operational_lessons"] = self._artifacts.read_skills(scenario_name)
+        variables["operational_lessons"] = _truncate_context_text(self._artifacts.read_skills(scenario_name))
 
         summary = self._build_analyst_summary(variables)
         return RlmContext(variables=variables, summary=summary)
@@ -61,11 +70,11 @@ class ContextLoader:
         variables["existing_tools"] = self._load_tool_sources(scenario_name)
         variables["metrics_history"] = self._load_metrics_files(run_id, generation)
         variables["replays"] = self._load_replays(run_id, generation, latest_only=True)
-        variables["playbook"] = self._artifacts.read_playbook(scenario_name)
-        variables["architect_changelog"] = self._load_architect_changelog(scenario_name)
+        variables["playbook"] = _truncate_context_text(self._artifacts.read_playbook(scenario_name))
+        variables["architect_changelog"] = _truncate_context_text(self._load_architect_changelog(scenario_name))
         variables["scenario_rules"] = scenario_rules
         variables["match_scores"] = self._sqlite.get_matches_for_run(run_id)
-        variables["operational_lessons"] = self._artifacts.read_skills(scenario_name)
+        variables["operational_lessons"] = _truncate_context_text(self._artifacts.read_skills(scenario_name))
 
         summary = self._build_architect_summary(variables)
         return RlmContext(variables=variables, summary=summary)
@@ -93,8 +102,8 @@ class ContextLoader:
         variables["match_scores"] = self._sqlite.get_matches_for_run(run_id)
 
         # Strategy guidance
-        variables["playbook"] = self._artifacts.read_playbook(scenario_name)
-        variables["coach_hints"] = self._artifacts.read_hints(scenario_name)
+        variables["playbook"] = _truncate_context_text(self._artifacts.read_playbook(scenario_name))
+        variables["coach_hints"] = _truncate_context_text(self._artifacts.read_hints(scenario_name))
 
         # Scenario context
         variables["scenario_rules"] = scenario_rules
@@ -103,7 +112,7 @@ class ContextLoader:
 
         # Prior analyses
         variables["prior_analyses"] = self._load_prior_analyses(scenario_name, generation)
-        variables["operational_lessons"] = self._artifacts.read_skills(scenario_name)
+        variables["operational_lessons"] = _truncate_context_text(self._artifacts.read_skills(scenario_name))
 
         summary = self._build_competitor_summary(variables)
         return RlmContext(variables=variables, summary=summary)

--- a/autocontext/src/autocontext/rlm/prompts.py
+++ b/autocontext/src/autocontext/rlm/prompts.py
@@ -21,6 +21,20 @@ print(len(replays))
 print(replays[0].keys())
 </code>
 
+Safe stdlib modules are preloaded and may also be imported directly if needed:
+`json`, `math`, `statistics`, `collections`, `pprint`, `re`, `time`.
+Do not attempt to import filesystem, process, or network modules.
+
+## Text helpers
+
+Use these helpers instead of printing entire large blobs:
+- `peek(text, start=0, length=2000)` -- inspect a slice of a large string
+- `grep(text, pattern, context=0)` -- find matching lines
+- `chunk_by_size(text, size=4000, overlap=0)` -- split a large string into chunks
+- `chunk_by_headers(text, pattern=r"^#{{1,3}} ")` -- split markdown into sections
+
+Prefer these helpers over dumping full tool code, playbooks, changelogs, or lesson files.
+
 ## Available function: llm_batch(prompts)
 
 Call llm_batch(prompts) with a list of prompt strings to dispatch parallel LLM calls.
@@ -136,7 +150,9 @@ answer["ready"] = True
 
 """
 
-ANALYST_MONTY_RLM_SYSTEM = MONTY_RLM_SCAFFOLDING_PREAMBLE + """\
+ANALYST_MONTY_RLM_SYSTEM = (
+    MONTY_RLM_SCAFFOLDING_PREAMBLE
+    + """\
 You are the Analyst agent in an iterative strategy evolution system. Your job is to
 analyze match replays, score distributions, and strategic patterns to produce actionable
 findings for the Coach and Competitor agents.
@@ -154,8 +170,11 @@ Your final answer (set in answer["content"]) must be markdown with these section
 
 Start by exploring the data structure, then dig into patterns.
 """
+)
 
-ARCHITECT_MONTY_RLM_SYSTEM = MONTY_RLM_SCAFFOLDING_PREAMBLE + """\
+ARCHITECT_MONTY_RLM_SYSTEM = (
+    MONTY_RLM_SCAFFOLDING_PREAMBLE
+    + """\
 You are the Architect agent in an iterative strategy evolution system. Your job is to
 analyze tool effectiveness, identify infrastructure bottlenecks, and propose tooling
 improvements.
@@ -180,8 +199,11 @@ If no new tools are needed, use an empty tools array.
 
 Start by examining existing tool code and correlating with performance metrics.
 """
+)
 
-COMPETITOR_MONTY_RLM_SYSTEM = MONTY_RLM_SCAFFOLDING_PREAMBLE + """\
+COMPETITOR_MONTY_RLM_SYSTEM = (
+    MONTY_RLM_SCAFFOLDING_PREAMBLE
+    + """\
 You are the Competitor agent in an iterative strategy evolution system. Your job is to
 explore match replays, analyze score patterns, and produce a JSON strategy that maximizes
 performance in the scenario.
@@ -210,6 +232,7 @@ answer["ready"] = True
 
 Start by exploring the data structure, then develop your strategy iteratively.
 """
+)
 
 # Constraint bullets shared with prompts/templates.py — keep in sync
 _RLM_ANALYST_CONSTRAINT = (
@@ -236,7 +259,9 @@ _RLM_COMPETITOR_CONSTRAINT = (
     "- Do NOT use parameter values outside the ranges defined in strategy_interface\n"
 )
 
-ANALYST_RLM_SYSTEM = RLM_SCAFFOLDING_PREAMBLE + """\
+ANALYST_RLM_SYSTEM = (
+    RLM_SCAFFOLDING_PREAMBLE
+    + """\
 You are the Analyst agent in an iterative strategy evolution system. Your job is to
 analyze match replays, score distributions, and strategic patterns to produce actionable
 findings for the Coach and Competitor agents.
@@ -254,8 +279,11 @@ Your final answer (set in answer["content"]) must be markdown with these section
 
 Start by exploring the data structure, then dig into patterns.
 """
+)
 
-ARCHITECT_RLM_SYSTEM = RLM_SCAFFOLDING_PREAMBLE + """\
+ARCHITECT_RLM_SYSTEM = (
+    RLM_SCAFFOLDING_PREAMBLE
+    + """\
 You are the Architect agent in an iterative strategy evolution system. Your job is to
 analyze tool effectiveness, identify infrastructure bottlenecks, and propose tooling
 improvements.
@@ -280,8 +308,11 @@ If no new tools are needed, use an empty tools array.
 
 Start by examining existing tool code and correlating with performance metrics.
 """
+)
 
-COMPETITOR_RLM_SYSTEM = RLM_SCAFFOLDING_PREAMBLE + """\
+COMPETITOR_RLM_SYSTEM = (
+    RLM_SCAFFOLDING_PREAMBLE
+    + """\
 You are the Competitor agent in an iterative strategy evolution system. Your job is to
 explore match replays, analyze score patterns, and produce a JSON strategy that maximizes
 performance in the scenario.
@@ -310,6 +341,7 @@ answer["ready"] = True
 
 Start by exploring the data structure, then develop your strategy iteratively.
 """
+)
 
 
 def _insert_rlm_constraint(base: str, constraint: str) -> str:

--- a/autocontext/tests/test_constraint_prompts.py
+++ b/autocontext/tests/test_constraint_prompts.py
@@ -172,6 +172,12 @@ class TestRlmConstrainedPrompts:
         assert "## Important rules" in ANALYST_RLM_SYSTEM_CONSTRAINED
         assert "## Important rules" in ARCHITECT_RLM_SYSTEM_CONSTRAINED
 
+    def test_standard_rlm_prompts_advertise_safe_helpers(self) -> None:
+        assert "pprint" in ANALYST_RLM_SYSTEM
+        assert "## Text helpers" in ANALYST_RLM_SYSTEM
+        assert "peek(text" in ANALYST_RLM_SYSTEM
+        assert "chunk_by_headers" in ARCHITECT_RLM_SYSTEM
+
     def test_constraint_before_important_rules(self) -> None:
         constraint_pos = ANALYST_RLM_SYSTEM_CONSTRAINED.find("## Constraints")
         rules_pos = ANALYST_RLM_SYSTEM_CONSTRAINED.find("## Important rules")
@@ -226,8 +232,7 @@ class TestCuratorConstraints:
         runtime = MagicMock()
         exec_result = MagicMock()
         exec_result.content = (
-            "<!-- CONSOLIDATED_LESSONS_START -->\n- lesson 1\n<!-- CONSOLIDATED_LESSONS_END -->\n"
-            "<!-- LESSONS_REMOVED: 1 -->"
+            "<!-- CONSOLIDATED_LESSONS_START -->\n- lesson 1\n<!-- CONSOLIDATED_LESSONS_END -->\n<!-- LESSONS_REMOVED: 1 -->"
         )
         runtime.run_task.return_value = exec_result
 
@@ -246,8 +251,7 @@ class TestCuratorConstraints:
         runtime = MagicMock()
         exec_result = MagicMock()
         exec_result.content = (
-            "<!-- CONSOLIDATED_LESSONS_START -->\n- lesson 1\n<!-- CONSOLIDATED_LESSONS_END -->\n"
-            "<!-- LESSONS_REMOVED: 1 -->"
+            "<!-- CONSOLIDATED_LESSONS_START -->\n- lesson 1\n<!-- CONSOLIDATED_LESSONS_END -->\n<!-- LESSONS_REMOVED: 1 -->"
         )
         runtime.run_task.return_value = exec_result
 

--- a/autocontext/tests/test_pi_cli_runtime.py
+++ b/autocontext/tests/test_pi_cli_runtime.py
@@ -254,6 +254,37 @@ def test_runtime_bridge_client_raises_on_runtime_error() -> None:
         client.generate(model="ignored", prompt="test", max_tokens=100, temperature=0.5)
 
 
+def test_runtime_bridge_client_multiturn_compacts_prompt_history() -> None:
+    mock_runtime = MagicMock()
+    mock_runtime.generate.return_value = MagicMock(text="bridge output", model="pi", metadata={})
+
+    client = RuntimeBridgeClient(mock_runtime)
+    long_feedback = "feedback-" * 1000
+    client.generate_multiturn(
+        model="ignored",
+        system="system prompt",
+        messages=[
+            {"role": "user", "content": "initial request"},
+            {"role": "assistant", "content": "assistant response 1"},
+            {"role": "user", "content": long_feedback},
+            {"role": "assistant", "content": "assistant response 2"},
+            {"role": "user", "content": "latest feedback"},
+        ],
+        max_tokens=100,
+        temperature=0.5,
+        role="architect",
+    )
+
+    prompt = mock_runtime.generate.call_args.args[0]
+    assert "system prompt" in prompt
+    assert "initial request" in prompt
+    assert "latest feedback" in prompt
+    assert "assistant response 1" not in prompt
+    assert "assistant response 2" not in prompt
+    assert "[truncated]" in prompt
+    assert len(prompt) < len(long_feedback)
+
+
 # ---------------------------------------------------------------------------
 # create_role_client("pi")
 # ---------------------------------------------------------------------------

--- a/autocontext/tests/test_rlm_competitor.py
+++ b/autocontext/tests/test_rlm_competitor.py
@@ -86,19 +86,22 @@ def seeded_artifacts(tmp_artifacts: Any, tmp_path: Path) -> Any:
     replay_dir = gen_dir / "replays"
     replay_dir.mkdir(parents=True)
     (replay_dir / "grid_ctf_1.json").write_text(
-        json.dumps({"score": 0.7, "moves": [1, 2, 3]}), encoding="utf-8",
+        json.dumps({"score": 0.7, "moves": [1, 2, 3]}),
+        encoding="utf-8",
     )
 
     # Create metrics
     (gen_dir / "metrics.json").write_text(
-        json.dumps({"elo": 1200, "win_rate": 0.6}), encoding="utf-8",
+        json.dumps({"elo": 1200, "win_rate": 0.6}),
+        encoding="utf-8",
     )
 
     # Create analysis
     analysis_dir = tmp_artifacts.knowledge_root / scenario / "analysis"
     analysis_dir.mkdir(parents=True)
     (analysis_dir / "gen_1.md").write_text(
-        "## Findings\n\n- Score improved.", encoding="utf-8",
+        "## Findings\n\n- Score improved.",
+        encoding="utf-8",
     )
 
     return tmp_artifacts
@@ -111,11 +114,16 @@ def seeded_artifacts(tmp_artifacts: Any, tmp_path: Path) -> Any:
 
 class TestContextLoaderCompetitor:
     def test_load_for_competitor_populates_replays(
-        self, context_loader: Any, seeded_artifacts: Any, tmp_sqlite: Any,
+        self,
+        context_loader: Any,
+        seeded_artifacts: Any,
+        tmp_sqlite: Any,
     ) -> None:
         """Replays loaded from run artifacts."""
         ctx = context_loader.load_for_competitor(
-            run_id="test_run", scenario_name="grid_ctf", generation=1,
+            run_id="test_run",
+            scenario_name="grid_ctf",
+            generation=1,
         )
         assert isinstance(ctx, RlmContext)
         assert isinstance(ctx.variables["replays"], list)
@@ -123,47 +131,70 @@ class TestContextLoaderCompetitor:
         assert ctx.variables["replays"][0]["score"] == 0.7
 
     def test_load_for_competitor_populates_metrics(
-        self, context_loader: Any, seeded_artifacts: Any, tmp_sqlite: Any,
+        self,
+        context_loader: Any,
+        seeded_artifacts: Any,
+        tmp_sqlite: Any,
     ) -> None:
         """Metrics history loaded."""
         ctx = context_loader.load_for_competitor(
-            run_id="test_run", scenario_name="grid_ctf", generation=1,
+            run_id="test_run",
+            scenario_name="grid_ctf",
+            generation=1,
         )
         assert isinstance(ctx.variables["metrics_history"], list)
         assert len(ctx.variables["metrics_history"]) == 1
         assert ctx.variables["metrics_history"][0]["elo"] == 1200
 
     def test_load_for_competitor_populates_match_scores(
-        self, context_loader: Any, seeded_artifacts: Any, tmp_sqlite: Any,
+        self,
+        context_loader: Any,
+        seeded_artifacts: Any,
+        tmp_sqlite: Any,
     ) -> None:
         """Match scores from DB (empty list when no matches recorded)."""
         ctx = context_loader.load_for_competitor(
-            run_id="test_run", scenario_name="grid_ctf", generation=1,
+            run_id="test_run",
+            scenario_name="grid_ctf",
+            generation=1,
         )
         assert isinstance(ctx.variables["match_scores"], list)
 
     def test_load_for_competitor_populates_playbook(
-        self, context_loader: Any, seeded_artifacts: Any, tmp_sqlite: Any,
+        self,
+        context_loader: Any,
+        seeded_artifacts: Any,
+        tmp_sqlite: Any,
     ) -> None:
         """Playbook string loaded."""
         ctx = context_loader.load_for_competitor(
-            run_id="test_run", scenario_name="grid_ctf", generation=1,
+            run_id="test_run",
+            scenario_name="grid_ctf",
+            generation=1,
         )
         assert isinstance(ctx.variables["playbook"], str)
         assert "aggressive" in ctx.variables["playbook"].lower()
 
     def test_load_for_competitor_populates_coach_hints(
-        self, context_loader: Any, seeded_artifacts: Any, tmp_sqlite: Any,
+        self,
+        context_loader: Any,
+        seeded_artifacts: Any,
+        tmp_sqlite: Any,
     ) -> None:
         """Hints loaded."""
         ctx = context_loader.load_for_competitor(
-            run_id="test_run", scenario_name="grid_ctf", generation=1,
+            run_id="test_run",
+            scenario_name="grid_ctf",
+            generation=1,
         )
         assert isinstance(ctx.variables["coach_hints"], str)
         assert "aggression" in ctx.variables["coach_hints"].lower()
 
     def test_load_for_competitor_populates_scenario_context(
-        self, context_loader: Any, seeded_artifacts: Any, tmp_sqlite: Any,
+        self,
+        context_loader: Any,
+        seeded_artifacts: Any,
+        tmp_sqlite: Any,
     ) -> None:
         """Rules + interface + current strategy populated."""
         ctx = context_loader.load_for_competitor(
@@ -179,17 +210,29 @@ class TestContextLoaderCompetitor:
         assert ctx.variables["current_strategy"] == {"aggression": 0.5}
 
     def test_load_for_competitor_summary_format(
-        self, context_loader: Any, seeded_artifacts: Any, tmp_sqlite: Any,
+        self,
+        context_loader: Any,
+        seeded_artifacts: Any,
+        tmp_sqlite: Any,
     ) -> None:
         """Summary string has all variable names."""
         ctx = context_loader.load_for_competitor(
-            run_id="test_run", scenario_name="grid_ctf", generation=1,
+            run_id="test_run",
+            scenario_name="grid_ctf",
+            generation=1,
         )
         summary = ctx.summary
         expected_vars = [
-            "replays", "metrics_history", "match_scores", "playbook",
-            "coach_hints", "scenario_rules", "strategy_interface",
-            "current_strategy", "prior_analyses", "operational_lessons",
+            "replays",
+            "metrics_history",
+            "match_scores",
+            "playbook",
+            "coach_hints",
+            "scenario_rules",
+            "strategy_interface",
+            "current_strategy",
+            "prior_analyses",
+            "operational_lessons",
         ]
         for var in expected_vars:
             assert var in summary, f"Expected '{var}' in summary"
@@ -206,9 +249,7 @@ class TestCompetitorPrompts:
         from autocontext.rlm.prompts import COMPETITOR_RLM_SYSTEM
 
         for placeholder in ["{max_turns}", "{max_stdout_chars}", "{variable_summary}"]:
-            assert placeholder in COMPETITOR_RLM_SYSTEM, (
-                f"Missing placeholder {placeholder}"
-            )
+            assert placeholder in COMPETITOR_RLM_SYSTEM, f"Missing placeholder {placeholder}"
 
     def test_competitor_rlm_constrained_has_constraints(self) -> None:
         """Constrained variant has constraint bullets."""
@@ -274,14 +315,9 @@ class _CompetitorReadyClient(LanguageModelClient):
     ) -> ModelResponse:
         self._turn += 1
         if self._turn == 1:
-            text = '<code>\nprint(len(replays))\nprint(scenario_rules)\n</code>'
+            text = "<code>\nprint(len(replays))\nprint(scenario_rules)\n</code>"
         else:
-            text = (
-                '<code>\n'
-                'answer["content"] = \'{"aggression": 0.65, "defense": 0.55}\'\n'
-                'answer["ready"] = True\n'
-                '</code>'
-            )
+            text = '<code>\nanswer["content"] = \'{"aggression": 0.65, "defense": 0.55}\'\nanswer["ready"] = True\n</code>'
         return ModelResponse(
             text=text,
             usage=RoleUsage(input_tokens=50, output_tokens=30, latency_ms=2, model=model),
@@ -428,7 +464,10 @@ class TestCompetitorRlmSession:
 
 class TestOrchestratorCompetitorRlm:
     def test_orchestrator_uses_rlm_when_enabled(
-        self, tmp_artifacts: Any, tmp_sqlite: Any, seeded_artifacts: Any,
+        self,
+        tmp_artifacts: Any,
+        tmp_sqlite: Any,
+        seeded_artifacts: Any,
     ) -> None:
         """When rlm_competitor_enabled=True, run_generation uses RLM path for competitor."""
         from autocontext.agents.orchestrator import AgentOrchestrator
@@ -467,7 +506,9 @@ class TestOrchestratorCompetitorRlm:
         assert "competitor" in roles
 
     def test_orchestrator_skips_rlm_when_disabled(
-        self, tmp_artifacts: Any, tmp_sqlite: Any,
+        self,
+        tmp_artifacts: Any,
+        tmp_sqlite: Any,
     ) -> None:
         """When rlm_competitor_enabled=False, normal single-shot path is used."""
         from autocontext.agents.orchestrator import AgentOrchestrator
@@ -504,7 +545,10 @@ class TestOrchestratorCompetitorRlm:
         assert "competitor" in roles
 
     def test_orchestrator_passes_scenario_rules_and_strategy(
-        self, tmp_artifacts: Any, tmp_sqlite: Any, seeded_artifacts: Any,
+        self,
+        tmp_artifacts: Any,
+        tmp_sqlite: Any,
+        seeded_artifacts: Any,
     ) -> None:
         """scenario_rules and current_strategy reach the context loader."""
         from autocontext.agents.orchestrator import AgentOrchestrator
@@ -551,7 +595,10 @@ class TestOrchestratorCompetitorRlm:
         assert captured_kwargs.get("current_strategy") == {"aggression": 0.5}
 
     def test_orchestrator_passes_scenario_rules_to_analyst_and_architect(
-        self, tmp_artifacts: Any, tmp_sqlite: Any, seeded_artifacts: Any,
+        self,
+        tmp_artifacts: Any,
+        tmp_sqlite: Any,
+        seeded_artifacts: Any,
     ) -> None:
         """scenario_rules reaches the analyst and architect context loaders."""
         from autocontext.agents.orchestrator import AgentOrchestrator
@@ -563,6 +610,7 @@ class TestOrchestratorCompetitorRlm:
             rlm_competitor_enabled=False,  # Use normal competitor path
             rlm_max_turns=5,
             curator_enabled=False,
+            architect_every_n_gens=1,
         )
         orch = AgentOrchestrator(
             client=DeterministicDevClient(),
@@ -605,6 +653,109 @@ class TestOrchestratorCompetitorRlm:
         assert analyst_kwargs.get("scenario_rules") == "Capture the flag on a 5x5 grid."
         assert architect_kwargs.get("scenario_rules") == "Capture the flag on a 5x5 grid."
 
+    def test_orchestrator_skips_off_cadence_rlm_architect_session(
+        self,
+        tmp_artifacts: Any,
+        tmp_sqlite: Any,
+        seeded_artifacts: Any,
+    ) -> None:
+        """Off-cadence architect generations should skip the live RLM architect session."""
+        from autocontext.agents.orchestrator import AgentOrchestrator
+        from autocontext.prompts.templates import PromptBundle
+
+        settings = AppSettings(
+            agent_provider="deterministic",
+            rlm_enabled=True,
+            rlm_competitor_enabled=False,
+            rlm_max_turns=5,
+            curator_enabled=False,
+            architect_every_n_gens=3,
+        )
+        orch = AgentOrchestrator(
+            client=DeterministicDevClient(),
+            settings=settings,
+            artifacts=seeded_artifacts,
+            sqlite=tmp_sqlite,
+        )
+        prompts = PromptBundle(
+            competitor="Describe your strategy.",
+            analyst="Analyze.",
+            coach="Coach.",
+            architect="Propose.",
+        )
+
+        calls: list[str] = []
+        original = orch._run_single_rlm_session
+
+        def _spy_run_single(*args: Any, **kwargs: Any) -> tuple[RoleExecution, list[Any]]:
+            calls.append(kwargs["role"])
+            return original(*args, **kwargs)
+
+        with patch.object(orch, "_run_single_rlm_session", side_effect=_spy_run_single):
+            outputs = orch.run_generation(
+                prompts,
+                generation_index=2,
+                run_id="test_run",
+                scenario_name="grid_ctf",
+                scenario_rules="Capture the flag on a 5x5 grid.",
+            )
+
+        assert calls.count("analyst") == 1
+        assert "architect" not in calls
+        assert outputs.architect_tools == []
+        assert "empty tools array" in outputs.architect_markdown.lower()
+
+    def test_orchestrator_skips_no_data_rlm_analyst_session(
+        self,
+        tmp_artifacts: Any,
+        tmp_sqlite: Any,
+        seeded_artifacts: Any,
+    ) -> None:
+        """No-data generations should skip the live RLM analyst session."""
+        from autocontext.agents.orchestrator import AgentOrchestrator
+        from autocontext.prompts.templates import PromptBundle
+
+        settings = AppSettings(
+            agent_provider="deterministic",
+            rlm_enabled=True,
+            rlm_competitor_enabled=False,
+            rlm_max_turns=5,
+            curator_enabled=False,
+            architect_every_n_gens=3,
+        )
+        orch = AgentOrchestrator(
+            client=DeterministicDevClient(),
+            settings=settings,
+            artifacts=seeded_artifacts,
+            sqlite=tmp_sqlite,
+        )
+        prompts = PromptBundle(
+            competitor="Describe your strategy.",
+            analyst="Analyze.",
+            coach="Coach.",
+            architect="Propose.",
+        )
+
+        calls: list[str] = []
+        original = orch._run_single_rlm_session
+
+        def _spy_run_single(*args: Any, **kwargs: Any) -> tuple[RoleExecution, list[Any]]:
+            calls.append(kwargs["role"])
+            return original(*args, **kwargs)
+
+        with patch.object(orch, "_run_single_rlm_session", side_effect=_spy_run_single):
+            outputs = orch.run_generation(
+                prompts,
+                generation_index=1,
+                run_id="fresh_run",
+                scenario_name="grid_ctf",
+                scenario_rules="Capture the flag on a 5x5 grid.",
+            )
+
+        assert "analyst" not in calls
+        assert "architect" not in calls
+        assert "no fresh match data" in outputs.analysis_markdown.lower()
+
 
 # ===========================================================================
 # 6. RLM Trial Summary & Experiment Log Tests (AC-100)
@@ -622,9 +773,11 @@ class TestBuildTrialSummary:
             ExecutionRecord(turn=2, code='answer["ready"] = True', stdout="", error=None, answer_ready=True),
         ]
         role_exec = RoleExecution(
-            role="competitor", content="done",
+            role="competitor",
+            content="done",
             usage=RoleUsage(input_tokens=100, output_tokens=50, latency_ms=500, model="test"),
-            subagent_id="abc", status="completed",
+            subagent_id="abc",
+            status="completed",
         )
         summary = _build_trial_summary(3, history, role_exec)
         assert "Generation 3" in summary
@@ -642,9 +795,11 @@ class TestBuildTrialSummary:
             ExecutionRecord(turn=2, code="ok()", stdout="ok", error=None, answer_ready=True),
         ]
         role_exec = RoleExecution(
-            role="competitor", content="done",
+            role="competitor",
+            content="done",
             usage=RoleUsage(input_tokens=10, output_tokens=10, latency_ms=100, model="t"),
-            subagent_id="x", status="completed",
+            subagent_id="x",
+            status="completed",
         )
         summary = _build_trial_summary(1, history, role_exec)
         assert "errors: 1" in summary
@@ -659,9 +814,11 @@ class TestBuildTrialSummary:
             ExecutionRecord(turn=1, code='answer["ready"] = True', stdout="", error=None, answer_ready=True),
         ]
         role_exec = RoleExecution(
-            role="competitor", content="done",
+            role="competitor",
+            content="done",
             usage=RoleUsage(input_tokens=10, output_tokens=10, latency_ms=50, model="t"),
-            subagent_id="x", status="completed",
+            subagent_id="x",
+            status="completed",
         )
         summary = _build_trial_summary(1, history, role_exec)
         assert "[READY]" in summary
@@ -681,8 +838,17 @@ class TestExperimentLog:
         """Create run + generation rows so FK constraints pass."""
         sqlite.create_run(run_id, "grid_ctf", len(generations), "local")
         for gen in generations:
-            sqlite.upsert_generation(run_id, gen, mean_score=0.5, best_score=0.5, elo=1500.0,
-                                     wins=0, losses=0, gate_decision="advance", status="completed")
+            sqlite.upsert_generation(
+                run_id,
+                gen,
+                mean_score=0.5,
+                best_score=0.5,
+                elo=1500.0,
+                wins=0,
+                losses=0,
+                gate_decision="advance",
+                status="completed",
+            )
 
     def test_build_experiment_log_collects_summaries(self, tmp_sqlite: Any) -> None:
         """Collects stored trial summaries across generations."""
@@ -714,7 +880,10 @@ class TestExperimentLog:
 
 class TestRlmTrialStorage:
     def test_rlm_competitor_stores_trial_summary(
-        self, tmp_artifacts: Any, tmp_sqlite: Any, seeded_artifacts: Any,
+        self,
+        tmp_artifacts: Any,
+        tmp_sqlite: Any,
+        seeded_artifacts: Any,
     ) -> None:
         """Running competitor via RLM stores a trial summary in sqlite."""
         from autocontext.agents.orchestrator import AgentOrchestrator
@@ -735,9 +904,17 @@ class TestRlmTrialStorage:
 
         # Seed run + generation so FK constraints pass
         tmp_sqlite.create_run("trial-test", "grid_ctf", 1, "local")
-        tmp_sqlite.upsert_generation("trial-test", 1, mean_score=0.5, best_score=0.5,
-                                     elo=1500.0, wins=0, losses=0, gate_decision="advance",
-                                     status="completed")
+        tmp_sqlite.upsert_generation(
+            "trial-test",
+            1,
+            mean_score=0.5,
+            best_score=0.5,
+            elo=1500.0,
+            wins=0,
+            losses=0,
+            gate_decision="advance",
+            status="completed",
+        )
 
         orch._run_rlm_competitor(
             run_id="trial-test",

--- a/autocontext/tests/test_rlm_context_loader.py
+++ b/autocontext/tests/test_rlm_context_loader.py
@@ -52,7 +52,9 @@ class TestLoadForAnalyst:
         )
 
         ctx = loader.load_for_analyst(
-            "r1", "grid_ctf", 1,
+            "r1",
+            "grid_ctf",
+            1,
             scenario_rules="Test rules",
             strategy_interface="Test interface",
             current_strategy={"aggression": 0.5},
@@ -76,6 +78,28 @@ class TestLoadForAnalyst:
 
 
 class TestLoadForArchitect:
+    def test_truncates_large_text_blobs_for_architect_context(self, store_pair: tuple[ArtifactStore, SQLiteStore]) -> None:
+        artifacts, sqlite = store_pair
+        loader = ContextLoader(artifacts, sqlite)
+
+        sqlite.create_run("r1", "grid_ctf", 1, "local")
+        changelog_path = artifacts.knowledge_root / "grid_ctf" / "architect" / "changelog.md"
+        changelog_path.parent.mkdir(parents=True, exist_ok=True)
+        changelog_path.write_text("A" * 12000, encoding="utf-8")
+        skill_dir = artifacts.skills_root / "grid-ctf-ops"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            "# Grid CTF Ops\n\n## Operational Lessons\n" + ("B" * 9000),
+            encoding="utf-8",
+        )
+
+        ctx = loader.load_for_architect("r1", "grid_ctf", 1)
+
+        assert len(ctx.variables["architect_changelog"]) < 12000
+        assert len(ctx.variables["operational_lessons"]) < 9000
+        assert "[truncated" in ctx.variables["architect_changelog"]
+        assert "[truncated" in ctx.variables["operational_lessons"]
+
     def test_includes_existing_tools(self, store_pair: tuple[ArtifactStore, SQLiteStore]) -> None:
         artifacts, sqlite = store_pair
         loader = ContextLoader(artifacts, sqlite)
@@ -83,9 +107,13 @@ class TestLoadForArchitect:
         sqlite.create_run("r1", "grid_ctf", 2, "local")
 
         # Create a tool file
-        artifacts.persist_tools("grid_ctf", 1, [
-            {"name": "threat_assessor", "description": "Risk estimator", "code": "def run(x): return x"},
-        ])
+        artifacts.persist_tools(
+            "grid_ctf",
+            1,
+            [
+                {"name": "threat_assessor", "description": "Risk estimator", "code": "def run(x): return x"},
+            ],
+        )
 
         ctx = loader.load_for_architect("r1", "grid_ctf", 1, scenario_rules="Rules here")
 

--- a/autocontext/tests/test_rlm_repl_worker.py
+++ b/autocontext/tests/test_rlm_repl_worker.py
@@ -46,12 +46,20 @@ class TestReplWorkerNamespace:
 
     def test_safe_modules_available(self) -> None:
         worker = ReplWorker()
-        worker.run_code(ReplCommand("import json; print(json.dumps({'a': 1}))"))
-        # json is in the namespace directly, but import also works via builtins
-        # Either way, the namespace has json available
+        result = worker.run_code(ReplCommand("import json; print(json.dumps({'a': 1}))"))
+        assert result.error is None
+        assert '{"a": 1}' in result.stdout
+
+        # json is in the namespace directly, but import should also work via builtins
         worker2 = ReplWorker()
         result2 = worker2.run_code(ReplCommand('print(json.dumps({"a": 1}))'))
+        assert result2.error is None
         assert '{"a": 1}' in result2.stdout
+
+        worker3 = ReplWorker()
+        result3 = worker3.run_code(ReplCommand("import pprint; pprint.pprint({'a': 1})"))
+        assert result3.error is None
+        assert "{'a': 1}" in result3.stdout
 
 
 class TestReplWorkerTruncation:

--- a/autocontext/tests/test_rlm_session.py
+++ b/autocontext/tests/test_rlm_session.py
@@ -60,8 +60,12 @@ class TestRlmSession:
         client = DeterministicDevClient()
         worker1 = ReplWorker()
         session1 = RlmSession(
-            client=client, worker=worker1, role="analyst",
-            model="m", system_prompt="s", max_turns=5,
+            client=client,
+            worker=worker1,
+            role="analyst",
+            model="m",
+            system_prompt="s",
+            max_turns=5,
         )
         r1 = session1.run()
         assert r1.status == "completed"
@@ -69,8 +73,12 @@ class TestRlmSession:
         client.reset_rlm_turns()
         worker2 = ReplWorker()
         session2 = RlmSession(
-            client=client, worker=worker2, role="architect",
-            model="m", system_prompt="s", max_turns=5,
+            client=client,
+            worker=worker2,
+            role="architect",
+            model="m",
+            system_prompt="s",
+            max_turns=5,
         )
         r2 = session2.run()
         assert r2.status == "completed"
@@ -115,8 +123,12 @@ class TestRlmSessionExecutionHistory:
         client = DeterministicDevClient()
         worker = ReplWorker()
         session = RlmSession(
-            client=client, worker=worker, role="analyst",
-            model="m", system_prompt="s", max_turns=5,
+            client=client,
+            worker=worker,
+            role="analyst",
+            model="m",
+            system_prompt="s",
+            max_turns=5,
         )
         session.run()
         assert len(session.execution_history) == 2
@@ -128,8 +140,12 @@ class TestRlmSessionExecutionHistory:
         client = _ErrorThenReadyClient()
         worker = ReplWorker()
         session = RlmSession(
-            client=client, worker=worker, role="analyst",
-            model="m", system_prompt="s", max_turns=5,
+            client=client,
+            worker=worker,
+            role="analyst",
+            model="m",
+            system_prompt="s",
+            max_turns=5,
         )
         session.run()
         assert len(session.execution_history) == 2
@@ -141,8 +157,12 @@ class TestRlmSessionExecutionHistory:
         client = DeterministicDevClient()
         worker = ReplWorker()
         session = RlmSession(
-            client=client, worker=worker, role="analyst",
-            model="m", system_prompt="s", max_turns=5,
+            client=client,
+            worker=worker,
+            role="analyst",
+            model="m",
+            system_prompt="s",
+            max_turns=5,
         )
         result = session.run()
         assert result.status == "completed"
@@ -155,11 +175,59 @@ class TestRlmSessionExecutionHistory:
         client = _NeverReadyClient()
         worker = ReplWorker()
         session = RlmSession(
-            client=client, worker=worker, role="analyst",
-            model="m", system_prompt="s", max_turns=3,
+            client=client,
+            worker=worker,
+            role="analyst",
+            model="m",
+            system_prompt="s",
+            max_turns=3,
         )
         session.run()
         assert len(session.execution_history) == 3
+
+    def test_session_compacts_large_feedback_messages(self) -> None:
+        client = _FeedbackCapturingClient()
+        worker = ReplWorker(max_stdout_chars=10000)
+        session = RlmSession(
+            client=client,
+            worker=worker,
+            role="architect",
+            model="m",
+            system_prompt="s",
+            max_turns=3,
+        )
+
+        result = session.run()
+
+        assert result.status == "completed"
+        second_call_messages = client.calls[1]
+        feedback_messages = [m for m in second_call_messages if m["role"] == "user"]
+        assert len(feedback_messages) >= 2
+        latest_feedback = feedback_messages[-1]["content"]
+        assert "[stdout]" in latest_feedback
+        assert "[truncated]" in latest_feedback
+        assert len(latest_feedback) < 2000
+
+    def test_session_adds_finalize_nudge_after_multiple_successful_turns(self) -> None:
+        client = _FinalizeNudgeCapturingClient()
+        worker = ReplWorker()
+        session = RlmSession(
+            client=client,
+            worker=worker,
+            role="analyst",
+            model="m",
+            system_prompt="s",
+            max_turns=4,
+        )
+
+        result = session.run()
+
+        assert result.status == "completed"
+        third_call_messages = client.calls[2]
+        feedback_messages = [m for m in third_call_messages if m["role"] == "user"]
+        latest_feedback = feedback_messages[-1]["content"]
+        assert "finalize now" in latest_feedback.lower()
+        assert 'answer["content"]' in latest_feedback
 
 
 class _ErrorThenReadyClient(LanguageModelClient):
@@ -169,12 +237,18 @@ class _ErrorThenReadyClient(LanguageModelClient):
         self._turn = 0
 
     def generate_multiturn(
-        self, *, model: str, system: str, messages: list[dict[str, str]],
-        max_tokens: int, temperature: float, role: str = "",
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+        temperature: float,
+        role: str = "",
     ) -> ModelResponse:
         self._turn += 1
         if self._turn == 1:
-            text = '<code>\n1 / 0\n</code>'
+            text = "<code>\n1 / 0\n</code>"
         else:
             text = '<code>\nanswer["content"] = "recovered"\nanswer["ready"] = True\n</code>'
         return ModelResponse(
@@ -187,10 +261,70 @@ class _NeverReadyClient(LanguageModelClient):
     """Always returns code that prints but never sets answer['ready']."""
 
     def generate_multiturn(
-        self, *, model: str, system: str, messages: list[dict[str, str]],
-        max_tokens: int, temperature: float, role: str = "",
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+        temperature: float,
+        role: str = "",
     ) -> ModelResponse:
         return ModelResponse(
             text='<code>\nprint("still working")\n</code>',
+            usage=RoleUsage(input_tokens=10, output_tokens=10, latency_ms=1, model=model),
+        )
+
+
+class _FeedbackCapturingClient(LanguageModelClient):
+    def __init__(self) -> None:
+        self._turn = 0
+        self.calls: list[list[dict[str, str]]] = []
+
+    def generate_multiturn(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+        temperature: float,
+        role: str = "",
+    ) -> ModelResponse:
+        self.calls.append([dict(message) for message in messages])
+        self._turn += 1
+        if self._turn == 1:
+            text = '<code>\nprint("x" * 5000)\n</code>'
+        else:
+            text = '<code>\nanswer["content"] = "done"\nanswer["ready"] = True\n</code>'
+        return ModelResponse(
+            text=text,
+            usage=RoleUsage(input_tokens=10, output_tokens=10, latency_ms=1, model=model),
+        )
+
+
+class _FinalizeNudgeCapturingClient(LanguageModelClient):
+    def __init__(self) -> None:
+        self._turn = 0
+        self.calls: list[list[dict[str, str]]] = []
+
+    def generate_multiturn(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+        temperature: float,
+        role: str = "",
+    ) -> ModelResponse:
+        self.calls.append([dict(message) for message in messages])
+        self._turn += 1
+        if self._turn < 3:
+            text = '<code>\nprint("ok")\n</code>'
+        else:
+            text = '<code>\nanswer["content"] = "done"\nanswer["ready"] = True\n</code>'
+        return ModelResponse(
+            text=text,
             usage=RoleUsage(input_tokens=10, output_tokens=10, latency_ms=1, model=model),
         )


### PR DESCRIPTION
## Summary

- harden Python RLM ecosystem runs against live Pi flake paths that were killing the provider-cycling stress workflow
- skip low-value RLM work on no-data analyst generations and off-cadence architect generations, while making REPL sessions and prompt handling more robust when live Pi is slow or returns awkward outputs

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check ...`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest ...`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Manual verification:
- `cd /Users/jayscambler/Repositories/autocontext/autocontext-ac-583/autocontext && uv run pytest tests/test_rlm_context_loader.py tests/test_rlm_repl_worker.py tests/test_harness/test_harness_repl_worker.py tests/test_rlm_session.py tests/test_ecosystem_runner.py tests/test_ecosystem_integration.py tests/test_per_role_provider.py tests/test_pi_cli_runtime.py tests/test_rlm_competitor.py tests/test_constraint_prompts.py tests/test_orchestrator_feedback.py tests/test_pipeline_adapter.py -x --tb=short`
- `cd /Users/jayscambler/Repositories/autocontext/autocontext-ac-583/autocontext && uv run ruff check src/autocontext/harness/repl/worker.py src/autocontext/harness/repl/session.py src/autocontext/rlm/prompts.py src/autocontext/rlm/context_loader.py src/autocontext/agents/orchestrator.py tests/test_rlm_repl_worker.py tests/test_rlm_session.py tests/test_constraint_prompts.py tests/test_rlm_competitor.py`
- live Pi-backed ecosystem rerun succeeded end-to-end:
  - root: `/tmp/ac583-live10-C9KuNy`
  - command: `uv run autoctx ecosystem --scenario grid_ctf --cycles 3 --gens-per-cycle 2 --provider-a pi --provider-b deterministic --rlm-a --no-rlm-b --json`
  - result: exit code `0`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- keeps the live Pi runtime in place; this is not a deterministic fallback
- the fix includes:
  - tighter runtime multiturn prompt compaction
  - safer REPL imports / helper guidance (`pprint`, text helpers)
  - compacted REPL feedback loops
  - truncated large RLM context blobs
  - RLM analyst no-data short-circuit
  - RLM architect off-cadence short-circuit honoring the existing cadence policy
- during one successful live validation run, a Pi timeout still appeared in stderr during a reflection step, but the ecosystem run recovered and completed successfully with exit code `0`
