### PR TITLE
fix(ac-624): normalize solve MCP tool aliases

### DIFF
--- a/autocontext/src/autocontext/mcp/server.py
+++ b/autocontext/src/autocontext/mcp/server.py
@@ -208,6 +208,10 @@ def autocontext_solve_scenario(description: str, generations: int = 5) -> str:
     """Submit a new problem for on-demand solving. autocontext creates a scenario from the
     description, runs strategy evolution, and produces a skill package.
     Returns a job_id for polling status."""
+    return _solve_scenario_response(description, generations)
+
+
+def _solve_scenario_response(description: str, generations: int = 5) -> str:
     from autocontext.knowledge.solver import SolveManager
 
     mgr: SolveManager = _get_solve_mgr()  # type: ignore[assignment]
@@ -218,6 +222,10 @@ def autocontext_solve_scenario(description: str, generations: int = 5) -> str:
 @mcp.tool()
 def autocontext_solve_status(job_id: str) -> str:
     """Check status of a solve-on-demand job."""
+    return _solve_status_response(job_id)
+
+
+def _solve_status_response(job_id: str) -> str:
     from autocontext.knowledge.solver import SolveManager
 
     mgr: SolveManager = _get_solve_mgr()  # type: ignore[assignment]
@@ -227,6 +235,10 @@ def autocontext_solve_status(job_id: str) -> str:
 @mcp.tool()
 def autocontext_solve_result(job_id: str) -> str:
     """Get the skill package result of a completed solve job."""
+    return _solve_result_response(job_id)
+
+
+def _solve_result_response(job_id: str) -> str:
     from autocontext.knowledge.solver import SolveManager
 
     mgr: SolveManager = _get_solve_mgr()  # type: ignore[assignment]
@@ -239,19 +251,19 @@ def autocontext_solve_result(job_id: str) -> str:
 @mcp.tool()
 def solve_scenario(description: str, generations: int = 5) -> str:
     """Alias for autocontext_solve_scenario."""
-    return autocontext_solve_scenario(description, generations)
+    return _solve_scenario_response(description, generations)
 
 
 @mcp.tool()
 def solve_status(job_id: str) -> str:
     """Alias for autocontext_solve_status."""
-    return autocontext_solve_status(job_id)
+    return _solve_status_response(job_id)
 
 
 @mcp.tool()
 def solve_result(job_id: str) -> str:
     """Alias for autocontext_solve_result."""
-    return autocontext_solve_result(job_id)
+    return _solve_result_response(job_id)
 
 
 # -- Human feedback tools --

--- a/autocontext/src/autocontext/mcp/server.py
+++ b/autocontext/src/autocontext/mcp/server.py
@@ -236,6 +236,24 @@ def autocontext_solve_result(job_id: str) -> str:
     return json.dumps(pkg.to_dict())
 
 
+@mcp.tool()
+def solve_scenario(description: str, generations: int = 5) -> str:
+    """Alias for autocontext_solve_scenario."""
+    return autocontext_solve_scenario(description, generations)
+
+
+@mcp.tool()
+def solve_status(job_id: str) -> str:
+    """Alias for autocontext_solve_status."""
+    return autocontext_solve_status(job_id)
+
+
+@mcp.tool()
+def solve_result(job_id: str) -> str:
+    """Alias for autocontext_solve_result."""
+    return autocontext_solve_result(job_id)
+
+
 # -- Human feedback tools --
 
 

--- a/autocontext/tests/test_mcp_server.py
+++ b/autocontext/tests/test_mcp_server.py
@@ -59,3 +59,19 @@ def test_evidence_artifact_tool_function_exists() -> None:
     from autocontext.mcp import server
 
     assert hasattr(server, "autocontext_evidence_artifact")
+
+
+def test_solve_tools_expose_prefixed_and_unprefixed_names() -> None:
+    from autocontext.mcp import server
+
+    tool_names = set(mcp._tool_manager._tools.keys())
+    for name in [
+        "autocontext_solve_scenario",
+        "autocontext_solve_status",
+        "autocontext_solve_result",
+        "solve_scenario",
+        "solve_status",
+        "solve_result",
+    ]:
+        assert name in tool_names
+        assert hasattr(server, name)

