### PR TITLE
AC-591: cache evidence workspaces and render role-specific evidence cards

### DIFF
--- a/autocontext/src/autocontext/evidence/manifest.py
+++ b/autocontext/src/autocontext/evidence/manifest.py
@@ -8,14 +8,15 @@ from pathlib import Path
 from autocontext.evidence.workspace import EvidenceArtifact, EvidenceWorkspace
 
 
-def render_evidence_manifest(workspace: EvidenceWorkspace) -> str:
+def render_evidence_manifest(workspace: EvidenceWorkspace, *, role: str = "default") -> str:
     """Render a compact prompt section describing available evidence."""
     n = len(workspace.artifacts)
     runs = len(workspace.source_runs)
     size_mb = round(workspace.total_size_bytes / (1024 * 1024), 1)
+    role_suffix = f" ({role.title()})" if role != "default" else ""
 
     lines = [
-        "## Prior-Run Evidence",
+        f"## Prior-Run Evidence{role_suffix}",
         f"Available: {n} artifacts from {runs} prior run(s) ({size_mb} MB)",
     ]
 
@@ -34,6 +35,18 @@ def render_evidence_manifest(workspace: EvidenceWorkspace) -> str:
             label = kind_labels.get(kind, kind)
             lines.append(f"- {label}: {count}")
 
+    cards = _top_evidence_cards(workspace, role=role)
+    if cards:
+        lines.append("")
+        lines.append("Top evidence cards:")
+        for artifact in cards:
+            path_label = Path(artifact.path).name
+            generation_label = f"gen {artifact.generation}" if artifact.generation is not None else "gen n/a"
+            lines.append(
+                f"- {artifact.artifact_id} | {artifact.kind} | {artifact.source_run_id} | {generation_label} | {path_label}"
+            )
+            lines.append(f"  Summary: {artifact.summary}")
+
     lines.append("")
     lines.append('Reference artifacts by ID (e.g., "gate_abc123") for detailed inspection.')
 
@@ -47,6 +60,45 @@ def render_artifact_detail(artifact: EvidenceArtifact, workspace_dir: str) -> st
         return f"[Artifact {artifact.artifact_id} not found at {artifact.path}]"
     try:
         content = path.read_text(encoding="utf-8")
-        return f"## {artifact.kind}: {artifact.summary}\n\n{content}"
+        source_path = artifact.source_path or artifact.path
+        return (
+            f"## {artifact.kind}: {artifact.summary}\n\n"
+            f"Artifact ID: {artifact.artifact_id}\n"
+            f"Source run: {artifact.source_run_id}\n"
+            f"Source path: {source_path}\n\n"
+            f"{content}"
+        )
     except (OSError, UnicodeDecodeError):
         return f"[Could not read artifact {artifact.artifact_id}: binary or inaccessible]"
+
+
+def _top_evidence_cards(workspace: EvidenceWorkspace, *, role: str) -> list[EvidenceArtifact]:
+    weights_by_role: dict[str, dict[str, int]] = {
+        "analyst": {
+            "gate_decision": 5,
+            "report": 4,
+            "role_output": 3,
+            "trace": 3,
+            "log": 2,
+            "tool": 1,
+        },
+        "architect": {
+            "tool": 5,
+            "gate_decision": 4,
+            "trace": 3,
+            "role_output": 3,
+            "report": 2,
+            "log": 2,
+        },
+    }
+    weights = weights_by_role.get(role, {})
+    ranked = sorted(
+        workspace.artifacts,
+        key=lambda artifact: (
+            weights.get(artifact.kind, 2),
+            artifact.generation if artifact.generation is not None else -1,
+            artifact.size_bytes,
+        ),
+        reverse=True,
+    )
+    return ranked[:5]

