### PR TITLE
AC-650 Batch control contract facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PY_CONTROL_SRC = REPO_ROOT / "packages" / "python" / "control" / "src"
+if str(PY_CONTROL_SRC) not in sys.path:
+    sys.path.insert(0, str(PY_CONTROL_SRC))
+
+control_package = import_module("autocontext_control")
+package_role = control_package.package_role
+package_topology_version = control_package.package_topology_version
+
+
+def test_python_control_package_identity() -> None:
+    assert package_role == "control"
+    assert package_topology_version == 1
+
+
+def test_python_control_reexports_research_domain_contracts() -> None:
+    Citation = control_package.Citation
+    ResearchAdapter = control_package.ResearchAdapter
+    ResearchConfig = control_package.ResearchConfig
+    ResearchQuery = control_package.ResearchQuery
+    ResearchResult = control_package.ResearchResult
+    Urgency = control_package.Urgency
+
+    query = ResearchQuery(
+        topic="refund policy changes",
+        context="customer support escalation",
+        urgency=Urgency.HIGH,
+        max_results=3,
+        constraints=["cite primary sources"],
+        scenario_family="agent_task",
+        metadata={"ticket": "t-1"},
+    )
+    citation = Citation(
+        source="policy handbook",
+        url="https://example.com/policy",
+        relevance=0.95,
+        snippet="Refunds require manager sign-off after 30 days.",
+        retrieved_at="2026-04-25T00:00:00Z",
+    )
+
+    class DemoResearchAdapter:
+        def search(self, query: ResearchQuery) -> ResearchResult:
+            return ResearchResult(
+                query_topic=query.topic,
+                summary="Manager sign-off required after 30 days.",
+                citations=[citation],
+                confidence=0.91,
+                metadata={"adapter": "demo"},
+            )
+
+    adapter = DemoResearchAdapter()
+    result = adapter.search(query)
+    config = ResearchConfig(enabled=True, adapter_name="demo", max_queries_per_turn=1)
+
+    assert query.urgency is Urgency.HIGH
+    assert query.constraints == ["cite primary sources"]
+    assert isinstance(adapter, ResearchAdapter)
+    assert result.has_citations is True
+    assert result.citations[0].source == "policy handbook"
+    assert result.metadata == {"adapter": "demo"}
+    assert config.enabled is True
+    assert config.adapter_name == "demo"
+    assert config.max_queries_per_turn == 1
+
+
+def test_python_control_reexports_research_brief() -> None:
+    Citation = control_package.Citation
+    ResearchBrief = control_package.ResearchBrief
+    ResearchResult = control_package.ResearchResult
+
+    citation = Citation(
+        source="policy handbook",
+        url="https://example.com/policy",
+        relevance=0.95,
+        snippet="Refunds require manager sign-off after 30 days.",
+        retrieved_at="2026-04-25T00:00:00Z",
+    )
+    strong_result = ResearchResult(
+        query_topic="refund policy",
+        summary="Manager sign-off required after 30 days.",
+        citations=[citation],
+        confidence=0.91,
+        metadata={"adapter": "demo"},
+    )
+    weak_result = ResearchResult(
+        query_topic="escalation policy",
+        summary="Escalate unusual refund cases.",
+        citations=[citation],
+        confidence=0.42,
+        metadata={"adapter": "demo"},
+    )
+
+    brief = ResearchBrief.from_results(
+        goal="Summarize refund policy changes",
+        results=[strong_result, weak_result],
+        min_confidence=0.9,
+    )
+
+    assert brief.goal == "Summarize refund policy changes"
+    assert len(brief.findings) == 1
+    assert brief.findings[0].query_topic == "refund policy"
+    assert len(brief.unique_citations) == 1
+    assert brief.unique_citations[0].source == "policy handbook"
+    assert brief.avg_confidence == 0.91
+    assert "Research Brief: Summarize refund policy changes" in brief.to_markdown()
+
+
+def test_python_control_reexports_production_trace_contracts() -> None:
+    Chosen = control_package.Chosen
+    EndedAt = control_package.EndedAt
+    EnvContext = control_package.EnvContext
+    Error = control_package.Error
+    FeedbackRef = control_package.FeedbackRef
+    Items = control_package.Items
+    Message = control_package.Message
+    ProductionOutcome = control_package.ProductionOutcome
+    ProductionTrace = control_package.ProductionTrace
+    Provider = control_package.Provider
+    RedactionMarker = control_package.RedactionMarker
+    Routing = control_package.Routing
+    Sdk = control_package.Sdk
+    SessionIdentifier = control_package.SessionIdentifier
+    TimingInfo = control_package.TimingInfo
+    ToolCall = control_package.ToolCall
+    TraceLinks = control_package.TraceLinks
+    TraceSource = control_package.TraceSource
+    UsageInfo = control_package.UsageInfo
+
+    sdk = Sdk(name="autoctx", version="0.1.0")
+    source = TraceSource(emitter="gateway", sdk=sdk, hostname="box-1")
+    provider = Provider(name="anthropic", endpoint="https://api.anthropic.com", providerVersion="2026-04")
+    env = EnvContext(
+        environmentTag="prod",
+        appId="support-bot",
+        taskType="triage",
+        deploymentMeta={"region": "us-east-1"},
+    )
+    session = SessionIdentifier(
+        userIdHash="a" * 64,
+        sessionIdHash="b" * 64,
+        requestId="req-1",
+    )
+    message = Message(
+        role="user",
+        content="help me with a refund",
+        timestamp="2026-04-25T00:00:00Z",
+        toolCalls=[Items(toolName="kb.search", args={"query": "refund"}, durationMs=12.0)],
+        metadata={"lang": "en"},
+    )
+    tool_call = ToolCall(
+        toolName="kb.search",
+        args={"query": "refund"},
+        result={"hits": 1},
+        durationMs=12.0,
+    )
+    outcome = ProductionOutcome(
+        label="success",
+        score=0.9,
+        reasoning="resolved",
+        signals={"accuracy": 0.9},
+        error=Error(type="none", message="no error"),
+    )
+    timing = TimingInfo(
+        startedAt="2026-04-25T00:00:00Z",
+        endedAt="2026-04-25T00:00:01Z",
+        latencyMs=1000.0,
+    )
+    usage = UsageInfo(tokensIn=10, tokensOut=5, estimatedCostUsd=0.01)
+    feedback = FeedbackRef(
+        kind="rating",
+        submittedAt="2026-04-25T00:00:02Z",
+        ref="feedback-1",
+        score=0.9,
+        comment="great help",
+    )
+    links = TraceLinks(
+        scenarioId="grid_ctf",
+        runId="run-1",
+        evalExampleIds=["eval-1"],
+        trainingRecordIds=["train-1"],
+    )
+    redaction = RedactionMarker(
+        path="messages[0].content",
+        reason="pii-name",
+        detectedBy="operator",
+        detectedAt="2026-04-25T00:00:03Z",
+    )
+    routing = Routing(
+        chosen=Chosen(
+            provider="anthropic",
+            model="claude-sonnet",
+            endpoint="https://api.anthropic.com",
+        ),
+        matchedRouteId="route-1",
+        reason="matched-route",
+        evaluatedAt="2026-04-25T00:00:04Z",
+    )
+
+    trace = ProductionTrace(
+        schemaVersion="1.0",
+        traceId="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        source=source,
+        provider=provider,
+        model="claude-sonnet",
+        session=session,
+        env=env,
+        messages=[message],
+        toolCalls=[tool_call],
+        outcome=outcome,
+        timing=timing,
+        usage=usage,
+        feedbackRefs=[feedback],
+        links=links,
+        redactions=[redaction],
+        routing=routing,
+        metadata={"run": "r1"},
+    )
+    recreated_trace = ProductionTrace.model_validate(trace.model_dump())
+
+    assert trace.model == "claude-sonnet"
+    assert trace.source.sdk.name == "autoctx"
+    assert trace.messages[0].toolCalls[0].toolName == "kb.search"
+    assert trace.feedbackRefs[0].ref == "feedback-1"
+    assert recreated_trace.routing.reason == "matched-route"
+    assert EndedAt.model_validate(trace.messages[0].timestamp).root.isoformat().startswith("2026-04-25")

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -47,7 +47,11 @@
 			"blockedDependencies": [
 				"autocontext"
 			],
