### PR TITLE
fix: raise solve runtime floor for generated scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,11 +145,20 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - uses: actions/setup-node@v5
+      - id: setup-node
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: "npm"
           cache-dependency-path: ts/package-lock.json
+      - name: Reuse setup-node headers for native addons
+        shell: bash
+        run: |
+          arch="${{ runner.arch }}"
+          arch="${arch,,}"
+          nodedir="${RUNNER_TOOL_CACHE}/node/${{ steps.setup-node.outputs.node-version }}/${arch}"
+          test -d "$nodedir/include/node"
+          echo "npm_config_nodedir=$nodedir" >> "$GITHUB_ENV"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - id: setup-node
-        uses: actions/setup-node@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: "npm"
@@ -154,9 +153,7 @@ jobs:
       - name: Reuse setup-node headers for native addons
         shell: bash
         run: |
-          arch="${{ runner.arch }}"
-          arch="${arch,,}"
-          nodedir="${RUNNER_TOOL_CACHE}/node/${{ steps.setup-node.outputs.node-version }}/${arch}"
+          nodedir="$(dirname "$(dirname "$(command -v node)")")"
           test -d "$nodedir/include/node"
           echo "npm_config_nodedir=$nodedir" >> "$GITHUB_ENV"
       - name: Install uv

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -52,6 +52,7 @@ _SIMULATION_INTERFACE_HINT_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 _AGENT_TASK_INTERFACE_HINT_RE = re.compile(r"\bagent[- ]task evaluation\b", re.IGNORECASE)
+_SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS = 600.0
 @dataclass
 class SolveJob:
     job_id: str
@@ -403,7 +404,7 @@ class SolveScenarioExecutor:
 
         from autocontext.loop.generation_runner import GenerationRunner
 
-        runner = GenerationRunner(self._settings)
+        runner = GenerationRunner(_settings_for_solve_runtime(self._settings))
         runner.migrate(self._migrations_dir)
         run_id = f"solve_{scenario_name}_{uuid.uuid4().hex[:8]}"
         summary = runner.run(scenario_name, generations, run_id)
