### PR TITLE
feat: export environment discovery messages through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -101,6 +101,43 @@ def test_python_control_reexports_shared_server_protocol_models() -> None:
     assert scoring.weight == 0.7
 
 
+def test_python_control_reexports_environment_discovery_messages() -> None:
+    EnvironmentsMsg = control_package.EnvironmentsMsg
+    ExecutorInfo = control_package.ExecutorInfo
+    ExecutorResources = control_package.ExecutorResources
+    ScenarioInfo = control_package.ScenarioInfo
+
+    environments = EnvironmentsMsg(
+        scenarios=[
+            ScenarioInfo(name="grid_ctf", description="Capture the flag"),
+            ScenarioInfo(name="schema_repair", description="Recover a schema from examples."),
+        ],
+        executors=[
+            ExecutorInfo(
+                mode="docker",
+                available=True,
+                description="Local Docker executor",
+                resources=ExecutorResources(
+                    docker_image="ghcr.io/greyhaven/executor:latest",
+                    cpu_cores=4,
+                    memory_gb=8,
+                    disk_gb=20,
+                    timeout_minutes=15,
+                ),
+            ),
+        ],
+        current_executor="docker",
+        agent_provider="pi",
+    )
+
+    assert environments.type == "environments"
+    assert environments.scenarios[1].name == "schema_repair"
+    assert environments.executors[0].resources is not None
+    assert environments.executors[0].resources.cpu_cores == 4
+    assert environments.current_executor == "docker"
+    assert environments.agent_provider == "pi"
+
+
 def test_python_control_reexports_basic_server_protocol_messages() -> None:
     AckMsg = control_package.AckMsg
     ErrorMsg = control_package.ErrorMsg

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -16,6 +16,7 @@ ExecutorInfo: Any = _server_protocol.ExecutorInfo
 StrategyParam: Any = _server_protocol.StrategyParam
 ScoringComponent: Any = _server_protocol.ScoringComponent
 HelloMsg: Any = _server_protocol.HelloMsg
+EnvironmentsMsg: Any = _server_protocol.EnvironmentsMsg
 StateMsg: Any = _server_protocol.StateMsg
 AckMsg: Any = _server_protocol.AckMsg
 ErrorMsg: Any = _server_protocol.ErrorMsg
@@ -63,6 +64,7 @@ __all__ = [
     "Citation",
     "EndedAt",
     "EnvContext",
+    "EnvironmentsMsg",
     "AckMsg",
     "Error",
     "ErrorMsg",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -48,6 +48,7 @@ export {
 } from "../../../../ts/src/research/types.js";
 export {
 	AckMsgSchema,
+	EnvironmentsMsgSchema,
 	ErrorMsgSchema,
 	ExecutorInfoSchema,
 	ExecutorResourcesSchema,

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -16,6 +16,7 @@ import type {
 import {
 	AckMsgSchema,
 	Citation,
+	EnvironmentsMsgSchema,
 	ErrorMsgSchema,
 	ExecutorInfoSchema,
 	ExecutorResourcesSchema,
@@ -123,6 +124,43 @@ describe("@autocontext/control-plane facade", () => {
 		expect(executor.resources?.cpu_cores).toBe(4);
 		expect(param.name).toBe("aggression");
 		expect(scoring.weight).toBe(0.7);
+	});
+
+	it("re-exports environment discovery messages", () => {
+		const environments = EnvironmentsMsgSchema.parse({
+			type: "environments",
+			scenarios: [
+				ScenarioInfoSchema.parse({
+					name: "grid_ctf",
+					description: "Capture the flag",
+				}),
+				ScenarioInfoSchema.parse({
+					name: "schema_repair",
+					description: "Recover a schema from examples.",
+				}),
+			],
+			executors: [
+				ExecutorInfoSchema.parse({
+					mode: "docker",
+					available: true,
+					description: "Local Docker executor",
+					resources: ExecutorResourcesSchema.parse({
+						docker_image: "ghcr.io/greyhaven/executor:latest",
+						cpu_cores: 4,
+						memory_gb: 8,
+						disk_gb: 20,
+						timeout_minutes: 15,
+					}),
+				}),
+			],
+			current_executor: "docker",
+			agent_provider: "pi",
+		});
+
+		expect(environments.scenarios[1]?.name).toBe("schema_repair");
+		expect(environments.executors[0]?.resources?.cpu_cores).toBe(4);
+		expect(environments.current_executor).toBe("docker");
+		expect(environments.agent_provider).toBe("pi");
 	});
 
 	it("re-exports basic server protocol message models", () => {


### PR DESCRIPTION
## Summary

- expose the next pure control-plane facade surface by re-exporting the environment discovery message model through `autocontext_control` and `@autocontext/control-plane`
- keep this slice strictly message-model-only: `EnvironmentsMsg` / `EnvironmentsMsgSchema`
- strengthen the AC-650 / AC-649 / AC-644 boundary by proving the dedicated control artifacts can carry another small cross-language protocol surface while source-of-truth modules remain in place
- keep PR #812 stable by publishing this as a stacked follow-up slice on top of the scenario-generation lifecycle message work

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] additional focused RED/GREEN checks described below

Manual verification:
- confirmed RED first with focused Python/TS checks for missing environment-discovery message exports
- confirmed GREEN after minimal facade re-export only
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #812
- Python control facade now also re-exports `EnvironmentsMsg`
- TypeScript control facade now also re-exports `EnvironmentsMsgSchema`
- this PR intentionally does **not** export server message unions, parser helpers, websocket/runtime behavior, or client commands
- no source-of-truth relocation was performed; the slice remains pure facade boundary work
- the message composes already-exported `ScenarioInfo`, `ExecutorInfo`, and `ExecutorResources`, so it deepens the existing control boundary without adding new behavior
