### PR TITLE
feat: export event messages through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -159,6 +159,16 @@ def test_python_control_reexports_chat_response_messages() -> None:
     assert response.text == "Schema looks valid."
 
 
+def test_python_control_reexports_event_messages() -> None:
+    EventMsg = control_package.EventMsg
+
+    event = EventMsg(event="run_progress", payload={"run_id": "run-123", "percent": 50})
+
+    assert event.type == "event"
+    assert event.event == "run_progress"
+    assert event.payload == {"run_id": "run-123", "percent": 50}
+
+
 def test_python_control_reexports_basic_server_protocol_messages() -> None:
     AckMsg = control_package.AckMsg
     ErrorMsg = control_package.ErrorMsg

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -17,6 +17,7 @@ StrategyParam: Any = _server_protocol.StrategyParam
 ScoringComponent: Any = _server_protocol.ScoringComponent
 HelloMsg: Any = _server_protocol.HelloMsg
 ChatResponseMsg: Any = _server_protocol.ChatResponseMsg
+EventMsg: Any = _server_protocol.EventMsg
 EnvironmentsMsg: Any = _server_protocol.EnvironmentsMsg
 StateMsg: Any = _server_protocol.StateMsg
 AckMsg: Any = _server_protocol.AckMsg
@@ -67,6 +68,7 @@ __all__ = [
     "Citation",
     "EndedAt",
     "EnvContext",
+    "EventMsg",
     "EnvironmentsMsg",
     "AckMsg",
     "Error",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -51,6 +51,7 @@ export {
 	ChatResponseMsgSchema,
 	EnvironmentsMsgSchema,
 	ErrorMsgSchema,
+	EventMsgSchema,
 	ExecutorInfoSchema,
 	ExecutorResourcesSchema,
 	HelloMsgSchema,

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -19,6 +19,7 @@ import {
 	Citation,
 	EnvironmentsMsgSchema,
 	ErrorMsgSchema,
+	EventMsgSchema,
 	ExecutorInfoSchema,
 	ExecutorResourcesSchema,
 	HelloMsgSchema,
@@ -187,6 +188,17 @@ describe("@autocontext/control-plane facade", () => {
 
 		expect(response.role).toBe("assistant");
 		expect(response.text).toBe("Schema looks valid.");
+	});
+
+	it("re-exports event messages", () => {
+		const event = EventMsgSchema.parse({
+			type: "event",
+			event: "run_progress",
+			payload: { run_id: "run-123", percent: 50 },
+		});
+
+		expect(event.event).toBe("run_progress");
+		expect(event.payload).toEqual({ run_id: "run-123", percent: 50 });
 	});
 
 	it("re-exports basic server protocol message models", () => {


### PR DESCRIPTION
## Summary

- expose the next pure control-plane facade surface by re-exporting the event message model through `autocontext_control` and `@autocontext/control-plane`
- keep this slice strictly message-model-only: `EventMsg` / `EventMsgSchema`
- strengthen the AC-650 / AC-649 / AC-644 boundary by proving the dedicated control artifacts can carry another small cross-language protocol surface while source-of-truth modules remain in place
- keep PR #815 stable by publishing this as a stacked follow-up slice on top of the chat-response message work

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] additional focused RED/GREEN checks described below

Manual verification:
- confirmed RED first with focused Python/TS checks for missing event-message exports
- confirmed GREEN after minimal facade re-export only
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #815
- Python control facade now also re-exports `EventMsg`
- TypeScript control facade now also re-exports `EventMsgSchema`
- this PR intentionally does **not** export server message unions, parser helpers, websocket/runtime behavior, or client commands
- no source-of-truth relocation was performed; the slice remains pure facade boundary work
- the message remains generic at the payload level, but still advances the shared control-plane protocol boundary without introducing behavior
