### PR TITLE
[codex] Add autoctx worker hosting contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Python and TypeScript now expose `autoctx worker` to run the existing task queue `TaskRunner` as a daemon or one-shot batch worker, with persistent-host deployment docs for `serve + worker`.
+- Added narrow Python/TypeScript task queue store contracts so future hosted storage adapters can provide Postgres-backed claim/complete/fail/enqueue semantics without changing `TaskRunner`.
+- Gondolin is documented as a reserved optional microVM sandbox backend, fails closed until a real adapter is configured, and now has public request/policy/backend contracts for out-of-tree adapters.
+
 ## [0.5.0] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to this project will be documented in this file.
 - Added narrow Python/TypeScript task queue store contracts so future hosted storage adapters can provide Postgres-backed claim/complete/fail/enqueue semantics without changing `TaskRunner`.
 - Gondolin is documented as a reserved optional microVM sandbox backend, fails closed until a real adapter is configured, and now has public request/policy/backend contracts for out-of-tree adapters.
 
+### Fixed
+
+- Worker commands now clamp concurrency to one for stateful persistent runtimes, and Python runtime-bridge providers close underlying runtimes on shutdown.
+- TypeScript task runners now await queue-store methods so hosted Postgres adapters can implement the queue contract asynchronously.
+
 ## [0.5.0] - 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ pi install npm:pi-autocontext
 | `analyze`     | `autoctx analyze --id <id> --type <kind>`          | Inspect or compare runs, simulations, investigations, or missions after the fact       |
 | `mission`     | `autoctx mission create --name "..." --goal "..."` | Verifier-driven goal advanced step by step until done                                  |
 | `campaign`    | `bunx autoctx campaign ...` (TypeScript)           | Coordinate multiple missions with budgets, dependencies, progress aggregation          |
+| `worker`      | `autoctx worker --poll-interval 5`                 | Process queued tasks on a persistent host beside `autoctx serve`                      |
 | `export`      | `autoctx export <run-id>`                          | Share solved knowledge as JSON, skills, or Pi-local package directories                |
 | `train`       | `autoctx train --scenario <name> --data <jsonl>`   | Distill stable exported data into a cheaper local runtime                              |
 | `hermes`      | `uv run autoctx hermes inspect --json` (Python)    | Inspect Hermes v0.12 skill usage and Curator reports, or export the Hermes skill       |
@@ -277,7 +278,7 @@ All 11 families execute in both Python and TypeScript. TypeScript uses V8 isolat
 
 **Agent runtimes**: Claude CLI, Codex CLI, Hermes CLI, Direct API, Pi variants, plus branch-aware session and persistent Pi RPC for local agent loops.
 
-**Executors**: Local subprocess, SSH remote, Monty (`pydantic-monty` sandbox), PrimeIntellect remote sandbox.
+**Executors**: Local subprocess, SSH remote, Monty (`pydantic-monty` sandbox), PrimeIntellect remote sandbox. Gondolin is reserved as an optional fail-closed microVM backend until its adapter is wired.
 
 **Harness profiles and hooks**: The Python control plane supports a Pi-shaped lean profile that caps prompt context during generation and exports a minimal tool-affordance allowlist for agent surfaces that enforce tool gating. Semantic prompt compactions are recorded as Pi-shaped JSONL entries under each run; the TypeScript package now includes a mirrored deterministic prompt compactor plus `ArtifactStore` ledger read/write/latest APIs for standalone npm runs. Python and TypeScript runs can load `AUTOCONTEXT_EXTENSIONS`; Python extensions are Python modules, while TypeScript extensions are JavaScript/ESM modules that register hooks around context assembly, semantic compaction, provider calls, judge calls, artifact writes, and run lifecycle events.
 
@@ -313,6 +314,7 @@ Yes. Wire `autoctx mcp-serve` (or `bunx autoctx mcp-serve`) into Claude Code, Cu
 - Repo layout for coding agents: [AGENTS.md](AGENTS.md)
 - Sandboxed agents that need to trigger MLX training on the host: [autocontext/docs/mlx-training.md](autocontext/docs/mlx-training.md)
 - Sandbox and executor notes: [autocontext/docs/sandbox.md](autocontext/docs/sandbox.md)
+- Persistent host worker: [autocontext/docs/persistent-host.md](autocontext/docs/persistent-host.md)
 - License: [LICENSE](LICENSE)
 
 ## Acknowledgments

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -155,6 +155,8 @@ Run a persistent queue worker beside the API server:
 uv run autoctx worker --poll-interval 5 --concurrency 2
 ```
 
+Stateful persistent providers, such as persistent Pi RPC, run with effective concurrency `1` so one long-lived runtime cannot mix events across tasks.
+
 Start the MCP server:
 
 ```bash

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -149,6 +149,12 @@ uv run autoctx serve --host 127.0.0.1 --port 8000
 
 Inspect `http://127.0.0.1:8000/` for the API index after the server starts. For an interactive terminal UI, use the TypeScript package: `npx autoctx tui`.
 
+Run a persistent queue worker beside the API server:
+
+```bash
+uv run autoctx worker --poll-interval 5 --concurrency 2
+```
+
 Start the MCP server:
 
 ```bash
@@ -167,6 +173,7 @@ uv run autoctx investigate --description "debug the outage timeline" --mode iter
 uv run autoctx investigate --description "checkout is failing in prod" --browser-url https://status.example.com
 uv run autoctx queue add --task-prompt "Write a 1-line fact about primes" --rubric "correct" --threshold 0.8 --rounds 2
 uv run autoctx queue --spec support_triage --browser-url https://status.example.com
+uv run autoctx worker --poll-interval 5 --concurrency 2
 uv run autoctx simulate --replay deploy_sim --variables threshold=0.9
 uv run autoctx list
 uv run autoctx status <run_id>
@@ -546,6 +553,7 @@ For the TypeScript equivalent, see `ts/src/integrations/anthropic/STABILITY.md`.
 - [Canonical concept model](../docs/concept-model.md)
 - [Agent integration guide](docs/agent-integration.md) — CLI-first integration for external agents, MCP fallback, JSON output reference
 - [Sandbox modes](docs/sandbox.md)
+- [Persistent host worker](docs/persistent-host.md)
 - [MLX host training](docs/mlx-training.md)
 - [TypeScript package guide](../ts/README.md) — `analyze`, mission control, and interactive TUI surfaces
 - [Demo data notes](demo_data/README.md)

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -889,13 +889,14 @@ package = ac.export_package("grid_ctf")
 
 ## TypeScript CLI
 
-The TypeScript package also publishes a narrower `autoctx` CLI for Node.js environments. It focuses on judge-based evaluation, improvement loops, task queueing, and MCP serving rather than the full multi-generation control plane:
+The TypeScript package also publishes a narrower `autoctx` CLI for Node.js environments. It focuses on judge-based evaluation, improvement loops, task queueing, worker execution, and MCP serving rather than the full multi-generation control plane:
 
 ```bash
 npx autoctx judge -p "Write a haiku" -o "output text" -r "evaluate quality"
 npx autoctx improve -p "Write a haiku" -o "draft" -r "evaluate quality" -n 3
 npx autoctx status