@@ -463,7 +464,7 @@ class SolveScenarioExecutor:
 
         try:
             provider, provider_model = resolve_role_runtime(
-                self._settings,
+                _settings_for_solve_runtime(self._settings),
                 role="competitor",
                 scenario_name=scenario_name,
                 sqlite=sqlite,
@@ -706,7 +707,8 @@ class SolveManager:
             from autocontext.agents.llm_client import build_client_from_settings
             from autocontext.agents.subagent_runtime import SubagentRuntime
 
-            client = build_client_from_settings(self._settings)
+            creator_settings = _settings_for_solve_runtime(self._settings)
+            client = build_client_from_settings(creator_settings)
             runtime = SubagentRuntime(client)
             designer_model = self._settings.model_translator or self._settings.model_architect
             llm_fn = _llm_fn_from_client(client, designer_model)
@@ -743,3 +745,11 @@ class SolveManager:
         if job is None or job.status != "completed":
             return None
         return job.result
+
+
+def _settings_for_solve_runtime(settings: AppSettings) -> AppSettings:
+    if settings.agent_provider not in {"pi", "pi-rpc"}:
+        return settings
+    if float(settings.pi_timeout) >= _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS:
+        return settings
+    return settings.model_copy(update={"pi_timeout": _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS})

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -524,6 +525,155 @@ class TestSolveLLMFn:
         assert builder is not None
         assert builder._model == "translator-sonnet"
 
+    def test_build_creator_raises_pi_timeout_floor_for_solve_design(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solver import (
+            _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS,
+            SolveManager,
+        )
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            agent_provider="pi",
+            pi_timeout=300.0,
+        )
+        manager = SolveManager(settings)
+        captured: dict[str, float] = {}
+
+        class _Client:
+            pass
+
+        class _Runtime:
+            def __init__(self, client: object) -> None:
+                self.client = client
+
+        def _fake_build_client(settings: AppSettings) -> _Client:
+            captured["pi_timeout"] = float(settings.pi_timeout)
+            return _Client()
+
+        monkeypatch.setattr(
+            "autocontext.agents.llm_client.build_client_from_settings",
+            _fake_build_client,
+        )
+        monkeypatch.setattr(
+            "autocontext.agents.subagent_runtime.SubagentRuntime",
+            _Runtime,
+        )
+
+        builder = manager._build_creator()
+
+        assert builder is not None
+        assert captured["pi_timeout"] == _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS
+
+    def test_task_like_executor_raises_pi_timeout_floor_for_solve_runtime(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solver import (
+            _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS,
+            SolveScenarioExecutor,
+        )
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+            agent_provider="pi",
+            pi_timeout=300.0,
+        )
+        scenario_name = "solve_runtime_timeout_floor"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        SCENARIO_REGISTRY[scenario_name] = _SolveAgentTask
+        provider = _StubProvider("improved draft")
+        captured: dict[str, float] = {}
+
+        def _fake_resolve_role_runtime(settings: AppSettings, **kwargs: object) -> tuple[_StubProvider, str]:
+            del kwargs
+            captured["pi_timeout"] = float(settings.pi_timeout)
+            return provider, "test-model"
+
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.resolve_role_runtime",
+            _fake_resolve_role_runtime,
+        )
+
+        try:
+            summary = SolveScenarioExecutor(settings).execute(
+                scenario_name=scenario_name,
+                family_name="agent_task",
+                generations=1,
+            )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        assert summary.best_score == 1.0
+        assert captured["pi_timeout"] == _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS
+
+    def test_generation_runner_executor_raises_pi_timeout_floor_for_solve_runtime(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solver import (
+            _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS,
+            SolveScenarioExecutor,
+        )
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+            agent_provider="pi",
+            pi_timeout=300.0,
+        )
+        scenario_name = "solve_generation_runner_timeout_floor"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        captured: dict[str, float] = {}
+
+        class _Scenario:
+            name = scenario_name
+
+        class _FakeGenerationRunner:
+            def __init__(self, settings: AppSettings) -> None:
+                captured["pi_timeout"] = float(settings.pi_timeout)
+
+            def migrate(self, migrations_dir: Path) -> None:
+                del migrations_dir
+
+            def run(self, scenario_name: str, generations: int, run_id: str) -> SimpleNamespace:
+                return SimpleNamespace(
+                    run_id=run_id,
+                    generations_executed=generations,
+                    best_score=0.73,
+                    scenario_name=scenario_name,
+                )
+
+        SCENARIO_REGISTRY[scenario_name] = _Scenario
+        monkeypatch.setattr(
+            "autocontext.loop.generation_runner.GenerationRunner",
+            _FakeGenerationRunner,
+        )
+
+        try:
+            summary = SolveScenarioExecutor(settings).execute(
+                scenario_name=scenario_name,
+                family_name="negotiation",
+                generations=2,
+            )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        assert summary.best_score == 0.73
+        assert summary.generations_executed == 2
+        assert captured["pi_timeout"] == _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS
 
 class TestSolveScenarioExecutor:
     def test_runs_agent_task_scenarios_through_task_loop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- fix the solve execution boundary so non-task-like generated scenarios use the same internal Pi timeout floor as other solve runtime paths
- add failing-first regression coverage for generated-scenario solve execution through `GenerationRunner`

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run --group dev python -m pytest tests/test_knowledge_solver.py tests/test_cli_solve_runtime.py -x --tb=short`
- [x] `cd autocontext && uv run --group dev ruff check src/autocontext/knowledge/solver.py tests/test_knowledge_solver.py`
- [x] additional manual verification described below

Manual verification:
- failing-first targeted red before the fix:
  - `tests/test_knowledge_solver.py::TestSolveLLMFn::test_generation_runner_executor_raises_pi_timeout_floor_for_solve_runtime`
  - failure: `assert 300.0 == 600.0`
- focused live repro on clean stacked base:
  - root: `/tmp/ac589-repro-ccefZM`
  - result: `1 / 3` failed at default settings
- timeout-floor control:
  - root: `/tmp/ac589-timeout600-TKLWCt`
  - result: `3 / 3` passed with `AUTOCONTEXT_PI_TIMEOUT=600`
- post-fix live validation:
  - root: `/tmp/ac589-live-fixed-CwzQzE`
  - command: `uv run --group dev autoctx solve --description "<AC-385 issue body>" --json`
  - result: `3 / 3` successful default-timeout live runs

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

Bounded-context decision:
- the bug was not scenario creation or family routing
- it was the non-task-like solve execution path instantiating `GenerationRunner` with raw settings instead of the existing solve runtime timeout-floor helper
- the fix keeps behavior DRY by reusing `_settings_for_solve_runtime(...)` rather than introducing a second solve timeout path
