### PR TITLE
fix(ac-607): stabilize babel_reverse solve scenario creation

### DIFF
--- a/autocontext/src/autocontext/knowledge/solve_agent_task_design.py
+++ b/autocontext/src/autocontext/knowledge/solve_agent_task_design.py
@@ -1,0 +1,107 @@
+"""Solve-specific AgentTask design helpers."""
+
+from __future__ import annotations
+
+import re
+
+from autocontext.scenarios.custom.agent_task_designer import (
+    RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM,  # noqa: F401 - re-exported through solver
+    SOLVE_AGENT_TASK_DESIGNER_SYSTEM,  # noqa: F401 - re-exported through solver
+)
+from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+from autocontext.scenarios.custom.classifier_input import build_family_classification_brief
+
+_SOLVE_AGENT_TASK_DESIGN_KEEP_SECTIONS = frozenset(
+    {
+        "Objective",
+        "Description",
+        "Scenario Design",
+        "Evaluation Dimensions",
+        "Success Criteria",
+    }
+)
+_SOLVE_AGENT_TASK_DESIGN_MAX_CHARS = 1000
+_SOLVE_AGENT_TASK_DESIGN_MAX_SECTION_LINES = 5
+_SOLVE_RUNTIME_HEAVY_TASK_PROMPT_RE = re.compile(
+    r"\b(run|execute|inspect)\b.*\b(provider|repository|scenario|generations?|command|file|artifact)\b",
+    re.IGNORECASE,
+)
+
+
+def _build_solve_description_brief(description: str) -> str:
+    return build_family_classification_brief(description)
+
+
+def _build_solve_agent_task_design_brief(description: str) -> str:
+    brief = _build_solve_description_brief(description)
+    if len(brief) <= _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS:
+        return brief
+
+    lines: list[str] = []
+    current_section: str | None = None
+    current_section_lines = 0
+    title_captured = False
+    kept_structured_section = False
+
+    for raw_line in brief.splitlines():
+        heading_match = re.match(r"^\s*#{2,6}\s+(.+?)\s*$", raw_line)
+        if heading_match is not None:
+            title = heading_match.group(1).strip()
+            if title in _SOLVE_AGENT_TASK_DESIGN_KEEP_SECTIONS:
+                current_section = title
+                current_section_lines = 0
+                kept_structured_section = True
+                if lines and lines[-1] != "":
+                    lines.append("")
+                lines.append(raw_line)
+                lines.append("")
+            else:
+                current_section = None
+            continue
+
+        stripped = raw_line.strip()
+        if not title_captured and stripped:
+            lines.append(raw_line)
+            title_captured = True
+            continue
+        if current_section is None:
+            continue
+        if not stripped:
+            if lines and lines[-1] != "":
+                lines.append("")
+            continue
+        if stripped.startswith("```"):
+            continue
+        if current_section_lines >= _SOLVE_AGENT_TASK_DESIGN_MAX_SECTION_LINES:
+            continue
+        lines.append(raw_line)
+        current_section_lines += 1
+
+    if not kept_structured_section:
+        return _truncate_to_line_boundary(brief, _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS)
+
+    compact = "\n".join(lines).strip()
+    compact = re.sub(r"\n{3,}", "\n\n", compact)
+    while len(compact) > _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS and "\n\n" in compact:
+        compact = compact.rsplit("\n\n", 1)[0].strip()
+    if len(compact) > _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS:
+        compact = _truncate_to_line_boundary(compact, _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS)
+    return compact or _truncate_to_line_boundary(brief, _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS)
+
+
+def _solve_task_spec_needs_compact_retry(spec: AgentTaskSpec) -> bool:
+    if spec.output_format != "json_schema":
+        return False
+    if spec.sample_input not in {None, ""}:
+        return False
+    prompt = spec.task_prompt.strip()
+    if "if available" in prompt.lower():
+        return True
+    return bool(_SOLVE_RUNTIME_HEAVY_TASK_PROMPT_RE.search(prompt))
+
+
+def _truncate_to_line_boundary(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text.strip()
+    truncated = text[:max_chars].rsplit("\n", 1)[0].strip()
+    return truncated or text[:max_chars].strip()

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -17,21 +17,21 @@ from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.config.settings import AppSettings
 from autocontext.execution.improvement_loop import ImprovementLoop
 from autocontext.knowledge.export import SkillPackage, export_skill_package
+from autocontext.knowledge.solve_agent_task_design import (
+    _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS,  # noqa: F401 - re-exported for existing tests/imports
+    RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+    SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+    _build_solve_agent_task_design_brief,
+    _build_solve_description_brief,
+    _solve_task_spec_needs_compact_retry,
+)
 from autocontext.mcp.tools import MtsToolContext
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
 from autocontext.scenarios.artifact_editing import Artifact, ArtifactEditingInterface
-from autocontext.scenarios.custom.agent_task_designer import (
-    RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
-    SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
-)
-from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
 from autocontext.scenarios.custom.classifier_cache import (
     ClassifierCache,
     default_classifier_cache_path,
-)
-from autocontext.scenarios.custom.classifier_input import (
-    build_family_classification_brief,
 )
 from autocontext.storage import artifact_store_from_settings
 from autocontext.storage.sqlite_store import SQLiteStore
@@ -58,22 +58,7 @@ _SIMULATION_INTERFACE_HINT_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 _AGENT_TASK_INTERFACE_HINT_RE = re.compile(r"\bagent[- ]task evaluation\b", re.IGNORECASE)
-_SOLVE_AGENT_TASK_DESIGN_KEEP_SECTIONS = frozenset(
-    {
-        "Objective",
-        "Description",
-        "Scenario Design",
-        "Evaluation Dimensions",
-        "Success Criteria",
-    }
-)
-_SOLVE_AGENT_TASK_DESIGN_MAX_CHARS = 1000
-_SOLVE_AGENT_TASK_DESIGN_MAX_SECTION_LINES = 5
 _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS = 600.0
-_SOLVE_RUNTIME_HEAVY_TASK_PROMPT_RE = re.compile(
-    r"\b(run|execute|inspect)\b.*\b(provider|repository|scenario|generations?|command|file|artifact)\b",
-    re.IGNORECASE,
-)
 
 
 @dataclass
@@ -313,73 +298,6 @@ class _BudgetedAgentTask(AgentTaskInterface):
         result = self._task.verify_facts(output, state)
         self._budget.check("fact verification")
         return result
-
-
-def _build_solve_description_brief(description: str) -> str:
-    return build_family_classification_brief(description)
-
-
-def _build_solve_agent_task_design_brief(description: str) -> str:
-    brief = _build_solve_description_brief(description)
-    if len(brief) <= _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS:
-        return brief
-
-    lines: list[str] = []
-    current_section: str | None = None
-    current_section_lines = 0
-    title_captured = False
-
-    for raw_line in brief.splitlines():
-        heading_match = re.match(r"^\s*#{2,6}\s+(.+?)\s*$", raw_line)
-        if heading_match is not None:
-            title = heading_match.group(1).strip()
-            if title in _SOLVE_AGENT_TASK_DESIGN_KEEP_SECTIONS:
-                current_section = title
-                current_section_lines = 0
-                if lines and lines[-1] != "":
-                    lines.append("")
-                lines.append(raw_line)
-                lines.append("")
-            else:
-                current_section = None
-            continue
-
-        stripped = raw_line.strip()
-        if not title_captured and stripped:
-            lines.append(raw_line)
-            title_captured = True
-            continue
-        if current_section is None:
-            continue
-        if not stripped:
-            if lines and lines[-1] != "":
-                lines.append("")
-            continue
-        if stripped.startswith("```"):
-            continue
-        if current_section_lines >= _SOLVE_AGENT_TASK_DESIGN_MAX_SECTION_LINES:
-            continue
-        lines.append(raw_line)
-        current_section_lines += 1
-
-    compact = "\n".join(lines).strip()
-    compact = re.sub(r"\n{3,}", "\n\n", compact)
-    while len(compact) > _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS and "\n\n" in compact:
-        compact = compact.rsplit("\n\n", 1)[0].strip()
-    if len(compact) > _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS:
-        compact = compact[:_SOLVE_AGENT_TASK_DESIGN_MAX_CHARS].rsplit("\n", 1)[0].strip()
-    return compact or brief[:_SOLVE_AGENT_TASK_DESIGN_MAX_CHARS].strip()
-
-
-def _solve_task_spec_needs_compact_retry(spec: AgentTaskSpec) -> bool:
-    if spec.output_format != "json_schema":
-        return False
-    if spec.sample_input not in {None, ""}:
-        return False
-    prompt = spec.task_prompt.strip()
-    if "if available" in prompt.lower():
-        return True
-    return bool(_SOLVE_RUNTIME_HEAVY_TASK_PROMPT_RE.search(prompt))
 
 
 def _normalize_family_hint_token(token: str) -> str:

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -21,6 +21,11 @@ from autocontext.mcp.tools import MtsToolContext
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
 from autocontext.scenarios.artifact_editing import Artifact, ArtifactEditingInterface
+from autocontext.scenarios.custom.agent_task_designer import (
+    RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+    SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+)
+from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
 from autocontext.scenarios.custom.classifier_cache import (
     ClassifierCache,
     default_classifier_cache_path,
@@ -46,13 +51,31 @@ _SOLVE_FAMILY_ALIASES = {
     "alignment_stress_test": "agent_task",
     "meta_learning": "agent_task",
     "capability_bootstrapping": "agent_task",
+    "compositional_generalization": "agent_task",
 }
 _SIMULATION_INTERFACE_HINT_RE = re.compile(
     r"\bsimulationinterface\b.*\bworldstate\b|\bworldstate\b.*\bsimulationinterface\b",
     re.IGNORECASE | re.DOTALL,
 )
 _AGENT_TASK_INTERFACE_HINT_RE = re.compile(r"\bagent[- ]task evaluation\b", re.IGNORECASE)
+_SOLVE_AGENT_TASK_DESIGN_KEEP_SECTIONS = frozenset(
+    {
+        "Objective",
+        "Description",
+        "Scenario Design",
+        "Evaluation Dimensions",
+        "Success Criteria",
+    }
+)
+_SOLVE_AGENT_TASK_DESIGN_MAX_CHARS = 1000
+_SOLVE_AGENT_TASK_DESIGN_MAX_SECTION_LINES = 5
 _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS = 600.0
+_SOLVE_RUNTIME_HEAVY_TASK_PROMPT_RE = re.compile(
+    r"\b(run|execute|inspect)\b.*\b(provider|repository|scenario|generations?|command|file|artifact)\b",
+    re.IGNORECASE,
+)
+
+
 @dataclass
 class SolveJob:
     job_id: str
@@ -294,6 +317,69 @@ class _BudgetedAgentTask(AgentTaskInterface):
 
 def _build_solve_description_brief(description: str) -> str:
     return build_family_classification_brief(description)
+
+
+def _build_solve_agent_task_design_brief(description: str) -> str:
+    brief = _build_solve_description_brief(description)
+    if len(brief) <= _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS:
+        return brief
+
+    lines: list[str] = []
+    current_section: str | None = None
+    current_section_lines = 0
+    title_captured = False
+
+    for raw_line in brief.splitlines():
+        heading_match = re.match(r"^\s*#{2,6}\s+(.+?)\s*$", raw_line)
+        if heading_match is not None:
+            title = heading_match.group(1).strip()
+            if title in _SOLVE_AGENT_TASK_DESIGN_KEEP_SECTIONS:
+                current_section = title
+                current_section_lines = 0
+                if lines and lines[-1] != "":
+                    lines.append("")
+                lines.append(raw_line)
+                lines.append("")
+            else:
+                current_section = None
+            continue
+
+        stripped = raw_line.strip()
+        if not title_captured and stripped:
+            lines.append(raw_line)
+            title_captured = True
+            continue
+        if current_section is None:
+            continue
+        if not stripped:
+            if lines and lines[-1] != "":
+                lines.append("")
+            continue
+        if stripped.startswith("```"):
+            continue
+        if current_section_lines >= _SOLVE_AGENT_TASK_DESIGN_MAX_SECTION_LINES:
+            continue
+        lines.append(raw_line)
+        current_section_lines += 1
+
+    compact = "\n".join(lines).strip()
+    compact = re.sub(r"\n{3,}", "\n\n", compact)
+    while len(compact) > _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS and "\n\n" in compact:
+        compact = compact.rsplit("\n\n", 1)[0].strip()
+    if len(compact) > _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS:
+        compact = compact[:_SOLVE_AGENT_TASK_DESIGN_MAX_CHARS].rsplit("\n", 1)[0].strip()
+    return compact or brief[:_SOLVE_AGENT_TASK_DESIGN_MAX_CHARS].strip()
+
+
+def _solve_task_spec_needs_compact_retry(spec: AgentTaskSpec) -> bool:
+    if spec.output_format != "json_schema":
+        return False
+    if spec.sample_input not in {None, ""}:
+        return False
+    prompt = spec.task_prompt.strip()
+    if "if available" in prompt.lower():
+        return True
+    return bool(_SOLVE_RUNTIME_HEAVY_TASK_PROMPT_RE.search(prompt))
 
 
 def _normalize_family_hint_token(token: str) -> str:
@@ -595,6 +681,10 @@ class SolveScenarioBuilder:
         family_creator = AgentTaskCreator(
             llm_fn=self._llm_fn,
             knowledge_root=self._knowledge_root,
+            designer_system_prompt=SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+            retry_designer_system_prompt=RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+            description_transform=_build_solve_agent_task_design_brief,
+            retry_spec_predicate=_solve_task_spec_needs_compact_retry,
         )
         scenario = family_creator.create(brief, family_name=family.name)
         scenario_name = str(cast(_NamedScenario, scenario).name)
@@ -611,8 +701,8 @@ def _llm_fn_from_client(client: Any, model: str) -> LlmFn:
         response = client.generate(
             model=model,
             prompt=f"{system}\n\n{user}",
-            max_tokens=1800,
-            temperature=0.3,
+            max_tokens=1200,
+            temperature=0.2,
             role="scenario_designer",
         )
         response_text: object = getattr(response, "text", "")

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -16,7 +16,7 @@ from autocontext.scenarios.coordination import CoordinationInterface
 from autocontext.scenarios.custom.agent_task_codegen import generate_agent_task_class
 from autocontext.scenarios.custom.agent_task_designer import (
     AGENT_TASK_DESIGNER_SYSTEM,
-    design_agent_task,
+    design_validated_agent_task,
 )
 from autocontext.scenarios.custom.agent_task_revision import (
     patch_legacy_generated_evaluate_output,
@@ -136,33 +136,14 @@ class AgentTaskCreator:
 
         # 1. Design
         logger.info("designing agent task from description")
-        try:
-            spec = design_agent_task(
-                design_description,
-                self.llm_fn,
-                system_prompt=self._designer_system_prompt,
-            )
-        except Exception as exc:
-            retry_system_prompt = (
-                self._retry_designer_system_prompt
-                if _is_timeout_like_error(exc) and self._retry_designer_system_prompt is not None
-                else self._designer_system_prompt
-            )
-            logger.warning("agent task design failed on first attempt; retrying once", exc_info=True)
-            spec = design_agent_task(
-                design_description,
-                self.llm_fn,
-                system_prompt=retry_system_prompt,
-            )
-
-        if self._retry_spec_predicate is not None and self._retry_spec_predicate(spec):
-            retry_system_prompt = self._retry_designer_system_prompt or self._designer_system_prompt
-            logger.warning("agent task design produced a retryable spec; retrying once with fallback prompt")
-            spec = design_agent_task(
-                design_description,
-                self.llm_fn,
-                system_prompt=retry_system_prompt,
-            )
+        spec = design_validated_agent_task(
+            design_description,
+            self.llm_fn,
+            system_prompt=self._designer_system_prompt,
+            retry_system_prompt=self._retry_designer_system_prompt,
+            retry_spec_predicate=self._retry_spec_predicate,
+            intent_description=description,
+        )
 
         # 1.5 Auto-heal: generate synthetic sample_input if needed (AC-309),
         # drop unsatisfiable runtime context keys, and clamp quality_threshold

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_creator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import logging
 import sys
+from collections.abc import Callable
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -14,7 +15,8 @@ from autocontext.scenarios.base import ScenarioInterface
 from autocontext.scenarios.coordination import CoordinationInterface
 from autocontext.scenarios.custom.agent_task_codegen import generate_agent_task_class
 from autocontext.scenarios.custom.agent_task_designer import (
-    design_validated_agent_task,
+    AGENT_TASK_DESIGNER_SYSTEM,
+    design_agent_task,
 )
 from autocontext.scenarios.custom.agent_task_revision import (
     patch_legacy_generated_evaluate_output,
@@ -55,6 +57,10 @@ from autocontext.util.json_io import write_json
 logger = logging.getLogger(__name__)
 
 
+def _is_timeout_like_error(exc: Exception) -> bool:
+    return "timeout" in str(exc).lower()
+
+
 class AgentTaskCreator:
     """Orchestrates the full agent task creation pipeline."""
 
@@ -62,9 +68,18 @@ class AgentTaskCreator:
         self,
         llm_fn: LlmFn,
         knowledge_root: Path,
+        *,
+        designer_system_prompt: str = AGENT_TASK_DESIGNER_SYSTEM,
+        retry_designer_system_prompt: str | None = None,
+        description_transform: Callable[[str], str] | None = None,
+        retry_spec_predicate: Callable[[Any], bool] | None = None,
     ) -> None:
         self.llm_fn = llm_fn
         self.knowledge_root = knowledge_root
+        self._designer_system_prompt = designer_system_prompt
+        self._retry_designer_system_prompt = retry_designer_system_prompt
+        self._description_transform = description_transform
+        self._retry_spec_predicate = retry_spec_predicate
 
     STOP_WORDS = SHARED_STOP_WORDS
 
@@ -94,6 +109,7 @@ class AgentTaskCreator:
             An instance of the generated scenario family implementation.
         """
         name = self.derive_name(description)
+        design_description = self._description_transform(description) if self._description_transform is not None else description
         if family_name:
             family = get_family(family_name)
         else:
@@ -108,13 +124,45 @@ class AgentTaskCreator:
         if family.name in FAMILY_CONFIGS:
             logger.info("routing description to %s creator", family.name)
             creator = create_for_family(family.name, self.llm_fn, self.knowledge_root)
-            return creator.create(description, name=name)
+            try:
+                return creator.create(design_description, name=name)
+            except Exception as exc:
+                if not _is_timeout_like_error(exc):
+                    raise
+                logger.warning("%s creator failed on first attempt; retrying once", family.name, exc_info=True)
+                return creator.create(design_description, name=name)
         if family.name != "agent_task":
             raise ValueError(f"Scenario family '{family.name}' is not yet supported for custom scaffolding")
 
         # 1. Design
         logger.info("designing agent task from description")
-        spec = design_validated_agent_task(description, self.llm_fn)
+        try:
+            spec = design_agent_task(
+                design_description,
+                self.llm_fn,
+                system_prompt=self._designer_system_prompt,
+            )
+        except Exception as exc:
+            retry_system_prompt = (
+                self._retry_designer_system_prompt
+                if _is_timeout_like_error(exc) and self._retry_designer_system_prompt is not None
+                else self._designer_system_prompt
+            )
+            logger.warning("agent task design failed on first attempt; retrying once", exc_info=True)
+            spec = design_agent_task(
+                design_description,
+                self.llm_fn,
+                system_prompt=retry_system_prompt,
+            )
+
+        if self._retry_spec_predicate is not None and self._retry_spec_predicate(spec):
+            retry_system_prompt = self._retry_designer_system_prompt or self._designer_system_prompt
+            logger.warning("agent task design produced a retryable spec; retrying once with fallback prompt")
+            spec = design_agent_task(
+                design_description,
+                self.llm_fn,
+                system_prompt=retry_system_prompt,
+            )
 
         # 1.5 Auto-heal: generate synthetic sample_input if needed (AC-309),
         # drop unsatisfiable runtime context keys, and clamp quality_threshold

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import Callable
 
 from autocontext.agents.types import LlmFn
 from autocontext.scenarios.custom.agent_task_spec import (
@@ -188,6 +189,10 @@ def design_validated_agent_task(
     llm_fn: LlmFn,
     *,
     max_retries: int = 2,
+    system_prompt: str = AGENT_TASK_DESIGNER_SYSTEM,
+    retry_system_prompt: str | None = None,
+    retry_spec_predicate: Callable[[AgentTaskSpec], bool] | None = None,
+    intent_description: str | None = None,
 ) -> AgentTaskSpec:
     """Design an agent task spec, retrying with validator feedback if intent drifts.
 
@@ -210,25 +215,27 @@ def design_validated_agent_task(
     total_attempts = max_retries + 1
     errors_per_attempt: list[list[str]] = []
     last_spec: AgentTaskSpec | None = None
+    validation_description = intent_description or description
+    effective_retry_system_prompt = retry_system_prompt or system_prompt
 
     for attempt in range(total_attempts):
         try:
             if attempt == 0:
-                spec = design_agent_task(description, llm_fn)
+                spec = design_agent_task(description, llm_fn, system_prompt=system_prompt)
             elif last_spec is None:
                 user_prompt = _build_parse_failure_retry_prompt(
                     description=description,
                     errors=errors_per_attempt[-1],
                 )
-                response = llm_fn(AGENT_TASK_DESIGNER_SYSTEM, user_prompt)
+                response = llm_fn(effective_retry_system_prompt, user_prompt)
                 spec = parse_agent_task_spec(response)
             else:
                 user_prompt = _build_correction_prompt(
-                    description=description,
+                    description=validation_description,
                     failed_spec=last_spec,
                     errors=errors_per_attempt[-1],
                 )
-                response = llm_fn(AGENT_TASK_DESIGNER_SYSTEM, user_prompt)
+                response = llm_fn(effective_retry_system_prompt, user_prompt)
                 spec = parse_agent_task_spec(response)
         except Exception as exc:
             errors = [f"designer response could not be parsed: {exc}"]
@@ -245,7 +252,15 @@ def design_validated_agent_task(
                 f"agent task design failed after {total_attempts} attempts. Errors per attempt: {errors_per_attempt}"
             ) from exc
 
-        errors = validate_intent(description, spec)
+        errors = validate_intent(validation_description, spec)
+        if (
+            not errors
+            and retry_spec_predicate is not None
+            and retry_spec_predicate(spec)
+            and attempt < total_attempts - 1
+        ):
+            errors = ["generated spec is too runtime-heavy for solve-on-demand; retry with a compact execution contract"]
+
         if not errors:
             return spec
 

--- a/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
+++ b/autocontext/src/autocontext/scenarios/custom/agent_task_designer.py
@@ -85,6 +85,47 @@ AGENT_TASK_DESIGNER_SYSTEM = (
     "Produce the smallest complete AgentTaskSpec that faithfully captures the user description.\n"
 )
 
+SOLVE_AGENT_TASK_DESIGNER_SYSTEM = (
+    "You design the smallest viable AgentTaskSpec JSON for autocontext solve-on-demand. "
+    "Return only one JSON object wrapped in the required delimiters.\n\n"
+    f"{SPEC_START}\n{{ ... }}\n{SPEC_END}\n\n"
+    "Required fields:\n"
+    '- "task_prompt": self-contained prompt for the evaluated agent\n'
+    '- "judge_rubric": concise scoring dimensions and criteria\n'
+    '- "output_format": one of free_text, json_schema, or code\n\n'
+    "Optional fields are allowed only when they materially change execution or evaluation: "
+    "judge_model, difficulty_tiers, reference_context, reference_sources, required_concepts, "
+    "sample_input, context_preparation, required_context_keys, calibration_examples, "
+    "max_rounds, quality_threshold, revision_prompt. "
+    "Omit unnecessary fields instead of filling them with prose.\n\n"
+    "Solve-specific rules:\n"
+    "- Keep the spec lean and execution-ready.\n"
+    "- Prefer a single structured output contract over long nested examples.\n"
+    "- Keep task_prompt under 550 characters whenever possible.\n"
+    "- Keep judge_rubric under 900 characters whenever possible.\n"
+    "- Keep sample_input under 800 characters whenever possible.\n"
+    "- Prefer compact sample_input that summarizes telemetry or state instead of "
+    "repeating long arrays or verbose examples when possible.\n"
+    "- Keep required_concepts short and focused; omit them if the prompt and rubric already carry the needed intent.\n"
+    "- Use context_preparation and required_context_keys only when absolutely necessary.\n"
+    "- Do not invent impossible external loaders or unsatisfied state keys.\n"
+    "- For structured tasks, prefer json_schema.\n"
+    "- If iterative refinement is useful, set max_rounds > 1 and provide a compact revision_prompt.\n\n"
+    "Produce the smallest complete AgentTaskSpec that faithfully captures the user description.\n"
+)
+
+RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM = (
+    "Design the smallest viable AgentTaskSpec JSON for autocontext solve-on-demand. "
+    "Return only one JSON object wrapped in the required delimiters.\n\n"
+    f"{SPEC_START}\n{{ ... }}\n{SPEC_END}\n\n"
+    "Required fields: task_prompt, judge_rubric, output_format. "
+    "Keep task_prompt under 550 characters, judge_rubric under 900 characters, and "
+    "sample_input under 800 characters whenever possible. "
+    "Prefer compact sample_input that summarizes telemetry or state instead of repeating "
+    "long arrays. Prefer 3-5 short evidence items and 1-3 short actions. "
+    "Omit optional fields unless they are essential for execution or evaluation. Prefer json_schema for structured tasks.\n"
+)
+
 
 def parse_agent_task_spec(text: str) -> AgentTaskSpec:
     """Parse an AgentTaskSpec from LLM response text."""
@@ -115,12 +156,18 @@ def parse_agent_task_spec(text: str) -> AgentTaskSpec:
     )
 
 
-def design_agent_task(description: str, llm_fn: LlmFn) -> AgentTaskSpec:
+def design_agent_task(
+    description: str,
+    llm_fn: LlmFn,
+    *,
+    system_prompt: str = AGENT_TASK_DESIGNER_SYSTEM,
+) -> AgentTaskSpec:
     """Design an agent task spec from a natural language description.
 
     Args:
         description: Natural language description of the task.
         llm_fn: Callable(system_prompt, user_prompt) -> response text.
+        system_prompt: Designer instructions used for the LLM call.
 
     Returns:
         Parsed AgentTaskSpec.
@@ -129,7 +176,7 @@ def design_agent_task(description: str, llm_fn: LlmFn) -> AgentTaskSpec:
 
     return design_with_parse_retry(
         llm_fn=llm_fn,
-        system_prompt=AGENT_TASK_DESIGNER_SYSTEM,
+        system_prompt=system_prompt,
         user_prompt=f"User description:\n{description}",
         parser=parse_agent_task_spec,
         delimiter_hint=f"{SPEC_START} ... {SPEC_END}",
@@ -195,8 +242,7 @@ def design_validated_agent_task(
                 )
                 continue
             raise ValueError(
-                f"agent task design failed after {total_attempts} attempts. "
-                f"Errors per attempt: {errors_per_attempt}"
+                f"agent task design failed after {total_attempts} attempts. Errors per attempt: {errors_per_attempt}"
             ) from exc
 
         errors = validate_intent(description, spec)
@@ -214,10 +260,7 @@ def design_validated_agent_task(
                 "; ".join(errors),
             )
 
-    raise ValueError(
-        f"intent validation failed after {total_attempts} attempts. "
-        f"Errors per attempt: {errors_per_attempt}"
-    )
+    raise ValueError(f"intent validation failed after {total_attempts} attempts. Errors per attempt: {errors_per_attempt}")
 
 
 def _build_parse_failure_retry_prompt(

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -385,6 +385,21 @@ class TestSolveScenarioBuilder:
 
         assert family.name == "agent_task"
 
+    def test_resolves_compositional_generalization_proposal_to_agent_task(self) -> None:
+        from autocontext.knowledge.solver import _resolve_requested_scenario_family
+
+        family = _resolve_requested_scenario_family(
+            "## Scenario Proposal\n\n"
+            "**Family:** compositional_generalization\n"
+            "**Priority:** Week 2\n"
+            "**Generations to signal:** 20-30\n\n"
+            "### Description\n\n"
+            "Given outputs from an unfamiliar domain, the system must reconstruct the implicit "
+            "schema, infer quality criteria, and produce conforming output for held-out inputs.\n"
+        )
+
+        assert family.name == "agent_task"
+
     def test_build_strips_nonessential_solve_sections_before_creation(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -433,6 +448,73 @@ class TestSolveScenarioBuilder:
         assert "Objective" in captured["description"]
         assert "Scenario Design" in captured["description"]
 
+    def test_build_uses_compact_designer_prompt_for_agent_task_solves(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from autocontext.knowledge.solver import (
+            _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS,
+            RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+            SOLVE_AGENT_TASK_DESIGNER_SYSTEM,
+            SolveScenarioBuilder,
+        )
+
+        runtime = SubagentRuntime(DeterministicDevClient())
+        builder = SolveScenarioBuilder(
+            runtime=runtime,
+            llm_fn=_operator_loop_llm,
+            model="test-model",
+            knowledge_root=tmp_path,
+        )
+        captured: dict[str, str] = {}
+
+        class _CreatedScenario:
+            name = "stress_test_rubric_fixture"
+
+        def _fake_create(self, description: str, *, family_name: str = "") -> _CreatedScenario:
+            del family_name
+            captured["description"] = description
+            captured["designer_system_prompt"] = self._designer_system_prompt
+            captured["retry_designer_system_prompt"] = self._retry_designer_system_prompt
+            transformed = self._description_transform(description) if self._description_transform is not None else description
+            captured["transformed_description"] = transformed
+            return _CreatedScenario()
+
+        monkeypatch.setattr(
+            "autocontext.scenarios.custom.agent_task_creator.AgentTaskCreator.create",
+            _fake_create,
+        )
+
+        builder.build(
+            "Harness Stress Test: rubric drift detection — long-horizon evaluation quality monitoring\n\n"
+            "## Objective\n\n"
+            "Run a scenario long enough (10+ generations) that rubric drift becomes measurable, then "
+            "validate that the analytics stack correctly detects and reports evaluation quality degradation.\n\n"
+            "## Scenario Design\n\n"
+            "* Use any stable scenario (grid_ctf or a custom agent-task)\n"
+            "* Run 10+ generations with live Anthropic provider\n"
+            "* Use analytics/rubric_drift.py, analytics/calibration.py, analytics/correlation.py, "
+            "analytics/timeline_inspector.py, and analytics/trace_reporter.py\n"
+            "* Capture concrete commands, artifacts, and metrics\n"
+            "* Report cross-module consistency\n\n"
+            "## Evaluation Dimensions\n\n"
+            "* Rubric drift coefficient\n"
+            "* Calibration error\n"
+            "* Inter-dimension correlation matrix health\n"
+            "* Score distribution entropy across generations\n"
+            "* Stagnation detection accuracy\n\n"
+            "## Success Criteria\n\n"
+            "* 10+ generation run completes without crashes\n"
+            "* Analytics modules produce non-trivial output\n"
+            "* Timeline inspector identifies at least one inflection point or trend\n"
+            "* All analytics outputs are internally consistent\n"
+        )
+
+        assert captured["designer_system_prompt"] == SOLVE_AGENT_TASK_DESIGNER_SYSTEM
+        assert captured["retry_designer_system_prompt"] == RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM
+        assert len(captured["transformed_description"]) <= _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS
+        assert len(captured["transformed_description"]) < len(captured["description"])
+        assert "## Scenario Design" in captured["transformed_description"]
+
     def test_build_strips_inline_example_parentheticals_before_creation(self) -> None:
         from autocontext.knowledge.solver import _build_solve_description_brief
 
@@ -450,6 +532,139 @@ class TestSolveScenarioBuilder:
         assert "essay-quality metric" not in brief
         assert "e.g." not in brief
         assert "gaming the metric" in brief
+
+    def test_build_solve_agent_task_design_brief_compacts_long_structured_descriptions(self) -> None:
+        from autocontext.knowledge.solver import (
+            _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS,
+            _build_solve_agent_task_design_brief,
+            _build_solve_description_brief,
+        )
+
+        description = (
+            "Harness Stress Test: rubric drift detection — long-horizon evaluation quality monitoring\n\n"
+            "## Objective\n\n"
+            "Run a scenario long enough (10+ generations) that rubric drift becomes measurable, then "
+            "validate that the analytics stack correctly detects and reports evaluation quality degradation.\n\n"
+            "## Scenario Design\n\n"
+            "* Use any stable scenario (grid_ctf or a custom agent-task)\n"
+            "* Run 10+ generations with live Anthropic provider\n"
+            "* Use analytics/rubric_drift.py, analytics/calibration.py, analytics/correlation.py, "
+            "analytics/timeline_inspector.py, and analytics/trace_reporter.py\n"
+            "* Capture concrete commands, artifacts, and metrics\n"
+            "* Report cross-module consistency\n\n"
+            "## Evaluation Dimensions\n\n"
+            "* Rubric drift coefficient\n"
+            "* Calibration error\n"
+            "* Inter-dimension correlation matrix health\n"
+            "* Score distribution entropy across generations\n"
+            "* Stagnation detection accuracy\n\n"
+            "## Success Criteria\n\n"
+            "* 10+ generation run completes without crashes\n"
+            "* Analytics modules produce non-trivial output\n"
+            "* Timeline inspector identifies at least one inflection point or trend\n"
+            "* All analytics outputs are internally consistent\n"
+        )
+
+        brief = _build_solve_description_brief(description)
+        compact = _build_solve_agent_task_design_brief(description)
+
+        assert len(brief) > _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS
+        assert len(compact) <= _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS
+        assert len(compact) < len(brief)
+        assert "## Objective" in compact
+        assert "## Scenario Design" in compact
+        assert "analytics/rubric_drift.py" in compact
+
+    def test_agent_task_creator_applies_description_transform_to_family_creators(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
+
+        captured: dict[str, str] = {}
+
+        class _FakeFamilyCreator:
+            def create(self, description: str, name: str) -> dict[str, str]:
+                captured["description"] = description
+                captured["name"] = name
+                return {"name": name, "description": description}
+
+        monkeypatch.setattr(
+            "autocontext.scenarios.custom.agent_task_creator.create_for_family",
+            lambda family, llm_fn, knowledge_root: _FakeFamilyCreator(),
+        )
+
+        creator = AgentTaskCreator(
+            llm_fn=lambda system, user: "",
+            knowledge_root=tmp_path,
+            description_transform=lambda description: f"compact::{description}",
+        )
+
+        creator.create(
+            "Original solve description",
+            family_name="artifact_editing",
+        )
+
+        assert captured["description"] == "compact::Original solve description"
+        assert captured["name"] == "original_solve_description"
+
+    def test_agent_task_creator_retries_family_creator_once_on_timeout(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.scenarios.custom.agent_task_creator import AgentTaskCreator
+
+        captured = {"attempts": 0}
+
+        class _FlakyFamilyCreator:
+            def create(self, description: str, name: str) -> dict[str, str]:
+                del description, name
+                captured["attempts"] += 1
+                if captured["attempts"] == 1:
+                    raise RuntimeError("PiCLIRuntime failed: timeout")
+                return {"status": "ok"}
+
+        monkeypatch.setattr(
+            "autocontext.scenarios.custom.agent_task_creator.create_for_family",
+            lambda family, llm_fn, knowledge_root: _FlakyFamilyCreator(),
+        )
+
+        creator = AgentTaskCreator(
+            llm_fn=lambda system, user: "",
+            knowledge_root=tmp_path,
+        )
+
+        result = creator.create(
+            "Original solve description",
+            family_name="artifact_editing",
+        )
+
+        assert result == {"status": "ok"}
+        assert captured["attempts"] == 2
+
+    def test_solve_task_spec_needs_compact_retry_for_runtime_heavy_specs(self) -> None:
+        from autocontext.knowledge.solver import _solve_task_spec_needs_compact_retry
+        from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+
+        heavy_spec = AgentTaskSpec(
+            task_prompt=(
+                "Run a stable eval (grid_ctf if available) for 10 generations with the live provider "
+                "and inspect repository analytics artifacts."
+            ),
+            judge_rubric="Score whether the run completed and analytics were inspected.",
+            output_format="json_schema",
+        )
+        compact_spec = AgentTaskSpec(
+            task_prompt="Inspect telemetry and return JSON only with keys drift_status, calibration_status, and summary.",
+            judge_rubric="Score contract fidelity and diagnosis quality.",
+            output_format="json_schema",
+            sample_input='{"score_entropy":0.18}',
+        )
+
+        assert _solve_task_spec_needs_compact_retry(heavy_spec) is True
+        assert _solve_task_spec_needs_compact_retry(compact_spec) is False
 
     def test_resolves_alignment_stress_proposal_to_agent_task(self) -> None:
         from autocontext.knowledge.solver import _resolve_requested_scenario_family
@@ -487,7 +702,8 @@ class TestSolveLLMFn:
 
         assert result == "ok"
         assert captured["model"] == "architect-model"
-        assert captured["max_tokens"] == 1800
+        assert captured["max_tokens"] == 1200
+        assert captured["temperature"] == 0.2
         assert captured["role"] == "scenario_designer"
 
     def test_build_creator_prefers_translator_model_for_solve_design(
@@ -674,6 +890,7 @@ class TestSolveLLMFn:
         assert summary.best_score == 0.73
         assert summary.generations_executed == 2
         assert captured["pi_timeout"] == _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS
+
 
 class TestSolveScenarioExecutor:
     def test_runs_agent_task_scenarios_through_task_loop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -575,6 +575,23 @@ class TestSolveScenarioBuilder:
         assert "## Scenario Design" in compact
         assert "analytics/rubric_drift.py" in compact
 
+    def test_build_solve_agent_task_design_brief_preserves_long_freeform_descriptions(self) -> None:
+        from autocontext.knowledge.solver import (
+            _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS,
+            _build_solve_agent_task_design_brief,
+        )
+
+        description = "Babel reverse solve scenario\n\n" + "\n".join(
+            f"detail {idx}: preserve translation inversion requirement {idx}." for idx in range(40)
+        )
+
+        compact = _build_solve_agent_task_design_brief(description)
+
+        assert len(compact) <= _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS
+        assert "Babel reverse solve scenario" in compact
+        assert "detail 0: preserve translation inversion requirement 0" in compact
+        assert "detail 1: preserve translation inversion requirement 1" in compact
+
     def test_agent_task_creator_applies_description_transform_to_family_creators(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary

- routes `compositional_generalization` solve proposals into the agent-task pipeline so AC-392 `babel_reverse` no longer falls into artifact-editing design
- adds solve-specific compact agent-task designer prompts and prompt compaction for long proposal descriptions to keep Pi-backed scenario design within runtime limits
- threads description transforms through family creators and retries timeout-like family creator calls once

## Motivation

AC-607 tracks a regression where Python `solve` timed out during scenario creation for the AC-392 `babel_reverse` current proposal. The failure happened before execution, during solve-side scenario materialization on live Pi. This PR makes solve honor the proposal family metadata and use a leaner solve-specific agent-task design path for long current-proposal descriptions.

## Implementation Details

- add `compositional_generalization -> agent_task` solve-family alias in `autocontext/src/autocontext/knowledge/solver.py`
- add `_build_solve_agent_task_design_brief` and `_solve_task_spec_needs_compact_retry`, and wire solve builder to `SOLVE_AGENT_TASK_DESIGNER_SYSTEM` / `RETRY_SOLVE_AGENT_TASK_DESIGNER_SYSTEM`
- tighten the solve scenario-designer runtime budget in `_llm_fn_from_client(...)`
- extend `AgentTaskCreator` so solve can pass description transforms and solve-specific prompts through the agent-task path while retrying timeout-like family creator calls once
- add solve-specific prompt constants to `autocontext/src/autocontext/scenarios/custom/agent_task_designer.py`

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check src/autocontext/knowledge/solver.py src/autocontext/scenarios/custom/agent_task_creator.py src/autocontext/scenarios/custom/agent_task_designer.py tests/test_knowledge_solver.py`
- [x] `cd autocontext && uv run mypy src/autocontext/knowledge/solver.py src/autocontext/scenarios/custom/agent_task_creator.py src/autocontext/scenarios/custom/agent_task_designer.py`
- [x] `cd autocontext && uv run pytest tests/test_knowledge_solver.py`
- [x] `cd autocontext && uv run pytest tests/test_agent_task_pipeline.py -k 'artifact_editing or agent_task_creator or retry or design'`
- [ ] `cd ts && npm run lint`
- [ ] `cd ts && npm test`
- [x] additional manual verification described below

### Manual verification

- live Pi-backed `SolveScenarioBuilder.build(...)` for the AC-392 `babel_reverse` current proposal now resolves `compositional_generalization` to `agent_task` and successfully materializes `babel_reverse_current` in ~418s with `AUTOCONTEXT_PI_TIMEOUT=600`

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- Linear: AC-607
- Validation target: AC-392 current proposal
- local investigation artifacts remain untracked and are not part of this PR
