### PR TITLE
AC-600: Add TypeScript Chrome CDP backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes in this section are on the branch/repo after `0.4.4` and are not part of
 ### Added
 
 - Added a shared browser exploration contract and package-safe configuration surface across Python and TypeScript, including canonical schemas, validation helpers, secure `AUTOCONTEXT_BROWSER_*` defaults, and policy helpers.
+- Added the TypeScript Chrome DevTools Protocol backend for browser exploration, including attach-only target discovery, websocket transport, policy-gated actions, and evidence artifacts.
 
 ## [0.4.4] - 2026-04-20
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -124,18 +124,20 @@ export type {
   BrowserSnapshot,
   BrowserSnapshotRef,
   BrowserValidationResult,
-} from "./integrations/browser/index.js";
+} from "./integrations/browser/types.js";
 export {
   BROWSER_CONTRACT_SCHEMA_VERSION,
-  buildDefaultBrowserSessionConfig,
-  evaluateBrowserActionPolicy,
-  normalizeBrowserAllowedDomains,
-  resolveBrowserSessionConfig,
   validateBrowserAction,
   validateBrowserAuditEvent,
   validateBrowserSessionConfig,
   validateBrowserSnapshot,
-} from "./integrations/browser/index.js";
+} from "./integrations/browser/contract/index.js";
+export {
+  buildDefaultBrowserSessionConfig,
+  evaluateBrowserActionPolicy,
+  normalizeBrowserAllowedDomains,
+  resolveBrowserSessionConfig,
+} from "./integrations/browser/policy.js";
 
 // Execution
 export { ImprovementLoop, isParseFailure, isImproved } from "./execution/improvement-loop.js";

