### PR TITLE
Align TS runtime session recording parity

### DIFF
--- a/ts/src/session/runtime-child-tasks.ts
+++ b/ts/src/session/runtime-child-tasks.ts
@@ -8,6 +8,7 @@ import {
   RuntimeSessionEventStore,
   RuntimeSessionEventType,
 } from "./runtime-events.js";
+import { jsonSafeRecord } from "./runtime-json.js";
 import type { RuntimeSessionEventSink } from "./runtime-session-notifications.js";
 
 export const DEFAULT_CHILD_TASK_MAX_DEPTH = 4;
@@ -120,7 +121,7 @@ export class RuntimeChildTaskRunner {
       cwd: opts.cwd,
       commands: opts.commands,
     });
-    const childSessionId = `task:${this.parentLog.sessionId}:${taskId}`;
+    const childSessionId = `task:${this.parentLog.sessionId}:${taskId}:${worker.workerId}`;
     const childLog = RuntimeSessionEventLog.create({
       sessionId: childSessionId,
       parentSessionId: this.parentLog.sessionId,
@@ -182,7 +183,7 @@ export class RuntimeChildTaskRunner {
       const text = output.text;
       childLog.append(RuntimeSessionEventType.ASSISTANT_MESSAGE, {
         text,
-        metadata: output.metadata ?? {},
+        metadata: jsonSafeRecord(output.metadata),
         depth: childDepth,
         maxDepth: this.maxDepth,
       });

--- a/ts/src/session/runtime-json.ts
+++ b/ts/src/session/runtime-json.ts
@@ -1,0 +1,61 @@
+export function jsonSafeRecord(value: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!value) return {};
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [String(key), jsonSafeValue(item)]),
+  );
+}
+
+function jsonSafeValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (value === null) return null;
+
+  switch (typeof value) {
+    case "string":
+    case "boolean":
+      return value;
+    case "number":
+      return Number.isFinite(value) ? value : String(value);
+    case "bigint":
+      return value.toString();
+    case "undefined":
+    case "function":
+    case "symbol":
+      return String(value);
+    case "object":
+      return jsonSafeObject(value, seen);
+  }
+}
+
+function jsonSafeObject(value: object, seen: WeakSet<object>): unknown {
+  if (seen.has(value)) {
+    return String(value);
+  }
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item) => jsonSafeValue(item, seen));
+    }
+    const toJSON = getToJSON(value);
+    if (toJSON) {
+      return jsonSafeValue(toJSON(), seen);
+    }
+    if (isPlainRecord(value)) {
+      return Object.fromEntries(
+        Object.entries(value).map(([key, item]) => [String(key), jsonSafeValue(item, seen)]),
+      );
+    }
+    return String(value);
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function isPlainRecord(value: object): value is Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function getToJSON(value: object): (() => unknown) | undefined {
+  const toJSON = Reflect.get(value, "toJSON");
+  if (typeof toJSON !== "function") return undefined;
+  return () => toJSON.call(value);
+}

--- a/ts/src/session/runtime-json.ts
+++ b/ts/src/session/runtime-json.ts
@@ -1,7 +1,9 @@
 export function jsonSafeRecord(value: Record<string, unknown> | undefined): Record<string, unknown> {
   if (!value) return {};
+  const entries = safeEntries(value);
+  if (!entries) return { value: safeString(value) };
   return Object.fromEntries(
-    Object.entries(value).map(([key, item]) => [String(key), jsonSafeValue(item)]),
+    entries.map(([key, item]) => [String(key), jsonSafeValue(item)]),
   );
 }
 
@@ -19,7 +21,7 @@ function jsonSafeValue(value: unknown, seen = new WeakSet<object>()): unknown {
     case "undefined":
     case "function":
     case "symbol":
-      return String(value);
+      return safeString(value);
     case "object":
       return jsonSafeObject(value, seen);
   }
