### PR TITLE
AC-627 Add HTTP API parity matrix

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -278,6 +278,8 @@ Credential resolution order is:
 
 `autoctx capabilities` returns structured JSON describing commands, providers, scenarios, the canonical concept model, and project-specific state such as the current project config, active runs, and knowledge directory summary.
 
+The HTTP server exposes `GET /api/capabilities/http` with a runtime parity matrix for Python and TypeScript REST/WebSocket routes, including explicit TypeScript gaps and TypeScript-only routes.
+
 `autoctx login` can prompt interactively for provider credentials. `autoctx login --provider ollama` validates that a local Ollama server is reachable before persisting the connection details, and `autoctx logout` clears the stored credentials.
 
 `autoctx replay` writes the selected generation and available generations to `stderr` before printing the replay JSON payload. `autoctx export-training-data` writes progress updates to `stderr` while keeping JSONL records on `stdout`.

--- a/ts/src/server/http-api-parity.ts
+++ b/ts/src/server/http-api-parity.ts
@@ -1,0 +1,262 @@
+export type HttpApiRuntime = "python" | "typescript";
+export type HttpApiMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "WEBSOCKET";
+export type HttpApiSupport = "supported" | "unsupported";
+export type HttpApiParityStatus = "aligned" | "typescript_gap" | "python_gap";
+
+export interface RuntimeRouteSupport {
+  support: HttpApiSupport;
+  source?: string;
+}
+
+export interface HttpApiParityEntry {
+  method: HttpApiMethod;
+  path: string;
+  domain: string;
+  python: RuntimeRouteSupport;
+  typescript: RuntimeRouteSupport;
+  status: HttpApiParityStatus;
+  issue?: string;
+  notes?: string;
+}
+
+export interface HttpApiParityMatrix {
+  version: 1;
+  runtimes: HttpApiRuntime[];
+  summary: Record<HttpApiParityStatus, number>;
+  routes: HttpApiParityEntry[];
+}
+
+const PY_APP = "autocontext/src/autocontext/server/app.py";
+const TS_SERVER = "ts/src/server/ws-server.ts";
+
+function both(
+  domain: string,
+  method: HttpApiMethod,
+  path: string,
+  pythonSource = PY_APP,
+  typescriptSource = TS_SERVER,
+): HttpApiParityEntry {
+  return {
+    domain,
+    method,
+    path,
+    python: { support: "supported", source: pythonSource },
+    typescript: { support: "supported", source: typescriptSource },
+    status: "aligned",
+  };
+}
+
+function pythonOnly(
+  domain: string,
+  method: HttpApiMethod,
+  path: string,
+  source: string,
+  notes: string,
+): HttpApiParityEntry {
+  return {
+    domain,
+    method,
+    path,
+    python: { support: "supported", source },
+    typescript: { support: "unsupported" },
+    status: "typescript_gap",
+    issue: "AC-627",
+    notes,
+  };
+}
+
+function typescriptOnly(
+  domain: string,
+  method: HttpApiMethod,
+  path: string,
+  notes: string,
+): HttpApiParityEntry {
+  return {
+    domain,
+    method,
+    path,
+    python: { support: "unsupported" },
+    typescript: { support: "supported", source: TS_SERVER },
+    status: "python_gap",
+    notes,
+  };
+}
+
+export const HTTP_API_PARITY_ROUTES: readonly HttpApiParityEntry[] = [
+  both("core", "GET", "/health"),
+  both("core", "GET", "/api/runs"),
+  both("core", "GET", "/api/runs/:run_id/status"),
+  both("core", "GET", "/api/runs/:run_id/replay/:generation"),
+  both("core", "WEBSOCKET", "/ws/events"),
+  both("core", "WEBSOCKET", "/ws/interactive"),
+
+  both("knowledge", "GET", "/api/knowledge/scenarios", "autocontext/src/autocontext/server/knowledge_api.py"),
+  both("knowledge", "GET", "/api/knowledge/export/:scenario", "autocontext/src/autocontext/server/knowledge_api.py"),
+  both("knowledge", "POST", "/api/knowledge/import", "autocontext/src/autocontext/server/knowledge_api.py"),
+  both("knowledge", "POST", "/api/knowledge/search", "autocontext/src/autocontext/server/knowledge_api.py"),
+  both("knowledge", "POST", "/api/knowledge/solve", "autocontext/src/autocontext/server/knowledge_api.py"),
+  both("knowledge", "GET", "/api/knowledge/solve/:job_id", "autocontext/src/autocontext/server/knowledge_api.py"),
+
+  typescriptOnly("discovery", "GET", "/", "TypeScript advertises endpoint discovery from the root response."),
+  typescriptOnly(
+    "discovery",
+    "GET",
+    "/api/capabilities/http",
+    "TypeScript exposes this parity matrix for clients that need runtime-aware HTTP discovery.",
+  ),
+  typescriptOnly("dashboard", "GET", "/dashboard", "TypeScript serves the lightweight dashboard shell."),
+  typescriptOnly("scenarios", "GET", "/api/scenarios", "TypeScript exposes built-in and custom scenario discovery."),
+  typescriptOnly("simulations", "GET", "/api/simulations", "TypeScript exposes simulation catalog routes."),
+  typescriptOnly("simulations", "GET", "/api/simulations/:name", "TypeScript exposes simulation detail routes."),
+  typescriptOnly(
+    "simulations",
+    "GET",
+    "/api/simulations/:name/dashboard",
+    "TypeScript exposes simulation dashboard payload routes.",
+  ),
+  typescriptOnly("campaigns", "GET", "/api/campaigns", "Campaign orchestration is currently TypeScript-only."),
+  typescriptOnly("campaigns", "POST", "/api/campaigns", "Campaign orchestration is currently TypeScript-only."),
+  typescriptOnly("campaigns", "GET", "/api/campaigns/:id", "Campaign orchestration is currently TypeScript-only."),
+  typescriptOnly(
+    "campaigns",
+    "GET",
+    "/api/campaigns/:id/progress",
+    "Campaign orchestration is currently TypeScript-only.",
+  ),
+  typescriptOnly(
+    "campaigns",
+    "POST",
+    "/api/campaigns/:id/missions",
+    "Campaign orchestration is currently TypeScript-only.",
+  ),
+  typescriptOnly(
+    "campaigns",
+    "POST",
+    "/api/campaigns/:id/:action",
+    "Campaign pause, resume, and cancel actions are currently TypeScript-only.",
+  ),
+  typescriptOnly("missions", "GET", "/api/missions", "Mission planning routes are currently TypeScript-only."),
+  typescriptOnly("missions", "GET", "/api/missions/:id", "Mission planning routes are currently TypeScript-only."),
+  typescriptOnly(
+    "missions",
+    "GET",
+    "/api/missions/:id/steps",
+    "Mission planning routes are currently TypeScript-only.",
+  ),
+  typescriptOnly(
+    "missions",
+    "GET",
+    "/api/missions/:id/subgoals",
+    "Mission planning routes are currently TypeScript-only.",
+  ),
+  typescriptOnly(
+    "missions",
+    "GET",
+    "/api/missions/:id/budget",
+    "Mission planning routes are currently TypeScript-only.",
+  ),
+  typescriptOnly(
+    "missions",
+    "GET",
+    "/api/missions/:id/artifacts",
+    "Mission planning routes are currently TypeScript-only.",
+  ),
+  typescriptOnly(
+    "missions",
+    "POST",
+    "/api/missions/:id/:action",
+    "Mission run, pause, resume, and cancel actions are currently TypeScript-only.",
+  ),
+
+  ...pythonOnlyRoutes("cockpit", "autocontext/src/autocontext/server/cockpit_api.py", [
+    ["GET", "/api/cockpit/notebooks"],
+    ["GET", "/api/cockpit/notebooks/:session_id"],
+    ["GET", "/api/cockpit/notebooks/:session_id/effective-context"],
+    ["PUT", "/api/cockpit/notebooks/:session_id"],
+    ["DELETE", "/api/cockpit/notebooks/:session_id"],
+    ["GET", "/api/cockpit/runs"],
+    ["GET", "/api/cockpit/runs/:run_id/status"],
+    ["GET", "/api/cockpit/runs/:run_id/changelog"],
+    ["GET", "/api/cockpit/runs/:run_id/compare/:gen_a/:gen_b"],
+    ["GET", "/api/cockpit/runs/:run_id/resume"],
+    ["GET", "/api/cockpit/writeup/:run_id"],
+    ["POST", "/api/cockpit/runs/:run_id/consult"],
+    ["GET", "/api/cockpit/runs/:run_id/consultations"],
+  ]),
+  ...pythonOnlyRoutes("hub", "autocontext/src/autocontext/server/hub_api.py", [
+    ["GET", "/api/hub/sessions"],
+    ["GET", "/api/hub/sessions/:session_id"],
+    ["PUT", "/api/hub/sessions/:session_id"],
+    ["POST", "/api/hub/sessions/:session_id/heartbeat"],
+    ["POST", "/api/hub/packages/from-run/:run_id"],
+    ["GET", "/api/hub/packages"],
+    ["GET", "/api/hub/packages/:package_id"],
+    ["POST", "/api/hub/packages/:package_id/adopt"],
+    ["POST", "/api/hub/results/from-run/:run_id"],
+    ["GET", "/api/hub/results"],
+    ["GET", "/api/hub/results/:result_id"],
+    ["POST", "/api/hub/promotions"],
+    ["GET", "/api/hub/feed"],
+  ]),
+  ...pythonOnlyRoutes("notebooks", "autocontext/src/autocontext/server/notebook_api.py", [
+    ["GET", "/api/notebooks"],
+    ["GET", "/api/notebooks/:session_id"],
+    ["PUT", "/api/notebooks/:session_id"],
+    ["DELETE", "/api/notebooks/:session_id"],
+  ]),
+  ...pythonOnlyRoutes("monitors", "autocontext/src/autocontext/server/monitor_api.py", [
+    ["POST", "/api/monitors"],
+    ["GET", "/api/monitors"],
+    ["DELETE", "/api/monitors/:condition_id"],
+    ["GET", "/api/monitors/alerts"],
+    ["POST", "/api/monitors/:condition_id/wait"],
+  ]),
+  ...pythonOnlyRoutes("openclaw", "autocontext/src/autocontext/server/openclaw_api.py", [
+    ["POST", "/api/openclaw/evaluate"],
+    ["POST", "/api/openclaw/validate"],
+    ["POST", "/api/openclaw/artifacts"],
+    ["GET", "/api/openclaw/artifacts"],
+    ["GET", "/api/openclaw/artifacts/:artifact_id"],
+    ["GET", "/api/openclaw/distill"],
+    ["POST", "/api/openclaw/distill"],
+    ["GET", "/api/openclaw/distill/:job_id"],
+    ["PATCH", "/api/openclaw/distill/:job_id"],
+    ["GET", "/api/openclaw/capabilities"],
+    ["GET", "/api/openclaw/discovery/capabilities"],
+    ["GET", "/api/openclaw/discovery/scenario/:scenario_name"],
+    ["GET", "/api/openclaw/discovery/health"],
+    ["GET", "/api/openclaw/discovery/scenario/:scenario_name/artifacts"],
+    ["GET", "/api/openclaw/skill/manifest"],
+  ]),
+];
+
+function pythonOnlyRoutes(
+  domain: string,
+  source: string,
+  routes: Array<[HttpApiMethod, string]>,
+): HttpApiParityEntry[] {
+  return routes.map(([method, path]) => pythonOnly(
+    domain,
+    method,
+    path,
+    source,
+    `${domain} HTTP routes are mounted by the Python FastAPI app and are not yet ported to TypeScript.`,
+  ));
+}
+
+export function buildHttpApiParityMatrix(): HttpApiParityMatrix {
+  const summary: Record<HttpApiParityStatus, number> = {
+    aligned: 0,
+    typescript_gap: 0,
+    python_gap: 0,
+  };
+  for (const route of HTTP_API_PARITY_ROUTES) {
+    summary[route.status] += 1;
+  }
+  return {
+    version: 1,
+    runtimes: ["python", "typescript"],
+    summary,
+    routes: HTTP_API_PARITY_ROUTES.map((route) => ({ ...route })),
+  };
+}

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -29,6 +29,7 @@ import { buildClientErrorMessage } from "./client-error-workflow.js";
 import { executeChatAgentCommand } from "./chat-agent-command-workflow.js";
 import { executeInteractiveControlCommand } from "./interactive-control-command-workflow.js";
 import { executeInteractiveScenarioCommand } from "./interactive-scenario-command-workflow.js";
