### PR TITLE
fix(ac-626): align capability provider inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- TypeScript capabilities now report the provider factory support surface and no longer mark the visible `train` command as Python-only (AC-626).
+
 ## [0.4.6] - 2026-04-23
 
 ### Added

--- a/ts/src/cli/capabilities-command-workflow.ts
+++ b/ts/src/cli/capabilities-command-workflow.ts
@@ -26,6 +26,7 @@ export const CAPABILITIES_COMMANDS = [
   "status",
   "serve",
   "mcp-serve",
+  "train",
   "version",
 ] as const;
 

--- a/ts/src/cli/export-training-data-command-workflow.ts
+++ b/ts/src/cli/export-training-data-command-workflow.ts
@@ -6,7 +6,7 @@ export const EXPORT_TRAINING_DATA_HELP_TEXT = [
   "",
   "Exports training data as JSONL with Python-compatible snake_case fields.",
   "",
-  "Unsupported Python commands: train, trigger-distillation (require MLX/CUDA backends)",
+  "For end-to-end local MLX/CUDA training, use the Python package's train command or inject a TypeScript training executor.",
 ].join("\n");
 
 export interface ExportTrainingDataCommandValues {

--- a/ts/src/mcp/capabilities.ts
+++ b/ts/src/mcp/capabilities.ts
@@ -5,6 +5,7 @@
 
 import { createRequire } from "node:module";
 import { getConceptModel, type ConceptModel } from "../concepts/model.js";
+import { SUPPORTED_PROVIDER_TYPES } from "../providers/supported-provider-types.js";
 import { SCENARIO_REGISTRY } from "../scenarios/registry.js";
 
 const require = createRequire(import.meta.url);
@@ -23,17 +24,7 @@ export function getCapabilities(): Capabilities {
   return {
     version: pkg.version,
     scenarios: Object.keys(SCENARIO_REGISTRY).sort(),
-    providers: [
-      "anthropic",
-      "openai",
-      "openai-compatible",
-      "ollama",
-      "vllm",
-      "hermes",
-      "pi",
-      "pi-rpc",
-      "deterministic",
-    ],
+    providers: [...SUPPORTED_PROVIDER_TYPES],
     features: [
       "generation_loop",
       "tournament",
@@ -51,7 +42,6 @@ export function getCapabilities(): Capabilities {
       "stagnation_detection",
     ],
     pythonOnly: [
-      "train",
       "ecosystem",
       "ab-test",
       "resume",

--- a/ts/src/providers/provider-factory.ts
+++ b/ts/src/providers/provider-factory.ts
@@ -6,6 +6,9 @@ import { CodexCLIRuntime, CodexCLIConfig } from "../runtimes/codex-cli.js";
 import { PiCLIRuntime, PiCLIConfig } from "../runtimes/pi-cli.js";
 import { PiRPCRuntime, PiRPCConfig } from "../runtimes/pi-rpc.js";
 import { RuntimeBridgeProvider } from "../agents/provider-bridge.js";
+import { SUPPORTED_PROVIDER_TYPES } from "./supported-provider-types.js";
+
+export { SUPPORTED_PROVIDER_TYPES } from "./supported-provider-types.js";
 
 export interface AnthropicProviderOpts {
   apiKey: string;
@@ -172,25 +175,6 @@ export interface CreateProviderOpts {
   piRpcApiKey?: string;
   piRpcSessionPersistence?: boolean;
 }
-
-export const SUPPORTED_PROVIDER_TYPES = [
-  "anthropic",
-  "openai",
-  "openai-compatible",
-  "ollama",
-  "vllm",
-  "hermes",
-  "gemini",
-  "mistral",
-  "groq",
-  "openrouter",
-  "azure-openai",
-  "claude-cli",
-  "codex",
-  "pi",
-  "pi-rpc",
-  "deterministic",
-] as const;
 
 export function createProvider(opts: CreateProviderOpts): LLMProvider {
   const type = opts.providerType.toLowerCase().trim();

--- a/ts/src/providers/supported-provider-types.ts
+++ b/ts/src/providers/supported-provider-types.ts
@@ -1,0 +1,20 @@
+export const SUPPORTED_PROVIDER_TYPES = [
+  "anthropic",
+  "openai",
+  "openai-compatible",
+  "ollama",
+  "vllm",
+  "hermes",
+  "gemini",
+  "mistral",
+  "groq",
+  "openrouter",
+  "azure-openai",
+  "claude-cli",
+  "codex",
+  "pi",
+  "pi-rpc",
+  "deterministic",
+] as const;
+
+export type SupportedProviderType = typeof SUPPORTED_PROVIDER_TYPES[number];

--- a/ts/tests/capabilities-command-workflow.test.ts
+++ b/ts/tests/capabilities-command-workflow.test.ts
@@ -40,6 +40,7 @@ describe("capabilities command workflow", () => {
         "status",
         "serve",
         "mcp-serve",
+        "train",
         "version",
       ]),
       features: {

--- a/ts/tests/capabilities-provider-parity.test.ts
+++ b/ts/tests/capabilities-provider-parity.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { CAPABILITIES_COMMANDS } from "../src/cli/capabilities-command-workflow.js";
+import { getCapabilities } from "../src/mcp/capabilities.js";
+import { SUPPORTED_PROVIDER_TYPES } from "../src/providers/provider-factory.js";
+
+describe("capabilities provider parity", () => {
+  it("reports the provider factory support surface", () => {
+    expect(getCapabilities().providers).toEqual([...SUPPORTED_PROVIDER_TYPES]);
+  });
+
+  it("does not mark visible TypeScript commands as Python-only", () => {
+    const capabilities = getCapabilities();
+
+    expect(CAPABILITIES_COMMANDS).toContain("train");
+    expect(capabilities.pythonOnly).not.toContain("train");
+  });
+});

--- a/ts/tests/export-training-data-command-workflow.test.ts
+++ b/ts/tests/export-training-data-command-workflow.test.ts
@@ -13,6 +13,7 @@ describe("export-training-data command workflow", () => {
     expect(EXPORT_TRAINING_DATA_HELP_TEXT).toContain("--run-id");
     expect(EXPORT_TRAINING_DATA_HELP_TEXT).toContain("--scenario");
     expect(EXPORT_TRAINING_DATA_HELP_TEXT).toContain("--include-matches");
+    expect(EXPORT_TRAINING_DATA_HELP_TEXT).not.toContain("Unsupported Python commands: train");
   });
 
   it("requires run-id or scenario", () => {


### PR DESCRIPTION
## Summary
- move supported provider type names into a shared provider source
- make MCP capabilities report that same provider support surface
- stop marking the visible TypeScript train command as Python-only

## Tests
- npm test -- capabilities-provider-parity.test.ts capabilities-command-workflow.test.ts
- npm run lint -- --pretty false