### PR TITLE
Add Python runtime session recording facade

### DIFF
--- a/autocontext/src/autocontext/session/__init__.py
+++ b/autocontext/src/autocontext/session/__init__.py
@@ -4,6 +4,18 @@ from autocontext.session.runtime_events import (
     RuntimeSessionEventStore,
     RuntimeSessionEventType,
 )
+from autocontext.session.runtime_session import (
+    DEFAULT_CHILD_TASK_MAX_DEPTH,
+    RuntimeChildTaskHandlerInput,
+    RuntimeChildTaskHandlerOutput,
+    RuntimeChildTaskResult,
+    RuntimeChildTaskRunner,
+    RuntimeSession,
+    RuntimeSessionEventSink,
+    RuntimeSessionPromptHandlerInput,
+    RuntimeSessionPromptHandlerOutput,
+    RuntimeSessionPromptResult,
+)
 from autocontext.session.runtime_session_ids import runtime_session_id_for_run
 from autocontext.session.runtime_session_read_model import (
     read_runtime_session_by_id,
@@ -18,10 +30,20 @@ from autocontext.session.runtime_session_timeline import (
 )
 
 __all__ = [
+    "DEFAULT_CHILD_TASK_MAX_DEPTH",
+    "RuntimeChildTaskHandlerInput",
+    "RuntimeChildTaskHandlerOutput",
+    "RuntimeChildTaskResult",
+    "RuntimeChildTaskRunner",
+    "RuntimeSession",
     "RuntimeSessionEvent",
     "RuntimeSessionEventLog",
+    "RuntimeSessionEventSink",
     "RuntimeSessionEventStore",
     "RuntimeSessionEventType",
+    "RuntimeSessionPromptHandlerInput",
+    "RuntimeSessionPromptHandlerOutput",
+    "RuntimeSessionPromptResult",
     "build_runtime_session_timeline",
     "read_runtime_session_by_id",
     "read_runtime_session_by_run_id",

--- a/autocontext/src/autocontext/session/coordinator.py
+++ b/autocontext/src/autocontext/session/coordinator.py
@@ -183,6 +183,23 @@ class Coordinator(BaseModel):
             "worker_id": worker_id,
         })
 
+    def start_worker(self, worker_id: str) -> None:
+        """Mark a delegated worker as running."""
+        worker = self._get_worker(worker_id)
+        worker.start()
+        self._emit(CoordinatorEventType.WORKER_STARTED, {
+            "worker_id": worker_id,
+        })
+
+    def fail_worker(self, worker_id: str, error: str = "") -> None:
+        """Mark a running worker as failed."""
+        worker = self._get_worker(worker_id)
+        worker.fail(error=error)
+        self._emit(CoordinatorEventType.WORKER_FAILED, {
+            "worker_id": worker_id,
+            "error": error,
+        })
+
     def stop_worker(self, worker_id: str, reason: str = "") -> None:
         """Redirect a worker away from its current task."""
         worker = self._get_worker(worker_id)

