### PR TITLE
Bump packages for 0.4.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.8] - 2026-04-30
+
 ### Fixed
 
 - TypeScript generated `schema_evolution` scenarios no longer score empty mutation plans as perfect, and generated actions now record mutation lineage before schema-coverage scoring (AC-666).
 - Python Claude CLI runtime calls now use bounded timeout retries with exponential backoff, total wall-clock caps, retry metadata, and warning/error logs for long-running live-agent calls (AC-684).
+- Python solve now enforces generation budgets across Pi/Pi-RPC role calls, including per-role overrides, and closes one-shot budgeted persistent Pi RPC clients after use (AC-691).
+- TypeScript schema-evolution creation now recovers from Pi-style invalid JSON responses with markdown fences, prose wrappers, comments, trailing commas, and camelCase fields (AC-692).
+- Python solve JSON/status output now includes resolved scenario-family metadata for stress harnesses and user workflows (AC-693).
+- Iterative investigation no longer requires resolving the architect runtime before the first analyst step.
+- Task-like solve lifecycle hooks now report persisted generation counts separately from improvement rounds.
+
+### Changed
+
+- Python `autocontext` and TypeScript `autoctx` package metadata are bumped to `0.4.8`.
+- Pi `pi-autocontext` package metadata is bumped to `0.2.2` while intentionally keeping its `autoctx` dependency one package behind at `^0.4.7`.
 
 ## [0.4.7] - 2026-04-29
 
@@ -296,7 +308,8 @@ All notable changes to this project will be documented in this file.
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
-[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.7...HEAD
+[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.8...HEAD
+[0.4.8]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.7...py-v0.4.8
 [0.4.7]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.6...py-v0.4.7
 [0.4.6]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.5...py-v0.4.6
 [0.4.5]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.4...py-v0.4.5

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Autocontext is a harness. You point it at a goal in plain language. It iterates 
 The fastest path uses our **Pi runtime**, a local coding agent that handles its own auth. No API key plumbing, no provider config: install Pi, install autocontext, point one at the other.
 
 ```bash
-uv tool install autocontext==0.4.7
+uv tool install autocontext==0.4.8
 
 AUTOCONTEXT_AGENT_PROVIDER=pi \
 AUTOCONTEXT_PI_COMMAND=pi \
@@ -36,7 +36,7 @@ Pi runs locally as a subprocess and emits live traces back into the harness. For
 Prefer TypeScript? Same surface, same command:
 
 ```bash
-bun add -g autoctx@0.4.7
+bun add -g autoctx@0.4.8
 AUTOCONTEXT_AGENT_PROVIDER=pi bunx autoctx solve \
   --description "improve customer-support replies for billing disputes" \
   --gens 5 --json
@@ -197,7 +197,7 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 ```
 
 <!-- autocontext-whats-new:start -->
-## What's New in 0.4.7
+## What's New in 0.4.8
 
 - **Anthropic SDK instrumentation** in Python and TypeScript: wrap any existing Anthropic client with `instrument_client` / `instrumentClient` to capture streaming and non-streaming production traces.
 - **TypeScript `autoctx solve` CLI** brings one-command scenario generation and execution to full parity with Python.
@@ -219,11 +219,11 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 
 ```bash
 # Python: library or CLI tool
-uv pip install autocontext==0.4.7
-uv tool install autocontext==0.4.7
+uv pip install autocontext==0.4.8
+uv tool install autocontext==0.4.8
 
 # TypeScript
-bun add -g autoctx@0.4.7
+bun add -g autoctx@0.4.8
 
 # Pi extension
 pi install npm:pi-autocontext

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -10,7 +10,7 @@ The intended use is to hand the harness a real task in plain language, let it so
 pip install autocontext
 ```
 
-The current PyPI release line is `autocontext==0.4.7`.
+The current PyPI release line is `autocontext==0.4.8`.
 The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
 
 ## Working Directory

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autocontext"
-version = "0.4.7"
+version = "0.4.8"
 description = "autocontext control plane for iterative strategy evolution."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/autocontext/src/autocontext/__init__.py
+++ b/autocontext/src/autocontext/__init__.py
@@ -5,4 +5,4 @@ from autocontext.sdk import AutoContext
 
 __all__ = ["AutoContext", "ExtensionAPI", "HookBus", "HookEvents", "HookResult", "__version__"]
 
-__version__ = "0.4.7"
+__version__ = "0.4.8"

--- a/autocontext/src/autocontext/banner.py
+++ b/autocontext/src/autocontext/banner.py
@@ -22,7 +22,7 @@ SYNC_BLOCK_START = "<!-- autocontext-readme-hero:start -->"
 SYNC_BLOCK_END = "<!-- autocontext-readme-hero:end -->"
 WHATS_NEW_BLOCK_START = "<!-- autocontext-whats-new:start -->"
 WHATS_NEW_BLOCK_END = "<!-- autocontext-whats-new:end -->"
-README_WHATS_NEW_HEADING = "What's New in 0.4.7"
+README_WHATS_NEW_HEADING = "What's New in 0.4.8"
 README_BADGES = (
     (
         "https://github.com/greyhaven-ai/autocontext/blob/main/LICENSE",

--- a/autocontext/uv.lock
+++ b/autocontext/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "autocontext"
-version = "0.4.7"
+version = "0.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,6 +1,6 @@
 # Release Checklist
 
-Use this checklist when preparing a tagged release such as `py-v0.4.7`, `ts-v0.4.7`, or `pi-v0.2.1`.
+Use this checklist when preparing a tagged release such as `py-v0.4.8`, `ts-v0.4.8`, or `pi-v0.2.2`.
 
 ## 1. Decide Scope
 

--- a/pi/package-lock.json
+++ b/pi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-autocontext",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-autocontext",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "autoctx": "^0.4.7"

--- a/pi/package.json
+++ b/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-autocontext",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "autocontext extension for Pi coding agent \u2014 iterative strategy generation, LLM judging, and evaluation tools",
   "type": "module",
   "keywords": ["pi-package", "pi", "pi-extension", "autocontext", "autoctx", "evaluation", "llm", "judging"],

--- a/ts/README.md
+++ b/ts/README.md
@@ -53,7 +53,7 @@ export function register(api) {
 npm install autoctx
 ```
 
-The current npm release line is `autoctx@0.4.7`.
+The current npm release line is `autoctx@0.4.8`.
 Important: use `autoctx`, not `autocontext`.
 `autocontext` on npm is a different package and not this project.
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoctx",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoctx",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoctx",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump Python autocontext and TypeScript autoctx package metadata/docs to 0.4.8
- bump pi-autocontext to 0.2.2 while keeping its autoctx dependency one package behind at ^0.4.7
- update release checklist and changelog for the new release tags

## Validation
- uv run --frozen ruff check src tests
- uv run --frozen mypy src
- uv build
- npm run build (ts)
- npm pack --dry-run (ts)
- npm ci --dry-run (pi)
- npm run lint (pi)
- npm test (pi)
- npm run build (pi)
- npm pack --dry-run (pi)

Note: full ts npm test was run and hit 7 pre-existing/unrelated failures: type assertion budget, scenario revision/provider expectation failures, two local .venv cross-runtime validation races, and two CLI timeout flakes.