### PR TITLE
AC-620 Preserve TS solve controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - TypeScript CLI now exposes `autoctx solve` as a DB-backed solve-on-demand entrypoint with `--description`, `--gens`, `--timeout`, and `--json` support (AC-619).
-- TypeScript solve now preserves Python-shaped controls for family override, generation-time-budget metadata, output file writing, and classifier fallback status metadata (AC-620).
+- TypeScript solve now preserves Python-shaped controls for structured family overrides, per-generation runtime-budget enforcement, output file writing, and classifier fallback status metadata (AC-620).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - TypeScript CLI now exposes `autoctx solve` as a DB-backed solve-on-demand entrypoint with `--description`, `--gens`, `--timeout`, and `--json` support (AC-619).
+- TypeScript solve now preserves Python-shaped controls for family override, generation-time-budget metadata, output file writing, and classifier fallback status metadata (AC-620).
 
 ### Fixed
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -138,7 +138,7 @@ autoctx providers
 autoctx models
 
 # Scenario execution
-autoctx solve --description "improve customer-support replies" --gens 3 --json
+autoctx solve --description "improve customer-support replies" --family agent_task --gens 3 --output package.json --json
 autoctx run --scenario support_triage --gens 3 --json
 autoctx list --json
 autoctx replay --run-id <id> --generation 1

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -526,6 +526,9 @@ async function cmdSolve(dbPath: string): Promise<void> {
       description: { type: "string", short: "d" },
       gens: { type: "string", short: "g" },
       timeout: { type: "string" },
+      "generation-time-budget": { type: "string" },
+      family: { type: "string" },
+      output: { type: "string" },
       json: { type: "boolean" },
       help: { type: "boolean", short: "h" },
     },
@@ -536,6 +539,7 @@ async function cmdSolve(dbPath: string): Promise<void> {
     planSolveCommand,
     renderSolveCommandSummary,
     SOLVE_HELP_TEXT,
+    writeSolveOutputFile,
   } = await import("./solve-command-workflow.js");
 
   if (values.help) {
@@ -570,6 +574,10 @@ async function cmdSolve(dbPath: string): Promise<void> {
       }),
       plan,
     });
