### PR TITLE
AC-661 add Pi runtime snapshot bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Python `autoctx export` now accepts `--format pi-package` to write a Pi-local package directory with `package.json`, `SKILL.md`, prompt markdown, and the original autocontext strategy payload.
+- Pi `pi-autocontext` now exposes `autocontext_runtime_snapshot` for run artifacts, package provenance, session branch lineage, and recent event-stream context.
 - TypeScript CLI now exposes `autoctx solve` as a DB-backed solve-on-demand entrypoint with `--description`, `--gens`, `--timeout`, and `--json` support (AC-619).
 - TypeScript solve now preserves Python-shaped controls for structured family overrides, per-generation runtime-budget enforcement, output file writing, and classifier fallback status metadata (AC-620).
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -27,6 +27,7 @@ Or add to your project's `.pi/settings.json`:
 | `autocontext_status` | Check status of autocontext runs and tasks |
 | `autocontext_scenarios` | List available evaluation scenarios and families |
 | `autocontext_queue` | Enqueue a task for background evaluation |
+| `autocontext_runtime_snapshot` | Inspect run artifacts, package provenance, session branch lineage, and recent events |
 
 ### Skills
 
@@ -44,6 +45,7 @@ Once installed, the tools are available to the LLM automatically. You can also i
 > Evaluate the quality of this code against our coding standards rubric
 > Run an improvement loop on this draft with max 5 rounds
 > Show me the status of recent autocontext runs
+> Inspect the runtime snapshot for run-123 and session sess-123
 > List available evaluation scenarios
 ```
 
@@ -65,6 +67,7 @@ The extension auto-discovers your autocontext configuration:
 
 - **Provider**: Uses Pi's configured LLM provider
 - **Database**: Looks for `runs/autocontext.sqlite3` or `AUTOCONTEXT_DB_PATH` env var
+- **Events**: Reads `runs/events.ndjson` or `AUTOCONTEXT_EVENT_STREAM_PATH` for recent runtime events
 - **Scenarios**: Discovers registered scenarios from the `autoctx` package
 
 ## Links

--- a/pi/prompts/autoctx-status.md
+++ b/pi/prompts/autoctx-status.md
@@ -2,8 +2,10 @@
 description: Check autocontext project status and recent runs
 ---
 Check the current autocontext project status. Use the `autocontext_status` tool
-to list recent runs and their outcomes. If a `.autoctx.json` config exists,
-report the configured scenario and provider. Summarize:
+to list recent runs and their outcomes, then use `autocontext_runtime_snapshot`
+for the most relevant run when artifact/package/session context is needed. If a
+`.autoctx.json` config exists, report the configured scenario and provider.
+Summarize:
 - Number of runs and their statuses
 - Most recent run's score and generation count
 - Any queued tasks awaiting evaluation

--- a/pi/skills/autocontext/SKILL.md
+++ b/pi/skills/autocontext/SKILL.md
@@ -3,9 +3,10 @@ name: autocontext
 description: >
   Iterative strategy generation and evaluation system. Use when the user wants
   to evaluate agent output quality, run improvement loops, queue tasks for
-  background evaluation, check run status, or discover available scenarios.
-  Provides LLM-based judging with rubric-driven scoring.
-allowed-tools: autocontext_judge autocontext_improve autocontext_status autocontext_scenarios autocontext_queue
+  background evaluation, check run status, inspect runtime artifacts and
+  session branch lineage, or discover available scenarios. Provides LLM-based
+  judging with rubric-driven scoring.
+allowed-tools: autocontext_judge autocontext_improve autocontext_status autocontext_scenarios autocontext_queue autocontext_runtime_snapshot
 ---
 
 # autocontext
@@ -25,6 +26,8 @@ LLM-based judging to score and improve agent outputs.
 - **autocontext_status** — Check the status of runs and queued tasks.
 - **autocontext_scenarios** — List available evaluation scenarios and their
   families.
+- **autocontext_runtime_snapshot** — Inspect run artifacts, package provenance,
+  branchable session lineage, and recent event-stream entries.
 
 ## Quick Start
 
@@ -65,6 +68,13 @@ autocontext_queue(spec_name="my_scenario")
 ```
 
 Check results later with `autocontext_status`.
+
+For deeper context, use `autocontext_runtime_snapshot` with the run ID. Add
+`session_id` when you need the active branch path before continuing work:
+
+```
+autocontext_runtime_snapshot(run_id="run_123", session_id="sess_123")
+```
 
 ### 4. Discover scenarios
 

--- a/pi/src/index.ts
+++ b/pi/src/index.ts
@@ -12,6 +12,16 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
+import {
+  collectRuntimeSnapshot,
+  isRecord,
+  parseRuntimeSnapshotRequest,
+  readString,
+  renderRuntimeSnapshot,
+  resolveSettings,
+  resolveStore,
+  runIdOf,
+} from "./runtime-snapshot.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -29,8 +39,7 @@ async function loadAutoctx(): Promise<AutoctxModule> {
 }
 
 function resolveProvider(ac: AutoctxModule) {
-  const settings =
-    typeof ac.loadSettings === "function" ? ac.loadSettings() : {};
+  const settings = resolveSettings(ac);
   const config =
     typeof ac.resolveProviderConfig === "function"
       ? ac.resolveProviderConfig()
@@ -51,22 +60,6 @@ function resolveProvider(ac: AutoctxModule) {
     piRpcApiKey: settings.piRpcApiKey,
     piRpcSessionPersistence: settings.piRpcSessionPersistence,
   });
