### PR TITLE
AC-596: Add on-demand evidence artifact drill-down

### DIFF
--- a/autocontext/src/autocontext/evidence/manifest.py
+++ b/autocontext/src/autocontext/evidence/manifest.py
@@ -60,8 +60,8 @@ def render_artifact_detail(
     excerpt_lines: int | None = None,
 ) -> str:
     """Read and return the content of a specific artifact."""
-    path = Path(workspace_dir) / artifact.path
-    if not path.exists():
+    path = _resolve_workspace_path(Path(workspace_dir), artifact.path)
+    if path is None or not path.exists():
         return f"[Artifact {artifact.artifact_id} not found at {artifact.path}]"
     try:
         content = path.read_text(encoding="utf-8")
@@ -77,6 +77,16 @@ def render_artifact_detail(
         )
     except (OSError, UnicodeDecodeError):
         return f"[Could not read artifact {artifact.artifact_id}: binary or inaccessible]"
+
+
+def _resolve_workspace_path(workspace_dir: Path, rel_path: str) -> Path | None:
+    """Resolve a manifest path inside the workspace and reject directory escapes."""
+    candidate = (workspace_dir / rel_path).resolve()
+    try:
+        candidate.relative_to(workspace_dir.resolve())
+    except ValueError:
+        return None
+    return candidate
 
 
 def _excerpt_content(content: str, *, excerpt_lines: int) -> str:

