### PR TITLE
AC-650 Claim production trace SDK validation in core

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -151,6 +151,11 @@ The contract-barrel slice adds `ts/src/production-traces/contract/index.ts` as
 a composition-only public contract entrypoint. The barrel may re-export only the
 already claimed contract files; adding a new re-export requires an explicit
 manifest/test update before core owns that file.
+The first emit-SDK slice claims only
+`ts/src/production-traces/sdk/validate.ts`. It is a customer-facing validation
+helper that delegates to the already claimed contract validator. The broader SDK
+barrel stays mixed until build, hashing, trace-batch, and JSONL writing helpers
+are each checked for workflow and dependency ownership.
 
 The next independent source-ownership slice claims the current exact taxonomy
 files, `ts/src/production-traces/taxonomy/anthropic-error-reasons.ts`,
@@ -164,7 +169,7 @@ explicit manifest/test update before core owns them.
 | Surface                               | Current path                                                                                            | Proposed owner                 | Boundary rule                                                                                          |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------ |
 | Production trace contract             | Manifest-listed contract files: `index.ts`, generated/types/ID/helper/validator files, plus schema assets | Core/open SDK                  | Public wire format, branded IDs, validators, generated types, and the composition-only contract barrel. |
-| Customer emit SDK                     | `ts/src/production-traces/sdk/**`                                                                       | Core/open SDK                  | Preserve `autoctx/production-traces` style surface; keep tree-shakable and management-free.            |
+| Customer emit SDK                     | Currently `ts/src/production-traces/sdk/validate.ts`; other SDK files are pending exact-file claims      | Core/open SDK                  | Preserve customer validation ergonomics; keep broader SDK helpers tree-shakable and management-free.   |
 | Taxonomy                              | `ts/src/production-traces/taxonomy/{anthropic-error-reasons.ts,openai-error-reasons.ts,index.ts}`        | Core/open SDK                  | Exact shared provider error/outcome vocabulary files; future taxonomy additions require manifest tests. |
 | Redaction primitives                  | `ts/src/production-traces/redaction/types.ts`, `policy.ts`, `hash-primitives.ts`, `apply.ts`, `mark.ts` | Open SDK if pure               | Keep pure local privacy helpers open; CLI policy management stays control-plane.                       |
 | Ingestion                             | `ts/src/production-traces/ingest/**`                                                                    | Control-plane                  | Scans incoming traces, locks, dedupes, validates receipts.                                             |

--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -153,9 +153,10 @@ already claimed contract files; adding a new re-export requires an explicit
 manifest/test update before core owns that file.
 The first emit-SDK slice claims only
 `ts/src/production-traces/sdk/validate.ts`. It is a customer-facing validation
-helper that delegates to the already claimed contract validator. The broader SDK
-barrel stays mixed until build, hashing, trace-batch, and JSONL writing helpers
-are each checked for workflow and dependency ownership.
+helper exposed through `@autocontext/core/production-traces/validate` and
+delegates to the already claimed contract validator. The broader SDK barrel
+stays mixed until build, hashing, trace-batch, and JSONL writing helpers are
+each checked for workflow and dependency ownership.
 
 The next independent source-ownership slice claims the current exact taxonomy
 files, `ts/src/production-traces/taxonomy/anthropic-error-reasons.ts`,

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -116,6 +116,7 @@
 				"../../../ts/src/production-traces/contract/factories.ts",
 				"../../../ts/src/production-traces/contract/invariants.ts",
 				"../../../ts/src/production-traces/contract/validators.ts",
+				"../../../ts/src/production-traces/sdk/validate.ts",
 				"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/index.ts"
@@ -236,6 +237,24 @@
 					"ajv",
 					"ajv-formats"
 				]
