### PR TITLE
AC-594: Benchmark semantic compaction against budget-only trimming

### DIFF
--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -324,6 +324,10 @@ class AppSettings(BaseModel):
     constraint_prompts_enabled: bool = Field(default=True, description="Append constraint suffixes to role prompts")
     # Context budget
     context_budget_tokens: int = Field(default=100_000, ge=0, description="Max estimated tokens for prompt context")
+    semantic_compaction_benchmark_enabled: bool = Field(
+        default=False,
+        description="Capture a semantic compaction benchmark report during prompt assembly",
+    )
     # Knowledge coherence
     coherence_check_enabled: bool = Field(default=True, description="Run knowledge coherence check after persistence")
     # Strategy pre-validation

--- a/autocontext/src/autocontext/evidence/materializer.py
+++ b/autocontext/src/autocontext/evidence/materializer.py
@@ -6,6 +6,7 @@ flat workspace directory, and returns a manifest.
 
 from __future__ import annotations
 
+import dataclasses
 import datetime
 import hashlib
 import json
@@ -117,6 +118,7 @@ def materialize_workspace(
         total_size_bytes=total_size,
         materialized_at=datetime.datetime.now(datetime.UTC).isoformat(),
         source_signature=source_signature,
+        cache_hit=False,
     )
 
     # Write manifest
@@ -174,9 +176,10 @@ def _load_cached_workspace(workspace_dir: Path, *, source_signature: str) -> Evi
         if artifact_path is None or not artifact_path.exists():
             return None
     try:
-        return EvidenceWorkspace.from_dict(data)
+        workspace = EvidenceWorkspace.from_dict(data)
     except (KeyError, TypeError, ValueError):
         return None
+    return dataclasses.replace(workspace, cache_hit=True)
 
 
 def _apply_secret_scan(

--- a/autocontext/src/autocontext/evidence/workspace.py
+++ b/autocontext/src/autocontext/evidence/workspace.py
@@ -58,6 +58,7 @@ class EvidenceWorkspace:
     total_size_bytes: int
     materialized_at: str
     source_signature: str = ""
+    cache_hit: bool = False
     accessed_artifacts: list[str] = field(default_factory=list)
 
     def get_artifact(self, artifact_id: str) -> EvidenceArtifact | None:
@@ -77,6 +78,7 @@ class EvidenceWorkspace:
             "total_size_bytes": self.total_size_bytes,
             "materialized_at": self.materialized_at,
             "source_signature": self.source_signature,
+            "cache_hit": self.cache_hit,
             "accessed_artifacts": list(self.accessed_artifacts),
         }
 
@@ -89,5 +91,6 @@ class EvidenceWorkspace:
             total_size_bytes=data.get("total_size_bytes", 0),
             materialized_at=data["materialized_at"],
             source_signature=str(data.get("source_signature", "")),
+            cache_hit=bool(data.get("cache_hit", False)),
             accessed_artifacts=data.get("accessed_artifacts", []),
         )

