### PR TITLE
Fix AC-687, AC-685, and AC-665 run regressions

### DIFF
--- a/autocontext/src/autocontext/analytics/events_to_trace.py
+++ b/autocontext/src/autocontext/analytics/events_to_trace.py
@@ -1,0 +1,278 @@
+"""Convert raw NDJSON event streams into canonical RunTrace artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from autocontext.analytics.run_trace import ActorRef, CausalEdge, ResourceRef, RunTrace, TraceEvent
+
+_CATEGORY_BY_EVENT: dict[str, str] = {
+    "run_started": "checkpoint",
+    "generation_started": "checkpoint",
+    "generation_completed": "checkpoint",
+    "generation_timing": "checkpoint",
+    "startup_verification": "checkpoint",
+    "agents_started": "action",
+    "role_event": "action",
+    "role_completed": "action",
+    "curator_started": "action",
+    "curator_completed": "action",
+    "skeptic_started": "action",
+    "skeptic_completed": "action",
+    "tournament_started": "validation",
+    "tournament_completed": "validation",
+    "match_completed": "validation",
+    "holdout_evaluated": "validation",
+    "staged_validation_started": "validation",
+    "staged_validation_completed": "validation",
+    "gate_decided": "validation",
+    "analyst_feedback_rated": "observation",
+    "consultation_triggered": "observation",
+    "consultation_completed": "observation",
+    "generation_failed": "failure",
+    "generation_budget_exhausted": "failure",
+    "validity_check_failed": "failure",
+    "harness_validation_failed": "failure",
+    "regression_fixtures_failed": "failure",
+    "dry_run_failed": "failure",
+    "validity_check_passed": "validation",
+    "harness_validation_passed": "validation",
+    "regression_fixtures_passed": "validation",
+    "dry_run_passed": "validation",
+}
+
+_STAGE_BY_EVENT: dict[str, str] = {
+    "run_started": "init",
+    "startup_verification": "init",
+    "agents_started": "init",
+    "generation_started": "init",
+    "generation_completed": "gate",
+    "generation_timing": "gate",
+    "generation_failed": "gate",
+    "generation_budget_exhausted": "gate",
+    "tournament_started": "match",
+    "tournament_completed": "match",
+    "match_completed": "match",
+    "holdout_evaluated": "match",
+    "staged_validation_started": "gate",
+    "staged_validation_completed": "gate",
+    "validity_check_failed": "gate",
+    "validity_check_passed": "gate",
+    "harness_validation_failed": "gate",
+    "harness_validation_passed": "gate",
+    "regression_fixtures_failed": "gate",
+    "regression_fixtures_passed": "gate",
+    "dry_run_failed": "gate",
+    "dry_run_passed": "gate",
+    "gate_decided": "gate",
+    "analyst_feedback_rated": "analyze",
+    "consultation_triggered": "analyze",
+    "consultation_completed": "analyze",
+    "curator_started": "curate",
+    "curator_completed": "curate",
+    "skeptic_started": "analyze",
+    "skeptic_completed": "analyze",
+}
+
+_ROLE_STAGE: dict[str, str] = {
+    "competitor": "compete",
+    "analyst": "analyze",
+    "coach": "coach",
+    "architect": "architect",
+    "curator": "curate",
+    "skeptic": "analyze",
+}
+
+
+def events_to_trace(events_path: Path, run_id: str) -> RunTrace:
+    """Build a RunTrace from an EventStreamEmitter NDJSON file."""
+    rows = _read_event_rows(events_path, run_id)
+    events: list[TraceEvent] = []
+    causal_edges: list[CausalEdge] = []
+    previous_event_id: str | None = None
+    scenario = ""
+
+    for index, row in enumerate(rows, start=1):
+        payload = _payload(row)
+        event_type = str(row.get("event") or "unknown")
+        if not scenario and isinstance(payload.get("scenario"), str):
+            scenario = payload["scenario"]
+        event_id = f"{event_type}-{_int_value(row.get('seq'), index)}"
+        event = TraceEvent(
+            event_id=event_id,
+            run_id=run_id,
+            generation_index=_generation_index(payload),
+            sequence_number=_int_value(row.get("seq"), index),
+            timestamp=str(row.get("ts") or ""),
+            category=_category_for(event_type),
+            event_type=event_type,
+            actor=_actor_for(event_type, payload),
+            resources=_resources_for(payload),
+            summary=_summary_for(event_type, payload),
+            detail=payload,
+            parent_event_id=previous_event_id,
+            cause_event_ids=[previous_event_id] if previous_event_id else [],
+            evidence_ids=[],
+            severity=_severity_for(event_type, payload),
+            stage=_stage_for(event_type, payload),
+            outcome=_outcome_for(event_type, payload),
+            duration_ms=_duration_ms(payload),
+            metadata={"channel": str(row.get("channel") or ""), "scenario": scenario},
+        )
+        events.append(event)
+        if previous_event_id is not None:
+            causal_edges.append(CausalEdge(
+                source_event_id=previous_event_id,
+                target_event_id=event_id,
+                relation="triggers",
+            ))
+        previous_event_id = event_id
+
+    return RunTrace(
+        trace_id=f"trace-{run_id}",
+        run_id=run_id,
+        generation_index=None,
+        schema_version="1.0.0",
+        events=events,
+        causal_edges=causal_edges,
+        created_at=events[0].timestamp if events else "",
+        metadata={
+            "scenario": scenario,
+            "source": str(events_path),
+            "event_count": len(events),
+        },
+    )
+
+
+def collect_run_ids(events_path: Path) -> list[str]:
+    """Return run ids present in an EventStreamEmitter NDJSON file."""
+    run_ids: set[str] = set()
+    for row in _iter_event_rows(events_path):
+        payload = _payload(row)
+        value = payload.get("run_id")
+        if isinstance(value, str) and value:
+            run_ids.add(value)
+    return sorted(run_ids)
+
+
+def _read_event_rows(events_path: Path, run_id: str) -> list[dict[str, Any]]:
+    return [
+        row for row in _iter_event_rows(events_path)
+        if _payload(row).get("run_id") == run_id
+    ]
+
+
+def _iter_event_rows(events_path: Path) -> list[dict[str, Any]]:
+    if not events_path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in events_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            rows.append(payload)
+    return rows
+
+
+def _payload(row: dict[str, Any]) -> dict[str, Any]:
+    payload = row.get("payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+def _category_for(event_type: str) -> str:
+    return _CATEGORY_BY_EVENT.get(event_type, "observation")
+
+
+def _stage_for(event_type: str, payload: dict[str, Any]) -> str:
+    role = str(payload.get("role") or "")
+    if role in _ROLE_STAGE:
+        return _ROLE_STAGE[role]
+    return _STAGE_BY_EVENT.get(event_type, "init")
+
+
+def _actor_for(event_type: str, payload: dict[str, Any]) -> ActorRef:
+    role = str(payload.get("role") or "")
+    if role:
+        return ActorRef(actor_type="role", actor_id=role, actor_name=str(payload.get("subagent_id") or role))
+    return ActorRef(actor_type="system", actor_id="event_stream", actor_name=event_type)
+
+
+def _resources_for(payload: dict[str, Any]) -> list[ResourceRef]:
+    model = payload.get("model") or payload.get("model_used")
+    if not model:
+        return []
+    model_text = str(model)
+    return [ResourceRef(
+        resource_type="model",
+        resource_id=model_text,
+        resource_name=model_text,
+        resource_path="",
+    )]
+
+
+def _summary_for(event_type: str, payload: dict[str, Any]) -> str:
+    if isinstance(payload.get("summary"), str):
+        return str(payload["summary"])
+    if isinstance(payload.get("reason"), str):
+        return f"{event_type}: {payload['reason']}"
+    return event_type.replace("_", " ")
+
+
+def _outcome_for(event_type: str, payload: dict[str, Any]) -> str | None:
+    for key in ("status", "outcome", "gate_decision", "decision"):
+        value = payload.get(key)
+        if value not in (None, ""):
+            return str(value)
+    if event_type == "match_completed" and isinstance(payload.get("passed_validation"), bool):
+        return "passed" if payload["passed_validation"] else "failed"
+    if event_type.endswith("_started"):
+        return "started"
+    if event_type.endswith("_completed"):
+        return "completed"
+    if event_type.endswith("_failed"):
+        return "failed"
+    return None
+
+
+def _severity_for(event_type: str, payload: dict[str, Any]) -> str:
+    explicit = str(payload.get("severity") or "").lower()
+    if explicit in {"info", "warning", "error", "critical"}:
+        return explicit
+    outcome = (_outcome_for(event_type, payload) or "").lower()
+    if "critical" in outcome:
+        return "critical"
+    if event_type.endswith("_failed") or outcome in {"failed", "error", "stalled"}:
+        return "error"
+    if outcome in {"retry", "rollback", "warning"}:
+        return "warning"
+    return "info"
+
+
+def _generation_index(payload: dict[str, Any]) -> int:
+    for key in ("generation_index", "generation"):
+        value = payload.get(key)
+        if value is not None:
+            return _int_value(value, 0)
+    return 0
+
+
+def _duration_ms(payload: dict[str, Any]) -> int | None:
+    for key in ("duration_ms", "latency_ms"):
+        if key in payload:
+            return _int_value(payload[key], 0)
+    if "duration_seconds" in payload:
+        return int(float(payload["duration_seconds"]) * 1000)
+    return None
+
+
+def _int_value(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/autocontext/src/autocontext/analytics/run_trace.py
+++ b/autocontext/src/autocontext/analytics/run_trace.py
@@ -15,6 +15,7 @@ Key types:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -145,13 +146,18 @@ class RunTrace(BaseModel):
 class TraceStore:
     """Persists and queries RunTrace artifacts as JSON files."""
 
-    def __init__(self, root: Path) -> None:
+    def __init__(self, root: Path, writer: Callable[[Path, dict[str, Any]], None] | None = None) -> None:
         self._dir = root / "traces"
+        self._writer = writer
         self._dir.mkdir(parents=True, exist_ok=True)
 
     def persist(self, trace: RunTrace) -> Path:
         path = self._dir / f"{trace.trace_id}.json"
-        write_json(path, trace.to_dict())
+        payload = trace.to_dict()
+        if self._writer is not None:
+            self._writer(path, payload)
+        else:
+            write_json(path, payload)
         return path
 
     def load(self, trace_id: str) -> RunTrace | None:

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.table import Table
 
 from autocontext.agents.orchestrator import AgentOrchestrator
+from autocontext.cli_analytics import register_analytics_command
 from autocontext.cli_investigate import run_investigate_command
 from autocontext.cli_queue import register_queue_command
 from autocontext.cli_role_runtime import resolve_role_runtime
@@ -1560,6 +1561,7 @@ def improve(
         console.print(f"[bold]Met threshold:[/bold] {result.met_threshold}")
 
 
+register_analytics_command(app, console=console)
 register_solve_command(app, console=console)
 register_queue_command(app, console=console)
 

--- a/autocontext/src/autocontext/cli_analytics.py
+++ b/autocontext/src/autocontext/cli_analytics.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, Any
+
+import typer
+
+from autocontext.analytics.events_to_trace import collect_run_ids, events_to_trace
+from autocontext.analytics.run_trace import TraceStore
+from autocontext.config.settings import AppSettings
+from autocontext.storage import artifact_store_from_settings
+from autocontext.storage.run_paths import resolve_run_root
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+def _cli_attr(dependency_module: str, name: str) -> Any:
+    return getattr(importlib.import_module(dependency_module), name)
+
+
+def run_rebuild_traces_command(
+    *,
+    run_id: str,
+    events_path: Path | None,
+    json_output: bool,
+    console: Console,
+    load_settings_fn: Callable[[], AppSettings],
+    write_json_stdout: Callable[[object], None],
+) -> None:
+    """Rebuild RunTrace artifacts from an events.ndjson stream."""
+    settings = load_settings_fn()
+    source_path = events_path or settings.event_stream_path
+    run_ids = [run_id] if run_id else collect_run_ids(source_path)
+    if not run_ids:
+        failed_result: dict[str, Any] = {"status": "failed", "error": f"No run ids found in {source_path}"}
+        if json_output:
+            write_json_stdout(failed_result)
+        else:
+            console.print(f"[red]{failed_result['error']}[/red]")
+        raise typer.Exit(code=1)
+
+    artifacts = artifact_store_from_settings(settings)
+    rebuilt: list[dict[str, Any]] = []
+    for current_run_id in run_ids:
+        try:
+            run_root = resolve_run_root(settings.runs_root, current_run_id)
+        except ValueError as exc:
+            failed_result = {"status": "failed", "error": str(exc), "run_id": current_run_id}
+            if json_output:
+                write_json_stdout(failed_result)
+            else:
+                console.print(f"[red]{failed_result['error']}[/red]")
+            raise typer.Exit(code=1) from exc
+
+        trace = events_to_trace(source_path, current_run_id)
+        path = TraceStore(run_root, writer=artifacts.write_json).persist(trace)
+        rebuilt.append({
+            "run_id": current_run_id,
+            "trace_id": trace.trace_id,
+            "event_count": len(trace.events),
+            "path": str(path),
+        })
+
+    result: dict[str, Any] = {"status": "completed", "events_path": str(source_path), "rebuilt": rebuilt}
+    if json_output:
+        write_json_stdout(result)
+        return
+
+    for item in rebuilt:
+        console.print(
+            f"[green]Rebuilt[/green] {item['trace_id']} " f"({item['event_count']} events) -> {item['path']}"
+        )
+
+
+def register_analytics_command(
+    app: typer.Typer,
+    *,
+    console: Console,
+    dependency_module: str = "autocontext.cli",
+) -> None:
+    analytics_app = typer.Typer(help="analytics utilities")
+
+    @analytics_app.command("rebuild-traces")
+    def rebuild_traces(
+        run_id: Annotated[
+            str,
+            typer.Option("--run-id", help="Run id to rebuild (default: all run ids in events stream)"),
+        ] = "",
+        events_path: Annotated[Path | None, typer.Option("--events", help="Path to events.ndjson")] = None,
+        json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    ) -> None:
+        run_rebuild_traces_command(
+            run_id=run_id,
+            events_path=events_path,
+            json_output=json_output,
+            console=console,
+            load_settings_fn=_cli_attr(dependency_module, "load_settings"),
+            write_json_stdout=_cli_attr(dependency_module, "_write_json_stdout"),
+        )
+
+    app.add_typer(analytics_app, name="analytics")

--- a/autocontext/src/autocontext/cli_analytics.py
+++ b/autocontext/src/autocontext/cli_analytics.py
@@ -33,16 +33,30 @@ def run_rebuild_traces_command(
     """Rebuild RunTrace artifacts from an events.ndjson stream."""
     settings = load_settings_fn()
     source_path = events_path or settings.event_stream_path
-    run_ids = [run_id] if run_id else collect_run_ids(source_path)
-    if not run_ids:
-        failed_result: dict[str, Any] = {"status": "failed", "error": f"No run ids found in {source_path}"}
+    available_run_ids = collect_run_ids(source_path)
+    if run_id and run_id not in available_run_ids:
+        missing_result: dict[str, Any] = {
+            "status": "failed",
+            "error": f"No events found for run id {run_id!r} in {source_path}",
+            "run_id": run_id,
+        }
         if json_output:
-            write_json_stdout(failed_result)
+            write_json_stdout(missing_result)
         else:
-            console.print(f"[red]{failed_result['error']}[/red]")
+            console.print(f"[red]{missing_result['error']}[/red]")
+        raise typer.Exit(code=1)
+
+    run_ids = [run_id] if run_id else available_run_ids
+    if not run_ids:
+        empty_result: dict[str, Any] = {"status": "failed", "error": f"No run ids found in {source_path}"}
+        if json_output:
+            write_json_stdout(empty_result)
+        else:
+            console.print(f"[red]{empty_result['error']}[/red]")
         raise typer.Exit(code=1)
 
     artifacts = artifact_store_from_settings(settings)
+    analytics_store = TraceStore(settings.knowledge_root / "analytics", writer=artifacts.write_json)
     rebuilt: list[dict[str, Any]] = []
     for current_run_id in run_ids:
         try:
@@ -56,12 +70,14 @@ def run_rebuild_traces_command(
             raise typer.Exit(code=1) from exc
 
         trace = events_to_trace(source_path, current_run_id)
+        analytics_path = analytics_store.persist(trace)
         path = TraceStore(run_root, writer=artifacts.write_json).persist(trace)
         rebuilt.append({
             "run_id": current_run_id,
             "trace_id": trace.trace_id,
             "event_count": len(trace.events),
             "path": str(path),
+            "analytics_path": str(analytics_path),
         })
 
     result: dict[str, Any] = {"status": "completed", "events_path": str(source_path), "rebuilt": rebuilt}

--- a/autocontext/src/autocontext/harness/repl/session.py
+++ b/autocontext/src/autocontext/harness/repl/session.py
@@ -16,7 +16,20 @@ from autocontext.harness.repl.types import ExecutionRecord, ReplCommand, ReplWor
 
 logger = logging.getLogger(__name__)
 
-_CODE_PATTERN = re.compile(r"<code>(.*?)</code>", re.DOTALL)
+_CODE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"<code>(.*?)</code>", re.DOTALL | re.IGNORECASE),
+    re.compile(r"```[ \t]*(?:python|py)[^\n`]*\r?\n(.*?)```", re.DOTALL | re.IGNORECASE),
+    re.compile(r"```[ \t]*\r?\n(.*?)```", re.DOTALL),
+)
+
+
+def _extract_code_block(text: str) -> str | None:
+    """Extract the first supported REPL code block, preserving legacy priority."""
+    for pattern in _CODE_PATTERNS:
+        match = pattern.search(text)
+        if match is not None:
+            return match.group(1).strip()
+    return None
 
 
 def make_llm_batch(
@@ -118,9 +131,8 @@ class RlmSession:
             assistant_text = response.text
             messages.append({"role": "assistant", "content": assistant_text})
 
-            code_match = _CODE_PATTERN.search(assistant_text)
-            if code_match:
-                code = code_match.group(1).strip()
+            code = _extract_code_block(assistant_text)
+            if code is not None:
                 result = self._worker.run_code(ReplCommand(code))
 
                 self.execution_history.append(ExecutionRecord(
@@ -153,8 +165,8 @@ class RlmSession:
                 # Model didn't emit code — nudge it
                 messages.append({
                     "role": "user",
-                    "content": "Please write code inside <code> tags to continue your analysis, "
-                    'or set answer["ready"] = True to finalize.',
+                    "content": "Please write code inside <code> tags or a ```python fenced block "
+                    'to continue your analysis, or set answer["ready"] = True to finalize.',
                 })
         else:
             status = "truncated"

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -322,6 +322,7 @@ def _resolve_family_hint(description: str) -> ScenarioFamily | None:
 
 
 def _resolve_solve_family_alias(description: str) -> ScenarioFamily | None:
+    from autocontext.scenarios.custom.family_classifier import resolve_direct_family_hint
     from autocontext.scenarios.families import get_family
 
     match = _FAMILY_HEADER_RE.search(description)
@@ -332,6 +333,9 @@ def _resolve_solve_family_alias(description: str) -> ScenarioFamily | None:
             if aliased is not None:
                 return get_family(aliased)
 
+    direct_family = resolve_direct_family_hint(description)
+    if direct_family is not None:
+        return get_family(direct_family)
     if _SIMULATION_INTERFACE_HINT_RE.search(description):
         return get_family("simulation")
     if _AGENT_TASK_INTERFACE_HINT_RE.search(description):

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -37,7 +37,6 @@ from autocontext.analytics.run_trace import (
 )
 from autocontext.analytics.store import FacetStore
 from autocontext.analytics.taxonomy import FacetTaxonomy
-from autocontext.analytics.timeline_inspector import StateInspector, TimelineBuilder
 from autocontext.analytics.trace_reporter import ReportStore, TraceReporter
 from autocontext.config import AppSettings
 from autocontext.execution import ExecutionSupervisor
@@ -61,10 +60,12 @@ from autocontext.loop.runner_hooks import (
     emit_run_start,
     initialize_hook_bus,
 )
+from autocontext.loop.trace_artifacts import persist_run_inspection
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.base import ScenarioInterface
 from autocontext.scenarios.families import detect_family
 from autocontext.storage import SQLiteStore, artifact_store_from_settings
+from autocontext.storage.run_paths import resolve_run_root
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +168,14 @@ class GenerationRunner:
         else:
             self.executor = ExecutionSupervisor(executor=LocalExecutor())
         self.events = EventStreamEmitter(settings.event_stream_path)
+        if settings.rlm_enabled:
+            logger.info(
+                "RLM enabled: agent_provider=%s backend=%s sub_model=%s max_turns=%d",
+                settings.agent_provider,
+                settings.rlm_backend,
+                settings.rlm_sub_model,
+                settings.rlm_max_turns,
+            )
         self.controller: LoopController | None = None
         self._meta_optimizer = MetaOptimizer.from_settings(settings)
 
@@ -533,8 +542,20 @@ class GenerationRunner:
         )
         analytics_root = self.settings.knowledge_root / "analytics"
         analytics_root.mkdir(parents=True, exist_ok=True)
-        trace_path = TraceStore(analytics_root).persist(trace)
-        self._persist_run_inspection(trace, analytics_root, trace_path)
+        trace_path = TraceStore(analytics_root, writer=self.artifacts.write_json).persist(trace)
+        TraceStore(resolve_run_root(self.settings.runs_root, run_id), writer=self.artifacts.write_json).persist(trace)
+        persist_run_inspection(trace, analytics_root, trace_path)
+
+    def _safe_generate_run_trace_artifacts(
+        self,
+        run_id: str,
+        scenario_name: str,
+        scenario: ScenarioInterface,
+    ) -> None:
+        try:
+            self._generate_run_trace_artifacts(run_id, scenario_name, scenario)
+        except Exception:
+            logger.warning("failed to generate run trace artifacts for run %s", run_id, exc_info=True)
 
     def _build_run_trace(
         self,
@@ -880,45 +901,6 @@ class GenerationRunner:
             },
         )
 
-    def _persist_run_inspection(
-        self,
-        trace: RunTrace,
-        analytics_root: Path,
-        trace_path: Path,
-    ) -> None:
-        """Persist operator-facing inspection artifacts derived from a run trace."""
-        inspection_dir = analytics_root / "inspections"
-        inspection_dir.mkdir(parents=True, exist_ok=True)
-        inspector = StateInspector()
-        builder = TimelineBuilder()
-        generation_indices = sorted({
-            event.generation_index for event in trace.events if event.generation_index is not None
-        })
-        payload = {
-            "trace_id": trace.trace_id,
-            "run_id": trace.run_id,
-            "trace_path": str(trace_path),
-            "created_at": trace.created_at,
-            "run_inspection": inspector.inspect_run(trace).model_dump(),
-            "generation_inspections": [
-                inspector.inspect_generation(trace, generation_index).model_dump()
-                for generation_index in generation_indices
-            ],
-            "timeline_summary": [entry.to_dict() for entry in builder.build_summary(trace)],
-            "failure_paths": [
-                [event.event_id for event in path]
-                for path in inspector.find_failure_paths(trace)
-            ],
-            "recovery_paths": [
-                [event.event_id for event in path]
-                for path in inspector.find_recovery_paths(trace)
-            ],
-        }
-        (inspection_dir / f"{trace.trace_id}.json").write_text(
-            json.dumps(payload, indent=2),
-            encoding="utf-8",
-        )
-
     def _role_stage(self, role: str) -> str:
         return {
             "competitor": "compete",
@@ -1244,6 +1226,7 @@ class GenerationRunner:
                     replay_narrative = ctx.replay_narrative
                     coach_competitor_hints = ctx.coach_competitor_hints
                     completed += 1
+                    self._safe_generate_run_trace_artifacts(active_run_id, scenario_name, scenario)
                 except Exception as exc:
                     logger.debug("loop.generation_runner: caught Exception", exc_info=True)
                     self.artifacts.mutation_log.append(
@@ -1325,6 +1308,7 @@ class GenerationRunner:
                 )
             except Exception:
                 logger.debug("RUN_END hook failed after run failure", exc_info=True)
+            self._safe_generate_run_trace_artifacts(active_run_id, scenario_name, scenario)
             raise
         finally:
             self.artifacts.shutdown_writer()
@@ -1352,10 +1336,7 @@ class GenerationRunner:
             self._generate_aggregate_analytics(active_run_id, scenario_name, scenario)
         except Exception:
             logger.warning("failed to generate aggregate analytics for run %s", active_run_id, exc_info=True)
-        try:
-            self._generate_run_trace_artifacts(active_run_id, scenario_name, scenario)
-        except Exception:
-            logger.warning("failed to generate run trace artifacts for run %s", active_run_id, exc_info=True)
+        self._safe_generate_run_trace_artifacts(active_run_id, scenario_name, scenario)
         try:
             self._generate_trace_grounded_reports(active_run_id, scenario_name)
         except Exception:

--- a/autocontext/src/autocontext/loop/trace_artifacts.py
+++ b/autocontext/src/autocontext/loop/trace_artifacts.py
@@ -1,0 +1,44 @@
+"""Trace artifact helpers for generation runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autocontext.analytics.run_trace import RunTrace
+from autocontext.analytics.timeline_inspector import StateInspector, TimelineBuilder
+
+
+def persist_run_inspection(trace: RunTrace, analytics_root: Path, trace_path: Path) -> None:
+    """Persist operator-facing inspection artifacts derived from a run trace."""
+    inspection_dir = analytics_root / "inspections"
+    inspection_dir.mkdir(parents=True, exist_ok=True)
+    inspector = StateInspector()
+    builder = TimelineBuilder()
+    generation_indices = sorted({
+        event.generation_index for event in trace.events if event.generation_index is not None
+    })
+    payload = {
+        "trace_id": trace.trace_id,
+        "run_id": trace.run_id,
+        "trace_path": str(trace_path),
+        "created_at": trace.created_at,
+        "run_inspection": inspector.inspect_run(trace).model_dump(),
+        "generation_inspections": [
+            inspector.inspect_generation(trace, generation_index).model_dump()
+            for generation_index in generation_indices
+        ],
+        "timeline_summary": [entry.to_dict() for entry in builder.build_summary(trace)],
+        "failure_paths": [
+            [event.event_id for event in path]
+            for path in inspector.find_failure_paths(trace)
+        ],
+        "recovery_paths": [
+            [event.event_id for event in path]
+            for path in inspector.find_recovery_paths(trace)
+        ],
+    }
+    (inspection_dir / f"{trace.trace_id}.json").write_text(
+        json.dumps(payload, indent=2),
+        encoding="utf-8",
+    )