-npx autoctx serve  # MCP server on stdio
+npx autoctx worker --once --json
+npx autoctx mcp-serve  # MCP server on stdio
 ```
 
 Key entrypoints live in:

--- a/autocontext/docs/persistent-host.md
+++ b/autocontext/docs/persistent-host.md
@@ -126,7 +126,7 @@ The image build, reverse proxy, auth, TLS, and secret distribution are deploymen
 The OSS worker now depends on a narrow task queue contract instead of SQLite inheritance:
 
 - Python: `autocontext.execution.TaskQueueStore` / `TaskQueueEnqueueStore`
-- TypeScript: `TaskQueueWorkerStore` / `TaskQueueEnqueueStore`
+- TypeScript: `TaskQueueWorkerStore` / `TaskQueueEnqueueStore`, with methods that may return values directly or as promises.
 
 Adapters must provide atomic task claim, task lookup, completion, failure, and enqueue semantics. SQLite is the bundled implementation. A hosted Postgres adapter can add leases, heartbeats, retries, and multi-worker coordination behind that contract without changing `TaskRunner`.
 

--- a/autocontext/docs/persistent-host.md
+++ b/autocontext/docs/persistent-host.md
@@ -22,6 +22,8 @@ autoctx worker --poll-interval 5 --concurrency 2
 
 `autoctx queue` and MCP `queue_task` calls write into the task queue. `autoctx worker` wraps the existing `TaskRunner`, polls that queue, processes tasks in priority order, and persists task results back into the configured store.
 
+If the selected provider/runtime is stateful and persistent, for example persistent Pi RPC, worker concurrency is forced to `1`. Use non-persistent provider instances or a hosted storage/runtime adapter when you need true parallel task execution.
+
 ## Durable State
 
 Keep these paths on persistent storage:

--- a/autocontext/docs/persistent-host.md
+++ b/autocontext/docs/persistent-host.md
@@ -1,0 +1,142 @@
+# Persistent Host Worker
+
+Use this shape when you want Autocontext to keep accepting queued work while a server stays online.
+
+Run the HTTP API and queue worker as separate long-lived processes against the same durable workspace:
+
+```bash
+export AUTOCONTEXT_DB_PATH=/srv/autoctx/runs/autocontext.sqlite3
+export AUTOCONTEXT_RUNS_ROOT=/srv/autoctx/runs
+export AUTOCONTEXT_KNOWLEDGE_ROOT=/srv/autoctx/knowledge
+
+uv run autoctx serve --host 0.0.0.0 --port 8000
+uv run autoctx worker --poll-interval 5 --concurrency 2
+```
+
+For the TypeScript package, the equivalent worker surface is:
+
+```bash
+autoctx serve --host 0.0.0.0 --port 8000
+autoctx worker --poll-interval 5 --concurrency 2
+```
+
+`autoctx queue` and MCP `queue_task` calls write into the task queue. `autoctx worker` wraps the existing `TaskRunner`, polls that queue, processes tasks in priority order, and persists task results back into the configured store.
+
+## Durable State
+
+Keep these paths on persistent storage:
+
+- `runs/`: run records, event streams, task queue SQLite DB, and per-run artifacts
+- `knowledge/`: playbooks, hints, custom scenarios, and reusable context
+- `skills/` and `.claude/skills/`: optional exported skills when those surfaces are enabled
+
+SQLite is the current open-source queue store. Treat the DB path as a single-writer operational boundary unless you explicitly deploy with a storage adapter that provides stronger multi-worker semantics. A Postgres-backed queue can fit the same `serve + worker` shape, but should be introduced behind the storage abstraction rather than by changing task-runner behavior.
+
+## Operational Notes
+
+Use `--once` for cron, smoke tests, or CI:
+
+```bash
+uv run autoctx worker --once --concurrency 4 --json
+```
+
+Use `--max-empty-polls` for bounded workers that should exit after the queue drains:
+
+```bash
+uv run autoctx worker --poll-interval 1 --max-empty-polls 3
+```
+
+On a service manager such as systemd, run `serve` and `worker` as separate units with the same environment file. Restarting the worker should not require restarting the API process as long as both use the same durable paths.
+
+### systemd Sketch
+
+Use one environment file for both units:
+
+```ini
+# /etc/autoctx/autoctx.env
+AUTOCONTEXT_DB_PATH=/srv/autoctx/runs/autocontext.sqlite3
+AUTOCONTEXT_RUNS_ROOT=/srv/autoctx/runs
+AUTOCONTEXT_KNOWLEDGE_ROOT=/srv/autoctx/knowledge
+AUTOCONTEXT_AGENT_PROVIDER=pi
+AUTOCONTEXT_PI_COMMAND=pi
+```
+
+```ini
+# /etc/systemd/system/autoctx-serve.service
+[Unit]
+Description=Autocontext HTTP API
+After=network-online.target
+
+[Service]
+WorkingDirectory=/srv/autoctx/app/autocontext
+EnvironmentFile=/etc/autoctx/autoctx.env
+ExecStart=/usr/bin/uv run autoctx serve --host 0.0.0.0 --port 8000
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```ini
+# /etc/systemd/system/autoctx-worker.service
+[Unit]
+Description=Autocontext queue worker
+After=network-online.target autoctx-serve.service
+
+[Service]
+WorkingDirectory=/srv/autoctx/app/autocontext
+EnvironmentFile=/etc/autoctx/autoctx.env
+ExecStart=/usr/bin/uv run autoctx worker --poll-interval 5 --concurrency 2
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Container Sketch
+
+Keep the same image for API and worker, but run separate processes and mount the same durable volume:
+
+```yaml
+services:
+  autoctx-serve:
+    image: ghcr.io/your-org/autoctx:latest
+    command: ["uv", "run", "autoctx", "serve", "--host", "0.0.0.0", "--port", "8000"]
+    env_file: .env.autoctx
+    volumes:
+      - autoctx-state:/srv/autoctx
+    ports:
+      - "8000:8000"
+
+  autoctx-worker:
+    image: ghcr.io/your-org/autoctx:latest
+    command: ["uv", "run", "autoctx", "worker", "--poll-interval", "5", "--concurrency", "2"]
+    env_file: .env.autoctx
+    volumes:
+      - autoctx-state:/srv/autoctx
+
+volumes:
+  autoctx-state:
+```
+
+The image build, reverse proxy, auth, TLS, and secret distribution are deployment-specific. Do not bake provider API keys into images.
+
+## Storage Adapter Contract
+
+The OSS worker now depends on a narrow task queue contract instead of SQLite inheritance:
+
+- Python: `autocontext.execution.TaskQueueStore` / `TaskQueueEnqueueStore`
+- TypeScript: `TaskQueueWorkerStore` / `TaskQueueEnqueueStore`
+
+Adapters must provide atomic task claim, task lookup, completion, failure, and enqueue semantics. SQLite is the bundled implementation. A hosted Postgres adapter can add leases, heartbeats, retries, and multi-worker coordination behind that contract without changing `TaskRunner`.
+
+What should stay outside the OSS contract is the hosted control plane: tenant scheduling, billing, policy UI, fleet routing, secret brokering, and managed retention/audit workflows.
+
+## Sandbox Boundary
+
+The worker uses the same evaluator/executor settings as the rest of Autocontext. Use Monty when you need in-process interpreter guardrails, PrimeIntellect or SSH when you need an external execution host, and reserve Gondolin for the optional microVM backend once it is wired. `AUTOCONTEXT_EXECUTOR_MODE=gondolin` is intentionally fail-closed today so deployments do not silently fall back to local execution when they expected a VM isolation boundary.
+
+For future Gondolin work, implement the public backend contracts rather than changing task-runner behavior:
+
+- Python: `autocontext.execution.executors.gondolin_contract.GondolinBackend`
+- TypeScript: `GondolinBackend` and `createDefaultGondolinSandboxPolicy` from `autoctx`

--- a/autocontext/docs/sandbox.md
+++ b/autocontext/docs/sandbox.md
@@ -1,15 +1,35 @@
 # Sandbox Modes
 
-autocontext supports three execution modes for game scenarios, plus judge-based evaluation for agent tasks:
+autocontext supports three shipped execution modes for game scenarios, plus judge-based evaluation for agent tasks:
 
 - `local` executor: runs strategies in a process pool with timeout controls, and applies memory limits in the subprocess path.
 - `primeintellect` executor: runs strategies remotely via PrimeIntellect sandbox lifecycle (create/wait/execute/delete).
 - `monty` executor: runs strategies in a pydantic-monty interpreter sandbox with external function callbacks and configurable timeout/call limits.
 - **Agent task evaluation**: Agent task scenarios bypass match execution entirely. `JudgeExecutor` delegates to `AgentTaskInterface.evaluate_output()`, which may use `LLMJudge` for LLM-based scoring against a rubric.
 
+## Gondolin Boundary
+
+Gondolin is reserved as an optional microVM sandbox backend for deployments that need stronger isolation, secret policy, and egress policy than the local/Monty paths provide. It is not a hosted scheduler or background-worker control plane by itself.
+
+`AUTOCONTEXT_EXECUTOR_MODE=gondolin` is intentionally fail-closed until a real backend adapter is configured. This prevents a deployment that expected a VM boundary from silently running tasks locally.
+
+Use the current modes this way:
+
+- Use `monty` when you want interpreter-level containment for Python evaluation with low operational overhead.
+- Use `local` for trusted local development and fast iteration.
+- Use `primeintellect` or `ssh` when you want execution off the current host.
+- Use Gondolin only after the adapter is wired for VM lifecycle, mounted artifacts, secret injection, and network/egress policy.
+
+The public OSS contract for a future Gondolin adapter is intentionally narrow:
+
+- Python: implement `GondolinBackend` from `autocontext.execution.executors.gondolin_contract` behind the existing `ExecutionEngine` boundary.
+- TypeScript: implement `GondolinBackend` from `autoctx` and start from `createDefaultGondolinSandboxPolicy()`.
+
+The contract carries policy and secret references, not secret values. Hosted fleet orchestration, tenant scheduling, policy UI, billing, and managed audit retention remain deployment concerns outside this OSS boundary.
+
 ## Relevant Environment Variables
 
-- `AUTOCONTEXT_EXECUTOR_MODE` (`local`, `primeintellect`, or `monty`)
+- `AUTOCONTEXT_EXECUTOR_MODE` (`local`, `primeintellect`, `monty`, `ssh`; `gondolin` is reserved/fail-closed)
 - `AUTOCONTEXT_PRIMEINTELLECT_API_BASE`
 - `AUTOCONTEXT_PRIMEINTELLECT_API_KEY`
 - `AUTOCONTEXT_PRIMEINTELLECT_DOCKER_IMAGE`

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -29,6 +29,7 @@ from autocontext.cli_runtime_overrides import (
     format_runtime_provider_error,
 )
 from autocontext.cli_solve import register_solve_command
+from autocontext.cli_worker import register_worker_command
 from autocontext.config import load_settings
 from autocontext.config.presets import VALID_PRESET_NAMES
 from autocontext.config.settings import AppSettings
@@ -1538,6 +1539,7 @@ register_hermes_command(app, console=console)
 register_new_scenario_command(app, console=console)
 register_solve_command(app, console=console)
 register_queue_command(app, console=console)
+register_worker_command(app, console=console)
 
 
 if __name__ == "__main__":

--- a/autocontext/src/autocontext/cli_worker.py
+++ b/autocontext/src/autocontext/cli_worker.py
@@ -81,6 +81,13 @@ def _select_worker_model(settings: AppSettings, provider: LLMProvider, model: st
     return provider.default_model()
 
 
+def _resolve_worker_concurrency(provider: LLMProvider, requested: int) -> int:
+    supports_concurrent = getattr(provider, "supports_concurrent_requests", True)
+    if requested > 1 and supports_concurrent is False:
+        return 1
+    return requested
+
+
 def run_worker_command(
     *,
     poll_interval: float,
@@ -118,6 +125,7 @@ def run_worker_command(
 
     try:
         provider = get_provider_fn(settings)
+        effective_concurrency = _resolve_worker_concurrency(provider, concurrency)
         runner = create_task_runner_fn(
             settings,
             store=store,
@@ -125,10 +133,10 @@ def run_worker_command(
             model=_select_worker_model(settings, provider, model),
             poll_interval=poll_interval,
             max_consecutive_empty=max_empty_polls,
-            concurrency=concurrency,
+            concurrency=effective_concurrency,
         )
         if once:
-            tasks_processed = runner.run_batch(concurrency)
+            tasks_processed = runner.run_batch(effective_concurrency)
             mode = "once"
         else:
             tasks_processed = runner.run()
@@ -151,7 +159,7 @@ def run_worker_command(
         "mode": mode,
         "tasks_processed": tasks_processed,
         "poll_interval": poll_interval,
-        "concurrency": concurrency,
+        "concurrency": effective_concurrency,
     }
     if json_output:
         write_json_stdout(payload)

--- a/autocontext/src/autocontext/cli_worker.py
+++ b/autocontext/src/autocontext/cli_worker.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Protocol
+
+import typer
+
+from autocontext.config.settings import AppSettings
+from autocontext.providers.base import LLMProvider, ProviderError
+from autocontext.storage.sqlite_store import SQLiteStore
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+class WorkerRunner(Protocol):
+    def run(self) -> int: ...
+
+    def run_batch(self, limit: int | None = None) -> int: ...
+
+
+class WorkerRunnerFactory(Protocol):
+    def __call__(
+        self,
+        settings: AppSettings,
+        *,
+        store: SQLiteStore,
+        provider: LLMProvider,
+        model: str = "",
+        poll_interval: float = 60.0,
+        max_consecutive_empty: int = 0,
+        concurrency: int = 1,
+    ) -> WorkerRunner: ...
+
+
+def _cli_attr(dependency_module: str, name: str) -> Any:
+    return getattr(importlib.import_module(dependency_module), name)
+
+
+def _close_if_supported(resource: object) -> None:
+    close = getattr(resource, "close", None)
+    if callable(close):
+        close()
+
+
+def _validate_worker_options(
+    *,
+    poll_interval: float,
+    concurrency: int,
+    max_empty_polls: int,
+) -> None:
+    if poll_interval < 0:
+        raise ValueError("--poll-interval must be non-negative")
+    if concurrency < 1:
+        raise ValueError("--concurrency must be a positive integer")
+    if max_empty_polls < 0:
+        raise ValueError("--max-empty-polls must be zero or a positive integer")
+
+
+def _write_worker_error(
+    message: str,
+    *,
+    json_output: bool,
+    console: Console,
+    write_json_stderr: Callable[[str], None],
+) -> None:
+    if json_output:
+        write_json_stderr(message)
+    else:
+        console.print(f"[red]{message}[/red]")
+
+
+def _select_worker_model(settings: AppSettings, provider: LLMProvider, model: str) -> str:
+    requested = model.strip()
+    if requested:
+        return requested
+    configured = getattr(settings, "judge_model", "")
+    if isinstance(configured, str) and configured.strip():
+        return configured.strip()
+    return provider.default_model()
+
+
+def run_worker_command(
+    *,
+    poll_interval: float,
+    concurrency: int,
+    max_empty_polls: int,
+    model: str,
+    once: bool,
+    json_output: bool,
+    console: Console,
+    load_settings_fn: Callable[[], AppSettings],
+    sqlite_from_settings: Callable[[AppSettings], SQLiteStore],
+    get_provider_fn: Callable[[AppSettings], LLMProvider],
+    create_task_runner_fn: WorkerRunnerFactory,
+    write_json_stdout: Callable[[object], None],
+    write_json_stderr: Callable[[str], None],
+) -> None:
+    try:
+        _validate_worker_options(
+            poll_interval=poll_interval,
+            concurrency=concurrency,
+            max_empty_polls=max_empty_polls,
+        )
+    except ValueError as exc:
+        _write_worker_error(
+            str(exc),
+            json_output=json_output,
+            console=console,
+            write_json_stderr=write_json_stderr,
+        )
+        raise typer.Exit(code=1) from exc
+
+    settings = load_settings_fn()
+    store = sqlite_from_settings(settings)
+    provider: LLMProvider | None = None
+
+    try:
+        provider = get_provider_fn(settings)
+        runner = create_task_runner_fn(
+            settings,
+            store=store,
+            provider=provider,
+            model=_select_worker_model(settings, provider, model),
+            poll_interval=poll_interval,
+            max_consecutive_empty=max_empty_polls,
+            concurrency=concurrency,
+        )
+        if once:
+            tasks_processed = runner.run_batch(concurrency)
+            mode = "once"
+        else:
+            tasks_processed = runner.run()
+            mode = "daemon"
+    except ProviderError as exc:
+        _write_worker_error(
+            str(exc),
+            json_output=json_output,
+            console=console,
+            write_json_stderr=write_json_stderr,
+        )
+        raise typer.Exit(code=1) from exc
+    finally:
+        if provider is not None:
+            _close_if_supported(provider)
+        _close_if_supported(store)
+
+    payload = {
+        "status": "stopped",
+        "mode": mode,
+        "tasks_processed": tasks_processed,
+        "poll_interval": poll_interval,
+        "concurrency": concurrency,
+    }
+    if json_output:
+        write_json_stdout(payload)
+    else:
+        console.print(
+            f"Worker stopped ({mode}). Processed {tasks_processed} task(s) "
+            f"with concurrency {concurrency}."
+        )
+
+
+def register_worker_command(
+    app: typer.Typer,
+    *,
+    console: Console,
+    dependency_module: str = "autocontext.cli",
+) -> None:
+    @app.command()
+    def worker(
+        poll_interval: float = typer.Option(
+            60.0,
+            "--poll-interval",
+            min=0.0,
+            help="Seconds to sleep between empty queue polls",
+        ),
+        concurrency: int = typer.Option(
+            1,
+            "--concurrency",
+            min=1,
+            help="Maximum queued tasks to process per batch",
+        ),
+        max_empty_polls: int = typer.Option(
+            0,
+            "--max-empty-polls",
+            min=0,
+            help="Stop after this many empty polls; 0 runs until signaled",
+        ),
+        model: str = typer.Option("", "--model", help="Judge model override for queued tasks"),
+        once: bool = typer.Option(False, "--once", help="Process one batch and exit"),
+        json_output: bool = typer.Option(False, "--json", help="Output structured JSON on exit"),
+    ) -> None:
+        """Run the background task queue worker."""
+        from autocontext.execution.task_runner import create_task_runner_from_settings
+        from autocontext.providers.registry import get_provider
+
+        run_worker_command(
+            poll_interval=poll_interval,
+            concurrency=concurrency,
+            max_empty_polls=max_empty_polls,
+            model=model,
+            once=once,
+            json_output=json_output,
+            console=console,
+            load_settings_fn=_cli_attr(dependency_module, "load_settings"),
+            sqlite_from_settings=_cli_attr(dependency_module, "_sqlite_from_settings"),
+            get_provider_fn=get_provider,
+            create_task_runner_fn=create_task_runner_from_settings,
+            write_json_stdout=_cli_attr(dependency_module, "_write_json_stdout"),
+            write_json_stderr=_cli_attr(dependency_module, "_write_json_stderr"),
+        )

--- a/autocontext/src/autocontext/execution/__init__.py
+++ b/autocontext/src/autocontext/execution/__init__.py
@@ -8,12 +8,15 @@ from .phased_execution import (
     split_budget,
 )
 from .supervisor import ExecutionInput, ExecutionOutput, ExecutionSupervisor
+from .task_queue_store import TaskQueueEnqueueStore, TaskQueueStore
 
 __all__ = [
     "ActionFilterHarness",
     "ExecutionSupervisor",
     "ExecutionInput",
     "ExecutionOutput",
+    "TaskQueueEnqueueStore",
+    "TaskQueueStore",
     "PhaseBudget",
     "PhaseResult",
     "PhasedExecutionPlan",

--- a/autocontext/src/autocontext/execution/executors/__init__.py
+++ b/autocontext/src/autocontext/execution/executors/__init__.py
@@ -1,6 +1,23 @@
 from .base import ExecutionEngine
+from .gondolin_contract import (
+    GondolinBackend,
+    GondolinExecutionRequest,
+    GondolinExecutionResult,
+    GondolinSandboxPolicy,
+    GondolinSecretRef,
+)
 from .local import LocalExecutor
 from .monty import MontyExecutor
 from .primeintellect import PrimeIntellectExecutor
 
-__all__ = ["ExecutionEngine", "LocalExecutor", "MontyExecutor", "PrimeIntellectExecutor"]
+__all__ = [
+    "ExecutionEngine",
+    "GondolinBackend",
+    "GondolinExecutionRequest",
+    "GondolinExecutionResult",
+    "GondolinSandboxPolicy",
+    "GondolinSecretRef",
+    "LocalExecutor",
+    "MontyExecutor",
+    "PrimeIntellectExecutor",
+]

--- a/autocontext/src/autocontext/execution/executors/gondolin_contract.py
+++ b/autocontext/src/autocontext/execution/executors/gondolin_contract.py
@@ -1,0 +1,61 @@
+"""Contract for optional Gondolin-backed microVM execution.
+
+This module intentionally contains only request/response shapes and a backend
+protocol. The open-source package does not ship a Gondolin runtime adapter; a
+deployment that needs VM isolation can implement this protocol behind the
+existing ``ExecutionEngine`` boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class GondolinSecretRef:
+    """Reference to a secret managed outside the task payload."""
+
+    name: str
+    env_var: str
+
+
+@dataclass(frozen=True, slots=True)
+class GondolinSandboxPolicy:
+    """Isolation policy requested for one microVM execution."""
+
+    allow_network: bool = False
+    allowed_egress_hosts: tuple[str, ...] = ()
+    read_only_mounts: tuple[Path, ...] = ()
+    writable_mounts: tuple[Path, ...] = ()
+    secrets: tuple[GondolinSecretRef, ...] = ()
+    timeout_seconds: float = 30.0
+
+
+@dataclass(frozen=True, slots=True)
+class GondolinExecutionRequest:
+    """Portable execution request for a Gondolin backend adapter."""
+
+    scenario_name: str
+    strategy: Mapping[str, Any]
+    seed: int
+    policy: GondolinSandboxPolicy = field(default_factory=GondolinSandboxPolicy)
+
+
+@dataclass(frozen=True, slots=True)
+class GondolinExecutionResult:
+    """Backend result after microVM execution completes."""
+
+    result: Mapping[str, Any]
+    replay: Mapping[str, Any]
+    stdout: str = ""
+    stderr: str = ""
+
+
+class GondolinBackend(Protocol):
+    """Backend adapter contract for optional Gondolin integration."""
+
+    def execute(self, request: GondolinExecutionRequest) -> GondolinExecutionResult:
+        """Run one isolated execution request and return structured results."""

--- a/autocontext/src/autocontext/execution/task_queue_store.py
+++ b/autocontext/src/autocontext/execution/task_queue_store.py
@@ -1,0 +1,56 @@
+"""Task queue storage contract for background workers.
+
+The open-source worker uses :class:`SQLiteStore`, but the task runner only
+needs this narrow surface. Hosted deployments can provide a stronger storage
+adapter, for example a Postgres-backed queue with leases, while preserving the
+same runner behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+TaskQueueRow = dict[str, Any]
+
+
+@runtime_checkable
+class TaskQueueStore(Protocol):
+    """Minimal store surface required by ``TaskRunner``."""
+
+    def dequeue_task(self) -> TaskQueueRow | None:
+        """Atomically claim and return the next runnable task."""
+
+    def get_task(self, task_id: str) -> TaskQueueRow | None:
+        """Return a task row by id."""
+
+    def complete_task(
+        self,
+        task_id: str,
+        best_score: float,
+        best_output: str,
+        total_rounds: int,
+        met_threshold: bool,
+        result_json: str | None = None,
+    ) -> None:
+        """Persist a successful task result."""
+
+    def fail_task(self, task_id: str, error: str) -> None:
+        """Persist a task failure."""
+
+    def get_calibration_examples(self, scenario_name: str, limit: int = 5) -> list[dict[str, Any]]:
+        """Return recent human-feedback anchors for judge calibration."""
+
+
+@runtime_checkable
+class TaskQueueEnqueueStore(TaskQueueStore, Protocol):
+    """Queue store surface required by ``enqueue_task``."""
+
+    def enqueue_task(
+        self,
+        task_id: str,
+        spec_name: str,
+        priority: int = 0,
+        config: dict[str, Any] | None = None,
+        scheduled_at: str | None = None,
+    ) -> None:
+        """Insert a pending task into the queue."""

--- a/autocontext/src/autocontext/execution/task_runner.py
+++ b/autocontext/src/autocontext/execution/task_runner.py
@@ -41,6 +41,7 @@ from autocontext.execution.simple_agent_task_workflow import (
     generate_simple_agent_task_output,
     revise_simple_agent_task_output,
 )
+from autocontext.execution.task_queue_store import TaskQueueEnqueueStore, TaskQueueStore
 from autocontext.execution.verification_dataset import enrich_objective_payload
 from autocontext.harness.pipeline.objective_guardrail import (
     evaluate_objective_guardrail,
@@ -48,7 +49,6 @@ from autocontext.harness.pipeline.objective_guardrail import (
 )
 from autocontext.providers.base import LLMProvider
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
-from autocontext.storage.sqlite_store import SQLiteStore
 
 logger = logging.getLogger(__name__)
 
@@ -309,7 +309,7 @@ def _build_evaluator_guardrail_payload(
 
 def _build_rubric_calibration_payload(
     *,
-    store: SQLiteStore,
+    store: TaskQueueStore,
     spec_name: str,
     task_prompt: str,
     rubric: str,
@@ -461,7 +461,7 @@ class TaskRunner:
 
     def __init__(
         self,
-        store: SQLiteStore,
+        store: TaskQueueStore,
         provider: LLMProvider,
         model: str = "",
         poll_interval: float = 60.0,
@@ -909,7 +909,7 @@ class TaskRunner:
 def create_task_runner_from_settings(
     settings: AppSettings,
     *,
-    store: SQLiteStore,
+    store: TaskQueueStore,
     provider: LLMProvider,
     model: str = "",
     poll_interval: float = 60.0,
@@ -936,7 +936,7 @@ def create_task_runner_from_settings(
 
 
 def enqueue_task(
-    store: SQLiteStore,
+    store: TaskQueueEnqueueStore,
     spec_name: str,
     task_prompt: str | None = None,
     rubric: str | None = None,

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -176,6 +176,12 @@ class GenerationRunner:
                         allow_fallback=settings.ssh_allow_fallback,
                     )
                 )
+        elif settings.executor_mode == "gondolin":
+            raise ValueError(
+                "Gondolin executor mode is reserved for the optional microVM "
+                "sandbox backend and is not wired yet. Use monty for in-process "
+                "sandboxing, or local/ssh/primeintellect for supported executors."
+            )
         else:
             self.executor = ExecutionSupervisor(executor=LocalExecutor())
         self.events = EventStreamEmitter(settings.event_stream_path)

--- a/autocontext/src/autocontext/providers/runtime_bridge.py
+++ b/autocontext/src/autocontext/providers/runtime_bridge.py
@@ -18,8 +18,17 @@ class RuntimeBridgeProvider(LLMProvider):
         self._runtime = runtime
         self._default_model_name = default_model_name
 
+    @property
+    def supports_concurrent_requests(self) -> bool:
+        return getattr(self._runtime, "supports_concurrent_requests", True) is not False
+
     def default_model(self) -> str:
         return self._default_model_name
+
+    def close(self) -> None:
+        close = getattr(self._runtime, "close", None)
+        if callable(close):
+            close()
 
     def complete(
         self,

--- a/autocontext/src/autocontext/runtimes/pi_rpc.py
+++ b/autocontext/src/autocontext/runtimes/pi_rpc.py
@@ -342,6 +342,8 @@ class PiPersistentRPCRuntime(PiRPCRuntime):
     use Pi's queue/state commands across a single session.
     """
 
+    supports_concurrent_requests = False
+
     def __init__(self, config: PiRPCConfig | None = None) -> None:
         super().__init__(config)
         self._process: subprocess.Popen[str] | None = None

--- a/autocontext/tests/test_cli_backport.py
+++ b/autocontext/tests/test_cli_backport.py
@@ -240,3 +240,67 @@ class TestQueueCommand:
             browser_url="https://status.example.com",
             priority=0,
         )
+
+
+class TestWorkerCommand:
+    def test_worker_help(self) -> None:
+        result = runner.invoke(app, ["worker", "--help"])
+        stdout = strip_ansi(result.stdout)
+        assert result.exit_code == 0
+        assert "--poll-interval" in stdout
+        assert "--concurrency" in stdout
+        assert "--max-empty-polls" in stdout
+        assert "--once" in stdout
+
+    def test_worker_once_wires_task_runner_factory(self) -> None:
+        settings = MagicMock(judge_model="settings-model", judge_provider="anthropic")
+        store = MagicMock()
+        provider = MagicMock()
+        provider.default_model.return_value = "provider-model"
+        runner_mock = MagicMock(tasks_processed=2)
+        runner_mock.run_batch.return_value = 2
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._sqlite_from_settings", return_value=store),
+            patch("autocontext.providers.registry.get_provider", return_value=provider),
+            patch(
+                "autocontext.execution.task_runner.create_task_runner_from_settings",
+                return_value=runner_mock,
+            ) as mock_create_runner,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "worker",
+                    "--once",
+                    "--poll-interval",
+                    "0.25",
+                    "--concurrency",
+                    "3",
+                    "--max-empty-polls",
+                    "1",
+                    "--model",
+                    "override-model",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout) == {
+            "status": "stopped",
+            "mode": "once",
+            "tasks_processed": 2,
+            "poll_interval": 0.25,
+            "concurrency": 3,
+        }
+        runner_mock.run_batch.assert_called_once_with(3)
+        mock_create_runner.assert_called_once_with(
+            settings,
+            store=store,
+            provider=provider,
+            model="override-model",
+            poll_interval=0.25,
+            max_consecutive_empty=1,
+            concurrency=3,
+        )

--- a/autocontext/tests/test_cli_backport.py
+++ b/autocontext/tests/test_cli_backport.py
@@ -304,3 +304,38 @@ class TestWorkerCommand:
             max_consecutive_empty=1,
             concurrency=3,
         )
+
+    def test_worker_forces_single_concurrency_for_stateful_provider(self) -> None:
+        settings = MagicMock(judge_model="settings-model", judge_provider="pi-rpc")
+        store = MagicMock()
+        provider = MagicMock()
+        provider.default_model.return_value = "provider-model"
+        provider.supports_concurrent_requests = False
+        runner_mock = MagicMock(tasks_processed=1)
+        runner_mock.run_batch.return_value = 1
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._sqlite_from_settings", return_value=store),
+            patch("autocontext.providers.registry.get_provider", return_value=provider),
+            patch(
+                "autocontext.execution.task_runner.create_task_runner_from_settings",
+                return_value=runner_mock,
+            ) as mock_create_runner,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "worker",
+                    "--once",
+                    "--concurrency",
+                    "4",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout)["concurrency"] == 1
+        runner_mock.run_batch.assert_called_once_with(1)
+        mock_create_runner.assert_called_once()
+        assert mock_create_runner.call_args.kwargs["concurrency"] == 1

--- a/autocontext/tests/test_gondolin_contract.py
+++ b/autocontext/tests/test_gondolin_contract.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from autocontext.execution.executors.gondolin_contract import (
+    GondolinBackend,
+    GondolinExecutionRequest,
+    GondolinExecutionResult,
+    GondolinSandboxPolicy,
+    GondolinSecretRef,
+)
+
+
+class _FakeGondolinBackend:
+    def execute(self, request: GondolinExecutionRequest) -> GondolinExecutionResult:
+        return GondolinExecutionResult(
+            result={"score": 1.0, "scenario": request.scenario_name},
+            replay={"seed": request.seed},
+            stdout="ok",
+        )
+
+
+def test_gondolin_contract_defaults_are_deny_by_default() -> None:
+    policy = GondolinSandboxPolicy()
+
+    assert policy.allow_network is False
+    assert policy.allowed_egress_hosts == ()
+    assert policy.secrets == ()
+
+
+def test_gondolin_contract_uses_secret_references_not_secret_values() -> None:
+    policy = GondolinSandboxPolicy(
+        secrets=(GondolinSecretRef(name="judge-api-key", env_var="AUTOCONTEXT_JUDGE_API_KEY"),)
+    )
+
+    assert policy.secrets[0].name == "judge-api-key"
+    assert policy.secrets[0].env_var == "AUTOCONTEXT_JUDGE_API_KEY"
+    assert "sk-" not in repr(policy)
+
+
+def test_gondolin_backend_protocol_can_be_implemented_out_of_tree() -> None:
+    backend: GondolinBackend = _FakeGondolinBackend()
+    result = backend.execute(
+        GondolinExecutionRequest(
+            scenario_name="grid_ctf",
+            strategy={"move": "north"},
+            seed=7,
+        )
+    )
+
+    assert result.result["score"] == 1.0
+    assert result.replay["seed"] == 7

--- a/autocontext/tests/test_monty_settings.py
+++ b/autocontext/tests/test_monty_settings.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from autocontext.config.settings import AppSettings, load_settings
 
 
@@ -66,3 +68,11 @@ class TestGenerationRunnerMontyWiring:
         runner = GenerationRunner(settings)
         assert isinstance(runner.executor.executor, LocalExecutor)
         assert runner.remote is None
+
+    def test_gondolin_executor_mode_is_reserved_until_backend_is_wired(self) -> None:
+        """Gondolin is fail-closed until a real microVM executor is configured."""
+        settings = AppSettings(agent_provider="deterministic", executor_mode="gondolin")
+        from autocontext.loop.generation_runner import GenerationRunner
+
+        with pytest.raises(ValueError, match="Gondolin"):
+            GenerationRunner(settings)

--- a/autocontext/tests/test_runtime_bridge_provider.py
+++ b/autocontext/tests/test_runtime_bridge_provider.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from autocontext.providers.runtime_bridge import RuntimeBridgeProvider
+
+
+def test_runtime_bridge_provider_closes_underlying_runtime() -> None:
+    runtime = MagicMock()
+    provider = RuntimeBridgeProvider(runtime, default_model_name="runtime-model")
+
+    provider.close()
+
+    runtime.close.assert_called_once_with()
+
+
+def test_runtime_bridge_provider_exposes_runtime_concurrency_capability() -> None:
+    runtime = MagicMock()
+    runtime.supports_concurrent_requests = False
+    provider = RuntimeBridgeProvider(runtime, default_model_name="runtime-model")
+
+    assert provider.supports_concurrent_requests is False

--- a/autocontext/tests/test_task_runner.py
+++ b/autocontext/tests/test_task_runner.py
@@ -10,6 +10,7 @@ import pytest
 
 from autocontext.config.settings import AppSettings
 from autocontext.execution.improvement_loop import ImprovementResult, RoundResult
+from autocontext.execution.task_queue_store import TaskQueueEnqueueStore, TaskQueueStore
 from autocontext.execution.task_runner import (
     SimpleAgentTask,
     TaskConfig,
@@ -267,6 +268,10 @@ class TestSimpleAgentTask:
 # ---------------------------------------------------------------------------
 
 class TestTaskRunner:
+    def test_sqlite_store_satisfies_task_queue_store_contract(self, store):
+        assert isinstance(store, TaskQueueStore)
+        assert isinstance(store, TaskQueueEnqueueStore)
+
     def test_run_once_empty_queue(self, store):
         provider = _MockProvider()
         runner = TaskRunner(store=store, provider=provider)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - [External agent integration guide](../autocontext/docs/agent-integration.md)
 - [Python and TypeScript extension hooks](../autocontext/docs/extensions.md)
 - [Sandbox and executor notes](../autocontext/docs/sandbox.md)
+- [Persistent host worker](../autocontext/docs/persistent-host.md)
 - [MLX host training notes](../autocontext/docs/mlx-training.md)
 
 ## Contributing And Support

--- a/examples/README.md
+++ b/examples/README.md
@@ -83,6 +83,8 @@ uv run autoctx serve --host 0.0.0.0 --port 8000
 uv run autoctx worker --poll-interval 5 --concurrency 2
 ```
 
