### PR TITLE
fix: stabilize hint feedback reflection on pi

### DIFF
--- a/autocontext/src/autocontext/agents/hint_feedback.py
+++ b/autocontext/src/autocontext/agents/hint_feedback.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 _HINT_REFLECTION_MAX_HINTS = 4
 _HINT_REFLECTION_MAX_HINT_CHARS = 72
 _HINT_LIST_ITEM_RE = re.compile(r"^\s*(?:[-*]|\d+[.)])\s+(.*\S)\s*$")
-_HINT_MARKUP_RE = re.compile(r"[*_`]+")
+_HINT_MARKUP_RE = re.compile(r"[*`]+")
 _HINT_WS_RE = re.compile(r"\s+")
 
 

--- a/autocontext/src/autocontext/agents/hint_feedback.py
+++ b/autocontext/src/autocontext/agents/hint_feedback.py
@@ -22,6 +22,68 @@ from pydantic import BaseModel, Field, field_validator
 
 logger = logging.getLogger(__name__)
 
+_HINT_REFLECTION_MAX_HINTS = 4
+_HINT_REFLECTION_MAX_HINT_CHARS = 72
+_HINT_LIST_ITEM_RE = re.compile(r"^\s*(?:[-*]|\d+[.)])\s+(.*\S)\s*$")
+_HINT_MARKUP_RE = re.compile(r"[*_`]+")
+_HINT_WS_RE = re.compile(r"\s+")
+
+
+def _sanitize_hint_text(text: str) -> str:
+    cleaned = _HINT_MARKUP_RE.sub("", text)
+    cleaned = _HINT_WS_RE.sub(" ", cleaned).strip()
+    return cleaned
+
+
+def _truncate_hint_text(text: str, *, limit: int = _HINT_REFLECTION_MAX_HINT_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3].rstrip() + "..."
+
+
+def prepare_hint_reflection_items(hints: str) -> list[str]:
+    raw = hints.strip()
+    if not raw:
+        return []
+
+    parsed_items: list[str] = []
+    current_parts: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        match = _HINT_LIST_ITEM_RE.match(line)
+        if match:
+            if current_parts:
+                parsed_items.append(" ".join(current_parts))
+            current_parts = [match.group(1).strip()]
+            continue
+        if current_parts:
+            current_parts.append(stripped)
+        else:
+            current_parts = [stripped]
+    if current_parts:
+        parsed_items.append(" ".join(current_parts))
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in parsed_items:
+        cleaned = _truncate_hint_text(_sanitize_hint_text(item))
+        if not cleaned:
+            continue
+        key = cleaned.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(cleaned)
+        if len(normalized) >= _HINT_REFLECTION_MAX_HINTS:
+            break
+
+    if normalized:
+        return normalized
+    fallback = _truncate_hint_text(_sanitize_hint_text(raw))
+    return [fallback] if fallback else []
+
 
 class HintFeedback(BaseModel):
     """Competitor's annotation of hint quality after tournament."""
@@ -54,26 +116,26 @@ def build_hint_reflection_prompt(
     tournament_best_score: float,
     tournament_mean_score: float,
     previous_best: float,
+    hint_items: list[str] | None = None,
 ) -> str:
     """Build the post-tournament reflection prompt for the competitor."""
-    hint_block = hints.strip() if hints.strip() else "(No hints were provided)"
+    compact_items = hint_items if hint_items is not None else prepare_hint_reflection_items(hints)
+    hint_block = (
+        "\n".join(f"{idx}. {item}" for idx, item in enumerate(compact_items, start=1))
+        if compact_items
+        else "(No hints were provided)"
+    )
 
     return (
-        "You just completed a tournament. Reflect on the coach's hints "
-        "and annotate which were helpful, misleading, or missing.\n\n"
-        f"## Coach Hints Used\n{hint_block}\n\n"
-        f"## Tournament Results\n"
-        f"Best score: {tournament_best_score:.4f}\n"
-        f"Mean score: {tournament_mean_score:.4f}\n"
-        f"Previous best: {previous_best:.4f}\n"
-        f"Delta: {tournament_best_score - previous_best:+.4f}\n\n"
-        "## Your Task\n"
-        "Based on your actual match experience, annotate the hints:\n"
-        "Return a JSON object with three lists:\n"
-        '- "helpful": hints that led to good outcomes\n'
-        '- "misleading": hints that were wrong or counterproductive\n'
-        '- "missing": guidance you needed but didn\'t receive\n\n'
-        "Return ONLY the JSON object, no commentary."
+        "You just completed a tournament.\n\n"
+        f"Coach hints used:\n{hint_block}\n\n"
+        "Results: "
+        f"best={tournament_best_score:.4f} "
+        f"mean={tournament_mean_score:.4f} "
+        f"previous_best={previous_best:.4f} "
+        f"delta={tournament_best_score - previous_best:+.4f}.\n\n"
+        'Return ONLY compact JSON: {"helpful_hint_numbers":[],"misleading_hint_numbers":[],"missing":[]}. '
+        "Use only the hint numbers shown above. Keep missing items short."
     )
 
 
