### PR TITLE
AC-590: add semantic context compaction before role prompt assembly

### DIFF
--- a/autocontext/src/autocontext/knowledge/compaction.py
+++ b/autocontext/src/autocontext/knowledge/compaction.py
@@ -1,0 +1,255 @@
+"""Deterministic context compaction for long-lived knowledge surfaces.
+
+These helpers keep structured context bounded before the final prompt budget
+fallback runs. The goal is not to perfectly summarize arbitrary text, but to
+preserve high-signal structure such as headings, bullets, findings, and recent
+history while dropping repetitive filler.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+
+from autocontext.prompts.context_budget import estimate_tokens
+
+_DEFAULT_COMPONENT_TOKEN_LIMITS: dict[str, int] = {
+    "playbook": 2800,
+    "lessons": 1600,
+    "analysis": 1800,
+    "trajectory": 1200,
+    "experiment_log": 1800,
+    "session_reports": 1400,
+    "research_protocol": 1200,
+    "evidence_manifest": 1200,
+    "evidence_manifest_analyst": 1200,
+    "evidence_manifest_architect": 1200,
+}
+
+_IMPORTANT_KEYWORDS = (
+    "root cause",
+    "finding",
+    "findings",
+    "recommendation",
+    "recommendations",
+    "rollback",
+    "guard",
+    "freshness",
+    "objective",
+    "score",
+    "hypothesis",
+    "diagnosis",
+    "regression",
+    "failure",
+    "mitigation",
+)
+
+
+def compact_prompt_components(components: Mapping[str, str]) -> dict[str, str]:
+    """Return a compacted copy of prompt-facing context components."""
+    result: dict[str, str] = {}
+    for key, value in components.items():
+        if not value:
+            result[key] = value
+            continue
+        limit = _DEFAULT_COMPONENT_TOKEN_LIMITS.get(key)
+        if limit is None:
+            result[key] = value
+            continue
+        result[key] = _compact_component(key, value, limit)
+    return result
+
+
+def extract_promotable_lines(text: str, *, max_items: int = 3) -> list[str]:
+    """Extract durable lessons from a report-like block of markdown."""
+    if not text.strip():
+        return []
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    prioritized_lines: list[str] = []
+    fallback_lines: list[str] = []
+
+    for line in lines:
+        normalized = line.lower()
+        cleaned = re.sub(r"\s+", " ", line).strip().lstrip("#").strip().lstrip("-* ").strip()
+        if not cleaned or cleaned.lower() in seen:
+            continue
+        if line.startswith("#"):
+            if cleaned.lower() not in {"findings", "summary"} and not cleaned.lower().startswith("session report"):
+                fallback_lines.append(cleaned)
+        elif line.startswith(("- ", "* ")) or any(keyword in normalized for keyword in _IMPORTANT_KEYWORDS):
+            prioritized_lines.append(cleaned)
+
+    for cleaned in [*prioritized_lines, *fallback_lines]:
+        if cleaned.lower() in seen:
+            continue
+        seen.add(cleaned.lower())
+        candidates.append(cleaned[:220])
+        if len(candidates) >= max_items:
+            break
+
+    if candidates:
+        return candidates
+
+    fallback = re.sub(r"\s+", " ", text).strip()
+    return [fallback[:220]] if fallback else []
+
+
+def _compact_component(key: str, text: str, max_tokens: int) -> str:
+    if key in {"experiment_log", "session_reports"}:
+        needs_history_compaction = len(text.splitlines()) > 24 or len(_split_sections(text)) > 4
+        if not needs_history_compaction and estimate_tokens(text) <= max_tokens:
+            return text
+    elif estimate_tokens(text) <= max_tokens:
+        return text
+
+    if key in {"experiment_log", "session_reports"}:
+        compacted = _compact_history(text, max_tokens=max_tokens)
+    elif key == "trajectory":
+        compacted = _compact_table(text, max_tokens=max_tokens)
+    else:
+        compacted = _compact_markdown(text, max_tokens=max_tokens)
+
+    if estimate_tokens(compacted) > max_tokens:
+        compacted = _truncate_text(compacted, max_tokens=max_tokens)
+    return compacted
+
+
+def _compact_history(text: str, *, max_tokens: int) -> str:
+    sections = _split_sections(text)
+    if not sections:
+        return _truncate_text(text, max_tokens=max_tokens)
+
+    selected = sections[-4:]
+    compacted_sections = [_compact_section(section) for section in selected]
+    compacted = "\n\n".join(section for section in compacted_sections if section.strip()).strip()
+    if compacted and compacted != text:
+        compacted = f"{compacted}\n\n[... condensed recent history ...]"
+    return compacted or _truncate_text(text, max_tokens=max_tokens)
+
+
+def _compact_markdown(text: str, *, max_tokens: int) -> str:
+    sections = _split_sections(text)
+    if not sections:
+        return _truncate_text(text, max_tokens=max_tokens)
+
+    compacted_sections = [_compact_section(section) for section in sections[:6]]
+    compacted = "\n\n".join(section for section in compacted_sections if section.strip()).strip()
+    if compacted and compacted != text:
+        compacted = f"{compacted}\n\n[... condensed structured context ...]"
+    return compacted or _truncate_text(text, max_tokens=max_tokens)
+
+
+def _compact_table(text: str, *, max_tokens: int) -> str:
+    lines = [line.rstrip() for line in text.splitlines()]
+    if len(lines) <= 12 and estimate_tokens(text) <= max_tokens:
+        return text
+
+    table_header: list[str] = []
+    table_rows: list[str] = []
+    other_lines: list[str] = []
+    in_table = False
+
+    for line in lines:
+        if line.startswith("|"):
+            in_table = True
+            if len(table_header) < 2:
+                table_header.append(line)
+            else:
+                table_rows.append(line)
+        elif in_table and not line.strip():
+            in_table = False
+            other_lines.append(line)
+        else:
+            other_lines.append(line)
+
+    selected_rows = table_rows[-8:]
+    compacted_lines = [
+        *other_lines[:4],
+        *table_header,
+        *selected_rows,
+    ]
+    compacted = "\n".join(line for line in compacted_lines if line is not None).strip()
+    if compacted and compacted != text:
+        compacted = f"{compacted}\n\n[... condensed trajectory ...]"
+    return compacted or _truncate_text(text, max_tokens=max_tokens)
+
+
+def _split_sections(text: str) -> list[str]:
+    if "\n\n---\n\n" in text:
+        return [section.strip() for section in text.split("\n\n---\n\n") if section.strip()]
+
+    sections: list[list[str]] = []
+    current: list[str] = []
+    for line in text.splitlines():
+        if re.match(r"^#{1,6}\s+", line) and current:
+            sections.append(current)
+            current = [line]
+            continue
+        current.append(line)
+    if current:
+        sections.append(current)
+    return ["\n".join(section).strip() for section in sections if any(line.strip() for line in section)]
+
+
+def _compact_section(section: str) -> str:
+    lines = [line.rstrip() for line in section.splitlines() if line.strip()]
+    if not lines:
+        return ""
+
+    selected: list[str] = []
+    heading_kept = False
+    body_candidates: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        normalized = stripped.lower()
+        if stripped.startswith("#"):
+            if not heading_kept:
+                selected.append(stripped)
+                heading_kept = True
+            continue
+        if _is_structured_line(stripped) or any(keyword in normalized for keyword in _IMPORTANT_KEYWORDS):
+            body_candidates.append(stripped)
+
+    if not body_candidates:
+        body_candidates = [line.strip() for line in lines[1:3] if line.strip()] or [lines[0].strip()]
+
+    selected.extend(_dedupe_lines(body_candidates)[:4])
+    return "\n".join(selected).strip()
+
+
+def _is_structured_line(line: str) -> bool:
+    return (
+        line.startswith(("- ", "* ", "> "))
+        or bool(re.match(r"^\d+\.\s+", line))
+        or ":" in line
+    )
+
+
+def _dedupe_lines(lines: Iterable[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for line in lines:
+        normalized = re.sub(r"\s+", " ", line.strip()).lower()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(line.strip())
+    return deduped
+
+
+def _truncate_text(text: str, *, max_tokens: int) -> str:
+    if max_tokens <= 0:
+        return ""
+    max_chars = max_tokens * 4
+    if len(text) <= max_chars:
+        return text
+    truncated = text[:max_chars].rstrip()
+    last_nl = truncated.rfind("\n")
+    if last_nl > max_chars // 2:
+        truncated = truncated[:last_nl].rstrip()
+    return f"{truncated}\n[... condensed for prompt budget ...]"

--- a/autocontext/src/autocontext/knowledge/compaction.py
+++ b/autocontext/src/autocontext/knowledge/compaction.py
@@ -110,6 +110,8 @@ def _compact_component(key: str, text: str, max_tokens: int) -> str:
         compacted = _compact_history(text, max_tokens=max_tokens)
     elif key == "trajectory":
         compacted = _compact_table(text, max_tokens=max_tokens)
+    elif key == "lessons":
+        compacted = _compact_markdown(text, max_tokens=max_tokens, prefer_recent=True)
     else:
         compacted = _compact_markdown(text, max_tokens=max_tokens)
 
@@ -131,12 +133,21 @@ def _compact_history(text: str, *, max_tokens: int) -> str:
     return compacted or _truncate_text(text, max_tokens=max_tokens)
 
 
-def _compact_markdown(text: str, *, max_tokens: int) -> str:
+def _compact_markdown(
+    text: str,
+    *,
+    max_tokens: int,
+    prefer_recent: bool = False,
+) -> str:
     sections = _split_sections(text)
     if not sections:
         return _truncate_text(text, max_tokens=max_tokens)
 
-    compacted_sections = [_compact_section(section) for section in sections[:6]]
+    selected_sections = sections[-6:] if prefer_recent else sections[:6]
+    compacted_sections = [
+        _compact_section(section, prefer_recent=prefer_recent)
+        for section in selected_sections
+    ]
     compacted = "\n\n".join(section for section in compacted_sections if section.strip()).strip()
     if compacted and compacted != text:
         compacted = f"{compacted}\n\n[... condensed structured context ...]"
@@ -150,28 +161,39 @@ def _compact_table(text: str, *, max_tokens: int) -> str:
 
     table_header: list[str] = []
     table_rows: list[str] = []
-    other_lines: list[str] = []
+    pre_table_lines: list[str] = []
+    post_table_lines: list[str] = []
     in_table = False
+    saw_table = False
 
     for line in lines:
         if line.startswith("|"):
             in_table = True
+            saw_table = True
             if len(table_header) < 2:
                 table_header.append(line)
             else:
                 table_rows.append(line)
         elif in_table and not line.strip():
             in_table = False
-            other_lines.append(line)
         else:
-            other_lines.append(line)
+            target = post_table_lines if saw_table and not in_table else pre_table_lines
+            target.append(line)
 
     selected_rows = table_rows[-8:]
+    trailing_context = "\n".join(line for line in post_table_lines if line.strip()).strip()
+    compacted_trailing_context = (
+        _compact_markdown(trailing_context, max_tokens=max_tokens)
+        if trailing_context
+        else ""
+    )
     compacted_lines = [
-        *other_lines[:4],
+        *pre_table_lines[:4],
         *table_header,
         *selected_rows,
     ]
+    if compacted_trailing_context:
+        compacted_lines.extend(["", compacted_trailing_context])
     compacted = "\n".join(line for line in compacted_lines if line is not None).strip()
     if compacted and compacted != text:
         compacted = f"{compacted}\n\n[... condensed trajectory ...]"
@@ -195,7 +217,7 @@ def _split_sections(text: str) -> list[str]:
     return ["\n".join(section).strip() for section in sections if any(line.strip() for line in section)]
 
 
-def _compact_section(section: str) -> str:
+def _compact_section(section: str, *, prefer_recent: bool = False) -> str:
     lines = [line.rstrip() for line in section.splitlines() if line.strip()]
     if not lines:
         return ""
@@ -218,7 +240,9 @@ def _compact_section(section: str) -> str:
     if not body_candidates:
         body_candidates = [line.strip() for line in lines[1:3] if line.strip()] or [lines[0].strip()]
 
-    selected.extend(_dedupe_lines(body_candidates)[:4])
+    deduped_candidates = _dedupe_lines(body_candidates)
+    chosen_candidates = deduped_candidates[-4:] if prefer_recent else deduped_candidates[:4]
+    selected.extend(chosen_candidates)
     return "\n".join(selected).strip()
 
 

--- a/autocontext/src/autocontext/knowledge/trajectory.py
+++ b/autocontext/src/autocontext/knowledge/trajectory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from autocontext.harness.evaluation.dimensional import format_dimension_trajectory
+from autocontext.knowledge.compaction import compact_prompt_components
 from autocontext.storage.sqlite_store import SQLiteStore
 
 
@@ -81,7 +82,7 @@ class ScoreTrajectoryBuilder:
         for row in rows:
             lines.append(str(row["content"]))
             lines.append("")
-        return "\n".join(lines)
+        return compact_prompt_components({"experiment_log": "\n".join(lines)})["experiment_log"]
 
     def build_strategy_registry(self, run_id: str) -> str:
         """Markdown table: Gen | Strategy (truncated) | Best Score | Gate"""

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -293,10 +293,17 @@ def stage_knowledge_setup(
     tool_usage_report = "" if ablation else _load_architect_tool_usage_report(ctx, artifacts=artifacts)
     weakness_reports = "" if ablation else artifacts.read_latest_weakness_reports_markdown(ctx.scenario_name)
     progress_reports = "" if ablation else artifacts.read_latest_progress_reports_markdown(ctx.scenario_name)
+    session_reports = (
+        ""
+        if ablation or not ctx.settings.session_reports_enabled
+        else artifacts.read_latest_session_reports(ctx.scenario_name)
+    )
     score_trajectory = "" if ablation else trajectory_builder.build_trajectory(ctx.run_id)
     strategy_registry = "" if ablation else trajectory_builder.build_strategy_registry(ctx.run_id)
     coach_hints_for_prompt = "" if ablation else ctx.coach_competitor_hints
     freshness_notes: list[str] = []
+    if not isinstance(session_reports, str):
+        session_reports = ""
 
     if not ablation and ctx.settings.evidence_freshness_enabled:
         skills_context, lesson_freshness = _load_fresh_skill_context(ctx, artifacts=artifacts)
@@ -422,6 +429,7 @@ def stage_knowledge_setup(
         strategy_registry=strategy_registry,
         progress_json=progress_json_str,
         experiment_log=experiment_log,
+        session_reports=session_reports,
         architect_tool_usage_report=tool_usage_report,
         constraint_mode=ctx.settings.constraint_prompts_enabled,
         context_budget_tokens=ctx.settings.context_budget_tokens,

--- a/autocontext/src/autocontext/prompts/templates.py
+++ b/autocontext/src/autocontext/prompts/templates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from autocontext.knowledge.compaction import compact_prompt_components
 from autocontext.prompts.context_budget import ContextBudget
 from autocontext.scenarios.base import Observation
 from autocontext.strategy_interface import is_action_plan_interface
@@ -82,6 +83,24 @@ def build_prompt_bundle(
     evidence_manifest: str = "",
 ) -> PromptBundle:
     _nb = dict(notebook_contexts or {})
+    compacted = compact_prompt_components(
+        {
+            "playbook": current_playbook,
+            "trajectory": score_trajectory,
+            "lessons": operational_lessons,
+            "analysis": recent_analysis,
+            "experiment_log": experiment_log,
+            "research_protocol": research_protocol,
+            "session_reports": session_reports,
+        }
+    )
+    current_playbook = compacted["playbook"]
+    score_trajectory = compacted["trajectory"]
+    operational_lessons = compacted["lessons"]
+    recent_analysis = compacted["analysis"]
+    experiment_log = compacted["experiment_log"]
+    research_protocol = compacted["research_protocol"]
+    session_reports = compacted["session_reports"]
     if context_budget_tokens > 0:
         budget = ContextBudget(max_tokens=context_budget_tokens)
         budgeted = budget.apply(

--- a/autocontext/src/autocontext/session/memory_consolidation.py
+++ b/autocontext/src/autocontext/session/memory_consolidation.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from autocontext.knowledge.compaction import extract_promotable_lines
+
 logger = logging.getLogger(__name__)
 
 
@@ -164,7 +166,7 @@ class MemoryConsolidator:
         if isinstance(session_reports, list):
             for report in session_reports:
                 if isinstance(report, str) and len(report.strip()) > 20:
-                    promoted_lessons.append(report.strip()[:200])
+                    promoted_lessons.extend(extract_promotable_lines(report, max_items=3))
                     reviewed.append("session_report")
 
         # Extract from verification outcomes

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -20,6 +20,7 @@ from autocontext.analytics.credit_assignment import CreditAssignmentRecord
 from autocontext.harness.mutations.spec import HarnessMutation
 from autocontext.harness.mutations.store import MutationStore
 from autocontext.harness.storage.versioned_store import VersionedFileStore
+from autocontext.knowledge.compaction import compact_prompt_components
 from autocontext.knowledge.hint_volume import HintManager, HintVolumePolicy
 from autocontext.knowledge.lessons import LessonStore
 from autocontext.knowledge.mutation_log import MutationEntry, MutationLog
@@ -1153,7 +1154,8 @@ class ArtifactStore:
         reports = []
         for path in report_files[:max_reports]:
             reports.append(path.read_text(encoding="utf-8"))
-        return "\n\n---\n\n".join(reports)
+        combined = "\n\n---\n\n".join(reports)
+        return compact_prompt_components({"session_reports": combined})["session_reports"]
 
     # --- Harness versioning ---------------------------------------------------
 

--- a/autocontext/tests/test_build_prompt_bundle_semantic_compaction.py
+++ b/autocontext/tests/test_build_prompt_bundle_semantic_compaction.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from autocontext.scenarios.base import Observation
+
+
+def test_build_prompt_bundle_compacts_history_before_budget_fallback() -> None:
+    from autocontext.prompts.templates import build_prompt_bundle
+
+    bundle = build_prompt_bundle(
+        scenario_rules="rules",
+        strategy_interface="interface",
+        evaluation_criteria="criteria",
+        previous_summary="summary",
+        observation=Observation(narrative="test", state={}, constraints=[]),
+        current_playbook="playbook",
+        available_tools="tools",
+        experiment_log=(
+            "## RLM Experiment Log\n\n"
+            "### Generation 1\n"
+            + ("noise line\n" * 120)
+            + "\n### Generation 7\n"
+            + "- Root cause: overfitting to stale hints\n"
+        ),
+        session_reports=(
+            "# Session Report: run_old\n"
+            + ("filler paragraph\n" * 80)
+            + "## Findings\n"
+            + "- Preserve the rollback guard after failed harness mutations.\n"
+        ),
+    )
+
+    assert "Generation 7" in bundle.competitor
+    assert "rollback guard" in bundle.competitor
+    assert "condensed" in bundle.competitor.lower()

--- a/autocontext/tests/test_generation_stages.py
+++ b/autocontext/tests/test_generation_stages.py
@@ -298,6 +298,54 @@ class TestStageKnowledgeSetup:
         assert "Recent progress reports:" in result.prompts.competitor
         assert "Tokens per advance" in result.prompts.competitor
 
+    def test_includes_recent_session_reports_in_prompt_context(self) -> None:
+        artifacts = MagicMock()
+        artifacts.read_playbook.return_value = ""
+        artifacts.read_tool_context.return_value = ""
+        artifacts.read_skills.return_value = ""
+        artifacts.read_mutation_replay.return_value = ""
+        artifacts.read_latest_weakness_reports_markdown.return_value = ""
+        artifacts.read_latest_progress_reports_markdown.return_value = ""
+        artifacts.read_latest_session_reports.return_value = (
+            "# Session Report: run_3\n## Key Findings\n- Preserve rollback guardrails"
+        )
+        artifacts.read_latest_advance_analysis.return_value = ""
+        artifacts.read_progress.return_value = None
+        trajectory = MagicMock()
+        trajectory.build_trajectory.return_value = ""
+        trajectory.build_strategy_registry.return_value = ""
+        trajectory.build_experiment_log.return_value = ""
+        ctx = _make_ctx()
+
+        result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
+
+        assert result.prompts is not None
+        assert "Prior session reports:" in result.prompts.competitor
+        assert "Preserve rollback guardrails" in result.prompts.competitor
+
+    def test_skips_session_reports_when_disabled(self) -> None:
+        settings = AppSettings(agent_provider="deterministic", session_reports_enabled=False)
+        artifacts = MagicMock()
+        artifacts.read_playbook.return_value = ""
+        artifacts.read_tool_context.return_value = ""
+        artifacts.read_skills.return_value = ""
+        artifacts.read_mutation_replay.return_value = ""
+        artifacts.read_latest_weakness_reports_markdown.return_value = ""
+        artifacts.read_latest_progress_reports_markdown.return_value = ""
+        artifacts.read_latest_advance_analysis.return_value = ""
+        artifacts.read_progress.return_value = None
+        trajectory = MagicMock()
+        trajectory.build_trajectory.return_value = ""
+        trajectory.build_strategy_registry.return_value = ""
+        trajectory.build_experiment_log.return_value = ""
+        ctx = _make_ctx(settings=settings)
+
+        result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
+
+        assert result.prompts is not None
+        assert "Prior session reports:" not in result.prompts.competitor
+        artifacts.read_latest_session_reports.assert_not_called()
+
     def test_applies_active_harness_mutations_to_live_prompts(self) -> None:
         from autocontext.harness.mutations.spec import HarnessMutation, MutationType
 

--- a/autocontext/tests/test_knowledge_compaction.py
+++ b/autocontext/tests/test_knowledge_compaction.py
@@ -41,3 +41,55 @@ def test_compact_prompt_components_extracts_key_session_report_lines() -> None:
     assert "rollback guard" in compacted["session_reports"]
     assert "freshness filtering" in compacted["session_reports"]
     assert len(compacted["session_reports"]) < len(components["session_reports"])
+
+
+def test_compact_prompt_components_keeps_recent_lessons() -> None:
+    from autocontext.knowledge.compaction import compact_prompt_components
+
+    components = {
+        "lessons": "## Lessons\n" + "\n".join(
+            [f"- old lesson {i} " + ("x" * 120) for i in range(1, 120)]
+            + ["- newest lesson keep me"]
+        ),
+    }
+
+    compacted = compact_prompt_components(components)
+
+    assert "newest lesson keep me" in compacted["lessons"]
+    assert "- old lesson 117 " in compacted["lessons"]
+    assert "- old lesson 1 " not in compacted["lessons"]
+
+
+def test_compact_prompt_components_preserves_trailing_dimension_section() -> None:
+    from autocontext.knowledge.compaction import compact_prompt_components
+
+    table_rows = [
+        f"| {i} | 0.5000 | 0.6000 | 1500.0 | advance | +0.0100 |"
+        for i in range(1, 120)
+    ]
+    components = {
+        "trajectory": "\n".join(
+            [
+                "## Score Trajectory",
+                "",
+                "| Gen | Mean | Best | Elo | Gate | Delta |",
+                "|-----|------|------|--------|------|-------|",
+                *table_rows,
+                "",
+                "## Dimension Trajectory (Best Match)",
+                "",
+                "```text",
+                ("aggression: up then down " * 20).strip(),
+                ("defense: stable high signal " * 20).strip(),
+                "```",
+            ]
+        ),
+    }
+
+    compacted = compact_prompt_components(components)
+
+    assert "## Dimension Trajectory (Best Match)" in compacted["trajectory"]
+    assert "aggression: up then down" in compacted["trajectory"]
+    assert compacted["trajectory"].index("## Dimension Trajectory (Best Match)") > compacted["trajectory"].index(
+        "| Gen | Mean | Best | Elo | Gate | Delta |"
+    )

--- a/autocontext/tests/test_knowledge_compaction.py
+++ b/autocontext/tests/test_knowledge_compaction.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+
+def test_compact_prompt_components_keeps_recent_experiment_sections() -> None:
+    from autocontext.knowledge.compaction import compact_prompt_components
+
+    components = {
+        "experiment_log": (
+            "## RLM Experiment Log\n\n"
+            "### Generation 1\n"
+            + ("noise line\n" * 120)
+            + "\n### Generation 7\n"
+            + "- Root cause: overfitting to stale hints\n"
+            + "- Keep broader opening exploration\n"
+        ),
+    }
+
+    compacted = compact_prompt_components(components)
+
+    assert "Generation 7" in compacted["experiment_log"]
+    assert "overfitting to stale hints" in compacted["experiment_log"]
+    assert len(compacted["experiment_log"]) < len(components["experiment_log"])
+
+
+def test_compact_prompt_components_extracts_key_session_report_lines() -> None:
+    from autocontext.knowledge.compaction import compact_prompt_components
+
+    components = {
+        "session_reports": (
+            "# Session Report: run_old\n"
+            "Long narrative that meanders without much signal.\n"
+            + ("filler paragraph\n" * 80)
+            + "\n## Findings\n"
+            "- Preserve the rollback guard after failed harness mutations.\n"
+            "- Prefer notebook freshness filtering before prompt injection.\n"
+        ),
+    }
+
+    compacted = compact_prompt_components(components)
+
+    assert "rollback guard" in compacted["session_reports"]
+    assert "freshness filtering" in compacted["session_reports"]
+    assert len(compacted["session_reports"]) < len(components["session_reports"])

--- a/autocontext/tests/test_memory_consolidation.py
+++ b/autocontext/tests/test_memory_consolidation.py
@@ -189,3 +189,29 @@ class TestMemoryConsolidator:
             dry_run=True,
         )
         assert result.dry_run
+
+    def test_promotes_structured_lessons_instead_of_raw_prefixes(self) -> None:
+        from autocontext.session.memory_consolidation import (
+            ConsolidationTrigger,
+            MemoryConsolidator,
+        )
+
+        trigger = ConsolidationTrigger(min_completed_turns=1)
+        consolidator = MemoryConsolidator(trigger=trigger)
+        report = (
+            "# Session Report: run_123\n"
+            "Verbose setup details that are not the main lesson.\n"
+            "## Findings\n"
+            "- Preserve the rollback guard after failed tool mutations.\n"
+            "- Prefer freshness-filtered notebook context over stale notes.\n"
+        )
+
+        result = consolidator.run(
+            completed_turns=3,
+            completed_sessions=1,
+            artifacts={"session_reports": [report]},
+            dry_run=True,
+        )
+
+        assert any("rollback guard" in lesson.lower() for lesson in result.promoted_lessons)
+        assert any("freshness-filtered" in lesson.lower() for lesson in result.promoted_lessons)

--- a/autocontext/tests/test_rlm_competitor.py
+++ b/autocontext/tests/test_rlm_competitor.py
@@ -711,6 +711,25 @@ class TestExperimentLog:
         assert "Gen 1 trial" in log
         assert "aggression" not in log
 
+    def test_build_experiment_log_compacts_noisy_history(self, tmp_sqlite: Any) -> None:
+        """Long trial histories are condensed while preserving recent signal."""
+        from autocontext.knowledge.trajectory import ScoreTrajectoryBuilder
+
+        self._seed_run(tmp_sqlite, "run-1", [1, 7])
+        tmp_sqlite.append_agent_output("run-1", 1, "competitor_rlm_trials", "### Generation 1\n" + ("noise line\n" * 120))
+        tmp_sqlite.append_agent_output(
+            "run-1",
+            7,
+            "competitor_rlm_trials",
+            "### Generation 7\n- Root cause: overfitting to stale hints\n- Keep broader opening exploration",
+        )
+
+        builder = ScoreTrajectoryBuilder(tmp_sqlite)
+        log = builder.build_experiment_log("run-1")
+        assert "Generation 7" in log
+        assert "overfitting to stale hints" in log
+        assert "condensed" in log.lower() or log.count("noise line") < 120
+
 
 class TestRlmTrialStorage:
     def test_rlm_competitor_stores_trial_summary(

--- a/autocontext/tests/test_session_reports.py
+++ b/autocontext/tests/test_session_reports.py
@@ -247,6 +247,22 @@ class TestArtifactStoreReports:
         assert "Mid Report" in result
         assert "Old Report" not in result
 
+    def test_read_latest_reports_compacts_verbose_reports(self, tmp_path: Path) -> None:
+        store = self._make_store(tmp_path)
+        verbose_report = (
+            "# Session Report: run_new\n"
+            + ("filler paragraph\n" * 80)
+            + "## Findings\n"
+            + "- Preserve the rollback guard after failed harness mutations.\n"
+            + "- Prefer notebook freshness filtering before prompt injection.\n"
+        )
+        store.write_session_report("grid_ctf", "run_new", verbose_report)
+
+        result = store.read_latest_session_reports("grid_ctf", max_reports=1)
+        assert "rollback guard" in result
+        assert "freshness filtering" in result
+        assert "condensed" in result.lower() or result.count("filler paragraph") < 20
+
 
 # ── Prompt bundle integration ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- add a deterministic context compaction module for long-lived prompt surfaces
- compact playbook, trajectory, lessons, analysis, experiment log, protocol, and session reports before budget trimming
- add focused tests for compaction behavior and prompt-bundle integration

## Testing
- uv run pytest tests/test_knowledge_compaction.py tests/test_build_prompt_bundle_semantic_compaction.py tests/test_context_budget.py tests/test_notebook_wiring.py tests/test_score_trajectory.py tests/test_session_reports.py
- uv run ruff check src/autocontext/knowledge/compaction.py src/autocontext/prompts/templates.py tests/test_knowledge_compaction.py tests/test_build_prompt_bundle_semantic_compaction.py
- uv run mypy src