### PR TITLE
docs: restructure top-level README; bump subpackage version refs to 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to this project will be documented in this file.
 - TypeScript capabilities now report the provider factory support surface and no longer mark the visible `train` command as Python-only (AC-626).
 - TypeScript `run` now supports saved custom `agent_task` scenarios through the agent-task improvement runner instead of rejecting scenarios already discoverable in the control plane (AC-625).
 
+### Changed
+
+- Restructured the top-level `README.md`: leads with the Pi runtime quick start, adds an MCP-driven natural-language entry path ("Or Just Talk To Your Agent"), shows a structured artifact tree with concrete `playbook.md` and `trace.jsonl` excerpts, surfaces production-trace capture as its own section, merges the surfaces table with command examples, and adds a short FAQ. Removes redundant "How People Use It" / "Choose An Entry Point" / "Repository Layout" sections (the last is already covered in `AGENTS.md`).
+- Bumped subpackage README references from `0.4.4` to `0.4.7` (`autocontext/README.md`, `ts/README.md`) to track the next release line.
+
 ## [0.4.6] - 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <img src="autocontext/assets/banner.svg" alt="autocontext ASCII banner" style="max-width: 100%; height: auto;" />
 </p>
 
-<p align="center"><strong>turn repeated agent work into validated, reusable execution</strong></p>
+<p align="center"><strong>a recursive self-improving harness designed to help your agents (and future iterations of those agents) succeed on any task</strong></p>
 
 <p align="center">
   <a href="https://github.com/greyhaven-ai/autocontext/blob/main/LICENSE"><img src="https://img.shields.io/github/license/greyhaven-ai/autocontext" alt="License"></a>
@@ -15,108 +15,230 @@
 
 <!-- autocontext-readme-hero:end -->
 
-autocontext runs LLM agents through structured scenarios, evaluates their outputs, and accumulates the knowledge that improved results — so repeated runs get better, not just different. Point the harness at a real task in plain language, let it work the problem, and then inspect the traces, reports, artifacts, datasets, playbooks, and optional distilled model it produces.
+Autocontext is a harness. You point it at a goal in plain language. It iterates against real evaluation, keeps what worked, throws out what didn't, and produces a structured trace of the work plus the artifacts, playbooks, datasets, and (optionally) a distilled local model that the next agent inherits. Repeated runs get better, not just different.
 
-## Table of Contents
+## Try It In 30 Seconds
 
