### PR TITLE
Unify cross-runtime migration ledgers

### DIFF
--- a/autocontext/src/autocontext/storage/bootstrap_schema.py
+++ b/autocontext/src/autocontext/storage/bootstrap_schema.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+from autocontext.storage.migration_ledgers import TYPESCRIPT_BASELINE_MIGRATIONS
+
 _BOOTSTRAP_MIGRATIONS = (
     "001_initial.sql",
     "002_phase3_phase7.sql",
@@ -33,6 +35,14 @@ def bootstrap_core_schema(conn: sqlite3.Connection) -> None:
         """
         CREATE TABLE IF NOT EXISTS schema_migrations (
             version TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_version (
+            filename TEXT PRIMARY KEY,
             applied_at TEXT NOT NULL DEFAULT (datetime('now'))
         );
         """
@@ -326,4 +336,8 @@ def bootstrap_core_schema(conn: sqlite3.Connection) -> None:
     conn.executemany(
         "INSERT OR IGNORE INTO schema_migrations(version) VALUES (?)",
         [(version,) for version in _BOOTSTRAP_MIGRATIONS],
+    )
+    conn.executemany(
+        "INSERT OR IGNORE INTO schema_version(filename) VALUES (?)",
+        [(version,) for version in TYPESCRIPT_BASELINE_MIGRATIONS],
     )

--- a/autocontext/src/autocontext/storage/migration_ledgers.py
+++ b/autocontext/src/autocontext/storage/migration_ledgers.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+TYPESCRIPT_TO_PYTHON_BASELINES: dict[str, tuple[str, ...]] = {
+    "007_task_queue.sql": ("007_task_queue.sql",),
+    "008_human_feedback.sql": ("006_human_feedback.sql",),
+    "009_generation_loop.sql": (
+        "001_initial.sql",
+        "002_phase3_phase7.sql",
+        "003_agent_subagent_metadata.sql",
+        "004_knowledge_inheritance.sql",
+        "005_ecosystem_provider_tracking.sql",
+        "009_generation_timing.sql",
+        "013_generation_dimension_summary.sql",
+        "014_scoring_backend_metadata.sql",
+        "015_match_replay.sql",
+    ),
+}
+
+PYTHON_TO_TYPESCRIPT_BASELINES: dict[str, tuple[str, ...]] = {
+    python_migration: (typescript_migration,)
+    for typescript_migration, python_migrations in TYPESCRIPT_TO_PYTHON_BASELINES.items()
+    for python_migration in python_migrations
+}
+
+TYPESCRIPT_BASELINE_MIGRATIONS: tuple[str, ...] = tuple(TYPESCRIPT_TO_PYTHON_BASELINES)
+
+
+def typescript_baselines_for_python_migrations(applied_python_migrations: set[str]) -> tuple[str, ...]:
+    return tuple(
+        typescript_migration
+        for typescript_migration, python_migrations in TYPESCRIPT_TO_PYTHON_BASELINES.items()
+        if all(migration in applied_python_migrations for migration in python_migrations)
+    )

--- a/autocontext/src/autocontext/storage/sqlite_migrations.py
+++ b/autocontext/src/autocontext/storage/sqlite_migrations.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+from collections.abc import Sequence
+from pathlib import Path
+
+from autocontext.storage.migration_ledgers import typescript_baselines_for_python_migrations
+
+_ALTER_ADD_COLUMN_RE = re.compile(r"^\s*(?:--[^\n]*\n\s*)*ALTER\s+TABLE\s+\S+\s+ADD\s+COLUMN\s+", re.IGNORECASE)
+
+
+def _iter_sql_statements(script: str) -> Sequence[str]:
+    statements: list[str] = []
+    pending: list[str] = []
+    for line in script.splitlines(keepends=True):
+        pending.append(line)
+        statement = "".join(pending).strip()
+        if statement and sqlite3.complete_statement(statement):
+            statements.append(statement)
+            pending = []
+    trailing = "".join(pending).strip()
+    if trailing:
+        statements.append(trailing)
+    return statements
+
+
+def _execute_migration_script(conn: sqlite3.Connection, script: str) -> None:
+    for statement in _iter_sql_statements(script):
+        try:
+            conn.execute(statement)
+        except sqlite3.OperationalError as exc:
+            if "duplicate column name" in str(exc).lower() and _ALTER_ADD_COLUMN_RE.match(statement):
+                continue
+            raise
+
+
+def apply_python_migration_files(conn: sqlite3.Connection, migrations_dir: Path) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            version TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_version (
+            filename TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        """
+    )
+    applied_python = {row[0] for row in conn.execute("SELECT version FROM schema_migrations").fetchall()}
+    for migration in sorted(migrations_dir.glob("*.sql")):
+        if migration.name in applied_python:
+            continue
+        _execute_migration_script(conn, migration.read_text(encoding="utf-8"))
+        conn.execute("INSERT INTO schema_migrations(version) VALUES (?)", (migration.name,))
+        applied_python.add(migration.name)
+        for typescript_migration in typescript_baselines_for_python_migrations(applied_python):
+            conn.execute(
+                "INSERT OR IGNORE INTO schema_version(filename) VALUES (?)",
+                (typescript_migration,),
+            )

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import json
-import re
 import sqlite3
 from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from autocontext.storage.bootstrap_schema import bootstrap_core_schema, default_migrations_dir
-from autocontext.storage.migration_ledgers import typescript_baselines_for_python_migrations
 from autocontext.storage.row_types import GenerationMetricsRow, RunRow
+from autocontext.storage.sqlite_migrations import apply_python_migration_files
 
 if TYPE_CHECKING:
     from autocontext.monitor.types import MonitorAlert, MonitorCondition
@@ -17,32 +16,6 @@ if TYPE_CHECKING:
 SQLITE_BUSY_TIMEOUT_MS = 5_000
 AgentOutputBatch = tuple[str, str]
 AgentRoleMetricBatch = tuple[str, str, int, int, int, str, str]
-_ALTER_ADD_COLUMN_RE = re.compile(r"^\s*(?:--[^\n]*\n\s*)*ALTER\s+TABLE\s+\S+\s+ADD\s+COLUMN\s+", re.IGNORECASE)
-
-
-def _iter_sql_statements(script: str) -> Sequence[str]:
-    statements: list[str] = []
-    pending: list[str] = []
-    for line in script.splitlines(keepends=True):
-        pending.append(line)
-        statement = "".join(pending).strip()
-        if statement and sqlite3.complete_statement(statement):
-            statements.append(statement)
-            pending = []
-    trailing = "".join(pending).strip()
-    if trailing:
-        statements.append(trailing)
-    return statements
-
-
-def _execute_migration_script(conn: sqlite3.Connection, script: str) -> None:
-    for statement in _iter_sql_statements(script):
-        try:
-            conn.execute(statement)
-        except sqlite3.OperationalError as exc:
-            if "duplicate column name" in str(exc).lower() and _ALTER_ADD_COLUMN_RE.match(statement):
-                continue
-            raise
 
 
 class SQLiteStore:
@@ -73,36 +46,7 @@ class SQLiteStore:
                 bootstrap_core_schema(conn)
             return
         with self.connect() as conn:
-            conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS schema_migrations (
-                    version TEXT PRIMARY KEY,
-                    applied_at TEXT NOT NULL DEFAULT (datetime('now'))
-                );
-                """
-            )
-            conn.execute(
-                """
-                CREATE TABLE IF NOT EXISTS schema_version (
-                    filename TEXT PRIMARY KEY,
-                    applied_at TEXT NOT NULL DEFAULT (datetime('now'))
-                );
-                """
-            )
-            applied_python = {
-                row[0] for row in conn.execute("SELECT version FROM schema_migrations").fetchall()
-            }
-            for migration in sorted(migrations_dir.glob("*.sql")):
-                if migration.name in applied_python:
-                    continue
-                _execute_migration_script(conn, migration.read_text(encoding="utf-8"))
-                conn.execute("INSERT INTO schema_migrations(version) VALUES (?)", (migration.name,))
-                applied_python.add(migration.name)
-                for typescript_migration in typescript_baselines_for_python_migrations(applied_python):
-                    conn.execute(
-                        "INSERT OR IGNORE INTO schema_version(filename) VALUES (?)",
-                        (typescript_migration,),
-                    )
+            apply_python_migration_files(conn, migrations_dir)
 
     def create_run(self, run_id: str, scenario: str, generations: int, executor_mode: str, agent_provider: str = "") -> None:
         with self.connect() as conn:

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from autocontext.storage.bootstrap_schema import bootstrap_core_schema, default_migrations_dir
+from autocontext.storage.migration_ledgers import typescript_baselines_for_python_migrations
 from autocontext.storage.row_types import GenerationMetricsRow, RunRow
 
 if TYPE_CHECKING:
@@ -15,6 +17,34 @@ if TYPE_CHECKING:
 SQLITE_BUSY_TIMEOUT_MS = 5_000
 AgentOutputBatch = tuple[str, str]
 AgentRoleMetricBatch = tuple[str, str, int, int, int, str, str]
+_ALTER_ADD_COLUMN_RE = re.compile(r"^\s*(?:--[^\n]*\n\s*)*ALTER\s+TABLE\s+\S+\s+ADD\s+COLUMN\s+", re.IGNORECASE)
+
+
+def _iter_sql_statements(script: str) -> Sequence[str]:
+    statements: list[str] = []
+    pending: list[str] = []
+    for line in script.splitlines(keepends=True):
+        pending.append(line)
+        statement = "".join(pending).strip()
+        if statement and sqlite3.complete_statement(statement):
+            statements.append(statement)
+            pending = []
+    trailing = "".join(pending).strip()
+    if trailing:
+        statements.append(trailing)
+    return statements
+
+
+def _execute_migration_script(conn: sqlite3.Connection, script: str) -> None:
+    for statement in _iter_sql_statements(script):
+        try:
+            conn.execute(statement)
+        except sqlite3.OperationalError as exc:
+            if "duplicate column name" in str(exc).lower() and _ALTER_ADD_COLUMN_RE.match(statement):
+                continue
+            raise
+
+
 class SQLiteStore:
     def __init__(self, db_path: Path) -> None:
         self.db_path = db_path
@@ -51,15 +81,28 @@ class SQLiteStore:
                 );
                 """
             )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schema_version (
+                    filename TEXT PRIMARY KEY,
+                    applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+                """
+            )
+            applied_python = {
+                row[0] for row in conn.execute("SELECT version FROM schema_migrations").fetchall()
+            }
             for migration in sorted(migrations_dir.glob("*.sql")):
