### PR TITLE
AC-650 Claim pure production trace hashing in core

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -175,6 +175,13 @@ The trace-batch slice adds exactly
 `@autocontext/core/production-traces/trace-batch`. It is a customer-side
 in-memory accumulator over the already claimed JSONL writer; it does not claim
 the broader SDK barrel or hashing/install-salt lifecycle.
+The pure hashing slice adds exactly
+`ts/src/production-traces/sdk/hashing-core.ts` plus
+`ts/src/production-traces/redaction/hash-primitives.ts` and exposes the public
+helper subpath through `@autocontext/core/production-traces/hashing`. This
+claims `hashUserId` and `hashSessionId` as deterministic privacy primitives
+while leaving install-salt file lifecycle and rotation surfaces on the
+umbrella/control side until they receive an explicit ownership decision.
 
 The next independent source-ownership slice claims the current exact taxonomy
 files, `ts/src/production-traces/taxonomy/anthropic-error-reasons.ts`,
@@ -188,9 +195,9 @@ explicit manifest/test update before core owns them.
 | Surface                               | Current path                                                                                            | Proposed owner                 | Boundary rule                                                                                          |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------ |
 | Production trace contract             | Manifest-listed contract files: `index.ts`, generated/types/ID/helper/validator/canonical JSON files, plus schema assets | Core/open SDK                  | Public wire format, branded IDs, validators, deterministic serialization, generated types, and the composition-only contract barrel. |
-| Customer emit SDK                     | Currently exact files `ts/src/production-traces/sdk/{validate.ts,build-trace.ts,write-jsonl.ts,trace-batch.ts}`; other SDK files are pending exact-file claims | Core/open SDK                  | Preserve customer validation/build/write/batch ergonomics; keep broader SDK helpers tree-shakable and management-free. |
+| Customer emit SDK                     | Currently exact files `ts/src/production-traces/sdk/{validate.ts,build-trace.ts,write-jsonl.ts,trace-batch.ts,hashing-core.ts}`; other SDK files are pending exact-file claims | Core/open SDK                  | Preserve customer validation/build/write/batch/hash ergonomics; keep broader SDK helpers tree-shakable and management-free. |
 | Taxonomy                              | `ts/src/production-traces/taxonomy/{anthropic-error-reasons.ts,openai-error-reasons.ts,index.ts}`        | Core/open SDK                  | Exact shared provider error/outcome vocabulary files; future taxonomy additions require manifest tests. |
-| Redaction primitives                  | `ts/src/production-traces/redaction/types.ts`, `policy.ts`, `hash-primitives.ts`, `apply.ts`, `mark.ts` | Open SDK if pure               | Keep pure local privacy helpers open; CLI policy management stays control-plane.                       |
+| Redaction primitives                  | Currently exact file `ts/src/production-traces/redaction/hash-primitives.ts`; other redaction files are pending exact-file claims | Open SDK if pure               | Keep pure local privacy helpers open; CLI policy management and install-salt lifecycle stay outside core until explicitly claimed. |
 | Ingestion                             | `ts/src/production-traces/ingest/**`                                                                    | Control-plane                  | Scans incoming traces, locks, dedupes, validates receipts.                                             |
 | Retention                             | `ts/src/production-traces/retention/**`                                                                 | Control-plane                  | Project/fleet policy enforcement and GC logs.                                                          |
 | Dataset generation                    | `ts/src/production-traces/dataset/**`                                                                   | Control-plane                  | Selection, clustering, splitting, manifests, and provenance workflows.                                 |

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -121,6 +121,8 @@
 				"../../../ts/src/production-traces/sdk/build-trace.ts",
 				"../../../ts/src/production-traces/sdk/write-jsonl.ts",
 				"../../../ts/src/production-traces/sdk/trace-batch.ts",
+				"../../../ts/src/production-traces/sdk/hashing-core.ts",
+				"../../../ts/src/production-traces/redaction/hash-primitives.ts",
 				"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/index.ts"
