### PR TITLE
Preserve install-salt identity invariant

### DIFF
--- a/autocontext/src/autocontext/integrations/_shared/__init__.py
+++ b/autocontext/src/autocontext/integrations/_shared/__init__.py
@@ -7,6 +7,7 @@ import or via re-exports from their own top-level module.
 Stability commitment: the surface exported here follows SemVer with the
 parent ``autocontext`` package. See ``STABILITY.md`` in this directory.
 """
+from autocontext.integrations._shared.identity import resolve_identity
 from autocontext.integrations._shared.session import (
     autocontext_session,
     current_session,
@@ -18,4 +19,5 @@ __all__ = [
     "TraceSink",
     "autocontext_session",
     "current_session",
+    "resolve_identity",
 ]

--- a/autocontext/src/autocontext/integrations/_shared/identity.py
+++ b/autocontext/src/autocontext/integrations/_shared/identity.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from autocontext.integrations._shared.session import current_session
+from autocontext.production_traces.hashing import (
+    hash_session_id,
+    hash_user_id,
+    load_install_salt,
+)
+
+
+def resolve_identity(
+    per_call: Mapping[str, Any] | None,
+    *,
+    cwd: str | Path = ".",
+) -> dict[str, str]:
+    """Resolve and hash per-call or ambient identity when an install salt exists."""
+    raw: dict[str, str] = {}
+    if per_call:
+        if per_call.get("user_id") is not None:
+            raw["user_id"] = str(per_call["user_id"])
+        if per_call.get("session_id") is not None:
+            raw["session_id"] = str(per_call["session_id"])
+    if not raw:
+        raw = current_session()
+    if not raw:
+        return {}
+
+    salt = load_install_salt(cwd)
+    if not salt:
+        return {}
+
+    hashed: dict[str, str] = {}
+    if raw.get("user_id"):
+        hashed["user_id_hash"] = hash_user_id(raw["user_id"], salt)
+    if raw.get("session_id"):
+        hashed["session_id_hash"] = hash_session_id(raw["session_id"], salt)
+    return hashed

--- a/autocontext/src/autocontext/integrations/anthropic/_proxy.py
+++ b/autocontext/src/autocontext/integrations/anthropic/_proxy.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from ulid import ULID
 
-from autocontext.integrations._shared.session import current_session
+from autocontext.integrations._shared.identity import resolve_identity
 from autocontext.integrations._shared.sink import TraceSink
 from autocontext.integrations.anthropic._taxonomy import map_exception_to_reason
 from autocontext.integrations.anthropic._trace_builder import (
@@ -16,11 +16,6 @@ from autocontext.integrations.anthropic._trace_builder import (
     build_request_snapshot,
     build_success_trace,
     finalize_streaming_trace,
-)
-from autocontext.production_traces.hashing import (
-    hash_session_id,
-    hash_user_id,
-    load_install_salt,
 )
 
 _WRAPPED_SENTINEL = "__autocontext_wrapped__"
@@ -37,26 +32,6 @@ def _is_async_client(client: Any) -> bool:
     except ImportError:
         pass
     return type(client).__name__.startswith("Async")
-
-
-def _resolve_identity(per_call: dict[str, Any] | None) -> dict[str, str]:
-    raw: dict[str, str] = {}
-    if per_call:
-        if "user_id" in per_call and per_call["user_id"] is not None:
-            raw["user_id"] = per_call["user_id"]
-        if "session_id" in per_call and per_call["session_id"] is not None:
-            raw["session_id"] = per_call["session_id"]
-    if not raw:
-        raw = dict(current_session())
-    if not raw:
-        return {}
-    salt = load_install_salt(".") or ""
-    hashed: dict[str, str] = {}
-    if "user_id" in raw:
-        hashed["user_id_hash"] = hash_user_id(raw["user_id"], salt)
-    if "session_id" in raw:
-        hashed["session_id_hash"] = hash_session_id(raw["session_id"], salt)
-    return hashed
 
 
 def _response_usage_and_content(response: Any) -> tuple[dict[str, Any] | None, list[dict[str, Any]], str | None]:
@@ -126,7 +101,7 @@ class ClientProxy:
 
     def _invoke_non_streaming(self, *, kwargs: dict[str, Any]) -> Any:
         per_call = kwargs.pop("autocontext", None)
-        identity = _resolve_identity(per_call)
+        identity = resolve_identity(per_call)
         request_snapshot = build_request_snapshot(
             model=kwargs.get("model", ""),
             messages=kwargs.get("messages", []),
@@ -171,7 +146,7 @@ class ClientProxy:
 
     async def _invoke_non_streaming_async(self, *, kwargs: dict[str, Any]) -> Any:
         per_call = kwargs.pop("autocontext", None)
-        identity = _resolve_identity(per_call)
+        identity = resolve_identity(per_call)
         request_snapshot = build_request_snapshot(
             model=kwargs.get("model", ""),
             messages=kwargs.get("messages", []),
@@ -217,7 +192,7 @@ class ClientProxy:
     def _invoke_streaming(self, *, kwargs: dict[str, Any]) -> Any:
         from autocontext.integrations.anthropic._stream import StreamProxy  # noqa: PLC0415
         per_call = kwargs.pop("autocontext", None)
-        identity = _resolve_identity(per_call)
+        identity = resolve_identity(per_call)
         request_snapshot = build_request_snapshot(
             model=kwargs.get("model", ""),
             messages=kwargs.get("messages", []),
@@ -253,7 +228,7 @@ class ClientProxy:
         from autocontext.integrations.anthropic._stream import HelperStreamManagerProxy  # noqa: PLC0415
 
         per_call = kwargs.pop("autocontext", None)
-        identity = _resolve_identity(per_call)
+        identity = resolve_identity(per_call)
         request_snapshot = build_request_snapshot(
             model=kwargs.get("model", ""),
             messages=kwargs.get("messages", []),
@@ -329,7 +304,7 @@ class ClientProxy:
 
         from autocontext.integrations.anthropic._stream import AsyncStreamProxy  # noqa: PLC0415
         per_call = kwargs.pop("autocontext", None)
-        identity = _resolve_identity(per_call)
+        identity = resolve_identity(per_call)
         request_snapshot = build_request_snapshot(
             model=kwargs.get("model", ""),
             messages=kwargs.get("messages", []),
@@ -372,7 +347,7 @@ class ClientProxy:
         from autocontext.integrations.anthropic._stream import AsyncHelperStreamManagerProxy  # noqa: PLC0415
 
         per_call = kwargs.pop("autocontext", None)
-        identity = _resolve_identity(per_call)
+        identity = resolve_identity(per_call)
         request_snapshot = build_request_snapshot(
             model=kwargs.get("model", ""),
             messages=kwargs.get("messages", []),

--- a/autocontext/src/autocontext/integrations/openai/_proxy.py
+++ b/autocontext/src/autocontext/integrations/openai/_proxy.py
@@ -16,18 +16,13 @@ from typing import Any
 
 from ulid import ULID
 
-from autocontext.integrations.openai._session import current_session
+from autocontext.integrations._shared.identity import resolve_identity
 from autocontext.integrations.openai._sink import TraceSink
 from autocontext.integrations.openai._taxonomy import map_exception_to_reason
 from autocontext.integrations.openai._trace_builder import (
     build_failure_trace,
     build_request_snapshot,
     build_success_trace,
-)
-from autocontext.production_traces.hashing import (
-    hash_session_id,
-    hash_user_id,
-    load_install_salt,
 )
 
 
@@ -46,27 +41,6 @@ _WRAPPED_SENTINEL = "__autocontext_wrapped__"
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
-
-
-def _resolve_identity(per_call: dict[str, Any] | None) -> dict[str, str]:
-    """Per-call kwarg wins → ambient contextvar → empty."""
-    raw: dict[str, str] = {}
-    if per_call:
-        if "user_id" in per_call and per_call["user_id"] is not None:
-            raw["user_id"] = per_call["user_id"]
-        if "session_id" in per_call and per_call["session_id"] is not None:
-            raw["session_id"] = per_call["session_id"]
-    if not raw:
-        raw = dict(current_session())
-    if not raw:
-        return {}
-    salt = load_install_salt(".") or ""
-    hashed: dict[str, str] = {}
-    if "user_id" in raw:
-        hashed["user_id_hash"] = hash_user_id(raw["user_id"], salt)
-    if "session_id" in raw:
-        hashed["session_id_hash"] = hash_session_id(raw["session_id"], salt)
-    return hashed
 
 
 class _ChatCompletionsProxy:
@@ -178,7 +152,7 @@ class ClientProxy:
         per_call = kwargs.pop("autocontext", None)
         if kwargs.get("stream", False):
             raise NotImplementedError("streaming not yet wired")
-        identity = _resolve_identity(per_call)
+        identity = resolve_identity(per_call)
         request_snapshot = build_request_snapshot(
             model=kwargs.get("model", ""),
             messages=kwargs.get("messages", []),
@@ -231,7 +205,7 @@ class ClientProxy:
         normalized_messages: list[dict[str, Any]],
     ) -> Any:
         per_call = kwargs.pop("autocontext", None)
-        identity = _resolve_identity(per_call)
+        identity = resolve_identity(per_call)
         model = kwargs.get("model", "")
         request_snapshot = build_request_snapshot(
             model=model,
@@ -283,7 +257,7 @@ class ClientProxy:
         per_call = kwargs.pop("autocontext", None)
         if kwargs.get("stream", False):
             raise NotImplementedError("async streaming wired in Task 2.8")
-        identity = _resolve_identity(per_call)
+        identity = resolve_identity(per_call)
         request_snapshot = build_request_snapshot(
             model=kwargs.get("model", ""),
             messages=kwargs.get("messages", []),
@@ -336,7 +310,7 @@ class ClientProxy:
         normalized_messages: list[dict[str, Any]],
     ) -> Any:
         per_call = kwargs.pop("autocontext", None)
-        identity = _resolve_identity(per_call)
+        identity = resolve_identity(per_call)
         model = kwargs.get("model", "")
         request_snapshot = build_request_snapshot(
             model=model,
@@ -391,7 +365,7 @@ class ClientProxy:
         if "include_usage" not in stream_opts:
             stream_opts["include_usage"] = True
             kwargs["stream_options"] = stream_opts
-        identity = _resolve_identity(per_call)
+        identity = resolve_identity(per_call)
         request_snapshot = build_request_snapshot(
             model=kwargs.get("model", ""),
             messages=kwargs.get("messages", []),
@@ -448,7 +422,7 @@ class ClientProxy:
         if "include_usage" not in stream_opts:
             stream_opts["include_usage"] = True
             kwargs["stream_options"] = stream_opts
-        identity = _resolve_identity(per_call)
+        identity = resolve_identity(per_call)
         request_snapshot = build_request_snapshot(
             model=kwargs.get("model", ""),
             messages=kwargs.get("messages", []),

--- a/autocontext/src/autocontext/production_traces/hashing.py
+++ b/autocontext/src/autocontext/production_traces/hashing.py
@@ -79,11 +79,13 @@ def hash_user_id(user_id: str, salt: str) -> str:
 
     Byte-identical to the TS ``hashValue(userId, salt)`` helper.
     """
