### PR TITLE
feat: export production trace contracts through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PY_CONTROL_SRC = REPO_ROOT / "packages" / "python" / "control" / "src"
+if str(PY_CONTROL_SRC) not in sys.path:
+    sys.path.insert(0, str(PY_CONTROL_SRC))
+
+control_package = import_module("autocontext_control")
+package_role = control_package.package_role
+package_topology_version = control_package.package_topology_version
+
+
+def test_python_control_package_identity() -> None:
+    assert package_role == "control"
+    assert package_topology_version == 1
+
+
+def test_python_control_reexports_production_trace_contracts() -> None:
+    Chosen = control_package.Chosen
+    EndedAt = control_package.EndedAt
+    EnvContext = control_package.EnvContext
+    Error = control_package.Error
+    FeedbackRef = control_package.FeedbackRef
+    Items = control_package.Items
+    Message = control_package.Message
+    ProductionOutcome = control_package.ProductionOutcome
+    ProductionTrace = control_package.ProductionTrace
+    Provider = control_package.Provider
+    RedactionMarker = control_package.RedactionMarker
+    Routing = control_package.Routing
+    Sdk = control_package.Sdk
+    SessionIdentifier = control_package.SessionIdentifier
+    TimingInfo = control_package.TimingInfo
+    ToolCall = control_package.ToolCall
+    TraceLinks = control_package.TraceLinks
+    TraceSource = control_package.TraceSource
+    UsageInfo = control_package.UsageInfo
+
+    sdk = Sdk(name="autoctx", version="0.1.0")
+    source = TraceSource(emitter="gateway", sdk=sdk, hostname="box-1")
+    provider = Provider(name="anthropic", endpoint="https://api.anthropic.com", providerVersion="2026-04")
+    env = EnvContext(
+        environmentTag="prod",
+        appId="support-bot",
+        taskType="triage",
+        deploymentMeta={"region": "us-east-1"},
+    )
+    session = SessionIdentifier(
+        userIdHash="a" * 64,
+        sessionIdHash="b" * 64,
+        requestId="req-1",
+    )
+    message = Message(
+        role="user",
+        content="help me with a refund",
+        timestamp="2026-04-25T00:00:00Z",
+        toolCalls=[Items(toolName="kb.search", args={"query": "refund"}, durationMs=12.0)],
+        metadata={"lang": "en"},
+    )
+    tool_call = ToolCall(
+        toolName="kb.search",
+        args={"query": "refund"},
+        result={"hits": 1},
+        durationMs=12.0,
+    )
+    outcome = ProductionOutcome(
+        label="success",
+        score=0.9,
+        reasoning="resolved",
+        signals={"accuracy": 0.9},
+        error=Error(type="none", message="no error"),
+    )
+    timing = TimingInfo(
+        startedAt="2026-04-25T00:00:00Z",
+        endedAt="2026-04-25T00:00:01Z",
+        latencyMs=1000.0,
+    )
+    usage = UsageInfo(tokensIn=10, tokensOut=5, estimatedCostUsd=0.01)
+    feedback = FeedbackRef(
+        kind="rating",
+        submittedAt="2026-04-25T00:00:02Z",
+        ref="feedback-1",
+        score=0.9,
+        comment="great help",
+    )
+    links = TraceLinks(
+        scenarioId="grid_ctf",
+        runId="run-1",
+        evalExampleIds=["eval-1"],
+        trainingRecordIds=["train-1"],
+    )
+    redaction = RedactionMarker(
+        path="messages[0].content",
+        reason="pii-name",
+        detectedBy="operator",
+        detectedAt="2026-04-25T00:00:03Z",
+    )
+    routing = Routing(
+        chosen=Chosen(
+            provider="anthropic",
+            model="claude-sonnet",
+            endpoint="https://api.anthropic.com",
+        ),
+        matchedRouteId="route-1",
+        reason="matched-route",
+        evaluatedAt="2026-04-25T00:00:04Z",
+    )
+
+    trace = ProductionTrace(
+        schemaVersion="1.0",
+        traceId="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        source=source,
+        provider=provider,
+        model="claude-sonnet",
+        session=session,
+        env=env,
+        messages=[message],
+        toolCalls=[tool_call],
+        outcome=outcome,
+        timing=timing,
+        usage=usage,
+        feedbackRefs=[feedback],
+        links=links,
+        redactions=[redaction],
+        routing=routing,
+        metadata={"run": "r1"},
+    )
+    recreated_trace = ProductionTrace.model_validate(trace.model_dump())
+
+    assert trace.model == "claude-sonnet"
+    assert trace.source.sdk.name == "autoctx"
+    assert trace.messages[0].toolCalls[0].toolName == "kb.search"
+    assert trace.feedbackRefs[0].ref == "feedback-1"
+    assert recreated_trace.routing.reason == "matched-route"
+    assert EndedAt.model_validate(trace.messages[0].timestamp).root.isoformat().startswith("2026-04-25")

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -1,4 +1,66 @@
-"""Package skeleton for the future autocontext control-plane artifact."""
+"""Facade for the future autocontext control-plane artifact."""
+
+from importlib import import_module
+from typing import Any
+
+_production_traces_contract = import_module(
+    "autocontext.production_traces.contract.models"
+)
+
+Sdk: Any = _production_traces_contract.Sdk
+TraceSource: Any = _production_traces_contract.TraceSource
+Provider: Any = _production_traces_contract.Provider
+EnvContext: Any = _production_traces_contract.EnvContext
+ToolCall: Any = _production_traces_contract.ToolCall
+Error: Any = _production_traces_contract.Error
+ProductionOutcome: Any = _production_traces_contract.ProductionOutcome
+UsageInfo: Any = _production_traces_contract.UsageInfo
+EvalExampleId: Any = _production_traces_contract.EvalExampleId
+TrainingRecordId: Any = _production_traces_contract.TrainingRecordId
+TraceLinks: Any = _production_traces_contract.TraceLinks
+Chosen: Any = _production_traces_contract.Chosen
+Routing: Any = _production_traces_contract.Routing
+UserIdHash: Any = _production_traces_contract.UserIdHash
+EndedAt: Any = _production_traces_contract.EndedAt
+Items: Any = _production_traces_contract.Items
+SessionIdentifier: Any = _production_traces_contract.SessionIdentifier
+Message: Any = _production_traces_contract.Message
+TimingInfo: Any = _production_traces_contract.TimingInfo
+FeedbackRef: Any = _production_traces_contract.FeedbackRef
+RedactionMarker: Any = _production_traces_contract.RedactionMarker
+ProductionTrace: Any = _production_traces_contract.ProductionTrace
 
 PACKAGE_ROLE = "control"
 PACKAGE_TOPOLOGY_VERSION = 1
