### PR TITLE
feat(ac-586): judge_provider='auto' default inherits from agent_provider

### DIFF
--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -299,7 +299,7 @@ Key environment variables:
 | `AUTOCONTEXT_ANALYST_API_KEY` / `AUTOCONTEXT_ANALYST_BASE_URL`       | Optional analyst-specific credential and endpoint override                                          |
 | `AUTOCONTEXT_COACH_API_KEY` / `AUTOCONTEXT_COACH_BASE_URL`           | Optional coach-specific credential and endpoint override                                            |
 | `AUTOCONTEXT_ARCHITECT_API_KEY` / `AUTOCONTEXT_ARCHITECT_BASE_URL`   | Optional architect-specific credential and endpoint override                                        |
-| `AUTOCONTEXT_JUDGE_PROVIDER`                                         | Judge provider (defaults to `anthropic`)                                                            |
+| `AUTOCONTEXT_JUDGE_PROVIDER`                                         | Judge provider (defaults to `auto`: inherit a runtime-bridged role/agent provider, else fall back to `anthropic`) |
 | `AUTOCONTEXT_JUDGE_API_KEY`                                          | API key for the judge provider                                                                      |
 | `AUTOCONTEXT_JUDGE_BASE_URL`                                         | Base URL for OpenAI-compatible judge endpoints                                                      |
 | `AUTOCONTEXT_JUDGE_MODEL`                                            | Override judge model name                                                                           |

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -271,10 +271,11 @@ class AppSettings(BaseModel):
     judge_samples: int = Field(default=1, ge=1)
     judge_temperature: float = Field(default=0.0, ge=0.0)
     # Multi-model provider settings.
-    # Default "auto" (AC-586): inherit the judge provider from ``agent_provider``
-    # at get_provider() time when it's a runtime-bridged provider (claude-cli,
-    # codex, pi, pi-rpc). Falls back to "anthropic" for unrelated agent modes so
-    # existing API-key-based setups continue to work unchanged.
+    # Default "auto" (AC-586): inherit the judge provider from the effective
+    # runtime provider (role override first, then ``agent_provider``) when it's
+    # a runtime-bridged provider (claude-cli, codex, pi, pi-rpc). Falls back to
+    # "anthropic" for unrelated agent modes so existing API-key-based setups
+    # continue to work unchanged.
     judge_provider: str = Field(default="auto")
     judge_base_url: str | None = Field(default=None)
     judge_api_key: str | None = Field(default=None)

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -270,8 +270,12 @@ class AppSettings(BaseModel):
     judge_model: str = Field(default="claude-sonnet-4-20250514")
     judge_samples: int = Field(default=1, ge=1)
     judge_temperature: float = Field(default=0.0, ge=0.0)
-    # Multi-model provider settings
-    judge_provider: str = Field(default="anthropic")
+    # Multi-model provider settings.
+    # Default "auto" (AC-586): inherit the judge provider from ``agent_provider``
+    # at get_provider() time when it's a runtime-bridged provider (claude-cli,
+    # codex, pi, pi-rpc). Falls back to "anthropic" for unrelated agent modes so
+    # existing API-key-based setups continue to work unchanged.
+    judge_provider: str = Field(default="auto")
     judge_base_url: str | None = Field(default=None)
     judge_api_key: str | None = Field(default=None)
     # Evaluator disagreement (AC-330)

