### PR TITLE
AC-650 Guard deferred license metadata

### DIFF
--- a/autocontext/tests/test_package_boundaries.py
+++ b/autocontext/tests/test_package_boundaries.py
@@ -77,8 +77,70 @@ def _dependency_name(requirement: object) -> str:
     )
 
 
+def _licensing_guardrails() -> dict[str, object]:
+    boundaries = _load_boundaries()
+    licensing = boundaries["licensing"]
+    assert isinstance(licensing, dict)
+    return licensing
+
+
 def test_package_boundaries_manifest_exists() -> None:
     assert BOUNDARIES_PATH.exists()
+
+
+def test_license_metadata_publication_is_deferred_to_linear_guardrails() -> None:
+    licensing = _licensing_guardrails()
+
+    assert licensing["status"] == "deferred"
+    assert licensing["licenseMetadataIssue"] == "AC-645"
+    assert licensing["rightsAuditIssue"] == "AC-646"
+
+
+def test_deferred_license_publication_files_are_absent() -> None:
+    licensing = _licensing_guardrails()
+    forbidden_paths = licensing["forbiddenPathsUntilAC645"]
+    assert isinstance(forbidden_paths, list)
+    assert forbidden_paths == [
+        "LICENSING.md",
+        "packages/python/core/LICENSE",
+        "packages/python/control/LICENSE",
+        "packages/ts/core/LICENSE",
+        "packages/ts/control-plane/LICENSE",
+    ]
+
+    for relative_path in forbidden_paths:
+        assert isinstance(relative_path, str)
+        assert not (REPO_ROOT / relative_path).exists()
+
+
+def test_python_license_metadata_stays_deferred_for_new_package_artifacts() -> None:
+    licensing = _licensing_guardrails()
+    python_metadata = licensing["pythonProjectMetadata"]
+    assert isinstance(python_metadata, dict)
+    pyproject_paths = python_metadata["paths"]
+    forbidden_project_keys = python_metadata["forbiddenProjectKeys"]
+    forbidden_classifier_prefixes = python_metadata["forbiddenClassifierPrefixes"]
+    assert isinstance(pyproject_paths, list)
+    assert isinstance(forbidden_project_keys, list)
+    assert isinstance(forbidden_classifier_prefixes, list)
+    assert forbidden_project_keys == ["license", "license-files"]
+    assert forbidden_classifier_prefixes == ["License ::"]
+
+    for relative_path in pyproject_paths:
+        assert isinstance(relative_path, str)
+        pyproject = _load_pyproject(REPO_ROOT / relative_path)
+        project = pyproject["project"]
+        assert isinstance(project, dict)
+        for key in forbidden_project_keys:
+            assert isinstance(key, str)
+            assert key not in project
+        classifiers = project.get("classifiers", [])
+        assert isinstance(classifiers, list)
+        for classifier in classifiers:
+            assert isinstance(classifier, str)
+            for prefix in forbidden_classifier_prefixes:
+                assert isinstance(prefix, str)
+                assert not classifier.startswith(prefix)
 
 
 def test_python_boundary_contract_reuses_topology_core_module() -> None:

--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -36,6 +36,11 @@ layout must make the licensing model true before the repo advertises it.
 - Prefer compatibility shims and re-exports over breaking old import paths
   during the first migration phases.
 
