### PR TITLE
AC-650 Batch control domain value facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -252,6 +252,94 @@ def test_python_control_reexports_monitor_alert_messages() -> None:
     assert alert.detail == "No events for 30.0s (timeout=30.0s)"
 
 
+def test_python_control_reexports_monitor_domain_value_objects() -> None:
+    ConditionType = control_package.ConditionType
+    MonitorAlert = control_package.MonitorAlert
+    MonitorCondition = control_package.MonitorCondition
+
+    condition = MonitorCondition(
+        id="cond-1",
+        name="stall-window",
+        condition_type=ConditionType.STALL_WINDOW,
+        params={"window": 3},
+        scope="run:run-123",
+        created_at="2026-04-25T00:00:00Z",
+    )
+    alert = MonitorAlert(
+        id="alert-1",
+        condition_id=condition.id,
+        condition_name=condition.name,
+        condition_type=condition.condition_type,
+        scope=condition.scope,
+        detail="3 consecutive rollbacks",
+        fired_at="2026-04-25T00:01:00Z",
+        payload={"window": 3},
+    )
+
+    assert ConditionType.STALL_WINDOW == "stall_window"
+    assert condition.condition_type is ConditionType.STALL_WINDOW
+    assert condition.params == {"window": 3}
+    assert alert.condition_type is ConditionType.STALL_WINDOW
+    assert alert.detail == "3 consecutive rollbacks"
+    assert alert.payload == {"window": 3}
+
+
+def test_python_control_reexports_agent_contract_dataclasses() -> None:
+    AnalystOutput = control_package.AnalystOutput
+    ArchitectOutput = control_package.ArchitectOutput
+    CoachOutput = control_package.CoachOutput
+    CompetitorOutput = control_package.CompetitorOutput
+
+    competitor = CompetitorOutput(
+        raw_text="Use beam search.",
+        strategy={"approach": "beam-search"},
+        reasoning="It keeps more candidate programs alive.",
+        is_code_strategy=True,
+    )
+    analyst = AnalystOutput(
+        raw_markdown="# Findings",
+        findings=["plateau detected"],
+        root_causes=["search space too narrow"],
+        recommendations=["increase branching"],
+    )
+    coach = CoachOutput(
+        raw_markdown="# Coaching",
+        playbook="Try wider exploration.",
+        lessons="Diversity matters.",
+        hints="Look for alternate decompositions.",
+    )
+    architect = ArchitectOutput(
+        raw_markdown="# Architecture",
+        tool_specs=[{"name": "scratchpad"}],
+        harness_specs=[{"id": "h1"}],
+        changelog_entry="Added scratchpad tool.",
+    )
+
+    assert competitor.is_code_strategy is True
+    assert competitor.strategy == {"approach": "beam-search"}
+    assert analyst.findings == ["plateau detected"]
+    assert analyst.root_causes == ["search space too narrow"]
+    assert coach.playbook == "Try wider exploration."
+    assert coach.hints == "Look for alternate decompositions."
+    assert architect.tool_specs == [{"name": "scratchpad"}]
+    assert architect.harness_specs == [{"id": "h1"}]
+    assert architect.changelog_entry == "Added scratchpad tool."
+
+
+def test_python_control_reexports_stagnation_report() -> None:
+    StagnationReport = control_package.StagnationReport
+
+    report = StagnationReport(
+        is_stagnated=True,
+        trigger="score_plateau",
+        detail="score variance 0.000001 < epsilon 0.01 over last 5 gens",
+    )
+
+    assert report.is_stagnated is True
+    assert report.trigger == "score_plateau"
+    assert report.detail == "score variance 0.000001 < epsilon 0.01 over last 5 gens"
+
+
 def test_python_control_reexports_basic_client_control_commands() -> None:
     InjectHintCmd = control_package.InjectHintCmd
     OverrideGateCmd = control_package.OverrideGateCmd

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -85,7 +85,10 @@
 				"autocontext.production_traces.contract.models",
 				"autocontext.research.types",
 				"autocontext.research.consultation",
-				"autocontext.server.protocol"
+				"autocontext.server.protocol",
+				"autocontext.monitor.types",
+				"autocontext.agents.contracts",
+				"autocontext.knowledge.stagnation"
 			]
 		}
 	},
@@ -132,7 +135,8 @@
 				"../../../ts/src/control-plane/contract/branded-ids.ts",
 				"../../../ts/src/research/types.ts",
 				"../../../ts/src/research/consultation.ts",
