### PR TITLE
AC-630 Cover missing install salt identity handling

### DIFF
--- a/autocontext/tests/integrations/anthropic/test_proxy_non_streaming.py
+++ b/autocontext/tests/integrations/anthropic/test_proxy_non_streaming.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import anthropic
@@ -140,3 +141,21 @@ def test_strips_autocontext_kwarg_before_forwarding(tmp_path, make_anthropic_cli
     )
     assert "autocontext" not in seen_kwargs
     sink.close()
+
+
+def test_skips_identity_when_install_salt_is_missing(tmp_path, make_anthropic_client) -> None:
+    (Path(".autocontext") / "install-salt").unlink()
+    client = make_anthropic_client(_handler_returning(canned_messages_response()))
+    sink = FileSink(path=tmp_path / "t.jsonl", batch_size=1)
+    wrapped = instrument_client(client, sink=sink, app_id="test-app")
+
+    wrapped.messages.create(
+        model="claude-sonnet-4-5",
+        max_tokens=100,
+        messages=[{"role": "user", "content": "hi"}],
+        autocontext={"user_id": "u1", "session_id": "s1"},
+    )
+
+    sink.close()
+    trace = json.loads((tmp_path / "t.jsonl").read_text().strip())
+    assert "session" not in trace

--- a/autocontext/tests/integrations/openai/test_proxy_non_streaming.py
+++ b/autocontext/tests/integrations/openai/test_proxy_non_streaming.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -84,6 +85,23 @@ def test_strips_autocontext_kwarg_before_forwarding(tmp_path, make_openai_client
     )
     assert "autocontext" not in seen_kwargs
     sink.close()
+
+
+def test_skips_identity_when_install_salt_is_missing(tmp_path, make_openai_client) -> None:
+    (Path(".autocontext") / "install-salt").unlink()
+    client = make_openai_client(_handler_returning(canned_chat_completion()))
+    sink = FileSink(path=tmp_path / "t.jsonl", batch_size=1)
+    wrapped = instrument_client(client, sink=sink, app_id="a")
+
+    wrapped.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        autocontext={"user_id": "u1", "session_id": "s1"},
+    )
+
+    sink.close()
+    trace = json.loads((tmp_path / "t.jsonl").read_text().strip())
+    assert "session" not in trace
 
 
 def test_per_call_kwarg_wins_over_ambient_context(tmp_path, make_openai_client) -> None:


### PR DESCRIPTION
## Summary
- Add OpenAI proxy regression coverage for per-call identity when the install salt is missing.
- Add Anthropic proxy regression coverage for the same no-salt invariant.
- Keep existing shared identity behavior intact: no salt means no hashed session data is emitted.

## Tests
- uv run pytest tests/integrations/test_shared_identity.py tests/integrations/openai/test_proxy_non_streaming.py tests/integrations/anthropic/test_proxy_non_streaming.py
- uv run ruff check tests/integrations/openai/test_proxy_non_streaming.py tests/integrations/anthropic/test_proxy_non_streaming.py

Linear: AC-630