### PR TITLE
feat: export curator lifecycle payloads through control facade

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -183,6 +183,32 @@ def test_python_control_reexports_tournament_completed_payload() -> None:
     assert payload.losses == 1
 
 
+def test_python_control_reexports_curator_started_payload() -> None:
+    CuratorStartedPayload = control_package.CuratorStartedPayload
+
+    payload = CuratorStartedPayload(
+        run_id="run-123",
+        generation=2,
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.generation == 2
+
+
+def test_python_control_reexports_curator_completed_payload() -> None:
+    CuratorCompletedPayload = control_package.CuratorCompletedPayload
+
+    payload = CuratorCompletedPayload(
+        run_id="run-123",
+        generation=2,
+        decision="accept",
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.generation == 2
+    assert payload.decision == "accept"
+
+
 def test_python_control_reexports_shared_server_protocol_models() -> None:
     ExecutorInfo = control_package.ExecutorInfo
     ExecutorResources = control_package.ExecutorResources

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -40,6 +40,8 @@ AgentsStartedPayload: Any = _server_protocol.AgentsStartedPayload
 RoleCompletedPayload: Any = _server_protocol.RoleCompletedPayload
 TournamentStartedPayload: Any = _server_protocol.TournamentStartedPayload
 TournamentCompletedPayload: Any = _server_protocol.TournamentCompletedPayload
+CuratorStartedPayload: Any = _server_protocol.CuratorStartedPayload
+CuratorCompletedPayload: Any = _server_protocol.CuratorCompletedPayload
 PauseCmd: Any = _server_protocol.PauseCmd
 ResumeCmd: Any = _server_protocol.ResumeCmd
 InjectHintCmd: Any = _server_protocol.InjectHintCmd
@@ -104,6 +106,8 @@ __all__ = [
     "ConditionType",
     "ConfirmScenarioCmd",
     "CreateScenarioCmd",
+    "CuratorCompletedPayload",
+    "CuratorStartedPayload",
     "EndedAt",
     "EnvContext",
     "EventMsg",


### PR DESCRIPTION
## Summary

- export the next truthful control-plane boundary slice by re-exporting Python curator lifecycle payloads through `autocontext_control`
- expose `CuratorStartedPayload` from the Python control facade
- expose `CuratorCompletedPayload` from the Python control facade
- add focused Python facade tests for both payload models
- keep this PR intentionally Python-only because the TypeScript curator event shapes currently live inline inside `ts/src/loop/generation-runner.ts`, and pulling them into the control facade honestly would widen the slice into heavier runtime refactoring
- publish this as a stacked follow-up on top of PR #832 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with focused Python tests failing on missing `CuratorStartedPayload` and `CuratorCompletedPayload`
- proved GREEN after adding only the minimal Python facade exports and focused tests
- deliberately left TypeScript untouched to avoid widening into `generation-runner.ts`
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #832
- scope is intentionally limited to Python curator lifecycle payloads
- this follows the truthful language-specific rule after the smaller shared helper-file payload seam was largely exhausted
- no source-of-truth relocation was performed
- no AC-645 license metadata work