+When using a stateful persistent provider such as persistent Pi RPC, the worker keeps effective concurrency at `1` for that provider so task streams cannot overlap.
+
 For bounded smoke tests, use `uv run autoctx worker --once --json`. See [autocontext/docs/persistent-host.md](../autocontext/docs/persistent-host.md) for deployment notes.
 
 ## Hermes Agent Skill And Curator Inspection

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ These are copy-paste starting points for people evaluating the repo, integrating
 - Want to wire Claude Code or another MCP client? Use the MCP config snippet.
 - Want a typed Python integration? Use the Python SDK example.
 - Want a Node/TypeScript integration? Use the TypeScript library example.
+- Want always-on queued work? Use the persistent host worker recipe.
 
 ## Python CLI From Source
 
@@ -67,6 +68,22 @@ Add this to your project-level `.claude/settings.json` and replace `/ABSOLUTE/PA
 ```
 
 For a fuller comparison of CLI, MCP, and SDK integrations, see [autocontext/docs/agent-integration.md](../autocontext/docs/agent-integration.md).
+
+## Persistent Host Worker
+
+Run the API server and worker from the same durable workspace when queued tasks should continue in the background:
+
+```bash
+cd autocontext
+export AUTOCONTEXT_DB_PATH=/srv/autoctx/runs/autocontext.sqlite3
+export AUTOCONTEXT_RUNS_ROOT=/srv/autoctx/runs
+export AUTOCONTEXT_KNOWLEDGE_ROOT=/srv/autoctx/knowledge
+
+uv run autoctx serve --host 0.0.0.0 --port 8000
+uv run autoctx worker --poll-interval 5 --concurrency 2
+```
+
+For bounded smoke tests, use `uv run autoctx worker --once --json`. See [autocontext/docs/persistent-host.md](../autocontext/docs/persistent-host.md) for deployment notes.
 
 ## Hermes Agent Skill And Curator Inspection
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -212,6 +212,8 @@ autoctx worker --poll-interval 5 --concurrency 2
 autoctx status
 ```
 
+Stateful persistent providers, including persistent Pi RPC, run with effective worker concurrency `1` to keep long-lived runtime sessions isolated.
+
 ## Provider Configuration
 
 Configure the agent provider via environment variables:

--- a/ts/README.md
+++ b/ts/README.md
@@ -183,6 +183,7 @@ autoctx new-scenario --template prompt-optimization --name support_triage
 # Interactive, simulations, and missions
 autoctx tui [--port 8000]
 autoctx serve [--port 8000] [--json] # HTTP API
+autoctx worker [--poll-interval 5] [--concurrency 2]
 autoctx mcp-serve                     # MCP server on stdio
 autoctx simulate -d "simulate deploying a web service with rollback"
 autoctx simulate -d "simulate escalation thresholds" --sweep max_escalations=1:5:1
@@ -207,6 +208,7 @@ autoctx repl --scenario my_saved_task
 
 # Task queue
 autoctx queue -s <spec> [--priority N] [--browser-url https://status.example.com]
+autoctx worker --poll-interval 5 --concurrency 2
 autoctx status
 ```
 

