### PR TITLE
Fix harness stress regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ pi install npm:pi-autocontext
 | `solve`       | `autoctx solve --description "..." --gens 3`       | Hand the harness a goal in plain language; it generates the scenario and runs the loop |
 | `run`         | `autoctx run --scenario <name> --gens 3`           | Improve behavior inside a saved scenario across generations                            |
 | `simulate`    | `autoctx simulate -d "..."`                        | Model a system, sweep parameters, replay, compare                                      |
-| `investigate` | `autoctx investigate -d "..."`                     | Evidence-driven diagnosis with hypotheses and confidence scoring                       |
+| `investigate` | `autoctx investigate -d "..."`                     | Evidence-driven diagnosis, either synthetic harness or live iterative LLM session      |
 | `analyze`     | `autoctx analyze --id <id> --type <kind>`          | Inspect or compare runs, simulations, investigations, or missions after the fact       |
 | `mission`     | `autoctx mission create --name "..." --goal "..."` | Verifier-driven goal advanced step by step until done                                  |
 | `campaign`    | `bunx autoctx campaign ...` (TypeScript)           | Coordinate multiple missions with budgets, dependencies, progress aggregation          |

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -105,7 +105,7 @@ uv run autoctx solve --description "improve customer-support replies for billing
 
 `autoctx simulate` now follows the effective architect-role runtime surface, so `AUTOCONTEXT_ARCHITECT_PROVIDER`, other role-routing overrides, and per-call `--provider <name>` overrides all apply to live simulation generation.
 
-`autoctx investigate` now ships as a first-class Python CLI surface as well. It uses the architect runtime for investigation-spec synthesis and the analyst runtime for hypothesis generation, so role-routing overrides apply there too. When browser exploration is enabled, `--browser-url <url>` captures a policy-checked snapshot and folds that evidence into the investigation prompts and report artifacts.
+`autoctx investigate` now ships as a first-class Python CLI surface as well. It uses the architect runtime for investigation-spec synthesis and the analyst runtime for hypothesis generation, so role-routing overrides apply there too. The default `--mode synthetic` creates and executes a compact investigation harness. `--mode iterative` runs a live multi-step LLM investigation, emits `events.ndjson` rows, and writes Pi-shaped compaction ledger entries under `runs/<investigation_id>/` when context budget pressure triggers compaction. When browser exploration is enabled, `--browser-url <url>` captures a policy-checked snapshot and folds that evidence into the investigation prompts and report artifacts.
 
 Run with Pi RPC (local Pi subprocess using `pi --mode rpc` JSONL):
 
@@ -162,6 +162,7 @@ uv run autoctx solve --description "improve customer-support replies for billing
 uv run autoctx simulate --description "simulate deploying a web service with rollback"
 uv run autoctx simulate --description "simulate deploying a web service with rollback" --provider claude-cli
 uv run autoctx investigate --description "why did conversion drop after Tuesday's release"
+uv run autoctx investigate --description "debug the outage timeline" --mode iterative
 uv run autoctx investigate --description "checkout is failing in prod" --browser-url https://status.example.com
 uv run autoctx queue add --task-prompt "Write a 1-line fact about primes" --rubric "correct" --threshold 0.8 --rounds 2
 uv run autoctx queue --spec support_triage --browser-url https://status.example.com

--- a/autocontext/src/autocontext/agents/orchestrator.py
+++ b/autocontext/src/autocontext/agents/orchestrator.py
@@ -18,9 +18,11 @@ from autocontext.agents.llm_client import LanguageModelClient, build_client_from
 from autocontext.agents.model_router import ModelRouter, TierConfig
 from autocontext.agents.parsers import parse_analyst_output, parse_architect_output, parse_coach_output, parse_competitor_output
 from autocontext.agents.role_router import ProviderClass, RoleRouter, RoutingContext
+from autocontext.agents.role_runtime_overrides import apply_role_overrides, settings_for_budgeted_role_call
 from autocontext.agents.skeptic import SkepticAgent
 from autocontext.agents.subagent_runtime import SubagentRuntime
 from autocontext.agents.translator import StrategyTranslator
+from autocontext.agents.trial_summary import build_trial_summary as _build_trial_summary
 from autocontext.agents.types import AgentOutputs, RoleExecution
 from autocontext.config.settings import AppSettings
 from autocontext.execution.harness_coverage import HarnessCoverage
@@ -35,30 +37,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _ARCHITECT_CADENCE_SKIP = "\n\nArchitect cadence note: no major intervention; return minimal status + empty tools array."
-
-
-def _build_trial_summary(
-    generation: int,
-    history: list[Any],
-    role_exec: RoleExecution,
-) -> str:
-    """Build a concise markdown summary of an RLM competitor session."""
-    total_turns = len(history)
-    code_runs = sum(1 for r in history if r.code)
-    errors = sum(1 for r in history if r.error)
-    lines = [
-        f"### Generation {generation} — RLM competitor trial",
-        f"- Turns: {total_turns}, code executions: {code_runs}, errors: {errors}",
-        f"- Status: {role_exec.status}",
-        f"- Latency: {role_exec.usage.latency_ms}ms",
-    ]
-    # Include a brief log of each turn
-    for rec in history:
-        err_flag = " [ERROR]" if rec.error else ""
-        ready_flag = " [READY]" if rec.answer_ready else ""
-        code_preview = rec.code[:80].replace("\n", " ")
-        lines.append(f"  - Turn {rec.turn}: `{code_preview}`{err_flag}{ready_flag}")
-    return "\n".join(lines)
 
 
 @dataclass(frozen=True, slots=True)
@@ -150,32 +128,6 @@ def apply_dag_changes(dag: RoleDAG, changes: Sequence[dict[str, Any]]) -> tuple[
     return applied, skipped
 
 
-def _apply_role_overrides(orch: AgentOrchestrator, settings: AppSettings) -> None:
-    """Apply per-role provider and credential overrides to an orchestrator."""
-    from autocontext.agents.provider_bridge import configured_role_provider, create_role_client, has_role_client_override
-
-    runner_map = {
-        "competitor": "competitor",
-        "analyst": "analyst",
-        "coach": "coach",
-        "architect": "architect",
-    }
-
-    for role, runner_name in runner_map.items():
-        if not has_role_client_override(role, settings):
-            continue
-        provider_type = configured_role_provider(role, settings) or settings.agent_provider
-        client = create_role_client(provider_type, settings, role=role)
-        if client is None:
-            continue
-        client = orch._wrap_client(client, provider_name=f"{provider_type}:{role}")
-        orch._role_clients[role] = client
-        runtime = SubagentRuntime(client=client)
-        runner = getattr(orch, runner_name)
-        runner.runtime = runtime
-        logger.info("role '%s' using dedicated provider config: %s", role, provider_type)
-
-
 class AgentOrchestrator:
     """Runs competitor/analyst/coach/architect role sequence."""
 
@@ -193,6 +145,7 @@ class AgentOrchestrator:
         self._artifacts = artifacts
         self._harness_coverage_cache: dict[str, HarnessCoverage | None] = {}
         self._routed_clients: dict[tuple[str, str | None, str | None, str | None], LanguageModelClient] = {}
+        self._disposable_client_ids: set[int] = set()
         runtime = SubagentRuntime(client=self.client)
         self.competitor = CompetitorRunner(runtime, settings.model_competitor)
         self.translator = StrategyTranslator(runtime, settings.model_translator)
@@ -206,6 +159,7 @@ class AgentOrchestrator:
         if settings.skeptic_enabled:
             self.skeptic = SkepticAgent(runtime, settings.model_skeptic)
         self._role_clients: dict[str, LanguageModelClient] = {}
+        self._active_generation_deadline: float | None = None
         self._role_router = RoleRouter(settings)
 
         self._model_router = ModelRouter(
@@ -231,6 +185,22 @@ class AgentOrchestrator:
     def _wrap_client(self, client: LanguageModelClient, *, provider_name: str = "") -> LanguageModelClient:
         return wrap_language_model_client(client, self.hook_bus, provider_name=provider_name)
 
+    def _mark_disposable_client(self, client: LanguageModelClient) -> LanguageModelClient:
+        self._disposable_client_ids.add(id(client))
+        return client
+
+    def _close_disposable_client(self, client: LanguageModelClient) -> None:
+        if id(client) not in self._disposable_client_ids:
+            return
+        self._disposable_client_ids.discard(id(client))
+        close = getattr(client, "close", None)
+        if not callable(close):
+            return
+        try:
+            close()
+        except Exception:
+            logger.debug("failed to close disposable role runtime client", exc_info=True)
+
     @classmethod
     def from_settings(
         cls,
@@ -244,7 +214,7 @@ class AgentOrchestrator:
         orch = cls(client=client, settings=settings, artifacts=artifacts, sqlite=sqlite, hook_bus=hook_bus)
 
         # Apply per-role provider overrides (AC-184)
-        _apply_role_overrides(orch, settings)
+        apply_role_overrides(orch, settings)
 
         return orch
 
@@ -299,20 +269,30 @@ class AgentOrchestrator:
 
         from autocontext.agents.provider_bridge import create_role_client
 
+        call_settings, is_budgeted = settings_for_budgeted_role_call(
+            self.settings,
+            provider_type,
+            role,
+            self._active_generation_deadline,
+        )
         key = (provider_type.lower(), None, scenario_name, role)
-        cached = self._routed_clients.get(key)
-        if cached is not None:
-            return cached
+        if not is_budgeted:
+            cached = self._routed_clients.get(key)
+            if cached is not None:
+                return cached
 
         client = create_role_client(
             provider_type,
-            self.settings,
+            call_settings,
             scenario_name=scenario_name,
             role=role,
         )
         if client is not None:
             client = self._wrap_client(client, provider_name=f"{provider_type}:{role}")
-            self._routed_clients[key] = client
+            if is_budgeted:
+                self._mark_disposable_client(client)
+            else:
+                self._routed_clients[key] = client
         return client
 
     def _scenario_bound_override_client(
@@ -403,13 +383,20 @@ class AgentOrchestrator:
 
         from autocontext.agents.provider_bridge import create_role_client
 
+        call_settings, is_budgeted = settings_for_budgeted_role_call(
+            self.settings,
+            config.provider_type,
+            role,
+            self._active_generation_deadline,
+        )
         key = (config.provider_type.lower(), config.model, scenario_name or None, role)
-        cached = self._routed_clients.get(key)
-        if cached is not None:
-            return cached
+        if not is_budgeted:
+            cached = self._routed_clients.get(key)
+            if cached is not None:
+                return cached
         client = create_role_client(
             config.provider_type,
-            self.settings,
+            call_settings,
             model_override=config.model,
             scenario_name=scenario_name,
             role=role,
@@ -417,7 +404,10 @@ class AgentOrchestrator:
         if client is None:
             return self._client_for_role(role)
         client = self._wrap_client(client, provider_name=f"{config.provider_type}:{role}")
-        self._routed_clients[key] = client
+        if is_budgeted:
+            self._mark_disposable_client(client)
+        else:
+            self._routed_clients[key] = client
         return client
 
     def _resolve_role_execution(
@@ -463,19 +453,25 @@ class AgentOrchestrator:
         retry_count: int = 0,
         is_plateau: bool = False,
         scenario_name: str = "",
+        generation_deadline: float | None = None,
     ) -> tuple[LanguageModelClient, str | None]:
         """Resolve the effective client and model for a role execution.
 
         This is the stable public wrapper for non-runner pipeline stages that need
         to respect per-role overrides and automatic routing decisions.
         """
-        return self._resolve_role_execution(
-            role,
-            generation=generation,
-            retry_count=retry_count,
-            is_plateau=is_plateau,
-            scenario_name=scenario_name,
-        )
+        previous_deadline = self._active_generation_deadline
+        self._active_generation_deadline = generation_deadline
+        try:
+            return self._resolve_role_execution(
+                role,
+                generation=generation,
+                retry_count=retry_count,
+                is_plateau=is_plateau,
+                scenario_name=scenario_name,
+            )
+        finally:
+            self._active_generation_deadline = previous_deadline
 
     @contextmanager
     def _use_role_runtime(
@@ -487,16 +483,23 @@ class AgentOrchestrator:
         retry_count: int = 0,
         is_plateau: bool = False,
         scenario_name: str = "",
+        generation_deadline: float | None = None,
     ) -> Any:
         original_client = runner.runtime.client
         original_model = runner.model
-        client, model = self._resolve_role_execution(
-            role,
-            generation=generation,
-            retry_count=retry_count,
-            is_plateau=is_plateau,
-            scenario_name=scenario_name,
-        )
+        previous_deadline = self._active_generation_deadline
+        self._active_generation_deadline = generation_deadline
+        client: LanguageModelClient | None = None
+        try:
+            client, model = self._resolve_role_execution(
+                role,
+                generation=generation,
+                retry_count=retry_count,
+                is_plateau=is_plateau,
+                scenario_name=scenario_name,
+            )
+        finally:
+            self._active_generation_deadline = previous_deadline
         runner.runtime.client = client
         if model is not None:
             runner.model = model
@@ -505,6 +508,8 @@ class AgentOrchestrator:
         finally:
             runner.runtime.client = original_client
             runner.model = original_model
+            if client is not None:
+                self._close_disposable_client(client)
 
     def run_generation(
         self,
@@ -517,6 +522,7 @@ class AgentOrchestrator:
         on_role_event: Callable[[str, str], None] | None = None,
         scenario_rules: str = "",
         current_strategy: dict[str, Any] | None = None,
+        generation_deadline: float | None = None,
     ) -> AgentOutputs:
         # Feature-gated pipeline codepath (skips RLM path when active)
         if self.settings.use_pipeline_engine and not (self.settings.rlm_enabled and self._rlm_loader is not None):
@@ -527,6 +533,7 @@ class AgentOrchestrator:
                 tool_context,
                 strategy_interface,
                 on_role_event,
+                generation_deadline,
             )
 
         def _notify(role: str, status: str) -> None:
@@ -573,6 +580,7 @@ class AgentOrchestrator:
                 self.competitor,
                 generation=generation_index,
                 scenario_name=scenario_name,
+                generation_deadline=generation_deadline,
             ):
                 raw_text, competitor_exec = self.competitor.run(competitor_prompt, tool_context=tool_context)
             _notify("competitor", "completed")
@@ -583,6 +591,7 @@ class AgentOrchestrator:
             self.translator,
             generation=generation_index,
             scenario_name=scenario_name,
+            generation_deadline=generation_deadline,
         ):
             if self.settings.code_strategies_enabled:
                 strategy, translator_exec = self.translator.translate_code(raw_text)
@@ -614,6 +623,7 @@ class AgentOrchestrator:
                     self.coach,
                     generation=generation_index,
                     scenario_name=scenario_name,
+                    generation_deadline=generation_deadline,
                 ):
                     coach_future = pool.submit(self.coach.run, enriched_coach_prompt)
                     coach_exec = coach_future.result()
@@ -626,6 +636,7 @@ class AgentOrchestrator:
                 self.analyst,
                 generation=generation_index,
                 scenario_name=scenario_name,
+                generation_deadline=generation_deadline,
             ):
                 analyst_exec = self.analyst.run(prompts.analyst)
             _notify("analyst", "completed")
@@ -638,12 +649,14 @@ class AgentOrchestrator:
                     self.coach,
                     generation=generation_index,
                     scenario_name=scenario_name,
+                    generation_deadline=generation_deadline,
                 ),
                 self._use_role_runtime(
                     "architect",
                     self.architect,
                     generation=generation_index,
                     scenario_name=scenario_name,
+                    generation_deadline=generation_deadline,
                 ),
             ):
                 with ThreadPoolExecutor(max_workers=2) as pool:
@@ -693,6 +706,7 @@ class AgentOrchestrator:
         tool_context: str,
         strategy_interface: str,
         on_role_event: Callable[[str, str], None] | None,
+        generation_deadline: float | None = None,
     ) -> AgentOutputs:
         """Execute the 5-role generation via PipelineEngine."""
         from autocontext.agents.pipeline_adapter import build_mts_dag, build_role_handler
@@ -718,6 +732,7 @@ class AgentOrchestrator:
             scenario_name=scenario_name,
             tool_context=tool_context,
             strategy_interface=strategy_interface,
+            generation_deadline=generation_deadline,
         )
         engine = PipelineEngine(dag, handler, max_workers=2)
         results = engine.execute(prompt_map, on_role_event=on_role_event)

--- a/autocontext/src/autocontext/agents/pipeline_adapter.py
+++ b/autocontext/src/autocontext/agents/pipeline_adapter.py
@@ -35,6 +35,7 @@ def build_role_handler(
     scenario_name: str = "",
     tool_context: str = "",
     strategy_interface: str = "",
+    generation_deadline: float | None = None,
 ) -> RoleHandler:
     """Build a RoleHandler callable that delegates to the orchestrator's role runners."""
 
@@ -45,6 +46,7 @@ def build_role_handler(
                 orch.competitor,
                 generation=generation,
                 scenario_name=scenario_name,
+                generation_deadline=generation_deadline,
             ):
                 _raw_text, exec_result = orch.competitor.run(prompt, tool_context=tool_context)
                 return exec_result
@@ -56,6 +58,7 @@ def build_role_handler(
                 orch.translator,
                 generation=generation,
                 scenario_name=scenario_name,
+                generation_deadline=generation_deadline,
             ):
                 _strategy, exec_result = orch.translator.translate(raw_text, strategy_interface)
                 return exec_result
@@ -65,6 +68,7 @@ def build_role_handler(
                 orch.analyst,
                 generation=generation,
                 scenario_name=scenario_name,
+                generation_deadline=generation_deadline,
             ):
                 return orch.analyst.run(prompt)
         elif name == "architect":
@@ -73,6 +77,7 @@ def build_role_handler(
                 orch.architect,
                 generation=generation,
                 scenario_name=scenario_name,
+                generation_deadline=generation_deadline,
             ):
                 return orch.architect.run(prompt)
         elif name == "coach":
@@ -85,6 +90,7 @@ def build_role_handler(
                 orch.coach,
                 generation=generation,
                 scenario_name=scenario_name,
+                generation_deadline=generation_deadline,
             ):
                 return orch.coach.run(enriched)
         else:

--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -109,6 +109,11 @@ class RuntimeBridgeClient(LanguageModelClient):
             metadata=dict(output.metadata),
         )
 
+    def close(self) -> None:
+        close = getattr(self._runtime, "close", None)
+        if callable(close):
+            close()
+
 
 def _role_setting(settings: AppSettings, role: str, suffix: str) -> str:
     if not role:

