### PR TITLE
AC-650 Claim production trace pure helpers in core

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -136,7 +136,10 @@ The first source-ownership slices claim `ts/src/production-traces/contract/gener
 `ts/src/production-traces/contract/branded-ids.ts`,
 `ts/src/production-traces/contract/types.ts`, and
 `ts/src/production-traces/contract/content-address.ts` for the TypeScript core
-package because they are public production-trace contract sources with no CLI,
+package. The next pure-helper slice adds
+`ts/src/production-traces/contract/factories.ts` and
+`ts/src/production-traces/contract/invariants.ts` because they are public
+production-trace contract helpers with no CLI,
 ingestion, dataset, retention, server, MCP, or control-plane dependencies.
 
 The next independent source-ownership slice claims `ts/src/production-traces/taxonomy/**`

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -112,6 +112,8 @@
 				"../../../ts/src/production-traces/contract/branded-ids.ts",
 				"../../../ts/src/production-traces/contract/types.ts",
 				"../../../ts/src/production-traces/contract/content-address.ts",
+				"../../../ts/src/production-traces/contract/factories.ts",
+				"../../../ts/src/production-traces/contract/invariants.ts",
 				"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/index.ts"
@@ -164,13 +166,17 @@
 					"../../../ts/src/production-traces/contract/generated-types.ts",
 					"../../../ts/src/production-traces/contract/branded-ids.ts",
 					"../../../ts/src/production-traces/contract/types.ts",
-					"../../../ts/src/production-traces/contract/content-address.ts"
+					"../../../ts/src/production-traces/contract/content-address.ts",
+					"../../../ts/src/production-traces/contract/factories.ts",
+					"../../../ts/src/production-traces/contract/invariants.ts"
 				],
 				"coreOwnedProgramPathSubstrings": [
 					"/ts/src/production-traces/contract/generated-types.ts",
 					"/ts/src/production-traces/contract/branded-ids.ts",
 					"/ts/src/production-traces/contract/types.ts",
-					"/ts/src/production-traces/contract/content-address.ts"
+					"/ts/src/production-traces/contract/content-address.ts",
+					"/ts/src/production-traces/contract/factories.ts",
+					"/ts/src/production-traces/contract/invariants.ts"
 				],
 				"forbiddenImportPathSubstrings": [
 					"control-plane/"

--- a/packages/ts/core/src/index.ts
+++ b/packages/ts/core/src/index.ts
@@ -32,6 +32,13 @@ export {
 	parseUserIdHash,
 } from "../../../../ts/src/production-traces/contract/branded-ids.js";
 export { deriveDatasetId } from "../../../../ts/src/production-traces/contract/content-address.js";
+export type { CreateProductionTraceInputs } from "../../../../ts/src/production-traces/contract/factories.js";
+export { createProductionTrace } from "../../../../ts/src/production-traces/contract/factories.js";
+export {
+	validateJsonPointer,
+	validateRedactionPaths,
+	validateTimingSanity,
+} from "../../../../ts/src/production-traces/contract/invariants.js";
 export type {
 	DetectedBy,
 	FeedbackKind,

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -23,6 +23,8 @@
 		"../../../ts/src/production-traces/contract/branded-ids.ts",
 		"../../../ts/src/production-traces/contract/types.ts",
 		"../../../ts/src/production-traces/contract/content-address.ts",
+		"../../../ts/src/production-traces/contract/factories.ts",
+		"../../../ts/src/production-traces/contract/invariants.ts",
 		"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/index.ts"

--- a/ts/src/production-traces/contract/invariants.ts
+++ b/ts/src/production-traces/contract/invariants.ts
@@ -49,7 +49,18 @@ export function validateJsonPointer(obj: unknown, pointer: string): ValidationRe
     return { valid: false, errors: [`json pointer '${pointer}' missing leading '/'`] };
   }
   // Split; first element is always empty (before the leading /) so drop it.
-  const tokens = pointer.slice(1).split("/").map(unescapeToken);
+  const rawTokens = pointer.slice(1).split("/");
+  for (const rawToken of rawTokens) {
+    if (/~(?![01])/.test(rawToken)) {
+      return {
+        valid: false,
+        errors: [
+          `json pointer '${pointer}': token '${rawToken}' contains invalid escape; use '~0' for '~' and '~1' for '/'`,
+        ],
+      };
+    }
+  }
+  const tokens = rawTokens.map(unescapeToken);
   let current: unknown = obj;
   for (let i = 0; i < tokens.length; i++) {
     const tok = tokens[i];

--- a/ts/tests/control-plane/production-traces/contract/invariants.test.ts
+++ b/ts/tests/control-plane/production-traces/contract/invariants.test.ts
@@ -122,6 +122,13 @@ describe("validateJsonPointer", () => {
     expect(validateJsonPointer(escaped, "/a~1b").valid).toBe(true);
     expect(validateJsonPointer(escaped, "/c~0d").valid).toBe(true);
   });
+
+  test("rejects invalid RFC 6901 escape sequences before resolving fields", () => {
+    const escaped = { "a~2b": 1, "bad~": 2 };
+
+    expect(validateJsonPointer(escaped, "/a~2b").valid).toBe(false);
+    expect(validateJsonPointer(escaped, "/bad~").valid).toBe(false);
+  });
 });
 
 describe("validateRedactionPaths", () => {
@@ -165,5 +172,24 @@ describe("validateRedactionPaths", () => {
     const r = validateRedactionPaths(t);
     expect(r.valid).toBe(false);
     if (!r.valid) expect(r.errors.some((e) => /messages/.test(e))).toBe(true);
+  });
+
+  test("rejects trace with malformed escaped redaction paths", () => {
+    const t: ProductionTrace = {
+      ...baseTrace(),
+      metadata: { "bad~": "secret" },
+      redactions: [
+        {
+          path: "/metadata/bad~",
+          reason: "pii-custom",
+          detectedBy: "operator",
+          detectedAt: "2026-04-17T12:00:02.000Z",
+        },
+      ],
+    };
+
+    const r = validateRedactionPaths(t);
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.errors.some((e) => /invalid/.test(e))).toBe(true);
   });
 });

--- a/ts/tests/core-package.test.ts
+++ b/ts/tests/core-package.test.ts
@@ -191,6 +191,7 @@ describe("@autocontext/core facade", () => {
     expect(trace.feedbackRefs).toEqual([]);
     expect(validateTimingSanity(trace.timing).valid).toBe(true);
     expect(validateJsonPointer(trace, "/messages/0/content").valid).toBe(true);
+    expect(validateJsonPointer({ "bad~": true }, "/bad~").valid).toBe(false);
     expect(validateRedactionPaths(trace).valid).toBe(true);
   });
 

--- a/ts/tests/core-package.test.ts
+++ b/ts/tests/core-package.test.ts
@@ -7,6 +7,7 @@ import type {
   AgentTaskResult,
   AppId,
   ArtifactEditingInterface,
+  CreateProductionTraceInputs,
   EnvironmentTag,
   ExecutionLimits,
   FeedbackRefId,
@@ -45,6 +46,7 @@ import {
   CompletionResultSchema,
   ContextBudget,
   checkRubricCoherence,
+  createProductionTrace,
   ExecutionLimitsSchema,
   estimateTokens,
   expectedScore,
@@ -57,6 +59,9 @@ import {
   ReplayEnvelopeSchema,
   ResultSchema,
   updateElo,
+  validateJsonPointer,
+  validateRedactionPaths,
+  validateTimingSanity,
 } from "../../packages/ts/core/src/index.ts";
 
 const repoRoot = join(import.meta.dirname, "..", "..");
@@ -139,6 +144,54 @@ describe("@autocontext/core facade", () => {
 
     expect(trace.source).toBe(traceSource);
     expect(trace.traceId).toBe("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+  });
+
+  it("re-exports production trace pure contract helpers", () => {
+    const inputs: CreateProductionTraceInputs = {
+      id: "01ARZ3NDEKTSV4RRFFQ69G5FAV" as ProductionTraceId,
+      source: {
+        emitter: "gateway",
+        sdk: { name: "autoctx", version: "0.1.0" },
+      },
+      provider: { name: "anthropic" },
+      model: "claude-sonnet",
+      env: {
+        environmentTag: "production" as EnvironmentTag,
+        appId: "support-bot" as AppId,
+      },
+      messages: [
+        {
+          role: "user",
+          content: "help me with a refund",
+          timestamp: "2026-04-25T00:00:00Z",
+        },
+      ],
+      timing: {
+        startedAt: "2026-04-25T00:00:00Z",
+        endedAt: "2026-04-25T00:00:01Z",
+        latencyMs: 1000,
+      },
+      usage: {
+        tokensIn: 10,
+        tokensOut: 5,
+      },
+      redactions: [
+        {
+          path: "/messages/0/content",
+          reason: "pii-name",
+          detectedBy: "operator",
+          detectedAt: "2026-04-25T00:00:02Z",
+        },
+      ],
+    };
+    const trace = createProductionTrace(inputs);
+
+    expect(trace.schemaVersion).toBe(PRODUCTION_TRACE_SCHEMA_VERSION);
+    expect(trace.toolCalls).toEqual([]);
+    expect(trace.feedbackRefs).toEqual([]);
+    expect(validateTimingSanity(trace.timing).valid).toBe(true);
+    expect(validateJsonPointer(trace, "/messages/0/content").valid).toBe(true);
+    expect(validateRedactionPaths(trace).valid).toBe(true);
   });
 
   it("re-exports Elo primitives from the core-safe execution surface", () => {

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -210,12 +210,16 @@ describe("package boundaries", () => {
 			"../../../ts/src/production-traces/contract/branded-ids.ts",
 			"../../../ts/src/production-traces/contract/types.ts",
 			"../../../ts/src/production-traces/contract/content-address.ts",
+			"../../../ts/src/production-traces/contract/factories.ts",
+			"../../../ts/src/production-traces/contract/invariants.ts",
 		]);
 		expect(productionTraces.coreOwnedProgramPathSubstrings).toEqual([
 			"/ts/src/production-traces/contract/generated-types.ts",
 			"/ts/src/production-traces/contract/branded-ids.ts",
 			"/ts/src/production-traces/contract/types.ts",
 			"/ts/src/production-traces/contract/content-address.ts",
+			"/ts/src/production-traces/contract/factories.ts",
+			"/ts/src/production-traces/contract/invariants.ts",
 		]);
 		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
 			expect(core.exactIncludes).toContain(sourceInclude);


### PR DESCRIPTION
## Summary

- claim `ts/src/production-traces/contract/factories.ts` and `ts/src/production-traces/contract/invariants.ts` for the TypeScript core package
- export `createProductionTrace`, `CreateProductionTraceInputs`, `validateTimingSanity`, `validateJsonPointer`, and `validateRedactionPaths` from `@autocontext/core`
- extend the shared production-trace open-contract boundary manifest and tests
- keep validators, JSON schemas, SDK writers, CLI, ingest, dataset, retention, public-trace workflows, and control-plane paths outside this slice

## TDD notes

RED was observed before implementation:

- `tests/core-package.test.ts` failed because `createProductionTrace` was not exported from the core facade
- `tests/package-boundaries.test.ts` failed because the manifest still listed only the four earlier production-trace contract files

GREEN:

- added exact core includes for `factories.ts` and `invariants.ts`
- exported the pure helper API from `packages/ts/core/src/index.ts`
- added facade coverage for helper exports and defaults
- updated the boundary map with the pure-helper slice

## Verification

- `cd ts && npx vitest run tests/core-package.test.ts tests/package-boundaries.test.ts tests/package-topology.test.ts --run`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `cd ts && ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- `cd ts && npx vitest run tests/control-plane/production-traces/contract/factories.test.ts tests/control-plane/production-traces/contract/invariants.test.ts tests/production-traces/sdk/validate.test.ts --run`
- `cd ts && npm run lint`
- `cd autocontext && uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `cd autocontext && uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `git diff --check`

## Licensing note

No license metadata is changed here. AC-645 remains deferred and AC-646 remains the blocker for non-Apache relicensing.