### PR TITLE
chore: add browser/investigation/tracing sweep scenarios + CDP bucket

### DIFF
--- a/autocontext/tests/test_escalation_sweep_summary.py
+++ b/autocontext/tests/test_escalation_sweep_summary.py
@@ -104,3 +104,19 @@ def test_summarize_tallies_llm_classifier_fallback_when_stderr_chatter_is_merged
     summary = json.loads((results_dir / "summary.json").read_text(encoding="utf-8"))
     assert summary["rows"][0]["bucket"] == "llm_fallback_fired"
     assert summary["buckets"]["llm_fallback_fired"] == 1
+
+
+def test_classify_error_buckets_common_browser_cdp_failures_before_generic_timeouts() -> None:
+    summary_mod = _load_summary_module()
+
+    messages = [
+        "Timed out connecting to CDP websocket: ws://127.0.0.1:9222/devtools/page/1",
+        "Failed to connect to CDP websocket: ECONNREFUSED",
+        "No attachable page targets were advertised by the debugger",
+        "No debugger targets matched the browser allowlist",
+        "Debugger target discovery failed with HTTP 404",
+        "browser exploration is not configured",
+    ]
+
+    for message in messages:
+        assert summary_mod.classify_error(message) == "browser_cdp_unavailable", message

--- a/scripts/escalation-sweep/README.md
+++ b/scripts/escalation-sweep/README.md
@@ -6,7 +6,7 @@ Release-validation helper: run every "Scenarios"-state Linear issue through
 ## Prerequisites
 
 - `jq` and Python 3.11+ on PATH.
-- `autoctx` CLI installed (either a published release `pip install autocontext==0.4.4`
+- `autoctx` CLI installed (either a published release `pip install autocontext==0.4.6`
   or run the checked-out source via `cd autocontext && uv run autoctx ...`).
 - An agent provider. By default the harness uses `AUTOCONTEXT_AGENT_PROVIDER=claude-cli`,
   which invokes the locally-authenticated `claude` binary (Anthropic subscription) — no
@@ -54,6 +54,7 @@ that payload instead of trusting the surrounding text. First-match-wins ordering
 | `designer_parse_exhausted`     | AC-575 retry window exhausted                                  |
 | `spec_validation_other`        | Spec / source / execution validation (non-quality_threshold)   |
 | `claude_cli_timeout`           | Subprocess or provider timed out                               |
+| `browser_cdp_unavailable`      | Browser context requested but browser/CDP runtime not reachable (AC-598–603) |
 | `scenario_execution_failed`    | Scenario built but generations errored                         |
 | `unknown`                      | Didn't match any pattern — inspect `<ID>.out.json` (and `.err.log` if present) |
 

--- a/scripts/escalation-sweep/summarize.py
+++ b/scripts/escalation-sweep/summarize.py
@@ -18,6 +18,7 @@ Buckets:
     designer_parse_exhausted      — AC-575 retry window exhausted
     spec_validation_other         — spec/source/execution validation (non-qt)
     claude_cli_timeout            — subprocess or provider timeout
+    browser_cdp_unavailable       — browser context requested but browser/CDP runtime unreachable
     scenario_execution_failed     — generations errored after scenario built
     unknown                       — didn't match any known pattern
 
@@ -45,6 +46,16 @@ BUCKET_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("designer_intent_drift", re.compile(r"intent validation failed", re.I)),
     ("designer_parse_exhausted", re.compile(r"parse(?:_| )retry exhausted|designer parse failed.*attempt 3/3", re.I)),
     ("spec_validation_other", re.compile(r"(spec|source|execution) validation failed", re.I)),
+    (
+        "browser_cdp_unavailable",
+        re.compile(
+            r"ChromeCdp|CDP websocket|debugger target|debugger targets|"
+            r"attachable page targets|page targets.*debugger|"
+            r"browser exploration is not configured|browser.*connect.*fail|"
+            r"chrome.*not.*running|cdp.*unavailable|no.*debug.*port",
+            re.I,
+        ),
+    ),
     ("claude_cli_timeout", re.compile(r"timed? ?out|PiCLIRuntime failed:.*timeout|claude.?cli.*timeout", re.I)),
     ("scenario_execution_failed", re.compile(r"solve did not complete|generation.*fail|executor error", re.I)),
 ]


### PR DESCRIPTION
## Summary

- Creates 4 new Linear issues in the Scenarios state (AC-614–617) targeting the surfaces added since 0.4.5:
  - **AC-614** — evidence-heavy investigation (hierarchical evidence, cards cache, drill-down — AC-592/596)
  - **AC-615** — browser-context investigation (Chrome CDP backend wired into investigations — AC-598–603)
  - **AC-616** — LLM observability/tracing pipeline (exercises classifier routing toward trace/observability descriptions + Anthropic integration path)
  - **AC-617** — long-context event-sourcing spec (secondary prompt reducer + semantic compaction smoke test)
- Adds `browser_cdp_unavailable` bucket to `summarize.py` so Chrome CDP failures from the new browser integration surface as a named bucket instead of `unknown`
- Bumps `pip install autocontext==0.4.4` reference in sweep README to `0.4.5`

No production code changes — sweep harness only.