### PR TITLE
feat: establish transitional core/control package facades

### DIFF
--- a/autocontext/tests/test_package_topology.py
+++ b/autocontext/tests/test_package_topology.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOPOLOGY_PATH = REPO_ROOT / "packages" / "package-topology.json"
+
+
+@dataclass(frozen=True, slots=True)
+class PythonPackageShell:
+    role: str
+    name: str
+    path: Path
+    module: str
+
+
+def _load_topology() -> dict[str, object]:
+    return json.loads(TOPOLOGY_PATH.read_text(encoding="utf-8"))
+
+
+def _load_pyproject(path: Path) -> dict[str, object]:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def _python_shells() -> list[PythonPackageShell]:
+    topology = _load_topology()
+    python_topology = topology["python"]
+    assert isinstance(python_topology, dict)
+    shells: list[PythonPackageShell] = []
+    for role in ("core", "control"):
+        entry = python_topology[role]
+        assert isinstance(entry, dict)
+        shells.append(
+            PythonPackageShell(
+                role=role,
+                name=str(entry["name"]),
+                path=REPO_ROOT / str(entry["path"]),
+                module=str(entry["module"]),
+            )
+        )
+    return shells
+
+
+def test_package_topology_manifest_exists() -> None:
+    assert TOPOLOGY_PATH.exists()
+
+
+def test_package_topology_declares_expected_domain_terms() -> None:
+    topology = _load_topology()
+    terms = topology["terms"]
+    assert isinstance(terms, dict)
+    assert set(terms) == {
+        "umbrellaPackage",
+        "corePackage",
+        "controlPackage",
+        "compatibilityShell",
+        "packageTopology",
+    }
+
+
+def test_python_package_shells_exist() -> None:
+    for shell in _python_shells():
+        assert shell.path.exists(), shell.path
+        assert (shell.path / "pyproject.toml").exists(), shell.path / "pyproject.toml"
+        assert (shell.path / "src" / shell.module / "__init__.py").exists()
+
+
+def test_python_package_shell_metadata_matches_topology() -> None:
+    for shell in _python_shells():
+        pyproject = _load_pyproject(shell.path / "pyproject.toml")
+        project = pyproject["project"]
+        assert isinstance(project, dict)
+        assert project["name"] == shell.name
+        assert project["version"] == "0.0.0"
+        assert project["requires-python"] == ">=3.11"
+
+
+def test_python_umbrella_package_keeps_existing_cli_entrypoint() -> None:
+    topology = _load_topology()
+    python_topology = topology["python"]
+    assert isinstance(python_topology, dict)
+    umbrella = python_topology["umbrella"]
+    assert isinstance(umbrella, dict)
+    assert umbrella["name"] == "autocontext"
+    assert umbrella["path"] == "autocontext"
+    assert umbrella["entrypoint"] == "autocontext.cli:app"

