### PR TITLE
feat: align and export chat agent command

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -349,6 +349,23 @@ def test_python_control_reexports_run_setup_commands() -> None:
     assert start_run.generations == 3
 
 
+def test_python_control_reexports_chat_agent_command() -> None:
+    ChatAgentCmd = control_package.ChatAgentCmd
+
+    chat = ChatAgentCmd(role="coach", message="Try broader search.")
+
+    assert chat.type == "chat_agent"
+    assert chat.role == "coach"
+    assert chat.message == "Try broader search."
+
+    try:
+        ChatAgentCmd(role="coach", message="")
+    except ValidationError:
+        pass
+    else:
+        raise AssertionError("ChatAgentCmd should require non-empty message")
+
+
 def test_python_control_requires_stage_for_scenario_error_messages() -> None:
     ScenarioErrorMsg = control_package.ScenarioErrorMsg
 

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -38,6 +38,7 @@ PauseCmd: Any = _server_protocol.PauseCmd
 ResumeCmd: Any = _server_protocol.ResumeCmd
 InjectHintCmd: Any = _server_protocol.InjectHintCmd
 OverrideGateCmd: Any = _server_protocol.OverrideGateCmd
+ChatAgentCmd: Any = _server_protocol.ChatAgentCmd
 CreateScenarioCmd: Any = _server_protocol.CreateScenarioCmd
 ConfirmScenarioCmd: Any = _server_protocol.ConfirmScenarioCmd
 ReviseScenarioCmd: Any = _server_protocol.ReviseScenarioCmd
@@ -91,6 +92,7 @@ __all__ = [
     "Chosen",
     "Citation",
     "CancelScenarioCmd",
+    "ChatAgentCmd",
     "CoachOutput",
     "ConditionType",
     "ConfirmScenarioCmd",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -51,6 +51,7 @@ export {
 	AckMsgSchema,
 	AuthStatusMsgSchema,
 	CancelScenarioCmdSchema,
+	ChatAgentCmdSchema,
 	ChatResponseMsgSchema,
 	ConfirmScenarioCmdSchema,
 	CreateScenarioCmdSchema,

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -18,6 +18,7 @@ import {
 	AckMsgSchema,
 	AuthStatusMsgSchema,
 	CancelScenarioCmdSchema,
+	ChatAgentCmdSchema,
 	ChatResponseMsgSchema,
 	Citation,
 	ConfirmScenarioCmdSchema,
@@ -303,6 +304,23 @@ describe("@autocontext/control-plane facade", () => {
 		expect(injectHint.text).toBe("Try broader search.");
 		expect(overrideGate.decision).toBe("retry");
 		expect(invalidHint.success).toBe(false);
+	});
+
+	it("re-exports chat agent command", () => {
+		const chatAgent = ChatAgentCmdSchema.parse({
+			type: "chat_agent",
+			role: "coach",
+			message: "Try broader search.",
+		});
+		const invalidChatAgent = ChatAgentCmdSchema.safeParse({
+			type: "chat_agent",
+			role: "coach",
+			message: "",
+		});
+
+		expect(chatAgent.role).toBe("coach");
+		expect(chatAgent.message).toBe("Try broader search.");
+		expect(invalidChatAgent.success).toBe(false);
 	});
 
 	it("re-exports run setup commands", () => {


### PR DESCRIPTION
## Summary

- align the shared `ChatAgentCmd` contract and export it through both control facades
- expose `ChatAgentCmd` from `autocontext_control`
- expose `ChatAgentCmdSchema` from `@autocontext/control-plane`
- tighten `ts/src/server/protocol.ts` so `ChatAgentCmdSchema.message` requires a non-empty string, matching Python's `Field(min_length=1)`
- keep the slice strictly contract-only: no parsers, no unions, no auth commands, and no runtime/server behavior
- publish this as a stacked follow-up on top of PR #825 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a Python runtime test failing on missing `ChatAgentCmd` and a TS type-check failing on missing `ChatAgentCmdSchema`
- used the TS control-package test to also prove the empty-message drift, forcing the source-of-truth alignment before export
- proved GREEN after adding only the minimal facade exports plus the one-line TS schema alignment
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #825
- scope is intentionally limited to the standalone `ChatAgentCmd` protocol contract already present in the shared protocol source of truth
- left out `ClientMessageSchema`, `parseClientMessage`, auth commands, and runtime/server behavior to preserve a narrow boundary proof
- no source-of-truth relocation was performed
