### PR TITLE
AC-650 Reset licensing strategy to Apache boundary wrap-up

### DIFF
--- a/autocontext/tests/test_package_boundaries.py
+++ b/autocontext/tests/test_package_boundaries.py
@@ -80,17 +80,21 @@ def test_package_boundaries_manifest_exists() -> None:
     assert BOUNDARIES_PATH.exists()
 
 
-def test_license_metadata_publication_is_deferred_to_linear_guardrails() -> None:
+def test_existing_code_strategy_is_apache_only() -> None:
     licensing = _licensing_guardrails()
 
-    assert licensing["status"] == "deferred"
+    assert licensing["status"] == "apache-only"
+    assert licensing["decisionDate"] == "2026-04-28"
+    assert licensing["existingCodeLicense"] == "Apache-2.0"
+    assert licensing["historicalRelicensing"] == "out-of-scope"
+    assert licensing["futureProprietaryWork"] == "separate-repository"
     assert licensing["licenseMetadataIssue"] == "AC-645"
     assert licensing["rightsAuditIssue"] == "AC-646"
 
 
-def test_deferred_license_publication_files_are_absent() -> None:
+def test_dual_license_publication_files_are_absent() -> None:
     licensing = _licensing_guardrails()
-    forbidden_paths = licensing["forbiddenPathsUntilAC645"]
+    forbidden_paths = licensing["forbiddenDualLicenseMetadataPaths"]
     assert isinstance(forbidden_paths, list)
     assert forbidden_paths == [
         "LICENSING.md",
@@ -105,12 +109,12 @@ def test_deferred_license_publication_files_are_absent() -> None:
         assert not (REPO_ROOT / relative_path).exists()
 
 
-def test_rights_audit_records_controlled_identity_and_final_signoff_blocker() -> None:
+def test_rights_audit_is_preserved_as_historical_context() -> None:
     licensing = _licensing_guardrails()
     rights_audit = licensing["rightsAudit"]
     assert isinstance(rights_audit, dict)
 
-    assert rights_audit["status"] == "in-progress"
+    assert rights_audit["status"] == "historical-context"
     assert rights_audit["auditDoc"] == "docs/contributor-rights-audit.md"
     assert (REPO_ROOT / str(rights_audit["auditDoc"])).exists()
     assert rights_audit["confirmedControlledContributorIdentities"] == [
@@ -122,13 +126,10 @@ def test_rights_audit_records_controlled_identity_and_final_signoff_blocker() ->
         }
     ]
     assert rights_audit["blockedRelicensingPathsUntilConfirmed"] == []
-    assert rights_audit["requiredFinalSignoffs"] == [
-        "grey-haven-authority-for-controlled-contributor-identities",
-        "grey-haven-legal-business-approval",
-    ]
+    assert rights_audit["requiredFinalSignoffs"] == []
 
 
-def test_python_license_metadata_stays_deferred_for_new_package_artifacts() -> None:
+def test_private_python_package_skeletons_have_no_separate_license_metadata() -> None:
     licensing = _licensing_guardrails()
     python_metadata = licensing["pythonProjectMetadata"]
     assert isinstance(python_metadata, dict)

--- a/autocontext/tests/test_package_topology.py
+++ b/autocontext/tests/test_package_topology.py
@@ -61,6 +61,23 @@ def test_package_topology_declares_expected_domain_terms() -> None:
     }
 
 
+def test_package_topology_declares_apache_boundary_wrap_up_guardrails() -> None:
+    topology = _load_topology()
+    assert topology["status"] == "apache-boundary-wrap-up"
+    guardrails = topology["guardrails"]
+    assert isinstance(guardrails, dict)
+
+    assert guardrails["repoWideLicenseFlip"] == (
+        "out-of-scope-existing-code-remains-apache-2.0"
+    )
+    assert guardrails["dualLicenseMetadata"] == "do-not-publish-for-existing-repo"
+    assert guardrails["historicalRelicensing"] == "out-of-scope"
+    assert guardrails["futureProprietaryWork"] == "separate-repository"
+    assert guardrails["defaultInstallCompatibility"] == (
+        "preserve-autocontext-autoctx-and-autoctx-cli"
+    )
+
+
 def test_python_package_shells_exist() -> None:
     for shell in _python_shells():
         assert shell.path.exists(), shell.path

--- a/docs/contributor-rights-audit.md
+++ b/docs/contributor-rights-audit.md
@@ -1,58 +1,58 @@
-# Contributor Rights Audit for the Core/Control Licensing Split
+# Contributor Rights Audit Historical Snapshot
 
-This is the AC-646 rights-audit artifact for the AutoContext licensing
-structure transition. It supports the package-boundary work in
+This is the AC-646 rights-audit historical snapshot that was created during the
+abandoned dual-license investigation. It now supports provenance context for the
+package-boundary work in
 [`core-control-package-split.md`](./core-control-package-split.md) and the
 machine-readable boundary guardrails in
 [`packages/package-boundaries.json`](../packages/package-boundaries.json).
 
 This document is an engineering audit, not legal advice. It records what git