@@ -27,23 +29,28 @@ function jsonSafeValue(value: unknown, seen = new WeakSet<object>()): unknown {
 
 function jsonSafeObject(value: object, seen: WeakSet<object>): unknown {
   if (seen.has(value)) {
-    return String(value);
+    return safeString(value);
   }
   seen.add(value);
   try {
     if (Array.isArray(value)) {
       return value.map((item) => jsonSafeValue(item, seen));
     }
-    const toJSON = getToJSON(value);
-    if (toJSON) {
-      return jsonSafeValue(toJSON(), seen);
+    const toJSON = readToJSON(value);
+    if (toJSON.status === "value") {
+      return jsonSafeValue(toJSON.value, seen);
+    }
+    if (toJSON.status === "failed") {
+      return safeString(value);
     }
     if (isPlainRecord(value)) {
+      const entries = safeEntries(value);
+      if (!entries) return safeString(value);
       return Object.fromEntries(
-        Object.entries(value).map(([key, item]) => [String(key), jsonSafeValue(item, seen)]),
+        entries.map(([key, item]) => [String(key), jsonSafeValue(item, seen)]),
       );
     }
-    return String(value);
+    return safeString(value);
   } finally {
     seen.delete(value);
   }
@@ -54,8 +61,40 @@ function isPlainRecord(value: object): value is Record<string, unknown> {
   return prototype === Object.prototype || prototype === null;
 }
 
-function getToJSON(value: object): (() => unknown) | undefined {
-  const toJSON = Reflect.get(value, "toJSON");
-  if (typeof toJSON !== "function") return undefined;
-  return () => toJSON.call(value);
+type ToJSONReadResult =
+  | { status: "missing" }
+  | { status: "value"; value: unknown }
+  | { status: "failed" };
+
+function readToJSON(value: object): ToJSONReadResult {
+  let toJSON: unknown;
+  try {
+    toJSON = Reflect.get(value, "toJSON");
+  } catch {
+    return { status: "failed" };
+  }
+  if (typeof toJSON !== "function") {
+    return { status: "missing" };
+  }
+  try {
+    return { status: "value", value: Reflect.apply(toJSON, value, []) };
+  } catch {
+    return { status: "failed" };
+  }
+}
+
+function safeEntries(value: object): Array<[string, unknown]> | undefined {
+  try {
+    return Object.entries(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function safeString(value: unknown): string {
+  try {
+    return String(value);
+  } catch {
+    return "[unserializable]";
+  }
 }

--- a/ts/src/session/runtime-session.ts
+++ b/ts/src/session/runtime-session.ts
@@ -11,6 +11,7 @@ import {
   RuntimeSessionEventStore,
   RuntimeSessionEventType,
 } from "./runtime-events.js";
+import { jsonSafeRecord } from "./runtime-json.js";
 import type { RuntimeSessionEventSink } from "./runtime-session-notifications.js";
 
 export interface RuntimeSessionCreateOpts {
@@ -105,7 +106,7 @@ export class RuntimeSession {
 
   static create(opts: RuntimeSessionCreateOpts): RuntimeSession {
     const sessionId = opts.sessionId ?? `runtime:${randomUUID().slice(0, 12)}`;
-    const metadata = { ...(opts.metadata ?? {}), goal: opts.goal };
+    const metadata = { ...jsonSafeRecord(opts.metadata), goal: opts.goal };
     const log = RuntimeSessionEventLog.create({ sessionId, metadata });
     return new RuntimeSession({
       goal: opts.goal,
@@ -166,7 +167,7 @@ export class RuntimeSession {
         requestId,
         promptEventId: promptEvent.eventId,
         text: output.text,
-        metadata: output.metadata ?? {},
+        metadata: jsonSafeRecord(output.metadata),
         role,
         cwd: scopedWorkspace.cwd,
       });

--- a/ts/tests/runtime-session.test.ts
+++ b/ts/tests/runtime-session.test.ts
@@ -275,6 +275,26 @@ describe("RuntimeSession", () => {
         return "marker-value";
       }
     }
+    class ThrowingToJSON {
+      toJSON(): unknown {
+        throw new Error("toJSON failed");
+      }
+
+      toString(): string {
+        return "throwing-to-json";
+      }
+    }
+    const throwingToJSONGetter = Object.defineProperty(
+      {
+        toString: () => "throwing-to-json-getter",
+      },
+      "toJSON",
+      {
+        get: () => {
+          throw new Error("toJSON getter failed");
+        },
+      },
+    );
     const result = await session.submitPrompt({
       prompt: "Inspect auth flow",
       handler: () => ({
@@ -282,6 +302,8 @@ describe("RuntimeSession", () => {
         metadata: {
           count: BigInt(7),
           marker: new Marker(),
+          throwingToJSON: new ThrowingToJSON(),
+          throwingToJSONGetter,
           nested: { count: BigInt(8) },
         },
       }),
@@ -297,6 +319,8 @@ describe("RuntimeSession", () => {
     expect(loaded!.events[1].payload.metadata).toEqual({
       count: "7",
       marker: "marker-value",
+      throwingToJSON: "throwing-to-json",
+      throwingToJSONGetter: "throwing-to-json-getter",
       nested: { count: "8" },
     });
 

--- a/ts/tests/runtime-session.test.ts
+++ b/ts/tests/runtime-session.test.ts
@@ -96,7 +96,7 @@ describe("RuntimeSession", () => {
       goal: "ship auth",
       workspace,
       eventStore,
-      metadata: { project: "autocontext" },
+      metadata: { project: "autocontext", attempt: BigInt(1) },
     });
 
     const result = await session.submitPrompt({
@@ -133,6 +133,7 @@ describe("RuntimeSession", () => {
     expect(loaded!.metadata).toMatchObject({
       goal: "ship auth",
       project: "autocontext",
+      attempt: "1",
     });
     expect(loaded!.events.at(-1)?.payload).toMatchObject({
       text: "parent done in /workspace/project",
@@ -167,7 +168,7 @@ describe("RuntimeSession", () => {
       ],
       handler: async ({ workspace: childWorkspace }) => {
         const command = await childWorkspace.exec("summarize auth flow");
-        return { text: command.stdout };
+        return { text: command.stdout, metadata: { tokens: BigInt(3) } };
       },
     });
 
@@ -199,6 +200,104 @@ describe("RuntimeSession", () => {
     expect(childLogs[0].taskId).toBe("task-1");
     expect(childLogs[0].events.at(-1)?.payload).toMatchObject({
       text: "/workspace/project:auth flow",
+      metadata: { tokens: "3" },
+    });
+
+    eventStore.close();
+  });
+
+  it("keeps reused child task ids as distinct child session logs", async () => {
+    const workspace = createInMemoryWorkspaceEnv({ cwd: "/workspace" });
+    const eventStore = createEventStore();
+    const session = RuntimeSession.create({
+      sessionId: "runtime-parent",
+      goal: "ship auth",
+      workspace,
+      eventStore,
+    });
+
+    const first = await session.runChildTask({
+      taskId: "retry",
+      prompt: "Investigate regression",
+      role: "analyst",
+      handler: () => ({ text: "first attempt" }),
+    });
+    const second = await session.runChildTask({
+      taskId: "retry",
+      prompt: "Investigate regression again",
+      role: "analyst",
+      handler: () => ({ text: "second attempt" }),
+    });
+
+    expect(first.taskId).toBe("retry");
+    expect(second.taskId).toBe("retry");
+    expect(first.childSessionId).not.toBe(second.childSessionId);
+    expect(first.childSessionId).toMatch(/^task:runtime-parent:retry:/);
+    expect(second.childSessionId).toMatch(/^task:runtime-parent:retry:/);
+
+    const children = new Map(session.listChildLogs().map((log) => [log.sessionId, log]));
+    expect([...children.keys()].sort()).toEqual(
+      [first.childSessionId, second.childSessionId].sort(),
+    );
+    expect(children.get(first.childSessionId)?.taskId).toBe("retry");
+    expect(children.get(second.childSessionId)?.taskId).toBe("retry");
+    expect(children.get(first.childSessionId)?.events.at(-1)?.payload.text).toBe("first attempt");
+    expect(children.get(second.childSessionId)?.events.at(-1)?.payload.text).toBe("second attempt");
+
+    const parent = eventStore.load("runtime-parent");
+    expect(parent).not.toBeNull();
+    expect(
+      parent!.events
+        .filter((event) => event.payload.taskId === "retry")
+        .map((event) => event.payload.childSessionId),
+    ).toEqual([
+      first.childSessionId,
+      first.childSessionId,
+      second.childSessionId,
+      second.childSessionId,
+    ]);
+
+    eventStore.close();
+  });
+
+  it("sanitizes non-json metadata before persisting prompt responses", async () => {
+    const workspace = createInMemoryWorkspaceEnv({ cwd: "/workspace" });
+    const eventStore = createEventStore();
+    const session = RuntimeSession.create({
+      sessionId: "runtime-metadata",
+      goal: "ship auth",
+      workspace,
+      eventStore,
+    });
+
+    class Marker {
+      toString(): string {
+        return "marker-value";
+      }
+    }
+    const result = await session.submitPrompt({
+      prompt: "Inspect auth flow",
+      handler: () => ({
+        text: "done",
+        metadata: {
+          count: BigInt(7),
+          marker: new Marker(),
+          nested: { count: BigInt(8) },
+        },
+      }),
+    });
+
+    expect(result.isError).toBe(false);
+    const loaded = eventStore.load("runtime-metadata");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.events.map((event) => event.eventType)).toEqual([
+      RuntimeSessionEventType.PROMPT_SUBMITTED,
+      RuntimeSessionEventType.ASSISTANT_MESSAGE,
+    ]);
+    expect(loaded!.events[1].payload.metadata).toEqual({
+      count: "7",
+      marker: "marker-value",
+      nested: { count: "8" },
     });
 
     eventStore.close();


### PR DESCRIPTION
Summary:
- Give TS child runtime sessions the same worker-correlated childSessionId shape as Python so reused task IDs keep distinct logs.
- Add a shared TS JSON-safe metadata normalizer for runtime-session creation, prompt responses, and child-task responses.
- Extend runtime-session tests for retry child logs plus non-JSON metadata persistence parity.

Tests:
- npm test -- tests/runtime-session.test.ts
- npm test -- tests/type-assertions.test.ts tests/runtime-session.test.ts
- npm test -- tests/production-traces/sdk/hashing-parity.property.test.ts
- npm run lint
- npm test
- uv run --frozen pytest tests/test_runtime_session_events.py
- git diff --check