### PR TITLE
AC-660 Add Pi package export format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Python `autoctx export` now accepts `--format pi-package` to write a Pi-local package directory with `package.json`, `SKILL.md`, prompt markdown, and the original autocontext strategy payload.
 - TypeScript CLI now exposes `autoctx solve` as a DB-backed solve-on-demand entrypoint with `--description`, `--gens`, `--timeout`, and `--json` support (AC-619).
 - TypeScript solve now preserves Python-shaped controls for structured family overrides, per-generation runtime-budget enforcement, output file writing, and classifier fallback status metadata (AC-620).
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ bun add -g autoctx@0.4.7
 | `analyze`     | `autoctx analyze --id <id> --type <kind>`          | Inspect or compare runs, simulations, investigations, or missions after the fact       |
 | `mission`     | `autoctx mission create --name "..." --goal "..."` | Verifier-driven goal advanced step by step until done                                  |
 | `campaign`    | `bunx autoctx campaign ...` (TypeScript)           | Coordinate multiple missions with budgets, dependencies, progress aggregation          |
+| `export`      | `uv run autoctx export --scenario <name> --format pi-package` (Python) | Share solved knowledge as JSON, skills, or Pi-local package directories                |
 | `train`       | `autoctx train --scenario <name> --data <jsonl>`   | Distill stable exported data into a cheaper local runtime                              |
 | `replay`      | `autoctx replay <run_id> --generation N`           | Inspect what happened before deciding what knowledge should persist                    |
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -257,6 +257,14 @@ The Python package includes a thin Chrome CDP backend that attaches to an existi
 
 `AUTOCONTEXT_HARNESS_PROFILE=lean` resolves a Pi-shaped runtime profile: prompt context is capped by `AUTOCONTEXT_LEAN_CONTEXT_BUDGET_TOKENS`, hidden/implicit context defaults to zero, and generated tool context is replaced by the lean allowlist before agent execution. `AUTOCONTEXT_PI_RPC_PERSISTENT=true` opts Pi RPC into a long-lived subprocess; one-shot Pi RPC remains the default.
 
+Solved strategy packages can also be exported as Pi-local package directories:
+
+```bash
+uv run autoctx export --scenario grid_ctf --format pi-package --output grid-ctf-pi-package
+```
+
+The directory contains `package.json`, a Pi skill, a prompt file, and the original `autocontext.package.json` strategy payload for re-import.
+
 See the repo-level [.env.example](../.env.example) for a working starting point.
 
 ## Repository Structure

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -172,6 +172,18 @@ JSON output shape:
 }
 ```
 
+For Pi-local package installation, export the same strategy knowledge as a
+package directory with a `package.json`, one `SKILL.md`, one prompt file, and
+the original autocontext strategy payload:
+
+```bash
+autoctx export \
+  --scenario grid_ctf \
+  --format pi-package \
+  --output grid-ctf-pi-package \
+  --json
+```
+
 #### `autoctx train` — Run a training loop
 
 ```bash
@@ -510,6 +522,16 @@ jq . "logs/${RUN_ID}.json"
 autoctx export \
   --scenario grid_ctf \
   --output "hermes_knowledge.json" \
