### PR TITLE
feat: export generation kickoff payloads through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -113,6 +113,24 @@ def test_python_control_reexports_research_brief() -> None:
     assert "Research Brief: Summarize refund policy changes" in brief.to_markdown()
 
 
+def test_python_control_reexports_generation_kickoff_payloads() -> None:
+    AgentsStartedPayload = control_package.AgentsStartedPayload
+    GenerationStartedPayload = control_package.GenerationStartedPayload
+
+    generation_started = GenerationStartedPayload(run_id="run-123", generation=2)
+    agents_started = AgentsStartedPayload(
+        run_id="run-123",
+        generation=2,
+        roles=["competitor", "analyst", "coach", "curator"],
+    )
+
+    assert generation_started.run_id == "run-123"
+    assert generation_started.generation == 2
+    assert agents_started.run_id == "run-123"
+    assert agents_started.generation == 2
+    assert agents_started.roles == ["competitor", "analyst", "coach", "curator"]
+
+
 def test_python_control_reexports_shared_server_protocol_models() -> None:
     ExecutorInfo = control_package.ExecutorInfo
     ExecutorResources = control_package.ExecutorResources

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -35,6 +35,8 @@ ScenarioGeneratingMsg: Any = _server_protocol.ScenarioGeneratingMsg
 ScenarioPreviewMsg: Any = _server_protocol.ScenarioPreviewMsg
 ScenarioReadyMsg: Any = _server_protocol.ScenarioReadyMsg
 ScenarioErrorMsg: Any = _server_protocol.ScenarioErrorMsg
+GenerationStartedPayload: Any = _server_protocol.GenerationStartedPayload
+AgentsStartedPayload: Any = _server_protocol.AgentsStartedPayload
 PauseCmd: Any = _server_protocol.PauseCmd
 ResumeCmd: Any = _server_protocol.ResumeCmd
 InjectHintCmd: Any = _server_protocol.InjectHintCmd
@@ -104,8 +106,10 @@ __all__ = [
     "EventMsg",
     "EnvironmentsMsg",
     "AckMsg",
+    "AgentsStartedPayload",
     "Error",
     "ErrorMsg",
+    "GenerationStartedPayload",
     "MonitorAlert",
     "MonitorAlertMsg",
     "MonitorCondition",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -1,6 +1,10 @@
 export const packageRole = "control";
 export const packageTopologyVersion = 1;
 
+export type {
+	AgentsStartedPayload,
+	GenerationStartedPayload,
+} from "../../../../ts/src/loop/generation-event-coordinator.js";
 export type { StagnationReport } from "../../../../ts/src/loop/stagnation.js";
 export type {
 	AppId,

--- a/packages/ts/control-plane/tsconfig.json
+++ b/packages/ts/control-plane/tsconfig.json
@@ -15,6 +15,7 @@
 		"../../../ts/src/research/types.ts",
 		"../../../ts/src/research/consultation.ts",
 		"../../../ts/src/server/protocol.ts",
+		"../../../ts/src/loop/generation-event-coordinator.ts",
 		"../../../ts/src/loop/stagnation.ts"
 	]
 }

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type {
+	AgentsStartedPayload,
 	AppId,
 	EnvironmentTag,
 	FeedbackRef,
 	FeedbackRefId,
+	GenerationStartedPayload,
 	ProductionTrace,
 	ProductionTraceId,
 	ProviderInfo,
@@ -151,6 +153,27 @@ describe("@autocontext/control-plane facade", () => {
 		expect(brief.toMarkdown()).toContain(
 			"Research Brief: Summarize refund policy changes",
 		);
+	});
+
+	it("re-exports generation kickoff payload types", () => {
+		const generationStarted: GenerationStartedPayload = {
+			run_id: "run-123",
+			generation: 2,
+		};
+		const agentsStarted: AgentsStartedPayload = {
+			run_id: "run-123",
+			generation: 2,
+			roles: ["competitor", "analyst", "coach", "curator"],
+		};
+
+		expect(generationStarted.run_id).toBe("run-123");
+		expect(generationStarted.generation).toBe(2);
+		expect(agentsStarted.roles).toEqual([
+			"competitor",
+			"analyst",
+			"coach",
+			"curator",
+		]);
 	});
 
 	it("re-exports shared server protocol models", () => {


### PR DESCRIPTION
## Summary

- export the next truthful cross-language control-plane value slice by re-exporting the generation kickoff payloads through both control facades
- expose `GenerationStartedPayload` and `AgentsStartedPayload` from `autocontext_control`
- expose `GenerationStartedPayload` and `AgentsStartedPayload` as type exports from `@autocontext/control-plane`
- add the one TS control-package include needed for `ts/src/loop/generation-event-coordinator.ts`
- keep the slice strictly on the kickoff payload subset and avoid the drifted run/completion payloads
- publish this as a stacked follow-up on top of PR #828 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a Python runtime test failing on missing kickoff payload exports and a TS type-check failing on missing type exports
- proved GREEN after adding only the minimal facade exports plus the single TS control-package include for `generation-event-coordinator.ts`
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #828
- scope is intentionally limited to the kickoff payload subset that is already modeled compatibly on both sides
- drifted `RunStartedPayload`, `GateDecidedPayload`, `GenerationCompletedPayload`, and `RunCompletedPayload` remain intentionally out of scope
- no source-of-truth relocation was performed
