### PR TITLE
feat: align run completed payload across control surfaces

### DIFF
--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -214,11 +214,10 @@ class GenerationRunner:
         return content.count("### Dead End")
 
     def _generate_session_report(
-        self, run_id: str, scenario_name: str, duration_seconds: float,
-    ) -> None:
+        self, run_id: str, scenario_name: str, duration_seconds: float, dead_ends_found: int,
+    ) -> str:
         """Generate and persist a session report for a completed run."""
         trajectory_rows = self.sqlite.get_generation_trajectory(run_id)
-        dead_ends_count = self._count_dead_ends(scenario_name)
         current_generation = max(
             (int(row.get("generation_index", 0)) for row in trajectory_rows),
             default=0,
@@ -242,12 +241,12 @@ class GenerationRunner:
             trajectory_rows=trajectory_rows,
             exploration_mode=self.settings.exploration_mode,
             duration_seconds=duration_seconds,
-            dead_ends_found=dead_ends_count,
+            dead_ends_found=dead_ends_found,
             stale_lessons_count=stale_lessons_count,
             superseded_lessons_count=superseded_lessons_count,
         )
         markdown = report.to_markdown()
-        self.artifacts.write_session_report(scenario_name, run_id, markdown)
+        return str(self.artifacts.write_session_report(scenario_name, run_id, markdown))
 
     def _generate_trace_grounded_reports(self, run_id: str, scenario_name: str) -> None:
         """Generate trace-backed writeups and weakness reports for a completed run.
@@ -1308,11 +1307,19 @@ class GenerationRunner:
         finally:
             self.artifacts.shutdown_writer()
 
+        dead_ends_found = self._count_dead_ends(scenario_name)
+        session_report_path: str | None = None
+
         # Generate session report
         if self.settings.session_reports_enabled:
             duration = time.monotonic() - run_start_time
             try:
-                self._generate_session_report(active_run_id, scenario_name, duration)
+                session_report_path = self._generate_session_report(
+                    active_run_id,
+                    scenario_name,
+                    duration,
+                    dead_ends_found,
+                )
             except Exception:
                 logger.warning("failed to generate session report for run %s", active_run_id, exc_info=True)
         try:
@@ -1347,7 +1354,17 @@ class GenerationRunner:
                 rating_uncertainty=challenger_uncertainty,
             )
 
-        self.events.emit("run_completed", {"run_id": active_run_id, "completed_generations": completed})
+        self.events.emit(
+            "run_completed",
+            {
+                "run_id": active_run_id,
+                "completed_generations": completed,
+                "best_score": previous_best,
+                "elo": challenger_elo,
+                "session_report_path": session_report_path,
+                "dead_ends_found": dead_ends_found,
+            },
+        )
         return RunSummary(
             run_id=active_run_id,
             scenario=scenario_name,

--- a/autocontext/src/autocontext/server/protocol.py
+++ b/autocontext/src/autocontext/server/protocol.py
@@ -402,6 +402,10 @@ class RunCompletedPayload(BaseModel):
 
     run_id: str
     completed_generations: int
+    best_score: float
+    elo: float
+    session_report_path: str | None
+    dead_ends_found: int
 
 
 # ---------------------------------------------------------------------------

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -1031,11 +1031,12 @@ class ArtifactStore:
                 continue  # Real file/dir exists, don't overwrite
             os.symlink(entry.resolve(), link)
 
-    def write_session_report(self, scenario_name: str, run_id: str, content: str) -> None:
+    def write_session_report(self, scenario_name: str, run_id: str, content: str) -> Path:
         """Write a session report for a completed run."""
         path = self.knowledge_root / scenario_name / "reports" / f"{run_id}.md"
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
+        return path
 
     # --- Normalized progress reports (AC-190) ---------------------------------
 

--- a/autocontext/tests/test_protocol.py
+++ b/autocontext/tests/test_protocol.py
@@ -232,7 +232,17 @@ class TestEventPayloads:
                     "created_tools": ["tool_a.py"],
                 },
             ),
-            (RunCompletedPayload, {"run_id": "r1", "completed_generations": 5}),
+            (
+                RunCompletedPayload,
+                {
+                    "run_id": "r1",
+                    "completed_generations": 5,
+                    "best_score": 0.9,
+                    "elo": 1088.0,
+                    "session_report_path": None,
+                    "dead_ends_found": 0,
+                },
+            ),
         ],
     )
     def test_validates(self, model: type, kwargs: dict) -> None:

--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -245,10 +245,18 @@ def test_python_control_reexports_run_completed_payload() -> None:
     payload = RunCompletedPayload(
         run_id="run-123",
         completed_generations=4,
+        best_score=0.82,
+        elo=1042,
+        session_report_path=None,
+        dead_ends_found=2,
     )
 
     assert payload.run_id == "run-123"
     assert payload.completed_generations == 4
+    assert payload.best_score == 0.82
+    assert payload.elo == 1042
+    assert payload.session_report_path is None
+    assert payload.dead_ends_found == 2
 
 
 def test_python_control_reexports_gate_decided_payload() -> None:

--- a/autocontext/tests/test_runner_integration.py
+++ b/autocontext/tests/test_runner_integration.py
@@ -46,6 +46,16 @@ def test_single_generation_persists_metadata_and_artifacts(tmp_path: Path) -> No
         "target_generations": 1,
     }
 
+    run_completed = next(event for event in events if event["event"] == "run_completed")
+    assert run_completed["payload"] == {
+        "run_id": run_id,
+        "completed_generations": 1,
+        "best_score": summary.best_score,
+        "elo": summary.current_elo,
+        "session_report_path": str(tmp_path / "knowledge" / "grid_ctf" / "reports" / f"{run_id}.md"),
+        "dead_ends_found": 0,
+    }
+
     # Coach history should exist as audit trail
     coach_history_path = tmp_path / "knowledge" / "grid_ctf" / "coach_history.md"
     assert coach_history_path.exists()
@@ -115,6 +125,38 @@ def test_playbook_not_updated_on_rollback(tmp_path: Path) -> None:
     assert "ROLLBACK" in skills_content
     # Bundled playbook should exist (from gen 1 advance)
     assert (skill_dir / "playbook.md").exists()
+
+
+def test_run_completed_omits_session_report_path_when_reports_disabled(tmp_path: Path) -> None:
+    settings = AppSettings(
+        db_path=tmp_path / "runs" / "autocontext.sqlite3",
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+        event_stream_path=tmp_path / "runs" / "events.ndjson",
+        seed_base=2000,
+        agent_provider="deterministic",
+        matches_per_generation=2,
+        session_reports_enabled=False,
+    )
+    runner = GenerationRunner(settings)
+    migrations_dir = Path(__file__).resolve().parents[1] / "migrations"
+    runner.migrate(migrations_dir)
+
+    run_id = "test_run_no_report"
+    summary = runner.run(scenario_name="grid_ctf", generations=1, run_id=run_id)
+
+    event_stream_path = tmp_path / "runs" / "events.ndjson"
+    events = [json.loads(line) for line in event_stream_path.read_text(encoding="utf-8").splitlines()]
+    run_completed = next(event for event in events if event["event"] == "run_completed")
+    assert run_completed["payload"] == {
+        "run_id": run_id,
+        "completed_generations": 1,
+        "best_score": summary.best_score,
+        "elo": summary.current_elo,
+        "session_report_path": None,
+        "dead_ends_found": 0,
+    }
 
 
 def test_resume_is_idempotent_for_existing_generation(tmp_path: Path) -> None:

--- a/ts/src/loop/generation-event-coordinator.ts
+++ b/ts/src/loop/generation-event-coordinator.ts
@@ -55,7 +55,7 @@ export interface RunCompletedPayload {
   completed_generations: number;
   best_score: number;
   elo: number;
-  session_report_path: string;
+  session_report_path: string | null;
   dead_ends_found: number;
 }
 
@@ -162,7 +162,7 @@ export function buildRunCompletedPayload(opts: {
   completedGenerations: number;
   bestScore: number;
   currentElo: number;
-  sessionReportPath: string;
+  sessionReportPath: string | null;
   deadEndsFound: number;
 }): RunCompletedPayload {
   return {

--- a/ts/src/server/run-start-workflow.ts
+++ b/ts/src/server/run-start-workflow.ts
@@ -254,6 +254,8 @@ export async function executeAgentTaskCustomStartRun(opts: {
     completed_generations: completedGenerations,
     best_score: bestScore,
     elo: 1000,
+    session_report_path: null,
+    dead_ends_found: 0,
     family: "agent_task",
     saved_custom: true,
   });
@@ -332,6 +334,8 @@ export async function executeGeneratedCustomStartRun(opts: {
     completed_generations: opts.generations,
     best_score: bestScoreOverall,
     elo: 1000,
+    session_report_path: null,
+    dead_ends_found: 0,
     family: opts.family,
     generated_custom: true,
   });

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -261,7 +261,7 @@ describe("@autocontext/control-plane facade", () => {
 			completed_generations: 4,
 			best_score: 0.82,
 			elo: 1042,
-			session_report_path: "/tmp/report.md",
+			session_report_path: null,
 			dead_ends_found: 2,
 		};
 
@@ -269,7 +269,7 @@ describe("@autocontext/control-plane facade", () => {
 		expect(payload.completed_generations).toBe(4);
 		expect(payload.best_score).toBe(0.82);
 		expect(payload.elo).toBe(1042);
-		expect(payload.session_report_path).toBe("/tmp/report.md");
+		expect(payload.session_report_path).toBeNull();
 		expect(payload.dead_ends_found).toBe(2);
 	});
 

--- a/ts/tests/run-start-workflow.test.ts
+++ b/ts/tests/run-start-workflow.test.ts
@@ -221,6 +221,9 @@ describe("run start workflow", () => {
     const completed = emitted.find((entry) => entry.event === "run_completed");
     expect(completed?.payload.best_score).toBe(0.9);
     expect(completed?.payload.completed_generations).toBe(2);
+    expect(completed?.payload.elo).toBe(1000);
+    expect(completed?.payload.session_report_path).toBeNull();
+    expect(completed?.payload.dead_ends_found).toBe(0);
   });
 
   it("executes saved agent-task runs and emits lifecycle events", async () => {
@@ -267,6 +270,11 @@ describe("run start workflow", () => {
     ]);
     expect(emitted.filter((entry) => entry.event === "generation_completed")).toHaveLength(2);
     expect(emitted.find((entry) => entry.event === "generation_completed")?.payload.best_score).toBe(0.82);
-    expect(emitted.find((entry) => entry.event === "run_completed")?.payload.completed_generations).toBe(2);
+    const completed = emitted.find((entry) => entry.event === "run_completed");
+    expect(completed?.payload.completed_generations).toBe(2);
+    expect(completed?.payload.best_score).toBe(0.82);
+    expect(completed?.payload.elo).toBe(1000);
+    expect(completed?.payload.session_report_path).toBeNull();
+    expect(completed?.payload.dead_ends_found).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- align `RunCompletedPayload` across the Python runtime/protocol surface and the existing TypeScript control contract
- expand the Python `RunCompletedPayload` model to carry completed-run summary fields: `best_score`, `elo`, `session_report_path`, and `dead_ends_found`
- make `session_report_path` nullable because a completed run is still truthful when session reports are disabled
- thread the richer payload through the live Python `GenerationRunner.run()` completion event
- return the written session report path from Python artifact persistence so the emitter can publish the exact persisted location without duplicating path logic
- align the TypeScript custom run emitters with the same completed-run payload shape by emitting `session_report_path: null` and `dead_ends_found: 0`
- update focused Python and TypeScript tests to prove both the report-present and report-absent cases
- keep the slice intentionally limited to `RunCompletedPayload` only

## Surfaces Touched

- [x] Python package
- [x] TypeScript package
- [ ] TUI
- [ ] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && uv run pytest tests/test_protocol.py tests/test_python_control_package.py tests/test_runner_integration.py -q`
- [x] `cd autocontext && uv run mypy src/autocontext/server/protocol.py src/autocontext/loop/generation_runner.py src/autocontext/storage/artifacts.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py tests/test_protocol.py tests/test_runner_integration.py tests/test_session_reports.py tests/test_session_report_wiring.py src/autocontext/server/protocol.py src/autocontext/loop/generation_runner.py src/autocontext/storage/artifacts.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_python_core_package.py tests/test_python_control_package.py tests/test_protocol.py tests/test_runner_integration.py tests/test_session_reports.py tests/test_session_report_wiring.py`
- [x] `cd autocontext && uv run mypy src/autocontext/server/protocol.py src/autocontext/loop/generation_runner.py src/autocontext/storage/artifacts.py ../packages/python/core/src/autocontext_core/__init__.py ../packages/python/control/src/autocontext_control/__init__.py`
- [x] `cd ts && npx vitest run tests/package-topology.test.ts tests/core-package.test.ts tests/control-plane-package.test.ts tests/generation-side-effect-coordinator.test.ts tests/generation-event-coordinator.test.ts tests/run-start-workflow.test.ts tests/typed-serialization.test.ts`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- [x] `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`

Manual verification:
- proved RED first by requiring the richer completed-run summary fields on the Python protocol/control-facade side
- added live Python run-completed event assertions for both report-present and report-absent cases
- tightened the TypeScript custom run emitters so they no longer omit fields from the shared completed-run concept
- kept the slice to one payload only; no wider lifecycle cleanup or source relocation
- restored `uv.lock` and generated skill-output drift before publication

## Docs And Release Impact

- [x] no user-facing docs changes needed
- [ ] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- this is a stacked follow-up PR on top of PR #845
- `session_report_path` is intentionally nullable because completed runs can truthfully finish without a persisted report when report generation is disabled
- this continues the deliberate one-payload runtime/protocol alignment phase after the earlier export-only facade slices
- no source-of-truth relocation was performed
- no AC-645 license metadata work
