### PR TITLE
feat: align and export role completed payload

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -131,6 +131,24 @@ def test_python_control_reexports_generation_kickoff_payloads() -> None:
     assert agents_started.roles == ["competitor", "analyst", "coach", "curator"]
 
 
+def test_python_control_reexports_role_completed_payload() -> None:
+    RoleCompletedPayload = control_package.RoleCompletedPayload
+
+    payload = RoleCompletedPayload(
+        run_id="run-123",
+        generation=2,
+        role="coach",
+        latency_ms=125,
+        tokens=42,
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.generation == 2
+    assert payload.role == "coach"
+    assert payload.latency_ms == 125
+    assert payload.tokens == 42
+
+
 def test_python_control_reexports_shared_server_protocol_models() -> None:
     ExecutorInfo = control_package.ExecutorInfo
     ExecutorResources = control_package.ExecutorResources

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -37,6 +37,7 @@ ScenarioReadyMsg: Any = _server_protocol.ScenarioReadyMsg
 ScenarioErrorMsg: Any = _server_protocol.ScenarioErrorMsg
 GenerationStartedPayload: Any = _server_protocol.GenerationStartedPayload
 AgentsStartedPayload: Any = _server_protocol.AgentsStartedPayload
+RoleCompletedPayload: Any = _server_protocol.RoleCompletedPayload
 PauseCmd: Any = _server_protocol.PauseCmd
 ResumeCmd: Any = _server_protocol.ResumeCmd
 InjectHintCmd: Any = _server_protocol.InjectHintCmd
@@ -138,6 +139,7 @@ __all__ = [
     "ResearchQuery",
     "ResearchResult",
     "ReviseScenarioCmd",
+    "RoleCompletedPayload",
     "ResumeCmd",
     "Routing",
     "ScenarioErrorMsg",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -5,6 +5,7 @@ export type {
 	AgentsStartedPayload,
 	GenerationStartedPayload,
 } from "../../../../ts/src/loop/generation-event-coordinator.js";
+export type { RoleCompletedPayload } from "../../../../ts/src/loop/generation-side-effect-coordinator.js";
 export type { StagnationReport } from "../../../../ts/src/loop/stagnation.js";
 export type {
 	AppId,

--- a/packages/ts/control-plane/tsconfig.json
+++ b/packages/ts/control-plane/tsconfig.json
@@ -16,6 +16,7 @@
 		"../../../ts/src/research/consultation.ts",
 		"../../../ts/src/server/protocol.ts",
 		"../../../ts/src/loop/generation-event-coordinator.ts",
+		"../../../ts/src/loop/generation-side-effect-coordinator.ts",
 		"../../../ts/src/loop/stagnation.ts"
 	]
 }

--- a/ts/src/loop/generation-attempt-workflow.ts
+++ b/ts/src/loop/generation-attempt-workflow.ts
@@ -62,6 +62,8 @@ export async function runGenerationAttemptWorkflow(
   );
 
   const competitorCompletion = await executeRoleCompletionSideEffect({
+    runId: workflow.runId,
+    generation: workflow.generation,
     role: "competitor",
     execute: workflow.executeCompetitor,
   });

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -418,8 +418,8 @@ export class GenerationRunner {
       this.completeRole("analyst", this.buildSupportPrompt("analyst", runId, attempt)),
       this.completeRole("coach", this.buildSupportPrompt("coach", runId, attempt)),
     ]);
-    this.emitRoleCompleted("analyst", analystStartedAt, analystResult.usage);
-    this.emitRoleCompleted("coach", coachStartedAt, coachResult.usage);
+    this.emitRoleCompleted(runId, gen, "analyst", analystStartedAt, analystResult.usage);
+    this.emitRoleCompleted(runId, gen, "coach", coachStartedAt, coachResult.usage);
 
     this.#store.appendAgentOutput(runId, gen, "analyst", analystResult.text);
     this.#store.appendAgentOutput(runId, gen, "coach", coachResult.text);
@@ -462,7 +462,7 @@ export class GenerationRunner {
         "curator",
         this.buildCuratorPrompt(runId, normalizedPlaybook, nextPlaybook, attempt),
       );
-      this.emitRoleCompleted("curator", curatorStartedAt, curatorResult.usage);
+      this.emitRoleCompleted(runId, gen, "curator", curatorStartedAt, curatorResult.usage);
       this.#store.appendAgentOutput(runId, gen, "curator", curatorResult.text);
       this.#artifactStore.writeMarkdown(join(generationDir, "curator.md"), curatorResult.text);
       this.#artifactStore.appendMarkdown(
@@ -608,13 +608,21 @@ export class GenerationRunner {
   }
 
   private emitRoleCompleted(
+    runId: string,
+    generation: number,
     role: "competitor" | "analyst" | "coach" | "curator",
     startedAt: number,
     usage: Record<string, number>,
   ): void {
     this.emit(
       "role_completed",
-      buildRoleCompletedPayload(role, Date.now() - startedAt, usage),
+      buildRoleCompletedPayload(
+        runId,
+        generation,
+        role,
+        Date.now() - startedAt,
+        usage,
+      ),
     );
   }
 }

