### PR TITLE
AC-656 Port OpenClaw REST API to TypeScript

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -278,7 +278,7 @@ Credential resolution order is:
 
 `autoctx capabilities` returns structured JSON describing commands, providers, scenarios, the canonical concept model, and project-specific state such as the current project config, active runs, and knowledge directory summary.
 
-The HTTP server exposes `GET /api/capabilities/http` with a runtime parity matrix for Python and TypeScript REST/WebSocket routes, including explicit TypeScript gaps and TypeScript-only routes. Session notebook CRUD routes are available under `/api/notebooks`, and monitor condition/alert routes are available under `/api/monitors`.
+The HTTP server exposes `GET /api/capabilities/http` with a runtime parity matrix for Python and TypeScript REST/WebSocket routes, including explicit TypeScript gaps and TypeScript-only routes. Session notebook CRUD routes are available under `/api/notebooks`, monitor condition/alert routes are available under `/api/monitors`, and OpenClaw-compatible evaluation, artifact, distillation, discovery, capability, and skill manifest routes are available under `/api/openclaw`.
 
 `autoctx login` can prompt interactively for provider credentials. `autoctx login --provider ollama` validates that a local Ollama server is reachable before persisting the connection details, and `autoctx logout` clears the stored credentials.
 

--- a/ts/src/openclaw/artifact-contract.ts
+++ b/ts/src/openclaw/artifact-contract.ts
@@ -1,0 +1,124 @@
+import { assertSafeScenarioId } from "../knowledge/scenario-id.js";
+
+export type OpenClawArtifactType = "harness" | "policy" | "distilled_model";
+
+export interface ValidatedOpenClawArtifact {
+  artifactId: string;
+  artifactType: OpenClawArtifactType;
+  scenario: string;
+  data: Record<string, unknown>;
+}
+
+const SAFE_FILE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireString(body: Record<string, unknown>, key: string): string {
+  const value = body[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${key} is required`);
+  }
+  return value.trim();
+}
+
+function requireSourceText(body: Record<string, unknown>, key: string): string {
+  const value = body[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${key} is required`);
+  }
+  return value;
+}
+
+function requireInteger(body: Record<string, unknown>, key: string, min: number): number {
+  const value = body[key];
+  if (typeof value !== "number" || !Number.isInteger(value) || value < min) {
+    throw new Error(`${key} must be an integer greater than or equal to ${min}`);
+  }
+  return value;
+}
+
+function optionalStringList(body: Record<string, unknown>, key: string): string[] {
+  const value = body[key];
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
+    throw new Error(`${key} must be a list of strings`);
+  }
+  return value.map((entry) => entry.trim()).filter(Boolean);
+}
+
+function optionalRecord(body: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = body[key];
+  if (value === undefined) {
+    return {};
+  }
+  if (!isRecord(value)) {
+    throw new Error(`${key} must be an object`);
+  }
+  return value;
+}
+
+function isOpenClawArtifactType(value: string): value is OpenClawArtifactType {
+  return value === "harness" || value === "policy" || value === "distilled_model";
+}
+
+function validateProvenance(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error("provenance is required");
+  }
+
+  return {
+    ...value,
+    run_id: requireString(value, "run_id"),
+    generation: requireInteger(value, "generation", 0),
+    scenario: requireString(value, "scenario"),
+    settings: optionalRecord(value, "settings"),
+  };
+}
+
+export function ensureSafeArtifactId(artifactId: string): string {
+  if (!SAFE_FILE_ID.test(artifactId)) {
+    throw new Error(`invalid artifact id: ${artifactId}`);
+  }
+  return artifactId;
+}
+
+export function validateOpenClawArtifactPayload(body: Record<string, unknown>): ValidatedOpenClawArtifact {
+  const rawArtifactType = requireString(body, "artifact_type");
+  if (!isOpenClawArtifactType(rawArtifactType)) {
+    throw new Error(
+      `Invalid or missing artifact_type: ${rawArtifactType}. Must be harness, policy, or distilled_model.`,
+    );
+  }
+  const artifactType = rawArtifactType;
+  const artifactId = ensureSafeArtifactId(requireString(body, "id"));
+  const scenario = assertSafeScenarioId(requireString(body, "scenario"));
+  const data: Record<string, unknown> = {
+    ...body,
+    id: artifactId,
+    name: requireString(body, "name"),
+    artifact_type: artifactType,
+    scenario,
+    version: requireInteger(body, "version", 1),
+    provenance: validateProvenance(body.provenance),
+    created_at: typeof body.created_at === "string" && body.created_at.trim()
+      ? body.created_at.trim()
+      : new Date().toISOString(),
+    compatible_scenarios: optionalStringList(body, "compatible_scenarios"),
+    tags: optionalStringList(body, "tags"),
+  };
+
+  if (artifactType === "harness" || artifactType === "policy") {
+    data.source_code = requireSourceText(body, "source_code");
+  } else {
+    data.architecture = requireString(body, "architecture");
+    data.parameter_count = requireInteger(body, "parameter_count", 1);
+    data.checkpoint_path = requireString(body, "checkpoint_path");
+    data.training_data_stats = optionalRecord(body, "training_data_stats");
+  }
+
+  return { artifactId, artifactType, scenario, data };
+}