--- a/autocontext/tests/test_python_core_package.py
+++ b/autocontext/tests/test_python_core_package.py
@@ -1,0 +1,1312 @@
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from pathlib import Path
+from typing import get_args
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PY_CORE_SRC = REPO_ROOT / "packages" / "python" / "core" / "src"
+if str(PY_CORE_SRC) not in sys.path:
+    sys.path.insert(0, str(PY_CORE_SRC))
+
+core_package = import_module("autocontext_core")
+CompletionResult = core_package.CompletionResult
+ContextBudget = core_package.ContextBudget
+PromptBundle = core_package.PromptBundle
+ProviderError = core_package.ProviderError
+build_prompt_bundle = core_package.build_prompt_bundle
+estimate_tokens = core_package.estimate_tokens
+expected_score = core_package.expected_score
+package_role = core_package.package_role
+package_topology_version = core_package.package_topology_version
+update_elo = core_package.update_elo
+
+
+def test_python_core_package_identity() -> None:
+    assert package_role == "core"
+    assert package_topology_version == 1
+
+
+def test_python_core_reexports_elo_primitives() -> None:
+    assert expected_score(1500, 1500) == 0.5
+    assert update_elo(1500, 1500, 1) == 1512
+
+
+def test_python_core_reexports_prompt_budget_helpers() -> None:
+    assert estimate_tokens("abcdabcd") == 2
+
+    budget = ContextBudget(max_tokens=5)
+    result = budget.apply({"playbook": "12345678901234567890", "hints": "keep-me"})
+
+    assert result["hints"] == "keep-me"
+    assert "truncated for context budget" in result["playbook"]
+
+
+def test_python_core_reexports_prompt_bundle_assembly() -> None:
+    Observation = core_package.Observation
+
+    bundle = build_prompt_bundle(
+        scenario_rules="Follow the rules.",
+        strategy_interface="Return JSON.",
+        evaluation_criteria="Maximize score.",
+        previous_summary="",
+        observation=Observation(narrative="Observe", state={}, constraints=[]),
+        current_playbook="",
+        available_tools="",
+        semantic_compaction=False,
+    )
+
+    assert isinstance(bundle, PromptBundle)
+    assert "Follow the rules." in bundle.competitor
+    assert "Findings, Root Causes, Actionable Recommendations" in bundle.analyst
+    assert "<!-- PLAYBOOK_START -->" in bundle.coach
+
+
+def test_python_core_reexports_provider_primitives() -> None:
+    result = CompletionResult(text="done", model="test-model", usage={"input_tokens": 3}, cost_usd=0.01)
+
+    assert result.text == "done"
+    assert isinstance(ProviderError("boom"), Exception)
+
+
+def test_python_core_reexports_rubric_coherence_helpers() -> None:
+    RubricCoherenceResult = core_package.RubricCoherenceResult
+    check_rubric_coherence = core_package.check_rubric_coherence
+
+    coherence = check_rubric_coherence("Write a brief but comprehensive and concise explanation.")
+
+    assert isinstance(coherence, RubricCoherenceResult)
+    assert coherence.is_coherent is False
+    assert "contradictory" in coherence.warnings[0]
+
+
+def test_python_core_reexports_scenario_value_objects() -> None:
+    Observation = core_package.Observation
+    Result = core_package.Result
+    ReplayEnvelope = core_package.ReplayEnvelope
+    GenerationMetrics = core_package.GenerationMetrics
+    ExecutionLimits = core_package.ExecutionLimits
+
+    observation = Observation(narrative="Observe", state={"board": "ready"}, constraints=["no network"])
+    result = Result(score=0.8, summary="solid", validation_errors=[])
+    replay = ReplayEnvelope(scenario="grid_ctf", seed=7, narrative="turn-by-turn")
+    metrics = GenerationMetrics(
+        generation_index=0,
+        mean_score=0.75,
+        best_score=0.8,
+        elo=1512,
+        wins=2,
+        losses=1,
+        runs=3,
+        gate_decision="promote",
+    )
+    limits = ExecutionLimits(timeout_seconds=30.0, max_memory_mb=1024, network_access=False)
+
+    assert observation.state["board"] == "ready"
+    assert result.passed_validation is True
+    assert replay.seed == 7
+    assert metrics.gate_decision == "promote"
+    assert limits.max_memory_mb == 1024
+
+
+def test_python_core_reexports_judge_value_objects() -> None:
+    DisagreementMetrics = core_package.DisagreementMetrics
+    JudgeResult = core_package.JudgeResult
+    ParseMethod = core_package.ParseMethod
+
+    disagreement = DisagreementMetrics(
+        score_std_dev=0.12,
+        score_range=(0.7, 0.9),
+        sample_scores=[0.7, 0.9],
+        is_high_disagreement=True,
+        sample_count=2,
+    )
+    result = JudgeResult(
+        score=0.8,
+        reasoning="solid",
+        dimension_scores={"accuracy": 0.9},
+        parse_method="markers",
+        disagreement=disagreement,
+    )
+
+    assert disagreement.to_dict()["sample_count"] == 2
+    assert result.dimension_scores["accuracy"] == 0.9
+    assert result.parse_method == "markers"
+    assert "markers" in get_args(ParseMethod)
+
+
+def test_python_core_reexports_scenario_contract_interface() -> None:
+    Observation = core_package.Observation
+    Result = core_package.Result
+    ScenarioInterface = core_package.ScenarioInterface
+
+    class DemoScenario(ScenarioInterface):
+        name = "demo"
+
+        def describe_rules(self) -> str:
+            return "rules"
+
+        def describe_strategy_interface(self) -> str:
+            return "return json"
+
+        def describe_evaluation_criteria(self) -> str:
+            return "maximize score"
+
+        def initial_state(self, seed: int | None = None) -> dict[str, object]:
+            return {"seed": seed}
+
+        def get_observation(self, state: dict[str, object], player_id: str):
+            return Observation(narrative=f"observe {player_id}", state=dict(state), constraints=[])
+
+        def validate_actions(self, state: dict[str, object], player_id: str, actions: dict[str, object]) -> tuple[bool, str]:
+            return True, ""
+
+        def step(self, state: dict[str, object], actions: dict[str, object]) -> dict[str, object]:
+            return {**state, **actions, "terminal": True}
+
+        def is_terminal(self, state: dict[str, object]) -> bool:
+            return bool(state.get("terminal", True))
+
+        def get_result(self, state: dict[str, object]):
+            return Result(score=1.0, summary="done")
+
+        def replay_to_narrative(self, replay: list[dict[str, object]]) -> str:
+            return f"{len(replay)} events"
+
+        def render_frame(self, state: dict[str, object]) -> dict[str, object]:
+            return dict(state)
+
+    scenario = DemoScenario()
+
+    assert isinstance(scenario, ScenarioInterface)
+    assert scenario.describe_rules() == "rules"
+    assert scenario.get_observation({"board": "ready"}, "challenger").narrative == "observe challenger"
+    assert scenario.execute_match({"move": "hold"}, 7).passed_validation is True
+
+
+def test_python_core_reexports_agent_task_family_contracts() -> None:
+    AgentTaskInterface = core_package.AgentTaskInterface
+    AgentTaskResult = core_package.AgentTaskResult
+
+    class DemoAgentTask(AgentTaskInterface):
+        def get_task_prompt(self, state: dict) -> str:
+            return f"solve {state['topic']}"
+
+        def evaluate_output(
+            self,
+            output: str,
+            state: dict,
+            reference_context: str | None = None,
+            required_concepts: list[str] | None = None,
+            calibration_examples: list[dict] | None = None,
+            pinned_dimensions: list[str] | None = None,
+        ):
+            return AgentTaskResult(score=0.8, reasoning=f"accepted {output}")
+
+        def get_rubric(self) -> str:
+            return "be accurate"
+
+        def initial_state(self, seed: int | None = None) -> dict:
+            return {"seed": seed, "topic": "grid_ctf"}
+
+        def describe_task(self) -> str:
+            return "demo task"
+
+    task = DemoAgentTask()
+    result = task.evaluate_output("answer", task.initial_state(7))
+
+    assert isinstance(task, AgentTaskInterface)
+    assert task.get_task_prompt(task.initial_state()) == "solve grid_ctf"
+    assert result.score == 0.8
+    assert task.prepare_context({"topic": "grid_ctf"}) == {"topic": "grid_ctf"}
+    assert task.validate_context({"topic": "grid_ctf"}) == []
+    assert task.revise_output("answer", result, task.initial_state()) == "answer"
+    assert task.verify_facts("answer", task.initial_state()) is None
+
+
+def test_python_core_reexports_artifact_editing_family_contracts() -> None:
+    Artifact = core_package.Artifact
+    ArtifactDiff = core_package.ArtifactDiff
+    ArtifactEditingInterface = core_package.ArtifactEditingInterface
+    ArtifactEditingResult = core_package.ArtifactEditingResult
+    ArtifactValidationResult = core_package.ArtifactValidationResult
+
+    original = [Artifact(path="README.md", content="old", content_type="text")]
+    edited = [
+        Artifact(path="README.md", content="new", content_type="text"),
+        Artifact(path="notes.md", content="extra", content_type="text"),
+    ]
+
+    class DemoArtifactEditing(ArtifactEditingInterface):
+        name = "demo-artifact"
+
+        def describe_task(self) -> str:
+            return "edit files"
+
+        def get_rubric(self) -> str:
+            return "be correct"
+
+        def initial_artifacts(self, seed: int | None = None):
+            return list(original)
+
+        def get_edit_prompt(self, artifacts):
+            return f"edit {len(artifacts)} files"
+
+        def validate_artifact(self, artifact):
+            return ArtifactValidationResult(valid=True, errors=[], warnings=[])
+
+        def evaluate_edits(self, original_artifacts, edited_artifacts):
+            diffs = self.compute_diffs(original_artifacts, edited_artifacts)
+            return ArtifactEditingResult(
+                score=0.8,
+                reasoning="accepted",
+                dimension_scores={"correctness": 0.9},
+                diffs=diffs,
+                validation=ArtifactValidationResult(valid=True, errors=[], warnings=[]),
+                artifacts_modified=len(diffs),
+                artifacts_valid=len(edited_artifacts),
+            )
+
+    scenario = DemoArtifactEditing()
+    result = scenario.evaluate_edits(original, edited)
+    state = scenario.initial_state(seed=7)
+    recreated_artifact = Artifact.from_dict(original[0].to_dict())
+    recreated_diff = ArtifactDiff.from_dict(result.diffs[0].to_dict())
+
+    assert isinstance(scenario, ArtifactEditingInterface)
+    assert scenario.get_edit_prompt(original) == "edit 1 files"
+    assert state["seed"] == 7
+    assert len(state["artifacts"]) == 1
+    assert result.artifacts_modified == 2
+    assert result.artifacts_valid == 2
+    assert result.validation.valid is True
+    assert recreated_artifact.path == "README.md"
+    assert recreated_diff.operation == "modify"
+
+
+def test_python_core_reexports_simulation_family_contracts() -> None:
+    Action = core_package.Action
+    ActionRecord = core_package.ActionRecord
+    ActionResult = core_package.ActionResult
+    ActionSpec = core_package.ActionSpec
+    ActionTrace = core_package.ActionTrace
+    EnvironmentSpec = core_package.EnvironmentSpec
+    SimulationInterface = core_package.SimulationInterface
+    SimulationResult = core_package.SimulationResult
+
+    inspect = ActionSpec(name="inspect", description="Inspect the board", parameters={"target": "cell"})
+    environment = EnvironmentSpec(
+        name="demo-sim",
+        description="A simple simulation",
+        available_actions=[inspect],
+        initial_state_description="board ready",
+        success_criteria=["finish safely"],
+    )
+    action = Action(name="inspect", parameters={"target": "cell-1"}, reasoning="check status")
+    action_result = ActionResult(success=True, output="ok", state_changes={"terminal": True})
+    trace = ActionTrace(
+        records=[
+            ActionRecord(
+                step=1,
+                action=action,
+                result=action_result,
+                state_before={"step": 0},
+                state_after={"step": 1, "terminal": True},
+            )
+        ]
+    )
+
+    class DemoSimulation(SimulationInterface):
+        name = "demo-sim"
+
+        def describe_scenario(self) -> str:
+            return "demo simulation"
+
+        def describe_environment(self):
+            return environment
+
+        def initial_state(self, seed: int | None = None) -> dict[str, object]:
+            return {"seed": seed, "step": 0}
+
+        def get_available_actions(self, state: dict[str, object]):
+            return [inspect]
+
+        def execute_action(self, state: dict[str, object], action):
+            return action_result, {**state, "step": 1, "terminal": True}
+
+        def is_terminal(self, state: dict[str, object]) -> bool:
+            return bool(state.get("terminal", False))
+
+        def evaluate_trace(self, trace, final_state: dict[str, object]):
+            return SimulationResult(
+                score=1.0,
+                reasoning=f"{len(trace.records)} actions",
+                dimension_scores={"workflow": 1.0},
+                workflow_complete=bool(final_state.get("terminal", False)),
+                actions_taken=len(trace.records),
+                actions_successful=1,
+            )
+
+        def get_rubric(self) -> str:
+            return "finish safely"
+
+    scenario = DemoSimulation()
+    evaluation = scenario.evaluate_trace(trace, {"terminal": True})
+    recreated_trace = ActionTrace.from_dict(trace.to_dict())
+
+    assert isinstance(scenario, SimulationInterface)
+    assert scenario.describe_rules().startswith("demo simulation")
+    assert "inspect" in scenario.describe_strategy_interface()
+    assert scenario.get_observation({"step": 0}, "challenger").constraints == ["max_steps=50"]
+    assert scenario.validate_actions({"step": 0}, "challenger", {"actions": [{"name": "inspect", "parameters": {}}]}) == (
+        True,
+        "ok",
+    )
+    assert trace.success_rate == 1.0
+    assert recreated_trace.actions[0].name == "inspect"
+    assert evaluation.workflow_complete is True
+    assert evaluation.actions_taken == 1
+
+
+def test_python_core_reexports_negotiation_family_contracts() -> None:
+    ActionResult = core_package.ActionResult
+    ActionSpec = core_package.ActionSpec
+    EnvironmentSpec = core_package.EnvironmentSpec
+    HiddenPreferences = core_package.HiddenPreferences
+    NegotiationInterface = core_package.NegotiationInterface
+    NegotiationResult = core_package.NegotiationResult
+    NegotiationRound = core_package.NegotiationRound
+    OpponentModel = core_package.OpponentModel
+    SimulationResult = core_package.SimulationResult
+
+    offer = ActionSpec(name="offer", description="Make an offer", parameters={"price": "number"})
+    environment = EnvironmentSpec(
+        name="demo-negotiation",
+        description="Negotiate over price",
+        available_actions=[offer],
+        initial_state_description="start bargaining",
+        success_criteria=["reach a deal"],
+    )
+    preferences = HiddenPreferences(
+        priorities={"price": 1.0},
+        reservation_value=0.4,
+        aspiration_value=0.9,
+        batna_description="walk away",
+    )
+    rounds = [
+        NegotiationRound(
+            round_number=1,
+            offer={"price": 0.6},
+            counter_offer={"price": 0.7},
+            accepted=False,
+            agent_reasoning="start near midpoint",
+        )
+    ]
+    opponent_model = OpponentModel(
+        inferred_priorities={"price": 1.0},
+        inferred_reservation=0.5,
+        strategy_hypothesis="anchoring",
+        confidence=0.8,
+    )
+
+    class DemoNegotiation(NegotiationInterface):
+        name = "demo-negotiation"
+
+        def describe_scenario(self) -> str:
+            return "demo negotiation"
+
+        def describe_environment(self):
+            return environment
+
+        def initial_state(self, seed: int | None = None) -> dict[str, object]:
+            return {"seed": seed, "terminal": False}
+
+        def get_available_actions(self, state: dict[str, object]):
+            return [offer]
+
+        def execute_action(self, state: dict[str, object], action):
+            return ActionResult(success=True, output="offer recorded", state_changes={"terminal": True}), {
+                **state,
+                "terminal": True,
+            }
+
+        def is_terminal(self, state: dict[str, object]) -> bool:
+            return bool(state.get("terminal", False))
+
+        def evaluate_trace(self, trace, final_state: dict[str, object]):
+            return SimulationResult(
+                score=0.9,
+                reasoning="completed",
+                dimension_scores={"workflow": 0.9},
+                workflow_complete=bool(final_state.get("terminal", False)),
+                actions_taken=1,
+                actions_successful=1,
+            )
+
+        def get_rubric(self) -> str:
+            return "reach a deal"
+
+        def get_hidden_preferences(self, state: dict[str, object]):
+            return preferences
+
+        def get_rounds(self, state: dict[str, object]):
+            return list(rounds)
+
+        def get_opponent_model(self, state: dict[str, object]):
+            return opponent_model
+
+        def update_opponent_model(self, state: dict[str, object], model):
+            return {**state, "opponent_model": model.to_dict()}
+
+        def evaluate_negotiation(self, state: dict[str, object]):
+            return NegotiationResult(
+                score=0.85,
+                reasoning="strong deal",
+                dimension_scores={"deal_quality": 0.9},
+                deal_value=0.75,
+                rounds_used=1,
+                max_rounds=5,
+                opponent_model_accuracy=0.8,
+                value_claimed_ratio=0.6,
+            )
+
+    scenario = DemoNegotiation()
+    recreated_preferences = HiddenPreferences.from_dict(preferences.to_dict())
+    recreated_round = NegotiationRound.from_dict(rounds[0].to_dict())
+    recreated_model = OpponentModel.from_dict(opponent_model.to_dict())
+    evaluation = scenario.evaluate_negotiation({"terminal": True})
+    updated_state = scenario.update_opponent_model({"seed": 7}, opponent_model)
+
+    assert isinstance(scenario, NegotiationInterface)
+    assert scenario.describe_scenario() == "demo negotiation"
+    assert scenario.get_hidden_preferences({}).reservation_value == 0.4
+    assert scenario.get_rounds({})[0].round_number == 1
+    assert scenario.get_opponent_model({}).strategy_hypothesis == "anchoring"
+    assert recreated_preferences.batna_description == "walk away"
+    assert recreated_round.counter_offer == {"price": 0.7}
+    assert recreated_model.confidence == 0.8
+    assert updated_state["opponent_model"]["confidence"] == 0.8
+    assert evaluation.deal_value == 0.75
+    assert evaluation.value_claimed_ratio == 0.6
+
+
+def test_python_core_reexports_investigation_family_contracts() -> None:
+    ActionResult = core_package.ActionResult
+    ActionSpec = core_package.ActionSpec
+    EnvironmentSpec = core_package.EnvironmentSpec
+    EvidenceChain = core_package.EvidenceChain
+    EvidenceItem = core_package.EvidenceItem
+    InvestigationInterface = core_package.InvestigationInterface
+    InvestigationResult = core_package.InvestigationResult
+    SimulationResult = core_package.SimulationResult
+
+    inspect = ActionSpec(name="inspect", description="Inspect the system", parameters={"target": "service"})
+    environment = EnvironmentSpec(
+        name="demo-investigation",
+        description="Investigate an incident",
+        available_actions=[inspect],
+        initial_state_description="alerts firing",
+        success_criteria=["identify root cause"],
+    )
+    evidence = [
+        EvidenceItem(
+            id="e-1",
+            content="error logs spike on checkout",
+            source="logs",
+            relevance=0.9,
+            is_red_herring=False,
+        ),
+        EvidenceItem(
+            id="e-2",
+            content="disk alert on analytics",
+            source="monitoring",
+            relevance=0.2,
+            is_red_herring=True,
+        ),
+    ]
+    chain = EvidenceChain(items=[evidence[0]], reasoning="checkout errors align with the incident")
+
+    class DemoInvestigation(InvestigationInterface):
+        name = "demo-investigation"
+
+        def describe_scenario(self) -> str:
+            return "demo investigation"
+
+        def describe_environment(self):
+            return environment
+
+        def initial_state(self, seed: int | None = None) -> dict[str, object]:
+            return {"seed": seed, "terminal": False}
+
+        def get_available_actions(self, state: dict[str, object]):
+            return [inspect]
+
+        def execute_action(self, state: dict[str, object], action):
+            return ActionResult(success=True, output="evidence gathered", state_changes={"terminal": True}), {
+                **state,
+                "terminal": True,
+            }
+
+        def is_terminal(self, state: dict[str, object]) -> bool:
+            return bool(state.get("terminal", False))
+
+        def evaluate_trace(self, trace, final_state: dict[str, object]):
+            return SimulationResult(
+                score=0.9,
+                reasoning="completed",
+                dimension_scores={"workflow": 0.9},
+                workflow_complete=bool(final_state.get("terminal", False)),
+                actions_taken=1,
+                actions_successful=1,
+            )
+
+        def get_rubric(self) -> str:
+            return "identify root cause"
+
+        def get_evidence_pool(self, state: dict[str, object]):
+            return list(evidence)
+
+        def evaluate_evidence_chain(self, chain, state: dict[str, object]) -> float:
+            return 0.95 if not chain.contains_red_herring else 0.1
+
+        def evaluate_diagnosis(self, diagnosis: str, evidence_chain, state: dict[str, object]):
+            return InvestigationResult(
+                score=0.88,
+                reasoning="strong diagnosis",
+                dimension_scores={"accuracy": 0.9},
+                diagnosis=diagnosis,
+                evidence_collected=len(evidence_chain.items),
+                red_herrings_avoided=1,
+                red_herrings_followed=0,
+                diagnosis_correct=True,
+            )
+
+    scenario = DemoInvestigation()
+    recreated_item = EvidenceItem.from_dict(evidence[0].to_dict())
+    recreated_chain = EvidenceChain.from_dict(chain.to_dict())
+    evaluation = scenario.evaluate_diagnosis("checkout db saturation", chain, {"terminal": True})
+
+    assert isinstance(scenario, InvestigationInterface)
+    assert scenario.describe_scenario() == "demo investigation"
+    assert scenario.get_evidence_pool({})[0].id == "e-1"
+    assert scenario.evaluate_evidence_chain(chain, {}) == 0.95
+    assert chain.contains_red_herring is False
+    assert recreated_item.source == "logs"
+    assert recreated_chain.reasoning.startswith("checkout")
+    assert evaluation.diagnosis_correct is True
+    assert evaluation.red_herrings_avoided == 1
+
+
+def test_python_core_reexports_workflow_family_contracts() -> None:
+    ActionResult = core_package.ActionResult
+    ActionSpec = core_package.ActionSpec
+    CompensationAction = core_package.CompensationAction
+    EnvironmentSpec = core_package.EnvironmentSpec
+    SideEffect = core_package.SideEffect
+    SimulationResult = core_package.SimulationResult
+    WorkflowInterface = core_package.WorkflowInterface
+    WorkflowResult = core_package.WorkflowResult
+    WorkflowStep = core_package.WorkflowStep
+
+    submit = ActionSpec(name="submit", description="Submit the order", parameters={"order_id": "string"})
+    environment = EnvironmentSpec(
+        name="demo-workflow",
+        description="Run a transactional workflow",
+        available_actions=[submit],
+        initial_state_description="order pending",
+        success_criteria=["complete all steps"],
+    )
+    steps = [
+        WorkflowStep(
+            name="charge-card",
+            description="Charge the credit card",
+            idempotent=False,
+            reversible=True,
+            compensation="refund-card",
+        )
+    ]
+    side_effects = [
+        SideEffect(
+            step_name="charge-card",
+            effect_type="payment",
+            description="Captured customer funds",
+            reversible=True,
+            reversed=False,
+        )
+    ]
+
+    class DemoWorkflow(WorkflowInterface):
+        name = "demo-workflow"
+
+        def describe_scenario(self) -> str:
+            return "demo workflow"
+
+        def describe_environment(self):
+            return environment
+
+        def initial_state(self, seed: int | None = None) -> dict[str, object]:
+            return {"seed": seed, "terminal": False}
+
+        def get_available_actions(self, state: dict[str, object]):
+            return [submit]
+
+        def execute_action(self, state: dict[str, object], action):
+            return ActionResult(success=True, output="step completed", state_changes={"terminal": True}), {
+                **state,
+                "terminal": True,
+            }
+
+        def is_terminal(self, state: dict[str, object]) -> bool:
+            return bool(state.get("terminal", False))
+
+        def evaluate_trace(self, trace, final_state: dict[str, object]):
+            return SimulationResult(
+                score=0.92,
+                reasoning="completed",
+                dimension_scores={"workflow": 0.92},
+                workflow_complete=bool(final_state.get("terminal", False)),
+                actions_taken=1,
+                actions_successful=1,
+            )
+
+        def get_rubric(self) -> str:
+            return "complete all steps"
+
+        def get_workflow_steps(self):
+            return list(steps)
+
+        def execute_step(self, state: dict[str, object], step):
+            return ActionResult(success=True, output=f"executed {step.name}", state_changes={"terminal": True}), {
+                **state,
+                "terminal": True,
+            }
+
+        def execute_compensation(self, state: dict[str, object], step):
+            return CompensationAction(
+                step_name=step.name,
+                compensation_name="refund-card",
+                success=True,
+                output="refund issued",
+            )
+
+        def get_side_effects(self, state: dict[str, object]):
+            return list(side_effects)
+
+        def evaluate_workflow(self, state: dict[str, object]):
+            return WorkflowResult(
+                score=0.9,
+                reasoning="contained side effects",
+                dimension_scores={"containment": 0.95},
+                steps_completed=1,
+                steps_total=1,
+                retries=0,
+                compensations_triggered=1,
+                compensations_successful=1,
+                side_effects=list(side_effects),
+                side_effects_reversed=1,
+                side_effects_leaked=0,
+            )
+
+    scenario = DemoWorkflow()
+    recreated_step = WorkflowStep.from_dict(steps[0].to_dict())
+    recreated_effect = SideEffect.from_dict(side_effects[0].to_dict())
+    evaluation = scenario.evaluate_workflow({"terminal": True})
+    compensation = scenario.execute_compensation({}, steps[0])
+
+    assert isinstance(scenario, WorkflowInterface)
+    assert scenario.describe_scenario() == "demo workflow"
+    assert scenario.get_workflow_steps()[0].name == "charge-card"
+    assert scenario.get_side_effects({})[0].effect_type == "payment"
+    assert recreated_step.compensation == "refund-card"
+    assert recreated_effect.reversible is True
+    assert compensation.success is True
+    assert evaluation.compensations_successful == 1
+    assert evaluation.side_effects_reversed == 1
+
+
+def test_python_core_reexports_schema_evolution_family_contracts() -> None:
+    ActionResult = core_package.ActionResult
+    ActionSpec = core_package.ActionSpec
+    ContextValidity = core_package.ContextValidity
+    EnvironmentSpec = core_package.EnvironmentSpec
+    SchemaEvolutionInterface = core_package.SchemaEvolutionInterface
+    SchemaEvolutionResult = core_package.SchemaEvolutionResult
+    SchemaMutation = core_package.SchemaMutation
+    SimulationResult = core_package.SimulationResult
+
+    migrate = ActionSpec(name="migrate", description="Apply schema migration", parameters={"version": "int"})
+    environment = EnvironmentSpec(
+        name="demo-schema-evolution",
+        description="Adapt to schema changes",
+        available_actions=[migrate],
+        initial_state_description="schema v1",
+        success_criteria=["adapt without stale assumptions"],
+    )
+    mutation = SchemaMutation(
+        version=2,
+        description="rename customer_id to account_id",
+        fields_added=["account_id"],
+        fields_removed=["customer_id"],
+        fields_modified={"status": "string -> enum"},
+        breaking=True,
+    )
+    validity = [
+        ContextValidity(
+            assumption="customer_id still exists",
+            still_valid=False,
+            invalidated_by_version=2,
+        )
+    ]
+
+    class DemoSchemaEvolution(SchemaEvolutionInterface):
+        name = "demo-schema-evolution"
+
+        def describe_scenario(self) -> str:
+            return "demo schema evolution"
+
+        def describe_environment(self):
+            return environment
+
+        def initial_state(self, seed: int | None = None) -> dict[str, object]:
+            return {"seed": seed, "schema_version": 1, "terminal": False}
+
+        def get_available_actions(self, state: dict[str, object]):
+            return [migrate]
+
+        def execute_action(self, state: dict[str, object], action):
+            return ActionResult(success=True, output="mutation applied", state_changes={"terminal": True}), {
+                **state,
+                "terminal": True,
+            }
+
+        def is_terminal(self, state: dict[str, object]) -> bool:
+            return bool(state.get("terminal", False))
+
+        def evaluate_trace(self, trace, final_state: dict[str, object]):
+            return SimulationResult(
+                score=0.9,
+                reasoning="adapted",
+                dimension_scores={"workflow": 0.9},
+                workflow_complete=bool(final_state.get("terminal", False)),
+                actions_taken=1,
+                actions_successful=1,
+            )
+
+        def get_rubric(self) -> str:
+            return "adapt without stale assumptions"
+
+        def get_mutations(self):
+            return [mutation]
+
+        def get_schema_version(self, state: dict[str, object]) -> int:
+            value = state.get("schema_version", 1)
+            return value if isinstance(value, int) else 1
+
+        def get_mutation_log(self, state: dict[str, object]):
+            return [mutation]
+
+        def apply_mutation(self, state: dict[str, object], mutation):
+            return {**state, "schema_version": mutation.version}
+
+        def check_context_validity(self, state: dict[str, object], assumptions: list[str]):
+            return list(validity)
+
+        def evaluate_adaptation(self, state: dict[str, object]):
+            return SchemaEvolutionResult(
+                score=0.87,
+                reasoning="detected stale context",
+                dimension_scores={"detection": 0.9},
+                mutations_applied=1,
+                stale_assumptions_detected=1,
+                stale_assumptions_missed=0,
+                recovery_actions_taken=1,
+                recovery_actions_successful=1,
+            )
+
+    scenario = DemoSchemaEvolution()
+    recreated_mutation = SchemaMutation.from_dict(mutation.to_dict())
+    recreated_validity = ContextValidity.from_dict(validity[0].to_dict())
+    updated_state = scenario.apply_mutation({"schema_version": 1}, mutation)
+    evaluation = scenario.evaluate_adaptation(updated_state)
+
+    assert isinstance(scenario, SchemaEvolutionInterface)
+    assert scenario.describe_scenario() == "demo schema evolution"
+    assert scenario.get_mutations()[0].version == 2
+    assert scenario.get_schema_version(updated_state) == 2
+    assert scenario.get_mutation_log({})[0].breaking is True
+    assert scenario.check_context_validity({}, ["customer_id still exists"])[0].still_valid is False
+    assert recreated_mutation.fields_removed == ["customer_id"]
+    assert recreated_validity.invalidated_by_version == 2
+    assert evaluation.stale_assumptions_detected == 1
+    assert evaluation.recovery_actions_successful == 1
+
+
+def test_python_core_reexports_tool_fragility_family_contracts() -> None:
+    ActionResult = core_package.ActionResult
+    ActionSpec = core_package.ActionSpec
+    EnvironmentSpec = core_package.EnvironmentSpec
+    FailureAttribution = core_package.FailureAttribution
+    SimulationResult = core_package.SimulationResult
+    ToolContract = core_package.ToolContract
+    ToolDrift = core_package.ToolDrift
+    ToolFragilityInterface = core_package.ToolFragilityInterface
+    ToolFragilityResult = core_package.ToolFragilityResult
+
+    invoke = ActionSpec(name="invoke", description="Call the external tool", parameters={"tool": "string"})
+    environment = EnvironmentSpec(
+        name="demo-tool-fragility",
+        description="Adapt to drifting tool contracts",
+        available_actions=[invoke],
+        initial_state_description="tool v1 available",
+        success_criteria=["adapt after tool drift"],
+    )
+    contract = ToolContract(
+        tool_name="ledger.lookup",
+        version=1,
+        input_schema={"account_id": "string"},
+        output_schema={"balance": "number"},
+        description="Lookup account balance",
+    )
+    drift = ToolDrift(
+        tool_name="ledger.lookup",
+        from_version=1,
+        to_version=2,
+        description="rename account_id to customer_id",
+        drift_type="schema_change",
+        breaking=True,
+    )
+    attribution = FailureAttribution(
+        step=1,
+        failure_class="tool_failure",
+        description="tool rejected stale input schema",
+        tool_name="ledger.lookup",
+        recoverable=True,
+    )
+
+    class DemoToolFragility(ToolFragilityInterface):
+        name = "demo-tool-fragility"
+
+        def describe_scenario(self) -> str:
+            return "demo tool fragility"
+
+        def describe_environment(self):
+            return environment
+
+        def initial_state(self, seed: int | None = None) -> dict[str, object]:
+            return {"seed": seed, "tool_version": 1, "terminal": False}
+
+        def get_available_actions(self, state: dict[str, object]):
+            return [invoke]
+
+        def execute_action(self, state: dict[str, object], action):
+            return ActionResult(success=True, output="tool invoked", state_changes={"terminal": True}), {
+                **state,
+                "terminal": True,
+            }
+
+        def is_terminal(self, state: dict[str, object]) -> bool:
+            return bool(state.get("terminal", False))
+
+        def evaluate_trace(self, trace, final_state: dict[str, object]):
+            return SimulationResult(
+                score=0.91,
+                reasoning="adapted after drift",
+                dimension_scores={"fragility": 0.91},
+                workflow_complete=bool(final_state.get("terminal", False)),
+                actions_taken=1,
+                actions_successful=1,
+            )
+
+        def get_rubric(self) -> str:
+            return "adapt after tool drift"
+
+        def get_tool_contracts(self, state: dict[str, object]):
+            return [contract]
+
+        def get_drift_log(self, state: dict[str, object]):
+            return [drift]
+
+        def inject_drift(self, state: dict[str, object], drift):
+            return {**state, "tool_version": drift.to_version}
+
+        def attribute_failure(self, state: dict[str, object], step: int, error: str):
+            return attribution
+
+        def evaluate_fragility(self, state: dict[str, object]):
+            return ToolFragilityResult(
+                score=0.88,
+                reasoning="detected tool drift quickly",
+                dimension_scores={"adaptation": 0.9},
+                drifts_injected=1,
+                drifts_detected=1,
+                drifts_adapted=1,
+                wasted_attempts=0,
+                failure_attributions=[attribution],
+            )
+
+    scenario = DemoToolFragility()
+    recreated_contract = ToolContract.from_dict(contract.to_dict())
+    recreated_drift = ToolDrift.from_dict(drift.to_dict())
+    recreated_attribution = FailureAttribution.from_dict(attribution.to_dict())
+    updated_state = scenario.inject_drift({"tool_version": 1}, drift)
+    failure = scenario.attribute_failure(updated_state, 1, "missing customer_id")
+    evaluation = scenario.evaluate_fragility(updated_state)
+
+    assert isinstance(scenario, ToolFragilityInterface)
+    assert scenario.describe_scenario() == "demo tool fragility"
+    assert scenario.get_tool_contracts({})[0].tool_name == "ledger.lookup"
+    assert scenario.get_drift_log({})[0].breaking is True
+    assert updated_state["tool_version"] == 2
+    assert failure.failure_class == "tool_failure"
+    assert recreated_contract.output_schema == {"balance": "number"}
+    assert recreated_drift.drift_type == "schema_change"
+    assert recreated_attribution.recoverable is True
+    assert evaluation.drifts_detected == 1
+    assert evaluation.failure_attributions[0].tool_name == "ledger.lookup"
+
+
+def test_python_core_reexports_operator_loop_family_contracts() -> None:
+    ActionResult = core_package.ActionResult
+    ActionSpec = core_package.ActionSpec
+    ClarificationRequest = core_package.ClarificationRequest
+    EnvironmentSpec = core_package.EnvironmentSpec
+    EscalationEvent = core_package.EscalationEvent
+    OperatorLoopInterface = core_package.OperatorLoopInterface
+    OperatorLoopResult = core_package.OperatorLoopResult
+    SimulationResult = core_package.SimulationResult
+
+    approve = ActionSpec(name="approve", description="Approve the deployment", parameters={"ticket": "string"})
+    environment = EnvironmentSpec(
+        name="demo-operator-loop",
+        description="Decide when to escalate or clarify",
+        available_actions=[approve],
+        initial_state_description="pending approval",
+        success_criteria=["escalate only when necessary"],
+    )
+    clarification = ClarificationRequest(
+        question="Is the maintenance window approved?",
+        context="production deploy for payment-api",
+        urgency="high",
+        metadata={"ticket": "chg-123"},
+    )
+    escalation = EscalationEvent(
+        step=2,
+        reason="missing maintenance approval",
+        severity="critical",
+        context="production deploy for payment-api",
+        was_necessary=True,
+        metadata={"ticket": "chg-123"},
+    )
+
+    class DemoOperatorLoop(OperatorLoopInterface):
+        name = "demo-operator-loop"
+
+        def describe_scenario(self) -> str:
+            return "demo operator loop"
+
+        def describe_environment(self):
+            return environment
+
+        def initial_state(self, seed: int | None = None) -> dict[str, object]:
+            return {"seed": seed, "terminal": False, "escalations": 0, "clarifications": 0}
+
+        def get_available_actions(self, state: dict[str, object]):
+            return [approve]
+
+        def execute_action(self, state: dict[str, object], action):
+            return ActionResult(success=True, output="decision recorded", state_changes={"terminal": True}), {
+                **state,
+                "terminal": True,
+            }
+
+        def is_terminal(self, state: dict[str, object]) -> bool:
+            return bool(state.get("terminal", False))
+
+        def evaluate_trace(self, trace, final_state: dict[str, object]):
+            return SimulationResult(
+                score=0.9,
+                reasoning="judged escalation boundary correctly",
+                dimension_scores={"judgment": 0.9},
+                workflow_complete=bool(final_state.get("terminal", False)),
+                actions_taken=1,
+                actions_successful=1,
+            )
+
+        def get_rubric(self) -> str:
+            return "escalate only when necessary"
+
+        def get_escalation_log(self, state: dict[str, object]):
+            return [escalation]
+
+        def get_clarification_log(self, state: dict[str, object]):
+            return [clarification]
+
+        def escalate(self, state: dict[str, object], event):
+            return {**state, "escalations": 1}
+
+        def request_clarification(self, state: dict[str, object], request):
+            return {**state, "clarifications": 1}
+
+        def evaluate_judgment(self, state: dict[str, object]):
+            return OperatorLoopResult(
+                score=0.89,
+                reasoning="escalated when operator approval was required",
+                dimension_scores={"escalation": 0.93},
+                total_actions=2,
+                escalations=1,
+                necessary_escalations=1,
+                unnecessary_escalations=0,
+                missed_escalations=0,
+                clarifications_requested=1,
+            )
+
+    scenario = DemoOperatorLoop()
+    recreated_clarification = ClarificationRequest.from_dict(clarification.to_dict())
+    recreated_escalation = EscalationEvent.from_dict(escalation.to_dict())
+    escalated_state = scenario.escalate({}, escalation)
+    clarified_state = scenario.request_clarification({}, clarification)
+    evaluation = scenario.evaluate_judgment({"terminal": True})
+
+    assert isinstance(scenario, OperatorLoopInterface)
+    assert scenario.describe_scenario() == "demo operator loop"
+    assert scenario.get_escalation_log({})[0].severity == "critical"
+    assert scenario.get_clarification_log({})[0].question.startswith("Is the maintenance")
+    assert escalated_state["escalations"] == 1
+    assert clarified_state["clarifications"] == 1
+    assert recreated_clarification.metadata == {"ticket": "chg-123"}
+    assert recreated_escalation.was_necessary is True
+    assert evaluation.necessary_escalations == 1
+    assert evaluation.clarifications_requested == 1
+
+
+def test_python_core_reexports_coordination_family_contracts() -> None:
+    ActionResult = core_package.ActionResult
+    ActionSpec = core_package.ActionSpec
+    CoordinationInterface = core_package.CoordinationInterface
+    CoordinationResult = core_package.CoordinationResult
+    EnvironmentSpec = core_package.EnvironmentSpec
+    HandoffRecord = core_package.HandoffRecord
+    SimulationResult = core_package.SimulationResult
+    WorkerContext = core_package.WorkerContext
+
+    merge = ActionSpec(name="merge", description="Merge worker outputs", parameters={"run_id": "string"})
+    environment = EnvironmentSpec(
+        name="demo-coordination",
+        description="Coordinate workers with partial context",
+        available_actions=[merge],
+        initial_state_description="two workers have partial context",
+        success_criteria=["handoff cleanly and merge outputs"],
+    )
+    workers = [
+        WorkerContext(
+            worker_id="worker-a",
+            role="researcher",
+            context_partition={"customer": "acme"},
+            visible_data=["customer"],
+            metadata={"team": "alpha"},
+        ),
+        WorkerContext(
+            worker_id="worker-b",
+            role="writer",
+            context_partition={"draft": "pending"},
+            visible_data=["draft"],
+            metadata={"team": "beta"},
+        ),
+    ]
+    handoff = HandoffRecord(
+        from_worker="worker-a",
+        to_worker="worker-b",
+        content="customer context summarized",
+        quality=0.95,
+        step=1,
+        metadata={"channel": "async"},
+    )
+
+    class DemoCoordination(CoordinationInterface):
+        name = "demo-coordination"
+
+        def describe_scenario(self) -> str:
+            return "demo coordination"
+
+        def describe_environment(self):
+            return environment
+
+        def initial_state(self, seed: int | None = None) -> dict[str, object]:
+            return {"seed": seed, "handoffs": 0, "merged": False, "terminal": False}
+
+        def get_available_actions(self, state: dict[str, object]):
+            return [merge]
+
+        def execute_action(self, state: dict[str, object], action):
+            return ActionResult(success=True, output="outputs merged", state_changes={"terminal": True}), {
+                **state,
+                "terminal": True,
+            }
+
+        def is_terminal(self, state: dict[str, object]) -> bool:
+            return bool(state.get("terminal", False))
+
+        def evaluate_trace(self, trace, final_state: dict[str, object]):
+            return SimulationResult(
+                score=0.92,
+                reasoning="workers coordinated successfully",
+                dimension_scores={"coordination": 0.92},
+                workflow_complete=bool(final_state.get("terminal", False)),
+                actions_taken=1,
+                actions_successful=1,
+            )
+
+        def get_rubric(self) -> str:
+            return "handoff cleanly and merge outputs"
+
+        def get_worker_contexts(self, state: dict[str, object]):
+            return list(workers)
+
+        def get_handoff_log(self, state: dict[str, object]):
+            return [handoff]
+
+        def record_handoff(self, state: dict[str, object], handoff):
+            return {**state, "handoffs": 1}
+
+        def merge_outputs(self, state: dict[str, object], worker_outputs: dict[str, str]):
+            return {**state, "merged": bool(worker_outputs), "terminal": True}
+
+        def evaluate_coordination(self, state: dict[str, object]):
+            return CoordinationResult(
+                score=0.9,
+                reasoning="avoided duplication and merged cleanly",
+                dimension_scores={"merge": 0.94},
+                workers_used=2,
+                handoffs_completed=1,
+                duplication_rate=0.0,
+                merge_conflicts=0,
+            )
+
+    scenario = DemoCoordination()
+    recreated_worker = WorkerContext.from_dict(workers[0].to_dict())
+    recreated_handoff = HandoffRecord.from_dict(handoff.to_dict())
+    handed_off_state = scenario.record_handoff({}, handoff)
+    merged_state = scenario.merge_outputs({}, {"worker-a": "facts", "worker-b": "draft"})
+    evaluation = scenario.evaluate_coordination({"terminal": True})
+
+    assert isinstance(scenario, CoordinationInterface)
+    assert scenario.describe_scenario() == "demo coordination"
+    assert scenario.get_worker_contexts({})[0].worker_id == "worker-a"
+    assert scenario.get_handoff_log({})[0].quality == 0.95
+    assert handed_off_state["handoffs"] == 1
+    assert merged_state["merged"] is True
+    assert recreated_worker.metadata == {"team": "alpha"}
+    assert recreated_handoff.metadata == {"channel": "async"}
+    assert evaluation.workers_used == 2
+    assert evaluation.merge_conflicts == 0
+
+
+def test_python_core_reexports_storage_row_contracts() -> None:
+    RunRow = core_package.RunRow
+    GenerationMetricsRow = core_package.GenerationMetricsRow
+    MatchRow = core_package.MatchRow
+    KnowledgeSnapshotRow = core_package.KnowledgeSnapshotRow
+    AgentOutputRow = core_package.AgentOutputRow
+    HumanFeedbackRow = core_package.HumanFeedbackRow
+    TaskQueueRow = core_package.TaskQueueRow
+
+    run_row = {
+        "run_id": "run-1",
+        "scenario": "grid_ctf",
+        "target_generations": 3,
+        "executor_mode": "local",
+        "status": "running",
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    generation_row = {
+        "run_id": "run-1",
+        "generation_index": 0,
+        "mean_score": 0.75,
+        "best_score": 0.8,
+        "elo": 1512.0,
+        "wins": 2,
+        "losses": 1,
+        "gate_decision": "promote",
+        "status": "completed",
+        "duration_seconds": 12.0,
+        "scoring_backend": "elo",
+        "rating_uncertainty": None,
+        "dimension_summary_json": '{"accuracy": 0.9}',
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:01Z",
+    }
+    match_row = {
+        "id": 1,
+        "run_id": "run-1",
+        "generation_index": 0,
+        "seed": 7,
+        "score": 0.75,
+        "winner": "candidate",
+        "strategy_json": "{}",
+        "replay_json": "{}",
+        "passed_validation": 1,
+        "validation_errors": "",
+        "created_at": "2026-01-01T00:00:02Z",
+    }
+    knowledge_snapshot_row = {
+        "scenario": "grid_ctf",
+        "run_id": "run-1",
+        "best_score": 0.8,
+        "best_elo": 1512.0,
+        "playbook_hash": "abc123",
+        "agent_provider": "deterministic",
+        "rlm_enabled": 0,
+        "scoring_backend": "elo",
+        "rating_uncertainty": None,
+        "created_at": "2026-01-01T00:00:03Z",
+    }
+    agent_output_row = {
+        "id": 2,
+        "run_id": "run-1",
+        "generation_index": 0,
+        "role": "competitor",
+        "content": "answer",
+        "created_at": "2026-01-01T00:00:04Z",
+    }
+    human_feedback_row = {
+        "id": 3,
+        "scenario_name": "grid_ctf",
+        "agent_output": "answer",
+        "human_score": 0.8,
+        "human_notes": "solid",
+        "generation_id": "run-1:0",
+        "created_at": "2026-01-01T00:00:05Z",
+    }
+    task_queue_row = {
+        "id": "task-1",
+        "spec_name": "grid_ctf",
+        "priority": 1,
+        "config_json": None,
+        "status": "pending",
+        "scheduled_at": None,
+        "started_at": None,
+        "completed_at": None,
+        "best_score": None,
+        "best_output": None,
+        "total_rounds": 0,
+        "met_threshold": 0,
+        "result_json": None,
+        "error": None,
+        "created_at": "2026-01-01T00:00:06Z",
+    }
+
+    assert run_row["scenario"] == "grid_ctf"
+    assert generation_row["elo"] == 1512.0
+    assert match_row["winner"] == "candidate"
+    assert knowledge_snapshot_row["playbook_hash"] == "abc123"
+    assert agent_output_row["role"] == "competitor"
+    assert human_feedback_row["human_notes"] == "solid"
+    assert task_queue_row["status"] == "pending"
+    assert "scenario" in RunRow.__annotations__
+    assert "elo" in GenerationMetricsRow.__annotations__
+    assert "validation_errors" in MatchRow.__annotations__
+    assert "playbook_hash" in KnowledgeSnapshotRow.__annotations__
+    assert "content" in AgentOutputRow.__annotations__
+    assert "human_notes" in HumanFeedbackRow.__annotations__
+    assert "spec_name" in TaskQueueRow.__annotations__

--- a/packages/python/control/README.md
+++ b/packages/python/control/README.md
@@ -1,0 +1,3 @@
+# autocontext-control skeleton
+
+Internal package skeleton for the future Python control-plane artifact.

--- a/packages/python/control/pyproject.toml
+++ b/packages/python/control/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["hatchling>=1.26.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "autocontext-control"
+version = "0.0.0"
+description = "Internal package skeleton for the future control-plane artifact."
+readme = "README.md"
+requires-python = ">=3.11"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/autocontext_control"]

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -1,0 +1,4 @@
+"""Package skeleton for the future autocontext control-plane artifact."""
+
+PACKAGE_ROLE = "control"
+PACKAGE_TOPOLOGY_VERSION = 1

--- a/packages/python/core/README.md
+++ b/packages/python/core/README.md
@@ -1,0 +1,3 @@
+# autocontext-core skeleton
+
+Internal package skeleton for the future Python core artifact.

--- a/packages/python/core/pyproject.toml
+++ b/packages/python/core/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["hatchling>=1.26.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "autocontext-core"
+version = "0.0.0"
+description = "Internal package skeleton for the future Apache core artifact."
+readme = "README.md"
+requires-python = ">=3.11"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/autocontext_core"]

--- a/packages/python/core/src/autocontext_core/__init__.py
+++ b/packages/python/core/src/autocontext_core/__init__.py
@@ -1,0 +1,183 @@
+"""Facade for the future autocontext Apache core artifact."""
+
+from importlib import import_module
+from typing import Any
+
+_elo = import_module("autocontext.harness.scoring.elo")
+_context_budget = import_module("autocontext.prompts.context_budget")
+_templates = import_module("autocontext.prompts.templates")
+_providers_base = import_module("autocontext.providers.base")
+_execution_judge = import_module("autocontext.execution.judge")
+_rubric_coherence = import_module("autocontext.execution.rubric_coherence")
+_scenarios_agent_task = import_module("autocontext.scenarios.agent_task")
+_scenarios_artifact_editing = import_module("autocontext.scenarios.artifact_editing")
+_scenarios_base = import_module("autocontext.scenarios.base")
+_scenarios_coordination = import_module("autocontext.scenarios.coordination")
+_scenarios_investigation = import_module("autocontext.scenarios.investigation")
+_scenarios_negotiation = import_module("autocontext.scenarios.negotiation")
+_scenarios_operator_loop = import_module("autocontext.scenarios.operator_loop")
+_scenarios_schema_evolution = import_module("autocontext.scenarios.schema_evolution")
+_scenarios_simulation = import_module("autocontext.scenarios.simulation")
+_scenarios_tool_fragility = import_module("autocontext.scenarios.tool_fragility")
+_scenarios_workflow = import_module("autocontext.scenarios.workflow")
+_storage_row_types = import_module("autocontext.storage.row_types")
+
+expected_score = _elo.expected_score
+update_elo = _elo.update_elo
+ContextBudget = _context_budget.ContextBudget
+estimate_tokens = _context_budget.estimate_tokens
+PromptBundle = _templates.PromptBundle
+build_prompt_bundle = _templates.build_prompt_bundle
+Observation: Any = _scenarios_base.Observation
+Result: Any = _scenarios_base.Result
+ReplayEnvelope: Any = _scenarios_base.ReplayEnvelope
+GenerationMetrics: Any = _scenarios_base.GenerationMetrics
+ExecutionLimits: Any = _scenarios_base.ExecutionLimits
+ScenarioInterface: Any = _scenarios_base.ScenarioInterface
+AgentTaskResult: Any = _scenarios_agent_task.AgentTaskResult
+AgentTaskInterface: Any = _scenarios_agent_task.AgentTaskInterface
+Artifact: Any = _scenarios_artifact_editing.Artifact
+ArtifactDiff: Any = _scenarios_artifact_editing.ArtifactDiff
+ArtifactValidationResult: Any = _scenarios_artifact_editing.ArtifactValidationResult
+ArtifactEditingResult: Any = _scenarios_artifact_editing.ArtifactEditingResult
+ArtifactEditingInterface: Any = _scenarios_artifact_editing.ArtifactEditingInterface
+ActionSpec: Any = _scenarios_simulation.ActionSpec
+Action: Any = _scenarios_simulation.Action
+ActionResult: Any = _scenarios_simulation.ActionResult
+ActionRecord: Any = _scenarios_simulation.ActionRecord
+ActionTrace: Any = _scenarios_simulation.ActionTrace
+EnvironmentSpec: Any = _scenarios_simulation.EnvironmentSpec
+SimulationResult: Any = _scenarios_simulation.SimulationResult
+SimulationInterface: Any = _scenarios_simulation.SimulationInterface
+HiddenPreferences: Any = _scenarios_negotiation.HiddenPreferences
+NegotiationRound: Any = _scenarios_negotiation.NegotiationRound
+OpponentModel: Any = _scenarios_negotiation.OpponentModel
+NegotiationResult: Any = _scenarios_negotiation.NegotiationResult
+NegotiationInterface: Any = _scenarios_negotiation.NegotiationInterface
+EvidenceItem: Any = _scenarios_investigation.EvidenceItem
+EvidenceChain: Any = _scenarios_investigation.EvidenceChain
+InvestigationResult: Any = _scenarios_investigation.InvestigationResult
+InvestigationInterface: Any = _scenarios_investigation.InvestigationInterface
+WorkflowStep: Any = _scenarios_workflow.WorkflowStep
+SideEffect: Any = _scenarios_workflow.SideEffect
+CompensationAction: Any = _scenarios_workflow.CompensationAction
+WorkflowResult: Any = _scenarios_workflow.WorkflowResult
+WorkflowInterface: Any = _scenarios_workflow.WorkflowInterface
+SchemaMutation: Any = _scenarios_schema_evolution.SchemaMutation
+ContextValidity: Any = _scenarios_schema_evolution.ContextValidity
+SchemaEvolutionResult: Any = _scenarios_schema_evolution.SchemaEvolutionResult
+SchemaEvolutionInterface: Any = _scenarios_schema_evolution.SchemaEvolutionInterface
+ToolContract: Any = _scenarios_tool_fragility.ToolContract
+ToolDrift: Any = _scenarios_tool_fragility.ToolDrift
+FailureAttribution: Any = _scenarios_tool_fragility.FailureAttribution
+ToolFragilityResult: Any = _scenarios_tool_fragility.ToolFragilityResult
+ToolFragilityInterface: Any = _scenarios_tool_fragility.ToolFragilityInterface
+ClarificationRequest: Any = _scenarios_operator_loop.ClarificationRequest
+EscalationEvent: Any = _scenarios_operator_loop.EscalationEvent
+OperatorLoopResult: Any = _scenarios_operator_loop.OperatorLoopResult
+OperatorLoopInterface: Any = _scenarios_operator_loop.OperatorLoopInterface
+WorkerContext: Any = _scenarios_coordination.WorkerContext
+HandoffRecord: Any = _scenarios_coordination.HandoffRecord
+CoordinationResult: Any = _scenarios_coordination.CoordinationResult
+CoordinationInterface: Any = _scenarios_coordination.CoordinationInterface
+CompletionResult: Any = _providers_base.CompletionResult
+LLMProvider: Any = _providers_base.LLMProvider
+ProviderError: Any = _providers_base.ProviderError
+ParseMethod: Any = _execution_judge.ParseMethod
+DisagreementMetrics: Any = _execution_judge.DisagreementMetrics
+JudgeResult: Any = _execution_judge.JudgeResult
+RubricCoherenceResult: Any = _rubric_coherence.RubricCoherenceResult
+check_rubric_coherence = _rubric_coherence.check_rubric_coherence
+RunRow: Any = _storage_row_types.RunRow
+GenerationMetricsRow: Any = _storage_row_types.GenerationMetricsRow
+MatchRow: Any = _storage_row_types.MatchRow
+KnowledgeSnapshotRow: Any = _storage_row_types.KnowledgeSnapshotRow
+AgentOutputRow: Any = _storage_row_types.AgentOutputRow
+HumanFeedbackRow: Any = _storage_row_types.HumanFeedbackRow
+TaskQueueRow: Any = _storage_row_types.TaskQueueRow
+
+PACKAGE_ROLE = "core"
+PACKAGE_TOPOLOGY_VERSION = 1
+
+package_role = PACKAGE_ROLE
+package_topology_version = PACKAGE_TOPOLOGY_VERSION
+
+__all__ = [
+    "Action",
+    "ActionRecord",
+    "ActionResult",
+    "ActionSpec",
+    "ActionTrace",
+    "AgentOutputRow",
+    "AgentTaskInterface",
+    "AgentTaskResult",
+    "Artifact",
+    "ArtifactDiff",
+    "ArtifactEditingInterface",
+    "ArtifactEditingResult",
+    "ArtifactValidationResult",
+    "ClarificationRequest",
+    "CompensationAction",
+    "CompletionResult",
+    "ContextValidity",
+    "ContextBudget",
+    "DisagreementMetrics",
+    "EnvironmentSpec",
+    "CoordinationInterface",
+    "CoordinationResult",
+    "ExecutionLimits",
+    "FailureAttribution",
+    "GenerationMetrics",
+    "GenerationMetricsRow",
+    "HandoffRecord",
+    "HumanFeedbackRow",
+    "InvestigationInterface",
+    "InvestigationResult",
+    "JudgeResult",
+    "KnowledgeSnapshotRow",
+    "LLMProvider",
+    "MatchRow",
+    "NegotiationInterface",
+    "NegotiationResult",
+    "NegotiationRound",
+    "Observation",
+    "OperatorLoopInterface",
+    "OperatorLoopResult",
+    "OpponentModel",
+    "PACKAGE_ROLE",
+    "PACKAGE_TOPOLOGY_VERSION",
+    "ParseMethod",
+    "PromptBundle",
+    "ProviderError",
+    "ReplayEnvelope",
+    "Result",
+    "RubricCoherenceResult",
+    "RunRow",
+    "ScenarioInterface",
+    "SchemaEvolutionInterface",
+    "SchemaEvolutionResult",
+    "SchemaMutation",
+    "SimulationInterface",
+    "SimulationResult",
+    "EscalationEvent",
+    "EvidenceChain",
+    "EvidenceItem",
+    "HiddenPreferences",
+    "SideEffect",
+    "TaskQueueRow",
+    "ToolContract",
+    "ToolDrift",
+    "ToolFragilityInterface",
+    "ToolFragilityResult",
+    "WorkerContext",
+    "WorkflowInterface",
+    "WorkflowResult",
+    "WorkflowStep",
+    "build_prompt_bundle",
+    "check_rubric_coherence",
+    "estimate_tokens",
+    "expected_score",
+    "package_role",
+    "package_topology_version",
+    "update_elo",
+]

--- a/packages/ts/control-plane/README.md
+++ b/packages/ts/control-plane/README.md
@@ -1,0 +1,3 @@
+# @autocontext/control-plane skeleton
+
+Internal package skeleton for the future TypeScript control-plane artifact.

--- a/packages/ts/control-plane/package.json
+++ b/packages/ts/control-plane/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@autocontext/control-plane",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Internal package skeleton for the future control-plane artifact.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "tsc --noEmit -p tsconfig.json"
+  }
+}

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -1,0 +1,2 @@
+export const packageRole = "control";
+export const packageTopologyVersion = 1;

--- a/packages/ts/control-plane/tsconfig.json
+++ b/packages/ts/control-plane/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../ts/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/ts/core/README.md
+++ b/packages/ts/core/README.md
@@ -1,0 +1,3 @@
+# @autocontext/core skeleton
+
+Internal package skeleton for the future TypeScript core artifact.

--- a/packages/ts/core/package.json
+++ b/packages/ts/core/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@autocontext/core",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Internal package skeleton for the future Apache core artifact.",
+  "type": "module",
+  "main": "dist/packages/ts/core/src/index.js",
+  "types": "dist/packages/ts/core/src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/packages/ts/core/src/index.js",
+      "types": "./dist/packages/ts/core/src/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "tsc --noEmit -p tsconfig.json"
+  }
+}