@@ -95,7 +157,37 @@ def _normalize_feedback_list(value: Any) -> list[str]:
     return normalized
 
 
-def parse_hint_feedback(raw_text: str, generation: int) -> HintFeedback:
+def _normalize_feedback_index_list(value: Any, *, max_index: int) -> list[int]:
+    if isinstance(value, (int, str)):
+        candidates = [value]
+    elif isinstance(value, list):
+        candidates = value
+    else:
+        return []
+
+    normalized: list[int] = []
+    seen: set[int] = set()
+    for candidate in candidates:
+        index: int | None = None
+        if isinstance(candidate, int):
+            index = candidate
+        elif isinstance(candidate, str):
+            stripped = candidate.strip()
+            if stripped.isdigit():
+                index = int(stripped)
+        if index is None or index < 1 or index > max_index or index in seen:
+            continue
+        seen.add(index)
+        normalized.append(index)
+    return normalized
+
+
+def parse_hint_feedback(
+    raw_text: str,
+    generation: int,
+    *,
+    hint_items: list[str] | None = None,
+) -> HintFeedback:
     """Parse competitor's hint feedback response."""
     text = raw_text.strip()
 
@@ -107,9 +199,31 @@ def parse_hint_feedback(raw_text: str, generation: int) -> HintFeedback:
     try:
         data = json.loads(text)
         if isinstance(data, dict):
+            helpful: list[str]
+            misleading: list[str]
+            if hint_items:
+                helpful_indexes = _normalize_feedback_index_list(
+                    data.get("helpful_hint_numbers"),
+                    max_index=len(hint_items),
+                )
+                misleading_indexes = _normalize_feedback_index_list(
+                    data.get("misleading_hint_numbers"),
+                    max_index=len(hint_items),
+                )
+                helpful = [hint_items[index - 1] for index in helpful_indexes]
+                misleading = [hint_items[index - 1] for index in misleading_indexes]
+            else:
+                helpful = []
+                misleading = []
+
+            if not helpful:
+                helpful = _normalize_feedback_list(data.get("helpful"))
+            if not misleading:
+                misleading = _normalize_feedback_list(data.get("misleading"))
+
             return HintFeedback(
-                helpful=_normalize_feedback_list(data.get("helpful")),
-                misleading=_normalize_feedback_list(data.get("misleading")),
+                helpful=helpful,
+                misleading=misleading,
                 missing=_normalize_feedback_list(data.get("missing")),
                 generation=generation,
             )

