### PR TITLE
docs: update CHANGELOG and READMEs through 0.4.5 + current unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Provider proxy runtime plumbing centralized into a shared `_shared/proxy-runtime` module so Anthropic and OpenAI integration proxies share consistent lifecycle and error handling (AC-611).
+- TypeScript scenario family designers now share response parsing across agent-task, artifact-editing, and tool-fragility families so generated specs preserve family-specific semantics (AC-612).
 - Install salt identity invariant preserved across process restarts (AC-609).
 - Cross-runtime migration ledger reconciliation so Python and TypeScript DBs stay aligned after schema divergence (AC-608).
 - CLI dispatch moved into a command registry so mission routes resolve correctly (AC-610).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Provider proxy runtime plumbing centralized into a shared `_shared/proxy-runtime` module so Anthropic and OpenAI integration proxies share consistent lifecycle and error handling (AC-611).
 - Install salt identity invariant preserved across process restarts (AC-609).
 - Cross-runtime migration ledger reconciliation so Python and TypeScript DBs stay aligned after schema divergence (AC-608).
 - CLI dispatch moved into a command registry so mission routes resolve correctly (AC-610).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-Changes in this section are on the branch/repo after `0.4.4` and are not part of the last published release until the next version is cut.
+### Added
+
+- **Browser integration surface** (AC-598–603): Chrome CDP backend for Python (`autocontext.integrations.browser`) and TypeScript (`autoctx/integrations/browser`), wired into investigations and the task queue. Includes a browser exploration contract, cross-runtime validation fixtures, parity enforcement, and selector generation for CDP element refs.
+- **A2-III Anthropic integration**: `instrument_client` / `InstrumentedAsyncAnthropic` (Python) and `instrumentClient` (TypeScript) intercept Anthropic SDK calls and route production traces through the autocontext pipeline, with `AnthropicStreamProxy`/`AnthropicStreamProxyAsync` for streaming and `AnthropicTaxonomyMapper` for outcome classification. Available at `autocontext.integrations.anthropic` and `autoctx/integrations/anthropic`. Includes cross-runtime parity (9 fixtures + 50-run property tests), anthropic-python/ts detector plugins, bundle-size enforcement, and zero-telemetry guarantee.
+- **Production traces `build-dataset` filters** (AC-606): `--provider`, `--app`, `--env`, and `--outcome` filters on the `build-dataset` CLI and MCP tool, plus an E2E integration test covering OpenAI + Anthropic traces through ingest→build-dataset.
+- Hierarchical investigation evidence with evidence cards cache and artifact drill-down hardening.
+- Tail context preservation in secondary prompt reducer surfaces.
+- Solve runtime floor raised for generated scenarios.
+
+### Fixed
+
+- Install salt identity invariant preserved across process restarts (AC-609).
+- Cross-runtime migration ledger reconciliation so Python and TypeScript DBs stay aligned after schema divergence (AC-608).
+- CLI dispatch moved into a command registry so mission routes resolve correctly (AC-610).
+- Babel reverse solve designer retries restored and scenario creation stabilized (AC-607).
+
+## [0.4.5] - 2026-04-21
+
+### Fixed
+
+- `quality_threshold` auto-heal no longer silently drops below the configured floor during multi-round improvement loops (AC-585).
+- Judge-provider inheritance now propagates correctly to nested evaluation calls so role-routing overrides are honored end-to-end (AC-586).
+- Claude CLI timeout default bumped from 300 to 600 seconds, reducing spurious failures in longer live-agent solve runs (AC-588).
+- Release-sweep accounting hardened to prevent double-counting across concurrent sweep legs.
 
 ### Added
 
@@ -238,6 +261,7 @@ Changes in this section are on the branch/repo after `0.4.4` and are not part of
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
+[0.4.5]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.4...py-v0.4.5
 [0.4.4]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.3...py-v0.4.4
 [0.4.3]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.2...py-v0.4.3
 [0.4.2]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.1...py-v0.4.2

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ autocontext runs LLM agents through structured scenarios, evaluates their output
 <!-- autocontext-whats-new:start -->
 ## What's New
 
