### PR TITLE
AC-599: Add Python Chrome CDP backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes in this section are on the branch/repo after `0.4.4` and are not part of
 ### Added
 
 - Added a shared browser exploration contract and package-safe configuration surface across Python and TypeScript, including canonical schemas, validation helpers, secure `AUTOCONTEXT_BROWSER_*` defaults, and policy helpers.
+- Added a thin Python Chrome CDP browser backend with debugger-target discovery, evidence persistence, WebSocket transport, runtime factory, and policy-checked session actions.
 
 ## [0.4.4] - 2026-04-20
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -237,6 +237,7 @@ Common settings:
 - `AUTOCONTEXT_BROWSER_ALLOW_DOWNLOADS` and `AUTOCONTEXT_BROWSER_DOWNLOADS_ROOT`
 
 Browser exploration defaults to a secure disabled posture and uses the shared contract described in [../docs/browser-exploration-contract.md](../docs/browser-exploration-contract.md).
+The Python package includes a thin Chrome CDP backend that attaches to an existing debugger endpoint, enforces the browser allowlist, and stores browser evidence under run-local roots.
 
 See the repo-level [.env.example](../.env.example) for a working starting point.
 

--- a/autocontext/src/autocontext/integrations/browser/__init__.py
+++ b/autocontext/src/autocontext/integrations/browser/__init__.py
@@ -1,5 +1,23 @@
 """Browser exploration contract, settings, and policy helpers."""
 