--- a/autocontext/src/autocontext/agents/role_runtime_overrides.py
+++ b/autocontext/src/autocontext/agents/role_runtime_overrides.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from autocontext.agents.subagent_runtime import SubagentRuntime
+from autocontext.config.settings import AppSettings
+
+logger = logging.getLogger(__name__)
+
+_ROLE_RUNTIME_TIMEOUT_FIELDS = {
+    "pi": "pi_timeout",
+    "pi-rpc": "pi_timeout",
+    "claude-cli": "claude_timeout",
+    "codex": "codex_timeout",
+    "hermes": "hermes_timeout",
+}
+
+
+def settings_for_budgeted_role_call(
+    settings: AppSettings,
+    provider_type: str,
+    role: str,
+    generation_deadline: float | None,
+) -> tuple[AppSettings, bool]:
+    field = _ROLE_RUNTIME_TIMEOUT_FIELDS.get(provider_type.lower().strip())
+    if field is None or generation_deadline is None:
+        return settings, False
+    remaining = generation_deadline - time.monotonic()
+    if remaining < 1.0:
+        raise TimeoutError(
+            f"generation time budget exhausted before {role} provider call "
+            f"({remaining:.2f}s remaining)"
+        )
+    configured = float(getattr(settings, field))
+    bounded = min(configured, remaining)
+    if bounded == configured:
+        return settings, False
+    updates: dict[str, Any] = {field: bounded}
+    if provider_type.lower().strip() == "pi-rpc":
+        updates["pi_rpc_persistent"] = False
+    return settings.model_copy(update=updates), True
+
+
+def apply_role_overrides(orch: Any, settings: AppSettings) -> None:
+    """Apply per-role provider and credential overrides to an orchestrator."""
+    from autocontext.agents.provider_bridge import configured_role_provider, create_role_client, has_role_client_override
+
+    runner_map = {
+        "competitor": "competitor",
+        "analyst": "analyst",
+        "coach": "coach",
+        "architect": "architect",
+    }
+
+    for role, runner_name in runner_map.items():
+        if not has_role_client_override(role, settings):
+            continue
+        provider_type = configured_role_provider(role, settings) or settings.agent_provider
+        client = create_role_client(provider_type, settings, role=role)
+        if client is None:
+            continue
+        client = orch._wrap_client(client, provider_name=f"{provider_type}:{role}")
+        orch._role_clients[role] = client
+        runtime = SubagentRuntime(client=client)
+        runner = getattr(orch, runner_name)
+        runner.runtime = runtime
+        logger.info("role '%s' using dedicated provider config: %s", role, provider_type)

--- a/autocontext/src/autocontext/agents/trial_summary.py
+++ b/autocontext/src/autocontext/agents/trial_summary.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+from autocontext.agents.types import RoleExecution
+
+
+def build_trial_summary(
+    generation: int,
+    history: list[Any],
+    role_exec: RoleExecution,
+) -> str:
+    """Build a concise markdown summary of an RLM competitor session."""
+    total_turns = len(history)
+    code_runs = sum(1 for r in history if r.code)
+    errors = sum(1 for r in history if r.error)
+    lines = [
+        f"### Generation {generation} — RLM competitor trial",
+        f"- Turns: {total_turns}, code executions: {code_runs}, errors: {errors}",
+        f"- Status: {role_exec.status}",
+        f"- Latency: {role_exec.usage.latency_ms}ms",
+    ]
+    for rec in history:
+        err_flag = " [ERROR]" if rec.error else ""
+        ready_flag = " [READY]" if rec.answer_ready else ""
+        code_preview = rec.code[:80].replace("\n", " ")
+        lines.append(f"  - Turn {rec.turn}: `{code_preview}`{err_flag}{ready_flag}")
+    return "\n".join(lines)

--- a/autocontext/src/autocontext/analytics/rubric_drift.py
+++ b/autocontext/src/autocontext/analytics/rubric_drift.py
@@ -8,9 +8,11 @@ jumps, and emits structured warnings when thresholds are crossed.
 
 from __future__ import annotations
 
+import json
 import statistics
 import uuid
 from datetime import UTC, datetime
+from itertools import combinations
 from pathlib import Path
 from typing import Any
 
@@ -54,6 +56,26 @@ class RubricSnapshot(BaseModel):
         return cls.model_validate(data)
 
 
+class DimensionDriftSnapshot(BaseModel):
+    """Point-in-time dimension-level score trajectories for one run."""
+
+    snapshot_id: str
+    created_at: str
+    run_id: str
+    generation_count: int
+    dimension_count: int
+    dimension_series: dict[str, list[float]]
+    best_dimension_series: dict[str, list[float]] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DimensionDriftSnapshot:
+        return cls.model_validate(data)
+
+
 class DriftThresholds(BaseModel):
     """Configurable thresholds for drift detection."""
 
@@ -63,6 +85,10 @@ class DriftThresholds(BaseModel):
     min_stddev: float = 0.05
     max_retry_rate: float = 0.5
     max_rollback_rate: float = 0.3
+    min_dimension_observations: int = 3
+    min_dimension_stddev: float = 0.01
+    max_dimension_decline: float = 0.15
+    max_dimension_correlation: float = 0.98
 
 
 class DriftWarning(BaseModel):
@@ -189,6 +215,38 @@ class RubricDriftMonitor:
             metadata={"scenarios": scenarios},
         )
 
