### PR TITLE
AC-592: cluster investigation evidence before hypothesis generation

### DIFF
--- a/autocontext/src/autocontext/investigation/engine.py
+++ b/autocontext/src/autocontext/investigation/engine.py
@@ -199,7 +199,6 @@ def _build_hypothesis_prompt(
     )
     user_prompt = (
         f"Investigation: {description}\n"
-        f"Diagnosis target: {diagnosis_target}\n"
         f"{evidence}\n"
         f"Steps taken: {execution.steps_executed}\n"
         f"Maximum hypotheses: {max_hypotheses or 5}"
@@ -384,11 +383,11 @@ def _build_clustered_evidence_summary(
     red = _cluster_by_source(red_herrings[:3])
 
     lines = ["Evidence clusters:"]
-    lines.extend(_render_clusters("Core signals", core))
+    lines.extend(_render_clusters("Core signals", core, diagnosis_target=diagnosis_target))
     if supporting:
-        lines.extend(_render_clusters("Supporting context", supporting))
+        lines.extend(_render_clusters("Supporting context", supporting, diagnosis_target=diagnosis_target))
     if red:
-        lines.extend(_render_clusters("Potential red herrings", red))
+        lines.extend(_render_clusters("Potential red herrings", red, diagnosis_target=diagnosis_target))
     return "\n".join(lines)
 
 
@@ -414,12 +413,20 @@ def _cluster_by_source(items: list[EvidenceItem]) -> list[tuple[str, list[Eviden
     return list(clusters.items())
 
 
-def _render_clusters(title: str, clusters: list[tuple[str, list[EvidenceItem]]]) -> list[str]:
+def _render_clusters(
+    title: str,
+    clusters: list[tuple[str, list[EvidenceItem]]],
+    *,
+    diagnosis_target: str,
+) -> list[str]:
     if not clusters:
         return []
     lines = [f"{title}:"]
     for source, items in clusters:
-        summaries = "; ".join(_shorten_text(item.content) for item in items[:2])
+        summaries = "; ".join(
+            _sanitize_evidence_for_prompt(item.content, diagnosis_target=diagnosis_target)
+            for item in items[:2]
+        )
         lines.append(f"- {source}: {summaries}")
     return lines
 
@@ -429,6 +436,25 @@ def _shorten_text(text: str, *, max_chars: int = 120) -> str:
     if len(normalized) <= max_chars:
         return normalized
     return normalized[: max_chars - 3].rstrip() + "..."
+
+
+def _sanitize_evidence_for_prompt(text: str, *, diagnosis_target: str) -> str:
+    summary = _shorten_text(text)
+    if not diagnosis_target:
+        return summary
+
+    lowered = summary.lower()
+    target_lower = diagnosis_target.lower().strip()
+    if not target_lower:
+        return summary
+
+    if "diagnosis target" in lowered:
+        return "Corroborating signal consistent with the observed failure mode"
+
+    if target_lower in lowered:
+        return _shorten_text(re.sub(re.escape(diagnosis_target), "the suspected root cause", summary, flags=re.IGNORECASE))
+
+    return summary
 
 
 def _parse_hypotheses(

--- a/autocontext/src/autocontext/investigation/engine.py
+++ b/autocontext/src/autocontext/investigation/engine.py
@@ -178,6 +178,7 @@ def _build_hypothesis_prompt(
     *,
     description: str,
     execution: _ExecutedInvestigation,
+    diagnosis_target: str,
     max_hypotheses: int | None,
 ) -> tuple[str, str]:
     system_prompt = (
@@ -191,10 +192,15 @@ def _build_hypothesis_prompt(
         "}\n"
         "Output ONLY the JSON object."
     )
-    evidence = ", ".join(item.content for item in execution.collected_evidence) or "none yet"
+    evidence = _build_clustered_evidence_summary(
+        execution.collected_evidence,
+        description=description,
+        diagnosis_target=diagnosis_target,
+    )
     user_prompt = (
         f"Investigation: {description}\n"
-        f"Evidence collected: {evidence}\n"
+        f"Diagnosis target: {diagnosis_target}\n"
+        f"{evidence}\n"
         f"Steps taken: {execution.steps_executed}\n"
         f"Maximum hypotheses: {max_hypotheses or 5}"
     )
@@ -354,6 +360,75 @@ def _build_evidence(execution: _ExecutedInvestigation) -> list[InvestigationEvid
         )
         for item in execution.collected_evidence
     ]
+
+
+def _build_clustered_evidence_summary(
+    evidence_items: list[EvidenceItem],
+    *,
+    description: str,
+    diagnosis_target: str,
+) -> str:
+    if not evidence_items:
+        return "Evidence clusters:\n- No evidence collected yet"
+
+    ranked = sorted(
+        evidence_items,
+        key=lambda item: _evidence_priority(item, description=description, diagnosis_target=diagnosis_target),
+        reverse=True,
+    )
+    relevant = [item for item in ranked if not item.is_red_herring]
+    red_herrings = [item for item in ranked if item.is_red_herring]
+
+    core = _cluster_by_source(relevant[:4])
+    supporting = _cluster_by_source(relevant[4:8])
+    red = _cluster_by_source(red_herrings[:3])
+
+    lines = ["Evidence clusters:"]
+    lines.extend(_render_clusters("Core signals", core))
+    if supporting:
+        lines.extend(_render_clusters("Supporting context", supporting))
+    if red:
+        lines.extend(_render_clusters("Potential red herrings", red))
+    return "\n".join(lines)
+
+
+def _evidence_priority(
+    item: EvidenceItem,
+    *,
+    description: str,
+    diagnosis_target: str,
+) -> float:
+    similarity = max(
+        _similarity_score(item.content, description),
+        _similarity_score(item.content, diagnosis_target),
+    )
+    relevance = float(item.relevance) if isinstance(item.relevance, (int, float)) else 0.0
+    red_herring_penalty = 0.35 if item.is_red_herring else 0.0
+    return relevance + similarity - red_herring_penalty
+
+
+def _cluster_by_source(items: list[EvidenceItem]) -> list[tuple[str, list[EvidenceItem]]]:
+    clusters: dict[str, list[EvidenceItem]] = {}
+    for item in items:
+        clusters.setdefault(item.source, []).append(item)
+    return list(clusters.items())
+
+
+def _render_clusters(title: str, clusters: list[tuple[str, list[EvidenceItem]]]) -> list[str]:
+    if not clusters:
+        return []
+    lines = [f"{title}:"]
+    for source, items in clusters:
+        summaries = "; ".join(_shorten_text(item.content) for item in items[:2])
+        lines.append(f"- {source}: {summaries}")
+    return lines
+
+
+def _shorten_text(text: str, *, max_chars: int = 120) -> str:
+    normalized = re.sub(r"\s+", " ", text.strip())
+    if len(normalized) <= max_chars:
+        return normalized
+    return normalized[: max_chars - 3].rstrip() + "..."
 
 
 def _parse_hypotheses(
@@ -567,6 +642,7 @@ class InvestigationEngine:
             hypothesis_system, hypothesis_user = _build_hypothesis_prompt(
                 description=request.description,
                 execution=execution,
+                diagnosis_target=spec.diagnosis_target,
                 max_hypotheses=request.max_hypotheses,
             )
             question, raw_hypotheses = _parse_hypotheses(

--- a/autocontext/tests/test_investigation_engine.py
+++ b/autocontext/tests/test_investigation_engine.py
@@ -229,3 +229,5 @@ class TestInvestigationEngine:
         prompt = captured_user_prompts[0]
         assert "Evidence clusters" in prompt
         assert "Potential red herrings" in prompt
+        assert "Diagnosis target:" not in prompt
+        assert "A config regression in the checkout service" not in prompt

--- a/autocontext/tests/test_investigation_engine.py
+++ b/autocontext/tests/test_investigation_engine.py
@@ -206,3 +206,26 @@ class TestInvestigationEngine:
 
         assert result.status == "failed"
         assert "valid JSON" in (result.error or "")
+
+    def test_hypothesis_prompt_uses_clustered_evidence_summary(self, tmp_path: Path) -> None:
+        from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
+
+        captured_user_prompts: list[str] = []
+
+        def analysis_llm(_system: str, user: str) -> str:
+            captured_user_prompts.append(user)
+            return _hypothesis_response()
+
+        engine = InvestigationEngine(
+            spec_llm_fn=lambda *_: _spec_response(),
+            analysis_llm_fn=analysis_llm,
+            knowledge_root=tmp_path,
+        )
+
+        result = engine.run(InvestigationRequest(description="Investigate checkout errors"))
+
+        assert result.status == "completed"
+        assert captured_user_prompts
+        prompt = captured_user_prompts[0]
+        assert "Evidence clusters" in prompt
+        assert "Potential red herrings" in prompt


### PR DESCRIPTION
## Summary
- replace flat evidence-string hypothesis prompting with clustered evidence summaries
- separate core signals, supporting context, and potential red herrings before hypothesis generation
- add targeted investigation-engine coverage for the new prompt shape

## Testing
- uv run pytest tests/test_investigation_engine.py tests/test_investigation_workflow.py tests/test_investigation_actions_coerce.py
- uv run ruff check src/autocontext/investigation/engine.py tests/test_investigation_engine.py
- uv run mypy src