### PR TITLE
Fix Pi simulate, timeout, and RLM regressions

### DIFF
--- a/autocontext/src/autocontext/agents/provider_bridge.py
+++ b/autocontext/src/autocontext/agents/provider_bridge.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, cast
 
 from autocontext.harness.core.llm_client import LanguageModelClient
 from autocontext.harness.core.types import ModelResponse, RoleUsage
+from autocontext.runtimes.errors import format_runtime_failure
 
 logger = logging.getLogger(__name__)
 
@@ -95,8 +96,7 @@ class RuntimeBridgeClient(LanguageModelClient):
         output = self._runtime.generate(prompt)
         error = output.metadata.get("error")
         if error:
-            detail = output.metadata.get("detail") or output.metadata.get("stderr") or ""
-            raise RuntimeError(f"{self._runtime.name} failed: {error}{f' ({detail})' if detail else ''}")
+            raise RuntimeError(format_runtime_failure(self._runtime.name, output.metadata))
         elapsed_ms = int((time.monotonic() - t0) * 1000)
         return ModelResponse(
             text=output.text,

--- a/autocontext/src/autocontext/analytics/rubric_drift.py
+++ b/autocontext/src/autocontext/analytics/rubric_drift.py
@@ -87,8 +87,9 @@ class DriftThresholds(BaseModel):
     max_rollback_rate: float = 0.3
     min_dimension_observations: int = 3
     min_dimension_stddev: float = 0.01
-    max_dimension_decline: float = 0.15
+    max_dimension_decline: float = 0.04
     max_dimension_correlation: float = 0.98
+    min_within_gen_variance_zero_streak: int = 3
 
 
 class DriftWarning(BaseModel):
@@ -396,6 +397,34 @@ class RubricDriftMonitor:
                     metadata={"run_id": current.run_id, "dimension": dimension, "series": series},
                 ))
 