+    def compute_dimension_snapshot(
+        self,
+        run_id: str,
+        generation_trajectory: list[dict[str, Any]],
+    ) -> DimensionDriftSnapshot:
+        """Build dimension score series from generation trajectory rows."""
+        now = datetime.now(UTC).isoformat()
+        dimension_series: dict[str, list[float]] = {}
+        best_dimension_series: dict[str, list[float]] = {}
+        generation_indexes: list[int] = []
+
+        for row in generation_trajectory:
+            summary = _dimension_summary_from_row(row)
+            if not summary:
+                continue
+            generation = row.get("generation_index")
+            if isinstance(generation, int):
+                generation_indexes.append(generation)
+            _append_dimension_values(dimension_series, summary.get("dimension_means"))
+            _append_dimension_values(best_dimension_series, summary.get("best_dimensions"))
+
+        return DimensionDriftSnapshot(
+            snapshot_id=f"dim-snap-{uuid.uuid4().hex[:8]}",
+            created_at=now,
+            run_id=run_id,
+            generation_count=len(generation_indexes) if generation_indexes else len(generation_trajectory),
+            dimension_count=len(dimension_series),
+            dimension_series=dimension_series,
+            best_dimension_series=best_dimension_series,
+            metadata={"generation_indexes": generation_indexes},
+        )
+
     def detect_drift(
         self,
         current: RubricSnapshot,
@@ -298,6 +356,95 @@ class RubricDriftMonitor:
 
         return warnings
 
+    def detect_dimension_drift(
+        self,
+        current: DimensionDriftSnapshot,
+        *,
+        scenario: str = "",
+        release: str = "",
+        agent_provider: str = "",
+    ) -> list[DriftWarning]:
+        """Detect dimension-level scoring drift within a run trajectory."""
+        if current.generation_count == 0 or current.dimension_count == 0:
+            return []
+
+        thresholds = self._thresholds
+        now = datetime.now(UTC).isoformat()
+        warnings: list[DriftWarning] = []
+        scenarios = [scenario] if scenario else []
+        providers = [agent_provider] if agent_provider else []
+        releases = [release] if release else []
+
+        for dimension, series in sorted(current.dimension_series.items()):
+            if len(series) < thresholds.min_dimension_observations:
+                continue
+            stddev = statistics.pstdev(series) if len(series) > 1 else 0.0
+            if stddev <= thresholds.min_dimension_stddev:
+                warnings.append(self._make_warning(
+                    now,
+                    "dimension_score_compression",
+                    "medium",
+                    f"Dimension '{dimension}' score stddev {stddev:.4f} is at or below "
+                    f"{thresholds.min_dimension_stddev:.4f}",
+                    current.snapshot_id,
+                    f"dimension.{dimension}.stddev",
+                    stddev,
+                    thresholds.min_dimension_stddev,
+                    scenarios,
+                    providers,
+                    releases,
+                    metadata={"run_id": current.run_id, "dimension": dimension, "series": series},
+                ))
+
+            decline = series[0] - series[-1]
+            if decline >= thresholds.max_dimension_decline and _is_monotonic_decline(series):
+                warnings.append(self._make_warning(
+                    now,
+                    "dimension_score_decline",
+                    "high",
+                    f"Dimension '{dimension}' declined by {decline:.2f} across the run",
+                    current.snapshot_id,
+                    f"dimension.{dimension}.decline",
+                    decline,
+                    thresholds.max_dimension_decline,
+                    scenarios,
+                    providers,
+                    releases,
+                    metadata={"run_id": current.run_id, "dimension": dimension, "series": series},
+                ))
+
+        for left, right in combinations(sorted(current.dimension_series), 2):
+            left_series = current.dimension_series[left]
+            right_series = current.dimension_series[right]
+            if (
+                len(left_series) < thresholds.min_dimension_observations
+                or len(right_series) < thresholds.min_dimension_observations
+            ):
+                continue
+            correlation = _pearson(left_series, right_series)
+            if correlation is None or abs(correlation) < thresholds.max_dimension_correlation:
+                continue
+            warnings.append(self._make_warning(
+                now,
+                "dimension_correlation_high",
+                "medium",
+                f"Dimensions '{left}' and '{right}' move together with correlation {correlation:.2f}",
+                current.snapshot_id,
+                f"dimension_correlation.{left}.{right}",
+                abs(correlation),
+                thresholds.max_dimension_correlation,
+                scenarios,
+                providers,
+                releases,
+                metadata={
+                    "run_id": current.run_id,
+                    "dimensions": [left, right],
+                    "correlation": round(correlation, 4),
+                },
+            ))
+
+        return warnings
+
     def analyze(
         self,
         facets: list[RunFacet],
@@ -327,6 +474,7 @@ class RubricDriftMonitor:
         scenarios: list[str],
         providers: list[str],
         releases: list[str],
+        metadata: dict[str, Any] | None = None,
     ) -> DriftWarning:
         return DriftWarning(
             warning_id=f"warn-{uuid.uuid4().hex[:8]}",
@@ -341,7 +489,51 @@ class RubricDriftMonitor:
             affected_scenarios=scenarios,
             affected_providers=providers,
             affected_releases=releases,
+            metadata=metadata or {},
         )
+
+
+def _dimension_summary_from_row(row: dict[str, Any]) -> dict[str, Any]:
+    summary = row.get("dimension_summary")
+    if isinstance(summary, dict):
+        return summary
+    raw_summary = row.get("dimension_summary_json")
+    if isinstance(raw_summary, str) and raw_summary:
+        try:
+            parsed = json.loads(raw_summary)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _append_dimension_values(target: dict[str, list[float]], raw_values: Any) -> None:
+    if not isinstance(raw_values, dict):
+        return
+    for raw_dimension, raw_score in raw_values.items():
+        if not isinstance(raw_dimension, str) or not isinstance(raw_score, (int, float)):
+            continue
+        target.setdefault(raw_dimension, []).append(round(float(raw_score), 6))
+
+
+def _is_monotonic_decline(series: list[float]) -> bool:
+    return all(right <= left for left, right in zip(series, series[1:], strict=False))
+
+
+def _pearson(left: list[float], right: list[float]) -> float | None:
+    length = min(len(left), len(right))
+    if length < 2:
+        return None
+    left_values = left[:length]
+    right_values = right[:length]
+    left_mean = statistics.mean(left_values)
+    right_mean = statistics.mean(right_values)
+    numerator = sum((a - left_mean) * (b - right_mean) for a, b in zip(left_values, right_values, strict=False))
+    left_var = sum((a - left_mean) ** 2 for a in left_values)
+    right_var = sum((b - right_mean) ** 2 for b in right_values)
+    if left_var == 0.0 or right_var == 0.0:
+        return None
+    return float(numerator / ((left_var * right_var) ** 0.5))
 
 
 class DriftStore:

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -20,6 +20,7 @@ from rich.table import Table
 from autocontext.agents.orchestrator import AgentOrchestrator
 from autocontext.cli_analytics import register_analytics_command
 from autocontext.cli_investigate import run_investigate_command
+from autocontext.cli_new_scenario import register_new_scenario_command
 from autocontext.cli_queue import register_queue_command
 from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.cli_runtime_overrides import (
@@ -43,6 +44,7 @@ from autocontext.util.json_io import read_json
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from autocontext.extensions import HookBus
     from autocontext.providers.base import LLMProvider
     from autocontext.training.runner import TrainingConfig, TrainingResult
 
@@ -142,11 +144,6 @@ def _resolve_export_artifact_roots(
     )
 
 
-def _get_custom_scenarios_dir() -> Path:
-    """Return the default directory for scaffolded custom scenarios."""
-    return Path("knowledge") / "_custom_scenarios"
-
-
 def _write_json_stdout(payload: object) -> None:
     sys.stdout.write(json.dumps(payload) + "\n")
 
@@ -202,6 +199,7 @@ def _resolve_role_runtime(
     *,
     role: str,
     scenario_name: str = "",
+    hook_bus: HookBus | None = None,
 ) -> tuple[LLMProvider, str]:
     return resolve_role_runtime(
         settings,
@@ -209,6 +207,7 @@ def _resolve_role_runtime(
         scenario_name=scenario_name,
         sqlite=_sqlite_from_settings(settings),
         artifacts=_artifacts_from_settings(settings),
+        hook_bus=hook_bus,
         orchestrator_cls=AgentOrchestrator,
     )
 
@@ -221,9 +220,14 @@ def _resolve_investigation_runtime(
     return _resolve_role_runtime(settings, role=role)
 
 
-def _resolve_agent_task_runtime(settings: AppSettings, scenario_name: str) -> tuple[LLMProvider, str]:
+def _resolve_agent_task_runtime(
+    settings: AppSettings,
+    scenario_name: str,
+    *,
+    hook_bus: HookBus | None = None,
+) -> tuple[LLMProvider, str]:
     """Resolve the effective competitor runtime for direct agent-task execution."""
-    return _resolve_role_runtime(settings, role="competitor", scenario_name=scenario_name)
+    return _resolve_role_runtime(settings, role="competitor", scenario_name=scenario_name, hook_bus=hook_bus)
 
 
 def _run_agent_task(
@@ -240,18 +244,22 @@ def _run_agent_task(
     # Runtime-validated: _is_agent_task() already confirmed this
     task: AgentTaskInterface = instance
 
-    provider, provider_model = _resolve_agent_task_runtime(settings, scenario_name)
+    if settings.extensions:
+        provider, provider_model = _resolve_agent_task_runtime(settings, scenario_name, hook_bus=hook_bus)
+    else:
+        provider, provider_model = _resolve_agent_task_runtime(settings, scenario_name)
     state = task.prepare_context(task.initial_state())
     context_errors = task.validate_context(state)
     if context_errors:
         raise ValueError(f"Context validation failed: {'; '.join(context_errors)}")
     prompt = task.get_task_prompt(state)
 
-    initial_output = provider.complete(
-        system_prompt="Complete the task precisely.",
-        user_prompt=prompt,
-        model=provider_model,
-    ).text
+    with active_hook_bus(hook_bus):
+        initial_output = provider.complete(
+            system_prompt="Complete the task precisely.",
+            user_prompt=prompt,
+            model=provider_model,
+        ).text
 
     loop = ImprovementLoop(task=task, max_rounds=max_rounds)
     active_run_id = run_id or f"task_{uuid.uuid4().hex[:12]}"
@@ -932,73 +940,6 @@ def export_training_data_cmd(
     console.print(f"[green]Exported {count} record(s) to {output_path}[/green]")
 
 
-@app.command("new-scenario")
-def new_scenario(
-    list_templates: bool = typer.Option(False, "--list", help="List available templates"),
-    template: str | None = typer.Option(None, "--template", help="Template to scaffold from"),
-    name: str | None = typer.Option(None, "--name", help="Name for the new scenario"),
-    judge_model: str | None = typer.Option(None, "--judge-model", help="Override judge model"),
-    non_interactive: bool = typer.Option(False, "--non-interactive", help="Use defaults, skip prompts"),
-) -> None:
-    """Scaffold a new scenario from the template library."""
-    from autocontext.scenarios.templates import TemplateLoader
-
-    loader = TemplateLoader()
-
-    if list_templates:
-        templates = loader.list_templates()
-        table = Table(title="Available Scenario Templates")
-        table.add_column("Name", style="bold")
-        table.add_column("Description")
-        table.add_column("Output Format")
-        table.add_column("Max Rounds", justify="right")
-        for t in templates:
-            table.add_row(t.name, t.description, t.output_format, str(t.max_rounds))
-        console.print(table)
-        return
-
-    # Scaffolding mode requires both --template and --name
-    if template is None:
-        console.print("[red]--template is required when not using --list[/red]")
-        raise typer.Exit(code=1)
-    if name is None:
-        console.print("[red]--name is required when scaffolding a scenario[/red]")
-        raise typer.Exit(code=1)
-
-    # Validate template exists
-    try:
-        loader.get_template(template)
-    except KeyError:
-        console.print(f"[red]Template '{template}' not found. Use --list to see available templates.[/red]")
-        raise typer.Exit(code=1) from None
-
-    # Build overrides
-    overrides: dict[str, Any] = {}
-    if judge_model is not None:
-        overrides["judge_model"] = judge_model
-
-    # Scaffold to target directory
-    target_dir = _get_custom_scenarios_dir() / name
-    try:
-        loader.scaffold(template_name=template, target_dir=target_dir, overrides=overrides or None)
-    except Exception as e:
-        logger.debug("cli: caught Exception", exc_info=True)
-        console.print(f"[red]Failed to scaffold scenario: {e}[/red]")
-        raise typer.Exit(code=1) from None
-
-    from autocontext.scenarios import SCENARIO_REGISTRY
-    from autocontext.scenarios.custom.registry import load_all_custom_scenarios
-
-    loaded = load_all_custom_scenarios(target_dir.parent.parent)
-    registered = loaded.get(name)
-    if registered is not None:
-        SCENARIO_REGISTRY[name] = registered
-
-    console.print(f"[green]Scenario '{name}' created from template '{template}'[/green]")
-    console.print(f"[dim]Files scaffolded to: {target_dir}[/dim]")
-    console.print("[dim]Available to agent-task tooling after scaffold/load via the custom scenario registry.[/dim]")
-
-
 @app.command("export")
 def export_cmd(
     scenario: str = typer.Option(..., "--scenario", help="Scenario to export"),
@@ -1268,6 +1209,7 @@ def investigate(
     hypotheses: int = typer.Option(5, "--hypotheses", min=1, help="Maximum hypotheses to generate"),
     save_as: str = typer.Option("", "--save-as", help="Name for the saved investigation"),
     browser_url: str = typer.Option("", "--browser-url", help="Optional browser URL to capture before investigation"),
+    mode: str = typer.Option("synthetic", "--mode", help="Investigation mode: synthetic or iterative"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
     """Run a plain-language investigation with evidence and hypotheses."""
@@ -1277,6 +1219,7 @@ def investigate(
         hypotheses=hypotheses,
         save_as=save_as,
         browser_url=browser_url,
+        mode=mode,
         json_output=json_output,
         console=console,
         load_settings_fn=load_settings,
@@ -1562,6 +1505,7 @@ def improve(
 
 
 register_analytics_command(app, console=console)
+register_new_scenario_command(app, console=console)
 register_solve_command(app, console=console)
 register_queue_command(app, console=console)
 

--- a/autocontext/src/autocontext/cli_analytics.py
+++ b/autocontext/src/autocontext/cli_analytics.py
@@ -8,10 +8,12 @@ from typing import TYPE_CHECKING, Annotated, Any
 import typer
 
 from autocontext.analytics.events_to_trace import collect_run_ids, events_to_trace
+from autocontext.analytics.rubric_drift import DriftStore, RubricDriftMonitor
 from autocontext.analytics.run_trace import TraceStore
 from autocontext.config.settings import AppSettings
 from autocontext.storage import artifact_store_from_settings
 from autocontext.storage.run_paths import resolve_run_root
+from autocontext.storage.sqlite_store import SQLiteStore
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -91,6 +93,54 @@ def run_rebuild_traces_command(
         )
 
 
+def run_drift_command(
+    *,
+    run_id: str,
+    json_output: bool,
+    console: Console,
+    load_settings_fn: Callable[[], AppSettings],
+    write_json_stdout: Callable[[object], None],
+) -> None:
+    """Analyze dimension-level rubric drift for a completed run."""
+    settings = load_settings_fn()
+    sqlite = SQLiteStore(settings.db_path)
+    sqlite.migrate(Path(__file__).resolve().parents[2] / "migrations")
+    trajectory = sqlite.get_generation_trajectory(run_id)
+    if not trajectory:
+        result: dict[str, Any] = {"status": "failed", "error": f"No completed generations found for {run_id!r}"}
+        if json_output:
+            write_json_stdout(result)
+        else:
+            console.print(f"[red]{result['error']}[/red]")
+        raise typer.Exit(code=1)
+
+    monitor = RubricDriftMonitor()
+    snapshot = monitor.compute_dimension_snapshot(run_id, trajectory)
+    warnings = monitor.detect_dimension_drift(snapshot)
+    store = DriftStore(settings.knowledge_root / "analytics")
+    warning_paths = [str(store.persist_warning(warning)) for warning in warnings]
+    result = {
+        "status": "completed",
+        "run_id": run_id,
+        "snapshot": snapshot.to_dict(),
+        "warnings": [warning.to_dict() for warning in warnings],
+        "warning_paths": warning_paths,
+    }
+    if json_output:
+        write_json_stdout(result)
+        return
+
+    console.print(
+        f"[green]Analyzed[/green] {snapshot.dimension_count} dimension(s) "
+        f"across {snapshot.generation_count} generation(s)."
+    )
+    if not warnings:
+        console.print("[dim]No dimension-level drift warnings.[/dim]")
+        return
+    for warning in warnings:
+        console.print(f"[yellow]{warning.warning_type}[/yellow] {warning.description}")
+
+
 def register_analytics_command(
     app: typer.Typer,
     *,
@@ -111,6 +161,19 @@ def register_analytics_command(
         run_rebuild_traces_command(
             run_id=run_id,
             events_path=events_path,
+            json_output=json_output,
+            console=console,
+            load_settings_fn=_cli_attr(dependency_module, "load_settings"),
+            write_json_stdout=_cli_attr(dependency_module, "_write_json_stdout"),
+        )
+
+    @analytics_app.command("drift")
+    def drift(
+        run_id: Annotated[str, typer.Option("--run-id", help="Run id to analyze")],
+        json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    ) -> None:
+        run_drift_command(
+            run_id=run_id,
             json_output=json_output,
             console=console,
             load_settings_fn=_cli_attr(dependency_module, "load_settings"),

--- a/autocontext/src/autocontext/cli_investigate.py
+++ b/autocontext/src/autocontext/cli_investigate.py
@@ -25,6 +25,7 @@ def run_investigate_command(
     hypotheses: int,
     save_as: str,
     browser_url: str,
+    mode: str,
     json_output: bool,
     console: Console,
     load_settings_fn: Callable[[], AppSettings],
@@ -38,9 +39,19 @@ def run_investigate_command(
         InvestigationRequest,
         derive_investigation_name,
     )
+    from autocontext.loop.events import EventStreamEmitter
+    from autocontext.storage import artifact_store_from_settings
 
     if not description:
         message = "--description is required. Run 'autoctx investigate --help' for usage."
+        if json_output:
+            write_json_stderr(message)
+        else:
+            console.print(f"[red]{message}[/red]")
+        raise typer.Exit(code=1)
+    normalized_mode = mode.strip().lower() if mode else "synthetic"
+    if normalized_mode not in {"synthetic", "iterative"}:
+        message = "--mode must be one of: synthetic, iterative"
         if json_output:
             write_json_stderr(message)
         else:
@@ -65,10 +76,14 @@ def run_investigate_command(
                 console.print(f"[red]{message}[/red]")
             raise typer.Exit(code=1) from exc
 
-    spec_provider, spec_model = resolve_investigation_runtime(settings, role="architect")
     analysis_provider, analysis_model = resolve_investigation_runtime(settings, role="analyst")
+    spec_runtime: tuple[LLMProvider, str] | None = None
 
     def _spec_llm_fn(system: str, user: str) -> str:
+        nonlocal spec_runtime
+        if spec_runtime is None:
+            spec_runtime = resolve_investigation_runtime(settings, role="architect")
+        spec_provider, spec_model = spec_runtime
         result = spec_provider.complete(system, user, model=spec_model)
         return result.text
 
@@ -80,6 +95,9 @@ def run_investigate_command(
         spec_llm_fn=_spec_llm_fn,
         analysis_llm_fn=_analysis_llm_fn,
         knowledge_root=settings.knowledge_root,
+        artifacts=artifact_store_from_settings(settings),
+        events=EventStreamEmitter(settings.event_stream_path),
+        context_budget_tokens=settings.context_budget_tokens,
     )
     result = engine.run(
         InvestigationRequest(
@@ -88,6 +106,7 @@ def run_investigate_command(
             max_hypotheses=hypotheses,
             save_as=save_as or None,
             browser_context=browser_context,
+            mode=normalized_mode,
         )
     )
     payload = result.to_dict()

--- a/autocontext/src/autocontext/cli_new_scenario.py
+++ b/autocontext/src/autocontext/cli_new_scenario.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.table import Table
+
+from autocontext.agents.orchestrator import AgentOrchestrator
+from autocontext.cli_role_runtime import resolve_role_runtime
+from autocontext.config.settings import AppSettings
+from autocontext.scenarios import SCENARIO_REGISTRY
+from autocontext.storage import SQLiteStore, artifact_store_from_settings
+
+logger = logging.getLogger(__name__)
+
+
+def _cli_attr(dependency_module: str, name: str) -> Any:
+    return getattr(importlib.import_module(dependency_module), name)
+
+
+def _get_custom_scenarios_dir() -> Path:
+    """Return the default directory for scaffolded custom scenarios."""
+    return Path("knowledge") / "_custom_scenarios"
+
+
+def _create_family_scenario(
+    *,
+    family: str,
+    name: str,
+    description: str,
+    settings: AppSettings,
+) -> object:
+    """Create a custom scenario through a registered family-specific pipeline."""
+    from autocontext.scenarios.custom.creator_registry import FAMILY_CONFIGS, create_for_family
+
+    if family not in FAMILY_CONFIGS:
+        raise ValueError(f"Unknown family '{family}'. Known families: {', '.join(sorted(FAMILY_CONFIGS))}")
+
+    sqlite = SQLiteStore(settings.db_path)
+    sqlite.migrate(Path(__file__).resolve().parents[2] / "migrations")
+    artifacts = artifact_store_from_settings(settings, enable_buffered_writes=True)
+    provider, model = resolve_role_runtime(
+        settings,
+        role="architect",
+        scenario_name=name,
+        sqlite=sqlite,
+        artifacts=artifacts,
+        orchestrator_cls=AgentOrchestrator,
+    )
+
+    def llm_fn(system: str, user: str) -> str:
+        return provider.complete(system, user, model=model).text
+
+    return create_for_family(family, llm_fn, settings.knowledge_root).create(description, name=name)
+
+
+def register_new_scenario_command(
+    app: typer.Typer,
+    *,
+    console: Any,
+    dependency_module: str = "autocontext.cli",
+) -> None:
+    @app.command("new-scenario")
+    def new_scenario(
+        list_templates: bool = typer.Option(False, "--list", help="List available templates"),
+        list_families: bool = typer.Option(False, "--list-families", help="List available family pipelines"),
+        template: str | None = typer.Option(None, "--template", help="Template to scaffold from"),
+        family: str | None = typer.Option(None, "--family", help="Family-specific pipeline to generate from"),
+        name: str | None = typer.Option(None, "--name", help="Name for the new scenario"),
+        description: str | None = typer.Option(None, "--description", help="Natural-language scenario description"),
+        judge_model: str | None = typer.Option(None, "--judge-model", help="Override judge model"),
+        non_interactive: bool = typer.Option(False, "--non-interactive", help="Use defaults, skip prompts"),
+    ) -> None:
+        """Scaffold a new scenario from the template library."""
+        del non_interactive
+        from autocontext.scenarios.templates import TemplateLoader
+
+        loader = TemplateLoader()
+
+        if list_templates:
+            templates = loader.list_templates()
+            table = Table(title="Available Scenario Templates")
+            table.add_column("Name", style="bold")
+            table.add_column("Description")
+            table.add_column("Output Format")
+            table.add_column("Max Rounds", justify="right")
+            for t in templates:
+                table.add_row(t.name, t.description, t.output_format, str(t.max_rounds))
+            console.print(table)
+            return
+
+        if list_families:
+            from autocontext.scenarios.custom.creator_registry import FAMILY_CONFIGS
+
+            table = Table(title="Available Scenario Family Pipelines")
+            table.add_column("Family", style="bold")
+            table.add_column("Spec")
+            for family_name, config in sorted(FAMILY_CONFIGS.items()):
+                table.add_row(family_name, config.spec_class_path.rsplit(":", 1)[-1])
+            console.print(table)
+            return
+
+        if family is not None:
+            if template is not None:
+                console.print("[red]--template cannot be combined with --family[/red]")
+                raise typer.Exit(code=1)
+            if name is None:
+                console.print("[red]--name is required when generating a family scenario[/red]")
+                raise typer.Exit(code=1)
+            if not description:
+                console.print("[red]--description is required when generating a family scenario[/red]")
+                raise typer.Exit(code=1)
+            settings = _cli_attr(dependency_module, "load_settings")()
+            try:
+                _create_family_scenario(
+                    family=family,
+                    name=name,
+                    description=description,
+                    settings=settings,
+                )
+            except Exception as e:
+                logger.debug("cli: caught Exception", exc_info=True)
+                console.print(f"[red]Failed to generate scenario: {e}[/red]")
+                raise typer.Exit(code=1) from None
+
+            target_dir = settings.knowledge_root / "_custom_scenarios" / name
+            console.print(f"[green]Scenario '{name}' created with family pipeline '{family}'[/green]")
+            console.print(f"[dim]Files scaffolded to: {target_dir}[/dim]")
+            return
+
+        if template is None:
+            console.print("[red]--template is required when not using --list[/red]")
+            raise typer.Exit(code=1)
+        if name is None:
+            console.print("[red]--name is required when scaffolding a scenario[/red]")
+            raise typer.Exit(code=1)
+
+        try:
+            loader.get_template(template)
+        except KeyError:
+            console.print(f"[red]Template '{template}' not found. Use --list to see available templates.[/red]")
+            raise typer.Exit(code=1) from None
+
+        overrides: dict[str, Any] = {}
+        if judge_model is not None:
+            overrides["judge_model"] = judge_model
+
+        target_dir = _get_custom_scenarios_dir() / name
+        try:
+            loader.scaffold(template_name=template, target_dir=target_dir, overrides=overrides or None)
+        except Exception as e:
+            logger.debug("cli: caught Exception", exc_info=True)
+            console.print(f"[red]Failed to scaffold scenario: {e}[/red]")
+            raise typer.Exit(code=1) from None
+
+        from autocontext.scenarios.custom.registry import load_all_custom_scenarios
+
+        loaded = load_all_custom_scenarios(target_dir.parent.parent)
+        registered = loaded.get(name)
+        if registered is not None:
+            SCENARIO_REGISTRY[name] = registered
+
+        console.print(f"[green]Scenario '{name}' created from template '{template}'[/green]")
+        console.print(f"[dim]Files scaffolded to: {target_dir}[/dim]")
+        console.print("[dim]Available to agent-task tooling after scaffold/load via the custom scenario registry.[/dim]")

--- a/autocontext/src/autocontext/cli_role_runtime.py
+++ b/autocontext/src/autocontext/cli_role_runtime.py
@@ -9,6 +9,7 @@ from autocontext.storage import SQLiteStore, artifact_store_from_settings
 
 if TYPE_CHECKING:
     from autocontext.agents.llm_client import LanguageModelClient
+    from autocontext.extensions import HookBus
     from autocontext.providers.base import LLMProvider
 
 
@@ -58,6 +59,8 @@ def resolve_role_runtime(
     scenario_name: str = "",
     sqlite: Any | None = None,
     artifacts: Any | None = None,
+    hook_bus: HookBus | None = None,
+    generation_deadline: float | None = None,
     orchestrator_cls: Any = AgentOrchestrator,
 ) -> tuple[LLMProvider, str]:
     resolved_sqlite = sqlite if sqlite is not None else _sqlite_from_settings(settings)
@@ -69,11 +72,18 @@ def resolve_role_runtime(
             enable_buffered_writes=True,
         )
     )
-    orchestrator = orchestrator_cls.from_settings(settings, artifacts=resolved_artifacts, sqlite=resolved_sqlite)
-    client, model = orchestrator.resolve_role_execution(
-        role,
-        generation=1,
-        scenario_name=scenario_name,
+    orchestrator = orchestrator_cls.from_settings(
+        settings,
+        artifacts=resolved_artifacts,
+        sqlite=resolved_sqlite,
+        hook_bus=hook_bus,
     )
+    resolve_kwargs: dict[str, Any] = {
+        "generation": 1,
+        "scenario_name": scenario_name,
+    }
+    if generation_deadline is not None:
+        resolve_kwargs["generation_deadline"] = generation_deadline
+    client, model = orchestrator.resolve_role_execution(role, **resolve_kwargs)
     resolved_model = model or _role_default_model(settings, role)
     return _wrap_role_client_as_provider(client, resolved_model, role=role)

--- a/autocontext/src/autocontext/cli_solve.py
+++ b/autocontext/src/autocontext/cli_solve.py
@@ -49,6 +49,7 @@ class SolveRunSummary:
     status: str
     description: str
     scenario_name: str | None
+    family_name: str | None
     generations: int
     progress: int
     output_path: str | None
@@ -129,6 +130,7 @@ def run_solve_command(
         status=job.status,
         description=job.description,
         scenario_name=job.scenario_name,
+        family_name=job.family_name,
         generations=job.generations,
         progress=job.progress,
         output_path=output_path,

--- a/autocontext/src/autocontext/extensions/__init__.py
+++ b/autocontext/src/autocontext/extensions/__init__.py
@@ -11,7 +11,7 @@ from autocontext.extensions.hooks import (
     event_block_error,
     get_current_hook_bus,
 )
-from autocontext.extensions.llm import HookedLanguageModelClient, wrap_language_model_client
+from autocontext.extensions.llm import HookedLanguageModelClient, HookedLLMProvider, wrap_language_model_client, wrap_llm_provider
 from autocontext.extensions.loader import load_extensions
 
 __all__ = [
@@ -22,9 +22,11 @@ __all__ = [
     "HookEvents",
     "HookResult",
     "HookedLanguageModelClient",
+    "HookedLLMProvider",
     "active_hook_bus",
     "event_block_error",
     "get_current_hook_bus",
     "load_extensions",
     "wrap_language_model_client",
+    "wrap_llm_provider",
 ]

--- a/autocontext/src/autocontext/extensions/llm.py
+++ b/autocontext/src/autocontext/extensions/llm.py
@@ -6,6 +6,7 @@ from typing import Any
 from autocontext.extensions.hooks import HookBus, HookEvents
 from autocontext.harness.core.llm_client import LanguageModelClient
 from autocontext.harness.core.types import ModelResponse, RoleUsage
+from autocontext.providers.base import CompletionResult, LLMProvider
 
 
 class HookedLanguageModelClient(LanguageModelClient):
@@ -103,6 +104,82 @@ class HookedLanguageModelClient(LanguageModelClient):
         return ModelResponse(text=str(response_payload.get("text", response.text)), usage=usage, metadata=metadata)
 
 
+class HookedLLMProvider(LLMProvider):
+    """Wrap any LLMProvider with provider request/response hooks."""
+
+    def __init__(
+        self,
+        inner: LLMProvider,
+        hook_bus: HookBus,
+        *,
+        provider_name: str = "",
+        role: str = "",
+    ) -> None:
+        self.inner = inner
+        self.hook_bus = hook_bus
+        self.provider_name = provider_name or inner.name
+        self.role = role
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.inner, name)
+
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+    ) -> CompletionResult:
+        payload = {
+            "provider": self.provider_name,
+            "role": self.role,
+            "model": model,
+            "system_prompt": system_prompt,
+            "user_prompt": user_prompt,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "multiturn": False,
+        }
+        before = self.hook_bus.emit(HookEvents.BEFORE_PROVIDER_REQUEST, payload)
+        before.raise_if_blocked()
+        request = before.payload
+        response = self.inner.complete(
+            system_prompt=str(request.get("system_prompt", system_prompt)),
+            user_prompt=str(request.get("user_prompt", user_prompt)),
+            model=_optional_str(request.get("model", model)),
+            temperature=float(request.get("temperature", temperature)),
+            max_tokens=int(request.get("max_tokens", max_tokens)),
+        )
+        response_model = getattr(response, "model", None)
+        response_usage = getattr(response, "usage", {})
+        response_cost = getattr(response, "cost_usd", None)
+        response_payload = {
+            "provider": self.provider_name,
+            "role": request.get("role", self.role),
+            "model": response_model or request.get("model") or model or self.default_model(),
+            "request": dict(request),
+            "text": response.text,
+            "usage": dict(response_usage) if isinstance(response_usage, dict) else {},
+            "cost_usd": response_cost,
+        }
+        after = self.hook_bus.emit(HookEvents.AFTER_PROVIDER_RESPONSE, response_payload)
+        after.raise_if_blocked()
+        return CompletionResult(
+            text=str(after.payload.get("text", response.text)),
+            model=_optional_str(after.payload.get("model", response_model)),
+            usage=_usage_dict(after.payload.get("usage", response_usage)),
+            cost_usd=_optional_float(after.payload.get("cost_usd", response_cost)),
+        )
+
+    def default_model(self) -> str:
+        return self.inner.default_model()
+
+    @property
+    def name(self) -> str:
+        return self.provider_name
+
+
 def _message_list(value: Any) -> list[dict[str, str]]:
     if not isinstance(value, list):
         return []
@@ -113,6 +190,24 @@ def _message_list(value: Any) -> list[dict[str, str]]:
             content = str(item.get("content", ""))
             messages.append({"role": role, "content": content})
     return messages
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _usage_dict(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    return {str(key): int(item) for key, item in value.items() if isinstance(item, (int, float))}
 
 
 def _usage_from_payload(default: RoleUsage, value: Any) -> RoleUsage:
@@ -137,3 +232,17 @@ def wrap_language_model_client(
     if isinstance(client, HookedLanguageModelClient):
         return client
     return HookedLanguageModelClient(client, hook_bus, provider_name=provider_name)
+
+
+def wrap_llm_provider(
+    provider: LLMProvider,
+    hook_bus: HookBus | None,
+    *,
+    provider_name: str = "",
+    role: str = "",
+) -> LLMProvider:
+    if hook_bus is None:
+        return provider
+    if isinstance(provider, HookedLLMProvider):
+        return provider
+    return HookedLLMProvider(provider, hook_bus, provider_name=provider_name, role=role)

--- a/autocontext/src/autocontext/investigation/engine.py
+++ b/autocontext/src/autocontext/investigation/engine.py
@@ -8,7 +8,7 @@ import sys
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from autocontext.agents.types import LlmFn
 from autocontext.investigation.browser_context import (
@@ -34,6 +34,7 @@ class InvestigationRequest:
     max_hypotheses: int | None = None
     save_as: str | None = None
     browser_context: InvestigationBrowserContext | None = None
+    mode: str = "synthetic"
 
 
 @dataclass(slots=True)
@@ -671,14 +672,45 @@ class InvestigationEngine:
         spec_llm_fn: LlmFn,
         knowledge_root: Path,
         analysis_llm_fn: LlmFn | None = None,
+        artifacts: Any | None = None,
+        events: Any | None = None,
+        context_budget_tokens: int = 0,
     ) -> None:
         self._spec_llm_fn = spec_llm_fn
         self._analysis_llm_fn = analysis_llm_fn or spec_llm_fn
         self._knowledge_root = knowledge_root
+        self._artifacts = artifacts
+        self._events = events
+        self._context_budget_tokens = context_budget_tokens
 
     def run(self, request: InvestigationRequest) -> InvestigationResult:
         investigation_id = generate_investigation_id()
         name = request.save_as or derive_investigation_name(request.description)
+        mode = (request.mode or "synthetic").strip().lower()
+        if mode not in {"synthetic", "iterative"}:
+            return _build_failed_result(
+                investigation_id=investigation_id,
+                name=name,
+                request=request,
+                errors=[f"unsupported investigation mode: {request.mode}"],
+            )
+        if mode == "iterative":
+            from autocontext.investigation.iterative import run_iterative_investigation
+
+            return cast(
+                InvestigationResult,
+                run_iterative_investigation(
+                    request=request,
+                    investigation_id=investigation_id,
+                    name=name,
+                    analysis_llm_fn=self._analysis_llm_fn,
+                    knowledge_root=self._knowledge_root,
+                    artifacts=self._artifacts,
+                    events=self._events,
+                    context_budget_tokens=self._context_budget_tokens,
+                    failed_result_fn=_build_failed_result,
+                ),
+            )
 
         try:
             spec_system, spec_user = _build_investigation_spec_prompt(

--- a/autocontext/src/autocontext/investigation/iterative.py
+++ b/autocontext/src/autocontext/investigation/iterative.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from autocontext.agents.types import LlmFn
+from autocontext.investigation.browser_context import (
+    InvestigationBrowserContext,
+    build_browser_evidence_summary,
+    render_investigation_browser_context,
+)
+from autocontext.knowledge.compaction import (
+    CompactionEntry,
+    compact_prompt_components,
+    compaction_entries_for_components,
+)
+from autocontext.prompts.context_budget import ContextBudget, estimate_tokens
+from autocontext.scenarios.families import get_family_marker
+from autocontext.util.json_io import write_json
+
+
+def run_iterative_investigation(
+    *,
+    request: Any,
+    investigation_id: str,
+    name: str,
+    analysis_llm_fn: LlmFn,
+    knowledge_root: Path,
+    artifacts: Any | None = None,
+    events: Any | None = None,
+    context_budget_tokens: int = 0,
+    failed_result_fn: Any,
+) -> Any:
+    from autocontext.investigation.engine import (
+        InvestigationArtifacts,
+        InvestigationResult,
+        normalize_positive_integer,
+        parse_investigation_json,
+    )
+
+    try:
+        max_steps = normalize_positive_integer(request.max_steps) or 8
+        transcript: list[dict[str, Any]] = []
+        latest_payload: dict[str, Any] = {}
+        compaction_parent_id = _latest_compaction_parent_id(artifacts, investigation_id)
+
+        _emit_investigation_event(
+            events,
+            "investigation_started",
+            {
+                "run_id": investigation_id,
+                "scenario": name,
+                "mode": "iterative",
+                "max_steps": max_steps,
+                "description": request.description,
+            },
+        )
+
+        for step in range(1, max_steps + 1):
+            _emit_investigation_event(
+                events,
+                "investigation_step_started",
+                {
+                    "run_id": investigation_id,
+                    "scenario": name,
+                    "mode": "iterative",
+                    "generation": step,
+                    "step": step,
+                },
+            )
+            system_prompt, user_prompt = _build_iterative_investigation_prompt(
+                description=request.description,
+                step=step,
+                max_steps=max_steps,
+                transcript=transcript,
+                browser_context=request.browser_context,
+            )
+            raw_response = analysis_llm_fn(system_prompt, user_prompt)
+            parsed = parse_investigation_json(raw_response) or {}
+            transcript.append(
+                {
+                    "step": step,
+                    "system": system_prompt,
+                    "user": user_prompt,
+                    "response": raw_response,
+                    "parsed": parsed,
+                }
+            )
+            if parsed:
+                latest_payload = parsed
+            entries = _compact_iterative_context_if_needed(
+                artifacts=artifacts,
+                investigation_id=investigation_id,
+                name=name,
+                step=step,
+                transcript=transcript,
+                context_budget_tokens=context_budget_tokens,
+                parent_id=compaction_parent_id,
+            )
+            if entries:
+                compaction_parent_id = entries[-1].entry_id
+            _emit_investigation_event(
+                events,
+                "investigation_step_completed",
+                {
+                    "run_id": investigation_id,
+                    "scenario": name,
+                    "mode": "iterative",
+                    "generation": step,
+                    "step": step,
+                    "response_length": len(raw_response),
+                    "transcript_tokens": estimate_tokens(_render_transcript_for_compaction(transcript)),
+                    "compaction_entries": len(entries),
+                },
+            )
+
+        investigation_dir = _persist_iterative_investigation_artifacts(knowledge_root, name, transcript, artifacts)
+        hypotheses = _coerce_iterative_hypotheses(latest_payload, request.max_hypotheses)
+        evidence = _coerce_iterative_evidence(latest_payload, browser_context=request.browser_context)
+        conclusion = _coerce_iterative_conclusion(latest_payload, hypotheses)
+        unknowns = _string_list(latest_payload.get("unknowns"))
+        next_steps = _string_list(latest_payload.get("recommended_next_steps"))
+        if not next_steps:
+            next_steps = _recommend_next_steps(hypotheses, unknowns)
+        report_path = investigation_dir / "report.json"
+        result = InvestigationResult(
+            id=investigation_id,
+            name=name,
+            family="investigation",
+            status="completed",
+            description=request.description,
+            question=str(latest_payload.get("question") or request.description),
+            hypotheses=hypotheses,
+            evidence=evidence,
+            conclusion=conclusion,
+            unknowns=unknowns,
+            recommended_next_steps=next_steps,
+            steps_executed=max_steps,
+            artifacts=InvestigationArtifacts(
+                investigation_dir=str(investigation_dir),
+                report_path=str(report_path),
+            ),
+        )
+        _write_json_artifact(artifacts, report_path, result.to_dict())
+        _emit_investigation_event(
+            events,
+            "investigation_completed",
+            {
+                "run_id": investigation_id,
+                "scenario": name,
+                "mode": "iterative",
+                "status": "completed",
+                "steps_executed": max_steps,
+            },
+        )
+        return result
+    except Exception as exc:
+        _emit_investigation_event(
+            events,
+            "investigation_failed",
+            {
+                "run_id": investigation_id,
+                "scenario": name,
+                "mode": "iterative",
+                "status": "failed",
+                "error": str(exc),
+            },
+        )
+        return failed_result_fn(
+            investigation_id=investigation_id,
+            name=name,
+            request=request,
+            errors=[str(exc)],
+        )
+
+
+def _build_iterative_investigation_prompt(
+    *,
+    description: str,
+    step: int,
+    max_steps: int,
+    transcript: list[dict[str, Any]],
+    browser_context: InvestigationBrowserContext | None = None,
+) -> tuple[str, str]:
+    system_prompt = (
+        "You are running a live iterative investigation session. Each step should refine hypotheses, "
+        "name evidence gathered so far, and identify what remains uncertain. Output ONLY JSON with keys: "
+        "question, hypotheses, evidence, conclusion, unknowns, recommended_next_steps."
+    )
+    previous = []
+    for item in transcript[-5:]:
+        parsed = item.get("parsed")
+        if isinstance(parsed, dict):
+            conclusion = parsed.get("conclusion")
+            if isinstance(conclusion, dict):
+                previous.append(str(conclusion.get("best_explanation") or ""))
+            elif conclusion:
+                previous.append(str(conclusion))
+    previous_summary = "\n".join(f"- {item}" for item in previous if item) or "- No prior step output."
+    user_prompt = (
+        f"Investigation: {description}\n"
+        f"Step: {step} of {max_steps}\n"
+        f"Previous step conclusions:\n{previous_summary}\n\n"
+        "Return updated JSON. Hypotheses may include optional status values: supported, contradicted, unresolved. "
+        "Evidence items may include id, kind, source, summary, supports, contradicts, and is_red_herring."
+    )
+    if browser_context is not None:
+        user_prompt = f"{user_prompt}\n\n{render_investigation_browser_context(browser_context)}"
+    return system_prompt, user_prompt
+
+
+def _coerce_iterative_hypotheses(payload: dict[str, Any], max_hypotheses: int | None) -> list[Any]:
+    from autocontext.investigation.engine import InvestigationHypothesis, normalize_positive_integer
+
+    raw_hypotheses = payload.get("hypotheses")
+    if not isinstance(raw_hypotheses, list):
+        raw_hypotheses = [{"statement": str(payload.get("question") or "Investigate the reported issue")}]
+    limit = normalize_positive_integer(max_hypotheses)
+    if limit is not None:
+        raw_hypotheses = raw_hypotheses[:limit]
+    hypotheses: list[Any] = []
+    for index, raw in enumerate(raw_hypotheses):
+        if not isinstance(raw, dict):
+            continue
+        confidence = raw.get("confidence", 0.5)
+        if not isinstance(confidence, (int, float)):
+            confidence = 0.5
+        status = str(raw.get("status") or "unresolved")
+        if status not in {"supported", "contradicted", "unresolved"}:
+            status = "unresolved"
+        hypotheses.append(
+            InvestigationHypothesis(
+                id=str(raw.get("id") or f"h{index}"),
+                statement=str(raw.get("statement") or raw.get("hypothesis") or "Unspecified hypothesis"),
+                status=status,
+                confidence=max(0.0, min(1.0, float(confidence))),
+            )
+        )
+    return hypotheses
+
+
+def _coerce_iterative_evidence(
+    payload: dict[str, Any],
+    *,
+    browser_context: InvestigationBrowserContext | None,
+) -> list[Any]:
+    from autocontext.investigation.engine import InvestigationEvidence
+
+    evidence: list[Any] = []
+    if browser_context is not None:
+        evidence.append(
+            InvestigationEvidence(
+                id="browser_snapshot",
+                kind="browser_snapshot",
+                source=browser_context.url,
+                summary=build_browser_evidence_summary(browser_context),
+                is_red_herring=False,
+            )
+        )
+    raw_evidence = payload.get("evidence")
+    if not isinstance(raw_evidence, list):
+        return evidence
+    for index, raw in enumerate(raw_evidence):
+        if not isinstance(raw, dict):
+            continue
+        supports = raw.get("supports")
+        contradicts = raw.get("contradicts")
+        evidence.append(
+            InvestigationEvidence(
+                id=str(raw.get("id") or f"e{index}"),
+                kind=str(raw.get("kind") or "observation"),
+                source=str(raw.get("source") or "iterative_session"),
+                summary=str(raw.get("summary") or raw.get("content") or ""),
+                supports=[str(item) for item in supports] if isinstance(supports, list) else [],
+                contradicts=[str(item) for item in contradicts] if isinstance(contradicts, list) else [],
+                is_red_herring=bool(raw.get("is_red_herring", False)),
+            )
+        )
+    return evidence
+
+
+def _coerce_iterative_conclusion(payload: dict[str, Any], hypotheses: list[Any]) -> Any:
+    from autocontext.investigation.engine import InvestigationConclusion
+
+    raw_conclusion = payload.get("conclusion")
+    if isinstance(raw_conclusion, dict):
+        confidence = raw_conclusion.get("confidence", 0.0)
+        if not isinstance(confidence, (int, float)):
+            confidence = 0.0
+        limitations = raw_conclusion.get("limitations")
+        return InvestigationConclusion(
+            best_explanation=str(raw_conclusion.get("best_explanation") or raw_conclusion.get("summary") or ""),
+            confidence=max(0.0, min(1.0, float(confidence))),
+            limitations=[str(item) for item in limitations] if isinstance(limitations, list) else [],
+        )
+    supported = sorted(
+        [hypothesis for hypothesis in hypotheses if hypothesis.status == "supported"],
+        key=lambda item: item.confidence,
+        reverse=True,
+    )
+    best = supported[0] if supported else (hypotheses[0] if hypotheses else None)
+    return InvestigationConclusion(
+        best_explanation=best.statement if best else "No hypothesis received sufficient support",
+        confidence=best.confidence if best else 0.0,
+        limitations=["Iterative investigation based on LLM session transcript"],
+    )
+
+
+def _recommend_next_steps(hypotheses: list[Any], unknowns: list[str]) -> list[str]:
+    steps: list[str] = []
+    supported = [hypothesis for hypothesis in hypotheses if hypothesis.status == "supported"]
+    if supported:
+        steps.append(f'Verify leading hypothesis: "{supported[0].statement}"')
+    for hypothesis in [item for item in hypotheses if item.status == "unresolved"][:2]:
+        steps.append(f'Gather evidence for: "{hypothesis.statement}"')
+    if unknowns:
+        steps.append("Address identified unknowns before concluding")
+    return steps
+
+
+def _string_list(value: Any) -> list[str]:
+    return [str(item) for item in value] if isinstance(value, list) else []
+
+
+def _persist_iterative_investigation_artifacts(
+    knowledge_root: Path,
+    name: str,
+    transcript: list[dict[str, Any]],
+    artifacts: Any | None = None,
+) -> Path:
+    investigation_dir = knowledge_root / "_investigations" / name
+    investigation_dir.mkdir(parents=True, exist_ok=True)
+    _write_json_artifact(
+        artifacts,
+        investigation_dir / "spec.json",
+        {
+            "name": name,
+            "family": "investigation",
+            "mode": "iterative",
+            "steps": len(transcript),
+        },
+    )
+    _write_json_artifact(artifacts, investigation_dir / "transcript.json", {"steps": transcript})
+    _write_text_artifact(artifacts, investigation_dir / "scenario_type.txt", get_family_marker("investigation"))
+    return investigation_dir
+
+
+def _compact_iterative_context_if_needed(
+    *,
+    artifacts: Any | None,
+    investigation_id: str,
+    name: str,
+    step: int,
+    transcript: list[dict[str, Any]],
+    context_budget_tokens: int,
+    parent_id: str,
+) -> list[CompactionEntry]:
+    if artifacts is None or context_budget_tokens <= 0:
+        return []
+    transcript_text = _render_transcript_for_compaction(transcript)
+    tokens_before = estimate_tokens(transcript_text)
+    if tokens_before <= context_budget_tokens:
+        return []
+
+    original = {"analysis": transcript_text}
+    compacted = ContextBudget(max_tokens=context_budget_tokens).apply(compact_prompt_components(original))
+    entries = compaction_entries_for_components(
+        original,
+        compacted,
+        context={
+            "scenario": name,
+            "run_id": investigation_id,
+            "mode": "iterative_investigation",
+            "step": step,
+            "trigger": "context_pressure",
+            "context_budget_tokens": context_budget_tokens,
+        },
+        parent_id=parent_id,
+    )
+    if entries:
+        artifacts.append_compaction_entries(investigation_id, entries)
+    return entries
+
+
+def _render_transcript_for_compaction(transcript: list[dict[str, Any]]) -> str:
+    chunks: list[str] = []
+    for item in transcript:
+        parsed = item.get("parsed") if isinstance(item, dict) else {}
+        conclusion = parsed.get("conclusion") if isinstance(parsed, dict) else None
+        if isinstance(conclusion, dict):
+            conclusion_summary = str(conclusion.get("best_explanation") or conclusion.get("summary") or "")
+        else:
+            conclusion_summary = str(conclusion or "")
+        chunks.append(
+            "\n".join(
+                [
+                    f"## Step {item.get('step', '')}",
+                    f"User prompt: {item.get('user', '')}",
+                    f"Response: {item.get('response', '')}",
+                    f"Conclusion: {conclusion_summary}",
+                ]
+            ).strip()
+        )
+    return "\n\n---\n\n".join(chunk for chunk in chunks if chunk)
+
+
+def _latest_compaction_parent_id(artifacts: Any | None, investigation_id: str) -> str:
+    if artifacts is None:
+        return ""
+    latest = getattr(artifacts, "latest_compaction_entry_id", None)
+    return str(latest(investigation_id) or "") if callable(latest) else ""
+
+
+def _emit_investigation_event(events: Any | None, event: str, payload: dict[str, Any]) -> None:
+    if events is None:
+        return
+    events.emit(event, payload, channel="investigation")
+
+
+def _write_json_artifact(artifacts: Any | None, path: Path, payload: dict[str, Any]) -> None:
+    writer = getattr(artifacts, "write_json", None)
+    if callable(writer):
+        writer(path, payload)
+        return
+    write_json(path, payload)
+
+
+def _write_text_artifact(artifacts: Any | None, path: Path, content: str) -> None:
+    writer = getattr(artifacts, "write_markdown", None)
+    if callable(writer):
+        writer(path, content)
+        return
+    path.write_text(content, encoding="utf-8")

--- a/autocontext/src/autocontext/knowledge/solve_task_execution.py
+++ b/autocontext/src/autocontext/knowledge/solve_task_execution.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from autocontext.agents.provider_bridge import configured_role_provider
+from autocontext.agents.role_runtime_overrides import settings_for_budgeted_role_call
+from autocontext.config.settings import AppSettings
+from autocontext.execution.improvement_loop import ImprovementLoop
+from autocontext.extensions import HookBus, HookEvents, active_hook_bus
+from autocontext.loop.runner_hooks import (
+    emit_generation_end,
+    emit_generation_failed,
+    emit_run_completed,
+    emit_run_failed,
+    emit_run_start,
+)
+from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
+from autocontext.storage import artifact_store_from_settings
+from autocontext.storage.sqlite_store import SQLiteStore
+
+logger = logging.getLogger(__name__)
+
+RoleRuntimeResolver = Callable[..., tuple[Any, str]]
+
+
+@dataclass(slots=True)
+class SolveExecutionSummary:
+    run_id: str
+    generations_executed: int
+    best_score: float
+
+
+@dataclass(slots=True)
+class _SolveHookSurface:
+    settings: AppSettings
+    hook_bus: HookBus
+    loaded_extensions: list[str]
+
+
+@dataclass(slots=True)
+class _SolveGenerationBudget:
+    scenario_name: str
+    budget_seconds: int
+    started_at: float = field(default_factory=lambda: time.monotonic())
+
+    def elapsed_seconds(self) -> float:
+        return max(0.0, time.monotonic() - self.started_at)
+
+    def remaining_seconds(self) -> float | None:
+        if self.budget_seconds <= 0:
+            return None
+        return max(0.0, float(self.budget_seconds) - self.elapsed_seconds())
+
+    def deadline(self) -> float | None:
+        if self.budget_seconds <= 0:
+            return None
+        return self.started_at + float(self.budget_seconds)
+
+    def check(self, phase: str) -> None:
+        if self.budget_seconds <= 0:
+            return
+        elapsed = self.elapsed_seconds()
+        if elapsed >= self.budget_seconds:
+            raise TimeoutError(
+                f"Solve generation time budget exceeded during {phase} "
+                f"after {elapsed:.2f}s for scenario '{self.scenario_name}' "
+                f"(budget {self.budget_seconds}s)"
+            )
+
+
+def _settings_for_budgeted_role_call(settings: AppSettings, budget: _SolveGenerationBudget, role: str) -> AppSettings:
+    effective_provider = configured_role_provider(role, settings) or settings.agent_provider
+    try:
+        role_settings, _ = settings_for_budgeted_role_call(
+            settings,
+            effective_provider,
+            role,
+            budget.deadline(),
+        )
+    except TimeoutError as exc:
+        raise TimeoutError(
+            f"Solve generation time budget exhausted before {role} provider call "
+            f"after {budget.elapsed_seconds():.2f}s for scenario '{budget.scenario_name}' "
+            f"(budget {budget.budget_seconds}s)"
+        ) from exc
+    return role_settings
+
+
+class _BudgetedAgentTask(AgentTaskInterface):
+    """Add solve generation budget checks around an AgentTaskInterface."""
+
+    def __init__(self, task: AgentTaskInterface, budget: _SolveGenerationBudget) -> None:
+        self._task = task
+        self._budget = budget
+        self.name = getattr(task, "name", task.__class__.__name__)
+
+    def get_task_prompt(self, state: dict) -> str:
+        self._budget.check("task prompt")
+        prompt = self._task.get_task_prompt(state)
+        self._budget.check("task prompt")
+        return prompt
+
+    def evaluate_output(
+        self,
+        output: str,
+        state: dict,
+        reference_context: str | None = None,
+        required_concepts: list[str] | None = None,
+        calibration_examples: list[dict] | None = None,
+        pinned_dimensions: list[str] | None = None,
+    ) -> AgentTaskResult:
+        self._budget.check("evaluation")
+        result = self._task.evaluate_output(
+            output,
+            state,
+            reference_context=reference_context,
+            required_concepts=required_concepts,
+            calibration_examples=calibration_examples,
+            pinned_dimensions=pinned_dimensions,
+        )
+        self._budget.check("evaluation")
+        return result
+
+    def get_rubric(self) -> str:
+        self._budget.check("rubric")
+        rubric = self._task.get_rubric()
+        self._budget.check("rubric")
+        return rubric
+
+    def initial_state(self, seed: int | None = None) -> dict:
+        self._budget.check("initial state")
+        state = self._task.initial_state(seed)
+        self._budget.check("initial state")
+        return state
+
+    def describe_task(self) -> str:
+        self._budget.check("task description")
+        description = self._task.describe_task()
+        self._budget.check("task description")
+        return description
+
+    def prepare_context(self, state: dict) -> dict:
+        self._budget.check("context preparation")
+        prepared = self._task.prepare_context(state)
+        self._budget.check("context preparation")
+        return prepared
+
+    def validate_context(self, state: dict) -> list[str]:
+        self._budget.check("context validation")
+        errors = self._task.validate_context(state)
+        self._budget.check("context validation")
+        return errors
+
+    def revise_output(
+        self,
+        output: str,
+        judge_result: AgentTaskResult,
+        state: dict,
+    ) -> str:
+        self._budget.check("revision")
+        revised = self._task.revise_output(output, judge_result, state)
+        self._budget.check("revision")
+        return revised
+
+    def verify_facts(self, output: str, state: dict) -> dict | None:
+        self._budget.check("fact verification")
+        result = self._task.verify_facts(output, state)
+        self._budget.check("fact verification")
+        return result
+
+
+def run_task_like_scenario(
+    *,
+    settings: AppSettings,
+    runtime_settings: AppSettings,
+    migrations_dir: Path,
+    scenario_name: str,
+    scenario_type: str,
+    task: AgentTaskInterface,
+    max_rounds: int,
+    hook_bus: HookBus,
+    loaded_extensions: list[str],
+    role_runtime_resolver: RoleRuntimeResolver,
+) -> SolveExecutionSummary:
+    sqlite = SQLiteStore(settings.db_path)
+    sqlite.migrate(migrations_dir)
+    active_run_id = f"solve_{scenario_name}_{uuid.uuid4().hex[:8]}"
+    sqlite.create_run(
+        active_run_id,
+        scenario_name,
+        1,
+        scenario_type,
+        agent_provider=settings.agent_provider,
+    )
+    sqlite.upsert_generation(
+        active_run_id,
+        1,
+        mean_score=0.0,
+        best_score=0.0,
+        elo=0.0,
+        wins=0,
+        losses=0,
+        gate_decision="running",
+        status="running",
+    )
+    budget = _SolveGenerationBudget(
+        scenario_name=scenario_name,
+        budget_seconds=settings.generation_time_budget_seconds,
+    )
+    hook_surface = _SolveHookSurface(settings=settings, hook_bus=hook_bus, loaded_extensions=loaded_extensions)
+    generation_started = False
+
+    try:
+        emit_run_start(hook_surface, run_id=active_run_id, scenario=scenario_name, target_generations=1)
+        generation_start = hook_bus.emit(
+            HookEvents.GENERATION_START,
+            {
+                "run_id": active_run_id,
+                "scenario": scenario_name,
+                "generation": 1,
+            },
+        )
+        generation_start.raise_if_blocked()
+        generation_started = True
+        budget.check("runtime resolution")
+        role_runtime_settings = _settings_for_budgeted_role_call(runtime_settings, budget, "competitor")
+        provider, provider_model = role_runtime_resolver(
+            role_runtime_settings,
+            role="competitor",
+            scenario_name=scenario_name,
+            sqlite=sqlite,
+            hook_bus=hook_bus,
+            generation_deadline=budget.deadline(),
+        )
+        budget.check("runtime resolution")
+        budgeted_task = _BudgetedAgentTask(task, budget)
+        state = budgeted_task.prepare_context(budgeted_task.initial_state())
+        context_errors = budgeted_task.validate_context(state)
+        if context_errors:
+            raise ValueError(f"Context validation failed: {'; '.join(context_errors)}")
+        prompt = budgeted_task.get_task_prompt(state)
+        with active_hook_bus(hook_bus):
+            initial_output = provider.complete(
+                system_prompt="Complete the task precisely.",
+                user_prompt=prompt,
+                model=provider_model,
+            ).text
+            budget.check("initial generation")
+            sqlite.append_agent_output(active_run_id, 1, "competitor_initial", initial_output)
+
+            loop = ImprovementLoop(task=budgeted_task, max_rounds=max_rounds)
+            result = loop.run(initial_output=initial_output, state=state)
+            budget.check("improvement loop")
+    except Exception as exc:
+        sqlite.upsert_generation(
+            active_run_id,
+            1,
+            mean_score=0.0,
+            best_score=0.0,
+            elo=0.0,
+            wins=0,
+            losses=0,
+            gate_decision="failed",
+            status="failed",
+            duration_seconds=budget.elapsed_seconds(),
+        )
+        sqlite.mark_run_failed(active_run_id)
+        if generation_started:
+            try:
+                emit_generation_failed(
+                    hook_surface,
+                    run_id=active_run_id,
+                    scenario=scenario_name,
+                    generation=1,
+                    error=str(exc),
+                )
+            except Exception:
+                logger.debug("GENERATION_END hook failed after solve generation failure", exc_info=True)
+        try:
+            emit_run_failed(
+                hook_surface,
+                run_id=active_run_id,
+                scenario=scenario_name,
+                completed_generations=0,
+                best_score=0.0,
+                elo=0.0,
+                error=str(exc),
+            )
+        except Exception:
+            logger.debug("RUN_END hook failed after solve run failure", exc_info=True)
+        raise
+
+    sqlite.append_agent_output(active_run_id, 1, "competitor", result.best_output)
+    sqlite.upsert_generation(
+        active_run_id,
+        1,
+        mean_score=result.best_score,
+        best_score=result.best_score,
+        elo=0.0,
+        wins=0,
+        losses=0,
+        gate_decision=result.termination_reason,
+        status="completed",
+        duration_seconds=(result.duration_ms / 1000.0) if result.duration_ms is not None else None,
+    )
+    sqlite.mark_run_completed(active_run_id)
+    if settings.cross_run_inheritance and not settings.ablation_no_feedback:
+        artifacts = artifact_store_from_settings(settings)
+        playbook_hash = artifacts.snapshot_knowledge(scenario_name, active_run_id)
+        sqlite.save_knowledge_snapshot(
+            scenario=scenario_name,
+            run_id=active_run_id,
+            best_score=result.best_score,
+            best_elo=1500.0,
+            playbook_hash=playbook_hash,
+            agent_provider=settings.agent_provider,
+            rlm_enabled=settings.rlm_enabled,
+            scoring_backend=settings.scoring_backend,
+        )
+    emit_generation_end(
+        hook_surface,
+        {
+            "run_id": active_run_id,
+            "scenario": scenario_name,
+            "generation": 1,
+            "status": "completed",
+            "elapsed_seconds": budget.elapsed_seconds(),
+            "gate_decision": result.termination_reason,
+            "best_score": result.best_score,
+            "elo": 1500.0,
+            "phased_execution": False,
+        },
+    )
+    emit_run_completed(
+        hook_surface,
+        run_id=active_run_id,
+        scenario=scenario_name,
+        completed_generations=1,
+        best_score=result.best_score,
+        elo=1500.0,
+        session_report_path=None,
+        dead_ends_found=0,
+        extra={"improvement_rounds": result.total_rounds},
+    )
+    return SolveExecutionSummary(
+        run_id=active_run_id,
+        generations_executed=result.total_rounds,
+        best_score=result.best_score,
+    )

--- a/autocontext/src/autocontext/knowledge/solver.py
+++ b/autocontext/src/autocontext/knowledge/solver.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 from autocontext.agents.types import LlmFn
 from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.config.settings import AppSettings
-from autocontext.execution.improvement_loop import ImprovementLoop
+from autocontext.extensions import HookBus, active_hook_bus, wrap_language_model_client
 from autocontext.knowledge.export import SkillPackage, export_skill_package
 from autocontext.knowledge.solve_agent_task_design import (
     _SOLVE_AGENT_TASK_DESIGN_MAX_CHARS,  # noqa: F401 - re-exported for existing tests/imports
@@ -25,6 +25,8 @@ from autocontext.knowledge.solve_agent_task_design import (
     _build_solve_description_brief,
     _solve_task_spec_needs_compact_retry,
 )
+from autocontext.knowledge.solve_task_execution import SolveExecutionSummary, run_task_like_scenario
+from autocontext.loop.runner_hooks import initialize_hook_bus
 from autocontext.mcp.tools import MtsToolContext
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
@@ -33,8 +35,6 @@ from autocontext.scenarios.custom.classifier_cache import (
     ClassifierCache,
     default_classifier_cache_path,
 )
-from autocontext.storage import artifact_store_from_settings
-from autocontext.storage.sqlite_store import SQLiteStore
 
 if TYPE_CHECKING:
     from autocontext.scenarios.families import ScenarioFamily
@@ -66,6 +66,7 @@ class SolveJob:
     job_id: str
     description: str
     scenario_name: str | None = None
+    family_name: str | None = None
     status: str = "pending"
     generations: int = 5
     progress: int = 0
@@ -87,13 +88,6 @@ class SolveScenarioBuildResult:
 class _ResolvedSolveFamily:
     family: ScenarioFamily
     llm_classifier_fallback_used: bool = False
-
-
-@dataclass(slots=True)
-class SolveExecutionSummary:
-    run_id: str
-    generations_executed: int
-    best_score: float
 
 
 class ArtifactEditingTaskAdapter(AgentTaskInterface):
@@ -196,110 +190,6 @@ class ArtifactEditingTaskAdapter(AgentTaskInterface):
         return list(edited_by_path.values())
 
 
-@dataclass(slots=True)
-class _SolveGenerationBudget:
-    scenario_name: str
-    budget_seconds: int
-    started_at: float = field(default_factory=lambda: time.monotonic())
-
-    def elapsed_seconds(self) -> float:
-        return max(0.0, time.monotonic() - self.started_at)
-
-    def check(self, phase: str) -> None:
-        if self.budget_seconds <= 0:
-            return
-        elapsed = self.elapsed_seconds()
-        if elapsed >= self.budget_seconds:
-            raise TimeoutError(
-                f"Solve generation time budget exceeded during {phase} "
-                f"after {elapsed:.2f}s for scenario '{self.scenario_name}' "
-                f"(budget {self.budget_seconds}s)"
-            )
-
-
-class _BudgetedAgentTask(AgentTaskInterface):
-    """Add solve generation budget checks around an AgentTaskInterface."""
-
-    def __init__(self, task: AgentTaskInterface, budget: _SolveGenerationBudget) -> None:
-        self._task = task
-        self._budget = budget
-        self.name = getattr(task, "name", task.__class__.__name__)
-
-    def get_task_prompt(self, state: dict) -> str:
-        self._budget.check("task prompt")
-        prompt = self._task.get_task_prompt(state)
-        self._budget.check("task prompt")
-        return prompt
-
-    def evaluate_output(
-        self,
-        output: str,
-        state: dict,
-        reference_context: str | None = None,
-        required_concepts: list[str] | None = None,
-        calibration_examples: list[dict] | None = None,
-        pinned_dimensions: list[str] | None = None,
-    ) -> AgentTaskResult:
-        self._budget.check("evaluation")
-        result = self._task.evaluate_output(
-            output,
-            state,
-            reference_context=reference_context,
-            required_concepts=required_concepts,
-            calibration_examples=calibration_examples,
-            pinned_dimensions=pinned_dimensions,
-        )
-        self._budget.check("evaluation")
-        return result
-
-    def get_rubric(self) -> str:
-        self._budget.check("rubric")
-        rubric = self._task.get_rubric()
-        self._budget.check("rubric")
-        return rubric
-
-    def initial_state(self, seed: int | None = None) -> dict:
-        self._budget.check("initial state")
-        state = self._task.initial_state(seed)
-        self._budget.check("initial state")
-        return state
-
-    def describe_task(self) -> str:
-        self._budget.check("task description")
-        description = self._task.describe_task()
-        self._budget.check("task description")
-        return description
-
-    def prepare_context(self, state: dict) -> dict:
-        self._budget.check("context preparation")
-        prepared = self._task.prepare_context(state)
-        self._budget.check("context preparation")
-        return prepared
-
-    def validate_context(self, state: dict) -> list[str]:
-        self._budget.check("context validation")
-        errors = self._task.validate_context(state)
-        self._budget.check("context validation")
-        return errors
-
-    def revise_output(
-        self,
-        output: str,
-        judge_result: AgentTaskResult,
-        state: dict,
-    ) -> str:
-        self._budget.check("revision")
-        revised = self._task.revise_output(output, judge_result, state)
-        self._budget.check("revision")
-        return revised
-
-    def verify_facts(self, output: str, state: dict) -> dict | None:
-        self._budget.check("fact verification")
-        result = self._task.verify_facts(output, state)
-        self._budget.check("fact verification")
-        return result
-
-
 def _normalize_family_hint_token(token: str) -> str:
     normalized = re.sub(r"[^a-z0-9_\-\s]", " ", token.lower()).strip()
     return normalized.replace("-", "_").replace(" ", "_")
@@ -378,9 +268,21 @@ def _resolve_requested_scenario_family_with_metadata(
 class SolveScenarioExecutor:
     """Execute created solve scenarios through the correct family-aware runtime surface."""
 
-    def __init__(self, settings: AppSettings, *, migrations_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        settings: AppSettings,
+        *,
+        migrations_dir: Path | None = None,
+        hook_bus: HookBus | None = None,
+        loaded_extensions: list[str] | None = None,
+    ) -> None:
         self._settings = settings
         self._migrations_dir = migrations_dir or Path(__file__).resolve().parents[2] / "migrations"
+        if hook_bus is None:
+            self._hook_bus, self._loaded_extensions = initialize_hook_bus(settings)
+        else:
+            self._hook_bus = hook_bus
+            self._loaded_extensions = list(loaded_extensions or [])
 
     def execute(
         self,
@@ -412,7 +314,11 @@ class SolveScenarioExecutor:
 
         from autocontext.loop.generation_runner import GenerationRunner
 
-        runner = GenerationRunner(_settings_for_solve_runtime(self._settings))
+        runner = GenerationRunner(
+            _settings_for_solve_runtime(self._settings, respect_generation_budget=True),
+            hook_bus=self._hook_bus,
+            loaded_extensions=self._loaded_extensions,
+        )
         runner.migrate(self._migrations_dir)
         run_id = f"solve_{scenario_name}_{uuid.uuid4().hex[:8]}"
         summary = runner.run(scenario_name, generations, run_id)
@@ -444,104 +350,17 @@ class SolveScenarioExecutor:
         task: AgentTaskInterface,
         max_rounds: int,
     ) -> SolveExecutionSummary:
-        sqlite = SQLiteStore(self._settings.db_path)
-        sqlite.migrate(self._migrations_dir)
-        active_run_id = f"solve_{scenario_name}_{uuid.uuid4().hex[:8]}"
-        sqlite.create_run(
-            active_run_id,
-            scenario_name,
-            1,
-            scenario_type,
-            agent_provider=self._settings.agent_provider,
-        )
-        sqlite.upsert_generation(
-            active_run_id,
-            1,
-            mean_score=0.0,
-            best_score=0.0,
-            elo=0.0,
-            wins=0,
-            losses=0,
-            gate_decision="running",
-            status="running",
-        )
-        budget = _SolveGenerationBudget(
+        return run_task_like_scenario(
+            settings=self._settings,
+            runtime_settings=_settings_for_solve_runtime(self._settings, respect_generation_budget=True),
+            migrations_dir=self._migrations_dir,
             scenario_name=scenario_name,
-            budget_seconds=self._settings.generation_time_budget_seconds,
-        )
-
-        try:
-            provider, provider_model = resolve_role_runtime(
-                _settings_for_solve_runtime(self._settings),
-                role="competitor",
-                scenario_name=scenario_name,
-                sqlite=sqlite,
-            )
-            budget.check("runtime resolution")
-            budgeted_task = _BudgetedAgentTask(task, budget)
-            state = budgeted_task.prepare_context(budgeted_task.initial_state())
-            context_errors = budgeted_task.validate_context(state)
-            if context_errors:
-                raise ValueError(f"Context validation failed: {'; '.join(context_errors)}")
-            prompt = budgeted_task.get_task_prompt(state)
-            initial_output = provider.complete(
-                system_prompt="Complete the task precisely.",
-                user_prompt=prompt,
-                model=provider_model,
-            ).text
-            budget.check("initial generation")
-            sqlite.append_agent_output(active_run_id, 1, "competitor_initial", initial_output)
-
-            loop = ImprovementLoop(task=budgeted_task, max_rounds=max_rounds)
-            result = loop.run(initial_output=initial_output, state=state)
-            budget.check("improvement loop")
-        except Exception:
-            sqlite.upsert_generation(
-                active_run_id,
-                1,
-                mean_score=0.0,
-                best_score=0.0,
-                elo=0.0,
-                wins=0,
-                losses=0,
-                gate_decision="failed",
-                status="failed",
-                duration_seconds=budget.elapsed_seconds(),
-            )
-            sqlite.mark_run_failed(active_run_id)
-            raise
-
-        sqlite.append_agent_output(active_run_id, 1, "competitor", result.best_output)
-        sqlite.upsert_generation(
-            active_run_id,
-            1,
-            mean_score=result.best_score,
-            best_score=result.best_score,
-            elo=0.0,
-            wins=0,
-            losses=0,
-            gate_decision=result.termination_reason,
-            status="completed",
-            duration_seconds=(result.duration_ms / 1000.0) if result.duration_ms is not None else None,
-        )
-        sqlite.mark_run_completed(active_run_id)
-        if self._settings.cross_run_inheritance and not self._settings.ablation_no_feedback:
-            artifacts = artifact_store_from_settings(self._settings)
-            playbook_hash = artifacts.snapshot_knowledge(scenario_name, active_run_id)
-            sqlite.save_knowledge_snapshot(
-                scenario=scenario_name,
-                run_id=active_run_id,
-                best_score=result.best_score,
-                best_elo=1500.0,
-                playbook_hash=playbook_hash,
-                agent_provider=self._settings.agent_provider,
-                rlm_enabled=self._settings.rlm_enabled,
-                scoring_backend=self._settings.scoring_backend,
-            )
-        return SolveExecutionSummary(
-            run_id=active_run_id,
-            generations_executed=result.total_rounds,
-            best_score=result.best_score,
+            scenario_type=scenario_type,
+            task=task,
+            max_rounds=max_rounds,
+            hook_bus=self._hook_bus,
+            loaded_extensions=self._loaded_extensions,
+            role_runtime_resolver=resolve_role_runtime,
         )
 
 
@@ -638,10 +457,21 @@ def _llm_fn_from_client(client: Any, model: str) -> LlmFn:
 class SolveManager:
     """Manage solve-on-demand jobs: create scenario -> run generations -> export skill."""
 
-    def __init__(self, settings: AppSettings) -> None:
+    def __init__(
+        self,
+        settings: AppSettings,
+        *,
+        hook_bus: HookBus | None = None,
+        loaded_extensions: list[str] | None = None,
+    ) -> None:
         self._jobs: dict[str, SolveJob] = {}
         self._settings = settings
         self._migrations_dir = Path(__file__).resolve().parents[2] / "migrations"
+        if hook_bus is None:
+            self.hook_bus, self.loaded_extensions = initialize_hook_bus(settings)
+        else:
+            self.hook_bus = hook_bus
+            self.loaded_extensions = list(loaded_extensions or [])
 
     def submit(self, description: str, generations: int = 5) -> str:
         """Create a solve job and run it in a background thread. Returns job_id."""
@@ -681,32 +511,39 @@ class SolveManager:
     def _run_job(self, job: SolveJob) -> None:
         """Background: create scenario -> run generations -> export skill package."""
         try:
-            # 1. Create scenario
-            job.status = "creating_scenario"
-            builder = self._build_creator()
-            if builder is None:
-                job.status = "failed"
-                job.error = "Scenario creation pipeline unavailable (no API key or unsupported provider)"
-                return
+            with active_hook_bus(self.hook_bus):
+                # 1. Create scenario
+                job.status = "creating_scenario"
+                builder = self._build_creator()
+                if builder is None:
+                    job.status = "failed"
+                    job.error = "Scenario creation pipeline unavailable (no API key or unsupported provider)"
+                    return
 
-            created = builder.build(job.description, family_override=job.family_override)
-            job.scenario_name = created.scenario_name
-            job.llm_classifier_fallback_used = created.llm_classifier_fallback_used
+                created = builder.build(job.description, family_override=job.family_override)
+                job.scenario_name = created.scenario_name
+                job.family_name = created.family_name
+                job.llm_classifier_fallback_used = created.llm_classifier_fallback_used
 
-            # 2. Run generations
-            job.status = "running"
-            executor = SolveScenarioExecutor(self._settings, migrations_dir=self._migrations_dir)
-            summary = executor.execute(
-                scenario_name=created.scenario_name,
-                family_name=created.family_name,
-                generations=job.generations,
-            )
-            job.progress = summary.generations_executed
+                # 2. Run generations
+                job.status = "running"
+                executor = SolveScenarioExecutor(
+                    self._settings,
+                    migrations_dir=self._migrations_dir,
+                    hook_bus=self.hook_bus,
+                    loaded_extensions=self.loaded_extensions,
+                )
+                summary = executor.execute(
+                    scenario_name=created.scenario_name,
+                    family_name=created.family_name,
+                    generations=job.generations,
+                )
+                job.progress = summary.generations_executed
 
-            # 3. Export skill package
-            ctx = MtsToolContext(self._settings)
-            job.result = export_skill_package(ctx, created.scenario_name)
-            job.status = "completed"
+                # 3. Export skill package
+                ctx = MtsToolContext(self._settings)
+                job.result = export_skill_package(ctx, created.scenario_name)
+                job.status = "completed"
 
         except Exception as exc:
             logger.exception("Solve job %s failed", job.job_id)
@@ -720,7 +557,11 @@ class SolveManager:
             from autocontext.agents.subagent_runtime import SubagentRuntime
 
             creator_settings = _settings_for_solve_runtime(self._settings)
-            client = build_client_from_settings(creator_settings)
+            client = wrap_language_model_client(
+                build_client_from_settings(creator_settings),
+                self.hook_bus,
+                provider_name="solve:scenario_designer",
+            )
             runtime = SubagentRuntime(client)
             designer_model = self._settings.model_translator or self._settings.model_architect
             llm_fn = _llm_fn_from_client(client, designer_model)
@@ -744,6 +585,7 @@ class SolveManager:
             "status": job.status,
             "description": job.description,
             "scenario_name": job.scenario_name,
+            "family_name": job.family_name,
             "generations": job.generations,
             "progress": job.progress,
             "error": job.error,
@@ -759,9 +601,18 @@ class SolveManager:
         return job.result
 
 
-def _settings_for_solve_runtime(settings: AppSettings) -> AppSettings:
+def _settings_for_solve_runtime(
+    settings: AppSettings,
+    *,
+    respect_generation_budget: bool = False,
+) -> AppSettings:
     if settings.agent_provider not in {"pi", "pi-rpc"}:
         return settings
+    if respect_generation_budget and settings.generation_time_budget_seconds > 0:
+        bounded_timeout = min(float(settings.pi_timeout), float(settings.generation_time_budget_seconds))
+        if bounded_timeout == float(settings.pi_timeout):
+            return settings
+        return settings.model_copy(update={"pi_timeout": bounded_timeout})
     if float(settings.pi_timeout) >= _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS:
         return settings
     return settings.model_copy(update={"pi_timeout": _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS})

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -41,6 +41,7 @@ from autocontext.analytics.trace_reporter import ReportStore, TraceReporter
 from autocontext.config import AppSettings
 from autocontext.execution import ExecutionSupervisor
 from autocontext.execution.executors import LocalExecutor, PrimeIntellectExecutor
+from autocontext.extensions import HookBus
 from autocontext.harness.meta_optimizer import MetaOptimizer
 from autocontext.harness.pipeline.gate import BackpressureGate
 from autocontext.harness.pipeline.trend_gate import TrendAwareGate
@@ -85,9 +86,19 @@ class RunSummary:
 
 
 class GenerationRunner:
-    def __init__(self, settings: AppSettings) -> None:
+    def __init__(
+        self,
+        settings: AppSettings,
+        *,
+        hook_bus: HookBus | None = None,
+        loaded_extensions: list[str] | None = None,
+    ) -> None:
         self.settings = settings
-        self.hook_bus, self.loaded_extensions = initialize_hook_bus(settings)
+        if hook_bus is None:
+            self.hook_bus, self.loaded_extensions = initialize_hook_bus(settings)
+        else:
+            self.hook_bus = hook_bus
+            self.loaded_extensions = list(loaded_extensions or [])
         self.sqlite = SQLiteStore(settings.db_path)
         self.trajectory_builder = ScoreTrajectoryBuilder(self.sqlite)
         self.artifacts = artifact_store_from_settings(settings, enable_buffered_writes=True, hook_bus=self.hook_bus)

--- a/autocontext/src/autocontext/loop/runner_hooks.py
+++ b/autocontext/src/autocontext/loop/runner_hooks.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from autocontext.config import AppSettings
 from autocontext.extensions import HookBus, HookEvents, load_extensions
 
+logger = logging.getLogger(__name__)
+
 
 def initialize_hook_bus(settings: AppSettings) -> tuple[HookBus, list[str]]:
     hook_bus = HookBus(fail_fast=settings.extension_fail_fast)
     loaded_extensions = load_extensions(settings.extensions, hook_bus) if settings.extensions else []
+    if loaded_extensions:
+        logger.info("loaded autocontext extension(s): %s", ", ".join(loaded_extensions))
     return hook_bus, loaded_extensions
 
 
@@ -98,17 +103,21 @@ def emit_run_completed(
     elo: float,
     session_report_path: str | None,
     dead_ends_found: int,
+    extra: dict[str, Any] | None = None,
 ) -> None:
+    payload = {
+        "run_id": run_id,
+        "scenario": scenario,
+        "status": "completed",
+        "completed_generations": completed_generations,
+        "best_score": best_score,
+        "elo": elo,
+        "session_report_path": session_report_path,
+        "dead_ends_found": dead_ends_found,
+    }
+    if extra:
+        payload.update(extra)
     emit_run_end(
         runner,
-        {
-            "run_id": run_id,
-            "scenario": scenario,
-            "status": "completed",
-            "completed_generations": completed_generations,
-            "best_score": best_score,
-            "elo": elo,
-            "session_report_path": session_report_path,
-            "dead_ends_found": dead_ends_found,
-        },
+        payload,
     )

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -468,6 +468,12 @@ def stage_agent_generation(
             "run_id": ctx.run_id, "generation": ctx.generation, "roles": roles,
         })
 
+    generation_started_at = ctx.generation_start_time or time.monotonic()
+    generation_deadline = (
+        generation_started_at + ctx.settings.generation_time_budget_seconds
+        if ctx.settings.generation_time_budget_seconds > 0
+        else None
+    )
     outputs = orchestrator.run_generation(
         ctx.prompts,
         generation_index=ctx.generation,
@@ -478,6 +484,7 @@ def stage_agent_generation(
         on_role_event=on_role_event,
         scenario_rules=ctx.scenario.describe_rules(),
         current_strategy=ctx.current_strategy or None,
+        generation_deadline=generation_deadline,
     )
 
     selected_strategy = outputs.strategy

--- a/autocontext/tests/test_cli_investigate.py
+++ b/autocontext/tests/test_cli_investigate.py
@@ -112,6 +112,7 @@ class TestInvestigateCli:
         assert "--description" in help_text
         assert "--hypotheses" in help_text
         assert "--browser-url" in help_text
+        assert "--mode" in help_text
 
     def test_json_success(self, tmp_path: Path) -> None:
         settings = _make_settings(tmp_path)
@@ -183,3 +184,47 @@ class TestInvestigateCli:
         assert result.exit_code == 0, result.output
         assert _CapturingInvestigationEngine.captured_request is not None
         assert _CapturingInvestigationEngine.captured_request.browser_context == browser_context
+
+    def test_mode_is_forwarded_to_investigation_request(self, tmp_path: Path) -> None:
+        settings = _make_settings(tmp_path)
+        _CapturingInvestigationEngine.captured_request = None
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._resolve_investigation_runtime", return_value=(object(), "mock-model")),
+            patch("autocontext.investigation.engine.InvestigationEngine", _CapturingInvestigationEngine),
+        ):
+            result = runner.invoke(
+                app,
+                ["investigate", "-d", "why did checkout fail", "--mode", "iterative", "--json"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert _CapturingInvestigationEngine.captured_request is not None
+        assert _CapturingInvestigationEngine.captured_request.mode == "iterative"
+
+    def test_iterative_mode_does_not_resolve_architect_runtime(self, tmp_path: Path) -> None:
+        settings = _make_settings(tmp_path)
+        resolved_roles: list[str] = []
+        _CapturingInvestigationEngine.captured_request = None
+
+        def _resolve_runtime(_settings, *, role: str):  # noqa: ANN001, ANN202
+            resolved_roles.append(role)
+            if role == "architect":
+                raise AssertionError("iterative mode should not resolve the architect runtime")
+            return object(), "mock-model"
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._resolve_investigation_runtime", side_effect=_resolve_runtime),
+            patch("autocontext.investigation.engine.InvestigationEngine", _CapturingInvestigationEngine),
+        ):
+            result = runner.invoke(
+                app,
+                ["investigate", "-d", "why did checkout fail", "--mode", "iterative", "--json"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert resolved_roles == ["analyst"]
+        assert _CapturingInvestigationEngine.captured_request is not None
+        assert _CapturingInvestigationEngine.captured_request.mode == "iterative"

--- a/autocontext/tests/test_cli_json.py
+++ b/autocontext/tests/test_cli_json.py
@@ -421,6 +421,7 @@ class TestSolveJson:
             job_id="solve_1234",
             description="Design a strategy",
             scenario_name="grid_ctf",
+            family_name="game",
             status="completed",
             generations=2,
             progress=2,
@@ -438,6 +439,7 @@ class TestSolveJson:
         assert data["job_id"] == "solve_1234"
         assert data["status"] == "completed"
         assert data["scenario_name"] == "grid_ctf"
+        assert data["family_name"] == "game"
         assert data["generations"] == 2
         assert data["progress"] == 2
         assert data["result"]["scenario_name"] == "grid_ctf"
@@ -463,6 +465,7 @@ class TestSolveJson:
             job_id="solve_5678",
             description="Design a strategy",
             scenario_name="grid_ctf",
+            family_name="game",
             status="completed",
             generations=3,
             progress=3,

--- a/autocontext/tests/test_cli_solve_runtime.py
+++ b/autocontext/tests/test_cli_solve_runtime.py
@@ -41,6 +41,7 @@ class _CapturingSolveManager:
             job_id="solve_1234",
             description="Design a strategy",
             scenario_name="grid_ctf",
+            family_name="game",
             status="completed",
             generations=1,
             progress=1,
@@ -95,6 +96,7 @@ class _FallbackSolveManager:
             job_id="solve_fallback",
             description="Fallback solve",
             scenario_name="fallback_case",
+            family_name="simulation",
             status="completed",
             generations=1,
             progress=1,
@@ -220,3 +222,4 @@ class TestSolveRuntimeOverrides:
         payload = json.loads(result.stdout)
         assert payload["llm_classifier_fallback_used"] is True
         assert payload["scenario_name"] == "fallback_case"
+        assert payload["family_name"] == "simulation"

--- a/autocontext/tests/test_investigation_engine.py
+++ b/autocontext/tests/test_investigation_engine.py
@@ -60,6 +60,149 @@ def _hypothesis_response() -> str:
 
 
 class TestInvestigationEngine:
+    def test_iterative_mode_runs_multi_step_llm_session_without_synthetic_scenario(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
+
+        calls: list[tuple[str, str]] = []
+
+        def analysis_llm(system: str, user: str) -> str:
+            calls.append((system, user))
+            return json.dumps(
+                {
+                    "question": "What caused checkout errors?",
+                    "hypotheses": [
+                        {
+                            "statement": "A config regression caused checkout errors",
+                            "confidence": 0.78,
+                            "status": "supported",
+                        }
+                    ],
+                    "evidence": [
+                        {
+                            "id": f"e{len(calls)}",
+                            "kind": "observation",
+                            "source": "iterative_session",
+                            "summary": "Deployment evidence points at a config regression",
+                            "supports": ["h0"],
+                            "contradicts": [],
+                            "is_red_herring": False,
+                        }
+                    ],
+                    "conclusion": {
+                        "best_explanation": "A config regression caused checkout errors",
+                        "confidence": 0.78,
+                        "limitations": [],
+                    },
+                    "unknowns": [],
+                    "recommended_next_steps": ["Inspect config diff"],
+                }
+            )
+
+        engine = InvestigationEngine(
+            spec_llm_fn=lambda *_: "synthetic path should not run",
+            analysis_llm_fn=analysis_llm,
+            knowledge_root=tmp_path,
+        )
+
+        result = engine.run(
+            InvestigationRequest(
+                description="Investigate checkout errors",
+                max_steps=3,
+                mode="iterative",
+            )
+        )
+
+        investigation_dir = tmp_path / "_investigations" / result.name
+        assert result.status == "completed"
+        assert result.steps_executed == 3
+        assert len(calls) == 3
+        assert result.evidence[0].source == "iterative_session"
+        assert (investigation_dir / "report.json").exists()
+        assert (investigation_dir / "transcript.json").exists()
+        assert not (investigation_dir / "scenario.py").exists()
+
+    def test_iterative_mode_records_compaction_ledger_and_events_under_context_pressure(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
+        from autocontext.loop.events import EventStreamEmitter
+        from autocontext.storage import ArtifactStore
+
+        long_signal = "root cause signal from deployment metadata " * 700
+
+        def analysis_llm(_system: str, _user: str) -> str:
+            return json.dumps(
+                {
+                    "question": "What caused checkout errors?",
+                    "hypotheses": [
+                        {
+                            "statement": "A config regression caused checkout errors",
+                            "confidence": 0.83,
+                            "status": "supported",
+                        }
+                    ],
+                    "evidence": [
+                        {
+                            "id": "e0",
+                            "kind": "observation",
+                            "source": "iterative_session",
+                            "summary": long_signal,
+                            "supports": ["h0"],
+                        }
+                    ],
+                    "conclusion": {
+                        "best_explanation": long_signal,
+                        "confidence": 0.83,
+                    },
+                }
+            )
+
+        artifacts = ArtifactStore(
+            runs_root=tmp_path / "runs",
+            knowledge_root=tmp_path / "knowledge",
+            skills_root=tmp_path / "skills",
+            claude_skills_path=tmp_path / ".claude" / "skills",
+        )
+        events_path = tmp_path / "runs" / "events.ndjson"
+        engine = InvestigationEngine(
+            spec_llm_fn=lambda *_: "synthetic path should not run",
+            analysis_llm_fn=analysis_llm,
+            knowledge_root=tmp_path / "knowledge",
+            artifacts=artifacts,
+            events=EventStreamEmitter(events_path),
+            context_budget_tokens=64,
+        )
+
+        result = engine.run(
+            InvestigationRequest(
+                description="Investigate checkout errors",
+                max_steps=2,
+                mode="iterative",
+            )
+        )
+
+        ledger_path = tmp_path / "runs" / result.id / "compactions.jsonl"
+        latest_path = tmp_path / "runs" / result.id / "compactions.latest"
+        assert result.status == "completed"
+        assert ledger_path.exists()
+        assert latest_path.exists()
+
+        event_rows = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines()]
+        event_names = [row["event"] for row in event_rows]
+        ledger_entries = [json.loads(line) for line in ledger_path.read_text(encoding="utf-8").splitlines()]
+
+        assert latest_path.read_text(encoding="utf-8").strip()
+        assert ledger_entries[0]["details"]["trigger"] == "context_pressure"
+        assert ledger_entries[0]["details"]["run_id"] == result.id
+        assert "investigation_started" in event_names
+        assert "investigation_step_completed" in event_names
+        assert "investigation_completed" in event_names
+        assert all(row["payload"].get("run_id") == result.id for row in event_rows)
+
     def test_runs_from_plain_language_description(self, tmp_path: Path) -> None:
         from autocontext.investigation.engine import InvestigationEngine, InvestigationRequest
 

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -73,8 +74,15 @@ class _StubProvider:
     def __init__(self, text: str) -> None:
         self._text = text
 
-    def complete(self, system_prompt: str, user_prompt: str, model: str = "") -> _StubProviderResponse:
-        del system_prompt, user_prompt, model
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = "",
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+    ) -> _StubProviderResponse:
+        del system_prompt, user_prompt, model, temperature, max_tokens
         return _StubProviderResponse(self._text)
 
     def default_model(self) -> str:
@@ -106,6 +114,37 @@ class _SolveAgentTask(AgentTaskInterface):
 
     def describe_task(self) -> str:
         return "Return the expected draft text."
+
+
+class _RevisingSolveAgentTask(AgentTaskInterface):
+    name = "solve_revising_agent_task_fixture"
+
+    def get_task_prompt(self, state: dict) -> str:
+        del state
+        return "Return the final answer."
+
+    def evaluate_output(self, output: str, state: dict, **kwargs: object) -> AgentTaskResult:
+        del state, kwargs
+        score = 1.0 if output.strip() == "final answer" else 0.2
+        return AgentTaskResult(
+            score=score,
+            reasoning="final answer found" if score == 1.0 else "needs revision",
+            dimension_scores={"quality": score},
+        )
+
+    def get_rubric(self) -> str:
+        return "Score exact_match 0-1."
+
+    def initial_state(self, seed: int | None = None) -> dict:
+        del seed
+        return {}
+
+    def describe_task(self) -> str:
+        return "Revise toward the final answer."
+
+    def revise_output(self, output: str, judge_result: AgentTaskResult, state: dict) -> str:
+        del output, judge_result, state
+        return "final answer"
 
 
 class _SolveArtifactEditing(ArtifactEditingInterface):
@@ -871,6 +910,101 @@ class TestSolveLLMFn:
         assert summary.best_score == 1.0
         assert captured["pi_timeout"] == _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS
 
+    def test_task_like_executor_bounds_pi_timeout_by_generation_budget(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solver import SolveScenarioExecutor
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+            agent_provider="pi",
+            pi_timeout=900.0,
+            generation_time_budget_seconds=420,
+        )
+        scenario_name = "solve_runtime_generation_budget"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        SCENARIO_REGISTRY[scenario_name] = _SolveAgentTask
+        provider = _StubProvider("improved draft")
+        captured: dict[str, float] = {}
+
+        def _fake_resolve_role_runtime(settings: AppSettings, **kwargs: object) -> tuple[_StubProvider, str]:
+            del kwargs
+            captured["pi_timeout"] = float(settings.pi_timeout)
+            return provider, "test-model"
+
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.resolve_role_runtime",
+            _fake_resolve_role_runtime,
+        )
+
+        try:
+            summary = SolveScenarioExecutor(settings).execute(
+                scenario_name=scenario_name,
+                family_name="agent_task",
+                generations=1,
+            )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        assert summary.best_score == 1.0
+        assert captured["pi_timeout"] <= 420.0
+
+    def test_task_like_executor_bounds_per_role_pi_override_by_generation_budget(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solver import SolveScenarioExecutor
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+            agent_provider="deterministic",
+            competitor_provider="pi-rpc",
+            pi_timeout=900.0,
+            pi_rpc_persistent=True,
+            generation_time_budget_seconds=420,
+        )
+        scenario_name = "solve_runtime_role_override_budget"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        SCENARIO_REGISTRY[scenario_name] = _SolveAgentTask
+        provider = _StubProvider("improved draft")
+        captured: dict[str, object] = {}
+
+        def _fake_resolve_role_runtime(settings: AppSettings, **kwargs: object) -> tuple[_StubProvider, str]:
+            captured["pi_timeout"] = float(settings.pi_timeout)
+            captured["pi_rpc_persistent"] = settings.pi_rpc_persistent
+            captured["generation_deadline"] = kwargs.get("generation_deadline")
+            return provider, "test-model"
+
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.resolve_role_runtime",
+            _fake_resolve_role_runtime,
+        )
+
+        try:
+            summary = SolveScenarioExecutor(settings).execute(
+                scenario_name=scenario_name,
+                family_name="agent_task",
+                generations=1,
+            )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        assert summary.best_score == 1.0
+        assert captured["pi_timeout"] <= 420.0
+        assert captured["pi_rpc_persistent"] is False
+        assert isinstance(captured["generation_deadline"], float)
+
     def test_generation_runner_executor_raises_pi_timeout_floor_for_solve_runtime(
         self,
         tmp_path: Path,
@@ -895,7 +1029,8 @@ class TestSolveLLMFn:
             name = scenario_name
 
         class _FakeGenerationRunner:
-            def __init__(self, settings: AppSettings) -> None:
+            def __init__(self, settings: AppSettings, **kwargs: object) -> None:
+                del kwargs
                 captured["pi_timeout"] = float(settings.pi_timeout)
 
             def migrate(self, migrations_dir: Path) -> None:
@@ -930,6 +1065,64 @@ class TestSolveLLMFn:
         assert summary.best_score == 0.73
         assert summary.generations_executed == 2
         assert captured["pi_timeout"] == _SOLVE_CREATOR_PI_TIMEOUT_FLOOR_SECONDS
+
+    def test_generation_runner_executor_bounds_pi_timeout_by_generation_budget(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.knowledge.solver import SolveScenarioExecutor
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+            agent_provider="pi",
+            pi_timeout=900.0,
+            generation_time_budget_seconds=420,
+        )
+        scenario_name = "solve_generation_runner_budget"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        captured: dict[str, float] = {}
+
+        class _Scenario:
+            name = scenario_name
+
+        class _FakeGenerationRunner:
+            def __init__(self, settings: AppSettings, **kwargs: object) -> None:
+                del kwargs
+                captured["pi_timeout"] = float(settings.pi_timeout)
+
+            def migrate(self, migrations_dir: Path) -> None:
+                del migrations_dir
+
+            def run(self, scenario_name: str, generations: int, run_id: str) -> SimpleNamespace:
+                return SimpleNamespace(
+                    run_id=run_id,
+                    generations_executed=generations,
+                    best_score=0.73,
+                    scenario_name=scenario_name,
+                )
+
+        SCENARIO_REGISTRY[scenario_name] = _Scenario
+        monkeypatch.setattr(
+            "autocontext.loop.generation_runner.GenerationRunner",
+            _FakeGenerationRunner,
+        )
+
+        try:
+            summary = SolveScenarioExecutor(settings).execute(
+                scenario_name=scenario_name,
+                family_name="schema_evolution",
+                generations=2,
+            )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        assert summary.best_score == 0.73
+        assert captured["pi_timeout"] == 420.0
 
 
 class TestSolveScenarioExecutor:
@@ -970,6 +1163,47 @@ class TestSolveScenarioExecutor:
         assert package.best_score == 1.0
         assert package.metadata["has_snapshot"] is True
         assert sqlite.count_completed_runs(scenario_name) == 1
+
+    def test_task_like_run_end_reports_generation_count_not_improvement_rounds(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.extensions import HookBus, HookEvents
+        from autocontext.knowledge.solver import SolveScenarioExecutor
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+        )
+        scenario_name = "solve_agent_task_run_end_rounds"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        SCENARIO_REGISTRY[scenario_name] = _RevisingSolveAgentTask
+        hook_bus = HookBus()
+        run_end_payloads: list[dict[str, object]] = []
+        hook_bus.on(HookEvents.RUN_END, lambda event: run_end_payloads.append(dict(event.payload)))
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.resolve_role_runtime",
+            lambda settings, **kwargs: (_StubProvider("draft"), "test-model"),
+        )
+
+        try:
+            executor = SolveScenarioExecutor(settings, hook_bus=hook_bus)
+            summary = executor.execute(
+                scenario_name=scenario_name,
+                family_name="agent_task",
+                generations=3,
+            )
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        assert summary.best_score == 1.0
+        assert run_end_payloads
+        assert run_end_payloads[-1]["completed_generations"] == 1
+        assert run_end_payloads[-1]["improvement_rounds"] == 2
 
     def test_artifact_editing_adapter_preserves_omitted_artifact_deletions(self) -> None:
         from autocontext.knowledge.solver import ArtifactEditingTaskAdapter
@@ -1090,6 +1324,122 @@ class TestSolveScenarioExecutor:
 
 
 class TestSolveManager:
+    def test_solve_sync_loads_extensions_and_emits_task_lifecycle_hooks(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from autocontext.extensions import wrap_llm_provider
+        from autocontext.knowledge.export import SkillPackage
+        from autocontext.knowledge.solver import (
+            SolveManager,
+            SolveScenarioBuildResult,
+        )
+
+        events_path = tmp_path / "solve-hooks.jsonl"
+        extension_path = tmp_path / "solve_extension.py"
+        extension_path.write_text(
+            """
+import json
+import os
+
+
+def _record(name, payload=None):
+    with open(os.environ["SOLVE_HOOK_EVENTS"], "a", encoding="utf-8") as handle:
+        handle.write(json.dumps({"name": name, "payload": payload or {}}) + "\\n")
+
+
+def register(api):
+    _record("registered")
+
+    @api.on("*")
+    def record_event(event):
+        _record(event.name, event.payload)
+""".lstrip(),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("SOLVE_HOOK_EVENTS", str(events_path))
+
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            db_path=tmp_path / "runs.sqlite3",
+            extensions=str(extension_path),
+            extension_fail_fast=True,
+        )
+        scenario_name = "solve_hooked_agent_task"
+        previous = SCENARIO_REGISTRY.get(scenario_name)
+        SCENARIO_REGISTRY[scenario_name] = _SolveAgentTask
+
+        manager = SolveManager(settings)
+
+        class _FakeBuilder:
+            def build(
+                self,
+                description: str,
+                *,
+                family_override: str | None = None,
+            ) -> SolveScenarioBuildResult:
+                del description, family_override
+                return SolveScenarioBuildResult(
+                    scenario_name=scenario_name,
+                    family_name="agent_task",
+                )
+
+        fake_package = SkillPackage(
+            scenario_name=scenario_name,
+            display_name="Solve Hooked Agent Task",
+            description="fixture",
+            playbook="",
+            lessons=[],
+            best_strategy=None,
+            best_score=1.0,
+            best_elo=1500.0,
+            hints="",
+            harness={},
+        )
+
+        def _fake_resolve_role_runtime(settings: AppSettings, **kwargs: object) -> tuple[Any, str]:
+            del settings
+            hook_bus = kwargs.get("hook_bus")
+            assert hook_bus is not None
+            return wrap_llm_provider(
+                _StubProvider("improved draft"),
+                hook_bus,  # type: ignore[arg-type]
+                provider_name="test:competitor",
+                role="competitor",
+            ), "test-model"
+
+        monkeypatch.setattr(manager, "_build_creator", lambda: _FakeBuilder())
+        monkeypatch.setattr(
+            "autocontext.knowledge.solver.resolve_role_runtime",
+            _fake_resolve_role_runtime,
+        )
+        monkeypatch.setattr("autocontext.knowledge.solver.export_skill_package", lambda ctx, name: fake_package)
+
+        try:
+            job = manager.solve_sync(description="fixture", generations=1)
+        finally:
+            if previous is None:
+                SCENARIO_REGISTRY.pop(scenario_name, None)
+            else:
+                SCENARIO_REGISTRY[scenario_name] = previous
+
+        event_names = [
+            json.loads(line)["name"]
+            for line in events_path.read_text(encoding="utf-8").splitlines()
+        ]
+
+        assert job.status == "completed"
+        assert job.family_name == "agent_task"
+        assert manager.get_status(job.job_id)["family_name"] == "agent_task"
+        assert "registered" in event_names
+        assert "run_start" in event_names
+        assert "generation_start" in event_names
+        assert "before_provider_request" in event_names
+        assert "after_provider_response" in event_names
+        assert "generation_end" in event_names
+        assert "run_end" in event_names
+
     def test_run_job_uses_family_aware_executor(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from autocontext.knowledge.export import SkillPackage
         from autocontext.knowledge.solver import (
@@ -1147,5 +1497,6 @@ class TestSolveManager:
         manager._run_job(job)
 
         assert job.status == "completed"
+        assert job.family_name == "agent_task"
         assert job.progress == 3
         assert job.result == fake_package

--- a/autocontext/tests/test_new_scenario_cli.py
+++ b/autocontext/tests/test_new_scenario_cli.py
@@ -7,10 +7,15 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from autocontext.cli import app
+from autocontext.config.settings import AppSettings
 from autocontext.scenarios import SCENARIO_REGISTRY
 from autocontext.scenarios.custom.registry import load_all_custom_scenarios
 
 runner = CliRunner()
+
+
+def _custom_dir(tmp_path: Path) -> Path:
+    return tmp_path / "knowledge" / "_custom_scenarios"
 
 
 class TestNewScenarioList:
@@ -29,13 +34,79 @@ class TestNewScenarioList:
         # Each template should show its description
         assert "Optimize" in result.stdout or "optimize" in result.stdout
 
+    def test_list_families_shows_registered_pipelines(self) -> None:
+        result = runner.invoke(app, ["new-scenario", "--list-families"])
+
+        assert result.exit_code == 0
+        assert "schema_evolution" in result.stdout
+        assert "operator_loop" in result.stdout
+        assert "tool_fragility" in result.stdout
+
 
 class TestNewScenarioScaffold:
     """Test `autoctx new-scenario --template <name> --name <scenario-name>` command."""
 
+    def test_family_pipeline_requires_description(self) -> None:
+        result = runner.invoke(
+            app,
+            ["new-scenario", "--family", "schema_evolution", "--name", "api-drift", "--non-interactive"],
+        )
+
+        assert result.exit_code != 0
+        assert "--description" in result.stdout
+
+    def test_family_pipeline_invokes_registered_creator(self, tmp_path: Path) -> None:
+        calls: list[dict[str, object]] = []
+
+        def _fake_create_family_scenario(
+            *,
+            family: str,
+            name: str,
+            description: str,
+            settings: AppSettings,
+        ) -> object:
+            calls.append(
+                {
+                    "family": family,
+                    "name": name,
+                    "description": description,
+                    "knowledge_root": settings.knowledge_root,
+                }
+            )
+            return object()
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=AppSettings(knowledge_root=tmp_path / "knowledge")),
+            patch("autocontext.cli_new_scenario._create_family_scenario", side_effect=_fake_create_family_scenario),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "new-scenario",
+                    "--family",
+                    "schema_evolution",
+                    "--name",
+                    "api-drift",
+                    "--description",
+                    "API contracts drift while producers and consumers evolve",
+                    "--non-interactive",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert calls == [
+            {
+                "family": "schema_evolution",
+                "name": "api-drift",
+                "description": "API contracts drift while producers and consumers evolve",
+                "knowledge_root": tmp_path / "knowledge",
+            }
+        ]
+        assert "created with family pipeline 'schema_evolution'" in result.stdout
+
     def test_scaffold_creates_directory(self, tmp_path: Path) -> None:
         target = tmp_path / "knowledge" / "_custom_scenarios" / "my-prompt-task"
-        with patch("autocontext.cli._get_custom_scenarios_dir", return_value=tmp_path / "knowledge" / "_custom_scenarios"):
+        with patch("autocontext.cli_new_scenario._get_custom_scenarios_dir", return_value=_custom_dir(tmp_path)):
             result = runner.invoke(
                 app,
                 ["new-scenario", "--template", "prompt-optimization", "--name", "my-prompt-task", "--non-interactive"],
@@ -47,7 +118,7 @@ class TestNewScenarioScaffold:
         assert (target / "scenario_type.txt").is_file()
 
     def test_scaffold_with_judge_model(self, tmp_path: Path) -> None:
-        with patch("autocontext.cli._get_custom_scenarios_dir", return_value=tmp_path / "knowledge" / "_custom_scenarios"):
+        with patch("autocontext.cli_new_scenario._get_custom_scenarios_dir", return_value=_custom_dir(tmp_path)):
             result = runner.invoke(
                 app,
                 [
@@ -64,7 +135,7 @@ class TestNewScenarioScaffold:
         assert "test-judge-model" in (target / "agent_task.py").read_text(encoding="utf-8")
 
     def test_scaffold_missing_template(self, tmp_path: Path) -> None:
-        with patch("autocontext.cli._get_custom_scenarios_dir", return_value=tmp_path / "knowledge" / "_custom_scenarios"):
+        with patch("autocontext.cli_new_scenario._get_custom_scenarios_dir", return_value=_custom_dir(tmp_path)):
             result = runner.invoke(
                 app,
                 ["new-scenario", "--template", "nonexistent", "--name", "test", "--non-interactive"],
@@ -81,7 +152,7 @@ class TestNewScenarioScaffold:
 
     def test_scaffold_registers_scenario(self, tmp_path: Path) -> None:
         """After scaffolding, the scenario should be registered."""
-        with patch("autocontext.cli._get_custom_scenarios_dir", return_value=tmp_path / "knowledge" / "_custom_scenarios"):
+        with patch("autocontext.cli_new_scenario._get_custom_scenarios_dir", return_value=_custom_dir(tmp_path)):
             result = runner.invoke(
                 app,
                 [
@@ -104,7 +175,7 @@ class TestNewScenarioNonInteractive:
     """Test the --non-interactive flag."""
 
     def test_non_interactive_uses_defaults(self, tmp_path: Path) -> None:
-        with patch("autocontext.cli._get_custom_scenarios_dir", return_value=tmp_path / "knowledge" / "_custom_scenarios"):
+        with patch("autocontext.cli_new_scenario._get_custom_scenarios_dir", return_value=_custom_dir(tmp_path)):
             result = runner.invoke(
                 app,
                 [

--- a/autocontext/tests/test_per_role_provider.py
+++ b/autocontext/tests/test_per_role_provider.py
@@ -13,7 +13,7 @@ import pytest
 
 from autocontext.agents.llm_client import DeterministicDevClient
 from autocontext.harness.core.llm_client import LanguageModelClient
-from autocontext.harness.core.types import ModelResponse
+from autocontext.harness.core.types import ModelResponse, RoleUsage
 from autocontext.providers.base import CompletionResult, LLMProvider
 
 # ── Helpers ─────────────────────────────────────────────────────────────
@@ -41,6 +41,29 @@ class _StubProvider(LLMProvider):
 
     def default_model(self) -> str:
         return "stub-model"
+
+
+class _ClosableClient(LanguageModelClient):
+    def __init__(self) -> None:
+        self.closed = False
+
+    def generate(
+        self,
+        *,
+        model: str,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+        role: str = "",
+    ) -> ModelResponse:
+        del prompt, max_tokens, temperature, role
+        return ModelResponse(
+            text="ok",
+            usage=RoleUsage(input_tokens=1, output_tokens=1, latency_ms=1, model=model),
+        )
+
+    def close(self) -> None:
+        self.closed = True
 
 
 # ── Config field tests ──────────────────────────────────────────────────
@@ -475,6 +498,116 @@ class TestOrchestratorPerRoleWiring:
         assert mock_create.call_args_list[0].kwargs == {"scenario_name": "grid_ctf", "role": "competitor"}
         assert mock_create.call_args_list[1].args == ("pi-rpc", settings)
         assert mock_create.call_args_list[1].kwargs == {"scenario_name": "grid_ctf", "role": "analyst"}
+
+    @patch("autocontext.agents.provider_bridge.create_role_client")
+    def test_pi_role_runtime_timeout_is_bounded_by_generation_deadline(self, mock_create: MagicMock) -> None:
+        from autocontext.agents.orchestrator import AgentOrchestrator
+        from autocontext.config.settings import AppSettings
+
+        shared_client = MagicMock(spec=LanguageModelClient)
+        role_client = MagicMock(spec=LanguageModelClient)
+        mock_create.return_value = role_client
+        settings = AppSettings(
+            agent_provider="pi",
+            pi_timeout=900.0,
+            generation_time_budget_seconds=420,
+        )
+        orch = AgentOrchestrator(shared_client, settings)
+
+        with patch("autocontext.agents.role_runtime_overrides.time.monotonic", return_value=100.0):
+            with orch._use_role_runtime(
+                "analyst",
+                orch.analyst,
+                generation=1,
+                scenario_name="portfolio_schema",
+                generation_deadline=520.0,
+            ):
+                pass
+
+        bounded_settings = mock_create.call_args.args[1]
+        assert bounded_settings.pi_timeout == 420.0
+        assert mock_create.call_args.kwargs == {"scenario_name": "portfolio_schema", "role": "analyst"}
+
+    @patch("autocontext.agents.provider_bridge.create_role_client")
+    def test_per_role_pi_runtime_timeout_is_bounded_by_generation_deadline(self, mock_create: MagicMock) -> None:
+        from autocontext.agents.orchestrator import AgentOrchestrator
+        from autocontext.config.settings import AppSettings
+
+        shared_client = MagicMock(spec=LanguageModelClient)
+        role_client = MagicMock(spec=LanguageModelClient)
+        mock_create.return_value = role_client
+        settings = AppSettings(
+            agent_provider="deterministic",
+            competitor_provider="pi-rpc",
+            pi_timeout=900.0,
+            pi_rpc_persistent=True,
+            generation_time_budget_seconds=420,
+        )
+        orch = AgentOrchestrator(shared_client, settings)
+
+        with patch("autocontext.agents.role_runtime_overrides.time.monotonic", return_value=100.0):
+            orch.resolve_role_execution(
+                "competitor",
+                generation=1,
+                scenario_name="portfolio_schema",
+                generation_deadline=520.0,
+            )
+
+        bounded_settings = mock_create.call_args.args[1]
+        assert bounded_settings.pi_timeout == 420.0
+        assert bounded_settings.pi_rpc_persistent is False
+        assert mock_create.call_args.kwargs == {"scenario_name": "portfolio_schema", "role": "competitor"}
+
+    @patch("autocontext.agents.provider_bridge.create_role_client")
+    def test_budgeted_role_runtime_client_is_closed_after_use(self, mock_create: MagicMock) -> None:
+        from autocontext.agents.orchestrator import AgentOrchestrator
+        from autocontext.config.settings import AppSettings
+
+        shared_client = MagicMock(spec=LanguageModelClient)
+        role_client = _ClosableClient()
+        mock_create.return_value = role_client
+        settings = AppSettings(agent_provider="pi-rpc", pi_timeout=900.0, pi_rpc_persistent=True)
+        orch = AgentOrchestrator(shared_client, settings)
+
+        with patch("autocontext.agents.role_runtime_overrides.time.monotonic", return_value=100.0):
+            with orch._use_role_runtime(
+                "analyst",
+                orch.analyst,
+                generation=1,
+                scenario_name="portfolio_schema",
+                generation_deadline=520.0,
+            ):
+                assert orch.analyst.runtime.client is role_client
+                assert role_client.closed is False
+
+        bounded_settings = mock_create.call_args.args[1]
+        assert bounded_settings.pi_rpc_persistent is False
+        assert role_client.closed is True
+
+    @patch("autocontext.agents.provider_bridge.create_role_client")
+    def test_pi_role_runtime_fails_before_call_when_generation_deadline_is_exhausted(
+        self,
+        mock_create: MagicMock,
+    ) -> None:
+        from autocontext.agents.orchestrator import AgentOrchestrator
+        from autocontext.config.settings import AppSettings
+
+        shared_client = MagicMock(spec=LanguageModelClient)
+        settings = AppSettings(agent_provider="pi", pi_timeout=900.0)
+        orch = AgentOrchestrator(shared_client, settings)
+
+        with patch("autocontext.agents.role_runtime_overrides.time.monotonic", return_value=519.6):
+            with pytest.raises(TimeoutError, match="generation time budget exhausted"):
+                with orch._use_role_runtime(
+                    "analyst",
+                    orch.analyst,
+                    generation=1,
+                    scenario_name="portfolio_schema",
+                    generation_deadline=520.0,
+                ):
+                    pass
+
+        mock_create.assert_not_called()
 
     @patch("autocontext.agents.provider_bridge.create_role_client")
     def test_override_does_not_affect_unset_roles(self, mock_create: MagicMock) -> None:

--- a/autocontext/tests/test_rubric_drift_calibration.py
+++ b/autocontext/tests/test_rubric_drift_calibration.py
@@ -438,6 +438,65 @@ class TestRubricDriftMonitor:
 
         assert len(warnings) == 0
 
+    def test_detect_dimension_level_drift_from_generation_summaries(self) -> None:
+        from autocontext.analytics.rubric_drift import (
+            DriftThresholds,
+            RubricDriftMonitor,
+        )
+
+        trajectory = [
+            {
+                "generation_index": 1,
+                "dimension_summary": {
+                    "dimension_means": {
+                        "factuality": 0.90,
+                        "evidence": 0.88,
+                        "style": 0.50,
+                    }
+                },
+            },
+            {
+                "generation_index": 2,
+                "dimension_summary": {
+                    "dimension_means": {
+                        "factuality": 0.80,
+                        "evidence": 0.78,
+                        "style": 0.50,
+                    }
+                },
+            },
+            {
+                "generation_index": 3,
+                "dimension_summary": {
+                    "dimension_means": {
+                        "factuality": 0.70,
+                        "evidence": 0.68,
+                        "style": 0.50,
+                    }
+                },
+            },
+        ]
+        monitor = RubricDriftMonitor(
+            thresholds=DriftThresholds(
+                min_dimension_observations=3,
+                min_dimension_stddev=0.001,
+                max_dimension_decline=0.15,
+                max_dimension_correlation=0.99,
+            )
+        )
+
+        snapshot = monitor.compute_dimension_snapshot("run-dim", trajectory)
+        warnings = monitor.detect_dimension_drift(snapshot)
+        warning_types = {warning.warning_type for warning in warnings}
+
+        assert snapshot.run_id == "run-dim"
+        assert snapshot.generation_count == 3
+        assert snapshot.dimension_count == 3
+        assert "dimension_score_decline" in warning_types
+        assert "dimension_score_compression" in warning_types
+        assert "dimension_correlation_high" in warning_types
+        assert any(warning.metadata.get("dimension") == "factuality" for warning in warnings)
+
     def test_analyze_combines_snapshot_and_warnings(self) -> None:
         from autocontext.analytics.rubric_drift import (
             DriftThresholds,

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 ## Execution Surfaces (0.3.0)
 
 - **`simulate`** — modeled-world exploration with sweeps, replay, compare, export
-- **`investigate`** — evidence-driven diagnosis with hypotheses and confidence
+- **`investigate`** — evidence-driven diagnosis in synthetic harness or iterative LLM modes
 - **`analyze`** — interpret and compare outputs from all surfaces
 - **`mission`** — real-world goal execution with adaptive planning and campaigns
 - **`train`** — distill curated datasets into scenario-local models

--- a/ts/src/scenarios/llm-json-response.ts
+++ b/ts/src/scenarios/llm-json-response.ts
@@ -1,19 +1,150 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function stripJsonComments(raw: string): string {
+  let output = "";
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i]!;
+    const next = raw[i + 1];
+    if (inString) {
+      output += ch;
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === "\"") {
+      inString = true;
+      output += ch;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      while (i < raw.length && raw[i] !== "\n") {
+        i += 1;
+      }
+      output += "\n";
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (i < raw.length && !(raw[i] === "*" && raw[i + 1] === "/")) {
+        i += 1;
+      }
+      i += 1;
+      continue;
+    }
+    output += ch;
+  }
+  return output;
+}
+
+function repairJsonText(raw: string): string {
+  return stripJsonComments(raw)
+    .replace(/,\s*([}\]])/g, "$1")
+    .trim();
+}
+
+function tryParseRecord(raw: string): Record<string, unknown> | null {
+  for (const candidate of [raw.trim(), repairJsonText(raw)]) {
+    if (!candidate) continue;
+    try {
+      const parsed: unknown = JSON.parse(candidate);
+      return isRecord(parsed) ? parsed : null;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return null;
+}
+
+function fencedJsonCandidates(text: string): string[] {
+  const candidates: string[] = [];
+  const fenceRe = /```(?:json|javascript|js)?\s*([\s\S]*?)```/gi;
+  let match: RegExpExecArray | null;
+  while ((match = fenceRe.exec(text)) !== null) {
+    if (match[1]?.trim()) {
+      candidates.push(match[1].trim());
+    }
+  }
+  return candidates;
+}
+
+function objectCandidates(text: string): string[] {
+  const candidates: string[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i]!;
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === "\"") {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      if (depth === 0) {
+        start = i;
+      }
+      depth += 1;
+      continue;
+    }
+    if (ch !== "}" || depth === 0) {
+      continue;
+    }
+    depth -= 1;
+    if (depth === 0 && start !== -1) {
+      candidates.push(text.slice(start, i + 1));
+      start = -1;
+    }
+  }
+  return candidates.sort((a, b) => b.length - a.length);
+}
+
 export function parseJsonObjectFromResponse(text: string): Record<string, unknown> | null {
   const trimmed = text.trim();
 
-  try {
-    return JSON.parse(trimmed) as Record<string, unknown>;
-  } catch {
-    // continue
+  const direct = tryParseRecord(trimmed);
+  if (direct) {
+    return direct;
+  }
+
+  for (const candidate of fencedJsonCandidates(trimmed)) {
+    const parsed = tryParseRecord(candidate);
+    if (parsed) {
+      return parsed;
+    }
+  }
+
+  for (const candidate of objectCandidates(trimmed)) {
+    const parsed = tryParseRecord(candidate);
+    if (parsed) {
+      return parsed;
+    }
   }
 
   const jsonStart = trimmed.indexOf("{");
   const jsonEnd = trimmed.lastIndexOf("}");
   if (jsonStart !== -1 && jsonEnd > jsonStart) {
-    try {
-      return JSON.parse(trimmed.slice(jsonStart, jsonEnd + 1)) as Record<string, unknown>;
-    } catch {
-      // continue
+    const parsed = tryParseRecord(trimmed.slice(jsonStart, jsonEnd + 1));
+    if (parsed) {
+      return parsed;
     }
   }
 
@@ -31,7 +162,11 @@ export function parseDelimitedJsonObject(opts: {
   const endIdx = text.indexOf(endDelimiter);
   if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
     const raw = text.slice(startIdx + startDelimiter.length, endIdx).trim();
-    return JSON.parse(raw) as Record<string, unknown>;
+    const parsed = parseJsonObjectFromResponse(raw);
+    if (parsed) {
+      return parsed;
+    }
+    throw new SyntaxError(`response contains invalid ${missingDelimiterLabel} JSON`);
   }
 
   const parsed = parseJsonObjectFromResponse(text);

--- a/ts/src/scenarios/schema-evolution-spec.ts
+++ b/ts/src/scenarios/schema-evolution-spec.ts
@@ -27,8 +27,8 @@ export type SchemaEvolutionSpec = z.infer<typeof SchemaEvolutionSpecSchema>;
 export function parseRawSchemaEvolutionSpec(data: Record<string, unknown>): SchemaEvolutionSpec {
   return SchemaEvolutionSpecSchema.parse({
     description: data.description,
-    environmentDescription: data.environment_description,
-    initialStateDescription: data.initial_state_description,
+    environmentDescription: data.environment_description ?? data.environmentDescription,
+    initialStateDescription: data.initial_state_description ?? data.initialStateDescription,
     mutations: Array.isArray(data.mutations)
       ? data.mutations.map((mutation) => {
           const raw = mutation as Record<string, unknown>;
@@ -36,15 +36,15 @@ export function parseRawSchemaEvolutionSpec(data: Record<string, unknown>): Sche
             version: raw.version,
             description: raw.description,
             breaking: raw.breaking,
-            fieldsAdded: raw.fields_added ?? [],
-            fieldsRemoved: raw.fields_removed ?? [],
-            fieldsModified: raw.fields_modified ?? {},
+            fieldsAdded: raw.fields_added ?? raw.fieldsAdded ?? [],
+            fieldsRemoved: raw.fields_removed ?? raw.fieldsRemoved ?? [],
+            fieldsModified: raw.fields_modified ?? raw.fieldsModified ?? {},
           };
         })
       : data.mutations,
-    successCriteria: data.success_criteria,
-    failureModes: data.failure_modes ?? [],
+    successCriteria: data.success_criteria ?? data.successCriteria,
+    failureModes: data.failure_modes ?? data.failureModes ?? [],
     actions: data.actions,
-    maxSteps: data.max_steps ?? 10,
+    maxSteps: data.max_steps ?? data.maxSteps ?? 10,
   });
 }

--- a/ts/tests/schema-evolution-designer-parsing.test.ts
+++ b/ts/tests/schema-evolution-designer-parsing.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseSchemaEvolutionSpec,
+  SCHEMA_EVOLUTION_SPEC_END,
+  SCHEMA_EVOLUTION_SPEC_START,
+} from "../src/scenarios/schema-evolution-designer.js";
+
+describe("schema-evolution designer parsing", () => {
+  it("recovers long Pi-style fenced JSON with comments, trailing commas, and camelCase fields", () => {
+    const raw = `
+Pi explored a few variants and selected the schema migration harness below.
+
+${SCHEMA_EVOLUTION_SPEC_START}
+\`\`\`json
+{
+  // Pi sometimes echoes a JS-style annotation in long runs.
+  "description": "Portfolio schema evolution under macro regime changes",
+  "environmentDescription": "A portfolio API changes allocation and risk schemas over time.",
+  "initialStateDescription": "The v1 schema contains equities, bonds, cash, commodities, and hedges.",
+  "mutations": [
+    {
+      "version": 2,
+      "description": "Add drawdown limits and regime confidence.",
+      "breaking": false,
+      "fieldsAdded": ["drawdown_limit", "regime_confidence"],
+      "fieldsRemoved": [],
+      "fieldsModified": {},
+    },
+    {
+      "version": 3,
+      "description": "Rename equities to risk_assets and remove legacy hedge weight.",
+      "breaking": true,
+      "fieldsAdded": ["risk_assets"],
+      "fieldsRemoved": ["equities", "legacy_hedge_weight"],
+      "fieldsModified": {"cash": "number -> object"},
+    },
+  ],
+  "successCriteria": ["detect schema mutations", "avoid stale removed fields"],
+  "failureModes": ["using equities after v3", "ignoring cash type changes"],
+  "maxSteps": 8,
+  "actions": [
+    {
+      "name": "inspect_schema",
+      "description": "Inspect the active schema.",
+      "parameters": {"endpoint": "string"},
+      "preconditions": [],
+      "effects": ["schema_observed"],
+    },
+    {
+      "name": "rebalance_portfolio",
+      "description": "Submit allocation under the active schema.",
+      "parameters": {"allocation": "object"},
+      "preconditions": ["inspect_schema"],
+      "effects": ["allocation_submitted"],
+    },
+  ],
+}
+\`\`\`
+${SCHEMA_EVOLUTION_SPEC_END}
+
+That is the final spec.`;
+
+    const spec = parseSchemaEvolutionSpec(raw);
+
+    expect(spec.description).toContain("Portfolio schema evolution");
+    expect(spec.environmentDescription).toContain("portfolio API");
+    expect(spec.mutations[1]?.fieldsRemoved).toContain("equities");
+    expect(spec.actions.map((action) => action.name)).toEqual([
+      "inspect_schema",
+      "rebalance_portfolio",
+    ]);
+  });
+
+  it("still fails explicitly when no JSON object is recoverable", () => {
+    expect(() =>
+      parseSchemaEvolutionSpec(
+        `${SCHEMA_EVOLUTION_SPEC_START}\nnot json at all\n${SCHEMA_EVOLUTION_SPEC_END}`,
+      ),
+    ).toThrow(/invalid SCHEMA_EVOLUTION_SPEC JSON/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add scenario-family/new-scenario ergonomics, drift analytics, and iterative investigation support for the harness stress work.
- Wire solve/provider/judge/lifecycle hook coverage through production solve paths.
- Bound Python Pi/Pi-RPC solve role calls by generation budget, including per-role overrides, and expose solve family metadata in JSON/status output.
- Harden TS schema-evolution designer parsing for Pi-style JSON with fences, prose, comments, trailing commas, and camelCase fields.
- Address reviewer follow-up: close one-shot budgeted runtime clients, lazy-resolve iterative investigate architect runtime, and report solve run-end generation counts separately from improvement rounds.

## Linear
Closes AC-686, AC-688, AC-689, AC-690, AC-691, AC-692, AC-693.

## Verification
- `uv run --frozen ruff check src tests/test_knowledge_solver.py tests/test_per_role_provider.py tests/test_cli_investigate.py tests/test_cli_simulate_runtime.py tests/test_rlm_competitor.py`
- `uv run --frozen mypy src`
- `uv run --frozen pytest` -> 6000 passed, 42 skipped
- `npm run lint`
- `npx vitest run tests/schema-evolution-designer-parsing.test.ts tests/agent-task-pipeline.test.ts tests/spec-auto-heal.test.ts` -> 94 passed

## Notes
- Full `npm test` was attempted before this reviewer patch. It still fails on unrelated existing TS CLI timeout tests and Python cross-runtime venv/uv races, plus the pre-existing TS type-assertion budget baseline. Targeted TS parser/family tests and TS typecheck pass.