+
+package_role = PACKAGE_ROLE
+package_topology_version = PACKAGE_TOPOLOGY_VERSION
+
+__all__ = [
+    "Chosen",
+    "EndedAt",
+    "EnvContext",
+    "Error",
+    "EvalExampleId",
+    "FeedbackRef",
+    "Items",
+    "Message",
+    "PACKAGE_ROLE",
+    "PACKAGE_TOPOLOGY_VERSION",
+    "ProductionOutcome",
+    "ProductionTrace",
+    "Provider",
+    "RedactionMarker",
+    "Routing",
+    "Sdk",
+    "SessionIdentifier",
+    "TimingInfo",
+    "ToolCall",
+    "TraceLinks",
+    "TraceSource",
+    "TrainingRecordId",
+    "UsageInfo",
+    "UserIdHash",
+    "package_role",
+    "package_topology_version",
+]

--- a/packages/ts/control-plane/package.json
+++ b/packages/ts/control-plane/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "description": "Internal package skeleton for the future control-plane artifact.",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/packages/ts/control-plane/src/index.js",
+  "types": "dist/packages/ts/control-plane/src/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/packages/ts/control-plane/src/index.js",
+      "types": "./dist/packages/ts/control-plane/src/index.d.ts"
     }
   },
   "files": [

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -1,2 +1,40 @@
 export const packageRole = "control";
 export const packageTopologyVersion = 1;
+
+export type {
+	AppId,
+	ContentHash,
+	EnvironmentTag,
+	FeedbackRefId,
+	ProductionTraceId,
+	Scenario,
+	SessionIdHash,
+	UserIdHash,
+} from "../../../../ts/src/production-traces/contract/branded-ids.js";
+export type {
+	DetectedBy,
+	EnvContext,
+	FeedbackKind,
+	FeedbackRef,
+	MessageRole,
+	ModelRoutingDecisionReason,
+	ModelRoutingFallbackReason,
+	OutcomeLabel,
+	ProductionOutcome,
+	ProductionTrace,
+	ProductionTraceRouting,
+	ProductionTraceSchemaVersion,
+	ProviderInfo,
+	ProviderName,
+	RedactionMarker,
+	RedactionReason,
+	SessionIdentifier,
+	TimingInfo,
+	ToolCall,
+	TraceLinks,
+	TraceMessage,
+	TraceSource,
+	UsageInfo,
+	ValidationResult,
+} from "../../../../ts/src/production-traces/contract/types.js";
+export { PRODUCTION_TRACE_SCHEMA_VERSION } from "../../../../ts/src/production-traces/contract/types.js";

--- a/packages/ts/control-plane/tsconfig.json
+++ b/packages/ts/control-plane/tsconfig.json
@@ -1,9 +1,14 @@
 {
   "extends": "../../../ts/tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "../../..",
     "outDir": "./dist",
     "noEmit": false
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts",
+    "../../../ts/src/production-traces/contract/types.ts",
+    "../../../ts/src/production-traces/contract/branded-ids.ts",
+    "../../../ts/src/control-plane/contract/branded-ids.ts"
+  ]
 }

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type {
+	AppId,
+	EnvironmentTag,
+	FeedbackRef,
+	FeedbackRefId,
+	ProductionTrace,
+	ProductionTraceId,
+	ProviderInfo,
+	Scenario,
+	SessionIdHash,
+	TraceSource,
+	UserIdHash,
+} from "../../packages/ts/control-plane/src/index.ts";
+import {
+	PRODUCTION_TRACE_SCHEMA_VERSION,
+	packageRole,
+	packageTopologyVersion,
+} from "../../packages/ts/control-plane/src/index.ts";
+
+describe("@autocontext/control-plane facade", () => {
+	it("preserves the control package identity", () => {
+		expect(packageRole).toBe("control");
+		expect(packageTopologyVersion).toBe(1);
+	});
+
+	it("re-exports production trace contract types", () => {
+		const source: TraceSource = {
+			emitter: "gateway",
+			sdk: { name: "autoctx", version: "0.1.0" },
+			hostname: "box-1",
+		};
+		const provider: ProviderInfo = {
+			name: "anthropic",
+			endpoint: "https://api.anthropic.com",
+			providerVersion: "2026-04",
+		};
+		const feedback: FeedbackRef = {
+			kind: "rating",
+			submittedAt: "2026-04-25T00:00:02Z",
+			ref: "feedback-1" as FeedbackRefId,
+			score: 0.9,
+			comment: "great help",
+		};
+		const trace: ProductionTrace = {
+			schemaVersion: PRODUCTION_TRACE_SCHEMA_VERSION,
+			traceId: "01ARZ3NDEKTSV4RRFFQ69G5FAV" as ProductionTraceId,
+			source,
+			provider,
+			model: "claude-sonnet",
+			session: {
+				userIdHash: "a".repeat(64) as UserIdHash,
+				sessionIdHash: "b".repeat(64) as SessionIdHash,
+				requestId: "req-1",
+			},
+			env: {
+				environmentTag: "prod" as EnvironmentTag,
+				appId: "support-bot" as AppId,
+				taskType: "triage",
+				deploymentMeta: { region: "us-east-1" },
+			},
+			messages: [
+				{
+					role: "user",
+					content: "help me with a refund",
+					timestamp: "2026-04-25T00:00:00Z",
+					toolCalls: [
+						{
+							toolName: "kb.search",
+							args: { query: "refund" },
+							durationMs: 12,
+						},
+					],
+					metadata: { lang: "en" },
+				},
+			],
+			toolCalls: [
+				{
+					toolName: "kb.search",
+					args: { query: "refund" },
+					result: { hits: 1 },
+				},
+			],
+			outcome: {
+				label: "success",
+				score: 0.9,
+				reasoning: "resolved",
+				signals: { accuracy: 0.9 },
+				error: { type: "none", message: "no error" },
+			},
+			timing: {
+				startedAt: "2026-04-25T00:00:00Z",
+				endedAt: "2026-04-25T00:00:01Z",
+				latencyMs: 1000,
+			},
+			usage: {
+				tokensIn: 10,
+				tokensOut: 5,
+				estimatedCostUsd: 0.01,
+			},
+			feedbackRefs: [feedback],
+			links: {
+				scenarioId: "grid_ctf" as Scenario,
+				runId: "run-1",
+				evalExampleIds: ["eval-1"],
+				trainingRecordIds: ["train-1"],
+			},
+			redactions: [
+				{
+					path: "messages[0].content",
+					reason: "pii-name",
+					detectedBy: "operator",
+					detectedAt: "2026-04-25T00:00:03Z",
+				},
+			],
+			routing: {
+				chosen: {
+					provider: "anthropic",
+					model: "claude-sonnet",
+					endpoint: "https://api.anthropic.com",
+				},
+				matchedRouteId: "route-1",
+				reason: "matched-route",
+				evaluatedAt: "2026-04-25T00:00:04Z",
+			},
+			metadata: { run: "r1" },
+		};
+
+		expect(trace.schemaVersion).toBe("1.0");
+		expect(trace.source.sdk.name).toBe("autoctx");
+		expect(trace.messages[0]?.toolCalls?.[0]?.toolName).toBe("kb.search");
+		expect(trace.feedbackRefs[0]?.ref).toBe("feedback-1");
+		expect(trace.routing?.reason).toBe("matched-route");
+	});
+});


