### PR TITLE
AC-602: Wire TypeScript browser context into investigations and queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes in this section are on the branch/repo after `0.4.4` and are not part of
 - Added Python browser exploration integration for investigations and queued tasks, including policy-gated snapshot capture, prompt/evidence enrichment, and fail-closed task-runner wiring.
 - Added a thin Python Chrome CDP browser backend with debugger-target discovery, evidence persistence, WebSocket transport, runtime factory, and policy-checked session actions.
 - Added cross-runtime browser contract fixtures so Python and TypeScript validators stay in lockstep.
+- Added TypeScript browser-context integration for investigations, queued tasks, and MCP queueing, including fail-closed navigation policy handling and artifact-backed browser evidence.
 
 ## [0.4.4] - 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Important:
 
 The Python package exposes the full `autoctx` control-plane CLI for scenario execution, API serving, exports, training, and operator workflows. The TypeScript package exposes the `autoctx` CLI and library surface for simulations, investigations, analysis, mission control, MCP serving, and Node integrations.
 
-Both packages share an optional, disabled-by-default browser exploration contract for thin browser control without bundling a heavyweight browser framework. See [docs/browser-exploration-contract.md](docs/browser-exploration-contract.md).
+Both packages share an optional, disabled-by-default browser exploration contract for thin browser control without bundling a heavyweight browser framework. The TypeScript CLI can attach a policy-gated browser snapshot to investigations and queued tasks with `--browser-url`. See [docs/browser-exploration-contract.md](docs/browser-exploration-contract.md).
 
 ## Which Package Should You Use?
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -157,6 +157,7 @@ autoctx mcp-serve                     # MCP server on stdio
 autoctx simulate -d "simulate deploying a web service with rollback"
 autoctx simulate -d "simulate escalation thresholds" --sweep max_escalations=1:5:1
 autoctx investigate -d "why did conversion drop after Tuesday's release"
+autoctx investigate -d "checkout is failing" --browser-url https://status.example.com
 autoctx analyze --id deploy_sim --type simulation
 autoctx analyze --left sim_a --right sim_b --type simulation
 autoctx mission create --name "Ship login" --goal "Implement OAuth"
@@ -175,7 +176,7 @@ autoctx improve --scenario my_saved_task [-o <output>]
 autoctx repl --scenario my_saved_task
 
 # Task queue