+            best_series = current.best_dimension_series.get(dimension, [])
+            zero_variance_streak = _max_equal_streak(
+                series,
+                best_series,
+                limit=thresholds.min_within_gen_variance_zero_streak,
+            )
+            if zero_variance_streak >= thresholds.min_within_gen_variance_zero_streak:
+                warnings.append(self._make_warning(
+                    now,
+                    "dimension_within_gen_variance_zero",
+                    "medium",
+                    f"Dimension '{dimension}' has mean==best for {zero_variance_streak} consecutive generations",
+                    current.snapshot_id,
+                    f"dimension.{dimension}.within_generation_equal_streak",
+                    float(zero_variance_streak),
+                    float(thresholds.min_within_gen_variance_zero_streak),
+                    scenarios,
+                    providers,
+                    releases,
+                    metadata={
+                        "run_id": current.run_id,
+                        "dimension": dimension,
+                        "streak": zero_variance_streak,
+                        "series": series,
+                        "best_series": best_series,
+                    },
+                ))
+
             decline = series[0] - series[-1]
             if decline >= thresholds.max_dimension_decline and _is_monotonic_decline(series):
                 warnings.append(self._make_warning(
@@ -518,6 +547,20 @@ def _append_dimension_values(target: dict[str, list[float]], raw_values: Any) ->
 
 def _is_monotonic_decline(series: list[float]) -> bool:
     return all(right <= left for left, right in zip(series, series[1:], strict=False))
+
+
+def _max_equal_streak(left: list[float], right: list[float], *, limit: int) -> int:
+    max_streak = 0
+    current_streak = 0
+    for left_value, right_value in zip(left, right, strict=False):
+        if abs(left_value - right_value) <= 1e-9:
+            current_streak += 1
+            max_streak = max(max_streak, current_streak)
+            if max_streak >= limit:
+                return max_streak
+        else:
+            current_streak = 0
+    return max_streak
 
 
 def _pearson(left: list[float], right: list[float]) -> float | None:

--- a/autocontext/src/autocontext/cli_runtime_overrides.py
+++ b/autocontext/src/autocontext/cli_runtime_overrides.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from autocontext.config.settings import AppSettings
@@ -11,6 +12,23 @@ _SOLVE_RUNTIME_PROVIDER_FIELDS = (
     "analyst_provider",
     "competitor_provider",
 )
+_TIMED_OUT_AFTER_RE = re.compile(r"\btimed out after (?P<seconds>\d+(?:\.\d+)?)s\b", re.IGNORECASE)
+
+
+def _format_timeout_seconds(seconds: float) -> str:
+    if float(seconds).is_integer():
+        return f"{seconds:.0f}s"
+    return f"{seconds:.2f}s"
+
+
+def _reported_timeout_seconds(message: str) -> float | None:
+    matches = list(_TIMED_OUT_AFTER_RE.finditer(message))
+    if not matches:
+        return None
+    try:
+        return float(matches[-1].group("seconds"))
+    except ValueError:
+        return None
 
 
 def runtime_timeout_field_for_provider(provider_name: str) -> str | None:
@@ -109,8 +127,15 @@ def format_runtime_provider_error(
     settings: AppSettings,
 ) -> str:
     message = str(exc)
-    if "timeout" not in message.lower():
+    message_lower = message.lower()
+    if "timeout" not in message_lower and "time budget" not in message_lower:
         return message
+
+    if "generation time budget" in message_lower or "time budget exhausted" in message_lower:
+        return (
+            f"{message}. Retry with --generation-time-budget <seconds> to allow a longer "
+            "per-generation solve budget."
+        )
 
     provider = provider_name.strip().lower()
     timeout_help = {
@@ -124,7 +149,21 @@ def format_runtime_provider_error(
         return message
 
     label, configured_timeout, env_var = help_details
+    reported_timeout = _reported_timeout_seconds(message)
+    effective_timeout = reported_timeout if reported_timeout is not None else configured_timeout
+    effective = _format_timeout_seconds(float(effective_timeout))
+    configured = _format_timeout_seconds(float(configured_timeout))
+    budget_bounded = reported_timeout is not None and reported_timeout < float(configured_timeout)
+    if budget_bounded:
+        return (
+            f"{label} timed out after {effective} "
+            f"(bounded by --generation-time-budget; configured {env_var}={configured}). "
+            "Retry with --generation-time-budget <seconds> to allow longer role calls, "
+            f"or retry with --timeout <seconds> / set {env_var} to raise the provider timeout ceiling. "
+            f"Original error: {message}"
+        )
+
     return (
-        f"{label} timed out after {configured_timeout:.0f}s. "
+        f"{label} timed out after {effective}. "
         f"Retry with --timeout <seconds> or set {env_var}. Original error: {message}"
     )

--- a/autocontext/src/autocontext/cli_solve.py
+++ b/autocontext/src/autocontext/cli_solve.py
@@ -106,7 +106,8 @@ def run_solve_command(
 
     if job.status != "completed" or job.result is None:
         message = job.error or "solve did not complete successfully"
-        if "timeout" in message.lower():
+        message_lower = message.lower()
+        if "timeout" in message_lower or "time budget" in message_lower:
             message = format_runtime_provider_error(
                 ProviderError(message),
                 provider_name=solve_primary_runtime_provider(settings),

--- a/autocontext/src/autocontext/harness/repl/session.py
+++ b/autocontext/src/autocontext/harness/repl/session.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import ast
+import hashlib
+import json
 import logging
 import re
 import time
@@ -21,6 +24,50 @@ _CODE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"```[ \t]*(?:python|py)[^\n`]*\r?\n(.*?)```", re.DOTALL | re.IGNORECASE),
     re.compile(r"```[ \t]*\r?\n(.*?)```", re.DOTALL),
 )
+_FINAL_ANSWER_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"<final_answer>(.*?)</final_answer>", re.DOTALL | re.IGNORECASE),
+    re.compile(r"<answer>(.*?)</answer>", re.DOTALL | re.IGNORECASE),
+)
+_NATURAL_CLOSURE_RE = re.compile(
+    r"(?:^|\b)(final answer:|the answer is|in summary,|i['’]?m confident the answer is)\s*(?P<body>.*)",
+    re.IGNORECASE | re.DOTALL,
+)
+_MUTATING_AST_NODES = (
+    ast.Assign,
+    ast.AnnAssign,
+    ast.AugAssign,
+    ast.Delete,
+    ast.For,
+    ast.AsyncFor,
+    ast.While,
+    ast.With,
+    ast.AsyncWith,
+    ast.FunctionDef,
+    ast.AsyncFunctionDef,
+    ast.ClassDef,
+    ast.Import,
+    ast.ImportFrom,
+    ast.Global,
+    ast.Nonlocal,
+    ast.Return,
+    ast.Raise,
+    ast.Try,
+)
+_MUTATING_METHODS = {
+    "add",
+    "append",
+    "clear",
+    "discard",
+    "extend",
+    "insert",
+    "pop",
+    "popitem",
+    "remove",
+    "setdefault",
+    "sort",
+    "update",
+}
+_NO_PROGRESS_TURN_LIMIT = 3
 
 
 def _extract_code_block(text: str) -> str | None:
@@ -30,6 +77,108 @@ def _extract_code_block(text: str) -> str | None:
         if match is not None:
             return match.group(1).strip()
     return None
+
+
+def _extract_final_answer_marker(text: str) -> str | None:
+    for pattern in _FINAL_ANSWER_PATTERNS:
+        match = pattern.search(text)
+        if match is not None:
+            return match.group(1).strip()
+    return None
+
+
+def _natural_closure_content(text: str) -> str | None:
+    match = _NATURAL_CLOSURE_RE.search(text)
+    if match is None:
+        return None
+    body = match.group("body").strip()
+    return body or text.strip()
+
+
+def _is_read_only_code(code: str) -> bool:
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, _MUTATING_AST_NODES):
+            return False
+        if isinstance(node, ast.NamedExpr):
+            return False
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr in _MUTATING_METHODS:
+                return False
+    return True
+
+
+def _set_answer_content(namespace: dict[str, Any], content: str) -> None:
+    answer = namespace.get("answer")
+    if not isinstance(answer, dict):
+        answer = {"content": "", "ready": False}
+        namespace["answer"] = answer
+    answer["content"] = content
+
+
+def _answer_content(namespace: dict[str, Any]) -> str:
+    answer = namespace.get("answer")
+    if not isinstance(answer, dict):
+        return ""
+    content = answer.get("content", "")
+    return content if isinstance(content, str) else str(content)
+
+
+def _snapshot_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return value[:500]
+    if isinstance(value, int | float | bool) or value is None:
+        return value
+    if isinstance(value, dict):
+        items = sorted(value.items(), key=lambda item: str(item[0]))[:25]
+        return {
+            "type": "dict",
+            "length": len(value),
+            "items": {str(k): _snapshot_value(v) for k, v in items},
+        }
+    if isinstance(value, list | tuple):
+        return {
+            "type": type(value).__name__,
+            "length": len(value),
+            "items": [_snapshot_value(item) for item in value[:10]],
+        }
+    if isinstance(value, set):
+        sample = sorted(repr(item)[:200] for item in value)[:10]
+        return {"type": "set", "length": len(value), "items": sample}
+    return {"type": type(value).__name__, "repr": repr(value)[:200]}
+
+
+def _progress_signature(namespace: dict[str, Any]) -> str:
+    values = {
+        str(key): _snapshot_value(value)
+        for key, value in sorted(namespace.items(), key=lambda item: str(item[0]))
+        if not str(key).startswith("__") and key not in {"get_history", "llm_batch"}
+    }
+    payload = {
+        "values": values,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=repr).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _turn_progress_signature(
+    *,
+    namespace: dict[str, Any],
+    code: str,
+    stdout: str,
+    error: str | None,
+) -> str:
+    payload = {
+        "namespace": _progress_signature(namespace),
+        "code": code,
+        "stdout": stdout,
+        "error": error or "",
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=repr).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def make_llm_batch(
@@ -103,6 +252,10 @@ class RlmSession:
         total_input = 0
         total_output = 0
         status = "completed"
+        finalize_reason = ""
+        last_observed_content = ""
+        no_progress_turns = 0
+        previous_no_progress_signature = ""
 
         def _get_history() -> list[dict[str, Any]]:
             return [
@@ -130,8 +283,26 @@ class RlmSession:
 
             assistant_text = response.text
             messages.append({"role": "assistant", "content": assistant_text})
+            if assistant_text.strip():
+                last_observed_content = assistant_text.strip()
+
+            marked_answer = _extract_final_answer_marker(assistant_text)
+            if marked_answer:
+                _set_answer_content(self._worker.namespace, marked_answer)
+                status = "soft_finalized"
+                finalize_reason = "final_answer_marker"
+                logger.info("RLM %s soft-finalized on turn %d via final-answer marker", self._role, turn)
+                break
 
             code = _extract_code_block(assistant_text)
+            natural_answer = _natural_closure_content(assistant_text)
+            if natural_answer is not None and (code is None or _is_read_only_code(code)):
+                _set_answer_content(self._worker.namespace, natural_answer)
+                status = "soft_finalized"
+                finalize_reason = "natural_language_closure"
+                logger.info("RLM %s soft-finalized on turn %d via natural closure", self._role, turn)
+                break
+
             if code is not None:
                 result = self._worker.run_code(ReplCommand(code))
 
@@ -142,6 +313,11 @@ class RlmSession:
                     error=result.error,
                     answer_ready=result.answer.get("ready", False),
                 ))
+                answer_content = _answer_content(self._worker.namespace)
+                if answer_content:
+                    last_observed_content = answer_content
+                elif result.stdout.strip():
+                    last_observed_content = result.stdout.strip()
 
                 # Build user feedback message
                 parts: list[str] = []
@@ -160,6 +336,35 @@ class RlmSession:
 
                 if result.answer.get("ready"):
                     logger.debug("RLM %s finished on turn %d", self._role, turn)
+                    finalize_reason = "answer_ready"
+                    break
+
+                no_progress_candidate = not result.stdout.strip() and result.error is None
+                current_progress_signature = _turn_progress_signature(
+                    namespace=self._worker.namespace,
+                    code=code,
+                    stdout=result.stdout,
+                    error=result.error,
+                )
+                if no_progress_candidate and current_progress_signature == previous_no_progress_signature:
+                    no_progress_turns += 1
+                elif no_progress_candidate:
+                    no_progress_turns = 1
+                    previous_no_progress_signature = current_progress_signature
+                else:
+                    no_progress_turns = 0
+                    previous_no_progress_signature = ""
+                if no_progress_turns >= _NO_PROGRESS_TURN_LIMIT and self._max_turns > _NO_PROGRESS_TURN_LIMIT:
+                    status = "soft_finalized"
+                    finalize_reason = "no_progress"
+                    if not _answer_content(self._worker.namespace) and last_observed_content:
+                        _set_answer_content(self._worker.namespace, last_observed_content)
+                    logger.info(
+                        "RLM %s soft-finalized on turn %d after %d no-progress turns",
+                        self._role,
+                        turn,
+                        no_progress_turns,
+                    )
                     break
             else:
                 # Model didn't emit code — nudge it
@@ -173,7 +378,9 @@ class RlmSession:
             logger.warning("RLM %s hit max_turns=%d without finalizing", self._role, self._max_turns)
 
         answer = self._worker.namespace.get("answer", {"content": "", "ready": False})
-        content = answer.get("content", "")
+        content = answer.get("content", "") if isinstance(answer, dict) else ""
+        if not content and last_observed_content:
+            content = last_observed_content
         elapsed_ms = int((time.perf_counter() - started) * 1000)
 
         return RoleExecution(
@@ -187,4 +394,5 @@ class RlmSession:
             ),
             subagent_id=uuid.uuid4().hex[:10],
             status=status,
+            metadata={"finalize_reason": finalize_reason} if finalize_reason else {},
         )