+			},
+			"typescriptOpenSdk": {
+				"coreOwnedSourceIncludes": [
+					"../../../ts/src/production-traces/sdk/validate.ts"
+				],
+				"coreOwnedSchemaAssetIncludes": [],
+				"coreOwnedProgramPathSubstrings": [
+					"/ts/src/production-traces/sdk/validate.ts"
+				],
+				"forbiddenImportPathSubstrings": [
+					"control-plane/",
+					"../cli/",
+					"../ingest/",
+					"../dataset/",
+					"../retention/",
+					"../../traces/"
+				],
+				"requiredPackageDependencies": []
 			},
 			"typescriptOpenTaxonomy": {
 				"coreOwnedSourceIncludes": [

--- a/packages/ts/core/package.json
+++ b/packages/ts/core/package.json
@@ -10,6 +10,10 @@
     ".": {
       "import": "./dist/packages/ts/core/src/index.js",
       "types": "./dist/packages/ts/core/src/index.d.ts"
+    },
+    "./production-traces/validate": {
+      "import": "./dist/ts/src/production-traces/sdk/validate.js",
+      "types": "./dist/ts/src/production-traces/sdk/validate.d.ts"
     }
   },
   "files": [

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -27,6 +27,7 @@
 		"../../../ts/src/production-traces/contract/factories.ts",
 		"../../../ts/src/production-traces/contract/invariants.ts",
 		"../../../ts/src/production-traces/contract/validators.ts",
+		"../../../ts/src/production-traces/sdk/validate.ts",
 		"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/index.ts"

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -43,6 +43,13 @@ const productionTraceOpenContractProgramPathSubstrings = [
 	...productionTraceOpenContractSourcePaths,
 	...productionTraceOpenContractSchemaAssetPaths,
 ].map((entry) => `/${entry}`);
+const productionTraceOpenSdkSourcePaths = [
+	"ts/src/production-traces/sdk/validate.ts",
+];
+const productionTraceOpenSdkSourceIncludes =
+	productionTraceOpenSdkSourcePaths.map((entry) => `../../../${entry}`);
+const productionTraceOpenSdkProgramPathSubstrings =
+	productionTraceOpenSdkSourcePaths.map((entry) => `/${entry}`);
 
 type TsCoreBoundary = {
 	packagePath: string;
@@ -84,6 +91,7 @@ type ProductionTraceOpenContractClaim = ProductionTraceSourceClaim & {
 
 type ProductionTraceBoundary = {
 	typescriptOpenContract: ProductionTraceOpenContractClaim;
+	typescriptOpenSdk: ProductionTraceOpenContractClaim;
 	typescriptOpenTaxonomy: ProductionTraceSourceClaim;
 };
 
@@ -156,6 +164,7 @@ function listProductionTraceCoreClaims(
 ): ProductionTraceSourceClaim[] {
 	return [
 		productionTraces.typescriptOpenContract,
+		productionTraces.typescriptOpenSdk,
 		productionTraces.typescriptOpenTaxonomy,
 	];
 }
@@ -293,6 +302,24 @@ describe("package boundaries", () => {
 		}
 	});
 
+	it("claims production trace SDK validation as an explicit TypeScript core-owned open SDK helper", () => {
+		const boundaries = loadBoundaries();
+		const core = boundaries.typescript.core;
+		const productionTraces =
+			boundaries.mixedDomains.productionTraces.typescriptOpenSdk;
+
+		expect(productionTraces.coreOwnedSourceIncludes).toEqual(
+			productionTraceOpenSdkSourceIncludes,
+		);
+		expect(productionTraces.coreOwnedSchemaAssetIncludes).toEqual([]);
+		expect(productionTraces.coreOwnedProgramPathSubstrings).toEqual(
+			productionTraceOpenSdkProgramPathSubstrings,
+		);
+		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
+			expect(core.exactIncludes).toContain(sourceInclude);
+		}
+	});
+
 	it("keeps TypeScript production trace core ownership limited to explicit open claims", () => {
 		const boundaries = loadBoundaries();
 		const core = boundaries.typescript.core;
@@ -359,6 +386,32 @@ describe("package boundaries", () => {
 		]);
 		for (const importedPath of importedPaths) {
 			expect(productionTraceOpenContractSourcePaths).toContain(importedPath);
+		}
+	});
+
+	it("keeps production trace SDK validation independent of control-plane workflows", () => {
+		const productionTraces =
+			loadBoundaries().mixedDomains.productionTraces.typescriptOpenSdk;
+
+		expect(productionTraces.forbiddenImportPathSubstrings).toEqual([
+			"control-plane/",
+			"../cli/",
+			"../ingest/",
+			"../dataset/",
+			"../retention/",
+			"../../traces/",
+		]);
+		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
+			const sourceText = readFileSync(
+				join(repoRoot, "packages", "ts", "core", sourceInclude),
+				"utf-8",
+			);
+			const imports = importSpecifiers(sourceText);
+			for (const forbidden of productionTraces.forbiddenImportPathSubstrings) {
+				expect(imports.some((specifier) => specifier.includes(forbidden))).toBe(
+					false,
+				);
+			}
 		}
 	});
 

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -117,6 +117,11 @@ type Topology = {
 	};
 };
 