+from autocontext.integrations.browser.chrome_cdp import ChromeCdpSession, ChromeCdpTransport
+from autocontext.integrations.browser.chrome_cdp_discovery import (
+    ChromeCdpDiscoveryError,
+    ChromeCdpTarget,
+    ChromeCdpTargetDiscovery,
+    ChromeCdpTargetDiscoveryPort,
+    select_chrome_cdp_target,
+)
+from autocontext.integrations.browser.chrome_cdp_runtime import ChromeCdpRuntime
+from autocontext.integrations.browser.chrome_cdp_transport import (
+    ChromeCdpTransportError,
+    ChromeCdpWebSocketTransport,
+)
+from autocontext.integrations.browser.evidence import BrowserArtifactPaths, BrowserEvidenceStore
+from autocontext.integrations.browser.factory import (
+    ConfiguredBrowserRuntime,
+    browser_runtime_from_settings,
+)
 from autocontext.integrations.browser.policy import (
     BrowserPolicyDecision,
     build_default_browser_session_config,
@@ -19,11 +37,25 @@ from autocontext.integrations.browser.validate import (
 )
 
 __all__ = [
+    "BrowserArtifactPaths",
+    "BrowserEvidenceStore",
+    "ConfiguredBrowserRuntime",
+    "ChromeCdpDiscoveryError",
+    "ChromeCdpSession",
+    "ChromeCdpTransport",
+    "ChromeCdpRuntime",
+    "ChromeCdpTarget",
+    "ChromeCdpTargetDiscovery",
+    "ChromeCdpTargetDiscoveryPort",
+    "ChromeCdpTransportError",
+    "ChromeCdpWebSocketTransport",
     "BrowserPolicyDecision",
+    "browser_runtime_from_settings",
     "build_default_browser_session_config",
     "evaluate_browser_action_policy",
     "normalize_browser_allowed_domains",
     "resolve_browser_session_config",
+    "select_chrome_cdp_target",
     "validate_browser_action",
     "validate_browser_action_dict",
     "validate_browser_audit_event",

--- a/autocontext/src/autocontext/integrations/browser/chrome_cdp.py
+++ b/autocontext/src/autocontext/integrations/browser/chrome_cdp.py
@@ -1,0 +1,410 @@
+"""Thin CDP-backed browser session helpers."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any, Protocol
+from uuid import uuid4
+
+from autocontext.integrations.browser.contract.models import (
+    BrowserAuditEvent,
+    BrowserSessionConfig,
+    BrowserSnapshot,
+)
+from autocontext.integrations.browser.contract.types import BrowserAction
+from autocontext.integrations.browser.evidence import BrowserArtifactPaths, BrowserEvidenceStore
+from autocontext.integrations.browser.policy import (
+    BrowserPolicyDecision,
+    evaluate_browser_action_policy,
+)
+from autocontext.integrations.browser.types import BrowserSessionPort
+from autocontext.integrations.browser.validate import (
+    validate_browser_action,
+    validate_browser_audit_event,
+    validate_browser_snapshot,
+)
+
+_SNAPSHOT_EXPRESSION = """
+(() => {
+  const candidates = Array.from(
+    document.querySelectorAll("a,button,input,select,textarea,[role],[tabindex]")
+  ).slice(0, 200);
+  const refs = candidates.map((element, index) => ({
+    id: `@e${index + 1}`,
+    role: element.getAttribute("role") ?? element.tagName.toLowerCase(),
+    name:
+      element.getAttribute("aria-label") ??
+      element.getAttribute("name") ??
+      element.textContent?.trim() ??
+      null,
+    text: element.textContent?.trim() ?? null,
+    selector: null,
+    disabled: element.hasAttribute("disabled"),
+  }));
+  return {
+    url: window.location.href,
+    title: document.title ?? "",
+    visibleText: document.body?.innerText ?? "",
+    refs,
+    html: document.documentElement?.outerHTML ?? "",
+  };
+})()
+""".strip()
+
+
+class ChromeCdpTransport(Protocol):
+    async def send(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]: ...
+    async def close(self) -> None: ...
+
+
+class ChromeCdpSession(BrowserSessionPort):
+    """Policy-aware CDP session wrapper with local evidence capture."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        config: BrowserSessionConfig,
+        transport: ChromeCdpTransport,
+        evidence_store: BrowserEvidenceStore | None = None,
+    ) -> None:
+        self.session_id = session_id
+        self.config = config
+        self.transport = transport
+        self.evidence_store = evidence_store
+        self._current_url = "about:blank"
+        self._domains_enabled = False
+        self._ref_selectors: dict[str, str] = {}
+
+    async def navigate(self, url: str) -> BrowserAuditEvent:
+        action = self._build_action("navigate", {"url": url})
+        decision = evaluate_browser_action_policy(self.config, action)
+        if not decision.allowed:
+            return self._record_action_result(
+                action=action,
+                decision=decision,
+                before_url=self._current_url,
+                after_url=self._current_url,
+                message="navigation blocked by browser policy",
+            )
+
+        await self._ensure_domains_enabled()
+        before_url = self._current_url
+        await self.transport.send("Page.navigate", {"url": url})
+        self._current_url = url
+        return self._record_action_result(
+            action=action,
+            decision=decision,
+            before_url=before_url,
+            after_url=url,
+            message="navigation allowed",
+        )
+
+    async def snapshot(self) -> BrowserSnapshot:
+        action = self._build_action(
+            "snapshot",
+            {
+                "captureHtml": True,
+                "captureScreenshot": bool(self.config.captureScreenshots),
+            },
+        )
+        await self._ensure_domains_enabled()
+
+        response = await self.transport.send(
+            "Runtime.evaluate",
+            {
+                "expression": _SNAPSHOT_EXPRESSION,
+                "returnByValue": True,
+                "awaitPromise": True,
+            },
+        )
+        payload = _extract_result_value(response)
+        refs = payload.get("refs")
+        parsed_refs = refs if isinstance(refs, list) else []
+        self._ref_selectors = {
+            str(ref.get("id")): str(ref.get("selector"))
+            for ref in parsed_refs
+            if isinstance(ref, dict) and ref.get("id") and ref.get("selector")
+        }
+
+        screenshot_base64: str | None = None
+        if bool(self.config.captureScreenshots):
+            screenshot_response = await self.transport.send("Page.captureScreenshot", {"format": "png"})
+            raw_data = screenshot_response.get("data")
+            screenshot_base64 = str(raw_data) if isinstance(raw_data, str) else None
+
+        artifacts = self._persist_snapshot_artifacts(
+            basename=str(action.actionId),
+            html=payload.get("html") if isinstance(payload.get("html"), str) else None,
+            screenshot_base64=screenshot_base64,
+        )
+
+        url = payload.get("url")
+        self._current_url = str(url) if isinstance(url, str) and url else self._current_url
+        return validate_browser_snapshot({
+            "schemaVersion": "1.0",
+            "sessionId": self.session_id,
+            "capturedAt": _utcnow(),
+            "url": self._current_url,
+            "title": str(payload.get("title") or ""),
+            "refs": parsed_refs,
+            "visibleText": str(payload.get("visibleText") or ""),
+            "htmlPath": artifacts["htmlPath"],
+            "screenshotPath": artifacts["screenshotPath"],
+        })
+
+    async def click(self, ref: str) -> BrowserAuditEvent:
+        action = self._build_action("click", {"ref": ref})
+        decision = evaluate_browser_action_policy(self.config, action)
+        if not decision.allowed:
+            return self._record_action_result(
+                action=action,
+                decision=decision,
+                before_url=self._current_url,
+                after_url=self._current_url,
+            )
+
+        await self._ensure_domains_enabled()
+        selector = self._selector_for_ref(ref)
+        await self.transport.send(
+            "Runtime.evaluate",
+            {
+                "expression": _click_expression(selector),
+                "returnByValue": True,
+                "awaitPromise": True,
+            },
+        )
+        return self._record_action_result(
+            action=action,
+            decision=decision,
+            before_url=self._current_url,
+            after_url=self._current_url,
+            message="click allowed",
+        )
+
+    async def fill(
+        self,
+        ref: str,
+        text: str,
+        *,
+        field_kind: str | None = None,
+    ) -> BrowserAuditEvent:
+        action = self._build_action("fill", {"ref": ref, "text": text, "fieldKind": field_kind})
+        decision = evaluate_browser_action_policy(self.config, action)
+        if not decision.allowed:
+            return self._record_action_result(
+                action=action,
+                decision=decision,
+                before_url=self._current_url,
+                after_url=self._current_url,
+                message="fill blocked by browser policy",
+            )
+
+        await self._ensure_domains_enabled()
+        selector = self._selector_for_ref(ref)
+        await self.transport.send(
+            "Runtime.evaluate",
+            {
+                "expression": _fill_expression(selector, text),
+                "returnByValue": True,
+                "awaitPromise": True,
+            },
+        )
+        return self._record_action_result(
+            action=action,
+            decision=decision,
+            before_url=self._current_url,
+            after_url=self._current_url,
+            message="fill allowed",
+        )
+
+    async def press(self, key: str) -> BrowserAuditEvent:
+        action = self._build_action("press", {"key": key})
+        decision = evaluate_browser_action_policy(self.config, action)
+        if not decision.allowed:
+            return self._record_action_result(
+                action=action,
+                decision=decision,
+                before_url=self._current_url,
+                after_url=self._current_url,
+            )
+
+        await self._ensure_domains_enabled()
+        await self.transport.send(
+            "Runtime.evaluate",
+            {
+                "expression": _press_expression(key),
+                "returnByValue": True,
+                "awaitPromise": True,
+            },
+        )
+        return self._record_action_result(
+            action=action,
+            decision=decision,
+            before_url=self._current_url,
+            after_url=self._current_url,
+            message="key press allowed",
+        )
+
+    async def screenshot(self, name: str) -> BrowserAuditEvent:
+        action = self._build_action("screenshot", {"name": name})
+        decision = evaluate_browser_action_policy(self.config, action)
+        if not decision.allowed:
+            return self._record_action_result(
+                action=action,
+                decision=decision,
+                before_url=self._current_url,
+                after_url=self._current_url,
+            )
+
+        await self._ensure_domains_enabled()
+        response = await self.transport.send("Page.captureScreenshot", {"format": "png"})
+        screenshot_base64 = response.get("data")
+        artifacts = self._persist_snapshot_artifacts(
+            basename=name,
+            screenshot_base64=str(screenshot_base64) if isinstance(screenshot_base64, str) else None,
+        )
+        return self._record_action_result(
+            action=action,
+            decision=decision,
+            before_url=self._current_url,
+            after_url=self._current_url,
+            message="screenshot captured",
+            artifacts=artifacts,
+        )
+
+    async def close(self) -> None:
+        await self.transport.close()
+
+    async def _ensure_domains_enabled(self) -> None:
+        if self._domains_enabled:
+            return
+        await self.transport.send("Page.enable", {})
+        await self.transport.send("Runtime.enable", {})
+        self._domains_enabled = True
+
+    def _build_action(self, action_type: str, params: dict[str, Any]) -> BrowserAction:
+        return validate_browser_action({
+            "schemaVersion": "1.0",
+            "actionId": _new_id("act"),
+            "sessionId": self.session_id,
+            "timestamp": _utcnow(),
+            "type": action_type,
+            "params": params,
+        })
+
+    def _record_action_result(
+        self,
+        *,
+        action: BrowserAction,
+        decision: BrowserPolicyDecision,
+        before_url: str | None,
+        after_url: str | None,
+        message: str | None = None,
+        artifacts: BrowserArtifactPaths | None = None,
+    ) -> BrowserAuditEvent:
+        event = validate_browser_audit_event({
+            "schemaVersion": "1.0",
+            "eventId": _new_id("evt"),
+            "sessionId": self.session_id,
+            "actionId": str(action.actionId),
+            "kind": "action_result",
+            "allowed": decision.allowed,
+            "policyReason": decision.reason,
+            "timestamp": _utcnow(),
+            "message": message,
+            "beforeUrl": before_url,
+            "afterUrl": after_url,
+            "artifacts": artifacts or _empty_artifacts(),
+        })
+        if self.evidence_store is not None:
+            self.evidence_store.append_audit_event(event)
+        return event
+
+    def _persist_snapshot_artifacts(
+        self,
+        *,
+        basename: str,
+        html: str | None = None,
+        screenshot_base64: str | None = None,
+    ) -> BrowserArtifactPaths:
+        if self.evidence_store is None:
+            return _empty_artifacts()
+        return self.evidence_store.persist_snapshot_artifacts(
+            session_id=self.session_id,
+            basename=basename,
+            html=html,
+            screenshot_base64=screenshot_base64,
+        )
+
+    def _selector_for_ref(self, ref: str) -> str:
+        return self._ref_selectors.get(ref, ref)
+
+
+def _extract_result_value(response: dict[str, Any]) -> dict[str, Any]:
+    result = response.get("result")
+    if not isinstance(result, dict):
+        return {}
+    value = result.get("value")
+    if not isinstance(value, dict):
+        return {}
+    return value
+
+
+def _click_expression(selector: str) -> str:
+    selector_json = json.dumps(selector)
+    return f"""
+(() => {{
+  const element = document.querySelector({selector_json});
+  if (!element) return {{ ok: false, error: "selector_not_found" }};
+  element.click();
+  return {{ ok: true }};
+}})()
+""".strip()
+
+
+def _fill_expression(selector: str, text: str) -> str:
+    selector_json = json.dumps(selector)
+    text_json = json.dumps(text)
+    return f"""
+(() => {{
+  const element = document.querySelector({selector_json});
+  if (!element) return {{ ok: false, error: "selector_not_found" }};
+  element.focus?.();
+  if ("value" in element) {{
+    element.value = {text_json};
+  }}
+  element.dispatchEvent(new Event("input", {{ bubbles: true }}));
+  element.dispatchEvent(new Event("change", {{ bubbles: true }}));
+  return {{ ok: true }};
+}})()
+""".strip()
+
+
+def _press_expression(key: str) -> str:
+    key_json = json.dumps(key)
+    return f"""
+(() => {{
+  const target = document.activeElement ?? document.body;
+  if (!target) return {{ ok: false, error: "missing_target" }};
+  target.dispatchEvent(new KeyboardEvent("keydown", {{ key: {key_json}, bubbles: true }}));
+  target.dispatchEvent(new KeyboardEvent("keyup", {{ key: {key_json}, bubbles: true }}));
+  return {{ ok: true }};
+}})()
+""".strip()
+
+
+def _empty_artifacts() -> BrowserArtifactPaths:
+    return {"htmlPath": None, "screenshotPath": None, "downloadPath": None}
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid4().hex}"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+__all__ = ["ChromeCdpSession", "ChromeCdpTransport"]

