### PR TITLE
AC-650 Own production trace branded IDs in core

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -132,10 +132,10 @@ These are not AC-645 license metadata. They are future product placement notes.
 
 ### TypeScript Production Traces and Public Traces
 
-The first source-ownership slice claims `ts/src/production-traces/contract/generated-types.ts`
-for the TypeScript core package because it is generated from the public
-production-trace JSON schemas and has no CLI, ingestion, dataset, retention,
-server, MCP, or control-plane dependencies.
+The first source-ownership slices claim `ts/src/production-traces/contract/generated-types.ts`
+and `ts/src/production-traces/contract/branded-ids.ts` for the TypeScript core
+package because they are public production-trace contract sources with no CLI,
+ingestion, dataset, retention, server, MCP, or control-plane dependencies.
 
 The next independent source-ownership slice claims `ts/src/production-traces/taxonomy/**`
 for the TypeScript core package because it is shared provider error/outcome

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -109,6 +109,7 @@
 				"../../../ts/src/storage/storage-contracts.ts",
 				"../../../ts/src/types/index.ts",
 				"../../../ts/src/production-traces/contract/generated-types.ts",
+				"../../../ts/src/production-traces/contract/branded-ids.ts",
 				"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/index.ts"
@@ -158,10 +159,18 @@
 		"productionTraces": {
 			"typescriptOpenContract": {
 				"coreOwnedSourceIncludes": [
-					"../../../ts/src/production-traces/contract/generated-types.ts"
+					"../../../ts/src/production-traces/contract/generated-types.ts",
+					"../../../ts/src/production-traces/contract/branded-ids.ts"
 				],
 				"coreOwnedProgramPathSubstrings": [
-					"/ts/src/production-traces/contract/generated-types.ts"
+					"/ts/src/production-traces/contract/generated-types.ts",
+					"/ts/src/production-traces/contract/branded-ids.ts"
+				],
+				"forbiddenImportPathSubstrings": [
+					"control-plane/"
+				],
+				"requiredPackageDependencies": [
+					"ulid"
 				]
 			},
 			"typescriptOpenTaxonomy": {

--- a/packages/ts/core/package.json
+++ b/packages/ts/core/package.json
@@ -20,5 +20,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "ulid": "^3.0.2"
   }
 }