--- a/autocontext/src/autocontext/providers/registry.py
+++ b/autocontext/src/autocontext/providers/registry.py
@@ -94,25 +94,44 @@ def create_provider(
 
 # Agent providers that can be inherited as judge providers without extra
 # credentials. When judge_provider is left as its "auto" default (AC-586),
-# get_provider() inherits from agent_provider if it's in this set.
+# get_provider() inherits from the effective execution provider if it's in this
+# set.
 _RUNTIME_BRIDGE_PROVIDERS: frozenset[str] = frozenset(
     {"claude-cli", "codex", "pi", "pi-rpc"}
 )
+
+_AUTO_JUDGE_PROVIDER_PRIORITY: tuple[str, ...] = (
+    "competitor_provider",
+    "architect_provider",
+    "analyst_provider",
+    "coach_provider",
+    "agent_provider",
+)
+
+
+def _configured_provider(settings: AppSettings, field_name: str) -> str:
+    value = getattr(settings, field_name, "")
+    return value.lower().strip() if isinstance(value, str) else ""
 
 
 def _resolve_auto_judge_provider(settings: AppSettings) -> str:
     """Map judge_provider='auto' to an effective provider type (AC-586).
 
-    If the caller set ``agent_provider`` to one of the runtime-bridged values
-    (claude-cli, codex, pi, pi-rpc), use that for the judge too — so
-    subscription-tier users who only have a local ``claude`` CLI auth don't
-    hit the Anthropic SDK's "Could not resolve authentication method" error
-    downstream. For any other agent provider (anthropic, openai, deterministic,
-    agent_sdk, etc.) preserve the historical anthropic default.
+    Prefer the first explicitly configured execution provider in priority order:
+    competitor → architect → analyst → coach → global agent_provider. If that
+    effective provider is one of the runtime-bridged values (claude-cli, codex,
+    pi, pi-rpc), use it for the judge too — so subscription-tier users who only
+    have local CLI auth don't hit the Anthropic SDK's "Could not resolve
+    authentication method" error downstream. For any other provider, preserve
+    the historical anthropic default.
     """
-    agent = settings.agent_provider.lower().strip()
-    if agent in _RUNTIME_BRIDGE_PROVIDERS:
-        return agent
+    for field_name in _AUTO_JUDGE_PROVIDER_PRIORITY:
+        provider = _configured_provider(settings, field_name)
+        if not provider:
+            continue
+        if provider in _RUNTIME_BRIDGE_PROVIDERS:
+            return provider
+        break
     return "anthropic"
 
 

--- a/autocontext/src/autocontext/providers/registry.py
+++ b/autocontext/src/autocontext/providers/registry.py
@@ -92,14 +92,43 @@ def create_provider(
     )
 
 
+# Agent providers that can be inherited as judge providers without extra
+# credentials. When judge_provider is left as its "auto" default (AC-586),
+# get_provider() inherits from agent_provider if it's in this set.
+_RUNTIME_BRIDGE_PROVIDERS: frozenset[str] = frozenset(
+    {"claude-cli", "codex", "pi", "pi-rpc"}
+)
+
+
+def _resolve_auto_judge_provider(settings: AppSettings) -> str:
+    """Map judge_provider='auto' to an effective provider type (AC-586).
+
+    If the caller set ``agent_provider`` to one of the runtime-bridged values
+    (claude-cli, codex, pi, pi-rpc), use that for the judge too — so
+    subscription-tier users who only have a local ``claude`` CLI auth don't
+    hit the Anthropic SDK's "Could not resolve authentication method" error
+    downstream. For any other agent provider (anthropic, openai, deterministic,
+    agent_sdk, etc.) preserve the historical anthropic default.
+    """
+    agent = settings.agent_provider.lower().strip()
+    if agent in _RUNTIME_BRIDGE_PROVIDERS:
+        return agent
+    return "anthropic"
+
+
 def get_provider(settings: AppSettings) -> LLMProvider:
     """Create a judge provider from autocontext settings.
 
     Uses ``settings.judge_provider``, ``settings.judge_base_url``, and
     ``settings.judge_api_key``. Falls back to provider-specific env vars
     (``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``) when ``judge_api_key`` is not set.
+
+    When ``judge_provider`` is ``"auto"`` (the default), inherits a
+    runtime-bridged provider from ``settings.agent_provider`` (AC-586).
     """
     provider_type = settings.judge_provider.lower().strip()
+    if provider_type == "auto":
+        provider_type = _resolve_auto_judge_provider(settings)
     base_url = settings.judge_base_url
 
     # MLX provider has its own construction path using mlx_* settings

--- a/autocontext/tests/test_judge_provider_inheritance.py
+++ b/autocontext/tests/test_judge_provider_inheritance.py
@@ -12,7 +12,7 @@ class TestDefaultJudgeProvider:
 
 
 class TestGetProviderAutoInheritance:
-    """When judge_provider='auto', get_provider picks a provider based on agent_provider."""
+    """When judge_provider='auto', get_provider picks a provider from the effective runtime path."""
 
     def _settings(self, tmp_path, *, agent_provider: str, judge_provider: str = "auto") -> AppSettings:
         return AppSettings(
@@ -42,6 +42,32 @@ class TestGetProviderAutoInheritance:
         from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
 
         settings = self._settings(tmp_path, agent_provider="codex")
+        provider = get_provider(settings)
+        assert isinstance(provider, RuntimeBridgeProvider)
+
+    def test_auto_inherits_competitor_override_before_global_agent_provider(self, tmp_path) -> None:
+        from autocontext.providers.registry import get_provider
+        from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "k",
+            agent_provider="anthropic",
+            competitor_provider="claude-cli",
+            judge_provider="auto",
+        )
+        provider = get_provider(settings)
+        assert isinstance(provider, RuntimeBridgeProvider)
+
+    def test_auto_inherits_architect_override_when_global_agent_provider_is_not_runtime_bridged(self, tmp_path) -> None:
+        from autocontext.providers.registry import get_provider
+        from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "k",
+            agent_provider="anthropic",
+            architect_provider="pi",
+            judge_provider="auto",
+        )
         provider = get_provider(settings)
         assert isinstance(provider, RuntimeBridgeProvider)
 

