### PR TITLE
AC-651 Add TS knowledge REST routes

### DIFF
--- a/ts/src/server/knowledge-api.ts
+++ b/ts/src/server/knowledge-api.ts
@@ -1,0 +1,175 @@
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { ArtifactStore } from "../knowledge/artifact-store.js";
+import { exportStrategyPackage } from "../knowledge/package.js";
+import type { GenerationRow, SQLiteStore } from "../storage/index.js";
+
+export interface KnowledgeApiResponse {
+  status: number;
+  body: unknown;
+}
+
+export interface KnowledgeSolveManager {
+  submit(description: string, generations: number): string;
+  getStatus(jobId: string): Record<string, unknown>;
+  getResult(jobId: string): Record<string, unknown> | null;
+}
+
+export interface KnowledgeApiRoutes {
+  listSolved(): KnowledgeApiResponse;
+  exportScenario(scenarioName: string): KnowledgeApiResponse;
+  search(body: Record<string, unknown>): KnowledgeApiResponse;
+  submitSolve(body: Record<string, unknown>): KnowledgeApiResponse;
+  solveStatus(jobId: string): KnowledgeApiResponse;
+}
+
+export function buildKnowledgeApiRoutes(opts: {
+  runsRoot: string;
+  knowledgeRoot: string;
+  openStore: () => SQLiteStore;
+  getSolveManager: () => KnowledgeSolveManager;
+}): KnowledgeApiRoutes {
+  return {
+    listSolved: () => ({
+      status: 200,
+      body: listSolvedScenarios(opts.knowledgeRoot),
+    }),
+    exportScenario: (scenarioName) =>
+      withStore(opts.openStore, (store) => {
+        if (!scenarioHasKnowledge(opts.knowledgeRoot, scenarioName)) {
+          return {
+            status: 404,
+            body: { error: `No exported knowledge found for scenario '${scenarioName}'` },
+          };
+        }
+        const artifacts = new ArtifactStore({
+          runsRoot: opts.runsRoot,
+          knowledgeRoot: opts.knowledgeRoot,
+        });
+        const pkg = exportStrategyPackage({ scenarioName, artifacts, store });
+        return {
+          status: 200,
+          body: {
+            ...pkg,
+            suggested_filename: `${scenarioName.replace(/_/g, "-")}-knowledge.md`,
+          },
+        };
+      }),
+    search: (body) =>
+      withStore(opts.openStore, (store) => {
+        const query = typeof body.query === "string" ? body.query.trim() : "";
+        if (!query) {
+          return { status: 422, body: { error: "query is required" } };
+        }
+        const topK = clampInteger(body.top_k, 5, 1, 20);
+        return {
+          status: 200,
+          body: searchStrategies(store, query, topK),
+        };
+      }),
+    submitSolve: (body) => {
+      const description = typeof body.description === "string" ? body.description.trim() : "";
+      if (!description) {
+        return { status: 422, body: { error: "description is required" } };
+      }
+      const generations = clampInteger(body.generations, 5, 1, 50);
+      const jobId = opts.getSolveManager().submit(description, generations);
+      return { status: 200, body: { job_id: jobId, status: "pending" } };
+    },
+    solveStatus: (jobId) => {
+      const manager = opts.getSolveManager();
+      const status = manager.getStatus(jobId);
+      if (status.status === "not_found") {
+        return { status: 404, body: { detail: status.error ?? `Job '${jobId}' not found` } };
+      }
+      const result = manager.getResult(jobId);
+      return {
+        status: 200,
+        body: result ? { ...status, result } : status,
+      };
+    },
+  };
+}
+
+function listSolvedScenarios(knowledgeRoot: string): Array<{ scenario: string; hasPlaybook: boolean }> {
+  const solved: Array<{ scenario: string; hasPlaybook: boolean }> = [];
+  if (!existsSync(knowledgeRoot)) {
+    return solved;
+  }
+
+  for (const name of readdirSync(knowledgeRoot)) {
+    if (name.startsWith("_")) {
+      continue;
+    }
+    const hasPlaybook = existsSync(join(knowledgeRoot, name, "playbook.md"));
+    if (hasPlaybook) {
+      solved.push({ scenario: name, hasPlaybook });
+    }
+  }
+  return solved.sort((a, b) => a.scenario.localeCompare(b.scenario));
+}
+
+function scenarioHasKnowledge(knowledgeRoot: string, scenarioName: string): boolean {
+  return existsSync(join(knowledgeRoot, scenarioName, "playbook.md"))
+    || existsSync(join(knowledgeRoot, scenarioName, "package_metadata.json"));
+}
+
+function searchStrategies(
+  store: Pick<SQLiteStore, "listRuns" | "getGenerations" | "getAgentOutputs">,
+  query: string,
+  topK: number,
+): Array<Record<string, unknown>> {
+  const queryLower = query.toLowerCase();
+  const results: Array<Record<string, unknown>> = [];
+  for (const run of store.listRuns(100)) {
+    const generations: GenerationRow[] = store.getGenerations(run.run_id);
+    for (const generation of generations) {
+      const outputs = store.getAgentOutputs(run.run_id, generation.generation_index);
+      const competitor = outputs.find((output) => output.role === "competitor");
+      if (!competitor || !competitor.content.toLowerCase().includes(queryLower)) {
+        continue;
+      }
+      results.push({
+        scenario: run.scenario,
+        display_name: humanizeScenarioName(run.scenario),
+        description: "",
+        relevance: 1,
+        best_score: generation.best_score,
+        best_elo: generation.elo,
+        match_reason: `Matched generation ${generation.generation_index} competitor output`,
+      });
+      if (results.length >= topK) {
+        return results;
+      }
+    }
+  }
+  return results;
+}
+
+function withStore(
+  openStore: () => SQLiteStore,
+  fn: (store: SQLiteStore) => KnowledgeApiResponse,
+): KnowledgeApiResponse {
+  const store = openStore();
+  try {
+    return fn(store);
+  } finally {
+    store.close();
+  }
+}
+
+function clampInteger(value: unknown, fallback: number, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, value));
+}
+
+function humanizeScenarioName(name: string): string {
+  return name
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join(" ");
+}

