### PR TITLE
Add external eval diagnostics helpers

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -53,6 +53,10 @@
       "import": "./dist/control-plane/memory-packs/index.js",
       "types": "./dist/control-plane/memory-packs/index.d.ts"
     },
+    "./control-plane/external-evals": {
+      "import": "./dist/control-plane/external-evals/index.js",
+      "types": "./dist/control-plane/external-evals/index.d.ts"
+    },
     "./production-traces": {
       "types": "./dist/production-traces/sdk/index.d.ts",
       "import": "./dist/production-traces/sdk/index.js",

--- a/ts/src/control-plane/external-evals/index.ts
+++ b/ts/src/control-plane/external-evals/index.ts
@@ -180,7 +180,7 @@ export function buildExternalEvalDiagnosticReport(
   }
 
   const diagnostics = inputs.trials
-    .filter((trial) => trial.status !== "passed" && trial.status !== "discarded")
+    .filter((trial) => trial.status !== "passed")
     .map((trial) => buildTrialDiagnostic(inputs.runId, trial, evidenceByTrialId.get(trial.trialId)));
 
   return {
@@ -225,9 +225,9 @@ function classifyUnresolvedStatus(inputs: ClassifyExternalEvalTrialInputs): Eval
   if (lifecycleStatus === "cancelled") return "cancelled";
   if (
     lifecycleStatus === "timed-out" ||
-    failureMode.includes("timeout") ||
-    failureMode === "agent_timeout" ||
-    failureMode === "infrastructure-error"
+    lifecycleStatus === "failed" ||
+    isInfrastructureFailureMode(failureMode) ||
+    isInfrastructureFailureMode(inputs.lifecycle?.errorKind)
   ) {
     return "infrastructure-error";
   }
@@ -266,6 +266,9 @@ function buildTrialNotes(inputs: ClassifyExternalEvalTrialInputs): readonly stri
     if (inputs.lifecycle.timeoutSource !== undefined) {
       notes.push(`timeout_source=${inputs.lifecycle.timeoutSource}`);
     }
+    if (inputs.lifecycle.errorKind !== undefined) {
+      notes.push(`adapter_error_kind=${inputs.lifecycle.errorKind}`);
+    }
     if (inputs.lifecycle.artifacts.stdoutPath !== undefined) {
       notes.push(`stdout=${inputs.lifecycle.artifacts.stdoutPath}`);
     }
@@ -283,7 +286,7 @@ function buildTrialDiagnostic(
 ): ExternalEvalTrialDiagnostic {
   const lifecycle = evidence?.adapterLifecycle;
   const category = classifyDiagnosticCategory(trial, evidence);
-  const failureExcerpts = buildFailureExcerpts(category, evidence);
+  const failureExcerpts = buildFailureExcerpts(category, trial, evidence);
 
   return {
     id: `${runId}:${trial.trialId}`,
@@ -308,7 +311,16 @@ function classifyDiagnosticCategory(
   trial: EvalTrial,
   evidence: ExternalEvalTrialEvidence | undefined,
 ): ExternalEvalDiagnosticCategory {
-  if (trial.status === "infrastructure-error" || evidence?.adapterLifecycle?.status === "timed-out") {
+  if (trial.status === "discarded") {
+    return "integrity-risk";
+  }
+  if (
+    trial.status === "infrastructure-error" ||
+    evidence?.adapterLifecycle?.status === "timed-out" ||
+    evidence?.adapterLifecycle?.status === "failed" ||
+    isInfrastructureFailureMode(trial.errorKind) ||
+    isInfrastructureFailureMode(evidence?.adapterLifecycle?.errorKind)
+  ) {
     return "adapter-runtime-failure";
   }
   if (trial.status === "cancelled") {
@@ -345,6 +357,7 @@ function diagnosticConfidence(
   evidence: ExternalEvalTrialEvidence | undefined,
 ): number {
   if (category === "adapter-runtime-failure" && trial.status === "infrastructure-error") return 0.95;
+  if (category === "integrity-risk" && trial.status === "discarded") return 0.9;
   if (evidence?.verifierOutput !== undefined && evidence.verifierOutput.length > 0) return 0.85;
   return category === "unknown" ? 0.25 : 0.6;
 }
@@ -400,17 +413,40 @@ function diagnosticRecommendations(category: ExternalEvalDiagnosticCategory): re
 
 function buildFailureExcerpts(
   category: ExternalEvalDiagnosticCategory,
+  trial: EvalTrial,
   evidence: ExternalEvalTrialEvidence | undefined,
 ): readonly string[] {
   if (category === "adapter-runtime-failure" && evidence?.adapterLifecycle !== undefined) {
     const lifecycle = evidence.adapterLifecycle;
     return [
       `adapter_status=${lifecycle.status}`,
+      ...(lifecycle.errorKind !== undefined ? [`adapter_error_kind=${lifecycle.errorKind}`] : []),
       ...(lifecycle.timeoutSource !== undefined ? [`timeout_source=${lifecycle.timeoutSource}`] : []),
+    ];
+  }
+  if (category === "integrity-risk") {
+    return [
+      `trial_status=${trial.status}`,
+      ...(trial.errorKind !== undefined ? [`error_kind=${trial.errorKind}`] : []),
+      ...(trial.notes ?? []),
     ];
   }
 
   return sanitizeVerifierOutput(evidence?.verifierOutput ?? "");
+}
+
+function isInfrastructureFailureMode(errorKind: string | undefined): boolean {
+  const kind = normalizedFailureMode(errorKind).toLowerCase();
+  return (
+    kind.includes("timeout") ||
+    kind.includes("adapter") ||
+    kind.includes("runtime") ||
+    kind.includes("infrastructure") ||
+    kind.includes("subprocess") ||
+    kind.includes("process") ||
+    kind.includes("container") ||
+    kind === "agent_timeout"
+  );
 }
 
 function sanitizeVerifierOutput(output: string): readonly string[] {

--- a/ts/src/control-plane/external-evals/index.ts
+++ b/ts/src/control-plane/external-evals/index.ts
@@ -1,0 +1,588 @@
+import type {
+  EvalRunIntegrity,
+  EvalTrial,
+  EvalTrialStatus,
+  ValidationResult,
+} from "../contract/types.js";
+import type {
+  OperationalMemoryFinding,
+  OperationalMemoryPack,
+} from "../memory-packs/index.js";
+
+export type ExternalEvalAdapterLifecycleStatus =
+  | "not-started"
+  | "running"
+  | "completed"
+  | "failed"
+  | "timed-out"
+  | "cancelled";
+
+export type ExternalEvalDiagnosticCategory =
+  | "agent-task-failure"
+  | "verifier-contract-mismatch"
+  | "setup-environment-failure"
+  | "adapter-runtime-failure"
+  | "integrity-risk"
+  | "unknown";
+
+export interface ExternalEvalTokenUsage {
+  readonly input: number;
+  readonly output: number;
+}
+
+export interface ExternalEvalAdapterCommand {
+  readonly argv: readonly string[];
+  readonly cwd: string;
+}
+
+export interface ExternalEvalAdapterArtifacts {
+  readonly stdoutPath?: string;
+  readonly stderrPath?: string;
+  readonly finalMessagePath?: string;
+  readonly tokens?: ExternalEvalTokenUsage;
+}
+
+export interface ExternalEvalAdapterLifecycle {
+  readonly runId: string;
+  readonly taskId: string;
+  readonly trialId: string;
+  readonly adapter: string;
+  readonly command: ExternalEvalAdapterCommand;
+  readonly status: ExternalEvalAdapterLifecycleStatus;
+  readonly pid?: number;
+  readonly exitCode?: number;
+  readonly signal?: string;
+  readonly timeoutSource?: string;
+  readonly errorKind?: string;
+  readonly startedAt?: string;
+  readonly endedAt?: string;
+  readonly artifacts: ExternalEvalAdapterArtifacts;
+}
+
+export interface ClassifyExternalEvalTrialInputs {
+  readonly taskId: string;
+  readonly trialId: string;
+  readonly attempt: number;
+  readonly isResolved: boolean;
+  readonly failureMode?: string;
+  readonly reward?: number;
+  readonly startedAt?: string;
+  readonly completedAt?: string;
+  readonly rawResultPath?: string;
+  readonly lifecycle?: ExternalEvalAdapterLifecycle;
+}
+
+export interface ExternalEvalTrialEvidence {
+  readonly trialId: string;
+  readonly evidenceRefs?: readonly string[];
+  readonly verifierOutput?: string;
+  readonly adapterLifecycle?: ExternalEvalAdapterLifecycle;
+}
+
+export interface ExternalEvalTrialDiagnostic {
+  readonly id: string;
+  readonly runId: string;
+  readonly taskId: string;
+  readonly trialId: string;
+  readonly category: ExternalEvalDiagnosticCategory;
+  readonly confidence: number;
+  readonly summary: string;
+  readonly evidenceRefs: readonly string[];
+  readonly failureExcerpts: readonly string[];
+  readonly recommendations: readonly string[];
+}
+
+export interface ExternalEvalDiagnosticReport {
+  readonly schemaVersion: "external-eval-diagnostics/v1";
+  readonly runId: string;
+  readonly createdAt: string;
+  readonly diagnostics: readonly ExternalEvalTrialDiagnostic[];
+  readonly summary: {
+    readonly totalTrials: number;
+    readonly unresolvedTrials: number;
+    readonly countsByCategory: Readonly<Partial<Record<ExternalEvalDiagnosticCategory, number>>>;
+  };
+}
+
+export interface BuildExternalEvalDiagnosticReportInputs {
+  readonly runId: string;
+  readonly createdAt: string;
+  readonly trials: readonly EvalTrial[];
+  readonly evidence?: readonly ExternalEvalTrialEvidence[];
+}
+
+export interface BuildOperationalMemoryPackFromDiagnosticsInputs {
+  readonly packId: string;
+  readonly version: string;
+  readonly createdAt: string;
+  readonly report: ExternalEvalDiagnosticReport;
+}
+
+export function validateExternalEvalAdapterLifecycle(input: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (!isRecord(input)) {
+    return { valid: false, errors: ["adapter lifecycle must be an object"] };
+  }
+
+  requireString(input, "runId", errors);
+  requireString(input, "taskId", errors);
+  requireString(input, "trialId", errors);
+  requireString(input, "adapter", errors);
+  requireEnum(
+    input,
+    "status",
+    ["not-started", "running", "completed", "failed", "timed-out", "cancelled"],
+    errors,
+  );
+  validateCommand(input.command, errors);
+  validateArtifacts(input.artifacts, errors);
+
+  if (input.status === "timed-out") {
+    requireString(input, "timeoutSource", errors);
+  }
+  requireOptionalNumber(input, "pid", errors);
+  requireOptionalNumber(input, "exitCode", errors);
+  requireOptionalString(input, "signal", errors);
+  requireOptionalString(input, "errorKind", errors);
+  requireOptionalString(input, "startedAt", errors);
+  requireOptionalString(input, "endedAt", errors);
+
+  return errors.length === 0 ? { valid: true } : { valid: false, errors };
+}
+
+export function classifyExternalEvalTrial(inputs: ClassifyExternalEvalTrialInputs): EvalTrial {
+  const status = inputs.isResolved ? "passed" : classifyUnresolvedStatus(inputs);
+  const errorKind = classifyErrorKind(inputs, status);
+  const reward = inputs.reward ?? defaultReward(status);
+  const notes = buildTrialNotes(inputs);
+
+  return {
+    taskId: inputs.taskId,
+    trialId: inputs.trialId,
+    attempt: inputs.attempt,
+    status,
+    ...(reward !== undefined ? { reward } : {}),
+    ...(errorKind !== undefined ? { errorKind } : {}),
+    ...(inputs.startedAt !== undefined ? { startedAt: inputs.startedAt } : {}),
+    ...(inputs.completedAt !== undefined ? { completedAt: inputs.completedAt } : {}),
+    ...(inputs.rawResultPath !== undefined ? { rawResultPath: inputs.rawResultPath } : {}),
+    ...(notes.length > 0 ? { notes } : {}),
+  };
+}
+
+export function buildExternalEvalDiagnosticReport(
+  inputs: BuildExternalEvalDiagnosticReportInputs,
+): ExternalEvalDiagnosticReport {
+  const evidenceByTrialId = new Map<string, ExternalEvalTrialEvidence>();
+  for (const evidence of inputs.evidence ?? []) {
+    evidenceByTrialId.set(evidence.trialId, evidence);
+  }
+
+  const diagnostics = inputs.trials
+    .filter((trial) => trial.status !== "passed" && trial.status !== "discarded")
+    .map((trial) => buildTrialDiagnostic(inputs.runId, trial, evidenceByTrialId.get(trial.trialId)));
+
+  return {
+    schemaVersion: "external-eval-diagnostics/v1",
+    runId: inputs.runId,
+    createdAt: inputs.createdAt,
+    diagnostics,
+    summary: {
+      totalTrials: inputs.trials.length,
+      unresolvedTrials: diagnostics.length,
+      countsByCategory: countDiagnosticsByCategory(diagnostics),
+    },
+  };
+}
+
+export function buildOperationalMemoryPackFromDiagnostics(
+  inputs: BuildOperationalMemoryPackFromDiagnosticsInputs,
+): OperationalMemoryPack {
+  const findings = buildOperationalFindings(inputs.report);
+  const integrity: EvalRunIntegrity = {
+    status: "clean",
+    notes: [
+      `Derived from external eval diagnostic report ${inputs.report.runId}.`,
+      "Findings are category-level operational guidance and exclude adapter-runtime failures.",
+    ],
+  };
+
+  return {
+    packId: inputs.packId,
+    version: inputs.version,
+    createdAt: inputs.createdAt,
+    status: "sanitized",
+    integrity,
+    findings,
+  };
+}
+
+function classifyUnresolvedStatus(inputs: ClassifyExternalEvalTrialInputs): EvalTrialStatus {
+  const failureMode = normalizedFailureMode(inputs.failureMode);
+  const lifecycleStatus = inputs.lifecycle?.status;
+
+  if (lifecycleStatus === "cancelled") return "cancelled";
+  if (
+    lifecycleStatus === "timed-out" ||
+    failureMode.includes("timeout") ||
+    failureMode === "agent_timeout" ||
+    failureMode === "infrastructure-error"
+  ) {
+    return "infrastructure-error";
+  }
+  return "failed";
+}
+
+function classifyErrorKind(
+  inputs: ClassifyExternalEvalTrialInputs,
+  status: EvalTrialStatus,
+): string | undefined {
+  if (status === "passed" || status === "failed") {
+    return normalizedFailureMode(inputs.failureMode) || undefined;
+  }
+  const failureMode = normalizedFailureMode(inputs.failureMode);
+  return failureMode || inputs.lifecycle?.errorKind || inputs.lifecycle?.timeoutSource || inputs.lifecycle?.status;
+}
+
+function normalizedFailureMode(failureMode: string | undefined): string {
+  return failureMode === undefined || failureMode === "unset" ? "" : failureMode;
+}
+
+function defaultReward(status: EvalTrialStatus): number | undefined {
+  if (status === "passed") return 1;
+  if (status === "failed") return 0;
+  return undefined;
+}
+
+function buildTrialNotes(inputs: ClassifyExternalEvalTrialInputs): readonly string[] {
+  const notes: string[] = [];
+  const failureMode = normalizedFailureMode(inputs.failureMode);
+  if (failureMode.length > 0) {
+    notes.push(`failure_mode=${failureMode}`);
+  }
+  if (inputs.lifecycle !== undefined) {
+    notes.push(`adapter_status=${inputs.lifecycle.status}`);
+    if (inputs.lifecycle.timeoutSource !== undefined) {
+      notes.push(`timeout_source=${inputs.lifecycle.timeoutSource}`);
+    }
+    if (inputs.lifecycle.artifacts.stdoutPath !== undefined) {
+      notes.push(`stdout=${inputs.lifecycle.artifacts.stdoutPath}`);
+    }
+    if (inputs.lifecycle.artifacts.stderrPath !== undefined) {
+      notes.push(`stderr=${inputs.lifecycle.artifacts.stderrPath}`);
+    }
+  }
+  return notes;
+}
+
+function buildTrialDiagnostic(
+  runId: string,
+  trial: EvalTrial,
+  evidence: ExternalEvalTrialEvidence | undefined,
+): ExternalEvalTrialDiagnostic {
+  const lifecycle = evidence?.adapterLifecycle;
+  const category = classifyDiagnosticCategory(trial, evidence);
+  const failureExcerpts = buildFailureExcerpts(category, evidence);
+
+  return {
+    id: `${runId}:${trial.trialId}`,
+    runId,
+    taskId: trial.taskId,
+    trialId: trial.trialId,
+    category,
+    confidence: diagnosticConfidence(category, trial, evidence),
+    summary: diagnosticSummary(category),
+    evidenceRefs: [
+      ...(trial.rawResultPath !== undefined ? [trial.rawResultPath] : []),
+      ...(evidence?.evidenceRefs ?? []),
+      ...(lifecycle?.artifacts.stdoutPath !== undefined ? [lifecycle.artifacts.stdoutPath] : []),
+      ...(lifecycle?.artifacts.stderrPath !== undefined ? [lifecycle.artifacts.stderrPath] : []),
+    ],
+    failureExcerpts,
+    recommendations: diagnosticRecommendations(category),
+  };
+}
+
+function classifyDiagnosticCategory(
+  trial: EvalTrial,
+  evidence: ExternalEvalTrialEvidence | undefined,
+): ExternalEvalDiagnosticCategory {
+  if (trial.status === "infrastructure-error" || evidence?.adapterLifecycle?.status === "timed-out") {
+    return "adapter-runtime-failure";
+  }
+  if (trial.status === "cancelled") {
+    return "adapter-runtime-failure";
+  }
+
+  const verifierOutput = stripAnsi(evidence?.verifierOutput ?? "").toLowerCase();
+  if (
+    verifierOutput.includes("branch yet to be born") ||
+    verifierOutput.includes("src refspec") ||
+    verifierOutput.includes("failed to push") ||
+    verifierOutput.includes("failed to clone") ||
+    verifierOutput.includes("connection refused") ||
+    verifierOutput.includes("permission denied")
+  ) {
+    return "setup-environment-failure";
+  }
+  if (
+    verifierOutput.includes("missing required") ||
+    verifierOutput.includes("required fields") ||
+    verifierOutput.includes("not configured") ||
+    verifierOutput.includes("could not find") ||
+    verifierOutput.includes("expected") ||
+    verifierOutput.includes("assertionerror")
+  ) {
+    return "verifier-contract-mismatch";
+  }
+  return trial.status === "failed" ? "agent-task-failure" : "unknown";
+}
+
+function diagnosticConfidence(
+  category: ExternalEvalDiagnosticCategory,
+  trial: EvalTrial,
+  evidence: ExternalEvalTrialEvidence | undefined,
+): number {
+  if (category === "adapter-runtime-failure" && trial.status === "infrastructure-error") return 0.95;
+  if (evidence?.verifierOutput !== undefined && evidence.verifierOutput.length > 0) return 0.85;
+  return category === "unknown" ? 0.25 : 0.6;
+}
+
+function diagnosticSummary(category: ExternalEvalDiagnosticCategory): string {
+  switch (category) {
+    case "adapter-runtime-failure":
+      return "The trial failed in the adapter or runtime before an ordinary verifier result could be trusted.";
+    case "setup-environment-failure":
+      return "The trial failed while preparing or validating environment state used by the consumer or verifier.";
+    case "verifier-contract-mismatch":
+      return "The trial output diverged from the verifier-facing contract or checked artifact location.";
+    case "agent-task-failure":
+      return "The trial reached the verifier and failed without an obvious adapter or setup signature.";
+    case "integrity-risk":
+      return "The trial has evidence that may affect evaluation integrity.";
+    case "unknown":
+      return "The trial failed, but available evidence is insufficient to classify it confidently.";
+  }
+}
+
+function diagnosticRecommendations(category: ExternalEvalDiagnosticCategory): readonly string[] {
+  switch (category) {
+    case "adapter-runtime-failure":
+      return [
+        "Preserve adapter lifecycle logs and timeout metadata before scoring the trial.",
+        "Treat adapter timeouts separately from normal task failures in score reconciliation.",
+      ];
+    case "setup-environment-failure":
+      return [
+        "Validate a fresh consumer path using the same entrypoints, branches, credentials, and paths the verifier will use.",
+        "Avoid relying only on manual smoke tests that bypass downstream setup state.",
+      ];
+    case "verifier-contract-mismatch":
+      return [
+        "Inspect the verifier-facing artifact and configuration locations before declaring completion.",
+        "Mirror the consumer or verifier path rather than checking only runtime behavior.",
+      ];
+    case "agent-task-failure":
+      return [
+        "Use the verifier output to identify the smallest missed requirement before retrying.",
+      ];
+    case "integrity-risk":
+      return [
+        "Discard or quarantine the trial until integrity status is resolved.",
+      ];
+    case "unknown":
+      return [
+        "Capture richer adapter and verifier evidence before converting this failure into persistent guidance.",
+      ];
+  }
+}
+
+function buildFailureExcerpts(
+  category: ExternalEvalDiagnosticCategory,
+  evidence: ExternalEvalTrialEvidence | undefined,
+): readonly string[] {
+  if (category === "adapter-runtime-failure" && evidence?.adapterLifecycle !== undefined) {
+    const lifecycle = evidence.adapterLifecycle;
+    return [
+      `adapter_status=${lifecycle.status}`,
+      ...(lifecycle.timeoutSource !== undefined ? [`timeout_source=${lifecycle.timeoutSource}`] : []),
+    ];
+  }
+
+  return sanitizeVerifierOutput(evidence?.verifierOutput ?? "");
+}
+
+function sanitizeVerifierOutput(output: string): readonly string[] {
+  const excerpts: string[] = [];
+  for (const rawLine of stripAnsi(output).split(/\r?\n/)) {
+    const line = sanitizeVerifierLine(rawLine);
+    if (line.length === 0 || excerpts.includes(line)) continue;
+    excerpts.push(line);
+    if (excerpts.length >= 4) break;
+  }
+  return excerpts;
+}
+
+function sanitizeVerifierLine(rawLine: string): string {
+  const line = rawLine.trim();
+  if (line.length === 0) return "";
+  if (/expected\b.*\bgot\b/i.test(line)) {
+    return "Verifier expected output differed from actual output [values redacted].";
+  }
+  if (/assert\s+.+==/i.test(line)) {
+    return "Verifier assertion failed [expression redacted].";
+  }
+  return line.length > 280 ? `${line.slice(0, 277)}...` : line;
+}
+
+function stripAnsi(input: string): string {
+  return input.replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "");
+}
+
+function countDiagnosticsByCategory(
+  diagnostics: readonly ExternalEvalTrialDiagnostic[],
+): Readonly<Partial<Record<ExternalEvalDiagnosticCategory, number>>> {
+  const counts = new Map<ExternalEvalDiagnosticCategory, number>();
+  for (const diagnostic of diagnostics) {
+    counts.set(diagnostic.category, (counts.get(diagnostic.category) ?? 0) + 1);
+  }
+  return Object.fromEntries(counts.entries()) as Readonly<Partial<Record<ExternalEvalDiagnosticCategory, number>>>;
+}
+
+function buildOperationalFindings(
+  report: ExternalEvalDiagnosticReport,
+): readonly OperationalMemoryFinding[] {
+  const findings: OperationalMemoryFinding[] = [];
+  const setupDiagnostics = report.diagnostics.filter(
+    (diagnostic) => diagnostic.category === "setup-environment-failure",
+  );
+  const verifierDiagnostics = report.diagnostics.filter(
+    (diagnostic) => diagnostic.category === "verifier-contract-mismatch",
+  );
+
+  if (setupDiagnostics.length > 0) {
+    findings.push({
+      id: `${report.runId}-setup-environment-failure`,
+      summary: "Validate setup through the same consumer path the verifier will use.",
+      evidenceRefs: collectEvidenceRefs(setupDiagnostics),
+      reusableBehavior:
+        "Before declaring setup complete, validate from a fresh consumer or client path with the same branches, entrypoints, credentials, and filesystem paths downstream checks will use.",
+      targetFamilies: ["terminal", "service-setup", "stateful-workflow"],
+      risk: "medium",
+      containsTaskAnswer: false,
+      containsSecret: false,
+    });
+  }
+  if (verifierDiagnostics.length > 0) {
+    findings.push({
+      id: `${report.runId}-verifier-contract-mismatch`,
+      summary: "Check artifacts and configuration in verifier-facing locations.",
+      evidenceRefs: collectEvidenceRefs(verifierDiagnostics),
+      reusableBehavior:
+        "Confirm required files, config directives, service routes, and output artifacts in the locations consumed by the checker, not only through manual smoke tests or included fragments.",
+      targetFamilies: ["terminal", "service-config", "artifact-contract"],
+      risk: "low",
+      containsTaskAnswer: false,
+      containsSecret: false,
+    });
+  }
+
+  return findings;
+}
+
+function collectEvidenceRefs(diagnostics: readonly ExternalEvalTrialDiagnostic[]): readonly string[] {
+  return [...new Set(diagnostics.flatMap((diagnostic) => diagnostic.evidenceRefs))];
+}
+
+function validateCommand(input: unknown, errors: string[]): void {
+  if (!isRecord(input)) {
+    errors.push("command must be an object");
+    return;
+  }
+  const argv = input.argv;
+  if (!Array.isArray(argv) || !argv.every((part) => typeof part === "string" && part.length > 0)) {
+    errors.push("command.argv must be an array of non-empty strings");
+  }
+  requireString(input, "cwd", errors, "command.cwd");
+}
+
+function validateArtifacts(input: unknown, errors: string[]): void {
+  if (!isRecord(input)) {
+    errors.push("artifacts must be an object");
+    return;
+  }
+  requireString(input, "stdoutPath", errors, "artifacts.stdoutPath");
+  requireString(input, "stderrPath", errors, "artifacts.stderrPath");
+  requireOptionalString(input, "finalMessagePath", errors, "artifacts.finalMessagePath");
+
+  if (Object.prototype.hasOwnProperty.call(input, "tokens")) {
+    if (!isRecord(input.tokens)) {
+      errors.push("artifacts.tokens must be an object");
+    } else {
+      requireNumber(input.tokens, "input", errors, "artifacts.tokens.input");
+      requireNumber(input.tokens, "output", errors, "artifacts.tokens.output");
+    }
+  }
+}
+
+function requireString(
+  input: Readonly<Record<string, unknown>>,
+  field: string,
+  errors: string[],
+  label = field,
+): void {
+  if (typeof input[field] !== "string" || input[field].length === 0) {
+    errors.push(`${label} must be a non-empty string`);
+  }
+}
+
+function requireOptionalString(
+  input: Readonly<Record<string, unknown>>,
+  field: string,
+  errors: string[],
+  label = field,
+): void {
+  if (Object.prototype.hasOwnProperty.call(input, field) && typeof input[field] !== "string") {
+    errors.push(`${label} must be a string when present`);
+  }
+}
+
+function requireNumber(
+  input: Readonly<Record<string, unknown>>,
+  field: string,
+  errors: string[],
+  label = field,
+): void {
+  if (typeof input[field] !== "number" || !Number.isFinite(input[field]) || input[field] < 0) {
+    errors.push(`${label} must be a non-negative finite number`);
+  }
+}
+
+function requireOptionalNumber(
+  input: Readonly<Record<string, unknown>>,
+  field: string,
+  errors: string[],
+): void {
+  if (
+    Object.prototype.hasOwnProperty.call(input, field) &&
+    (typeof input[field] !== "number" || !Number.isFinite(input[field]))
+  ) {
+    errors.push(`${field} must be a finite number when present`);
+  }
+}
+
+function requireEnum(
+  input: Readonly<Record<string, unknown>>,
+  field: string,
+  values: readonly string[],
+  errors: string[],
+): void {
+  if (typeof input[field] !== "string" || !values.includes(input[field])) {
+    errors.push(`${field} must be one of ${values.join(", ")}`);
+  }
+}
+
+function isRecord(input: unknown): input is Readonly<Record<string, unknown>> {
+  return typeof input === "object" && input !== null && !Array.isArray(input);
+}

--- a/ts/src/control-plane/memory-packs/index.ts
+++ b/ts/src/control-plane/memory-packs/index.ts
@@ -1,4 +1,4 @@
-import type { ValidationResult } from "../contract/types.js";
+import type { EvalRunIntegrity, ValidationResult } from "../contract/types.js";
 
 export type OperationalMemoryPackStatus = "draft" | "sanitized" | "active" | "deprecated";
 export type OperationalMemoryRisk = "low" | "medium" | "high";
@@ -19,6 +19,7 @@ export interface OperationalMemoryPack {
   readonly version: string;
   readonly createdAt: string;
   readonly status: OperationalMemoryPackStatus;
+  readonly integrity?: EvalRunIntegrity;
   readonly findings: readonly OperationalMemoryFinding[];
 }
 
@@ -33,6 +34,7 @@ export function validateOperationalMemoryPack(input: unknown): ValidationResult 
   requireString(input, "version", errors);
   requireString(input, "createdAt", errors);
   requireEnum(input, "status", ["draft", "sanitized", "active", "deprecated"], errors);
+  validateOptionalIntegrity(input.integrity, errors);
 
   if (!Array.isArray(input.findings)) {
     errors.push("findings must be an array");
@@ -43,6 +45,23 @@ export function validateOperationalMemoryPack(input: unknown): ValidationResult 
   }
 
   return errors.length === 0 ? { valid: true } : { valid: false, errors };
+}
+
+function validateOptionalIntegrity(input: unknown, errors: string[]): void {
+  if (input === undefined) return;
+  if (!isRecord(input)) {
+    errors.push("integrity must be an object when present");
+    return;
+  }
+
+  requireEnum(input, "status", ["clean", "discarded", "contaminated"], errors);
+  requireOptionalString(input, "discardedReason", "integrity", errors);
+  if (
+    Object.prototype.hasOwnProperty.call(input, "notes") &&
+    (!Array.isArray(input.notes) || !input.notes.every((item) => typeof item === "string" && item.length > 0))
+  ) {
+    errors.push("integrity notes must be an array of non-empty strings when present");
+  }
 }
 
 function validateFinding(input: unknown, errors: string[]): void {
@@ -77,6 +96,17 @@ function requireOptionalBoolean(
 ): void {
   if (Object.prototype.hasOwnProperty.call(input, field) && typeof input[field] !== "boolean") {
     errors.push(`finding ${findingId} ${field} must be a boolean when present`);
+  }
+}
+
+function requireOptionalString(
+  input: Readonly<Record<string, unknown>>,
+  field: string,
+  parent: string,
+  errors: string[],
+): void {
+  if (Object.prototype.hasOwnProperty.call(input, field) && typeof input[field] !== "string") {
+    errors.push(`${parent} ${field} must be a string when present`);
   }
 }
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -692,3 +692,23 @@ export type {
   OperationalMemoryPackStatus,
   OperationalMemoryRisk,
 } from "./control-plane/memory-packs/index.js";
+export {
+  buildExternalEvalDiagnosticReport,
+  buildOperationalMemoryPackFromDiagnostics,
+  classifyExternalEvalTrial,
+  validateExternalEvalAdapterLifecycle,
+} from "./control-plane/external-evals/index.js";
+export type {
+  BuildExternalEvalDiagnosticReportInputs,
+  BuildOperationalMemoryPackFromDiagnosticsInputs,
+  ClassifyExternalEvalTrialInputs,
+  ExternalEvalAdapterArtifacts,
+  ExternalEvalAdapterCommand,
+  ExternalEvalAdapterLifecycle,
+  ExternalEvalAdapterLifecycleStatus,
+  ExternalEvalDiagnosticCategory,
+  ExternalEvalDiagnosticReport,
+  ExternalEvalTokenUsage,
+  ExternalEvalTrialDiagnostic,
+  ExternalEvalTrialEvidence,
+} from "./control-plane/external-evals/index.js";

--- a/ts/tests/control-plane/external-evals/diagnostics.test.ts
+++ b/ts/tests/control-plane/external-evals/diagnostics.test.ts
@@ -133,4 +133,84 @@ describe("external eval diagnostics", () => {
     expect(pack.findings.map((finding) => finding.targetFamilies).flat()).toContain("terminal");
     expect(validateOperationalMemoryPack(pack)).toEqual({ valid: true });
   });
+
+  test("classifies adapter crash evidence as adapter-runtime failure", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-run-1",
+      createdAt: "2026-05-07T15:10:00.000Z",
+      trials: [
+        {
+          taskId: "adapter-crash-task",
+          trialId: "adapter-crash-task.1-of-1.tb-run-1",
+          attempt: 1,
+          status: "infrastructure-error",
+          errorKind: "adapter-crash",
+        },
+      ],
+      evidence: [
+        {
+          trialId: "adapter-crash-task.1-of-1.tb-run-1",
+          evidenceRefs: ["adapter-crash-task/agent-logs/host-codex-stderr.txt"],
+          adapterLifecycle: {
+            runId: "tb-run-1",
+            taskId: "adapter-crash-task",
+            trialId: "adapter-crash-task.1-of-1.tb-run-1",
+            adapter: "host-codex-docker",
+            command: { argv: ["codex", "exec"], cwd: "/tmp" },
+            status: "failed",
+            errorKind: "adapter-crash",
+            exitCode: 1,
+            artifacts: {
+              stdoutPath: "agent-logs/host-codex-stdout.txt",
+              stderrPath: "agent-logs/host-codex-stderr.txt",
+            },
+          },
+        },
+      ],
+    });
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      category: "adapter-runtime-failure",
+      confidence: 0.95,
+    });
+    expect(report.diagnostics[0]?.failureExcerpts).toContain("adapter_error_kind=adapter-crash");
+    expect(report.summary.countsByCategory).toEqual({
+      "adapter-runtime-failure": 1,
+    });
+  });
+
+  test("keeps discarded integrity-risk trials visible in diagnostics", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-run-1",
+      createdAt: "2026-05-07T15:15:00.000Z",
+      trials: [
+        {
+          taskId: "contaminated-task",
+          trialId: "contaminated-task.1-of-1.tb-run-1",
+          attempt: 1,
+          status: "discarded",
+          errorKind: "contaminated",
+          notes: ["integrity_status=contaminated"],
+        },
+      ],
+      evidence: [
+        {
+          trialId: "contaminated-task.1-of-1.tb-run-1",
+          evidenceRefs: ["contaminated-task/results.json"],
+        },
+      ],
+    });
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      category: "integrity-risk",
+      confidence: 0.9,
+    });
+    expect(report.diagnostics[0]?.failureExcerpts).toContain("integrity_status=contaminated");
+    expect(report.summary).toMatchObject({
+      unresolvedTrials: 1,
+      countsByCategory: { "integrity-risk": 1 },
+    });
+  });
 });

