### PR TITLE
AC-650 Enforce core/control package boundaries in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,37 @@ jobs:
           path: autocontext/htmlcov/
           retention-days: 14
 
+  package-boundaries:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: ts/package-lock.json
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Install Python deps
+        working-directory: autocontext
+        run: uv sync --group dev
+      - name: Install TypeScript deps
+        working-directory: ts
+        run: npm ci
+      - name: Python package boundary checks
+        working-directory: autocontext
+        run: uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q
+      - name: TypeScript package boundary checks
+        working-directory: ts
+        run: npx vitest run tests/package-topology.test.ts tests/package-boundaries.test.ts
+
   smoke:
-    needs: [lint, test]
+    needs: [lint, test, package-boundaries]
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/autocontext/tests/test_package_boundaries.py
+++ b/autocontext/tests/test_package_boundaries.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import tomllib
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOUNDARIES_PATH = REPO_ROOT / "packages" / "package-boundaries.json"
+TOPOLOGY_PATH = REPO_ROOT / "packages" / "package-topology.json"
+CORE_INIT_PATH = REPO_ROOT / "packages" / "python" / "core" / "src" / "autocontext_core" / "__init__.py"
+CONTROL_INIT_PATH = (
+    REPO_ROOT
+    / "packages"
+    / "python"
+    / "control"
+    / "src"
+    / "autocontext_control"
+    / "__init__.py"
+)
+
+
+def _load_boundaries() -> dict[str, object]:
+    return json.loads(BOUNDARIES_PATH.read_text(encoding="utf-8"))
+
+
+def _load_topology() -> dict[str, object]:
+    return json.loads(TOPOLOGY_PATH.read_text(encoding="utf-8"))
+
+
+def _load_pyproject(path: Path) -> dict[str, object]:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def _python_import_targets(path: Path) -> list[str]:
+    targets: list[str] = []
+    module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+    class ImportModuleVisitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:
+            if (
+                isinstance(node.func, ast.Name)
+                and node.func.id == "import_module"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                targets.append(node.args[0].value)
+            self.generic_visit(node)
+
+    ImportModuleVisitor().visit(module)
+    return targets
+
+
+def _python_core_import_targets() -> list[str]:
+    return _python_import_targets(CORE_INIT_PATH)
+
+
+def _python_control_import_targets() -> list[str]:
+    return _python_import_targets(CONTROL_INIT_PATH)
+
+
+def _dependency_name(requirement: object) -> str:
+    return (
+        str(requirement)
+        .split(";", 1)[0]
+        .split("[", 1)[0]
+        .split("<", 1)[0]
+        .split(">", 1)[0]
+        .split("=", 1)[0]
+        .split("~", 1)[0]
+        .split("!", 1)[0]
+        .strip()
+    )
+
+
+def test_package_boundaries_manifest_exists() -> None:
+    assert BOUNDARIES_PATH.exists()
+
+
+def test_python_boundary_contract_reuses_topology_core_module() -> None:
+    boundaries = _load_boundaries()
+    topology = _load_topology()
+    python_boundaries = boundaries["python"]
+    python_topology = topology["python"]
+    assert isinstance(python_boundaries, dict)
+    assert isinstance(python_topology, dict)
+    core_boundary = python_boundaries["core"]
+    core_topology = python_topology["core"]
+    assert isinstance(core_boundary, dict)
+    assert isinstance(core_topology, dict)
+
+    assert core_boundary["module"] == core_topology["module"]
+
+
+def test_python_core_facade_imports_match_boundary_contract() -> None:
+    boundaries = _load_boundaries()
+    python_boundaries = boundaries["python"]
+    assert isinstance(python_boundaries, dict)
+    core = python_boundaries["core"]
+    assert isinstance(core, dict)
+    allowed_imports = core["allowedImports"]
+    assert isinstance(allowed_imports, list)
+
+    assert _python_core_import_targets() == allowed_imports
+
+
+def test_python_core_facade_excludes_control_plane_imports() -> None:
+    boundaries = _load_boundaries()
+    python_boundaries = boundaries["python"]
+    assert isinstance(python_boundaries, dict)
+    core = python_boundaries["core"]
+    assert isinstance(core, dict)
+    blocked_prefixes = core["blockedImportPrefixes"]
+    assert isinstance(blocked_prefixes, list)
+
+    import_targets = _python_core_import_targets()
+    for target in import_targets:
+        for prefix in blocked_prefixes:
+            assert isinstance(prefix, str)
+            assert target != prefix
+            assert not target.startswith(f"{prefix}.")
+
+
+def test_python_core_package_dependencies_point_away_from_control_and_umbrella_packages() -> None:
+    boundaries = _load_boundaries()
+    python_boundaries = boundaries["python"]
+    assert isinstance(python_boundaries, dict)
+    core = python_boundaries["core"]
+    assert isinstance(core, dict)
+    blocked_dependencies = core["blockedDependencies"]
+    assert blocked_dependencies == ["autocontext", "autocontext-control"]
+
+    pyproject = _load_pyproject(REPO_ROOT / "packages" / "python" / "core" / "pyproject.toml")
+    project = pyproject["project"]
+    assert isinstance(project, dict)
+    dependency_names = {_dependency_name(dependency) for dependency in project.get("dependencies", [])}
+    optional_dependencies = project.get("optional-dependencies", {})
+    assert isinstance(optional_dependencies, dict)
+    for group_dependencies in optional_dependencies.values():
+        assert isinstance(group_dependencies, list)
+        dependency_names.update(_dependency_name(dependency) for dependency in group_dependencies)
+
+    for dependency in blocked_dependencies:
+        assert dependency not in dependency_names
+
+
+def test_python_control_boundary_contract_reuses_topology_control_module() -> None:
+    boundaries = _load_boundaries()
+    topology = _load_topology()
+    python_boundaries = boundaries["python"]
+    python_topology = topology["python"]
+    assert isinstance(python_boundaries, dict)
+    assert isinstance(python_topology, dict)
+    control_boundary = python_boundaries["control"]
+    control_topology = python_topology["control"]
+    assert isinstance(control_boundary, dict)
+    assert isinstance(control_topology, dict)
+
+    assert control_boundary["module"] == control_topology["module"]
+
+
+def test_python_control_facade_imports_match_boundary_contract() -> None:
+    boundaries = _load_boundaries()
+    python_boundaries = boundaries["python"]
+    assert isinstance(python_boundaries, dict)
+    control = python_boundaries["control"]
+    assert isinstance(control, dict)
+    allowed_imports = control["allowedImports"]
+    assert isinstance(allowed_imports, list)
+
+    assert _python_control_import_targets() == allowed_imports
+
+
+def test_python_control_package_dependencies_point_away_from_umbrella_package() -> None:
+    boundaries = _load_boundaries()
+    python_boundaries = boundaries["python"]
+    assert isinstance(python_boundaries, dict)
+    control = python_boundaries["control"]
+    assert isinstance(control, dict)
+    blocked_dependencies = control["blockedDependencies"]
+    assert blocked_dependencies == ["autocontext"]
+
+    pyproject = _load_pyproject(REPO_ROOT / "packages" / "python" / "control" / "pyproject.toml")
+    project = pyproject["project"]
+    assert isinstance(project, dict)
+    dependency_names = {_dependency_name(dependency) for dependency in project.get("dependencies", [])}
+    optional_dependencies = project.get("optional-dependencies", {})
+    assert isinstance(optional_dependencies, dict)
+    for group_dependencies in optional_dependencies.values():
+        assert isinstance(group_dependencies, list)
+        dependency_names.update(_dependency_name(dependency) for dependency in group_dependencies)
+
+    for dependency in blocked_dependencies:
+        assert dependency not in dependency_names
+
+
+def test_python_package_builds_emit_wheel_and_sdist() -> None:
+    packages = [
+        REPO_ROOT / "packages" / "python" / "core",
+        REPO_ROOT / "packages" / "python" / "control",
+    ]
+
+    for package_dir in packages:
+        pyproject = _load_pyproject(package_dir / "pyproject.toml")
+        project = pyproject["project"]
+        assert isinstance(project, dict)
+        project_name = str(project["name"])
+        normalized_name = project_name.replace("-", "_")
+
+        with TemporaryDirectory(prefix=f"{normalized_name}-dist-") as tmpdir:
+            out_dir = Path(tmpdir)
+            subprocess.run(
+                ["uv", "build", str(package_dir), "-o", str(out_dir)],
+                check=True,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            wheel = next(out_dir.glob(f"{normalized_name}-*.whl"), None)
+            sdist = next(out_dir.glob(f"{normalized_name}-*.tar.gz"), None)
+            assert wheel is not None
+            assert sdist is not None
+
+            module_dir = package_dir / "src"
+            package_modules = [path.name for path in module_dir.iterdir() if path.is_dir()]
+            with zipfile.ZipFile(wheel) as wheel_zip:
+                wheel_names = set(wheel_zip.namelist())
+            for module in package_modules:
+                assert f"{module}/__init__.py" in wheel_names

--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -39,13 +39,16 @@ layout must make the licensing model true before the repo advertises it.
 ## Package Topology
 
 The machine-readable topology map lives in
-[`packages/package-topology.json`](../packages/package-topology.json).
+[`packages/package-topology.json`](../packages/package-topology.json). The
+machine-readable boundary-enforcement contract lives in
+[`packages/package-boundaries.json`](../packages/package-boundaries.json) and is
+checked in CI.
 
-| Ecosystem | Umbrella package | Apache core artifact | Control-plane artifact |
-| --- | --- | --- | --- |
-| Python | `autocontext` | `autocontext-core` | `autocontext-control` |
-| TypeScript | `autoctx` | `@autocontext/core` | `@autocontext/control-plane` |
-| Pi | `pi-autocontext` initially depends on `autoctx` | Deferred | Deferred |
+| Ecosystem  | Umbrella package                                | Apache core artifact | Control-plane artifact       |
+| ---------- | ----------------------------------------------- | -------------------- | ---------------------------- |
+| Python     | `autocontext`                                   | `autocontext-core`   | `autocontext-control`        |
+| TypeScript | `autoctx`                                       | `@autocontext/core`  | `@autocontext/control-plane` |
+| Pi         | `pi-autocontext` initially depends on `autoctx` | Deferred             | Deferred                     |
 
 The umbrella packages preserve the default install and CLI experience. The new
 core/control artifacts make the future license boundary real at the artifact
@@ -213,8 +216,12 @@ Move to the control plane:
 ## Review Checks
 
 - Core package builds must not compile or ship control-plane-only code.
+- Core packages must not depend on control-plane artifacts or umbrella
+  compatibility packages.
 - Control-plane package builds may depend on core, but core must not depend on
   control-plane artifacts.
+- Control-plane package facades must update the boundary manifest when they add
+  source imports or TypeScript build includes.
 - Broad package globs should be treated suspiciously during the split; prefer
   exact includes until ownership is settled.
 - Any PR that changes existing protocol or payload semantics should say so

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -1,0 +1,97 @@
+{
+	"version": 1,
+	"python": {
+		"core": {
+			"module": "autocontext_core",
+			"blockedDependencies": [
+				"autocontext",
+				"autocontext-control"
+			],
+			"blockedImportPrefixes": [
+				"autocontext.cli",
+				"autocontext.consultation",
+				"autocontext.knowledge",
+				"autocontext.mcp",
+				"autocontext.monitor",
+				"autocontext.notebook",
+				"autocontext.openclaw",
+				"autocontext.production_traces",
+				"autocontext.research",
+				"autocontext.server",
+				"autocontext.sharing",
+				"autocontext.training"
+			],
+			"allowedImports": [
+				"autocontext.harness.scoring.elo",
+				"autocontext.prompts.context_budget",
+				"autocontext.prompts.templates",
+				"autocontext.providers.base",
+				"autocontext.execution.judge",
+				"autocontext.execution.rubric_coherence",
+				"autocontext.scenarios.agent_task",
+				"autocontext.scenarios.artifact_editing",
+				"autocontext.scenarios.base",
+				"autocontext.scenarios.coordination",
+				"autocontext.scenarios.investigation",
+				"autocontext.scenarios.negotiation",
+				"autocontext.scenarios.operator_loop",
+				"autocontext.scenarios.schema_evolution",
+				"autocontext.scenarios.simulation",
+				"autocontext.scenarios.tool_fragility",
+				"autocontext.scenarios.workflow",
+				"autocontext.storage.row_types"
+			]
+		},
+		"control": {
+			"module": "autocontext_control",
+			"blockedDependencies": [
+				"autocontext"
+			],
+			"allowedImports": []
+		}
+	},
+	"typescript": {
+		"core": {
+			"packagePath": "packages/ts/core",
+			"tsconfigPath": "packages/ts/core/tsconfig.json",
+			"exactIncludes": [
+				"src/index.ts",
+				"../../../ts/src/execution/elo.ts",
+				"../../../ts/src/judge/parse.ts",
+				"../../../ts/src/judge/rubric-coherence.ts",
+				"../../../ts/src/prompts/context-budget.ts",
+				"../../../ts/src/prompts/templates.ts",
+				"../../../ts/src/scenarios/game-interface.ts",
+				"../../../ts/src/scenarios/primary-family-interface-types.ts",
+				"../../../ts/src/scenarios/simulation-family-interface-types.ts",
+				"../../../ts/src/storage/storage-contracts.ts",
+				"../../../ts/src/types/index.ts"
+			],
+			"blockedProgramPathSubstrings": [
+				"/ts/src/control-plane/",
+				"/ts/src/production-traces/",
+				"/ts/src/research/",
+				"/ts/src/server/",
+				"/ts/src/loop/",
+				"/ts/src/config/",
+				"/ts/src/runtimes/",
+				"/ts/src/providers/",
+				"/ts/src/agents/"
+			],
+			"blockedPackageDependencies": [
+				"@autocontext/control-plane",
+				"autoctx"
+			]
+		},
+		"control": {
+			"packagePath": "packages/ts/control-plane",
+			"tsconfigPath": "packages/ts/control-plane/tsconfig.json",
+			"exactIncludes": [
+				"src/index.ts"
+			],
+			"blockedPackageDependencies": [
+				"autoctx"
+			]
+		}
+	}
+}

--- a/packages/ts/control-plane/tsconfig.json
+++ b/packages/ts/control-plane/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./dist",
     "noEmit": false
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/index.ts"]
 }

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -1,21 +1,21 @@
 {
-  "extends": "../../../ts/tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../../..",
-    "outDir": "./dist",
-    "noEmit": false
-  },
-  "include": [
-    "src/**/*.ts",
-    "../../../ts/src/execution/elo.ts",
-    "../../../ts/src/judge/parse.ts",
-    "../../../ts/src/judge/rubric-coherence.ts",
-    "../../../ts/src/prompts/context-budget.ts",
-    "../../../ts/src/prompts/templates.ts",
-    "../../../ts/src/scenarios/game-interface.ts",
-    "../../../ts/src/scenarios/primary-family-interface-types.ts",
-    "../../../ts/src/scenarios/simulation-family-interface-types.ts",
-    "../../../ts/src/storage/storage-contracts.ts",
-    "../../../ts/src/types/index.ts"
-  ]
+	"extends": "../../../ts/tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "../../..",
+		"outDir": "./dist",
+		"noEmit": false
+	},
+	"include": [
+		"src/index.ts",
+		"../../../ts/src/execution/elo.ts",
+		"../../../ts/src/judge/parse.ts",
+		"../../../ts/src/judge/rubric-coherence.ts",
+		"../../../ts/src/prompts/context-budget.ts",
+		"../../../ts/src/prompts/templates.ts",
+		"../../../ts/src/scenarios/game-interface.ts",
+		"../../../ts/src/scenarios/primary-family-interface-types.ts",
+		"../../../ts/src/scenarios/simulation-family-interface-types.ts",
+		"../../../ts/src/storage/storage-contracts.ts",
+		"../../../ts/src/types/index.ts"
+	]
 }

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -1,0 +1,210 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(import.meta.dirname, "..", "..");
+const boundariesPath = join(repoRoot, "packages", "package-boundaries.json");
+
+type TsCoreBoundary = {
+	packagePath: string;
+	tsconfigPath: string;
+	exactIncludes: string[];
+	blockedProgramPathSubstrings: string[];
+	blockedPackageDependencies: string[];
+};
+
+type TsControlBoundary = {
+	packagePath: string;
+	tsconfigPath: string;
+	exactIncludes: string[];
+	blockedPackageDependencies: string[];
+};
+
+type PackageBoundaries = {
+	typescript: {
+		core: TsCoreBoundary;
+		control: TsControlBoundary;
+	};
+};
+
+type Topology = {
+	typescript: {
+		core: {
+			path: string;
+		};
+		control: {
+			path: string;
+		};
+	};
+};
+
+type TsPackageJson = {
+	main: string;
+	types: string;
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+	exports: {
+		".": {
+			import: string;
+			types: string;
+		};
+	};
+};
+
+function loadBoundaries(): PackageBoundaries {
+	return JSON.parse(readFileSync(boundariesPath, "utf-8")) as PackageBoundaries;
+}
+
+function loadTopology(): Topology {
+	return loadJson<Topology>(
+		join(repoRoot, "packages", "package-topology.json"),
+	);
+}
+
+function loadJson<T>(path: string): T {
+	return JSON.parse(readFileSync(path, "utf-8")) as T;
+}
+
+describe("package boundaries", () => {
+	it("defines a shared package-boundary contract", () => {
+		expect(existsSync(boundariesPath)).toBe(true);
+	});
+
+	it("reuses the topology path for the TypeScript core package", () => {
+		const boundaries = loadBoundaries();
+		const topology = loadTopology();
+
+		expect(boundaries.typescript.core.packagePath).toBe(
+			topology.typescript.core.path,
+		);
+	});
+
+	it("reuses the topology path for the TypeScript control package", () => {
+		const boundaries = loadBoundaries();
+		const topology = loadTopology();
+
+		expect(boundaries.typescript.control.packagePath).toBe(
+			topology.typescript.control.path,
+		);
+	});
+
+	it("requires exact include paths for the TypeScript core package", () => {
+		const boundaries = loadBoundaries();
+		const core = boundaries.typescript.core;
+		const tsconfig = loadJson<{
+			compilerOptions?: { noEmit?: boolean };
+			include: string[];
+		}>(join(repoRoot, core.tsconfigPath));
+
+		expect(tsconfig.compilerOptions?.noEmit).toBe(false);
+		expect(tsconfig.include).toEqual(core.exactIncludes);
+		expect(tsconfig.include.every((entry) => !entry.includes("*"))).toBe(true);
+	});
+
+	it("keeps the TypeScript core package dependencies pointed away from control and umbrella packages", () => {
+		const boundaries = loadBoundaries();
+		const core = boundaries.typescript.core;
+		const packageJson = loadJson<TsPackageJson>(
+			join(repoRoot, core.packagePath, "package.json"),
+		);
+		const dependencySections = [
+			packageJson.dependencies,
+			packageJson.devDependencies,
+			packageJson.peerDependencies,
+			packageJson.optionalDependencies,
+		];
+
+		expect(core.blockedPackageDependencies).toEqual([
+			"@autocontext/control-plane",
+			"autoctx",
+		]);
+		for (const blockedPackage of core.blockedPackageDependencies) {
+			for (const dependencies of dependencySections) {
+				expect(Object.keys(dependencies ?? {})).not.toContain(blockedPackage);
+			}
+		}
+	});
+
+	it("requires exact include paths for the TypeScript control package", () => {
+		const boundaries = loadBoundaries();
+		const control = boundaries.typescript.control;
+		const tsconfig = loadJson<{
+			compilerOptions?: { noEmit?: boolean };
+			include: string[];
+		}>(join(repoRoot, control.tsconfigPath));
+
+		expect(tsconfig.compilerOptions?.noEmit).toBe(false);
+		expect(tsconfig.include).toEqual(control.exactIncludes);
+		expect(tsconfig.include.every((entry) => !entry.includes("*"))).toBe(true);
+	});
+
+	it("keeps the TypeScript control package dependencies pointed away from the umbrella package", () => {
+		const boundaries = loadBoundaries();
+		const control = boundaries.typescript.control;
+		const packageJson = loadJson<TsPackageJson>(
+			join(repoRoot, control.packagePath, "package.json"),
+		);
+		const dependencySections = [
+			packageJson.dependencies,
+			packageJson.devDependencies,
+			packageJson.peerDependencies,
+			packageJson.optionalDependencies,
+		];
+
+		expect(control.blockedPackageDependencies).toEqual(["autoctx"]);
+		for (const blockedPackage of control.blockedPackageDependencies) {
+			for (const dependencies of dependencySections) {
+				expect(Object.keys(dependencies ?? {})).not.toContain(blockedPackage);
+			}
+		}
+	});
+
+	it("keeps the TypeScript core program free of control-plane paths", () => {
+		const boundaries = loadBoundaries();
+		const core = boundaries.typescript.core;
+
+		const output = execFileSync(
+			join(repoRoot, "ts", "node_modules", ".bin", "tsc"),
+			["-p", core.tsconfigPath, "--listFilesOnly"],
+			{
+				cwd: repoRoot,
+				encoding: "utf-8",
+			},
+		);
+
+		const fileList = output.split(/\r?\n/).filter(Boolean);
+		for (const blocked of core.blockedProgramPathSubstrings) {
+			expect(fileList.some((entry) => entry.includes(blocked))).toBe(false);
+		}
+	});
+
+	it("builds package artifacts at the paths advertised by package.json", () => {
+		const packages = [
+			join(repoRoot, "packages", "ts", "core"),
+			join(repoRoot, "packages", "ts", "control-plane"),
+		];
+
+		for (const packageDir of packages) {
+			rmSync(join(packageDir, "dist"), { force: true, recursive: true });
+			execFileSync("npm", ["run", "build"], {
+				cwd: packageDir,
+				encoding: "utf-8",
+			});
+
+			const packageJson = loadJson<TsPackageJson>(
+				join(packageDir, "package.json"),
+			);
+			expect(existsSync(join(packageDir, packageJson.main))).toBe(true);
+			expect(existsSync(join(packageDir, packageJson.types))).toBe(true);
+			expect(
+				existsSync(join(packageDir, packageJson.exports["."].import)),
+			).toBe(true);
+			expect(existsSync(join(packageDir, packageJson.exports["."].types))).toBe(
+				true,
+			);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- add a machine-readable `packages/package-boundaries.json` contract for the core/control split
- add Python and TypeScript package-boundary tests that enforce the current DDD boundary language: core, control plane, and umbrella compatibility shell
- tighten the TypeScript core package from a broad `src/**/*.ts` include to the exact facade entrypoint plus approved core-safe source files
- add a dedicated CI `package-boundaries` job and make smoke depend on it
- document the boundary-enforcement contract in the PR0 core/control split guardrail doc

## TDD notes

RED checks observed before the manifest update:

- Python boundary test failed on missing `blockedImportPrefixes`
- Python dependency-boundary test failed on missing `blockedDependencies`
- TypeScript dependency-boundary test failed on missing `blockedPackageDependencies`

GREEN implementation was limited to the boundary manifest, exact TS core include scope, and CI wiring.

## Boundary rules enforced

- Python core facade imports must match the allowed import contract
- Python core facade imports must not target control-plane prefixes
- Python core package metadata must not depend on `autocontext` or `autocontext-control`
- TypeScript core package build includes must be exact, not globs
- TypeScript core program must not include blocked control-plane paths
- TypeScript core package metadata must not depend on `autoctx` or `@autocontext/control-plane`
- Python and TypeScript core/control package artifacts must build at advertised paths

## Verification

- `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `cd ts && npx vitest run tests/package-topology.test.ts tests/package-boundaries.test.ts --run`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- `git diff --check`

## Licensing guardrail

No license metadata is changed here. AC-645 remains deferred, and non-Apache relicensing remains blocked on AC-646.
