### PR TITLE
feat: export stagnation report through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -284,6 +284,20 @@ def test_python_control_reexports_agent_contract_dataclasses() -> None:
     assert architect.changelog_entry == "Added scratchpad tool."
 
 
+def test_python_control_reexports_stagnation_report() -> None:
+    StagnationReport = control_package.StagnationReport
+
+    report = StagnationReport(
+        is_stagnated=True,
+        trigger="score_plateau",
+        detail="score variance 0.000001 < epsilon 0.01 over last 5 gens",
+    )
+
+    assert report.is_stagnated is True
+    assert report.trigger == "score_plateau"
+    assert report.detail == "score variance 0.000001 < epsilon 0.01 over last 5 gens"
+
+
 def test_python_control_requires_stage_for_scenario_error_messages() -> None:
     ScenarioErrorMsg = control_package.ScenarioErrorMsg
 

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -10,6 +10,7 @@ _research_types = import_module("autocontext.research.types")
 _server_protocol = import_module("autocontext.server.protocol")
 _monitor_types = import_module("autocontext.monitor.types")
 _agent_contracts = import_module("autocontext.agents.contracts")
+_stagnation = import_module("autocontext.knowledge.stagnation")
 
 PROTOCOL_VERSION = _server_protocol.PROTOCOL_VERSION
 ScenarioInfo: Any = _server_protocol.ScenarioInfo
@@ -38,6 +39,7 @@ CompetitorOutput: Any = _agent_contracts.CompetitorOutput
 AnalystOutput: Any = _agent_contracts.AnalystOutput
 CoachOutput: Any = _agent_contracts.CoachOutput
 ArchitectOutput: Any = _agent_contracts.ArchitectOutput
+StagnationReport: Any = _stagnation.StagnationReport
 ResearchQuery: Any = _research_types.ResearchQuery
 Citation: Any = _research_types.Citation
 ResearchResult: Any = _research_types.ResearchResult
@@ -119,6 +121,7 @@ __all__ = [
     "ScoringComponent",
     "Sdk",
     "SessionIdentifier",
+    "StagnationReport",
     "StateMsg",
     "StrategyParam",
     "TimingInfo",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -1,6 +1,7 @@
 export const packageRole = "control";
 export const packageTopologyVersion = 1;
 
+export type { StagnationReport } from "../../../../ts/src/loop/stagnation.js";
 export type {
 	AppId,
 	ContentHash,

--- a/packages/ts/control-plane/tsconfig.json
+++ b/packages/ts/control-plane/tsconfig.json
@@ -11,6 +11,7 @@
     "../../../ts/src/production-traces/contract/branded-ids.ts",
     "../../../ts/src/control-plane/contract/branded-ids.ts",
     "../../../ts/src/research/types.ts",
-    "../../../ts/src/server/protocol.ts"
+    "../../../ts/src/server/protocol.ts",
+    "../../../ts/src/loop/stagnation.ts"
   ]
 }

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -10,6 +10,7 @@ import type {
 	ResearchAdapter,
 	Scenario,
 	SessionIdHash,
+	StagnationReport,
 	TraceSource,
 	UserIdHash,
 } from "../../packages/ts/control-plane/src/index.ts";
@@ -269,6 +270,20 @@ describe("@autocontext/control-plane facade", () => {
 		expect(progress.latestStep).toBe("evaluate candidate");
 		expect(progress.budgetUsed).toBe(1.25);
 		expect(progress.budgetMax).toBe(5);
+	});
+
+	it("re-exports stagnation report types", () => {
+		const report: StagnationReport = {
+			isStagnated: true,
+			trigger: "score_plateau",
+			detail: "score stddev 0.000001 < epsilon 0.01 over last 5 gens",
+		};
+
+		expect(report.isStagnated).toBe(true);
+		expect(report.trigger).toBe("score_plateau");
+		expect(report.detail).toBe(
+			"score stddev 0.000001 < epsilon 0.01 over last 5 gens",
+		);
 	});
 
 	it("re-exports monitor alert messages", () => {


### PR DESCRIPTION
## Summary

- expose the next truthful control-plane facade surface by re-exporting `StagnationReport` through both `autocontext_control` and `@autocontext/control-plane`
- keep this slice strictly contract/value-only: the Python dataclass and TypeScript type, without exporting `StagnationDetector` behavior
- continue the AC-650 / AC-649 / AC-644 boundary with a real cross-language control-domain value surface after the recent language-specific slices
- keep PR #821 stable by publishing this as a stacked follow-up slice on top of the Python-only agent contract work

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] additional focused RED/GREEN checks described below

Manual verification:
- confirmed RED first with a focused Python runtime test and TS type-level test for missing `StagnationReport` exports
- confirmed GREEN after minimal facade exports only
- added the one control-plane package include needed for `ts/src/loop/stagnation.ts`
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #821
- Python control facade now also re-exports `StagnationReport`
- TypeScript control facade now also re-exports `StagnationReport` as a type export
- `StagnationDetector` behavior and `StagnationDetectorOpts` remain intentionally out of scope
- no source-of-truth relocation was performed; the slice remains pure contract/value facade work
