### PR TITLE
feat: export generation completed payload through control facades

### DIFF
--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -4,6 +4,7 @@ export const packageTopologyVersion = 1;
 export type {
 	AgentsStartedPayload,
 	GateDecidedPayload,
+	GenerationCompletedPayload,
 	GenerationStartedPayload,
 	RunCompletedPayload,
 	RunFailedPayload,

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -6,6 +6,7 @@ import type {
 	FeedbackRef,
 	FeedbackRefId,
 	GateDecidedPayload,
+	GenerationCompletedPayload,
 	GenerationStartedPayload,
 	ProductionTrace,
 	ProductionTraceId,
@@ -234,6 +235,24 @@ describe("@autocontext/control-plane facade", () => {
 		expect(payload.decision).toBe("advance");
 		expect(payload.delta).toBe(0.18);
 		expect(payload.threshold).toBe(0.005);
+	});
+
+	it("re-exports generation completed payload types", () => {
+		const payload: GenerationCompletedPayload = {
+			run_id: "run-123",
+			generation: 2,
+			mean_score: 0.68,
+			best_score: 0.72,
+			elo: 1068,
+			gate_decision: "advance",
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.generation).toBe(2);
+		expect(payload.mean_score).toBe(0.68);
+		expect(payload.best_score).toBe(0.72);
+		expect(payload.elo).toBe(1068);
+		expect(payload.gate_decision).toBe("advance");
 	});
 
 	it("re-exports run completed payload types", () => {


### PR DESCRIPTION
## Summary

- export the next truthful control-plane boundary slice by re-exporting `GenerationCompletedPayload` through `@autocontext/control-plane`
- expose `GenerationCompletedPayload` as a TypeScript type export from the control facade
- add a focused TypeScript control-package test for the payload shape
- keep this PR intentionally TypeScript-only because Python’s live `generation_completed` runtime events currently carry richer metadata beyond the smaller helper-layer payload
- publish this as a stacked follow-up on top of PR #840 so the existing branch stays stable

## Surfaces Touched

- [ ] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a focused TS type-check failing on missing `GenerationCompletedPayload`
- proved GREEN after adding only the minimal TS facade export and focused test
- deliberately left Python untouched because its live `generation_completed` runtime events carry richer metadata
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #840
- scope is intentionally limited to a TS-only helper-layer payload export
- this follows the truthful language-specific rule after the smaller shared payload seam was mostly exhausted
- no source-of-truth relocation was performed
- no AC-645 license metadata work
