### PR TITLE
feat(AC-628): LLM-primary family classifier with fast-path threshold

### DIFF
--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -692,6 +692,16 @@ class AppSettings(BaseModel):
     blob_store_repo: str = Field(default="", description="HF repo ID for hf_bucket backend")
     blob_store_cache_max_mb: int = Field(default=500, ge=1, description="Max hydration cache size in MB")
     blob_store_min_size_bytes: int = Field(default=1024, ge=0, description="Min artifact size to mirror (0=all)")
+    # Classifier fast-path threshold (AC-628)
+    classifier_fast_path_threshold: float = Field(
+        default_factory=lambda: float(
+            __import__("os").getenv("AUTOCONTEXT_CLASSIFIER_FAST_PATH_THRESHOLD", "0.65")
+        ),
+        ge=0.0,
+        le=1.0,
+        validate_default=True,
+        description="Keyword confidence >= this skips LLM classification; ambiguous descriptions call LLM",
+    )
 
     @field_validator("cost_budget_limit", mode="before")
     @classmethod

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -367,7 +367,7 @@ def _resolve_requested_scenario_family_with_metadata(
     classification = classify_scenario_family(brief, llm_fn=llm_fn, cache=cache)
     return _ResolvedSolveFamily(
         family=route_to_family(classification),
-        llm_classifier_fallback_used=classification.llm_fallback_used,
+        llm_classifier_fallback_used=classification.llm_classifier_used,
     )
 
 

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -44,8 +44,8 @@ class FamilyClassification(BaseModel):
     rationale: str
     alternatives: list[FamilyCandidate] = Field(default_factory=list)
     no_signals_matched: bool = False
-    llm_fallback_used: bool = False
-    llm_fallback_attempted: bool = False
+    llm_classifier_used: bool = False
+    llm_classifier_attempted: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return self.model_dump()
@@ -74,7 +74,7 @@ class LowConfidenceError(Exception):
         if classification.no_signals_matched:
             fallback_note = (
                 " LLM fallback was attempted but returned no parseable response."
-                if classification.llm_fallback_attempted
+                if classification.llm_classifier_attempted
                 else ""
             )
             return (
@@ -474,7 +474,7 @@ _LLM_FALLBACK_SYSTEM_PROMPT = (
 )
 
 
-def _llm_classify_fallback(
+def _llm_classify(
     description: str,
     registered_families: list[str],
     llm_fn: LlmFn,
@@ -493,7 +493,7 @@ def _llm_classify_fallback(
         cached = cache.get(description, registered_families)
         if cached is not None:
             logger.info(
-                "LLM classifier fallback: cache hit family=%s confidence=%.2f",
+                "LLM classifier: cache hit family=%s confidence=%.2f",
                 cached.family_name,
                 cached.confidence,
             )
@@ -504,20 +504,20 @@ def _llm_classify_fallback(
 
     try:
         raw = llm_fn(system, description)
-    except Exception as exc:  # noqa: BLE001 - fallback must tolerate any provider failure
-        logger.warning("LLM classifier fallback failed: llm_fn raised %s", exc)
+    except Exception as exc:  # noqa: BLE001 - classifier must tolerate any provider failure
+        logger.warning("LLM classifier failed: llm_fn raised %s", exc)
         return None
 
     json_start = raw.find("{")
     json_end = raw.rfind("}")
     if json_start == -1 or json_end == -1 or json_end <= json_start:
-        logger.warning("LLM classifier fallback failed: no JSON object in response")
+        logger.warning("LLM classifier failed: no JSON object in response")
         return None
 
     try:
         payload = json.loads(raw[json_start : json_end + 1])
     except json.JSONDecodeError as exc:
-        logger.warning("LLM classifier fallback failed: JSON decode error %s", exc)
+        logger.warning("LLM classifier failed: JSON decode error %s", exc)
         return None
 
     family = payload.get("family") if isinstance(payload, dict) else None
@@ -525,25 +525,25 @@ def _llm_classify_fallback(
     rationale = payload.get("rationale") if isinstance(payload, dict) else None
 
     if not isinstance(family, str) or family not in registered_families:
-        logger.warning("LLM classifier fallback failed: family %r not registered", family)
+        logger.warning("LLM classifier failed: family %r not registered", family)
         return None
     if not isinstance(rationale, str) or not rationale.strip():
-        logger.warning("LLM classifier fallback failed: missing rationale")
+        logger.warning("LLM classifier failed: missing rationale")
         return None
     try:
         conf_value = float(confidence)  # type: ignore[arg-type]
     except (TypeError, ValueError):
-        logger.warning("LLM classifier fallback failed: confidence %r not numeric", confidence)
+        logger.warning("LLM classifier failed: confidence %r not numeric", confidence)
         return None
 
     clamped = max(0.0, min(1.0, conf_value))
-    logger.info("LLM classifier fallback: family=%s confidence=%.2f", family, clamped)
+    logger.info("LLM classifier: family=%s confidence=%.2f", family, clamped)
 
     alternatives = [
         FamilyCandidate(
             family_name=other,
             confidence=0.0,
-            rationale="LLM fallback selected a different family",
+            rationale="LLM classifier selected a different family",
         )
         for other in registered_families
         if other != family
@@ -554,7 +554,7 @@ def _llm_classify_fallback(
         rationale=rationale,
         alternatives=alternatives,
         no_signals_matched=False,
-        llm_fallback_used=True,
+        llm_classifier_used=True,
     )
     if cache is not None:
         cache.put(description, registered_families, classification)
@@ -574,19 +574,19 @@ def classify_scenario_family(
 ) -> FamilyClassification:
     """Classify a natural-language description into a scenario family.
 
-    Returns a FamilyClassification with the top choice, confidence,
-    rationale, and ranked alternatives.
+    Two-gate flow (AC-628):
+      Gate 1 — keyword fast-path: if top keyword confidence >= threshold, return
+        immediately without calling the LLM.
+      Gate 2 — ambiguous: if total > 0 but confidence < threshold, call LLM when
+        available; fall back to the keyword result on failure.
+      Zero-signal: if no keywords matched, the LLM is required; raises
+        LowConfidenceError when the LLM is unavailable or fails.
 
-    When ``llm_fn`` is provided and the keyword classifier matches no signals,
-    a single structured LLM call is made to pick a family before returning the
-    keyword fallback (AC-580). If the LLM call fails for any reason, the
-    keyword fallback is returned unchanged.
-
-    When ``cache`` is provided (AC-581), the LLM fallback consults the cache
-    first and writes successful results back, eliminating repeat calls for
-    the same description as long as the registered family set is stable.
+    When ``cache`` is provided (AC-581), LLM calls consult the cache first and
+    write successful results back.
 
     Raises ValueError if description is empty/whitespace.
+    Raises LowConfidenceError on zero-signal when LLM unavailable or fails.
     """
     if not description or not description.strip():
         raise ValueError("description must be non-empty")
@@ -596,6 +596,9 @@ def classify_scenario_family(
     if not registered_families:
         raise ValueError("no scenario families are registered")
 
+    from autocontext.config.settings import AppSettings  # local import avoids circular dep
+    threshold = AppSettings().classifier_fast_path_threshold
+
     raw_scores: dict[str, float] = {}
     matched_signals: dict[str, list[str]] = {}
     for family_name in registered_families:
@@ -604,16 +607,15 @@ def classify_scenario_family(
         matched_signals[family_name] = matched
 
     total = sum(raw_scores.values())
+
     if total == 0:
-        llm_fallback_attempted = False
+        # Zero-signal: LLM required; raise if unavailable or failed.
+        llm_classifier_attempted = False
         if llm_fn is not None:
-            llm_result = _llm_classify_fallback(
-                description, registered_families, llm_fn, cache=cache
-            )
+            llm_result = _llm_classify(description, registered_families, llm_fn, cache=cache)
             if llm_result is not None:
                 return llm_result
-            llm_fallback_attempted = True
-        # No signals matched — default to agent_task with low confidence if available.
+            llm_classifier_attempted = True
         default_family = _DEFAULT_FAMILY_NAME if _DEFAULT_FAMILY_NAME in registered_families else registered_families[0]
         alternatives = [
             FamilyCandidate(
@@ -624,19 +626,18 @@ def classify_scenario_family(
             for family_name in registered_families
             if family_name != default_family
         ]
-        return FamilyClassification(
+        classification = FamilyClassification(
             family_name=default_family,
             confidence=0.2,
             rationale=f"No strong signals detected; defaulting to {default_family}",
             alternatives=alternatives,
             no_signals_matched=True,
-            llm_fallback_attempted=llm_fallback_attempted,
+            llm_classifier_attempted=llm_classifier_attempted,
         )
+        raise LowConfidenceError(classification, min_confidence=threshold)
 
     # Normalize to confidences
     confidences = {name: score / total for name, score in raw_scores.items()}
-
-    # Rank by confidence
     ranked = sorted(confidences.items(), key=lambda x: x[1], reverse=True)
     top_name, top_conf = ranked[0]
 
@@ -649,11 +650,29 @@ def classify_scenario_family(
         for name, conf in ranked[1:]
     ]
 
+    # Gate 1 — fast-path: high-confidence keywords skip LLM.
+    if top_conf >= threshold:
+        return FamilyClassification(
+            family_name=top_name,
+            confidence=round(top_conf, 4),
+            rationale=_build_rationale(matched_signals[top_name], top_name),
+            alternatives=alternatives,
+        )
+
+    # Gate 2 — ambiguous: call LLM when available; return keyword result on failure.
+    llm_classifier_attempted = False
+    if llm_fn is not None:
+        llm_result = _llm_classify(description, registered_families, llm_fn, cache=cache)
+        if llm_result is not None:
+            return llm_result
+        llm_classifier_attempted = True
+
     return FamilyClassification(
         family_name=top_name,
         confidence=round(top_conf, 4),
         rationale=_build_rationale(matched_signals[top_name], top_name),
         alternatives=alternatives,
+        llm_classifier_attempted=llm_classifier_attempted,
     )
 
 

--- a/autocontext/tests/test_ac628_classifier.py
+++ b/autocontext/tests/test_ac628_classifier.py
@@ -1,0 +1,186 @@
+"""AC-628: LLM-primary family classifier with config-driven fast-path threshold.
+
+RED tests — drive the full AC-628 implementation:
+  - Field renames: llm_fallback_* → llm_classifier_*
+  - AppSettings.classifier_fast_path_threshold (default 0.65)
+  - Two-gate flow: high-confidence keywords skip LLM; ambiguous always calls LLM
+  - Zero-signal: raises LowConfidenceError when LLM unavailable or fails
+  - _llm_classify_fallback renamed → _llm_classify (internal, tested via behaviour)
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from autocontext.scenarios.custom.family_classifier import (
+    FamilyClassification,
+    LowConfidenceError,
+    classify_scenario_family,
+)
+
+# ---------------------------------------------------------------------------
+# Field renames: llm_classifier_used / llm_classifier_attempted
+# ---------------------------------------------------------------------------
+
+_AMBIGUOUS = "Investigate the root cause of a performance regression using traces and metrics"
+_GIBBERISH = "xqztp nnvw rrb no keyword signals at all"
+_CLEAR_GAME = "Create a competitive two-player board game tournament with territory control"
+
+
+class TestFieldRenames:
+    def test_llm_classifier_used_field_exists(self) -> None:
+        c = FamilyClassification(
+            family_name="agent_task",
+            confidence=0.9,
+            rationale="r",
+            llm_classifier_used=True,
+        )
+        assert c.llm_classifier_used is True
+
+    def test_llm_classifier_used_defaults_false(self) -> None:
+        c = FamilyClassification(family_name="agent_task", confidence=0.9, rationale="r")
+        assert c.llm_classifier_used is False
+
+    def test_llm_classifier_attempted_field_exists(self) -> None:
+        c = FamilyClassification(
+            family_name="agent_task",
+            confidence=0.9,
+            rationale="r",
+            llm_classifier_attempted=True,
+        )
+        assert c.llm_classifier_attempted is True
+
+    def test_llm_classifier_attempted_defaults_false(self) -> None:
+        c = FamilyClassification(family_name="agent_task", confidence=0.9, rationale="r")
+        assert c.llm_classifier_attempted is False
+
+    def test_old_field_names_do_not_exist(self) -> None:
+        c = FamilyClassification(family_name="agent_task", confidence=0.9, rationale="r")
+        assert not hasattr(c, "llm_fallback_used")
+        assert not hasattr(c, "llm_fallback_attempted")
+
+
+# ---------------------------------------------------------------------------
+# AppSettings: classifier_fast_path_threshold
+# ---------------------------------------------------------------------------
+
+
+class TestFastPathThresholdConfig:
+    def test_default_threshold_is_0_65(self) -> None:
+        from autocontext.config.settings import AppSettings
+        s = AppSettings()
+        assert s.classifier_fast_path_threshold == pytest.approx(0.65)
+
+    def test_threshold_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOCONTEXT_CLASSIFIER_FAST_PATH_THRESHOLD", "0.8")
+        # Settings are re-read each construction
+        from autocontext.config.settings import AppSettings
+        s = AppSettings()
+        assert s.classifier_fast_path_threshold == pytest.approx(0.8)
+
+    def test_threshold_must_be_in_range(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AUTOCONTEXT_CLASSIFIER_FAST_PATH_THRESHOLD", "1.5")
+        from autocontext.config.settings import AppSettings
+        with pytest.raises(Exception):
+            AppSettings()
+
+
+# ---------------------------------------------------------------------------
+# Fast-path: high-confidence keywords skip the LLM entirely
+# ---------------------------------------------------------------------------
+
+
+class TestFastPathSkipsLlm:
+    def test_clear_description_does_not_call_llm(self) -> None:
+        forbidden = MagicMock(side_effect=AssertionError("LLM must not be called on fast-path"))
+        result = classify_scenario_family(_CLEAR_GAME, llm_fn=forbidden)
+        forbidden.assert_not_called()
+        assert result.family_name == "game"
+        assert result.llm_classifier_used is False
+
+    def test_fast_path_result_has_no_classifier_used_flag(self) -> None:
+        result = classify_scenario_family(_CLEAR_GAME)
+        assert result.llm_classifier_used is False
+        assert result.llm_classifier_attempted is False
+
+
+# ---------------------------------------------------------------------------
+# Two-gate: ambiguous keywords (total > 0, confidence < threshold) → calls LLM
+# ---------------------------------------------------------------------------
+
+
+class TestAmbiguousInvokesLlm:
+    def test_ambiguous_description_calls_llm_when_provided(self) -> None:
+        called = {"n": 0}
+
+        def stub_llm(system: str, user: str) -> str:
+            called["n"] += 1
+            return '{"family": "investigation", "confidence": 0.8, "rationale": "matches investigation"}'
+
+        result = classify_scenario_family(_AMBIGUOUS, llm_fn=stub_llm)
+        assert called["n"] == 1
+        assert result.family_name == "investigation"
+        assert result.llm_classifier_used is True
+
+    def test_ambiguous_description_no_llm_returns_keyword_result(self) -> None:
+        result = classify_scenario_family(_AMBIGUOUS)
+        assert result.llm_classifier_used is False
+        assert result.confidence > 0.0
+
+    def test_ambiguous_llm_failure_returns_keyword_result(self) -> None:
+        def bad_llm(system: str, user: str) -> str:
+            return "not json"
+
+        result = classify_scenario_family(_AMBIGUOUS, llm_fn=bad_llm)
+        assert result.llm_classifier_used is False
+        assert result.llm_classifier_attempted is True
+        assert result.confidence > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Zero-signal: no keyword matches → LLM required, else raises
+# ---------------------------------------------------------------------------
+
+
+class TestZeroSignalBehaviour:
+    def test_zero_signal_with_good_llm_returns_result(self) -> None:
+        def good_llm(system: str, user: str) -> str:
+            return '{"family": "agent_task", "confidence": 0.75, "rationale": "default task"}'
+
+        result = classify_scenario_family(_GIBBERISH, llm_fn=good_llm)
+        assert result.family_name == "agent_task"
+        assert result.llm_classifier_used is True
+        assert result.llm_classifier_attempted is False
+
+    def test_zero_signal_no_llm_raises(self) -> None:
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family(_GIBBERISH)
+        assert exc_info.value.classification.llm_classifier_attempted is False
+        assert exc_info.value.classification.no_signals_matched is True
+
+    def test_zero_signal_failed_llm_raises_with_attempted_flag(self) -> None:
+        def bad_llm(system: str, user: str) -> str:
+            return "sorry, cannot classify"
+
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family(_GIBBERISH, llm_fn=bad_llm)
+        c = exc_info.value.classification
+        assert c.llm_classifier_attempted is True
+        assert c.no_signals_matched is True
+
+    def test_zero_signal_error_message_mentions_failed_llm(self) -> None:
+        def bad_llm(system: str, user: str) -> str:
+            return "not parseable"
+
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family(_GIBBERISH, llm_fn=bad_llm)
+        assert "fallback" in str(exc_info.value).lower()
+
+    def test_zero_signal_no_llm_message_suggests_rephrasing_only(self) -> None:
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family(_GIBBERISH)
+        msg = str(exc_info.value).lower()
+        assert "rephras" in msg
+        assert "fallback" not in msg

--- a/autocontext/tests/test_ac628_classifier.py
+++ b/autocontext/tests/test_ac628_classifier.py
@@ -9,10 +9,10 @@ RED tests — drive the full AC-628 implementation:
 """
 from __future__ import annotations
 
-import os
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from autocontext.scenarios.custom.family_classifier import (
     FamilyClassification,
@@ -83,7 +83,7 @@ class TestFastPathThresholdConfig:
     def test_threshold_must_be_in_range(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("AUTOCONTEXT_CLASSIFIER_FAST_PATH_THRESHOLD", "1.5")
         from autocontext.config.settings import AppSettings
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             AppSettings()
 
 

--- a/autocontext/tests/test_agent_task_pipeline.py
+++ b/autocontext/tests/test_agent_task_pipeline.py
@@ -603,11 +603,13 @@ class TestAgentTaskCreator:
             )
             from unittest.mock import patch
 
-            from autocontext.scenarios.families import get_family
+            from autocontext.scenarios.custom.family_classifier import FamilyClassification
 
             with patch(
-                "autocontext.scenarios.custom.agent_task_creator.route_to_family",
-                return_value=get_family("agent_task"),
+                "autocontext.scenarios.custom.agent_task_creator.classify_scenario_family",
+                return_value=FamilyClassification(
+                    family_name="agent_task", confidence=0.9, rationale="mocked"
+                ),
             ):
                 instance = creator.create("Design a clinical trial protocol for oncology")
             registered_name = creator.derive_name("Design a clinical trial protocol for oncology")

--- a/autocontext/tests/test_classifier_cache.py
+++ b/autocontext/tests/test_classifier_cache.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from autocontext.scenarios.custom.classifier_cache import ClassifierCache
 from autocontext.scenarios.custom.family_classifier import (
     FamilyCandidate,
     FamilyClassification,
+    LowConfidenceError,
 )
 
 FAMILIES_A = ["agent_task", "simulation", "game"]
@@ -172,6 +175,7 @@ class TestLlmFallbackCacheIntegration:
     def test_llm_failure_is_not_cached(self, tmp_path) -> None:
         # Negative results (LLM raised / parse failed) must not be written —
         # otherwise a transient provider hiccup would poison future lookups.
+        # AC-628: zero-signal + failed LLM raises LowConfidenceError; nothing cached.
         from autocontext.scenarios.custom.family_classifier import classify_scenario_family
 
         cache = ClassifierCache(tmp_path / "cache.json")
@@ -180,11 +184,11 @@ class TestLlmFallbackCacheIntegration:
             del system, user
             return "not json at all"
 
-        result = classify_scenario_family(self._gibberish(), llm_fn=bad_llm, cache=cache)
-        # Fallback failed → keyword fallback returned.
-        assert result.no_signals_matched is True
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family(self._gibberish(), llm_fn=bad_llm, cache=cache)
+        assert exc_info.value.classification.no_signals_matched is True
 
-        # Cache file should be empty (or non-existent) — no entries written.
+        # Cache file should be empty — failed LLM results must not be cached.
         cache_path = tmp_path / "cache.json"
         if cache_path.exists():
             data = json.loads(cache_path.read_text(encoding="utf-8"))

--- a/autocontext/tests/test_classifier_observability.py
+++ b/autocontext/tests/test_classifier_observability.py
@@ -47,8 +47,10 @@ class TestFamilyClassificationFlag:
         assert c.no_signals_matched is False
 
     def test_classify_sets_no_signals_matched_true_when_no_keywords_match(self) -> None:
-        # A totally noise-word description with no registered signals.
-        c = classify_scenario_family("xyz plop qux widget")
+        # AC-628: zero-signal raises LowConfidenceError; classification still has no_signals_matched=True.
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family("xyz plop qux widget")
+        c = exc_info.value.classification
         assert c.no_signals_matched is True
         assert c.confidence == pytest.approx(0.2)
 

--- a/autocontext/tests/test_family_classifier.py
+++ b/autocontext/tests/test_family_classifier.py
@@ -260,10 +260,14 @@ class TestClassificationAlternatives:
         )
         register_family(temp_family)
         try:
-            result = classify_scenario_family("do something unusual")
-            all_names = {result.family_name} | {a.family_name for a in result.alternatives}
+            # AC-628: zero-signal raises LowConfidenceError; classification still
+            # contains all registered families in alternatives.
+            with pytest.raises(LowConfidenceError) as exc_info:
+                classify_scenario_family("do something unusual")
+            classification = exc_info.value.classification
+            all_names = {classification.family_name} | {a.family_name for a in classification.alternatives}
             assert "_test_family" in all_names
-            assert result.family_name == _DEFAULT_FAMILY_NAME
+            assert classification.family_name == _DEFAULT_FAMILY_NAME
         finally:
             FAMILY_REGISTRY.pop("_test_family", None)
 
@@ -283,15 +287,16 @@ class TestClassifyEdgeCases:
             classify_scenario_family("   ")
 
     def test_very_short_description(self) -> None:
-        """Short descriptions should still produce a classification."""
-        result = classify_scenario_family("write code")
-        assert result.family_name in {"agent_task", "game", "simulation"}
+        """Short descriptions with keyword signals still produce a classification."""
+        result = classify_scenario_family("write a haiku")
+        assert result.family_name == "agent_task"
         assert result.confidence > 0.0
 
     def test_ambiguous_description_has_lower_confidence(self) -> None:
-        """A vague description should produce lower confidence than a clear one."""
+        """A vague description with split signals has lower confidence than a clear one."""
         clear = classify_scenario_family("Build a competitive two-player board game tournament")
-        vague = classify_scenario_family("Do something interesting with data")
+        # "evaluate" (agent_task) + "trace" (simulation) → split signals, confidence < 0.65
+        vague = classify_scenario_family("evaluate some data and trace results")
         assert clear.confidence > vague.confidence
 
 
@@ -429,26 +434,30 @@ class TestFallbackAttemptedFlag:
             rationale="r",
             no_signals_matched=False,
         )
-        assert c.llm_fallback_attempted is False
+        assert c.llm_classifier_attempted is False
 
-    def test_flag_set_when_fallback_tried_but_returns_non_json(self) -> None:
+    def test_flag_set_when_classifier_tried_but_returns_non_json(self) -> None:
         def bad_llm(system: str, user: str) -> str:
             return "I cannot determine the family for this input."
 
-        classification = classify_scenario_family(_GIBBERISH, llm_fn=bad_llm)
-        assert classification.llm_fallback_attempted is True
+        # AC-628: zero-signal + failed LLM → raises LowConfidenceError with attempted=True
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family(_GIBBERISH, llm_fn=bad_llm)
+        assert exc_info.value.classification.llm_classifier_attempted is True
 
     def test_flag_not_set_when_no_llm_fn_provided(self) -> None:
-        classification = classify_scenario_family(_GIBBERISH)
-        assert classification.llm_fallback_attempted is False
+        # AC-628: zero-signal + no LLM → raises LowConfidenceError with attempted=False
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family(_GIBBERISH)
+        assert exc_info.value.classification.llm_classifier_attempted is False
 
-    def test_flag_not_set_on_successful_llm_fallback(self) -> None:
+    def test_flag_not_set_on_successful_llm_classifier(self) -> None:
         def good_llm(system: str, user: str) -> str:
             return '{"family": "agent_task", "confidence": 0.75, "rationale": "default task"}'
 
         classification = classify_scenario_family(_GIBBERISH, llm_fn=good_llm)
-        assert classification.llm_fallback_attempted is False
-        assert classification.llm_fallback_used is True
+        assert classification.llm_classifier_attempted is False
+        assert classification.llm_classifier_used is True
 
 
 class TestLowConfidenceErrorMentionsFallback:
@@ -456,23 +465,20 @@ class TestLowConfidenceErrorMentionsFallback:
         def bad_llm(system: str, user: str) -> str:
             return "Sorry, I cannot classify this."
 
-        classification = classify_scenario_family(_GIBBERISH, llm_fn=bad_llm)
-        assert classification.llm_fallback_attempted is True
-
+        # AC-628: zero-signal + failed LLM → classify raises directly
         with pytest.raises(LowConfidenceError) as exc_info:
-            route_to_family(classification)
+            classify_scenario_family(_GIBBERISH, llm_fn=bad_llm)
 
+        assert exc_info.value.classification.llm_classifier_attempted is True
         msg = str(exc_info.value).lower()
         assert "fallback" in msg
 
     def test_message_does_not_mention_fallback_when_not_attempted(self) -> None:
-        classification = classify_scenario_family(_GIBBERISH)
-        assert classification.llm_fallback_attempted is False
-
+        # AC-628: zero-signal + no LLM → classify raises directly
         with pytest.raises(LowConfidenceError) as exc_info:
-            route_to_family(classification)
+            classify_scenario_family(_GIBBERISH)
 
-        # No llm_fn passed — message should only recommend rephrasing
+        assert exc_info.value.classification.llm_classifier_attempted is False
         msg = str(exc_info.value).lower()
         assert "fallback" not in msg
 
@@ -480,9 +486,7 @@ class TestLowConfidenceErrorMentionsFallback:
         def bad_llm(system: str, user: str) -> str:
             return "not json"
 
-        classification = classify_scenario_family(_GIBBERISH, llm_fn=bad_llm)
-
         with pytest.raises(LowConfidenceError) as exc_info:
-            route_to_family(classification)
+            classify_scenario_family(_GIBBERISH, llm_fn=bad_llm)
 
         assert "rephras" in str(exc_info.value).lower()

--- a/autocontext/tests/test_llm_classifier_fallback.py
+++ b/autocontext/tests/test_llm_classifier_fallback.py
@@ -1,29 +1,39 @@
-"""AC-580 — LLM classifier fallback when no keyword signals matched."""
+"""AC-580 — LLM classifier fallback when no keyword signals matched.
+
+Updated for AC-628: zero-signal + no/failed LLM now raises LowConfidenceError.
+"""
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from autocontext.scenarios.custom.family_classifier import classify_scenario_family
+import pytest
+
+from autocontext.scenarios.custom.family_classifier import (
+    LowConfidenceError,
+    classify_scenario_family,
+)
 
 
 class TestClassifyWithoutLlmFn:
-    def test_classify_without_llm_fn_preserves_keyword_only_behavior(self) -> None:
-        # Gibberish description → keyword fallback (no_signals_matched=True).
-        result = classify_scenario_family("xyz zzz qqq nonsense gibberish")
-        assert result.no_signals_matched is True
-        assert result.llm_fallback_used is False
-        assert result.confidence == 0.2
-        assert result.family_name == "agent_task"
+    def test_classify_without_llm_fn_raises_on_zero_signal(self) -> None:
+        # AC-628: zero-signal + no LLM → LowConfidenceError (no longer returns fallback).
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family("xyz zzz qqq nonsense gibberish")
+        c = exc_info.value.classification
+        assert c.no_signals_matched is True
+        assert c.llm_classifier_used is False
+        assert c.confidence == pytest.approx(0.2)
+        assert c.family_name == "agent_task"
 
     def test_classify_with_keyword_match_skips_llm_fn(self) -> None:
-        # When keywords match, llm_fn must not be invoked.
+        # When keywords match above fast-path threshold, llm_fn must not be invoked.
         forbidden_llm = MagicMock(side_effect=AssertionError("must not be called"))
         result = classify_scenario_family(
             "Build a simulation of a deployment pipeline with rollback and failover",
             llm_fn=forbidden_llm,
         )
         assert result.no_signals_matched is False
-        assert result.llm_fallback_used is False
+        assert result.llm_classifier_used is False
         assert result.family_name == "simulation"
         forbidden_llm.assert_not_called()
 
@@ -39,54 +49,60 @@ class TestLlmFallbackHappyPath:
             llm_fn=stub_llm,
         )
         assert result.family_name == "simulation"
-        assert result.confidence == 0.82
+        assert result.confidence == pytest.approx(0.82)
         assert result.rationale == "matches simulation pattern"
         assert result.no_signals_matched is False
-        assert result.llm_fallback_used is True
+        assert result.llm_classifier_used is True
 
 
 class TestLlmFallbackFailureModes:
-    """Any failure in the LLM path must fall through to the keyword fallback."""
+    """On zero-signal, any failure in the LLM path raises LowConfidenceError."""
 
-    def test_llm_fallback_unknown_family_falls_through(self) -> None:
+    def test_llm_fallback_unknown_family_raises(self) -> None:
         def stub_llm(system: str, user: str) -> str:
             del system, user
             return '{"family": "bogus_family", "confidence": 0.9, "rationale": "r"}'
 
-        result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
-        assert result.no_signals_matched is True
-        assert result.llm_fallback_used is False
-        assert result.family_name == "agent_task"
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
+        c = exc_info.value.classification
+        assert c.no_signals_matched is True
+        assert c.llm_classifier_used is False
+        assert c.llm_classifier_attempted is True
 
-    def test_llm_fallback_unparseable_json_falls_through(self) -> None:
+    def test_llm_fallback_unparseable_json_raises(self) -> None:
         def stub_llm(system: str, user: str) -> str:
             del system, user
             return "not json at all"
 
-        result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
-        assert result.no_signals_matched is True
-        assert result.llm_fallback_used is False
-        assert result.family_name == "agent_task"
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
+        c = exc_info.value.classification
+        assert c.no_signals_matched is True
+        assert c.llm_classifier_used is False
+        assert c.llm_classifier_attempted is True
 
-    def test_llm_fallback_missing_rationale_falls_through(self) -> None:
+    def test_llm_fallback_missing_rationale_raises(self) -> None:
         def stub_llm(system: str, user: str) -> str:
             del system, user
             return '{"family": "simulation", "confidence": 0.9}'
 
-        result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
-        assert result.no_signals_matched is True
-        assert result.llm_fallback_used is False
-        assert result.family_name == "agent_task"
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
+        c = exc_info.value.classification
+        assert c.no_signals_matched is True
+        assert c.llm_classifier_attempted is True
 
-    def test_llm_fallback_llm_fn_raises_falls_through(self) -> None:
+    def test_llm_fallback_llm_fn_raises_raises(self) -> None:
         def stub_llm(system: str, user: str) -> str:
             del system, user
             raise RuntimeError("boom")
 
-        result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
-        assert result.no_signals_matched is True
-        assert result.llm_fallback_used is False
-        assert result.family_name == "agent_task"
+        with pytest.raises(LowConfidenceError) as exc_info:
+            classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
+        c = exc_info.value.classification
+        assert c.no_signals_matched is True
+        assert c.llm_classifier_attempted is True
 
     def test_llm_fallback_clamps_out_of_range_confidence(self) -> None:
         def stub_llm(system: str, user: str) -> str:
@@ -94,8 +110,8 @@ class TestLlmFallbackFailureModes:
             return '{"family": "simulation", "confidence": 1.5, "rationale": "overshoot"}'
 
         result = classify_scenario_family("xyz zzz qqq", llm_fn=stub_llm)
-        assert result.confidence == 1.0
-        assert result.llm_fallback_used is True
+        assert result.confidence == pytest.approx(1.0)
+        assert result.llm_classifier_used is True
         assert result.family_name == "simulation"
 
 

--- a/ts/src/scenarios/family-classifier-scoring.ts
+++ b/ts/src/scenarios/family-classifier-scoring.ts
@@ -74,5 +74,6 @@ export function buildRankedFamilyClassification(opts: {
       confidence: normalizeConfidence(confidence),
       rationale: buildRationale(opts.matchedSignals.get(familyName) ?? [], familyName),
     })),
+    noSignalsMatched: false,
   };
 }

--- a/ts/src/scenarios/family-classifier.ts
+++ b/ts/src/scenarios/family-classifier.ts
@@ -8,6 +8,14 @@ import {
 import { FAMILY_SIGNAL_GROUPS } from "./family-classifier-signals.js";
 
 export type LlmFn = (system: string, user: string) => string;
+export type AsyncLlmFn = (system: string, user: string) => string | Promise<string>;
+
+interface PreparedFamilyClassification {
+  description: string;
+  families: ScenarioFamilyName[];
+  threshold: number;
+  ranked: FamilyClassification | null;
+}
 
 export interface FamilyCandidate {
   familyName: ScenarioFamilyName;
@@ -67,13 +75,30 @@ function _llmClassify(
   llmFn: LlmFn,
 ): FamilyClassification | null {
   const system = _LLM_SYSTEM_PROMPT.replace("{family_list}", families.join(", "));
-  let raw: string;
   try {
-    raw = llmFn(system, description);
+    return parseLlmClassification(llmFn(system, description), families);
   } catch {
     return null;
   }
+}
 
+async function _llmClassifyAsync(
+  description: string,
+  families: ScenarioFamilyName[],
+  llmFn: AsyncLlmFn,
+): Promise<FamilyClassification | null> {
+  const system = _LLM_SYSTEM_PROMPT.replace("{family_list}", families.join(", "));
+  try {
+    return parseLlmClassification(await llmFn(system, description), families);
+  } catch {
+    return null;
+  }
+}
+
+function parseLlmClassification(
+  raw: string,
+  families: ScenarioFamilyName[],
+): FamilyClassification | null {
   const jsonStart = raw.indexOf("{");
   const jsonEnd = raw.lastIndexOf("}");
   if (jsonStart === -1 || jsonEnd === -1 || jsonEnd <= jsonStart) return null;
@@ -119,10 +144,17 @@ function _llmClassify(
 // Public API
 // ---------------------------------------------------------------------------
 
-export function classifyScenarioFamily(
-  description: string,
-  options?: { llmFn?: LlmFn },
-): FamilyClassification {
+function readClassifierFastPathThreshold(): number {
+  const envKey = "AUTOCONTEXT_CLASSIFIER_FAST_PATH_THRESHOLD";
+  const thresholdRaw = process.env[envKey] ?? "0.65";
+  const threshold = Number(thresholdRaw);
+  if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+    throw new Error(`${envKey} must be a number between 0 and 1`);
+  }
+  return threshold;
+}
+
+function prepareFamilyClassification(description: string): PreparedFamilyClassification {
   if (!description.trim()) {
     throw new Error("description must be non-empty");
   }
@@ -139,43 +171,109 @@ export function classifyScenarioFamily(
   }
 
   const total = [...rawScores.values()].reduce((sum, score) => sum + score, 0);
-  const thresholdRaw = process.env["AUTOCONTEXT_CLASSIFIER_FAST_PATH_THRESHOLD"] ?? "0.65";
-  const threshold = parseFloat(thresholdRaw);
+  const threshold = readClassifierFastPathThreshold();
+
+  return {
+    description,
+    families,
+    threshold,
+    ranked:
+      total > 0
+        ? buildRankedFamilyClassification({ families, rawScores, matchedSignals, total })
+        : null,
+  };
+}
+
+function buildZeroSignalLowConfidenceError(
+  families: ScenarioFamilyName[],
+  threshold: number,
+  llmClassifierAttempted: boolean,
+): LowConfidenceError {
+  return new LowConfidenceError(
+    {
+      ...buildDefaultFamilyClassification(families),
+      noSignalsMatched: true,
+      llmClassifierAttempted,
+    },
+    threshold,
+  );
+}
+
+export function classifyScenarioFamily(
+  description: string,
+  options?: { llmFn?: LlmFn },
+): FamilyClassification {
+  const prepared = prepareFamilyClassification(description);
   const llmFn = options?.llmFn;
 
-  if (total === 0) {
+  if (prepared.ranked === null) {
     let llmClassifierAttempted = false;
     if (llmFn) {
-      const llmResult = _llmClassify(description, families, llmFn);
+      const llmResult = _llmClassify(prepared.description, prepared.families, llmFn);
       if (llmResult !== null) return llmResult;
       llmClassifierAttempted = true;
     }
-    throw new LowConfidenceError(
-      {
-        ...buildDefaultFamilyClassification(families),
-        noSignalsMatched: true,
-        llmClassifierAttempted,
-      },
-      threshold,
+    throw buildZeroSignalLowConfidenceError(
+      prepared.families,
+      prepared.threshold,
+      llmClassifierAttempted,
     );
   }
 
-  const ranked = buildRankedFamilyClassification({ families, rawScores, matchedSignals, total });
+  const ranked = prepared.ranked;
+  if (ranked === null) {
+    throw buildZeroSignalLowConfidenceError(prepared.families, prepared.threshold, false);
+  }
 
   // Gate 1 — fast-path: high-confidence keywords skip LLM.
-  if (ranked.confidence >= threshold) {
+  if (ranked.confidence >= prepared.threshold) {
     return ranked;
   }
 
   // Gate 2 — ambiguous: call LLM when available; return keyword result on failure.
   let llmClassifierAttempted = false;
   if (llmFn) {
-    const llmResult = _llmClassify(description, families, llmFn);
+    const llmResult = _llmClassify(prepared.description, prepared.families, llmFn);
     if (llmResult !== null) return llmResult;
     llmClassifierAttempted = true;
   }
 
   return { ...ranked, llmClassifierAttempted };
+}
+
+export async function classifyScenarioFamilyAsync(
+  description: string,
+  options?: { llmFn?: AsyncLlmFn },
+): Promise<FamilyClassification> {
+  const prepared = prepareFamilyClassification(description);
+  const llmFn = options?.llmFn;
+
+  if (prepared.ranked === null) {
+    let llmClassifierAttempted = false;
+    if (llmFn) {
+      const llmResult = await _llmClassifyAsync(prepared.description, prepared.families, llmFn);
+      if (llmResult !== null) return llmResult;
+      llmClassifierAttempted = true;
+    }
+    throw buildZeroSignalLowConfidenceError(
+      prepared.families,
+      prepared.threshold,
+      llmClassifierAttempted,
+    );
+  }
+
+  if (prepared.ranked.confidence >= prepared.threshold) {
+    return prepared.ranked;
+  }
+
+  let llmClassifierAttempted = false;
+  if (llmFn) {
+    const llmResult = await _llmClassifyAsync(prepared.description, prepared.families, llmFn);
+    if (llmResult !== null) return llmResult;
+    llmClassifierAttempted = true;
+  }
+
+  return { ...prepared.ranked, llmClassifierAttempted };
 }
 
 export function routeToFamily(

--- a/ts/src/scenarios/family-classifier.ts
+++ b/ts/src/scenarios/family-classifier.ts
@@ -1,7 +1,13 @@
 import type { ScenarioFamilyName } from "./families.js";
 import { SCENARIO_TYPE_MARKERS } from "./families.js";
-import { buildDefaultFamilyClassification, buildRankedFamilyClassification, scoreSignals } from "./family-classifier-scoring.js";
+import {
+  buildDefaultFamilyClassification,
+  buildRankedFamilyClassification,
+  scoreSignals,
+} from "./family-classifier-scoring.js";
 import { FAMILY_SIGNAL_GROUPS } from "./family-classifier-signals.js";
+
+export type LlmFn = (system: string, user: string) => string;
 
 export interface FamilyCandidate {
   familyName: ScenarioFamilyName;
@@ -14,6 +20,9 @@ export interface FamilyClassification {
   confidence: number;
   rationale: string;
   alternatives: FamilyCandidate[];
+  noSignalsMatched?: boolean;
+  llmClassifierUsed?: boolean;
+  llmClassifierAttempted?: boolean;
 }
 
 export class LowConfidenceError extends Error {
@@ -21,15 +30,99 @@ export class LowConfidenceError extends Error {
   minConfidence: number;
 
   constructor(classification: FamilyClassification, minConfidence: number) {
-    super(
-      `Family classification confidence ${classification.confidence.toFixed(2)} is below threshold ${minConfidence.toFixed(2)} for family '${classification.familyName}'`,
-    );
+    const conf = classification.confidence.toFixed(2);
+    const thr = minConfidence.toFixed(2);
+    let msg: string;
+    if (classification.noSignalsMatched) {
+      const fallbackNote = classification.llmClassifierAttempted
+        ? " LLM fallback was attempted but returned no parseable response."
+        : "";
+      msg =
+        `Family classification confidence ${conf} < threshold ${thr}: ` +
+        `no family keywords matched in description (fell back to ${classification.familyName}).` +
+        fallbackNote +
+        ` Consider rephrasing with domain keywords.`;
+    } else {
+      msg = `Family classification confidence ${conf} is below threshold ${thr} for family '${classification.familyName}'`;
+    }
+    super(msg);
     this.classification = classification;
     this.minConfidence = minConfidence;
   }
 }
 
-export function classifyScenarioFamily(description: string): FamilyClassification {
+// ---------------------------------------------------------------------------
+// LLM classifier (AC-628)
+// ---------------------------------------------------------------------------
+
+const _LLM_SYSTEM_PROMPT =
+  "You classify a natural-language scenario description into one of the " +
+  "registered scenario families. Respond with a single JSON object on one line: " +
+  '{"family": "<name>", "confidence": <0.0-1.0>, "rationale": "<short explanation>"}. ' +
+  "The family name MUST be one of: {family_list}. Do not invent new family names.";
+
+function _llmClassify(
+  description: string,
+  families: ScenarioFamilyName[],
+  llmFn: LlmFn,
+): FamilyClassification | null {
+  const system = _LLM_SYSTEM_PROMPT.replace("{family_list}", families.join(", "));
+  let raw: string;
+  try {
+    raw = llmFn(system, description);
+  } catch {
+    return null;
+  }
+
+  const jsonStart = raw.indexOf("{");
+  const jsonEnd = raw.lastIndexOf("}");
+  if (jsonStart === -1 || jsonEnd === -1 || jsonEnd <= jsonStart) return null;
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw.slice(jsonStart, jsonEnd + 1));
+  } catch {
+    return null;
+  }
+
+  if (typeof payload !== "object" || payload === null) return null;
+  const p = payload as Record<string, unknown>;
+
+  const family = p["family"];
+  const confidence = p["confidence"];
+  const rationale = p["rationale"];
+
+  if (typeof family !== "string" || !families.includes(family as ScenarioFamilyName)) return null;
+  if (typeof rationale !== "string" || !rationale.trim()) return null;
+
+  const confNum = Number(confidence);
+  if (isNaN(confNum)) return null;
+  const clamped = Math.max(0, Math.min(1, confNum));
+
+  return {
+    familyName: family as ScenarioFamilyName,
+    confidence: Math.round(clamped * 10000) / 10000,
+    rationale,
+    alternatives: families
+      .filter((f) => f !== family)
+      .map((f) => ({
+        familyName: f,
+        confidence: 0,
+        rationale: "LLM classifier selected a different family",
+      })),
+    noSignalsMatched: false,
+    llmClassifierUsed: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function classifyScenarioFamily(
+  description: string,
+  options?: { llmFn?: LlmFn },
+): FamilyClassification {
   if (!description.trim()) {
     throw new Error("description must be non-empty");
   }
@@ -46,16 +139,43 @@ export function classifyScenarioFamily(description: string): FamilyClassificatio
   }
 
   const total = [...rawScores.values()].reduce((sum, score) => sum + score, 0);
+  const thresholdRaw = process.env["AUTOCONTEXT_CLASSIFIER_FAST_PATH_THRESHOLD"] ?? "0.65";
+  const threshold = parseFloat(thresholdRaw);
+  const llmFn = options?.llmFn;
+
   if (total === 0) {
-    return buildDefaultFamilyClassification(families);
+    let llmClassifierAttempted = false;
+    if (llmFn) {
+      const llmResult = _llmClassify(description, families, llmFn);
+      if (llmResult !== null) return llmResult;
+      llmClassifierAttempted = true;
+    }
+    throw new LowConfidenceError(
+      {
+        ...buildDefaultFamilyClassification(families),
+        noSignalsMatched: true,
+        llmClassifierAttempted,
+      },
+      threshold,
+    );
   }
 
-  return buildRankedFamilyClassification({
-    families,
-    rawScores,
-    matchedSignals,
-    total,
-  });
+  const ranked = buildRankedFamilyClassification({ families, rawScores, matchedSignals, total });
+
+  // Gate 1 — fast-path: high-confidence keywords skip LLM.
+  if (ranked.confidence >= threshold) {
+    return ranked;
+  }
+
+  // Gate 2 — ambiguous: call LLM when available; return keyword result on failure.
+  let llmClassifierAttempted = false;
+  if (llmFn) {
+    const llmResult = _llmClassify(description, families, llmFn);
+    if (llmResult !== null) return llmResult;
+    llmClassifierAttempted = true;
+  }
+
+  return { ...ranked, llmClassifierAttempted };
 }
 
 export function routeToFamily(

--- a/ts/src/scenarios/index.ts
+++ b/ts/src/scenarios/index.ts
@@ -28,8 +28,13 @@ export { createAgentTask } from "./agent-task-factory.js";
 export type { AgentTaskFactoryOpts } from "./agent-task-factory.js";
 export { AgentTaskCreator } from "./agent-task-creator.js";
 export type { AgentTaskCreatorOpts, CreatedScenario } from "./agent-task-creator.js";
-export { classifyScenarioFamily, routeToFamily, LowConfidenceError } from "./family-classifier.js";
-export type { FamilyCandidate, FamilyClassification } from "./family-classifier.js";
+export {
+  classifyScenarioFamily,
+  classifyScenarioFamilyAsync,
+  routeToFamily,
+  LowConfidenceError,
+} from "./family-classifier.js";
+export type { AsyncLlmFn, FamilyCandidate, FamilyClassification, LlmFn } from "./family-classifier.js";
 export { getPipeline, hasPipeline, UnsupportedFamilyError, validateForFamily } from "./family-pipeline.js";
 export type { FamilyPipeline } from "./family-pipeline.js";
 export {

--- a/ts/src/scenarios/scenario-creator.ts
+++ b/ts/src/scenarios/scenario-creator.ts
@@ -6,7 +6,11 @@
 import type { LLMProvider } from "../types/index.js";
 import { designCoordination } from "./coordination-designer.js";
 import type { CoordinationSpec } from "./coordination-spec.js";
-import { classifyScenarioFamily, routeToFamily } from "./family-classifier.js";
+import {
+  classifyScenarioFamily,
+  routeToFamily,
+  type LlmFn as ClassifierLlmFn,
+} from "./family-classifier.js";
 import { SCENARIO_TYPE_MARKERS, type ScenarioFamilyName } from "./families.js";
 import { designInvestigation } from "./investigation-designer.js";
 import { fallbackCodegenFamilyToAgentTask } from "./scenario-family-fallback.js";
@@ -108,7 +112,10 @@ export function deriveScenarioName(description: string): string {
  *
  * @see classifyScenarioFamily for the full classification with confidence scores
  */
-export function detectScenarioFamily(description: string): ScenarioFamilyName {
+export function detectScenarioFamily(
+  description: string,
+  options?: { llmFn?: ClassifierLlmFn },
+): ScenarioFamilyName {
   if (!description.trim()) return "agent_task";
 
   const hintedFamily = resolveScenarioFamilyHint(description);
@@ -117,7 +124,7 @@ export function detectScenarioFamily(description: string): ScenarioFamilyName {
   }
 
   try {
-    const family = routeToFamily(classifyScenarioFamily(description), 0.15);
+    const family = routeToFamily(classifyScenarioFamily(description, options), 0.15);
     return family === "game" ? "agent_task" : family;
   } catch {
     // LowConfidenceError — fall back to agent_task

--- a/ts/src/scenarios/scenario-creator.ts
+++ b/ts/src/scenarios/scenario-creator.ts
@@ -7,8 +7,11 @@ import type { LLMProvider } from "../types/index.js";
 import { designCoordination } from "./coordination-designer.js";
 import type { CoordinationSpec } from "./coordination-spec.js";
 import {
+  classifyScenarioFamilyAsync,
   classifyScenarioFamily,
+  LowConfidenceError,
   routeToFamily,
+  type AsyncLlmFn as ClassifierAsyncLlmFn,
   type LlmFn as ClassifierLlmFn,
 } from "./family-classifier.js";
 import { SCENARIO_TYPE_MARKERS, type ScenarioFamilyName } from "./families.js";
@@ -38,7 +41,7 @@ export interface CreatedScenarioResult {
   };
 }
 
-type LlmFn = (system: string, user: string) => Promise<string>;
+type ProviderLlmFn = (system: string, user: string) => Promise<string>;
 type FamilyAwareScenarioFamily =
   | "coordination"
   | "investigation"
@@ -120,16 +123,44 @@ export function detectScenarioFamily(
 
   const hintedFamily = resolveScenarioFamilyHint(description);
   if (hintedFamily) {
-    return hintedFamily === "game" ? "agent_task" : hintedFamily;
+    return normalizeDetectedFamily(hintedFamily);
   }
 
   try {
     const family = routeToFamily(classifyScenarioFamily(description, options), 0.15);
-    return family === "game" ? "agent_task" : family;
-  } catch {
-    // LowConfidenceError — fall back to agent_task
+    return normalizeDetectedFamily(family);
+  } catch (error) {
+    if (!(error instanceof LowConfidenceError)) {
+      throw error;
+    }
     return "agent_task";
   }
+}
+
+export async function detectScenarioFamilyAsync(
+  description: string,
+  options?: { llmFn?: ClassifierAsyncLlmFn },
+): Promise<ScenarioFamilyName> {
+  if (!description.trim()) return "agent_task";
+
+  const hintedFamily = resolveScenarioFamilyHint(description);
+  if (hintedFamily) {
+    return normalizeDetectedFamily(hintedFamily);
+  }
+
+  try {
+    const family = routeToFamily(await classifyScenarioFamilyAsync(description, options), 0.15);
+    return normalizeDetectedFamily(family);
+  } catch (error) {
+    if (!(error instanceof LowConfidenceError)) {
+      throw error;
+    }
+    return "agent_task";
+  }
+}
+
+function normalizeDetectedFamily(family: ScenarioFamilyName): ScenarioFamilyName {
+  return family === "game" ? "agent_task" : family;
 }
 
 export function isScenarioFamilyName(value: string): value is ScenarioFamilyName {
@@ -157,7 +188,7 @@ export function buildScenarioCreationPrompt(description: string): string {
   return [scenarioCreationInstructions(), "", `User description: ${description}`].join("\n");
 }
 
-function createProviderLlmFn(provider: LLMProvider): LlmFn {
+function createProviderLlmFn(provider: LLMProvider): ProviderLlmFn {
   return async (system: string, user: string): Promise<string> => {
     const result = await provider.complete({
       systemPrompt: system,
@@ -364,7 +395,7 @@ function buildCoordinationCreatedSpec(
 
 const FAMILY_AWARE_SCENARIO_FACTORIES: Record<
   FamilyAwareScenarioFamily,
-  (description: string, llmFn: LlmFn) => Promise<CreatedScenarioResult["spec"]>
+  (description: string, llmFn: ProviderLlmFn) => Promise<CreatedScenarioResult["spec"]>
 > = {
   coordination: async (description, llmFn) =>
     buildCoordinationCreatedSpec(description, await designCoordination(description, llmFn)),
@@ -384,14 +415,14 @@ const FAMILY_AWARE_SCENARIO_FACTORIES: Record<
 
 async function createFamilyAwareScenarioFromDescription(
   description: string,
-  provider: LLMProvider,
   name: string,
   family: FamilyAwareScenarioFamily,
+  llmFn: ProviderLlmFn,
 ): Promise<CreatedScenarioResult> {
   return {
     name,
     family,
-    spec: await FAMILY_AWARE_SCENARIO_FACTORIES[family](description, createProviderLlmFn(provider)),
+    spec: await FAMILY_AWARE_SCENARIO_FACTORIES[family](description, llmFn),
   };
 }
 
@@ -471,15 +502,16 @@ export async function createScenarioFromDescription(
   provider: LLMProvider,
 ): Promise<CreatedScenarioResult> {
   const defaultName = deriveScenarioName(description);
-  const defaultFamily = detectScenarioFamily(description);
+  const providerLlmFn = createProviderLlmFn(provider);
+  const defaultFamily = await detectScenarioFamilyAsync(description, { llmFn: providerLlmFn });
 
   if (hasFamilyAwareScenarioFactory(defaultFamily)) {
     try {
       const created = await createFamilyAwareScenarioFromDescription(
         description,
-        provider,
         defaultName,
         defaultFamily,
+        providerLlmFn,
       );
       return {
         ...created,

--- a/ts/tests/ac628-classifier.test.ts
+++ b/ts/tests/ac628-classifier.test.ts
@@ -6,8 +6,10 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  classifyScenarioFamilyAsync,
   classifyScenarioFamily,
   LowConfidenceError,
+  type AsyncLlmFn,
   type LlmFn,
 } from "../src/scenarios/family-classifier.js";
 
@@ -86,6 +88,20 @@ describe("AC-628: fast-path threshold from env", () => {
     classifyScenarioFamily("evaluate some data and trace results", { llmFn });
     expect(llmCalled).toBe(false);
   });
+
+  it("rejects invalid threshold values instead of silently disabling the fast path", () => {
+    process.env[ENV_KEY] = "not-a-number";
+    expect(() => classifyScenarioFamily(HIGH_SIGNAL_DESCRIPTION)).toThrow(
+      "AUTOCONTEXT_CLASSIFIER_FAST_PATH_THRESHOLD",
+    );
+  });
+
+  it("rejects out-of-range threshold values consistently with Python settings", () => {
+    process.env[ENV_KEY] = "1.5";
+    expect(() => classifyScenarioFamily(HIGH_SIGNAL_DESCRIPTION)).toThrow(
+      "AUTOCONTEXT_CLASSIFIER_FAST_PATH_THRESHOLD",
+    );
+  });
 });
 
 describe("AC-628: fast-path skips LLM on high-signal input", () => {
@@ -158,6 +174,14 @@ describe("AC-628: zero-signal behaviour", () => {
     expect(c.familyName).toBe("simulation");
     expect(c.llmClassifierUsed).toBe(true);
     expect(c.noSignalsMatched).toBe(false);
+  });
+
+  it("awaits provider-backed async LLM classification for zero-signal descriptions", async () => {
+    const llmFn: AsyncLlmFn = async () =>
+      '{"family": "workflow", "confidence": 0.81, "rationale": "async provider classified it"}';
+    const c = await classifyScenarioFamilyAsync(ZERO_SIGNAL_DESCRIPTION, { llmFn });
+    expect(c.familyName).toBe("workflow");
+    expect(c.llmClassifierUsed).toBe(true);
   });
 
   it("raises LowConfidenceError with llmClassifierAttempted=true when zero-signal + llmFn fails", () => {

--- a/ts/tests/ac628-classifier.test.ts
+++ b/ts/tests/ac628-classifier.test.ts
@@ -1,0 +1,185 @@
+/**
+ * AC-628 — TS parity tests for LLM-primary family classifier with config-driven
+ * fast-path threshold.
+ *
+ * Mirrors `autocontext/tests/test_ac628_classifier.py`.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  classifyScenarioFamily,
+  LowConfidenceError,
+  type LlmFn,
+} from "../src/scenarios/family-classifier.js";
+
+const HIGH_SIGNAL_DESCRIPTION = "negotiate price with the supplier and reach a deal";
+const ZERO_SIGNAL_DESCRIPTION = "xyz plop qux widget zzzz";
+
+const ENV_KEY = "AUTOCONTEXT_CLASSIFIER_FAST_PATH_THRESHOLD";
+
+describe("AC-628: classification fields", () => {
+  it("does not expose legacy llmFallbackUsed field on classification", () => {
+    const c = classifyScenarioFamily(HIGH_SIGNAL_DESCRIPTION);
+    expect(c).not.toHaveProperty("llmFallbackUsed");
+    expect(c).not.toHaveProperty("llmFallbackAttempted");
+  });
+
+  it("exposes llmClassifierUsed=true when LLM picks the family on ambiguous input", () => {
+    // Ambiguous: split signals (evaluate→agent_task, trace→simulation), confidence below threshold.
+    const ambiguous = "evaluate some data and trace results";
+    const llmFn: LlmFn = () =>
+      '{"family": "simulation", "confidence": 0.7, "rationale": "llm picked simulation"}';
+    const c = classifyScenarioFamily(ambiguous, { llmFn });
+    expect(c.llmClassifierUsed).toBe(true);
+    expect(c.familyName).toBe("simulation");
+  });
+
+  it("does not set llmClassifierUsed on the fast path", () => {
+    const c = classifyScenarioFamily(HIGH_SIGNAL_DESCRIPTION);
+    expect(c.llmClassifierUsed).toBeFalsy();
+  });
+});
+
+describe("AC-628: fast-path threshold from env", () => {
+  const originalThreshold = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (originalThreshold === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = originalThreshold;
+    }
+  });
+
+  it("uses default threshold 0.65 when env var is unset", () => {
+    delete process.env[ENV_KEY];
+    let llmCalled = false;
+    const llmFn: LlmFn = () => {
+      llmCalled = true;
+      return "";
+    };
+    // High-signal description should clear default 0.65 → fast-path.
+    classifyScenarioFamily(HIGH_SIGNAL_DESCRIPTION, { llmFn });
+    expect(llmCalled).toBe(false);
+  });
+
+  it("respects a high custom threshold by routing ambiguous descriptions to LLM", () => {
+    // "evaluate ... trace" splits across agent_task + simulation → ~0.5 confidence,
+    // which clears default 0.65? No: 0.5 < 0.65 → ambiguous → LLM. We bump threshold
+    // to 0.99 to ensure ambiguous descriptions can't fast-path under any tweak.
+    process.env[ENV_KEY] = "0.99";
+    let llmCalled = false;
+    const llmFn: LlmFn = () => {
+      llmCalled = true;
+      return '{"family": "simulation", "confidence": 0.9, "rationale": "ok"}';
+    };
+    classifyScenarioFamily("evaluate some data and trace results", { llmFn });
+    expect(llmCalled).toBe(true);
+  });
+
+  it("respects a low threshold by skipping LLM even on ambiguous descriptions", () => {
+    process.env[ENV_KEY] = "0.05";
+    let llmCalled = false;
+    const llmFn: LlmFn = () => {
+      llmCalled = true;
+      return "";
+    };
+    classifyScenarioFamily("evaluate some data and trace results", { llmFn });
+    expect(llmCalled).toBe(false);
+  });
+});
+
+describe("AC-628: fast-path skips LLM on high-signal input", () => {
+  it("does not invoke llmFn when keyword confidence clears threshold", () => {
+    let llmCalls = 0;
+    const llmFn: LlmFn = () => {
+      llmCalls += 1;
+      return "";
+    };
+    classifyScenarioFamily(HIGH_SIGNAL_DESCRIPTION, { llmFn });
+    expect(llmCalls).toBe(0);
+  });
+
+  it("returns the keyword-derived family on the fast path (no LLM)", () => {
+    const c = classifyScenarioFamily(HIGH_SIGNAL_DESCRIPTION);
+    expect(c.familyName).toBe("negotiation");
+    expect(c.noSignalsMatched).toBe(false);
+  });
+});
+
+describe("AC-628: ambiguous descriptions invoke LLM when provided", () => {
+  const AMBIGUOUS = "evaluate some data and trace results";
+
+  it("calls llmFn exactly once on ambiguous input", () => {
+    let llmCalls = 0;
+    const llmFn: LlmFn = () => {
+      llmCalls += 1;
+      return '{"family": "simulation", "confidence": 0.6, "rationale": "ok"}';
+    };
+    classifyScenarioFamily(AMBIGUOUS, { llmFn });
+    expect(llmCalls).toBe(1);
+  });
+
+  it("returns LLM-picked family on ambiguous + parseable LLM response", () => {
+    const llmFn: LlmFn = () =>
+      '{"family": "simulation", "confidence": 0.7, "rationale": "picked"}';
+    const c = classifyScenarioFamily(AMBIGUOUS, { llmFn });
+    expect(c.familyName).toBe("simulation");
+    expect(c.llmClassifierUsed).toBe(true);
+  });
+
+  it("falls back to keyword result on ambiguous + bad LLM response", () => {
+    const llmFn: LlmFn = () => "not json at all";
+    const c = classifyScenarioFamily(AMBIGUOUS, { llmFn });
+    expect(c.llmClassifierUsed).toBeFalsy();
+    expect(c.llmClassifierAttempted).toBe(true);
+  });
+});
+
+describe("AC-628: zero-signal behaviour", () => {
+  it("raises LowConfidenceError when no keywords match and no llmFn is provided", () => {
+    expect(() => classifyScenarioFamily(ZERO_SIGNAL_DESCRIPTION)).toThrow(LowConfidenceError);
+  });
+
+  it("attaches a classification with noSignalsMatched=true to the error", () => {
+    try {
+      classifyScenarioFamily(ZERO_SIGNAL_DESCRIPTION);
+      throw new Error("expected LowConfidenceError");
+    } catch (e) {
+      expect(e).toBeInstanceOf(LowConfidenceError);
+      const err = e as LowConfidenceError;
+      expect(err.classification.noSignalsMatched).toBe(true);
+    }
+  });
+
+  it("returns LLM result when zero-signal + llmFn succeeds", () => {
+    const llmFn: LlmFn = () =>
+      '{"family": "simulation", "confidence": 0.82, "rationale": "llm rescued zero-signal"}';
+    const c = classifyScenarioFamily(ZERO_SIGNAL_DESCRIPTION, { llmFn });
+    expect(c.familyName).toBe("simulation");
+    expect(c.llmClassifierUsed).toBe(true);
+    expect(c.noSignalsMatched).toBe(false);
+  });
+
+  it("raises LowConfidenceError with llmClassifierAttempted=true when zero-signal + llmFn fails", () => {
+    const llmFn: LlmFn = () => "not json";
+    try {
+      classifyScenarioFamily(ZERO_SIGNAL_DESCRIPTION, { llmFn });
+      throw new Error("expected LowConfidenceError");
+    } catch (e) {
+      expect(e).toBeInstanceOf(LowConfidenceError);
+      const err = e as LowConfidenceError;
+      expect(err.classification.noSignalsMatched).toBe(true);
+      expect(err.classification.llmClassifierAttempted).toBe(true);
+    }
+  });
+
+  it("does not call llmFn when keywords match (only zero-signal triggers required-LLM)", () => {
+    let llmCalls = 0;
+    const llmFn: LlmFn = () => {
+      llmCalls += 1;
+      return "";
+    };
+    classifyScenarioFamily(HIGH_SIGNAL_DESCRIPTION, { llmFn });
+    expect(llmCalls).toBe(0);
+  });
+});

--- a/ts/tests/scenario-creator-family-aware.test.ts
+++ b/ts/tests/scenario-creator-family-aware.test.ts
@@ -5,8 +5,105 @@ import {
   OPERATOR_LOOP_SPEC_END,
   OPERATOR_LOOP_SPEC_START,
 } from "../src/scenarios/operator-loop-designer.js";
+import { WORKFLOW_SPEC_END, WORKFLOW_SPEC_START } from "../src/scenarios/workflow-designer.js";
 
 describe("createScenarioFromDescription family-aware routing", () => {
+  it("uses the provider-backed LLM classifier before choosing the family-aware designer", async () => {
+    const workflowSpec = {
+      description: "Opaque request routed by classifier",
+      environment_description: "A workflow with ordered side effects.",
+      initial_state_description: "No steps have run.",
+      workflow_steps: [
+        {
+          name: "prepare_payload",
+          description: "Prepare the payload.",
+          idempotent: true,
+          reversible: false,
+        },
+        {
+          name: "commit_payload",
+          description: "Commit the payload.",
+          idempotent: false,
+          reversible: true,
+          compensation: "rollback_payload",
+        },
+      ],
+      success_criteria: ["Prepare the payload.", "Commit the payload safely."],
+      failure_modes: ["Commit fails after preparation."],
+      max_steps: 5,
+      actions: [
+        {
+          name: "prepare_payload",
+          description: "Prepare the payload.",
+          parameters: {},
+          preconditions: [],
+          effects: ["payload_prepared"],
+        },
+        {
+          name: "commit_payload",
+          description: "Commit the payload.",
+          parameters: {},
+          preconditions: ["prepare_payload"],
+          effects: ["payload_committed"],
+        },
+      ],
+    };
+    const provider = {
+      defaultModel: () => "mock-model",
+      complete: vi.fn(async ({ systemPrompt }: { systemPrompt?: string }) => {
+        if (systemPrompt?.includes("You classify a natural-language scenario description")) {
+          return {
+            text: JSON.stringify({
+              family: "workflow",
+              confidence: 0.83,
+              rationale: "Opaque request requires ordered workflow execution",
+            }),
+            model: "mock-model",
+            usage: { inputTokens: 0, outputTokens: 0 },
+          };
+        }
+
+        if (systemPrompt?.includes("produce a WorkflowSpec JSON")) {
+          return {
+            text: [WORKFLOW_SPEC_START, JSON.stringify(workflowSpec), WORKFLOW_SPEC_END].join("\n"),
+            model: "mock-model",
+            usage: { inputTokens: 0, outputTokens: 0 },
+          };
+        }
+
+        return {
+          text: JSON.stringify({
+            family: "agent_task",
+            name: "generic_fallback",
+            taskPrompt: "Generic fallback.",
+            rubric: "Generic fallback rubric.",
+            description: "Generic fallback output",
+          }),
+          model: "mock-model",
+          usage: { inputTokens: 0, outputTokens: 0 },
+        };
+      }),
+    };
+
+    const created = await createScenarioFromDescription(
+      "glimmer plinth orbit vascade",
+      provider as never,
+    );
+
+    expect(provider.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        systemPrompt: expect.stringContaining("You classify a natural-language scenario description"),
+      }),
+    );
+    expect(provider.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        systemPrompt: expect.stringContaining("produce a WorkflowSpec JSON"),
+      }),
+    );
+    expect(created.family).toBe("workflow");
+    expect(created.spec.description).toBe(workflowSpec.description);
+  });
+
   it("uses the operator-loop designer for operator_loop descriptions", async () => {
     const provider = {
       defaultModel: () => "mock-model",


### PR DESCRIPTION
## Summary

Implements AC-628: makes the LLM the primary signal for ambiguous and zero-signal scenario family classification, with a config-driven keyword fast-path threshold. Keyword classification stays the cheap default; the LLM is invoked only when keyword evidence is genuinely weak.

- **Two-gate classifier flow**:
  - Gate 1 (fast path): keyword confidence ≥ threshold returns the keyword result with no LLM call.
  - Gate 2 (ambiguous): keyword evidence below threshold calls `llm_fn` when available, falling back to the keyword result on parse failure.
  - Zero-signal: no keyword matches at all raises `LowConfidenceError` (LLM result returned if `llm_fn` parses; otherwise the error carries `llm_classifier_attempted=True`).
- **Field renames**: `llm_fallback_used`/`llm_fallback_attempted` → `llm_classifier_used`/`llm_classifier_attempted`. The LLM is no longer a fallback — it is the primary signal for ambiguous input.
- **Config**: `AUTOCONTEXT_CLASSIFIER_FAST_PATH_THRESHOLD` (default `0.65`) controls the Gate 1 cutoff. Wired through `AppSettings` (Pydantic) on the Python side and read from `process.env` at call time on the TS side.
- **TS parity**: TS classifier now mirrors the Python flow byte-for-byte, including richer `LowConfidenceError` messaging and the new optional fields on `FamilyClassification`.

## Behaviour-preserving changes

- `LowConfidenceError` now carries `classification` and `min_confidence` so consumers can introspect the failed classification (Python already did this; the TS error gains parity).
- TS `detectScenarioFamily` accepts an optional `{ llmFn }`; the existing zero-arg call sites are unchanged. The imported classifier `LlmFn` is aliased to `ClassifierLlmFn` to avoid colliding with the async `LlmFn` used by family-aware scenario factories.

## Test plan

- [x] Python: 18 new RED-first AC-628 tests in `autocontext/tests/test_ac628_classifier.py` cover field renames, threshold config (default + env + range validation), fast-path skip, ambiguous LLM invocation, and zero-signal raise/recover semantics.
- [x] Python: existing classifier tests updated for new error semantics (zero-signal raises rather than returns) and renamed fields. Full classifier suite (`test_classifier_*`, `test_family_classifier`, `test_llm_classifier_fallback`) green: **106 passed**.
- [x] Python: full pytest suite green.
- [x] TS: 16 parity tests in `ts/tests/ac628-classifier.test.ts` mirror the Python AC-628 test cases (field shape, fast-path skip, ambiguous LLM, threshold env override, zero-signal raise/recover).
- [x] TS: classifier-adjacent suites (`unified-classifier`, `scenario-creator-family-aware`, `family-classifier-scoring-workflow`, `simulation-family-routing`, `solve-scenario-routing`, `new-scenario-family-resolution`, `agent-task-pipeline`) — **133 passed**.
- [x] TS: `tsc --noEmit` clean.
- [x] Full TS suite: **4474 passed / 9 pre-existing failures** (campaign-cli, mission-cli, package-parity, server-protocol, cross-runtime — all CLI/contract integration tests unrelated to this change).