### PR TITLE
feat: export run failed payload through control facades

### DIFF
--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -4,6 +4,7 @@ export const packageTopologyVersion = 1;
 export type {
 	AgentsStartedPayload,
 	GenerationStartedPayload,
+	RunFailedPayload,
 	TournamentCompletedPayload,
 } from "../../../../ts/src/loop/generation-event-coordinator.js";
 export type { RoleCompletedPayload } from "../../../../ts/src/loop/generation-side-effect-coordinator.js";

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -11,6 +11,7 @@ import type {
 	ProviderInfo,
 	ResearchAdapter,
 	RoleCompletedPayload,
+	RunFailedPayload,
 	Scenario,
 	SessionIdHash,
 	StagnationReport,
@@ -202,6 +203,16 @@ describe("@autocontext/control-plane facade", () => {
 		expect(payload.role).toBe("coach");
 		expect(payload.latency_ms).toBe(125);
 		expect(payload.tokens).toBe(42);
+	});
+
+	it("re-exports run failed payload types", () => {
+		const payload: RunFailedPayload = {
+			run_id: "run-123",
+			error: "boom",
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.error).toBe("boom");
 	});
 
 	it("re-exports generation kickoff payload types", () => {


### PR DESCRIPTION
## Summary

- export the next truthful control-plane boundary slice by re-exporting `RunFailedPayload` through `@autocontext/control-plane`
- expose `RunFailedPayload` as a TypeScript type export from the control facade
- add a focused TypeScript control-package test for the payload shape
- keep this PR intentionally TypeScript-only because there is no truthful Python `RunFailedPayload` model in `autocontext.server.protocol`
- publish this as a stacked follow-up on top of PR #833 so the existing branch stays stable

## Surfaces Touched

- [ ] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a focused TS type-check failing on missing `RunFailedPayload`
- proved GREEN after adding only the minimal TS facade export and focused test
- deliberately left Python untouched because there is no truthful Python counterpart
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #833
- scope is intentionally limited to a TS-only helper-layer payload export
- this follows the truthful language-specific rule after the smaller shared payload seam was mostly exhausted
- no source-of-truth relocation was performed
- no AC-645 license metadata work
