### PR TITLE
feat: export run acceptance messages through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -138,6 +138,17 @@ def test_python_control_reexports_environment_discovery_messages() -> None:
     assert environments.agent_provider == "pi"
 
 
+def test_python_control_reexports_run_acceptance_messages() -> None:
+    RunAcceptedMsg = control_package.RunAcceptedMsg
+
+    accepted = RunAcceptedMsg(run_id="run-123", scenario="schema_repair", generations=4)
+
+    assert accepted.type == "run_accepted"
+    assert accepted.run_id == "run-123"
+    assert accepted.scenario == "schema_repair"
+    assert accepted.generations == 4
+
+
 def test_python_control_reexports_basic_server_protocol_messages() -> None:
     AckMsg = control_package.AckMsg
     ErrorMsg = control_package.ErrorMsg

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -19,6 +19,7 @@ HelloMsg: Any = _server_protocol.HelloMsg
 EnvironmentsMsg: Any = _server_protocol.EnvironmentsMsg
 StateMsg: Any = _server_protocol.StateMsg
 AckMsg: Any = _server_protocol.AckMsg
+RunAcceptedMsg: Any = _server_protocol.RunAcceptedMsg
 ErrorMsg: Any = _server_protocol.ErrorMsg
 ScenarioGeneratingMsg: Any = _server_protocol.ScenarioGeneratingMsg
 ScenarioPreviewMsg: Any = _server_protocol.ScenarioPreviewMsg
@@ -81,6 +82,7 @@ __all__ = [
     "ProductionOutcome",
     "ProductionTrace",
     "Provider",
+    "RunAcceptedMsg",
     "RedactionMarker",
     "ResearchAdapter",
     "ResearchConfig",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -54,6 +54,7 @@ export {
 	ExecutorResourcesSchema,
 	HelloMsgSchema,
 	PROTOCOL_VERSION,
+	RunAcceptedMsgSchema,
 	ScenarioErrorMsgSchema,
 	ScenarioGeneratingMsgSchema,
 	ScenarioInfoSchema,

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -28,6 +28,7 @@ import {
 	ResearchConfig,
 	ResearchQuery,
 	ResearchResult,
+	RunAcceptedMsgSchema,
 	ScenarioErrorMsgSchema,
 	ScenarioGeneratingMsgSchema,
 	ScenarioInfoSchema,
@@ -161,6 +162,19 @@ describe("@autocontext/control-plane facade", () => {
 		expect(environments.executors[0]?.resources?.cpu_cores).toBe(4);
 		expect(environments.current_executor).toBe("docker");
 		expect(environments.agent_provider).toBe("pi");
+	});
+
+	it("re-exports run acceptance messages", () => {
+		const accepted = RunAcceptedMsgSchema.parse({
+			type: "run_accepted",
+			run_id: "run-123",
+			scenario: "schema_repair",
+			generations: 4,
+		});
+
+		expect(accepted.run_id).toBe("run-123");
+		expect(accepted.scenario).toBe("schema_repair");
+		expect(accepted.generations).toBe(4);
 	});
 
 	it("re-exports basic server protocol message models", () => {


### PR DESCRIPTION
## Summary

- expose the next pure control-plane facade surface by re-exporting the run acceptance message model through `autocontext_control` and `@autocontext/control-plane`
- keep this slice strictly message-model-only: `RunAcceptedMsg` / `RunAcceptedMsgSchema`
- strengthen the AC-650 / AC-649 / AC-644 boundary by proving the dedicated control artifacts can carry another small cross-language protocol surface while source-of-truth modules remain in place
- keep PR #813 stable by publishing this as a stacked follow-up slice on top of the environment-discovery message work

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] additional focused RED/GREEN checks described below

Manual verification:
- confirmed RED first with focused Python/TS checks for missing run-acceptance message exports
- confirmed GREEN after minimal facade re-export only
- re-tightened the TypeScript facade diff to avoid whitespace churn before publication
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #813
- Python control facade now also re-exports `RunAcceptedMsg`
- TypeScript control facade now also re-exports `RunAcceptedMsgSchema`
- this PR intentionally does **not** export server message unions, parser helpers, websocket/runtime behavior, or client commands
- no source-of-truth relocation was performed; the slice remains pure facade boundary work
- the message is a narrow control-plane acknowledgment model for accepted runs and keeps the package boundary aligned with AC-644 rather than widening into orchestration