+  --json | jq .
+```
+
+For Pi, use `--format pi-package` to produce a local package directory:
+
+```bash
+autoctx export \
+  --scenario grid_ctf \
+  --format pi-package \
+  --output "grid-ctf-pi-package" \
   --json | jq .
 ```
 

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -997,7 +997,15 @@ def new_scenario(
 @app.command("export")
 def export_cmd(
     scenario: str = typer.Option(..., "--scenario", help="Scenario to export"),
-    output: str = typer.Option("", "--output", help="Output JSON file path (default: <scenario>_package.json)"),
+    output: str = typer.Option(
+        "",
+        "--output",
+        help=(
+            "Output path: strategy JSON file (default: <scenario>_package.json) "
+            "or pi-package directory (default: <scenario>-pi-package)"
+        ),
+    ),
+    export_format: str = typer.Option("strategy", "--format", help="Export format: strategy or pi-package"),
     db_path: str | None = typer.Option(None, "--db-path", help="Override database path"),
     runs_root: str | None = typer.Option(None, "--runs-root", help="Override runs root"),
     knowledge_root: str | None = typer.Option(None, "--knowledge-root", help="Override knowledge root"),
@@ -1044,6 +1052,39 @@ def export_cmd(
             console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
 
+    normalized_format = export_format.strip().lower()
+    if normalized_format not in {"strategy", "pi-package"}:
+        message = "--format must be one of strategy, pi-package"
+        if json_output:
+            _write_json_stderr(message)
+        else:
+            console.print(f"[red]{message}[/red]")
+        raise typer.Exit(code=1)
+
+    if normalized_format == "pi-package":
+        from autocontext.knowledge.pi_package import (
+            build_pi_package,
+            default_pi_package_output_dir,
+            write_pi_package,
+        )
+
+        output_path = Path(output) if output else default_pi_package_output_dir(scenario)
+        written = write_pi_package(build_pi_package(pkg), output_path)
+        if json_output:
+            _write_json_stdout(
+                {
+                    "scenario": scenario,
+                    "format": normalized_format,
+                    "output_path": str(output_path),
+                    "file_count": len(written.files),
+                    "files": [str(path.relative_to(output_path)) for path in written.files],
+                }
+            )
+        else:
+            console.print(f"[green]Exported {scenario} Pi package to {output_path}[/green]")
+            console.print(f"[dim]files={len(written.files)} best_score={pkg.best_score:.4f}[/dim]")
+        return
+
     output_path = Path(output) if output else Path(f"{scenario}_package.json")
     pkg.to_file(output_path)
 
@@ -1051,6 +1092,7 @@ def export_cmd(
         _write_json_stdout(
             {
                 "scenario": scenario,
+                "format": normalized_format,
                 "output_path": str(output_path),
                 "best_score": pkg.best_score,
                 "lessons_count": len(pkg.lessons),

--- a/autocontext/src/autocontext/knowledge/pi_package.py
+++ b/autocontext/src/autocontext/knowledge/pi_package.py
@@ -1,0 +1,176 @@
+"""Pi-compatible package export for autocontext strategy packages."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from autocontext import __version__
+
+if TYPE_CHECKING:
+    from autocontext.knowledge.package import StrategyPackage
+
+_PI_TOOL_NAMES = (
+    "autocontext_solve_scenario",
+    "autocontext_export_package",
+    "autocontext_import_package",
+    "autocontext_run_status",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PiPackage:
+    """In-memory representation of a local Pi-installable package directory."""
+
+    package_dir_name: str
+    files: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class WrittenPiPackage:
+    """Filesystem result for a written Pi package."""
+
+    output_dir: Path
+    files: tuple[Path, ...]
+
+
+def build_pi_package(package: StrategyPackage) -> PiPackage:
+    """Build a Pi-compatible local package from a strategy package."""
+    scenario_slug = _slug(package.scenario_name)
+    skill_path = f"skills/{scenario_slug}-knowledge/SKILL.md"
+    prompt_path = f"prompts/{scenario_slug}.md"
+    strategy_path = "autocontext.package.json"
+
+    files = {
+        "README.md": _render_readme(package),
+        strategy_path: package.to_json(),
+        "package.json": _render_package_json(package, skill_path=skill_path, prompt_path=prompt_path),
+        prompt_path: _render_prompt(package),
+        skill_path: package.to_skill_package().to_skill_markdown(),
+    }
+    return PiPackage(package_dir_name=f"{scenario_slug}-pi-package", files=_sort_files(files))
+
+
+def write_pi_package(package: PiPackage, output_dir: Path) -> WrittenPiPackage:
+    """Write a Pi package directory and return the files written."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for relative_path, content in package.files.items():
+        path = output_dir / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content.rstrip() + "\n", encoding="utf-8")
+        written.append(path)
+    return WrittenPiPackage(output_dir=output_dir, files=tuple(written))
+
+
+def default_pi_package_output_dir(scenario_name: str) -> Path:
+    """Return the default local package directory for a scenario."""
+    return Path(f"{_slug(scenario_name)}-pi-package")
+
+
+def _sort_files(files: dict[str, str]) -> dict[str, str]:
+    return {key: files[key] for key in sorted(files)}
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "autocontext"
+
+
+def _npm_package_name(scenario_name: str) -> str:
+    return f"autocontext-{_slug(scenario_name)}-pi-package"
+
+
+def _description(package: StrategyPackage) -> str:
+    description = package.description.strip()
+    return description or f"Autocontext package for {package.display_name or package.scenario_name}"
+
+
+def _render_package_json(package: StrategyPackage, *, skill_path: str, prompt_path: str) -> str:
+    manifest = {
+        "name": _npm_package_name(package.scenario_name),
+        "version": _package_version(package),
+        "private": True,
+        "description": _description(package)[:200],
+        "files": [
+            "README.md",
+            "autocontext.package.json",
+            "prompts",
+            "skills",
+        ],
+        "pi": {
+            "skills": [skill_path],
+            "prompts": [prompt_path],
+            "extensions": [],
+            "themes": [],
+        },
+        "autocontext": {
+            "format": "pi-package",
+            "scenario_name": package.scenario_name,
+            "strategy_package": "autocontext.package.json",
+            "tools": list(_PI_TOOL_NAMES),
+        },
+    }
+    return json.dumps(manifest, indent=2, sort_keys=True)
+
+
+def _package_version(package: StrategyPackage) -> str:
+    version = package.metadata.mts_version.strip()
+    return version or __version__
+
+
+def _render_prompt(package: StrategyPackage) -> str:
+    title = package.display_name or package.scenario_name.replace("_", " ").title()
+    parts = [
+        f"# {title}",
+        "",
+        _description(package),
+        "",
+        "Use this Pi package as a lean autocontext operating context.",
+        "",
+        "## Autocontext Tools",
+        "",
+    ]
+    parts.extend(f"- `{tool}`" for tool in _PI_TOOL_NAMES)
+    if package.task_prompt:
+        parts.extend(["", "## Task", "", package.task_prompt])
+    if package.judge_rubric:
+        parts.extend(["", "## Evaluation Criteria", "", package.judge_rubric])
+    if package.playbook:
+        parts.extend(["", "## Playbook", "", package.playbook])
+    if package.lessons:
+        parts.extend(["", "## Lessons", ""])
+        parts.extend(f"- {lesson}" for lesson in package.lessons)
+    if package.best_strategy:
+        parts.extend([
+            "",
+            "## Best Known Strategy",
+            "",
+            "```json",
+            json.dumps(package.best_strategy, indent=2, sort_keys=True),
+            "```",
+        ])
+    return "\n".join(parts)
+
+
+def _render_readme(package: StrategyPackage) -> str:
+    title = package.display_name or package.scenario_name.replace("_", " ").title()
+    scenario_slug = _slug(package.scenario_name)
+    return "\n".join([
+        f"# {title} Pi Package",
+        "",
+        _description(package),
+        "",
+        "This package was generated by autocontext for local Pi package installation.",
+        "",
+        "## Contents",
+        "",
+        f"- `skills/{scenario_slug}-knowledge/SKILL.md`",
+        f"- `prompts/{scenario_slug}.md`",
+        "- `autocontext.package.json`",
+        "",
+        "The strategy package can be re-imported with `autocontext_import_package`.",
+    ])

