### PR TITLE
feat: export run started payload through control facade

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -225,6 +225,18 @@ def test_python_control_reexports_curator_completed_payload() -> None:
     assert payload.decision == "accept"
 
 
+def test_python_control_reexports_run_started_payload() -> None:
+    RunStartedPayload = control_package.RunStartedPayload
+
+    payload = RunStartedPayload(
+        run_id="run-123",
+        scenario="grid_ctf",
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.scenario == "grid_ctf"
+
+
 def test_python_control_reexports_shared_server_protocol_models() -> None:
     ExecutorInfo = control_package.ExecutorInfo
     ExecutorResources = control_package.ExecutorResources

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -35,6 +35,7 @@ ScenarioGeneratingMsg: Any = _server_protocol.ScenarioGeneratingMsg
 ScenarioPreviewMsg: Any = _server_protocol.ScenarioPreviewMsg
 ScenarioReadyMsg: Any = _server_protocol.ScenarioReadyMsg
 ScenarioErrorMsg: Any = _server_protocol.ScenarioErrorMsg
+RunStartedPayload: Any = _server_protocol.RunStartedPayload
 GenerationStartedPayload: Any = _server_protocol.GenerationStartedPayload
 AgentsStartedPayload: Any = _server_protocol.AgentsStartedPayload
 RoleCompletedPayload: Any = _server_protocol.RoleCompletedPayload
@@ -143,6 +144,7 @@ __all__ = [
     "RedactionMarker",
     "ResearchAdapter",
     "ResearchBrief",
+    "RunStartedPayload",
     "ResearchConfig",
     "ResearchQuery",
     "ResearchResult",


### PR DESCRIPTION
## Summary

- export the next truthful control-plane boundary slice by re-exporting Python `RunStartedPayload` through `autocontext_control`
- expose `RunStartedPayload` from the Python control facade
- add a focused Python facade test for the payload model
- keep this PR intentionally Python-only because the TypeScript helper-layer `RunStartedPayload` currently includes an extra `target_generations` field
- publish this as a stacked follow-up on top of PR #835 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a focused Python test failing on missing `RunStartedPayload`
- proved GREEN after adding only the minimal Python facade export and focused test
- deliberately left TypeScript untouched because its helper-layer `RunStartedPayload` currently includes `target_generations`
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #835
- scope is intentionally limited to the Python `RunStartedPayload` export
- this follows the truthful language-specific rule after the smaller shared payload seam was mostly exhausted
- no source-of-truth relocation was performed
- no AC-645 license metadata work