--- a/autocontext/src/autocontext/knowledge/semantic_compaction_benchmark.py
+++ b/autocontext/src/autocontext/knowledge/semantic_compaction_benchmark.py
@@ -1,0 +1,237 @@
+"""Benchmark and observability helpers for semantic prompt compaction."""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from autocontext.knowledge.compaction import compact_prompt_components, extract_promotable_lines
+from autocontext.prompts.context_budget import ContextBudget, estimate_tokens
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from autocontext.prompts.templates import PromptBundle
+
+
+@dataclass(slots=True, frozen=True)
+class CompactionComponentBenchmark:
+    """Per-component comparison of semantic compaction vs budget-only trimming."""
+
+    name: str
+    raw_tokens: int
+    semantic_tokens: int
+    budget_only_tokens: int
+    semantic_budgeted_tokens: int
+    signal_lines: list[str] = field(default_factory=list)
+    semantic_signal_lines_preserved: int = 0
+    budget_only_signal_lines_preserved: int = 0
+
+    def to_dict(self) -> dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass(slots=True, frozen=True)
+class PromptVariantBenchmark:
+    """Prompt-level metrics for one build variant."""
+
+    name: str
+    context_tokens: int
+    total_prompt_tokens: int
+    role_prompt_tokens: dict[str, int]
+    build_latency_ms: float
+    signal_lines_preserved: int
+
+    def to_dict(self) -> dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass(slots=True, frozen=True)
+class RegressionCheck:
+    """Boolean quality/regression check captured in the benchmark report."""
+
+    name: str
+    passed: bool
+    detail: str
+
+    def to_dict(self) -> dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+@dataclass(slots=True, frozen=True)
+class SemanticCompactionBenchmarkReport:
+    """Persistable benchmark report for semantic compaction vs budget-only trimming."""
+
+    scenario_name: str
+    run_id: str
+    generation: int
+    context_budget_tokens: int
+    raw_context_tokens: int
+    semantic_variant: PromptVariantBenchmark
+    budget_only_variant: PromptVariantBenchmark
+    components: list[CompactionComponentBenchmark]
+    evidence_cache_hits: int = 0
+    evidence_cache_lookups: int = 0
+    regression_checks: list[RegressionCheck] = field(default_factory=list)
+
+    @property
+    def evidence_cache_hit_rate(self) -> float:
+        if self.evidence_cache_lookups <= 0:
+            return 0.0
+        return round(self.evidence_cache_hits / self.evidence_cache_lookups, 4)
+
+    def to_dict(self) -> dict[str, object]:
+        payload = dataclasses.asdict(self)
+        payload["evidence_cache_hit_rate"] = self.evidence_cache_hit_rate
+        return payload
+
+
+def build_semantic_compaction_benchmark_report(
+    *,
+    scenario_name: str,
+    run_id: str,
+    generation: int,
+    context_budget_tokens: int,
+    raw_components: Mapping[str, str],
+    semantic_prompts: PromptBundle,
+    budget_only_prompts: PromptBundle,
+    semantic_build_latency_ms: float,
+    budget_only_build_latency_ms: float,
+    evidence_cache_hits: int = 0,
+    evidence_cache_lookups: int = 0,
+) -> SemanticCompactionBenchmarkReport:
+    """Compare semantic compaction against budget-only trimming on the same inputs."""
+    filtered_components = {key: value for key, value in raw_components.items() if value}
+    semantic_components = compact_prompt_components(filtered_components)
+    budget_only_components = _apply_budget(filtered_components, context_budget_tokens)
+    semantic_budgeted_components = _apply_budget(semantic_components, context_budget_tokens)
+
+    components = [
+        _build_component_benchmark(
+            name=key,
+            raw_text=filtered_components[key],
+            semantic_text=semantic_components.get(key, filtered_components[key]),
+            budget_only_text=budget_only_components.get(key, filtered_components[key]),
+            semantic_budgeted_text=semantic_budgeted_components.get(key, semantic_components.get(key, filtered_components[key])),
+        )
+        for key in sorted(filtered_components)
+    ]
+    semantic_signal_lines = sum(item.semantic_signal_lines_preserved for item in components)
+    budget_only_signal_lines = sum(item.budget_only_signal_lines_preserved for item in components)
+
+    semantic_variant = PromptVariantBenchmark(
+        name="semantic_compaction",
+        context_tokens=_total_tokens(semantic_budgeted_components),
+        total_prompt_tokens=_bundle_total_tokens(semantic_prompts),
+        role_prompt_tokens=_bundle_role_tokens(semantic_prompts),
+        build_latency_ms=round(semantic_build_latency_ms, 3),
+        signal_lines_preserved=semantic_signal_lines,
+    )
+    budget_only_variant = PromptVariantBenchmark(
+        name="budget_only",
+        context_tokens=_total_tokens(budget_only_components),
+        total_prompt_tokens=_bundle_total_tokens(budget_only_prompts),
+        role_prompt_tokens=_bundle_role_tokens(budget_only_prompts),
+        build_latency_ms=round(budget_only_build_latency_ms, 3),
+        signal_lines_preserved=budget_only_signal_lines,
+    )
+
+    regression_checks = [
+        RegressionCheck(
+            name="signal_preservation_non_regression",
+            passed=semantic_signal_lines >= budget_only_signal_lines,
+            detail=(
+                f"semantic preserved {semantic_signal_lines} signal lines; "
+                f"budget-only preserved {budget_only_signal_lines}"
+            ),
+        ),
+        RegressionCheck(
+            name="semantic_context_non_expansive",
+            passed=semantic_variant.context_tokens <= _total_tokens(filtered_components),
+            detail=(
+                f"semantic context tokens {semantic_variant.context_tokens}; "
+                f"raw context tokens {_total_tokens(filtered_components)}"
+            ),
+        ),
+        RegressionCheck(
+            name="evidence_cache_accounting_valid",
+            passed=evidence_cache_hits <= evidence_cache_lookups,
+            detail=(
+                f"cache hits {evidence_cache_hits}; "
+                f"cache lookups {evidence_cache_lookups}"
+            ),
+        ),
+    ]
+
+    return SemanticCompactionBenchmarkReport(
+        scenario_name=scenario_name,
+        run_id=run_id,
+        generation=generation,
+        context_budget_tokens=context_budget_tokens,
+        raw_context_tokens=_total_tokens(filtered_components),
+        semantic_variant=semantic_variant,
+        budget_only_variant=budget_only_variant,
+        components=components,
+        evidence_cache_hits=evidence_cache_hits,
+        evidence_cache_lookups=evidence_cache_lookups,
+        regression_checks=regression_checks,
+    )
+
+
+def _build_component_benchmark(
+    *,
+    name: str,
+    raw_text: str,
+    semantic_text: str,
+    budget_only_text: str,
+    semantic_budgeted_text: str,
+) -> CompactionComponentBenchmark:
+    signal_lines = extract_promotable_lines(raw_text)
+    return CompactionComponentBenchmark(
+        name=name,
+        raw_tokens=estimate_tokens(raw_text),
+        semantic_tokens=estimate_tokens(semantic_text),
+        budget_only_tokens=estimate_tokens(budget_only_text),
+        semantic_budgeted_tokens=estimate_tokens(semantic_budgeted_text),
+        signal_lines=signal_lines,
+        semantic_signal_lines_preserved=_count_preserved_signal_lines(signal_lines, semantic_budgeted_text),
+        budget_only_signal_lines_preserved=_count_preserved_signal_lines(signal_lines, budget_only_text),
+    )
+
+
+def _apply_budget(components: Mapping[str, str], context_budget_tokens: int) -> dict[str, str]:
+    if context_budget_tokens <= 0:
+        return dict(components)
+    return ContextBudget(max_tokens=context_budget_tokens).apply(dict(components))
+
+
+def _total_tokens(components: Mapping[str, str]) -> int:
+    return sum(estimate_tokens(value) for value in components.values())
+
+
+def _bundle_role_tokens(bundle: PromptBundle) -> dict[str, int]:
+    return {
+        "competitor": estimate_tokens(bundle.competitor),
+        "analyst": estimate_tokens(bundle.analyst),
+        "coach": estimate_tokens(bundle.coach),
+        "architect": estimate_tokens(bundle.architect),
+    }
+
+
+def _bundle_total_tokens(bundle: PromptBundle) -> int:
+    return sum(_bundle_role_tokens(bundle).values())
+
+
+def _count_preserved_signal_lines(signal_lines: list[str], text: str) -> int:
+    normalized_text = _normalize(text)
+    return sum(
+        1
+        for line in signal_lines
+        if (normalized_line := _normalize(line)) and normalized_line in normalized_text
+    )
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", text.lower())).strip()