--- a/autocontext/src/autocontext/evidence/materializer.py
+++ b/autocontext/src/autocontext/evidence/materializer.py
@@ -43,7 +43,6 @@ def materialize_workspace(
 ) -> EvidenceWorkspace:
     """Materialize evidence from prior runs into a flat workspace directory."""
     workspace_dir.mkdir(parents=True, exist_ok=True)
-    _cleanup_previous_workspace(workspace_dir)
 
     all_artifacts: list[EvidenceArtifact] = []
 
@@ -58,6 +57,19 @@ def materialize_workspace(
         knowledge_dir = knowledge_root / scenario_name
         if knowledge_dir.is_dir():
             all_artifacts.extend(_scan_knowledge_artifacts(knowledge_dir, scenario_name))
+
+    source_signature = _compute_source_signature(
+        artifacts=all_artifacts,
+        source_run_ids=source_run_ids,
+        budget_bytes=budget_bytes,
+        scenario_name=scenario_name,
+        scan_for_secrets=scan_for_secrets,
+    )
+    cached = _load_cached_workspace(workspace_dir, source_signature=source_signature)
+    if cached is not None:
+        return cached
+
+    _cleanup_previous_workspace(workspace_dir)
 
     # Sort by priority then recency (mtime descending)
     priority_map = {kind: i for i, kind in enumerate(ARTIFACT_PRIORITY)}
@@ -88,6 +100,8 @@ def materialize_workspace(
             summary=artifact.summary,
             size_bytes=artifact.size_bytes,
             generation=artifact.generation,
+            source_path=artifact.source_path or str(src_path),
+            source_mtime_ns=artifact.source_mtime_ns,
         )
         selected.append(workspace_artifact)
         total_size += artifact.size_bytes
@@ -102,6 +116,7 @@ def materialize_workspace(
         artifacts=selected,
         total_size_bytes=total_size,
         materialized_at=datetime.datetime.now(datetime.UTC).isoformat(),
+        source_signature=source_signature,
     )
 
     # Write manifest
@@ -109,6 +124,59 @@ def materialize_workspace(
     manifest_path.write_text(json.dumps(workspace.to_dict(), indent=2), encoding="utf-8")
 
     return workspace
+
+
+def _compute_source_signature(
+    *,
+    artifacts: list[EvidenceArtifact],
+    source_run_ids: list[str],
+    budget_bytes: int,
+    scenario_name: str | None,
+    scan_for_secrets: bool,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(str(sorted(source_run_ids)).encode())
+    digest.update(str(budget_bytes).encode())
+    digest.update(str(bool(scan_for_secrets)).encode())
+    digest.update(str(scenario_name or "").encode())
+    for artifact in sorted(artifacts, key=lambda item: (item.source_run_id, item.kind, item.path)):
+        digest.update(artifact.source_run_id.encode())
+        digest.update(artifact.kind.encode())
+        digest.update((artifact.source_path or artifact.path).encode())
+        digest.update(str(artifact.size_bytes).encode())
+        digest.update(str(artifact.source_mtime_ns or 0).encode())
+        digest.update(str(artifact.generation if artifact.generation is not None else "").encode())
+    return digest.hexdigest()
+
+
+def _load_cached_workspace(workspace_dir: Path, *, source_signature: str) -> EvidenceWorkspace | None:
+    manifest_path = workspace_dir / _MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        return None
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    if str(data.get("source_signature", "")) != source_signature:
+        return None
+    artifacts = data.get("artifacts", [])
+    if not isinstance(artifacts, list):
+        return None
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            return None
+        rel_path = artifact.get("path")
+        if not isinstance(rel_path, str):
+            return None
+        artifact_path = _resolve_workspace_path(workspace_dir, rel_path)
+        if artifact_path is None or not artifact_path.exists():
+            return None
+    try:
+        return EvidenceWorkspace.from_dict(data)
+    except (KeyError, TypeError, ValueError):
+        return None
 
 
 def _apply_secret_scan(
@@ -217,6 +285,8 @@ def _scan_run_artifacts(run_dir: Path, run_id: str) -> list[EvidenceArtifact]:
                     summary=f"{kind}: {path.name} from {run_id}",
                     size_bytes=path.stat().st_size,
                     generation=generation,
+                    source_path=str(path),
+                    source_mtime_ns=path.stat().st_mtime_ns,
                 )
             )
     except OSError:
@@ -246,6 +316,8 @@ def _scan_knowledge_artifacts(knowledge_dir: Path, scenario_name: str) -> list[E
                     summary=f"{kind}: {fname} for {scenario_name}",
                     size_bytes=fpath.stat().st_size,
                     generation=None,
+                    source_path=str(fpath),
+                    source_mtime_ns=fpath.stat().st_mtime_ns,
                 )
             )
 
@@ -263,6 +335,8 @@ def _scan_knowledge_artifacts(knowledge_dir: Path, scenario_name: str) -> list[E
                         summary=f"tool: {tpath.name} for {scenario_name}",
                         size_bytes=tpath.stat().st_size,
                         generation=None,
+                        source_path=str(tpath),
+                        source_mtime_ns=tpath.stat().st_mtime_ns,
                     )
                 )
 
