### PR TITLE
feat: export research brief through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -71,6 +71,48 @@ def test_python_control_reexports_research_domain_contracts() -> None:
     assert config.max_queries_per_turn == 1
 
 
+def test_python_control_reexports_research_brief() -> None:
+    Citation = control_package.Citation
+    ResearchBrief = control_package.ResearchBrief
+    ResearchResult = control_package.ResearchResult
+
+    citation = Citation(
+        source="policy handbook",
+        url="https://example.com/policy",
+        relevance=0.95,
+        snippet="Refunds require manager sign-off after 30 days.",
+        retrieved_at="2026-04-25T00:00:00Z",
+    )
+    strong_result = ResearchResult(
+        query_topic="refund policy",
+        summary="Manager sign-off required after 30 days.",
+        citations=[citation],
+        confidence=0.91,
+        metadata={"adapter": "demo"},
+    )
+    weak_result = ResearchResult(
+        query_topic="escalation policy",
+        summary="Escalate unusual refund cases.",
+        citations=[citation],
+        confidence=0.42,
+        metadata={"adapter": "demo"},
+    )
+
+    brief = ResearchBrief.from_results(
+        goal="Summarize refund policy changes",
+        results=[strong_result, weak_result],
+        min_confidence=0.9,
+    )
+
+    assert brief.goal == "Summarize refund policy changes"
+    assert len(brief.findings) == 1
+    assert brief.findings[0].query_topic == "refund policy"
+    assert len(brief.unique_citations) == 1
+    assert brief.unique_citations[0].source == "policy handbook"
+    assert brief.avg_confidence == 0.91
+    assert "Research Brief: Summarize refund policy changes" in brief.to_markdown()
+
+
 def test_python_control_reexports_shared_server_protocol_models() -> None:
     ExecutorInfo = control_package.ExecutorInfo
     ExecutorResources = control_package.ExecutorResources

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -7,6 +7,7 @@ _production_traces_contract = import_module(
     "autocontext.production_traces.contract.models"
 )
 _research_types = import_module("autocontext.research.types")
+_research_consultation = import_module("autocontext.research.consultation")
 _server_protocol = import_module("autocontext.server.protocol")
 _monitor_types = import_module("autocontext.monitor.types")
 _agent_contracts = import_module("autocontext.agents.contracts")
@@ -56,6 +57,7 @@ Citation: Any = _research_types.Citation
 ResearchResult: Any = _research_types.ResearchResult
 ResearchAdapter: Any = _research_types.ResearchAdapter
 ResearchConfig: Any = _research_types.ResearchConfig
+ResearchBrief: Any = _research_consultation.ResearchBrief
 Sdk: Any = _production_traces_contract.Sdk
 TraceSource: Any = _production_traces_contract.TraceSource
 Provider: Any = _production_traces_contract.Provider