--- a/ts/src/integrations/browser/chrome-cdp-discovery.ts
+++ b/ts/src/integrations/browser/chrome-cdp-discovery.ts
@@ -1,0 +1,140 @@
+import type { BrowserSessionConfig } from "./contract/index.js";
+import { evaluateBrowserActionPolicy } from "./policy.js";
+
+export class ChromeCdpDiscoveryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ChromeCdpDiscoveryError";
+  }
+}
+
+export interface ChromeCdpTarget {
+  readonly targetId: string;
+  readonly targetType: string;
+  readonly title: string;
+  readonly url: string;
+  readonly webSocketDebuggerUrl: string;
+}
+
+export interface ChromeCdpTargetDiscoveryPort {
+  resolveWebSocketUrl(
+    config: BrowserSessionConfig,
+    opts?: { preferredUrl?: string },
+  ): Promise<string>;
+}
+
+export interface BrowserFetchResponseLike {
+  readonly ok: boolean;
+  readonly status: number;
+  json(): Promise<unknown>;
+}
+
+export type BrowserFetchFn = (input: string, init?: RequestInit) => Promise<BrowserFetchResponseLike>;
+
+export interface ChromeCdpTargetDiscoveryOpts {
+  readonly debuggerUrl: string;
+  readonly fetchFn?: BrowserFetchFn;
+}
+
+export class ChromeCdpTargetDiscovery implements ChromeCdpTargetDiscoveryPort {
+  readonly debuggerUrl: string;
+
+  private readonly fetchFn: BrowserFetchFn;
+
+  constructor(opts: ChromeCdpTargetDiscoveryOpts) {
+    this.debuggerUrl = opts.debuggerUrl.replace(/\/+$/, "");
+    this.fetchFn = opts.fetchFn ?? defaultFetch;
+  }
+
+  async listTargets(): Promise<ChromeCdpTarget[]> {
+    const response = await this.fetchFn(`${this.debuggerUrl}/json/list`);
+    if (!response.ok) {
+      throw new ChromeCdpDiscoveryError(
+        `Debugger target discovery failed with HTTP ${response.status}`,
+      );
+    }
+    const payload = await response.json();
+    if (!Array.isArray(payload)) {
+      throw new ChromeCdpDiscoveryError("Debugger target discovery expected a JSON array from /json/list");
+    }
+    return payload.flatMap((entry) => {
+      const target = parseTarget(entry);
+      return target ? [target] : [];
+    });
+  }
+
+  async resolveWebSocketUrl(
+    config: BrowserSessionConfig,
+    opts: { preferredUrl?: string } = {},
+  ): Promise<string> {
+    const target = selectChromeCdpTarget(await this.listTargets(), config, opts);
+    return target.webSocketDebuggerUrl;
+  }
+}
+
+export function selectChromeCdpTarget(
+  targets: readonly ChromeCdpTarget[],
+  config: BrowserSessionConfig,
+  opts: { preferredUrl?: string } = {},
+): ChromeCdpTarget {
+  const attachableTargets = targets.filter(
+    (target) => target.targetType === "page" && target.webSocketDebuggerUrl.length > 0,
+  );
+  if (opts.preferredUrl) {
+    const preferredTarget = attachableTargets.find((target) => target.url === opts.preferredUrl);
+    if (preferredTarget) {
+      if (isTargetAllowed(config, preferredTarget.url)) {
+        return preferredTarget;
+      }
+      throw new ChromeCdpDiscoveryError(
+        `Preferred debugger target is not allowed by browser policy: ${opts.preferredUrl}`,
+      );
+    }
+  }
+
+  const allowedTargets = attachableTargets.filter((target) => isTargetAllowed(config, target.url));
+  if (allowedTargets.length > 0) {
+    return allowedTargets[0];
+  }
+  if (attachableTargets.length === 0) {
+    throw new ChromeCdpDiscoveryError("No attachable page targets were advertised by the debugger");
+  }
+  if (opts.preferredUrl) {
+    throw new ChromeCdpDiscoveryError(`Preferred debugger target was not found: ${opts.preferredUrl}`);
+  }
+  throw new ChromeCdpDiscoveryError("No debugger targets matched the browser allowlist");
+}
+
+function parseTarget(payload: unknown): ChromeCdpTarget | null {
+  if (!isRecord(payload) || typeof payload.id !== "string" || typeof payload.type !== "string") {
+    return null;
+  }
+  return {
+    targetId: payload.id,
+    targetType: payload.type,
+    title: typeof payload.title === "string" ? payload.title : "",
+    url: typeof payload.url === "string" ? payload.url : "",
+    webSocketDebuggerUrl:
+      typeof payload.webSocketDebuggerUrl === "string" ? payload.webSocketDebuggerUrl : "",
+  };
+}
+
+function isTargetAllowed(config: BrowserSessionConfig, url: string): boolean {
+  return evaluateBrowserActionPolicy(config, {
+    schemaVersion: "1.0",
+    actionId: "act_discovery_probe",
+    sessionId: "session_discovery",
+    timestamp: new Date().toISOString(),
+    type: "navigate",
+    params: { url },
+  }).allowed;
+}
+
+async function defaultFetch(input: string, init?: RequestInit): Promise<BrowserFetchResponseLike> {
+  const response = await fetch(input, init);
+  return response;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/ts/src/integrations/browser/chrome-cdp-runtime.ts
+++ b/ts/src/integrations/browser/chrome-cdp-runtime.ts
@@ -1,0 +1,75 @@
+import { randomUUID } from "node:crypto";
+import { ChromeCdpSession, type ChromeCdpTransport } from "./chrome-cdp.js";
+import {
+  ChromeCdpTargetDiscovery,
+  type ChromeCdpTargetDiscoveryPort,
+} from "./chrome-cdp-discovery.js";
+import { ChromeCdpWebSocketTransport } from "./chrome-cdp-transport.js";
+import { BrowserEvidenceStore } from "./evidence.js";
+import type { BrowserRuntimePort, BrowserSessionConfig, BrowserSessionPort } from "./types.js";
+
+export type ChromeCdpTransportFactory = (url: string) => ChromeCdpTransport;
+export type BrowserSessionIdFactory = () => string;
+
+export interface ChromeCdpRuntimeOpts {
+  readonly websocketUrl?: string;
+  readonly debuggerUrl?: string;
+  readonly preferredTargetUrl?: string;
+  readonly evidenceRoot?: string;
+  readonly targetDiscovery?: ChromeCdpTargetDiscoveryPort;
+  readonly transportFactory?: ChromeCdpTransportFactory;
+  readonly sessionIdFactory?: BrowserSessionIdFactory;
+}
+
+export class ChromeCdpRuntime implements BrowserRuntimePort {
+  readonly websocketUrl: string | null;
+  readonly debuggerUrl: string | null;
+  readonly evidenceRoot: string | null;
+  readonly preferredTargetUrl: string | null;
+
+  private readonly transportFactory: ChromeCdpTransportFactory;
+  private readonly sessionIdFactory: BrowserSessionIdFactory;
+  private readonly targetDiscovery: ChromeCdpTargetDiscoveryPort | null;
+
+  constructor(opts: ChromeCdpRuntimeOpts) {
+    if (!opts.websocketUrl && !opts.debuggerUrl && !opts.targetDiscovery) {
+      throw new Error("ChromeCdpRuntime requires websocketUrl, debuggerUrl, or targetDiscovery");
+    }
+    this.websocketUrl = opts.websocketUrl ?? null;
+    this.debuggerUrl = opts.debuggerUrl ?? null;
+    this.evidenceRoot = opts.evidenceRoot ?? null;
+    this.preferredTargetUrl = opts.preferredTargetUrl ?? null;
+    this.targetDiscovery = opts.targetDiscovery ?? null;
+    this.transportFactory = opts.transportFactory ?? ((url) => new ChromeCdpWebSocketTransport({ url }));
+    this.sessionIdFactory = opts.sessionIdFactory ?? defaultSessionId;
+  }
+
+  async createSession(config: BrowserSessionConfig): Promise<BrowserSessionPort> {
+    const websocketUrl = await this.resolveWebSocketUrl(config);
+    return new ChromeCdpSession({
+      sessionId: this.sessionIdFactory(),
+      config,
+      transport: this.transportFactory(websocketUrl),
+      evidenceStore: this.evidenceRoot ? new BrowserEvidenceStore({ rootDir: this.evidenceRoot }) : undefined,
+    });
+  }
+
+  private async resolveWebSocketUrl(config: BrowserSessionConfig): Promise<string> {
+    if (this.websocketUrl) {
+      return this.websocketUrl;
+    }
+    const discovery =
+      this.targetDiscovery ??
+      (this.debuggerUrl ? new ChromeCdpTargetDiscovery({ debuggerUrl: this.debuggerUrl }) : null);
+    if (!discovery) {
+      throw new Error("ChromeCdpRuntime cannot resolve a websocket target without discovery");
+    }
+    return await discovery.resolveWebSocketUrl(config, {
+      preferredUrl: this.preferredTargetUrl ?? undefined,
+    });
+  }
+}
+
+function defaultSessionId(): string {
+  return `browser_${randomUUID().replaceAll("-", "")}`;
+}

--- a/ts/src/integrations/browser/chrome-cdp-transport.ts
+++ b/ts/src/integrations/browser/chrome-cdp-transport.ts
@@ -1,0 +1,229 @@
+import WebSocket from "ws";
+
+export class ChromeCdpTransportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ChromeCdpTransportError";
+  }
+}
+
+export interface BrowserWebSocketLike {
+  readonly readyState: number;
+  on(event: "message", listener: (data: unknown) => void): this;
+  on(event: "close", listener: () => void): this;
+  on(event: "error", listener: (error: Error) => void): this;
+  once(event: "open", listener: () => void): this;
+  once(event: "error", listener: (error: Error) => void): this;
+  once(event: "close", listener: () => void): this;
+  removeListener(event: "open" | "error" | "close", listener: (...args: any[]) => void): this;
+  send(data: string): void;
+  close(): void;
+}
+
+export type BrowserWebSocketFactory = (url: string) => BrowserWebSocketLike;
+
+export interface ChromeCdpWebSocketTransportOpts {
+  readonly url: string;
+  readonly connectionTimeoutMs?: number;
+  readonly webSocketFactory?: BrowserWebSocketFactory;
+}
+
+type PendingRequest = {
+  readonly resolve: (value: Record<string, unknown>) => void;
+  readonly reject: (error: Error) => void;
+};
+
+const OPEN_READY_STATE = 1;
+const CLOSED_READY_STATE = 3;
+
+export class ChromeCdpWebSocketTransport {
+  readonly url: string;
+  readonly connectionTimeoutMs: number;
+
+  private readonly webSocketFactory: BrowserWebSocketFactory;
+  private socket: BrowserWebSocketLike | null = null;
+  private connectPromise: Promise<void> | null = null;
+  private nextId = 0;
+  private readonly pending = new Map<number, PendingRequest>();
+
+  constructor(opts: ChromeCdpWebSocketTransportOpts) {
+    this.url = opts.url;
+    this.connectionTimeoutMs = opts.connectionTimeoutMs ?? 5_000;
+    this.webSocketFactory = opts.webSocketFactory ?? ((url) => new WebSocket(url));
+  }
+
+  async connect(): Promise<void> {
+    if (this.socket && this.socket.readyState === OPEN_READY_STATE) {
+      return;
+    }
+    if (this.connectPromise) {
+      return this.connectPromise;
+    }
+
+    this.connectPromise = new Promise<void>((resolve, reject) => {
+      const socket = this.webSocketFactory(this.url);
+      const timeout = setTimeout(() => {
+        reject(new ChromeCdpTransportError(`Timed out connecting to CDP websocket: ${this.url}`));
+      }, this.connectionTimeoutMs);
+
+      const onOpen = () => {
+        clearTimeout(timeout);
+        socket.removeListener("error", onError);
+        this.socket = socket;
+        resolve();
+      };
+
+      const onError = (error: Error) => {
+        clearTimeout(timeout);
+        socket.removeListener("open", onOpen);
+        reject(new ChromeCdpTransportError(`Failed to connect to CDP websocket: ${error.message}`));
+      };
+
+      this.attachSocketHandlers(socket);
+      socket.once("open", onOpen);
+      socket.once("error", onError);
+    });
+
+    try {
+      await this.connectPromise;
+    } finally {
+      this.connectPromise = null;
+    }
+  }
+
+  async send(method: string, params: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    await this.connect();
+    const socket = this.socket;
+    if (!socket || socket.readyState !== OPEN_READY_STATE) {
+      throw new ChromeCdpTransportError("CDP websocket is not connected");
+    }
+
+    this.nextId += 1;
+    const id = this.nextId;
+
+    return await new Promise<Record<string, unknown>>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      try {
+        socket.send(JSON.stringify({ id, method, params }));
+      } catch (error) {
+        this.pending.delete(id);
+        reject(asTransportError(error, `Failed to send CDP message ${method}`));
+      }
+    });
+  }
+
+  async close(): Promise<void> {
+    const socket = this.socket;
+    this.socket = null;
+    if (!socket) {
+      if (this.connectPromise) {
+        await this.connectPromise.catch(() => undefined);
+      }
+      return;
+    }
+    if (socket.readyState === CLOSED_READY_STATE) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      socket.once("close", () => resolve());
+      socket.close();
+    });
+  }
+
+  private attachSocketHandlers(socket: BrowserWebSocketLike): void {
+    socket.on("message", (data) => {
+      const payload = decodeMessage(data);
+      if (!payload) {
+        return;
+      }
+      const messageId = payload.id;
+      if (typeof messageId !== "number") {
+        return;
+      }
+      const pending = this.pending.get(messageId);
+      if (!pending) {
+        return;
+      }
+      this.pending.delete(messageId);
+      if (isRecord(payload.error)) {
+        pending.reject(new ChromeCdpTransportError(errorMessage(payload.error)));
+        return;
+      }
+      pending.resolve(payload);
+    });
+
+    socket.on("close", () => {
+      this.failPending(new ChromeCdpTransportError("CDP websocket closed"));
+      this.socket = null;
+    });
+
+    socket.on("error", (error) => {
+      if (!this.connectPromise) {
+        this.failPending(new ChromeCdpTransportError(`CDP websocket failed: ${error.message}`));
+        this.socket = null;
+      }
+    });
+  }
+
+  private failPending(error: ChromeCdpTransportError): void {
+    const entries = [...this.pending.values()];
+    this.pending.clear();
+    for (const pending of entries) {
+      pending.reject(error);
+    }
+  }
+}
+
+function decodeMessage(data: unknown): Record<string, unknown> | null {
+  const text = rawDataToString(data);
+  if (text === null) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function rawDataToString(data: unknown): string | null {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString("utf-8");
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString("utf-8");
+  }
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("utf-8");
+  }
+  if (Array.isArray(data) && data.every((entry) => Buffer.isBuffer(entry))) {
+    return Buffer.concat(data).toString("utf-8");
+  }
+  return null;
+}
+
+function errorMessage(error: Record<string, unknown>): string {
+  const message = error.message;
+  if (typeof message === "string" && message.length > 0) {
+    return message;
+  }
+  return `CDP error: ${JSON.stringify(error)}`;
+}
+
+function asTransportError(error: unknown, prefix: string): ChromeCdpTransportError {
+  if (error instanceof ChromeCdpTransportError) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return new ChromeCdpTransportError(`${prefix}: ${error.message}`);
+  }
+  return new ChromeCdpTransportError(prefix);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/ts/src/integrations/browser/chrome-cdp.ts
+++ b/ts/src/integrations/browser/chrome-cdp.ts
@@ -1,0 +1,480 @@
+import { randomUUID } from "node:crypto";
+import type {
+  BrowserAction,
+  BrowserAuditEvent,
+  BrowserFieldKind,
+  BrowserPolicyDecision,
+  BrowserSessionConfig,
+  BrowserSnapshot,
+  BrowserSnapshotRef,
+  BrowserValidationResult,
+} from "./contract/index.js";
+import {
+  BROWSER_CONTRACT_SCHEMA_VERSION,
+  validateBrowserAction,
+  validateBrowserAuditEvent,
+  validateBrowserSnapshot,
+} from "./contract/index.js";
+import type { BrowserArtifactPaths } from "./evidence.js";
+import { BrowserEvidenceStore } from "./evidence.js";
+import { evaluateBrowserActionPolicy } from "./policy.js";
+import type { BrowserSessionPort } from "./types.js";
+
+const SNAPSHOT_EXPRESSION = `
+(() => {
+  const cssEscape = (value) =>
+    globalThis.CSS?.escape
+      ? CSS.escape(value)
+      : String(value).replace(/[^a-zA-Z0-9_-]/g, "\\\\$&");
+  const selectorFor = (element) => {
+    if (element.id) return "#" + cssEscape(element.id);
+    const parts = [];
+    let current = element;
+    while (current && current.nodeType === Node.ELEMENT_NODE && current !== document.documentElement) {
+      const tag = current.tagName.toLowerCase();
+      const parent = current.parentElement;
+      if (!parent) {
+        parts.unshift(tag);
+        break;
+      }
+      const siblings = Array.from(parent.children).filter((sibling) => sibling.tagName === current.tagName);
+      const index = siblings.indexOf(current) + 1;
+      parts.unshift(siblings.length > 1 ? tag + ":nth-of-type(" + index + ")" : tag);
+      current = parent;
+      if (parts.length >= 4) break;
+    }
+    return parts.join(" > ");
+  };
+  const candidates = Array.from(
+    document.querySelectorAll("a,button,input,select,textarea,[role],[tabindex]")
+  ).slice(0, 200);
+  const refs = candidates.map((element, index) => ({
+    id: \`@e\${index + 1}\`,
+    role: element.getAttribute("role") ?? element.tagName.toLowerCase(),
+    name:
+      element.getAttribute("aria-label") ??
+      element.getAttribute("name") ??
+      element.textContent?.trim() ??
+      null,
+    text: element.textContent?.trim() ?? null,
+    selector: selectorFor(element),
+    disabled: element.hasAttribute("disabled"),
+  }));
+  return {
+    url: window.location.href,
+    title: document.title ?? "",
+    visibleText: document.body?.innerText ?? "",
+    refs,
+    html: document.documentElement?.outerHTML ?? "",
+  };
+})()
+`.trim();
+
+export interface ChromeCdpTransport {
+  send(method: string, params?: Record<string, unknown>): Promise<Record<string, unknown>>;
+  close(): Promise<void>;
+}
+
+export interface ChromeCdpSessionOpts {
+  readonly sessionId: string;
+  readonly config: BrowserSessionConfig;
+  readonly transport: ChromeCdpTransport;
+  readonly evidenceStore?: BrowserEvidenceStore;
+}
+
+type BrowserActionFor<TType extends BrowserAction["type"]> = Extract<BrowserAction, { type: TType }>;
+
+export class ChromeCdpSession implements BrowserSessionPort {
+  readonly config: BrowserSessionConfig;
+  readonly sessionId: string;
+  readonly transport: ChromeCdpTransport;
+  readonly evidenceStore?: BrowserEvidenceStore;
+
+  private currentUrl = "about:blank";
+  private domainsEnabled = false;
+  private readonly refSelectors = new Map<string, string>();
+
+  constructor(opts: ChromeCdpSessionOpts) {
+    this.sessionId = opts.sessionId;
+    this.config = opts.config;
+    this.transport = opts.transport;
+    this.evidenceStore = opts.evidenceStore;
+  }
+
+  async navigate(url: string): Promise<BrowserAuditEvent> {
+    const action = buildAction(this.sessionId, "navigate", { url });
+    const decision = evaluateBrowserActionPolicy(this.config, action);
+    if (!decision.allowed) {
+      return this.recordActionResult({
+        action,
+        decision,
+        beforeUrl: this.currentUrl,
+        afterUrl: this.currentUrl,
+        message: "navigation blocked by browser policy",
+      });
+    }
+
+    await this.ensureDomainsEnabled();
+    const beforeUrl = this.currentUrl;
+    await this.transport.send("Page.navigate", { url });
+    this.currentUrl = url;
+    return this.recordActionResult({
+      action,
+      decision,
+      beforeUrl,
+      afterUrl: url,
+      message: "navigation allowed",
+    });
+  }
+
+  async snapshot(): Promise<BrowserSnapshot> {
+    const action = buildAction(this.sessionId, "snapshot", {
+      captureHtml: true,
+      captureScreenshot: this.config.captureScreenshots,
+    });
+    await this.ensureDomainsEnabled();
+
+    const response = await this.transport.send("Runtime.evaluate", {
+      expression: SNAPSHOT_EXPRESSION,
+      returnByValue: true,
+      awaitPromise: true,
+    });
+    const payload = extractResultValue(response);
+    const refs = extractRefs(payload.refs);
+
+    this.refSelectors.clear();
+    for (const ref of refs) {
+      if (typeof ref.selector === "string" && ref.selector.length > 0) {
+        this.refSelectors.set(ref.id, ref.selector);
+      }
+    }
+
+    let screenshotBase64: string | null = null;
+    if (this.config.captureScreenshots) {
+      const screenshotResponse = await this.transport.send("Page.captureScreenshot", { format: "png" });
+      screenshotBase64 = typeof screenshotResponse.data === "string" ? screenshotResponse.data : null;
+    }
+
+    const artifacts = this.persistSnapshotArtifacts({
+      basename: action.actionId,
+      html: typeof payload.html === "string" ? payload.html : null,
+      screenshotBase64,
+    });
+
+    if (typeof payload.url === "string" && payload.url.length > 0) {
+      this.currentUrl = payload.url;
+    }
+
+    return assertValidDocument(
+      "browser snapshot",
+      {
+        schemaVersion: BROWSER_CONTRACT_SCHEMA_VERSION,
+        sessionId: this.sessionId,
+        capturedAt: new Date().toISOString(),
+        url: this.currentUrl,
+        title: typeof payload.title === "string" ? payload.title : "",
+        refs,
+        visibleText: typeof payload.visibleText === "string" ? payload.visibleText : "",
+        htmlPath: artifacts.htmlPath,
+        screenshotPath: artifacts.screenshotPath,
+      },
+      validateBrowserSnapshot,
+    );
+  }
+
+  async click(ref: string): Promise<BrowserAuditEvent> {
+    const action = buildAction(this.sessionId, "click", { ref });
+    const decision = evaluateBrowserActionPolicy(this.config, action);
+    if (!decision.allowed) {
+      return this.recordActionResult({
+        action,
+        decision,
+        beforeUrl: this.currentUrl,
+        afterUrl: this.currentUrl,
+      });
+    }
+
+    await this.ensureDomainsEnabled();
+    const selector = this.selectorForRef(ref);
+    await this.transport.send("Runtime.evaluate", {
+      expression: buildClickExpression(selector),
+      returnByValue: true,
+      awaitPromise: true,
+    });
+    return this.recordActionResult({
+      action,
+      decision,
+      beforeUrl: this.currentUrl,
+      afterUrl: this.currentUrl,
+      message: "click allowed",
+    });
+  }
+
+  async fill(
+    ref: string,
+    text: string,
+    opts: { fieldKind?: BrowserFieldKind } = {},
+  ): Promise<BrowserAuditEvent> {
+    const action = buildAction(this.sessionId, "fill", {
+      ref,
+      text,
+      fieldKind: opts.fieldKind,
+    });
+    const decision = evaluateBrowserActionPolicy(this.config, action);
+    if (!decision.allowed) {
+      return this.recordActionResult({
+        action,
+        decision,
+        beforeUrl: this.currentUrl,
+        afterUrl: this.currentUrl,
+        message: "fill blocked by browser policy",
+      });
+    }
+
+    await this.ensureDomainsEnabled();
+    const selector = this.selectorForRef(ref);
+    await this.transport.send("Runtime.evaluate", {
+      expression: buildFillExpression(selector, text),
+      returnByValue: true,
+      awaitPromise: true,
+    });
+    return this.recordActionResult({
+      action,
+      decision,
+      beforeUrl: this.currentUrl,
+      afterUrl: this.currentUrl,
+      message: "fill allowed",
+    });
+  }
+
+  async press(key: string): Promise<BrowserAuditEvent> {
+    const action = buildAction(this.sessionId, "press", { key });
+    const decision = evaluateBrowserActionPolicy(this.config, action);
+    if (!decision.allowed) {
+      return this.recordActionResult({
+        action,
+        decision,
+        beforeUrl: this.currentUrl,
+        afterUrl: this.currentUrl,
+      });
+    }
+
+    await this.ensureDomainsEnabled();
+    await this.transport.send("Runtime.evaluate", {
+      expression: buildPressExpression(key),
+      returnByValue: true,
+      awaitPromise: true,
+    });
+    return this.recordActionResult({
+      action,
+      decision,
+      beforeUrl: this.currentUrl,
+      afterUrl: this.currentUrl,
+      message: "key press allowed",
+    });
+  }
+
+  async screenshot(name: string): Promise<BrowserAuditEvent> {
+    const action = buildAction(this.sessionId, "screenshot", { name });
+    const decision = evaluateBrowserActionPolicy(this.config, action);
+    if (!decision.allowed) {
+      return this.recordActionResult({
+        action,
+        decision,
+        beforeUrl: this.currentUrl,
+        afterUrl: this.currentUrl,
+      });
+    }
+
+    await this.ensureDomainsEnabled();
+    const response = await this.transport.send("Page.captureScreenshot", { format: "png" });
+    const artifacts = this.persistSnapshotArtifacts({
+      basename: name,
+      screenshotBase64: typeof response.data === "string" ? response.data : null,
+    });
+    return this.recordActionResult({
+      action,
+      decision,
+      beforeUrl: this.currentUrl,
+      afterUrl: this.currentUrl,
+      message: "screenshot captured",
+      artifacts,
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.transport.close();
+  }
+
+  private async ensureDomainsEnabled(): Promise<void> {
+    if (this.domainsEnabled) {
+      return;
+    }
+    await this.transport.send("Page.enable", {});
+    await this.transport.send("Runtime.enable", {});
+    this.domainsEnabled = true;
+  }
+
+  private recordActionResult(opts: {
+    readonly action: BrowserAction;
+    readonly decision: BrowserPolicyDecision;
+    readonly beforeUrl: string | null;
+    readonly afterUrl: string | null;
+    readonly message?: string;
+    readonly artifacts?: BrowserArtifactPaths;
+  }): BrowserAuditEvent {
+    const rawEvent: BrowserAuditEvent = {
+      schemaVersion: BROWSER_CONTRACT_SCHEMA_VERSION,
+      eventId: newId("evt"),
+      sessionId: this.sessionId,
+      actionId: opts.action.actionId,
+      kind: "action_result",
+      allowed: opts.decision.allowed,
+      policyReason: opts.decision.reason,
+      timestamp: new Date().toISOString(),
+      message: opts.message ?? null,
+      beforeUrl: opts.beforeUrl,
+      afterUrl: opts.afterUrl,
+      artifacts: opts.artifacts ?? emptyArtifacts(),
+    };
+    const event = assertValidDocument("browser audit event", rawEvent, validateBrowserAuditEvent);
+    this.evidenceStore?.appendAuditEvent(event);
+    return event;
+  }
+
+  private persistSnapshotArtifacts(opts: {
+    readonly basename: string;
+    readonly html?: string | null;
+    readonly screenshotBase64?: string | null;
+  }): BrowserArtifactPaths {
+    return (
+      this.evidenceStore?.persistSnapshotArtifacts({
+        sessionId: this.sessionId,
+        basename: opts.basename,
+        html: opts.html,
+        screenshotBase64: opts.screenshotBase64,
+      }) ?? emptyArtifacts()
+    );
+  }
+
+  private selectorForRef(ref: string): string {
+    return this.refSelectors.get(ref) ?? ref;
+  }
+}
+
+function buildAction<TType extends BrowserAction["type"]>(
+  sessionId: string,
+  type: TType,
+  params: BrowserActionFor<TType>["params"],
+): BrowserActionFor<TType> {
+  const rawAction = {
+    schemaVersion: BROWSER_CONTRACT_SCHEMA_VERSION,
+    actionId: newId("act"),
+    sessionId,
+    timestamp: new Date().toISOString(),
+    type,
+    params,
+  } as unknown as BrowserActionFor<TType>;
+  return assertValidDocument(
+    "browser action",
+    rawAction,
+    validateBrowserAction,
+  );
+}
+
+function assertValidDocument<T>(
+  label: string,
+  value: T,
+  validate: (input: unknown) => BrowserValidationResult,
+): T {
+  const result = validate(value);
+  if (!result.valid) {
+    throw new TypeError(`invalid ${label}: ${result.errors.join("; ")}`);
+  }
+  return value;
+}
+
+function extractResultValue(response: Record<string, unknown>): Record<string, unknown> {
+  const result = response.result;
+  if (!isRecord(result)) {
+    return {};
+  }
+  const value = result.value;
+  return isRecord(value) ? value : {};
+}
+
+function extractRefs(raw: unknown): BrowserSnapshotRef[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.flatMap((entry) => {
+    if (!isRecord(entry) || typeof entry.id !== "string") {
+      return [];
+    }
+    return [
+      {
+        id: entry.id,
+        role: typeof entry.role === "string" ? entry.role : undefined,
+        name: typeof entry.name === "string" ? entry.name : undefined,
+        text: typeof entry.text === "string" ? entry.text : undefined,
+        selector: typeof entry.selector === "string" ? entry.selector : undefined,
+        disabled: typeof entry.disabled === "boolean" ? entry.disabled : undefined,
+      },
+    ];
+  });
+}
+
+function buildClickExpression(selector: string): string {
+  return `
+(() => {
+  const element = document.querySelector(${JSON.stringify(selector)});
+  if (!element) return { ok: false, error: "selector_not_found" };
+  element.click();
+  return { ok: true };
+})()
+`.trim();
+}
+
+function buildFillExpression(selector: string, text: string): string {
+  return `
+(() => {
+  const element = document.querySelector(${JSON.stringify(selector)});
+  if (!element) return { ok: false, error: "selector_not_found" };
+  element.focus?.();
+  if ("value" in element) {
+    element.value = ${JSON.stringify(text)};
+  }
+  element.dispatchEvent(new Event("input", { bubbles: true }));
+  element.dispatchEvent(new Event("change", { bubbles: true }));
+  return { ok: true };
+})()
+`.trim();
+}
+
+function buildPressExpression(key: string): string {
+  return `
+(() => {
+  const target = document.activeElement ?? document.body;
+  if (!target) return { ok: false, error: "missing_target" };
+  target.dispatchEvent(new KeyboardEvent("keydown", { key: ${JSON.stringify(key)}, bubbles: true }));
+  target.dispatchEvent(new KeyboardEvent("keyup", { key: ${JSON.stringify(key)}, bubbles: true }));
+  return { ok: true };
+})()
+`.trim();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function emptyArtifacts(): BrowserArtifactPaths {
+  return {
+    htmlPath: null,
+    screenshotPath: null,
+    downloadPath: null,
+  };
+}
+
+function newId(prefix: string): string {
+  return `${prefix}_${randomUUID().replaceAll("-", "")}`;
+}

--- a/ts/src/integrations/browser/evidence.ts
+++ b/ts/src/integrations/browser/evidence.ts
@@ -1,0 +1,74 @@
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { canonicalJsonStringify } from "../../control-plane/contract/canonical-json.js";
+import type { BrowserAuditEvent } from "./contract/index.js";
+import { validateBrowserAuditEvent } from "./contract/index.js";
+
+export interface BrowserArtifactPaths {
+  readonly htmlPath: string | null;
+  readonly screenshotPath: string | null;
+  readonly downloadPath: string | null;
+}
+
+export interface BrowserEvidenceStoreOpts {
+  readonly rootDir: string;
+}
+
+export interface PersistSnapshotArtifactsOpts {
+  readonly sessionId: string;
+  readonly basename: string;
+  readonly html?: string | null;
+  readonly screenshotBase64?: string | null;
+}
+
+export class BrowserEvidenceStore {
+  readonly rootDir: string;
+
+  constructor(opts: BrowserEvidenceStoreOpts) {
+    this.rootDir = resolve(opts.rootDir);
+  }
+
+  appendAuditEvent(event: BrowserAuditEvent): string {
+    assertValidAuditEvent(event);
+    const sessionDir = this.sessionDir(event.sessionId);
+    mkdirSync(sessionDir, { recursive: true });
+    const outPath = join(sessionDir, "actions.jsonl");
+    appendFileSync(outPath, canonicalJsonStringify(event) + "\n", "utf-8");
+    return outPath;
+  }
+
+  persistSnapshotArtifacts(opts: PersistSnapshotArtifactsOpts): BrowserArtifactPaths {
+    const sessionDir = this.sessionDir(opts.sessionId);
+    let htmlPath: string | null = null;
+    let screenshotPath: string | null = null;
+
+    if (opts.html !== undefined && opts.html !== null) {
+      htmlPath = join(sessionDir, "html", `${opts.basename}.html`);
+      mkdirSync(join(sessionDir, "html"), { recursive: true });
+      writeFileSync(htmlPath, opts.html, "utf-8");
+    }
+
+    if (opts.screenshotBase64 !== undefined && opts.screenshotBase64 !== null) {
+      screenshotPath = join(sessionDir, "screenshots", `${opts.basename}.png`);
+      mkdirSync(join(sessionDir, "screenshots"), { recursive: true });
+      writeFileSync(screenshotPath, Buffer.from(opts.screenshotBase64, "base64"));
+    }
+
+    return {
+      htmlPath,
+      screenshotPath,
+      downloadPath: null,
+    };
+  }
+
+  private sessionDir(sessionId: string): string {
+    return join(this.rootDir, "browser", "sessions", sessionId);
+  }
+}
+
+function assertValidAuditEvent(event: BrowserAuditEvent): void {
+  const validation = validateBrowserAuditEvent(event);
+  if (!validation.valid) {
+    throw new TypeError(`invalid browser audit event: ${validation.errors.join("; ")}`);
+  }
+}

--- a/ts/src/integrations/browser/factory.ts
+++ b/ts/src/integrations/browser/factory.ts
@@ -1,0 +1,36 @@
+import { ChromeCdpRuntime } from "./chrome-cdp-runtime.js";
+import { resolveBrowserSessionConfig } from "./policy.js";
+import type { BrowserRuntimePort, BrowserSettingsLike, BrowserSessionConfig } from "./types.js";
+
+export interface BrowserRuntimeSettingsLike extends BrowserSettingsLike {
+  readonly browserEnabled: boolean;
+  readonly browserBackend: string;
+  readonly runsRoot: string;
+}
+
+export interface ConfiguredBrowserRuntime {
+  readonly sessionConfig: BrowserSessionConfig;
+  readonly runtime: BrowserRuntimePort;
+}
+
+export function createBrowserRuntimeFromSettings(
+  settings: BrowserRuntimeSettingsLike,
+  opts: { evidenceRoot?: string } = {},
+): ConfiguredBrowserRuntime | null {
+  if (!settings.browserEnabled) {
+    return null;
+  }
+
+  if (settings.browserBackend !== "chrome-cdp") {
+    throw new Error(`unsupported browser backend: ${settings.browserBackend}`);
+  }
+
+  return {
+    sessionConfig: resolveBrowserSessionConfig(settings),
+    runtime: new ChromeCdpRuntime({
+      debuggerUrl: settings.browserDebuggerUrl || undefined,
+      preferredTargetUrl: settings.browserPreferredTargetUrl || undefined,
+      evidenceRoot: opts.evidenceRoot ?? settings.runsRoot,
+    }),
+  };
+}

--- a/ts/src/integrations/browser/index.ts
+++ b/ts/src/integrations/browser/index.ts
@@ -7,7 +7,9 @@ export type {
   BrowserPolicyDecision,
   BrowserPolicyReason,
   BrowserProfileMode,
+  BrowserRuntimePort,
   BrowserSessionConfig,
+  BrowserSessionPort,
   BrowserSettingsLike,
   BrowserSnapshot,
   BrowserSnapshotRef,
@@ -26,3 +28,37 @@ export {
   normalizeBrowserAllowedDomains,
   resolveBrowserSessionConfig,
 } from "./policy.js";
+export type {
+  BrowserArtifactPaths,
+  BrowserEvidenceStoreOpts,
+  PersistSnapshotArtifactsOpts,
+} from "./evidence.js";
+export { BrowserEvidenceStore } from "./evidence.js";
+export type { ChromeCdpSessionOpts, ChromeCdpTransport } from "./chrome-cdp.js";
+export { ChromeCdpSession } from "./chrome-cdp.js";
+export type {
+  BrowserFetchFn,
+  BrowserFetchResponseLike,
+  ChromeCdpTarget,
+  ChromeCdpTargetDiscoveryOpts,
+  ChromeCdpTargetDiscoveryPort,
+} from "./chrome-cdp-discovery.js";
+export {
+  ChromeCdpDiscoveryError,
+  ChromeCdpTargetDiscovery,
+  selectChromeCdpTarget,
+} from "./chrome-cdp-discovery.js";
+export type { BrowserRuntimeSettingsLike, ConfiguredBrowserRuntime } from "./factory.js";
+export { createBrowserRuntimeFromSettings } from "./factory.js";
+export type {
+  BrowserWebSocketFactory,
+  BrowserWebSocketLike,
+  ChromeCdpWebSocketTransportOpts,
+} from "./chrome-cdp-transport.js";
+export { ChromeCdpTransportError, ChromeCdpWebSocketTransport } from "./chrome-cdp-transport.js";
+export type {
+  BrowserSessionIdFactory,
+  ChromeCdpRuntimeOpts,
+  ChromeCdpTransportFactory,
+} from "./chrome-cdp-runtime.js";
+export { ChromeCdpRuntime } from "./chrome-cdp-runtime.js";

--- a/ts/tests/integrations/browser/chrome-cdp-discovery.test.ts
+++ b/ts/tests/integrations/browser/chrome-cdp-discovery.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  ChromeCdpDiscoveryError,
+  ChromeCdpTargetDiscovery,
+  selectChromeCdpTarget,
+} from "../../../src/integrations/browser/chrome-cdp-discovery.js";
+import { buildDefaultBrowserSessionConfig } from "../../../src/integrations/browser/policy.js";
+
+describe("chrome cdp discovery", () => {
+  test("selects the preferred allowed target when present", () => {
+    const config = buildDefaultBrowserSessionConfig({ allowedDomains: ["example.com"] });
+    const target = selectChromeCdpTarget(
+      [
+        {
+          targetId: "target_1",
+          targetType: "page",
+          title: "Home",
+          url: "https://example.com/home",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/1",
+        },
+        {
+          targetId: "target_2",
+          targetType: "page",
+          title: "Dashboard",
+          url: "https://example.com/dashboard",
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/2",
+        },
+      ],
+      config,
+      { preferredUrl: "https://example.com/dashboard" },
+    );
+
+    expect(target.targetId).toBe("target_2");
+  });
+
+  test("rejects when no debugger target matches the allowlist", () => {
+    const config = buildDefaultBrowserSessionConfig({ allowedDomains: ["example.com"] });
+
+    expect(() =>
+      selectChromeCdpTarget(
+        [
+          {
+            targetId: "target_1",
+            targetType: "page",
+            title: "Blocked",
+            url: "https://blocked.example.net/home",
+            webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/1",
+          },
+        ],
+        config,
+      ),
+    ).toThrowError(ChromeCdpDiscoveryError);
+  });
+
+  test("fetches /json/list and resolves a websocket url", async () => {
+    const seenUrls: string[] = [];
+    const discovery = new ChromeCdpTargetDiscovery({
+      debuggerUrl: "http://127.0.0.1:9222/",
+      fetchFn: async (url) => {
+        seenUrls.push(url);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              id: "target_1",
+              type: "page",
+              title: "Dashboard",
+              url: "https://example.com/dashboard",
+              webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/1",
+            },
+          ],
+        };
+      },
+    });
+    const config = buildDefaultBrowserSessionConfig({ allowedDomains: ["example.com"] });
+
+    const websocketUrl = await discovery.resolveWebSocketUrl(config);
+
+    expect(seenUrls).toEqual(["http://127.0.0.1:9222/json/list"]);
+    expect(websocketUrl).toBe("ws://127.0.0.1:9222/devtools/page/1");
+  });
+});

