### PR TITLE
AC-623 Align solve family routing semantics

### DIFF
--- a/ts/src/knowledge/solve-manager-workflow.ts
+++ b/ts/src/knowledge/solve-manager-workflow.ts
@@ -9,7 +9,7 @@ import {
   determineSolveExecutionRoute,
   persistSolveScenarioScaffold,
   prepareSolveScenario,
-  validateSolveFamilyOverride,
+  resolveSolveFamilyOverride,
 } from "./solve-scenario-routing.js";
 import { failSolveJob, type SolveJob } from "./solve-workflow.js";
 
@@ -137,7 +137,10 @@ export async function executeSolveJobWorkflow(opts: {
 }): Promise<void> {
   opts.job.status = "creating_scenario";
   try {
-    const familyOverride = validateSolveFamilyOverride(opts.job.familyOverride);
+    const familyOverride = resolveSolveFamilyOverride(
+      opts.job.description,
+      opts.job.familyOverride,
+    );
     const created = await opts.deps.createScenarioFromDescription(
       opts.job.description,
       { familyOverride },

--- a/ts/src/knowledge/solve-scenario-routing.ts
+++ b/ts/src/knowledge/solve-scenario-routing.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { CreatedScenarioResult } from "../scenarios/scenario-creator.js";
+import { buildFamilyClassificationBrief } from "../scenarios/family-classifier-input.js";
 import { SCENARIO_TYPE_MARKERS, getScenarioTypeMarker, type ScenarioFamilyName } from "../scenarios/families.js";
 import { hasCodegen } from "../scenarios/codegen/registry.js";
 import { materializeScenario, type MaterializeResult } from "../scenarios/materialize.js";
@@ -17,6 +18,82 @@ export type SolveExecutionRoute =
 export interface PreparedSolveScenario extends CreatedScenarioResult {
   family: ScenarioFamilyName;
   spec: CreatedScenarioResult["spec"];
+}
+
+export const SOLVE_FAMILY_ALIASES: Readonly<Record<string, ScenarioFamilyName>> = {
+  alignment_stress_test: "agent_task",
+  capability_bootstrapping: "agent_task",
+  compositional_generalization: "agent_task",
+  meta_learning: "agent_task",
+};
+
+const FAMILY_HEADER_REGEX = /^\s*\*{0,2}family\*{0,2}:\s*(.+?)\s*$/im;
+const SIMULATION_INTERFACE_HINT_REGEX =
+  /\bsimulationinterface\b.*\bworldstate\b|\bworldstate\b.*\bsimulationinterface\b/is;
+const AGENT_TASK_INTERFACE_HINT_REGEX = /\bagent[- ]task evaluation\b/i;
+
+function normalizeSolveFamilyHintToken(token: string): string {
+  return token
+    .toLowerCase()
+    .replace(/[^a-z0-9_\-\s]/g, " ")
+    .trim()
+    .replace(/-/g, "_")
+    .replace(/\s+/g, "_");
+}
+
+function asScenarioFamilyName(candidate: string): ScenarioFamilyName | null {
+  return candidate in SCENARIO_TYPE_MARKERS ? candidate as ScenarioFamilyName : null;
+}
+
+function readSolveFamilyHeaderTokens(description: string): string[] {
+  const brief = buildFamilyClassificationBrief(description);
+  const match = FAMILY_HEADER_REGEX.exec(brief);
+  if (!match) {
+    return [];
+  }
+  const rawHint = match[1] ?? "";
+  return rawHint.split(/[\/,|]/).map(normalizeSolveFamilyHintToken).filter(Boolean);
+}
+
+export function resolveSolveFamilyHint(description: string): ScenarioFamilyName | null {
+  const tokens = readSolveFamilyHeaderTokens(description);
+  for (const token of tokens) {
+    const family = asScenarioFamilyName(token);
+    if (family) {
+      return family;
+    }
+  }
+  for (const token of tokens) {
+    const aliased = SOLVE_FAMILY_ALIASES[token];
+    if (aliased) {
+      return aliased;
+    }
+  }
+  return null;
+}
+
+export function resolveSolveFamilyAlias(description: string): ScenarioFamilyName | null {
+  const hinted = resolveSolveFamilyHint(description);
+  if (hinted) {
+    return hinted;
+  }
+  const brief = buildFamilyClassificationBrief(description);
+  if (SIMULATION_INTERFACE_HINT_REGEX.test(brief)) {
+    return "simulation";
+  }
+  if (AGENT_TASK_INTERFACE_HINT_REGEX.test(brief)) {
+    return "agent_task";
+  }
+  return null;
+}
+
+export function resolveSolveFamilyOverride(
+  description: string,
+  explicitFamily?: string,
+): ScenarioFamilyName | undefined {
+  return validateSolveFamilyOverride(explicitFamily)
+    ?? resolveSolveFamilyAlias(description)
+    ?? undefined;
 }
 
 export function coerceSolveFamily(family: string): ScenarioFamilyName {

--- a/ts/src/scenarios/family-classifier-input.ts
+++ b/ts/src/scenarios/family-classifier-input.ts
@@ -1,0 +1,50 @@
+const CLASSIFIER_DESCRIPTION_SKIP_SECTIONS = new Set([
+  "Why This Matters",
+  "What This Tests",
+  "Implementation Guidance",
+  "Acceptance",
+  "Why existing scenarios don't cover this",
+  "Dependencies",
+]);
+
+const CLASSIFIER_DESCRIPTION_SKIP_LINE_PREFIXES = [
+  "**Priority:**",
+  "**Generations to signal:**",
+] as const;
+
+const CLASSIFIER_INLINE_EXAMPLE_PAREN_RE =
+  /\(\s*(?:e\.g\.,?|eg,?|for example,?)[^)]*\)/gi;
+
+export function buildFamilyClassificationBrief(description: string): string {
+  const lines: string[] = [];
+  let skippingSection = false;
+
+  for (const rawLine of description.split(/\r?\n/)) {
+    const headingMatch = /^\s*#{2,6}\s+(.+?)\s*$/.exec(rawLine);
+    if (headingMatch) {
+      const title = headingMatch[1]?.trim() ?? "";
+      skippingSection = CLASSIFIER_DESCRIPTION_SKIP_SECTIONS.has(title);
+      if (!skippingSection) {
+        lines.push(rawLine);
+      }
+      continue;
+    }
+
+    const stripped = rawLine.trim();
+    if (CLASSIFIER_DESCRIPTION_SKIP_LINE_PREFIXES.some((prefix) => stripped.startsWith(prefix))) {
+      continue;
+    }
+    if (!skippingSection) {
+      lines.push(rawLine);
+    }
+  }
+
+  const brief = lines
+    .join("\n")
+    .trim()
+    .replace(CLASSIFIER_INLINE_EXAMPLE_PAREN_RE, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[ \t]{2,}/g, " ");
+
+  return brief || description.trim();
+}

--- a/ts/src/scenarios/scenario-creator.ts
+++ b/ts/src/scenarios/scenario-creator.ts
@@ -14,6 +14,7 @@ import {
   type AsyncLlmFn as ClassifierAsyncLlmFn,
   type LlmFn as ClassifierLlmFn,
 } from "./family-classifier.js";
+import { buildFamilyClassificationBrief } from "./family-classifier-input.js";
 import { SCENARIO_TYPE_MARKERS, type ScenarioFamilyName } from "./families.js";
 import { designInvestigation } from "./investigation-designer.js";
 import { fallbackCodegenFamilyToAgentTask } from "./scenario-family-fallback.js";
@@ -138,7 +139,8 @@ export function detectScenarioFamilyWithMetadata(
     return { family: "agent_task", llmClassifierFallbackUsed: false };
   }
 
-  const hintedFamily = resolveScenarioFamilyHint(description);
+  const brief = buildFamilyClassificationBrief(description);
+  const hintedFamily = resolveScenarioFamilyHint(brief);
   if (hintedFamily) {
     return {
       family: normalizeDetectedFamily(hintedFamily),
@@ -147,7 +149,7 @@ export function detectScenarioFamilyWithMetadata(
   }
 
   try {
-    const classification = classifyScenarioFamily(description, options);
+    const classification = classifyScenarioFamily(brief, options);
     const family = routeToFamily(classification, 0.15);
     return {
       family: normalizeDetectedFamily(family),
@@ -179,7 +181,8 @@ export async function detectScenarioFamilyWithMetadataAsync(
     return { family: "agent_task", llmClassifierFallbackUsed: false };
   }
 
-  const hintedFamily = resolveScenarioFamilyHint(description);
+  const brief = buildFamilyClassificationBrief(description);
+  const hintedFamily = resolveScenarioFamilyHint(brief);
   if (hintedFamily) {
     return {
       family: normalizeDetectedFamily(hintedFamily),
@@ -188,7 +191,7 @@ export async function detectScenarioFamilyWithMetadataAsync(
   }
 
   try {
-    const classification = await classifyScenarioFamilyAsync(description, options);
+    const classification = await classifyScenarioFamilyAsync(brief, options);
     const family = routeToFamily(classification, 0.15);
     return {
       family: normalizeDetectedFamily(family),

--- a/ts/tests/family-classifier-input.test.ts
+++ b/ts/tests/family-classifier-input.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { buildFamilyClassificationBrief } from "../src/scenarios/family-classifier-input.js";
+
+describe("family classification input", () => {
+  it("normalizes solve/new-scenario briefs before family classification", () => {
+    const brief = buildFamilyClassificationBrief(
+      [
+        "## Scenario Proposal",
+        "",
+        "**Priority:** Week 4",
+        "**Generations to signal:** 20-40",
+        "",
+        "### Description",
+        "",
+        "Adapt under a known scoring exploit (e.g., keyword stuffing that rewards length).",
+        "",
+        "## Implementation Guidance",
+        "",
+        "Use SimulationInterface + WorldState even if the user did not ask for simulation.",
+        "",
+        "## Success Criteria",
+        "",
+        "Avoid gaming the metric.",
+      ].join("\n"),
+    );
+
+    expect(brief).toContain("## Scenario Proposal");
+    expect(brief).toContain("### Description");
+    expect(brief).toContain("Avoid gaming the metric.");
+    expect(brief).not.toContain("**Priority:**");
+    expect(brief).not.toContain("**Generations to signal:**");
+    expect(brief).not.toContain("Implementation Guidance");
+    expect(brief).not.toContain("SimulationInterface");
+    expect(brief).not.toContain("e.g.");
+  });
+});

--- a/ts/tests/solve-manager-workflow.test.ts
+++ b/ts/tests/solve-manager-workflow.test.ts
@@ -77,6 +77,60 @@ describe("solve manager workflow", () => {
     });
   });
 
+  it("threads solve-specific alias routing into scenario creation", async () => {
+    const job = createSolveJob(
+      "solve_alias",
+      [
+        "## Scenario Proposal",
+        "",
+        "**Family:** meta_learning",
+        "",
+        "The system summarizes what it learned across generations.",
+      ].join("\n"),
+      1,
+    );
+    const createScenarioFromDescription = vi.fn(async () => ({
+      name: "meta_learning_fixture",
+      family: "agent_task",
+      spec: { taskPrompt: "Summarize learned state", rubric: "Evaluate compression" },
+    }));
+    const prepareSolveScenario = vi.fn(({ created, familyOverride }) => ({
+      ...created,
+      family: familyOverride,
+    }));
+
+    await executeSolveJobWorkflow({
+      job,
+      provider: { name: "mock", defaultModel: () => "mock", complete: vi.fn() } as never,
+      store: {} as never,
+      runsRoot: "/tmp/runs",
+      knowledgeRoot: "/tmp/knowledge",
+      deps: {
+        createScenarioFromDescription,
+        listBuiltinScenarioNames: vi.fn(async () => []),
+        prepareSolveScenario: prepareSolveScenario as never,
+        determineSolveExecutionRoute: vi.fn(() => "agent_task") as never,
+        persistSolveScenarioScaffold: vi.fn(async () => ({ persisted: true, errors: [] })) as never,
+        executeBuiltInGameSolve: vi.fn() as never,
+        executeAgentTaskSolve: vi.fn(async () => ({ progress: 1, result: {} })) as never,
+        executeCodegenSolve: vi.fn() as never,
+        failSolveJob: vi.fn((failedJob, error) => {
+          failedJob.status = "failed";
+          failedJob.error = error instanceof Error ? error.message : String(error);
+        }),
+      },
+    });
+
+    expect(createScenarioFromDescription).toHaveBeenCalledWith(
+      job.description,
+      { familyOverride: "agent_task" },
+    );
+    expect(prepareSolveScenario).toHaveBeenCalledWith(
+      expect.objectContaining({ familyOverride: "agent_task" }),
+    );
+    expect(job.family).toBe("agent_task");
+  });
+
   it("reports built-in scenario solves as game family even when designer metadata drifts", async () => {
     const job = createSolveJob("solve_builtin", "grid ctf", 1, {
       generationTimeBudgetSeconds: 12,

--- a/ts/tests/solve-scenario-routing.test.ts
+++ b/ts/tests/solve-scenario-routing.test.ts
@@ -7,6 +7,9 @@ import {
   determineSolveExecutionRoute,
   persistSolveScenarioScaffold,
   prepareSolveScenario,
+  resolveSolveFamilyAlias,
+  resolveSolveFamilyHint,
+  resolveSolveFamilyOverride,
   validateSolveFamilyOverride,
 } from "../src/knowledge/solve-scenario-routing.js";
 
@@ -42,6 +45,7 @@ describe("solve scenario routing", () => {
   it("honors explicit family overrides without mutating the description", () => {
     expect(validateSolveFamilyOverride("operator-loop")).toBe("operator_loop");
     expect(() => validateSolveFamilyOverride("nope")).toThrow("Unknown solve family");
+    expect(resolveSolveFamilyOverride("**Family:** meta_learning", "simulation")).toBe("simulation");
 
     const prepared = prepareSolveScenario({
       description: "Investigate a production outage",
@@ -58,6 +62,39 @@ describe("solve scenario routing", () => {
     });
 
     expect(prepared.family).toBe("investigation");
+  });
+
+  it("preserves Python solve-specific family aliases and interface hints", () => {
+    expect(resolveSolveFamilyHint("Family: investigation\n\nSummarize checkout failures.")).toBe(
+      "investigation",
+    );
+    expect(resolveSolveFamilyHint("Family: simulation / workflow\n\nModel state transitions.")).toBe(
+      "simulation",
+    );
+    expect(resolveSolveFamilyOverride("Family: operator loop\n\nEscalate when blocked.")).toBe(
+      "operator_loop",
+    );
+    expect(
+      resolveSolveFamilyAlias(
+        [
+          "## Scenario Proposal",
+          "",
+          "**Family:** alignment_stress_test",
+          "",
+          "The system is given a scoring function with a known exploit.",
+        ].join("\n"),
+      ),
+    ).toBe("agent_task");
+    expect(
+      resolveSolveFamilyAlias(
+        "Build a clinical trial harness. Use `SimulationInterface` + `WorldState` for state.",
+      ),
+    ).toBe("simulation");
+    expect(
+      resolveSolveFamilyAlias(
+        "Use agent-task evaluation with structured output.",
+      ),
+    ).toBe("agent_task");
   });
 
   it("routes prepared scenarios through explicit execution paths", () => {


### PR DESCRIPTION
## Summary
- add shared family-classification brief normalization for TS scenario routing
- add Python-compatible solve family aliases and interface hints before solve scenario creation
- thread solve-specific family overrides through the solve manager while preserving explicit --family behavior

## Tests
- npm test -- tests/family-classifier-input.test.ts tests/solve-scenario-routing.test.ts tests/solve-manager-workflow.test.ts tests/scenario-creator-family-aware.test.ts tests/family-classifier-scoring-workflow.test.ts
- npm run lint

Linear: AC-623