### PR TITLE
Add external eval boundary policy

### DIFF
--- a/ts/src/control-plane/external-evals/index.ts
+++ b/ts/src/control-plane/external-evals/index.ts
@@ -17,6 +17,24 @@ export type ExternalEvalAdapterLifecycleStatus =
   | "timed-out"
   | "cancelled";
 
+export type ExternalEvalBoundaryPolicyMode = "report-only" | "discard";
+export type ExternalEvalBoundaryAccessKind =
+  | "read"
+  | "write"
+  | "list"
+  | "execute"
+  | "search"
+  | "unknown";
+export type ExternalEvalBoundaryObservationSource =
+  | "adapter-command"
+  | "adapter-log"
+  | "tool-call"
+  | "trace"
+  | "manual";
+export type ExternalEvalBoundaryViolationReason =
+  | "blocked-path-prefix"
+  | "outside-allowed-path-prefix";
+
 export type ExternalEvalDiagnosticCategory =
   | "agent-task-failure"
   | "verifier-contract-mismatch"
@@ -66,6 +84,36 @@ export interface ExternalEvalAdapterLifecycle {
   readonly artifacts: ExternalEvalAdapterArtifacts;
 }
 
+export interface ExternalEvalBoundaryPolicy {
+  readonly mode: ExternalEvalBoundaryPolicyMode;
+  readonly blockedPathPrefixes?: readonly string[];
+  readonly allowedPathPrefixes?: readonly string[];
+}
+
+export interface ExternalEvalBoundaryObservation {
+  readonly trialId: string;
+  readonly accessKind: ExternalEvalBoundaryAccessKind;
+  readonly path: string;
+  readonly source: ExternalEvalBoundaryObservationSource;
+  readonly command?: string;
+}
+
+export interface ExternalEvalBoundaryViolation extends ExternalEvalBoundaryObservation {
+  readonly reason: ExternalEvalBoundaryViolationReason;
+}
+
+export interface ExternalEvalBoundaryAssessment {
+  readonly status: EvalRunIntegrity["status"];
+  readonly mode: ExternalEvalBoundaryPolicyMode;
+  readonly violations: readonly ExternalEvalBoundaryViolation[];
+  readonly notes: readonly string[];
+}
+
+export interface AssessExternalEvalBoundaryPolicyInputs {
+  readonly policy: ExternalEvalBoundaryPolicy;
+  readonly observations: readonly ExternalEvalBoundaryObservation[];
+}
+
 export interface ClassifyExternalEvalTrialInputs {
   readonly taskId: string;
   readonly trialId: string;
@@ -77,6 +125,7 @@ export interface ClassifyExternalEvalTrialInputs {
   readonly completedAt?: string;
   readonly rawResultPath?: string;
   readonly lifecycle?: ExternalEvalAdapterLifecycle;
+  readonly boundaryAssessment?: ExternalEvalBoundaryAssessment;
 }
 
 export interface ExternalEvalTrialEvidence {
@@ -84,6 +133,7 @@ export interface ExternalEvalTrialEvidence {
   readonly evidenceRefs?: readonly string[];
   readonly verifierOutput?: string;
   readonly adapterLifecycle?: ExternalEvalAdapterLifecycle;
+  readonly boundaryAssessment?: ExternalEvalBoundaryAssessment;
 }
 
 export interface ExternalEvalTrialDiagnostic {
@@ -174,10 +224,55 @@ export function validateExternalEvalAdapterLifecycle(input: unknown): Validation
   return errors.length === 0 ? { valid: true } : { valid: false, errors };
 }
 
+export function validateExternalEvalBoundaryPolicy(input: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (!isRecord(input)) {
+    return { valid: false, errors: ["boundary policy must be an object"] };
+  }
+
+  requireEnum(input, "mode", ["report-only", "discard"], errors);
+  validateOptionalStringArray(input, "blockedPathPrefixes", errors);
+  validateOptionalStringArray(input, "allowedPathPrefixes", errors);
+
+  const blockedCount = Array.isArray(input.blockedPathPrefixes) ? input.blockedPathPrefixes.length : 0;
+  const allowedCount = Array.isArray(input.allowedPathPrefixes) ? input.allowedPathPrefixes.length : 0;
+  if (blockedCount + allowedCount === 0) {
+    errors.push("boundary policy must declare at least one blocked or allowed path prefix");
+  }
+
+  return errors.length === 0 ? { valid: true } : { valid: false, errors };
+}
+
+export function assessExternalEvalBoundaryPolicy(
+  inputs: AssessExternalEvalBoundaryPolicyInputs,
+): ExternalEvalBoundaryAssessment {
+  const blockedPathPrefixes = normalizeBoundaryPrefixes(inputs.policy.blockedPathPrefixes ?? []);
+  const allowedPathPrefixes = normalizeBoundaryPrefixes(inputs.policy.allowedPathPrefixes ?? []);
+  const violations = inputs.observations.flatMap((observation) =>
+    assessBoundaryObservation(observation, blockedPathPrefixes, allowedPathPrefixes),
+  );
+  const status =
+    violations.length === 0 ? "clean" : inputs.policy.mode === "discard" ? "discarded" : "contaminated";
+
+  return {
+    status,
+    mode: inputs.policy.mode,
+    violations,
+    notes: violations.map(
+      (violation) => `boundary_violation=${violation.accessKind} ${violation.path} ${violation.reason}`,
+    ),
+  };
+}
+
 export function classifyExternalEvalTrial(inputs: ClassifyExternalEvalTrialInputs): EvalTrial {
-  const status = inputs.isResolved ? "passed" : classifyUnresolvedStatus(inputs);
+  const status = shouldDiscardBoundaryAssessment(inputs.boundaryAssessment)
+    ? "discarded"
+    : inputs.isResolved
+      ? "passed"
+      : classifyUnresolvedStatus(inputs);
   const errorKind = classifyErrorKind(inputs, status);
-  const reward = inputs.reward ?? defaultReward(status);
+  const reward = isScoreableTrialStatus(status) ? inputs.reward ?? defaultReward(status) : undefined;
   const notes = buildTrialNotes(inputs);
 
   return {
@@ -207,7 +302,12 @@ export function buildExternalEvalDiagnosticReport(
     evidence: evidenceByTrialId.get(trial.trialId),
   }));
   const diagnostics = trialsWithEvidence
-    .filter(({ trial, evidence }) => trial.status !== "passed" || hasAdapterRuntimeIssue(trial, evidence))
+    .filter(
+      ({ trial, evidence }) =>
+        trial.status !== "passed" ||
+        hasAdapterRuntimeIssue(trial, evidence) ||
+        hasBoundaryIntegrityRisk(trial, evidence),
+    )
     .map(({ trial, evidence }) => buildTrialDiagnostic(inputs.runId, trial, evidence));
   const improvementSignals = buildImprovementSignals(inputs.runId, diagnostics);
   const countsByCategory = countDiagnosticsByCategory(diagnostics);
@@ -275,6 +375,9 @@ function classifyErrorKind(
   inputs: ClassifyExternalEvalTrialInputs,
   status: EvalTrialStatus,
 ): string | undefined {
+  if (status === "discarded" && shouldDiscardBoundaryAssessment(inputs.boundaryAssessment)) {
+    return "external-eval-boundary-violation";
+  }
   if (status === "passed") {
     return normalizedFailureMode(inputs.failureMode) || runtimeLifecycleErrorKind(inputs) || undefined;
   }
@@ -305,6 +408,10 @@ function defaultReward(status: EvalTrialStatus): number | undefined {
   return undefined;
 }
 
+function isScoreableTrialStatus(status: EvalTrialStatus): boolean {
+  return status === "passed" || status === "failed";
+}
+
 function buildTrialNotes(inputs: ClassifyExternalEvalTrialInputs): readonly string[] {
   const notes: string[] = [];
   const failureMode = normalizedFailureMode(inputs.failureMode);
@@ -325,6 +432,10 @@ function buildTrialNotes(inputs: ClassifyExternalEvalTrialInputs): readonly stri
     if (inputs.lifecycle.artifacts.stderrPath !== undefined) {
       notes.push(`stderr=${inputs.lifecycle.artifacts.stderrPath}`);
     }
+  }
+  if (hasBoundaryAssessmentIssue(inputs.boundaryAssessment)) {
+    notes.push(`integrity_status=${inputs.boundaryAssessment.status}`);
+    notes.push(...inputs.boundaryAssessment.notes);
   }
   return notes;
 }
@@ -361,7 +472,7 @@ function classifyDiagnosticCategory(
   trial: EvalTrial,
   evidence: ExternalEvalTrialEvidence | undefined,
 ): ExternalEvalDiagnosticCategory {
-  if (trial.status === "discarded") {
+  if (trial.status === "discarded" || hasBoundaryIntegrityRisk(trial, evidence)) {
     return "integrity-risk";
   }
   if (
@@ -403,6 +514,7 @@ function diagnosticConfidence(
   trial: EvalTrial,
   evidence: ExternalEvalTrialEvidence | undefined,
 ): number {
+  if (category === "integrity-risk" && hasBoundaryIntegrityRisk(trial, evidence)) return 0.95;
   if (category === "adapter-runtime-failure" && trial.status === "infrastructure-error") return 0.95;
   if (category === "adapter-runtime-failure" && hasAdapterRuntimeIssue(trial, evidence)) return 0.9;
   if (category === "integrity-risk" && trial.status === "discarded") return 0.9;
@@ -468,7 +580,8 @@ function buildFailureExcerpts(
     return buildAdapterRuntimeExcerpts(trial, evidence?.adapterLifecycle);
   }
   if (category === "integrity-risk") {
-    return [
+    const boundaryExcerpts = buildBoundaryIntegrityExcerpts(trial, evidence);
+    return boundaryExcerpts.length > 0 ? boundaryExcerpts : [
       `trial_status=${trial.status}`,
       ...(trial.errorKind !== undefined ? [`error_kind=${trial.errorKind}`] : []),
       ...(trial.notes ?? []),
@@ -506,6 +619,110 @@ function buildAdapterRuntimeExcerpts(
   }
 
   return excerpts;
+}
+
+function buildBoundaryIntegrityExcerpts(
+  trial: EvalTrial,
+  evidence: ExternalEvalTrialEvidence | undefined,
+): readonly string[] {
+  const assessment = evidence?.boundaryAssessment;
+  if (hasBoundaryAssessmentIssue(assessment)) {
+    return [`integrity_status=${assessment.status}`, ...assessment.notes];
+  }
+
+  const trialNotes = trial.notes ?? [];
+  const boundaryNotes = trialNotes.filter(
+    (note) => note.startsWith("integrity_status=") || note.startsWith("boundary_violation="),
+  );
+  return boundaryNotes;
+}
+
+function hasBoundaryIntegrityRisk(
+  trial: EvalTrial,
+  evidence: ExternalEvalTrialEvidence | undefined,
+): boolean {
+  return hasBoundaryAssessmentIssue(evidence?.boundaryAssessment) || hasTrialBoundaryIntegrityNote(trial);
+}
+
+function hasBoundaryAssessmentIssue(
+  assessment: ExternalEvalBoundaryAssessment | undefined,
+): assessment is ExternalEvalBoundaryAssessment {
+  return assessment !== undefined && assessment.status !== "clean";
+}
+
+function shouldDiscardBoundaryAssessment(
+  assessment: ExternalEvalBoundaryAssessment | undefined,
+): assessment is ExternalEvalBoundaryAssessment {
+  return assessment !== undefined && assessment.status === "discarded";
+}
+
+function hasTrialBoundaryIntegrityNote(trial: EvalTrial): boolean {
+  return (trial.notes ?? []).some((note) => note.startsWith("boundary_violation="));
+}
+
+function assessBoundaryObservation(
+  observation: ExternalEvalBoundaryObservation,
+  blockedPathPrefixes: readonly string[],
+  allowedPathPrefixes: readonly string[],
+): readonly ExternalEvalBoundaryViolation[] {
+  const path = normalizeBoundaryPath(observation.path);
+  if (blockedPathPrefixes.some((prefix) => boundaryPathMatchesPrefix(path, prefix))) {
+    return [buildBoundaryViolation(observation, path, "blocked-path-prefix")];
+  }
+  if (
+    allowedPathPrefixes.length > 0 &&
+    !allowedPathPrefixes.some((prefix) => boundaryPathMatchesPrefix(path, prefix))
+  ) {
+    return [buildBoundaryViolation(observation, path, "outside-allowed-path-prefix")];
+  }
+  return [];
+}
+
+function buildBoundaryViolation(
+  observation: ExternalEvalBoundaryObservation,
+  path: string,
+  reason: ExternalEvalBoundaryViolationReason,
+): ExternalEvalBoundaryViolation {
+  return {
+    trialId: observation.trialId,
+    accessKind: observation.accessKind,
+    path,
+    source: observation.source,
+    reason,
+    ...(observation.command !== undefined ? { command: observation.command } : {}),
+  };
+}
+
+function normalizeBoundaryPrefixes(prefixes: readonly string[]): readonly string[] {
+  return [...new Set(prefixes.map(normalizeBoundaryPath))];
+}
+
+function boundaryPathMatchesPrefix(path: string, prefix: string): boolean {
+  return prefix === "/" ? path.startsWith("/") : path === prefix || path.startsWith(`${prefix}/`);
+}
+
+function normalizeBoundaryPath(input: string): string {
+  const raw = input.trim().replace(/\\/g, "/");
+  if (raw.length === 0) return ".";
+
+  const absolute = raw.startsWith("/");
+  const parts: string[] = [];
+  for (const part of raw.split("/")) {
+    if (part.length === 0 || part === ".") continue;
+    if (part === "..") {
+      if (parts.length > 0 && parts[parts.length - 1] !== "..") {
+        parts.pop();
+      } else if (!absolute) {
+        parts.push(part);
+      }
+      continue;
+    }
+    parts.push(part);
+  }
+
+  const normalized = parts.join("/");
+  if (absolute) return normalized.length > 0 ? `/${normalized}` : "/";
+  return normalized.length > 0 ? normalized : ".";
 }
 
 function isInfrastructureFailureMode(errorKind: string | undefined): boolean {
@@ -895,6 +1112,18 @@ function requireOptionalString(
 ): void {
   if (Object.prototype.hasOwnProperty.call(input, field) && typeof input[field] !== "string") {
     errors.push(`${label} must be a string when present`);
+  }
+}
+
+function validateOptionalStringArray(
+  input: Readonly<Record<string, unknown>>,
+  field: string,
+  errors: string[],
+): void {
+  if (!Object.prototype.hasOwnProperty.call(input, field)) return;
+  const value = input[field];
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string" && item.length > 0)) {
+    errors.push(`${field} must be an array of non-empty strings when present`);
   }
 }
 

--- a/ts/src/control-plane/external-evals/index.ts
+++ b/ts/src/control-plane/external-evals/index.ts
@@ -259,21 +259,20 @@ export function assessExternalEvalBoundaryPolicy(
     status,
     mode: inputs.policy.mode,
     violations,
-    notes: violations.map(
-      (violation) => `boundary_violation=${violation.accessKind} ${violation.path} ${violation.reason}`,
-    ),
+    notes: boundaryViolationNotes(violations),
   };
 }
 
 export function classifyExternalEvalTrial(inputs: ClassifyExternalEvalTrialInputs): EvalTrial {
-  const status = shouldDiscardBoundaryAssessment(inputs.boundaryAssessment)
+  const scopedInputs = scopedClassifyInputs(inputs);
+  const status = shouldDiscardBoundaryAssessment(scopedInputs.boundaryAssessment)
     ? "discarded"
-    : inputs.isResolved
+    : scopedInputs.isResolved
       ? "passed"
-      : classifyUnresolvedStatus(inputs);
-  const errorKind = classifyErrorKind(inputs, status);
+      : classifyUnresolvedStatus(scopedInputs);
+  const errorKind = classifyErrorKind(scopedInputs, status);
   const reward = isScoreableTrialStatus(status) ? inputs.reward ?? defaultReward(status) : undefined;
-  const notes = buildTrialNotes(inputs);
+  const notes = buildTrialNotes(scopedInputs);
 
   return {
     taskId: inputs.taskId,
@@ -289,6 +288,23 @@ export function classifyExternalEvalTrial(inputs: ClassifyExternalEvalTrialInput
   };
 }
 
+function scopedClassifyInputs(inputs: ClassifyExternalEvalTrialInputs): ClassifyExternalEvalTrialInputs {
+  const boundaryAssessment = boundaryAssessmentForTrial(inputs.boundaryAssessment, inputs.trialId);
+  return {
+    taskId: inputs.taskId,
+    trialId: inputs.trialId,
+    attempt: inputs.attempt,
+    isResolved: inputs.isResolved,
+    ...(inputs.failureMode !== undefined ? { failureMode: inputs.failureMode } : {}),
+    ...(inputs.reward !== undefined ? { reward: inputs.reward } : {}),
+    ...(inputs.startedAt !== undefined ? { startedAt: inputs.startedAt } : {}),
+    ...(inputs.completedAt !== undefined ? { completedAt: inputs.completedAt } : {}),
+    ...(inputs.rawResultPath !== undefined ? { rawResultPath: inputs.rawResultPath } : {}),
+    ...(inputs.lifecycle !== undefined ? { lifecycle: inputs.lifecycle } : {}),
+    ...(boundaryAssessment !== undefined ? { boundaryAssessment } : {}),
+  };
+}
+
 export function buildExternalEvalDiagnosticReport(
   inputs: BuildExternalEvalDiagnosticReportInputs,
 ): ExternalEvalDiagnosticReport {
@@ -299,7 +315,7 @@ export function buildExternalEvalDiagnosticReport(
 
   const trialsWithEvidence = inputs.trials.map((trial) => ({
     trial,
-    evidence: evidenceByTrialId.get(trial.trialId),
+    evidence: scopedTrialEvidence(evidenceByTrialId.get(trial.trialId), trial.trialId),
   }));
   const diagnostics = trialsWithEvidence
     .filter(
@@ -321,7 +337,9 @@ export function buildExternalEvalDiagnosticReport(
     summary: {
       totalTrials: inputs.trials.length,
       unresolvedTrials: inputs.trials.filter((trial) => trial.status !== "passed").length,
-      runtimeIssueTrials: countsByCategory["adapter-runtime-failure"] ?? 0,
+      runtimeIssueTrials: trialsWithEvidence.filter(({ trial, evidence }) =>
+        hasRuntimeIssueForSummary(trial, evidence),
+      ).length,
       countsByCategory,
     },
   };
@@ -637,6 +655,46 @@ function buildBoundaryIntegrityExcerpts(
   return boundaryNotes;
 }
 
+function scopedTrialEvidence(
+  evidence: ExternalEvalTrialEvidence | undefined,
+  trialId: string,
+): ExternalEvalTrialEvidence | undefined {
+  if (evidence === undefined || evidence.boundaryAssessment === undefined) return evidence;
+  const boundaryAssessment = boundaryAssessmentForTrial(evidence.boundaryAssessment, trialId);
+
+  return {
+    trialId: evidence.trialId,
+    ...(evidence.evidenceRefs !== undefined ? { evidenceRefs: evidence.evidenceRefs } : {}),
+    ...(evidence.verifierOutput !== undefined ? { verifierOutput: evidence.verifierOutput } : {}),
+    ...(evidence.adapterLifecycle !== undefined ? { adapterLifecycle: evidence.adapterLifecycle } : {}),
+    ...(boundaryAssessment !== undefined ? { boundaryAssessment } : {}),
+  };
+}
+
+function boundaryAssessmentForTrial(
+  assessment: ExternalEvalBoundaryAssessment | undefined,
+  trialId: string,
+): ExternalEvalBoundaryAssessment | undefined {
+  if (assessment === undefined) return undefined;
+  const violations = assessment.violations.filter((violation) => violation.trialId === trialId);
+  if (violations.length === 0) return undefined;
+
+  return {
+    status: assessment.mode === "discard" ? "discarded" : "contaminated",
+    mode: assessment.mode,
+    violations,
+    notes: boundaryViolationNotes(violations),
+  };
+}
+
+function boundaryViolationNotes(
+  violations: readonly ExternalEvalBoundaryViolation[],
+): readonly string[] {
+  return violations.map(
+    (violation) => `boundary_violation=${violation.accessKind} ${violation.path} ${violation.reason}`,
+  );
+}
+
 function hasBoundaryIntegrityRisk(
   trial: EvalTrial,
   evidence: ExternalEvalTrialEvidence | undefined,
@@ -756,6 +814,17 @@ function isRuntimeIssueLifecycleStatus(
   status: ExternalEvalAdapterLifecycleStatus | undefined,
 ): boolean {
   return status === "failed" || status === "timed-out" || status === "cancelled";
+}
+
+function hasRuntimeIssueForSummary(
+  trial: EvalTrial,
+  evidence: ExternalEvalTrialEvidence | undefined,
+): boolean {
+  return (
+    trial.status === "infrastructure-error" ||
+    trial.status === "cancelled" ||
+    hasAdapterRuntimeIssue(trial, evidence)
+  );
 }
 
 function sanitizeVerifierOutput(output: string): readonly string[] {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -718,13 +718,16 @@ export type {
   OperationalMemoryRisk,
 } from "./control-plane/memory-packs/index.js";
 export {
+  assessExternalEvalBoundaryPolicy,
   buildExternalEvalDiagnosticReport,
   buildExternalEvalImprovementSignals,
   buildOperationalMemoryPackFromDiagnostics,
   classifyExternalEvalTrial,
   validateExternalEvalAdapterLifecycle,
+  validateExternalEvalBoundaryPolicy,
 } from "./control-plane/external-evals/index.js";
 export type {
+  AssessExternalEvalBoundaryPolicyInputs,
   BuildExternalEvalDiagnosticReportInputs,
   BuildOperationalMemoryPackFromDiagnosticsInputs,
   ClassifyExternalEvalTrialInputs,
@@ -732,6 +735,14 @@ export type {
   ExternalEvalAdapterCommand,
   ExternalEvalAdapterLifecycle,
   ExternalEvalAdapterLifecycleStatus,
+  ExternalEvalBoundaryAccessKind,
+  ExternalEvalBoundaryAssessment,
+  ExternalEvalBoundaryObservation,
+  ExternalEvalBoundaryObservationSource,
+  ExternalEvalBoundaryPolicy,
+  ExternalEvalBoundaryPolicyMode,
+  ExternalEvalBoundaryViolation,
+  ExternalEvalBoundaryViolationReason,
   ExternalEvalDiagnosticCategory,
   ExternalEvalDiagnosticReport,
   ExternalEvalImprovementSignal,

--- a/ts/tests/control-plane/external-evals/boundary-policy.test.ts
+++ b/ts/tests/control-plane/external-evals/boundary-policy.test.ts
@@ -91,6 +91,46 @@ describe("external eval benchmark boundary policy", () => {
     );
   });
 
+  test("scopes run-level boundary assessments to the classified trial", () => {
+    const boundaryAssessment = assessExternalEvalBoundaryPolicy({
+      policy,
+      observations: [
+        {
+          trialId: "bad",
+          accessKind: "read",
+          path: "/protected/answer.txt",
+          source: "tool-call",
+        },
+      ],
+    });
+
+    const goodTrial = classifyExternalEvalTrial({
+      taskId: "good-task",
+      trialId: "good",
+      attempt: 1,
+      isResolved: true,
+      boundaryAssessment,
+    });
+    const badTrial = classifyExternalEvalTrial({
+      taskId: "bad-task",
+      trialId: "bad",
+      attempt: 1,
+      isResolved: true,
+      boundaryAssessment,
+    });
+
+    expect(goodTrial.status).toBe("passed");
+    expect(goodTrial.errorKind).toBeUndefined();
+    expect(goodTrial.notes).toBeUndefined();
+    expect(badTrial).toMatchObject({
+      status: "discarded",
+      errorKind: "external-eval-boundary-violation",
+    });
+    expect(badTrial.notes).toContain(
+      "boundary_violation=read /protected/answer.txt blocked-path-prefix",
+    );
+  });
+
   test("can report boundary contamination without changing the trial score", () => {
     const boundaryAssessment = assessExternalEvalBoundaryPolicy({
       policy: { ...policy, mode: "report-only" },
@@ -127,6 +167,51 @@ describe("external eval benchmark boundary policy", () => {
     expect(report.diagnostics[0]).toMatchObject({
       category: "integrity-risk",
       confidence: 0.95,
+    });
+  });
+
+  test("scopes run-level boundary diagnostics to the affected trial", () => {
+    const boundaryAssessment = assessExternalEvalBoundaryPolicy({
+      policy,
+      observations: [
+        {
+          trialId: "bad",
+          accessKind: "read",
+          path: "/protected/answer.txt",
+          source: "trace",
+        },
+      ],
+    });
+
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-run-1",
+      createdAt: "2026-05-08T15:29:00.000Z",
+      trials: [
+        {
+          taskId: "good-task",
+          trialId: "good",
+          attempt: 1,
+          status: "passed",
+          reward: 1,
+        },
+        {
+          taskId: "bad-task",
+          trialId: "bad",
+          attempt: 1,
+          status: "passed",
+          reward: 1,
+        },
+      ],
+      evidence: [
+        { trialId: "good", boundaryAssessment },
+        { trialId: "bad", boundaryAssessment },
+      ],
+    });
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      trialId: "bad",
+      category: "integrity-risk",
     });
   });
 
@@ -174,5 +259,48 @@ describe("external eval benchmark boundary policy", () => {
       "boundary_violation=search / outside-allowed-path-prefix",
     ]);
     expect(report.summary.countsByCategory).toEqual({ "integrity-risk": 1 });
+  });
+
+  test("counts runtime issues even when integrity risk is the primary diagnostic", () => {
+    const boundaryAssessment = assessExternalEvalBoundaryPolicy({
+      policy,
+      observations: [
+        {
+          trialId: "infra-with-boundary",
+          accessKind: "read",
+          path: "/protected",
+          source: "adapter-log",
+        },
+      ],
+    });
+
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-run-1",
+      createdAt: "2026-05-08T15:31:00.000Z",
+      trials: [
+        {
+          taskId: "infra-with-boundary",
+          trialId: "infra-with-boundary",
+          attempt: 1,
+          status: "infrastructure-error",
+          errorKind: "adapter-crash",
+        },
+      ],
+      evidence: [
+        {
+          trialId: "infra-with-boundary",
+          boundaryAssessment,
+        },
+      ],
+    });
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      category: "integrity-risk",
+    });
+    expect(report.summary).toMatchObject({
+      runtimeIssueTrials: 1,
+      countsByCategory: { "integrity-risk": 1 },
+    });
   });
 });

--- a/ts/tests/control-plane/external-evals/boundary-policy.test.ts
+++ b/ts/tests/control-plane/external-evals/boundary-policy.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "vitest";
+import {
+  assessExternalEvalBoundaryPolicy,
+  buildExternalEvalDiagnosticReport,
+  classifyExternalEvalTrial,
+  validateExternalEvalBoundaryPolicy,
+} from "../../../src/control-plane/external-evals/index.js";
+
+describe("external eval benchmark boundary policy", () => {
+  const policy = {
+    mode: "discard",
+    blockedPathPrefixes: ["/protected"],
+    allowedPathPrefixes: ["/workspace"],
+  } as const;
+
+  test("validates explicit benchmark boundary policy configuration", () => {
+    expect(validateExternalEvalBoundaryPolicy(policy)).toEqual({ valid: true });
+
+    const invalid = validateExternalEvalBoundaryPolicy({
+      mode: "discard",
+      blockedPathPrefixes: [],
+      allowedPathPrefixes: [],
+    });
+
+    expect(invalid.valid).toBe(false);
+    if (!invalid.valid) {
+      expect(invalid.errors).toContain(
+        "boundary policy must declare at least one blocked or allowed path prefix",
+      );
+    }
+  });
+
+  test("flags normalized verifier-only path access as contaminated evidence", () => {
+    const assessment = assessExternalEvalBoundaryPolicy({
+      policy,
+      observations: [
+        {
+          trialId: "task.1-of-1.tb-run-1",
+          accessKind: "read",
+          path: "/workspace/../protected/answer.txt",
+          source: "tool-call",
+        },
+      ],
+    });
+
+    expect(assessment.status).toBe("discarded");
+    expect(assessment.violations).toEqual([
+      {
+        trialId: "task.1-of-1.tb-run-1",
+        accessKind: "read",
+        path: "/protected/answer.txt",
+        source: "tool-call",
+        reason: "blocked-path-prefix",
+      },
+    ]);
+    expect(assessment.notes).toContain(
+      "boundary_violation=read /protected/answer.txt blocked-path-prefix",
+    );
+  });
+
+  test("discards otherwise resolved trials when boundary policy is violated", () => {
+    const boundaryAssessment = assessExternalEvalBoundaryPolicy({
+      policy,
+      observations: [
+        {
+          trialId: "task.1-of-1.tb-run-1",
+          accessKind: "list",
+          path: "/protected",
+          source: "adapter-log",
+        },
+      ],
+    });
+
+    const trial = classifyExternalEvalTrial({
+      taskId: "task",
+      trialId: "task.1-of-1.tb-run-1",
+      attempt: 1,
+      isResolved: true,
+      reward: 1,
+      boundaryAssessment,
+    });
+
+    expect(trial).toMatchObject({
+      status: "discarded",
+      errorKind: "external-eval-boundary-violation",
+    });
+    expect(trial.reward).toBeUndefined();
+    expect(trial.notes).toContain("integrity_status=discarded");
+    expect(trial.notes).toContain(
+      "boundary_violation=list /protected blocked-path-prefix",
+    );
+  });
+
+  test("can report boundary contamination without changing the trial score", () => {
+    const boundaryAssessment = assessExternalEvalBoundaryPolicy({
+      policy: { ...policy, mode: "report-only" },
+      observations: [
+        {
+          trialId: "task.1-of-1.tb-run-1",
+          accessKind: "read",
+          path: "/protected",
+          source: "trace",
+        },
+      ],
+    });
+
+    const trial = classifyExternalEvalTrial({
+      taskId: "task",
+      trialId: "task.1-of-1.tb-run-1",
+      attempt: 1,
+      isResolved: true,
+      boundaryAssessment,
+    });
+
+    expect(boundaryAssessment.status).toBe("contaminated");
+    expect(trial.status).toBe("passed");
+    expect(trial.reward).toBe(1);
+    expect(trial.notes).toContain("integrity_status=contaminated");
+
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-run-1",
+      createdAt: "2026-05-08T15:28:00.000Z",
+      trials: [trial],
+    });
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      category: "integrity-risk",
+      confidence: 0.95,
+    });
+  });
+
+  test("keeps evidence-only boundary violations visible as integrity diagnostics", () => {
+    const boundaryAssessment = assessExternalEvalBoundaryPolicy({
+      policy,
+      observations: [
+        {
+          trialId: "task.1-of-1.tb-run-1",
+          accessKind: "search",
+          path: "/",
+          source: "adapter-command",
+          command: "find / -name '*answer*'",
+        },
+      ],
+    });
+
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-run-1",
+      createdAt: "2026-05-08T15:30:00.000Z",
+      trials: [
+        {
+          taskId: "task",
+          trialId: "task.1-of-1.tb-run-1",
+          attempt: 1,
+          status: "passed",
+          reward: 1,
+        },
+      ],
+      evidence: [
+        {
+          trialId: "task.1-of-1.tb-run-1",
+          boundaryAssessment,
+        },
+      ],
+    });
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      category: "integrity-risk",
+      confidence: 0.95,
+    });
+    expect(report.diagnostics[0]?.failureExcerpts).toEqual([
+      "integrity_status=discarded",
+      "boundary_violation=search / outside-allowed-path-prefix",
+    ]);
+    expect(report.summary.countsByCategory).toEqual({ "integrity-risk": 1 });
+  });
+});

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -29,6 +29,8 @@ describe("package root exports", () => {
     expect(pkg.probeDirectoryContract).toBeDefined();
     expect(pkg.validateOperationalMemoryPack).toBeDefined();
     expect(pkg.classifyExternalEvalTrial).toBeDefined();
+    expect(pkg.assessExternalEvalBoundaryPolicy).toBeDefined();
+    expect(pkg.validateExternalEvalBoundaryPolicy).toBeDefined();
     expect(pkg.buildExternalEvalDiagnosticReport).toBeDefined();
     expect(pkg.buildExternalEvalImprovementSignals).toBeDefined();
     expect(pkg.buildOperationalMemoryPackFromDiagnostics).toBeDefined();


### PR DESCRIPTION
## Summary
- add an external-eval boundary policy API for explicit blocked/allowed benchmark path controls
- let boundary assessments discard contaminated trials or surface report-only contamination as integrity-risk diagnostics
- export the new helpers from the package root and cover the policy/classification/reporting behavior

## Verification
- npm test -- --run tests/control-plane/external-evals/boundary-policy.test.ts tests/control-plane/external-evals/diagnostics.test.ts tests/control-plane/external-evals/lifecycle.test.ts tests/package-export-catalogs.test.ts
- npm run lint
- npm run build
- npm test