--- a/ts/tests/control-plane/external-evals/diagnostics.test.ts
+++ b/ts/tests/control-plane/external-evals/diagnostics.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildExternalEvalDiagnosticReport,
+  buildOperationalMemoryPackFromDiagnostics,
+} from "../../../src/control-plane/external-evals/index.js";
+import { validateOperationalMemoryPack } from "../../../src/control-plane/memory-packs/index.js";
+import type { EvalTrial } from "../../../src/control-plane/contract/types.js";
+
+const trials: EvalTrial[] = [
+  {
+    taskId: "git-multibranch",
+    trialId: "git-multibranch.1-of-1.tb-run-1",
+    attempt: 1,
+    status: "failed",
+    reward: 0,
+  },
+  {
+    taskId: "nginx-request-logging",
+    trialId: "nginx-request-logging.1-of-1.tb-run-1",
+    attempt: 1,
+    status: "failed",
+    reward: 0,
+  },
+  {
+    taskId: "polyglot-c-py",
+    trialId: "polyglot-c-py.1-of-1.tb-run-1",
+    attempt: 1,
+    status: "infrastructure-error",
+    errorKind: "agent_timeout",
+    notes: ["failure_mode=agent_timeout"],
+  },
+];
+
+describe("external eval diagnostics", () => {
+  test("separates setup, verifier-contract, and adapter-runtime failures", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-run-1",
+      createdAt: "2026-05-07T15:00:00.000Z",
+      trials,
+      evidence: [
+        {
+          trialId: "git-multibranch.1-of-1.tb-run-1",
+          evidenceRefs: ["git-multibranch/sessions/tests.log"],
+          verifierOutput: [
+            "fatal: You are on a branch yet to be born",
+            "error: src refspec main does not match any",
+          ].join("\n"),
+        },
+        {
+          trialId: "nginx-request-logging.1-of-1.tb-run-1",
+          evidenceRefs: ["nginx-request-logging/sessions/tests.log"],
+          verifierOutput: [
+            "AssertionError: Custom log format is missing required fields",
+            "Expected main: 'main branch content', got: custom content",
+          ].join("\n"),
+        },
+        {
+          trialId: "polyglot-c-py.1-of-1.tb-run-1",
+          evidenceRefs: ["polyglot-c-py/results.json"],
+          adapterLifecycle: {
+            runId: "tb-run-1",
+            taskId: "polyglot-c-py",
+            trialId: "polyglot-c-py.1-of-1.tb-run-1",
+            adapter: "host-codex-docker",
+            command: { argv: ["codex", "exec"], cwd: "/tmp" },
+            status: "timed-out",
+            timeoutSource: "global-agent-timeout",
+            startedAt: "2026-05-07T04:41:32.967Z",
+            endedAt: "2026-05-07T14:29:41.251Z",
+            artifacts: {
+              stdoutPath: "agent-logs/host-codex-stdout.txt",
+              stderrPath: "agent-logs/host-codex-stderr.txt",
+            },
+          },
+        },
+      ],
+    });
+
+    expect(report.diagnostics).toHaveLength(3);
+    expect(report.diagnostics.map((diagnostic) => diagnostic.category)).toEqual([
+      "setup-environment-failure",
+      "verifier-contract-mismatch",
+      "adapter-runtime-failure",
+    ]);
+    expect(report.summary.countsByCategory).toEqual({
+      "adapter-runtime-failure": 1,
+      "setup-environment-failure": 1,
+      "verifier-contract-mismatch": 1,
+    });
+    expect(report.diagnostics[1]?.failureExcerpts.join("\n")).not.toContain("main branch content");
+    expect(report.diagnostics[1]?.failureExcerpts.join("\n")).not.toContain("custom content");
+  });
+
+  test("derives sanitized operational memory candidates from actionable diagnostics", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-run-1",
+      createdAt: "2026-05-07T15:00:00.000Z",
+      trials,
+      evidence: [
+        {
+          trialId: "git-multibranch.1-of-1.tb-run-1",
+          evidenceRefs: ["git-multibranch/sessions/tests.log"],
+          verifierOutput: "error: src refspec main does not match any",
+        },
+        {
+          trialId: "nginx-request-logging.1-of-1.tb-run-1",
+          evidenceRefs: ["nginx-request-logging/sessions/tests.log"],
+          verifierOutput: "AssertionError: Custom log format is missing required fields",
+        },
+        {
+          trialId: "polyglot-c-py.1-of-1.tb-run-1",
+          evidenceRefs: ["polyglot-c-py/results.json"],
+        },
+      ],
+    });
+
+    const pack = buildOperationalMemoryPackFromDiagnostics({
+      packId: "tb-run-1-operational-checklists",
+      version: "1.0.0",
+      createdAt: "2026-05-07T15:05:00.000Z",
+      report,
+    });
+
+    expect(pack.status).toBe("sanitized");
+    expect(pack.integrity).toMatchObject({ status: "clean" });
+    expect(pack.findings).toHaveLength(2);
+    expect(pack.findings.map((finding) => finding.id)).toEqual([
+      "tb-run-1-setup-environment-failure",
+      "tb-run-1-verifier-contract-mismatch",
+    ]);
+    expect(pack.findings.every((finding) => finding.containsTaskAnswer === false)).toBe(true);
+    expect(pack.findings.every((finding) => finding.containsSecret === false)).toBe(true);
+    expect(pack.findings.map((finding) => finding.targetFamilies).flat()).toContain("terminal");
+    expect(validateOperationalMemoryPack(pack)).toEqual({ valid: true });
+  });
+});

