### PR TITLE
AC-650 Claim production trace content address in core

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -133,7 +133,8 @@ These are not AC-645 license metadata. They are future product placement notes.
 ### TypeScript Production Traces and Public Traces
 
 The first source-ownership slices claim `ts/src/production-traces/contract/generated-types.ts`
-and `ts/src/production-traces/contract/branded-ids.ts` for the TypeScript core
+`ts/src/production-traces/contract/branded-ids.ts`, and
+`ts/src/production-traces/contract/content-address.ts` for the TypeScript core
 package because they are public production-trace contract sources with no CLI,
 ingestion, dataset, retention, server, MCP, or control-plane dependencies.
 

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -110,6 +110,7 @@
 				"../../../ts/src/types/index.ts",
 				"../../../ts/src/production-traces/contract/generated-types.ts",
 				"../../../ts/src/production-traces/contract/branded-ids.ts",
+				"../../../ts/src/production-traces/contract/content-address.ts",
 				"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/index.ts"
@@ -160,11 +161,13 @@
 			"typescriptOpenContract": {
 				"coreOwnedSourceIncludes": [
 					"../../../ts/src/production-traces/contract/generated-types.ts",
-					"../../../ts/src/production-traces/contract/branded-ids.ts"
+					"../../../ts/src/production-traces/contract/branded-ids.ts",
+					"../../../ts/src/production-traces/contract/content-address.ts"
 				],
 				"coreOwnedProgramPathSubstrings": [
 					"/ts/src/production-traces/contract/generated-types.ts",
-					"/ts/src/production-traces/contract/branded-ids.ts"
+					"/ts/src/production-traces/contract/branded-ids.ts",
+					"/ts/src/production-traces/contract/content-address.ts"
 				],
 				"forbiddenImportPathSubstrings": [
 					"control-plane/"

--- a/packages/ts/core/src/index.ts
+++ b/packages/ts/core/src/index.ts
@@ -31,6 +31,7 @@ export {
 	parseSessionIdHash,
 	parseUserIdHash,
 } from "../../../../ts/src/production-traces/contract/branded-ids.js";
+export { deriveDatasetId } from "../../../../ts/src/production-traces/contract/content-address.js";
 export type {
 	ProductionOutcome,
 	ProductionTrace,

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -3,7 +3,9 @@
 	"compilerOptions": {
 		"rootDir": "../../..",
 		"outDir": "./dist",
-		"noEmit": false
+		"noEmit": false,
+		"typeRoots": ["../../../ts/node_modules/@types"],
+		"types": ["node"]
 	},
 	"include": [
 		"src/index.ts",
@@ -19,6 +21,7 @@
 		"../../../ts/src/types/index.ts",
 		"../../../ts/src/production-traces/contract/generated-types.ts",
 		"../../../ts/src/production-traces/contract/branded-ids.ts",
+		"../../../ts/src/production-traces/contract/content-address.ts",
 		"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/index.ts"

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -208,10 +208,12 @@ describe("package boundaries", () => {
 		expect(productionTraces.coreOwnedSourceIncludes).toEqual([
 			"../../../ts/src/production-traces/contract/generated-types.ts",
 			"../../../ts/src/production-traces/contract/branded-ids.ts",
+			"../../../ts/src/production-traces/contract/content-address.ts",
 		]);
 		expect(productionTraces.coreOwnedProgramPathSubstrings).toEqual([
 			"/ts/src/production-traces/contract/generated-types.ts",
 			"/ts/src/production-traces/contract/branded-ids.ts",
+			"/ts/src/production-traces/contract/content-address.ts",
 		]);
 		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
 			expect(core.exactIncludes).toContain(sourceInclude);


### PR DESCRIPTION
## Summary

- claim `ts/src/production-traces/contract/content-address.ts` for the TypeScript core package
- export `deriveDatasetId` from `@autocontext/core`
- keep production-trace core ownership constrained to explicit manifest claims
- opt the core package tsconfig into Node built-in types needed by `node:crypto`
- update the knowledge/trace boundary map with the content-address source-ownership decision

## TDD notes

RED was observed before implementation:

- `claims only explicit production trace open contract sources in the TypeScript core package` failed because `content-address.ts` was not in `typescriptOpenContract.coreOwnedSourceIncludes`
- after adding the exact include, core package typecheck/build failed because `content-address.ts` imports `node:crypto` and the package skeleton did not resolve Node built-in types

GREEN:

- added `content-address.ts` to `packages/package-boundaries.json` and `packages/ts/core/tsconfig.json`
- exported `deriveDatasetId` from `packages/ts/core/src/index.ts`
- added explicit `typeRoots`/`types` for Node built-in types in the core package tsconfig

## DDD / DRY notes

- DDD: content-addressing is public production-trace contract logic: deterministic dataset ID derivation from public content hashes.
- DRY: `packages/package-boundaries.json` remains the single source for exact core includes and production-trace core ownership claims.
- Parallelism: this intentionally avoids `contract/types.ts`, factories, validators, SDK helpers, CLI, ingest, dataset workflows, retention, and public-trace workflows so the other agent's types slice can proceed independently.

## Verification

- `cd ts && npx vitest run tests/package-boundaries.test.ts tests/package-topology.test.ts --run`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- `cd ts && npm run lint`
- `cd ts && npx vitest run tests/control-plane/production-traces/contract/content-address.test.ts tests/control-plane/production-traces/dataset/manifest.test.ts --run`
- `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `git diff --check`

## Licensing note

No license metadata is changed here. AC-645 remains deferred and AC-646 remains the blocker for any non-Apache relicensing.