--- a/packages/ts/core/src/index.ts
+++ b/packages/ts/core/src/index.ts
@@ -10,6 +10,28 @@ export { parseJudgeResponse } from "../../../../ts/src/judge/parse.js";
 export type { RubricCoherenceResult } from "../../../../ts/src/judge/rubric-coherence.js";
 export { checkRubricCoherence } from "../../../../ts/src/judge/rubric-coherence.js";
 export type {
+	AppId,
+	ContentHash,
+	EnvironmentTag,
+	FeedbackRefId,
+	ProductionTraceId,
+	Scenario,
+	SessionIdHash,
+	UserIdHash,
+} from "../../../../ts/src/production-traces/contract/branded-ids.js";
+export {
+	defaultEnvironmentTag,
+	newProductionTraceId,
+	parseAppId,
+	parseContentHash,
+	parseEnvironmentTag,
+	parseFeedbackRefId,
+	parseProductionTraceId,
+	parseScenario,
+	parseSessionIdHash,
+	parseUserIdHash,
+} from "../../../../ts/src/production-traces/contract/branded-ids.js";
+export type {
 	ProductionOutcome,
 	ProductionTrace,
 	TraceLinks,

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -18,6 +18,7 @@
 		"../../../ts/src/storage/storage-contracts.ts",
 		"../../../ts/src/types/index.ts",
 		"../../../ts/src/production-traces/contract/generated-types.ts",
+		"../../../ts/src/production-traces/contract/branded-ids.ts",
 		"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/index.ts"

--- a/ts/src/control-plane/contract/branded-ids.ts
+++ b/ts/src/control-plane/contract/branded-ids.ts
@@ -1,58 +1,47 @@
 import { ulid } from "ulid";
 
+export type {
+	ContentHash,
+	EnvironmentTag,
+	Scenario,
+} from "../../production-traces/contract/branded-ids.js";
+export {
+	defaultEnvironmentTag,
+	parseContentHash,
+	parseEnvironmentTag,
+	parseScenario,
+} from "../../production-traces/contract/branded-ids.js";
+
 declare const brand: unique symbol;
 type Brand<T, B> = T & { readonly [brand]: B };
 
-export type ArtifactId     = Brand<string, "ArtifactId">;
-export type ChangeSetId    = Brand<string, "ChangeSetId">;
-export type Scenario       = Brand<string, "Scenario">;
-export type EnvironmentTag = Brand<string, "EnvironmentTag">;
-export type SuiteId        = Brand<string, "SuiteId">;
-export type ContentHash    = Brand<string, "ContentHash">;
+export type ArtifactId = Brand<string, "ArtifactId">;
+export type ChangeSetId = Brand<string, "ChangeSetId">;
+export type SuiteId = Brand<string, "SuiteId">;
 
 // Crockford base32: 0-9 A-H J K M N P-T V-Z (excludes I L O U). ULID is 26 chars.
 const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
-// Scenario / SuiteId: lowercase alnum + hyphen + underscore, non-empty, no path separators.
+// SuiteId: lowercase alnum + hyphen + underscore, non-empty, no path separators.
 const SLUG_RE = /^[a-z0-9][a-z0-9_-]*$/;
-// EnvironmentTag: slightly more permissive (allows tenant prefixes) but still path-safe.
-const ENV_TAG_RE = /^[a-z0-9][a-z0-9_-]*$/i;
-// sha256:<64 lowercase hex>.
-const CONTENT_HASH_RE = /^sha256:[0-9a-f]{64}$/;
 
 export function newArtifactId(): ArtifactId {
-  return ulid() as ArtifactId;
+	return ulid() as ArtifactId;
 }
 
 export function parseArtifactId(input: string): ArtifactId | null {
-  return ULID_RE.test(input) ? (input as ArtifactId) : null;
+	return ULID_RE.test(input) ? (input as ArtifactId) : null;
 }
 
 export function newChangeSetId(): ChangeSetId {
-  return ulid() as ChangeSetId;
+	return ulid() as ChangeSetId;
 }
 
 export function parseChangeSetId(input: string): ChangeSetId | null {
-  return ULID_RE.test(input) ? (input as ChangeSetId) : null;
-}
-
-export function parseScenario(input: string): Scenario | null {
-  return SLUG_RE.test(input) ? (input as Scenario) : null;
-}
-
-export function parseEnvironmentTag(input: string): EnvironmentTag | null {
-  if (input === ".." || input.includes("/") || input.includes("\\")) return null;
-  return ENV_TAG_RE.test(input) ? (input as EnvironmentTag) : null;
-}
-
-export function defaultEnvironmentTag(): EnvironmentTag {
-  return "production" as EnvironmentTag;
+	return ULID_RE.test(input) ? (input as ChangeSetId) : null;
 }
 
 export function parseSuiteId(input: string): SuiteId | null {
-  if (input === ".." || input.includes("/") || input.includes("\\")) return null;
-  return SLUG_RE.test(input) ? (input as SuiteId) : null;
-}
-
-export function parseContentHash(input: string): ContentHash | null {
-  return CONTENT_HASH_RE.test(input) ? (input as ContentHash) : null;
+	if (input === ".." || input.includes("/") || input.includes("\\"))
+		return null;
+	return SLUG_RE.test(input) ? (input as SuiteId) : null;
 }

--- a/ts/src/production-traces/contract/branded-ids.ts
+++ b/ts/src/production-traces/contract/branded-ids.ts
@@ -5,56 +5,69 @@ type Brand<T, B> = T & { readonly [brand]: B };
 
 // Branded IDs introduced by the production-traces contract.
 export type ProductionTraceId = Brand<string, "ProductionTraceId">;
-export type AppId             = Brand<string, "AppId">;
-export type UserIdHash        = Brand<string, "UserIdHash">;
-export type SessionIdHash     = Brand<string, "SessionIdHash">;
-export type FeedbackRefId     = Brand<string, "FeedbackRefId">;
+export type AppId = Brand<string, "AppId">;
+export type UserIdHash = Brand<string, "UserIdHash">;
+export type SessionIdHash = Brand<string, "SessionIdHash">;
+export type FeedbackRefId = Brand<string, "FeedbackRefId">;
+export type EnvironmentTag = Brand<string, "EnvironmentTag">;
+export type ContentHash = Brand<string, "ContentHash">;
+export type Scenario = Brand<string, "Scenario">;
 
 // Crockford base32: 0-9 A-H J K M N P-T V-Z (excludes I L O U). ULID is 26 chars.
 const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
-// AppId: lowercase alnum start + [a-z0-9_-]* — path-safe and grep-friendly.
-const APP_ID_RE = /^[a-z0-9][a-z0-9_-]*$/;
+// AppId and Scenario: lowercase alnum start + [a-z0-9_-]* — path-safe and grep-friendly.
+const SLUG_RE = /^[a-z0-9][a-z0-9_-]*$/;
+// EnvironmentTag: slightly more permissive (allows tenant prefixes) but still path-safe.
+const ENV_TAG_RE = /^[a-z0-9][a-z0-9_-]*$/i;
 // SHA-256 hex — 64 chars, lowercase.
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+// sha256:<64 lowercase hex>.
+const CONTENT_HASH_RE = /^sha256:[0-9a-f]{64}$/;
 
 export function newProductionTraceId(): ProductionTraceId {
-  return ulid() as ProductionTraceId;
+	return ulid() as ProductionTraceId;
 }
 
-export function parseProductionTraceId(input: string): ProductionTraceId | null {
-  return ULID_RE.test(input) ? (input as ProductionTraceId) : null;
+export function parseProductionTraceId(
+	input: string,
+): ProductionTraceId | null {
+	return ULID_RE.test(input) ? (input as ProductionTraceId) : null;
 }
 
 export function parseAppId(input: string): AppId | null {
-  if (input === ".." || input.includes("/") || input.includes("\\")) return null;
-  return APP_ID_RE.test(input) ? (input as AppId) : null;
+	if (input === ".." || input.includes("/") || input.includes("\\"))
+		return null;
+	return SLUG_RE.test(input) ? (input as AppId) : null;
 }
 
 export function parseUserIdHash(input: string): UserIdHash | null {
-  return SHA256_HEX_RE.test(input) ? (input as UserIdHash) : null;
+	return SHA256_HEX_RE.test(input) ? (input as UserIdHash) : null;
 }
 
 export function parseSessionIdHash(input: string): SessionIdHash | null {
-  return SHA256_HEX_RE.test(input) ? (input as SessionIdHash) : null;
+	return SHA256_HEX_RE.test(input) ? (input as SessionIdHash) : null;
 }
 
 export function parseFeedbackRefId(input: string): FeedbackRefId | null {
-  // Opaque customer-supplied identifier: reject only if fully whitespace or empty.
-  if (input.trim().length === 0) return null;
-  return input as FeedbackRefId;
+	// Opaque customer-supplied identifier: reject only if fully whitespace or empty.
+	if (input.trim().length === 0) return null;
+	return input as FeedbackRefId;
 }
 
-// Re-exports from control-plane/contract/ for ergonomic downstream imports.
-// Do NOT duplicate — downstream consumers should import these brands from here
-// so production-traces stays the single import origin for this contract.
-export {
-  parseEnvironmentTag,
-  defaultEnvironmentTag,
-  parseContentHash,
-  parseScenario,
-} from "../../control-plane/contract/branded-ids.js";
-export type {
-  EnvironmentTag,
-  ContentHash,
-  Scenario,
-} from "../../control-plane/contract/branded-ids.js";
+export function parseEnvironmentTag(input: string): EnvironmentTag | null {
+	if (input === ".." || input.includes("/") || input.includes("\\"))
+		return null;
+	return ENV_TAG_RE.test(input) ? (input as EnvironmentTag) : null;
+}
+
+export function defaultEnvironmentTag(): EnvironmentTag {
+	return "production" as EnvironmentTag;
+}
+
+export function parseContentHash(input: string): ContentHash | null {
+	return CONTENT_HASH_RE.test(input) ? (input as ContentHash) : null;
+}
+
+export function parseScenario(input: string): Scenario | null {
+	return SLUG_RE.test(input) ? (input as Scenario) : null;
+}

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -37,8 +37,13 @@ type ProductionTraceSourceClaim = {
 	coreOwnedProgramPathSubstrings: string[];
 };
 
+type ProductionTraceOpenContractClaim = ProductionTraceSourceClaim & {
+	forbiddenImportPathSubstrings: string[];
+	requiredPackageDependencies: string[];
+};
+
 type ProductionTraceBoundary = {
-	typescriptOpenContract: ProductionTraceSourceClaim;
+	typescriptOpenContract: ProductionTraceOpenContractClaim;
 	typescriptOpenTaxonomy: ProductionTraceSourceClaim;
 };
 
@@ -113,6 +118,12 @@ function listProductionTraceCoreClaims(
 		productionTraces.typescriptOpenContract,
 		productionTraces.typescriptOpenTaxonomy,
 	];
+}
+
+function importSpecifiers(sourceText: string): string[] {
+	return [...sourceText.matchAll(/(?:from|import)\s*["']([^"']+)["']/g)].map(
+		(match) => match[1],
+	);
 }
 
 describe("package boundaries", () => {
@@ -196,9 +207,11 @@ describe("package boundaries", () => {
 
 		expect(productionTraces.coreOwnedSourceIncludes).toEqual([
 			"../../../ts/src/production-traces/contract/generated-types.ts",
+			"../../../ts/src/production-traces/contract/branded-ids.ts",
 		]);
 		expect(productionTraces.coreOwnedProgramPathSubstrings).toEqual([
 			"/ts/src/production-traces/contract/generated-types.ts",
+			"/ts/src/production-traces/contract/branded-ids.ts",
 		]);
 		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
 			expect(core.exactIncludes).toContain(sourceInclude);
@@ -252,6 +265,43 @@ describe("package boundaries", () => {
 					filePath.includes(ownedPath),
 				),
 			).toBe(true);
+		}
+	});
+
+	it("keeps production trace open contract sources independent of control-plane imports", () => {
+		const productionTraces =
+			loadBoundaries().mixedDomains.productionTraces.typescriptOpenContract;
+
+		expect(productionTraces.forbiddenImportPathSubstrings).toEqual([
+			"control-plane/",
+		]);
+		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
+			const sourceText = readFileSync(
+				join(repoRoot, "packages", "ts", "core", sourceInclude),
+				"utf-8",
+			);
+			const imports = importSpecifiers(sourceText);
+			for (const forbidden of productionTraces.forbiddenImportPathSubstrings) {
+				expect(imports.some((specifier) => specifier.includes(forbidden))).toBe(
+					false,
+				);
+			}
+		}
+	});
+
+	it("declares runtime dependencies needed by production trace open contract sources", () => {
+		const boundaries = loadBoundaries();
+		const core = boundaries.typescript.core;
+		const productionTraces =
+			boundaries.mixedDomains.productionTraces.typescriptOpenContract;
+		const packageJson = loadJson<TsPackageJson>(
+			join(repoRoot, core.packagePath, "package.json"),
+		);
+		const dependencies = packageJson.dependencies ?? {};
+
+		expect(productionTraces.requiredPackageDependencies).toEqual(["ulid"]);
+		for (const dependency of productionTraces.requiredPackageDependencies) {
+			expect(Object.keys(dependencies)).toContain(dependency);
 		}
 	});
 


### PR DESCRIPTION
## Summary

- claim `ts/src/production-traces/contract/branded-ids.ts` for the TypeScript core package
- move shared public-contract brands (`Scenario`, `EnvironmentTag`, `ContentHash`) into the production-traces contract origin
- make control-plane branded IDs re-export those shared brands/functions instead of being the upstream dependency
- export production-trace branded IDs/parsers from `@autocontext/core`
- declare the core package runtime dependency on `ulid`
- keep CLI, ingest, dataset, retention, public-trace workflow, and control-plane paths blocked from the core program

## TDD notes

RED was observed after adding the manifest/test expectations and before implementation:

- `requires exact include paths for the TypeScript core package` failed because the core tsconfig did not include `../../../ts/src/production-traces/contract/branded-ids.ts`
- `claims only explicit production trace open contract sources in the TypeScript core package` failed because the core program listed only one production-trace file instead of two
- `keeps production trace open contract sources independent of control-plane imports` failed because `branded-ids.ts` imported `../../control-plane/contract/branded-ids.js`
- `declares runtime dependencies needed by production trace open contract sources` failed because `@autocontext/core` did not declare `ulid`

GREEN:

- added branded IDs to the core exact include list and package export surface
- moved shared public-contract brand definitions/parsers into production-traces branded IDs
- changed control-plane branded IDs to depend on/re-export the production-traces contract values
- added `ulid` to `@autocontext/core` dependencies

## DDD / DRY notes

- DDD: production-trace public-contract value objects now originate in the production-trace contract context; control-plane payloads depend on that public contract instead of the reverse.
- DRY: `Scenario`, `EnvironmentTag`, and `ContentHash` brands/parsers have one implementation origin.
- Boundary: the core package still blocks control-plane, CLI, ingest, dataset, retention, and public-trace workflow paths.
- Compatibility: existing control-plane imports continue through re-exports; `autoctx`, `autocontext`, and CLI paths are unchanged.

## Verification

- `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `cd ts && npx vitest run tests/package-topology.test.ts tests/package-boundaries.test.ts --run`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- `cd ts && npx vitest run tests/production-traces/sdk/build-trace.test.ts tests/public-trace-schema.test.ts --run`
- `cd ts && npx vitest run tests/control-plane/contract/branded-ids.test.ts tests/control-plane/production-traces/contract/branded-ids.test.ts --run`
- `git diff --check`

## Licensing note

No license metadata is changed here. AC-645 remains deferred and AC-646 remains the blocker for any non-Apache relicensing.