--- a/ts/tests/control-plane/external-evals/lifecycle.test.ts
+++ b/ts/tests/control-plane/external-evals/lifecycle.test.ts
@@ -84,4 +84,36 @@ describe("external eval adapter lifecycle", () => {
     expect(trial.status).toBe("failed");
     expect(trial.errorKind).toBeUndefined();
   });
+
+  test("classifies adapter crashes as infrastructure errors and preserves lifecycle error kind", () => {
+    const trial = classifyExternalEvalTrial({
+      taskId: "adapter-crash-task",
+      trialId: "adapter-crash-task.1-of-1.tb-run-1",
+      attempt: 1,
+      isResolved: false,
+      failureMode: "unset",
+      lifecycle: {
+        runId: "tb-run-1",
+        taskId: "adapter-crash-task",
+        trialId: "adapter-crash-task.1-of-1.tb-run-1",
+        adapter: "host-codex-docker",
+        command: {
+          argv: ["codex", "exec"],
+          cwd: "/tmp",
+        },
+        status: "failed",
+        errorKind: "adapter-crash",
+        exitCode: 1,
+        artifacts: {
+          stdoutPath: "agent-logs/host-codex-stdout.txt",
+          stderrPath: "agent-logs/host-codex-stderr.txt",
+        },
+      },
+    });
+
+    expect(trial.status).toBe("infrastructure-error");
+    expect(trial.errorKind).toBe("adapter-crash");
+    expect(trial.reward).toBeUndefined();
+    expect(trial.notes).toContain("adapter_status=failed");
+  });
 });

