### PR TITLE
feat: export auth status messages through control facades

### DIFF
--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -48,6 +48,7 @@ export {
 } from "../../../../ts/src/research/types.js";
 export {
 	AckMsgSchema,
+	AuthStatusMsgSchema,
 	ChatResponseMsgSchema,
 	EnvironmentsMsgSchema,
 	ErrorMsgSchema,

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../packages/ts/control-plane/src/index.ts";
 import {
 	AckMsgSchema,
+	AuthStatusMsgSchema,
 	ChatResponseMsgSchema,
 	Citation,
 	EnvironmentsMsgSchema,
@@ -231,6 +232,24 @@ describe("@autocontext/control-plane facade", () => {
 		expect(ack.action).toBe("pause");
 		expect(ack.decision).toBe("accepted");
 		expect(error.message).toBe("run failed");
+	});
+
+	it("re-exports auth status messages", () => {
+		const auth = AuthStatusMsgSchema.parse({
+			type: "auth_status",
+			provider: "anthropic",
+			authenticated: true,
+			model: "claude-sonnet",
+			configuredProviders: [
+				{ provider: "anthropic", hasApiKey: true },
+				{ provider: "openai", hasApiKey: false },
+			],
+		});
+
+		expect(auth.provider).toBe("anthropic");
+		expect(auth.authenticated).toBe(true);
+		expect(auth.model).toBe("claude-sonnet");
+		expect(auth.configuredProviders?.[1]?.hasApiKey).toBe(false);
 	});
 
 	it("re-exports mission progress messages", () => {


### PR DESCRIPTION
## Summary

- expose the next truthful control-plane facade surface by re-exporting the TypeScript-only auth status message model through `@autocontext/control-plane`
- keep this slice strictly message-model-only: `AuthStatusMsgSchema`
- continue the AC-650 / AC-649 / AC-644 boundary after exhausting the currently shared Python/TS server-message layer, without inventing fake Python symmetry
- keep PR #818 stable by publishing this as a stacked follow-up slice on top of the mission-progress message work

## Surfaces Touched

- [ ] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] additional focused RED/GREEN checks described below

Manual verification:
- confirmed RED first with focused TS type-checking for missing `AuthStatusMsgSchema` export
- confirmed GREEN after the minimal TS control-facade export only
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #818
- TypeScript control facade now also re-exports `AuthStatusMsgSchema`
- Python is intentionally untouched in this slice because the currently shared Python/TS server-message surface has been exhausted; this is the next truthful TS-only control-plane contract
- this PR intentionally does **not** export server message unions, parser helpers, websocket/runtime behavior, or client commands
- no source-of-truth relocation was performed; the slice remains pure facade boundary work
