### PR TITLE
feat(ac-625): run saved agent-task scenarios in TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - TypeScript capabilities now report the provider factory support surface and no longer mark the visible `train` command as Python-only (AC-626).
+- TypeScript `run` now supports saved custom `agent_task` scenarios through the agent-task improvement runner instead of rejecting scenarios already discoverable in the control plane (AC-625).
 
 ## [0.4.6] - 2026-04-23
 

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -412,6 +412,7 @@ async function cmdRun(dbPath: string): Promise<void> {
   });
 
   const {
+    executeAgentTaskRunCommandWorkflow,
     executeRunCommandWorkflow,
     planRunCommand,
     renderRunResult,
@@ -454,6 +455,30 @@ async function cmdRun(dbPath: string): Promise<void> {
     settings,
     plan.providerType ? { providerType: plan.providerType } : {},
   );
+
+  if (!SCENARIO_REGISTRY[plan.scenarioName]) {
+    const { resolveCustomAgentTask } = await import("../scenarios/custom-loader.js");
+    const savedAgentTask = resolveCustomAgentTask(
+      resolve(settings.knowledgeRoot),
+      plan.scenarioName,
+    );
+    if (savedAgentTask) {
+      const { executeAgentTaskSolve } =
+        await import("../knowledge/agent-task-solve-execution.js");
+      const result = await executeAgentTaskRunCommandWorkflow({
+        plan,
+        providerBundle,
+        spec: savedAgentTask.spec,
+        executeAgentTaskSolve: executeAgentTaskSolve as never,
+      });
+      const rendered = renderRunResult(result, plan.json);
+      if (rendered.stderr) {
+        console.error(rendered.stderr);
+      }
+      console.log(rendered.stdout);
+      return;
+    }
+  }
 
   let ScenarioClass;
   try {

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -470,6 +470,9 @@ async function cmdRun(dbPath: string): Promise<void> {
         providerBundle,
         spec: savedAgentTask.spec,
         executeAgentTaskSolve: executeAgentTaskSolve as never,
+        dbPath,
+        migrationsDir: getMigrationsDir(),
+        createStore: (runDbPath) => new SQLiteStore(runDbPath),
       });
       const rendered = renderRunResult(result, plan.json);
       if (rendered.stderr) {

--- a/ts/src/cli/run-command-workflow.ts
+++ b/ts/src/cli/run-command-workflow.ts
@@ -3,7 +3,7 @@ export const RUN_HELP_TEXT = `autoctx run — Run the generation loop for a scen
 Usage: autoctx run [options]
 
 Options:
-  --scenario <name>    Scenario to run (current built-in: grid_ctf)
+  --scenario <name>    Scenario to run (built-in or saved custom agent_task)
   --gens N             Number of generations to run (default: from config or 1)
   --run-id <id>        Custom run identifier (default: auto-generated)
   --provider <type>    LLM provider: anthropic, openai, ollama, deterministic, etc.
@@ -68,7 +68,44 @@ export interface RunCommandResult {
   bestScore: number;
   currentElo: number;
   provider: string;
+  skillPackage?: Record<string, unknown>;
   synthetic?: true;
+}
+
+type AgentTaskSolveExecutor = (opts: {
+  provider: unknown;
+  created: { name: string; spec: Record<string, unknown> };
+  generations: number;
+}) => Promise<{ progress: number; result: Record<string, unknown> }>;
+
+export async function executeAgentTaskRunCommandWorkflow<TProviderBundle extends {
+  defaultProvider: unknown;
+  defaultConfig: { providerType: string };
+}>(opts: {
+  plan: RunCommandPlan;
+  providerBundle: TProviderBundle;
+  spec: Record<string, unknown>;
+  executeAgentTaskSolve: AgentTaskSolveExecutor;
+}): Promise<RunCommandResult> {
+  const result = await opts.executeAgentTaskSolve({
+    provider: opts.providerBundle.defaultProvider,
+    created: {
+      name: opts.plan.scenarioName,
+      spec: opts.spec,
+    },
+    generations: opts.plan.gens,
+  });
+  const bestScore = typeof result.result.best_score === "number" ? result.result.best_score : 0;
+  const provider = opts.providerBundle.defaultConfig.providerType;
+  return {
+    runId: opts.plan.runId,
+    generationsCompleted: result.progress,
+    bestScore,
+    currentElo: 1000,
+    provider,
+    skillPackage: result.result,
+    ...(provider === "deterministic" ? { synthetic: true } : {}),
+  };
 }
 
 export async function planRunCommand(

--- a/ts/src/cli/run-command-workflow.ts
+++ b/ts/src/cli/run-command-workflow.ts
@@ -78,6 +78,34 @@ type AgentTaskSolveExecutor = (opts: {
   generations: number;
 }) => Promise<{ progress: number; result: Record<string, unknown> }>;
 
+export interface AgentTaskRunStore {
+  migrate(migrationsDir: string): void;
+  createRun(
+    runId: string,
+    scenario: string,
+    generations: number,
+    executorMode: string,
+    agentProvider?: string,
+  ): void;
+  updateRunStatus(runId: string, status: string): void;
+  upsertGeneration(
+    runId: string,
+    generationIndex: number,
+    opts: {
+      meanScore: number;
+      bestScore: number;
+      elo: number;
+      wins: number;
+      losses: number;
+      gateDecision: string;
+      status: string;
+      scoringBackend?: string;
+      ratingUncertainty?: number | null;
+    },
+  ): void;
+  close(): void;
+}
+
 export async function executeAgentTaskRunCommandWorkflow<TProviderBundle extends {
   defaultProvider: unknown;
   defaultConfig: { providerType: string };
@@ -86,26 +114,62 @@ export async function executeAgentTaskRunCommandWorkflow<TProviderBundle extends
   providerBundle: TProviderBundle;
   spec: Record<string, unknown>;
   executeAgentTaskSolve: AgentTaskSolveExecutor;
+  dbPath?: string;
+  migrationsDir?: string;
+  createStore?: (dbPath: string) => AgentTaskRunStore;
 }): Promise<RunCommandResult> {
-  const result = await opts.executeAgentTaskSolve({
-    provider: opts.providerBundle.defaultProvider,
-    created: {
-      name: opts.plan.scenarioName,
-      spec: opts.spec,
-    },
-    generations: opts.plan.gens,
-  });
-  const bestScore = typeof result.result.best_score === "number" ? result.result.best_score : 0;
   const provider = opts.providerBundle.defaultConfig.providerType;
-  return {
-    runId: opts.plan.runId,
-    generationsCompleted: result.progress,
-    bestScore,
-    currentElo: 1000,
-    provider,
-    skillPackage: result.result,
-    ...(provider === "deterministic" ? { synthetic: true } : {}),
-  };
+  const migrationsDir = opts.migrationsDir;
+  const store = opts.createStore && opts.dbPath && opts.migrationsDir
+    ? opts.createStore(opts.dbPath)
+    : null;
+
+  try {
+    if (store && migrationsDir) {
+      store.migrate(migrationsDir);
+    }
+    store?.createRun(opts.plan.runId, opts.plan.scenarioName, opts.plan.gens, "agent_task", provider);
+
+    const result = await opts.executeAgentTaskSolve({
+      provider: opts.providerBundle.defaultProvider,
+      created: {
+        name: opts.plan.scenarioName,
+        spec: opts.spec,
+      },
+      generations: opts.plan.gens,
+    });
+    const bestScore = typeof result.result.best_score === "number" ? result.result.best_score : 0;
+    const generationsCompleted = normalizeCompletedGenerations(result.progress);
+
+    for (let generation = 1; generation <= generationsCompleted; generation++) {
+      store?.upsertGeneration(opts.plan.runId, generation, {
+        meanScore: bestScore,
+        bestScore,
+        elo: 1000,
+        wins: 0,
+        losses: 0,
+        gateDecision: "advance",
+        status: "completed",
+        scoringBackend: "agent_task",
+      });
+    }
+    store?.updateRunStatus(opts.plan.runId, "completed");
+
+    return {
+      runId: opts.plan.runId,
+      generationsCompleted,
+      bestScore,
+      currentElo: 1000,
+      provider,
+      skillPackage: result.result,
+      ...(provider === "deterministic" ? { synthetic: true } : {}),
+    };
+  } catch (error) {
+    store?.updateRunStatus(opts.plan.runId, "failed");
+    throw error;
+  } finally {
+    store?.close();
+  }
 }
 
 export async function planRunCommand(
@@ -262,4 +326,8 @@ export function renderRunResult(
       : {}),
     stdout: `Run ${result.runId}: ${result.generationsCompleted} generations, best score ${result.bestScore.toFixed(4)}, Elo ${result.currentElo.toFixed(1)}`,
   };
+}
+
+function normalizeCompletedGenerations(progress: number): number {
+  return Number.isFinite(progress) ? Math.max(0, Math.floor(progress)) : 0;
 }

--- a/ts/src/knowledge/agent-task-solve-execution.ts
+++ b/ts/src/knowledge/agent-task-solve-execution.ts
@@ -137,7 +137,14 @@ export async function executeAgentTaskSolve(opts: {
   generations: number;
   deps?: AgentTaskSolveExecutionDeps;
 }): Promise<AgentTaskSolveExecutionResult> {
-  const spec = buildAgentTaskSolveSpec(opts.created.spec, opts.generations);
+  const spec = buildAgentTaskSolveSpec(
+    {
+      ...opts.created.spec,
+      maxRounds: opts.generations,
+      max_rounds: opts.generations,
+    },
+    opts.generations,
+  );
   const task = (opts.deps?.createTask ?? createAgentTask)({
     spec,
     name: opts.created.name,

--- a/ts/src/server/run-manager.ts
+++ b/ts/src/server/run-manager.ts
@@ -30,6 +30,7 @@ import { executeChatAgentInteraction } from "./chat-agent-workflow.js";
 import { RunCustomScenarioRegistry } from "./run-custom-scenario-registry.js";
 import { RunManagerProviderSession } from "./run-manager-provider-session.js";
 import {
+  executeAgentTaskCustomStartRun,
   executeBuiltInGameStartRun,
   executeGeneratedCustomStartRun,
   resolveBuiltInGameScenario,
@@ -270,6 +271,32 @@ export class RunManager {
       return id;
     }
 
+    if (plan.kind === "agent_task_custom") {
+      const settings = loadSettings();
+      const providerBundle = this.#resolveProviderBundle(settings);
+      this.#runPromise = createManagedRunExecution({
+        runId: id,
+        execute: () => executeAgentTaskCustomStartRun({
+          runId: id,
+          scenarioName: plan.scenarioName,
+          entry: plan.entry,
+          generations,
+          provider: providerBundle.defaultProvider,
+          controller: this.#controller,
+          events: this.#events,
+        }),
+        events: this.#events,
+        getPaused: () => this.#controller.isPaused(),
+        setActive: (active) => {
+          this.#active = active;
+        },
+        updateState: (patch) => {
+          this.#updateState(patch);
+        },
+      });
+      return id;
+    }
+
     this.#runPromise = createManagedRunExecution({
       runId: id,
       execute: () => executeGeneratedCustomStartRun({
@@ -351,4 +378,3 @@ export class RunManager {
       .join(" ");
   }
 }
-

--- a/ts/src/server/run-start-workflow.ts
+++ b/ts/src/server/run-start-workflow.ts
@@ -9,12 +9,18 @@ import { assertFamilyContract } from "../scenarios/family-interfaces.js";
 import type { ScenarioInterface } from "../scenarios/game-interface.js";
 import type { CustomScenarioEntry } from "../scenarios/custom-loader.js";
 import { executeGeneratedScenarioEntry } from "../scenarios/codegen/executor.js";
+import { executeAgentTaskSolve } from "../knowledge/agent-task-solve-execution.js";
 import type { ScenarioFamilyName } from "../scenarios/families.js";
 import { SCENARIO_REGISTRY } from "../scenarios/registry.js";
 import { SQLiteStore } from "../storage/index.js";
 
 export type RunStartPlan =
   | { kind: "builtin_game"; scenarioName: string }
+  | {
+    kind: "agent_task_custom";
+    scenarioName: string;
+    entry: CustomScenarioEntry;
+  }
   | {
     kind: "generated_custom";
     scenarioName: string;
@@ -37,10 +43,18 @@ export function resolveRunStartPlan(opts: {
   if (!customScenario) {
     throw new Error(`Unknown scenario: ${opts.scenario}. Available: ${opts.builtinScenarioNames.join(", ")}`);
   }
-  if (!customScenario.hasGeneratedSource || !family || family === "agent_task") {
+  if (family === "agent_task" || customScenario.type === "agent_task") {
+    return {
+      kind: "agent_task_custom",
+      scenarioName: opts.scenario,
+      entry: customScenario,
+    };
+  }
+
+  if (!customScenario.hasGeneratedSource || !family) {
     throw new Error(
       `Scenario '${opts.scenario}' is a saved custom ${customScenario.type ?? "unknown"} scenario. ` +
-      "It is discoverable in the TS control plane, but /run currently supports only built-in game scenarios and generated non-agent-task scenarios.",
+      "It is discoverable in the TS control plane, but /run currently supports only built-in game, saved agent-task, and generated custom scenarios.",
     );
   }
 
@@ -172,6 +186,67 @@ export async function executeBuiltInGameStartRun(opts: {
   } finally {
     store.close();
   }
+}
+
+export interface AgentTaskCustomStartRunDeps {
+  executeAgentTaskSolve?: typeof executeAgentTaskSolve;
+}
+
+function readBestScore(result: Record<string, unknown>): number {
+  const raw = result.best_score;
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : 0;
+}
+
+export async function executeAgentTaskCustomStartRun(opts: {
+  runId: string;
+  scenarioName: string;
+  entry: CustomScenarioEntry;
+  generations: number;
+  provider: import("../types/index.js").LLMProvider;
+  controller: LoopController;
+  events: EventStreamEmitter;
+  deps?: AgentTaskCustomStartRunDeps;
+}): Promise<void> {
+  const executeTask = opts.deps?.executeAgentTaskSolve ?? executeAgentTaskSolve;
+
+  opts.events.emit("run_started", {
+    run_id: opts.runId,
+    scenario: opts.scenarioName,
+    target_generations: opts.generations,
+    family: "agent_task",
+    saved_custom: true,
+  });
+  await opts.controller.waitIfPaused();
+  opts.events.emit("generation_started", { run_id: opts.runId, generation: 1 });
+
+  const result = await executeTask({
+    provider: opts.provider,
+    created: {
+      name: opts.scenarioName,
+      spec: opts.entry.spec,
+    },
+    generations: opts.generations,
+  });
+  const bestScore = readBestScore(result.result);
+
+  opts.events.emit("generation_completed", {
+    run_id: opts.runId,
+    generation: 1,
+    mean_score: bestScore,
+    best_score: bestScore,
+    elo: 1000,
+    gate_decision: "advance",
+    family: "agent_task",
+    rounds_completed: result.progress,
+  });
+  opts.events.emit("run_completed", {
+    run_id: opts.runId,
+    completed_generations: result.progress,
+    best_score: bestScore,
+    elo: 1000,
+    family: "agent_task",
+    saved_custom: true,
+  });
 }
 
 export interface GeneratedCustomStartRunDeps {

--- a/ts/src/server/run-start-workflow.ts
+++ b/ts/src/server/run-start-workflow.ts
@@ -197,6 +197,10 @@ function readBestScore(result: Record<string, unknown>): number {
   return typeof raw === "number" && Number.isFinite(raw) ? raw : 0;
 }
 
+function normalizeCompletedGenerations(progress: number): number {
+  return Number.isFinite(progress) ? Math.max(0, Math.floor(progress)) : 0;
+}
+
 export async function executeAgentTaskCustomStartRun(opts: {
   runId: string;
   scenarioName: string;
@@ -228,20 +232,26 @@ export async function executeAgentTaskCustomStartRun(opts: {
     generations: opts.generations,
   });
   const bestScore = readBestScore(result.result);
+  const completedGenerations = normalizeCompletedGenerations(result.progress);
 
-  opts.events.emit("generation_completed", {
-    run_id: opts.runId,
-    generation: 1,
-    mean_score: bestScore,
-    best_score: bestScore,
-    elo: 1000,
-    gate_decision: "advance",
-    family: "agent_task",
-    rounds_completed: result.progress,
-  });
+  for (let generation = 1; generation <= completedGenerations; generation++) {
+    if (generation > 1) {
+      opts.events.emit("generation_started", { run_id: opts.runId, generation });
+    }
+    opts.events.emit("generation_completed", {
+      run_id: opts.runId,
+      generation,
+      mean_score: bestScore,
+      best_score: bestScore,
+      elo: 1000,
+      gate_decision: "advance",
+      family: "agent_task",
+      rounds_completed: completedGenerations,
+    });
+  }
   opts.events.emit("run_completed", {
     run_id: opts.runId,
-    completed_generations: result.progress,
+    completed_generations: completedGenerations,
     best_score: bestScore,
     elo: 1000,
     family: "agent_task",

--- a/ts/tests/agent-task-solve-execution.test.ts
+++ b/ts/tests/agent-task-solve-execution.test.ts
@@ -119,6 +119,74 @@ describe("agent-task solve execution", () => {
     expect(result.result.skill_markdown).toContain("Best round: 1");
   });
 
+  it("lets the requested generation count override saved maxRounds", async () => {
+    const provider: LLMProvider = {
+      name: "test-provider",
+      defaultModel: () => "test-model",
+      complete: vi.fn(async () => ({
+        text: "Initial response",
+        model: "test-model",
+        usage: {},
+      })),
+    };
+    const taskFromSpec = vi.fn((opts: {
+      spec: ReturnType<typeof buildAgentTaskSolveSpec>;
+      name: string;
+      provider: LLMProvider;
+    }) => ({
+      name: "saved_task",
+      spec: opts.spec,
+      getTaskPrompt: () => "Do work",
+      getRubric: () => "Do it well",
+      describeTask: () => "Do work",
+      initialState: () => ({}),
+      validateContext: () => [],
+      evaluateOutput: async () => ({
+        score: 0.5,
+        reasoning: "ok",
+        dimensionScores: {},
+        internalRetries: 0,
+      }),
+    }));
+
+    await executeAgentTaskSolve({
+      provider,
+      created: {
+        name: "saved_task",
+        spec: {
+          taskPrompt: "Do work",
+          judgeRubric: "Do it well",
+          maxRounds: 1,
+        },
+      },
+      generations: 3,
+      deps: {
+        createTask: taskFromSpec,
+        createLoop: ({ maxRounds }) => {
+          expect(maxRounds).toBe(3);
+          return {
+            run: vi.fn(async () => ({
+              rounds: [],
+              bestOutput: "Initial response",
+              bestScore: 0.5,
+              bestRound: 1,
+              totalRounds: 3,
+              metThreshold: false,
+              judgeFailures: 0,
+              terminationReason: "max_rounds",
+              dimensionTrajectory: {},
+              totalInternalRetries: 0,
+              durationMs: 1,
+              judgeCalls: 1,
+            })),
+          };
+        },
+      },
+    });
+
+    expect(taskFromSpec.mock.calls[0]?.[0].spec.maxRounds).toBe(3);
+  });
+
   it("fails when prepared context is invalid", async () => {
     const provider: LLMProvider = {
       name: "test-provider",

--- a/ts/tests/run-command-workflow.test.ts
+++ b/ts/tests/run-command-workflow.test.ts
@@ -213,6 +213,15 @@ describe("run command workflow", () => {
       },
       spec: { taskPrompt: "Do work", judgeRubric: "Do it well" },
       executeAgentTaskSolve,
+      dbPath: "/tmp/run.db",
+      migrationsDir: "/tmp/migrations",
+      createStore: vi.fn(() => ({
+        migrate: vi.fn(),
+        createRun: vi.fn(),
+        updateRunStatus: vi.fn(),
+        upsertGeneration: vi.fn(),
+        close: vi.fn(),
+      })),
     });
 
     expect(executeAgentTaskSolve).toHaveBeenCalledWith({
@@ -235,6 +244,61 @@ describe("run command workflow", () => {
       },
       synthetic: true,
     });
+  });
+
+  it("persists saved agent-task runs and completed generations", async () => {
+    const store = {
+      migrate: vi.fn(),
+      createRun: vi.fn(),
+      updateRunStatus: vi.fn(),
+      upsertGeneration: vi.fn(),
+      close: vi.fn(),
+    };
+
+    await executeAgentTaskRunCommandWorkflow({
+      plan: {
+        scenarioName: "saved_task",
+        gens: 2,
+        runId: "run-task",
+        providerType: "deterministic",
+        matches: 1,
+        json: true,
+      },
+      providerBundle: {
+        defaultProvider: { name: "provider" },
+        defaultConfig: { providerType: "deterministic" },
+      },
+      spec: { taskPrompt: "Do work", judgeRubric: "Do it well" },
+      executeAgentTaskSolve: vi.fn(async () => ({
+        progress: 2,
+        result: { scenario_name: "saved_task", best_score: 0.91 },
+      })),
+      dbPath: "/tmp/run.db",
+      migrationsDir: "/tmp/migrations",
+      createStore: vi.fn(() => store),
+    });
+
+    expect(store.migrate).toHaveBeenCalledWith("/tmp/migrations");
+    expect(store.createRun).toHaveBeenCalledWith(
+      "run-task",
+      "saved_task",
+      2,
+      "agent_task",
+      "deterministic",
+    );
+    expect(store.upsertGeneration).toHaveBeenCalledTimes(2);
+    expect(store.upsertGeneration).toHaveBeenNthCalledWith(2, "run-task", 2, {
+      meanScore: 0.91,
+      bestScore: 0.91,
+      elo: 1000,
+      wins: 0,
+      losses: 0,
+      gateDecision: "advance",
+      status: "completed",
+      scoringBackend: "agent_task",
+    });
+    expect(store.updateRunStatus).toHaveBeenCalledWith("run-task", "completed");
+    expect(store.close).toHaveBeenCalledOnce();
   });
 
   it("renders json and human-readable run results", () => {

--- a/ts/tests/run-command-workflow.test.ts
+++ b/ts/tests/run-command-workflow.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  executeAgentTaskRunCommandWorkflow,
   executeRunCommandWorkflow,
   planRunCommand,
   renderRunResult,
@@ -184,6 +185,54 @@ describe("run command workflow", () => {
       bestScore: 0.8123,
       currentElo: 1112.4,
       provider: "deterministic",
+      synthetic: true,
+    });
+  });
+
+  it("executes saved agent-task scenarios through the task solve runner", async () => {
+    const executeAgentTaskSolve = vi.fn(async () => ({
+      progress: 2,
+      result: {
+        scenario_name: "saved_task",
+        best_score: 0.91,
+      },
+    }));
+
+    const result = await executeAgentTaskRunCommandWorkflow({
+      plan: {
+        scenarioName: "saved_task",
+        gens: 2,
+        runId: "run-task",
+        providerType: "deterministic",
+        matches: 1,
+        json: true,
+      },
+      providerBundle: {
+        defaultProvider: { name: "provider" },
+        defaultConfig: { providerType: "deterministic" },
+      },
+      spec: { taskPrompt: "Do work", judgeRubric: "Do it well" },
+      executeAgentTaskSolve,
+    });
+
+    expect(executeAgentTaskSolve).toHaveBeenCalledWith({
+      provider: { name: "provider" },
+      created: {
+        name: "saved_task",
+        spec: { taskPrompt: "Do work", judgeRubric: "Do it well" },
+      },
+      generations: 2,
+    });
+    expect(result).toEqual({
+      runId: "run-task",
+      generationsCompleted: 2,
+      bestScore: 0.91,
+      currentElo: 1000,
+      provider: "deterministic",
+      skillPackage: {
+        scenario_name: "saved_task",
+        best_score: 0.91,
+      },
       synthetic: true,
     });
   });

--- a/ts/tests/run-start-workflow.test.ts
+++ b/ts/tests/run-start-workflow.test.ts
@@ -5,6 +5,7 @@ import type { CustomScenarioEntry } from "../src/scenarios/custom-loader.js";
 import type { ScenarioFamilyName } from "../src/scenarios/families.js";
 import type { RoleProviderBundle } from "../src/providers/index.js";
 import {
+  executeAgentTaskCustomStartRun,
   executeBuiltInGameStartRun,
   executeGeneratedCustomStartRun,
   resolveRunStartPlan,
@@ -68,7 +69,7 @@ describe("run start workflow", () => {
     });
   });
 
-  it("rejects saved custom agent-task scenarios for /run", () => {
+  it("resolves saved custom agent-task scenarios for /run", () => {
     const entry: CustomScenarioEntry = {
       name: "saved_task",
       type: "agent_task",
@@ -77,12 +78,16 @@ describe("run start workflow", () => {
       hasGeneratedSource: false,
     };
 
-    expect(() => resolveRunStartPlan({
+    expect(resolveRunStartPlan({
       scenario: "saved_task",
       builtinScenarioNames: ["grid_ctf"],
       customScenario: entry,
       customScenarioFamily: "agent_task",
-    })).toThrow(/only built-in game scenarios and generated non-agent-task scenarios/i);
+    })).toEqual({
+      kind: "agent_task_custom",
+      scenarioName: "saved_task",
+      entry,
+    });
   });
 
   it("executes built-in game runs through the generation runner boundary", async () => {
@@ -216,5 +221,47 @@ describe("run start workflow", () => {
     const completed = emitted.find((entry) => entry.event === "run_completed");
     expect(completed?.payload.best_score).toBe(0.9);
     expect(completed?.payload.completed_generations).toBe(2);
+  });
+
+  it("executes saved agent-task runs and emits lifecycle events", async () => {
+    const emitted: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    const events = {
+      emit: (event: string, payload: Record<string, unknown>) => {
+        emitted.push({ event, payload });
+      },
+    };
+    const executeAgentTaskSolve = vi.fn(async () => ({
+      progress: 2,
+      result: { best_score: 0.82, scenario_name: "saved_task" },
+    }));
+
+    await executeAgentTaskCustomStartRun({
+      runId: "run_task",
+      scenarioName: "saved_task",
+      entry: {
+        name: "saved_task",
+        type: "agent_task",
+        spec: { taskPrompt: "Do work", judgeRubric: "Do it well" },
+        path: "/tmp/saved_task",
+        hasGeneratedSource: false,
+      },
+      generations: 2,
+      provider: { name: "test", defaultModel: () => "test", complete: vi.fn() },
+      controller: { waitIfPaused: async () => {} } as never,
+      events: events as never,
+      deps: { executeAgentTaskSolve: executeAgentTaskSolve as never },
+    });
+
+    expect(executeAgentTaskSolve).toHaveBeenCalledWith({
+      provider: expect.objectContaining({ name: "test" }),
+      created: {
+        name: "saved_task",
+        spec: { taskPrompt: "Do work", judgeRubric: "Do it well" },
+      },
+      generations: 2,
+    });
+    expect(emitted[0]?.event).toBe("run_started");
+    expect(emitted.find((entry) => entry.event === "generation_completed")?.payload.best_score).toBe(0.82);
+    expect(emitted.find((entry) => entry.event === "run_completed")?.payload.completed_generations).toBe(2);
   });
 });

--- a/ts/tests/run-start-workflow.test.ts
+++ b/ts/tests/run-start-workflow.test.ts
@@ -261,6 +261,11 @@ describe("run start workflow", () => {
       generations: 2,
     });
     expect(emitted[0]?.event).toBe("run_started");
+    expect(emitted.filter((entry) => entry.event === "generation_started")).toEqual([
+      { event: "generation_started", payload: { run_id: "run_task", generation: 1 } },
+      { event: "generation_started", payload: { run_id: "run_task", generation: 2 } },
+    ]);
+    expect(emitted.filter((entry) => entry.event === "generation_completed")).toHaveLength(2);
     expect(emitted.find((entry) => entry.event === "generation_completed")?.payload.best_score).toBe(0.82);
     expect(emitted.find((entry) => entry.event === "run_completed")?.payload.completed_generations).toBe(2);
   });


### PR DESCRIPTION
## Summary
- allow TS run planning to resolve saved custom agent_task scenarios instead of rejecting them
- execute saved agent tasks through the existing agent-task solve runner for CLI and server run paths
- emit run lifecycle events for saved agent-task runs and cover CLI/server workflows in tests

## Tests
- npm test -- run-start-workflow.test.ts run-command-workflow.test.ts
- npm run lint -- --pretty false