@@ -249,14 +251,16 @@
 					"../../../ts/src/production-traces/sdk/validate.ts",
 					"../../../ts/src/production-traces/sdk/build-trace.ts",
 					"../../../ts/src/production-traces/sdk/write-jsonl.ts",
-					"../../../ts/src/production-traces/sdk/trace-batch.ts"
+					"../../../ts/src/production-traces/sdk/trace-batch.ts",
+					"../../../ts/src/production-traces/sdk/hashing-core.ts"
 				],
 				"coreOwnedSchemaAssetIncludes": [],
 				"coreOwnedProgramPathSubstrings": [
 					"/ts/src/production-traces/sdk/validate.ts",
 					"/ts/src/production-traces/sdk/build-trace.ts",
 					"/ts/src/production-traces/sdk/write-jsonl.ts",
-					"/ts/src/production-traces/sdk/trace-batch.ts"
+					"/ts/src/production-traces/sdk/trace-batch.ts",
+					"/ts/src/production-traces/sdk/hashing-core.ts"
 				],
 				"forbiddenImportPathSubstrings": [
 					"control-plane/",
@@ -268,6 +272,14 @@
 				],
 				"requiredPackageDependencies": [
 					"ulid"
+				]
+			},
+			"typescriptOpenRedaction": {
+				"coreOwnedSourceIncludes": [
+					"../../../ts/src/production-traces/redaction/hash-primitives.ts"
+				],
+				"coreOwnedProgramPathSubstrings": [
+					"/ts/src/production-traces/redaction/hash-primitives.ts"
 				]
 			},
 			"typescriptOpenTaxonomy": {

--- a/packages/ts/core/package.json
+++ b/packages/ts/core/package.json
@@ -26,6 +26,10 @@
     "./production-traces/trace-batch": {
       "import": "./dist/ts/src/production-traces/sdk/trace-batch.js",
       "types": "./dist/ts/src/production-traces/sdk/trace-batch.d.ts"
+    },
+    "./production-traces/hashing": {
+      "import": "./dist/ts/src/production-traces/sdk/hashing-core.js",
+      "types": "./dist/ts/src/production-traces/sdk/hashing-core.d.ts"
     }
   },
   "files": [

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -32,6 +32,8 @@
 		"../../../ts/src/production-traces/sdk/build-trace.ts",
 		"../../../ts/src/production-traces/sdk/write-jsonl.ts",
 		"../../../ts/src/production-traces/sdk/trace-batch.ts",
+		"../../../ts/src/production-traces/sdk/hashing-core.ts",
+		"../../../ts/src/production-traces/redaction/hash-primitives.ts",
 		"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/index.ts"

--- a/ts/src/production-traces/sdk/hashing-core.ts
+++ b/ts/src/production-traces/sdk/hashing-core.ts
@@ -1,0 +1,36 @@
+import { sha256HexSalted } from "../redaction/hash-primitives.js";
+import type { SessionIdHash, UserIdHash } from "../contract/branded-ids.js";
+
+/**
+ * Customer-facing pure identifier hashing helpers.
+ *
+ * DDD anchor: names mirror Python's hash_user_id / hash_session_id. The
+ * install-salt filesystem lifecycle is intentionally not owned here; callers
+ * pass the salt explicitly so this module stays a deterministic SDK primitive.
+ */
+
+/**
+ * Hash a user identifier with the install salt. Returns 64-char lowercase hex,
+ * which can be stored in session.userIdHash.
+ */
+export function hashUserId(userId: string, salt: string): UserIdHash {
+  assertNonEmptySalt(salt);
+  return sha256HexSalted(userId, salt) as UserIdHash;
+}
+
+/**
+ * Hash a session identifier. The algorithm matches hashUserId; the distinct
+ * name documents intent and preserves the branded return type.
+ */
+export function hashSessionId(sessionId: string, salt: string): SessionIdHash {
+  assertNonEmptySalt(salt);
+  return sha256HexSalted(sessionId, salt) as SessionIdHash;
+}
+
+function assertNonEmptySalt(salt: string): void {
+  if (typeof salt !== "string" || salt.length === 0) {
+    throw new Error(
+      "hashing salt must be a non-empty string; pass an initialized install salt explicitly",
+    );
+  }
+}

--- a/ts/src/production-traces/sdk/hashing.ts
+++ b/ts/src/production-traces/sdk/hashing.ts
@@ -1,6 +1,3 @@
-import { sha256HexSalted } from "../redaction/hash-primitives.js";
-import type { SessionIdHash, UserIdHash } from "../contract/branded-ids.js";
-
 /**
  * Customer-facing hashing helpers.
  *
@@ -9,11 +6,12 @@ import type { SessionIdHash, UserIdHash } from "../contract/branded-ids.js";
  * hex, NO ``sha256:`` prefix — that prefix is specific to the redaction-
  * marker placeholder format inside a ProductionTrace document).
  *
- * DRY anchor: the SHA-256 primitive lives in
- * ``../redaction/hash-primitives.ts`` and is shared with the apply-at-export
- * redaction engine. Byte-identity with Python is enforced by
- * P-hashing-parity (100 runs) in the cross-runtime parity suite.
+ * Compatibility anchor: this module remains the umbrella SDK hashing surface.
+ * Pure hashing lives in ``hashing-core.ts`` so @autocontext/core can claim it
+ * without pulling in install-salt filesystem lifecycle.
  */
+
+export { hashUserId, hashSessionId } from "./hashing-core.js";
 
 // Re-export install-salt lifecycle so customers import everything from a
 // single entry point: `import { ... } from "autoctx/production-traces"`.
@@ -23,33 +21,3 @@ export {
   rotateInstallSalt,
   installSaltPath,
 } from "../redaction/install-salt.js";
-
-/**
- * Hash a user identifier with the install salt. Returns 64-char lowercase
- * hex — the value you can store in ``session.userIdHash``.
- *
- * Throws if ``salt`` is empty: hashing without a salt produces trivially
- * reversible output and must never silently proceed.
- */
-export function hashUserId(userId: string, salt: string): UserIdHash {
-  assertNonEmptySalt(salt);
-  return sha256HexSalted(userId, salt) as UserIdHash;
-}
-
-/**
- * Hash a session identifier. Algorithmically identical to :func:`hashUserId`;
- * the distinct name documents intent and lets downstream processors filter
- * by the branded return type.
- */
-export function hashSessionId(sessionId: string, salt: string): SessionIdHash {
-  assertNonEmptySalt(salt);
-  return sha256HexSalted(sessionId, salt) as SessionIdHash;
-}
-
-function assertNonEmptySalt(salt: string): void {
-  if (typeof salt !== "string" || salt.length === 0) {
-    throw new Error(
-      "hashing salt must be a non-empty string — use loadInstallSalt() or initializeInstallSalt()",
-    );
-  }
-}

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -58,11 +58,19 @@ const productionTraceOpenSdkSourcePaths = [
 	"ts/src/production-traces/sdk/build-trace.ts",
 	"ts/src/production-traces/sdk/write-jsonl.ts",
 	"ts/src/production-traces/sdk/trace-batch.ts",
+	"ts/src/production-traces/sdk/hashing-core.ts",
 ];
 const productionTraceOpenSdkSourceIncludes =
 	productionTraceOpenSdkSourcePaths.map((entry) => `../../../${entry}`);
 const productionTraceOpenSdkProgramPathSubstrings =
 	productionTraceOpenSdkSourcePaths.map((entry) => `/${entry}`);
+const productionTraceOpenRedactionSourcePaths = [
+	"ts/src/production-traces/redaction/hash-primitives.ts",
+];
+const productionTraceOpenRedactionSourceIncludes =
+	productionTraceOpenRedactionSourcePaths.map((entry) => `../../../${entry}`);
+const productionTraceOpenRedactionProgramPathSubstrings =
+	productionTraceOpenRedactionSourcePaths.map((entry) => `/${entry}`);
 
 type TsCoreBoundary = {
 	packagePath: string;
@@ -105,6 +113,7 @@ type ProductionTraceOpenContractClaim = ProductionTraceSourceClaim & {
 type ProductionTraceBoundary = {
 	typescriptOpenContract: ProductionTraceOpenContractClaim;
 	typescriptOpenSdk: ProductionTraceOpenContractClaim;
+	typescriptOpenRedaction: ProductionTraceSourceClaim;
 	typescriptOpenTaxonomy: ProductionTraceSourceClaim;
 };
 
@@ -178,6 +187,7 @@ function listProductionTraceCoreClaims(
 	return [
 		productionTraces.typescriptOpenContract,
 		productionTraces.typescriptOpenSdk,
+		productionTraces.typescriptOpenRedaction,
 		productionTraces.typescriptOpenTaxonomy,
 	];
 }
@@ -333,6 +343,23 @@ describe("package boundaries", () => {
 		}
 	});
 
+	it("claims production trace redaction primitives as explicit TypeScript core-owned open privacy helpers", () => {
+		const boundaries = loadBoundaries();
+		const core = boundaries.typescript.core;
+		const productionTraces =
+			boundaries.mixedDomains.productionTraces.typescriptOpenRedaction;
+
+		expect(productionTraces.coreOwnedSourceIncludes).toEqual(
+			productionTraceOpenRedactionSourceIncludes,
+		);
+		expect(productionTraces.coreOwnedProgramPathSubstrings).toEqual(
+			productionTraceOpenRedactionProgramPathSubstrings,
+		);
+		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
+			expect(core.exactIncludes).toContain(sourceInclude);
+		}
+	});
+
 	it("exposes production trace SDK helpers through stable TypeScript core subpaths", () => {
 		const boundaries = loadBoundaries();
 		const core = boundaries.typescript.core;
@@ -355,6 +382,10 @@ describe("package boundaries", () => {
 		expect(packageJson.exports["./production-traces/trace-batch"]).toEqual({
 			import: "./dist/ts/src/production-traces/sdk/trace-batch.js",
 			types: "./dist/ts/src/production-traces/sdk/trace-batch.d.ts",
+		});
+		expect(packageJson.exports["./production-traces/hashing"]).toEqual({
+			import: "./dist/ts/src/production-traces/sdk/hashing-core.js",
+			types: "./dist/ts/src/production-traces/sdk/hashing-core.d.ts",
 		});
 	});
 


### PR DESCRIPTION
## Summary
- claim pure `hashUserId` / `hashSessionId` helpers through new `ts/src/production-traces/sdk/hashing-core.ts`
- claim shared pure `ts/src/production-traces/redaction/hash-primitives.ts` so hashing stays DRY without pulling install-salt lifecycle into core
- expose `@autocontext/core/production-traces/hashing` and keep `sdk/hashing.ts` as the umbrella compatibility wrapper for install-salt re-exports
- update the boundary map and exact-file manifest for the pure hashing/redaction primitive split

## Verification
- RED: `npx vitest run tests/package-boundaries.test.ts --run` failed on missing SDK claim, redaction primitive claim, and hashing subpath
- GREEN: `npx vitest run tests/package-boundaries.test.ts --run`
- `npx vitest run tests/control-plane/production-traces/redaction/hash-primitives.test.ts tests/production-traces/sdk/hashing.test.ts tests/package-boundaries.test.ts tests/package-topology.test.ts --run`
- `./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `npm run lint`
- `uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `git diff --check`

## Note
- Local hashing parity assertions passed for both `hashUserId` and `hashSessionId` over 100 Python comparisons, but Vitest exited nonzero afterward with `[vitest-worker]: Timeout calling onTaskUpdate`; CI should provide the clean full-suite signal.