--- a/autocontext/src/autocontext/loop/stage_types.py
+++ b/autocontext/src/autocontext/loop/stage_types.py
@@ -56,6 +56,7 @@ class GenerationContext:
     base_lessons: str = ""
     exploration_metadata: dict[str, Any] = field(default_factory=dict)
     cost_control_metadata: dict[str, Any] = field(default_factory=dict)
+    semantic_compaction_benchmark: dict[str, Any] | None = None
 
     # Pipeline wiring: tuning proposal from architect (AR-6)
     tuning_proposal: TuningConfig | None = None

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -128,7 +128,11 @@ def _evidence_source_run_ids(ctx: GenerationContext, *, artifacts: ArtifactStore
         return []
 
 
-def _materialize_evidence_manifests(ctx: GenerationContext, *, artifacts: ArtifactStore) -> dict[str, str]:
+def _materialize_evidence_manifests(
+    ctx: GenerationContext,
+    *,
+    artifacts: ArtifactStore,
+) -> tuple[dict[str, str], Any]:
     """Build the evidence workspace and render role-specific prompt manifests."""
     from autocontext.evidence import materialize_workspace, render_evidence_manifest
 
@@ -141,9 +145,66 @@ def _materialize_evidence_manifests(ctx: GenerationContext, *, artifacts: Artifa
         scenario_name=ctx.scenario_name,
         scan_for_secrets=True,
     )
+    return (
+        {
+            "analyst": render_evidence_manifest(workspace, role="analyst"),
+            "architect": render_evidence_manifest(workspace, role="architect"),
+        },
+        workspace,
+    )
+
+
+def _benchmarkable_prompt_components(
+    *,
+    current_playbook: str,
+    score_trajectory: str,
+    operational_lessons: str,
+    available_tools: str,
+    recent_analysis: str,
+    analyst_feedback: str,
+    analyst_attribution: str,
+    coach_attribution: str,
+    architect_attribution: str,
+    coach_competitor_hints: str,
+    coach_hint_feedback: str,
+    experiment_log: str,
+    dead_ends: str,
+    research_protocol: str,
+    session_reports: str,
+    architect_tool_usage_report: str,
+    environment_snapshot: str,
+    evidence_manifest: str,
+    evidence_manifests: dict[str, str] | None,
+    notebook_contexts: dict[str, str] | None,
+) -> dict[str, str]:
+    """Collect prompt-facing context components for benchmarking and observability."""
+    _evidence = dict(evidence_manifests or {})
+    _nb = dict(notebook_contexts or {})
     return {
-        "analyst": render_evidence_manifest(workspace, role="analyst"),
-        "architect": render_evidence_manifest(workspace, role="architect"),
+        "playbook": current_playbook,
+        "trajectory": score_trajectory,
+        "lessons": operational_lessons,
+        "tools": available_tools,
+        "analysis": recent_analysis,
+        "analyst_feedback": analyst_feedback,
+        "analyst_attribution": analyst_attribution,
+        "coach_attribution": coach_attribution,
+        "architect_attribution": architect_attribution,
+        "hints": coach_competitor_hints,
+        "coach_hint_feedback": coach_hint_feedback,
+        "experiment_log": experiment_log,
+        "dead_ends": dead_ends,
+        "research_protocol": research_protocol,
+        "session_reports": session_reports,
+        "tool_usage_report": architect_tool_usage_report,
+        "environment_snapshot": environment_snapshot,
+        "evidence_manifest": evidence_manifest,
+        "evidence_manifest_analyst": _evidence.get("analyst", evidence_manifest),
+        "evidence_manifest_architect": _evidence.get("architect", evidence_manifest),
+        "notebook_competitor": _nb.get("competitor", ""),
+        "notebook_analyst": _nb.get("analyst", ""),
+        "notebook_coach": _nb.get("coach", ""),
+        "notebook_architect": _nb.get("architect", ""),
     }
 
 
@@ -296,6 +357,12 @@ def stage_knowledge_setup(
     tool_usage_report = "" if ablation else _load_architect_tool_usage_report(ctx, artifacts=artifacts)
     weakness_reports = "" if ablation else artifacts.read_latest_weakness_reports_markdown(ctx.scenario_name)
     progress_reports = "" if ablation else artifacts.read_latest_progress_reports_markdown(ctx.scenario_name)
+    session_reports = "" if ablation else artifacts.read_latest_session_reports(ctx.scenario_name)
+    if not isinstance(session_reports, str):
+        session_reports = ""
+    dead_ends = "" if ablation else artifacts.read_dead_ends(ctx.scenario_name)
+    if not isinstance(dead_ends, str):
+        dead_ends = ""
     score_trajectory = "" if ablation else trajectory_builder.build_trajectory(ctx.run_id)
     strategy_registry = "" if ablation else trajectory_builder.build_strategy_registry(ctx.run_id)
     coach_hints_for_prompt = "" if ablation else ctx.coach_competitor_hints
@@ -326,8 +393,11 @@ def stage_knowledge_setup(
                 logger.warning("Failed to parse tuning.json for %s", ctx.scenario_name)
 
     # #166 - Apply protocol tuning overrides when protocol_enabled
+    research_protocol = "" if ablation else artifacts.read_research_protocol(ctx.scenario_name)
+    if not isinstance(research_protocol, str):
+        research_protocol = ""
     if ctx.settings.protocol_enabled:
-        raw_protocol = artifacts.read_research_protocol(ctx.scenario_name)
+        raw_protocol = research_protocol
         if raw_protocol:
             protocol = parse_research_protocol(raw_protocol)
             # Apply exploration mode from protocol
@@ -369,6 +439,8 @@ def stage_knowledge_setup(
     strategy_interface = scenario.describe_strategy_interface()
     evidence_manifest = ""
     evidence_manifests: dict[str, str] | None = None
+    evidence_cache_hits = 0
+    evidence_cache_lookups = 0
     notebook_contexts: dict[str, str] | None = None
     active_harness_mutations = [] if ablation else load_active_harness_mutations(artifacts, ctx.scenario_name)
     if not ablation:
@@ -401,40 +473,99 @@ def stage_knowledge_setup(
         experiment_log = f"{experiment_log}\n\n{context_policy_block}".strip() if experiment_log else context_policy_block
     if not ablation and ctx.settings.evidence_workspace_enabled:
         try:
-            evidence_manifests = _materialize_evidence_manifests(ctx, artifacts=artifacts)
+            evidence_manifests, evidence_workspace = _materialize_evidence_manifests(ctx, artifacts=artifacts)
             evidence_manifest = evidence_manifests.get("analyst", "")
+            evidence_cache_lookups = 1
+            evidence_cache_hits = int(bool(getattr(evidence_workspace, "cache_hit", False)))
         except Exception:
             logger.warning("failed to materialize evidence workspace for %s", ctx.scenario_name, exc_info=True)
 
-    prompts = build_prompt_bundle(
-        scenario_rules=scenario.describe_rules(),
-        strategy_interface=strategy_interface,
-        evaluation_criteria=scenario.describe_evaluation_criteria(),
-        previous_summary=summary_text,
-        observation=observation,
-        current_playbook=playbook,
-        available_tools=tool_context,
-        operational_lessons=skills_context,
-        replay_narrative="" if ablation else ctx.replay_narrative,
-        coach_competitor_hints=coach_hints_for_prompt,
-        coach_hint_feedback=coach_hint_feedback,
-        recent_analysis=recent_analysis,
-        analyst_feedback=analyst_feedback,
-        analyst_attribution=analyst_attribution,
-        coach_attribution=coach_attribution,
-        architect_attribution=architect_attribution,
-        score_trajectory=score_trajectory,
-        strategy_registry=strategy_registry,
-        progress_json=progress_json_str,
-        experiment_log=experiment_log,
-        architect_tool_usage_report=tool_usage_report,
-        constraint_mode=ctx.settings.constraint_prompts_enabled,
-        context_budget_tokens=ctx.settings.context_budget_tokens,
-        notebook_contexts=notebook_contexts,
-        environment_snapshot="" if ablation else ctx.environment_snapshot,
-        evidence_manifest=evidence_manifest,
-        evidence_manifests=evidence_manifests,
-    )
+    environment_snapshot = "" if ablation else ctx.environment_snapshot
+    prompt_kwargs: dict[str, Any] = {
+        "scenario_rules": scenario.describe_rules(),
+        "strategy_interface": strategy_interface,
+        "evaluation_criteria": scenario.describe_evaluation_criteria(),
+        "previous_summary": summary_text,
+        "observation": observation,
+        "current_playbook": playbook,
+        "available_tools": tool_context,
+        "operational_lessons": skills_context,
+        "replay_narrative": "" if ablation else ctx.replay_narrative,
+        "coach_competitor_hints": coach_hints_for_prompt,
+        "coach_hint_feedback": coach_hint_feedback,
+        "recent_analysis": recent_analysis,
+        "analyst_feedback": analyst_feedback,
+        "analyst_attribution": analyst_attribution,
+        "coach_attribution": coach_attribution,
+        "architect_attribution": architect_attribution,
+        "score_trajectory": score_trajectory,
+        "strategy_registry": strategy_registry,
+        "progress_json": progress_json_str,
+        "experiment_log": experiment_log,
+        "dead_ends": dead_ends,
+        "research_protocol": research_protocol,
+        "session_reports": session_reports,
+        "architect_tool_usage_report": tool_usage_report,
+        "constraint_mode": ctx.settings.constraint_prompts_enabled,
+        "context_budget_tokens": ctx.settings.context_budget_tokens,
+        "notebook_contexts": notebook_contexts,
+        "environment_snapshot": environment_snapshot,
+        "evidence_manifest": evidence_manifest,
+        "evidence_manifests": evidence_manifests,
+    }
+    build_start = time.perf_counter()
+    prompts = build_prompt_bundle(**prompt_kwargs)
+    semantic_build_latency_ms = (time.perf_counter() - build_start) * 1000.0
+    if ctx.settings.semantic_compaction_benchmark_enabled:
+        from autocontext.knowledge.semantic_compaction_benchmark import (
+            build_semantic_compaction_benchmark_report,
+        )
+
+        baseline_start = time.perf_counter()
+        budget_only_prompts = build_prompt_bundle(**prompt_kwargs, semantic_compaction=False)
+        budget_only_build_latency_ms = (time.perf_counter() - baseline_start) * 1000.0
+        benchmark_report = build_semantic_compaction_benchmark_report(
+            scenario_name=ctx.scenario_name,
+            run_id=ctx.run_id,
+            generation=ctx.generation,
+            context_budget_tokens=ctx.settings.context_budget_tokens,
+            raw_components=_benchmarkable_prompt_components(
+                current_playbook=playbook,
+                score_trajectory=score_trajectory,
+                operational_lessons=skills_context,
+                available_tools=tool_context,
+                recent_analysis=recent_analysis,
+                analyst_feedback=analyst_feedback,
+                analyst_attribution=analyst_attribution,
+                coach_attribution=coach_attribution,
+                architect_attribution=architect_attribution,
+                coach_competitor_hints=coach_hints_for_prompt,
+                coach_hint_feedback=coach_hint_feedback,
+                experiment_log=experiment_log,
+                dead_ends=dead_ends,
+                research_protocol=research_protocol,
+                session_reports=session_reports,
+                architect_tool_usage_report=tool_usage_report,
+                environment_snapshot=environment_snapshot,
+                evidence_manifest=evidence_manifest,
+                evidence_manifests=evidence_manifests,
+                notebook_contexts=notebook_contexts,
+            ),
+            semantic_prompts=prompts,
+            budget_only_prompts=budget_only_prompts,
+            semantic_build_latency_ms=semantic_build_latency_ms,
+            budget_only_build_latency_ms=budget_only_build_latency_ms,
+            evidence_cache_hits=evidence_cache_hits,
+            evidence_cache_lookups=evidence_cache_lookups,
+        )
+        artifacts.write_semantic_compaction_report(
+            ctx.scenario_name,
+            ctx.run_id,
+            ctx.generation,
+            benchmark_report,
+        )
+        ctx.semantic_compaction_benchmark = benchmark_report.to_dict()
+
     prompts = apply_harness_mutations_to_prompts(prompts, active_harness_mutations)
 
     ctx.applied_competitor_hints = "" if ablation else coach_hints_for_prompt

--- a/autocontext/src/autocontext/prompts/templates.py
+++ b/autocontext/src/autocontext/prompts/templates.py
@@ -82,29 +82,31 @@ def build_prompt_bundle(
     environment_snapshot: str = "",
     evidence_manifest: str = "",
     evidence_manifests: dict[str, str] | None = None,
+    semantic_compaction: bool = True,
 ) -> PromptBundle:
     _nb = dict(notebook_contexts or {})
     _evidence = dict(evidence_manifests or {})
     analyst_evidence_manifest = _evidence.get("analyst", evidence_manifest)
     architect_evidence_manifest = _evidence.get("architect", evidence_manifest)
-    compacted = compact_prompt_components(
-        {
-            "playbook": current_playbook,
-            "trajectory": score_trajectory,
-            "lessons": operational_lessons,
-            "analysis": recent_analysis,
-            "experiment_log": experiment_log,
-            "research_protocol": research_protocol,
-            "session_reports": session_reports,
-        }
-    )
-    current_playbook = compacted["playbook"]
-    score_trajectory = compacted["trajectory"]
-    operational_lessons = compacted["lessons"]
-    recent_analysis = compacted["analysis"]
-    experiment_log = compacted["experiment_log"]
-    research_protocol = compacted["research_protocol"]
-    session_reports = compacted["session_reports"]
+    if semantic_compaction:
+        compacted = compact_prompt_components(
+            {
+                "playbook": current_playbook,
+                "trajectory": score_trajectory,
+                "lessons": operational_lessons,
+                "analysis": recent_analysis,
+                "experiment_log": experiment_log,
+                "research_protocol": research_protocol,
+                "session_reports": session_reports,
+            }
+        )
+        current_playbook = compacted["playbook"]
+        score_trajectory = compacted["trajectory"]
+        operational_lessons = compacted["lessons"]
+        recent_analysis = compacted["analysis"]
+        experiment_log = compacted["experiment_log"]
+        research_protocol = compacted["research_protocol"]
+        session_reports = compacted["session_reports"]
     if context_budget_tokens > 0:
         budget = ContextBudget(max_tokens=context_budget_tokens)
         budgeted = budget.apply(

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -1037,6 +1037,22 @@ class ArtifactStore:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
 
+    def _semantic_compaction_report_dir(self, scenario_name: str) -> Path:
+        return self.knowledge_root / scenario_name / "semantic_compaction_reports"
+
+    def write_semantic_compaction_report(
+        self,
+        scenario_name: str,
+        run_id: str,
+        generation: int,
+        report: DictSerializable,
+    ) -> None:
+        """Persist a semantic compaction benchmark report as JSON."""
+        report_dir = self._semantic_compaction_report_dir(scenario_name)
+        report_dir.mkdir(parents=True, exist_ok=True)
+        path = report_dir / f"{run_id}_gen_{generation}.json"
+        self.write_json(path, report.to_dict())
+
     # --- Normalized progress reports (AC-190) ---------------------------------
 
     def _progress_report_dir(self, scenario_name: str) -> Path:

--- a/autocontext/tests/test_generation_stages.py
+++ b/autocontext/tests/test_generation_stages.py
@@ -446,6 +446,109 @@ class TestStageKnowledgeSetup:
         assert "## Prior-Run Evidence" in result.prompts.analyst
         assert "## Prior-Run Evidence" not in result.prompts.competitor
 
+    def test_writes_semantic_compaction_benchmark_report(self, tmp_path) -> None:
+        settings = AppSettings(
+            agent_provider="deterministic",
+            context_budget_tokens=180,
+            semantic_compaction_benchmark_enabled=True,
+            evidence_workspace_enabled=True,
+            evidence_workspace_budget_mb=1,
+        )
+        artifacts = MagicMock()
+        artifacts.runs_root = tmp_path / "runs"
+        artifacts.knowledge_root = tmp_path / "knowledge"
+        artifacts.read_playbook.return_value = (
+            "## Lessons\n"
+            + ("filler paragraph\n" * 140)
+            + "- Root cause: stale hints kept pushing the same failing opening.\n"
+            + "- Recommendation: preserve the rollback guard and diversify early probes.\n"
+        )
+        artifacts.read_tool_context.return_value = ""
+        artifacts.read_skills.return_value = ""
+        artifacts.read_mutation_replay.return_value = ""
+        artifacts.read_latest_weakness_reports_markdown.return_value = ""
+        artifacts.read_latest_progress_reports_markdown.return_value = ""
+        artifacts.read_latest_advance_analysis.return_value = ""
+        artifacts.read_progress.return_value = None
+        artifacts.read_tool_usage_report.return_value = ""
+        artifacts.read_notebook.return_value = None
+
+        prior_run_dir = artifacts.runs_root / "run_prior"
+        prior_run_dir.mkdir(parents=True)
+        (prior_run_dir / "events.ndjson").write_text('{"event":"start"}\n', encoding="utf-8")
+
+        snapshots_dir = artifacts.knowledge_root / "test_scenario" / "snapshots" / "run_prior"
+        snapshots_dir.mkdir(parents=True)
+        (artifacts.knowledge_root / "test_scenario" / "playbook.md").parent.mkdir(parents=True, exist_ok=True)
+        (artifacts.knowledge_root / "test_scenario" / "playbook.md").write_text("# Playbook\n", encoding="utf-8")
+
+        trajectory = MagicMock()
+        trajectory.build_trajectory.return_value = ""
+        trajectory.build_strategy_registry.return_value = ""
+        trajectory.build_experiment_log.return_value = (
+            "## Experiment Log\n\n"
+            "### Generation 1\n"
+            + ("noise line\n" * 120)
+            + "\n### Generation 9\n"
+            + "- Root cause: stale hints amplified retries.\n"
+        )
+        ctx = _make_ctx(settings=settings)
+
+        result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
+
+        artifacts.write_semantic_compaction_report.assert_called_once()
+        report = artifacts.write_semantic_compaction_report.call_args.args[3]
+        assert report.semantic_variant.signal_lines_preserved >= report.budget_only_variant.signal_lines_preserved
+        assert report.evidence_cache_lookups == 1
+        assert result.semantic_compaction_benchmark is not None
+        assert result.semantic_compaction_benchmark["context_budget_tokens"] == 180
+
+    def test_benchmark_report_records_evidence_cache_hits_on_repeat(self, tmp_path) -> None:
+        settings = AppSettings(
+            agent_provider="deterministic",
+            context_budget_tokens=180,
+            semantic_compaction_benchmark_enabled=True,
+            evidence_workspace_enabled=True,
+            evidence_workspace_budget_mb=1,
+        )
+        artifacts = MagicMock()
+        artifacts.runs_root = tmp_path / "runs"
+        artifacts.knowledge_root = tmp_path / "knowledge"
+        artifacts.read_playbook.return_value = ""
+        artifacts.read_tool_context.return_value = ""
+        artifacts.read_skills.return_value = ""
+        artifacts.read_mutation_replay.return_value = ""
+        artifacts.read_latest_weakness_reports_markdown.return_value = ""
+        artifacts.read_latest_progress_reports_markdown.return_value = ""
+        artifacts.read_latest_advance_analysis.return_value = ""
+        artifacts.read_progress.return_value = None
+        artifacts.read_tool_usage_report.return_value = ""
+        artifacts.read_notebook.return_value = None
+
+        prior_run_dir = artifacts.runs_root / "run_prior"
+        prior_run_dir.mkdir(parents=True)
+        (prior_run_dir / "events.ndjson").write_text('{"event":"start"}\n', encoding="utf-8")
+        snapshots_dir = artifacts.knowledge_root / "test_scenario" / "snapshots" / "run_prior"
+        snapshots_dir.mkdir(parents=True)
+        (artifacts.knowledge_root / "test_scenario" / "playbook.md").parent.mkdir(parents=True, exist_ok=True)
+        (artifacts.knowledge_root / "test_scenario" / "playbook.md").write_text("# Playbook\n", encoding="utf-8")
+
+        trajectory = MagicMock()
+        trajectory.build_trajectory.return_value = ""
+        trajectory.build_strategy_registry.return_value = ""
+        trajectory.build_experiment_log.return_value = ""
+
+        first = _make_ctx(settings=settings)
+        stage_knowledge_setup(first, artifacts=artifacts, trajectory_builder=trajectory)
+        artifacts.write_semantic_compaction_report.reset_mock()
+
+        second = _make_ctx(settings=settings)
+        stage_knowledge_setup(second, artifacts=artifacts, trajectory_builder=trajectory)
+
+        report = artifacts.write_semantic_compaction_report.call_args.args[3]
+        assert report.evidence_cache_hits == 1
+        assert report.evidence_cache_hit_rate == 1.0
+
     def test_includes_prior_analyst_feedback_in_analyst_prompt(self) -> None:
         artifacts = MagicMock()
         artifacts.read_playbook.return_value = ""

--- a/autocontext/tests/test_semantic_compaction_benchmark.py
+++ b/autocontext/tests/test_semantic_compaction_benchmark.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+from autocontext.scenarios.base import Observation
+
+
+def test_benchmark_report_measures_semantic_signal_preservation() -> None:
+    from autocontext.knowledge.semantic_compaction_benchmark import (
+        build_semantic_compaction_benchmark_report,
+    )
+    from autocontext.prompts.templates import build_prompt_bundle
+
+    observation = Observation(narrative="Investigate stalled optimizer", state={}, constraints=[])
+    prompt_kwargs = {
+        "scenario_rules": "rules",
+        "strategy_interface": "interface",
+        "evaluation_criteria": "criteria",
+        "previous_summary": "best 0.5",
+        "observation": observation,
+        "current_playbook": (
+            "## Lessons\n"
+            + ("filler paragraph\n" * 140)
+            + "- Root cause: stale hints kept pushing the same failing opening.\n"
+            + "- Recommendation: preserve the rollback guard and diversify early probes.\n"
+        ),
+        "available_tools": "tools",
+        "experiment_log": (
+            "## Experiment Log\n\n"
+            "### Generation 1\n"
+            + ("noise line\n" * 120)
+            + "\n### Generation 9\n"
+            + "- Root cause: stale hints amplified retries.\n"
+            + "- Recommendation: promote fresh evidence before tuning.\n"
+        ),
+        "session_reports": (
+            "# Session Report: run_old\n"
+            + ("filler paragraph\n" * 120)
+            + "## Findings\n"
+            + "- Preserve the rollback guard after failed harness mutations.\n"
+        ),
+        "context_budget_tokens": 180,
+    }
+    raw_components = {
+        "playbook": prompt_kwargs["current_playbook"],
+        "experiment_log": prompt_kwargs["experiment_log"],
+        "session_reports": prompt_kwargs["session_reports"],
+    }
+
+    semantic_prompts = build_prompt_bundle(**prompt_kwargs)
+    budget_only_prompts = build_prompt_bundle(**prompt_kwargs, semantic_compaction=False)
+    report = build_semantic_compaction_benchmark_report(
+        scenario_name="test_scenario",
+        run_id="run_001",
+        generation=3,
+        context_budget_tokens=180,
+        raw_components=raw_components,
+        semantic_prompts=semantic_prompts,
+        budget_only_prompts=budget_only_prompts,
+        semantic_build_latency_ms=4.5,
+        budget_only_build_latency_ms=2.0,
+        evidence_cache_hits=1,
+        evidence_cache_lookups=2,
+    )
+
+    assert report.raw_context_tokens > report.semantic_variant.context_tokens
+    assert report.semantic_variant.signal_lines_preserved >= report.budget_only_variant.signal_lines_preserved
+    assert report.evidence_cache_hit_rate == pytest.approx(0.5)
+    assert any(check.name == "signal_preservation_non_regression" and check.passed for check in report.regression_checks)
+


### PR DESCRIPTION
## Summary
- add a semantic compaction benchmark domain that compares semantic compaction against budget-only trimming on the same prompt inputs
- capture prompt-assembly observability during stage_knowledge_setup, including token deltas, signal-preservation checks, build latency, and evidence workspace cache hit accounting
- persist per-generation semantic compaction reports and cover the new path with focused benchmark and stage tests

## Verification
- uv run pytest tests/test_semantic_compaction_benchmark.py tests/test_generation_stages.py tests/test_build_prompt_bundle_semantic_compaction.py tests/test_context_budget.py tests/test_evidence_workspace.py tests/test_loop_integration_snapshot_evidence.py tests/test_investigation_engine.py
- uv run ruff check src tests
- uv run mypy src