+The boundary-enforcement contract also encodes the deferred licensing
+publication rule: no root `LICENSING.md`, no per-package `LICENSE` files, and no
+new core/control package license metadata until AC-645. Any non-Apache
+relicensing remains blocked by the AC-646 rights audit.
+
 ## Package Topology
 
 The machine-readable topology map lives in

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -1,5 +1,39 @@
 {
 	"version": 1,
+	"licensing": {
+		"status": "deferred",
+		"licenseMetadataIssue": "AC-645",
+		"rightsAuditIssue": "AC-646",
+		"forbiddenPathsUntilAC645": [
+			"LICENSING.md",
+			"packages/python/core/LICENSE",
+			"packages/python/control/LICENSE",
+			"packages/ts/core/LICENSE",
+			"packages/ts/control-plane/LICENSE"
+		],
+		"pythonProjectMetadata": {
+			"paths": [
+				"packages/python/core/pyproject.toml",
+				"packages/python/control/pyproject.toml"
+			],
+			"forbiddenProjectKeys": [
+				"license",
+				"license-files"
+			],
+			"forbiddenClassifierPrefixes": [
+				"License ::"
+			]
+		},
+		"typescriptPackageMetadata": {
+			"paths": [
+				"packages/ts/core/package.json",
+				"packages/ts/control-plane/package.json"
+			],
+			"forbiddenPackageKeys": [
+				"license"
+			]
+		}
+	},
 	"python": {
 		"core": {
 			"module": "autocontext_core",

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -21,7 +21,19 @@ type TsControlBoundary = {
 	blockedPackageDependencies: string[];
 };
 
+type LicensingGuardrails = {
+	status: string;
+	licenseMetadataIssue: string;
+	rightsAuditIssue: string;
+	forbiddenPathsUntilAC645: string[];
+	typescriptPackageMetadata: {
+		paths: string[];
+		forbiddenPackageKeys: string[];
+	};
+};
+
 type PackageBoundaries = {
+	licensing: LicensingGuardrails;
 	typescript: {
 		core: TsCoreBoundary;
 		control: TsControlBoundary;
@@ -71,6 +83,43 @@ function loadJson<T>(path: string): T {
 describe("package boundaries", () => {
 	it("defines a shared package-boundary contract", () => {
 		expect(existsSync(boundariesPath)).toBe(true);
+	});
+
+	it("keeps license metadata publication deferred to the blocking Linear issues", () => {
+		const licensing = loadBoundaries().licensing;
+
+		expect(licensing.status).toBe("deferred");
+		expect(licensing.licenseMetadataIssue).toBe("AC-645");
+		expect(licensing.rightsAuditIssue).toBe("AC-646");
+	});
+
+	it("keeps deferred license publication files absent", () => {
+		const licensing = loadBoundaries().licensing;
+
+		expect(licensing.forbiddenPathsUntilAC645).toEqual([
+			"LICENSING.md",
+			"packages/python/core/LICENSE",
+			"packages/python/control/LICENSE",
+			"packages/ts/core/LICENSE",
+			"packages/ts/control-plane/LICENSE",
+		]);
+		for (const relativePath of licensing.forbiddenPathsUntilAC645) {
+			expect(existsSync(join(repoRoot, relativePath))).toBe(false);
+		}
+	});
+
+	it("keeps TypeScript package license metadata deferred for new package artifacts", () => {
+		const metadata = loadBoundaries().licensing.typescriptPackageMetadata;
+
+		expect(metadata.forbiddenPackageKeys).toEqual(["license"]);
+		for (const relativePath of metadata.paths) {
+			const packageJson = loadJson<Record<string, unknown>>(
+				join(repoRoot, relativePath),
+			);
+			for (const key of metadata.forbiddenPackageKeys) {
+				expect(packageJson).not.toHaveProperty(key);
+			}
+		}
 	});
 
 	it("reuses the topology path for the TypeScript core package", () => {


### PR DESCRIPTION
## Summary

- extend `packages/package-boundaries.json` with a deferred licensing-publication guardrail
- assert AC-645 owns future license metadata publication and AC-646 remains the rights-audit blocker
- add Python and TypeScript tests that keep premature `LICENSING.md`, per-package `LICENSE` files, and new core/control package license metadata absent
- document the deferred licensing-publication rule in the core/control split guardrail doc

## TDD notes

RED checks observed before implementation:

- Python boundary tests failed on missing `licensing` guardrail metadata
- TypeScript boundary tests failed on missing `licensing` guardrail metadata

GREEN implementation was limited to the shared boundary manifest and documentation. No license metadata was added.

## DDD boundary language

This PR treats licensing publication as a separate boundary concern from package topology:

- `licenseMetadataIssue`: AC-645 owns future per-package license files/metadata
- `rightsAuditIssue`: AC-646 blocks any non-Apache relicensing
- `forbiddenPathsUntilAC645`: files that must stay absent until the licensing metadata phase
- `pythonProjectMetadata` / `typescriptPackageMetadata`: package metadata fields that must stay absent in new core/control artifacts until AC-645

## Verification

- `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `cd ts && npx vitest run tests/package-topology.test.ts tests/package-boundaries.test.ts --run`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- `git diff --check`

## Licensing guardrail

No license metadata is changed here. This PR only adds tests and manifest entries that prevent premature license metadata publication before AC-645, with AC-646 still blocking non-Apache relicensing.
