### PR TITLE
Surface external eval runtime diagnostics

### DIFF
--- a/ts/src/control-plane/external-evals/index.ts
+++ b/ts/src/control-plane/external-evals/index.ts
@@ -122,6 +122,7 @@ export interface ExternalEvalDiagnosticReport {
   readonly summary: {
     readonly totalTrials: number;
     readonly unresolvedTrials: number;
+    readonly runtimeIssueTrials: number;
     readonly countsByCategory: Readonly<Partial<Record<ExternalEvalDiagnosticCategory, number>>>;
   };
 }
@@ -201,9 +202,13 @@ export function buildExternalEvalDiagnosticReport(
     evidenceByTrialId.set(evidence.trialId, evidence);
   }
 
-  const diagnostics = inputs.trials
-    .filter((trial) => trial.status !== "passed")
-    .map((trial) => buildTrialDiagnostic(inputs.runId, trial, evidenceByTrialId.get(trial.trialId)));
+  const trialsWithEvidence = inputs.trials.map((trial) => ({
+    trial,
+    evidence: evidenceByTrialId.get(trial.trialId),
+  }));
+  const diagnostics = trialsWithEvidence
+    .filter(({ trial, evidence }) => trial.status !== "passed" || hasAdapterRuntimeIssue(trial, evidence))
+    .map(({ trial, evidence }) => buildTrialDiagnostic(inputs.runId, trial, evidence));
   const improvementSignals = buildImprovementSignals(inputs.runId, diagnostics);
 
   return {
@@ -214,7 +219,10 @@ export function buildExternalEvalDiagnosticReport(
     improvementSignals,
     summary: {
       totalTrials: inputs.trials.length,
-      unresolvedTrials: diagnostics.length,
+      unresolvedTrials: inputs.trials.filter((trial) => trial.status !== "passed").length,
+      runtimeIssueTrials: trialsWithEvidence.filter(({ trial, evidence }) =>
+        hasAdapterRuntimeIssue(trial, evidence),
+      ).length,
       countsByCategory: countDiagnosticsByCategory(diagnostics),
     },
   };
@@ -268,15 +276,28 @@ function classifyErrorKind(
   inputs: ClassifyExternalEvalTrialInputs,
   status: EvalTrialStatus,
 ): string | undefined {
-  if (status === "passed" || status === "failed") {
+  if (status === "passed") {
+    return normalizedFailureMode(inputs.failureMode) || runtimeLifecycleErrorKind(inputs) || undefined;
+  }
+  if (status === "failed") {
     return normalizedFailureMode(inputs.failureMode) || undefined;
   }
   const failureMode = normalizedFailureMode(inputs.failureMode);
-  return failureMode || inputs.lifecycle?.errorKind || inputs.lifecycle?.timeoutSource || inputs.lifecycle?.status;
+  return failureMode || runtimeLifecycleErrorKind(inputs);
 }
 
 function normalizedFailureMode(failureMode: string | undefined): string {
   return failureMode === undefined || failureMode === "unset" ? "" : failureMode;
+}
+
+function runtimeLifecycleErrorKind(inputs: ClassifyExternalEvalTrialInputs): string | undefined {
+  const lifecycle = inputs.lifecycle;
+  if (lifecycle === undefined) return undefined;
+  const errorKind = normalizedFailureMode(lifecycle.errorKind);
+  if (errorKind.length > 0) return errorKind;
+  const timeoutSource = normalizedFailureMode(lifecycle.timeoutSource);
+  if (timeoutSource.length > 0) return timeoutSource;
+  return isRuntimeIssueLifecycleStatus(lifecycle.status) ? lifecycle.status : undefined;
 }
 
 function defaultReward(status: EvalTrialStatus): number | undefined {
@@ -346,10 +367,7 @@ function classifyDiagnosticCategory(
   }
   if (
     trial.status === "infrastructure-error" ||
-    evidence?.adapterLifecycle?.status === "timed-out" ||
-    evidence?.adapterLifecycle?.status === "failed" ||
-    isInfrastructureFailureMode(trial.errorKind) ||
-    isInfrastructureFailureMode(evidence?.adapterLifecycle?.errorKind)
+    hasAdapterRuntimeIssue(trial, evidence)
   ) {
     return "adapter-runtime-failure";
   }
@@ -387,6 +405,7 @@ function diagnosticConfidence(
   evidence: ExternalEvalTrialEvidence | undefined,
 ): number {
   if (category === "adapter-runtime-failure" && trial.status === "infrastructure-error") return 0.95;
+  if (category === "adapter-runtime-failure" && hasAdapterRuntimeIssue(trial, evidence)) return 0.9;
   if (category === "integrity-risk" && trial.status === "discarded") return 0.9;
   if (evidence?.verifierOutput !== undefined && evidence.verifierOutput.length > 0) return 0.85;
   return category === "unknown" ? 0.25 : 0.6;
@@ -395,7 +414,7 @@ function diagnosticConfidence(
 function diagnosticSummary(category: ExternalEvalDiagnosticCategory): string {
   switch (category) {
     case "adapter-runtime-failure":
-      return "The trial failed in the adapter or runtime before an ordinary verifier result could be trusted.";
+      return "The trial reported adapter or runtime failure metadata that should be isolated from task-quality scoring.";
     case "setup-environment-failure":
       return "The trial failed while preparing or validating environment state used by the consumer or verifier.";
     case "verifier-contract-mismatch":
@@ -446,13 +465,8 @@ function buildFailureExcerpts(
   trial: EvalTrial,
   evidence: ExternalEvalTrialEvidence | undefined,
 ): readonly string[] {
-  if (category === "adapter-runtime-failure" && evidence?.adapterLifecycle !== undefined) {
-    const lifecycle = evidence.adapterLifecycle;
-    return [
-      `adapter_status=${lifecycle.status}`,
-      ...(lifecycle.errorKind !== undefined ? [`adapter_error_kind=${lifecycle.errorKind}`] : []),
-      ...(lifecycle.timeoutSource !== undefined ? [`timeout_source=${lifecycle.timeoutSource}`] : []),
-    ];
+  if (category === "adapter-runtime-failure") {
+    return buildAdapterRuntimeExcerpts(trial, evidence?.adapterLifecycle);
   }
   if (category === "integrity-risk") {
     return [
@@ -463,6 +477,36 @@ function buildFailureExcerpts(
   }
 
   return sanitizeVerifierOutput(evidence?.verifierOutput ?? "");
+}
+
+function buildAdapterRuntimeExcerpts(
+  trial: EvalTrial,
+  lifecycle: ExternalEvalAdapterLifecycle | undefined,
+): readonly string[] {
+  const excerpts: string[] = [];
+  const add = (excerpt: string | undefined): void => {
+    if (excerpt !== undefined && excerpt.length > 0 && !excerpts.includes(excerpt)) {
+      excerpts.push(excerpt);
+    }
+  };
+
+  add(trial.errorKind !== undefined ? `error_kind=${trial.errorKind}` : undefined);
+  add(lifecycle !== undefined ? `adapter_status=${lifecycle.status}` : undefined);
+  add(lifecycle?.errorKind !== undefined ? `adapter_error_kind=${lifecycle.errorKind}` : undefined);
+  add(lifecycle?.timeoutSource !== undefined ? `timeout_source=${lifecycle.timeoutSource}` : undefined);
+
+  for (const note of trial.notes ?? []) {
+    if (
+      note.startsWith("failure_mode=") ||
+      note.startsWith("adapter_status=") ||
+      note.startsWith("adapter_error_kind=") ||
+      note.startsWith("timeout_source=")
+    ) {
+      add(note);
+    }
+  }
+
+  return excerpts;
 }
 
 function isInfrastructureFailureMode(errorKind: string | undefined): boolean {
@@ -477,6 +521,25 @@ function isInfrastructureFailureMode(errorKind: string | undefined): boolean {
     kind.includes("container") ||
     kind === "agent_timeout"
   );
+}
+
+function hasAdapterRuntimeIssue(
+  trial: EvalTrial,
+  evidence: ExternalEvalTrialEvidence | undefined,
+): boolean {
+  const lifecycle = evidence?.adapterLifecycle;
+  return (
+    isInfrastructureFailureMode(trial.errorKind) ||
+    isRuntimeIssueLifecycleStatus(lifecycle?.status) ||
+    isInfrastructureFailureMode(lifecycle?.errorKind) ||
+    isInfrastructureFailureMode(lifecycle?.timeoutSource)
+  );
+}
+
+function isRuntimeIssueLifecycleStatus(
+  status: ExternalEvalAdapterLifecycleStatus | undefined,
+): boolean {
+  return status === "failed" || status === "timed-out" || status === "cancelled";
 }
 
 function sanitizeVerifierOutput(output: string): readonly string[] {
@@ -561,6 +624,9 @@ function buildOperationalFindings(
   const verifierDiagnostics = report.diagnostics.filter(
     (diagnostic) => diagnostic.category === "verifier-contract-mismatch",
   );
+  const integrityDiagnostics = report.diagnostics.filter(
+    (diagnostic) => diagnostic.category === "integrity-risk",
+  );
 
   if (setupDiagnostics.length > 0) {
     findings.push({
@@ -584,6 +650,19 @@ function buildOperationalFindings(
         "Confirm required files, config directives, service routes, and output artifacts in the locations consumed by the checker, not only through manual smoke tests or included fragments.",
       targetFamilies: ["terminal", "service-config", "artifact-contract"],
       risk: "low",
+      containsTaskAnswer: false,
+      containsSecret: false,
+    });
+  }
+  if (integrityDiagnostics.length > 0) {
+    findings.push({
+      id: `${report.runId}-benchmark-integrity-boundary`,
+      summary: "Keep benchmark verifier-only data outside agent inspection paths.",
+      evidenceRefs: collectEvidenceRefs(integrityDiagnostics),
+      reusableBehavior:
+        "For external benchmark runs, do not list, read, copy, execute, or search verifier-only directories, hidden grader files, benchmark canaries, or solution files; avoid broad filesystem scans unless verifier-only paths are explicitly pruned, and prefer allowlisted task-visible paths.",
+      targetFamilies: ["terminal", "external-eval", "benchmark-integrity"],
+      risk: "medium",
       containsTaskAnswer: false,
       containsSecret: false,
     });

--- a/ts/src/control-plane/external-evals/index.ts
+++ b/ts/src/control-plane/external-evals/index.ts
@@ -210,6 +210,7 @@ export function buildExternalEvalDiagnosticReport(
     .filter(({ trial, evidence }) => trial.status !== "passed" || hasAdapterRuntimeIssue(trial, evidence))
     .map(({ trial, evidence }) => buildTrialDiagnostic(inputs.runId, trial, evidence));
   const improvementSignals = buildImprovementSignals(inputs.runId, diagnostics);
+  const countsByCategory = countDiagnosticsByCategory(diagnostics);
 
   return {
     schemaVersion: "external-eval-diagnostics/v1",
@@ -220,10 +221,8 @@ export function buildExternalEvalDiagnosticReport(
     summary: {
       totalTrials: inputs.trials.length,
       unresolvedTrials: inputs.trials.filter((trial) => trial.status !== "passed").length,
-      runtimeIssueTrials: trialsWithEvidence.filter(({ trial, evidence }) =>
-        hasAdapterRuntimeIssue(trial, evidence),
-      ).length,
-      countsByCategory: countDiagnosticsByCategory(diagnostics),
+      runtimeIssueTrials: countsByCategory["adapter-runtime-failure"] ?? 0,
+      countsByCategory,
     },
   };
 }

--- a/ts/tests/control-plane/external-evals/diagnostics.test.ts
+++ b/ts/tests/control-plane/external-evals/diagnostics.test.ts
@@ -181,6 +181,32 @@ describe("external eval diagnostics", () => {
     });
   });
 
+  test("counts runtime-status diagnostics as runtime issue trials", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-run-1",
+      createdAt: "2026-05-07T15:11:00.000Z",
+      trials: [
+        {
+          taskId: "bare-infra-task",
+          trialId: "bare-infra-task.1-of-1.tb-run-1",
+          attempt: 1,
+          status: "infrastructure-error",
+        },
+      ],
+    });
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      category: "adapter-runtime-failure",
+    });
+    expect(report.summary).toMatchObject({
+      totalTrials: 1,
+      unresolvedTrials: 1,
+      runtimeIssueTrials: 1,
+      countsByCategory: { "adapter-runtime-failure": 1 },
+    });
+  });
+
   test("keeps resolved trials with adapter runtime issues visible without counting them unresolved", () => {
     const report = buildExternalEvalDiagnosticReport({
       runId: "tb-run-1",

--- a/ts/tests/control-plane/external-evals/diagnostics.test.ts
+++ b/ts/tests/control-plane/external-evals/diagnostics.test.ts
@@ -181,6 +181,60 @@ describe("external eval diagnostics", () => {
     });
   });
 
+  test("keeps resolved trials with adapter runtime issues visible without counting them unresolved", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-run-1",
+      createdAt: "2026-05-07T15:12:00.000Z",
+      trials: [
+        {
+          taskId: "service-completed-but-agent-timeout",
+          trialId: "service-completed-but-agent-timeout.1-of-1.tb-run-1",
+          attempt: 1,
+          status: "passed",
+          reward: 1,
+          errorKind: "terminal-bench-agent-timeout",
+          notes: ["failure_mode=terminal-bench-agent-timeout", "timeout_source=terminal-bench-agent-timeout"],
+        },
+      ],
+      evidence: [
+        {
+          trialId: "service-completed-but-agent-timeout.1-of-1.tb-run-1",
+          evidenceRefs: ["service-completed-but-agent-timeout/results.json"],
+          adapterLifecycle: {
+            runId: "tb-run-1",
+            taskId: "service-completed-but-agent-timeout",
+            trialId: "service-completed-but-agent-timeout.1-of-1.tb-run-1",
+            adapter: "host-codex-docker",
+            command: { argv: ["codex", "exec"], cwd: "/tmp" },
+            status: "completed",
+            artifacts: {
+              stdoutPath: "agent-logs/host-codex-stdout.txt",
+              stderrPath: "agent-logs/host-codex-stderr.txt",
+            },
+          },
+        },
+      ],
+    });
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      category: "adapter-runtime-failure",
+      confidence: 0.9,
+    });
+    expect(report.diagnostics[0]?.failureExcerpts).toEqual([
+      "error_kind=terminal-bench-agent-timeout",
+      "adapter_status=completed",
+      "failure_mode=terminal-bench-agent-timeout",
+      "timeout_source=terminal-bench-agent-timeout",
+    ]);
+    expect(report.summary).toMatchObject({
+      totalTrials: 1,
+      unresolvedTrials: 0,
+      runtimeIssueTrials: 1,
+      countsByCategory: { "adapter-runtime-failure": 1 },
+    });
+  });
+
   test("keeps discarded integrity-risk trials visible in diagnostics", () => {
     const report = buildExternalEvalDiagnosticReport({
       runId: "tb-run-1",
@@ -213,6 +267,52 @@ describe("external eval diagnostics", () => {
       unresolvedTrials: 1,
       countsByCategory: { "integrity-risk": 1 },
     });
+  });
+
+  test("derives sanitized benchmark-boundary memory from integrity-risk diagnostics", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-integrity-1",
+      createdAt: "2026-05-07T15:20:00.000Z",
+      trials: [
+        {
+          taskId: "contaminated-task",
+          trialId: "contaminated-task.1-of-1.tb-integrity-1",
+          attempt: 1,
+          status: "discarded",
+          errorKind: "integrity-contamination",
+          notes: [
+            "integrity_leak=/protected command observed in agent logs",
+            "adapter_status=completed",
+          ],
+        },
+      ],
+      evidence: [
+        {
+          trialId: "contaminated-task.1-of-1.tb-integrity-1",
+          evidenceRefs: ["contaminated-task/results.json"],
+        },
+      ],
+    });
+
+    const pack = buildOperationalMemoryPackFromDiagnostics({
+      packId: "tb-integrity-1-operational-checklists",
+      version: "1.0.0",
+      createdAt: "2026-05-07T15:25:00.000Z",
+      report,
+    });
+
+    expect(pack.findings).toHaveLength(1);
+    expect(pack.findings[0]).toMatchObject({
+      id: "tb-integrity-1-benchmark-integrity-boundary",
+      summary: "Keep benchmark verifier-only data outside agent inspection paths.",
+      risk: "medium",
+      containsTaskAnswer: false,
+      containsSecret: false,
+    });
+    expect(pack.findings[0]?.reusableBehavior).toContain("verifier-only");
+    expect(pack.findings[0]?.reusableBehavior).not.toContain("contaminated-task");
+    expect(pack.findings[0]?.targetFamilies).toContain("benchmark-integrity");
+    expect(validateOperationalMemoryPack(pack)).toEqual({ valid: true });
   });
 
   test("derives reusable improvement signals from agent-task verifier failures", () => {

--- a/ts/tests/control-plane/external-evals/lifecycle.test.ts
+++ b/ts/tests/control-plane/external-evals/lifecycle.test.ts
@@ -85,6 +85,38 @@ describe("external eval adapter lifecycle", () => {
     expect(trial.errorKind).toBeUndefined();
   });
 
+  test("preserves runtime timeout metadata on resolved trials", () => {
+    const trial = classifyExternalEvalTrial({
+      taskId: "service-completed-but-agent-timeout",
+      trialId: "service-completed-but-agent-timeout.1-of-1.tb-run-1",
+      attempt: 1,
+      isResolved: true,
+      failureMode: "unset",
+      lifecycle: {
+        runId: "tb-run-1",
+        taskId: "service-completed-but-agent-timeout",
+        trialId: "service-completed-but-agent-timeout.1-of-1.tb-run-1",
+        adapter: "host-codex-docker",
+        command: {
+          argv: ["codex", "exec"],
+          cwd: "/tmp",
+        },
+        status: "timed-out",
+        timeoutSource: "terminal-bench-agent-timeout",
+        artifacts: {
+          stdoutPath: "agent-logs/host-codex-stdout.txt",
+          stderrPath: "agent-logs/host-codex-stderr.txt",
+        },
+      },
+    });
+
+    expect(trial.status).toBe("passed");
+    expect(trial.reward).toBe(1);
+    expect(trial.errorKind).toBe("terminal-bench-agent-timeout");
+    expect(trial.notes).toContain("adapter_status=timed-out");
+    expect(trial.notes).toContain("timeout_source=terminal-bench-agent-timeout");
+  });
+
   test("classifies adapter crashes as infrastructure errors and preserves lifecycle error kind", () => {
     const trial = classifyExternalEvalTrial({
       taskId: "adapter-crash-task",


### PR DESCRIPTION
## Summary
- keep passed external-eval trials with adapter/runtime issues visible in diagnostic reports
- add runtimeIssueTrials summary count and richer runtime excerpts
- derive sanitized benchmark-boundary memory from integrity-risk diagnostics

## Verification
- npm test -- --run tests/control-plane/external-evals/lifecycle.test.ts tests/control-plane/external-evals/diagnostics.test.ts
- npm run lint
- npm run build
- npm test (725 files, 4981 tests)