### PR TITLE
AC-593: consolidate memory sources before prompt injection

### DIFF
--- a/autocontext/src/autocontext/knowledge/trajectory.py
+++ b/autocontext/src/autocontext/knowledge/trajectory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from autocontext.harness.evaluation.dimensional import format_dimension_trajectory
+from autocontext.knowledge.compaction import compact_prompt_components
 from autocontext.storage.sqlite_store import SQLiteStore
 
 
@@ -81,7 +82,7 @@ class ScoreTrajectoryBuilder:
         for row in rows:
             lines.append(str(row["content"]))
             lines.append("")
-        return "\n".join(lines)
+        return compact_prompt_components({"experiment_log": "\n".join(lines)})["experiment_log"]
 
     def build_strategy_registry(self, run_id: str) -> str:
         """Markdown table: Gen | Strategy (truncated) | Best Score | Gate"""

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -293,10 +293,17 @@ def stage_knowledge_setup(
     tool_usage_report = "" if ablation else _load_architect_tool_usage_report(ctx, artifacts=artifacts)
     weakness_reports = "" if ablation else artifacts.read_latest_weakness_reports_markdown(ctx.scenario_name)
     progress_reports = "" if ablation else artifacts.read_latest_progress_reports_markdown(ctx.scenario_name)
+    session_reports = (
+        ""
+        if ablation or not ctx.settings.session_reports_enabled
+        else artifacts.read_latest_session_reports(ctx.scenario_name)
+    )
     score_trajectory = "" if ablation else trajectory_builder.build_trajectory(ctx.run_id)
     strategy_registry = "" if ablation else trajectory_builder.build_strategy_registry(ctx.run_id)
     coach_hints_for_prompt = "" if ablation else ctx.coach_competitor_hints
     freshness_notes: list[str] = []
+    if not isinstance(session_reports, str):
+        session_reports = ""
 
     if not ablation and ctx.settings.evidence_freshness_enabled:
         skills_context, lesson_freshness = _load_fresh_skill_context(ctx, artifacts=artifacts)
@@ -422,6 +429,7 @@ def stage_knowledge_setup(
         strategy_registry=strategy_registry,
         progress_json=progress_json_str,
         experiment_log=experiment_log,
+        session_reports=session_reports,
         architect_tool_usage_report=tool_usage_report,
         constraint_mode=ctx.settings.constraint_prompts_enabled,
         context_budget_tokens=ctx.settings.context_budget_tokens,

--- a/autocontext/src/autocontext/session/memory_consolidation.py
+++ b/autocontext/src/autocontext/session/memory_consolidation.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from autocontext.knowledge.compaction import extract_promotable_lines
+
 logger = logging.getLogger(__name__)
 
 
@@ -164,7 +166,7 @@ class MemoryConsolidator:
         if isinstance(session_reports, list):
             for report in session_reports:
                 if isinstance(report, str) and len(report.strip()) > 20:
-                    promoted_lessons.append(report.strip()[:200])
+                    promoted_lessons.extend(extract_promotable_lines(report, max_items=3))
                     reviewed.append("session_report")
 
         # Extract from verification outcomes

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -20,6 +20,7 @@ from autocontext.analytics.credit_assignment import CreditAssignmentRecord
 from autocontext.harness.mutations.spec import HarnessMutation
 from autocontext.harness.mutations.store import MutationStore
 from autocontext.harness.storage.versioned_store import VersionedFileStore
+from autocontext.knowledge.compaction import compact_prompt_components
 from autocontext.knowledge.hint_volume import HintManager, HintVolumePolicy
 from autocontext.knowledge.lessons import LessonStore
 from autocontext.knowledge.mutation_log import MutationEntry, MutationLog
@@ -1153,7 +1154,8 @@ class ArtifactStore:
         reports = []
         for path in report_files[:max_reports]:
             reports.append(path.read_text(encoding="utf-8"))
-        return "\n\n---\n\n".join(reports)
+        combined = "\n\n---\n\n".join(reports)
+        return compact_prompt_components({"session_reports": combined})["session_reports"]
 
     # --- Harness versioning ---------------------------------------------------
 

--- a/autocontext/tests/test_generation_stages.py
+++ b/autocontext/tests/test_generation_stages.py
@@ -298,6 +298,54 @@ class TestStageKnowledgeSetup:
         assert "Recent progress reports:" in result.prompts.competitor
         assert "Tokens per advance" in result.prompts.competitor
 
+    def test_includes_recent_session_reports_in_prompt_context(self) -> None:
+        artifacts = MagicMock()
+        artifacts.read_playbook.return_value = ""
+        artifacts.read_tool_context.return_value = ""
+        artifacts.read_skills.return_value = ""
+        artifacts.read_mutation_replay.return_value = ""
+        artifacts.read_latest_weakness_reports_markdown.return_value = ""
+        artifacts.read_latest_progress_reports_markdown.return_value = ""
+        artifacts.read_latest_session_reports.return_value = (
+            "# Session Report: run_3\n## Key Findings\n- Preserve rollback guardrails"
+        )
+        artifacts.read_latest_advance_analysis.return_value = ""
+        artifacts.read_progress.return_value = None
+        trajectory = MagicMock()
+        trajectory.build_trajectory.return_value = ""
+        trajectory.build_strategy_registry.return_value = ""
+        trajectory.build_experiment_log.return_value = ""
+        ctx = _make_ctx()
+
+        result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
+
+        assert result.prompts is not None
+        assert "Prior session reports:" in result.prompts.competitor
+        assert "Preserve rollback guardrails" in result.prompts.competitor
+
+    def test_skips_session_reports_when_disabled(self) -> None:
+        settings = AppSettings(agent_provider="deterministic", session_reports_enabled=False)
+        artifacts = MagicMock()
+        artifacts.read_playbook.return_value = ""
+        artifacts.read_tool_context.return_value = ""
+        artifacts.read_skills.return_value = ""
+        artifacts.read_mutation_replay.return_value = ""
+        artifacts.read_latest_weakness_reports_markdown.return_value = ""
+        artifacts.read_latest_progress_reports_markdown.return_value = ""
+        artifacts.read_latest_advance_analysis.return_value = ""
+        artifacts.read_progress.return_value = None
+        trajectory = MagicMock()
+        trajectory.build_trajectory.return_value = ""
+        trajectory.build_strategy_registry.return_value = ""
+        trajectory.build_experiment_log.return_value = ""
+        ctx = _make_ctx(settings=settings)
+
+        result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
+
+        assert result.prompts is not None
+        assert "Prior session reports:" not in result.prompts.competitor
+        artifacts.read_latest_session_reports.assert_not_called()
+
     def test_applies_active_harness_mutations_to_live_prompts(self) -> None:
         from autocontext.harness.mutations.spec import HarnessMutation, MutationType
 

--- a/autocontext/tests/test_memory_consolidation.py
+++ b/autocontext/tests/test_memory_consolidation.py
@@ -189,3 +189,29 @@ class TestMemoryConsolidator:
             dry_run=True,
         )
         assert result.dry_run
+
+    def test_promotes_structured_lessons_instead_of_raw_prefixes(self) -> None:
+        from autocontext.session.memory_consolidation import (
+            ConsolidationTrigger,
+            MemoryConsolidator,
+        )
+
+        trigger = ConsolidationTrigger(min_completed_turns=1)
+        consolidator = MemoryConsolidator(trigger=trigger)
+        report = (
+            "# Session Report: run_123\n"
+            "Verbose setup details that are not the main lesson.\n"
+            "## Findings\n"
+            "- Preserve the rollback guard after failed tool mutations.\n"
+            "- Prefer freshness-filtered notebook context over stale notes.\n"
+        )
+
+        result = consolidator.run(
+            completed_turns=3,
+            completed_sessions=1,
+            artifacts={"session_reports": [report]},
+            dry_run=True,
+        )
+
+        assert any("rollback guard" in lesson.lower() for lesson in result.promoted_lessons)
+        assert any("freshness-filtered" in lesson.lower() for lesson in result.promoted_lessons)

--- a/autocontext/tests/test_rlm_competitor.py
+++ b/autocontext/tests/test_rlm_competitor.py
@@ -711,6 +711,25 @@ class TestExperimentLog:
         assert "Gen 1 trial" in log
         assert "aggression" not in log
 
+    def test_build_experiment_log_compacts_noisy_history(self, tmp_sqlite: Any) -> None:
+        """Long trial histories are condensed while preserving recent signal."""
+        from autocontext.knowledge.trajectory import ScoreTrajectoryBuilder
+
+        self._seed_run(tmp_sqlite, "run-1", [1, 7])
+        tmp_sqlite.append_agent_output("run-1", 1, "competitor_rlm_trials", "### Generation 1\n" + ("noise line\n" * 120))
+        tmp_sqlite.append_agent_output(
+            "run-1",
+            7,
+            "competitor_rlm_trials",
+            "### Generation 7\n- Root cause: overfitting to stale hints\n- Keep broader opening exploration",
+        )
+
+        builder = ScoreTrajectoryBuilder(tmp_sqlite)
+        log = builder.build_experiment_log("run-1")
+        assert "Generation 7" in log
+        assert "overfitting to stale hints" in log
+        assert "condensed" in log.lower() or log.count("noise line") < 120
+
 
 class TestRlmTrialStorage:
     def test_rlm_competitor_stores_trial_summary(

--- a/autocontext/tests/test_session_reports.py
+++ b/autocontext/tests/test_session_reports.py
@@ -247,6 +247,22 @@ class TestArtifactStoreReports:
         assert "Mid Report" in result
         assert "Old Report" not in result
 
+    def test_read_latest_reports_compacts_verbose_reports(self, tmp_path: Path) -> None:
+        store = self._make_store(tmp_path)
+        verbose_report = (
+            "# Session Report: run_new\n"
+            + ("filler paragraph\n" * 80)
+            + "## Findings\n"
+            + "- Preserve the rollback guard after failed harness mutations.\n"
+            + "- Prefer notebook freshness filtering before prompt injection.\n"
+        )
+        store.write_session_report("grid_ctf", "run_new", verbose_report)
+
+        result = store.read_latest_session_reports("grid_ctf", max_reports=1)
+        assert "rollback guard" in result
+        assert "freshness filtering" in result
+        assert "condensed" in result.lower() or result.count("filler paragraph") < 20
+
 
 # ── Prompt bundle integration ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- promote structured lessons from session reports instead of raw text prefixes
- compact experiment-log and session-report sources before they are injected into prompts
- keep this PR stacked on AC-590 so the shared compaction helper is reused instead of duplicated

## Testing
- uv run pytest tests/test_memory_consolidation.py tests/test_rlm_competitor.py tests/test_session_reports.py tests/test_knowledge_compaction.py tests/test_build_prompt_bundle_semantic_compaction.py
- uv run ruff check src/autocontext/session/memory_consolidation.py src/autocontext/knowledge/trajectory.py src/autocontext/storage/artifacts.py tests/test_memory_consolidation.py tests/test_rlm_competitor.py tests/test_session_reports.py
- uv run mypy src