### PR TITLE
Add TypeScript extension hook bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Python `autoctx export` now accepts `--format pi-package` to write a Pi-local package directory with `package.json`, `SKILL.md`, prompt markdown, and the original autocontext strategy payload.
-- Python autocontext now exposes a Pi-shaped extension hook bus via `AUTOCONTEXT_EXTENSIONS`, covering run/generation lifecycle, context transforms, provider requests/responses, judge calls, and artifact writes.
+- Python and TypeScript autocontext now expose Pi-shaped extension hook buses via `AUTOCONTEXT_EXTENSIONS`, covering run/generation lifecycle, context transforms, semantic compaction, provider requests/responses, judge calls, and artifact writes.
 - Pi `pi-autocontext` now exposes `autocontext_runtime_snapshot` for run artifacts, package provenance, session branch lineage, and recent event-stream context.
 - TypeScript Pi RPC now supports an opt-in persistent runtime via `AUTOCONTEXT_PI_RPC_PERSISTENT=true`, reusing one `pi --mode rpc` subprocess for prompt and live-control calls.
 - TypeScript CLI now exposes `autoctx solve` as a DB-backed solve-on-demand entrypoint with `--description`, `--gens`, `--timeout`, and `--json` support (AC-619).

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ All 11 families execute in both Python and TypeScript. TypeScript uses V8 isolat
 
 **Executors**: Local subprocess, SSH remote, Monty (`pydantic-monty` sandbox), PrimeIntellect remote sandbox.
 
-**Harness profiles and hooks**: The Python control plane supports a Pi-shaped lean profile that caps prompt context during generation and exports a minimal tool-affordance allowlist for agent surfaces that enforce tool gating. Semantic prompt compactions are recorded as Pi-shaped JSONL entries under each run; the TypeScript package now includes a mirrored deterministic prompt compactor plus `ArtifactStore` ledger read/write/latest APIs for standalone npm runs. Python extensions can register hooks around context assembly, provider calls, judge calls, artifact writes, and run lifecycle events with `AUTOCONTEXT_EXTENSIONS`.
+**Harness profiles and hooks**: The Python control plane supports a Pi-shaped lean profile that caps prompt context during generation and exports a minimal tool-affordance allowlist for agent surfaces that enforce tool gating. Semantic prompt compactions are recorded as Pi-shaped JSONL entries under each run; the TypeScript package now includes a mirrored deterministic prompt compactor plus `ArtifactStore` ledger read/write/latest APIs for standalone npm runs. Python and TypeScript runs can load `AUTOCONTEXT_EXTENSIONS`; Python extensions are Python modules, while TypeScript extensions are JavaScript/ESM modules that register hooks around context assembly, semantic compaction, provider calls, judge calls, artifact writes, and run lifecycle events.
 
 A deterministic offline provider exists for the test suite. Configuration matrix: [`.env.example`](.env.example) and [docs/concept-model.md](docs/concept-model.md).
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -259,7 +259,7 @@ The Python package includes a thin Chrome CDP backend that attaches to an existi
 
 `AUTOCONTEXT_HARNESS_PROFILE=lean` resolves a Pi-shaped runtime profile: prompt context is capped by `AUTOCONTEXT_LEAN_CONTEXT_BUDGET_TOKENS`, hidden/implicit context defaults to zero, and generated tool context is replaced by the lean allowlist before agent execution. `AUTOCONTEXT_PI_RPC_PERSISTENT=true` opts Pi RPC into a long-lived subprocess; one-shot Pi RPC remains the default.
 
-`AUTOCONTEXT_EXTENSIONS` loads comma-separated Python modules or `.py` files that register Pi-shaped runtime hooks for context transforms, provider requests/responses, judge calls, artifact writes, and run/generation lifecycle events. See [docs/extensions.md](docs/extensions.md).
+`AUTOCONTEXT_EXTENSIONS` loads comma-separated extension modules that register Pi-shaped runtime hooks for context transforms, provider requests/responses, judge calls, artifact writes, and run/generation lifecycle events. Python runs load Python modules or `.py` files; TypeScript runs load JavaScript/ESM modules. See [docs/extensions.md](docs/extensions.md).
 
 Semantic prompt compactions are also persisted as Pi-shaped JSONL entries at
 `runs/<run_id>/compactions.jsonl`, including `summary`, `firstKeptEntryId`,

--- a/autocontext/docs/extensions.md
+++ b/autocontext/docs/extensions.md
@@ -1,12 +1,20 @@
 # Extension Hooks
 
-Autocontext exposes a small Python extension hook bus for Pi-shaped runtime customization. It is intentionally narrow: extensions receive structured events at stable runtime boundaries and may mutate the event payload, block the operation, or record side metadata.
+Autocontext exposes small Python and TypeScript extension hook buses for Pi-shaped runtime customization. They are intentionally narrow: extensions receive structured events at stable runtime boundaries and may mutate the event payload, block the operation, or record side metadata.
 
 Load extensions with `AUTOCONTEXT_EXTENSIONS`:
 
 ```bash
 AUTOCONTEXT_EXTENSIONS=my_project.autoctx_hooks,./local_hooks.py \
 uv run autoctx run --scenario grid_ctf --gens 3
+```
+
+For the TypeScript package, point `AUTOCONTEXT_EXTENSIONS` at JavaScript/ESM
+modules or `module:callable` targets:
+
+```bash
+AUTOCONTEXT_EXTENSIONS=./local-hooks.mjs \
+bunx autoctx run --scenario grid_ctf --gens 3
 ```
 
 Set `AUTOCONTEXT_EXTENSION_FAIL_FAST=true` when hook failures should stop the run. By default, hook handler exceptions are recorded on the event and the run continues.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 ## Integrating External Agents
 
 - [External agent integration guide](../autocontext/docs/agent-integration.md)
-- [Python extension hooks](../autocontext/docs/extensions.md)
+- [Python and TypeScript extension hooks](../autocontext/docs/extensions.md)
 - [Sandbox and executor notes](../autocontext/docs/sandbox.md)
 - [MLX host training notes](../autocontext/docs/mlx-training.md)
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -28,6 +28,25 @@ then record Pi-shaped entries via the `ArtifactStore` ledger contract:
 `latestCompactionEntryId()` persist/read `runs/<run_id>/compactions.jsonl` plus
 the `compactions.latest` sidecar for cheap latest-entry lookups.
 
+The TypeScript runtime also mirrors the Python extension hook bus for
+standalone npm runs. Set `AUTOCONTEXT_EXTENSIONS` to a comma-separated list of
+JavaScript/ESM modules or `module:callable` targets, and set
+`AUTOCONTEXT_EXTENSION_FAIL_FAST=true` when hook errors should stop the run.
+Extensions receive ordered Pi-shaped events for run lifecycle, context
+assembly, semantic compaction, provider calls, judge calls, and artifact
+writes:
+
+```js
+export function register(api) {
+  api.on("context", (event) => ({
+    roles: {
+      ...event.payload.roles,
+      competitor: `${event.payload.roles.competitor}\nPrefer concise, testable strategies.`,
+    },
+  }));
+}
+```
+
 ## Install
 
 ```bash

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -432,6 +432,7 @@ async function cmdRun(dbPath: string): Promise<void> {
     await import("../scenarios/family-interfaces.js");
   const { loadSettings } = await import("../config/index.js");
   const { buildRoleProviderBundle } = await import("../providers/index.js");
+  const { initializeHookBus } = await import("../extensions/index.js");
   const { resolveRunnableScenarioClass } = await import("./runnable-scenario-resolution.js");
 
   const settings = loadSettings();
@@ -452,6 +453,10 @@ async function cmdRun(dbPath: string): Promise<void> {
     process.exit(1);
   }
 
+  const { hookBus, loadedExtensions } = await initializeHookBus({
+    extensions: settings.extensions,
+    failFast: settings.extensionFailFast,
+  });
   const providerBundle = buildRoleProviderBundle(
     settings,
     plan.providerType ? { providerType: plan.providerType } : {},
@@ -471,6 +476,7 @@ async function cmdRun(dbPath: string): Promise<void> {
         providerBundle,
         spec: savedAgentTask.spec,
         executeAgentTaskSolve: executeAgentTaskSolve as never,
+        hookBus,
         dbPath,
         migrationsDir: getMigrationsDir(),
         createStore: (runDbPath) => new SQLiteStore(runDbPath),
@@ -509,7 +515,11 @@ async function cmdRun(dbPath: string): Promise<void> {
     createStore: (runDbPath) => new SQLiteStore(runDbPath),
     createRunner: (runnerOpts) =>
       new GenerationRunner(
-        runnerOpts as import("../loop/generation-runner.js").GenerationRunnerOpts,
+        {
+          ...(runnerOpts as import("../loop/generation-runner.js").GenerationRunnerOpts),
+          hookBus,
+          loadedExtensions,
+        },
       ),
   });
 
@@ -719,6 +729,13 @@ async function cmdJudge(_dbPath: string): Promise<void> {
     }
   }
 
+  const { loadSettings } = await import("../config/index.js");
+  const { initializeHookBus } = await import("../extensions/index.js");
+  const settings = loadSettings();
+  const { hookBus } = await initializeHookBus({
+    extensions: settings.extensions,
+    failFast: settings.extensionFailFast,
+  });
   const { provider, model } = await getProvider();
   try {
     const { LLMJudge } = await import("../judge/index.js");
@@ -741,6 +758,7 @@ async function cmdJudge(_dbPath: string): Promise<void> {
           provider,
           model: judgeOpts.model ?? provider.defaultModel(),
           rubric: judgeOpts.rubric,
+          hookBus,
         });
       },
     });
@@ -1204,6 +1222,7 @@ async function cmdBenchmark(dbPath: string): Promise<void> {
     await import("../scenarios/family-interfaces.js");
   const { loadSettings } = await import("../config/index.js");
   const { buildRoleProviderBundle } = await import("../providers/index.js");
+  const { initializeHookBus } = await import("../extensions/index.js");
   const { resolveRunnableScenarioClass } = await import("./runnable-scenario-resolution.js");
 
   const plan = await planBenchmarkCommand(values, resolveScenarioOption);
@@ -1220,6 +1239,10 @@ async function cmdBenchmark(dbPath: string): Promise<void> {
     console.error(errorMessage(error));
     process.exit(1);
   }
+  const { hookBus, loadedExtensions } = await initializeHookBus({
+    extensions: settings.extensions,
+    failFast: settings.extensionFailFast,
+  });
   const providerBundle = buildRoleProviderBundle(
     settings,
     plan.providerType ? { providerType: plan.providerType } : {},
@@ -1234,7 +1257,11 @@ async function cmdBenchmark(dbPath: string): Promise<void> {
     ScenarioClass,
     assertFamilyContract,
     createStore: (benchmarkDbPath) => new SQLiteStore(benchmarkDbPath),
-    createRunner: (runnerOpts) => new GenerationRunner(runnerOpts),
+    createRunner: (runnerOpts) => new GenerationRunner({
+      ...runnerOpts,
+      hookBus,
+      loadedExtensions,
+    }),
   });
   const rendered = renderBenchmarkResult(result, plan.json);
   if (rendered.stderr) {

--- a/ts/src/cli/run-command-workflow.ts
+++ b/ts/src/cli/run-command-workflow.ts
@@ -1,3 +1,5 @@
+import type { HookBus } from "../extensions/index.js";
+
 export const RUN_HELP_TEXT = `autoctx run — Run the generation loop for a scenario
 
 Usage: autoctx run [options]
@@ -76,6 +78,7 @@ type AgentTaskSolveExecutor = (opts: {
   provider: unknown;
   created: { name: string; spec: Record<string, unknown> };
   generations: number;
+  hookBus?: HookBus | null;
 }) => Promise<{ progress: number; result: Record<string, unknown> }>;
 
 export interface AgentTaskRunStore {
@@ -115,6 +118,7 @@ export async function executeAgentTaskRunCommandWorkflow<TProviderBundle extends
   providerBundle: TProviderBundle;
   spec: Record<string, unknown>;
   executeAgentTaskSolve: AgentTaskSolveExecutor;
+  hookBus?: HookBus | null;
   dbPath?: string;
   migrationsDir?: string;
   createStore?: (dbPath: string) => AgentTaskRunStore;
@@ -138,6 +142,7 @@ export async function executeAgentTaskRunCommandWorkflow<TProviderBundle extends
         spec: opts.spec,
       },
       generations: opts.plan.gens,
+      ...(opts.hookBus ? { hookBus: opts.hookBus } : {}),
     });
     const bestScore = typeof result.result.best_score === "number" ? result.result.best_score : 0;
     const generationsCompleted = normalizeCompletedGenerations(result.progress);

