### PR TITLE
feat: align and export monitor alert messages

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -4,6 +4,8 @@ import sys
 from importlib import import_module
 from pathlib import Path
 
+from pydantic import ValidationError
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PY_CONTROL_SRC = REPO_ROOT / "packages" / "python" / "control" / "src"
 if str(PY_CONTROL_SRC) not in sys.path:
@@ -189,6 +191,34 @@ def test_python_control_reexports_basic_server_protocol_messages() -> None:
     assert ack.decision == "accepted"
     assert error.type == "error"
     assert error.message == "run failed"
+
+
+def test_python_control_reexports_monitor_alert_messages() -> None:
+    MonitorAlertMsg = control_package.MonitorAlertMsg
+
+    alert = MonitorAlertMsg(
+        alert_id="alert-1",
+        condition_id="cond-1",
+        condition_name="stalled-run",
+        condition_type="stall_window",
+        scope="run:run-123",
+        detail="No events for 30.0s (timeout=30.0s)",
+    )
+
+    assert alert.type == "monitor_alert"
+    assert alert.condition_name == "stalled-run"
+    assert alert.detail == "No events for 30.0s (timeout=30.0s)"
+
+
+def test_python_control_requires_stage_for_scenario_error_messages() -> None:
+    ScenarioErrorMsg = control_package.ScenarioErrorMsg
+
+    try:
+        ScenarioErrorMsg(message="designer failed")
+    except ValidationError:
+        pass
+    else:
+        raise AssertionError("ScenarioErrorMsg should require stage")
 
 
 def test_python_control_reexports_scenario_generation_lifecycle_messages() -> None:

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -23,6 +23,7 @@ StateMsg: Any = _server_protocol.StateMsg
 AckMsg: Any = _server_protocol.AckMsg
 RunAcceptedMsg: Any = _server_protocol.RunAcceptedMsg
 ErrorMsg: Any = _server_protocol.ErrorMsg
+MonitorAlertMsg: Any = _server_protocol.MonitorAlertMsg
 ScenarioGeneratingMsg: Any = _server_protocol.ScenarioGeneratingMsg
 ScenarioPreviewMsg: Any = _server_protocol.ScenarioPreviewMsg
 ScenarioReadyMsg: Any = _server_protocol.ScenarioReadyMsg
@@ -73,6 +74,7 @@ __all__ = [
     "AckMsg",
     "Error",
     "ErrorMsg",
+    "MonitorAlertMsg",
     "EvalExampleId",
     "FeedbackRef",
     "Items",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -53,6 +53,7 @@ export {
 	ErrorMsgSchema,
 	EventMsgSchema,
 	ExecutorInfoSchema,
+	MonitorAlertMsgSchema,
 	ExecutorResourcesSchema,
 	HelloMsgSchema,
 	PROTOCOL_VERSION,

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -21,6 +21,7 @@ import {
 	ErrorMsgSchema,
 	EventMsgSchema,
 	ExecutorInfoSchema,
+	MonitorAlertMsgSchema,
 	ExecutorResourcesSchema,
 	HelloMsgSchema,
 	PRODUCTION_TRACE_SCHEMA_VERSION,
@@ -229,6 +230,30 @@ describe("@autocontext/control-plane facade", () => {
 		expect(ack.action).toBe("pause");
 		expect(ack.decision).toBe("accepted");
 		expect(error.message).toBe("run failed");
+	});
+
+	it("re-exports monitor alert messages", () => {
+		const alert = MonitorAlertMsgSchema.parse({
+			type: "monitor_alert",
+			alert_id: "alert-1",
+			condition_id: "cond-1",
+			condition_name: "stalled-run",
+			condition_type: "stall_window",
+			scope: "run:run-123",
+			detail: "No events for 30.0s (timeout=30.0s)",
+		});
+
+		expect(alert.condition_name).toBe("stalled-run");
+		expect(alert.detail).toBe("No events for 30.0s (timeout=30.0s)");
+	});
+
+	it("requires stage for scenario error messages", () => {
+		const parsed = ScenarioErrorMsgSchema.safeParse({
+			type: "scenario_error",
+			message: "designer failed",
+		});
+
+		expect(parsed.success).toBe(false);
 	});
 
 	it("re-exports scenario generation lifecycle messages", () => {


### PR DESCRIPTION
## Summary

- expose the next pure control-plane facade surface by re-exporting the shared monitor-alert message model through `autocontext_control` and `@autocontext/control-plane`
- tighten TypeScript server protocol drift so the shared contract matches Python and the generated TUI protocol: `ScenarioErrorMsgSchema.stage` is now required and `MonitorAlertMsgSchema.detail` is now a string
- keep this slice model-only: `MonitorAlertMsg` / `MonitorAlertMsgSchema` plus the minimal contract-alignment needed to make the export truthful
- keep PR #816 stable by publishing this as a stacked follow-up slice on top of the event-message work

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] additional focused RED/GREEN checks described below

Manual verification:
- confirmed RED first with focused Python/TS checks for missing `MonitorAlertMsg` exports
- added a TS contract guard that `ScenarioErrorMsgSchema` rejects a missing `stage`
- confirmed the generated TUI protocol already matches the tightened TS server protocol shape
- re-tightened TS edits to avoid formatter-only churn before publication
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #816
- Python control facade now also re-exports `MonitorAlertMsg`
- TypeScript control facade now also re-exports `MonitorAlertMsgSchema`
- this PR intentionally does **not** export server message unions, parser helpers, websocket/runtime behavior, or client commands
- no source-of-truth relocation was performed; the slice remains pure contract/facade boundary work
- the small TS source alignment is necessary to keep the shared control-plane contract truthful across Python, `ts/src/server/protocol.ts`, and `ts/src/tui/protocol.generated.ts`