--- a/autocontext/src/autocontext/rlm/prompts.py
+++ b/autocontext/src/autocontext/rlm/prompts.py
@@ -12,8 +12,8 @@ everything is already available as variables.
 
 ## How to use the REPL
 
-Write Python code inside <code> tags. The code will be executed and you will see the output
-(stdout and any errors). Variables persist between code blocks.
+Write Python code inside <code> tags or a ```python fenced block. The code will be executed
+and you will see the output (stdout and any errors). Variables persist between code blocks.
 
 Example:
 <code>
@@ -63,7 +63,8 @@ You do NOT need to read files or make API calls -- everything is already availab
 
 ## How to use the REPL
 
-Write Python code inside <code> tags. The code will be executed and you will see the output.
+Write Python code inside <code> tags or a ```python fenced block. The code will be executed
+and you will see the output.
 
 Example:
 <code>

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -22,6 +22,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_DIRECT_FAMILY_HINTS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "schema_evolution",
+        re.compile(
+            r"\bschema[-_ ]evolution\b|\bschemaevolutioninterface\b|\bschemamutation\b|"
+            r"\bschema\b.*\b(?:mutat|migrat|drift|version|breaking|stale assumption|regime change)\b|"
+            r"\b(?:mutat|migrat|drift|version|breaking|stale assumption|regime change)\b.*\bschema\b",
+            re.IGNORECASE | re.DOTALL,
+        ),
+    ),
+)
+
 # ---------------------------------------------------------------------------
 # Data models
 # ---------------------------------------------------------------------------
