### PR TITLE
AC-650 Claim redaction apply helper in core

### DIFF
--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -182,6 +182,14 @@ helper subpath through `@autocontext/core/production-traces/hashing`. This
 claims `hashUserId` and `hashSessionId` as deterministic privacy primitives
 while leaving install-salt file lifecycle and rotation surfaces on the
 umbrella/control side until they receive an explicit ownership decision.
+The redaction apply slice adds exactly
+`ts/src/production-traces/redaction/types.ts` and
+`ts/src/production-traces/redaction/apply.ts`, exposed through
+`@autocontext/core/production-traces/redaction/apply`. It is customer-side
+export-boundary rewriting over caller-provided traces, policies, and salts. It
+does not claim redaction policy file IO, install-salt lifecycle, mark-at-ingest
+detection, CLI workflows, ingestion, dataset generation, retention, or
+`ts/src/traces` workflows.
 
 The next independent source-ownership slice claims the current exact taxonomy
 files, `ts/src/production-traces/taxonomy/anthropic-error-reasons.ts`,
@@ -197,7 +205,7 @@ explicit manifest/test update before core owns them.
 | Production trace contract             | Manifest-listed contract files: `index.ts`, generated/types/ID/helper/validator/canonical JSON files, plus schema assets | Core/open SDK                  | Public wire format, branded IDs, validators, deterministic serialization, generated types, and the composition-only contract barrel. |
 | Customer emit SDK                     | Currently exact files `ts/src/production-traces/sdk/{validate.ts,build-trace.ts,write-jsonl.ts,trace-batch.ts,hashing-core.ts}`; other SDK files are pending exact-file claims | Core/open SDK                  | Preserve customer validation/build/write/batch/hash ergonomics; keep broader SDK helpers tree-shakable and management-free. |
 | Taxonomy                              | `ts/src/production-traces/taxonomy/{anthropic-error-reasons.ts,openai-error-reasons.ts,index.ts}`        | Core/open SDK                  | Exact shared provider error/outcome vocabulary files; future taxonomy additions require manifest tests. |
-| Redaction primitives                  | Currently exact file `ts/src/production-traces/redaction/hash-primitives.ts`; other redaction files are pending exact-file claims | Open SDK if pure               | Keep pure local privacy helpers open; CLI policy management and install-salt lifecycle stay outside core until explicitly claimed. |
+| Redaction apply helpers               | Currently exact files `ts/src/production-traces/redaction/{hash-primitives.ts,types.ts,apply.ts}`; other redaction files are pending exact-file claims | Open SDK if pure               | Keep pure local privacy/export helpers open; CLI policy management, mark-at-ingest detection, and install-salt lifecycle stay outside core until explicitly claimed. |
 | Ingestion                             | `ts/src/production-traces/ingest/**`                                                                    | Control-plane                  | Scans incoming traces, locks, dedupes, validates receipts.                                             |
 | Retention                             | `ts/src/production-traces/retention/**`                                                                 | Control-plane                  | Project/fleet policy enforcement and GC logs.                                                          |
 | Dataset generation                    | `ts/src/production-traces/dataset/**`                                                                   | Control-plane                  | Selection, clustering, splitting, manifests, and provenance workflows.                                 |

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -140,6 +140,8 @@
 				"../../../ts/src/production-traces/sdk/trace-batch.ts",
 				"../../../ts/src/production-traces/sdk/hashing-core.ts",
 				"../../../ts/src/production-traces/redaction/hash-primitives.ts",
+				"../../../ts/src/production-traces/redaction/types.ts",
+				"../../../ts/src/production-traces/redaction/apply.ts",
 				"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 				"../../../ts/src/production-traces/taxonomy/index.ts"