-- [What's New](#whats-new)
-- [What actually is autocontext?](#what-actually-is-autocontext)
-- [How People Use It](#how-people-use-it)
-- [How It Works](#how-it-works)
-- [Which Surface Fits Which Job](#which-surface-fits-which-job)
-- [Choose An Entry Point](#choose-an-entry-point)
-- [Scenario Families](#scenario-families)
-- [Core Capabilities](#core-capabilities)
-- [Quick Start From Source](#quick-start-from-source)
-- [Installable Packages](#installable-packages)
-- [Which Package Should You Use?](#which-package-should-you-use)
-- [Common Workflows](#common-workflows)
-- [Repository Layout](#repository-layout)
-- [Where To Look Next](#where-to-look-next)
+The fastest path uses our **Pi runtime**, a local coding agent that handles its own auth. No API key plumbing, no provider config: install Pi, install autocontext, point one at the other.
 
-<!-- autocontext-whats-new:start -->
-## What's New
+```bash
+uv tool install autocontext==0.4.7
 
-- Browser integration now spans Python and TypeScript CDP backends, investigations, queued tasks, and policy-gated evidence.
-- Anthropic SDK instrumentation captures Python and TypeScript production traces, streaming outcomes, and cross-runtime parity.
-- Production trace datasets gained provider/app/env/outcome filters and shared OpenAI/Anthropic E2E coverage.
-- Scenario family designers now share parser logic across TypeScript families, preserving family-specific prompt semantics.
-- Investigation evidence, secondary prompt reducers, migration ledgers, CLI dispatch, and proxy runtime plumbing were hardened.
-<!-- autocontext-whats-new:end -->
+AUTOCONTEXT_AGENT_PROVIDER=pi \
+AUTOCONTEXT_PI_COMMAND=pi \
+uv run autoctx solve \
+  --description "improve customer-support replies for billing disputes" \
+  --gens 3
+```
 
-## What actually is autocontext?
+Pi runs locally as a subprocess and emits live traces back into the harness. For a hosted Pi, set `AUTOCONTEXT_AGENT_PROVIDER=pi-rpc` and `AUTOCONTEXT_PI_RPC_ENDPOINT` instead.
 
-Most agent systems still start every run cold. They do not reliably preserve what worked, separate signal from noise, or turn repeated success into a reusable asset.
+Prefer TypeScript? Same surface, same command:
 
-autocontext is built to close that loop:
+```bash
+bun add -g autoctx@0.4.7
+AUTOCONTEXT_AGENT_PROVIDER=pi bunx autoctx solve \
+  --description "improve customer-support replies for billing disputes" \
+  --gens 5 --json
+```
 
-- run a scenario, task, or mission
-- evaluate what actually happened
-- persist validated knowledge and artifacts
-- replay, analyze, or compare results
-- distill stable behavior into cheaper local runtimes when it is ready
+Already on Anthropic, OpenAI, Gemini, Mistral, Groq, OpenRouter, Azure, Claude CLI, Codex CLI, or MLX? Set `AUTOCONTEXT_AGENT_PROVIDER` and the matching credential env var:
 
-## How People Use It
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=anthropic \
+ANTHROPIC_API_KEY=sk-ant-... \
+uv run autoctx solve --description "..." --gens 3
+```
 
-- hand the harness a real task, let it iterate mostly hands-off, and review the resulting traces, datasets, playbooks, artifacts, and optional distilled model
-- improve agent behavior across repeated runs instead of prompting from scratch every time
-- model and test environments through reusable scenarios
-- run plain-language simulations with sweeps, replay, compare, and export
-- run evidence-driven investigations and analyze the resulting artifacts
-- operate verifier-driven missions for longer-running goals
-- analyze runs, replays, and artifacts to understand regressions and stable wins
-- export knowledge, artifacts, and training data for downstream systems
-- expose the system over CLI, MCP, API, and TUI/operator surfaces for external agents and operator tooling
+See [`.env.example`](.env.example) for every provider's variables. Prefer to clone and run a starter? [`examples/README.md`](examples/README.md) has copy-paste recipes for Python CLI, Claude Code MCP, Python SDK, and TypeScript library usage.
+
+## Or Just Talk To Your Agent
+
+If you already work inside a coding agent (Claude Code, Pi, Cursor, or anything MCP-aware), you don't need to learn the CLI. Wire autocontext in once and your agent gets a natural-language entry point.
+
+**Pi** ships an autocontext skill out of the box. Install the autocontext Pi extension and Pi loads `autocontext_solve`, `autocontext_judge`, `autocontext_improve`, `autocontext_status`, and `autocontext_scenarios` as native tools. Then you just ask:
+
+> "Solve: improve customer-support replies for billing disputes."
+>
+> "Judge this output against this rubric and improve it until it scores 0.85."
+
+**Claude Code** (and any other MCP client) gets the same surface by adding one entry to `.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "autocontext": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/autocontext", "autoctx", "mcp-serve"],
+      "env": { "AUTOCONTEXT_AGENT_PROVIDER": "pi", "AUTOCONTEXT_PI_COMMAND": "pi" }
+    }
+  }
+}
+```
+
+After that, the harness exposes `autocontext_solve_scenario`, `autocontext_judge`, `autocontext_improve`, `autocontext_run_*`, `autocontext_export_skill`, and `autocontext_search_strategies`. The MCP server runs on stdio. The TypeScript package exposes the same tools via `bunx autoctx mcp-serve`.
+
+Full integration guide: [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md).
+
+## What You Get Back
+
+Every run leaves a structured record on disk. Replay it, diff it, export it, feed it back into training.
+
+```
+runs/<run_id>/
+├── trace.jsonl              # every prompt, tool call, and outcome, in order
+├── generations/
+│   ├── gen_1/
+│   │   ├── strategy.json    # what the competitor proposed
+│   │   ├── analysis.md      # what the analyst observed
+│   │   └── score.json       # how it was evaluated
+│   └── gen_2/ ...
+├── report.md                # human-readable summary of the whole run
+└── artifacts/               # files, configs, packages the run produced
+
+knowledge/<scenario>/
+├── playbook.md              # accumulated lessons that carried forward
+├── hints.md                 # competitor hints that survived the curator
+└── tools/                   # any helper tools the architect generated
+```
+
+A `playbook.md` is plain markdown the next run reads as context:
+
+```markdown
+<!-- PLAYBOOK_START -->
+
+## Billing dispute replies
+
+- Always restate the disputed charge in the first sentence; refunds requested without
+  explicit confirmation cause loops.
+- "Pending" charges are not yet billable. Don't promise a refund until status flips
+  to `posted`. Verified gen_4, regressed in gen_7 when omitted.
+- Empathy + specific next step beats empathy alone. Escalation rate dropped from
+0.31 to 0.12 once the second sentence named the next-step owner.
+<!-- PLAYBOOK_END -->
+```
+
+A `trace.jsonl` line is one event:
+
+```json
+{
+  "ts": "2026-04-28T17:42:11Z",
+  "gen": 4,
+  "role": "competitor",
+  "event": "strategy_proposed",
+  "score": 0.78,
+  "tokens_in": 1840,
+  "tokens_out": 612,
+  "strategy_id": "s_4f2a"
+}
+```
+
+Inspect, replay, or compare any of it:
+
+```bash
+uv run autoctx list
+uv run autoctx status <run_id>
+uv run autoctx replay <run_id> --generation 2
+```
 
 ## How It Works
 
-The product model centers on a few stable ideas:
+Inside each run, five roles cooperate:
 
-- `Scenario`: a reusable environment or evaluation context with stable rules and scoring
-- `Task`: a prompt-centric unit of work that can be evaluated directly or embedded elsewhere
-- `Mission`: a long-running goal advanced step by step until a verifier says it is done
-- `Campaign`: a planned grouping of missions under long-term goals; today it has partial TypeScript CLI/API/MCP support but is not yet a Python package surface
-- `Run`: a concrete execution instance of a scenario or task
-- `Verifier`: the runtime check that decides whether a mission, step, or output is acceptable
-- `Knowledge`: validated lessons that should carry forward across runs
-- `Artifact`: persisted outputs such as replays, checkpoints, reports, packages, and exports
-- `Budget` and `Policy`: the constraints and rules that shape how runs and missions are allowed to proceed
+- **competitor** proposes a strategy or artifact for the task
+- **analyst** explains what happened and why
+- **coach** turns that analysis into playbook updates and future hints
+- **architect** proposes tools or harness changes when the loop is stuck
+- **curator** gates what knowledge is allowed to persist across runs
 
-Inside a run, autocontext uses a structured multi-agent loop:
+Strategies are evaluated through scenario execution, staged validation, and gating. Weak changes are rolled back. Successful changes accumulate as reusable knowledge that future runs (and future agents) inherit automatically.
 
-- `competitor` proposes a strategy or artifact for the task
-- `analyst` explains what happened and why
-- `coach` turns that analysis into playbook updates and future hints
-- `architect` proposes tools, harness improvements, or structural changes
-- `curator` gates what knowledge is allowed to persist
+The full vocabulary (Scenario, Task, Mission, Campaign, Run, Verifier, Knowledge, Artifact, Budget, Policy) lives in [docs/concept-model.md](docs/concept-model.md).
 
-Strategies are then evaluated through scenario execution, staged validation, and gating. Weak changes are rolled back. Successful changes accumulate into reusable knowledge.
+## Capture What's Happening In Production
 
-## Which Surface Fits Which Job
+Autocontext can sit alongside your live application and record what your agents do, then turn that into training data. Wrap your existing Anthropic or OpenAI client once:
 
-| Surface       | When to use it                                                                            |
-| ------------- | ----------------------------------------------------------------------------------------- |
-| `run`         | Improve behavior inside a reusable scenario or task across generations                    |
-| `simulate`    | Model a system, explore parameter sweeps, or compare replayable outcomes                  |
-| `investigate` | Evidence-driven diagnosis with hypotheses, confidence scoring, and optional browser context |
-| `analyze`     | Inspect or compare runs, simulations, investigations, or missions after the fact          |
-| `mission`     | Verifier-driven goal advanced step by step with checkpoints and completion criteria       |
-| `campaign`    | Coordinate multiple missions with budget tracking, dependencies, and progress aggregation |
-| `train`       | Distill stable exported data into a cheaper local runtime                                 |
-| `replay`      | Inspect what happened before deciding what knowledge should persist                       |
+```python
+from anthropic import Anthropic
+from autocontext.production_traces import instrument_client
 
-`campaign` now ships as a TypeScript CLI/API/MCP workflow for multi-mission coordination. The Python package still does not expose a campaign control-plane surface.
+client = instrument_client(Anthropic(), app="billing-bot", env="prod")
+# use `client` exactly like before; calls are captured to JSONL with content blocks,
+# cache-aware usage, and Anthropic-native outcome taxonomy.
+```
 
-## Choose An Entry Point
+```ts
+import Anthropic from "@anthropic-ai/sdk";
+import { instrumentClient } from "autoctx/production-traces";
 
-- Want the full Python control plane for scenario execution, training, API serving, and operator workflows? Start with `autocontext/`.
-- Want the Node/TypeScript package for simulations, investigations, analysis, mission control, operator tooling, and external integrations? Start with `ts/`.
-- Want to wire another agent into autocontext? Start with the CLI-first guide in `autocontext/docs/agent-integration.md`.
-- Want to contribute or point a coding agent at the repo? Read `CONTRIBUTING.md` and `AGENTS.md`.
+const client = instrumentClient(new Anthropic(), { app: "billing-bot", env: "prod" });
+```
+
+Then build scoped datasets from the captured traces:
+
+```bash
+uv run autoctx build-dataset \
+  --app billing-bot --provider anthropic \
+  --env prod --outcome success \
+  --output training/billing.jsonl
+```
+
+And distill them into a smaller local model with MLX (Apple Silicon) or CUDA (Linux GPUs):
+
+```bash
+uv run autoctx train --scenario support_triage --data training/billing.jsonl --time-budget 300
+```
+
+<!-- autocontext-whats-new:start -->
+
+## What's New in 0.4.7
+
+- **Anthropic SDK instrumentation** in Python and TypeScript: wrap any existing Anthropic client with `instrument_client` / `instrumentClient` to capture streaming and non-streaming production traces.
+- **TypeScript `autoctx solve` CLI** brings one-command scenario generation and execution to full parity with Python.
+- **`autoctx build-dataset` filters** (`--provider`, `--app`, `--env`, `--outcome`) turn captured production traces into scoped training datasets.
+- **CUDA training backend** alongside MLX, so distillation is no longer Apple Silicon only.
+- **Semantic prompt compaction** with tail-preserving reducers for longer sessions.
+- **Hierarchical investigation evidence** with artifact drill-down for richer diagnosis traces.
+<!-- autocontext-whats-new:end -->
+
+## Choose Your Package
+
+| If you want to...                                               | Start here                                                                     |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Run the full multi-generation control plane (Python)            | [autocontext/README.md](autocontext/README.md)                                 |
+| Run from Node, or operate missions, simulations, investigations | [ts/README.md](ts/README.md)                                                   |
+| Wire an external coding agent into autocontext over MCP         | [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md) |
+| Grab copy-paste integration snippets                            | [examples/README.md](examples/README.md)                                       |
+
+```bash
+# Python: library or CLI tool
+uv pip install autocontext==0.4.7
+uv tool install autocontext==0.4.7
+
+# TypeScript
+bun add -g autoctx@0.4.7
+```
+
+> The PyPI package is `autocontext`. The CLI entrypoint is `autoctx`. The npm package is `autoctx` (note: an unrelated package on npm uses the name `autocontext`; that is not this project).
+
+## Surfaces
+
+| Surface       | Command                                            | When to use it                                                                         |
+| ------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `solve`       | `autoctx solve --description "..." --gens 3`       | Hand the harness a goal in plain language; it generates the scenario and runs the loop |
+| `run`         | `autoctx run --scenario <name> --gens 3`           | Improve behavior inside a saved scenario across generations                            |
+| `simulate`    | `autoctx simulate -d "..."`                        | Model a system, sweep parameters, replay, compare                                      |
+| `investigate` | `autoctx investigate -d "..."`                     | Evidence-driven diagnosis with hypotheses and confidence scoring                       |
+| `analyze`     | `autoctx analyze --id <id> --type <kind>`          | Inspect or compare runs, simulations, investigations, or missions after the fact       |
+| `mission`     | `autoctx mission create --name "..." --goal "..."` | Verifier-driven goal advanced step by step until done                                  |
+| `campaign`    | `bunx autoctx campaign ...` (TypeScript)           | Coordinate multiple missions with budgets, dependencies, progress aggregation          |
+| `train`       | `autoctx train --scenario <name> --data <jsonl>`   | Distill stable exported data into a cheaper local runtime                              |
+| `replay`      | `autoctx replay <run_id> --generation N`           | Inspect what happened before deciding what knowledge should persist                    |
 
 ## Scenario Families
 
-All 11 families are executable in both Python and TypeScript. TypeScript uses V8 isolate codegen for secure execution; Python uses subprocess-based executors.
+All 11 families execute in both Python and TypeScript. TypeScript uses V8 isolate codegen; Python uses subprocess executors.
 
 | Family             | Evaluation              | What it tests                                                           |
 | ------------------ | ----------------------- | ----------------------------------------------------------------------- |
@@ -132,184 +254,45 @@ All 11 families are executable in both Python and TypeScript. TypeScript uses V8
 | `operator_loop`    | Judgment evaluation     | Escalation and clarification judgment in operator-in-the-loop workflows |
 | `coordination`     | Coordination evaluation | Multi-agent partial context, handoff, merge, and duplication detection  |
 
-## Core Capabilities
+## Providers, Runtimes, Executors
 
-- Persistent playbooks, hints, tools, reports, and progress snapshots across runs
-- Staged validation, harness synthesis, and harness-aware execution
-- Replays, checkpoints, reports, and exported artifacts for inspection and reuse
-- Frontier-to-local distillation with MLX on Apple Silicon
-- Notification hooks via Slack, HTTP webhooks, stdout, and composite routing (`AUTOCONTEXT_NOTIFY_*`)
-- OpenClaw-facing APIs and agent integration surfaces
-- CLI, API server, MCP, and TypeScript/TUI surfaces for operators and external agents
+**LLM providers**: Anthropic (with `instrument_client` capture), OpenAI-compatible (vLLM, Ollama, Hermes), Gemini, Mistral, Groq, OpenRouter, Azure OpenAI, MLX (Apple Silicon), CUDA (Linux GPUs), Pi (CLI and RPC).
 
-### Providers
+**Agent runtimes**: Claude CLI, Codex CLI, Hermes CLI, Direct API, Pi variants.
 
-Runtime routing across multiple LLM backends:
+**Executors**: Local subprocess, SSH remote, Monty (`pydantic-monty` sandbox), PrimeIntellect remote sandbox.
 
-- **Anthropic** — native Anthropic API and Agent SDK
-- **OpenAI-compatible** — any OpenAI-compatible endpoint (vLLM, Ollama, Hermes)
-- **Gemini, Mistral, Groq, OpenRouter, Azure OpenAI** — env-driven config in TypeScript
-- **MLX** — Apple Silicon local inference
-- **Pi** — CLI and RPC-based Pi agent runtimes
-- **Deterministic** — reproducible testing without API keys
+A deterministic offline provider exists for the test suite. Configuration matrix: [`.env.example`](.env.example) and [docs/concept-model.md](docs/concept-model.md).
 
-### Runtimes
+## FAQ
 
-Agent runtimes control how agents execute during runs:
+**Is autocontext a benchmark?**
+No. It's a harness for improving real agent behavior on real work. Benchmarks (the 11 scenario families) are one of many surfaces; you can also point it at production tasks, missions, or simulations.
 
-- **Claude CLI** and **Codex CLI** — subprocess-based agent execution
-- **Hermes CLI** — Hermes gateway runtime
-- **Direct API** — in-process API calls
-- **Pi CLI, Pi RPC, Pi Artifacts** — Pi agent runtime variants
+**How is this different from DSPy, Inspect, TextGrad, or a prompt optimizer?**
+Those tools optimize prompts. Autocontext takes a goal in plain language, generates the scenario, runs a multi-role loop with verifier-driven gating, and produces transferable artifacts (playbooks, datasets, distilled models) that the next run inherits. Prompt optimization is a special case.
 
-### Executors
+**Do I need API keys?**
+No. The Pi runtime runs locally and handles its own auth. Anthropic, OpenAI, Gemini, Mistral, Groq, OpenRouter, Azure, MLX, and Claude/Codex CLI are all opt-in via env vars.
 
-Strategy and code execution backends:
+**Where does the knowledge live?**
+On your filesystem. Runs go to `runs/`, accumulated knowledge to `knowledge/`. Indexed metadata is in SQLite. Everything is inspectable, diffable, and portable.
 
-- **Local** — subprocess execution with timeout and memory limits
-- **SSH** — remote execution over SSH
-- **Monty** — sandboxed execution via pydantic-monty (`AUTOCONTEXT_EXECUTOR_MODE=monty`)
-- **PrimeIntellect** — remote sandbox via PrimeIntellect SDK
-
-## Quick Start From Source
-
-The Python application lives in `autocontext/`, and most `uv`, `pytest`, `ruff`, and `mypy` commands should be run from there.
-
-```bash
-cd autocontext
-uv venv
-source .venv/bin/activate
-uv sync --group dev
-
-AUTOCONTEXT_AGENT_PROVIDER=deterministic uv run autoctx solve \
-  --description "improve customer-support replies for billing disputes" \
-  --gens 3
-```
-
-That hands the harness a real task, materializes the working scenario, runs the loop, and writes traces and artifacts under `runs/` and `knowledge/`. It also works without external API keys.
-
-Run with Anthropic:
-
-```bash
-cd autocontext
-AUTOCONTEXT_AGENT_PROVIDER=anthropic \
-ANTHROPIC_API_KEY=your-key \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
-```
-
-`ANTHROPIC_API_KEY` is the preferred Anthropic credential env var. `AUTOCONTEXT_ANTHROPIC_API_KEY` remains supported as a compatibility alias.
-
-Run with Claude CLI:
-
-```bash
-cd autocontext
-AUTOCONTEXT_AGENT_PROVIDER=claude-cli \
-AUTOCONTEXT_CLAUDE_MODEL=sonnet \
-AUTOCONTEXT_CLAUDE_TIMEOUT=300 \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
-```
-
-For longer live prompts, `autoctx solve`, `autoctx judge`, and `autoctx improve` all accept `--timeout <seconds>`. `autoctx solve` also accepts `--generation-time-budget <seconds>` to cap per-generation solve runtime. You can still use provider env vars such as `AUTOCONTEXT_CLAUDE_TIMEOUT` or `AUTOCONTEXT_PI_TIMEOUT`.
-
-Run with Codex CLI:
-
-```bash
-cd autocontext
-AUTOCONTEXT_AGENT_PROVIDER=codex \
-AUTOCONTEXT_CODEX_MODEL=o4-mini \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
-```
-
-Start the API server:
-
-```bash
-cd autocontext
-uv run autoctx serve --host 127.0.0.1 --port 8000
-```
-
-Then inspect `http://127.0.0.1:8000/` for the API index, or use `npx autoctx tui` for the interactive terminal UI.
-
-Use the repo-level `.env.example` as the reference for available `AUTOCONTEXT_*` settings and supported provider-native credential aliases such as `ANTHROPIC_API_KEY`.
-
-## Installable Packages
-
-The repo publishes two installable packages with different scopes:
-
-- Python package: `pip install autocontext`
-- TypeScript package: `npm install autoctx`
-- Current release line: `autocontext==0.4.6` and `autoctx@0.4.6`
-
-Important:
-
-- The Python package on PyPI is now `autocontext`.
-- The CLI entrypoint remains `autoctx`.
-- The npm package for this project is still `autoctx`.
-- `autocontext` on npm is a different package.
-
-The Python package exposes the full `autoctx` control-plane CLI for scenario execution, API serving, exports, training, and operator workflows. The TypeScript package exposes the `autoctx` CLI and library surface for simulations, investigations, analysis, mission control, MCP serving, and Node integrations.
-
-Both packages share an optional, disabled-by-default browser exploration contract for thin browser control without bundling a heavyweight browser framework. The TypeScript CLI can attach a policy-gated browser snapshot to investigations and queued tasks with `--browser-url`. See [docs/browser-exploration-contract.md](docs/browser-exploration-contract.md).
-
-## Which Package Should You Use?
-
-| If you want to...                                                | Start here                                                                     | Why                                                                                                             |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| Run the full multi-generation control plane                      | [autocontext/README.md](autocontext/README.md)                                 | Python has the API server, training loop, scenario scaffolding, export/import, and full CLI surface.            |
-| Run simulations, investigations, analysis, or missions from Node | [ts/README.md](ts/README.md)                                                   | The TypeScript package is focused on operator-facing workflows, integrations, mission control, and MCP serving. |
-| Embed autocontext in a Node app or operator workflow             | [ts/README.md](ts/README.md)                                                   | The TypeScript package also exposes library surfaces for evaluation, artifacts, publishing, and integrations.   |
-| Point an external agent at autocontext                           | [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md) | It documents the CLI-first contract, JSON output, MCP usage, and SDK options.                                   |
-| Grab copy-paste integration snippets                             | [examples/README.md](examples/README.md)                                       | The examples cover Python CLI, Claude Code MCP, Python SDK, and TypeScript library usage.                       |
-| Catch up on recent repo evolution                                | [CHANGELOG.md](CHANGELOG.md)                                                   | It summarizes recent public releases and notable changes.                                                       |
-
-## Common Workflows
-
-- Hand the harness a task in plain language: `uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3`
-- Run and improve a saved scenario: `uv run autoctx run --scenario support_triage --gens 3`
-- Inspect or replay outputs: `uv run autoctx list`, `uv run autoctx status <run_id>`
-- Run an investigation from Python: `uv run autoctx investigate -d "why did conversion drop after Tuesday's release"`
-- Add a policy-checked browser snapshot to an investigation: `uv run autoctx investigate -d "checkout is failing in prod" --browser-url https://status.example.com`
-- Enqueue an ad hoc queued task from Python: `uv run autoctx queue add --task-prompt "Write a 1-line fact about primes" --rubric "correct" --threshold 0.8 --rounds 2`
-- Enqueue a browser-enriched queued task when browser exploration is configured: `uv run autoctx queue --spec support_triage --browser-url https://status.example.com`
-- Override the simulation provider per call: `uv run autoctx simulate -d "simulate deploying a web service with rollback" --provider claude-cli`
-- Scaffold a custom scenario: `uv run autoctx new-scenario --template prompt-optimization --name my-task`
-- Export training data: `uv run autoctx export-training-data --scenario support_triage --all-runs --output training/support_triage.jsonl`
-- Train a local model: `uv run autoctx train --scenario support_triage --data training/support_triage.jsonl --time-budget 300`
-- Start operator surfaces: `uv run autoctx serve --host 127.0.0.1 --port 8000`, `uv run autoctx mcp-serve`
-- Wait on a monitor condition: `uv run autoctx wait <condition_id> --json`
-
-Representative TypeScript operator workflows:
-
-- Run a simulation: `npx autoctx simulate -d "simulate deploying a web service with rollback"`
-- Analyze an artifact: `npx autoctx analyze --id deploy_sim --type simulation`
-- Operate a mission: `npx autoctx mission create --name "Ship login" --goal "Implement OAuth"`
-
-`operator-in-the-loop` is a fully runnable scenario family in both Python and TypeScript. It tests escalation and clarification judgment with real escalation/clarification hooks and behavioral-contract signals across multi-run, sweep, and replay flows.
-
-MLX training is host-only on Apple Silicon macOS. If you want a sandboxed OpenClaw agent to trigger training, use the file-based host watcher flow documented in [autocontext/docs/mlx-training.md](autocontext/docs/mlx-training.md).
-
-## Repository Layout
-
-- `autocontext/`: Python package, CLI, API server, and training loop
-- `ts/`: published TypeScript package, CLI, and MCP-compatible tooling
-- `docs/`: docs landing page and maintainer checklists
-- `examples/`: copy-paste integration snippets for package users and external agents
-- `infra/`: Docker, Fly.io, and bootstrap scripts
-- `protocol/`: shared protocol artifacts
-- `scripts/`: repo maintenance and generation scripts
+**Can my coding agent drive autocontext directly?**
+Yes. Wire `autoctx mcp-serve` (or `bunx autoctx mcp-serve`) into Claude Code, Cursor, or Pi as an MCP server, and the agent gets natural-language access to `solve`, `judge`, `improve`, `status`, `export_skill`, and the rest. See [Or Just Talk To Your Agent](#or-just-talk-to-your-agent).
 
 ## Where To Look Next
 
 - Canonical vocabulary and object model: [docs/concept-model.md](docs/concept-model.md)
 - Docs overview: [docs/README.md](docs/README.md)
-- Analytics and adoption: [docs/analytics.md](docs/analytics.md)
 - Python package guide: [autocontext/README.md](autocontext/README.md)
 - TypeScript package guide: [ts/README.md](ts/README.md)
 - Copy-paste examples: [examples/README.md](examples/README.md)
 - External agent integration: [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md)
 - Recent changes: [CHANGELOG.md](CHANGELOG.md)
 - Contributor setup: [CONTRIBUTING.md](CONTRIBUTING.md)
-- Repo agent guide: [AGENTS.md](AGENTS.md)
-- MLX host training and OpenClaw bridge: [autocontext/docs/mlx-training.md](autocontext/docs/mlx-training.md)
+- Repo layout for coding agents: [AGENTS.md](AGENTS.md)
+- Sandboxed agents that need to trigger MLX training on the host: [autocontext/docs/mlx-training.md](autocontext/docs/mlx-training.md)
 - Sandbox and executor notes: [autocontext/docs/sandbox.md](autocontext/docs/sandbox.md)
 - License: [LICENSE](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See [`.env.example`](.env.example) for every provider's variables. Prefer to clo
 
 If you already work inside a coding agent (Claude Code, Pi, Cursor, or anything MCP-aware), you don't need to learn the CLI. Wire autocontext in once and your agent gets a natural-language entry point.
 
-**Pi** ships an autocontext skill out of the box. Install the autocontext Pi extension and Pi loads `autocontext_solve`, `autocontext_judge`, `autocontext_improve`, `autocontext_status`, and `autocontext_scenarios` as native tools. Then you just ask:
+**Pi** ships an autocontext skill out of the box. Install the autocontext Pi extension and Pi loads natural-language wrappers over live tools such as `autocontext_solve_scenario`, `autocontext_evaluate_output`, `autocontext_run_improvement_loop`, `autocontext_run_status`, and `autocontext_list_scenarios`. Then you just ask:
 
 > "Solve: improve customer-support replies for billing disputes."
 >
@@ -76,7 +76,7 @@ If you already work inside a coding agent (Claude Code, Pi, Cursor, or anything 
 }
 ```
 
-After that, the harness exposes `autocontext_solve_scenario`, `autocontext_judge`, `autocontext_improve`, `autocontext_run_*`, `autocontext_export_skill`, and `autocontext_search_strategies`. The MCP server runs on stdio. The TypeScript package exposes the same tools via `bunx autoctx mcp-serve`.
+After that, Python MCP exposes prefixed tools such as `autocontext_solve_scenario`, `autocontext_evaluate_output`, `autocontext_run_improvement_loop`, `autocontext_run_status`, `autocontext_list_scenarios`, `autocontext_export_skill`, and `autocontext_search_strategies`. The MCP server runs on stdio. The TypeScript package exposes the same capabilities with its documented tool names via `bunx autoctx mcp-serve`.
 
 Full integration guide: [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md).
 
@@ -191,7 +191,6 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 ```
 
 <!-- autocontext-whats-new:start -->
-
 ## What's New in 0.4.7
 
 - **Anthropic SDK instrumentation** in Python and TypeScript: wrap any existing Anthropic client with `instrument_client` / `instrumentClient` to capture streaming and non-streaming production traces.

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -10,7 +10,7 @@ The intended use is to hand the harness a real task in plain language, let it so
 pip install autocontext
 ```
 
-The current PyPI release line is `autocontext==0.4.6`.
+The current PyPI release line is `autocontext==0.4.7`.
 The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
 
 ## Working Directory
@@ -105,7 +105,7 @@ uv run autoctx solve --description "improve customer-support replies for billing
 
 `autoctx simulate` now follows the effective architect-role runtime surface, so `AUTOCONTEXT_ARCHITECT_PROVIDER`, other role-routing overrides, and per-call `--provider <name>` overrides all apply to live simulation generation.
 
-`autoctx investigate` now ships as a first-class Python CLI surface as well. It uses the architect runtime for investigation-spec synthesis and the analyst runtime for hypothesis generation, so role-routing overrides apply there too. When browser exploration is enabled, `--browser-url <url>` captures a policy-checked snapshot and folds that evidence into the investigation prompts and report artifacts.
+`autoctx investigate` now ships as a first-class Python CLI surface as well. It uses the architect runtime for investigation-spec synthesis and the analyst runtime for hypothesis generation, so role-routing overrides apply there too.
 
 Run with Pi RPC (local Pi subprocess using `pi --mode rpc` JSONL):
 
@@ -153,9 +153,7 @@ uv run autoctx solve --description "improve customer-support replies for billing
 uv run autoctx simulate --description "simulate deploying a web service with rollback"
 uv run autoctx simulate --description "simulate deploying a web service with rollback" --provider claude-cli
 uv run autoctx investigate --description "why did conversion drop after Tuesday's release"
-uv run autoctx investigate --description "checkout is failing in prod" --browser-url https://status.example.com
 uv run autoctx queue add --task-prompt "Write a 1-line fact about primes" --rubric "correct" --threshold 0.8 --rounds 2
-uv run autoctx queue --spec support_triage --browser-url https://status.example.com
 uv run autoctx simulate --replay deploy_sim --variables threshold=0.9
 uv run autoctx list
 uv run autoctx status <run_id>
@@ -207,25 +205,10 @@ uv sync --group dev --extra mlx
 uv run autoctx train \
   --scenario support_triage \
   --data training/support_triage.jsonl \
-  --backend mlx \
   --time-budget 300
 ```
 
 MLX training is host-only. It must run on an Apple Silicon macOS machine with Metal access. It will not run correctly inside a Docker sandbox on macOS.
-
-CUDA training uses the same autoresearch loop with a PyTorch model branch:
-
-```bash
-uv sync --group dev
-uv pip install torch rustbpe tiktoken
-uv run autoctx train \
-  --scenario support_triage \
-  --data training/support_triage.jsonl \
-  --backend cuda \
-  --time-budget 300
-```
-
-CUDA requires a CUDA-enabled PyTorch install where `torch.cuda.is_available()` is true. The CUDA bundle writes `config.json`, `tokenizer.json`, and `model.pt` under the selected checkpoint directory. Until a Torch provider loader lands, CUDA checkpoints are published as checkpoint artifacts only and are not auto-routed as live provider models.
 
 If you only want to inspect generated training data first, export without training and open the JSONL directly.
 
@@ -247,14 +230,6 @@ Common settings:
 - `AUTOCONTEXT_RLM_ENABLED`
 - `AUTOCONTEXT_HARNESS_PREFLIGHT_ENABLED`
 - `AUTOCONTEXT_STAGED_VALIDATION_ENABLED`
-- `AUTOCONTEXT_BROWSER_ENABLED`
-- `AUTOCONTEXT_BROWSER_ALLOWED_DOMAINS`
-- `AUTOCONTEXT_BROWSER_PROFILE_MODE`
-- `AUTOCONTEXT_BROWSER_ALLOW_AUTH`
-- `AUTOCONTEXT_BROWSER_ALLOW_DOWNLOADS` and `AUTOCONTEXT_BROWSER_DOWNLOADS_ROOT`
-
-Browser exploration defaults to a secure disabled posture and uses the shared contract described in [../docs/browser-exploration-contract.md](../docs/browser-exploration-contract.md).
-The Python package includes a thin Chrome CDP backend that attaches to an existing debugger endpoint, enforces the browser allowlist, and stores browser evidence under run-local roots.
 
 See the repo-level [.env.example](../.env.example) for a working starting point.
 
@@ -369,7 +344,41 @@ sink.close()
 Emitted trace line (pretty-printed for readability):
 
 ```jsonl
-{"schemaVersion":"1.0","traceId":"...","sessionContext":{"userId":"u_123"},"request":{"model":"gpt-4o","messages":[{"role":"user","content":"Hello!"}]},"response":{"id":"...","choices":[{"message":{"role":"assistant","content":"Hi! How can I help?"},"finish_reason":"stop"}],"usage":{"prompt_tokens":9,"completion_tokens":7,"total_tokens":16}},"durationMs":342,"errorReason":null}
+{
+  "schemaVersion": "1.0",
+  "traceId": "...",
+  "sessionContext": {
+    "userId": "u_123"
+  },
+  "request": {
+    "model": "gpt-4o",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello!"
+      }
+    ]
+  },
+  "response": {
+    "id": "...",
+    "choices": [
+      {
+        "message": {
+          "role": "assistant",
+          "content": "Hi! How can I help?"
+        },
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 9,
+      "completion_tokens": 7,
+      "total_tokens": 16
+    }
+  },
+  "durationMs": 342,
+  "errorReason": null
+}
 ```
 
 For the TypeScript equivalent, see `ts/src/integrations/openai/STABILITY.md`.
@@ -450,7 +459,38 @@ sink.close()
 Emitted trace line (pretty-printed for readability):
 
 ```jsonl
-{"schemaVersion":"1.0","traceId":"...","sessionContext":{"userId":"u_123"},"request":{"model":"claude-opus-4-7-20251101","messages":[{"role":"user","content":"Hello!"}]},"response":{"id":"...","content":[{"type":"text","text":"Hi! How can I help?"}],"stop_reason":"end_turn","usage":{"input_tokens":9,"output_tokens":7}},"durationMs":342,"errorReason":null}
+{
+  "schemaVersion": "1.0",
+  "traceId": "...",
+  "sessionContext": {
+    "userId": "u_123"
+  },
+  "request": {
+    "model": "claude-opus-4-7-20251101",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello!"
+      }
+    ]
+  },
+  "response": {
+    "id": "...",
+    "content": [
+      {
+        "type": "text",
+        "text": "Hi! How can I help?"
+      }
+    ],
+    "stop_reason": "end_turn",
+    "usage": {
+      "input_tokens": 9,
+      "output_tokens": 7
+    }
+  },
+  "durationMs": 342,
+  "errorReason": null
+}
 ```
 
 For the TypeScript equivalent, see `ts/src/integrations/anthropic/STABILITY.md`.

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -105,7 +105,7 @@ uv run autoctx solve --description "improve customer-support replies for billing
 
 `autoctx simulate` now follows the effective architect-role runtime surface, so `AUTOCONTEXT_ARCHITECT_PROVIDER`, other role-routing overrides, and per-call `--provider <name>` overrides all apply to live simulation generation.
 
-`autoctx investigate` now ships as a first-class Python CLI surface as well. It uses the architect runtime for investigation-spec synthesis and the analyst runtime for hypothesis generation, so role-routing overrides apply there too.
+`autoctx investigate` now ships as a first-class Python CLI surface as well. It uses the architect runtime for investigation-spec synthesis and the analyst runtime for hypothesis generation, so role-routing overrides apply there too. When browser exploration is enabled, `--browser-url <url>` captures a policy-checked snapshot and folds that evidence into the investigation prompts and report artifacts.
 
 Run with Pi RPC (local Pi subprocess using `pi --mode rpc` JSONL):
 
@@ -153,7 +153,9 @@ uv run autoctx solve --description "improve customer-support replies for billing
 uv run autoctx simulate --description "simulate deploying a web service with rollback"
 uv run autoctx simulate --description "simulate deploying a web service with rollback" --provider claude-cli
 uv run autoctx investigate --description "why did conversion drop after Tuesday's release"
+uv run autoctx investigate --description "checkout is failing in prod" --browser-url https://status.example.com
 uv run autoctx queue add --task-prompt "Write a 1-line fact about primes" --rubric "correct" --threshold 0.8 --rounds 2
+uv run autoctx queue --spec support_triage --browser-url https://status.example.com
 uv run autoctx simulate --replay deploy_sim --variables threshold=0.9
 uv run autoctx list
 uv run autoctx status <run_id>
@@ -230,6 +232,14 @@ Common settings:
 - `AUTOCONTEXT_RLM_ENABLED`
 - `AUTOCONTEXT_HARNESS_PREFLIGHT_ENABLED`
 - `AUTOCONTEXT_STAGED_VALIDATION_ENABLED`
+- `AUTOCONTEXT_BROWSER_ENABLED`
+- `AUTOCONTEXT_BROWSER_ALLOWED_DOMAINS`
+- `AUTOCONTEXT_BROWSER_PROFILE_MODE`
+- `AUTOCONTEXT_BROWSER_ALLOW_AUTH`
+- `AUTOCONTEXT_BROWSER_ALLOW_DOWNLOADS` and `AUTOCONTEXT_BROWSER_DOWNLOADS_ROOT`
+
+Browser exploration defaults to a secure disabled posture and uses the shared contract described in [../docs/browser-exploration-contract.md](../docs/browser-exploration-contract.md).
+The Python package includes a thin Chrome CDP backend that attaches to an existing debugger endpoint, enforces the browser allowlist, and stores browser evidence under run-local roots.
 
 See the repo-level [.env.example](../.env.example) for a working starting point.
 

--- a/autocontext/assets/whats_new.txt
+++ b/autocontext/assets/whats_new.txt
@@ -1,5 +1,6 @@
-Browser integration now spans Python and TypeScript CDP backends, investigations, queued tasks, and policy-gated evidence.
-Anthropic SDK instrumentation captures Python and TypeScript production traces, streaming outcomes, and cross-runtime parity.
-Production trace datasets gained provider/app/env/outcome filters and shared OpenAI/Anthropic E2E coverage.
-Scenario family designers now share parser logic across TypeScript families, preserving family-specific prompt semantics.
-Investigation evidence, secondary prompt reducers, migration ledgers, CLI dispatch, and proxy runtime plumbing were hardened.
+**Anthropic SDK instrumentation** in Python and TypeScript: wrap any existing Anthropic client with `instrument_client` / `instrumentClient` to capture streaming and non-streaming production traces.
+**TypeScript `autoctx solve` CLI** brings one-command scenario generation and execution to full parity with Python.
+**`autoctx build-dataset` filters** (`--provider`, `--app`, `--env`, `--outcome`) turn captured production traces into scoped training datasets.
+**CUDA training backend** alongside MLX, so distillation is no longer Apple Silicon only.
+**Semantic prompt compaction** with tail-preserving reducers for longer sessions.
+**Hierarchical investigation evidence** with artifact drill-down for richer diagnosis traces.

--- a/autocontext/src/autocontext/banner.py
+++ b/autocontext/src/autocontext/banner.py
@@ -14,11 +14,15 @@ from html import escape as html_escape
 from pathlib import Path
 from xml.sax.saxutils import escape as xml_escape
 
-TAGLINE = "turn repeated agent work into validated, reusable execution"
+TAGLINE = (
+    "a recursive self-improving harness designed to help your agents "
+    "(and future iterations of those agents) succeed on any task"
+)
 SYNC_BLOCK_START = "<!-- autocontext-readme-hero:start -->"
 SYNC_BLOCK_END = "<!-- autocontext-readme-hero:end -->"
 WHATS_NEW_BLOCK_START = "<!-- autocontext-whats-new:start -->"
 WHATS_NEW_BLOCK_END = "<!-- autocontext-whats-new:end -->"
+README_WHATS_NEW_HEADING = "What's New in 0.4.7"
 README_BADGES = (
     (
         "https://github.com/greyhaven-ai/autocontext/blob/main/LICENSE",
@@ -184,7 +188,7 @@ def render_readme_whats_new_block() -> str:
     whats_new = "\n".join(f"- {item}" for item in load_whats_new())
     return (
         f"{WHATS_NEW_BLOCK_START}\n"
-        "## What's New\n\n"
+        f"## {README_WHATS_NEW_HEADING}\n\n"
         f"{whats_new}\n"
         f"{WHATS_NEW_BLOCK_END}"
     )

--- a/ts/README.md
+++ b/ts/README.md
@@ -155,6 +155,7 @@ autoctx mcp-serve                     # MCP server on stdio
 autoctx simulate -d "simulate deploying a web service with rollback"
 autoctx simulate -d "simulate escalation thresholds" --sweep max_escalations=1:5:1
 autoctx investigate -d "why did conversion drop after Tuesday's release"
+autoctx investigate -d "checkout is failing" --browser-url https://status.example.com
 autoctx analyze --id deploy_sim --type simulation
 autoctx analyze --left sim_a --right sim_b --type simulation
 autoctx mission create --name "Ship login" --goal "Implement OAuth"
@@ -173,7 +174,7 @@ autoctx improve --scenario my_saved_task [-o <output>]
 autoctx repl --scenario my_saved_task
 
 # Task queue
-autoctx queue -s <spec> [--priority N]
+autoctx queue -s <spec> [--priority N] [--browser-url https://status.example.com]
 autoctx status
 ```
 
@@ -356,6 +357,14 @@ The TypeScript package includes the current 0.4.x operator-facing surfaces:
 `campaign` now ships as a first-class TypeScript CLI/API/MCP workflow for multi-mission coordination.
 
 For end-to-end local MLX/CUDA training, the Python package is still the canonical out-of-the-box runtime.
+
+## Browser Exploration Contract
+
+The TypeScript package exposes the shared browser exploration contract and policy helpers from the package root. Browser exploration is disabled by default and configured through `AUTOCONTEXT_BROWSER_*` settings such as `AUTOCONTEXT_BROWSER_ENABLED`, `AUTOCONTEXT_BROWSER_ALLOWED_DOMAINS`, and `AUTOCONTEXT_BROWSER_PROFILE_MODE`.
+
+Use `resolveBrowserSessionConfig(...)`, `evaluateBrowserActionPolicy(...)`, and the `validateBrowser*` helpers when integrating a browser backend or agent harness.
+
+When browser exploration is enabled, the TS CLI can capture a policy-gated Chrome DevTools Protocol snapshot and attach it as evidence for `autoctx investigate --browser-url <url>`. Queued agent tasks can also store `--browser-url`; the runner resolves it through an injected browser-context service so enterprise deployments can keep browser access disabled by default, domain-scoped, and audit-artifact backed.
 
 ## Python-Only Commands
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -26,7 +26,7 @@ Need the canonical product/runtime vocabulary first? Start with [docs/concept-mo
 npm install autoctx
 ```
 
-The current npm release line is `autoctx@0.4.6`.
+The current npm release line is `autoctx@0.4.7`.
 Important: use `autoctx`, not `autocontext`.
 `autocontext` on npm is a different package and not this project.
 
@@ -64,9 +64,7 @@ const userIdHash = hashUserId(session.user.id, salt);
 const trace = buildTrace({
   provider: "openai",
   model: "gpt-4o-mini",
-  messages: [
-    { role: "user", content: prompt, timestamp: new Date().toISOString() },
-  ],
+  messages: [{ role: "user", content: prompt, timestamp: new Date().toISOString() }],
   timing: {
     startedAt: "2026-04-17T12:00:00.000Z",
     endedAt: "2026-04-17T12:00:01.250Z",
@@ -82,7 +80,7 @@ writeJsonl(trace);
 
 const batch = new TraceBatch();
 for (const event of stream) batch.add(buildTrace(/* ... */));
-batch.flush();  // writes accumulated traces as one file
+batch.flush(); // writes accumulated traces as one file
 ```
 
 Both ESM and CommonJS consumers are supported via the `"exports"` map:
@@ -138,7 +136,6 @@ autoctx providers
 autoctx models
 
 # Scenario execution
-autoctx solve --description "improve customer-support replies" --family agent_task --gens 3 --output package.json --json
 autoctx run --scenario support_triage --gens 3 --json
 autoctx list --json
 autoctx replay --run-id <id> --generation 1
@@ -158,7 +155,6 @@ autoctx mcp-serve                     # MCP server on stdio
 autoctx simulate -d "simulate deploying a web service with rollback"
 autoctx simulate -d "simulate escalation thresholds" --sweep max_escalations=1:5:1
 autoctx investigate -d "why did conversion drop after Tuesday's release"
-autoctx investigate -d "checkout is failing" --browser-url https://status.example.com
 autoctx analyze --id deploy_sim --type simulation
 autoctx analyze --left sim_a --right sim_b --type simulation
 autoctx mission create --name "Ship login" --goal "Implement OAuth"
@@ -177,7 +173,7 @@ autoctx improve --scenario my_saved_task [-o <output>]
 autoctx repl --scenario my_saved_task
 
 # Task queue
-autoctx queue -s <spec> [--priority N] [--browser-url https://status.example.com]
+autoctx queue -s <spec> [--priority N]
 autoctx status
 ```
 
@@ -242,20 +238,20 @@ Supported providers: `anthropic`, `openai`, `openai-compatible`, `gemini`, `mist
 
 Key environment variables:
 
-| Variable | Purpose |
-|----------|---------|
-| `AUTOCONTEXT_AGENT_PROVIDER` | Agent provider selection |
-| `AUTOCONTEXT_AGENT_API_KEY` | Global API key override (or use provider-specific env vars) |
-| `AUTOCONTEXT_AGENT_BASE_URL` | Global base URL override for compatible providers |
-| `AUTOCONTEXT_AGENT_DEFAULT_MODEL` | Override default model |
-| `AUTOCONTEXT_COMPETITOR_API_KEY` / `AUTOCONTEXT_COMPETITOR_BASE_URL` | Optional competitor-specific credential/endpoint override |
-| `AUTOCONTEXT_ANALYST_API_KEY` / `AUTOCONTEXT_ANALYST_BASE_URL` | Optional analyst-specific credential/endpoint override |
-| `AUTOCONTEXT_COACH_API_KEY` / `AUTOCONTEXT_COACH_BASE_URL` | Optional coach-specific credential/endpoint override |
-| `AUTOCONTEXT_ARCHITECT_API_KEY` / `AUTOCONTEXT_ARCHITECT_BASE_URL` | Optional architect-specific credential/endpoint override |
-| `AUTOCONTEXT_CLAUDE_MODEL` | Claude CLI model alias override |
-| `AUTOCONTEXT_CODEX_MODEL` | Codex CLI model override |
-| `AUTOCONTEXT_CONFIG_DIR` | Override where `login` / `whoami` read saved credentials |
-| `AUTOCONTEXT_DB_PATH` | SQLite database path |
+| Variable                                                             | Purpose                                                     |
+| -------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `AUTOCONTEXT_AGENT_PROVIDER`                                         | Agent provider selection                                    |
+| `AUTOCONTEXT_AGENT_API_KEY`                                          | Global API key override (or use provider-specific env vars) |
+| `AUTOCONTEXT_AGENT_BASE_URL`                                         | Global base URL override for compatible providers           |
+| `AUTOCONTEXT_AGENT_DEFAULT_MODEL`                                    | Override default model                                      |
+| `AUTOCONTEXT_COMPETITOR_API_KEY` / `AUTOCONTEXT_COMPETITOR_BASE_URL` | Optional competitor-specific credential/endpoint override   |
+| `AUTOCONTEXT_ANALYST_API_KEY` / `AUTOCONTEXT_ANALYST_BASE_URL`       | Optional analyst-specific credential/endpoint override      |
+| `AUTOCONTEXT_COACH_API_KEY` / `AUTOCONTEXT_COACH_BASE_URL`           | Optional coach-specific credential/endpoint override        |
+| `AUTOCONTEXT_ARCHITECT_API_KEY` / `AUTOCONTEXT_ARCHITECT_BASE_URL`   | Optional architect-specific credential/endpoint override    |
+| `AUTOCONTEXT_CLAUDE_MODEL`                                           | Claude CLI model alias override                             |
+| `AUTOCONTEXT_CODEX_MODEL`                                            | Codex CLI model override                                    |
+| `AUTOCONTEXT_CONFIG_DIR`                                             | Override where `login` / `whoami` read saved credentials    |
+| `AUTOCONTEXT_DB_PATH`                                                | SQLite database path                                        |
 
 Credential resolution order is:
 
@@ -278,8 +274,6 @@ Credential resolution order is:
 
 `autoctx capabilities` returns structured JSON describing commands, providers, scenarios, the canonical concept model, and project-specific state such as the current project config, active runs, and knowledge directory summary.
 
-The HTTP server exposes `GET /api/capabilities/http` with a runtime parity matrix for Python and TypeScript REST/WebSocket routes, including explicit TypeScript gaps and TypeScript-only routes. Session notebook CRUD routes are available under `/api/notebooks`, cockpit notebook/run/readout routes are available under `/api/cockpit`, research hub session/package/result routes are available under `/api/hub`, monitor condition/alert routes are available under `/api/monitors`, and OpenClaw-compatible evaluation, artifact, distillation, discovery, capability, and skill manifest routes are available under `/api/openclaw`.
-
 `autoctx login` can prompt interactively for provider credentials. `autoctx login --provider ollama` validates that a local Ollama server is reachable before persisting the connection details, and `autoctx logout` clears the stored credentials.
 
 `autoctx replay` writes the selected generation and available generations to `stderr` before printing the replay JSON payload. `autoctx export-training-data` writes progress updates to `stderr` while keeping JSONL records on `stdout`.
@@ -290,20 +284,20 @@ Saved custom scenarios under `knowledge/_custom_scenarios/` can be reused direct
 
 `mcp-serve` starts the MCP server on stdio with tools across these families:
 
-| Family | Tools |
-|--------|-------|
-| Scenarios | list_scenarios, get_scenario, validate_strategy, run_match, run_tournament, run_scenario |
-| Runs | list_runs, get_run_status, get_generation_detail, run_replay |
-| Knowledge | get_playbook, read_trajectory, read_hints, read_analysis, read_tools, read_skills |
-| Evaluation | evaluate_output, run_improvement_loop, run_repl_session, generate_output |
-| Task queue | queue_task, get_queue_status, get_task_result |
-| Export/Search | export_skill, export_package, import_package, list_solved, search_strategies |
-| Feedback | record_feedback, get_feedback |
-| Solve | solve_scenario, solve_status, solve_result |
-| Sandbox | sandbox_create, sandbox_run, sandbox_status, sandbox_playbook, sandbox_list, sandbox_destroy |
-| Agent tasks | create_agent_task, list_agent_tasks, get_agent_task |
-| Missions | create_mission, mission_status, mission_result, mission_artifacts, pause_mission, resume_mission, cancel_mission |
-| Discovery | capabilities |
+| Family        | Tools                                                                                                            |
+| ------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Scenarios     | list_scenarios, get_scenario, validate_strategy, run_match, run_tournament, run_scenario                         |
+| Runs          | list_runs, get_run_status, get_generation_detail, run_replay                                                     |
+| Knowledge     | get_playbook, read_trajectory, read_hints, read_analysis, read_tools, read_skills                                |
+| Evaluation    | evaluate_output, run_improvement_loop, run_repl_session, generate_output                                         |
+| Task queue    | queue_task, get_queue_status, get_task_result                                                                    |
+| Export/Search | export_skill, export_package, import_package, list_solved, search_strategies                                     |
+| Feedback      | record_feedback, get_feedback                                                                                    |
+| Solve         | solve_scenario, solve_status, solve_result                                                                       |
+| Sandbox       | sandbox_create, sandbox_run, sandbox_status, sandbox_playbook, sandbox_list, sandbox_destroy                     |
+| Agent tasks   | create_agent_task, list_agent_tasks, get_agent_task                                                              |
+| Missions      | create_mission, mission_status, mission_result, mission_artifacts, pause_mission, resume_mission, cancel_mission |
+| Discovery     | capabilities                                                                                                     |
 
 `create_mission` and `autoctx mission create` both support a code-mission variant with `type=code` plus `repo_path` / `test_command` (and optional `lint_command` / `build_command`) so mission success is tied to external checks instead of model self-report.
 
@@ -326,12 +320,7 @@ Saved custom scenarios under `knowledge/_custom_scenarios/` can be reused direct
 ## Library Usage
 
 ```ts
-import {
-  createProvider,
-  LLMJudge,
-  ImprovementLoop,
-  SimpleAgentTask,
-} from "autoctx";
+import { createProvider, LLMJudge, ImprovementLoop, SimpleAgentTask } from "autoctx";
 
 // One-shot evaluation
 const provider = createProvider({ providerType: "anthropic", apiKey: "sk-ant-..." });
@@ -342,9 +331,16 @@ const result = await judge.evaluate({
 });
 
 // Multi-round improvement
-const task = new SimpleAgentTask("Draft a support reply for a billing dispute.", "Score accuracy, policy compliance, and tone.", provider);
+const task = new SimpleAgentTask(
+  "Draft a support reply for a billing dispute.",
+  "Score accuracy, policy compliance, and tone.",
+  provider,
+);
 const loop = new ImprovementLoop({ task, maxRounds: 3, qualityThreshold: 0.9 });
-const improved = await loop.run({ initialOutput: "We can help with that billing issue.", state: {} });
+const improved = await loop.run({
+  initialOutput: "We can help with that billing issue.",
+  state: {},
+});
 ```
 
 ## TS / Python Scope
@@ -360,14 +356,6 @@ The TypeScript package includes the current 0.4.x operator-facing surfaces:
 `campaign` now ships as a first-class TypeScript CLI/API/MCP workflow for multi-mission coordination.
 
 For end-to-end local MLX/CUDA training, the Python package is still the canonical out-of-the-box runtime.
-
-## Browser Exploration Contract
-
-The TypeScript package exposes the shared browser exploration contract and policy helpers from the package root. Browser exploration is disabled by default and configured through `AUTOCONTEXT_BROWSER_*` settings such as `AUTOCONTEXT_BROWSER_ENABLED`, `AUTOCONTEXT_BROWSER_ALLOWED_DOMAINS`, and `AUTOCONTEXT_BROWSER_PROFILE_MODE`.
-
-Use `resolveBrowserSessionConfig(...)`, `evaluateBrowserActionPolicy(...)`, and the `validateBrowser*` helpers when integrating a browser backend or agent harness.
-
-When browser exploration is enabled, the TS CLI can capture a policy-gated Chrome DevTools Protocol snapshot and attach it as evidence for `autoctx investigate --browser-url <url>`. Queued agent tasks can also store `--browser-url`; the runner resolves it through an injected browser-context service so enterprise deployments can keep browser access disabled by default, domain-scoped, and audit-artifact backed.
 
 ## Python-Only Commands
 
@@ -457,7 +445,41 @@ await sink.close();
 Emitted trace line (pretty-printed for readability):
 
 ```jsonl
-{"schemaVersion":"1.0","traceId":"...","sessionContext":{"userId":"u_123"},"request":{"model":"gpt-4o","messages":[{"role":"user","content":"Hello!"}]},"response":{"id":"...","choices":[{"message":{"role":"assistant","content":"Hi! How can I help?"},"finish_reason":"stop"}],"usage":{"prompt_tokens":9,"completion_tokens":7,"total_tokens":16}},"durationMs":342,"errorReason":null}
+{
+  "schemaVersion": "1.0",
+  "traceId": "...",
+  "sessionContext": {
+    "userId": "u_123"
+  },
+  "request": {
+    "model": "gpt-4o",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello!"
+      }
+    ]
+  },
+  "response": {
+    "id": "...",
+    "choices": [
+      {
+        "message": {
+          "role": "assistant",
+          "content": "Hi! How can I help?"
+        },
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "prompt_tokens": 9,
+      "completion_tokens": 7,
+      "total_tokens": 16
+    }
+  },
+  "durationMs": 342,
+  "errorReason": null
+}
 ```
 
 For the Python equivalent, see
@@ -540,7 +562,38 @@ await sink.close();
 Emitted trace line (pretty-printed for readability):
 
 ```jsonl
-{"schemaVersion":"1.0","traceId":"...","sessionContext":{"userId":"u_123"},"request":{"model":"claude-opus-4-7-20251101","messages":[{"role":"user","content":"Hello!"}]},"response":{"id":"...","content":[{"type":"text","text":"Hi! How can I help?"}],"stop_reason":"end_turn","usage":{"input_tokens":9,"output_tokens":7}},"durationMs":342,"errorReason":null}
+{
+  "schemaVersion": "1.0",
+  "traceId": "...",
+  "sessionContext": {
+    "userId": "u_123"
+  },
+  "request": {
+    "model": "claude-opus-4-7-20251101",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Hello!"
+      }
+    ]
+  },
+  "response": {
+    "id": "...",
+    "content": [
+      {
+        "type": "text",
+        "text": "Hi! How can I help?"
+      }
+    ],
+    "stop_reason": "end_turn",
+    "usage": {
+      "input_tokens": 9,
+      "output_tokens": 7
+    }
+  },
+  "durationMs": 342,
+  "errorReason": null
+}
 ```
 
 For the Python equivalent, see


### PR DESCRIPTION
## Summary

- Restructure the top-level `README.md` to lead with the Pi runtime quick start, add a natural-language entry path through MCP ("Or Just Talk To Your Agent"), show a concrete artifact tree (real `playbook.md` + `trace.jsonl` excerpts), surface production-trace capture as its own section, merge the Surfaces table with command examples, and add a short FAQ.
- Drop redundant sections: "How People Use It," "Choose An Entry Point," and "Repository Layout" (the last is already covered in `AGENTS.md`).
- Bump `current release line` references in `autocontext/README.md` and `ts/README.md` from `0.4.4` to `0.4.7` to track the next release.
- Add a `Changed` entry under `[Unreleased]` in `CHANGELOG.md`.

## What this is and isn't

- This is a **docs-only PR**. No code, no CLI flags, no env vars, no public API change.
- Package metadata (`pyproject.toml`, `package.json`) is **not** bumped here. The `0.4.7` references in the READMEs are forward-looking and land alongside the `0.4.7` release cut.
- "What's Coming" / hosted Cloud + Enclave content was intentionally removed; this README documents the OSS package only.

## Why

The previous README front-loaded six overlapping "what is this" sections before any runnable command, buried Quick Start at line 179, duplicated entry-point guidance across two sections, hid the new TypeScript `solve` parity, and never mentioned that an MCP-aware harness can drive autocontext with natural language. The restructure puts the runnable command in the first scroll, replaces abstract feature lists with concrete artifact output, and surfaces the Pi + MCP entry paths as the lead story.

## Test plan

- [ ] Render `README.md` on GitHub and verify all anchor links resolve (FAQ link to `#or-just-talk-to-your-agent`, etc.).
- [ ] Verify the `runs/<run_id>/` and `knowledge/<scenario>/` artifact trees match the architecture in `CLAUDE.md` (PLAYBOOK_START markers, gen_N analysis, etc.).
- [ ] Confirm no `pyproject.toml` / `package.json` changes are introduced (this is intentionally docs-only).
- [ ] Sanity-check that `autoctx solve` and `autoctx mcp-serve` references match the actual CLI in both `autocontext/src/autocontext/mcp/server.py` and `ts/src/mcp/`.
- [ ] Spot-check the FAQ for accuracy against current behavior (Pi runs without API keys, knowledge lives on filesystem + SQLite, MCP path exists).

## Out of scope

- Package version bumps (lands with `0.4.7` release).
- Updates to `autocontext/docs/agent-integration.md`, `examples/README.md`, or `docs/README.md`: nothing in those files is contradicted by this PR; they document a stable contract that did not change.