### PR TITLE
Add Hermes Agent integration helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Python and TypeScript `autoctx run <scenario>` now accept a positional scenario while keeping `--scenario` for scripts.
 - Python and TypeScript `autoctx export <run-id>` now export knowledge from a specific run while keeping scenario-level export support.
 - TypeScript CLI/TUI help now uses the same plain-language run vocabulary, including `status <run-id>`, `show <run-id> --best`, and `watch <run-id>`.
+- Python `autoctx hermes inspect` now reads Hermes v0.12 skill usage telemetry and Curator reports without mutating `~/.hermes`, and `autoctx hermes export-skill` emits a first-class Hermes `autocontext` skill that teaches CLI-first workflows with MCP as optional.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-01
+
 ### Added
 
 - Python and TypeScript `autoctx solve` now accept the plain-language goal as a positional argument while keeping `--description` as a named option.
@@ -16,6 +18,11 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Python installed `autoctx` no longer crashes on no-args startup when packaged banner assets are missing.
+
+### Changed
+
+- Python `autocontext` and TypeScript `autoctx` package metadata are bumped to `0.5.0`.
+- Pi `pi-autocontext` package metadata is bumped to `0.2.4`, and its `autoctx` dependency range accepts both the current `0.4.9` package and the upcoming `0.5.0` npm line.
 
 ## [0.4.9] - 2026-04-30
 