@@ -293,10 +295,22 @@
 			},
 			"typescriptOpenRedaction": {
 				"coreOwnedSourceIncludes": [
-					"../../../ts/src/production-traces/redaction/hash-primitives.ts"
+					"../../../ts/src/production-traces/redaction/hash-primitives.ts",
+					"../../../ts/src/production-traces/redaction/types.ts",
+					"../../../ts/src/production-traces/redaction/apply.ts"
 				],
 				"coreOwnedProgramPathSubstrings": [
-					"/ts/src/production-traces/redaction/hash-primitives.ts"
+					"/ts/src/production-traces/redaction/hash-primitives.ts",
+					"/ts/src/production-traces/redaction/types.ts",
+					"/ts/src/production-traces/redaction/apply.ts"
+				],
+				"forbiddenImportPathSubstrings": [
+					"control-plane/",
+					"../cli/",
+					"../ingest/",
+					"../dataset/",
+					"../retention/",
+					"../../traces/"
 				]
 			},
 			"typescriptOpenTaxonomy": {

--- a/packages/ts/core/package.json
+++ b/packages/ts/core/package.json
@@ -30,6 +30,10 @@
     "./production-traces/hashing": {
       "import": "./dist/ts/src/production-traces/sdk/hashing-core.js",
       "types": "./dist/ts/src/production-traces/sdk/hashing-core.d.ts"
+    },
+    "./production-traces/redaction/apply": {
+      "import": "./dist/ts/src/production-traces/redaction/apply.js",
+      "types": "./dist/ts/src/production-traces/redaction/apply.d.ts"
     }
   },
   "files": [

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -34,6 +34,8 @@
 		"../../../ts/src/production-traces/sdk/trace-batch.ts",
 		"../../../ts/src/production-traces/sdk/hashing-core.ts",
 		"../../../ts/src/production-traces/redaction/hash-primitives.ts",
+		"../../../ts/src/production-traces/redaction/types.ts",
+		"../../../ts/src/production-traces/redaction/apply.ts",
 		"../../../ts/src/production-traces/taxonomy/anthropic-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/openai-error-reasons.ts",
 		"../../../ts/src/production-traces/taxonomy/index.ts"

--- a/ts/src/production-traces/contract/invariants.ts
+++ b/ts/src/production-traces/contract/invariants.ts
@@ -1,5 +1,9 @@
 import type { ProductionTrace, TimingInfo, ValidationResult } from "./types.js";
 
+export type JsonPointerParseResult =
+  | { valid: true; tokens: string[] }
+  | { valid: false; error: string };
+
 /**
  * I3 — Timing sanity: endedAt must be >= startedAt, latencyMs must be >= 0.
  * Timestamps must be parseable as dates.
@@ -44,23 +48,12 @@ export function validateTimingSanity(timing: TimingInfo): ValidationResult {
  *   - paths that traverse into a missing field
  */
 export function validateJsonPointer(obj: unknown, pointer: string): ValidationResult {
-  if (pointer === "") return { valid: true };
-  if (!pointer.startsWith("/")) {
-    return { valid: false, errors: [`json pointer '${pointer}' missing leading '/'`] };
+  const parsed = parseJsonPointerTokens(pointer);
+  if (!parsed.valid) {
+    return { valid: false, errors: [parsed.error] };
   }
-  // Split; first element is always empty (before the leading /) so drop it.
-  const rawTokens = pointer.slice(1).split("/");
-  for (const rawToken of rawTokens) {
-    if (/~(?![01])/.test(rawToken)) {
-      return {
-        valid: false,
-        errors: [
-          `json pointer '${pointer}': token '${rawToken}' contains invalid escape; use '~0' for '~' and '~1' for '/'`,
-        ],
-      };
-    }
-  }
-  const tokens = rawTokens.map(unescapeToken);
+  if (parsed.tokens.length === 0) return { valid: true };
+  const tokens = parsed.tokens;
   let current: unknown = obj;
   for (let i = 0; i < tokens.length; i++) {
     const tok = tokens[i];
@@ -85,6 +78,24 @@ export function validateJsonPointer(obj: unknown, pointer: string): ValidationRe
     }
   }
   return { valid: true };
+}
+
+export function parseJsonPointerTokens(pointer: string): JsonPointerParseResult {
+  if (pointer === "") return { valid: true, tokens: [] };
+  if (!pointer.startsWith("/")) {
+    return { valid: false, error: `json pointer '${pointer}' missing leading '/'` };
+  }
+  // Split; first element is always empty (before the leading /) so drop it.
+  const rawTokens = pointer.slice(1).split("/");
+  for (const rawToken of rawTokens) {
+    if (/~(?![01])/.test(rawToken)) {
+      return {
+        valid: false,
+        error: `json pointer '${pointer}': token '${rawToken}' contains invalid escape; use '~0' for '~' and '~1' for '/'`,
+      };
+    }
+  }
+  return { valid: true, tokens: rawTokens.map(unescapeToken) };
 }
 
 function unescapeToken(t: string): string {

--- a/ts/src/production-traces/redaction/apply.ts
+++ b/ts/src/production-traces/redaction/apply.ts
@@ -2,12 +2,23 @@ import type {
   ProductionTrace,
   RedactionMarker,
 } from "../contract/types.js";
+import { parseJsonPointerTokens } from "../contract/invariants.js";
 import type {
   CategoryAction,
   CategoryOverride,
   LoadedRedactionPolicy,
 } from "./types.js";
 import { hashValue } from "./hash-primitives.js";
+
+export type {
+  CategoryAction,
+  CategoryOverride,
+  CustomPolicyPattern,
+  ExportPolicy,
+  LoadedRedactionPolicy,
+  RawProviderPayloadBehavior,
+  RedactionMode,
+} from "./types.js";
 
 /**
  * Apply-at-export redaction (spec §7.3, §7.6).
@@ -200,13 +211,8 @@ function dropField(root: unknown, pointer: string): void {
 }
 
 function parsePointer(pointer: string): string[] | null {
-  if (!pointer.startsWith("/")) return null;
-  return pointer.slice(1).split("/").map(unescapeToken);
-}
-
-function unescapeToken(t: string): string {
-  // Per RFC 6901: decode ~1 before ~0.
-  return t.replace(/~1/g, "/").replace(/~0/g, "~");
+  const parsed = parseJsonPointerTokens(pointer);
+  return parsed.valid ? parsed.tokens : null;
 }
 
 function stepInto(value: unknown, token: string): unknown {

--- a/ts/tests/control-plane/production-traces/redaction/apply.test.ts
+++ b/ts/tests/control-plane/production-traces/redaction/apply.test.ts
@@ -467,4 +467,35 @@ describe("applyRedactions", () => {
     const out = applyRedactions(trace, policy, SALT);
     expect(out.messages[0].content).toBe("[redacted]");
   });
+
+  test("malformed JSON pointer escapes are ignored before rewriting literal keys", () => {
+    const trace = traceWith({
+      metadata: {
+        "bad~": "secret",
+        "a~2b": "also-secret",
+      },
+      redactions: [
+        {
+          path: "/metadata/bad~",
+          reason: "pii-custom",
+          category: "pii-custom",
+          detectedBy: "client",
+          detectedAt: "2026-04-17T12:00:00.500Z",
+        },
+        {
+          path: "/metadata/a~2b",
+          reason: "pii-custom",
+          category: "pii-custom",
+          detectedBy: "client",
+          detectedAt: "2026-04-17T12:00:00.500Z",
+        },
+      ],
+    });
+
+    const out = applyRedactions(trace, policy, SALT);
+    const meta = out.metadata as Record<string, unknown>;
+
+    expect(meta["bad~"]).toBe("secret");
+    expect(meta["a~2b"]).toBe("also-secret");
+  });
 });

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -68,6 +68,8 @@ const productionTraceOpenSdkProgramPathSubstrings =
 	productionTraceOpenSdkSourcePaths.map((entry) => `/${entry}`);
 const productionTraceOpenRedactionSourcePaths = [
 	"ts/src/production-traces/redaction/hash-primitives.ts",
+	"ts/src/production-traces/redaction/types.ts",
+	"ts/src/production-traces/redaction/apply.ts",
 ];
 const productionTraceOpenRedactionSourceIncludes =
 	productionTraceOpenRedactionSourcePaths.map((entry) => `../../../${entry}`);
@@ -118,6 +120,10 @@ type ProductionTraceSourceClaim = {
 	coreOwnedProgramPathSubstrings: string[];
 };
 
+type ProductionTraceOpenRedactionClaim = ProductionTraceSourceClaim & {
+	forbiddenImportPathSubstrings: string[];
+};
+
 type ProductionTraceOpenContractClaim = ProductionTraceSourceClaim & {
 	coreOwnedSchemaAssetIncludes: string[];
 	forbiddenImportPathSubstrings: string[];
@@ -127,7 +133,7 @@ type ProductionTraceOpenContractClaim = ProductionTraceSourceClaim & {
 type ProductionTraceBoundary = {
 	typescriptOpenContract: ProductionTraceOpenContractClaim;
 	typescriptOpenSdk: ProductionTraceOpenContractClaim;
-	typescriptOpenRedaction: ProductionTraceSourceClaim;
+	typescriptOpenRedaction: ProductionTraceOpenRedactionClaim;
 	typescriptOpenTaxonomy: ProductionTraceSourceClaim;
 };
 
@@ -382,7 +388,7 @@ describe("package boundaries", () => {
 		}
 	});
 
-	it("claims production trace redaction primitives as explicit TypeScript core-owned open privacy helpers", () => {
+	it("claims production trace redaction apply helpers as explicit TypeScript core-owned open privacy helpers", () => {
 		const boundaries = loadBoundaries();
 		const core = boundaries.typescript.core;
 		const productionTraces =
@@ -425,6 +431,10 @@ describe("package boundaries", () => {
 		expect(packageJson.exports["./production-traces/hashing"]).toEqual({
 			import: "./dist/ts/src/production-traces/sdk/hashing-core.js",
 			types: "./dist/ts/src/production-traces/sdk/hashing-core.d.ts",
+		});
+		expect(packageJson.exports["./production-traces/redaction/apply"]).toEqual({
+			import: "./dist/ts/src/production-traces/redaction/apply.js",
+			types: "./dist/ts/src/production-traces/redaction/apply.d.ts",
 		});
 	});
 
@@ -606,6 +616,32 @@ describe("package boundaries", () => {
 	it("keeps production trace SDK helpers independent of control-plane workflows", () => {
 		const productionTraces =
 			loadBoundaries().mixedDomains.productionTraces.typescriptOpenSdk;
+
+		expect(productionTraces.forbiddenImportPathSubstrings).toEqual([
+			"control-plane/",
+			"../cli/",
+			"../ingest/",
+			"../dataset/",
+			"../retention/",
+			"../../traces/",
+		]);
+		for (const sourceInclude of productionTraces.coreOwnedSourceIncludes) {
+			const sourceText = readFileSync(
+				join(repoRoot, "packages", "ts", "core", sourceInclude),
+				"utf-8",
+			);
+			const imports = importSpecifiers(sourceText);
+			for (const forbidden of productionTraces.forbiddenImportPathSubstrings) {
+				expect(imports.some((specifier) => specifier.includes(forbidden))).toBe(
+					false,
+				);
+			}
+		}
+	});
+
+	it("keeps production trace redaction apply helpers independent of control-plane workflows", () => {
+		const productionTraces =
+			loadBoundaries().mixedDomains.productionTraces.typescriptOpenRedaction;
 
 		expect(productionTraces.forbiddenImportPathSubstrings).toEqual([
 			"control-plane/",


### PR DESCRIPTION
## Summary
- Claim exact TypeScript redaction apply/type files for the core package without claiming policy IO, mark-at-ingest detection, install-salt lifecycle, CLI, ingest, dataset, retention, or traces workflows.
- Expose `@autocontext/core/production-traces/redaction/apply` and re-export the policy types needed by `applyRedactions`.
- Reuse the contract JSON Pointer parser so exported redaction apply behavior rejects malformed RFC 6901 escapes before rewriting literal keys.

## Tests
- `npx vitest run tests/package-boundaries.test.ts tests/control-plane/production-traces/redaction/apply.test.ts --run`
- `./node_modules/.bin/tsc --noEmit -p ../packages/ts/core/tsconfig.json`
- `npx vitest run tests/control-plane/production-traces/contract/invariants.test.ts tests/control-plane/production-traces/redaction/apply.test.ts tests/package-topology.test.ts tests/package-boundaries.test.ts --run`
- `git diff --check`
- `npm run lint`
- `uv run ruff check tests/test_package_topology.py tests/test_package_boundaries.py`
- `uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q`

Full `npm test` was also attempted locally. The touched redaction/package tests passed, but the full suite exited non-zero on unrelated local timeouts/pre-existing assertions in campaign/mission/CLI/server/type-budget tests plus Vitest worker `onTaskUpdate` timeouts.