--- a/ts/src/agents/provider-bridge.ts
+++ b/ts/src/agents/provider-bridge.ts
@@ -20,6 +20,10 @@ export class RuntimeBridgeProvider implements LLMProvider {
     this.#model = model;
   }
 
+  get supportsConcurrentRequests(): boolean {
+    return this.#runtime.supportsConcurrentRequests !== false;
+  }
+
   defaultModel(): string {
     return this.#model;
   }
@@ -70,6 +74,10 @@ export class RetryProvider implements LLMProvider {
     this.#maxRetries = opts.maxRetries;
     this.#baseDelay = opts.baseDelay ?? 250;
     this.#maxDelay = opts.maxDelay ?? 10_000;
+  }
+
+  get supportsConcurrentRequests(): boolean {
+    return this.#inner.supportsConcurrentRequests !== false;
   }
 
   defaultModel(): string {

--- a/ts/src/cli/command-registry.ts
+++ b/ts/src/cli/command-registry.ts
@@ -43,6 +43,7 @@ export type DbCommandName =
   | "improve"
   | "repl"
   | "queue"
+  | "worker"
   | "status"
   | "serve"
   | "mcp-serve";
@@ -88,6 +89,7 @@ const COMMANDS: readonly CommandDescriptor[] = [
   { name: "improve", description: "Run multi-round improvement loop", group: "primary", route: { kind: "db", command: "improve" } },
   { name: "repl", description: "Run a direct REPL-loop session", group: "primary", route: { kind: "db", command: "repl" } },
   { name: "queue", description: "Add a task to the background runner queue", group: "primary", route: { kind: "db", command: "queue" } },
+  { name: "worker", description: "Run the background task queue worker", group: "primary", route: { kind: "db", command: "worker" } },
   { name: "status", description: "Show queue status", group: "primary", route: { kind: "db", command: "status" } },
   { name: "serve", description: "Start HTTP API server [--json]", group: "primary", route: { kind: "db", command: "serve" } },
   { name: "train", description: "Train a distilled model from curated dataset (requires configured executor)", group: "primary", route: { kind: "no-db", command: "train" } },

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -996,6 +996,7 @@ async function cmdWorker(dbPath: string): Promise<void> {
   const {
     planWorkerCommand,
     renderWorkerResult,
+    resolveWorkerConcurrency,
     WORKER_HELP_TEXT,
   } = await import("./worker-command-workflow.js");
 
@@ -1018,6 +1019,7 @@ async function cmdWorker(dbPath: string): Promise<void> {
   const { provider, model } = await getProvider(
     plan.model ? { model: plan.model } : {},
   );
+  const concurrency = resolveWorkerConcurrency(provider, plan.concurrency);
 
   const { hookBus } = await initializeHookBus({
     extensions: settings.extensions,
@@ -1031,7 +1033,7 @@ async function cmdWorker(dbPath: string): Promise<void> {
     model: plan.model ?? model,
     pollInterval: plan.pollInterval,
     maxConsecutiveEmpty: plan.maxEmptyPolls,
-    concurrency: plan.concurrency,
+    concurrency,
     hookBus,
   });
 
@@ -1041,13 +1043,13 @@ async function cmdWorker(dbPath: string): Promise<void> {
 
   try {
     const tasksProcessed = plan.once
-      ? await runner.runBatch(plan.concurrency)
+      ? await runner.runBatch(concurrency)
       : await runner.run();
     console.log(renderWorkerResult({
       mode: plan.once ? "once" : "daemon",
       tasksProcessed,
       pollInterval: plan.pollInterval,
-      concurrency: plan.concurrency,
+      concurrency,
       json: plan.json,
     }));
   } finally {

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -7,6 +7,7 @@
  *   autoctx improve   — run improvement loop
  *   autoctx repl      — run a direct REPL-loop session
  *   autoctx queue     — add task to background queue
+ *   autoctx worker    — run background queue worker
  *   autoctx status    — check queue status
  *   autoctx serve     — start HTTP API server
  *   autoctx mcp-serve — start MCP server on stdio
@@ -69,6 +70,7 @@ const DB_COMMAND_HANDLERS: Record<DbCommandName, (dbPath: string) => Promise<voi
   improve: cmdImprove,
   repl: cmdRepl,
   queue: cmdQueue,
+  worker: cmdWorker,
   status: cmdStatus,
   serve: cmdServeHttp,
   "mcp-serve": cmdMcpServe,
@@ -975,6 +977,85 @@ async function cmdQueue(dbPath: string): Promise<void> {
 
   console.log(renderQueuedTaskResult({ taskId: id, specName: plan.specName }));
   store.close();
+}
+
+async function cmdWorker(dbPath: string): Promise<void> {
+  const { values } = parseArgs({
+    args: process.argv.slice(3),
+    options: {
+      "poll-interval": { type: "string", default: "60" },
+      concurrency: { type: "string", default: "1" },
+      "max-empty-polls": { type: "string", default: "0" },
+      model: { type: "string" },
+      once: { type: "boolean" },
+      json: { type: "boolean" },
+      help: { type: "boolean", short: "h" },
+    },
+  });
+
+  const {
+    planWorkerCommand,
+    renderWorkerResult,
+    WORKER_HELP_TEXT,
+  } = await import("./worker-command-workflow.js");
+
+  if (values.help) {
+    console.log(WORKER_HELP_TEXT);
+    process.exit(0);
+  }
+
+  const plan = planWorkerCommand(values);
+  const { SQLiteStore } = await import("../storage/index.js");
+  const {
+    createTaskRunnerFromSettings,
+  } = await import("../execution/task-runner.js");
+  const { loadSettings } = await import("../config/index.js");
+  const { initializeHookBus } = await import("../extensions/index.js");
+
+  const settings = loadSettings();
+  const store = new SQLiteStore(dbPath);
+  store.migrate(getMigrationsDir());
+  const { provider, model } = await getProvider(
+    plan.model ? { model: plan.model } : {},
+  );
+
+  const { hookBus } = await initializeHookBus({
+    extensions: settings.extensions,
+    failFast: settings.extensionFailFast,
+  });
+
+  const runner = createTaskRunnerFromSettings({
+    settings,
+    store,
+    provider,
+    model: plan.model ?? model,
+    pollInterval: plan.pollInterval,
+    maxConsecutiveEmpty: plan.maxEmptyPolls,
+    concurrency: plan.concurrency,
+    hookBus,
+  });
+
+  const handleShutdown = () => runner.shutdown();
+  process.once("SIGINT", handleShutdown);
+  process.once("SIGTERM", handleShutdown);
+
+  try {
+    const tasksProcessed = plan.once
+      ? await runner.runBatch(plan.concurrency)
+      : await runner.run();
+    console.log(renderWorkerResult({
+      mode: plan.once ? "once" : "daemon",
+      tasksProcessed,
+      pollInterval: plan.pollInterval,
+      concurrency: plan.concurrency,
+      json: plan.json,
+    }));
+  } finally {
+    process.off("SIGINT", handleShutdown);
+    process.off("SIGTERM", handleShutdown);
+    provider.close?.();
+    store.close();
+  }
 }
 
 async function cmdStatus(dbPath: string): Promise<void> {

--- a/ts/src/cli/worker-command-workflow.ts
+++ b/ts/src/cli/worker-command-workflow.ts
@@ -30,6 +30,10 @@ export interface WorkerCommandPlan {
   json: boolean;
 }
 
+export interface WorkerConcurrencyProvider {
+  readonly supportsConcurrentRequests?: boolean;
+}
+
 export function planWorkerCommand(values: WorkerCommandValues): WorkerCommandPlan {
   const pollInterval = parseNonNegativeFloat(
     values["poll-interval"] ?? "60",
@@ -53,6 +57,16 @@ export function planWorkerCommand(values: WorkerCommandValues): WorkerCommandPla
     once: values.once === true,
     json: values.json === true,
   };
+}
+
+export function resolveWorkerConcurrency(
+  provider: WorkerConcurrencyProvider,
+  requestedConcurrency: number,
+): number {
+  if (requestedConcurrency > 1 && provider.supportsConcurrentRequests === false) {
+    return 1;
+  }
+  return requestedConcurrency;
 }
 
 export function renderWorkerResult(input: {

--- a/ts/src/cli/worker-command-workflow.ts
+++ b/ts/src/cli/worker-command-workflow.ts
@@ -1,0 +1,111 @@
+export const WORKER_HELP_TEXT = `
+autoctx worker [--poll-interval seconds] [--concurrency N] [--max-empty-polls N] [--once] [--json]
+
+Run the background task queue worker.
+
+Options:
+  --poll-interval N     Seconds to sleep between empty queue polls (default: 60)
+  --concurrency N       Maximum queued tasks to process per batch (default: 1)
+  --max-empty-polls N   Stop after N empty polls; 0 runs until signaled (default: 0)
+  --model MODEL         Judge model override for queued tasks
+  --once                Process one batch and exit
+  --json                Output structured JSON on exit
+`.trim();
+
+export interface WorkerCommandValues {
+  "poll-interval"?: string;
+  concurrency?: string;
+  "max-empty-polls"?: string;
+  model?: string;
+  once?: boolean;
+  json?: boolean;
+}
+
+export interface WorkerCommandPlan {
+  pollInterval: number;
+  concurrency: number;
+  maxEmptyPolls: number;
+  model?: string;
+  once: boolean;
+  json: boolean;
+}
+
+export function planWorkerCommand(values: WorkerCommandValues): WorkerCommandPlan {
+  const pollInterval = parseNonNegativeFloat(
+    values["poll-interval"] ?? "60",
+    "poll interval",
+  );
+  const concurrency = parsePositiveInteger(
+    values.concurrency ?? "1",
+    "concurrency",
+  );
+  const maxEmptyPolls = parseNonNegativeInteger(
+    values["max-empty-polls"] ?? "0",
+    "max empty polls",
+  );
+  const model = values.model?.trim() || undefined;
+
+  return {
+    pollInterval,
+    concurrency,
+    maxEmptyPolls,
+    model,
+    once: values.once === true,
+    json: values.json === true,
+  };
+}
+
+export function renderWorkerResult(input: {
+  mode: "once" | "daemon";
+  tasksProcessed: number;
+  pollInterval: number;
+  concurrency: number;
+  json: boolean;
+}): string {
+  if (input.json) {
+    return JSON.stringify({
+      status: "stopped",
+      mode: input.mode,
+      tasksProcessed: input.tasksProcessed,
+      pollInterval: input.pollInterval,
+      concurrency: input.concurrency,
+    });
+  }
+
+  return [
+    `Worker stopped (${input.mode}).`,
+    `Processed ${input.tasksProcessed} task(s).`,
+    `Concurrency: ${input.concurrency}.`,
+  ].join(" ");
+}
+
+function parsePositiveInteger(raw: string, label: string): number {
+  const trimmed = raw.trim();
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!/^\d+$/.test(trimmed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(raw: string, label: string): number {
+  const trimmed = raw.trim();
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`${label} must be zero or a positive integer`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeFloat(raw: string, label: string): number {
+  const trimmed = raw.trim();
+  const parsed = Number.parseFloat(trimmed);
+  if (
+    !/^(?:\d+(?:\.\d+)?|\.\d+)$/.test(trimmed) ||
+    !Number.isFinite(parsed) ||
+    parsed < 0
+  ) {
+    throw new Error(`${label} must be non-negative`);
+  }
+  return parsed;
+}

--- a/ts/src/execution/gondolin-contract.ts
+++ b/ts/src/execution/gondolin-contract.ts
@@ -1,0 +1,45 @@
+export interface GondolinSecretRef {
+  name: string;
+  envVar: string;
+}
+
+export interface GondolinSandboxPolicy {
+  allowNetwork: boolean;
+  allowedEgressHosts: string[];
+  readOnlyMounts: string[];
+  writableMounts: string[];
+  secrets: GondolinSecretRef[];
+  timeoutSeconds: number;
+}
+
+export interface GondolinExecutionRequest {
+  scenarioName: string;
+  strategy: Record<string, unknown>;
+  seed: number;
+  policy: GondolinSandboxPolicy;
+}
+
+export interface GondolinExecutionResult {
+  result: Record<string, unknown>;
+  replay: Record<string, unknown>;
+  stdout?: string;
+  stderr?: string;
+}
+
+export interface GondolinBackend {
+  execute(request: GondolinExecutionRequest): Promise<GondolinExecutionResult>;
+}
+
+export function createDefaultGondolinSandboxPolicy(
+  overrides: Partial<GondolinSandboxPolicy> = {},
+): GondolinSandboxPolicy {
+  return {
+    allowNetwork: false,
+    allowedEgressHosts: [],
+    readOnlyMounts: [],
+    writableMounts: [],
+    secrets: [],
+    timeoutSeconds: 30,
+    ...overrides,
+  };
+}

--- a/ts/src/execution/task-processing-workflow.ts
+++ b/ts/src/execution/task-processing-workflow.ts
@@ -2,11 +2,12 @@ import { ImprovementLoop } from "./improvement-loop.js";
 import { SequentialDelegatedJudge, type JudgeInterface } from "../judge/delegated.js";
 import { renderAgentTaskPrompt, resolveCustomAgentTask } from "../scenarios/custom-loader.js";
 import type { LLMProvider, AgentTaskInterface, ImprovementResult } from "../types/index.js";
-import type { SQLiteStore, TaskQueueRow } from "../storage/index.js";
+import type { TaskQueueRow } from "../storage/index.js";
 import type { TaskConfig } from "./task-runner-config.js";
 import { parseTaskConfig, serializeTaskResult } from "./task-runner-config.js";
 import type { RlmSessionRecord, RlmTaskConfig } from "../rlm/types.js";
 import type { QueuedTaskBrowserContextService } from "./queued-task-browser-context.js";
+import type { TaskQueueWorkerStore } from "./task-queue-store.js";
 
 interface SavedTaskSpec {
   judgeRubric?: string;
@@ -130,7 +131,7 @@ export function buildQueuedTaskExecutionPlan(opts: {
 }
 
 export async function executeQueuedTaskWorkflow(opts: {
-  store: SQLiteStore;
+  store: TaskQueueWorkerStore;
   task: TaskQueueRow;
   provider: LLMProvider;
   model: string;

--- a/ts/src/execution/task-processing-workflow.ts
+++ b/ts/src/execution/task-processing-workflow.ts
@@ -190,7 +190,7 @@ export async function executeQueuedTaskWorkflow(opts: {
       calibrationExamples: plan.calibrationExamples,
     });
 
-    opts.store.completeTask(
+    await opts.store.completeTask(
       opts.task.id,
       result.bestScore,
       result.bestOutput,
@@ -200,7 +200,7 @@ export async function executeQueuedTaskWorkflow(opts: {
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    opts.store.failTask(opts.task.id, message);
+    await opts.store.failTask(opts.task.id, message);
   }
 }
 

--- a/ts/src/execution/task-queue-store.ts
+++ b/ts/src/execution/task-queue-store.ts
@@ -1,0 +1,25 @@
+import type { TaskQueueRow } from "../storage/index.js";
+
+export interface TaskQueueWorkerStore {
+  dequeueTask(): TaskQueueRow | null;
+  getTask(taskId: string): TaskQueueRow | null;
+  completeTask(
+    taskId: string,
+    bestScore: number,
+    bestOutput: string,
+    totalRounds: number,
+    metThreshold: boolean,
+    resultJson?: string,
+  ): void;
+  failTask(taskId: string, error: string): void;
+}
+
+export interface TaskQueueEnqueueStore extends TaskQueueWorkerStore {
+  enqueueTask(
+    id: string,
+    specName: string,
+    priority?: number,
+    config?: Record<string, unknown>,
+    scheduledAt?: string,
+  ): void;
+}

--- a/ts/src/execution/task-queue-store.ts
+++ b/ts/src/execution/task-queue-store.ts
@@ -1,8 +1,10 @@
 import type { TaskQueueRow } from "../storage/index.js";
 
+export type MaybePromise<T> = T | Promise<T>;
+
 export interface TaskQueueWorkerStore {
-  dequeueTask(): TaskQueueRow | null;
-  getTask(taskId: string): TaskQueueRow | null;
+  dequeueTask(): MaybePromise<TaskQueueRow | null>;
+  getTask(taskId: string): MaybePromise<TaskQueueRow | null>;
   completeTask(
     taskId: string,
     bestScore: number,
@@ -10,8 +12,8 @@ export interface TaskQueueWorkerStore {
     totalRounds: number,
     metThreshold: boolean,
     resultJson?: string,
-  ): void;
-  failTask(taskId: string, error: string): void;
+  ): MaybePromise<void>;
+  failTask(taskId: string, error: string): MaybePromise<void>;
 }
 
 export interface TaskQueueEnqueueStore extends TaskQueueWorkerStore {
@@ -21,5 +23,5 @@ export interface TaskQueueEnqueueStore extends TaskQueueWorkerStore {
     priority?: number,
     config?: Record<string, unknown>,
     scheduledAt?: string,
-  ): void;
+  ): MaybePromise<void>;
 }

--- a/ts/src/execution/task-runner-config.ts
+++ b/ts/src/execution/task-runner-config.ts
@@ -8,7 +8,7 @@ import {
   type RlmSessionRecord,
   type RlmTaskConfig,
 } from "../rlm/types.js";
-import type { SQLiteStore } from "../storage/index.js";
+import type { TaskQueueEnqueueStore } from "./task-queue-store.js";
 
 export interface TaskConfig {
   maxRounds?: number;
@@ -169,7 +169,7 @@ export function buildEnqueueTaskConfig(opts?: EnqueueTaskRequest): Record<string
 }
 
 export function enqueueConfiguredTask(
-  store: SQLiteStore,
+  store: TaskQueueEnqueueStore,
   specName: string,
   opts?: EnqueueTaskRequest,
 ): string {

--- a/ts/src/execution/task-runner-loop-workflow.ts
+++ b/ts/src/execution/task-runner-loop-workflow.ts
@@ -5,13 +5,13 @@ export function buildTaskRunnerModel(defaultModel: string, explicitModel?: strin
   return explicitModel || defaultModel;
 }
 
-export function dequeueTaskBatch(
+export async function dequeueTaskBatch(
   store: Pick<TaskQueueWorkerStore, "dequeueTask">,
   maxTasks: number,
-): TaskQueueRow[] {
+): Promise<TaskQueueRow[]> {
   const tasks: TaskQueueRow[] = [];
   for (let index = 0; index < maxTasks; index++) {
-    const task = store.dequeueTask();
+    const task = await store.dequeueTask();
     if (!task) {
       break;
     }

--- a/ts/src/execution/task-runner-loop-workflow.ts
+++ b/ts/src/execution/task-runner-loop-workflow.ts
@@ -1,11 +1,12 @@
-import type { TaskQueueRow, SQLiteStore } from "../storage/index.js";
+import type { TaskQueueRow } from "../storage/index.js";
+import type { TaskQueueWorkerStore } from "./task-queue-store.js";
 
 export function buildTaskRunnerModel(defaultModel: string, explicitModel?: string): string {
   return explicitModel || defaultModel;
 }
 
 export function dequeueTaskBatch(
-  store: SQLiteStore,
+  store: Pick<TaskQueueWorkerStore, "dequeueTask">,
   maxTasks: number,
 ): TaskQueueRow[] {
   const tasks: TaskQueueRow[] = [];

--- a/ts/src/execution/task-runner.ts
+++ b/ts/src/execution/task-runner.ts
@@ -217,16 +217,16 @@ export class TaskRunner {
   }
 
   async runOnce(): Promise<TaskQueueRow | null> {
-    const task = this.#store.dequeueTask();
+    const task = await this.#store.dequeueTask();
     if (!task) return null;
     await this.#processTask(task);
     this.#tasksProcessed++;
-    return this.#store.getTask(task.id) ?? null;
+    return (await this.#store.getTask(task.id)) ?? null;
   }
 
   async runBatch(limit?: number): Promise<number> {
     const maxTasks = limit ?? this.#concurrency;
-    const tasks = dequeueTaskBatch(this.#store, maxTasks);
+    const tasks = await dequeueTaskBatch(this.#store, maxTasks);
     if (tasks.length === 0) return 0;
 
     await Promise.all(tasks.map((task) => this.#processTask(task)));

--- a/ts/src/execution/task-runner.ts
+++ b/ts/src/execution/task-runner.ts
@@ -11,7 +11,7 @@ import type {
 import type { HookBus } from "../extensions/index.js";
 import type { AppSettings } from "../config/index.js";
 import { type DelegatedResult, type JudgeInterface } from "../judge/delegated.js";
-import type { SQLiteStore, TaskQueueRow } from "../storage/index.js";
+import type { TaskQueueRow } from "../storage/index.js";
 import { assertFamilyContract } from "../scenarios/family-interfaces.js";
 import {
   type RlmSessionRecord,
@@ -37,6 +37,10 @@ import {
   buildTaskRunnerModel,
   dequeueTaskBatch,
 } from "./task-runner-loop-workflow.js";
+import type {
+  TaskQueueEnqueueStore,
+  TaskQueueWorkerStore,
+} from "./task-queue-store.js";
 
 export type { TaskConfig } from "./task-runner-config.js";
 
@@ -164,7 +168,7 @@ export class SimpleAgentTask implements AgentTaskInterface {
 }
 
 export interface TaskRunnerOpts {
-  store: SQLiteStore;
+  store: TaskQueueWorkerStore;
   provider: LLMProvider;
   model?: string;
   knowledgeRoot?: string;
@@ -184,7 +188,7 @@ export interface TaskRunnerFromSettingsOpts
 }
 
 export class TaskRunner {
-  #store: SQLiteStore;
+  #store: TaskQueueWorkerStore;
   #provider: LLMProvider;
   #model: string;
   #knowledgeRoot?: string;
@@ -230,6 +234,29 @@ export class TaskRunner {
     return tasks.length;
   }
 
+  async run(): Promise<number> {
+    let consecutiveEmpty = 0;
+
+    while (!this.#shutdown) {
+      const processed = await this.runBatch(this.#concurrency);
+      if (processed === 0) {
+        consecutiveEmpty++;
+        if (
+          this.#maxConsecutiveEmpty > 0 &&
+          consecutiveEmpty >= this.#maxConsecutiveEmpty
+        ) {
+          break;
+        }
+        await this.#sleep(this.#pollInterval);
+        continue;
+      }
+
+      consecutiveEmpty = 0;
+    }
+
+    return this.#tasksProcessed;
+  }
+
   shutdown(): void {
     this.#shutdown = true;
   }
@@ -264,10 +291,19 @@ export class TaskRunner {
       },
     });
   }
+
+  async #sleep(seconds: number): Promise<void> {
+    let remainingMs = Math.max(0, seconds * 1000);
+    while (remainingMs > 0 && !this.#shutdown) {
+      const chunkMs = Math.min(1000, remainingMs);
+      await new Promise((resolve) => setTimeout(resolve, chunkMs));
+      remainingMs -= chunkMs;
+    }
+  }
 }
 
 export function enqueueTask(
-  store: SQLiteStore,
+  store: TaskQueueEnqueueStore,
   specName: string,
   opts?: EnqueueTaskRequest,
 ): string {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -175,6 +175,7 @@ export type {
   TaskConfig,
 } from "./execution/task-runner.js";
 export type {
+  MaybePromise,
   TaskQueueEnqueueStore,
   TaskQueueWorkerStore,
 } from "./execution/task-queue-store.js";

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -174,6 +174,18 @@ export type {
   TaskRunnerFromSettingsOpts,
   TaskConfig,
 } from "./execution/task-runner.js";
+export type {
+  TaskQueueEnqueueStore,
+  TaskQueueWorkerStore,
+} from "./execution/task-queue-store.js";
+export { createDefaultGondolinSandboxPolicy } from "./execution/gondolin-contract.js";
+export type {
+  GondolinBackend,
+  GondolinExecutionRequest,
+  GondolinExecutionResult,
+  GondolinSandboxPolicy,
+  GondolinSecretRef,
+} from "./execution/gondolin-contract.js";
 export { JudgeExecutor } from "./execution/judge-executor.js";
 export { ActionFilterHarness, ActionDictSchema } from "./execution/action-filter.js";
 export type { ActionDict, ScenarioLike, HarnessLoaderLike } from "./execution/action-filter.js";

--- a/ts/src/runtimes/base.ts
+++ b/ts/src/runtimes/base.ts
@@ -28,5 +28,7 @@ export interface AgentRuntime {
 
   close?(): void;
 
+  readonly supportsConcurrentRequests?: boolean;
+
   readonly name: string;
 }

--- a/ts/src/runtimes/pi-rpc.ts
+++ b/ts/src/runtimes/pi-rpc.ts
@@ -359,6 +359,7 @@ type PiRpcCommand = Record<string, unknown> & { type: string; id?: string };
 type PiRpcEvent = Record<string, unknown> & { type?: string };
 
 export class PiPersistentRPCRuntime extends PiRPCRuntime {
+  readonly supportsConcurrentRequests = false;
   private process: ReturnType<typeof spawn> | null = null;
   private stdoutBuffer = "";
   private stdoutLines: string[] = [];

--- a/ts/src/server/run-environment-catalog.ts
+++ b/ts/src/server/run-environment-catalog.ts
@@ -74,6 +74,11 @@ export function buildEnvironmentInfo(opts: {
     ],
     executors: [
       { mode: "local", available: true, description: "Local subprocess execution" },
+      {
+        mode: "gondolin",
+        available: false,
+        description: "Optional microVM sandbox backend; reserved until a Gondolin executor is configured",
+      },
     ],
     currentExecutor: "local",
     agentProvider: opts.activeProviderType ?? "none",

--- a/ts/src/types/index.ts
+++ b/ts/src/types/index.ts
@@ -37,6 +37,8 @@ export interface LLMProvider {
 
   close?(): void;
 
+  readonly supportsConcurrentRequests?: boolean;
+
   readonly name: string;
 }
 

--- a/ts/tests/gondolin-contract.test.ts
+++ b/ts/tests/gondolin-contract.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultGondolinSandboxPolicy,
+  type GondolinBackend,
+} from "../src/execution/gondolin-contract.js";
+
+describe("gondolin contract", () => {
+  it("defaults to deny-by-default network and secret policy", () => {
+    const policy = createDefaultGondolinSandboxPolicy();
+
+    expect(policy.allowNetwork).toBe(false);
+    expect(policy.allowedEgressHosts).toEqual([]);
+    expect(policy.secrets).toEqual([]);
+  });
+
+  it("lets out-of-tree backends implement the execution contract", async () => {
+    const backend = {
+      execute: async (request) => ({
+        result: { score: 1, scenario: request.scenarioName },
+        replay: { seed: request.seed },
+        stdout: "ok",
+      }),
+    } satisfies GondolinBackend;
+
+    await expect(
+      backend.execute({
+        scenarioName: "grid_ctf",
+        strategy: { move: "north" },
+        seed: 7,
+        policy: createDefaultGondolinSandboxPolicy({
+          secrets: [{ name: "judge-api-key", envVar: "AUTOCONTEXT_JUDGE_API_KEY" }],
+        }),
+      }),
+    ).resolves.toEqual({
+      result: { score: 1, scenario: "grid_ctf" },
+      replay: { seed: 7 },
+      stdout: "ok",
+    });
+  });
+});

--- a/ts/tests/pi-runtime.test.ts
+++ b/ts/tests/pi-runtime.test.ts
@@ -601,6 +601,7 @@ describe("PiRPCRuntime", () => {
       },
     );
 
+    expect(provider.supportsConcurrentRequests).toBe(false);
     const first = await provider.complete({ systemPrompt: "", userPrompt: "first prompt" });
     const second = await provider.complete({ systemPrompt: "", userPrompt: "second prompt" });
 

--- a/ts/tests/run-environment-catalog.test.ts
+++ b/ts/tests/run-environment-catalog.test.ts
@@ -86,6 +86,11 @@ describe("run environment catalog", () => {
     });
 
     expect(info.currentExecutor).toBe("local");
+    expect(info.executors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ mode: "gondolin", available: false }),
+      ]),
+    );
     expect(info.agentProvider).toBe("deterministic");
     expect(info.scenarios).toEqual([
       { name: "grid_ctf", description: "Capture the flag rules" },

--- a/ts/tests/task-queue-store-contract.test.ts
+++ b/ts/tests/task-queue-store-contract.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { enqueueTask } from "../src/execution/task-runner.js";
+import type { TaskQueueEnqueueStore } from "../src/execution/task-queue-store.js";
+import type { TaskQueueRow } from "../src/storage/index.js";
+
+function makeTask(id: string, specName: string): TaskQueueRow {
+  return {
+    id,
+    spec_name: specName,
+    status: "pending",
+    priority: 0,
+    config_json: null,
+    scheduled_at: null,
+    started_at: null,
+    completed_at: null,
+    best_score: null,
+    best_output: null,
+    total_rounds: null,
+    met_threshold: 0,
+    result_json: null,
+    error: null,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+  };
+}
+
+describe("task queue store contract", () => {
+  it("lets hosted stores provide the queue surface without subclassing SQLiteStore", () => {
+    const rows = new Map<string, TaskQueueRow>();
+    const store = {
+      enqueueTask: (id: string, specName: string) => {
+        rows.set(id, makeTask(id, specName));
+      },
+      dequeueTask: () => rows.values().next().value ?? null,
+      getTask: (taskId: string) => rows.get(taskId) ?? null,
+      completeTask: (taskId: string) => {
+        const task = rows.get(taskId);
+        if (task) rows.set(taskId, { ...task, status: "completed" });
+      },
+      failTask: (taskId: string, error: string) => {
+        const task = rows.get(taskId);
+        if (task) rows.set(taskId, { ...task, status: "failed", error });
+      },
+    } satisfies TaskQueueEnqueueStore;
+
+    const taskId = enqueueTask(store, "hosted-spec", {
+      taskPrompt: "Do the thing",
+      priority: 5,
+    });
+
+    expect(store.getTask(taskId)?.spec_name).toBe("hosted-spec");
+  });
+});

--- a/ts/tests/task-queue-store-contract.test.ts
+++ b/ts/tests/task-queue-store-contract.test.ts
@@ -51,4 +51,32 @@ describe("task queue store contract", () => {
 
     expect(store.getTask(taskId)?.spec_name).toBe("hosted-spec");
   });
+
+  it("lets hosted Postgres-style stores expose async queue methods", async () => {
+    const rows = new Map<string, TaskQueueRow>();
+    const store = {
+      enqueueTask: async (id: string, specName: string) => {
+        rows.set(id, makeTask(id, specName));
+      },
+      dequeueTask: async () => rows.values().next().value ?? null,
+      getTask: async (taskId: string) => rows.get(taskId) ?? null,
+      completeTask: async (taskId: string) => {
+        const task = rows.get(taskId);
+        if (task) rows.set(taskId, { ...task, status: "completed" });
+      },
+      failTask: async (taskId: string, error: string) => {
+        const task = rows.get(taskId);
+        if (task) rows.set(taskId, { ...task, status: "failed", error });
+      },
+    } satisfies TaskQueueEnqueueStore;
+
+    await store.enqueueTask("hosted-async", "postgres-spec");
+    const task = await store.dequeueTask();
+    expect(task?.spec_name).toBe("postgres-spec");
+
+    await store.completeTask("hosted-async", 0.9, "done", 1, true);
+    await expect(store.getTask("hosted-async")).resolves.toMatchObject({
+      status: "completed",
+    });
+  });
 });

--- a/ts/tests/task-runner-workflows.test.ts
+++ b/ts/tests/task-runner-workflows.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../src/execution/task-runner-loop-workflow.js";
 
 describe("task runner workflows", () => {
-  it("builds task runner model defaults and dequeues up to the requested batch size", () => {
+  it("builds task runner model defaults and dequeues up to the requested batch size", async () => {
     expect(buildTaskRunnerModel("provider-default")).toBe("provider-default");
     expect(buildTaskRunnerModel("provider-default", "explicit-model")).toBe("explicit-model");
 
@@ -20,7 +20,7 @@ describe("task runner workflows", () => {
       dequeueTask: vi.fn(() => dequeued[index++] ?? null),
     } as never;
 
-    expect(dequeueTaskBatch(store, 5)).toEqual([{ id: "t1" }, { id: "t2" }]);
+    await expect(dequeueTaskBatch(store, 5)).resolves.toEqual([{ id: "t1" }, { id: "t2" }]);
   });
 
   it("builds revision prompts and normalizes judge results", async () => {

--- a/ts/tests/task-runner.test.ts
+++ b/ts/tests/task-runner.test.ts
@@ -386,6 +386,54 @@ describe("TaskRunner.runBatch", () => {
   });
 });
 
+describe("TaskRunner.run", () => {
+  it("processes queued tasks until the empty-poll limit is reached", async () => {
+    const store = createStore();
+    enqueueTask(store, "spec-1", {
+      taskPrompt: "Task 1",
+      rubric: "Be good",
+      initialOutput: "Output 1",
+    });
+    enqueueTask(store, "spec-2", {
+      taskPrompt: "Task 2",
+      rubric: "Be good",
+      initialOutput: "Output 2",
+    });
+
+    const runner = new TaskRunner({
+      store,
+      provider: makeMockProvider(),
+      concurrency: 2,
+      pollInterval: 0,
+      maxConsecutiveEmpty: 1,
+    });
+
+    await expect(runner.run()).resolves.toBe(2);
+    expect(runner.tasksProcessed).toBe(2);
+    expect(store.pendingTaskCount()).toBe(0);
+  });
+
+  it("stops immediately after shutdown is requested", async () => {
+    const store = createStore();
+    enqueueTask(store, "spec-1", {
+      taskPrompt: "Task 1",
+      rubric: "Be good",
+      initialOutput: "Output 1",
+    });
+
+    const runner = new TaskRunner({
+      store,
+      provider: makeMockProvider(),
+      pollInterval: 0,
+      maxConsecutiveEmpty: 1,
+    });
+    runner.shutdown();
+
+    await expect(runner.run()).resolves.toBe(0);
+    expect(store.pendingTaskCount()).toBe(1);
+  });
+});
+
 describe("minRounds wiring (AC-53)", () => {
   it("enqueueTask passes minRounds to config", () => {
     const store = createStore();

--- a/ts/tests/worker-command-workflow.test.ts
+++ b/ts/tests/worker-command-workflow.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   planWorkerCommand,
   renderWorkerResult,
+  resolveWorkerConcurrency,
   WORKER_HELP_TEXT,
 } from "../src/cli/worker-command-workflow.js";
 
@@ -68,6 +69,12 @@ describe("worker command workflow", () => {
       concurrency: 1,
       json: false,
     })).toContain("Processed 1 task");
+  });
+
+  it("forces single concurrency for stateful providers", () => {
+    expect(resolveWorkerConcurrency({ supportsConcurrentRequests: false }, 4)).toBe(1);
+    expect(resolveWorkerConcurrency({ supportsConcurrentRequests: true }, 4)).toBe(4);
+    expect(resolveWorkerConcurrency({}, 4)).toBe(4);
   });
 
   it("documents persistent worker options", () => {

--- a/ts/tests/worker-command-workflow.test.ts
+++ b/ts/tests/worker-command-workflow.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  planWorkerCommand,
+  renderWorkerResult,
+  WORKER_HELP_TEXT,
+} from "../src/cli/worker-command-workflow.js";
+
+describe("worker command workflow", () => {
+  it("plans daemon defaults and once-mode overrides", () => {
+    expect(planWorkerCommand({})).toEqual({
+      pollInterval: 60,
+      concurrency: 1,
+      maxEmptyPolls: 0,
+      model: undefined,
+      once: false,
+      json: false,
+    });
+
+    expect(planWorkerCommand({
+      "poll-interval": "0.25",
+      concurrency: "3",
+      "max-empty-polls": "1",
+      model: "override-model",
+      once: true,
+      json: true,
+    })).toEqual({
+      pollInterval: 0.25,
+      concurrency: 3,
+      maxEmptyPolls: 1,
+      model: "override-model",
+      once: true,
+      json: true,
+    });
+  });
+
+  it("validates daemon command values before the CLI touches providers", () => {
+    expect(() => planWorkerCommand({ "poll-interval": "-1" })).toThrow(
+      "poll interval must be non-negative",
+    );
+    expect(() => planWorkerCommand({ concurrency: "0" })).toThrow(
+      "concurrency must be a positive integer",
+    );
+    expect(() => planWorkerCommand({ "max-empty-polls": "-1" })).toThrow(
+      "max empty polls must be zero or a positive integer",
+    );
+  });
+
+  it("renders JSON and human results", () => {
+    expect(renderWorkerResult({
+      mode: "once",
+      tasksProcessed: 2,
+      pollInterval: 0.25,
+      concurrency: 3,
+      json: true,
+    })).toBe(JSON.stringify({
+      status: "stopped",
+      mode: "once",
+      tasksProcessed: 2,
+      pollInterval: 0.25,
+      concurrency: 3,
+    }));
+
+    expect(renderWorkerResult({
+      mode: "daemon",
+      tasksProcessed: 1,
+      pollInterval: 60,
+      concurrency: 1,
+      json: false,
+    })).toContain("Processed 1 task");
+  });
+
+  it("documents persistent worker options", () => {
+    expect(WORKER_HELP_TEXT).toContain("autoctx worker");
+    expect(WORKER_HELP_TEXT).toContain("--poll-interval");
+    expect(WORKER_HELP_TEXT).toContain("--max-empty-polls");
+  });
+});


### PR DESCRIPTION
## Summary

This PR productizes the existing TaskRunner as a persistent worker surface while keeping the hosted monetization boundary intact. It adds matching Python and TypeScript worker commands, public queue-store contracts for out-of-tree storage adapters, and a fail-closed Gondolin sandbox contract without shipping a hosted isolation implementation.

## Why

The current task queue can enqueue and execute work, but there was no first-class daemon command for running queued tasks on a persistent host. That made the OSS path less clear for background AutoContext operation and left the future hosted Postgres integration point implicit. It also left Gondolin as an idea rather than a bounded optional backend contract.

## What Changed

- Added `autoctx worker` in Python and TypeScript with `--once`, `--json`, polling interval, concurrency, max-empty-poll, and model options.
- Added shutdown-aware daemon execution to the TypeScript TaskRunner to match the Python runner behavior.
- Introduced Python and TypeScript queue-store interfaces so hosted Postgres can implement atomic claim, lookup, complete, fail, and enqueue behavior behind a stable OSS contract.
- Added Gondolin sandbox policy/backend contracts in both runtimes and made `AUTOCONTEXT_EXECUTOR_MODE=gondolin` fail closed until an adapter is wired.
- Documented persistent hosting with `autoctx serve` plus `autoctx worker`, durable `runs/`, `knowledge/`, and SQLite/Postgres storage.
- Documented what remains proprietary for hosted monetization: tenant scheduling, Postgres leases/heartbeats/retries, billing, policy UI, secret brokering, fleet routing, and retention/audit workflows.

## Validation

- `uv run pytest` — 6028 passed, 42 skipped
- `uv run ruff check src tests`
- `uv run mypy src`
- `npm test` — 695 files passed, 4750 tests passed
- `npm run lint`
- `git diff --check`