--- a/autocontext/src/autocontext/session/runtime_session.py
+++ b/autocontext/src/autocontext/session/runtime_session.py
@@ -1,0 +1,567 @@
+"""Runtime-session writer facade for Python runtime observability."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol, Self
+
+from autocontext.session.coordinator import Coordinator
+from autocontext.session.runtime_events import (
+    RuntimeSessionEvent,
+    RuntimeSessionEventLog,
+    RuntimeSessionEventStore,
+    RuntimeSessionEventType,
+)
+
+DEFAULT_CHILD_TASK_MAX_DEPTH = 4
+
+
+class RuntimeSessionEventSink(Protocol):
+    """Observer for live runtime-session events."""
+
+    def on_runtime_session_event(self, event: RuntimeSessionEvent, log: RuntimeSessionEventLog) -> None:
+        """Receive a newly appended runtime-session event."""
+
+
+@dataclass(frozen=True)
+class RuntimeSessionPromptHandlerInput:
+    session_id: str
+    prompt: str
+    role: str
+    cwd: str
+    session_log: RuntimeSessionEventLog
+
+
+@dataclass(frozen=True)
+class RuntimeSessionPromptHandlerOutput:
+    text: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+RuntimeSessionPromptHandler = Callable[
+    [RuntimeSessionPromptHandlerInput],
+    RuntimeSessionPromptHandlerOutput | str,
+]
+
+
+@dataclass(frozen=True)
+class RuntimeSessionPromptResult:
+    session_id: str
+    role: str
+    cwd: str
+    text: str
+    is_error: bool
+    error: str
+    session_log: RuntimeSessionEventLog
+
+
+@dataclass(frozen=True)
+class RuntimeChildTaskHandlerInput:
+    task_id: str
+    child_session_id: str
+    parent_session_id: str
+    worker_id: str
+    prompt: str
+    role: str
+    cwd: str
+    depth: int
+    max_depth: int
+    session_log: RuntimeSessionEventLog
+
+
+@dataclass(frozen=True)
+class RuntimeChildTaskHandlerOutput:
+    text: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+RuntimeChildTaskHandler = Callable[
+    [RuntimeChildTaskHandlerInput],
+    RuntimeChildTaskHandlerOutput | str,
+]
+
+
+@dataclass(frozen=True)
+class RuntimeChildTaskResult:
+    task_id: str
+    child_session_id: str
+    parent_session_id: str
+    worker_id: str
+    role: str
+    cwd: str
+    text: str
+    is_error: bool
+    error: str
+    depth: int
+    max_depth: int
+    child_session_log: RuntimeSessionEventLog
+
+
+class RuntimeSession:
+    """Aggregate facade that records prompt/response and child-task events."""
+
+    def __init__(
+        self,
+        *,
+        goal: str,
+        log: RuntimeSessionEventLog,
+        coordinator: Coordinator,
+        event_store: RuntimeSessionEventStore | None = None,
+        event_sink: RuntimeSessionEventSink | None = None,
+        depth: int = 0,
+        max_depth: int = DEFAULT_CHILD_TASK_MAX_DEPTH,
+    ) -> None:
+        self.goal = goal
+        self.log = log
+        self.coordinator = coordinator
+        self._event_store = event_store
+        self._event_sink = event_sink
+        self._depth = _normalize_depth(depth, "depth")
+        self._max_depth = _normalize_depth(max_depth, "max_depth")
+        _observe_runtime_session_log(self.log, self._event_store, self._event_sink)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        goal: str,
+        session_id: str | None = None,
+        event_store: RuntimeSessionEventStore | None = None,
+        event_sink: RuntimeSessionEventSink | None = None,
+        metadata: dict[str, Any] | None = None,
+        depth: int = 0,
+        max_depth: int = DEFAULT_CHILD_TASK_MAX_DEPTH,
+    ) -> Self:
+        clean_session_id = session_id or f"runtime:{uuid.uuid4().hex[:12]}"
+        log = RuntimeSessionEventLog.create(
+            session_id=clean_session_id,
+            metadata={**(metadata or {}), "goal": goal},
+        )
+        return cls(
+            goal=goal,
+            log=log,
+            coordinator=Coordinator.create(clean_session_id, goal),
+            event_store=event_store,
+            event_sink=event_sink,
+            depth=depth,
+            max_depth=max_depth,
+        )
+
+    @classmethod
+    def load(
+        cls,
+        *,
+        session_id: str,
+        event_store: RuntimeSessionEventStore,
+        event_sink: RuntimeSessionEventSink | None = None,
+        depth: int = 0,
+        max_depth: int = DEFAULT_CHILD_TASK_MAX_DEPTH,
+    ) -> Self | None:
+        log = event_store.load(session_id)
+        if log is None:
+            return None
+        goal = _read_str(log.metadata.get("goal"))
+        return cls(
+            goal=goal,
+            log=log,
+            coordinator=Coordinator.create(log.session_id, goal),
+            event_store=event_store,
+            event_sink=event_sink,
+            depth=depth,
+            max_depth=max_depth,
+        )
+
+    @property
+    def session_id(self) -> str:
+        return self.log.session_id
+
+    def submit_prompt(
+        self,
+        *,
+        prompt: str,
+        handler: RuntimeSessionPromptHandler,
+        role: str = "assistant",
+        cwd: str = "",
+    ) -> RuntimeSessionPromptResult:
+        request_id = uuid.uuid4().hex[:12]
+        prompt_event = self.log.append(
+            RuntimeSessionEventType.PROMPT_SUBMITTED,
+            {
+                "requestId": request_id,
+                "prompt": prompt,
+                "role": role,
+                "cwd": cwd,
+            },
+        )
+
+        try:
+            output = _normalize_prompt_output(
+                handler(
+                    RuntimeSessionPromptHandlerInput(
+                        session_id=self.session_id,
+                        prompt=prompt,
+                        role=role,
+                        cwd=cwd,
+                        session_log=self.log,
+                    )
+                )
+            )
+            self.log.append(
+                RuntimeSessionEventType.ASSISTANT_MESSAGE,
+                {
+                    "requestId": request_id,
+                    "promptEventId": prompt_event.event_id,
+                    "text": output.text,
+                    "metadata": dict(output.metadata),
+                    "role": role,
+                    "cwd": cwd,
+                },
+            )
+            result = self._prompt_result(role=role, cwd=cwd, text=output.text, is_error=False, error="")
+            self.save()
+            return result
+        except Exception as exc:
+            message = str(exc)
+            self.log.append(
+                RuntimeSessionEventType.ASSISTANT_MESSAGE,
+                {
+                    "requestId": request_id,
+                    "promptEventId": prompt_event.event_id,
+                    "text": "",
+                    "error": message,
+                    "isError": True,
+                    "role": role,
+                    "cwd": cwd,
+                },
+            )
+            result = self._prompt_result(role=role, cwd=cwd, text="", is_error=True, error=message)
+            self.save()
+            return result
+
+    def run_child_task(
+        self,
+        *,
+        prompt: str,
+        role: str,
+        handler: RuntimeChildTaskHandler,
+        task_id: str | None = None,
+        cwd: str = "",
+    ) -> RuntimeChildTaskResult:
+        return RuntimeChildTaskRunner(
+            coordinator=self.coordinator,
+            parent_log=self.log,
+            event_store=self._event_store,
+            event_sink=self._event_sink,
+            depth=self._depth,
+            max_depth=self._max_depth,
+        ).run(prompt=prompt, role=role, handler=handler, task_id=task_id, cwd=cwd)
+
+    def list_child_logs(self) -> list[RuntimeSessionEventLog]:
+        return self._event_store.list_children(self.session_id) if self._event_store is not None else []
+
+    def save(self) -> None:
+        if self._event_store is not None:
+            self._event_store.save(self.log)
+
+    def _prompt_result(
+        self,
+        *,
+        role: str,
+        cwd: str,
+        text: str,
+        is_error: bool,
+        error: str,
+    ) -> RuntimeSessionPromptResult:
+        return RuntimeSessionPromptResult(
+            session_id=self.session_id,
+            role=role,
+            cwd=cwd,
+            text=text,
+            is_error=is_error,
+            error=error,
+            session_log=self.log,
+        )
+
+
+class RuntimeChildTaskRunner:
+    """Runs a child task while preserving parent/child event lineage."""
+
+    def __init__(
+        self,
+        *,
+        coordinator: Coordinator,
+        parent_log: RuntimeSessionEventLog,
+        event_store: RuntimeSessionEventStore | None = None,
+        event_sink: RuntimeSessionEventSink | None = None,
+        depth: int = 0,
+        max_depth: int = DEFAULT_CHILD_TASK_MAX_DEPTH,
+    ) -> None:
+        self._coordinator = coordinator
+        self._parent_log = parent_log
+        self._event_store = event_store
+        self._event_sink = event_sink
+        self._depth = _normalize_depth(depth, "depth")
+        self._max_depth = _normalize_depth(max_depth, "max_depth")
+
+    def run(
+        self,
+        *,
+        prompt: str,
+        role: str,
+        handler: RuntimeChildTaskHandler,
+        task_id: str | None = None,
+        cwd: str = "",
+    ) -> RuntimeChildTaskResult:
+        clean_task_id = task_id or uuid.uuid4().hex[:12]
+        worker = self._coordinator.delegate(prompt, role)
+        self._coordinator.start_worker(worker.worker_id)
+        child_depth = self._depth + 1
+        child_session_id = f"task:{self._parent_log.session_id}:{clean_task_id}"
+        child_log = RuntimeSessionEventLog.create(
+            session_id=child_session_id,
+            parent_session_id=self._parent_log.session_id,
+            task_id=clean_task_id,
+            worker_id=worker.worker_id,
+            metadata={
+                "role": role,
+                "cwd": cwd,
+                "depth": child_depth,
+                "maxDepth": self._max_depth,
+            },
+        )
+        _observe_runtime_session_log(child_log, self._event_store, self._event_sink)
+
+        self._parent_log.append(
+            RuntimeSessionEventType.CHILD_TASK_STARTED,
+            {
+                "taskId": clean_task_id,
+                "childSessionId": child_session_id,
+                "workerId": worker.worker_id,
+                "role": role,
+                "cwd": cwd,
+                "depth": child_depth,
+                "maxDepth": self._max_depth,
+            },
+        )
+        child_log.append(
+            RuntimeSessionEventType.PROMPT_SUBMITTED,
+            {
+                "prompt": prompt,
+                "role": role,
+                "cwd": cwd,
+                "depth": child_depth,
+                "maxDepth": self._max_depth,
+            },
+        )
+
+        if self._depth >= self._max_depth:
+            return self._fail_child_task(
+                task_id=clean_task_id,
+                child_session_id=child_session_id,
+                worker_id=worker.worker_id,
+                role=role,
+                cwd=cwd,
+                depth=child_depth,
+                child_log=child_log,
+                message=f"Maximum child task depth ({self._max_depth}) exceeded",
+            )
+
+        try:
+            output = _normalize_child_output(
+                handler(
+                    RuntimeChildTaskHandlerInput(
+                        task_id=clean_task_id,
+                        child_session_id=child_session_id,
+                        parent_session_id=self._parent_log.session_id,
+                        worker_id=worker.worker_id,
+                        prompt=prompt,
+                        role=role,
+                        cwd=cwd,
+                        depth=child_depth,
+                        max_depth=self._max_depth,
+                        session_log=child_log,
+                    )
+                )
+            )
+            child_log.append(
+                RuntimeSessionEventType.ASSISTANT_MESSAGE,
+                {
+                    "text": output.text,
+                    "metadata": dict(output.metadata),
+                    "depth": child_depth,
+                    "maxDepth": self._max_depth,
+                },
+            )
+            self._coordinator.complete_worker(worker.worker_id, output.text)
+            self._parent_log.append(
+                RuntimeSessionEventType.CHILD_TASK_COMPLETED,
+                {
+                    "taskId": clean_task_id,
+                    "childSessionId": child_session_id,
+                    "workerId": worker.worker_id,
+                    "role": role,
+                    "cwd": cwd,
+                    "result": output.text,
+                    "isError": False,
+                    "depth": child_depth,
+                    "maxDepth": self._max_depth,
+                },
+            )
+            result = self._result(
+                task_id=clean_task_id,
+                child_session_id=child_session_id,
+                worker_id=worker.worker_id,
+                role=role,
+                cwd=cwd,
+                text=output.text,
+                is_error=False,
+                error="",
+                depth=child_depth,
+                child_log=child_log,
+            )
+            self._persist(child_log)
+            return result
+        except Exception as exc:
+            return self._fail_child_task(
+                task_id=clean_task_id,
+                child_session_id=child_session_id,
+                worker_id=worker.worker_id,
+                role=role,
+                cwd=cwd,
+                depth=child_depth,
+                child_log=child_log,
+                message=str(exc),
+            )
+
+    def _fail_child_task(
+        self,
+        *,
+        task_id: str,
+        child_session_id: str,
+        worker_id: str,
+        role: str,
+        cwd: str,
+        depth: int,
+        child_log: RuntimeSessionEventLog,
+        message: str,
+    ) -> RuntimeChildTaskResult:
+        self._coordinator.fail_worker(worker_id, message)
+        child_log.append(
+            RuntimeSessionEventType.ASSISTANT_MESSAGE,
+            {
+                "text": "",
+                "error": message,
+                "isError": True,
+                "depth": depth,
+                "maxDepth": self._max_depth,
+            },
+        )
+        self._parent_log.append(
+            RuntimeSessionEventType.CHILD_TASK_COMPLETED,
+            {
+                "taskId": task_id,
+                "childSessionId": child_session_id,
+                "workerId": worker_id,
+                "role": role,
+                "cwd": cwd,
+                "result": "",
+                "error": message,
+                "isError": True,
+                "depth": depth,
+                "maxDepth": self._max_depth,
+            },
+        )
+        result = self._result(
+            task_id=task_id,
+            child_session_id=child_session_id,
+            worker_id=worker_id,
+            role=role,
+            cwd=cwd,
+            text="",
+            is_error=True,
+            error=message,
+            depth=depth,
+            child_log=child_log,
+        )
+        self._persist(child_log)
+        return result
+
+    def _result(
+        self,
+        *,
+        task_id: str,
+        child_session_id: str,
+        worker_id: str,
+        role: str,
+        cwd: str,
+        text: str,
+        is_error: bool,
+        error: str,
+        depth: int,
+        child_log: RuntimeSessionEventLog,
+    ) -> RuntimeChildTaskResult:
+        return RuntimeChildTaskResult(
+            task_id=task_id,
+            child_session_id=child_session_id,
+            parent_session_id=self._parent_log.session_id,
+            worker_id=worker_id,
+            role=role,
+            cwd=cwd,
+            text=text,
+            is_error=is_error,
+            error=error,
+            depth=depth,
+            max_depth=self._max_depth,
+            child_session_log=child_log,
+        )
+
+    def _persist(self, child_log: RuntimeSessionEventLog) -> None:
+        if self._event_store is None:
+            return
+        self._event_store.save(self._parent_log)
+        self._event_store.save(child_log)
+
+
+def _observe_runtime_session_log(
+    log: RuntimeSessionEventLog,
+    event_store: RuntimeSessionEventStore | None,
+    event_sink: RuntimeSessionEventSink | None,
+) -> None:
+    if event_store is None and event_sink is None:
+        return
+
+    def on_event(event: RuntimeSessionEvent, current_log: RuntimeSessionEventLog) -> None:
+        if event_store is not None:
+            event_store.save(current_log)
+        if event_sink is not None:
+            try:
+                event_sink.on_runtime_session_event(event, current_log)
+            except Exception:
+                pass
+
+    log.subscribe(on_event)
+
+
+def _normalize_prompt_output(output: RuntimeSessionPromptHandlerOutput | str) -> RuntimeSessionPromptHandlerOutput:
+    if isinstance(output, RuntimeSessionPromptHandlerOutput):
+        return output
+    return RuntimeSessionPromptHandlerOutput(text=output)
+
+
+def _normalize_child_output(output: RuntimeChildTaskHandlerOutput | str) -> RuntimeChildTaskHandlerOutput:
+    if isinstance(output, RuntimeChildTaskHandlerOutput):
+        return output
+    return RuntimeChildTaskHandlerOutput(text=output)
+
+
+def _normalize_depth(value: int, name: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        msg = f"{name} must be a non-negative integer"
+        raise ValueError(msg)
+    return value
+
+
+def _read_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""

--- a/autocontext/src/autocontext/session/runtime_session.py
+++ b/autocontext/src/autocontext/session/runtime_session.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Protocol, Self
 
@@ -137,7 +138,7 @@ class RuntimeSession:
         clean_session_id = session_id or f"runtime:{uuid.uuid4().hex[:12]}"
         log = RuntimeSessionEventLog.create(
             session_id=clean_session_id,
-            metadata={**(metadata or {}), "goal": goal},
+            metadata={**_json_safe_record(metadata), "goal": goal},
         )
         return cls(
             goal=goal,
@@ -214,7 +215,7 @@ class RuntimeSession:
                     "requestId": request_id,
                     "promptEventId": prompt_event.event_id,
                     "text": output.text,
-                    "metadata": dict(output.metadata),
+                    "metadata": _json_safe_record(output.metadata),
                     "role": role,
                     "cwd": cwd,
                 },
@@ -318,7 +319,7 @@ class RuntimeChildTaskRunner:
         worker = self._coordinator.delegate(prompt, role)
         self._coordinator.start_worker(worker.worker_id)
         child_depth = self._depth + 1
-        child_session_id = f"task:{self._parent_log.session_id}:{clean_task_id}"
+        child_session_id = f"task:{self._parent_log.session_id}:{clean_task_id}:{worker.worker_id}"
         child_log = RuntimeSessionEventLog.create(
             session_id=child_session_id,
             parent_session_id=self._parent_log.session_id,
@@ -389,7 +390,7 @@ class RuntimeChildTaskRunner:
                 RuntimeSessionEventType.ASSISTANT_MESSAGE,
                 {
                     "text": output.text,
-                    "metadata": dict(output.metadata),
+                    "metadata": _json_safe_record(output.metadata),
                     "depth": child_depth,
                     "maxDepth": self._max_depth,
                 },
@@ -554,6 +555,23 @@ def _normalize_child_output(output: RuntimeChildTaskHandlerOutput | str) -> Runt
     if isinstance(output, RuntimeChildTaskHandlerOutput):
         return output
     return RuntimeChildTaskHandlerOutput(text=output)
+
+
+def _json_safe_record(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    if value is None:
+        return {}
+    return {str(key): _json_safe_value(item) for key, item in value.items()}
+
+
+def _json_safe_value(value: Any) -> Any:
+    try:
+        return json.loads(json.dumps(value, allow_nan=False))
+    except (TypeError, ValueError):
+        if isinstance(value, Mapping):
+            return {str(key): _json_safe_value(item) for key, item in value.items()}
+        if isinstance(value, list | tuple):
+            return [_json_safe_value(item) for item in value]
+        return str(value)
 
 
 def _normalize_depth(value: int, name: str) -> int:

--- a/autocontext/tests/test_runtime_session_events.py
+++ b/autocontext/tests/test_runtime_session_events.py
@@ -203,6 +203,232 @@ def test_runtime_session_event_store_closes_operation_connections(tmp_path: Path
     assert closed_connections >= 4
 
 
+def test_runtime_session_records_successful_prompt_with_request_correlation(tmp_path: Path) -> None:
+    from autocontext.session import RuntimeSession, RuntimeSessionPromptHandlerOutput
+    from autocontext.session.runtime_events import RuntimeSessionEventStore, RuntimeSessionEventType
+
+    observed: list[tuple[RuntimeSessionEventType, str]] = []
+
+    class EventSink:
+        def on_runtime_session_event(self, event, log) -> None:
+            observed.append((event.event_type, log.session_id))
+
+    store = RuntimeSessionEventStore(tmp_path / "runtime-events.db")
+    try:
+        session = RuntimeSession.create(
+            session_id="run:abc:runtime",
+            goal="autoctx run support_triage",
+            event_store=store,
+            event_sink=EventSink(),
+            metadata={"runId": "abc"},
+        )
+
+        def handler(input):
+            assert input.session_id == "run:abc:runtime"
+            assert input.prompt == "Analyze the failure"
+            assert input.role == "analyst"
+            assert input.cwd == "/workspace"
+            assert input.session_log is session.log
+            return RuntimeSessionPromptHandlerOutput(text="Analysis complete", metadata={"tokens": 12})
+
+        result = session.submit_prompt(
+            prompt="Analyze the failure",
+            role="analyst",
+            cwd="/workspace",
+            handler=handler,
+        )
+
+        assert result.session_id == "run:abc:runtime"
+        assert result.role == "analyst"
+        assert result.cwd == "/workspace"
+        assert result.text == "Analysis complete"
+        assert result.is_error is False
+        assert result.error == ""
+
+        loaded = store.load("run:abc:runtime")
+        assert loaded is not None
+        assert loaded.metadata == {"goal": "autoctx run support_triage", "runId": "abc"}
+        prompt, response = loaded.events
+        assert prompt.event_type == RuntimeSessionEventType.PROMPT_SUBMITTED
+        assert response.event_type == RuntimeSessionEventType.ASSISTANT_MESSAGE
+        assert prompt.payload["requestId"]
+        assert response.payload["requestId"] == prompt.payload["requestId"]
+        assert response.payload["promptEventId"] == prompt.event_id
+        assert response.payload["metadata"] == {"tokens": 12}
+        assert observed == [
+            (RuntimeSessionEventType.PROMPT_SUBMITTED, "run:abc:runtime"),
+            (RuntimeSessionEventType.ASSISTANT_MESSAGE, "run:abc:runtime"),
+        ]
+    finally:
+        store.close()
+
+
+def test_runtime_session_records_handler_failure_without_raising(tmp_path: Path) -> None:
+    from autocontext.session import RuntimeSession
+    from autocontext.session.runtime_events import RuntimeSessionEventStore, RuntimeSessionEventType
+
+    store = RuntimeSessionEventStore(tmp_path / "runtime-events.db")
+    try:
+        session = RuntimeSession.create(
+            session_id="run:abc:runtime",
+            goal="autoctx run support_triage",
+            event_store=store,
+        )
+
+        def handler(input):
+            raise RuntimeError("runtime down")
+
+        result = session.submit_prompt(prompt="Analyze the failure", handler=handler)
+
+        assert result.session_id == "run:abc:runtime"
+        assert result.role == "assistant"
+        assert result.cwd == ""
+        assert result.text == ""
+        assert result.is_error is True
+        assert result.error == "runtime down"
+
+        loaded = store.load("run:abc:runtime")
+        assert loaded is not None
+        assert [event.event_type for event in loaded.events] == [
+            RuntimeSessionEventType.PROMPT_SUBMITTED,
+            RuntimeSessionEventType.ASSISTANT_MESSAGE,
+        ]
+        response = loaded.events[1]
+        assert response.payload["isError"] is True
+        assert response.payload["error"] == "runtime down"
+    finally:
+        store.close()
+
+
+def test_runtime_session_event_sink_failures_do_not_interrupt_recording(tmp_path: Path) -> None:
+    from autocontext.session import RuntimeSession, RuntimeSessionPromptHandlerOutput
+    from autocontext.session.runtime_events import RuntimeSessionEventStore
+
+    class FailingSink:
+        def on_runtime_session_event(self, event, log) -> None:
+            raise RuntimeError("sink unavailable")
+
+    store = RuntimeSessionEventStore(tmp_path / "runtime-events.db")
+    try:
+        session = RuntimeSession.create(
+            session_id="run:abc:runtime",
+            goal="autoctx run support_triage",
+            event_store=store,
+            event_sink=FailingSink(),
+        )
+
+        result = session.submit_prompt(
+            prompt="Analyze",
+            handler=lambda input: RuntimeSessionPromptHandlerOutput(text="Still recorded"),
+        )
+
+        assert result.text == "Still recorded"
+        assert store.load("run:abc:runtime") is not None
+    finally:
+        store.close()
+
+
+def test_runtime_session_records_child_task_lineage(tmp_path: Path) -> None:
+    from autocontext.session import RuntimeChildTaskHandlerOutput, RuntimeSession
+    from autocontext.session.runtime_events import RuntimeSessionEventStore, RuntimeSessionEventType
+
+    store = RuntimeSessionEventStore(tmp_path / "runtime-events.db")
+    try:
+        session = RuntimeSession.create(
+            session_id="run:abc:runtime",
+            goal="autoctx run support_triage",
+            event_store=store,
+        )
+
+        def handler(input):
+            assert input.task_id == "retry"
+            assert input.child_session_id == "task:run:abc:runtime:retry"
+            assert input.parent_session_id == "run:abc:runtime"
+            assert input.role == "analyst"
+            assert input.cwd == "/workspace"
+            assert input.depth == 1
+            assert input.max_depth == 4
+            return RuntimeChildTaskHandlerOutput(text="Child complete", metadata={"role": "analyst"})
+
+        result = session.run_child_task(
+            prompt="Investigate regression",
+            role="analyst",
+            task_id="retry",
+            cwd="/workspace",
+            handler=handler,
+        )
+
+        assert result.task_id == "retry"
+        assert result.child_session_id == "task:run:abc:runtime:retry"
+        assert result.parent_session_id == "run:abc:runtime"
+        assert result.role == "analyst"
+        assert result.cwd == "/workspace"
+        assert result.text == "Child complete"
+        assert result.is_error is False
+        assert result.error == ""
+        assert result.depth == 1
+        assert result.max_depth == 4
+
+        parent = store.load("run:abc:runtime")
+        child = store.load("task:run:abc:runtime:retry")
+        assert parent is not None
+        assert child is not None
+        assert [event.event_type for event in parent.events] == [
+            RuntimeSessionEventType.CHILD_TASK_STARTED,
+            RuntimeSessionEventType.CHILD_TASK_COMPLETED,
+        ]
+        started, completed = parent.events
+        assert started.payload["childSessionId"] == child.session_id
+        assert completed.payload["childSessionId"] == child.session_id
+        assert completed.payload["result"] == "Child complete"
+        assert child.parent_session_id == parent.session_id
+        assert child.task_id == "retry"
+        assert child.worker_id
+        assert [event.event_type for event in child.events] == [
+            RuntimeSessionEventType.PROMPT_SUBMITTED,
+            RuntimeSessionEventType.ASSISTANT_MESSAGE,
+        ]
+        assert child.events[1].payload["metadata"] == {"role": "analyst"}
+        assert [log.session_id for log in session.list_child_logs()] == [child.session_id]
+    finally:
+        store.close()
+
+
+def test_runtime_session_child_task_depth_limit_is_recorded(tmp_path: Path) -> None:
+    from autocontext.session import RuntimeSession
+    from autocontext.session.runtime_events import RuntimeSessionEventStore
+
+    store = RuntimeSessionEventStore(tmp_path / "runtime-events.db")
+    try:
+        session = RuntimeSession.create(
+            session_id="run:abc:runtime",
+            goal="autoctx run support_triage",
+            event_store=store,
+            depth=1,
+            max_depth=1,
+        )
+
+        def handler(input):
+            raise AssertionError("depth-limited child task should not run")
+
+        result = session.run_child_task(
+            prompt="Too deep",
+            role="analyst",
+            task_id="depth",
+            handler=handler,
+        )
+
+        assert result.is_error is True
+        assert result.text == ""
+        assert result.error == "Maximum child task depth (1) exceeded"
+        child = store.load("task:run:abc:runtime:depth")
+        assert child is not None
+        assert child.events[1].payload["isError"] is True
+        assert child.events[1].payload["error"] == "Maximum child task depth (1) exceeded"
+    finally:
+        store.close()
+
+
 def test_runtime_session_read_model_resolves_run_ids_and_summaries() -> None:
     from autocontext.session.runtime_session_ids import runtime_session_id_for_run
     from autocontext.session.runtime_session_read_model import (

--- a/autocontext/tests/test_runtime_session_events.py
+++ b/autocontext/tests/test_runtime_session_events.py
@@ -328,6 +328,45 @@ def test_runtime_session_event_sink_failures_do_not_interrupt_recording(tmp_path
         store.close()
 
 
+def test_runtime_session_sanitizes_non_json_metadata_before_recording(tmp_path: Path) -> None:
+    from autocontext.session import RuntimeSession, RuntimeSessionPromptHandlerOutput
+    from autocontext.session.runtime_events import RuntimeSessionEventStore, RuntimeSessionEventType
+
+    class Marker:
+        def __str__(self) -> str:
+            return "marker-value"
+
+    store = RuntimeSessionEventStore(tmp_path / "runtime-events.db")
+    try:
+        session = RuntimeSession.create(
+            session_id="run:abc:runtime",
+            goal="autoctx run support_triage",
+            event_store=store,
+        )
+
+        result = session.submit_prompt(
+            prompt="Analyze",
+            handler=lambda input: RuntimeSessionPromptHandlerOutput(
+                text="Recorded",
+                metadata={"path": tmp_path, "marker": Marker()},
+            ),
+        )
+
+        assert result.is_error is False
+        loaded = store.load("run:abc:runtime")
+        assert loaded is not None
+        assert [event.event_type for event in loaded.events] == [
+            RuntimeSessionEventType.PROMPT_SUBMITTED,
+            RuntimeSessionEventType.ASSISTANT_MESSAGE,
+        ]
+        assert loaded.events[1].payload["metadata"] == {
+            "path": str(tmp_path),
+            "marker": "marker-value",
+        }
+    finally:
+        store.close()
+
+
 def test_runtime_session_records_child_task_lineage(tmp_path: Path) -> None:
     from autocontext.session import RuntimeChildTaskHandlerOutput, RuntimeSession
     from autocontext.session.runtime_events import RuntimeSessionEventStore, RuntimeSessionEventType
@@ -342,13 +381,13 @@ def test_runtime_session_records_child_task_lineage(tmp_path: Path) -> None:
 
         def handler(input):
             assert input.task_id == "retry"
-            assert input.child_session_id == "task:run:abc:runtime:retry"
+            assert input.child_session_id == f"task:run:abc:runtime:retry:{input.worker_id}"
             assert input.parent_session_id == "run:abc:runtime"
             assert input.role == "analyst"
             assert input.cwd == "/workspace"
             assert input.depth == 1
             assert input.max_depth == 4
-            return RuntimeChildTaskHandlerOutput(text="Child complete", metadata={"role": "analyst"})
+            return RuntimeChildTaskHandlerOutput(text="Child complete", metadata={"role": "analyst", "artifact": tmp_path})
 
         result = session.run_child_task(
             prompt="Investigate regression",
@@ -359,7 +398,7 @@ def test_runtime_session_records_child_task_lineage(tmp_path: Path) -> None:
         )
 
         assert result.task_id == "retry"
-        assert result.child_session_id == "task:run:abc:runtime:retry"
+        assert result.child_session_id == f"task:run:abc:runtime:retry:{result.worker_id}"
         assert result.parent_session_id == "run:abc:runtime"
         assert result.role == "analyst"
         assert result.cwd == "/workspace"
@@ -370,7 +409,7 @@ def test_runtime_session_records_child_task_lineage(tmp_path: Path) -> None:
         assert result.max_depth == 4
 
         parent = store.load("run:abc:runtime")
-        child = store.load("task:run:abc:runtime:retry")
+        child = store.load(result.child_session_id)
         assert parent is not None
         assert child is not None
         assert [event.event_type for event in parent.events] == [
@@ -388,8 +427,62 @@ def test_runtime_session_records_child_task_lineage(tmp_path: Path) -> None:
             RuntimeSessionEventType.PROMPT_SUBMITTED,
             RuntimeSessionEventType.ASSISTANT_MESSAGE,
         ]
-        assert child.events[1].payload["metadata"] == {"role": "analyst"}
+        assert child.events[1].payload["metadata"] == {"role": "analyst", "artifact": str(tmp_path)}
         assert [log.session_id for log in session.list_child_logs()] == [child.session_id]
+    finally:
+        store.close()
+
+
+def test_runtime_session_reused_task_ids_keep_distinct_child_logs(tmp_path: Path) -> None:
+    from autocontext.session import RuntimeChildTaskHandlerOutput, RuntimeSession
+    from autocontext.session.runtime_events import RuntimeSessionEventStore
+
+    store = RuntimeSessionEventStore(tmp_path / "runtime-events.db")
+    try:
+        session = RuntimeSession.create(
+            session_id="run:abc:runtime",
+            goal="autoctx run support_triage",
+            event_store=store,
+        )
+
+        first = session.run_child_task(
+            prompt="Investigate regression",
+            role="analyst",
+            task_id="retry",
+            handler=lambda input: RuntimeChildTaskHandlerOutput(text="first attempt"),
+        )
+        second = session.run_child_task(
+            prompt="Investigate regression again",
+            role="analyst",
+            task_id="retry",
+            handler=lambda input: RuntimeChildTaskHandlerOutput(text="second attempt"),
+        )
+
+        assert first.task_id == second.task_id == "retry"
+        assert first.child_session_id != second.child_session_id
+        assert first.child_session_id.startswith("task:run:abc:runtime:retry:")
+        assert second.child_session_id.startswith("task:run:abc:runtime:retry:")
+
+        children = {log.session_id: log for log in session.list_child_logs()}
+        assert set(children) == {first.child_session_id, second.child_session_id}
+        assert children[first.child_session_id].task_id == "retry"
+        assert children[second.child_session_id].task_id == "retry"
+        assert children[first.child_session_id].events[1].payload["text"] == "first attempt"
+        assert children[second.child_session_id].events[1].payload["text"] == "second attempt"
+
+        parent = store.load("run:abc:runtime")
+        assert parent is not None
+        started_child_sessions = [
+            event.payload["childSessionId"]
+            for event in parent.events
+            if event.payload.get("taskId") == "retry" and "childSessionId" in event.payload
+        ]
+        assert started_child_sessions == [
+            first.child_session_id,
+            first.child_session_id,
+            second.child_session_id,
+            second.child_session_id,
+        ]
     finally:
         store.close()
 
@@ -421,7 +514,7 @@ def test_runtime_session_child_task_depth_limit_is_recorded(tmp_path: Path) -> N
         assert result.is_error is True
         assert result.text == ""
         assert result.error == "Maximum child task depth (1) exceeded"
-        child = store.load("task:run:abc:runtime:depth")
+        child = store.load(result.child_session_id)
         assert child is not None
         assert child.events[1].payload["isError"] is True
         assert child.events[1].payload["error"] == "Maximum child task depth (1) exceeded"


### PR DESCRIPTION
## Summary
- add Python RuntimeSession writer facade for prompt/assistant recording
- add child task runner with parent/child lineage and depth-limit recording
- export new runtime-session domain types and coordinator start/fail lifecycle helpers

## Verification
- uv run --frozen ruff check src tests
- uv run --frozen mypy src
- uv run --frozen pytest