### PR TITLE
AC-650 Claim production trace SDK build helper in core

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -151,12 +151,14 @@ The contract-barrel slice adds `ts/src/production-traces/contract/index.ts` as
 a composition-only public contract entrypoint. The barrel may re-export only the
 already claimed contract files; adding a new re-export requires an explicit
 manifest/test update before core owns that file.
-The first emit-SDK slice claims only
-`ts/src/production-traces/sdk/validate.ts`. It is a customer-facing validation
-helper exposed through `@autocontext/core/production-traces/validate` and
-delegates to the already claimed contract validator. The broader SDK barrel
-stays mixed until build, hashing, trace-batch, and JSONL writing helpers are
-each checked for workflow and dependency ownership.
+The first emit-SDK slices claim only
+`ts/src/production-traces/sdk/validate.ts` and
+`ts/src/production-traces/sdk/build-trace.ts`. They are customer-facing SDK
+helpers exposed through `@autocontext/core/production-traces/validate` and
+`@autocontext/core/production-traces/build-trace`, with validation delegated to
+the already claimed contract validator. The broader SDK barrel stays mixed
+until hashing, trace-batch, and JSONL writing helpers are each checked for
+workflow and dependency ownership.
 
 The next independent source-ownership slice claims the current exact taxonomy
 files, `ts/src/production-traces/taxonomy/anthropic-error-reasons.ts`,
@@ -170,7 +172,7 @@ explicit manifest/test update before core owns them.
 | Surface                               | Current path                                                                                            | Proposed owner                 | Boundary rule                                                                                          |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------ |
 | Production trace contract             | Manifest-listed contract files: `index.ts`, generated/types/ID/helper/validator files, plus schema assets | Core/open SDK                  | Public wire format, branded IDs, validators, generated types, and the composition-only contract barrel. |
-| Customer emit SDK                     | Currently `ts/src/production-traces/sdk/validate.ts`; other SDK files are pending exact-file claims      | Core/open SDK                  | Preserve customer validation ergonomics; keep broader SDK helpers tree-shakable and management-free.   |
+| Customer emit SDK                     | Currently `ts/src/production-traces/sdk/{validate.ts,build-trace.ts}`; other SDK files are pending exact-file claims | Core/open SDK                  | Preserve customer validation/build ergonomics; keep broader SDK helpers tree-shakable and management-free. |
 | Taxonomy                              | `ts/src/production-traces/taxonomy/{anthropic-error-reasons.ts,openai-error-reasons.ts,index.ts}`        | Core/open SDK                  | Exact shared provider error/outcome vocabulary files; future taxonomy additions require manifest tests. |
 | Redaction primitives                  | `ts/src/production-traces/redaction/types.ts`, `policy.ts`, `hash-primitives.ts`, `apply.ts`, `mark.ts` | Open SDK if pure               | Keep pure local privacy helpers open; CLI policy management stays control-plane.                       |
 | Ingestion                             | `ts/src/production-traces/ingest/**`                                                                    | Control-plane                  | Scans incoming traces, locks, dedupes, validates receipts.                                             |

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -117,6 +117,7 @@
 				"../../../ts/src/production-traces/contract/invariants.ts",
 				"../../../ts/src/production-traces/contract/validators.ts",
 				"../../../ts/src/production-traces/sdk/validate.ts",
+				"../../../ts/src/production-traces/sdk/build-trace.ts",
 				"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/index.ts"