--- a/autocontext/src/autocontext/providers/runtime_bridge.py
+++ b/autocontext/src/autocontext/providers/runtime_bridge.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from autocontext.providers.base import CompletionResult, LLMProvider, ProviderError
 from autocontext.runtimes.base import AgentRuntime
+from autocontext.runtimes.errors import format_runtime_failure
 
 
 class RuntimeBridgeProvider(LLMProvider):
@@ -35,10 +36,7 @@ class RuntimeBridgeProvider(LLMProvider):
         )
         error = output.metadata.get("error") if output.metadata else None
         if error:
-            detail = ""
-            if output.metadata:
-                detail = str(output.metadata.get("detail") or output.metadata.get("stderr") or "")
-            raise ProviderError(f"{self._runtime.name} failed: {error}{f' ({detail})' if detail else ''}")
+            raise ProviderError(format_runtime_failure(self._runtime.name, output.metadata or {}))
         return CompletionResult(
             text=output.text,
             model=output.model or model or self._default_model_name,

--- a/autocontext/src/autocontext/rlm/prompts.py
+++ b/autocontext/src/autocontext/rlm/prompts.py
@@ -38,6 +38,8 @@ for s in summaries:
 
 The variable `answer` is pre-initialized as {{"content": "", "ready": False}}.
 Build your answer incrementally. When done, set answer["ready"] = True.
+If the REPL state is already sufficient and you cannot safely set the ready flag,
+you may instead wrap your final response in <final_answer>...</final_answer>.
 
 <code>
 answer["content"] = "## Findings\\n\\n- Key finding here..."
@@ -119,6 +121,8 @@ Returns a list of response strings.
 
 The variable `answer` is pre-initialized as {{"content": "", "ready": False}}.
 Build your answer incrementally. When done, set answer["ready"] = True.
+If the REPL state is already sufficient and you cannot safely set the ready flag,
+you may instead wrap your final response in <final_answer>...</final_answer>.
 
 <code>
 answer["content"] = "## Findings\\n\\n- Key finding here..."

--- a/autocontext/src/autocontext/runtimes/errors.py
+++ b/autocontext/src/autocontext/runtimes/errors.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def _format_seconds(value: object) -> str:
+    try:
+        seconds = float(str(value))
+    except (TypeError, ValueError):
+        return str(value)
+    if seconds.is_integer():
+        return f"{seconds:.0f}s"
+    return f"{seconds:.2f}s"
+
+
+def format_runtime_failure(runtime_name: str, metadata: Mapping[str, Any]) -> str:
+    """Build a stable runtime failure message from AgentOutput metadata."""
+    error = metadata.get("error")
+    details: list[str] = []
+    timeout_seconds = metadata.get("timeout_seconds")
+    if error == "timeout" and timeout_seconds is not None:
+        details.append(f"timed out after {_format_seconds(timeout_seconds)}")
+    raw_detail = metadata.get("detail") or metadata.get("stderr") or ""
+    if raw_detail:
+        details.append(str(raw_detail))
+    suffix = f" ({'; '.join(details)})" if details else ""
+    return f"{runtime_name} failed: {error}{suffix}"

--- a/autocontext/src/autocontext/runtimes/pi_cli.py
+++ b/autocontext/src/autocontext/runtimes/pi_cli.py
@@ -116,7 +116,10 @@ class PiCLIRuntime(AgentRuntime):
             )
         except subprocess.TimeoutExpired:
             logger.error("pi CLI timed out after %.0fs", self._config.timeout)