--- a/ts/tests/integrations/browser/chrome-cdp-runtime.test.ts
+++ b/ts/tests/integrations/browser/chrome-cdp-runtime.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { ChromeCdpSession } from "../../../src/integrations/browser/chrome-cdp.js";
+import { ChromeCdpRuntime } from "../../../src/integrations/browser/chrome-cdp-runtime.js";
+import { buildDefaultBrowserSessionConfig } from "../../../src/integrations/browser/policy.js";
+
+class FakeTransport {
+  async send(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  async close(): Promise<void> {
+    return;
+  }
+}
+
+describe("chrome cdp runtime", () => {
+  test("creates sessions with the configured transport and evidence store", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "browser-runtime-"));
+    const createdUrls: string[] = [];
+    const transport = new FakeTransport();
+    const runtime = new ChromeCdpRuntime({
+      websocketUrl: "ws://127.0.0.1:9222/devtools/page/1",
+      evidenceRoot: rootDir,
+      transportFactory: (url) => {
+        createdUrls.push(url);
+        return transport;
+      },
+      sessionIdFactory: () => "session_fixed",
+    });
+
+    const session = await runtime.createSession(
+      buildDefaultBrowserSessionConfig({ allowedDomains: ["example.com"] }),
+    );
+
+    expect(session).toBeInstanceOf(ChromeCdpSession);
+    expect(createdUrls).toEqual(["ws://127.0.0.1:9222/devtools/page/1"]);
+    expect(session.sessionId).toBe("session_fixed");
+    expect(session.transport).toBe(transport);
+    expect(session.evidenceStore?.rootDir).toBe(rootDir);
+  });
+
+  test("resolves the websocket target from discovery before creating the session", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "browser-runtime-"));
+    const createdUrls: string[] = [];
+    const transport = new FakeTransport();
+    const discoveryCalls: Array<{ preferredUrl?: string }> = [];
+    const runtime = new ChromeCdpRuntime({
+      debuggerUrl: "http://127.0.0.1:9222",
+      preferredTargetUrl: "https://example.com/dashboard",
+      evidenceRoot: rootDir,
+      targetDiscovery: {
+        async resolveWebSocketUrl(_config, opts = {}) {
+          discoveryCalls.push(opts);
+          return "ws://127.0.0.1:9222/devtools/page/discovered";
+        },
+      },
+      transportFactory: (url) => {
+        createdUrls.push(url);
+        return transport;
+      },
+      sessionIdFactory: () => "session_fixed",
+    });
+
+    const session = await runtime.createSession(
+      buildDefaultBrowserSessionConfig({ allowedDomains: ["example.com"] }),
+    );
+
+    expect(session).toBeInstanceOf(ChromeCdpSession);
+    expect(createdUrls).toEqual(["ws://127.0.0.1:9222/devtools/page/discovered"]);
+    expect(discoveryCalls).toEqual([{ preferredUrl: "https://example.com/dashboard" }]);
+  });
+});

