### PR TITLE
AC-654 Port notebook REST API to TypeScript

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -278,7 +278,7 @@ Credential resolution order is:
 
 `autoctx capabilities` returns structured JSON describing commands, providers, scenarios, the canonical concept model, and project-specific state such as the current project config, active runs, and knowledge directory summary.
 
-The HTTP server exposes `GET /api/capabilities/http` with a runtime parity matrix for Python and TypeScript REST/WebSocket routes, including explicit TypeScript gaps and TypeScript-only routes.
+The HTTP server exposes `GET /api/capabilities/http` with a runtime parity matrix for Python and TypeScript REST/WebSocket routes, including explicit TypeScript gaps and TypeScript-only routes. Session notebook CRUD routes are available under `/api/notebooks`.
 
 `autoctx login` can prompt interactively for provider credentials. `autoctx login --provider ollama` validates that a local Ollama server is reachable before persisting the connection details, and `autoctx logout` clears the stored credentials.
 

--- a/ts/migrations/010_session_notebook.sql
+++ b/ts/migrations/010_session_notebook.sql
@@ -1,0 +1,19 @@
+-- Session notebook table shared with the Python control plane.
+
+CREATE TABLE IF NOT EXISTS session_notebooks (
+    session_id TEXT PRIMARY KEY,
+    scenario_name TEXT NOT NULL,
+    current_objective TEXT NOT NULL DEFAULT '',
+    current_hypotheses TEXT NOT NULL DEFAULT '[]',
+    best_run_id TEXT,
+    best_generation INTEGER,
+    best_score REAL,
+    unresolved_questions TEXT NOT NULL DEFAULT '[]',
+    operator_observations TEXT NOT NULL DEFAULT '[]',
+    follow_ups TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_notebooks_scenario
+    ON session_notebooks(scenario_name);

--- a/ts/src/knowledge/artifact-store.ts
+++ b/ts/src/knowledge/artifact-store.ts
@@ -10,9 +10,10 @@ import {
   readdirSync,
   readFileSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { PlaybookManager, EMPTY_PLAYBOOK_SENTINEL } from "./playbook.js";
 
 export interface ArtifactStoreOpts {
@@ -91,6 +92,38 @@ export class ArtifactStore {
   writeSessionReport(scenarioName: string, runId: string, content: string): string {
     const path = join(this.knowledgeRoot, scenarioName, "session_reports", `${runId}.md`);
     this.writeMarkdown(path, content);
+    return path;
+  }
+
+  readNotebook(sessionId: string): Record<string, unknown> | null {
+    const path = this.notebookPath(sessionId);
+    if (!existsSync(path)) {
+      return null;
+    }
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  }
+
+  writeNotebook(sessionId: string, notebook: Record<string, unknown>): void {
+    this.writeJson(this.notebookPath(sessionId), notebook);
+  }
+
+  deleteNotebook(sessionId: string): void {
+    const path = this.notebookPath(sessionId);
+    if (existsSync(path)) {
+      unlinkSync(path);
+    }
+  }
+
+  private notebookPath(sessionId: string): string {
+    const sessionsRoot = resolve(this.runsRoot, "sessions");
+    const path = resolve(sessionsRoot, sessionId, "notebook.json");
+    const relativePath = relative(sessionsRoot, path);
+    if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+      throw new Error("session_id must stay within the notebook sessions root");
+    }
     return path;
   }
 

--- a/ts/src/server/http-api-parity.ts
+++ b/ts/src/server/http-api-parity.ts
@@ -104,6 +104,10 @@ export const HTTP_API_PARITY_ROUTES: readonly HttpApiParityEntry[] = [
     "/api/knowledge/playbook/:scenario",
     "TypeScript exposes direct playbook readback from the interactive server.",
   ),
+  both("notebooks", "GET", "/api/notebooks", "autocontext/src/autocontext/server/notebook_api.py"),
+  both("notebooks", "GET", "/api/notebooks/:session_id", "autocontext/src/autocontext/server/notebook_api.py"),
+  both("notebooks", "PUT", "/api/notebooks/:session_id", "autocontext/src/autocontext/server/notebook_api.py"),
+  both("notebooks", "DELETE", "/api/notebooks/:session_id", "autocontext/src/autocontext/server/notebook_api.py"),
 
   both(
     "discovery",
@@ -219,12 +223,6 @@ export const HTTP_API_PARITY_ROUTES: readonly HttpApiParityEntry[] = [
     ["GET", "/api/hub/results/:result_id"],
     ["POST", "/api/hub/promotions"],
     ["GET", "/api/hub/feed"],
-  ]),
-  ...pythonOnlyRoutes("notebooks", "autocontext/src/autocontext/server/notebook_api.py", [
-    ["GET", "/api/notebooks"],
-    ["GET", "/api/notebooks/:session_id"],
-    ["PUT", "/api/notebooks/:session_id"],
-    ["DELETE", "/api/notebooks/:session_id"],
   ]),
   ...pythonOnlyRoutes("monitors", "autocontext/src/autocontext/server/monitor_api.py", [
     ["POST", "/api/monitors"],

--- a/ts/src/server/notebook-api.ts
+++ b/ts/src/server/notebook-api.ts
@@ -1,0 +1,228 @@
+import type { ArtifactStore } from "../knowledge/artifact-store.js";
+import type { SQLiteStore, UpsertNotebookOpts } from "../storage/index.js";
+
+export interface NotebookApiResponse {
+  status: number;
+  body: unknown;
+}
+
+export interface NotebookApiRoutes {
+  list(): NotebookApiResponse;
+  get(sessionId: string): NotebookApiResponse;
+  upsert(sessionId: string, body: Record<string, unknown>): NotebookApiResponse;
+  delete(sessionId: string): NotebookApiResponse;
+}
+
+export function buildNotebookApiRoutes(opts: {
+  openStore: () => SQLiteStore;
+  artifacts: Pick<ArtifactStore, "writeNotebook" | "deleteNotebook">;
+  emitNotebookEvent: (
+    event: "notebook_updated" | "notebook_deleted",
+    payload: Record<string, unknown>,
+  ) => void;
+}): NotebookApiRoutes {
+  return {
+    list: () => withStore(opts.openStore, (store) => ({
+      status: 200,
+      body: store.listNotebooks(),
+    })),
+    get: (sessionId) => {
+      const invalidSession = validateNotebookSessionId(sessionId);
+      if (invalidSession) return invalidSession;
+      return withStore(opts.openStore, (store) => {
+        const notebook = store.getNotebook(sessionId);
+        if (!notebook) {
+          return { status: 404, body: { detail: `Notebook not found: ${sessionId}` } };
+        }
+        return { status: 200, body: notebook };
+      });
+    },
+    upsert: (sessionId, body) => {
+      const invalidSession = validateNotebookSessionId(sessionId);
+      if (invalidSession) return invalidSession;
+      return withStore(opts.openStore, (store) => {
+        const request = parseNotebookUpsertRequest(body);
+        if (!request.ok) {
+          return { status: 422, body: { detail: request.error } };
+        }
+        const existing = store.getNotebook(sessionId);
+        const scenarioName = request.values.scenarioName ?? existing?.scenario_name;
+        if (!scenarioName) {
+          return {
+            status: 400,
+            body: { detail: "scenario_name is required when creating a notebook" },
+          };
+        }
+        store.upsertNotebook({
+          sessionId,
+          ...request.values,
+          scenarioName,
+        });
+        const notebook = store.getNotebook(sessionId);
+        if (notebook) {
+          opts.artifacts.writeNotebook(sessionId, notebook as unknown as Record<string, unknown>);
+          opts.emitNotebookEvent("notebook_updated", {
+            session_id: sessionId,
+            scenario_name: notebook.scenario_name,
+          });
+        }
+        return { status: 200, body: notebook ?? { session_id: sessionId, scenario_name: scenarioName } };
+      });
+    },
+    delete: (sessionId) => {
+      const invalidSession = validateNotebookSessionId(sessionId);
+      if (invalidSession) return invalidSession;
+      return withStore(opts.openStore, (store) => {
+        const existing = store.getNotebook(sessionId);
+        const deleted = store.deleteNotebook(sessionId);
+        if (!deleted) {
+          return { status: 404, body: { detail: `Notebook not found: ${sessionId}` } };
+        }
+        opts.artifacts.deleteNotebook(sessionId);
+        opts.emitNotebookEvent("notebook_deleted", {
+          session_id: sessionId,
+          scenario_name: existing?.scenario_name ?? "",
+        });
+        return { status: 200, body: { status: "deleted", session_id: sessionId } };
+      });
+    },
+  };
+}
+
+const SAFE_NOTEBOOK_SESSION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+function validateNotebookSessionId(sessionId: string): NotebookApiResponse | null {
+  if (SAFE_NOTEBOOK_SESSION_ID_RE.test(sessionId)) {
+    return null;
+  }
+  return {
+    status: 422,
+    body: {
+      detail: "Invalid session_id: use letters, digits, underscores, or hyphens; no path separators",
+    },
+  };
+}
+
+function withStore(
+  openStore: () => SQLiteStore,
+  fn: (store: SQLiteStore) => NotebookApiResponse,
+): NotebookApiResponse {
+  const store = openStore();
+  try {
+    return fn(store);
+  } finally {
+    store.close();
+  }
+}
+
+type NotebookUpsertRequestResult =
+  | { ok: true; values: NotebookUpsertValues }
+  | { ok: false; error: string };
+
+type NotebookUpsertValues =
+  Partial<Omit<UpsertNotebookOpts, "sessionId" | "scenarioName">>
+  & { scenarioName?: string };
+
+function parseNotebookUpsertRequest(body: Record<string, unknown>): NotebookUpsertRequestResult {
+  const scenarioName = readOptionalString(body, ["scenario_name", "scenarioName"]);
+  if (!scenarioName.ok) return scenarioName;
+  const currentObjective = readOptionalString(body, ["current_objective", "currentObjective"]);
+  if (!currentObjective.ok) return currentObjective;
+  const bestRunId = readOptionalString(body, ["best_run_id", "bestRunId"]);
+  if (!bestRunId.ok) return bestRunId;
+  const bestGeneration = readOptionalInteger(body, ["best_generation", "bestGeneration"]);
+  if (!bestGeneration.ok) return bestGeneration;
+  const bestScore = readOptionalNumber(body, ["best_score", "bestScore"]);
+  if (!bestScore.ok) return bestScore;
+  const currentHypotheses = readOptionalStringArray(body, ["current_hypotheses", "currentHypotheses"]);
+  if (!currentHypotheses.ok) return currentHypotheses;
+  const unresolvedQuestions = readOptionalStringArray(body, ["unresolved_questions", "unresolvedQuestions"]);
+  if (!unresolvedQuestions.ok) return unresolvedQuestions;
+  const operatorObservations = readOptionalStringArray(body, ["operator_observations", "operatorObservations"]);
+  if (!operatorObservations.ok) return operatorObservations;
+  const followUps = readOptionalStringArray(body, ["follow_ups", "followUps"]);
+  if (!followUps.ok) return followUps;
+
+  return {
+    ok: true,
+    values: {
+      scenarioName: scenarioName.value,
+      currentObjective: currentObjective.value,
+      bestRunId: bestRunId.value,
+      bestGeneration: bestGeneration.value,
+      bestScore: bestScore.value,
+      currentHypotheses: currentHypotheses.value,
+      unresolvedQuestions: unresolvedQuestions.value,
+      operatorObservations: operatorObservations.value,
+      followUps: followUps.value,
+    },
+  };
+}
+
+function readOptionalString(
+  body: Record<string, unknown>,
+  keys: string[],
+): { ok: true; value?: string } | { ok: false; error: string } {
+  const entry = firstPresent(body, keys);
+  if (!entry || entry.value === null) {
+    return { ok: true };
+  }
+  if (typeof entry.value !== "string") {
+    return { ok: false, error: `${entry.key} must be a string` };
+  }
+  return { ok: true, value: entry.value };
+}
+
+function readOptionalInteger(
+  body: Record<string, unknown>,
+  keys: string[],
+): { ok: true; value?: number } | { ok: false; error: string } {
+  const entry = firstPresent(body, keys);
+  if (!entry || entry.value === null) {
+    return { ok: true };
+  }
+  if (typeof entry.value !== "number" || !Number.isInteger(entry.value)) {
+    return { ok: false, error: `${entry.key} must be an integer` };
+  }
+  return { ok: true, value: entry.value };
+}
+
+function readOptionalNumber(
+  body: Record<string, unknown>,
+  keys: string[],
+): { ok: true; value?: number } | { ok: false; error: string } {
+  const entry = firstPresent(body, keys);
+  if (!entry || entry.value === null) {
+    return { ok: true };
+  }
+  if (typeof entry.value !== "number") {
+    return { ok: false, error: `${entry.key} must be a number` };
+  }
+  return { ok: true, value: entry.value };
+}
+
+function readOptionalStringArray(
+  body: Record<string, unknown>,
+  keys: string[],
+): { ok: true; value?: string[] } | { ok: false; error: string } {
+  const entry = firstPresent(body, keys);
+  if (!entry || entry.value === null) {
+    return { ok: true };
+  }
+  if (!Array.isArray(entry.value) || !entry.value.every((value) => typeof value === "string")) {
+    return { ok: false, error: `${entry.key} must be an array of strings` };
+  }
+  return { ok: true, value: entry.value };
+}
+
+function firstPresent(
+  body: Record<string, unknown>,
+  keys: string[],
+): { key: string; value: unknown } | null {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(body, key)) {
+      return { key, value: body[key] };
+    }
+  }
+  return null;
+}

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -32,6 +32,7 @@ import { executeInteractiveScenarioCommand } from "./interactive-scenario-comman
 import { buildHttpApiParityMatrix } from "./http-api-parity.js";
 import { buildKnowledgeApiRoutes } from "./knowledge-api.js";
 import { buildMissionApiRoutes } from "./mission-api.js";
+import { buildNotebookApiRoutes } from "./notebook-api.js";
 import { buildSimulationApiRoutes } from "./simulation-api.js";
 import { renderDashboardHtml } from "./simulation-dashboard.js";
 import { buildSessionBootstrapMessages, buildStateMessage } from "./websocket-session-bootstrap.js";
@@ -161,6 +162,10 @@ export class InteractiveServer {
     const method = req.method ?? "GET";
     const campaignApi = buildCampaignApiRoutes(this.#campaignManager);
     const missionApi = buildMissionApiRoutes(this.#missionManager, this.#runManager.getRunsRoot());
+    const artifactStore = new ArtifactStore({
+      runsRoot: this.#runManager.getRunsRoot(),
+      knowledgeRoot: this.#runManager.getKnowledgeRoot(),
+    });
     const knowledgeApi = buildKnowledgeApiRoutes({
       runsRoot: this.#runManager.getRunsRoot(),
       knowledgeRoot: this.#runManager.getKnowledgeRoot(),
@@ -168,11 +173,18 @@ export class InteractiveServer {
       openStore: () => this.#openStore(),
       getSolveManager: () => this.#getSolveManager(),
     });
+    const notebookApi = buildNotebookApiRoutes({
+      openStore: () => this.#openStore(),
+      artifacts: artifactStore,
+      emitNotebookEvent: (event, payload) => {
+        this.#runManager.events.emit(event, payload, "notebook");
+      },
+    });
     const simulationApi = buildSimulationApiRoutes(this.#runManager.getKnowledgeRoot());
 
     // CORS headers for dashboard
     res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
     res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 
     if (method === "OPTIONS") {
@@ -210,6 +222,7 @@ export class InteractiveServer {
           },
           campaigns: "/api/campaigns",
           missions: "/api/missions",
+          notebooks: "/api/notebooks",
           websocket: "/ws/interactive",
           events: "/ws/events",
         },
@@ -234,6 +247,35 @@ export class InteractiveServer {
     if (method === "GET" && url === "/api/capabilities/http") {
       json(200, buildHttpApiParityMatrix());
       return;
+    }
+
+    // GET /api/notebooks
+    if (method === "GET" && (url === "/api/notebooks" || url === "/api/notebooks/")) {
+      const response = notebookApi.list();
+      json(response.status, response.body);
+      return;
+    }
+
+    // GET/PUT/DELETE /api/notebooks/:sessionId
+    const notebookMatch = url.match(/^\/api\/notebooks\/([^/]+)$/);
+    if (notebookMatch) {
+      const [, rawSessionId] = notebookMatch;
+      const sessionId = decodeURIComponent(rawSessionId!);
+      if (method === "GET") {
+        const response = notebookApi.get(sessionId);
+        json(response.status, response.body);
+        return;
+      }
+      if (method === "PUT") {
+        const response = notebookApi.upsert(sessionId, await this.#readJsonBody(req));
+        json(response.status, response.body);
+        return;
+      }
+      if (method === "DELETE") {
+        const response = notebookApi.delete(sessionId);
+        json(response.status, response.body);
+        return;
+      }
     }
 
     // GET /api/runs

--- a/ts/src/storage/index.ts
+++ b/ts/src/storage/index.ts
@@ -3,10 +3,12 @@ export type {
   GenerationRow,
   HumanFeedbackRow,
   MatchRow,
+  NotebookRow,
   RecordMatchOpts,
   RunRow,
   TaskQueueRow,
   TrajectoryRow,
+  UpsertNotebookOpts,
   UpsertGenerationOpts,
 } from "./storage-contracts.js";
 

--- a/ts/src/storage/notebook-store.ts
+++ b/ts/src/storage/notebook-store.ts
@@ -1,0 +1,108 @@
+import type Database from "better-sqlite3";
+
+import type { NotebookRow, UpsertNotebookOpts } from "./storage-contracts.js";
+
+const NOTEBOOK_JSON_FIELDS = [
+  "current_hypotheses",
+  "unresolved_questions",
+  "operator_observations",
+  "follow_ups",
+] as const;
+
+type NotebookJsonField = typeof NOTEBOOK_JSON_FIELDS[number];
+type RawNotebookRow = Omit<NotebookRow, NotebookJsonField> & Record<NotebookJsonField, string>;
+
+function parseJsonArray(raw: unknown): string[] {
+  if (typeof raw !== "string") {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((value): value is string => typeof value === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseNotebookRow(row: RawNotebookRow): NotebookRow {
+  return {
+    ...row,
+    current_hypotheses: parseJsonArray(row.current_hypotheses),
+    unresolved_questions: parseJsonArray(row.unresolved_questions),
+    operator_observations: parseJsonArray(row.operator_observations),
+    follow_ups: parseJsonArray(row.follow_ups),
+  };
+}
+
+export function upsertNotebookRecord(
+  db: Database.Database,
+  opts: UpsertNotebookOpts,
+): void {
+  const existing = getNotebookRecord(db, opts.sessionId);
+  const currentObjective = opts.currentObjective ?? existing?.current_objective ?? "";
+  const currentHypotheses = opts.currentHypotheses ?? existing?.current_hypotheses ?? [];
+  const bestRunId = opts.bestRunId ?? existing?.best_run_id ?? null;
+  const bestGeneration = opts.bestGeneration ?? existing?.best_generation ?? null;
+  const bestScore = opts.bestScore ?? existing?.best_score ?? null;
+  const unresolvedQuestions = opts.unresolvedQuestions ?? existing?.unresolved_questions ?? [];
+  const operatorObservations = opts.operatorObservations ?? existing?.operator_observations ?? [];
+  const followUps = opts.followUps ?? existing?.follow_ups ?? [];
+
+  db.prepare(`
+    INSERT INTO session_notebooks(
+      session_id, scenario_name, current_objective, current_hypotheses,
+      best_run_id, best_generation, best_score,
+      unresolved_questions, operator_observations, follow_ups
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(session_id) DO UPDATE SET
+      scenario_name = excluded.scenario_name,
+      current_objective = excluded.current_objective,
+      current_hypotheses = excluded.current_hypotheses,
+      best_run_id = excluded.best_run_id,
+      best_generation = excluded.best_generation,
+      best_score = excluded.best_score,
+      unresolved_questions = excluded.unresolved_questions,
+      operator_observations = excluded.operator_observations,
+      follow_ups = excluded.follow_ups,
+      updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+  `).run(
+    opts.sessionId,
+    opts.scenarioName,
+    currentObjective,
+    JSON.stringify(currentHypotheses),
+    bestRunId,
+    bestGeneration,
+    bestScore,
+    JSON.stringify(unresolvedQuestions),
+    JSON.stringify(operatorObservations),
+    JSON.stringify(followUps),
+  );
+}
+
+export function getNotebookRecord(
+  db: Database.Database,
+  sessionId: string,
+): NotebookRow | null {
+  const row = db.prepare(
+    "SELECT * FROM session_notebooks WHERE session_id = ?",
+  ).get(sessionId) as RawNotebookRow | undefined;
+  return row ? parseNotebookRow(row) : null;
+}
+
+export function listNotebookRecords(db: Database.Database): NotebookRow[] {
+  const rows = db.prepare(
+    "SELECT * FROM session_notebooks ORDER BY updated_at DESC",
+  ).all() as RawNotebookRow[];
+  return rows.map((row) => parseNotebookRow(row));
+}
+
+export function deleteNotebookRecord(
+  db: Database.Database,
+  sessionId: string,
+): boolean {
+  const result = db.prepare("DELETE FROM session_notebooks WHERE session_id = ?").run(sessionId);
+  return result.changes > 0;
+}

--- a/ts/src/storage/sqlite-store.ts
+++ b/ts/src/storage/sqlite-store.ts
@@ -5,10 +5,12 @@ import type {
   GenerationRow,
   HumanFeedbackRow,
   MatchRow,
+  NotebookRow,
   RecordMatchOpts,
   RunRow,
   TaskQueueRow,
   TrajectoryRow,
+  UpsertNotebookOpts,
   UpsertGenerationOpts,
 } from "./storage-contracts.js";
 import {
@@ -42,6 +44,12 @@ import {
   getStoreHumanFeedback,
   insertStoreHumanFeedback,
 } from "./storage-human-feedback-facade.js";
+import {
+  deleteStoreNotebook,
+  getStoreNotebook,
+  listStoreNotebooks,
+  upsertStoreNotebook,
+} from "./storage-notebook-facade.js";
 import { migrateDatabase } from "./storage-migration-workflow.js";
 
 export function configureSqliteDatabase(db: Pick<Database.Database, "pragma">): void {
@@ -129,6 +137,22 @@ export class SQLiteStore {
 
   getCalibrationExamples(scenarioName: string, limit = 5): HumanFeedbackRow[] {
     return getStoreCalibrationExamples(this.#db, scenarioName, limit);
+  }
+
+  upsertNotebook(opts: UpsertNotebookOpts): void {
+    upsertStoreNotebook(this.#db, opts);
+  }
+
+  getNotebook(sessionId: string): NotebookRow | null {
+    return getStoreNotebook(this.#db, sessionId);
+  }
+
+  listNotebooks(): NotebookRow[] {
+    return listStoreNotebooks(this.#db);
+  }
+
+  deleteNotebook(sessionId: string): boolean {
+    return deleteStoreNotebook(this.#db, sessionId);
   }
 
   createRun(

--- a/ts/src/storage/storage-contracts.ts
+++ b/ts/src/storage/storage-contracts.ts
@@ -91,6 +91,34 @@ export interface TrajectoryRow {
   rating_uncertainty: number | null;
 }
 
+export interface NotebookRow {
+  session_id: string;
+  scenario_name: string;
+  current_objective: string;
+  current_hypotheses: string[];
+  best_run_id: string | null;
+  best_generation: number | null;
+  best_score: number | null;
+  unresolved_questions: string[];
+  operator_observations: string[];
+  follow_ups: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UpsertNotebookOpts {
+  sessionId: string;
+  scenarioName: string;
+  currentObjective?: string | null;
+  currentHypotheses?: string[] | null;
+  bestRunId?: string | null;
+  bestGeneration?: number | null;
+  bestScore?: number | null;
+  unresolvedQuestions?: string[] | null;
+  operatorObservations?: string[] | null;
+  followUps?: string[] | null;
+}
+
 export interface UpsertGenerationOpts {
   meanScore: number;
   bestScore: number;

--- a/ts/src/storage/storage-migration-workflow.ts
+++ b/ts/src/storage/storage-migration-workflow.ts
@@ -16,6 +16,7 @@ export const TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES: Record<string, readonly s
     "014_scoring_backend_metadata.sql",
     "015_match_replay.sql",
   ],
+  "010_session_notebook.sql": ["010_session_notebook.sql"],
 };
 
 const TYPESCRIPT_BASELINE_SCHEMA_RECONCILIATION: Record<string, readonly string[]> = {

--- a/ts/src/storage/storage-notebook-facade.ts
+++ b/ts/src/storage/storage-notebook-facade.ts
@@ -1,0 +1,34 @@
+import type Database from "better-sqlite3";
+
+import type { NotebookRow, UpsertNotebookOpts } from "./storage-contracts.js";
+import {
+  deleteNotebookRecord,
+  getNotebookRecord,
+  listNotebookRecords,
+  upsertNotebookRecord,
+} from "./notebook-store.js";
+
+export function upsertStoreNotebook(
+  db: Database.Database,
+  opts: UpsertNotebookOpts,
+): void {
+  upsertNotebookRecord(db, opts);
+}
+
+export function getStoreNotebook(
+  db: Database.Database,
+  sessionId: string,
+): NotebookRow | null {
+  return getNotebookRecord(db, sessionId);
+}
+
+export function listStoreNotebooks(db: Database.Database): NotebookRow[] {
+  return listNotebookRecords(db);
+}
+
+export function deleteStoreNotebook(
+  db: Database.Database,
+  sessionId: string,
+): boolean {
+  return deleteNotebookRecord(db, sessionId);
+}

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -31,6 +31,15 @@ async function postJson(url: string, body: Record<string, unknown>): Promise<{ s
   return { status: res.status, body: await res.json() };
 }
 
+async function putJson(url: string, body: Record<string, unknown>): Promise<{ status: number; body: unknown }> {
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.json() };
+}
+
 async function fetchText(url: string): Promise<{ status: number; body: string }> {
   const res = await fetch(url);
   const body = await res.text();
@@ -159,6 +168,7 @@ describe("HTTP API — health", () => {
     expect(endpoints.capabilities).toMatchObject({
       http: "/api/capabilities/http",
     });
+    expect(endpoints.notebooks).toBe("/api/notebooks");
     expect(endpoints.knowledge).toMatchObject({
       scenarios: "/api/knowledge/scenarios",
       export: "/api/knowledge/export/:scenario",
@@ -202,6 +212,11 @@ describe("HTTP API — health", () => {
       method: "GET",
       path: "/api/knowledge/playbook/:scenario",
       status: "python_gap",
+    }));
+    expect(matrix.routes).toContainEqual(expect.objectContaining({
+      method: "GET",
+      path: "/api/notebooks",
+      status: "aligned",
     }));
     expect(matrix.routes).toContainEqual(expect.objectContaining({
       method: "GET",
@@ -271,6 +286,135 @@ describe("HTTP API — runs", () => {
   it("GET /api/runs/:id/replay/:gen returns 404 when replay artifact is missing", async () => {
     const res = await fetch(`${baseUrl}/api/runs/test-run-1/replay/99`);
     expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Notebook endpoints
+// ---------------------------------------------------------------------------
+
+describe("HTTP API — notebooks", () => {
+  let dir: string;
+  let server: Awaited<ReturnType<typeof createTestServer>>["server"];
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    dir = makeTempDir();
+    const s = await createTestServer(dir);
+    server = s.server;
+    baseUrl = s.baseUrl;
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("GET /api/notebooks lists notebooks", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/notebooks`);
+    expect(status).toBe(200);
+    expect(body).toEqual([]);
+  });
+
+  it("PUT /api/notebooks/:session_id creates and syncs a notebook", async () => {
+    const { status, body } = await putJson(`${baseUrl}/api/notebooks/session-1`, {
+      scenario_name: "grid_ctf",
+      current_objective: "Hold the center route.",
+      current_hypotheses: ["Center pressure improves capture odds."],
+      best_run_id: "test-run-1",
+      best_generation: 1,
+      best_score: 0.7,
+      unresolved_questions: ["Does flank pressure help?"],
+      operator_observations: ["Blue team favored center."],
+      follow_ups: ["Try a lower-risk opening."],
+    });
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      session_id: "session-1",
+      scenario_name: "grid_ctf",
+      current_objective: "Hold the center route.",
+      current_hypotheses: ["Center pressure improves capture odds."],
+      best_run_id: "test-run-1",
+      best_generation: 1,
+      best_score: 0.7,
+      unresolved_questions: ["Does flank pressure help?"],
+      operator_observations: ["Blue team favored center."],
+      follow_ups: ["Try a lower-risk opening."],
+    });
+    const notebookPath = join(dir, "runs", "sessions", "session-1", "notebook.json");
+    expect(JSON.parse(readFileSync(notebookPath, "utf-8"))).toMatchObject({
+      session_id: "session-1",
+      scenario_name: "grid_ctf",
+    });
+    const eventLog = readFileSync(join(dir, "runs", "_interactive", "events.ndjson"), "utf-8");
+    expect(eventLog).toContain("notebook_updated");
+  });
+
+  it("PUT /api/notebooks/:session_id merges partial updates", async () => {
+    await putJson(`${baseUrl}/api/notebooks/session-1`, {
+      scenario_name: "grid_ctf",
+      current_objective: "First objective.",
+      current_hypotheses: ["Keep this."],
+    });
+
+    const { status, body } = await putJson(`${baseUrl}/api/notebooks/session-1`, {
+      current_objective: "Updated objective.",
+    });
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      scenario_name: "grid_ctf",
+      current_objective: "Updated objective.",
+      current_hypotheses: ["Keep this."],
+    });
+  });
+
+  it("PUT /api/notebooks/:session_id requires scenario_name for new notebooks", async () => {
+    const { status, body } = await putJson(`${baseUrl}/api/notebooks/session-2`, {
+      current_objective: "Missing scenario.",
+    });
+
+    expect(status).toBe(400);
+    expect((body as Record<string, unknown>).detail).toContain("scenario_name");
+  });
+
+  it("PUT /api/notebooks/:session_id rejects decoded path traversal", async () => {
+    const encodedTraversal = encodeURIComponent("../../escaped");
+
+    const { status, body } = await putJson(`${baseUrl}/api/notebooks/${encodedTraversal}`, {
+      scenario_name: "grid_ctf",
+      current_objective: "Do not write outside the sessions root.",
+    });
+
+    expect(status).toBe(422);
+    expect((body as Record<string, unknown>).detail).toContain("session_id");
+    expect(existsSync(join(dir, "escaped", "notebook.json"))).toBe(false);
+    expect(existsSync(join(dir, "runs", "escaped", "notebook.json"))).toBe(false);
+  });
+
+  it("GET /api/notebooks/:session_id returns 404 for missing notebooks", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/notebooks/missing`);
+    expect(status).toBe(404);
+    expect((body as Record<string, unknown>).detail).toContain("Notebook not found");
+  });
+
+  it("DELETE /api/notebooks/:session_id deletes the notebook and artifact", async () => {
+    await putJson(`${baseUrl}/api/notebooks/session-1`, {
+      scenario_name: "grid_ctf",
+      current_objective: "Delete this.",
+    });
+    const notebookPath = join(dir, "runs", "sessions", "session-1", "notebook.json");
+    expect(existsSync(notebookPath)).toBe(true);
+
+    const res = await fetch(`${baseUrl}/api/notebooks/session-1`, { method: "DELETE" });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ status: "deleted", session_id: "session-1" });
+    expect(existsSync(notebookPath)).toBe(false);
+    const eventLog = readFileSync(join(dir, "runs", "_interactive", "events.ndjson"), "utf-8");
+    expect(eventLog).toContain("notebook_deleted");
   });
 });
 


### PR DESCRIPTION
## Summary
- add TS session notebook storage, migration, and SQLite facade methods
- add Notebook API route workflow for list/get/upsert/delete
- wire /api/notebooks into the interactive HTTP server with artifact sync and notebook events
- update the HTTP parity matrix from Python-only to aligned for notebook routes
- document notebook CRUD routes in the TS README

## Tests
- npm test -- tests/http-api.test.ts
- npm test -- tests/http-api.test.ts tests/storage.test.ts tests/storage-migration-workflow.test.ts
- npm run lint

## Notes
- Full npm test was also run; the notebook/storage/HTTP tests passed, but the full suite still has unrelated pre-existing timeout/provider failures in campaign/mission/scenario-spec/server-protocol/subpath-export areas under local load.

## Stack
- stacked on #793 / AC-627

Linear: AC-654