### PR TITLE
feat: export scenario authoring commands through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -317,6 +317,25 @@ def test_python_control_reexports_basic_client_control_commands() -> None:
     assert override_gate.decision == "retry"
 
 
+def test_python_control_reexports_scenario_authoring_commands() -> None:
+    CancelScenarioCmd = control_package.CancelScenarioCmd
+    ConfirmScenarioCmd = control_package.ConfirmScenarioCmd
+    CreateScenarioCmd = control_package.CreateScenarioCmd
+    ReviseScenarioCmd = control_package.ReviseScenarioCmd
+
+    create = CreateScenarioCmd(description="Design a schema repair scenario.")
+    confirm = ConfirmScenarioCmd()
+    revise = ReviseScenarioCmd(feedback="Make the failure mode more concrete.")
+    cancel = CancelScenarioCmd()
+
+    assert create.type == "create_scenario"
+    assert create.description == "Design a schema repair scenario."
+    assert confirm.type == "confirm_scenario"
+    assert revise.type == "revise_scenario"
+    assert revise.feedback == "Make the failure mode more concrete."
+    assert cancel.type == "cancel_scenario"
+
+
 def test_python_control_requires_stage_for_scenario_error_messages() -> None:
     ScenarioErrorMsg = control_package.ScenarioErrorMsg
 

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -38,6 +38,10 @@ PauseCmd: Any = _server_protocol.PauseCmd
 ResumeCmd: Any = _server_protocol.ResumeCmd
 InjectHintCmd: Any = _server_protocol.InjectHintCmd
 OverrideGateCmd: Any = _server_protocol.OverrideGateCmd
+CreateScenarioCmd: Any = _server_protocol.CreateScenarioCmd
+ConfirmScenarioCmd: Any = _server_protocol.ConfirmScenarioCmd
+ReviseScenarioCmd: Any = _server_protocol.ReviseScenarioCmd
+CancelScenarioCmd: Any = _server_protocol.CancelScenarioCmd
 Urgency: Any = _research_types.Urgency
 CompetitorOutput: Any = _agent_contracts.CompetitorOutput
 AnalystOutput: Any = _agent_contracts.AnalystOutput
@@ -84,8 +88,11 @@ __all__ = [
     "ChatResponseMsg",
     "Chosen",
     "Citation",
+    "CancelScenarioCmd",
     "CoachOutput",
     "ConditionType",
+    "ConfirmScenarioCmd",
+    "CreateScenarioCmd",
     "EndedAt",
     "EnvContext",
     "EventMsg",
@@ -118,6 +125,7 @@ __all__ = [
     "ResearchConfig",
     "ResearchQuery",
     "ResearchResult",
+    "ReviseScenarioCmd",
     "ResumeCmd",
     "Routing",
     "ScenarioErrorMsg",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -50,7 +50,10 @@ export {
 export {
 	AckMsgSchema,
 	AuthStatusMsgSchema,
+	CancelScenarioCmdSchema,
 	ChatResponseMsgSchema,
+	ConfirmScenarioCmdSchema,
+	CreateScenarioCmdSchema,
 	EnvironmentsMsgSchema,
 	ErrorMsgSchema,
 	EventMsgSchema,
@@ -64,6 +67,7 @@ export {
 	PauseCmdSchema,
 	PROTOCOL_VERSION,
 	ResumeCmdSchema,
+	ReviseScenarioCmdSchema,
 	RunAcceptedMsgSchema,
 	ScenarioErrorMsgSchema,
 	ScenarioGeneratingMsgSchema,

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -17,8 +17,11 @@ import type {
 import {
 	AckMsgSchema,
 	AuthStatusMsgSchema,
+	CancelScenarioCmdSchema,
 	ChatResponseMsgSchema,
 	Citation,
+	ConfirmScenarioCmdSchema,
+	CreateScenarioCmdSchema,
 	EnvironmentsMsgSchema,
 	ErrorMsgSchema,
 	EventMsgSchema,
@@ -38,6 +41,7 @@ import {
 	ResearchQuery,
 	ResearchResult,
 	ResumeCmdSchema,
+	ReviseScenarioCmdSchema,
 	RunAcceptedMsgSchema,
 	ScenarioErrorMsgSchema,
 	ScenarioGeneratingMsgSchema,
@@ -297,6 +301,33 @@ describe("@autocontext/control-plane facade", () => {
 		expect(injectHint.text).toBe("Try broader search.");
 		expect(overrideGate.decision).toBe("retry");
 		expect(invalidHint.success).toBe(false);
+	});
+
+	it("re-exports scenario authoring commands", () => {
+		const create = CreateScenarioCmdSchema.parse({
+			type: "create_scenario",
+			description: "Design a schema repair scenario.",
+		});
+		const confirm = ConfirmScenarioCmdSchema.parse({
+			type: "confirm_scenario",
+		});
+		const revise = ReviseScenarioCmdSchema.parse({
+			type: "revise_scenario",
+			feedback: "Make the failure mode more concrete.",
+		});
+		const cancel = CancelScenarioCmdSchema.parse({
+			type: "cancel_scenario",
+		});
+		const invalidCreate = CreateScenarioCmdSchema.safeParse({
+			type: "create_scenario",
+			description: "",
+		});
+
+		expect(create.description).toBe("Design a schema repair scenario.");
+		expect(confirm.type).toBe("confirm_scenario");
+		expect(revise.feedback).toBe("Make the failure mode more concrete.");
+		expect(cancel.type).toBe("cancel_scenario");
+		expect(invalidCreate.success).toBe(false);
 	});
 
 	it("re-exports stagnation report types", () => {


### PR DESCRIPTION
## Summary

- export the next truthful shared control-plane protocol slice by re-exporting the scenario authoring client→server commands through both control facades
- expose `CreateScenarioCmd`, `ConfirmScenarioCmd`, `ReviseScenarioCmd`, and `CancelScenarioCmd` from `autocontext_control`
- expose `CreateScenarioCmdSchema`, `ConfirmScenarioCmdSchema`, `ReviseScenarioCmdSchema`, and `CancelScenarioCmdSchema` from `@autocontext/control-plane`
- keep the slice strictly contract-only: no parsers, no unions, no auth commands, no run-start commands, and no runtime/server behavior
- publish this as a stacked follow-up on top of PR #823 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a Python runtime test failing on missing `CancelScenarioCmd` and a TS type-check failing on missing scenario authoring command schema exports
- proved GREEN after adding only the minimal facade exports
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #823
- scope is intentionally limited to the scenario authoring workflow family already modeled in the shared protocol source of truth
- left out `ClientMessageSchema`, `parseClientMessage`, auth commands, run-start/list-scenarios commands, and runtime/server behavior to preserve a narrow boundary proof
- no source-of-truth relocation was performed
