### PR TITLE
Prepare 0.4.7 release

### DIFF
--- a/.github/workflows/publish-pi-autocontext.yml
+++ b/.github/workflows/publish-pi-autocontext.yml
@@ -1,0 +1,52 @@
+name: publish-pi-autocontext
+
+on:
+  push:
+    tags:
+      - "pi-v*"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-pi-autocontext-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    environment: publish-pi-autocontext
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: pi
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - name: Validate tag matches Pi package version
+        if: startsWith(github.ref, 'refs/tags/pi-v')
+        run: |
+          expected="${GITHUB_REF_NAME#pi-v}"
+          actual="$(node -p "require('./package.json').version")"
+          if [ "$actual" != "$expected" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match pi/package.json version ${actual}." >&2
+            exit 1
+          fi
+      - name: Install dependencies
+        run: npm ci
+      - name: Show npm version
+        run: npm --version
+      - name: Lint package
+        run: npm run lint
+      - name: Test package
+        run: npm test
+      - name: Build package
+        run: npm run build
+      - name: Publish to npm
+        run: npm publish --access public --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-04-29
+
 ### Added
 
 - Python `autoctx export` now accepts `--format pi-package` to write a Pi-local package directory with `package.json`, `SKILL.md`, prompt markdown, and the original autocontext strategy payload.
@@ -22,6 +24,7 @@ All notable changes to this project will be documented in this file.
 
 - Restructured the top-level `README.md`: leads with the Pi runtime quick start, adds an MCP-driven natural-language entry path ("Or Just Talk To Your Agent"), shows a structured artifact tree with concrete `playbook.md` and `trace.jsonl` excerpts, surfaces production-trace capture as its own section, merges the surfaces table with command examples, and adds a short FAQ. Removes redundant "How People Use It" / "Choose An Entry Point" / "Repository Layout" sections (the last is already covered in `AGENTS.md`).
 - Bumped subpackage README references from `0.4.4` to `0.4.7` (`autocontext/README.md`, `ts/README.md`) to track the next release line.
+- Python `autocontext`, TypeScript `autoctx`, and Pi `pi-autocontext` package metadata are bumped for the release.
 
 ## [0.4.6] - 2026-04-23
 
@@ -288,7 +291,8 @@ All notable changes to this project will be documented in this file.
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
-[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.6...HEAD
+[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.7...HEAD
+[0.4.7]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.6...py-v0.4.7
 [0.4.6]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.5...py-v0.4.6
 [0.4.5]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.4...py-v0.4.5
 [0.4.4]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.3...py-v0.4.4

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autocontext"
-version = "0.4.6"
+version = "0.4.7"
 description = "autocontext control plane for iterative strategy evolution."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/autocontext/src/autocontext/__init__.py
+++ b/autocontext/src/autocontext/__init__.py
@@ -5,4 +5,4 @@ from autocontext.sdk import AutoContext
 
 __all__ = ["AutoContext", "ExtensionAPI", "HookBus", "HookEvents", "HookResult", "__version__"]
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"

--- a/autocontext/uv.lock
+++ b/autocontext/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "autocontext"
-version = "0.4.6"
+version = "0.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,11 +1,11 @@
 # Release Checklist
 
-Use this checklist when preparing a tagged release such as `v0.2.1`.
+Use this checklist when preparing a tagged release such as `py-v0.4.7`, `ts-v0.4.7`, or `pi-v0.2.1`.
 
 ## 1. Decide Scope
 
 - Review `CHANGELOG.md` and recent merged PRs.
-- Decide whether the release affects the Python package, the TypeScript package, or both.
+- Decide whether the release affects the Python package, the TypeScript package, the Pi extension package, or a combination.
 - Confirm whether any user-facing docs, examples, support text, or issue templates should change with the release.
 
 ## 2. Sync Version Metadata
@@ -15,6 +15,7 @@ Update every version surface that should ship together:
 - `autocontext/pyproject.toml`
 - `autocontext/src/autocontext/__init__.py`
 - `ts/package.json`
+- `pi/package.json`
 
 If one package is intentionally not being released, note that clearly in the PR.
 
@@ -57,19 +58,30 @@ npm test
 npm pack --dry-run
 ```
 
+Pi:
+
+```bash
+cd pi
+npm run lint
+npm test
+npm run build
+npm pack --dry-run
+```
+
 ## 5. Sanity-Check Publishing Inputs
 
-- Confirm `.github/workflows/publish-python.yml` and `.github/workflows/publish-ts.yml` still match the intended publish surfaces.
-- Treat `.github/workflows/publish-python.yml` and `.github/workflows/publish-ts.yml` as the supported release workflows. Do not add a parallel publish path without updating the trusted publisher configuration first.
+- Confirm `.github/workflows/publish-python.yml`, `.github/workflows/publish-ts.yml`, and `.github/workflows/publish-pi-autocontext.yml` still match the intended publish surfaces.
+- Treat `.github/workflows/publish-python.yml`, `.github/workflows/publish-ts.yml`, and `.github/workflows/publish-pi-autocontext.yml` as the supported release workflows. Do not add a parallel publish path without updating the trusted publisher configuration first.
 - Confirm release notes in `CHANGELOG.md` reflect the tagged version.
 - Confirm any install commands in the READMEs still match the package names and binaries.
 
 ## 6. Publish
 
 - Merge the release prep to the intended branch.
-- Create and push package-specific tags in the format `py-vX.Y.Z` and `ts-vX.Y.Z`.
-- Watch the tag-triggered GitHub Actions `publish-python` and `publish-ts` workflows for PyPI and npm.
-- Approve the `release` environment when the trusted publish jobs pause for deployment review.
+- Create and push package-specific tags in the format `py-vX.Y.Z`, `ts-vX.Y.Z`, and `pi-vX.Y.Z`.
+- Watch the tag-triggered GitHub Actions `publish-python`, `publish-ts`, and `publish-pi-autocontext` workflows for PyPI and npm.
+- Approve the package-specific publish environment when the trusted publish jobs pause for deployment review.
+- If releasing `pi-autocontext` with a dependency on a new `autoctx` version, publish and verify `autoctx` first, then push the `pi-vX.Y.Z` tag.
 
 ## 7. Post-Release
 

--- a/pi/package-lock.json
+++ b/pi/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "pi-autocontext",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-autocontext",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "autoctx": "^0.4.6"
+        "autoctx": "^0.4.7"
       },
       "devDependencies": {
         "@sinclair/typebox": "^0.34.0",

--- a/pi/package.json
+++ b/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-autocontext",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "autocontext extension for Pi coding agent \u2014 iterative strategy generation, LLM judging, and evaluation tools",
   "type": "module",
   "keywords": ["pi-package", "pi", "pi-extension", "autocontext", "autoctx", "evaluation", "llm", "judging"],
@@ -18,7 +18,7 @@
     "@sinclair/typebox": "*"
   },
   "dependencies": {
-    "autoctx": "^0.4.6"
+    "autoctx": "^0.4.7"
   },
   "devDependencies": {
     "@sinclair/typebox": "^0.34.0",

--- a/pi/tests/extension.test.ts
+++ b/pi/tests/extension.test.ts
@@ -323,7 +323,7 @@ describe("Package manifest", () => {
 
   it("depends on the current autoctx toolkit line", () => {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-    expect(pkg.dependencies.autoctx).toBe("^0.4.6");
+    expect(pkg.dependencies.autoctx).toBe("^0.4.7");
   });
 });
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoctx",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoctx",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoctx",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump Python autocontext and TypeScript autoctx to 0.4.7
- bump pi-autocontext to 0.2.1 and add its environment-backed publish workflow
- update release checklist and changelog for the three package publish flow

## Verification
- npm run lint/build in ts passed earlier
- uv ruff/mypy/pytest/build in autocontext passed earlier
- pi lint/test/build/pack passed earlier