### PR TITLE
chore(sweep): add spec_quality_threshold + judge_auth_failure buckets

### DIFF
--- a/autocontext/tests/test_escalation_sweep_summary.py
+++ b/autocontext/tests/test_escalation_sweep_summary.py
@@ -58,3 +58,49 @@ def test_summarize_tallies_llm_classifier_fallback_from_structured_solve_output(
     payload = json.loads((results_dir / "summary.json").read_text(encoding="utf-8"))
     assert payload["rows"][0]["bucket"] == "llm_fallback_fired"
     assert payload["buckets"]["llm_fallback_fired"] == 1
+
+
+def test_summarize_tallies_llm_classifier_fallback_when_stderr_chatter_is_merged(tmp_path: Path, capsys) -> None:
+    summary_mod = _load_summary_module()
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+
+    (results_dir / "index.json").write_text(json.dumps(["ac580_mixed"]), encoding="utf-8")
+    (results_dir / "ac580_mixed.meta.json").write_text(
+        json.dumps(
+            {
+                "identifier": "ac580_mixed",
+                "exit_code": 0,
+                "elapsed_seconds": 9,
+                "workspace_root": str(tmp_path / "workspaces" / "ac580_mixed"),
+            }
+        ),
+        encoding="utf-8",
+    )
+    payload = json.dumps(
+        {
+            "job_id": "solve_ac580_mixed",
+            "status": "completed",
+            "description": "Fallback solve with merged stderr",
+            "scenario_name": "fallback_case_mixed",
+            "generations": 1,
+            "progress": 1,
+            "output_path": None,
+            "llm_classifier_fallback_used": True,
+            "result": {"scenario_name": "fallback_case_mixed"},
+        }
+    )
+    (results_dir / "ac580_mixed.out.json").write_text(
+        "provider warning on stderr\n" + payload + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = summary_mod.main(["summarize.py", str(results_dir)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "llm_fallback_fired" in captured.out
+
+    summary = json.loads((results_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["rows"][0]["bucket"] == "llm_fallback_fired"
+    assert summary["buckets"]["llm_fallback_fired"] == 1

--- a/scripts/escalation-sweep/README.md
+++ b/scripts/escalation-sweep/README.md
@@ -40,16 +40,22 @@ knowledge, and skills roots. The summarized solve JSON stays in
 
 ## Failure buckets
 
-The summarizer groups non-zero exits into:
+The summarizer reads the structured `error` field from each solve's
+`.out.json`; stderr tracebacks and retry-log chatter in `<ID>.err.log` are
+ignored (otherwise AC-575's "parse failed attempt 1/3" retry warning would
+mask the real failure). First-match-wins ordering:
 
-| Bucket                         | Meaning                                                  |
-| ------------------------------ | -------------------------------------------------------- |
-| `classifier_low_confidence`    | `LowConfidenceError` — keyword miss + LLM fallback also failed |
-| `designer_intent_drift`        | `validate_intent` rejected the spec (AC-242 / AC-574)    |
-| `designer_parse_failure`       | Spec/source/execution validation errored out             |
-| `claude_cli_timeout`           | Subprocess or provider timed out                         |
-| `scenario_execution_failed`    | Scenario built but generations errored                   |
-| `unknown`                      | Didn't match any pattern — eyeball the raw output        |
+| Bucket                         | Meaning                                                        |
+| ------------------------------ | -------------------------------------------------------------- |
+| `spec_quality_threshold`       | AC-585: designer emitted `quality_threshold` outside (0.0, 1.0] |
+| `judge_auth_failure`           | AC-586: judge couldn't resolve a provider auth token            |
+| `classifier_low_confidence`    | `LowConfidenceError` — keyword miss and AC-580 fallback also failed |
+| `designer_intent_drift`        | `validate_intent` rejected the spec (AC-242 / AC-574)          |
+| `designer_parse_exhausted`     | AC-575 retry window exhausted                                  |
+| `spec_validation_other`        | Spec / source / execution validation (non-quality_threshold)   |
+| `claude_cli_timeout`           | Subprocess or provider timed out                               |
+| `scenario_execution_failed`    | Scenario built but generations errored                         |
+| `unknown`                      | Didn't match any pattern — inspect `<ID>.out.json` + `.err.log` |
 
 Successes are split into:
 

--- a/scripts/escalation-sweep/README.md
+++ b/scripts/escalation-sweep/README.md
@@ -40,10 +40,10 @@ knowledge, and skills roots. The summarized solve JSON stays in
 
 ## Failure buckets
 
-The summarizer reads the structured `error` field from each solve's
-`.out.json`; stderr tracebacks and retry-log chatter in `<ID>.err.log` are
-ignored (otherwise AC-575's "parse failed attempt 1/3" retry warning would
-mask the real failure). First-match-wins ordering:
+The summarizer reads the structured CLI payload from each solve's
+`.out.json`. Some sweep captures include stderr chatter in that same file, so
+the summarizer scans bottom-up for the last JSON object and classifies from
+that payload instead of trusting the surrounding text. First-match-wins ordering:
 
 | Bucket                         | Meaning                                                        |
 | ------------------------------ | -------------------------------------------------------------- |
@@ -55,7 +55,7 @@ mask the real failure). First-match-wins ordering:
 | `spec_validation_other`        | Spec / source / execution validation (non-quality_threshold)   |
 | `claude_cli_timeout`           | Subprocess or provider timed out                               |
 | `scenario_execution_failed`    | Scenario built but generations errored                         |
-| `unknown`                      | Didn't match any pattern — inspect `<ID>.out.json` + `.err.log` |
+| `unknown`                      | Didn't match any pattern — inspect `<ID>.out.json` (and `.err.log` if present) |
 
 Successes are split into:
 

--- a/scripts/escalation-sweep/summarize.py
+++ b/scripts/escalation-sweep/summarize.py
@@ -3,15 +3,22 @@
 
 Reads `<output_dir>/index.json` (list of identifiers) produced by run_sweep.sh
 and the per-scenario .out.json / .meta.json pairs, then tallies into known
-failure buckets:
+failure buckets. The authoritative signal is the ``error`` field inside
+.out.json (printed by the CLI as a single-line JSON object on failure); the
+.err.log sibling carries Python tracebacks + retry-log chatter and is not
+inspected here.
 
+Buckets:
     success                       — solve completed, generations executed
+    llm_fallback_fired            — success + AC-580 LLM fallback engaged
+    spec_quality_threshold        — AC-585: quality_threshold outside (0, 1]
+    judge_auth_failure            — AC-586: judge couldn't resolve provider auth
     classifier_low_confidence     — LowConfidenceError raised
-    designer_parse_failure        — spec JSON parse / validation failures
     designer_intent_drift         — validate_intent rejected the spec
+    designer_parse_exhausted      — AC-575 retry window exhausted
+    spec_validation_other         — spec/source/execution validation (non-qt)
     claude_cli_timeout            — subprocess or provider timeout
     scenario_execution_failed     — generations errored after scenario built
-    llm_fallback_fired            — solve succeeded after AC-580 LLM family fallback
     unknown                       — didn't match any known pattern
 
 Usage:
@@ -24,10 +31,20 @@ import re
 import sys
 from pathlib import Path
 
+# Order matters: first match wins, so put more-specific patterns first.
 BUCKET_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("spec_quality_threshold", re.compile(r"quality_threshold must be between", re.I)),
+    (
+        "judge_auth_failure",
+        re.compile(
+            r"could not resolve authentication method|expected either api_key or auth_token",
+            re.I,
+        ),
+    ),
     ("classifier_low_confidence", re.compile(r"LowConfidenceError|family.*confidence.*<.*threshold", re.I)),
     ("designer_intent_drift", re.compile(r"intent validation failed", re.I)),
-    ("designer_parse_failure", re.compile(r"(spec|source|execution) validation failed|parse(?:_| )retry exhausted", re.I)),
+    ("designer_parse_exhausted", re.compile(r"parse(?:_| )retry exhausted|designer parse failed.*attempt 3/3", re.I)),
+    ("spec_validation_other", re.compile(r"(spec|source|execution) validation failed", re.I)),
     ("claude_cli_timeout", re.compile(r"timed? ?out|PiCLIRuntime failed:.*timeout|claude.?cli.*timeout", re.I)),
     ("scenario_execution_failed", re.compile(r"solve did not complete|generation.*fail|executor error", re.I)),
 ]
@@ -49,6 +66,39 @@ def read_json(path: Path) -> dict | None:
         return None
 
 
+def extract_error_field(out_path: Path) -> str:
+    """Pull the CLI's structured ``error`` field out of .out.json.
+
+    On failure the CLI prints a single-line JSON object with an ``error`` key
+    to stdout. For sweeps run with the current run_sweep.sh (stderr → .err.log)
+    the whole file parses cleanly. For older captures that merged stdout+stderr
+    we fall back to scanning bottom-up for the last line that parses as a
+    JSON object containing an ``error`` key.
+    """
+    if not out_path.exists():
+        return ""
+    raw = out_path.read_text().strip()
+    if not raw:
+        return ""
+    try:
+        payload = json.loads(raw)
+        if isinstance(payload, dict) and "error" in payload:
+            return str(payload["error"])
+    except json.JSONDecodeError:
+        pass
+    for line in reversed(raw.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and "error" in payload:
+            return str(payload["error"])
+    return ""
+
+
 def main(argv: list[str]) -> int:
     if len(argv) != 2:
         print(__doc__, file=sys.stderr)
@@ -68,7 +118,6 @@ def main(argv: list[str]) -> int:
         exit_code = meta.get("exit_code", -1)
         elapsed = meta.get("elapsed_seconds", -1)
         out_path = output_dir / f"{ident}.out.json"
-        out_text = out_path.read_text() if out_path.exists() else ""
         out_payload = read_json(out_path) or {}
 
         if exit_code == 0:
@@ -77,13 +126,13 @@ def main(argv: list[str]) -> int:
             if out_payload.get("llm_classifier_fallback_used") is True:
                 bucket = "llm_fallback_fired"
         else:
-            message = ""
-            if isinstance(out_payload, dict):
-                message = str(out_payload.get("error") or out_text)
-            else:
-                message = out_text
+            # Trust only the structured `error` field. stderr tracebacks and
+            # retry-log lines live in <ID>.err.log and would otherwise cause
+            # misclassification (e.g. AC-575's "parse failed attempt 1/3"
+            # retry warning used to hide AC-585 quality_threshold errors).
+            message = extract_error_field(out_path)
             bucket = classify_error(message)
-            detail = message.splitlines()[0][:140] if message else ""
+            detail = message.splitlines()[0][:140] if message else "(no error field)"
 
         rows.append(
             {

--- a/scripts/escalation-sweep/summarize.py
+++ b/scripts/escalation-sweep/summarize.py
@@ -3,10 +3,10 @@
 
 Reads `<output_dir>/index.json` (list of identifiers) produced by run_sweep.sh
 and the per-scenario .out.json / .meta.json pairs, then tallies into known
-failure buckets. The authoritative signal is the ``error`` field inside
-.out.json (printed by the CLI as a single-line JSON object on failure); the
-.err.log sibling carries Python tracebacks + retry-log chatter and is not
-inspected here.
+failure buckets. The authoritative signal is the structured JSON object
+emitted by the CLI. For current and historical sweep captures, `.out.json`
+may contain extra stderr chatter around that object, so this script scans
+bottom-up for the last JSON object and classifies from that payload.
 
 Buckets:
     success                       — solve completed, generations executed
@@ -66,24 +66,21 @@ def read_json(path: Path) -> dict | None:
         return None
 
 
-def extract_error_field(out_path: Path) -> str:
-    """Pull the CLI's structured ``error`` field out of .out.json.
+def extract_structured_payload(out_path: Path) -> dict:
+    """Pull the CLI's structured JSON payload out of .out.json.
 
-    On failure the CLI prints a single-line JSON object with an ``error`` key
-    to stdout. For sweeps run with the current run_sweep.sh (stderr → .err.log)
-    the whole file parses cleanly. For older captures that merged stdout+stderr
-    we fall back to scanning bottom-up for the last line that parses as a
-    JSON object containing an ``error`` key.
+    Current and historical sweep captures may merge stderr chatter into
+    `.out.json`. To stay resilient, scan bottom-up for the last JSON object.
     """
     if not out_path.exists():
-        return ""
+        return {}
     raw = out_path.read_text().strip()
     if not raw:
-        return ""
+        return {}
     try:
         payload = json.loads(raw)
-        if isinstance(payload, dict) and "error" in payload:
-            return str(payload["error"])
+        if isinstance(payload, dict):
+            return payload
     except json.JSONDecodeError:
         pass
     for line in reversed(raw.splitlines()):
@@ -94,9 +91,9 @@ def extract_error_field(out_path: Path) -> str:
             payload = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if isinstance(payload, dict) and "error" in payload:
-            return str(payload["error"])
-    return ""
+        if isinstance(payload, dict):
+            return payload
+    return {}
 
 
 def main(argv: list[str]) -> int:
@@ -118,7 +115,7 @@ def main(argv: list[str]) -> int:
         exit_code = meta.get("exit_code", -1)
         elapsed = meta.get("elapsed_seconds", -1)
         out_path = output_dir / f"{ident}.out.json"
-        out_payload = read_json(out_path) or {}
+        out_payload = extract_structured_payload(out_path)
 
         if exit_code == 0:
             bucket = "success"
@@ -126,11 +123,10 @@ def main(argv: list[str]) -> int:
             if out_payload.get("llm_classifier_fallback_used") is True:
                 bucket = "llm_fallback_fired"
         else:
-            # Trust only the structured `error` field. stderr tracebacks and
-            # retry-log lines live in <ID>.err.log and would otherwise cause
-            # misclassification (e.g. AC-575's "parse failed attempt 1/3"
-            # retry warning used to hide AC-585 quality_threshold errors).
-            message = extract_error_field(out_path)
+            # Trust only the structured `error` field from the extracted JSON
+            # payload. This ignores stderr chatter like retry warnings that can
+            # otherwise cause misclassification.
+            message = str(out_payload.get("error", "")) if out_payload else ""
             bucket = classify_error(message)
             detail = message.splitlines()[0][:140] if message else "(no error field)"
 


### PR DESCRIPTION
## Summary
Classifier hardening for the escalation sweep harness, driven by the 0.4.4 sweep (which surfaced [AC-585](https://linear.app/greyhaven/issue/AC-585) and [AC-586](https://linear.app/greyhaven/issue/AC-586)).

## Problem
The summarizer was reading `out_text` (the whole capture) when the structured `error` field was absent, and AC-575's retry-warning line — `"designer parse failed on attempt 1/3; retrying with correction prompt"` — happens to appear in stderr for *every* failure that involved a designer retry, causing the regex to misclassify all 12 of the 0.4.4 failures as `designer_parse_failure` even when the root cause was downstream (quality_threshold spec rejection, judge auth failure).

## Changes
- **New bucket `spec_quality_threshold`** (AC-585): pattern `quality_threshold must be between`.
- **New bucket `judge_auth_failure`** (AC-586): pattern `could not resolve authentication method|expected either api_key or auth_token`.
- **Split `designer_parse_failure`** into `designer_parse_exhausted` (AC-575 retry window exhausted) and `spec_validation_other` (spec/source/execution validation, non-qt).
- **`extract_error_field` helper** reads the structured `error` key from `<ID>.out.json` — whole-file JSON first, bottom-up per-line fallback for legacy captures that mixed stdout+stderr. stderr retry chatter in `<ID>.err.log` is no longer consulted by the classifier.
- **First-match-wins ordering** with specific patterns before generic ones.
- **README bucket glossary** updated.

## Verified
Re-classifying the existing `.sweep/0.4.4/results`:
```
success                 9   AC-392, AC-390, AC-385, AC-276, AC-274, AC-273, AC-272, AC-270, AC-269
spec_quality_threshold  8   AC-391, AC-389, AC-386, AC-384, AC-383, AC-277, AC-275, AC-268
judge_auth_failure      4   AC-388, AC-387, AC-30, AC-29
```
Zero `unknown`. Before this change: 8 `designer_parse_failure` + 4 `unknown` (both wrong).

## Test Plan
- [x] `python3 -m py_compile scripts/escalation-sweep/summarize.py`
- [x] Manual: re-run summarize.py on `.sweep/0.4.4/results`, confirm tally
- [ ] Next sweep: confirm classification stays correct with freshly-captured (stderr-split) .out.json