### PR TITLE
Share scenario family designer parsing

### DIFF
--- a/ts/src/scenarios/agent-task-designer.ts
+++ b/ts/src/scenarios/agent-task-designer.ts
@@ -5,10 +5,22 @@
 
 import type { AgentTaskSpec } from "./agent-task-spec.js";
 import { parseRawSpec } from "./agent-task-spec.js";
-import { healSpec } from "./spec-auto-heal.js";
+import {
+  designFamilySpec,
+  parseFamilyDesignerSpec,
+  type FamilyDesignerDescriptor,
+} from "./family-designer.js";
 
 export const SPEC_START = "<!-- AGENT_TASK_SPEC_START -->";
 export const SPEC_END = "<!-- AGENT_TASK_SPEC_END -->";
+
+const AGENT_TASK_DESCRIPTOR: FamilyDesignerDescriptor<AgentTaskSpec> = {
+  family: "agent_task",
+  startDelimiter: SPEC_START,
+  endDelimiter: SPEC_END,
+  missingDelimiterLabel: "AGENT_TASK_SPEC",
+  parseRaw: parseRawSpec,
+};
 
 const EXAMPLE_SPEC = {
   task_prompt:
@@ -107,14 +119,7 @@ Now design an agent task scenario for the user's description.
  * Parse an AgentTaskSpec from LLM response text containing delimiters.
  */
 export function parseAgentTaskSpec(text: string): AgentTaskSpec {
-  const startIdx = text.indexOf(SPEC_START);
-  const endIdx = text.indexOf(SPEC_END);
-  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
-    throw new Error("response does not contain AGENT_TASK_SPEC delimiters");
-  }
-  const raw = text.slice(startIdx + SPEC_START.length, endIdx).trim();
-  const data = healSpec(JSON.parse(raw) as Record<string, unknown>, "agent_task");
-  return parseRawSpec(data);
+  return parseFamilyDesignerSpec(text, AGENT_TASK_DESCRIPTOR);
 }
 
 /**
@@ -124,7 +129,10 @@ export async function designAgentTask(
   description: string,
   llmFn: (system: string, user: string) => Promise<string>,
 ): Promise<AgentTaskSpec> {
-  const userPrompt = `User description:\n${description}`;
-  const response = await llmFn(AGENT_TASK_DESIGNER_SYSTEM, userPrompt);
-  return parseAgentTaskSpec(response);
+  return designFamilySpec(
+    description,
+    AGENT_TASK_DESIGNER_SYSTEM,
+    AGENT_TASK_DESCRIPTOR,
+    llmFn,
+  );
 }

--- a/ts/src/scenarios/artifact-editing-designer.ts
+++ b/ts/src/scenarios/artifact-editing-designer.ts
@@ -1,9 +1,21 @@
 import type { ArtifactEditingSpec } from "./artifact-editing-spec.js";
 import { parseRawArtifactEditingSpec } from "./artifact-editing-spec.js";
-import { healSpec } from "./spec-auto-heal.js";
+import {
+  designFamilySpec,
+  parseFamilyDesignerSpec,
+  type FamilyDesignerDescriptor,
+} from "./family-designer.js";
 
 export const ARTIFACT_SPEC_START = "<!-- ARTIFACT_EDITING_SPEC_START -->";
 export const ARTIFACT_SPEC_END = "<!-- ARTIFACT_EDITING_SPEC_END -->";
+
+const ARTIFACT_EDITING_DESCRIPTOR: FamilyDesignerDescriptor<ArtifactEditingSpec> = {
+  family: "artifact_editing",
+  startDelimiter: ARTIFACT_SPEC_START,
+  endDelimiter: ARTIFACT_SPEC_END,
+  missingDelimiterLabel: "ARTIFACT_EDITING_SPEC",
+  parseRaw: parseRawArtifactEditingSpec,
+};
 
 const EXAMPLE_SPEC = {
   task_description: "Update a YAML service config to add a database section without changing unrelated settings.",
@@ -58,22 +70,17 @@ ${ARTIFACT_SPEC_END}
 `;
 
 export function parseArtifactEditingSpec(text: string): ArtifactEditingSpec {
-  const startIdx = text.indexOf(ARTIFACT_SPEC_START);
-  const endIdx = text.indexOf(ARTIFACT_SPEC_END);
-  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
-    throw new Error("response does not contain ARTIFACT_EDITING_SPEC delimiters");
-  }
-  const raw = text.slice(startIdx + ARTIFACT_SPEC_START.length, endIdx).trim();
-  return parseRawArtifactEditingSpec(
-    healSpec(JSON.parse(raw) as Record<string, unknown>, "artifact_editing"),
-  );
+  return parseFamilyDesignerSpec(text, ARTIFACT_EDITING_DESCRIPTOR);
 }
 
 export async function designArtifactEditing(
   description: string,
   llmFn: (system: string, user: string) => Promise<string>,
 ): Promise<ArtifactEditingSpec> {
-  return parseArtifactEditingSpec(
-    await llmFn(ARTIFACT_EDITING_DESIGNER_SYSTEM, `User description:\n${description}`),
+  return designFamilySpec(
+    description,
+    ARTIFACT_EDITING_DESIGNER_SYSTEM,
+    ARTIFACT_EDITING_DESCRIPTOR,
+    llmFn,
   );
 }

--- a/ts/src/scenarios/family-designer.ts
+++ b/ts/src/scenarios/family-designer.ts
@@ -1,0 +1,35 @@
+import { parseDelimitedJsonObject } from "./llm-json-response.js";
+import { healSpec } from "./spec-auto-heal.js";
+
+export interface FamilyDesignerDescriptor<TSpec> {
+  family: string;
+  startDelimiter: string;
+  endDelimiter: string;
+  missingDelimiterLabel: string;
+  parseRaw: (raw: Record<string, unknown>) => TSpec;
+}
+
+export function parseFamilyDesignerSpec<TSpec>(
+  text: string,
+  descriptor: FamilyDesignerDescriptor<TSpec>,
+): TSpec {
+  const raw = parseDelimitedJsonObject({
+    text,
+    startDelimiter: descriptor.startDelimiter,
+    endDelimiter: descriptor.endDelimiter,
+    missingDelimiterLabel: descriptor.missingDelimiterLabel,
+  });
+  return descriptor.parseRaw(healSpec(raw, descriptor.family));
+}
+
+export async function designFamilySpec<TSpec>(
+  description: string,
+  systemPrompt: string,
+  descriptor: FamilyDesignerDescriptor<TSpec>,
+  llmFn: (system: string, user: string) => Promise<string>,
+): Promise<TSpec> {
+  return parseFamilyDesignerSpec(
+    await llmFn(systemPrompt, `User description:\n${description}`),
+    descriptor,
+  );
+}

--- a/ts/src/scenarios/tool-fragility-designer.ts
+++ b/ts/src/scenarios/tool-fragility-designer.ts
@@ -1,9 +1,21 @@
 import type { ToolFragilitySpec } from "./tool-fragility-spec.js";
 import { parseRawToolFragilitySpec } from "./tool-fragility-spec.js";
-import { healSpec } from "./spec-auto-heal.js";
+import {
+  designFamilySpec,
+  parseFamilyDesignerSpec,
+  type FamilyDesignerDescriptor,
+} from "./family-designer.js";
 
 export const TOOL_FRAGILITY_SPEC_START = "<!-- TOOL_FRAGILITY_SPEC_START -->";
 export const TOOL_FRAGILITY_SPEC_END = "<!-- TOOL_FRAGILITY_SPEC_END -->";
+
+const TOOL_FRAGILITY_DESCRIPTOR: FamilyDesignerDescriptor<ToolFragilitySpec> = {
+  family: "tool_fragility",
+  startDelimiter: TOOL_FRAGILITY_SPEC_START,
+  endDelimiter: TOOL_FRAGILITY_SPEC_END,
+  missingDelimiterLabel: "TOOL_FRAGILITY_SPEC",
+  parseRaw: parseRawToolFragilitySpec,
+};
 
 const EXAMPLE_SPEC = {
   description: "API contracts drift during a data processing pipeline.",
@@ -83,22 +95,17 @@ ${TOOL_FRAGILITY_SPEC_END}
 `;
 
 export function parseToolFragilitySpec(text: string): ToolFragilitySpec {
-  const startIdx = text.indexOf(TOOL_FRAGILITY_SPEC_START);
-  const endIdx = text.indexOf(TOOL_FRAGILITY_SPEC_END);
-  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
-    throw new Error("response does not contain TOOL_FRAGILITY_SPEC delimiters");
-  }
-  const raw = text.slice(startIdx + TOOL_FRAGILITY_SPEC_START.length, endIdx).trim();
-  return parseRawToolFragilitySpec(
-    healSpec(JSON.parse(raw) as Record<string, unknown>, "tool_fragility"),
-  );
+  return parseFamilyDesignerSpec(text, TOOL_FRAGILITY_DESCRIPTOR);
 }
 
 export async function designToolFragility(
   description: string,
   llmFn: (system: string, user: string) => Promise<string>,
 ): Promise<ToolFragilitySpec> {
-  return parseToolFragilitySpec(
-    await llmFn(TOOL_FRAGILITY_DESIGNER_SYSTEM, `User description:\n${description}`),
+  return designFamilySpec(
+    description,
+    TOOL_FRAGILITY_DESIGNER_SYSTEM,
+    TOOL_FRAGILITY_DESCRIPTOR,
+    llmFn,
   );
 }

--- a/ts/tests/agent-task-pipeline.test.ts
+++ b/ts/tests/agent-task-pipeline.test.ts
@@ -505,6 +505,16 @@ describe("Designer", () => {
     const spec = parseAgentTaskSpec(response);
     expect(spec.taskPrompt).toBe(SAMPLE_SPEC.taskPrompt);
   });
+
+  it("falls back to raw JSON when delimiters are missing", () => {
+    const spec = parseAgentTaskSpec(JSON.stringify({
+      task_prompt: SAMPLE_SPEC.taskPrompt,
+      judge_rubric: SAMPLE_SPEC.judgeRubric,
+      output_format: SAMPLE_SPEC.outputFormat,
+      judge_model: SAMPLE_SPEC.judgeModel,
+    }));
+    expect(spec.taskPrompt).toBe(SAMPLE_SPEC.taskPrompt);
+  });
 });
 
 describe("Validator", () => {


### PR DESCRIPTION
## Summary
- add a FamilyDesigner descriptor pipeline for delimiter parsing, JSON fallback, healing, and raw spec parsing
- route AgentTask, ArtifactEditing, and ToolFragility designers through the shared pipeline
- add regression coverage for AgentTask delimiter-free JSON fallback

## Linear
- AC-612

## Tests
- npx vitest run tests/agent-task-pipeline.test.ts tests/spec-auto-heal.test.ts tests/spec-auto-heal-agent-task-workflow.test.ts
- npm run lint