### PR TITLE
AC-603: Add browser contract parity fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changes in this section are on the branch/repo after `0.4.4` and are not part of
 - Added a shared browser exploration contract and package-safe configuration surface across Python and TypeScript, including canonical schemas, validation helpers, secure `AUTOCONTEXT_BROWSER_*` defaults, and policy helpers.
 - Added the TypeScript Chrome DevTools Protocol backend for browser exploration, including attach-only target discovery, websocket transport, policy-gated actions, and evidence artifacts.
 - Added a thin Python Chrome CDP browser backend with debugger-target discovery, evidence persistence, WebSocket transport, runtime factory, and policy-checked session actions.
+- Added cross-runtime browser contract fixtures so Python and TypeScript validators stay in lockstep.
 
 ## [0.4.4] - 2026-04-20
 

--- a/autocontext/src/autocontext/integrations/browser/validate.py
+++ b/autocontext/src/autocontext/integrations/browser/validate.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from collections.abc import Mapping
+from typing import Annotated, Any, cast
 
-from pydantic import TypeAdapter, ValidationError, model_validator
+from pydantic import BeforeValidator, TypeAdapter, ValidationError, model_validator
 
 from autocontext.integrations.browser.contract.types import (
     BrowserAction,
@@ -26,16 +27,38 @@ class ValidatedBrowserSessionConfig(BrowserSessionConfig):
         return self
 
 
+_ACTION_NON_NULL_OPTIONAL_PATHS = (
+    ("params", "captureHtml"),
+    ("params", "captureScreenshot"),
+    ("params", "fieldKind"),
+)
+
+_SNAPSHOT_NON_NULL_OPTIONAL_PATHS = (
+    ("refs", "*", "role"),
+    ("refs", "*", "name"),
+    ("refs", "*", "text"),
+    ("refs", "*", "selector"),
+    ("refs", "*", "disabled"),
+)
+
+_VALIDATED_BROWSER_ACTION_ADAPTER: TypeAdapter[BrowserAction] = TypeAdapter(
+    Annotated[BrowserAction, BeforeValidator(lambda data: _reject_explicit_nulls_for_action(data))]
+)
+_VALIDATED_BROWSER_SNAPSHOT_ADAPTER: TypeAdapter[BrowserSnapshot] = TypeAdapter(
+    Annotated[BrowserSnapshot, BeforeValidator(lambda data: _reject_explicit_nulls_for_snapshot(data))]
+)
+
+
 def validate_browser_session_config(data: Any) -> BrowserSessionConfig:
     return ValidatedBrowserSessionConfig.model_validate(data)
 
 
 def validate_browser_action(data: Any) -> BrowserAction:
-    return cast(BrowserAction, _validate_any(data, BrowserAction))
+    return cast(BrowserAction, _VALIDATED_BROWSER_ACTION_ADAPTER.validate_python(data))
 
 
 def validate_browser_snapshot(data: Any) -> BrowserSnapshot:
-    return BrowserSnapshot.model_validate(data)
+    return cast(BrowserSnapshot, _VALIDATED_BROWSER_SNAPSHOT_ADAPTER.validate_python(data))
 
 
 def validate_browser_audit_event(data: Any) -> BrowserAuditEvent:
@@ -43,27 +66,37 @@ def validate_browser_audit_event(data: Any) -> BrowserAuditEvent:
 
 
 def validate_browser_session_config_dict(data: Any) -> tuple[bool, list[str]]:
-    return _validate_dict(data, ValidatedBrowserSessionConfig)
+    return _validate_dict(data, validate_browser_session_config)
 
 
 def validate_browser_action_dict(data: Any) -> tuple[bool, list[str]]:
-    return _validate_dict(data, BrowserAction)
+    return _validate_dict(data, validate_browser_action)
 
 
 def validate_browser_snapshot_dict(data: Any) -> tuple[bool, list[str]]:
-    return _validate_dict(data, BrowserSnapshot)
+    return _validate_dict(data, validate_browser_snapshot)
 
 
 def validate_browser_audit_event_dict(data: Any) -> tuple[bool, list[str]]:
-    return _validate_dict(data, BrowserAuditEvent)
+    return _validate_dict(data, validate_browser_audit_event)
 
 
-def _validate_dict(data: Any, model: Any) -> tuple[bool, list[str]]:
+def _validate_dict(data: Any, validator: Any) -> tuple[bool, list[str]]:
     try:
-        _validate_any(data, model)
+        validator(data)
     except ValidationError as exc:
         return False, [_format_error(err) for err in exc.errors()]
     return True, []
+
+
+def _reject_explicit_nulls_for_action(data: Any) -> Any:
+    _reject_explicit_null_paths(data, _ACTION_NON_NULL_OPTIONAL_PATHS)
+    return data
+
+
+def _reject_explicit_nulls_for_snapshot(data: Any) -> Any:
+    _reject_explicit_null_paths(data, _SNAPSHOT_NON_NULL_OPTIONAL_PATHS)
+    return data
 
 
 def _validate_any(data: Any, model: Any) -> Any:
@@ -78,6 +111,34 @@ def _format_error(err: Any) -> str:
     path = ".".join(str(part) for part in loc) if loc else "<root>"
     msg = err.get("msg", "invalid")
     return f"{path}: {msg}"
+
+
+def _reject_explicit_null_paths(data: Any, paths: tuple[tuple[str, ...], ...]) -> None:
+    for path in paths:
+        _reject_explicit_null_path(data, path, ())
+
+
+def _reject_explicit_null_path(data: Any, path: tuple[str, ...], current: tuple[str, ...]) -> None:
+    if not path:
+        return
+
+    head, *tail = path
+    if head == "*":
+        if isinstance(data, list):
+            for idx, item in enumerate(data):
+                _reject_explicit_null_path(item, tuple(tail), (*current, str(idx)))
+        return
+
+    if not isinstance(data, Mapping) or head not in data:
+        return
+
+    value = data[head]
+    if not tail:
+        if value is None:
+            raise ValueError(f"{'.'.join((*current, head))} must not be null")
+        return
+
+    _reject_explicit_null_path(value, tuple(tail), (*current, head))
 
 
 __all__ = [

--- a/autocontext/tests/test_browser_contract_fixtures.py
+++ b/autocontext/tests/test_browser_contract_fixtures.py
@@ -1,0 +1,70 @@
+"""Fixture-driven parity tests for browser contract validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from autocontext.integrations.browser.validate import (
+    validate_browser_action,
+    validate_browser_audit_event,
+    validate_browser_session_config,
+    validate_browser_snapshot,
+)
+
+WORKTREE_ROOT = Path(__file__).resolve().parent.parent.parent
+FIXTURES_DIR = WORKTREE_ROOT / "ts" / "tests" / "integrations" / "browser" / "fixtures"
+
+
+def _all_fixtures() -> list[Path]:
+    assert FIXTURES_DIR.is_dir(), f"expected fixtures dir at {FIXTURES_DIR}"
+    return sorted(FIXTURES_DIR.glob("*.json"))
+
+
+def _validator_for_fixture_name(name: str):
+    if "-session-config-" in name:
+        return validate_browser_session_config
+    if "-action-" in name:
+        return validate_browser_action
+    if "-snapshot-" in name:
+        return validate_browser_snapshot
+    if "-audit-event-" in name:
+        return validate_browser_audit_event
+    raise AssertionError(f"unrecognized fixture name: {name}")
+
+
+@pytest.mark.parametrize("fixture", [p for p in _all_fixtures() if p.name.startswith("valid-")], ids=lambda p: p.name)
+def test_valid_browser_fixtures_accepted(fixture: Path) -> None:
+    data = json.loads(fixture.read_text())
+    validator = _validator_for_fixture_name(fixture.name)
+    doc = validator(data)
+    assert doc.schemaVersion == "1.0"
+
+
+@pytest.mark.parametrize("fixture", [p for p in _all_fixtures() if p.name.startswith("invalid-")], ids=lambda p: p.name)
+def test_invalid_browser_fixtures_rejected(fixture: Path) -> None:
+    data = json.loads(fixture.read_text())
+    validator = _validator_for_fixture_name(fixture.name)
+    with pytest.raises(ValidationError):
+        validator(data)
+
+
+def test_browser_fixture_directory_contains_expected_set() -> None:
+    names = {p.name for p in _all_fixtures()}
+    required = {
+        "valid-session-config-ephemeral.json",
+        "valid-session-config-isolated-downloads.json",
+        "invalid-session-config-downloads-root.json",
+        "invalid-session-config-user-profile-auth.json",
+        "valid-action-navigate.json",
+        "invalid-action-missing-session.json",
+        "valid-snapshot-minimal.json",
+        "invalid-snapshot-bad-ref.json",
+        "valid-audit-event-allowed.json",
+        "invalid-audit-event-missing-reason.json",
+    }
+    missing = required - names
+    assert not missing, f"missing fixtures: {sorted(missing)}"

--- a/autocontext/tests/test_browser_contract_fixtures.py
+++ b/autocontext/tests/test_browser_contract_fixtures.py
@@ -10,9 +10,13 @@ from pydantic import ValidationError
 
 from autocontext.integrations.browser.validate import (
     validate_browser_action,
+    validate_browser_action_dict,
     validate_browser_audit_event,
+    validate_browser_audit_event_dict,
     validate_browser_session_config,
+    validate_browser_session_config_dict,
     validate_browser_snapshot,
+    validate_browser_snapshot_dict,
 )
 
 WORKTREE_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -36,12 +40,33 @@ def _validator_for_fixture_name(name: str):
     raise AssertionError(f"unrecognized fixture name: {name}")
 
 
+def _dict_validator_for_fixture_name(name: str):
+    if "-session-config-" in name:
+        return validate_browser_session_config_dict
+    if "-action-" in name:
+        return validate_browser_action_dict
+    if "-snapshot-" in name:
+        return validate_browser_snapshot_dict
+    if "-audit-event-" in name:
+        return validate_browser_audit_event_dict
+    raise AssertionError(f"unrecognized fixture name: {name}")
+
+
 @pytest.mark.parametrize("fixture", [p for p in _all_fixtures() if p.name.startswith("valid-")], ids=lambda p: p.name)
 def test_valid_browser_fixtures_accepted(fixture: Path) -> None:
     data = json.loads(fixture.read_text())
     validator = _validator_for_fixture_name(fixture.name)
     doc = validator(data)
     assert doc.schemaVersion == "1.0"
+
+
+@pytest.mark.parametrize("fixture", [p for p in _all_fixtures() if p.name.startswith("valid-")], ids=lambda p: p.name)
+def test_valid_browser_fixtures_accepted_by_dict_helpers(fixture: Path) -> None:
+    data = json.loads(fixture.read_text())
+    validator = _dict_validator_for_fixture_name(fixture.name)
+    valid, errors = validator(data)
+    assert valid
+    assert not errors
 
 
 @pytest.mark.parametrize("fixture", [p for p in _all_fixtures() if p.name.startswith("invalid-")], ids=lambda p: p.name)
@@ -52,17 +77,29 @@ def test_invalid_browser_fixtures_rejected(fixture: Path) -> None:
         validator(data)
 
 
+@pytest.mark.parametrize("fixture", [p for p in _all_fixtures() if p.name.startswith("invalid-")], ids=lambda p: p.name)
+def test_invalid_browser_fixtures_rejected_by_dict_helpers(fixture: Path) -> None:
+    data = json.loads(fixture.read_text())
+    validator = _dict_validator_for_fixture_name(fixture.name)
+    valid, errors = validator(data)
+    assert not valid
+    assert errors
+
+
 def test_browser_fixture_directory_contains_expected_set() -> None:
     names = {p.name for p in _all_fixtures()}
     required = {
+        "invalid-action-fill-null-field-kind.json",
         "valid-session-config-ephemeral.json",
         "valid-session-config-isolated-downloads.json",
         "invalid-session-config-downloads-root.json",
         "invalid-session-config-user-profile-auth.json",
         "valid-action-navigate.json",
         "invalid-action-missing-session.json",
+        "invalid-action-snapshot-null-capture-html.json",
         "valid-snapshot-minimal.json",
         "invalid-snapshot-bad-ref.json",
+        "invalid-snapshot-null-ref-name.json",
         "valid-audit-event-allowed.json",
         "invalid-audit-event-missing-reason.json",
     }

--- a/ts/tests/integrations/browser/contract/cross-runtime.test.ts
+++ b/ts/tests/integrations/browser/contract/cross-runtime.test.ts
@@ -1,0 +1,94 @@
+import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import {
+  validateBrowserAction,
+  validateBrowserAuditEvent,
+  validateBrowserSessionConfig,
+  validateBrowserSnapshot,
+} from "../../../../src/integrations/browser/contract/validators.js";
+
+const TS_ROOT = resolve(__dirname, "..", "..", "..", "..");
+const WORKTREE_ROOT = resolve(TS_ROOT, "..");
+const FIXTURES_DIR = resolve(__dirname, "..", "fixtures");
+const PY_CWD = resolve(WORKTREE_ROOT, "autocontext");
+
+type PythonResult = { valid: boolean; error?: string };
+
+function validatorForFixture(file: string) {
+  if (file.includes("-session-config-")) return validateBrowserSessionConfig;
+  if (file.includes("-action-")) return validateBrowserAction;
+  if (file.includes("-snapshot-")) return validateBrowserSnapshot;
+  if (file.includes("-audit-event-")) return validateBrowserAuditEvent;
+  throw new Error(`unrecognized fixture file: ${file}`);
+}
+
+function pythonValidatorNameForFixture(file: string): string {
+  if (file.includes("-session-config-")) return "validate_browser_session_config";
+  if (file.includes("-action-")) return "validate_browser_action";
+  if (file.includes("-snapshot-")) return "validate_browser_snapshot";
+  if (file.includes("-audit-event-")) return "validate_browser_audit_event";
+  throw new Error(`unrecognized fixture file: ${file}`);
+}
+
+function runPythonValidate(validatorName: string, input: unknown): PythonResult {
+  const script = [
+    "import json, sys",
+    "from pydantic import ValidationError",
+    "from autocontext.integrations.browser.validate import (",
+    "    validate_browser_action,",
+    "    validate_browser_audit_event,",
+    "    validate_browser_session_config,",
+    "    validate_browser_snapshot,",
+    ")",
+    "validator_name = sys.argv[1]",
+    "validator = globals()[validator_name]",
+    "data = json.loads(sys.stdin.read())",
+    "try:",
+    "    doc = validator(data)",
+    "    print(json.dumps({'valid': True, 'schemaVersion': doc.schemaVersion}))",
+    "except ValidationError as e:",
+    "    print(json.dumps({'valid': False, 'error': str(e)}))",
+  ].join("\n");
+  const result = spawnSync("uv", ["run", "python", "-c", script, validatorName], {
+    cwd: PY_CWD,
+    input: JSON.stringify(input),
+    encoding: "utf-8",
+    env: process.env,
+  });
+  if (result.status !== 0 && !result.stdout) {
+    throw new Error(`python validate exited ${result.status}: ${result.stderr}`);
+  }
+  const line = result.stdout.trim().split("\n").pop() ?? "{}";
+  return JSON.parse(line) as PythonResult;
+}
+
+function hasUv(): boolean {
+  const r = spawnSync("uv", ["--version"], { encoding: "utf-8" });
+  return r.status === 0;
+}
+
+const maybeDescribe = hasUv() ? describe : describe.skip;
+
+maybeDescribe("browser contract cross-runtime fixtures", () => {
+  const fixtureFiles = readdirSync(FIXTURES_DIR).filter((f) => f.endsWith(".json")).sort();
+
+  test("non-empty fixture set", () => {
+    expect(fixtureFiles.length).toBeGreaterThanOrEqual(10);
+  });
+
+  for (const file of fixtureFiles) {
+    const isInvalid = file.startsWith("invalid-");
+    test(`${file}: TS and Python agree on ${isInvalid ? "rejection" : "acceptance"}`, () => {
+      const body = readFileSync(resolve(FIXTURES_DIR, file), "utf-8");
+      const data: unknown = JSON.parse(body);
+      const tsResult = validatorForFixture(file)(data);
+      const pyResult = runPythonValidate(pythonValidatorNameForFixture(file), data);
+
+      expect(tsResult.valid).toBe(pyResult.valid);
+      expect(tsResult.valid).toBe(!isInvalid);
+    });
+  }
+});

--- a/ts/tests/integrations/browser/contract/cross-runtime.test.ts
+++ b/ts/tests/integrations/browser/contract/cross-runtime.test.ts
@@ -16,6 +16,7 @@ const FIXTURES_DIR = resolve(__dirname, "..", "fixtures");
 const PY_CWD = resolve(WORKTREE_ROOT, "autocontext");
 
 type PythonResult = { valid: boolean; error?: string };
+type PythonDictResult = { valid: boolean; errors: string[] };
 
 function validatorForFixture(file: string) {
   if (file.includes("-session-config-")) return validateBrowserSessionConfig;
@@ -30,6 +31,14 @@ function pythonValidatorNameForFixture(file: string): string {
   if (file.includes("-action-")) return "validate_browser_action";
   if (file.includes("-snapshot-")) return "validate_browser_snapshot";
   if (file.includes("-audit-event-")) return "validate_browser_audit_event";
+  throw new Error(`unrecognized fixture file: ${file}`);
+}
+
+function pythonDictValidatorNameForFixture(file: string): string {
+  if (file.includes("-session-config-")) return "validate_browser_session_config_dict";
+  if (file.includes("-action-")) return "validate_browser_action_dict";
+  if (file.includes("-snapshot-")) return "validate_browser_snapshot_dict";
+  if (file.includes("-audit-event-")) return "validate_browser_audit_event_dict";
   throw new Error(`unrecognized fixture file: ${file}`);
 }
 
@@ -65,6 +74,34 @@ function runPythonValidate(validatorName: string, input: unknown): PythonResult 
   return JSON.parse(line) as PythonResult;
 }
 
+function runPythonValidateDict(validatorName: string, input: unknown): PythonDictResult {
+  const script = [
+    "import json, sys",
+    "from autocontext.integrations.browser.validate import (",
+    "    validate_browser_action_dict,",
+    "    validate_browser_audit_event_dict,",
+    "    validate_browser_session_config_dict,",
+    "    validate_browser_snapshot_dict,",
+    ")",
+    "validator_name = sys.argv[1]",
+    "validator = globals()[validator_name]",
+    "data = json.loads(sys.stdin.read())",
+    "valid, errors = validator(data)",
+    "print(json.dumps({'valid': valid, 'errors': errors}))",
+  ].join("\n");
+  const result = spawnSync("uv", ["run", "python", "-c", script, validatorName], {
+    cwd: PY_CWD,
+    input: JSON.stringify(input),
+    encoding: "utf-8",
+    env: process.env,
+  });
+  if (result.status !== 0 && !result.stdout) {
+    throw new Error(`python validate exited ${result.status}: ${result.stderr}`);
+  }
+  const line = result.stdout.trim().split("\n").pop() ?? "{}";
+  return JSON.parse(line) as PythonDictResult;
+}
+
 function hasUv(): boolean {
   const r = spawnSync("uv", ["--version"], { encoding: "utf-8" });
   return r.status === 0;
@@ -86,9 +123,14 @@ maybeDescribe("browser contract cross-runtime fixtures", () => {
       const data: unknown = JSON.parse(body);
       const tsResult = validatorForFixture(file)(data);
       const pyResult = runPythonValidate(pythonValidatorNameForFixture(file), data);
+      const pyDictResult = runPythonValidateDict(pythonDictValidatorNameForFixture(file), data);
 
       expect(tsResult.valid).toBe(pyResult.valid);
+      expect(tsResult.valid).toBe(pyDictResult.valid);
       expect(tsResult.valid).toBe(!isInvalid);
+      if (isInvalid) {
+        expect(pyDictResult.errors.length).toBeGreaterThan(0);
+      }
     });
   }
 });

--- a/ts/tests/integrations/browser/contract/validators.test.ts
+++ b/ts/tests/integrations/browser/contract/validators.test.ts
@@ -1,0 +1,39 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import {
+  validateBrowserAction,
+  validateBrowserAuditEvent,
+  validateBrowserSessionConfig,
+  validateBrowserSnapshot,
+} from "../../../../src/integrations/browser/contract/validators.js";
+
+const FIXTURES_DIR = resolve(__dirname, "..", "fixtures");
+
+function validatorForFixture(file: string) {
+  if (file.includes("-session-config-")) return validateBrowserSessionConfig;
+  if (file.includes("-action-")) return validateBrowserAction;
+  if (file.includes("-snapshot-")) return validateBrowserSnapshot;
+  if (file.includes("-audit-event-")) return validateBrowserAuditEvent;
+  throw new Error(`unrecognized fixture file: ${file}`);
+}
+
+describe("browser contract fixtures", () => {
+  const fixtureFiles = readdirSync(FIXTURES_DIR).filter((f) => f.endsWith(".json")).sort();
+
+  test("non-empty fixture set", () => {
+    expect(fixtureFiles.length).toBeGreaterThanOrEqual(10);
+  });
+
+  for (const file of fixtureFiles) {
+    const isInvalid = file.startsWith("invalid-");
+    test(`${file}: validator ${isInvalid ? "rejects" : "accepts"}`, () => {
+      const body = readFileSync(resolve(FIXTURES_DIR, file), "utf-8");
+      const data: unknown = JSON.parse(body);
+      const result = validatorForFixture(file)(data);
+
+      expect(result.valid).toBe(!isInvalid);
+    });
+  }
+});

--- a/ts/tests/integrations/browser/fixtures/invalid-action-fill-null-field-kind.json
+++ b/ts/tests/integrations/browser/fixtures/invalid-action-fill-null-field-kind.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "1.0",
+  "actionId": "act_fill_1",
+  "sessionId": "session_1",
+  "timestamp": "2026-04-22T12:00:00Z",
+  "type": "fill",
+  "params": {
+    "ref": "@e1",
+    "text": "hello@example.com",
+    "fieldKind": null
+  }
+}

--- a/ts/tests/integrations/browser/fixtures/invalid-action-missing-session.json
+++ b/ts/tests/integrations/browser/fixtures/invalid-action-missing-session.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "1.0",
+  "actionId": "act_nav_1",
+  "timestamp": "2026-04-22T12:00:00Z",
+  "type": "navigate",
+  "params": {
+    "url": "https://example.com/dashboard"
+  }
+}

--- a/ts/tests/integrations/browser/fixtures/invalid-action-snapshot-null-capture-html.json
+++ b/ts/tests/integrations/browser/fixtures/invalid-action-snapshot-null-capture-html.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": "1.0",
+  "actionId": "act_snapshot_1",
+  "sessionId": "session_1",
+  "timestamp": "2026-04-22T12:00:00Z",
+  "type": "snapshot",
+  "params": {
+    "captureHtml": null,
+    "captureScreenshot": true
+  }
+}

--- a/ts/tests/integrations/browser/fixtures/invalid-audit-event-missing-reason.json
+++ b/ts/tests/integrations/browser/fixtures/invalid-audit-event-missing-reason.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.0",
+  "eventId": "evt_1",
+  "sessionId": "session_1",
+  "actionId": "act_nav_1",
+  "kind": "action_result",
+  "allowed": true,
+  "timestamp": "2026-04-22T12:00:02Z",
+  "message": "navigation allowed",
+  "beforeUrl": "about:blank",
+  "afterUrl": "https://example.com/dashboard",
+  "artifacts": {
+    "htmlPath": null,
+    "screenshotPath": "runs/browser/shots/0001.png",
+    "downloadPath": null
+  }
+}

--- a/ts/tests/integrations/browser/fixtures/invalid-session-config-downloads-root.json
+++ b/ts/tests/integrations/browser/fixtures/invalid-session-config-downloads-root.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "1.0",
+  "profileMode": "isolated",
+  "allowedDomains": [
+    "docs.example.com"
+  ],
+  "allowAuth": false,
+  "allowUploads": false,
+  "allowDownloads": true,
+  "captureScreenshots": true,
+  "headless": true,
+  "downloadsRoot": null,
+  "uploadsRoot": null
+}

--- a/ts/tests/integrations/browser/fixtures/invalid-session-config-user-profile-auth.json
+++ b/ts/tests/integrations/browser/fixtures/invalid-session-config-user-profile-auth.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "1.0",
+  "profileMode": "user-profile",
+  "allowedDomains": [
+    "app.example.com"
+  ],
+  "allowAuth": false,
+  "allowUploads": false,
+  "allowDownloads": false,
+  "captureScreenshots": true,
+  "headless": false,
+  "downloadsRoot": null,
+  "uploadsRoot": null
+}

--- a/ts/tests/integrations/browser/fixtures/invalid-snapshot-bad-ref.json
+++ b/ts/tests/integrations/browser/fixtures/invalid-snapshot-bad-ref.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.0",
+  "sessionId": "session_1",
+  "capturedAt": "2026-04-22T12:00:01Z",
+  "url": "https://example.com/dashboard",
+  "title": "Example Dashboard",
+  "refs": [
+    {
+      "id": "e1",
+      "role": "button",
+      "name": "Continue"
+    }
+  ],
+  "visibleText": "Welcome back",
+  "htmlPath": "runs/browser/html/0001.html",
+  "screenshotPath": "runs/browser/shots/0001.png"
+}

--- a/ts/tests/integrations/browser/fixtures/invalid-snapshot-null-ref-name.json
+++ b/ts/tests/integrations/browser/fixtures/invalid-snapshot-null-ref-name.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.0",
+  "sessionId": "session_1",
+  "capturedAt": "2026-04-22T12:00:01Z",
+  "url": "https://example.com/dashboard",
+  "title": "Example Dashboard",
+  "refs": [
+    {
+      "id": "@e1",
+      "role": "button",
+      "name": null
+    }
+  ],
+  "visibleText": "Welcome back",
+  "htmlPath": "runs/browser/html/0001.html",
+  "screenshotPath": "runs/browser/shots/0001.png"
+}

--- a/ts/tests/integrations/browser/fixtures/valid-action-navigate.json
+++ b/ts/tests/integrations/browser/fixtures/valid-action-navigate.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "1.0",
+  "actionId": "act_nav_1",
+  "sessionId": "session_1",
+  "timestamp": "2026-04-22T12:00:00Z",
+  "type": "navigate",
+  "params": {
+    "url": "https://example.com/dashboard"
+  }
+}

--- a/ts/tests/integrations/browser/fixtures/valid-audit-event-allowed.json
+++ b/ts/tests/integrations/browser/fixtures/valid-audit-event-allowed.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "1.0",
+  "eventId": "evt_1",
+  "sessionId": "session_1",
+  "actionId": "act_nav_1",
+  "kind": "action_result",
+  "allowed": true,
+  "policyReason": "allowed",
+  "timestamp": "2026-04-22T12:00:02Z",
+  "message": "navigation allowed",
+  "beforeUrl": "about:blank",
+  "afterUrl": "https://example.com/dashboard",
+  "artifacts": {
+    "htmlPath": null,
+    "screenshotPath": "runs/browser/shots/0001.png",
+    "downloadPath": null
+  }
+}

--- a/ts/tests/integrations/browser/fixtures/valid-session-config-ephemeral.json
+++ b/ts/tests/integrations/browser/fixtures/valid-session-config-ephemeral.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0",
+  "profileMode": "ephemeral",
+  "allowedDomains": [
+    "example.com",
+    "*.example.org"
+  ],
+  "allowAuth": false,
+  "allowUploads": false,
+  "allowDownloads": false,
+  "captureScreenshots": true,
+  "headless": true,
+  "downloadsRoot": null,
+  "uploadsRoot": null
+}

--- a/ts/tests/integrations/browser/fixtures/valid-session-config-isolated-downloads.json
+++ b/ts/tests/integrations/browser/fixtures/valid-session-config-isolated-downloads.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "1.0",
+  "profileMode": "isolated",
+  "allowedDomains": [
+    "docs.example.com"
+  ],
+  "allowAuth": false,
+  "allowUploads": false,
+  "allowDownloads": true,
+  "captureScreenshots": true,
+  "headless": true,
+  "downloadsRoot": "/tmp/browser-downloads",
+  "uploadsRoot": null
+}

--- a/ts/tests/integrations/browser/fixtures/valid-snapshot-minimal.json
+++ b/ts/tests/integrations/browser/fixtures/valid-snapshot-minimal.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "1.0",
+  "sessionId": "session_1",
+  "capturedAt": "2026-04-22T12:00:01Z",
+  "url": "https://example.com/dashboard",
+  "title": "Example Dashboard",
+  "refs": [
+    {
+      "id": "@e1",
+      "role": "button",
+      "name": "Continue"
+    }
+  ],
+  "visibleText": "Welcome back",
+  "htmlPath": "runs/browser/html/0001.html",
+  "screenshotPath": "runs/browser/shots/0001.png"
+}


### PR DESCRIPTION
## Summary
- Add shared browser contract fixtures for valid and invalid session configs, actions, snapshots, and audit events.
- Add Python fixture-driven validation tests and TypeScript validator tests.
- Add a cross-runtime Vitest parity test that compares TypeScript validation with Python validators through uv.

## Tests
- cd autocontext && uv run pytest tests/test_browser_contract_fixtures.py -q
- cd autocontext && uv run ruff check tests/test_browser_contract_fixtures.py
- cd ts && npx vitest run tests/integrations/browser/contract/validators.test.ts tests/integrations/browser/contract/cross-runtime.test.ts
- cd ts && npm run lint

Linear: AC-603