### PR TITLE
feat: export run started payload through control facades

### DIFF
--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -5,6 +5,7 @@ export type {
 	AgentsStartedPayload,
 	GenerationStartedPayload,
 	RunFailedPayload,
+	RunStartedPayload,
 	TournamentCompletedPayload,
 } from "../../../../ts/src/loop/generation-event-coordinator.js";
 export type { RoleCompletedPayload } from "../../../../ts/src/loop/generation-side-effect-coordinator.js";

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -12,6 +12,7 @@ import type {
 	ResearchAdapter,
 	RoleCompletedPayload,
 	RunFailedPayload,
+	RunStartedPayload,
 	Scenario,
 	SessionIdHash,
 	StagnationReport,
@@ -203,6 +204,18 @@ describe("@autocontext/control-plane facade", () => {
 		expect(payload.role).toBe("coach");
 		expect(payload.latency_ms).toBe(125);
 		expect(payload.tokens).toBe(42);
+	});
+
+	it("re-exports run started payload types", () => {
+		const payload: RunStartedPayload = {
+			run_id: "run-123",
+			scenario: "grid_ctf",
+			target_generations: 5,
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.scenario).toBe("grid_ctf");
+		expect(payload.target_generations).toBe(5);
 	});
 
 	it("re-exports run failed payload types", () => {


### PR DESCRIPTION
## Summary

- export the next truthful control-plane boundary slice by re-exporting `RunStartedPayload` through `@autocontext/control-plane`
- expose `RunStartedPayload` as a TypeScript type export from the control facade
- add a focused TypeScript control-package test for the payload shape
- keep this PR intentionally TypeScript-only because the Python runtime `RunStartedPayload` does not carry the helper-layer `target_generations` field
- publish this as a stacked follow-up on top of PR #837 so the existing branch stays stable

## Surfaces Touched

- [ ] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a focused TS type-check failing on missing `RunStartedPayload`
- proved GREEN after adding only the minimal TS facade export and focused test
- deliberately left Python untouched because its runtime `RunStartedPayload` does not include `target_generations`
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #837
- scope is intentionally limited to a TS-only helper-layer payload export
- this follows the truthful language-specific rule after the smaller shared payload seam was mostly exhausted
- no source-of-truth relocation was performed
- no AC-645 license metadata work