-- Anthropic integration (A2-III): `instrument_client` (Python) and `instrumentClient` (TypeScript) wrap Anthropic SDK calls and route production traces through the autocontext pipeline without changing call sites. Streaming, outcome classification, and cross-runtime parity are included. See `autocontext.integrations.anthropic` / `autoctx/integrations/anthropic`.
-- Investigation evidence improvements: hierarchical evidence, evidence cards cache, and artifact drill-down hardening across the investigation surface.
-- Secondary prompt reducers now preserve tail context across secondary prompt surfaces.
+- Browser integration now spans Python and TypeScript CDP backends, investigations, queued tasks, and policy-gated evidence.
+- Anthropic SDK instrumentation captures Python and TypeScript production traces, streaming outcomes, and cross-runtime parity.
+- Production trace datasets gained provider/app/env/outcome filters and shared OpenAI/Anthropic E2E coverage.
+- Scenario family designers now share parser logic across TypeScript families, preserving family-specific prompt semantics.
+- Investigation evidence, secondary prompt reducers, migration ledgers, CLI dispatch, and proxy runtime plumbing were hardened.
 <!-- autocontext-whats-new:end -->
 
 ## What actually is autocontext?

--- a/README.md
+++ b/README.md
@@ -37,11 +37,9 @@ autocontext runs LLM agents through structured scenarios, evaluates their output
 <!-- autocontext-whats-new:start -->
 ## What's New
 
-- Pi RPC and solve runtime budgets hardened for longer live-agent runs
-- Custom scenario registry diagnostics and spec-to-scenario auto-materialization
-- Structured agent-task JSON payloads now validate and render safely
-- TypeScript new-scenario and improve fallbacks preserve family semantics
-- Generated scenario solve/export paths keep family-specific signals intact
+- Anthropic integration (A2-III): `instrument_client` (Python) and `instrumentClient` (TypeScript) wrap Anthropic SDK calls and route production traces through the autocontext pipeline without changing call sites. Streaming, outcome classification, and cross-runtime parity are included. See `autocontext.integrations.anthropic` / `autoctx/integrations/anthropic`.
+- Investigation evidence improvements: hierarchical evidence, evidence cards cache, and artifact drill-down hardening across the investigation surface.
+- Secondary prompt reducers now preserve tail context across secondary prompt surfaces.
 <!-- autocontext-whats-new:end -->
 
 ## What actually is autocontext?

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -10,7 +10,7 @@ The intended use is to hand the harness a real task in plain language, let it so
 pip install autocontext
 ```
 
-The current PyPI release line is `autocontext==0.4.4`.
+The current PyPI release line is `autocontext==0.4.5`.
 The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
 
 ## Working Directory

--- a/autocontext/assets/whats_new.txt
+++ b/autocontext/assets/whats_new.txt
@@ -1,5 +1,5 @@
-Pi RPC and solve runtime budgets hardened for longer live-agent runs
-Custom scenario registry diagnostics and spec-to-scenario auto-materialization
-Structured agent-task JSON payloads now validate and render safely
-TypeScript new-scenario and improve fallbacks preserve family semantics
-Generated scenario solve/export paths keep family-specific signals intact
+Browser integration now spans Python and TypeScript CDP backends, investigations, queued tasks, and policy-gated evidence.
+Anthropic SDK instrumentation captures Python and TypeScript production traces, streaming outcomes, and cross-runtime parity.
+Production trace datasets gained provider/app/env/outcome filters and shared OpenAI/Anthropic E2E coverage.
+Scenario family designers now share parser logic across TypeScript families, preserving family-specific prompt semantics.
+Investigation evidence, secondary prompt reducers, migration ledgers, CLI dispatch, and proxy runtime plumbing were hardened.

--- a/ts/README.md
+++ b/ts/README.md
@@ -26,7 +26,7 @@ Need the canonical product/runtime vocabulary first? Start with [docs/concept-mo
 npm install autoctx
 ```
 
-The current npm release line is `autoctx@0.4.4`.
+The current npm release line is `autoctx@0.4.5`.
 Important: use `autoctx`, not `autocontext`.
 `autocontext` on npm is a different package and not this project.
 


### PR DESCRIPTION
## Summary

- Add missing `[0.4.5]` CHANGELOG section (the release commit was never merged into main)
- Expand `[Unreleased]` to cover all work merged since 0.4.5: browser integration surface (AC-598–603), A2-III Anthropic integration, build-dataset filters (AC-606), migration ledger reconciliation (AC-608), CLI registry refactor (AC-610), AC-611 proxy-runtime centralization, and supporting fixes
- Update `What's New` in root README to lead with browser + Anthropic surfaces
- Bump PyPI/npm version lines to `0.4.5` in `autocontext/README.md` and `ts/README.md`

No code changes — docs only.