### PR TITLE
feat(AC-582): classifier vocabulary miner

### DIFF
--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -1516,5 +1516,32 @@ register_solve_command(app, console=console)
 register_queue_command(app, console=console)
 
 
+@app.command("classifier-mine-vocab")
+def classifier_mine_vocab(
+    cache: Path | None = typer.Option(None, "--cache", help="Path to classifier cache JSON"),  # noqa: B008
+    out: Path | None = typer.Option(None, "--out", help="Write report to file instead of stdout"),  # noqa: B008
+    min_occurrences: int = typer.Option(3, "--min-occurrences", min=1, help="Minimum token occurrences to propose"),
+) -> None:
+    """Mine cached LLM classifications to propose keyword vocabulary additions (AC-582)."""
+    from autocontext.scenarios.custom.classifier_vocab_miner import (
+        _default_cache_path,
+        format_proposals_report,
+        load_cache_entries,
+        mine_vocab_proposals,
+    )
+    from autocontext.scenarios.custom.family_classifier import _FAMILY_SIGNAL_GROUPS
+
+    cache_path = cache if cache is not None else _default_cache_path()
+    entries = load_cache_entries(cache_path)
+    proposals = mine_vocab_proposals(entries, _FAMILY_SIGNAL_GROUPS, min_occurrences=min_occurrences)
+    report = format_proposals_report(proposals, total_cache_entries=len(entries))
+
+    if out is not None:
+        out.write_text(report, encoding="utf-8")
+        console.print(f"Report written to {out}")
+    else:
+        console.print(report)
+
+
 if __name__ == "__main__":
     app()

--- a/autocontext/src/autocontext/scenarios/custom/classifier_cache.py
+++ b/autocontext/src/autocontext/scenarios/custom/classifier_cache.py
@@ -17,6 +17,7 @@ File format (``cache.json``)::
                 "rationale": "matches simulation pattern",
                 "alternatives": [...],
                 "no_signals_matched": false,
+                "description": "<original description, retained for AC-582 vocab mining>",
                 "cached_at": "2026-04-22T12:34:56Z"
             },
             ...
@@ -74,7 +75,10 @@ class ClassifierCache:
         entry = data.get("entries", {}).get(_description_key(description))
         if not isinstance(entry, dict):
             return None
-        payload = {k: v for k, v in entry.items() if k != "cached_at"}
+        payload = {
+            k: v for k, v in entry.items()
+            if k not in ("cached_at", "description")
+        }
         try:
             return FamilyClassification.from_dict(payload)
         except Exception as exc:
@@ -98,6 +102,7 @@ class ClassifierCache:
             data = {"schema_version": schema, "entries": {}}
 
         entry: dict[str, Any] = classification.to_dict()
+        entry["description"] = description
         entry["cached_at"] = datetime.now(UTC).isoformat()
         data["entries"][_description_key(description)] = entry
 

--- a/autocontext/src/autocontext/scenarios/custom/classifier_vocab_miner.py
+++ b/autocontext/src/autocontext/scenarios/custom/classifier_vocab_miner.py
@@ -25,7 +25,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from autocontext.scenarios.custom.classifier_cache import _schema_version
 from autocontext.scenarios.custom.family_classifier import _STOP_WORDS
+from autocontext.scenarios.families import list_families
 
 _DEFAULT_SUGGESTED_WEIGHT = 1.5
 _EXAMPLES_PER_PROPOSAL = 3