-            return AgentOutput(text="", metadata={"error": "timeout"})
+            return AgentOutput(
+                text="",
+                metadata={"error": "timeout", "timeout_seconds": self._config.timeout},
+            )
         except FileNotFoundError:
             logger.error("pi CLI not found at %r", self._config.pi_command)
             return AgentOutput(text="", metadata={"error": "pi_not_found"})

--- a/autocontext/src/autocontext/runtimes/pi_rpc.py
+++ b/autocontext/src/autocontext/runtimes/pi_rpc.py
@@ -214,7 +214,10 @@ class PiRPCRuntime(AgentRuntime):
             if process is not None:
                 process.kill()
                 process.wait(timeout=1.0)
-            return AgentOutput(text="", metadata={"error": "timeout"})
+            return AgentOutput(
+                text="",
+                metadata={"error": "timeout", "timeout_seconds": self._config.timeout},
+            )
         except FileNotFoundError:
             logger.error("pi CLI not found at %r", self._config.pi_command)
             return AgentOutput(text="", metadata={"error": "pi_not_found"})
@@ -483,7 +486,10 @@ class PiPersistentRPCRuntime(PiRPCRuntime):
         except subprocess.TimeoutExpired:
             logger.error("persistent pi RPC timed out after %.0fs", self._config.timeout)
             self.close()