--- a/autocontext/tests/test_pi_package_export.py
+++ b/autocontext/tests/test_pi_package_export.py
@@ -1,0 +1,150 @@
+"""Pi-compatible package export tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+from autocontext.storage.artifacts import ArtifactStore
+from autocontext.storage.sqlite_store import SQLiteStore
+
+runner = CliRunner()
+
+
+def _strategy_package() -> object:
+    from autocontext.knowledge.package import StrategyPackage
+
+    return StrategyPackage(
+        scenario_name="grid_ctf",
+        display_name="Grid CTF",
+        description="Capture the flag on a grid.",
+        playbook="## Playbook\n\nScout, then strike.",
+        lessons=["Prefer short routes.", "Avoid stale scouts."],
+        best_strategy={"aggression": 0.7},
+        best_score=0.88,
+        best_elo=1710.0,
+        hints="Watch borders.",
+    )
+
+
+def _setup_db_and_artifacts(tmp_path: Path) -> tuple[SQLiteStore, ArtifactStore, Path]:
+    db_path = tmp_path / "runs" / "autocontext.sqlite3"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = SQLiteStore(db_path)
+    db.migrate(Path(__file__).resolve().parents[1] / "migrations")
+    artifacts = ArtifactStore(
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / ".claude" / "skills",
+    )
+    return db, artifacts, db_path
+
+
+def _seed_grid_ctf(db: SQLiteStore, artifacts: ArtifactStore) -> None:
+    artifacts.write_playbook("grid_ctf", "## Playbook\n\nScout, then strike.")
+    artifacts.write_hints("grid_ctf", "Watch borders.")
+    db.create_run("pi_pkg_run", "grid_ctf", 1, "local")
+    db.mark_run_completed("pi_pkg_run")
+
+
+def test_pi_package_builds_installable_file_map() -> None:
+    from autocontext.knowledge.pi_package import build_pi_package
+
+    package = build_pi_package(_strategy_package())
+
+    assert package.package_dir_name == "grid-ctf-pi-package"
+    assert set(package.files) == {
+        "README.md",
+        "autocontext.package.json",
+        "package.json",
+        "prompts/grid-ctf.md",
+        "skills/grid-ctf-knowledge/SKILL.md",
+    }
+
+    manifest = json.loads(package.files["package.json"])
+    assert manifest["name"] == "autocontext-grid-ctf-pi-package"
+    assert manifest["private"] is True
+    assert manifest["pi"]["skills"] == ["skills/grid-ctf-knowledge/SKILL.md"]
+    assert manifest["pi"]["prompts"] == ["prompts/grid-ctf.md"]
+    assert manifest["autocontext"]["scenario_name"] == "grid_ctf"
+
+    prompt = package.files["prompts/grid-ctf.md"]
+    assert "Grid CTF" in prompt
+    assert "Scout, then strike." in prompt
+    assert "autocontext_export_package" in prompt
+
+
+def test_pi_package_writer_creates_directory_layout(tmp_path: Path) -> None:
+    from autocontext.knowledge.pi_package import build_pi_package, write_pi_package
+
+    target = tmp_path / "pkg"
+    written = write_pi_package(build_pi_package(_strategy_package()), target)
+
+    assert written.output_dir == target
+    assert sorted(path.relative_to(target).as_posix() for path in written.files) == [
+        "README.md",
+        "autocontext.package.json",
+        "package.json",
+        "prompts/grid-ctf.md",
+        "skills/grid-ctf-knowledge/SKILL.md",
+    ]
+    assert (target / "skills" / "grid-ctf-knowledge" / "SKILL.md").read_text(encoding="utf-8").startswith("---")
+
+
+def test_export_command_writes_pi_package(tmp_path: Path) -> None:
+    db, artifacts, db_path = _setup_db_and_artifacts(tmp_path)
+    _seed_grid_ctf(db, artifacts)
+    output_dir = tmp_path / "grid-ctf-pi-package"
+
+    result = runner.invoke(app, [
+        "export",
+        "--format", "pi-package",
+        "--scenario", "grid_ctf",
+        "--output", str(output_dir),
+        "--db-path", str(db_path),
+        "--knowledge-root", str(tmp_path / "knowledge"),
+        "--skills-root", str(tmp_path / "skills"),
+        "--claude-skills-path", str(tmp_path / ".claude" / "skills"),
+    ])
+
+    assert result.exit_code == 0, result.output
+    manifest = json.loads((output_dir / "package.json").read_text(encoding="utf-8"))
+    assert manifest["pi"]["skills"] == ["skills/grid-ctf-knowledge/SKILL.md"]
+    assert (output_dir / "autocontext.package.json").exists()
+
+
+def test_export_command_reports_pi_package_json(tmp_path: Path) -> None:
+    db, artifacts, db_path = _setup_db_and_artifacts(tmp_path)
+    _seed_grid_ctf(db, artifacts)
+    output_dir = tmp_path / "grid-ctf-pi-package"
+
+    result = runner.invoke(app, [
+        "export",
+        "--json",
+        "--format", "pi-package",
+        "--scenario", "grid_ctf",
+        "--output", str(output_dir),
+        "--db-path", str(db_path),
+        "--knowledge-root", str(tmp_path / "knowledge"),
+        "--skills-root", str(tmp_path / "skills"),
+        "--claude-skills-path", str(tmp_path / ".claude" / "skills"),
+    ])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["format"] == "pi-package"
+    assert payload["output_path"] == str(output_dir)
+    assert payload["file_count"] == 5
+
+
+def test_export_help_describes_format_dependent_output_path() -> None:
+    result = runner.invoke(app, ["export", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "Output path: strategy JSON file" in result.output
+    assert "pi-package directory" in result.output
+    assert "Output JSON file path" not in result.output

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,12 @@ uv run autoctx export \
   --scenario grid_ctf \
   --output "exports/${RUN_ID}.json" \
   --json | jq .
+
+uv run autoctx export \
+  --scenario grid_ctf \
+  --format pi-package \
+  --output "exports/${RUN_ID}-pi-package" \
+  --json | jq .
 ```
 
 ## Claude Code MCP Config


### PR DESCRIPTION
## Summary
- add a Pi-compatible package exporter around existing StrategyPackage knowledge
- wire `autoctx export --format pi-package` with human and JSON output
- document the Pi-local package flow in README, examples, agent integration docs, and changelog

## Tests
- `uv run pytest tests/test_pi_package_export.py tests/test_strategy_package_cli.py`
- `uv run ruff check src tests/test_pi_package_export.py tests/test_strategy_package_cli.py`
- `uv run mypy src`
- `uv run pytest tests/test_pi_package_export.py tests/test_strategy_package_cli.py tests/test_cli_json.py::TestExportJson`
- `uv run pytest tests/test_pi_package_export.py tests/test_strategy_package_cli.py tests/test_cli_json.py::TestExportJson tests/test_knowledge_api.py tests/test_export_skill_md.py`
- `uv run ruff check src tests`
- `uv run mypy src`
- `uv run pytest`