### PR TITLE
AC-621 Add TS knowledge import REST route

### DIFF
--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -621,6 +621,7 @@ async function cmdTui(dbPath: string): Promise<void> {
     migrationsDir: getMigrationsDir(),
     runsRoot: resolve(settings.runsRoot),
     knowledgeRoot: resolve(settings.knowledgeRoot),
+    skillsRoot: resolve(settings.skillsRoot),
     providerType: providerConfig.providerType,
     apiKey: providerConfig.apiKey,
     baseUrl: providerConfig.baseUrl,
@@ -994,6 +995,7 @@ async function cmdServeHttp(dbPath: string): Promise<void> {
     migrationsDir: getMigrationsDir(),
     runsRoot: resolve(settings.runsRoot),
     knowledgeRoot: resolve(settings.knowledgeRoot),
+    skillsRoot: resolve(settings.skillsRoot),
     providerType: settings.agentProvider,
   });
   const server = new InteractiveServer({

--- a/ts/src/knowledge/package.ts
+++ b/ts/src/knowledge/package.ts
@@ -20,6 +20,7 @@ import {
   lessonsFromPlaybook,
 } from "./package-content.js";
 import { coercePackage } from "./package-coercion.js";
+import { assertSafeScenarioId } from "./scenario-id.js";
 import type {
   ConflictPolicy,
   ImportStrategyPackageResult,
@@ -103,6 +104,7 @@ export function importStrategyPackage(opts: {
 }): ImportStrategyPackageResult {
   const conflictPolicy = opts.conflictPolicy ?? "overwrite";
   const pkg = coercePackage(opts.rawPackage, opts.scenarioOverride);
+  assertSafeScenarioId(pkg.scenarioName, "scenario_name");
   const result: ImportStrategyPackageResult = {
     scenario: pkg.scenarioName,
     playbookWritten: false,

--- a/ts/src/knowledge/scenario-id.ts
+++ b/ts/src/knowledge/scenario-id.ts
@@ -1,0 +1,15 @@
+const SAFE_SCENARIO_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+export function isSafeScenarioId(value: string): boolean {
+  return SAFE_SCENARIO_ID_RE.test(value);
+}
+
+export function assertSafeScenarioId(value: string, fieldName = "scenario"): string {
+  if (isSafeScenarioId(value)) {
+    return value;
+  }
+  throw new Error(
+    `${fieldName} must be a safe scenario identifier ` +
+      "(letters, digits, underscores, or hyphens; no path separators)",
+  );
+}

--- a/ts/src/server/knowledge-api.ts
+++ b/ts/src/server/knowledge-api.ts
@@ -2,7 +2,11 @@ import { existsSync, readdirSync, realpathSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { ArtifactStore } from "../knowledge/artifact-store.js";
-import { exportStrategyPackage } from "../knowledge/package.js";
+import {
+  exportStrategyPackage,
+  importStrategyPackage,
+  type ConflictPolicy,
+} from "../knowledge/package.js";
 import type { SolveSubmitOptions } from "../knowledge/solver.js";
 import type { GenerationRow, SQLiteStore } from "../storage/index.js";
 
@@ -20,6 +24,7 @@ export interface KnowledgeSolveManager {
 export interface KnowledgeApiRoutes {
   listSolved(): KnowledgeApiResponse;
   exportScenario(scenarioName: string): KnowledgeApiResponse;
+  importPackage(body: Record<string, unknown>): KnowledgeApiResponse;
   search(body: Record<string, unknown>): KnowledgeApiResponse;
   submitSolve(body: Record<string, unknown>): KnowledgeApiResponse;
   solveStatus(jobId: string): KnowledgeApiResponse;
@@ -28,6 +33,7 @@ export interface KnowledgeApiRoutes {
 export function buildKnowledgeApiRoutes(opts: {
   runsRoot: string;
   knowledgeRoot: string;
+  skillsRoot: string;
   openStore: () => SQLiteStore;
   getSolveManager: () => KnowledgeSolveManager;
 }): KnowledgeApiRoutes {
@@ -61,6 +67,28 @@ export function buildKnowledgeApiRoutes(opts: {
           },
         };
       });
+    },
+    importPackage: (body) => {
+      const request = parseImportPackageRequest(body);
+      if (!request.ok) {
+        return { status: 422, body: { detail: request.error } };
+      }
+      try {
+        const artifacts = new ArtifactStore({
+          runsRoot: opts.runsRoot,
+          knowledgeRoot: opts.knowledgeRoot,
+        });
+        const result = importStrategyPackage({
+          rawPackage: request.rawPackage,
+          artifacts,
+          skillsRoot: opts.skillsRoot,
+          conflictPolicy: request.conflictPolicy,
+        });
+        return { status: 200, body: result };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { status: 422, body: { detail: `Invalid package: ${message}` } };
+      }
     },
     search: (body) =>
       withStore(opts.openStore, (store) => {
@@ -103,6 +131,40 @@ export function buildKnowledgeApiRoutes(opts: {
         body: result ? { ...status, result } : status,
       };
     },
+  };
+}
+
+type ImportPackageRequestResult =
+  | {
+    ok: true;
+    rawPackage: Record<string, unknown>;
+    conflictPolicy: ConflictPolicy;
+  }
+  | { ok: false; error: string };
+
+const CONFLICT_POLICIES = new Set<ConflictPolicy>(["overwrite", "merge", "skip"]);
+
+function parseImportPackageRequest(body: Record<string, unknown>): ImportPackageRequestResult {
+  const packageEntry = firstPresent(body, ["package", "rawPackage", "raw_package"]);
+  if (!packageEntry || !isRecord(packageEntry.value)) {
+    return { ok: false, error: "package is required" };
+  }
+
+  const conflictEntry = firstPresent(body, ["conflict_policy", "conflictPolicy"]);
+  if (!conflictEntry) {
+    return { ok: true, rawPackage: packageEntry.value, conflictPolicy: "merge" };
+  }
+  if (typeof conflictEntry.value !== "string") {
+    return { ok: false, error: `${conflictEntry.key} must be one of overwrite, merge, skip` };
+  }
+  const conflictPolicy = conflictEntry.value.trim();
+  if (!CONFLICT_POLICIES.has(conflictPolicy as ConflictPolicy)) {
+    return { ok: false, error: `${conflictEntry.key} must be one of overwrite, merge, skip` };
+  }
+  return {
+    ok: true,
+    rawPackage: packageEntry.value,
+    conflictPolicy: conflictPolicy as ConflictPolicy,
   };
 }
 
@@ -154,6 +216,10 @@ function resolveKnowledgeScenarioDir(knowledgeRoot: string, scenarioName: string
 function scenarioHasKnowledge(scenarioDir: string): boolean {
   return existsSync(join(scenarioDir, "playbook.md"))
     || existsSync(join(scenarioDir, "package_metadata.json"));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function isChildPath(root: string, candidate: string): boolean {

--- a/ts/src/server/knowledge-api.ts
+++ b/ts/src/server/knowledge-api.ts
@@ -7,6 +7,7 @@ import {
   importStrategyPackage,
   type ConflictPolicy,
 } from "../knowledge/package.js";
+import { isSafeScenarioId } from "../knowledge/scenario-id.js";
 import type { SolveSubmitOptions } from "../knowledge/solver.js";
 import type { GenerationRow, SQLiteStore } from "../storage/index.js";
 
@@ -190,10 +191,8 @@ function listSolvedScenarios(knowledgeRoot: string): Array<{ scenario: string; h
   return solved.sort((a, b) => a.scenario.localeCompare(b.scenario));
 }
 
-const KNOWLEDGE_SCENARIO_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
-
 function resolveKnowledgeScenarioDir(knowledgeRoot: string, scenarioName: string): string | null {
-  if (!KNOWLEDGE_SCENARIO_NAME_RE.test(scenarioName)) {
+  if (!isSafeScenarioId(scenarioName)) {
     return null;
   }
   const root = resolve(knowledgeRoot);

--- a/ts/src/server/run-manager.ts
+++ b/ts/src/server/run-manager.ts
@@ -3,7 +3,7 @@
  * Mirrors Python's autocontext/server/run_manager.py.
  */
 
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { LoopController } from "../loop/controller.js";
 import { EventStreamEmitter } from "../loop/events.js";
 import type { EventCallback } from "../loop/events.js";
@@ -42,6 +42,7 @@ export interface RunManagerOpts {
   migrationsDir: string;
   runsRoot: string;
   knowledgeRoot: string;
+  skillsRoot?: string;
   providerType?: string;
   apiKey?: string;
   baseUrl?: string;
@@ -127,6 +128,10 @@ export class RunManager {
 
   getKnowledgeRoot(): string {
     return this.#opts.knowledgeRoot;
+  }
+
+  getSkillsRoot(): string {
+    return this.#opts.skillsRoot ?? join(dirname(this.#opts.knowledgeRoot), "skills");
   }
 
   buildMissionProvider() {

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -4,10 +4,10 @@
 
 import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from "node:http";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { WebSocketServer, WebSocket } from "ws";
 import type { AddressInfo } from "node:net";
-import { URL, fileURLToPath } from "node:url";
+import { URL } from "node:url";
 import { MissionEventEmitter } from "../mission/events.js";
 import { CampaignManager } from "../mission/campaign.js";
 import { MissionManager } from "../mission/manager.js";
@@ -163,6 +163,7 @@ export class InteractiveServer {
     const knowledgeApi = buildKnowledgeApiRoutes({
       runsRoot: this.#runManager.getRunsRoot(),
       knowledgeRoot: this.#runManager.getKnowledgeRoot(),
+      skillsRoot: this.#runManager.getSkillsRoot(),
       openStore: () => this.#openStore(),
       getSolveManager: () => this.#getSolveManager(),
     });
@@ -198,6 +199,7 @@ export class InteractiveServer {
           knowledge: {
             scenarios: "/api/knowledge/scenarios",
             export: "/api/knowledge/export/:scenario",
+            import: "/api/knowledge/import",
             search: "/api/knowledge/search",
             solve: "/api/knowledge/solve",
             playbook: "/api/knowledge/playbook/:scenario",
@@ -313,6 +315,13 @@ export class InteractiveServer {
     if (method === "GET" && knowledgeExportMatch) {
       const [, rawScenario] = knowledgeExportMatch;
       const response = knowledgeApi.exportScenario(decodeURIComponent(rawScenario!));
+      json(response.status, response.body);
+      return;
+    }
+
+    // POST /api/knowledge/import
+    if (method === "POST" && url === "/api/knowledge/import") {
+      const response = knowledgeApi.importPackage(await this.#readJsonBody(req));
       json(response.status, response.body);
       return;
     }

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -159,6 +159,7 @@ describe("HTTP API — health", () => {
     expect(endpoints.knowledge).toMatchObject({
       scenarios: "/api/knowledge/scenarios",
       export: "/api/knowledge/export/:scenario",
+      import: "/api/knowledge/import",
       search: "/api/knowledge/search",
       solve: "/api/knowledge/solve",
       playbook: "/api/knowledge/playbook/:scenario",
@@ -277,6 +278,57 @@ describe("HTTP API — knowledge", () => {
 
     expect(status).toBe(422);
     expect((body as Record<string, unknown>).error).toContain("Invalid scenario");
+  });
+
+  it("POST /api/knowledge/import imports a strategy package", async () => {
+    const { status, body } = await postJson(`${baseUrl}/api/knowledge/import`, {
+      package: {
+        scenario_name: "imported_task",
+        display_name: "Imported Task",
+        description: "A package imported over the REST API.",
+        playbook: "# Imported Task\n\nUse the imported strategy.",
+        lessons: ["Prefer known-good imported strategy."],
+        best_strategy: { answer: "imported" },
+        best_score: 0.93,
+        best_elo: 1510,
+        hints: "Keep the imported hint close.",
+        harness: {
+          validator: "def validate():\n    return True\n",
+        },
+        metadata: {
+          source: "http-test",
+        },
+        skill_markdown: "# Imported Skill\n\nUse the imported skill.",
+      },
+      conflict_policy: "overwrite",
+    });
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      scenario: "imported_task",
+      playbookWritten: true,
+      harnessWritten: ["validator"],
+      skillWritten: true,
+      metadataWritten: true,
+      conflictPolicy: "overwrite",
+    });
+    expect(readFileSync(join(dir, "knowledge", "imported_task", "playbook.md"), "utf-8"))
+      .toContain("Use the imported strategy.");
+    expect(readFileSync(
+      join(dir, "knowledge", "imported_task", "package_metadata.json"),
+      "utf-8",
+    )).toContain("http-test");
+    expect(existsSync(join(dir, "skills", "imported-task-ops", "SKILL.md"))).toBe(true);
+  });
+
+  it("POST /api/knowledge/import rejects unknown conflict policies", async () => {
+    const { status, body } = await postJson(`${baseUrl}/api/knowledge/import`, {
+      package: { scenario_name: "imported_task" },
+      conflict_policy: "replace",
+    });
+
+    expect(status).toBe(422);
+    expect((body as Record<string, unknown>).detail).toContain("conflict_policy");
   });
 
   it("POST /api/knowledge/search finds prior strategy text", async () => {

--- a/ts/tests/knowledge-api-workflow.test.ts
+++ b/ts/tests/knowledge-api-workflow.test.ts
@@ -1,3 +1,6 @@
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { buildKnowledgeApiRoutes } from "../src/server/knowledge-api.js";
@@ -15,6 +18,7 @@ describe("knowledge API workflow", () => {
     const routes = buildKnowledgeApiRoutes({
       runsRoot: "/unused/runs",
       knowledgeRoot: "/unused/knowledge",
+      skillsRoot: "/unused/skills",
       openStore: () => {
         throw new Error("store should not be opened for solve submission");
       },
@@ -53,6 +57,7 @@ describe("knowledge API workflow", () => {
     const routes = buildKnowledgeApiRoutes({
       runsRoot: "/unused/runs",
       knowledgeRoot: "/unused/knowledge",
+      skillsRoot: "/unused/skills",
       openStore: () => {
         throw new Error("store should not be opened for solve submission");
       },
@@ -76,5 +81,36 @@ describe("knowledge API workflow", () => {
       body: { error: "generationTimeBudgetSeconds must be a non-negative integer" },
     });
     expect(submitted).toBe(false);
+  });
+
+  it("rejects import packages whose scenario escapes knowledge and skills roots", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ac-knowledge-api-"));
+    const routes = buildKnowledgeApiRoutes({
+      runsRoot: join(dir, "runs"),
+      knowledgeRoot: join(dir, "knowledge"),
+      skillsRoot: join(dir, "skills"),
+      openStore: () => {
+        throw new Error("store should not be opened for package import");
+      },
+      getSolveManager: () => ({
+        submit: () => "job_123",
+        getStatus: () => ({ status: "not_found" }),
+        getResult: () => null,
+      }),
+    });
+
+    const response = routes.importPackage({
+      package: {
+        scenario_name: "../outside",
+        playbook: "# should not be written",
+        skill_markdown: "# should not be written",
+      },
+      conflict_policy: "overwrite",
+    });
+
+    expect(response.status).toBe(422);
+    expect((response.body as Record<string, unknown>).detail).toContain("scenario");
+    expect(existsSync(join(dir, "outside", "playbook.md"))).toBe(false);
+    expect(existsSync(join(dir, "outside-ops", "SKILL.md"))).toBe(false);
   });
 });

--- a/ts/tests/skill-export.test.ts
+++ b/ts/tests/skill-export.test.ts
@@ -1,5 +1,14 @@
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, expect } from "vitest";
-import { SkillPackage, exportAgentTaskSkill, cleanLessons } from "../src/knowledge/index.js";
+import {
+  ArtifactStore,
+  SkillPackage,
+  cleanLessons,
+  exportAgentTaskSkill,
+  importStrategyPackage,
+} from "../src/knowledge/index.js";
 import type { SkillPackageData } from "../src/knowledge/index.js";
 
 function makeExampleOutputs() {
@@ -181,6 +190,32 @@ describe("exportAgentTaskSkill", () => {
     });
     expect(pkg.bestScore).toBe(0.0);
     expect(pkg.exampleOutputs).toBeNull();
+  });
+});
+
+describe("importStrategyPackage", () => {
+  it("rejects unsafe scenario identifiers before writing artifacts", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ac-package-import-"));
+    const artifacts = new ArtifactStore({
+      runsRoot: join(dir, "runs"),
+      knowledgeRoot: join(dir, "knowledge"),
+    });
+
+    expect(() =>
+      importStrategyPackage({
+        rawPackage: {
+          scenario_name: "../outside",
+          playbook: "# should not be written",
+          skill_markdown: "# should not be written",
+        },
+        artifacts,
+        skillsRoot: join(dir, "skills"),
+        conflictPolicy: "overwrite",
+      }),
+    ).toThrow("scenario_name must be a safe scenario identifier");
+
+    expect(existsSync(join(dir, "outside", "playbook.md"))).toBe(false);
+    expect(existsSync(join(dir, "outside-ops", "SKILL.md"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- add POST /api/knowledge/import to the TypeScript server
- reuse the existing importStrategyPackage domain service instead of duplicating import logic in the HTTP layer
- thread skillsRoot through RunManager so imported packages write skills to the configured root
- advertise the import route in root endpoint discovery

## Tests
- npm test -- tests/http-api.test.ts
- npm run lint

Linear: AC-621