### PR TITLE
feat(ac-585): auto-heal quality_threshold spec violations

### DIFF
--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -103,14 +103,18 @@ class AgentTaskCreator:
         logger.info("designing agent task from description")
         spec = design_validated_agent_task(description, self.llm_fn)
 
-        # 1.5 Auto-heal: generate synthetic sample_input if needed (AC-309)
+        # 1.5 Auto-heal: generate synthetic sample_input if needed (AC-309),
+        # drop unsatisfiable runtime context keys, and clamp quality_threshold
+        # into the validator's (0.0, 1.0] range (AC-585).
         from autocontext.scenarios.custom.spec_auto_heal import (
+            heal_spec_quality_threshold,
             heal_spec_runtime_context_requirements,
             heal_spec_sample_input,
         )
 
         spec = heal_spec_sample_input(spec, description=description)
         spec = heal_spec_runtime_context_requirements(spec)
+        spec = heal_spec_quality_threshold(spec)
 
         # 2. Validate spec
         spec_errors = validate_for_family("agent_task", asdict(spec))

--- a/autocontext/src/autocontext/scenarios/custom/spec_auto_heal.py
+++ b/autocontext/src/autocontext/scenarios/custom/spec_auto_heal.py
@@ -14,6 +14,7 @@ Functions:
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import replace
 from typing import Any
@@ -24,6 +25,10 @@ from autocontext.scenarios.custom.agent_task_validator import (
     _CONTEXTUAL_DATA_PATTERNS,
     _has_inline_data_after,
 )
+
+logger = logging.getLogger(__name__)
+
+_QUALITY_THRESHOLD_DEFAULT = 0.9
 
 _AUTOMATIC_RUNTIME_CONTEXT_KEYS = frozenset(
     {
@@ -120,6 +125,35 @@ def heal_spec_sample_input(
 
     synthetic = generate_synthetic_sample_input(spec.task_prompt, description)
     return replace(spec, sample_input=synthetic)
+
+
+def heal_spec_quality_threshold(spec: AgentTaskSpec) -> AgentTaskSpec:
+    """Clamp ``quality_threshold`` into the validator's (0.0, 1.0] range (AC-585).
+
+    LLM designers occasionally emit out-of-range values (e.g. 1.5, 10, 0, -0.5)
+    which the spec validator rejects before any autoheal runs. This helper runs
+    before validation:
+
+    - Values > 1.0 are clamped to 1.0 (preserves "aim high" intent).
+    - Values <= 0.0 are replaced with the field default (0.9) because there is
+      no coherent interpretation of "stop improving at or below 0".
+
+    Valid values pass through unchanged.
+    """
+    qt = spec.quality_threshold
+    if qt > 1.0:
+        logger.warning(
+            "heal_spec_quality_threshold: clamping quality_threshold %s > 1.0 to 1.0", qt
+        )
+        return replace(spec, quality_threshold=1.0)
+    if qt <= 0.0:
+        logger.warning(
+            "heal_spec_quality_threshold: quality_threshold %s <= 0.0, falling back to default %s",
+            qt,
+            _QUALITY_THRESHOLD_DEFAULT,
+        )
+        return replace(spec, quality_threshold=_QUALITY_THRESHOLD_DEFAULT)
+    return spec
 
 
 def heal_spec_runtime_context_requirements(spec: AgentTaskSpec) -> AgentTaskSpec:

--- a/autocontext/tests/test_heal_quality_threshold.py
+++ b/autocontext/tests/test_heal_quality_threshold.py
@@ -1,0 +1,55 @@
+"""AC-585 — heal_spec_quality_threshold clamps designer output into the valid range."""
+from __future__ import annotations
+
+import logging
+
+from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+from autocontext.scenarios.custom.spec_auto_heal import heal_spec_quality_threshold
+
+
+def _spec(quality_threshold: float) -> AgentTaskSpec:
+    return AgentTaskSpec(
+        task_prompt="do the thing",
+        judge_rubric="score 0-1",
+        quality_threshold=quality_threshold,
+    )
+
+
+class TestHealSpecQualityThreshold:
+    def test_clamps_above_one_to_one(self) -> None:
+        # Designer hallucinated a >1.0 threshold (e.g. 1.5, 10); clamp to 1.0.
+        healed = heal_spec_quality_threshold(_spec(1.5))
+        assert healed.quality_threshold == 1.0
+
+    def test_clamps_absurdly_large_to_one(self) -> None:
+        healed = heal_spec_quality_threshold(_spec(10.0))
+        assert healed.quality_threshold == 1.0
+
+    def test_replaces_zero_with_default(self) -> None:
+        # 0.0 is invalid (exclusive lower bound); fall back to the field default 0.9.
+        healed = heal_spec_quality_threshold(_spec(0.0))
+        assert healed.quality_threshold == 0.9
+
+    def test_replaces_negative_with_default(self) -> None:
+        healed = heal_spec_quality_threshold(_spec(-0.5))
+        assert healed.quality_threshold == 0.9
+
+    def test_preserves_valid_value(self) -> None:
+        # Anything in (0.0, 1.0] passes through unchanged.
+        healed = heal_spec_quality_threshold(_spec(0.7))
+        assert healed.quality_threshold == 0.7
+
+    def test_preserves_one_exactly(self) -> None:
+        # 1.0 is valid (inclusive upper bound).
+        healed = heal_spec_quality_threshold(_spec(1.0))
+        assert healed.quality_threshold == 1.0
+
+    def test_logs_warning_when_clamping(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="autocontext.scenarios.custom.spec_auto_heal"):
+            heal_spec_quality_threshold(_spec(1.5))
+        assert any("quality_threshold" in rec.message for rec in caplog.records)
+
+    def test_no_log_for_valid_value(self, caplog) -> None:
+        with caplog.at_level(logging.WARNING, logger="autocontext.scenarios.custom.spec_auto_heal"):
+            heal_spec_quality_threshold(_spec(0.7))
+        assert not any("quality_threshold" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
Fixes the spec-validation bucket that accounted for **8 of 12 failures** in the 0.4.4 escalation sweep. LLM designers occasionally emit \`quality_threshold\` values outside the validator's \`(0.0, 1.0]\` range (e.g. 1.5, 10, 0, -0.5); those specs were rejected before any auto-heal could run.

## Design
New helper \`heal_spec_quality_threshold\` in \`scenarios/custom/spec_auto_heal.py\`, wired into \`AgentTaskCreator.create\` alongside the existing \`heal_spec_sample_input\` / \`heal_spec_runtime_context_requirements\` calls — **before** \`validate_for_family\`.

- Values \`> 1.0\` → clamp to \`1.0\` (preserves "aim high" intent).
- Values \`<= 0.0\` → fall back to the field default \`0.9\` (no coherent "stop at or below 0" interpretation).
- Valid values pass through unchanged.
- WARNING log when a value is clamped or replaced so regressions surface in the sweep output.

## Test Plan
- [x] \`uv run pytest autocontext/tests/test_heal_quality_threshold.py\` — 8 new tests (clamp > 1, clamp absurdly large, replace zero, replace negative, preserve valid, preserve 1.0 exactly, warning logged, no log when valid).
- [x] \`uv run pytest\` — **5534 passed, 54 skipped**.
- [x] \`uv run ruff check src tests\` — clean.
- [x] \`uv run mypy src\` — clean (458 files).

## Linked
- Linear: AC-585
- Sweep surfaced by: \`scripts/escalation-sweep/\` (PR #739, merged)
- Related: AC-586 (judge provider inheritance — same sweep, different bucket).