### PR TITLE
feat: export run completed payload through control facade

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -237,6 +237,18 @@ def test_python_control_reexports_run_started_payload() -> None:
     assert payload.scenario == "grid_ctf"
 
 
+def test_python_control_reexports_run_completed_payload() -> None:
+    RunCompletedPayload = control_package.RunCompletedPayload
+
+    payload = RunCompletedPayload(
+        run_id="run-123",
+        completed_generations=4,
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.completed_generations == 4
+
+
 def test_python_control_reexports_shared_server_protocol_models() -> None:
     ExecutorInfo = control_package.ExecutorInfo
     ExecutorResources = control_package.ExecutorResources

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -36,6 +36,7 @@ ScenarioPreviewMsg: Any = _server_protocol.ScenarioPreviewMsg
 ScenarioReadyMsg: Any = _server_protocol.ScenarioReadyMsg
 ScenarioErrorMsg: Any = _server_protocol.ScenarioErrorMsg
 RunStartedPayload: Any = _server_protocol.RunStartedPayload
+RunCompletedPayload: Any = _server_protocol.RunCompletedPayload
 GenerationStartedPayload: Any = _server_protocol.GenerationStartedPayload
 AgentsStartedPayload: Any = _server_protocol.AgentsStartedPayload
 RoleCompletedPayload: Any = _server_protocol.RoleCompletedPayload
@@ -144,6 +145,7 @@ __all__ = [
     "RedactionMarker",
     "ResearchAdapter",
     "ResearchBrief",
+    "RunCompletedPayload",
     "RunStartedPayload",
     "ResearchConfig",
     "ResearchQuery",


### PR DESCRIPTION
## Summary

- export the next truthful control-plane boundary slice by re-exporting Python `RunCompletedPayload` through `autocontext_control`
- expose `RunCompletedPayload` from the Python control facade
- add a focused Python facade test for the payload model
- keep this PR intentionally Python-only because the TypeScript helper-layer `RunCompletedPayload` currently includes additional fields beyond the exact Python runtime event payload
- publish this as a stacked follow-up on top of PR #836 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a focused Python test failing on missing `RunCompletedPayload`
- proved GREEN after adding only the minimal Python facade export and focused test
- deliberately left TypeScript untouched because its helper-layer `RunCompletedPayload` currently includes richer run-completion fields
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #836
- scope is intentionally limited to the Python `RunCompletedPayload` export
- this follows the truthful language-specific rule after the smaller shared payload seam was mostly exhausted
- no source-of-truth relocation was performed
- no AC-645 license metadata work
