### PR TITLE
Refresh pi-autocontext release lockfile

### DIFF
--- a/pi/package-lock.json
+++ b/pi/package-lock.json
@@ -3310,9 +3310,9 @@
       }
     },
     "node_modules/autoctx": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/autoctx/-/autoctx-0.4.6.tgz",
-      "integrity": "sha512-frq9sqVGEUjVveu9JoYSe0gBv29txlZCLEXbPqm30TROFV01ozNeQHYOgX754WtT+Vy+vNjRbFzwqwZoT6DC1Q==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/autoctx/-/autoctx-0.4.7.tgz",
+      "integrity": "sha512-MgeX3Yij3Juqzk6fT0XgIFAcwvssjeWDIDN07K8X1XRgwq+7Cscq3h+/Cct+hT04Wxf0iDCOGvvgPKBjk35OmQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",


### PR DESCRIPTION
## Summary
- refresh pi/package-lock.json so the nested autoctx entry resolves to the published 0.4.7 package

## Verification
- npm ci
- npm run lint
- npm test
- npm run build