-autoctx queue -s <spec> [--priority N]
+autoctx queue -s <spec> [--priority N] [--browser-url https://status.example.com]
 autoctx status
 ```
 
@@ -362,6 +363,8 @@ For end-to-end local MLX/CUDA training, the Python package is still the canonica
 The TypeScript package exposes the shared browser exploration contract and policy helpers from the package root. Browser exploration is disabled by default and configured through `AUTOCONTEXT_BROWSER_*` settings such as `AUTOCONTEXT_BROWSER_ENABLED`, `AUTOCONTEXT_BROWSER_ALLOWED_DOMAINS`, and `AUTOCONTEXT_BROWSER_PROFILE_MODE`.
 
 Use `resolveBrowserSessionConfig(...)`, `evaluateBrowserActionPolicy(...)`, and the `validateBrowser*` helpers when integrating a browser backend or agent harness.
+
+When browser exploration is enabled, the TS CLI can capture a policy-gated Chrome DevTools Protocol snapshot and attach it as evidence for `autoctx investigate --browser-url <url>`. Queued agent tasks can also store `--browser-url`; the runner resolves it through an injected browser-context service so enterprise deployments can keep browser access disabled by default, domain-scoped, and audit-artifact backed.
 
 ## Python-Only Commands
 

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -893,6 +893,7 @@ async function cmdQueue(dbPath: string): Promise<void> {
       spec: { type: "string", short: "s" },
       prompt: { type: "string", short: "p" },
       rubric: { type: "string", short: "r" },
+      "browser-url": { type: "string" },
       priority: { type: "string", default: "0" },
       "min-rounds": { type: "string" },
       rlm: { type: "boolean" },
@@ -2582,6 +2583,7 @@ async function cmdInvestigate(): Promise<void> {
       "max-steps": { type: "string" },
       hypotheses: { type: "string" },
       "save-as": { type: "string" },
+      "browser-url": { type: "string" },
       json: { type: "boolean" },
       help: { type: "boolean", short: "h" },
     },
@@ -2590,6 +2592,7 @@ async function cmdInvestigate(): Promise<void> {
   const {
     INVESTIGATE_HELP_TEXT,
     executeInvestigateCommandWorkflow,
+    prepareInvestigateRequest,
     renderInvestigationSuccess,
   } = await import("./investigate-command-workflow.js");
 
@@ -2610,9 +2613,11 @@ async function cmdInvestigate(): Promise<void> {
     resolve(settings.knowledgeRoot),
   );
 
+  let request;
   let result;
   try {
-    result = await executeInvestigateCommandWorkflow({ values, engine });
+    request = await prepareInvestigateRequest({ values, settings });
+    result = await executeInvestigateCommandWorkflow({ values, request, engine });
   } catch (error) {
     console.error(errorMessage(error));
     process.exit(1);

--- a/ts/src/cli/investigate-command-workflow.ts
+++ b/ts/src/cli/investigate-command-workflow.ts
@@ -2,6 +2,11 @@ import type {
   InvestigationRequest,
   InvestigationResult,
 } from "../investigation/engine.js";
+import {
+  captureInvestigationBrowserContext,
+  type InvestigationBrowserContextSettingsLike,
+} from "../investigation/browser-context.js";
+import { deriveInvestigationName } from "../investigation/investigation-engine-helpers.js";
 
 export const INVESTIGATE_HELP_TEXT = `autoctx investigate — run a plain-language investigation
 
@@ -12,25 +17,36 @@ Options:
   --max-steps <N>            Maximum investigation steps (default: 8)
   --hypotheses <N>           Maximum hypotheses to generate (default: 5)
   --save-as <name>           Name for the saved investigation
+  --browser-url <url>        Capture a browser snapshot from the given URL and use it as evidence
   --json                     Output as JSON
   -h, --help                 Show this help
 
 Examples:
   autoctx investigate -d "why did conversion drop after Tuesday's release"
   autoctx investigate -d "intermittent CI failures" --max-steps 12 --json
-  autoctx investigate -d "model benchmark improved but real performance fell" --save-as benchmark_rca`;
+  autoctx investigate -d "model benchmark improved but real performance fell" --save-as benchmark_rca
+  autoctx investigate -d "checkout is failing in prod" --browser-url https://status.example.com`;
 
 export interface InvestigateCommandValues {
   description?: string;
   "max-steps"?: string;
   hypotheses?: string;
   "save-as"?: string;
+  "browser-url"?: string;
   json?: boolean;
 }
 
 export interface InvestigateCommandEngine {
   run(request: InvestigationRequest): Promise<InvestigationResult>;
 }
+
+export interface PrepareInvestigateRequestDependencies {
+  captureBrowserContext: typeof captureInvestigationBrowserContext;
+}
+
+const DEFAULT_PREPARE_DEPENDENCIES: PrepareInvestigateRequestDependencies = {
+  captureBrowserContext: captureInvestigationBrowserContext,
+};
 
 export function planInvestigateCommand(
   values: InvestigateCommandValues,
@@ -53,11 +69,39 @@ export function planInvestigateCommand(
   };
 }
 
+export async function prepareInvestigateRequest(
+  opts: {
+    values: InvestigateCommandValues;
+    settings: InvestigationBrowserContextSettingsLike;
+  },
+  dependencies: Partial<PrepareInvestigateRequestDependencies> = {},
+): Promise<InvestigationRequest> {
+  const resolved = {
+    ...DEFAULT_PREPARE_DEPENDENCIES,
+    ...dependencies,
+  };
+  const request = planInvestigateCommand(opts.values);
+  const browserUrl = opts.values["browser-url"];
+  if (!browserUrl) {
+    return request;
+  }
+
+  return {
+    ...request,
+    browserContext: await resolved.captureBrowserContext({
+      settings: opts.settings,
+      browserUrl,
+      investigationName: request.saveAs ?? deriveInvestigationName(request.description),
+    }),
+  };
+}
+
 export async function executeInvestigateCommandWorkflow(opts: {
   values: InvestigateCommandValues;
   engine: InvestigateCommandEngine;
+  request?: InvestigationRequest;
 }): Promise<InvestigationResult> {
-  const request = planInvestigateCommand(opts.values);
+  const request = opts.request ?? planInvestigateCommand(opts.values);
   return opts.engine.run(request);
 }
 

--- a/ts/src/cli/queue-status-command-workflow.ts
+++ b/ts/src/cli/queue-status-command-workflow.ts
@@ -1,11 +1,12 @@
 export const QUEUE_HELP_TEXT =
   "autoctx queue -s <spec-name> [-p prompt] [-r rubric] [--priority N] " +
-  "[--min-rounds N] [--rlm] [--rlm-turns N]";
+  "[--min-rounds N] [--browser-url URL] [--rlm] [--rlm-turns N]";
 
 export interface QueueCommandValues {
   spec?: string;
   prompt?: string;
   rubric?: string;
+  "browser-url"?: string;
   priority?: string;
   "min-rounds"?: string;
   rlm?: boolean;
@@ -32,6 +33,7 @@ export interface PlannedQueueCommand {
   request: {
     taskPrompt?: string;
     rubric?: string;
+    browserUrl?: string;
     referenceContext?: string;
     requiredConcepts?: string[];
     maxRounds?: number;
@@ -66,6 +68,7 @@ export function planQueueCommand(
     request: {
       taskPrompt: values.prompt ?? savedScenario?.taskPrompt,
       rubric: values.rubric ?? savedScenario?.rubric,
+      browserUrl: values["browser-url"],
       referenceContext: savedScenario?.referenceContext,
       requiredConcepts: savedScenario?.requiredConcepts,
       maxRounds: savedScenario?.maxRounds,

--- a/ts/src/execution/queued-task-browser-context.ts
+++ b/ts/src/execution/queued-task-browser-context.ts
@@ -1,0 +1,70 @@
+import { join, resolve } from "node:path";
+
+import {
+  captureBrowserContextFromUrl,
+  renderCapturedBrowserContext,
+  type BrowserContextCaptureSettingsLike,
+} from "../integrations/browser/context-capture.js";
+
+export interface QueuedTaskBrowserContextRequest {
+  readonly taskId: string;
+  readonly browserUrl: string;
+  readonly referenceContext?: string;
+}
+
+export interface QueuedTaskBrowserContextService {
+  buildReferenceContext(request: QueuedTaskBrowserContextRequest): Promise<string>;
+}
+
+export interface QueuedTaskBrowserContextSettingsLike extends BrowserContextCaptureSettingsLike {
+  readonly runsRoot: string;
+}
+
+export interface QueuedTaskBrowserContextDependencies {
+  readonly captureBrowserContextFromUrl: typeof captureBrowserContextFromUrl;
+}
+
+const DEFAULT_DEPENDENCIES: QueuedTaskBrowserContextDependencies = {
+  captureBrowserContextFromUrl,
+};
+
+export class SettingsBackedQueuedTaskBrowserContextService implements QueuedTaskBrowserContextService {
+  readonly #settings: QueuedTaskBrowserContextSettingsLike;
+  readonly #dependencies: QueuedTaskBrowserContextDependencies;
+
+  constructor(
+    settings: QueuedTaskBrowserContextSettingsLike,
+    dependencies: QueuedTaskBrowserContextDependencies = DEFAULT_DEPENDENCIES,
+  ) {
+    this.#settings = settings;
+    this.#dependencies = dependencies;
+  }
+
+  async buildReferenceContext(request: QueuedTaskBrowserContextRequest): Promise<string> {
+    const context = await this.#dependencies.captureBrowserContextFromUrl({
+      settings: this.#settings,
+      browserUrl: request.browserUrl,
+      evidenceRoot: join(resolve(this.#settings.runsRoot), "task_queue", request.taskId),
+    });
+    return mergeQueuedTaskReferenceContext(
+      request.referenceContext,
+      renderCapturedBrowserContext(context),
+    );
+  }
+}
+
+export function createQueuedTaskBrowserContextService(
+  settings: QueuedTaskBrowserContextSettingsLike,
+  dependencies: QueuedTaskBrowserContextDependencies = DEFAULT_DEPENDENCIES,
+): QueuedTaskBrowserContextService {
+  return new SettingsBackedQueuedTaskBrowserContextService(settings, dependencies);
+}
+
+export function mergeQueuedTaskReferenceContext(
+  referenceContext: string | undefined,
+  browserContext: string,
+): string {
+  const trimmedReferenceContext = referenceContext?.trim();
+  const trimmedBrowserContext = browserContext.trim();
+  return [trimmedReferenceContext, trimmedBrowserContext].filter(Boolean).join("\n\n");
+}

--- a/ts/src/execution/simple-agent-task-workflow.ts
+++ b/ts/src/execution/simple-agent-task-workflow.ts
@@ -103,10 +103,27 @@ export async function generateSimpleAgentTaskOutput(opts: {
 
   const result = await opts.provider.complete({
     systemPrompt: "You are a skilled writer and analyst. Complete the task precisely.",
-    userPrompt: opts.taskPrompt,
+    userPrompt: buildSimpleAgentTaskUserPrompt({
+      taskPrompt: opts.taskPrompt,
+      referenceContext: opts.referenceContext,
+      requiredConcepts: opts.requiredConcepts,
+    }),
     model: opts.model,
   });
   return result.text;
+}
+
+export function buildSimpleAgentTaskUserPrompt(opts: {
+  taskPrompt: string;
+  referenceContext?: string;
+  requiredConcepts?: string[];
+}): string {
+  const blocks = [
+    opts.taskPrompt.trim(),
+    buildReferenceContextBlock(opts.referenceContext),
+    buildRequiredConceptsBlock(opts.requiredConcepts),
+  ].filter((value) => value.length > 0);
+  return blocks.join("\n\n");
 }
 
 export function buildSimpleAgentTaskRevisionPrompt(opts: {
@@ -114,18 +131,22 @@ export function buildSimpleAgentTaskRevisionPrompt(opts: {
   output: string;
   judgeResult: AgentTaskResult;
   taskPrompt: string;
+  referenceContext?: string;
+  requiredConcepts?: string[];
 }): string {
   const instruction = opts.revisionPrompt
     ?? "Revise the following output based on the judge's feedback. Maintain what works, fix what doesn't.";
 
-  return (
-    `${instruction}\n\n` +
-    `## Original Output\n${opts.output}\n\n` +
-    `## Judge Score: ${opts.judgeResult.score.toFixed(2)}\n` +
-    `## Judge Feedback\n${opts.judgeResult.reasoning}\n\n` +
-    `## Task\n${opts.taskPrompt}\n\n` +
-    "Produce an improved version:"
-  );
+  return [
+    instruction,
+    `## Original Output\n${opts.output}`,
+    `## Judge Score: ${opts.judgeResult.score.toFixed(2)}`,
+    `## Judge Feedback\n${opts.judgeResult.reasoning}`,
+    buildReferenceContextBlock(opts.referenceContext),
+    buildRequiredConceptsBlock(opts.requiredConcepts),
+    `## Task\n${opts.taskPrompt}`,
+    "Produce an improved version:",
+  ].filter((value) => value.length > 0).join("\n\n");
 }
 
 export async function reviseSimpleAgentTaskOutput(opts: {
@@ -170,8 +191,24 @@ export async function reviseSimpleAgentTaskOutput(opts: {
       output: opts.output,
       judgeResult: opts.judgeResult,
       taskPrompt: opts.taskPrompt,
+      referenceContext: opts.referenceContext,
+      requiredConcepts: opts.requiredConcepts,
     }),
     model: opts.model,
   });
   return result.text;
+}
+
+function buildReferenceContextBlock(referenceContext?: string): string {
+  const trimmedReferenceContext = referenceContext?.trim();
+  return trimmedReferenceContext ? `## Reference Context\n${trimmedReferenceContext}` : "";
+}
+
+function buildRequiredConceptsBlock(requiredConcepts?: string[]): string {
+  const normalizedConcepts = requiredConcepts
+    ?.map((concept) => concept.trim())
+    .filter((concept) => concept.length > 0);
+  return normalizedConcepts && normalizedConcepts.length > 0
+    ? `## Required Concepts\n${normalizedConcepts.map((concept) => `- ${concept}`).join("\n")}`
+    : "";
 }

--- a/ts/src/execution/task-processing-workflow.ts
+++ b/ts/src/execution/task-processing-workflow.ts
@@ -6,6 +6,7 @@ import type { SQLiteStore, TaskQueueRow } from "../storage/index.js";
 import type { TaskConfig } from "./task-runner-config.js";
 import { parseTaskConfig, serializeTaskResult } from "./task-runner-config.js";
 import type { RlmSessionRecord, RlmTaskConfig } from "../rlm/types.js";
+import type { QueuedTaskBrowserContextService } from "./queued-task-browser-context.js";
 
 interface SavedTaskSpec {
   judgeRubric?: string;
@@ -25,6 +26,7 @@ export interface QueuedTaskExecutionPlan {
   taskPrompt: string;
   rubric: string;
   referenceContext?: string;
+  browserUrl?: string;
   requiredConcepts?: string[];
   calibrationExamples?: Array<Record<string, unknown>>;
   maxRounds: number;
@@ -112,6 +114,7 @@ export function buildQueuedTaskExecutionPlan(opts: {
     taskPrompt,
     rubric,
     referenceContext: config.referenceContext ?? savedTask?.spec.referenceContext ?? undefined,
+    browserUrl: config.browserUrl,
     requiredConcepts: config.requiredConcepts ?? savedTask?.spec.requiredConcepts ?? undefined,
     calibrationExamples: config.calibrationExamples ?? savedTask?.spec.calibrationExamples ?? undefined,
     maxRounds: config.maxRounds ?? savedTask?.spec.maxRounds ?? 5,
@@ -132,6 +135,7 @@ export async function executeQueuedTaskWorkflow(opts: {
   provider: LLMProvider;
   model: string;
   knowledgeRoot?: string;
+  browserContextService?: QueuedTaskBrowserContextService;
   internals?: Partial<TaskProcessingInternals>;
 }): Promise<void> {
   const internals: TaskProcessingInternals = {
@@ -145,6 +149,14 @@ export async function executeQueuedTaskWorkflow(opts: {
       knowledgeRoot: opts.knowledgeRoot,
       internals,
     });
+    const resolvedReferenceContext = plan.browserUrl
+      ? await resolveQueuedTaskBrowserReferenceContext({
+          taskId: opts.task.id,
+          browserUrl: plan.browserUrl,
+          referenceContext: plan.referenceContext,
+          browserContextService: opts.browserContextService,
+        })
+      : plan.referenceContext;
 
     const agentTask = internals.createAgentTask({
       taskPrompt: plan.taskPrompt,
@@ -159,7 +171,7 @@ export async function executeQueuedTaskWorkflow(opts: {
     let initialOutput = plan.initialOutput;
     if (!initialOutput) {
       initialOutput = await agentTask.generateOutput({
-        referenceContext: plan.referenceContext,
+        referenceContext: resolvedReferenceContext,
         requiredConcepts: plan.requiredConcepts,
       });
     }
@@ -172,7 +184,7 @@ export async function executeQueuedTaskWorkflow(opts: {
     }).run({
       initialOutput,
       state: agentTask.initialState(),
-      referenceContext: plan.referenceContext,
+      referenceContext: resolvedReferenceContext,
       requiredConcepts: plan.requiredConcepts,
       calibrationExamples: plan.calibrationExamples,
     });
@@ -189,4 +201,20 @@ export async function executeQueuedTaskWorkflow(opts: {
     const message = err instanceof Error ? err.message : String(err);
     opts.store.failTask(opts.task.id, message);
   }
+}
+
+async function resolveQueuedTaskBrowserReferenceContext(opts: {
+  taskId: string;
+  browserUrl: string;
+  referenceContext?: string;
+  browserContextService?: QueuedTaskBrowserContextService;
+}): Promise<string> {
+  if (!opts.browserContextService) {
+    throw new Error("browser exploration is not configured");
+  }
+  return opts.browserContextService.buildReferenceContext({
+    taskId: opts.taskId,
+    browserUrl: opts.browserUrl,
+    referenceContext: opts.referenceContext,
+  });
 }

--- a/ts/src/execution/task-runner-config.ts
+++ b/ts/src/execution/task-runner-config.ts
@@ -15,6 +15,7 @@ export interface TaskConfig {
   qualityThreshold?: number;
   minRounds?: number;
   referenceContext?: string;
+  browserUrl?: string;
   requiredConcepts?: string[];
   calibrationExamples?: Array<Record<string, unknown>>;
   initialOutput?: string;
@@ -29,6 +30,7 @@ export interface EnqueueTaskRequest {
   taskPrompt?: string;
   rubric?: string;
   referenceContext?: string;
+  browserUrl?: string;
   requiredConcepts?: string[];
   maxRounds?: number;
   qualityThreshold?: number;
@@ -58,6 +60,7 @@ const TaskConfigSchema = z.object({
   quality_threshold: z.number().min(0).max(1).optional(),
   min_rounds: z.number().int().positive().optional(),
   reference_context: z.string().optional(),
+  browser_url: z.string().url().optional(),
   required_concepts: z.array(z.string()).optional(),
   calibration_examples: z.array(z.record(z.unknown())).optional(),
   initial_output: z.string().optional(),
@@ -89,6 +92,7 @@ export function parseTaskConfig(json: string | null): TaskConfig {
     qualityThreshold: parsed.quality_threshold,
     minRounds: parsed.min_rounds,
     referenceContext: parsed.reference_context,
+    browserUrl: parsed.browser_url,
     requiredConcepts: parsed.required_concepts,
     calibrationExamples: parsed.calibration_examples,
     initialOutput: parsed.initial_output,
@@ -143,6 +147,7 @@ export function buildEnqueueTaskConfig(opts?: EnqueueTaskRequest): Record<string
   if (opts?.taskPrompt) config.task_prompt = opts.taskPrompt;
   if (opts?.rubric) config.rubric = opts.rubric;
   if (opts?.referenceContext) config.reference_context = opts.referenceContext;
+  if (opts?.browserUrl) config.browser_url = opts.browserUrl;
   if (opts?.requiredConcepts) config.required_concepts = opts.requiredConcepts;
   if (opts?.initialOutput) config.initial_output = opts.initialOutput;
   if (opts?.delegatedResults?.length) {

--- a/ts/src/execution/task-runner.ts
+++ b/ts/src/execution/task-runner.ts
@@ -22,6 +22,7 @@ import {
 } from "./task-runner-config.js";
 import type { TaskConfig } from "./task-runner-config.js";
 import { executeQueuedTaskWorkflow } from "./task-processing-workflow.js";
+import type { QueuedTaskBrowserContextService } from "./queued-task-browser-context.js";
 import {
   evaluateSimpleAgentTaskOutput,
   generateSimpleAgentTaskOutput,
@@ -156,6 +157,7 @@ export interface TaskRunnerOpts {
   provider: LLMProvider;
   model?: string;
   knowledgeRoot?: string;
+  browserContextService?: QueuedTaskBrowserContextService;
   pollInterval?: number;
   maxConsecutiveEmpty?: number;
   concurrency?: number;
@@ -166,6 +168,7 @@ export class TaskRunner {
   #provider: LLMProvider;
   #model: string;
   #knowledgeRoot?: string;
+  #browserContextService?: QueuedTaskBrowserContextService;
   #pollInterval: number;
   #maxConsecutiveEmpty: number;
   #concurrency: number;
@@ -177,6 +180,7 @@ export class TaskRunner {
     this.#provider = opts.provider;
     this.#model = buildTaskRunnerModel(opts.provider.defaultModel(), opts.model);
     this.#knowledgeRoot = opts.knowledgeRoot;
+    this.#browserContextService = opts.browserContextService;
     this.#pollInterval = opts.pollInterval ?? 60;
     this.#maxConsecutiveEmpty = opts.maxConsecutiveEmpty ?? 0;
     this.#concurrency = Math.max(1, opts.concurrency ?? 1);
@@ -215,6 +219,7 @@ export class TaskRunner {
       provider: this.#provider,
       model: this.#model,
       knowledgeRoot: this.#knowledgeRoot,
+      browserContextService: this.#browserContextService,
       internals: {
         createAgentTask: ({
           taskPrompt,

--- a/ts/src/execution/task-runner.ts
+++ b/ts/src/execution/task-runner.ts
@@ -8,6 +8,7 @@ import type {
   AgentTaskInterface,
   AgentTaskResult,
 } from "../types/index.js";
+import type { AppSettings } from "../config/index.js";
 import { type DelegatedResult, type JudgeInterface } from "../judge/delegated.js";
 import type { SQLiteStore, TaskQueueRow } from "../storage/index.js";
 import { assertFamilyContract } from "../scenarios/family-interfaces.js";
@@ -22,7 +23,10 @@ import {
 } from "./task-runner-config.js";
 import type { TaskConfig } from "./task-runner-config.js";
 import { executeQueuedTaskWorkflow } from "./task-processing-workflow.js";
-import type { QueuedTaskBrowserContextService } from "./queued-task-browser-context.js";
+import {
+  createQueuedTaskBrowserContextService,
+  type QueuedTaskBrowserContextService,
+} from "./queued-task-browser-context.js";
 import {
   evaluateSimpleAgentTaskOutput,
   generateSimpleAgentTaskOutput,
@@ -163,6 +167,14 @@ export interface TaskRunnerOpts {
   concurrency?: number;
 }
 
+export interface TaskRunnerFromSettingsOpts
+  extends Omit<TaskRunnerOpts, "knowledgeRoot" | "browserContextService"> {
+  settings: AppSettings;
+  knowledgeRoot?: string;
+  browserContextService?: QueuedTaskBrowserContextService;
+  createBrowserContextService?: typeof createQueuedTaskBrowserContextService;
+}
+
 export class TaskRunner {
   #store: SQLiteStore;
   #provider: LLMProvider;
@@ -249,4 +261,24 @@ export function enqueueTask(
   opts?: EnqueueTaskRequest,
 ): string {
   return enqueueConfiguredTask(store, specName, opts);
+}
+
+export function createTaskRunnerFromSettings(opts: TaskRunnerFromSettingsOpts): TaskRunner {
+  const createBrowserContextService =
+    opts.createBrowserContextService ?? createQueuedTaskBrowserContextService;
+  const browserContextService = opts.browserContextService
+    ?? (opts.settings.browserEnabled
+      ? createBrowserContextService(opts.settings)
+      : undefined);
+
+  return new TaskRunner({
+    store: opts.store,
+    provider: opts.provider,
+    model: opts.model,
+    knowledgeRoot: opts.knowledgeRoot ?? opts.settings.knowledgeRoot,
+    browserContextService,
+    pollInterval: opts.pollInterval,
+    maxConsecutiveEmpty: opts.maxConsecutiveEmpty,
+    concurrency: opts.concurrency,
+  });
 }

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -143,8 +143,17 @@ export {
 export { ImprovementLoop, isParseFailure, isImproved } from "./execution/improvement-loop.js";
 export type { ImprovementLoopOpts } from "./execution/improvement-loop.js";
 export { cleanRevisionOutput } from "./execution/output-cleaner.js";
-export { TaskRunner, SimpleAgentTask, enqueueTask } from "./execution/task-runner.js";
-export type { TaskRunnerOpts, TaskConfig } from "./execution/task-runner.js";
+export {
+  TaskRunner,
+  SimpleAgentTask,
+  enqueueTask,
+  createTaskRunnerFromSettings,
+} from "./execution/task-runner.js";
+export type {
+  TaskRunnerOpts,
+  TaskRunnerFromSettingsOpts,
+  TaskConfig,
+} from "./execution/task-runner.js";
 export { JudgeExecutor } from "./execution/judge-executor.js";
 export { ActionFilterHarness, ActionDictSchema } from "./execution/action-filter.js";
 export type { ActionDict, ScenarioLike, HarnessLoaderLike } from "./execution/action-filter.js";

--- a/ts/src/integrations/browser/context-capture.ts
+++ b/ts/src/integrations/browser/context-capture.ts
@@ -1,0 +1,81 @@
+import { createBrowserRuntimeFromSettings, type BrowserRuntimeSettingsLike } from "./factory.js";
+
+const MAX_BROWSER_VISIBLE_TEXT_CHARS = 1200;
+
+export interface CapturedBrowserContext {
+  readonly url: string;
+  readonly title: string;
+  readonly visibleText: string;
+  readonly htmlPath?: string | null;
+  readonly screenshotPath?: string | null;
+}
+
+export type BrowserContextCaptureSettingsLike = BrowserRuntimeSettingsLike;
+
+export interface CaptureBrowserContextRequest {
+  readonly settings: BrowserContextCaptureSettingsLike;
+  readonly browserUrl: string;
+  readonly evidenceRoot: string;
+}
+
+export interface BrowserContextCaptureDependencies {
+  readonly createBrowserRuntimeFromSettings: typeof createBrowserRuntimeFromSettings;
+}
+
+const DEFAULT_DEPENDENCIES: BrowserContextCaptureDependencies = {
+  createBrowserRuntimeFromSettings,
+};
+
+export async function captureBrowserContextFromUrl(
+  opts: CaptureBrowserContextRequest,
+  dependencies: BrowserContextCaptureDependencies = DEFAULT_DEPENDENCIES,
+): Promise<CapturedBrowserContext> {
+  const configured = dependencies.createBrowserRuntimeFromSettings(opts.settings, {
+    evidenceRoot: opts.evidenceRoot,
+  });
+  if (!configured) {
+    throw new Error("browser exploration is disabled");
+  }
+
+  const session = await configured.runtime.createSession(configured.sessionConfig);
+  try {
+    const navigation = await session.navigate(opts.browserUrl);
+    if (!navigation.allowed) {
+      throw new Error(`browser navigation blocked by policy: ${navigation.policyReason}`);
+    }
+
+    const snapshot = await session.snapshot();
+    return {
+      url: snapshot.url,
+      title: snapshot.title,
+      visibleText: trimCapturedBrowserText(snapshot.visibleText),
+      htmlPath: snapshot.htmlPath ?? null,
+      screenshotPath: snapshot.screenshotPath ?? null,
+    };
+  } finally {
+    await session.close();
+  }
+}
+
+export function renderCapturedBrowserContext(context: CapturedBrowserContext): string {
+  const lines = [
+    "Live browser context:",
+    `URL: ${context.url}`,
+    `Title: ${context.title}`,
+    `Visible text: ${context.visibleText}`,
+  ];
+  if (context.htmlPath) {
+    lines.push(`HTML artifact: ${context.htmlPath}`);
+  }
+  if (context.screenshotPath) {
+    lines.push(`Screenshot artifact: ${context.screenshotPath}`);
+  }
+  return lines.join("\n");
+}
+
+function trimCapturedBrowserText(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  return normalized.length <= MAX_BROWSER_VISIBLE_TEXT_CHARS
+    ? normalized
+    : normalized.slice(0, MAX_BROWSER_VISIBLE_TEXT_CHARS).trimEnd();
+}

--- a/ts/src/integrations/browser/index.ts
+++ b/ts/src/integrations/browser/index.ts
@@ -51,6 +51,15 @@ export {
 export type { BrowserRuntimeSettingsLike, ConfiguredBrowserRuntime } from "./factory.js";
 export { createBrowserRuntimeFromSettings } from "./factory.js";
 export type {
+  BrowserContextCaptureSettingsLike,
+  CaptureBrowserContextRequest,
+  CapturedBrowserContext,
+} from "./context-capture.js";
+export {
+  captureBrowserContextFromUrl,
+  renderCapturedBrowserContext,
+} from "./context-capture.js";
+export type {
   BrowserWebSocketFactory,
   BrowserWebSocketLike,
   ChromeCdpWebSocketTransportOpts,

--- a/ts/src/investigation/browser-context.ts
+++ b/ts/src/investigation/browser-context.ts
@@ -1,0 +1,63 @@
+import { join, resolve } from "node:path";
+
+import {
+  captureBrowserContextFromUrl,
+  renderCapturedBrowserContext,
+  type BrowserContextCaptureSettingsLike,
+  type CapturedBrowserContext,
+} from "../integrations/browser/context-capture.js";
+import type { Evidence } from "./investigation-contracts.js";
+
+export interface InvestigationBrowserContext extends CapturedBrowserContext {}
+
+export interface InvestigationBrowserContextSettingsLike extends BrowserContextCaptureSettingsLike {
+  readonly knowledgeRoot: string;
+}
+
+export interface CaptureInvestigationBrowserContextRequest {
+  readonly settings: InvestigationBrowserContextSettingsLike;
+  readonly browserUrl: string;
+  readonly investigationName: string;
+}
+
+export interface InvestigationBrowserContextDependencies {
+  readonly captureBrowserContextFromUrl: typeof captureBrowserContextFromUrl;
+}
+
+const DEFAULT_DEPENDENCIES: InvestigationBrowserContextDependencies = {
+  captureBrowserContextFromUrl,
+};
+
+export async function captureInvestigationBrowserContext(
+  opts: CaptureInvestigationBrowserContextRequest,
+  dependencies: InvestigationBrowserContextDependencies = DEFAULT_DEPENDENCIES,
+): Promise<InvestigationBrowserContext> {
+  return dependencies.captureBrowserContextFromUrl({
+    settings: opts.settings,
+    browserUrl: opts.browserUrl,
+    evidenceRoot: join(resolve(opts.settings.knowledgeRoot), "_investigations", opts.investigationName),
+  });
+}
+
+export function renderInvestigationBrowserContext(context: InvestigationBrowserContext): string {
+  return renderCapturedBrowserContext(context);
+}
+
+export function buildInvestigationBrowserEvidence(context: InvestigationBrowserContext): Evidence {
+  return {
+    id: "browser_snapshot",
+    kind: "browser_snapshot",
+    source: context.url,
+    summary: buildInvestigationBrowserSummary(context),
+    supports: [],
+    contradicts: [],
+    isRedHerring: false,
+  };
+}
+
+export function buildInvestigationBrowserSummary(context: InvestigationBrowserContext): string {
+  if (context.title && context.visibleText) {
+    return `${context.title}\n${context.visibleText}`;
+  }
+  return context.title || context.visibleText || context.url;
+}

--- a/ts/src/investigation/investigation-analysis-result-workflow.ts
+++ b/ts/src/investigation/investigation-analysis-result-workflow.ts
@@ -50,16 +50,21 @@ export async function executeInvestigationAnalysisResult(
     description: opts.request.description,
     execution,
     maxHypotheses: opts.request.maxHypotheses,
+    browserContext: opts.request.browserContext,
   });
 
-  const evidence = dependencies.buildInvestigationEvidence(execution);
+  const evidence = dependencies.buildInvestigationEvidence(execution, {
+    browserContext: opts.request.browserContext,
+  });
   const { evidence: annotatedEvidence, hypotheses } = dependencies.evaluateInvestigationHypotheses(
     hypothesisData,
     evidence,
     opts.healedSpec,
   );
 
-  const conclusion = dependencies.buildInvestigationConclusion(hypotheses, annotatedEvidence);
+  const conclusion = dependencies.buildInvestigationConclusion(hypotheses, annotatedEvidence, {
+    hasBrowserContext: !!opts.request.browserContext,
+  });
   const unknowns = dependencies.identifyInvestigationUnknowns(hypotheses, annotatedEvidence);
   const nextSteps = dependencies.recommendInvestigationNextSteps(hypotheses, unknowns);
   const reportPath = join(opts.investigationDir, "report.json");

--- a/ts/src/investigation/investigation-analysis-workflow.ts
+++ b/ts/src/investigation/investigation-analysis-workflow.ts
@@ -1,4 +1,8 @@
 import type { Conclusion, Evidence, Hypothesis } from "./investigation-contracts.js";
+import {
+  buildInvestigationBrowserEvidence,
+  type InvestigationBrowserContext,
+} from "./browser-context.js";
 
 interface CollectedEvidenceItem {
   id: string;
@@ -38,8 +42,8 @@ function similarityScore(left: string, right: string): number {
 
 export function buildInvestigationEvidence(execution: {
   collectedEvidence: CollectedEvidenceItem[];
-}): Evidence[] {
-  return execution.collectedEvidence.map((item, index) => ({
+}, opts: { browserContext?: InvestigationBrowserContext } = {}): Evidence[] {
+  const evidence = execution.collectedEvidence.map((item, index) => ({
     id: item.id ?? `e${index}`,
     kind: item.isRedHerring ? "red_herring" : "observation",
     source: "scenario execution",
@@ -48,6 +52,10 @@ export function buildInvestigationEvidence(execution: {
     contradicts: [],
     isRedHerring: !!item.isRedHerring,
   }));
+  if (opts.browserContext) {
+    return [buildInvestigationBrowserEvidence(opts.browserContext), ...evidence];
+  }
+  return evidence;
 }
 
 export function evaluateInvestigationHypotheses(
@@ -112,6 +120,7 @@ export function evaluateInvestigationHypotheses(
 export function buildInvestigationConclusion(
   hypotheses: Hypothesis[],
   evidence: Evidence[],
+  opts: { hasBrowserContext?: boolean } = {},
 ): Conclusion {
   const best = hypotheses
     .filter((hypothesis) => hypothesis.status === "supported")
@@ -125,7 +134,11 @@ export function buildInvestigationConclusion(
   if (hypotheses.some((hypothesis) => hypothesis.status === "unresolved")) {
     limitations.push("Some hypotheses remain unresolved");
   }
-  limitations.push("Investigation based on generated scenario — not live system data");
+  limitations.push(
+    opts.hasBrowserContext
+      ? "Investigation combines generated scenario reasoning with browser snapshot evidence"
+      : "Investigation based on generated scenario — not live system data",
+  );
 
   return {
     bestExplanation: best?.statement ?? "No hypothesis received sufficient support",

--- a/ts/src/investigation/investigation-contracts.ts
+++ b/ts/src/investigation/investigation-contracts.ts
@@ -1,9 +1,12 @@
+import type { InvestigationBrowserContext } from "./browser-context.js";
+
 export interface InvestigationRequest {
   description: string;
   maxSteps?: number;
   maxHypotheses?: number;
   saveAs?: string;
   strictEvidence?: boolean;
+  browserContext?: InvestigationBrowserContext;
 }
 
 export interface Hypothesis {

--- a/ts/src/investigation/investigation-generation-prompts.ts
+++ b/ts/src/investigation/investigation-generation-prompts.ts
@@ -1,9 +1,22 @@
+import {
+  renderInvestigationBrowserContext,
+  type InvestigationBrowserContext,
+} from "./browser-context.js";
+
 export interface InvestigationPrompt {
   systemPrompt: string;
   userPrompt: string;
 }
 
-export function buildInvestigationSpecPrompt(description: string): InvestigationPrompt {
+export function buildInvestigationSpecPrompt(
+  description: string,
+  opts: { browserContext?: InvestigationBrowserContext } = {},
+): InvestigationPrompt {
+  let userPrompt = `Investigation: ${description}`;
+  if (opts.browserContext) {
+    userPrompt = `${userPrompt}\n\n${renderInvestigationBrowserContext(opts.browserContext)}`;
+  }
+
   return {
     systemPrompt: `You are an investigation designer. Given a problem description, produce an investigation spec as JSON.
 
@@ -21,7 +34,7 @@ Required fields:
 - correct_diagnosis: the ground truth answer
 
 Output ONLY the JSON object, no markdown fences.`,
-    userPrompt: `Investigation: ${description}`,
+    userPrompt,
   };
 }
 
@@ -29,7 +42,15 @@ export function buildInvestigationHypothesisPrompt(opts: {
   description: string;
   execution: { stepsExecuted: number; collectedEvidence: Array<{ content: string }> };
   maxHypotheses?: number;
+  browserContext?: InvestigationBrowserContext;
 }): InvestigationPrompt {
+  let userPrompt = `Investigation: ${opts.description}\nEvidence collected: ${
+    opts.execution.collectedEvidence.map((item) => item.content).join(", ") || "none yet"
+  }\nSteps taken: ${opts.execution.stepsExecuted}\nMaximum hypotheses: ${opts.maxHypotheses ?? 5}`;
+  if (opts.browserContext) {
+    userPrompt = `${userPrompt}\n\n${renderInvestigationBrowserContext(opts.browserContext)}`;
+  }
+
   return {
     systemPrompt: `You are a diagnostic analyst. Given an investigation description and collected evidence, generate hypotheses. Output JSON:
 {
@@ -39,8 +60,6 @@ export function buildInvestigationHypothesisPrompt(opts: {
   ]
 }
 Output ONLY the JSON object.`,
-    userPrompt: `Investigation: ${opts.description}\nEvidence collected: ${
-      opts.execution.collectedEvidence.map((item) => item.content).join(", ") || "none yet"
-    }\nSteps taken: ${opts.execution.stepsExecuted}\nMaximum hypotheses: ${opts.maxHypotheses ?? 5}`,
+    userPrompt,
   };
 }

--- a/ts/src/investigation/investigation-generation-workflow.ts
+++ b/ts/src/investigation/investigation-generation-workflow.ts
@@ -10,6 +10,7 @@ import {
   buildInvestigationHypothesisPrompt,
   buildInvestigationSpecPrompt,
 } from "./investigation-generation-prompts.js";
+import type { InvestigationBrowserContext } from "./browser-context.js";
 
 export interface InvestigationHypothesisDraft {
   statement: string;
@@ -38,8 +39,13 @@ function serializeDesignedInvestigationSpec(spec: InvestigationSpec): Record<str
 export async function buildInvestigationSpec(opts: {
   provider: LLMProvider;
   description: string;
+  browserContext?: InvestigationBrowserContext;
 }): Promise<Record<string, unknown>> {
-  const result = await opts.provider.complete(buildInvestigationSpecPrompt(opts.description));
+  const result = await opts.provider.complete(
+    buildInvestigationSpecPrompt(opts.description, {
+      browserContext: opts.browserContext,
+    }),
+  );
 
   const parsed = parseInvestigationSpecResponse(result.text);
   if (parsed) {
@@ -61,6 +67,7 @@ export async function generateInvestigationHypotheses(opts: {
   description: string;
   execution: { stepsExecuted: number; collectedEvidence: Array<{ content: string }> };
   maxHypotheses?: number;
+  browserContext?: InvestigationBrowserContext;
 }): Promise<InvestigationHypothesisSet> {
   try {
     const result = await opts.provider.complete(
@@ -68,6 +75,7 @@ export async function generateInvestigationHypotheses(opts: {
         description: opts.description,
         execution: opts.execution,
         maxHypotheses: opts.maxHypotheses,
+        browserContext: opts.browserContext,
       }),
     );
 

--- a/ts/src/investigation/investigation-run-workflow.ts
+++ b/ts/src/investigation/investigation-run-workflow.ts
@@ -30,6 +30,7 @@ export async function executeInvestigationRun(
         description: opts.request.description,
         knowledgeRoot: opts.knowledgeRoot,
         name: opts.name,
+        browserContext: opts.request.browserContext,
       },
       dependencies,
     );

--- a/ts/src/investigation/investigation-scenario-preparation-workflow.ts
+++ b/ts/src/investigation/investigation-scenario-preparation-workflow.ts
@@ -2,6 +2,7 @@ import { generateScenarioSource } from "../scenarios/codegen/registry.js";
 import { validateGeneratedScenario } from "../scenarios/codegen/execution-validator.js";
 import { healSpec as defaultHealSpec } from "../scenarios/spec-auto-heal.js";
 import type { LLMProvider } from "../types/index.js";
+import type { InvestigationBrowserContext } from "./browser-context.js";
 import { buildInvestigationSpec } from "./investigation-generation-workflow.js";
 import { persistInvestigationArtifacts } from "./investigation-engine-helpers.js";
 
@@ -10,6 +11,7 @@ export interface InvestigationScenarioPreparationRequest {
   description: string;
   knowledgeRoot: string;
   name: string;
+  browserContext?: InvestigationBrowserContext;
 }
 
 export interface InvestigationScenarioPreparationDependencies {
@@ -43,6 +45,7 @@ export async function prepareInvestigationScenario(
   const spec = await dependencies.buildInvestigationSpec({
     provider: opts.provider,
     description: opts.description,
+    browserContext: opts.browserContext,
   });
   const healedSpec = dependencies.healSpec(spec, "investigation");
   const source = dependencies.generateScenarioSource("investigation", healedSpec, opts.name);

--- a/ts/src/mcp/core-control-tools.ts
+++ b/ts/src/mcp/core-control-tools.ts
@@ -215,6 +215,7 @@ const QueueTaskArgsSchema = z.object({
   specName: z.string().describe("Task spec name / identifier"),
   taskPrompt: z.string().optional(),
   rubric: z.string().optional(),
+  browserUrl: z.string().url().optional(),
   initialOutput: z.string().optional(),
   delegatedResults: z.array(DelegatedResultArgSchema).optional(),
   maxRounds: z.number().int().optional(),
@@ -418,6 +419,7 @@ export function registerCoreControlPlaneTools(
       const taskId = internals.enqueueTask(opts.store, args.specName, {
         taskPrompt: args.taskPrompt,
         rubric: args.rubric,
+        browserUrl: args.browserUrl,
         initialOutput: args.initialOutput,
         delegatedResults: args.delegatedResults,
         maxRounds: args.maxRounds,

--- a/ts/tests/cli.test.ts
+++ b/ts/tests/cli.test.ts
@@ -90,10 +90,11 @@ describe("CLI", () => {
     });
   });
 
-  it("queue --help shows RLM flags", () => {
+  it("queue --help shows RLM and browser flags", () => {
     const { stdout, exitCode } = runCli(["queue", "--help"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("--rlm");
+    expect(stdout).toContain("--browser-url");
   });
 
   it("repl --help shows phase option", () => {

--- a/ts/tests/core-control-tools.test.ts
+++ b/ts/tests/core-control-tools.test.ts
@@ -198,12 +198,21 @@ describe("core control plane MCP tools", () => {
     const queued = await server.registeredTools.queue_task.handler({
       specName: "spec-a",
       priority: 2,
+      browserUrl: "https://status.example.com",
     });
     expect(JSON.parse(queued.content[0].text)).toEqual({
       taskId: "task-123",
       specName: "spec-a",
       status: "queued",
     });
+    expect(enqueueTask).toHaveBeenCalledWith(
+      expect.anything(),
+      "spec-a",
+      expect.objectContaining({
+        priority: 2,
+        browserUrl: "https://status.example.com",
+      }),
+    );
 
     const queueStatus = await server.registeredTools.get_queue_status.handler({});
     expect(JSON.parse(queueStatus.content[0].text)).toEqual({ pendingCount: 4 });

--- a/ts/tests/integrations/browser/context-capture.test.ts
+++ b/ts/tests/integrations/browser/context-capture.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  captureBrowserContextFromUrl,
+  renderCapturedBrowserContext,
+} from "../../../src/integrations/browser/context-capture.js";
+import type {
+  BrowserAuditEvent,
+  BrowserSessionConfig,
+  BrowserSnapshot,
+} from "../../../src/integrations/browser/index.js";
+
+function buildSessionConfig(): BrowserSessionConfig {
+  return {
+    schemaVersion: "1.0",
+    profileMode: "ephemeral",
+    allowedDomains: ["example.com"],
+    allowAuth: false,
+    allowUploads: false,
+    allowDownloads: false,
+    captureScreenshots: true,
+    headless: true,
+    downloadsRoot: null,
+    uploadsRoot: null,
+  };
+}
+
+function buildAuditEvent(overrides: Partial<BrowserAuditEvent> = {}): BrowserAuditEvent {
+  return {
+    schemaVersion: "1.0",
+    eventId: "evt_1",
+    sessionId: "browser_session",
+    actionId: "act_1",
+    kind: "action_result",
+    allowed: true,
+    policyReason: "allowed",
+    timestamp: "2026-04-22T12:00:00.000Z",
+    beforeUrl: "about:blank",
+    afterUrl: "https://example.com/status",
+    artifacts: {
+      htmlPath: null,
+      screenshotPath: null,
+      downloadPath: null,
+    },
+    ...overrides,
+  };
+}
+
+function buildSnapshot(): BrowserSnapshot {
+  return {
+    schemaVersion: "1.0",
+    sessionId: "browser_session",
+    capturedAt: "2026-04-22T12:00:01.000Z",
+    url: "https://example.com/status",
+    title: "Example Status",
+    refs: [],
+    visibleText: " Checkout   is degraded due to upstream latency. ".repeat(40),
+    htmlPath: "/tmp/status.html",
+    screenshotPath: "/tmp/status.png",
+  };
+}
+
+const SETTINGS = {
+  browserEnabled: true,
+  browserBackend: "chrome-cdp",
+  browserProfileMode: "ephemeral" as const,
+  browserAllowedDomains: "example.com",
+  browserAllowAuth: false,
+  browserAllowUploads: false,
+  browserAllowDownloads: false,
+  browserCaptureScreenshots: true,
+  browserHeadless: true,
+  browserDebuggerUrl: "http://127.0.0.1:9222",
+  browserPreferredTargetUrl: "",
+  browserDownloadsRoot: "",
+  browserUploadsRoot: "",
+  runsRoot: "/tmp/runs",
+};
+
+describe("browser context capture", () => {
+  it("captures a normalized browser snapshot and closes the session", async () => {
+    const session = {
+      navigate: vi.fn(async () => buildAuditEvent()),
+      snapshot: vi.fn(async () => buildSnapshot()),
+      close: vi.fn(async () => undefined),
+    };
+    const createBrowserRuntimeFromSettings = vi.fn(() => ({
+      sessionConfig: buildSessionConfig(),
+      runtime: {
+        createSession: vi.fn(async () => session),
+      },
+    }));
+
+    const context = await captureBrowserContextFromUrl(
+      {
+        settings: SETTINGS,
+        browserUrl: "https://example.com/status",
+        evidenceRoot: "/tmp/evidence",
+      },
+      { createBrowserRuntimeFromSettings } as never,
+    );
+
+    expect(createBrowserRuntimeFromSettings).toHaveBeenCalledWith(SETTINGS, {
+      evidenceRoot: "/tmp/evidence",
+    });
+    expect(session.navigate).toHaveBeenCalledWith("https://example.com/status");
+    expect(session.snapshot).toHaveBeenCalledOnce();
+    expect(session.close).toHaveBeenCalledOnce();
+    expect(context).toEqual({
+      url: "https://example.com/status",
+      title: "Example Status",
+      visibleText: expect.stringMatching(/^Checkout is degraded/),
+      htmlPath: "/tmp/status.html",
+      screenshotPath: "/tmp/status.png",
+    });
+    expect(context.visibleText.length).toBeLessThanOrEqual(1200);
+  });
+
+  it("fails closed when navigation is denied by policy", async () => {
+    const session = {
+      navigate: vi.fn(async () => buildAuditEvent({
+        allowed: false,
+        policyReason: "domain_not_allowed",
+      })),
+      snapshot: vi.fn(async () => buildSnapshot()),
+      close: vi.fn(async () => undefined),
+    };
+    const createBrowserRuntimeFromSettings = vi.fn(() => ({
+      sessionConfig: buildSessionConfig(),
+      runtime: {
+        createSession: vi.fn(async () => session),
+      },
+    }));
+
+    await expect(
+      captureBrowserContextFromUrl(
+        {
+          settings: SETTINGS,
+          browserUrl: "https://blocked.example/status",
+          evidenceRoot: "/tmp/evidence",
+        },
+        { createBrowserRuntimeFromSettings } as never,
+      ),
+    ).rejects.toThrow("browser navigation blocked by policy: domain_not_allowed");
+
+    expect(session.snapshot).not.toHaveBeenCalled();
+    expect(session.close).toHaveBeenCalledOnce();
+  });
+
+  it("requires browser exploration to be enabled", async () => {
+    await expect(
+      captureBrowserContextFromUrl(
+        {
+          settings: {
+            ...SETTINGS,
+            browserEnabled: false,
+          },
+          browserUrl: "https://example.com/status",
+          evidenceRoot: "/tmp/evidence",
+        },
+        { createBrowserRuntimeFromSettings: vi.fn(() => null) } as never,
+      ),
+    ).rejects.toThrow("browser exploration is disabled");
+  });
+
+  it("renders prompt-friendly browser context", () => {
+    expect(
+      renderCapturedBrowserContext({
+        url: "https://example.com/status",
+        title: "Example Status",
+        visibleText: "Checkout is degraded",
+        htmlPath: "/tmp/status.html",
+        screenshotPath: "/tmp/status.png",
+      }),
+    ).toContain("URL: https://example.com/status");
+  });
+});

--- a/ts/tests/investigate-command-workflow.test.ts
+++ b/ts/tests/investigate-command-workflow.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   INVESTIGATE_HELP_TEXT,
   executeInvestigateCommandWorkflow,
+  prepareInvestigateRequest,
   planInvestigateCommand,
   renderInvestigationSuccess,
 } from "../src/cli/investigate-command-workflow.js";
@@ -41,6 +42,7 @@ describe("investigate command workflow", () => {
     expect(INVESTIGATE_HELP_TEXT).toContain("autoctx investigate");
     expect(INVESTIGATE_HELP_TEXT).toContain("--description");
     expect(INVESTIGATE_HELP_TEXT).toContain("--max-steps");
+    expect(INVESTIGATE_HELP_TEXT).toContain("--browser-url");
   });
 
   it("plans an investigation request from CLI values", () => {
@@ -108,5 +110,62 @@ describe("investigate command workflow", () => {
       saveAs: undefined,
     });
     expect(result.name).toBe("checkout_rca");
+  });
+
+  it("prepares an investigation request with captured browser context when requested", async () => {
+    const browserContext = {
+      url: "https://example.com/status",
+      title: "Status",
+      visibleText: "Checkout is degraded",
+      htmlPath: "/tmp/status.html",
+      screenshotPath: "/tmp/status.png",
+    };
+    const captureBrowserContext = vi.fn().mockResolvedValue(browserContext);
+
+    const request = await prepareInvestigateRequest(
+      {
+        values: {
+          description: "why did conversion drop",
+          "browser-url": "https://example.com/status",
+          "save-as": "checkout_rca",
+        },
+        settings: {
+          browserEnabled: true,
+          browserBackend: "chrome-cdp",
+          browserProfileMode: "ephemeral",
+          browserAllowedDomains: "example.com",
+          browserAllowAuth: false,
+          browserAllowUploads: false,
+          browserAllowDownloads: false,
+          browserCaptureScreenshots: true,
+          browserHeadless: true,
+          browserDebuggerUrl: "http://127.0.0.1:9333",
+          browserPreferredTargetUrl: "",
+          browserDownloadsRoot: "",
+          browserUploadsRoot: "",
+          runsRoot: "/tmp/runs",
+          knowledgeRoot: "/tmp/knowledge",
+        },
+      },
+      {
+        captureBrowserContext,
+      },
+    );
+
+    expect(captureBrowserContext).toHaveBeenCalledWith({
+      settings: expect.objectContaining({
+        browserEnabled: true,
+        browserBackend: "chrome-cdp",
+      }),
+      browserUrl: "https://example.com/status",
+      investigationName: "checkout_rca",
+    });
+    expect(request).toEqual({
+      description: "why did conversion drop",
+      maxSteps: undefined,
+      maxHypotheses: undefined,
+      saveAs: "checkout_rca",
+      browserContext,
+    });
   });
 });

--- a/ts/tests/investigation-analysis-workflow.test.ts
+++ b/ts/tests/investigation-analysis-workflow.test.ts
@@ -37,6 +37,44 @@ describe("investigation analysis workflow", () => {
     ]);
   });
 
+  it("prepends browser evidence when browser context is provided", () => {
+    expect(buildInvestigationEvidence(
+      {
+        collectedEvidence: [
+          { id: "db", content: "Database saturation detected", isRedHerring: false },
+        ],
+      },
+      {
+        browserContext: {
+          url: "https://example.com/status",
+          title: "Status Page",
+          visibleText: "Checkout is degraded",
+          htmlPath: "/tmp/status.html",
+          screenshotPath: "/tmp/status.png",
+        },
+      },
+    )).toEqual([
+      {
+        id: "browser_snapshot",
+        kind: "browser_snapshot",
+        source: "https://example.com/status",
+        summary: "Status Page\nCheckout is degraded",
+        supports: [],
+        contradicts: [],
+        isRedHerring: false,
+      },
+      {
+        id: "db",
+        kind: "observation",
+        source: "scenario execution",
+        summary: "Database saturation detected",
+        supports: [],
+        contradicts: [],
+        isRedHerring: false,
+      },
+    ]);
+  });
+
   it("annotates evidence support/contradiction and hypothesis status", () => {
     const evidence = buildInvestigationEvidence({
       collectedEvidence: [

--- a/ts/tests/investigation-browser-context.test.ts
+++ b/ts/tests/investigation-browser-context.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildInvestigationBrowserEvidence,
+  captureInvestigationBrowserContext,
+  renderInvestigationBrowserContext,
+} from "../src/investigation/browser-context.js";
+
+const SETTINGS = {
+  browserEnabled: true,
+  browserBackend: "chrome-cdp",
+  browserProfileMode: "ephemeral" as const,
+  browserAllowedDomains: "example.com",
+  browserAllowAuth: false,
+  browserAllowUploads: false,
+  browserAllowDownloads: false,
+  browserCaptureScreenshots: true,
+  browserHeadless: true,
+  browserDebuggerUrl: "http://127.0.0.1:9333",
+  browserPreferredTargetUrl: "",
+  browserDownloadsRoot: "",
+  browserUploadsRoot: "",
+  runsRoot: "/tmp/runs",
+  knowledgeRoot: "/tmp/knowledge",
+};
+
+describe("investigation browser context", () => {
+  it("captures browser context under the investigation artifact root", async () => {
+    const browserContext = {
+      url: "https://example.com/status",
+      title: "Status",
+      visibleText: "Checkout is degraded",
+      htmlPath: "/tmp/status.html",
+      screenshotPath: "/tmp/status.png",
+    };
+    const captureBrowserContextFromUrl = vi.fn(async () => browserContext);
+
+    const context = await captureInvestigationBrowserContext(
+      {
+        settings: SETTINGS,
+        browserUrl: "https://example.com/status",
+        investigationName: "checkout_rca",
+      },
+      {
+        captureBrowserContextFromUrl,
+      },
+    );
+
+    expect(context).toBe(browserContext);
+    expect(captureBrowserContextFromUrl).toHaveBeenCalledWith({
+      settings: SETTINGS,
+      browserUrl: "https://example.com/status",
+      evidenceRoot: "/tmp/knowledge/_investigations/checkout_rca",
+    });
+  });
+
+  it("renders and converts browser context into evidence", () => {
+    const context = {
+      url: "https://example.com/status",
+      title: "Status",
+      visibleText: "Checkout is degraded",
+      htmlPath: "/tmp/status.html",
+      screenshotPath: "/tmp/status.png",
+    };
+
+    expect(renderInvestigationBrowserContext(context)).toContain("Live browser context");
+    expect(buildInvestigationBrowserEvidence(context)).toEqual({
+      id: "browser_snapshot",
+      kind: "browser_snapshot",
+      source: "https://example.com/status",
+      summary: "Status\nCheckout is degraded",
+      supports: [],
+      contradicts: [],
+      isRedHerring: false,
+    });
+  });
+});

--- a/ts/tests/investigation-generation-prompts.test.ts
+++ b/ts/tests/investigation-generation-prompts.test.ts
@@ -14,6 +14,29 @@ describe("investigation generation prompts", () => {
     expect(prompt.userPrompt).toBe("Investigation: Investigate anomaly");
   });
 
+  it("includes browser context in investigation prompts when provided", () => {
+    const browserContext = {
+      url: "https://example.com/status",
+      title: "Status Page",
+      visibleText: "Checkout is degraded for some users.",
+      htmlPath: "/tmp/status.html",
+      screenshotPath: "/tmp/status.png",
+    };
+
+    const specPrompt = buildInvestigationSpecPrompt("Investigate anomaly", {
+      browserContext,
+    });
+    const hypothesisPrompt = buildInvestigationHypothesisPrompt({
+      description: "Investigate outage",
+      execution: { stepsExecuted: 1, collectedEvidence: [] },
+      browserContext,
+    });
+
+    expect(specPrompt.userPrompt).toContain("Live browser context");
+    expect(specPrompt.userPrompt).toContain("https://example.com/status");
+    expect(hypothesisPrompt.userPrompt).toContain("Checkout is degraded for some users.");
+  });
+
   it("builds the hypothesis prompt with evidence, steps, and max hypotheses", () => {
     const prompt = buildInvestigationHypothesisPrompt({
       description: "Investigate outage",

--- a/ts/tests/queue-status-command-workflow.test.ts
+++ b/ts/tests/queue-status-command-workflow.test.ts
@@ -14,6 +14,7 @@ describe("queue/status command workflow", () => {
     expect(QUEUE_HELP_TEXT).toContain("autoctx queue");
     expect(QUEUE_HELP_TEXT).toContain("--priority");
     expect(QUEUE_HELP_TEXT).toContain("--rlm");
+    expect(QUEUE_HELP_TEXT).toContain("--browser-url");
   });
 
   it("returns the right queue usage exit code", () => {
@@ -28,6 +29,7 @@ describe("queue/status command workflow", () => {
           spec: "saved-scenario",
           prompt: "override prompt",
           rubric: undefined,
+          "browser-url": "https://status.example.com",
           priority: "2",
           "min-rounds": "3",
           rlm: true,
@@ -53,6 +55,7 @@ describe("queue/status command workflow", () => {
       request: {
         taskPrompt: "override prompt",
         rubric: "saved rubric",
+        browserUrl: "https://status.example.com",
         referenceContext: "saved context",
         requiredConcepts: ["concept-a"],
         maxRounds: 5,
@@ -78,6 +81,7 @@ describe("queue/status command workflow", () => {
           spec: undefined,
           prompt: undefined,
           rubric: undefined,
+          "browser-url": undefined,
           priority: "0",
           "min-rounds": undefined,
           rlm: false,

--- a/ts/tests/queued-task-browser-context.test.ts
+++ b/ts/tests/queued-task-browser-context.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createQueuedTaskBrowserContextService,
+  mergeQueuedTaskReferenceContext,
+} from "../src/execution/queued-task-browser-context.js";
+
+const SETTINGS = {
+  browserEnabled: true,
+  browserBackend: "chrome-cdp",
+  browserProfileMode: "ephemeral" as const,
+  browserAllowedDomains: "example.com",
+  browserAllowAuth: false,
+  browserAllowUploads: false,
+  browserAllowDownloads: false,
+  browserCaptureScreenshots: true,
+  browserHeadless: true,
+  browserDebuggerUrl: "http://127.0.0.1:9222",
+  browserPreferredTargetUrl: "",
+  browserDownloadsRoot: "",
+  browserUploadsRoot: "",
+  runsRoot: "/tmp/runs",
+};
+
+describe("queued task browser context", () => {
+  it("captures browser context below the queued task artifact root", async () => {
+    const captureBrowserContextFromUrl = vi.fn(async () => ({
+      url: "https://example.com/status",
+      title: "Status",
+      visibleText: "Checkout is degraded",
+      htmlPath: "/tmp/status.html",
+      screenshotPath: "/tmp/status.png",
+    }));
+
+    const service = createQueuedTaskBrowserContextService(
+      SETTINGS,
+      { captureBrowserContextFromUrl },
+    );
+
+    const referenceContext = await service.buildReferenceContext({
+      taskId: "task_123",
+      browserUrl: "https://example.com/status",
+      referenceContext: "Saved facts",
+    });
+
+    expect(captureBrowserContextFromUrl).toHaveBeenCalledWith({
+      settings: SETTINGS,
+      browserUrl: "https://example.com/status",
+      evidenceRoot: "/tmp/runs/task_queue/task_123",
+    });
+    expect(referenceContext).toContain("Saved facts");
+    expect(referenceContext).toContain("Live browser context:");
+    expect(referenceContext).toContain("Checkout is degraded");
+  });
+
+  it("merges queued reference context without introducing blank noise", () => {
+    expect(mergeQueuedTaskReferenceContext(" Existing facts ", " Browser facts ")).toBe(
+      "Existing facts\n\nBrowser facts",
+    );
+    expect(mergeQueuedTaskReferenceContext(undefined, " Browser facts ")).toBe("Browser facts");
+  });
+});

--- a/ts/tests/task-processing-workflow.test.ts
+++ b/ts/tests/task-processing-workflow.test.ts
@@ -13,6 +13,7 @@ describe("task processing workflow", () => {
         config_json: JSON.stringify({
           task_prompt: "Queued prompt",
           min_rounds: 3,
+          browser_url: "https://example.com",
           delegated_results: [{ score: 0.8, reasoning: "delegated" }],
         }),
       },
@@ -37,6 +38,7 @@ describe("task processing workflow", () => {
       rubric: "Saved rubric",
       referenceContext: "Saved context",
       requiredConcepts: ["clarity"],
+      browserUrl: "https://example.com",
       maxRounds: 7,
       qualityThreshold: 0.95,
       minRounds: 3,
@@ -125,5 +127,108 @@ describe("task processing workflow", () => {
 
     expect(completeTask).not.toHaveBeenCalled();
     expect(failTask).toHaveBeenCalledWith("task-2", "workflow exploded");
+  });
+
+  it("captures browser context and merges it into the authoritative reference context", async () => {
+    const completeTask = vi.fn();
+    const failTask = vi.fn();
+    const generateOutput = vi.fn(async () => "generated output");
+    const run = vi.fn(async () => ({
+      rounds: [],
+      bestOutput: "best output",
+      bestScore: 0.92,
+      bestRound: 2,
+      totalRounds: 2,
+      metThreshold: true,
+      judgeFailures: 0,
+      terminationReason: "threshold_met",
+      dimensionTrajectory: {},
+      totalInternalRetries: 0,
+      durationMs: 10,
+      judgeCalls: 2,
+    }));
+    const mergedReferenceContext = [
+      "Saved context",
+      "Live browser context:",
+      "URL: https://status.example.com",
+      "Title: Status page",
+      "Visible text: All systems operational",
+    ].join("\n");
+    const browserContextService = {
+      buildReferenceContext: vi.fn(async () => mergedReferenceContext),
+    };
+
+    await executeQueuedTaskWorkflow({
+      store: { completeTask, failTask } as never,
+      task: {
+        id: "task-browser",
+        spec_name: "queued-spec",
+        config_json: JSON.stringify({
+          task_prompt: "Prompt",
+          reference_context: "Saved context",
+          browser_url: "https://status.example.com",
+        }),
+      } as never,
+      provider: { complete: vi.fn(), defaultModel: () => "mock", name: "mock" } as never,
+      model: "mock-model",
+      browserContextService: browserContextService as never,
+      internals: {
+        createAgentTask: vi.fn(() => ({
+          initialState: () => ({ seed: 1 }),
+          generateOutput,
+          getRlmSessions: () => [],
+        })) as never,
+        createImprovementLoop: vi.fn(() => ({ run })) as never,
+        serializeTaskResult: vi.fn(() => "serialized-result"),
+      },
+    });
+
+    expect(browserContextService.buildReferenceContext).toHaveBeenCalledWith({
+      taskId: "task-browser",
+      browserUrl: "https://status.example.com",
+      referenceContext: "Saved context",
+    });
+    expect(generateOutput).toHaveBeenCalledWith({
+      referenceContext: mergedReferenceContext,
+      requiredConcepts: undefined,
+    });
+    expect(run).toHaveBeenCalledWith({
+      initialOutput: "generated output",
+      state: { seed: 1 },
+      referenceContext: mergedReferenceContext,
+      requiredConcepts: undefined,
+      calibrationExamples: undefined,
+    });
+    expect(failTask).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when queued browser context is requested without a service", async () => {
+    const completeTask = vi.fn();
+    const failTask = vi.fn();
+
+    await executeQueuedTaskWorkflow({
+      store: { completeTask, failTask } as never,
+      task: {
+        id: "task-browser-disabled",
+        spec_name: "queued-spec",
+        config_json: JSON.stringify({
+          task_prompt: "Prompt",
+          browser_url: "https://status.example.com",
+        }),
+      } as never,
+      provider: { complete: vi.fn(), defaultModel: () => "mock", name: "mock" } as never,
+      model: "mock-model",
+      internals: {
+        createAgentTask: vi.fn(() => {
+          throw new Error("agent should not be created");
+        }) as never,
+      },
+    });
+
+    expect(completeTask).not.toHaveBeenCalled();
+    expect(failTask).toHaveBeenCalledWith(
+      "task-browser-disabled",
+      "browser exploration is not configured",
+    );
   });
 });

--- a/ts/tests/task-runner-config-workflow.test.ts
+++ b/ts/tests/task-runner-config-workflow.test.ts
@@ -13,6 +13,7 @@ describe("task runner config workflow", () => {
         max_rounds: 4,
         quality_threshold: 0.85,
         min_rounds: 2,
+        browser_url: "https://example.com",
         task_prompt: "Write a summary",
         rubric: "Be clear",
         delegated_results: [{
@@ -27,6 +28,7 @@ describe("task runner config workflow", () => {
       maxRounds: 4,
       qualityThreshold: 0.85,
       minRounds: 2,
+      browserUrl: "https://example.com",
       taskPrompt: "Write a summary",
       rubric: "Be clear",
       delegatedResults: [{
@@ -74,11 +76,13 @@ describe("task runner config workflow", () => {
   it("builds snake_case enqueue config fields only for provided values", () => {
     expect(buildEnqueueTaskConfig({
       taskPrompt: "Prompt",
+      browserUrl: "https://example.com",
       minRounds: 3,
       rlmEnabled: true,
       rlmModel: "claude",
     })).toEqual({
       task_prompt: "Prompt",
+      browser_url: "https://example.com",
       min_rounds: 3,
       rlm_enabled: true,
       rlm_model: "claude",

--- a/ts/tests/task-runner.test.ts
+++ b/ts/tests/task-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mkdtempSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -311,6 +311,36 @@ describe("TaskRunner.runBatch", () => {
     expect(count).toBe(2);
     expect(store.pendingTaskCount()).toBe(1);
   });
+
+  it("passes browser reference context service into queued task processing", async () => {
+    const store = createStore();
+    const browserContextService = {
+      buildReferenceContext: vi.fn(async () =>
+        "Saved facts\n\nLive browser context:\nVisible text: Checkout is degraded"),
+    };
+    const id = enqueueTask(store, "browser-spec", {
+      taskPrompt: "Summarize current status",
+      rubric: "Be accurate",
+      initialOutput: "Draft",
+      referenceContext: "Saved facts",
+      browserUrl: "https://status.example.com",
+    });
+
+    const runner = new TaskRunner({
+      store,
+      provider: makeMockProvider(),
+      browserContextService,
+    });
+    const result = await runner.runOnce();
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("completed");
+    expect(browserContextService.buildReferenceContext).toHaveBeenCalledWith({
+      taskId: id,
+      browserUrl: "https://status.example.com",
+      referenceContext: "Saved facts",
+    });
+  });
 });
 
 describe("minRounds wiring (AC-53)", () => {
@@ -350,6 +380,31 @@ describe("SimpleAgentTask", () => {
     expect(revised).toBe("generated text"); // Mock returns same for non-judge calls
   });
 
+  it("includes reference context and required concepts in generation prompts", async () => {
+    const calls: Array<{ systemPrompt: string; userPrompt: string }> = [];
+    const provider: LLMProvider = {
+      name: "mock",
+      defaultModel: () => "mock",
+      complete: async (opts) => {
+        calls.push({ systemPrompt: opts.systemPrompt, userPrompt: opts.userPrompt });
+        return { text: "generated text", usage: {} };
+      },
+    };
+
+    const task = new SimpleAgentTask("Write something", "Be good", provider);
+    const output = await task.generateOutput({
+      referenceContext: "Trusted facts only",
+      requiredConcepts: ["safety", "latency"],
+    });
+
+    expect(output).toBe("generated text");
+    expect(calls[0]!.userPrompt).toContain("## Reference Context");
+    expect(calls[0]!.userPrompt).toContain("Trusted facts only");
+    expect(calls[0]!.userPrompt).toContain("## Required Concepts");
+    expect(calls[0]!.userPrompt).toContain("- safety");
+    expect(calls[0]!.userPrompt).toContain("- latency");
+  });
+
   it("can revise through RLM mode", async () => {
     const task = new SimpleAgentTask(
       "Write something",
@@ -378,5 +433,49 @@ describe("SimpleAgentTask", () => {
     expect(revised).toBe("RLM fixed draft");
     expect(task.getRlmSessions()).toHaveLength(1);
     expect(task.getRlmSessions()[0].phase).toBe("revise");
+  });
+
+  it("includes reference context and required concepts in revision prompts", async () => {
+    const calls: Array<{ systemPrompt: string; userPrompt: string }> = [];
+    const provider: LLMProvider = {
+      name: "mock",
+      defaultModel: () => "mock",
+      complete: async (opts) => {
+        calls.push({ systemPrompt: opts.systemPrompt, userPrompt: opts.userPrompt });
+        if (opts.systemPrompt.includes("judge")) {
+          return {
+            text:
+              "<!-- JUDGE_RESULT_START -->\n" +
+              JSON.stringify({
+                score: 0.5,
+                reasoning: "Needs work",
+                dimensions: { quality: 0.5 },
+              }) +
+              "\n<!-- JUDGE_RESULT_END -->",
+            usage: {},
+          };
+        }
+        return { text: "revised text", usage: {} };
+      },
+    };
+
+    const task = new SimpleAgentTask("Write something", "Be good", provider);
+    await task.evaluateOutput("Original draft", {}, {
+      referenceContext: "Trusted facts only",
+      requiredConcepts: ["safety", "latency"],
+    });
+
+    const revised = await task.reviseOutput(
+      "Original draft",
+      { score: 0.5, reasoning: "Needs work", dimensionScores: { quality: 0.5 } },
+      {},
+    );
+
+    expect(revised).toBe("revised text");
+    expect(calls.at(-1)?.userPrompt).toContain("## Reference Context");
+    expect(calls.at(-1)?.userPrompt).toContain("Trusted facts only");
+    expect(calls.at(-1)?.userPrompt).toContain("## Required Concepts");
+    expect(calls.at(-1)?.userPrompt).toContain("- safety");
+    expect(calls.at(-1)?.userPrompt).toContain("- latency");
   });
 });

--- a/ts/tests/task-runner.test.ts
+++ b/ts/tests/task-runner.test.ts
@@ -3,7 +3,12 @@ import { mkdtempSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { SQLiteStore } from "../src/storage/index.js";
-import { TaskRunner, SimpleAgentTask, enqueueTask } from "../src/execution/task-runner.js";
+import {
+  TaskRunner,
+  SimpleAgentTask,
+  createTaskRunnerFromSettings,
+  enqueueTask,
+} from "../src/execution/task-runner.js";
 import type { LLMProvider, CompletionResult } from "../src/types/index.js";
 
 const MIGRATIONS_DIR = join(import.meta.dirname, "..", "migrations");
@@ -339,6 +344,43 @@ describe("TaskRunner.runBatch", () => {
       taskId: id,
       browserUrl: "https://status.example.com",
       referenceContext: "Saved facts",
+    });
+  });
+
+  it("builds the browser reference context service from app settings", async () => {
+    const store = createStore();
+    const browserContextService = {
+      buildReferenceContext: vi.fn(async () =>
+        "Live browser context:\nVisible text: Checkout is degraded"),
+    };
+    const createBrowserContextService = vi.fn(() => browserContextService);
+    const id = enqueueTask(store, "browser-settings-spec", {
+      taskPrompt: "Summarize current status",
+      rubric: "Be accurate",
+      initialOutput: "Draft",
+      browserUrl: "https://status.example.com",
+    });
+    const settings = {
+      browserEnabled: true,
+      knowledgeRoot: "/tmp/knowledge",
+      runsRoot: "/tmp/runs",
+    };
+
+    const runner = createTaskRunnerFromSettings({
+      settings: settings as never,
+      store,
+      provider: makeMockProvider(),
+      createBrowserContextService,
+    });
+    const result = await runner.runOnce();
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("completed");
+    expect(createBrowserContextService).toHaveBeenCalledWith(settings);
+    expect(browserContextService.buildReferenceContext).toHaveBeenCalledWith({
+      taskId: id,
+      browserUrl: "https://status.example.com",
+      referenceContext: undefined,
     });
   });
 });


### PR DESCRIPTION
Linear: AC-602

Depends on PR #765 for the TypeScript Chrome CDP backend.

Summary:
- Adds TypeScript browser context capture with fail-closed navigation policy handling and prompt-friendly rendering.
- Wires browser context into investigations, CLI investigate, queued task config, task processing, TaskRunner injection, and MCP queue_task arguments.
- Keeps the browser runtime behind the browser integration subpath and an injectable queue service rather than adding a heavyweight automation dependency to the root package surface.
- Updates README and changelog docs for browser-url workflows.

Testing:
- npx vitest run tests/integrations/browser/context-capture.test.ts tests/investigation-browser-context.test.ts tests/queued-task-browser-context.test.ts tests/investigation-generation-prompts.test.ts tests/investigation-analysis-workflow.test.ts tests/investigate-command-workflow.test.ts tests/task-runner-config-workflow.test.ts tests/queue-status-command-workflow.test.ts tests/task-processing-workflow.test.ts tests/task-runner.test.ts tests/core-control-tools.test.ts tests/cli.test.ts tests/package-export-catalogs.test.ts
- npm run lint