### PR TITLE
AC-601: Wire Python browser context into investigations and queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes in this section are on the branch/repo after `0.4.4` and are not part of
 
 - Added a shared browser exploration contract and package-safe configuration surface across Python and TypeScript, including canonical schemas, validation helpers, secure `AUTOCONTEXT_BROWSER_*` defaults, and policy helpers.
 - Added the TypeScript Chrome DevTools Protocol backend for browser exploration, including attach-only target discovery, websocket transport, policy-gated actions, and evidence artifacts.
+- Added Python browser exploration integration for investigations and queued tasks, including policy-gated snapshot capture, prompt/evidence enrichment, and fail-closed task-runner wiring.
 - Added a thin Python Chrome CDP browser backend with debugger-target discovery, evidence persistence, WebSocket transport, runtime factory, and policy-checked session actions.
 - Added cross-runtime browser contract fixtures so Python and TypeScript validators stay in lockstep.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Strategies are then evaluated through scenario execution, staged validation, and
 | ------------- | ----------------------------------------------------------------------------------------- |
 | `run`         | Improve behavior inside a reusable scenario or task across generations                    |
 | `simulate`    | Model a system, explore parameter sweeps, or compare replayable outcomes                  |
-| `investigate` | Evidence-driven diagnosis with hypotheses and confidence scoring                          |
+| `investigate` | Evidence-driven diagnosis with hypotheses, confidence scoring, and optional browser context |
 | `analyze`     | Inspect or compare runs, simulations, investigations, or missions after the fact          |
 | `mission`     | Verifier-driven goal advanced step by step with checkpoints and completion criteria       |
 | `campaign`    | Coordinate multiple missions with budget tracking, dependencies, and progress aggregation |
@@ -267,7 +267,9 @@ Both packages share an optional, disabled-by-default browser exploration contrac
 - Run and improve a saved scenario: `uv run autoctx run --scenario support_triage --gens 3`
 - Inspect or replay outputs: `uv run autoctx list`, `uv run autoctx status <run_id>`
 - Run an investigation from Python: `uv run autoctx investigate -d "why did conversion drop after Tuesday's release"`
+- Add a policy-checked browser snapshot to an investigation: `uv run autoctx investigate -d "checkout is failing in prod" --browser-url https://status.example.com`
 - Enqueue an ad hoc queued task from Python: `uv run autoctx queue add --task-prompt "Write a 1-line fact about primes" --rubric "correct" --threshold 0.8 --rounds 2`
+- Enqueue a browser-enriched queued task when browser exploration is configured: `uv run autoctx queue --spec support_triage --browser-url https://status.example.com`
 - Override the simulation provider per call: `uv run autoctx simulate -d "simulate deploying a web service with rollback" --provider claude-cli`
 - Scaffold a custom scenario: `uv run autoctx new-scenario --template prompt-optimization --name my-task`
 - Export training data: `uv run autoctx export-training-data --scenario support_triage --all-runs --output training/support_triage.jsonl`

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -105,7 +105,7 @@ uv run autoctx solve --description "improve customer-support replies for billing
 
 `autoctx simulate` now follows the effective architect-role runtime surface, so `AUTOCONTEXT_ARCHITECT_PROVIDER`, other role-routing overrides, and per-call `--provider <name>` overrides all apply to live simulation generation.
 
-`autoctx investigate` now ships as a first-class Python CLI surface as well. It uses the architect runtime for investigation-spec synthesis and the analyst runtime for hypothesis generation, so role-routing overrides apply there too.
+`autoctx investigate` now ships as a first-class Python CLI surface as well. It uses the architect runtime for investigation-spec synthesis and the analyst runtime for hypothesis generation, so role-routing overrides apply there too. When browser exploration is enabled, `--browser-url <url>` captures a policy-checked snapshot and folds that evidence into the investigation prompts and report artifacts.
 
 Run with Pi RPC (local Pi subprocess using `pi --mode rpc` JSONL):
 
@@ -153,7 +153,9 @@ uv run autoctx solve --description "improve customer-support replies for billing
 uv run autoctx simulate --description "simulate deploying a web service with rollback"
 uv run autoctx simulate --description "simulate deploying a web service with rollback" --provider claude-cli
 uv run autoctx investigate --description "why did conversion drop after Tuesday's release"
+uv run autoctx investigate --description "checkout is failing in prod" --browser-url https://status.example.com
 uv run autoctx queue add --task-prompt "Write a 1-line fact about primes" --rubric "correct" --threshold 0.8 --rounds 2