--- a/ts/src/config/app-settings-schema.ts
+++ b/ts/src/config/app-settings-schema.ts
@@ -19,6 +19,8 @@ export const AppSettingsSchema = z.object({
   executorMode: z.string().default("local"),
   agentProvider: z.string().default("anthropic"),
   anthropicApiKey: z.string().nullable().default(null),
+  extensions: z.string().default(""),
+  extensionFailFast: z.boolean().default(false),
 
   // Models
   modelCompetitor: z.string().default("claude-sonnet-4-5-20250929"),

--- a/ts/src/execution/simple-agent-task-workflow.ts
+++ b/ts/src/execution/simple-agent-task-workflow.ts
@@ -1,5 +1,6 @@
 import { LLMJudge } from "../judge/llm-judge.js";
 import type { AgentTaskResult, LLMProvider } from "../types/index.js";
+import { completeWithProviderHooks, type HookBus } from "../extensions/index.js";
 import type { JudgeInterface } from "../judge/delegated.js";
 import type { RlmSessionRecord, RlmTaskConfig } from "../rlm/types.js";
 import { runAgentTaskRlmSession } from "../rlm/agent-task.js";
@@ -11,6 +12,7 @@ export interface EvaluateSimpleAgentTaskOpts {
   model: string;
   output: string;
   judgeOverride?: JudgeInterface;
+  hookBus?: HookBus | null;
   referenceContext?: string;
   requiredConcepts?: string[];
   calibrationExamples?: Array<Record<string, unknown>>;
@@ -24,6 +26,7 @@ export async function evaluateSimpleAgentTaskOutput(
     provider: opts.provider,
     model: opts.model,
     rubric: opts.rubric,
+    hookBus: opts.hookBus ?? null,
   });
   const result = await judge.evaluate({
     taskPrompt: opts.taskPrompt,
@@ -83,6 +86,7 @@ export async function generateSimpleAgentTaskOutput(opts: {
   rubric: string;
   rlmConfig: RlmTaskConfig | null;
   rlmSessions: RlmSessionRecord[];
+  hookBus?: HookBus | null;
   referenceContext?: string;
   requiredConcepts?: string[];
 }): Promise<string> {
@@ -101,7 +105,10 @@ export async function generateSimpleAgentTaskOutput(opts: {
     return rlmOutput;
   }
 
-  const result = await opts.provider.complete({
+  const result = await completeWithProviderHooks({
+    hookBus: opts.hookBus ?? null,
+    provider: opts.provider,
+    role: "agent_task_generate",
     systemPrompt: "You are a skilled writer and analyst. Complete the task precisely.",
     userPrompt: buildSimpleAgentTaskUserPrompt({
       taskPrompt: opts.taskPrompt,
@@ -159,6 +166,7 @@ export async function reviseSimpleAgentTaskOutput(opts: {
   judgeResult: AgentTaskResult;
   rlmConfig: RlmTaskConfig | null;
   rlmSessions: RlmSessionRecord[];
+  hookBus?: HookBus | null;
   referenceContext?: string;
   requiredConcepts?: string[];
 }): Promise<string> {
@@ -180,7 +188,10 @@ export async function reviseSimpleAgentTaskOutput(opts: {
     return rlmOutput;
   }
 
-  const result = await opts.provider.complete({
+  const result = await completeWithProviderHooks({
+    hookBus: opts.hookBus ?? null,
+    provider: opts.provider,
+    role: "agent_task_revise",
     systemPrompt:
       "You are revising content based on expert feedback. Improve the output. " +
       "IMPORTANT: Return ONLY the revised content. Do NOT include analysis, " +

--- a/ts/src/execution/task-runner.ts
+++ b/ts/src/execution/task-runner.ts
@@ -8,6 +8,7 @@ import type {
   AgentTaskInterface,
   AgentTaskResult,
 } from "../types/index.js";
+import type { HookBus } from "../extensions/index.js";
 import type { AppSettings } from "../config/index.js";
 import { type DelegatedResult, type JudgeInterface } from "../judge/delegated.js";
 import type { SQLiteStore, TaskQueueRow } from "../storage/index.js";
@@ -53,6 +54,7 @@ export class SimpleAgentTask implements AgentTaskInterface {
   #lastReferenceContext?: string;
   #lastRequiredConcepts?: string[];
   readonly #judgeOverride?: JudgeInterface;
+  readonly #hookBus: HookBus | null;
 
   constructor(
     taskPrompt: string,
@@ -62,6 +64,7 @@ export class SimpleAgentTask implements AgentTaskInterface {
     revisionPrompt?: string,
     rlmConfig?: Partial<RlmTaskConfig> | null,
     judgeOverride?: JudgeInterface,
+    hookBus?: HookBus | null,
   ) {
     this.#taskPrompt = taskPrompt;
     this.#rubric = rubric;
@@ -70,6 +73,7 @@ export class SimpleAgentTask implements AgentTaskInterface {
     this.#revisionPrompt = revisionPrompt;
     this.#rlmConfig = resolveRlmConfig(rlmConfig);
     this.#judgeOverride = judgeOverride;
+    this.#hookBus = hookBus ?? null;
     assertFamilyContract(this, "agent_task", "SimpleAgentTask");
   }
 
@@ -108,6 +112,7 @@ export class SimpleAgentTask implements AgentTaskInterface {
       model: this.#model,
       output,
       judgeOverride: this.#judgeOverride,
+      hookBus: this.#hookBus,
       referenceContext: opts?.referenceContext,
       requiredConcepts: opts?.requiredConcepts,
       calibrationExamples: opts?.calibrationExamples,
@@ -130,6 +135,7 @@ export class SimpleAgentTask implements AgentTaskInterface {
       rubric: this.#rubric,
       rlmConfig: this.#rlmConfig,
       rlmSessions: this.#rlmSessions,
+      hookBus: this.#hookBus,
       referenceContext: context?.referenceContext,
       requiredConcepts: context?.requiredConcepts,
     });
@@ -150,6 +156,7 @@ export class SimpleAgentTask implements AgentTaskInterface {
       judgeResult,
       rlmConfig: this.#rlmConfig,
       rlmSessions: this.#rlmSessions,
+      hookBus: this.#hookBus,
       referenceContext: this.#lastReferenceContext,
       requiredConcepts: this.#lastRequiredConcepts,
     });
@@ -165,6 +172,7 @@ export interface TaskRunnerOpts {
   pollInterval?: number;
   maxConsecutiveEmpty?: number;
   concurrency?: number;
+  hookBus?: HookBus | null;
 }
 
 export interface TaskRunnerFromSettingsOpts
@@ -184,6 +192,7 @@ export class TaskRunner {
   #pollInterval: number;
   #maxConsecutiveEmpty: number;
   #concurrency: number;
+  #hookBus: HookBus | null;
   #shutdown = false;
   #tasksProcessed = 0;
 
@@ -196,6 +205,7 @@ export class TaskRunner {
     this.#pollInterval = opts.pollInterval ?? 60;
     this.#maxConsecutiveEmpty = opts.maxConsecutiveEmpty ?? 0;
     this.#concurrency = Math.max(1, opts.concurrency ?? 1);
+    this.#hookBus = opts.hookBus ?? null;
   }
 
   get tasksProcessed(): number {
@@ -249,6 +259,7 @@ export class TaskRunner {
           revisionPrompt,
           rlm,
           delegatedJudge,
+          this.#hookBus,
         ),
       },
     });
@@ -280,5 +291,6 @@ export function createTaskRunnerFromSettings(opts: TaskRunnerFromSettingsOpts): 
     pollInterval: opts.pollInterval,
     maxConsecutiveEmpty: opts.maxConsecutiveEmpty,
     concurrency: opts.concurrency,
+    hookBus: opts.hookBus,
   });
 }

--- a/ts/src/extensions/hooks.ts
+++ b/ts/src/extensions/hooks.ts
@@ -1,0 +1,201 @@
+export enum HookEvents {
+  RUN_START = "run_start",
+  RUN_END = "run_end",
+  GENERATION_START = "generation_start",
+  GENERATION_END = "generation_end",
+  CONTEXT_COMPONENTS = "context_components",
+  CONTEXT = "context",
+  BEFORE_COMPACTION = "before_compaction",
+  AFTER_COMPACTION = "after_compaction",
+  BEFORE_PROVIDER_REQUEST = "before_provider_request",
+  AFTER_PROVIDER_RESPONSE = "after_provider_response",
+  BEFORE_JUDGE = "before_judge",
+  AFTER_JUDGE = "after_judge",
+  ARTIFACT_WRITE = "artifact_write",
+}
+
+export interface HookResultOptions {
+  payload?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  replacePayload?: boolean;
+  block?: boolean;
+  reason?: string;
+}
+
+export class HookResult {
+  readonly payload: Record<string, unknown> | null;
+  readonly metadata: Record<string, unknown> | null;
+  readonly replacePayload: boolean;
+  readonly block: boolean;
+  readonly reason: string;
+
+  constructor(opts: HookResultOptions = {}) {
+    this.payload = opts.payload ?? null;
+    this.metadata = opts.metadata ?? null;
+    this.replacePayload = opts.replacePayload ?? false;
+    this.block = opts.block ?? false;
+    this.reason = opts.reason ?? "";
+  }
+}
+
+export interface HookError {
+  eventName: string;
+  handler: string;
+  message: string;
+}
+
+export class HookEvent {
+  readonly name: string;
+  payload: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  errors: HookError[];
+  blocked: boolean;
+  blockReason: string;
+
+  constructor(
+    name: HookEvents | string,
+    payload: Record<string, unknown> = {},
+    metadata: Record<string, unknown> = {},
+  ) {
+    this.name = eventName(name);
+    this.payload = { ...payload };
+    this.metadata = { ...metadata };
+    this.errors = [];
+    this.blocked = false;
+    this.blockReason = "";
+  }
+
+  raiseIfBlocked(): void {
+    if (this.blocked) {
+      throw eventBlockError(this);
+    }
+  }
+}
+
+export type HookHandler = (event: HookEvent) => HookResult | Record<string, unknown> | undefined | null;
+
+export function eventName(value: HookEvents | string): string {
+  return typeof value === "string" ? value : String(value);
+}
+
+export function eventBlockError(event: HookEvent): Error {
+  const reason = event.blockReason ? `: ${event.blockReason}` : "";
+  return new Error(`extension hook blocked ${event.name}${reason}`);
+}
+
+export class HookBus {
+  readonly failFast: boolean;
+  readonly loadedExtensions: string[];
+  private handlers: Map<string, HookHandler[]>;
+
+  constructor(opts: { failFast?: boolean; loadedExtensions?: string[] } = {}) {
+    this.failFast = opts.failFast ?? false;
+    this.loadedExtensions = [...(opts.loadedExtensions ?? [])];
+    this.handlers = new Map();
+  }
+
+  on(name: HookEvents | string, handler: HookHandler): HookHandler {
+    const normalized = eventName(name);
+    const handlers = this.handlers.get(normalized) ?? [];
+    handlers.push(handler);
+    this.handlers.set(normalized, handlers);
+    return handler;
+  }
+
+  hasHandlers(name: HookEvents | string): boolean {
+    const normalized = eventName(name);
+    return Boolean(this.handlers.get(normalized)?.length || this.handlers.get("*")?.length);
+  }
+
+  emit(
+    name: HookEvents | string,
+    payload: Record<string, unknown> = {},
+    opts: { metadata?: Record<string, unknown> } = {},
+  ): HookEvent {
+    const normalized = eventName(name);
+    const event = new HookEvent(normalized, payload, opts.metadata ?? {});
+    const handlers = [
+      ...(this.handlers.get(normalized) ?? []),
+      ...(this.handlers.get("*") ?? []),
+    ];
+
+    for (const handler of handlers) {
+      try {
+        const result = handler(event);
+        applyHookResult(event, result);
+      } catch (error) {
+        if (this.failFast) {
+          throw error;
+        }
+        event.errors.push({
+          eventName: normalized,
+          handler: handlerName(handler),
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+      if (event.blocked) {
+        break;
+      }
+    }
+    return event;
+  }
+}
+
+export class ExtensionAPI {
+  readonly bus: HookBus;
+
+  constructor(bus: HookBus) {
+    this.bus = bus;
+  }
+
+  on(name: HookEvents | string, handler: HookHandler): HookHandler;
+  on(name: HookEvents | string): (handler: HookHandler) => HookHandler;
+  on(
+    name: HookEvents | string,
+    handler?: HookHandler,
+  ): HookHandler | ((handler: HookHandler) => HookHandler) {
+    if (handler) {
+      return this.bus.on(name, handler);
+    }
+    return (actual: HookHandler) => this.bus.on(name, actual);
+  }
+
+  emit(
+    name: HookEvents | string,
+    payload: Record<string, unknown> = {},
+    opts: { metadata?: Record<string, unknown> } = {},
+  ): HookEvent {
+    return this.bus.emit(name, payload, opts);
+  }
+}
+
+function applyHookResult(
+  event: HookEvent,
+  result: HookResult | Record<string, unknown> | undefined | null,
+): void {
+  if (result === undefined || result === null) {
+    return;
+  }
+  if (result instanceof HookResult) {
+    if (result.payload) {
+      if (result.replacePayload) {
+        event.payload = { ...result.payload };
+      } else {
+        event.payload = { ...event.payload, ...result.payload };
+      }
+    }
+    if (result.metadata) {
+      event.metadata = { ...event.metadata, ...result.metadata };
+    }
+    if (result.block) {
+      event.blocked = true;
+      event.blockReason = result.reason;
+    }
+    return;
+  }
+  event.payload = { ...event.payload, ...result };
+}
+
+function handlerName(handler: HookHandler): string {
+  return handler.name || "anonymous_hook_handler";
+}

--- a/ts/src/extensions/index.ts
+++ b/ts/src/extensions/index.ts
@@ -1,0 +1,13 @@
+export {
+  ExtensionAPI,
+  HookBus,
+  HookEvent,
+  HookEvents,
+  HookResult,
+  eventBlockError,
+  eventName,
+} from "./hooks.js";
+export type { HookError, HookHandler, HookResultOptions } from "./hooks.js";
+export { initializeHookBus, loadExtensions } from "./loader.js";
+export { completeWithProviderHooks } from "./provider-hooks.js";
+export type { HookedProviderCompletionOpts } from "./provider-hooks.js";

--- a/ts/src/extensions/loader.ts
+++ b/ts/src/extensions/loader.ts
@@ -1,0 +1,125 @@
+import { existsSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { ExtensionAPI, HookBus } from "./hooks.js";
+
+type ExtensionCallable = (api?: ExtensionAPI) => unknown | Promise<unknown>;
+
+export async function loadExtensions(
+  refs: string | Iterable<string>,
+  bus: HookBus,
+): Promise<string[]> {
+  const loaded: string[] = [];
+  const api = new ExtensionAPI(bus);
+  for (const ref of splitRefs(refs)) {
+    const target = await loadTarget(ref);
+    await invokeExtension(target, api);
+    loaded.push(ref);
+    bus.loadedExtensions.push(ref);
+  }
+  return loaded;
+}
+
+export async function initializeHookBus(opts: {
+  extensions?: string | Iterable<string> | null;
+  failFast?: boolean;
+} = {}): Promise<{ hookBus: HookBus; loadedExtensions: string[] }> {
+  const hookBus = new HookBus({ failFast: opts.failFast ?? false });
+  const loadedExtensions = opts.extensions
+    ? await loadExtensions(opts.extensions, hookBus)
+    : [];
+  return { hookBus, loadedExtensions };
+}
+
+function splitRefs(refs: string | Iterable<string>): string[] {
+  if (typeof refs === "string") {
+    return refs.split(",").map((part) => part.trim()).filter(Boolean);
+  }
+  return [...refs].map((part) => String(part).trim()).filter(Boolean);
+}
+
+async function loadTarget(ref: string): Promise<unknown> {
+  const [moduleRef, attrPath] = splitModuleRef(ref);
+  const moduleValue = await loadModule(moduleRef);
+  if (attrPath) {
+    let target: unknown = moduleValue;
+    for (const part of attrPath.split(".")) {
+      if (!isRecord(target)) {
+        throw new Error(`extension target ${ref} could not resolve ${part}`);
+      }
+      target = target[part];
+    }
+    return target;
+  }
+  if (isRecord(moduleValue)) {
+    for (const name of ["register", "configure", "setup"]) {
+      const target = moduleValue[name];
+      if (isCallable(target)) {
+        return target;
+      }
+    }
+  }
+  return moduleValue;
+}
+
+function splitModuleRef(ref: string): [string, string] {
+  const colonIndex = ref.indexOf(":");
+  if (colonIndex < 0) {
+    return [ref, ""];
+  }
+  return [ref.slice(0, colonIndex), ref.slice(colonIndex + 1)];
+}
+
+async function loadModule(moduleRef: string): Promise<unknown> {
+  const pathLike = isPathLike(moduleRef);
+  const resolved = pathLike ? resolve(moduleRef) : moduleRef;
+  const specifier = pathLike ? pathToFileURL(resolved).href : moduleRef;
+  try {
+    return await import(specifier);
+  } catch (error) {
+    const label = pathLike ? resolved : moduleRef;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`could not load extension ${label}: ${message}`);
+  }
+}
+
+function isPathLike(ref: string): boolean {
+  if (ref.startsWith(".") || ref.startsWith("~") || isAbsolute(ref)) {
+    return true;
+  }
+  if (/\.[cm]?[jt]s$/.test(ref)) {
+    return true;
+  }
+  return existsSync(ref);
+}
+
+async function invokeExtension(target: unknown, api: ExtensionAPI): Promise<void> {
+  if (isRecord(target)) {
+    const register = target.register;
+    if (isCallable(register)) {
+      await callExtension(register, api);
+      return;
+    }
+  }
+  if (isCallable(target)) {
+    const result = await callExtension(target, api);
+    if (isRecord(result) && isCallable(result.register)) {
+      await callExtension(result.register, api);
+    }
+    return;
+  }
+  throw new Error("extension module must export register, configure, setup, or a callable target");
+}
+
+async function callExtension(func: ExtensionCallable, api: ExtensionAPI): Promise<unknown> {
+  return func.length === 0 ? await func() : await func(api);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isCallable(value: unknown): value is ExtensionCallable {
+  return typeof value === "function";
+}

--- a/ts/src/extensions/provider-hooks.ts
+++ b/ts/src/extensions/provider-hooks.ts
@@ -1,0 +1,106 @@
+import type { CompletionResult, LLMProvider } from "../types/index.js";
+import { HookEvents, type HookBus } from "./hooks.js";
+
+export interface HookedProviderCompletionOpts {
+  hookBus?: HookBus | null;
+  provider: LLMProvider;
+  role: string;
+  systemPrompt: string;
+  userPrompt: string;
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export async function completeWithProviderHooks(
+  opts: HookedProviderCompletionOpts,
+): Promise<CompletionResult> {
+  const request = {
+    provider: opts.provider.name,
+    role: opts.role,
+    model: opts.model,
+    systemPrompt: opts.systemPrompt,
+    userPrompt: opts.userPrompt,
+    temperature: opts.temperature,
+    maxTokens: opts.maxTokens,
+    ...(opts.metadata ?? {}),
+  };
+  const before = emitHook(opts.hookBus ?? null, HookEvents.BEFORE_PROVIDER_REQUEST, request);
+  const finalSystemPrompt = readString(before.payload.systemPrompt) ?? opts.systemPrompt;
+  const finalUserPrompt = readString(before.payload.userPrompt) ?? opts.userPrompt;
+  const finalModel = readString(before.payload.model) ?? opts.model;
+  const finalTemperature = readNumber(before.payload.temperature) ?? opts.temperature;
+  const finalMaxTokens = readNumber(before.payload.maxTokens) ?? opts.maxTokens;
+
+  const result = await opts.provider.complete({
+    systemPrompt: finalSystemPrompt,
+    userPrompt: finalUserPrompt,
+    model: finalModel,
+    temperature: finalTemperature,
+    maxTokens: finalMaxTokens,
+  });
+  const after = emitHook(opts.hookBus ?? null, HookEvents.AFTER_PROVIDER_RESPONSE, {
+    provider: opts.provider.name,
+    role: opts.role,
+    model: finalModel,
+    request: {
+      ...request,
+      systemPrompt: finalSystemPrompt,
+      userPrompt: finalUserPrompt,
+      model: finalModel,
+      temperature: finalTemperature,
+      maxTokens: finalMaxTokens,
+    },
+    text: result.text,
+    usage: result.usage,
+    costUsd: result.costUsd,
+    ...(opts.metadata ?? {}),
+  });
+
+  return {
+    ...result,
+    text: readString(after.payload.text) ?? result.text,
+    model: readString(after.payload.model) ?? result.model,
+    usage: readNumberRecord(after.payload.usage) ?? result.usage,
+    costUsd: readNumber(after.payload.costUsd) ?? result.costUsd,
+  };
+}
+
+function emitHook(
+  hookBus: HookBus | null,
+  name: HookEvents,
+  payload: Record<string, unknown>,
+): { payload: Record<string, unknown> } {
+  if (!hookBus?.hasHandlers(name)) {
+    return { payload };
+  }
+  const event = hookBus.emit(name, payload);
+  event.raiseIfBlocked();
+  return event;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readNumberRecord(value: unknown): Record<string, number> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const result: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "number" && Number.isFinite(raw)) {
+      result[key] = raw;
+    }
+  }
+  return result;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -109,6 +109,26 @@ export type {
   ValidationResult as ApiKeyValidationResult,
 } from "./config/credentials.js";
 
+// Extensions
+export {
+  ExtensionAPI,
+  HookBus,
+  HookEvent,
+  HookEvents,
+  HookResult,
+  completeWithProviderHooks,
+  eventBlockError,
+  eventName,
+  initializeHookBus,
+  loadExtensions,
+} from "./extensions/index.js";
+export type {
+  HookedProviderCompletionOpts,
+  HookError,
+  HookHandler,
+  HookResultOptions,
+} from "./extensions/index.js";
+
 // Browser exploration
 export type {
   BrowserAction,

--- a/ts/src/judge/llm-judge.ts
+++ b/ts/src/judge/llm-judge.ts
@@ -1,4 +1,5 @@
 import type { LLMProvider, JudgeResult } from "../types/index.js";
+import { HookEvents, type HookBus } from "../extensions/index.js";
 import { parseJudgeResponse } from "./parse.js";
 import type { ParseMethod } from "./parse.js";
 import { checkRubricCoherence } from "./rubric-coherence.js";
@@ -12,6 +13,7 @@ export interface LLMJudgeOpts {
   samples?: number;
   temperature?: number;
   checkCoherence?: boolean;
+  hookBus?: HookBus | null;
 }
 
 export function detectGeneratedDimensions(
@@ -39,6 +41,7 @@ export class LLMJudge {
   #samples: number;
   #temperature: number;
   #rubricWarnings: string[];
+  #hookBus: HookBus | null;
 
   constructor(opts: LLMJudgeOpts) {
     this.#provider = opts.provider;
@@ -46,6 +49,7 @@ export class LLMJudge {
     this.rubric = opts.rubric;
     this.#samples = Math.max(1, opts.samples ?? 1);
     this.#temperature = opts.temperature ?? 0;
+    this.#hookBus = opts.hookBus ?? null;
 
     if (opts.checkCoherence) {
       const result = checkRubricCoherence(opts.rubric);
@@ -102,15 +106,56 @@ export class LLMJudge {
       let sampleParseMethod: ParseMethod = "none";
 
       for (let attempt = 0; attempt < 2; attempt++) {
-        const result = await this.#provider.complete({
+        const before = this.emitHook(HookEvents.BEFORE_JUDGE, {
+          provider: this.#provider.name,
+          model: this.model,
+          rubric: this.rubric,
+          samples: this.#samples,
+          sample: s + 1,
+          attempt: attempt + 1,
+          temperature: this.#temperature,
           systemPrompt,
           userPrompt,
-          model: this.model,
-          temperature: this.#temperature,
+          task_prompt: opts.taskPrompt,
+          agent_output: opts.agentOutput,
+          reference_context: opts.referenceContext,
+          required_concepts: opts.requiredConcepts,
+          calibration_examples: opts.calibrationExamples,
+          pinned_dimensions: opts.pinnedDimensions,
         });
-        rawResponses.push(result.text);
+        const finalSystemPrompt = readString(before.payload.systemPrompt) ?? systemPrompt;
+        const finalUserPrompt = readString(before.payload.userPrompt) ?? userPrompt;
+        const finalModel = readString(before.payload.model) ?? this.model;
+        const finalTemperature = readNumber(before.payload.temperature) ?? this.#temperature;
+        const result = await this.#provider.complete({
+          systemPrompt: finalSystemPrompt,
+          userPrompt: finalUserPrompt,
+          model: finalModel,
+          temperature: finalTemperature,
+        });
+        const after = this.emitHook(HookEvents.AFTER_JUDGE, {
+          provider: this.#provider.name,
+          model: finalModel,
+          rubric: this.rubric,
+          samples: this.#samples,
+          sample: s + 1,
+          attempt: attempt + 1,
+          request: {
+            systemPrompt: finalSystemPrompt,
+            userPrompt: finalUserPrompt,
+            model: finalModel,
+            temperature: finalTemperature,
+          },
+          response_text: result.text,
+          text: result.text,
+          usage: result.usage,
+          costUsd: result.costUsd,
+        });
+        const responseText =
+          readString(after.payload.response_text) ?? readString(after.payload.text) ?? result.text;
+        rawResponses.push(responseText);
 
-        const parsed = parseJudgeResponse(result.text);
+        const parsed = parseJudgeResponse(responseText);
         score = parsed.score;
         reasoning = parsed.reasoning;
         dims = parsed.dimensionScores;
@@ -225,4 +270,24 @@ export class LLMJudge {
 
     return parts.join("\n");
   }
+
+  private emitHook(
+    name: HookEvents,
+    payload: Record<string, unknown>,
+  ): { payload: Record<string, unknown> } {
+    if (!this.#hookBus?.hasHandlers(name)) {
+      return { payload };
+    }
+    const event = this.#hookBus.emit(name, payload);
+    event.raiseIfBlocked();
+    return event;
+  }
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }

--- a/ts/src/knowledge/agent-task-solve-execution.ts
+++ b/ts/src/knowledge/agent-task-solve-execution.ts
@@ -7,6 +7,7 @@ import type {
   ImprovementResult,
   LLMProvider,
 } from "../types/index.js";
+import { completeWithProviderHooks, type HookBus } from "../extensions/index.js";
 import type { SerializedSkillPackageDict } from "./package.js";
 import { buildAgentTaskSolvePackage } from "./solve-workflow.js";
 
@@ -107,6 +108,7 @@ export interface AgentTaskSolveExecutionDeps {
     spec: AgentTaskSpec;
     name: string;
     provider: LLMProvider;
+    hookBus?: HookBus | null;
   }) => AgentTaskSolveTask;
   createLoop?: (opts: {
     task: AgentTaskSolveTask;
@@ -140,6 +142,7 @@ export async function executeAgentTaskSolve(opts: {
   created: { name: string; spec: Record<string, unknown> };
   generations: number;
   generationTimeBudgetSeconds?: number | null;
+  hookBus?: HookBus | null;
   deps?: AgentTaskSolveExecutionDeps;
 }): Promise<AgentTaskSolveExecutionResult> {
   const spec = buildAgentTaskSolveSpec(
@@ -154,6 +157,7 @@ export async function executeAgentTaskSolve(opts: {
     spec,
     name: opts.created.name,
     provider: opts.provider,
+    hookBus: opts.hookBus ?? null,
   });
   const timeBudget = new SolveGenerationBudget({
     scenarioName: opts.created.name,
@@ -180,7 +184,10 @@ export async function executeAgentTaskSolve(opts: {
   }
 
   timeBudget.check("initial generation");
-  const initialOutput = await opts.provider.complete({
+  const initialOutput = await completeWithProviderHooks({
+    hookBus: opts.hookBus ?? null,
+    provider: opts.provider,
+    role: "agent_task_initial",
     systemPrompt: "You are a helpful assistant.",
     userPrompt: task.getTaskPrompt(initialState),
   });

--- a/ts/src/knowledge/artifact-store.ts
+++ b/ts/src/knowledge/artifact-store.ts
@@ -14,14 +14,29 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { HookEvents, type HookBus } from "../extensions/index.js";
 import { PlaybookManager, EMPTY_PLAYBOOK_SENTINEL } from "./playbook.js";
-import { CompactionLedgerStore } from "./compaction-ledger.js";
+import {
+  CompactionLedgerStore,
+  normalizeCompactionEntry,
+  serializeCompactionEntries,
+} from "./compaction-ledger.js";
 import type { CompactionEntry } from "./compaction-ledger.js";
 
 export interface ArtifactStoreOpts {
   runsRoot: string;
   knowledgeRoot: string;
   maxPlaybookVersions?: number;
+  hookBus?: HookBus | null;
+}
+
+interface ArtifactWriteRequest {
+  path: string;
+  format: "json" | "jsonl" | "markdown" | "text";
+  append: boolean;
+  payload?: Record<string, unknown>;
+  content?: string;
+  heading?: string;
 }
 
 export class ArtifactStore {
@@ -29,10 +44,12 @@ export class ArtifactStore {
   readonly knowledgeRoot: string;
   private playbookManager: PlaybookManager;
   private compactionLedger: CompactionLedgerStore;
+  private hookBus: HookBus | null;
 
   constructor(opts: ArtifactStoreOpts) {
     this.runsRoot = opts.runsRoot;
     this.knowledgeRoot = opts.knowledgeRoot;
+    this.hookBus = opts.hookBus ?? null;
     this.playbookManager = new PlaybookManager(
       opts.knowledgeRoot,
       opts.maxPlaybookVersions ?? 5,
@@ -53,7 +70,36 @@ export class ArtifactStore {
   }
 
   appendCompactionEntries(runId: string, entries: CompactionEntry[]): void {
-    this.compactionLedger.appendEntries(runId, entries);
+    if (entries.length === 0) return;
+    const normalizedEntries = entries.map(normalizeCompactionEntry);
+    const ledgerRequest = this.applyArtifactWriteHook({
+      path: this.compactionLedger.ledgerPath(runId),
+      format: "jsonl",
+      append: true,
+      payload: { entries: normalizedEntries },
+      content: serializeCompactionEntries(normalizedEntries),
+    });
+    const payloadEntries = readCompactionEntries(ledgerRequest.payload?.entries);
+    const finalEntries = payloadEntries ?? normalizedEntries;
+    const ledgerContent = payloadEntries
+      ? serializeCompactionEntries(finalEntries)
+      : ledgerRequest.content ?? serializeCompactionEntries(finalEntries);
+    mkdirSync(dirname(ledgerRequest.path), { recursive: true });
+    appendFileSync(ledgerRequest.path, ensureTrailingNewline(ledgerContent), "utf-8");
+
+    const latestEntryId = finalEntries.at(-1)?.id ?? entries.at(-1)!.id;
+    const latestRequest = this.applyArtifactWriteHook({
+      path: this.compactionLedger.latestEntryPath(runId),
+      format: "text",
+      append: false,
+      content: `${latestEntryId}\n`,
+    });
+    mkdirSync(dirname(latestRequest.path), { recursive: true });
+    writeFileSync(
+      latestRequest.path,
+      ensureTrailingNewline(latestRequest.content ?? `${latestEntryId}\n`),
+      "utf-8",
+    );
   }
 
   readCompactionEntries(runId: string, opts: { limit?: number } = {}): CompactionEntry[] {
@@ -65,22 +111,42 @@ export class ArtifactStore {
   }
 
   writeJson(path: string, payload: Record<string, unknown>): void {
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, JSON.stringify(payload, null, 2) + "\n", "utf-8");
+    const request = this.applyArtifactWriteHook({
+      path,
+      format: "json",
+      append: false,
+      payload,
+    });
+    const finalPayload = request.payload ?? payload;
+    mkdirSync(dirname(request.path), { recursive: true });
+    writeFileSync(request.path, JSON.stringify(finalPayload, null, 2) + "\n", "utf-8");
   }
 
   writeMarkdown(path: string, content: string): void {
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, content.trim() + "\n", "utf-8");
+    const request = this.applyArtifactWriteHook({
+      path,
+      format: "markdown",
+      append: false,
+      content,
+    });
+    mkdirSync(dirname(request.path), { recursive: true });
+    writeFileSync(request.path, (request.content ?? content).trim() + "\n", "utf-8");
   }
 
   appendMarkdown(path: string, content: string, heading: string): void {
-    mkdirSync(dirname(path), { recursive: true });
-    const chunk = `\n## ${heading}\n\n${content.trim()}\n`;
-    if (existsSync(path)) {
-      appendFileSync(path, chunk, "utf-8");
+    const request = this.applyArtifactWriteHook({
+      path,
+      format: "markdown",
+      append: true,
+      content,
+      heading,
+    });
+    mkdirSync(dirname(request.path), { recursive: true });
+    const chunk = `\n## ${request.heading ?? heading}\n\n${(request.content ?? content).trim()}\n`;
+    if (existsSync(request.path)) {
+      appendFileSync(request.path, chunk, "utf-8");
     } else {
-      writeFileSync(path, chunk.replace(/^\n/, ""), "utf-8");
+      writeFileSync(request.path, chunk.replace(/^\n/, ""), "utf-8");
     }
   }
 
@@ -89,7 +155,20 @@ export class ArtifactStore {
   }
 
   writePlaybook(scenarioName: string, content: string): void {
-    this.playbookManager.write(scenarioName, content);
+    const path = join(this.knowledgeRoot, scenarioName, "playbook.md");
+    const request = this.applyArtifactWriteHook({
+      path,
+      format: "markdown",
+      append: false,
+      content,
+    });
+    const finalContent = request.content ?? content;
+    if (resolve(request.path) === resolve(path)) {
+      this.playbookManager.write(scenarioName, finalContent);
+      return;
+    }
+    mkdirSync(dirname(request.path), { recursive: true });
+    writeFileSync(request.path, finalContent.trim() + "\n", "utf-8");
   }
 
   readDeadEnds(scenarioName: string): string {
@@ -99,12 +178,19 @@ export class ArtifactStore {
 
   appendDeadEnd(scenarioName: string, entry: string): void {
     const path = join(this.knowledgeRoot, scenarioName, "dead_ends.md");
-    mkdirSync(dirname(path), { recursive: true });
-    const chunk = `\n### Dead End\n\n${entry.trim()}\n`;
-    if (existsSync(path)) {
-      appendFileSync(path, chunk, "utf-8");
+    const request = this.applyArtifactWriteHook({
+      path,
+      format: "markdown",
+      append: true,
+      content: entry,
+      heading: "Dead End",
+    });
+    mkdirSync(dirname(request.path), { recursive: true });
+    const chunk = `\n### ${request.heading ?? "Dead End"}\n\n${(request.content ?? entry).trim()}\n`;
+    if (existsSync(request.path)) {
+      appendFileSync(request.path, chunk, "utf-8");
     } else {
-      writeFileSync(path, chunk.replace(/^\n/, ""), "utf-8");
+      writeFileSync(request.path, chunk.replace(/^\n/, ""), "utf-8");
     }
   }
 
@@ -151,6 +237,67 @@ export class ArtifactStore {
     return path;
   }
 
+  private applyArtifactWriteHook(request: ArtifactWriteRequest): ArtifactWriteRequest {
+    if (!this.hookBus?.hasHandlers(HookEvents.ARTIFACT_WRITE)) {
+      return request;
+    }
+    const event = this.hookBus.emit(HookEvents.ARTIFACT_WRITE, {
+      path: request.path,
+      format: request.format,
+      append: request.append,
+      payload: request.payload,
+      content: request.content,
+      heading: request.heading,
+    });
+    event.raiseIfBlocked();
+
+    const nextPath = readString(event.payload.path) ?? request.path;
+    this.validateArtifactHookPath(request.path, nextPath);
+    const result: ArtifactWriteRequest = {
+      path: nextPath,
+      format: request.format,
+      append: request.append,
+    };
+    const nextPayload = event.payload.payload;
+    if (isRecord(nextPayload)) {
+      result.payload = nextPayload;
+    } else if (request.payload !== undefined) {
+      result.payload = request.payload;
+    }
+    const nextContent = readString(event.payload.content);
+    if (nextContent !== null) {
+      result.content = nextContent;
+    } else if (request.content !== undefined) {
+      result.content = request.content;
+    }
+    const nextHeading = readString(event.payload.heading);
+    if (nextHeading !== null) {
+      result.heading = nextHeading;
+    } else if (request.heading !== undefined) {
+      result.heading = request.heading;
+    }
+    return result;
+  }
+
+  private validateArtifactHookPath(originalPath: string, nextPath: string): void {
+    if (resolve(originalPath) === resolve(nextPath)) {
+      return;
+    }
+    const originalRoot = this.managedRootForPath(originalPath);
+    if (!originalRoot || !pathIsInsideRoot(originalRoot, nextPath)) {
+      throw new Error("artifact_write path must stay within the original managed root");
+    }
+  }
+
+  private managedRootForPath(path: string): string | null {
+    for (const root of [this.runsRoot, this.knowledgeRoot]) {
+      if (pathIsInsideRoot(root, path)) {
+        return resolve(root);
+      }
+    }
+    return null;
+  }
+
   readSessionReports(scenarioName: string, limit = 3): string {
     const dir = join(this.knowledgeRoot, scenarioName, "session_reports");
     if (!existsSync(dir)) return "";
@@ -173,3 +320,45 @@ export class ArtifactStore {
 }
 
 export { EMPTY_PLAYBOOK_SENTINEL };
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function readCompactionEntries(value: unknown): CompactionEntry[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const entries: CompactionEntry[] = [];
+  for (const raw of value) {
+    if (!isRecord(raw) || typeof raw.id !== "string") {
+      return null;
+    }
+    entries.push({
+      type: raw.type === "compaction" ? "compaction" : undefined,
+      id: raw.id,
+      parentId: typeof raw.parentId === "string" ? raw.parentId : "",
+      timestamp: typeof raw.timestamp === "string" ? raw.timestamp : "",
+      summary: typeof raw.summary === "string" ? raw.summary : "",
+      firstKeptEntryId: typeof raw.firstKeptEntryId === "string" ? raw.firstKeptEntryId : "",
+      tokensBefore: typeof raw.tokensBefore === "number" && Number.isFinite(raw.tokensBefore)
+        ? raw.tokensBefore
+        : 0,
+      details: isRecord(raw.details) ? raw.details : {},
+    });
+  }
+  return entries;
+}
+
+function ensureTrailingNewline(content: string): string {
+  return content.endsWith("\n") ? content : `${content}\n`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function pathIsInsideRoot(root: string, path: string): boolean {
+  const relativePath = relative(resolve(root), resolve(path));
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}

--- a/ts/src/knowledge/compaction-ledger.ts
+++ b/ts/src/knowledge/compaction-ledger.ts
@@ -43,8 +43,7 @@ export class CompactionLedgerStore {
     if (entries.length === 0) return;
     const path = this.ledgerPath(runId);
     mkdirSync(dirname(path), { recursive: true });
-    const lines = entries.map((entry) => JSON.stringify(normalizeEntry(entry))).join("\n") + "\n";
-    appendFileSync(path, lines, "utf-8");
+    appendFileSync(path, serializeCompactionEntries(entries), "utf-8");
     writeFileSync(this.latestEntryPath(runId), `${entries.at(-1)!.id}\n`, "utf-8");
   }
 
@@ -96,7 +95,11 @@ export class CompactionLedgerStore {
   }
 }
 
-function normalizeEntry(entry: CompactionEntry): Required<CompactionEntry> {
+export function serializeCompactionEntries(entries: CompactionEntry[]): string {
+  return entries.map((entry) => JSON.stringify(normalizeCompactionEntry(entry))).join("\n") + "\n";
+}
+
+export function normalizeCompactionEntry(entry: CompactionEntry): Required<CompactionEntry> {
   return {
     type: "compaction",
     id: entry.id,

--- a/ts/src/loop/generation-runner.ts
+++ b/ts/src/loop/generation-runner.ts
@@ -10,7 +10,7 @@
  *   5. Persist to SQLite + artifacts
  */
 
-import type { LLMProvider } from "../types/index.js";
+import type { CompletionResult, LLMProvider } from "../types/index.js";
 import type { ScenarioInterface } from "../scenarios/game-interface.js";
 import type { SQLiteStore } from "../storage/index.js";
 import { TournamentRunner } from "../execution/tournament.js";
@@ -19,7 +19,11 @@ import { ArtifactStore, EMPTY_PLAYBOOK_SENTINEL } from "../knowledge/artifact-st
 import { PlaybookGuard, PLAYBOOK_MARKERS } from "../knowledge/playbook.js";
 import { ScoreTrajectoryBuilder } from "../knowledge/trajectory.js";
 import { generateSessionReport } from "../knowledge/session-report.js";
-import { compactPromptComponentsWithEntries } from "../knowledge/semantic-compaction.js";
+import {
+  compactPromptComponents,
+  compactionEntriesForComponents,
+} from "../knowledge/semantic-compaction.js";
+import { completeWithProviderHooks, HookEvents, HookBus } from "../extensions/index.js";
 import { ContextBudget } from "../prompts/context-budget.js";
 import { parseCuratorLessonResult, parseCuratorPlaybookDecision } from "../agents/curator-parser.js";
 import {
@@ -94,6 +98,8 @@ export interface GenerationRunnerOpts {
   controller?: LoopController;
   events?: EventStreamEmitter;
   generationTimeBudgetSeconds?: number | null;
+  hookBus?: HookBus | null;
+  loadedExtensions?: string[];
 }
 
 export interface RunResult {
@@ -132,6 +138,8 @@ export class GenerationRunner {
   #controller: LoopController | null;
   #events: EventStreamEmitter | null;
   #generationTimeBudgetSeconds: number | null;
+  #hookBus: HookBus;
+  #loadedExtensions: string[];
   #runState: GenerationRunState | null = null;
 
   constructor(opts: GenerationRunnerOpts) {
@@ -144,6 +152,7 @@ export class GenerationRunner {
       runsRoot: opts.runsRoot,
       knowledgeRoot: opts.knowledgeRoot,
       maxPlaybookVersions: opts.playbookMaxVersions,
+      hookBus: opts.hookBus ?? null,
     });
     this.#journal = new GenerationJournal({
       store: this.#store,
@@ -185,9 +194,17 @@ export class GenerationRunner {
     this.#controller = opts.controller ?? null;
     this.#events = opts.events ?? null;
     this.#generationTimeBudgetSeconds = opts.generationTimeBudgetSeconds ?? null;
+    this.#hookBus = opts.hookBus ?? new HookBus();
+    this.#loadedExtensions = opts.loadedExtensions ?? this.#hookBus.loadedExtensions;
   }
 
   async run(runId: string, generations: number): Promise<RunResult> {
+    this.emitHook(HookEvents.RUN_START, {
+      run_id: runId,
+      scenario: this.#scenario.name,
+      target_generations: generations,
+      loaded_extensions: this.#loadedExtensions,
+    });
     // Create run record
     this.#store.createRun(runId, this.#scenario.name, generations, "local");
     let orchestration = createGenerationLoopOrchestration({
@@ -207,48 +224,66 @@ export class GenerationRunner {
           budgetSeconds: this.#generationTimeBudgetSeconds,
         });
         generationBudget.check("generation start");
-        let lifecycle = await runGenerationLifecycleWorkflow(
-          createGenerationLifecycleWorkflow({
-            orchestration,
-            curatorEnabled: this.#curatorEnabled,
-            maxRetries: this.#maxRetries,
-            runAttempt: async ({ attemptOrchestration, generation }) => {
-              await this.#controller?.waitIfPaused();
-              const competitorPrompt = this.buildCompetitorPrompt(runId, generation);
-              return runGenerationAttemptWorkflow(
-                createGenerationAttemptWorkflow({
-                  attemptOrchestration,
-                  runId,
-                  generation,
-                  competitorPrompt,
-                  seedBase: this.#seedBase,
-                  matchesPerGeneration: this.#matchesPerGeneration,
-                  currentElo: this.#runState!.currentElo,
-                  executeCompetitor: () => this.completeRole("competitor", competitorPrompt),
-                  beforeTournament: async () => {
-                    await this.#controller?.waitIfPaused();
-                  },
-                  executeTournament: ({ strategy: nextStrategy, tournamentOptions }) =>
-                    new TournamentRunner(this.#scenario, tournamentOptions).run(nextStrategy),
-                  decideGate: ({ attemptOrchestration: currentAttemptOrchestration, tournamentResult }) => {
-                    const decision = this.#gate.evaluate(
-                      currentAttemptOrchestration.orchestration.cycleState.previousBestOverall,
-                      tournamentResult.bestScore,
-                      currentAttemptOrchestration.phaseState.attemptState.retryCount,
-                      this.#maxRetries,
-                    );
-                    const gateDecision = this.#controller?.takeGateOverride() as GenerationAttempt["gateDecision"] | null ?? decision.decision;
-                    return {
-                      gateDecision,
-                      delta: decision.delta,
-                      threshold: decision.threshold,
-                    };
-                  },
-                }),
-              );
-            },
-          }),
-        );
+        const activeGeneration = orchestration.cycleState.completedGenerations + 1;
+        this.emitHook(HookEvents.GENERATION_START, {
+          run_id: runId,
+          scenario: this.#scenario.name,
+          generation: activeGeneration,
+        });
+        let lifecycle: Awaited<ReturnType<typeof runGenerationLifecycleWorkflow>>;
+        try {
+          lifecycle = await runGenerationLifecycleWorkflow(
+            createGenerationLifecycleWorkflow({
+              orchestration,
+              curatorEnabled: this.#curatorEnabled,
+              maxRetries: this.#maxRetries,
+              runAttempt: async ({ attemptOrchestration, generation }) => {
+                await this.#controller?.waitIfPaused();
+                const competitorPrompt = this.buildCompetitorPrompt(runId, generation);
+                return runGenerationAttemptWorkflow(
+                  createGenerationAttemptWorkflow({
+                    attemptOrchestration,
+                    runId,
+                    generation,
+                    competitorPrompt,
+                    seedBase: this.#seedBase,
+                    matchesPerGeneration: this.#matchesPerGeneration,
+                    currentElo: this.#runState!.currentElo,
+                    executeCompetitor: () => this.completeRole("competitor", competitorPrompt),
+                    beforeTournament: async () => {
+                      await this.#controller?.waitIfPaused();
+                    },
+                    executeTournament: ({ strategy: nextStrategy, tournamentOptions }) =>
+                      new TournamentRunner(this.#scenario, tournamentOptions).run(nextStrategy),
+                    decideGate: ({ attemptOrchestration: currentAttemptOrchestration, tournamentResult }) => {
+                      const decision = this.#gate.evaluate(
+                        currentAttemptOrchestration.orchestration.cycleState.previousBestOverall,
+                        tournamentResult.bestScore,
+                        currentAttemptOrchestration.phaseState.attemptState.retryCount,
+                        this.#maxRetries,
+                      );
+                      const gateDecision = this.#controller?.takeGateOverride() as GenerationAttempt["gateDecision"] | null ?? decision.decision;
+                      return {
+                        gateDecision,
+                        delta: decision.delta,
+                        threshold: decision.threshold,
+                      };
+                    },
+                  }),
+                );
+              },
+            }),
+          );
+        } catch (error) {
+          this.emitHook(HookEvents.GENERATION_END, {
+            run_id: runId,
+            scenario: this.#scenario.name,
+            generation: activeGeneration,
+            status: "failed",
+            error: error instanceof Error ? error.message : String(error),
+          });
+          throw error;
+        }
         generationBudget.check("generation lifecycle");
         orchestration = lifecycle.orchestration;
         this.#runState = orchestration.runState;
@@ -271,6 +306,16 @@ export class GenerationRunner {
         lifecycle = completeGenerationLifecycleWorkflow(lifecycle);
         orchestration = lifecycle.orchestration;
         this.emit("generation_completed", orchestration.events.generationCompleted!);
+        this.emitHook(HookEvents.GENERATION_END, {
+          run_id: runId,
+          scenario: this.#scenario.name,
+          generation: lifecycle.generation,
+          status: "completed",
+          mean_score: lifecycle.finalizedAttempt.tournamentResult.meanScore,
+          best_score: lifecycle.finalizedAttempt.tournamentResult.bestScore,
+          elo: lifecycle.finalizedAttempt.tournamentResult.elo,
+          gate_decision: lifecycle.finalizedAttempt.gateDecision,
+        });
       }
 
       this.#store.updateRunStatus(runId, "completed");
@@ -285,6 +330,16 @@ export class GenerationRunner {
       });
       this.#runState = orchestration.runState;
       this.emit("run_completed", orchestration.events.runCompleted!);
+      this.emitHook(HookEvents.RUN_END, {
+        run_id: runId,
+        scenario: this.#scenario.name,
+        status: "completed",
+        completed_generations: orchestration.cycleState.completedGenerations,
+        best_score: this.#runState.bestScore,
+        elo: this.#runState.currentElo,
+        session_report_path: sessionReportPath,
+        dead_ends_found: this.#journal.countDeadEnds(),
+      });
       await this.notify("completion", runId, this.#runState.bestScore, {
         roundCount: orchestration.cycleState.completedGenerations,
         metadata: { session_report_path: sessionReportPath },
@@ -304,6 +359,15 @@ export class GenerationRunner {
       this.#runState = orchestration.runState;
       this.#store.updateRunStatus(runId, "failed");
       this.emit("run_failed", orchestration.events.runFailed!);
+      this.emitHook(HookEvents.RUN_END, {
+        run_id: runId,
+        scenario: this.#scenario.name,
+        status: "failed",
+        completed_generations: this.#store.getScoreTrajectory(runId).length,
+        best_score: this.#runState.bestScore,
+        elo: this.#runState.currentElo,
+        error: error instanceof Error ? error.message : String(error),
+      });
       await this.notify("failure", runId, this.#runState.bestScore, {
         roundCount: this.#store.getScoreTrajectory(runId).length,
         error: error instanceof Error ? error.message : String(error),
@@ -316,18 +380,19 @@ export class GenerationRunner {
     const consumedHint = consumeFreshStartHint(this.#runState!);
     this.#runState = consumedHint.state;
     const freshStartHint = consumedHint.hint;
-    const compacted = this.compactPromptComponentsForRun(runId, generation, {
+    const contextComponents = this.applyContextComponentsHook(runId, generation, "competitor", {
       playbook: this.#artifactStore.readPlaybook(this.#scenario.name),
       trajectory: new ScoreTrajectoryBuilder(this.#store.getScoreTrajectory(runId)).build(),
       session_reports: this.#artifactStore.readSessionReports(this.#scenario.name),
     });
+    const compacted = this.compactPromptComponentsForRun(runId, generation, contextComponents);
     const trimmed = this.#contextBudget.apply({
       ...compacted,
       dead_ends: this.#artifactStore.readDeadEnds(this.#scenario.name),
     });
     const injectedHint = this.#controller?.takeHint();
 
-    return buildCompetitorPrompt({
+    const competitor = buildCompetitorPrompt({
       scenarioName: this.#scenario.name,
       scenarioRules: this.#scenario.describeRules(),
       strategyInterface: this.#scenario.describeStrategyInterface(),
@@ -339,6 +404,23 @@ export class GenerationRunner {
       freshStartHint,
       operatorHint: injectedHint,
     });
+    return this.applyContextHook(runId, generation, { competitor }).competitor ?? competitor;
+  }
+
+  private applyContextComponentsHook(
+    runId: string,
+    generation: number,
+    role: string,
+    components: Record<string, string>,
+  ): Record<string, string> {
+    const event = this.emitHook(HookEvents.CONTEXT_COMPONENTS, {
+      run_id: runId,
+      scenario: this.#scenario.name,
+      generation,
+      role,
+      components,
+    });
+    return readStringRecord(event.payload.components) ?? components;
   }
 
   private compactPromptComponentsForRun(
@@ -346,7 +428,25 @@ export class GenerationRunner {
     generation: number,
     components: Record<string, string>,
   ): Record<string, string> {
-    const result = compactPromptComponentsWithEntries(components, {
+    const before = this.emitHook(HookEvents.BEFORE_COMPACTION, {
+      run_id: runId,
+      scenario: this.#scenario.name,
+      generation,
+      components,
+      semantic_compaction: true,
+    });
+    const inputComponents = readStringRecord(before.payload.components) ?? components;
+    const compacted = compactPromptComponents(inputComponents);
+    const after = this.emitHook(HookEvents.AFTER_COMPACTION, {
+      run_id: runId,
+      scenario: this.#scenario.name,
+      generation,
+      input_components: inputComponents,
+      components: compacted,
+      semantic_compaction: true,
+    });
+    const finalComponents = readStringRecord(after.payload.components) ?? compacted;
+    const entries = compactionEntriesForComponents(inputComponents, finalComponents, {
       context: {
         scenario: this.#scenario.name,
         run_id: runId,
@@ -354,15 +454,16 @@ export class GenerationRunner {
       },
       parentId: this.#artifactStore.latestCompactionEntryId(runId),
     });
-    if (result.entries.length > 0) {
-      this.#artifactStore.appendCompactionEntries(runId, result.entries);
+    if (entries.length > 0) {
+      this.#artifactStore.appendCompactionEntries(runId, entries);
     }
-    return result.components;
+    return finalComponents;
   }
 
   private buildSupportPrompt(
     role: "analyst" | "coach",
     runId: string,
+    generation: number,
     attempt: GenerationAttempt,
   ): string {
     const trimmed = this.#contextBudget.apply({
@@ -376,7 +477,7 @@ export class GenerationRunner {
       dead_ends: this.#artifactStore.readDeadEnds(this.#scenario.name),
     });
 
-    return buildSupportPrompt({
+    const prompt = buildSupportPrompt({
       role,
       scenarioName: this.#scenario.name,
       scenarioRules: this.#scenario.describeRules(),
@@ -387,6 +488,7 @@ export class GenerationRunner {
       trajectory: trimmed.trajectory,
       deadEnds: trimmed.dead_ends,
     });
+    return this.applyContextHook(runId, generation, { [role]: prompt })[role] ?? prompt;
   }
 
   private buildCuratorPrompt(
@@ -421,11 +523,14 @@ export class GenerationRunner {
     return this.#roleModels[role];
   }
 
-  private completeRole(role: GenerationRole, userPrompt: string, systemPrompt = "") {
-    return this.providerForRole(role).complete({
+  private async completeRole(role: GenerationRole, userPrompt: string, systemPrompt = ""): Promise<CompletionResult> {
+    return completeWithProviderHooks({
+      hookBus: this.#hookBus,
+      provider: this.providerForRole(role),
+      role,
+      model: this.modelForRole(role),
       systemPrompt,
       userPrompt,
-      model: this.modelForRole(role),
     });
   }
 
@@ -438,8 +543,8 @@ export class GenerationRunner {
     const analystStartedAt = Date.now();
     const coachStartedAt = Date.now();
     const [analystResult, coachResult] = await Promise.all([
-      this.completeRole("analyst", this.buildSupportPrompt("analyst", runId, attempt)),
-      this.completeRole("coach", this.buildSupportPrompt("coach", runId, attempt)),
+      this.completeRole("analyst", this.buildSupportPrompt("analyst", runId, gen, attempt)),
+      this.completeRole("coach", this.buildSupportPrompt("coach", runId, gen, attempt)),
     ]);
     this.emitRoleCompleted(runId, gen, "analyst", analystStartedAt, analystResult.usage);
     this.emitRoleCompleted(runId, gen, "coach", coachStartedAt, coachResult.usage);
@@ -626,6 +731,26 @@ export class GenerationRunner {
     }
   }
 
+  private applyContextHook(
+    runId: string,
+    generation: number,
+    roles: Record<string, string>,
+  ): Record<string, string> {
+    const event = this.emitHook(HookEvents.CONTEXT, {
+      run_id: runId,
+      scenario: this.#scenario.name,
+      generation,
+      roles,
+    });
+    return readStringRecord(event.payload.roles) ?? roles;
+  }
+
+  private emitHook(name: HookEvents, payload: Record<string, unknown>): ReturnType<HookBus["emit"]> {
+    const event = this.#hookBus.emit(name, payload);
+    event.raiseIfBlocked();
+    return event;
+  }
+
   private emit(event: string, payload: Record<string, unknown>): void {
     this.#events?.emit(event, payload);
   }
@@ -695,4 +820,25 @@ function replaceMarkedSection(
     "\n",
     content.slice(end),
   ].join("");
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const result: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "string") {
+      result[key] = raw;
+    }
+  }
+  return result;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/ts/src/scenarios/agent-task-factory.ts
+++ b/ts/src/scenarios/agent-task-factory.ts
@@ -5,6 +5,7 @@
 import type { AgentTaskInterface, AgentTaskResult } from "../types/index.js";
 import { LLMJudge } from "../judge/llm-judge.js";
 import type { LLMProvider } from "../types/index.js";
+import { completeWithProviderHooks, type HookBus } from "../extensions/index.js";
 import type { AgentTaskSpec } from "./agent-task-spec.js";
 import { assertFamilyContract } from "./family-interfaces.js";
 
@@ -12,6 +13,7 @@ export interface AgentTaskFactoryOpts {
   spec: AgentTaskSpec;
   name: string;
   provider?: LLMProvider;
+  hookBus?: HookBus | null;
 }
 
 /**
@@ -21,7 +23,7 @@ export function createAgentTask(opts: AgentTaskFactoryOpts): AgentTaskInterface 
   readonly name: string;
   readonly spec: AgentTaskSpec;
 } {
-  const { spec, name, provider } = opts;
+  const { spec, name, provider, hookBus } = opts;
 
   const task = {
     name,
@@ -67,6 +69,7 @@ export function createAgentTask(opts: AgentTaskFactoryOpts): AgentTaskInterface 
         provider,
         model: spec.judgeModel || provider.defaultModel(),
         rubric: spec.judgeRubric,
+        hookBus: hookBus ?? null,
       });
       const result = await judge.evaluate({
         taskPrompt: spec.taskPrompt,
@@ -119,7 +122,10 @@ export function createAgentTask(opts: AgentTaskFactoryOpts): AgentTaskInterface 
         `\nRevision instructions: ${revisionInstructions}`,
         `\nProvide the revised output:`,
       ].join("\n");
-      const result = await provider.complete({
+      const result = await completeWithProviderHooks({
+        hookBus: hookBus ?? null,
+        provider,
+        role: "agent_task_revise",
         systemPrompt: "You are a helpful assistant revising your previous output.",
         userPrompt: prompt,
         model: spec.judgeModel || undefined,

--- a/ts/src/server/run-manager.ts
+++ b/ts/src/server/run-manager.ts
@@ -288,6 +288,7 @@ export class RunManager {
               entry: plan.entry,
               generations,
               provider: providerBundle.defaultProvider,
+              settings,
               controller: this.#controller,
               events: this.#events,
             });

--- a/ts/src/server/run-start-workflow.ts
+++ b/ts/src/server/run-start-workflow.ts
@@ -10,6 +10,7 @@ import type { ScenarioInterface } from "../scenarios/game-interface.js";
 import type { CustomScenarioEntry } from "../scenarios/custom-loader.js";
 import { executeGeneratedScenarioEntry } from "../scenarios/codegen/executor.js";
 import { executeAgentTaskSolve } from "../knowledge/agent-task-solve-execution.js";
+import { HookEvents, initializeHookBus, type HookBus } from "../extensions/index.js";
 import type { ScenarioFamilyName } from "../scenarios/families.js";
 import { SCENARIO_REGISTRY } from "../scenarios/registry.js";
 import { SQLiteStore } from "../storage/index.js";
@@ -122,6 +123,10 @@ export async function executeBuiltInGameStartRun(opts: {
 
   const store = opts.deps?.createStore?.(opts.opts.dbPath) ?? new SQLiteStore(opts.opts.dbPath);
   store.migrate(opts.opts.migrationsDir);
+  const { hookBus, loadedExtensions } = await initializeHookBus({
+    extensions: opts.settings.extensions,
+    failFast: opts.settings.extensionFailFast,
+  });
 
   try {
     const runner = opts.deps?.createRunner?.({
@@ -152,6 +157,8 @@ export async function executeBuiltInGameStartRun(opts: {
       notifyOn: opts.settings.notifyOn,
       controller: opts.controller,
       events: opts.events,
+      hookBus,
+      loadedExtensions,
     }) ?? new GenerationRunner({
       provider: opts.providerBundle.defaultProvider,
       roleProviders: opts.providerBundle.roleProviders,
@@ -180,6 +187,8 @@ export async function executeBuiltInGameStartRun(opts: {
       notifyOn: opts.settings.notifyOn,
       controller: opts.controller,
       events: opts.events,
+      hookBus,
+      loadedExtensions,
     });
 
     await runner.run(opts.runId, opts.generations);
@@ -208,11 +217,27 @@ export async function executeAgentTaskCustomStartRun(opts: {
   entry: CustomScenarioEntry;
   generations: number;
   provider: import("../types/index.js").LLMProvider;
+  settings?: AppSettings;
   controller: LoopController;
   events: EventStreamEmitter;
   deps?: AgentTaskCustomStartRunDeps;
 }): Promise<void> {
   const executeTask = opts.deps?.executeAgentTaskSolve ?? executeAgentTaskSolve;
+  const { hookBus, loadedExtensions } = opts.settings
+    ? await initializeHookBus({
+      extensions: opts.settings.extensions,
+      failFast: opts.settings.extensionFailFast,
+    })
+    : { hookBus: null, loadedExtensions: [] };
+
+  emitHook(hookBus, HookEvents.RUN_START, {
+    run_id: opts.runId,
+    scenario: opts.scenarioName,
+    target_generations: opts.generations,
+    family: "agent_task",
+    saved_custom: true,
+    loaded_extensions: loadedExtensions,
+  });
 
   opts.events.emit("run_started", {
     run_id: opts.runId,
@@ -222,21 +247,62 @@ export async function executeAgentTaskCustomStartRun(opts: {
     saved_custom: true,
   });
   await opts.controller.waitIfPaused();
+  emitHook(hookBus, HookEvents.GENERATION_START, {
+    run_id: opts.runId,
+    scenario: opts.scenarioName,
+    generation: 1,
+    family: "agent_task",
+    saved_custom: true,
+  });
   opts.events.emit("generation_started", { run_id: opts.runId, generation: 1 });
 
-  const result = await executeTask({
-    provider: opts.provider,
-    created: {
-      name: opts.scenarioName,
-      spec: opts.entry.spec,
-    },
-    generations: opts.generations,
-  });
+  let result;
+  try {
+    result = await executeTask({
+      provider: opts.provider,
+      created: {
+        name: opts.scenarioName,
+        spec: opts.entry.spec,
+      },
+      generations: opts.generations,
+      ...(hookBus ? { hookBus } : {}),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    emitHook(hookBus, HookEvents.GENERATION_END, {
+      run_id: opts.runId,
+      scenario: opts.scenarioName,
+      generation: 1,
+      status: "failed",
+      family: "agent_task",
+      saved_custom: true,
+      error: message,
+    });
+    emitHook(hookBus, HookEvents.RUN_END, {
+      run_id: opts.runId,
+      scenario: opts.scenarioName,
+      status: "failed",
+      completed_generations: 0,
+      best_score: 0,
+      elo: 1000,
+      family: "agent_task",
+      saved_custom: true,
+      error: message,
+    });
+    throw error;
+  }
   const bestScore = readBestScore(result.result);
   const completedGenerations = normalizeCompletedGenerations(result.progress);
 
   for (let generation = 1; generation <= completedGenerations; generation++) {
     if (generation > 1) {
+      emitHook(hookBus, HookEvents.GENERATION_START, {
+        run_id: opts.runId,
+        scenario: opts.scenarioName,
+        generation,
+        family: "agent_task",
+        saved_custom: true,
+      });
       opts.events.emit("generation_started", { run_id: opts.runId, generation });
     }
     opts.events.emit("generation_completed", {
@@ -249,9 +315,34 @@ export async function executeAgentTaskCustomStartRun(opts: {
       family: "agent_task",
       rounds_completed: completedGenerations,
     });
+    emitHook(hookBus, HookEvents.GENERATION_END, {
+      run_id: opts.runId,
+      scenario: opts.scenarioName,
+      generation,
+      status: "completed",
+      mean_score: bestScore,
+      best_score: bestScore,
+      elo: 1000,
+      gate_decision: "advance",
+      family: "agent_task",
+      saved_custom: true,
+      rounds_completed: completedGenerations,
+    });
   }
   opts.events.emit("run_completed", {
     run_id: opts.runId,
+    completed_generations: completedGenerations,
+    best_score: bestScore,
+    elo: 1000,
+    session_report_path: null,
+    dead_ends_found: 0,
+    family: "agent_task",
+    saved_custom: true,
+  });
+  emitHook(hookBus, HookEvents.RUN_END, {
+    run_id: opts.runId,
+    scenario: opts.scenarioName,
+    status: "completed",
     completed_generations: completedGenerations,
     best_score: bestScore,
     elo: 1000,
@@ -340,4 +431,16 @@ export async function executeGeneratedCustomStartRun(opts: {
     family: opts.family,
     generated_custom: true,
   });
+}
+
+function emitHook(
+  hookBus: HookBus | null,
+  name: HookEvents,
+  payload: Record<string, unknown>,
+): void {
+  if (!hookBus?.hasHandlers(name)) {
+    return;
+  }
+  const event = hookBus.emit(name, payload);
+  event.raiseIfBlocked();
 }

--- a/ts/tests/agent-task-solve-execution.test.ts
+++ b/ts/tests/agent-task-solve-execution.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { AgentTaskInterface, ImprovementResult, LLMProvider } from "../src/types/index.js";
+import { HookBus, HookEvents } from "../src/extensions/index.js";
 import {
   buildAgentTaskSolveSpec,
   executeAgentTaskSolve,
@@ -242,5 +243,71 @@ describe("agent-task solve execution", () => {
         },
       }),
     ).rejects.toThrow("agent_task context preparation failed: missing required context key: 'timeline'");
+  });
+
+  it("threads provider hooks through saved agent-task initial generation", async () => {
+    const providerPrompts: string[] = [];
+    const provider: LLMProvider = {
+      name: "test-provider",
+      defaultModel: () => "test-model",
+      complete: vi.fn(async (opts) => {
+        providerPrompts.push(opts.userPrompt);
+        if (opts.userPrompt.includes("## Agent Output")) {
+          return {
+            text:
+              "<!-- JUDGE_RESULT_START -->\n" +
+              JSON.stringify({
+                score: 0.8,
+                reasoning: "Good",
+                dimensions: { clarity: 0.8 },
+              }) +
+              "\n<!-- JUDGE_RESULT_END -->",
+            model: "test-model",
+            usage: {},
+          };
+        }
+        return {
+          text: "Initial provider answer",
+          model: "test-model",
+          usage: {},
+        };
+      }),
+    };
+    const bus = new HookBus();
+    const seen: string[] = [];
+    bus.on(HookEvents.BEFORE_PROVIDER_REQUEST, (event) => {
+      if (event.payload.role === "agent_task_initial") {
+        seen.push("before_initial");
+        return { userPrompt: `${event.payload.userPrompt}\nhook provider request` };
+      }
+      return undefined;
+    });
+    bus.on(HookEvents.AFTER_PROVIDER_RESPONSE, (event) => {
+      if (event.payload.role === "agent_task_initial") {
+        seen.push("after_initial");
+        return { text: "Initial answer rewritten by provider hook" };
+      }
+      return undefined;
+    });
+
+    const result = await executeAgentTaskSolve({
+      provider,
+      hookBus: bus,
+      created: {
+        name: "hooked_task",
+        spec: {
+          taskPrompt: "Write a concise answer.",
+          judgeRubric: "Score clarity.",
+          outputFormat: "free_text",
+        },
+      },
+      generations: 1,
+    });
+
+    expect(seen).toEqual(["before_initial", "after_initial"]);
+    expect(providerPrompts[0]).toContain("hook provider request");
+    expect(result.result.skill_markdown).toContain(
+      "Initial answer rewritten by provider hook",
+    );
   });
 });

--- a/ts/tests/artifact-store-hooks.test.ts
+++ b/ts/tests/artifact-store-hooks.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { HookBus, HookEvents } from "../src/extensions/index.js";
+import { ArtifactStore } from "../src/knowledge/artifact-store.js";
+
+function makeRoot(): string {
+  return mkdtempSync(join(tmpdir(), "autoctx-artifact-hooks-"));
+}
+
+describe("ArtifactStore extension hooks", () => {
+  it("lets artifact_write hooks mutate markdown content inside managed roots", () => {
+    const root = makeRoot();
+    try {
+      const bus = new HookBus();
+      bus.on(HookEvents.ARTIFACT_WRITE, (event) => ({
+        content: `${event.payload.content}\nmutated by hook`,
+      }));
+      const store = new ArtifactStore({
+        runsRoot: join(root, "runs"),
+        knowledgeRoot: join(root, "knowledge"),
+        hookBus: bus,
+      });
+      const path = join(root, "runs", "run-1", "out.md");
+
+      store.writeMarkdown(path, "original");
+
+      expect(readFileSync(path, "utf-8")).toBe("original\nmutated by hook\n");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects artifact_write path rewrites outside the original managed root", () => {
+    const root = makeRoot();
+    try {
+      const bus = new HookBus();
+      bus.on(HookEvents.ARTIFACT_WRITE, () => ({
+        path: join(root, "outside.md"),
+      }));
+      const store = new ArtifactStore({
+        runsRoot: join(root, "runs"),
+        knowledgeRoot: join(root, "knowledge"),
+        hookBus: bus,
+      });
+
+      expect(() => store.writeMarkdown(join(root, "runs", "run-1", "out.md"), "content"))
+        .toThrow(/artifact_write path must stay within the original managed root/);
+      expect(existsSync(join(root, "outside.md"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("applies artifact_write hooks to playbooks, dead ends, and compaction ledgers", () => {
+    const root = makeRoot();
+    try {
+      const bus = new HookBus();
+      const seen: string[] = [];
+      bus.on(HookEvents.ARTIFACT_WRITE, (event) => {
+        const path = String(event.payload.path ?? "");
+        seen.push(`${event.payload.format}:${path.slice(path.lastIndexOf("/") + 1)}`);
+        if (path.endsWith("playbook.md")) {
+          return { content: `${event.payload.content}\nplaybook hook` };
+        }
+        if (path.endsWith("dead_ends.md")) {
+          return { content: `${event.payload.content}\ndead-end hook` };
+        }
+        return undefined;
+      });
+      const store = new ArtifactStore({
+        runsRoot: join(root, "runs"),
+        knowledgeRoot: join(root, "knowledge"),
+        hookBus: bus,
+      });
+
+      store.writePlaybook("grid_ctf", "base playbook");
+      store.appendDeadEnd("grid_ctf", "base dead end");
+      store.appendCompactionEntries("run-1", [{
+        id: "entry-1",
+        parentId: "",
+        timestamp: "2026-04-29T00:00:00.000Z",
+        summary: "summary",
+        firstKeptEntryId: "turn-1",
+        tokensBefore: 100,
+      }]);
+
+      expect(readFileSync(join(root, "knowledge", "grid_ctf", "playbook.md"), "utf-8"))
+        .toContain("playbook hook");
+      expect(readFileSync(join(root, "knowledge", "grid_ctf", "dead_ends.md"), "utf-8"))
+        .toContain("dead-end hook");
+      expect(seen).toEqual(expect.arrayContaining([
+        "markdown:playbook.md",
+        "markdown:dead_ends.md",
+        "jsonl:compactions.jsonl",
+        "text:compactions.latest",
+      ]));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/ts/tests/extensions.test.ts
+++ b/ts/tests/extensions.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  ExtensionAPI,
+  HookBus,
+  HookEvents,
+  HookResult,
+  loadExtensions,
+} from "../src/extensions/index.js";
+
+describe("TypeScript extension hooks", () => {
+  it("runs handlers in order and applies returned payload/metadata", () => {
+    const bus = new HookBus();
+    const order: string[] = [];
+
+    bus.on(HookEvents.CONTEXT_COMPONENTS, (event) => {
+      order.push("first");
+      return {
+        components: {
+          ...readStringRecord(event.payload.components),
+          playbook: "hooked playbook",
+        },
+      };
+    });
+    bus.on(HookEvents.CONTEXT_COMPONENTS, (event) => {
+      order.push("second");
+      expect(readStringRecord(event.payload.components).playbook).toBe("hooked playbook");
+      return new HookResult({ metadata: { seen: true } });
+    });
+
+    const event = bus.emit(HookEvents.CONTEXT_COMPONENTS, {
+      components: { playbook: "base" },
+    });
+
+    expect(order).toEqual(["first", "second"]);
+    expect(event.payload.components).toEqual({ playbook: "hooked playbook" });
+    expect(event.metadata.seen).toBe(true);
+  });
+
+  it("raises a clear error when a hook blocks an event", () => {
+    const bus = new HookBus();
+    bus.on(HookEvents.ARTIFACT_WRITE, () => new HookResult({
+      block: true,
+      reason: "policy rejected artifact",
+    }));
+
+    const event = bus.emit(HookEvents.ARTIFACT_WRITE, { path: "runs/r1/out.md" });
+
+    expect(() => event.raiseIfBlocked()).toThrow(/blocked artifact_write: policy rejected artifact/);
+  });
+
+  it("loads an extension module and lets it register through the API facade", async () => {
+    const root = mkdtempSync(join(tmpdir(), "autoctx-ts-ext-"));
+    try {
+      const extensionPath = join(root, "hook.mjs");
+      writeFileSync(
+        extensionPath,
+        `
+          export function register(api) {
+            api.on("context", (event) => ({
+              roles: {
+                ...event.payload.roles,
+                competitor: event.payload.roles.competitor + "\\nloaded extension"
+              }
+            }));
+          }
+        `,
+        "utf-8",
+      );
+
+      const bus = new HookBus();
+      const loaded = await loadExtensions(extensionPath, bus);
+      const event = bus.emit(HookEvents.CONTEXT, {
+        roles: { competitor: "base prompt" },
+      });
+
+      expect(loaded).toEqual([extensionPath]);
+      expect(event.payload.roles).toEqual({ competitor: "base prompt\nloaded extension" });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("supports decorator-style registration via ExtensionAPI.on", () => {
+    const bus = new HookBus();
+    const api = new ExtensionAPI(bus);
+
+    api.on(HookEvents.AFTER_PROVIDER_RESPONSE)((event) => ({
+      text: `${event.payload.text} decorated`,
+    }));
+
+    const event = api.emit(HookEvents.AFTER_PROVIDER_RESPONSE, { text: "response" });
+
+    expect(event.payload.text).toBe("response decorated");
+  });
+});
+
+function readStringRecord(value: unknown): Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+  const result: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "string") {
+      result[key] = raw;
+    }
+  }
+  return result;
+}

--- a/ts/tests/generation-runner-hooks.test.ts
+++ b/ts/tests/generation-runner-hooks.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { HookBus, HookEvents } from "../src/extensions/index.js";
+
+function makeRoot(): string {
+  return mkdtempSync(join(tmpdir(), "autoctx-runner-hooks-"));
+}
+
+describe("GenerationRunner extension hooks", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("mutates prompt context and observes provider requests/responses in a real run", async () => {
+    const { GenerationRunner } = await import("../src/loop/generation-runner.js");
+    const { GridCtfScenario } = await import("../src/scenarios/grid-ctf.js");
+    const { SQLiteStore } = await import("../src/storage/index.js");
+
+    class RecordingProvider {
+      readonly name = "recording";
+      prompts: string[] = [];
+
+      defaultModel(): string {
+        return "recording-model";
+      }
+
+      async complete(opts: { userPrompt: string }): Promise<{ text: string; model: string; usage: Record<string, number> }> {
+        this.prompts.push(opts.userPrompt);
+        if (opts.userPrompt.includes("Describe your strategy")) {
+          return {
+            text: JSON.stringify({ aggression: 0.60, defense: 0.55, path_bias: 0.50 }),
+            model: "recording-model",
+            usage: { output_tokens: 4 },
+          };
+        }
+        if (opts.userPrompt.includes("Analyze strengths/failures")) {
+          return {
+            text: "## Findings\n\n- Hooked run stayed stable.",
+            model: "recording-model",
+            usage: {},
+          };
+        }
+        return {
+          text:
+            "<!-- PLAYBOOK_START -->\n" +
+            "## Strategy Updates\n\n- Hooked coach preserved defender coverage.\n" +
+            "<!-- PLAYBOOK_END -->\n\n" +
+            "<!-- LESSONS_START -->\n- Extension context can shape prompt state.\n<!-- LESSONS_END -->\n\n" +
+            "<!-- COMPETITOR_HINTS_START -->\n- Keep defense above 0.5.\n<!-- COMPETITOR_HINTS_END -->",
+          model: "recording-model",
+          usage: {},
+        };
+      }
+    }
+
+    const root = makeRoot();
+    roots.push(root);
+    const provider = new RecordingProvider();
+    const bus = new HookBus();
+    const seenEvents: string[] = [];
+    bus.on(HookEvents.GENERATION_START, () => {
+      seenEvents.push("generation_start");
+    });
+    bus.on(HookEvents.GENERATION_END, () => {
+      seenEvents.push("generation_end");
+    });
+    bus.on(HookEvents.CONTEXT_COMPONENTS, (event) => {
+      seenEvents.push("context_components");
+      return {
+        components: {
+          ...readStringRecord(event.payload.components),
+          playbook: "hook playbook guidance",
+          session_reports: "hook session report context",
+        },
+      };
+    });
+    bus.on(HookEvents.BEFORE_COMPACTION, () => {
+      seenEvents.push("before_compaction");
+    });
+    bus.on(HookEvents.AFTER_COMPACTION, () => {
+      seenEvents.push("after_compaction");
+    });
+    bus.on(HookEvents.CONTEXT, (event) => {
+      seenEvents.push("context");
+      const roles = readStringRecord(event.payload.roles);
+      return {
+        roles: {
+          ...roles,
+          competitor: `${roles.competitor}\nhook final context`,
+        },
+      };
+    });
+    bus.on(HookEvents.BEFORE_PROVIDER_REQUEST, (event) => {
+      seenEvents.push(`before_provider:${event.payload.role}`);
+      if (event.payload.role === "competitor") {
+        return { userPrompt: `${event.payload.userPrompt}\nhook provider request` };
+      }
+      return undefined;
+    });
+    bus.on(HookEvents.AFTER_PROVIDER_RESPONSE, (event) => {
+      seenEvents.push(`after_provider:${event.payload.role}`);
+      return { metadata: { hookObserved: true } };
+    });
+
+    const store = new SQLiteStore(join(root, "test.db"));
+    store.migrate(join(import.meta.dirname, "..", "migrations"));
+    const runner = new GenerationRunner({
+      provider,
+      scenario: new GridCtfScenario(),
+      store,
+      runsRoot: join(root, "runs"),
+      knowledgeRoot: join(root, "knowledge"),
+      matchesPerGeneration: 2,
+      maxRetries: 0,
+      minDelta: 0.0,
+      hookBus: bus,
+    });
+
+    await runner.run("hook-run", 1);
+
+    const competitorProviderPrompt = provider.prompts.find((prompt) =>
+      prompt.includes("Describe your strategy"),
+    );
+    expect(competitorProviderPrompt).toContain("hook playbook guidance");
+    expect(competitorProviderPrompt).toContain("hook session report context");
+    expect(competitorProviderPrompt).toContain("hook final context");
+    expect(competitorProviderPrompt).toContain("hook provider request");
+
+    const artifactPrompt = readFileSync(
+      join(root, "runs", "hook-run", "generations", "gen_1", "competitor_prompt.md"),
+      "utf-8",
+    );
+    expect(artifactPrompt).toContain("hook final context");
+    expect(artifactPrompt).not.toContain("hook provider request");
+    expect(seenEvents).toEqual(expect.arrayContaining([
+      "context_components",
+      "generation_start",
+      "generation_end",
+      "before_compaction",
+      "after_compaction",
+      "context",
+      "before_provider:competitor",
+      "after_provider:competitor",
+    ]));
+
+    store.close();
+  });
+});
+
+function readStringRecord(value: unknown): Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+  const result: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "string") {
+      result[key] = raw;
+    }
+  }
+  return result;
+}

--- a/ts/tests/judge-hooks.test.ts
+++ b/ts/tests/judge-hooks.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { HookBus, HookEvents, LLMJudge } from "../src/index.js";
+import type { LLMProvider } from "../src/index.js";
+
+function judgeResponse(score: number, reasoning = "Hooked judge result"): string {
+  return (
+    "<!-- JUDGE_RESULT_START -->\n" +
+    JSON.stringify({
+      score,
+      reasoning,
+      dimensions: { clarity: score },
+    }) +
+    "\n<!-- JUDGE_RESULT_END -->"
+  );
+}
+
+describe("LLMJudge extension hooks", () => {
+  it("fires before_judge and after_judge around real provider judge calls", async () => {
+    const providerPrompts: string[] = [];
+    const provider: LLMProvider = {
+      name: "hook-provider",
+      defaultModel: () => "hook-model",
+      complete: async (opts) => {
+        providerPrompts.push(opts.userPrompt);
+        return {
+          text: judgeResponse(0.1, "provider raw score"),
+          model: "hook-model",
+          usage: {},
+        };
+      },
+    };
+    const bus = new HookBus();
+    const seen: string[] = [];
+
+    bus.on(HookEvents.BEFORE_JUDGE, (event) => {
+      seen.push(`before:${event.payload.sample}:${event.payload.attempt}`);
+      return {
+        userPrompt: `${event.payload.userPrompt}\nHooked judge instruction`,
+      };
+    });
+    bus.on(HookEvents.AFTER_JUDGE, (event) => {
+      seen.push(`after:${event.payload.sample}:${event.payload.attempt}`);
+      return {
+        response_text: judgeResponse(0.77),
+      };
+    });
+
+    const judge = new LLMJudge({
+      provider,
+      model: "hook-model",
+      rubric: "Score clarity.",
+      hookBus: bus,
+    });
+    const result = await judge.evaluate({
+      taskPrompt: "Write a summary.",
+      agentOutput: "Summary.",
+    });
+
+    expect(providerPrompts).toEqual([expect.stringContaining("Hooked judge instruction")]);
+    expect(seen).toEqual(["before:1:1", "after:1:1"]);
+    expect(result.score).toBe(0.77);
+    expect(result.rawResponses).toEqual([judgeResponse(0.77)]);
+  });
+
+  it("threads judge hooks through saved agent-task solve evaluations", async () => {
+    const provider: LLMProvider = {
+      name: "agent-task-provider",
+      defaultModel: () => "agent-task-model",
+      complete: async (opts) => {
+        if (opts.userPrompt.includes("## Agent Output")) {
+          return {
+            text: judgeResponse(0.66),
+            model: "agent-task-model",
+            usage: {},
+          };
+        }
+        return {
+          text: "Initial answer",
+          model: "agent-task-model",
+          usage: {},
+        };
+      },
+    };
+    const bus = new HookBus();
+    const seen: string[] = [];
+    bus.on(HookEvents.BEFORE_JUDGE, () => {
+      seen.push("before_judge");
+    });
+    bus.on(HookEvents.AFTER_JUDGE, () => {
+      seen.push("after_judge");
+    });
+    const { executeAgentTaskSolve } =
+      await import("../src/knowledge/agent-task-solve-execution.js");
+
+    const result = await executeAgentTaskSolve({
+      provider,
+      hookBus: bus,
+      created: {
+        name: "hooked_task",
+        spec: {
+          taskPrompt: "Write a concise answer.",
+          judgeRubric: "Score clarity.",
+          outputFormat: "free_text",
+        },
+      },
+      generations: 1,
+    });
+
+    expect(seen).toEqual(["before_judge", "after_judge"]);
+    expect(result.result.best_score).toBe(0.66);
+  });
+});

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -19,6 +19,10 @@ describe("package root exports", () => {
     expect(pkg.PiPersistentRPCRuntime).toBeDefined();
     expect(pkg.compactPromptComponents).toBeDefined();
     expect(pkg.compactPromptComponentsWithEntries).toBeDefined();
+    expect(pkg.HookBus).toBeDefined();
+    expect(pkg.HookEvents).toBeDefined();
+    expect(pkg.loadExtensions).toBeDefined();
+    expect(pkg.completeWithProviderHooks).toBeDefined();
     expect(pkg.chooseModel).toBeDefined();
     expect(pkg.resolveBrowserSessionConfig).toBeDefined();
     expect(pkg.evaluateBrowserActionPolicy).toBeDefined();

--- a/ts/tests/run-start-workflow.test.ts
+++ b/ts/tests/run-start-workflow.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import type { AppSettings } from "../src/config/index.js";
 import type { CustomScenarioEntry } from "../src/scenarios/custom-loader.js";
 import type { ScenarioFamilyName } from "../src/scenarios/families.js";
 import type { RoleProviderBundle } from "../src/providers/index.js";
+import { HookBus } from "../src/extensions/index.js";
 import {
   executeAgentTaskCustomStartRun,
   executeBuiltInGameStartRun,
@@ -253,6 +257,7 @@ describe("run start workflow", () => {
       },
       generations: 2,
       provider: { name: "test", defaultModel: () => "test", complete: vi.fn() },
+      settings: makeSettings(),
       controller: { waitIfPaused: async () => {} } as never,
       events: events as never,
       deps: { executeAgentTaskSolve: executeAgentTaskSolve as never },
@@ -265,6 +270,7 @@ describe("run start workflow", () => {
         spec: { taskPrompt: "Do work", judgeRubric: "Do it well" },
       },
       generations: 2,
+      hookBus: expect.any(HookBus),
     });
     expect(emitted[0]?.event).toBe("run_started");
     expect(emitted.filter((entry) => entry.event === "generation_started")).toEqual([
@@ -280,4 +286,151 @@ describe("run start workflow", () => {
     expect(completed?.payload.session_report_path).toBeNull();
     expect(completed?.payload.dead_ends_found).toBe(0);
   });
+
+  it("emits extension lifecycle hooks for saved agent-task runs", async () => {
+    const root = mkdtempSync(join(tmpdir(), "autoctx-agent-task-hooks-"));
+    vi.stubGlobal("__autoctxLifecycleEvents", []);
+    try {
+      const extensionPath = join(root, "lifecycle.mjs");
+      writeFileSync(
+        extensionPath,
+        `
+          export function register(api) {
+            api.on("*", (event) => {
+              globalThis.__autoctxLifecycleEvents.push({
+                name: event.name,
+                status: event.payload.status ?? "",
+                generation: event.payload.generation ?? 0
+              });
+            });
+          }
+        `,
+        "utf-8",
+      );
+      const executeAgentTaskSolve = vi.fn(async () => ({
+        progress: 1,
+        result: { best_score: 0.82, scenario_name: "saved_task" },
+      }));
+
+      await executeAgentTaskCustomStartRun({
+        runId: "run_task_hooks",
+        scenarioName: "saved_task",
+        entry: {
+          name: "saved_task",
+          type: "agent_task",
+          spec: { taskPrompt: "Do work", judgeRubric: "Do it well" },
+          path: "/tmp/saved_task",
+          hasGeneratedSource: false,
+        },
+        generations: 1,
+        provider: { name: "test", defaultModel: () => "test", complete: vi.fn() },
+        settings: {
+          ...makeSettings(),
+          extensions: extensionPath,
+          extensionFailFast: true,
+        },
+        controller: { waitIfPaused: async () => {} } as never,
+        events: { emit: vi.fn() } as never,
+        deps: { executeAgentTaskSolve: executeAgentTaskSolve as never },
+      });
+
+      expect(readLifecycleEventNames()).toEqual([
+        "run_start",
+        "generation_start",
+        "generation_end",
+        "run_end",
+      ]);
+      expect(readLifecycleStatuses()).toEqual(["", "", "completed", "completed"]);
+    } finally {
+      vi.unstubAllGlobals();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("emits failure lifecycle hooks for saved agent-task runs", async () => {
+    const root = mkdtempSync(join(tmpdir(), "autoctx-agent-task-hooks-"));
+    vi.stubGlobal("__autoctxLifecycleEvents", []);
+    try {
+      const extensionPath = join(root, "lifecycle-failure.mjs");
+      writeFileSync(
+        extensionPath,
+        `
+          export function register(api) {
+            api.on("*", (event) => {
+              globalThis.__autoctxLifecycleEvents.push({
+                name: event.name,
+                status: event.payload.status ?? "",
+                generation: event.payload.generation ?? 0
+              });
+            });
+          }
+        `,
+        "utf-8",
+      );
+
+      await expect(executeAgentTaskCustomStartRun({
+        runId: "run_task_hooks_failed",
+        scenarioName: "saved_task",
+        entry: {
+          name: "saved_task",
+          type: "agent_task",
+          spec: { taskPrompt: "Do work", judgeRubric: "Do it well" },
+          path: "/tmp/saved_task",
+          hasGeneratedSource: false,
+        },
+        generations: 1,
+        provider: { name: "test", defaultModel: () => "test", complete: vi.fn() },
+        settings: {
+          ...makeSettings(),
+          extensions: extensionPath,
+          extensionFailFast: true,
+        },
+        controller: { waitIfPaused: async () => {} } as never,
+        events: { emit: vi.fn() } as never,
+        deps: {
+          executeAgentTaskSolve: vi.fn(async () => {
+            throw new Error("agent task failed");
+          }) as never,
+        },
+      })).rejects.toThrow("agent task failed");
+
+      expect(readLifecycleEventNames()).toEqual([
+        "run_start",
+        "generation_start",
+        "generation_end",
+        "run_end",
+      ]);
+      expect(readLifecycleStatuses()).toEqual(["", "", "failed", "failed"]);
+    } finally {
+      vi.unstubAllGlobals();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
+
+function readLifecycleEventNames(): string[] {
+  return readLifecycleEvents().map((event) => event.name);
+}
+
+function readLifecycleStatuses(): string[] {
+  return readLifecycleEvents().map((event) => event.status);
+}
+
+function readLifecycleEvents(): Array<{ name: string; status: string }> {
+  const raw = Reflect.get(globalThis, "__autoctxLifecycleEvents");
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.flatMap((entry) => {
+    if (!isRecord(entry)) {
+      return [];
+    }
+    const name = typeof entry.name === "string" ? entry.name : "";
+    const status = typeof entry.status === "string" ? entry.status : "";
+    return name ? [{ name, status }] : [];
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/ts/tests/settings-resolution-workflow.test.ts
+++ b/ts/tests/settings-resolution-workflow.test.ts
@@ -64,6 +64,23 @@ describe("settings resolution workflow", () => {
     });
   });
 
+  it("resolves TypeScript extension hook settings from env", () => {
+    const defaults = {
+      extensions: "",
+      extensionFailFast: false,
+    } satisfies Partial<AppSettings>;
+
+    const overrides = resolveEnvSettingsOverrides(defaults, {
+      AUTOCONTEXT_EXTENSIONS: "./hooks.mjs,autoctx-policy",
+      AUTOCONTEXT_EXTENSION_FAIL_FAST: "true",
+    });
+
+    expect(overrides).toMatchObject({
+      extensions: "./hooks.mjs,autoctx-policy",
+      extensionFailFast: true,
+    });
+  });
+
   it("builds project-config overrides for provider, model, and artifact roots", () => {
     const overrides = buildProjectConfigSettingsOverrides({
       provider: "ollama",

--- a/ts/tests/task-runner.test.ts
+++ b/ts/tests/task-runner.test.ts
@@ -9,6 +9,7 @@ import {
   createTaskRunnerFromSettings,
   enqueueTask,
 } from "../src/execution/task-runner.js";
+import { HookBus, HookEvents } from "../src/extensions/index.js";
 import type { LLMProvider, CompletionResult } from "../src/types/index.js";
 
 const MIGRATIONS_DIR = join(import.meta.dirname, "..", "migrations");
@@ -519,5 +520,52 @@ describe("SimpleAgentTask", () => {
     expect(calls.at(-1)?.userPrompt).toContain("## Required Concepts");
     expect(calls.at(-1)?.userPrompt).toContain("- safety");
     expect(calls.at(-1)?.userPrompt).toContain("- latency");
+  });
+
+  it("wraps generation and revision provider calls with provider hooks", async () => {
+    const provider: LLMProvider = {
+      name: "hook-provider",
+      defaultModel: () => "hook-model",
+      complete: vi.fn(async () => ({
+        text: "provider output",
+        model: "hook-model",
+        usage: {},
+      })),
+    };
+    const bus = new HookBus();
+    const seen: string[] = [];
+    bus.on(HookEvents.BEFORE_PROVIDER_REQUEST, (event) => {
+      seen.push(`before:${event.payload.role}`);
+      return undefined;
+    });
+    bus.on(HookEvents.AFTER_PROVIDER_RESPONSE, (event) => {
+      seen.push(`after:${event.payload.role}`);
+      return { text: `${event.payload.role} hooked output` };
+    });
+    const task = new SimpleAgentTask(
+      "Do work",
+      "Score work",
+      provider,
+      "hook-model",
+      undefined,
+      null,
+      undefined,
+      bus,
+    );
+
+    await expect(task.generateOutput()).resolves.toBe("agent_task_generate hooked output");
+    await expect(
+      task.reviseOutput(
+        "old output",
+        { score: 0.2, reasoning: "revise", dimensionScores: {}, internalRetries: 0 },
+        {},
+      ),
+    ).resolves.toBe("agent_task_revise hooked output");
+    expect(seen).toEqual([
+      "before:agent_task_generate",
+      "after:agent_task_generate",
+      "before:agent_task_revise",
+      "after:agent_task_revise",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- add a TypeScript Pi-shaped extension hook bus with module loading via AUTOCONTEXT_EXTENSIONS
- wire hooks through GenerationRunner context/compaction/provider/run lifecycle, LLMJudge judge calls, and ArtifactStore writes with managed-root path validation
- expose the hook API from the package root and document Python/TypeScript extension behavior

## Tests
- npm run lint
- npm run build
- npx vitest run tests/extensions.test.ts tests/artifact-store-hooks.test.ts tests/generation-runner-hooks.test.ts tests/judge-hooks.test.ts tests/judge.test.ts tests/smoke-judge.test.ts tests/package-export-catalogs.test.ts tests/settings-resolution-workflow.test.ts tests/run-command-workflow.test.ts tests/run-start-workflow.test.ts tests/benchmark-command-workflow.test.ts tests/task-runner.test.ts tests/agent-task-solve-execution.test.ts

## Notes
- Full npm test was attempted and still fails in the existing broad-suite state: mostly CLI/cross-runtime property test timeouts plus the existing type-assertion budget failure (966 > 950).