@@ -335,7 +342,8 @@ All notable changes to this project will be documented in this file.
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
-[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.9...HEAD
+[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.5.0...HEAD
+[0.5.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.9...py-v0.5.0
 [0.4.9]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.8...py-v0.4.9
 [0.4.8]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.7...py-v0.4.8
 [0.4.7]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.6...py-v0.4.7

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See [`.env.example`](.env.example) for every provider's variables. Prefer to clo
 
 ## Or Just Talk To Your Agent
 
-If you already work inside a coding agent (Claude Code, Pi, Cursor, or anything MCP-aware), you don't need to learn the CLI. Wire autocontext in once and your agent gets a natural-language entry point.
+If you already work inside a coding agent, you can wire autocontext in once and give the agent a natural-language entry point. Hermes and other terminal-capable agents should start with the CLI-backed skill; MCP remains available for clients that want a tool-catalog protocol.
 
 **Pi** ships an autocontext skill out of the box. Install the published Pi package and Pi loads natural-language wrappers over live tools such as `autocontext_solve_scenario`, `autocontext_evaluate_output`, `autocontext_run_improvement_loop`, `autocontext_run_status`, and `autocontext_list_scenarios`.
 
@@ -83,6 +83,14 @@ Then you just ask:
 ```
 
 After that, Python MCP exposes prefixed tools such as `autocontext_solve_scenario`, `autocontext_evaluate_output`, `autocontext_run_improvement_loop`, `autocontext_run_status`, `autocontext_list_scenarios`, `autocontext_export_skill`, and `autocontext_search_strategies`. The MCP server runs on stdio. The TypeScript package exposes the same capabilities with its documented tool names via `bunx autoctx mcp-serve`.
+
+**Hermes Agent** can load a CLI-first skill and inspect Hermes Curator state without MCP:
+
+```bash
+cd autocontext
+uv run autoctx hermes export-skill --output ~/.hermes/skills/autocontext/SKILL.md --json
+uv run autoctx hermes inspect --json
+```
 
 Full integration guide: [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md).
 
@@ -244,6 +252,7 @@ pi install npm:pi-autocontext
 | `campaign`    | `bunx autoctx campaign ...` (TypeScript)           | Coordinate multiple missions with budgets, dependencies, progress aggregation          |
 | `export`      | `autoctx export <run-id>`                          | Share solved knowledge as JSON, skills, or Pi-local package directories                |
 | `train`       | `autoctx train --scenario <name> --data <jsonl>`   | Distill stable exported data into a cheaper local runtime                              |
+| `hermes`      | `uv run autoctx hermes inspect --json` (Python)    | Inspect Hermes v0.12 skill usage and Curator reports, or export the Hermes skill       |
 | `replay`      | `autoctx replay <run_id> --generation N`           | Inspect what happened before deciding what knowledge should persist                    |
 
 ## Scenario Families

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Autocontext is a harness. You point it at a goal in plain language. It iterates 
 The fastest path uses our **Pi runtime**, a local coding agent that handles its own auth. No API key plumbing, no provider config: install Pi, install autocontext, point one at the other.
 
 ```bash
-uv tool install autocontext==0.4.9
+uv tool install autocontext==0.5.0
 
 AUTOCONTEXT_AGENT_PROVIDER=pi \
 AUTOCONTEXT_PI_COMMAND=pi \
@@ -36,7 +36,7 @@ Pi runs locally as a subprocess and emits live traces back into the harness. For
 Prefer TypeScript? Same surface, same command:
 
 ```bash
-bun add -g autoctx@0.4.9
+bun add -g autoctx@0.5.0
 AUTOCONTEXT_AGENT_PROVIDER=pi bunx autoctx solve \
   "improve customer-support replies for billing disputes" \
   --iterations 5 --json
@@ -205,14 +205,12 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 ```
 
 <!-- autocontext-whats-new:start -->
-## What's New in 0.4.9
+## What's New in 0.5.0
 
-- **Pi-shaped scenario hardening** keeps schema-evolution simulations from persisting empty mutation plans and improves recovery from Pi-style JSON wrappers.
-- **Budgeted Pi/Pi-RPC role calls** now report effective bounded timeouts and clean up one-shot persistent clients after use.
-- **RLM convergence guards** capture explicit final-answer tags, cautious closure cues, and repeated silent no-progress cases without stealing normal inspection turns.
-- **Rubric drift monitoring** now catches within-generation mean-versus-best compression and slower dimension decline.
-- **Task-like solve lifecycle metadata** separates persisted generations from improvement rounds for hook consumers.
-- **Pi extension release alignment** keeps `pi-autocontext` one package behind `autoctx` while publishing the next extension patch.
+- **Plain-language CLI continuity** lets Python and TypeScript callers use positional goals/scenarios, `--iterations`, and run-scoped exports while preserving the existing flag forms.
+- **Hermes Agent integration** adds read-only Hermes v0.12 inspection plus an exportable CLI-first `autocontext` skill for Hermes agents.
+- **Packaged CLI startup** no longer crashes when installed without banner assets.
+- **Release alignment** bumps Python `autocontext` and npm `autoctx` to `0.5.0`, with `pi-autocontext` moving to `0.2.4` on its own lower-numbered line.
 <!-- autocontext-whats-new:end -->
 
 ## Choose Your Package
@@ -227,11 +225,11 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 
 ```bash
 # Python: library or CLI tool
-uv pip install autocontext==0.4.9
-uv tool install autocontext==0.4.9
+uv pip install autocontext==0.5.0
+uv tool install autocontext==0.5.0
 
 # TypeScript
-bun add -g autoctx@0.4.9
+bun add -g autoctx@0.5.0
 
 # Pi extension
 pi install npm:pi-autocontext

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -35,6 +35,7 @@ The Python package is the full control-plane surface in this repo. It currently 
 - plain-language investigation via `autoctx investigate`
 - local training workflows via `autoctx export-training-data` and `autoctx train`
 - scenario creation and materialization via `autoctx new-scenario`
+- Hermes Agent integration helpers via `autoctx hermes inspect` and `autoctx hermes export-skill`
 - HTTP API and MCP server surfaces via `autoctx serve` and `autoctx mcp-serve`
 
 Some newer operator-facing surfaces are currently TypeScript-first:
@@ -175,6 +176,8 @@ uv run autoctx benchmark --scenario support_triage --runs 5
 uv run autoctx new-scenario --template prompt-optimization --name support_triage
 uv run autoctx export-training-data --scenario support_triage --all-runs --output training/support_triage.jsonl
 uv run autoctx train --scenario support_triage --data training/support_triage.jsonl --time-budget 300
+uv run autoctx hermes inspect --json
+uv run autoctx hermes export-skill --output ~/.hermes/skills/autocontext/SKILL.md --json
 uv run autoctx serve --host 127.0.0.1 --port 8000
 uv run autoctx mcp-serve
 uv run autoctx wait <condition_id> --json

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -10,7 +10,7 @@ The intended use is to hand the harness a real task in plain language, let it so
 pip install autocontext
 ```
 
-The current PyPI release line is `autocontext==0.4.9`.
+The current PyPI release line is `autocontext==0.5.0`.
 The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
 
 ## Working Directory

--- a/autocontext/assets/whats_new.txt
+++ b/autocontext/assets/whats_new.txt
@@ -1,6 +1,4 @@
-**Pi-shaped scenario hardening** keeps schema-evolution simulations from persisting empty mutation plans and improves recovery from Pi-style JSON wrappers.
-**Budgeted Pi/Pi-RPC role calls** now report effective bounded timeouts and clean up one-shot persistent clients after use.
-**RLM convergence guards** capture explicit final-answer tags, cautious closure cues, and repeated silent no-progress cases without stealing normal inspection turns.
-**Rubric drift monitoring** now catches within-generation mean-versus-best compression and slower dimension decline.
-**Task-like solve lifecycle metadata** separates persisted generations from improvement rounds for hook consumers.
-**Pi extension release alignment** keeps `pi-autocontext` one package behind `autoctx` while publishing the next extension patch.
+**Plain-language CLI continuity** lets Python and TypeScript callers use positional goals/scenarios, `--iterations`, and run-scoped exports while preserving the existing flag forms.
+**Hermes Agent integration** adds read-only Hermes v0.12 inspection plus an exportable CLI-first `autocontext` skill for Hermes agents.
+**Packaged CLI startup** no longer crashes when installed without banner assets.
+**Release alignment** bumps Python `autocontext` and npm `autoctx` to `0.5.0`, with `pi-autocontext` moving to `0.2.4` on its own lower-numbered line.

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -227,6 +227,45 @@ JSON output shape:
 }
 ```
 
+#### `autoctx hermes` — Inspect Hermes and export the Hermes skill
+
+```bash
+# Read-only inventory of Hermes v0.12 skills, usage telemetry, and Curator reports
+autoctx hermes inspect --json
+
+# Inspect a non-default profile
+autoctx hermes inspect --home "$HERMES_HOME" --json
+
+# Export the Hermes autocontext skill for Hermes to load
+autoctx hermes export-skill --output ~/.hermes/skills/autocontext/SKILL.md --json
+```
+
+JSON output shape for `inspect`:
+
+```json
+{
+  "hermes_home": "/Users/alice/.hermes",
+  "skill_count": 12,
+  "agent_created_skill_count": 4,
+  "bundled_skill_count": 7,
+  "hub_skill_count": 1,
+  "pinned_skill_count": 2,
+  "archived_skill_count": 3,
+  "skills": [],
+  "curator": {
+    "run_count": 2,
+    "latest": {
+      "counts": {
+        "consolidated_this_run": 1,
+        "pruned_this_run": 0
+      }
+    }
+  }
+}
+```
+
+`autoctx hermes inspect` does not mutate `~/.hermes`. Treat Hermes Curator as the owner of Hermes skill lifecycle changes; use this command for read-only analysis, dataset planning, and recommendations.
+
 ### Error Handling
 
 All commands follow the same error contract when `--json` is passed:
@@ -470,6 +509,9 @@ A Hermes agent can drive autocontext entirely through CLI commands. This workflo
 # Install autocontext (from repo root)
 cd autocontext && uv venv && source .venv/bin/activate && uv sync --group dev
 
+# Install the Hermes-facing autocontext skill into the active Hermes profile
+autoctx hermes export-skill --output ~/.hermes/skills/autocontext/SKILL.md --json
+
 # Set the Hermes gateway env vars once
 export AUTOCONTEXT_AGENT_PROVIDER=openai-compatible
 export AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1
@@ -481,6 +523,12 @@ export AUTOCONTEXT_JUDGE_PROVIDER=openai-compatible
 export AUTOCONTEXT_JUDGE_BASE_URL=http://localhost:8080/v1
 export AUTOCONTEXT_JUDGE_API_KEY=no-key
 export AUTOCONTEXT_JUDGE_MODEL=hermes-3-llama-3.1-70b
+```
+
+Before using local Hermes curation data, inspect it read-only:
+
+```bash
+autoctx hermes inspect --json | jq .
 ```
 
 #### Step 1: Discover scenarios
@@ -564,12 +612,12 @@ autoctx solve \
 
 | Path                           | Best for                                                                          | Complexity |
 | ------------------------------ | --------------------------------------------------------------------------------- | ---------- |
-| **CLI-first** (this section)   | Hermes agents driving `autoctx` via shell commands                                | Lowest     |
+| **CLI-first** (this section)   | Hermes agents driving `autoctx` via shell commands and `--json` output            | Lowest     |
 | **OpenAI-compatible provider** | autocontext calling Hermes for agent/judge completions                            | Low        |
-| **MCP server**                 | Tool-catalog agents (Claude Code, MCP clients)                                    | Medium     |
+| **MCP server**                 | Managed tool-catalog environments where schemas/discovery add value               | Medium     |
 | **Native Hermes runtime**      | autocontext calling the local Hermes CLI with Hermes-side workspace/skill context | Highest    |
 
-The CLI-first path is recommended for getting started. Move to the gateway or native provider paths when you want autocontext to call Hermes instead of Hermes calling autocontext.
+The CLI-first path is recommended for getting started, especially now that the `autoctx` CLI is the mature shared surface. Move to the gateway or native provider paths when you want autocontext to call Hermes instead of Hermes calling autocontext. Add MCP only when typed schemas, discovery, or host policy make it better than the CLI for that environment.
 
 ## MCP Integration (Secondary)
 
@@ -814,7 +862,7 @@ All tools use the `autocontext_` prefix (e.g., `autocontext_list_scenarios`). Th
 | **Long-running jobs** | Poll via `autocontext_solve_status` | Poll via `autoctx status`       |
 | **Best for**          | Hermes agents with MCP support      | Hermes agents with shell access |
 
-Use MCP when Hermes has native MCP client support and you want automatic tool discovery. Use CLI-first when you want simpler debugging or are scripting a workflow.
+Use CLI-first as the default Hermes skill workflow. Use MCP when Hermes has native MCP client support and automatic tool discovery or typed invocation materially improves the local setup.
 
 ## Python SDK (Programmatic)
 

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autocontext"
-version = "0.4.9"
+version = "0.5.0"
 description = "autocontext control plane for iterative strategy evolution."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/autocontext/src/autocontext/__init__.py
+++ b/autocontext/src/autocontext/__init__.py
@@ -5,4 +5,4 @@ from autocontext.sdk import AutoContext
 
 __all__ = ["AutoContext", "ExtensionAPI", "HookBus", "HookEvents", "HookResult", "__version__"]
 
-__version__ = "0.4.9"
+__version__ = "0.5.0"

--- a/autocontext/src/autocontext/banner.py
+++ b/autocontext/src/autocontext/banner.py
@@ -23,7 +23,7 @@ SYNC_BLOCK_START = "<!-- autocontext-readme-hero:start -->"
 SYNC_BLOCK_END = "<!-- autocontext-readme-hero:end -->"
 WHATS_NEW_BLOCK_START = "<!-- autocontext-whats-new:start -->"
 WHATS_NEW_BLOCK_END = "<!-- autocontext-whats-new:end -->"
-README_WHATS_NEW_HEADING = "What's New in 0.4.9"
+README_WHATS_NEW_HEADING = "What's New in 0.5.0"
 FALLBACK_BANNER_ART = "autocontext"
 README_BADGES = (
     (

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -19,6 +19,7 @@ from rich.table import Table
 
 from autocontext.agents.orchestrator import AgentOrchestrator
 from autocontext.cli_analytics import register_analytics_command
+from autocontext.cli_hermes import register_hermes_command
 from autocontext.cli_investigate import run_investigate_command
 from autocontext.cli_new_scenario import register_new_scenario_command
 from autocontext.cli_queue import register_queue_command
@@ -1533,6 +1534,7 @@ def improve(
 
 
 register_analytics_command(app, console=console)
+register_hermes_command(app, console=console)
 register_new_scenario_command(app, console=console)
 register_solve_command(app, console=console)
 register_queue_command(app, console=console)

--- a/autocontext/src/autocontext/cli_hermes.py
+++ b/autocontext/src/autocontext/cli_hermes.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, Any
+
+import typer
+from rich.table import Table
+
+from autocontext.hermes.inspection import HermesInventory, inspect_hermes_home
+from autocontext.hermes.skill import AUTOCONTEXT_HERMES_SKILL_NAME, render_autocontext_skill
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+def _cli_attr(dependency_module: str, name: str) -> Any:
+    return getattr(importlib.import_module(dependency_module), name)
+
+
+def run_hermes_inspect_command(
+    *,
+    home: Path | None,
+    json_output: bool,
+    console: Console,
+    write_json_stdout: Any,
+) -> None:
+    """Run the read-only Hermes inventory command."""
+
+    inventory = inspect_hermes_home(home)
+    if json_output:
+        write_json_stdout(inventory.to_dict())
+        return
+    _print_inventory(inventory, console=console)
+
+
+def run_hermes_export_skill_command(
+    *,
+    output: Path | None,
+    force: bool,
+    json_output: bool,
+    console: Console,
+    write_json_stdout: Any,
+    write_json_stderr: Any,
+) -> None:
+    """Emit the bundled Hermes Autocontext skill."""
+
+    skill_markdown = render_autocontext_skill()
+    if output is None:
+        if json_output:
+            write_json_stdout({
+                "skill_name": AUTOCONTEXT_HERMES_SKILL_NAME,
+                "skill_markdown": skill_markdown,
+            })
+        else:
+            console.print(skill_markdown.rstrip())
+        return
+
+    if output.exists() and not force:
+        message = f"Refusing to overwrite existing file without --force: {output}"
+        if json_output:
+            write_json_stderr(message)
+        else:
+            console.print(f"[red]{message}[/red]")
+        raise typer.Exit(code=1)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(skill_markdown, encoding="utf-8")
+    payload = {
+        "skill_name": AUTOCONTEXT_HERMES_SKILL_NAME,
+        "output_path": str(output),
+        "bytes_written": len(skill_markdown.encode("utf-8")),
+    }
+    if json_output:
+        write_json_stdout(payload)
+    else:
+        console.print(f"[green]Wrote[/green] {AUTOCONTEXT_HERMES_SKILL_NAME} skill to {output}")
+
+
+def register_hermes_command(
+    app: typer.Typer,
+    *,
+    console: Console,
+    dependency_module: str = "autocontext.cli",
+) -> None:
+    hermes_app = typer.Typer(help="Hermes Agent integration helpers")
+
+    @hermes_app.command("inspect")
+    def inspect(
+        home: Annotated[
+            Path | None,
+            typer.Option("--home", help="Hermes home directory (default: HERMES_HOME or ~/.hermes)"),
+        ] = None,
+        json_output: Annotated[bool, typer.Option("--json", help="Output structured JSON")] = False,
+    ) -> None:
+        """Read Hermes skill usage and Curator reports without mutating Hermes."""
+
+        run_hermes_inspect_command(
+            home=home,
+            json_output=json_output,
+            console=console,
+            write_json_stdout=_cli_attr(dependency_module, "_write_json_stdout"),
+        )
+
+    @hermes_app.command("export-skill")
+    def export_skill(
+        output: Annotated[
+            Path | None,
+            typer.Option("--output", help="Write the Hermes SKILL.md to this path; omit to print it"),
+        ] = None,
+        force: Annotated[bool, typer.Option("--force", help="Overwrite --output if it already exists")] = False,
+        json_output: Annotated[bool, typer.Option("--json", help="Output structured JSON")] = False,
+    ) -> None:
+        """Emit the first-class Hermes autocontext skill."""
+
+        run_hermes_export_skill_command(
+            output=output,
+            force=force,
+            json_output=json_output,
+            console=console,
+            write_json_stdout=_cli_attr(dependency_module, "_write_json_stdout"),
+            write_json_stderr=_cli_attr(dependency_module, "_write_json_stderr"),
+        )
+
+    app.add_typer(hermes_app, name="hermes")
+
+
+def _print_inventory(inventory: HermesInventory, *, console: Console) -> None:
+    console.print(f"[bold]Hermes home:[/bold] {inventory.hermes_home}")
+    console.print(
+        "[dim]"
+        f"skills={inventory.skill_count} "
+        f"agent-created={inventory.agent_created_skill_count} "
+        f"bundled={inventory.bundled_skill_count} "
+        f"hub={inventory.hub_skill_count} "
+        f"pinned={inventory.pinned_skill_count} "
+        f"archived={inventory.archived_skill_count}"
+        "[/dim]"
+    )
+
+    table = Table(title="Hermes Skills")
+    table.add_column("Name")
+    table.add_column("Provenance")
+    table.add_column("State")
+    table.add_column("Pinned")
+    table.add_column("Activity")
+    table.add_column("Last Activity")
+    for skill in inventory.skills:
+        table.add_row(
+            skill.name,
+            skill.provenance,
+            skill.state,
+            "yes" if skill.pinned else "no",
+            str(skill.activity_count),
+            skill.last_activity_at or "",
+        )
+    console.print(table)
+
+    latest = inventory.curator.latest
+    if latest is None:
+        console.print("[dim]No Hermes Curator reports found.[/dim]")
+        return
+    console.print(
+        "[bold]Latest curator run:[/bold] "
+        f"{latest.started_at or latest.path.parent.name} "
+        f"consolidated={latest.counts.get('consolidated_this_run', latest.consolidated_count)} "
+        f"pruned={latest.counts.get('pruned_this_run', latest.pruned_count)} "
+        f"archived={latest.counts.get('archived_this_run', latest.archived_count)}"
+    )

--- a/autocontext/src/autocontext/hermes/__init__.py
+++ b/autocontext/src/autocontext/hermes/__init__.py
@@ -1,0 +1,14 @@
+"""Hermes Agent integration helpers."""
+
+from autocontext.hermes.inspection import CuratorInventory, CuratorRunSummary, HermesInventory, HermesSkill, inspect_hermes_home
+from autocontext.hermes.skill import AUTOCONTEXT_HERMES_SKILL_NAME, render_autocontext_skill
+
+__all__ = [
+    "AUTOCONTEXT_HERMES_SKILL_NAME",
+    "CuratorInventory",
+    "CuratorRunSummary",
+    "HermesInventory",
+    "HermesSkill",
+    "inspect_hermes_home",
+    "render_autocontext_skill",
+]

--- a/autocontext/src/autocontext/hermes/inspection.py
+++ b/autocontext/src/autocontext/hermes/inspection.py
@@ -1,0 +1,449 @@
+"""Read-only inspection of Hermes Agent v0.12 skill and curator state."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_USAGE_FILENAME = ".usage.json"
+_BUNDLED_MANIFEST_FILENAME = ".bundled_manifest"
+_HUB_LOCK_PATH = Path(".hub") / "lock.json"
+
+
+@dataclass(frozen=True, slots=True)
+class HermesSkill:
+    """A skill discovered in a Hermes skills tree."""
+
+    name: str
+    path: Path
+    description: str
+    provenance: str
+    state: str
+    pinned: bool
+    use_count: int
+    view_count: int
+    patch_count: int
+    created_at: str | None
+    last_used_at: str | None
+    last_viewed_at: str | None
+    last_patched_at: str | None
+    archived_at: str | None
+
+    @property
+    def agent_created(self) -> bool:
+        return self.provenance == "agent-created"
+
+    @property
+    def activity_count(self) -> int:
+        return self.use_count + self.view_count + self.patch_count
+
+    @property
+    def last_activity_at(self) -> str | None:
+        return _latest_activity_at(
+            self.last_used_at,
+            self.last_viewed_at,
+            self.last_patched_at,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "path": str(self.path),
+            "description": self.description,
+            "provenance": self.provenance,
+            "agent_created": self.agent_created,
+            "state": self.state,
+            "pinned": self.pinned,
+            "use_count": self.use_count,
+            "view_count": self.view_count,
+            "patch_count": self.patch_count,
+            "activity_count": self.activity_count,
+            "created_at": self.created_at,
+            "last_used_at": self.last_used_at,
+            "last_viewed_at": self.last_viewed_at,
+            "last_patched_at": self.last_patched_at,
+            "last_activity_at": self.last_activity_at,
+            "archived_at": self.archived_at,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CuratorRunSummary:
+    """A compact summary of one Hermes Curator run.json report."""
+
+    path: Path
+    report_path: Path | None
+    started_at: str | None
+    duration_seconds: float | None
+    provider: str | None
+    model: str | None
+    counts: dict[str, Any] = field(default_factory=dict)
+    auto_transitions: dict[str, Any] = field(default_factory=dict)
+    tool_call_counts: dict[str, Any] = field(default_factory=dict)
+    consolidated_count: int = 0
+    pruned_count: int = 0
+    archived_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "report_path": str(self.report_path) if self.report_path is not None else None,
+            "started_at": self.started_at,
+            "duration_seconds": self.duration_seconds,
+            "provider": self.provider,
+            "model": self.model,
+            "counts": dict(self.counts),
+            "auto_transitions": dict(self.auto_transitions),
+            "tool_call_counts": dict(self.tool_call_counts),
+            "consolidated_count": self.consolidated_count,
+            "pruned_count": self.pruned_count,
+            "archived_count": self.archived_count,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CuratorInventory:
+    """Read-only view of Hermes Curator report artifacts."""
+
+    reports_root: Path
+    run_count: int
+    latest: CuratorRunSummary | None
+    runs: tuple[CuratorRunSummary, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "reports_root": str(self.reports_root),
+            "run_count": self.run_count,
+            "latest": self.latest.to_dict() if self.latest is not None else None,
+            "runs": [run.to_dict() for run in self.runs],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HermesInventory:
+    """Read-only inventory of a Hermes home directory."""
+
+    hermes_home: Path
+    skills_root: Path
+    skill_count: int
+    agent_created_skill_count: int
+    bundled_skill_count: int
+    hub_skill_count: int
+    pinned_skill_count: int
+    archived_skill_count: int
+    usage_path: Path
+    bundled_manifest_path: Path
+    hub_lock_path: Path
+    skills: tuple[HermesSkill, ...]
+    curator: CuratorInventory
+
+    @property
+    def skills_by_name(self) -> dict[str, HermesSkill]:
+        return {skill.name: skill for skill in self.skills}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "hermes_home": str(self.hermes_home),
+            "skills_root": str(self.skills_root),
+            "skill_count": self.skill_count,
+            "agent_created_skill_count": self.agent_created_skill_count,
+            "bundled_skill_count": self.bundled_skill_count,
+            "hub_skill_count": self.hub_skill_count,
+            "pinned_skill_count": self.pinned_skill_count,
+            "archived_skill_count": self.archived_skill_count,
+            "usage_path": str(self.usage_path),
+            "bundled_manifest_path": str(self.bundled_manifest_path),
+            "hub_lock_path": str(self.hub_lock_path),
+            "skills": [skill.to_dict() for skill in self.skills],
+            "curator": self.curator.to_dict(),
+        }
+
+
+def inspect_hermes_home(hermes_home: str | Path | None = None) -> HermesInventory:
+    """Inspect Hermes Agent skill/curator state without mutating it."""
+
+    home = _resolve_hermes_home(hermes_home)
+    skills_root = home / "skills"
+    usage_path = skills_root / _USAGE_FILENAME
+    bundled_manifest_path = skills_root / _BUNDLED_MANIFEST_FILENAME
+    hub_lock_path = skills_root / _HUB_LOCK_PATH
+
+    usage = _read_usage(usage_path)
+    bundled_names = _read_bundled_manifest_names(bundled_manifest_path)
+    hub_names = _read_hub_installed_names(hub_lock_path)
+    skills = tuple(
+        sorted(
+            (
+                _skill_from_path(
+                    skill_md,
+                    skills_root=skills_root,
+                    usage=usage,
+                    bundled_names=bundled_names,
+                    hub_names=hub_names,
+                )
+                for skill_md in _iter_active_skill_files(skills_root)
+            ),
+            key=lambda skill: skill.name,
+        )
+    )
+    archived_count = sum(1 for _ in _iter_archived_skill_files(skills_root))
+
+    return HermesInventory(
+        hermes_home=home,
+        skills_root=skills_root,
+        skill_count=len(skills),
+        agent_created_skill_count=sum(1 for skill in skills if skill.agent_created),
+        bundled_skill_count=sum(1 for skill in skills if skill.provenance == "bundled"),
+        hub_skill_count=sum(1 for skill in skills if skill.provenance == "hub"),
+        pinned_skill_count=sum(1 for skill in skills if skill.pinned),
+        archived_skill_count=archived_count,
+        usage_path=usage_path,
+        bundled_manifest_path=bundled_manifest_path,
+        hub_lock_path=hub_lock_path,
+        skills=skills,
+        curator=_inspect_curator(home / "logs" / "curator"),
+    )
+
+
+def _resolve_hermes_home(hermes_home: str | Path | None) -> Path:
+    if hermes_home is not None:
+        return Path(hermes_home).expanduser()
+    env_home = os.environ.get("HERMES_HOME", "").strip()
+    if env_home:
+        return Path(env_home).expanduser()
+    return Path.home() / ".hermes"
+
+
+def _iter_active_skill_files(skills_root: Path) -> tuple[Path, ...]:
+    if not skills_root.exists():
+        return ()
+    files: list[Path] = []
+    for skill_md in skills_root.rglob("SKILL.md"):
+        try:
+            rel = skill_md.relative_to(skills_root)
+        except ValueError:
+            continue
+        if not rel.parts:
+            continue
+        first = rel.parts[0]
+        if first.startswith(".") or first == "node_modules":
+            continue
+        files.append(skill_md)
+    return tuple(files)
+
+
+def _iter_archived_skill_files(skills_root: Path) -> tuple[Path, ...]:
+    archive_root = skills_root / ".archive"
+    if not archive_root.exists():
+        return ()
+    return tuple(archive_root.rglob("SKILL.md"))
+
+
+def _skill_from_path(
+    skill_md: Path,
+    *,
+    skills_root: Path,
+    usage: dict[str, dict[str, Any]],
+    bundled_names: set[str],
+    hub_names: set[str],
+) -> HermesSkill:
+    frontmatter = _read_skill_frontmatter(skill_md)
+    name = _as_str(frontmatter.get("name")) or skill_md.parent.name
+    description = _as_str(frontmatter.get("description")) or ""
+    record = usage.get(name, {})
+    provenance = _provenance(name, bundled_names=bundled_names, hub_names=hub_names)
+    return HermesSkill(
+        name=name,
+        path=skill_md.parent.relative_to(skills_root) if _is_relative_to(skill_md.parent, skills_root) else skill_md.parent,
+        description=description,
+        provenance=provenance,
+        state=_as_str(record.get("state")) or "active",
+        pinned=bool(record.get("pinned", False)),
+        use_count=_as_int(record.get("use_count")),
+        view_count=_as_int(record.get("view_count")),
+        patch_count=_as_int(record.get("patch_count")),
+        created_at=_as_str(record.get("created_at")),
+        last_used_at=_as_str(record.get("last_used_at")),
+        last_viewed_at=_as_str(record.get("last_viewed_at")),
+        last_patched_at=_as_str(record.get("last_patched_at")),
+        archived_at=_as_str(record.get("archived_at")),
+    )
+
+
+def _read_skill_frontmatter(skill_md: Path) -> dict[str, Any]:
+    try:
+        text = skill_md.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    if not text.startswith("---"):
+        return {}
+    parts = text.split("\n---\n", 1)
+    if len(parts) != 2:
+        return {}
+    frontmatter: dict[str, Any] = {}
+    for line in parts[0].removeprefix("---\n").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        if key in {"name", "description"}:
+            frontmatter[key] = value.strip().strip("\"'")
+    return frontmatter
+
+
+def _read_usage(path: Path) -> dict[str, dict[str, Any]]:
+    data = _read_json_object(path)
+    clean: dict[str, dict[str, Any]] = {}
+    for key, value in data.items():
+        if isinstance(value, dict):
+            clean[str(key)] = value
+    return clean
+
+
+def _read_bundled_manifest_names(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return set()
+    names: set[str] = set()
+    for line in lines:
+        name = line.strip().split(":", 1)[0].strip()
+        if name:
+            names.add(name)
+    return names
+
+
+def _read_hub_installed_names(path: Path) -> set[str]:
+    data = _read_json_object(path)
+    installed = data.get("installed")
+    if isinstance(installed, dict):
+        return {str(name) for name in installed}
+    return set()
+
+
+def _inspect_curator(reports_root: Path) -> CuratorInventory:
+    runs = tuple(sorted((_curator_run_from_path(path) for path in reports_root.rglob("run.json")), key=_curator_sort_key))
+    latest = runs[-1] if runs else None
+    return CuratorInventory(
+        reports_root=reports_root,
+        run_count=len(runs),
+        latest=latest,
+        runs=runs,
+    )
+
+
+def _curator_run_from_path(path: Path) -> CuratorRunSummary:
+    data = _read_json_object(path)
+    report_path = path.with_name("REPORT.md")
+    consolidated = data.get("consolidated")
+    pruned = data.get("pruned")
+    archived = data.get("archived")
+    return CuratorRunSummary(
+        path=path,
+        report_path=report_path if report_path.exists() else None,
+        started_at=_as_str(data.get("started_at")),
+        duration_seconds=_as_float(data.get("duration_seconds")),
+        provider=_as_str(data.get("provider")),
+        model=_as_str(data.get("model")),
+        counts=_as_dict(data.get("counts")),
+        auto_transitions=_as_dict(data.get("auto_transitions")),
+        tool_call_counts=_as_dict(data.get("tool_call_counts")),
+        consolidated_count=len(consolidated) if isinstance(consolidated, list) else 0,
+        pruned_count=len(pruned) if isinstance(pruned, list) else 0,
+        archived_count=len(archived) if isinstance(archived, list) else 0,
+    )
+
+
+def _curator_sort_key(run: CuratorRunSummary) -> tuple[datetime, str]:
+    parsed = _parse_iso_datetime(run.started_at)
+    if parsed is None:
+        parsed = (
+            datetime.fromtimestamp(run.path.stat().st_mtime, tz=UTC)
+            if run.path.exists()
+            else datetime.min.replace(tzinfo=UTC)
+        )
+    return parsed, str(run.path)
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _provenance(name: str, *, bundled_names: set[str], hub_names: set[str]) -> str:
+    if name in bundled_names:
+        return "bundled"
+    if name in hub_names:
+        return "hub"
+    return "agent-created"
+
+
+def _latest_activity_at(*values: str | None) -> str | None:
+    latest_dt: datetime | None = None
+    latest_raw: str | None = None
+    for value in values:
+        parsed = _parse_iso_datetime(value)
+        if parsed is None:
+            continue
+        if latest_dt is None or parsed > latest_dt:
+            latest_dt = parsed
+            latest_raw = value
+    return latest_raw
+
+
+def _parse_iso_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _as_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True

--- a/autocontext/src/autocontext/hermes/skill.py
+++ b/autocontext/src/autocontext/hermes/skill.py
@@ -1,0 +1,186 @@
+# ruff: noqa: E501
+"""Hermes Agent skill content for Autocontext."""
+
+from __future__ import annotations
+
+AUTOCONTEXT_HERMES_SKILL_NAME = "autocontext"
+
+
+def render_autocontext_skill() -> str:
+    """Return a Hermes-valid SKILL.md that teaches Autocontext usage."""
+
+    return _AUTOCONTEXT_HERMES_SKILL.rstrip() + "\n"
+
+
+_AUTOCONTEXT_HERMES_SKILL = """---
+name: autocontext
+description: Use when a Hermes agent needs to evaluate agent behavior, run Autocontext scenarios, inspect Hermes curator state, export reusable knowledge, or prepare local MLX/CUDA training data through the autoctx CLI.
+version: 1.0.0
+author: Autocontext
+license: Apache-2.0
+metadata:
+  hermes:
+    tags: [autocontext, evaluation, traces, cli, curator, mlx, cuda, skills]
+    related_skills: [native-mcp, hermes-agent-skill-authoring, axolotl]
+---
+
+# Autocontext
+
+## Overview
+
+Autocontext is a control plane for evaluating agent behavior, preserving useful run artifacts, exporting training data, and distilling stable behavior into local runtimes. In Hermes, use this skill when the work calls for measurement, replay, datasets, local MLX/CUDA training, or read-only analysis of Hermes skill curation.
+
+Hermes Curator owns Hermes skill mutation. Autocontext should inspect, evaluate, replay, export, and recommend. Do not use Autocontext as a replacement for Hermes Curator, and do not edit Hermes skills directly unless the user explicitly asks for that operation.
+
+## When to Use
+
+- You need to run an Autocontext scenario from Hermes and inspect the result.
+- You need machine-readable status for runs, solved knowledge, or training jobs.
+- You need to inspect Hermes v0.12 Curator reports, skill usage counters, pinned state, or skill provenance.
+- You need to export Autocontext knowledge into a reusable package or skill-like artifact.
+- You need to prepare data for local MLX or CUDA training.
+- You need to decide whether MCP is useful in a configured environment.
+
+Do not use this skill for normal Hermes memory updates, direct skill consolidation, or user-local skill deletion. Those are Hermes Curator responsibilities.
+
+## Integration Surface Order
+
+Use the CLI first. The `autoctx` CLI is the default surface because Hermes agents can run it with normal terminal tools, see stdout and stderr, preserve logs, and debug failures without special host configuration.
+
+MCP is optional. Use MCP when the environment already has Autocontext MCP configured and the task benefits from typed schemas, constrained invocation, or tool discovery. Do not require MCP just to wrap a command that the CLI already exposes cleanly.
+
+Use a native Hermes runtime or OpenAI-compatible gateway when Autocontext is calling Hermes as an agent provider. Use a Hermes plugin emitter only when the user specifically needs high-fidelity live traces beyond read-only import of existing Hermes artifacts.
+
+## CLI Quick Start
+
+From a checkout of Autocontext:
+
+```bash
+cd autocontext
+uv run autoctx --help
+```
+
+Inspect Hermes skill and curator state without modifying Hermes:
+
+```bash
+uv run autoctx hermes inspect --json
+```
+
+For a custom profile or test fixture:
+
+```bash
+uv run autoctx hermes inspect --home "$HERMES_HOME" --json
+```
+
+Install or refresh this skill into a Hermes profile:
+
+```bash
+uv run autoctx hermes export-skill --output ~/.hermes/skills/autocontext/SKILL.md --json
+```
+
+If the file already exists and the user wants to replace it:
+
+```bash
+uv run autoctx hermes export-skill --output ~/.hermes/skills/autocontext/SKILL.md --force --json
+```
+
+## Running Autocontext From Hermes
+
+Use `--json` whenever Hermes needs to parse the result.
+
+```bash
+RUN_ID="hermes_$(date +%s)"
+uv run autoctx run --scenario grid_ctf --gens 3 --run-id "$RUN_ID" --json
+uv run autoctx status "$RUN_ID" --json
+uv run autoctx replay "$RUN_ID" --generation 1
+```
+
+For a plain-language task:
+
+```bash
+uv run autoctx solve --description "Improve the support-triage response policy." --gens 3 --json
+```
+
+For one-shot judgment or improvement:
+
+```bash
+uv run autoctx judge --task-prompt "..." --output "..." --rubric "..." --json
+uv run autoctx improve --task-prompt "..." --rubric "..." --rounds 3 --json
+```
+
+## Hermes Runtime Configuration
+
+When Autocontext should call a Hermes-served model through an OpenAI-compatible gateway:
+
+```bash
+export AUTOCONTEXT_AGENT_PROVIDER=openai-compatible
+export AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1
+export AUTOCONTEXT_AGENT_API_KEY=no-key
+export AUTOCONTEXT_AGENT_DEFAULT_MODEL=hermes-3-llama-3.1-8b
+uv run autoctx solve --description "..." --gens 3 --json
+```
+
+Keep provider configuration outside the skill when possible. The user or profile should own secrets, base URLs, and model names.
+
+## Working With Hermes Curator
+
+Hermes v0.12 writes Curator reports under `~/.hermes/logs/curator/<timestamp>/run.json` and `REPORT.md`. It tracks skill usage in `~/.hermes/skills/.usage.json`, and protects bundled or hub-installed skills through `.bundled_manifest` and `.hub/lock.json`.
+
+Use:
+
+```bash
+uv run autoctx hermes inspect --json
+```
+
+Read the output as an inventory:
+
+- `agent_created_skill_count` means Curator-eligible user or agent skills.
+- `bundled_skill_count` and `hub_skill_count` are upstream-owned skills and should not be pruned by Autocontext.
+- `pinned_skill_count` identifies skills Curator and agents should not modify.
+- `curator.latest.counts` summarizes the latest consolidation, pruning, and archive activity.
+
+Autocontext can use these signals for reports, datasets, and recommendations. Hermes Curator remains the writer for Hermes skill lifecycle changes.
+
+## Training Path
+
+For Autocontext-owned runs, export training data and train locally:
+
+```bash
+uv run autoctx export-training-data --scenario grid_ctf --all-runs --output training/grid_ctf.jsonl
+uv run autoctx train --scenario grid_ctf --data training/grid_ctf.jsonl --backend mlx --time-budget 300 --json
+uv run autoctx train --scenario grid_ctf --data training/grid_ctf.jsonl --backend cuda --time-budget 300 --json
+```
+
+Use MLX on Apple Silicon hosts. Use CUDA on Linux GPU hosts with a CUDA-enabled PyTorch install. Do not run host-GPU training inside a sandbox unless the user has already provided a host bridge or direct GPU access.
+
+For Hermes Curator artifacts, start with read-only inspection and dataset design before training. Curator reports are decision traces; they are best suited for advisor/ranker/classifier training, not full autonomous skill mutation.
+
+## MCP Workflow When Configured
+
+MCP is optional. If the user has already configured Autocontext MCP, prefer it for structured tool calls that are easier or safer than shell commands. Otherwise, stay with the CLI.
+
+Check the local integration guide before inventing tool names:
+
+```bash
+uv run autoctx mcp-serve --help
+```
+
+Use MCP only when it adds value beyond the CLI: stable schemas, lower parsing burden, managed tool discovery, or a host policy that disallows shell access.
+
+## Common Pitfalls
+
+1. Treating Autocontext as the Hermes Curator. Autocontext should inspect and recommend; Hermes Curator owns skill mutation.
+2. Starting with MCP in an unconfigured environment. Use the CLI first unless MCP is already present and helpful.
+3. Mutating `~/.hermes/skills` after inspection. `autoctx hermes inspect` is read-only; keep it that way during analysis.
+4. Training on raw curator artifacts without a target. First decide whether the target is ranking, consolidation classification, pruning advice, or model-routing advice.
+5. Forgetting `--json` when Hermes needs to parse command output.
+
+## Verification Checklist
+
+- [ ] Use `autoctx hermes inspect --json` before making claims about local Hermes skill state.
+- [ ] Confirm pinned skills are not modified.
+- [ ] Confirm bundled and hub skills are treated as upstream-owned.
+- [ ] Prefer CLI commands for first-run workflows.
+- [ ] Use MCP only when configured and materially better for the task.
+- [ ] Keep Hermes Curator as the system of record for Hermes skill lifecycle changes.
+"""

--- a/autocontext/tests/test_hermes_integration.py
+++ b/autocontext/tests/test_hermes_integration.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+from autocontext.hermes.inspection import inspect_hermes_home
+from autocontext.hermes.skill import render_autocontext_skill
+
+runner = CliRunner()
+
+
+def _write_skill(root: Path, relative_dir: str, *, name: str, description: str = "Use when testing.") -> Path:
+    skill_dir = root / "skills" / relative_dir
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    path = skill_dir / "SKILL.md"
+    path.write_text(
+        "\n".join([
+            "---",
+            f"name: {name}",
+            f"description: {description}",
+            "version: 1.0.0",
+            "author: Test",
+            "license: MIT",
+            "---",
+            "",
+            f"# {name}",
+            "",
+            "Body.",
+        ]),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _seed_hermes_home(tmp_path: Path) -> Path:
+    home = tmp_path / ".hermes"
+    skills_root = home / "skills"
+    _write_skill(home, "software-development/autocontext", name="autocontext")
+    _write_skill(home, "software-development/bundled-helper", name="bundled-helper")
+    _write_skill(home, "data-science/hub-helper", name="hub-helper")
+    _write_skill(home, ".archive/old-skill", name="old-skill")
+
+    (skills_root / ".bundled_manifest").write_text("bundled-helper:sha256-demo\n", encoding="utf-8")
+    (skills_root / ".hub").mkdir(parents=True, exist_ok=True)
+    (skills_root / ".hub" / "lock.json").write_text(
+        json.dumps({"installed": {"hub-helper": {"version": "1.2.3"}}}),
+        encoding="utf-8",
+    )
+    (skills_root / ".usage.json").write_text(
+        json.dumps(
+            {
+                "autocontext": {
+                    "use_count": 5,
+                    "view_count": 2,
+                    "patch_count": 1,
+                    "last_used_at": "2026-04-30T18:00:00+00:00",
+                    "last_viewed_at": "2026-04-30T18:05:00+00:00",
+                    "last_patched_at": "2026-04-30T17:00:00+00:00",
+                    "created_at": "2026-04-30T16:00:00+00:00",
+                    "state": "active",
+                    "pinned": True,
+                    "archived_at": None,
+                },
+                "bundled-helper": {"use_count": 9, "state": "active", "pinned": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    run_dir = home / "logs" / "curator" / "20260430-183000"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "run.json").write_text(
+        json.dumps(
+            {
+                "started_at": "2026-04-30T18:30:00+00:00",
+                "duration_seconds": 12.5,
+                "model": "qwen/qwen3-30b-a3b",
+                "provider": "openai-compatible",
+                "counts": {
+                    "skills_before": 4,
+                    "skills_after": 3,
+                    "archived_this_run": 1,
+                    "consolidated_this_run": 1,
+                    "pruned_this_run": 0,
+                },
+                "auto_transitions": {"checked": 3, "marked_stale": 1, "archived": 0, "reactivated": 0},
+                "tool_call_counts": {"skill_manage": 2},
+                "consolidated": [{"name": "old-specific", "into": "umbrella", "reason": "merged"}],
+                "pruned": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "REPORT.md").write_text("# Curator Report\n", encoding="utf-8")
+    return home
+
+
+def test_inspect_hermes_home_reads_v012_skill_usage_and_curator_reports(tmp_path: Path) -> None:
+    home = _seed_hermes_home(tmp_path)
+
+    inventory = inspect_hermes_home(home)
+
+    assert inventory.hermes_home == home
+    assert inventory.skill_count == 3
+    assert inventory.agent_created_skill_count == 1
+    assert inventory.bundled_skill_count == 1
+    assert inventory.hub_skill_count == 1
+    assert inventory.pinned_skill_count == 1
+    assert inventory.archived_skill_count == 1
+
+    autocontext_skill = inventory.skills_by_name["autocontext"]
+    assert autocontext_skill.agent_created is True
+    assert autocontext_skill.pinned is True
+    assert autocontext_skill.activity_count == 8
+    assert autocontext_skill.last_activity_at == "2026-04-30T18:05:00+00:00"
+
+    assert inventory.skills_by_name["bundled-helper"].agent_created is False
+    assert inventory.skills_by_name["hub-helper"].provenance == "hub"
+    assert inventory.curator.run_count == 1
+    assert inventory.curator.latest is not None
+    assert inventory.curator.latest.counts["consolidated_this_run"] == 1
+    assert inventory.curator.latest.report_path == home / "logs" / "curator" / "20260430-183000" / "REPORT.md"
+
+
+def test_hermes_inspect_cli_outputs_machine_readable_json(tmp_path: Path) -> None:
+    home = _seed_hermes_home(tmp_path)
+
+    result = runner.invoke(app, ["hermes", "inspect", "--home", str(home), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["hermes_home"] == str(home)
+    assert payload["skill_count"] == 3
+    assert payload["agent_created_skill_count"] == 1
+    assert payload["curator"]["run_count"] == 1
+    assert payload["skills"][0]["name"] == "autocontext"
+
+
+def test_autocontext_hermes_skill_matches_hermes_frontmatter_contract() -> None:
+    skill = render_autocontext_skill()
+
+    assert skill.startswith("---\n")
+    frontmatter_text = skill.split("\n---\n", 1)[0].removeprefix("---\n")
+    frontmatter = yaml.safe_load(frontmatter_text)
+    assert frontmatter["name"] == "autocontext"
+    assert frontmatter["description"].startswith("Use when")
+    assert len(frontmatter["description"]) <= 1024
+    assert frontmatter["metadata"]["hermes"]["tags"]
+    assert "# Autocontext" in skill
+    assert "autoctx hermes inspect --json" in skill
+    assert "MCP is optional" in skill
+    assert "Hermes Curator owns Hermes skill mutation" in skill
+    assert "MCP primary" not in skill
+
+
+def test_hermes_export_skill_writes_skill_markdown(tmp_path: Path) -> None:
+    output_path = tmp_path / "skills" / "autocontext" / "SKILL.md"
+
+    result = runner.invoke(app, ["hermes", "export-skill", "--output", str(output_path), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["skill_name"] == "autocontext"
+    assert payload["output_path"] == str(output_path)
+    assert output_path.exists()
+    assert output_path.read_text(encoding="utf-8") == render_autocontext_skill().rstrip() + "\n"

--- a/autocontext/uv.lock
+++ b/autocontext/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "autocontext"
-version = "0.4.9"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - **`analyze`** — interpret and compare outputs from all surfaces
 - **`mission`** — real-world goal execution with adaptive planning and campaigns
 - **`train`** — distill curated datasets into scenario-local models
+- **`hermes`** — read-only Hermes v0.12 skill/Curator inspection plus Hermes skill export
 
 ## Trace Pipeline (0.3.0)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ These are copy-paste starting points for people evaluating the repo, integrating
 ## Which Example To Start With
 
 - Want the full control plane from a source checkout? Use the Python CLI example.
+- Want Hermes Agent to understand autocontext? Use the Hermes CLI-first workflow.
 - Want to wire Claude Code or another MCP client? Use the MCP config snippet.
 - Want a typed Python integration? Use the Python SDK example.
 - Want a Node/TypeScript integration? Use the TypeScript library example.
@@ -66,6 +67,22 @@ Add this to your project-level `.claude/settings.json` and replace `/ABSOLUTE/PA
 ```
 
 For a fuller comparison of CLI, MCP, and SDK integrations, see [autocontext/docs/agent-integration.md](../autocontext/docs/agent-integration.md).
+
+## Hermes Agent Skill And Curator Inspection
+
+Hermes agents can use autocontext through the CLI without MCP. Export the Hermes skill into a Hermes profile, then inspect Hermes v0.12 skill usage and Curator reports read-only.
+
+```bash
+cd autocontext
+
+uv run autoctx hermes export-skill \
+  --output ~/.hermes/skills/autocontext/SKILL.md \
+  --json | jq .
+
+uv run autoctx hermes inspect --json | jq .
+```
+
+For a fuller walkthrough, see [autocontext/docs/agent-integration.md](../autocontext/docs/agent-integration.md#hermes-cli-first-starter-workflow).
 
 ## Python SDK
 

--- a/pi/package-lock.json
+++ b/pi/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "pi-autocontext",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-autocontext",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
-        "autoctx": "^0.4.8"
+        "autoctx": "^0.4.9 || ^0.5.0"
       },
       "devDependencies": {
         "@sinclair/typebox": "^0.34.0",
@@ -3310,9 +3310,9 @@
       }
     },
     "node_modules/autoctx": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/autoctx/-/autoctx-0.4.8.tgz",
-      "integrity": "sha512-xzKZpTtmkC538yy4u53DtfFHIpT7qXB1Xk59+8h/w3gMG/EeB5F2z2kQHFWdMHZmXKRnxTtfMl5FrNTNeyIw4g==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/autoctx/-/autoctx-0.4.9.tgz",
+      "integrity": "sha512-bKZNoo4VeqEwDz2XAL1+soJpkSU44fYCP8n6YrQEuVYsZb39FuyHhLtqm8Nz14PhDnMwpyH985xNKcSeZAdofA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",

--- a/pi/package.json
+++ b/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-autocontext",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "autocontext extension for Pi coding agent \u2014 iterative strategy generation, LLM judging, and evaluation tools",
   "type": "module",
   "keywords": ["pi-package", "pi", "pi-extension", "autocontext", "autoctx", "evaluation", "llm", "judging"],
@@ -18,7 +18,7 @@
     "@sinclair/typebox": "*"
   },
   "dependencies": {
-    "autoctx": "^0.4.8"
+    "autoctx": "^0.4.9 || ^0.5.0"
   },
   "devDependencies": {
     "@sinclair/typebox": "^0.34.0",

--- a/pi/tests/extension.test.ts
+++ b/pi/tests/extension.test.ts
@@ -323,7 +323,7 @@ describe("Package manifest", () => {
 
   it("depends on the current autoctx toolkit line", () => {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-    expect(pkg.dependencies.autoctx).toBe("^0.4.8");
+    expect(pkg.dependencies.autoctx).toBe("^0.4.9 || ^0.5.0");
   });
 });
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -165,6 +165,7 @@ autoctx models
 # Scenario execution
 autoctx solve "improve customer-support replies for billing disputes" --iterations 3 --json
 autoctx run support_triage --iterations 3 --json
+autoctx run --scenario support_triage --iterations 3 --json
 autoctx list --json
 autoctx status <run-id>
 autoctx show <run-id> --best

--- a/ts/README.md
+++ b/ts/README.md
@@ -410,6 +410,7 @@ These workflows require infrastructure not available in the npm package:
 - `ecosystem` — Multi-provider cycling
 - `ab-test` — Requires ecosystem runner
 - `resume` / `wait` — Run recovery infrastructure
+- `hermes inspect` / `hermes export-skill` — Hermes v0.12 Curator inspection and Hermes skill export
 - `trigger-distillation` — Training pipeline
 - Monitor conditions — Monitoring engine
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -53,7 +53,7 @@ export function register(api) {
 npm install autoctx
 ```
 
-The current npm release line is `autoctx@0.4.9`.
+The current npm release line is `autoctx@0.5.0`.
 Important: use `autoctx`, not `autocontext`.
 `autocontext` on npm is a different package and not this project.
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoctx",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoctx",
-      "version": "0.4.9",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoctx",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",

--- a/ts/src/server/run-environment-catalog.ts
+++ b/ts/src/server/run-environment-catalog.ts
@@ -15,7 +15,7 @@ export function describeCustomScenarioEntry(entry: CustomScenarioEntry): string 
     const taskPrompt = typeof entry.spec.taskPrompt === "string"
       ? entry.spec.taskPrompt
       : entry.name;
-    return `Custom agent task: ${taskPrompt} (saved for custom-scenario tooling; not runnable via /run yet)`;
+    return `Custom agent task: ${taskPrompt} (saved custom scenario; runnable via /run)`;
   }
   const description = typeof entry.spec.description === "string"
     ? entry.spec.description

--- a/ts/src/server/run-manager.ts
+++ b/ts/src/server/run-manager.ts
@@ -4,10 +4,11 @@
  */
 
 import { dirname, join } from "node:path";
+import type { AppSettings } from "../config/index.js";
 import { LoopController } from "../loop/controller.js";
 import { EventStreamEmitter } from "../loop/events.js";
 import type { EventCallback } from "../loop/events.js";
-import type { GenerationRole } from "../providers/index.js";
+import type { GenerationRole, RoleProviderBundle } from "../providers/index.js";
 import type { ScenarioPreviewInfo } from "../scenarios/draft-workflow.js";
 import {
   InteractiveScenarioSession,
@@ -47,6 +48,11 @@ export interface RunManagerOpts {
   apiKey?: string;
   baseUrl?: string;
   model?: string;
+  deps?: RunManagerDeps;
+}
+
+export interface RunManagerDeps {
+  resolveProviderBundle?: (settings?: AppSettings) => RoleProviderBundle;
 }
 
 export interface EnvironmentInfo {
@@ -368,6 +374,9 @@ export class RunManager {
   }
 
   #resolveProviderBundle(settings = loadSettings()) {
+    if (this.#opts.deps?.resolveProviderBundle) {
+      return this.#opts.deps.resolveProviderBundle(settings);
+    }
     return this.#providerSession.resolveProviderBundle(settings);
   }
 

--- a/ts/tests/_helpers/python-runner.ts
+++ b/ts/tests/_helpers/python-runner.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { existsSync } from "node:fs";
@@ -57,6 +57,41 @@ export function callPythonHelper(scriptName: string, payload: unknown): PythonRu
   };
 }
 
+export function callPythonHelperAsync(scriptName: string, payload: unknown): Promise<PythonRunResult> {
+  const script = join(HELPER_DIR, scriptName);
+  if (!existsSync(script)) {
+    return Promise.reject(new Error(`python helper missing: ${script}`));
+  }
+
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(resolveParityPython(), [script], {
+      env: { ...process.env, PYTHONPATH: join(PYTHON_PKG, "src") },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (status) => {
+      resolvePromise({
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        status: status ?? -1,
+      });
+    });
+
+    child.stdin.end(JSON.stringify(payload));
+  });
+}
+
 /**
  * Invoke Python ``build_trace(**snake_case_inputs)`` via the helper at
  * ``build_trace_canonical.py``. Returns the canonical JSON string that
@@ -73,6 +108,14 @@ export function callPythonBuildTrace(inputs: unknown): string {
   return r.stdout;
 }
 
+export async function callPythonBuildTraceAsync(inputs: unknown): Promise<string> {
+  const r = await callPythonHelperAsync("build_trace_canonical.py", inputs);
+  if (r.status !== 0) {
+    throw new Error(`python build_trace failed (status ${r.status}):\nstderr:\n${r.stderr}`);
+  }
+  return r.stdout;
+}
+
 export function callPythonHashUserId(userId: string, salt: string): string {
   const r = callPythonHelper("hash_user_id.py", { mode: "user", value: userId, salt });
   if (r.status !== 0) {
@@ -81,8 +124,24 @@ export function callPythonHashUserId(userId: string, salt: string): string {
   return r.stdout;
 }
 
+export async function callPythonHashUserIdAsync(userId: string, salt: string): Promise<string> {
+  const r = await callPythonHelperAsync("hash_user_id.py", { mode: "user", value: userId, salt });
+  if (r.status !== 0) {
+    throw new Error(`python hash_user_id failed (status ${r.status}):\nstderr:\n${r.stderr}`);
+  }
+  return r.stdout;
+}
+
 export function callPythonHashSessionId(sessionId: string, salt: string): string {
   const r = callPythonHelper("hash_user_id.py", { mode: "session", value: sessionId, salt });
+  if (r.status !== 0) {
+    throw new Error(`python hash_session_id failed (status ${r.status}):\nstderr:\n${r.stderr}`);
+  }
+  return r.stdout;
+}
+
+export async function callPythonHashSessionIdAsync(sessionId: string, salt: string): Promise<string> {
+  const r = await callPythonHelperAsync("hash_user_id.py", { mode: "session", value: sessionId, salt });
   if (r.status !== 0) {
     throw new Error(`python hash_session_id failed (status ${r.status}):\nstderr:\n${r.stderr}`);
   }

--- a/ts/tests/campaign-cli.test.ts
+++ b/ts/tests/campaign-cli.test.ts
@@ -308,7 +308,7 @@ describe("autoctx campaign add-mission and progress", () => {
     );
     const progress = JSON.parse(progressOut);
     expect(progress.totalMissions).toBe(1);
-  });
+  }, 15000);
 
   it("adds a mission with priority and dependencies", () => {
     const { stdout: cOut } = runCli(
@@ -356,7 +356,7 @@ describe("autoctx campaign add-mission and progress", () => {
     );
     const status = JSON.parse(statusOut);
     expect(status.missions.length).toBe(2);
-  });
+  }, 15000);
 
   it("rejects invalid priority values", () => {
     const { stdout: cOut } = runCli(
@@ -430,7 +430,7 @@ describe("autoctx campaign lifecycle", () => {
 
     const { stdout } = runCli(["campaign", "status", "--id", id], { cwd: dir });
     expect(JSON.parse(stdout).status).toBe("active");
-  });
+  }, 15000);
 
   it("cancel sets status to canceled", () => {
     const { stdout: created } = runCli(

--- a/ts/tests/mission-cli.test.ts
+++ b/ts/tests/mission-cli.test.ts
@@ -264,7 +264,7 @@ describe("autoctx mission run and artifacts", () => {
     const artifactsPayload = JSON.parse(artifactsOut);
     expect(artifactsPayload.checkpoints.length).toBeGreaterThanOrEqual(2);
     expect(artifactsPayload.latestCheckpoint.mission.id).toBe(id);
-  });
+  }, 15000);
 });
 
 // ---------------------------------------------------------------------------

--- a/ts/tests/production-traces/sdk/cross-runtime-parity.property.test.ts
+++ b/ts/tests/production-traces/sdk/cross-runtime-parity.property.test.ts
@@ -3,7 +3,7 @@ import fc from "fast-check";
 import { buildTrace, type BuildTraceInputs } from "../../../src/production-traces/sdk/build-trace.js";
 import { canonicalJsonStringify } from "../../../src/control-plane/contract/canonical-json.js";
 import {
-  callPythonBuildTrace,
+  callPythonBuildTraceAsync,
   isPythonParityAvailable,
 } from "../../_helpers/python-runner.js";
 import type {
@@ -93,11 +93,11 @@ const validBuildTraceInputsArb: fc.Arbitrary<BuildTraceInputs> = fc.record({
 });
 
 maybeSuite("P-cross-runtime-emit-parity (property, 50 runs)", () => {
-  test("TS buildTrace and Python build_trace produce byte-identical canonical JSON", () => {
-    fc.assert(
-      fc.property(validBuildTraceInputsArb, (inputs) => {
+  test("TS buildTrace and Python build_trace produce byte-identical canonical JSON", async () => {
+    await fc.assert(
+      fc.asyncProperty(validBuildTraceInputsArb, async (inputs) => {
         const tsCanonical = canonicalJsonStringify(buildTrace(inputs));
-        const pyCanonical = callPythonBuildTrace(inputs);
+        const pyCanonical = await callPythonBuildTraceAsync(inputs);
         return tsCanonical === pyCanonical;
       }),
       { numRuns: 50 },

--- a/ts/tests/production-traces/sdk/hashing-parity.property.test.ts
+++ b/ts/tests/production-traces/sdk/hashing-parity.property.test.ts
@@ -5,8 +5,8 @@ import {
   hashSessionId,
 } from "../../../src/production-traces/sdk/hashing.js";
 import {
-  callPythonHashUserId,
-  callPythonHashSessionId,
+  callPythonHashUserIdAsync,
+  callPythonHashSessionIdAsync,
   isPythonParityAvailable,
 } from "../../_helpers/python-runner.js";
 
@@ -34,22 +34,22 @@ const saltArb = fc.string({ minLength: 1, maxLength: 64 }).filter((s) => s.lengt
 const idArb = fc.string({ minLength: 1, maxLength: 64 }).filter((s) => s.length > 0 && !s.includes("\u0000"));
 
 maybeSuite("P-hashing-parity (property, 100 runs)", () => {
-  test("hashUserId matches Python hash_user_id byte-for-byte", () => {
-    fc.assert(
-      fc.property(idArb, saltArb, (userId, salt) => {
+  test("hashUserId matches Python hash_user_id byte-for-byte", async () => {
+    await fc.assert(
+      fc.asyncProperty(idArb, saltArb, async (userId, salt) => {
         const ts = hashUserId(userId, salt);
-        const py = callPythonHashUserId(userId, salt);
+        const py = await callPythonHashUserIdAsync(userId, salt);
         return ts === py;
       }),
       { numRuns: 100 },
     );
   }, 120_000);
 
-  test("hashSessionId matches Python hash_session_id byte-for-byte", () => {
-    fc.assert(
-      fc.property(idArb, saltArb, (sessionId, salt) => {
+  test("hashSessionId matches Python hash_session_id byte-for-byte", async () => {
+    await fc.assert(
+      fc.asyncProperty(idArb, saltArb, async (sessionId, salt) => {
         const ts = hashSessionId(sessionId, salt);
-        const py = callPythonHashSessionId(sessionId, salt);
+        const py = await callPythonHashSessionIdAsync(sessionId, salt);
         return ts === py;
       }),
       { numRuns: 100 },

--- a/ts/tests/run-environment-catalog.test.ts
+++ b/ts/tests/run-environment-catalog.test.ts
@@ -62,7 +62,7 @@ describe("run environment catalog", () => {
       hasGeneratedSource: true,
     };
 
-    expect(describeCustomScenarioEntry(agentTask)).toContain("not runnable via /run yet");
+    expect(describeCustomScenarioEntry(agentTask)).toContain("runnable via /run");
     expect(describeCustomScenarioEntry(generated)).toContain("runnable via /run");
   });
 

--- a/ts/tests/scenario-revision.test.ts
+++ b/ts/tests/scenario-revision.test.ts
@@ -217,16 +217,8 @@ describe("RunManager scenario revision flow", () => {
   it("revises the pending spec instead of recreating from the description", async () => {
     const { RunManager } = await import("../src/server/run-manager.js");
     const dir = makeTempDir();
-    const mgr = new RunManager({
-      dbPath: join(dir, "test.db"),
-      migrationsDir: join(__dirname, "..", "migrations"),
-      runsRoot: join(dir, "runs"),
-      knowledgeRoot: join(dir, "knowledge"),
-      providerType: "deterministic",
-    }) as any;
-
     let sawRevisionPrompt = false;
-    mgr.buildProvider = () => ({
+    const provider = {
       complete: async (opts: { systemPrompt: string; userPrompt: string }) => {
         if (opts.systemPrompt.includes("Revise the agent_task spec")) {
           sawRevisionPrompt = opts.userPrompt.includes("\"taskPrompt\": \"Summarize incident reports with a triage focus.\"");
@@ -250,6 +242,22 @@ describe("RunManager scenario revision flow", () => {
       },
       defaultModel: () => "test-model",
       name: "mock-provider",
+    };
+    const mgr = new RunManager({
+      dbPath: join(dir, "test.db"),
+      migrationsDir: join(__dirname, "..", "migrations"),
+      runsRoot: join(dir, "runs"),
+      knowledgeRoot: join(dir, "knowledge"),
+      providerType: "deterministic",
+      deps: {
+        resolveProviderBundle: () => ({
+          defaultProvider: provider as never,
+          defaultConfig: { providerType: "mock-provider" },
+          roleProviders: {},
+          roleModels: {},
+          close: () => {},
+        }),
+      },
     });
 
     await mgr.createScenario("Create a scenario about incident report triage.");

--- a/ts/tests/server-protocol.test.ts
+++ b/ts/tests/server-protocol.test.ts
@@ -241,10 +241,28 @@ describe("RunManager", () => {
       migrationsDir: join(__dirname, "..", "migrations"),
       runsRoot: join(dir, "runs"),
       knowledgeRoot: join(dir, "knowledge"),
+      providerType: "deterministic",
     });
     const info = mgr.getEnvironmentInfo();
     expect(info.scenarios.some((scenario) => scenario.name === "saved_task")).toBe(true);
-    await expect(mgr.startRun("saved_task", 1)).rejects.toThrow(/only built-in game scenarios/i);
+    const savedTask = info.scenarios.find((scenario) => scenario.name === "saved_task");
+    expect(savedTask?.description).toContain("runnable via /run");
+
+    const seenEvents: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    mgr.subscribeEvents((event, payload) => {
+      seenEvents.push({ event, payload });
+    });
+
+    const runId = await mgr.startRun("saved_task", 1);
+    await waitForCondition(() => seenEvents.some((entry) => (
+      entry.event === "run_completed" || entry.event === "run_failed"
+    )));
+
+    const failed = seenEvents.find((entry) => entry.event === "run_failed");
+    const completed = seenEvents.find((entry) => entry.event === "run_completed");
+    expect(failed).toBeUndefined();
+    expect(completed?.payload.run_id).toBe(runId);
+    expect(completed?.payload.family).toBe("agent_task");
   });
 
   it("startRun executes saved generated custom scenarios after discovery", async () => {

--- a/ts/tests/type-assertions.test.ts
+++ b/ts/tests/type-assertions.test.ts
@@ -135,7 +135,9 @@ describe("TypeScript type assertion budget", () => {
     // lookups in the detector's produce() function. Budget grows linearly with
     // each new integration library — A2-III Anthropic integration added ~50 casts
     // (proxy + trace-builder analogues). LangChain etc. will require similar bumps.
-    expect(total).toBeLessThanOrEqual(950);
+    // Bumped to 970 when CLI-continuity support kept legacy flag forms alongside
+    // positional `solve` / `run` forms across the TS command surface.
+    expect(total).toBeLessThanOrEqual(970);
   });
 
   it("mission/store.ts should use row types instead of inline casts", () => {

--- a/ts/vitest.config.ts
+++ b/ts/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
+    maxWorkers: 4,
   },
 });


### PR DESCRIPTION
## Summary
- add read-only Hermes v0.12 skill/Curator inspection via autoctx hermes inspect
- add autoctx hermes export-skill with a CLI-first Hermes autocontext skill
- document Hermes CLI-first usage and MCP-as-optional positioning

## Verification
- uv run ruff check src tests
- uv run mypy src
- uv run pytest
- git diff --check