-history can prove and identifies which business/legal records still need to be
-checked before any non-Apache relicensing or AC-645 license metadata publication
-can proceed.
+history could prove at the time of the audit. It is no longer a go/no-go gate
+for relicensing this repository: existing public repo code remains Apache-2.0,
+and future proprietary work should live in a separate repo under its own
+license.
 
 ## Current Status
 
 - Audit snapshot: `0aa0114e` (`main`, after production-trace SDK build helper)
-- License metadata status: still deferred to AC-645.
-- Non-Apache relicensing status: **not finally approved yet**.
+- License strategy status: existing public repo code remains Apache-2.0.
+- Historical relicensing status: **out of scope**.
 - Grey Haven confirmation received on 2026-04-28: contributions authored under
   `cirdan-greyhaven` are treated as a Grey Haven-controlled contributor identity
   for this engineering audit.
-- Current blocker: Grey Haven still needs a final business/legal sign-off that
-  it has authority to license/relicense the affected contributions from all
-  observed Grey Haven-controlled contributor identities.
+- Current blocker: none for boundary wrap-up. This audit would need fresh legal
+  review only if the project reopens historical relicensing later.
 - Repository records checked: `CONTRIBUTING.md`, `.github/`, docs, and root
   license files. No CLA, DCO, copyright assignment, or contributor license
   agreement was found in-repo.
-- The controlled-identity confirmation, empty current path-specific block list,
-  and required final sign-offs are encoded in `packages/package-boundaries.json` under
-  `licensing.rightsAudit` so CI can keep AC-645 metadata blocked while final
-  authority is pending.
+- The controlled-identity confirmation and empty current path-specific block
+  list are preserved in `packages/package-boundaries.json` under
+  `licensing.rightsAudit` as historical context.
 
-## Go / No-Go Summary
+## Historical Summary
 
-| Area                               | Current evidence                                                                                                                                                                 | Relicensing status                                                                                                                |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| Grey Haven-controlled affected paths | Git history/blame show Jay Scambler identities and `cirdan-greyhaven` identities confirmed as Grey Haven-controlled in the current source lines for audited non-Apache candidate path groups. | **Conditionally clear** once Grey Haven records confirm authority to license/relicense those contributions. |
-| Path-specific third-party blockers | No current non-Grey-Haven-controlled source-line blockers were found in the audited non-Apache candidate paths after recording the Cirdan identity confirmation. | **No current path-specific blocker** from git evidence; re-run if path ownership changes. |
-| Gingiris contribution              | Git history shows one contribution touching `README.md` and `autocontext/src/autocontext/banner.py`; neither is currently in the proposed non-Apache path groups audited here.   | **Not a current non-Apache blocker**, but re-check if either path is moved into a non-Apache package or root docs are relicensed. |
-| AC-645 license metadata            | Guarded by tests and `packages/package-boundaries.json`.                                                                                                                         | **Blocked** until final Grey Haven sign-off is recorded.                                                                          |
+| Area                               | Current evidence                                                                                                                                                                 | Current treatment                                                                                                                |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Grey Haven-controlled affected paths | Git history/blame show Jay Scambler identities and `cirdan-greyhaven` identities confirmed as Grey Haven-controlled in the current source lines for previously audited candidate path groups. | Historical provenance context only; existing code remains Apache-2.0. |
+| Path-specific third-party blockers | No current non-Grey-Haven-controlled source-line blockers were found in the audited path groups after recording the Cirdan identity confirmation. | No blocker for boundary wrap-up; re-run only if historical relicensing is reconsidered. |
+| Gingiris contribution              | Git history shows one contribution touching `README.md` and `autocontext/src/autocontext/banner.py`. | Keep the touched files Apache-2.0 with the rest of the existing repo. |
+| AC-645 license metadata            | Guarded by tests and `packages/package-boundaries.json`. | Superseded unless re-scoped to Apache metadata hygiene. |
 
 ## Contributor Identities Seen in Affected Areas
 
 | Canonical audit identity | Git author identities observed                                                      | Audit treatment                                 | Required authority evidence                                                                                  |
 | ------------------------ | ------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `jay-scambler`           | `Jay Scambler <jayscambler@gmail.com>`, `Jay Scambler <jay@greyhaven.ai>` | Grey Haven contributor identity. | Confirm Grey Haven ownership/assignment or authorization covering both observed email identities. |
