### PR TITLE
Tighten TypeScript cleanup compliance

### DIFF
--- a/ts/src/agentos/adapter.ts
+++ b/ts/src/agentos/adapter.ts
@@ -57,7 +57,7 @@ export class AgentOsSessionAdapter {
   }
 
   async submitTurn(sessionId: string, prompt: string): Promise<TurnResult> {
-    const binding = this.getBinding(sessionId);
+    const binding = this.#getBinding(sessionId);
     const { session, aosSessionId } = binding;
 
     // Submit turn through autocontext's session model
@@ -83,7 +83,7 @@ export class AgentOsSessionAdapter {
   }
 
   async closeSession(sessionId: string): Promise<void> {
-    const binding = this.getBinding(sessionId);
+    const binding = this.#getBinding(sessionId);
     const { session, aosSessionId } = binding;
 
     await this.#runtime.closeSession(aosSessionId);
@@ -100,7 +100,7 @@ export class AgentOsSessionAdapter {
     return this.#bindings.get(sessionId)?.session;
   }
 
-  private getBinding(sessionId: string): SessionBinding {
+  #getBinding(sessionId: string): SessionBinding {
     const binding = this.#bindings.get(sessionId);
     if (!binding) throw new Error(`Session '${sessionId}' not found in adapter`);
     if (binding.session.status !== SessionStatus.ACTIVE) {

--- a/ts/src/agentos/lifecycle.ts
+++ b/ts/src/agentos/lifecycle.ts
@@ -9,11 +9,12 @@
 
 import type { AgentOsRuntimePort } from "./types.js";
 
-const SANDBOX_KEYWORDS = [
+export const SANDBOX_KEYWORDS = [
   "browser", "playwright", "puppeteer", "selenium",
   "dev server", "port 3000", "port 8080", "localhost",
   "gui", "native build", "docker", "container",
 ] as const;
+export type SandboxKeyword = (typeof SANDBOX_KEYWORDS)[number];
 
 export class AgentOsLifecycle {
   #runtime: AgentOsRuntimePort;

--- a/ts/src/agents/model-router.ts
+++ b/ts/src/agents/model-router.ts
@@ -83,21 +83,21 @@ export class ModelRouter {
       tier = opts.generation <= this.#config.competitorHaikuMaxGen ? "haiku" : "sonnet";
 
       if (opts.retryCount >= this.#config.competitorRetryEscalation) {
-        tier = this.maxTier(tier, "sonnet");
+        tier = this.#maxTier(tier, "sonnet");
       }
       if (opts.isPlateau) {
         tier = "opus";
       }
     } else if (role === "analyst" || role === "coach") {
       if (opts.isPlateau) {
-        tier = this.maxTier(tier, "opus");
+        tier = this.#maxTier(tier, "opus");
       }
     }
 
     return this.#tierMap[tier] ?? null;
   }
 
-  private maxTier(a: string, b: string): string {
+  #maxTier(a: string, b: string): string {
     const ai = TIER_ORDER.indexOf(a as (typeof TIER_ORDER)[number]);
     const bi = TIER_ORDER.indexOf(b as (typeof TIER_ORDER)[number]);
     return ai >= bi ? a : b;

--- a/ts/src/control-plane/instrument/index.ts
+++ b/ts/src/control-plane/instrument/index.ts
@@ -11,7 +11,36 @@
  *     Buffer form as the public name `parseDirectives`, and the lines form as
  *     `parseDirectivesFromLines`. Downstream callers pick whichever shape fits.
  */
-export * from "./contract/index.js";
+export type {
+  InstrumentLanguage,
+  DirectiveMap,
+  DirectiveValue,
+  IndentationStyle,
+  ExistingImport,
+  ImportSet,
+  SourceRange,
+  ImportSpec,
+  BaseEdit,
+  WrapExpressionEdit,
+  InsertStatementEdit,
+  ReplaceExpressionEdit,
+  EditDescriptor,
+  SecretMatch,
+  SourceFile,
+  DetectorPlugin,
+  TreeSitterMatch,
+  InstrumentSession,
+  InstrumentFlagsSnapshot,
+  PlanSourceFileMetadata,
+  ConflictDecision,
+  SafetyDecision,
+  InstrumentPlan,
+  ValidationResult,
+} from "./contract/index.js";
+export {
+  validateInstrumentSession,
+  validateInstrumentPlan,
+} from "./contract/index.js";
 // Scanner barrel minus the name-colliding `parseDirectives` (the lines form
 // remains accessible via scanner/ internals; external callers get the Buffer
 // form from safety/).
@@ -31,10 +60,66 @@ export {
   type LoadedParser,
   type TreeSitterTree,
 } from "./scanner/index.js";
-export * from "./safety/index.js";
-export * from "./registry/index.js";
-export * from "./planner/index.js";
-export * from "./pipeline/index.js";
+export {
+  HARDCODED_DEFAULT_PATTERNS,
+  detectSecretLiterals,
+  type SecretMatch as DetectedSecretMatch,
+  parseDirectives,
+  parseDirectivesFromLines,
+} from "./safety/index.js";
+export {
+  registerDetectorPlugin,
+  pluginsForLanguage,
+  resetRegistryForTests,
+} from "./registry/index.js";
+export {
+  detectConflicts,
+  type ConflictReport,
+  type ConflictReason,
+  planImports,
+  type ImportPlan,
+  type PlanImportsOpts,
+  matchIndentation,
+  type MatchIndentationOpts,
+  composeEdits,
+  type ComposeResult,
+  type ComposedEdit,
+  type RefusalReason,
+  type ComposeEditsOpts,
+} from "./planner/index.js";
+export {
+  runInstrument,
+  type InstrumentInputs,
+  type InstrumentResult,
+  type InstrumentMode,
+  type ConflictReason as PipelineConflictReason,
+  checkCwdReadable,
+  checkExcludeFromReadable,
+  checkRegistryPopulated,
+  checkWorkingTreeClean,
+  checkBranchPreconditions,
+  defaultGitDetector,
+  type PreflightVerdict,
+  type GitDetector,
+  runDryRunMode,
+  type DryRunModeInputs,
+  type DetectionLine,
+  runApplyMode,
+  writeApplyLog,
+  type ApplyModeInputs,
+  type ApplyModeResult,
+  runBranchMode,
+  defaultBranchGitExecutor,
+  type BranchModeInputs,
+  type BranchModeResult,
+  type BranchGitExecutor,
+  renderPrBody,
+  sha256ContentHash,
+  type PrBodyInputs,
+  type PerFileDetailedEdits,
+  type SkippedFile,
+  type DetectedUnchanged,
+} from "./pipeline/index.js";
 export {
   runInstrumentCommand,
   INSTRUMENT_HELP_TEXT,

--- a/ts/tests/agent-orchestration.test.ts
+++ b/ts/tests/agent-orchestration.test.ts
@@ -310,6 +310,21 @@ describe("ModelRouter", () => {
     const model = router.select("coach", { generation: 1, retryCount: 0, isPlateau: true });
     expect(model).toContain("opus");
   });
+
+  it("uses real #private fields and helpers for routing internals", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "src", "agents", "model-router.ts"),
+      "utf-8",
+    );
+
+    expect(source).toContain("#config");
+    expect(source).toContain("#tierMap");
+    expect(source).toContain("#maxTier");
+    expect(source).not.toContain("private maxTier");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ts/tests/agentos-adapter.test.ts
+++ b/ts/tests/agentos-adapter.test.ts
@@ -6,6 +6,8 @@
  * stub AgentOsRuntime so there's no real VM dependency.
  */
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it, beforeEach } from "vitest";
 
 // ---- Stub agentOS runtime ----
@@ -178,6 +180,20 @@ describe("AgentOsSessionAdapter", () => {
     await adapter.closeSession(s1.sessionId);
     expect(adapter.activeSessions).toHaveLength(1);
   });
+
+  it("uses real #private runtime fields and helpers", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "src", "agentos", "adapter.ts"),
+      "utf-8",
+    );
+
+    expect(source).toContain("#runtime");
+    expect(source).toContain("#config");
+    expect(source).toContain("#bindings");
+    expect(source).toContain("#getBinding");
+    expect(source).not.toContain("private runtime:");
+    expect(source).not.toContain("private getBinding");
+  });
 });
 
 describe("AgentOsLifecycle", () => {
@@ -206,5 +222,15 @@ describe("AgentOsLifecycle", () => {
     expect(lifecycle.needsSandbox("Run browser tests with Playwright")).toBe(true);
     expect(lifecycle.needsSandbox("Write a utility function")).toBe(false);
     expect(lifecycle.needsSandbox("Start a dev server on port 3000")).toBe(true);
+  });
+
+  it("keeps sandbox keywords as a const tuple for literal-union typing", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "src", "agentos", "lifecycle.ts"),
+      "utf-8",
+    );
+
+    expect(source).toContain("] as const;");
+    expect(source).toContain("type SandboxKeyword = (typeof SANDBOX_KEYWORDS)[number]");
   });
 });


### PR DESCRIPTION
## Summary
- expose sandbox keywords as a const tuple with a derived literal-union type
- move remaining adapter/router helpers in this cleanup area to true #private methods
- replace remaining instrument export-star barrel with explicit exports
- add regression coverage for #private fields and sandbox keyword typing

## Tests
- npm run lint
- npx vitest run tests/control-plane/instrument/cli/mcp-exposure.test.ts tests/internal-module-imports.test.ts tests/agentos-adapter.test.ts tests/agent-orchestration.test.ts

Additional note: the full TypeScript suite passed before the final explicit-export barrel cleanup: npm test, 692 files / 4744 tests.