### PR TITLE
AC-650 Claim production trace contract types in core

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -132,8 +132,9 @@ These are not AC-645 license metadata. They are future product placement notes.
 
 ### TypeScript Production Traces and Public Traces
 
-The first source-ownership slices claim `ts/src/production-traces/contract/generated-types.ts`
-`ts/src/production-traces/contract/branded-ids.ts`, and
+The first source-ownership slices claim `ts/src/production-traces/contract/generated-types.ts`,
+`ts/src/production-traces/contract/branded-ids.ts`,
+`ts/src/production-traces/contract/types.ts`, and
 `ts/src/production-traces/contract/content-address.ts` for the TypeScript core
 package because they are public production-trace contract sources with no CLI,
 ingestion, dataset, retention, server, MCP, or control-plane dependencies.

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -110,6 +110,7 @@
 				"../../../ts/src/types/index.ts",
 				"../../../ts/src/production-traces/contract/generated-types.ts",
 				"../../../ts/src/production-traces/contract/branded-ids.ts",
+				"../../../ts/src/production-traces/contract/types.ts",
 				"../../../ts/src/production-traces/contract/content-address.ts",
 				"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
@@ -162,11 +163,13 @@
 				"coreOwnedSourceIncludes": [
 					"../../../ts/src/production-traces/contract/generated-types.ts",
 					"../../../ts/src/production-traces/contract/branded-ids.ts",
+					"../../../ts/src/production-traces/contract/types.ts",
 					"../../../ts/src/production-traces/contract/content-address.ts"
 				],
 				"coreOwnedProgramPathSubstrings": [
 					"/ts/src/production-traces/contract/generated-types.ts",
 					"/ts/src/production-traces/contract/branded-ids.ts",
+					"/ts/src/production-traces/contract/types.ts",
 					"/ts/src/production-traces/contract/content-address.ts"
 				],
 				"forbiddenImportPathSubstrings": [

--- a/packages/ts/core/src/index.ts
+++ b/packages/ts/core/src/index.ts
@@ -33,11 +33,22 @@ export {
 } from "../../../../ts/src/production-traces/contract/branded-ids.js";
 export { deriveDatasetId } from "../../../../ts/src/production-traces/contract/content-address.js";
 export type {
+	DetectedBy,
+	FeedbackKind,
+	MessageRole,
+	ModelRoutingDecisionReason,
+	ModelRoutingFallbackReason,
+	OutcomeLabel,
 	ProductionOutcome,
 	ProductionTrace,
+	ProductionTraceSchemaVersion,
+	ProviderName,
+	RedactionReason,
 	TraceLinks,
 	TraceSource,
-} from "../../../../ts/src/production-traces/contract/generated-types.js";
+	ValidationResult,
+} from "../../../../ts/src/production-traces/contract/types.js";
+export { PRODUCTION_TRACE_SCHEMA_VERSION } from "../../../../ts/src/production-traces/contract/types.js";
 export type {
 	AnthropicErrorReasonKey,
 	OpenAiErrorReasonKey,

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -21,6 +21,7 @@
 		"../../../ts/src/types/index.ts",
 		"../../../ts/src/production-traces/contract/generated-types.ts",
 		"../../../ts/src/production-traces/contract/branded-ids.ts",
+		"../../../ts/src/production-traces/contract/types.ts",
 		"../../../ts/src/production-traces/contract/content-address.ts",
 		"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",

--- a/ts/tests/core-package.test.ts
+++ b/ts/tests/core-package.test.ts
@@ -1,10 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import type {
   AgentOutputRow,
   AgentTaskInterface,
   AgentTaskResult,
+  AppId,
   ArtifactEditingInterface,
+  EnvironmentTag,
   ExecutionLimits,
+  FeedbackRefId,
   GenerationRow,
   HumanFeedbackRow,
   InvestigationInterface,
@@ -14,18 +19,24 @@ import type {
   CoordinationInterface,
   Observation,
   OperatorLoopInterface,
+  ProductionTrace,
+  ProductionTraceId,
   RecordMatchOpts,
   ReplayEnvelope,
   Result,
   RunRow,
+  Scenario,
   ScenarioInterface,
   SchemaEvolutionInterface,
   ScoringDimension,
+  SessionIdHash,
   SimulationInterface,
   TaskQueueRow,
   ToolFragilityInterface,
+  TraceSource,
   TrajectoryRow,
   UpsertGenerationOpts,
+  UserIdHash,
   WorkflowInterface,
 } from "../../packages/ts/core/src/index.ts";
 import {
@@ -39,6 +50,7 @@ import {
   expectedScore,
   ObservationSchema,
   ProviderError,
+  PRODUCTION_TRACE_SCHEMA_VERSION,
   packageRole,
   packageTopologyVersion,
   parseJudgeResponse,
@@ -47,10 +59,86 @@ import {
   updateElo,
 } from "../../packages/ts/core/src/index.ts";
 
+const repoRoot = join(import.meta.dirname, "..", "..");
+
 describe("@autocontext/core facade", () => {
   it("preserves the core package identity", () => {
     expect(packageRole).toBe("core");
     expect(packageTopologyVersion).toBe(1);
+  });
+
+  it("re-exports production trace contracts from the handwritten contract surface", () => {
+    const facadeSource = readFileSync(
+      join(repoRoot, "packages", "ts", "core", "src", "index.ts"),
+      "utf-8",
+    );
+    const typeExports = [
+      ...facadeSource.matchAll(/export type \{([\s\S]*?)\} from "([^"]+)";/g),
+    ].map((match) => ({
+      specifiers: match[1]?.match(/\b[A-Za-z][A-Za-z0-9_]*\b/g) ?? [],
+      source: match[2],
+    }));
+    const sourceFor = (specifier: string) =>
+      typeExports.find((entry) => entry.specifiers.includes(specifier))?.source;
+
+    expect(PRODUCTION_TRACE_SCHEMA_VERSION).toBe("1.0");
+    expect(sourceFor("ProductionTrace")).toBe(
+      "../../../../ts/src/production-traces/contract/types.js",
+    );
+    expect(sourceFor("ProductionOutcome")).toBe(
+      "../../../../ts/src/production-traces/contract/types.js",
+    );
+
+    const traceSource: TraceSource = {
+      emitter: "gateway",
+      sdk: { name: "autoctx", version: "0.1.0" },
+    };
+    const trace: ProductionTrace = {
+      schemaVersion: PRODUCTION_TRACE_SCHEMA_VERSION,
+      traceId: "01ARZ3NDEKTSV4RRFFQ69G5FAV" as ProductionTraceId,
+      source: traceSource,
+      provider: { name: "anthropic" },
+      model: "claude-sonnet",
+      session: {
+        userIdHash: "a".repeat(64) as UserIdHash,
+        sessionIdHash: "b".repeat(64) as SessionIdHash,
+      },
+      env: {
+        environmentTag: "production" as EnvironmentTag,
+        appId: "support-bot" as AppId,
+      },
+      messages: [
+        {
+          role: "user",
+          content: "help me with a refund",
+          timestamp: "2026-04-25T00:00:00Z",
+        },
+      ],
+      toolCalls: [],
+      timing: {
+        startedAt: "2026-04-25T00:00:00Z",
+        endedAt: "2026-04-25T00:00:01Z",
+        latencyMs: 1000,
+      },
+      usage: {
+        tokensIn: 10,
+        tokensOut: 5,
+      },
+      feedbackRefs: [
+        {
+          kind: "rating",
+          submittedAt: "2026-04-25T00:00:02Z",
+          ref: "feedback-1" as FeedbackRefId,
+        },
+      ],
+      links: {
+        scenarioId: "grid_ctf" as Scenario,
+      },
+      redactions: [],
+    };
+
+    expect(trace.source).toBe(traceSource);
+    expect(trace.traceId).toBe("01ARZ3NDEKTSV4RRFFQ69G5FAV");
   });
 
   it("re-exports Elo primitives from the core-safe execution surface", () => {

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -208,11 +208,13 @@ describe("package boundaries", () => {
 		expect(productionTraces.coreOwnedSourceIncludes).toEqual([
 			"../../../ts/src/production-traces/contract/generated-types.ts",
 			"../../../ts/src/production-traces/contract/branded-ids.ts",
+			"../../../ts/src/production-traces/contract/types.ts",
 			"../../../ts/src/production-traces/contract/content-address.ts",
 		]);
 		expect(productionTraces.coreOwnedProgramPathSubstrings).toEqual([
 			"/ts/src/production-traces/contract/generated-types.ts",
 			"/ts/src/production-traces/contract/branded-ids.ts",
+			"/ts/src/production-traces/contract/types.ts",
 			"/ts/src/production-traces/contract/content-address.ts",
 		]);
 		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
@@ -253,9 +255,7 @@ describe("package boundaries", () => {
 		const productionTraceFiles = fileList.filter((entry) =>
 			entry.includes("/ts/src/production-traces/"),
 		);
-		expect(productionTraceFiles).toHaveLength(
-			ownedPathSubstrings.length,
-		);
+		expect(productionTraceFiles).toHaveLength(ownedPathSubstrings.length);
 		for (const ownedPath of ownedPathSubstrings) {
 			expect(
 				productionTraceFiles.some((entry) => entry.includes(ownedPath)),
@@ -263,9 +263,7 @@ describe("package boundaries", () => {
 		}
 		for (const filePath of productionTraceFiles) {
 			expect(
-				ownedPathSubstrings.some((ownedPath) =>
-					filePath.includes(ownedPath),
-				),
+				ownedPathSubstrings.some((ownedPath) => filePath.includes(ownedPath)),
 			).toBe(true);
 		}
 	});


### PR DESCRIPTION
## Summary

- claim `ts/src/production-traces/contract/types.ts` for the TypeScript core package
- extend the shared production-trace open-contract manifest claim to include the hand-written contract type source
- export selected stable production-trace contract literals/types from `@autocontext/core`
- keep production-traces CLI, ingest, dataset, retention, public-trace workflow, and control-plane paths blocked from the core program

## TDD notes

RED was observed after adding the manifest/test expectations and before the core package implementation:

- `requires exact include paths for the TypeScript core package` failed because `packages/ts/core/tsconfig.json` did not include `../../../ts/src/production-traces/contract/types.ts`
- `keeps TypeScript production trace core ownership limited to explicit open claims` failed because the core program listed five production-trace files while the manifest expected six

GREEN:

- added `types.ts` to `packages/ts/core/tsconfig.json`
- exported selected contract vocabulary from `packages/ts/core/src/index.ts`:
  - `PRODUCTION_TRACE_SCHEMA_VERSION`
  - `ProductionTraceSchemaVersion`
  - `ProviderName`
  - `MessageRole`
  - `OutcomeLabel`
  - `FeedbackKind`
  - `RedactionReason`
  - `DetectedBy`
  - `ModelRoutingDecisionReason`
  - `ModelRoutingFallbackReason`
  - `ValidationResult`
- updated the boundary map to record the new source-ownership slice

## DDD / DRY notes

- DDD: this keeps handwritten production-trace contract vocabulary in the open/core contract context.
- DRY: `packages/package-boundaries.json` remains the source of truth for core-owned production-trace sources; package topology tests reuse the manifest.
- Boundary: validators/JSON-schema runtime, CLI, ingest, dataset, retention, and public-trace workflows remain outside core.
- Compatibility: no `autoctx`, `autocontext`, or CLI paths changed.

## Verification

- `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `cd ts && npx vitest run tests/package-topology.test.ts tests/package-boundaries.test.ts --run`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- `cd ts && npx vitest run tests/production-traces/sdk/build-trace.test.ts tests/public-trace-schema.test.ts --run`
- `cd ts && npx vitest run tests/control-plane/contract/branded-ids.test.ts tests/control-plane/production-traces/contract/branded-ids.test.ts --run`
- `git diff --check`

## Licensing note

No license metadata is changed here. AC-645 remains deferred and AC-646 remains the blocker for any non-Apache relicensing.
