### PR TITLE
AC-650 Claim production trace contract in core package

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -132,6 +132,11 @@ These are not AC-645 license metadata. They are future product placement notes.
 
 ### TypeScript Production Traces and Public Traces
 
+The first source-ownership slice claims `ts/src/production-traces/contract/generated-types.ts`
+for the TypeScript core package because it is generated from the public
+production-trace JSON schemas and has no CLI, ingestion, dataset, retention,
+server, MCP, or control-plane dependencies.
+
 | Surface                               | Current path                                                                                            | Proposed owner                 | Boundary rule                                                                                          |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------ |
 | Production trace contract             | `ts/src/production-traces/contract/**`                                                                  | Core/open SDK                  | Public wire format, branded IDs, validators, generated types.                                          |

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -107,18 +107,23 @@
 				"../../../ts/src/scenarios/primary-family-interface-types.ts",
 				"../../../ts/src/scenarios/simulation-family-interface-types.ts",
 				"../../../ts/src/storage/storage-contracts.ts",
-				"../../../ts/src/types/index.ts"
+				"../../../ts/src/types/index.ts",
+				"../../../ts/src/production-traces/contract/generated-types.ts"
 			],
 			"blockedProgramPathSubstrings": [
 				"/ts/src/control-plane/",
-				"/ts/src/production-traces/",
 				"/ts/src/research/",
 				"/ts/src/server/",
 				"/ts/src/loop/",
 				"/ts/src/config/",
 				"/ts/src/runtimes/",
 				"/ts/src/providers/",
-				"/ts/src/agents/"
+				"/ts/src/agents/",
+				"/ts/src/production-traces/cli/",
+				"/ts/src/production-traces/ingest/",
+				"/ts/src/production-traces/dataset/",
+				"/ts/src/production-traces/retention/",
+				"/ts/src/traces/"
 			],
 			"blockedPackageDependencies": [
 				"@autocontext/control-plane",
@@ -144,6 +149,18 @@
 			"blockedPackageDependencies": [
 				"autoctx"
 			]
+		}
+	},
+	"mixedDomains": {
+		"productionTraces": {
+			"typescriptOpenContract": {
+				"coreOwnedSourceIncludes": [
+					"../../../ts/src/production-traces/contract/generated-types.ts"
+				],
+				"coreOwnedProgramPathSubstrings": [
+					"/ts/src/production-traces/contract/generated-types.ts"
+				]
+			}
 		}
 	}
 }

--- a/packages/ts/core/src/index.ts
+++ b/packages/ts/core/src/index.ts
@@ -9,6 +9,12 @@ export type {
 export { parseJudgeResponse } from "../../../../ts/src/judge/parse.js";
 export type { RubricCoherenceResult } from "../../../../ts/src/judge/rubric-coherence.js";
 export { checkRubricCoherence } from "../../../../ts/src/judge/rubric-coherence.js";
+export type {
+	ProductionOutcome,
+	ProductionTrace,
+	TraceLinks,
+	TraceSource,
+} from "../../../../ts/src/production-traces/contract/generated-types.js";
 export {
 	ContextBudget,
 	estimateTokens,

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -16,6 +16,7 @@
 		"../../../ts/src/scenarios/primary-family-interface-types.ts",
 		"../../../ts/src/scenarios/simulation-family-interface-types.ts",
 		"../../../ts/src/storage/storage-contracts.ts",
-		"../../../ts/src/types/index.ts"
+		"../../../ts/src/types/index.ts",
+		"../../../ts/src/production-traces/contract/generated-types.ts"
 	]
 }

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -32,8 +32,18 @@ type LicensingGuardrails = {
 	};
 };
 
