### PR TITLE
Add TS persistent Pi RPC runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Python `autoctx export` now accepts `--format pi-package` to write a Pi-local package directory with `package.json`, `SKILL.md`, prompt markdown, and the original autocontext strategy payload.
 - Pi `pi-autocontext` now exposes `autocontext_runtime_snapshot` for run artifacts, package provenance, session branch lineage, and recent event-stream context.
+- TypeScript Pi RPC now supports an opt-in persistent runtime via `AUTOCONTEXT_PI_RPC_PERSISTENT=true`, reusing one `pi --mode rpc` subprocess for prompt and live-control calls.
 - TypeScript CLI now exposes `autoctx solve` as a DB-backed solve-on-demand entrypoint with `--description`, `--gens`, `--timeout`, and `--json` support (AC-619).
 - TypeScript solve now preserves Python-shaped controls for structured family overrides, per-generation runtime-budget enforcement, output file writing, and classifier fallback status metadata (AC-620).
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ All 11 families execute in both Python and TypeScript. TypeScript uses V8 isolat
 
 **LLM providers**: Anthropic (with `instrument_client` capture), OpenAI-compatible (vLLM, Ollama, Hermes), Gemini, Mistral, Groq, OpenRouter, Azure OpenAI, MLX (Apple Silicon), CUDA (Linux GPUs), Pi (CLI and RPC).
 
-**Agent runtimes**: Claude CLI, Codex CLI, Hermes CLI, Direct API, Pi variants, plus branch-aware session and persistent Pi RPC scaffolding for local agent loops.
+**Agent runtimes**: Claude CLI, Codex CLI, Hermes CLI, Direct API, Pi variants, plus branch-aware session and persistent Pi RPC for local agent loops.
 
 **Executors**: Local subprocess, SSH remote, Monty (`pydantic-monty` sandbox), PrimeIntellect remote sandbox.
 