--- a/packages/ts/core/src/index.ts
+++ b/packages/ts/core/src/index.ts
@@ -1,0 +1,68 @@
+export const packageRole = "core";
+export const packageTopologyVersion = 1;
+
+export { expectedScore, updateElo } from "../../../../ts/src/execution/elo.js";
+export type {
+	ParsedJudge,
+	ParseMethod,
+} from "../../../../ts/src/judge/parse.js";
+export { parseJudgeResponse } from "../../../../ts/src/judge/parse.js";
+export type { RubricCoherenceResult } from "../../../../ts/src/judge/rubric-coherence.js";
+export { checkRubricCoherence } from "../../../../ts/src/judge/rubric-coherence.js";
+export {
+	ContextBudget,
+	estimateTokens,
+} from "../../../../ts/src/prompts/context-budget.js";
+export type {
+	PromptBundle,
+	PromptContext,
+} from "../../../../ts/src/prompts/templates.js";
+export { buildPromptBundle } from "../../../../ts/src/prompts/templates.js";
+export type {
+	ExecutionLimits,
+	LegalAction,
+	Observation,
+	ReplayEnvelope,
+	Result,
+	ScenarioInterface,
+	ScoringDimension,
+} from "../../../../ts/src/scenarios/game-interface.js";
+export {
+	ExecutionLimitsSchema,
+	ObservationSchema,
+	ReplayEnvelopeSchema,
+	ResultSchema,
+} from "../../../../ts/src/scenarios/game-interface.js";
+export type { ArtifactEditingInterface } from "../../../../ts/src/scenarios/primary-family-interface-types.js";
+export type {
+	CoordinationInterface,
+	InvestigationInterface,
+	NegotiationInterface,
+	OperatorLoopInterface,
+	SchemaEvolutionInterface,
+	SimulationInterface,
+	ToolFragilityInterface,
+	WorkflowInterface,
+} from "../../../../ts/src/scenarios/simulation-family-interface-types.js";
+export type {
+	AgentOutputRow,
+	GenerationRow,
+	HumanFeedbackRow,
+	MatchRow,
+	RecordMatchOpts,
+	RunRow,
+	TaskQueueRow,
+	TrajectoryRow,
+	UpsertGenerationOpts,
+} from "../../../../ts/src/storage/storage-contracts.js";
+export type {
+	AgentTaskInterface,
+	AgentTaskResult,
+	CompletionResult,
+	LLMProvider,
+} from "../../../../ts/src/types/index.js";
+export {
+	AgentTaskResultSchema,
+	CompletionResultSchema,
+	ProviderError,
+} from "../../../../ts/src/types/index.js";

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../ts/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../../..",
+    "outDir": "./dist",
+    "noEmit": false
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../../ts/src/execution/elo.ts",
+    "../../../ts/src/judge/parse.ts",
+    "../../../ts/src/judge/rubric-coherence.ts",
+    "../../../ts/src/prompts/context-budget.ts",
+    "../../../ts/src/prompts/templates.ts",
+    "../../../ts/src/scenarios/game-interface.ts",
+    "../../../ts/src/scenarios/primary-family-interface-types.ts",
+    "../../../ts/src/scenarios/simulation-family-interface-types.ts",
+    "../../../ts/src/storage/storage-contracts.ts",
+    "../../../ts/src/types/index.ts"
+  ]
+}

