### PR TITLE
feat(ac-588): raise claude-cli per-call default timeout 300s → 600s

### DIFF
--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -304,7 +304,7 @@ Key environment variables:
 | `AUTOCONTEXT_JUDGE_BASE_URL`                                         | Base URL for OpenAI-compatible judge endpoints                                                      |
 | `AUTOCONTEXT_JUDGE_MODEL`                                            | Override judge model name                                                                           |
 | `AUTOCONTEXT_CLAUDE_MODEL`                                           | Claude CLI model alias (default: `sonnet`)                                                          |
-| `AUTOCONTEXT_CLAUDE_TIMEOUT`                                         | Claude CLI execution timeout in seconds (default: 120)                                              |
+| `AUTOCONTEXT_CLAUDE_TIMEOUT`                                         | Claude CLI execution timeout in seconds (default: 600)                                              |
 | `AUTOCONTEXT_MODEL_COMPETITOR`                                       | Override competitor agent model                                                                     |
 | `AUTOCONTEXT_DB_PATH`                                                | SQLite database path                                                                                |
 | `AUTOCONTEXT_PI_COMMAND`                                             | Path to Pi CLI binary (default: `pi`)                                                               |

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -574,7 +574,11 @@ class AppSettings(BaseModel):
     notebook_enabled: bool = Field(default=True, description="Enable session notebook feature")
     # Claude Code CLI runtime (AC-317)
     claude_model: str = Field(default="sonnet", description="Claude CLI model alias")
-    claude_timeout: float = Field(default=300.0, ge=1.0, description="Claude CLI execution timeout")
+    claude_timeout: float = Field(
+        default=600.0,
+        ge=1.0,
+        description="Claude CLI per-call execution timeout (AC-588: 300→600 after 0.4.5 sweep showed long scenarios hitting the cap)",
+    )
     claude_tools: str | None = Field(default=None, description="Claude CLI tools override")
     claude_permission_mode: str = Field(default="bypassPermissions", description="Claude CLI permission mode")
     claude_session_persistence: bool = Field(default=False, description="Persist Claude CLI sessions across turns")

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -577,7 +577,10 @@ class AppSettings(BaseModel):
     claude_timeout: float = Field(
         default=600.0,
         ge=1.0,
-        description="Claude CLI per-call execution timeout (AC-588: 300→600 after 0.4.5 sweep showed long scenarios hitting the cap)",
+        description=(
+            "Claude CLI per-call execution timeout "
+            "(AC-588: 300→600 after 0.4.5 sweep)"
+        ),
     )
     claude_tools: str | None = Field(default=None, description="Claude CLI tools override")
     claude_permission_mode: str = Field(default="bypassPermissions", description="Claude CLI permission mode")

--- a/autocontext/src/autocontext/runtimes/claude_cli.py
+++ b/autocontext/src/autocontext/runtimes/claude_cli.py
@@ -29,7 +29,7 @@ class ClaudeCLIConfig:
     permission_mode: str = "bypassPermissions"
     session_persistence: bool = False
     session_id: str | None = None  # Set to maintain context across rounds
-    timeout: float = 300.0
+    timeout: float = 600.0  # AC-588: per-call default (was 300, AC-570 raised from 120)
     system_prompt: str | None = None
     append_system_prompt: str | None = None
     extra_args: list[str] = field(default_factory=list)

--- a/autocontext/tests/test_claude_cli_timeout.py
+++ b/autocontext/tests/test_claude_cli_timeout.py
@@ -1,7 +1,8 @@
-"""AC-570 — claude-cli timeout defaults and observability.
+"""AC-570 / AC-588 — claude-cli timeout defaults and observability.
 