--- a/docs/app-settings-contract.json
+++ b/docs/app-settings-contract.json
@@ -1399,6 +1399,15 @@
       ]
     },
     {
+      "python": "pi_rpc_persistent",
+      "typescript": "piRpcPersistent",
+      "type": "boolean",
+      "default": false,
+      "env": [
+        "AUTOCONTEXT_PI_RPC_PERSISTENT"
+      ]
+    },
+    {
       "python": "pi_timeout",
       "typescript": "piTimeout",
       "type": "number",

--- a/ts/README.md
+++ b/ts/README.md
@@ -227,6 +227,11 @@ autoctx run --scenario support_triage --json
 # Pi CLI
 AUTOCONTEXT_AGENT_PROVIDER=pi autoctx run --scenario support_triage --json
 
+# Pi RPC with one long-lived subprocess
+AUTOCONTEXT_AGENT_PROVIDER=pi-rpc \
+AUTOCONTEXT_PI_RPC_PERSISTENT=true \
+autoctx run --scenario support_triage --json
+
 # Deterministic (CI/testing)
 AUTOCONTEXT_AGENT_PROVIDER=deterministic autoctx run --scenario support_triage --json
 ```
@@ -251,6 +256,7 @@ Key environment variables:
 | `AUTOCONTEXT_ARCHITECT_API_KEY` / `AUTOCONTEXT_ARCHITECT_BASE_URL`   | Optional architect-specific credential/endpoint override    |
 | `AUTOCONTEXT_CLAUDE_MODEL`                                           | Claude CLI model alias override                             |
 | `AUTOCONTEXT_CODEX_MODEL`                                            | Codex CLI model override                                    |
+| `AUTOCONTEXT_PI_RPC_PERSISTENT`                                      | Reuse one Pi RPC subprocess across provider calls           |
 | `AUTOCONTEXT_CONFIG_DIR`                                             | Override where `login` / `whoami` read saved credentials    |
 | `AUTOCONTEXT_DB_PATH`                                                | SQLite database path                                        |
 

--- a/ts/src/agents/provider-bridge.ts
+++ b/ts/src/agents/provider-bridge.ts
@@ -24,6 +24,10 @@ export class RuntimeBridgeProvider implements LLMProvider {
     return this.#model;
   }
 
+  close(): void {
+    this.#runtime.close?.();
+  }
+
   async complete(opts: {
     systemPrompt: string;
     userPrompt: string;
@@ -70,6 +74,10 @@ export class RetryProvider implements LLMProvider {
 
   defaultModel(): string {
     return this.#inner.defaultModel();
+  }
+
+  close(): void {
+    this.#inner.close?.();
   }
 
   async complete(opts: {

--- a/ts/src/cli/benchmark-command-workflow.ts
+++ b/ts/src/cli/benchmark-command-workflow.ts
@@ -60,6 +60,7 @@ export async function executeBenchmarkCommandWorkflow<
     roleProviders: unknown;
     roleModels: unknown;
     defaultConfig: { providerType: string };
+    close?: () => void;
   },
   TStore extends { migrate(path: string): void; close(): void },
   TRunner extends { run(runId: string, numGens: number): Promise<{ bestScore: number }> },
@@ -88,40 +89,44 @@ export async function executeBenchmarkCommandWorkflow<
   const scores: number[] = [];
   const now = opts.now ?? Date.now;
 
-  for (let i = 0; i < opts.plan.numRuns; i++) {
-    const store = opts.createStore(opts.dbPath);
-    try {
-      store.migrate(opts.migrationsDir);
-      const scenario = new opts.ScenarioClass();
-      opts.assertFamilyContract(scenario, "game", `scenario '${opts.plan.scenarioName}'`);
-      const runner = opts.createRunner({
-        provider: opts.providerBundle.defaultProvider,
-        roleProviders: opts.providerBundle.roleProviders,
-        roleModels: opts.providerBundle.roleModels,
-        scenario,
-        store,
-        runsRoot: opts.runsRoot,
-        knowledgeRoot: opts.knowledgeRoot,
-      });
-      const result = await runner.run(`bench_${now()}_${i}`, opts.plan.numGens);
-      scores.push(result.bestScore);
-    } finally {
-      store.close();
+  try {
+    for (let i = 0; i < opts.plan.numRuns; i++) {
+      const store = opts.createStore(opts.dbPath);
+      try {
+        store.migrate(opts.migrationsDir);
+        const scenario = new opts.ScenarioClass();
+        opts.assertFamilyContract(scenario, "game", `scenario '${opts.plan.scenarioName}'`);
+        const runner = opts.createRunner({
+          provider: opts.providerBundle.defaultProvider,
+          roleProviders: opts.providerBundle.roleProviders,
+          roleModels: opts.providerBundle.roleModels,
+          scenario,
+          store,
+          runsRoot: opts.runsRoot,
+          knowledgeRoot: opts.knowledgeRoot,
+        });
+        const result = await runner.run(`bench_${now()}_${i}`, opts.plan.numGens);
+        scores.push(result.bestScore);
+      } finally {
+        store.close();
+      }
     }
+
+    const provider = opts.providerBundle.defaultConfig.providerType;
+    const synthetic = provider === "deterministic" ? true : undefined;
+
+    return {
+      scenario: opts.plan.scenarioName,
+      runs: opts.plan.numRuns,
+      generations: opts.plan.numGens,
+      scores,
+      meanBestScore: scores.reduce((sum, score) => sum + score, 0) / scores.length,
+      provider,
+      ...(synthetic ? { synthetic } : {}),
+    };
+  } finally {
+    opts.providerBundle.close?.();
   }
-
-  const provider = opts.providerBundle.defaultConfig.providerType;
-  const synthetic = provider === "deterministic" ? true : undefined;
-
-  return {
-    scenario: opts.plan.scenarioName,
-    runs: opts.plan.numRuns,
-    generations: opts.plan.numGens,
-    scores,
-    meanBestScore: scores.reduce((sum, score) => sum + score, 0) / scores.length,
-    provider,
-    ...(synthetic ? { synthetic } : {}),
-  };
 }
 
 export function renderBenchmarkResult(

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -24,6 +24,7 @@ import {
 } from "./command-registry.js";
 import { emitEngineResult } from "./emit-engine-result.js";
 import type { CampaignStatus } from "../mission/campaign.js";
+import type { LLMProvider } from "../types/index.js";
 
 function getMigrationsDir(): string {
   const thisDir = dirname(fileURLToPath(import.meta.url));
@@ -563,8 +564,9 @@ async function cmdSolve(dbPath: string): Promise<void> {
   const store = new SQLiteStore(dbPath);
   store.migrate(getMigrationsDir());
 
+  let provider: LLMProvider | undefined;
   try {
-    const { provider } = await getProvider();
+    provider = (await getProvider()).provider;
     const summary = await executeSolveCommandWorkflow({
       manager: new SolveManager({
         provider,
@@ -581,8 +583,10 @@ async function cmdSolve(dbPath: string): Promise<void> {
     console.log(renderSolveCommandSummary(summary, plan.json));
   } catch (error) {
     console.error(errorMessage(error));
+    provider?.close?.();
     process.exit(1);
   } finally {
+    provider?.close?.();
     store.close();
   }
 }
@@ -716,38 +720,39 @@ async function cmdJudge(_dbPath: string): Promise<void> {
   }
 
   const { provider, model } = await getProvider();
-  const { LLMJudge } = await import("../judge/index.js");
-  const savedScenario = values.scenario
-    ? await loadSavedAgentTaskScenario(values.scenario)
-    : null;
-  if (values.scenario && !savedScenario) {
-    console.error(`Unknown saved custom scenario: ${values.scenario}`);
-    process.exit(1);
-  }
-
-  let plan;
   try {
-    plan = planJudgeCommand(values, savedScenario);
+    const { LLMJudge } = await import("../judge/index.js");
+    const savedScenario = values.scenario
+      ? await loadSavedAgentTaskScenario(values.scenario)
+      : null;
+    if (values.scenario && !savedScenario) {
+      throw new Error(`Unknown saved custom scenario: ${values.scenario}`);
+    }
+
+    const plan = planJudgeCommand(values, savedScenario);
+
+    const result = await executeJudgeCommandWorkflow({
+      plan,
+      provider,
+      model: model ?? undefined,
+      createJudge: (judgeOpts) => {
+        const provider = judgeOpts.provider as import("../types/index.js").LLMProvider;
+        return new LLMJudge({
+          provider,
+          model: judgeOpts.model ?? provider.defaultModel(),
+          rubric: judgeOpts.rubric,
+        });
+      },
+    });
+
+    console.log(renderJudgeResult(result));
   } catch (error) {
     console.error(errorMessage(error));
+    provider.close?.();
     process.exit(1);
+  } finally {
+    provider.close?.();
   }
-
-  const result = await executeJudgeCommandWorkflow({
-    plan,
-    provider,
-    model: model ?? undefined,
-    createJudge: (judgeOpts) => {
-      const provider = judgeOpts.provider as import("../types/index.js").LLMProvider;
-      return new LLMJudge({
-        provider,
-        model: judgeOpts.model ?? provider.defaultModel(),
-        rubric: judgeOpts.rubric,
-      });
-    },
-  });
-
-  console.log(renderJudgeResult(result));
 }
 
 async function cmdImprove(_dbPath: string): Promise<void> {
@@ -789,50 +794,51 @@ async function cmdImprove(_dbPath: string): Promise<void> {
   }
 
   const { provider, model } = await getProvider();
-  const { SimpleAgentTask } = await import("../execution/task-runner.js");
-  const { ImprovementLoop } = await import("../execution/improvement-loop.js");
-  const savedScenario = values.scenario
-    ? await loadSavedAgentTaskScenario(values.scenario)
-    : null;
-  if (values.scenario && !savedScenario) {
-    console.error(`Unknown saved custom scenario: ${values.scenario}`);
-    process.exit(1);
-  }
-
-  let plan;
   try {
-    plan = planImproveCommand(values, savedScenario, parsePositiveInteger);
+    const { SimpleAgentTask } = await import("../execution/task-runner.js");
+    const { ImprovementLoop } = await import("../execution/improvement-loop.js");
+    const savedScenario = values.scenario
+      ? await loadSavedAgentTaskScenario(values.scenario)
+      : null;
+    if (values.scenario && !savedScenario) {
+      throw new Error(`Unknown saved custom scenario: ${values.scenario}`);
+    }
+
+    const plan = planImproveCommand(values, savedScenario, parsePositiveInteger);
+
+    const result = await executeImproveCommandWorkflow({
+      plan,
+      provider,
+      model,
+      savedScenario,
+      createTask: (taskPrompt, rubric, taskProvider, taskModel, revisionPrompt, rlmConfig) =>
+        new SimpleAgentTask(
+          taskPrompt,
+          rubric,
+          taskProvider as import("../types/index.js").LLMProvider,
+          taskModel ?? undefined,
+          revisionPrompt ?? undefined,
+          rlmConfig,
+        ),
+      createLoop: (loopOpts) =>
+        new ImprovementLoop(
+          loopOpts as import("../execution/improvement-loop.js").ImprovementLoopOpts,
+        ),
+      now: () => performance.now(),
+    });
+
+    const rendered = renderImproveResult(result, plan.verbose);
+    for (const line of rendered.stderrLines) {
+      console.error(line);
+    }
+    console.log(rendered.stdout);
   } catch (error) {
     console.error(errorMessage(error));
+    provider.close?.();
     process.exit(1);
+  } finally {
+    provider.close?.();
   }
-
-  const result = await executeImproveCommandWorkflow({
-    plan,
-    provider,
-    model,
-    savedScenario,
-    createTask: (taskPrompt, rubric, taskProvider, taskModel, revisionPrompt, rlmConfig) =>
-      new SimpleAgentTask(
-        taskPrompt,
-        rubric,
-        taskProvider as import("../types/index.js").LLMProvider,
-        taskModel ?? undefined,
-        revisionPrompt ?? undefined,
-        rlmConfig,
-      ),
-    createLoop: (loopOpts) =>
-      new ImprovementLoop(
-        loopOpts as import("../execution/improvement-loop.js").ImprovementLoopOpts,
-      ),
-    now: () => performance.now(),
-  });
-
-  const rendered = renderImproveResult(result, plan.verbose);
-  for (const line of rendered.stderrLines) {
-    console.error(line);
-  }
-  console.log(rendered.stdout);
 }
 
 async function cmdRepl(_dbPath: string): Promise<void> {
@@ -870,31 +876,32 @@ async function cmdRepl(_dbPath: string): Promise<void> {
   }
 
   const { provider, model } = await getProvider();
-  const { runAgentTaskRlmSession } = await import("../rlm/agent-task.js");
-  const savedScenario = values.scenario
-    ? await loadSavedAgentTaskScenario(values.scenario)
-    : null;
-  if (values.scenario && !savedScenario) {
-    console.error(`Unknown saved custom scenario: ${values.scenario}`);
-    process.exit(1);
-  }
-  let plan;
   try {
-    plan = planReplCommand(values, savedScenario);
+    const { runAgentTaskRlmSession } = await import("../rlm/agent-task.js");
+    const savedScenario = values.scenario
+      ? await loadSavedAgentTaskScenario(values.scenario)
+      : null;
+    if (values.scenario && !savedScenario) {
+      throw new Error(`Unknown saved custom scenario: ${values.scenario}`);
+    }
+    const plan = planReplCommand(values, savedScenario);
+
+    const result = await runAgentTaskRlmSession(
+      buildReplSessionRequest({
+        provider,
+        model,
+        plan,
+      }),
+    );
+
+    console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error(errorMessage(error));
+    provider.close?.();
     process.exit(1);
+  } finally {
+    provider.close?.();
   }
-
-  const result = await runAgentTaskRlmSession(
-    buildReplSessionRequest({
-      provider,
-      model,
-      plan,
-    }),
-  );
-
-  console.log(JSON.stringify(result, null, 2));
 }
 
 async function cmdQueue(dbPath: string): Promise<void> {
@@ -1056,16 +1063,20 @@ async function cmdMcpServe(dbPath: string): Promise<void> {
   const { provider, model } = await getProvider();
   const settings = loadSettings();
 
-  await startServer(
-    buildMcpServeRequest({
-      store,
-      provider,
-      model,
-      dbPath,
-      runsRoot: resolve(settings.runsRoot),
-      knowledgeRoot: resolve(settings.knowledgeRoot),
-    }),
-  );
+  try {
+    await startServer(
+      buildMcpServeRequest({
+        store,
+        provider,
+        model,
+        dbPath,
+        runsRoot: resolve(settings.runsRoot),
+        knowledgeRoot: resolve(settings.knowledgeRoot),
+      }),
+    );
+  } finally {
+    provider.close?.();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1582,7 +1593,7 @@ async function cmdNewScenario(_dbPath: string): Promise<void> {
     process.exit(1);
   }
 
-  let provider;
+  let provider: LLMProvider;
   try {
     const result = await getProvider();
     provider = result.provider;
@@ -1592,12 +1603,12 @@ async function cmdNewScenario(_dbPath: string): Promise<void> {
     provider = new DeterministicProvider();
   }
 
-  const result = await createScenarioFromDescription(description, provider);
-
-  // Materialize the created scenario to disk (AC-433)
-  const { materializeScenario } = await import("../scenarios/materialize.js");
-  const settings = loadSettings();
   try {
+    const result = await createScenarioFromDescription(description, provider);
+
+    // Materialize the created scenario to disk (AC-433)
+    const { materializeScenario } = await import("../scenarios/materialize.js");
+    const settings = loadSettings();
     console.log(
       await executeCreatedScenarioMaterialization({
         created: result,
@@ -1608,7 +1619,10 @@ async function cmdNewScenario(_dbPath: string): Promise<void> {
     );
   } catch (error) {
     console.error(errorMessage(error));
+    provider.close?.();
     process.exit(1);
+  } finally {
+    provider.close?.();
   }
 }
 
@@ -2560,26 +2574,30 @@ async function cmdSimulate(): Promise<void> {
 
   const { provider } = await getProvider();
 
-  const result = await executeSimulateRunWorkflow({
-    description: plan.description!,
-    provider,
-    knowledgeRoot: resolve(settings.knowledgeRoot),
-    variables,
-    sweep,
-    runs: values.runs,
-    maxSteps: values["max-steps"],
-    saveAs: values["save-as"],
-    createEngine: (runProvider, knowledgeRoot) =>
-      new SimulationEngine(runProvider, knowledgeRoot),
-  });
+  try {
+    const result = await executeSimulateRunWorkflow({
+      description: plan.description!,
+      provider,
+      knowledgeRoot: resolve(settings.knowledgeRoot),
+      variables,
+      sweep,
+      runs: values.runs,
+      maxSteps: values["max-steps"],
+      saveAs: values["save-as"],
+      createEngine: (runProvider, knowledgeRoot) =>
+        new SimulationEngine(runProvider, knowledgeRoot),
+    });
 
-  emitEngineResult(result, {
-    json: !!values.json,
-    label: "Simulation",
-    renderSuccess: (r) => {
-      console.log(renderSimulationSuccess(r));
-    },
-  });
+    emitEngineResult(result, {
+      json: !!values.json,
+      label: "Simulation",
+      renderSuccess: (r) => {
+        console.log(renderSimulationSuccess(r));
+      },
+    });
+  } finally {
+    provider.close?.();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -2632,16 +2650,21 @@ async function cmdInvestigate(): Promise<void> {
     result = await executeInvestigateCommandWorkflow({ values, request, engine });
   } catch (error) {
     console.error(errorMessage(error));
+    provider.close?.();
     process.exit(1);
   }
 
-  emitEngineResult(result, {
-    json: !!values.json,
-    label: "Investigation",
-    renderSuccess: (r) => {
-      console.log(renderInvestigationSuccess(r));
-    },
-  });
+  try {
+    emitEngineResult(result, {
+      json: !!values.json,
+      label: "Investigation",
+      renderSuccess: (r) => {
+        console.log(renderInvestigationSuccess(r));
+      },
+    });
+  } finally {
+    provider.close?.();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/ts/src/cli/run-command-workflow.ts
+++ b/ts/src/cli/run-command-workflow.ts
@@ -109,6 +109,7 @@ export interface AgentTaskRunStore {
 export async function executeAgentTaskRunCommandWorkflow<TProviderBundle extends {
   defaultProvider: unknown;
   defaultConfig: { providerType: string };
+  close?: () => void;
 }>(opts: {
   plan: RunCommandPlan;
   providerBundle: TProviderBundle;
@@ -169,6 +170,7 @@ export async function executeAgentTaskRunCommandWorkflow<TProviderBundle extends
     throw error;
   } finally {
     store?.close();
+    opts.providerBundle.close?.();
   }
 }
 
@@ -219,6 +221,7 @@ export async function executeRunCommandWorkflow<
     roleProviders: unknown;
     roleModels: unknown;
     defaultConfig: { providerType: string };
+    close?: () => void;
   },
   TStore extends { migrate(path: string): void; close(): void },
   TRunner extends { run(runId: string, gens: number): Promise<{
@@ -309,6 +312,7 @@ export async function executeRunCommandWorkflow<
     };
   } finally {
     store.close();
+    opts.providerBundle.close?.();
   }
 }
 

--- a/ts/src/config/app-settings-schema.ts
+++ b/ts/src/config/app-settings-schema.ts
@@ -120,6 +120,7 @@ export const AppSettingsSchema = z.object({
   piRpcEndpoint: z.string().default(""),
   piRpcApiKey: z.string().default(""),
   piRpcSessionPersistence: z.boolean().default(true),
+  piRpcPersistent: z.boolean().default(false),
 
   // Browser exploration
   browserEnabled: z.boolean().default(false),

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -179,6 +179,14 @@ export type { AgentOutput, AgentRuntime } from "./runtimes/index.js";
 export { DirectAPIRuntime } from "./runtimes/index.js";
 export { ClaudeCLIRuntime, createSessionRuntime } from "./runtimes/index.js";
 export type { ClaudeCLIConfig } from "./runtimes/index.js";
+export {
+  PiCLIRuntime,
+  PiCLIConfig,
+  PiPersistentRPCRuntime,
+  PiRPCRuntime,
+  PiRPCConfig,
+} from "./runtimes/index.js";
+export type { PiCLIConfigOpts, PiRPCConfigOpts } from "./runtimes/index.js";
 
 // Sessions
 export {

--- a/ts/src/providers/index.ts
+++ b/ts/src/providers/index.ts
@@ -21,6 +21,7 @@ export {
 
 export {
   buildRoleProviderBundle,
+  closeProviderBundle,
   createConfiguredProvider,
   withRuntimeSettings,
   type GenerationRole,

--- a/ts/src/providers/provider-factory.ts
+++ b/ts/src/providers/provider-factory.ts
@@ -4,7 +4,7 @@ import { DeterministicProvider } from "./deterministic.js";
 import { ClaudeCLIRuntime } from "../runtimes/claude-cli.js";
 import { CodexCLIRuntime, CodexCLIConfig } from "../runtimes/codex-cli.js";
 import { PiCLIRuntime, PiCLIConfig } from "../runtimes/pi-cli.js";
-import { PiRPCRuntime, PiRPCConfig } from "../runtimes/pi-rpc.js";
+import { PiPersistentRPCRuntime, PiRPCRuntime, PiRPCConfig } from "../runtimes/pi-rpc.js";
 import { RuntimeBridgeProvider } from "../agents/provider-bridge.js";
 import { SUPPORTED_PROVIDER_TYPES } from "./supported-provider-types.js";
 
@@ -174,6 +174,7 @@ export interface CreateProviderOpts {
   piRpcEndpoint?: string;
   piRpcApiKey?: string;
   piRpcSessionPersistence?: boolean;
+  piRpcPersistent?: boolean;
 }
 
 export function createProvider(opts: CreateProviderOpts): LLMProvider {
@@ -262,11 +263,13 @@ export function createProvider(opts: CreateProviderOpts): LLMProvider {
 
   if (type === "pi-rpc") {
     const resolvedModel = opts.model ?? opts.piModel;
-    const runtime = new PiRPCRuntime(
+    const Runtime = opts.piRpcPersistent ? PiPersistentRPCRuntime : PiRPCRuntime;
+    const runtime = new Runtime(
       new PiRPCConfig({
         piCommand: opts.piCommand,
         model: resolvedModel,
         timeout: opts.piTimeout,
+        workspace: opts.piWorkspace,
         sessionPersistence: opts.piRpcSessionPersistence,
         noContextFiles: opts.piNoContextFiles,
       }),

--- a/ts/src/providers/role-provider-bundle.ts
+++ b/ts/src/providers/role-provider-bundle.ts
@@ -42,6 +42,7 @@ export interface RoleProviderSettings {
   piRpcEndpoint?: string;
   piRpcApiKey?: string;
   piRpcSessionPersistence?: boolean;
+  piRpcPersistent?: boolean;
 }
 
 export interface RoleProviderBundle {
@@ -76,6 +77,7 @@ export function withRuntimeSettings(
     piRpcEndpoint: settings.piRpcEndpoint,
     piRpcApiKey: settings.piRpcApiKey,
     piRpcSessionPersistence: settings.piRpcSessionPersistence,
+    piRpcPersistent: settings.piRpcPersistent,
   };
 }
 

--- a/ts/src/providers/role-provider-bundle.ts
+++ b/ts/src/providers/role-provider-bundle.ts
@@ -50,6 +50,22 @@ export interface RoleProviderBundle {
   defaultConfig: ProviderConfig;
   roleProviders: Partial<Record<GenerationRole, LLMProvider>>;
   roleModels: Partial<Record<GenerationRole, string>>;
+  close?: () => void;
+}
+
+export function closeProviderBundle(
+  bundle: Pick<RoleProviderBundle, "defaultProvider" | "roleProviders">,
+): void {
+  const closed = new Set<LLMProvider>();
+  const closeProvider = (provider: LLMProvider | undefined): void => {
+    if (!provider || closed.has(provider)) return;
+    closed.add(provider);
+    provider.close?.();
+  };
+  closeProvider(bundle.defaultProvider);
+  for (const provider of Object.values(bundle.roleProviders)) {
+    closeProvider(provider);
+  }
 }
 
 export function withRuntimeSettings(
@@ -173,16 +189,17 @@ export function buildRoleProviderBundle(
     }),
   };
 
-  return {
+  const roleProviders: Partial<Record<GenerationRole, LLMProvider>> = {
+    competitor: createProvider(withRuntimeSettings(roleConfigs.competitor, settings)),
+    analyst: createProvider(withRuntimeSettings(roleConfigs.analyst, settings)),
+    coach: createProvider(withRuntimeSettings(roleConfigs.coach, settings)),
+    architect: createProvider(withRuntimeSettings(roleConfigs.architect, settings)),
+    curator: createProvider(withRuntimeSettings(roleConfigs.curator, settings)),
+  };
+  const bundle: RoleProviderBundle = {
     defaultProvider,
     defaultConfig,
-    roleProviders: {
-      competitor: createProvider(withRuntimeSettings(roleConfigs.competitor, settings)),
-      analyst: createProvider(withRuntimeSettings(roleConfigs.analyst, settings)),
-      coach: createProvider(withRuntimeSettings(roleConfigs.coach, settings)),
-      architect: createProvider(withRuntimeSettings(roleConfigs.architect, settings)),
-      curator: createProvider(withRuntimeSettings(roleConfigs.curator, settings)),
-    },
+    roleProviders,
     roleModels: {
       competitor: roleConfigs.competitor.model,
       analyst: roleConfigs.analyst.model,
@@ -190,5 +207,9 @@ export function buildRoleProviderBundle(
       architect: roleConfigs.architect.model,
       curator: roleConfigs.curator.model,
     },
+  };
+  return {
+    ...bundle,
+    close: () => closeProviderBundle(bundle),
   };
 }

--- a/ts/src/runtimes/base.ts
+++ b/ts/src/runtimes/base.ts
@@ -26,5 +26,7 @@ export interface AgentRuntime {
     system?: string;
   }): Promise<AgentOutput>;
 
+  close?(): void;
+
   readonly name: string;
 }

--- a/ts/src/runtimes/index.ts
+++ b/ts/src/runtimes/index.ts
@@ -6,5 +6,5 @@ export { CodexCLIRuntime, CodexCLIConfig } from "./codex-cli.js";
 export type { CodexCLIConfigOpts } from "./codex-cli.js";
 export { PiCLIRuntime, PiCLIConfig } from "./pi-cli.js";
 export type { PiCLIConfigOpts } from "./pi-cli.js";
-export { PiRPCRuntime, PiRPCConfig } from "./pi-rpc.js";
+export { PiPersistentRPCRuntime, PiRPCRuntime, PiRPCConfig } from "./pi-rpc.js";
 export type { PiRPCConfigOpts } from "./pi-rpc.js";

--- a/ts/src/runtimes/pi-rpc.ts
+++ b/ts/src/runtimes/pi-rpc.ts
@@ -11,6 +11,7 @@ export interface PiRPCConfigOpts {
   piCommand?: string;
   model?: string;
   timeout?: number;
+  workspace?: string;
   sessionPersistence?: boolean;
   noContextFiles?: boolean;
   extraArgs?: string[];
@@ -20,6 +21,7 @@ export class PiRPCConfig {
   readonly piCommand: string;
   readonly model: string;
   readonly timeout: number;
+  readonly workspace: string;
   readonly sessionPersistence: boolean;
   readonly noContextFiles: boolean;
   readonly extraArgs: string[];
@@ -28,6 +30,7 @@ export class PiRPCConfig {
     this.piCommand = opts.piCommand ?? "pi";
     this.model = opts.model ?? "";
     this.timeout = opts.timeout ?? 120.0;
+    this.workspace = opts.workspace ?? "";
     this.sessionPersistence = opts.sessionPersistence ?? true;
     this.noContextFiles = opts.noContextFiles ?? false;
     this.extraArgs = [...(opts.extraArgs ?? [])];
@@ -36,8 +39,8 @@ export class PiRPCConfig {
 
 export class PiRPCRuntime {
   readonly name = "pi-rpc";
-  private config: PiRPCConfig;
-  private _currentSessionId: string | null = null;
+  protected config: PiRPCConfig;
+  protected _currentSessionId: string | null = null;
 
   constructor(config?: PiRPCConfig) {
     this.config = config ?? new PiRPCConfig();
@@ -71,7 +74,7 @@ export class PiRPCRuntime {
     });
   }
 
-  private buildArgs(): string[] {
+  protected buildArgs(): string[] {
     const args = ["--mode", "rpc"];
     if (this.config.model) {
       args.push("--model", this.config.model);
@@ -86,7 +89,7 @@ export class PiRPCRuntime {
     return args;
   }
 
-  private buildPromptCommand(prompt: string): { type: string; id: string; message: string } {
+  protected buildPromptCommand(prompt: string): { type: string; id: string; message: string } {
     return {
       type: "prompt",
       id: randomUUID().slice(0, 8),
@@ -98,6 +101,7 @@ export class PiRPCRuntime {
     return new Promise((resolve) => {
       const child = spawn(this.config.piCommand, args, {
         stdio: ["pipe", "pipe", "pipe"],
+        cwd: this.config.workspace || undefined,
       });
       let stdout = "";
       let stderr = "";
@@ -171,7 +175,7 @@ export class PiRPCRuntime {
     });
   }
 
-  private isTerminalRpcEvent(record: string): boolean {
+  protected isTerminalRpcEvent(record: string): boolean {
     try {
       const event = JSON.parse(record) as {
         type?: string;
@@ -184,7 +188,7 @@ export class PiRPCRuntime {
     }
   }
 
-  private parseOutput(raw: string, exitCode: number, stderr: string): AgentOutput {
+  protected parseOutput(raw: string, exitCode: number, stderr: string): AgentOutput {
     const trimmed = raw.trim();
     if (!trimmed) {
       return exitCode === 0
@@ -309,7 +313,7 @@ export class PiRPCRuntime {
         };
   }
 
-  private extractTextContent(content: unknown): string {
+  protected extractTextContent(content: unknown): string {
     if (typeof content === "string") {
       return content;
     }
@@ -328,7 +332,7 @@ export class PiRPCRuntime {
       .join("");
   }
 
-  private updateSessionId(event: {
+  protected updateSessionId(event: {
     data?: { session_id?: unknown; sessionId?: unknown };
     session_id?: unknown;
     sessionId?: unknown;
@@ -340,7 +344,7 @@ export class PiRPCRuntime {
     }
   }
 
-  private normalizeOutput(value: string | Buffer | undefined): string {
+  protected normalizeOutput(value: string | Buffer | undefined): string {
     if (typeof value === "string") {
       return value;
     }
@@ -348,5 +352,253 @@ export class PiRPCRuntime {
       return value.toString("utf-8");
     }
     return "";
+  }
+}
+
+type PiRpcCommand = Record<string, unknown> & { type: string; id?: string };
+type PiRpcEvent = Record<string, unknown> & { type?: string };
+
+export class PiPersistentRPCRuntime extends PiRPCRuntime {
+  private process: ReturnType<typeof spawn> | null = null;
+  private stdoutBuffer = "";
+  private stdoutLines: string[] = [];
+  private stderr = "";
+  private waiters: Array<() => void> = [];
+  private processError: Error | null = null;
+
+  close(): void {
+    const child = this.process;
+    if (!child) return;
+    if (child.stdin && child.stdin.writable && !child.stdin.destroyed) {
+      child.stdin.end();
+    }
+    if (!child.killed && child.exitCode === null) {
+      child.kill();
+    }
+    this.process = null;
+    this.notifyWaiters();
+  }
+
+  override async generate(opts: {
+    prompt: string;
+    system?: string;
+    schema?: Record<string, unknown>;
+  }): Promise<AgentOutput> {
+    void opts.schema;
+    const fullPrompt = opts.system ? `${opts.system}\n\n${opts.prompt}` : opts.prompt;
+    const command = this.withId(this.buildPromptCommand(fullPrompt));
+    try {
+      const lines = await this.collectUntil(command, (line) => this.isTerminalRpcEvent(line));
+      return this.parseOutput(lines.join(""), 0, this.stderr);
+    } catch (error) {
+      if (error instanceof Error && error.message === "timeout") {
+        this.close();
+        return { text: "", metadata: { error: "timeout" } };
+      }
+      this.close();
+      return { text: "", metadata: { error: error instanceof Error ? error.message : String(error) } };
+    }
+  }
+
+  async steer(message: string): Promise<Record<string, unknown>> {
+    return this.collectResponse({ type: "steer", message });
+  }
+
+  async followUp(message: string): Promise<Record<string, unknown>> {
+    return this.collectResponse({ type: "follow_up", message });
+  }
+
+  async abort(): Promise<Record<string, unknown>> {
+    return this.collectResponse({ type: "abort" });
+  }
+
+  async getState(): Promise<Record<string, unknown>> {
+    const response = await this.collectResponse({ type: "get_state" });
+    const { success: _success, ...state } = response;
+    return state;
+  }
+
+  async getMessages(): Promise<Array<Record<string, unknown>>> {
+    const response = await this.collectResponse({ type: "get_messages" });
+    return Array.isArray(response.messages)
+      ? response.messages.filter((message): message is Record<string, unknown> =>
+          Boolean(message) && typeof message === "object" && !Array.isArray(message),
+        )
+      : [];
+  }
+
+  private ensureProcess(): ReturnType<typeof spawn> {
+    if (this.process && this.process.exitCode === null && !this.process.killed) {
+      return this.process;
+    }
+    this.stdoutBuffer = "";
+    this.stdoutLines = [];
+    this.stderr = "";
+    this.processError = null;
+
+    const child = spawn(this.config.piCommand, this.buildArgs(), {
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd: this.config.workspace || undefined,
+    });
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+    child.stdout.on("data", (chunk: string | Buffer) => {
+      this.pushStdout(chunk);
+    });
+    child.stderr.on("data", (chunk: string | Buffer) => {
+      this.stderr += this.normalizeOutput(chunk);
+    });
+    child.on("error", (error) => {
+      this.processError = error instanceof Error ? error : new Error(String(error));
+      this.notifyWaiters();
+    });
+    child.on("close", () => {
+      if (this.stdoutBuffer) {
+        this.stdoutLines.push(this.stdoutBuffer);
+        this.stdoutBuffer = "";
+      }
+      this.notifyWaiters();
+    });
+    this.process = child;
+    return child;
+  }
+
+  private pushStdout(chunk: string | Buffer): void {
+    this.stdoutBuffer += this.normalizeOutput(chunk);
+    let newlineIndex = this.stdoutBuffer.indexOf("\n");
+    while (newlineIndex >= 0) {
+      const line = this.stdoutBuffer.slice(0, newlineIndex);
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      this.stdoutLines.push(`${line}\n`);
+      newlineIndex = this.stdoutBuffer.indexOf("\n");
+    }
+    this.notifyWaiters();
+  }
+
+  private writeCommand(command: PiRpcCommand): void {
+    const child = this.ensureProcess();
+    const stdin = child.stdin;
+    if (!stdin || !stdin.writable || stdin.destroyed) {
+      throw new Error("pi RPC stdin unavailable");
+    }
+    stdin.write(`${JSON.stringify(command)}\n`);
+  }
+
+  private async collectUntil(command: PiRpcCommand, terminal: (line: string) => boolean): Promise<string[]> {
+    this.writeCommand(command);
+    const deadline = Date.now() + this.config.timeout * 1000;
+    const lines: string[] = [];
+    while (true) {
+      const line = await this.nextLine(deadline);
+      if (line === null) break;
+      lines.push(line);
+      if (terminal(line)) break;
+    }
+    return lines;
+  }
+
+  private async collectResponse(command: PiRpcCommand): Promise<Record<string, unknown>> {
+    const resolved = this.withId(command);
+    const lines = await this.collectUntil(resolved, (line) => {
+      const event = this.loadEvent(line);
+      return Boolean(event && this.isResponseFor(event, resolved));
+    });
+
+    for (const line of [...lines].reverse()) {
+      const event = this.loadEvent(line);
+      if (!event || !this.isResponseFor(event, resolved)) continue;
+      if (event.success === false) {
+        return {
+          success: false,
+          error: event.error ?? "",
+          command: event.command ?? resolved.type,
+        };
+      }
+      const data = event.data;
+      return this.isRecord(data)
+        ? { success: true, ...data }
+        : { success: true, data };
+    }
+
+    return { success: false, error: "missing_rpc_response", command: resolved.type };
+  }
+
+  private async nextLine(deadline: number): Promise<string | null> {
+    if (this.stdoutLines.length > 0) {
+      return this.stdoutLines.shift() ?? null;
+    }
+    if (this.processError) {
+      throw this.processError;
+    }
+    if (this.process && this.process.exitCode !== null) {
+      return null;
+    }
+
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error("timeout");
+    }
+    await this.waitForOutput(remaining);
+    if (this.stdoutLines.length > 0) {
+      return this.stdoutLines.shift() ?? null;
+    }
+    if (this.processError) {
+      throw this.processError;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error("timeout");
+    }
+    return null;
+  }
+
+  private waitForOutput(timeoutMs: number): Promise<void> {
+    return new Promise((resolve) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        this.waiters = this.waiters.filter((waiter) => waiter !== notify);
+        resolve();
+      }, timeoutMs);
+      const notify = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      this.waiters.push(notify);
+    });
+  }
+
+  private notifyWaiters(): void {
+    const waiters = this.waiters.splice(0);
+    for (const waiter of waiters) {
+      waiter();
+    }
+  }
+
+  private withId<T extends PiRpcCommand>(command: T): T {
+    return command.id ? command : { ...command, id: randomUUID().slice(0, 8) };
+  }
+
+  private loadEvent(line: string): PiRpcEvent | null {
+    try {
+      const event: unknown = JSON.parse(line);
+      return this.isRecord(event) ? event : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private isRecord(value: unknown): value is PiRpcEvent {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  }
+
+  private isResponseFor(event: PiRpcEvent, command: PiRpcCommand): boolean {
+    if (event.type !== "response") return false;
+    if (typeof event.id === "string" && command.id) {
+      return event.id === command.id;
+    }
+    return event.command === command.type;
   }
 }

--- a/ts/src/runtimes/pi-rpc.ts
+++ b/ts/src/runtimes/pi-rpc.ts
@@ -365,6 +365,7 @@ export class PiPersistentRPCRuntime extends PiRPCRuntime {
   private stderr = "";
   private waiters: Array<() => void> = [];
   private processError: Error | null = null;
+  private processExitCode: number | null = null;
 
   close(): void {
     const child = this.process;
@@ -389,7 +390,7 @@ export class PiPersistentRPCRuntime extends PiRPCRuntime {
     const command = this.withId(this.buildPromptCommand(fullPrompt));
     try {
       const lines = await this.collectUntil(command, (line) => this.isTerminalRpcEvent(line));
-      return this.parseOutput(lines.join(""), 0, this.stderr);
+      return this.parseOutput(lines.join(""), this.processExitCode ?? 0, this.stderr);
     } catch (error) {
       if (error instanceof Error && error.message === "timeout") {
         this.close();
@@ -435,6 +436,7 @@ export class PiPersistentRPCRuntime extends PiRPCRuntime {
     this.stdoutLines = [];
     this.stderr = "";
     this.processError = null;
+    this.processExitCode = null;
 
     const child = spawn(this.config.piCommand, this.buildArgs(), {
       stdio: ["pipe", "pipe", "pipe"],
@@ -452,11 +454,12 @@ export class PiPersistentRPCRuntime extends PiRPCRuntime {
       this.processError = error instanceof Error ? error : new Error(String(error));
       this.notifyWaiters();
     });
-    child.on("close", () => {
+    child.on("close", (code, signal) => {
       if (this.stdoutBuffer) {
         this.stdoutLines.push(this.stdoutBuffer);
         this.stdoutBuffer = "";
       }
+      this.processExitCode = code ?? (signal ? 1 : 0);
       this.notifyWaiters();
     });
     this.process = child;
@@ -530,7 +533,7 @@ export class PiPersistentRPCRuntime extends PiRPCRuntime {
     if (this.processError) {
       throw this.processError;
     }
-    if (this.process && this.process.exitCode !== null) {
+    if (this.processExitCode !== null) {
       return null;
     }
 

--- a/ts/src/server/chat-agent-workflow.ts
+++ b/ts/src/server/chat-agent-workflow.ts
@@ -1,5 +1,4 @@
 import type { GenerationRole, RoleProviderBundle } from "../providers/index.js";
-import type { LLMProvider } from "../types/index.js";
 import type { RunManagerState } from "./run-manager.js";
 
 export function normalizeChatAgentRole(role: string): GenerationRole | undefined {
@@ -33,19 +32,24 @@ export async function executeChatAgentInteraction(opts: {
   message: string;
   state: RunManagerState;
   resolveProviderBundle: () => RoleProviderBundle;
-  buildProvider: (role?: GenerationRole) => LLMProvider;
 }): Promise<string> {
   const normalizedRole = normalizeChatAgentRole(opts.role);
   const bundle = opts.resolveProviderBundle();
-  const provider = opts.buildProvider(normalizedRole);
-  const response = await provider.complete({
-    systemPrompt: "",
-    model: normalizedRole ? bundle.roleModels[normalizedRole] : bundle.defaultConfig.model,
-    userPrompt: buildChatAgentUserPrompt({
-      role: opts.role,
-      message: opts.message,
-      state: opts.state,
-    }),
-  });
-  return response.text;
+  const provider = normalizedRole
+    ? bundle.roleProviders[normalizedRole] ?? bundle.defaultProvider
+    : bundle.defaultProvider;
+  try {
+    const response = await provider.complete({
+      systemPrompt: "",
+      model: normalizedRole ? bundle.roleModels[normalizedRole] : bundle.defaultConfig.model,
+      userPrompt: buildChatAgentUserPrompt({
+        role: opts.role,
+        message: opts.message,
+        state: opts.state,
+      }),
+    });
+    return response.text;
+  } finally {
+    bundle.close?.();
+  }
 }

--- a/ts/src/server/cockpit-consultation.ts
+++ b/ts/src/server/cockpit-consultation.ts
@@ -240,6 +240,8 @@ async function completeConsultation(
         body: { detail: `Consultation call failed: ${errorMessage(error)}` },
       },
     };
+  } finally {
+    provider.close?.();
   }
 }
 

--- a/ts/src/server/cockpit-consultation.ts
+++ b/ts/src/server/cockpit-consultation.ts
@@ -168,6 +168,7 @@ function createConsultationProvider(
         piNoContextFiles: settings.piNoContextFiles,
         piRpcApiKey: settings.piRpcApiKey,
         piRpcEndpoint: settings.piRpcEndpoint,
+        piRpcPersistent: settings.piRpcPersistent,
         piRpcSessionPersistence: settings.piRpcSessionPersistence,
         piTimeout: settings.piTimeout,
         piWorkspace: settings.piWorkspace,

--- a/ts/src/server/mission-action-workflow.ts
+++ b/ts/src/server/mission-action-workflow.ts
@@ -81,16 +81,20 @@ export async function executeMissionActionRequest(opts: {
       mission,
       buildMissionProvider: () => opts.runManager.buildMissionProvider(),
     });
-    return {
-      status: 200,
-      body: await deps.runMissionLoop(
-        opts.missionManager as never,
-        opts.missionId,
-        opts.runManager.getRunsRoot(),
-        opts.runManager.getKnowledgeRoot(),
-        runRequest,
-      ),
-    };
+    try {
+      return {
+        status: 200,
+        body: await deps.runMissionLoop(
+          opts.missionManager as never,
+          opts.missionId,
+          opts.runManager.getRunsRoot(),
+          opts.runManager.getKnowledgeRoot(),
+          runRequest,
+        ),
+      };
+    } finally {
+      runRequest.provider?.close?.();
+    }
   }
 
   if (opts.action === "pause") {

--- a/ts/src/server/run-manager.ts
+++ b/ts/src/server/run-manager.ts
@@ -219,7 +219,6 @@ export class RunManager {
       message,
       state: this.getState(),
       resolveProviderBundle: () => this.#resolveProviderBundle(),
-      buildProvider: (chatRole) => this.buildProvider(chatRole),
     });
   }
 
@@ -281,15 +280,21 @@ export class RunManager {
       const providerBundle = this.#resolveProviderBundle(settings);
       this.#runPromise = createManagedRunExecution({
         runId: id,
-        execute: () => executeAgentTaskCustomStartRun({
-          runId: id,
-          scenarioName: plan.scenarioName,
-          entry: plan.entry,
-          generations,
-          provider: providerBundle.defaultProvider,
-          controller: this.#controller,
-          events: this.#events,
-        }),
+        execute: async () => {
+          try {
+            await executeAgentTaskCustomStartRun({
+              runId: id,
+              scenarioName: plan.scenarioName,
+              entry: plan.entry,
+              generations,
+              provider: providerBundle.defaultProvider,
+              controller: this.#controller,
+              events: this.#events,
+            });
+          } finally {
+            providerBundle.close?.();
+          }
+        },
         events: this.#events,
         getPaused: () => this.#controller.isPaused(),
         setActive: (active) => {
@@ -328,17 +333,27 @@ export class RunManager {
   }
 
   async createScenario(description: string): Promise<ScenarioPreviewInfo> {
-    return this.#scenarioSession.createScenario({
-      description,
-      provider: this.buildProvider(),
-    });
+    const providerBundle = this.#resolveProviderBundle();
+    try {
+      return await this.#scenarioSession.createScenario({
+        description,
+        provider: providerBundle.defaultProvider,
+      });
+    } finally {
+      providerBundle.close?.();
+    }
   }
 
   async reviseScenario(feedback: string): Promise<ScenarioPreviewInfo> {
-    return this.#scenarioSession.reviseScenario({
-      feedback,
-      provider: this.buildProvider(),
-    });
+    const providerBundle = this.#resolveProviderBundle();
+    try {
+      return await this.#scenarioSession.reviseScenario({
+        feedback,
+        provider: providerBundle.defaultProvider,
+      });
+    } finally {
+      providerBundle.close?.();
+    }
   }
 
   cancelScenario(): void {

--- a/ts/src/server/run-start-workflow.ts
+++ b/ts/src/server/run-start-workflow.ts
@@ -185,6 +185,7 @@ export async function executeBuiltInGameStartRun(opts: {
     await runner.run(opts.runId, opts.generations);
   } finally {
     store.close();
+    opts.providerBundle.close?.();
   }
 }
 

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -50,6 +50,7 @@ import { loadSettings, type AppSettings } from "../config/index.js";
 import { SQLiteStore } from "../storage/index.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import { SolveManager } from "../knowledge/solver.js";
+import type { LLMProvider } from "../types/index.js";
 
 export interface InteractiveServerOpts {
   runManager: RunManager;
@@ -79,6 +80,7 @@ export class InteractiveServer {
   readonly #requestedPort: number;
   #solveManager: SolveManager | null = null;
   #solveStore: SQLiteStore | null = null;
+  #solveProvider: LLMProvider | null = null;
   #monitorEngine: MonitorEngine | null = null;
   #monitorStore: SQLiteStore | null = null;
   // Dashboard removed (AC-467) — server is API-only
@@ -1083,8 +1085,9 @@ export class InteractiveServer {
   #getSolveManager(): SolveManager {
     if (!this.#solveManager) {
       this.#solveStore = this.#openStore();
+      this.#solveProvider = this.#runManager.buildProvider();
       this.#solveManager = new SolveManager({
-        provider: this.#runManager.buildProvider(),
+        provider: this.#solveProvider,
         store: this.#solveStore,
         runsRoot: this.#runManager.getRunsRoot(),
         knowledgeRoot: this.#runManager.getKnowledgeRoot(),
@@ -1166,6 +1169,8 @@ export class InteractiveServer {
     this.#monitorStore = null;
     this.#solveStore?.close();
     this.#solveStore = null;
+    this.#solveProvider?.close?.();
+    this.#solveProvider = null;
     this.#solveManager = null;
   }
 

--- a/ts/src/types/index.ts
+++ b/ts/src/types/index.ts
@@ -35,6 +35,8 @@ export interface LLMProvider {
 
   defaultModel(): string;
 
+  close?(): void;
+
   readonly name: string;
 }
 

--- a/ts/tests/benchmark-command-workflow.test.ts
+++ b/ts/tests/benchmark-command-workflow.test.ts
@@ -39,6 +39,7 @@ describe("benchmark command workflow", () => {
   it("executes benchmark runs with migrated stores and runner inputs", async () => {
     const migrate = vi.fn();
     const close = vi.fn();
+    const closeProviderBundle = vi.fn();
     const run = vi
       .fn()
       .mockResolvedValueOnce({ bestScore: 0.75 })
@@ -65,6 +66,7 @@ describe("benchmark command workflow", () => {
         roleProviders: { judge: { name: "judge" } },
         roleModels: { judge: "claude" },
         defaultConfig: { providerType: "anthropic" },
+        close: closeProviderBundle,
       },
       ScenarioClass: FakeScenario,
       assertFamilyContract,
@@ -89,6 +91,7 @@ describe("benchmark command workflow", () => {
     expect(run).toHaveBeenNthCalledWith(1, "bench_12345_0", 3);
     expect(run).toHaveBeenNthCalledWith(2, "bench_12345_1", 3);
     expect(close).toHaveBeenCalledTimes(2);
+    expect(closeProviderBundle).toHaveBeenCalledOnce();
     expect(result).toEqual({
       scenario: "grid_ctf",
       runs: 2,
@@ -97,6 +100,45 @@ describe("benchmark command workflow", () => {
       meanBestScore: 0.8,
       provider: "anthropic",
     });
+  });
+
+  it("closes provider bundles when benchmark execution fails", async () => {
+    const closeProviderBundle = vi.fn();
+    const runError = new Error("benchmark failed");
+    const store = { migrate: vi.fn(), close: vi.fn() };
+    class FakeScenario {}
+
+    await expect(
+      executeBenchmarkCommandWorkflow({
+        dbPath: "/tmp/autocontext.db",
+        migrationsDir: "/tmp/migrations",
+        runsRoot: "/tmp/runs",
+        knowledgeRoot: "/tmp/knowledge",
+        plan: {
+          scenarioName: "grid_ctf",
+          numRuns: 1,
+          numGens: 3,
+          providerType: "anthropic",
+          json: false,
+        },
+        providerBundle: {
+          defaultProvider: { name: "provider" },
+          roleProviders: {},
+          roleModels: {},
+          defaultConfig: { providerType: "anthropic" },
+          close: closeProviderBundle,
+        },
+        ScenarioClass: FakeScenario,
+        assertFamilyContract: vi.fn(),
+        createStore: vi.fn(() => store),
+        createRunner: vi.fn(() => ({
+          run: vi.fn().mockRejectedValue(runError),
+        })),
+      }),
+    ).rejects.toThrow(runError);
+
+    expect(store.close).toHaveBeenCalledOnce();
+    expect(closeProviderBundle).toHaveBeenCalledOnce();
   });
 
   it("renders benchmark results as json", () => {

--- a/ts/tests/chat-agent-workflow.test.ts
+++ b/ts/tests/chat-agent-workflow.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { GenerationRole, RoleProviderBundle } from "../src/providers/index.js";
+import type { RoleProviderBundle } from "../src/providers/index.js";
 import {
   buildChatAgentUserPrompt,
   executeChatAgentInteraction,
@@ -42,6 +42,7 @@ describe("chat agent workflow", () => {
       model: "analyst-model",
       usage: {},
     }));
+    const closeProviderBundle = vi.fn();
     const bundle: RoleProviderBundle = {
       defaultProvider: { name: "default", defaultModel: () => "default-model", complete: vi.fn() },
       defaultConfig: { providerType: "deterministic", apiKey: "", baseUrl: "", model: "default-model" },
@@ -51,6 +52,7 @@ describe("chat agent workflow", () => {
       roleModels: {
         analyst: "analyst-model",
       },
+      close: closeProviderBundle,
     };
 
     const text = await executeChatAgentInteraction({
@@ -65,7 +67,6 @@ describe("chat agent workflow", () => {
         phase: null,
       },
       resolveProviderBundle: () => bundle,
-      buildProvider: (role?: GenerationRole) => role ? (bundle.roleProviders[role] ?? bundle.defaultProvider) : bundle.defaultProvider,
     });
 
     expect(text).toContain("## Findings");
@@ -73,6 +74,7 @@ describe("chat agent workflow", () => {
       model: "analyst-model",
       systemPrompt: "",
     }));
+    expect(closeProviderBundle).toHaveBeenCalledOnce();
   });
 
   it("falls back to the default model for unknown roles", async () => {
@@ -81,11 +83,13 @@ describe("chat agent workflow", () => {
       model: "default-model",
       usage: {},
     }));
+    const closeProviderBundle = vi.fn();
     const bundle: RoleProviderBundle = {
       defaultProvider: { name: "default", defaultModel: () => "default-model", complete },
       defaultConfig: { providerType: "deterministic", apiKey: "", baseUrl: "", model: "default-model" },
       roleProviders: {},
       roleModels: {},
+      close: closeProviderBundle,
     };
 
     await executeChatAgentInteraction({
@@ -100,11 +104,11 @@ describe("chat agent workflow", () => {
         phase: null,
       },
       resolveProviderBundle: () => bundle,
-      buildProvider: () => bundle.defaultProvider,
     });
 
     expect(complete).toHaveBeenCalledWith(expect.objectContaining({
       model: "default-model",
     }));
+    expect(closeProviderBundle).toHaveBeenCalledOnce();
   });
 });

--- a/ts/tests/mission-action-workflow.test.ts
+++ b/ts/tests/mission-action-workflow.test.ts
@@ -54,6 +54,7 @@ describe("mission action workflow", () => {
 
   it("runs mission loops with normalized options", async () => {
     const runMissionLoop = vi.fn(async () => ({ finalStatus: "completed", checkpointPath: "/tmp/checkpoint.json" }));
+    const closeProvider = vi.fn();
 
     await expect(executeMissionActionRequest({
       action: "run",
@@ -68,7 +69,7 @@ describe("mission action workflow", () => {
       runManager: {
         getRunsRoot: () => "/tmp/runs",
         getKnowledgeRoot: () => "/tmp/knowledge",
-        buildMissionProvider: () => ({ complete: vi.fn() }),
+        buildMissionProvider: () => ({ complete: vi.fn(), close: closeProvider }),
       },
       deps: {
         runMissionLoop,
@@ -87,6 +88,7 @@ describe("mission action workflow", () => {
       maxIterations: 2,
       stepDescription: "Advance once",
     });
+    expect(closeProvider).toHaveBeenCalledOnce();
   });
 
   it("applies pause/resume/cancel mission controls and returns checkpointed status", async () => {

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -16,6 +16,7 @@ describe("package root exports", () => {
     expect(pkg.MissionManager).toBeDefined();
     expect(pkg.SessionStore).toBeDefined();
     expect(pkg.Session).toBeDefined();
+    expect(pkg.PiPersistentRPCRuntime).toBeDefined();
     expect(pkg.chooseModel).toBeDefined();
     expect(pkg.resolveBrowserSessionConfig).toBeDefined();
     expect(pkg.evaluateBrowserActionPolicy).toBeDefined();

--- a/ts/tests/pi-runtime.test.ts
+++ b/ts/tests/pi-runtime.test.ts
@@ -570,6 +570,22 @@ describe("PiRPCRuntime", () => {
     expect(fakeProcess.child.kill).toHaveBeenCalledTimes(1);
   });
 
+  it("persistent pi-rpc reports early child exit as a nonzero error", async () => {
+    vi.resetModules();
+    const fakeProcess = createFakeSpawnProcess([], 1);
+    spawnMock.mockReturnValue(fakeProcess.child as never);
+
+    const { PiPersistentRPCRuntime, PiRPCConfig } = await import("../src/runtimes/pi-rpc.js");
+    const runtime = new PiPersistentRPCRuntime(new PiRPCConfig({ piCommand: "pi-rpc-local" }));
+    const result = await runtime.generate({ prompt: "first prompt" });
+
+    expect(result.text).toBe("");
+    expect(result.metadata).toEqual(expect.objectContaining({
+      error: "nonzero_exit",
+      exitCode: 1,
+    }));
+  });
+
   it("createConfiguredProvider uses persistent pi-rpc when configured", async () => {
     vi.resetModules();
     const fakeProcess = createInteractiveFakeSpawnProcess();
@@ -591,6 +607,27 @@ describe("PiRPCRuntime", () => {
     expect(first.text).toBe("answer:first prompt");
     expect(second.text).toBe("answer:second prompt");
     expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("persistent pi-rpc provider exposes close to stop the child process", async () => {
+    vi.resetModules();
+    const fakeProcess = createInteractiveFakeSpawnProcess();
+    spawnMock.mockReturnValue(fakeProcess.child as never);
+
+    const { createConfiguredProvider } = await import("../src/providers/index.js");
+    const { provider } = createConfiguredProvider(
+      { providerType: "pi-rpc" },
+      {
+        agentProvider: "pi-rpc",
+        piCommand: "pi-rpc-local",
+        piRpcPersistent: true,
+      },
+    );
+
+    await provider.complete({ systemPrompt: "", userPrompt: "first prompt" });
+    provider.close?.();
+
+    expect(fakeProcess.child.kill).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/ts/tests/pi-runtime.test.ts
+++ b/ts/tests/pi-runtime.test.ts
@@ -39,6 +39,29 @@ class FakeStream extends EventEmitter {
   }
 }
 
+class InteractiveFakeStream extends EventEmitter {
+  writable = true;
+  destroyed = false;
+  readonly chunks: string[] = [];
+
+  constructor(private readonly onWrite: (chunk: string) => void) {
+    super();
+  }
+
+  setEncoding(_encoding: string): void {}
+
+  write(chunk: string): boolean {
+    this.chunks.push(chunk);
+    this.onWrite(chunk);
+    return true;
+  }
+
+  end(): void {
+    this.writable = false;
+    this.emit("finish");
+  }
+}
+
 function createFakeSpawnProcess(stdoutLines: string[], closeCode = 0): {
   child: EventEmitter & {
     stdin: FakeStream;
@@ -85,6 +108,94 @@ function createFakeSpawnProcess(stdoutLines: string[], closeCode = 0): {
   return { child, stdin };
 }
 
+function createInteractiveFakeSpawnProcess(): {
+  child: EventEmitter & {
+    stdin: InteractiveFakeStream;
+    stdout: FakeStream;
+    stderr: FakeStream;
+    killed: boolean;
+    exitCode: number | null;
+    kill: () => void;
+  };
+  stdin: InteractiveFakeStream;
+} {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: InteractiveFakeStream;
+    stdout: FakeStream;
+    stderr: FakeStream;
+    killed: boolean;
+    exitCode: number | null;
+    kill: () => void;
+  };
+  let buffer = "";
+  const emitRecord = (record: Record<string, unknown>): void => {
+    queueMicrotask(() => {
+      child.stdout.emit("data", `${JSON.stringify(record)}\n`);
+    });
+  };
+  const handleCommand = (command: Record<string, unknown>): void => {
+    const id = command.id as string | undefined;
+    if (command.type === "prompt") {
+      emitRecord({ type: "response", command: "prompt", id, success: true });
+      emitRecord({
+        type: "agent_end",
+        messages: [{ role: "assistant", content: `answer:${String(command.message)}` }],
+        session_id: "sess-1",
+      });
+      return;
+    }
+    if (command.type === "steer") {
+      emitRecord({ type: "response", command: "steer", id, success: true, data: { accepted: true } });
+      return;
+    }
+    if (command.type === "follow_up") {
+      emitRecord({ type: "response", command: "follow_up", id, success: true, data: { queued: true } });
+      return;
+    }
+    if (command.type === "get_state") {
+      emitRecord({ type: "response", command: "get_state", id, success: true, data: { status: "idle", sessionId: "sess-1" } });
+      return;
+    }
+    if (command.type === "get_messages") {
+      emitRecord({
+        type: "response",
+        command: "get_messages",
+        id,
+        success: true,
+        data: { messages: [{ role: "assistant", content: "answer" }] },
+      });
+      return;
+    }
+    if (command.type === "abort") {
+      emitRecord({ type: "response", command: "abort", id, success: true, data: { aborted: true } });
+    }
+  };
+  const stdin = new InteractiveFakeStream((chunk) => {
+    buffer += chunk;
+    let newlineIndex = buffer.indexOf("\n");
+    while (newlineIndex >= 0) {
+      const line = buffer.slice(0, newlineIndex).trim();
+      buffer = buffer.slice(newlineIndex + 1);
+      if (line) {
+        handleCommand(JSON.parse(line) as Record<string, unknown>);
+      }
+      newlineIndex = buffer.indexOf("\n");
+    }
+  });
+  child.stdin = stdin;
+  child.stdout = new FakeStream();
+  child.stderr = new FakeStream();
+  child.killed = false;
+  child.exitCode = null;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    child.exitCode = -9;
+    child.emit("close", -9);
+  });
+
+  return { child, stdin };
+}
+
 // ---------------------------------------------------------------------------
 // Pi config in AppSettingsSchema
 // ---------------------------------------------------------------------------
@@ -106,6 +217,7 @@ describe("Pi config in AppSettingsSchema", () => {
     expect(settings.piRpcEndpoint).toBe("");
     expect(settings.piRpcApiKey).toBe("");
     expect(settings.piRpcSessionPersistence).toBe(true);
+    expect(settings.piRpcPersistent).toBe(false);
   });
 });
 
@@ -303,6 +415,11 @@ describe("PiRPCRuntime", () => {
     expect(PiRPCRuntime).toBeDefined();
   });
 
+  it("exports persistent Pi RPC runtime", async () => {
+    const { PiPersistentRPCRuntime } = await import("../src/runtimes/pi-rpc.js");
+    expect(PiPersistentRPCRuntime).toBeDefined();
+  });
+
   it("has correct defaults", async () => {
     const { PiRPCConfig } = await import("../src/runtimes/pi-rpc.js");
     const config = new PiRPCConfig();
@@ -422,6 +539,58 @@ describe("PiRPCRuntime", () => {
       ["--mode", "rpc", "--model", "manual-pi-model"],
       expect.any(Object),
     );
+  });
+
+  it("persistent pi-rpc reuses one subprocess for prompts and live control commands", async () => {
+    vi.resetModules();
+    const fakeProcess = createInteractiveFakeSpawnProcess();
+    spawnMock.mockReturnValue(fakeProcess.child as never);
+
+    const { PiPersistentRPCRuntime, PiRPCConfig } = await import("../src/runtimes/pi-rpc.js");
+    const runtime = new PiPersistentRPCRuntime(new PiRPCConfig({ piCommand: "pi-rpc-local" }));
+
+    const first = await runtime.generate({ prompt: "first prompt" });
+    const steer = await runtime.steer("prefer shorter answers");
+    const followUp = await runtime.followUp("next prompt");
+    const state = await runtime.getState();
+    const messages = await runtime.getMessages();
+    const abort = await runtime.abort();
+    const second = await runtime.generate({ prompt: "second prompt" });
+    runtime.close();
+
+    expect(first.text).toBe("answer:first prompt");
+    expect(first.metadata?.sessionId).toBe("sess-1");
+    expect(steer).toEqual(expect.objectContaining({ success: true, accepted: true }));
+    expect(followUp).toEqual(expect.objectContaining({ success: true, queued: true }));
+    expect(state).toEqual({ status: "idle", sessionId: "sess-1" });
+    expect(messages).toEqual([{ role: "assistant", content: "answer" }]);
+    expect(abort).toEqual(expect.objectContaining({ success: true, aborted: true }));
+    expect(second.text).toBe("answer:second prompt");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(fakeProcess.child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("createConfiguredProvider uses persistent pi-rpc when configured", async () => {
+    vi.resetModules();
+    const fakeProcess = createInteractiveFakeSpawnProcess();
+    spawnMock.mockReturnValue(fakeProcess.child as never);
+
+    const { createConfiguredProvider } = await import("../src/providers/index.js");
+    const { provider } = createConfiguredProvider(
+      { providerType: "pi-rpc" },
+      {
+        agentProvider: "pi-rpc",
+        piCommand: "pi-rpc-local",
+        piRpcPersistent: true,
+      },
+    );
+
+    const first = await provider.complete({ systemPrompt: "", userPrompt: "first prompt" });
+    const second = await provider.complete({ systemPrompt: "", userPrompt: "second prompt" });
+
+    expect(first.text).toBe("answer:first prompt");
+    expect(second.text).toBe("answer:second prompt");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/ts/tests/role-provider-bundle-workflow.test.ts
+++ b/ts/tests/role-provider-bundle-workflow.test.ts
@@ -1,10 +1,13 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { saveProviderCredentials } from "../src/config/index.js";
-import { buildRoleProviderBundle } from "../src/providers/role-provider-bundle.js";
+import {
+  buildRoleProviderBundle,
+  closeProviderBundle,
+} from "../src/providers/role-provider-bundle.js";
 
 const savedEnv: Record<string, string | undefined> = {};
 
@@ -75,5 +78,31 @@ describe("role provider bundle workflow", () => {
     } finally {
       rmSync(configDir, { recursive: true, force: true });
     }
+  });
+
+  it("closes each unique provider in a role bundle once", () => {
+    const sharedProvider = {
+      name: "shared",
+      defaultModel: () => "shared-model",
+      complete: vi.fn(),
+      close: vi.fn(),
+    };
+    const roleProvider = {
+      name: "role",
+      defaultModel: () => "role-model",
+      complete: vi.fn(),
+      close: vi.fn(),
+    };
+
+    closeProviderBundle({
+      defaultProvider: sharedProvider,
+      roleProviders: {
+        competitor: sharedProvider,
+        analyst: roleProvider,
+      },
+    });
+
+    expect(sharedProvider.close).toHaveBeenCalledOnce();
+    expect(roleProvider.close).toHaveBeenCalledOnce();
   });
 });

--- a/ts/tests/run-command-workflow.test.ts
+++ b/ts/tests/run-command-workflow.test.ts
@@ -90,6 +90,7 @@ describe("run command workflow", () => {
     class FakeScenario {}
     const migrate = vi.fn();
     const close = vi.fn();
+    const closeProviderBundle = vi.fn();
     const store = { migrate, close };
     const run = vi.fn().mockResolvedValue({
       runId: "run-custom",
@@ -137,6 +138,7 @@ describe("run command workflow", () => {
         roleProviders: { judge: { name: "judge" } },
         roleModels: { judge: "claude" },
         defaultConfig: { providerType: "deterministic" },
+        close: closeProviderBundle,
       },
       ScenarioClass: FakeScenario,
       assertFamilyContract,
@@ -179,6 +181,7 @@ describe("run command workflow", () => {
     });
     expect(run).toHaveBeenCalledWith("run-custom", 3);
     expect(close).toHaveBeenCalled();
+    expect(closeProviderBundle).toHaveBeenCalledOnce();
     expect(result).toEqual({
       runId: "run-custom",
       generationsCompleted: 3,
@@ -247,6 +250,7 @@ describe("run command workflow", () => {
   });
 
   it("persists saved agent-task runs and completed generations", async () => {
+    const closeProviderBundle = vi.fn();
     const store = {
       migrate: vi.fn(),
       createRun: vi.fn(),
@@ -267,6 +271,7 @@ describe("run command workflow", () => {
       providerBundle: {
         defaultProvider: { name: "provider" },
         defaultConfig: { providerType: "deterministic" },
+        close: closeProviderBundle,
       },
       spec: { taskPrompt: "Do work", judgeRubric: "Do it well" },
       executeAgentTaskSolve: vi.fn(async () => ({
@@ -299,6 +304,70 @@ describe("run command workflow", () => {
     });
     expect(store.updateRunStatus).toHaveBeenCalledWith("run-task", "completed");
     expect(store.close).toHaveBeenCalledOnce();
+    expect(closeProviderBundle).toHaveBeenCalledOnce();
+  });
+
+  it("closes provider bundles when run execution fails", async () => {
+    class FakeScenario {}
+    const closeProviderBundle = vi.fn();
+    const store = {
+      migrate: vi.fn(),
+      close: vi.fn(),
+    };
+    const runError = new Error("runner failed");
+    const createRunner = vi.fn(() => ({
+      run: vi.fn().mockRejectedValue(runError),
+    }));
+
+    await expect(
+      executeRunCommandWorkflow({
+        dbPath: "/tmp/autocontext.db",
+        migrationsDir: "/tmp/migrations",
+        runsRoot: "/tmp/runs",
+        knowledgeRoot: "/tmp/knowledge",
+        settings: {
+          maxRetries: 2,
+          backpressureMinDelta: 0.1,
+          playbookMaxVersions: 5,
+          contextBudgetTokens: 1024,
+          curatorEnabled: true,
+          curatorConsolidateEveryNGens: 2,
+          skillMaxLessons: 6,
+          deadEndTrackingEnabled: true,
+          deadEndMaxEntries: 10,
+          stagnationResetEnabled: true,
+          stagnationRollbackThreshold: 0.05,
+          stagnationPlateauWindow: 4,
+          stagnationPlateauEpsilon: 0.01,
+          stagnationDistillTopLessons: 3,
+          explorationMode: "balanced",
+          notifyWebhookUrl: "",
+          notifyOn: [],
+        },
+        plan: {
+          scenarioName: "grid_ctf",
+          gens: 3,
+          runId: "run-failed",
+          providerType: "deterministic",
+          matches: 4,
+          json: false,
+        },
+        providerBundle: {
+          defaultProvider: { name: "provider" },
+          roleProviders: {},
+          roleModels: {},
+          defaultConfig: { providerType: "deterministic" },
+          close: closeProviderBundle,
+        },
+        ScenarioClass: FakeScenario,
+        assertFamilyContract: vi.fn(),
+        createStore: vi.fn(() => store),
+        createRunner,
+      }),
+    ).rejects.toThrow(runError);
+
+    expect(store.close).toHaveBeenCalledOnce();
+    expect(closeProviderBundle).toHaveBeenCalledOnce();
   });
 
   it("renders json and human-readable run results", () => {

--- a/ts/tests/run-start-workflow.test.ts
+++ b/ts/tests/run-start-workflow.test.ts
@@ -134,11 +134,13 @@ describe("run start workflow", () => {
     const store = { migrate, close };
     const run = vi.fn(async () => ({ generationsCompleted: 2 }));
     const createRunner = vi.fn(() => ({ run }));
+    const closeProviderBundle = vi.fn();
     const bundle: RoleProviderBundle = {
       defaultProvider: { name: "test", defaultModel: () => "test", complete: vi.fn() },
       defaultConfig: { providerType: "deterministic", apiKey: "", baseUrl: "", model: "test" },
       roleProviders: {},
       roleModels: {},
+      close: closeProviderBundle,
     };
 
     const result = await executeBuiltInGameStartRun({
@@ -165,6 +167,7 @@ describe("run start workflow", () => {
     expect(migrate).toHaveBeenCalledWith("/tmp/migrations");
     expect(run).toHaveBeenCalledWith("run_1", 2);
     expect(close).toHaveBeenCalledOnce();
+    expect(closeProviderBundle).toHaveBeenCalledOnce();
     expect(result).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary
- add `PiPersistentRPCRuntime` for long-lived `pi --mode rpc` JSONL subprocess sessions
- support prompt generation plus `steer`, `followUp`, `abort`, `getState`, `getMessages`, and `close`
- wire `piRpcPersistent` / `AUTOCONTEXT_PI_RPC_PERSISTENT=true` through TypeScript settings, provider creation, role bundles, and cockpit consultation
- export the persistent Pi runtime from the public TS package root and update docs/settings contract

## Testing
- `npx vitest run tests/pi-runtime.test.ts` (red before implementation, green after)
- `npm run lint` (ts)
- `npx vitest run tests/pi-runtime.test.ts tests/app-settings-contract.test.ts tests/package-export-catalogs.test.ts` (ts)
- `uv run pytest tests/test_app_settings_contract.py tests/test_pi_provider_surface.py tests/test_pi_rpc.py` (autocontext)
- `git diff --check`

## Notes
- Linear issue creation was attempted, but the Linear connector returned a transport/deserialize error in this session.
- Local `npx vitest run tests/type-assertions.test.ts` still reports the existing budget mismatch `966 > 950`; this patch avoids adding new source-level type assertions.