### PR TITLE
feat: export agent contract dataclasses through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -242,6 +242,48 @@ def test_python_control_reexports_monitor_domain_value_objects() -> None:
     assert alert.payload == {"window": 3}
 
 
+def test_python_control_reexports_agent_contract_dataclasses() -> None:
+    AnalystOutput = control_package.AnalystOutput
+    ArchitectOutput = control_package.ArchitectOutput
+    CoachOutput = control_package.CoachOutput
+    CompetitorOutput = control_package.CompetitorOutput
+
+    competitor = CompetitorOutput(
+        raw_text="Use beam search.",
+        strategy={"approach": "beam-search"},
+        reasoning="It keeps more candidate programs alive.",
+        is_code_strategy=True,
+    )
+    analyst = AnalystOutput(
+        raw_markdown="# Findings",
+        findings=["plateau detected"],
+        root_causes=["search space too narrow"],
+        recommendations=["increase branching"],
+    )
+    coach = CoachOutput(
+        raw_markdown="# Coaching",
+        playbook="Try wider exploration.",
+        lessons="Diversity matters.",
+        hints="Look for alternate decompositions.",
+    )
+    architect = ArchitectOutput(
+        raw_markdown="# Architecture",
+        tool_specs=[{"name": "scratchpad"}],
+        harness_specs=[{"id": "h1"}],
+        changelog_entry="Added scratchpad tool.",
+    )
+
+    assert competitor.is_code_strategy is True
+    assert competitor.strategy == {"approach": "beam-search"}
+    assert analyst.findings == ["plateau detected"]
+    assert analyst.root_causes == ["search space too narrow"]
+    assert coach.playbook == "Try wider exploration."
+    assert coach.hints == "Look for alternate decompositions."
+    assert architect.tool_specs == [{"name": "scratchpad"}]
+    assert architect.harness_specs == [{"id": "h1"}]
+    assert architect.changelog_entry == "Added scratchpad tool."
+
+
 def test_python_control_requires_stage_for_scenario_error_messages() -> None:
     ScenarioErrorMsg = control_package.ScenarioErrorMsg
 

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -9,6 +9,7 @@ _production_traces_contract = import_module(
 _research_types = import_module("autocontext.research.types")
 _server_protocol = import_module("autocontext.server.protocol")
 _monitor_types = import_module("autocontext.monitor.types")
+_agent_contracts = import_module("autocontext.agents.contracts")
 
 PROTOCOL_VERSION = _server_protocol.PROTOCOL_VERSION
 ScenarioInfo: Any = _server_protocol.ScenarioInfo
@@ -33,6 +34,10 @@ ScenarioPreviewMsg: Any = _server_protocol.ScenarioPreviewMsg
 ScenarioReadyMsg: Any = _server_protocol.ScenarioReadyMsg
 ScenarioErrorMsg: Any = _server_protocol.ScenarioErrorMsg
 Urgency: Any = _research_types.Urgency
+CompetitorOutput: Any = _agent_contracts.CompetitorOutput
+AnalystOutput: Any = _agent_contracts.AnalystOutput
+CoachOutput: Any = _agent_contracts.CoachOutput
+ArchitectOutput: Any = _agent_contracts.ArchitectOutput
 ResearchQuery: Any = _research_types.ResearchQuery
 Citation: Any = _research_types.Citation
 ResearchResult: Any = _research_types.ResearchResult
@@ -68,9 +73,12 @@ package_role = PACKAGE_ROLE
 package_topology_version = PACKAGE_TOPOLOGY_VERSION
 
 __all__ = [
+    "AnalystOutput",
+    "ArchitectOutput",
     "ChatResponseMsg",
     "Chosen",
     "Citation",
+    "CoachOutput",
     "ConditionType",
     "EndedAt",
     "EnvContext",
@@ -95,6 +103,7 @@ __all__ = [
     "ProductionOutcome",
     "ProductionTrace",
     "Provider",
+    "CompetitorOutput",
     "RunAcceptedMsg",
     "RedactionMarker",
     "ResearchAdapter",


### PR DESCRIPTION
## Summary

- expose the next truthful control-plane facade surface by re-exporting the Python-only agent contract dataclasses through `autocontext_control`
- keep this slice strictly value-model-only: `CompetitorOutput`, `AnalystOutput`, `CoachOutput`, and `ArchitectOutput`
- continue the AC-650 / AC-649 / AC-644 boundary after exhausting the shared Python/TS server-message layer, without inventing fake TypeScript symmetry
- keep PR #820 stable by publishing this as a stacked follow-up slice on top of the monitor-domain value work

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] additional focused RED/GREEN checks described below

Manual verification:
- confirmed RED first with a focused Python control-package test for missing agent contract exports
- confirmed GREEN after the minimal Python control-facade re-exports only
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #820
- Python control facade now also re-exports `CompetitorOutput`, `AnalystOutput`, `CoachOutput`, and `ArchitectOutput`
- `AgentOutputs`, role execution records, and orchestrator/runtime behavior remain intentionally out of scope
- TypeScript is intentionally untouched in this slice because there is no truthful TS counterpart today
- this PR intentionally does **not** export orchestration, persistence behavior, or runtime helpers
- no source-of-truth relocation was performed; the slice remains pure facade boundary work