--- a/ts/tests/control-plane/external-evals/lifecycle.test.ts
+++ b/ts/tests/control-plane/external-evals/lifecycle.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+import {
+  classifyExternalEvalTrial,
+  validateExternalEvalAdapterLifecycle,
+} from "../../../src/control-plane/external-evals/index.js";
+
+describe("external eval adapter lifecycle", () => {
+  test("requires durable stdout and stderr paths for timed-out adapter runs", () => {
+    const result = validateExternalEvalAdapterLifecycle({
+      runId: "tb-run-1",
+      taskId: "polyglot-c-py",
+      trialId: "polyglot-c-py.1-of-1.tb-run-1",
+      adapter: "host-codex-docker",
+      command: {
+        argv: ["codex", "exec", "--output-last-message", "host-codex-final.txt"],
+        cwd: "/tmp",
+      },
+      status: "timed-out",
+      timeoutSource: "global-agent-timeout",
+      startedAt: "2026-05-07T04:41:32.967Z",
+      endedAt: "2026-05-07T14:29:41.251Z",
+      artifacts: {
+        finalMessagePath: "agent-logs/host-codex-final.txt",
+      },
+    });
+
+    expect(result).toMatchObject({ valid: false });
+    if (!result.valid) {
+      expect(result.errors).toContain("artifacts.stdoutPath must be a non-empty string");
+      expect(result.errors).toContain("artifacts.stderrPath must be a non-empty string");
+    }
+  });
+
+  test("classifies adapter timeouts as infrastructure errors instead of normal task failures", () => {
+    const trial = classifyExternalEvalTrial({
+      taskId: "polyglot-c-py",
+      trialId: "polyglot-c-py.1-of-1.tb-run-1",
+      attempt: 1,
+      isResolved: false,
+      failureMode: "agent_timeout",
+      rawResultPath: "polyglot-c-py/results.json",
+      lifecycle: {
+        runId: "tb-run-1",
+        taskId: "polyglot-c-py",
+        trialId: "polyglot-c-py.1-of-1.tb-run-1",
+        adapter: "host-codex-docker",
+        command: {
+          argv: ["codex", "exec"],
+          cwd: "/tmp",
+        },
+        status: "timed-out",
+        timeoutSource: "global-agent-timeout",
+        startedAt: "2026-05-07T04:41:32.967Z",
+        endedAt: "2026-05-07T14:29:41.251Z",
+        artifacts: {
+          stdoutPath: "agent-logs/host-codex-stdout.txt",
+          stderrPath: "agent-logs/host-codex-stderr.txt",
+          finalMessagePath: "agent-logs/host-codex-final.txt",
+          tokens: { input: 0, output: 0 },
+        },
+      },
+    });
+
+    expect(trial).toMatchObject({
+      taskId: "polyglot-c-py",
+      status: "infrastructure-error",
+      errorKind: "agent_timeout",
+      rawResultPath: "polyglot-c-py/results.json",
+    });
+    expect(trial.notes).toContain("failure_mode=agent_timeout");
+    expect(trial.notes).toContain("adapter_status=timed-out");
+    expect(trial.notes).toContain("timeout_source=global-agent-timeout");
+  });
+
+  test("classifies unresolved verifier results without adapter failure as task failures", () => {
+    const trial = classifyExternalEvalTrial({
+      taskId: "nginx-request-logging",
+      trialId: "nginx-request-logging.1-of-1.tb-run-1",
+      attempt: 1,
+      isResolved: false,
+      failureMode: "unset",
+    });
+
+    expect(trial.status).toBe("failed");
+    expect(trial.errorKind).toBeUndefined();
+  });
+});

