### PR TITLE
Move CLI dispatch into command registry

### DIFF
--- a/ts/src/cli/command-registry.ts
+++ b/ts/src/cli/command-registry.ts
@@ -75,6 +75,7 @@ const COMMANDS: readonly CommandDescriptor[] = [
   { name: "logout", description: "Clear stored provider credentials", group: "primary", route: { kind: "no-db", command: "logout" } },
   { name: "providers", description: "List all known providers with auth status (JSON)", group: "primary", route: { kind: "no-db", command: "providers" } },
   { name: "models", description: "List available models for authenticated providers (JSON)", group: "primary", route: { kind: "no-db", command: "models" } },
+  { name: "mission", description: "Manage multi-step task missions", group: "primary", route: { kind: "db", command: "mission" } },
   { name: "campaign", description: "Manage multi-mission campaigns", group: "primary", route: { kind: "db", command: "campaign" } },
   { name: "tui", description: "Start interactive TUI (WebSocket server + Ink UI)", group: "primary", route: { kind: "db", command: "tui" } },
   { name: "judge", description: "One-shot evaluation of output against a rubric", group: "primary", route: { kind: "db", command: "judge" } },

--- a/ts/src/cli/command-registry.ts
+++ b/ts/src/cli/command-registry.ts
@@ -1,0 +1,147 @@
+type CommandGroup = "primary" | "control-plane" | "python-only";
+
+interface CommandDescriptor {
+  name: string;
+  description: string;
+  group: CommandGroup;
+  route: CliCommandRoute;
+  visible?: boolean;
+}
+
+export type NoDbCommandName =
+  | "init"
+  | "capabilities"
+  | "login"
+  | "whoami"
+  | "logout"
+  | "providers"
+  | "models"
+  | "train"
+  | "simulate"
+  | "investigate"
+  | "analyze"
+  | "blob"
+  | "production-traces"
+  | "instrument";
+
+export type DbCommandName =
+  | "mission"
+  | "campaign"
+  | "run"
+  | "list"
+  | "replay"
+  | "benchmark"
+  | "export"
+  | "export-training-data"
+  | "import-package"
+  | "new-scenario"
+  | "tui"
+  | "judge"
+  | "improve"
+  | "repl"
+  | "queue"
+  | "status"
+  | "serve"
+  | "mcp-serve";
+
+export type ControlPlaneCommandName =
+  | "candidate"
+  | "eval"
+  | "promotion"
+  | "registry"
+  | "emit-pr";
+
+export type CliCommandRoute =
+  | { kind: "no-db"; command: NoDbCommandName }
+  | { kind: "db"; command: DbCommandName }
+  | { kind: "control-plane"; command: ControlPlaneCommandName }
+  | { kind: "version"; command: "version" }
+  | { kind: "python-only"; command: string }
+  | { kind: "unknown"; command: string };
+
+const COMMANDS: readonly CommandDescriptor[] = [
+  { name: "init", description: "Scaffold project config and AGENTS guidance", group: "primary", route: { kind: "no-db", command: "init" } },
+  { name: "run", description: "Run generation loop for a scenario", group: "primary", route: { kind: "db", command: "run" } },
+  { name: "list", description: "List recent runs", group: "primary", route: { kind: "db", command: "list" } },
+  { name: "replay", description: "Print replay JSON for a generation", group: "primary", route: { kind: "db", command: "replay" } },
+  { name: "benchmark", description: "Run benchmark (multiple runs, aggregate stats)", group: "primary", route: { kind: "db", command: "benchmark" } },
+  { name: "export", description: "Export strategy package for a scenario", group: "primary", route: { kind: "db", command: "export" } },
+  { name: "export-training-data", description: "Export training data as JSONL", group: "primary", route: { kind: "db", command: "export-training-data" } },
+  { name: "import-package", description: "Import a strategy package from file", group: "primary", route: { kind: "db", command: "import-package" } },
+  { name: "new-scenario", description: "Create or scaffold a scenario", group: "primary", route: { kind: "db", command: "new-scenario" } },
+  { name: "capabilities", description: "Show available scenarios, providers, and features (JSON)", group: "primary", route: { kind: "no-db", command: "capabilities" } },
+  { name: "login", description: "Store provider credentials persistently", group: "primary", route: { kind: "no-db", command: "login" } },
+  { name: "whoami", description: "Show current auth status and provider", group: "primary", route: { kind: "no-db", command: "whoami" } },
+  { name: "logout", description: "Clear stored provider credentials", group: "primary", route: { kind: "no-db", command: "logout" } },
+  { name: "providers", description: "List all known providers with auth status (JSON)", group: "primary", route: { kind: "no-db", command: "providers" } },
+  { name: "models", description: "List available models for authenticated providers (JSON)", group: "primary", route: { kind: "no-db", command: "models" } },
+  { name: "campaign", description: "Manage multi-mission campaigns", group: "primary", route: { kind: "db", command: "campaign" } },
+  { name: "tui", description: "Start interactive TUI (WebSocket server + Ink UI)", group: "primary", route: { kind: "db", command: "tui" } },
+  { name: "judge", description: "One-shot evaluation of output against a rubric", group: "primary", route: { kind: "db", command: "judge" } },
+  { name: "improve", description: "Run multi-round improvement loop", group: "primary", route: { kind: "db", command: "improve" } },
+  { name: "repl", description: "Run a direct REPL-loop session", group: "primary", route: { kind: "db", command: "repl" } },
+  { name: "queue", description: "Add a task to the background runner queue", group: "primary", route: { kind: "db", command: "queue" } },
+  { name: "status", description: "Show queue status", group: "primary", route: { kind: "db", command: "status" } },
+  { name: "serve", description: "Start HTTP API server [--json]", group: "primary", route: { kind: "db", command: "serve" } },
+  { name: "train", description: "Train a distilled model from curated dataset (requires configured executor)", group: "primary", route: { kind: "no-db", command: "train" } },
+  { name: "simulate", description: "Run a plain-language simulation with sweeps and analysis", group: "primary", route: { kind: "no-db", command: "simulate" } },
+  { name: "investigate", description: "Run a plain-language investigation with evidence and hypotheses", group: "primary", route: { kind: "no-db", command: "investigate" } },
+  { name: "analyze", description: "Analyze and compare runs, simulations, investigations, and missions", group: "primary", route: { kind: "no-db", command: "analyze" } },
+  { name: "mcp-serve", description: "Start MCP server on stdio", group: "primary", route: { kind: "db", command: "mcp-serve" } },
+  { name: "version", description: "Show version", group: "primary", route: { kind: "version", command: "version" } },
+  { name: "blob", description: "Manage blob artifacts", group: "primary", route: { kind: "no-db", command: "blob" }, visible: false },
+  { name: "candidate", description: "Register/list/show/lineage/rollback control-plane artifacts", group: "control-plane", route: { kind: "control-plane", command: "candidate" } },
+  { name: "eval", description: "Attach/list EvalRuns on artifacts", group: "control-plane", route: { kind: "control-plane", command: "eval" } },
+  { name: "promotion", description: "Decide/apply/history for promotion transitions", group: "control-plane", route: { kind: "control-plane", command: "promotion" } },
+  { name: "registry", description: "Repair/validate/migrate the control-plane registry", group: "control-plane", route: { kind: "control-plane", command: "registry" } },
+  { name: "emit-pr", description: "Generate a promotion PR (or dry-run bundle) for a candidate", group: "control-plane", route: { kind: "control-plane", command: "emit-pr" } },
+  { name: "production-traces", description: "Ingest/list/show/stats/build-dataset/export/policy/rotate-salt/prune (Foundation A — AC-539)", group: "control-plane", route: { kind: "no-db", command: "production-traces" } },
+  { name: "instrument", description: "Scan a repo for LLM clients and propose/apply Autocontext wrappers (A2-I — AC-540)", group: "control-plane", route: { kind: "no-db", command: "instrument" } },
+  { name: "ecosystem", description: "", group: "python-only", route: { kind: "python-only", command: "ecosystem" } },
+  { name: "ab-test", description: "", group: "python-only", route: { kind: "python-only", command: "ab-test" } },
+  { name: "resume", description: "", group: "python-only", route: { kind: "python-only", command: "resume" } },
+  { name: "wait", description: "", group: "python-only", route: { kind: "python-only", command: "wait" } },
+  { name: "trigger-distillation", description: "", group: "python-only", route: { kind: "python-only", command: "trigger-distillation" } },
+];
+
+const COMMAND_ROUTE_BY_NAME = new Map(COMMANDS.map((command) => [command.name, command.route]));
+
+export function resolveCliCommand(command: string): CliCommandRoute {
+  return COMMAND_ROUTE_BY_NAME.get(command) ?? { kind: "unknown", command };
+}
+
+export function buildCliHelp(): string {
+  return `
+autoctx — always-on agent evaluation harness
+
+Commands:
+${formatCommandList("primary")}
+
+Control plane (Layer 7-9):
+${formatCommandList("control-plane")}
+
+Python-only commands (not supported in npm package):
+  ${visibleCommands("python-only").map((command) => command.name).join(", ")}
+
+Run \`autoctx <command> --help\` for command-specific options.
+
+Install: npm install -g autoctx
+Note: The npm package is \`autoctx\`, not \`autocontext\` (different package).
+`.trim();
+}
+
+export function visibleCommandNames(): string[] {
+  return COMMANDS.filter((command) => command.visible !== false).map((command) => command.name);
+}
+
+function visibleCommands(group: CommandGroup): CommandDescriptor[] {
+  return COMMANDS.filter((command) => command.group === group && command.visible !== false);
+}
+
+function formatCommandList(group: CommandGroup): string {
+  const commands = visibleCommands(group);
+  const width = Math.max(...commands.map((command) => command.name.length)) + 2;
+  return commands
+    .map((command) => `  ${command.name.padEnd(width)}${command.description}`)
+    .join("\n");
+}

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -15,6 +15,13 @@
 import { parseArgs } from "node:util";
 import { resolve, join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  buildCliHelp,
+  resolveCliCommand,
+  type ControlPlaneCommandName,
+  type DbCommandName,
+  type NoDbCommandName,
+} from "./command-registry.js";
 import { emitEngineResult } from "./emit-engine-result.js";
 import type { CampaignStatus } from "../mission/campaign.js";
 
@@ -23,57 +30,45 @@ function getMigrationsDir(): string {
   return join(thisDir, "..", "..", "migrations");
 }
 
-const HELP = `
-autoctx — always-on agent evaluation harness
+const HELP = buildCliHelp();
 
-Commands:
-  init             Scaffold project config and AGENTS guidance
-  run              Run generation loop for a scenario
-  list             List recent runs
-  replay           Print replay JSON for a generation
-  benchmark        Run benchmark (multiple runs, aggregate stats)
-  export           Export strategy package for a scenario
-  export-training-data  Export training data as JSONL
-  import-package   Import a strategy package from file
-  new-scenario     Create or scaffold a scenario
-  capabilities     Show available scenarios, providers, and features (JSON)
-  login            Store provider credentials persistently
-  whoami           Show current auth status and provider
-  logout           Clear stored provider credentials
-  providers        List all known providers with auth status (JSON)
-  models           List available models for authenticated providers (JSON)
-  campaign         Manage multi-mission campaigns
-  tui              Start interactive TUI (WebSocket server + Ink UI)
-  judge            One-shot evaluation of output against a rubric
-  improve          Run multi-round improvement loop
-  repl             Run a direct REPL-loop session
-  queue            Add a task to the background runner queue
-  status           Show queue status
-  serve            Start HTTP API server [--json]
-  train            Train a distilled model from curated dataset (requires configured executor)
-  simulate         Run a plain-language simulation with sweeps and analysis
-  investigate      Run a plain-language investigation with evidence and hypotheses
-  analyze          Analyze and compare runs, simulations, investigations, and missions
-  mcp-serve        Start MCP server on stdio
-  version          Show version
+const NO_DB_COMMAND_HANDLERS: Record<NoDbCommandName, () => Promise<void>> = {
+  init: cmdInit,
+  capabilities: cmdCapabilities,
+  login: cmdLogin,
+  whoami: cmdWhoami,
+  logout: cmdLogout,
+  providers: cmdProviders,
+  models: cmdModels,
+  train: cmdTrain,
+  simulate: cmdSimulate,
+  investigate: cmdInvestigate,
+  analyze: cmdAnalyze,
+  blob: cmdBlob,
+  "production-traces": cmdProductionTraces,
+  instrument: cmdInstrument,
+};
 
-Control plane (Layer 7-9):
-  candidate        Register/list/show/lineage/rollback control-plane artifacts
-  eval             Attach/list EvalRuns on artifacts
-  promotion        Decide/apply/history for promotion transitions
-  registry         Repair/validate/migrate the control-plane registry
-  emit-pr          Generate a promotion PR (or dry-run bundle) for a candidate
-  production-traces Ingest/list/show/stats/build-dataset/export/policy/rotate-salt/prune (Foundation A — AC-539)
-  instrument       Scan a repo for LLM clients and propose/apply Autocontext wrappers (A2-I — AC-540)
-
-Python-only commands (not supported in npm package):
-  ecosystem, ab-test, resume, wait, trigger-distillation
-
-Run \`autoctx <command> --help\` for command-specific options.
-
-Install: npm install -g autoctx
-Note: The npm package is \`autoctx\`, not \`autocontext\` (different package).
-`.trim();
+const DB_COMMAND_HANDLERS: Record<DbCommandName, (dbPath: string) => Promise<void>> = {
+  mission: cmdMission,
+  campaign: cmdCampaign,
+  run: cmdRun,
+  list: cmdList,
+  replay: cmdReplay,
+  benchmark: cmdBenchmark,
+  export: cmdExport,
+  "export-training-data": cmdExportTrainingData,
+  "import-package": cmdImportPackage,
+  "new-scenario": cmdNewScenario,
+  tui: cmdTui,
+  judge: cmdJudge,
+  improve: cmdImprove,
+  repl: cmdRepl,
+  queue: cmdQueue,
+  status: cmdStatus,
+  serve: cmdServeHttp,
+  "mcp-serve": cmdMcpServe,
+};
 
 async function main(): Promise<void> {
   const command = process.argv[2];
@@ -97,118 +92,36 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  if (command === "version" || command === "--version") {
+  if (command === "--version") {
     const pkg = await import("../../package.json", { with: { type: "json" } });
     console.log(pkg.default.version);
     process.exit(0);
   }
 
-  switch (command) {
-    case "init":
-      await cmdInit();
+  const route = resolveCliCommand(command);
+  switch (route.kind) {
+    case "version": {
+      const pkg = await import("../../package.json", { with: { type: "json" } });
+      console.log(pkg.default.version);
       break;
-    case "capabilities":
-      await cmdCapabilities();
+    }
+    case "no-db":
+      await NO_DB_COMMAND_HANDLERS[route.command]();
       break;
-    case "login":
-      await cmdLogin();
+    case "db":
+      await DB_COMMAND_HANDLERS[route.command](await getDbPath());
       break;
-    case "whoami":
-      await cmdWhoami();
+    case "control-plane":
+      await cmdControlPlane(route.command as ControlPlaneCommandName);
       break;
-    case "logout":
-      await cmdLogout();
-      break;
-    case "providers":
-      await cmdProviders();
-      break;
-    case "models":
-      await cmdModels();
-      break;
-    case "mission":
-      await cmdMission(await getDbPath());
-      break;
-    case "campaign":
-      await cmdCampaign(await getDbPath());
-      break;
-    case "run":
-      await cmdRun(await getDbPath());
-      break;
-    case "list":
-      await cmdList(await getDbPath());
-      break;
-    case "replay":
-      await cmdReplay(await getDbPath());
-      break;
-    case "benchmark":
-      await cmdBenchmark(await getDbPath());
-      break;
-    case "export":
-      await cmdExport(await getDbPath());
-      break;
-    case "export-training-data":
-      await cmdExportTrainingData(await getDbPath());
-      break;
-    case "import-package":
-      await cmdImportPackage(await getDbPath());
-      break;
-    case "new-scenario":
-      await cmdNewScenario(await getDbPath());
-      break;
-    case "tui":
-      await cmdTui(await getDbPath());
-      break;
-    case "judge":
-      await cmdJudge(await getDbPath());
-      break;
-    case "improve":
-      await cmdImprove(await getDbPath());
-      break;
-    case "repl":
-      await cmdRepl(await getDbPath());
-      break;
-    case "queue":
-      await cmdQueue(await getDbPath());
-      break;
-    case "status":
-      await cmdStatus(await getDbPath());
-      break;
-    case "serve":
-      await cmdServeHttp(await getDbPath());
-      break;
-    case "mcp-serve":
-      await cmdMcpServe(await getDbPath());
-      break;
-    case "train":
-      await cmdTrain();
-      break;
-    case "simulate":
-      await cmdSimulate();
-      break;
-    case "investigate":
-      await cmdInvestigate();
-      break;
-    case "analyze":
-      await cmdAnalyze();
-      break;
-    case "blob":
-      await cmdBlob();
-      break;
-    case "candidate":
-    case "eval":
-    case "promotion":
-    case "registry":
-    case "emit-pr":
-      await cmdControlPlane(command);
-      break;
-    case "production-traces":
-      await cmdProductionTraces();
-      break;
-    case "instrument":
-      await cmdInstrument();
-      break;
-    default:
-      console.error(`Unknown command: ${command}\n`);
+    case "python-only":
+      console.error(
+        `${route.command} is only supported by the Python package, not the npm CLI.\n`,
+      );
+      console.log(HELP);
+      process.exit(1);
+    case "unknown":
+      console.error(`Unknown command: ${route.command}\n`);
       console.log(HELP);
       process.exit(1);
   }

--- a/ts/tests/cli-command-registry.test.ts
+++ b/ts/tests/cli-command-registry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCliHelp,
+  resolveCliCommand,
+  visibleCommandNames,
+} from "../src/cli/command-registry.js";
+
+describe("CLI command registry", () => {
+  it("keeps visible command metadata unique and present in help", () => {
+    const names = visibleCommandNames();
+    const help = buildCliHelp();
+
+    expect(new Set(names).size).toBe(names.length);
+    for (const name of names) {
+      expect(help).toContain(name);
+    }
+  });
+
+  it("classifies commands by dispatch surface", () => {
+    expect(resolveCliCommand("run")).toEqual({ kind: "db", command: "run" });
+    expect(resolveCliCommand("init")).toEqual({ kind: "no-db", command: "init" });
+    expect(resolveCliCommand("registry")).toEqual({
+      kind: "control-plane",
+      command: "registry",
+    });
+    expect(resolveCliCommand("ecosystem")).toEqual({
+      kind: "python-only",
+      command: "ecosystem",
+    });
+    expect(resolveCliCommand("definitely-not-real")).toEqual({
+      kind: "unknown",
+      command: "definitely-not-real",
+    });
+  });
+});

--- a/ts/tests/cli-command-registry.test.ts
+++ b/ts/tests/cli-command-registry.test.ts
@@ -19,6 +19,10 @@ describe("CLI command registry", () => {
 
   it("classifies commands by dispatch surface", () => {
     expect(resolveCliCommand("run")).toEqual({ kind: "db", command: "run" });
+    expect(resolveCliCommand("mission")).toEqual({
+      kind: "db",
+      command: "mission",
+    });
     expect(resolveCliCommand("init")).toEqual({ kind: "no-db", command: "init" });
     expect(resolveCliCommand("registry")).toEqual({
       kind: "control-plane",


### PR DESCRIPTION
## Summary
- add a CLI command descriptor registry for help metadata and route classification
- replace the top-level CLI switch with registry-driven handler maps
- keep hidden/internal and Python-only command metadata explicit
- add registry tests so help and dispatch stay in sync

## Linear
- AC-610

## Tests
- npx vitest run tests/cli-command-registry.test.ts tests/cli-dx.test.ts
- npm run lint