-| `cirdan-greyhaven`       | `Cirdan <cirdan@greyhaven.ai>`, `Cirdan Shipwright <cirdan@greyhaven.ai>` | Grey Haven-controlled contributor identity. | Covered by final Grey Haven authority confirmation; preserve the 2026-04-28 confirmation in AC-646 records. |
-| `gingiris`               | `Gingiris <iris103195@gmail.com>`                                         | No current non-Apache path impact found.        | If future path maps include the touched files, request explicit permission or keep those files Apache.       |
+| `jay-scambler`           | `Jay Scambler <jayscambler@gmail.com>`, `Jay Scambler <jay@greyhaven.ai>` | Grey Haven contributor identity. | Historical context only while existing code remains Apache-2.0. |
+| `cirdan-greyhaven`       | `Cirdan <cirdan@greyhaven.ai>`, `Cirdan Shipwright <cirdan@greyhaven.ai>` | Grey Haven-controlled contributor identity. | Preserve the 2026-04-28 confirmation in AC-646 records. |
+| `gingiris`               | `Gingiris <iris103195@gmail.com>`                                         | Outside contributor identity.        | Keep existing contributions Apache-2.0.       |
 
 ## Affected Path Groups Audited
 
-The audit uses the current package/path split documents as the source of truth
-for code that may move into a source-available control-plane tier. Open/core
-production-trace contracts and SDK helpers are intentionally excluded unless the
-path map later marks them non-Apache.
+The audit used the package/path split documents that existed at the time as the
+source of truth for code that might have moved into a non-Apache control-plane
+tier. This framing is now historical; current boundary work keeps the existing
+repo Apache-2.0.
 
 ### Python control-plane directories
 
@@ -73,8 +73,8 @@ Evidence summary:
 
 | Contributor        | Direct path-log commits in group | Current blamed lines in group | Status                                                                                                  |
 | ------------------ | -------------------------------: | ----------------------------: | ------------------------------------------------------------------------------------------------------- |
-| `jay-scambler`     |                               75 |                        12,016 | Conditionally clear pending final Grey Haven authority confirmation.                                    |
-| `cirdan-greyhaven` |                                1 |                           117 | Treated as Grey Haven-controlled contributor identity; conditionally clear with final Grey Haven sign-off. |
+| `jay-scambler`     |                               75 |                        12,016 | Historical provenance context; existing code remains Apache-2.0.                                    |
+| `cirdan-greyhaven` |                                1 |                           117 | Treated as Grey Haven-controlled contributor identity for historical context. |
 
 Current files with Cirdan-identity lines:
 
@@ -98,8 +98,8 @@ Evidence summary:
 
 | Contributor        | Direct path-log commits in group | Current blamed lines in group | Status                                                                                                  |
 | ------------------ | -------------------------------: | ----------------------------: | ------------------------------------------------------------------------------------------------------- |
-| `jay-scambler`     |                               28 |                         2,399 | Conditionally clear pending final Grey Haven authority confirmation.                                    |
-| `cirdan-greyhaven` |         See blamed commits below |                           170 | Treated as Grey Haven-controlled contributor identity; conditionally clear with final Grey Haven sign-off. |
+| `jay-scambler`     |                               28 |                         2,399 | Historical provenance context; existing code remains Apache-2.0.                                    |
+| `cirdan-greyhaven` |         See blamed commits below |                           170 | Treated as Grey Haven-controlled contributor identity for historical context. |
 
 Current files with Cirdan-identity lines:
 
@@ -125,7 +125,7 @@ Evidence summary:
 
 | Contributor    | Direct path-log commits in group | Current blamed lines in group | Status                                                               |
 | -------------- | -------------------------------: | ----------------------------: | -------------------------------------------------------------------- |
-| `jay-scambler` |                              146 |                        32,004 | Conditionally clear pending final Grey Haven authority confirmation. |
+| `jay-scambler` |                              146 |                        32,004 | Historical provenance context; existing code remains Apache-2.0. |
 
 No non-Grey-Haven-controlled current source lines were found in this path group.
 
@@ -142,7 +142,7 @@ Evidence summary:
 
 | Contributor    | Direct path-log commits in group | Current blamed lines in group | Status                                                               |
 | -------------- | -------------------------------: | ----------------------------: | -------------------------------------------------------------------- |
-| `jay-scambler` |                                4 |                         5,014 | Conditionally clear pending final Grey Haven authority confirmation. |
+| `jay-scambler` |                                4 |                         5,014 | Historical provenance context; existing code remains Apache-2.0. |
 
 No non-Grey-Haven-controlled current source lines were found in this path group.
 
@@ -150,14 +150,13 @@ No non-Grey-Haven-controlled current source lines were found in this path group.
 
 Audited paths include data-plane, dataset, distillation, export, publishing,
 redaction workflow, and ingest workflow files under `ts/src/traces/`. The open
-public schema files are intentionally excluded from this non-Apache candidate
-set.
+public schema files were excluded from the historical candidate set.
 
 Evidence summary:
 
 | Contributor    | Direct path-log commits in group | Current blamed lines in group | Status                                                               |
 | -------------- | -------------------------------: | ----------------------------: | -------------------------------------------------------------------- |