+type ProductionTraceBoundary = {
+	typescriptOpenContract: {
+		coreOwnedSourceIncludes: string[];
+		coreOwnedProgramPathSubstrings: string[];
+	};
+};
+
 type PackageBoundaries = {
 	licensing: LicensingGuardrails;
+	mixedDomains: {
+		productionTraces: ProductionTraceBoundary;
+	};
 	typescript: {
 		core: TsCoreBoundary;
 		control: TsControlBoundary;
@@ -78,6 +88,19 @@ function loadTopology(): Topology {
 
 function loadJson<T>(path: string): T {
 	return JSON.parse(readFileSync(path, "utf-8")) as T;
+}
+
+function listTypeScriptProgramFiles(tsconfigPath: string): string[] {
+	const output = execFileSync(
+		join(repoRoot, "ts", "node_modules", ".bin", "tsc"),
+		["-p", tsconfigPath, "--listFilesOnly"],
+		{
+			cwd: repoRoot,
+			encoding: "utf-8",
+		},
+	);
+
+	return output.split(/\r?\n/).filter(Boolean);
 }
 
 describe("package boundaries", () => {
@@ -153,6 +176,43 @@ describe("package boundaries", () => {
 		expect(tsconfig.include.every((entry) => !entry.includes("*"))).toBe(true);
 	});
 
+	it("claims only explicit production trace open contract sources in the TypeScript core package", () => {
+		const boundaries = loadBoundaries();
+		const core = boundaries.typescript.core;
+		const productionTraces =
+			boundaries.mixedDomains.productionTraces.typescriptOpenContract;
+
+		expect(productionTraces.coreOwnedSourceIncludes).toEqual([
+			"../../../ts/src/production-traces/contract/generated-types.ts",
+		]);
+		expect(productionTraces.coreOwnedProgramPathSubstrings).toEqual([
+			"/ts/src/production-traces/contract/generated-types.ts",
+		]);
+		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
+			expect(core.exactIncludes).toContain(sourceInclude);
+		}
+
+		const fileList = listTypeScriptProgramFiles(core.tsconfigPath);
+		const productionTraceFiles = fileList.filter((entry) =>
+			entry.includes("/ts/src/production-traces/"),
+		);
+		expect(productionTraceFiles).toHaveLength(
+			productionTraces.coreOwnedProgramPathSubstrings.length,
+		);
+		for (const ownedPath of productionTraces.coreOwnedProgramPathSubstrings) {
+			expect(
+				productionTraceFiles.some((entry) => entry.includes(ownedPath)),
+			).toBe(true);
+		}
+		for (const filePath of productionTraceFiles) {
+			expect(
+				productionTraces.coreOwnedProgramPathSubstrings.some((ownedPath) =>
+					filePath.includes(ownedPath),
+				),
+			).toBe(true);
+		}
+	});
+
 	it("keeps the TypeScript core package dependencies pointed away from control and umbrella packages", () => {
 		const boundaries = loadBoundaries();
 		const core = boundaries.typescript.core;
@@ -214,17 +274,8 @@ describe("package boundaries", () => {
 	it("keeps the TypeScript core program free of control-plane paths", () => {
 		const boundaries = loadBoundaries();
 		const core = boundaries.typescript.core;
+		const fileList = listTypeScriptProgramFiles(core.tsconfigPath);
 
-		const output = execFileSync(
-			join(repoRoot, "ts", "node_modules", ".bin", "tsc"),
-			["-p", core.tsconfigPath, "--listFilesOnly"],
-			{
-				cwd: repoRoot,
-				encoding: "utf-8",
-			},
-		);
-
-		const fileList = output.split(/\r?\n/).filter(Boolean);
 		for (const blocked of core.blockedProgramPathSubstrings) {
 			expect(fileList.some((entry) => entry.includes(blocked))).toBe(false);
 		}

--- a/ts/tests/package-topology.test.ts
+++ b/ts/tests/package-topology.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = join(import.meta.dirname, "..", "..");
 const topologyPath = join(repoRoot, "packages", "package-topology.json");
+const boundariesPath = join(repoRoot, "packages", "package-boundaries.json");
 
 type PackageEntry = {
   name: string;
@@ -22,8 +23,20 @@ type Topology = {
   };
 };
 
+type PackageBoundaries = {
+  typescript: {
+    core: {
+      exactIncludes: string[];
+    };
+  };
+};
+
 function loadTopology(): Topology {
   return JSON.parse(readFileSync(topologyPath, "utf-8")) as Topology;
+}
+
+function loadBoundaries(): PackageBoundaries {
+  return JSON.parse(readFileSync(boundariesPath, "utf-8")) as PackageBoundaries;
 }
 
 function loadPackageJson(relativePath: string): Record<string, unknown> {
@@ -110,23 +123,16 @@ describe("package topology", () => {
 
   it("keeps the TypeScript core external source scope exact", () => {
     const topology = loadTopology();
+    const boundaries = loadBoundaries();
     const coreConfig = loadTsConfig(topology.typescript.core.path);
     const externalCoreSources = (coreConfig.include ?? []).filter((entry) =>
       entry.startsWith("../../../ts/src/"),
     );
+    const expectedExternalCoreSources = boundaries.typescript.core.exactIncludes.filter((entry) =>
+      entry.startsWith("../../../ts/src/"),
+    );
 
-    expect(externalCoreSources).toEqual([
-      "../../../ts/src/execution/elo.ts",
-      "../../../ts/src/judge/parse.ts",
-      "../../../ts/src/judge/rubric-coherence.ts",
-      "../../../ts/src/prompts/context-budget.ts",
-      "../../../ts/src/prompts/templates.ts",
-      "../../../ts/src/scenarios/game-interface.ts",
-      "../../../ts/src/scenarios/primary-family-interface-types.ts",
-      "../../../ts/src/scenarios/simulation-family-interface-types.ts",
-      "../../../ts/src/storage/storage-contracts.ts",
-      "../../../ts/src/types/index.ts",
-    ]);
+    expect(externalCoreSources).toEqual(expectedExternalCoreSources);
     expect(externalCoreSources.every((entry) => !entry.includes("*"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- claim the first production-trace open contract source in the TypeScript core package
- add `mixedDomains.productionTraces.typescriptOpenContract` to the shared boundary manifest
- include and export selected generated production-trace contract types from `@autocontext/core`
- keep production-traces CLI, ingest, dataset, retention, and `ts/src/traces` workflows blocked from the core program
- link the change back to the knowledge/trace boundary map as the first source-ownership slice

## TDD notes

RED was observed by adding the mixed-domain contract/tests before restoring the core package implementation:

- `requires exact include paths for the TypeScript core package` failed because `packages/ts/core/tsconfig.json` did not include `../../../ts/src/production-traces/contract/generated-types.ts`
- `claims only explicit production trace open contract sources in the TypeScript core package` failed with `expected [] to have a length of 1 but got +0`

GREEN:

- added the generated contract source to `packages/ts/core/tsconfig.json`
- exported selected generated production-trace contract types from `packages/ts/core/src/index.ts`
- made the topology test reuse `packages/package-boundaries.json` for the exact external-source list instead of duplicating it

## DDD / DRY notes

- DDD: this claims only a public contract source generated from production-trace JSON schemas; management workflows remain control-plane.
- DRY: `packages/package-boundaries.json` is the single source for the core exact include list and the production-trace mixed-domain claim.
- Compatibility: no `autoctx`, `autocontext`, or CLI paths were changed.

## Verification

- `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `cd ts && npx vitest run tests/package-topology.test.ts tests/package-boundaries.test.ts --run`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- `git diff --check`

## Licensing note

No license metadata is changed here. AC-645 remains deferred and AC-646 remains the blocker for any non-Apache relicensing.