--- a/ts/tests/core-package.test.ts
+++ b/ts/tests/core-package.test.ts
@@ -1,0 +1,670 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AgentOutputRow,
+  AgentTaskInterface,
+  AgentTaskResult,
+  ArtifactEditingInterface,
+  ExecutionLimits,
+  GenerationRow,
+  HumanFeedbackRow,
+  InvestigationInterface,
+  LegalAction,
+  MatchRow,
+  NegotiationInterface,
+  CoordinationInterface,
+  Observation,
+  OperatorLoopInterface,
+  RecordMatchOpts,
+  ReplayEnvelope,
+  Result,
+  RunRow,
+  ScenarioInterface,
+  SchemaEvolutionInterface,
+  ScoringDimension,
+  SimulationInterface,
+  TaskQueueRow,
+  ToolFragilityInterface,
+  TrajectoryRow,
+  UpsertGenerationOpts,
+  WorkflowInterface,
+} from "../../packages/ts/core/src/index.ts";
+import {
+  AgentTaskResultSchema,
+  buildPromptBundle,
+  CompletionResultSchema,
+  ContextBudget,
+  checkRubricCoherence,
+  ExecutionLimitsSchema,
+  estimateTokens,
+  expectedScore,
+  ObservationSchema,
+  ProviderError,
+  packageRole,
+  packageTopologyVersion,
+  parseJudgeResponse,
+  ReplayEnvelopeSchema,
+  ResultSchema,
+  updateElo,
+} from "../../packages/ts/core/src/index.ts";
+
+describe("@autocontext/core facade", () => {
+  it("preserves the core package identity", () => {
+    expect(packageRole).toBe("core");
+    expect(packageTopologyVersion).toBe(1);
+  });
+
+  it("re-exports Elo primitives from the core-safe execution surface", () => {
+    expect(expectedScore(1500, 1500)).toBe(0.5);
+    expect(updateElo(1500, 1500, 1)).toBe(1512);
+  });
+
+  it("re-exports prompt context budget helpers", () => {
+    expect(estimateTokens("abcdabcd")).toBe(2);
+
+    const budget = new ContextBudget(5);
+    const result = budget.apply({
+      playbook: "12345678901234567890",
+      hints: "keep-me",
+    });
+
+    expect(result.hints).toBe("keep-me");
+    expect(result.playbook).toContain("truncated for context budget");
+  });
+
+  it("re-exports prompt bundle assembly", () => {
+    const bundle = buildPromptBundle({
+      scenarioRules: "Follow the rules.",
+      strategyInterface: "Return JSON.",
+      evaluationCriteria: "Maximize score.",
+      playbook: "",
+      trajectory: "",
+      lessons: "",
+      tools: "",
+      hints: "",
+      analysis: "",
+    });
+
+    expect(bundle.competitor).toContain("## Scenario Rules");
+    expect(bundle.analyst).toContain("## Findings");
+    expect(bundle.coach).toContain("<!-- PLAYBOOK_START -->");
+    expect(bundle.architect).toContain('"tools"');
+  });
+
+  it("re-exports core provider and completion types", () => {
+    const parsed = CompletionResultSchema.parse({
+      text: "done",
+      model: "test-model",
+      usage: { input_tokens: 3 },
+      costUsd: 0.01,
+    });
+
+    expect(parsed.text).toBe("done");
+    expect(new ProviderError("boom")).toBeInstanceOf(Error);
+  });
+
+  it("re-exports judge parsing and rubric coherence helpers", () => {
+    const parsed = parseJudgeResponse(
+      '<!-- JUDGE_RESULT_START -->{"score":0.85,"reasoning":"solid","dimensions":{"accuracy":0.9}}<!-- JUDGE_RESULT_END -->',
+    );
+    const coherence = checkRubricCoherence(
+      "Write a brief but comprehensive and concise explanation.",
+    );
+
+    expect(parsed.score).toBe(0.85);
+    expect(parsed.dimensionScores.accuracy).toBe(0.9);
+    expect(coherence.isCoherent).toBe(false);
+    expect(coherence.warnings[0]).toContain("contradictory");
+  });
+
+  it("re-exports scenario value schemas and types", () => {
+    const observation: Observation = ObservationSchema.parse({
+      narrative: "Observe",
+      state: { board: "ready" },
+      constraints: ["no network"],
+    });
+    const result: Result = ResultSchema.parse({
+      score: 0.8,
+      summary: "solid",
+      validationErrors: [],
+    });
+    const replay: ReplayEnvelope = ReplayEnvelopeSchema.parse({
+      scenario: "grid_ctf",
+      seed: 7,
+      narrative: "turn-by-turn",
+    });
+    const limits: ExecutionLimits = ExecutionLimitsSchema.parse({
+      timeoutSeconds: 30,
+      maxMemoryMb: 1024,
+      networkAccess: false,
+    });
+
+    expect(observation.state.board).toBe("ready");
+    expect(result.passedValidation).toBe(true);
+    expect(replay.seed).toBe(7);
+    expect(limits.maxMemoryMb).toBe(1024);
+  });
+
+  it("re-exports scenario contract interfaces", () => {
+    const observation: Observation = ObservationSchema.parse({
+      narrative: "Observe",
+      state: { board: "ready" },
+      constraints: [],
+    });
+    const result: Result = ResultSchema.parse({
+      score: 0.8,
+      summary: "solid",
+      validationErrors: [],
+    });
+    const dimension: ScoringDimension = {
+      name: "accuracy",
+      weight: 0.7,
+      description: "Reward accurate play",
+    };
+    const action: LegalAction = {
+      action: "hold",
+      description: "Keep current position",
+      range: [0, 1],
+    };
+    const scenario: ScenarioInterface = {
+      name: "demo",
+      describeRules: () => "rules",
+      describeStrategyInterface: () => "return json",
+      describeEvaluationCriteria: () => "maximize score",
+      initialState: (seed?: number) => ({ seed }),
+      getObservation: () => observation,
+      validateActions: () => [true, ""],
+      step: (state: Record<string, unknown>, actions: Record<string, unknown>) => ({
+        ...state,
+        ...actions,
+        terminal: true,
+      }),
+      isTerminal: () => true,
+      getResult: () => result,
+      replayToNarrative: (replay: Array<Record<string, unknown>>) => `${replay.length} events`,
+      renderFrame: (state: Record<string, unknown>) => state,
+      enumerateLegalActions: () => [action],
+      scoringDimensions: () => [dimension],
+      executeMatch: () => result,
+    };
+
+    expect(scenario.describeRules()).toBe("rules");
+    expect(scenario.enumerateLegalActions({})?.[0]?.action).toBe("hold");
+    expect(scenario.scoringDimensions()?.[0]?.name).toBe("accuracy");
+  });
+
+  it("re-exports agent-task family contracts", async () => {
+    const evaluation: AgentTaskResult = AgentTaskResultSchema.parse({
+      score: 0.8,
+      reasoning: "accepted",
+      dimensionScores: { accuracy: 0.9 },
+      internalRetries: 1,
+    });
+    const task: AgentTaskInterface = {
+      getTaskPrompt: (state: Record<string, unknown>) =>
+        `solve ${String(state.topic ?? "unknown")}`,
+      evaluateOutput: async () => evaluation,
+      getRubric: () => "be accurate",
+      initialState: (seed?: number) => ({ seed, topic: "grid_ctf" }),
+      describeTask: () => "demo task",
+      prepareContext: async (state: Record<string, unknown>) => ({
+        ...state,
+        prepared: true,
+      }),
+      validateContext: () => [],
+      reviseOutput: async (output: string) => output,
+      verifyFacts: async () => ({ verified: true, issues: [] }),
+    };
+
+    expect(task.getTaskPrompt(task.initialState())).toBe("solve grid_ctf");
+    expect((await task.evaluateOutput("answer", task.initialState())).score).toBe(0.8);
+    expect(await task.prepareContext?.({ topic: "grid_ctf" })).toMatchObject({
+      prepared: true,
+    });
+    expect(await task.verifyFacts?.("answer", task.initialState())).toEqual({
+      verified: true,
+      issues: [],
+    });
+  });
+
+  it("re-exports artifact-editing family contracts", () => {
+    const scenario: ArtifactEditingInterface = {
+      describeTask: () => "edit files",
+      getRubric: () => "be correct",
+      initialArtifacts: () => [{ path: "README.md", content: "old" }],
+      getEditPrompt: (artifacts: unknown[]) => `edit ${artifacts.length} files`,
+      validateArtifact: (artifact: unknown) => ({ valid: true, artifact }),
+      evaluateEdits: (original: unknown[], edited: unknown[]) => ({
+        score: 0.8,
+        modified: edited.length - original.length,
+      }),
+    };
+
+    expect(scenario.describeTask()).toBe("edit files");
+    expect(scenario.getEditPrompt(scenario.initialArtifacts())).toBe("edit 1 files");
+    expect((scenario.evaluateEdits([], [{}]) as { score: number }).score).toBe(0.8);
+  });
+
+  it("re-exports simulation family contracts", () => {
+    const simulation: SimulationInterface = {
+      describeScenario: () => "demo simulation",
+      describeEnvironment: () => ({ name: "demo-sim" }),
+      initialState: (seed?: number) => ({ seed, step: 0 }),
+      getAvailableActions: () => [{ name: "inspect" }],
+      executeAction: (state: Record<string, unknown>, action: unknown) => [
+        { success: true, action },
+        { ...state, terminal: true },
+      ],
+      isTerminal: (state: Record<string, unknown>) => Boolean(state.terminal),
+      evaluateTrace: (trace: unknown, finalState: Record<string, unknown>) => ({
+        trace,
+        finalState,
+        score: 1,
+      }),
+      getRubric: () => "finish safely",
+    };
+
+    expect(simulation.describeScenario()).toBe("demo simulation");
+    expect(simulation.getAvailableActions({})[0]).toMatchObject({
+      name: "inspect",
+    });
+    expect(simulation.executeAction({ step: 0 }, { name: "inspect" })[1]).toMatchObject({
+      terminal: true,
+    });
+  });
+
+  it("re-exports negotiation simulation subfamily contracts", () => {
+    const negotiation: NegotiationInterface = {
+      describeScenario: () => "demo negotiation",
+      describeEnvironment: () => ({ name: "demo-negotiation" }),
+      initialState: (seed?: number) => ({ seed, round: 1 }),
+      getAvailableActions: () => [{ name: "offer" }],
+      executeAction: (state: Record<string, unknown>, action: unknown) => [
+        { accepted: false, action },
+        { ...state, terminal: true },
+      ],
+      isTerminal: (state: Record<string, unknown>) => Boolean(state.terminal),
+      evaluateTrace: (trace: unknown, finalState: Record<string, unknown>) => ({
+        trace,
+        finalState,
+        score: 1,
+      }),
+      getRubric: () => "reach a deal",
+      getHiddenPreferences: () => ({ reservationValue: 0.4 }),
+      getRounds: () => [{ roundNumber: 1 }],
+      getOpponentModel: () => ({ confidence: 0.8 }),
+      updateOpponentModel: (state: Record<string, unknown>, model: unknown) => ({
+        ...state,
+        model,
+      }),
+      evaluateNegotiation: () => ({ score: 0.85 }),
+    };
+
+    expect(negotiation.describeScenario()).toBe("demo negotiation");
+    expect(negotiation.getRounds({})[0]).toMatchObject({ roundNumber: 1 });
+    expect(negotiation.getOpponentModel({})).toMatchObject({ confidence: 0.8 });
+    expect(negotiation.updateOpponentModel({ seed: 7 }, { confidence: 0.9 })).toMatchObject({
+      model: { confidence: 0.9 },
+    });
+  });
+
+  it("re-exports investigation simulation subfamily contracts", () => {
+    const investigation: InvestigationInterface = {
+      describeScenario: () => "demo investigation",
+      describeEnvironment: () => ({ name: "demo-investigation" }),
+      initialState: (seed?: number) => ({ seed, collected: 0 }),
+      getAvailableActions: () => [{ name: "inspect" }],
+      executeAction: (state: Record<string, unknown>, action: unknown) => [
+        { gathered: true, action },
+        { ...state, terminal: true },
+      ],
+      isTerminal: (state: Record<string, unknown>) => Boolean(state.terminal),
+      evaluateTrace: (trace: unknown, finalState: Record<string, unknown>) => ({
+        trace,
+        finalState,
+        score: 1,
+      }),
+      getRubric: () => "identify root cause",
+      getEvidencePool: () => [{ id: "e-1" }],
+      evaluateEvidenceChain: () => 0.95,
+      evaluateDiagnosis: () => ({ diagnosisCorrect: true }),
+    };
+
+    expect(investigation.describeScenario()).toBe("demo investigation");
+    expect(investigation.getEvidencePool({})[0]).toMatchObject({ id: "e-1" });
+    expect(investigation.evaluateEvidenceChain({}, {})).toBe(0.95);
+    expect(investigation.evaluateDiagnosis("root cause", {}, {})).toMatchObject({
+      diagnosisCorrect: true,
+    });
+  });
+
+  it("re-exports workflow simulation subfamily contracts", () => {
+    const workflow: WorkflowInterface = {
+      describeScenario: () => "demo workflow",
+      describeEnvironment: () => ({ name: "demo-workflow" }),
+      initialState: (seed?: number) => ({ seed, completed: 0 }),
+      getAvailableActions: () => [{ name: "submit" }],
+      executeAction: (state: Record<string, unknown>, action: unknown) => [
+        { completed: true, action },
+        { ...state, terminal: true },
+      ],
+      isTerminal: (state: Record<string, unknown>) => Boolean(state.terminal),
+      evaluateTrace: (trace: unknown, finalState: Record<string, unknown>) => ({
+        trace,
+        finalState,
+        score: 1,
+      }),
+      getRubric: () => "complete all steps",
+      getWorkflowSteps: () => [{ name: "charge-card" }],
+      executeStep: () => ({ success: true }),
+      executeCompensation: () => ({ success: true }),
+      getSideEffects: () => [{ effectType: "payment" }],
+      evaluateWorkflow: () => ({ sideEffectsReversed: 1 }),
+    };
+
+    expect(workflow.describeScenario()).toBe("demo workflow");
+    expect(workflow.getWorkflowSteps()[0]).toMatchObject({
+      name: "charge-card",
+    });
+    expect(workflow.getSideEffects({})[0]).toMatchObject({
+      effectType: "payment",
+    });
+    expect(workflow.evaluateWorkflow({})).toMatchObject({
+      sideEffectsReversed: 1,
+    });
+  });
+
+  it("re-exports schema-evolution simulation subfamily contracts", () => {
+    const schemaEvolution: SchemaEvolutionInterface = {
+      describeScenario: () => "demo schema evolution",
+      describeEnvironment: () => ({ name: "demo-schema-evolution" }),
+      initialState: (seed?: number) => ({ seed, schemaVersion: 1 }),
+      getAvailableActions: () => [{ name: "migrate" }],
+      executeAction: (state: Record<string, unknown>, action: unknown) => [
+        { applied: true, action },
+        { ...state, schemaVersion: 2 },
+      ],
+      isTerminal: (state: Record<string, unknown>) => Boolean(state.terminal),
+      evaluateTrace: (trace: unknown, finalState: Record<string, unknown>) => ({
+        trace,
+        finalState,
+        score: 1,
+      }),
+      getRubric: () => "adapt without stale assumptions",
+      getMutations: () => [{ version: 2 }],
+      getSchemaVersion: (state: Record<string, unknown>) =>
+        typeof state.schemaVersion === "number" ? state.schemaVersion : 1,
+      getMutationLog: () => [{ version: 2 }],
+      applyMutation: (state: Record<string, unknown>, mutation: unknown) => ({
+        ...state,
+        mutation,
+      }),
+      checkContextValidity: () => [{ stillValid: false }],
+      evaluateAdaptation: () => ({ staleAssumptionsDetected: 1 }),
+    };
+
+    expect(schemaEvolution.describeScenario()).toBe("demo schema evolution");
+    expect(schemaEvolution.getMutations()[0]).toMatchObject({ version: 2 });
+    expect(schemaEvolution.getSchemaVersion({ schemaVersion: 2 })).toBe(2);
+    expect(schemaEvolution.checkContextValidity({}, ["customer_id still exists"])).toMatchObject([
+      { stillValid: false },
+    ]);
+  });
+
+  it("re-exports tool-fragility simulation subfamily contracts", () => {
+    const toolFragility: ToolFragilityInterface = {
+      describeScenario: () => "demo tool fragility",
+      describeEnvironment: () => ({ name: "demo-tool-fragility" }),
+      initialState: (seed?: number) => ({ seed, toolVersion: 1 }),
+      getAvailableActions: () => [{ name: "invoke" }],
+      executeAction: (state: Record<string, unknown>, action: unknown) => [
+        { invoked: true, action },
+        { ...state, toolVersion: 2 },
+      ],
+      isTerminal: (state: Record<string, unknown>) => Boolean(state.terminal),
+      evaluateTrace: (trace: unknown, finalState: Record<string, unknown>) => ({
+        trace,
+        finalState,
+        score: 1,
+      }),
+      getRubric: () => "adapt after tool drift",
+      getToolContracts: () => [{ toolName: "ledger.lookup", version: 1 }],
+      getDriftLog: () => [{ toolName: "ledger.lookup", breaking: true }],
+      injectDrift: (state: Record<string, unknown>, drift: unknown) => ({
+        ...state,
+        drift,
+      }),
+      attributeFailure: () => ({ failureClass: "tool_failure" }),
+      evaluateFragility: () => ({ driftsDetected: 1 }),
+    };
+
+    expect(toolFragility.describeScenario()).toBe("demo tool fragility");
+    expect(toolFragility.getToolContracts({})[0]).toMatchObject({
+      toolName: "ledger.lookup",
+    });
+    expect(toolFragility.getDriftLog({})[0]).toMatchObject({
+      breaking: true,
+    });
+    expect(toolFragility.attributeFailure({}, 1, "missing customer_id")).toMatchObject({
+      failureClass: "tool_failure",
+    });
+  });
+
+  it("re-exports operator-loop simulation subfamily contracts", () => {
+    const operatorLoop: OperatorLoopInterface = {
+      describeScenario: () => "demo operator loop",
+      describeEnvironment: () => ({ name: "demo-operator-loop" }),
+      initialState: (seed?: number) => ({
+        seed,
+        escalations: 0,
+        clarifications: 0,
+      }),
+      getAvailableActions: () => [{ name: "approve" }],
+      executeAction: (state: Record<string, unknown>, action: unknown) => [
+        { decided: true, action },
+        { ...state, terminal: true },
+      ],
+      isTerminal: (state: Record<string, unknown>) => Boolean(state.terminal),
+      evaluateTrace: (trace: unknown, finalState: Record<string, unknown>) => ({
+        trace,
+        finalState,
+        score: 1,
+      }),
+      getRubric: () => "escalate only when necessary",
+      getEscalationLog: () => [{ severity: "critical" }],
+      getClarificationLog: () => [{ urgency: "high" }],
+      escalate: (state: Record<string, unknown>, event: unknown) => ({
+        ...state,
+        event,
+        escalations: 1,
+      }),
+      requestClarification: (state: Record<string, unknown>, request: unknown) => ({
+        ...state,
+        request,
+        clarifications: 1,
+      }),
+      evaluateJudgment: () => ({
+        necessaryEscalations: 1,
+        clarificationsRequested: 1,
+      }),
+    };
+
+    expect(operatorLoop.describeScenario()).toBe("demo operator loop");
+    expect(operatorLoop.getEscalationLog({})[0]).toMatchObject({
+      severity: "critical",
+    });
+    expect(operatorLoop.getClarificationLog({})[0]).toMatchObject({
+      urgency: "high",
+    });
+    expect(operatorLoop.evaluateJudgment({})).toMatchObject({
+      necessaryEscalations: 1,
+      clarificationsRequested: 1,
+    });
+  });
+
+  it("re-exports coordination simulation subfamily contracts", () => {
+    const coordination: CoordinationInterface = {
+      describeScenario: () => "demo coordination",
+      describeEnvironment: () => ({ name: "demo-coordination" }),
+      initialState: (seed?: number) => ({ seed, handoffs: 0, merged: false }),
+      getAvailableActions: () => [{ name: "merge" }],
+      executeAction: (state: Record<string, unknown>, action: unknown) => [
+        { merged: true, action },
+        { ...state, terminal: true },
+      ],
+      isTerminal: (state: Record<string, unknown>) => Boolean(state.terminal),
+      evaluateTrace: (trace: unknown, finalState: Record<string, unknown>) => ({
+        trace,
+        finalState,
+        score: 1,
+      }),
+      getRubric: () => "handoff cleanly and merge outputs",
+      getWorkerContexts: () => [{ workerId: "worker-a", role: "researcher" }],
+      getHandoffLog: () => [{ fromWorker: "worker-a", toWorker: "worker-b" }],
+      recordHandoff: (state: Record<string, unknown>, handoff: unknown) => ({
+        ...state,
+        handoff,
+        handoffs: 1,
+      }),
+      mergeOutputs: (state: Record<string, unknown>, workerOutputs: Record<string, string>) => ({
+        ...state,
+        workerOutputs,
+        merged: true,
+      }),
+      evaluateCoordination: () => ({ workersUsed: 2, mergeConflicts: 0 }),
+    };
+
+    expect(coordination.describeScenario()).toBe("demo coordination");
+    expect(coordination.getWorkerContexts({})[0]).toMatchObject({
+      workerId: "worker-a",
+    });
+    expect(coordination.getHandoffLog({})[0]).toMatchObject({
+      fromWorker: "worker-a",
+      toWorker: "worker-b",
+    });
+    expect(coordination.evaluateCoordination({})).toMatchObject({
+      workersUsed: 2,
+      mergeConflicts: 0,
+    });
+  });
+
+  it("re-exports storage row contracts", () => {
+    const run: RunRow = {
+      run_id: "run-1",
+      scenario: "grid_ctf",
+      target_generations: 3,
+      executor_mode: "local",
+      status: "running",
+      agent_provider: "deterministic",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:01Z",
+    };
+    const generation: GenerationRow = {
+      run_id: "run-1",
+      generation_index: 0,
+      mean_score: 0.75,
+      best_score: 0.8,
+      elo: 1512,
+      wins: 2,
+      losses: 1,
+      gate_decision: "promote",
+      status: "completed",
+      duration_seconds: 12,
+      dimension_summary_json: '{"accuracy":0.9}',
+      scoring_backend: "elo",
+      rating_uncertainty: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:01Z",
+    };
+    const match: MatchRow = {
+      id: 1,
+      run_id: "run-1",
+      generation_index: 0,
+      seed: 7,
+      score: 0.75,
+      passed_validation: 1,
+      validation_errors: "",
+      winner: "candidate",
+      strategy_json: "{}",
+      replay_json: "{}",
+      created_at: "2026-01-01T00:00:02Z",
+    };
+    const output: AgentOutputRow = {
+      id: 2,
+      run_id: "run-1",
+      generation_index: 0,
+      role: "competitor",
+      content: "answer",
+      created_at: "2026-01-01T00:00:03Z",
+    };
+    const feedback: HumanFeedbackRow = {
+      id: 3,
+      scenario_name: "grid_ctf",
+      generation_id: "run-1:0",
+      agent_output: "answer",
+      human_score: 0.8,
+      human_notes: "solid",
+      created_at: "2026-01-01T00:00:04Z",
+    };
+    const queue: TaskQueueRow = {
+      id: "task-1",
+      spec_name: "grid_ctf",
+      status: "pending",
+      priority: 1,
+      config_json: null,
+      scheduled_at: null,
+      started_at: null,
+      completed_at: null,
+      best_score: null,
+      best_output: null,
+      total_rounds: null,
+      met_threshold: 0,
+      result_json: null,
+      error: null,
+      created_at: "2026-01-01T00:00:05Z",
+      updated_at: "2026-01-01T00:00:06Z",
+    };
+    const trajectory: TrajectoryRow = {
+      generation_index: 0,
+      mean_score: 0.75,
+      best_score: 0.8,
+      elo: 1512,
+      gate_decision: "promote",
+      delta: 12,
+      dimension_summary: { accuracy: 0.9 },
+      scoring_backend: "elo",
+      rating_uncertainty: null,
+    };
+    const upsert: UpsertGenerationOpts = {
+      meanScore: 0.75,
+      bestScore: 0.8,
+      elo: 1512,
+      wins: 2,
+      losses: 1,
+      gateDecision: "promote",
+      status: "completed",
+      durationSeconds: 12,
+      dimensionSummaryJson: '{"accuracy":0.9}',
+      scoringBackend: "elo",
+      ratingUncertainty: null,
+    };
+    const recordMatch: RecordMatchOpts = {
+      seed: 7,
+      score: 0.75,
+      passedValidation: true,
+      validationErrors: "",
+      winner: "candidate",
+      strategyJson: "{}",
+      replayJson: "{}",
+    };
+
+    expect(run.scenario).toBe("grid_ctf");
+    expect(generation.elo).toBe(1512);
+    expect(match.winner).toBe("candidate");
+    expect(output.role).toBe("competitor");
+    expect(feedback.human_notes).toBe("solid");
+    expect(queue.status).toBe("pending");
+    expect(trajectory.delta).toBe(12);
+    expect(upsert.gateDecision).toBe("promote");
+    expect(recordMatch.passedValidation).toBe(true);
+  });
+});