@@ -82,7 +84,7 @@ def mine_vocab_proposals(
     Algorithm:
         1. Group descriptions by ``family_name``.
         2. Tokenize each description (lowercase, stopwords removed, min length).
-        3. Count tokens per family.
+        3. Count distinct descriptions per token, per family.
         4. Filter: count must meet ``min_occurrences``.
         5. Filter: token must not already be covered by any signal (substring).
         6. Sort by count descending; emit one :class:`VocabProposal` per term.
@@ -102,10 +104,11 @@ def mine_vocab_proposals(
         for description in descriptions:
             seen_in_this_desc: set[str] = set()
             for token in _tokenize(description):
+                if token in seen_in_this_desc:
+                    continue
                 token_counts[token] += 1
-                if token not in seen_in_this_desc:
-                    examples_by_term.setdefault(token, []).append(description)
-                    seen_in_this_desc.add(token)
+                examples_by_term.setdefault(token, []).append(description)
+                seen_in_this_desc.add(token)
 
         for term, count in token_counts.most_common():
             if count < min_occurrences:
@@ -180,6 +183,9 @@ def load_cache_entries(cache_path: Path) -> list[dict[str, Any]]:
     Returns a list of ``{"description": str, "family_name": str}`` dicts.
     Silently skips entries missing either field — tolerates the legacy cache
     format from the first AC-581 ship that stored only SHA-256 keys.
+
+    Applies the same schema-version invalidation rule as ``ClassifierCache``:
+    if the registered family set has changed, treat the whole file as stale.
     """
     import json
 
@@ -192,6 +198,9 @@ def load_cache_entries(cache_path: Path) -> list[dict[str, Any]]:
     except json.JSONDecodeError:
         return []
     if not isinstance(payload, dict):
+        return []
+    expected_schema = _schema_version([family.name for family in list_families()])
+    if payload.get("schema_version") != expected_schema:
         return []
     entries = payload.get("entries")
     if not isinstance(entries, dict):

--- a/autocontext/src/autocontext/scenarios/custom/classifier_vocab_miner.py
+++ b/autocontext/src/autocontext/scenarios/custom/classifier_vocab_miner.py
@@ -1,0 +1,218 @@
+"""AC-582 — mine cached LLM classifier fallback entries for vocabulary proposals.
+
+The AC-580 fallback hands niche prompts to an LLM; AC-581 caches those results.
+This module closes the feedback loop: it reads the cache, groups entries by
+the family the LLM chose, and proposes new keyword signals that would let the
+deterministic keyword classifier handle similar prompts without an LLM call.
+
+Output is a markdown report for human review — never an automatic code change.
+
+Layering:
+    - :func:`mine_vocab_proposals` is a pure function over primitive data
+      (dict entries, signal group dicts). Callable from tests without I/O.
+    - :func:`format_proposals_report` renders proposals to markdown.
+    - :func:`load_cache_entries` adapts a :class:`ClassifierCache` file into
+      the entry shape the miner expects.
+
+The miner DRYs on the classifier's stopword list — mining stopwords like
+"and" or "the" is meaningless noise.
+"""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from autocontext.scenarios.custom.family_classifier import _STOP_WORDS
+
+_DEFAULT_SUGGESTED_WEIGHT = 1.5
+_EXAMPLES_PER_PROPOSAL = 3
+# Terms shorter than this are too noisy (e.g. "ok", "us").
+_MIN_TERM_LENGTH = 4
+
+
+@dataclass(slots=True, frozen=True)
+class VocabProposal:
+    """A proposed keyword signal addition for human review."""
+
+    family_name: str
+    term: str
+    suggested_weight: float
+    occurrence_count: int
+    example_descriptions: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _tokenize(description: str) -> list[str]:
+    """Lowercased word tokens, stopwords removed."""
+    words = re.sub(r"[^a-z0-9\s\-]", " ", description.lower()).split()
+    return [
+        w for w in words
+        if w not in _STOP_WORDS and len(w) >= _MIN_TERM_LENGTH
+    ]
+
+
+def _existing_signal_covers(
+    candidate: str,
+    signal_groups: dict[str, dict[str, float]],
+) -> bool:
+    """True when the candidate is already a substring match of any registered signal.
+
+    Matches the classifier's own matching semantics: signals like ``escalat``
+    are prefix substrings that fire on ``escalate`` and ``escalation``. So if
+    a cached description's token is ``escalation``, the signal ``escalat``
+    already covers it — don't propose ``escalation`` as a new keyword.
+    """
+    for signals in signal_groups.values():
+        for signal in signals:
+            if signal in candidate or candidate in signal:
+                return True
+    return False
+
+
+def mine_vocab_proposals(
+    cache_entries: list[dict[str, Any]],
+    signal_groups: dict[str, dict[str, float]],
+    *,
+    min_occurrences: int = 3,
+) -> list[VocabProposal]:
+    """Return vocabulary-addition proposals from cached classifications.
+
+    Algorithm:
+        1. Group descriptions by ``family_name``.
+        2. Tokenize each description (lowercase, stopwords removed, min length).
+        3. Count tokens per family.
+        4. Filter: count must meet ``min_occurrences``.
+        5. Filter: token must not already be covered by any signal (substring).
+        6. Sort by count descending; emit one :class:`VocabProposal` per term.
+    """
+    by_family: dict[str, list[str]] = {}
+    for entry in cache_entries:
+        family = entry.get("family_name")
+        description = entry.get("description", "")
+        if not family or not description:
+            continue
+        by_family.setdefault(family, []).append(description)
+
+    proposals: list[VocabProposal] = []
+    for family_name, descriptions in by_family.items():
+        token_counts: Counter[str] = Counter()
+        examples_by_term: dict[str, list[str]] = {}
+        for description in descriptions:
+            seen_in_this_desc: set[str] = set()
+            for token in _tokenize(description):
+                token_counts[token] += 1
+                if token not in seen_in_this_desc:
+                    examples_by_term.setdefault(token, []).append(description)
+                    seen_in_this_desc.add(token)
+
+        for term, count in token_counts.most_common():
+            if count < min_occurrences:
+                break  # most_common is sorted; everything else is below
+            if _existing_signal_covers(term, signal_groups):
+                continue
+            examples = tuple(examples_by_term[term][:_EXAMPLES_PER_PROPOSAL])
+            proposals.append(
+                VocabProposal(
+                    family_name=family_name,
+                    term=term,
+                    suggested_weight=_DEFAULT_SUGGESTED_WEIGHT,
+                    occurrence_count=count,
+                    example_descriptions=examples,
+                )
+            )
+    return proposals
+
+
+def format_proposals_report(
+    proposals: list[VocabProposal],
+    *,
+    total_cache_entries: int,
+) -> str:
+    """Render proposals as a human-readable markdown report."""
+    lines: list[str] = []
+    lines.append("# Classifier Vocabulary Mining Report")
+    lines.append("")
+    lines.append(f"- Cache entries analyzed: **{total_cache_entries}**")
+    lines.append(f"- Proposals generated: **{len(proposals)}**")
+    lines.append("")
+
+    if not proposals:
+        lines.append("No vocabulary proposals — the keyword classifier already covers every cached family.")
+        return "\n".join(lines) + "\n"
+
+    by_family: dict[str, list[VocabProposal]] = {}
+    for p in proposals:
+        by_family.setdefault(p.family_name, []).append(p)
+
+    for family_name in sorted(by_family):
+        lines.append(f"## Family: `{family_name}`")
+        lines.append("")
+        lines.append("| Term | Suggested weight | Occurrences | Example |")
+        lines.append("| --- | ---: | ---: | --- |")
+        for proposal in by_family[family_name]:
+            example = proposal.example_descriptions[0] if proposal.example_descriptions else ""
+            example = example.replace("|", "\\|").replace("\n", " ")
+            if len(example) > 80:
+                example = example[:77] + "..."
+            lines.append(
+                f"| `{proposal.term}` "
+                f"| {proposal.suggested_weight:.1f} "
+                f"| {proposal.occurrence_count} "
+                f"| {example} |"
+            )
+        lines.append("")
+        # Include extra examples below the table for proposals with multiple.
+        for proposal in by_family[family_name]:
+            if len(proposal.example_descriptions) > 1:
+                lines.append(f"**`{proposal.term}` additional examples:**")
+                for ex in proposal.example_descriptions[1:]:
+                    lines.append(f"- {ex}")
+                lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def load_cache_entries(cache_path: Path) -> list[dict[str, Any]]:
+    """Read entries from a :class:`ClassifierCache` file for mining.
+
+    Returns a list of ``{"description": str, "family_name": str}`` dicts.
+    Silently skips entries missing either field — tolerates the legacy cache
+    format from the first AC-581 ship that stored only SHA-256 keys.
+    """
+    import json
+
+    try:
+        raw = cache_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(payload, dict):
+        return []
+    entries = payload.get("entries")
+    if not isinstance(entries, dict):
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    for value in entries.values():
+        if not isinstance(value, dict):
+            continue
+        description = value.get("description")
+        family_name = value.get("family_name")
+        if not isinstance(description, str) or not isinstance(family_name, str):
+            continue
+        normalized.append({"description": description, "family_name": family_name})
+    return normalized
+
+
+def _default_cache_path() -> Path:
+    """Where the AC-581 cache is expected by default."""
+    import os
+
+    override = os.getenv("AUTOCONTEXT_CLASSIFIER_CACHE_DIR")
+    base = Path(override) if override else Path.home() / ".cache" / "autocontext"
+    return base / "classifier_fallback.json"

--- a/autocontext/tests/test_classifier_vocab_miner.py
+++ b/autocontext/tests/test_classifier_vocab_miner.py
@@ -1,0 +1,269 @@
+"""AC-582 — mine cached LLM classifications to propose keyword vocabulary additions."""
+from __future__ import annotations
+
+from autocontext.scenarios.custom.classifier_cache import ClassifierCache
+from autocontext.scenarios.custom.classifier_vocab_miner import (
+    VocabProposal,
+    format_proposals_report,
+    load_cache_entries,
+    mine_vocab_proposals,
+)
+from autocontext.scenarios.custom.family_classifier import (
+    FamilyClassification,
+)
+
+
+# Minimal signal groups for tests — real classifier has 11 families and many keywords.
+_SIGNAL_GROUPS = {
+    "simulation": {"pipeline": 1.5, "rollback": 2.0},
+    "agent_task": {"essay": 2.0, "haiku": 1.5},
+    "game": {"tournament": 2.0},
+}
+
+
+def _entry(description: str, family: str) -> dict:
+    """Shape of a ClassifierCache entry."""
+    return {"description": description, "family_name": family}
+
+
+class TestMineVocabProposals:
+    def test_empty_cache_returns_no_proposals(self) -> None:
+        proposals = mine_vocab_proposals([], _SIGNAL_GROUPS, min_occurrences=3)
+        assert proposals == []
+
+    def test_proposes_term_that_recurs_for_a_family(self) -> None:
+        cache = [
+            _entry("biomedical drug interaction study", "agent_task"),
+            _entry("biomedical research protocol design", "agent_task"),
+            _entry("biomedical literature summarization", "agent_task"),
+        ]
+        proposals = mine_vocab_proposals(cache, _SIGNAL_GROUPS, min_occurrences=3)
+
+        terms = {p.term for p in proposals}
+        assert "biomedical" in terms
+        biomedical = next(p for p in proposals if p.term == "biomedical")
+        assert biomedical.family_name == "agent_task"
+        assert biomedical.occurrence_count == 3
+
+    def test_does_not_propose_existing_signal(self) -> None:
+        # "pipeline" is already in simulation signals; must not be proposed
+        # even if it recurs in the cache for that family.
+        cache = [
+            _entry("deploy a pipeline to staging", "simulation"),
+            _entry("failover pipeline with rollback", "simulation"),
+            _entry("multi-stage pipeline orchestration", "simulation"),
+        ]
+        proposals = mine_vocab_proposals(cache, _SIGNAL_GROUPS, min_occurrences=3)
+        assert not any(p.term == "pipeline" for p in proposals)
+
+    def test_does_not_propose_substring_of_existing_signal(self) -> None:
+        # The simulation group has "orchestrat" as a prefix match for
+        # "orchestrate" / "orchestration". A candidate term "orchestrate"
+        # must not be proposed because it's already covered.
+        groups_with_prefix = {
+            "simulation": {"orchestrat": 2.0},
+        }
+        cache = [
+            _entry("orchestrate a deployment", "simulation"),
+            _entry("orchestrate retries carefully", "simulation"),
+            _entry("orchestrate multi-stage rollouts", "simulation"),
+        ]
+        proposals = mine_vocab_proposals(cache, groups_with_prefix, min_occurrences=3)
+        assert not any(p.term == "orchestrate" for p in proposals)
+
+    def test_skips_stopwords(self) -> None:
+        cache = [
+            _entry("and the a an of for to in on", "agent_task"),
+            _entry("and the a an of for to in on", "agent_task"),
+            _entry("and the a an of for to in on", "agent_task"),
+        ]
+        proposals = mine_vocab_proposals(cache, _SIGNAL_GROUPS, min_occurrences=3)
+        assert proposals == []
+
+    def test_respects_min_occurrences_threshold(self) -> None:
+        cache = [
+            _entry("cryptographic protocol analysis", "agent_task"),
+            _entry("cryptographic key derivation", "agent_task"),
+        ]
+        proposals = mine_vocab_proposals(cache, _SIGNAL_GROUPS, min_occurrences=3)
+        assert not any(p.term == "cryptographic" for p in proposals)
+
+        proposals_lower = mine_vocab_proposals(cache, _SIGNAL_GROUPS, min_occurrences=2)
+        assert any(p.term == "cryptographic" for p in proposals_lower)
+
+    def test_proposal_includes_example_descriptions(self) -> None:
+        cache = [
+            _entry("quantum circuit simulation one", "simulation"),
+            _entry("quantum circuit simulation two", "simulation"),
+            _entry("quantum annealing walkthrough", "simulation"),
+        ]
+        proposals = mine_vocab_proposals(cache, _SIGNAL_GROUPS, min_occurrences=3)
+        quantum = next(p for p in proposals if p.term == "quantum")
+        assert len(quantum.example_descriptions) >= 1
+        assert len(quantum.example_descriptions) <= 3
+        assert all("quantum" in ex.lower() for ex in quantum.example_descriptions)
+
+    def test_proposals_sorted_by_count_desc_within_family(self) -> None:
+        cache = [
+            _entry("forensic analysis report", "agent_task"),
+            _entry("forensic audit trail", "agent_task"),
+            _entry("forensic evidence summary", "agent_task"),
+            _entry("forensic report writeup", "agent_task"),
+            _entry("subpoena response letter", "agent_task"),
+            _entry("subpoena compliance review", "agent_task"),
+            _entry("subpoena draft package", "agent_task"),
+        ]
+        proposals = mine_vocab_proposals(cache, _SIGNAL_GROUPS, min_occurrences=3)
+        agent_task_proposals = [p for p in proposals if p.family_name == "agent_task"]
+        counts = [p.occurrence_count for p in agent_task_proposals]
+        assert counts == sorted(counts, reverse=True)
+
+    def test_returns_vocab_proposal_instances(self) -> None:
+        cache = [
+            _entry("logistics routing planner", "simulation"),
+            _entry("logistics warehouse turnover", "simulation"),
+            _entry("logistics freight lane design", "simulation"),
+        ]
+        proposals = mine_vocab_proposals(cache, _SIGNAL_GROUPS, min_occurrences=3)
+        assert all(isinstance(p, VocabProposal) for p in proposals)
+
+
+class TestFormatProposalsReport:
+    def test_empty_proposals_produces_non_empty_report(self) -> None:
+        report = format_proposals_report([], total_cache_entries=0)
+        # Still renders a helpful report even with no proposals.
+        assert report.strip() != ""
+        assert "No vocabulary proposals" in report or "0 proposals" in report
+
+    def test_report_includes_family_term_count_and_examples(self) -> None:
+        proposals = [
+            VocabProposal(
+                family_name="agent_task",
+                term="biomedical",
+                suggested_weight=1.5,
+                occurrence_count=4,
+                example_descriptions=["biomedical drug study", "biomedical research"],
+            ),
+        ]
+        report = format_proposals_report(proposals, total_cache_entries=4)
+        assert "agent_task" in report
+        assert "biomedical" in report
+        assert "4" in report  # occurrence count somewhere
+        assert "biomedical drug study" in report
+
+    def test_report_groups_by_family(self) -> None:
+        proposals = [
+            VocabProposal(
+                family_name="simulation",
+                term="logistics",
+                suggested_weight=1.5,
+                occurrence_count=3,
+                example_descriptions=["logistics routing"],
+            ),
+            VocabProposal(
+                family_name="agent_task",
+                term="biomedical",
+                suggested_weight=1.5,
+                occurrence_count=3,
+                example_descriptions=["biomedical analysis"],
+            ),
+        ]
+        report = format_proposals_report(proposals, total_cache_entries=6)
+        # Each family has its own section heading.
+        assert report.count("### Family:") == 2 or report.count("## Family:") == 2
+
+
+class TestLoadCacheEntriesFromClassifierCache:
+    """Miner consumes the AC-581 cache file directly."""
+
+    _FAMILIES = ["agent_task", "simulation", "game"]
+
+    def _classification(self, family: str) -> FamilyClassification:
+        return FamilyClassification(
+            family_name=family,
+            confidence=0.8,
+            rationale="r",
+            no_signals_matched=False,
+        )
+
+    def test_missing_file_returns_empty(self, tmp_path) -> None:
+        assert load_cache_entries(tmp_path / "missing.json") == []
+
+    def test_corrupt_file_returns_empty(self, tmp_path) -> None:
+        path = tmp_path / "cache.json"
+        path.write_text("{not json", encoding="utf-8")
+        assert load_cache_entries(path) == []
+
+    def test_returns_description_and_family_from_cache_entries(self, tmp_path) -> None:
+        path = tmp_path / "cache.json"
+        cache = ClassifierCache(path)
+        cache.put("biomedical study one", self._FAMILIES, self._classification("agent_task"))
+        cache.put("biomedical study two", self._FAMILIES, self._classification("agent_task"))
+        cache.put("failover runbook", self._FAMILIES, self._classification("simulation"))
+
+        entries = load_cache_entries(path)
+        assert len(entries) == 3
+        descriptions = {e["description"] for e in entries}
+        assert descriptions == {
+            "biomedical study one",
+            "biomedical study two",
+            "failover runbook",
+        }
+        assert {e["family_name"] for e in entries} == {"agent_task", "simulation"}
+
+    def test_end_to_end_cache_to_proposals(self, tmp_path) -> None:
+        # Seed the cache with recurring "biomedical" in agent_task descriptions,
+        # then mine — proposal should surface.
+        path = tmp_path / "cache.json"
+        cache = ClassifierCache(path)
+        for desc in [
+            "biomedical drug study design",
+            "biomedical literature summary",
+            "biomedical research protocol",
+        ]:
+            cache.put(desc, self._FAMILIES, self._classification("agent_task"))
+
+        entries = load_cache_entries(path)
+        proposals = mine_vocab_proposals(entries, _SIGNAL_GROUPS, min_occurrences=3)
+        assert any(p.term == "biomedical" and p.family_name == "agent_task" for p in proposals)
+
+
+class TestClassifierCacheStoresDescription:
+    """The cache now retains the raw description in each entry so mining can work."""
+
+    def test_put_writes_description_in_entry_value(self, tmp_path) -> None:
+        import json
+
+        path = tmp_path / "cache.json"
+        cache = ClassifierCache(path)
+        cache.put(
+            "some niche biomedical prompt",
+            ["agent_task", "simulation"],
+            FamilyClassification(
+                family_name="agent_task",
+                confidence=0.8,
+                rationale="r",
+                no_signals_matched=False,
+            ),
+        )
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+        entry = next(iter(data["entries"].values()))
+        assert entry["description"] == "some niche biomedical prompt"
+
+    def test_get_still_works_with_new_field(self, tmp_path) -> None:
+        path = tmp_path / "cache.json"
+        cache = ClassifierCache(path)
+        cache.put(
+            "a description",
+            ["agent_task"],
+            FamilyClassification(
+                family_name="agent_task",
+                confidence=0.8,
+                rationale="r",
+                no_signals_matched=False,
+            ),
+        )
+        fetched = cache.get("a description", ["agent_task"])
+        assert fetched is not None
+        assert fetched.family_name == "agent_task"

--- a/autocontext/tests/test_classifier_vocab_miner.py
+++ b/autocontext/tests/test_classifier_vocab_miner.py
@@ -12,7 +12,6 @@ from autocontext.scenarios.custom.family_classifier import (
     FamilyClassification,
 )
 
-
 # Minimal signal groups for tests — real classifier has 11 families and many keywords.
 _SIGNAL_GROUPS = {
     "simulation": {"pipeline": 1.5, "rollback": 2.0},

--- a/autocontext/tests/test_classifier_vocab_miner.py
+++ b/autocontext/tests/test_classifier_vocab_miner.py
@@ -1,16 +1,18 @@
 """AC-582 — mine cached LLM classifications to propose keyword vocabulary additions."""
 from __future__ import annotations
 
-from autocontext.scenarios.custom.classifier_cache import ClassifierCache
+from autocontext.scenarios.custom.classifier_cache import (
+    ClassifierCache,
+    _schema_version,
+)
 from autocontext.scenarios.custom.classifier_vocab_miner import (
     VocabProposal,
     format_proposals_report,
     load_cache_entries,
     mine_vocab_proposals,
 )
-from autocontext.scenarios.custom.family_classifier import (
-    FamilyClassification,
-)
+from autocontext.scenarios.custom.family_classifier import FamilyClassification
+from autocontext.scenarios.families import list_families
 
 # Minimal signal groups for tests — real classifier has 11 families and many keywords.
 _SIGNAL_GROUPS = {
@@ -89,6 +91,13 @@ class TestMineVocabProposals:
 
         proposals_lower = mine_vocab_proposals(cache, _SIGNAL_GROUPS, min_occurrences=2)
         assert any(p.term == "cryptographic" for p in proposals_lower)
+
+    def test_counts_distinct_descriptions_not_repeated_tokens(self) -> None:
+        cache = [
+            _entry("biomedical biomedical biomedical protocol", "agent_task"),
+        ]
+        proposals = mine_vocab_proposals(cache, _SIGNAL_GROUPS, min_occurrences=3)
+        assert not any(p.term == "biomedical" for p in proposals)
 
     def test_proposal_includes_example_descriptions(self) -> None:
         cache = [
@@ -175,7 +184,7 @@ class TestFormatProposalsReport:
 class TestLoadCacheEntriesFromClassifierCache:
     """Miner consumes the AC-581 cache file directly."""
 
-    _FAMILIES = ["agent_task", "simulation", "game"]
+    _FAMILIES = [family.name for family in list_families()]
 
     def _classification(self, family: str) -> FamilyClassification:
         return FamilyClassification(
@@ -192,6 +201,48 @@ class TestLoadCacheEntriesFromClassifierCache:
         path = tmp_path / "cache.json"
         path.write_text("{not json", encoding="utf-8")
         assert load_cache_entries(path) == []
+
+    def test_stale_schema_returns_empty(self, tmp_path) -> None:
+        import json
+
+        path = tmp_path / "cache.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "stale-schema",
+                    "entries": {
+                        "deadbeef": {
+                            "family_name": "deleted_family",
+                            "description": "novel domain token",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert load_cache_entries(path) == []
+
+    def test_current_schema_is_accepted(self, tmp_path) -> None:
+        import json
+
+        path = tmp_path / "cache.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": _schema_version(self._FAMILIES),
+                    "entries": {
+                        "deadbeef": {
+                            "family_name": "agent_task",
+                            "description": "biomedical protocol review",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        assert load_cache_entries(path) == [
+            {"description": "biomedical protocol review", "family_name": "agent_task"}
+        ]
 
     def test_returns_description_and_family_from_cache_entries(self, tmp_path) -> None:
         path = tmp_path / "cache.json"

--- a/autocontext/tests/test_cli_classifier_vocab_miner.py
+++ b/autocontext/tests/test_cli_classifier_vocab_miner.py
@@ -1,6 +1,7 @@
 """AC-582 — CLI tests for `autoctx classifier-mine-vocab`."""
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from unittest.mock import patch
@@ -8,16 +9,15 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from autocontext.cli import app
+from autocontext.scenarios.custom.classifier_cache import _schema_version
+from autocontext.scenarios.families import list_families
 
 runner = CliRunner()
 
 
 def _write_cache(path: Path, entries: dict) -> None:
     """Write a minimal cache.json at *path*."""
-    import hashlib
-
-    families = sorted(entries.keys()) if entries else ["agent_task"]
-    schema = hashlib.sha256(",".join(families).encode()).hexdigest()
+    schema = _schema_version([family.name for family in list_families()])
     raw_entries = {}
     for family, descs in entries.items():
         for desc in descs:

--- a/autocontext/tests/test_cli_classifier_vocab_miner.py
+++ b/autocontext/tests/test_cli_classifier_vocab_miner.py
@@ -1,0 +1,147 @@
+"""AC-582 — CLI tests for `autoctx classifier-mine-vocab`."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+
+runner = CliRunner()
+
+
+def _write_cache(path: Path, entries: dict) -> None:
+    """Write a minimal cache.json at *path*."""
+    import hashlib
+
+    families = sorted(entries.keys()) if entries else ["agent_task"]
+    schema = hashlib.sha256(",".join(families).encode()).hexdigest()
+    raw_entries = {}
+    for family, descs in entries.items():
+        for desc in descs:
+            key = hashlib.sha256(desc.encode()).hexdigest()
+            raw_entries[key] = {
+                "family_name": family,
+                "confidence": 0.8,
+                "rationale": "r",
+                "no_signals_matched": False,
+                "description": desc,
+                "cached_at": "2026-04-22T00:00:00+00:00",
+            }
+    path.write_text(
+        json.dumps({"schema_version": schema, "entries": raw_entries}),
+        encoding="utf-8",
+    )
+
+
+class TestClassifierMineVocabCommand:
+    def test_command_is_registered(self) -> None:
+        result = runner.invoke(app, ["classifier-mine-vocab", "--help"])
+        assert result.exit_code == 0
+
+    def test_missing_cache_exits_with_message(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            ["classifier-mine-vocab", "--cache", str(tmp_path / "missing.json")],
+        )
+        assert result.exit_code == 0
+        assert "0" in result.output  # 0 proposals or 0 entries
+
+    def test_produces_markdown_report_to_stdout(self, tmp_path: Path) -> None:
+        cache_path = tmp_path / "cache.json"
+        _write_cache(
+            cache_path,
+            {
+                "agent_task": [
+                    "biomedical drug study",
+                    "biomedical research protocol",
+                    "biomedical literature summary",
+                ]
+            },
+        )
+        result = runner.invoke(
+            app,
+            ["classifier-mine-vocab", "--cache", str(cache_path), "--min-occurrences", "3"],
+        )
+        assert result.exit_code == 0
+        assert "biomedical" in result.output
+
+    def test_out_flag_writes_file_instead_of_stdout(self, tmp_path: Path) -> None:
+        cache_path = tmp_path / "cache.json"
+        out_path = tmp_path / "proposals.md"
+        _write_cache(
+            cache_path,
+            {
+                "agent_task": [
+                    "biomedical drug study",
+                    "biomedical research protocol",
+                    "biomedical literature summary",
+                ]
+            },
+        )
+        result = runner.invoke(
+            app,
+            [
+                "classifier-mine-vocab",
+                "--cache",
+                str(cache_path),
+                "--out",
+                str(out_path),
+                "--min-occurrences",
+                "3",
+            ],
+        )
+        assert result.exit_code == 0
+        assert out_path.exists()
+        content = out_path.read_text(encoding="utf-8")
+        assert "biomedical" in content
+
+    def test_default_cache_path_used_when_flag_omitted(self, tmp_path: Path) -> None:
+        """When --cache is omitted the command uses the default path (may be empty)."""
+        default_cache = tmp_path / "classifier_fallback.json"
+        _write_cache(
+            default_cache,
+            {
+                "simulation": [
+                    "logistics routing system",
+                    "logistics warehouse design",
+                    "logistics freight analysis",
+                ]
+            },
+        )
+        with patch(
+            "autocontext.scenarios.custom.classifier_vocab_miner._default_cache_path",
+            return_value=default_cache,
+        ):
+            result = runner.invoke(app, ["classifier-mine-vocab", "--min-occurrences", "3"])
+        assert result.exit_code == 0
+        assert "logistics" in result.output
+
+    def test_min_occurrences_flag_controls_threshold(self, tmp_path: Path) -> None:
+        cache_path = tmp_path / "cache.json"
+        _write_cache(
+            cache_path,
+            {
+                "agent_task": [
+                    "cryptographic protocol analysis",
+                    "cryptographic key derivation",
+                ]
+            },
+        )
+        # threshold 3 → no proposal
+        result3 = runner.invoke(
+            app,
+            ["classifier-mine-vocab", "--cache", str(cache_path), "--min-occurrences", "3"],
+        )
+        assert result3.exit_code == 0
+        assert "cryptographic" not in result3.output
+
+        # threshold 2 → proposal present
+        result2 = runner.invoke(
+            app,
+            ["classifier-mine-vocab", "--cache", str(cache_path), "--min-occurrences", "2"],
+        )
+        assert result2.exit_code == 0
+        assert "cryptographic" in result2.output


### PR DESCRIPTION
## Summary

- Adds `classifier_vocab_miner.py` — pure `mine_vocab_proposals()` + `format_proposals_report()` + `load_cache_entries()` that reads the AC-581 cache and proposes keyword signal additions for human review
- Extends `ClassifierCache.put()` to persist the raw description in each entry (required for mining); `get()` strips it before deserialization — no breaking change
- Wires `autoctx classifier-mine-vocab --cache <path> [--out <file>] [--min-occurrences N]` CLI command

Stacked on AC-581 (#755) — base branch is `feature/ac-581-classifier-cache`.

## Test Plan

- [ ] 18 unit tests for miner logic (proposals, filtering, formatting, cache load)
- [ ] 15 existing cache tests still pass (description field backwards-compatible)
- [ ] 6 CLI tests for the new command
- [ ] `uv run ruff check src tests` — clean
- [ ] `uv run mypy src` — clean