### PR TITLE
AC-650 Claim production trace taxonomy in core package

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -137,6 +137,11 @@ for the TypeScript core package because it is generated from the public
 production-trace JSON schemas and has no CLI, ingestion, dataset, retention,
 server, MCP, or control-plane dependencies.
 
+The next independent source-ownership slice claims `ts/src/production-traces/taxonomy/**`
+for the TypeScript core package because it is shared provider error/outcome
+vocabulary and does not depend on branded IDs, emit SDK helpers, CLI workflows,
+ingestion, dataset generation, retention, or `ts/src/traces` workflows.
+
 | Surface                               | Current path                                                                                            | Proposed owner                 | Boundary rule                                                                                          |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------ |
 | Production trace contract             | `ts/src/production-traces/contract/**`                                                                  | Core/open SDK                  | Public wire format, branded IDs, validators, generated types.                                          |

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -108,7 +108,10 @@
 				"../../../ts/src/scenarios/simulation-family-interface-types.ts",
 				"../../../ts/src/storage/storage-contracts.ts",
 				"../../../ts/src/types/index.ts",
-				"../../../ts/src/production-traces/contract/generated-types.ts"
+				"../../../ts/src/production-traces/contract/generated-types.ts",
+				"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
+				"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
+				"../../../ts/src/production-traces/taxonomy/index.ts"
 			],
 			"blockedProgramPathSubstrings": [
 				"/ts/src/control-plane/",
@@ -159,6 +162,18 @@
 				],
 				"coreOwnedProgramPathSubstrings": [
 					"/ts/src/production-traces/contract/generated-types.ts"
+				]
+			},
+			"typescriptOpenTaxonomy": {
+				"coreOwnedSourceIncludes": [
+					"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
+					"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
+					"../../../ts/src/production-traces/taxonomy/index.ts"
+				],
+				"coreOwnedProgramPathSubstrings": [
+					"/ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
+					"/ts/src/production-traces/taxonomy/openai-error-reasons.ts",
+					"/ts/src/production-traces/taxonomy/index.ts"
 				]
 			}
 		}

--- a/packages/ts/core/src/index.ts
+++ b/packages/ts/core/src/index.ts
@@ -15,6 +15,18 @@ export type {
 	TraceLinks,
 	TraceSource,
 } from "../../../../ts/src/production-traces/contract/generated-types.js";
+export type {
+	AnthropicErrorReasonKey,
+	OpenAiErrorReasonKey,
+	OutcomeReasonKey,
+} from "../../../../ts/src/production-traces/taxonomy/index.js";
+export {
+	ANTHROPIC_ERROR_REASON_KEYS,
+	ANTHROPIC_ERROR_REASONS,
+	OPENAI_ERROR_REASON_KEYS,
+	OPENAI_ERROR_REASONS,
+	OUTCOME_REASON_KEYS,
+} from "../../../../ts/src/production-traces/taxonomy/index.js";
 export {
 	ContextBudget,
 	estimateTokens,

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -17,6 +17,9 @@
 		"../../../ts/src/scenarios/simulation-family-interface-types.ts",
 		"../../../ts/src/storage/storage-contracts.ts",
 		"../../../ts/src/types/index.ts",
-		"../../../ts/src/production-traces/contract/generated-types.ts"
+		"../../../ts/src/production-traces/contract/generated-types.ts",
+		"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
+		"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
+		"../../../ts/src/production-traces/taxonomy/index.ts"
 	]
 }

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -32,11 +32,14 @@ type LicensingGuardrails = {
 	};
 };
 