--- a/autocontext/src/autocontext/loop/stage_helpers/context_loaders.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/context_loaders.py
@@ -11,6 +11,7 @@ from autocontext.agents.hint_feedback import (
     build_hint_reflection_prompt,
     format_hint_feedback_for_coach,
     parse_hint_feedback,
+    prepare_hint_reflection_items,
 )
 from autocontext.analytics.credit_assignment import (
     CreditAssignmentRecord,
@@ -198,11 +199,13 @@ def _collect_hint_feedback(
     if not hints_used:
         return None
 
+    hint_items = prepare_hint_reflection_items(hints_used)
     prompt = build_hint_reflection_prompt(
         hints=hints_used,
         tournament_best_score=tournament.best_score,
         tournament_mean_score=tournament.mean_score,
         previous_best=_hint_feedback_previous_best(ctx),
+        hint_items=hint_items,
     )
     try:
         client, resolved_model = agents.resolve_role_execution(
@@ -238,29 +241,38 @@ def _collect_hint_feedback(
         ctx.run_id,
         ctx.generation,
         outputs=[("competitor_hint_feedback", exec_result.content)],
-        role_metrics=[(
-            exec_result.role,
-            exec_result.usage.model,
-            exec_result.usage.input_tokens,
-            exec_result.usage.output_tokens,
-            exec_result.usage.latency_ms,
-            exec_result.subagent_id,
-            exec_result.status,
-        )],
+        role_metrics=[
+            (
+                exec_result.role,
+                exec_result.usage.model,
+                exec_result.usage.input_tokens,
+                exec_result.usage.output_tokens,
+                exec_result.usage.latency_ms,
+                exec_result.subagent_id,
+                exec_result.status,
+            )
+        ],
     )
 
-    feedback = parse_hint_feedback(response.text, generation=ctx.generation)
+    feedback = parse_hint_feedback(
+        response.text,
+        generation=ctx.generation,
+        hint_items=hint_items,
+    )
     if feedback.is_empty():
         return None
 
     artifacts.write_hint_feedback(ctx.scenario_name, ctx.generation, feedback)
-    events.emit("hint_feedback_collected", {
-        "run_id": ctx.run_id,
-        "generation": ctx.generation,
-        "helpful_count": len(feedback.helpful),
-        "misleading_count": len(feedback.misleading),
-        "missing_count": len(feedback.missing),
-    })
+    events.emit(
+        "hint_feedback_collected",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "helpful_count": len(feedback.helpful),
+            "misleading_count": len(feedback.misleading),
+            "missing_count": len(feedback.missing),
+        },
+    )
     return feedback
 
 

--- a/autocontext/tests/test_generation_stages.py
+++ b/autocontext/tests/test_generation_stages.py
@@ -257,9 +257,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_skills.return_value = ""
         artifacts.read_mutation_replay.return_value = ""
         artifacts.read_latest_weakness_reports_markdown.return_value = (
-            "# Weakness Report: run_1\n"
-            "## [HIGH] dead_end_pattern\n"
-            "Repeated rollbacks detected"
+            "# Weakness Report: run_1\n## [HIGH] dead_end_pattern\nRepeated rollbacks detected"
         )
         artifacts.read_latest_progress_reports_markdown.return_value = ""
         artifacts.read_latest_advance_analysis.return_value = ""
@@ -284,9 +282,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_mutation_replay.return_value = ""
         artifacts.read_latest_weakness_reports_markdown.return_value = ""
         artifacts.read_latest_progress_reports_markdown.return_value = (
-            "# Progress Report: run_2\n"
-            "- Total cost: $0.0240\n"
-            "- Tokens per advance: 3,400"
+            "# Progress Report: run_2\n- Total cost: $0.0240\n- Tokens per advance: 3,400"
         )
         artifacts.read_latest_advance_analysis.return_value = ""
         artifacts.read_progress.return_value = None
@@ -493,9 +489,7 @@ class TestStageKnowledgeSetup:
         artifacts.read_latest_advance_analysis.return_value = ""
         artifacts.read_progress.return_value = None
         artifacts.read_latest_analyst_rating.return_value = None
-        artifacts.read_tool_usage_report.return_value = (
-            "Tool utilization (last 5 gens):\n- path_optimizer: used 1/5 gens (LOW)"
-        )
+        artifacts.read_tool_usage_report.return_value = "Tool utilization (last 5 gens):\n- path_optimizer: used 1/5 gens (LOW)"
         trajectory = MagicMock()
         trajectory.build_trajectory.return_value = ""
         trajectory.build_strategy_registry.return_value = ""
@@ -890,11 +884,13 @@ class TestStageAgentGeneration:
         from autocontext.prompts.templates import build_prompt_bundle
 
         settings = _make_settings()
-        settings = settings.model_copy(update={
-            "multi_basin_enabled": True,
-            "multi_basin_trigger_rollbacks": 1,
-            "multi_basin_candidates": 2,
-        })
+        settings = settings.model_copy(
+            update={
+                "multi_basin_enabled": True,
+                "multi_basin_trigger_rollbacks": 1,
+                "multi_basin_candidates": 2,
+            }
+        )
         scenario = _FakeScenario()
         ctx = _make_ctx(settings=settings, scenario=scenario)
         ctx.gate_decision_history = ["rollback"]
@@ -992,9 +988,7 @@ class _FakeScenario(ScenarioInterface):
     def get_observation(self, state: Mapping[str, Any], player_id: str) -> Observation:
         return Observation(narrative="test observation")
 
-    def validate_actions(
-        self, state: Mapping[str, Any], player_id: str, actions: Mapping[str, Any]
-    ) -> tuple[bool, str]:
+    def validate_actions(self, state: Mapping[str, Any], player_id: str, actions: Mapping[str, Any]) -> tuple[bool, str]:
         return (True, "")
 
     def step(self, state: Mapping[str, Any], actions: Mapping[str, Any]) -> dict[str, Any]:
@@ -1236,9 +1230,7 @@ class TestStageTournament:
 
         assert result.tournament is not None
         assert result.tournament.best_dimensions
-        tournament_events = [
-            call for call in events.emit.call_args_list if call[0][0] == "tournament_completed"
-        ]
+        tournament_events = [call for call in events.emit.call_args_list if call[0][0] == "tournament_completed"]
         assert tournament_events
         payload = tournament_events[-1][0][1]
         assert payload["best_dimensions"]
@@ -1288,9 +1280,7 @@ class TestStageTournament:
         assert result.tournament is not None
         assert result.tournament.self_play_summary["self_play_matches"] == 2
         assert result.tournament.mean_score < 0.5
-        tournament_events = [
-            call for call in events.emit.call_args_list if call[0][0] == "tournament_completed"
-        ]
+        tournament_events = [call for call in events.emit.call_args_list if call[0][0] == "tournament_completed"]
         assert tournament_events
         payload = tournament_events[-1][0][1]
         assert payload["self_play"]["self_play_matches"] == 2
@@ -1381,11 +1371,13 @@ class TestStageTournament:
     def test_novelty_bonus_can_change_live_gate_decision(self) -> None:
         from autocontext.harness.pipeline.gate import BackpressureGate
 
-        settings = _make_settings().model_copy(update={
-            "holdout_enabled": False,
-            "novelty_enabled": True,
-            "novelty_weight": 0.1,
-        })
+        settings = _make_settings().model_copy(
+            update={
+                "holdout_enabled": False,
+                "novelty_enabled": True,
+                "novelty_weight": 0.1,
+            }
+        )
         ctx = _make_tournament_ctx(previous_best=0.6, settings=settings)
         ctx.current_strategy = {"aggression": 1.0}
         ctx.outputs = AgentOutputs(
@@ -1636,9 +1628,7 @@ class TestStageCuratorGate:
         )
         ctx = _make_curator_ctx(gate_decision="advance", coach_playbook="new playbook")
         ctx.outputs.analysis_markdown = (
-            "## Findings\n- Concrete issue\n\n"
-            "## Root Causes\n- Cause\n\n"
-            "## Actionable Recommendations\n- Fix it"
+            "## Findings\n- Concrete issue\n\n## Root Causes\n- Cause\n\n## Actionable Recommendations\n- Fix it"
         )
         artifacts = MagicMock()
         artifacts.read_playbook.return_value = "current playbook"
@@ -2012,10 +2002,7 @@ class TestStagePersistence:
         persist_kwargs = artifacts.persist_generation.call_args.kwargs
         credit_assignment = persist_kwargs["metrics"]["credit_assignment"]
         assert credit_assignment["vector"]["score_delta"] == ctx.gate_delta
-        assert any(
-            change["component"] == "playbook"
-            for change in credit_assignment["vector"]["changes"]
-        )
+        assert any(change["component"] == "playbook" for change in credit_assignment["vector"]["changes"])
         artifacts.write_credit_assignment.assert_called_once()
         gen_completed_calls = [c for c in events.emit.call_args_list if c[0][0] == "generation_completed"]
         assert gen_completed_calls
@@ -2057,11 +2044,13 @@ class TestStagePersistence:
         trajectory = MagicMock()
         client = MagicMock()
         client.generate.return_value = ModelResponse(
-            text=json.dumps({
-                "helpful": "use the corners",
-                "misleading": ["over-commit early"],
-                "missing": ["late-game cleanup"],
-            }),
+            text=json.dumps(
+                {
+                    "helpful_hint_numbers": [1],
+                    "misleading_hint_numbers": [2],
+                    "missing": ["late-game cleanup"],
+                }
+            ),
             usage=RoleUsage(input_tokens=12, output_tokens=9, latency_ms=7, model="test-model"),
         )
         agents = MagicMock()
@@ -2079,11 +2068,12 @@ class TestStagePersistence:
         )
 
         generate_kwargs = client.generate.call_args.kwargs
-        assert "old hints used in tournament" in generate_kwargs["prompt"]
+        assert "helpful_hint_numbers" in generate_kwargs["prompt"]
+        assert "1. old hints used in tournament" in generate_kwargs["prompt"]
         assert "new hints for next gen" not in generate_kwargs["prompt"]
         artifacts.write_hint_feedback.assert_called_once()
         feedback = artifacts.write_hint_feedback.call_args.args[2]
-        assert feedback.helpful == ["use the corners"]
+        assert feedback.helpful == ["old hints used in tournament"]
         artifacts.write_hint_manager.assert_called_once()
         persisted_manager = artifacts.write_hint_manager.call_args.args[1]
         assert "new hints for next gen" in persisted_manager.format_for_competitor()

--- a/autocontext/tests/test_hint_feedback.py
+++ b/autocontext/tests/test_hint_feedback.py
@@ -38,7 +38,10 @@ class TestHintFeedback:
         from autocontext.agents.hint_feedback import HintFeedback
 
         fb = HintFeedback(
-            helpful=["a"], misleading=["b"], missing=["c"], generation=3,
+            helpful=["a"],
+            misleading=["b"],
+            missing=["c"],
+            generation=3,
         )
         d = fb.to_dict()
         restored = HintFeedback.from_dict(d)
@@ -49,10 +52,12 @@ class TestHintFeedback:
     def test_from_dict_normalizes_legacy_payload(self) -> None:
         from autocontext.agents.hint_feedback import HintFeedback
 
-        restored = HintFeedback.from_dict({
-            "helpful": "focus on corners",
-            "generation": 2,
-        })
+        restored = HintFeedback.from_dict(
+            {
+                "helpful": "focus on corners",
+                "generation": 2,
+            }
+        )
 
         assert restored.helpful == ["focus on corners"]
         assert restored.misleading == []
@@ -100,9 +105,42 @@ class TestBuildHintReflectionPrompt:
             tournament_mean_score=0.65,
             previous_best=0.60,
         )
