### PR TITLE
feat: export auth commands through control facades

### DIFF
--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -63,6 +63,8 @@ export {
 	HelloMsgSchema,
 	InjectHintCmdSchema,
 	ListScenariosCmdSchema,
+	LoginCmdSchema,
+	LogoutCmdSchema,
 	MissionProgressMsgSchema,
 	MonitorAlertMsgSchema,
 	OverrideGateCmdSchema,
@@ -80,4 +82,6 @@ export {
 	StartRunCmdSchema,
 	StateMsgSchema,
 	StrategyParamSchema,
+	SwitchProviderCmdSchema,
+	WhoamiCmdSchema,
 } from "../../../../ts/src/server/protocol.js";

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -31,6 +31,8 @@ import {
 	HelloMsgSchema,
 	InjectHintCmdSchema,
 	ListScenariosCmdSchema,
+	LoginCmdSchema,
+	LogoutCmdSchema,
 	MissionProgressMsgSchema,
 	MonitorAlertMsgSchema,
 	OverrideGateCmdSchema,
@@ -54,7 +56,9 @@ import {
 	StartRunCmdSchema,
 	StateMsgSchema,
 	StrategyParamSchema,
+	SwitchProviderCmdSchema,
 	Urgency,
+	WhoamiCmdSchema,
 } from "../../packages/ts/control-plane/src/index.ts";
 
 describe("@autocontext/control-plane facade", () => {
@@ -304,6 +308,41 @@ describe("@autocontext/control-plane facade", () => {
 		expect(injectHint.text).toBe("Try broader search.");
 		expect(overrideGate.decision).toBe("retry");
 		expect(invalidHint.success).toBe(false);
+	});
+
+	it("re-exports auth commands", () => {
+		const login = LoginCmdSchema.parse({
+			type: "login",
+			provider: "anthropic",
+			apiKey: "test-key",
+			model: "claude-sonnet",
+			baseUrl: "https://api.anthropic.com",
+		});
+		const logout = LogoutCmdSchema.parse({
+			type: "logout",
+			provider: "anthropic",
+		});
+		const switchProvider = SwitchProviderCmdSchema.parse({
+			type: "switch_provider",
+			provider: "openai",
+		});
+		const whoami = WhoamiCmdSchema.parse({ type: "whoami" });
+		const invalidLogin = LoginCmdSchema.safeParse({
+			type: "login",
+			provider: "",
+		});
+		const invalidSwitch = SwitchProviderCmdSchema.safeParse({
+			type: "switch_provider",
+			provider: "",
+		});
+
+		expect(login.provider).toBe("anthropic");
+		expect(login.model).toBe("claude-sonnet");
+		expect(logout.provider).toBe("anthropic");
+		expect(switchProvider.provider).toBe("openai");
+		expect(whoami.type).toBe("whoami");
+		expect(invalidLogin.success).toBe(false);
+		expect(invalidSwitch.success).toBe(false);
 	});
 
 	it("re-exports chat agent command", () => {


### PR DESCRIPTION
## Summary

- export the next truthful language-specific control-plane protocol slice by re-exporting the TypeScript-only auth client→server command schemas through `@autocontext/control-plane`
- expose `LoginCmdSchema`, `LogoutCmdSchema`, `SwitchProviderCmdSchema`, and `WhoamiCmdSchema`
- keep Python intentionally untouched because there is no truthful Python source-of-truth counterpart for these auth commands
- keep the slice strictly contract-only: no parsers, no unions, no auth-status message changes, and no runtime/server behavior
- publish this as a stacked follow-up on top of PR #826 so the existing branch stays stable

## Surfaces Touched

- [ ] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a focused TS type-check failing on missing auth command schema exports
- proved GREEN after adding only the minimal control-facade re-exports and dedicated test coverage
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #826
- scope is intentionally limited to the auth command workflow family already modeled in the TypeScript protocol source of truth
- left out `ClientMessageSchema`, `parseClientMessage`, `AuthStatusMsgSchema`, and runtime/server behavior to preserve a narrow boundary proof
- Python is intentionally unchanged because exporting fake symmetry would be dishonest here
