### PR TITLE
feat: export chat response messages through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -149,6 +149,16 @@ def test_python_control_reexports_run_acceptance_messages() -> None:
     assert accepted.generations == 4
 
 
+def test_python_control_reexports_chat_response_messages() -> None:
+    ChatResponseMsg = control_package.ChatResponseMsg
+
+    response = ChatResponseMsg(role="assistant", text="Schema looks valid.")
+
+    assert response.type == "chat_response"
+    assert response.role == "assistant"
+    assert response.text == "Schema looks valid."
+
+
 def test_python_control_reexports_basic_server_protocol_messages() -> None:
     AckMsg = control_package.AckMsg
     ErrorMsg = control_package.ErrorMsg

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -16,6 +16,7 @@ ExecutorInfo: Any = _server_protocol.ExecutorInfo
 StrategyParam: Any = _server_protocol.StrategyParam
 ScoringComponent: Any = _server_protocol.ScoringComponent
 HelloMsg: Any = _server_protocol.HelloMsg
+ChatResponseMsg: Any = _server_protocol.ChatResponseMsg
 EnvironmentsMsg: Any = _server_protocol.EnvironmentsMsg
 StateMsg: Any = _server_protocol.StateMsg
 AckMsg: Any = _server_protocol.AckMsg
@@ -61,6 +62,7 @@ package_role = PACKAGE_ROLE
 package_topology_version = PACKAGE_TOPOLOGY_VERSION
 
 __all__ = [
+    "ChatResponseMsg",
     "Chosen",
     "Citation",
     "EndedAt",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -48,6 +48,7 @@ export {
 } from "../../../../ts/src/research/types.js";
 export {
 	AckMsgSchema,
+	ChatResponseMsgSchema,
 	EnvironmentsMsgSchema,
 	ErrorMsgSchema,
 	ExecutorInfoSchema,

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../packages/ts/control-plane/src/index.ts";
 import {
 	AckMsgSchema,
+	ChatResponseMsgSchema,
 	Citation,
 	EnvironmentsMsgSchema,
 	ErrorMsgSchema,
@@ -175,6 +176,17 @@ describe("@autocontext/control-plane facade", () => {
 		expect(accepted.run_id).toBe("run-123");
 		expect(accepted.scenario).toBe("schema_repair");
 		expect(accepted.generations).toBe(4);
+	});
+
+	it("re-exports chat response messages", () => {
+		const response = ChatResponseMsgSchema.parse({
+			type: "chat_response",
+			role: "assistant",
+			text: "Schema looks valid.",
+		});
+
+		expect(response.role).toBe("assistant");
+		expect(response.text).toBe("Schema looks valid.");
 	});
 
 	it("re-exports basic server protocol message models", () => {


### PR DESCRIPTION
## Summary

- expose the next pure control-plane facade surface by re-exporting the chat response message model through `autocontext_control` and `@autocontext/control-plane`
- keep this slice strictly message-model-only: `ChatResponseMsg` / `ChatResponseMsgSchema`
- strengthen the AC-650 / AC-649 / AC-644 boundary by proving the dedicated control artifacts can carry another small cross-language protocol surface while source-of-truth modules remain in place
- keep PR #814 stable by publishing this as a stacked follow-up slice on top of the run-acceptance message work

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] additional focused RED/GREEN checks described below

Manual verification:
- confirmed RED first with focused Python/TS checks for missing chat-response message exports
- confirmed GREEN after minimal facade re-export only
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #814
- Python control facade now also re-exports `ChatResponseMsg`
- TypeScript control facade now also re-exports `ChatResponseMsgSchema`
- this PR intentionally does **not** export server message unions, parser helpers, websocket/runtime behavior, or client commands
- no source-of-truth relocation was performed; the slice remains pure facade boundary work
- the message is a narrow conversational control-plane model and keeps the package boundary moving without widening into runtime behavior