--- a/ts/tests/integrations/browser/chrome-cdp-transport.test.ts
+++ b/ts/tests/integrations/browser/chrome-cdp-transport.test.ts
@@ -1,0 +1,122 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, test } from "vitest";
+
+import {
+  ChromeCdpTransportError,
+  ChromeCdpWebSocketTransport,
+  type BrowserWebSocketFactory,
+} from "../../../src/integrations/browser/chrome-cdp-transport.js";
+
+type ScriptStep = (request: Record<string, unknown>) => Record<string, unknown>;
+
+class FakeWebSocket extends EventEmitter {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+
+  readonly sent: Array<Record<string, unknown>> = [];
+  readyState = FakeWebSocket.CONNECTING;
+
+  private readonly steps: ScriptStep[];
+
+  constructor(
+    readonly url: string,
+    script: ScriptStep[],
+  ) {
+    super();
+    this.steps = [...script];
+    queueMicrotask(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      this.emit("open");
+    });
+  }
+
+  send(data: string): void {
+    const request = JSON.parse(data) as Record<string, unknown>;
+    this.sent.push(request);
+    const next = this.steps.shift() ?? ((message) => ({ id: message.id, result: { ok: true } }));
+    const response = next(request);
+    queueMicrotask(() => {
+      this.emit("message", Buffer.from(JSON.stringify(response)));
+    });
+  }
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    queueMicrotask(() => {
+      this.emit("close");
+    });
+  }
+}
+
+function createFactory(script: ScriptStep[]): {
+  readonly factory: BrowserWebSocketFactory;
+  readonly sockets: FakeWebSocket[];
+} {
+  const sockets: FakeWebSocket[] = [];
+  return {
+    factory: (url: string) => {
+      const socket = new FakeWebSocket(url, script);
+      sockets.push(socket);
+      return socket;
+    },
+    sockets,
+  };
+}
+
+describe("chrome cdp websocket transport", () => {
+  test("round trips cdp commands over the websocket", async () => {
+    const { factory, sockets } = createFactory([
+      (request) => ({
+        id: request.id,
+        result: {
+          product: "Chrome",
+          echoMethod: request.method,
+          echoParams: request.params,
+        },
+      }),
+    ]);
+    const transport = new ChromeCdpWebSocketTransport({
+      url: "ws://127.0.0.1:9222/devtools/page/1",
+      webSocketFactory: factory,
+    });
+
+    const response = await transport.send("Browser.getVersion", { verbose: true });
+    await transport.close();
+
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0]?.sent).toEqual([
+      {
+        id: 1,
+        method: "Browser.getVersion",
+        params: { verbose: true },
+      },
+    ]);
+    expect(response.result).toEqual({
+      product: "Chrome",
+      echoMethod: "Browser.getVersion",
+      echoParams: { verbose: true },
+    });
+  });
+
+  test("raises on cdp protocol errors", async () => {
+    const { factory } = createFactory([
+      (request) => ({
+        id: request.id,
+        error: {
+          message: "domain blocked",
+        },
+      }),
+    ]);
+    const transport = new ChromeCdpWebSocketTransport({
+      url: "ws://127.0.0.1:9222/devtools/page/1",
+      webSocketFactory: factory,
+    });
+
+    const sendPromise = transport.send("Page.navigate", { url: "https://blocked.example" });
+
+    await expect(sendPromise).rejects.toThrowError(ChromeCdpTransportError);
+    await expect(sendPromise).rejects.toThrow("domain blocked");
+    await transport.close();
+  });
+});

