### PR TITLE
feat(ac-619): add TypeScript solve CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- TypeScript CLI now exposes `autoctx solve` as a DB-backed solve-on-demand entrypoint with `--description`, `--gens`, `--timeout`, and `--json` support (AC-619).
+
 ### Fixed
 
 - TypeScript capabilities now report the provider factory support surface and no longer mark the visible `train` command as Python-only (AC-626).

--- a/ts/README.md
+++ b/ts/README.md
@@ -138,6 +138,7 @@ autoctx providers
 autoctx models
 
 # Scenario execution
+autoctx solve --description "improve customer-support replies" --gens 3 --json
 autoctx run --scenario support_triage --gens 3 --json
 autoctx list --json
 autoctx replay --run-id <id> --generation 1

--- a/ts/src/cli/capabilities-command-workflow.ts
+++ b/ts/src/cli/capabilities-command-workflow.ts
@@ -10,6 +10,7 @@ export const CAPABILITIES_COMMANDS = [
   "export-training-data",
   "import-package",
   "new-scenario",
+  "solve",
   "capabilities",
   "login",
   "whoami",

--- a/ts/src/cli/command-registry.ts
+++ b/ts/src/cli/command-registry.ts
@@ -27,6 +27,7 @@ export type NoDbCommandName =
 export type DbCommandName =
   | "mission"
   | "campaign"
+  | "solve"
   | "run"
   | "list"
   | "replay"
@@ -77,6 +78,7 @@ const COMMANDS: readonly CommandDescriptor[] = [
   { name: "models", description: "List available models for authenticated providers (JSON)", group: "primary", route: { kind: "no-db", command: "models" } },
   { name: "mission", description: "Manage multi-step task missions", group: "primary", route: { kind: "db", command: "mission" } },
   { name: "campaign", description: "Manage multi-mission campaigns", group: "primary", route: { kind: "db", command: "campaign" } },
+  { name: "solve", description: "Create and solve a scenario from plain language", group: "primary", route: { kind: "db", command: "solve" } },
   { name: "tui", description: "Start interactive TUI (WebSocket server + Ink UI)", group: "primary", route: { kind: "db", command: "tui" } },
   { name: "judge", description: "One-shot evaluation of output against a rubric", group: "primary", route: { kind: "db", command: "judge" } },
   { name: "improve", description: "Run multi-round improvement loop", group: "primary", route: { kind: "db", command: "improve" } },

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -52,6 +52,7 @@ const NO_DB_COMMAND_HANDLERS: Record<NoDbCommandName, () => Promise<void>> = {
 const DB_COMMAND_HANDLERS: Record<DbCommandName, (dbPath: string) => Promise<void>> = {
   mission: cmdMission,
   campaign: cmdCampaign,
+  solve: cmdSolve,
   run: cmdRun,
   list: cmdList,
   replay: cmdReplay,
@@ -488,6 +489,66 @@ async function cmdRun(dbPath: string): Promise<void> {
     console.error(rendered.stderr);
   }
   console.log(rendered.stdout);
+}
+
+async function cmdSolve(dbPath: string): Promise<void> {
+  const { values } = parseArgs({
+    args: process.argv.slice(3),
+    options: {
+      description: { type: "string", short: "d" },
+      gens: { type: "string", short: "g" },
+      timeout: { type: "string" },
+      json: { type: "boolean" },
+      help: { type: "boolean", short: "h" },
+    },
+  });
+
+  const {
+    executeSolveCommandWorkflow,
+    planSolveCommand,
+    renderSolveCommandSummary,
+    SOLVE_HELP_TEXT,
+  } = await import("./solve-command-workflow.js");
+
+  if (values.help) {
+    console.log(SOLVE_HELP_TEXT);
+    process.exit(0);
+  }
+
+  let plan;
+  try {
+    plan = planSolveCommand(values, parsePositiveInteger);
+  } catch (error) {
+    console.error(errorMessage(error));
+    process.exit(1);
+  }
+
+  const { SQLiteStore } = await import("../storage/index.js");
+  const { loadSettings } = await import("../config/index.js");
+  const { SolveManager } = await import("../knowledge/solver.js");
+
+  const settings = loadSettings();
+  const store = new SQLiteStore(dbPath);
+  store.migrate(getMigrationsDir());
+
+  try {
+    const { provider } = await getProvider();
+    const summary = await executeSolveCommandWorkflow({
+      manager: new SolveManager({
+        provider,
+        store,
+        runsRoot: resolve(settings.runsRoot),
+        knowledgeRoot: resolve(settings.knowledgeRoot),
+      }),
+      plan,
+    });
+    console.log(renderSolveCommandSummary(summary, plan.json));
+  } catch (error) {
+    console.error(errorMessage(error));
+    process.exit(1);
+  } finally {
+    store.close();
+  }
 }
 
 async function cmdTui(dbPath: string): Promise<void> {

--- a/ts/src/cli/solve-command-workflow.ts
+++ b/ts/src/cli/solve-command-workflow.ts
@@ -1,0 +1,140 @@
+export const SOLVE_HELP_TEXT = `autoctx solve — create and solve a scenario from a plain-language description
+
+Usage:
+  autoctx solve --description "..." [--gens N] [--json]
+
+Options:
+  -d, --description <text>   Natural-language scenario/problem description
+  -g, --gens <N>             Generations to run (default: 5)
+  --timeout <seconds>        Maximum time to wait for solve completion (default: 300)
+  --json                     Output structured JSON
+  -h, --help                 Show this help
+
+Examples:
+  autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+  autoctx solve -d "investigate a production outage from logs" --gens 2 --json`;
+
+export interface SolveCommandValues {
+  description?: string;
+  gens?: string;
+  timeout?: string;
+  json?: boolean;
+}
+
+export interface SolveCommandPlan {
+  description: string;
+  generations: number;
+  timeoutMs: number;
+  json: boolean;
+}
+
+export interface SolveManagerLike {
+  submit(description: string, generations: number): string;
+  getStatus(jobId: string): Record<string, unknown>;
+  getResult(jobId: string): Record<string, unknown> | null;
+}
+
+export interface SolveCommandSummary {
+  jobId: string;
+  status: string;
+  description: string;
+  scenarioName: string | null;
+  family: string | null;
+  generations: number;
+  progress: number;
+  result: Record<string, unknown>;
+}
+
+const DEFAULT_TIMEOUT_MS = 300_000;
+const DEFAULT_POLL_INTERVAL_MS = 250;
+
+export function planSolveCommand(
+  values: SolveCommandValues,
+  parsePositiveInteger: (raw: string | undefined, label: string) => number,
+): SolveCommandPlan {
+  const description = values.description?.trim();
+  if (!description) {
+    throw new Error("Error: --description is required. Run 'autoctx solve --help' for usage.");
+  }
+
+  const timeoutMs = values.timeout
+    ? parsePositiveInteger(values.timeout, "--timeout") * 1000
+    : DEFAULT_TIMEOUT_MS;
+
+  return {
+    description,
+    generations: values.gens ? parsePositiveInteger(values.gens, "--gens") : 5,
+    timeoutMs,
+    json: Boolean(values.json),
+  };
+}
+
+export async function executeSolveCommandWorkflow(opts: {
+  manager: SolveManagerLike;
+  plan: SolveCommandPlan;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  pollIntervalMs?: number;
+}): Promise<SolveCommandSummary> {
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const deadline = now() + opts.plan.timeoutMs;
+  const jobId = opts.manager.submit(opts.plan.description, opts.plan.generations);
+
+  let status = opts.manager.getStatus(jobId);
+  while (!isTerminalSolveStatus(status)) {
+    if (now() >= deadline) {
+      throw new Error(`Solve timed out waiting for job '${jobId}'`);
+    }
+    await sleep(pollIntervalMs);
+    status = opts.manager.getStatus(jobId);
+  }
+
+  if (String(status.status) !== "completed") {
+    throw new Error(String(status.error ?? `Solve failed with status '${String(status.status)}'`));
+  }
+
+  const result = opts.manager.getResult(jobId);
+  if (!result) {
+    throw new Error(`Solve job '${jobId}' completed without an exported result`);
+  }
+
+  return {
+    jobId,
+    status: String(status.status),
+    description: String(status.description ?? opts.plan.description),
+    scenarioName: stringOrNull(status.scenarioName),
+    family: stringOrNull(status.family),
+    generations: numberOrDefault(status.generations, opts.plan.generations),
+    progress: numberOrDefault(status.progress, 0),
+    result,
+  };
+}
+
+export function renderSolveCommandSummary(summary: SolveCommandSummary, json: boolean): string {
+  if (json) {
+    return JSON.stringify(summary, null, 2);
+  }
+
+  return [
+    "Solve completed",
+    `  Job ID: ${summary.jobId}`,
+    `  Scenario: ${summary.scenarioName ?? "unknown"}`,
+    `  Family: ${summary.family ?? "unknown"}`,
+    `  Generations: ${summary.generations}`,
+    `  Progress: ${summary.progress}`,
+  ].join("\n");
+}
+
+function isTerminalSolveStatus(status: Record<string, unknown>): boolean {
+  return ["completed", "failed", "not_found"].includes(String(status.status ?? ""));
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function numberOrDefault(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}

--- a/ts/src/knowledge/solve-manager-workflow.ts
+++ b/ts/src/knowledge/solve-manager-workflow.ts
@@ -139,6 +139,7 @@ export async function executeSolveJobWorkflow(opts: {
     const route = opts.deps.determineSolveExecutionRoute(prepared, builtinScenarioNames);
 
     if (route === "builtin_game") {
+      opts.job.family = "game";
       await runBuiltInGameSolveJob({
         job: opts.job,
         provider: opts.provider,

--- a/ts/tests/cli-command-registry.test.ts
+++ b/ts/tests/cli-command-registry.test.ts
@@ -23,6 +23,7 @@ describe("CLI command registry", () => {
       kind: "db",
       command: "mission",
     });
+    expect(resolveCliCommand("solve")).toEqual({ kind: "db", command: "solve" });
     expect(resolveCliCommand("init")).toEqual({ kind: "no-db", command: "init" });
     expect(resolveCliCommand("registry")).toEqual({
       kind: "control-plane",

--- a/ts/tests/cli-dx.test.ts
+++ b/ts/tests/cli-dx.test.ts
@@ -357,6 +357,24 @@ describe("AC-405: autoctx capabilities", () => {
   });
 });
 
+describe("AC-619: autoctx solve", () => {
+  it("appears in top-level and command-specific help", () => {
+    const topLevel = runCli(["--help"]);
+    expect(topLevel.stdout).toContain("solve");
+
+    const solveHelp = runCli(["solve", "--help"]);
+    expect(solveHelp.exitCode).toBe(0);
+    expect(solveHelp.stdout).toContain("autoctx solve");
+    expect(solveHelp.stdout).toContain("--description");
+  });
+
+  it("requires a description", () => {
+    const { stderr, exitCode } = runCli(["solve"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--description is required");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // AC-418: capabilities reports dynamic version
 // ---------------------------------------------------------------------------

--- a/ts/tests/solve-command-workflow.test.ts
+++ b/ts/tests/solve-command-workflow.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executeSolveCommandWorkflow,
+  planSolveCommand,
+  renderSolveCommandSummary,
+} from "../src/cli/solve-command-workflow.js";
+
+describe("solve command workflow", () => {
+  it("plans required description, generations, timeout, and JSON output", () => {
+    const parsePositiveInteger = vi.fn((raw: string | undefined) => Number(raw));
+
+    expect(
+      planSolveCommand(
+        {
+          description: "  investigate checkout failures  ",
+          gens: "3",
+          timeout: "12",
+          json: true,
+        },
+        parsePositiveInteger,
+      ),
+    ).toEqual({
+      description: "investigate checkout failures",
+      generations: 3,
+      timeoutMs: 12_000,
+      json: true,
+    });
+    expect(parsePositiveInteger).toHaveBeenCalledWith("3", "--gens");
+    expect(parsePositiveInteger).toHaveBeenCalledWith("12", "--timeout");
+  });
+
+  it("rejects missing descriptions", () => {
+    expect(() =>
+      planSolveCommand({}, () => 1),
+    ).toThrow("--description is required");
+  });
+
+  it("submits a solve job and waits for completion", async () => {
+    const submit = vi.fn(() => "solve-123");
+    const getStatus = vi
+      .fn()
+      .mockReturnValueOnce({ jobId: "solve-123", status: "running", progress: 0 })
+      .mockReturnValueOnce({
+        jobId: "solve-123",
+        status: "completed",
+        description: "grid ctf",
+        scenarioName: "grid_ctf",
+        family: "game",
+        generations: 1,
+        progress: 1,
+      });
+    const getResult = vi.fn(() => ({ scenario_name: "grid_ctf" }));
+
+    const summary = await executeSolveCommandWorkflow({
+      manager: { submit, getStatus, getResult },
+      plan: {
+        description: "grid ctf",
+        generations: 1,
+        timeoutMs: 1000,
+        json: true,
+      },
+      sleep: vi.fn(async () => undefined),
+      pollIntervalMs: 1,
+    });
+
+    expect(submit).toHaveBeenCalledWith("grid ctf", 1);
+    expect(getStatus).toHaveBeenCalledTimes(2);
+    expect(summary).toEqual({
+      jobId: "solve-123",
+      status: "completed",
+      description: "grid ctf",
+      scenarioName: "grid_ctf",
+      family: "game",
+      generations: 1,
+      progress: 1,
+      result: { scenario_name: "grid_ctf" },
+    });
+  });
+
+  it("renders structured JSON or concise text", () => {
+    const summary = {
+      jobId: "solve-123",
+      status: "completed",
+      description: "grid ctf",
+      scenarioName: "grid_ctf",
+      family: "game",
+      generations: 1,
+      progress: 1,
+      result: { scenario_name: "grid_ctf" },
+    };
+
+    expect(JSON.parse(renderSolveCommandSummary(summary, true))).toEqual(summary);
+    expect(renderSolveCommandSummary(summary, false)).toContain("Solve completed");
+  });
+});

--- a/ts/tests/solve-manager-workflow.test.ts
+++ b/ts/tests/solve-manager-workflow.test.ts
@@ -58,6 +58,53 @@ describe("solve manager workflow", () => {
     });
   });
 
+  it("reports built-in scenario solves as game family even when designer metadata drifts", async () => {
+    const job = createSolveJob("solve_builtin", "grid ctf", 1);
+    const executeBuiltInGameSolve = vi.fn(async () => ({
+      progress: 1,
+      result: { scenario_name: "grid_ctf", best_score: 0.73 },
+    }));
+
+    await executeSolveJobWorkflow({
+      job,
+      provider: { name: "mock", defaultModel: () => "mock", complete: vi.fn() } as never,
+      store: {} as never,
+      runsRoot: "/tmp/runs",
+      knowledgeRoot: "/tmp/knowledge",
+      deps: {
+        createScenarioFromDescription: vi.fn(async () => ({
+          name: "grid_ctf",
+          family: "agent_task",
+          spec: { taskPrompt: "grid ctf", rubric: "score" },
+        })),
+        listBuiltinScenarioNames: vi.fn(async () => ["grid_ctf"]),
+        prepareSolveScenario: vi.fn(({ created, description }) => ({ ...created, description })) as never,
+        determineSolveExecutionRoute: vi.fn(() => "builtin_game") as never,
+        persistSolveScenarioScaffold: vi.fn() as never,
+        executeBuiltInGameSolve: executeBuiltInGameSolve as never,
+        executeAgentTaskSolve: vi.fn() as never,
+        executeCodegenSolve: vi.fn() as never,
+        failSolveJob: vi.fn((failedJob, error) => {
+          failedJob.status = "failed";
+          failedJob.error = error instanceof Error ? error.message : String(error);
+        }),
+      },
+    });
+
+    expect(executeBuiltInGameSolve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scenarioName: "grid_ctf",
+        generations: 1,
+      }),
+    );
+    expect(job).toMatchObject({
+      status: "completed",
+      scenarioName: "grid_ctf",
+      family: "game",
+      result: { scenario_name: "grid_ctf", best_score: 0.73 },
+    });
+  });
+
   it("records route/materialization failures on the solve job", async () => {
     const job = createSolveJob("solve_fail", "Create a game", 1);
     const failSolveJob = vi.fn((failedJob, error) => {


### PR DESCRIPTION
## Summary
- register autoctx solve in the TypeScript command registry and DB-backed dispatch table
- add a solve command workflow around the existing TS SolveManager
- expose solve in capabilities, docs, and tests

## Tests
- npm test -- solve-command-workflow.test.ts cli-command-registry.test.ts
- npm test -- cli-dx.test.ts
- npm run lint -- --pretty false