### PR TITLE
AC-622 Use command registry for capabilities

### DIFF
--- a/ts/src/cli/capabilities-command-workflow.ts
+++ b/ts/src/cli/capabilities-command-workflow.ts
@@ -1,35 +1,7 @@
 import type { Capabilities } from "../mcp/capabilities.js";
+import { visibleSupportedCommandNames } from "./command-registry.js";
 
-export const CAPABILITIES_COMMANDS = [
-  "init",
-  "run",
-  "list",
-  "replay",
-  "benchmark",
-  "export",
-  "export-training-data",
-  "import-package",
-  "new-scenario",
-  "solve",
-  "capabilities",
-  "login",
-  "whoami",
-  "logout",
-  "providers",
-  "models",
-  "mission",
-  "campaign",
-  "tui",
-  "judge",
-  "improve",
-  "repl",
-  "queue",
-  "status",
-  "serve",
-  "mcp-serve",
-  "train",
-  "version",
-] as const;
+export const CAPABILITIES_COMMANDS: readonly string[] = visibleSupportedCommandNames();
 
 export interface CapabilitiesCommandPayload
   extends Omit<Capabilities, "features"> {

--- a/ts/src/cli/command-registry.ts
+++ b/ts/src/cli/command-registry.ts
@@ -137,6 +137,12 @@ export function visibleCommandNames(): string[] {
   return COMMANDS.filter((command) => command.visible !== false).map((command) => command.name);
 }
 
+export function visibleSupportedCommandNames(): string[] {
+  return COMMANDS.filter((command) => command.group !== "python-only" && command.visible !== false).map(
+    (command) => command.name,
+  );
+}
+
 function visibleCommands(group: CommandGroup): CommandDescriptor[] {
   return COMMANDS.filter((command) => command.group === group && command.visible !== false);
 }

--- a/ts/tests/capabilities-command-workflow.test.ts
+++ b/ts/tests/capabilities-command-workflow.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { buildCapabilitiesPayload } from "../src/cli/capabilities-command-workflow.js";
+import { visibleSupportedCommandNames } from "../src/cli/command-registry.js";
 
 describe("capabilities command workflow", () => {
   it("builds capabilities payload with CLI command inventory and feature flags", () => {
-    expect(
-      buildCapabilitiesPayload({
+    const payload = buildCapabilitiesPayload(
+      {
         version: "0.3.7",
         scenarios: ["grid_ctf"],
         providers: ["deterministic"],
@@ -16,8 +17,11 @@ describe("capabilities command workflow", () => {
           user_facing: [],
           runtime: [],
         },
-      }, null),
-    ).toMatchObject({
+      },
+      null,
+    );
+
+    expect(payload).toMatchObject({
       version: "0.3.7",
       scenarios: ["grid_ctf"],
       providers: ["deterministic"],
@@ -41,6 +45,17 @@ describe("capabilities command workflow", () => {
         "serve",
         "mcp-serve",
         "train",
+        "solve",
+        "simulate",
+        "investigate",
+        "analyze",
+        "candidate",
+        "eval",
+        "promotion",
+        "registry",
+        "emit-pr",
+        "production-traces",
+        "instrument",
         "version",
       ]),
       features: {
@@ -52,6 +67,8 @@ describe("capabilities command workflow", () => {
       },
       project_config: null,
     });
+    expect(payload.commands).toEqual(visibleSupportedCommandNames());
+    expect(payload.commands).not.toContain("ecosystem");
   });
 
   it("preserves project config when provided", () => {

--- a/ts/tests/cli-command-registry.test.ts
+++ b/ts/tests/cli-command-registry.test.ts
@@ -4,6 +4,7 @@ import {
   buildCliHelp,
   resolveCliCommand,
   visibleCommandNames,
+  visibleSupportedCommandNames,
 } from "../src/cli/command-registry.js";
 
 describe("CLI command registry", () => {
@@ -15,6 +16,27 @@ describe("CLI command registry", () => {
     for (const name of names) {
       expect(help).toContain(name);
     }
+  });
+
+  it("exposes supported commands separately from Python-only help entries", () => {
+    const names = visibleSupportedCommandNames();
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "train",
+        "simulate",
+        "investigate",
+        "analyze",
+        "candidate",
+        "eval",
+        "promotion",
+        "registry",
+        "emit-pr",
+        "production-traces",
+        "instrument",
+      ]),
+    );
+    expect(names).not.toContain("ecosystem");
   });
 
   it("classifies commands by dispatch surface", () => {


### PR DESCRIPTION
## Summary
- Add a supported-command view to the CLI command registry.
- Build the capabilities command inventory from the registry instead of a hard-coded list.
- Add tests for previously omitted commands and Python-only exclusion.

## Tests
- npm test -- capabilities-command-workflow.test.ts cli-command-registry.test.ts
- npm run lint

Linear: AC-622