### PR TITLE
Fix schema evolution scoring and Claude CLI retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- TypeScript generated `schema_evolution` scenarios no longer score empty mutation plans as perfect, and generated actions now record mutation lineage before schema-coverage scoring (AC-666).
+- Python Claude CLI runtime calls now use bounded timeout retries with exponential backoff, total wall-clock caps, retry metadata, and warning/error logs for long-running live-agent calls (AC-684).
+
 ## [0.4.7] - 2026-04-29
 
 ### Added

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -85,7 +85,7 @@ AUTOCONTEXT_CLAUDE_TIMEOUT=300 \
 uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
 ```
 
-For longer live prompts, `autoctx solve`, `autoctx judge`, and `autoctx improve` all accept `--timeout <seconds>`. `autoctx solve` also accepts `--generation-time-budget <seconds>` to cap per-generation solve runtime. You can still use provider env vars such as `AUTOCONTEXT_CLAUDE_TIMEOUT` or `AUTOCONTEXT_PI_TIMEOUT`.
+For longer live prompts, `autoctx solve`, `autoctx judge`, and `autoctx improve` all accept `--timeout <seconds>`. `autoctx solve` also accepts `--generation-time-budget <seconds>` to cap per-generation solve runtime. You can still use provider env vars such as `AUTOCONTEXT_CLAUDE_TIMEOUT`, `AUTOCONTEXT_CLAUDE_MAX_RETRIES`, `AUTOCONTEXT_CLAUDE_MAX_TOTAL_SECONDS`, or `AUTOCONTEXT_PI_TIMEOUT`.
 
 Run with Codex CLI (`codex exec` via a local authenticated Codex runtime):
 

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -327,6 +327,10 @@ Key environment variables:
 | `AUTOCONTEXT_JUDGE_MODEL`                                            | Override judge model name                                                                           |
 | `AUTOCONTEXT_CLAUDE_MODEL`                                           | Claude CLI model alias (default: `sonnet`)                                                          |
 | `AUTOCONTEXT_CLAUDE_TIMEOUT`                                         | Claude CLI execution timeout in seconds (default: 600)                                              |
+| `AUTOCONTEXT_CLAUDE_MAX_RETRIES`                                     | Claude CLI timeout retry budget per provider invocation (default: 2)                                |
+| `AUTOCONTEXT_CLAUDE_RETRY_BACKOFF_SECONDS`                           | Initial Claude CLI timeout retry backoff in seconds (default: 0.25)                                 |
+| `AUTOCONTEXT_CLAUDE_RETRY_BACKOFF_MULTIPLIER`                        | Claude CLI timeout retry backoff multiplier (default: 2.0)                                          |
+| `AUTOCONTEXT_CLAUDE_MAX_TOTAL_SECONDS`                               | Total wall-clock cap across Claude CLI timeout retries (default: 1500)                              |
 | `AUTOCONTEXT_MODEL_COMPETITOR`                                       | Override competitor agent model                                                                     |
 | `AUTOCONTEXT_DB_PATH`                                                | SQLite database path                                                                                |
 | `AUTOCONTEXT_PI_COMMAND`                                             | Path to Pi CLI binary (default: `pi`)                                                               |

--- a/autocontext/src/autocontext/agents/llm_client.py
+++ b/autocontext/src/autocontext/agents/llm_client.py
@@ -586,6 +586,10 @@ def build_client_from_settings(
             permission_mode=settings.claude_permission_mode,
             session_persistence=settings.claude_session_persistence,
             timeout=settings.claude_timeout,
+            max_retries=settings.claude_max_retries,
+            retry_backoff_seconds=settings.claude_retry_backoff_seconds,
+            retry_backoff_multiplier=settings.claude_retry_backoff_multiplier,
+            max_total_seconds=settings.claude_max_total_seconds,
         )
         return RuntimeBridgeClient(ClaudeCLIRuntime(claude_config))
     if settings.agent_provider == "codex":

--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -199,6 +199,10 @@ def _create_claude_cli_bridge(
         permission_mode=settings.claude_permission_mode,
         session_persistence=settings.claude_session_persistence,
         timeout=settings.claude_timeout,
+        max_retries=settings.claude_max_retries,
+        retry_backoff_seconds=settings.claude_retry_backoff_seconds,
+        retry_backoff_multiplier=settings.claude_retry_backoff_multiplier,
+        max_total_seconds=settings.claude_max_total_seconds,
     )
     return RuntimeBridgeClient(ClaudeCLIRuntime(config))
 

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -625,6 +625,26 @@ class AppSettings(BaseModel):
             "(AC-588: 300→600 after 0.4.5 sweep)"
         ),
     )
+    claude_max_retries: int = Field(
+        default=2,
+        ge=0,
+        description="Claude CLI timeout retry budget per provider invocation",
+    )
+    claude_retry_backoff_seconds: float = Field(
+        default=0.25,
+        ge=0.0,
+        description="Initial Claude CLI timeout retry backoff in seconds",
+    )
+    claude_retry_backoff_multiplier: float = Field(
+        default=2.0,
+        ge=1.0,
+        description="Multiplier for Claude CLI timeout retry backoff",
+    )
+    claude_max_total_seconds: float = Field(
+        default=25 * 60.0,
+        ge=1.0,
+        description="Total wall-clock cap across Claude CLI timeout retries",
+    )
     claude_tools: str | None = Field(default=None, description="Claude CLI tools override")
     claude_permission_mode: str = Field(default="bypassPermissions", description="Claude CLI permission mode")
     claude_session_persistence: bool = Field(default=False, description="Persist Claude CLI sessions across turns")

--- a/autocontext/src/autocontext/config/settings.py
+++ b/autocontext/src/autocontext/config/settings.py
@@ -617,34 +617,11 @@ class AppSettings(BaseModel):
     notebook_enabled: bool = Field(default=True, description="Enable session notebook feature")
     # Claude Code CLI runtime (AC-317)
     claude_model: str = Field(default="sonnet", description="Claude CLI model alias")
-    claude_timeout: float = Field(
-        default=600.0,
-        ge=1.0,
-        description=(
-            "Claude CLI per-call execution timeout "
-            "(AC-588: 300→600 after 0.4.5 sweep)"
-        ),
-    )
-    claude_max_retries: int = Field(
-        default=2,
-        ge=0,
-        description="Claude CLI timeout retry budget per provider invocation",
-    )
-    claude_retry_backoff_seconds: float = Field(
-        default=0.25,
-        ge=0.0,
-        description="Initial Claude CLI timeout retry backoff in seconds",
-    )
-    claude_retry_backoff_multiplier: float = Field(
-        default=2.0,
-        ge=1.0,
-        description="Multiplier for Claude CLI timeout retry backoff",
-    )
-    claude_max_total_seconds: float = Field(
-        default=25 * 60.0,
-        ge=1.0,
-        description="Total wall-clock cap across Claude CLI timeout retries",
-    )
+    claude_timeout: float = Field(default=600.0, ge=1.0, description="Claude CLI per-call execution timeout")
+    claude_max_retries: int = Field(default=2, ge=0, description="Claude CLI timeout retry budget per invocation")
+    claude_retry_backoff_seconds: float = Field(default=0.25, ge=0.0, description="Claude CLI retry backoff")
+    claude_retry_backoff_multiplier: float = Field(default=2.0, ge=1.0, description="Claude CLI retry backoff multiplier")
+    claude_max_total_seconds: float = Field(default=25 * 60.0, ge=1.0, description="Claude CLI total retry cap")
     claude_tools: str | None = Field(default=None, description="Claude CLI tools override")
     claude_permission_mode: str = Field(default="bypassPermissions", description="Claude CLI permission mode")
     claude_session_persistence: bool = Field(default=False, description="Persist Claude CLI sessions across turns")

--- a/autocontext/src/autocontext/providers/registry.py
+++ b/autocontext/src/autocontext/providers/registry.py
@@ -173,6 +173,10 @@ def get_provider(settings: AppSettings) -> LLMProvider:
             permission_mode=settings.claude_permission_mode,
             session_persistence=settings.claude_session_persistence,
             timeout=settings.claude_timeout,
+            max_retries=settings.claude_max_retries,
+            retry_backoff_seconds=settings.claude_retry_backoff_seconds,
+            retry_backoff_multiplier=settings.claude_retry_backoff_multiplier,
+            max_total_seconds=settings.claude_max_total_seconds,
         ))
         return RuntimeBridgeProvider(claude_runtime, default_model_name=settings.claude_model)
 

--- a/autocontext/src/autocontext/runtimes/claude_cli.py
+++ b/autocontext/src/autocontext/runtimes/claude_cli.py
@@ -176,6 +176,20 @@ class ClaudeCLIRuntime(AgentRuntime):
                 elapsed = time.monotonic() - start
                 if attempt_index < max_retries and self._has_retry_budget(total_start):
                     delay = self._retry_delay(attempt_index)
+                    remaining = self._remaining_total_budget(total_start)
+                    if remaining is not None and delay >= remaining:
+                        logger.warning(
+                            "claude-cli retry skipped reason=timeout_budget_exhausted "
+                            "delay=%.2fs remaining=%.2fs elapsed=%.1fs",
+                            delay,
+                            remaining,
+                            elapsed,
+                        )
+                        return self._timeout_output(
+                            attempts=attempt,
+                            total_elapsed=time.monotonic() - total_start,
+                            retry_exhausted=True,
+                        )
                     logger.warning(
                         "claude-cli retry attempt=%d/%d reason=timeout delay=%.2fs elapsed=%.1fs",
                         attempt,
@@ -230,16 +244,21 @@ class ClaudeCLIRuntime(AgentRuntime):
             retry_exhausted=True,
         )
 
-    def _attempt_timeout(self, total_start: float) -> float:
+    def _remaining_total_budget(self, total_start: float) -> float | None:
         max_total = float(self._config.max_total_seconds)
         if max_total <= 0:
+            return None
+        return max(0.0, max_total - (time.monotonic() - total_start))
+
+    def _attempt_timeout(self, total_start: float) -> float:
+        remaining = self._remaining_total_budget(total_start)
+        if remaining is None:
             return float(self._config.timeout)
-        remaining = max_total - (time.monotonic() - total_start)
         return min(float(self._config.timeout), remaining)
 
     def _has_retry_budget(self, total_start: float) -> bool:
-        max_total = float(self._config.max_total_seconds)
-        return max_total <= 0 or (time.monotonic() - total_start) < max_total
+        remaining = self._remaining_total_budget(total_start)
+        return remaining is None or remaining > 0
 
     def _retry_delay(self, retry_index: int) -> float:
         base = max(0.0, float(self._config.retry_backoff_seconds))

--- a/autocontext/src/autocontext/runtimes/claude_cli.py
+++ b/autocontext/src/autocontext/runtimes/claude_cli.py
@@ -30,6 +30,11 @@ class ClaudeCLIConfig:
     session_persistence: bool = False
     session_id: str | None = None  # Set to maintain context across rounds
     timeout: float = 600.0  # AC-588: per-call default (was 300, AC-570 raised from 120)
+    max_retries: int = 2
+    retry_backoff_seconds: float = 0.25
+    retry_backoff_multiplier: float = 2.0
+    max_total_seconds: float = 25 * 60.0
+    timeout_warning_fraction: float = 0.8
     system_prompt: str | None = None
     append_system_prompt: str | None = None
     extra_args: list[str] = field(default_factory=list)
@@ -136,45 +141,147 @@ class ClaudeCLIRuntime(AgentRuntime):
 
     def _invoke(self, prompt: str, args: list[str]) -> AgentOutput:
         """Execute claude -p and parse the JSON result."""
-        logger.info(
-            "claude-cli invoke: model=%s timeout=%ds",
-            self._config.model,
-            int(self._config.timeout),
-        )
+        total_start = time.monotonic()
+        max_retries = max(0, int(self._config.max_retries))
+        total_attempts = max_retries + 1
 
-        start = time.monotonic()
-        try:
-            result = subprocess.run(
-                args,
-                input=prompt,
-                capture_output=True,
-                text=True,
-                timeout=self._config.timeout,
-            )
-        except subprocess.TimeoutExpired:
-            logger.error("claude CLI timed out after %.0fs", self._config.timeout)
-            return AgentOutput(text="", metadata={"error": "timeout"})
-        except FileNotFoundError:
-            logger.error("claude CLI not found. Install Claude Code first.")
-            return AgentOutput(text="", metadata={"error": "claude_not_found"})
-
-        elapsed = time.monotonic() - start
-        logger.debug(
-            "claude-cli completed in %.1fs (budget %ds)",
-            elapsed,
-            int(self._config.timeout),
-        )
-
-        if result.returncode != 0:
-            logger.warning("claude CLI exited with code %d: %s", result.returncode, result.stderr[:200])
-            # Try to use stdout anyway — sometimes there's partial output
-            if not result.stdout.strip():
-                return AgentOutput(
-                    text="",
-                    metadata={"error": "nonzero_exit", "stderr": result.stderr[:500]},
+        for attempt_index in range(total_attempts):
+            attempt = attempt_index + 1
+            timeout = self._attempt_timeout(total_start)
+            if timeout <= 0:
+                return self._timeout_output(
+                    attempts=attempt_index,
+                    total_elapsed=time.monotonic() - total_start,
+                    retry_exhausted=True,
                 )
 
-        return self._parse_output(result.stdout)
+            logger.info(
+                "claude-cli invoke: model=%s timeout=%ds attempt=%d/%d",
+                self._config.model,
+                int(timeout),
+                attempt,
+                total_attempts,
+            )
+
+            start = time.monotonic()
+            try:
+                result = subprocess.run(
+                    args,
+                    input=prompt,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+            except subprocess.TimeoutExpired:
+                elapsed = time.monotonic() - start
+                if attempt_index < max_retries and self._has_retry_budget(total_start):
+                    delay = self._retry_delay(attempt_index)
+                    logger.warning(
+                        "claude-cli retry attempt=%d/%d reason=timeout delay=%.2fs elapsed=%.1fs",
+                        attempt,
+                        max_retries,
+                        delay,
+                        elapsed,
+                    )
+                    time.sleep(delay)
+                    continue
+                return self._timeout_output(
+                    attempts=attempt,
+                    total_elapsed=time.monotonic() - total_start,
+                    retry_exhausted=True,
+                )
+            except FileNotFoundError:
+                logger.error("claude CLI not found. Install Claude Code first.")
+                return AgentOutput(text="", metadata={"error": "claude_not_found", "attempts": attempt})
+
+            elapsed = time.monotonic() - start
+            logger.debug(
+                "claude-cli completed in %.1fs (budget %ds)",
+                elapsed,
+                int(timeout),
+            )
+            self._warn_if_slow_attempt(elapsed, timeout, attempt)
+
+            if result.returncode != 0:
+                logger.warning("claude CLI exited with code %d: %s", result.returncode, result.stderr[:200])
+                # Try to use stdout anyway — sometimes there's partial output
+                if not result.stdout.strip():
+                    return AgentOutput(
+                        text="",
+                        metadata={
+                            "error": "nonzero_exit",
+                            "stderr": result.stderr[:500],
+                            "attempts": attempt,
+                            "retry_count": attempt_index,
+                        },
+                    )
+
+            output = self._parse_output(result.stdout)
+            output.metadata = {
+                **output.metadata,
+                "attempts": attempt,
+                "retry_count": attempt_index,
+            }
+            return output
+
+        return self._timeout_output(
+            attempts=total_attempts,
+            total_elapsed=time.monotonic() - total_start,
+            retry_exhausted=True,
+        )
+
+    def _attempt_timeout(self, total_start: float) -> float:
+        max_total = float(self._config.max_total_seconds)
+        if max_total <= 0:
+            return float(self._config.timeout)
+        remaining = max_total - (time.monotonic() - total_start)
+        return min(float(self._config.timeout), remaining)
+
+    def _has_retry_budget(self, total_start: float) -> bool:
+        max_total = float(self._config.max_total_seconds)
+        return max_total <= 0 or (time.monotonic() - total_start) < max_total
+
+    def _retry_delay(self, retry_index: int) -> float:
+        base = max(0.0, float(self._config.retry_backoff_seconds))
+        multiplier = max(1.0, float(self._config.retry_backoff_multiplier))
+        return base * (multiplier ** retry_index)
+
+    def _warn_if_slow_attempt(self, elapsed: float, timeout: float, attempt: int) -> None:
+        fraction = float(self._config.timeout_warning_fraction)
+        if fraction <= 0:
+            return
+        threshold = timeout * fraction
+        if elapsed >= threshold:
+            logger.warning(
+                "claude-cli slow invoke: attempt=%d elapsed=%.1fs timeout=%.0fs",
+                attempt,
+                elapsed,
+                timeout,
+            )
+
+    def _timeout_output(
+        self,
+        *,
+        attempts: int,
+        total_elapsed: float,
+        retry_exhausted: bool,
+    ) -> AgentOutput:
+        logger.error(
+            "claude CLI timed out after %d attempt(s) (timeout=%.0fs total_elapsed=%.1fs)",
+            attempts,
+            self._config.timeout,
+            total_elapsed,
+        )
+        return AgentOutput(
+            text="",
+            metadata={
+                "error": "timeout",
+                "attempts": attempts,
+                "retry_count": max(0, attempts - 1),
+                "retry_exhausted": retry_exhausted,
+                "total_elapsed_seconds": total_elapsed,
+            },
+        )
 
     def _parse_output(self, raw: str) -> AgentOutput:
         """Parse JSON output from claude -p --output-format json."""

--- a/autocontext/tests/test_per_role_provider.py
+++ b/autocontext/tests/test_per_role_provider.py
@@ -271,6 +271,10 @@ class TestCreateClientForProvider:
         settings = AppSettings(
             claude_model="opus",
             claude_timeout=45.0,
+            claude_max_retries=1,
+            claude_retry_backoff_seconds=0.1,
+            claude_retry_backoff_multiplier=3.0,
+            claude_max_total_seconds=900.0,
             claude_tools="Bash,Read",
             claude_permission_mode="acceptEdits",
             claude_session_persistence=True,
@@ -281,6 +285,10 @@ class TestCreateClientForProvider:
         assert isinstance(client, RuntimeBridgeClient)
         assert client._runtime._config.model == "opus"  # type: ignore[attr-defined]
         assert client._runtime._config.timeout == 45.0  # type: ignore[attr-defined]
+        assert client._runtime._config.max_retries == 1  # type: ignore[attr-defined]
+        assert client._runtime._config.retry_backoff_seconds == 0.1  # type: ignore[attr-defined]
+        assert client._runtime._config.retry_backoff_multiplier == 3.0  # type: ignore[attr-defined]
+        assert client._runtime._config.max_total_seconds == 900.0  # type: ignore[attr-defined]
         assert client._runtime._config.tools == "Bash,Read"  # type: ignore[attr-defined]
         assert client._runtime._config.permission_mode == "acceptEdits"  # type: ignore[attr-defined]
         assert client._runtime._config.session_persistence is True  # type: ignore[attr-defined]

--- a/autocontext/tests/test_runtimes.py
+++ b/autocontext/tests/test_runtimes.py
@@ -300,6 +300,26 @@ class TestClaudeCLIRuntime:
         assert mock_run.call_count == 2
         mock_sleep.assert_called_once_with(0.0)
 
+    @patch("autocontext.runtimes.claude_cli.time.sleep")
+    @patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=1))
+    def test_timeout_retry_skips_sleep_that_would_exhaust_total_cap(self, mock_run, mock_sleep):
+        cfg = ClaudeCLIConfig(
+            timeout=1.0,
+            max_retries=2,
+            retry_backoff_seconds=60.0,
+            max_total_seconds=10.0,
+        )
+        runtime = ClaudeCLIRuntime(cfg)
+        runtime._claude_path = "/usr/bin/claude"
+
+        result = runtime.generate("slow task")
+
+        assert result.metadata.get("error") == "timeout"
+        assert result.metadata.get("attempts") == 1
+        assert result.metadata.get("retry_exhausted") is True
+        assert mock_run.call_count == 1
+        mock_sleep.assert_not_called()
+
     @patch("subprocess.run", side_effect=FileNotFoundError)
     def test_missing_cli(self, mock_run):
         runtime = ClaudeCLIRuntime()

--- a/autocontext/tests/test_runtimes.py
+++ b/autocontext/tests/test_runtimes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 from unittest.mock import patch
 
@@ -98,6 +99,11 @@ class TestClaudeCLIConfig:
         cfg = ClaudeCLIConfig(model="opus", tools="Bash,Read", timeout=60.0)
         assert cfg.model == "opus"
         assert cfg.tools == "Bash,Read"
+
+    def test_retry_defaults_bound_total_runtime(self):
+        cfg = ClaudeCLIConfig()
+        assert cfg.max_retries <= 3
+        assert cfg.max_total_seconds < 30 * 60
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +245,60 @@ class TestClaudeCLIRuntime:
         result = runtime.generate("slow task")
         assert result.text == ""
         assert result.metadata.get("error") == "timeout"
+
+    @patch("autocontext.runtimes.claude_cli.time.sleep")
+    @patch("subprocess.run")
+    def test_timeout_retries_are_bounded_and_observable(
+        self,
+        mock_run,
+        mock_sleep,
+        caplog,
+    ):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=5)
+        cfg = ClaudeCLIConfig(
+            timeout=5.0,
+            max_retries=2,
+            retry_backoff_seconds=0.25,
+            retry_backoff_multiplier=2.0,
+            max_total_seconds=30.0,
+        )
+        runtime = ClaudeCLIRuntime(cfg)
+        runtime._claude_path = "/usr/bin/claude"
+
+        with caplog.at_level(logging.WARNING, logger="autocontext.runtimes.claude_cli"):
+            result = runtime.generate("slow task")
+
+        assert result.text == ""
+        assert result.metadata.get("error") == "timeout"
+        assert result.metadata.get("attempts") == 3
+        assert result.metadata.get("retry_exhausted") is True
+        assert mock_run.call_count == 3
+        assert [call.args[0] for call in mock_sleep.call_args_list] == [0.25, 0.5]
+        messages = "\n".join(record.getMessage() for record in caplog.records)
+        assert "claude-cli retry attempt=1/2 reason=timeout" in messages
+        assert "claude-cli retry attempt=2/2 reason=timeout" in messages
+        assert "claude CLI timed out after 3 attempt(s)" in messages
+
+    @patch("autocontext.runtimes.claude_cli.time.sleep")
+    @patch("subprocess.run")
+    def test_timeout_retry_can_recover(self, mock_run, mock_sleep):
+        mock_run.side_effect = [
+            subprocess.TimeoutExpired(cmd="claude", timeout=5),
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=_mock_claude_json("recovered"), stderr="",
+            ),
+        ]
+        cfg = ClaudeCLIConfig(timeout=5.0, max_retries=2, retry_backoff_seconds=0.0)
+        runtime = ClaudeCLIRuntime(cfg)
+        runtime._claude_path = "/usr/bin/claude"
+
+        result = runtime.generate("slow task")
+
+        assert result.text == "recovered"
+        assert result.metadata.get("attempts") == 2
+        assert result.metadata.get("retry_count") == 1
+        assert mock_run.call_count == 2
+        mock_sleep.assert_called_once_with(0.0)
 
     @patch("subprocess.run", side_effect=FileNotFoundError)
     def test_missing_cli(self, mock_run):

--- a/ts/src/scenarios/codegen/templates/schema-evolution-template.ts
+++ b/ts/src/scenarios/codegen/templates/schema-evolution-template.ts
@@ -51,6 +51,9 @@ const scenario = {
   },
 
   getAvailableActions(state) {
+    if ((state.schemaVersion || 0) < MUTATIONS.length) {
+      return ACTIONS;
+    }
     const completed = new Set(state.completedActions || []);
     return ACTIONS.filter((action) => !completed.has(action.name));
   },

--- a/ts/src/scenarios/codegen/templates/schema-evolution-template.ts
+++ b/ts/src/scenarios/codegen/templates/schema-evolution-template.ts
@@ -2,6 +2,22 @@ export const SCHEMA_EVOLUTION_SCENARIO_TEMPLATE = String.raw`// Generated schema
 const ACTIONS = __ACTIONS__;
 const MUTATIONS = __MUTATIONS__;
 
