### PR TITLE
Unify autoctx CLI continuity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Python and TypeScript `autoctx solve` now accept the plain-language goal as a positional argument while keeping `--description` as a named option.
+- Python and TypeScript `solve`/`run` commands now accept `--iterations` as the plain-language alias for `--gens`.
+- Python and TypeScript `autoctx run <scenario>` now accept a positional scenario while keeping `--scenario` for scripts.
+- Python and TypeScript `autoctx export <run-id>` now export knowledge from a specific run while keeping scenario-level export support.
+- TypeScript CLI/TUI help now uses the same plain-language run vocabulary, including `status <run-id>`, `show <run-id> --best`, and `watch <run-id>`.
+
+### Fixed
+
+- Python installed `autoctx` no longer crashes on no-args startup when packaged banner assets are missing.
+
 ## [0.4.9] - 2026-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ uv tool install autocontext==0.4.9
 AUTOCONTEXT_AGENT_PROVIDER=pi \
 AUTOCONTEXT_PI_COMMAND=pi \
 uv run autoctx solve \
-  --description "improve customer-support replies for billing disputes" \
-  --gens 3
+  "improve customer-support replies for billing disputes" \
+  --iterations 3
 ```
 
 Pi runs locally as a subprocess and emits live traces back into the harness. For a hosted Pi, set `AUTOCONTEXT_AGENT_PROVIDER=pi-rpc` and `AUTOCONTEXT_PI_RPC_ENDPOINT` instead.
@@ -38,8 +38,8 @@ Prefer TypeScript? Same surface, same command:
 ```bash
 bun add -g autoctx@0.4.9
 AUTOCONTEXT_AGENT_PROVIDER=pi bunx autoctx solve \
-  --description "improve customer-support replies for billing disputes" \
-  --gens 5 --json
+  "improve customer-support replies for billing disputes" \
+  --iterations 5 --json
 ```
 
 Already on Anthropic, OpenAI, Gemini, Mistral, Groq, OpenRouter, Azure, Claude CLI, Codex CLI, or MLX? Set `AUTOCONTEXT_AGENT_PROVIDER` and the matching credential env var:
@@ -47,7 +47,7 @@ Already on Anthropic, OpenAI, Gemini, Mistral, Groq, OpenRouter, Azure, Claude C
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=anthropic \
 ANTHROPIC_API_KEY=sk-ant-... \
-uv run autoctx solve --description "..." --gens 3
+uv run autoctx solve "..." --iterations 3
 ```
 
 See [`.env.example`](.env.example) for every provider's variables. Prefer to clone and run a starter? [`examples/README.md`](examples/README.md) has copy-paste recipes for Python CLI, Claude Code MCP, Python SDK, and TypeScript library usage.
@@ -235,14 +235,14 @@ pi install npm:pi-autocontext
 
 | Surface       | Command                                            | When to use it                                                                         |
 | ------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `solve`       | `autoctx solve --description "..." --gens 3`       | Hand the harness a goal in plain language; it generates the scenario and runs the loop |
-| `run`         | `autoctx run --scenario <name> --gens 3`           | Improve behavior inside a saved scenario across generations                            |
+| `solve`       | `autoctx solve "..." --iterations 3`               | Hand the harness a goal in plain language; it generates the scenario and runs the loop |
+| `run`         | `autoctx run <scenario> --iterations 3`            | Improve behavior inside a saved scenario across generations                            |
 | `simulate`    | `autoctx simulate -d "..."`                        | Model a system, sweep parameters, replay, compare                                      |
 | `investigate` | `autoctx investigate -d "..."`                     | Evidence-driven diagnosis, either synthetic harness or live iterative LLM session      |
 | `analyze`     | `autoctx analyze --id <id> --type <kind>`          | Inspect or compare runs, simulations, investigations, or missions after the fact       |
 | `mission`     | `autoctx mission create --name "..." --goal "..."` | Verifier-driven goal advanced step by step until done                                  |
 | `campaign`    | `bunx autoctx campaign ...` (TypeScript)           | Coordinate multiple missions with budgets, dependencies, progress aggregation          |
-| `export`      | `uv run autoctx export --scenario <name> --format pi-package` (Python) | Share solved knowledge as JSON, skills, or Pi-local package directories                |
+| `export`      | `autoctx export <run-id>`                          | Share solved knowledge as JSON, skills, or Pi-local package directories                |
 | `train`       | `autoctx train --scenario <name> --data <jsonl>`   | Distill stable exported data into a cheaper local runtime                              |
 | `replay`      | `autoctx replay <run_id> --generation N`           | Inspect what happened before deciding what knowledge should persist                    |
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -63,7 +63,7 @@ Run a deterministic local scenario:
 
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=deterministic \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
 
 Run with Anthropic:
@@ -71,7 +71,7 @@ Run with Anthropic:
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=anthropic \
 ANTHROPIC_API_KEY=... \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
 
 `ANTHROPIC_API_KEY` is the preferred Anthropic credential env var. `AUTOCONTEXT_ANTHROPIC_API_KEY` remains supported as a compatibility alias.
@@ -82,7 +82,7 @@ Run with Claude CLI (`claude -p` via a local authenticated Claude Code runtime):
 AUTOCONTEXT_AGENT_PROVIDER=claude-cli \
 AUTOCONTEXT_CLAUDE_MODEL=sonnet \
 AUTOCONTEXT_CLAUDE_TIMEOUT=300 \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
 
 For longer live prompts, `autoctx solve`, `autoctx judge`, and `autoctx improve` all accept `--timeout <seconds>`. `autoctx solve` also accepts `--generation-time-budget <seconds>` to cap per-generation solve runtime. You can still use provider env vars such as `AUTOCONTEXT_CLAUDE_TIMEOUT`, `AUTOCONTEXT_CLAUDE_MAX_RETRIES`, `AUTOCONTEXT_CLAUDE_MAX_TOTAL_SECONDS`, or `AUTOCONTEXT_PI_TIMEOUT`.
@@ -92,7 +92,7 @@ Run with Codex CLI (`codex exec` via a local authenticated Codex runtime):
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=codex \
 AUTOCONTEXT_CODEX_MODEL=o4-mini \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
 
 Run with Pi CLI (local Pi agent runtime):
@@ -100,7 +100,7 @@ Run with Pi CLI (local Pi agent runtime):
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=pi \
 AUTOCONTEXT_PI_COMMAND=pi \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
 
 `autoctx simulate` now follows the effective architect-role runtime surface, so `AUTOCONTEXT_ARCHITECT_PROVIDER`, other role-routing overrides, and per-call `--provider <name>` overrides all apply to live simulation generation.
@@ -112,7 +112,7 @@ Run with Pi RPC (local Pi subprocess using `pi --mode rpc` JSONL):
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=pi-rpc \
 AUTOCONTEXT_PI_COMMAND=pi \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
 
 For deterministic evals where Pi should ignore repo-local `AGENTS.md` / `CLAUDE.md`, add:
@@ -137,7 +137,7 @@ AUTOCONTEXT_AGENT_PROVIDER=openai-compatible \
 AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1 \
 AUTOCONTEXT_AGENT_API_KEY=no-key \
 AUTOCONTEXT_AGENT_DEFAULT_MODEL=hermes-3-llama-3.1-8b \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
 
 Start the API server:
@@ -158,7 +158,7 @@ uv run autoctx mcp-serve
 ## Main CLI Commands
 
 ```bash
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 uv run autoctx simulate --description "simulate deploying a web service with rollback"
 uv run autoctx simulate --description "simulate deploying a web service with rollback" --provider claude-cli
 uv run autoctx investigate --description "why did conversion drop after Tuesday's release"
@@ -170,7 +170,7 @@ uv run autoctx simulate --replay deploy_sim --variables threshold=0.9
 uv run autoctx list
 uv run autoctx status <run_id>
 uv run autoctx replay <run_id> --generation 1
-uv run autoctx run --scenario support_triage --gens 3
+uv run autoctx run support_triage --iterations 3
 uv run autoctx benchmark --scenario support_triage --runs 5
 uv run autoctx new-scenario --template prompt-optimization --name support_triage
 uv run autoctx export-training-data --scenario support_triage --all-runs --output training/support_triage.jsonl
@@ -186,17 +186,17 @@ Useful variants:
 
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=anthropic ANTHROPIC_API_KEY=... \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 
 AUTOCONTEXT_AGENT_PROVIDER=anthropic \
 ANTHROPIC_API_KEY=sk-ant-primary \
 AUTOCONTEXT_COMPETITOR_PROVIDER=openai-compatible \
 AUTOCONTEXT_COMPETITOR_API_KEY=sk-role \
 AUTOCONTEXT_COMPETITOR_BASE_URL=http://localhost:8000/v1 \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 
 AUTOCONTEXT_AGENT_PROVIDER=deterministic AUTOCONTEXT_RLM_ENABLED=true \
-uv run autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
 
 ## Training Workflow
@@ -269,7 +269,7 @@ Semantic prompt compactions are also persisted as Pi-shaped JSONL entries at
 Solved strategy packages can also be exported as Pi-local package directories:
 
 ```bash
-uv run autoctx export --scenario grid_ctf --format pi-package --output grid-ctf-pi-package
+uv run autoctx export <run_id> --format pi-package --output grid-ctf-pi-package
 ```
 
 The directory contains `package.json`, a Pi skill, a prompt file, and the original `autocontext.package.json` strategy payload for re-import.

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -26,8 +26,8 @@ Most `autoctx` commands accept a `--json` flag that switches output to structure
 # Structured JSON to stdout
 autoctx list --json
 autoctx status <run_id> --json
-autoctx run --scenario grid_ctf --gens 3 --json
-autoctx export --scenario grid_ctf --json
+autoctx run grid_ctf --iterations 3 --json
+autoctx export <run_id> --json
 autoctx train --scenario grid_ctf --data data.jsonl --json
 ```
 
@@ -44,10 +44,10 @@ autoctx train --scenario grid_ctf --data data.jsonl --json
 
 ```bash
 # Game scenario (tournament-based)
-autoctx run --scenario grid_ctf --gens 5 --run-id my_run --json
+autoctx run grid_ctf --iterations 5 --run-id my_run --json
 
 # Agent task scenario (judge-based evaluation)
-autoctx run --scenario my_agent_task --gens 3 --json
+autoctx run my_agent_task --iterations 3 --json
 ```
 
 JSON output shape:
@@ -157,7 +157,7 @@ JSON output shape on timeout:
 #### `autoctx export` — Export a strategy package
 
 ```bash
-autoctx export --scenario grid_ctf --output pkg.json --json
+autoctx export <run_id> --output pkg.json --json
 ```
 
 JSON output shape:
@@ -247,26 +247,26 @@ Configure which LLM provider autocontext uses via environment variables:
 # Anthropic (default)
 AUTOCONTEXT_AGENT_PROVIDER=anthropic \
 ANTHROPIC_API_KEY=sk-ant-... \
-autoctx run --scenario my_task --json
+autoctx run my_task --json
 
 # OpenAI-compatible
 AUTOCONTEXT_AGENT_PROVIDER=openai-compatible \
 AUTOCONTEXT_JUDGE_PROVIDER=openai-compatible \
 AUTOCONTEXT_JUDGE_API_KEY=sk-... \
 AUTOCONTEXT_JUDGE_BASE_URL=https://api.openai.com/v1 \
-autoctx run --scenario my_task --json
+autoctx run my_task --json
 
 # Ollama (local, no API key needed)
 AUTOCONTEXT_AGENT_PROVIDER=ollama \
 AUTOCONTEXT_JUDGE_PROVIDER=ollama \
-autoctx run --scenario my_task --json
+autoctx run my_task --json
 
 # Hermes (via OpenAI-compatible gateway)
 AUTOCONTEXT_AGENT_PROVIDER=openai-compatible \
 AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1 \
 AUTOCONTEXT_AGENT_API_KEY=hermes-key \
 AUTOCONTEXT_AGENT_DEFAULT_MODEL=hermes-3-llama-3.1-8b \
-autoctx run --scenario my_task --json
+autoctx run my_task --json
 
 # Hermes for both agent and judge
 AUTOCONTEXT_AGENT_PROVIDER=openai-compatible \
@@ -277,18 +277,18 @@ AUTOCONTEXT_JUDGE_PROVIDER=openai-compatible \
 AUTOCONTEXT_JUDGE_BASE_URL=http://localhost:8080/v1 \
 AUTOCONTEXT_JUDGE_API_KEY=hermes-key \
 AUTOCONTEXT_JUDGE_MODEL=hermes-3-llama-3.1-70b \
-autoctx run --scenario my_task --json
+autoctx run my_task --json
 
 # Pi CLI (local Pi agent runtime)
 AUTOCONTEXT_AGENT_PROVIDER=pi \
 AUTOCONTEXT_PI_COMMAND=pi \
 AUTOCONTEXT_PI_TIMEOUT=120 \
-autoctx run --scenario my_task --json
+autoctx run my_task --json
 
 # Pi RPC (Pi subprocess via `pi --mode rpc` JSONL)
 AUTOCONTEXT_AGENT_PROVIDER=pi-rpc \
 AUTOCONTEXT_PI_COMMAND=pi \
-autoctx run --scenario my_task --json
+autoctx run my_task --json
 
 # Optional: keep Pi deterministic by ignoring AGENTS.md / CLAUDE.md context files
 AUTOCONTEXT_PI_NO_CONTEXT_FILES=true
@@ -305,7 +305,7 @@ ANTHROPIC_API_KEY=sk-ant-primary \
 AUTOCONTEXT_COMPETITOR_PROVIDER=openai-compatible \
 AUTOCONTEXT_COMPETITOR_API_KEY=sk-role \
 AUTOCONTEXT_COMPETITOR_BASE_URL=http://localhost:8000/v1 \