+type TsPackageExport = {
+	import: string;
+	types: string;
+};
+
 type TsPackageJson = {
 	main: string;
 	types: string;
@@ -124,12 +129,7 @@ type TsPackageJson = {
 	devDependencies?: Record<string, string>;
 	peerDependencies?: Record<string, string>;
 	optionalDependencies?: Record<string, string>;
-	exports: {
-		".": {
-			import: string;
-			types: string;
-		};
-	};
+	exports: Record<string, TsPackageExport>;
 };
 
 function loadBoundaries(): PackageBoundaries {
@@ -318,6 +318,19 @@ describe("package boundaries", () => {
 		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
 			expect(core.exactIncludes).toContain(sourceInclude);
 		}
+	});
+
+	it("exposes production trace SDK validation through a stable TypeScript core subpath", () => {
+		const boundaries = loadBoundaries();
+		const core = boundaries.typescript.core;
+		const packageJson = loadJson<TsPackageJson>(
+			join(repoRoot, core.packagePath, "package.json"),
+		);
+
+		expect(packageJson.exports["./production-traces/validate"]).toEqual({
+			import: "./dist/ts/src/production-traces/sdk/validate.js",
+			types: "./dist/ts/src/production-traces/sdk/validate.d.ts",
+		});
 	});
 
 	it("keeps TypeScript production trace core ownership limited to explicit open claims", () => {
@@ -540,12 +553,10 @@ describe("package boundaries", () => {
 			);
 			expect(existsSync(join(packageDir, packageJson.main))).toBe(true);
 			expect(existsSync(join(packageDir, packageJson.types))).toBe(true);
-			expect(
-				existsSync(join(packageDir, packageJson.exports["."].import)),
-			).toBe(true);
-			expect(existsSync(join(packageDir, packageJson.exports["."].types))).toBe(
-				true,
-			);
+			for (const packageExport of Object.values(packageJson.exports)) {
+				expect(existsSync(join(packageDir, packageExport.import))).toBe(true);
+				expect(existsSync(join(packageDir, packageExport.types))).toBe(true);
+			}
 
 			if (packageDir.endsWith(join("packages", "ts", "core"))) {
 				const productionTraces =


### PR DESCRIPTION
## Summary
- claim only ts/src/production-traces/sdk/validate.ts as a TypeScript core-owned open SDK helper
- add boundary tests that keep SDK validation independent of CLI, ingest, dataset, retention, traces, and control-plane workflows
- leave the broader SDK barrel and other SDK helpers pending exact-file review to avoid widening the boundary
- document the exact-file SDK validation slice in the production-trace boundary map

## Verification
- npx vitest run tests/package-boundaries.test.ts tests/production-traces/sdk/validate.test.ts tests/core-package.test.ts tests/package-topology.test.ts --run
- ./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json
- ./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json
- npm run lint
- uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py
- uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q
- git diff --check