--- a/ts/tests/integrations/browser/chrome-cdp.test.ts
+++ b/ts/tests/integrations/browser/chrome-cdp.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { ChromeCdpSession } from "../../../src/integrations/browser/chrome-cdp.js";
+import { BrowserEvidenceStore } from "../../../src/integrations/browser/evidence.js";
+import { buildDefaultBrowserSessionConfig } from "../../../src/integrations/browser/policy.js";
+
+class FakeTransport {
+  readonly calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+  readonly responses: Array<Record<string, unknown>>;
+  closed = false;
+
+  constructor(responses: Array<Record<string, unknown>>) {
+    this.responses = [...responses];
+  }
+
+  async send(method: string, params: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    this.calls.push({ method, params });
+    return this.responses.shift() ?? {};
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+describe("chrome cdp session", () => {
+  test("navigate blocks disallowed domains before transport", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "browser-cdp-"));
+    const transport = new FakeTransport([]);
+    const session = new ChromeCdpSession({
+      sessionId: "session_1",
+      config: buildDefaultBrowserSessionConfig({ allowedDomains: ["example.com"] }),
+      transport,
+      evidenceStore: new BrowserEvidenceStore({ rootDir }),
+    });
+
+    const event = await session.navigate("https://blocked.example.net/dashboard");
+
+    expect(event.allowed).toBe(false);
+    expect(event.policyReason).toBe("domain_not_allowed");
+    expect(transport.calls).toHaveLength(0);
+  });
+
+  test("snapshot persists artifacts and click uses ref mapping", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "browser-cdp-"));
+    const transport = new FakeTransport([
+      {},
+      {},
+      {
+        result: {
+          value: {
+            url: "https://example.com/dashboard",
+            title: "Dashboard",
+            visibleText: "Welcome back",
+            refs: [
+              {
+                id: "@e1",
+                role: "button",
+                name: "Continue",
+                selector: "button:nth-of-type(1)",
+              },
+            ],
+            html: "<html><body>Welcome back</body></html>",
+          },
+        },
+      },
+      { data: Buffer.from("png-bytes").toString("base64") },
+      { result: { value: { ok: true } } },
+    ]);
+    const session = new ChromeCdpSession({
+      sessionId: "session_1",
+      config: buildDefaultBrowserSessionConfig({ allowedDomains: ["example.com"] }),
+      transport,
+      evidenceStore: new BrowserEvidenceStore({ rootDir }),
+    });
+
+    const snapshot = await session.snapshot();
+    const event = await session.click("@e1");
+
+    expect(snapshot.url).toBe("https://example.com/dashboard");
+    expect(snapshot.htmlPath).toBeTruthy();
+    expect(snapshot.screenshotPath).toBeTruthy();
+    expect(readFileSync(snapshot.screenshotPath!)).toEqual(Buffer.from("png-bytes"));
+    expect(String(transport.calls[2]?.params.expression)).toContain("selectorFor(element)");
+    expect(event.allowed).toBe(true);
+    expect(transport.calls.at(-1)?.method).toBe("Runtime.evaluate");
+    expect(String(transport.calls.at(-1)?.params.expression)).toContain("button:nth-of-type(1)");
+  });
+
+  test("fill denies password entry when auth is disabled", async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "browser-cdp-"));
+    const transport = new FakeTransport([]);
+    const session = new ChromeCdpSession({
+      sessionId: "session_1",
+      config: buildDefaultBrowserSessionConfig({ allowedDomains: ["example.com"] }),
+      transport,
+      evidenceStore: new BrowserEvidenceStore({ rootDir }),
+    });
+
+    const event = await session.fill("@e1", "super-secret", { fieldKind: "password" });
+
+    expect(event.allowed).toBe(false);
+    expect(event.policyReason).toBe("auth_blocked");
+    expect(transport.calls).toHaveLength(0);
+  });
+});