+function recordMutation(state, mutation) {
+  return {
+    ...state,
+    schemaVersion: (state.schemaVersion || 0) + 1,
+    mutationLog: [...(state.mutationLog || []), mutation],
+    staleDetections: (state.staleDetections || 0) + 1,
+  };
+}
+
+function applyPendingMutation(state) {
+  const currentVersion = state.schemaVersion || 0;
+  const mutation = MUTATIONS[currentVersion];
+  if (!mutation) return state;
+  return recordMutation(state, mutation);
+}
+
 const scenario = {
   name: __SCENARIO_NAME__,
 
@@ -57,9 +73,10 @@ const scenario = {
     }
     nextState.completedActions.push(action.name);
     nextState.timeline.push({ action: action.name, parameters: action.parameters || {} });
+    const evolvedState = applyPendingMutation(nextState);
     return {
       result: { success: true, output: "executed " + action.name, stateChanges: {} },
-      state: nextState,
+      state: evolvedState,
     };
   },
 
@@ -69,13 +86,16 @@ const scenario = {
 
   getResult(state, trace) {
     const versionsHandled = state.schemaVersion || 0;
-    const coverage = MUTATIONS.length > 0 ? versionsHandled / MUTATIONS.length : 1;
+    const hasMutations = MUTATIONS.length > 0;
+    const coverage = hasMutations ? versionsHandled / MUTATIONS.length : 0;
     const detections = state.staleDetections || 0;
-    const detectionRate = MUTATIONS.length > 0 ? Math.min(1, detections / MUTATIONS.length) : 1;
+    const detectionRate = hasMutations ? Math.min(1, detections / MUTATIONS.length) : 0;
     const score = Math.round((coverage * 0.5 + detectionRate * 0.5) * 10000) / 10000;
+    const reasoning = versionsHandled + "/" + MUTATIONS.length + " versions handled"
+      + (hasMutations ? "" : " (no schema mutations defined)");
     return {
       score,
-      reasoning: versionsHandled + "/" + MUTATIONS.length + " versions handled",
+      reasoning,
       dimensionScores: {
         schemaCoverage: Math.round(coverage * 10000) / 10000,
         staleDetection: Math.round(detectionRate * 10000) / 10000,
@@ -96,12 +116,7 @@ const scenario = {
   },
 
   applyMutation(state, mutation) {
-    return {
-      ...state,
-      schemaVersion: (state.schemaVersion || 0) + 1,
-      mutationLog: [...(state.mutationLog || []), mutation],
-      staleDetections: (state.staleDetections || 0) + 1,
-    };
+    return recordMutation(state, mutation);
   },
 
   getRubric() {

--- a/ts/tests/codegen.test.ts
+++ b/ts/tests/codegen.test.ts
@@ -18,6 +18,35 @@ import { generateSchemaEvolutionSource } from "../src/scenarios/codegen/schema-e
 import { generateToolFragilitySource } from "../src/scenarios/codegen/tool-fragility-codegen.js";
 import { generateCoordinationSource } from "../src/scenarios/codegen/coordination-codegen.js";
 
+interface GeneratedScenarioForTest {
+  initialState(seed?: number): Record<string, unknown>;
+  getAvailableActions(state: Record<string, unknown>): Array<{
+    name: string;
+    parameters?: Record<string, unknown>;
+  }>;
+  executeAction(
+    state: Record<string, unknown>,
+    action: { name: string; parameters?: Record<string, unknown> },
+  ): { result: Record<string, unknown>; state: Record<string, unknown> };
+  getResult(
+    state: Record<string, unknown>,
+    trace: Record<string, unknown>,
+  ): {
+    score: number;
+    reasoning: string;
+    dimensionScores: Record<string, number>;
+  };
+}
+
+function loadGeneratedScenarioForTest(source: string): GeneratedScenarioForTest {
+  const module: { exports: { scenario?: GeneratedScenarioForTest } } = { exports: {} };
+  new Function("module", "exports", source)(module, module.exports);
+  if (!module.exports.scenario) {
+    throw new Error("generated source did not export scenario");
+  }
+  return module.exports.scenario;
+}
+
 // ---------------------------------------------------------------------------
 // Registry routing
 // ---------------------------------------------------------------------------
@@ -197,6 +226,51 @@ describe("schema-evolution codegen", () => {
     expect(source).toContain("getMutations");
     expect(source).toContain("applyMutation");
     new Function(source);
+  });
+
+  it("does not score zero-mutation schema evolution as perfect", () => {
+    const source = generateSchemaEvolutionSource({
+      description: "Schema migration with no discovered mutations",
+      mutations: [],
+      actions: [
+        { name: "inspect", description: "Inspect schema", parameters: {}, preconditions: [], effects: [] },
+      ],
+    }, "empty_schema_migration");
+    const scenario = loadGeneratedScenarioForTest(source);
+
+    const result = scenario.getResult(scenario.initialState(7), { records: [] });
+
+    expect(result.score).toBe(0);
+    expect(result.reasoning).toContain("0/0 versions handled");
+    expect(result.reasoning).toMatch(/no schema mutations/i);
+    expect(result.dimensionScores.schemaCoverage).toBe(0);
+    expect(result.dimensionScores.staleDetection).toBe(0);
+  });
+
+  it("records mutation lineage when schema-evolution actions execute", () => {
+    const source = generateSchemaEvolutionSource({
+      description: "Schema migration",
+      mutations: [
+        { version: 2, description: "Add priority", changes: { added: ["priority"] } },
+        { version: 3, description: "Rename status", changes: { renamed: ["status"] } },
+      ],
+      actions: [
+        { name: "inspect", description: "Inspect schema", parameters: {}, preconditions: [], effects: [] },
+      ],
+    }, "lineage_schema_migration");
+    const scenario = loadGeneratedScenarioForTest(source);
+    const state = scenario.initialState(3);
+    const [action] = scenario.getAvailableActions(state);
+
+    const { state: nextState } = scenario.executeAction(state, action);
+    const result = scenario.getResult(nextState, { records: [{ action }] });
+
+    expect(nextState.schemaVersion).toBe(1);
+    expect(nextState.mutationLog).toEqual([
+      { version: 2, description: "Add priority", changes: { added: ["priority"] } },
+    ]);
+    expect(result.score).toBe(0.5);
+    expect(result.reasoning).toBe("1/2 versions handled");
   });
 });
 

--- a/ts/tests/codegen.test.ts
+++ b/ts/tests/codegen.test.ts
@@ -272,6 +272,38 @@ describe("schema-evolution codegen", () => {
     expect(result.score).toBe(0.5);
     expect(result.reasoning).toBe("1/2 versions handled");
   });
+
+  it("allows sparse schema-evolution action sets to handle every mutation", () => {
+    const source = generateSchemaEvolutionSource({
+      description: "Schema migration with fewer actions than mutations",
+      mutations: [
+        { version: 2, description: "Add priority", changes: { added: ["priority"] } },
+        { version: 3, description: "Rename status", changes: { renamed: ["status"] } },
+      ],
+      actions: [
+        { name: "inspect", description: "Inspect schema", parameters: {}, preconditions: [], effects: [] },
+      ],
+    }, "sparse_schema_migration");
+    const scenario = loadGeneratedScenarioForTest(source);
+    const state = scenario.initialState(3);
+    const [firstAction] = scenario.getAvailableActions(state);
+    const first = scenario.executeAction(state, firstAction);
+
+    const availableAfterFirst = scenario.getAvailableActions(first.state);
+    expect(availableAfterFirst.map((action) => action.name)).toEqual(["inspect"]);
+
+    const [secondAction] = availableAfterFirst;
+    const second = scenario.executeAction(first.state, secondAction);
+    const result = scenario.getResult(second.state, { records: [{ action: firstAction }] });
+
+    expect(second.state.schemaVersion).toBe(2);
+    expect(second.state.mutationLog).toEqual([
+      { version: 2, description: "Add priority", changes: { added: ["priority"] } },
+      { version: 3, description: "Rename status", changes: { renamed: ["status"] } },
+    ]);
+    expect(result.score).toBe(1);
+    expect(result.reasoning).toBe("2/2 versions handled");
+  });
 });
 
 describe("tool-fragility codegen", () => {


### PR DESCRIPTION
## Summary
- Fix generated TypeScript schema_evolution scenarios so empty mutation plans no longer score as perfect and actions record mutation lineage before scoring.
- Add bounded Claude CLI timeout retries with backoff, total wall-clock caps, retry metadata, and warning/error logs.
- Thread the Claude retry policy through runtime bridge/provider-registry creation paths and document the new env knobs.

## Verification
- npx vitest run tests/codegen.test.ts
- npm run lint
- uv run pytest tests/test_runtimes.py tests/test_claude_cli_timeout.py tests/test_per_role_provider.py -q
- uv run ruff check src tests/test_runtimes.py tests/test_per_role_provider.py tests/test_claude_cli_timeout.py
- uv run mypy src/autocontext/runtimes/claude_cli.py src/autocontext/agents/provider_bridge.py src/autocontext/agents/llm_client.py src/autocontext/providers/registry.py

## Notes
Full npm test was attempted and still has unrelated baseline/flaky failures in tests/type-assertions.test.ts, tests/scenario-revision.test.ts, tests/server-protocol.test.ts, and tests/campaign-cli.test.ts.

Linear: AC-666, AC-684