### PR TITLE
AC-635 Add WebSocket protocol contract

### DIFF
--- a/autocontext/tests/test_websocket_protocol_contract.py
+++ b/autocontext/tests/test_websocket_protocol_contract.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from autocontext.harness.core.events import EventStreamEmitter
+from autocontext.server.protocol import PROTOCOL_VERSION, export_json_schema, parse_client_message
+
+
+def _contract() -> dict[str, Any]:
+    contract_path = Path(__file__).resolve().parents[2] / "docs" / "websocket-protocol-contract.json"
+    return json.loads(contract_path.read_text(encoding="utf-8"))
+
+
+def _message_types(schema: dict[str, Any]) -> set[str]:
+    found: set[str] = set()
+    for definition in schema.get("$defs", {}).values():
+        type_field = definition.get("properties", {}).get("type", {})
+        if isinstance(type_field.get("const"), str):
+            found.add(type_field["const"])
+    return found
+
+
+def _runtime_only_types(contract: dict[str, Any], key: str) -> set[str]:
+    return {item["type"] for item in contract[key]}
+
+
+def test_python_websocket_protocol_matches_shared_contract() -> None:
+    contract = _contract()
+    exported = export_json_schema()
+
+    assert PROTOCOL_VERSION == contract["protocol_version"]
+    assert _message_types(exported["server_messages"]) == set(contract["shared_server_messages"])
+    assert _message_types(exported["client_messages"]) == set(contract["shared_client_messages"])
+
+
+def test_python_protocol_excludes_typescript_only_messages() -> None:
+    contract = _contract()
+    exported = export_json_schema()
+
+    assert _message_types(exported["server_messages"]).isdisjoint(
+        _runtime_only_types(contract, "typescript_only_server_messages"),
+    )
+    assert _message_types(exported["client_messages"]).isdisjoint(
+        _runtime_only_types(contract, "typescript_only_client_messages"),
+    )
+
+
+def test_python_protocol_forbids_unknown_top_level_client_fields() -> None:
+    assert _contract()["top_level_unknown_field_policy"] == "forbid"
+
+    with pytest.raises(ValidationError):
+        parse_client_message({"type": "pause", "unexpected": True})
+
+
+def test_python_event_stream_envelope_matches_shared_contract(tmp_path: Path) -> None:
+    contract = _contract()["event_stream_envelope"]
+    event_path = tmp_path / "events.ndjson"
+    emitter = EventStreamEmitter(event_path)
+
+    emitter.emit("run_started", {"run_id": "run_1"}, channel="generation")
+
+    line = json.loads(event_path.read_text(encoding="utf-8").strip())
+    assert sorted(line) == sorted(contract["required_fields"])
+    assert line["v"] == contract["version"]
+    assert line["seq"] == 1
+    assert line["channel"] in contract["fields"]["channel"]["known_values"]
+    assert isinstance(line["payload"], dict)

--- a/docs/websocket-protocol-contract.json
+++ b/docs/websocket-protocol-contract.json
@@ -1,0 +1,105 @@
+{
+  "version": 1,
+  "contract": "interactive WebSocket protocol surface shared by Python and TypeScript with runtime-only extensions marked explicitly",
+  "protocol_version": 1,
+  "endpoints": [
+    {
+      "path": "/ws/interactive",
+      "runtimes": ["python", "typescript"],
+      "message_contract": "interactive"
+    },
+    {
+      "path": "/ws/events",
+      "runtimes": ["python", "typescript"],
+      "message_contract": "event-stream"
+    }
+  ],
+  "top_level_unknown_field_policy": "forbid",
+  "event_stream_envelope": {
+    "version": 1,
+    "unknown_field_policy": "forbid",
+    "required_fields": ["ts", "v", "seq", "channel", "event", "payload"],
+    "fields": {
+      "ts": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "v": {
+        "type": "integer",
+        "const": 1
+      },
+      "seq": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "channel": {
+        "type": "string",
+        "known_values": ["generation", "mission", "notebook", "cockpit"]
+      },
+      "event": {
+        "type": "string"
+      },
+      "payload": {
+        "type": "object"
+      }
+    }
+  },
+  "shared_server_messages": [
+    "hello",
+    "event",
+    "state",
+    "chat_response",
+    "environments",
+    "run_accepted",
+    "ack",
+    "error",
+    "scenario_generating",
+    "scenario_preview",
+    "scenario_ready",
+    "scenario_error",
+    "monitor_alert"
+  ],
+  "shared_client_messages": [
+    "pause",
+    "resume",
+    "inject_hint",
+    "override_gate",
+    "chat_agent",
+    "start_run",
+    "list_scenarios",
+    "create_scenario",
+    "confirm_scenario",
+    "revise_scenario",
+    "cancel_scenario"
+  ],
+  "typescript_only_server_messages": [
+    {
+      "type": "auth_status",
+      "reason": "TypeScript TUI provider-auth workflow"
+    },
+    {
+      "type": "mission_progress",
+      "reason": "TypeScript mission dashboard workflow"
+    }
+  ],
+  "typescript_only_client_messages": [
+    {
+      "type": "login",
+      "reason": "TypeScript TUI provider-auth workflow"
+    },
+    {
+      "type": "logout",
+      "reason": "TypeScript TUI provider-auth workflow"
+    },
+    {
+      "type": "switch_provider",
+      "reason": "TypeScript TUI provider-auth workflow"
+    },
+    {
+      "type": "whoami",
+      "reason": "TypeScript TUI provider-auth workflow"
+    }
+  ],
+  "python_only_server_messages": [],
+  "python_only_client_messages": []
+}

