### PR TITLE
feat: export match completed payload through control facade

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -195,6 +195,22 @@ def test_python_control_reexports_curator_started_payload() -> None:
     assert payload.generation == 2
 
 
+def test_python_control_reexports_match_completed_payload() -> None:
+    MatchCompletedPayload = control_package.MatchCompletedPayload
+
+    payload = MatchCompletedPayload(
+        run_id="run-123",
+        generation=2,
+        match_index=3,
+        score=0.55,
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.generation == 2
+    assert payload.match_index == 3
+    assert payload.score == 0.55
+
+
 def test_python_control_reexports_curator_completed_payload() -> None:
     CuratorCompletedPayload = control_package.CuratorCompletedPayload
 

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -39,6 +39,7 @@ GenerationStartedPayload: Any = _server_protocol.GenerationStartedPayload
 AgentsStartedPayload: Any = _server_protocol.AgentsStartedPayload
 RoleCompletedPayload: Any = _server_protocol.RoleCompletedPayload
 TournamentStartedPayload: Any = _server_protocol.TournamentStartedPayload
+MatchCompletedPayload: Any = _server_protocol.MatchCompletedPayload
 TournamentCompletedPayload: Any = _server_protocol.TournamentCompletedPayload
 CuratorStartedPayload: Any = _server_protocol.CuratorStartedPayload
 CuratorCompletedPayload: Any = _server_protocol.CuratorCompletedPayload
@@ -128,6 +129,7 @@ __all__ = [
     "HelloMsg",
     "InjectHintCmd",
     "ListScenariosCmd",
+    "MatchCompletedPayload",
     "Message",
     "PACKAGE_ROLE",
     "PACKAGE_TOPOLOGY_VERSION",


### PR DESCRIPTION
## Summary

- export the next truthful control-plane boundary slice by re-exporting Python `MatchCompletedPayload` through `autocontext_control`
- expose `MatchCompletedPayload` from the Python control facade
- add a focused Python facade test for the payload model
- keep this PR intentionally Python-only because the TypeScript tournament event path currently carries an extra `winner` field and does not yet expose an explicit shared `MatchCompletedPayload` source type
- publish this as a stacked follow-up on top of PR #834 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a focused Python test failing on missing `MatchCompletedPayload`
- proved GREEN after adding only the minimal Python facade export and focused test
- deliberately left TypeScript untouched because its tournament event path currently carries extra `winner` data
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #834
- scope is intentionally limited to the Python `MatchCompletedPayload` export
- this follows the truthful language-specific rule after the smaller shared payload seam was mostly exhausted
- no source-of-truth relocation was performed
- no AC-645 license metadata work