@@ -281,6 +355,8 @@ def _scan_knowledge_artifacts(knowledge_dir: Path, scenario_name: str) -> list[E
                         summary=f"analysis: {apath.name} for {scenario_name}",
                         size_bytes=apath.stat().st_size,
                         generation=gen,
+                        source_path=str(apath),
+                        source_mtime_ns=apath.stat().st_mtime_ns,
                     )
                 )
 

--- a/autocontext/src/autocontext/evidence/workspace.py
+++ b/autocontext/src/autocontext/evidence/workspace.py
@@ -17,6 +17,8 @@ class EvidenceArtifact:
     summary: str  # one-line description
     size_bytes: int
     generation: int | None
+    source_path: str = ""
+    source_mtime_ns: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -27,6 +29,8 @@ class EvidenceArtifact:
             "summary": self.summary,
             "size_bytes": self.size_bytes,
             "generation": self.generation,
+            "source_path": self.source_path,
+            "source_mtime_ns": self.source_mtime_ns,
         }
 
     @classmethod
@@ -39,6 +43,8 @@ class EvidenceArtifact:
             summary=data["summary"],
             size_bytes=data["size_bytes"],
             generation=data.get("generation"),
+            source_path=str(data.get("source_path", "")),
+            source_mtime_ns=data.get("source_mtime_ns"),
         )
 
 
@@ -51,6 +57,7 @@ class EvidenceWorkspace:
     artifacts: list[EvidenceArtifact]
     total_size_bytes: int
     materialized_at: str
+    source_signature: str = ""
     accessed_artifacts: list[str] = field(default_factory=list)
 
     def get_artifact(self, artifact_id: str) -> EvidenceArtifact | None:
@@ -69,6 +76,7 @@ class EvidenceWorkspace:
             "artifacts": [a.to_dict() for a in self.artifacts],
             "total_size_bytes": self.total_size_bytes,
             "materialized_at": self.materialized_at,
+            "source_signature": self.source_signature,
             "accessed_artifacts": list(self.accessed_artifacts),
         }
 
@@ -80,5 +88,6 @@ class EvidenceWorkspace:
             artifacts=[EvidenceArtifact.from_dict(a) for a in data.get("artifacts", [])],
             total_size_bytes=data.get("total_size_bytes", 0),
             materialized_at=data["materialized_at"],