-            return AgentOutput(text="", metadata={"error": "timeout"})
+            return AgentOutput(
+                text="",
+                metadata={"error": "timeout", "timeout_seconds": self._config.timeout},
+            )
         return self._parse_rpc_output(
             "".join(lines),
             exit_code=0,

--- a/autocontext/tests/test_cli_solve_runtime.py
+++ b/autocontext/tests/test_cli_solve_runtime.py
@@ -70,6 +70,27 @@ class _FailingSolveManager:
         )
 
 
+class _BudgetedFailingSolveManager:
+    def __init__(self, settings: AppSettings) -> None:
+        self._settings = settings
+
+    def solve_sync(
+        self,
+        description: str,
+        generations: int = 5,
+        family_override: str | None = None,
+    ) -> SolveJob:
+        del description, generations, family_override
+        return SolveJob(
+            job_id="solve_budget_fail",
+            description="Budgeted solve",
+            status="failed",
+            generations=1,
+            progress=0,
+            error="PiCLIRuntime failed: timeout (timed out after 60s)",
+        )
+
+
 class _FallbackSolveManager:
     def __init__(self, settings: AppSettings) -> None:
         self._settings = settings
@@ -198,6 +219,38 @@ class TestSolveRuntimeOverrides:
         assert "timed out" in payload["error"].lower()
         assert "--timeout" in payload["error"]
         assert "AUTOCONTEXT_PI_TIMEOUT" in payload["error"]
+
+    def test_solve_json_timeout_error_reports_effective_budgeted_role_timeout(self, tmp_path: Path) -> None:
+        settings = _settings(
+            tmp_path,
+            agent_provider="deterministic",
+            competitor_provider="pi-rpc",
+            pi_timeout=900.0,
+            generation_time_budget_seconds=60,
+        )
+
+        from unittest.mock import patch
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.knowledge.solver.SolveManager", _BudgetedFailingSolveManager),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "solve",
+                    "--description",
+                    "Budgeted solve",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stderr)
+        assert "timed out after 60s" in payload["error"]
+        assert "timed out after 900s" not in payload["error"]
+        assert "configured AUTOCONTEXT_PI_TIMEOUT=900s" in payload["error"]
+        assert "--generation-time-budget" in payload["error"]
 
     def test_solve_json_output_surfaces_classifier_fallback_flag(self, tmp_path: Path) -> None:
         settings = _settings(tmp_path)

--- a/autocontext/tests/test_pi_cli_runtime.py
+++ b/autocontext/tests/test_pi_cli_runtime.py
@@ -129,6 +129,7 @@ def test_generate_timeout() -> None:
             output = runtime.generate("test prompt")
     assert output.text == ""
     assert output.metadata.get("error") == "timeout"
+    assert output.metadata.get("timeout_seconds") == 5.0
 
 
 # ---------------------------------------------------------------------------
@@ -247,10 +248,13 @@ def test_runtime_bridge_client_delegates() -> None:
 def test_runtime_bridge_client_raises_on_runtime_error() -> None:
     mock_runtime = MagicMock()
     mock_runtime.name = "PiCLIRuntime"
-    mock_runtime.generate.return_value = AgentOutput(text="", metadata={"error": "timeout"})
+    mock_runtime.generate.return_value = AgentOutput(
+        text="",
+        metadata={"error": "timeout", "timeout_seconds": 60.0},
+    )
 
     client = RuntimeBridgeClient(mock_runtime)
-    with pytest.raises(RuntimeError, match="PiCLIRuntime failed: timeout"):
+    with pytest.raises(RuntimeError, match="PiCLIRuntime failed: timeout .*60s"):
         client.generate(model="ignored", prompt="test", max_tokens=100, temperature=0.5)
 
 

--- a/autocontext/tests/test_pi_rpc.py
+++ b/autocontext/tests/test_pi_rpc.py
@@ -155,6 +155,7 @@ def test_generate_timeout() -> None:
         output = runtime.generate("test")
     assert output.text == ""
     assert output.metadata.get("error") == "timeout"
+    assert output.metadata.get("timeout_seconds") == 0.01
     assert process.killed is True
 
 

--- a/autocontext/tests/test_rlm_session.py
+++ b/autocontext/tests/test_rlm_session.py
@@ -26,7 +26,7 @@ class TestRlmSession:
 
     def test_respects_max_turns(self) -> None:
         """When the model never sets ready=True, session should truncate."""
-        client = _NeverReadyClient()
+        client = _ChangingNeverReadyClient()
         worker = ReplWorker()
         session = RlmSession(
             client=client,
@@ -38,6 +38,80 @@ class TestRlmSession:
         )
         result = session.run()
         assert result.status == "truncated"