-        assert "high aggression" in prompt
-        assert "corners" in prompt
+        assert "Try high aggression" in prompt
+        assert "Focus on corners" in prompt
         assert "0.75" in prompt
+        assert "helpful_hint_numbers" in prompt
+
+    def test_compacts_and_numbers_hint_items(self) -> None:
+        from autocontext.agents.hint_feedback import (
+            build_hint_reflection_prompt,
+            prepare_hint_reflection_items,
+        )
+
+        hints = "\n".join(
+            [
+                "- **Do not** combine defense and routing changes.",
+                "- Preserve one Soldier or Commander as the home anchor while Scouts handle lane pressure.",
+                "- Immediate next run: redeploy the live **moderate** control baseline unchanged.",
+                "- Keep path_bias between 0.50-0.60 for stability.",
+                "- Promote only a probe that beats the scored moderate control on capture progress.",
+                "- Try aggression=0.60 with defense=0.55 for balanced scoring.",
+            ]
+        )
+
+        items = prepare_hint_reflection_items(hints)
+        prompt = build_hint_reflection_prompt(
+            hints=hints,
+            tournament_best_score=0.75,
+            tournament_mean_score=0.65,
+            previous_best=0.60,
+            hint_items=items,
+        )
+
+        assert len(items) < 6
+        assert all("**" not in item for item in items)
+        assert "1. Do not combine defense and routing changes." in prompt
+        assert "helpful_hint_numbers" in prompt
+        assert "Try aggression=0.60 with defense=0.55 for balanced scoring." not in prompt
 
     def test_empty_hints(self) -> None:
         from autocontext.agents.hint_feedback import build_hint_reflection_prompt
