### PR TITLE
Enforce concept model parity

### DIFF
--- a/autocontext/src/autocontext/concepts.py
+++ b/autocontext/src/autocontext/concepts.py
@@ -32,8 +32,8 @@ _CONCEPT_MODEL: dict[str, Any] = {
             "description": (
                 "A planned grouping of missions, runs, and scenarios used to "
                 "coordinate broader work over time. Partial support exists "
-                "today through TypeScript CLI/API/MCP surfaces; the Python "
-                "package does not expose campaign workflows yet."
+                "today through TypeScript CLI/API/MCP surfaces; there is not "
+                "yet a Python package campaign workflow."
             ),
             "status": "partial",
         },

--- a/autocontext/tests/test_concept_model_parity.py
+++ b/autocontext/tests/test_concept_model_parity.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autocontext.concepts import get_concept_model
+
+
+def test_concept_model_matches_shared_artifact() -> None:
+    shared_model = json.loads(
+        (Path(__file__).resolve().parents[2] / "docs" / "concept-model.json").read_text(encoding="utf-8")
+    )
+
+    assert get_concept_model() == shared_model

--- a/docs/concept-model.json
+++ b/docs/concept-model.json
@@ -1,0 +1,113 @@
+{
+  "version": 1,
+  "source_doc": "docs/concept-model.md",
+  "user_facing": [
+    {
+      "name": "Scenario",
+      "description": "A reusable environment, simulation, or evaluation context with stable rules and scoring.",
+      "status": "implemented"
+    },
+    {
+      "name": "Task",
+      "description": "A user-authored unit of work or prompt-centric objective that can be evaluated directly or embedded inside another surface.",
+      "status": "partial"
+    },
+    {
+      "name": "Mission",
+      "description": "A long-running goal advanced step by step until a verifier says it is complete.",
+      "status": "partial"
+    },
+    {
+      "name": "Campaign",
+      "description": "A planned grouping of missions, runs, and scenarios used to coordinate broader work over time. Partial support exists today through TypeScript CLI/API/MCP surfaces; there is not yet a Python package campaign workflow.",
+      "status": "partial"
+    }
+  ],
+  "runtime": [
+    {
+      "name": "Run",
+      "description": "A concrete execution instance of a Scenario or Task.",
+      "status": "implemented"
+    },
+    {
+      "name": "Step",
+      "description": "A bounded action taken while advancing a Mission or another long-running workflow.",
+      "status": "partial"
+    },
+    {
+      "name": "Verifier",
+      "description": "The runtime check that decides whether a mission, step, or output is acceptable.",
+      "status": "partial"
+    },
+    {
+      "name": "Artifact",
+      "description": "A persisted runtime output such as a replay, checkpoint, package, report, harness, or skill export.",
+      "status": "implemented"
+    },
+    {
+      "name": "Knowledge",
+      "description": "Persisted learned state that should carry forward across runs, such as playbooks, hints, lessons, and analysis.",
+      "status": "implemented"
+    },
+    {
+      "name": "Budget",
+      "description": "Constraints that bound runtime behavior, such as max steps, cost, time, or retries.",
+      "status": "partial"
+    },
+    {
+      "name": "Policy",
+      "description": "Structured rules that constrain or guide runtime behavior, such as escalation, hint volume, cost, conflict, or harness policies.",
+      "status": "partial"
+    }
+  ],
+  "mappings": [
+    {
+      "surface": "run",
+      "canonical_concept": "Run",
+      "category": "operation",
+      "notes": "CLI and MCP keep the verb, but the underlying runtime noun is Run."
+    },
+    {
+      "surface": "task queue / TaskRow",
+      "canonical_concept": "Task",
+      "category": "runtime_job",
+      "notes": "Represents background evaluation jobs today, not the canonical user-facing Task concept."
+    },
+    {
+      "surface": "AgentTask / AgentTaskSpec",
+      "canonical_concept": "Task",
+      "category": "internal_type",
+      "notes": "Current prompt-centric Task implementation."
+    },
+    {
+      "surface": "solve",
+      "canonical_concept": "Run",
+      "category": "operation",
+      "notes": "Solve is a workflow that creates or selects a scenario/task, launches a run, and exports resulting knowledge."
+    },
+    {
+      "surface": "sandbox",
+      "canonical_concept": "Policy",
+      "category": "runtime_boundary",
+      "notes": "Sandboxing is runtime isolation around execution, not a peer product noun."
+    },
+    {
+      "surface": "replay",
+      "canonical_concept": "Artifact",
+      "category": "artifact",
+      "notes": "A replay is an artifact view over a run or generation."
+    },
+    {
+      "surface": "playbook",
+      "canonical_concept": "Knowledge",
+      "category": "artifact",
+      "notes": "A playbook is one kind of knowledge artifact."
+    },
+    {
+      "surface": "artifacts",
+      "canonical_concept": "Artifact",
+      "category": "collection",
+      "notes": "Collection term for runtime outputs."
+    }
+  ]
+}