+
+    def test_soft_finalizes_explicit_final_answer_marker(self) -> None:
+        client = _StaticMultiturnClient("<final_answer>Y</final_answer>")
+        worker = ReplWorker()
+        session = RlmSession(
+            client=client,
+            worker=worker,
+            role="analyst",
+            model="test-model",
+            system_prompt="You are a test agent.",
+            max_turns=5,
+        )
+
+        result = session.run()
+
+        assert result.status == "soft_finalized"
+        assert result.content == "Y"
+        assert result.metadata["finalize_reason"] == "final_answer_marker"
+        assert len(session.execution_history) == 0
+
+    def test_soft_finalizes_natural_language_closure_without_ready_mutation(self) -> None:
+        client = _StaticMultiturnClient("I'm confident the answer is X")
+        worker = ReplWorker()
+        session = RlmSession(
+            client=client,
+            worker=worker,
+            role="analyst",
+            model="test-model",
+            system_prompt="You are a test agent.",
+            max_turns=5,
+        )
+
+        result = session.run()
+
+        assert result.status == "soft_finalized"
+        assert "X" in result.content
+        assert result.metadata["finalize_reason"] == "natural_language_closure"
+
+    def test_soft_finalizes_after_repeated_no_progress_turns(self) -> None:
+        client = _SilentNoProgressClient()
+        worker = ReplWorker()
+        session = RlmSession(
+            client=client,
+            worker=worker,
+            role="analyst",
+            model="test-model",
+            system_prompt="You are a test agent.",
+            max_turns=25,
+        )
+
+        result = session.run()
+
+        assert result.status == "soft_finalized"
+        assert result.metadata["finalize_reason"] == "no_progress"
+        assert len(session.execution_history) == 3
+        assert result.content
+
+    def test_distinct_read_only_inspection_turns_are_not_no_progress(self) -> None:
+        client = _DistinctInspectionClient()
+        worker = ReplWorker(namespace={"values": [1, 2, 3]})
+        session = RlmSession(
+            client=client,
+            worker=worker,
+            role="analyst",
+            model="test-model",
+            system_prompt="You are a test agent.",
+            max_turns=5,
+        )
+
+        result = session.run()
+
+        assert result.status == "truncated"
+        assert result.metadata.get("finalize_reason") != "no_progress"
+        assert len(session.execution_history) == 5
 
     def test_usage_aggregated_across_turns(self) -> None:
         client = DeterministicDevClient()
@@ -192,5 +266,69 @@ class _NeverReadyClient(LanguageModelClient):
     ) -> ModelResponse:
         return ModelResponse(
             text='<code>\nprint("still working")\n</code>',
+            usage=RoleUsage(input_tokens=10, output_tokens=10, latency_ms=1, model=model),
+        )
+
+
+class _ChangingNeverReadyClient(LanguageModelClient):
+    """Returns code that mutates state but never sets answer['ready']."""
+
+    def __init__(self) -> None:
+        self._turn = 0
+
+    def generate_multiturn(
+        self, *, model: str, system: str, messages: list[dict[str, str]],
+        max_tokens: int, temperature: float, role: str = "",
+    ) -> ModelResponse:
+        del system, messages, max_tokens, temperature, role
+        self._turn += 1
+        return ModelResponse(
+            text=f'<code>\nstate_{self._turn} = {self._turn}\nprint("turn {self._turn}")\n</code>',
+            usage=RoleUsage(input_tokens=10, output_tokens=10, latency_ms=1, model=model),
+        )
+
+
+class _SilentNoProgressClient(LanguageModelClient):
+    """Always returns identical silent no-op code."""
+
+    def generate_multiturn(
+        self, *, model: str, system: str, messages: list[dict[str, str]],
+        max_tokens: int, temperature: float, role: str = "",
+    ) -> ModelResponse:
+        return ModelResponse(
+            text="<code>\npass\n</code>",
+            usage=RoleUsage(input_tokens=10, output_tokens=10, latency_ms=1, model=model),
+        )
+
+
+class _DistinctInspectionClient(LanguageModelClient):
+    """Returns read-only inspection code that makes observable progress."""
+
+    def __init__(self) -> None:
+        self._turn = 0
+
+    def generate_multiturn(
+        self, *, model: str, system: str, messages: list[dict[str, str]],
+        max_tokens: int, temperature: float, role: str = "",
+    ) -> ModelResponse:
+        del system, messages, max_tokens, temperature, role
+        self._turn += 1
+        return ModelResponse(
+            text=f'<code>\nprint("inspection {self._turn}", values[{(self._turn - 1) % 3}])\n</code>',
+            usage=RoleUsage(input_tokens=10, output_tokens=10, latency_ms=1, model=model),
+        )
+
+
+class _StaticMultiturnClient(LanguageModelClient):
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def generate_multiturn(
+        self, *, model: str, system: str, messages: list[dict[str, str]],
+        max_tokens: int, temperature: float, role: str = "",
+    ) -> ModelResponse:
+        del system, messages, max_tokens, temperature, role
+        return ModelResponse(
+            text=self._text,
             usage=RoleUsage(input_tokens=10, output_tokens=10, latency_ms=1, model=model),
         )

--- a/autocontext/tests/test_rubric_drift_calibration.py
+++ b/autocontext/tests/test_rubric_drift_calibration.py
@@ -497,6 +497,68 @@ class TestRubricDriftMonitor:
         assert "dimension_correlation_high" in warning_types
         assert any(warning.metadata.get("dimension") == "factuality" for warning in warnings)
 
