### PR TITLE
AC-650 Claim production trace contract barrel in core

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -147,6 +147,10 @@ it imports. That claim is limited to schema validation and package artifact
 emission; dataset generation, retention enforcement, ingestion receipts, and
 CLI workflows remain control-plane even when their wire schemas are registered
 by the shared validator module.
+The contract-barrel slice adds `ts/src/production-traces/contract/index.ts` as
+a composition-only public contract entrypoint. The barrel may re-export only the
+already claimed contract files; adding a new re-export requires an explicit
+manifest/test update before core owns that file.
 
 The next independent source-ownership slice claims the current exact taxonomy
 files, `ts/src/production-traces/taxonomy/anthropic-error-reasons.ts`,
@@ -159,7 +163,7 @@ explicit manifest/test update before core owns them.
 
 | Surface                               | Current path                                                                                            | Proposed owner                 | Boundary rule                                                                                          |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| Production trace contract             | `ts/src/production-traces/contract/**`                                                                  | Core/open SDK                  | Public wire format, branded IDs, validators, generated types.                                          |
+| Production trace contract             | Manifest-listed contract files: `index.ts`, generated/types/ID/helper/validator files, plus schema assets | Core/open SDK                  | Public wire format, branded IDs, validators, generated types, and the composition-only contract barrel. |
 | Customer emit SDK                     | `ts/src/production-traces/sdk/**`                                                                       | Core/open SDK                  | Preserve `autoctx/production-traces` style surface; keep tree-shakable and management-free.            |
 | Taxonomy                              | `ts/src/production-traces/taxonomy/{anthropic-error-reasons.ts,openai-error-reasons.ts,index.ts}`        | Core/open SDK                  | Exact shared provider error/outcome vocabulary files; future taxonomy additions require manifest tests. |
 | Redaction primitives                  | `ts/src/production-traces/redaction/types.ts`, `policy.ts`, `hash-primitives.ts`, `apply.ts`, `mark.ts` | Open SDK if pure               | Keep pure local privacy helpers open; CLI policy management stays control-plane.                       |

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -108,6 +108,7 @@
 				"../../../ts/src/scenarios/simulation-family-interface-types.ts",
 				"../../../ts/src/storage/storage-contracts.ts",
 				"../../../ts/src/types/index.ts",
+				"../../../ts/src/production-traces/contract/index.ts",
 				"../../../ts/src/production-traces/contract/generated-types.ts",
 				"../../../ts/src/production-traces/contract/branded-ids.ts",
 				"../../../ts/src/production-traces/contract/types.ts",
@@ -170,6 +171,7 @@
 		"productionTraces": {
 			"typescriptOpenContract": {
 				"coreOwnedSourceIncludes": [
+					"../../../ts/src/production-traces/contract/index.ts",
 					"../../../ts/src/production-traces/contract/generated-types.ts",
 					"../../../ts/src/production-traces/contract/branded-ids.ts",
 					"../../../ts/src/production-traces/contract/types.ts",
@@ -199,6 +201,7 @@
 					"../../../ts/src/production-traces/contract/json-schemas/dataset-manifest.schema.json"
 				],
 				"coreOwnedProgramPathSubstrings": [
+					"/ts/src/production-traces/contract/index.ts",
 					"/ts/src/production-traces/contract/generated-types.ts",
 					"/ts/src/production-traces/contract/branded-ids.ts",
 					"/ts/src/production-traces/contract/types.ts",

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -19,6 +19,7 @@
 		"../../../ts/src/scenarios/simulation-family-interface-types.ts",
 		"../../../ts/src/storage/storage-contracts.ts",
 		"../../../ts/src/types/index.ts",
+		"../../../ts/src/production-traces/contract/index.ts",
 		"../../../ts/src/production-traces/contract/generated-types.ts",
 		"../../../ts/src/production-traces/contract/branded-ids.ts",
 		"../../../ts/src/production-traces/contract/types.ts",

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 const repoRoot = join(import.meta.dirname, "..", "..");
 const boundariesPath = join(repoRoot, "packages", "package-boundaries.json");
 const productionTraceOpenContractSourcePaths = [
+	"ts/src/production-traces/contract/index.ts",
 	"ts/src/production-traces/contract/generated-types.ts",
 	"ts/src/production-traces/contract/branded-ids.ts",
 	"ts/src/production-traces/contract/types.ts",
@@ -163,6 +164,13 @@ function importSpecifiers(sourceText: string): string[] {
 	return [...sourceText.matchAll(/(?:from|import)\s*["']([^"']+)["']/g)].map(
 		(match) => match[1],
 	);
+}
+
+function resolveProductionTraceContractSpecifier(specifier: string): string {
+	if (!specifier.startsWith("./") || !specifier.endsWith(".js")) {
+		throw new Error(`Unexpected production-trace contract specifier: ${specifier}`);
+	}
+	return `ts/src/production-traces/contract/${specifier.slice(2, -3)}.ts`;
 }
 
 describe("package boundaries", () => {
@@ -328,6 +336,29 @@ describe("package boundaries", () => {
 					false,
 				);
 			}
+		}
+	});
+
+	it("keeps the production trace contract barrel limited to core-owned contract sources", () => {
+		const contractBarrel = readFileSync(
+			join(repoRoot, "ts", "src", "production-traces", "contract", "index.ts"),
+			"utf-8",
+		);
+		const imports = importSpecifiers(contractBarrel);
+		const importedPaths = [
+			...new Set(imports.map(resolveProductionTraceContractSpecifier)),
+		];
+
+		expect(importedPaths).toEqual([
+			"ts/src/production-traces/contract/branded-ids.ts",
+			"ts/src/production-traces/contract/types.ts",
+			"ts/src/production-traces/contract/validators.ts",
+			"ts/src/production-traces/contract/factories.ts",
+			"ts/src/production-traces/contract/invariants.ts",
+			"ts/src/production-traces/contract/content-address.ts",
+		]);
+		for (const importedPath of importedPaths) {
+			expect(productionTraceOpenContractSourcePaths).toContain(importedPath);
 		}
 	});
 


### PR DESCRIPTION
## Summary
- claim the production-trace contract barrel ts/src/production-traces/contract/index.ts in the TypeScript core boundary
- add a boundary test that the barrel only composes already core-owned contract sources
- document the barrel as composition-only and keep production-trace workflow code out of core

## Verification
- npx vitest run tests/package-boundaries.test.ts tests/core-package.test.ts tests/package-topology.test.ts --run
- ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json
- ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json
- npm run lint
- uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py
- uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q
- git diff --check