### PR TITLE
AC-650 Batch remaining control payload facades

### DIFF
--- a/autocontext/tests/test_python_control_package.py
+++ b/autocontext/tests/test_python_control_package.py
@@ -163,6 +163,130 @@ def test_python_control_reexports_tournament_started_payload() -> None:
     assert payload.matches == 8
 
 
+def test_python_control_reexports_tournament_completed_payload() -> None:
+    TournamentCompletedPayload = control_package.TournamentCompletedPayload
+
+    payload = TournamentCompletedPayload(
+        run_id="run-123",
+        generation=2,
+        mean_score=0.55,
+        best_score=0.7,
+        wins=3,
+        losses=1,
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.generation == 2
+    assert payload.mean_score == 0.55
+    assert payload.best_score == 0.7
+    assert payload.wins == 3
+    assert payload.losses == 1
+
+
+def test_python_control_reexports_curator_started_payload() -> None:
+    CuratorStartedPayload = control_package.CuratorStartedPayload
+
+    payload = CuratorStartedPayload(
+        run_id="run-123",
+        generation=2,
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.generation == 2
+
+
+def test_python_control_reexports_match_completed_payload() -> None:
+    MatchCompletedPayload = control_package.MatchCompletedPayload
+
+    payload = MatchCompletedPayload(
+        run_id="run-123",
+        generation=2,
+        match_index=3,
+        score=0.55,
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.generation == 2
+    assert payload.match_index == 3
+    assert payload.score == 0.55
+
+
+def test_python_control_reexports_curator_completed_payload() -> None:
+    CuratorCompletedPayload = control_package.CuratorCompletedPayload
+
+    payload = CuratorCompletedPayload(
+        run_id="run-123",
+        generation=2,
+        decision="accept",
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.generation == 2
+    assert payload.decision == "accept"
+
+
+def test_python_control_reexports_run_started_payload() -> None:
+    RunStartedPayload = control_package.RunStartedPayload
+
+    payload = RunStartedPayload(
+        run_id="run-123",
+        scenario="grid_ctf",
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.scenario == "grid_ctf"
+
+
+def test_python_control_reexports_run_completed_payload() -> None:
+    RunCompletedPayload = control_package.RunCompletedPayload
+
+    payload = RunCompletedPayload(
+        run_id="run-123",
+        completed_generations=4,
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.completed_generations == 4
+
+
+def test_python_control_reexports_gate_decided_payload() -> None:
+    GateDecidedPayload = control_package.GateDecidedPayload
+
+    payload = GateDecidedPayload(
+        run_id="run-123",
+        generation=2,
+        decision="advance",
+        delta=0.18,
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.generation == 2
+    assert payload.decision == "advance"
+    assert payload.delta == 0.18
+
+
+def test_python_control_reexports_generation_completed_payload() -> None:
+    GenerationCompletedPayload = control_package.GenerationCompletedPayload
+
+    payload = GenerationCompletedPayload(
+        run_id="run-123",
+        generation=2,
+        mean_score=0.68,
+        best_score=0.72,
+        elo=1068,
+        gate_decision="advance",
+        created_tools=["tool_a.py"],
+    )
+
+    assert payload.run_id == "run-123"
+    assert payload.generation == 2
+    assert payload.mean_score == 0.68
+    assert payload.best_score == 0.72
+    assert payload.elo == 1068
+    assert payload.gate_decision == "advance"
+    assert payload.created_tools == ["tool_a.py"]
+
+
 def test_python_control_reexports_shared_server_protocol_models() -> None:
     ExecutorInfo = control_package.ExecutorInfo
     ExecutorResources = control_package.ExecutorResources

--- a/packages/python/control/src/autocontext_control/__init__.py
+++ b/packages/python/control/src/autocontext_control/__init__.py
@@ -35,10 +35,18 @@ ScenarioGeneratingMsg: Any = _server_protocol.ScenarioGeneratingMsg
 ScenarioPreviewMsg: Any = _server_protocol.ScenarioPreviewMsg
 ScenarioReadyMsg: Any = _server_protocol.ScenarioReadyMsg
 ScenarioErrorMsg: Any = _server_protocol.ScenarioErrorMsg
+RunStartedPayload: Any = _server_protocol.RunStartedPayload
+RunCompletedPayload: Any = _server_protocol.RunCompletedPayload
 GenerationStartedPayload: Any = _server_protocol.GenerationStartedPayload
+GenerationCompletedPayload: Any = _server_protocol.GenerationCompletedPayload
 AgentsStartedPayload: Any = _server_protocol.AgentsStartedPayload
 RoleCompletedPayload: Any = _server_protocol.RoleCompletedPayload
 TournamentStartedPayload: Any = _server_protocol.TournamentStartedPayload
+MatchCompletedPayload: Any = _server_protocol.MatchCompletedPayload
+TournamentCompletedPayload: Any = _server_protocol.TournamentCompletedPayload
+GateDecidedPayload: Any = _server_protocol.GateDecidedPayload
+CuratorStartedPayload: Any = _server_protocol.CuratorStartedPayload
+CuratorCompletedPayload: Any = _server_protocol.CuratorCompletedPayload
 PauseCmd: Any = _server_protocol.PauseCmd
 ResumeCmd: Any = _server_protocol.ResumeCmd
 InjectHintCmd: Any = _server_protocol.InjectHintCmd
@@ -103,6 +111,8 @@ __all__ = [
     "ConditionType",
     "ConfirmScenarioCmd",
     "CreateScenarioCmd",
+    "CuratorCompletedPayload",
+    "CuratorStartedPayload",
     "EndedAt",
     "EnvContext",
     "EventMsg",
@@ -111,7 +121,9 @@ __all__ = [
     "AgentsStartedPayload",
     "Error",
     "ErrorMsg",
+    "GenerationCompletedPayload",
     "GenerationStartedPayload",
+    "GateDecidedPayload",
     "MonitorAlert",
     "MonitorAlertMsg",
     "MonitorCondition",
@@ -123,6 +135,7 @@ __all__ = [
     "InjectHintCmd",
     "Items",
     "ListScenariosCmd",
+    "MatchCompletedPayload",
     "Message",
     "PACKAGE_ROLE",
     "PACKAGE_TOPOLOGY_VERSION",
@@ -136,11 +149,14 @@ __all__ = [
     "RedactionMarker",
     "ResearchAdapter",
     "ResearchBrief",
+    "RunCompletedPayload",
+    "RunStartedPayload",
     "ResearchConfig",
     "ResearchQuery",
     "ResearchResult",
     "ReviseScenarioCmd",
     "RoleCompletedPayload",
+    "TournamentCompletedPayload",
     "TournamentStartedPayload",
     "ResumeCmd",
     "Routing",

--- a/packages/ts/control-plane/src/index.ts
+++ b/packages/ts/control-plane/src/index.ts
@@ -3,7 +3,13 @@ export const packageTopologyVersion = 1;
 
 export type {
 	AgentsStartedPayload,
+	GateDecidedPayload,
+	GenerationCompletedPayload,
 	GenerationStartedPayload,
+	RunCompletedPayload,
+	RunFailedPayload,
+	RunStartedPayload,
+	TournamentCompletedPayload,
 } from "../../../../ts/src/loop/generation-event-coordinator.js";
 export type { RoleCompletedPayload } from "../../../../ts/src/loop/generation-side-effect-coordinator.js";
 export type { TournamentStartedPayload } from "../../../../ts/src/loop/generation-tournament-event-sequencing.js";

--- a/ts/tests/control-plane-package.test.ts
+++ b/ts/tests/control-plane-package.test.ts
@@ -5,15 +5,21 @@ import type {
 	EnvironmentTag,
 	FeedbackRef,
 	FeedbackRefId,
+	GateDecidedPayload,
+	GenerationCompletedPayload,
 	GenerationStartedPayload,
 	ProductionTrace,
 	ProductionTraceId,
 	ProviderInfo,
 	ResearchAdapter,
 	RoleCompletedPayload,
+	RunCompletedPayload,
+	RunFailedPayload,
+	RunStartedPayload,
 	Scenario,
 	SessionIdHash,
 	StagnationReport,
+	TournamentCompletedPayload,
 	TournamentStartedPayload,
 	TraceSource,
 	UserIdHash,
@@ -169,6 +175,24 @@ describe("@autocontext/control-plane facade", () => {
 		expect(payload.matches).toBe(8);
 	});
 
+	it("re-exports tournament completed payload types", () => {
+		const payload: TournamentCompletedPayload = {
+			run_id: "run-123",
+			generation: 2,
+			mean_score: 0.55,
+			best_score: 0.7,
+			wins: 3,
+			losses: 1,
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.generation).toBe(2);
+		expect(payload.mean_score).toBe(0.55);
+		expect(payload.best_score).toBe(0.7);
+		expect(payload.wins).toBe(3);
+		expect(payload.losses).toBe(1);
+	});
+
 	it("re-exports role completed payload types", () => {
 		const payload: RoleCompletedPayload = {
 			run_id: "run-123",
@@ -183,6 +207,80 @@ describe("@autocontext/control-plane facade", () => {
 		expect(payload.role).toBe("coach");
 		expect(payload.latency_ms).toBe(125);
 		expect(payload.tokens).toBe(42);
+	});
+
+	it("re-exports run started payload types", () => {
+		const payload: RunStartedPayload = {
+			run_id: "run-123",
+			scenario: "grid_ctf",
+			target_generations: 5,
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.scenario).toBe("grid_ctf");
+		expect(payload.target_generations).toBe(5);
+	});
+
+	it("re-exports gate decided payload types", () => {
+		const payload: GateDecidedPayload = {
+			run_id: "run-123",
+			generation: 2,
+			decision: "advance",
+			delta: 0.18,
+			threshold: 0.005,
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.generation).toBe(2);
+		expect(payload.decision).toBe("advance");
+		expect(payload.delta).toBe(0.18);
+		expect(payload.threshold).toBe(0.005);
+	});
+
+	it("re-exports generation completed payload types", () => {
+		const payload: GenerationCompletedPayload = {
+			run_id: "run-123",
+			generation: 2,
+			mean_score: 0.68,
+			best_score: 0.72,
+			elo: 1068,
+			gate_decision: "advance",
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.generation).toBe(2);
+		expect(payload.mean_score).toBe(0.68);
+		expect(payload.best_score).toBe(0.72);
+		expect(payload.elo).toBe(1068);
+		expect(payload.gate_decision).toBe("advance");
+	});
+
+	it("re-exports run completed payload types", () => {
+		const payload: RunCompletedPayload = {
+			run_id: "run-123",
+			completed_generations: 4,
+			best_score: 0.82,
+			elo: 1042,
+			session_report_path: "/tmp/report.md",
+			dead_ends_found: 2,
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.completed_generations).toBe(4);
+		expect(payload.best_score).toBe(0.82);
+		expect(payload.elo).toBe(1042);
+		expect(payload.session_report_path).toBe("/tmp/report.md");
+		expect(payload.dead_ends_found).toBe(2);
+	});
+
+	it("re-exports run failed payload types", () => {
+		const payload: RunFailedPayload = {
+			run_id: "run-123",
+			error: "boom",
+		};
+
+		expect(payload.run_id).toBe("run-123");
+		expect(payload.error).toBe("boom");
 	});
 
 	it("re-exports generation kickoff payload types", () => {


### PR DESCRIPTION
## Summary
- Consolidates the remaining facade-only payload export PRs from #832-#844 into one batch.
- Re-exports run, tournament, gate, generation, curator, and run-failed payloads through the Python/TypeScript control packages.
- Keeps package boundaries exact; no new boundary manifest entries are needed because these reuse already-included protocol/event modules.

## Verification
- uv run pytest tests/test_python_control_package.py tests/test_package_boundaries.py -q
- npx vitest run tests/control-plane-package.test.ts tests/package-boundaries.test.ts --run
- ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json