+    def test_detects_within_generation_dimension_variance_zero_streak(self) -> None:
+        from autocontext.analytics.rubric_drift import RubricDriftMonitor
+
+        trajectory = [
+            {
+                "generation_index": 1,
+                "dimension_summary": {
+                    "dimension_means": {"defender_survival": 1.0},
+                    "best_dimensions": {"defender_survival": 1.0},
+                },
+            },
+            {
+                "generation_index": 2,
+                "dimension_summary": {
+                    "dimension_means": {"defender_survival": 0.985},
+                    "best_dimensions": {"defender_survival": 0.985},
+                },
+            },
+            {
+                "generation_index": 3,
+                "dimension_summary": {
+                    "dimension_means": {"defender_survival": 0.971},
+                    "best_dimensions": {"defender_survival": 0.971},
+                },
+            },
+        ]
+
+        snapshot = RubricDriftMonitor().compute_dimension_snapshot("run-within", trajectory)
+        warnings = RubricDriftMonitor().detect_dimension_drift(snapshot)
+        within_gen_warnings = [
+            warning for warning in warnings
+            if warning.warning_type == "dimension_within_gen_variance_zero"
+        ]
+
+        assert within_gen_warnings
+        assert within_gen_warnings[0].metadata["dimension"] == "defender_survival"
+        assert within_gen_warnings[0].metadata["streak"] == 3
+
+    def test_default_dimension_decline_threshold_catches_slow_ac268_sized_drift(self) -> None:
+        from autocontext.analytics.rubric_drift import DriftThresholds, RubricDriftMonitor
+
+        trajectory = [
+            {
+                "generation_index": 1,
+                "dimension_summary": {"dimension_means": {"defender_survival": 1.0}},
+            },
+            {
+                "generation_index": 2,
+                "dimension_summary": {"dimension_means": {"defender_survival": 0.974}},
+            },
+            {
+                "generation_index": 3,
+                "dimension_summary": {"dimension_means": {"defender_survival": 0.948}},
+            },
+        ]
+
+        assert DriftThresholds().max_dimension_decline == 0.04
+        snapshot = RubricDriftMonitor().compute_dimension_snapshot("run-slow-decline", trajectory)
+        warnings = RubricDriftMonitor().detect_dimension_drift(snapshot)
+
+        assert any(warning.warning_type == "dimension_score_decline" for warning in warnings)
+
     def test_analyze_combines_snapshot_and_warnings(self) -> None:
         from autocontext.analytics.rubric_drift import (
             DriftThresholds,

--- a/ts/src/simulation/variant-materializer.ts
+++ b/ts/src/simulation/variant-materializer.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { generateScenarioSource } from "../scenarios/codegen/registry.js";
 import { validateGeneratedScenario } from "../scenarios/codegen/execution-validator.js";
+import { designSchemaEvolution } from "../scenarios/schema-evolution-designer.js";
 import type { ScenarioFamilyName } from "../scenarios/families.js";
 import { healSpec } from "../scenarios/spec-auto-heal.js";
 import type { LLMProvider } from "../types/index.js";
@@ -63,6 +64,19 @@ export async function buildSimulationSpec(opts: {
     opts.variables && Object.keys(opts.variables).length > 0
       ? JSON.stringify(opts.variables, null, 2)
       : "";
+  if (opts.family === "schema_evolution") {
+    const description = serializedVariables
+      ? `${opts.description}\n\nRequested simulation parameters:\n${serializedVariables}`
+      : opts.description;
+    return designSchemaEvolution(description, async (systemPrompt, userPrompt) => {
+      const result = await opts.provider.complete({
+        systemPrompt,
+        userPrompt,
+      });
+      return result.text;
+    }) as unknown as Record<string, unknown>;
+  }
+
   const systemPrompt = `You are a simulation designer. Given a plain-language description, produce a ${opts.family} spec as a JSON object.
 
 Required fields:

--- a/ts/tests/simulation-schema-evolution-simulate.test.ts
+++ b/ts/tests/simulation-schema-evolution-simulate.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { SimulationEngine } from "../src/simulation/engine.js";
+import type { LLMProvider } from "../src/types/index.js";
+
+const AC277_PROMPT =
+  "Harness Stress Test AC-277: portfolio construction under macroeconomic regime change with schema evolution. " +
+  "Manage allocations across equities, bonds, cash, commodities, and hedges while regimes shift from expansion to inflation shock to recession. " +
+  "Track Sharpe, drawdown, exposure limits, turnover, regime detection speed, delayed effects, breaking schema mutations, stale-assumption detection, " +
+  "and adaptation speed after each mutation.";
+
+function genericZeroMutationSpec(): string {
+  return JSON.stringify({
+    description: "Portfolio construction under macro regime change",
+    environment_description: "Portfolio optimizer with changing market data payloads",
+    initial_state_description: "Expansion regime with v1 allocation metrics",
+    success_criteria: ["adapt allocations", "detect stale assumptions"],
+    failure_modes: ["uses stale fields"],
+    max_steps: 6,
+    actions: [
+      {
+        name: "inspect_market_payload",
+        description: "Inspect the latest market payload",
+        parameters: {},
+        preconditions: [],
+        effects: ["payload_seen"],
+      },
+      {
+        name: "rebalance_portfolio",
+        description: "Rebalance after schema review",
+        parameters: {},
+        preconditions: ["payload_seen"],
+        effects: ["portfolio_rebalanced"],
+      },
+    ],
+    mutations: [],
+  });
+}
+
+function schemaEvolutionSpec(mutations: unknown[]): string {
+  return `<!-- SCHEMA_EVOLUTION_SPEC_START -->
+${JSON.stringify({
+  description: "Portfolio construction under macro regime change with evolving schemas",
+  environment_description: "Risk and allocation feeds change shape as regimes shift",
+  initial_state_description: "v1 feed reports sharpe, drawdown, and exposure limits",
+  mutations,
+  success_criteria: [
+    "detect each schema version change",
+    "discard stale assumptions after breaking mutations",
+  ],
+  failure_modes: ["continues to read removed fields", "ignores regime-specific payload changes"],
+  max_steps: 6,
+  actions: [
+    {
+      name: "inspect_market_payload",
+      description: "Inspect the latest market payload",
+      parameters: {},
+      preconditions: [],
+      effects: ["payload_seen"],
+    },
+    {
+      name: "rebalance_portfolio",
+      description: "Rebalance after schema review",
+      parameters: {},
+      preconditions: ["payload_seen"],
+      effects: ["portfolio_rebalanced"],
+    },
+  ],
+})}
+<!-- SCHEMA_EVOLUTION_SPEC_END -->`;
+}
+
+function providerForSchemaDesigner(text: string): LLMProvider {
+  return {
+    name: "test-pi",
+    defaultModel: () => "test-model",
+    complete: async ({ systemPrompt }) => {
+      if (systemPrompt.includes("SchemaEvolutionSpec")) {
+        return { text };
+      }
+      return { text: genericZeroMutationSpec() };
+    },
+  };
+}
+
+describe("schema-evolution simulate materialization", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ac-schema-sim-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("uses the schema-evolution designer and persists real AC-277 mutations", async () => {
+    const provider = providerForSchemaDesigner(
+      schemaEvolutionSpec([
+        {
+          version: 2,
+          description: "Inflation shock renames exposure_limit to risk_budget",
+          breaking: true,
+          fields_added: ["risk_budget"],
+          fields_removed: ["exposure_limit"],
+          fields_modified: { turnover: "daily_number -> rolling_window_object" },
+        },
+        {
+          version: 3,
+          description: "Recession feed removes sharpe and adds downside_capture",
+          breaking: true,
+          fields_added: ["downside_capture"],
+          fields_removed: ["sharpe"],
+          fields_modified: { drawdown: "percent -> basis_points" },
+        },
+      ]),
+    );
+
+    const result = await new SimulationEngine(provider, tmpDir).run({
+      description: AC277_PROMPT,
+      saveAs: "ac277_schema_evolution",
+      runs: 1,
+      maxSteps: 4,
+    });
+
+    expect(result.status).not.toBe("failed");
+    expect(result.family).toBe("schema_evolution");
+
+    const specPath = join(tmpDir, "_simulations", "ac277_schema_evolution", "spec.json");
+    const spec = JSON.parse(readFileSync(specPath, "utf-8")) as { mutations?: unknown[] };
+    expect(spec.mutations).toHaveLength(2);
+    expect(
+      spec.mutations?.some(
+        (mutation) =>
+          typeof mutation === "object" &&
+          mutation !== null &&
+          (mutation as { breaking?: unknown }).breaking === true,
+      ),
+    ).toBe(true);
+  });
+
+  it("fails before persisting schema-evolution artifacts when mutations are empty", async () => {
+    const provider = providerForSchemaDesigner(schemaEvolutionSpec([]));
+
+    const result = await new SimulationEngine(provider, tmpDir).run({
+      description: AC277_PROMPT,
+      saveAs: "ac277_empty_mutations",
+      runs: 1,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatch(/mutations/i);
+    expect(
+      existsSync(join(tmpDir, "_simulations", "ac277_empty_mutations", "spec.json")),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- fix TS schema_evolution simulate to use the family-specific designer and reject zero-mutation specs before artifact persistence
- report effective Pi CLI/RPC timeout in runtime bridge and solve JSON errors, including generation-budget guidance
- add RLM soft-finalization heuristics and prompt fallback final-answer tags
- add dimension within-generation variance-zero drift warning and lower default dimension decline threshold

## Linear
- Fixes AC-694
- Fixes AC-695
- Addresses AC-696
- Addresses AC-686 follow-up tightening

## Tests
- npm test -- --run tests/simulation-schema-evolution-simulate.test.ts tests/simulation-variant-materializer.test.ts tests/simulate-execution-workflow.test.ts
- npm run lint
- npm run build
- uv run --frozen pytest tests/test_rlm_session.py tests/test_rubric_drift_calibration.py tests/test_cli_solve_runtime.py tests/test_pi_cli_runtime.py tests/test_pi_rpc.py -q
- uv run --frozen pytest tests/test_module_size_limits.py -q
- targeted ruff/mypy on touched Python files
- git diff --check

## Notes
- AC-270 live claude-cli ecosystem validation is not run locally; this PR includes unit coverage for the convergence modes and leaves that as the live validation gate.