### PR TITLE
feat: align run started payload across control surfaces

### DIFF
--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -1062,6 +1062,7 @@ class GenerationRunner:
         scenario = self._scenario(scenario_name)
         active_run_id = run_id or f"run_{uuid.uuid4().hex[:12]}"
         run_start_time = time.monotonic()
+        target_generations = generations
         existing_run = self.sqlite.get_run(active_run_id)
         if existing_run is None:
             self.sqlite.create_run(
@@ -1071,11 +1072,11 @@ class GenerationRunner:
         else:
             self._recover_stale_run_state(active_run_id)
             refreshed_run = self.sqlite.get_run(active_run_id) or existing_run
+            target_generations = max(
+                self._int_value(refreshed_run.get("target_generations"), generations),
+                generations,
+            )
             if str(refreshed_run.get("status") or "") != "completed":
-                target_generations = max(
-                    self._int_value(refreshed_run.get("target_generations"), generations),
-                    generations,
-                )
                 self.sqlite.mark_run_running(active_run_id, target_generations=target_generations)
         (
             previous_best,
@@ -1085,7 +1086,10 @@ class GenerationRunner:
             gate_decision_history,
         ) = self._hydrate_run_state(active_run_id)
         completed = 0
-        self.events.emit("run_started", {"run_id": active_run_id, "scenario": scenario_name})
+        self.events.emit(
+            "run_started",
+            {"run_id": active_run_id, "scenario": scenario_name, "target_generations": target_generations},
+        )
 
         # Seed scenario-specific tools before first generation
         if not self.artifacts.tools_dir(scenario_name).exists():

--- a/autocontext/src/autocontext/server/protocol.py
+++ b/autocontext/src/autocontext/server/protocol.py
@@ -305,6 +305,7 @@ class RunStartedPayload(BaseModel):
 
     run_id: str
     scenario: str
+    target_generations: int
 
 
 class GenerationStartedPayload(BaseModel):

--- a/autocontext/tests/test_protocol.py
+++ b/autocontext/tests/test_protocol.py
@@ -207,7 +207,7 @@ class TestEventPayloads:
     @pytest.mark.parametrize(
         "model,kwargs",
         [
-            (RunStartedPayload, {"run_id": "r1", "scenario": "grid_ctf"}),
+            (RunStartedPayload, {"run_id": "r1", "scenario": "grid_ctf", "target_generations": 3}),
             (GenerationStartedPayload, {"run_id": "r1", "generation": 1}),
             (AgentsStartedPayload, {"run_id": "r1", "generation": 1, "roles": ["competitor", "analyst"]}),
             (RoleCompletedPayload, {"run_id": "r1", "generation": 1, "role": "analyst", "latency_ms": 1200, "tokens": 500}),

--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -231,10 +231,12 @@ def test_python_control_reexports_run_started_payload() -> None:
     payload = RunStartedPayload(
         run_id="run-123",
         scenario="grid_ctf",
+        target_generations=5,
     )
 
     assert payload.run_id == "run-123"
     assert payload.scenario == "grid_ctf"
+    assert payload.target_generations == 5
 
 
 def test_python_control_reexports_run_completed_payload() -> None:

--- a/autocontext/tests/test_runner_integration.py
+++ b/autocontext/tests/test_runner_integration.py
@@ -37,6 +37,15 @@ def test_single_generation_persists_metadata_and_artifacts(tmp_path: Path) -> No
     assert payload["generation_index"] == 1
     assert "elo" in payload
 
+    event_stream_path = tmp_path / "runs" / "events.ndjson"
+    events = [json.loads(line) for line in event_stream_path.read_text(encoding="utf-8").splitlines()]
+    run_started = next(event for event in events if event["event"] == "run_started")
+    assert run_started["payload"] == {
+        "run_id": run_id,
+        "scenario": "grid_ctf",
+        "target_generations": 1,
+    }
+
     # Coach history should exist as audit trail
     coach_history_path = tmp_path / "knowledge" / "grid_ctf" / "coach_history.md"
     assert coach_history_path.exists()


### PR DESCRIPTION
## Summary

- align `RunStartedPayload` across the Python control/runtime surface and the existing TypeScript helper-layer contract
- extend Python `RunStartedPayload` to include `target_generations`
- thread `target_generations` through the live Python `run_started` emitter in `GenerationRunner.run()`
- update focused Python protocol, control-facade, and runner integration tests to prove the aligned shape
- keep the slice intentionally limited to `RunStartedPayload` only
- publish this as a stacked follow-up on top of PR #844 so the existing branch stays stable

## Surfaces Touched

- [x] Python package
- [ ] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run pytest tests/test_protocol.py -q`
- [x] `cd autocontext && uv run pytest tests/test_python_control_package.py -q`
- [x] `cd autocontext && uv run pytest tests/test_runner_integration.py -q`
- [x] `cd autocontext && uv run mypy src/autocontext/loop/generation_runner.py src/autocontext/server/protocol.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py tests/test_protocol.py tests/test_runner_integration.py src/autocontext/server/protocol.py src/autocontext/loop/generation_runner.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py tests/test_protocol.py tests/test_runner_integration.py`
- [x] `cd autocontext && uv run mypy src/autocontext/server/protocol.py src/autocontext/loop/generation_runner.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`

Manual verification:
- proved RED first by making the Python protocol/control-facade `RunStartedPayload` require `target_generations`
- added a live runner assertion that the emitted `run_started` event includes `target_generations`
- fixed the one real implementation gap by binding `target_generations` for both new-run and recovered-run paths before emission
- kept unrelated lifecycle payloads and runtime metadata out of scope
- restored `uv.lock` and generated skill-output drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #844
- scope is intentionally limited to `RunStartedPayload` alignment
- this is the first deliberate lifecycle alignment slice after the earlier export-only facade work
- no source-of-truth relocation was performed
- no AC-645 license metadata work