@@ -461,6 +473,14 @@ def _build_rationale(matched: list[str], family_name: str) -> str:
     return f"Matched {family_name} signals: {', '.join(top)}"
 
 
+def resolve_direct_family_hint(description: str) -> str | None:
+    """Return a high-confidence family when the description names a domain contract."""
+    for family_name, pattern in _DIRECT_FAMILY_HINTS:
+        if pattern.search(description):
+            return family_name
+    return None
+
+
 # ---------------------------------------------------------------------------
 # LLM fallback (AC-580)
 # ---------------------------------------------------------------------------
@@ -595,6 +615,24 @@ def classify_scenario_family(
     registered_families = [family.name for family in list_families()]
     if not registered_families:
         raise ValueError("no scenario families are registered")
+
+    direct_family = resolve_direct_family_hint(description)
+    if direct_family in registered_families:
+        alternatives = [
+            FamilyCandidate(
+                family_name=family_name,
+                confidence=0.0,
+                rationale=f"Direct hint selected {direct_family}",
+            )
+            for family_name in registered_families
+            if family_name != direct_family
+        ]
+        return FamilyClassification(
+            family_name=direct_family,
+            confidence=0.95,
+            rationale=f"Direct family hint matched {direct_family}",
+            alternatives=alternatives,
+        )
 
     from autocontext.config.settings import AppSettings  # local import avoids circular dep
     threshold = AppSettings().classifier_fast_path_threshold

--- a/autocontext/src/autocontext/scenarios/custom/family_classifier.py
+++ b/autocontext/src/autocontext/scenarios/custom/family_classifier.py
@@ -24,11 +24,24 @@ logger = logging.getLogger(__name__)
 
 _DIRECT_FAMILY_HINTS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
+        "tool_fragility",
+        re.compile(
+            r"\btool[-_ ]fragility\b|\btoolfragilityinterface\b|"
+            r"\b(?:tool|tools|api|endpoint)\b.*\b(?:contract drift|api contract|response schema|response format|"
+            r"tool drift|tool version|endpoint deprecat|api deprecat|tool failure)\b|"
+            r"\b(?:contract drift|api contract|response schema|response format|tool drift|tool version|"
+            r"endpoint deprecat|api deprecat|tool failure)\b.*\b(?:tool|tools|api|endpoint)\b",
+            re.IGNORECASE | re.DOTALL,
+        ),
+    ),
+    (
         "schema_evolution",
         re.compile(
             r"\bschema[-_ ]evolution\b|\bschemaevolutioninterface\b|\bschemamutation\b|"
-            r"\bschema\b.*\b(?:mutat|migrat|drift|version|breaking|stale assumption|regime change)\b|"
-            r"\b(?:mutat|migrat|drift|version|breaking|stale assumption|regime change)\b.*\bschema\b",
+            r"\b(?:domain|data|database|market|portfolio|world state|state|context|knowledge) schema\b"
+            r".*\b(?:changes?|mutat|migrat|version|breaking|stale assumption|regime change)\b|"
+            r"\b(?:changes?|mutat|migrat|version|breaking|stale assumption|regime change)\b.*"
+            r"\b(?:domain|data|database|market|portfolio|world state|state|context|knowledge) schema\b",
             re.IGNORECASE | re.DOTALL,
         ),
     ),

