### PR TITLE
feat: export tournament started payload through control facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -149,6 +149,20 @@ def test_python_control_reexports_role_completed_payload() -> None:
     assert payload.tokens == 42
 
 
+def test_python_control_reexports_tournament_started_payload() -> None:
+    TournamentStartedPayload = control_package.TournamentStartedPayload
+
+    payload = TournamentStartedPayload(
+        run_id="run-123",
+        generation=2,
+        matches=8,
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.generation == 2
+    assert payload.matches == 8
+
+
 def test_python_control_reexports_shared_server_protocol_models() -> None:
     ExecutorInfo = control_package.ExecutorInfo
     ExecutorResources = control_package.ExecutorResources

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -38,6 +38,7 @@ ScenarioErrorMsg: Any = _server_protocol.ScenarioErrorMsg
 GenerationStartedPayload: Any = _server_protocol.GenerationStartedPayload
 AgentsStartedPayload: Any = _server_protocol.AgentsStartedPayload
 RoleCompletedPayload: Any = _server_protocol.RoleCompletedPayload
+TournamentStartedPayload: Any = _server_protocol.TournamentStartedPayload
 PauseCmd: Any = _server_protocol.PauseCmd
 ResumeCmd: Any = _server_protocol.ResumeCmd
 InjectHintCmd: Any = _server_protocol.InjectHintCmd
@@ -140,6 +141,7 @@ __all__ = [
     "ResearchResult",
     "ReviseScenarioCmd",
     "RoleCompletedPayload",
+    "TournamentStartedPayload",
     "ResumeCmd",
     "Routing",
     "ScenarioErrorMsg",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -6,6 +6,7 @@ export type {
 	GenerationStartedPayload,
 } from "../../../../ts/src/loop/generation-event-coordinator.js";
 export type { RoleCompletedPayload } from "../../../../ts/src/loop/generation-side-effect-coordinator.js";
+export type { TournamentStartedPayload } from "../../../../ts/src/loop/generation-tournament-event-sequencing.js";
 export type { StagnationReport } from "../../../../ts/src/loop/stagnation.js";
 export type {
 	AppId,

--- a/packages/ts/control-plane/tsconfig.json
+++ b/packages/ts/control-plane/tsconfig.json
@@ -17,6 +17,7 @@
 		"../../../ts/src/server/protocol.ts",
 		"../../../ts/src/loop/generation-event-coordinator.ts",
 		"../../../ts/src/loop/generation-side-effect-coordinator.ts",
+		"../../../ts/src/loop/generation-tournament-event-sequencing.ts",
 		"../../../ts/src/loop/stagnation.ts"
 	]
 }

--- a/ts/src/loop/generation-tournament-event-sequencing.ts
+++ b/ts/src/loop/generation-tournament-event-sequencing.ts
@@ -6,6 +6,13 @@ export interface GenerationLoopEventSequenceItem {
   payload: Record<string, unknown>;
 }
 
+export interface TournamentStartedPayload {
+  [key: string]: unknown;
+  run_id: string;
+  generation: number;
+  matches: number;
+}
+
 export function buildGenerationTournamentEventSequence(opts: {
   runId: string;
   generation: number;
@@ -32,7 +39,7 @@ function buildTournamentStartedEvent(
       run_id: runId,
       generation,
       matches: scheduledMatches,
-    },
+    } as TournamentStartedPayload,
   };
 }
 

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -14,6 +14,7 @@ import type {
 	Scenario,
 	SessionIdHash,
 	StagnationReport,
+	TournamentStartedPayload,
 	TraceSource,
 	UserIdHash,
 } from "../../packages/ts/control-plane/src/index.ts";
@@ -154,6 +155,18 @@ describe("@autocontext/control-plane facade", () => {
 		expect(brief.toMarkdown()).toContain(
 			"Research Brief: Summarize refund policy changes",
 		);
+	});
+
+	it("re-exports tournament started payload types", () => {
+		const payload: TournamentStartedPayload = {
+			run_id: "run-123",
+			generation: 2,
+			matches: 8,
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.generation).toBe(2);
+		expect(payload.matches).toBe(8);
 	});
 
 	it("re-exports role completed payload types", () => {


### PR DESCRIPTION
## Summary

- export the next truthful cross-language loop-event slice by re-exporting `TournamentStartedPayload` through both control facades
- expose `TournamentStartedPayload` from `autocontext_control`
- expose `TournamentStartedPayload` as a type export from `@autocontext/control-plane`
- add an explicit source-of-truth `TournamentStartedPayload` interface in `ts/src/loop/generation-tournament-event-sequencing.ts` for the already-emitted payload shape
- add the one TS control-package include needed for that source file
- keep the slice strictly on the aligned tournament-started payload and avoid nearby drifted payloads like `MatchCompletedPayload` and `TournamentCompletedPayload`
- publish this as a stacked follow-up on top of PR #830 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a Python runtime test failing on missing `TournamentStartedPayload` and a TS type-check failing on missing export
- proved GREEN after adding only the minimal Python facade export, TS source payload interface, TS facade type export, and one TS control-package include
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #830
- scope is intentionally limited to `TournamentStartedPayload`
- `MatchCompletedPayload`, `TournamentCompletedPayload`, and other drifted event payloads remain intentionally out of scope
- no source-of-truth relocation was performed