--- a/ts/tests/control-plane/memory-packs/memory-pack.test.ts
+++ b/ts/tests/control-plane/memory-packs/memory-pack.test.ts
@@ -8,6 +8,10 @@ describe("validateOperationalMemoryPack", () => {
       version: "1.0.0",
       createdAt: "2026-05-06T19:00:00.000Z",
       status: "sanitized",
+      integrity: {
+        status: "clean",
+        notes: ["Derived from external eval diagnostics without task answers."],
+      },
       findings: [
         {
           id: "preserve-sidecars",

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -28,6 +28,9 @@ describe("package root exports", () => {
     expect(pkg.reconcileEvalTrials).toBeDefined();
     expect(pkg.probeDirectoryContract).toBeDefined();
     expect(pkg.validateOperationalMemoryPack).toBeDefined();
+    expect(pkg.classifyExternalEvalTrial).toBeDefined();
+    expect(pkg.buildExternalEvalDiagnosticReport).toBeDefined();
+    expect(pkg.buildOperationalMemoryPackFromDiagnostics).toBeDefined();
     expect(pkg.resolveBrowserSessionConfig).toBeDefined();
     expect(pkg.evaluateBrowserActionPolicy).toBeDefined();
     expect(pkg.validateBrowserSessionConfig).toBeDefined();
@@ -69,6 +72,10 @@ describe("package root exports", () => {
     expect(packageJson.exports?.["./control-plane/memory-packs"]).toEqual({
       import: "./dist/control-plane/memory-packs/index.js",
       types: "./dist/control-plane/memory-packs/index.d.ts",
+    });
+    expect(packageJson.exports?.["./control-plane/external-evals"]).toEqual({
+      import: "./dist/control-plane/external-evals/index.js",
+      types: "./dist/control-plane/external-evals/index.d.ts",
     });
   });
 


### PR DESCRIPTION
## Summary
- add external eval adapter lifecycle validation and timeout-aware trial classification
- add external eval diagnostic reports that separate verifier, setup, and adapter/runtime failures
- derive sanitized operational memory-pack candidates from actionable diagnostics
- publish the new ./control-plane/external-evals package subpath and root exports

Refs AC-739, AC-740, AC-741.

## Verification
- npm run lint
- npm test -- --run tests/control-plane/external-evals/lifecycle.test.ts tests/control-plane/external-evals/diagnostics.test.ts tests/control-plane/memory-packs/memory-pack.test.ts tests/package-export-catalogs.test.ts
- npm test -- --run tests/control-plane/eval-ledger/reconcile.test.ts tests/control-plane/eval-ingest/validator.test.ts tests/control-plane/eval-ingest/attach.test.ts tests/control-plane/eval-ingest/errors.test.ts tests/control-plane/promotion/decide.test.ts
- npm run build
- npm test (725 files, 4970 tests)