-Pins the raised default (300s) and the existing override paths
-(--timeout flag, AUTOCONTEXT_CLAUDE_TIMEOUT env var).
+Pins the per-call default (AC-570 raised 120→300; AC-588 raised 300→600 after
+the 0.4.5 escalation sweep showed long scenarios still hitting the cap) and
+the existing override paths (--timeout flag, AUTOCONTEXT_CLAUDE_TIMEOUT env var).
 """
 from __future__ import annotations
 
@@ -16,13 +17,15 @@ from autocontext.runtimes.claude_cli import ClaudeCLIConfig, ClaudeCLIRuntime
 
 
 class TestClaudeTimeoutDefaults:
-    def test_app_settings_claude_timeout_default_is_300s(self) -> None:
+    def test_app_settings_claude_timeout_default_is_600s(self) -> None:
+        # AC-588: raised 300→600 after the 0.4.5 escalation sweep showed long
+        # designer/judge calls exceeding 300s on complex scenarios.
         settings = AppSettings()
-        assert settings.claude_timeout == 300.0
+        assert settings.claude_timeout == 600.0
 
-    def test_claude_cli_config_default_is_300s(self) -> None:
+    def test_claude_cli_config_default_is_600s(self) -> None:
         cfg = ClaudeCLIConfig()
-        assert cfg.timeout == 300.0
+        assert cfg.timeout == 600.0
 
     def test_env_var_overrides_default(
         self, monkeypatch: pytest.MonkeyPatch
@@ -39,7 +42,7 @@ class TestClaudeTimeoutDefaults:
         over the default for CLI-backed providers."""
         from autocontext.cli_runtime_overrides import apply_judge_runtime_overrides
 
-        base = AppSettings()  # claude_timeout defaults to 300
+        base = AppSettings()  # claude_timeout defaults to 600 (AC-588)
         resolved = apply_judge_runtime_overrides(
             base, provider_name="claude-cli", timeout=90.0
         )

--- a/autocontext/tests/test_per_role_provider.py
+++ b/autocontext/tests/test_per_role_provider.py
@@ -93,7 +93,7 @@ class TestPerRoleConfigFields:
 
         settings = AppSettings()
         assert settings.claude_model == "sonnet"
-        assert settings.claude_timeout == 300.0
+        assert settings.claude_timeout == 600.0  # AC-588
         assert settings.claude_tools is None
         assert settings.claude_permission_mode == "bypassPermissions"
         assert settings.claude_session_persistence is False


### PR DESCRIPTION
## Summary
Closes the last non-zero bucket from the 0.4.5 escalation sweep: 2/21 failures (AC-386, AC-268), both `claude_cli_timeout` with the per-call default of 300s insufficient for long designer/judge calls on complex scenarios.

## 0.4.5 sweep context
After AC-585 + AC-586 merged:

| Bucket | 0.4.4 | 0.4.5 |
|--------|------:|------:|
| `success` | 9 | 19 |
| `spec_quality_threshold` (AC-585) | 8 | 0 |
| `judge_auth_failure` (AC-586) | 4 | 0 |
| `claude_cli_timeout` | 0 | **2** |

AC-268 ran **9130s** (2.5h) in wall time before a single claude CLI invocation exceeded the 300s cap and the run aborted. AC-269 (same release, same family) succeeded but took 3133s — similar pattern, just luckier on individual call durations.

## Changes
- `ClaudeCLIConfig.timeout` default `300.0` → `600.0`.
- `AppSettings.claude_timeout` default `300.0` → `600.0` (with AC-588 annotation in the description).
- `tests/test_claude_cli_timeout.py` — two pins flipped (`test_app_settings_claude_timeout_default_is_600s`, `test_claude_cli_config_default_is_600s`), module docstring updated.
- `tests/test_per_role_provider.py` — one pin flipped.

Override paths (`--timeout` flag, `AUTOCONTEXT_CLAUDE_TIMEOUT` env var) unchanged — explicit values still win.

## Test Plan
- [x] `uv run pytest` — **5553 passed, 54 skipped**.
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run mypy src` — clean (458 files).
- [ ] Re-sweep 0.4.6 once released; expected outcome: `success` 19 → 20-21 (both AC-386 and AC-268 land in success bucket or remain as genuine multi-hour hangs worth investigating separately).

## Linked
- Linear: AC-588
- Prior bumps: AC-570 (120→300s).
- Companion fixes surfaced by the same sweep: AC-585 (#743 merged), AC-586 (#744 merged).