--- a/autocontext/src/autocontext/simulation/engine.py
+++ b/autocontext/src/autocontext/simulation/engine.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from autocontext.agents.types import LlmFn
+from autocontext.simulation import schema_evolution as schema_evolution_sim
 from autocontext.simulation.helpers import (
     aggregate_contract_signal_counts,
     apply_behavioral_contract,
@@ -31,8 +32,6 @@ if TYPE_CHECKING:
     from autocontext.scenarios.operator_loop import OperatorLoopInterface
 
 
-# Backward-compatible alias for existing tests and callers that still import
-# the abstract-class filter helper from this module.
 _find_scenario_class = find_scenario_class
 
 
@@ -72,7 +71,7 @@ class SimulationEngine:
 
         try:
             family = infer_family(description)
-            spec = self._normalize_spec(self._apply_variables(self._build_spec(description, family), resolved_variables))
+            spec = self._normalize_spec(self._apply_variables(self._build_spec(description, family), resolved_variables), family)
 
             source = self._generate_source(spec, name, family)
             scenario_dir = self._persist(name, family, spec, source)
@@ -300,13 +299,15 @@ class SimulationEngine:
     # ------------------------------------------------------------------
 
     def _build_spec(self, description: str, family: str) -> dict[str, Any]:
+        if family == "schema_evolution" and (designed := schema_evolution_sim.design_spec(description, self.llm_fn)):
+            return designed
         if family == "operator_loop":
             from autocontext.scenarios.custom.generic_creator import spec_to_plain_data
             from autocontext.scenarios.custom.operator_loop_designer import design_operator_loop
 
             try:
-                designed = design_operator_loop(description, self.llm_fn)
-                plain = spec_to_plain_data(designed)
+                operator_spec = design_operator_loop(description, self.llm_fn)
+                plain = spec_to_plain_data(operator_spec)
                 if isinstance(plain, dict):
                     return plain
             except Exception:
@@ -339,7 +340,9 @@ class SimulationEngine:
             "actions": [{"name": "act", "description": "Take action", "parameters": {}, "preconditions": [], "effects": []}],
         }
 
