### PR TITLE
AC-639 Add storage schema parity checks

### DIFF
--- a/ts/migrations/013_runs_status_default_parity.sql
+++ b/ts/migrations/013_runs_status_default_parity.sql
@@ -1,0 +1,42 @@
+-- AC-639: Align the TypeScript runs.status column default with Python.
+-- SQLite cannot drop a column default in place, so rebuild the table while
+-- preserving existing run rows and the agent_provider column added by TS 009.
+
+PRAGMA foreign_keys=off;
+
+CREATE TABLE runs_without_status_default (
+    run_id TEXT PRIMARY KEY,
+    scenario TEXT NOT NULL,
+    target_generations INTEGER NOT NULL,
+    executor_mode TEXT NOT NULL,
+    status TEXT NOT NULL,
+    agent_provider TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO runs_without_status_default (
+    run_id,
+    scenario,
+    target_generations,
+    executor_mode,
+    status,
+    agent_provider,
+    created_at,
+    updated_at
+)
+SELECT
+    run_id,
+    scenario,
+    target_generations,
+    executor_mode,
+    status,
+    agent_provider,
+    created_at,
+    updated_at
+FROM runs;
+
+DROP TABLE runs;
+ALTER TABLE runs_without_status_default RENAME TO runs;
+
+PRAGMA foreign_keys=on;

--- a/ts/src/storage/schema-parity-manifest.ts
+++ b/ts/src/storage/schema-parity-manifest.ts
@@ -1,0 +1,33 @@
+export const SCHEMA_PARITY_SHARED_TABLES = [
+  "agent_outputs",
+  "agent_role_metrics",
+  "consultation_log",
+  "generation_recovery",
+  "generations",
+  "hub_packages",
+  "hub_promotions",
+  "hub_results",
+  "hub_sessions",
+  "human_feedback",
+  "knowledge_snapshots",
+  "matches",
+  "monitor_alerts",
+  "monitor_conditions",
+  "runs",
+  "session_notebooks",
+  "task_queue",
+] as const;
+
+export const SCHEMA_PARITY_PYTHON_ONLY_TABLES = [
+  {
+    table: "staged_validation_results",
+    reason: "Python-only staged validation metadata until TypeScript staged validation is ported.",
+  },
+] as const;
+
+export const SCHEMA_PARITY_TYPESCRIPT_ONLY_TABLES = [] as const;
+
+export const SCHEMA_PARITY_LEDGER_TABLES = [
+  "schema_migrations",
+  "schema_version",
+] as const;

--- a/ts/tests/storage-migration-workflow.test.ts
+++ b/ts/tests/storage-migration-workflow.test.ts
@@ -20,6 +20,23 @@ function columnNames(db: Database.Database, tableName: string): Set<string> {
   );
 }
 
