### PR TITLE
feat: export gate decided payload through control facades

### DIFF
--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -3,6 +3,7 @@ export const packageTopologyVersion = 1;
 
 export type {
 	AgentsStartedPayload,
+	GateDecidedPayload,
 	GenerationStartedPayload,
 	RunCompletedPayload,
 	RunFailedPayload,

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -5,6 +5,7 @@ import type {
 	EnvironmentTag,
 	FeedbackRef,
 	FeedbackRefId,
+	GateDecidedPayload,
 	GenerationStartedPayload,
 	ProductionTrace,
 	ProductionTraceId,
@@ -217,6 +218,22 @@ describe("@autocontext/control-plane facade", () => {
 		expect(payload.run_id).toBe("run-123");
 		expect(payload.scenario).toBe("grid_ctf");
 		expect(payload.target_generations).toBe(5);
+	});
+
+	it("re-exports gate decided payload types", () => {
+		const payload: GateDecidedPayload = {
+			run_id: "run-123",
+			generation: 2,
+			decision: "advance",
+			delta: 0.18,
+			threshold: 0.005,
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.generation).toBe(2);
+		expect(payload.decision).toBe("advance");
+		expect(payload.delta).toBe(0.18);
+		expect(payload.threshold).toBe(0.005);
 	});
 
 	it("re-exports run completed payload types", () => {


### PR DESCRIPTION
## Summary

- export the next truthful control-plane boundary slice by re-exporting `GateDecidedPayload` through `@autocontext/control-plane`
- expose `GateDecidedPayload` as a TypeScript type export from the control facade
- add a focused TypeScript control-package test for the payload shape
- keep this PR intentionally TypeScript-only because Python’s live `gate_decided` runtime events currently carry richer metadata beyond the smaller protocol model
- publish this as a stacked follow-up on top of PR #839 so the existing branch stays stable

## Surfaces Touched

- [ ] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a focused TS type-check failing on missing `GateDecidedPayload`
- proved GREEN after adding only the minimal TS facade export and focused test
- deliberately left Python untouched because its live `gate_decided` runtime events carry richer metadata
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #839
- scope is intentionally limited to a TS-only helper-layer payload export
- this follows the truthful language-specific rule after the smaller shared payload seam was mostly exhausted
- no source-of-truth relocation was performed
- no AC-645 license metadata work