-| `jay-scambler` |                               16 |                         2,756 | Conditionally clear pending final Grey Haven authority confirmation. |
+| `jay-scambler` |                               16 |                         2,756 | Historical provenance context; existing code remains Apache-2.0. |
 
 No non-Grey-Haven-controlled current source lines were found in this path group.
 
@@ -167,14 +166,14 @@ Audited paths include solve workflows, package workflows, skill-package
 workflows, research hub, and package helper files under `ts/src/knowledge/`.
 Core-leaning local runtime artifacts such as `artifact-store.ts`, `playbook.ts`,
 `trajectory.ts`, and public package/skill contract files are intentionally
-excluded unless the path map later assigns them to the non-Apache tier.
+excluded from this historical audit slice.
 
 Evidence summary:
 
 | Contributor        | Direct path-log commits in group | Current blamed lines in group | Status                                                                                                  |
 | ------------------ | -------------------------------: | ----------------------------: | ------------------------------------------------------------------------------------------------------- |
-| `jay-scambler`     |                               22 |                         2,836 | Conditionally clear pending final Grey Haven authority confirmation.                                    |
-| `cirdan-greyhaven` |                                1 |                            70 | Treated as Grey Haven-controlled contributor identity; conditionally clear with final Grey Haven sign-off. |
+| `jay-scambler`     |                               22 |                         2,836 | Historical provenance context; existing code remains Apache-2.0.                                    |
+| `cirdan-greyhaven` |                                1 |                            70 | Treated as Grey Haven-controlled contributor identity for historical context. |
 
 Current files with Cirdan-identity lines:
 
@@ -184,28 +183,22 @@ Current files with Cirdan-identity lines:
 
 ## Current Path-Specific Blockers
 
-No current path-specific third-party relicensing blockers remain in the audited
-non-Apache candidate paths after recording the `cirdan-greyhaven` Grey Haven
-controlled-identity confirmation.
+No current path-specific third-party blocker remains relevant to the boundary
+wrap-up because the existing repo is staying Apache-2.0.
 
-This does **not** approve non-Apache relicensing yet. AC-645 remains blocked
-until final Grey Haven authority/sign-off is recorded for affected
-contributions across all observed Grey Haven-controlled contributor identities.
+This does **not** approve non-Apache relicensing. It records that historical
+relicensing is out of scope. If Grey Haven later reopens historical relicensing,
+this audit should be treated as stale input and rerun with legal review.
 
-## Required Follow-Up Before AC-645
+## Follow-Up
 
-1. Record final Grey Haven authority/ownership confirmation for affected
-   contributions across all observed Grey Haven-controlled contributor identities.
-2. Preserve the 2026-04-28 confirmation that `cirdan-greyhaven` contributions
-   are covered by Grey Haven AI licensing authority in the AC-646 Linear/PR
-   records.
-3. Decide how to handle `gingiris` if root docs, banner code, or other currently
-   Apache-compatible surfaces become part of a non-Apache package or path-level
-   notice.
-4. Re-run this audit after any substantial AC-644 path movement and before
-   AC-645 adds per-package license metadata.
-5. Add the final legal/business sign-off reference to this document or to the
-   AC-646 Linear issue before marking AC-646 Done.
+1. Preserve the 2026-04-28 confirmation that `cirdan-greyhaven` contributions
+   are treated as a Grey Haven-controlled contributor identity in the AC-646
+   Linear/PR records.
+2. Keep existing `gingiris` contributions Apache-2.0 with the rest of the
+   public repo.
+3. Put future proprietary work in a separate repo under its own license rather
+   than trying to reclassify historical files in this repo.
 
 ## Reproduction Commands
 
