### PR TITLE
feat: export basic server messages through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -101,6 +101,28 @@ def test_python_control_reexports_shared_server_protocol_models() -> None:
     assert scoring.weight == 0.7
 
 
+def test_python_control_reexports_basic_server_protocol_messages() -> None:
+    AckMsg = control_package.AckMsg
+    ErrorMsg = control_package.ErrorMsg
+    HelloMsg = control_package.HelloMsg
+    StateMsg = control_package.StateMsg
+
+    hello = HelloMsg()
+    state = StateMsg(paused=True, generation=3, phase="evaluation")
+    ack = AckMsg(action="pause", decision="accepted")
+    error = ErrorMsg(message="run failed")
+
+    assert hello.type == "hello"
+    assert hello.protocol_version == control_package.PROTOCOL_VERSION
+    assert state.paused is True
+    assert state.generation == 3
+    assert state.phase == "evaluation"
+    assert ack.action == "pause"
+    assert ack.decision == "accepted"
+    assert error.type == "error"
+    assert error.message == "run failed"
+
+
 def test_python_control_reexports_production_trace_contracts() -> None:
     Chosen = control_package.Chosen
     EndedAt = control_package.EndedAt

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -15,6 +15,10 @@ ExecutorResources: Any = _server_protocol.ExecutorResources
 ExecutorInfo: Any = _server_protocol.ExecutorInfo
 StrategyParam: Any = _server_protocol.StrategyParam
 ScoringComponent: Any = _server_protocol.ScoringComponent
+HelloMsg: Any = _server_protocol.HelloMsg
+StateMsg: Any = _server_protocol.StateMsg
+AckMsg: Any = _server_protocol.AckMsg
+ErrorMsg: Any = _server_protocol.ErrorMsg
 Urgency: Any = _research_types.Urgency
 ResearchQuery: Any = _research_types.ResearchQuery
 Citation: Any = _research_types.Citation
@@ -55,12 +59,15 @@ __all__ = [
     "Citation",
     "EndedAt",
     "EnvContext",
+    "AckMsg",
     "Error",
+    "ErrorMsg",
     "EvalExampleId",
     "FeedbackRef",
     "Items",
     "ExecutorInfo",
     "ExecutorResources",
+    "HelloMsg",
     "Message",
     "PACKAGE_ROLE",
     "PACKAGE_TOPOLOGY_VERSION",
@@ -78,6 +85,7 @@ __all__ = [
     "ScoringComponent",
     "Sdk",
     "SessionIdentifier",
+    "StateMsg",
     "StrategyParam",
     "TimingInfo",
     "ToolCall",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -47,10 +47,14 @@ export {
 	Urgency,
 } from "../../../../ts/src/research/types.js";
 export {
+	AckMsgSchema,
+	ErrorMsgSchema,
 	ExecutorInfoSchema,
 	ExecutorResourcesSchema,
+	HelloMsgSchema,
 	PROTOCOL_VERSION,
 	ScenarioInfoSchema,
 	ScoringComponentSchema,
+	StateMsgSchema,
 	StrategyParamSchema,
 } from "../../../../ts/src/server/protocol.js";

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -14,11 +14,15 @@ import type {
   UserIdHash,
 } from "../../packages/ts/control-plane/src/index.ts";
 import {
+  AckMsgSchema,
   Citation,
+  ErrorMsgSchema,
   ExecutorInfoSchema,
   ExecutorResourcesSchema,
+  HelloMsgSchema,
   PRODUCTION_TRACE_SCHEMA_VERSION,
   PROTOCOL_VERSION,
+  StateMsgSchema,
   packageRole,
   packageTopologyVersion,
   ResearchConfig,
@@ -115,6 +119,36 @@ describe("@autocontext/control-plane facade", () => {
     expect(executor.resources?.cpu_cores).toBe(4);
     expect(param.name).toBe("aggression");
     expect(scoring.weight).toBe(0.7);
+  });
+
+  it("re-exports basic server protocol message models", () => {
+    const hello = HelloMsgSchema.parse({
+      type: "hello",
+      protocol_version: PROTOCOL_VERSION,
+    });
+    const state = StateMsgSchema.parse({
+      type: "state",
+      paused: true,
+      generation: 3,
+      phase: "evaluation",
+    });
+    const ack = AckMsgSchema.parse({
+      type: "ack",
+      action: "pause",
+      decision: "accepted",
+    });
+    const error = ErrorMsgSchema.parse({
+      type: "error",
+      message: "run failed",
+    });
+
+    expect(hello.protocol_version).toBe(1);
+    expect(state.paused).toBe(true);
+    expect(state.generation).toBe(3);
+    expect(state.phase).toBe("evaluation");
+    expect(ack.action).toBe("pause");
+    expect(ack.decision).toBe("accepted");
+    expect(error.message).toBe("run failed");
   });
 
   it("re-exports production trace contract types", () => {


### PR DESCRIPTION
## Summary

- expose the next pure control-plane facade surface by re-exporting the narrow basic server message-model layer through `autocontext_control` and `@autocontext/control-plane`
- keep this slice strictly message-model-only: `HelloMsg`, `StateMsg`, `AckMsg`, and `ErrorMsg` (and the matching TypeScript schemas)
- strengthen the AC-650 / AC-649 / AC-644 boundary by proving the dedicated control artifacts can carry another small cross-language protocol surface while source-of-truth modules remain in place
- keep PR #810 stable by publishing this as a stacked follow-up slice on top of the shared server-protocol model work

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] additional manual verification described below

Manual verification:
- confirmed the new branch isolates only the basic server-message follow-up commit on top of `ac-650/control-server-protocol-models`
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #810
- Python control facade now also re-exports the narrow basic message-model layer: `HelloMsg`, `StateMsg`, `AckMsg`, and `ErrorMsg`
- TypeScript control facade now also re-exports `HelloMsgSchema`, `StateMsgSchema`, `AckMsgSchema`, and `ErrorMsgSchema`
- this PR intentionally does **not** export larger message unions, parse helpers, client commands, websocket runtime behavior, or server orchestration
- this keeps the boundary truthful: control artifacts now have another tiny cross-language message-model surface, while behavior remains deferred for later intentional slices