+    if (plan.outputPath) {
+      writeSolveOutputFile(summary.result, resolve(plan.outputPath));
+      summary.outputPath = resolve(plan.outputPath);
+    }
     console.log(renderSolveCommandSummary(summary, plan.json));
   } catch (error) {
     console.error(errorMessage(error));

--- a/ts/src/cli/solve-command-workflow.ts
+++ b/ts/src/cli/solve-command-workflow.ts
@@ -1,23 +1,33 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
 export const SOLVE_HELP_TEXT = `autoctx solve — create and solve a scenario from a plain-language description
 
 Usage:
-  autoctx solve --description "..." [--gens N] [--json]
+  autoctx solve --description "..." [--gens N] [--family name] [--json]
 
 Options:
   -d, --description <text>   Natural-language scenario/problem description
   -g, --gens <N>             Generations to run (default: 5)
+  --family <name>            Force a scenario family before creation/routing
   --timeout <seconds>        Maximum time to wait for solve completion (default: 300)
+  --generation-time-budget <seconds>
+                              Soft per-generation solve runtime budget metadata (0 = unlimited)
+  --output <path>            Write the solved package JSON to a file
   --json                     Output structured JSON
   -h, --help                 Show this help
 
 Examples:
   autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
-  autoctx solve -d "investigate a production outage from logs" --gens 2 --json`;
+  autoctx solve -d "investigate a production outage from logs" --family investigation --gens 2 --json`;
 
 export interface SolveCommandValues {
   description?: string;
   gens?: string;
   timeout?: string;
+  "generation-time-budget"?: string;
+  family?: string;
+  output?: string;
   json?: boolean;
 }
 
@@ -25,11 +35,21 @@ export interface SolveCommandPlan {
   description: string;
   generations: number;
   timeoutMs: number;
+  generationTimeBudgetSeconds: number | null;
+  familyOverride: string | null;
+  outputPath: string | null;
   json: boolean;
 }
 
 export interface SolveManagerLike {
-  submit(description: string, generations: number): string;
+  submit(
+    description: string,
+    generations: number,
+    opts?: {
+      familyOverride?: string;
+      generationTimeBudgetSeconds?: number | null;
+    },
+  ): string;
   getStatus(jobId: string): Record<string, unknown>;
   getResult(jobId: string): Record<string, unknown> | null;
 }
@@ -41,6 +61,9 @@ export interface SolveCommandSummary {
   scenarioName: string | null;
   family: string | null;
   generations: number;
+  generationTimeBudgetSeconds: number | null;
+  outputPath: string | null;
+  llmClassifierFallbackUsed: boolean;
   progress: number;
   result: Record<string, unknown>;
 }
@@ -60,11 +83,17 @@ export function planSolveCommand(
   const timeoutMs = values.timeout
     ? parsePositiveInteger(values.timeout, "--timeout") * 1000
     : DEFAULT_TIMEOUT_MS;
+  const generationTimeBudgetSeconds = values["generation-time-budget"] === undefined
+    ? null
+    : parseNonNegativeInteger(values["generation-time-budget"], "--generation-time-budget");
 
   return {
     description,
     generations: values.gens ? parsePositiveInteger(values.gens, "--gens") : 5,
     timeoutMs,
+    generationTimeBudgetSeconds,
+    familyOverride: values.family?.trim() ? values.family.trim() : null,
+    outputPath: values.output?.trim() ? values.output.trim() : null,
     json: Boolean(values.json),
   };
 }
@@ -80,7 +109,10 @@ export async function executeSolveCommandWorkflow(opts: {
   const sleep = opts.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const deadline = now() + opts.plan.timeoutMs;
-  const jobId = opts.manager.submit(opts.plan.description, opts.plan.generations);
+  const jobId = opts.manager.submit(opts.plan.description, opts.plan.generations, {
+    familyOverride: opts.plan.familyOverride ?? undefined,
+    generationTimeBudgetSeconds: opts.plan.generationTimeBudgetSeconds,
+  });
 
   let status = opts.manager.getStatus(jobId);
   while (!isTerminalSolveStatus(status)) {
@@ -107,9 +139,22 @@ export async function executeSolveCommandWorkflow(opts: {
     scenarioName: stringOrNull(status.scenarioName),
     family: stringOrNull(status.family),
     generations: numberOrDefault(status.generations, opts.plan.generations),
+    generationTimeBudgetSeconds: nullableNumberOrDefault(
+      status.generationTimeBudgetSeconds ?? status.generation_time_budget_seconds,
+      opts.plan.generationTimeBudgetSeconds,
+    ),
+    outputPath: opts.plan.outputPath,
+    llmClassifierFallbackUsed: Boolean(
+      status.llmClassifierFallbackUsed ?? status.llm_classifier_fallback_used,
+    ),
     progress: numberOrDefault(status.progress, 0),
     result,
   };
+}
+
+export function writeSolveOutputFile(result: Record<string, unknown>, outputPath: string): void {
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, JSON.stringify(result, null, 2) + "\n", "utf-8");
 }
 
 export function renderSolveCommandSummary(summary: SolveCommandSummary, json: boolean): string {
@@ -124,6 +169,7 @@ export function renderSolveCommandSummary(summary: SolveCommandSummary, json: bo
     `  Family: ${summary.family ?? "unknown"}`,
     `  Generations: ${summary.generations}`,
     `  Progress: ${summary.progress}`,
+    ...(summary.outputPath ? [`  Output: ${summary.outputPath}`] : []),
   ].join("\n");
 }
 
@@ -137,4 +183,16 @@ function stringOrNull(value: unknown): string | null {
 
 function numberOrDefault(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function nullableNumberOrDefault(value: unknown, fallback: number | null): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function parseNonNegativeInteger(raw: string | undefined, label: string): number {
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return parsed;
 }

--- a/ts/src/cli/solve-command-workflow.ts
+++ b/ts/src/cli/solve-command-workflow.ts
@@ -12,7 +12,7 @@ Options:
   --family <name>            Force a scenario family before creation/routing
   --timeout <seconds>        Maximum time to wait for solve completion (default: 300)
   --generation-time-budget <seconds>
-                              Soft per-generation solve runtime budget metadata (0 = unlimited)
+                              Soft per-generation solve runtime budget (0 = unlimited)
   --output <path>            Write the solved package JSON to a file
   --json                     Output structured JSON
   -h, --help                 Show this help

--- a/ts/src/execution/improvement-loop.ts
+++ b/ts/src/execution/improvement-loop.ts
@@ -25,6 +25,7 @@ export interface ImprovementLoopOpts {
   maxScoreDelta?: number;
   capScoreJumps?: boolean;
   dimensionThreshold?: number;
+  timeBudget?: { check(phase: string): void };
 }
 
 export class ImprovementLoop {
@@ -35,6 +36,7 @@ export class ImprovementLoop {
   #maxScoreDelta: number;
   #capScoreJumps: boolean;
   #dimensionThreshold: number | null;
+  #timeBudget: { check(phase: string): void } | null;
 
   constructor(opts: ImprovementLoopOpts) {
     this.#task = opts.task;
@@ -44,6 +46,7 @@ export class ImprovementLoop {
     this.#maxScoreDelta = opts.maxScoreDelta ?? 0.5;
     this.#capScoreJumps = opts.capScoreJumps ?? false;
     this.#dimensionThreshold = opts.dimensionThreshold ?? null;
+    this.#timeBudget = opts.timeBudget ?? null;
   }
 
   async run(opts: {
@@ -74,12 +77,14 @@ export class ImprovementLoop {
 
     for (let roundNum = 1; roundNum <= this.#maxRounds; roundNum++) {
       const roundStart = performance.now();
+      this.#timeBudget?.check(`round ${roundNum} evaluation`);
       const result = await this.#task.evaluateOutput(currentOutput, opts.state, {
         referenceContext: opts.referenceContext,
         requiredConcepts: opts.requiredConcepts,
         calibrationExamples: opts.calibrationExamples,
         pinnedDimensions,
       });
+      this.#timeBudget?.check(`round ${roundNum} evaluation`);
       judgeCalls += 1;
       const roundMs = Math.round(performance.now() - roundStart);
       totalInternalRetries += result.internalRetries ?? 0;
@@ -111,7 +116,9 @@ export class ImprovementLoop {
             dimensionScores: lastGoodResult.dimensionScores,
             internalRetries: 0,
           };
+          this.#timeBudget?.check(`round ${roundNum} revision`);
           const revised = await this.#task.reviseOutput(currentOutput, feedbackResult, opts.state);
+          this.#timeBudget?.check(`round ${roundNum} revision`);
           const cleaned = cleanRevisionOutput(revised);
           if (cleaned !== currentOutput) {
             currentOutput = cleaned;
@@ -143,7 +150,9 @@ export class ImprovementLoop {
       let effectiveScore = scoreDeltaPolicy.effectiveScore;
 
       if (effectiveScore > 0 && this.#task.verifyFacts) {
+        this.#timeBudget?.check(`round ${roundNum} fact verification`);
         const verifyResult = await this.#task.verifyFacts(currentOutput, opts.state);
+        this.#timeBudget?.check(`round ${roundNum} fact verification`);
         if (verifyResult && !verifyResult.verified) {
           const issues = verifyResult.issues ?? [];
           if (issues.length > 0) {
@@ -211,7 +220,9 @@ export class ImprovementLoop {
                 previousValidRound: previousValidRound ?? undefined,
               })
             : result;
+        this.#timeBudget?.check(`round ${roundNum} revision`);
         const revised = await this.#task.reviseOutput(currentOutput, revisionFeedback, opts.state);
+        this.#timeBudget?.check(`round ${roundNum} revision`);
         const cleaned = cleanRevisionOutput(revised);
         if (cleaned === currentOutput) {
           terminationReason = "unchanged_output";

--- a/ts/src/knowledge/agent-task-solve-execution.ts
+++ b/ts/src/knowledge/agent-task-solve-execution.ts
@@ -1,6 +1,7 @@
 import { ImprovementLoop } from "../execution/improvement-loop.js";
 import { createAgentTask } from "../scenarios/agent-task-factory.js";
 import { AgentTaskSpecSchema, type AgentTaskSpec } from "../scenarios/agent-task-spec.js";
+import { SolveGenerationBudget } from "./solve-generation-budget.js";
 import type {
   AgentTaskInterface,
   ImprovementResult,
@@ -111,6 +112,7 @@ export interface AgentTaskSolveExecutionDeps {
     task: AgentTaskSolveTask;
     maxRounds: number;
     qualityThreshold: number;
+    timeBudget?: SolveGenerationBudget;
   }) => AgentTaskSolveLoop;
 }
 
@@ -123,11 +125,13 @@ function defaultCreateLoop(opts: {
   task: AgentTaskSolveTask;
   maxRounds: number;
   qualityThreshold: number;
+  timeBudget?: SolveGenerationBudget;
 }): AgentTaskSolveLoop {
   return new ImprovementLoop({
     task: opts.task,
     maxRounds: opts.maxRounds,
     qualityThreshold: opts.qualityThreshold,
+    timeBudget: opts.timeBudget,
   });
 }
 
@@ -135,6 +139,7 @@ export async function executeAgentTaskSolve(opts: {
   provider: LLMProvider;
   created: { name: string; spec: Record<string, unknown> };
   generations: number;
+  generationTimeBudgetSeconds?: number | null;
   deps?: AgentTaskSolveExecutionDeps;
 }): Promise<AgentTaskSolveExecutionResult> {
   const spec = buildAgentTaskSolveSpec(
@@ -150,26 +155,36 @@ export async function executeAgentTaskSolve(opts: {
     name: opts.created.name,
     provider: opts.provider,
   });
+  const timeBudget = new SolveGenerationBudget({
+    scenarioName: opts.created.name,
+    budgetSeconds: opts.generationTimeBudgetSeconds,
+  });
   const loop = (opts.deps?.createLoop ?? defaultCreateLoop)({
     task,
     maxRounds: spec.maxRounds,
     qualityThreshold: spec.qualityThreshold,
+    timeBudget,
   });
 
+  timeBudget.check("initial state");
   const initialState = task.prepareContext
     ? await task.prepareContext(task.initialState())
     : task.initialState();
+  timeBudget.check("context preparation");
   const contextErrors = task.validateContext
     ? task.validateContext(initialState)
     : [];
+  timeBudget.check("context validation");
   if (contextErrors.length > 0) {
     throw new Error(`agent_task context preparation failed: ${contextErrors.join("; ")}`);
   }
 
+  timeBudget.check("initial generation");
   const initialOutput = await opts.provider.complete({
     systemPrompt: "You are a helpful assistant.",
     userPrompt: task.getTaskPrompt(initialState),
   });
+  timeBudget.check("initial generation");
 
   const result = await loop.run({
     initialOutput: initialOutput.text,
@@ -178,6 +193,7 @@ export async function executeAgentTaskSolve(opts: {
     requiredConcepts: spec.requiredConcepts ?? undefined,
     calibrationExamples: spec.calibrationExamples ?? undefined,
   });
+  timeBudget.check("improvement loop");
 
   const bestRound = result.rounds.find((round) => round.roundNumber === result.bestRound);
   return {

--- a/ts/src/knowledge/built-in-game-solve-execution.ts
+++ b/ts/src/knowledge/built-in-game-solve-execution.ts
@@ -23,6 +23,7 @@ export interface BuiltInGameSolveDeps {
     matchesPerGeneration: number;
     maxRetries: number;
     minDelta: number;
+    generationTimeBudgetSeconds?: number | null;
   }) => { run(runId: string, generations: number): Promise<{ generationsCompleted: number }> };
   exportPackage?: (opts: {
     scenarioName: string;
@@ -45,6 +46,7 @@ async function defaultCreateRunner(opts: {
   matchesPerGeneration: number;
   maxRetries: number;
   minDelta: number;
+  generationTimeBudgetSeconds?: number | null;
 }): Promise<{ run(runId: string, generations: number): Promise<{ generationsCompleted: number }> }> {
   const { GenerationRunner } = await import("../loop/generation-runner.js");
   return new GenerationRunner(opts);
@@ -58,6 +60,7 @@ export async function executeBuiltInGameSolve(opts: {
   scenarioName: string;
   jobId: string;
   generations: number;
+  generationTimeBudgetSeconds?: number | null;
   deps?: BuiltInGameSolveDeps;
 }): Promise<BuiltInGameSolveExecutionResult> {
   const ScenarioClass = await (opts.deps?.resolveScenarioClass ?? defaultResolveScenarioClass)(opts.scenarioName);
@@ -76,6 +79,7 @@ export async function executeBuiltInGameSolve(opts: {
     matchesPerGeneration: 2,
     maxRetries: 0,
     minDelta: 0,
+    generationTimeBudgetSeconds: opts.generationTimeBudgetSeconds,
   });
 
   const runId = `solve_${opts.scenarioName}_${opts.jobId}`;

--- a/ts/src/knowledge/codegen-solve-execution.ts
+++ b/ts/src/knowledge/codegen-solve-execution.ts
@@ -6,6 +6,7 @@ import type { GeneratedScenarioExecutionResult } from "../scenarios/codegen/exec
 import type { ExecutionValidationResult } from "../scenarios/codegen/index.js";
 import type { SerializedSkillPackageDict } from "./package.js";
 import { buildGeneratedScenarioSolvePackage } from "./solve-workflow.js";
+import { SolveGenerationBudget } from "./solve-generation-budget.js";
 
 export interface CodegenSolveExecutionResult {
   progress: number;
@@ -86,28 +87,38 @@ export async function executeCodegenSolve(opts: {
     spec: Record<string, unknown>;
   };
   deps?: CodegenSolveDeps;
+  generationTimeBudgetSeconds?: number | null;
 }): Promise<CodegenSolveExecutionResult> {
   const generateSource = opts.deps?.generateSource ?? defaultGenerateSource;
   const executeScenario = opts.deps?.executeScenario ?? defaultExecuteScenario;
+  const timeBudget = new SolveGenerationBudget({
+    scenarioName: opts.created.name,
+    budgetSeconds: opts.generationTimeBudgetSeconds,
+  });
 
+  timeBudget.check("source generation");
   const { source, validation } = await generateSource(
     opts.created.family,
     opts.created.spec,
     opts.created.name,
   );
+  timeBudget.check("source generation");
 
   persistGeneratedScenarioSource({
     knowledgeRoot: opts.knowledgeRoot,
     name: opts.created.name,
     source,
   });
+  timeBudget.check("source persistence");
 
+  timeBudget.check("scenario execution");
   const execution = await executeScenario({
     source,
     family: opts.created.family,
     name: opts.created.name,
     maxSteps: resolveMaxSteps(opts.created.spec),
   });
+  timeBudget.check("scenario execution");
 
   return {
     progress: execution.stepsExecuted,

--- a/ts/src/knowledge/solve-generation-budget.ts
+++ b/ts/src/knowledge/solve-generation-budget.ts
@@ -1,0 +1,40 @@
+export interface SolveGenerationBudgetOpts {
+  scenarioName: string;
+  budgetSeconds?: number | null;
+  nowMs?: () => number;
+}
+
+export class SolveGenerationBudget {
+  readonly scenarioName: string;
+  readonly budgetSeconds: number;
+  #startedAtMs: number;
+  #nowMs: () => number;
+
+  constructor(opts: SolveGenerationBudgetOpts) {
+    this.scenarioName = opts.scenarioName;
+    this.budgetSeconds = normalizeBudgetSeconds(opts.budgetSeconds);
+    this.#nowMs = opts.nowMs ?? (() => performance.now());
+    this.#startedAtMs = this.#nowMs();
+  }
+
+  check(phase: string): void {
+    if (this.budgetSeconds <= 0) {
+      return;
+    }
+    const elapsedSeconds = Math.max(0, this.#nowMs() - this.#startedAtMs) / 1000;
+    if (elapsedSeconds >= this.budgetSeconds) {
+      throw new Error(
+        `Solve generation time budget exceeded during ${phase} ` +
+        `after ${elapsedSeconds.toFixed(2)}s for scenario '${this.scenarioName}' ` +
+        `(budget ${this.budgetSeconds}s)`,
+      );
+    }
+  }
+}
+
+function normalizeBudgetSeconds(value: number | null | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.floor(value);
+}

--- a/ts/src/knowledge/solve-job-workflow.ts
+++ b/ts/src/knowledge/solve-job-workflow.ts
@@ -2,6 +2,9 @@ export interface SolveJob {
   jobId: string;
   description: string;
   generations: number;
+  familyOverride?: string;
+  generationTimeBudgetSeconds?: number | null;
+  llmClassifierFallbackUsed?: boolean;
   status: "pending" | "creating_scenario" | "running" | "completed" | "failed";
   scenarioName?: string;
   family?: string;
@@ -14,11 +17,18 @@ export function createSolveJob(
   jobId: string,
   description: string,
   generations: number,
+  opts: {
+    familyOverride?: string;
+    generationTimeBudgetSeconds?: number | null;
+  } = {},
 ): SolveJob {
   return {
     jobId,
     description,
     generations,
+    familyOverride: opts.familyOverride,
+    generationTimeBudgetSeconds: opts.generationTimeBudgetSeconds,
+    llmClassifierFallbackUsed: false,
     status: "pending",
   };
 }
@@ -37,7 +47,12 @@ export function getSolveJobStatus(
     description: job.description,
     scenarioName: job.scenarioName ?? null,
     family: job.family ?? null,
+    familyOverride: job.familyOverride ?? null,
     generations: job.generations,
+    generationTimeBudgetSeconds: job.generationTimeBudgetSeconds ?? null,
+    generation_time_budget_seconds: job.generationTimeBudgetSeconds ?? null,
+    llmClassifierFallbackUsed: job.llmClassifierFallbackUsed ?? false,
+    llm_classifier_fallback_used: job.llmClassifierFallbackUsed ?? false,
     progress: job.progress ?? 0,
     error: job.error,
   };

--- a/ts/src/knowledge/solve-manager-workflow.ts
+++ b/ts/src/knowledge/solve-manager-workflow.ts
@@ -6,9 +6,11 @@ import { executeBuiltInGameSolve } from "./built-in-game-solve-execution.js";
 import { executeAgentTaskSolve } from "./agent-task-solve-execution.js";
 import { executeCodegenSolve } from "./codegen-solve-execution.js";
 import {
+  buildSolveScenarioDescription,
   determineSolveExecutionRoute,
   persistSolveScenarioScaffold,
   prepareSolveScenario,
+  validateSolveFamilyOverride,
 } from "./solve-scenario-routing.js";
 import { failSolveJob, type SolveJob } from "./solve-workflow.js";
 
@@ -127,10 +129,14 @@ export async function executeSolveJobWorkflow(opts: {
 }): Promise<void> {
   opts.job.status = "creating_scenario";
   try {
-    const created = await opts.deps.createScenarioFromDescription(opts.job.description);
+    const familyOverride = validateSolveFamilyOverride(opts.job.familyOverride);
+    const created = await opts.deps.createScenarioFromDescription(
+      buildSolveScenarioDescription(opts.job.description, familyOverride),
+    );
     const prepared = opts.deps.prepareSolveScenario({
       created: created as never,
       description: opts.job.description,
+      familyOverride,
     });
     opts.job.scenarioName = prepared.name;
     opts.job.family = prepared.family;

--- a/ts/src/knowledge/solve-manager-workflow.ts
+++ b/ts/src/knowledge/solve-manager-workflow.ts
@@ -6,7 +6,6 @@ import { executeBuiltInGameSolve } from "./built-in-game-solve-execution.js";
 import { executeAgentTaskSolve } from "./agent-task-solve-execution.js";
 import { executeCodegenSolve } from "./codegen-solve-execution.js";
 import {
-  buildSolveScenarioDescription,
   determineSolveExecutionRoute,
   persistSolveScenarioScaffold,
   prepareSolveScenario,
@@ -15,7 +14,10 @@ import {
 import { failSolveJob, type SolveJob } from "./solve-workflow.js";
 
 export interface SolveExecutionDeps {
-  createScenarioFromDescription: (description: string) => Promise<unknown>;
+  createScenarioFromDescription: (
+    description: string,
+    opts?: { familyOverride?: ScenarioFamilyName },
+  ) => Promise<unknown>;
   listBuiltinScenarioNames: () => Promise<string[]>;
   persistSolveScenarioScaffold: typeof persistSolveScenarioScaffold;
   prepareSolveScenario: typeof prepareSolveScenario;
@@ -37,9 +39,9 @@ export function createSolveExecutionDeps(opts: {
   knowledgeRoot: string;
 }): SolveExecutionDeps {
   return {
-    createScenarioFromDescription: async (description) => {
+    createScenarioFromDescription: async (description, createOpts) => {
       const { createScenarioFromDescription } = await import("../scenarios/scenario-creator.js");
-      return createScenarioFromDescription(description, opts.provider);
+      return createScenarioFromDescription(description, opts.provider, createOpts);
     },
     listBuiltinScenarioNames: async () => {
       const { SCENARIO_REGISTRY } = await import("../scenarios/registry.js");
@@ -63,6 +65,7 @@ export async function runBuiltInGameSolveJob(opts: {
   knowledgeRoot: string;
   scenarioName: string;
   generations: number;
+  generationTimeBudgetSeconds?: number | null;
   executeBuiltInGameSolve: typeof executeBuiltInGameSolve;
 }): Promise<void> {
   opts.job.status = "running";
@@ -74,6 +77,7 @@ export async function runBuiltInGameSolveJob(opts: {
     scenarioName: opts.scenarioName,
     jobId: opts.job.jobId,
     generations: opts.generations,
+    generationTimeBudgetSeconds: opts.generationTimeBudgetSeconds,
   });
   opts.job.progress = result.progress;
   opts.job.status = "completed";
@@ -85,6 +89,7 @@ export async function runAgentTaskSolveJob(opts: {
   provider: LLMProvider;
   created: { name: string; spec: Record<string, unknown> };
   generations: number;
+  generationTimeBudgetSeconds?: number | null;
   executeAgentTaskSolve: typeof executeAgentTaskSolve;
 }): Promise<void> {
   opts.job.status = "running";
@@ -92,6 +97,7 @@ export async function runAgentTaskSolveJob(opts: {
     provider: opts.provider,
     created: opts.created,
     generations: opts.generations,
+    generationTimeBudgetSeconds: opts.generationTimeBudgetSeconds,
   });
   opts.job.progress = result.progress;
   opts.job.status = "completed";
@@ -103,6 +109,7 @@ export async function runCodegenSolveJob(opts: {
   knowledgeRoot: string;
   created: { name: string; family: string; spec: Record<string, unknown> };
   family: ScenarioFamilyName;
+  generationTimeBudgetSeconds?: number | null;
   executeCodegenSolve: typeof executeCodegenSolve;
 }): Promise<void> {
   opts.job.status = "running";
@@ -113,6 +120,7 @@ export async function runCodegenSolveJob(opts: {
       family: opts.family,
       spec: opts.created.spec,
     },
+    generationTimeBudgetSeconds: opts.generationTimeBudgetSeconds,
   });
   opts.job.progress = result.progress;
   opts.job.status = "completed";
@@ -131,8 +139,10 @@ export async function executeSolveJobWorkflow(opts: {
   try {
     const familyOverride = validateSolveFamilyOverride(opts.job.familyOverride);
     const created = await opts.deps.createScenarioFromDescription(
-      buildSolveScenarioDescription(opts.job.description, familyOverride),
+      opts.job.description,
+      { familyOverride },
     );
+    opts.job.llmClassifierFallbackUsed = readClassifierFallbackUsed(created);
     const prepared = opts.deps.prepareSolveScenario({
       created: created as never,
       description: opts.job.description,
@@ -154,6 +164,7 @@ export async function executeSolveJobWorkflow(opts: {
         knowledgeRoot: opts.knowledgeRoot,
         scenarioName: prepared.name,
         generations: opts.job.generations,
+        generationTimeBudgetSeconds: opts.job.generationTimeBudgetSeconds,
         executeBuiltInGameSolve: opts.deps.executeBuiltInGameSolve,
       });
       return;
@@ -179,6 +190,7 @@ export async function executeSolveJobWorkflow(opts: {
         provider: opts.provider,
         created: prepared,
         generations: opts.job.generations,
+        generationTimeBudgetSeconds: opts.job.generationTimeBudgetSeconds,
         executeAgentTaskSolve: opts.deps.executeAgentTaskSolve,
       });
       return;
@@ -189,6 +201,7 @@ export async function executeSolveJobWorkflow(opts: {
         knowledgeRoot: opts.knowledgeRoot,
         created: prepared,
         family: prepared.family,
+        generationTimeBudgetSeconds: opts.job.generationTimeBudgetSeconds,
         executeCodegenSolve: opts.deps.executeCodegenSolve,
       });
       return;
@@ -197,4 +210,12 @@ export async function executeSolveJobWorkflow(opts: {
   } catch (error) {
     opts.deps.failSolveJob(opts.job, error);
   }
+}
+
+function readClassifierFallbackUsed(created: unknown): boolean {
+  if (typeof created !== "object" || created === null) {
+    return false;
+  }
+  const payload = created as Record<string, unknown>;
+  return payload.llmClassifierFallbackUsed === true;
 }

--- a/ts/src/knowledge/solve-scenario-routing.ts
+++ b/ts/src/knowledge/solve-scenario-routing.ts
@@ -51,16 +51,6 @@ export function validateSolveFamilyOverride(family: string | undefined): Scenari
   );
 }
 
-export function buildSolveScenarioDescription(
-  description: string,
-  familyOverride?: ScenarioFamilyName,
-): string {
-  if (!familyOverride) {
-    return description;
-  }
-  return `**Family:** ${familyOverride}\n\n${description}`;
-}
-
 export function prepareSolveScenario(opts: {
   created: CreatedScenarioResult;
   description: string;

--- a/ts/src/knowledge/solve-scenario-routing.ts
+++ b/ts/src/knowledge/solve-scenario-routing.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { CreatedScenarioResult } from "../scenarios/scenario-creator.js";
-import { getScenarioTypeMarker, type ScenarioFamilyName } from "../scenarios/families.js";
+import { SCENARIO_TYPE_MARKERS, getScenarioTypeMarker, type ScenarioFamilyName } from "../scenarios/families.js";
 import { hasCodegen } from "../scenarios/codegen/registry.js";
 import { materializeScenario, type MaterializeResult } from "../scenarios/materialize.js";
 import { healSpec } from "../scenarios/spec-auto-heal.js";
@@ -38,11 +38,35 @@ export function coerceSolveFamily(family: string): ScenarioFamilyName {
   }
 }
 
+export function validateSolveFamilyOverride(family: string | undefined): ScenarioFamilyName | undefined {
+  const normalized = family?.trim().toLowerCase().replace(/-/g, "_");
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized in SCENARIO_TYPE_MARKERS) {
+    return normalized as ScenarioFamilyName;
+  }
+  throw new Error(
+    `Unknown solve family '${family}'. Valid families: ${Object.keys(SCENARIO_TYPE_MARKERS).sort().join(", ")}`,
+  );
+}
+
+export function buildSolveScenarioDescription(
+  description: string,
+  familyOverride?: ScenarioFamilyName,
+): string {
+  if (!familyOverride) {
+    return description;
+  }
+  return `**Family:** ${familyOverride}\n\n${description}`;
+}
+
 export function prepareSolveScenario(opts: {
   created: CreatedScenarioResult;
   description: string;
+  familyOverride?: ScenarioFamilyName;
 }): PreparedSolveScenario {
-  const family = coerceSolveFamily(opts.created.family);
+  const family = opts.familyOverride ?? coerceSolveFamily(opts.created.family);
   return {
     ...opts.created,
     family,

--- a/ts/src/knowledge/solver.ts
+++ b/ts/src/knowledge/solver.ts
@@ -27,6 +27,11 @@ export interface SolveManagerOpts {
   knowledgeRoot: string;
 }
 
+export interface SolveSubmitOptions {
+  familyOverride?: string;
+  generationTimeBudgetSeconds?: number | null;
+}
+
 export { buildAgentTaskSolveSpec } from "./agent-task-solve-execution.js";
 
 export class SolveManager {
@@ -43,9 +48,9 @@ export class SolveManager {
     this.#knowledgeRoot = opts.knowledgeRoot;
   }
 
-  submit(description: string, generations: number): string {
+  submit(description: string, generations: number, opts: SolveSubmitOptions = {}): string {
     const jobId = buildSolveJobId();
-    const job = createSolveJob(jobId, description, generations);
+    const job = createSolveJob(jobId, description, generations, opts);
     this.#jobs.set(jobId, job);
 
     this.#runJob(job).catch(() => {

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -38,6 +38,7 @@ import {
   buildSupportPrompt,
 } from "./generation-prompts.js";
 import { createGenerationAttemptWorkflow, runGenerationAttemptWorkflow } from "./generation-attempt-workflow.js";
+import { SolveGenerationBudget } from "../knowledge/solve-generation-budget.js";
 import {
   completeGenerationLifecycleWorkflow,
   createGenerationLifecycleWorkflow,
@@ -91,6 +92,7 @@ export interface GenerationRunnerOpts {
   notifier?: Notifier | null;
   controller?: LoopController;
   events?: EventStreamEmitter;
+  generationTimeBudgetSeconds?: number | null;
 }
 
 export interface RunResult {
@@ -128,6 +130,7 @@ export class GenerationRunner {
   #notifyOn: Set<EventType>;
   #controller: LoopController | null;
   #events: EventStreamEmitter | null;
+  #generationTimeBudgetSeconds: number | null;
   #runState: GenerationRunState | null = null;
 
   constructor(opts: GenerationRunnerOpts) {
@@ -180,6 +183,7 @@ export class GenerationRunner {
       ?? buildConfiguredNotifier(opts.notifyWebhookUrl ?? null, [...this.#notifyOn]);
     this.#controller = opts.controller ?? null;
     this.#events = opts.events ?? null;
+    this.#generationTimeBudgetSeconds = opts.generationTimeBudgetSeconds ?? null;
   }
 
   async run(runId: string, generations: number): Promise<RunResult> {
@@ -197,6 +201,11 @@ export class GenerationRunner {
 
       while (hasRemainingGenerationCycles(orchestration.cycleState)) {
         await this.#controller?.waitIfPaused();
+        const generationBudget = new SolveGenerationBudget({
+          scenarioName: this.#scenario.name,
+          budgetSeconds: this.#generationTimeBudgetSeconds,
+        });
+        generationBudget.check("generation start");
         let lifecycle = await runGenerationLifecycleWorkflow(
           createGenerationLifecycleWorkflow({
             orchestration,
@@ -239,6 +248,7 @@ export class GenerationRunner {
             },
           }),
         );
+        generationBudget.check("generation lifecycle");
         orchestration = lifecycle.orchestration;
         this.#runState = orchestration.runState;
         for (const event of lifecycle.events) {
@@ -246,14 +256,17 @@ export class GenerationRunner {
         }
 
         this.#journal.persistGeneration(runId, lifecycle.generation, lifecycle.finalizedAttempt);
+        generationBudget.check("generation persistence");
         await this.#controller?.waitIfPaused();
         await this.runSupportRoles(runId, lifecycle.generation, lifecycle.finalizedAttempt);
+        generationBudget.check("support roles");
         await this.applyAdvancedFeatures(
           runId,
           lifecycle.generation,
           lifecycle.finalizedAttempt,
           lifecycle.phaseState.previousBestForGeneration,
         );
+        generationBudget.check("advanced generation features");
         lifecycle = completeGenerationLifecycleWorkflow(lifecycle);
         orchestration = lifecycle.orchestration;
         this.emit("generation_completed", orchestration.events.generationCompleted!);

--- a/ts/src/mcp/solve-tools.ts
+++ b/ts/src/mcp/solve-tools.ts
@@ -12,7 +12,14 @@ type McpToolRegistrar = {
 };
 
 interface SolveToolManager {
-  submit(description: string, generations: number): string;
+  submit(
+    description: string,
+    generations: number,
+    opts?: {
+      familyOverride?: string;
+      generationTimeBudgetSeconds?: number | null;
+    },
+  ): string;
   getStatus(jobId: string): Record<string, unknown>;
   getResult(jobId: string): Record<string, unknown> | null;
 }
@@ -72,29 +79,74 @@ function toPrefixedSolveStatusPayload(payload: Record<string, unknown>): Record<
   return prefixedPayload;
 }
 
+function solveSubmitSchema(): Record<string, unknown> {
+  return {
+    description: z.string(),
+    generations: z.number().int().default(5),
+    family: z.string().optional(),
+    generationTimeBudget: z.number().int().min(0).optional(),
+    generationTimeBudgetSeconds: z.number().int().min(0).optional(),
+    generation_time_budget: z.number().int().min(0).optional(),
+  };
+}
+
+function solveSubmitOptions(args: Record<string, unknown>):
+  | {
+    familyOverride?: string;
+    generationTimeBudgetSeconds?: number | null;
+  }
+  | undefined {
+  const familyOverride = typeof args.family === "string" && args.family.trim()
+    ? args.family.trim()
+    : undefined;
+  const generationTimeBudgetSeconds =
+    typeof args.generationTimeBudgetSeconds === "number"
+      ? args.generationTimeBudgetSeconds
+      : typeof args.generationTimeBudget === "number"
+        ? args.generationTimeBudget
+        : typeof args.generation_time_budget === "number"
+          ? args.generation_time_budget
+          : undefined;
+
+  if (familyOverride === undefined && generationTimeBudgetSeconds === undefined) {
+    return undefined;
+  }
+  return {
+    familyOverride,
+    generationTimeBudgetSeconds,
+  };
+}
+
+function submitSolveJob(
+  solveManager: SolveToolManager,
+  args: Record<string, unknown>,
+): string {
+  const description = String(args.description);
+  const generations = Number(args.generations ?? 5);
+  const options = solveSubmitOptions(args);
+  if (options === undefined) {
+    return solveManager.submit(description, generations);
+  }
+  return solveManager.submit(description, generations, options);
+}
+
 function buildSolveToolDefinitions(solveManager: SolveToolManager): SolveToolDefinition[] {
   return [
     {
       name: "solve_scenario",
       description: "Submit a problem for on-demand solving. Returns a job_id for polling.",
-      schema: { description: z.string(), generations: z.number().int().default(5) },
+      schema: solveSubmitSchema(),
       handler: async (args: Record<string, unknown>) => {
-        const jobId = solveManager.submit(
-          String(args.description),
-          Number(args.generations ?? 5),
-        );
+        const jobId = submitSolveJob(solveManager, args);
         return jsonText({ jobId, status: "pending" });
       },
       aliases: [
         {
           name: "autocontext_solve_scenario",
           description: "Submit a problem for on-demand solving. Returns a job_id for polling.",
-          schema: { description: z.string(), generations: z.number().int().default(5) },
+          schema: solveSubmitSchema(),
           handler: async (args: Record<string, unknown>) => {
-            const jobId = solveManager.submit(
-              String(args.description),
-              Number(args.generations ?? 5),
-            );
+            const jobId = submitSolveJob(solveManager, args);
             return jsonText({ job_id: jobId, status: "pending" });
           },
         },

--- a/ts/src/scenarios/scenario-creator.ts
+++ b/ts/src/scenarios/scenario-creator.ts
@@ -33,6 +33,7 @@ import type { WorkflowSpec } from "./workflow-spec.js";
 export interface CreatedScenarioResult {
   name: string;
   family: string;
+  llmClassifierFallbackUsed?: boolean;
   spec: {
     taskPrompt: string;
     rubric: string;
@@ -42,6 +43,13 @@ export interface CreatedScenarioResult {
 }
 
 type ProviderLlmFn = (system: string, user: string) => Promise<string>;
+export interface CreateScenarioOptions {
+  familyOverride?: ScenarioFamilyName;
+}
+interface ScenarioFamilyDetection {
+  family: ScenarioFamilyName;
+  llmClassifierFallbackUsed: boolean;
+}
 type FamilyAwareScenarioFamily =
   | "coordination"
   | "investigation"
@@ -119,21 +127,40 @@ export function detectScenarioFamily(
   description: string,
   options?: { llmFn?: ClassifierLlmFn },
 ): ScenarioFamilyName {
-  if (!description.trim()) return "agent_task";
+  return detectScenarioFamilyWithMetadata(description, options).family;
+}
+
+export function detectScenarioFamilyWithMetadata(
+  description: string,
+  options?: { llmFn?: ClassifierLlmFn },
+): ScenarioFamilyDetection {
+  if (!description.trim()) {
+    return { family: "agent_task", llmClassifierFallbackUsed: false };
+  }
 
   const hintedFamily = resolveScenarioFamilyHint(description);
   if (hintedFamily) {
-    return normalizeDetectedFamily(hintedFamily);
+    return {
+      family: normalizeDetectedFamily(hintedFamily),
+      llmClassifierFallbackUsed: false,
+    };
   }
 
   try {
-    const family = routeToFamily(classifyScenarioFamily(description, options), 0.15);
-    return normalizeDetectedFamily(family);
+    const classification = classifyScenarioFamily(description, options);
+    const family = routeToFamily(classification, 0.15);
+    return {
+      family: normalizeDetectedFamily(family),
+      llmClassifierFallbackUsed: Boolean(classification.llmClassifierUsed),
+    };
   } catch (error) {
     if (!(error instanceof LowConfidenceError)) {
       throw error;
     }
-    return "agent_task";
+    return {
+      family: "agent_task",
+      llmClassifierFallbackUsed: false,
+    };
   }
 }
 
@@ -141,21 +168,40 @@ export async function detectScenarioFamilyAsync(
   description: string,
   options?: { llmFn?: ClassifierAsyncLlmFn },
 ): Promise<ScenarioFamilyName> {
-  if (!description.trim()) return "agent_task";
+  return (await detectScenarioFamilyWithMetadataAsync(description, options)).family;
+}
+
+export async function detectScenarioFamilyWithMetadataAsync(
+  description: string,
+  options?: { llmFn?: ClassifierAsyncLlmFn },
+): Promise<ScenarioFamilyDetection> {
+  if (!description.trim()) {
+    return { family: "agent_task", llmClassifierFallbackUsed: false };
+  }
 
   const hintedFamily = resolveScenarioFamilyHint(description);
   if (hintedFamily) {
-    return normalizeDetectedFamily(hintedFamily);
+    return {
+      family: normalizeDetectedFamily(hintedFamily),
+      llmClassifierFallbackUsed: false,
+    };
   }
 
   try {
-    const family = routeToFamily(await classifyScenarioFamilyAsync(description, options), 0.15);
-    return normalizeDetectedFamily(family);
+    const classification = await classifyScenarioFamilyAsync(description, options);
+    const family = routeToFamily(classification, 0.15);
+    return {
+      family: normalizeDetectedFamily(family),
+      llmClassifierFallbackUsed: Boolean(classification.llmClassifierUsed),
+    };
   } catch (error) {
     if (!(error instanceof LowConfidenceError)) {
       throw error;
     }
-    return "agent_task";
+    return {
+      family: "agent_task",
+      llmClassifierFallbackUsed: false,
+    };
   }
 }
 
@@ -500,10 +546,17 @@ async function createGenericScenarioFromDescription(
 export async function createScenarioFromDescription(
   description: string,
   provider: LLMProvider,
+  options: CreateScenarioOptions = {},
 ): Promise<CreatedScenarioResult> {
   const defaultName = deriveScenarioName(description);
   const providerLlmFn = createProviderLlmFn(provider);
-  const defaultFamily = await detectScenarioFamilyAsync(description, { llmFn: providerLlmFn });
+  const detection = options.familyOverride
+    ? {
+        family: normalizeDetectedFamily(options.familyOverride),
+        llmClassifierFallbackUsed: false,
+      }
+    : await detectScenarioFamilyWithMetadataAsync(description, { llmFn: providerLlmFn });
+  const defaultFamily = detection.family;
 
   if (hasFamilyAwareScenarioFactory(defaultFamily)) {
     try {
@@ -515,6 +568,7 @@ export async function createScenarioFromDescription(
       );
       return {
         ...created,
+        llmClassifierFallbackUsed: detection.llmClassifierFallbackUsed,
         spec: healSpec(
           created.spec as Record<string, unknown>,
           created.family,
@@ -528,5 +582,8 @@ export async function createScenarioFromDescription(
     }
   }
 
-  return createGenericScenarioFromDescription(description, provider, defaultName, defaultFamily);
+  return {
+    ...(await createGenericScenarioFromDescription(description, provider, defaultName, defaultFamily)),
+    llmClassifierFallbackUsed: detection.llmClassifierFallbackUsed,
+  };
 }

--- a/ts/tests/agent-task-solve-execution.test.ts
+++ b/ts/tests/agent-task-solve-execution.test.ts
@@ -104,11 +104,15 @@ describe("agent-task solve execution", () => {
         },
       },
       generations: 2,
+      generationTimeBudgetSeconds: 11,
       deps: {
         createTask: () => task,
-        createLoop: () => ({
-          run: vi.fn(async () => loopResult),
-        }),
+        createLoop: (opts) => {
+          expect(opts.timeBudget).toBeDefined();
+          return {
+            run: vi.fn(async () => loopResult),
+          };
+        },
       },
     });
 

--- a/ts/tests/built-in-game-solve-execution.test.ts
+++ b/ts/tests/built-in-game-solve-execution.test.ts
@@ -67,6 +67,7 @@ describe("built-in game solve execution", () => {
       scenarioName: "grid_ctf",
       jobId: "job_1",
       generations: 2,
+      generationTimeBudgetSeconds: 7,
       deps: {
         resolveScenarioClass: () => FakeGameScenario,
         createRunner,
@@ -75,6 +76,9 @@ describe("built-in game solve execution", () => {
     });
 
     expect(createRunner).toHaveBeenCalledOnce();
+    expect(createRunner).toHaveBeenCalledWith(
+      expect.objectContaining({ generationTimeBudgetSeconds: 7 }),
+    );
     expect(run).toHaveBeenCalledWith("solve_grid_ctf_job_1", 2);
     expect(exportPackage).toHaveBeenCalledOnce();
     expect(result.progress).toBe(2);

--- a/ts/tests/scenario-creator-family-aware.test.ts
+++ b/ts/tests/scenario-creator-family-aware.test.ts
@@ -101,6 +101,7 @@ describe("createScenarioFromDescription family-aware routing", () => {
       }),
     );
     expect(created.family).toBe("workflow");
+    expect(created.llmClassifierFallbackUsed).toBe(true);
     expect(created.spec.description).toBe(workflowSpec.description);
   });
 

--- a/ts/tests/solve-command-workflow.test.ts
+++ b/ts/tests/solve-command-workflow.test.ts
@@ -4,7 +4,11 @@ import {
   executeSolveCommandWorkflow,
   planSolveCommand,
   renderSolveCommandSummary,
+  writeSolveOutputFile,
 } from "../src/cli/solve-command-workflow.js";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 describe("solve command workflow", () => {
   it("plans required description, generations, timeout, and JSON output", () => {
@@ -16,6 +20,9 @@ describe("solve command workflow", () => {
           description: "  investigate checkout failures  ",
           gens: "3",
           timeout: "12",
+          "generation-time-budget": "4",
+          family: "investigation",
+          output: "solve-result.json",
           json: true,
         },
         parsePositiveInteger,
@@ -24,6 +31,9 @@ describe("solve command workflow", () => {
       description: "investigate checkout failures",
       generations: 3,
       timeoutMs: 12_000,
+      generationTimeBudgetSeconds: 4,
+      familyOverride: "investigation",
+      outputPath: "solve-result.json",
       json: true,
     });
     expect(parsePositiveInteger).toHaveBeenCalledWith("3", "--gens");
@@ -58,13 +68,19 @@ describe("solve command workflow", () => {
         description: "grid ctf",
         generations: 1,
         timeoutMs: 1000,
+        generationTimeBudgetSeconds: 7,
+        familyOverride: "game",
+        outputPath: "result.json",
         json: true,
       },
       sleep: vi.fn(async () => undefined),
       pollIntervalMs: 1,
     });
 
-    expect(submit).toHaveBeenCalledWith("grid ctf", 1);
+    expect(submit).toHaveBeenCalledWith("grid ctf", 1, {
+      familyOverride: "game",
+      generationTimeBudgetSeconds: 7,
+    });
     expect(getStatus).toHaveBeenCalledTimes(2);
     expect(summary).toEqual({
       jobId: "solve-123",
@@ -73,6 +89,9 @@ describe("solve command workflow", () => {
       scenarioName: "grid_ctf",
       family: "game",
       generations: 1,
+      generationTimeBudgetSeconds: 7,
+      outputPath: "result.json",
+      llmClassifierFallbackUsed: false,
       progress: 1,
       result: { scenario_name: "grid_ctf" },
     });
@@ -86,11 +105,28 @@ describe("solve command workflow", () => {
       scenarioName: "grid_ctf",
       family: "game",
       generations: 1,
+      generationTimeBudgetSeconds: null,
+      outputPath: null,
+      llmClassifierFallbackUsed: false,
       progress: 1,
       result: { scenario_name: "grid_ctf" },
     };
 
     expect(JSON.parse(renderSolveCommandSummary(summary, true))).toEqual(summary);
     expect(renderSolveCommandSummary(summary, false)).toContain("Solve completed");
+  });
+
+  it("writes solved package output JSON files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ac-solve-output-"));
+    try {
+      const outputPath = join(dir, "package.json");
+      writeSolveOutputFile({ scenario_name: "grid_ctf" }, outputPath);
+      expect(existsSync(outputPath)).toBe(true);
+      expect(JSON.parse(readFileSync(outputPath, "utf-8"))).toEqual({
+        scenario_name: "grid_ctf",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/ts/tests/solve-generation-budget.test.ts
+++ b/ts/tests/solve-generation-budget.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { SolveGenerationBudget } from "../src/knowledge/solve-generation-budget.js";
+
+describe("solve generation budget", () => {
+  it("allows unlimited budgets and raises once elapsed time exceeds the cap", () => {
+    let nowMs = 0;
+    const unlimited = new SolveGenerationBudget({
+      scenarioName: "grid_ctf",
+      budgetSeconds: 0,
+      nowMs: () => 10_000,
+    });
+    expect(() => unlimited.check("setup")).not.toThrow();
+
+    const budget = new SolveGenerationBudget({
+      scenarioName: "incident_triage",
+      budgetSeconds: 2,
+      nowMs: () => nowMs,
+    });
+    expect(() => budget.check("initial generation")).not.toThrow();
+
+    nowMs = 2_001;
+    expect(() => budget.check("evaluation")).toThrow(
+      "Solve generation time budget exceeded during evaluation after 2.00s for scenario 'incident_triage' (budget 2s)",
+    );
+  });
+});

--- a/ts/tests/solve-manager-workflow.test.ts
+++ b/ts/tests/solve-manager-workflow.test.ts
@@ -12,7 +12,20 @@ describe("solve manager workflow", () => {
   });
 
   it("routes agent-task jobs through scenario preparation, persistence, and execution", async () => {
-    const job = createSolveJob("solve_job", "Summarize outage escalations", 2);
+    const job = createSolveJob("solve_job", "Summarize outage escalations", 2, {
+      familyOverride: "agent_task",
+      generationTimeBudgetSeconds: 30,
+    });
+    const createScenarioFromDescription = vi.fn(async () => ({
+      name: "incident_triage",
+      family: "agent_task",
+      spec: { taskPrompt: "Summarize incident reports", rubric: "Evaluate completeness" },
+    }));
+    const prepareSolveScenario = vi.fn(({ created, description, familyOverride }) => ({
+      ...created,
+      description,
+      family: familyOverride,
+    }));
     const executeAgentTaskSolve = vi.fn(async () => ({
       progress: 1,
       result: { scenario_name: "incident_triage", best_score: 0.93 },
@@ -25,13 +38,9 @@ describe("solve manager workflow", () => {
       runsRoot: "/tmp/runs",
       knowledgeRoot: "/tmp/knowledge",
       deps: {
-        createScenarioFromDescription: vi.fn(async () => ({
-          name: "incident_triage",
-          family: "agent_task",
-          spec: { taskPrompt: "Summarize incident reports", rubric: "Evaluate completeness" },
-        })),
+        createScenarioFromDescription,
         listBuiltinScenarioNames: vi.fn(async () => ["grid_ctf"]),
-        prepareSolveScenario: vi.fn(({ created, description }) => ({ ...created, description })) as never,
+        prepareSolveScenario: prepareSolveScenario as never,
         determineSolveExecutionRoute: vi.fn(() => "agent_task") as never,
         persistSolveScenarioScaffold: vi.fn(async () => ({ persisted: true, errors: [] })) as never,
         executeBuiltInGameSolve: vi.fn() as never,
@@ -44,6 +53,12 @@ describe("solve manager workflow", () => {
       },
     });
 
+    expect(createScenarioFromDescription).toHaveBeenCalledWith(
+      expect.stringContaining("**Family:** agent_task"),
+    );
+    expect(prepareSolveScenario).toHaveBeenCalledWith(
+      expect.objectContaining({ familyOverride: "agent_task" }),
+    );
     expect(executeAgentTaskSolve).toHaveBeenCalledWith({
       provider: expect.objectContaining({ name: "mock" }),
       created: expect.objectContaining({ name: "incident_triage" }),

--- a/ts/tests/solve-manager-workflow.test.ts
+++ b/ts/tests/solve-manager-workflow.test.ts
@@ -20,6 +20,7 @@ describe("solve manager workflow", () => {
       name: "incident_triage",
       family: "agent_task",
       spec: { taskPrompt: "Summarize incident reports", rubric: "Evaluate completeness" },
+      llmClassifierFallbackUsed: true,
     }));
     const prepareSolveScenario = vi.fn(({ created, description, familyOverride }) => ({
       ...created,
@@ -54,7 +55,8 @@ describe("solve manager workflow", () => {
     });
 
     expect(createScenarioFromDescription).toHaveBeenCalledWith(
-      expect.stringContaining("**Family:** agent_task"),
+      "Summarize outage escalations",
+      { familyOverride: "agent_task" },
     );
     expect(prepareSolveScenario).toHaveBeenCalledWith(
       expect.objectContaining({ familyOverride: "agent_task" }),
@@ -63,18 +65,22 @@ describe("solve manager workflow", () => {
       provider: expect.objectContaining({ name: "mock" }),
       created: expect.objectContaining({ name: "incident_triage" }),
       generations: 2,
+      generationTimeBudgetSeconds: 30,
     });
     expect(job).toMatchObject({
       status: "completed",
       scenarioName: "incident_triage",
       family: "agent_task",
+      llmClassifierFallbackUsed: true,
       progress: 1,
       result: { scenario_name: "incident_triage", best_score: 0.93 },
     });
   });
 
   it("reports built-in scenario solves as game family even when designer metadata drifts", async () => {
-    const job = createSolveJob("solve_builtin", "grid ctf", 1);
+    const job = createSolveJob("solve_builtin", "grid ctf", 1, {
+      generationTimeBudgetSeconds: 12,
+    });
     const executeBuiltInGameSolve = vi.fn(async () => ({
       progress: 1,
       result: { scenario_name: "grid_ctf", best_score: 0.73 },
@@ -110,6 +116,7 @@ describe("solve manager workflow", () => {
       expect.objectContaining({
         scenarioName: "grid_ctf",
         generations: 1,
+        generationTimeBudgetSeconds: 12,
       }),
     );
     expect(job).toMatchObject({
@@ -153,5 +160,54 @@ describe("solve manager workflow", () => {
     expect(failSolveJob).toHaveBeenCalledOnce();
     expect(job.status).toBe("failed");
     expect(job.error).toContain("Game scenario 'grid_ctf' not found in SCENARIO_REGISTRY");
+  });
+
+  it("passes generation budgets through generated-scenario solve routes", async () => {
+    const job = createSolveJob("solve_codegen", "Investigate outage", 1, {
+      generationTimeBudgetSeconds: 9,
+    });
+    const executeCodegenSolve = vi.fn(async () => ({
+      progress: 3,
+      result: { scenario_name: "outage_investigation", best_score: 0.81 },
+    }));
+
+    await executeSolveJobWorkflow({
+      job,
+      provider: { name: "mock", defaultModel: () => "mock", complete: vi.fn() } as never,
+      store: {} as never,
+      runsRoot: "/tmp/runs",
+      knowledgeRoot: "/tmp/knowledge",
+      deps: {
+        createScenarioFromDescription: vi.fn(async () => ({
+          name: "outage_investigation",
+          family: "investigation",
+          spec: { description: "Investigate outage", actions: [] },
+        })),
+        listBuiltinScenarioNames: vi.fn(async () => []),
+        prepareSolveScenario: vi.fn(({ created, description }) => ({ ...created, description })) as never,
+        determineSolveExecutionRoute: vi.fn(() => "codegen") as never,
+        persistSolveScenarioScaffold: vi.fn(async () => ({ persisted: true, errors: [] })) as never,
+        executeBuiltInGameSolve: vi.fn() as never,
+        executeAgentTaskSolve: vi.fn() as never,
+        executeCodegenSolve: executeCodegenSolve as never,
+        failSolveJob: vi.fn((failedJob, error) => {
+          failedJob.status = "failed";
+          failedJob.error = error instanceof Error ? error.message : String(error);
+        }),
+      },
+    });
+
+    expect(executeCodegenSolve).toHaveBeenCalledWith({
+      knowledgeRoot: "/tmp/knowledge",
+      created: expect.objectContaining({
+        name: "outage_investigation",
+        family: "investigation",
+      }),
+      generationTimeBudgetSeconds: 9,
+    });
+    expect(job).toMatchObject({
+      status: "completed",
+      progress: 3,
+    });
   });
 });

--- a/ts/tests/solve-scenario-routing.test.ts
+++ b/ts/tests/solve-scenario-routing.test.ts
@@ -4,7 +4,6 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
-  buildSolveScenarioDescription,
   determineSolveExecutionRoute,
   persistSolveScenarioScaffold,
   prepareSolveScenario,
@@ -40,12 +39,9 @@ describe("solve scenario routing", () => {
     expect(prepared.spec.description).toBe("Incident summary task");
   });
 
-  it("honors explicit family overrides and builds classifier hints", () => {
+  it("honors explicit family overrides without mutating the description", () => {
     expect(validateSolveFamilyOverride("operator-loop")).toBe("operator_loop");
     expect(() => validateSolveFamilyOverride("nope")).toThrow("Unknown solve family");
-    expect(buildSolveScenarioDescription("Handle escalations", "operator_loop")).toContain(
-      "**Family:** operator_loop",
-    );
 
     const prepared = prepareSolveScenario({
       description: "Investigate a production outage",

--- a/ts/tests/solve-scenario-routing.test.ts
+++ b/ts/tests/solve-scenario-routing.test.ts
@@ -4,9 +4,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
+  buildSolveScenarioDescription,
   determineSolveExecutionRoute,
   persistSolveScenarioScaffold,
   prepareSolveScenario,
+  validateSolveFamilyOverride,
 } from "../src/knowledge/solve-scenario-routing.js";
 
 let tmpDir: string;
@@ -36,6 +38,30 @@ describe("solve scenario routing", () => {
 
     expect(prepared.family).toBe("agent_task");
     expect(prepared.spec.description).toBe("Incident summary task");
+  });
+
+  it("honors explicit family overrides and builds classifier hints", () => {
+    expect(validateSolveFamilyOverride("operator-loop")).toBe("operator_loop");
+    expect(() => validateSolveFamilyOverride("nope")).toThrow("Unknown solve family");
+    expect(buildSolveScenarioDescription("Handle escalations", "operator_loop")).toContain(
+      "**Family:** operator_loop",
+    );
+
+    const prepared = prepareSolveScenario({
+      description: "Investigate a production outage",
+      familyOverride: "investigation",
+      created: {
+        name: "outage_summary",
+        family: "agent_task",
+        spec: {
+          taskPrompt: "Summarize outage reports",
+          rubric: "Evaluate completeness",
+          description: "Outage task",
+        },
+      },
+    });
+
+    expect(prepared.family).toBe("investigation");
   });
 
   it("routes prepared scenarios through explicit execution paths", () => {

--- a/ts/tests/solve-tools.test.ts
+++ b/ts/tests/solve-tools.test.ts
@@ -44,9 +44,14 @@ describe("solve MCP tools", () => {
     const result = await server.registeredTools.solve_scenario.handler({
       description: "grid ctf",
       generations: 2,
+      family: "game",
+      generation_time_budget: 10,
     });
 
-    expect(submit).toHaveBeenCalledWith("grid ctf", 2);
+    expect(submit).toHaveBeenCalledWith("grid ctf", 2, {
+      familyOverride: "game",
+      generationTimeBudgetSeconds: 10,
+    });
     expect(JSON.parse(result.content[0].text)).toEqual({
       jobId: "solve-123",
       status: "pending",

--- a/ts/tests/solve-workflow.test.ts
+++ b/ts/tests/solve-workflow.test.ts
@@ -11,12 +11,18 @@ import {
 
 describe("solve workflow", () => {
   it("creates solve jobs and reports status payloads", () => {
-    const job = createSolveJob("solve_123", "Summarize outage escalations", 3);
+    const job = createSolveJob("solve_123", "Summarize outage escalations", 3, {
+      familyOverride: "agent_task",
+      generationTimeBudgetSeconds: 15,
+    });
 
     expect(job).toMatchObject({
       jobId: "solve_123",
       description: "Summarize outage escalations",
       generations: 3,
+      familyOverride: "agent_task",
+      generationTimeBudgetSeconds: 15,
+      llmClassifierFallbackUsed: false,
       status: "pending",
     });
 
@@ -24,6 +30,11 @@ describe("solve workflow", () => {
       jobId: "solve_123",
       status: "pending",
       generations: 3,
+      familyOverride: "agent_task",
+      generationTimeBudgetSeconds: 15,
+      generation_time_budget_seconds: 15,
+      llmClassifierFallbackUsed: false,
+      llm_classifier_fallback_used: false,
       progress: 0,
     });
 


### PR DESCRIPTION
## Summary
- Add TS solve CLI controls for family override, timeout, generation time budget, JSON, and output file writing
- Thread solve controls through job metadata, routing, solver, and MCP solve tools
- Preserve compatibility for canonical and autocontext-prefixed MCP solve tool calls

## Tests
- npm test -- tests/solve-command-workflow.test.ts tests/solve-tools.test.ts tests/solve-manager-workflow.test.ts tests/solve-scenario-routing.test.ts tests/solve-workflow.test.ts tests/cli-dx.test.ts
- npm run lint
- git diff --check

Linear: AC-620