### PR TITLE
feat(ac-620): preserve TypeScript solve controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - TypeScript CLI now exposes `autoctx solve` as a DB-backed solve-on-demand entrypoint with `--description`, `--gens`, `--timeout`, and `--json` support (AC-619).
+- TypeScript solve now preserves Python-shaped controls for family override, generation-time-budget metadata, output file writing, and classifier fallback status metadata (AC-620).
 
 ## [0.4.6] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- TypeScript CLI now exposes `autoctx solve` as a DB-backed solve-on-demand entrypoint with `--description`, `--gens`, `--timeout`, and `--json` support (AC-619).
+
 ## [0.4.6] - 2026-04-23
 
 ### Added

--- a/ts/README.md
+++ b/ts/README.md
@@ -138,7 +138,7 @@ autoctx providers
 autoctx models
 
 # Scenario execution
-autoctx solve --description "improve customer-support replies" --gens 3 --json
+autoctx solve --description "improve customer-support replies" --family agent_task --gens 3 --output package.json --json
 autoctx run --scenario support_triage --gens 3 --json
 autoctx list --json
 autoctx replay --run-id <id> --generation 1

--- a/ts/README.md
+++ b/ts/README.md
@@ -138,6 +138,7 @@ autoctx providers
 autoctx models
 
 # Scenario execution
+autoctx solve --description "improve customer-support replies" --gens 3 --json
 autoctx run --scenario support_triage --gens 3 --json
 autoctx list --json
 autoctx replay --run-id <id> --generation 1

--- a/ts/src/cli/capabilities-command-workflow.ts
+++ b/ts/src/cli/capabilities-command-workflow.ts
@@ -10,6 +10,7 @@ export const CAPABILITIES_COMMANDS = [
   "export-training-data",
   "import-package",
   "new-scenario",
+  "solve",
   "capabilities",
   "login",
   "whoami",

--- a/ts/src/cli/command-registry.ts
+++ b/ts/src/cli/command-registry.ts
@@ -27,6 +27,7 @@ export type NoDbCommandName =
 export type DbCommandName =
   | "mission"
   | "campaign"
+  | "solve"
   | "run"
   | "list"
   | "replay"
@@ -77,6 +78,7 @@ const COMMANDS: readonly CommandDescriptor[] = [
   { name: "models", description: "List available models for authenticated providers (JSON)", group: "primary", route: { kind: "no-db", command: "models" } },
   { name: "mission", description: "Manage multi-step task missions", group: "primary", route: { kind: "db", command: "mission" } },
   { name: "campaign", description: "Manage multi-mission campaigns", group: "primary", route: { kind: "db", command: "campaign" } },
+  { name: "solve", description: "Create and solve a scenario from plain language", group: "primary", route: { kind: "db", command: "solve" } },
   { name: "tui", description: "Start interactive TUI (WebSocket server + Ink UI)", group: "primary", route: { kind: "db", command: "tui" } },
   { name: "judge", description: "One-shot evaluation of output against a rubric", group: "primary", route: { kind: "db", command: "judge" } },
   { name: "improve", description: "Run multi-round improvement loop", group: "primary", route: { kind: "db", command: "improve" } },

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -498,6 +498,9 @@ async function cmdSolve(dbPath: string): Promise<void> {
       description: { type: "string", short: "d" },
       gens: { type: "string", short: "g" },
       timeout: { type: "string" },
+      "generation-time-budget": { type: "string" },
+      family: { type: "string" },
+      output: { type: "string" },
       json: { type: "boolean" },
       help: { type: "boolean", short: "h" },
     },
@@ -508,6 +511,7 @@ async function cmdSolve(dbPath: string): Promise<void> {
     planSolveCommand,
     renderSolveCommandSummary,
     SOLVE_HELP_TEXT,
+    writeSolveOutputFile,
   } = await import("./solve-command-workflow.js");
 
   if (values.help) {
@@ -542,6 +546,10 @@ async function cmdSolve(dbPath: string): Promise<void> {
       }),
       plan,
     });