--- a/autocontext/src/autocontext/integrations/browser/chrome_cdp.py
+++ b/autocontext/src/autocontext/integrations/browser/chrome_cdp.py
@@ -60,8 +60,8 @@ _SNAPSHOT_EXPRESSION = """
       element.getAttribute("aria-label") ??
       element.getAttribute("name") ??
       element.textContent?.trim() ??
-      null,
-    text: element.textContent?.trim() ?? null,
+      "",
+    text: element.textContent?.trim() ?? "",
     selector: selectorFor(element),
     disabled: element.hasAttribute("disabled"),
   }));
@@ -143,8 +143,7 @@ class ChromeCdpSession(BrowserSessionPort):
             },
         )
         payload = _extract_result_value(response)
-        refs = payload.get("refs")
-        parsed_refs = refs if isinstance(refs, list) else []
+        parsed_refs = _normalize_snapshot_refs(payload.get("refs"))
         self._ref_selectors = {
             str(ref.get("id")): str(ref.get("selector"))
             for ref in parsed_refs
@@ -198,11 +197,10 @@ class ChromeCdpSession(BrowserSessionPort):
                 "awaitPromise": True,
             },
         )
-        return self._record_action_result(
+        return await self._record_interactive_result(
             action=action,
             decision=decision,
             before_url=self._current_url,
-            after_url=self._current_url,
             message="click allowed",
         )
 
@@ -234,11 +232,10 @@ class ChromeCdpSession(BrowserSessionPort):
                 "awaitPromise": True,
             },
         )
-        return self._record_action_result(
+        return await self._record_interactive_result(
             action=action,
             decision=decision,
             before_url=self._current_url,
-            after_url=self._current_url,
             message="fill allowed",
         )
 
@@ -262,11 +259,10 @@ class ChromeCdpSession(BrowserSessionPort):
                 "awaitPromise": True,
             },
         )
-        return self._record_action_result(
+        return await self._record_interactive_result(
             action=action,
             decision=decision,
             before_url=self._current_url,
-            after_url=self._current_url,
             message="key press allowed",
         )
 
@@ -364,6 +360,48 @@ class ChromeCdpSession(BrowserSessionPort):
     def _selector_for_ref(self, ref: str) -> str:
         return self._ref_selectors.get(ref, ref)
 
+    async def _record_interactive_result(
+        self,
+        *,
+        action: BrowserAction,
+        decision: BrowserPolicyDecision,
+        before_url: str | None,
+        message: str,
+    ) -> BrowserAuditEvent:
+        after_url = await self._read_current_url()
+        self._current_url = after_url
+        after_decision = _evaluate_navigation_url_policy(self.config, after_url)
+        if not after_decision.allowed:
+            return self._record_action_result(
+                action=action,
+                decision=after_decision,
+                before_url=before_url,
+                after_url=after_url,
+                message="interaction navigated outside browser policy",
+            )
+        return self._record_action_result(
+            action=action,
+            decision=decision,
+            before_url=before_url,
+            after_url=after_url,
+            message=message,
+        )
+
+    async def _read_current_url(self) -> str:
+        response = await self.transport.send(
+            "Runtime.evaluate",
+            {
+                "expression": "(() => window.location.href)()",
+                "returnByValue": True,
+                "awaitPromise": True,
+            },
+        )
+        result = response.get("result")
+        if not isinstance(result, dict):
+            return self._current_url
+        value = result.get("value")
+        return value if isinstance(value, str) and value else self._current_url
+
 
 def _extract_result_value(response: dict[str, Any]) -> dict[str, Any]:
     result = response.get("result")
@@ -373,6 +411,42 @@ def _extract_result_value(response: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
     return value
+
+
+def _normalize_snapshot_refs(refs: Any) -> list[dict[str, Any]]:
+    if not isinstance(refs, list):
+        return []
+    normalized_refs: list[dict[str, Any]] = []
+    for item in refs:
+        if not isinstance(item, dict):
+            continue
+        ref_id = item.get("id")
+        if not isinstance(ref_id, str):
+            continue
+        normalized: dict[str, Any] = {"id": ref_id}
+        for key in ("role", "name", "text", "selector"):
+            value = item.get(key)
+            if isinstance(value, str):
+                normalized[key] = value
+        disabled = item.get("disabled")
+        if isinstance(disabled, bool):
+            normalized["disabled"] = disabled
+        normalized_refs.append(normalized)
+    return normalized_refs
+
+
+def _evaluate_navigation_url_policy(config: BrowserSessionConfig, url: str) -> BrowserPolicyDecision:
+    return evaluate_browser_action_policy(
+        config,
+        {
+            "schemaVersion": "1.0",
+            "actionId": "act_interaction_url_probe",
+            "sessionId": "session_interaction_url_probe",
+            "timestamp": _utcnow(),
+            "type": "navigate",
+            "params": {"url": url},
+        },
+    )
 
 
 def _click_expression(selector: str) -> str:

--- a/autocontext/src/autocontext/integrations/browser/chrome_cdp.py
+++ b/autocontext/src/autocontext/integrations/browser/chrome_cdp.py
@@ -27,6 +27,29 @@ from autocontext.integrations.browser.validate import (
 
 _SNAPSHOT_EXPRESSION = """
 (() => {
+  const cssEscape = (value) =>
+    globalThis.CSS?.escape
+      ? CSS.escape(value)
+      : String(value).replace(/[^a-zA-Z0-9_-]/g, "\\\\$&");
+  const selectorFor = (element) => {
+    if (element.id) return "#" + cssEscape(element.id);
+    const parts = [];
+    let current = element;
+    while (current && current.nodeType === Node.ELEMENT_NODE && current !== document.documentElement) {
+      const tag = current.tagName.toLowerCase();
+      const parent = current.parentElement;
+      if (!parent) {
+        parts.unshift(tag);
+        break;
+      }
+      const siblings = Array.from(parent.children).filter((sibling) => sibling.tagName === current.tagName);
+      const index = siblings.indexOf(current) + 1;
+      parts.unshift(siblings.length > 1 ? tag + ":nth-of-type(" + index + ")" : tag);
+      current = parent;
+      if (parts.length >= 4) break;
+    }
+    return parts.join(" > ");
+  };
   const candidates = Array.from(
     document.querySelectorAll("a,button,input,select,textarea,[role],[tabindex]")
   ).slice(0, 200);
@@ -39,7 +62,7 @@ _SNAPSHOT_EXPRESSION = """
       element.textContent?.trim() ??
       null,
     text: element.textContent?.trim() ?? null,
-    selector: null,
+    selector: selectorFor(element),
     disabled: element.hasAttribute("disabled"),
   }));
   return {

--- a/autocontext/src/autocontext/integrations/browser/chrome_cdp_discovery.py
+++ b/autocontext/src/autocontext/integrations/browser/chrome_cdp_discovery.py
@@ -1,0 +1,151 @@
+"""Debugger target discovery for Chrome CDP runtimes."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol, TypeAlias, runtime_checkable
+
+import httpx
+
+from autocontext.integrations.browser.contract.models import BrowserSessionConfig
+from autocontext.integrations.browser.policy import evaluate_browser_action_policy
+
+FetchJson: TypeAlias = Callable[[str], Awaitable[object]]
+
+
+class ChromeCdpDiscoveryError(RuntimeError):
+    """Raised when debugger target discovery fails or yields no safe target."""
+
+
+@dataclass(frozen=True, slots=True)
+class ChromeCdpTarget:
+    target_id: str
+    target_type: str
+    title: str
+    url: str
+    websocket_debugger_url: str
+
+
+@runtime_checkable
+class ChromeCdpTargetDiscoveryPort(Protocol):
+    async def resolve_websocket_url(
+        self,
+        config: BrowserSessionConfig,
+        *,
+        preferred_url: str | None = None,
+    ) -> str: ...
+
+
+class ChromeCdpTargetDiscovery(ChromeCdpTargetDiscoveryPort):
+    """Fetch and select attachable CDP targets from a debugger endpoint."""
+
+    def __init__(
+        self,
+        debugger_url: str,
+        *,
+        fetch_json: FetchJson | None = None,
+    ) -> None:
+        self.debugger_url = debugger_url.rstrip("/")
+        self.fetch_json = fetch_json or _fetch_json
+
+    async def list_targets(self) -> list[ChromeCdpTarget]:
+        payload = await self.fetch_json(f"{self.debugger_url}/json/list")
+        if not isinstance(payload, list):
+            raise ChromeCdpDiscoveryError("Debugger target discovery expected a JSON array from /json/list")
+        targets: list[ChromeCdpTarget] = []
+        for item in payload:
+            target = _parse_target(item)
+            if target is not None:
+                targets.append(target)
+        return targets
+
+    async def resolve_websocket_url(
+        self,
+        config: BrowserSessionConfig,
+        *,
+        preferred_url: str | None = None,
+    ) -> str:
+        target = select_chrome_cdp_target(
+            await self.list_targets(),
+            config,
+            preferred_url=preferred_url,
+        )
+        return target.websocket_debugger_url
+
+
+def select_chrome_cdp_target(
+    targets: Sequence[ChromeCdpTarget],
+    config: BrowserSessionConfig,
+    *,
+    preferred_url: str | None = None,
+) -> ChromeCdpTarget:
+    attachable_targets = [target for target in targets if target.target_type == "page" and target.websocket_debugger_url]
+    if preferred_url:
+        preferred_target = next((target for target in attachable_targets if target.url == preferred_url), None)
+        if preferred_target is not None:
+            if _is_target_allowed(config, preferred_target.url):
+                return preferred_target
+            raise ChromeCdpDiscoveryError(
+                f"Preferred debugger target is not allowed by browser policy: {preferred_url}",
+            )
+
+    allowed_targets = [target for target in attachable_targets if _is_target_allowed(config, target.url)]
+    if allowed_targets:
+        return allowed_targets[0]
+    if not attachable_targets:
+        raise ChromeCdpDiscoveryError("No attachable page targets were advertised by the debugger")
+    if preferred_url:
+        raise ChromeCdpDiscoveryError(f"Preferred debugger target was not found: {preferred_url}")
+    raise ChromeCdpDiscoveryError("No debugger targets matched the browser allowlist")
+
+
+async def _fetch_json(url: str) -> object:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url)
+    response.raise_for_status()
+    return response.json()
+
+
+def _parse_target(payload: object) -> ChromeCdpTarget | None:
+    if not isinstance(payload, dict):
+        return None
+    target_id = payload.get("id")
+    target_type = payload.get("type")
+    title = payload.get("title")
+    url = payload.get("url")
+    websocket_url = payload.get("webSocketDebuggerUrl")
+    if not isinstance(target_id, str) or not isinstance(target_type, str):
+        return None
+    return ChromeCdpTarget(
+        target_id=target_id,
+        target_type=target_type,
+        title=title if isinstance(title, str) else "",
+        url=url if isinstance(url, str) else "",
+        websocket_debugger_url=websocket_url if isinstance(websocket_url, str) else "",
+    )
+
+
+def _is_target_allowed(config: BrowserSessionConfig, url: str) -> bool:
+    decision = evaluate_browser_action_policy(
+        config,
+        {
+            "schemaVersion": "1.0",
+            "actionId": "act_discovery_probe",
+            "sessionId": "session_discovery",
+            "timestamp": datetime.now(UTC),
+            "type": "navigate",
+            "params": {"url": url},
+        },
+    )
+    return decision.allowed
+
+
+__all__ = [
+    "ChromeCdpDiscoveryError",
+    "ChromeCdpTarget",
+    "ChromeCdpTargetDiscovery",
+    "ChromeCdpTargetDiscoveryPort",
+    "select_chrome_cdp_target",
+]

--- a/autocontext/src/autocontext/integrations/browser/chrome_cdp_runtime.py
+++ b/autocontext/src/autocontext/integrations/browser/chrome_cdp_runtime.py
@@ -1,0 +1,77 @@
+"""Runtime factory for Chrome CDP browser sessions."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeAlias
+from uuid import uuid4
+
+from autocontext.integrations.browser.chrome_cdp import ChromeCdpSession, ChromeCdpTransport
+from autocontext.integrations.browser.chrome_cdp_discovery import (
+    ChromeCdpTargetDiscovery,
+    ChromeCdpTargetDiscoveryPort,
+)
+from autocontext.integrations.browser.chrome_cdp_transport import ChromeCdpWebSocketTransport
+from autocontext.integrations.browser.contract.models import BrowserSessionConfig
+from autocontext.integrations.browser.evidence import BrowserEvidenceStore
+from autocontext.integrations.browser.types import BrowserRuntimePort, BrowserSessionPort
+
+TransportFactory: TypeAlias = Callable[[str], ChromeCdpTransport]
+SessionIdFactory: TypeAlias = Callable[[], str]
+
+
+class ChromeCdpRuntime(BrowserRuntimePort):
+    """Create thin CDP browser sessions from a single debugger websocket URL."""
+
+    def __init__(
+        self,
+        *,
+        websocket_url: str | None = None,
+        debugger_url: str | None = None,
+        preferred_target_url: str | None = None,
+        evidence_root: str | Path | None = None,
+        target_discovery: ChromeCdpTargetDiscoveryPort | None = None,
+        transport_factory: TransportFactory | None = None,
+        session_id_factory: SessionIdFactory | None = None,
+    ) -> None:
+        if websocket_url is None and debugger_url is None and target_discovery is None:
+            raise ValueError("ChromeCdpRuntime requires websocket_url, debugger_url, or target_discovery")
+        self.websocket_url = websocket_url
+        self.debugger_url = debugger_url
+        self.preferred_target_url = preferred_target_url
+        self.evidence_root = Path(evidence_root).resolve() if evidence_root is not None else None
+        self.target_discovery = target_discovery
+        self.transport_factory = transport_factory or (lambda url: ChromeCdpWebSocketTransport(url))
+        self.session_id_factory = session_id_factory or _new_session_id
+
+    async def create_session(self, config: BrowserSessionConfig) -> BrowserSessionPort:
+        session_id = self.session_id_factory()
+        evidence_store = BrowserEvidenceStore(self.evidence_root) if self.evidence_root is not None else None
+        websocket_url = await self._resolve_websocket_url(config)
+        return ChromeCdpSession(
+            session_id=session_id,
+            config=config,
+            transport=self.transport_factory(websocket_url),
+            evidence_store=evidence_store,
+        )
+
+    async def _resolve_websocket_url(self, config: BrowserSessionConfig) -> str:
+        if self.websocket_url is not None:
+            return self.websocket_url
+        discovery = self.target_discovery
+        if discovery is None:
+            if self.debugger_url is None:
+                raise RuntimeError("ChromeCdpRuntime cannot resolve a websocket URL without debugger_url")
+            discovery = ChromeCdpTargetDiscovery(self.debugger_url)
+        return await discovery.resolve_websocket_url(
+            config,
+            preferred_url=self.preferred_target_url or None,
+        )
+
+
+def _new_session_id() -> str:
+    return f"browser_{uuid4().hex}"
+
+
+__all__ = ["ChromeCdpRuntime"]

--- a/autocontext/src/autocontext/integrations/browser/chrome_cdp_transport.py
+++ b/autocontext/src/autocontext/integrations/browser/chrome_cdp_transport.py
@@ -1,0 +1,141 @@
+"""WebSocket transport for Chrome DevTools Protocol."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import Any, cast
+
+from websockets.asyncio.client import connect
+
+
+class ChromeCdpTransportError(RuntimeError):
+    """Raised when the CDP websocket transport fails or returns an error."""
+
+
+class ChromeCdpWebSocketTransport:
+    """Thin CDP transport that connects to an existing debugger websocket URL."""
+
+    def __init__(
+        self,
+        websocket_url: str,
+        *,
+        connect_timeout: float = 5.0,
+    ) -> None:
+        self.websocket_url = websocket_url
+        self.connect_timeout = connect_timeout
+        self._websocket: Any | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._pending: dict[int, asyncio.Future[dict[str, Any]]] = {}
+        self._next_id = 0
+        self._connect_lock = asyncio.Lock()
+        self._send_lock = asyncio.Lock()
+        self._closing = False
+
+    async def connect(self) -> None:
+        if self._websocket is not None:
+            return
+        async with self._connect_lock:
+            if self._websocket is not None:
+                return
+            self._closing = False
+            self._websocket = await connect(
+                self.websocket_url,
+                open_timeout=self.connect_timeout,
+                max_size=None,
+            )
+            self._reader_task = asyncio.create_task(self._reader_loop())
+
+    async def send(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        await self.connect()
+        websocket = self._websocket
+        if websocket is None:
+            raise ChromeCdpTransportError("CDP websocket is not connected")
+
+        async with self._send_lock:
+            self._next_id += 1
+            message_id = self._next_id
+            future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+            self._pending[message_id] = future
+            try:
+                await websocket.send(json.dumps({
+                    "id": message_id,
+                    "method": method,
+                    "params": params or {},
+                }))
+            except Exception as exc:
+                self._pending.pop(message_id, None)
+                raise ChromeCdpTransportError(f"Failed to send CDP message {method}: {exc}") from exc
+
+        return await future
+
+    async def close(self) -> None:
+        self._closing = True
+        websocket = self._websocket
+        reader_task = self._reader_task
+        self._websocket = None
+        self._reader_task = None
+        if websocket is not None:
+            await websocket.close()
+        if reader_task is not None:
+            with contextlib.suppress(asyncio.CancelledError):
+                await reader_task
+
+    async def _reader_loop(self) -> None:
+        failure: ChromeCdpTransportError | None = None
+        websocket = self._websocket
+        if websocket is None:
+            return
+        try:
+            async for raw_message in websocket:
+                payload = self._decode_message(raw_message)
+                if payload is None:
+                    continue
+                message_id = payload.get("id")
+                if not isinstance(message_id, int):
+                    continue
+                future = self._pending.pop(message_id, None)
+                if future is None or future.done():
+                    continue
+                error = payload.get("error")
+                if isinstance(error, dict):
+                    future.set_exception(ChromeCdpTransportError(_error_message(error)))
+                    continue
+                future.set_result(payload)
+        except Exception as exc:
+            failure = ChromeCdpTransportError(f"CDP websocket transport failed: {exc}")
+        finally:
+            if failure is None and not self._closing:
+                failure = ChromeCdpTransportError("CDP websocket closed unexpectedly")
+            elif failure is None:
+                failure = ChromeCdpTransportError("CDP websocket closed")
+            self._fail_pending(failure)
+            self._websocket = None
+            self._reader_task = None
+
+    def _fail_pending(self, error: ChromeCdpTransportError) -> None:
+        pending = list(self._pending.values())
+        self._pending.clear()
+        for future in pending:
+            if not future.done():
+                future.set_exception(error)
+
+    def _decode_message(self, raw_message: Any) -> dict[str, Any] | None:
+        try:
+            if isinstance(raw_message, bytes):
+                return cast(dict[str, Any], json.loads(raw_message.decode("utf-8")))
+            if isinstance(raw_message, str):
+                return cast(dict[str, Any], json.loads(raw_message))
+        except json.JSONDecodeError:
+            return None
+        return None
+
+
+def _error_message(error: dict[str, Any]) -> str:
+    message = error.get("message")
+    if isinstance(message, str) and message:
+        return message
+    return f"CDP error: {json.dumps(error, sort_keys=True)}"
+
+__all__ = ["ChromeCdpTransportError", "ChromeCdpWebSocketTransport"]

--- a/autocontext/src/autocontext/integrations/browser/evidence.py
+++ b/autocontext/src/autocontext/integrations/browser/evidence.py
@@ -1,0 +1,73 @@
+"""Filesystem evidence persistence for browser exploration."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import Any, TypedDict
+
+from autocontext.integrations.browser.contract.models import BrowserAuditEvent
+from autocontext.integrations.browser.validate import validate_browser_audit_event
+
+
+class BrowserArtifactPaths(TypedDict):
+    htmlPath: str | None
+    screenshotPath: str | None
+    downloadPath: str | None
+
+
+class BrowserEvidenceStore:
+    """Persist browser action evidence beneath a run-local root directory."""
+
+    def __init__(self, root_dir: str | Path) -> None:
+        self.root_dir = Path(root_dir).resolve()
+
+    def append_audit_event(self, event: BrowserAuditEvent | dict[str, Any]) -> Path:
+        parsed = validate_browser_audit_event(event) if isinstance(event, dict) else event
+        out_path = self._session_dir(str(parsed.sessionId)) / "actions.jsonl"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("a", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    parsed.model_dump(mode="json"),
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+            )
+            fh.write("\n")
+        return out_path
+
+    def persist_snapshot_artifacts(
+        self,
+        *,
+        session_id: str,
+        basename: str,
+        html: str | None = None,
+        screenshot_base64: str | None = None,
+    ) -> BrowserArtifactPaths:
+        html_path: Path | None = None
+        screenshot_path: Path | None = None
+
+        if html is not None:
+            html_path = self._session_dir(session_id) / "html" / f"{basename}.html"
+            html_path.parent.mkdir(parents=True, exist_ok=True)
+            html_path.write_text(html, encoding="utf-8")
+
+        if screenshot_base64 is not None:
+            screenshot_path = self._session_dir(session_id) / "screenshots" / f"{basename}.png"
+            screenshot_path.parent.mkdir(parents=True, exist_ok=True)
+            screenshot_path.write_bytes(base64.b64decode(screenshot_base64, validate=True))
+
+        return {
+            "htmlPath": str(html_path.resolve()) if html_path is not None else None,
+            "screenshotPath": str(screenshot_path.resolve()) if screenshot_path is not None else None,
+            "downloadPath": None,
+        }
+
+    def _session_dir(self, session_id: str) -> Path:
+        return self.root_dir / "browser" / "sessions" / session_id
+
+
+__all__ = ["BrowserArtifactPaths", "BrowserEvidenceStore"]

--- a/autocontext/src/autocontext/integrations/browser/evidence.py
+++ b/autocontext/src/autocontext/integrations/browser/evidence.py
@@ -50,13 +50,23 @@ class BrowserEvidenceStore:
         html_path: Path | None = None
         screenshot_path: Path | None = None
 
+        safe_basename = _safe_path_component(basename, fallback="artifact")
+
         if html is not None:
-            html_path = self._session_dir(session_id) / "html" / f"{basename}.html"
+            html_path = self._artifact_path(
+                session_id=session_id,
+                subdir="html",
+                filename=f"{safe_basename}.html",
+            )
             html_path.parent.mkdir(parents=True, exist_ok=True)
             html_path.write_text(html, encoding="utf-8")
 
         if screenshot_base64 is not None:
-            screenshot_path = self._session_dir(session_id) / "screenshots" / f"{basename}.png"
+            screenshot_path = self._artifact_path(
+                session_id=session_id,
+                subdir="screenshots",
+                filename=f"{safe_basename}.png",
+            )
             screenshot_path.parent.mkdir(parents=True, exist_ok=True)
             screenshot_path.write_bytes(base64.b64decode(screenshot_base64, validate=True))
 
@@ -67,7 +77,21 @@ class BrowserEvidenceStore:
         }
 
     def _session_dir(self, session_id: str) -> Path:
-        return self.root_dir / "browser" / "sessions" / session_id
+        return self.root_dir / "browser" / "sessions" / _safe_path_component(session_id, fallback="session")
+
+    def _artifact_path(self, *, session_id: str, subdir: str, filename: str) -> Path:
+        path = self._session_dir(session_id) / subdir / filename
+        resolved = path.resolve()
+        if not resolved.is_relative_to(self.root_dir):
+            raise ValueError("browser artifact path escaped evidence root")
+        return resolved
+
+
+def _safe_path_component(value: str, *, fallback: str) -> str:
+    leaf = Path(str(value)).name
+    safe = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in leaf)
+    safe = safe.strip("._")
+    return safe or fallback
 
 
 __all__ = ["BrowserArtifactPaths", "BrowserEvidenceStore"]

--- a/autocontext/src/autocontext/integrations/browser/factory.py
+++ b/autocontext/src/autocontext/integrations/browser/factory.py
@@ -1,0 +1,48 @@
+"""Factory helpers for building browser runtimes from app settings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from autocontext.config.settings import AppSettings
+from autocontext.integrations.browser.chrome_cdp_runtime import ChromeCdpRuntime
+from autocontext.integrations.browser.contract.models import BrowserSessionConfig
+from autocontext.integrations.browser.policy import resolve_browser_session_config
+from autocontext.integrations.browser.types import BrowserRuntimePort
+
+
+@dataclass(frozen=True, slots=True)
+class ConfiguredBrowserRuntime:
+    """Resolved browser session config plus the runtime that can create sessions."""
+
+    session_config: BrowserSessionConfig
+    runtime: BrowserRuntimePort
+
+
+def browser_runtime_from_settings(
+    settings: AppSettings,
+    *,
+    evidence_root: Path | None = None,
+) -> ConfiguredBrowserRuntime | None:
+    """Build a configured browser runtime from app settings.
+
+    Returns ``None`` when browser exploration is disabled.
+    """
+    if not settings.browser_enabled:
+        return None
+
+    if settings.browser_backend != "chrome-cdp":
+        raise ValueError(f"unsupported browser backend: {settings.browser_backend}")
+
+    return ConfiguredBrowserRuntime(
+        session_config=resolve_browser_session_config(settings),
+        runtime=ChromeCdpRuntime(
+            debugger_url=settings.browser_debugger_url or None,
+            preferred_target_url=settings.browser_preferred_target_url or None,
+            evidence_root=evidence_root or settings.runs_root,
+        ),
+    )
+
+
+__all__ = ["ConfiguredBrowserRuntime", "browser_runtime_from_settings"]

--- a/autocontext/tests/test_browser_chrome_cdp.py
+++ b/autocontext/tests/test_browser_chrome_cdp.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autocontext.integrations.browser.chrome_cdp import ChromeCdpSession
+from autocontext.integrations.browser.evidence import BrowserEvidenceStore
+from autocontext.integrations.browser.policy import build_default_browser_session_config
+
+
+class FakeTransport:
+    def __init__(self, responses: list[dict]) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[str, dict]] = []
+        self.closed = False
+
+    async def send(self, method: str, params: dict | None = None) -> dict:
+        self.calls.append((method, params or {}))
+        if not self.responses:
+            return {}
+        return self.responses.pop(0)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_navigate_blocks_disallowed_domain_before_transport(tmp_path: Path) -> None:
+    session = ChromeCdpSession(
+        session_id="session_1",
+        config=build_default_browser_session_config(allowed_domains=["example.com"]),
+        transport=FakeTransport([]),
+        evidence_store=BrowserEvidenceStore(tmp_path),
+    )
+
+    event = await session.navigate("https://blocked.example.net/dashboard")
+
+    assert event.allowed is False
+    assert event.policyReason == "domain_not_allowed"
+    assert session.transport.calls == []
+
+
+@pytest.mark.asyncio
+async def test_snapshot_persists_artifacts_and_click_uses_ref_mapping(tmp_path: Path) -> None:
+    transport = FakeTransport([
+        {},
+        {},
+        {
+            "result": {
+                "value": {
+                    "url": "https://example.com/dashboard",
+                    "title": "Dashboard",
+                    "visibleText": "Welcome back",
+                    "refs": [
+                        {
+                            "id": "@e1",
+                            "role": "button",
+                            "name": "Continue",
+                            "selector": "button:nth-of-type(1)",
+                        }
+                    ],
+                    "html": "<html><body>Welcome back</body></html>",
+                }
+            }
+        },
+        {"data": "cG5nLWJ5dGVz"},
+        {"result": {"value": {"ok": True}}},
+    ])
+    session = ChromeCdpSession(
+        session_id="session_1",
+        config=build_default_browser_session_config(allowed_domains=["example.com"]),
+        transport=transport,
+        evidence_store=BrowserEvidenceStore(tmp_path),
+    )
+
+    snapshot = await session.snapshot()
+    event = await session.click("@e1")
+
+    assert snapshot.url == "https://example.com/dashboard"
+    assert snapshot.htmlPath is not None
+    assert snapshot.screenshotPath is not None
+    assert Path(snapshot.htmlPath).exists()
+    assert Path(snapshot.screenshotPath).read_bytes() == b"png-bytes"
+    assert event.allowed is True
+    assert transport.calls[-1][0] == "Runtime.evaluate"
+    assert "button:nth-of-type(1)" in transport.calls[-1][1]["expression"]
+
+
+@pytest.mark.asyncio
+async def test_fill_password_denied_when_auth_disabled(tmp_path: Path) -> None:
+    session = ChromeCdpSession(
+        session_id="session_1",
+        config=build_default_browser_session_config(allowed_domains=["example.com"]),
+        transport=FakeTransport([]),
+        evidence_store=BrowserEvidenceStore(tmp_path),
+    )
+
+    event = await session.fill("@e1", "super-secret", field_kind="password")
+
+    assert event.allowed is False
+    assert event.policyReason == "auth_blocked"
+    assert session.transport.calls == []

--- a/autocontext/tests/test_browser_chrome_cdp.py
+++ b/autocontext/tests/test_browser_chrome_cdp.py
@@ -82,6 +82,7 @@ async def test_snapshot_persists_artifacts_and_click_uses_ref_mapping(tmp_path: 
     assert snapshot.screenshotPath is not None
     assert Path(snapshot.htmlPath).exists()
     assert Path(snapshot.screenshotPath).read_bytes() == b"png-bytes"
+    assert "selectorFor(element)" in transport.calls[2][1]["expression"]
     assert event.allowed is True
     assert transport.calls[-1][0] == "Runtime.evaluate"
     assert "button:nth-of-type(1)" in transport.calls[-1][1]["expression"]

--- a/autocontext/tests/test_browser_chrome_cdp.py
+++ b/autocontext/tests/test_browser_chrome_cdp.py
@@ -66,6 +66,7 @@ async def test_snapshot_persists_artifacts_and_click_uses_ref_mapping(tmp_path: 
         },
         {"data": "cG5nLWJ5dGVz"},
         {"result": {"value": {"ok": True}}},
+        {"result": {"value": "https://example.com/dashboard"}},
     ])
     session = ChromeCdpSession(
         session_id="session_1",
@@ -84,8 +85,88 @@ async def test_snapshot_persists_artifacts_and_click_uses_ref_mapping(tmp_path: 
     assert Path(snapshot.screenshotPath).read_bytes() == b"png-bytes"
     assert "selectorFor(element)" in transport.calls[2][1]["expression"]
     assert event.allowed is True
-    assert transport.calls[-1][0] == "Runtime.evaluate"
-    assert "button:nth-of-type(1)" in transport.calls[-1][1]["expression"]
+    assert event.afterUrl == "https://example.com/dashboard"
+    assert transport.calls[-2][0] == "Runtime.evaluate"
+    assert "button:nth-of-type(1)" in transport.calls[-2][1]["expression"]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_normalizes_null_ref_fields(tmp_path: Path) -> None:
+    transport = FakeTransport([
+        {},
+        {},
+        {
+            "result": {
+                "value": {
+                    "url": "https://example.com/dashboard",
+                    "title": "Dashboard",
+                    "visibleText": "Welcome back",
+                    "refs": [
+                        {
+                            "id": "@e1",
+                            "role": "button",
+                            "name": None,
+                            "text": None,
+                            "selector": "button:nth-of-type(1)",
+                        }
+                    ],
+                    "html": "<html><body>Welcome back</body></html>",
+                }
+            }
+        },
+    ])
+    session = ChromeCdpSession(
+        session_id="session_1",
+        config=build_default_browser_session_config(
+            allowed_domains=["example.com"],
+            capture_screenshots=False,
+        ),
+        transport=transport,
+        evidence_store=BrowserEvidenceStore(tmp_path),
+    )
+
+    snapshot = await session.snapshot()
+
+    ref = snapshot.model_dump(mode="json", exclude_none=True)["refs"][0]
+    assert "name" not in ref
+    assert "text" not in ref
+
+
+@pytest.mark.asyncio
+async def test_click_records_blocked_when_interaction_leaves_allowlist(tmp_path: Path) -> None:
+    transport = FakeTransport([
+        {},
+        {},
+        {
+            "result": {
+                "value": {
+                    "url": "https://example.com/dashboard",
+                    "title": "Dashboard",
+                    "visibleText": "Continue",
+                    "refs": [{"id": "@e1", "selector": "a:nth-of-type(1)"}],
+                    "html": "<html><body><a href='https://blocked.example.net'>Continue</a></body></html>",
+                }
+            }
+        },
+        {"result": {"value": {"ok": True}}},
+        {"result": {"value": "https://blocked.example.net"}},
+    ])
+    session = ChromeCdpSession(
+        session_id="session_1",
+        config=build_default_browser_session_config(
+            allowed_domains=["example.com"],
+            capture_screenshots=False,
+        ),
+        transport=transport,
+        evidence_store=BrowserEvidenceStore(tmp_path),
+    )
+
+    await session.snapshot()
+    event = await session.click("@e1")
+
+    assert event.allowed is False
+    assert event.policyReason == "domain_not_allowed"
+    assert event.afterUrl == "https://blocked.example.net"
 
 
 @pytest.mark.asyncio

--- a/autocontext/tests/test_browser_discovery.py
+++ b/autocontext/tests/test_browser_discovery.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pytest
+
+from autocontext.integrations.browser.chrome_cdp_discovery import (
+    ChromeCdpDiscoveryError,
+    ChromeCdpTarget,
+    ChromeCdpTargetDiscovery,
+    select_chrome_cdp_target,
+)
+from autocontext.integrations.browser.policy import build_default_browser_session_config
+
+
+def test_select_target_prefers_exact_allowed_match() -> None:
+    config = build_default_browser_session_config(allowed_domains=["example.com"])
+    targets = [
+        ChromeCdpTarget(
+            target_id="target_1",
+            target_type="page",
+            title="Home",
+            url="https://example.com/home",
+            websocket_debugger_url="ws://127.0.0.1:9222/devtools/page/1",
+        ),
+        ChromeCdpTarget(
+            target_id="target_2",
+            target_type="page",
+            title="Dashboard",
+            url="https://example.com/dashboard",
+            websocket_debugger_url="ws://127.0.0.1:9222/devtools/page/2",
+        ),
+    ]
+
+    target = select_chrome_cdp_target(
+        targets,
+        config,
+        preferred_url="https://example.com/dashboard",
+    )
+
+    assert target.target_id == "target_2"
+
+
+def test_select_target_rejects_when_allowlist_does_not_match() -> None:
+    config = build_default_browser_session_config(allowed_domains=["example.com"])
+    targets = [
+        ChromeCdpTarget(
+            target_id="target_1",
+            target_type="page",
+            title="Blocked",
+            url="https://blocked.example.net/home",
+            websocket_debugger_url="ws://127.0.0.1:9222/devtools/page/1",
+        ),
+    ]
+
+    with pytest.raises(ChromeCdpDiscoveryError, match="allowlist"):
+        select_chrome_cdp_target(targets, config)
+
+
+@pytest.mark.asyncio
+async def test_target_discovery_fetches_json_list_and_resolves_websocket_url() -> None:
+    seen_urls: list[str] = []
+
+    async def fake_fetch_json(url: str) -> object:
+        seen_urls.append(url)
+        return [
+            {
+                "id": "target_1",
+                "type": "page",
+                "title": "Dashboard",
+                "url": "https://example.com/dashboard",
+                "webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/page/1",
+            }
+        ]
+
+    discovery = ChromeCdpTargetDiscovery(
+        "http://127.0.0.1:9222/",
+        fetch_json=fake_fetch_json,
+    )
+    config = build_default_browser_session_config(allowed_domains=["example.com"])
+
+    websocket_url = await discovery.resolve_websocket_url(config)
+
+    assert seen_urls == ["http://127.0.0.1:9222/json/list"]
+    assert websocket_url == "ws://127.0.0.1:9222/devtools/page/1"

--- a/autocontext/tests/test_browser_evidence.py
+++ b/autocontext/tests/test_browser_evidence.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autocontext.integrations.browser.evidence import BrowserEvidenceStore
+
+
+def test_append_audit_event_writes_jsonl(tmp_path: Path) -> None:
+    store = BrowserEvidenceStore(tmp_path)
+    event = {
+        "schemaVersion": "1.0",
+        "eventId": "evt_1",
+        "sessionId": "session_1",
+        "actionId": "act_1",
+        "kind": "action_result",
+        "allowed": True,
+        "policyReason": "allowed",
+        "timestamp": "2026-04-22T12:00:02Z",
+        "message": "navigation allowed",
+        "beforeUrl": "about:blank",
+        "afterUrl": "https://example.com",
+        "artifacts": {
+            "htmlPath": None,
+            "screenshotPath": None,
+            "downloadPath": None,
+        },
+    }
+
+    path = store.append_audit_event(event)
+
+    assert path.exists()
+    assert path.name == "actions.jsonl"
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["eventId"] == "evt_1"
+
+
+def test_persist_snapshot_artifacts_writes_html_and_png(tmp_path: Path) -> None:
+    store = BrowserEvidenceStore(tmp_path)
+
+    result = store.persist_snapshot_artifacts(
+        session_id="session_1",
+        basename="snap_1",
+        html="<html><body>Hello</body></html>",
+        screenshot_base64="cG5nLWJ5dGVz",
+    )
+
+    assert result["htmlPath"] is not None
+    assert result["screenshotPath"] is not None
+    html_path = Path(result["htmlPath"])
+    screenshot_path = Path(result["screenshotPath"])
+    assert html_path.read_text(encoding="utf-8") == "<html><body>Hello</body></html>"
+    assert screenshot_path.read_bytes() == b"png-bytes"

--- a/autocontext/tests/test_browser_evidence.py
+++ b/autocontext/tests/test_browser_evidence.py
@@ -52,3 +52,20 @@ def test_persist_snapshot_artifacts_writes_html_and_png(tmp_path: Path) -> None:
     screenshot_path = Path(result["screenshotPath"])
     assert html_path.read_text(encoding="utf-8") == "<html><body>Hello</body></html>"
     assert screenshot_path.read_bytes() == b"png-bytes"
+
+
+def test_persist_snapshot_artifacts_contains_traversal_names(tmp_path: Path) -> None:
+    store = BrowserEvidenceStore(tmp_path)
+
+    result = store.persist_snapshot_artifacts(
+        session_id="../session_1",
+        basename="../../../../../escaped",
+        screenshot_base64="cG5nLWJ5dGVz",
+    )
+
+    assert result["screenshotPath"] is not None
+    screenshot_path = Path(result["screenshotPath"]).resolve()
+    assert screenshot_path.is_relative_to(tmp_path.resolve())
+    assert screenshot_path.name == "escaped.png"
+    assert screenshot_path.read_bytes() == b"png-bytes"
+    assert not (tmp_path.parent / "escaped.png").exists()

--- a/autocontext/tests/test_browser_factory.py
+++ b/autocontext/tests/test_browser_factory.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autocontext.config.settings import AppSettings
+from autocontext.integrations.browser.chrome_cdp_runtime import ChromeCdpRuntime
+from autocontext.integrations.browser.factory import (
+    ConfiguredBrowserRuntime,
+    browser_runtime_from_settings,
+)
+
+
+def test_browser_runtime_from_settings_returns_none_when_disabled(tmp_path: Path) -> None:
+    settings = AppSettings(
+        browser_enabled=False,
+        runs_root=tmp_path / "runs",
+    )
+
+    assert browser_runtime_from_settings(settings) is None
+
+
+def test_browser_runtime_from_settings_builds_chrome_cdp_runtime(tmp_path: Path) -> None:
+    settings = AppSettings(
+        browser_enabled=True,
+        browser_backend="chrome-cdp",
+        browser_allowed_domains="example.com",
+        browser_debugger_url="http://127.0.0.1:9333",
+        browser_preferred_target_url="https://example.com/dashboard",
+        runs_root=tmp_path / "runs",
+    )
+
+    configured = browser_runtime_from_settings(settings)
+
+    assert isinstance(configured, ConfiguredBrowserRuntime)
+    assert configured.session_config.allowedDomains == ["example.com"]
+    assert isinstance(configured.runtime, ChromeCdpRuntime)
+    assert configured.runtime.debugger_url == "http://127.0.0.1:9333"
+    assert configured.runtime.preferred_target_url == "https://example.com/dashboard"
+    assert configured.runtime.evidence_root == (tmp_path / "runs").resolve()
+
+
+def test_browser_runtime_from_settings_rejects_unknown_backend(tmp_path: Path) -> None:
+    settings = AppSettings(
+        browser_enabled=True,
+        browser_backend="mystery",
+        runs_root=tmp_path / "runs",
+    )
+
+    with pytest.raises(ValueError, match="unsupported browser backend"):
+        browser_runtime_from_settings(settings)

--- a/autocontext/tests/test_browser_runtime.py
+++ b/autocontext/tests/test_browser_runtime.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autocontext.integrations.browser.chrome_cdp import ChromeCdpSession
+from autocontext.integrations.browser.chrome_cdp_runtime import ChromeCdpRuntime
+from autocontext.integrations.browser.policy import build_default_browser_session_config
+
+
+class FakeTransport:
+    async def send(self, method: str, params: dict | None = None) -> dict:
+        return {}
+
+    async def close(self) -> None:
+        return None
+
+
+class FakeDiscovery:
+    def __init__(self, websocket_url: str) -> None:
+        self.websocket_url = websocket_url
+        self.calls: list[tuple[object, str | None]] = []
+
+    async def resolve_websocket_url(self, config: object, *, preferred_url: str | None = None) -> str:
+        self.calls.append((config, preferred_url))
+        return self.websocket_url
+
+
+@pytest.mark.asyncio
+async def test_runtime_creates_session_with_transport_and_evidence(tmp_path: Path) -> None:
+    created_urls: list[str] = []
+    transport = FakeTransport()
+    runtime = ChromeCdpRuntime(
+        websocket_url="ws://127.0.0.1:9222/devtools/page/1",
+        evidence_root=tmp_path,
+        transport_factory=lambda url: created_urls.append(url) or transport,
+        session_id_factory=lambda: "session_fixed",
+    )
+
+    session = await runtime.create_session(
+        build_default_browser_session_config(allowed_domains=["example.com"]),
+    )
+
+    assert isinstance(session, ChromeCdpSession)
+    assert created_urls == ["ws://127.0.0.1:9222/devtools/page/1"]
+    assert session.session_id == "session_fixed"
+    assert session.transport is transport
+    assert session.evidence_store is not None
+    assert session.evidence_store.root_dir == tmp_path.resolve()
+
+
+@pytest.mark.asyncio
+async def test_runtime_resolves_transport_url_from_discovery(tmp_path: Path) -> None:
+    created_urls: list[str] = []
+    transport = FakeTransport()
+    discovery = FakeDiscovery("ws://127.0.0.1:9222/devtools/page/discovered")
+    runtime = ChromeCdpRuntime(
+        debugger_url="http://127.0.0.1:9222",
+        preferred_target_url="https://example.com/dashboard",
+        evidence_root=tmp_path,
+        target_discovery=discovery,
+        transport_factory=lambda url: created_urls.append(url) or transport,
+        session_id_factory=lambda: "session_fixed",
+    )
+    config = build_default_browser_session_config(allowed_domains=["example.com"])
+
+    session = await runtime.create_session(config)
+
+    assert isinstance(session, ChromeCdpSession)
+    assert created_urls == ["ws://127.0.0.1:9222/devtools/page/discovered"]
+    assert discovery.calls == [(config, "https://example.com/dashboard")]

--- a/autocontext/tests/test_browser_transport.py
+++ b/autocontext/tests/test_browser_transport.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from websockets.asyncio.server import serve
+
+from autocontext.integrations.browser.chrome_cdp_transport import (
+    ChromeCdpTransportError,
+    ChromeCdpWebSocketTransport,
+)
+
+
+@pytest.mark.asyncio
+async def test_websocket_transport_round_trips_cdp_commands() -> None:
+    received: list[dict[str, object]] = []
+
+    async def handler(websocket) -> None:  # type: ignore[no-untyped-def]
+        message = json.loads(await websocket.recv())
+        received.append(message)
+        await websocket.send(
+            json.dumps({
+                "id": message["id"],
+                "result": {
+                    "product": "Chrome",
+                    "echoMethod": message["method"],
+                    "echoParams": message["params"],
+                },
+            }),
+        )
+        await websocket.wait_closed()
+
+    async with serve(handler, "127.0.0.1", 0) as server:
+        port = int(server.sockets[0].getsockname()[1])
+        transport = ChromeCdpWebSocketTransport(f"ws://127.0.0.1:{port}/devtools/page/1")
+
+        response = await transport.send("Browser.getVersion", {"verbose": True})
+        await transport.close()
+
+    assert received == [
+        {
+            "id": 1,
+            "method": "Browser.getVersion",
+            "params": {"verbose": True},
+        }
+    ]
+    assert response["result"] == {
+        "product": "Chrome",
+        "echoMethod": "Browser.getVersion",
+        "echoParams": {"verbose": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_websocket_transport_raises_on_cdp_error() -> None:
+    async def handler(websocket) -> None:  # type: ignore[no-untyped-def]
+        message = json.loads(await websocket.recv())
+        await websocket.send(
+            json.dumps({
+                "id": message["id"],
+                "error": {
+                    "message": "domain blocked",
+                },
+            }),
+        )
+        await websocket.wait_closed()
+
+    async with serve(handler, "127.0.0.1", 0) as server:
+        port = int(server.sockets[0].getsockname()[1])
+        transport = ChromeCdpWebSocketTransport(f"ws://127.0.0.1:{port}/devtools/page/1")
+        with pytest.raises(ChromeCdpTransportError, match="domain blocked"):
+            await transport.send("Page.navigate", {"url": "https://blocked.example"})
+        await transport.close()

--- a/docs/browser-exploration-contract.md
+++ b/docs/browser-exploration-contract.md
@@ -19,7 +19,7 @@ The architecture is inspired by thin browser-control projects such as `browser-h
 
 ## Current Scope
 
-This foundation currently includes the shared contract, settings, validation, and policy layer. It does not yet ship a browser backend or CLI execution path.
+This foundation currently includes the shared contract, settings, validation, policy layer, and a thin Python Chrome/CDP attachment backend. It does not yet ship TypeScript browser execution or CLI investigation wiring.
 
 Included:
 
@@ -30,13 +30,14 @@ Included:
 - security-focused policy helpers for allowlists and auth-sensitive actions
 - mirrored `AUTOCONTEXT_BROWSER_*` settings in both packages
 - backend-agnostic session/runtime protocol types for future adapters
+- Python evidence stores for browser audit and snapshot artifacts
+- Python Chrome/CDP session wrappers for `navigate`, `snapshot`, `click`, `fill`, `press`, and `screenshot`
+- Python WebSocket CDP transport and debugger target discovery from `/json/list`
+- Python settings-backed runtime factory for attaching to an existing debugger target
 
 Not yet included:
 
-- thin CDP session wrappers or websocket transports
-- debugger target discovery from `/json/list`
-- browser evidence stores for audit and snapshot artifacts
-- settings-backed browser runtime factories
+- TypeScript browser runtime implementation beyond the shared contract and policy helpers
 - CLI investigation wiring such as `investigate --browser-url <url>`
 - browser process launching or lifecycle management
 - domain-skill persistence
@@ -90,9 +91,9 @@ Python exposes the matching validation and policy helpers under:
 
 - `autocontext.integrations.browser`
 
-Both surfaces are intentionally small and backend-agnostic so a thin CDP implementation can be introduced later without changing the contract.
+Both surfaces are intentionally small and backend-agnostic so additional runtime implementations can be introduced later without changing the contract.
 
-The reserved debugger settings are intended for a future attach-oriented CDP implementation:
+The Python CDP implementation is intentionally attach-oriented:
 
 - use `AUTOCONTEXT_BROWSER_DEBUGGER_URL` / `browserDebuggerUrl` to point at an existing Chrome debugger endpoint
 - use `AUTOCONTEXT_BROWSER_PREFERRED_TARGET_URL` / `browserPreferredTargetUrl` to prefer a specific page when multiple allowed targets are present


### PR DESCRIPTION
## Summary
- Add the Python Chrome CDP session, discovery, runtime, transport, evidence store, and settings-backed factory behind the AC-598 browser contract.
- Keep browser exploration attach-only and policy-gated, with deterministic tests for runtime/evidence/transport behavior.
- Export the Python backend surface without pulling it into the TypeScript package or queue orchestration yet.

## Tests
- cd autocontext && uv run pytest tests/test_browser_chrome_cdp.py tests/test_browser_discovery.py tests/test_browser_evidence.py tests/test_browser_factory.py tests/test_browser_runtime.py tests/test_browser_transport.py -q
- cd autocontext && uv run ruff check src/autocontext/integrations/browser tests/test_browser_chrome_cdp.py tests/test_browser_discovery.py tests/test_browser_evidence.py tests/test_browser_factory.py tests/test_browser_runtime.py tests/test_browser_transport.py
- cd autocontext && uv run mypy src/autocontext/integrations/browser

Linear: AC-599