### PR TITLE
AC-650 Claim production trace JSONL writer in core

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -164,6 +164,12 @@ helpers exposed through `@autocontext/core/production-traces/validate` and
 the already claimed contract validator. The broader SDK barrel stays mixed
 until hashing, trace-batch, and JSONL writing helpers are each checked for
 workflow and dependency ownership.
+The JSONL writer slice adds exactly
+`ts/src/production-traces/sdk/write-jsonl.ts` and exposes it through
+`@autocontext/core/production-traces/write-jsonl`. The helper remains
+customer-side emit SDK: it writes caller-provided traces to the local incoming
+partition using core-owned canonical JSON, and it does not import CLI,
+ingestion, dataset, retention, public-trace, or control-plane workflows.
 
 The next independent source-ownership slice claims the current exact taxonomy
 files, `ts/src/production-traces/taxonomy/anthropic-error-reasons.ts`,
@@ -177,7 +183,7 @@ explicit manifest/test update before core owns them.
 | Surface                               | Current path                                                                                            | Proposed owner                 | Boundary rule                                                                                          |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------ |
 | Production trace contract             | Manifest-listed contract files: `index.ts`, generated/types/ID/helper/validator/canonical JSON files, plus schema assets | Core/open SDK                  | Public wire format, branded IDs, validators, deterministic serialization, generated types, and the composition-only contract barrel. |
-| Customer emit SDK                     | Currently `ts/src/production-traces/sdk/{validate.ts,build-trace.ts}`; other SDK files are pending exact-file claims | Core/open SDK                  | Preserve customer validation/build ergonomics; keep broader SDK helpers tree-shakable and management-free. |
+| Customer emit SDK                     | Currently exact files `ts/src/production-traces/sdk/{validate.ts,build-trace.ts,write-jsonl.ts}`; other SDK files are pending exact-file claims | Core/open SDK                  | Preserve customer validation/build/write ergonomics; keep broader SDK helpers tree-shakable and management-free. |
 | Taxonomy                              | `ts/src/production-traces/taxonomy/{anthropic-error-reasons.ts,openai-error-reasons.ts,index.ts}`        | Core/open SDK                  | Exact shared provider error/outcome vocabulary files; future taxonomy additions require manifest tests. |
 | Redaction primitives                  | `ts/src/production-traces/redaction/types.ts`, `policy.ts`, `hash-primitives.ts`, `apply.ts`, `mark.ts` | Open SDK if pure               | Keep pure local privacy helpers open; CLI policy management stays control-plane.                       |
 | Ingestion                             | `ts/src/production-traces/ingest/**`                                                                    | Control-plane                  | Scans incoming traces, locks, dedupes, validates receipts.                                             |

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -119,6 +119,7 @@
 				"../../../ts/src/production-traces/contract/validators.ts",
 				"../../../ts/src/production-traces/sdk/validate.ts",
 				"../../../ts/src/production-traces/sdk/build-trace.ts",
+				"../../../ts/src/production-traces/sdk/write-jsonl.ts",
 				"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/index.ts"
@@ -245,12 +246,14 @@
 			"typescriptOpenSdk": {
 				"coreOwnedSourceIncludes": [
 					"../../../ts/src/production-traces/sdk/validate.ts",
-					"../../../ts/src/production-traces/sdk/build-trace.ts"
+					"../../../ts/src/production-traces/sdk/build-trace.ts",
+					"../../../ts/src/production-traces/sdk/write-jsonl.ts"
 				],
 				"coreOwnedSchemaAssetIncludes": [],
 				"coreOwnedProgramPathSubstrings": [
 					"/ts/src/production-traces/sdk/validate.ts",
-					"/ts/src/production-traces/sdk/build-trace.ts"
+					"/ts/src/production-traces/sdk/build-trace.ts",
+					"/ts/src/production-traces/sdk/write-jsonl.ts"
 				],
 				"forbiddenImportPathSubstrings": [
 					"control-plane/",

--- a/packages/ts/core/package.json
+++ b/packages/ts/core/package.json
@@ -18,6 +18,10 @@
     "./production-traces/build-trace": {
       "import": "./dist/ts/src/production-traces/sdk/build-trace.js",
       "types": "./dist/ts/src/production-traces/sdk/build-trace.d.ts"
+    },
+    "./production-traces/write-jsonl": {
+      "import": "./dist/ts/src/production-traces/sdk/write-jsonl.js",
+      "types": "./dist/ts/src/production-traces/sdk/write-jsonl.d.ts"
     }
   },
   "files": [

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -30,6 +30,7 @@
 		"../../../ts/src/production-traces/contract/validators.ts",
 		"../../../ts/src/production-traces/sdk/validate.ts",
 		"../../../ts/src/production-traces/sdk/build-trace.ts",
+		"../../../ts/src/production-traces/sdk/write-jsonl.ts",
 		"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/index.ts"

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -56,6 +56,7 @@ const productionTraceOpenContractProgramPathSubstrings = [
 const productionTraceOpenSdkSourcePaths = [
 	"ts/src/production-traces/sdk/validate.ts",
 	"ts/src/production-traces/sdk/build-trace.ts",
+	"ts/src/production-traces/sdk/write-jsonl.ts",
 ];
 const productionTraceOpenSdkSourceIncludes =
 	productionTraceOpenSdkSourcePaths.map((entry) => `../../../${entry}`);
@@ -345,6 +346,10 @@ describe("package boundaries", () => {
 		expect(packageJson.exports["./production-traces/build-trace"]).toEqual({
 			import: "./dist/ts/src/production-traces/sdk/build-trace.js",
 			types: "./dist/ts/src/production-traces/sdk/build-trace.d.ts",
+		});
+		expect(packageJson.exports["./production-traces/write-jsonl"]).toEqual({
+			import: "./dist/ts/src/production-traces/sdk/write-jsonl.js",
+			types: "./dist/ts/src/production-traces/sdk/write-jsonl.d.ts",
 		});
 	});
 


### PR DESCRIPTION
## Summary
- claim `ts/src/production-traces/sdk/write-jsonl.ts` as an exact TypeScript core-owned production trace SDK helper
- expose it through `@autocontext/core/production-traces/write-jsonl`
- keep the boundary map aligned with the enforced exact-file manifest

## Verification
- RED: `npx vitest run tests/package-boundaries.test.ts --run` failed on missing SDK claim/export
- GREEN: `npx vitest run tests/package-boundaries.test.ts --run`
- `npx vitest run tests/package-boundaries.test.ts tests/production-traces/sdk/write-jsonl.test.ts tests/production-traces/sdk/trace-batch.test.ts tests/package-topology.test.ts --run`
- `./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `npm run lint`
- `uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `git diff --check`