--- a/ts/src/loop/events.ts
+++ b/ts/src/loop/events.ts
@@ -6,7 +6,20 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 
-export type EventCallback = (event: string, payload: Record<string, unknown>) => void;
+export interface EventStreamRecord {
+  channel: string;
+  event: string;
+  payload: Record<string, unknown>;
+  seq: number;
+  ts: string;
+  v: 1;
+}
+
+export type EventCallback = (
+  event: string,
+  payload: Record<string, unknown>,
+  record?: EventStreamRecord,
+) => void;
 
 export class EventStreamEmitter {
   readonly path: string;
@@ -40,7 +53,7 @@ export class EventStreamEmitter {
     const seq = this.#sequence;
     const subscribersCopy = [...this.#subscribers];
 
-    const line = {
+    const line: EventStreamRecord = {
       channel,
       event,
       payload,
@@ -53,7 +66,7 @@ export class EventStreamEmitter {
 
     for (const cb of subscribersCopy) {
       try {
-        cb(event, payload);
+        cb(event, payload, line);
       } catch {
         // subscriber errors must never crash the loop
       }

--- a/ts/src/server/event-stream-envelope.ts
+++ b/ts/src/server/event-stream-envelope.ts
@@ -1,9 +1,10 @@
 import type { ServerMessage } from "./protocol.js";
 
 export interface EventStreamEnvelope<TPayload> {
-  channel: "generation" | "mission";
+  channel: string;
   event: string;
   payload: TPayload;
+  seq: number;
   ts: string;
   v: 1;
 }
@@ -12,12 +13,14 @@ export function buildEventStreamEnvelope<TPayload>(opts: {
   channel: EventStreamEnvelope<TPayload>["channel"];
   event: string;
   payload: TPayload;
+  seq: number;
   timestamp?: string;
 }): EventStreamEnvelope<TPayload> {
   return {
     channel: opts.channel,
     event: opts.event,
     payload: opts.payload,
+    seq: opts.seq,
     ts: opts.timestamp ?? new Date().toISOString(),
     v: 1,
   };
@@ -26,24 +29,28 @@ export function buildEventStreamEnvelope<TPayload>(opts: {
 export function buildGenerationEventEnvelope(
   event: string,
   payload: Record<string, unknown>,
+  seq: number,
   timestamp?: string,
 ): EventStreamEnvelope<Record<string, unknown>> {
   return buildEventStreamEnvelope({
     channel: "generation",
     event,
     payload,
+    seq,
     timestamp,
   });
 }
 
 export function buildMissionProgressEventEnvelope(
   payload: Extract<ServerMessage, { type: "mission_progress" }>,
+  seq: number,
   timestamp?: string,
 ): EventStreamEnvelope<Extract<ServerMessage, { type: "mission_progress" }>> {
   return buildEventStreamEnvelope({
     channel: "mission",
     event: "mission_progress",
     payload,
+    seq,
     timestamp,
   });
 }

--- a/ts/src/server/protocol.ts
+++ b/ts/src/server/protocol.ts
@@ -7,36 +7,90 @@ import { z } from "zod";
 
 export const PROTOCOL_VERSION = 1;
 
+const protocolObject = <T extends z.ZodRawShape>(shape: T) => z.object(shape).strict();
+
+export const PYTHON_SHARED_SERVER_MESSAGE_TYPES = [
+  "hello",
+  "event",
+  "state",
+  "chat_response",
+  "environments",
+  "run_accepted",
+  "ack",
+  "error",
+  "scenario_generating",
+  "scenario_preview",
+  "scenario_ready",
+  "scenario_error",
+  "monitor_alert",
+] as const;
+
+export const TYPESCRIPT_ONLY_SERVER_MESSAGE_TYPES = [
+  "auth_status",
+  "mission_progress",
+] as const;
+
+export const SERVER_MESSAGE_TYPES = [
+  ...PYTHON_SHARED_SERVER_MESSAGE_TYPES,
+  ...TYPESCRIPT_ONLY_SERVER_MESSAGE_TYPES,
+] as const;
+
+export const PYTHON_SHARED_CLIENT_MESSAGE_TYPES = [
+  "pause",
+  "resume",
+  "inject_hint",
+  "override_gate",
+  "chat_agent",
+  "start_run",
+  "list_scenarios",
+  "create_scenario",
+  "confirm_scenario",
+  "revise_scenario",
+  "cancel_scenario",
+] as const;
+
+export const TYPESCRIPT_ONLY_CLIENT_MESSAGE_TYPES = [
+  "login",
+  "logout",
+  "switch_provider",
+  "whoami",
+] as const;
+
+export const CLIENT_MESSAGE_TYPES = [
+  ...PYTHON_SHARED_CLIENT_MESSAGE_TYPES,
+  ...TYPESCRIPT_ONLY_CLIENT_MESSAGE_TYPES,
+] as const;
+
 // ---------------------------------------------------------------------------
 // Nested models
 // ---------------------------------------------------------------------------
 
-export const ScenarioInfoSchema = z.object({
+export const ScenarioInfoSchema = protocolObject({
   name: z.string(),
   description: z.string(),
 });
 
-export const ExecutorResourcesSchema = z.object({
+export const ExecutorResourcesSchema = protocolObject({
   docker_image: z.string(),
-  cpu_cores: z.number(),
-  memory_gb: z.number(),
-  disk_gb: z.number(),
+  cpu_cores: z.number().int(),
+  memory_gb: z.number().int(),
+  disk_gb: z.number().int(),
   timeout_minutes: z.number().int(),
 });
 
-export const ExecutorInfoSchema = z.object({
+export const ExecutorInfoSchema = protocolObject({
   mode: z.string(),
   available: z.boolean(),
   description: z.string(),
   resources: ExecutorResourcesSchema.optional().nullable(),
 });
 
-export const StrategyParamSchema = z.object({
+export const StrategyParamSchema = protocolObject({
   name: z.string(),
   description: z.string(),
 });
 
-export const ScoringComponentSchema = z.object({
+export const ScoringComponentSchema = protocolObject({
   name: z.string(),
   description: z.string(),
   weight: z.number(),
@@ -46,31 +100,31 @@ export const ScoringComponentSchema = z.object({
 // Server → Client messages
 // ---------------------------------------------------------------------------
 
-export const HelloMsgSchema = z.object({
+export const HelloMsgSchema = protocolObject({
   type: z.literal("hello"),
   protocol_version: z.number().int().optional(),
 });
 
-export const EventMsgSchema = z.object({
+export const EventMsgSchema = protocolObject({
   type: z.literal("event"),
   event: z.string(),
   payload: z.record(z.unknown()),
 });
 
-export const StateMsgSchema = z.object({
+export const StateMsgSchema = protocolObject({
   type: z.literal("state"),
   paused: z.boolean(),
   generation: z.number().int().optional(),
   phase: z.string().optional(),
 });
 
-export const ChatResponseMsgSchema = z.object({
+export const ChatResponseMsgSchema = protocolObject({
   type: z.literal("chat_response"),
   role: z.string(),
   text: z.string(),
 });
 
-export const EnvironmentsMsgSchema = z.object({
+export const EnvironmentsMsgSchema = protocolObject({
   type: z.literal("environments"),
   scenarios: z.array(ScenarioInfoSchema),
   executors: z.array(ExecutorInfoSchema),
@@ -78,30 +132,30 @@ export const EnvironmentsMsgSchema = z.object({
   agent_provider: z.string(),
 });
 
-export const RunAcceptedMsgSchema = z.object({
+export const RunAcceptedMsgSchema = protocolObject({
   type: z.literal("run_accepted"),
   run_id: z.string(),
   scenario: z.string(),
   generations: z.number().int(),
 });
 
-export const AckMsgSchema = z.object({
+export const AckMsgSchema = protocolObject({
   type: z.literal("ack"),
   action: z.string(),
-  decision: z.string().optional(),
+  decision: z.string().optional().nullable(),
 });
 
-export const ErrorMsgSchema = z.object({
+export const ErrorMsgSchema = protocolObject({
   type: z.literal("error"),
   message: z.string(),
 });
 
-export const ScenarioGeneratingMsgSchema = z.object({
+export const ScenarioGeneratingMsgSchema = protocolObject({
   type: z.literal("scenario_generating"),
   name: z.string(),
 });
 
-export const ScenarioPreviewMsgSchema = z.object({
+export const ScenarioPreviewMsgSchema = protocolObject({
   type: z.literal("scenario_preview"),
   name: z.string(),
   display_name: z.string(),
@@ -112,30 +166,30 @@ export const ScenarioPreviewMsgSchema = z.object({
   win_threshold: z.number(),
 });
 
-export const ScenarioReadyMsgSchema = z.object({
+export const ScenarioReadyMsgSchema = protocolObject({
   type: z.literal("scenario_ready"),
   name: z.string(),
   test_scores: z.array(z.number()),
 });
 
-export const ScenarioErrorMsgSchema = z.object({
+export const ScenarioErrorMsgSchema = protocolObject({
   type: z.literal("scenario_error"),
   message: z.string(),
-  stage: z.string().optional(),
+  stage: z.string(),
 });
 
-export const MonitorAlertMsgSchema = z.object({
+export const MonitorAlertMsgSchema = protocolObject({
   type: z.literal("monitor_alert"),
   alert_id: z.string(),
   condition_id: z.string(),
   condition_name: z.string(),
   condition_type: z.string(),
   scope: z.string(),
-  detail: z.record(z.unknown()),
+  detail: z.string(),
 });
 
 // Mission progress (AC-414)
-export const MissionProgressMsgSchema = z.object({
+export const MissionProgressMsgSchema = protocolObject({
   type: z.literal("mission_progress"),
   missionId: z.string(),
   status: z.string(),
@@ -146,12 +200,12 @@ export const MissionProgressMsgSchema = z.object({
 });
 
 // Auth status response (AC-408)
-export const AuthStatusMsgSchema = z.object({
+export const AuthStatusMsgSchema = protocolObject({
   type: z.literal("auth_status"),
   provider: z.string(),
   authenticated: z.boolean(),
   model: z.string().optional(),
-  configuredProviders: z.array(z.object({
+  configuredProviders: z.array(protocolObject({
     provider: z.string(),
     hasApiKey: z.boolean(),
   })).optional(),
@@ -161,55 +215,55 @@ export const AuthStatusMsgSchema = z.object({
 // Client → Server commands
 // ---------------------------------------------------------------------------
 
-export const PauseCmdSchema = z.object({ type: z.literal("pause") });
-export const ResumeCmdSchema = z.object({ type: z.literal("resume") });
+export const PauseCmdSchema = protocolObject({ type: z.literal("pause") });
+export const ResumeCmdSchema = protocolObject({ type: z.literal("resume") });
 
-export const InjectHintCmdSchema = z.object({
+export const InjectHintCmdSchema = protocolObject({
   type: z.literal("inject_hint"),
   text: z.string().min(1),
 });
 
-export const OverrideGateCmdSchema = z.object({
+export const OverrideGateCmdSchema = protocolObject({
   type: z.literal("override_gate"),
   decision: z.enum(["advance", "retry", "rollback"]),
 });
 
-export const ChatAgentCmdSchema = z.object({
+export const ChatAgentCmdSchema = protocolObject({
   type: z.literal("chat_agent"),
   role: z.string(),
-  message: z.string(),
+  message: z.string().min(1),
 });
 
-export const StartRunCmdSchema = z.object({
+export const StartRunCmdSchema = protocolObject({
   type: z.literal("start_run"),
   scenario: z.string(),
   generations: z.number().int().positive(),
 });
 
-export const ListScenariosCmdSchema = z.object({
+export const ListScenariosCmdSchema = protocolObject({
   type: z.literal("list_scenarios"),
 });
 
-export const CreateScenarioCmdSchema = z.object({
+export const CreateScenarioCmdSchema = protocolObject({
   type: z.literal("create_scenario"),
   description: z.string().min(1),
 });
 
-export const ConfirmScenarioCmdSchema = z.object({
+export const ConfirmScenarioCmdSchema = protocolObject({
   type: z.literal("confirm_scenario"),
 });
 
-export const ReviseScenarioCmdSchema = z.object({
+export const ReviseScenarioCmdSchema = protocolObject({
   type: z.literal("revise_scenario"),
   feedback: z.string().min(1),
 });
 
-export const CancelScenarioCmdSchema = z.object({
+export const CancelScenarioCmdSchema = protocolObject({
   type: z.literal("cancel_scenario"),
 });
 
 // Auth commands (AC-408)
-export const LoginCmdSchema = z.object({
+export const LoginCmdSchema = protocolObject({
   type: z.literal("login"),
   provider: z.string().min(1),
   apiKey: z.string().optional(),
@@ -217,17 +271,17 @@ export const LoginCmdSchema = z.object({
   baseUrl: z.string().optional(),
 });
 
-export const LogoutCmdSchema = z.object({
+export const LogoutCmdSchema = protocolObject({
   type: z.literal("logout"),
   provider: z.string().optional(),
 });
 
-export const SwitchProviderCmdSchema = z.object({
+export const SwitchProviderCmdSchema = protocolObject({
   type: z.literal("switch_provider"),
   provider: z.string().min(1),
 });
 
-export const WhoamiCmdSchema = z.object({
+export const WhoamiCmdSchema = protocolObject({
   type: z.literal("whoami"),
 });
 

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -13,7 +13,7 @@ import { CampaignManager } from "../mission/campaign.js";
 import { MissionManager } from "../mission/manager.js";
 import { executeAuthCommand } from "./auth-command-workflow.js";
 import {
-  buildGenerationEventEnvelope,
+  buildEventStreamEnvelope,
   buildMissionProgressEventEnvelope,
 } from "./event-stream-envelope.js";
 import {
@@ -1211,11 +1211,23 @@ export class InteractiveServer {
   }
 
   #attachEventStreamClient(ws: WebSocket): void {
-    const eventCallback: EventCallback = (event, payload) => {
+    let sequence = 0;
+    const nextSequence = () => {
+      sequence += 1;
+      return sequence;
+    };
+
+    const eventCallback: EventCallback = (event, payload, record) => {
       if (ws.readyState !== WebSocket.OPEN) {
         return;
       }
-      ws.send(JSON.stringify(buildGenerationEventEnvelope(event, payload)));
+      ws.send(JSON.stringify(buildEventStreamEnvelope({
+        channel: record?.channel ?? "generation",
+        event,
+        payload,
+        seq: nextSequence(),
+        timestamp: record?.ts,
+      })));
     };
 
     this.#runManager.subscribeEvents(eventCallback);
@@ -1227,7 +1239,7 @@ export class InteractiveServer {
         if (ws.readyState !== WebSocket.OPEN) {
           return;
         }
-        ws.send(JSON.stringify(buildMissionProgressEventEnvelope(progress)));
+        ws.send(JSON.stringify(buildMissionProgressEventEnvelope(progress, nextSequence())));
       },
     });
 

--- a/ts/tests/event-stream-envelope.test.ts
+++ b/ts/tests/event-stream-envelope.test.ts
@@ -12,11 +12,13 @@ describe("event stream envelope", () => {
       channel: "generation",
       event: "run_started",
       payload: { run_id: "run_1" },
+      seq: 1,
       timestamp: "2026-04-09T14:00:00.000Z",
     })).toEqual({
       channel: "generation",
       event: "run_started",
       payload: { run_id: "run_1" },
+      seq: 1,
       ts: "2026-04-09T14:00:00.000Z",
       v: 1,
     });
@@ -26,11 +28,13 @@ describe("event stream envelope", () => {
     expect(buildGenerationEventEnvelope(
       "generation_completed",
       { generation: 3 },
+      2,
       "2026-04-09T14:00:01.000Z",
     )).toEqual({
       channel: "generation",
       event: "generation_completed",
       payload: { generation: 3 },
+      seq: 2,
       ts: "2026-04-09T14:00:01.000Z",
       v: 1,
     });
@@ -44,7 +48,7 @@ describe("event stream envelope", () => {
       stepsCompleted: 2,
       budgetUsed: 2,
       budgetMax: 5,
-    }, "2026-04-09T14:00:02.000Z")).toEqual({
+    }, 3, "2026-04-09T14:00:02.000Z")).toEqual({
       channel: "mission",
       event: "mission_progress",
       payload: {
@@ -55,6 +59,7 @@ describe("event stream envelope", () => {
         budgetUsed: 2,
         budgetMax: 5,
       },
+      seq: 3,
       ts: "2026-04-09T14:00:02.000Z",
       v: 1,
     });

--- a/ts/tests/event-stream.test.ts
+++ b/ts/tests/event-stream.test.ts
@@ -113,6 +113,38 @@ describe("EventStreamEmitter", () => {
     expect(received[1].payload.score).toBe(0.8);
   });
 
+  it("should dispatch canonical envelope records to subscribers", async () => {
+    const { EventStreamEmitter } = await import("../src/loop/events.js");
+    const path = join(dir, "events.ndjson");
+    const emitter = new EventStreamEmitter(path);
+
+    const records: Array<{
+      channel: string;
+      event: string;
+      payload: Record<string, unknown>;
+      seq: number;
+      ts: string;
+      v: 1;
+    }> = [];
+    emitter.subscribe((_event, _payload, record) => {
+      if (record) {
+        records.push(record);
+      }
+    });
+
+    emitter.emit("session_updated", { session_id: "session_1" }, "notebook");
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      channel: "notebook",
+      event: "session_updated",
+      payload: { session_id: "session_1" },
+      seq: 1,
+      v: 1,
+    });
+    expect(typeof records[0]?.ts).toBe("string");
+  });
+
   it("should support multiple subscribers", async () => {
     const { EventStreamEmitter } = await import("../src/loop/events.js");
     const path = join(dir, "events.ndjson");

--- a/ts/tests/websocket-protocol-contract.test.ts
+++ b/ts/tests/websocket-protocol-contract.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { buildEventStreamEnvelope } from "../src/server/event-stream-envelope.js";
+import {
+  AckMsgSchema,
+  CLIENT_MESSAGE_TYPES,
+  ChatAgentCmdSchema,
+  ExecutorResourcesSchema,
+  MonitorAlertMsgSchema,
+  PYTHON_SHARED_CLIENT_MESSAGE_TYPES,
+  PYTHON_SHARED_SERVER_MESSAGE_TYPES,
+  ScenarioErrorMsgSchema,
+  SERVER_MESSAGE_TYPES,
+  TYPESCRIPT_ONLY_CLIENT_MESSAGE_TYPES,
+  TYPESCRIPT_ONLY_SERVER_MESSAGE_TYPES,
+  parseClientMessage,
+} from "../src/server/protocol.js";
+
+type RuntimeOnlyMessage = {
+  reason: string;
+  type: string;
+};
+
+type EventStreamEnvelopeContract = {
+  fields: {
+    channel: { known_values: string[] };
+  };
+  required_fields: string[];
+  unknown_field_policy: "forbid";
+  version: 1;
+};
+
+type WebSocketProtocolContract = {
+  event_stream_envelope: EventStreamEnvelopeContract;
+  protocol_version: number;
+  shared_client_messages: string[];
+  shared_server_messages: string[];
+  top_level_unknown_field_policy: "forbid";
+  typescript_only_client_messages: RuntimeOnlyMessage[];
+  typescript_only_server_messages: RuntimeOnlyMessage[];
+};
+
+const CONTRACT = JSON.parse(
+  readFileSync(
+    join(import.meta.dirname, "..", "..", "docs", "websocket-protocol-contract.json"),
+    "utf-8",
+  ),
+) as WebSocketProtocolContract;
+
+function runtimeOnlyTypes(items: RuntimeOnlyMessage[]): string[] {
+  return items.map((item) => item.type);
+}
+
+describe("WebSocket protocol shared contract", () => {
+  it("keeps TypeScript message inventories aligned with the shared manifest", () => {
+    const tsOnlyServer = runtimeOnlyTypes(CONTRACT.typescript_only_server_messages);
+    const tsOnlyClient = runtimeOnlyTypes(CONTRACT.typescript_only_client_messages);
+
+    expect(PYTHON_SHARED_SERVER_MESSAGE_TYPES).toEqual(CONTRACT.shared_server_messages);
+    expect(PYTHON_SHARED_CLIENT_MESSAGE_TYPES).toEqual(CONTRACT.shared_client_messages);
+    expect(TYPESCRIPT_ONLY_SERVER_MESSAGE_TYPES).toEqual(tsOnlyServer);
+    expect(TYPESCRIPT_ONLY_CLIENT_MESSAGE_TYPES).toEqual(tsOnlyClient);
+    expect(SERVER_MESSAGE_TYPES).toEqual([...CONTRACT.shared_server_messages, ...tsOnlyServer]);
+    expect(CLIENT_MESSAGE_TYPES).toEqual([...CONTRACT.shared_client_messages, ...tsOnlyClient]);
+  });
+
+  it("forbids unknown top-level client fields like the Python protocol", () => {
+    expect(CONTRACT.top_level_unknown_field_policy).toBe("forbid");
+
+    expect(() => parseClientMessage({ type: "pause", unexpected: true })).toThrow();
+  });
+
+  it("keeps representative shared payload shapes aligned with Python's generated schema", () => {
+    expect(AckMsgSchema.parse({ type: "ack", action: "override_gate", decision: null }).decision)
+      .toBeNull();
+    expect(() => ChatAgentCmdSchema.parse({
+      type: "chat_agent",
+      role: "analyst",
+      message: "",
+    })).toThrow();
+    expect(() => ExecutorResourcesSchema.parse({
+      docker_image: "python:3.11",
+      cpu_cores: 1.5,
+      memory_gb: 2,
+      disk_gb: 5,
+      timeout_minutes: 30,
+    })).toThrow();
+    expect(() => ScenarioErrorMsgSchema.parse({
+      type: "scenario_error",
+      message: "missing stage",
+    })).toThrow();
+    expect(() => MonitorAlertMsgSchema.parse({
+      type: "monitor_alert",
+      alert_id: "a1",
+      condition_id: "c1",
+      condition_name: "threshold",
+      condition_type: "metric_threshold",
+      scope: "run:r1",
+      detail: { reason: "too high" },
+    })).toThrow();
+  });
+
+  it("requires runtime-only messages to carry an explicit reason", () => {
+    const allRuntimeOnly = [
+      ...CONTRACT.typescript_only_client_messages,
+      ...CONTRACT.typescript_only_server_messages,
+    ];
+
+    expect(allRuntimeOnly.length).toBeGreaterThan(0);
+    for (const item of allRuntimeOnly) {
+      expect(item.reason.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps the event-stream envelope aligned with the shared manifest", () => {
+    const envelope = buildEventStreamEnvelope({
+      channel: "generation",
+      event: "run_started",
+      payload: { run_id: "run_1" },
+      seq: 1,
+      timestamp: "2026-04-09T14:00:00.000Z",
+    });
+
+    expect(Object.keys(envelope).sort()).toEqual(
+      [...CONTRACT.event_stream_envelope.required_fields].sort(),
+    );
+    expect(envelope.v).toBe(CONTRACT.event_stream_envelope.version);
+    expect(envelope.seq).toBe(1);
+    expect(CONTRACT.event_stream_envelope.unknown_field_policy).toBe("forbid");
+    expect(CONTRACT.event_stream_envelope.fields.channel.known_values).toEqual(
+      expect.arrayContaining(["generation", "mission", "notebook", "cockpit"]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared WebSocket protocol contract manifest that marks Python/TS shared messages and TypeScript-only auth/mission extensions
- add Python and TypeScript parity tests for message inventories and top-level unknown-field policy
- tighten TS protocol schemas to match representative Python-generated payload rules, including strict top-level objects, required scenario error stage, nullable ack decisions, integer executor resources, non-empty chat messages, and string monitor alert detail

## Tests
- npm test -- tests/websocket-protocol-contract.test.ts tests/websocket-session-bootstrap.test.ts tests/tui-auth.test.ts tests/client-error-workflow.test.ts
- npm run lint
- uv run pytest tests/test_websocket_protocol_contract.py tests/test_protocol.py tests/test_protocol_parity.py
- uv run ruff check src/autocontext/server/protocol.py tests/test_websocket_protocol_contract.py tests/test_protocol.py tests/test_protocol_parity.py
- uv run mypy src

Note: broader live-server TS suites that bind localhost hit sandbox EPERM in this worktree, so the verified TS set is scoped to protocol behavior and non-listening command workflows.