### PR TITLE
AC-595: Extend semantic reducers to secondary prompt surfaces

### DIFF
--- a/autocontext/src/autocontext/consultation/runner.py
+++ b/autocontext/src/autocontext/consultation/runner.py
@@ -5,6 +5,7 @@ import logging
 import re
 
 from autocontext.consultation.types import ConsultationRequest, ConsultationResult
+from autocontext.knowledge.compaction import compact_prompt_component
 from autocontext.providers.base import CompletionResult, LLMProvider
 
 logger = logging.getLogger(__name__)
@@ -32,16 +33,18 @@ class ConsultationRunner:
         )
 
     def _build_user_prompt(self, request: ConsultationRequest) -> str:
+        context_summary = compact_prompt_component("consultation_context", request.context_summary)
+        strategy_summary = compact_prompt_component("consultation_strategy", request.current_strategy_summary)
         parts = [
             f"Run: {request.run_id}, Generation: {request.generation}",
             f"Trigger: {request.trigger.value}",
-            f"Context: {request.context_summary}",
-            f"Current strategy: {request.current_strategy_summary}",
+            f"Context: {context_summary}",
+            f"Current strategy: {strategy_summary}",
         ]
         if request.score_history:
-            parts.append(f"Score history: {request.score_history}")
+            parts.append(f"Score history: {_format_score_history(request.score_history)}")
         if request.gate_history:
-            parts.append(f"Gate history: {request.gate_history}")
+            parts.append(f"Gate history: {_format_gate_history(request.gate_history)}")
         return "\n".join(parts)
 
     def _parse_response(self, completion: CompletionResult) -> ConsultationResult:
@@ -62,3 +65,19 @@ def _extract_section(text: str, heading: str) -> str:
     pattern = rf"##\s*{re.escape(heading)}\s*\n(.*?)(?=\n##\s|\Z)"
     match = re.search(pattern, text, re.DOTALL)
     return match.group(1).strip() if match else ""
+
+
+def _format_score_history(scores: list[float], *, max_items: int = 8) -> str:
+    recent = scores[-max_items:]
+    rendered = " -> ".join(f"{score:.2f}" for score in recent)
+    if len(scores) <= max_items:
+        return rendered
+    return f"{rendered} (recent {len(recent)} of {len(scores)})"
+
+
+def _format_gate_history(gates: list[str], *, max_items: int = 8) -> str:
+    recent = gates[-max_items:]
+    rendered = " -> ".join(recent)
+    if len(gates) <= max_items:
+        return rendered
+    return f"{rendered} (recent {len(recent)} of {len(gates)})"

--- a/autocontext/src/autocontext/execution/agent_task_evolution.py
+++ b/autocontext/src/autocontext/execution/agent_task_evolution.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from autocontext.knowledge.compaction import compact_prompt_component
 from autocontext.scenarios.agent_task import AgentTaskResult
 
 
@@ -92,6 +93,8 @@ def build_enriched_prompt(
     best_score: float,
 ) -> str:
     """Enrich a task prompt with cross-generation context."""
+    playbook = compact_prompt_component("agent_task_playbook", playbook)
+    best_output = compact_prompt_component("agent_task_best_output", best_output)
     sections: list[str] = [task_prompt]
 
     if playbook:

--- a/autocontext/src/autocontext/execution/policy_refinement.py
+++ b/autocontext/src/autocontext/execution/policy_refinement.py
@@ -15,6 +15,7 @@ import re
 from dataclasses import dataclass
 
 from autocontext.execution.policy_executor import PolicyExecutor, PolicyMatchResult
+from autocontext.knowledge.compaction import compact_prompt_component
 from autocontext.providers.base import LLMProvider
 from autocontext.scenarios.base import ScenarioInterface
 
@@ -84,27 +85,37 @@ def _build_refinement_prompt(
     iteration: int,
 ) -> tuple[str, str]:
     """Build (system_prompt, user_prompt) for the LLM refinement call."""