-                applied = conn.execute(
-                    "SELECT version FROM schema_migrations WHERE version = ?",
-                    (migration.name,),
-                ).fetchone()
-                if applied:
+                if migration.name in applied_python:
                     continue
-                conn.executescript(migration.read_text(encoding="utf-8"))
+                _execute_migration_script(conn, migration.read_text(encoding="utf-8"))
                 conn.execute("INSERT INTO schema_migrations(version) VALUES (?)", (migration.name,))
+                applied_python.add(migration.name)
+                for typescript_migration in typescript_baselines_for_python_migrations(applied_python):
+                    conn.execute(
+                        "INSERT OR IGNORE INTO schema_version(filename) VALUES (?)",
+                        (typescript_migration,),
+                    )
 
     def create_run(self, run_id: str, scenario: str, generations: int, executor_mode: str, agent_provider: str = "") -> None:
         with self.connect() as conn:

--- a/autocontext/tests/test_cross_runtime_migration_ledgers.py
+++ b/autocontext/tests/test_cross_runtime_migration_ledgers.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from autocontext.storage.migration_ledgers import TYPESCRIPT_BASELINE_MIGRATIONS
+from autocontext.storage.sqlite_store import SQLiteStore
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PACKAGE_ROOT.parent
+PYTHON_MIGRATIONS_DIR = PACKAGE_ROOT / "migrations"
+TYPESCRIPT_MIGRATIONS_DIR = REPO_ROOT / "ts" / "migrations"
+
+
+def _apply_typescript_migrations(db_path: Path) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schema_version (
+                filename TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            """
+        )
+        for migration in sorted(TYPESCRIPT_MIGRATIONS_DIR.glob("*.sql")):
+            conn.executescript(migration.read_text(encoding="utf-8"))
+            conn.execute("INSERT INTO schema_version(filename) VALUES (?)", (migration.name,))
+
+
+def _ledger_values(db_path: Path, table: str, column: str) -> set[str]:
+    with sqlite3.connect(db_path) as conn:
+        return {row[0] for row in conn.execute(f"SELECT {column} FROM {table}").fetchall()}
+
+
+def test_python_migrations_can_follow_typescript_migrations(tmp_path: Path) -> None:
+    db_path = tmp_path / "cross-runtime.db"
+    _apply_typescript_migrations(db_path)
+
+    store = SQLiteStore(db_path)
+    store.migrate(PYTHON_MIGRATIONS_DIR)
+
+    applied_python = _ledger_values(db_path, "schema_migrations", "version")
+    applied_typescript = _ledger_values(db_path, "schema_version", "filename")
+
+    assert applied_python == {migration.name for migration in PYTHON_MIGRATIONS_DIR.glob("*.sql")}
+    assert set(TYPESCRIPT_BASELINE_MIGRATIONS).issubset(applied_typescript)
+
+
+def test_bootstrap_schema_seeds_typescript_ledger(tmp_path: Path) -> None:
+    db_path = tmp_path / "bootstrap.db"
+
+    store = SQLiteStore(db_path)
+    store.migrate(tmp_path / "missing-migrations")
+
+    applied_typescript = _ledger_values(db_path, "schema_version", "filename")
+    assert set(TYPESCRIPT_BASELINE_MIGRATIONS).issubset(applied_typescript)

--- a/ts/migrations/009_generation_loop.sql
+++ b/ts/migrations/009_generation_loop.sql
@@ -56,3 +56,46 @@ CREATE TABLE IF NOT EXISTS agent_outputs (
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     FOREIGN KEY (run_id, generation_index) REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS generation_recovery (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    generation_index INTEGER NOT NULL,
+    decision TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    retry_count INTEGER NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (run_id, generation_index) REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS agent_role_metrics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    generation_index INTEGER NOT NULL,
+    role TEXT NOT NULL,
+    model TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL,
+    output_tokens INTEGER NOT NULL,
+    latency_ms INTEGER NOT NULL,
+    subagent_id TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'completed',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (run_id, generation_index) REFERENCES generations(run_id, generation_index) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS knowledge_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    scenario TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    best_score REAL NOT NULL,
+    best_elo REAL NOT NULL,
+    playbook_hash TEXT NOT NULL,
+    agent_provider TEXT NOT NULL DEFAULT '',
+    rlm_enabled INTEGER NOT NULL DEFAULT 0,
+    scoring_backend TEXT NOT NULL DEFAULT 'elo',
+    rating_uncertainty REAL DEFAULT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_knowledge_snapshots_scenario
+    ON knowledge_snapshots(scenario, best_score DESC);

--- a/ts/src/storage/storage-migration-workflow.ts
+++ b/ts/src/storage/storage-migration-workflow.ts
@@ -18,6 +18,28 @@ export const TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES: Record<string, readonly s
   ],
 };
 
+const TYPESCRIPT_BASELINE_SCHEMA_RECONCILIATION: Record<string, readonly string[]> = {
+  "009_generation_loop.sql": [
+    "ALTER TABLE generations ADD COLUMN elo REAL NOT NULL DEFAULT 1000.0",
+    "ALTER TABLE generations ADD COLUMN wins INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE generations ADD COLUMN losses INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE agent_role_metrics ADD COLUMN subagent_id TEXT NOT NULL DEFAULT ''",
+    "ALTER TABLE agent_role_metrics ADD COLUMN status TEXT NOT NULL DEFAULT 'completed'",
+    "ALTER TABLE runs ADD COLUMN agent_provider TEXT NOT NULL DEFAULT ''",
+    "ALTER TABLE knowledge_snapshots ADD COLUMN agent_provider TEXT NOT NULL DEFAULT ''",
+    "ALTER TABLE knowledge_snapshots ADD COLUMN rlm_enabled INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE generations ADD COLUMN duration_seconds REAL DEFAULT NULL",
+    "ALTER TABLE generations ADD COLUMN dimension_summary_json TEXT DEFAULT NULL",
+    "ALTER TABLE generations ADD COLUMN scoring_backend TEXT NOT NULL DEFAULT 'elo'",
+    "ALTER TABLE generations ADD COLUMN rating_uncertainty REAL DEFAULT NULL",
+    "ALTER TABLE knowledge_snapshots ADD COLUMN scoring_backend TEXT NOT NULL DEFAULT 'elo'",
+    "ALTER TABLE knowledge_snapshots ADD COLUMN rating_uncertainty REAL DEFAULT NULL",
+    "ALTER TABLE matches ADD COLUMN winner TEXT NOT NULL DEFAULT ''",
+    "ALTER TABLE matches ADD COLUMN strategy_json TEXT NOT NULL DEFAULT ''",
+    "ALTER TABLE matches ADD COLUMN replay_json TEXT NOT NULL DEFAULT ''",
+  ],
+};
+
 function readAppliedSet(
   db: Database.Database,
   sql: string,
@@ -33,6 +55,22 @@ function readAppliedSet(
 function isCoveredByPythonLedger(file: string, appliedPython: Set<string>): boolean {
   const pythonBaselines = TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES[file] ?? [];
   return pythonBaselines.length > 0 && pythonBaselines.every((migration) => appliedPython.has(migration));
+}
+
+function isDuplicateColumnError(error: unknown): boolean {
+  return error instanceof Error && error.message.toLowerCase().includes("duplicate column name");
+}
+
+function reconcilePythonBaselineSchema(db: Database.Database, file: string): void {
+  for (const statement of TYPESCRIPT_BASELINE_SCHEMA_RECONCILIATION[file] ?? []) {
+    try {
+      db.exec(statement);
+    } catch (error: unknown) {
+      if (!isDuplicateColumnError(error)) {
+        throw error;
+      }
+    }
+  }
 }
 
 export function migrateDatabase(
@@ -70,6 +108,7 @@ export function migrateDatabase(
     }
     const sql = readFileSync(join(migrationsDir, file), "utf8");
     db.exec(sql);
+    reconcilePythonBaselineSchema(db, file);
     db.prepare("INSERT INTO schema_version(filename) VALUES (?)").run(file);
     appliedTypescript.add(file);
     for (const pythonMigration of TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES[file] ?? []) {

--- a/ts/src/storage/storage-migration-workflow.ts
+++ b/ts/src/storage/storage-migration-workflow.ts
@@ -2,6 +2,39 @@ import type Database from "better-sqlite3";
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
+export const TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES: Record<string, readonly string[]> = {
+  "007_task_queue.sql": ["007_task_queue.sql"],
+  "008_human_feedback.sql": ["006_human_feedback.sql"],
+  "009_generation_loop.sql": [
+    "001_initial.sql",
+    "002_phase3_phase7.sql",
+    "003_agent_subagent_metadata.sql",
+    "004_knowledge_inheritance.sql",
+    "005_ecosystem_provider_tracking.sql",
+    "009_generation_timing.sql",
+    "013_generation_dimension_summary.sql",
+    "014_scoring_backend_metadata.sql",
+    "015_match_replay.sql",
+  ],
+};
+
+function readAppliedSet(
+  db: Database.Database,
+  sql: string,
+  column: "filename" | "version",
+): Set<string> {
+  return new Set(
+    (db.prepare(sql).all() as Array<Record<typeof column, string>>).map(
+      (row) => row[column],
+    ),
+  );
+}
+
+function isCoveredByPythonLedger(file: string, appliedPython: Set<string>): boolean {
+  const pythonBaselines = TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES[file] ?? [];
+  return pythonBaselines.length > 0 && pythonBaselines.every((migration) => appliedPython.has(migration));
+}
+
 export function migrateDatabase(
   db: Database.Database,
   migrationsDir: string,
@@ -12,22 +45,36 @@ export function migrateDatabase(
        applied_at TEXT NOT NULL DEFAULT (datetime('now'))
      )`,
   );
-
-  const applied = new Set(
-    (db.prepare("SELECT filename FROM schema_version").all() as Array<{ filename: string }>)
-      .map((row) => row.filename),
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS schema_migrations (
+       version TEXT PRIMARY KEY,
+       applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+     )`,
   );
+
+  const appliedTypescript = readAppliedSet(db, "SELECT filename FROM schema_version", "filename");
+  const appliedPython = readAppliedSet(db, "SELECT version FROM schema_migrations", "version");
 
   const files = readdirSync(migrationsDir)
     .filter((file) => file.endsWith(".sql"))
     .sort();
 
   for (const file of files) {
-    if (applied.has(file)) {
+    if (appliedTypescript.has(file)) {
+      continue;
+    }
+    if (isCoveredByPythonLedger(file, appliedPython)) {
+      db.prepare("INSERT OR IGNORE INTO schema_version(filename) VALUES (?)").run(file);
+      appliedTypescript.add(file);
       continue;
     }
     const sql = readFileSync(join(migrationsDir, file), "utf8");
     db.exec(sql);
     db.prepare("INSERT INTO schema_version(filename) VALUES (?)").run(file);
+    appliedTypescript.add(file);
+    for (const pythonMigration of TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES[file] ?? []) {
+      db.prepare("INSERT OR IGNORE INTO schema_migrations(version) VALUES (?)").run(pythonMigration);
+      appliedPython.add(pythonMigration);
+    }
   }
 }

--- a/ts/tests/storage-migration-workflow.test.ts
+++ b/ts/tests/storage-migration-workflow.test.ts
@@ -1,6 +1,6 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -10,6 +10,15 @@ import {
 } from "../src/storage/storage-migration-workflow.js";
 
 const MIGRATIONS_DIR = join(import.meta.dirname, "..", "migrations");
+const PYTHON_MIGRATIONS_DIR = join(import.meta.dirname, "..", "..", "autocontext", "migrations");
+
+function columnNames(db: Database.Database, tableName: string): Set<string> {
+  return new Set(
+    (db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>).map(
+      (row) => row.name,
+    ),
+  );
+}
 
 describe("storage migration workflow", () => {
   let dir: string;
@@ -68,6 +77,49 @@ describe("storage migration workflow", () => {
     );
     for (const typescriptMigration of Object.keys(TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES)) {
       expect(appliedTypescript.has(typescriptMigration)).toBe(true);
+    }
+  });
+
+  it("reconciles partial Python baselines before seeding their ledger rows", () => {
+    db.exec(
+      `CREATE TABLE schema_migrations (
+         version TEXT PRIMARY KEY,
+         applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+       )`,
+    );
+    const insert = db.prepare("INSERT INTO schema_migrations(version) VALUES (?)");
+    for (const pythonMigration of [
+      "001_initial.sql",
+      "002_phase3_phase7.sql",
+      "003_agent_subagent_metadata.sql",
+      "004_knowledge_inheritance.sql",
+      "005_ecosystem_provider_tracking.sql",
+    ]) {
+      db.exec(readFileSync(join(PYTHON_MIGRATIONS_DIR, pythonMigration), "utf8"));
+      insert.run(pythonMigration);
+    }
+
+    migrateDatabase(db, MIGRATIONS_DIR);
+
+    expect(Array.from(columnNames(db, "generations"))).toEqual(
+      expect.arrayContaining([
+        "duration_seconds",
+        "dimension_summary_json",
+        "scoring_backend",
+        "rating_uncertainty",
+      ]),
+    );
+    expect(Array.from(columnNames(db, "matches"))).toEqual(
+      expect.arrayContaining(["winner", "strategy_json", "replay_json"]),
+    );
+
+    const appliedPython = new Set(
+      (db.prepare("SELECT version FROM schema_migrations").all() as Array<{ version: string }>).map(
+        (row) => row.version,
+      ),
+    );
+    for (const pythonMigration of TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES["009_generation_loop.sql"]) {
+      expect(appliedPython.has(pythonMigration)).toBe(true);
     }
   });
 });

--- a/ts/tests/storage-migration-workflow.test.ts
+++ b/ts/tests/storage-migration-workflow.test.ts
@@ -4,7 +4,10 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { migrateDatabase } from "../src/storage/storage-migration-workflow.js";
+import {
+  migrateDatabase,
+  TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES,
+} from "../src/storage/storage-migration-workflow.js";
 
 const MIGRATIONS_DIR = join(import.meta.dirname, "..", "migrations");
 
@@ -29,5 +32,42 @@ describe("storage migration workflow", () => {
     const versions = db.prepare("SELECT filename FROM schema_version ORDER BY filename").all() as Array<{ filename: string }>;
     expect(versions.length).toBeGreaterThan(0);
     expect(new Set(versions.map((row) => row.filename)).size).toBe(versions.length);
+  });
+
+  it("seeds the Python migration ledger for shared TypeScript baselines", () => {
+    migrateDatabase(db, MIGRATIONS_DIR);
+
+    const appliedPython = new Set(
+      (db.prepare("SELECT version FROM schema_migrations").all() as Array<{ version: string }>).map(
+        (row) => row.version,
+      ),
+    );
+    for (const pythonMigration of Object.values(TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES).flat()) {
+      expect(appliedPython.has(pythonMigration)).toBe(true);
+    }
+  });
+
+  it("marks TypeScript migrations applied when Python already owns the equivalent schema", () => {
+    db.exec(
+      `CREATE TABLE schema_migrations (
+         version TEXT PRIMARY KEY,
+         applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+       )`,
+    );
+    const insert = db.prepare("INSERT INTO schema_migrations(version) VALUES (?)");
+    for (const pythonMigration of Object.values(TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES).flat()) {
+      insert.run(pythonMigration);
+    }
+
+    migrateDatabase(db, MIGRATIONS_DIR);
+
+    const appliedTypescript = new Set(
+      (db.prepare("SELECT filename FROM schema_version").all() as Array<{ filename: string }>).map(
+        (row) => row.filename,
+      ),
+    );
+    for (const typescriptMigration of Object.keys(TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES)) {
+      expect(appliedTypescript.has(typescriptMigration)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- create both runtime migration ledgers in TS/Python migration paths
- seed equivalent Python ledger rows from TS baselines and TS ledger rows from Python baselines
- expand the TS generation-loop baseline to include the Python tables it claims to consolidate
- make Python migration replay tolerate already-applied ADD COLUMN effects while still applying missing statements

## Linear
- AC-608

## Tests
- npx vitest run tests/storage-migration-workflow.test.ts
- uv run pytest tests/test_cross_runtime_migration_ledgers.py
- npm run lint
- uv run ruff check src/autocontext/storage/sqlite_store.py src/autocontext/storage/bootstrap_schema.py src/autocontext/storage/migration_ledgers.py tests/test_cross_runtime_migration_ledgers.py
- uv run mypy src