-autoctx run --scenario my_task --json
+autoctx run my_task --json
 ```
 
 `ANTHROPIC_API_KEY` is the preferred Anthropic credential env var. `AUTOCONTEXT_ANTHROPIC_API_KEY` remains supported as a compatibility alias.
@@ -436,8 +436,8 @@ RUN_ID="agent_run_$(date +%s)"
 
 # 1. Start a run and capture structured output
 result=$(autoctx run \
-  --scenario "$SCENARIO" \
-  --gens 3 \
+  "$SCENARIO" \
+  --iterations 3 \
   --run-id "$RUN_ID" \
   --json 2>/dev/null)
 
@@ -448,7 +448,7 @@ echo "Run completed. Best score: $best_score" >&2
 autoctx status "$RUN_ID" --json | jq '.generations[-1]'
 
 # 3. Export the strategy package
-autoctx export --scenario "$SCENARIO" --output "${SCENARIO}_pkg.json" --json
+autoctx export "$RUN_ID" --output "${SCENARIO}_pkg.json" --json
 
 # 4. Training loop (if training data available)
 if [ -f "training/${SCENARIO}.jsonl" ]; then
@@ -497,8 +497,8 @@ RUN_ID="hermes_$(date +%s)"
 mkdir -p logs
 
 autoctx run \
-  --scenario grid_ctf \
-  --gens 5 \
+  grid_ctf \
+  --iterations 5 \
   --run-id "$RUN_ID" \
   --json \
   >"logs/${RUN_ID}.json" \
@@ -533,7 +533,7 @@ jq . "logs/${RUN_ID}.json"
 
 ```bash
 autoctx export \
-  --scenario grid_ctf \
+  "$RUN_ID" \
   --output "hermes_knowledge.json" \
   --json | jq .
 ```
@@ -542,7 +542,7 @@ For Pi, use `--format pi-package` to produce a local package directory:
 
 ```bash
 autoctx export \
-  --scenario grid_ctf \
+  "$RUN_ID" \
   --format pi-package \
   --output "grid-ctf-pi-package" \
   --json | jq .