--- a/autocontext/tests/test_judge_provider_inheritance.py
+++ b/autocontext/tests/test_judge_provider_inheritance.py
@@ -1,8 +1,6 @@
 """AC-586 — judge_provider='auto' inherits from agent_provider."""
 from __future__ import annotations
 
-import pytest
-
 from autocontext.config.settings import AppSettings
 
 

--- a/autocontext/tests/test_judge_provider_inheritance.py
+++ b/autocontext/tests/test_judge_provider_inheritance.py
@@ -1,0 +1,124 @@
+"""AC-586 — judge_provider='auto' inherits from agent_provider."""
+from __future__ import annotations
+
+import pytest
+
+from autocontext.config.settings import AppSettings
+
+
+class TestDefaultJudgeProvider:
+    def test_default_judge_provider_is_auto(self, tmp_path) -> None:
+        # New default: 'auto' → inherit from agent_provider at get_provider time.
+        settings = AppSettings(knowledge_root=tmp_path / "k")
+        assert settings.judge_provider == "auto"
+
+
+class TestGetProviderAutoInheritance:
+    """When judge_provider='auto', get_provider picks a provider based on agent_provider."""
+
+    def _settings(self, tmp_path, *, agent_provider: str, judge_provider: str = "auto") -> AppSettings:
+        return AppSettings(
+            knowledge_root=tmp_path / "k",
+            agent_provider=agent_provider,
+            judge_provider=judge_provider,
+        )
+
+    def test_auto_inherits_claude_cli(self, tmp_path) -> None:
+        from autocontext.providers.registry import get_provider
+        from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
+
+        settings = self._settings(tmp_path, agent_provider="claude-cli")
+        provider = get_provider(settings)
+        assert isinstance(provider, RuntimeBridgeProvider)
+
+    def test_auto_inherits_pi(self, tmp_path) -> None:
+        from autocontext.providers.registry import get_provider
+        from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
+
+        settings = self._settings(tmp_path, agent_provider="pi")
+        provider = get_provider(settings)
+        assert isinstance(provider, RuntimeBridgeProvider)
+
+    def test_auto_inherits_codex(self, tmp_path) -> None:
+        from autocontext.providers.registry import get_provider
+        from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
+
+        settings = self._settings(tmp_path, agent_provider="codex")
+        provider = get_provider(settings)
+        assert isinstance(provider, RuntimeBridgeProvider)
+
+    def test_auto_falls_back_to_anthropic_for_anthropic_agent(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-anthropic")
+        from autocontext.providers.registry import get_provider
+        from autocontext.providers.retry import RetryProvider
+
+        settings = self._settings(tmp_path, agent_provider="anthropic")
+        provider = get_provider(settings)
+        # AnthropicProvider is wrapped by RetryProvider for the anthropic path.
+        assert isinstance(provider, RetryProvider)
+
+    def test_auto_falls_back_to_anthropic_for_deterministic_agent(self, tmp_path, monkeypatch) -> None:
+        # Deterministic agents have no judge counterpart; default to anthropic
+        # so the error surface is unchanged for users who had this setup pre-AC-586.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-anthropic")
+        from autocontext.providers.registry import get_provider
+        from autocontext.providers.retry import RetryProvider
+
+        settings = self._settings(tmp_path, agent_provider="deterministic")
+        provider = get_provider(settings)
+        assert isinstance(provider, RetryProvider)
+
+
+class TestExplicitJudgeProviderOverride:
+    """Explicit judge_provider values take precedence over agent_provider inheritance."""
+
+    def test_explicit_anthropic_wins_over_claude_cli_agent(self, tmp_path, monkeypatch) -> None:
+        # Someone set AUTOCONTEXT_JUDGE_PROVIDER=anthropic explicitly: don't auto-inherit.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-anthropic")
+        from autocontext.providers.registry import get_provider
+        from autocontext.providers.retry import RetryProvider
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "k",
+            agent_provider="claude-cli",
+            judge_provider="anthropic",
+        )
+        provider = get_provider(settings)
+        assert isinstance(provider, RetryProvider)
+
+    def test_explicit_claude_cli_judge_still_works(self, tmp_path) -> None:
+        from autocontext.providers.registry import get_provider
+        from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "k",
+            agent_provider="anthropic",
+            judge_provider="claude-cli",
+        )
+        provider = get_provider(settings)
+        assert isinstance(provider, RuntimeBridgeProvider)
+
+
+class TestUnknownAgentProviderWithAutoJudge:
+    def test_auto_with_unknown_agent_raises_clear_error(self, tmp_path) -> None:
+        # Agent set to a value that isn't a known judge-capable type; we fall
+        # back to anthropic (the pre-AC-586 default) rather than failing cryptically.
+        from autocontext.providers.base import ProviderError
+        from autocontext.providers.registry import get_provider
+
+        # Use openai as agent — not a runtime-bridged provider, but valid judge.
+        # Expect fallback to anthropic (judge list's historical default).
+        settings = AppSettings(
+            knowledge_root=tmp_path / "k",
+            agent_provider="openai",
+            judge_provider="auto",
+        )
+        # No key set → expect an Anthropic-style error, not a cryptic "unknown provider type: 'auto'".
+        try:
+            get_provider(settings)
+        except ProviderError as exc:
+            assert "auto" not in str(exc).lower()
+        except Exception:
+            # Any Anthropic-SDK-level error is also fine; the key assertion is
+            # that we never surface a "'auto'" provider type error.
+            pass