--- a/ts/src/loop/generation-side-effect-coordinator.ts
+++ b/ts/src/loop/generation-side-effect-coordinator.ts
@@ -4,6 +4,8 @@ import type { GenerationRole } from "../providers/index.js";
 
 export interface RoleCompletedPayload {
   [key: string]: unknown;
+  run_id: string;
+  generation: number;
   role: "competitor" | "analyst" | "coach" | "curator";
   latency_ms: number;
   tokens: number;
@@ -17,6 +19,8 @@ import {
 export type { GenerationLoopEventSequenceItem };
 
 export function buildRoleCompletedPayload(
+  runId: string,
+  generation: number,
   role: "competitor" | "analyst" | "coach" | "curator",
   latencyMs: number,
   usage: Record<string, number>,
@@ -25,6 +29,8 @@ export function buildRoleCompletedPayload(
   const outputTokens = usage.output_tokens ?? usage.outputTokens ?? 0;
 
   return {
+    run_id: runId,
+    generation,
     role,
     latency_ms: latencyMs,
     tokens: inputTokens + outputTokens,
@@ -32,6 +38,8 @@ export function buildRoleCompletedPayload(
 }
 
 export async function executeRoleCompletionSideEffect(opts: {
+  runId: string;
+  generation: number;
   role: "competitor" | "analyst" | "coach" | "curator";
   execute: () => Promise<CompletionResult>;
   now?: () => number;
@@ -47,6 +55,8 @@ export async function executeRoleCompletionSideEffect(opts: {
   return {
     result,
     roleCompletedPayload: buildRoleCompletedPayload(
+      opts.runId,
+      opts.generation,
       opts.role,
       finishedAt - startedAt,
       result.usage,

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -10,6 +10,7 @@ import type {
 	ProductionTraceId,
 	ProviderInfo,
 	ResearchAdapter,
+	RoleCompletedPayload,
 	Scenario,
 	SessionIdHash,
 	StagnationReport,
@@ -153,6 +154,22 @@ describe("@autocontext/control-plane facade", () => {
 		expect(brief.toMarkdown()).toContain(
 			"Research Brief: Summarize refund policy changes",
 		);
+	});
+
+	it("re-exports role completed payload types", () => {
+		const payload: RoleCompletedPayload = {
+			run_id: "run-123",
+			generation: 2,
+			role: "coach",
+			latency_ms: 125,
+			tokens: 42,
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.generation).toBe(2);
+		expect(payload.role).toBe("coach");
+		expect(payload.latency_ms).toBe(125);
+		expect(payload.tokens).toBe(42);
 	});
 
 	it("re-exports generation kickoff payload types", () => {

--- a/ts/tests/generation-side-effect-coordinator.test.ts
+++ b/ts/tests/generation-side-effect-coordinator.test.ts
@@ -12,11 +12,13 @@ import type { TournamentExecutionPlan } from "../src/loop/generation-execution-s
 describe("generation side-effect coordinator", () => {
   it("builds role completion payloads from mixed usage token formats", () => {
     expect(
-      buildRoleCompletedPayload("competitor", 125, {
+      buildRoleCompletedPayload("run-1", 2, "competitor", 125, {
         input_tokens: 2,
         outputTokens: 5,
       }),
     ).toEqual({
+      run_id: "run-1",
+      generation: 2,
       role: "competitor",
       latency_ms: 125,
       tokens: 7,
@@ -27,6 +29,8 @@ describe("generation side-effect coordinator", () => {
     const marks = [1000, 1145];
 
     const completed = await executeRoleCompletionSideEffect({
+      runId: "run-1",
+      generation: 2,
       role: "competitor",
       execute: async () => ({
         text: '{"aggression":0.7}',
@@ -38,6 +42,8 @@ describe("generation side-effect coordinator", () => {
 
     expect(completed.result.text).toBe('{"aggression":0.7}');
     expect(completed.roleCompletedPayload).toEqual({
+      run_id: "run-1",
+      generation: 2,
       role: "competitor",
       latency_ms: 145,
       tokens: 7,

--- a/ts/tests/typed-serialization.test.ts
+++ b/ts/tests/typed-serialization.test.ts
@@ -69,7 +69,7 @@ describe("typed serialization contracts", () => {
       targetGenerations: 3,
     });
     const gateDecided = buildGateDecidedPayload("run-1", 2, "advance", 0.1, 0.05);
-    const roleCompleted = buildRoleCompletedPayload("competitor", 125, {
+    const roleCompleted = buildRoleCompletedPayload("run-1", 2, "competitor", 125, {
       input_tokens: 2,
       outputTokens: 5,
     });
@@ -81,6 +81,8 @@ describe("typed serialization contracts", () => {
     expect(runStarted.target_generations).toBe(3);
     expect(gateDecided.decision).toBe("advance");
     expect(roleCompleted.tokens).toBe(7);
+    expect(roleCompleted.run_id).toBe("run-1");
+    expect(roleCompleted.generation).toBe(2);
   });
 
   it("exposes an explicit dict type for skill packages and serialized package payloads", () => {


### PR DESCRIPTION
## Summary

- align the shared `RoleCompletedPayload` contract and export it through both control facades
- expose `RoleCompletedPayload` from `autocontext_control`
- expose `RoleCompletedPayload` as a type export from `@autocontext/control-plane`
- align the TypeScript source-of-truth payload shape with Python by adding `run_id` and `generation` to `ts/src/loop/generation-side-effect-coordinator.ts`
- thread those two fields through the small existing TS helper call sites without changing broader orchestration behavior
- add the one TS control-package include needed for `generation-side-effect-coordinator.ts`
- publish this as a stacked follow-up on top of PR #829 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a Python runtime test failing on missing `RoleCompletedPayload` and a TS type-check failing on missing type export
- aligned the TS payload shape additively by including `run_id` and `generation`
- updated the minimal existing TS helper call sites and their tests to match the now-truthful payload contract
- proved GREEN after the minimal alignment/export changes only
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #829
- scope is intentionally limited to `RoleCompletedPayload` and the additive TS alignment required to make it truthful
- drifted tournament/run completion payloads remain intentionally out of scope
- no source-of-truth relocation was performed