@@ -127,6 +129,7 @@ __all__ = [
     "RunAcceptedMsg",
     "RedactionMarker",
     "ResearchAdapter",
+    "ResearchBrief",
     "ResearchConfig",
     "ResearchQuery",
     "ResearchResult",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -39,6 +39,7 @@ export type {
 	ValidationResult,
 } from "../../../../ts/src/production-traces/contract/types.js";
 export { PRODUCTION_TRACE_SCHEMA_VERSION } from "../../../../ts/src/production-traces/contract/types.js";
+export { ResearchBrief } from "../../../../ts/src/research/consultation.js";
 export type { ResearchAdapter } from "../../../../ts/src/research/types.js";
 export {
 	Citation,

--- a/packages/ts/control-plane/tsconfig.json
+++ b/packages/ts/control-plane/tsconfig.json
@@ -1,17 +1,20 @@
 {
-  "extends": "../../../ts/tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../../..",
-    "outDir": "./dist",
-    "noEmit": false
-  },
-  "include": [
-    "src/**/*.ts",
-    "../../../ts/src/production-traces/contract/types.ts",
-    "../../../ts/src/production-traces/contract/branded-ids.ts",
-    "../../../ts/src/control-plane/contract/branded-ids.ts",
-    "../../../ts/src/research/types.ts",
-    "../../../ts/src/server/protocol.ts",
-    "../../../ts/src/loop/stagnation.ts"
-  ]
+	"extends": "../../../ts/tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "../../..",
+		"outDir": "./dist",
+		"noEmit": false,
+		"types": ["node"],
+		"typeRoots": ["../../../ts/node_modules/@types"]
+	},
+	"include": [
+		"src/**/*.ts",
+		"../../../ts/src/production-traces/contract/types.ts",
+		"../../../ts/src/production-traces/contract/branded-ids.ts",
+		"../../../ts/src/control-plane/contract/branded-ids.ts",
+		"../../../ts/src/research/types.ts",
+		"../../../ts/src/research/consultation.ts",
+		"../../../ts/src/server/protocol.ts",
+		"../../../ts/src/loop/stagnation.ts"
+	]
 }

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -41,6 +41,7 @@ import {
 	PROTOCOL_VERSION,
 	packageRole,
 	packageTopologyVersion,
+	ResearchBrief,
 	ResearchConfig,
 	ResearchQuery,
 	ResearchResult,
@@ -111,6 +112,45 @@ describe("@autocontext/control-plane facade", () => {
 		expect(config.enabled).toBe(true);
 		expect(config.adapterName).toBe("demo");
 		expect(config.maxQueriesPerTurn).toBe(1);
+	});
+
+	it("re-exports research brief values", () => {
+		const citation = new Citation({
+			source: "policy handbook",
+			url: "https://example.com/policy",
+			relevance: 0.95,
+			snippet: "Refunds require manager sign-off after 30 days.",
+			retrievedAt: "2026-04-25T00:00:00Z",
+		});
+		const strongResult = new ResearchResult({
+			queryTopic: "refund policy",
+			summary: "Manager sign-off required after 30 days.",
+			citations: [citation],
+			confidence: 0.91,
+			metadata: { adapter: "demo" },
+		});
+		const weakResult = new ResearchResult({
+			queryTopic: "escalation policy",
+			summary: "Escalate unusual refund cases.",
+			citations: [citation],
+			confidence: 0.42,
+			metadata: { adapter: "demo" },
+		});
+		const brief = ResearchBrief.fromResults(
+			"Summarize refund policy changes",
+			[strongResult, weakResult],
+			0.9,
+		);
+
+		expect(brief.goal).toBe("Summarize refund policy changes");
+		expect(brief.findings).toHaveLength(1);
+		expect(brief.findings[0]?.queryTopic).toBe("refund policy");
+		expect(brief.uniqueCitations).toHaveLength(1);
+		expect(brief.uniqueCitations[0]?.source).toBe("policy handbook");
+		expect(brief.avgConfidence).toBe(0.91);
+		expect(brief.toMarkdown()).toContain(
+			"Research Brief: Summarize refund policy changes",
+		);
 	});
 
 	it("re-exports shared server protocol models", () => {


### PR DESCRIPTION
## Summary

- export the next truthful cross-language control-plane value slice by re-exporting `ResearchBrief` through both control facades
- expose `ResearchBrief` from `autocontext_control`
- expose `ResearchBrief` from `@autocontext/control-plane`
- keep the slice focused on the brief value object only; do not export `ResearchConsultant` behavior
- add the one transitional TS control-package config change needed to type-check `ts/src/research/consultation.ts` and its transitive Node runtime import
- publish this as a stacked follow-up on top of PR #827 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a Python runtime test failing on missing `ResearchBrief` and a TS type-check failing on missing export
- proved GREEN after adding only the minimal facade exports plus the TS control-package include and type-root config needed for the consultation module
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #827
- scope is intentionally limited to the `ResearchBrief` value object already modeled on both sides
- `ResearchConsultant` and session/runtime orchestration remain intentionally out of scope
- no source-of-truth relocation was performed
