### PR TITLE
chore: release 0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-04-23
+
 ### Added
 
 - **Browser integration surface** (AC-598–603): Chrome CDP backend for Python (`autocontext.integrations.browser`) and TypeScript (`autoctx/integrations/browser`), wired into investigations and the task queue. Includes a browser exploration contract, cross-runtime validation fixtures, parity enforcement, and selector generation for CDP element refs.
@@ -21,6 +23,10 @@ All notable changes to this project will be documented in this file.
 - Cross-runtime migration ledger reconciliation so Python and TypeScript DBs stay aligned after schema divergence (AC-608).
 - CLI dispatch moved into a command registry so mission routes resolve correctly (AC-610).
 - Babel reverse solve designer retries restored and scenario creation stabilized (AC-607).
+
+### Changed
+
+- Python and TypeScript package metadata are bumped to `0.4.6`.
 
 ## [0.4.5] - 2026-04-21
 
@@ -263,6 +269,8 @@ All notable changes to this project will be documented in this file.
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
+[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.6...HEAD
+[0.4.6]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.5...py-v0.4.6
 [0.4.5]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.4...py-v0.4.5
 [0.4.4]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.3...py-v0.4.4
 [0.4.3]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.2...py-v0.4.3

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ The repo publishes two installable packages with different scopes:
 
 - Python package: `pip install autocontext`
 - TypeScript package: `npm install autoctx`
-- Current release line: `autocontext==0.4.4` and `autoctx@0.4.4`
+- Current release line: `autocontext==0.4.6` and `autoctx@0.4.6`
 
 Important:
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -10,7 +10,7 @@ The intended use is to hand the harness a real task in plain language, let it so
 pip install autocontext
 ```
 
-The current PyPI release line is `autocontext==0.4.5`.
+The current PyPI release line is `autocontext==0.4.6`.
 The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
 
 ## Working Directory

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autocontext"
-version = "0.4.4"
+version = "0.4.6"
 description = "autocontext control plane for iterative strategy evolution."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/autocontext/src/autocontext/__init__.py
+++ b/autocontext/src/autocontext/__init__.py
@@ -4,4 +4,4 @@ from autocontext.sdk import AutoContext
 
 __all__ = ["AutoContext", "__version__"]
 
-__version__ = "0.4.3"
+__version__ = "0.4.6"

--- a/autocontext/uv.lock
+++ b/autocontext/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "autocontext"
-version = "0.4.4"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/ts/README.md
+++ b/ts/README.md
@@ -26,7 +26,7 @@ Need the canonical product/runtime vocabulary first? Start with [docs/concept-mo
 npm install autoctx
 ```
 
-The current npm release line is `autoctx@0.4.5`.
+The current npm release line is `autoctx@0.4.6`.
 Important: use `autoctx`, not `autocontext`.
 `autocontext` on npm is a different package and not this project.
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoctx",
-  "version": "0.4.4",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoctx",
-      "version": "0.4.4",
+      "version": "0.4.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoctx",
-  "version": "0.4.4",
+  "version": "0.4.6",
   "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump Python and TypeScript package metadata to 0.4.6
- update README release lines for PyPI/npm
- roll current unreleased changelog entries into 0.4.6

## Verification
- git diff --check
- npm/package-lock version consistency
- Python package/runtime version consistency

## Release
- Publish Python and TypeScript packages after PR creation using the configured trusted publish environments.