### PR TITLE
Bump packages for 0.4.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.9] - 2026-04-30
+
+### Fixed
+
+- TypeScript `simulate` now uses the schema-evolution scenario designer for schema-evolution prompts and rejects zero-mutation generated specs before persistence (AC-694).
+- Python Pi/Pi-RPC budget errors now report the effective bounded role timeout instead of the original unbounded Pi timeout (AC-695).
+- RLM sessions can soft-finalize from explicit final-answer tags, cautious natural-language closure cues, and repeated silent no-progress turns, while preserving real inspection progress (AC-696).
+- Rubric drift monitoring now flags within-generation mean-versus-best compression and catches slower dimension decline patterns (AC-686).
+
+### Changed
+
+- Python `autocontext` and TypeScript `autoctx` package metadata are bumped to `0.4.9`.
+- Pi `pi-autocontext` package metadata is bumped to `0.2.3` while intentionally keeping its `autoctx` dependency one package behind at `^0.4.8`.
+
 ## [0.4.8] - 2026-04-30
 
 ### Fixed
@@ -308,7 +322,8 @@ All notable changes to this project will be documented in this file.
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
-[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.8...HEAD
+[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.9...HEAD
+[0.4.9]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.8...py-v0.4.9
 [0.4.8]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.7...py-v0.4.8
 [0.4.7]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.6...py-v0.4.7
 [0.4.6]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.5...py-v0.4.6

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Autocontext is a harness. You point it at a goal in plain language. It iterates 
 The fastest path uses our **Pi runtime**, a local coding agent that handles its own auth. No API key plumbing, no provider config: install Pi, install autocontext, point one at the other.
 
 ```bash
-uv tool install autocontext==0.4.8
+uv tool install autocontext==0.4.9
 
 AUTOCONTEXT_AGENT_PROVIDER=pi \
 AUTOCONTEXT_PI_COMMAND=pi \
@@ -36,7 +36,7 @@ Pi runs locally as a subprocess and emits live traces back into the harness. For
 Prefer TypeScript? Same surface, same command:
 
 ```bash
-bun add -g autoctx@0.4.8
+bun add -g autoctx@0.4.9
 AUTOCONTEXT_AGENT_PROVIDER=pi bunx autoctx solve \
   --description "improve customer-support replies for billing disputes" \
   --gens 5 --json
@@ -197,14 +197,14 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 ```
 
 <!-- autocontext-whats-new:start -->
-## What's New in 0.4.8
+## What's New in 0.4.9
 
-- **Anthropic SDK instrumentation** in Python and TypeScript: wrap any existing Anthropic client with `instrument_client` / `instrumentClient` to capture streaming and non-streaming production traces.
-- **TypeScript `autoctx solve` CLI** brings one-command scenario generation and execution to full parity with Python.
-- **`autoctx build-dataset` filters** (`--provider`, `--app`, `--env`, `--outcome`) turn captured production traces into scoped training datasets.
-- **CUDA training backend** alongside MLX, so distillation is no longer Apple Silicon only.
-- **Semantic prompt compaction** with tail-preserving reducers for longer sessions.
-- **Hierarchical investigation evidence** with artifact drill-down for richer diagnosis traces.
+- **Pi-shaped scenario hardening** keeps schema-evolution simulations from persisting empty mutation plans and improves recovery from Pi-style JSON wrappers.
+- **Budgeted Pi/Pi-RPC role calls** now report effective bounded timeouts and clean up one-shot persistent clients after use.
+- **RLM convergence guards** capture explicit final-answer tags, cautious closure cues, and repeated silent no-progress cases without stealing normal inspection turns.
+- **Rubric drift monitoring** now catches within-generation mean-versus-best compression and slower dimension decline.
+- **Task-like solve lifecycle metadata** separates persisted generations from improvement rounds for hook consumers.
+- **Pi extension release alignment** keeps `pi-autocontext` one package behind `autoctx` while publishing the next extension patch.
 <!-- autocontext-whats-new:end -->
 
 ## Choose Your Package
@@ -219,11 +219,11 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 
 ```bash
 # Python: library or CLI tool
-uv pip install autocontext==0.4.8
-uv tool install autocontext==0.4.8
+uv pip install autocontext==0.4.9
+uv tool install autocontext==0.4.9
 
 # TypeScript
-bun add -g autoctx@0.4.8
+bun add -g autoctx@0.4.9
 
 # Pi extension
 pi install npm:pi-autocontext

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -10,7 +10,7 @@ The intended use is to hand the harness a real task in plain language, let it so
 pip install autocontext
 ```
 
-The current PyPI release line is `autocontext==0.4.8`.
+The current PyPI release line is `autocontext==0.4.9`.
 The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
 
 ## Working Directory

--- a/autocontext/assets/whats_new.txt
+++ b/autocontext/assets/whats_new.txt
@@ -1,6 +1,6 @@
-**Anthropic SDK instrumentation** in Python and TypeScript: wrap any existing Anthropic client with `instrument_client` / `instrumentClient` to capture streaming and non-streaming production traces.
-**TypeScript `autoctx solve` CLI** brings one-command scenario generation and execution to full parity with Python.
-**`autoctx build-dataset` filters** (`--provider`, `--app`, `--env`, `--outcome`) turn captured production traces into scoped training datasets.
-**CUDA training backend** alongside MLX, so distillation is no longer Apple Silicon only.
-**Semantic prompt compaction** with tail-preserving reducers for longer sessions.
-**Hierarchical investigation evidence** with artifact drill-down for richer diagnosis traces.
+**Pi-shaped scenario hardening** keeps schema-evolution simulations from persisting empty mutation plans and improves recovery from Pi-style JSON wrappers.
+**Budgeted Pi/Pi-RPC role calls** now report effective bounded timeouts and clean up one-shot persistent clients after use.
+**RLM convergence guards** capture explicit final-answer tags, cautious closure cues, and repeated silent no-progress cases without stealing normal inspection turns.
+**Rubric drift monitoring** now catches within-generation mean-versus-best compression and slower dimension decline.
+**Task-like solve lifecycle metadata** separates persisted generations from improvement rounds for hook consumers.
+**Pi extension release alignment** keeps `pi-autocontext` one package behind `autoctx` while publishing the next extension patch.

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autocontext"
-version = "0.4.8"
+version = "0.4.9"
 description = "autocontext control plane for iterative strategy evolution."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/autocontext/src/autocontext/__init__.py
+++ b/autocontext/src/autocontext/__init__.py
@@ -5,4 +5,4 @@ from autocontext.sdk import AutoContext
 
 __all__ = ["AutoContext", "ExtensionAPI", "HookBus", "HookEvents", "HookResult", "__version__"]
 
-__version__ = "0.4.8"
+__version__ = "0.4.9"

--- a/autocontext/src/autocontext/banner.py
+++ b/autocontext/src/autocontext/banner.py
@@ -22,7 +22,7 @@ SYNC_BLOCK_START = "<!-- autocontext-readme-hero:start -->"
 SYNC_BLOCK_END = "<!-- autocontext-readme-hero:end -->"
 WHATS_NEW_BLOCK_START = "<!-- autocontext-whats-new:start -->"
 WHATS_NEW_BLOCK_END = "<!-- autocontext-whats-new:end -->"
-README_WHATS_NEW_HEADING = "What's New in 0.4.8"
+README_WHATS_NEW_HEADING = "What's New in 0.4.9"
 README_BADGES = (
     (
         "https://github.com/greyhaven-ai/autocontext/blob/main/LICENSE",

--- a/autocontext/uv.lock
+++ b/autocontext/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "autocontext"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,6 +1,6 @@
 # Release Checklist
 
-Use this checklist when preparing a tagged release such as `py-v0.4.8`, `ts-v0.4.8`, or `pi-v0.2.2`.
+Use this checklist when preparing a tagged release such as `py-v0.4.9`, `ts-v0.4.9`, or `pi-v0.2.3`.
 
 ## 1. Decide Scope
 

--- a/pi/package-lock.json
+++ b/pi/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "pi-autocontext",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-autocontext",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
-        "autoctx": "^0.4.7"
+        "autoctx": "^0.4.8"
       },
       "devDependencies": {
         "@sinclair/typebox": "^0.34.0",
@@ -3310,9 +3310,9 @@
       }
     },
     "node_modules/autoctx": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/autoctx/-/autoctx-0.4.7.tgz",
-      "integrity": "sha512-MgeX3Yij3Juqzk6fT0XgIFAcwvssjeWDIDN07K8X1XRgwq+7Cscq3h+/Cct+hT04Wxf0iDCOGvvgPKBjk35OmQ==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/autoctx/-/autoctx-0.4.8.tgz",
+      "integrity": "sha512-xzKZpTtmkC538yy4u53DtfFHIpT7qXB1Xk59+8h/w3gMG/EeB5F2z2kQHFWdMHZmXKRnxTtfMl5FrNTNeyIw4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",

--- a/pi/package.json
+++ b/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-autocontext",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "autocontext extension for Pi coding agent \u2014 iterative strategy generation, LLM judging, and evaluation tools",
   "type": "module",
   "keywords": ["pi-package", "pi", "pi-extension", "autocontext", "autoctx", "evaluation", "llm", "judging"],
@@ -18,7 +18,7 @@
     "@sinclair/typebox": "*"
   },
   "dependencies": {
-    "autoctx": "^0.4.7"
+    "autoctx": "^0.4.8"
   },
   "devDependencies": {
     "@sinclair/typebox": "^0.34.0",

--- a/pi/tests/extension.test.ts
+++ b/pi/tests/extension.test.ts
@@ -323,7 +323,7 @@ describe("Package manifest", () => {
 
   it("depends on the current autoctx toolkit line", () => {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-    expect(pkg.dependencies.autoctx).toBe("^0.4.7");
+    expect(pkg.dependencies.autoctx).toBe("^0.4.8");
   });
 });
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -53,7 +53,7 @@ export function register(api) {
 npm install autoctx
 ```
 
-The current npm release line is `autoctx@0.4.8`.
+The current npm release line is `autoctx@0.4.9`.
 Important: use `autoctx`, not `autocontext`.
 `autocontext` on npm is a different package and not this project.
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoctx",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoctx",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
@@ -19,7 +19,7 @@
         "ignore": "5.3.2",
         "ink": "^5.1.0",
         "ink-text-input": "^6.0.0",
-        "openai": "^4.104.0",
+        "openai": "^4",
         "react": "^18.3.1",
         "secure-exec": "^0.1.0",
         "tree-sitter": "0.21.1",
@@ -49,9 +49,13 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
+        "@anthropic-ai/sdk": "^0.32",
         "openai": "^4"
       },
       "peerDependenciesMeta": {
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
         "openai": {
           "optional": true
         }

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoctx",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump Python autocontext and TypeScript autoctx to 0.4.9
- bump pi-autocontext to 0.2.3 while keeping autoctx one patch behind at ^0.4.8
- update changelog, README release notes, lockfiles, and Pi package expectation test

## Verification
- uv run --frozen pytest tests/test_banner_sync.py tests/test_module_size_limits.py -q
- uv build
- uv run --frozen python -c "import autocontext; print(autocontext.__version__)"
- npm run lint (ts)
- npm run build (ts)
- npm pack --dry-run (ts)
- npm run lint (pi)
- npm test (pi)
- npm run build (pi)
- npm pack --dry-run (pi)
- npm ci --ignore-scripts (ts, pi)

Note: full local ts npm test was run and exposed unrelated existing/local-environment failures in cross-runtime Python uv subprocesses, local 5s CLI timeouts, and the existing type assertion budget; publish-ts does not run that suite.