+    _assert_non_empty_salt(salt)
     return hashlib.sha256((salt + user_id).encode("utf-8")).hexdigest()
 
 
 def hash_session_id(session_id: str, salt: str) -> str:
     """Same algorithm as :func:`hash_user_id`; semantic distinction at call site."""
+    _assert_non_empty_salt(salt)
     return hashlib.sha256((salt + session_id).encode("utf-8")).hexdigest()
 
 
@@ -101,6 +103,14 @@ def _write_salt(path: Path) -> str:
     except (OSError, NotImplementedError):  # pragma: no cover - Windows guard
         pass
     return salt
+
+
+def _assert_non_empty_salt(salt: str) -> None:
+    if not isinstance(salt, str) or len(salt) == 0:
+        raise ValueError(
+            "hashing salt must be a non-empty string; "
+            "use load_install_salt() or initialize_install_salt()"
+        )
 
 
 __all__ = [

--- a/autocontext/tests/integrations/test_shared_identity.py
+++ b/autocontext/tests/integrations/test_shared_identity.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from autocontext.integrations._shared.identity import resolve_identity
+from autocontext.integrations._shared.session import autocontext_session
+from autocontext.production_traces.hashing import initialize_install_salt
+
+
+def test_resolve_identity_skips_hashing_without_install_salt(tmp_path: Path) -> None:
+    identity = resolve_identity({"user_id": "user-123", "session_id": "session-abc"}, cwd=tmp_path)
+
+    assert identity == {}
+
+
+def test_resolve_identity_hashes_when_install_salt_exists(tmp_path: Path) -> None:
+    initialize_install_salt(tmp_path)
+
+    identity = resolve_identity({"user_id": "user-123", "session_id": "session-abc"}, cwd=tmp_path)
+
+    assert set(identity) == {"user_id_hash", "session_id_hash"}
+    assert identity["user_id_hash"] != identity["session_id_hash"]
+
+
+def test_resolve_identity_prefers_per_call_identity(tmp_path: Path) -> None:
+    initialize_install_salt(tmp_path)
+
+    with autocontext_session(user_id="ambient", session_id="ambient-session"):
+        explicit = resolve_identity({"user_id": "explicit", "session_id": "explicit-session"}, cwd=tmp_path)
+        ambient = resolve_identity(None, cwd=tmp_path)
+
+    assert explicit != ambient

--- a/autocontext/tests/test_production_traces_hashing.py
+++ b/autocontext/tests/test_production_traces_hashing.py
@@ -68,6 +68,15 @@ def test_hash_session_id_uses_same_algorithm_as_user_id() -> None:
     assert hash_session_id(value, salt) == hash_user_id(value, salt)
 
 
+def test_hash_helpers_reject_empty_salt() -> None:
+    from autocontext.production_traces.hashing import hash_session_id, hash_user_id
+
+    with pytest.raises(ValueError, match="salt"):
+        hash_user_id("user-123", "")
+    with pytest.raises(ValueError, match="salt"):
+        hash_session_id("session-abc", "")
+
+
 def test_hash_user_id_matches_ts_reference_output() -> None:
     """Cross-runtime byte-identical check.
 


### PR DESCRIPTION
## Summary
- add a shared provider identity resolver for Python integrations
- skip identity hashing when no install salt exists instead of hashing with an empty salt
- make Python hash helpers reject empty salts to match TypeScript behavior
- update OpenAI and Anthropic proxies to use the shared resolver

## Linear
- AC-609

## Tests
- uv run pytest tests/integrations/test_shared_identity.py tests/test_production_traces_hashing.py tests/integrations/openai/test_proxy_non_streaming.py tests/integrations/anthropic/test_proxy_non_streaming.py
- uv run ruff check src/autocontext/integrations/_shared src/autocontext/integrations/openai/_proxy.py src/autocontext/integrations/anthropic/_proxy.py src/autocontext/production_traces/hashing.py tests/integrations/test_shared_identity.py tests/test_production_traces_hashing.py
- uv run mypy src