### PR TITLE
feat: export monitor domain values through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -210,6 +210,38 @@ def test_python_control_reexports_monitor_alert_messages() -> None:
     assert alert.detail == "No events for 30.0s (timeout=30.0s)"
 
 
+def test_python_control_reexports_monitor_domain_value_objects() -> None:
+    ConditionType = control_package.ConditionType
+    MonitorAlert = control_package.MonitorAlert
+    MonitorCondition = control_package.MonitorCondition
+
+    condition = MonitorCondition(
+        id="cond-1",
+        name="stall-window",
+        condition_type=ConditionType.STALL_WINDOW,
+        params={"window": 3},
+        scope="run:run-123",
+        created_at="2026-04-25T00:00:00Z",
+    )
+    alert = MonitorAlert(
+        id="alert-1",
+        condition_id=condition.id,
+        condition_name=condition.name,
+        condition_type=condition.condition_type,
+        scope=condition.scope,
+        detail="3 consecutive rollbacks",
+        fired_at="2026-04-25T00:01:00Z",
+        payload={"window": 3},
+    )
+
+    assert ConditionType.STALL_WINDOW == "stall_window"
+    assert condition.condition_type is ConditionType.STALL_WINDOW
+    assert condition.params == {"window": 3}
+    assert alert.condition_type is ConditionType.STALL_WINDOW
+    assert alert.detail == "3 consecutive rollbacks"
+    assert alert.payload == {"window": 3}
+
+
 def test_python_control_requires_stage_for_scenario_error_messages() -> None:
     ScenarioErrorMsg = control_package.ScenarioErrorMsg
 

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -8,6 +8,7 @@ _production_traces_contract = import_module(
 )
 _research_types = import_module("autocontext.research.types")
 _server_protocol = import_module("autocontext.server.protocol")
+_monitor_types = import_module("autocontext.monitor.types")
 
 PROTOCOL_VERSION = _server_protocol.PROTOCOL_VERSION
 ScenarioInfo: Any = _server_protocol.ScenarioInfo
@@ -24,6 +25,9 @@ AckMsg: Any = _server_protocol.AckMsg
 RunAcceptedMsg: Any = _server_protocol.RunAcceptedMsg
 ErrorMsg: Any = _server_protocol.ErrorMsg
 MonitorAlertMsg: Any = _server_protocol.MonitorAlertMsg
+ConditionType: Any = _monitor_types.ConditionType
+MonitorCondition: Any = _monitor_types.MonitorCondition
+MonitorAlert: Any = _monitor_types.MonitorAlert
 ScenarioGeneratingMsg: Any = _server_protocol.ScenarioGeneratingMsg
 ScenarioPreviewMsg: Any = _server_protocol.ScenarioPreviewMsg
 ScenarioReadyMsg: Any = _server_protocol.ScenarioReadyMsg
@@ -67,6 +71,7 @@ __all__ = [
     "ChatResponseMsg",
     "Chosen",
     "Citation",
+    "ConditionType",
     "EndedAt",
     "EnvContext",
     "EventMsg",
@@ -74,7 +79,9 @@ __all__ = [
     "AckMsg",
     "Error",
     "ErrorMsg",
+    "MonitorAlert",
     "MonitorAlertMsg",
+    "MonitorCondition",
     "EvalExampleId",
     "FeedbackRef",
     "Items",


### PR DESCRIPTION
## Summary

- expose the next truthful control-plane facade surface by re-exporting the Python-only monitor domain value objects through `autocontext_control`
- keep this slice strictly value-model-only: `ConditionType`, `MonitorCondition`, and `MonitorAlert`
- continue the AC-650 / AC-649 / AC-644 boundary after exhausting the shared Python/TS server-message layer, without inventing fake TypeScript symmetry
- keep PR #819 stable by publishing this as a stacked follow-up slice on top of the auth-status message work

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] additional focused RED/GREEN checks described below

Manual verification:
- confirmed RED first with a focused Python control-package test for missing monitor domain exports
- confirmed GREEN after the minimal Python control-facade re-exports only
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #819
- Python control facade now also re-exports `ConditionType`, `MonitorCondition`, and `MonitorAlert`
- `make_id` and monitor evaluator/engine behavior remain intentionally out of scope
- TypeScript is intentionally untouched in this slice because there is no truthful TS monitor-domain counterpart today
- this PR intentionally does **not** export orchestration, persistence behavior, or runtime helpers
- no source-of-truth relocation was performed; the slice remains pure facade boundary work