@@ -233,5 +226,5 @@ git log --format='%H%x09%an%x09%ae%x09%aI%x09%s' -- \
 git blame --line-porcelain -- autocontext/src/autocontext/mcp/server.py
 ```
 
-The audit should be regenerated if new path groups are added to the non-Apache
-control-plane tier or if AC-644 physically moves source files before AC-645.
+The audit should be regenerated only if the project reopens historical
+relicensing. It is not required for Apache package-boundary wrap-up.

--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -1,32 +1,38 @@
 # Core/Control Package Split
 
-This document is the PR0 source of truth for the AutoContext package and
-licensing split. It turns the Linear strategy in AC-642, AC-643, AC-644,
-AC-648, AC-649, and AC-650 into a concrete implementation guardrail before
-moving behavior or changing license metadata.
+This document is the source of truth for the AutoContext core/control package
+boundary. It turns the Linear strategy in AC-642, AC-643, AC-644, AC-648,
+AC-649, and AC-650 into a concrete implementation guardrail before moving
+behavior or changing public install paths.
 
 ## Strategy
 
-AutoContext is moving toward a three-tier open-core model:
+AutoContext is keeping the existing public repository and already-written code
+Apache-2.0. The boundary work continues as architecture and package hygiene, not
+as a historical relicensing project.
 
-1. Apache 2.0 core: foundational runtime, SDK, scenario contracts, providers,
+The package split should make these domains clear:
+
+1. Apache-2.0 core: foundational runtime, SDK, scenario contracts, providers,
    execution primitives, local state, and extension points.
-2. Separately licensed control plane: operator workflows, management UX,
-   orchestration, advanced trace management, knowledge packaging/export, and
-   other monetizable control surfaces.
-3. Proprietary Cloud and Box: hosted infrastructure, enterprise deployment, and
-   service-only features.
+2. Apache-2.0 control plane: operator workflows, management UX, orchestration,
+   advanced trace management, knowledge packaging/export, and other higher-level
+   control surfaces that still live in this repo.
+3. Future proprietary products: hosted infrastructure, enterprise deployment,
+   service-only features, and other net-new proprietary work in a separate repo
+   under its own license.
 
-The goal is not a repo-wide source-available license flip. The code and package
-layout must make the licensing model true before the repo advertises it.
+The goal is not a repo-wide source-available license flip. The goal is a clean
+Apache public foundation with stable contracts that a future proprietary repo can
+depend on without copying or relicensing historical code.
 
 ## Hard Guardrails
 
-- Do not change the repo-wide license before package boundaries are real.
-- Do not add per-package license files, license metadata, or a root
-  `LICENSING.md` until AC-645.
-- Do not relicense any code into a non-Apache tier until AC-646 confirms the
-  required contributor rights.
+- Keep the existing public repository and already-written code Apache-2.0.
+- Do not add dual-license metadata, per-package non-Apache license files, or a
+  root `LICENSING.md` for the existing repo.
+- Treat AC-645 as superseded unless it is re-scoped to Apache metadata hygiene.
+- Treat AC-646 as provenance context, not as a blocker for boundary wrap-up.
 - Preserve `pip install autocontext`, `npm install autoctx`, and the `autoctx`
   CLI as the default compatibility path while the split is in progress.
 - Keep `autocontext/` and `ts/` as umbrella compatibility packages until the
@@ -36,11 +42,11 @@ layout must make the licensing model true before the repo advertises it.
 - Prefer compatibility shims and re-exports over breaking old import paths
   during the first migration phases.
 
-The boundary-enforcement contract also encodes the deferred licensing
-publication rule: no root `LICENSING.md`, no per-package `LICENSE` files, and no
-new core/control package license metadata until AC-645. Any non-Apache
-relicensing remains blocked by the AC-646 rights audit. The current engineering
-audit lives in [`contributor-rights-audit.md`](./contributor-rights-audit.md).
+The boundary-enforcement contract also encodes the Apache-only publication rule:
+no root `LICENSING.md`, no per-package non-Apache `LICENSE` files, and no
+dual-license metadata for the existing repo. The AC-646 engineering audit is
+preserved as historical provenance context in
+[`contributor-rights-audit.md`](./contributor-rights-audit.md).
 
 ## Package Topology
 
@@ -57,8 +63,8 @@ checked in CI.
 | Pi         | `pi-autocontext` initially depends on `autoctx` | Deferred             | Deferred                     |
 
 The umbrella packages preserve the default install and CLI experience. The new
-core/control artifacts make the future license boundary real at the artifact
-level.
+core/control artifacts make the dependency boundary explicit at the artifact
+level while remaining Apache-2.0 in this repo.
 
 ## Path Map
 
@@ -218,8 +224,8 @@ Move to the control plane:
 6. Split `knowledge` deliberately.
 7. Split production trace contracts/SDK from management workflows.
 8. Rewire umbrella packages and CLI ownership.
-9. Apply AC-645 licensing metadata only after boundaries are real and AC-646 is
-   complete.
+9. Remove or reword any user-facing dual-license migration language before
+   publishing the package split.
 10. Revisit Pi dependency ownership after the TypeScript split stabilizes.
 
 ## Review Checks
@@ -235,5 +241,6 @@ Move to the control plane:
   exact includes until ownership is settled.
 - Any PR that changes existing protocol or payload semantics should say so
   explicitly instead of presenting itself as facade-only work.
-- Public docs should not advertise the licensing split until package metadata
-  and rights review are complete.
+- Public docs should not advertise a dual-license migration for the existing
+  repo. They should describe Apache package boundaries and any future
+  proprietary work as separate-repo work.

--- a/docs/knowledge-production-trace-boundary-map.md
+++ b/docs/knowledge-production-trace-boundary-map.md
@@ -15,8 +15,8 @@ facade only that row while preserving the existing compatibility surfaces.
 - Do not move all trace code as one unit.
 - Do not change `autocontext`, `autoctx`, or the `autoctx` CLI compatibility
   paths while the split is in progress.
-- Do not publish AC-645 license metadata or any non-Apache relicensing while
-  AC-646 remains unresolved.
+- Do not publish dual-license metadata or non-Apache relicensing for the
+  existing public repo. Existing code remains Apache-2.0.
 
 ## Ubiquitous Language
 
@@ -63,17 +63,19 @@ Owns operator workflows and management surfaces:
 Control-plane code may depend on core contracts and SDK helpers. Core code must
 not depend on control-plane code.
 
-### Proprietary / Deferred Cloud + Box
+### Future Proprietary / Separate Repo
 
-Keep these out of Apache/core and source-available control-plane artifacts until
-the product boundary is explicitly implemented:
+Keep these out of the existing Apache repo unless they are intentionally made
+Apache-2.0. Future proprietary implementations should live in a separate repo
+under their own license:
 
 - hosted trace warehouse, cross-tenant registry, or fleet retention service;
 - enterprise-only dataset marketplace, promotion approval UI, or policy center;
 - managed knowledge sharing across organizations;
 - Cloud/Box deployment automation and hosted control-plane infrastructure.
 
-These are not AC-645 license metadata. They are future product placement notes.
+These are not AC-645 license metadata. They are future product placement notes
+for net-new proprietary work, not a plan to relicense historical code.
 
 ## Knowledge Split Map
 
@@ -252,10 +254,13 @@ families:
 6. **Compatibility smoke tests** — keep `autocontext.production_traces`,
    `autocontext.knowledge`, `autoctx`, `autoctx/production-traces`, and
    `autoctx production-traces` working while internals move.
-7. **No premature licensing publication** — reuse the AC-645/AC-646 guardrail;
-   extraction PRs must not add license metadata.
+7. **No dual-license publication for this repo** — keep the public repo
+   Apache-2.0; extraction PRs must not add non-Apache or dual-license metadata.
 
 ## Recommended Extraction Order
+
+This order is now capped to boundary wrap-up. Do not continue extracting
+historical code only to prepare a non-Apache licensing split.
 
 1. Production trace contract and emit SDK package ownership. This is the cleanest
    boundary: schemas, branded IDs, validation, hashing, taxonomy, and emit
@@ -274,4 +279,6 @@ families:
    distillation, and dataset workflows to control-plane.
 
 Each step should be a small PR with one manifest change, one RED boundary test,
-one GREEN extraction/facade change, and compatibility smoke coverage.
+one GREEN extraction/facade change, and compatibility smoke coverage. Stop the
+sequence once the Apache package boundary is clear enough for users and future
+separate-repo proprietary work.

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,7 +1,7 @@
 # Package Topology
 
 This directory is the source of truth for the phase-one package topology of the
-core/control split.
+Apache core/control boundary cleanup.
 
 The human-readable strategy and guardrails live in
 [`docs/core-control-package-split.md`](../docs/core-control-package-split.md).

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -1,10 +1,14 @@
 {
 	"version": 1,
 	"licensing": {
-		"status": "deferred",
+		"status": "apache-only",
+		"decisionDate": "2026-04-28",
+		"existingCodeLicense": "Apache-2.0",
+		"historicalRelicensing": "out-of-scope",
+		"futureProprietaryWork": "separate-repository",
 		"licenseMetadataIssue": "AC-645",
 		"rightsAuditIssue": "AC-646",
-		"forbiddenPathsUntilAC645": [
+		"forbiddenDualLicenseMetadataPaths": [
 			"LICENSING.md",
 			"packages/python/core/LICENSE",
 			"packages/python/control/LICENSE",
@@ -12,7 +16,7 @@
 			"packages/ts/control-plane/LICENSE"
 		],
 		"rightsAudit": {
-			"status": "in-progress",
+			"status": "historical-context",
 			"auditDoc": "docs/contributor-rights-audit.md",
 			"confirmedControlledContributorIdentities": [
 				{
@@ -23,10 +27,7 @@
 				}
 			],
 			"blockedRelicensingPathsUntilConfirmed": [],
-			"requiredFinalSignoffs": [
-				"grey-haven-authority-for-controlled-contributor-identities",
-				"grey-haven-legal-business-approval"
-			]
+			"requiredFinalSignoffs": []
 		},
 		"pythonProjectMetadata": {
 			"paths": [

--- a/packages/package-topology.json
+++ b/packages/package-topology.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "status": "planning-guardrail",
+  "status": "apache-boundary-wrap-up",
   "linearIssues": {
     "strategy": "AC-642",
     "pathMap": "AC-643",
@@ -13,15 +13,16 @@
     "implementationSequence": "AC-650"
   },
   "guardrails": {
-    "repoWideLicenseFlip": "blocked-until-package-boundaries-are-real",
-    "licenseMetadata": "deferred-to-AC-645",
-    "nonApacheRelicensing": "blocked-by-AC-646",
+    "repoWideLicenseFlip": "out-of-scope-existing-code-remains-apache-2.0",
+    "dualLicenseMetadata": "do-not-publish-for-existing-repo",
+    "historicalRelicensing": "out-of-scope",
+    "futureProprietaryWork": "separate-repository",
     "defaultInstallCompatibility": "preserve-autocontext-autoctx-and-autoctx-cli"
   },
   "terms": {
     "umbrellaPackage": "User-facing compatibility distribution that preserves the current install and CLI experience while delegating behavior to core and control-plane artifacts.",
     "corePackage": "Apache 2.0 foundational runtime package that carries the reusable execution substrate.",
-    "controlPackage": "Higher-level operator and management package that will carry the separately licensed control-plane surfaces.",
+    "controlPackage": "Apache 2.0 operator and management package boundary for higher-level control-plane workflows.",
     "compatibilityShell": "Thin package layer that re-exports or dispatches into the new internal artifacts while the migration is in progress.",
     "packageTopology": "The path and artifact map that defines which package owns each ecosystem role during the migration."
   },

--- a/packages/python/control/README.md
+++ b/packages/python/control/README.md
@@ -1,3 +1,3 @@
 # autocontext-control skeleton
 
-Internal package skeleton for the future Python control-plane artifact.
+Internal Apache-2.0 package skeleton for the Python control-plane boundary.

--- a/packages/python/control/pyproject.toml
+++ b/packages/python/control/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "autocontext-control"
 version = "0.0.0"
-description = "Internal package skeleton for the future control-plane artifact."
+description = "Internal Apache-2.0 package skeleton for the Python control-plane boundary."
 readme = "README.md"
 requires-python = ">=3.11"
 

--- a/packages/python/core/README.md
+++ b/packages/python/core/README.md
@@ -1,3 +1,3 @@
 # autocontext-core skeleton
 
-Internal package skeleton for the future Python core artifact.
+Internal Apache-2.0 package skeleton for the Python core boundary.

--- a/packages/python/core/pyproject.toml
+++ b/packages/python/core/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "autocontext-core"
 version = "0.0.0"
-description = "Internal package skeleton for the future Apache core artifact."
+description = "Internal Apache-2.0 package skeleton for the Python core boundary."
 readme = "README.md"
 requires-python = ">=3.11"
 

--- a/packages/ts/control-plane/README.md
+++ b/packages/ts/control-plane/README.md
@@ -1,3 +1,3 @@
 # @autocontext/control-plane skeleton
 
-Internal package skeleton for the future TypeScript control-plane artifact.
+Internal Apache-2.0 package skeleton for the TypeScript control-plane boundary.

--- a/packages/ts/control-plane/package.json
+++ b/packages/ts/control-plane/package.json
@@ -2,7 +2,7 @@
   "name": "@autocontext/control-plane",
   "version": "0.0.0",
   "private": true,
-  "description": "Internal package skeleton for the future control-plane artifact.",
+  "description": "Internal Apache-2.0 package skeleton for the TypeScript control-plane boundary.",
   "type": "module",
   "main": "dist/packages/ts/control-plane/src/index.js",
   "types": "dist/packages/ts/control-plane/src/index.d.ts",

--- a/packages/ts/core/README.md
+++ b/packages/ts/core/README.md
@@ -1,3 +1,3 @@
 # @autocontext/core skeleton
 
-Internal package skeleton for the future TypeScript core artifact.
+Internal Apache-2.0 package skeleton for the TypeScript core boundary.

--- a/packages/ts/core/package.json
+++ b/packages/ts/core/package.json
@@ -2,7 +2,7 @@
   "name": "@autocontext/core",
   "version": "0.0.0",
   "private": true,
-  "description": "Internal package skeleton for the future Apache core artifact.",
+  "description": "Internal Apache-2.0 package skeleton for the TypeScript core boundary.",
   "type": "module",
   "main": "dist/packages/ts/core/src/index.js",
   "types": "dist/packages/ts/core/src/index.d.ts",

--- a/ts/tests/package-boundaries.test.ts
+++ b/ts/tests/package-boundaries.test.ts
@@ -94,9 +94,13 @@ type TsControlBoundary = {
 
 type LicensingGuardrails = {
 	status: string;
+	decisionDate: string;
+	existingCodeLicense: string;
+	historicalRelicensing: string;
+	futureProprietaryWork: string;
 	licenseMetadataIssue: string;
 	rightsAuditIssue: string;
-	forbiddenPathsUntilAC645: string[];
+	forbiddenDualLicenseMetadataPaths: string[];
 	rightsAudit: {
 		status: string;
 		auditDoc: string;
@@ -232,33 +236,37 @@ describe("package boundaries", () => {
 		expect(existsSync(boundariesPath)).toBe(true);
 	});
 
-	it("keeps license metadata publication deferred to the blocking Linear issues", () => {
+	it("records the Apache-only strategy decision for existing code", () => {
 		const licensing = loadBoundaries().licensing;
 
-		expect(licensing.status).toBe("deferred");
+		expect(licensing.status).toBe("apache-only");
+		expect(licensing.decisionDate).toBe("2026-04-28");
+		expect(licensing.existingCodeLicense).toBe("Apache-2.0");
+		expect(licensing.historicalRelicensing).toBe("out-of-scope");
+		expect(licensing.futureProprietaryWork).toBe("separate-repository");
 		expect(licensing.licenseMetadataIssue).toBe("AC-645");
 		expect(licensing.rightsAuditIssue).toBe("AC-646");
 	});
 
-	it("keeps deferred license publication files absent", () => {
+	it("keeps dual-license publication files absent from the Apache repo", () => {
 		const licensing = loadBoundaries().licensing;
 
-		expect(licensing.forbiddenPathsUntilAC645).toEqual([
+		expect(licensing.forbiddenDualLicenseMetadataPaths).toEqual([
 			"LICENSING.md",
 			"packages/python/core/LICENSE",
 			"packages/python/control/LICENSE",
 			"packages/ts/core/LICENSE",
 			"packages/ts/control-plane/LICENSE",
 		]);
-		for (const relativePath of licensing.forbiddenPathsUntilAC645) {
+		for (const relativePath of licensing.forbiddenDualLicenseMetadataPaths) {
 			expect(existsSync(join(repoRoot, relativePath))).toBe(false);
 		}
 	});
 
-	it("records controlled contributor identity while preserving final signoff blockers", () => {
+	it("keeps the rights audit as provenance context, not a relicensing blocker", () => {
 		const rightsAudit = loadBoundaries().licensing.rightsAudit;
 
-		expect(rightsAudit.status).toBe("in-progress");
+		expect(rightsAudit.status).toBe("historical-context");
 		expect(rightsAudit.auditDoc).toBe("docs/contributor-rights-audit.md");
 		expect(existsSync(join(repoRoot, rightsAudit.auditDoc))).toBe(true);
 		expect(rightsAudit.confirmedControlledContributorIdentities).toEqual([
@@ -270,13 +278,10 @@ describe("package boundaries", () => {
 			},
 		]);
 		expect(rightsAudit.blockedRelicensingPathsUntilConfirmed).toEqual([]);
-		expect(rightsAudit.requiredFinalSignoffs).toEqual([
-			"grey-haven-authority-for-controlled-contributor-identities",
-			"grey-haven-legal-business-approval",
-		]);
+		expect(rightsAudit.requiredFinalSignoffs).toEqual([]);
 	});
 
-	it("keeps TypeScript package license metadata deferred for new package artifacts", () => {
+	it("keeps private TypeScript package skeletons free of separate license metadata", () => {
 		const metadata = loadBoundaries().licensing.typescriptPackageMetadata;
 
 		expect(metadata.forbiddenPackageKeys).toEqual(["license"]);

--- a/ts/tests/package-topology.test.ts
+++ b/ts/tests/package-topology.test.ts
@@ -16,6 +16,8 @@ type TsPackageEntry = PackageEntry & {
 };
 
 type Topology = {
+  status: string;
+  guardrails: Record<string, string>;
   typescript: {
     umbrella: PackageEntry & { bin: string };
     core: TsPackageEntry;
@@ -84,6 +86,19 @@ describe("package topology", () => {
       expect(existsSync(join(repoRoot, entry.path, "tsconfig.json"))).toBe(true);
       expect(existsSync(join(repoRoot, entry.path, entry.source))).toBe(true);
     }
+  });
+
+  it("declares Apache boundary wrap-up guardrails", () => {
+    const topology = loadTopology();
+
+    expect(topology.status).toBe("apache-boundary-wrap-up");
+    expect(topology.guardrails).toMatchObject({
+      repoWideLicenseFlip: "out-of-scope-existing-code-remains-apache-2.0",
+      dualLicenseMetadata: "do-not-publish-for-existing-repo",
+      historicalRelicensing: "out-of-scope",
+      futureProprietaryWork: "separate-repository",
+      defaultInstallCompatibility: "preserve-autocontext-autoctx-and-autoctx-cli",
+    });
   });
 
   it("matches TypeScript package names to the topology", () => {


### PR DESCRIPTION
## Summary
- record the Apache-only strategy for existing public repo code in the package manifests and boundary tests
- reframe the AC-646 rights audit as historical provenance context instead of a relicensing blocker
- update core/control, knowledge/trace, and package skeleton docs to describe Apache boundary cleanup and future proprietary work in a separate repo

## Tests
- npx vitest run tests/package-boundaries.test.ts tests/package-topology.test.ts --run
- uv run pytest tests/test_package_boundaries.py tests/test_package_topology.py -q
- uv run ruff check tests/test_package_boundaries.py tests/test_package_topology.py
- git diff --check