+function columnDefault(
+  db: Database.Database,
+  tableName: string,
+  columnName: string,
+): string | null {
+  const row = (
+    db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{
+      dflt_value: string | null;
+      name: string;
+    }>
+  ).find((column) => column.name === columnName);
+  if (!row) {
+    throw new Error(`missing column ${tableName}.${columnName}`);
+  }
+  return row.dflt_value;
+}
+
 describe("storage migration workflow", () => {
   let dir: string;
   let db: Database.Database;
@@ -63,8 +80,11 @@ describe("storage migration workflow", () => {
          applied_at TEXT NOT NULL DEFAULT (datetime('now'))
        )`,
     );
+    const pythonMigrations = [...new Set(Object.values(TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES).flat())]
+      .sort();
     const insert = db.prepare("INSERT INTO schema_migrations(version) VALUES (?)");
-    for (const pythonMigration of Object.values(TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES).flat()) {
+    for (const pythonMigration of pythonMigrations) {
+      db.exec(readFileSync(join(PYTHON_MIGRATIONS_DIR, pythonMigration), "utf8"));
       insert.run(pythonMigration);
     }
 
@@ -121,5 +141,59 @@ describe("storage migration workflow", () => {
     for (const pythonMigration of TYPESCRIPT_TO_PYTHON_MIGRATION_BASELINES["009_generation_loop.sql"]) {
       expect(appliedPython.has(pythonMigration)).toBe(true);
     }
+  });
+
+  it("removes the historical runs.status default from existing TypeScript databases", () => {
+    db.exec(
+      `CREATE TABLE runs (
+         run_id TEXT PRIMARY KEY,
+         scenario TEXT NOT NULL,
+         target_generations INTEGER NOT NULL,
+         executor_mode TEXT NOT NULL,
+         status TEXT NOT NULL DEFAULT 'running',
+         agent_provider TEXT NOT NULL DEFAULT '',
+         created_at TEXT NOT NULL DEFAULT (datetime('now')),
+         updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+       );
+       INSERT INTO runs(
+         run_id,
+         scenario,
+         target_generations,
+         executor_mode,
+         status,
+         agent_provider,
+         created_at,
+         updated_at
+       )
+       VALUES (
+         'run-1',
+         'grid_ctf',
+         2,
+         'codex',
+         'queued',
+         'claude',
+         '2026-04-25T00:00:00.000Z',
+         '2026-04-25T00:00:01.000Z'
+       );
+       CREATE TABLE schema_version (
+         filename TEXT PRIMARY KEY,
+         applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+       );
+       INSERT INTO schema_version(filename) VALUES ('009_generation_loop.sql');`,
+    );
+
+    migrateDatabase(db, MIGRATIONS_DIR);
+
+    expect(columnDefault(db, "runs", "status")).toBeNull();
+    expect(
+      db.prepare("SELECT status, agent_provider FROM runs WHERE run_id = ?").get("run-1"),
+    ).toEqual({
+      agent_provider: "claude",
+      status: "queued",
+    });
+    expect(
+      db.prepare("SELECT filename FROM schema_version WHERE filename = ?")
+        .get("013_runs_status_default_parity.sql"),
+    ).toEqual({ filename: "013_runs_status_default_parity.sql" });
   });
 });

--- a/ts/tests/storage-schema-parity.test.ts
+++ b/ts/tests/storage-schema-parity.test.ts
@@ -1,0 +1,214 @@
+import Database from "better-sqlite3";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  SCHEMA_PARITY_LEDGER_TABLES,
+  SCHEMA_PARITY_PYTHON_ONLY_TABLES,
+  SCHEMA_PARITY_SHARED_TABLES,
+  SCHEMA_PARITY_TYPESCRIPT_ONLY_TABLES,
+} from "../src/storage/schema-parity-manifest.js";
+import { migrateDatabase } from "../src/storage/storage-migration-workflow.js";
+
+const TYPESCRIPT_MIGRATIONS_DIR = join(import.meta.dirname, "..", "migrations");
+const PYTHON_MIGRATIONS_DIR = join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "autocontext",
+  "migrations",
+);
+
+type ColumnSnapshot = {
+  defaultValue: string | null;
+  name: string;
+  notNull: boolean;
+  primaryKey: number;
+  type: string;
+};
+
+type ForeignKeySnapshot = {
+  from: string;
+  match: string;
+  onDelete: string;
+  onUpdate: string;
+  table: string;
+  to: string | null;
+};
+
+type IndexSnapshot = {
+  columns: Array<{
+    collation: string | null;
+    descending: boolean;
+    name: string | null;
+  }>;
+  name: string;
+  unique: boolean;
+};
+
+type TableSnapshot = {
+  columns: ColumnSnapshot[];
+  foreignKeys: ForeignKeySnapshot[];
+  indexes: IndexSnapshot[];
+};
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll("\"", "\"\"")}"`;
+}
+
+function applyPythonMigrations(db: Database.Database): void {
+  for (const migration of readdirSync(PYTHON_MIGRATIONS_DIR).filter((file) => file.endsWith(".sql")).sort()) {
+    db.exec(readFileSync(join(PYTHON_MIGRATIONS_DIR, migration), "utf8"));
+  }
+}
+
+function listDomainTables(db: Database.Database): string[] {
+  return (
+    db
+      .prepare(
+        `SELECT name
+           FROM sqlite_schema
+          WHERE type = 'table'
+            AND name NOT LIKE 'sqlite_%'
+          ORDER BY name`,
+      )
+      .all() as Array<{ name: string }>
+  )
+    .map((row) => row.name)
+    .filter((name) => !SCHEMA_PARITY_LEDGER_TABLES.includes(name as typeof SCHEMA_PARITY_LEDGER_TABLES[number]));
+}
+
+function snapshotTable(db: Database.Database, tableName: string): TableSnapshot {
+  const tableIdentifier = quoteIdentifier(tableName);
+  const columns = (
+    db.prepare(`PRAGMA table_info(${tableIdentifier})`).all() as Array<{
+      dflt_value: string | null;
+      name: string;
+      notnull: number;
+      pk: number;
+      type: string;
+    }>
+  )
+    .map((column) => ({
+      defaultValue: column.dflt_value,
+      name: column.name,
+      notNull: column.notnull === 1,
+      primaryKey: column.pk,
+      type: column.type,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const indexes = (
+    db.prepare(`PRAGMA index_list(${tableIdentifier})`).all() as Array<{
+      name: string;
+      origin: string;
+      unique: number;
+    }>
+  )
+    .filter((index) => index.origin === "c")
+    .map((index) => {
+      const columnsForIndex = (
+        db.prepare(`PRAGMA index_xinfo(${quoteIdentifier(index.name)})`).all() as Array<{
+          coll: string | null;
+          desc: number;
+          key: number;
+          name: string | null;
+          seqno: number;
+        }>
+      )
+        .filter((column) => column.key === 1)
+        .sort((left, right) => left.seqno - right.seqno)
+        .map((column) => ({
+          collation: column.coll,
+          descending: column.desc === 1,
+          name: column.name,
+        }));
+      return {
+        columns: columnsForIndex,
+        name: index.name,
+        unique: index.unique === 1,
+      };
+    })
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const foreignKeys = (
+    db.prepare(`PRAGMA foreign_key_list(${tableIdentifier})`).all() as Array<{
+      from: string;
+      match: string;
+      on_delete: string;
+      on_update: string;
+      table: string;
+      to: string | null;
+    }>
+  )
+    .map((foreignKey) => ({
+      from: foreignKey.from,
+      match: foreignKey.match,
+      onDelete: foreignKey.on_delete,
+      onUpdate: foreignKey.on_update,
+      table: foreignKey.table,
+      to: foreignKey.to,
+    }))
+    .sort((left, right) => `${left.table}.${left.from}`.localeCompare(`${right.table}.${right.from}`));
+
+  return { columns, foreignKeys, indexes };
+}
+
+describe("storage schema parity", () => {
+  let dir: string;
+  let typescriptDb: Database.Database;
+  let pythonDb: Database.Database;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ac-schema-parity-"));
+    typescriptDb = new Database(join(dir, "typescript.db"));
+    pythonDb = new Database(join(dir, "python.db"));
+    migrateDatabase(typescriptDb, TYPESCRIPT_MIGRATIONS_DIR);
+    applyPythonMigrations(pythonDb);
+  });
+
+  afterEach(() => {
+    typescriptDb.close();
+    pythonDb.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("keeps every shared storage table structurally aligned", () => {
+    for (const tableName of SCHEMA_PARITY_SHARED_TABLES) {
+      expect(snapshotTable(typescriptDb, tableName), tableName).toEqual(snapshotTable(pythonDb, tableName));
+    }
+  });
+
+  it("documents intentionally one-sided storage tables", () => {
+    const typescriptTables = new Set(listDomainTables(typescriptDb));
+    const pythonTables = new Set(listDomainTables(pythonDb));
+
+    const pythonOnly = [...pythonTables].filter((table) => !typescriptTables.has(table)).sort();
+    const typescriptOnly = [...typescriptTables].filter((table) => !pythonTables.has(table)).sort();
+
+    expect(pythonOnly).toEqual(
+      SCHEMA_PARITY_PYTHON_ONLY_TABLES.map((entry) => entry.table).sort(),
+    );
+    expect(typescriptOnly).toEqual(
+      SCHEMA_PARITY_TYPESCRIPT_ONLY_TABLES.map((entry) => entry.table).sort(),
+    );
+  });
+
+  it("keeps the parity manifest internally consistent", () => {
+    const shared = new Set<string>(SCHEMA_PARITY_SHARED_TABLES);
+    expect(shared.size).toBe(SCHEMA_PARITY_SHARED_TABLES.length);
+
+    const pythonOnly = new Set(SCHEMA_PARITY_PYTHON_ONLY_TABLES.map((entry) => entry.table));
+    const typescriptOnly = new Set(SCHEMA_PARITY_TYPESCRIPT_ONLY_TABLES.map((entry) => entry.table));
+
+    for (const tableName of shared) {
+      expect(pythonOnly.has(tableName), tableName).toBe(false);
+      expect(typescriptOnly.has(tableName), tableName).toBe(false);
+    }
+    for (const tableName of pythonOnly) {
+      expect(typescriptOnly.has(tableName), tableName).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a TypeScript/Python storage schema parity manifest for shared and intentionally one-sided tables
- compare normalized columns, indexes, and foreign keys from fresh TS and Python migration databases
- align the consolidated TS runs.status schema with Python by removing the implicit default

## Tests
- npm test -- tests/storage-schema-parity.test.ts tests/storage-migration-workflow.test.ts
- npm test -- tests/http-api.test.ts tests/storage.test.ts tests/storage-schema-parity.test.ts tests/storage-migration-workflow.test.ts
- npm run lint

Linear: AC-639