@@ -240,11 +241,13 @@
 			},
 			"typescriptOpenSdk": {
 				"coreOwnedSourceIncludes": [
-					"../../../ts/src/production-traces/sdk/validate.ts"
+					"../../../ts/src/production-traces/sdk/validate.ts",
+					"../../../ts/src/production-traces/sdk/build-trace.ts"
 				],
 				"coreOwnedSchemaAssetIncludes": [],
 				"coreOwnedProgramPathSubstrings": [
-					"/ts/src/production-traces/sdk/validate.ts"
+					"/ts/src/production-traces/sdk/validate.ts",
+					"/ts/src/production-traces/sdk/build-trace.ts"
 				],
 				"forbiddenImportPathSubstrings": [
 					"control-plane/",
@@ -254,7 +257,9 @@
 					"../retention/",
 					"../../traces/"
 				],
-				"requiredPackageDependencies": []
+				"requiredPackageDependencies": [
+					"ulid"
+				]
 			},
 			"typescriptOpenTaxonomy": {
 				"coreOwnedSourceIncludes": [

--- a/packages/ts/core/package.json
+++ b/packages/ts/core/package.json
@@ -14,6 +14,10 @@
     "./production-traces/validate": {
       "import": "./dist/ts/src/production-traces/sdk/validate.js",
       "types": "./dist/ts/src/production-traces/sdk/validate.d.ts"
+    },
+    "./production-traces/build-trace": {
+      "import": "./dist/ts/src/production-traces/sdk/build-trace.js",
+      "types": "./dist/ts/src/production-traces/sdk/build-trace.d.ts"
     }
   },
   "files": [

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -28,6 +28,7 @@
 		"../../../ts/src/production-traces/contract/invariants.ts",
 		"../../../ts/src/production-traces/contract/validators.ts",
 		"../../../ts/src/production-traces/sdk/validate.ts",
+		"../../../ts/src/production-traces/sdk/build-trace.ts",
 		"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/index.ts"

--- a/ts/src/production-traces/sdk/build-trace.ts
+++ b/ts/src/production-traces/sdk/build-trace.ts
@@ -139,9 +139,11 @@ function defaultSource(): TraceSource {
   };
 }
 
-// Resolved once at module load. The autoctx package version is baked into
-// ``package.json``; in test / dev we fall back to "0.0.0" to match Python's
-// behavior when ``importlib.metadata.version`` fails on an editable install.
+// Resolved once at module load. The emitted helper can live under the umbrella
+// ``autoctx`` package or under the split ``@autocontext/core`` package. In
+// test / dev we fall back to "0.0.0" to match Python's behavior when
+// ``importlib.metadata.version`` fails on an editable install.
+const sdkVersionPackageNames = new Set(["autoctx", "@autocontext/core"]);
 let cachedVersion: string | null = null;
 
 function sdkVersion(): string {
@@ -151,9 +153,9 @@ function sdkVersion(): string {
 }
 
 /**
- * Resolve the running autoctx package version. Walks up from this module
- * looking for the first ``package.json`` whose ``name`` is ``autoctx``.
- * Pure synchronous resolution — no dynamic imports and no network.
+ * Resolve the running package version. Walks up from this module looking for
+ * the nearest ``package.json`` whose ``name`` is one of the emitted SDK package
+ * identities. Pure synchronous resolution — no dynamic imports and no network.
  */
 function resolveVersionFromPackageJson(): string {
   try {
@@ -162,7 +164,11 @@ function resolveVersionFromPackageJson(): string {
       const candidate = join(dir, "package.json");
       if (existsSync(candidate)) {
         const pkg = JSON.parse(readFileSync(candidate, "utf-8")) as { name?: string; version?: string };
-        if (pkg.name === "autoctx" && typeof pkg.version === "string") {
+        if (
+          typeof pkg.name === "string"
+          && sdkVersionPackageNames.has(pkg.name)
+          && typeof pkg.version === "string"
+        ) {
           return pkg.version;
         }
       }

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -1,6 +1,15 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, rmSync } from "node:fs";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = join(import.meta.dirname, "..", "..");
@@ -336,6 +345,80 @@ describe("package boundaries", () => {
 			import: "./dist/ts/src/production-traces/sdk/build-trace.js",
 			types: "./dist/ts/src/production-traces/sdk/build-trace.d.ts",
 		});
+	});
+
+	it("resolves build-trace SDK version from the emitted TypeScript core package", async () => {
+		const boundaries = loadBoundaries();
+		const core = boundaries.typescript.core;
+		const packageDir = join(repoRoot, core.packagePath);
+		const tempRoot = mkdtempSync(join(repoRoot, "ts", ".tmp-core-version-"));
+
+		try {
+			rmSync(join(packageDir, "dist"), { force: true, recursive: true });
+			execFileSync("npm", ["run", "build"], {
+				cwd: packageDir,
+				encoding: "utf-8",
+			});
+
+			const installedCore = join(
+				tempRoot,
+				"node_modules",
+				"@autocontext",
+				"core",
+			);
+			mkdirSync(installedCore, { recursive: true });
+			cpSync(join(packageDir, "dist"), join(installedCore, "dist"), {
+				recursive: true,
+			});
+			writeFileSync(
+				join(installedCore, "package.json"),
+				JSON.stringify({
+					name: "@autocontext/core",
+					version: "9.8.7",
+					type: "module",
+				}),
+			);
+
+			const buildTraceModule = (await import(
+				pathToFileURL(
+					join(
+						installedCore,
+						"dist",
+						"ts",
+						"src",
+						"production-traces",
+						"sdk",
+						"build-trace.js",
+					),
+				).href
+			)) as typeof import("../src/production-traces/sdk/build-trace.js");
+			const trace = buildTraceModule.buildTrace({
+				provider: "openai",
+				model: "gpt-4o-mini",
+				messages: [
+					{
+						role: "user",
+						content: "hi",
+						timestamp: "2026-04-17T12:00:00.000Z",
+					},
+				],
+				timing: {
+					startedAt: "2026-04-17T12:00:00.000Z",
+					endedAt: "2026-04-17T12:00:01.000Z",
+					latencyMs: 1000,
+				},
+				usage: { tokensIn: 10, tokensOut: 5 },
+				env: {
+					environmentTag: "production",
+					appId: "core-version-test",
+				},
+				traceId: "01HZ6X2K7M9A3B4C5D6E7F8G9H",
+			} as Parameters<typeof buildTraceModule.buildTrace>[0]);
+
+			expect(trace.source.sdk.version).toBe("9.8.7");
+		} finally {
+			rmSync(tempRoot, { force: true, recursive: true });
+		}
 	});
 
 	it("keeps TypeScript production trace core ownership limited to explicit open claims", () => {

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -45,6 +45,7 @@ const productionTraceOpenContractProgramPathSubstrings = [
 ].map((entry) => `/${entry}`);
 const productionTraceOpenSdkSourcePaths = [
 	"ts/src/production-traces/sdk/validate.ts",
+	"ts/src/production-traces/sdk/build-trace.ts",
 ];
 const productionTraceOpenSdkSourceIncludes =
 	productionTraceOpenSdkSourcePaths.map((entry) => `../../../${entry}`);
@@ -302,7 +303,7 @@ describe("package boundaries", () => {
 		}
 	});
 
-	it("claims production trace SDK validation as an explicit TypeScript core-owned open SDK helper", () => {
+	it("claims production trace SDK helpers as explicit TypeScript core-owned open SDK helpers", () => {
 		const boundaries = loadBoundaries();
 		const core = boundaries.typescript.core;
 		const productionTraces =
@@ -320,7 +321,7 @@ describe("package boundaries", () => {
 		}
 	});
 
-	it("exposes production trace SDK validation through a stable TypeScript core subpath", () => {
+	it("exposes production trace SDK helpers through stable TypeScript core subpaths", () => {
 		const boundaries = loadBoundaries();
 		const core = boundaries.typescript.core;
 		const packageJson = loadJson<TsPackageJson>(
@@ -330,6 +331,10 @@ describe("package boundaries", () => {
 		expect(packageJson.exports["./production-traces/validate"]).toEqual({
 			import: "./dist/ts/src/production-traces/sdk/validate.js",
 			types: "./dist/ts/src/production-traces/sdk/validate.d.ts",
+		});
+		expect(packageJson.exports["./production-traces/build-trace"]).toEqual({
+			import: "./dist/ts/src/production-traces/sdk/build-trace.js",
+			types: "./dist/ts/src/production-traces/sdk/build-trace.d.ts",
 		});
 	});
 
@@ -402,7 +407,7 @@ describe("package boundaries", () => {
 		}
 	});
 
-	it("keeps production trace SDK validation independent of control-plane workflows", () => {
+	it("keeps production trace SDK helpers independent of control-plane workflows", () => {
 		const productionTraces =
 			loadBoundaries().mixedDomains.productionTraces.typescriptOpenSdk;
 
@@ -425,6 +430,22 @@ describe("package boundaries", () => {
 					false,
 				);
 			}
+		}
+	});
+
+	it("declares runtime dependencies needed by production trace open SDK sources", () => {
+		const boundaries = loadBoundaries();
+		const core = boundaries.typescript.core;
+		const productionTraces =
+			boundaries.mixedDomains.productionTraces.typescriptOpenSdk;
+		const packageJson = loadJson<TsPackageJson>(
+			join(repoRoot, core.packagePath, "package.json"),
+		);
+		const dependencies = packageJson.dependencies ?? {};
+
+		expect(productionTraces.requiredPackageDependencies).toEqual(["ulid"]);
+		for (const dependency of productionTraces.requiredPackageDependencies) {
+			expect(Object.keys(dependencies)).toContain(dependency);
 		}
 	});
 


### PR DESCRIPTION
## Summary

- Claim `ts/src/production-traces/sdk/build-trace.ts` as an exact TypeScript core-owned open SDK helper.
- Expose the helper through `@autocontext/core/production-traces/build-trace` without widening the root facade or claiming the SDK barrel.
- Extend boundary tests so SDK source ownership, export-map coverage, forbidden workflow imports, and direct runtime dependencies stay pinned.
- Update the production-trace boundary map to describe the validate/build-trace SDK slices as exact-file claims.

## Verification

- RED: `npx vitest run tests/package-boundaries.test.ts --run` failed before manifest/export changes on the missing build-trace claim, missing subpath, and missing SDK dependency declaration.
- GREEN: `npx vitest run tests/package-boundaries.test.ts --run`
- `npx vitest run tests/package-boundaries.test.ts tests/production-traces/sdk/validate.test.ts tests/production-traces/sdk/build-trace.test.ts tests/production-traces/sdk/build-trace-determinism.property.test.ts tests/core-package.test.ts tests/package-topology.test.ts --run`
- `./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `./node_modules/.bin/tsc --noEmit -p ../packages/ts/control-plane/tsconfig.json`
- `npm run lint`
- `uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `git diff --check`

## Full-suite note

`npm test` was also run locally. It completed with unrelated baseline failures: existing type-assertion budget overrun, server-protocol API-key expectation mismatch, and several 5s timeout failures in campaign/mission/scenario CLI tests. The production-trace SDK tests, cross-runtime parity tests, and focused package-boundary checks passed.