@@ -552,8 +552,8 @@ autoctx export \
 
 ```bash
 autoctx solve \
-  --description "Design a grid capture-the-flag strategy that prioritizes safe flag captures, defends home base when behind, and adapts pathing when lanes are contested." \
-  --gens 3 \
+  "Design a grid capture-the-flag strategy that prioritizes safe flag captures, defends home base when behind, and adapts pathing when lanes are contested." \
+  --iterations 3 \
   --output "logs/${RUN_ID}_solve_package.json" \
   --json | jq .
 ```

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -69,6 +69,9 @@ exclude = [".claude", ".claude/**"]
 [tool.hatch.build.targets.wheel]
 packages = ["src/autocontext"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"assets" = "autocontext/assets"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q --strict-markers --disable-warnings"

--- a/autocontext/src/autocontext/banner.py
+++ b/autocontext/src/autocontext/banner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from html import escape as html_escape
+from importlib import resources
 from pathlib import Path
 from xml.sax.saxutils import escape as xml_escape
 
@@ -23,6 +24,7 @@ SYNC_BLOCK_END = "<!-- autocontext-readme-hero:end -->"
 WHATS_NEW_BLOCK_START = "<!-- autocontext-whats-new:start -->"
 WHATS_NEW_BLOCK_END = "<!-- autocontext-whats-new:end -->"
 README_WHATS_NEW_HEADING = "What's New in 0.4.9"
+FALLBACK_BANNER_ART = "autocontext"
 README_BADGES = (
     (
         "https://github.com/greyhaven-ai/autocontext/blob/main/LICENSE",
@@ -71,18 +73,41 @@ def get_banner_svg_path() -> Path:
     return _assets_dir() / "banner.svg"
 
 
+def _read_packaged_asset(name: str) -> str | None:
+    try:
+        return (
+            resources.files("autocontext")
+            .joinpath("assets")
+            .joinpath(name)
+            .read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, ModuleNotFoundError, OSError):
+        return None
+
+
+def _read_source_asset(name: str) -> str | None:
+    try:
+        return (_assets_dir() / name).read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
 @lru_cache(maxsize=1)
 def load_banner_art() -> str:
     """Load the canonical ASCII banner art."""
-    return get_banner_path().read_text(encoding="utf-8").strip("\n")
+    content = _read_packaged_asset("banner.txt") or _read_source_asset("banner.txt")
+    return (content or FALLBACK_BANNER_ART).strip("\n")
 
 
 @lru_cache(maxsize=1)
 def load_whats_new() -> tuple[str, ...]:
     """Load the canonical What's New entries."""
+    content = _read_packaged_asset("whats_new.txt") or _read_source_asset("whats_new.txt")
+    if content is None:
+        return ()
     return tuple(
         line.strip()
-        for line in get_whats_new_path().read_text(encoding="utf-8").splitlines()
+        for line in content.splitlines()
         if line.strip()
     )
 

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -328,8 +328,10 @@ def _run_agent_task(
 
 @app.command()
 def run(
-    scenario: str = typer.Option("grid_ctf", "--scenario"),
-    gens: int = typer.Option(1, "--gens", min=1),
+    scenario_text: str | None = typer.Argument(None, help="Scenario to run"),
+    scenario: str = typer.Option("", "--scenario"),
+    gens: int | None = typer.Option(None, "--gens", min=1),
+    iterations: int | None = typer.Option(None, "--iterations", min=1, help="Plain-language alias for --gens"),
     run_id: str | None = typer.Option(None, "--run-id"),
     serve: bool = typer.Option(False, "--serve", help="Start interactive server alongside generation loop"),
     port: int = typer.Option(8000, "--port", help="Server port (only used with --serve)"),
@@ -337,6 +339,8 @@ def run(
     json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
 ) -> None:
     """Run generation loop."""
+    scenario = scenario.strip() or (scenario_text or "").strip() or "grid_ctf"
+    gens = gens if gens is not None else iterations if iterations is not None else 1
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 
@@ -942,12 +946,14 @@ def export_training_data_cmd(
 
 @app.command("export")
 def export_cmd(
-    scenario: str = typer.Option(..., "--scenario", help="Scenario to export"),
+    run_id_text: str | None = typer.Argument(None, help="Run id to export"),
+    scenario: str = typer.Option("", "--scenario", help="Scenario to export"),
+    run_id: str | None = typer.Option(None, "--run-id", help="Run id to export"),
     output: str = typer.Option(
         "",
         "--output",
         help=(
-            "Output path: strategy JSON file (default: <scenario>_package.json) "
+            "Output path: strategy JSON file (default: <scenario-or-run-id>_package.json) "
             "or pi-package directory (default: <scenario>-pi-package)"
         ),
     ),
@@ -989,8 +995,29 @@ def export_cmd(
     ctx.sqlite = sqlite
     ctx.artifacts = artifacts
 
+    source_run_id = run_id.strip() if run_id else None
+    scenario_name = scenario.strip()
+    if not scenario_name:
+        source_run_id = source_run_id or ((run_id_text or "").strip() or None)
+        if source_run_id is None:
+            message = "--scenario or <run-id> is required"
+            if json_output:
+                _write_json_stderr(message)
+            else:
+                console.print(f"[red]{message}[/red]")
+            raise typer.Exit(code=1)
+        run_row = sqlite.get_run(source_run_id)
+        if run_row is None:
+            message = f"run '{source_run_id}' not found"
+            if json_output:
+                _write_json_stderr(message)
+            else:
+                console.print(f"[red]{message}[/red]")
+            raise typer.Exit(code=1)
+        scenario_name = str(run_row["scenario"])
+
     try:
-        pkg = export_strategy_package(ctx, scenario)
+        pkg = export_strategy_package(ctx, scenario_name, source_run_id=source_run_id)
     except ValueError as exc:
         if json_output:
             _write_json_stderr(str(exc))
@@ -1014,12 +1041,12 @@ def export_cmd(
             write_pi_package,
         )
 
-        output_path = Path(output) if output else default_pi_package_output_dir(scenario)
+        output_path = Path(output) if output else default_pi_package_output_dir(scenario_name)
         written = write_pi_package(build_pi_package(pkg), output_path)
         if json_output:
             _write_json_stdout(
                 {
-                    "scenario": scenario,
+                    "scenario": scenario_name,
                     "format": normalized_format,
                     "output_path": str(output_path),
                     "file_count": len(written.files),
@@ -1027,17 +1054,18 @@ def export_cmd(
                 }
             )
         else:
-            console.print(f"[green]Exported {scenario} Pi package to {output_path}[/green]")
+            console.print(f"[green]Exported {scenario_name} Pi package to {output_path}[/green]")
             console.print(f"[dim]files={len(written.files)} best_score={pkg.best_score:.4f}[/dim]")
         return
 
-    output_path = Path(output) if output else Path(f"{scenario}_package.json")
+    output_stem = source_run_id or scenario_name
+    output_path = Path(output) if output else Path(f"{output_stem}_package.json")
     pkg.to_file(output_path)
 
     if json_output:
         _write_json_stdout(
             {
-                "scenario": scenario,
+                "scenario": scenario_name,
                 "format": normalized_format,
                 "output_path": str(output_path),
                 "best_score": pkg.best_score,
@@ -1046,7 +1074,7 @@ def export_cmd(
             }
         )
     else:
-        console.print(f"[green]Exported {scenario} package to {output_path}[/green]")
+        console.print(f"[green]Exported {scenario_name} package to {output_path}[/green]")
         console.print(f"[dim]best_score={pkg.best_score:.4f} lessons={len(pkg.lessons)} harness={len(pkg.harness)}[/dim]")
 
 

--- a/autocontext/src/autocontext/cli_solve.py
+++ b/autocontext/src/autocontext/cli_solve.py
@@ -160,6 +160,17 @@ def run_solve_command(
     console.print(table)
 
 
+def _resolve_solve_description(
+    option_description: str,
+    positional_description: str | None,
+) -> str:
+    return option_description.strip() or (positional_description or "").strip()
+
+
+def _resolve_solve_generations(gens: int | None, iterations: int | None) -> int:
+    return gens if gens is not None else iterations if iterations is not None else 5
+
+
 def register_solve_command(
     app: typer.Typer,
     *,
@@ -168,8 +179,10 @@ def register_solve_command(
 ) -> None:
     @app.command()
     def solve(
-        description: str = typer.Option(..., "--description", help="Natural-language scenario/problem description"),
-        gens: int = typer.Option(5, "--gens", min=1, max=50, help="Generations to run for the solve"),
+        description_text: str | None = typer.Argument(None, help="Plain-language scenario/problem description"),
+        description: str = typer.Option("", "--description", "-d", help="Same description as a named option"),
+        gens: int | None = typer.Option(None, "--gens", min=1, max=50, help="Generations to run for the solve"),
+        iterations: int | None = typer.Option(None, "--iterations", min=1, max=50, help="Plain-language alias for --gens"),
         timeout: float | None = typer.Option(
             None,
             "--timeout",
@@ -191,9 +204,18 @@ def register_solve_command(
         ),
     ) -> None:
         _validate_family_override(family)
+        resolved_description = _resolve_solve_description(description, description_text)
+        write_json_stderr = _cli_attr(dependency_module, "_write_json_stderr")
+        if not resolved_description:
+            message = '--description is required. You can also run: autoctx solve "plain-language goal".'
+            if json_output:
+                write_json_stderr(message)
+            else:
+                typer.echo(message, err=True)
+            raise typer.Exit(code=1)
         run_solve_command(
-            description=description,
-            gens=gens,
+            description=resolved_description,
+            gens=_resolve_solve_generations(gens, iterations),
             timeout=timeout,
             generation_time_budget=generation_time_budget,
             output=output,
@@ -201,6 +223,6 @@ def register_solve_command(
             console=console,
             load_settings_fn=_cli_attr(dependency_module, "load_settings"),
             write_json_stdout=_cli_attr(dependency_module, "_write_json_stdout"),
-            write_json_stderr=_cli_attr(dependency_module, "_write_json_stderr"),
+            write_json_stderr=write_json_stderr,
             family_override=family or None,
         )

--- a/autocontext/src/autocontext/knowledge/export.py
+++ b/autocontext/src/autocontext/knowledge/export.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from autocontext.knowledge.package import StrategyPackage
+    from autocontext.storage.row_types import GenerationMetricsRow
 
 from autocontext.mcp.tools import MtsToolContext
 from autocontext.scenarios import SCENARIO_REGISTRY
@@ -20,6 +21,59 @@ logger = logging.getLogger(__name__)
 _ROLLBACK_RE = re.compile(r"^-\s*Generation\s+\d+\s+ROLLBACK\b", re.IGNORECASE)
 _RAW_JSON_RE = re.compile(r'\{"[a-z_]+"\s*:\s*[\d.]+')
 _SCORE_PARENS_RE = re.compile(r"\(score=[0-9.]+,\s*delta=[0-9.+-]+,\s*threshold=[0-9.]+\)")
+
+
+def _parse_strategy_json(raw: str | None) -> dict[str, Any] | None:
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _best_generation_for_run(ctx: MtsToolContext, run_id: str) -> GenerationMetricsRow | None:
+    generations = ctx.sqlite.get_generation_metrics(run_id)
+    if not generations:
+        return None
+    return max(
+        generations,
+        key=lambda generation: (
+            float(generation.get("best_score", 0.0)),
+            int(generation.get("generation_index", 0)),
+        ),
+    )
+
+
+def _best_run_strategy(ctx: MtsToolContext, run_id: str, generation_index: int) -> dict[str, Any] | None:
+    matches = [
+        match
+        for match in ctx.sqlite.get_matches_for_run(run_id)
+        if int(match.get("generation_index", 0)) == generation_index
+    ]
+    if matches:
+        best_match = max(
+            matches,
+            key=lambda match: (
+                float(match.get("score", 0.0)),
+                int(match.get("id", 0)),
+            ),
+        )
+        parsed = _parse_strategy_json(best_match.get("strategy_json"))
+        if parsed is not None:
+            return parsed
+
+    competitor_outputs = [
+        output
+        for output in ctx.sqlite.get_agent_outputs_by_role(run_id, "competitor")
+        if int(output.get("generation_index", 0)) == generation_index
+    ]
+    if competitor_outputs:
+        parsed = _parse_strategy_json(competitor_outputs[-1].get("content"))
+        if parsed is not None:
+            return parsed
+    return None
 
 
 @dataclass(slots=True)
@@ -173,30 +227,43 @@ class SkillPackage:
         return "".join(parts)
 
 
-def export_skill_package(ctx: MtsToolContext, scenario_name: str) -> SkillPackage:
+def export_skill_package(ctx: MtsToolContext, scenario_name: str, source_run_id: str | None = None) -> SkillPackage:
     """Assemble a portable skill package from accumulated scenario knowledge."""
     if scenario_name not in SCENARIO_REGISTRY:
         supported = ", ".join(sorted(SCENARIO_REGISTRY.keys()))
         raise ValueError(f"Unknown scenario '{scenario_name}'. Available: {supported}")
 
     scenario = SCENARIO_REGISTRY[scenario_name]()
+    source_generation: int | None = None
+    has_snapshot = False
 
     playbook = ctx.artifacts.read_playbook(scenario_name)
     raw_lessons = ctx.artifacts.read_skill_lessons_raw(scenario_name)
     lessons = _clean_lessons(raw_lessons)
     hints = ctx.artifacts.read_hints(scenario_name)
 
-    snapshot = ctx.sqlite.get_best_knowledge_snapshot(scenario_name)
-    best_score = snapshot["best_score"] if snapshot else 0.0
-    best_elo = snapshot["best_elo"] if snapshot else 1500.0
-
-    best_strategy_raw = ctx.sqlite.get_best_competitor_output(scenario_name)
-    best_strategy: dict[str, Any] | None = None
-    if best_strategy_raw:
-        try:
-            best_strategy = json.loads(best_strategy_raw)
-        except (json.JSONDecodeError, TypeError):
-            best_strategy = None
+    if source_run_id is not None:
+        run = ctx.sqlite.get_run(source_run_id)
+        if run is None:
+            raise ValueError(f"Unknown run '{source_run_id}'")
+        if run.get("scenario") != scenario_name:
+            raise ValueError(
+                f"Run '{source_run_id}' belongs to scenario '{run.get('scenario')}', not '{scenario_name}'"
+            )
+        best_generation = _best_generation_for_run(ctx, source_run_id)
+        if best_generation is None:
+            raise ValueError(f"No generation metrics found for run {source_run_id}")
+        source_generation = int(best_generation["generation_index"])
+        best_score = float(best_generation["best_score"])
+        best_elo = float(best_generation.get("elo") or 1500.0)
+        best_strategy = _best_run_strategy(ctx, source_run_id, source_generation)
+        has_snapshot = True
+    else:
+        snapshot = ctx.sqlite.get_best_knowledge_snapshot(scenario_name)
+        best_score = snapshot["best_score"] if snapshot else 0.0
+        best_elo = snapshot["best_elo"] if snapshot else 1500.0
+        best_strategy = _parse_strategy_json(ctx.sqlite.get_best_competitor_output(scenario_name))
+        has_snapshot = snapshot is not None
 
     completed_runs = ctx.sqlite.count_completed_runs(scenario_name)
 
@@ -245,7 +312,9 @@ def export_skill_package(ctx: MtsToolContext, scenario_name: str) -> SkillPackag
         harness=harness,
         metadata={
             "completed_runs": completed_runs,
-            "has_snapshot": snapshot is not None,
+            "has_snapshot": has_snapshot,
+            "source_run_id": source_run_id,
+            "source_generation": source_generation,
         },
         task_prompt=task_prompt,
         judge_rubric=judge_rubric,
@@ -338,7 +407,11 @@ def _clean_lessons(raw_bullets: list[str]) -> list[str]:
     return cleaned
 
 
-def export_strategy_package(ctx: MtsToolContext, scenario_name: str) -> StrategyPackage:
+def export_strategy_package(
+    ctx: MtsToolContext,
+    scenario_name: str,
+    source_run_id: str | None = None,
+) -> StrategyPackage:
     """Export a versioned, portable StrategyPackage for a scenario.
 
     Wraps the existing export_skill_package() with format versioning and
@@ -346,18 +419,25 @@ def export_strategy_package(ctx: MtsToolContext, scenario_name: str) -> Strategy
     """
     from autocontext.knowledge.package import StrategyPackage, read_package_metadata
 
-    skill_pkg = export_skill_package(ctx, scenario_name)
+    skill_pkg = export_skill_package(ctx, scenario_name, source_run_id=source_run_id)
     imported_meta = read_package_metadata(ctx.artifacts, scenario_name)
 
     # Determine source_run_id from the best knowledge snapshot
-    source_run_id: str | None = None
-    snapshot = ctx.sqlite.get_best_knowledge_snapshot(scenario_name)
-    if snapshot:
-        source_run_id = snapshot.get("run_id")
-    elif isinstance(imported_meta.get("metadata"), dict):
-        source_run_id = imported_meta["metadata"].get("source_run_id")
+    resolved_source_run_id = source_run_id
+    source_generation = skill_pkg.metadata.get("source_generation")
+    if resolved_source_run_id is None:
+        snapshot = ctx.sqlite.get_best_knowledge_snapshot(scenario_name)
+        if snapshot:
+            resolved_source_run_id = snapshot.get("run_id")
+        elif isinstance(imported_meta.get("metadata"), dict):
+            resolved_source_run_id = imported_meta["metadata"].get("source_run_id")
+            source_generation = imported_meta["metadata"].get("source_generation")
 
-    pkg = StrategyPackage.from_skill_package(skill_pkg, source_run_id=source_run_id)
+    pkg = StrategyPackage.from_skill_package(
+        skill_pkg,
+        source_run_id=resolved_source_run_id,
+        source_generation=source_generation if isinstance(source_generation, int) else None,
+    )
     imported_meta_payload = imported_meta.get("metadata")
     if isinstance(imported_meta_payload, dict):
         pkg.metadata.completed_runs = max(

--- a/autocontext/src/autocontext/knowledge/package.py
+++ b/autocontext/src/autocontext/knowledge/package.py
@@ -41,6 +41,7 @@ class PackageMetadata(BaseModel):
 
     mts_version: str = Field(default="", description="autocontext version that created this package")
     source_run_id: str | None = Field(default=None, description="Run that produced the best strategy")
+    source_generation: int | None = Field(default=None, description="Generation that produced the best strategy")
     created_at: str = Field(
         default_factory=lambda: datetime.now(UTC).isoformat(),
         description="ISO-8601 creation timestamp",
@@ -94,7 +95,10 @@ class StrategyPackage(BaseModel):
 
     @classmethod
     def from_skill_package(
-        cls, pkg: SkillPackage, source_run_id: str | None = None,
+        cls,
+        pkg: SkillPackage,
+        source_run_id: str | None = None,
+        source_generation: int | None = None,
     ) -> StrategyPackage:
         """Build a StrategyPackage from an existing SkillPackage."""
         from autocontext import __version__
@@ -123,6 +127,7 @@ class StrategyPackage(BaseModel):
             metadata=PackageMetadata(
                 mts_version=__version__,
                 source_run_id=source_run_id,
+                source_generation=source_generation,
                 completed_runs=raw_meta.get("completed_runs", 0) if isinstance(raw_meta, dict) else 0,
                 has_snapshot=raw_meta.get("has_snapshot", False) if isinstance(raw_meta, dict) else False,
             ),

--- a/autocontext/tests/test_banner_sync.py
+++ b/autocontext/tests/test_banner_sync.py
@@ -1,17 +1,24 @@
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
+
+from typer.testing import CliRunner
 
 from autocontext.banner import (
     SYNC_BLOCK_END,
     SYNC_BLOCK_START,
     WHATS_NEW_BLOCK_END,
     WHATS_NEW_BLOCK_START,
+    banner_plain,
     get_banner_svg_path,
+    load_banner_art,
+    load_whats_new,
     render_banner_svg,
     render_readme_banner_block,
     render_readme_whats_new_block,
 )
+from autocontext.cli import app
 
 
 def _extract_synced_block(path: Path, start_marker: str, end_marker: str) -> str:
@@ -42,3 +49,41 @@ def test_root_readme_whats_new_stays_synced() -> None:
 
 def test_banner_svg_stays_synced() -> None:
     assert get_banner_svg_path().read_text(encoding="utf-8") == render_banner_svg()
+
+
+def test_banner_falls_back_when_assets_are_missing(monkeypatch, tmp_path: Path) -> None:
+    import autocontext.banner as banner
+
+    monkeypatch.setattr(banner, "_assets_dir", lambda: tmp_path / "missing-assets")
+    load_banner_art.cache_clear()
+    load_whats_new.cache_clear()
+    try:
+        assert load_banner_art() == "autocontext"
+        assert load_whats_new() == ()
+        assert "autocontext" in banner_plain()
+    finally:
+        load_banner_art.cache_clear()
+        load_whats_new.cache_clear()
+
+
+def test_no_args_cli_does_not_traceback_when_banner_assets_are_missing(monkeypatch, tmp_path: Path) -> None:
+    import autocontext.banner as banner
+
+    monkeypatch.setattr(banner, "_assets_dir", lambda: tmp_path / "missing-assets")
+    load_banner_art.cache_clear()
+    load_whats_new.cache_clear()
+    try:
+        result = CliRunner().invoke(app, [])
+    finally:
+        load_banner_art.cache_clear()
+        load_whats_new.cache_clear()
+
+    assert result.exit_code == 0, result.output
+    assert "Traceback" not in result.output
+
+
+def test_wheel_packages_banner_assets() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    pyproject = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+    force_include = pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+    assert force_include["assets"] == "autocontext/assets"

--- a/autocontext/tests/test_cli_agent_task.py
+++ b/autocontext/tests/test_cli_agent_task.py
@@ -112,6 +112,21 @@ class TestAgentTaskDetection:
         assert result.exit_code == 0, result.output
         mock_runner.assert_not_called()
 
+    def test_run_accepts_positional_scenario_and_iterations_alias(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+        with (
+            patch("autocontext.cli.SCENARIO_REGISTRY", {"mock_task": _MockAgentTask}),
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._resolve_agent_task_runtime", return_value=(_FakeProvider(), "test-model")),
+            patch("autocontext.cli.ImprovementLoop") as mock_loop,
+            patch("autocontext.cli._runner") as mock_runner,
+        ):
+            mock_loop.return_value.run.return_value = _FakeLoopResult()
+            result = runner.invoke(app, ["run", "mock_task", "--iterations", "3"])
+
+        assert result.exit_code == 0, result.output
+        mock_runner.assert_not_called()
+
 
 class TestAgentTaskPersistence:
     def test_run_persists_agent_task_as_canonical_run_state(self, tmp_path: Path) -> None:

--- a/autocontext/tests/test_cli_solve_runtime.py
+++ b/autocontext/tests/test_cli_solve_runtime.py
@@ -15,6 +15,9 @@ runner = CliRunner()
 
 class _CapturingSolveManager:
     last_settings: AppSettings | None = None
+    last_description: str | None = None
+    last_generations: int | None = None
+    last_family_override: str | None = None
 
     def __init__(self, settings: AppSettings) -> None:
         type(self).last_settings = settings
@@ -25,7 +28,9 @@ class _CapturingSolveManager:
         generations: int = 5,
         family_override: str | None = None,
     ) -> SolveJob:
-        del description, generations, family_override
+        type(self).last_description = description
+        type(self).last_generations = generations
+        type(self).last_family_override = family_override
         pkg = SkillPackage(
             scenario_name="grid_ctf",
             display_name="Grid Ctf",
@@ -143,6 +148,76 @@ def _settings(tmp_path: Path, **overrides: object) -> AppSettings:
 
 
 class TestSolveRuntimeOverrides:
+    def test_solve_accepts_plain_language_positional_description(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+
+        from unittest.mock import patch
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.knowledge.solver.SolveManager", _CapturingSolveManager),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "solve",
+                    "Design a strategy",
+                    "--gens",
+                    "2",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert _CapturingSolveManager.last_description == "Design a strategy"
+        assert _CapturingSolveManager.last_generations == 2
+
+    def test_solve_accepts_iterations_alias(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+
+        from unittest.mock import patch
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.knowledge.solver.SolveManager", _CapturingSolveManager),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "solve",
+                    "Design a strategy",
+                    "--iterations",
+                    "4",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert _CapturingSolveManager.last_generations == 4
+
+    def test_solve_prefers_description_option_over_positional_description(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path)
+
+        from unittest.mock import patch
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.knowledge.solver.SolveManager", _CapturingSolveManager),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "solve",
+                    "Positional strategy",
+                    "--description",
+                    "Named strategy",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert _CapturingSolveManager.last_description == "Named strategy"
+
     def test_solve_timeout_override_updates_runtime_settings(self, tmp_path: Path) -> None:
         settings = _settings(tmp_path)
 

--- a/autocontext/tests/test_strategy_package.py
+++ b/autocontext/tests/test_strategy_package.py
@@ -497,6 +497,40 @@ class TestExportStrategyPackage:
             pkg = export_strategy_package(tool_ctx, "grid_ctf")
         assert pkg.metadata.source_run_id == "run_123"
 
+    def test_export_can_target_specific_run(self, tool_ctx: MagicMock) -> None:
+        tool_ctx.sqlite.get_run.return_value = {"run_id": "run_low", "scenario": "grid_ctf"}
+        tool_ctx.sqlite.get_generation_metrics.return_value = [
+            {"run_id": "run_low", "generation_index": 1, "best_score": 0.4, "elo": 1040.0},
+        ]
+        tool_ctx.sqlite.get_matches_for_run.return_value = [
+            {
+                "id": 1,
+                "generation_index": 1,
+                "score": 0.4,
+                "strategy_json": '{"aggression": 0.4}',
+            },
+        ]
+
+        with patch("autocontext.knowledge.export.SCENARIO_REGISTRY", self._mock_registry()):
+            from autocontext.knowledge.export import export_strategy_package
+            pkg = export_strategy_package(tool_ctx, "grid_ctf", source_run_id="run_low")
+
+        assert pkg.best_score == pytest.approx(0.4)
+        assert pkg.best_elo == pytest.approx(1040.0)
+        assert pkg.best_strategy == {"aggression": 0.4}
+        assert pkg.metadata.source_run_id == "run_low"
+        assert pkg.metadata.source_generation == 1
+
+    def test_export_rejects_run_without_generation_metrics(self, tool_ctx: MagicMock) -> None:
+        tool_ctx.sqlite.get_run.return_value = {"run_id": "run_empty", "scenario": "grid_ctf"}
+        tool_ctx.sqlite.get_generation_metrics.return_value = []
+
+        with patch("autocontext.knowledge.export.SCENARIO_REGISTRY", self._mock_registry()):
+            from autocontext.knowledge.export import export_strategy_package
+
+            with pytest.raises(ValueError, match="No generation metrics found for run run_empty"):
+                export_strategy_package(tool_ctx, "grid_ctf", source_run_id="run_empty")
+
 
 # ── Full roundtrip tests ────────────────────────────────────────────────
 

--- a/autocontext/tests/test_strategy_package_cli.py
+++ b/autocontext/tests/test_strategy_package_cli.py
@@ -37,6 +37,26 @@ def _seed_scenario(db: SQLiteStore, artifacts: ArtifactStore, scenario: str = "g
     artifacts.write_hints(scenario, "Scout the borders.")
     artifacts.write_harness(scenario, "bounds_check", "def validate(s): return True\n")
     db.create_run("test_run_001", scenario=scenario, generations=3, executor_mode="local")
+    db.upsert_generation(
+        "test_run_001",
+        1,
+        mean_score=0.5,
+        best_score=0.65,
+        elo=1065.0,
+        wins=1,
+        losses=0,
+        gate_decision="advance",
+        status="completed",
+    )
+    db.insert_match(
+        "test_run_001",
+        1,
+        seed=1,
+        score=0.65,
+        passed_validation=True,
+        validation_errors="",
+        strategy_json='{"aggression": 0.65}',
+    )
     db.mark_run_completed("test_run_001")
 
 
@@ -91,6 +111,30 @@ class TestExportCommand:
             "--claude-skills-path", str(tmp_path / ".claude" / "skills"),
         ])
         assert result.exit_code != 0
+
+    def test_export_accepts_positional_run_id(self, tmp_path: Path) -> None:
+        db, artifacts, db_path = _setup_db_and_artifacts(tmp_path)
+        _seed_scenario(db, artifacts)
+        output = tmp_path / "run-export.json"
+
+        result = runner.invoke(app, [
+            "export",
+            "test_run_001",
+            "--output", str(output),
+            "--db-path", str(db_path),
+            "--knowledge-root", str(tmp_path / "knowledge"),
+            "--skills-root", str(tmp_path / "skills"),
+            "--claude-skills-path", str(tmp_path / ".claude" / "skills"),
+        ])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(output.read_text(encoding="utf-8"))
+        assert data["scenario_name"] == "grid_ctf"
+        assert data["best_score"] == pytest.approx(0.65)
+        assert data["best_elo"] == pytest.approx(1065.0)
+        assert data["best_strategy"] == {"aggression": 0.65}
+        assert data["metadata"]["source_run_id"] == "test_run_001"
+        assert data["metadata"]["source_generation"] == 1
 
 
 class TestImportCommand:

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,8 +20,8 @@ export AUTOCONTEXT_AGENT_PROVIDER=deterministic
 RUN_ID="example_$(date +%s)"
 
 uv run autoctx run \
-  --scenario grid_ctf \
-  --gens 3 \
+  grid_ctf \
+  --iterations 3 \
   --run-id "$RUN_ID" \
   --json | jq .
 
@@ -29,12 +29,12 @@ uv run autoctx status "$RUN_ID" --json | jq .
 
 mkdir -p exports
 uv run autoctx export \
-  --scenario grid_ctf \
+  "$RUN_ID" \
   --output "exports/${RUN_ID}.json" \
   --json | jq .
 
 uv run autoctx export \
-  --scenario grid_ctf \
+  "$RUN_ID" \
   --format pi-package \
   --output "exports/${RUN_ID}-pi-package" \
   --json | jq .
@@ -151,7 +151,7 @@ export AUTOCONTEXT_AGENT_DEFAULT_MODEL=hermes-3-llama-3.1-8b
 # Run → status → export loop
 RUN_ID="hermes_$(date +%s)"
 mkdir -p logs
-uv run autoctx run --scenario grid_ctf --gens 3 --run-id "$RUN_ID" --json >"logs/${RUN_ID}.json" 2>"logs/${RUN_ID}.err" &
+uv run autoctx run grid_ctf --iterations 3 --run-id "$RUN_ID" --json >"logs/${RUN_ID}.json" 2>"logs/${RUN_ID}.err" &
 RUN_PID=$!
 while kill -0 "$RUN_PID" 2>/dev/null; do
   uv run autoctx status "$RUN_ID" --json | jq '.generations[-1]'
@@ -159,8 +159,8 @@ while kill -0 "$RUN_PID" 2>/dev/null; do
 done
 wait "$RUN_PID"
 cat "logs/${RUN_ID}.json" | jq .
-uv run autoctx export --scenario grid_ctf --output "exports/${RUN_ID}.json" --json | jq .
-uv run autoctx solve --description "Design a safe, adaptive grid capture-the-flag strategy." --gens 2 --json | jq .
+uv run autoctx export "$RUN_ID" --output "exports/${RUN_ID}.json" --json | jq .
+uv run autoctx solve "Design a safe, adaptive grid capture-the-flag strategy." --iterations 2 --json | jq .
 ```
 
 For the full walkthrough including polling, timeouts, and integration path comparison, see [autocontext/docs/agent-integration.md](../autocontext/docs/agent-integration.md#hermes-cli-first-starter-workflow).

--- a/ts/README.md
+++ b/ts/README.md
@@ -163,13 +163,17 @@ autoctx providers
 autoctx models
 
 # Scenario execution
-autoctx run --scenario support_triage --gens 3 --json
+autoctx solve "improve customer-support replies for billing disputes" --iterations 3 --json
+autoctx run support_triage --iterations 3 --json
 autoctx list --json
+autoctx status <run-id>
+autoctx show <run-id> --best
+autoctx watch <run-id>
 autoctx replay --run-id <id> --generation 1
 autoctx benchmark --scenario support_triage --runs 5
 
 # Package management
-autoctx export --scenario support_triage --output pkg.json
+autoctx export <run-id> --output pkg.json
 autoctx export-training-data --run-id <id> --output data.jsonl
 autoctx import-package --file pkg.json
 autoctx new-scenario --description "Test summarization quality"
@@ -211,13 +215,13 @@ Configure the agent provider via environment variables:
 
 ```bash
 # Anthropic (default)
-ANTHROPIC_API_KEY=sk-ant-... autoctx run --scenario support_triage --json
+ANTHROPIC_API_KEY=sk-ant-... autoctx run support_triage --json
 
 # OpenAI-compatible
 AUTOCONTEXT_AGENT_PROVIDER=openai-compatible \
 AUTOCONTEXT_AGENT_API_KEY=sk-... \
 AUTOCONTEXT_AGENT_BASE_URL=https://api.openai.com/v1 \
-autoctx run --scenario support_triage --json
+autoctx run support_triage --json
 
 # Role-scoped override: competitor uses a separate gateway/key
 AUTOCONTEXT_AGENT_PROVIDER=anthropic \
@@ -225,42 +229,42 @@ ANTHROPIC_API_KEY=sk-ant-primary \
 AUTOCONTEXT_COMPETITOR_PROVIDER=openai-compatible \
 AUTOCONTEXT_COMPETITOR_API_KEY=sk-role \
 AUTOCONTEXT_COMPETITOR_BASE_URL=http://localhost:8000/v1 \
-autoctx run --scenario support_triage --json
+autoctx run support_triage --json
 
 # Ollama (local)
-AUTOCONTEXT_AGENT_PROVIDER=ollama autoctx run --scenario support_triage --json
+AUTOCONTEXT_AGENT_PROVIDER=ollama autoctx run support_triage --json
 
 # Hermes (via OpenAI-compatible gateway)
 AUTOCONTEXT_AGENT_PROVIDER=openai-compatible \
 AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1 \
 AUTOCONTEXT_AGENT_DEFAULT_MODEL=hermes-3-llama-3.1-8b \
-autoctx run --scenario support_triage --json
+autoctx run support_triage --json
 
 # Hermes shortcut provider (same gateway path, Hermes defaults)
 AUTOCONTEXT_AGENT_PROVIDER=hermes \
 AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1 \
-autoctx run --scenario support_triage --json
+autoctx run support_triage --json
 
 # Claude CLI (local authenticated Claude Code runtime)
 AUTOCONTEXT_AGENT_PROVIDER=claude-cli \
 AUTOCONTEXT_CLAUDE_MODEL=sonnet \
-autoctx run --scenario support_triage --json
+autoctx run support_triage --json
 
 # Codex CLI (local authenticated Codex runtime)
 AUTOCONTEXT_AGENT_PROVIDER=codex \
 AUTOCONTEXT_CODEX_MODEL=o4-mini \
-autoctx run --scenario support_triage --json
+autoctx run support_triage --json
 
 # Pi CLI
-AUTOCONTEXT_AGENT_PROVIDER=pi autoctx run --scenario support_triage --json
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx run support_triage --json
 
 # Pi RPC with one long-lived subprocess
 AUTOCONTEXT_AGENT_PROVIDER=pi-rpc \
 AUTOCONTEXT_PI_RPC_PERSISTENT=true \
-autoctx run --scenario support_triage --json
+autoctx run support_triage --json
 
 # Deterministic (CI/testing)
-AUTOCONTEXT_AGENT_PROVIDER=deterministic autoctx run --scenario support_triage --json
+AUTOCONTEXT_AGENT_PROVIDER=deterministic autoctx run support_triage --json
 ```
 
 `ANTHROPIC_API_KEY` is the preferred Anthropic credential env var. `AUTOCONTEXT_ANTHROPIC_API_KEY` remains supported as a compatibility alias.

--- a/ts/src/cli/command-registry.ts
+++ b/ts/src/cli/command-registry.ts
@@ -31,6 +31,8 @@ export type DbCommandName =
   | "run"
   | "list"
   | "replay"
+  | "show"
+  | "watch"
   | "benchmark"
   | "export"
   | "export-training-data"
@@ -65,6 +67,8 @@ const COMMANDS: readonly CommandDescriptor[] = [
   { name: "run", description: "Run generation loop for a scenario", group: "primary", route: { kind: "db", command: "run" } },
   { name: "list", description: "List recent runs", group: "primary", route: { kind: "db", command: "list" } },
   { name: "replay", description: "Print replay JSON for a generation", group: "primary", route: { kind: "db", command: "replay" } },
+  { name: "show", description: "Show the best or latest generation for a run", group: "primary", route: { kind: "db", command: "show" } },
+  { name: "watch", description: "Follow a run until it finishes", group: "primary", route: { kind: "db", command: "watch" } },
   { name: "benchmark", description: "Run benchmark (multiple runs, aggregate stats)", group: "primary", route: { kind: "db", command: "benchmark" } },
   { name: "export", description: "Export strategy package for a scenario", group: "primary", route: { kind: "db", command: "export" } },
   { name: "export-training-data", description: "Export training data as JSONL", group: "primary", route: { kind: "db", command: "export-training-data" } },
@@ -116,6 +120,14 @@ export function resolveCliCommand(command: string): CliCommandRoute {
 export function buildCliHelp(): string {
   return `
 autoctx — always-on agent evaluation harness
+
+Plain-language first:
+  autoctx solve "build an orbital transfer optimizer" --iterations 3
+  autoctx run grid_ctf --iterations 3
+  autoctx status <run-id>
+  autoctx watch <run-id>
+  autoctx show <run-id> --best
+  autoctx export <run-id>
 
 Commands:
 ${formatCommandList("primary")}

--- a/ts/src/cli/export-command-workflow.ts
+++ b/ts/src/cli/export-command-workflow.ts
@@ -1,12 +1,16 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
-export const EXPORT_HELP_TEXT = `autoctx export — Export strategy package for a scenario
+export const EXPORT_HELP_TEXT = `autoctx export — Export strategy package for a run or scenario
 
-Usage: autoctx export [options]
+Usage:
+  autoctx export <run-id> [--output <file>] [--json]
+  autoctx export --scenario <name> [--output <file>] [--json]
 
 Options:
-  --scenario <name>    Scenario to export (required)
+  <run-id>             Run to export as a strategy package
+  --run-id <id>        Same run id as a named option
+  --scenario <name>    Scenario to export
   --output <file>      Output file path (default: stdout)
   --json               Force JSON output format
 
@@ -14,12 +18,15 @@ See also: import-package, run, replay`;
 
 export interface ExportCommandValues {
   scenario?: string;
+  "run-id"?: string;
+  positionals?: string[];
   output?: string;
   json?: boolean;
 }
 
 export interface ExportCommandPlan {
   scenarioName: string;
+  runId?: string;
   output?: string;
   json: boolean;
 }
@@ -27,16 +34,55 @@ export interface ExportCommandPlan {
 export async function planExportCommand(
   values: ExportCommandValues,
   resolveScenarioOption: (scenario: string | undefined) => Promise<string | undefined>,
+  resolveRunScenario: (runId: string) => Promise<string | undefined>,
 ): Promise<ExportCommandPlan> {
-  const scenarioName = await resolveScenarioOption(values.scenario);
-  if (!scenarioName) {
-    throw new Error("Error: --scenario is required");
+  const explicitScenario = values.scenario?.trim();
+  if (explicitScenario) {
+    const scenarioName = await resolveScenarioOption(explicitScenario);
+    if (!scenarioName) {
+      throw new Error("Error: --scenario or <run-id> is required");
+    }
+    const explicitRunId = values["run-id"]?.trim();
+    if (explicitRunId) {
+      const runScenario = await resolveRunScenario(explicitRunId);
+      if (!runScenario) {
+        throw new Error(`Error: run '${explicitRunId}' not found`);
+      }
+      if (runScenario !== scenarioName) {
+        throw new Error(
+          `Error: run '${explicitRunId}' belongs to scenario '${runScenario}', not '${scenarioName}'`,
+        );
+      }
+      return {
+        scenarioName,
+        runId: explicitRunId,
+        output: values.output,
+        json: !!values.json,
+      };
+    }
+    return {
+      scenarioName,
+      runId: undefined,
+      output: values.output,
+      json: !!values.json,
+    };
   }
-  return {
-    scenarioName,
-    output: values.output,
-    json: !!values.json,
-  };
+
+  const runId = values["run-id"]?.trim() || values.positionals?.[0]?.trim();
+  if (runId) {
+    const scenarioName = await resolveRunScenario(runId);
+    if (!scenarioName) {
+      throw new Error(`Error: run '${runId}' not found`);
+    }
+    return {
+      scenarioName,
+      runId,
+      output: values.output,
+      json: !!values.json,
+    };
+  }
+
+  throw new Error("Error: --scenario or <run-id> is required");
 }
 
 function writeOutputFileWithParents(path: string, content: string): void {
@@ -50,10 +96,12 @@ export function executeExportCommandWorkflow<
   TStore,
 >(opts: {
   scenarioName: string;
+  runId?: string;
   output?: string;
   json?: boolean;
   exportStrategyPackage: (args: {
     scenarioName: string;
+    sourceRunId?: string;
     artifacts: TArtifacts;
     store: TStore;
   }) => TResult;
@@ -63,6 +111,7 @@ export function executeExportCommandWorkflow<
 }): string {
   const result = opts.exportStrategyPackage({
     scenarioName: opts.scenarioName,
+    ...(opts.runId ? { sourceRunId: opts.runId } : {}),
     artifacts: opts.artifacts,
     store: opts.store,
   });

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -57,6 +57,8 @@ const DB_COMMAND_HANDLERS: Record<DbCommandName, (dbPath: string) => Promise<voi
   run: cmdRun,
   list: cmdList,
   replay: cmdReplay,
+  show: cmdShow,
+  watch: cmdWatch,
   benchmark: cmdBenchmark,
   export: cmdExport,
   "export-training-data": cmdExportTrainingData,
@@ -399,11 +401,13 @@ async function getProvider(
 }
 
 async function cmdRun(dbPath: string): Promise<void> {
-  const { values } = parseArgs({
+  const { values, positionals } = parseArgs({
     args: process.argv.slice(3),
+    allowPositionals: true,
     options: {
       scenario: { type: "string", short: "s" },
       gens: { type: "string", short: "g" },
+      iterations: { type: "string" },
       "run-id": { type: "string" },
       provider: { type: "string" },
       matches: { type: "string", default: "3" },
@@ -439,7 +443,7 @@ async function cmdRun(dbPath: string): Promise<void> {
   let plan;
   try {
     plan = await planRunCommand(
-      values,
+      { ...values, positionals },
       resolveScenarioOption,
       {
         defaultGenerations: settings.defaultGenerations,
@@ -531,11 +535,13 @@ async function cmdRun(dbPath: string): Promise<void> {
 }
 
 async function cmdSolve(dbPath: string): Promise<void> {
-  const { values } = parseArgs({
+  const { values, positionals } = parseArgs({
     args: process.argv.slice(3),
+    allowPositionals: true,
     options: {
       description: { type: "string", short: "d" },
       gens: { type: "string", short: "g" },
+      iterations: { type: "string" },
       timeout: { type: "string" },
       "generation-time-budget": { type: "string" },
       family: { type: "string" },
@@ -560,7 +566,7 @@ async function cmdSolve(dbPath: string): Promise<void> {
 
   let plan;
   try {
-    plan = planSolveCommand(values, parsePositiveInteger);
+    plan = planSolveCommand({ ...values, positionals }, parsePositiveInteger);
   } catch (error) {
     console.error(errorMessage(error));
     process.exit(1);
@@ -972,10 +978,41 @@ async function cmdQueue(dbPath: string): Promise<void> {
 }
 
 async function cmdStatus(dbPath: string): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(3),
+    allowPositionals: true,
+    options: {
+      "run-id": { type: "string" },
+      json: { type: "boolean" },
+      help: { type: "boolean", short: "h" },
+    },
+  });
+
+  const runId = values["run-id"]?.trim() || positionals[0]?.trim();
+  if (values.help) {
+    const { RUN_STATUS_HELP_TEXT } = await import("./run-inspection-command-workflow.js");
+    console.log(RUN_STATUS_HELP_TEXT);
+    process.exit(0);
+  }
+
   const { executeStatusCommandWorkflow, renderStatusResult } =
     await import("./queue-status-command-workflow.js");
   const { SQLiteStore } = await import("../storage/index.js");
   const store = new SQLiteStore(dbPath);
+
+  if (runId) {
+    const { renderRunStatus } = await import("./run-inspection-command-workflow.js");
+    store.migrate(getMigrationsDir());
+    const run = store.getRun(runId);
+    if (!run) {
+      console.error(`Error: run '${runId}' not found`);
+      store.close();
+      process.exit(1);
+    }
+    console.log(renderRunStatus(run, store.getGenerations(runId), !!values.json));
+    store.close();
+    return;
+  }
 
   console.log(
     renderStatusResult(
@@ -985,6 +1022,7 @@ async function cmdStatus(dbPath: string): Promise<void> {
       }),
     ),
   );
+  store.close();
 }
 
 async function cmdServeHttp(dbPath: string): Promise<void> {
@@ -1190,6 +1228,112 @@ async function cmdReplay(_dbPath: string): Promise<void> {
   }
 }
 
+async function cmdShow(dbPath: string): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(3),
+    allowPositionals: true,
+    options: {
+      "run-id": { type: "string" },
+      generation: { type: "string" },
+      best: { type: "boolean" },
+      json: { type: "boolean" },
+      help: { type: "boolean", short: "h" },
+    },
+  });
+
+  const {
+    renderRunShow,
+    resolveRunId,
+    SHOW_HELP_TEXT,
+  } = await import("./run-inspection-command-workflow.js");
+
+  if (values.help) {
+    console.log(SHOW_HELP_TEXT);
+    process.exit(0);
+  }
+
+  let runId;
+  try {
+    runId = resolveRunId(values, positionals, "show");
+  } catch (error) {
+    console.error(errorMessage(error));
+    process.exit(1);
+  }
+
+  const { SQLiteStore } = await import("../storage/index.js");
+  const store = new SQLiteStore(dbPath);
+  store.migrate(getMigrationsDir());
+  try {
+    const run = store.getRun(runId);
+    if (!run) {
+      throw new Error(`Error: run '${runId}' not found`);
+    }
+    console.log(renderRunShow(run, store.getGenerations(runId), values));
+  } catch (error) {
+    console.error(errorMessage(error));
+    process.exit(1);
+  } finally {
+    store.close();
+  }
+}
+
+async function cmdWatch(dbPath: string): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(3),
+    allowPositionals: true,
+    options: {
+      "run-id": { type: "string" },
+      interval: { type: "string" },
+      json: { type: "boolean" },
+      help: { type: "boolean", short: "h" },
+    },
+  });
+
+  const {
+    parseWatchIntervalSeconds,
+    renderRunStatus,
+    resolveRunId,
+    WATCH_HELP_TEXT,
+  } = await import("./run-inspection-command-workflow.js");
+
+  if (values.help) {
+    console.log(WATCH_HELP_TEXT);
+    process.exit(0);
+  }
+
+  let runId;
+  let intervalSeconds;
+  try {
+    runId = resolveRunId(values, positionals, "watch");
+    intervalSeconds = parseWatchIntervalSeconds(values.interval);
+  } catch (error) {
+    console.error(errorMessage(error));
+    process.exit(1);
+  }
+
+  const { SQLiteStore } = await import("../storage/index.js");
+  const store = new SQLiteStore(dbPath);
+  store.migrate(getMigrationsDir());
+  try {
+    while (true) {
+      const run = store.getRun(runId);
+      if (!run) {
+        throw new Error(`Error: run '${runId}' not found`);
+      }
+      console.log(renderRunStatus(run, store.getGenerations(runId), !!values.json));
+      if (run.status !== "running") {
+        return;
+      }
+      await new Promise((resolveSleep) => setTimeout(resolveSleep, intervalSeconds * 1000));
+    }
+  } catch (error) {
+    console.error(errorMessage(error));
+    process.exit(1);
+  } finally {
+    store.close();
+  }
+}
+
 async function cmdBenchmark(dbPath: string): Promise<void> {
   const { values } = parseArgs({
     args: process.argv.slice(3),
@@ -1271,10 +1415,12 @@ async function cmdBenchmark(dbPath: string): Promise<void> {
 }
 
 async function cmdExport(dbPath: string): Promise<void> {
-  const { values } = parseArgs({
+  const { values, positionals } = parseArgs({
     args: process.argv.slice(3),
+    allowPositionals: true,
     options: {
       scenario: { type: "string", short: "s" },
+      "run-id": { type: "string" },
       output: { type: "string", short: "o" },
       json: { type: "boolean" },
       help: { type: "boolean", short: "h" },
@@ -1292,14 +1438,6 @@ async function cmdExport(dbPath: string): Promise<void> {
     process.exit(0);
   }
 
-  let plan;
-  try {
-    plan = await planExportCommand(values, resolveScenarioOption);
-  } catch (error) {
-    console.error(errorMessage(error));
-    process.exit(1);
-  }
-
   const { loadSettings } = await import("../config/index.js");
   const { ArtifactStore } = await import("../knowledge/artifact-store.js");
   const { exportStrategyPackage } = await import("../knowledge/package.js");
@@ -1308,6 +1446,20 @@ async function cmdExport(dbPath: string): Promise<void> {
   const settings = loadSettings();
   const store = new SQLiteStore(dbPath);
   store.migrate(getMigrationsDir());
+
+  let plan;
+  try {
+    plan = await planExportCommand(
+      { ...values, positionals },
+      resolveScenarioOption,
+      async (runId) => store.getRun(runId)?.scenario,
+    );
+  } catch (error) {
+    console.error(errorMessage(error));
+    store.close();
+    process.exit(1);
+  }
+
   const artifacts = new ArtifactStore({
     runsRoot: resolve(settings.runsRoot),
     knowledgeRoot: resolve(settings.knowledgeRoot),
@@ -1317,6 +1469,7 @@ async function cmdExport(dbPath: string): Promise<void> {
     console.log(
       executeExportCommandWorkflow({
         scenarioName: plan.scenarioName,
+        runId: plan.runId,
         output: plan.output,
         json: plan.json,
         exportStrategyPackage,

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -1292,6 +1292,7 @@ async function cmdWatch(dbPath: string): Promise<void> {
   const {
     parseWatchIntervalSeconds,
     renderRunStatus,
+    renderRunStatusJsonLine,
     resolveRunId,
     WATCH_HELP_TEXT,
   } = await import("./run-inspection-command-workflow.js");
@@ -1320,7 +1321,12 @@ async function cmdWatch(dbPath: string): Promise<void> {
       if (!run) {
         throw new Error(`Error: run '${runId}' not found`);
       }
-      console.log(renderRunStatus(run, store.getGenerations(runId), !!values.json));
+      const generations = store.getGenerations(runId);
+      console.log(
+        values.json
+          ? renderRunStatusJsonLine(run, generations)
+          : renderRunStatus(run, generations, false),
+      );
       if (run.status !== "running") {
         return;
       }

--- a/ts/src/cli/run-command-workflow.ts
+++ b/ts/src/cli/run-command-workflow.ts
@@ -3,10 +3,12 @@ import type { HookBus } from "../extensions/index.js";
 export const RUN_HELP_TEXT = `autoctx run — Run the generation loop for a scenario
 
 Usage: autoctx run [options]
+Usage: autoctx run <scenario> [options]
 
 Options:
   --scenario <name>    Scenario to run (built-in or saved custom agent_task)
   --gens N             Number of generations to run (default: from config or 1)
+  --iterations N       Plain-language alias for --gens
   --run-id <id>        Custom run identifier (default: auto-generated)
   --provider <type>    LLM provider: anthropic, openai, ollama, deterministic, etc.
   --matches N          Matches per generation (default: 3)
@@ -15,15 +17,17 @@ Options:
 If project config (.autoctx.json) exists, --scenario and --gens default from it.
 
 Examples:
+  autoctx run grid_ctf --iterations 3
   autoctx run --scenario grid_ctf --provider deterministic --gens 3
-  autoctx run --scenario grid_ctf --gens 5 --matches 5
   autoctx run                          # uses defaults from .autoctx.json
 
 See also: list, replay, export, benchmark`;
 
 export interface RunCommandValues {
   scenario?: string;
+  positionals?: string[];
   gens?: string;
+  iterations?: string;
   "run-id"?: string;
   provider?: string;
   matches?: string;
@@ -186,17 +190,20 @@ export async function planRunCommand(
   now: () => number,
   parsePositiveInteger: (raw: string, label: string) => number,
 ): Promise<RunCommandPlan> {
-  const scenarioName = await resolveScenarioOption(values.scenario);
+  const scenarioInput = values.scenario?.trim() || values.positionals?.[0]?.trim();
+  const scenarioName = await resolveScenarioOption(scenarioInput);
   if (!scenarioName) {
     throw new Error(
-      "Error: no scenario configured. Run `autoctx init` or pass --scenario <name>.",
+      "Error: no scenario configured. Run `autoctx init` or pass <scenario> / --scenario <name>.",
     );
   }
+  const generationRaw = values.gens ?? values.iterations;
+  const generationLabel = values.gens ? "--gens" : "--iterations";
 
   return {
     scenarioName,
-    gens: values.gens
-      ? parsePositiveInteger(values.gens, "--gens")
+    gens: generationRaw
+      ? parsePositiveInteger(generationRaw, generationLabel)
       : settings.defaultGenerations,
     runId: values["run-id"] ?? `run-${now()}`,
     providerType: values.provider,

--- a/ts/src/cli/run-inspection-command-workflow.ts
+++ b/ts/src/cli/run-inspection-command-workflow.ts
@@ -1,0 +1,164 @@
+export const RUN_STATUS_HELP_TEXT = `autoctx status — show queue status or a run status
+
+Usage:
+  autoctx status
+  autoctx status <run-id> [--json]
+  autoctx status --run-id <run-id> [--json]
+
+Examples:
+  autoctx status
+  autoctx status run-123`;
+
+export const SHOW_HELP_TEXT = `autoctx show — show the best or latest generation for a run
+
+Usage:
+  autoctx show <run-id> [--best] [--json]
+  autoctx show --run-id <run-id> [--generation N] [--json]
+
+Examples:
+  autoctx show run-123 --best
+  autoctx show --run-id run-123 --generation 2 --json`;
+
+export const WATCH_HELP_TEXT = `autoctx watch — follow a run until it finishes
+
+Usage:
+  autoctx watch <run-id> [--interval seconds] [--json]
+  autoctx watch --run-id <run-id> [--interval seconds] [--json]
+
+Examples:
+  autoctx watch run-123
+  autoctx watch --run-id run-123 --interval 2`;
+
+export interface RunInspectionRun {
+  run_id: string;
+  scenario: string;
+  target_generations: number;
+  executor_mode: string;
+  status: string;
+  agent_provider: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RunInspectionGeneration {
+  generation_index: number;
+  mean_score: number;
+  best_score: number;
+  elo: number;
+  gate_decision: string;
+  status: string;
+  duration_seconds: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RunIdValues {
+  "run-id"?: string;
+}
+
+export interface ShowValues extends RunIdValues {
+  generation?: string;
+  best?: boolean;
+  json?: boolean;
+}
+
+export function resolveRunId(
+  values: RunIdValues,
+  positionals: string[],
+  commandName: "status" | "show" | "watch",
+): string {
+  const runId = values["run-id"]?.trim() || positionals[0]?.trim();
+  if (!runId) {
+    throw new Error(`Error: ${commandName} needs a run id. Use 'autoctx ${commandName} <run-id>'.`);
+  }
+  return runId;
+}
+
+export function parseWatchIntervalSeconds(raw: string | undefined): number {
+  const parsed = Number.parseFloat(raw ?? "2");
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error("Error: --interval must be a positive number of seconds");
+  }
+  return parsed;
+}
+
+export function renderRunStatus(
+  run: RunInspectionRun,
+  generations: RunInspectionGeneration[],
+  json: boolean,
+): string {
+  const latest = latestGeneration(generations);
+  if (json) {
+    return JSON.stringify({ run, latest_generation: latest }, null, 2);
+  }
+
+  return [
+    `Run ${run.run_id}`,
+    `  Status: ${run.status}`,
+    `  Scenario: ${run.scenario}`,
+    `  Generations: ${generations.length}/${run.target_generations}`,
+    latest ? `  Latest best score: ${formatScore(latest.best_score)} (generation ${latest.generation_index})` : null,
+    latest ? `  Latest gate: ${latest.gate_decision}` : null,
+  ].filter((line): line is string => line !== null).join("\n");
+}
+
+export function renderRunShow(
+  run: RunInspectionRun,
+  generations: RunInspectionGeneration[],
+  values: ShowValues,
+): string {
+  const generation = selectGeneration(generations, values);
+  if (!generation) {
+    throw new Error(`Error: run '${run.run_id}' has no generations yet`);
+  }
+
+  if (values.json) {
+    return JSON.stringify({ run, generation }, null, 2);
+  }
+
+  return [
+    `Run ${run.run_id}`,
+    `  Scenario: ${run.scenario}`,
+    `  Generation: ${generation.generation_index}`,
+    `  Status: ${generation.status}`,
+    `  Best score: ${formatScore(generation.best_score)}`,
+    `  Mean score: ${formatScore(generation.mean_score)}`,
+    `  ELO: ${formatScore(generation.elo)}`,
+    `  Gate: ${generation.gate_decision}`,
+  ].join("\n");
+}
+
+function selectGeneration(
+  generations: RunInspectionGeneration[],
+  values: ShowValues,
+): RunInspectionGeneration | null {
+  if (values.generation) {
+    const requested = Number.parseInt(values.generation, 10);
+    if (!Number.isInteger(requested) || requested <= 0) {
+      throw new Error("Error: --generation must be a positive integer");
+    }
+    return generations.find((generation) => generation.generation_index === requested) ?? null;
+  }
+
+  return values.best ? bestGeneration(generations) : latestGeneration(generations);
+}
+
+function latestGeneration(generations: RunInspectionGeneration[]): RunInspectionGeneration | null {
+  return generations.reduce<RunInspectionGeneration | null>(
+    (latest, generation) =>
+      !latest || generation.generation_index > latest.generation_index ? generation : latest,
+    null,
+  );
+}
+
+function bestGeneration(generations: RunInspectionGeneration[]): RunInspectionGeneration | null {
+  return generations.reduce<RunInspectionGeneration | null>(
+    (best, generation) =>
+      !best || generation.best_score > best.best_score ? generation : best,
+    null,
+  );
+}
+
+function formatScore(score: number): string {
+  return Number.isFinite(score) ? score.toFixed(3) : String(score);
+}

--- a/ts/src/cli/run-inspection-command-workflow.ts
+++ b/ts/src/cli/run-inspection-command-workflow.ts
@@ -25,6 +25,9 @@ Usage:
   autoctx watch <run-id> [--interval seconds] [--json]
   autoctx watch --run-id <run-id> [--interval seconds] [--json]
 
+Options:
+  --json               Emit compact newline-delimited JSON snapshots
+
 Examples:
   autoctx watch run-123
   autoctx watch --run-id run-123 --interval 2`;
@@ -87,11 +90,11 @@ export function renderRunStatus(
   generations: RunInspectionGeneration[],
   json: boolean,
 ): string {
-  const latest = latestGeneration(generations);
   if (json) {
-    return JSON.stringify({ run, latest_generation: latest }, null, 2);
+    return JSON.stringify(runStatusPayload(run, generations), null, 2);
   }
 
+  const latest = latestGeneration(generations);
   return [
     `Run ${run.run_id}`,
     `  Status: ${run.status}`,
@@ -100,6 +103,13 @@ export function renderRunStatus(
     latest ? `  Latest best score: ${formatScore(latest.best_score)} (generation ${latest.generation_index})` : null,
     latest ? `  Latest gate: ${latest.gate_decision}` : null,
   ].filter((line): line is string => line !== null).join("\n");
+}
+
+export function renderRunStatusJsonLine(
+  run: RunInspectionRun,
+  generations: RunInspectionGeneration[],
+): string {
+  return JSON.stringify(runStatusPayload(run, generations));
 }
 
 export function renderRunShow(
@@ -149,6 +159,19 @@ function latestGeneration(generations: RunInspectionGeneration[]): RunInspection
       !latest || generation.generation_index > latest.generation_index ? generation : latest,
     null,
   );
+}
+
+function runStatusPayload(
+  run: RunInspectionRun,
+  generations: RunInspectionGeneration[],
+): {
+  run: RunInspectionRun;
+  latest_generation: RunInspectionGeneration | null;
+} {
+  return {
+    run,
+    latest_generation: latestGeneration(generations),
+  };
 }
 
 function bestGeneration(generations: RunInspectionGeneration[]): RunInspectionGeneration | null {

--- a/ts/src/cli/solve-command-workflow.ts
+++ b/ts/src/cli/solve-command-workflow.ts
@@ -4,11 +4,14 @@ import { dirname } from "node:path";
 export const SOLVE_HELP_TEXT = `autoctx solve — create and solve a scenario from a plain-language description
 
 Usage:
+  autoctx solve "..." [--iterations N] [--family name] [--json]
   autoctx solve --description "..." [--gens N] [--family name] [--json]
 
 Options:
-  -d, --description <text>   Natural-language scenario/problem description
+  <text>                     Plain-language scenario/problem description
+  -d, --description <text>   Same description as a named option
   -g, --gens <N>             Generations to run (default: 5)
+  --iterations <N>           Plain-language alias for --gens
   --family <name>            Force a scenario family before creation/routing
   --timeout <seconds>        Maximum time to wait for solve completion (default: 300)
   --generation-time-budget <seconds>
@@ -18,12 +21,14 @@ Options:
   -h, --help                 Show this help
 
 Examples:
-  autoctx solve --description "improve customer-support replies for billing disputes" --gens 3
+  autoctx solve "improve customer-support replies for billing disputes" --iterations 3
   autoctx solve -d "investigate a production outage from logs" --family investigation --gens 2 --json`;
 
 export interface SolveCommandValues {
   description?: string;
+  positionals?: string[];
   gens?: string;
+  iterations?: string;
   timeout?: string;
   "generation-time-budget"?: string;
   family?: string;
@@ -75,9 +80,12 @@ export function planSolveCommand(
   values: SolveCommandValues,
   parsePositiveInteger: (raw: string | undefined, label: string) => number,
 ): SolveCommandPlan {
-  const description = values.description?.trim();
+  const positionalDescription = values.positionals?.join(" ").trim();
+  const description = values.description?.trim() || positionalDescription;
   if (!description) {
-    throw new Error("Error: --description is required. Run 'autoctx solve --help' for usage.");
+    throw new Error(
+      "Error: --description is required. You can also run 'autoctx solve \"plain-language goal\"'. Run 'autoctx solve --help' for usage.",
+    );
   }
 
   const timeoutMs = values.timeout
@@ -87,9 +95,12 @@ export function planSolveCommand(
     ? null
     : parseNonNegativeInteger(values["generation-time-budget"], "--generation-time-budget");
 
+  const generationsRaw = values.gens ?? values.iterations;
+  const generationsLabel = values.gens ? "--gens" : "--iterations";
+
   return {
     description,
-    generations: values.gens ? parsePositiveInteger(values.gens, "--gens") : 5,
+    generations: generationsRaw ? parsePositiveInteger(generationsRaw, generationsLabel) : 5,
     timeoutMs,
     generationTimeBudgetSeconds,
     familyOverride: values.family?.trim() ? values.family.trim() : null,

--- a/ts/src/knowledge/package.ts
+++ b/ts/src/knowledge/package.ts
@@ -68,7 +68,7 @@ export function exportStrategyPackage(opts: {
     playbook,
     lessons: lessonsFromPlaybook(playbook),
     bestStrategy: opts.sourceRunId && bestGeneration
-      ? bestStrategyForRun(opts.store, opts.sourceRunId, bestGeneration.generation_index, persisted)
+      ? bestStrategyForRun(opts.store, opts.sourceRunId, bestGeneration.generation_index)
       : bestStrategyForScenario(opts.store, opts.scenarioName, persisted),
     bestScore: bestGeneration?.best_score ?? persisted.best_score ?? 0,
     bestElo: bestGeneration?.elo ?? persisted.best_elo ?? 1500,
@@ -121,7 +121,6 @@ function bestStrategyForRun(
   store: SQLiteStore,
   runId: string,
   generationIndex: number,
-  persisted: PersistedPackageMetadata,
 ): Record<string, unknown> | null {
   const match = bestMatchForRunGeneration(store.getMatchesForRun(runId), generationIndex);
   const parsedMatch = parseStrategyJson(match?.strategy_json);
@@ -134,7 +133,7 @@ function bestStrategyForRun(
     .filter((output) => output.role === "competitor")
     .at(-1);
   const parsedCompetitor = parseStrategyJson(competitor?.content);
-  return parsedCompetitor ?? persisted.best_strategy ?? null;
+  return parsedCompetitor ?? null;
 }
 
 function bestMatchForRunGeneration(

--- a/ts/src/knowledge/package.ts
+++ b/ts/src/knowledge/package.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { SQLiteStore } from "../storage/index.js";
+import type { GenerationRow, MatchRow } from "../storage/storage-contracts.js";
 import { ArtifactStore, EMPTY_PLAYBOOK_SENTINEL } from "./artifact-store.js";
 import { HarnessStore } from "./harness-store.js";
 import {
@@ -34,12 +35,26 @@ export type { ConflictPolicy, ImportStrategyPackageResult, StrategyPackageData }
 
 export function exportStrategyPackage(opts: {
   scenarioName: string;
+  sourceRunId?: string;
   artifacts: ArtifactStore;
   store: SQLiteStore;
 }): Record<string, unknown> {
+  const sourceRun = opts.sourceRunId ? opts.store.getRun(opts.sourceRunId) : null;
+  if (opts.sourceRunId && !sourceRun) {
+    throw new Error(`Unknown run: ${opts.sourceRunId}`);
+  }
+  if (sourceRun && sourceRun.scenario !== opts.scenarioName) {
+    throw new Error(`Run '${opts.sourceRunId}' belongs to scenario '${sourceRun.scenario}', not '${opts.scenarioName}'`);
+  }
+
   const persisted = readPackageMetadata(opts.artifacts.knowledgeRoot, opts.scenarioName);
   const playbook = opts.artifacts.readPlaybook(opts.scenarioName);
-  const bestGeneration = opts.store.getBestGenerationForScenario(opts.scenarioName);
+  const bestGeneration = opts.sourceRunId
+    ? bestGenerationForRun(opts.store.getGenerations(opts.sourceRunId), opts.sourceRunId)
+    : opts.store.getBestGenerationForScenario(opts.scenarioName);
+  if (opts.sourceRunId && !bestGeneration) {
+    throw new Error(`No generation metrics found for run ${opts.sourceRunId}`);
+  }
   const completedRuns = opts.store.countCompletedRuns(opts.scenarioName);
   const persistedMeta =
     persisted.metadata && typeof persisted.metadata === "object" && !Array.isArray(persisted.metadata)
@@ -52,7 +67,9 @@ export function exportStrategyPackage(opts: {
     description: descriptionForScenario(opts.scenarioName),
     playbook,
     lessons: lessonsFromPlaybook(playbook),
-    bestStrategy: bestStrategyForScenario(opts.store, opts.scenarioName, persisted),
+    bestStrategy: opts.sourceRunId && bestGeneration
+      ? bestStrategyForRun(opts.store, opts.sourceRunId, bestGeneration.generation_index, persisted)
+      : bestStrategyForScenario(opts.store, opts.scenarioName, persisted),
     bestScore: bestGeneration?.best_score ?? persisted.best_score ?? 0,
     bestElo: bestGeneration?.elo ?? persisted.best_elo ?? 1500,
     hints: hintsFromPlaybook(playbook),
@@ -73,10 +90,79 @@ export function exportStrategyPackage(opts: {
       source_run_id:
         bestGeneration?.run_id
         ?? (typeof persistedMeta.source_run_id === "string" ? persistedMeta.source_run_id : null),
+      source_generation:
+        bestGeneration?.generation_index
+        ?? (typeof persistedMeta.source_generation === "number" ? persistedMeta.source_generation : null),
     },
   });
 
   return serializeSkillPackage(pkg, PACKAGE_FORMAT_VERSION);
+}
+
+function bestGenerationForRun(
+  generations: GenerationRow[],
+  runId: string,
+): (GenerationRow & { run_id: string }) | null {
+  const best = generations.reduce<GenerationRow | null>((currentBest, generation) => {
+    if (!currentBest) return generation;
+    if (generation.best_score > currentBest.best_score) return generation;
+    if (
+      generation.best_score === currentBest.best_score
+      && generation.generation_index > currentBest.generation_index
+    ) {
+      return generation;
+    }
+    return currentBest;
+  }, null);
+  return best ? { ...best, run_id: runId } : null;
+}
+
+function bestStrategyForRun(
+  store: SQLiteStore,
+  runId: string,
+  generationIndex: number,
+  persisted: PersistedPackageMetadata,
+): Record<string, unknown> | null {
+  const match = bestMatchForRunGeneration(store.getMatchesForRun(runId), generationIndex);
+  const parsedMatch = parseStrategyJson(match?.strategy_json);
+  if (parsedMatch) {
+    return parsedMatch;
+  }
+
+  const competitor = store
+    .getAgentOutputs(runId, generationIndex)
+    .filter((output) => output.role === "competitor")
+    .at(-1);
+  const parsedCompetitor = parseStrategyJson(competitor?.content);
+  return parsedCompetitor ?? persisted.best_strategy ?? null;
+}
+
+function bestMatchForRunGeneration(
+  matches: MatchRow[],
+  generationIndex: number,
+): MatchRow | null {
+  return matches
+    .filter((match) => match.generation_index === generationIndex)
+    .reduce<MatchRow | null>((best, match) => {
+      if (!best) return match;
+      if (match.score > best.score) return match;
+      if (match.score === best.score && match.id > best.id) return match;
+      return best;
+    }, null);
+}
+
+function parseStrategyJson(raw: string | undefined): Record<string, unknown> | null {
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 export interface SerializedSkillPackageDict extends SkillPackageDict {

--- a/ts/src/tui/commands.ts
+++ b/ts/src/tui/commands.ts
@@ -54,9 +54,48 @@ function applyProviderSelection(
   return selection;
 }
 
+function unquotePlainGoal(raw: string): string {
+  const trimmed = raw.trim();
+  const quoted = trimmed.match(/^"(.+)"$/);
+  return (quoted?.[1] ?? trimmed).trim();
+}
+
+function resolveTuiRunId(raw: string, manager: RunManager): string | null {
+  const [, runId] = raw.split(/\s+/, 2);
+  return runId?.trim() || manager.getState().runId || null;
+}
+
+async function loadTuiRunInspection(
+  manager: RunManager,
+  runId: string,
+): Promise<{
+  run: import("../cli/run-inspection-command-workflow.js").RunInspectionRun;
+  generations: import("../cli/run-inspection-command-workflow.js").RunInspectionGeneration[];
+}> {
+  const { SQLiteStore } = await import("../storage/index.js");
+  const store = new SQLiteStore(manager.getDbPath());
+  store.migrate(manager.getMigrationsDir());
+  try {
+    const run = store.getRun(runId);
+    if (!run) {
+      throw new Error(`run '${runId}' not found`);
+    }
+    return {
+      run,
+      generations: store.getGenerations(runId),
+    };
+  } finally {
+    store.close();
+  }
+}
+
 export function formatCommandHelp(): string[] {
   return [
-    "/run <scenario> [gens]",
+    '/solve "plain-language goal"',
+    "/run <scenario> [iterations]",
+    "/status <run-id>",
+    "/show <run-id> --best",
+    "/watch <run-id>",
     "/pause or /resume",
     "/hint <text>",
     "/gate <advance|retry|rollback>",
@@ -134,12 +173,84 @@ export async function handleInteractiveTuiCommand(args: {
     };
   }
 
+  if (value.startsWith("/solve ")) {
+    const description = unquotePlainGoal(value.slice("/solve ".length));
+    if (!description) {
+      return { logLines: ['usage: /solve "plain-language goal"'], pendingLogin: null };
+    }
+    try {
+      const preview = await manager.createScenario(description);
+      const ready = await manager.confirmScenario();
+      const runId = await manager.startRun(ready.name, 5);
+      return {
+        logLines: [
+          `created scenario ${preview.name}`,
+          `accepted run ${runId}`,
+        ],
+        pendingLogin: null,
+      };
+    } catch (err) {
+      return { logLines: [err instanceof Error ? err.message : String(err)], pendingLogin: null };
+    }
+  }
+
   if (value.startsWith("/run ")) {
     const [, scenario = "grid_ctf", gensText = "5"] = value.split(/\s+/, 3);
     const generations = Number.parseInt(gensText, 10);
     try {
       const runId = await manager.startRun(scenario, Number.isFinite(generations) ? generations : 5);
       return { logLines: [`accepted run ${runId}`], pendingLogin: null };
+    } catch (err) {
+      return { logLines: [err instanceof Error ? err.message : String(err)], pendingLogin: null };
+    }
+  }
+
+  if (value === "/status" || value.startsWith("/status ")) {
+    const runId = resolveTuiRunId(value, manager);
+    if (!runId) {
+      return { logLines: ["usage: /status <run-id>"], pendingLogin: null };
+    }
+    try {
+      const { renderRunStatus } = await import("../cli/run-inspection-command-workflow.js");
+      const { run, generations } = await loadTuiRunInspection(manager, runId);
+      return { logLines: renderRunStatus(run, generations, false).split("\n"), pendingLogin: null };
+    } catch (err) {
+      return { logLines: [err instanceof Error ? err.message : String(err)], pendingLogin: null };
+    }
+  }
+
+  if (value === "/show" || value.startsWith("/show ")) {
+    const runId = resolveTuiRunId(value, manager);
+    if (!runId) {
+      return { logLines: ["usage: /show <run-id> [--best]"], pendingLogin: null };
+    }
+    try {
+      const { renderRunShow } = await import("../cli/run-inspection-command-workflow.js");
+      const { run, generations } = await loadTuiRunInspection(manager, runId);
+      return {
+        logLines: renderRunShow(run, generations, { best: value.includes("--best") }).split("\n"),
+        pendingLogin: null,
+      };
+    } catch (err) {
+      return { logLines: [err instanceof Error ? err.message : String(err)], pendingLogin: null };
+    }
+  }
+
+  if (value === "/watch" || value.startsWith("/watch ")) {
+    const runId = resolveTuiRunId(value, manager);
+    if (!runId) {
+      return { logLines: ["usage: /watch <run-id>"], pendingLogin: null };
+    }
+    try {
+      const { renderRunStatus } = await import("../cli/run-inspection-command-workflow.js");
+      const { run, generations } = await loadTuiRunInspection(manager, runId);
+      return {
+        logLines: [
+          `watching ${runId}`,
+          ...renderRunStatus(run, generations, false).split("\n"),
+        ],
+        pendingLogin: null,
+      };
     } catch (err) {
       return { logLines: [err instanceof Error ? err.message : String(err)], pendingLogin: null };
     }

--- a/ts/tests/cli-help.test.ts
+++ b/ts/tests/cli-help.test.ts
@@ -29,6 +29,14 @@ describe("Top-level --help", () => {
     expect(out).toContain("list");
     expect(out).toContain("replay");
   });
+
+  it("leads with plain-language paved-road examples", () => {
+    const out = runHelp("");
+    expect(out).toContain('autoctx solve "build an orbital transfer optimizer"');
+    expect(out).toContain("autoctx show <run-id> --best");
+    expect(out).toContain("autoctx watch <run-id>");
+    expect(out).toContain("autoctx export <run-id>");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -137,6 +145,7 @@ describe("export --help", () => {
   const out = runHelp("export");
 
   it("includes flag descriptions", () => {
+    expect(out).toContain("autoctx export <run-id>");
     expect(out).toContain("--scenario");
     expect(out).toContain("--output");
   });

--- a/ts/tests/export-command-workflow.test.ts
+++ b/ts/tests/export-command-workflow.test.ts
@@ -9,6 +9,7 @@ import {
 describe("export command workflow", () => {
   it("exposes stable help text", () => {
     expect(EXPORT_HELP_TEXT).toContain("autoctx export");
+    expect(EXPORT_HELP_TEXT).toContain("autoctx export <run-id>");
     expect(EXPORT_HELP_TEXT).toContain("--scenario");
     expect(EXPORT_HELP_TEXT).toContain("import-package");
   });
@@ -18,8 +19,9 @@ describe("export command workflow", () => {
       planExportCommand(
         { scenario: undefined, output: undefined, json: false },
         async () => undefined,
+        async () => undefined,
       ),
-    ).rejects.toThrow("Error: --scenario is required");
+    ).rejects.toThrow("Error: --scenario or <run-id> is required");
   });
 
   it("plans export with resolved scenario and output options", async () => {
@@ -27,11 +29,54 @@ describe("export command workflow", () => {
       planExportCommand(
         { scenario: "grid_ctf", output: "/tmp/pkg.json", json: true },
         async (value: string | undefined) => `${value}_resolved`,
+        async () => undefined,
       ),
     ).resolves.toEqual({
       scenarioName: "grid_ctf_resolved",
+      runId: undefined,
       output: "/tmp/pkg.json",
       json: true,
+    });
+  });
+
+  it("plans export from a positional run id", async () => {
+    await expect(
+      planExportCommand(
+        { positionals: ["run-123"], json: true },
+        async () => undefined,
+        async (runId: string) => (runId === "run-123" ? "grid_ctf" : undefined),
+      ),
+    ).resolves.toEqual({
+      scenarioName: "grid_ctf",
+      runId: "run-123",
+      output: undefined,
+      json: true,
+    });
+  });
+
+  it("prefers precise scenario flags over positional run ids", async () => {
+    await expect(
+      planExportCommand(
+        { scenario: "support_triage", positionals: ["run-123"] },
+        async (scenario: string | undefined) => `${scenario}_resolved`,
+        async () => "grid_ctf",
+      ),
+    ).resolves.toMatchObject({
+      scenarioName: "support_triage_resolved",
+      runId: undefined,
+    });
+  });
+
+  it("keeps a named run id when paired with an explicit scenario", async () => {
+    await expect(
+      planExportCommand(
+        { scenario: "grid_ctf", "run-id": "run-123" },
+        async (scenario: string | undefined) => scenario,
+        async (runId: string) => (runId === "run-123" ? "grid_ctf" : undefined),
+      ),
+    ).resolves.toMatchObject({
+      scenarioName: "grid_ctf",
+      runId: "run-123",
     });
   });
 
@@ -40,6 +85,7 @@ describe("export command workflow", () => {
 
     const rendered = executeExportCommandWorkflow({
       scenarioName: "grid_ctf",
+      runId: "run-123",
       exportStrategyPackage,
       artifacts: { kind: "artifacts" },
       store: { kind: "store" },
@@ -47,6 +93,7 @@ describe("export command workflow", () => {
 
     expect(exportStrategyPackage).toHaveBeenCalledWith({
       scenarioName: "grid_ctf",
+      sourceRunId: "run-123",
       artifacts: { kind: "artifacts" },
       store: { kind: "store" },
     });

--- a/ts/tests/run-command-workflow.test.ts
+++ b/ts/tests/run-command-workflow.test.ts
@@ -14,6 +14,7 @@ describe("run command workflow", () => {
     expect(RUN_HELP_TEXT).toContain("autoctx run");
     expect(RUN_HELP_TEXT).toContain("--scenario");
     expect(RUN_HELP_TEXT).toContain("--gens");
+    expect(RUN_HELP_TEXT).toContain("--iterations");
     expect(RUN_HELP_TEXT).toContain("--matches");
   });
 
@@ -37,7 +38,7 @@ describe("run command workflow", () => {
         vi.fn((raw: string) => Number.parseInt(raw, 10)),
       ),
     ).rejects.toThrow(
-      "Error: no scenario configured. Run `autoctx init` or pass --scenario <name>.",
+      "Error: no scenario configured. Run `autoctx init` or pass <scenario> / --scenario <name>.",
     );
   });
 
@@ -73,6 +74,57 @@ describe("run command workflow", () => {
 
     expect(parsePositiveInteger).toHaveBeenNthCalledWith(1, "5", "--gens");
     expect(parsePositiveInteger).toHaveBeenNthCalledWith(2, "7", "--matches");
+  });
+
+  it("accepts a positional scenario and iterations alias", async () => {
+    const parsePositiveInteger = vi.fn((raw: string) => Number.parseInt(raw, 10));
+
+    await expect(
+      planRunCommand(
+        {
+          positionals: ["grid_ctf"],
+          iterations: "4",
+          matches: "2",
+        },
+        async (value: string | undefined) => value,
+        {
+          defaultGenerations: 1,
+          matchesPerGeneration: 3,
+        },
+        () => 12345,
+        parsePositiveInteger,
+      ),
+    ).resolves.toMatchObject({
+      scenarioName: "grid_ctf",
+      gens: 4,
+      matches: 2,
+    });
+
+    expect(parsePositiveInteger).toHaveBeenNthCalledWith(1, "4", "--iterations");
+    expect(parsePositiveInteger).toHaveBeenNthCalledWith(2, "2", "--matches");
+  });
+
+  it("prefers precise --scenario and --gens flags over positional aliases", async () => {
+    await expect(
+      planRunCommand(
+        {
+          scenario: "support_triage",
+          positionals: ["grid_ctf"],
+          gens: "5",
+          iterations: "4",
+        },
+        async (value: string | undefined) => value,
+        {
+          defaultGenerations: 1,
+          matchesPerGeneration: 3,
+        },
+        () => 12345,
+        (raw: string) => Number.parseInt(raw, 10),
+      ),
+    ).resolves.toMatchObject({
+      scenarioName: "support_triage",
+      gens: 5,
+    });
   });
 
   it("resolves known run scenarios and rejects unknown ones with available names", () => {

--- a/ts/tests/run-inspection-command-workflow.test.ts
+++ b/ts/tests/run-inspection-command-workflow.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   parseWatchIntervalSeconds,
+  renderRunStatusJsonLine,
   renderRunShow,
   renderRunStatus,
   resolveRunId,
@@ -55,6 +56,16 @@ describe("run inspection command workflow", () => {
     expect(text).toContain("Run run-123");
     expect(text).toContain("Generations: 2/3");
     expect(text).toContain("Latest best score: 0.900");
+  });
+
+  it("renders watch json snapshots as compact parseable lines", () => {
+    const line = renderRunStatusJsonLine(run, generations);
+
+    expect(line).not.toContain("\n");
+    expect(JSON.parse(line)).toMatchObject({
+      run: { run_id: "run-123" },
+      latest_generation: { generation_index: 2 },
+    });
   });
 
   it("shows the best generation when requested", () => {

--- a/ts/tests/run-inspection-command-workflow.test.ts
+++ b/ts/tests/run-inspection-command-workflow.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseWatchIntervalSeconds,
+  renderRunShow,
+  renderRunStatus,
+  resolveRunId,
+} from "../src/cli/run-inspection-command-workflow.js";
+
+const run = {
+  run_id: "run-123",
+  scenario: "grid_ctf",
+  target_generations: 3,
+  executor_mode: "local",
+  status: "completed",
+  agent_provider: "deterministic",
+  created_at: "2026-04-30T00:00:00Z",
+  updated_at: "2026-04-30T00:01:00Z",
+};
+
+const generations = [
+  {
+    generation_index: 1,
+    mean_score: 0.2,
+    best_score: 0.4,
+    elo: 1200,
+    gate_decision: "advance",
+    status: "completed",
+    duration_seconds: 1,
+    created_at: "2026-04-30T00:00:10Z",
+    updated_at: "2026-04-30T00:00:20Z",
+  },
+  {
+    generation_index: 2,
+    mean_score: 0.3,
+    best_score: 0.9,
+    elo: 1300,
+    gate_decision: "advance",
+    status: "completed",
+    duration_seconds: 1,
+    created_at: "2026-04-30T00:00:30Z",
+    updated_at: "2026-04-30T00:00:40Z",
+  },
+];
+
+describe("run inspection command workflow", () => {
+  it("accepts run ids as either plain positionals or named options", () => {
+    expect(resolveRunId({}, ["run-positional"], "show")).toBe("run-positional");
+    expect(resolveRunId({ "run-id": "run-named" }, ["run-positional"], "show")).toBe("run-named");
+  });
+
+  it("renders concise run status with latest progress", () => {
+    const text = renderRunStatus(run, generations, false);
+
+    expect(text).toContain("Run run-123");
+    expect(text).toContain("Generations: 2/3");
+    expect(text).toContain("Latest best score: 0.900");
+  });
+
+  it("shows the best generation when requested", () => {
+    const text = renderRunShow(run, generations, { best: true });
+
+    expect(text).toContain("Generation: 2");
+    expect(text).toContain("Best score: 0.900");
+  });
+
+  it("validates watch intervals", () => {
+    expect(parseWatchIntervalSeconds("0.5")).toBe(0.5);
+    expect(() => parseWatchIntervalSeconds("0")).toThrow("--interval");
+  });
+});

--- a/ts/tests/solve-command-workflow.test.ts
+++ b/ts/tests/solve-command-workflow.test.ts
@@ -40,6 +40,63 @@ describe("solve command workflow", () => {
     expect(parsePositiveInteger).toHaveBeenCalledWith("12", "--timeout");
   });
 
+  it("accepts a plain-language positional description", () => {
+    expect(
+      planSolveCommand(
+        {
+          positionals: ["build an orbital transfer optimizer"],
+          gens: "2",
+        },
+        (raw: string | undefined) => Number(raw),
+      ),
+    ).toMatchObject({
+      description: "build an orbital transfer optimizer",
+      generations: 2,
+    });
+  });
+
+  it("accepts iterations as a plain-language alias for generations", () => {
+    const parsePositiveInteger = vi.fn((raw: string | undefined) => Number(raw));
+
+    expect(
+      planSolveCommand(
+        {
+          positionals: ["build an orbital transfer optimizer"],
+          iterations: "4",
+        },
+        parsePositiveInteger,
+      ),
+    ).toMatchObject({
+      generations: 4,
+    });
+    expect(parsePositiveInteger).toHaveBeenCalledWith("4", "--iterations");
+  });
+
+  it("prefers precise gens over iterations when both are present", () => {
+    expect(
+      planSolveCommand(
+        {
+          description: "explicit task",
+          gens: "3",
+          iterations: "4",
+        },
+        (raw: string | undefined) => Number(raw),
+      ).generations,
+    ).toBe(3);
+  });
+
+  it("prefers explicit descriptions over positional shorthand", () => {
+    expect(
+      planSolveCommand(
+        {
+          description: "  explicit task  ",
+          positionals: ["positional task"],
+        },
+        () => 1,
+      ).description,
+    ).toBe("explicit task");
+  });
+
   it("rejects missing descriptions", () => {
     expect(() =>
       planSolveCommand({}, () => 1),

--- a/ts/tests/strategy-package-run-export.test.ts
+++ b/ts/tests/strategy-package-run-export.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { join } from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+import { ArtifactStore } from "../src/knowledge/artifact-store.js";
+import { exportStrategyPackage } from "../src/knowledge/package.js";
+import { SQLiteStore } from "../src/storage/index.js";
+
+describe("strategy package run export", () => {
+  let dir: string;
+  let store: SQLiteStore;
+  let artifacts: ArtifactStore;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ac-strategy-package-run-"));
+    store = new SQLiteStore(join(dir, "test.db"));
+    store.migrate(join(import.meta.dirname, "..", "migrations"));
+    artifacts = new ArtifactStore({
+      runsRoot: join(dir, "runs"),
+      knowledgeRoot: join(dir, "knowledge"),
+    });
+    artifacts.writePlaybook("grid_ctf", "## Lesson\n\nTake the safe lane.");
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("exports package scores and strategy from the requested run id", () => {
+    store.createRun("run-low", "grid_ctf", 1, "local");
+    store.upsertGeneration("run-low", 1, {
+      meanScore: 0.3,
+      bestScore: 0.4,
+      elo: 1040,
+      wins: 1,
+      losses: 0,
+      gateDecision: "advance",
+      status: "completed",
+    });
+    store.updateRunStatus("run-low", "completed");
+    store.recordMatch("run-low", 1, {
+      seed: 1,
+      score: 0.4,
+      passedValidation: true,
+      validationErrors: "",
+      strategyJson: '{"aggression":0.4}',
+    });
+
+    store.createRun("run-high", "grid_ctf", 1, "local");
+    store.upsertGeneration("run-high", 1, {
+      meanScore: 0.7,
+      bestScore: 0.9,
+      elo: 1300,
+      wins: 3,
+      losses: 0,
+      gateDecision: "advance",
+      status: "completed",
+    });
+    store.updateRunStatus("run-high", "completed");
+    store.recordMatch("run-high", 1, {
+      seed: 2,
+      score: 0.9,
+      passedValidation: true,
+      validationErrors: "",
+      strategyJson: '{"aggression":0.9}',
+    });
+
+    const pkg = exportStrategyPackage({
+      scenarioName: "grid_ctf",
+      sourceRunId: "run-low",
+      artifacts,
+      store,
+    });
+
+    expect(pkg.best_score).toBe(0.4);
+    expect(pkg.best_elo).toBe(1040);
+    expect(pkg.best_strategy).toEqual({ aggression: 0.4 });
+    expect(pkg.metadata).toMatchObject({
+      source_run_id: "run-low",
+      source_generation: 1,
+    });
+  });
+
+  it("rejects run-specific exports when the run has no generation metrics", () => {
+    store.createRun("run-empty", "grid_ctf", 1, "local");
+
+    expect(() =>
+      exportStrategyPackage({
+        scenarioName: "grid_ctf",
+        sourceRunId: "run-empty",
+        artifacts,
+        store,
+      }),
+    ).toThrow("No generation metrics found for run run-empty");
+  });
+});

--- a/ts/tests/strategy-package-run-export.test.ts
+++ b/ts/tests/strategy-package-run-export.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 
 import { ArtifactStore } from "../src/knowledge/artifact-store.js";
 import { exportStrategyPackage } from "../src/knowledge/package.js";
+import { writePackageMetadata } from "../src/knowledge/package-metadata.js";
 import { SQLiteStore } from "../src/storage/index.js";
 
 describe("strategy package run export", () => {
@@ -94,5 +95,42 @@ describe("strategy package run export", () => {
         store,
       }),
     ).toThrow("No generation metrics found for run run-empty");
+  });
+
+  it("does not mix persisted scenario strategy into a run-specific export", () => {
+    writePackageMetadata(artifacts.knowledgeRoot, "grid_ctf", {
+      best_strategy: { aggression: 0.99 },
+      best_score: 0.99,
+      best_elo: 1900,
+      metadata: {
+        source_run_id: "another-run",
+        source_generation: 7,
+      },
+    });
+    store.createRun("run-no-strategy", "grid_ctf", 1, "local");
+    store.upsertGeneration("run-no-strategy", 1, {
+      meanScore: 0.3,
+      bestScore: 0.4,
+      elo: 1040,
+      wins: 1,
+      losses: 0,
+      gateDecision: "advance",
+      status: "completed",
+    });
+
+    const pkg = exportStrategyPackage({
+      scenarioName: "grid_ctf",
+      sourceRunId: "run-no-strategy",
+      artifacts,
+      store,
+    });
+
+    expect(pkg.best_score).toBe(0.4);
+    expect(pkg.best_elo).toBe(1040);
+    expect(pkg.best_strategy).toBeNull();
+    expect(pkg.metadata).toMatchObject({
+      source_run_id: "run-no-strategy",
+      source_generation: 1,
+    });
   });
 });

--- a/ts/tests/tui-command-help.test.ts
+++ b/ts/tests/tui-command-help.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { formatCommandHelp, handleInteractiveTuiCommand } from "../src/tui/commands.js";
+
+describe("TUI command help", () => {
+  it("uses the same plain-language concepts as the CLI contract", () => {
+    const help = formatCommandHelp().join("\n");
+
+    expect(help).toContain('/solve "plain-language goal"');
+    expect(help).toContain("/run <scenario> [iterations]");
+    expect(help).toContain("/status <run-id>");
+    expect(help).toContain("/show <run-id> --best");
+    expect(help).toContain("/watch <run-id>");
+  });
+
+  it("turns /solve plain language into scenario creation and a run", async () => {
+    const manager = {
+      createScenario: vi.fn(async () => ({ name: "orbital_transfer" })),
+      confirmScenario: vi.fn(async () => ({ name: "orbital_transfer", testScores: [] })),
+      startRun: vi.fn(async () => "run-123"),
+    };
+
+    const result = await handleInteractiveTuiCommand({
+      manager: manager as never,
+      configDir: ".",
+      raw: '/solve "build an orbital transfer optimizer"',
+      pendingLogin: null,
+    });
+
+    expect(manager.createScenario).toHaveBeenCalledWith("build an orbital transfer optimizer");
+    expect(manager.startRun).toHaveBeenCalledWith("orbital_transfer", 5);
+    expect(result.logLines).toContain("accepted run run-123");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds plain-language CLI continuity across Python and TypeScript: positional solve/run, --iterations aliases, and run-id-oriented status/show/watch/export flows.
- Fixes installed Python banner asset loading and packages the banner assets.
- Aligns run-specific strategy package export with source_run_id/source_generation provenance.
- Updates TUI help, docs, examples, changelog, and regression coverage.

## Linear

- AC-698
- AC-699
- CTCCMD-20 preserves the hosted scenario catalog idea for future product planning.

## Tests

- npx vitest run tests/run-command-workflow.test.ts tests/solve-command-workflow.test.ts tests/export-command-workflow.test.ts tests/strategy-package-run-export.test.ts tests/cli-help.test.ts tests/tui-command-help.test.ts tests/run-inspection-command-workflow.test.ts
- uv run pytest tests/test_cli_solve_runtime.py tests/test_cli_agent_task.py tests/test_banner_sync.py tests/test_strategy_package.py tests/test_strategy_package_cli.py tests/test_pi_package_export.py -q
- uv run ruff check src tests/test_banner_sync.py tests/test_cli_solve_runtime.py tests/test_cli_agent_task.py tests/test_strategy_package.py tests/test_strategy_package_cli.py tests/test_pi_package_export.py
- uv run mypy src
- npm run lint
- git diff --check