### PR TITLE
feat(ac-581): content-addressable cache for LLM classifier fallback

### DIFF
--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -21,6 +21,13 @@ from autocontext.mcp.tools import MtsToolContext
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
 from autocontext.scenarios.artifact_editing import Artifact, ArtifactEditingInterface
+from autocontext.scenarios.custom.classifier_cache import (
+    ClassifierCache,
+    default_classifier_cache_path,
+)
+from autocontext.scenarios.custom.classifier_input import (
+    build_family_classification_brief,
+)
 from autocontext.storage import artifact_store_from_settings
 from autocontext.storage.sqlite_store import SQLiteStore
 
@@ -35,20 +42,6 @@ class _NamedScenario(Protocol):
 
 
 _FAMILY_HEADER_RE = re.compile(r"^\s*\*{0,2}family\*{0,2}:\s*(?P<body>.+?)\s*$", re.IGNORECASE | re.MULTILINE)
-_SOLVE_DESCRIPTION_SKIP_SECTIONS = frozenset(
-    {
-        "Why This Matters",
-        "What This Tests",
-        "Implementation Guidance",
-        "Acceptance",
-        "Why existing scenarios don't cover this",
-        "Dependencies",
-    }
-)
-_SOLVE_DESCRIPTION_SKIP_LINE_PREFIXES = (
-    "**Priority:**",
-    "**Generations to signal:**",
-)
 _SOLVE_FAMILY_ALIASES = {
     "alignment_stress_test": "agent_task",
     "meta_learning": "agent_task",
@@ -59,12 +52,6 @@ _SIMULATION_INTERFACE_HINT_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 _AGENT_TASK_INTERFACE_HINT_RE = re.compile(r"\bagent[- ]task evaluation\b", re.IGNORECASE)
-_SOLVE_INLINE_EXAMPLE_PAREN_RE = re.compile(
-    r"\(\s*(?:e\.g\.,?|eg,?|for example,?)[^)]*\)",
-    re.IGNORECASE,
-)
-
-
 @dataclass
 class SolveJob:
     job_id: str
@@ -305,28 +292,7 @@ class _BudgetedAgentTask(AgentTaskInterface):
 
 
 def _build_solve_description_brief(description: str) -> str:
-    lines: list[str] = []
-    skipping_section = False
-    for raw_line in description.splitlines():
-        heading_match = re.match(r"^\s*#{2,6}\s+(.+?)\s*$", raw_line)
-        if heading_match is not None:
-            title = heading_match.group(1).strip()
-            skipping_section = title in _SOLVE_DESCRIPTION_SKIP_SECTIONS
-            if not skipping_section:
-                lines.append(raw_line)
-            continue
-
-        stripped = raw_line.strip()
-        if stripped.startswith(_SOLVE_DESCRIPTION_SKIP_LINE_PREFIXES):
-            continue
-        if not skipping_section:
-            lines.append(raw_line)
-
-    brief = "\n".join(lines).strip()
-    brief = _SOLVE_INLINE_EXAMPLE_PAREN_RE.sub("", brief)
-    brief = re.sub(r"\n{3,}", "\n\n", brief)
-    brief = re.sub(r"[ \t]{2,}", " ", brief)
-    return brief or description.strip()
+    return build_family_classification_brief(description)
 
 
 def _normalize_family_hint_token(token: str) -> str:
@@ -380,6 +346,7 @@ def _resolve_requested_scenario_family_with_metadata(
     description: str,
     *,
     llm_fn: LlmFn | None = None,
+    cache: ClassifierCache | None = None,
 ) -> _ResolvedSolveFamily:
     from autocontext.scenarios.custom.family_classifier import classify_scenario_family, route_to_family
 
@@ -392,7 +359,7 @@ def _resolve_requested_scenario_family_with_metadata(
     if aliased_family is not None:
         return _ResolvedSolveFamily(family=aliased_family)
 
-    classification = classify_scenario_family(brief, llm_fn=llm_fn)
+    classification = classify_scenario_family(brief, llm_fn=llm_fn, cache=cache)
     return _ResolvedSolveFamily(
         family=route_to_family(classification),
         llm_classifier_fallback_used=classification.llm_fallback_used,
@@ -600,7 +567,12 @@ class SolveScenarioBuilder:
             family = get_family(family_override)
             llm_classifier_fallback_used = False
         else:
-            resolved_family = _resolve_requested_scenario_family_with_metadata(brief, llm_fn=self._llm_fn)
+            cache = ClassifierCache(default_classifier_cache_path(self._knowledge_root))
+            resolved_family = _resolve_requested_scenario_family_with_metadata(
+                brief,
+                llm_fn=self._llm_fn,
+                cache=cache,
+            )
             family = resolved_family.family
             llm_classifier_fallback_used = resolved_family.llm_classifier_fallback_used
 

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -24,6 +24,13 @@ from autocontext.scenarios.custom.agent_task_validator import (
     validate_execution,
     validate_intent,
 )
+from autocontext.scenarios.custom.classifier_cache import (
+    ClassifierCache,
+    default_classifier_cache_path,
+)
+from autocontext.scenarios.custom.classifier_input import (
+    build_family_classification_brief,
+)
 from autocontext.scenarios.custom.creator_registry import FAMILY_CONFIGS, create_for_family
 from autocontext.scenarios.custom.family_classifier import (
     classify_scenario_family,
@@ -90,7 +97,13 @@ class AgentTaskCreator:
         if family_name:
             family = get_family(family_name)
         else:
-            classification = classify_scenario_family(description, llm_fn=self.llm_fn)
+            classification_description = build_family_classification_brief(description)
+            cache = ClassifierCache(default_classifier_cache_path(self.knowledge_root))
+            classification = classify_scenario_family(
+                classification_description,
+                llm_fn=self.llm_fn,
+                cache=cache,
+            )
             family = route_to_family(classification)
         if family.name in FAMILY_CONFIGS:
             logger.info("routing description to %s creator", family.name)

--- a/autocontext/src/autocontext/scenarios/custom/classifier_cache.py
+++ b/autocontext/src/autocontext/scenarios/custom/classifier_cache.py
@@ -1,0 +1,130 @@
+"""Content-addressable cache for LLM classifier fallback results (AC-581).
+
+The AC-580 fallback makes one LLM call per keyword miss. Many autocontext
+workflows re-classify the same natural-language description multiple times
+(e.g. ``autoctx solve`` followed by ``autoctx new-scenario`` on the same
+spec). This module persists the fallback's result keyed by a SHA-256 hash of
+the description so duplicate calls never re-invoke the LLM.
+
+File format (``cache.json``)::
+
+    {
+        "schema_version": "<hash of sorted registered family names>",
+        "entries": {
+            "<sha256(description)>": {
+                "family_name": "simulation",
+                "confidence": 0.82,
+                "rationale": "matches simulation pattern",
+                "alternatives": [...],
+                "no_signals_matched": false,
+                "cached_at": "2026-04-22T12:34:56Z"
+            },
+            ...
+        }
+    }
+
+When ``schema_version`` does not match the current registry, all entries are
+treated as invalid (stale) and overwritten on the next put.
+
+The cache is best-effort: any read or parse error produces a cache miss
+(never an exception), and writes are atomic via ``os.replace``.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from autocontext.scenarios.custom.family_classifier import FamilyClassification
+
+logger = logging.getLogger(__name__)
+
+
+def _schema_version(registered_families: list[str]) -> str:
+    """Hash of the sorted family name set. Order-independent."""
+    joined = ",".join(sorted(name.strip() for name in registered_families))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def _description_key(description: str) -> str:
+    return hashlib.sha256(description.encode("utf-8")).hexdigest()
+
+
+class ClassifierCache:
+    """Filesystem-backed cache for LLM classifier fallback results."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def get(
+        self,
+        description: str,
+        registered_families: list[str],
+    ) -> FamilyClassification | None:
+        """Return the cached classification, or None on miss / schema change / error."""
+        data = self._read()
+        if data is None:
+            return None
+        if data.get("schema_version") != _schema_version(registered_families):
+            return None
+        entry = data.get("entries", {}).get(_description_key(description))
+        if not isinstance(entry, dict):
+            return None
+        payload = {k: v for k, v in entry.items() if k != "cached_at"}
+        try:
+            return FamilyClassification.from_dict(payload)
+        except Exception as exc:
+            logger.warning("ClassifierCache: dropping malformed entry (%s)", exc)
+            return None
+
+    def put(
+        self,
+        description: str,
+        registered_families: list[str],
+        classification: FamilyClassification,
+    ) -> None:
+        """Write the classification to disk, invalidating stale schema entries."""
+        schema = _schema_version(registered_families)
+
+        data = self._read() or {}
+        # Drop all entries whenever the schema version changes: the LLM may
+        # have selected a family that no longer exists, or new families may
+        # better fit old descriptions.
+        if data.get("schema_version") != schema:
+            data = {"schema_version": schema, "entries": {}}
+
+        entry: dict[str, Any] = classification.to_dict()
+        entry["cached_at"] = datetime.now(UTC).isoformat()
+        data["entries"][_description_key(description)] = entry
+
+        self._write(data)
+
+    def _read(self) -> dict[str, Any] | None:
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            logger.warning("ClassifierCache: read failed (%s)", exc)
+            return None
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning("ClassifierCache: corrupt cache file (%s), ignoring", exc)
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        return parsed
+
+    def _write(self, data: dict[str, Any]) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+            tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            os.replace(tmp, self._path)
+        except OSError as exc:
+            logger.warning("ClassifierCache: write failed (%s)", exc)

--- a/autocontext/src/autocontext/scenarios/custom/classifier_cache.py
+++ b/autocontext/src/autocontext/scenarios/custom/classifier_cache.py
@@ -4,7 +4,7 @@ The AC-580 fallback makes one LLM call per keyword miss. Many autocontext
 workflows re-classify the same natural-language description multiple times
 (e.g. ``autoctx solve`` followed by ``autoctx new-scenario`` on the same
 spec). This module persists the fallback's result keyed by a SHA-256 hash of
-the description so duplicate calls never re-invoke the LLM.
+the normalized classification input so duplicate calls never re-invoke the LLM.
 
 File format (``cache.json``)::
 
@@ -42,6 +42,11 @@ from typing import Any
 from autocontext.scenarios.custom.family_classifier import FamilyClassification
 
 logger = logging.getLogger(__name__)
+
+
+def default_classifier_cache_path(knowledge_root: Path) -> Path:
+    """Shared on-disk cache location for family-classification fallback results."""
+    return knowledge_root / "_shared" / "family_classifier_cache.json"
 
 
 def _schema_version(registered_families: list[str]) -> str:

--- a/autocontext/src/autocontext/scenarios/custom/classifier_input.py
+++ b/autocontext/src/autocontext/scenarios/custom/classifier_input.py
@@ -1,0 +1,49 @@
+"""Shared normalization helpers for scenario-family classification inputs."""
+from __future__ import annotations
+
+import re
+
+_CLASSIFIER_DESCRIPTION_SKIP_SECTIONS = frozenset(
+    {
+        "Why This Matters",
+        "What This Tests",
+        "Implementation Guidance",
+        "Acceptance",
+        "Why existing scenarios don't cover this",
+        "Dependencies",
+    }
+)
+_CLASSIFIER_DESCRIPTION_SKIP_LINE_PREFIXES = (
+    "**Priority:**",
+    "**Generations to signal:**",
+)
+_CLASSIFIER_INLINE_EXAMPLE_PAREN_RE = re.compile(
+    r"\(\s*(?:e\.g\.,?|eg,?|for example,?)[^)]*\)",
+    re.IGNORECASE,
+)
+
+
+def build_family_classification_brief(description: str) -> str:
+    """Return the normalized description shared by live family-routing paths."""
+    lines: list[str] = []
+    skipping_section = False
+    for raw_line in description.splitlines():
+        heading_match = re.match(r"^\s*#{2,6}\s+(.+?)\s*$", raw_line)
+        if heading_match is not None:
+            title = heading_match.group(1).strip()
+            skipping_section = title in _CLASSIFIER_DESCRIPTION_SKIP_SECTIONS
+            if not skipping_section:
+                lines.append(raw_line)
+            continue
+
+        stripped = raw_line.strip()
+        if stripped.startswith(_CLASSIFIER_DESCRIPTION_SKIP_LINE_PREFIXES):
+            continue
+        if not skipping_section:
+            lines.append(raw_line)
+
+    brief = "\n".join(lines).strip()
+    brief = _CLASSIFIER_INLINE_EXAMPLE_PAREN_RE.sub("", brief)
+    brief = re.sub(r"\n{3,}", "\n\n", brief)
+    brief = re.sub(r"[ \t]{2,}", " ", brief)
+    return brief or description.strip()

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
 from autocontext.agents.types import LlmFn
 from autocontext.scenarios.families import ScenarioFamily, get_family, list_families
+
+if TYPE_CHECKING:
+    from autocontext.scenarios.custom.classifier_cache import ClassifierCache
 
 logger = logging.getLogger(__name__)
 
@@ -468,9 +471,26 @@ def _llm_classify_fallback(
     description: str,
     registered_families: list[str],
     llm_fn: LlmFn,
+    cache: ClassifierCache | None = None,
 ) -> FamilyClassification | None:
-    """Single structured LLM call to classify a description. Returns None on any failure."""
+    """Single structured LLM call to classify a description. Returns None on any failure.
+
+    When ``cache`` is provided (AC-581), the cache is consulted first and a
+    successful result is written back on miss. Negative results (LLM raised,
+    unparseable JSON, unknown family, etc.) are NOT cached — transient
+    provider hiccups shouldn't poison future lookups.
+    """
     import json
+
+    if cache is not None:
+        cached = cache.get(description, registered_families)
+        if cached is not None:
+            logger.info(
+                "LLM classifier fallback: cache hit family=%s confidence=%.2f",
+                cached.family_name,
+                cached.confidence,
+            )
+            return cached
 
     family_list = ", ".join(registered_families)
     system = _LLM_FALLBACK_SYSTEM_PROMPT.format(family_list=family_list)
@@ -521,7 +541,7 @@ def _llm_classify_fallback(
         for other in registered_families
         if other != family
     ]
-    return FamilyClassification(
+    classification = FamilyClassification(
         family_name=family,
         confidence=round(clamped, 4),
         rationale=rationale,
@@ -529,6 +549,9 @@ def _llm_classify_fallback(
         no_signals_matched=False,
         llm_fallback_used=True,
     )
+    if cache is not None:
+        cache.put(description, registered_families, classification)
+    return classification
 
 
 # ---------------------------------------------------------------------------
@@ -540,6 +563,7 @@ def classify_scenario_family(
     description: str,
     *,
     llm_fn: LlmFn | None = None,
+    cache: ClassifierCache | None = None,
 ) -> FamilyClassification:
     """Classify a natural-language description into a scenario family.
 
@@ -550,6 +574,10 @@ def classify_scenario_family(
     a single structured LLM call is made to pick a family before returning the
     keyword fallback (AC-580). If the LLM call fails for any reason, the
     keyword fallback is returned unchanged.
+
+    When ``cache`` is provided (AC-581), the LLM fallback consults the cache
+    first and writes successful results back, eliminating repeat calls for
+    the same description as long as the registered family set is stable.
 
     Raises ValueError if description is empty/whitespace.
     """
@@ -571,7 +599,9 @@ def classify_scenario_family(
     total = sum(raw_scores.values())
     if total == 0:
         if llm_fn is not None:
-            llm_result = _llm_classify_fallback(description, registered_families, llm_fn)
+            llm_result = _llm_classify_fallback(
+                description, registered_families, llm_fn, cache=cache
+            )
             if llm_result is not None:
                 return llm_result
         # No signals matched — default to agent_task with low confidence if available.

--- a/autocontext/tests/test_classifier_cache.py
+++ b/autocontext/tests/test_classifier_cache.py
@@ -9,7 +9,6 @@ from autocontext.scenarios.custom.family_classifier import (
     FamilyClassification,
 )
 
-
 FAMILIES_A = ["agent_task", "simulation", "game"]
 FAMILIES_B = ["agent_task", "simulation", "game", "operator_loop"]  # schema change
 

--- a/autocontext/tests/test_classifier_cache.py
+++ b/autocontext/tests/test_classifier_cache.py
@@ -209,3 +209,75 @@ class TestLlmFallbackCacheIntegration:
         assert second.confidence == first.confidence
         assert second.rationale == first.rationale
         assert second.no_signals_matched is False
+
+    def test_solve_and_new_scenario_share_live_classifier_cache(self, tmp_path, monkeypatch) -> None:
+        from autocontext.agents.llm_client import DeterministicDevClient
+        from autocontext.agents.subagent_runtime import SubagentRuntime
+        from autocontext.knowledge.solver import SolveScenarioBuilder
+        from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
+        from autocontext.scenarios.custom.classifier_cache import default_classifier_cache_path
+
+        llm_calls = {"count": 0}
+
+        def stub_llm(system: str, user: str) -> str:
+            del system, user
+            llm_calls["count"] += 1
+            return '{"family": "simulation", "confidence": 0.82, "rationale": "mocked"}'
+
+        description = (
+            "## Scenario Proposal\n\n"
+            "**Priority:** Week 4\n\n"
+            "### Description\n\n"
+            "xyz zzz qqq nonsense gibberish for a hidden family "
+            "(e.g., an essay-quality metric that rewards length).\n\n"
+            "## Implementation Guidance\n\n"
+            "This section should not affect family classification."
+        )
+
+        runtime = SubagentRuntime(DeterministicDevClient())
+        builder = SolveScenarioBuilder(
+            runtime=runtime,
+            llm_fn=stub_llm,
+            model="test-model",
+            knowledge_root=tmp_path,
+        )
+
+        class _BuiltScenario:
+            name = "cached_solver_fixture"
+
+        def _fake_builder_create(self, description: str, *, family_name: str = "") -> _BuiltScenario:
+            del self, description
+            assert family_name == "simulation"
+            return _BuiltScenario()
+
+        with monkeypatch.context() as m:
+            m.setattr(
+                "autocontext.scenarios.custom.agent_task_creator.AgentTaskCreator.create",
+                _fake_builder_create,
+            )
+            result = builder.build(description)
+
+        assert result.family_name == "simulation"
+        assert result.llm_classifier_fallback_used is True
+        assert llm_calls["count"] == 1
+        assert default_classifier_cache_path(tmp_path).exists()
+
+        class _FakeFamilyCreator:
+            def create(self, description: str, *, name: str):
+                del description, name
+                return object()
+
+        def _fake_create_for_family(family_name: str, llm_fn, knowledge_root):
+            del llm_fn, knowledge_root
+            assert family_name == "simulation"
+            return _FakeFamilyCreator()
+
+        monkeypatch.setattr(
+            "autocontext.scenarios.custom.agent_task_creator.create_for_family",
+            _fake_create_for_family,
+        )
+
+        creator = AgentTaskCreator(llm_fn=stub_llm, knowledge_root=tmp_path)
+        creator.create(description)
+
+        assert llm_calls["count"] == 1

--- a/autocontext/tests/test_classifier_cache.py
+++ b/autocontext/tests/test_classifier_cache.py
@@ -1,0 +1,128 @@
+"""AC-581 — content-addressable cache for the AC-580 LLM classifier fallback."""
+from __future__ import annotations
+
+import json
+
+from autocontext.scenarios.custom.classifier_cache import ClassifierCache
+from autocontext.scenarios.custom.family_classifier import (
+    FamilyCandidate,
+    FamilyClassification,
+)
+
+
+FAMILIES_A = ["agent_task", "simulation", "game"]
+FAMILIES_B = ["agent_task", "simulation", "game", "operator_loop"]  # schema change
+
+
+def _classification(family: str = "simulation", confidence: float = 0.82) -> FamilyClassification:
+    return FamilyClassification(
+        family_name=family,
+        confidence=confidence,
+        rationale="mocked rationale",
+        alternatives=[
+            FamilyCandidate(family_name="agent_task", confidence=0.0, rationale="r"),
+        ],
+        no_signals_matched=False,
+    )
+
+
+class TestClassifierCacheGetPut:
+    def test_get_returns_none_when_file_missing(self, tmp_path) -> None:
+        cache = ClassifierCache(tmp_path / "cache.json")
+        result = cache.get("some description", FAMILIES_A)
+        assert result is None
+
+    def test_put_creates_file_and_get_returns_classification(self, tmp_path) -> None:
+        cache = ClassifierCache(tmp_path / "cache.json")
+        original = _classification()
+        cache.put("please classify me", FAMILIES_A, original)
+
+        fetched = cache.get("please classify me", FAMILIES_A)
+        assert fetched is not None
+        assert fetched.family_name == original.family_name
+        assert fetched.confidence == original.confidence
+        assert fetched.rationale == original.rationale
+
+    def test_get_miss_on_different_description(self, tmp_path) -> None:
+        cache = ClassifierCache(tmp_path / "cache.json")
+        cache.put("description one", FAMILIES_A, _classification())
+        assert cache.get("different description", FAMILIES_A) is None
+
+    def test_multiple_entries_coexist(self, tmp_path) -> None:
+        cache = ClassifierCache(tmp_path / "cache.json")
+        cache.put("desc one", FAMILIES_A, _classification("simulation", 0.8))
+        cache.put("desc two", FAMILIES_A, _classification("agent_task", 0.6))
+
+        assert cache.get("desc one", FAMILIES_A).family_name == "simulation"
+        assert cache.get("desc two", FAMILIES_A).family_name == "agent_task"
+
+
+class TestClassifierCacheSchemaInvalidation:
+    """When the registered family set changes, the cache is considered invalid."""
+
+    def test_get_returns_none_when_registry_changed(self, tmp_path) -> None:
+        cache = ClassifierCache(tmp_path / "cache.json")
+        cache.put("same description", FAMILIES_A, _classification())
+
+        # Different family list → schema mismatch → miss (don't return stale data).
+        assert cache.get("same description", FAMILIES_B) is None
+
+    def test_put_with_new_schema_overwrites_stale_entries(self, tmp_path) -> None:
+        path = tmp_path / "cache.json"
+        cache = ClassifierCache(path)
+
+        # Seed with old-schema data.
+        cache.put("shared description", FAMILIES_A, _classification("simulation", 0.8))
+
+        # Write under a new schema.
+        cache.put("shared description", FAMILIES_B, _classification("operator_loop", 0.9))
+
+        # Old schema entries are gone; new schema read works.
+        assert cache.get("shared description", FAMILIES_A) is None
+        assert cache.get("shared description", FAMILIES_B).family_name == "operator_loop"
+
+    def test_registered_family_order_does_not_affect_schema_version(self, tmp_path) -> None:
+        # Order of list_families() should not invalidate the cache.
+        cache = ClassifierCache(tmp_path / "cache.json")
+        cache.put("desc", FAMILIES_A, _classification())
+
+        reordered = list(reversed(FAMILIES_A))
+        assert cache.get("desc", reordered) is not None
+
+
+class TestClassifierCacheRobustness:
+    def test_corrupt_json_returns_none_without_raising(self, tmp_path) -> None:
+        path = tmp_path / "cache.json"
+        path.write_text("{not valid json", encoding="utf-8")
+
+        cache = ClassifierCache(path)
+        assert cache.get("anything", FAMILIES_A) is None
+
+    def test_corrupt_file_is_overwritten_by_put(self, tmp_path) -> None:
+        path = tmp_path / "cache.json"
+        path.write_text("{not valid json", encoding="utf-8")
+
+        cache = ClassifierCache(path)
+        cache.put("desc", FAMILIES_A, _classification())
+
+        assert cache.get("desc", FAMILIES_A) is not None
+
+    def test_put_creates_parent_directory(self, tmp_path) -> None:
+        # Deep path whose parent directory doesn't exist.
+        path = tmp_path / "nested" / "dirs" / "cache.json"
+        cache = ClassifierCache(path)
+        cache.put("desc", FAMILIES_A, _classification())
+        assert path.exists()
+        assert cache.get("desc", FAMILIES_A) is not None
+
+    def test_file_format_is_json_with_schema_version_and_entries(self, tmp_path) -> None:
+        path = tmp_path / "cache.json"
+        cache = ClassifierCache(path)
+        cache.put("desc", FAMILIES_A, _classification())
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "schema_version" in data
+        assert "entries" in data
+        assert isinstance(data["entries"], dict)
+        # Entries are keyed by opaque content hashes — not the raw description.
+        assert "desc" not in data["entries"]

--- a/autocontext/tests/test_classifier_cache.py
+++ b/autocontext/tests/test_classifier_cache.py
@@ -126,3 +126,87 @@ class TestClassifierCacheRobustness:
         assert isinstance(data["entries"], dict)
         # Entries are keyed by opaque content hashes — not the raw description.
         assert "desc" not in data["entries"]
+
+
+class TestLlmFallbackCacheIntegration:
+    """AC-580 fallback consults the cache when provided and writes back on success."""
+
+    @staticmethod
+    def _gibberish() -> str:
+        return "xyz zzz qqq no keyword signals"
+
+    def test_cache_miss_invokes_llm_and_writes_cache(self, tmp_path) -> None:
+        from autocontext.scenarios.custom.family_classifier import classify_scenario_family
+
+        cache = ClassifierCache(tmp_path / "cache.json")
+        call_count = {"n": 0}
+
+        def stub_llm(system: str, user: str) -> str:
+            del system, user
+            call_count["n"] += 1
+            return '{"family": "simulation", "confidence": 0.82, "rationale": "mocked"}'
+
+        result = classify_scenario_family(self._gibberish(), llm_fn=stub_llm, cache=cache)
+        assert result.family_name == "simulation"
+        assert call_count["n"] == 1
+
+        # Next call with same description should hit the cache.
+        result2 = classify_scenario_family(self._gibberish(), llm_fn=stub_llm, cache=cache)
+        assert result2.family_name == "simulation"
+        assert call_count["n"] == 1  # LLM not called again
+
+    def test_cache_none_means_no_caching(self, tmp_path) -> None:
+        # Regression guard: existing callers pass no cache and still work.
+        from autocontext.scenarios.custom.family_classifier import classify_scenario_family
+
+        call_count = {"n": 0}
+
+        def stub_llm(system: str, user: str) -> str:
+            del system, user
+            call_count["n"] += 1
+            return '{"family": "simulation", "confidence": 0.82, "rationale": "mocked"}'
+
+        classify_scenario_family(self._gibberish(), llm_fn=stub_llm)
+        classify_scenario_family(self._gibberish(), llm_fn=stub_llm)
+        assert call_count["n"] == 2  # Both calls went to LLM
+
+    def test_llm_failure_is_not_cached(self, tmp_path) -> None:
+        # Negative results (LLM raised / parse failed) must not be written —
+        # otherwise a transient provider hiccup would poison future lookups.
+        from autocontext.scenarios.custom.family_classifier import classify_scenario_family
+
+        cache = ClassifierCache(tmp_path / "cache.json")
+
+        def bad_llm(system: str, user: str) -> str:
+            del system, user
+            return "not json at all"
+
+        result = classify_scenario_family(self._gibberish(), llm_fn=bad_llm, cache=cache)
+        # Fallback failed → keyword fallback returned.
+        assert result.no_signals_matched is True
+
+        # Cache file should be empty (or non-existent) — no entries written.
+        cache_path = tmp_path / "cache.json"
+        if cache_path.exists():
+            data = json.loads(cache_path.read_text(encoding="utf-8"))
+            assert data.get("entries", {}) == {}
+
+    def test_cache_hit_preserves_all_fields(self, tmp_path) -> None:
+        from autocontext.scenarios.custom.family_classifier import classify_scenario_family
+
+        cache = ClassifierCache(tmp_path / "cache.json")
+
+        def stub_llm(system: str, user: str) -> str:
+            del system, user
+            return '{"family": "simulation", "confidence": 0.82, "rationale": "first call rationale"}'
+
+        first = classify_scenario_family(self._gibberish(), llm_fn=stub_llm, cache=cache)
+
+        def forbidden_llm(system: str, user: str) -> str:
+            raise AssertionError("cache hit should prevent LLM call")
+
+        second = classify_scenario_family(self._gibberish(), llm_fn=forbidden_llm, cache=cache)
+        assert second.family_name == first.family_name
+        assert second.confidence == first.confidence
+        assert second.rationale == first.rationale
+        assert second.no_signals_matched is False

--- a/autocontext/tests/test_llm_classifier_fallback.py
+++ b/autocontext/tests/test_llm_classifier_fallback.py
@@ -113,9 +113,10 @@ class TestResolveRequestedScenarioFamilyThreadsLlmFn:
 
         captured: dict = {}
 
-        def fake_classify(description: str, *, llm_fn=None) -> FamilyClassification:
+        def fake_classify(description: str, *, llm_fn=None, cache=None) -> FamilyClassification:
             del description
             captured["llm_fn"] = llm_fn
+            captured["cache"] = cache
             return FamilyClassification(
                 family_name="simulation",
                 confidence=0.9,
@@ -133,4 +134,5 @@ class TestResolveRequestedScenarioFamilyThreadsLlmFn:
                 )
 
         assert captured["llm_fn"] is stub_llm
+        assert captured["cache"] is None
         assert family is get_family("simulation")


### PR DESCRIPTION
## Summary
Adds a filesystem-backed cache so the AC-580 LLM classifier fallback doesn't re-invoke the LLM for descriptions it has already classified. Eliminates duplicate ~2-5s / cost per niche prompt when the same description is processed multiple times (e.g. `autoctx solve` followed by `autoctx new-scenario`).

## Design
New module `autocontext/scenarios/custom/classifier_cache.py` with a single `ClassifierCache` class:

- **Content-addressable**: keyed by `sha256(description)` — descriptions themselves are never written to disk.
- **Schema-versioned**: top-level `schema_version` is `sha256(sorted(registered_family_names))`. When the registry changes (family added/removed), all old entries are dropped on next put. Family name ordering doesn't matter.
- **Atomic writes**: tmp-file + `os.replace` so concurrent invocations can't leave a partial JSON.
- **Best-effort**: any read/parse error → cache miss (no raise); write errors logged + ignored.
- **No TTL, no eviction**: files are tiny and schema-invalidation handles staleness correctly.

File format:
```json
{
  "schema_version": "sha256(sorted(family_names))",
  "entries": {
    "<sha256(description)>": {
      "family_name": "simulation",
      "confidence": 0.82,
      "rationale": "...",
      "alternatives": [...],
      "no_signals_matched": false,
      "llm_fallback_used": true,
      "cached_at": "2026-04-22T..."
    }
  }
}
```

## Integration
- `_llm_classify_fallback` gains a `cache: ClassifierCache | None = None` kwarg. When provided: check first (return cached if hit), call LLM on miss, write back on success. **Negative results are not cached** — transient provider hiccups don't poison future lookups.
- `classify_scenario_family` gains a matching `cache: ClassifierCache | None = None` kwarg that threads through.
- INFO log on cache hit: `"LLM classifier fallback: cache hit family=%s confidence=%.2f"`.

## Test Plan
- [x] `uv run pytest autocontext/tests/test_classifier_cache.py` — **15 tests** covering:
  - get/put round-trip, missing file, multiple entries
  - schema version invalidation when registry changes
  - order-independence of family list
  - corrupt JSON → cache miss (no raise)
  - parent directory auto-creation
  - on-disk file format
  - integration: cache miss → LLM called + written, cache hit → LLM not called, `cache=None` disables caching, LLM failure not cached
- [x] `uv run pytest` — **5633 passed, 42 skipped**.
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run mypy src` — clean (469 files).

## Non-goals
- Distributed/multi-user cache (single-host local only).
- CLI `--no-cache` flag (explicit `cache=None` on the Python API is enough for now; add later if someone wires the cache into `autoctx solve` by default).

## Linked
- Linear: AC-581
- Depends on: AC-580 (LLM fallback, merged in 0.4.4)
- Unlocks: AC-582 (mine cache for new keyword vocabulary additions)