--- a/ts/tests/integrations/browser/evidence.test.ts
+++ b/ts/tests/integrations/browser/evidence.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { BrowserEvidenceStore } from "../../../src/integrations/browser/evidence.js";
+
+describe("browser evidence store", () => {
+  test("appendAuditEvent writes JSONL", () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "browser-evidence-"));
+    const store = new BrowserEvidenceStore({ rootDir });
+
+    const path = store.appendAuditEvent({
+      schemaVersion: "1.0",
+      eventId: "evt_1",
+      sessionId: "session_1",
+      actionId: "act_1",
+      kind: "action_result",
+      allowed: true,
+      policyReason: "allowed",
+      timestamp: "2026-04-22T12:00:02Z",
+      message: "navigation allowed",
+      beforeUrl: "about:blank",
+      afterUrl: "https://example.com",
+      artifacts: {
+        htmlPath: null,
+        screenshotPath: null,
+        downloadPath: null,
+      },
+    });
+
+    const lines = readFileSync(path, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).eventId).toBe("evt_1");
+  });
+
+  test("persistSnapshotArtifacts writes html and png", () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "browser-evidence-"));
+    const store = new BrowserEvidenceStore({ rootDir });
+
+    const result = store.persistSnapshotArtifacts({
+      sessionId: "session_1",
+      basename: "snap_1",
+      html: "<html><body>Hello</body></html>",
+      screenshotBase64: Buffer.from("png-bytes").toString("base64"),
+    });
+
+    expect(result.htmlPath).toBeTruthy();
+    expect(result.screenshotPath).toBeTruthy();
+    expect(readFileSync(result.htmlPath!, "utf-8")).toBe("<html><body>Hello</body></html>");
+    expect(readFileSync(result.screenshotPath!)).toEqual(Buffer.from("png-bytes"));
+  });
+});