+import { buildHttpApiParityMatrix } from "./http-api-parity.js";
 import { buildKnowledgeApiRoutes } from "./knowledge-api.js";
 import { buildMissionApiRoutes } from "./mission-api.js";
 import { buildSimulationApiRoutes } from "./simulation-api.js";
@@ -193,6 +194,9 @@ export class InteractiveServer {
         endpoints: {
           health: "/health",
           dashboard: "/dashboard",
+          capabilities: {
+            http: "/api/capabilities/http",
+          },
           runs: "/api/runs",
           simulations: "/api/simulations",
           scenarios: "/api/scenarios",
@@ -223,6 +227,12 @@ export class InteractiveServer {
     // Health
     if (url === "/health") {
       json(200, { status: "ok" });
+      return;
+    }
+
+    // GET /api/capabilities/http
+    if (method === "GET" && url === "/api/capabilities/http") {
+      json(200, buildHttpApiParityMatrix());
       return;
     }
 

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -156,6 +156,9 @@ describe("HTTP API — health", () => {
     expect((body as Record<string, unknown>).service).toBe("autocontext");
     const endpoints = (body as Record<string, unknown>).endpoints as Record<string, unknown>;
     expect(endpoints).toBeDefined();
+    expect(endpoints.capabilities).toMatchObject({
+      http: "/api/capabilities/http",
+    });
     expect(endpoints.knowledge).toMatchObject({
       scenarios: "/api/knowledge/scenarios",
       export: "/api/knowledge/export/:scenario",
@@ -164,6 +167,36 @@ describe("HTTP API — health", () => {
       solve: "/api/knowledge/solve",
       playbook: "/api/knowledge/playbook/:scenario",
     });
+  });
+
+  it("GET /api/capabilities/http returns the runtime parity matrix", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/capabilities/http`);
+    expect(status).toBe(200);
+    const matrix = body as {
+      version: number;
+      summary: Record<string, number>;
+      routes: Array<Record<string, unknown>>;
+    };
+    expect(matrix.version).toBe(1);
+    expect(matrix.summary.aligned).toBeGreaterThan(0);
+    expect(matrix.summary.typescript_gap).toBeGreaterThan(0);
+    expect(matrix.summary.python_gap).toBeGreaterThan(0);
+    expect(matrix.routes).toContainEqual(expect.objectContaining({
+      method: "POST",
+      path: "/api/knowledge/import",
+      status: "aligned",
+    }));
+    expect(matrix.routes).toContainEqual(expect.objectContaining({
+      method: "GET",
+      path: "/api/openclaw/capabilities",
+      status: "typescript_gap",
+      issue: "AC-627",
+    }));
+    expect(matrix.routes).toContainEqual(expect.objectContaining({
+      method: "GET",
+      path: "/api/missions",
+      status: "python_gap",
+    }));
   });
 });
 


### PR DESCRIPTION
## Summary
- add a TypeScript HTTP/WebSocket parity manifest for Python and TypeScript routes
- expose the manifest at GET /api/capabilities/http and advertise it from the root endpoint
- document the discovery endpoint in the TypeScript README

## Tests
- npm test -- tests/http-api.test.ts
- npm run lint

## Stack
- stacked on #792 / AC-621 so the knowledge import route is represented as aligned

Linear: AC-627