-    def _normalize_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
+    def _normalize_spec(self, spec: dict[str, Any], family: str = "simulation") -> dict[str, Any]:
+        if family == "schema_evolution":
+            return schema_evolution_sim.normalize_spec(spec)
         from autocontext.scenarios.custom.simulation_spec import normalize_simulation_spec_dict
 
         return normalize_simulation_spec_dict(spec)
@@ -361,6 +364,8 @@ class SimulationEngine:
                 max_steps=spec.get("max_steps", 10),
             )
             return generate_operator_loop_class(ol_spec, name)
+        elif family == "schema_evolution":
+            return schema_evolution_sim.generate_source(spec, name)
         else:
             from autocontext.scenarios.custom.simulation_codegen import generate_simulation_class
             from autocontext.scenarios.custom.simulation_spec import SimulationSpec, parse_simulation_actions
@@ -574,7 +579,7 @@ class SimulationEngine:
         for i, variables in enumerate(combos):
             merged_variables = {**base_variables, **variables}
             variant_name = f"{name}__sweep_{i + 1}"
-            variant_spec = self._normalize_spec(self._apply_variables(base_spec, merged_variables))
+            variant_spec = self._normalize_spec(self._apply_variables(base_spec, merged_variables), family)
             source = self._generate_source(variant_spec, variant_name, family)
             variant_dir = scenario_dir / "sweep" / str(i + 1)
             self._persist(variant_name, family, variant_spec, source, variant_dir)
@@ -684,7 +689,7 @@ class SimulationEngine:
         if not variables and source_path.exists():
             return source_path.read_text(encoding="utf-8")
 
-        updated_spec = self._normalize_spec(self._apply_variables(spec, variables))
+        updated_spec = self._normalize_spec(self._apply_variables(spec, variables), family)
         return self._generate_source(updated_spec, name, family)
 
     def _apply_variables(self, spec: dict[str, Any], variables: dict[str, Any] | None) -> dict[str, Any]:
@@ -743,7 +748,7 @@ class SimulationEngine:
         for i, cell in enumerate(original_results):
             cell_variables = {**(cell.get("variables") or {}), **overrides}
             variant_name = f"{base_name}__sweep_{i + 1}"
-            variant_spec = self._normalize_spec(self._apply_variables(base_spec, cell_variables))
+            variant_spec = self._normalize_spec(self._apply_variables(base_spec, cell_variables), family)
             source = self._generate_source(variant_spec, variant_name, family)
             variant_dir = scenario_dir / "sweep" / str(i + 1)
             self._persist(variant_name, family, variant_spec, source, variant_dir)

--- a/autocontext/src/autocontext/simulation/helpers.py
+++ b/autocontext/src/autocontext/simulation/helpers.py
@@ -68,7 +68,9 @@ def infer_family(description: str) -> str:
         family = route_to_family(classify_scenario_family(description), 0.15).name
         if family == "operator_loop" and _STATECRAFT_SIMULATION_CONTEXT.search(text_lower):
             return "simulation"
-        return "operator_loop" if family == "operator_loop" else "simulation"
+        if family in {"operator_loop", "schema_evolution"}:
+            return family
+        return "simulation"
     except Exception:
         return "simulation"
 