--- a/ts/src/mcp/solve-tools.ts
+++ b/ts/src/mcp/solve-tools.ts
@@ -17,6 +17,14 @@ interface SolveToolManager {
   getResult(jobId: string): Record<string, unknown> | null;
 }
 
+interface SolveToolDefinition {
+  name: string;
+  aliases: string[];
+  description: string;
+  schema: Record<string, unknown>;
+  handler: (args: Record<string, unknown>) => Promise<JsonToolResponse>;
+}
+
 function jsonText(payload: unknown, indent?: number): JsonToolResponse {
   return {
     content: [
@@ -38,41 +46,62 @@ export function buildSolveResultNotFoundPayload(jobId: string): {
   };
 }
 
+function buildSolveToolDefinitions(solveManager: SolveToolManager): SolveToolDefinition[] {
+  return [
+    {
+      name: "solve_scenario",
+      aliases: ["autocontext_solve_scenario"],
+      description: "Submit a problem for on-demand solving. Returns a job_id for polling.",
+      schema: { description: z.string(), generations: z.number().int().default(5) },
+      handler: async (args: Record<string, unknown>) => {
+        const jobId = solveManager.submit(
+          String(args.description),
+          Number(args.generations ?? 5),
+        );
+        return jsonText({ jobId, status: "pending" });
+      },
+    },
+    {
+      name: "solve_status",
+      aliases: ["autocontext_solve_status"],
+      description: "Check status of a solve-on-demand job",
+      schema: { jobId: z.string() },
+      handler: async (args: Record<string, unknown>) =>
+        jsonText(solveManager.getStatus(String(args.jobId)), 2),
+    },
+    {
+      name: "solve_result",
+      aliases: ["autocontext_solve_result"],
+      description: "Get the exported skill package result of a completed solve-on-demand job",
+      schema: { jobId: z.string() },
+      handler: async (args: Record<string, unknown>) => {
+        const jobId = String(args.jobId);
+        const result = solveManager.getResult(jobId);
+        return jsonText(result ?? buildSolveResultNotFoundPayload(jobId), 2);
+      },
+    },
+  ];
+}
+
+function registerToolDefinition(server: McpToolRegistrar, definition: SolveToolDefinition): void {
+  server.tool(definition.name, definition.description, definition.schema, definition.handler);
+  for (const alias of definition.aliases) {
+    server.tool(
+      alias,
+      `${definition.description} Alias for ${definition.name}.`,
+      definition.schema,
+      definition.handler,
+    );
+  }
+}
+
 export function registerSolveTools(
   server: McpToolRegistrar,
   opts: {
     solveManager: SolveToolManager;
   },
 ): void {
-  server.tool(
-    "solve_scenario",
-    "Submit a problem for on-demand solving. Returns a job_id for polling.",
-    { description: z.string(), generations: z.number().int().default(5) },
-    async (args: Record<string, unknown>) => {
-      const jobId = opts.solveManager.submit(
-        String(args.description),
-        Number(args.generations ?? 5),
-      );
-      return jsonText({ jobId, status: "pending" });
-    },
-  );
-
-  server.tool(
-    "solve_status",
-    "Check status of a solve-on-demand job",
-    { jobId: z.string() },
-    async (args: Record<string, unknown>) =>
-      jsonText(opts.solveManager.getStatus(String(args.jobId)), 2),
-  );
-
-  server.tool(
-    "solve_result",
-    "Get the exported skill package result of a completed solve-on-demand job",
-    { jobId: z.string() },
-    async (args: Record<string, unknown>) => {
-      const jobId = String(args.jobId);
-      const result = opts.solveManager.getResult(jobId);
-      return jsonText(result ?? buildSolveResultNotFoundPayload(jobId), 2);
-    },
-  );
+  for (const definition of buildSolveToolDefinitions(opts.solveManager)) {
+    registerToolDefinition(server, definition);
+  }
 }

--- a/ts/src/mcp/solve-tools.ts
+++ b/ts/src/mcp/solve-tools.ts
@@ -17,12 +17,15 @@ interface SolveToolManager {
   getResult(jobId: string): Record<string, unknown> | null;
 }
 
-interface SolveToolDefinition {
+interface SolveToolRegistration {
   name: string;
-  aliases: string[];
   description: string;
   schema: Record<string, unknown>;
   handler: (args: Record<string, unknown>) => Promise<JsonToolResponse>;
+}
+
+interface SolveToolDefinition extends SolveToolRegistration {
+  aliases: SolveToolRegistration[];
 }
 
 function jsonText(payload: unknown, indent?: number): JsonToolResponse {
@@ -46,11 +49,33 @@ export function buildSolveResultNotFoundPayload(jobId: string): {
   };
 }
 
+function buildPrefixedSolveResultNotFoundPayload(jobId: string): {
+  error: string;
+  job_id: string;
+} {
+  return {
+    error: "Job not completed or not found",
+    job_id: jobId,
+  };
+}
+
+function toPrefixedSolveStatusPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  const prefixedPayload = { ...payload };
+  if ("jobId" in prefixedPayload) {
+    prefixedPayload.job_id = prefixedPayload.jobId;
+    delete prefixedPayload.jobId;
+  }
+  if ("scenarioName" in prefixedPayload) {
+    prefixedPayload.scenario_name = prefixedPayload.scenarioName;
+    delete prefixedPayload.scenarioName;
+  }
+  return prefixedPayload;
+}
+
 function buildSolveToolDefinitions(solveManager: SolveToolManager): SolveToolDefinition[] {
   return [
     {
       name: "solve_scenario",
-      aliases: ["autocontext_solve_scenario"],
       description: "Submit a problem for on-demand solving. Returns a job_id for polling.",
       schema: { description: z.string(), generations: z.number().int().default(5) },
       handler: async (args: Record<string, unknown>) => {
@@ -60,18 +85,39 @@ function buildSolveToolDefinitions(solveManager: SolveToolManager): SolveToolDef
         );
         return jsonText({ jobId, status: "pending" });
       },
+      aliases: [
+        {
+          name: "autocontext_solve_scenario",
+          description: "Submit a problem for on-demand solving. Returns a job_id for polling.",
+          schema: { description: z.string(), generations: z.number().int().default(5) },
+          handler: async (args: Record<string, unknown>) => {
+            const jobId = solveManager.submit(
+              String(args.description),
+              Number(args.generations ?? 5),
+            );
+            return jsonText({ job_id: jobId, status: "pending" });
+          },
+        },
+      ],
     },
     {
       name: "solve_status",
-      aliases: ["autocontext_solve_status"],
       description: "Check status of a solve-on-demand job",
       schema: { jobId: z.string() },
       handler: async (args: Record<string, unknown>) =>
         jsonText(solveManager.getStatus(String(args.jobId)), 2),
+      aliases: [
+        {
+          name: "autocontext_solve_status",
+          description: "Check status of a solve-on-demand job",
+          schema: { job_id: z.string() },
+          handler: async (args: Record<string, unknown>) =>
+            jsonText(toPrefixedSolveStatusPayload(solveManager.getStatus(String(args.job_id))), 2),
+        },
+      ],
     },
     {
       name: "solve_result",
-      aliases: ["autocontext_solve_result"],
       description: "Get the exported skill package result of a completed solve-on-demand job",
       schema: { jobId: z.string() },
       handler: async (args: Record<string, unknown>) => {
@@ -79,19 +125,30 @@ function buildSolveToolDefinitions(solveManager: SolveToolManager): SolveToolDef
         const result = solveManager.getResult(jobId);
         return jsonText(result ?? buildSolveResultNotFoundPayload(jobId), 2);
       },
+      aliases: [
+        {
+          name: "autocontext_solve_result",
+          description: "Get the exported skill package result of a completed solve-on-demand job",
+          schema: { job_id: z.string() },
+          handler: async (args: Record<string, unknown>) => {
+            const jobId = String(args.job_id);
+            const result = solveManager.getResult(jobId);
+            return jsonText(result ?? buildPrefixedSolveResultNotFoundPayload(jobId), 2);
+          },
+        },
+      ],
     },
   ];
 }
 
+function registerTool(server: McpToolRegistrar, registration: SolveToolRegistration): void {
+  server.tool(registration.name, registration.description, registration.schema, registration.handler);
+}
+
 function registerToolDefinition(server: McpToolRegistrar, definition: SolveToolDefinition): void {
-  server.tool(definition.name, definition.description, definition.schema, definition.handler);
+  registerTool(server, definition);
   for (const alias of definition.aliases) {
-    server.tool(
-      alias,
-      `${definition.description} Alias for ${definition.name}.`,
-      definition.schema,
-      definition.handler,
-    );
+    registerTool(server, alias);
   }
 }
 

--- a/ts/tests/solve-tools.test.ts
+++ b/ts/tests/solve-tools.test.ts
@@ -79,20 +79,27 @@ describe("solve MCP tools", () => {
     });
     expect(submit).toHaveBeenCalledWith("grid ctf", 5);
     expect(JSON.parse(result.content[0].text)).toEqual({
-      jobId: "solve-123",
+      job_id: "solve-123",
       status: "pending",
     });
 
     const aliasStatus = await server.registeredTools.autocontext_solve_status.handler({
-      jobId: "solve-123",
+      job_id: "solve-123",
     });
     const canonicalStatus = await server.registeredTools.solve_status.handler({
       jobId: "solve-123",
     });
-    expect(aliasStatus).toEqual(canonicalStatus);
+    expect(JSON.parse(aliasStatus.content[0].text)).toEqual({
+      job_id: "solve-123",
+      status: "completed",
+    });
+    expect(JSON.parse(canonicalStatus.content[0].text)).toEqual({
+      jobId: "solve-123",
+      status: "completed",
+    });
 
     const aliasResult = await server.registeredTools.autocontext_solve_result.handler({
-      jobId: "solve-123",
+      job_id: "solve-123",
     });
     const canonicalResult = await server.registeredTools.solve_result.handler({
       jobId: "solve-123",

--- a/ts/tests/solve-tools.test.ts
+++ b/ts/tests/solve-tools.test.ts
@@ -53,6 +53,53 @@ describe("solve MCP tools", () => {
     });
   });
 
+  it("registers Python-compatible solve tool aliases", async () => {
+    const server = createFakeServer();
+    const submit = vi.fn(() => "solve-123");
+
+    registerSolveTools(server, {
+      solveManager: {
+        submit,
+        getStatus: vi.fn(() => ({ jobId: "solve-123", status: "completed" })),
+        getResult: vi.fn(() => ({ scenario_name: "grid_ctf" })),
+      },
+    });
+
+    expect(Object.keys(server.registeredTools).sort()).toEqual([
+      "autocontext_solve_result",
+      "autocontext_solve_scenario",
+      "autocontext_solve_status",
+      "solve_result",
+      "solve_scenario",
+      "solve_status",
+    ]);
+
+    const result = await server.registeredTools.autocontext_solve_scenario.handler({
+      description: "grid ctf",
+    });
+    expect(submit).toHaveBeenCalledWith("grid ctf", 5);
+    expect(JSON.parse(result.content[0].text)).toEqual({
+      jobId: "solve-123",
+      status: "pending",
+    });
+
+    const aliasStatus = await server.registeredTools.autocontext_solve_status.handler({
+      jobId: "solve-123",
+    });
+    const canonicalStatus = await server.registeredTools.solve_status.handler({
+      jobId: "solve-123",
+    });
+    expect(aliasStatus).toEqual(canonicalStatus);
+
+    const aliasResult = await server.registeredTools.autocontext_solve_result.handler({
+      jobId: "solve-123",
+    });
+    const canonicalResult = await server.registeredTools.solve_result.handler({
+      jobId: "solve-123",
+    });
+    expect(aliasResult).toEqual(canonicalResult);
+  });
+
   it("returns solve status payloads from the shared manager", async () => {
     const server = createFakeServer();
 


### PR DESCRIPTION
## Summary
- add TypeScript autocontext_* aliases for solve MCP tools while keeping existing unprefixed names
- add Python unprefixed solve MCP aliases while keeping existing autocontext_* names
- cover alias registration in TS/Python tests

## Tests
- npm test -- solve-tools.test.ts
- npm run lint -- --pretty false
- uv run ruff check src/autocontext/mcp/server.py tests/test_mcp_server.py
- uv run pytest tests/test_mcp_server.py (skipped: optional MCP package not installed)