--- a/ts/tests/package-topology.test.ts
+++ b/ts/tests/package-topology.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(import.meta.dirname, "..", "..");
+const topologyPath = join(repoRoot, "packages", "package-topology.json");
+
+type PackageEntry = {
+  name: string;
+  path: string;
+};
+
+type TsPackageEntry = PackageEntry & {
+  source: string;
+};
+
+type Topology = {
+  typescript: {
+    umbrella: PackageEntry & { bin: string };
+    core: TsPackageEntry;
+    control: TsPackageEntry;
+  };
+};
+
+function loadTopology(): Topology {
+  return JSON.parse(readFileSync(topologyPath, "utf-8")) as Topology;
+}
+
+function loadPackageJson(relativePath: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(repoRoot, relativePath, "package.json"), "utf-8")) as Record<string, unknown>;
+}
+
+function loadTsConfig(relativePath: string): {
+  compilerOptions?: Record<string, unknown>;
+  include?: string[];
+} {
+  return JSON.parse(readFileSync(join(repoRoot, relativePath, "tsconfig.json"), "utf-8")) as {
+    compilerOptions?: Record<string, unknown>;
+    include?: string[];
+  };
+}
+
+function expectedBuiltEntry(
+  entry: TsPackageEntry,
+  config: { compilerOptions?: Record<string, unknown> },
+  extension: ".js" | ".d.ts",
+): string {
+  const source = entry.source.replace(/\.ts$/, extension);
+  const rootDir = String(config.compilerOptions?.rootDir ?? "./src").replace(/^\.\//, "");
+
+  if (rootDir === "src") {
+    return `dist/${source.replace(/^src\//, "")}`;
+  }
+  if (rootDir === "../../..") {
+    return `dist/${entry.path}/${source}`;
+  }
+
+  throw new Error(`Unexpected rootDir for ${entry.name}: ${rootDir}`);
+}
+
+describe("package topology", () => {
+  it("defines a shared topology manifest", () => {
+    expect(existsSync(topologyPath)).toBe(true);
+  });
+
+  it("defines TypeScript core and control package skeletons", () => {
+    const topology = loadTopology();
+    for (const entry of [topology.typescript.core, topology.typescript.control]) {
+      expect(existsSync(join(repoRoot, entry.path))).toBe(true);
+      expect(existsSync(join(repoRoot, entry.path, "package.json"))).toBe(true);
+      expect(existsSync(join(repoRoot, entry.path, "tsconfig.json"))).toBe(true);
+      expect(existsSync(join(repoRoot, entry.path, entry.source))).toBe(true);
+    }
+  });
+
+  it("matches TypeScript package names to the topology", () => {
+    const topology = loadTopology();
+    const corePackage = loadPackageJson(topology.typescript.core.path);
+    const controlPackage = loadPackageJson(topology.typescript.control.path);
+
+    expect(corePackage.name).toBe(topology.typescript.core.name);
+    expect(controlPackage.name).toBe(topology.typescript.control.name);
+    expect(corePackage.version).toBe("0.0.0");
+    expect(controlPackage.version).toBe("0.0.0");
+    expect(corePackage.private).toBe(true);
+    expect(controlPackage.private).toBe(true);
+  });
+
+  it("preserves the umbrella TypeScript package as the phase-one install surface", () => {
+    const topology = loadTopology();
+    expect(topology.typescript.umbrella.name).toBe("autoctx");
+    expect(topology.typescript.umbrella.path).toBe("ts");
+    expect(topology.typescript.umbrella.bin).toBe("autoctx");
+  });
+
+  it("configures TypeScript package builds to emit their advertised dist artifacts", () => {
+    const topology = loadTopology();
+    const corePackage = loadPackageJson(topology.typescript.core.path);
+    const controlPackage = loadPackageJson(topology.typescript.control.path);
+    const coreConfig = loadTsConfig(topology.typescript.core.path);
+    const controlConfig = loadTsConfig(topology.typescript.control.path);
+
+    expect(coreConfig.compilerOptions?.noEmit).toBe(false);
+    expect(controlConfig.compilerOptions?.noEmit).toBe(false);
+    expect(corePackage.main).toBe(expectedBuiltEntry(topology.typescript.core, coreConfig, ".js"));
+    expect(corePackage.types).toBe(expectedBuiltEntry(topology.typescript.core, coreConfig, ".d.ts"));
+    expect(controlPackage.main).toBe(expectedBuiltEntry(topology.typescript.control, controlConfig, ".js"));
+    expect(controlPackage.types).toBe(expectedBuiltEntry(topology.typescript.control, controlConfig, ".d.ts"));
+  });
+
+  it("keeps the TypeScript core external source scope exact", () => {
+    const topology = loadTopology();
+    const coreConfig = loadTsConfig(topology.typescript.core.path);
+    const externalCoreSources = (coreConfig.include ?? []).filter((entry) =>
+      entry.startsWith("../../../ts/src/"),
+    );
+
+    expect(externalCoreSources).toEqual([
+      "../../../ts/src/execution/elo.ts",
+      "../../../ts/src/judge/parse.ts",
+      "../../../ts/src/judge/rubric-coherence.ts",
+      "../../../ts/src/prompts/context-budget.ts",
+      "../../../ts/src/prompts/templates.ts",
+      "../../../ts/src/scenarios/game-interface.ts",
+      "../../../ts/src/scenarios/primary-family-interface-types.ts",
+      "../../../ts/src/scenarios/simulation-family-interface-types.ts",
+      "../../../ts/src/storage/storage-contracts.ts",
+      "../../../ts/src/types/index.ts",
+    ]);
+    expect(externalCoreSources.every((entry) => !entry.includes("*"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- establish the phase-one package topology for the core/control split across Python and TypeScript
- add transitional `autocontext-core` / `autocontext-control` and `@autocontext/core` / `@autocontext/control-plane` package skeletons without moving source-of-truth behavior
- expose an initial shared-core facade surface made of topology metadata plus contract/value exports that strengthen the real Apache-core/control-plane boundary for AC-650 / AC-649 / AC-644
- keep this slice strictly non-breaking and contract-first: no orchestration moves, no concrete runtime/control implementations promoted into core, and no AC-645 license-metadata work yet

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [x] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py ../packages/python/core/src/autocontext_core/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] additional manual verification described below

Manual verification:
- confirmed the clean worktree contains only the intended package/test boundary files before commit
- confirmed all simulation-family contract surfaces are now exposed through the transitional core facades
- reverted unrelated `autocontext/uv.lock` and `ts/package-lock.json` drift before publishing

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [x] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- Python core facade now re-exports shared execution/prompt/provider surfaces plus scenario contract/value surfaces for:
  - base scenario values/interfaces
  - AgentTask
  - ArtifactEditing
  - Simulation
  - Negotiation
  - Investigation
  - Workflow
  - SchemaEvolution
  - ToolFragility
  - OperatorLoop
  - Coordination
- TypeScript core facade now mirrors the first shared contract boundary with topology metadata, shared execution/prompt/provider exports, storage contract exports, and simulation-family interfaces
- this PR intentionally stops at facade + topology work; source-of-truth modules stay in the monolith for now
- follow-up work can now focus on the next truthful boundary slices on top of these artifacts instead of moving early into licensing metadata