+    if (plan.outputPath) {
+      writeSolveOutputFile(summary.result, resolve(plan.outputPath));
+      summary.outputPath = resolve(plan.outputPath);
+    }
     console.log(renderSolveCommandSummary(summary, plan.json));
   } catch (error) {
     console.error(errorMessage(error));

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -52,6 +52,7 @@ const NO_DB_COMMAND_HANDLERS: Record<NoDbCommandName, () => Promise<void>> = {
 const DB_COMMAND_HANDLERS: Record<DbCommandName, (dbPath: string) => Promise<void>> = {
   mission: cmdMission,
   campaign: cmdCampaign,
+  solve: cmdSolve,
   run: cmdRun,
   list: cmdList,
   replay: cmdReplay,
@@ -488,6 +489,66 @@ async function cmdRun(dbPath: string): Promise<void> {
     console.error(rendered.stderr);
   }
   console.log(rendered.stdout);
+}
+
+async function cmdSolve(dbPath: string): Promise<void> {
+  const { values } = parseArgs({
+    args: process.argv.slice(3),
+    options: {
+      description: { type: "string", short: "d" },
+      gens: { type: "string", short: "g" },
+      timeout: { type: "string" },
+      json: { type: "boolean" },
+      help: { type: "boolean", short: "h" },
+    },
+  });
+
+  const {
+    executeSolveCommandWorkflow,
+    planSolveCommand,
+    renderSolveCommandSummary,
+    SOLVE_HELP_TEXT,
+  } = await import("./solve-command-workflow.js");
+
+  if (values.help) {
+    console.log(SOLVE_HELP_TEXT);
+    process.exit(0);
+  }
+
+  let plan;
+  try {
+    plan = planSolveCommand(values, parsePositiveInteger);
+  } catch (error) {
+    console.error(errorMessage(error));
+    process.exit(1);
+  }
+
+  const { SQLiteStore } = await import("../storage/index.js");
+  const { loadSettings } = await import("../config/index.js");
+  const { SolveManager } = await import("../knowledge/solver.js");
+
+  const settings = loadSettings();
+  const store = new SQLiteStore(dbPath);
+  store.migrate(getMigrationsDir());
+
+  try {
+    const { provider } = await getProvider();
+    const summary = await executeSolveCommandWorkflow({
+      manager: new SolveManager({
+        provider,
+        store,
+        runsRoot: resolve(settings.runsRoot),
+        knowledgeRoot: resolve(settings.knowledgeRoot),
+      }),
+      plan,
+    });
+    console.log(renderSolveCommandSummary(summary, plan.json));
+  } catch (error) {
+    console.error(errorMessage(error));
+    process.exit(1);
+  } finally {
+    store.close();
+  }
 }
 
 async function cmdTui(dbPath: string): Promise<void> {

--- a/ts/src/cli/solve-command-workflow.ts
+++ b/ts/src/cli/solve-command-workflow.ts
@@ -1,23 +1,33 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
 export const SOLVE_HELP_TEXT = `autoctx solve — create and solve a scenario from a plain-language description
 
 Usage:
-  autoctx solve --description "..." [--gens N] [--json]
+  autoctx solve --description "..." [--gens N] [--family name] [--json]
 
 Options:
   -d, --description <text>   Natural-language scenario/problem description
   -g, --gens <N>             Generations to run (default: 5)
+  --family <name>            Force a scenario family before creation/routing
   --timeout <seconds>        Maximum time to wait for solve completion (default: 300)
+  --generation-time-budget <seconds>
+                              Soft per-generation solve runtime budget metadata (0 = unlimited)
+  --output <path>            Write the solved package JSON to a file
   --json                     Output structured JSON
   -h, --help                 Show this help
 
 Examples:
   autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
-  autoctx solve -d "investigate a production outage from logs" --gens 2 --json`;
+  autoctx solve -d "investigate a production outage from logs" --family investigation --gens 2 --json`;
 
 export interface SolveCommandValues {
   description?: string;
   gens?: string;
   timeout?: string;
+  "generation-time-budget"?: string;
+  family?: string;
+  output?: string;
   json?: boolean;
 }
 
@@ -25,11 +35,21 @@ export interface SolveCommandPlan {
   description: string;
   generations: number;
   timeoutMs: number;
+  generationTimeBudgetSeconds: number | null;
+  familyOverride: string | null;
+  outputPath: string | null;
   json: boolean;
 }
 
 export interface SolveManagerLike {
-  submit(description: string, generations: number): string;
+  submit(
+    description: string,
+    generations: number,
+    opts?: {
+      familyOverride?: string;
+      generationTimeBudgetSeconds?: number | null;
+    },
+  ): string;
   getStatus(jobId: string): Record<string, unknown>;
   getResult(jobId: string): Record<string, unknown> | null;
 }
@@ -41,6 +61,9 @@ export interface SolveCommandSummary {
   scenarioName: string | null;
   family: string | null;
   generations: number;
+  generationTimeBudgetSeconds: number | null;
+  outputPath: string | null;
+  llmClassifierFallbackUsed: boolean;
   progress: number;
   result: Record<string, unknown>;
 }
@@ -60,11 +83,17 @@ export function planSolveCommand(
   const timeoutMs = values.timeout
     ? parsePositiveInteger(values.timeout, "--timeout") * 1000
     : DEFAULT_TIMEOUT_MS;
+  const generationTimeBudgetSeconds = values["generation-time-budget"] === undefined
+    ? null
+    : parseNonNegativeInteger(values["generation-time-budget"], "--generation-time-budget");
 
   return {
     description,
     generations: values.gens ? parsePositiveInteger(values.gens, "--gens") : 5,
     timeoutMs,
+    generationTimeBudgetSeconds,
+    familyOverride: values.family?.trim() ? values.family.trim() : null,
+    outputPath: values.output?.trim() ? values.output.trim() : null,
     json: Boolean(values.json),
   };
 }
@@ -80,7 +109,10 @@ export async function executeSolveCommandWorkflow(opts: {
   const sleep = opts.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const deadline = now() + opts.plan.timeoutMs;
-  const jobId = opts.manager.submit(opts.plan.description, opts.plan.generations);
+  const jobId = opts.manager.submit(opts.plan.description, opts.plan.generations, {
+    familyOverride: opts.plan.familyOverride ?? undefined,
+    generationTimeBudgetSeconds: opts.plan.generationTimeBudgetSeconds,
+  });
 
   let status = opts.manager.getStatus(jobId);
   while (!isTerminalSolveStatus(status)) {
@@ -107,9 +139,22 @@ export async function executeSolveCommandWorkflow(opts: {
     scenarioName: stringOrNull(status.scenarioName),
     family: stringOrNull(status.family),
     generations: numberOrDefault(status.generations, opts.plan.generations),
+    generationTimeBudgetSeconds: nullableNumberOrDefault(
+      status.generationTimeBudgetSeconds ?? status.generation_time_budget_seconds,
+      opts.plan.generationTimeBudgetSeconds,
+    ),
+    outputPath: opts.plan.outputPath,
+    llmClassifierFallbackUsed: Boolean(
+      status.llmClassifierFallbackUsed ?? status.llm_classifier_fallback_used,
+    ),
     progress: numberOrDefault(status.progress, 0),
     result,
   };
+}
+
+export function writeSolveOutputFile(result: Record<string, unknown>, outputPath: string): void {
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, JSON.stringify(result, null, 2) + "\n", "utf-8");
 }
 
 export function renderSolveCommandSummary(summary: SolveCommandSummary, json: boolean): string {
@@ -124,6 +169,7 @@ export function renderSolveCommandSummary(summary: SolveCommandSummary, json: bo
     `  Family: ${summary.family ?? "unknown"}`,
     `  Generations: ${summary.generations}`,
     `  Progress: ${summary.progress}`,
+    ...(summary.outputPath ? [`  Output: ${summary.outputPath}`] : []),
   ].join("\n");
 }
 
@@ -137,4 +183,16 @@ function stringOrNull(value: unknown): string | null {
 
 function numberOrDefault(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function nullableNumberOrDefault(value: unknown, fallback: number | null): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function parseNonNegativeInteger(raw: string | undefined, label: string): number {
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return parsed;
 }

--- a/ts/src/cli/solve-command-workflow.ts
+++ b/ts/src/cli/solve-command-workflow.ts
@@ -1,0 +1,140 @@
+export const SOLVE_HELP_TEXT = `autoctx solve — create and solve a scenario from a plain-language description
+
+Usage:
+  autoctx solve --description "..." [--gens N] [--json]
+
+Options:
+  -d, --description <text>   Natural-language scenario/problem description
+  -g, --gens <N>             Generations to run (default: 5)
+  --timeout <seconds>        Maximum time to wait for solve completion (default: 300)
+  --json                     Output structured JSON
+  -h, --help                 Show this help
+
+Examples:
+  autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+  autoctx solve -d "investigate a production outage from logs" --gens 2 --json`;
+
+export interface SolveCommandValues {
+  description?: string;
+  gens?: string;
+  timeout?: string;
+  json?: boolean;
+}
+
+export interface SolveCommandPlan {
+  description: string;
+  generations: number;
+  timeoutMs: number;
+  json: boolean;
+}
+
+export interface SolveManagerLike {
+  submit(description: string, generations: number): string;
+  getStatus(jobId: string): Record<string, unknown>;
+  getResult(jobId: string): Record<string, unknown> | null;
+}
+
+export interface SolveCommandSummary {
+  jobId: string;
+  status: string;
+  description: string;
+  scenarioName: string | null;
+  family: string | null;
+  generations: number;
+  progress: number;
+  result: Record<string, unknown>;
+}
+
+const DEFAULT_TIMEOUT_MS = 300_000;
+const DEFAULT_POLL_INTERVAL_MS = 250;
+
+export function planSolveCommand(
+  values: SolveCommandValues,
+  parsePositiveInteger: (raw: string | undefined, label: string) => number,
+): SolveCommandPlan {
+  const description = values.description?.trim();
+  if (!description) {
+    throw new Error("Error: --description is required. Run 'autoctx solve --help' for usage.");
+  }
+
+  const timeoutMs = values.timeout
+    ? parsePositiveInteger(values.timeout, "--timeout") * 1000
+    : DEFAULT_TIMEOUT_MS;
+
+  return {
+    description,
+    generations: values.gens ? parsePositiveInteger(values.gens, "--gens") : 5,
+    timeoutMs,
+    json: Boolean(values.json),
+  };
+}
+
+export async function executeSolveCommandWorkflow(opts: {
+  manager: SolveManagerLike;
+  plan: SolveCommandPlan;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  pollIntervalMs?: number;
+}): Promise<SolveCommandSummary> {
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const deadline = now() + opts.plan.timeoutMs;
+  const jobId = opts.manager.submit(opts.plan.description, opts.plan.generations);
+
+  let status = opts.manager.getStatus(jobId);
+  while (!isTerminalSolveStatus(status)) {
+    if (now() >= deadline) {
+      throw new Error(`Solve timed out waiting for job '${jobId}'`);
+    }
+    await sleep(pollIntervalMs);
+    status = opts.manager.getStatus(jobId);
+  }
+
+  if (String(status.status) !== "completed") {
+    throw new Error(String(status.error ?? `Solve failed with status '${String(status.status)}'`));
+  }
+
+  const result = opts.manager.getResult(jobId);
+  if (!result) {
+    throw new Error(`Solve job '${jobId}' completed without an exported result`);
+  }
+
+  return {
+    jobId,
+    status: String(status.status),
+    description: String(status.description ?? opts.plan.description),
+    scenarioName: stringOrNull(status.scenarioName),
+    family: stringOrNull(status.family),
+    generations: numberOrDefault(status.generations, opts.plan.generations),
+    progress: numberOrDefault(status.progress, 0),
+    result,
+  };
+}
+
+export function renderSolveCommandSummary(summary: SolveCommandSummary, json: boolean): string {
+  if (json) {
+    return JSON.stringify(summary, null, 2);
+  }
+
+  return [
+    "Solve completed",
+    `  Job ID: ${summary.jobId}`,
+    `  Scenario: ${summary.scenarioName ?? "unknown"}`,
+    `  Family: ${summary.family ?? "unknown"}`,
+    `  Generations: ${summary.generations}`,
+    `  Progress: ${summary.progress}`,
+  ].join("\n");
+}
+
+function isTerminalSolveStatus(status: Record<string, unknown>): boolean {
+  return ["completed", "failed", "not_found"].includes(String(status.status ?? ""));
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function numberOrDefault(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}

--- a/ts/src/knowledge/solve-job-workflow.ts
+++ b/ts/src/knowledge/solve-job-workflow.ts
@@ -2,6 +2,9 @@ export interface SolveJob {
   jobId: string;
   description: string;
   generations: number;
+  familyOverride?: string;
+  generationTimeBudgetSeconds?: number | null;
+  llmClassifierFallbackUsed?: boolean;
   status: "pending" | "creating_scenario" | "running" | "completed" | "failed";
   scenarioName?: string;
   family?: string;
@@ -14,11 +17,18 @@ export function createSolveJob(
   jobId: string,
   description: string,
   generations: number,
+  opts: {
+    familyOverride?: string;
+    generationTimeBudgetSeconds?: number | null;
+  } = {},
 ): SolveJob {
   return {
     jobId,
     description,
     generations,
+    familyOverride: opts.familyOverride,
+    generationTimeBudgetSeconds: opts.generationTimeBudgetSeconds,
+    llmClassifierFallbackUsed: false,
     status: "pending",
   };
 }
@@ -37,7 +47,12 @@ export function getSolveJobStatus(
     description: job.description,
     scenarioName: job.scenarioName ?? null,
     family: job.family ?? null,
+    familyOverride: job.familyOverride ?? null,
     generations: job.generations,
+    generationTimeBudgetSeconds: job.generationTimeBudgetSeconds ?? null,
+    generation_time_budget_seconds: job.generationTimeBudgetSeconds ?? null,
+    llmClassifierFallbackUsed: job.llmClassifierFallbackUsed ?? false,
+    llm_classifier_fallback_used: job.llmClassifierFallbackUsed ?? false,
     progress: job.progress ?? 0,
     error: job.error,
   };

--- a/ts/src/knowledge/solve-manager-workflow.ts
+++ b/ts/src/knowledge/solve-manager-workflow.ts
@@ -6,9 +6,11 @@ import { executeBuiltInGameSolve } from "./built-in-game-solve-execution.js";
 import { executeAgentTaskSolve } from "./agent-task-solve-execution.js";
 import { executeCodegenSolve } from "./codegen-solve-execution.js";
 import {
+  buildSolveScenarioDescription,
   determineSolveExecutionRoute,
   persistSolveScenarioScaffold,
   prepareSolveScenario,
+  validateSolveFamilyOverride,
 } from "./solve-scenario-routing.js";
 import { failSolveJob, type SolveJob } from "./solve-workflow.js";
 
@@ -127,10 +129,14 @@ export async function executeSolveJobWorkflow(opts: {
 }): Promise<void> {
   opts.job.status = "creating_scenario";
   try {
-    const created = await opts.deps.createScenarioFromDescription(opts.job.description);
+    const familyOverride = validateSolveFamilyOverride(opts.job.familyOverride);
+    const created = await opts.deps.createScenarioFromDescription(
+      buildSolveScenarioDescription(opts.job.description, familyOverride),
+    );
     const prepared = opts.deps.prepareSolveScenario({
       created: created as never,
       description: opts.job.description,
+      familyOverride,
     });
     opts.job.scenarioName = prepared.name;
     opts.job.family = prepared.family;

--- a/ts/src/knowledge/solve-scenario-routing.ts
+++ b/ts/src/knowledge/solve-scenario-routing.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { CreatedScenarioResult } from "../scenarios/scenario-creator.js";
-import { getScenarioTypeMarker, type ScenarioFamilyName } from "../scenarios/families.js";
+import { SCENARIO_TYPE_MARKERS, getScenarioTypeMarker, type ScenarioFamilyName } from "../scenarios/families.js";
 import { hasCodegen } from "../scenarios/codegen/registry.js";
 import { materializeScenario, type MaterializeResult } from "../scenarios/materialize.js";
 import { healSpec } from "../scenarios/spec-auto-heal.js";
@@ -38,11 +38,35 @@ export function coerceSolveFamily(family: string): ScenarioFamilyName {
   }
 }
 
+export function validateSolveFamilyOverride(family: string | undefined): ScenarioFamilyName | undefined {
+  const normalized = family?.trim().toLowerCase().replace(/-/g, "_");
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized in SCENARIO_TYPE_MARKERS) {
+    return normalized as ScenarioFamilyName;
+  }
+  throw new Error(
+    `Unknown solve family '${family}'. Valid families: ${Object.keys(SCENARIO_TYPE_MARKERS).sort().join(", ")}`,
+  );
+}
+
+export function buildSolveScenarioDescription(
+  description: string,
+  familyOverride?: ScenarioFamilyName,
+): string {
+  if (!familyOverride) {
+    return description;
+  }
+  return `**Family:** ${familyOverride}\n\n${description}`;
+}
+
 export function prepareSolveScenario(opts: {
   created: CreatedScenarioResult;
   description: string;
+  familyOverride?: ScenarioFamilyName;
 }): PreparedSolveScenario {
-  const family = coerceSolveFamily(opts.created.family);
+  const family = opts.familyOverride ?? coerceSolveFamily(opts.created.family);
   return {
     ...opts.created,
     family,

--- a/ts/src/knowledge/solver.ts
+++ b/ts/src/knowledge/solver.ts
@@ -27,6 +27,11 @@ export interface SolveManagerOpts {
   knowledgeRoot: string;
 }
 
+export interface SolveSubmitOptions {
+  familyOverride?: string;
+  generationTimeBudgetSeconds?: number | null;
+}
+
 export { buildAgentTaskSolveSpec } from "./agent-task-solve-execution.js";
 
 export class SolveManager {
@@ -43,9 +48,9 @@ export class SolveManager {
     this.#knowledgeRoot = opts.knowledgeRoot;
   }
 
-  submit(description: string, generations: number): string {
+  submit(description: string, generations: number, opts: SolveSubmitOptions = {}): string {
     const jobId = buildSolveJobId();
-    const job = createSolveJob(jobId, description, generations);
+    const job = createSolveJob(jobId, description, generations, opts);
     this.#jobs.set(jobId, job);
 
     this.#runJob(job).catch(() => {

--- a/ts/src/mcp/solve-tools.ts
+++ b/ts/src/mcp/solve-tools.ts
@@ -12,7 +12,14 @@ type McpToolRegistrar = {
 };
 
 interface SolveToolManager {
-  submit(description: string, generations: number): string;
+  submit(
+    description: string,
+    generations: number,
+    opts?: {
+      familyOverride?: string;
+      generationTimeBudgetSeconds?: number | null;
+    },
+  ): string;
   getStatus(jobId: string): Record<string, unknown>;
   getResult(jobId: string): Record<string, unknown> | null;
 }
@@ -47,11 +54,32 @@ export function registerSolveTools(
   server.tool(
     "solve_scenario",
     "Submit a problem for on-demand solving. Returns a job_id for polling.",
-    { description: z.string(), generations: z.number().int().default(5) },
+    {
+      description: z.string(),
+      generations: z.number().int().default(5),
+      family: z.string().optional(),
+      generationTimeBudget: z.number().int().min(0).optional(),
+      generationTimeBudgetSeconds: z.number().int().min(0).optional(),
+      generation_time_budget: z.number().int().min(0).optional(),
+    },
     async (args: Record<string, unknown>) => {
+      const generationTimeBudgetSeconds =
+        typeof args.generationTimeBudgetSeconds === "number"
+          ? args.generationTimeBudgetSeconds
+          : typeof args.generationTimeBudget === "number"
+            ? args.generationTimeBudget
+            : typeof args.generation_time_budget === "number"
+              ? args.generation_time_budget
+              : undefined;
       const jobId = opts.solveManager.submit(
         String(args.description),
         Number(args.generations ?? 5),
+        {
+          familyOverride: typeof args.family === "string" && args.family.trim()
+            ? args.family.trim()
+            : undefined,
+          generationTimeBudgetSeconds,
+        },
       );
       return jsonText({ jobId, status: "pending" });
     },

--- a/ts/tests/cli-command-registry.test.ts
+++ b/ts/tests/cli-command-registry.test.ts
@@ -23,6 +23,7 @@ describe("CLI command registry", () => {
       kind: "db",
       command: "mission",
     });
+    expect(resolveCliCommand("solve")).toEqual({ kind: "db", command: "solve" });
     expect(resolveCliCommand("init")).toEqual({ kind: "no-db", command: "init" });
     expect(resolveCliCommand("registry")).toEqual({
       kind: "control-plane",

--- a/ts/tests/cli-dx.test.ts
+++ b/ts/tests/cli-dx.test.ts
@@ -357,6 +357,24 @@ describe("AC-405: autoctx capabilities", () => {
   });
 });
 
+describe("AC-619: autoctx solve", () => {
+  it("appears in top-level and command-specific help", () => {
+    const topLevel = runCli(["--help"]);
+    expect(topLevel.stdout).toContain("solve");
+
+    const solveHelp = runCli(["solve", "--help"]);
+    expect(solveHelp.exitCode).toBe(0);
+    expect(solveHelp.stdout).toContain("autoctx solve");
+    expect(solveHelp.stdout).toContain("--description");
+  });
+
+  it("requires a description", () => {
+    const { stderr, exitCode } = runCli(["solve"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("--description is required");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // AC-418: capabilities reports dynamic version
 // ---------------------------------------------------------------------------

--- a/ts/tests/solve-command-workflow.test.ts
+++ b/ts/tests/solve-command-workflow.test.ts
@@ -4,7 +4,11 @@ import {
   executeSolveCommandWorkflow,
   planSolveCommand,
   renderSolveCommandSummary,
+  writeSolveOutputFile,
 } from "../src/cli/solve-command-workflow.js";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 describe("solve command workflow", () => {
   it("plans required description, generations, timeout, and JSON output", () => {
@@ -16,6 +20,9 @@ describe("solve command workflow", () => {
           description: "  investigate checkout failures  ",
           gens: "3",
           timeout: "12",
+          "generation-time-budget": "4",
+          family: "investigation",
+          output: "solve-result.json",
           json: true,
         },
         parsePositiveInteger,
@@ -24,6 +31,9 @@ describe("solve command workflow", () => {
       description: "investigate checkout failures",
       generations: 3,
       timeoutMs: 12_000,
+      generationTimeBudgetSeconds: 4,
+      familyOverride: "investigation",
+      outputPath: "solve-result.json",
       json: true,
     });
     expect(parsePositiveInteger).toHaveBeenCalledWith("3", "--gens");
@@ -58,13 +68,19 @@ describe("solve command workflow", () => {
         description: "grid ctf",
         generations: 1,
         timeoutMs: 1000,
+        generationTimeBudgetSeconds: 7,
+        familyOverride: "game",
+        outputPath: "result.json",
         json: true,
       },
       sleep: vi.fn(async () => undefined),
       pollIntervalMs: 1,
     });
 
-    expect(submit).toHaveBeenCalledWith("grid ctf", 1);
+    expect(submit).toHaveBeenCalledWith("grid ctf", 1, {
+      familyOverride: "game",
+      generationTimeBudgetSeconds: 7,
+    });
     expect(getStatus).toHaveBeenCalledTimes(2);
     expect(summary).toEqual({
       jobId: "solve-123",
@@ -73,6 +89,9 @@ describe("solve command workflow", () => {
       scenarioName: "grid_ctf",
       family: "game",
       generations: 1,
+      generationTimeBudgetSeconds: 7,
+      outputPath: "result.json",
+      llmClassifierFallbackUsed: false,
       progress: 1,
       result: { scenario_name: "grid_ctf" },
     });
@@ -86,11 +105,28 @@ describe("solve command workflow", () => {
       scenarioName: "grid_ctf",
       family: "game",
       generations: 1,
+      generationTimeBudgetSeconds: null,
+      outputPath: null,
+      llmClassifierFallbackUsed: false,
       progress: 1,
       result: { scenario_name: "grid_ctf" },
     };
 
     expect(JSON.parse(renderSolveCommandSummary(summary, true))).toEqual(summary);
     expect(renderSolveCommandSummary(summary, false)).toContain("Solve completed");
+  });
+
+  it("writes solved package output JSON files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ac-solve-output-"));
+    try {
+      const outputPath = join(dir, "package.json");
+      writeSolveOutputFile({ scenario_name: "grid_ctf" }, outputPath);
+      expect(existsSync(outputPath)).toBe(true);
+      expect(JSON.parse(readFileSync(outputPath, "utf-8"))).toEqual({
+        scenario_name: "grid_ctf",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/ts/tests/solve-command-workflow.test.ts
+++ b/ts/tests/solve-command-workflow.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executeSolveCommandWorkflow,
+  planSolveCommand,
+  renderSolveCommandSummary,
+} from "../src/cli/solve-command-workflow.js";
+
+describe("solve command workflow", () => {
+  it("plans required description, generations, timeout, and JSON output", () => {
+    const parsePositiveInteger = vi.fn((raw: string | undefined) => Number(raw));
+
+    expect(
+      planSolveCommand(
+        {
+          description: "  investigate checkout failures  ",
+          gens: "3",
+          timeout: "12",
+          json: true,
+        },
+        parsePositiveInteger,
+      ),
+    ).toEqual({
+      description: "investigate checkout failures",
+      generations: 3,
+      timeoutMs: 12_000,
+      json: true,
+    });
+    expect(parsePositiveInteger).toHaveBeenCalledWith("3", "--gens");
+    expect(parsePositiveInteger).toHaveBeenCalledWith("12", "--timeout");
+  });
+
+  it("rejects missing descriptions", () => {
+    expect(() =>
+      planSolveCommand({}, () => 1),
+    ).toThrow("--description is required");
+  });
+
+  it("submits a solve job and waits for completion", async () => {
+    const submit = vi.fn(() => "solve-123");
+    const getStatus = vi
+      .fn()
+      .mockReturnValueOnce({ jobId: "solve-123", status: "running", progress: 0 })
+      .mockReturnValueOnce({
+        jobId: "solve-123",
+        status: "completed",
+        description: "grid ctf",
+        scenarioName: "grid_ctf",
+        family: "game",
+        generations: 1,
+        progress: 1,
+      });
+    const getResult = vi.fn(() => ({ scenario_name: "grid_ctf" }));
+
+    const summary = await executeSolveCommandWorkflow({
+      manager: { submit, getStatus, getResult },
+      plan: {
+        description: "grid ctf",
+        generations: 1,
+        timeoutMs: 1000,
+        json: true,
+      },
+      sleep: vi.fn(async () => undefined),
+      pollIntervalMs: 1,
+    });
+
+    expect(submit).toHaveBeenCalledWith("grid ctf", 1);
+    expect(getStatus).toHaveBeenCalledTimes(2);
+    expect(summary).toEqual({
+      jobId: "solve-123",
+      status: "completed",
+      description: "grid ctf",
+      scenarioName: "grid_ctf",
+      family: "game",
+      generations: 1,
+      progress: 1,
+      result: { scenario_name: "grid_ctf" },
+    });
+  });
+
+  it("renders structured JSON or concise text", () => {
+    const summary = {
+      jobId: "solve-123",
+      status: "completed",
+      description: "grid ctf",
+      scenarioName: "grid_ctf",
+      family: "game",
+      generations: 1,
+      progress: 1,
+      result: { scenario_name: "grid_ctf" },
+    };
+
+    expect(JSON.parse(renderSolveCommandSummary(summary, true))).toEqual(summary);
+    expect(renderSolveCommandSummary(summary, false)).toContain("Solve completed");
+  });
+});

--- a/ts/tests/solve-manager-workflow.test.ts
+++ b/ts/tests/solve-manager-workflow.test.ts
@@ -12,7 +12,20 @@ describe("solve manager workflow", () => {
   });
 
   it("routes agent-task jobs through scenario preparation, persistence, and execution", async () => {
-    const job = createSolveJob("solve_job", "Summarize outage escalations", 2);
+    const job = createSolveJob("solve_job", "Summarize outage escalations", 2, {
+      familyOverride: "agent_task",
+      generationTimeBudgetSeconds: 30,
+    });
+    const createScenarioFromDescription = vi.fn(async () => ({
+      name: "incident_triage",
+      family: "agent_task",
+      spec: { taskPrompt: "Summarize incident reports", rubric: "Evaluate completeness" },
+    }));
+    const prepareSolveScenario = vi.fn(({ created, description, familyOverride }) => ({
+      ...created,
+      description,
+      family: familyOverride,
+    }));
     const executeAgentTaskSolve = vi.fn(async () => ({
       progress: 1,
       result: { scenario_name: "incident_triage", best_score: 0.93 },
@@ -25,13 +38,9 @@ describe("solve manager workflow", () => {
       runsRoot: "/tmp/runs",
       knowledgeRoot: "/tmp/knowledge",
       deps: {
-        createScenarioFromDescription: vi.fn(async () => ({
-          name: "incident_triage",
-          family: "agent_task",
-          spec: { taskPrompt: "Summarize incident reports", rubric: "Evaluate completeness" },
-        })),
+        createScenarioFromDescription,
         listBuiltinScenarioNames: vi.fn(async () => ["grid_ctf"]),
-        prepareSolveScenario: vi.fn(({ created, description }) => ({ ...created, description })) as never,
+        prepareSolveScenario: prepareSolveScenario as never,
         determineSolveExecutionRoute: vi.fn(() => "agent_task") as never,
         persistSolveScenarioScaffold: vi.fn(async () => ({ persisted: true, errors: [] })) as never,
         executeBuiltInGameSolve: vi.fn() as never,
@@ -44,6 +53,12 @@ describe("solve manager workflow", () => {
       },
     });
 
+    expect(createScenarioFromDescription).toHaveBeenCalledWith(
+      expect.stringContaining("**Family:** agent_task"),
+    );
+    expect(prepareSolveScenario).toHaveBeenCalledWith(
+      expect.objectContaining({ familyOverride: "agent_task" }),
+    );
     expect(executeAgentTaskSolve).toHaveBeenCalledWith({
       provider: expect.objectContaining({ name: "mock" }),
       created: expect.objectContaining({ name: "incident_triage" }),

--- a/ts/tests/solve-scenario-routing.test.ts
+++ b/ts/tests/solve-scenario-routing.test.ts
@@ -4,9 +4,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
+  buildSolveScenarioDescription,
   determineSolveExecutionRoute,
   persistSolveScenarioScaffold,
   prepareSolveScenario,
+  validateSolveFamilyOverride,
 } from "../src/knowledge/solve-scenario-routing.js";
 
 let tmpDir: string;
@@ -36,6 +38,30 @@ describe("solve scenario routing", () => {
 
     expect(prepared.family).toBe("agent_task");
     expect(prepared.spec.description).toBe("Incident summary task");
+  });
+
+  it("honors explicit family overrides and builds classifier hints", () => {
+    expect(validateSolveFamilyOverride("operator-loop")).toBe("operator_loop");
+    expect(() => validateSolveFamilyOverride("nope")).toThrow("Unknown solve family");
+    expect(buildSolveScenarioDescription("Handle escalations", "operator_loop")).toContain(
+      "**Family:** operator_loop",
+    );
+
+    const prepared = prepareSolveScenario({
+      description: "Investigate a production outage",
+      familyOverride: "investigation",
+      created: {
+        name: "outage_summary",
+        family: "agent_task",
+        spec: {
+          taskPrompt: "Summarize outage reports",
+          rubric: "Evaluate completeness",
+          description: "Outage task",
+        },
+      },
+    });
+
+    expect(prepared.family).toBe("investigation");
   });
 
   it("routes prepared scenarios through explicit execution paths", () => {

--- a/ts/tests/solve-tools.test.ts
+++ b/ts/tests/solve-tools.test.ts
@@ -44,9 +44,14 @@ describe("solve MCP tools", () => {
     const result = await server.registeredTools.solve_scenario.handler({
       description: "grid ctf",
       generations: 2,
+      family: "game",
+      generation_time_budget: 10,
     });
 
-    expect(submit).toHaveBeenCalledWith("grid ctf", 2);
+    expect(submit).toHaveBeenCalledWith("grid ctf", 2, {
+      familyOverride: "game",
+      generationTimeBudgetSeconds: 10,
+    });
     expect(JSON.parse(result.content[0].text)).toEqual({
       jobId: "solve-123",
       status: "pending",

--- a/ts/tests/solve-workflow.test.ts
+++ b/ts/tests/solve-workflow.test.ts
@@ -11,12 +11,18 @@ import {
 
 describe("solve workflow", () => {
   it("creates solve jobs and reports status payloads", () => {
-    const job = createSolveJob("solve_123", "Summarize outage escalations", 3);
+    const job = createSolveJob("solve_123", "Summarize outage escalations", 3, {
+      familyOverride: "agent_task",
+      generationTimeBudgetSeconds: 15,
+    });
 
     expect(job).toMatchObject({
       jobId: "solve_123",
       description: "Summarize outage escalations",
       generations: 3,
+      familyOverride: "agent_task",
+      generationTimeBudgetSeconds: 15,
+      llmClassifierFallbackUsed: false,
       status: "pending",
     });
 
@@ -24,6 +30,11 @@ describe("solve workflow", () => {
       jobId: "solve_123",
       status: "pending",
       generations: 3,
+      familyOverride: "agent_task",
+      generationTimeBudgetSeconds: 15,
+      generation_time_budget_seconds: 15,
+      llmClassifierFallbackUsed: false,
+      llm_classifier_fallback_used: false,
       progress: 0,
     });
 


### PR DESCRIPTION
## Summary
- extend TS solve jobs with family override, generation-time-budget metadata, and classifier fallback metadata
- wire family/generation budget through CLI and MCP solve submission
- add CLI output file writing for solved package JSON

## Stack
- Stacked on #782 / codex/ac-619-ts-solve-cli because this extends the TS solve CLI added there.

## Tests
- npm test -- solve-command-workflow.test.ts solve-tools.test.ts solve-manager-workflow.test.ts solve-workflow.test.ts solve-scenario-routing.test.ts
- npm run lint -- --pretty false