--- a/autocontext/src/autocontext/evidence/manifest.py
+++ b/autocontext/src/autocontext/evidence/manifest.py
@@ -53,13 +53,20 @@ def render_evidence_manifest(workspace: EvidenceWorkspace, *, role: str = "defau
     return "\n".join(lines)
 
 
-def render_artifact_detail(artifact: EvidenceArtifact, workspace_dir: str) -> str:
+def render_artifact_detail(
+    artifact: EvidenceArtifact,
+    workspace_dir: str,
+    *,
+    excerpt_lines: int | None = None,
+) -> str:
     """Read and return the content of a specific artifact."""
     path = Path(workspace_dir) / artifact.path
     if not path.exists():
         return f"[Artifact {artifact.artifact_id} not found at {artifact.path}]"
     try:
         content = path.read_text(encoding="utf-8")
+        if excerpt_lines is not None and excerpt_lines > 0:
+            content = _excerpt_content(content, excerpt_lines=excerpt_lines)
         source_path = artifact.source_path or artifact.path
         return (
             f"## {artifact.kind}: {artifact.summary}\n\n"
@@ -70,6 +77,18 @@ def render_artifact_detail(artifact: EvidenceArtifact, workspace_dir: str) -> st
         )
     except (OSError, UnicodeDecodeError):
         return f"[Could not read artifact {artifact.artifact_id}: binary or inaccessible]"
+
+
+def _excerpt_content(content: str, *, excerpt_lines: int) -> str:
+    lines = content.splitlines()
+    if len(lines) <= excerpt_lines:
+        return content
+    excerpt = "\n".join(lines[:excerpt_lines]).rstrip()
+    omitted = len(lines) - excerpt_lines
+    return (
+        f"{excerpt}\n"
+        f"[... {omitted} additional lines omitted; request full artifact for complete content ...]"
+    )
 
 
 def _top_evidence_cards(workspace: EvidenceWorkspace, *, role: str) -> list[EvidenceArtifact]:

--- a/autocontext/src/autocontext/mcp/knowledge_tools.py
+++ b/autocontext/src/autocontext/mcp/knowledge_tools.py
@@ -420,5 +420,6 @@ def _load_evidence_workspace(
     except (KeyError, TypeError, ValueError) as exc:
         return None, json.dumps({"error": f"Evidence manifest is invalid: {exc}"})
 
+    workspace.workspace_dir = str(manifest_path.parent)
     workspace.accessed_artifacts = load_access_log(workspace.workspace_dir)
     return workspace, None

--- a/autocontext/src/autocontext/mcp/knowledge_tools.py
+++ b/autocontext/src/autocontext/mcp/knowledge_tools.py
@@ -4,9 +4,17 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from autocontext.concepts import get_concept_model
+from autocontext.evidence import (
+    EvidenceWorkspace,
+    load_access_log,
+    record_access,
+    render_artifact_detail,
+    save_access_log,
+)
 from autocontext.execution.rubric_calibration import run_judge_calibration
 from autocontext.mcp._base import _OPENCLAW_VERSION, MtsToolContext
 from autocontext.scenarios import SCENARIO_REGISTRY
@@ -352,10 +360,65 @@ def get_env_snapshot(ctx: MtsToolContext, scenario_name: str) -> str:
 
 def get_evidence_list(ctx: MtsToolContext, scenario_name: str) -> str:
     """Return the evidence workspace manifest for a scenario, or a not-found message."""
-    manifest_path = ctx.settings.knowledge_root / scenario_name / "_evidence" / "manifest.json"
+    manifest_path = _evidence_manifest_path(ctx, scenario_name)
     if not manifest_path.exists():
         return json.dumps({"error": f"No evidence workspace found for scenario '{scenario_name}'"})
     try:
         return manifest_path.read_text(encoding="utf-8")
     except OSError as exc:
         return json.dumps({"error": f"Failed to read evidence manifest: {exc}"})
+
+
+def get_evidence_artifact(
+    ctx: MtsToolContext,
+    scenario_name: str,
+    artifact_id: str,
+    excerpt_lines: int = 40,
+) -> str:
+    """Return a specific evidence artifact by ID and record that it was consulted."""
+    workspace, error = _load_evidence_workspace(ctx, scenario_name)
+    if error is not None:
+        return error
+    if workspace is None:
+        return json.dumps({"error": f"No evidence workspace found for scenario '{scenario_name}'"})
+
+    artifact = workspace.get_artifact(artifact_id)
+    if artifact is None:
+        return f"[Artifact {artifact_id} not found in evidence workspace for scenario '{scenario_name}']"
+
+    record_access(workspace, artifact_id)
+    save_access_log(workspace)
+    return render_artifact_detail(
+        artifact,
+        workspace.workspace_dir,
+        excerpt_lines=excerpt_lines if excerpt_lines > 0 else None,
+    )
+
+
+def _evidence_manifest_path(ctx: MtsToolContext, scenario_name: str) -> Path:
+    return ctx.settings.knowledge_root / scenario_name / "_evidence" / "manifest.json"
+
+
+def _load_evidence_workspace(
+    ctx: MtsToolContext,
+    scenario_name: str,
+) -> tuple[EvidenceWorkspace, None] | tuple[None, str]:
+    manifest_path = _evidence_manifest_path(ctx, scenario_name)
+    if not manifest_path.exists():
+        return None, json.dumps({"error": f"No evidence workspace found for scenario '{scenario_name}'"})
+
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        return None, json.dumps({"error": f"Failed to read evidence manifest: {exc}"})
+
+    if not isinstance(data, dict):
+        return None, json.dumps({"error": "Evidence manifest is malformed"})
+
+    try:
+        workspace = EvidenceWorkspace.from_dict(data)
+    except (KeyError, TypeError, ValueError) as exc:
+        return None, json.dumps({"error": f"Evidence manifest is invalid: {exc}"})
+
+    workspace.accessed_artifacts = load_access_log(workspace.workspace_dir)
+    return workspace, None

--- a/autocontext/src/autocontext/mcp/server.py
+++ b/autocontext/src/autocontext/mcp/server.py
@@ -700,6 +700,16 @@ def autocontext_evidence_list(scenario_name: str) -> str:
     return tools.get_evidence_list(_get_ctx(), scenario_name)
 
 
+@mcp.tool()
+def autocontext_evidence_artifact(
+    scenario_name: str,
+    artifact_id: str,
+    excerpt_lines: int = 40,
+) -> str:
+    """Return a specific evidence artifact by ID, with optional excerpting."""
+    return tools.get_evidence_artifact(_get_ctx(), scenario_name, artifact_id, excerpt_lines)
+
+
 def run_server() -> None:
     """Synchronous entry point for the MCP server."""
     mcp.run(transport="stdio")

--- a/autocontext/src/autocontext/mcp/tools.py
+++ b/autocontext/src/autocontext/mcp/tools.py
@@ -43,6 +43,7 @@ from autocontext.mcp.knowledge_tools import (  # noqa: F401
     export_skill,
     get_capabilities,
     get_env_snapshot,
+    get_evidence_artifact,
     get_evidence_list,
     get_feedback,
     import_package,

--- a/autocontext/tests/test_evidence_workspace.py
+++ b/autocontext/tests/test_evidence_workspace.py
@@ -381,6 +381,19 @@ class TestManifest:
             assert "line 4" not in result
             assert "request full artifact" in result.lower()
 
+    def test_render_artifact_detail_rejects_workspace_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace_dir = Path(tmp) / "workspace"
+            workspace_dir.mkdir()
+            outside_path = Path(tmp) / "outside.txt"
+            outside_path.write_text("secret outside workspace", encoding="utf-8")
+            artifact = _make_artifact(path="../../outside.txt", source_path=str(outside_path))
+
+            result = render_artifact_detail(artifact, str(workspace_dir))
+
+            assert "secret outside workspace" not in result
+            assert "not found" in result.lower()
+
     def test_render_artifact_detail_handles_missing(self) -> None:
         artifact = _make_artifact(path="nonexistent.md")
         result = render_artifact_detail(artifact, "/tmp/does_not_exist")

--- a/autocontext/tests/test_evidence_workspace.py
+++ b/autocontext/tests/test_evidence_workspace.py
@@ -312,6 +312,19 @@ class TestManifest:
             assert "Source path" in result
             assert "Hello evidence!" in result
 
+    def test_render_artifact_detail_supports_excerpt_windows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "test_file.md").write_text(
+                "line 1\nline 2\nline 3\nline 4\nline 5\n",
+                encoding="utf-8",
+            )
+            artifact = _make_artifact(path="test_file.md", source_path="/tmp/source/test_file.md")
+            result = render_artifact_detail(artifact, tmp, excerpt_lines=3)
+            assert "line 1" in result
+            assert "line 3" in result
+            assert "line 4" not in result
+            assert "request full artifact" in result.lower()
+
     def test_render_artifact_detail_handles_missing(self) -> None:
         artifact = _make_artifact(path="nonexistent.md")
         result = render_artifact_detail(artifact, "/tmp/does_not_exist")

--- a/autocontext/tests/test_loop_integration_snapshot_evidence.py
+++ b/autocontext/tests/test_loop_integration_snapshot_evidence.py
@@ -303,3 +303,42 @@ class TestMcpTools:
             result = get_evidence_artifact(ctx, "test_scenario", "missing")
 
             assert "not found" in result.lower()
+
+    def test_evidence_artifact_tool_ignores_manifest_workspace_dir(self) -> None:
+        from autocontext.mcp.knowledge_tools import get_evidence_artifact
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            evidence_dir = root / "test_scenario" / "_evidence"
+            evidence_dir.mkdir(parents=True)
+            outside_path = root / "outside.txt"
+            outside_path.write_text("top secret", encoding="utf-8")
+            (evidence_dir / "safe.md").write_text("safe evidence", encoding="utf-8")
+            manifest = {
+                "workspace_dir": str(root),
+                "source_runs": ["run_001"],
+                "artifacts": [
+                    {
+                        "artifact_id": "escape_abc123",
+                        "source_run_id": "run_001",
+                        "kind": "report",
+                        "path": "outside.txt",
+                        "summary": "outside file",
+                        "size_bytes": 10,
+                        "generation": 1,
+                        "source_path": str(outside_path),
+                    },
+                ],
+                "total_size_bytes": 10,
+                "materialized_at": "2026-04-22T00:00:00+00:00",
+            }
+            (evidence_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            ctx = MagicMock()
+            ctx.settings.knowledge_root = root
+
+            result = get_evidence_artifact(ctx, "test_scenario", "escape_abc123")
+
+            assert "top secret" not in result
+            assert "not found" in result.lower()
+            access_log = json.loads((evidence_dir / "evidence_access_log.json").read_text(encoding="utf-8"))
+            assert access_log["accessed"] == ["escape_abc123"]

--- a/autocontext/tests/test_loop_integration_snapshot_evidence.py
+++ b/autocontext/tests/test_loop_integration_snapshot_evidence.py
@@ -238,3 +238,68 @@ class TestMcpTools:
             ctx.settings.knowledge_root = Path(tmp)
             result = get_evidence_list(ctx, "nonexistent")
             assert "not found" in result.lower() or "no evidence" in result.lower()
+
+    def test_evidence_artifact_tool_returns_excerpt_and_tracks_access(self) -> None:
+        from autocontext.mcp.knowledge_tools import get_evidence_artifact
+
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp) / "test_scenario" / "_evidence"
+            evidence_dir.mkdir(parents=True)
+            manifest = {
+                "workspace_dir": str(evidence_dir),
+                "source_runs": ["run_001"],
+                "artifacts": [
+                    {
+                        "artifact_id": "gate_abc123",
+                        "source_run_id": "run_001",
+                        "kind": "gate_decision",
+                        "path": "gate_abc123_gate_decision.json",
+                        "summary": "advance decision",
+                        "size_bytes": 64,
+                        "generation": 2,
+                        "source_path": "/tmp/source/run_001/gate_decision.json",
+                    },
+                ],
+                "total_size_bytes": 64,
+                "materialized_at": "2026-04-22T00:00:00+00:00",
+            }
+            (evidence_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            (evidence_dir / "gate_abc123_gate_decision.json").write_text(
+                '{"decision":"advance"}\n{"delta":0.08}\n{"note":"retain guard"}\n',
+                encoding="utf-8",
+            )
+            ctx = MagicMock()
+            ctx.settings.knowledge_root = Path(tmp)
+
+            result = get_evidence_artifact(ctx, "test_scenario", "gate_abc123", excerpt_lines=2)
+
+            assert "Artifact ID: gate_abc123" in result
+            assert '"decision":"advance"' in result
+            assert '"note":"retain guard"' not in result
+            access_log = json.loads((evidence_dir / "evidence_access_log.json").read_text(encoding="utf-8"))
+            assert access_log["accessed"] == ["gate_abc123"]
+
+    def test_evidence_artifact_tool_returns_not_found(self) -> None:
+        from autocontext.mcp.knowledge_tools import get_evidence_artifact
+
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp) / "test_scenario" / "_evidence"
+            evidence_dir.mkdir(parents=True)
+            (evidence_dir / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "workspace_dir": str(evidence_dir),
+                        "source_runs": [],
+                        "artifacts": [],
+                        "total_size_bytes": 0,
+                        "materialized_at": "2026-04-22T00:00:00+00:00",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            ctx = MagicMock()
+            ctx.settings.knowledge_root = Path(tmp)
+
+            result = get_evidence_artifact(ctx, "test_scenario", "missing")
+
+            assert "not found" in result.lower()

--- a/autocontext/tests/test_mcp_server.py
+++ b/autocontext/tests/test_mcp_server.py
@@ -53,3 +53,9 @@ def test_run_match_tool() -> None:
     parsed = json.loads(result)
     assert "score" in parsed
     assert isinstance(parsed["score"], float)
+
+
+def test_evidence_artifact_tool_function_exists() -> None:
+    from autocontext.mcp import server
+
+    assert hasattr(server, "autocontext_evidence_artifact")


### PR DESCRIPTION
## Summary
- add excerpt-aware artifact detail rendering for evidence workspaces
- expose a targeted evidence-artifact MCP surface that resolves artifacts by ID and records access utilization
- cover artifact drill-down behavior across evidence rendering and MCP knowledge tools

## Verification
- uv run pytest tests/test_evidence_workspace.py tests/test_loop_integration_snapshot_evidence.py tests/test_mcp_tools.py tests/test_mcp_server.py
- uv run ruff check src tests
- uv run mypy src