--- a/autocontext/src/autocontext/simulation/schema_evolution.py
+++ b/autocontext/src/autocontext/simulation/schema_evolution.py
@@ -1,0 +1,124 @@
+"""Schema-evolution helpers for simulation-generated scenarios."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from autocontext.agents.types import LlmFn
+from autocontext.scenarios.custom.schema_evolution_codegen import generate_schema_evolution_class
+from autocontext.scenarios.custom.schema_evolution_designer import design_schema_evolution
+from autocontext.scenarios.custom.schema_evolution_spec import (
+    SchemaEvolutionMutationModel,
+    SchemaEvolutionSpec,
+)
+from autocontext.scenarios.custom.simulation_spec import (
+    SimulationActionSpecModel,
+    normalize_simulation_spec_dict,
+    parse_simulation_actions,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def design_spec(description: str, llm_fn: LlmFn) -> dict[str, Any] | None:
+    try:
+        return _spec_to_dict(design_schema_evolution(description, llm_fn))
+    except Exception:
+        logger.debug("simulation.schema_evolution: designer fallback", exc_info=True)
+        return None
+
+
+def normalize_spec(spec: dict[str, Any]) -> dict[str, Any]:
+    normalized = normalize_simulation_spec_dict(spec)
+    normalized["mutations"] = _normalize_mutations(spec.get("mutations"))
+    return normalized
+
+
+def generate_source(spec: dict[str, Any], name: str) -> str:
+    return generate_schema_evolution_class(_spec_from_dict(spec), name)
+
+
+def _spec_to_dict(spec: SchemaEvolutionSpec) -> dict[str, Any]:
+    return {
+        "description": spec.description,
+        "environment_description": spec.environment_description,
+        "initial_state_description": spec.initial_state_description,
+        "mutations": [_mutation_to_dict(mutation) for mutation in spec.mutations],
+        "success_criteria": list(spec.success_criteria),
+        "failure_modes": list(spec.failure_modes),
+        "actions": [_action_to_dict(action) for action in spec.actions],
+        "max_steps": spec.max_steps,
+    }
+
+
+def _spec_from_dict(spec: dict[str, Any]) -> SchemaEvolutionSpec:
+    return SchemaEvolutionSpec(
+        description=str(spec.get("description") or ""),
+        environment_description=str(spec.get("environment_description") or "Schema-evolution environment"),
+        initial_state_description=str(spec.get("initial_state_description") or "Initial schema version is active."),
+        mutations=[
+            SchemaEvolutionMutationModel(
+                version=int(mutation["version"]),
+                description=str(mutation["description"]),
+                breaking=bool(mutation["breaking"]),
+                fields_added=list(mutation.get("fields_added", [])),
+                fields_removed=list(mutation.get("fields_removed", [])),
+                fields_modified=dict(mutation.get("fields_modified", {})),
+            )
+            for mutation in _normalize_mutations(spec.get("mutations"))
+        ],
+        success_criteria=[str(item) for item in spec.get("success_criteria", [])],
+        failure_modes=[str(item) for item in spec.get("failure_modes", [])],
+        actions=parse_simulation_actions(spec.get("actions", [])),
+        max_steps=int(spec.get("max_steps") or 10),
+    )
+
+
+def _normalize_mutations(raw: Any) -> list[dict[str, Any]]:
+    mutations: list[dict[str, Any]] = []
+    if isinstance(raw, list):
+        for index, item in enumerate(raw, start=2):
+            if not isinstance(item, dict):
+                continue
+            fields_modified = item.get("fields_modified", {})
+            mutations.append({
+                "version": int(item.get("version") or index),
+                "description": str(item.get("description") or f"Schema version {index} mutation"),
+                "breaking": bool(item.get("breaking", False)),
+                "fields_added": _text_list(item.get("fields_added")),
+                "fields_removed": _text_list(item.get("fields_removed")),
+                "fields_modified": {
+                    str(field): str(change)
+                    for field, change in (fields_modified.items() if isinstance(fields_modified, dict) else [])
+                },
+            })
+    if mutations:
+        return mutations
+    return [{
+        "version": 2,
+        "description": "Schema changes during the run and invalidates stale assumptions.",
+        "breaking": True,
+        "fields_added": ["schema_version"],
+        "fields_removed": ["legacy_status"],
+        "fields_modified": {"risk_model_assumptions": "v1 -> v2"},
+    }]
+
+
+def _mutation_to_dict(mutation: SchemaEvolutionMutationModel) -> dict[str, Any]:
+    return {
+        "version": mutation.version,
+        "description": mutation.description,
+        "breaking": mutation.breaking,
+        "fields_added": list(mutation.fields_added),
+        "fields_removed": list(mutation.fields_removed),
+        "fields_modified": dict(mutation.fields_modified),
+    }
+
+
+def _action_to_dict(action: SimulationActionSpecModel) -> dict[str, Any]:
+    return action.to_dict()
+
+
+def _text_list(value: Any) -> list[str]:
+    return [str(item) for item in value] if isinstance(value, list) else []

--- a/autocontext/src/autocontext/storage/run_paths.py
+++ b/autocontext/src/autocontext/storage/run_paths.py
@@ -1,0 +1,22 @@
+"""Helpers for resolving per-run filesystem paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_run_root(runs_root: Path, run_id: str) -> Path:
+    """Resolve a run directory and ensure it stays under runs_root."""
+    normalized = run_id.strip()
+    if not normalized:
+        raise ValueError("run_id is required")
+
+    root = runs_root.resolve()
+    candidate = (runs_root / normalized).resolve()
+    if candidate == root:
+        raise ValueError(f"run_id must name a run subdirectory: {run_id!r}")
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"run_id escapes runs root: {run_id!r}") from exc
+    return candidate