--- a/ts/tests/integrations/browser/factory.test.ts
+++ b/ts/tests/integrations/browser/factory.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+
+import { AppSettingsSchema } from "../../../src/config/index.js";
+import { ChromeCdpRuntime } from "../../../src/integrations/browser/chrome-cdp-runtime.js";
+import {
+  createBrowserRuntimeFromSettings,
+  type ConfiguredBrowserRuntime,
+} from "../../../src/integrations/browser/factory.js";
+
+describe("browser runtime factory", () => {
+  test("returns null when browser exploration is disabled", () => {
+    const settings = AppSettingsSchema.parse({
+      browserEnabled: false,
+      runsRoot: "/tmp/runs",
+    });
+
+    expect(createBrowserRuntimeFromSettings(settings)).toBeNull();
+  });
+
+  test("builds a chrome cdp runtime from settings", () => {
+    const settings = AppSettingsSchema.parse({
+      browserEnabled: true,
+      browserBackend: "chrome-cdp",
+      browserAllowedDomains: "example.com",
+      browserDebuggerUrl: "http://127.0.0.1:9333",
+      browserPreferredTargetUrl: "https://example.com/dashboard",
+      runsRoot: "/tmp/runs",
+    });
+
+    const configured = createBrowserRuntimeFromSettings(settings);
+
+    expect(configured).not.toBeNull();
+    expect((configured as ConfiguredBrowserRuntime).sessionConfig.allowedDomains).toEqual(["example.com"]);
+    expect((configured as ConfiguredBrowserRuntime).runtime).toBeInstanceOf(ChromeCdpRuntime);
+    expect(((configured as ConfiguredBrowserRuntime).runtime as ChromeCdpRuntime).debuggerUrl).toBe(
+      "http://127.0.0.1:9333",
+    );
+    expect(((configured as ConfiguredBrowserRuntime).runtime as ChromeCdpRuntime).preferredTargetUrl).toBe(
+      "https://example.com/dashboard",
+    );
+    expect(((configured as ConfiguredBrowserRuntime).runtime as ChromeCdpRuntime).evidenceRoot).toBe("/tmp/runs");
+  });
+
+  test("rejects unsupported browser backends", () => {
+    const settings = AppSettingsSchema.parse({
+      browserEnabled: true,
+      browserBackend: "mystery",
+      runsRoot: "/tmp/runs",
+    });
+
+    expect(() => createBrowserRuntimeFromSettings(settings)).toThrowError(
+      "unsupported browser backend: mystery",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add the TypeScript Chrome CDP session, attach-only target discovery, websocket transport, evidence store, and settings-backed runtime factory.
- Keep heavier browser backend exports behind the browser integration subpath while preserving lightweight root contract exports.
- Generate deterministic selectors in snapshots so ref-based actions can work against real pages instead of test-only refs.

## Tests
- cd ts && npx vitest run tests/integrations/browser/chrome-cdp.test.ts tests/integrations/browser/chrome-cdp-discovery.test.ts tests/integrations/browser/chrome-cdp-runtime.test.ts tests/integrations/browser/chrome-cdp-transport.test.ts tests/integrations/browser/evidence.test.ts tests/integrations/browser/factory.test.ts tests/package-export-catalogs.test.ts
- cd ts && npm run lint

Linear: AC-600