### PR TITLE
feat: export run completed payload through control facades

### DIFF
--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -4,6 +4,7 @@ export const packageTopologyVersion = 1;
 export type {
 	AgentsStartedPayload,
 	GenerationStartedPayload,
+	RunCompletedPayload,
 	RunFailedPayload,
 	RunStartedPayload,
 	TournamentCompletedPayload,

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -11,6 +11,7 @@ import type {
 	ProviderInfo,
 	ResearchAdapter,
 	RoleCompletedPayload,
+	RunCompletedPayload,
 	RunFailedPayload,
 	RunStartedPayload,
 	Scenario,
@@ -216,6 +217,24 @@ describe("@autocontext/control-plane facade", () => {
 		expect(payload.run_id).toBe("run-123");
 		expect(payload.scenario).toBe("grid_ctf");
 		expect(payload.target_generations).toBe(5);
+	});
+
+	it("re-exports run completed payload types", () => {
+		const payload: RunCompletedPayload = {
+			run_id: "run-123",
+			completed_generations: 4,
+			best_score: 0.82,
+			elo: 1042,
+			session_report_path: "/tmp/report.md",
+			dead_ends_found: 2,
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.completed_generations).toBe(4);
+		expect(payload.best_score).toBe(0.82);
+		expect(payload.elo).toBe(1042);
+		expect(payload.session_report_path).toBe("/tmp/report.md");
+		expect(payload.dead_ends_found).toBe(2);
 	});
 
 	it("re-exports run failed payload types", () => {


### PR DESCRIPTION
## Summary

- export the next truthful control-plane boundary slice by re-exporting `RunCompletedPayload` through `@autocontext/control-plane`
- expose `RunCompletedPayload` as a TypeScript type export from the control facade
- add a focused TypeScript control-package test for the payload shape
- keep this PR intentionally TypeScript-only because the Python runtime `RunCompletedPayload` only carries `run_id` and `completed_generations`
- publish this as a stacked follow-up on top of PR #838 so the existing branch stays stable

## Surfaces Touched

- [ ] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a focused TS type-check failing on missing `RunCompletedPayload`
- proved GREEN after adding only the minimal TS facade export and focused test
- deliberately left Python untouched because its runtime `RunCompletedPayload` does not include the richer helper-layer fields
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #838
- scope is intentionally limited to a TS-only helper-layer payload export
- this follows the truthful language-specific rule after the smaller shared payload seam was mostly exhausted
- no source-of-truth relocation was performed
- no AC-645 license metadata work