### PR DESCRIPTION
## Summary

- expose the first real control-plane facade surface by re-exporting the production traces contract through `autocontext_control` and `@autocontext/control-plane`
- keep this slice strictly contract/value-only: no ingestion, retention, SDK, CLI, or runtime behavior moves
- strengthen the AC-650 / AC-649 / AC-644 boundary by proving that a control-only domain can now be surfaced through the dedicated control artifacts instead of the umbrella monolith
- keep PR #805 stable by publishing this as a stacked follow-up slice

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] additional manual verification described below

Manual verification:
- confirmed the new branch isolates only the control-package follow-up commit on top of `ac-650/core-control-package-skeletons`
- confirmed the TypeScript control-package tsconfig is scoped only to the exact source-of-truth contract files the facade re-exports
- reverted unrelated `autocontext/uv.lock` drift before branch publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #805
- Python control facade now re-exports the production-trace aggregate and its direct contract sub-aggregates, including `ProductionTrace`, `TraceSource`, `Provider`, `EnvContext`, `Message`, `ToolCall`, `TimingInfo`, `UsageInfo`, `ProductionOutcome`, `FeedbackRef`, `TraceLinks`, `RedactionMarker`, and `Routing`
- TypeScript control facade now re-exports the production-trace contract type surface, including related branded IDs / contract brands plus `PRODUCTION_TRACE_SCHEMA_VERSION`
- this PR intentionally does **not** move any production-traces behavior (ingest, retention, sdk, cli, runtime) into the control package yet
- this keeps the boundary truthful: control artifacts now have a real domain contract surface, while behavior remains in place until a later intentional split