--- a/ts/src/openclaw/distill-job-store.ts
+++ b/ts/src/openclaw/distill-job-store.ts
@@ -44,14 +44,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+export function isDistillJobStatus(value: string): value is DistillJobStatus {
+  return value === "pending" || value === "running" || value === "completed" || value === "failed";
+}
+
 function parseJob(raw: unknown): DistillJob | null {
   if (!isRecord(raw)) return null;
   if (typeof raw.job_id !== "string" || typeof raw.scenario !== "string") return null;
-  if (!["pending", "running", "completed", "failed"].includes(String(raw.status))) return null;
+  if (typeof raw.status !== "string" || !isDistillJobStatus(raw.status)) return null;
   return {
     job_id: raw.job_id,
     scenario: raw.scenario,
-    status: raw.status as DistillJobStatus,
+    status: raw.status,
     source_artifact_ids: Array.isArray(raw.source_artifact_ids)
       ? raw.source_artifact_ids.filter((entry): entry is string => typeof entry === "string")
       : [],
@@ -169,7 +173,7 @@ export class DistillJobStore {
       return null;
     }
     try {
-      return parseJob(JSON.parse(readFileSync(path, "utf-8")) as unknown);
+      return parseJob(JSON.parse(readFileSync(path, "utf-8")));
     } catch {
       return null;
     }

--- a/ts/src/openclaw/distill-job-store.ts
+++ b/ts/src/openclaw/distill-job-store.ts
@@ -1,0 +1,182 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+export type DistillJobStatus = "pending" | "running" | "completed" | "failed";
+
+export interface DistillJob {
+  job_id: string;
+  scenario: string;
+  status: DistillJobStatus;
+  source_artifact_ids: string[];
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  result_artifact_id: string | null;
+  error_message: string | null;
+  training_config: Record<string, unknown>;
+  training_metrics: Record<string, unknown>;
+}
+
+export class DistillJobError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DistillJobError";
+  }
+}
+
+const VALID_TRANSITIONS: Record<DistillJobStatus, ReadonlySet<DistillJobStatus>> = {
+  pending: new Set(["running", "failed"]),
+  running: new Set(["completed", "failed"]),
+  completed: new Set(),
+  failed: new Set(),
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function createJobId(): string {
+  return randomUUID().replace(/-/g, "");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseJob(raw: unknown): DistillJob | null {
+  if (!isRecord(raw)) return null;
+  if (typeof raw.job_id !== "string" || typeof raw.scenario !== "string") return null;
+  if (!["pending", "running", "completed", "failed"].includes(String(raw.status))) return null;
+  return {
+    job_id: raw.job_id,
+    scenario: raw.scenario,
+    status: raw.status as DistillJobStatus,
+    source_artifact_ids: Array.isArray(raw.source_artifact_ids)
+      ? raw.source_artifact_ids.filter((entry): entry is string => typeof entry === "string")
+      : [],
+    created_at: typeof raw.created_at === "string" ? raw.created_at : nowIso(),
+    started_at: typeof raw.started_at === "string" ? raw.started_at : null,
+    completed_at: typeof raw.completed_at === "string" ? raw.completed_at : null,
+    result_artifact_id: typeof raw.result_artifact_id === "string" ? raw.result_artifact_id : null,
+    error_message: typeof raw.error_message === "string" ? raw.error_message : null,
+    training_config: isRecord(raw.training_config) ? raw.training_config : {},
+    training_metrics: isRecord(raw.training_metrics) ? raw.training_metrics : {},
+  };
+}
+
+export class DistillJobStore {
+  readonly #jobsDir: string;
+
+  constructor(knowledgeRoot: string) {
+    this.#jobsDir = join(knowledgeRoot, "_openclaw_distill_jobs");
+  }
+
+  createJob(opts: {
+    scenario: string;
+    sourceArtifactIds?: string[];
+    trainingConfig?: Record<string, unknown>;
+  }): DistillJob {
+    const job: DistillJob = {
+      job_id: createJobId(),
+      scenario: opts.scenario,
+      status: "pending",
+      source_artifact_ids: opts.sourceArtifactIds ?? [],
+      created_at: nowIso(),
+      started_at: null,
+      completed_at: null,
+      result_artifact_id: null,
+      error_message: null,
+      training_config: opts.trainingConfig ?? {},
+      training_metrics: {},
+    };
+    this.#writeJob(job);
+    return job;
+  }
+
+  listJobs(scenario?: string): DistillJob[] {
+    if (!existsSync(this.#jobsDir)) {
+      return [];
+    }
+    return readdirSync(this.#jobsDir)
+      .filter((name) => name.endsWith(".json"))
+      .sort()
+      .map((name) => this.#readJobFromPath(join(this.#jobsDir, name)))
+      .filter((job): job is DistillJob => job !== null)
+      .filter((job) => scenario === undefined || job.scenario === scenario);
+  }
+
+  getJob(jobId: string): DistillJob | null {
+    return this.#readJobFromPath(this.#jobPath(jobId));
+  }
+
+  transition(
+    jobId: string,
+    targetStatus: DistillJobStatus,
+    opts: {
+      resultArtifactId?: string | null;
+      errorMessage?: string | null;
+      trainingMetrics?: Record<string, unknown> | null;
+    } = {},
+  ): DistillJob | null {
+    const job = this.getJob(jobId);
+    if (!job) return null;
+
+    const allowed = VALID_TRANSITIONS[job.status];
+    if (!allowed.has(targetStatus)) {
+      throw new DistillJobError(
+        `Invalid transition: ${job.status} -> ${targetStatus} (allowed: ${allowed.size > 0 ? [...allowed].join(", ") : "none"})`,
+      );
+    }
+    if (targetStatus === "completed" && !(opts.resultArtifactId ?? job.result_artifact_id)) {
+      throw new DistillJobError("Completed distill jobs require a result_artifact_id");
+    }
+    if (targetStatus === "failed" && !(opts.errorMessage ?? job.error_message)) {
+      throw new DistillJobError("Failed distill jobs require an error_message");
+    }
+
+    const timestamp = nowIso();
+    job.status = targetStatus;
+    if (targetStatus === "running") {
+      job.started_at = timestamp;
+    }
+    if (targetStatus === "completed" || targetStatus === "failed") {
+      job.completed_at = timestamp;
+    }
+    if (opts.resultArtifactId !== undefined) {
+      job.result_artifact_id = opts.resultArtifactId;
+    }
+    if (opts.errorMessage !== undefined) {
+      job.error_message = opts.errorMessage;
+    }
+    if (opts.trainingMetrics !== undefined && opts.trainingMetrics !== null) {
+      job.training_metrics = opts.trainingMetrics;
+    }
+    this.#writeJob(job);
+    return job;
+  }
+
+  activeJobCount(): number {
+    return this.listJobs().filter((job) => job.status === "pending" || job.status === "running").length;
+  }
+
+  #jobPath(jobId: string): string {
+    return join(this.#jobsDir, `${jobId}.json`);
+  }
+
+  #readJobFromPath(path: string): DistillJob | null {
+    if (!existsSync(path)) {
+      return null;
+    }
+    try {
+      return parseJob(JSON.parse(readFileSync(path, "utf-8")) as unknown);
+    } catch {
+      return null;
+    }
+  }
+
+  #writeJob(job: DistillJob): void {
+    mkdirSync(this.#jobsDir, { recursive: true });
+    writeFileSync(this.#jobPath(job.job_id), JSON.stringify(job, null, 2) + "\n", "utf-8");
+  }
+}

--- a/ts/src/openclaw/service.ts
+++ b/ts/src/openclaw/service.ts
@@ -11,14 +11,19 @@ import type { SQLiteStore } from "../storage/index.js";
 import { SCENARIO_REGISTRY } from "../scenarios/registry.js";
 import { detectFamily } from "../scenarios/family-interfaces.js";
 import type { ScenarioInterface } from "../scenarios/game-interface.js";
-import { DistillJobError, DistillJobStore, type DistillJob, type DistillJobStatus } from "./distill-job-store.js";
+import { ensureSafeArtifactId, validateOpenClawArtifactPayload } from "./artifact-contract.js";
+import {
+  DistillJobError,
+  DistillJobStore,
+  isDistillJobStatus,
+  type DistillJob,
+  type DistillJobStatus,
+} from "./distill-job-store.js";
 
 const require = createRequire(import.meta.url);
 const pkg = require("../../package.json") as { version: string };
 
 const DISCOVERY_VERSION = "0.1.0";
-const ARTIFACT_TYPES = new Set(["harness", "policy", "distilled_model"]);
-const SAFE_FILE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
 export interface OpenClawServiceOpts {
   knowledgeRoot: string;
@@ -89,13 +94,6 @@ function readStringList(body: Record<string, unknown>, key: string): string[] {
   return value;
 }
 
-function ensureSafeArtifactId(artifactId: string): string {
-  if (!SAFE_FILE_ID.test(artifactId)) {
-    throw new Error(`invalid artifact id: ${artifactId}`);
-  }
-  return artifactId;
-}
-
 function toHarnessModuleName(artifactId: string): string {
   return `openclaw_${artifactId.replace(/[^A-Za-z0-9_]/g, "_")}`;
 }
@@ -118,7 +116,7 @@ function artifactPath(knowledgeRoot: string, artifactId: string): string {
 
 function readJsonRecord(path: string): Record<string, unknown> | null {
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
     return isRecord(parsed) ? parsed : null;
   } catch {
     return null;
@@ -233,20 +231,7 @@ export class OpenClawService {
   }
 
   publishArtifact(body: Record<string, unknown>): Record<string, unknown> {
-    const artifactType = readRequiredString(body, "artifact_type");
-    if (!ARTIFACT_TYPES.has(artifactType)) {
-      throw new Error(
-        `Invalid or missing artifact_type: ${artifactType}. Must be harness, policy, or distilled_model.`,
-      );
-    }
-    const artifactId = ensureSafeArtifactId(readRequiredString(body, "id"));
-    const scenario = readRequiredString(body, "scenario");
-    const data: Record<string, unknown> = {
-      ...body,
-      id: artifactId,
-      artifact_type: artifactType,
-      scenario,
-    };
+    const { artifactId, artifactType, scenario, data } = validateOpenClawArtifactPayload(body);
     const path = artifactPath(this.#knowledgeRoot, artifactId);
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, JSON.stringify(data, null, 2) + "\n", "utf-8");
@@ -353,13 +338,13 @@ export class OpenClawService {
 
   updateDistillJob(jobId: string, body: Record<string, unknown>): DistillJob | null {
     const status = readRequiredString(body, "status");
-    if (!["pending", "running", "completed", "failed"].includes(status)) {
+    if (!isDistillJobStatus(status)) {
       throw new DistillJobError(`Invalid distill job status: ${status}`);
     }
     const trainingMetrics = body.training_metrics === undefined || body.training_metrics === null
       ? null
       : readRecord(body, "training_metrics");
-    return this.#distillJobs.transition(jobId, status as DistillJobStatus, {
+    return this.#distillJobs.transition(jobId, status, {
       resultArtifactId: readOptionalString(body, "result_artifact_id") ?? null,
       errorMessage: readOptionalString(body, "error_message") ?? null,
       trainingMetrics,

--- a/ts/src/openclaw/service.ts
+++ b/ts/src/openclaw/service.ts
@@ -1,0 +1,562 @@
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+import { getConceptModel } from "../concepts/model.js";
+import type { AppSettings } from "../config/index.js";
+import { HarnessStore } from "../knowledge/harness-store.js";
+import { getCapabilities } from "../mcp/capabilities.js";
+import type { SQLiteStore } from "../storage/index.js";
+import { SCENARIO_REGISTRY } from "../scenarios/registry.js";
+import { detectFamily } from "../scenarios/family-interfaces.js";
+import type { ScenarioInterface } from "../scenarios/game-interface.js";
+import { DistillJobError, DistillJobStore, type DistillJob, type DistillJobStatus } from "./distill-job-store.js";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { version: string };
+
+const DISCOVERY_VERSION = "0.1.0";
+const ARTIFACT_TYPES = new Set(["harness", "policy", "distilled_model"]);
+const SAFE_FILE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export interface OpenClawServiceOpts {
+  knowledgeRoot: string;
+  settings: AppSettings;
+  openStore: () => SQLiteStore;
+}
+
+export interface ArtifactSummary {
+  id: string;
+  name: string;
+  artifact_type: string;
+  scenario: string;
+  version: number;
+}
+
+export interface ScenarioCapabilities {
+  scenario_name: string;
+  evaluation_mode: string;
+  has_harness: boolean;
+  has_policy: boolean;
+  has_playbook: boolean;
+  harness_count: number;
+  best_score: number | null;
+  best_elo: number | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readRequiredString(body: Record<string, unknown>, key: string): string {
+  const value = body[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${key} is required`);
+  }
+  return value.trim();
+}
+
+function readOptionalString(body: Record<string, unknown>, key: string): string | undefined {
+  const value = body[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readInteger(body: Record<string, unknown>, key: string, fallback: number, min: number, max: number): number {
+  const value = body[key];
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, value));
+}
+
+function readRecord(body: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = body[key];
+  if (!isRecord(value)) {
+    throw new Error(`${key} is required`);
+  }
+  return value;
+}
+
+function readStringList(body: Record<string, unknown>, key: string): string[] {
+  const value = body[key];
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
+    throw new Error(`${key} must be a list of strings`);
+  }
+  return value;
+}
+
+function ensureSafeArtifactId(artifactId: string): string {
+  if (!SAFE_FILE_ID.test(artifactId)) {
+    throw new Error(`invalid artifact id: ${artifactId}`);
+  }
+  return artifactId;
+}
+
+function toHarnessModuleName(artifactId: string): string {
+  return `openclaw_${artifactId.replace(/[^A-Za-z0-9_]/g, "_")}`;
+}
+
+function humanizeScenarioName(name: string): string {
+  return name
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function artifactDir(knowledgeRoot: string): string {
+  return join(knowledgeRoot, "_openclaw_artifacts");
+}
+
+function artifactPath(knowledgeRoot: string, artifactId: string): string {
+  return join(artifactDir(knowledgeRoot), `${ensureSafeArtifactId(artifactId)}.json`);
+}
+
+function readJsonRecord(path: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function listArtifactRecords(knowledgeRoot: string): Record<string, unknown>[] {
+  const dir = artifactDir(knowledgeRoot);
+  if (!existsSync(dir)) {
+    return [];
+  }
+  return readdirSync(dir)
+    .filter((name) => name.endsWith(".json"))
+    .sort()
+    .map((name) => readJsonRecord(join(dir, name)))
+    .filter((record): record is Record<string, unknown> => record !== null);
+}
+
+function buildArtifactSummary(data: Record<string, unknown>, fallbackId: string): ArtifactSummary {
+  return {
+    id: typeof data.id === "string" ? data.id : fallbackId,
+    name: typeof data.name === "string" ? data.name : "",
+    artifact_type: typeof data.artifact_type === "string" ? data.artifact_type : "",
+    scenario: typeof data.scenario === "string" ? data.scenario : "",
+    version: typeof data.version === "number" ? data.version : 0,
+  };
+}
+
+function parseCommandLine(command: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quote: "'" | "\"" | null = null;
+  for (let i = 0; i < command.length; i += 1) {
+    const char = command[i]!;
+    if ((char === "'" || char === "\"") && quote === null) {
+      quote = char;
+      continue;
+    }
+    if (char === quote) {
+      quote = null;
+      continue;
+    }
+    if (/\s/.test(char) && quote === null) {
+      if (current) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current) {
+    parts.push(current);
+  }
+  return parts;
+}
+
+function applyCommandTemplate(commandTemplate: string, job: DistillJob): string {
+  return commandTemplate
+    .replaceAll("{job_id}", job.job_id)
+    .replaceAll("{scenario}", job.scenario);
+}
+
+export class OpenClawService {
+  readonly #knowledgeRoot: string;
+  readonly #settings: AppSettings;
+  readonly #openStore: () => SQLiteStore;
+  readonly #distillJobs: DistillJobStore;
+
+  constructor(opts: OpenClawServiceOpts) {
+    this.#knowledgeRoot = opts.knowledgeRoot;
+    this.#settings = opts.settings;
+    this.#openStore = opts.openStore;
+    this.#distillJobs = new DistillJobStore(opts.knowledgeRoot);
+  }
+
+  evaluateStrategy(body: Record<string, unknown>): Record<string, unknown> {
+    const scenarioName = readRequiredString(body, "scenario_name");
+    const strategy = readRecord(body, "strategy");
+    const numMatches = readInteger(body, "num_matches", 3, 1, 100);
+    const seedBase = readInteger(body, "seed_base", 42, Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
+    const scenario = this.#loadGameScenario(scenarioName);
+    const scores: number[] = [];
+    for (let i = 0; i < numMatches; i += 1) {
+      const result = scenario.executeMatch(strategy, seedBase + i);
+      scores.push(result.score);
+    }
+    return {
+      scenario: scenarioName,
+      matches: numMatches,
+      scores,
+      mean_score: scores.length > 0 ? scores.reduce((sum, score) => sum + score, 0) / scores.length : 0,
+      best_score: scores.length > 0 ? Math.max(...scores) : 0,
+    };
+  }
+
+  validateStrategy(body: Record<string, unknown>): Record<string, unknown> {
+    const scenarioName = readRequiredString(body, "scenario_name");
+    const strategy = readRecord(body, "strategy");
+    const scenario = this.#loadGameScenario(scenarioName);
+    const state = scenario.initialState(42);
+    const [valid, reason] = scenario.validateActions(state, "challenger", strategy);
+    const harnessLoaded = this.#listHarnessModules(scenarioName);
+    return {
+      valid,
+      reason,
+      scenario: scenarioName,
+      harness_loaded: harnessLoaded,
+      harness_passed: valid,
+      harness_errors: valid ? [] : [reason],
+    };
+  }
+
+  publishArtifact(body: Record<string, unknown>): Record<string, unknown> {
+    const artifactType = readRequiredString(body, "artifact_type");
+    if (!ARTIFACT_TYPES.has(artifactType)) {
+      throw new Error(
+        `Invalid or missing artifact_type: ${artifactType}. Must be harness, policy, or distilled_model.`,
+      );
+    }
+    const artifactId = ensureSafeArtifactId(readRequiredString(body, "id"));
+    const scenario = readRequiredString(body, "scenario");
+    const data: Record<string, unknown> = {
+      ...body,
+      id: artifactId,
+      artifact_type: artifactType,
+      scenario,
+    };
+    const path = artifactPath(this.#knowledgeRoot, artifactId);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(data, null, 2) + "\n", "utf-8");
+
+    if (artifactType === "harness" && typeof data.source_code === "string" && data.source_code.trim()) {
+      new HarnessStore(this.#knowledgeRoot, scenario)
+        .writeVersioned(toHarnessModuleName(artifactId), data.source_code, 0);
+    }
+
+    return {
+      status: "published",
+      artifact_id: artifactId,
+      artifact_type: artifactType,
+      path,
+    };
+  }
+
+  listArtifacts(params: URLSearchParams): ArtifactSummary[] {
+    const scenario = params.get("scenario") ?? undefined;
+    const artifactType = params.get("artifact_type") ?? undefined;
+    return listArtifactRecords(this.#knowledgeRoot)
+      .filter((data) => scenario === undefined || data.scenario === scenario)
+      .filter((data) => artifactType === undefined || data.artifact_type === artifactType)
+      .map((data) => buildArtifactSummary(data, typeof data.id === "string" ? data.id : ""));
+  }
+
+  fetchArtifact(artifactId: string): Record<string, unknown> | null {
+    return readJsonRecord(artifactPath(this.#knowledgeRoot, artifactId));
+  }
+
+  distillStatus(params: URLSearchParams): Record<string, unknown> {
+    const scenario = params.get("scenario") ?? undefined;
+    const jobs = this.#distillJobs.listJobs(scenario);
+    return {
+      active_jobs: jobs.filter((job) => job.status === "pending" || job.status === "running").length,
+      jobs,
+    };
+  }
+
+  triggerDistillation(body: Record<string, unknown>): Record<string, unknown> {
+    const scenario = readRequiredString(body, "scenario");
+    const sourceArtifactIds = readStringList(body, "source_artifact_ids");
+    const trainingConfig = body.training_config === undefined
+      ? {}
+      : readRecord(body, "training_config");
+    const job = this.#distillJobs.createJob({ scenario, sourceArtifactIds, trainingConfig });
+    const commandTemplate = this.#settings.openclawDistillSidecarCommand.trim();
+    if (!commandTemplate) {
+      const errorMessage = (
+        "No distillation sidecar configured. Set " +
+        "AUTOCONTEXT_OPENCLAW_DISTILL_SIDECAR_COMMAND."
+      );
+      const failed = this.#distillJobs.transition(job.job_id, "failed", { errorMessage });
+      return {
+        error: errorMessage,
+        job_id: failed?.job_id ?? job.job_id,
+        status: failed?.status ?? "failed",
+        scenario: failed?.scenario ?? job.scenario,
+      };
+    }
+
+    const command = parseCommandLine(applyCommandTemplate(commandTemplate, job));
+    if (command.length === 0) {
+      const errorMessage = "AUTOCONTEXT_OPENCLAW_DISTILL_SIDECAR_COMMAND is empty after template expansion.";
+      const failed = this.#distillJobs.transition(job.job_id, "failed", { errorMessage });
+      return {
+        error: errorMessage,
+        job_id: failed?.job_id ?? job.job_id,
+        status: failed?.status ?? "failed",
+        scenario: failed?.scenario ?? job.scenario,
+      };
+    }
+
+    const [bin, ...args] = command;
+    try {
+      const child = spawn(bin!, args, {
+        cwd: dirname(this.#knowledgeRoot),
+        detached: true,
+        stdio: "ignore",
+        env: {
+          ...process.env,
+          AUTOCONTEXT_DISTILL_JOB_ID: job.job_id,
+          AUTOCONTEXT_DISTILL_SCENARIO: job.scenario,
+          AUTOCONTEXT_DISTILL_TRAINING_CONFIG: JSON.stringify(job.training_config),
+        },
+      });
+      child.unref();
+      return { ...(this.#distillJobs.transition(job.job_id, "running") ?? job) };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const failed = this.#distillJobs.transition(job.job_id, "failed", { errorMessage: message });
+      return {
+        error: message,
+        job_id: failed?.job_id ?? job.job_id,
+        status: failed?.status ?? "failed",
+        scenario: failed?.scenario ?? job.scenario,
+      };
+    }
+  }
+
+  getDistillJob(jobId: string): DistillJob | null {
+    return this.#distillJobs.getJob(jobId);
+  }
+
+  updateDistillJob(jobId: string, body: Record<string, unknown>): DistillJob | null {
+    const status = readRequiredString(body, "status");
+    if (!["pending", "running", "completed", "failed"].includes(status)) {
+      throw new DistillJobError(`Invalid distill job status: ${status}`);
+    }
+    const trainingMetrics = body.training_metrics === undefined || body.training_metrics === null
+      ? null
+      : readRecord(body, "training_metrics");
+    return this.#distillJobs.transition(jobId, status as DistillJobStatus, {
+      resultArtifactId: readOptionalString(body, "result_artifact_id") ?? null,
+      errorMessage: readOptionalString(body, "error_message") ?? null,
+      trainingMetrics,
+    });
+  }
+
+  capabilities(): Record<string, unknown> {
+    return getCapabilities() as unknown as Record<string, unknown>;
+  }
+
+  advertiseCapabilities(): Record<string, unknown> {
+    const scenarioCapabilities: Record<string, ScenarioCapabilities> = {};
+    for (const scenarioName of Object.keys(SCENARIO_REGISTRY).sort()) {
+      try {
+        scenarioCapabilities[scenarioName] = this.discoverScenarioCapabilities(scenarioName);
+      } catch {
+        // Keep capability discovery resilient, matching Python's best-effort behavior.
+      }
+    }
+    return {
+      version: DISCOVERY_VERSION,
+      runtime_health: this.runtimeHealth(),
+      concept_model: getConceptModel(),
+      scenario_capabilities: scenarioCapabilities,
+      artifact_counts: this.#artifactCounts(),
+    };
+  }
+
+  discoverScenarioCapabilities(scenarioName: string): ScenarioCapabilities {
+    const ScenarioClass = SCENARIO_REGISTRY[scenarioName];
+    if (!ScenarioClass) {
+      throw new Error(`Scenario '${scenarioName}' not found`);
+    }
+    const scenario = new ScenarioClass();
+    const family = detectFamily(scenario);
+    if (family === null) {
+      throw new Error(`Unable to determine scenario family for '${scenarioName}'`);
+    }
+    const harness = new HarnessStore(this.#knowledgeRoot, scenarioName);
+    const harnessModules = harness.listHarness();
+    const best = this.#getBestGenerationMetrics(scenarioName);
+    return {
+      scenario_name: scenarioName,
+      evaluation_mode: family === "agent_task" ? "judge" : family === "game" ? "tournament" : family,
+      has_harness: harnessModules.length > 0,
+      has_policy: this.#hasPolicyArtifact(scenarioName),
+      has_playbook: this.#hasPlaybook(scenarioName),
+      harness_count: harnessModules.length,
+      best_score: best?.best_score ?? null,
+      best_elo: best?.elo ?? null,
+    };
+  }
+
+  runtimeHealth(): Record<string, unknown> {
+    return {
+      executor_mode: this.#settings.executorMode,
+      agent_provider: this.#settings.agentProvider,
+      harness_mode: this.#settings.harnessMode,
+      rlm_enabled: this.#settings.rlmEnabled,
+      available_models: {
+        competitor: this.#settings.modelCompetitor,
+        analyst: this.#settings.modelAnalyst,
+        coach: this.#settings.modelCoach,
+        architect: this.#settings.modelArchitect,
+        judge: this.#settings.judgeModel,
+      },
+      openclaw_runtime_kind: this.#settings.openclawRuntimeKind.trim() || null,
+      openclaw_compatibility_version: this.#settings.openclawCompatibilityVersion.trim() || null,
+    };
+  }
+
+  scenarioArtifactLookup(scenarioName: string): Array<Record<string, unknown>> {
+    return listArtifactRecords(this.#knowledgeRoot)
+      .filter((data) => data.scenario === scenarioName)
+      .map((data) => ({
+        artifact_id: typeof data.id === "string" ? data.id : "",
+        name: typeof data.name === "string" ? data.name : "",
+        artifact_type: typeof data.artifact_type === "string" ? data.artifact_type : "",
+        scenario: typeof data.scenario === "string" ? data.scenario : "",
+        version: typeof data.version === "number" ? data.version : 0,
+      }));
+  }
+
+  skillManifest(): Record<string, unknown> {
+    return {
+      name: "autocontext",
+      version: pkg.version,
+      description: "autocontext iterative strategy evolution and evaluation system",
+      capabilities: [
+        "scenario_evaluation",
+        "strategy_validation",
+        "artifact_management",
+        "knowledge_export",
+        "strategy_search",
+      ],
+      scenarios: Object.keys(SCENARIO_REGISTRY).sort().map((name) => this.#scenarioInfo(name)),
+      mcp_tools: [
+        "autocontext_capabilities",
+        "autocontext_list_scenarios",
+        "autocontext_describe_scenario",
+        "autocontext_run_match",
+        "autocontext_run_tournament",
+        "autocontext_read_playbook",
+        "autocontext_list_solved",
+        "autocontext_search_strategies",
+        "autocontext_solve_scenario",
+        "autocontext_solve_status",
+        "autocontext_solve_result",
+      ],
+      rest_base_path: "/api/openclaw",
+    };
+  }
+
+  #loadGameScenario(scenarioName: string): ScenarioInterface {
+    const ScenarioClass = SCENARIO_REGISTRY[scenarioName];
+    if (!ScenarioClass) {
+      const supported = Object.keys(SCENARIO_REGISTRY).sort().join(", ");
+      throw new Error(`Unknown scenario '${scenarioName}'. Available: ${supported}`);
+    }
+    return new ScenarioClass();
+  }
+
+  #listHarnessModules(scenarioName: string): string[] {
+    try {
+      return new HarnessStore(this.#knowledgeRoot, scenarioName).listHarness();
+    } catch {
+      return [];
+    }
+  }
+
+  #hasPlaybook(scenarioName: string): boolean {
+    const path = join(this.#knowledgeRoot, scenarioName, "playbook.md");
+    if (!existsSync(path)) return false;
+    return readFileSync(path, "utf-8").trim().length > 0;
+  }
+
+  #hasPolicyArtifact(scenarioName: string): boolean {
+    return listArtifactRecords(this.#knowledgeRoot)
+      .some((artifact) => artifact.artifact_type === "policy" && artifact.scenario === scenarioName);
+  }
+
+  #artifactCounts(): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const artifact of listArtifactRecords(this.#knowledgeRoot)) {
+      if (typeof artifact.artifact_type !== "string" || !artifact.artifact_type) continue;
+      counts[artifact.artifact_type] = (counts[artifact.artifact_type] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  #getBestGenerationMetrics(scenarioName: string): { best_score: number | null; elo: number | null } | null {
+    return this.#withStore((store) => {
+      const completedBest = store.getBestGenerationForScenario(scenarioName);
+      if (completedBest) {
+        return { best_score: completedBest.best_score, elo: completedBest.elo };
+      }
+      let fallback: { best_score: number | null; elo: number | null } | null = null;
+      for (const run of store.listRuns(200, scenarioName)) {
+        for (const generation of store.getGenerations(run.run_id)) {
+          if (generation.status !== "completed") {
+            continue;
+          }
+          if (
+            fallback === null
+            || (generation.best_score ?? Number.NEGATIVE_INFINITY) > (fallback.best_score ?? Number.NEGATIVE_INFINITY)
+            || (
+              generation.best_score === fallback.best_score
+              && (generation.elo ?? Number.NEGATIVE_INFINITY) > (fallback.elo ?? Number.NEGATIVE_INFINITY)
+            )
+          ) {
+            fallback = { best_score: generation.best_score, elo: generation.elo };
+          }
+        }
+      }
+      return fallback;
+    });
+  }
+
+  #scenarioInfo(name: string): Record<string, unknown> {
+    const ScenarioClass = SCENARIO_REGISTRY[name]!;
+    const scenario = new ScenarioClass();
+    const family = detectFamily(scenario);
+    return {
+      name,
+      display_name: humanizeScenarioName(name),
+      scenario_type: family === "game" ? "parametric" : family ?? "unknown",
+      description: scenario.describeRules().slice(0, 500),
+      strategy_interface: scenario.describeStrategyInterface(),
+    };
+  }
+
+  #withStore<T>(fn: (store: SQLiteStore) => T): T {
+    const store = this.#openStore();
+    try {
+      return fn(store);
+    } finally {
+      store.close();
+    }
+  }
+}

--- a/ts/src/server/http-api-parity.ts
+++ b/ts/src/server/http-api-parity.ts
@@ -28,6 +28,7 @@ export interface HttpApiParityMatrix {
 
 const PY_APP = "autocontext/src/autocontext/server/app.py";
 const TS_SERVER = "ts/src/server/ws-server.ts";
+const PY_OPENCLAW_API = "autocontext/src/autocontext/server/openclaw_api.py";
 
 function both(
   domain: string,
@@ -229,23 +230,21 @@ export const HTTP_API_PARITY_ROUTES: readonly HttpApiParityEntry[] = [
     ["POST", "/api/hub/promotions"],
     ["GET", "/api/hub/feed"],
   ]),
-  ...pythonOnlyRoutes("openclaw", "autocontext/src/autocontext/server/openclaw_api.py", [
-    ["POST", "/api/openclaw/evaluate"],
-    ["POST", "/api/openclaw/validate"],
-    ["POST", "/api/openclaw/artifacts"],
-    ["GET", "/api/openclaw/artifacts"],
-    ["GET", "/api/openclaw/artifacts/:artifact_id"],
-    ["GET", "/api/openclaw/distill"],
-    ["POST", "/api/openclaw/distill"],
-    ["GET", "/api/openclaw/distill/:job_id"],
-    ["PATCH", "/api/openclaw/distill/:job_id"],
-    ["GET", "/api/openclaw/capabilities"],
-    ["GET", "/api/openclaw/discovery/capabilities"],
-    ["GET", "/api/openclaw/discovery/scenario/:scenario_name"],
-    ["GET", "/api/openclaw/discovery/health"],
-    ["GET", "/api/openclaw/discovery/scenario/:scenario_name/artifacts"],
-    ["GET", "/api/openclaw/skill/manifest"],
-  ]),
+  both("openclaw", "POST", "/api/openclaw/evaluate", PY_OPENCLAW_API),
+  both("openclaw", "POST", "/api/openclaw/validate", PY_OPENCLAW_API),
+  both("openclaw", "POST", "/api/openclaw/artifacts", PY_OPENCLAW_API),
+  both("openclaw", "GET", "/api/openclaw/artifacts", PY_OPENCLAW_API),
+  both("openclaw", "GET", "/api/openclaw/artifacts/:artifact_id", PY_OPENCLAW_API),
+  both("openclaw", "GET", "/api/openclaw/distill", PY_OPENCLAW_API),
+  both("openclaw", "POST", "/api/openclaw/distill", PY_OPENCLAW_API),
+  both("openclaw", "GET", "/api/openclaw/distill/:job_id", PY_OPENCLAW_API),
+  both("openclaw", "PATCH", "/api/openclaw/distill/:job_id", PY_OPENCLAW_API),
+  both("openclaw", "GET", "/api/openclaw/capabilities", PY_OPENCLAW_API),
+  both("openclaw", "GET", "/api/openclaw/discovery/capabilities", PY_OPENCLAW_API),
+  both("openclaw", "GET", "/api/openclaw/discovery/scenario/:scenario_name", PY_OPENCLAW_API),
+  both("openclaw", "GET", "/api/openclaw/discovery/health", PY_OPENCLAW_API),
+  both("openclaw", "GET", "/api/openclaw/discovery/scenario/:scenario_name/artifacts", PY_OPENCLAW_API),
+  both("openclaw", "GET", "/api/openclaw/skill/manifest", PY_OPENCLAW_API),
 ];
 
 function pythonOnlyRoutes(

--- a/ts/src/server/openclaw-api.ts
+++ b/ts/src/server/openclaw-api.ts
@@ -1,0 +1,90 @@
+import type { AppSettings } from "../config/index.js";
+import { DistillJobError } from "../openclaw/distill-job-store.js";
+import { OpenClawService } from "../openclaw/service.js";
+import type { SQLiteStore } from "../storage/index.js";
+
+export interface OpenClawApiResponse {
+  status: number;
+  body: unknown;
+}
+
+export interface OpenClawApiRoutes {
+  evaluate(body: Record<string, unknown>): OpenClawApiResponse;
+  validate(body: Record<string, unknown>): OpenClawApiResponse;
+  publishArtifact(body: Record<string, unknown>): OpenClawApiResponse;
+  listArtifacts(params: URLSearchParams): OpenClawApiResponse;
+  fetchArtifact(artifactId: string): OpenClawApiResponse;
+  distillStatus(params: URLSearchParams): OpenClawApiResponse;
+  triggerDistillation(body: Record<string, unknown>): OpenClawApiResponse;
+  getDistillJob(jobId: string): OpenClawApiResponse;
+  updateDistillJob(jobId: string, body: Record<string, unknown>): OpenClawApiResponse;
+  capabilities(): OpenClawApiResponse;
+  discoveryCapabilities(): OpenClawApiResponse;
+  discoveryScenario(scenarioName: string): OpenClawApiResponse;
+  discoveryHealth(): OpenClawApiResponse;
+  discoveryScenarioArtifacts(scenarioName: string): OpenClawApiResponse;
+  skillManifest(): OpenClawApiResponse;
+}
+
+export function buildOpenClawApiRoutes(opts: {
+  knowledgeRoot: string;
+  settings: AppSettings;
+  openStore: () => SQLiteStore;
+}): OpenClawApiRoutes {
+  const service = new OpenClawService(opts);
+  return {
+    evaluate: (body) => mapErrorToResponse(() => ({ status: 200, body: service.evaluateStrategy(body) })),
+    validate: (body) => mapErrorToResponse(() => ({ status: 200, body: service.validateStrategy(body) })),
+    publishArtifact: (body) => mapErrorToResponse(() => ({ status: 200, body: service.publishArtifact(body) })),
+    listArtifacts: (params) => ({ status: 200, body: service.listArtifacts(params) }),
+    fetchArtifact: (artifactId) => mapErrorToResponse(() => {
+      const artifact = service.fetchArtifact(artifactId);
+      return artifact
+        ? { status: 200, body: artifact }
+        : { status: 404, body: { detail: `Artifact '${artifactId}' not found` } };
+    }),
+    distillStatus: (params) => ({ status: 200, body: service.distillStatus(params) }),
+    triggerDistillation: (body) => mapErrorToResponse(() => {
+      const result = service.triggerDistillation(body);
+      return "error" in result
+        ? { status: 400, body: result }
+        : { status: 200, body: result };
+    }),
+    getDistillJob: (jobId) => {
+      const job = service.getDistillJob(jobId);
+      return job
+        ? { status: 200, body: job }
+        : { status: 404, body: { detail: `Distillation job '${jobId}' not found` } };
+    },
+    updateDistillJob: (jobId, body) => mapErrorToResponse(() => {
+      const job = service.updateDistillJob(jobId, body);
+      return job
+        ? { status: 200, body: job }
+        : { status: 404, body: { detail: `Distillation job '${jobId}' not found` } };
+    }),
+    capabilities: () => ({ status: 200, body: service.capabilities() }),
+    discoveryCapabilities: () => ({ status: 200, body: service.advertiseCapabilities() }),
+    discoveryScenario: (scenarioName) => mapErrorToResponse(
+      () => ({ status: 200, body: service.discoverScenarioCapabilities(scenarioName) }),
+      404,
+    ),
+    discoveryHealth: () => ({ status: 200, body: service.runtimeHealth() }),
+    discoveryScenarioArtifacts: (scenarioName) => ({
+      status: 200,
+      body: service.scenarioArtifactLookup(scenarioName),
+    }),
+    skillManifest: () => ({ status: 200, body: service.skillManifest() }),
+  };
+}
+
+function mapErrorToResponse(fn: () => OpenClawApiResponse, defaultStatus = 400): OpenClawApiResponse {
+  try {
+    return fn();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      status: error instanceof DistillJobError ? 400 : defaultStatus,
+      body: { detail: message },
+    };
+  }
+}

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -35,6 +35,7 @@ import { buildMissionApiRoutes } from "./mission-api.js";
 import { buildMonitorApiRoutes } from "./monitor-api.js";
 import { MonitorEngine } from "./monitor-engine.js";
 import { buildNotebookApiRoutes } from "./notebook-api.js";
+import { buildOpenClawApiRoutes } from "./openclaw-api.js";
 import { buildSimulationApiRoutes } from "./simulation-api.js";
 import { renderDashboardHtml } from "./simulation-dashboard.js";
 import { buildSessionBootstrapMessages, buildStateMessage } from "./websocket-session-bootstrap.js";
@@ -47,6 +48,7 @@ import { loadSettings, type AppSettings } from "../config/index.js";
 import { SQLiteStore } from "../storage/index.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import { SolveManager } from "../knowledge/solver.js";
+import { loadSettings } from "../config/index.js";
 
 export interface InteractiveServerOpts {
   runManager: RunManager;
@@ -192,6 +194,11 @@ export class InteractiveServer {
       defaultHeartbeatTimeoutSeconds: settings.monitorHeartbeatTimeout,
       maxConditions: settings.monitorMaxConditions,
     });
+    const openClawApi = buildOpenClawApiRoutes({
+      knowledgeRoot: this.#runManager.getKnowledgeRoot(),
+      settings: loadSettings(),
+      openStore: () => this.#openStore(),
+    });
     const simulationApi = buildSimulationApiRoutes(this.#runManager.getKnowledgeRoot());
 
     // CORS headers for dashboard
@@ -241,6 +248,7 @@ export class InteractiveServer {
           missions: "/api/missions",
           monitors: "/api/monitors",
           notebooks: "/api/notebooks",
+          openclaw: "/api/openclaw",
           websocket: "/ws/interactive",
           events: "/ws/events",
         },
@@ -331,6 +339,122 @@ export class InteractiveServer {
     if (method === "DELETE" && monitorMatch) {
       const [, rawConditionId] = monitorMatch;
       const response = monitorApi.delete(decodeURIComponent(rawConditionId!));
+      json(response.status, response.body);
+      return;
+    }
+
+    // POST /api/openclaw/evaluate
+    if (method === "POST" && url === "/api/openclaw/evaluate") {
+      const response = openClawApi.evaluate(await this.#readJsonBody(req));
+      json(response.status, response.body);
+      return;
+    }
+
+    // POST /api/openclaw/validate
+    if (method === "POST" && url === "/api/openclaw/validate") {
+      const response = openClawApi.validate(await this.#readJsonBody(req));
+      json(response.status, response.body);
+      return;
+    }
+
+    // GET/POST /api/openclaw/artifacts
+    if (url === "/api/openclaw/artifacts" || url === "/api/openclaw/artifacts/") {
+      if (method === "GET") {
+        const response = openClawApi.listArtifacts(requestUrl.searchParams);
+        json(response.status, response.body);
+        return;
+      }
+      if (method === "POST") {
+        const response = openClawApi.publishArtifact(await this.#readJsonBody(req));
+        json(response.status, response.body);
+        return;
+      }
+    }
+
+    // GET /api/openclaw/artifacts/:artifactId
+    const openClawArtifactMatch = url.match(/^\/api\/openclaw\/artifacts\/([^/]+)$/);
+    if (method === "GET" && openClawArtifactMatch) {
+      const [, rawArtifactId] = openClawArtifactMatch;
+      const response = openClawApi.fetchArtifact(decodeURIComponent(rawArtifactId!));
+      json(response.status, response.body);
+      return;
+    }
+
+    // GET/POST /api/openclaw/distill
+    if (url === "/api/openclaw/distill" || url === "/api/openclaw/distill/") {
+      if (method === "GET") {
+        const response = openClawApi.distillStatus(requestUrl.searchParams);
+        json(response.status, response.body);
+        return;
+      }
+      if (method === "POST") {
+        const response = openClawApi.triggerDistillation(await this.#readJsonBody(req));
+        json(response.status, response.body);
+        return;
+      }
+    }
+
+    // GET/PATCH /api/openclaw/distill/:jobId
+    const openClawDistillMatch = url.match(/^\/api\/openclaw\/distill\/([^/]+)$/);
+    if (openClawDistillMatch) {
+      const [, rawJobId] = openClawDistillMatch;
+      const jobId = decodeURIComponent(rawJobId!);
+      if (method === "GET") {
+        const response = openClawApi.getDistillJob(jobId);
+        json(response.status, response.body);
+        return;
+      }
+      if (method === "PATCH") {
+        const response = openClawApi.updateDistillJob(jobId, await this.#readJsonBody(req));
+        json(response.status, response.body);
+        return;
+      }
+    }
+
+    // GET /api/openclaw/capabilities
+    if (method === "GET" && url === "/api/openclaw/capabilities") {
+      const response = openClawApi.capabilities();
+      json(response.status, response.body);
+      return;
+    }
+
+    // GET /api/openclaw/discovery/capabilities
+    if (method === "GET" && url === "/api/openclaw/discovery/capabilities") {
+      const response = openClawApi.discoveryCapabilities();
+      json(response.status, response.body);
+      return;
+    }
+
+    // GET /api/openclaw/discovery/health
+    if (method === "GET" && url === "/api/openclaw/discovery/health") {
+      const response = openClawApi.discoveryHealth();
+      json(response.status, response.body);
+      return;
+    }
+
+    // GET /api/openclaw/discovery/scenario/:scenarioName/artifacts
+    const openClawScenarioArtifactsMatch = url.match(
+      /^\/api\/openclaw\/discovery\/scenario\/([^/]+)\/artifacts$/,
+    );
+    if (method === "GET" && openClawScenarioArtifactsMatch) {
+      const [, rawScenarioName] = openClawScenarioArtifactsMatch;
+      const response = openClawApi.discoveryScenarioArtifacts(decodeURIComponent(rawScenarioName!));
+      json(response.status, response.body);
+      return;
+    }
+
+    // GET /api/openclaw/discovery/scenario/:scenarioName
+    const openClawScenarioMatch = url.match(/^\/api\/openclaw\/discovery\/scenario\/([^/]+)$/);
+    if (method === "GET" && openClawScenarioMatch) {
+      const [, rawScenarioName] = openClawScenarioMatch;
+      const response = openClawApi.discoveryScenario(decodeURIComponent(rawScenarioName!));
+      json(response.status, response.body);
+      return;
+    }
+
+    // GET /api/openclaw/skill/manifest
+    if (method === "GET" && url === "/api/openclaw/skill/manifest") {
+      const response = openClawApi.skillManifest();
       json(response.status, response.body);
       return;
     }

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -48,7 +48,6 @@ import { loadSettings, type AppSettings } from "../config/index.js";
 import { SQLiteStore } from "../storage/index.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import { SolveManager } from "../knowledge/solver.js";
-import { loadSettings } from "../config/index.js";
 
 export interface InteractiveServerOpts {
   runManager: RunManager;

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -714,7 +714,13 @@ describe("HTTP API — OpenClaw", () => {
       artifact_type: "policy",
       scenario: "grid_ctf",
       version: 1,
-      policy: { aggression: 0.6 },
+      provenance: {
+        run_id: "test-run-1",
+        generation: 1,
+        scenario: "grid_ctf",
+        settings: {},
+      },
+      source_code: "def strategy(state):\n    return {'aggression': 0.6}\n",
       tags: ["smoke"],
       created_at: "2026-04-25T00:00:00Z",
     };
@@ -740,6 +746,46 @@ describe("HTTP API — OpenClaw", () => {
     const fetched = await fetchJson(`${baseUrl}/api/openclaw/artifacts/artifact-1`);
     expect(fetched.status).toBe(200);
     expect(fetched.body).toMatchObject(artifact);
+  });
+
+  it("POST /api/openclaw/artifacts rejects malformed policy artifacts", async () => {
+    const { status, body } = await postJson(`${baseUrl}/api/openclaw/artifacts`, {
+      id: "artifact-missing-source",
+      name: "Grid policy",
+      artifact_type: "policy",
+      scenario: "grid_ctf",
+      version: 1,
+      provenance: {
+        run_id: "test-run-1",
+        generation: 1,
+        scenario: "grid_ctf",
+        settings: {},
+      },
+    });
+
+    expect(status).toBe(400);
+    expect((body as Record<string, unknown>).detail).toContain("source_code");
+  });
+
+  it("POST /api/openclaw/artifacts rejects scenario traversal before harness writes", async () => {
+    const { status, body } = await postJson(`${baseUrl}/api/openclaw/artifacts`, {
+      id: "harness-escape",
+      name: "Escaping harness",
+      artifact_type: "harness",
+      scenario: "../outside",
+      version: 1,
+      provenance: {
+        run_id: "test-run-1",
+        generation: 1,
+        scenario: "../outside",
+        settings: {},
+      },
+      source_code: "def validate(state, strategy):\n    return True\n",
+    });
+
+    expect(status).toBe(400);
+    expect((body as Record<string, unknown>).detail).toContain("scenario");
+    expect(existsSync(join(dir, "outside", "harness"))).toBe(false);
   });
 
   it("GET /api/openclaw/discovery endpoints advertise runtime and scenario state", async () => {

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -51,6 +51,15 @@ async function putJson(url: string, body: Record<string, unknown>): Promise<{ st
   return { status: res.status, body: await res.json() };
 }
 
+async function patchJson(url: string, body: Record<string, unknown>): Promise<{ status: number; body: unknown }> {
+  const res = await fetch(url, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.json() };
+}
+
 async function fetchText(url: string): Promise<{ status: number; body: string }> {
   const res = await fetch(url);
   const body = await res.text();
@@ -181,6 +190,7 @@ describe("HTTP API — health", () => {
     });
     expect(endpoints.monitors).toBe("/api/monitors");
     expect(endpoints.notebooks).toBe("/api/notebooks");
+    expect(endpoints.openclaw).toBe("/api/openclaw");
     expect(endpoints.knowledge).toMatchObject({
       scenarios: "/api/knowledge/scenarios",
       export: "/api/knowledge/export/:scenario",
@@ -238,8 +248,12 @@ describe("HTTP API — health", () => {
     expect(matrix.routes).toContainEqual(expect.objectContaining({
       method: "GET",
       path: "/api/openclaw/capabilities",
-      status: "typescript_gap",
-      issue: "AC-627",
+      status: "aligned",
+    }));
+    expect(matrix.routes).toContainEqual(expect.objectContaining({
+      method: "POST",
+      path: "/api/openclaw/evaluate",
+      status: "aligned",
     }));
     expect(matrix.routes).toContainEqual(expect.objectContaining({
       method: "GET",
@@ -608,6 +622,228 @@ describe("HTTP API — monitors", () => {
 
     expect(status).toBe(409);
     expect((body as Record<string, unknown>).detail).toContain("invalid monitor condition type");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenClaw endpoints
+// ---------------------------------------------------------------------------
+
+describe("HTTP API — OpenClaw", () => {
+  let dir: string;
+  let server: Awaited<ReturnType<typeof createTestServer>>["server"];
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    dir = makeTempDir();
+    const s = await createTestServer(dir);
+    server = s.server;
+    baseUrl = s.baseUrl;
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("POST /api/openclaw/evaluate scores a built-in game strategy", async () => {
+    const { status, body } = await postJson(`${baseUrl}/api/openclaw/evaluate`, {
+      scenario_name: "grid_ctf",
+      strategy: { aggression: 0.6, defense: 0.4, path_bias: 0.7 },
+      num_matches: 2,
+      seed_base: 42,
+    });
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      scenario: "grid_ctf",
+      matches: 2,
+    });
+    expect((body as Record<string, unknown>).scores).toHaveLength(2);
+    expect(typeof (body as Record<string, unknown>).mean_score).toBe("number");
+    expect(typeof (body as Record<string, unknown>).best_score).toBe("number");
+  });
+
+  it("POST /api/openclaw/validate returns harness-compatible validation shape", async () => {
+    const { status, body } = await postJson(`${baseUrl}/api/openclaw/validate`, {
+      scenario_name: "grid_ctf",
+      strategy: { aggression: 0.6, defense: 0.4, path_bias: 0.7 },
+    });
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      valid: true,
+      reason: "ok",
+      scenario: "grid_ctf",
+      harness_loaded: [],
+      harness_passed: true,
+      harness_errors: [],
+    });
+  });
+
+  it("POST /api/openclaw/validate reports invalid strategies without transport failure", async () => {
+    const { status, body } = await postJson(`${baseUrl}/api/openclaw/validate`, {
+      scenario_name: "grid_ctf",
+      strategy: { aggression: 0.9, defense: 0.8, path_bias: 0.7 },
+    });
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      valid: false,
+      reason: expect.stringContaining("combined aggression"),
+      scenario: "grid_ctf",
+      harness_passed: false,
+      harness_errors: [expect.stringContaining("combined aggression")],
+    });
+  });
+
+  it("POST /api/openclaw/validate returns 400 for unknown scenarios", async () => {
+    const { status, body } = await postJson(`${baseUrl}/api/openclaw/validate`, {
+      scenario_name: "not_real",
+      strategy: {},
+    });
+
+    expect(status).toBe(400);
+    expect((body as Record<string, unknown>).detail).toContain("Unknown scenario");
+  });
+
+  it("POST /api/openclaw/artifacts publishes and lists artifacts", async () => {
+    const artifact = {
+      id: "artifact-1",
+      name: "Grid policy",
+      artifact_type: "policy",
+      scenario: "grid_ctf",
+      version: 1,
+      policy: { aggression: 0.6 },
+      tags: ["smoke"],
+      created_at: "2026-04-25T00:00:00Z",
+    };
+
+    const published = await postJson(`${baseUrl}/api/openclaw/artifacts`, artifact);
+    expect(published.status).toBe(200);
+    expect(published.body).toMatchObject({
+      status: "published",
+      artifact_id: "artifact-1",
+      artifact_type: "policy",
+    });
+
+    const listed = await fetchJson(`${baseUrl}/api/openclaw/artifacts?scenario=grid_ctf&artifact_type=policy`);
+    expect(listed.status).toBe(200);
+    expect(listed.body).toContainEqual(expect.objectContaining({
+      id: "artifact-1",
+      name: "Grid policy",
+      artifact_type: "policy",
+      scenario: "grid_ctf",
+      version: 1,
+    }));
+
+    const fetched = await fetchJson(`${baseUrl}/api/openclaw/artifacts/artifact-1`);
+    expect(fetched.status).toBe(200);
+    expect(fetched.body).toMatchObject(artifact);
+  });
+
+  it("GET /api/openclaw/discovery endpoints advertise runtime and scenario state", async () => {
+    const capabilities = await fetchJson(`${baseUrl}/api/openclaw/discovery/capabilities`);
+    expect(capabilities.status).toBe(200);
+    expect(capabilities.body).toMatchObject({
+      version: "0.1.0",
+      runtime_health: expect.objectContaining({
+        executor_mode: expect.any(String),
+        agent_provider: expect.any(String),
+      }),
+      scenario_capabilities: expect.objectContaining({
+        grid_ctf: expect.objectContaining({
+          scenario_name: "grid_ctf",
+          evaluation_mode: "tournament",
+          has_playbook: true,
+        }),
+      }),
+    });
+
+    const scenario = await fetchJson(`${baseUrl}/api/openclaw/discovery/scenario/grid_ctf`);
+    expect(scenario.status).toBe(200);
+    expect(scenario.body).toMatchObject({
+      scenario_name: "grid_ctf",
+      evaluation_mode: "tournament",
+      has_playbook: true,
+      best_score: 0.7,
+      best_elo: 1050,
+    });
+
+    const health = await fetchJson(`${baseUrl}/api/openclaw/discovery/health`);
+    expect(health.status).toBe(200);
+    expect(health.body).toMatchObject({
+      executor_mode: expect.any(String),
+      openclaw_runtime_kind: "factory",
+      openclaw_compatibility_version: "1.0",
+    });
+  });
+
+  it("GET /api/openclaw/skill/manifest returns a ClawHub manifest", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/openclaw/skill/manifest`);
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      name: "autocontext",
+      rest_base_path: "/api/openclaw",
+    });
+    expect((body as Record<string, unknown>).scenarios).toContainEqual(expect.objectContaining({
+      name: "grid_ctf",
+      display_name: "Grid Ctf",
+      scenario_type: "parametric",
+    }));
+  });
+
+  it("distillation job endpoints keep Python-compatible lifecycle semantics", async () => {
+    const triggered = await postJson(`${baseUrl}/api/openclaw/distill`, {
+      scenario: "grid_ctf",
+      source_artifact_ids: ["artifact-1"],
+      training_config: { epochs: 1 },
+    });
+
+    expect(triggered.status).toBe(400);
+    expect(triggered.body).toMatchObject({
+      status: "failed",
+      scenario: "grid_ctf",
+    });
+    expect((triggered.body as Record<string, unknown>).error).toContain("No distillation sidecar configured");
+    const jobId = (triggered.body as Record<string, unknown>).job_id as string;
+
+    const job = await fetchJson(`${baseUrl}/api/openclaw/distill/${jobId}`);
+    expect(job.status).toBe(200);
+    expect(job.body).toMatchObject({
+      job_id: jobId,
+      status: "failed",
+      scenario: "grid_ctf",
+    });
+
+    const status = await fetchJson(`${baseUrl}/api/openclaw/distill?scenario=grid_ctf`);
+    expect(status.status).toBe(200);
+    expect(status.body).toMatchObject({
+      active_jobs: 0,
+      jobs: [expect.objectContaining({ job_id: jobId })],
+    });
+  });
+
+  it("PATCH /api/openclaw/distill/:job_id rejects invalid transitions", async () => {
+    const triggered = await postJson(`${baseUrl}/api/openclaw/distill`, {
+      scenario: "grid_ctf",
+    });
+    const jobId = (triggered.body as Record<string, unknown>).job_id as string;
+
+    const updated = await patchJson(`${baseUrl}/api/openclaw/distill/${jobId}`, {
+      status: "completed",
+      result_artifact_id: "artifact-1",
+    });
+
+    expect(updated.status).toBe(400);
+    expect((updated.body as Record<string, unknown>).detail).toContain("Invalid transition");
+  });
+
+  it("GET /api/openclaw/artifacts/:artifact_id returns 404 for unknown artifacts", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/openclaw/artifacts/not-real`);
+    expect(status).toBe(404);
+    expect((body as Record<string, unknown>).detail).toContain("not found");
   });
 });
 


### PR DESCRIPTION
## Summary
- add TypeScript OpenClaw REST routes for evaluation, validation, artifacts, distillation jobs, discovery, capabilities, and skill manifest
- add an OpenClaw domain service plus file-backed distillation job lifecycle store
- mark OpenClaw HTTP routes aligned in the parity matrix and document /api/openclaw

## Tests
- npm test -- tests/http-api.test.ts tests/storage.test.ts tests/storage-migration-workflow.test.ts
- npm run lint

Linear: AC-656