--- a/autocontext/tests/test_providers.py
+++ b/autocontext/tests/test_providers.py
@@ -222,7 +222,8 @@ class TestSettingsIntegration:
     def test_new_settings_have_defaults(self):
         from autocontext.config.settings import AppSettings
         s = AppSettings()
-        assert s.judge_provider == "anthropic"
+        # AC-586: default "auto" — resolves to agent_provider at get_provider() time.
+        assert s.judge_provider == "auto"
         assert s.judge_base_url is None
         assert s.judge_api_key is None
 


### PR DESCRIPTION
## Summary
Fixes the judge-auth bucket that accounted for **4 of 12 failures** in the 0.4.4 escalation sweep. Subscription-tier users running `AUTOCONTEXT_AGENT_PROVIDER=claude-cli` (the default in the sweep harness) were hitting `Could not resolve authentication method. Expected either api_key or auth_token to be set` during execution because the **judge** provider still defaulted to `anthropic` and required its own API key.

## Design
- Change the `judge_provider` field default from `"anthropic"` to `"auto"` in `config/settings.py`.
- In `providers/registry.py::get_provider`, a new `_resolve_auto_judge_provider(settings)` helper maps `judge_provider="auto"` to the agent provider when it's one of the runtime-bridged types (`claude-cli`, `codex`, `pi`, `pi-rpc`). Otherwise falls back to `"anthropic"` so existing API-key-based setups stay unchanged.
- Explicit values (`AUTOCONTEXT_JUDGE_PROVIDER=anthropic` etc.) always win over `"auto"` inheritance.

## Behavior
| agent_provider | judge_provider (unset) | Resolves to |
| -------------- | ---------------------- | ----------- |
| `claude-cli`   | `auto` (default)       | `claude-cli` ← fixes AC-586 |
| `codex`        | `auto`                 | `codex`      |
| `pi`           | `auto`                 | `pi`         |
| `pi-rpc`       | `auto`                 | `pi-rpc`     |
| `anthropic`    | `auto`                 | `anthropic`  |
| `openai`       | `auto`                 | `anthropic` (preserves pre-AC-586 default) |
| `deterministic`| `auto`                 | `anthropic` (no deterministic judge) |
| `claude-cli`   | `anthropic` (explicit) | `anthropic`  |

## Test Plan
- [x] `uv run pytest autocontext/tests/test_judge_provider_inheritance.py` — 9 new tests (default value, auto inherits claude-cli/pi/codex, auto falls back to anthropic for anthropic/deterministic agents, explicit override wins both directions, 'auto' never surfaces as an unknown-provider-type error).
- [x] `uv run pytest` — **5535 passed, 54 skipped**.
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run mypy src` — clean (458 files).
- [x] Updated one existing test (`test_providers.py::test_new_settings_have_defaults`) to reflect the new default.

## Linked
- Linear: AC-586
- Sweep surfaced by: `scripts/escalation-sweep/` (PR #739, merged)
- Companion: AC-585 (PR #743, open) — fixes the spec_quality_threshold bucket from the same sweep.