### PR TITLE
AC-652 Port cockpit REST API to TypeScript

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -278,7 +278,7 @@ Credential resolution order is:
 
 `autoctx capabilities` returns structured JSON describing commands, providers, scenarios, the canonical concept model, and project-specific state such as the current project config, active runs, and knowledge directory summary.
 
-The HTTP server exposes `GET /api/capabilities/http` with a runtime parity matrix for Python and TypeScript REST/WebSocket routes, including explicit TypeScript gaps and TypeScript-only routes. Session notebook CRUD routes are available under `/api/notebooks`, monitor condition/alert routes are available under `/api/monitors`, and OpenClaw-compatible evaluation, artifact, distillation, discovery, capability, and skill manifest routes are available under `/api/openclaw`.
+The HTTP server exposes `GET /api/capabilities/http` with a runtime parity matrix for Python and TypeScript REST/WebSocket routes, including explicit TypeScript gaps and TypeScript-only routes. Session notebook CRUD routes are available under `/api/notebooks`, cockpit notebook/run/readout routes are available under `/api/cockpit`, monitor condition/alert routes are available under `/api/monitors`, and OpenClaw-compatible evaluation, artifact, distillation, discovery, capability, and skill manifest routes are available under `/api/openclaw`.
 
 `autoctx login` can prompt interactively for provider credentials. `autoctx login --provider ollama` validates that a local Ollama server is reachable before persisting the connection details, and `autoctx logout` clears the stored credentials.
 