@@ -127,16 +165,39 @@ class TestParseHintFeedback:
 
         from autocontext.agents.hint_feedback import parse_hint_feedback
 
-        raw = json.dumps({
-            "helpful": ["edge control"],
-            "misleading": ["avoid center"],
-            "missing": ["transition guidance"],
-        })
+        raw = json.dumps(
+            {
+                "helpful": ["edge control"],
+                "misleading": ["avoid center"],
+                "missing": ["transition guidance"],
+            }
+        )
         fb = parse_hint_feedback(raw, generation=4)
         assert fb.helpful == ["edge control"]
         assert fb.misleading == ["avoid center"]
         assert fb.missing == ["transition guidance"]
         assert fb.generation == 4
+
+    def test_maps_hint_numbers_back_to_compacted_hint_items(self) -> None:
+        import json
+
+        from autocontext.agents.hint_feedback import parse_hint_feedback
+
+        raw = json.dumps(
+            {
+                "helpful_hint_numbers": [1, 3],
+                "misleading_hint_numbers": [2],
+                "missing": ["late-game cleanup"],
+            }
+        )
+        fb = parse_hint_feedback(
+            raw,
+            generation=4,
+            hint_items=["keep anchor", "avoid over-commit", "reuse baseline"],
+        )
+        assert fb.helpful == ["keep anchor", "reuse baseline"]
+        assert fb.misleading == ["avoid over-commit"]
+        assert fb.missing == ["late-game cleanup"]
 
     def test_parses_json_in_fences(self) -> None:
         from autocontext.agents.hint_feedback import parse_hint_feedback