--- a/ts/src/server/knowledge-api.ts
+++ b/ts/src/server/knowledge-api.ts
@@ -1,8 +1,9 @@
-import { existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readdirSync, realpathSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import { exportStrategyPackage } from "../knowledge/package.js";
+import type { SolveSubmitOptions } from "../knowledge/solver.js";
 import type { GenerationRow, SQLiteStore } from "../storage/index.js";
 
 export interface KnowledgeApiResponse {
@@ -11,7 +12,7 @@ export interface KnowledgeApiResponse {
 }
 
 export interface KnowledgeSolveManager {
-  submit(description: string, generations: number): string;
+  submit(description: string, generations: number, opts?: SolveSubmitOptions): string;
   getStatus(jobId: string): Record<string, unknown>;
   getResult(jobId: string): Record<string, unknown> | null;
 }
@@ -35,14 +36,18 @@ export function buildKnowledgeApiRoutes(opts: {
       status: 200,
       body: listSolvedScenarios(opts.knowledgeRoot),
     }),
-    exportScenario: (scenarioName) =>
-      withStore(opts.openStore, (store) => {
-        if (!scenarioHasKnowledge(opts.knowledgeRoot, scenarioName)) {
-          return {
-            status: 404,
-            body: { error: `No exported knowledge found for scenario '${scenarioName}'` },
-          };
-        }
+    exportScenario: (scenarioName) => {
+      const scenarioDir = resolveKnowledgeScenarioDir(opts.knowledgeRoot, scenarioName);
+      if (!scenarioDir) {
+        return { status: 422, body: { error: `Invalid scenario '${scenarioName}'` } };
+      }
+      if (!scenarioHasKnowledge(scenarioDir)) {
+        return {
+          status: 404,
+          body: { error: `No exported knowledge found for scenario '${scenarioName}'` },
+        };
+      }
+      return withStore(opts.openStore, (store) => {
         const artifacts = new ArtifactStore({
           runsRoot: opts.runsRoot,
           knowledgeRoot: opts.knowledgeRoot,
@@ -55,7 +60,8 @@ export function buildKnowledgeApiRoutes(opts: {
             suggested_filename: `${scenarioName.replace(/_/g, "-")}-knowledge.md`,
           },
         };
-      }),
+      });
+    },
     search: (body) =>
       withStore(opts.openStore, (store) => {
         const query = typeof body.query === "string" ? body.query.trim() : "";
@@ -74,7 +80,15 @@ export function buildKnowledgeApiRoutes(opts: {
         return { status: 422, body: { error: "description is required" } };
       }
       const generations = clampInteger(body.generations, 5, 1, 50);
-      const jobId = opts.getSolveManager().submit(description, generations);
+      const solveOptions = parseSolveSubmitOptions(body);
+      if (!solveOptions.ok) {
+        return { status: 422, body: { error: solveOptions.error } };
+      }
+      const jobId = opts.getSolveManager().submit(
+        description,
+        generations,
+        solveOptions.options,
+      );
       return { status: 200, body: { job_id: jobId, status: "pending" } };
     },
     solveStatus: (jobId) => {
@@ -102,7 +116,11 @@ function listSolvedScenarios(knowledgeRoot: string): Array<{ scenario: string; h
     if (name.startsWith("_")) {
       continue;
     }
-    const hasPlaybook = existsSync(join(knowledgeRoot, name, "playbook.md"));
+    const scenarioDir = resolveKnowledgeScenarioDir(knowledgeRoot, name);
+    if (!scenarioDir) {
+      continue;
+    }
+    const hasPlaybook = existsSync(join(scenarioDir, "playbook.md"));
     if (hasPlaybook) {
       solved.push({ scenario: name, hasPlaybook });
     }
@@ -110,9 +128,37 @@ function listSolvedScenarios(knowledgeRoot: string): Array<{ scenario: string; h
   return solved.sort((a, b) => a.scenario.localeCompare(b.scenario));
 }
 
-function scenarioHasKnowledge(knowledgeRoot: string, scenarioName: string): boolean {
-  return existsSync(join(knowledgeRoot, scenarioName, "playbook.md"))
-    || existsSync(join(knowledgeRoot, scenarioName, "package_metadata.json"));
+const KNOWLEDGE_SCENARIO_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+function resolveKnowledgeScenarioDir(knowledgeRoot: string, scenarioName: string): string | null {
+  if (!KNOWLEDGE_SCENARIO_NAME_RE.test(scenarioName)) {
+    return null;
+  }
+  const root = resolve(knowledgeRoot);
+  const scenarioDir = resolve(root, scenarioName);
+  if (!isChildPath(root, scenarioDir)) {
+    return null;
+  }
+  if (!existsSync(scenarioDir)) {
+    return scenarioDir;
+  }
+  try {
+    const realRoot = realpathSync.native(root);
+    const realScenarioDir = realpathSync.native(scenarioDir);
+    return isChildPath(realRoot, realScenarioDir) ? scenarioDir : null;
+  } catch {
+    return null;
+  }
+}
+
+function scenarioHasKnowledge(scenarioDir: string): boolean {
+  return existsSync(join(scenarioDir, "playbook.md"))
+    || existsSync(join(scenarioDir, "package_metadata.json"));
+}
+
+function isChildPath(root: string, candidate: string): boolean {
+  const relativePath = relative(root, candidate);
+  return relativePath !== "" && !relativePath.startsWith("..") && !isAbsolute(relativePath);
 }
 
 function searchStrategies(
@@ -164,6 +210,82 @@ function clampInteger(value: unknown, fallback: number, min: number, max: number
     return fallback;
   }
   return Math.min(max, Math.max(min, value));
+}
+
+type SolveSubmitOptionsResult =
+  | { ok: true; options?: SolveSubmitOptions }
+  | { ok: false; error: string };
+
+function parseSolveSubmitOptions(body: Record<string, unknown>): SolveSubmitOptionsResult {
+  const family = readOptionalString(body, ["family", "familyOverride", "family_override"]);
+  if (!family.ok) {
+    return family;
+  }
+  const budget = readOptionalNonNegativeInteger(body, [
+    "generationTimeBudgetSeconds",
+    "generationTimeBudget",
+    "generation_time_budget_seconds",
+    "generation_time_budget",
+  ]);
+  if (!budget.ok) {
+    return budget;
+  }
+
+  if (family.value === undefined && budget.value === undefined) {
+    return { ok: true };
+  }
+  return {
+    ok: true,
+    options: {
+      familyOverride: family.value,
+      generationTimeBudgetSeconds: budget.value,
+    },
+  };
+}
+
+function readOptionalString(
+  body: Record<string, unknown>,
+  keys: string[],
+): { ok: true; value?: string } | { ok: false; error: string } {
+  const entry = firstPresent(body, keys);
+  if (!entry) {
+    return { ok: true };
+  }
+  if (typeof entry.value !== "string") {
+    return { ok: false, error: `${entry.key} must be a string` };
+  }
+  const value = entry.value.trim();
+  return value ? { ok: true, value } : { ok: true };
+}
+
+function readOptionalNonNegativeInteger(
+  body: Record<string, unknown>,
+  keys: string[],
+): { ok: true; value?: number } | { ok: false; error: string } {
+  const entry = firstPresent(body, keys);
+  if (!entry) {
+    return { ok: true };
+  }
+  if (
+    typeof entry.value !== "number"
+    || !Number.isInteger(entry.value)
+    || entry.value < 0
+  ) {
+    return { ok: false, error: `${entry.key} must be a non-negative integer` };
+  }
+  return { ok: true, value: entry.value };
+}
+
+function firstPresent(
+  body: Record<string, unknown>,
+  keys: string[],
+): { key: string; value: unknown } | null {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(body, key)) {
+      return { key, value: body[key] };
+    }
+  }
+  return null;
 }
 
 function humanizeScenarioName(name: string): string {

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -29,6 +29,7 @@ import { buildClientErrorMessage } from "./client-error-workflow.js";
 import { executeChatAgentCommand } from "./chat-agent-command-workflow.js";
 import { executeInteractiveControlCommand } from "./interactive-control-command-workflow.js";
 import { executeInteractiveScenarioCommand } from "./interactive-scenario-command-workflow.js";
+import { buildKnowledgeApiRoutes } from "./knowledge-api.js";
 import { buildMissionApiRoutes } from "./mission-api.js";
 import { buildSimulationApiRoutes } from "./simulation-api.js";
 import { renderDashboardHtml } from "./simulation-dashboard.js";
@@ -40,6 +41,7 @@ import type { RunManagerState } from "./run-manager.js";
 import type { EventCallback } from "../loop/events.js";
 import { SQLiteStore } from "../storage/index.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
+import { SolveManager } from "../knowledge/solver.js";
 
 export interface InteractiveServerOpts {
   runManager: RunManager;
@@ -67,6 +69,8 @@ export class InteractiveServer {
   readonly #missionEvents: MissionEventEmitter;
   readonly #host: string;
   readonly #requestedPort: number;
+  #solveManager: SolveManager | null = null;
+  #solveStore: SQLiteStore | null = null;
   // Dashboard removed (AC-467) — server is API-only
   #httpServer: HttpServer | null = null;
   #wsServer: WebSocketServer | null = null;
@@ -156,6 +160,12 @@ export class InteractiveServer {
     const method = req.method ?? "GET";
     const campaignApi = buildCampaignApiRoutes(this.#campaignManager);
     const missionApi = buildMissionApiRoutes(this.#missionManager, this.#runManager.getRunsRoot());
+    const knowledgeApi = buildKnowledgeApiRoutes({
+      runsRoot: this.#runManager.getRunsRoot(),
+      knowledgeRoot: this.#runManager.getKnowledgeRoot(),
+      openStore: () => this.#openStore(),
+      getSolveManager: () => this.#getSolveManager(),
+    });
     const simulationApi = buildSimulationApiRoutes(this.#runManager.getKnowledgeRoot());
 
     // CORS headers for dashboard
@@ -185,7 +195,13 @@ export class InteractiveServer {
           runs: "/api/runs",
           simulations: "/api/simulations",
           scenarios: "/api/scenarios",
-          knowledge: "/api/knowledge/playbook/:scenario",
+          knowledge: {
+            scenarios: "/api/knowledge/scenarios",
+            export: "/api/knowledge/export/:scenario",
+            search: "/api/knowledge/search",
+            solve: "/api/knowledge/solve",
+            playbook: "/api/knowledge/playbook/:scenario",
+          },
           campaigns: "/api/campaigns",
           missions: "/api/missions",
           websocket: "/ws/interactive",
@@ -281,6 +297,45 @@ export class InteractiveServer {
           loadReplayArtifactResponse,
         },
       });
+      json(response.status, response.body);
+      return;
+    }
+
+    // GET /api/knowledge/scenarios
+    if (method === "GET" && url === "/api/knowledge/scenarios") {
+      const response = knowledgeApi.listSolved();
+      json(response.status, response.body);
+      return;
+    }
+
+    // GET /api/knowledge/export/:scenario
+    const knowledgeExportMatch = url.match(/^\/api\/knowledge\/export\/([^/]+)$/);
+    if (method === "GET" && knowledgeExportMatch) {
+      const [, rawScenario] = knowledgeExportMatch;
+      const response = knowledgeApi.exportScenario(decodeURIComponent(rawScenario!));
+      json(response.status, response.body);
+      return;
+    }
+
+    // POST /api/knowledge/search
+    if (method === "POST" && url === "/api/knowledge/search") {
+      const response = knowledgeApi.search(await this.#readJsonBody(req));
+      json(response.status, response.body);
+      return;
+    }
+
+    // POST /api/knowledge/solve
+    if (method === "POST" && url === "/api/knowledge/solve") {
+      const response = knowledgeApi.submitSolve(await this.#readJsonBody(req));
+      json(response.status, response.body);
+      return;
+    }
+
+    // GET /api/knowledge/solve/:jobId
+    const knowledgeSolveMatch = url.match(/^\/api\/knowledge\/solve\/([^/]+)$/);
+    if (method === "GET" && knowledgeSolveMatch) {
+      const [, rawJobId] = knowledgeSolveMatch;
+      const response = knowledgeApi.solveStatus(decodeURIComponent(rawJobId!));
       json(response.status, response.body);
       return;
     }
@@ -556,6 +611,19 @@ export class InteractiveServer {
     }
   }
 
+  #getSolveManager(): SolveManager {
+    if (!this.#solveManager) {
+      this.#solveStore = this.#openStore();
+      this.#solveManager = new SolveManager({
+        provider: this.#runManager.buildProvider(),
+        store: this.#solveStore,
+        runsRoot: this.#runManager.getRunsRoot(),
+        knowledgeRoot: this.#runManager.getKnowledgeRoot(),
+      });
+    }
+    return this.#solveManager;
+  }
+
   async #readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
     const chunks: Buffer[] = [];
     for await (const chunk of req) {
@@ -609,6 +677,9 @@ export class InteractiveServer {
 
     this.#campaignManager.close();
     this.#missionManager.close();
+    this.#solveStore?.close();
+    this.#solveStore = null;
+    this.#solveManager = null;
   }
 
   #attachClient(ws: WebSocket): void {

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -266,6 +266,19 @@ describe("HTTP API — knowledge", () => {
     expect(data.suggested_filename).toBe("grid-ctf-knowledge.md");
   });
 
+  it("GET /api/knowledge/export/:scenario rejects decoded path traversal", async () => {
+    const outsideDir = join(dir, "outside");
+    mkdirSync(outsideDir, { recursive: true });
+    writeFileSync(join(outsideDir, "playbook.md"), "# Outside\n\nshould not export", "utf-8");
+
+    const { status, body } = await fetchJson(
+      `${baseUrl}/api/knowledge/export/${encodeURIComponent("../outside")}`,
+    );
+
+    expect(status).toBe(422);
+    expect((body as Record<string, unknown>).error).toContain("Invalid scenario");
+  });
+
   it("POST /api/knowledge/search finds prior strategy text", async () => {
     const { status, body } = await postJson(`${baseUrl}/api/knowledge/search`, {
       query: "aggression",

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -22,6 +22,15 @@ async function fetchJson(url: string): Promise<{ status: number; body: unknown }
   return { status: res.status, body };
 }
 
+async function postJson(url: string, body: Record<string, unknown>): Promise<{ status: number; body: unknown }> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.json() };
+}
+
 async function fetchText(url: string): Promise<{ status: number; body: string }> {
   const res = await fetch(url);
   const body = await res.text();
@@ -67,6 +76,24 @@ async function createTestServer(dir: string) {
       timeline: [{ turn: 1, action: "advance" }],
       matches: [{ seed: 42, score: 0.7, winner: "challenger" }],
     }, null, 2),
+    "utf-8",
+  );
+
+  const scenarioKnowledgeDir = join(dir, "knowledge", "grid_ctf");
+  mkdirSync(scenarioKnowledgeDir, { recursive: true });
+  writeFileSync(
+    join(scenarioKnowledgeDir, "playbook.md"),
+    [
+      "# Grid CTF Playbook",
+      "",
+      "<!-- LESSONS_START -->",
+      "- Hold the center route.",
+      "<!-- LESSONS_END -->",
+      "",
+      "<!-- COMPETITOR_HINTS_START -->",
+      "Use measured aggression around the flag.",
+      "<!-- COMPETITOR_HINTS_END -->",
+    ].join("\n"),
     "utf-8",
   );
 
@@ -127,7 +154,15 @@ describe("HTTP API — health", () => {
     const { status, body } = await fetchJson(`${baseUrl}/`);
     expect(status).toBe(200);
     expect((body as Record<string, unknown>).service).toBe("autocontext");
-    expect((body as Record<string, unknown>).endpoints).toBeDefined();
+    const endpoints = (body as Record<string, unknown>).endpoints as Record<string, unknown>;
+    expect(endpoints).toBeDefined();
+    expect(endpoints.knowledge).toMatchObject({
+      scenarios: "/api/knowledge/scenarios",
+      export: "/api/knowledge/export/:scenario",
+      search: "/api/knowledge/search",
+      solve: "/api/knowledge/solve",
+      playbook: "/api/knowledge/playbook/:scenario",
+    });
   });
 });
 
@@ -214,6 +249,51 @@ describe("HTTP API — knowledge", () => {
     expect(status).toBe(200);
     const data = body as Record<string, unknown>;
     expect(typeof data.content).toBe("string");
+  });
+
+  it("GET /api/knowledge/scenarios lists solved knowledge", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/knowledge/scenarios`);
+    expect(status).toBe(200);
+    expect(body).toContainEqual({ scenario: "grid_ctf", hasPlaybook: true });
+  });
+
+  it("GET /api/knowledge/export/:scenario exports a skill package", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/knowledge/export/grid_ctf`);
+    expect(status).toBe(200);
+    const data = body as Record<string, unknown>;
+    expect(data.scenario_name).toBe("grid_ctf");
+    expect(data.skill_markdown).toContain("Grid CTF");
+    expect(data.suggested_filename).toBe("grid-ctf-knowledge.md");
+  });
+
+  it("POST /api/knowledge/search finds prior strategy text", async () => {
+    const { status, body } = await postJson(`${baseUrl}/api/knowledge/search`, {
+      query: "aggression",
+      top_k: 3,
+    });
+    expect(status).toBe(200);
+    const results = body as Array<Record<string, unknown>>;
+    expect(results[0]).toMatchObject({
+      scenario: "grid_ctf",
+      display_name: "Grid Ctf",
+      best_score: 0.7,
+    });
+  });
+
+  it("POST /api/knowledge/solve submits a solve job", async () => {
+    const { status, body } = await postJson(`${baseUrl}/api/knowledge/solve`, {
+      description: "solve grid ctf",
+      generations: 1,
+    });
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ status: "pending" });
+    expect(typeof (body as Record<string, unknown>).job_id).toBe("string");
+  });
+
+  it("GET /api/knowledge/solve/:jobId returns 404 for missing jobs", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/knowledge/solve/not-real`);
+    expect(status).toBe(404);
+    expect((body as Record<string, unknown>).detail).toContain("not found");
   });
 
   it("GET /api/scenarios returns scenario list", async () => {

--- a/ts/tests/knowledge-api-workflow.test.ts
+++ b/ts/tests/knowledge-api-workflow.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { buildKnowledgeApiRoutes } from "../src/server/knowledge-api.js";
+
+describe("knowledge API workflow", () => {
+  it("forwards REST solve controls to the solve manager", () => {
+    const submissions: Array<{
+      description: string;
+      generations: number;
+      opts?: {
+        familyOverride?: string;
+        generationTimeBudgetSeconds?: number | null;
+      };
+    }> = [];
+    const routes = buildKnowledgeApiRoutes({
+      runsRoot: "/unused/runs",
+      knowledgeRoot: "/unused/knowledge",
+      openStore: () => {
+        throw new Error("store should not be opened for solve submission");
+      },
+      getSolveManager: () => ({
+        submit: (description, generations, opts) => {
+          submissions.push({ description, generations, opts });
+          return "job_123";
+        },
+        getStatus: () => ({ status: "not_found" }),
+        getResult: () => null,
+      }),
+    });
+
+    const response = routes.submitSolve({
+      description: " investigate checkout failures ",
+      generations: 2,
+      family: "investigation",
+      generation_time_budget: 9,
+    });
+
+    expect(response).toEqual({ status: 200, body: { job_id: "job_123", status: "pending" } });
+    expect(submissions).toEqual([
+      {
+        description: "investigate checkout failures",
+        generations: 2,
+        opts: {
+          familyOverride: "investigation",
+          generationTimeBudgetSeconds: 9,
+        },
+      },
+    ]);
+  });
+
+  it("rejects invalid REST solve controls before submission", () => {
+    let submitted = false;
+    const routes = buildKnowledgeApiRoutes({
+      runsRoot: "/unused/runs",
+      knowledgeRoot: "/unused/knowledge",
+      openStore: () => {
+        throw new Error("store should not be opened for solve submission");
+      },
+      getSolveManager: () => ({
+        submit: () => {
+          submitted = true;
+          return "job_123";
+        },
+        getStatus: () => ({ status: "not_found" }),
+        getResult: () => null,
+      }),
+    });
+
+    const response = routes.submitSolve({
+      description: "investigate checkout failures",
+      generationTimeBudgetSeconds: "9",
+    });
+
+    expect(response).toEqual({
+      status: 422,
+      body: { error: "generationTimeBudgetSeconds must be a non-negative integer" },
+    });
+    expect(submitted).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a focused TypeScript knowledge API route workflow for solved scenarios, export, search, solve submit, and solve status
- Route /api/knowledge/scenarios, /api/knowledge/export/:scenario, /api/knowledge/search, /api/knowledge/solve, and /api/knowledge/solve/:jobId from the TS server
- Update root endpoint discovery and HTTP API tests for the expanded knowledge surface

## Tests
- npm test -- tests/http-api.test.ts
- npm run lint
- git diff --check

Linear: AC-651