### PR TITLE
AC-633 Share scenario family designer pipeline

### DIFF
--- a/ts/src/scenarios/coordination-designer.ts
+++ b/ts/src/scenarios/coordination-designer.ts
@@ -1,10 +1,21 @@
 import type { CoordinationSpec } from "./coordination-spec.js";
 import { parseRawCoordinationSpec } from "./coordination-spec.js";
-import { healSpec } from "./spec-auto-heal.js";
-import { parseDelimitedJsonObject } from "./llm-json-response.js";
+import {
+  designFamilySpec,
+  parseFamilyDesignerSpec,
+  type FamilyDesignerDescriptor,
+} from "./family-designer.js";
 
 export const COORDINATION_SPEC_START = "<!-- COORDINATION_SPEC_START -->";
 export const COORDINATION_SPEC_END = "<!-- COORDINATION_SPEC_END -->";
+
+const COORDINATION_DESCRIPTOR: FamilyDesignerDescriptor<CoordinationSpec> = {
+  family: "coordination",
+  startDelimiter: COORDINATION_SPEC_START,
+  endDelimiter: COORDINATION_SPEC_END,
+  missingDelimiterLabel: "COORDINATION_SPEC",
+  parseRaw: parseRawCoordinationSpec,
+};
 
 const EXAMPLE_SPEC = {
   description: "Multi-agent research report writing.",
@@ -81,24 +92,17 @@ ${COORDINATION_SPEC_END}
 `;
 
 export function parseCoordinationSpec(text: string): CoordinationSpec {
-  return parseRawCoordinationSpec(
-    healSpec(
-      parseDelimitedJsonObject({
-        text,
-        startDelimiter: COORDINATION_SPEC_START,
-        endDelimiter: COORDINATION_SPEC_END,
-        missingDelimiterLabel: "COORDINATION_SPEC",
-      }),
-      "coordination",
-    ),
-  );
+  return parseFamilyDesignerSpec(text, COORDINATION_DESCRIPTOR);
 }
 
 export async function designCoordination(
   description: string,
   llmFn: (system: string, user: string) => Promise<string>,
 ): Promise<CoordinationSpec> {
-  return parseCoordinationSpec(
-    await llmFn(COORDINATION_DESIGNER_SYSTEM, `User description:\n${description}`),
+  return designFamilySpec(
+    description,
+    COORDINATION_DESIGNER_SYSTEM,
+    COORDINATION_DESCRIPTOR,
+    llmFn,
   );
 }

--- a/ts/src/scenarios/investigation-designer.ts
+++ b/ts/src/scenarios/investigation-designer.ts
@@ -1,10 +1,21 @@
 import type { InvestigationSpec } from "./investigation-spec.js";
 import { parseRawInvestigationSpec } from "./investigation-spec.js";
-import { healSpec } from "./spec-auto-heal.js";
-import { parseDelimitedJsonObject } from "./llm-json-response.js";
+import {
+  designFamilySpec,
+  parseFamilyDesignerSpec,
+  type FamilyDesignerDescriptor,
+} from "./family-designer.js";
 
 export const INVESTIGATION_SPEC_START = "<!-- INVESTIGATION_SPEC_START -->";
 export const INVESTIGATION_SPEC_END = "<!-- INVESTIGATION_SPEC_END -->";
+
+const INVESTIGATION_DESCRIPTOR: FamilyDesignerDescriptor<InvestigationSpec> = {
+  family: "investigation",
+  startDelimiter: INVESTIGATION_SPEC_START,
+  endDelimiter: INVESTIGATION_SPEC_END,
+  missingDelimiterLabel: "INVESTIGATION_SPEC",
+  parseRaw: parseRawInvestigationSpec,
+};
 
 const EXAMPLE_SPEC = {
   description: "Investigate a production outage by gathering evidence and identifying the root cause.",
@@ -87,24 +98,17 @@ ${INVESTIGATION_SPEC_END}
 `;
 
 export function parseInvestigationSpec(text: string): InvestigationSpec {
-  return parseRawInvestigationSpec(
-    healSpec(
-      parseDelimitedJsonObject({
-        text,
-        startDelimiter: INVESTIGATION_SPEC_START,
-        endDelimiter: INVESTIGATION_SPEC_END,
-        missingDelimiterLabel: "INVESTIGATION_SPEC",
-      }),
-      "investigation",
-    ),
-  );
+  return parseFamilyDesignerSpec(text, INVESTIGATION_DESCRIPTOR);
 }
 
 export async function designInvestigation(
   description: string,
   llmFn: (system: string, user: string) => Promise<string>,
 ): Promise<InvestigationSpec> {
-  return parseInvestigationSpec(
-    await llmFn(INVESTIGATION_DESIGNER_SYSTEM, `User description:\n${description}`),
+  return designFamilySpec(
+    description,
+    INVESTIGATION_DESIGNER_SYSTEM,
+    INVESTIGATION_DESCRIPTOR,
+    llmFn,
   );
 }

--- a/ts/src/scenarios/negotiation-designer.ts
+++ b/ts/src/scenarios/negotiation-designer.ts
@@ -1,10 +1,21 @@
 import type { NegotiationSpec } from "./negotiation-spec.js";
 import { parseRawNegotiationSpec } from "./negotiation-spec.js";
-import { healSpec } from "./spec-auto-heal.js";
-import { parseDelimitedJsonObject } from "./llm-json-response.js";
+import {
+  designFamilySpec,
+  parseFamilyDesignerSpec,
+  type FamilyDesignerDescriptor,
+} from "./family-designer.js";
 
 export const NEGOTIATION_SPEC_START = "<!-- NEGOTIATION_SPEC_START -->";
 export const NEGOTIATION_SPEC_END = "<!-- NEGOTIATION_SPEC_END -->";
+
+const NEGOTIATION_DESCRIPTOR: FamilyDesignerDescriptor<NegotiationSpec> = {
+  family: "negotiation",
+  startDelimiter: NEGOTIATION_SPEC_START,
+  endDelimiter: NEGOTIATION_SPEC_END,
+  missingDelimiterLabel: "NEGOTIATION_SPEC",
+  parseRaw: parseRawNegotiationSpec,
+};
 
 const EXAMPLE_SPEC = {
   description: "Contract price negotiation with hidden BATNA.",
@@ -92,24 +103,17 @@ ${NEGOTIATION_SPEC_END}
 `;
 
 export function parseNegotiationSpec(text: string): NegotiationSpec {
-  return parseRawNegotiationSpec(
-    healSpec(
-      parseDelimitedJsonObject({
-        text,
-        startDelimiter: NEGOTIATION_SPEC_START,
-        endDelimiter: NEGOTIATION_SPEC_END,
-        missingDelimiterLabel: "NEGOTIATION_SPEC",
-      }),
-      "negotiation",
-    ),
-  );
+  return parseFamilyDesignerSpec(text, NEGOTIATION_DESCRIPTOR);
 }
 
 export async function designNegotiation(
   description: string,
   llmFn: (system: string, user: string) => Promise<string>,
 ): Promise<NegotiationSpec> {
-  return parseNegotiationSpec(
-    await llmFn(NEGOTIATION_DESIGNER_SYSTEM, `User description:\n${description}`),
+  return designFamilySpec(
+    description,
+    NEGOTIATION_DESIGNER_SYSTEM,
+    NEGOTIATION_DESCRIPTOR,
+    llmFn,
   );
 }

--- a/ts/src/scenarios/operator-loop-designer.ts
+++ b/ts/src/scenarios/operator-loop-designer.ts
@@ -1,10 +1,21 @@
 import type { OperatorLoopSpec } from "./operator-loop-spec.js";
 import { parseRawOperatorLoopSpec } from "./operator-loop-spec.js";
-import { healSpec } from "./spec-auto-heal.js";
-import { parseDelimitedJsonObject } from "./llm-json-response.js";
+import {
+  designFamilySpec,
+  parseFamilyDesignerSpec,
+  type FamilyDesignerDescriptor,
+} from "./family-designer.js";
 
 export const OPERATOR_LOOP_SPEC_START = "<!-- OPERATOR_LOOP_SPEC_START -->";
 export const OPERATOR_LOOP_SPEC_END = "<!-- OPERATOR_LOOP_SPEC_END -->";
+
+const OPERATOR_LOOP_DESCRIPTOR: FamilyDesignerDescriptor<OperatorLoopSpec> = {
+  family: "operator_loop",
+  startDelimiter: OPERATOR_LOOP_SPEC_START,
+  endDelimiter: OPERATOR_LOOP_SPEC_END,
+  missingDelimiterLabel: "OPERATOR_LOOP_SPEC",
+  parseRaw: parseRawOperatorLoopSpec,
+};
 
 export const OPERATOR_LOOP_DESIGNER_SYSTEM = `You are describing operator-in-the-loop capabilities for autocontext.
 Given a natural-language request for an operator-in-the-loop scenario, produce an OperatorLoopSpec JSON.
@@ -42,24 +53,17 @@ Rules:
 `;
 
 export function parseOperatorLoopSpec(text: string): OperatorLoopSpec {
-  return parseRawOperatorLoopSpec(
-    healSpec(
-      parseDelimitedJsonObject({
-        text,
-        startDelimiter: OPERATOR_LOOP_SPEC_START,
-        endDelimiter: OPERATOR_LOOP_SPEC_END,
-        missingDelimiterLabel: "OPERATOR_LOOP_SPEC",
-      }),
-      "operator_loop",
-    ),
-  );
+  return parseFamilyDesignerSpec(text, OPERATOR_LOOP_DESCRIPTOR);
 }
 
 export async function designOperatorLoop(
   description: string,
   llmFn: (system: string, user: string) => Promise<string>,
 ): Promise<OperatorLoopSpec> {
-  return parseOperatorLoopSpec(
-    await llmFn(OPERATOR_LOOP_DESIGNER_SYSTEM, `User description:\n${description}`),
+  return designFamilySpec(
+    description,
+    OPERATOR_LOOP_DESIGNER_SYSTEM,
+    OPERATOR_LOOP_DESCRIPTOR,
+    llmFn,
   );
 }

--- a/ts/src/scenarios/schema-evolution-designer.ts
+++ b/ts/src/scenarios/schema-evolution-designer.ts
@@ -1,10 +1,21 @@
 import type { SchemaEvolutionSpec } from "./schema-evolution-spec.js";
 import { parseRawSchemaEvolutionSpec } from "./schema-evolution-spec.js";
-import { healSpec } from "./spec-auto-heal.js";
-import { parseDelimitedJsonObject } from "./llm-json-response.js";
+import {
+  designFamilySpec,
+  parseFamilyDesignerSpec,
+  type FamilyDesignerDescriptor,
+} from "./family-designer.js";
 
 export const SCHEMA_EVOLUTION_SPEC_START = "<!-- SCHEMA_EVOLUTION_SPEC_START -->";
 export const SCHEMA_EVOLUTION_SPEC_END = "<!-- SCHEMA_EVOLUTION_SPEC_END -->";
+
+const SCHEMA_EVOLUTION_DESCRIPTOR: FamilyDesignerDescriptor<SchemaEvolutionSpec> = {
+  family: "schema_evolution",
+  startDelimiter: SCHEMA_EVOLUTION_SPEC_START,
+  endDelimiter: SCHEMA_EVOLUTION_SPEC_END,
+  missingDelimiterLabel: "SCHEMA_EVOLUTION_SPEC",
+  parseRaw: parseRawSchemaEvolutionSpec,
+};
 
 const EXAMPLE_SPEC = {
   description: "API schema evolves from v1 to v3 during a data migration task.",
@@ -101,24 +112,17 @@ ${SCHEMA_EVOLUTION_SPEC_END}
 `;
 
 export function parseSchemaEvolutionSpec(text: string): SchemaEvolutionSpec {
-  return parseRawSchemaEvolutionSpec(
-    healSpec(
-      parseDelimitedJsonObject({
-        text,
-        startDelimiter: SCHEMA_EVOLUTION_SPEC_START,
-        endDelimiter: SCHEMA_EVOLUTION_SPEC_END,
-        missingDelimiterLabel: "SCHEMA_EVOLUTION_SPEC",
-      }),
-      "schema_evolution",
-    ),
-  );
+  return parseFamilyDesignerSpec(text, SCHEMA_EVOLUTION_DESCRIPTOR);
 }
 
 export async function designSchemaEvolution(
   description: string,
   llmFn: (system: string, user: string) => Promise<string>,
 ): Promise<SchemaEvolutionSpec> {
-  return parseSchemaEvolutionSpec(
-    await llmFn(SCHEMA_EVOLUTION_DESIGNER_SYSTEM, `User description:\n${description}`),
+  return designFamilySpec(
+    description,
+    SCHEMA_EVOLUTION_DESIGNER_SYSTEM,
+    SCHEMA_EVOLUTION_DESCRIPTOR,
+    llmFn,
   );
 }

--- a/ts/src/scenarios/simulation-designer.ts
+++ b/ts/src/scenarios/simulation-designer.ts
@@ -1,10 +1,21 @@
 import type { SimulationSpec } from "./simulation-spec.js";
 import { parseRawSimulationSpec } from "./simulation-spec.js";
-import { healSpec } from "./spec-auto-heal.js";
-import { parseDelimitedJsonObject } from "./llm-json-response.js";
+import {
+  designFamilySpec,
+  parseFamilyDesignerSpec,
+  type FamilyDesignerDescriptor,
+} from "./family-designer.js";
 
 export const SIM_SPEC_START = "<!-- SIMULATION_SPEC_START -->";
 export const SIM_SPEC_END = "<!-- SIMULATION_SPEC_END -->";
+
+const SIMULATION_DESCRIPTOR: FamilyDesignerDescriptor<SimulationSpec> = {
+  family: "simulation",
+  startDelimiter: SIM_SPEC_START,
+  endDelimiter: SIM_SPEC_END,
+  missingDelimiterLabel: "SIMULATION_SPEC",
+  parseRaw: parseRawSimulationSpec,
+};
 
 const EXAMPLE_SPEC = {
   description: "Recover a multi-step API workflow after a mid-flow cancellation.",
@@ -74,24 +85,17 @@ ${SIM_SPEC_END}
 `;
 
 export function parseSimulationSpec(text: string): SimulationSpec {
-  return parseRawSimulationSpec(
-    healSpec(
-      parseDelimitedJsonObject({
-        text,
-        startDelimiter: SIM_SPEC_START,
-        endDelimiter: SIM_SPEC_END,
-        missingDelimiterLabel: "SIMULATION_SPEC",
-      }),
-      "simulation",
-    ),
-  );
+  return parseFamilyDesignerSpec(text, SIMULATION_DESCRIPTOR);
 }
 
 export async function designSimulation(
   description: string,
   llmFn: (system: string, user: string) => Promise<string>,
 ): Promise<SimulationSpec> {
-  return parseSimulationSpec(
-    await llmFn(SIMULATION_DESIGNER_SYSTEM, `User description:\n${description}`),
+  return designFamilySpec(
+    description,
+    SIMULATION_DESIGNER_SYSTEM,
+    SIMULATION_DESCRIPTOR,
+    llmFn,
   );
 }

--- a/ts/src/scenarios/workflow-designer.ts
+++ b/ts/src/scenarios/workflow-designer.ts
@@ -1,10 +1,21 @@
 import type { WorkflowSpec } from "./workflow-spec.js";
 import { parseRawWorkflowSpec } from "./workflow-spec.js";
-import { healSpec } from "./spec-auto-heal.js";
-import { parseDelimitedJsonObject } from "./llm-json-response.js";
+import {
+  designFamilySpec,
+  parseFamilyDesignerSpec,
+  type FamilyDesignerDescriptor,
+} from "./family-designer.js";
 
 export const WORKFLOW_SPEC_START = "<!-- WORKFLOW_SPEC_START -->";
 export const WORKFLOW_SPEC_END = "<!-- WORKFLOW_SPEC_END -->";
+
+const WORKFLOW_DESCRIPTOR: FamilyDesignerDescriptor<WorkflowSpec> = {
+  family: "workflow",
+  startDelimiter: WORKFLOW_SPEC_START,
+  endDelimiter: WORKFLOW_SPEC_END,
+  missingDelimiterLabel: "WORKFLOW_SPEC",
+  parseRaw: parseRawWorkflowSpec,
+};
 
 const EXAMPLE_SPEC = {
   description: "Execute an order-processing workflow with compensation when downstream steps fail.",
@@ -113,24 +124,17 @@ ${WORKFLOW_SPEC_END}
 `;
 
 export function parseWorkflowSpec(text: string): WorkflowSpec {
-  return parseRawWorkflowSpec(
-    healSpec(
-      parseDelimitedJsonObject({
-        text,
-        startDelimiter: WORKFLOW_SPEC_START,
-        endDelimiter: WORKFLOW_SPEC_END,
-        missingDelimiterLabel: "WORKFLOW_SPEC",
-      }),
-      "workflow",
-    ),
-  );
+  return parseFamilyDesignerSpec(text, WORKFLOW_DESCRIPTOR);
 }
 
 export async function designWorkflow(
   description: string,
   llmFn: (system: string, user: string) => Promise<string>,
 ): Promise<WorkflowSpec> {
-  return parseWorkflowSpec(
-    await llmFn(WORKFLOW_DESIGNER_SYSTEM, `User description:\n${description}`),
+  return designFamilySpec(
+    description,
+    WORKFLOW_DESIGNER_SYSTEM,
+    WORKFLOW_DESCRIPTOR,
+    llmFn,
   );
 }

--- a/ts/tests/family-designer.test.ts
+++ b/ts/tests/family-designer.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  designFamilySpec,
+  parseFamilyDesignerSpec,
+  type FamilyDesignerDescriptor,
+} from "../src/scenarios/family-designer.js";
+
+type ExampleSpec = {
+  count: number;
+  title: string;
+};
+
+const EXAMPLE_DESCRIPTOR: FamilyDesignerDescriptor<ExampleSpec> = {
+  family: "example",
+  startDelimiter: "<!-- EXAMPLE_START -->",
+  endDelimiter: "<!-- EXAMPLE_END -->",
+  missingDelimiterLabel: "EXAMPLE_SPEC",
+  parseRaw: (raw) => ({
+    count: Number(raw.count),
+    title: String(raw.title),
+  }),
+};
+
+describe("family designer pipeline", () => {
+  it("parses delimited JSON through the shared descriptor path", () => {
+    const spec = parseFamilyDesignerSpec(
+      [
+        "Here is the scenario:",
+        "<!-- EXAMPLE_START -->",
+        JSON.stringify({ count: "3", title: "Delimited" }),
+        "<!-- EXAMPLE_END -->",
+      ].join("\n"),
+      EXAMPLE_DESCRIPTOR,
+    );
+
+    expect(spec).toEqual({ count: 3, title: "Delimited" });
+  });
+
+  it("falls back to raw JSON when delimiters are absent", () => {
+    const spec = parseFamilyDesignerSpec(
+      JSON.stringify({ count: "5", title: "Raw JSON" }),
+      EXAMPLE_DESCRIPTOR,
+    );
+
+    expect(spec).toEqual({ count: 5, title: "Raw JSON" });
+  });
+
+  it("passes designer prompts through the shared design workflow", async () => {
+    const llmFn = vi.fn(async () => JSON.stringify({ count: 8, title: "Designed" }));
+
+    await expect(
+      designFamilySpec(
+        "make an example",
+        "system prompt",
+        EXAMPLE_DESCRIPTOR,
+        llmFn,
+      ),
+    ).resolves.toEqual({ count: 8, title: "Designed" });
+
+    expect(llmFn).toHaveBeenCalledWith(
+      "system prompt",
+      "User description:\nmake an example",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- move simulation, workflow, schema-evolution, operator-loop, investigation, negotiation, and coordination designers onto the shared FamilyDesigner descriptor pipeline
- keep family-specific files focused on prompt text, delimiters, and raw spec parsing
- add focused coverage for delimited parsing, raw JSON fallback, and shared design invocation

## Tests
- npm test -- tests/family-designer.test.ts tests/agent-task-pipeline.test.ts tests/scenario-creator-family-aware.test.ts tests/spec-auto-heal.test.ts
- npm run lint

Linear: AC-633