-			"allowedImports": []
+			"allowedImports": [
+				"autocontext.production_traces.contract.models",
+				"autocontext.research.types",
+				"autocontext.research.consultation"
+			]
 		}
 	},
 	"typescript": {
@@ -87,7 +91,12 @@
 			"packagePath": "packages/ts/control-plane",
 			"tsconfigPath": "packages/ts/control-plane/tsconfig.json",
 			"exactIncludes": [
-				"src/index.ts"
+				"src/index.ts",
+				"../../../ts/src/production-traces/contract/types.ts",
+				"../../../ts/src/production-traces/contract/branded-ids.ts",
+				"../../../ts/src/control-plane/contract/branded-ids.ts",
+				"../../../ts/src/research/types.ts",
+				"../../../ts/src/research/consultation.ts"
 			],
 			"blockedPackageDependencies": [
 				"autoctx"

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -1,4 +1,82 @@
-"""Package skeleton for the future autocontext control-plane artifact."""
+"""Facade for the future autocontext control-plane artifact."""
+
+from importlib import import_module
+from typing import Any
+
+_production_traces_contract = import_module(
+    "autocontext.production_traces.contract.models"
+)
+_research_types = import_module("autocontext.research.types")
+_research_consultation = import_module("autocontext.research.consultation")
+
+Urgency: Any = _research_types.Urgency
+ResearchQuery: Any = _research_types.ResearchQuery
+Citation: Any = _research_types.Citation
+ResearchResult: Any = _research_types.ResearchResult
+ResearchAdapter: Any = _research_types.ResearchAdapter
+ResearchConfig: Any = _research_types.ResearchConfig
+ResearchBrief: Any = _research_consultation.ResearchBrief
+Sdk: Any = _production_traces_contract.Sdk
+TraceSource: Any = _production_traces_contract.TraceSource
+Provider: Any = _production_traces_contract.Provider
+EnvContext: Any = _production_traces_contract.EnvContext
+ToolCall: Any = _production_traces_contract.ToolCall
+Error: Any = _production_traces_contract.Error
+ProductionOutcome: Any = _production_traces_contract.ProductionOutcome
+UsageInfo: Any = _production_traces_contract.UsageInfo
+EvalExampleId: Any = _production_traces_contract.EvalExampleId
+TrainingRecordId: Any = _production_traces_contract.TrainingRecordId
+TraceLinks: Any = _production_traces_contract.TraceLinks
+Chosen: Any = _production_traces_contract.Chosen
+Routing: Any = _production_traces_contract.Routing
+UserIdHash: Any = _production_traces_contract.UserIdHash
+EndedAt: Any = _production_traces_contract.EndedAt
+Items: Any = _production_traces_contract.Items
+SessionIdentifier: Any = _production_traces_contract.SessionIdentifier
+Message: Any = _production_traces_contract.Message
+TimingInfo: Any = _production_traces_contract.TimingInfo
+FeedbackRef: Any = _production_traces_contract.FeedbackRef
+RedactionMarker: Any = _production_traces_contract.RedactionMarker
+ProductionTrace: Any = _production_traces_contract.ProductionTrace
 
 PACKAGE_ROLE = "control"
 PACKAGE_TOPOLOGY_VERSION = 1
+
+package_role = PACKAGE_ROLE
+package_topology_version = PACKAGE_TOPOLOGY_VERSION
+
+__all__ = [
+    "Chosen",
+    "Citation",
+    "EndedAt",
+    "EnvContext",
+    "Error",
+    "EvalExampleId",
+    "FeedbackRef",
+    "Items",
+    "Message",
+    "PACKAGE_ROLE",
+    "PACKAGE_TOPOLOGY_VERSION",
+    "ProductionOutcome",
+    "ProductionTrace",
+    "Provider",
+    "RedactionMarker",
+    "ResearchAdapter",
+    "ResearchBrief",
+    "ResearchConfig",
+    "ResearchQuery",
+    "ResearchResult",
+    "Routing",
+    "Sdk",
+    "SessionIdentifier",
+    "TimingInfo",
+    "ToolCall",
+    "TraceLinks",
+    "TraceSource",
+    "TrainingRecordId",
+    "Urgency",
+    "UsageInfo",
+    "UserIdHash",
+    "package_role",
+    "package_topology_version",
+]

--- a/packages/ts/control-plane/package.json
+++ b/packages/ts/control-plane/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "description": "Internal package skeleton for the future control-plane artifact.",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/packages/ts/control-plane/src/index.js",
+  "types": "dist/packages/ts/control-plane/src/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/packages/ts/control-plane/src/index.js",
+      "types": "./dist/packages/ts/control-plane/src/index.d.ts"
     }
   },
   "files": [

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -1,2 +1,49 @@
 export const packageRole = "control";
 export const packageTopologyVersion = 1;
+
+export type {
+  AppId,
+  ContentHash,
+  EnvironmentTag,
+  FeedbackRefId,
+  ProductionTraceId,
+  Scenario,
+  SessionIdHash,
+  UserIdHash,
+} from "../../../../ts/src/production-traces/contract/branded-ids.js";
+export type {
+  DetectedBy,
+  EnvContext,
+  FeedbackKind,
+  FeedbackRef,
+  MessageRole,
+  ModelRoutingDecisionReason,
+  ModelRoutingFallbackReason,
+  OutcomeLabel,
+  ProductionOutcome,
+  ProductionTrace,
+  ProductionTraceRouting,
+  ProductionTraceSchemaVersion,
+  ProviderInfo,
+  ProviderName,
+  RedactionMarker,
+  RedactionReason,
+  SessionIdentifier,
+  TimingInfo,
+  ToolCall,
+  TraceLinks,
+  TraceMessage,
+  TraceSource,
+  UsageInfo,
+  ValidationResult,
+} from "../../../../ts/src/production-traces/contract/types.js";
+export { PRODUCTION_TRACE_SCHEMA_VERSION } from "../../../../ts/src/production-traces/contract/types.js";
+export { ResearchBrief } from "../../../../ts/src/research/consultation.js";
+export type { ResearchAdapter } from "../../../../ts/src/research/types.js";
+export {
+  Citation,
+  ResearchConfig,
+  ResearchQuery,
+  ResearchResult,
+  Urgency,
+} from "../../../../ts/src/research/types.js";

--- a/packages/ts/control-plane/tsconfig.json
+++ b/packages/ts/control-plane/tsconfig.json
@@ -1,9 +1,18 @@
 {
   "extends": "../../../ts/tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src",
+    "rootDir": "../../..",
     "outDir": "./dist",
-    "noEmit": false
+    "noEmit": false,
+    "types": ["node"],
+    "typeRoots": ["../../../ts/node_modules/@types"]
   },
-  "include": ["src/index.ts"]
+  "include": [
+    "src/index.ts",
+    "../../../ts/src/production-traces/contract/types.ts",
+    "../../../ts/src/production-traces/contract/branded-ids.ts",
+    "../../../ts/src/control-plane/contract/branded-ids.ts",
+    "../../../ts/src/research/types.ts",
+    "../../../ts/src/research/consultation.ts"
+  ]
 }

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AppId,
+  EnvironmentTag,
+  FeedbackRef,
+  FeedbackRefId,
+  ProductionTrace,
+  ProductionTraceId,
+  ProviderInfo,
+  ResearchAdapter,
+  Scenario,
+  SessionIdHash,
+  TraceSource,
+  UserIdHash,
+} from "../../packages/ts/control-plane/src/index.ts";
+import {
+  Citation,
+  PRODUCTION_TRACE_SCHEMA_VERSION,
+  packageRole,
+  packageTopologyVersion,
+  ResearchBrief,
+  ResearchConfig,
+  ResearchQuery,
+  ResearchResult,
+  Urgency,
+} from "../../packages/ts/control-plane/src/index.ts";
+
+describe("@autocontext/control-plane facade", () => {
+  it("preserves the control package identity", () => {
+    expect(packageRole).toBe("control");
+    expect(packageTopologyVersion).toBe(1);
+  });
+
+  it("re-exports research domain contracts", () => {
+    const urgency = Urgency.HIGH;
+    const query = new ResearchQuery({
+      topic: "refund policy changes",
+      context: "customer support escalation",
+      urgency,
+      maxResults: 3,
+      constraints: ["cite primary sources"],
+      scenarioFamily: "agent_task",
+      metadata: { ticket: "t-1" },
+    });
+    const citation = new Citation({
+      source: "policy handbook",
+      url: "https://example.com/policy",
+      relevance: 0.95,
+      snippet: "Refunds require manager sign-off after 30 days.",
+      retrievedAt: "2026-04-25T00:00:00Z",
+    });
+    const adapter: ResearchAdapter = {
+      search(input: ResearchQuery): ResearchResult {
+        return new ResearchResult({
+          queryTopic: input.topic,
+          summary: "Manager sign-off required after 30 days.",
+          citations: [citation],
+          confidence: 0.91,
+          metadata: { adapter: "demo" },
+        });
+      },
+    };
+    const result = adapter.search(query);
+    const config = new ResearchConfig({
+      enabled: true,
+      adapterName: "demo",
+      maxQueriesPerTurn: 1,
+    });
+
+    expect(query.urgency).toBe(Urgency.HIGH);
+    expect(query.constraints).toEqual(["cite primary sources"]);
+    expect(result.hasCitations).toBe(true);
+    expect(result.citations[0]?.source).toBe("policy handbook");
+    expect(result.metadata).toMatchObject({ adapter: "demo" });
+    expect(config.enabled).toBe(true);
+    expect(config.adapterName).toBe("demo");
+    expect(config.maxQueriesPerTurn).toBe(1);
+  });
+
+  it("re-exports research brief values", () => {
+    const citation = new Citation({
+      source: "policy handbook",
+      url: "https://example.com/policy",
+      relevance: 0.95,
+      snippet: "Refunds require manager sign-off after 30 days.",
+      retrievedAt: "2026-04-25T00:00:00Z",
+    });
+    const strongResult = new ResearchResult({
+      queryTopic: "refund policy",
+      summary: "Manager sign-off required after 30 days.",
+      citations: [citation],
+      confidence: 0.91,
+      metadata: { adapter: "demo" },
+    });
+    const weakResult = new ResearchResult({
+      queryTopic: "escalation policy",
+      summary: "Escalate unusual refund cases.",
+      citations: [citation],
+      confidence: 0.42,
+      metadata: { adapter: "demo" },
+    });
+    const brief = ResearchBrief.fromResults(
+      "Summarize refund policy changes",
+      [strongResult, weakResult],
+      0.9,
+    );
+
+    expect(brief.goal).toBe("Summarize refund policy changes");
+    expect(brief.findings).toHaveLength(1);
+    expect(brief.findings[0]?.queryTopic).toBe("refund policy");
+    expect(brief.uniqueCitations).toHaveLength(1);
+    expect(brief.uniqueCitations[0]?.source).toBe("policy handbook");
+    expect(brief.avgConfidence).toBe(0.91);
+    expect(brief.toMarkdown()).toContain(
+      "Research Brief: Summarize refund policy changes",
+    );
+  });
+
+  it("re-exports production trace contract types", () => {
+    const source: TraceSource = {
+      emitter: "gateway",
+      sdk: { name: "autoctx", version: "0.1.0" },
+      hostname: "box-1",
+    };
+    const provider: ProviderInfo = {
+      name: "anthropic",
+      endpoint: "https://api.anthropic.com",
+      providerVersion: "2026-04",
+    };
+    const feedback: FeedbackRef = {
+      kind: "rating",
+      submittedAt: "2026-04-25T00:00:02Z",
+      ref: "feedback-1" as FeedbackRefId,
+      score: 0.9,
+      comment: "great help",
+    };
+    const trace: ProductionTrace = {
+      schemaVersion: PRODUCTION_TRACE_SCHEMA_VERSION,
+      traceId: "01ARZ3NDEKTSV4RRFFQ69G5FAV" as ProductionTraceId,
+      source,
+      provider,
+      model: "claude-sonnet",
+      session: {
+        userIdHash: "a".repeat(64) as UserIdHash,
+        sessionIdHash: "b".repeat(64) as SessionIdHash,
+        requestId: "req-1",
+      },
+      env: {
+        environmentTag: "prod" as EnvironmentTag,
+        appId: "support-bot" as AppId,
+        taskType: "triage",
+        deploymentMeta: { region: "us-east-1" },
+      },
+      messages: [
+        {
+          role: "user",
+          content: "help me with a refund",
+          timestamp: "2026-04-25T00:00:00Z",
+          toolCalls: [
+            {
+              toolName: "kb.search",
+              args: { query: "refund" },
+              durationMs: 12,
+            },
+          ],
+          metadata: { lang: "en" },
+        },
+      ],
+      toolCalls: [
+        {
+          toolName: "kb.search",
+          args: { query: "refund" },
+          result: { hits: 1 },
+        },
+      ],
+      outcome: {
+        label: "success",
+        score: 0.9,
+        reasoning: "resolved",
+        signals: { accuracy: 0.9 },
+        error: { type: "none", message: "no error" },
+      },
+      timing: {
+        startedAt: "2026-04-25T00:00:00Z",
+        endedAt: "2026-04-25T00:00:01Z",
+        latencyMs: 1000,
+      },
+      usage: {
+        tokensIn: 10,
+        tokensOut: 5,
+        estimatedCostUsd: 0.01,
+      },
+      feedbackRefs: [feedback],
+      links: {
+        scenarioId: "grid_ctf" as Scenario,
+        runId: "run-1",
+        evalExampleIds: ["eval-1"],
+        trainingRecordIds: ["train-1"],
+      },
+      redactions: [
+        {
+          path: "messages[0].content",
+          reason: "pii-name",
+          detectedBy: "operator",
+          detectedAt: "2026-04-25T00:00:03Z",
+        },
+      ],
+      routing: {
+        chosen: {
+          provider: "anthropic",
+          model: "claude-sonnet",
+          endpoint: "https://api.anthropic.com",
+        },
+        matchedRouteId: "route-1",
+        reason: "matched-route",
+        evaluatedAt: "2026-04-25T00:00:04Z",
+      },
+      metadata: { run: "r1" },
+    };
+
+    expect(trace.schemaVersion).toBe("1.0");
+    expect(trace.source.sdk.name).toBe("autoctx");
+    expect(trace.messages[0]?.toolCalls?.[0]?.toolName).toBe("kb.search");
+    expect(trace.feedbackRefs[0]?.ref).toBe("feedback-1");
+    expect(trace.routing?.reason).toBe("matched-route");
+  });
+});


### PR DESCRIPTION
Consolidates the production trace, research contract, and research brief facade exports from the former one-symbol PRs. Tests: uv run ruff check tests/test_python_control_package.py ../packages/python/control/src/autocontext_control/__init__.py; uv run mypy ../packages/python/control/src/autocontext_control/__init__.py; uv run pytest tests/test_python_control_package.py; npx vitest run tests/control-plane-package.test.ts tests/package-topology.test.ts; ./node_modules/.bin/tsc -p ../packages/ts/control-plane/tsconfig.json --pretty false.