+type ProductionTraceSourceClaim = {
+	coreOwnedSourceIncludes: string[];
+	coreOwnedProgramPathSubstrings: string[];
+};
+
 type ProductionTraceBoundary = {
-	typescriptOpenContract: {
-		coreOwnedSourceIncludes: string[];
-		coreOwnedProgramPathSubstrings: string[];
-	};
+	typescriptOpenContract: ProductionTraceSourceClaim;
+	typescriptOpenTaxonomy: ProductionTraceSourceClaim;
 };
 
 type PackageBoundaries = {
@@ -101,6 +104,15 @@ function listTypeScriptProgramFiles(tsconfigPath: string): string[] {
 	);
 
 	return output.split(/\r?\n/).filter(Boolean);
+}
+
+function listProductionTraceCoreClaims(
+	productionTraces: ProductionTraceBoundary,
+): ProductionTraceSourceClaim[] {
+	return [
+		productionTraces.typescriptOpenContract,
+		productionTraces.typescriptOpenTaxonomy,
+	];
 }
 
 describe("package boundaries", () => {
@@ -191,22 +203,52 @@ describe("package boundaries", () => {
 		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
 			expect(core.exactIncludes).toContain(sourceInclude);
 		}
+	});
+
+	it("claims production trace taxonomy as explicit TypeScript core-owned open vocabulary", () => {
+		const boundaries = loadBoundaries();
+		const core = boundaries.typescript.core;
+		const productionTraces =
+			boundaries.mixedDomains.productionTraces.typescriptOpenTaxonomy;
+
+		expect(productionTraces.coreOwnedSourceIncludes).toEqual([
+			"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
+			"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
+			"../../../ts/src/production-traces/taxonomy/index.ts",
+		]);
+		expect(productionTraces.coreOwnedProgramPathSubstrings).toEqual([
+			"/ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
+			"/ts/src/production-traces/taxonomy/openai-error-reasons.ts",
+			"/ts/src/production-traces/taxonomy/index.ts",
+		]);
+		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
+			expect(core.exactIncludes).toContain(sourceInclude);
+		}
+	});
+
+	it("keeps TypeScript production trace core ownership limited to explicit open claims", () => {
+		const boundaries = loadBoundaries();
+		const core = boundaries.typescript.core;
+		const productionTraces = boundaries.mixedDomains.productionTraces;
+		const ownedPathSubstrings = listProductionTraceCoreClaims(
+			productionTraces,
+		).flatMap((claim) => claim.coreOwnedProgramPathSubstrings);
 
 		const fileList = listTypeScriptProgramFiles(core.tsconfigPath);
 		const productionTraceFiles = fileList.filter((entry) =>
 			entry.includes("/ts/src/production-traces/"),
 		);
 		expect(productionTraceFiles).toHaveLength(
-			productionTraces.coreOwnedProgramPathSubstrings.length,
+			ownedPathSubstrings.length,
 		);
-		for (const ownedPath of productionTraces.coreOwnedProgramPathSubstrings) {
+		for (const ownedPath of ownedPathSubstrings) {
 			expect(
 				productionTraceFiles.some((entry) => entry.includes(ownedPath)),
 			).toBe(true);
 		}
 		for (const filePath of productionTraceFiles) {
 			expect(
-				productionTraces.coreOwnedProgramPathSubstrings.some((ownedPath) =>
+				ownedPathSubstrings.some((ownedPath) =>
 					filePath.includes(ownedPath),
 				),
 			).toBe(true);


### PR DESCRIPTION
## Summary

- claim the production-trace taxonomy sources as a separate TypeScript core-owned open vocabulary slice
- export provider error and outcome taxonomy constants/types from @autocontext/core
- keep production-trace core ownership constrained to explicit manifest claims instead of broad directory ownership
- update the knowledge/trace boundary map with the taxonomy source-ownership decision

## TDD notes

RED was observed before implementation:

- `claims production trace taxonomy as explicit TypeScript core-owned open vocabulary` failed because `typescriptOpenTaxonomy` was missing from `packages/package-boundaries.json`
- `keeps TypeScript production trace core ownership limited to explicit open claims` failed for the same missing claim

GREEN:

- added the taxonomy claim to `packages/package-boundaries.json`
- added exact taxonomy includes to `packages/ts/core/tsconfig.json`
- exported taxonomy constants/types from `packages/ts/core/src/index.ts`

## DDD / DRY notes

- DDD: taxonomy is shared provider error/outcome vocabulary and does not depend on branded IDs, emit SDK helpers, CLI workflows, ingestion, datasets, retention, or public-trace workflows.
- DRY: `packages/package-boundaries.json` remains the single source for exact core includes and production-trace core ownership claims.
- Parallelism: this intentionally avoids `contract/branded-ids.ts`, `contract/types.ts`, factories, validators, content-addressing, and SDK helpers so another agent can work that dependency shape independently.

## Verification

- `cd ts && npx vitest run tests/package-boundaries.test.ts tests/package-topology.test.ts --run`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- `cd ts && npm run lint`
- `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `git diff --check`

## Licensing note

No license metadata is changed here. AC-645 remains deferred and AC-646 remains the blocker for any non-Apache relicensing.