--- a/docs/concept-model.md
+++ b/docs/concept-model.md
@@ -26,8 +26,8 @@ These are the nouns we should prefer in docs, APIs, and product copy when descri
 | Concept | Definition | Current status |
 | --- | --- | --- |
 | `Scenario` | A reusable environment, simulation, or evaluation context with stable rules and scoring. | Implemented across Python, TypeScript, CLI, MCP, API/TUI surfaces, and docs. |
-| `Task` | A user-authored unit of work or prompt-centric objective that can be evaluated directly or embedded inside another surface. | Implemented, but overloaded. |
-| `Mission` | A long-running goal advanced step by step until a verifier says it is complete. | Implemented in TypeScript CLI/MCP/API/TUI surfaces. |
+| `Task` | A user-authored unit of work or prompt-centric objective that can be evaluated directly or embedded inside another surface. | Partial: prompt-centric task support exists, but the name is still overloaded across agent-task specs, queued runtime jobs, and generic prompts. |
+| `Mission` | A long-running goal advanced step by step until a verifier says it is complete. | Partial: implemented in TypeScript CLI/MCP/API/TUI surfaces, but not yet a shared Python package concept. |
 | `Campaign` | A planned grouping of missions, runs, and/or scenarios used to coordinate broader work over time. | Partially implemented through TypeScript CLI/API/MCP surfaces. Not yet a Python package surface. |
 
 ### Runtime concepts
@@ -37,12 +37,12 @@ These are the execution nouns we should use when describing how the system actua
 | Concept | Definition | Current status |
 | --- | --- | --- |
 | `Run` | A concrete execution instance of a `Scenario` or `Task`. | Implemented broadly. |
-| `Step` | A bounded action taken while advancing a `Mission` or another long-running workflow. | Implemented for missions. |
-| `Verifier` | The runtime check that decides whether a mission, step, or output is acceptable. | Implemented for missions and several evaluation flows. |
+| `Step` | A bounded action taken while advancing a `Mission` or another long-running workflow. | Partial: implemented for missions, but not yet generalized across every long-running workflow. |
+| `Verifier` | The runtime check that decides whether a mission, step, or output is acceptable. | Partial: implemented for missions and several evaluation flows, but not yet a unified runtime concept. |
 | `Artifact` | A persisted runtime output such as a replay, checkpoint, package, report, harness, or skill export. | Implemented broadly. |
 | `Knowledge` | Persisted learned state that should carry forward across runs, such as playbooks, hints, lessons, and analysis. | Implemented broadly. |
-| `Budget` | Constraints that bound runtime behavior, such as max steps, cost, time, or retries. | Implemented in several places, but not yet described consistently. |
-| `Policy` | Structured rules that constrain or guide runtime behavior, such as escalation, hint volume, cost, conflict, or harness policies. | Implemented in pockets, but not yet presented as one concept. |
+| `Budget` | Constraints that bound runtime behavior, such as max steps, cost, time, or retries. | Partial: implemented in several places, but not yet described consistently. |
+| `Policy` | Structured rules that constrain or guide runtime behavior, such as escalation, hint volume, cost, conflict, or harness policies. | Partial: implemented in pockets, but not yet presented as one concept. |
 
 ## Relationship Model
 

--- a/ts/src/concepts/model.ts
+++ b/ts/src/concepts/model.ts
@@ -1,7 +1,7 @@
 /**
  * Canonical concept model metadata for capability discovery.
  *
- * Keep this aligned with docs/concept-model.md.
+ * Keep this exact with docs/concept-model.json.
  */
 
 export type ConceptStatus = "implemented" | "partial" | "reserved";

--- a/ts/tests/concept-model-parity.test.ts
+++ b/ts/tests/concept-model-parity.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { getConceptModel } from "../src/concepts/model.js";
+
+describe("concept model parity", () => {
+  it("matches the shared machine-readable concept model", () => {
+    const sharedModel = JSON.parse(
+      readFileSync(
+        join(import.meta.dirname, "..", "..", "docs", "concept-model.json"),
+        "utf-8",
+      ),
+    );
+
+    expect(getConceptModel()).toEqual(sharedModel);
+  });
+});


### PR DESCRIPTION
## Summary
- add docs/concept-model.json as the machine-readable concept model artifact
- align the Python concept prose with the shared artifact
- add exact TS and Python parity tests against the shared concept model

## Linear
- AC-613

## Tests
- npx vitest run tests/concept-model-parity.test.ts tests/campaign-surfaces.test.ts
- npm run lint
- uv run pytest tests/test_concept_model_parity.py
- uv run ruff check src/autocontext/concepts.py tests/test_concept_model_parity.py
- uv run mypy src