-				"../../../ts/src/server/protocol.ts"
+				"../../../ts/src/server/protocol.ts",
+				"../../../ts/src/loop/stagnation.ts"
 			],
 			"blockedPackageDependencies": [
 				"autoctx"

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -9,6 +9,9 @@ _production_traces_contract = import_module(
 _research_types = import_module("autocontext.research.types")
 _research_consultation = import_module("autocontext.research.consultation")
 _server_protocol = import_module("autocontext.server.protocol")
+_monitor_types = import_module("autocontext.monitor.types")
+_agent_contracts = import_module("autocontext.agents.contracts")
+_stagnation = import_module("autocontext.knowledge.stagnation")
 
 PROTOCOL_VERSION = _server_protocol.PROTOCOL_VERSION
 ScenarioInfo: Any = _server_protocol.ScenarioInfo
@@ -25,6 +28,9 @@ AckMsg: Any = _server_protocol.AckMsg
 RunAcceptedMsg: Any = _server_protocol.RunAcceptedMsg
 ErrorMsg: Any = _server_protocol.ErrorMsg
 MonitorAlertMsg: Any = _server_protocol.MonitorAlertMsg
+ConditionType: Any = _monitor_types.ConditionType
+MonitorCondition: Any = _monitor_types.MonitorCondition
+MonitorAlert: Any = _monitor_types.MonitorAlert
 ScenarioGeneratingMsg: Any = _server_protocol.ScenarioGeneratingMsg
 ScenarioPreviewMsg: Any = _server_protocol.ScenarioPreviewMsg
 ScenarioReadyMsg: Any = _server_protocol.ScenarioReadyMsg
@@ -41,6 +47,11 @@ CancelScenarioCmd: Any = _server_protocol.CancelScenarioCmd
 StartRunCmd: Any = _server_protocol.StartRunCmd
 ListScenariosCmd: Any = _server_protocol.ListScenariosCmd
 Urgency: Any = _research_types.Urgency
+CompetitorOutput: Any = _agent_contracts.CompetitorOutput
+AnalystOutput: Any = _agent_contracts.AnalystOutput
+CoachOutput: Any = _agent_contracts.CoachOutput
+ArchitectOutput: Any = _agent_contracts.ArchitectOutput
+StagnationReport: Any = _stagnation.StagnationReport
 ResearchQuery: Any = _research_types.ResearchQuery
 Citation: Any = _research_types.Citation
 ResearchResult: Any = _research_types.ResearchResult
@@ -77,11 +88,15 @@ package_role = PACKAGE_ROLE
 package_topology_version = PACKAGE_TOPOLOGY_VERSION
 
 __all__ = [
+    "AnalystOutput",
+    "ArchitectOutput",
     "ChatResponseMsg",
     "Chosen",
     "Citation",
     "CancelScenarioCmd",
     "ChatAgentCmd",
+    "CoachOutput",
+    "ConditionType",
     "ConfirmScenarioCmd",
     "CreateScenarioCmd",
     "EndedAt",
@@ -91,7 +106,9 @@ __all__ = [
     "AckMsg",
     "Error",
     "ErrorMsg",
+    "MonitorAlert",
     "MonitorAlertMsg",
+    "MonitorCondition",
     "EvalExampleId",
     "ExecutorInfo",
     "ExecutorResources",
@@ -108,6 +125,7 @@ __all__ = [
     "ProductionOutcome",
     "ProductionTrace",
     "Provider",
+    "CompetitorOutput",
     "RunAcceptedMsg",
     "RedactionMarker",
     "ResearchAdapter",
@@ -128,6 +146,7 @@ __all__ = [
     "ScoringComponent",
     "Sdk",
     "SessionIdentifier",
+    "StagnationReport",
     "StateMsg",
     "StrategyParam",
     "TimingInfo",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -1,6 +1,7 @@
 export const packageRole = "control";
 export const packageTopologyVersion = 1;
 
+export type { StagnationReport } from "../../../../ts/src/loop/stagnation.js";
 export type {
 	AppId,
 	ContentHash,

--- a/packages/ts/control-plane/tsconfig.json
+++ b/packages/ts/control-plane/tsconfig.json
@@ -14,6 +14,7 @@
     "../../../ts/src/control-plane/contract/branded-ids.ts",
     "../../../ts/src/research/types.ts",
     "../../../ts/src/research/consultation.ts",
-    "../../../ts/src/server/protocol.ts"
+    "../../../ts/src/server/protocol.ts",
+    "../../../ts/src/loop/stagnation.ts"
   ]
 }

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -10,6 +10,7 @@ import type {
 	ResearchAdapter,
 	Scenario,
 	SessionIdHash,
+	StagnationReport,
 	TraceSource,
 	UserIdHash,
 } from "../../packages/ts/control-plane/src/index.ts";
@@ -324,6 +325,20 @@ describe("@autocontext/control-plane facade", () => {
 		expect(progress.latestStep).toBe("evaluate candidate");
 		expect(progress.budgetUsed).toBe(1.25);
 		expect(progress.budgetMax).toBe(5);
+	});
+
+	it("re-exports stagnation report types", () => {
+		const report: StagnationReport = {
+			isStagnated: true,
+			trigger: "score_plateau",
+			detail: "score stddev 0.000001 < epsilon 0.01 over last 5 gens",
+		};
+
+		expect(report.isStagnated).toBe(true);
+		expect(report.trigger).toBe("score_plateau");
+		expect(report.detail).toBe(
+			"score stddev 0.000001 < epsilon 0.01 over last 5 gens",
+		);
 	});
 
 	it("re-exports basic client control commands", () => {


### PR DESCRIPTION
Consolidates monitor domain values, agent contract dataclasses, and stagnation report facade exports, stacked after the protocol facade batch. Tests: uv run ruff check tests/test_python_control_package.py ../packages/python/control/src/autocontext_control/__init__.py; uv run mypy ../packages/python/control/src/autocontext_control/__init__.py; uv run pytest tests/test_python_control_package.py; npx vitest run tests/control-plane-package.test.ts tests/package-topology.test.ts; ./node_modules/.bin/tsc -p ../packages/ts/control-plane/tsconfig.json --pretty false.