### PR TITLE
AC-650 Claim production trace batch helper in core

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -162,7 +162,7 @@ The first emit-SDK slices claim only
 helpers exposed through `@autocontext/core/production-traces/validate` and
 `@autocontext/core/production-traces/build-trace`, with validation delegated to
 the already claimed contract validator. The broader SDK barrel stays mixed
-until hashing, trace-batch, and JSONL writing helpers are each checked for
+until hashing and any remaining SDK composition helpers are each checked for
 workflow and dependency ownership.
 The JSONL writer slice adds exactly
 `ts/src/production-traces/sdk/write-jsonl.ts` and exposes it through
@@ -170,6 +170,11 @@ The JSONL writer slice adds exactly
 customer-side emit SDK: it writes caller-provided traces to the local incoming
 partition using core-owned canonical JSON, and it does not import CLI,
 ingestion, dataset, retention, public-trace, or control-plane workflows.
+The trace-batch slice adds exactly
+`ts/src/production-traces/sdk/trace-batch.ts` and exposes it through
+`@autocontext/core/production-traces/trace-batch`. It is a customer-side
+in-memory accumulator over the already claimed JSONL writer; it does not claim
+the broader SDK barrel or hashing/install-salt lifecycle.
 
 The next independent source-ownership slice claims the current exact taxonomy
 files, `ts/src/production-traces/taxonomy/anthropic-error-reasons.ts`,
@@ -183,7 +188,7 @@ explicit manifest/test update before core owns them.
 | Surface                               | Current path                                                                                            | Proposed owner                 | Boundary rule                                                                                          |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------ |
 | Production trace contract             | Manifest-listed contract files: `index.ts`, generated/types/ID/helper/validator/canonical JSON files, plus schema assets | Core/open SDK                  | Public wire format, branded IDs, validators, deterministic serialization, generated types, and the composition-only contract barrel. |
-| Customer emit SDK                     | Currently exact files `ts/src/production-traces/sdk/{validate.ts,build-trace.ts,write-jsonl.ts}`; other SDK files are pending exact-file claims | Core/open SDK                  | Preserve customer validation/build/write ergonomics; keep broader SDK helpers tree-shakable and management-free. |
+| Customer emit SDK                     | Currently exact files `ts/src/production-traces/sdk/{validate.ts,build-trace.ts,write-jsonl.ts,trace-batch.ts}`; other SDK files are pending exact-file claims | Core/open SDK                  | Preserve customer validation/build/write/batch ergonomics; keep broader SDK helpers tree-shakable and management-free. |
 | Taxonomy                              | `ts/src/production-traces/taxonomy/{anthropic-error-reasons.ts,openai-error-reasons.ts,index.ts}`        | Core/open SDK                  | Exact shared provider error/outcome vocabulary files; future taxonomy additions require manifest tests. |
 | Redaction primitives                  | `ts/src/production-traces/redaction/types.ts`, `policy.ts`, `hash-primitives.ts`, `apply.ts`, `mark.ts` | Open SDK if pure               | Keep pure local privacy helpers open; CLI policy management stays control-plane.                       |
 | Ingestion                             | `ts/src/production-traces/ingest/**`                                                                    | Control-plane                  | Scans incoming traces, locks, dedupes, validates receipts.                                             |

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -120,6 +120,7 @@
 				"../../../ts/src/production-traces/sdk/validate.ts",
 				"../../../ts/src/production-traces/sdk/build-trace.ts",
 				"../../../ts/src/production-traces/sdk/write-jsonl.ts",
+				"../../../ts/src/production-traces/sdk/trace-batch.ts",
 				"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/index.ts"
@@ -247,13 +248,15 @@
 				"coreOwnedSourceIncludes": [
 					"../../../ts/src/production-traces/sdk/validate.ts",
 					"../../../ts/src/production-traces/sdk/build-trace.ts",
-					"../../../ts/src/production-traces/sdk/write-jsonl.ts"
+					"../../../ts/src/production-traces/sdk/write-jsonl.ts",
+					"../../../ts/src/production-traces/sdk/trace-batch.ts"
 				],
 				"coreOwnedSchemaAssetIncludes": [],
 				"coreOwnedProgramPathSubstrings": [
 					"/ts/src/production-traces/sdk/validate.ts",
 					"/ts/src/production-traces/sdk/build-trace.ts",
-					"/ts/src/production-traces/sdk/write-jsonl.ts"
+					"/ts/src/production-traces/sdk/write-jsonl.ts",
+					"/ts/src/production-traces/sdk/trace-batch.ts"
 				],
 				"forbiddenImportPathSubstrings": [
 					"control-plane/",

--- a/packages/ts/core/package.json
+++ b/packages/ts/core/package.json
@@ -22,6 +22,10 @@
     "./production-traces/write-jsonl": {
       "import": "./dist/ts/src/production-traces/sdk/write-jsonl.js",
       "types": "./dist/ts/src/production-traces/sdk/write-jsonl.d.ts"
+    },
+    "./production-traces/trace-batch": {
+      "import": "./dist/ts/src/production-traces/sdk/trace-batch.js",
+      "types": "./dist/ts/src/production-traces/sdk/trace-batch.d.ts"
     }
   },
   "files": [

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -31,6 +31,7 @@
 		"../../../ts/src/production-traces/sdk/validate.ts",
 		"../../../ts/src/production-traces/sdk/build-trace.ts",
 		"../../../ts/src/production-traces/sdk/write-jsonl.ts",
+		"../../../ts/src/production-traces/sdk/trace-batch.ts",
 		"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/index.ts"

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -57,6 +57,7 @@ const productionTraceOpenSdkSourcePaths = [
 	"ts/src/production-traces/sdk/validate.ts",
 	"ts/src/production-traces/sdk/build-trace.ts",
 	"ts/src/production-traces/sdk/write-jsonl.ts",
+	"ts/src/production-traces/sdk/trace-batch.ts",
 ];
 const productionTraceOpenSdkSourceIncludes =
 	productionTraceOpenSdkSourcePaths.map((entry) => `../../../${entry}`);
@@ -350,6 +351,10 @@ describe("package boundaries", () => {
 		expect(packageJson.exports["./production-traces/write-jsonl"]).toEqual({
 			import: "./dist/ts/src/production-traces/sdk/write-jsonl.js",
 			types: "./dist/ts/src/production-traces/sdk/write-jsonl.d.ts",
+		});
+		expect(packageJson.exports["./production-traces/trace-batch"]).toEqual({
+			import: "./dist/ts/src/production-traces/sdk/trace-batch.js",
+			types: "./dist/ts/src/production-traces/sdk/trace-batch.d.ts",
 		});
 	});
 


### PR DESCRIPTION
## Summary
- claim `ts/src/production-traces/sdk/trace-batch.ts` as an exact TypeScript core-owned production trace SDK helper
- expose it through `@autocontext/core/production-traces/trace-batch`
- keep the boundary map aligned with the enforced exact-file manifest and leave the broader SDK barrel/hashing lifecycle unclaimed

## Verification
- RED: `npx vitest run tests/package-boundaries.test.ts --run` failed on missing SDK claim/export
- GREEN: `npx vitest run tests/package-boundaries.test.ts --run`
- `npx vitest run tests/package-boundaries.test.ts tests/production-traces/sdk/trace-batch.test.ts tests/production-traces/sdk/write-jsonl.test.ts tests/package-topology.test.ts --run`
- `./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `npm run lint`
- `uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `git diff --check`