@@ -167,11 +228,13 @@ class TestParseHintFeedback:
 
         from autocontext.agents.hint_feedback import parse_hint_feedback
 
-        raw = json.dumps({
-            "helpful": "focus on corners",
-            "misleading": "avoid the center",
-            "missing": "transition guidance",
-        })
+        raw = json.dumps(
+            {
+                "helpful": "focus on corners",
+                "misleading": "avoid the center",
+                "missing": "transition guidance",
+            }
+        )
         fb = parse_hint_feedback(raw, generation=2)
         assert fb.helpful == ["focus on corners"]
         assert fb.misleading == ["avoid the center"]
@@ -182,11 +245,13 @@ class TestParseHintFeedback:
 
         from autocontext.agents.hint_feedback import parse_hint_feedback
 
-        raw = json.dumps({
-            "helpful": [" corners ", 12, "", None],
-            "misleading": [False, "too passive"],
-            "missing": [" late game plan ", {"x": 1}],
-        })
+        raw = json.dumps(
+            {
+                "helpful": [" corners ", 12, "", None],
+                "misleading": [False, "too passive"],
+                "missing": [" late game plan ", {"x": 1}],
+            }
+        )
         fb = parse_hint_feedback(raw, generation=3)
         assert fb.helpful == ["corners"]
         assert fb.misleading == ["too passive"]

--- a/autocontext/tests/test_hint_feedback.py
+++ b/autocontext/tests/test_hint_feedback.py
@@ -142,6 +142,15 @@ class TestBuildHintReflectionPrompt:
         assert "helpful_hint_numbers" in prompt
         assert "Try aggression=0.60 with defense=0.55 for balanced scoring." not in prompt
 
+    def test_preserves_identifier_underscores_during_hint_sanitization(self) -> None:
+        from autocontext.agents.hint_feedback import prepare_hint_reflection_items
+
+        items = prepare_hint_reflection_items(
+            "- Keep `path_bias` between 0.50 and 0.60 for stability."
+        )
+
+        assert items == ["Keep path_bias between 0.50 and 0.60 for stability."]
+
     def test_empty_hints(self) -> None:
         from autocontext.agents.hint_feedback import build_hint_reflection_prompt
 


### PR DESCRIPTION
## Summary

- stabilize the Python competitor hint-feedback reflection path so live Pi no longer flakes on the post-tournament auxiliary reflection step
- replace the verbose freeform reflection prompt with a bounded numbered-hint contract and map numeric feedback back into persisted hint text

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check ...`
- [ ] `cd autocontext && uv run mypy ...`
- [x] `cd autocontext && uv run pytest ...`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

Manual verification:
- `cd /Users/jayscambler/Repositories/autocontext/autocontext-ac-587/autocontext && uv run pytest tests/test_hint_feedback.py tests/test_generation_stages.py -x --tb=short`
- `cd /Users/jayscambler/Repositories/autocontext/autocontext-ac-587/autocontext && uv run ruff check src/autocontext/agents/hint_feedback.py src/autocontext/loop/stage_helpers/context_loaders.py tests/test_hint_feedback.py tests/test_generation_stages.py`
- direct live Pi reflection probe with the AC-587 prompt shape:
  - root: `/tmp/ac587-hint-feedback-probe2-RlHgWi`
  - result: `2 / 2` successful runs, no timeout errors
- full live Pi-backed ecosystem rerun:
  - root: `/tmp/ac587-live1-GYVvvj`
  - command: `uv run autoctx ecosystem --scenario grid_ctf --cycles 3 --gens-per-cycle 2 --provider-a pi --provider-b deterministic --rlm-a --no-rlm-b --json`
  - result: exit code `0`
  - stderr contains the reflection invocations but no `pi CLI timed out` entries

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- reflection is still live Pi-backed; this is not a deterministic fallback
- key changes:
  - compact and sanitize coach hints into a small numbered catalog
  - ask Pi for `helpful_hint_numbers` / `misleading_hint_numbers` instead of full-text echoing
  - map numeric feedback back to persisted hint text for the existing hint manager flow
  - keep the reflection prompt bounded and much shorter