-}
-
-function resolveStore(ac: AutoctxModule) {
-  try {
-    const settings =
-      typeof ac.loadSettings === "function" ? ac.loadSettings() : {};
-    const dbPath =
-      process.env.AUTOCONTEXT_DB_PATH ??
-      settings.dbPath ??
-      "runs/autocontext.sqlite3";
-    return new ac.SQLiteStore(dbPath) as {
-      listRuns: () => Array<{ id: string; status: string }>;
-    };
-  } catch {
-    return null;
-  }
 }
 
 function renderScore(score: number): string {
@@ -256,19 +249,18 @@ export default function autocontextExtension(pi: ExtensionAPI): void {
           "No autocontext database found. Run `autoctx init` first.",
         );
       }
+      if (typeof store.listRuns !== "function") {
+        throw new Error("Installed autoctx SQLiteStore does not support listRuns.");
+      }
       const runs = store.listRuns();
-      if (params.run_id) {
-        const run = runs.find(
-          (r: { id: string }) => r.id === params.run_id,
-        );
-        if (!run) throw new Error(`Run ${params.run_id} not found.`);
-        return ok(
-          JSON.stringify(run, null, 2),
-          run as Record<string, unknown>,
-        );
+      const requestedRunId = typeof params.run_id === "string" ? params.run_id : "";
+      if (requestedRunId) {
+        const run = runs.find((candidate) => runIdOf(candidate) === requestedRunId);
+        if (!run) throw new Error(`Run ${requestedRunId} not found.`);
+        return ok(JSON.stringify(run, null, 2), run);
       }
       return ok(
-        `${runs.length} run(s) found.\n${runs.map((r: { id: string; status: string }) => `- ${r.id}: ${r.status}`).join("\n")}`,
+        `${runs.length} run(s) found.\n${runs.map((run) => `- ${runIdOf(run)}: ${readString(run, "status")}`).join("\n")}`,
         { count: runs.length },
       );
     },