+    scenario_rules = compact_prompt_component(
+        "policy_refinement_rules",
+        scenario.describe_rules(),
+    )
+    strategy_interface = compact_prompt_component(
+        "policy_refinement_interface",
+        scenario.describe_strategy_interface(),
+    )
+    evaluation_criteria = compact_prompt_component(
+        "policy_refinement_criteria",
+        scenario.describe_evaluation_criteria(),
+    )
     system_prompt = (
         "You are a Python policy optimization expert. "
         "You write choose_action(state) -> dict functions that play game scenarios well. "
         "You must output a complete Python function definition.\n\n"
-        f"Scenario rules:\n{scenario.describe_rules()}\n\n"
-        f"Strategy interface:\n{scenario.describe_strategy_interface()}\n\n"
-        f"Evaluation criteria:\n{scenario.describe_evaluation_criteria()}"
+        f"Scenario rules:\n{scenario_rules}\n\n"
+        f"Strategy interface:\n{strategy_interface}\n\n"
+        f"Evaluation criteria:\n{evaluation_criteria}"
     )
 
-    scores_str = ", ".join(f"{r.score:.4f}" for r in match_results)
-    errors_str = ""
-    for r in match_results:
-        if r.errors:
-            errors_str += f"\nErrors: {'; '.join(r.errors)}"
-        if r.had_illegal_actions:
-            errors_str += f"\nIllegal actions: {r.illegal_action_count}"
+    scores_str = _format_score_history(match_results)
+    feedback_block = compact_prompt_component(
+        "policy_refinement_feedback",
+        _build_match_feedback(match_results),
+    )
 
     user_prompt = (
         f"Iteration {iteration}. The current policy achieved heuristic {heuristic_value:.4f}.\n"
-        f"Match scores: [{scores_str}]\n"
-        f"{errors_str}\n\n"
+        f"Match scores: {scores_str}\n\n"
+        f"{feedback_block}\n\n"
         f"Current policy:\n```python\n{current_policy}\n```\n\n"
         "Write an improved choose_action(state) -> dict function. "
         "Output ONLY the Python code in a ```python``` code block. "
@@ -113,6 +124,35 @@ def _build_refinement_prompt(
     )
 
     return system_prompt, user_prompt
+
+
+def _format_score_history(match_results: list[PolicyMatchResult], *, max_items: int = 8) -> str:
+    scores = [f"{result.score:.4f}" for result in match_results[-max_items:]]
+    rendered = "[" + ", ".join(scores) + "]"
+    if len(match_results) <= max_items:
+        return rendered
+    return f"{rendered} (recent {min(len(match_results), max_items)} of {len(match_results)})"
+
+
+def _build_match_feedback(match_results: list[PolicyMatchResult]) -> str:
+    if not match_results:
+        return "## Match Feedback\n- No match results were recorded."
+
+    sections: list[str] = []
+    for index, result in enumerate(match_results, start=1):
+        lines = [
+            f"### Match {index}",
+            f"- Score: {result.score:.4f}",
+            f"- Normalized score: {result.normalized_score:.4f}",
+            f"- Moves played: {result.moves_played}",
+        ]
+        if result.had_illegal_actions:
+            lines.append(f"- Illegal actions: {result.illegal_action_count}")
+        if result.errors:
+            lines.append(f"- Errors: {'; '.join(result.errors)}")
+        sections.append("\n".join(lines))
+
+    return "\n\n---\n\n".join(sections)
 
 
 class PolicyRefinementLoop:

--- a/autocontext/src/autocontext/knowledge/compaction.py
+++ b/autocontext/src/autocontext/knowledge/compaction.py
@@ -34,6 +34,12 @@ _DEFAULT_COMPONENT_TOKEN_LIMITS: dict[str, int] = {
     "consultation_strategy": 400,
 }
 
+_TAIL_PRESERVING_COMPONENTS = {
+    "agent_task_best_output",
+    "consultation_context",
+    "consultation_strategy",
+}
+
 _IMPORTANT_KEYWORDS = (
     "root cause",
     "finding",
@@ -121,6 +127,8 @@ def _compact_component(key: str, text: str, max_tokens: int) -> str:
         compacted = _compact_history(text, max_tokens=max_tokens)
     elif key == "trajectory":
         compacted = _compact_table(text, max_tokens=max_tokens)
+    elif key in _TAIL_PRESERVING_COMPONENTS and _looks_like_plain_prose(text):
+        compacted = _compact_plain_prose(text, max_tokens=max_tokens)
     else:
         compacted = _compact_markdown(text, max_tokens=max_tokens)
 
@@ -189,6 +197,20 @@ def _compact_table(text: str, *, max_tokens: int) -> str:
     return compacted or _truncate_text(text, max_tokens=max_tokens)
 
 
+def _compact_plain_prose(text: str, *, max_tokens: int) -> str:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return _truncate_text(text, max_tokens=max_tokens)
+
+    head = lines[:2]
+    tail = lines[-3:]
+    selected = _dedupe_lines([*head, *tail])
+    compacted = "\n".join(selected).strip()
+    if compacted and compacted != text:
+        compacted = f"{compacted}\n\n[... condensed recent context ...]"
+    return compacted or _truncate_text(text, max_tokens=max_tokens)
+
+
 def _split_sections(text: str) -> list[str]:
     if "\n\n---\n\n" in text:
         return [section.strip() for section in text.split("\n\n---\n\n") if section.strip()]
@@ -204,6 +226,19 @@ def _split_sections(text: str) -> list[str]:
     if current:
         sections.append(current)
     return ["\n".join(section).strip() for section in sections if any(line.strip() for line in section)]
+
+
+def _looks_like_plain_prose(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped:
+        return False
+    if re.search(r"^#{1,6}\s+", stripped, re.MULTILINE):
+        return False
+    if "\n\n---\n\n" in stripped:
+        return False
+    if re.search(r"^\s*(?:[-*]|\d+\.)\s+", stripped, re.MULTILINE):
+        return False
+    return True
 
 
 def _compact_section(section: str) -> str:

--- a/autocontext/src/autocontext/knowledge/compaction.py
+++ b/autocontext/src/autocontext/knowledge/compaction.py
@@ -24,6 +24,14 @@ _DEFAULT_COMPONENT_TOKEN_LIMITS: dict[str, int] = {
     "evidence_manifest": 1200,
     "evidence_manifest_analyst": 1200,
     "evidence_manifest_architect": 1200,
+    "agent_task_playbook": 600,
+    "agent_task_best_output": 900,
+    "policy_refinement_rules": 1600,
+    "policy_refinement_interface": 1000,
+    "policy_refinement_criteria": 1000,
+    "policy_refinement_feedback": 1400,
+    "consultation_context": 400,
+    "consultation_strategy": 400,
 }
 
 _IMPORTANT_KEYWORDS = (
@@ -49,15 +57,18 @@ def compact_prompt_components(components: Mapping[str, str]) -> dict[str, str]:
     """Return a compacted copy of prompt-facing context components."""
     result: dict[str, str] = {}
     for key, value in components.items():
-        if not value:
-            result[key] = value
-            continue
-        limit = _DEFAULT_COMPONENT_TOKEN_LIMITS.get(key)
-        if limit is None:
-            result[key] = value
-            continue
-        result[key] = _compact_component(key, value, limit)
+        result[key] = compact_prompt_component(key, value)
     return result
+
+
+def compact_prompt_component(key: str, value: str) -> str:
+    """Compact a single prompt-facing component when a limit is configured."""
+    if not value:
+        return value
+    limit = _DEFAULT_COMPONENT_TOKEN_LIMITS.get(key)
+    if limit is None:
+        return value
+    return _compact_component(key, value, limit)
 
 
 def extract_promotable_lines(text: str, *, max_items: int = 3) -> list[str]:
@@ -99,14 +110,14 @@ def extract_promotable_lines(text: str, *, max_items: int = 3) -> list[str]:
 
 
 def _compact_component(key: str, text: str, max_tokens: int) -> str:
-    if key in {"experiment_log", "session_reports"}:
+    if key in {"experiment_log", "session_reports", "policy_refinement_feedback"}:
         needs_history_compaction = len(text.splitlines()) > 24 or len(_split_sections(text)) > 4
         if not needs_history_compaction and estimate_tokens(text) <= max_tokens:
             return text
     elif estimate_tokens(text) <= max_tokens:
         return text
 
-    if key in {"experiment_log", "session_reports"}:
+    if key in {"experiment_log", "session_reports", "policy_refinement_feedback"}:
         compacted = _compact_history(text, max_tokens=max_tokens)
     elif key == "trajectory":
         compacted = _compact_table(text, max_tokens=max_tokens)

--- a/autocontext/tests/test_agent_task_multi_gen.py
+++ b/autocontext/tests/test_agent_task_multi_gen.py
@@ -180,6 +180,33 @@ class TestBuildEnrichedPrompt:
         )
         assert "5" in prompt or "generation 5" in prompt.lower()
 
+    def test_compacts_verbose_playbook_and_best_output(self) -> None:
+        from autocontext.execution.agent_task_evolution import build_enriched_prompt
+
+        prompt = build_enriched_prompt(
+            task_prompt="Write a better incident review.",
+            playbook=(
+                "## Lessons\n"
+                + ("filler paragraph\n" * 220)
+                + "- Root cause: preserve concrete failure evidence in the write-up.\n"
+                + "- Recommendation: end with an explicit mitigation checklist.\n"
+            ),
+            generation=6,
+            best_output=(
+                "# Previous Report\n\n"
+                + ("background sentence\n" * 220)
+                + "## Findings\n"
+                + "- Root cause: stale assumptions hid the real failure mode.\n"
+                + "- Recommendation: cite the strongest evidence first.\n"
+            ),
+            best_score=0.84,
+        )
+
+        assert "root cause" in prompt.lower()
+        assert "mitigation checklist" in prompt.lower()
+        assert "strongest evidence first" in prompt.lower()
+        assert "condensed" in prompt.lower()
+
 
 # ===========================================================================
 # AgentTaskTrajectory

--- a/autocontext/tests/test_agent_task_multi_gen.py
+++ b/autocontext/tests/test_agent_task_multi_gen.py
@@ -207,6 +207,28 @@ class TestBuildEnrichedPrompt:
         assert "strongest evidence first" in prompt.lower()
         assert "condensed" in prompt.lower()
 
+    def test_compacts_plain_text_best_output_without_losing_tail(self) -> None:
+        from autocontext.execution.agent_task_evolution import build_enriched_prompt
+
+        prompt = build_enriched_prompt(
+            task_prompt="Write a better incident review.",
+            playbook="",
+            generation=6,
+            best_output=(
+                "\n".join(
+                    f"Paragraph {idx}: filler filler filler filler filler filler filler filler."
+                    for idx in range(1, 80)
+                )
+                + "\nFinal answer: preserve the rollback guard and cite evidence first."
+            ),
+            best_score=0.91,
+        )
+
+        assert "final answer" in prompt.lower()
+        assert "rollback guard" in prompt.lower()
+        assert "cite evidence first" in prompt.lower()
+        assert "condensed" in prompt.lower()
+
 
 # ===========================================================================
 # AgentTaskTrajectory

--- a/autocontext/tests/test_consultation.py
+++ b/autocontext/tests/test_consultation.py
@@ -404,6 +404,41 @@ class TestConsultationRunner:
         assert "score history" in prompt.lower()
         assert "condensed" in prompt.lower()
 
+    def test_user_prompt_keeps_tail_of_plain_text_operator_context(self) -> None:
+        from autocontext.consultation.runner import ConsultationRunner
+        from autocontext.consultation.types import ConsultationRequest, ConsultationTrigger
+
+        provider = CallableProvider(lambda _system, _user: "## Critique\nDone", model_name="spy")
+        runner = ConsultationRunner(provider)
+        request = ConsultationRequest(
+            run_id="run-1",
+            generation=9,
+            trigger=ConsultationTrigger.OPERATOR_REQUEST,
+            context_summary=(
+                "\n".join(
+                    f"Old note {idx}: filler filler filler filler filler filler filler."
+                    for idx in range(1, 60)
+                )
+                + "\nActual operator ask: explain why the new guard mutation caused the regression."
+            ),
+            current_strategy_summary=(
+                "\n".join(
+                    f"Old strategy {idx}: filler filler filler filler filler."
+                    for idx in range(1, 40)
+                )
+                + "\nCurrent issue: the fallback branch is being removed too early."
+            ),
+            score_history=[0.51] * 20,
+            gate_history=["retry"] * 20,
+        )
+
+        prompt = runner._build_user_prompt(request)
+
+        assert "actual operator ask" in prompt.lower()
+        assert "guard mutation caused the regression" in prompt.lower()
+        assert "fallback branch is being removed too early" in prompt.lower()
+        assert "condensed" in prompt.lower()
+
 
 # ===========================================================================
 # 4. SQLite Migration + Store Methods

--- a/autocontext/tests/test_consultation.py
+++ b/autocontext/tests/test_consultation.py
@@ -371,6 +371,39 @@ class TestConsultationRunner:
         assert "3 consecutive rollbacks observed" in captured_user[0]
         assert "aggressive flag capture" in captured_user[0]
 
+    def test_user_prompt_compacts_verbose_context(self) -> None:
+        from autocontext.consultation.runner import ConsultationRunner
+        from autocontext.consultation.types import ConsultationRequest, ConsultationTrigger
+
+        provider = CallableProvider(lambda _system, _user: "## Critique\nDone", model_name="spy")
+        runner = ConsultationRunner(provider)
+        request = ConsultationRequest(
+            run_id="run-1",
+            generation=8,
+            trigger=ConsultationTrigger.STAGNATION,
+            context_summary=(
+                "## Context\n"
+                + ("repeated stall detail\n" * 180)
+                + "- Finding: retries happen after the same fragile opening.\n"
+                + "- Recommendation: preserve broader map control early.\n"
+            ),
+            current_strategy_summary=(
+                "## Current strategy\n"
+                + ("strategy filler\n" * 180)
+                + "- Root cause: the planner commits too early to a narrow route.\n"
+                + "- Mitigation: keep a fallback branch until the first checkpoint.\n"
+            ),
+            score_history=[0.52] * 16,
+            gate_history=["retry"] * 16,
+        )
+
+        prompt = runner._build_user_prompt(request)
+
+        assert "fragile opening" in prompt.lower()
+        assert "fallback branch" in prompt.lower()
+        assert "score history" in prompt.lower()
+        assert "condensed" in prompt.lower()
+
 
 # ===========================================================================
 # 4. SQLite Migration + Store Methods

--- a/autocontext/tests/test_policy_refinement.py
+++ b/autocontext/tests/test_policy_refinement.py
@@ -11,6 +11,7 @@ from autocontext.execution.policy_refinement import (
     PolicyIteration,
     PolicyRefinementLoop,
     PolicyRefinementResult,
+    _build_refinement_prompt,
     compute_heuristic,
 )
 from autocontext.providers.base import CompletionResult, LLMProvider
@@ -241,6 +242,42 @@ class TestPolicyRefinementLoopRefine:
         assert result.best_heuristic > 0.0
         assert len(result.iteration_log) == 1
         assert result.total_matches_run == 2
+
+    def test_build_refinement_prompt_compacts_verbose_feedback(self) -> None:
+        scenario = GridCtfScenario()
+        match_results = [
+            PolicyMatchResult(
+                score=0.45 + (idx * 0.01),
+                normalized_score=0.45 + (idx * 0.01),
+                had_illegal_actions=idx % 2 == 0,
+                illegal_action_count=idx + 1,
+                errors=[
+                    f"Iteration {idx} repeated timeout while evaluating extended path search with stale state payload"
+                ],
+                moves_played=20 + idx,
+                replay=None,
+            )
+            for idx in range(12)
+        ]
+        current_policy = textwrap.dedent("""\
+            def choose_action(state):
+                if state.get("enemy_distance", 0) < 3:
+                    return {"aggression": 0.9, "defense": 0.1, "path_bias": 0.6}
+                return {"aggression": 0.5, "defense": 0.7, "path_bias": 0.8}
+        """)
+
+        _system_prompt, user_prompt = _build_refinement_prompt(
+            scenario,
+            current_policy,
+            match_results,
+            heuristic_value=0.58,
+            iteration=7,
+        )
+
+        assert "choose_action(state)" in user_prompt
+        assert "Iteration 11 repeated timeout" in user_prompt
+        assert "Illegal actions" in user_prompt
+        assert "condensed" in user_prompt.lower()
 
     def test_best_policy_tracked(self) -> None:
         """Best policy should be the one with the highest heuristic."""


### PR DESCRIPTION
## Summary
- apply the shared prompt compaction layer to agent-task evolution, policy refinement, and consultation prompts
- add tighter secondary-surface budgets plus compact history formatting so long carry-forward context stays bounded
- cover the new behavior with focused tests for each prompt builder

## Verification
- uv run pytest tests/test_agent_task_multi_gen.py tests/test_policy_refinement.py tests/test_consultation.py tests/test_knowledge_compaction.py tests/test_build_prompt_bundle_semantic_compaction.py
- uv run ruff check src tests
- uv run mypy src