+            source_signature=str(data.get("source_signature", "")),
             accessed_artifacts=data.get("accessed_artifacts", []),
         )

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -128,8 +128,8 @@ def _evidence_source_run_ids(ctx: GenerationContext, *, artifacts: ArtifactStore
         return []
 
 
-def _materialize_evidence_manifest(ctx: GenerationContext, *, artifacts: ArtifactStore) -> str:
-    """Build the evidence workspace and render its prompt-facing manifest."""
+def _materialize_evidence_manifests(ctx: GenerationContext, *, artifacts: ArtifactStore) -> dict[str, str]:
+    """Build the evidence workspace and render role-specific prompt manifests."""
     from autocontext.evidence import materialize_workspace, render_evidence_manifest
 
     workspace = materialize_workspace(
@@ -141,7 +141,10 @@ def _materialize_evidence_manifest(ctx: GenerationContext, *, artifacts: Artifac
         scenario_name=ctx.scenario_name,
         scan_for_secrets=True,
     )
-    return render_evidence_manifest(workspace)
+    return {
+        "analyst": render_evidence_manifest(workspace, role="analyst"),
+        "architect": render_evidence_manifest(workspace, role="architect"),
+    }
 
 
 class _ClientAsProvider(LLMProvider):
@@ -365,6 +368,7 @@ def stage_knowledge_setup(
     summary_text = f"best score so far: {ctx.previous_best:.4f}"
     strategy_interface = scenario.describe_strategy_interface()
     evidence_manifest = ""
+    evidence_manifests: dict[str, str] | None = None
     notebook_contexts: dict[str, str] | None = None
     active_harness_mutations = [] if ablation else load_active_harness_mutations(artifacts, ctx.scenario_name)
     if not ablation:
@@ -397,7 +401,8 @@ def stage_knowledge_setup(
         experiment_log = f"{experiment_log}\n\n{context_policy_block}".strip() if experiment_log else context_policy_block
     if not ablation and ctx.settings.evidence_workspace_enabled:
         try:
-            evidence_manifest = _materialize_evidence_manifest(ctx, artifacts=artifacts)
+            evidence_manifests = _materialize_evidence_manifests(ctx, artifacts=artifacts)
+            evidence_manifest = evidence_manifests.get("analyst", "")
         except Exception:
             logger.warning("failed to materialize evidence workspace for %s", ctx.scenario_name, exc_info=True)
 
@@ -428,6 +433,7 @@ def stage_knowledge_setup(
         notebook_contexts=notebook_contexts,
         environment_snapshot="" if ablation else ctx.environment_snapshot,
         evidence_manifest=evidence_manifest,
+        evidence_manifests=evidence_manifests,
     )
     prompts = apply_harness_mutations_to_prompts(prompts, active_harness_mutations)
 

--- a/autocontext/src/autocontext/prompts/context_budget.py
+++ b/autocontext/src/autocontext/prompts/context_budget.py
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 _TRIM_ORDER = (
     "session_reports",
     "evidence_manifest",
+    "evidence_manifest_analyst",
+    "evidence_manifest_architect",
     "notebook_architect",
     "notebook_coach",
     "notebook_analyst",

--- a/autocontext/src/autocontext/prompts/templates.py
+++ b/autocontext/src/autocontext/prompts/templates.py
@@ -80,8 +80,12 @@ def build_prompt_bundle(
     notebook_contexts: dict[str, str] | None = None,
     environment_snapshot: str = "",
     evidence_manifest: str = "",
+    evidence_manifests: dict[str, str] | None = None,
 ) -> PromptBundle:
     _nb = dict(notebook_contexts or {})
+    _evidence = dict(evidence_manifests or {})
+    analyst_evidence_manifest = _evidence.get("analyst", evidence_manifest)
+    architect_evidence_manifest = _evidence.get("architect", evidence_manifest)
     if context_budget_tokens > 0:
         budget = ContextBudget(max_tokens=context_budget_tokens)
         budgeted = budget.apply(
@@ -103,7 +107,8 @@ def build_prompt_bundle(
                 "session_reports": session_reports,
                 "tool_usage_report": architect_tool_usage_report,
                 "environment_snapshot": environment_snapshot,
-                "evidence_manifest": evidence_manifest,
+                "evidence_manifest_analyst": analyst_evidence_manifest,
+                "evidence_manifest_architect": architect_evidence_manifest,
                 "notebook_competitor": _nb.get("competitor", ""),
                 "notebook_analyst": _nb.get("analyst", ""),
                 "notebook_coach": _nb.get("coach", ""),
@@ -127,7 +132,8 @@ def build_prompt_bundle(
         session_reports = budgeted["session_reports"]
         architect_tool_usage_report = budgeted["tool_usage_report"]
         environment_snapshot = budgeted["environment_snapshot"]
-        evidence_manifest = budgeted["evidence_manifest"]
+        analyst_evidence_manifest = budgeted["evidence_manifest_analyst"]
+        architect_evidence_manifest = budgeted["evidence_manifest_architect"]
         _nb = {
             "competitor": budgeted["notebook_competitor"],
             "analyst": budgeted["notebook_analyst"],
@@ -152,7 +158,8 @@ def build_prompt_bundle(
     session_reports_block = f"Prior session reports:\n{session_reports}\n\n" if session_reports else ""
     tool_usage_block = f"{architect_tool_usage_report.strip()}\n\n" if architect_tool_usage_report else ""
     snapshot_block = f"{environment_snapshot}\n\n" if environment_snapshot else ""
-    evidence_block = f"{evidence_manifest}\n\n" if evidence_manifest else ""
+    analyst_evidence_block = f"{analyst_evidence_manifest}\n\n" if analyst_evidence_manifest else ""
+    architect_evidence_block = f"{architect_evidence_manifest}\n\n" if architect_evidence_manifest else ""
     base_context = (
         f"Scenario rules:\n{scenario_rules}\n\n"
         f"Strategy interface:\n{strategy_interface}\n\n"
@@ -194,7 +201,7 @@ def build_prompt_bundle(
     return PromptBundle(
         competitor=base_context + hints_block + competitor_nb + competitor_constraint + competitor_task,
         analyst=base_context
-        + evidence_block
+        + analyst_evidence_block
         + analyst_feedback_block
         + analyst_attribution_block
         + analyst_nb
@@ -225,7 +232,7 @@ def build_prompt_bundle(
             "<!-- COMPETITOR_HINTS_END -->"
         ),
         architect=base_context
-        + evidence_block
+        + architect_evidence_block
         + tool_usage_block
         + architect_attribution_block
         + architect_nb

--- a/autocontext/tests/test_build_prompt_bundle_semantic_compaction.py
+++ b/autocontext/tests/test_build_prompt_bundle_semantic_compaction.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from autocontext.scenarios.base import Observation
+
+
+def test_build_prompt_bundle_accepts_role_specific_evidence_manifests() -> None:
+    from autocontext.prompts.templates import build_prompt_bundle
+
+    bundle = build_prompt_bundle(
+        scenario_rules="rules",
+        strategy_interface="interface",
+        evaluation_criteria="criteria",
+        previous_summary="summary",
+        observation=Observation(narrative="test", state={}, constraints=[]),
+        current_playbook="playbook",
+        available_tools="tools",
+        evidence_manifests={
+            "analyst": "## Prior-Run Evidence (Analyst)\nA1",
+            "architect": "## Prior-Run Evidence (Architect)\nB1",
+        },
+    )
+
+    assert "Prior-Run Evidence (Analyst)" in bundle.analyst
+    assert "Prior-Run Evidence (Architect)" in bundle.architect
+    assert "Prior-Run Evidence (Architect)" not in bundle.analyst

--- a/autocontext/tests/test_evidence_workspace.py
+++ b/autocontext/tests/test_evidence_workspace.py
@@ -236,6 +236,26 @@ class TestMaterializer:
         assert "report" in kinds  # playbook.md, dead_ends.md
         assert "tool" in kinds  # tools/validator.py
 
+    def test_reuses_cached_workspace_when_sources_are_unchanged(self, evidence_tmpdir: Path) -> None:
+        ws_dir = evidence_tmpdir / "workspace"
+        first = materialize_workspace(
+            knowledge_root=evidence_tmpdir / "knowledge",
+            runs_root=evidence_tmpdir / "runs",
+            source_run_ids=["run_001"],
+            workspace_dir=ws_dir,
+            scenario_name="test_scenario",
+        )
+
+        second = materialize_workspace(
+            knowledge_root=evidence_tmpdir / "knowledge",
+            runs_root=evidence_tmpdir / "runs",
+            source_run_ids=["run_001"],
+            workspace_dir=ws_dir,
+            scenario_name="test_scenario",
+        )
+
+        assert second.materialized_at == first.materialized_at
+
 
 # ---------------------------------------------------------------------------
 # Manifest tests
@@ -266,11 +286,30 @@ class TestManifest:
         output = render_evidence_manifest(ws)
         assert "2 prior run" in output
 
+    def test_renders_evidence_cards_with_provenance(self) -> None:
+        artifacts = [
+            _make_artifact(
+                artifact_id="gate_abc123",
+                kind="gate_decision",
+                source_run_id="run_002",
+                generation=3,
+                source_path="/tmp/source/run_002/gate_decision.json",
+                path="gate_abc123_gate_decision.json",
+            ),
+        ]
+        ws = _make_workspace(artifacts=artifacts, source_runs=["run_002"])
+        output = render_evidence_manifest(ws, role="analyst")
+        assert "Top evidence cards" in output
+        assert "gate_abc123" in output
+        assert "run_002" in output
+        assert "gen 3" in output.lower()
+
     def test_render_artifact_detail_reads_content(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             Path(tmp, "test_file.md").write_text("Hello evidence!", encoding="utf-8")
-            artifact = _make_artifact(path="test_file.md")
+            artifact = _make_artifact(path="test_file.md", source_path="/tmp/source/test_file.md")
             result = render_artifact_detail(artifact, tmp)
+            assert "Source path" in result
             assert "Hello evidence!" in result
 
     def test_render_artifact_detail_handles_missing(self) -> None:

--- a/ts/tests/integrations/openai/runtime-detector-contract-python.test.ts
+++ b/ts/tests/integrations/openai/runtime-detector-contract-python.test.ts
@@ -165,7 +165,9 @@ describe("runtime↔detector contract: Python pair", () => {
     ).toBeGreaterThan(0);
   });
 
-  test(`Python runtime exports every name emitted by the detector (${emittedNames.size} name(s))`, () => {
+  test(
+    `Python runtime exports every name emitted by the detector (${emittedNames.size} name(s))`,
+    () => {
     // Spawn Python subprocess to enumerate runtime exports — args are hardcoded, no injection risk
     const proc = spawnSync(
       "uv",
@@ -195,5 +197,7 @@ describe("runtime↔detector contract: Python pair", () => {
         `runtime missing "${name}" — detector emits it but ${RUNTIME_MODULE} does not export it`,
       ).toBe(true);
     }
-  });
+    },
+    35_000,
+  );
 });


### PR DESCRIPTION
## Summary
- add source-signature caching for evidence workspaces so unchanged materializations are reused
- extend evidence artifacts with provenance metadata and render role-specific evidence cards for analyst and architect prompts
- wire role-specific evidence manifests through stage knowledge setup and prompt assembly

## Testing
- uv run pytest tests/test_evidence_workspace.py tests/test_build_prompt_bundle_semantic_compaction.py tests/test_loop_integration_snapshot_evidence.py tests/test_generation_stages.py
- uv run ruff check src/autocontext/evidence/manifest.py src/autocontext/evidence/materializer.py src/autocontext/evidence/workspace.py src/autocontext/loop/stages.py src/autocontext/prompts/context_budget.py src/autocontext/prompts/templates.py tests/test_evidence_workspace.py tests/test_build_prompt_bundle_semantic_compaction.py
- uv run mypy src