@@ -379,6 +371,80 @@ export default function autocontextExtension(pi: ExtensionAPI): void {
       const label = theme.fg("toolTitle", theme.bold("autocontext queue "));
       const spec = theme.fg("accent", args.spec_name as string);
       return new Text(`${label}${spec}`, 0, 0);
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool: autocontext_runtime_snapshot
+  // -----------------------------------------------------------------------
+
+  pi.registerTool({
+    name: "autocontext_runtime_snapshot",
+    label: "autocontext Runtime",
+    description:
+      "Inspect autocontext runtime state for Pi: run artifacts, package records, session branch lineage, and recent event-stream entries.",
+    promptSnippet:
+      "Inspect autocontext runs, packages, sessions, and event stream state",
+    promptGuidelines: [
+      "Use when you need run artifacts, package provenance, or session branch context before continuing work.",
+      "Pass run_id for a specific run, session_id for branch lineage, or scenario to filter recent state.",
+      "Set include_outputs only when output previews are needed; previews are truncated.",
+    ],
+    parameters: Type.Object({
+      run_id: Type.Optional(
+        Type.String({ description: "Specific autocontext run ID to inspect" }),
+      ),
+      session_id: Type.Optional(
+        Type.String({ description: "Specific branchable session ID to inspect" }),
+      ),
+      scenario: Type.Optional(
+        Type.String({ description: "Scenario name to filter recent runs and package records" }),
+      ),
+      limit: Type.Optional(
+        Type.Number({ description: "Maximum rows/events to return, 1-50 (default 10)" }),
+      ),
+      generation_index: Type.Optional(
+        Type.Number({ description: "Generation index for output previews; defaults to latest generation" }),
+      ),
+      include_outputs: Type.Optional(
+        Type.Boolean({ description: "Include truncated agent output previews for the selected generation" }),
+      ),
+    }),
+    async execute(_toolCallId, params, _signal, onUpdate, _ctx) {
+      onUpdate?.({ content: [{ type: "text", text: "Collecting autocontext runtime snapshot..." }], details: {} });
+      const request = parseRuntimeSnapshotRequest(params);
+      const ac = await loadAutoctx();
+      const settings = resolveSettings(ac);
+      const store = resolveStore(ac);
+      if (!store) {
+        throw new Error(
+          "No autocontext database found. Run `autoctx init` first.",
+        );
+      }
+      try {
+        const snapshot = collectRuntimeSnapshot(ac, store, settings, request);
+        return ok(renderRuntimeSnapshot(snapshot), snapshot);
+      } finally {
+        store.close?.();
+      }
+    },
+    renderCall(args, theme) {
+      const label = theme.fg("toolTitle", theme.bold("autocontext runtime "));
+      const target = args.run_id
+        ? theme.fg("accent", args.run_id as string)
+        : args.session_id
+          ? theme.fg("accent", args.session_id as string)
+          : args.scenario
+            ? theme.fg("accent", args.scenario as string)
+            : theme.fg("dim", "(recent)");
+      return new Text(`${label}${target}`, 0, 0);
+    },
+    renderResult(result, _options, theme) {
+      const details = result.details as Record<string, unknown> | undefined;
+      const run = details && isRecord(details.run) ? runIdOf(details.run) : "";
+      const session = details && isRecord(details.session) ? readString(details.session, "sessionId") : "";
+      const label = run || session || "snapshot";
+      return new Text(theme.fg("accent", `runtime ${label}`), 0, 0);
     },
   });
 

--- a/pi/src/runtime-snapshot.ts
+++ b/pi/src/runtime-snapshot.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AutoctxModule = any;
@@ -35,6 +35,8 @@ type SessionStoreLike = {
   list?: (status?: string, limit?: number) => unknown[];
   close?: () => void;
 };
+
+const EVENT_STREAM_TAIL_BYTES = 64 * 1024;
 
 export type RuntimeSnapshotRequest = {
   runId: string;
@@ -104,8 +106,10 @@ function selectedGenerationIndex(
 
 function compactOutput(output: Record<string, unknown>): Record<string, unknown> {
   const content = readString(output, "content");
+  const metadata = { ...output };
+  delete metadata.content;
   return {
-    ...output,
+    ...metadata,
     contentLength: content.length,
     preview: content.slice(0, 500),
   };
@@ -143,13 +147,33 @@ function eventMatchesRun(event: Record<string, unknown>, runId: string): boolean
   return readString(payload, "run_id", readString(payload, "runId", readString(event, "run_id"))) === runId;
 }
 
+function readTailText(path: string, maxBytes: number): string {
+  const { size } = statSync(path);
+  if (size <= 0) return "";
+  const bytesToRead = Math.min(size, maxBytes);
+  const start = size - bytesToRead;
+  const buffer = Buffer.allocUnsafe(bytesToRead);
+  const fd = openSync(path, "r");
+  try {
+    let offset = 0;
+    while (offset < bytesToRead) {
+      const bytesRead = readSync(fd, buffer, offset, bytesToRead - offset, start + offset);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    return buffer.subarray(0, offset).toString("utf-8");
+  } finally {
+    closeSync(fd);
+  }
+}
+
 function readRecentEvents(settings: SettingsLike, request: RuntimeSnapshotRequest): Record<string, unknown>[] {
   const eventStreamPath =
     process.env.AUTOCONTEXT_EVENT_STREAM_PATH ??
     settings.eventStreamPath ??
     "runs/events.ndjson";
   if (!existsSync(eventStreamPath)) return [];
-  const lines = readFileSync(eventStreamPath, "utf-8")
+  const lines = readTailText(eventStreamPath, EVENT_STREAM_TAIL_BYTES)
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean)

--- a/pi/src/runtime-snapshot.ts
+++ b/pi/src/runtime-snapshot.ts
@@ -1,0 +1,337 @@
+import { existsSync, readFileSync } from "node:fs";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AutoctxModule = any;
+
+export type SettingsLike = {
+  dbPath?: string;
+  eventStreamPath?: string;
+  knowledgeRoot?: string;
+  piCommand?: string;
+  piModel?: string;
+  piRpcApiKey?: string;
+  piRpcEndpoint?: string;
+  piRpcSessionPersistence?: boolean;
+  piTimeout?: number;
+  piWorkspace?: string;
+  runsRoot?: string;
+};
+
+export type StoreLike = {
+  listRuns?: (limit?: number, scenario?: string) => Record<string, unknown>[];
+  getRun?: (runId: string) => Record<string, unknown> | null;
+  getGenerations?: (runId: string) => Record<string, unknown>[];
+  getScoreTrajectory?: (runId: string) => Record<string, unknown>[];
+  getAgentOutputs?: (runId: string, generationIndex: number) => Record<string, unknown>[];
+  getMatchesForRun?: (runId: string) => Record<string, unknown>[];
+  listHubPackageRecords?: () => Record<string, unknown>[];
+  listHubResultRecords?: () => Record<string, unknown>[];
+  listHubPromotionRecords?: () => Record<string, unknown>[];
+  close?: () => void;
+};
+
+type SessionStoreLike = {
+  load?: (sessionId: string) => unknown | null;
+  list?: (status?: string, limit?: number) => unknown[];
+  close?: () => void;
+};
+
+export type RuntimeSnapshotRequest = {
+  runId: string;
+  sessionId: string;
+  scenario: string;
+  limit: number;
+  includeOutputs: boolean;
+  generationIndex: number | null;
+};
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function recordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+export function readString(value: Record<string, unknown>, key: string, fallback = ""): string {
+  const raw = value[key];
+  return typeof raw === "string" ? raw : fallback;
+}
+
+function readNumber(value: Record<string, unknown>, key: string): number | null {
+  const raw = value[key];
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+}
+
+function clampLimit(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 10;
+  return Math.min(Math.max(Math.trunc(value), 1), 50);
+}
+
+export function resolveSettings(ac: AutoctxModule): SettingsLike {
+  try {
+    return typeof ac.loadSettings === "function" ? ac.loadSettings() : {};
+  } catch {
+    return {};
+  }
+}
+
+function resolveDbPath(settings: SettingsLike): string {
+  return process.env.AUTOCONTEXT_DB_PATH ?? settings.dbPath ?? "runs/autocontext.sqlite3";
+}
+
+export function resolveStore(ac: AutoctxModule): StoreLike | null {
+  try {
+    const settings = resolveSettings(ac);
+    return new ac.SQLiteStore(resolveDbPath(settings)) as StoreLike;
+  } catch {
+    return null;
+  }
+}
+
+export function runIdOf(run: Record<string, unknown>): string {
+  return readString(run, "run_id", readString(run, "id"));
+}
+
+function selectedGenerationIndex(
+  generations: Record<string, unknown>[],
+  requested: number | null,
+): number | null {
+  if (requested !== null) return requested;
+  const last = generations.at(-1);
+  return last ? readNumber(last, "generation_index") : null;
+}
+
+function compactOutput(output: Record<string, unknown>): Record<string, unknown> {
+  const content = readString(output, "content");
+  return {
+    ...output,
+    contentLength: content.length,
+    preview: content.slice(0, 500),
+  };
+}
+
+function safeArrayCall(
+  unavailable: string[],
+  label: string,
+  call: () => Record<string, unknown>[],
+): Record<string, unknown>[] {
+  try {
+    return call();
+  } catch (error) {
+    unavailable.push(`${label}: ${error instanceof Error ? error.message : String(error)}`);
+    return [];
+  }
+}
+
+function filterByRunOrScenario(
+  rows: Record<string, unknown>[],
+  request: Pick<RuntimeSnapshotRequest, "runId" | "scenario">,
+): Record<string, unknown>[] {
+  return rows.filter((row) => {
+    const sourceRunId = readString(row, "source_run_id", readString(row, "run_id"));
+    const scenarioName = readString(row, "scenario_name", readString(row, "scenario"));
+    if (request.runId && sourceRunId) return sourceRunId === request.runId;
+    if (request.scenario && scenarioName) return scenarioName === request.scenario;
+    return true;
+  });
+}
+
+function eventMatchesRun(event: Record<string, unknown>, runId: string): boolean {
+  if (!runId) return true;
+  const payload = isRecord(event.payload) ? event.payload : {};
+  return readString(payload, "run_id", readString(payload, "runId", readString(event, "run_id"))) === runId;
+}
+
+function readRecentEvents(settings: SettingsLike, request: RuntimeSnapshotRequest): Record<string, unknown>[] {
+  const eventStreamPath =
+    process.env.AUTOCONTEXT_EVENT_STREAM_PATH ??
+    settings.eventStreamPath ??
+    "runs/events.ndjson";
+  if (!existsSync(eventStreamPath)) return [];
+  const lines = readFileSync(eventStreamPath, "utf-8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(-request.limit * 5);
+  const events: Record<string, unknown>[] = [];
+  for (const line of lines) {
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (isRecord(parsed) && eventMatchesRun(parsed, request.runId)) {
+        events.push(parsed);
+      }
+    } catch {
+      // Ignore partial event-stream lines.
+    }
+  }
+  return events.slice(-request.limit);
+}
+
+function buildSessionSummary(sessionValue: unknown): Record<string, unknown> | null {
+  if (!isRecord(sessionValue)) return null;
+  const branchPath = typeof sessionValue.branchPath === "function"
+    ? sessionValue.branchPath.bind(sessionValue) as (branchId?: string) => unknown[]
+    : null;
+  const branches = recordArray(sessionValue.branches).map((branch) => {
+    const branchId = readString(branch, "branchId");
+    const path = branchPath ? recordArray(branchPath(branchId)) : [];
+    return {
+      branchId,
+      label: readString(branch, "label"),
+      parentTurnId: readString(branch, "parentTurnId"),
+      summary: readString(branch, "summary"),
+      pathTurnIds: path.map((turn) => readString(turn, "turnId")).filter(Boolean),
+    };
+  });
+  const turns = recordArray(sessionValue.turns);
+  return {
+    sessionId: readString(sessionValue, "sessionId"),
+    goal: readString(sessionValue, "goal"),
+    status: readString(sessionValue, "status"),
+    activeBranchId: readString(sessionValue, "activeBranchId"),
+    activeTurnId: readString(sessionValue, "activeTurnId"),
+    turnCount: readNumber(sessionValue, "turnCount") ?? turns.length,
+    totalTokens: readNumber(sessionValue, "totalTokens") ?? 0,
+    branches,
+    recentEvents: recordArray(sessionValue.events).slice(-5),
+  };
+}
+
+function resolveSessionStore(ac: AutoctxModule, dbPath: string): SessionStoreLike | null {
+  if (typeof ac.SessionStore !== "function") return null;
+  try {
+    return new ac.SessionStore(dbPath) as SessionStoreLike;
+  } catch {
+    return null;
+  }
+}
+
+export function parseRuntimeSnapshotRequest(params: Record<string, unknown>): RuntimeSnapshotRequest {
+  const generationIndex = readNumber(params, "generation_index");
+  return {
+    runId: readString(params, "run_id").trim(),
+    sessionId: readString(params, "session_id").trim(),
+    scenario: readString(params, "scenario").trim(),
+    limit: clampLimit(params.limit),
+    includeOutputs: params.include_outputs === true,
+    generationIndex,
+  };
+}
+
+export function collectRuntimeSnapshot(
+  ac: AutoctxModule,
+  store: StoreLike,
+  settings: SettingsLike,
+  request: RuntimeSnapshotRequest,
+): Record<string, unknown> {
+  const unavailable: string[] = [];
+  const details: Record<string, unknown> = {
+    format: "autocontext.runtime_snapshot.v1",
+    unavailable,
+  };
+
+  if (request.runId) {
+    let run = store.getRun?.(request.runId) ?? null;
+    if (!run && store.listRuns) {
+      run = store.listRuns(request.limit).find((candidate) => runIdOf(candidate) === request.runId) ?? null;
+    }
+    if (!run) {
+      throw new Error(`Run ${request.runId} not found.`);
+    }
+    details.run = run;
+    const generations = store.getGenerations
+      ? safeArrayCall(unavailable, "getGenerations", () => store.getGenerations!(request.runId))
+      : [];
+    details.generations = generations;
+    details.scoreTrajectory = store.getScoreTrajectory
+      ? safeArrayCall(unavailable, "getScoreTrajectory", () => store.getScoreTrajectory!(request.runId))
+      : [];
+    details.matches = store.getMatchesForRun
+      ? safeArrayCall(unavailable, "getMatchesForRun", () => store.getMatchesForRun!(request.runId)).slice(0, request.limit)
+      : [];
+    const generationIndex = selectedGenerationIndex(generations, request.generationIndex);
+    if (request.includeOutputs && generationIndex !== null && store.getAgentOutputs) {
+      details.agentOutputs = safeArrayCall(
+        unavailable,
+        "getAgentOutputs",
+        () => store.getAgentOutputs!(request.runId, generationIndex),
+      ).map(compactOutput);
+    }
+  } else if (store.listRuns) {
+    details.runs = store.listRuns(request.limit, request.scenario || undefined);
+  }
+
+  if (store.listHubPackageRecords) {
+    details.packages = filterByRunOrScenario(
+      safeArrayCall(unavailable, "listHubPackageRecords", () => store.listHubPackageRecords!()),
+      request,
+    ).slice(0, request.limit);
+  }
+  if (store.listHubResultRecords) {
+    details.results = filterByRunOrScenario(
+      safeArrayCall(unavailable, "listHubResultRecords", () => store.listHubResultRecords!()),
+      request,
+    ).slice(0, request.limit);
+  }
+  if (store.listHubPromotionRecords) {
+    details.promotions = filterByRunOrScenario(
+      safeArrayCall(unavailable, "listHubPromotionRecords", () => store.listHubPromotionRecords!()),
+      request,
+    ).slice(0, request.limit);
+  }
+
+  const sessionStore = resolveSessionStore(ac, resolveDbPath(settings));
+  if (sessionStore) {
+    try {
+      if (request.sessionId) {
+        details.session = buildSessionSummary(sessionStore.load?.(request.sessionId) ?? null);
+      } else if (typeof sessionStore.list === "function") {
+        details.sessions = sessionStore.list(undefined, request.limit)
+          .map(buildSessionSummary)
+          .filter((session): session is Record<string, unknown> => session !== null);
+      }
+    } finally {
+      sessionStore.close?.();
+    }
+  } else {
+    unavailable.push("SessionStore");
+  }
+
+  details.events = readRecentEvents(settings, request);
+  return details;
+}
+
+function bestScoreFromSnapshot(snapshot: Record<string, unknown>): number | null {
+  const generations = recordArray(snapshot.generations);
+  const scores = generations
+    .map((generation) => readNumber(generation, "best_score"))
+    .filter((score): score is number => score !== null);
+  return scores.length > 0 ? Math.max(...scores) : null;
+}
+
+export function renderRuntimeSnapshot(snapshot: Record<string, unknown>): string {
+  const lines = ["Runtime snapshot"];
+  const run = isRecord(snapshot.run) ? snapshot.run : null;
+  if (run) {
+    const bestScore = bestScoreFromSnapshot(snapshot);
+    const score = bestScore === null ? "" : ` best=${bestScore.toFixed(3)}`;
+    lines.push(`Run ${runIdOf(run)}: ${readString(run, "status", "unknown")}${score}`);
+    lines.push(`Generations: ${recordArray(snapshot.generations).length}`);
+  } else {
+    lines.push(`Runs: ${recordArray(snapshot.runs).length}`);
+  }
+  lines.push(`Packages: ${recordArray(snapshot.packages).length}`);
+  const session = isRecord(snapshot.session) ? snapshot.session : null;
+  if (session) {
+    lines.push(`Session ${readString(session, "sessionId")}: ${recordArray(session.branches).length} branch(es)`);
+  } else {
+    lines.push(`Sessions: ${recordArray(snapshot.sessions).length}`);
+  }
+  lines.push(`Recent events: ${recordArray(snapshot.events).length}`);
+  const unavailable = Array.isArray(snapshot.unavailable) ? snapshot.unavailable : [];
+  if (unavailable.length > 0) {
+    lines.push(`Unavailable: ${unavailable.join(", ")}`);
+  }
+  return lines.join("\n");
+}

--- a/pi/tests/extension.test.ts
+++ b/pi/tests/extension.test.ts
@@ -9,7 +9,8 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { readFileSync, existsSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 // ---------------------------------------------------------------------------
@@ -57,10 +58,30 @@ function createMockPiAPI() {
 
 type MockState = {
   providerConfig: { providerType: string; apiKey?: string; model?: string; baseUrl?: string };
-  settings: { dbPath: string };
-  runs: Array<{ id: string; status: string }>;
+  settings: { dbPath: string; runsRoot: string; knowledgeRoot: string; eventStreamPath: string };
+  runs: Array<{ id?: string; run_id?: string; scenario?: string; status: string }>;
+  generations: Array<{ run_id: string; generation_index: number; best_score: number; mean_score: number }>;
+  trajectory: Array<{ generation_index: number; best_score: number; delta: number }>;
+  agentOutputs: Array<{ run_id: string; generation_index: number; role: string; content: string }>;
+  matches: Array<{ run_id: string; generation_index: number; seed: number; score: number }>;
+  hubPackages: Array<{ package_id: string; scenario_name: string; source_run_id: string; metadata: Record<string, unknown> }>;
+  hubResults: Array<{ result_id: string; run_id: string; package_id: string | null }>;
+  hubPromotions: Array<{ event_id: string; package_id: string; source_run_id: string; action: string }>;
+  sessions: Array<{
+    sessionId: string;
+    goal: string;
+    status: string;
+    activeBranchId: string;
+    turnCount: number;
+    totalTokens: number;
+    branches: Array<{ branchId: string; label: string; parentTurnId: string; summary: string }>;
+    turns: Array<{ turnId: string; branchId: string; parentTurnId: string; role: string }>;
+    events: Array<{ eventId: string; eventType: string }>;
+    branchPath: (branchId?: string) => Array<{ turnId: string }>;
+  }>;
   providerOpts: Record<string, unknown> | null;
   storeDbPath: string | null;
+  sessionStoreDbPath: string | null;
   simpleTaskArgs: unknown[] | null;
   loopOpts: Record<string, unknown> | null;
   loopInput: Record<string, unknown> | null;
@@ -79,10 +100,57 @@ function resetMockState(): void {
     },
     settings: {
       dbPath: "runs/autocontext.sqlite3",
+      runsRoot: "runs",
+      knowledgeRoot: "knowledge",
+      eventStreamPath: "runs/events.ndjson",
     },
-    runs: [{ id: "run-1", status: "completed" }],
+    runs: [{ id: "run-1", run_id: "run-1", scenario: "grid_ctf", status: "completed" }],
+    generations: [
+      { run_id: "run-1", generation_index: 0, best_score: 0.72, mean_score: 0.61 },
+      { run_id: "run-1", generation_index: 1, best_score: 0.88, mean_score: 0.74 },
+    ],
+    trajectory: [
+      { generation_index: 0, best_score: 0.72, delta: 0 },
+      { generation_index: 1, best_score: 0.88, delta: 0.16 },
+    ],
+    agentOutputs: [
+      { run_id: "run-1", generation_index: 1, role: "competitor", content: "candidate strategy body" },
+    ],
+    matches: [
+      { run_id: "run-1", generation_index: 1, seed: 42, score: 0.88 },
+    ],
+    hubPackages: [
+      { package_id: "pkg-1", scenario_name: "grid_ctf", source_run_id: "run-1", metadata: { promotion: "candidate" } },
+    ],
+    hubResults: [
+      { result_id: "result-1", run_id: "run-1", package_id: "pkg-1" },
+    ],
+    hubPromotions: [
+      { event_id: "promo-1", package_id: "pkg-1", source_run_id: "run-1", action: "promote" },
+    ],
+    sessions: [
+      {
+        sessionId: "sess-1",
+        goal: "Explore strategy branches",
+        status: "active",
+        activeBranchId: "alt",
+        turnCount: 2,
+        totalTokens: 33,
+        branches: [
+          { branchId: "main", label: "Main", parentTurnId: "", summary: "" },
+          { branchId: "alt", label: "Alternate", parentTurnId: "t1", summary: "try alternate route" },
+        ],
+        turns: [
+          { turnId: "t1", branchId: "main", parentTurnId: "", role: "competitor" },
+          { turnId: "t2", branchId: "alt", parentTurnId: "t1", role: "analyst" },
+        ],
+        events: [{ eventId: "e1", eventType: "branch_created" }],
+        branchPath: (branchId?: string) => (branchId === "alt" ? [{ turnId: "t1" }, { turnId: "t2" }] : [{ turnId: "t1" }]),
+      },
+    ],
     providerOpts: null,
     storeDbPath: null,
+    sessionStoreDbPath: null,
     simpleTaskArgs: null,
     loopOpts: null,
     loopInput: null,
@@ -99,6 +167,60 @@ function installAutoctxMock(): void {
 
       listRuns() {
         return mockState.runs;
+      }
+
+      getRun(runId: string) {
+        return mockState.runs.find((run) => run.id === runId || run.run_id === runId) ?? null;
+      }
+
+      getGenerations(runId: string) {
+        return mockState.generations.filter((generation) => generation.run_id === runId);
+      }
+
+      getScoreTrajectory(runId: string) {
+        return mockState.trajectory.filter((entry) => mockState.runs.some((run) => (run.run_id ?? run.id) === runId));
+      }
+
+      getAgentOutputs(runId: string, generationIndex: number) {
+        return mockState.agentOutputs.filter((output) => output.run_id === runId && output.generation_index === generationIndex);
+      }
+
+      getMatchesForRun(runId: string) {
+        return mockState.matches.filter((match) => match.run_id === runId);
+      }
+
+      listHubPackageRecords() {
+        return mockState.hubPackages;
+      }
+
+      listHubResultRecords() {
+        return mockState.hubResults;
+      }
+
+      listHubPromotionRecords() {
+        return mockState.hubPromotions;
+      }
+
+      close() {
+        // no-op in tests
+      }
+    }
+
+    class SessionStore {
+      constructor(dbPath: string) {
+        mockState.sessionStoreDbPath = dbPath;
+      }
+
+      load(sessionId: string) {
+        return mockState.sessions.find((session) => session.sessionId === sessionId) ?? null;
+      }
+
+      list(_status?: string, limit = 50) {
+        return mockState.sessions.slice(0, limit);
+      }
+
+      close() {
+        // no-op in tests
       }
     }
 
@@ -147,6 +269,7 @@ function installAutoctxMock(): void {
       SimpleAgentTask,
       ImprovementLoop,
       SQLiteStore,
+      SessionStore,
       enqueueTask: (
         _store: unknown,
         specName: string,
@@ -242,6 +365,7 @@ describe("SKILL.md", () => {
     expect(content).toContain("autocontext_judge");
     expect(content).toContain("autocontext_improve");
     expect(content).toContain("autocontext_status");
+    expect(content).toContain("autocontext_runtime_snapshot");
   });
 });
 
@@ -322,6 +446,12 @@ describe("Extension entry point", () => {
     expect(queue).toBeDefined();
   });
 
+  it("registers autocontext_runtime_snapshot tool", async () => {
+    const api = await loadExtension();
+    const runtime = api.tools.find((t) => t.name === "autocontext_runtime_snapshot");
+    expect(runtime).toBeDefined();
+  });
+
   it("registers /autocontext slash command", async () => {
     const api = await loadExtension();
     const cmd = api.commands.find((c) => c.name === "autocontext");
@@ -399,6 +529,17 @@ describe("Tool parameter schemas", () => {
     const props = (schema as { properties?: Record<string, unknown> }).properties;
     expect(props).toBeDefined();
     expect(props!.spec_name).toBeDefined();
+  });
+
+  it("autocontext_runtime_snapshot has run and session selectors", async () => {
+    const api = await loadExtension();
+    const runtime = api.tools.find((t) => t.name === "autocontext_runtime_snapshot")!;
+    const schema = runtime.parameters as Record<string, unknown>;
+    const props = (schema as { properties?: Record<string, unknown> }).properties;
+    expect(props).toBeDefined();
+    expect(props!.run_id).toBeDefined();
+    expect(props!.session_id).toBeDefined();
+    expect(props!.include_outputs).toBeDefined();
   });
 });
 
@@ -490,5 +631,59 @@ describe("Tool execution", () => {
         priority: 5,
       },
     });
+  });
+
+  it("autocontext_runtime_snapshot returns run artifacts, package records, session lineage, and recent events", async () => {
+    const eventDir = mkdtempSync(join(tmpdir(), "autoctx-pi-events-"));
+    mockState.settings.dbPath = "/workspace/runs/autocontext.sqlite3";
+    mockState.settings.eventStreamPath = join(eventDir, "events.ndjson");
+    writeFileSync(
+      mockState.settings.eventStreamPath,
+      [
+        JSON.stringify({ event: "run_started", payload: { run_id: "run-1" } }),
+        JSON.stringify({ event: "generation_completed", payload: { run_id: "run-1", generation_index: 1 } }),
+        JSON.stringify({ event: "run_started", payload: { run_id: "other" } }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const api = await loadExtension();
+    const runtime = api.tools.find((t) => t.name === "autocontext_runtime_snapshot");
+    expect(runtime).toBeDefined();
+
+    const result = await runtime!.execute("call-4", {
+      run_id: "run-1",
+      session_id: "sess-1",
+      include_outputs: true,
+      generation_index: 1,
+      limit: 5,
+    }) as {
+      content: Array<{ type: "text"; text: string }>;
+      details: Record<string, unknown>;
+    };
+
+    expect(mockState.storeDbPath).toBe("/workspace/runs/autocontext.sqlite3");
+    expect(mockState.sessionStoreDbPath).toBe("/workspace/runs/autocontext.sqlite3");
+    expect(result.content[0].text).toContain("run-1");
+    expect(result.content[0].text).toContain("sess-1");
+    expect(result.details.run).toEqual(expect.objectContaining({ run_id: "run-1" }));
+    expect(result.details.generations).toHaveLength(2);
+    expect(result.details.agentOutputs).toEqual([
+      expect.objectContaining({ role: "competitor", preview: "candidate strategy body" }),
+    ]);
+    expect(result.details.packages).toEqual([
+      expect.objectContaining({ package_id: "pkg-1", source_run_id: "run-1" }),
+    ]);
+    expect(result.details.session).toEqual(expect.objectContaining({
+      sessionId: "sess-1",
+      activeBranchId: "alt",
+      branches: [
+        expect.objectContaining({ branchId: "main", pathTurnIds: ["t1"] }),
+        expect.objectContaining({ branchId: "alt", pathTurnIds: ["t1", "t2"] }),
+      ],
+    }));
+    expect(result.details.events).toEqual([
+      expect.objectContaining({ event: "run_started" }),
+      expect.objectContaining({ event: "generation_completed" }),
+    ]);
   });
 });

--- a/pi/tests/extension.test.ts
+++ b/pi/tests/extension.test.ts
@@ -670,6 +670,7 @@ describe("Tool execution", () => {
     expect(result.details.agentOutputs).toEqual([
       expect.objectContaining({ role: "competitor", preview: "candidate strategy body" }),
     ]);
+    expect((result.details.agentOutputs as Array<Record<string, unknown>>)[0].content).toBeUndefined();
     expect(result.details.packages).toEqual([
       expect.objectContaining({ package_id: "pkg-1", source_run_id: "run-1" }),
     ]);

--- a/pi/tests/runtime-snapshot.test.ts
+++ b/pi/tests/runtime-snapshot.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.doUnmock("node:fs");
+  vi.resetModules();
+});
+
+describe("runtime snapshot", () => {
+  it("returns truncated output previews without full content payloads", async () => {
+    const { collectRuntimeSnapshot, parseRuntimeSnapshotRequest } = await import("../src/runtime-snapshot.js");
+    const fullContent = "x".repeat(700);
+    const request = parseRuntimeSnapshotRequest({
+      run_id: "run-1",
+      include_outputs: true,
+      generation_index: 1,
+    });
+
+    const snapshot = collectRuntimeSnapshot(
+      {},
+      {
+        getRun: () => ({ run_id: "run-1", status: "completed" }),
+        getGenerations: () => [{ run_id: "run-1", generation_index: 1, best_score: 0.91 }],
+        getAgentOutputs: () => [{ run_id: "run-1", generation_index: 1, role: "competitor", content: fullContent }],
+      },
+      { eventStreamPath: "/missing/events.ndjson" },
+      request,
+    );
+
+    const outputs = snapshot.agentOutputs as Array<Record<string, unknown>>;
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0]).toEqual(expect.objectContaining({
+      role: "competitor",
+      contentLength: 700,
+      preview: "x".repeat(500),
+    }));
+    expect(outputs[0]).not.toHaveProperty("content");
+  });
+
+  it("tails a bounded event-stream byte range instead of reading the whole stream", async () => {
+    const stream = Buffer.from(
+      [
+        JSON.stringify({ event: "run_started", payload: { run_id: "old" } }),
+        JSON.stringify({ event: "run_started", payload: { run_id: "run-1" } }),
+        JSON.stringify({ event: "generation_completed", payload: { run_id: "run-1", generation_index: 1 } }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const readLengths: number[] = [];
+    const closeSync = vi.fn();
+
+    vi.doMock("node:fs", () => ({
+      closeSync,
+      existsSync: () => true,
+      openSync: () => 12,
+      readFileSync: () => {
+        throw new Error("event snapshots must not read the entire stream");
+      },
+      readSync: (_fd: number, buffer: Buffer, offset: number, length: number, position: number) => {
+        readLengths.push(length);
+        const chunk = stream.subarray(position, position + length);
+        chunk.copy(buffer, offset);
+        return chunk.length;
+      },
+      statSync: () => ({ size: stream.length }),
+    }));
+
+    const { collectRuntimeSnapshot, parseRuntimeSnapshotRequest } = await import("../src/runtime-snapshot.js");
+    const snapshot = collectRuntimeSnapshot(
+      {},
+      {
+        getRun: () => ({ run_id: "run-1", status: "completed" }),
+        getGenerations: () => [],
+      },
+      { eventStreamPath: "/events.ndjson" },
+      parseRuntimeSnapshotRequest({ run_id: "run-1", limit: 2 }),
+    );
+
+    expect(readLengths.length).toBeGreaterThan(0);
+    expect(Math.max(...readLengths)).toBeLessThanOrEqual(64 * 1024);
+    expect(closeSync).toHaveBeenCalledWith(12);
+    expect(snapshot.events).toEqual([
+      expect.objectContaining({ event: "run_started" }),
+      expect.objectContaining({ event: "generation_completed" }),
+    ]);
+  });
+});

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -180,6 +180,18 @@ export { DirectAPIRuntime } from "./runtimes/index.js";
 export { ClaudeCLIRuntime, createSessionRuntime } from "./runtimes/index.js";
 export type { ClaudeCLIConfig } from "./runtimes/index.js";
 
+// Sessions
+export {
+  Session,
+  Branch,
+  Turn,
+  SessionStatus,
+  SessionEventType,
+  TurnOutcome,
+} from "./session/types.js";
+export type { SessionEvent } from "./session/types.js";
+export { SessionStore } from "./session/store.js";
+
 // Scenarios
 export type {
   AgentTaskSpec,

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -14,6 +14,8 @@ describe("package root exports", () => {
     expect(pkg.ModelStrategySelector).toBeDefined();
     expect(pkg.createMcpServer).toBeDefined();
     expect(pkg.MissionManager).toBeDefined();
+    expect(pkg.SessionStore).toBeDefined();
+    expect(pkg.Session).toBeDefined();
     expect(pkg.chooseModel).toBeDefined();
     expect(pkg.resolveBrowserSessionConfig).toBeDefined();
     expect(pkg.evaluateBrowserActionPolicy).toBeDefined();


### PR DESCRIPTION
## Summary
- add a Pi `autocontext_runtime_snapshot` tool backed by a small runtime-snapshot domain module
- expose run artifacts, score trajectory, matches, output previews, package/result/promotion records, branchable session lineage, and recent event-stream entries
- re-export TypeScript session APIs from the package root so Pi can inspect branchable sessions through `autoctx`
- document the new Pi tool in README, skill, status prompt, and changelog

## Testing
- `npm run lint` (pi)
- `npm test` (pi)
- `npm run lint` (ts)
- `npx vitest run tests/package-export-catalogs.test.ts tests/session-store.test.ts` (ts)
- `git diff --check`

## Notes
- Full `npm test` in `ts/` was attempted and failed on existing broad-suite timeout/API-key/assertion-budget failures unrelated to this slice, including campaign/mission CLI timeouts, cross-runtime fixture timeouts, hashing parity timeout, server-protocol API-key ordering, and the current type assertion budget of 966 > 950.
- Linear update was attempted, but the Linear MCP token/transport failed in this session.