+uv run autoctx queue --spec support_triage --browser-url https://status.example.com
 uv run autoctx simulate --replay deploy_sim --variables threshold=0.9
 uv run autoctx list
 uv run autoctx status <run_id>

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -1220,6 +1220,7 @@ def investigate(
     max_steps: int = typer.Option(8, "--max-steps", min=1, help="Maximum investigation steps"),
     hypotheses: int = typer.Option(5, "--hypotheses", min=1, help="Maximum hypotheses to generate"),
     save_as: str = typer.Option("", "--save-as", help="Name for the saved investigation"),
+    browser_url: str = typer.Option("", "--browser-url", help="Optional browser URL to capture before investigation"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
     """Run a plain-language investigation with evidence and hypotheses."""
@@ -1228,6 +1229,7 @@ def investigate(
         max_steps=max_steps,
         hypotheses=hypotheses,
         save_as=save_as,
+        browser_url=browser_url,
         json_output=json_output,
         console=console,
         load_settings_fn=load_settings,

--- a/autocontext/src/autocontext/cli_investigate.py
+++ b/autocontext/src/autocontext/cli_investigate.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 import typer
 
 from autocontext.config.settings import AppSettings
+from autocontext.investigation.browser_context import capture_investigation_browser_context
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -23,6 +24,7 @@ def run_investigate_command(
     max_steps: int,
     hypotheses: int,
     save_as: str,
+    browser_url: str,
     json_output: bool,
     console: Console,
     load_settings_fn: Callable[[], AppSettings],
@@ -31,7 +33,11 @@ def run_investigate_command(
     write_json_stderr: Callable[[str], None],
     check_json_exit: Callable[[dict[str, Any]], None],
 ) -> None:
-    from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
+    from autocontext.investigation.engine import (
+        InvestigationEngine,
+        InvestigationRequest,
+        derive_investigation_name,
+    )
 
     if not description:
         message = "--description is required. Run 'autoctx investigate --help' for usage."
@@ -42,6 +48,23 @@ def run_investigate_command(
         raise typer.Exit(code=1)
 
     settings = load_settings_fn()
+    browser_context = None
+    if browser_url:
+        investigation_name = save_as or derive_investigation_name(description)
+        try:
+            browser_context = capture_investigation_browser_context(
+                settings,
+                browser_url=browser_url,
+                investigation_name=investigation_name,
+            )
+        except Exception as exc:
+            message = f"Browser exploration failed: {exc}"
+            if json_output:
+                write_json_stderr(message)
+            else:
+                console.print(f"[red]{message}[/red]")
+            raise typer.Exit(code=1) from exc
+
     spec_provider, spec_model = resolve_investigation_runtime(settings, role="architect")
     analysis_provider, analysis_model = resolve_investigation_runtime(settings, role="analyst")
 
@@ -64,6 +87,7 @@ def run_investigate_command(
             max_steps=max_steps,
             max_hypotheses=hypotheses,
             save_as=save_as or None,
+            browser_context=browser_context,
         )
     )
     payload = result.to_dict()

--- a/autocontext/src/autocontext/cli_queue.py
+++ b/autocontext/src/autocontext/cli_queue.py
@@ -22,6 +22,7 @@ class QueueEnqueuer(Protocol):
         spec_name: str,
         task_prompt: str | None = None,
         rubric: str | None = None,
+        browser_url: str | None = None,
         max_rounds: int = 5,
         quality_threshold: float = 0.9,
         min_rounds: int = 1,
@@ -56,6 +57,7 @@ def run_queue_command(
     spec: str,
     task_prompt: str,
     rubric: str,
+    browser_url: str,
     max_rounds: int,
     threshold: float,
     min_rounds: int,
@@ -92,34 +94,28 @@ def run_queue_command(
     settings = load_settings_fn()
     store = sqlite_from_settings(settings)
 
-    has_direct_task_payload = bool(task_prompt.strip() or rubric.strip())
-    if not has_direct_task_payload and max_rounds == 5 and threshold == 0.9 and min_rounds == 1:
-        task_id = enqueue_task_fn(
-            store=store,
-            spec_name=resolved_spec_name,
-            priority=priority,
-        )
-    elif min_rounds == 1:
-        task_id = enqueue_task_fn(
-            store=store,
-            spec_name=resolved_spec_name,
-            task_prompt=task_prompt.strip() or None,
-            rubric=rubric.strip() or None,
-            max_rounds=max_rounds,
-            quality_threshold=threshold,
-            priority=priority,
-        )
-    else:
-        task_id = enqueue_task_fn(
-            store=store,
-            spec_name=resolved_spec_name,
-            task_prompt=task_prompt.strip() or None,
-            rubric=rubric.strip() or None,
-            max_rounds=max_rounds,
-            quality_threshold=threshold,
-            min_rounds=min_rounds,
-            priority=priority,
-        )
+    task_kwargs: dict[str, Any] = {
+        "store": store,
+        "spec_name": resolved_spec_name,
+        "priority": priority,
+    }
+    normalized_task_prompt = task_prompt.strip() or None
+    normalized_rubric = rubric.strip() or None
+    normalized_browser_url = browser_url.strip() or None
+    if normalized_task_prompt is not None:
+        task_kwargs["task_prompt"] = normalized_task_prompt
+    if normalized_rubric is not None:
+        task_kwargs["rubric"] = normalized_rubric
+    if normalized_browser_url is not None:
+        task_kwargs["browser_url"] = normalized_browser_url
+    if max_rounds != 5:
+        task_kwargs["max_rounds"] = max_rounds
+    if threshold != 0.9:
+        task_kwargs["quality_threshold"] = threshold
+    if min_rounds != 1:
+        task_kwargs["min_rounds"] = min_rounds
+
+    task_id = enqueue_task_fn(**task_kwargs)
 
     payload = {"task_id": task_id, "spec_name": resolved_spec_name, "status": "queued"}
     if json_output:
@@ -140,6 +136,7 @@ def register_queue_command(
         spec: str = typer.Option("", "--spec", "-s", help="Task spec name"),
         task_prompt: str = typer.Option("", "--task-prompt", "--prompt", "-p", help="The queued task prompt"),
         rubric: str = typer.Option("", "--rubric", "-r", help="Evaluation rubric"),
+        browser_url: str = typer.Option("", "--browser-url", help="Optional browser URL to capture before execution"),
         max_rounds: int = typer.Option(5, "--rounds", "-n", min=1, help="Maximum improvement rounds"),
         threshold: float = typer.Option(0.9, "--threshold", "-t", help="Quality threshold to stop"),
         min_rounds: int = typer.Option(1, "--min-rounds", min=1, help="Minimum rounds before threshold stops"),
@@ -155,6 +152,7 @@ def register_queue_command(
             spec=spec,
             task_prompt=task_prompt,
             rubric=rubric,
+            browser_url=browser_url,
             max_rounds=max_rounds,
             threshold=threshold,
             min_rounds=min_rounds,

--- a/autocontext/src/autocontext/execution/queued_task_browser_context.py
+++ b/autocontext/src/autocontext/execution/queued_task_browser_context.py
@@ -1,0 +1,79 @@
+"""Browser-backed reference-context enrichment for queued tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from autocontext.config.settings import AppSettings
+from autocontext.integrations.browser.context_capture import (
+    capture_browser_context,
+    render_captured_browser_context,
+)
+
+
+class QueuedTaskBrowserContextService(Protocol):
+    """Build authoritative reference context from a browser snapshot."""
+
+    def build_reference_context(
+        self,
+        *,
+        task_id: str,
+        browser_url: str,
+        reference_context: str | None,
+    ) -> str: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsBackedQueuedTaskBrowserContextService:
+    """Capture browser context for queued tasks using AppSettings."""
+
+    settings: AppSettings
+
+    def build_reference_context(
+        self,
+        *,
+        task_id: str,
+        browser_url: str,
+        reference_context: str | None,
+    ) -> str:
+        context = capture_browser_context(
+            self.settings,
+            browser_url=browser_url,
+            evidence_root=(self.settings.runs_root / "task_queue" / task_id),
+        )
+        return merge_queued_task_reference_context(
+            reference_context=reference_context,
+            browser_context=render_captured_browser_context(context),
+        )
+
+
+def create_queued_task_browser_context_service(
+    settings: AppSettings,
+) -> QueuedTaskBrowserContextService:
+    """Create a settings-backed queued-task browser context service."""
+    return SettingsBackedQueuedTaskBrowserContextService(settings=settings)
+
+
+def merge_queued_task_reference_context(
+    *,
+    reference_context: str | None,
+    browser_context: str,
+) -> str:
+    """Merge queued-task reference context with browser-derived context."""
+    parts = []
+    trimmed_reference_context = (reference_context or "").strip()
+    if trimmed_reference_context:
+        parts.append(trimmed_reference_context)
+    trimmed_browser_context = browser_context.strip()
+    if trimmed_browser_context:
+        parts.append(trimmed_browser_context)
+    return "\n\n".join(parts)
+
+
+__all__ = [
+    "QueuedTaskBrowserContextService",
+    "SettingsBackedQueuedTaskBrowserContextService",
+    "create_queued_task_browser_context_service",
+    "merge_queued_task_reference_context",
+]

--- a/autocontext/src/autocontext/execution/simple_agent_task_workflow.py
+++ b/autocontext/src/autocontext/execution/simple_agent_task_workflow.py
@@ -1,0 +1,135 @@
+"""Prompt helpers for simple queued agent tasks."""
+
+from __future__ import annotations
+
+from autocontext.providers.base import LLMProvider
+from autocontext.scenarios.agent_task import AgentTaskResult
+
+
+def generate_simple_agent_task_output(
+    *,
+    provider: LLMProvider,
+    model: str,
+    task_prompt: str,
+    reference_context: str | None = None,
+    required_concepts: list[str] | None = None,
+) -> str:
+    """Generate initial output for a simple queued task."""
+    result = provider.complete(
+        system_prompt="You are a skilled writer and analyst. Complete the task precisely.",
+        user_prompt=build_simple_agent_task_user_prompt(
+            task_prompt=task_prompt,
+            reference_context=reference_context,
+            required_concepts=required_concepts,
+        ),
+        model=model,
+    )
+    return result.text
+
+
+def revise_simple_agent_task_output(
+    *,
+    provider: LLMProvider,
+    model: str,
+    task_prompt: str,
+    output: str,
+    judge_result: AgentTaskResult,
+    revision_prompt: str | None = None,
+    reference_context: str | None = None,
+    required_concepts: list[str] | None = None,
+    objective_feedback: str | None = None,
+) -> str:
+    """Revise output for a simple queued task."""
+    result = provider.complete(
+        system_prompt=(
+            "You are revising content based on expert feedback. Improve the output. "
+            "IMPORTANT: Return ONLY the revised content. Do NOT include analysis, "
+            "explanations, headers like '## Revised Output', or self-assessment. "
+            "Just output the improved version directly."
+        ),
+        user_prompt=build_simple_agent_task_revision_prompt(
+            task_prompt=task_prompt,
+            output=output,
+            judge_result=judge_result,
+            revision_prompt=revision_prompt,
+            reference_context=reference_context,
+            required_concepts=required_concepts,
+            objective_feedback=objective_feedback,
+        ),
+        model=model,
+    )
+    return result.text
+
+
+def build_simple_agent_task_user_prompt(
+    *,
+    task_prompt: str,
+    reference_context: str | None = None,
+    required_concepts: list[str] | None = None,
+) -> str:
+    """Build the direct-generation prompt for a simple queued task."""
+    blocks = [
+        task_prompt.strip(),
+        _build_reference_context_block(reference_context),
+        _build_required_concepts_block(required_concepts),
+    ]
+    return "\n\n".join(block for block in blocks if block)
+
+
+def build_simple_agent_task_revision_prompt(
+    *,
+    task_prompt: str,
+    output: str,
+    judge_result: AgentTaskResult,
+    revision_prompt: str | None = None,
+    reference_context: str | None = None,
+    required_concepts: list[str] | None = None,
+    objective_feedback: str | None = None,
+) -> str:
+    """Build the revision prompt for a simple queued task."""
+    instruction = revision_prompt or (
+        "Revise the following output based on the judge's feedback. "
+        "Maintain what works, fix what doesn't."
+    )
+    blocks = [
+        instruction,
+        f"## Original Output\n{output}",
+        f"## Judge Score: {judge_result.score:.2f}",
+        f"## Judge Feedback\n{judge_result.reasoning}",
+        _build_objective_feedback_block(objective_feedback),
+        _build_reference_context_block(reference_context),
+        _build_required_concepts_block(required_concepts),
+        f"## Task\n{task_prompt}",
+        "Produce an improved version:",
+    ]
+    return "\n\n".join(block for block in blocks if block)
+
+
+def _build_reference_context_block(reference_context: str | None) -> str:
+    trimmed_reference_context = (reference_context or "").strip()
+    if not trimmed_reference_context:
+        return ""
+    return f"## Reference Context\n{trimmed_reference_context}"
+
+
+def _build_required_concepts_block(required_concepts: list[str] | None) -> str:
+    normalized_concepts = [concept.strip() for concept in required_concepts or [] if concept.strip()]
+    if not normalized_concepts:
+        return ""
+    concepts = "\n".join(f"- {concept}" for concept in normalized_concepts)
+    return f"## Required Concepts\n{concepts}"
+
+
+def _build_objective_feedback_block(objective_feedback: str | None) -> str:
+    trimmed_objective_feedback = (objective_feedback or "").strip()
+    if not trimmed_objective_feedback:
+        return ""
+    return f"## Objective Verification Feedback\n{trimmed_objective_feedback}"
+
+
+__all__ = [
+    "build_simple_agent_task_revision_prompt",
+    "build_simple_agent_task_user_prompt",
+    "generate_simple_agent_task_output",
+    "revise_simple_agent_task_output",
+]

--- a/autocontext/src/autocontext/execution/task_runner.py
+++ b/autocontext/src/autocontext/execution/task_runner.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from autocontext.notifications.base import Notifier
 
+from autocontext.config.settings import AppSettings
 from autocontext.execution.agent_task_evolution import (
     AgentTaskEvolutionRunner,
     AgentTaskGenerationEvaluation,
@@ -31,7 +32,15 @@ from autocontext.execution.objective_verification import (
     ObjectiveVerificationConfig,
     run_objective_verification,
 )
+from autocontext.execution.queued_task_browser_context import (
+    QueuedTaskBrowserContextService,
+    create_queued_task_browser_context_service,
+)
 from autocontext.execution.rubric_calibration import run_judge_calibration
+from autocontext.execution.simple_agent_task_workflow import (
+    generate_simple_agent_task_output,
+    revise_simple_agent_task_output,
+)
 from autocontext.execution.verification_dataset import enrich_objective_payload
 from autocontext.harness.pipeline.objective_guardrail import (
     evaluate_objective_guardrail,
@@ -53,6 +62,7 @@ class TaskConfig:
     quality_threshold: float = 0.9
     min_rounds: int = 1
     reference_context: str | None = None
+    browser_url: str | None = None
     required_concepts: list[str] | None = None
     calibration_examples: list[dict] | None = None
     initial_output: str | None = None
@@ -76,6 +86,7 @@ class TaskConfig:
             quality_threshold=parsed.get("quality_threshold", 0.9),
             min_rounds=parsed.get("min_rounds", 1),
             reference_context=parsed.get("reference_context"),
+            browser_url=parsed.get("browser_url"),
             required_concepts=parsed.get("required_concepts"),
             calibration_examples=parsed.get("calibration_examples"),
             initial_output=parsed.get("initial_output"),
@@ -280,6 +291,8 @@ def _build_evaluator_guardrail_payload(
     task: AgentTaskInterface,
     output: str,
     config: TaskConfig,
+    *,
+    reference_context: str | None = None,
 ) -> dict[str, Any] | None:
     """Run live evaluator guardrails on the best output when enabled."""
     if config.judge_samples <= 1 and not config.judge_bias_probes_enabled:
@@ -287,7 +300,7 @@ def _build_evaluator_guardrail_payload(
     evaluation = task.evaluate_output(
         output,
         task.initial_state(),
-        reference_context=config.reference_context,
+        reference_context=reference_context,
         required_concepts=config.required_concepts,
         calibration_examples=config.calibration_examples,
     )
@@ -409,45 +422,32 @@ class SimpleAgentTask(AgentTaskInterface):
 
     def generate_output(self, state: dict) -> str:
         """Generate initial output using the provider."""
-        result = self._provider.complete(
-            system_prompt="You are a skilled writer and analyst. Complete the task precisely.",
-            user_prompt=self._task_prompt,
+        return generate_simple_agent_task_output(
+            provider=self._provider,
             model=self._model,
+            task_prompt=self._task_prompt,
+            reference_context=state.get("reference_context"),
+            required_concepts=state.get("required_concepts"),
         )
-        return result.text
 
     def revise_output(self, output: str, judge_result: AgentTaskResult, state: dict) -> str:
         """Revise output using judge feedback."""
-        revision_instruction = self._revision_prompt or (
-            "Revise the following output based on the judge's feedback. "
-            "Maintain what works, fix what doesn't."
-        )
         objective_feedback = state.get("oracle_revision_feedback_context")
-        objective_block = ""
-        if isinstance(objective_feedback, str) and objective_feedback.strip():
-            objective_block = (
-                f"## Objective Verification Feedback\n{objective_feedback}\n\n"
-            )
-        prompt = (
-            f"{revision_instruction}\n\n"
-            f"## Original Output\n{output}\n\n"
-            f"## Judge Score: {judge_result.score:.2f}\n"
-            f"## Judge Feedback\n{judge_result.reasoning}\n\n"
-            f"{objective_block}"
-            f"## Task\n{self._task_prompt}\n\n"
-            "Produce an improved version:"
-        )
-        result = self._provider.complete(
-            system_prompt=(
-                "You are revising content based on expert feedback. Improve the output. "
-                "IMPORTANT: Return ONLY the revised content. Do NOT include analysis, "
-                "explanations, headers like '## Revised Output', or self-assessment. "
-                "Just output the improved version directly."
-            ),
-            user_prompt=prompt,
+        return revise_simple_agent_task_output(
+            provider=self._provider,
             model=self._model,
+            task_prompt=self._task_prompt,
+            output=output,
+            judge_result=judge_result,
+            revision_prompt=self._revision_prompt,
+            reference_context=state.get("reference_context"),
+            required_concepts=state.get("required_concepts"),
+            objective_feedback=(
+                objective_feedback
+                if isinstance(objective_feedback, str)
+                else None
+            ),
         )
-        return result.text
 
 
 class TaskRunner:
@@ -468,6 +468,7 @@ class TaskRunner:
         max_consecutive_empty: int = 0,  # 0 = run forever
         notifier: Notifier | None = None,
         concurrency: int = 1,
+        browser_context_service: QueuedTaskBrowserContextService | None = None,
     ) -> None:
         self.store = store
         self.provider = provider
@@ -476,6 +477,7 @@ class TaskRunner:
         self.max_consecutive_empty = max_consecutive_empty
         self.notifier = notifier
         self.concurrency = max(1, concurrency)
+        self.browser_context_service = browser_context_service
         self._shutdown = False
         self._tasks_processed = 0
 
@@ -569,6 +571,7 @@ class TaskRunner:
 
         try:
             config = TaskConfig.from_json(task.get("config_json"))
+            reference_context = self._resolve_reference_context(task_id, config)
 
             agent_task = SimpleAgentTask(
                 task_prompt=config.task_prompt or f"Complete the task: {spec_name}",
@@ -586,7 +589,10 @@ class TaskRunner:
             initial_output = config.initial_output
             if not initial_output:
                 logger.info("generating initial output for task %s", task_id)
-                initial_output = agent_task.generate_output({})
+                initial_output = agent_task.generate_output({
+                    "reference_context": reference_context,
+                    "required_concepts": config.required_concepts,
+                })
             if config.generations > 1:
                 result = self._run_task_multi_generation(
                     task_id=task_id,
@@ -594,6 +600,7 @@ class TaskRunner:
                     spec_name=spec_name,
                     initial_output=initial_output,
                     config=config,
+                    reference_context=reference_context,
                 )
             else:
                 loop = ImprovementLoop(
@@ -602,7 +609,10 @@ class TaskRunner:
                     quality_threshold=config.quality_threshold,
                     min_rounds=config.min_rounds,
                 )
-                loop_state: dict[str, Any] = {}
+                loop_state: dict[str, Any] = {
+                    "reference_context": reference_context,
+                    "required_concepts": config.required_concepts,
+                }
                 if config.objective_verification:
                     loop_state["revision_feedback_callback"] = (
                         lambda current_output, judge_result: _build_objective_revision_feedback(
@@ -615,7 +625,7 @@ class TaskRunner:
                 result = loop.run(
                     initial_output=initial_output,
                     state=loop_state,
-                    reference_context=config.reference_context,
+                    reference_context=reference_context,
                     required_concepts=config.required_concepts,
                     calibration_examples=config.calibration_examples,
                 )
@@ -633,6 +643,7 @@ class TaskRunner:
                     agent_task,
                     result.best_output,
                     config,
+                    reference_context=reference_context,
                 )
                 effective_met_threshold = result.met_threshold and (
                     objective_guardrail is None or bool(objective_guardrail.get("passed"))
@@ -647,7 +658,7 @@ class TaskRunner:
                     rubric=agent_task.get_rubric(),
                     provider=self.provider,
                     model=self.model,
-                    reference_context=config.reference_context,
+                    reference_context=reference_context,
                     required_concepts=config.required_concepts,
                 )
 
@@ -686,20 +697,19 @@ class TaskRunner:
         spec_name: str,
         initial_output: str,
         config: TaskConfig,
+        reference_context: str | None = None,
     ) -> ImprovementResult:
         """Run first-class multi-generation learning for an AgentTask."""
         generation_results: dict[int, ImprovementResult] = {}
 
         def generate_fn(prompt: str, generation: int) -> str:
-            result = self.provider.complete(
-                system_prompt=(
-                    "You are a skilled writer and analyst. Complete the task precisely and "
-                    "apply any accumulated lessons to improve on prior attempts."
-                ),
-                user_prompt=prompt,
+            return generate_simple_agent_task_output(
+                provider=self.provider,
                 model=self.model or self.provider.default_model(),
+                task_prompt=prompt,
+                reference_context=reference_context,
+                required_concepts=config.required_concepts,
             )
-            return result.text
 
         def evaluate_fn(output: str, generation: int) -> AgentTaskGenerationEvaluation:
             loop = ImprovementLoop(
@@ -708,7 +718,10 @@ class TaskRunner:
                 quality_threshold=config.quality_threshold,
                 min_rounds=config.min_rounds,
             )
-            loop_state: dict[str, Any] = {}
+            loop_state: dict[str, Any] = {
+                "reference_context": reference_context,
+                "required_concepts": config.required_concepts,
+            }
             if config.objective_verification:
                 loop_state["revision_feedback_callback"] = (
                     lambda current_output, judge_result: _build_objective_revision_feedback(
@@ -720,7 +733,7 @@ class TaskRunner:
             loop_result = loop.run(
                 initial_output=output,
                 state=loop_state,
-                reference_context=config.reference_context,
+                reference_context=reference_context,
                 required_concepts=config.required_concepts,
                 calibration_examples=config.calibration_examples,
             )
@@ -770,6 +783,7 @@ class TaskRunner:
             agent_task,
             best_output,
             config,
+            reference_context=reference_context,
         )
         effective_met_threshold = met_threshold and (
             objective_guardrail is None or bool(objective_guardrail.get("passed"))
@@ -783,7 +797,7 @@ class TaskRunner:
             rubric=agent_task.get_rubric(),
             provider=self.provider,
             model=self.model,
-            reference_context=config.reference_context,
+            reference_context=reference_context,
             required_concepts=config.required_concepts,
         )
 
@@ -821,6 +835,18 @@ class TaskRunner:
             duration_ms=sum(result.duration_ms or 0 for result in ordered_results),
             judge_calls=sum(result.judge_calls for result in ordered_results),
             dimension_trajectory={},
+        )
+
+    def _resolve_reference_context(self, task_id: str, config: TaskConfig) -> str | None:
+        """Resolve authoritative reference context for a queued task."""
+        if not config.browser_url:
+            return config.reference_context
+        if self.browser_context_service is None:
+            raise ValueError("browser exploration is not configured")
+        return self.browser_context_service.build_reference_context(
+            task_id=task_id,
+            browser_url=config.browser_url,
+            reference_context=config.reference_context,
         )
 
     def _emit_completion_event(
@@ -880,12 +906,42 @@ class TaskRunner:
             time.sleep(min(1.0, end - time.monotonic()))
 
 
+def create_task_runner_from_settings(
+    settings: AppSettings,
+    *,
+    store: SQLiteStore,
+    provider: LLMProvider,
+    model: str = "",
+    poll_interval: float = 60.0,
+    max_consecutive_empty: int = 0,
+    notifier: Notifier | None = None,
+    concurrency: int = 1,
+) -> TaskRunner:
+    """Build a task runner from app settings with optional browser enrichment."""
+    browser_context_service = (
+        create_queued_task_browser_context_service(settings)
+        if settings.browser_enabled
+        else None
+    )
+    return TaskRunner(
+        store=store,
+        provider=provider,
+        model=model,
+        poll_interval=poll_interval,
+        max_consecutive_empty=max_consecutive_empty,
+        notifier=notifier,
+        concurrency=concurrency,
+        browser_context_service=browser_context_service,
+    )
+
+
 def enqueue_task(
     store: SQLiteStore,
     spec_name: str,
     task_prompt: str | None = None,
     rubric: str | None = None,
     reference_context: str | None = None,
+    browser_url: str | None = None,
     required_concepts: list[str] | None = None,
     generations: int = 1,
     max_rounds: int = 5,
@@ -909,6 +965,7 @@ def enqueue_task(
         "task_prompt": task_prompt,
         "rubric": rubric,
         "reference_context": reference_context,
+        "browser_url": browser_url,
         "required_concepts": required_concepts,
         "initial_output": initial_output,
         "objective_verification": objective_verification,

--- a/autocontext/src/autocontext/integrations/browser/__init__.py
+++ b/autocontext/src/autocontext/integrations/browser/__init__.py
@@ -13,6 +13,11 @@ from autocontext.integrations.browser.chrome_cdp_transport import (
     ChromeCdpTransportError,
     ChromeCdpWebSocketTransport,
 )
+from autocontext.integrations.browser.context_capture import (
+    CapturedBrowserContext,
+    capture_browser_context,
+    render_captured_browser_context,
+)
 from autocontext.integrations.browser.evidence import BrowserArtifactPaths, BrowserEvidenceStore
 from autocontext.integrations.browser.factory import (
     ConfiguredBrowserRuntime,
@@ -49,11 +54,14 @@ __all__ = [
     "ChromeCdpTargetDiscoveryPort",
     "ChromeCdpTransportError",
     "ChromeCdpWebSocketTransport",
+    "CapturedBrowserContext",
     "BrowserPolicyDecision",
     "browser_runtime_from_settings",
     "build_default_browser_session_config",
+    "capture_browser_context",
     "evaluate_browser_action_policy",
     "normalize_browser_allowed_domains",
+    "render_captured_browser_context",
     "resolve_browser_session_config",
     "select_chrome_cdp_target",
     "validate_browser_action",

--- a/autocontext/src/autocontext/integrations/browser/context_capture.py
+++ b/autocontext/src/autocontext/integrations/browser/context_capture.py
@@ -1,0 +1,98 @@
+"""Reusable browser snapshot capture helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+from autocontext.config.settings import AppSettings
+from autocontext.integrations.browser.contract.models import BrowserSessionConfig
+from autocontext.integrations.browser.factory import browser_runtime_from_settings
+from autocontext.integrations.browser.types import BrowserRuntimePort
+
+MAX_BROWSER_VISIBLE_TEXT_CHARS = 1200
+
+
+@dataclass(frozen=True, slots=True)
+class CapturedBrowserContext:
+    """Stable browser-derived context that can be folded into prompts."""
+
+    url: str
+    title: str
+    visible_text: str
+    html_path: str | None = None
+    screenshot_path: str | None = None
+
+
+def capture_browser_context(
+    settings: AppSettings,
+    *,
+    browser_url: str,
+    evidence_root: Path,
+) -> CapturedBrowserContext:
+    """Capture a single browser snapshot and normalize its text payload."""
+    configured = browser_runtime_from_settings(settings, evidence_root=evidence_root)
+    if configured is None:
+        raise ValueError("browser exploration is disabled")
+
+    return asyncio.run(
+        _capture_browser_context_async(
+            configured.runtime,
+            configured.session_config,
+            browser_url=browser_url,
+        )
+    )
+
+
+async def _capture_browser_context_async(
+    runtime: BrowserRuntimePort,
+    session_config: BrowserSessionConfig,
+    *,
+    browser_url: str,
+) -> CapturedBrowserContext:
+    session = await runtime.create_session(session_config)
+    try:
+        navigation = await session.navigate(browser_url)
+        if not navigation.allowed:
+            raise ValueError(f"browser navigation blocked by policy: {navigation.policyReason}")
+        snapshot = await session.snapshot()
+    finally:
+        await session.close()
+
+    return CapturedBrowserContext(
+        url=snapshot.url,
+        title=snapshot.title,
+        visible_text=_trim_visible_text(snapshot.visibleText),
+        html_path=snapshot.htmlPath,
+        screenshot_path=snapshot.screenshotPath,
+    )
+
+
+def render_captured_browser_context(context: CapturedBrowserContext) -> str:
+    """Render browser context into prompt-friendly lines."""
+    lines = [
+        "Live browser context:",
+        f"URL: {context.url}",
+        f"Title: {context.title}",
+        f"Visible text: {context.visible_text}",
+    ]
+    if context.html_path:
+        lines.append(f"HTML artifact: {context.html_path}")
+    if context.screenshot_path:
+        lines.append(f"Screenshot artifact: {context.screenshot_path}")
+    return "\n".join(lines)
+
+
+def _trim_visible_text(text: str) -> str:
+    normalized = " ".join(text.split())
+    if len(normalized) <= MAX_BROWSER_VISIBLE_TEXT_CHARS:
+        return normalized
+    return normalized[:MAX_BROWSER_VISIBLE_TEXT_CHARS].rstrip()
+
+
+__all__ = [
+    "CapturedBrowserContext",
+    "capture_browser_context",
+    "render_captured_browser_context",
+]

--- a/autocontext/src/autocontext/investigation/__init__.py
+++ b/autocontext/src/autocontext/investigation/__init__.py
@@ -1,3 +1,9 @@
+from autocontext.investigation.browser_context import (
+    InvestigationBrowserContext,
+    build_browser_evidence_summary,
+    capture_investigation_browser_context,
+    render_investigation_browser_context,
+)
 from autocontext.investigation.engine import (
     InvestigationArtifacts,
     InvestigationConclusion,
@@ -13,6 +19,7 @@ from autocontext.investigation.engine import (
 )
 
 __all__ = [
+    "InvestigationBrowserContext",
     "InvestigationArtifacts",
     "InvestigationConclusion",
     "InvestigationEngine",
@@ -20,8 +27,11 @@ __all__ = [
     "InvestigationHypothesis",
     "InvestigationRequest",
     "InvestigationResult",
+    "build_browser_evidence_summary",
+    "capture_investigation_browser_context",
     "derive_investigation_name",
     "generate_investigation_id",
     "normalize_positive_integer",
     "parse_investigation_json",
+    "render_investigation_browser_context",
 ]

--- a/autocontext/src/autocontext/investigation/browser_context.py
+++ b/autocontext/src/autocontext/investigation/browser_context.py
@@ -1,0 +1,72 @@
+"""Browser-backed investigation context capture."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from autocontext.config.settings import AppSettings
+from autocontext.integrations.browser.context_capture import (
+    CapturedBrowserContext,
+    capture_browser_context,
+    render_captured_browser_context,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class InvestigationBrowserContext:
+    """Stable browser-derived context folded into investigation inputs."""
+
+    url: str
+    title: str
+    visible_text: str
+    html_path: str | None = None
+    screenshot_path: str | None = None
+
+
+def render_investigation_browser_context(context: InvestigationBrowserContext) -> str:
+    """Render browser context into prompt-friendly text."""
+    return render_captured_browser_context(
+        CapturedBrowserContext(
+            url=context.url,
+            title=context.title,
+            visible_text=context.visible_text,
+            html_path=context.html_path,
+            screenshot_path=context.screenshot_path,
+        )
+    )
+
+
+def build_browser_evidence_summary(context: InvestigationBrowserContext) -> str:
+    """Condense browser context into a single evidence summary."""
+    if context.title and context.visible_text:
+        return f"{context.title}\n{context.visible_text}"
+    return context.title or context.visible_text or context.url
+
+
+def capture_investigation_browser_context(
+    settings: AppSettings,
+    *,
+    browser_url: str,
+    investigation_name: str,
+) -> InvestigationBrowserContext:
+    """Capture a single browser snapshot for an investigation."""
+    context = capture_browser_context(
+        settings,
+        browser_url=browser_url,
+        evidence_root=(settings.knowledge_root / "_investigations" / investigation_name),
+    )
+    return InvestigationBrowserContext(
+        url=context.url,
+        title=context.title,
+        visible_text=context.visible_text,
+        html_path=context.html_path,
+        screenshot_path=context.screenshot_path,
+    )
+
+
+__all__ = [
+    "InvestigationBrowserContext",
+    "build_browser_evidence_summary",
+    "capture_investigation_browser_context",
+    "render_investigation_browser_context",
+]

--- a/autocontext/src/autocontext/investigation/engine.py
+++ b/autocontext/src/autocontext/investigation/engine.py
@@ -11,6 +11,11 @@ from pathlib import Path
 from typing import Any
 
 from autocontext.agents.types import LlmFn
+from autocontext.investigation.browser_context import (
+    InvestigationBrowserContext,
+    build_browser_evidence_summary,
+    render_investigation_browser_context,
+)
 from autocontext.scenarios.custom.family_pipeline import validate_for_family, validate_source_for_family
 from autocontext.scenarios.custom.investigation_codegen import generate_investigation_class
 from autocontext.scenarios.custom.investigation_spec import InvestigationSpec
@@ -28,6 +33,7 @@ class InvestigationRequest:
     max_steps: int | None = None
     max_hypotheses: int | None = None
     save_as: str | None = None
+    browser_context: InvestigationBrowserContext | None = None
 
 
 @dataclass(slots=True)
@@ -155,7 +161,11 @@ def parse_investigation_json(text: str) -> dict[str, Any] | None:
     return None
 
 
-def _build_investigation_spec_prompt(description: str) -> tuple[str, str]:
+def _build_investigation_spec_prompt(
+    description: str,
+    *,
+    browser_context: InvestigationBrowserContext | None = None,
+) -> tuple[str, str]:
     system_prompt = (
         "You are an investigation designer. Given a problem description, produce an investigation spec as JSON.\n\n"
         "Required fields:\n"
@@ -171,7 +181,10 @@ def _build_investigation_spec_prompt(description: str) -> tuple[str, str]:
         "- when preconditions represent ordering, reference prior action names instead of environmental access assumptions\n\n"
         "Output ONLY the JSON object, no markdown fences."
     )
-    return system_prompt, f"Investigation: {description}"
+    user_prompt = f"Investigation: {description}"
+    if browser_context is not None:
+        user_prompt = f"{user_prompt}\n\n{render_investigation_browser_context(browser_context)}"
+    return system_prompt, user_prompt
 
 
 def _build_hypothesis_prompt(
@@ -180,6 +193,7 @@ def _build_hypothesis_prompt(
     execution: _ExecutedInvestigation,
     diagnosis_target: str,
     max_hypotheses: int | None,
+    browser_context: InvestigationBrowserContext | None = None,
 ) -> tuple[str, str]:
     system_prompt = (
         "You are a diagnostic analyst. Given an investigation description and collected evidence, generate hypotheses. "
@@ -203,6 +217,8 @@ def _build_hypothesis_prompt(
         f"Steps taken: {execution.steps_executed}\n"
         f"Maximum hypotheses: {max_hypotheses or 5}"
     )
+    if browser_context is not None:
+        user_prompt = f"{user_prompt}\n\n{render_investigation_browser_context(browser_context)}"
     return system_prompt, user_prompt
 
 
@@ -348,8 +364,24 @@ def _similarity_score(left: str, right: str) -> float:
     return matches / max(len(left_tokens), len(right_tokens))
 
 
-def _build_evidence(execution: _ExecutedInvestigation) -> list[InvestigationEvidence]:
-    return [
+def _build_evidence(
+    execution: _ExecutedInvestigation,
+    *,
+    browser_context: InvestigationBrowserContext | None = None,
+) -> list[InvestigationEvidence]:
+    evidence: list[InvestigationEvidence] = []
+    if browser_context is not None:
+        evidence.append(
+            InvestigationEvidence(
+                id="browser_snapshot",
+                kind="browser_snapshot",
+                source=browser_context.url,
+                summary=build_browser_evidence_summary(browser_context),
+                is_red_herring=False,
+            )
+        )
+    evidence.extend(
+        [
         InvestigationEvidence(
             id=item.id,
             kind="red_herring" if item.is_red_herring else "observation",
@@ -358,7 +390,9 @@ def _build_evidence(execution: _ExecutedInvestigation) -> list[InvestigationEvid
             is_red_herring=item.is_red_herring,
         )
         for item in execution.collected_evidence
-    ]
+        ]
+    )
+    return evidence
 
 
 def _build_clustered_evidence_summary(
@@ -550,6 +584,8 @@ def _evaluate_hypotheses(
 def _build_conclusion(
     hypotheses: list[InvestigationHypothesis],
     evidence: list[InvestigationEvidence],
+    *,
+    has_browser_context: bool = False,
 ) -> InvestigationConclusion:
     supported = sorted(
         [hypothesis for hypothesis in hypotheses if hypothesis.status == "supported"],
@@ -563,7 +599,10 @@ def _build_conclusion(
         limitations.append(f"{red_herrings} potential red herring(s) in evidence pool")
     if any(hypothesis.status == "unresolved" for hypothesis in hypotheses):
         limitations.append("Some hypotheses remain unresolved")
-    limitations.append("Investigation based on generated scenario — not live system data")
+    if has_browser_context:
+        limitations.append("Investigation combines generated scenario reasoning with browser snapshot evidence")
+    else:
+        limitations.append("Investigation based on generated scenario — not live system data")
     return InvestigationConclusion(
         best_explanation=best.statement if best else "No hypothesis received sufficient support",
         confidence=best.confidence if best else 0.0,
@@ -642,7 +681,10 @@ class InvestigationEngine:
         name = request.save_as or derive_investigation_name(request.description)
 
         try:
-            spec_system, spec_user = _build_investigation_spec_prompt(request.description)
+            spec_system, spec_user = _build_investigation_spec_prompt(
+                request.description,
+                browser_context=request.browser_context,
+            )
             raw_spec = parse_investigation_json(self._spec_llm_fn(spec_system, spec_user))
             if raw_spec is None:
                 raise ValueError("Investigation spec generation did not return valid JSON")
@@ -670,6 +712,7 @@ class InvestigationEngine:
                 execution=execution,
                 diagnosis_target=spec.diagnosis_target,
                 max_hypotheses=request.max_hypotheses,
+                browser_context=request.browser_context,
             )
             question, raw_hypotheses = _parse_hypotheses(
                 text=self._analysis_llm_fn(hypothesis_system, hypothesis_user),
@@ -677,13 +720,17 @@ class InvestigationEngine:
                 max_hypotheses=request.max_hypotheses,
             )
 
-            evidence = _build_evidence(execution)
+            evidence = _build_evidence(execution, browser_context=request.browser_context)
             hypotheses, annotated_evidence = _evaluate_hypotheses(
                 hypotheses=raw_hypotheses,
                 evidence=evidence,
                 diagnosis_target=spec.diagnosis_target,
             )
-            conclusion = _build_conclusion(hypotheses, annotated_evidence)
+            conclusion = _build_conclusion(
+                hypotheses,
+                annotated_evidence,
+                has_browser_context=request.browser_context is not None,
+            )
             unknowns = _identify_unknowns(hypotheses, annotated_evidence)
             next_steps = _recommend_next_steps(hypotheses, unknowns)
             report_path = investigation_dir / "report.json"

--- a/autocontext/src/autocontext/mcp/agent_task_tools.py
+++ b/autocontext/src/autocontext/mcp/agent_task_tools.py
@@ -253,6 +253,7 @@ def queue_improvement_run(
     task_name: str,
     initial_output: str | None = None,
     priority: int = 0,
+    browser_url: str | None = None,
 ) -> dict[str, Any]:
     """Add a task to the runner queue for background processing."""
 
@@ -284,6 +285,7 @@ def queue_improvement_run(
         task_prompt=data.get("task_prompt"),
         rubric=data.get("rubric"),
         reference_context=data.get("reference_context"),
+        browser_url=browser_url,
         required_concepts=data.get("required_concepts"),
         generations=data.get("generations", 1),
         max_rounds=data.get("max_rounds", 5),

--- a/autocontext/src/autocontext/mcp/server.py
+++ b/autocontext/src/autocontext/mcp/server.py
@@ -367,10 +367,11 @@ def autocontext_queue_improvement_run(
     task_name: str,
     initial_output: str | None = None,
     priority: int = 0,
+    browser_url: str | None = None,
 ) -> str:
     """Queue an agent task for background improvement loop processing.
     The task runner daemon will pick it up automatically."""
-    return json.dumps(tools.queue_improvement_run(_get_ctx(), task_name, initial_output, priority))
+    return json.dumps(tools.queue_improvement_run(_get_ctx(), task_name, initial_output, priority, browser_url))
 
 
 @mcp.tool()

--- a/autocontext/tests/test_browser_context_capture.py
+++ b/autocontext/tests/test_browser_context_capture.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from autocontext.integrations.browser.context_capture import _capture_browser_context_async
+from autocontext.integrations.browser.policy import build_default_browser_session_config
+
+
+class _BlockedSession:
+    closed = False
+
+    async def navigate(self, _url: str):
+        return SimpleNamespace(allowed=False, policyReason="domain_not_allowed")
+
+    async def snapshot(self):
+        raise AssertionError("snapshot should not run after blocked navigation")
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _Runtime:
+    def __init__(self, session: _BlockedSession) -> None:
+        self.session = session
+
+    async def create_session(self, _config):
+        return self.session
+
+
+@pytest.mark.asyncio
+async def test_capture_browser_context_fails_closed_on_blocked_navigation() -> None:
+    session = _BlockedSession()
+
+    with pytest.raises(ValueError, match="domain_not_allowed"):
+        await _capture_browser_context_async(
+            _Runtime(session),
+            build_default_browser_session_config(allowed_domains=["example.com"]),
+            browser_url="https://blocked.example.net",
+        )
+
+    assert session.closed is True

--- a/autocontext/tests/test_cli_backport.py
+++ b/autocontext/tests/test_cli_backport.py
@@ -7,6 +7,7 @@ originated in the TS package.
 from __future__ import annotations
 
 import json
+import re
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -15,6 +16,11 @@ from typer.testing import CliRunner
 from autocontext.cli import app
 
 runner = CliRunner()
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", text)
 
 
 class _FakeProvider:
@@ -128,11 +134,12 @@ class TestImproveCommand:
 class TestQueueCommand:
     def test_queue_help(self) -> None:
         result = runner.invoke(app, ["queue", "--help"])
+        stdout = strip_ansi(result.stdout)
         assert result.exit_code == 0
-        assert "--spec" in result.stdout or "-s" in result.stdout
-        assert "--task-prompt" in result.stdout or "-p" in result.stdout
-        assert "--rounds" in result.stdout or "-n" in result.stdout
-        assert "--browser-url" in result.stdout
+        assert "--spec" in stdout or "-s" in stdout
+        assert "--task-prompt" in stdout or "-p" in stdout
+        assert "--rounds" in stdout or "-n" in stdout
+        assert "--browser-url" in stdout
 
     def test_queue_requires_spec_or_task_prompt(self) -> None:
         result = runner.invoke(app, ["queue"])

--- a/autocontext/tests/test_cli_backport.py
+++ b/autocontext/tests/test_cli_backport.py
@@ -132,6 +132,7 @@ class TestQueueCommand:
         assert "--spec" in result.stdout or "-s" in result.stdout
         assert "--task-prompt" in result.stdout or "-p" in result.stdout
         assert "--rounds" in result.stdout or "-n" in result.stdout
+        assert "--browser-url" in result.stdout
 
     def test_queue_requires_spec_or_task_prompt(self) -> None:
         result = runner.invoke(app, ["queue"])
@@ -196,5 +197,39 @@ class TestQueueCommand:
             rubric="correct",
             quality_threshold=0.8,
             max_rounds=2,
+            priority=0,
+        )
+
+    def test_queue_passes_browser_url_through_to_the_runner(self) -> None:
+        settings = MagicMock()
+        store = MagicMock()
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._sqlite_from_settings", return_value=store),
+            patch("autocontext.execution.task_runner.enqueue_task", return_value="task-789") as mock_enqueue,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "queue",
+                    "--spec",
+                    "browser-task",
+                    "--browser-url",
+                    "https://status.example.com",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout) == {
+            "task_id": "task-789",
+            "spec_name": "browser-task",
+            "status": "queued",
+        }
+        mock_enqueue.assert_called_once_with(
+            store=store,
+            spec_name="browser-task",
+            browser_url="https://status.example.com",
             priority=0,
         )

--- a/autocontext/tests/test_cli_investigate.py
+++ b/autocontext/tests/test_cli_investigate.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from autocontext.cli import app
+from autocontext.investigation.browser_context import InvestigationBrowserContext
 
 runner = CliRunner()
 
@@ -88,6 +89,19 @@ class _FailingInvestigationEngine:
         return InvestigationResult.from_dict(payload)
 
 
+class _CapturingInvestigationEngine:
+    captured_request = None
+
+    def __init__(self, **_: object) -> None:
+        pass
+
+    def run(self, request):  # noqa: ANN001
+        from autocontext.investigation.engine import InvestigationResult
+
+        _CapturingInvestigationEngine.captured_request = request
+        return InvestigationResult.from_dict(_completed_payload())
+
+
 class TestInvestigateCli:
     def test_help_exists(self) -> None:
         result = runner.invoke(app, ["investigate", "--help"])
@@ -97,6 +111,7 @@ class TestInvestigateCli:
         assert "investigate" in help_text.lower()
         assert "--description" in help_text
         assert "--hypotheses" in help_text
+        assert "--browser-url" in help_text
 
     def test_json_success(self, tmp_path: Path) -> None:
         settings = _make_settings(tmp_path)
@@ -128,3 +143,43 @@ class TestInvestigateCli:
         payload = json.loads(result.output.strip())
         assert payload["status"] == "failed"
         assert payload["error"] == "spec generation did not return valid JSON"
+
+    def test_browser_url_attaches_browser_context_to_the_investigation_request(self, tmp_path: Path) -> None:
+        settings = _make_settings(tmp_path).model_copy(
+            update={
+                "browser_enabled": True,
+                "browser_backend": "chrome-cdp",
+                "browser_allowed_domains": "example.com",
+                "browser_debugger_url": "http://127.0.0.1:9333",
+            }
+        )
+        browser_context = InvestigationBrowserContext(
+            url="https://example.com/status",
+            title="Status",
+            visible_text="Checkout is degraded",
+            html_path="/tmp/status.html",
+            screenshot_path="/tmp/status.png",
+        )
+        _CapturingInvestigationEngine.captured_request = None
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._resolve_investigation_runtime", return_value=(object(), "mock-model")),
+            patch("autocontext.cli_investigate.capture_investigation_browser_context", return_value=browser_context),
+            patch("autocontext.investigation.engine.InvestigationEngine", _CapturingInvestigationEngine),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "investigate",
+                    "-d",
+                    "why did checkout fail",
+                    "--browser-url",
+                    "https://example.com/status",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert _CapturingInvestigationEngine.captured_request is not None
+        assert _CapturingInvestigationEngine.captured_request.browser_context == browser_context

--- a/autocontext/tests/test_investigation_browser_context.py
+++ b/autocontext/tests/test_investigation_browser_context.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autocontext.config.settings import AppSettings
+from autocontext.integrations.browser.context_capture import CapturedBrowserContext
+from autocontext.investigation.browser_context import (
+    InvestigationBrowserContext,
+    capture_investigation_browser_context,
+    render_investigation_browser_context,
+)
+
+
+def _make_settings(tmp_path: Path) -> AppSettings:
+    return AppSettings(
+        browser_enabled=True,
+        browser_backend="chrome-cdp",
+        browser_allowed_domains="example.com",
+        browser_debugger_url="http://127.0.0.1:9333",
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+    )
+
+
+def test_capture_investigation_browser_context_collects_snapshot_and_closes_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = CapturedBrowserContext(
+        url="https://example.com/status",
+        title="Example Status",
+        visible_text=("Checkout is degraded due to upstream latency." * 40)[:1200],
+        html_path="/tmp/status.html",
+        screenshot_path="/tmp/status.png",
+    )
+    settings = _make_settings(tmp_path)
+    expected_evidence_root = (tmp_path / "knowledge" / "_investigations" / "checkout_rca").resolve()
+
+    def _fake_capture_browser_context(
+        loaded_settings: AppSettings,
+        *,
+        browser_url: str,
+        evidence_root: Path,
+    ) -> CapturedBrowserContext:
+        assert loaded_settings is settings
+        assert browser_url == "https://example.com/status"
+        assert evidence_root == expected_evidence_root
+        return context
+
+    monkeypatch.setattr(
+        "autocontext.investigation.browser_context.capture_browser_context",
+        _fake_capture_browser_context,
+    )
+
+    captured = capture_investigation_browser_context(
+        settings,
+        browser_url="https://example.com/status",
+        investigation_name="checkout_rca",
+    )
+
+    assert captured == InvestigationBrowserContext(
+        url="https://example.com/status",
+        title="Example Status",
+        visible_text=context.visible_text,
+        html_path="/tmp/status.html",
+        screenshot_path="/tmp/status.png",
+    )
+
+
+def test_capture_investigation_browser_context_requires_browser_to_be_enabled(
+    tmp_path: Path,
+) -> None:
+    settings = AppSettings(
+        browser_enabled=False,
+        knowledge_root=tmp_path / "knowledge",
+        runs_root=tmp_path / "runs",
+    )
+
+    with pytest.raises(ValueError, match="browser exploration is disabled"):
+        capture_investigation_browser_context(
+            settings,
+            browser_url="https://example.com/status",
+            investigation_name="checkout_rca",
+        )
+
+
+def test_render_investigation_browser_context_includes_artifact_paths() -> None:
+    rendered = render_investigation_browser_context(
+        InvestigationBrowserContext(
+            url="https://example.com/status",
+            title="Example Status",
+            visible_text="Checkout is degraded due to upstream latency.",
+            html_path="/tmp/status.html",
+            screenshot_path="/tmp/status.png",
+        )
+    )
+
+    assert "URL: https://example.com/status" in rendered
+    assert "Title: Example Status" in rendered
+    assert "Visible text: Checkout is degraded due to upstream latency." in rendered
+    assert "HTML artifact: /tmp/status.html" in rendered
+    assert "Screenshot artifact: /tmp/status.png" in rendered

--- a/autocontext/tests/test_investigation_engine.py
+++ b/autocontext/tests/test_investigation_engine.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from autocontext.investigation.browser_context import InvestigationBrowserContext
+
 
 def _spec_response() -> str:
     return json.dumps(
@@ -206,6 +208,46 @@ class TestInvestigationEngine:
 
         assert result.status == "failed"
         assert "valid JSON" in (result.error or "")
+
+    def test_includes_browser_context_in_prompts_and_evidence(self, tmp_path: Path) -> None:
+        from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
+
+        calls: list[tuple[str, str]] = []
+
+        def spec_llm(system: str, user: str) -> str:
+            calls.append((system, user))
+            return _spec_response()
+
+        def analysis_llm(system: str, user: str) -> str:
+            calls.append((system, user))
+            return _hypothesis_response()
+
+        engine = InvestigationEngine(
+            spec_llm_fn=spec_llm,
+            analysis_llm_fn=analysis_llm,
+            knowledge_root=tmp_path,
+        )
+
+        result = engine.run(
+            InvestigationRequest(
+                description="Investigate checkout errors",
+                browser_context=InvestigationBrowserContext(
+                    url="https://example.com/status",
+                    title="Status Page",
+                    visible_text="Checkout is degraded for some users.",
+                    html_path="/tmp/status.html",
+                    screenshot_path="/tmp/status.png",
+                ),
+            )
+        )
+
+        assert result.status == "completed"
+        assert len(calls) == 2
+        assert "Live browser context" in calls[0][1]
+        assert "https://example.com/status" in calls[0][1]
+        assert "Checkout is degraded for some users." in calls[1][1]
+        assert any(item.kind == "browser_snapshot" for item in result.evidence)
+        assert any(item.source == "https://example.com/status" for item in result.evidence)
 
     def test_hypothesis_prompt_uses_clustered_evidence_summary(self, tmp_path: Path) -> None:
         from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest

--- a/autocontext/tests/test_mcp_agent_tasks.py
+++ b/autocontext/tests/test_mcp_agent_tasks.py
@@ -427,6 +427,20 @@ class TestQueueTools:
         assert "task_id" in result
         assert result["generations"] == 1
 
+    def test_queue_task_accepts_browser_url_override(self, ctx):
+        create_agent_task(ctx, "queue-browser-task", "Do something", "Quality")
+        result = queue_improvement_run(
+            ctx,
+            "queue-browser-task",
+            priority=2,
+            browser_url="https://status.example.com",
+        )
+
+        task = ctx.sqlite.get_task(result["task_id"])
+        assert task is not None
+        config = json.loads(task["config_json"])
+        assert config["browser_url"] == "https://status.example.com"
+
     def test_queue_task_propagates_judge_guardrail_settings(self, ctx):
         ctx.settings = ctx.settings.model_copy(update={
             "judge_samples": 2,

--- a/autocontext/tests/test_task_runner.py
+++ b/autocontext/tests/test_task_runner.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+from autocontext.config.settings import AppSettings
 from autocontext.execution.improvement_loop import ImprovementResult, RoundResult
 from autocontext.execution.task_runner import (
     SimpleAgentTask,
@@ -14,10 +16,11 @@ from autocontext.execution.task_runner import (
     TaskRunner,
     _serialize_evolution_result,
     _serialize_result,
+    create_task_runner_from_settings,
     enqueue_task,
 )
 from autocontext.providers.base import CompletionResult, LLMProvider
-from autocontext.scenarios.agent_task import AgentTaskInterface
+from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
 from autocontext.storage.sqlite_store import SQLiteStore
 
 # ---------------------------------------------------------------------------
@@ -72,12 +75,14 @@ class TestTaskConfig:
             "max_rounds": 3,
             "quality_threshold": 0.8,
             "reference_context": "ref",
+            "browser_url": "https://example.com",
         })
         cfg = TaskConfig.from_json(data)
         assert cfg.generations == 3
         assert cfg.max_rounds == 3
         assert cfg.quality_threshold == 0.8
         assert cfg.reference_context == "ref"
+        assert cfg.browser_url == "https://example.com"
 
     def test_from_empty_string(self):
         cfg = TaskConfig.from_json("")
@@ -182,6 +187,23 @@ class TestSimpleAgentTask:
         output = task.generate_output({})
         assert output == "Generated content"
 
+    def test_generate_output_includes_reference_context_and_required_concepts(self):
+        provider = _MockProvider(["Generated content"])
+        task = SimpleAgentTask(task_prompt="Write something", rubric="Quality", provider=provider)
+
+        output = task.generate_output({
+            "reference_context": "Trusted facts only",
+            "required_concepts": ["safety", "latency"],
+        })
+
+        assert output == "Generated content"
+        prompt = provider.calls[0]["user"]
+        assert "Reference Context" in prompt
+        assert "Trusted facts only" in prompt
+        assert "Required Concepts" in prompt
+        assert "- safety" in prompt
+        assert "- latency" in prompt
+
     def test_evaluate_output(self):
         provider = _MockProvider([_judge_response(0.85, "nice work")])
         task = SimpleAgentTask(task_prompt="Write something", rubric="Quality", provider=provider)
@@ -217,6 +239,27 @@ class TestSimpleAgentTask:
         result = task.evaluate_output("bad output", {})
         revised = task.revise_output("bad output", result, {})
         assert revised == "Revised content"
+
+    def test_revise_output_includes_reference_context_and_required_concepts(self):
+        provider = _MockProvider(["Revised content"])
+        task = SimpleAgentTask(task_prompt="Write something", rubric="Quality", provider=provider)
+
+        revised = task.revise_output(
+            "bad output",
+            AgentTaskResult(score=0.5, reasoning="needs work"),
+            {
+                "reference_context": "Trusted facts only",
+                "required_concepts": ["safety", "latency"],
+            },
+        )
+
+        assert revised == "Revised content"
+        prompt = provider.calls[0]["user"]
+        assert "Reference Context" in prompt
+        assert "Trusted facts only" in prompt
+        assert "Required Concepts" in prompt
+        assert "- safety" in prompt
+        assert "- latency" in prompt
 
 
 # ---------------------------------------------------------------------------
@@ -362,6 +405,67 @@ class TestTaskRunner:
         assert r2["id"] == "mid"
         assert r3["id"] == "low"
 
+    def test_run_once_merges_browser_context_into_reference_context(self, store):
+        provider = _MockProvider([
+            "Initial output",
+            _judge_response(0.95, "excellent"),
+        ])
+        store.enqueue_task(
+            "t-browser",
+            "browser-spec",
+            config={
+                "task_prompt": "Write a summary",
+                "rubric": "Quality",
+                "reference_context": "Saved context",
+                "browser_url": "https://status.example.com",
+            },
+        )
+
+        class _FakeBrowserContextService:
+            def __init__(self) -> None:
+                self.calls: list[dict[str, str | None]] = []
+
+            def build_reference_context(
+                self,
+                *,
+                task_id: str,
+                browser_url: str,
+                reference_context: str | None,
+            ) -> str:
+                self.calls.append({
+                    "task_id": task_id,
+                    "browser_url": browser_url,
+                    "reference_context": reference_context,
+                })
+                return (
+                    "Saved context\n\n"
+                    "Live browser context:\n"
+                    "URL: https://status.example.com\n"
+                    "Title: Status page\n"
+                    "Visible text: All systems operational"
+                )
+
+        browser_context_service = _FakeBrowserContextService()
+        runner = TaskRunner(
+            store=store,
+            provider=provider,
+            browser_context_service=browser_context_service,
+        )
+
+        result = runner.run_once()
+
+        assert result is not None
+        assert result["status"] == "completed"
+        assert browser_context_service.calls == [{
+            "task_id": "t-browser",
+            "browser_url": "https://status.example.com",
+            "reference_context": "Saved context",
+        }]
+        prompt = provider.calls[0]["user"]
+        assert "Saved context" in prompt
+        assert "Live browser context:" in prompt
+        assert "All systems operational" in prompt
+
 
 # ---------------------------------------------------------------------------
 # Enqueue convenience function
@@ -381,6 +485,7 @@ class TestEnqueueFunction:
             task_prompt="Write a post",
             rubric="Accuracy and voice",
             reference_context="RLM = Recursive Language Model",
+            browser_url="https://example.com",
             required_concepts=["context folding", "Python REPL"],
             generations=4,
             max_rounds=3,
@@ -411,6 +516,7 @@ class TestEnqueueFunction:
         assert config["judge_temperature"] == 0.2
         assert config["judge_disagreement_threshold"] == 0.07
         assert config["judge_bias_probes_enabled"] is True
+        assert config["browser_url"] == "https://example.com"
         assert "context folding" in config["required_concepts"]
         assert config["objective_verification"]["ground_truth"][0]["item_id"] == "warfarin-aspirin"
 
@@ -937,3 +1043,88 @@ class TestTaskRunnerTiming:
         assert isinstance(result_data["duration_ms"], (int, float))
         assert result_data["duration_ms"] >= 0
         assert result_data["duration_ms"] < 60000  # sanity: mock task shouldn't take a minute
+
+
+class TestTaskRunnerFactory:
+    def test_create_task_runner_from_settings_wires_browser_context_service(self, store):
+        provider = _MockProvider([_judge_response(0.9, "good enough")])
+        enqueue_task(
+            store,
+            "browser-factory-spec",
+            task_prompt="Summarize current status",
+            rubric="Be accurate",
+            initial_output="Draft",
+            reference_context="Saved context",
+            browser_url="https://status.example.com",
+        )
+
+        class _FactoryBrowserContextService:
+            def __init__(self) -> None:
+                self.calls: list[dict[str, str | None]] = []
+
+            def build_reference_context(
+                self,
+                *,
+                task_id: str,
+                browser_url: str,
+                reference_context: str | None,
+            ) -> str:
+                self.calls.append({
+                    "task_id": task_id,
+                    "browser_url": browser_url,
+                    "reference_context": reference_context,
+                })
+                return "Saved context\n\nLive browser context:\nVisible text: All systems operational"
+
+        browser_context_service = _FactoryBrowserContextService()
+        settings = AppSettings(browser_enabled=True, runs_root=Path(store.db_path).parent / "runs")
+
+        with patch(
+            "autocontext.execution.task_runner.create_queued_task_browser_context_service",
+            return_value=browser_context_service,
+        ) as mock_create:
+            runner = create_task_runner_from_settings(
+                settings,
+                store=store,
+                provider=provider,
+            )
+
+        result = runner.run_once()
+
+        assert result is not None
+        assert result["status"] == "completed"
+        assert browser_context_service.calls == [{
+            "task_id": result["id"],
+            "browser_url": "https://status.example.com",
+            "reference_context": "Saved context",
+        }]
+        mock_create.assert_called_once_with(settings)
+
+    def test_create_task_runner_from_settings_preserves_fail_closed_behavior_when_disabled(self, store):
+        provider = _MockProvider([_judge_response(0.9, "good enough")])
+        enqueue_task(
+            store,
+            "browser-disabled-spec",
+            task_prompt="Summarize current status",
+            rubric="Be accurate",
+            initial_output="Draft",
+            browser_url="https://status.example.com",
+        )
+
+        settings = AppSettings(browser_enabled=False, runs_root=Path(store.db_path).parent / "runs")
+
+        with patch(
+            "autocontext.execution.task_runner.create_queued_task_browser_context_service",
+        ) as mock_create:
+            runner = create_task_runner_from_settings(
+                settings,
+                store=store,
+                provider=provider,
+            )
+
+        result = runner.run_once()
+
+        assert result is not None
+        assert result["status"] == "failed"
+        assert "browser exploration is not configured" in (result["error"] or "")
+        mock_create.assert_not_called()


### PR DESCRIPTION
## Summary
- Add Python one-shot browser context capture that fails closed on denied navigation and persists artifacts under investigation/task evidence roots.
- Wire autoctx investigate --browser-url into prompt/evidence generation and expose browser-enriched queued tasks through CLI, MCP, and task runner paths.
- Keep recurrence and queue-worker controls out of this PR; this slice is browser context plumbing only.

## Tests
- cd autocontext && uv run pytest tests/test_browser_context_capture.py tests/test_investigation_browser_context.py tests/test_investigation_engine.py tests/test_cli_investigate.py tests/test_cli_backport.py tests/test_task_runner.py tests/test_mcp_agent_tasks.py -q
- cd autocontext && uv run ruff check touched Python browser integration modules and tests
- cd autocontext && uv run mypy touched Python browser integration modules

Linear: AC-601