### PR TITLE
feat: export run setup commands through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -336,6 +336,19 @@ def test_python_control_reexports_scenario_authoring_commands() -> None:
     assert cancel.type == "cancel_scenario"
 
 
+def test_python_control_reexports_run_setup_commands() -> None:
+    ListScenariosCmd = control_package.ListScenariosCmd
+    StartRunCmd = control_package.StartRunCmd
+
+    list_scenarios = ListScenariosCmd()
+    start_run = StartRunCmd(scenario="schema_repair", generations=3)
+
+    assert list_scenarios.type == "list_scenarios"
+    assert start_run.type == "start_run"
+    assert start_run.scenario == "schema_repair"
+    assert start_run.generations == 3
+
+
 def test_python_control_requires_stage_for_scenario_error_messages() -> None:
     ScenarioErrorMsg = control_package.ScenarioErrorMsg
 

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -42,6 +42,8 @@ CreateScenarioCmd: Any = _server_protocol.CreateScenarioCmd
 ConfirmScenarioCmd: Any = _server_protocol.ConfirmScenarioCmd
 ReviseScenarioCmd: Any = _server_protocol.ReviseScenarioCmd
 CancelScenarioCmd: Any = _server_protocol.CancelScenarioCmd
+StartRunCmd: Any = _server_protocol.StartRunCmd
+ListScenariosCmd: Any = _server_protocol.ListScenariosCmd
 Urgency: Any = _research_types.Urgency
 CompetitorOutput: Any = _agent_contracts.CompetitorOutput
 AnalystOutput: Any = _agent_contracts.AnalystOutput
@@ -110,6 +112,7 @@ __all__ = [
     "ExecutorResources",
     "HelloMsg",
     "InjectHintCmd",
+    "ListScenariosCmd",
     "Message",
     "PACKAGE_ROLE",
     "PACKAGE_TOPOLOGY_VERSION",
@@ -133,6 +136,7 @@ __all__ = [
     "ScenarioInfo",
     "ScenarioPreviewMsg",
     "ScenarioReadyMsg",
+    "StartRunCmd",
     "OverrideGateCmd",
     "ScoringComponent",
     "Sdk",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -61,6 +61,7 @@ export {
 	ExecutorResourcesSchema,
 	HelloMsgSchema,
 	InjectHintCmdSchema,
+	ListScenariosCmdSchema,
 	MissionProgressMsgSchema,
 	MonitorAlertMsgSchema,
 	OverrideGateCmdSchema,
@@ -75,6 +76,7 @@ export {
 	ScenarioPreviewMsgSchema,
 	ScenarioReadyMsgSchema,
 	ScoringComponentSchema,
+	StartRunCmdSchema,
 	StateMsgSchema,
 	StrategyParamSchema,
 } from "../../../../ts/src/server/protocol.js";

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -29,6 +29,7 @@ import {
 	ExecutorResourcesSchema,
 	HelloMsgSchema,
 	InjectHintCmdSchema,
+	ListScenariosCmdSchema,
 	MissionProgressMsgSchema,
 	MonitorAlertMsgSchema,
 	OverrideGateCmdSchema,
@@ -49,6 +50,7 @@ import {
 	ScenarioPreviewMsgSchema,
 	ScenarioReadyMsgSchema,
 	ScoringComponentSchema,
+	StartRunCmdSchema,
 	StateMsgSchema,
 	StrategyParamSchema,
 	Urgency,
@@ -301,6 +303,27 @@ describe("@autocontext/control-plane facade", () => {
 		expect(injectHint.text).toBe("Try broader search.");
 		expect(overrideGate.decision).toBe("retry");
 		expect(invalidHint.success).toBe(false);
+	});
+
+	it("re-exports run setup commands", () => {
+		const listScenarios = ListScenariosCmdSchema.parse({
+			type: "list_scenarios",
+		});
+		const startRun = StartRunCmdSchema.parse({
+			type: "start_run",
+			scenario: "schema_repair",
+			generations: 3,
+		});
+		const invalidStartRun = StartRunCmdSchema.safeParse({
+			type: "start_run",
+			scenario: "schema_repair",
+			generations: 0,
+		});
+
+		expect(listScenarios.type).toBe("list_scenarios");
+		expect(startRun.scenario).toBe("schema_repair");
+		expect(startRun.generations).toBe(3);
+		expect(invalidStartRun.success).toBe(false);
 	});
 
 	it("re-exports scenario authoring commands", () => {


### PR DESCRIPTION
## Summary

- export the next truthful shared control-plane protocol slice by re-exporting the run setup client→server commands through both control facades
- expose `ListScenariosCmd` and `StartRunCmd` from `autocontext_control`
- expose `ListScenariosCmdSchema` and `StartRunCmdSchema` from `@autocontext/control-plane`
- keep the slice strictly contract-only: no parsers, no unions, no chat/auth commands, and no runtime/server behavior
- publish this as a stacked follow-up on top of PR #824 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a Python runtime test failing on missing `ListScenariosCmd` and a TS type-check failing on missing run setup schema exports
- proved GREEN after adding only the minimal facade exports
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #824
- scope is intentionally limited to the run setup workflow family already modeled in the shared protocol source of truth
- left out `ClientMessageSchema`, `parseClientMessage`, chat commands, auth commands, and runtime/server behavior to preserve a narrow boundary proof
- no source-of-truth relocation was performed