--- a/autocontext/tests/test_events_to_trace.py
+++ b/autocontext/tests/test_events_to_trace.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+from autocontext.config.settings import AppSettings
+
+
+def _write_events(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def _event(seq: int, event: str, payload: dict) -> dict:
+    return {
+        "ts": f"2026-04-30T00:00:{seq:02d}+00:00",
+        "v": 1,
+        "seq": seq,
+        "channel": "generation",
+        "event": event,
+        "payload": {"run_id": "run-1", "generation": 1, **payload},
+    }
+
+
+def _settings(tmp_path: Path, events_path: Path) -> AppSettings:
+    return AppSettings(
+        db_path=tmp_path / "runs" / "autocontext.sqlite3",
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / ".claude" / "skills",
+        event_stream_path=events_path,
+        agent_provider="deterministic",
+    )
+
+
+def test_events_to_trace_maps_runner_event_contract(tmp_path: Path) -> None:
+    from autocontext.analytics.events_to_trace import collect_run_ids, events_to_trace
+
+    rows = [
+        _event(1, "run_started", {"scenario": "grid_ctf"}),
+        _event(2, "agents_started", {}),
+        _event(3, "role_event", {"role": "competitor", "status": "started", "model": "m"}),
+        _event(4, "role_completed", {"role": "competitor", "status": "completed"}),
+        _event(5, "tournament_started", {}),
+        _event(6, "match_completed", {"passed_validation": True}),
+        _event(7, "tournament_completed", {}),
+        _event(8, "staged_validation_started", {}),
+        _event(9, "staged_validation_completed", {"status": "passed"}),
+        _event(10, "gate_decided", {"gate_decision": "advance"}),
+        _event(11, "analyst_feedback_rated", {}),
+        _event(12, "generation_completed", {}),
+        _event(13, "generation_timing", {"duration_ms": 42}),
+        _event(14, "holdout_evaluated", {}),
+        _event(15, "curator_started", {}),
+        _event(16, "curator_completed", {}),
+        _event(17, "startup_verification", {"status": "passed"}),
+        {"ts": "2026-04-30T00:01:00+00:00", "v": 1, "seq": 18, "event": "run_started", "payload": {"run_id": "run-2"}},
+    ]
+    events_path = tmp_path / "runs" / "events.ndjson"
+    _write_events(events_path, rows)
+
+    assert collect_run_ids(events_path) == ["run-1", "run-2"]
+    trace = events_to_trace(events_path, "run-1")
+    by_type = {event.event_type: event for event in trace.events}
+
+    assert trace.run_id == "run-1"
+    assert len(trace.events) == 17
+    assert len(trace.causal_edges) == 16
+    assert by_type["run_started"].category == "checkpoint"
+    assert by_type["run_started"].stage == "init"
+    assert by_type["role_event"].category == "action"
+    assert by_type["role_event"].stage == "compete"
+    assert by_type["match_completed"].category == "validation"
+    assert by_type["match_completed"].stage == "match"
+    assert by_type["match_completed"].outcome == "passed"
+    assert by_type["staged_validation_completed"].stage == "gate"
+    assert by_type["gate_decided"].outcome == "advance"
+    assert by_type["analyst_feedback_rated"].category == "observation"
+    assert by_type["generation_timing"].duration_ms == 42
+    assert by_type["curator_completed"].stage == "curate"
+    assert by_type["startup_verification"].stage == "init"
+
+
+def test_analytics_rebuild_traces_cli_writes_run_local_trace(tmp_path: Path) -> None:
+    events_path = tmp_path / "runs" / "events.ndjson"
+    _write_events(events_path, [_event(1, "run_started", {"scenario": "grid_ctf"})])
+    settings = _settings(tmp_path, events_path)
+
+    runner = CliRunner()
+    with patch("autocontext.cli.load_settings", return_value=settings):
+        result = runner.invoke(
+            app,
+            ["analytics", "rebuild-traces", "--events", str(events_path), "--run-id", "run-1", "--json"],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    trace_path = tmp_path / "runs" / "run-1" / "traces" / "trace-run-1.json"
+    assert payload["status"] == "completed"
+    assert payload["rebuilt"][0]["path"] == str(trace_path)
+    assert json.loads(trace_path.read_text(encoding="utf-8"))["run_id"] == "run-1"
+
+
+def test_analytics_rebuild_traces_cli_rejects_run_id_escape(tmp_path: Path) -> None:
+    events_path = tmp_path / "runs" / "events.ndjson"
+    _write_events(events_path, [_event(1, "run_started", {"scenario": "grid_ctf", "run_id": "../outside"})])
+    settings = _settings(tmp_path, events_path)
+
+    runner = CliRunner()
+    with patch("autocontext.cli.load_settings", return_value=settings):
+        result = runner.invoke(
+            app,
+            ["analytics", "rebuild-traces", "--events", str(events_path), "--run-id", "../outside", "--json"],
+        )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "failed"
+    assert "escapes runs root" in payload["error"]
+    assert not (tmp_path / "outside" / "traces" / "trace-../outside.json").exists()

--- a/autocontext/tests/test_events_to_trace.py
+++ b/autocontext/tests/test_events_to_trace.py
@@ -101,9 +101,30 @@ def test_analytics_rebuild_traces_cli_writes_run_local_trace(tmp_path: Path) -> 
     assert result.exit_code == 0, result.output
     payload = json.loads(result.stdout)
     trace_path = tmp_path / "runs" / "run-1" / "traces" / "trace-run-1.json"
+    analytics_trace_path = tmp_path / "knowledge" / "analytics" / "traces" / "trace-run-1.json"
     assert payload["status"] == "completed"
     assert payload["rebuilt"][0]["path"] == str(trace_path)
     assert json.loads(trace_path.read_text(encoding="utf-8"))["run_id"] == "run-1"
+    assert json.loads(analytics_trace_path.read_text(encoding="utf-8"))["run_id"] == "run-1"
+
+
+def test_analytics_rebuild_traces_cli_rejects_missing_run_id(tmp_path: Path) -> None:
+    events_path = tmp_path / "runs" / "events.ndjson"
+    _write_events(events_path, [_event(1, "run_started", {"scenario": "grid_ctf"})])
+    settings = _settings(tmp_path, events_path)
+
+    runner = CliRunner()
+    with patch("autocontext.cli.load_settings", return_value=settings):
+        result = runner.invoke(
+            app,
+            ["analytics", "rebuild-traces", "--events", str(events_path), "--run-id", "run-missing", "--json"],
+        )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "failed"
+    assert "No events found for run id" in payload["error"]
+    assert not (tmp_path / "runs" / "run-missing" / "traces" / "trace-run-missing.json").exists()
 
 
 def test_analytics_rebuild_traces_cli_rejects_run_id_escape(tmp_path: Path) -> None:

--- a/autocontext/tests/test_harness/test_harness_repl_session.py
+++ b/autocontext/tests/test_harness/test_harness_repl_session.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import logging
+
+import pytest
+
 from autocontext.harness.core.llm_client import LanguageModelClient
 from autocontext.harness.core.types import ModelResponse, RoleExecution, RoleUsage
 from autocontext.harness.repl.session import RlmSession, make_llm_batch
@@ -37,6 +41,56 @@ def test_session_runs_single_turn() -> None:
     assert result.content == "done"
 
 
+@pytest.mark.parametrize(
+    ("response", "expected_code"),
+    [
+        (
+            '<code>\nanswer["content"] = "tagged"\nanswer["ready"] = True\n</code>',
+            'answer["content"] = "tagged"\nanswer["ready"] = True',
+        ),
+        (
+            '```python\nanswer["content"] = "python fence"\nanswer["ready"] = True\n```',
+            'answer["content"] = "python fence"\nanswer["ready"] = True',
+        ),
+        (
+            '```\nanswer["content"] = "plain fence"\nanswer["ready"] = True\n```',
+            'answer["content"] = "plain fence"\nanswer["ready"] = True',
+        ),
+    ],
+)
+def test_session_accepts_supported_code_block_shapes(response: str, expected_code: str) -> None:
+    client = FakeClient([response])
+    worker = ReplWorker()
+    session = RlmSession(client=client, worker=worker, role="analyst", model="m", system_prompt="test")
+    result = session.run()
+    assert result.status == "completed"
+    assert session.execution_history[0].code == expected_code
+
+
+def test_session_prefers_code_tags_when_mixed_with_markdown_fence() -> None:
+    client = FakeClient([
+        '<code>\nanswer["content"] = "from tag"\nanswer["ready"] = True\n</code>\n'
+        '```python\nanswer["content"] = "from fence"\nanswer["ready"] = True\n```'
+    ])
+    worker = ReplWorker()
+    session = RlmSession(client=client, worker=worker, role="analyst", model="m", system_prompt="test")
+    result = session.run()
+    assert result.content == "from tag"
+    assert "from fence" not in session.execution_history[0].code
+
+
+def test_session_accepts_mixed_code_block_styles_across_turns() -> None:
+    client = FakeClient([
+        "```python\nx = 1\nprint(x)\n```",
+        '<code>\nanswer["content"] = f"final {x}"\nanswer["ready"] = True\n</code>',
+    ])
+    worker = ReplWorker()
+    session = RlmSession(client=client, worker=worker, role="analyst", model="m", system_prompt="test")
+    result = session.run()
+    assert result.content == "final 1"
+    assert len(session.execution_history) == 2
+
+
 def test_session_stops_when_ready() -> None:
     client = FakeClient([
         '<code>\nx = 1\n</code>',
@@ -56,6 +110,16 @@ def test_session_respects_max_turns() -> None:
     result = session.run()
     assert result.status == "truncated"
     assert len(session.execution_history) == 3
+
+
+def test_session_logs_truncation_when_max_turns_exhausted(caplog: pytest.LogCaptureFixture) -> None:
+    client = FakeClient(['<code>\nx = 1\n</code>'] * 20)
+    worker = ReplWorker()
+    session = RlmSession(client=client, worker=worker, role="analyst", model="m", system_prompt="test", max_turns=2)
+    with caplog.at_level(logging.WARNING, logger="autocontext.harness.repl.session"):
+        result = session.run()
+    assert result.status == "truncated"
+    assert "hit max_turns=2 without finalizing" in caplog.text
 
 
 def test_session_feeds_stdout_back() -> None:
@@ -128,7 +192,7 @@ def test_session_nudges_no_code_response() -> None:
     assert len(messages_seen) >= 2
     second_msgs = messages_seen[1]
     user_msgs = [m for m in second_msgs if m["role"] == "user"]
-    assert any("code" in m["content"].lower() for m in user_msgs)
+    assert any("```python" in m["content"] for m in user_msgs)
 
 
 def test_session_returns_role_execution() -> None:

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -254,6 +254,29 @@ class TestSolveScenarioBuilder:
 
         assert family.name == "schema_evolution"
 
+    def test_resolves_ac277_portfolio_regime_change_prompt_to_schema_evolution(self) -> None:
+        from autocontext.knowledge.solver import _resolve_requested_scenario_family
+
+        family = _resolve_requested_scenario_family(
+            "Harness Stress Test: portfolio construction under regime change — "
+            "quantitative adaptation with schema evolution\n\n"
+            "## Objective\n\n"
+            "Build and run a financial portfolio construction scenario where the agent must "
+            "build and manage portfolios across macroeconomic regime changes, accumulating "
+            "quantitative investment heuristics.\n\n"
+            "## Scenario Design\n\n"
+            "Use SimulationInterface + WorldState to simulate market regimes. "
+            "The agent receives market regime inputs, portfolio constraints, and performance "
+            "feedback. Mid-run, the market schema changes: rate regime, volatility regime, "
+            "correlation structure, and risk model assumptions mutate. The agent must update "
+            "allocation heuristics, migrate knowledge, and avoid stale assumptions.\n\n"
+            "## Evaluation Dimensions\n\n"
+            "Stale-assumption detection. Knowledge migration completeness. Drawdown control. "
+            "Adaptation speed. Regime-aware allocation quality."
+        )
+
+        assert family.name == "schema_evolution"
+
     def test_passes_supported_family_hint_into_creator(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from autocontext.knowledge.solver import SolveScenarioBuilder
 

--- a/autocontext/tests/test_session_report_wiring.py
+++ b/autocontext/tests/test_session_report_wiring.py
@@ -38,6 +38,7 @@ def _make_runner_with_mocks(settings: AppSettings) -> tuple[Any, dict[str, Any]]
     sqlite, artifacts, agents, executor, events, gate, trajectory_builder, scenario.
     """
     from autocontext.loop.generation_runner import GenerationRunner
+    from autocontext.util.json_io import write_json
 
     with patch.object(GenerationRunner, "__init__", lambda self, s: None):
         runner = GenerationRunner.__new__(GenerationRunner)
@@ -45,6 +46,7 @@ def _make_runner_with_mocks(settings: AppSettings) -> tuple[Any, dict[str, Any]]
     runner.settings = settings
     runner.sqlite = MagicMock()
     runner.artifacts = MagicMock()
+    runner.artifacts.write_json.side_effect = write_json
     runner.agents = MagicMock()
     runner.executor = MagicMock()
     runner.events = MagicMock()
@@ -540,11 +542,14 @@ class TestRunTraceWiring:
         _run_with_pipeline_mock(runner, mocks, "grid_ctf", 2, "test_trace")
 
         trace_path = tmp_path / "knowledge" / "analytics" / "traces" / "trace-test_trace.json"
+        run_trace_path = tmp_path / "runs" / "test_trace" / "traces" / "trace-test_trace.json"
         inspection_path = tmp_path / "knowledge" / "analytics" / "inspections" / "trace-test_trace.json"
         assert trace_path.exists()
+        assert run_trace_path.exists()
         assert inspection_path.exists()
 
         trace_payload = json.loads(trace_path.read_text(encoding="utf-8"))
+        assert json.loads(run_trace_path.read_text(encoding="utf-8")) == trace_payload
         event_types = {event["event_type"] for event in trace_payload["events"]}
         categories = {event["category"] for event in trace_payload["events"]}
         assert "generation_summary" in event_types

--- a/autocontext/tests/test_simulate_command.py
+++ b/autocontext/tests/test_simulate_command.py
@@ -130,6 +130,28 @@ class TestSimulationEngine:
         assert result["summary"]["best_case"] is not None
         assert result["summary"]["worst_case"] is not None
 
+    def test_schema_evolution_prompt_preserves_family_metadata(self, tmp_knowledge: Path) -> None:
+        from autocontext.scenarios.families import get_family_marker
+        from autocontext.simulation.engine import SimulationEngine
+
+        description = (
+            "Harness Stress Test: portfolio construction under regime change — "
+            "quantitative adaptation with schema evolution\n\n"
+            "Use SimulationInterface + WorldState to simulate market regimes. Mid-run, "
+            "the market schema changes: rate regime, volatility regime, correlation "
+            "structure, and risk model assumptions mutate. The agent must migrate "
+            "knowledge and avoid stale assumptions."
+        )
+
+        engine = SimulationEngine(llm_fn=_mock_llm_fn(), knowledge_root=tmp_knowledge)
+        result = engine.run(description=description, save_as="portfolio_regime_schema")
+
+        scenario_dir = Path(result["artifacts"]["scenario_dir"])
+        persisted = json.loads((scenario_dir / "spec.json").read_text())
+        assert result["family"] == "schema_evolution"
+        assert persisted["family"] == "schema_evolution"
+        assert (scenario_dir / "scenario_type.txt").read_text(encoding="utf-8") == get_family_marker("schema_evolution")
+
     def test_sweep_cells_change_execution_when_variables_change_runtime(self, tmp_knowledge: Path) -> None:
         from autocontext.simulation.engine import SimulationEngine
 

--- a/autocontext/tests/test_simulate_command.py
+++ b/autocontext/tests/test_simulate_command.py
@@ -5,7 +5,9 @@ builds simulation specs, executes trajectories/sweeps, and returns
 structured findings with assumptions and warnings.
 """
 
+import importlib.util
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -131,8 +133,9 @@ class TestSimulationEngine:
         assert result["summary"]["worst_case"] is not None
 
     def test_schema_evolution_prompt_preserves_family_metadata(self, tmp_knowledge: Path) -> None:
-        from autocontext.scenarios.families import get_family_marker
-        from autocontext.simulation.engine import SimulationEngine
+        from autocontext.scenarios.families import detect_family, get_family_marker
+        from autocontext.scenarios.schema_evolution import SchemaEvolutionInterface
+        from autocontext.simulation.engine import SimulationEngine, _find_scenario_class
 
         description = (
             "Harness Stress Test: portfolio construction under regime change — "
@@ -151,6 +154,19 @@ class TestSimulationEngine:
         assert result["family"] == "schema_evolution"
         assert persisted["family"] == "schema_evolution"
         assert (scenario_dir / "scenario_type.txt").read_text(encoding="utf-8") == get_family_marker("schema_evolution")
+
+        source_path = scenario_dir / "scenario.py"
+        module_name = "autocontext.tests.generated_schema_evolution_simulate"
+        spec = importlib.util.spec_from_file_location(module_name, source_path)
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        scenario_cls = _find_scenario_class(module)
+        assert scenario_cls is not None
+        assert issubclass(scenario_cls, SchemaEvolutionInterface)
+        assert detect_family(scenario_cls()).name == "schema_evolution"
 
     def test_sweep_cells_change_execution_when_variables_change_runtime(self, tmp_knowledge: Path) -> None:
         from autocontext.simulation.engine import SimulationEngine


### PR DESCRIPTION
## Summary
- Accept markdown fenced Python/plain code blocks in RLM sessions, while preserving legacy <code> priority and updating prompts/nudges.
- Route schema-evolution/domain-contract prompts ahead of generic simulation hints and preserve schema_evolution metadata in simulate output.
- Persist RunTrace artifacts to per-run roots, add event-stream trace rebuild support, and harden run-id path containment.

## Validation
- uv run ruff check src tests/test_events_to_trace.py tests/test_harness/test_harness_repl_session.py tests/test_knowledge_solver.py tests/test_session_report_wiring.py tests/test_simulate_command.py
- uv run mypy src/autocontext/analytics/events_to_trace.py src/autocontext/analytics/run_trace.py src/autocontext/cli.py src/autocontext/cli_analytics.py src/autocontext/harness/repl/session.py src/autocontext/knowledge/solver.py src/autocontext/loop/generation_runner.py src/autocontext/loop/trace_artifacts.py src/autocontext/scenarios/custom/family_classifier.py src/autocontext/simulation/helpers.py src/autocontext/storage/run_paths.py
- uv run --frozen pytest tests/test_module_size_limits.py -q
- uv run pytest tests/test_events_to_trace.py tests/test_harness/test_harness_repl_session.py tests/test_simulate_command.py::TestSimulationEngine::test_schema_evolution_prompt_preserves_family_metadata tests/test_knowledge_solver.py::TestSolveScenarioBuilder::test_resolves_ac277_portfolio_regime_change_prompt_to_schema_evolution tests/test_session_report_wiring.py::TestRunTraceWiring -q
- uv run pytest tests/test_harness/test_harness_repl_session.py tests/test_rlm_session.py tests/test_monty_repl_integration.py tests/test_rlm_competitor.py tests/test_simulate_command.py tests/test_knowledge_solver.py tests/test_ac628_classifier.py tests/test_family_pipeline.py tests/test_session_report_wiring.py::TestRunTraceWiring tests/test_run_trace.py tests/test_events_to_trace.py -q