--- a/ts/migrations/012_consultation_log.sql
+++ b/ts/migrations/012_consultation_log.sql
@@ -1,0 +1,20 @@
+-- Provider consultation log shared with the Python control plane.
+
+CREATE TABLE IF NOT EXISTS consultation_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    generation_index INTEGER NOT NULL,
+    trigger TEXT NOT NULL,
+    context_summary TEXT NOT NULL DEFAULT '',
+    critique TEXT NOT NULL DEFAULT '',
+    alternative_hypothesis TEXT NOT NULL DEFAULT '',
+    tiebreak_recommendation TEXT NOT NULL DEFAULT '',
+    suggested_next_action TEXT NOT NULL DEFAULT '',
+    raw_response TEXT NOT NULL DEFAULT '',
+    model_used TEXT NOT NULL DEFAULT '',
+    cost_usd REAL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    FOREIGN KEY (run_id) REFERENCES runs(run_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_consultation_log_run ON consultation_log(run_id);

--- a/ts/src/config/app-settings-schema.ts
+++ b/ts/src/config/app-settings-schema.ts
@@ -256,6 +256,15 @@ export const AppSettingsSchema = z.object({
   monitorHeartbeatTimeout: z.number().min(1).default(300.0),
   monitorMaxConditions: z.number().int().min(1).default(100),
 
+  // Provider consultation
+  consultationEnabled: z.boolean().default(false),
+  consultationProvider: z.string().default("anthropic"),
+  consultationModel: z.string().default("claude-sonnet-4-20250514"),
+  consultationApiKey: z.string().default(""),
+  consultationBaseUrl: z.string().default(""),
+  consultationStagnationThreshold: z.number().int().min(2).default(3),
+  consultationCostBudget: z.number().min(0).default(0.0),
+
   // Blob store (AC-518)
   blobStoreEnabled: z.boolean().default(false),
   blobStoreBackend: z.string().default("local"),

--- a/ts/src/server/cockpit-api.ts
+++ b/ts/src/server/cockpit-api.ts
@@ -1,0 +1,420 @@
+import type {
+  GenerationRow,
+  NotebookRow,
+  RunRow,
+  SQLiteStore,
+  TrajectoryRow,
+} from "../storage/index.js";
+import type { NotebookApiRoutes } from "./notebook-api.js";
+
+export interface CockpitApiResponse {
+  status: number;
+  body: unknown;
+}
+
+export interface CockpitApiRoutes {
+  listNotebooks(): CockpitApiResponse;
+  getNotebook(sessionId: string): CockpitApiResponse;
+  effectiveNotebookContext(sessionId: string): CockpitApiResponse;
+  upsertNotebook(sessionId: string, body: Record<string, unknown>): CockpitApiResponse;
+  deleteNotebook(sessionId: string): CockpitApiResponse;
+  listRuns(): CockpitApiResponse;
+  runStatus(runId: string): CockpitApiResponse;
+  changelog(runId: string): CockpitApiResponse;
+  compareGenerations(runId: string, genA: number, genB: number): CockpitApiResponse;
+  resumeInfo(runId: string): CockpitApiResponse;
+  writeup(runId: string): CockpitApiResponse;
+  requestConsultation(runId: string, body: Record<string, unknown>): CockpitApiResponse;
+  listConsultations(runId: string): CockpitApiResponse;
+}
+
+type RoleName = "competitor" | "analyst" | "coach" | "architect";
+type NotebookField =
+  | "current_objective"
+  | "current_hypotheses"
+  | "unresolved_questions"
+  | "operator_observations"
+  | "follow_ups";
+
+const ROLE_NOTEBOOK_FIELDS: Record<RoleName, NotebookField[]> = {
+  competitor: ["current_objective", "current_hypotheses", "follow_ups"],
+  analyst: ["current_objective", "unresolved_questions", "operator_observations"],
+  coach: ["current_objective", "follow_ups", "operator_observations"],
+  architect: ["current_hypotheses", "unresolved_questions"],
+};
+
+const FIELD_HEADERS: Record<NotebookField, string> = {
+  current_objective: "Current Objective",
+  current_hypotheses: "Active Hypotheses",
+  unresolved_questions: "Unresolved Questions",
+  operator_observations: "Operator Observations",
+  follow_ups: "Follow-ups",
+};
+
+export function buildCockpitApiRoutes(opts: {
+  openStore: () => SQLiteStore;
+  notebookApi: NotebookApiRoutes;
+}): CockpitApiRoutes {
+  return {
+    listNotebooks: () => opts.notebookApi.list(),
+    getNotebook: (sessionId) => opts.notebookApi.get(sessionId),
+    effectiveNotebookContext: (sessionId) => withStore(opts.openStore, (store) => {
+      const notebook = store.getNotebook(sessionId);
+      if (!notebook) {
+        return { status: 404, body: { detail: `Notebook not found: ${sessionId}` } };
+      }
+      return {
+        status: 200,
+        body: buildEffectiveNotebookPreview(notebook, getRunBestScore(store, sessionId)),
+      };
+    }),
+    upsertNotebook: (sessionId, body) => opts.notebookApi.upsert(sessionId, body),
+    deleteNotebook: (sessionId) => opts.notebookApi.delete(sessionId),
+    listRuns: () => withStore(opts.openStore, (store) => ({
+      status: 200,
+      body: store.listRuns(50).map((run) => summarizeRun(store, run)),
+    })),
+    runStatus: (runId) => withStore(opts.openStore, (store) => {
+      const run = store.getRun(runId);
+      if (!run) {
+        return { status: 404, body: { detail: `Run '${runId}' not found` } };
+      }
+      return {
+        status: 200,
+        body: {
+          run_id: run.run_id,
+          scenario_name: run.scenario,
+          target_generations: run.target_generations,
+          status: run.status,
+          created_at: run.created_at,
+          generations: store.getGenerations(runId).map(formatGenerationStatus),
+        },
+      };
+    }),
+    changelog: (runId) => withStore(opts.openStore, (store) => {
+      if (!store.getRun(runId)) {
+        return { status: 404, body: { detail: `Run '${runId}' not found` } };
+      }
+      return { status: 200, body: buildChangelog(store, runId) };
+    }),
+    compareGenerations: (runId, genA, genB) => withStore(opts.openStore, (store) => {
+      const generations = store.getGenerations(runId);
+      const rowA = generations.find((generation) => generation.generation_index === genA);
+      const rowB = generations.find((generation) => generation.generation_index === genB);
+      if (!rowA) {
+        return { status: 404, body: { detail: `Generation ${genA} not found for run '${runId}'` } };
+      }
+      if (!rowB) {
+        return { status: 404, body: { detail: `Generation ${genB} not found for run '${runId}'` } };
+      }
+      return {
+        status: 200,
+        body: {
+          gen_a: formatGenerationComparison(rowA),
+          gen_b: formatGenerationComparison(rowB),
+          score_delta: roundDelta(rowB.best_score - rowA.best_score),
+          elo_delta: roundDelta(rowB.elo - rowA.elo),
+        },
+      };
+    }),
+    resumeInfo: (runId) => withStore(opts.openStore, (store) => {
+      const run = store.getRun(runId);
+      if (!run) {
+        return { status: 404, body: { detail: `Run '${runId}' not found` } };
+      }
+      const generations = store.getGenerations(runId);
+      const last = generations.at(-1);
+      const lastGeneration = last?.generation_index ?? 0;
+      let canResume = run.status === "running" && lastGeneration < run.target_generations;
+      let resumeHint: string;
+      if (run.status === "completed") {
+        resumeHint = "Run completed successfully. Start a new run to continue exploration.";
+      } else if (run.status === "running" && lastGeneration >= run.target_generations) {
+        resumeHint = "All target generations completed. Mark as complete or increase target.";
+        canResume = false;
+      } else if (run.status === "running") {
+        resumeHint = `Run in progress. Resume from generation ${lastGeneration + 1}.`;
+      } else {
+        resumeHint = `Run status is '${run.status}'.`;
+      }
+      const notebook = store.getNotebook(runId);
+      return {
+        status: 200,
+        body: {
+          run_id: runId,
+          status: run.status,
+          last_generation: lastGeneration,
+          last_gate_decision: last?.gate_decision ?? "",
+          can_resume: canResume,
+          resume_hint: resumeHint,
+          effective_notebook_context: notebook
+            ? buildEffectiveNotebookPreview(notebook, getRunBestScore(store, runId))
+            : null,
+        },
+      };
+    }),
+    writeup: (runId) => withStore(opts.openStore, (store) => {
+      const run = store.getRun(runId);
+      if (!run) {
+        return { status: 404, body: { detail: `Run '${runId}' not found` } };
+      }
+      return {
+        status: 200,
+        body: {
+          run_id: run.run_id,
+          scenario_name: run.scenario,
+          writeup_markdown: buildWriteup(store, run),
+        },
+      };
+    }),
+    requestConsultation: () => ({
+      status: 400,
+      body: { detail: "Consultation is not enabled in the TypeScript cockpit backend" },
+    }),
+    listConsultations: () => ({ status: 200, body: [] }),
+  };
+}
+
+function withStore(
+  openStore: () => SQLiteStore,
+  fn: (store: SQLiteStore) => CockpitApiResponse,
+): CockpitApiResponse {
+  const store = openStore();
+  try {
+    return fn(store);
+  } finally {
+    store.close();
+  }
+}
+
+function summarizeRun(store: SQLiteStore, run: RunRow): Record<string, unknown> {
+  const generations = store.getGenerations(run.run_id);
+  const bestScore = generations.length > 0
+    ? Math.max(...generations.map((generation) => generation.best_score))
+    : 0;
+  const bestElo = generations.length > 0
+    ? Math.max(...generations.map((generation) => generation.elo))
+    : 0;
+  const totalDuration = generations.reduce(
+    (sum, generation) => sum + (generation.duration_seconds ?? 0),
+    0,
+  );
+  return {
+    run_id: run.run_id,
+    scenario_name: run.scenario,
+    generations_completed: generations.length,
+    best_score: bestScore,
+    best_elo: bestElo,
+    status: run.status,
+    created_at: run.created_at,
+    duration_seconds: Math.round(totalDuration * 10) / 10,
+  };
+}
+
+function formatGenerationStatus(generation: GenerationRow): Record<string, unknown> {
+  return {
+    generation: generation.generation_index,
+    mean_score: generation.mean_score,
+    best_score: generation.best_score,
+    elo: generation.elo,
+    wins: generation.wins,
+    losses: generation.losses,
+    gate_decision: generation.gate_decision,
+    status: generation.status,
+    duration_seconds: generation.duration_seconds,
+  };
+}
+
+function formatGenerationComparison(generation: GenerationRow): Record<string, unknown> {
+  return {
+    generation: generation.generation_index,
+    mean_score: generation.mean_score,
+    best_score: generation.best_score,
+    elo: generation.elo,
+    gate_decision: generation.gate_decision,
+  };
+}
+
+function buildChangelog(store: SQLiteStore, runId: string): Record<string, unknown> {
+  const generations = store.getGenerations(runId);
+  if (generations.length < 2) {
+    return { run_id: runId, changes: [] };
+  }
+  const changes = generations.slice(1).map((generation, index) => {
+    const previous = generations[index]!;
+    return {
+      generation: generation.generation_index,
+      previous_generation: previous.generation_index,
+      score_delta: roundDelta(generation.best_score - previous.best_score),
+      elo_delta: roundDelta(generation.elo - previous.elo),
+      gate_decision: generation.gate_decision,
+      duration_seconds: generation.duration_seconds,
+    };
+  });
+  return { run_id: runId, changes };
+}
+
+function buildWriteup(store: SQLiteStore, run: RunRow): string {
+  const trajectory = store.getScoreTrajectory(run.run_id);
+  const sections = [
+    `# Run Summary: ${run.run_id}`,
+    "",
+    `- **Scenario**: ${run.scenario}`,
+    `- **Target generations**: ${run.target_generations}`,
+    `- **Status**: ${run.status}`,
+    `- **Created**: ${run.created_at}`,
+    "",
+    "## Score Trajectory",
+    "",
+  ];
+
+  if (trajectory.length === 0) {
+    sections.push("No completed generations.", "");
+  } else {
+    sections.push("| Gen | Best Score | Elo | Delta | Gate |");
+    sections.push("|-----|------------|-----|-------|------|");
+    for (const generation of trajectory) {
+      sections.push(
+        `| ${generation.generation_index} | ${generation.best_score.toFixed(2)} `
+          + `| ${generation.elo.toFixed(0)} | ${formatDelta(generation.delta)} `
+          + `| ${generation.gate_decision} |`,
+      );
+    }
+    sections.push("");
+  }
+
+  sections.push("## Gate Decisions", "");
+  if (trajectory.length === 0) {
+    sections.push("No gate decisions recorded.", "");
+  } else {
+    for (const generation of trajectory) {
+      sections.push(`- Generation ${generation.generation_index}: **${generation.gate_decision}**`);
+    }
+    sections.push("");
+  }
+
+  const bestOutput = bestCompetitorOutput(store, run.run_id, trajectory);
+  if (bestOutput) {
+    sections.push("## Best Strategy", "");
+    sections.push(`Generation ${bestOutput.generation} (score: ${bestOutput.bestScore.toFixed(2)}):`, "");
+    sections.push("```");
+    sections.push(truncate(bestOutput.content, 500));
+    sections.push("```", "");
+  }
+
+  return sections.join("\n");
+}
+
+function bestCompetitorOutput(
+  store: SQLiteStore,
+  runId: string,
+  trajectory: TrajectoryRow[],
+): { generation: number; bestScore: number; content: string } | null {
+  if (trajectory.length === 0) {
+    return null;
+  }
+  const best = trajectory.reduce((current, candidate) => (
+    candidate.best_score > current.best_score ? candidate : current
+  ));
+  const output = store
+    .getAgentOutputs(runId, best.generation_index)
+    .filter((entry) => entry.role === "competitor")
+    .at(-1);
+  if (!output) {
+    return null;
+  }
+  return {
+    generation: best.generation_index,
+    bestScore: best.best_score,
+    content: output.content,
+  };
+}
+
+function buildEffectiveNotebookPreview(
+  notebook: NotebookRow,
+  currentBestScore: number | null,
+): Record<string, unknown> {
+  const roleContexts = Object.fromEntries(
+    (Object.keys(ROLE_NOTEBOOK_FIELDS) as RoleName[])
+      .map((role) => [role, roleContext(notebook, role)] as const)
+      .filter(([, context]) => context.length > 0),
+  );
+  return {
+    session_id: notebook.session_id,
+    role_contexts: roleContexts,
+    warnings: notebookWarnings(notebook, currentBestScore),
+    notebook_empty: isNotebookEmpty(notebook),
+    created_at: new Date().toISOString(),
+    metadata: {},
+  };
+}
+
+function roleContext(notebook: NotebookRow, role: RoleName): string {
+  const sections = ROLE_NOTEBOOK_FIELDS[role]
+    .map((field) => formatNotebookSection(field, notebook[field]))
+    .filter((section): section is string => section !== null);
+  if (sections.length === 0) {
+    return "";
+  }
+  return `## Session Notebook (${notebook.session_id})\n\n${sections.join("\n\n")}`;
+}
+
+function formatNotebookSection(field: NotebookField, value: string | string[]): string | null {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return null;
+    }
+    return `### ${FIELD_HEADERS[field]}\n${value.map((item) => `- ${item}`).join("\n")}`;
+  }
+  if (!value) {
+    return null;
+  }
+  return `### ${FIELD_HEADERS[field]}\n${value}`;
+}
+
+function notebookWarnings(
+  notebook: NotebookRow,
+  currentBestScore: number | null,
+): Array<Record<string, string>> {
+  if (
+    notebook.best_score !== null
+    && currentBestScore !== null
+    && currentBestScore > notebook.best_score
+  ) {
+    return [{
+      field: "best_score",
+      warning_type: "stale_score",
+      description: `Notebook best score ${notebook.best_score} is below current run best ${currentBestScore}`,
+    }];
+  }
+  return [];
+}
+
+function isNotebookEmpty(notebook: NotebookRow): boolean {
+  return !Object.values(ROLE_NOTEBOOK_FIELDS)
+    .flat()
+    .some((field) => {
+      const value = notebook[field];
+      return Array.isArray(value) ? value.length > 0 : value.length > 0;
+    });
+}
+
+function getRunBestScore(store: SQLiteStore, runId: string): number | null {
+  const generations = store.getGenerations(runId);
+  if (generations.length === 0) {
+    return null;
+  }
+  return Math.max(...generations.map((generation) => generation.best_score));
+}
+
+function roundDelta(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function formatDelta(value: number): string {
+  return value >= 0 ? `+${value.toFixed(4)}` : value.toFixed(4);
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+}

--- a/ts/src/server/cockpit-api.ts
+++ b/ts/src/server/cockpit-api.ts
@@ -1,10 +1,16 @@
+import type { AppSettings } from "../config/index.js";
+import { createProvider as defaultCreateProvider } from "../providers/provider-factory.js";
+import type { CreateProviderOpts } from "../providers/provider-factory.js";
 import type {
   GenerationRow,
   NotebookRow,
   RunRow,
   SQLiteStore,
-  TrajectoryRow,
 } from "../storage/index.js";
+import type { LLMProvider } from "../types/index.js";
+import { buildChangelog } from "./cockpit-changelog.js";
+import { requestConsultation } from "./cockpit-consultation.js";
+import { buildWriteup } from "./cockpit-writeup.js";
 import type { NotebookApiRoutes } from "./notebook-api.js";
 
 export interface CockpitApiResponse {
@@ -24,7 +30,7 @@ export interface CockpitApiRoutes {
   compareGenerations(runId: string, genA: number, genB: number): CockpitApiResponse;
   resumeInfo(runId: string): CockpitApiResponse;
   writeup(runId: string): CockpitApiResponse;
-  requestConsultation(runId: string, body: Record<string, unknown>): CockpitApiResponse;
+  requestConsultation(runId: string, body: Record<string, unknown>): Promise<CockpitApiResponse>;
   listConsultations(runId: string): CockpitApiResponse;
 }
 
@@ -54,7 +60,12 @@ const FIELD_HEADERS: Record<NotebookField, string> = {
 export function buildCockpitApiRoutes(opts: {
   openStore: () => SQLiteStore;
   notebookApi: NotebookApiRoutes;
+  settings: AppSettings;
+  runsRoot: string;
+  knowledgeRoot: string;
+  createProvider?: (opts: CreateProviderOpts) => LLMProvider;
 }): CockpitApiRoutes {
+  const createProvider = opts.createProvider ?? defaultCreateProvider;
   return {
     listNotebooks: () => opts.notebookApi.list(),
     getNotebook: (sessionId) => opts.notebookApi.get(sessionId),
@@ -163,15 +174,24 @@ export function buildCockpitApiRoutes(opts: {
         body: {
           run_id: run.run_id,
           scenario_name: run.scenario,
-          writeup_markdown: buildWriteup(store, run),
+          writeup_markdown: buildWriteup(store, run, opts.knowledgeRoot),
         },
       };
     }),
-    requestConsultation: () => ({
-      status: 400,
-      body: { detail: "Consultation is not enabled in the TypeScript cockpit backend" },
+    requestConsultation: (runId, body) => withStoreAsync(opts.openStore, async (store) =>
+      requestConsultation(store, {
+        body,
+        createProvider,
+        runId,
+        runsRoot: opts.runsRoot,
+        settings: opts.settings,
+      })),
+    listConsultations: (runId) => withStore(opts.openStore, (store) => {
+      if (!store.getRun(runId)) {
+        return { status: 404, body: { detail: `Run '${runId}' not found` } };
+      }
+      return { status: 200, body: store.getConsultationsForRun(runId) };
     }),
-    listConsultations: () => ({ status: 200, body: [] }),
   };
 }
 
@@ -182,6 +202,18 @@ function withStore(
   const store = openStore();
   try {
     return fn(store);
+  } finally {
+    store.close();
+  }
+}
+
+async function withStoreAsync(
+  openStore: () => SQLiteStore,
+  fn: (store: SQLiteStore) => Promise<CockpitApiResponse>,
+): Promise<CockpitApiResponse> {
+  const store = openStore();
+  try {
+    return await fn(store);
   } finally {
     store.close();
   }
@@ -232,101 +264,6 @@ function formatGenerationComparison(generation: GenerationRow): Record<string, u
     best_score: generation.best_score,
     elo: generation.elo,
     gate_decision: generation.gate_decision,
-  };
-}
-
-function buildChangelog(store: SQLiteStore, runId: string): Record<string, unknown> {
-  const generations = store.getGenerations(runId);
-  if (generations.length < 2) {
-    return { run_id: runId, changes: [] };
-  }
-  const changes = generations.slice(1).map((generation, index) => {
-    const previous = generations[index]!;
-    return {
-      generation: generation.generation_index,
-      previous_generation: previous.generation_index,
-      score_delta: roundDelta(generation.best_score - previous.best_score),
-      elo_delta: roundDelta(generation.elo - previous.elo),
-      gate_decision: generation.gate_decision,
-      duration_seconds: generation.duration_seconds,
-    };
-  });
-  return { run_id: runId, changes };
-}
-
-function buildWriteup(store: SQLiteStore, run: RunRow): string {
-  const trajectory = store.getScoreTrajectory(run.run_id);
-  const sections = [
-    `# Run Summary: ${run.run_id}`,
-    "",
-    `- **Scenario**: ${run.scenario}`,
-    `- **Target generations**: ${run.target_generations}`,
-    `- **Status**: ${run.status}`,
-    `- **Created**: ${run.created_at}`,
-    "",
-    "## Score Trajectory",
-    "",
-  ];
-
-  if (trajectory.length === 0) {
-    sections.push("No completed generations.", "");
-  } else {
-    sections.push("| Gen | Best Score | Elo | Delta | Gate |");
-    sections.push("|-----|------------|-----|-------|------|");
-    for (const generation of trajectory) {
-      sections.push(
-        `| ${generation.generation_index} | ${generation.best_score.toFixed(2)} `
-          + `| ${generation.elo.toFixed(0)} | ${formatDelta(generation.delta)} `
-          + `| ${generation.gate_decision} |`,
-      );
-    }
-    sections.push("");
-  }
-
-  sections.push("## Gate Decisions", "");
-  if (trajectory.length === 0) {
-    sections.push("No gate decisions recorded.", "");
-  } else {
-    for (const generation of trajectory) {
-      sections.push(`- Generation ${generation.generation_index}: **${generation.gate_decision}**`);
-    }
-    sections.push("");
-  }
-
-  const bestOutput = bestCompetitorOutput(store, run.run_id, trajectory);
-  if (bestOutput) {
-    sections.push("## Best Strategy", "");
-    sections.push(`Generation ${bestOutput.generation} (score: ${bestOutput.bestScore.toFixed(2)}):`, "");
-    sections.push("```");
-    sections.push(truncate(bestOutput.content, 500));
-    sections.push("```", "");
-  }
-
-  return sections.join("\n");
-}
-
-function bestCompetitorOutput(
-  store: SQLiteStore,
-  runId: string,
-  trajectory: TrajectoryRow[],
-): { generation: number; bestScore: number; content: string } | null {
-  if (trajectory.length === 0) {
-    return null;
-  }
-  const best = trajectory.reduce((current, candidate) => (
-    candidate.best_score > current.best_score ? candidate : current
-  ));
-  const output = store
-    .getAgentOutputs(runId, best.generation_index)
-    .filter((entry) => entry.role === "competitor")
-    .at(-1);
-  if (!output) {
-    return null;
-  }
-  return {
-    generation: best.generation_index,
-    bestScore: best.best_score,
-    content: output.content,
   };
 }
 
@@ -409,12 +346,4 @@ function getRunBestScore(store: SQLiteStore, runId: string): number | null {
 
 function roundDelta(value: number): number {
   return Math.round(value * 1_000_000) / 1_000_000;
-}
-
-function formatDelta(value: number): string {
-  return value >= 0 ? `+${value.toFixed(4)}` : value.toFixed(4);
-}
-
-function truncate(value: string, maxLength: number): string {
-  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
 }

--- a/ts/src/server/cockpit-changelog.ts
+++ b/ts/src/server/cockpit-changelog.ts
@@ -1,0 +1,104 @@
+import type { AgentOutputRow, SQLiteStore } from "../storage/index.js";
+
+export function buildChangelog(store: SQLiteStore, runId: string): Record<string, unknown> {
+  const generations = store.getGenerations(runId);
+  if (generations.length === 0) {
+    return { run_id: runId, generations: [] };
+  }
+
+  const outputsByGeneration = new Map<number, AgentOutputRow[]>();
+  for (const generation of generations) {
+    outputsByGeneration.set(
+      generation.generation_index,
+      store.getAgentOutputs(runId, generation.generation_index),
+    );
+  }
+
+  const entries = generations.map((generation, index) => {
+    const previous = index === 0 ? null : generations[index - 1]!;
+    const previousBestScore = previous?.best_score ?? 0;
+    const previousElo = previous?.elo ?? 1000;
+    const outputs = outputsByGeneration.get(generation.generation_index) ?? [];
+    return {
+      generation: generation.generation_index,
+      score_delta: roundDelta(generation.best_score - previousBestScore),
+      elo_delta: roundDelta(generation.elo - previousElo),
+      gate_decision: generation.gate_decision,
+      new_tools: outputs
+        .filter((output) => output.role === "architect")
+        .flatMap((output) => extractToolNames(output.content)),
+      playbook_changed: outputs
+        .filter((output) => output.role === "coach")
+        .some((output) => extractMarkedSection(output.content, "PLAYBOOK").trim().length > 0),
+      duration_seconds: generation.duration_seconds,
+    };
+  });
+  return { run_id: runId, generations: entries };
+}
+
+function extractToolNames(content: string): string[] {
+  return jsonCandidates(content)
+    .flatMap((candidate) => {
+      const parsed = parseJson(candidate);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .filter(isRecord)
+          .map((entry) => readString(entry, "name"))
+          .filter((name): name is string => name !== null);
+      }
+      if (isRecord(parsed) && Array.isArray(parsed.tools)) {
+        return parsed.tools
+          .filter(isRecord)
+          .map((entry) => readString(entry, "name"))
+          .filter((name): name is string => name !== null);
+      }
+      return [];
+    });
+}
+
+function jsonCandidates(content: string): string[] {
+  const candidates = [content];
+  const fencedJson = /```(?:json)?\s*([\s\S]*?)```/gi;
+  let match: RegExpExecArray | null;
+  while ((match = fencedJson.exec(content)) !== null) {
+    const candidate = match[1]?.trim();
+    if (candidate) {
+      candidates.push(candidate);
+    }
+  }
+  return candidates;
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function extractMarkedSection(content: string, name: string): string {
+  const marker = escapeRegExp(name);
+  const match = new RegExp(
+    `<!--\\s*${marker}_START\\s*-->([\\s\\S]*?)<!--\\s*${marker}_END\\s*-->`,
+    "i",
+  ).exec(content);
+  return match?.[1] ?? "";
+}
+
+function roundDelta(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/ts/src/server/cockpit-consultation.ts
+++ b/ts/src/server/cockpit-consultation.ts
@@ -1,0 +1,385 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import type { AppSettings } from "../config/index.js";
+import type { CreateProviderOpts } from "../providers/provider-factory.js";
+import type { GenerationRow, SQLiteStore } from "../storage/index.js";
+import type { CompletionResult, LLMProvider } from "../types/index.js";
+import type { CockpitApiResponse } from "./cockpit-api.js";
+
+export async function requestConsultation(
+  store: SQLiteStore,
+  opts: {
+    body: Record<string, unknown>;
+    createProvider: (opts: CreateProviderOpts) => LLMProvider;
+    runId: string;
+    runsRoot: string;
+    settings: AppSettings;
+  },
+): Promise<CockpitApiResponse> {
+  if (!opts.settings.consultationEnabled) {
+    return { status: 400, body: { detail: "Consultation is not enabled" } };
+  }
+
+  const run = store.getRun(opts.runId);
+  if (!run) {
+    return { status: 404, body: { detail: `Run '${opts.runId}' not found` } };
+  }
+
+  const generations = store.getGenerations(opts.runId);
+  if (generations.length === 0) {
+    return {
+      status: 400,
+      body: { detail: "Cannot request consultation for a run with no generations yet" },
+    };
+  }
+
+  const generationResult = resolveConsultationGeneration(opts.body, generations);
+  if ("response" in generationResult) {
+    return generationResult.response;
+  }
+
+  if (opts.settings.consultationCostBudget > 0) {
+    const spent = store.getTotalConsultationCost(opts.runId);
+    if (spent >= opts.settings.consultationCostBudget) {
+      return {
+        status: 429,
+        body: {
+          detail: `Consultation budget exceeded (spent $${spent.toFixed(2)} `
+            + `of $${opts.settings.consultationCostBudget.toFixed(2)})`,
+        },
+      };
+    }
+  }
+
+  const providerResult = createConsultationProvider(opts.settings, opts.createProvider);
+  if ("response" in providerResult) {
+    return providerResult.response;
+  }
+
+  const contextSummary = readOptionalString(opts.body.context_summary)
+    ?? readOptionalString(opts.body.contextSummary)
+    ?? `Operator-requested consultation for run ${opts.runId} at generation ${generationResult.generation}`;
+  const strategySummary = latestCompetitorStrategy(store, opts.runId, generations);
+  const completionResult = await completeConsultation(providerResult.provider, opts.settings, {
+    contextSummary,
+    gateHistory: generations.map((generation) => generation.gate_decision),
+    generation: generationResult.generation,
+    runId: opts.runId,
+    scoreHistory: generations.map((generation) => generation.best_score),
+    strategySummary,
+  });
+  if ("response" in completionResult) {
+    return completionResult.response;
+  }
+
+  const parsed = parseConsultationCompletion(completionResult.completion, providerResult.provider);
+  const rowId = store.insertConsultation({
+    runId: opts.runId,
+    generationIndex: generationResult.generation,
+    trigger: "operator_request",
+    contextSummary,
+    critique: parsed.critique,
+    alternativeHypothesis: parsed.alternativeHypothesis,
+    tiebreakRecommendation: parsed.tiebreakRecommendation,
+    suggestedNextAction: parsed.suggestedNextAction,
+    rawResponse: parsed.rawResponse,
+    modelUsed: parsed.modelUsed,
+    costUsd: parsed.costUsd,
+  });
+  const advisoryMarkdown = renderConsultationAdvisory(parsed);
+  writeConsultationAdvisory(opts.runsRoot, opts.runId, generationResult.generation, advisoryMarkdown);
+
+  return {
+    status: 200,
+    body: {
+      consultation_id: rowId,
+      run_id: opts.runId,
+      generation: generationResult.generation,
+      trigger: "operator_request",
+      critique: parsed.critique,
+      alternative_hypothesis: parsed.alternativeHypothesis,
+      tiebreak_recommendation: parsed.tiebreakRecommendation,
+      suggested_next_action: parsed.suggestedNextAction,
+      model_used: parsed.modelUsed,
+      cost_usd: parsed.costUsd,
+      advisory_markdown: advisoryMarkdown,
+    },
+  };
+}
+
+function resolveConsultationGeneration(
+  body: Record<string, unknown>,
+  generations: GenerationRow[],
+): { generation: number } | { response: CockpitApiResponse } {
+  const requested = body.generation;
+  if (requested !== undefined && requested !== null) {
+    if (typeof requested !== "number" || !Number.isInteger(requested) || requested < 1) {
+      return { response: { status: 400, body: { detail: "generation must be a positive integer" } } };
+    }
+    if (!generations.some((generation) => generation.generation_index === requested)) {
+      return {
+        response: {
+          status: 404,
+          body: { detail: `Generation ${requested} not found` },
+        },
+      };
+    }
+    return { generation: requested };
+  }
+  return {
+    generation: Math.max(...generations.map((generation) => generation.generation_index)),
+  };
+}
+
+function createConsultationProvider(
+  settings: AppSettings,
+  createProvider: (opts: CreateProviderOpts) => LLMProvider,
+): { provider: LLMProvider } | { response: CockpitApiResponse } {
+  const providerType = settings.consultationProvider.trim() || "anthropic";
+  const apiKey = settings.consultationApiKey || settings.anthropicApiKey || "";
+  if (requiresConsultationApiKey(providerType) && apiKey.length === 0) {
+    return {
+      response: {
+        status: 503,
+        body: { detail: "Consultation provider not configured (missing API key)" },
+      },
+    };
+  }
+
+  try {
+    return {
+      provider: createProvider({
+        apiKey,
+        baseUrl: settings.consultationBaseUrl || undefined,
+        claudeFallbackModel: settings.claudeFallbackModel,
+        claudeModel: settings.claudeModel,
+        claudePermissionMode: settings.claudePermissionMode,
+        claudeSessionPersistence: settings.claudeSessionPersistence,
+        claudeTimeout: settings.claudeTimeout,
+        claudeTools: settings.claudeTools ?? undefined,
+        codexApprovalMode: settings.codexApprovalMode,
+        codexModel: settings.codexModel,
+        codexQuiet: settings.codexQuiet,
+        codexTimeout: settings.codexTimeout,
+        codexWorkspace: settings.codexWorkspace,
+        model: settings.consultationModel,
+        piCommand: settings.piCommand,
+        piModel: settings.piModel,
+        piNoContextFiles: settings.piNoContextFiles,
+        piRpcApiKey: settings.piRpcApiKey,
+        piRpcEndpoint: settings.piRpcEndpoint,
+        piRpcSessionPersistence: settings.piRpcSessionPersistence,
+        piTimeout: settings.piTimeout,
+        piWorkspace: settings.piWorkspace,
+        providerType,
+      }),
+    };
+  } catch (error: unknown) {
+    return {
+      response: {
+        status: 503,
+        body: { detail: `Consultation provider not configured: ${errorMessage(error)}` },
+      },
+    };
+  }
+}
+
+function requiresConsultationApiKey(providerType: string): boolean {
+  return new Set([
+    "anthropic",
+    "azure-openai",
+    "gemini",
+    "groq",
+    "mistral",
+    "openai",
+    "openai-compatible",
+    "openrouter",
+  ]).has(providerType.toLowerCase().trim());
+}
+
+async function completeConsultation(
+  provider: LLMProvider,
+  settings: AppSettings,
+  opts: {
+    contextSummary: string;
+    gateHistory: string[];
+    generation: number;
+    runId: string;
+    scoreHistory: number[];
+    strategySummary: string;
+  },
+): Promise<{ completion: CompletionResult } | { response: CockpitApiResponse }> {
+  try {
+    const completion = await provider.complete({
+      systemPrompt: [
+        "You are a strategy consultant for an iterative optimisation system.",
+        "Provide analysis using these markdown sections:",
+        "## Critique",
+        "## Alternative Hypothesis",
+        "## Tiebreak Recommendation",
+        "## Suggested Next Action",
+      ].join("\n"),
+      userPrompt: [
+        `Run: ${opts.runId}, Generation: ${opts.generation}`,
+        "Trigger: operator_request",
+        `Context: ${opts.contextSummary}`,
+        `Current strategy: ${opts.strategySummary}`,
+        `Score history: ${formatNumberHistory(opts.scoreHistory)}`,
+        `Gate history: ${opts.gateHistory.join(" -> ")}`,
+      ].join("\n"),
+      model: settings.consultationModel,
+      temperature: 0.3,
+      maxTokens: 1200,
+    });
+    return { completion };
+  } catch (error: unknown) {
+    return {
+      response: {
+        status: 502,
+        body: { detail: `Consultation call failed: ${errorMessage(error)}` },
+      },
+    };
+  }
+}
+
+interface ParsedConsultation {
+  critique: string;
+  alternativeHypothesis: string;
+  tiebreakRecommendation: string;
+  suggestedNextAction: string;
+  rawResponse: string;
+  modelUsed: string;
+  costUsd: number | null;
+}
+
+function parseConsultationCompletion(
+  completion: CompletionResult,
+  provider: LLMProvider,
+): ParsedConsultation {
+  const critique = extractMarkdownSection(completion.text, "Critique");
+  const alternativeHypothesis = extractMarkdownSection(completion.text, "Alternative Hypothesis");
+  const tiebreakRecommendation = extractMarkdownSection(completion.text, "Tiebreak Recommendation");
+  const suggestedNextAction = extractMarkdownSection(completion.text, "Suggested Next Action");
+  const hasStructuredSections = [
+    critique,
+    alternativeHypothesis,
+    tiebreakRecommendation,
+    suggestedNextAction,
+  ].some((value) => value.length > 0);
+  return {
+    critique: hasStructuredSections ? critique : completion.text.trim(),
+    alternativeHypothesis,
+    tiebreakRecommendation,
+    suggestedNextAction,
+    rawResponse: completion.text,
+    modelUsed: completion.model ?? provider.defaultModel(),
+    costUsd: completion.costUsd ?? null,
+  };
+}
+
+function renderConsultationAdvisory(result: ParsedConsultation): string {
+  const sections: string[] = [];
+  if (result.critique) {
+    sections.push(`## Critique\n${result.critique}`);
+  }
+  if (result.alternativeHypothesis) {
+    sections.push(`## Alternative Hypothesis\n${result.alternativeHypothesis}`);
+  }
+  if (result.tiebreakRecommendation) {
+    sections.push(`## Tiebreak Recommendation\n${result.tiebreakRecommendation}`);
+  }
+  if (result.suggestedNextAction) {
+    sections.push(`## Suggested Next Action\n${result.suggestedNextAction}`);
+  }
+  if (result.modelUsed) {
+    sections.push(`---\n*Consultation model: ${result.modelUsed}*`);
+  }
+  return sections.length > 0 ? sections.join("\n\n") : "*No advisory content.*";
+}
+
+function latestCompetitorStrategy(
+  store: SQLiteStore,
+  runId: string,
+  generations: GenerationRow[],
+): string {
+  for (const generation of [...generations].sort(
+    (left, right) => right.generation_index - left.generation_index,
+  )) {
+    const output = store
+      .getAgentOutputs(runId, generation.generation_index)
+      .filter((entry) => entry.role === "competitor")
+      .at(-1);
+    if (output) {
+      return truncate(output.content, 500);
+    }
+  }
+  return "";
+}
+
+function writeConsultationAdvisory(
+  runsRoot: string,
+  runId: string,
+  generation: number,
+  markdown: string,
+): void {
+  const advisoryPath = resolveContainedPath(
+    runsRoot,
+    runId,
+    "generations",
+    `gen_${generation}`,
+    "consultation.md",
+  );
+  mkdirSync(dirname(advisoryPath), { recursive: true });
+  if (existsSync(advisoryPath)) {
+    const existing = readFileSync(advisoryPath, "utf-8");
+    writeFileSync(
+      advisoryPath,
+      `${existing.trimEnd()}\n\n# Operator Requested Consultation\n\n${markdown}\n`,
+      "utf-8",
+    );
+    return;
+  }
+  writeFileSync(advisoryPath, `${markdown}\n`, "utf-8");
+}
+
+function readOptionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function formatNumberHistory(values: number[], maxItems = 8): string {
+  const recent = values.slice(-maxItems).map((value) => value.toFixed(2)).join(" -> ");
+  if (values.length <= maxItems) {
+    return recent;
+  }
+  return `${recent} (recent ${Math.min(values.length, maxItems)} of ${values.length})`;
+}
+
+function extractMarkdownSection(content: string, heading: string): string {
+  const match = new RegExp(
+    `##\\s*${escapeRegExp(heading)}\\s*\\n([\\s\\S]*?)(?=\\n##\\s|$)`,
+    "i",
+  ).exec(content);
+  return match?.[1]?.trim() ?? "";
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+}
+
+function resolveContainedPath(root: string, ...segments: string[]): string {
+  const resolvedRoot = resolve(root);
+  const target = resolve(resolvedRoot, ...segments);
+  const pathToTarget = relative(resolvedRoot, target);
+  if (pathToTarget === "" || (!pathToTarget.startsWith("..") && !isAbsolute(pathToTarget))) {
+    return target;
+  }
+  throw new Error("path escapes configured root");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/ts/src/server/cockpit-writeup.ts
+++ b/ts/src/server/cockpit-writeup.ts
@@ -1,0 +1,241 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import { assertSafeScenarioId } from "../knowledge/scenario-id.js";
+import type { RunRow, SQLiteStore, TrajectoryRow } from "../storage/index.js";
+
+export function buildWriteup(store: SQLiteStore, run: RunRow, knowledgeRoot: string): string {
+  const persisted = latestPersistedTraceWriteup(knowledgeRoot, run.run_id);
+  if (persisted !== null) {
+    return persisted;
+  }
+
+  const trajectory = store.getScoreTrajectory(run.run_id);
+  const sections = [
+    `# Run Summary: ${run.run_id}`,
+    "",
+    `- **Scenario**: ${run.scenario}`,
+    `- **Target generations**: ${run.target_generations}`,
+    `- **Status**: ${run.status}`,
+    `- **Created**: ${run.created_at}`,
+    "",
+    "## Score Trajectory",
+    "",
+  ];
+
+  if (trajectory.length === 0) {
+    sections.push("No completed generations.", "");
+  } else {
+    sections.push("| Gen | Best Score | Elo | Delta | Gate |");
+    sections.push("|-----|------------|-----|-------|------|");
+    for (const generation of trajectory) {
+      sections.push(
+        `| ${generation.generation_index} | ${generation.best_score.toFixed(2)} `
+          + `| ${generation.elo.toFixed(0)} | ${formatDelta(generation.delta)} `
+          + `| ${generation.gate_decision} |`,
+      );
+    }
+    sections.push("");
+  }
+
+  sections.push("## Gate Decisions", "");
+  if (trajectory.length === 0) {
+    sections.push("No gate decisions recorded.", "");
+  } else {
+    for (const generation of trajectory) {
+      sections.push(`- Generation ${generation.generation_index}: **${generation.gate_decision}**`);
+    }
+    sections.push("");
+  }
+
+  const bestOutput = bestCompetitorOutput(store, run.run_id, trajectory);
+  if (bestOutput) {
+    sections.push("## Best Strategy", "");
+    sections.push(`Generation ${bestOutput.generation} (score: ${bestOutput.bestScore.toFixed(2)}):`, "");
+    sections.push("```");
+    sections.push(truncate(bestOutput.content, 500));
+    sections.push("```", "");
+  }
+
+  const playbook = readScenarioPlaybook(knowledgeRoot, run.scenario);
+  if (playbook !== null && !playbook.includes("No playbook yet")) {
+    sections.push("## Playbook", "");
+    sections.push(truncate(playbook, 1000), "");
+  }
+
+  return sections.join("\n");
+}
+
+function bestCompetitorOutput(
+  store: SQLiteStore,
+  runId: string,
+  trajectory: TrajectoryRow[],
+): { generation: number; bestScore: number; content: string } | null {
+  if (trajectory.length === 0) {
+    return null;
+  }
+  const best = trajectory.reduce((current, candidate) => (
+    candidate.best_score > current.best_score ? candidate : current
+  ));
+  const output = store
+    .getAgentOutputs(runId, best.generation_index)
+    .filter((entry) => entry.role === "competitor")
+    .at(-1);
+  if (!output) {
+    return null;
+  }
+  return {
+    generation: best.generation_index,
+    bestScore: best.best_score,
+    content: output.content,
+  };
+}
+
+function latestPersistedTraceWriteup(knowledgeRoot: string, runId: string): string | null {
+  const writeupsDir = join(knowledgeRoot, "analytics", "writeups");
+  if (!existsSync(writeupsDir)) {
+    return null;
+  }
+
+  let best: { createdAt: string; markdown: string } | null = null;
+  for (const file of readdirSync(writeupsDir)) {
+    if (!file.endsWith(".json")) {
+      continue;
+    }
+    const parsed = readJsonRecord(join(writeupsDir, file));
+    if (parsed === null || readString(parsed, "run_id") !== runId) {
+      continue;
+    }
+    const createdAt = readString(parsed, "created_at") ?? "";
+    const markdown = renderTraceWriteup(parsed);
+    if (best === null || createdAt > best.createdAt) {
+      best = { createdAt, markdown };
+    }
+  }
+  return best?.markdown ?? null;
+}
+
+function renderTraceWriteup(writeup: Record<string, unknown>): string {
+  const runId = readString(writeup, "run_id") ?? "unknown";
+  const metadata = readRecord(writeup, "metadata") ?? {};
+  const scenario = readString(metadata, "scenario") ?? "";
+  const family = readString(metadata, "scenario_family") ?? "";
+  const lines = [`# Run Summary: ${runId}`, ""];
+  const context = [scenario, family].filter((value) => value.length > 0).join(" | ");
+  if (context.length > 0) {
+    lines.push(`**Context:** ${context}`, "");
+  }
+
+  lines.push("## Trace Summary", readString(writeup, "summary") ?? "", "");
+  lines.push("## Findings");
+  const findings = readRecordArray(writeup, "findings");
+  if (findings.length === 0) {
+    lines.push("No notable findings.");
+  } else {
+    for (const finding of findings) {
+      const evidence = readStringArray(finding, "evidence_event_ids").join(", ") || "none";
+      lines.push(
+        `- **${readString(finding, "title") ?? "Finding"}** `
+          + `[${readString(finding, "finding_type") ?? "unknown"}/`
+          + `${readString(finding, "severity") ?? "unknown"}] `
+          + `${readString(finding, "description") ?? ""} (evidence: ${evidence})`,
+      );
+    }
+  }
+  lines.push("");
+
+  lines.push("## Failure Motifs");
+  const motifs = readRecordArray(writeup, "failure_motifs");
+  if (motifs.length === 0) {
+    lines.push("No recurring failure motifs.");
+  } else {
+    for (const motif of motifs) {
+      lines.push(
+        `- **${readString(motif, "pattern_name") ?? "motif"}**: `
+          + `${readNumber(motif, "occurrence_count") ?? 0} occurrence(s)`,
+      );
+    }
+  }
+  lines.push("");
+
+  lines.push("## Recovery Paths");
+  const recoveries = readRecordArray(writeup, "recovery_paths");
+  if (recoveries.length === 0) {
+    lines.push("No recovery paths observed.");
+  } else {
+    for (const recovery of recoveries) {
+      lines.push(
+        `- ${readString(recovery, "failure_event_id") ?? "unknown"} -> `
+          + `${readString(recovery, "recovery_event_id") ?? "unknown"} `
+          + `(${readStringArray(recovery, "path_event_ids").length} events)`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function readScenarioPlaybook(knowledgeRoot: string, scenario: string): string | null {
+  try {
+    const scenarioId = assertSafeScenarioId(scenario, "scenario");
+    const playbookPath = resolveContainedPath(knowledgeRoot, scenarioId, "playbook.md");
+    return existsSync(playbookPath) ? readFileSync(playbookPath, "utf-8") : null;
+  } catch {
+    return null;
+  }
+}
+
+function readJsonRecord(path: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function readNumber(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key];
+  return typeof value === "number" ? value : null;
+}
+
+function readRecord(record: Record<string, unknown>, key: string): Record<string, unknown> | null {
+  const value = record[key];
+  return isRecord(value) ? value : null;
+}
+
+function readRecordArray(record: Record<string, unknown>, key: string): Array<Record<string, unknown>> {
+  const value = record[key];
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function readStringArray(record: Record<string, unknown>, key: string): string[] {
+  const value = record[key];
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function formatDelta(value: number): string {
+  return value >= 0 ? `+${value.toFixed(4)}` : value.toFixed(4);
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+}
+
+function resolveContainedPath(root: string, ...segments: string[]): string {
+  const resolvedRoot = resolve(root);
+  const target = resolve(resolvedRoot, ...segments);
+  const pathToTarget = relative(resolvedRoot, target);
+  if (pathToTarget === "" || (!pathToTarget.startsWith("..") && !isAbsolute(pathToTarget))) {
+    return target;
+  }
+  throw new Error("path escapes configured root");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/ts/src/server/http-api-parity.ts
+++ b/ts/src/server/http-api-parity.ts
@@ -28,6 +28,7 @@ export interface HttpApiParityMatrix {
 
 const PY_APP = "autocontext/src/autocontext/server/app.py";
 const TS_SERVER = "ts/src/server/ws-server.ts";
+const PY_COCKPIT_API = "autocontext/src/autocontext/server/cockpit_api.py";
 const PY_OPENCLAW_API = "autocontext/src/autocontext/server/openclaw_api.py";
 
 function both(
@@ -200,21 +201,19 @@ export const HTTP_API_PARITY_ROUTES: readonly HttpApiParityEntry[] = [
     "Mission run, pause, resume, and cancel actions are currently TypeScript-only.",
   ),
 
-  ...pythonOnlyRoutes("cockpit", "autocontext/src/autocontext/server/cockpit_api.py", [
-    ["GET", "/api/cockpit/notebooks"],
-    ["GET", "/api/cockpit/notebooks/:session_id"],
-    ["GET", "/api/cockpit/notebooks/:session_id/effective-context"],
-    ["PUT", "/api/cockpit/notebooks/:session_id"],
-    ["DELETE", "/api/cockpit/notebooks/:session_id"],
-    ["GET", "/api/cockpit/runs"],
-    ["GET", "/api/cockpit/runs/:run_id/status"],
-    ["GET", "/api/cockpit/runs/:run_id/changelog"],
-    ["GET", "/api/cockpit/runs/:run_id/compare/:gen_a/:gen_b"],
-    ["GET", "/api/cockpit/runs/:run_id/resume"],
-    ["GET", "/api/cockpit/writeup/:run_id"],
-    ["POST", "/api/cockpit/runs/:run_id/consult"],
-    ["GET", "/api/cockpit/runs/:run_id/consultations"],
-  ]),
+  both("cockpit", "GET", "/api/cockpit/notebooks", PY_COCKPIT_API),
+  both("cockpit", "GET", "/api/cockpit/notebooks/:session_id", PY_COCKPIT_API),
+  both("cockpit", "GET", "/api/cockpit/notebooks/:session_id/effective-context", PY_COCKPIT_API),
+  both("cockpit", "PUT", "/api/cockpit/notebooks/:session_id", PY_COCKPIT_API),
+  both("cockpit", "DELETE", "/api/cockpit/notebooks/:session_id", PY_COCKPIT_API),
+  both("cockpit", "GET", "/api/cockpit/runs", PY_COCKPIT_API),
+  both("cockpit", "GET", "/api/cockpit/runs/:run_id/status", PY_COCKPIT_API),
+  both("cockpit", "GET", "/api/cockpit/runs/:run_id/changelog", PY_COCKPIT_API),
+  both("cockpit", "GET", "/api/cockpit/runs/:run_id/compare/:gen_a/:gen_b", PY_COCKPIT_API),
+  both("cockpit", "GET", "/api/cockpit/runs/:run_id/resume", PY_COCKPIT_API),
+  both("cockpit", "GET", "/api/cockpit/writeup/:run_id", PY_COCKPIT_API),
+  both("cockpit", "POST", "/api/cockpit/runs/:run_id/consult", PY_COCKPIT_API),
+  both("cockpit", "GET", "/api/cockpit/runs/:run_id/consultations", PY_COCKPIT_API),
   ...pythonOnlyRoutes("hub", "autocontext/src/autocontext/server/hub_api.py", [
     ["GET", "/api/hub/sessions"],
     ["GET", "/api/hub/sessions/:session_id"],

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -30,6 +30,7 @@ import { executeChatAgentCommand } from "./chat-agent-command-workflow.js";
 import { executeInteractiveControlCommand } from "./interactive-control-command-workflow.js";
 import { executeInteractiveScenarioCommand } from "./interactive-scenario-command-workflow.js";
 import { buildHttpApiParityMatrix } from "./http-api-parity.js";
+import { buildCockpitApiRoutes } from "./cockpit-api.js";
 import { buildKnowledgeApiRoutes } from "./knowledge-api.js";
 import { buildMissionApiRoutes } from "./mission-api.js";
 import { buildMonitorApiRoutes } from "./monitor-api.js";
@@ -187,6 +188,17 @@ export class InteractiveServer {
         this.#runManager.events.emit(event, payload, "notebook");
       },
     });
+    const cockpitNotebookApi = buildNotebookApiRoutes({
+      openStore: () => this.#openStore(),
+      artifacts: artifactStore,
+      emitNotebookEvent: (event, payload) => {
+        this.#runManager.events.emit(event, { ...payload, source: "cockpit" }, "cockpit");
+      },
+    });
+    const cockpitApi = buildCockpitApiRoutes({
+      openStore: () => this.#openStore(),
+      notebookApi: cockpitNotebookApi,
+    });
     const monitorApi = buildMonitorApiRoutes({
       openStore: () => this.#openStore(),
       monitorEngine: settings.monitorEnabled ? this.#getMonitorEngine(settings) : null,
@@ -248,6 +260,7 @@ export class InteractiveServer {
           monitors: "/api/monitors",
           notebooks: "/api/notebooks",
           openclaw: "/api/openclaw",
+          cockpit: "/api/cockpit",
           websocket: "/ws/interactive",
           events: "/ws/events",
         },
@@ -454,6 +467,101 @@ export class InteractiveServer {
     // GET /api/openclaw/skill/manifest
     if (method === "GET" && url === "/api/openclaw/skill/manifest") {
       const response = openClawApi.skillManifest();
+      json(response.status, response.body);
+      return;
+    }
+
+    // Cockpit notebook context routes
+    if (method === "GET" && (url === "/api/cockpit/notebooks" || url === "/api/cockpit/notebooks/")) {
+      const response = cockpitApi.listNotebooks();
+      json(response.status, response.body);
+      return;
+    }
+
+    const cockpitNotebookEffectiveMatch = url.match(
+      /^\/api\/cockpit\/notebooks\/([^/]+)\/effective-context$/,
+    );
+    if (method === "GET" && cockpitNotebookEffectiveMatch) {
+      const [, rawSessionId] = cockpitNotebookEffectiveMatch;
+      const response = cockpitApi.effectiveNotebookContext(decodeURIComponent(rawSessionId!));
+      json(response.status, response.body);
+      return;
+    }
+
+    const cockpitNotebookMatch = url.match(/^\/api\/cockpit\/notebooks\/([^/]+)$/);
+    if (cockpitNotebookMatch) {
+      const [, rawSessionId] = cockpitNotebookMatch;
+      const sessionId = decodeURIComponent(rawSessionId!);
+      if (method === "GET") {
+        const response = cockpitApi.getNotebook(sessionId);
+        json(response.status, response.body);
+        return;
+      }
+      if (method === "PUT") {
+        const response = cockpitApi.upsertNotebook(sessionId, await this.#readJsonBody(req));
+        json(response.status, response.body);
+        return;
+      }
+      if (method === "DELETE") {
+        const response = cockpitApi.deleteNotebook(sessionId);
+        json(response.status, response.body);
+        return;
+      }
+    }
+
+    // Cockpit run routes
+    if (method === "GET" && (url === "/api/cockpit/runs" || url === "/api/cockpit/runs/")) {
+      const response = cockpitApi.listRuns();
+      json(response.status, response.body);
+      return;
+    }
+
+    const cockpitCompareMatch = url.match(
+      /^\/api\/cockpit\/runs\/([^/]+)\/compare\/(\d+)\/(\d+)$/,
+    );
+    if (method === "GET" && cockpitCompareMatch) {
+      const [, rawRunId, rawGenA, rawGenB] = cockpitCompareMatch;
+      const response = cockpitApi.compareGenerations(
+        decodeURIComponent(rawRunId!),
+        Number.parseInt(rawGenA!, 10),
+        Number.parseInt(rawGenB!, 10),
+      );
+      json(response.status, response.body);
+      return;
+    }
+
+    const cockpitRunResourceMatch = url.match(
+      /^\/api\/cockpit\/runs\/([^/]+)\/(status|changelog|resume|consultations)$/,
+    );
+    if (method === "GET" && cockpitRunResourceMatch) {
+      const [, rawRunId, resource] = cockpitRunResourceMatch;
+      const runId = decodeURIComponent(rawRunId!);
+      const response = resource === "status"
+        ? cockpitApi.runStatus(runId)
+        : resource === "changelog"
+          ? cockpitApi.changelog(runId)
+          : resource === "resume"
+            ? cockpitApi.resumeInfo(runId)
+            : cockpitApi.listConsultations(runId);
+      json(response.status, response.body);
+      return;
+    }
+
+    const cockpitConsultMatch = url.match(/^\/api\/cockpit\/runs\/([^/]+)\/consult$/);
+    if (method === "POST" && cockpitConsultMatch) {
+      const [, rawRunId] = cockpitConsultMatch;
+      const response = cockpitApi.requestConsultation(
+        decodeURIComponent(rawRunId!),
+        await this.#readJsonBody(req),
+      );
+      json(response.status, response.body);
+      return;
+    }
+
+    const cockpitWriteupMatch = url.match(/^\/api\/cockpit\/writeup\/([^/]+)$/);
+    if (method === "GET" && cockpitWriteupMatch) {
+      const [, rawRunId] = cockpitWriteupMatch;
+      const response = cockpitApi.writeup(decodeURIComponent(rawRunId!));
       json(response.status, response.body);
       return;
     }

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -198,6 +198,9 @@ export class InteractiveServer {
     const cockpitApi = buildCockpitApiRoutes({
       openStore: () => this.#openStore(),
       notebookApi: cockpitNotebookApi,
+      settings,
+      runsRoot: this.#runManager.getRunsRoot(),
+      knowledgeRoot: this.#runManager.getKnowledgeRoot(),
     });
     const monitorApi = buildMonitorApiRoutes({
       openStore: () => this.#openStore(),
@@ -550,7 +553,7 @@ export class InteractiveServer {
     const cockpitConsultMatch = url.match(/^\/api\/cockpit\/runs\/([^/]+)\/consult$/);
     if (method === "POST" && cockpitConsultMatch) {
       const [, rawRunId] = cockpitConsultMatch;
-      const response = cockpitApi.requestConsultation(
+      const response = await cockpitApi.requestConsultation(
         decodeURIComponent(rawRunId!),
         await this.#readJsonBody(req),
       );

--- a/ts/src/storage/consultation-store.ts
+++ b/ts/src/storage/consultation-store.ts
@@ -1,0 +1,92 @@
+import type Database from "better-sqlite3";
+
+import type { ConsultationRow, InsertConsultationOpts } from "./storage-contracts.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isConsultationRow(value: unknown): value is ConsultationRow {
+  return isRecord(value)
+    && typeof value.id === "number"
+    && typeof value.run_id === "string"
+    && typeof value.generation_index === "number"
+    && typeof value.trigger === "string"
+    && typeof value.context_summary === "string"
+    && typeof value.critique === "string"
+    && typeof value.alternative_hypothesis === "string"
+    && typeof value.tiebreak_recommendation === "string"
+    && typeof value.suggested_next_action === "string"
+    && typeof value.raw_response === "string"
+    && typeof value.model_used === "string"
+    && (typeof value.cost_usd === "number" || value.cost_usd === null)
+    && typeof value.created_at === "string";
+}
+
+function requireConsultationRow(value: unknown): ConsultationRow {
+  if (!isConsultationRow(value)) {
+    throw new Error("invalid consultation row");
+  }
+  return value;
+}
+
+export function insertConsultationRecord(
+  db: Database.Database,
+  opts: InsertConsultationOpts,
+): number {
+  const result = db.prepare(`
+    INSERT INTO consultation_log(
+      run_id,
+      generation_index,
+      trigger,
+      context_summary,
+      critique,
+      alternative_hypothesis,
+      tiebreak_recommendation,
+      suggested_next_action,
+      raw_response,
+      model_used,
+      cost_usd
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    opts.runId,
+    opts.generationIndex,
+    opts.trigger,
+    opts.contextSummary ?? "",
+    opts.critique ?? "",
+    opts.alternativeHypothesis ?? "",
+    opts.tiebreakRecommendation ?? "",
+    opts.suggestedNextAction ?? "",
+    opts.rawResponse ?? "",
+    opts.modelUsed ?? "",
+    opts.costUsd ?? null,
+  );
+  return Number(result.lastInsertRowid);
+}
+
+export function listConsultationRecords(
+  db: Database.Database,
+  runId: string,
+): ConsultationRow[] {
+  const rows = db.prepare(`
+    SELECT *
+    FROM consultation_log
+    WHERE run_id = ?
+    ORDER BY generation_index ASC, created_at ASC, id ASC
+  `).all(runId);
+  return rows.map((row) => requireConsultationRow(row));
+}
+
+export function totalConsultationCostRecord(
+  db: Database.Database,
+  runId: string,
+): number {
+  const row = db.prepare(
+    "SELECT COALESCE(SUM(cost_usd), 0.0) AS total FROM consultation_log WHERE run_id = ?",
+  ).get(runId);
+  if (!isRecord(row) || typeof row.total !== "number") {
+    return 0;
+  }
+  return row.total;
+}

--- a/ts/src/storage/index.ts
+++ b/ts/src/storage/index.ts
@@ -1,7 +1,9 @@
 export type {
   AgentOutputRow,
+  ConsultationRow,
   GenerationRow,
   HumanFeedbackRow,
+  InsertConsultationOpts,
   InsertMonitorAlertOpts,
   InsertMonitorConditionOpts,
   MatchRow,

--- a/ts/src/storage/sqlite-store.ts
+++ b/ts/src/storage/sqlite-store.ts
@@ -2,8 +2,10 @@ import Database from "better-sqlite3";
 
 import type {
   AgentOutputRow,
+  ConsultationRow,
   GenerationRow,
   HumanFeedbackRow,
+  InsertConsultationOpts,
   InsertMonitorAlertOpts,
   InsertMonitorConditionOpts,
   MatchRow,
@@ -64,6 +66,11 @@ import {
   listStoreMonitorAlerts,
   listStoreMonitorConditions,
 } from "./storage-monitor-facade.js";
+import {
+  getStoreTotalConsultationCost,
+  insertStoreConsultation,
+  listStoreConsultations,
+} from "./storage-consultation-facade.js";
 import { migrateDatabase } from "./storage-migration-workflow.js";
 
 export function configureSqliteDatabase(db: Pick<Database.Database, "pragma">): void {
@@ -204,6 +211,18 @@ export class SQLiteStore {
 
   getLatestMonitorAlert(conditionId: string): MonitorAlertRow | null {
     return getStoreLatestMonitorAlert(this.#db, conditionId);
+  }
+
+  insertConsultation(opts: InsertConsultationOpts): number {
+    return insertStoreConsultation(this.#db, opts);
+  }
+
+  getConsultationsForRun(runId: string): ConsultationRow[] {
+    return listStoreConsultations(this.#db, runId);
+  }
+
+  getTotalConsultationCost(runId: string): number {
+    return getStoreTotalConsultationCost(this.#db, runId);
   }
 
   createRun(

--- a/ts/src/storage/storage-consultation-facade.ts
+++ b/ts/src/storage/storage-consultation-facade.ts
@@ -1,0 +1,29 @@
+import type Database from "better-sqlite3";
+
+import type { ConsultationRow, InsertConsultationOpts } from "./storage-contracts.js";
+import {
+  insertConsultationRecord,
+  listConsultationRecords,
+  totalConsultationCostRecord,
+} from "./consultation-store.js";
+
+export function insertStoreConsultation(
+  db: Database.Database,
+  opts: InsertConsultationOpts,
+): number {
+  return insertConsultationRecord(db, opts);
+}
+
+export function listStoreConsultations(
+  db: Database.Database,
+  runId: string,
+): ConsultationRow[] {
+  return listConsultationRecords(db, runId);
+}
+
+export function getStoreTotalConsultationCost(
+  db: Database.Database,
+  runId: string,
+): number {
+  return totalConsultationCostRecord(db, runId);
+}

--- a/ts/src/storage/storage-contracts.ts
+++ b/ts/src/storage/storage-contracts.ts
@@ -140,6 +140,22 @@ export interface MonitorAlertRow {
   fired_at: string;
 }
 
+export interface ConsultationRow {
+  id: number;
+  run_id: string;
+  generation_index: number;
+  trigger: string;
+  context_summary: string;
+  critique: string;
+  alternative_hypothesis: string;
+  tiebreak_recommendation: string;
+  suggested_next_action: string;
+  raw_response: string;
+  model_used: string;
+  cost_usd: number | null;
+  created_at: string;
+}
+
 export interface InsertMonitorConditionOpts {
   id: string;
   name: string;
@@ -158,6 +174,20 @@ export interface InsertMonitorAlertOpts {
   detail?: string;
   payload?: Record<string, unknown>;
   firedAt?: string;
+}
+
+export interface InsertConsultationOpts {
+  runId: string;
+  generationIndex: number;
+  trigger: string;
+  contextSummary?: string;
+  critique?: string;
+  alternativeHypothesis?: string;
+  tiebreakRecommendation?: string;
+  suggestedNextAction?: string;
+  rawResponse?: string;
+  modelUsed?: string;
+  costUsd?: number | null;
 }
 
 export interface UpsertGenerationOpts {

--- a/ts/src/storage/storage-migration-workflow.ts
+++ b/ts/src/storage/storage-migration-workflow.ts
@@ -18,6 +18,7 @@ export const TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES: Record<string, readonly s
   ],
   "010_session_notebook.sql": ["010_session_notebook.sql"],
   "011_monitors.sql": ["011_monitors.sql"],
+  "012_consultation_log.sql": ["010_consultation_log.sql"],
 };
 
 const TYPESCRIPT_BASELINE_SCHEMA_RECONCILIATION: Record<string, readonly string[]> = {

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -773,7 +773,41 @@ describe("HTTP API — cockpit", () => {
       run_id: "test-run-1",
       scenario_name: "grid_ctf",
     });
-    expect((body as Record<string, unknown>).writeup_markdown).toContain("test-run-1");
+    const writeup = readStringProperty(body, "writeup_markdown");
+    expect(writeup).toContain("test-run-1");
+    expect(writeup).toContain("## Playbook");
+    expect(writeup).toContain("Hold the center route.");
+  });
+
+  it("GET /api/cockpit/writeup/:run_id prefers persisted trace writeups", async () => {
+    const writeupsDir = join(dir, "knowledge", "analytics", "writeups");
+    mkdirSync(writeupsDir, { recursive: true });
+    writeFileSync(
+      join(writeupsDir, "trace-writeup-test-run-1.json"),
+      JSON.stringify({
+        writeup_id: "trace-writeup-test-run-1",
+        run_id: "test-run-1",
+        generation_index: 1,
+        findings: [],
+        failure_motifs: [],
+        recovery_paths: [],
+        summary: "Persisted trace-grounded summary.",
+        created_at: "2025-01-01T00:00:00.000Z",
+        metadata: {
+          scenario: "grid_ctf",
+          scenario_family: "game",
+        },
+      }, null, 2),
+      "utf-8",
+    );
+
+    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/writeup/test-run-1`);
+
+    expect(status).toBe(200);
+    const writeup = readStringProperty(body, "writeup_markdown");
+    expect(writeup).toContain("## Trace Summary");
+    expect(writeup).toContain("Persisted trace-grounded summary.");
+    expect(writeup).not.toContain("## Playbook");
   });
 
   it("GET /api/cockpit/runs/:run_id/changelog returns generation deltas", async () => {
@@ -782,20 +816,64 @@ describe("HTTP API — cockpit", () => {
     expect(status).toBe(200);
     expect(body).toMatchObject({
       run_id: "test-run-1",
-      changes: [],
+      generations: [
+        {
+          generation: 1,
+          score_delta: 0.7,
+          elo_delta: 50,
+          gate_decision: "advance",
+          new_tools: [],
+          playbook_changed: false,
+        },
+      ],
     });
   });
 
-  it("consultation routes are explicit when the TS consultation backend is unavailable", async () => {
-    const consultation = await postJson(`${baseUrl}/api/cockpit/runs/test-run-1/consult`, {
-      context_summary: "Need another opinion.",
-    });
-    expect(consultation.status).toBe(400);
-    expect((consultation.body as Record<string, unknown>).detail).toContain("Consultation is not enabled");
+  it("POST /api/cockpit/runs/:run_id/consult persists a settings-backed advisory", async () => {
+    const savedEnv = {
+      enabled: process.env.AUTOCONTEXT_CONSULTATION_ENABLED,
+      provider: process.env.AUTOCONTEXT_CONSULTATION_PROVIDER,
+      model: process.env.AUTOCONTEXT_CONSULTATION_MODEL,
+    };
+    process.env.AUTOCONTEXT_CONSULTATION_ENABLED = "true";
+    process.env.AUTOCONTEXT_CONSULTATION_PROVIDER = "deterministic";
+    process.env.AUTOCONTEXT_CONSULTATION_MODEL = "deterministic-dev";
 
-    const listed = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/consultations`);
-    expect(listed.status).toBe(200);
-    expect(listed.body).toEqual([]);
+    try {
+      const consultation = await postJson(`${baseUrl}/api/cockpit/runs/test-run-1/consult`, {
+        context_summary: "Need another opinion.",
+      });
+      expect(consultation.status).toBe(200);
+      expect(consultation.body).toMatchObject({
+        run_id: "test-run-1",
+        generation: 1,
+        trigger: "operator_request",
+        model_used: "deterministic-dev",
+      });
+      expect(readStringProperty(consultation.body, "advisory_markdown")).toContain("Consultation model");
+
+      const listed = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/consultations`);
+      expect(listed.status).toBe(200);
+      expect(listed.body).toEqual([
+        expect.objectContaining({
+          run_id: "test-run-1",
+          generation_index: 1,
+          trigger: "operator_request",
+          context_summary: "Need another opinion.",
+          model_used: "deterministic-dev",
+        }),
+      ]);
+      expect(
+        existsSync(join(dir, "runs", "test-run-1", "generations", "gen_1", "consultation.md")),
+      ).toBe(true);
+    } finally {
+      if (savedEnv.enabled === undefined) delete process.env.AUTOCONTEXT_CONSULTATION_ENABLED;
+      else process.env.AUTOCONTEXT_CONSULTATION_ENABLED = savedEnv.enabled;
+      if (savedEnv.provider === undefined) delete process.env.AUTOCONTEXT_CONSULTATION_PROVIDER;
+      else process.env.AUTOCONTEXT_CONSULTATION_PROVIDER = savedEnv.provider;
+      if (savedEnv.model === undefined) delete process.env.AUTOCONTEXT_CONSULTATION_MODEL;
+      else process.env.AUTOCONTEXT_CONSULTATION_MODEL = savedEnv.model;
+    }
   });
 });
 

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -191,6 +191,7 @@ describe("HTTP API — health", () => {
     expect(endpoints.monitors).toBe("/api/monitors");
     expect(endpoints.notebooks).toBe("/api/notebooks");
     expect(endpoints.openclaw).toBe("/api/openclaw");
+    expect(endpoints.cockpit).toBe("/api/cockpit");
     expect(endpoints.knowledge).toMatchObject({
       scenarios: "/api/knowledge/scenarios",
       export: "/api/knowledge/export/:scenario",
@@ -253,6 +254,11 @@ describe("HTTP API — health", () => {
     expect(matrix.routes).toContainEqual(expect.objectContaining({
       method: "POST",
       path: "/api/openclaw/evaluate",
+      status: "aligned",
+    }));
+    expect(matrix.routes).toContainEqual(expect.objectContaining({
+      method: "GET",
+      path: "/api/cockpit/runs",
       status: "aligned",
     }));
     expect(matrix.routes).toContainEqual(expect.objectContaining({
@@ -622,6 +628,174 @@ describe("HTTP API — monitors", () => {
 
     expect(status).toBe(409);
     expect((body as Record<string, unknown>).detail).toContain("invalid monitor condition type");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cockpit endpoints
+// ---------------------------------------------------------------------------
+
+describe("HTTP API — cockpit", () => {
+  let dir: string;
+  let server: Awaited<ReturnType<typeof createTestServer>>["server"];
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    dir = makeTempDir();
+    const s = await createTestServer(dir);
+    server = s.server;
+    baseUrl = s.baseUrl;
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("mirrors notebook CRUD under /api/cockpit/notebooks", async () => {
+    const created = await putJson(`${baseUrl}/api/cockpit/notebooks/test-run-1`, {
+      scenario_name: "grid_ctf",
+      current_objective: "Keep center control.",
+      current_hypotheses: ["Center control raises capture odds."],
+      best_score: 0.1,
+      unresolved_questions: ["Does flank pressure matter?"],
+      operator_observations: ["Prior run preferred middle lanes."],
+      follow_ups: ["Try a higher path bias."],
+    });
+
+    expect(created.status).toBe(200);
+    expect(created.body).toMatchObject({
+      session_id: "test-run-1",
+      scenario_name: "grid_ctf",
+      current_objective: "Keep center control.",
+    });
+
+    const fetched = await fetchJson(`${baseUrl}/api/cockpit/notebooks/test-run-1`);
+    expect(fetched.status).toBe(200);
+    expect(fetched.body).toMatchObject({ session_id: "test-run-1" });
+
+    const listed = await fetchJson(`${baseUrl}/api/cockpit/notebooks`);
+    expect(listed.status).toBe(200);
+    expect(listed.body).toContainEqual(expect.objectContaining({ session_id: "test-run-1" }));
+
+    const effective = await fetchJson(`${baseUrl}/api/cockpit/notebooks/test-run-1/effective-context`);
+    expect(effective.status).toBe(200);
+    expect(effective.body).toMatchObject({
+      session_id: "test-run-1",
+      role_contexts: expect.objectContaining({
+        competitor: expect.stringContaining("Keep center control."),
+      }),
+      warnings: [expect.objectContaining({
+        field: "best_score",
+        warning_type: "stale_score",
+      })],
+      notebook_empty: false,
+    });
+
+    const deleted = await fetch(`${baseUrl}/api/cockpit/notebooks/test-run-1`, { method: "DELETE" });
+    expect(deleted.status).toBe(200);
+  });
+
+  it("GET /api/cockpit/runs returns cockpit run summaries", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs`);
+
+    expect(status).toBe(200);
+    expect(body).toContainEqual(expect.objectContaining({
+      run_id: "test-run-1",
+      scenario_name: "grid_ctf",
+      generations_completed: 1,
+      best_score: 0.7,
+      best_elo: 1050,
+      status: "running",
+    }));
+  });
+
+  it("GET /api/cockpit/runs/:run_id/status returns detailed generation state", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/status`);
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      run_id: "test-run-1",
+      scenario_name: "grid_ctf",
+      target_generations: 3,
+      status: "running",
+      generations: [expect.objectContaining({
+        generation: 1,
+        best_score: 0.7,
+        elo: 1050,
+      })],
+    });
+  });
+
+  it("GET /api/cockpit/runs/:run_id/compare/:gen_a/:gen_b compares generations", async () => {
+    const { SQLiteStore } = await import("../src/storage/index.js");
+    const store = new SQLiteStore(join(dir, "test.db"));
+    store.upsertGeneration("test-run-1", 2, {
+      meanScore: 0.72,
+      bestScore: 0.78,
+      elo: 1105,
+      wins: 4,
+      losses: 1,
+      gateDecision: "advance",
+      status: "completed",
+    });
+    store.close();
+
+    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/compare/1/2`);
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      gen_a: expect.objectContaining({ generation: 1, best_score: 0.7 }),
+      gen_b: expect.objectContaining({ generation: 2, best_score: 0.78 }),
+      score_delta: 0.08,
+      elo_delta: 55,
+    });
+  });
+
+  it("GET /api/cockpit/runs/:run_id/resume returns resume affordances", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/resume`);
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      run_id: "test-run-1",
+      status: "running",
+      last_generation: 1,
+      can_resume: true,
+    });
+    expect((body as Record<string, unknown>).resume_hint).toContain("generation 2");
+  });
+
+  it("GET /api/cockpit/writeup/:run_id returns a markdown writeup", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/writeup/test-run-1`);
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      run_id: "test-run-1",
+      scenario_name: "grid_ctf",
+    });
+    expect((body as Record<string, unknown>).writeup_markdown).toContain("test-run-1");
+  });
+
+  it("GET /api/cockpit/runs/:run_id/changelog returns generation deltas", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/changelog`);
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      run_id: "test-run-1",
+      changes: [],
+    });
+  });
+
+  it("consultation routes are explicit when the TS consultation backend is unavailable", async () => {
+    const consultation = await postJson(`${baseUrl}/api/cockpit/runs/test-run-1/consult`, {
+      context_summary: "Need another opinion.",
+    });
+    expect(consultation.status).toBe(400);
+    expect((consultation.body as Record<string, unknown>).detail).toContain("Consultation is not enabled");
+
+    const listed = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/consultations`);
+    expect(listed.status).toBe(200);
+    expect(listed.body).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a TypeScript cockpit REST adapter for notebook context, run summaries, status, comparison, resume, changelog, writeup, and explicit consultation stubs
- wire /api/cockpit into the HTTP server root discovery and parity matrix
- add HTTP regression coverage for the Python-compatible cockpit surface

## Tests
- npm test -- tests/http-api.test.ts tests/storage.test.ts tests/storage-migration-workflow.test.ts
- npm run lint

Linear: AC-652