### PR TITLE
feat: export generation completed payload through control facade

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -265,6 +265,28 @@ def test_python_control_reexports_gate_decided_payload() -> None:
     assert payload.delta == 0.18
 
 
+def test_python_control_reexports_generation_completed_payload() -> None:
+    GenerationCompletedPayload = control_package.GenerationCompletedPayload
+
+    payload = GenerationCompletedPayload(
+        run_id="run-123",
+        generation=2,
+        mean_score=0.68,
+        best_score=0.72,
+        elo=1068,
+        gate_decision="advance",
+        created_tools=["tool_a.py"],
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.generation == 2
+    assert payload.mean_score == 0.68
+    assert payload.best_score == 0.72
+    assert payload.elo == 1068
+    assert payload.gate_decision == "advance"
+    assert payload.created_tools == ["tool_a.py"]
+
+
 def test_python_control_reexports_shared_server_protocol_models() -> None:
     ExecutorInfo = control_package.ExecutorInfo
     ExecutorResources = control_package.ExecutorResources

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -38,6 +38,7 @@ ScenarioErrorMsg: Any = _server_protocol.ScenarioErrorMsg
 RunStartedPayload: Any = _server_protocol.RunStartedPayload
 RunCompletedPayload: Any = _server_protocol.RunCompletedPayload
 GenerationStartedPayload: Any = _server_protocol.GenerationStartedPayload
+GenerationCompletedPayload: Any = _server_protocol.GenerationCompletedPayload
 AgentsStartedPayload: Any = _server_protocol.AgentsStartedPayload
 RoleCompletedPayload: Any = _server_protocol.RoleCompletedPayload
 TournamentStartedPayload: Any = _server_protocol.TournamentStartedPayload
@@ -120,6 +121,7 @@ __all__ = [
     "AgentsStartedPayload",
     "Error",
     "ErrorMsg",
+    "GenerationCompletedPayload",
     "GenerationStartedPayload",
     "GateDecidedPayload",
     "MonitorAlert",


### PR DESCRIPTION
## Summary

- export the next truthful control-plane boundary slice by re-exporting Python `GenerationCompletedPayload` through `autocontext_control`
- expose `GenerationCompletedPayload` from the Python control facade
- add a focused Python facade test for the payload model
- keep this PR intentionally Python-only because the TypeScript helper-layer `GenerationCompletedPayload` export already exists and this slice closes the remaining Python facade gap
- publish this as a stacked follow-up on top of PR #842 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run mypy ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- [x] focused RED/GREEN checks before broader validation

Manual verification:
- proved RED first with a focused Python test failing on missing `GenerationCompletedPayload`
- proved GREEN after adding only the minimal Python facade export and focused test
- deliberately left TypeScript untouched because the helper-layer `GenerationCompletedPayload` export already exists there
- reverted unrelated `autocontext/uv.lock` drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #842
- scope is intentionally limited to the Python `GenerationCompletedPayload` export
- this follows the truthful language-specific rule while keeping runtime cleanup out of scope
- no source-of-truth relocation was performed
- no AC-645 license metadata work
