### PR TITLE
Add runtime-session RunTrace adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - TypeScript runtime workspace command grants now expose structured start/end/error observability events, a no-shell local process wrapper with explicit env inheritance, redacted/truncated command output previews, child-task inheritance policy, and scoped command/tool grant types for runtime-session calls without serializing trusted env values into prompts or session logs.
 - The canonical concept model now documents durable runtime-session event storage as an `Artifact` model for provider turns, shell/tool activity, child-task lineage, compaction summaries, replay, and the boundary with `RunTrace`/production traces.
 - Python and TypeScript runtime-session logs now record semantic compaction ledger writes as `COMPACTION` events with entry ids, component names, ledger paths, and generation metadata for replay timelines; TypeScript records the hook-finalized ledger entries and paths after artifact write hooks run.
+- Python and TypeScript now expose explicit runtime-session-to-`RunTrace` adapters for analytics reuse, mapping child-task lineage, command/tool status, and compaction artifact references without copying raw prompts, model responses, stdout/stderr, or arbitrary runtime metadata.
 
 ### Fixed
 

--- a/autocontext/src/autocontext/analytics/__init__.py
+++ b/autocontext/src/autocontext/analytics/__init__.py
@@ -1,1 +1,5 @@
 """Aggregate analytics for cross-run facets, signal extraction, and pattern clustering."""
+
+from autocontext.analytics.runtime_session_run_trace import runtime_session_log_to_run_trace
+
+__all__ = ["runtime_session_log_to_run_trace"]

--- a/autocontext/src/autocontext/analytics/runtime_session_run_trace.py
+++ b/autocontext/src/autocontext/analytics/runtime_session_run_trace.py
@@ -36,21 +36,24 @@ def runtime_session_log_to_run_trace(
     resolved_run_id = run_id or _infer_run_id(log)
     resolved_scenario = scenario_name or _infer_scenario_name(log)
     child_start_by_session: dict[str, str] = {}
+    prompt_by_request_id: dict[str, str] = {}
+    trace_event_by_runtime_event_id: dict[str, str] = {}
+    previous_by_session_id: dict[str, str] = {}
     events: list[TraceEvent] = []
     causal_edges: list[CausalEdge] = []
     previous_event_id: str | None = None
 
     for sequence_number, record in enumerate(records, start=1):
         event_id = f"runtime-{record.event.event_id}"
-        if record.event.event_type == RuntimeSessionEventType.CHILD_TASK_STARTED:
-            child_session_id = _read_str(record.event.payload.get("childSessionId"))
-            if child_session_id:
-                child_start_by_session[child_session_id] = event_id
-
-        lineage_parent_id = ""
-        if record.log.parent_session_id:
-            lineage_parent_id = child_start_by_session.get(record.log.session_id, "")
-        parent_event_id = lineage_parent_id or previous_event_id
+        session_id = _runtime_session_id(record)
+        parent_event_id = _parent_event_id_for(
+            record,
+            prompt_by_request_id=prompt_by_request_id,
+            trace_event_by_runtime_event_id=trace_event_by_runtime_event_id,
+            previous_by_session_id=previous_by_session_id,
+            child_start_by_session=child_start_by_session,
+            previous_event_id=previous_event_id,
+        )
         cause_event_ids = [parent_event_id] if parent_event_id else []
         trace_event = TraceEvent(
             event_id=event_id,
@@ -87,6 +90,16 @@ def runtime_session_log_to_run_trace(
                 )
             )
         previous_event_id = event_id
+        previous_by_session_id[session_id] = event_id
+        trace_event_by_runtime_event_id[record.event.event_id] = event_id
+        if record.event.event_type == RuntimeSessionEventType.PROMPT_SUBMITTED:
+            request_id = _read_str(record.event.payload.get("requestId"))
+            if request_id:
+                prompt_by_request_id[request_id] = event_id
+        if record.event.event_type == RuntimeSessionEventType.CHILD_TASK_STARTED:
+            child_session_id = _read_str(record.event.payload.get("childSessionId"))
+            if child_session_id:
+                child_start_by_session[child_session_id] = event_id
 
     created_at = events[0].timestamp if events else log.created_at
     return RunTrace(
@@ -105,6 +118,46 @@ def runtime_session_log_to_run_trace(
             "event_count": len(events),
         },
     )
+
+
+def _parent_event_id_for(
+    record: _RuntimeEventRecord,
+    *,
+    prompt_by_request_id: dict[str, str],
+    trace_event_by_runtime_event_id: dict[str, str],
+    previous_by_session_id: dict[str, str],
+    child_start_by_session: dict[str, str],
+    previous_event_id: str | None,
+) -> str | None:
+    payload = record.event.payload
+    prompt_event_id = _read_str(payload.get("promptEventId"))
+    if prompt_event_id:
+        correlated_parent_id = trace_event_by_runtime_event_id.get(prompt_event_id)
+        if correlated_parent_id:
+            return correlated_parent_id
+
+    if record.event.event_type != RuntimeSessionEventType.PROMPT_SUBMITTED:
+        request_id = _read_str(payload.get("requestId"))
+        if request_id:
+            correlated_parent_id = prompt_by_request_id.get(request_id)
+            if correlated_parent_id:
+                return correlated_parent_id
+
+    session_id = _runtime_session_id(record)
+    previous_session_event_id = previous_by_session_id.get(session_id)
+    if previous_session_event_id:
+        return previous_session_event_id
+
+    if record.log.parent_session_id:
+        child_start_event_id = child_start_by_session.get(record.log.session_id)
+        if child_start_event_id:
+            return child_start_event_id
+
+    return previous_event_id
+
+
+def _runtime_session_id(record: _RuntimeEventRecord) -> str:
+    return record.event.session_id or record.log.session_id
 
 
 def _flatten_runtime_events(
@@ -298,7 +351,7 @@ def _infer_scenario_name(log: RuntimeSessionEventLog) -> str:
 
 def _copy_str(source: dict[str, Any], target: dict[str, Any], source_key: str, target_key: str) -> None:
     value = _read_str(source.get(source_key))
-    if value and target_key not in target:
+    if value and not _read_str(target.get(target_key)):
         target[target_key] = value
 
 

--- a/autocontext/src/autocontext/analytics/runtime_session_run_trace.py
+++ b/autocontext/src/autocontext/analytics/runtime_session_run_trace.py
@@ -1,0 +1,335 @@
+"""Adapt runtime-session observability logs into canonical RunTrace artifacts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from math import isfinite
+from typing import Any
+
+from autocontext.analytics.run_trace import ActorRef, CausalEdge, ResourceRef, RunTrace, TraceEvent
+from autocontext.session.runtime_events import RuntimeSessionEvent, RuntimeSessionEventLog, RuntimeSessionEventType
+
+
+@dataclass(frozen=True)
+class _RuntimeEventRecord:
+    event: RuntimeSessionEvent
+    log: RuntimeSessionEventLog
+    log_index: int
+
+
+def runtime_session_log_to_run_trace(
+    log: RuntimeSessionEventLog,
+    *,
+    run_id: str | None = None,
+    scenario_name: str | None = None,
+    child_logs: list[RuntimeSessionEventLog] | None = None,
+    trace_id: str | None = None,
+) -> RunTrace:
+    """Build a deterministic RunTrace from selected runtime-session events.
+
+    Runtime-session logs can contain prompts, model outputs, and arbitrary
+    handler metadata. This adapter intentionally maps only a small allowlist of
+    lineage and artifact-reference fields into the analytics trace.
+    """
+    records = _flatten_runtime_events(log, child_logs or [])
+    resolved_run_id = run_id or _infer_run_id(log)
+    resolved_scenario = scenario_name or _infer_scenario_name(log)
+    child_start_by_session: dict[str, str] = {}
+    events: list[TraceEvent] = []
+    causal_edges: list[CausalEdge] = []
+    previous_event_id: str | None = None
+
+    for sequence_number, record in enumerate(records, start=1):
+        event_id = f"runtime-{record.event.event_id}"
+        if record.event.event_type == RuntimeSessionEventType.CHILD_TASK_STARTED:
+            child_session_id = _read_str(record.event.payload.get("childSessionId"))
+            if child_session_id:
+                child_start_by_session[child_session_id] = event_id
+
+        lineage_parent_id = ""
+        if record.log.parent_session_id:
+            lineage_parent_id = child_start_by_session.get(record.log.session_id, "")
+        parent_event_id = lineage_parent_id or previous_event_id
+        cause_event_ids = [parent_event_id] if parent_event_id else []
+        trace_event = TraceEvent(
+            event_id=event_id,
+            run_id=resolved_run_id,
+            generation_index=_generation_index(record.event),
+            sequence_number=sequence_number,
+            timestamp=record.event.timestamp,
+            category=_category_for(record.event),
+            event_type=_trace_event_type(record.event),
+            actor=_actor_for(record),
+            resources=_resources_for(record.event),
+            summary=_summary_for(record.event),
+            detail=_detail_for(record),
+            parent_event_id=parent_event_id,
+            cause_event_ids=cause_event_ids,
+            evidence_ids=[],
+            severity=_severity_for(record.event),
+            stage=_stage_for(record),
+            outcome=_outcome_for(record.event),
+            duration_ms=None,
+            metadata={
+                "scenario": resolved_scenario,
+                "source": "runtime_session",
+                "runtime_session_id": record.log.session_id,
+            },
+        )
+        events.append(trace_event)
+        if parent_event_id:
+            causal_edges.append(
+                CausalEdge(
+                    source_event_id=parent_event_id,
+                    target_event_id=event_id,
+                    relation="triggers",
+                )
+            )
+        previous_event_id = event_id
+
+    created_at = events[0].timestamp if events else log.created_at
+    return RunTrace(
+        trace_id=trace_id or f"trace-{resolved_run_id}-runtime-session",
+        run_id=resolved_run_id,
+        generation_index=None,
+        schema_version="1.0.0",
+        events=events,
+        causal_edges=causal_edges,
+        created_at=created_at,
+        metadata={
+            "scenario": resolved_scenario,
+            "source": "runtime_session",
+            "source_session_id": log.session_id,
+            "child_session_count": len(child_logs or []),
+            "event_count": len(events),
+        },
+    )
+
+
+def _flatten_runtime_events(
+    log: RuntimeSessionEventLog,
+    child_logs: list[RuntimeSessionEventLog],
+) -> list[_RuntimeEventRecord]:
+    records: list[_RuntimeEventRecord] = []
+    for log_index, current_log in enumerate([log, *child_logs]):
+        records.extend(
+            _RuntimeEventRecord(event=event, log=current_log, log_index=log_index)
+            for event in current_log.events
+        )
+    return sorted(
+        records,
+        key=lambda record: (
+            record.event.timestamp,
+            record.log_index,
+            record.event.sequence,
+            record.event.event_id,
+        ),
+    )
+
+
+def _trace_event_type(event: RuntimeSessionEvent) -> str:
+    return f"runtime_{event.event_type.value}"
+
+
+def _actor_for(record: _RuntimeEventRecord) -> ActorRef:
+    event = record.event
+    payload = event.payload
+    if event.event_type == RuntimeSessionEventType.SHELL_COMMAND:
+        command_name = _read_str(payload.get("commandName")) or _read_str(payload.get("command")) or "command"
+        return ActorRef(actor_type="tool", actor_id=command_name, actor_name=command_name)
+    if event.event_type == RuntimeSessionEventType.TOOL_CALL:
+        tool_name = _read_str(payload.get("toolName")) or _read_str(payload.get("tool")) or "tool"
+        return ActorRef(actor_type="tool", actor_id=tool_name, actor_name=tool_name)
+    if event.event_type in {RuntimeSessionEventType.CHILD_TASK_STARTED, RuntimeSessionEventType.CHILD_TASK_COMPLETED}:
+        return ActorRef(actor_type="system", actor_id="runtime_session", actor_name="runtime_session")
+    if event.event_type == RuntimeSessionEventType.COMPACTION:
+        return ActorRef(actor_type="system", actor_id="compaction_ledger", actor_name="compaction_ledger")
+    role = _read_str(payload.get("role")) or _read_str(record.log.metadata.get("role")) or "runtime"
+    return ActorRef(actor_type="role", actor_id=role, actor_name=role)
+
+
+def _detail_for(record: _RuntimeEventRecord) -> dict[str, Any]:
+    event = record.event
+    payload = event.payload
+    detail: dict[str, Any] = {
+        "runtime_session_id": event.session_id or record.log.session_id,
+        "runtime_event_id": event.event_id,
+        "runtime_event_type": event.event_type.value,
+        "sequence": event.sequence,
+        "parent_session_id": event.parent_session_id or record.log.parent_session_id,
+        "task_id": event.task_id or record.log.task_id,
+        "worker_id": event.worker_id or record.log.worker_id,
+    }
+    _copy_str(payload, detail, "requestId", "request_id")
+    _copy_str(payload, detail, "promptEventId", "prompt_event_id")
+    _copy_str(payload, detail, "role", "role")
+    _copy_str(payload, detail, "cwd", "cwd")
+    _copy_str(payload, detail, "phase", "phase")
+    _copy_str(payload, detail, "commandName", "command_name")
+    _copy_str(payload, detail, "command", "command_name")
+    _copy_str(payload, detail, "toolName", "tool_name")
+    _copy_str(payload, detail, "tool", "tool_name")
+    _copy_str(payload, detail, "argsSummary", "args_summary")
+    _copy_str(payload, detail, "taskId", "task_id")
+    _copy_str(payload, detail, "childSessionId", "child_session_id")
+    _copy_str(payload, detail, "workerId", "worker_id")
+    _copy_str(payload, detail, "entryId", "entry_id")
+    _copy_str(payload, detail, "components", "components")
+    _copy_str(payload, detail, "ledgerPath", "ledger_path")
+    _copy_str(payload, detail, "latestEntryPath", "latest_entry_path")
+    _copy_str(payload, detail, "firstKeptEntryId", "first_kept_entry_id")
+    _copy_str(payload, detail, "promotedKnowledgeId", "promoted_knowledge_id")
+    _copy_str(payload, detail, "runId", "run_id")
+    _copy_number(payload, detail, "exitCode", "exit_code")
+    _copy_number(payload, detail, "depth", "depth")
+    _copy_number(payload, detail, "maxDepth", "max_depth")
+    _copy_number(payload, detail, "entryCount", "entry_count")
+    _copy_number(payload, detail, "generation", "generation")
+    _copy_number(payload, detail, "tokensBefore", "tokens_before")
+    _copy_bool(payload, detail, "isError", "is_error")
+    _copy_str_list(payload, detail, "entryIds", "entry_ids")
+    return _json_safe_record(detail)
+
+
+def _resources_for(event: RuntimeSessionEvent) -> list[ResourceRef]:
+    if event.event_type != RuntimeSessionEventType.COMPACTION:
+        return []
+    ledger_path = _read_str(event.payload.get("ledgerPath"))
+    entry_id = _read_str(event.payload.get("entryId")) or "compaction"
+    if not ledger_path:
+        return []
+    return [
+        ResourceRef(
+            resource_type="artifact",
+            resource_id=entry_id,
+            resource_name="compaction_ledger",
+            resource_path=ledger_path,
+        )
+    ]
+
+
+def _category_for(event: RuntimeSessionEvent) -> str:
+    if event.event_type in {RuntimeSessionEventType.SHELL_COMMAND, RuntimeSessionEventType.TOOL_CALL}:
+        return "tool_invocation"
+    if event.event_type == RuntimeSessionEventType.ASSISTANT_MESSAGE and _is_error(event):
+        return "failure"
+    if event.event_type == RuntimeSessionEventType.COMPACTION:
+        return "checkpoint"
+    return "action" if event.event_type != RuntimeSessionEventType.ASSISTANT_MESSAGE else "observation"
+
+
+def _stage_for(record: _RuntimeEventRecord) -> str:
+    if record.event.event_type == RuntimeSessionEventType.COMPACTION:
+        return "curate"
+    role = _read_str(record.event.payload.get("role")) or _read_str(record.log.metadata.get("role"))
+    return {
+        "competitor": "compete",
+        "analyst": "analyze",
+        "coach": "coach",
+        "architect": "architect",
+        "curator": "curate",
+    }.get(role, "init")
+
+
+def _severity_for(event: RuntimeSessionEvent) -> str:
+    if _is_error(event):
+        return "error"
+    exit_code = event.payload.get("exitCode")
+    finite_exit_code = _finite_number(exit_code)
+    if finite_exit_code is not None and finite_exit_code != 0:
+        return "error"
+    return "info"
+
+
+def _outcome_for(event: RuntimeSessionEvent) -> str | None:
+    if _is_error(event):
+        return "error"
+    phase = _read_str(event.payload.get("phase"))
+    if phase:
+        return phase
+    if event.event_type == RuntimeSessionEventType.CHILD_TASK_STARTED:
+        return "started"
+    if event.event_type == RuntimeSessionEventType.CHILD_TASK_COMPLETED:
+        return "completed"
+    return None
+
+
+def _summary_for(event: RuntimeSessionEvent) -> str:
+    if event.event_type == RuntimeSessionEventType.SHELL_COMMAND:
+        name = _read_str(event.payload.get("commandName")) or _read_str(event.payload.get("command")) or "command"
+        return f"Runtime shell command {name}"
+    if event.event_type == RuntimeSessionEventType.TOOL_CALL:
+        name = _read_str(event.payload.get("toolName")) or _read_str(event.payload.get("tool")) or "tool"
+        return f"Runtime tool call {name}"
+    if event.event_type == RuntimeSessionEventType.COMPACTION:
+        entry_id = _read_str(event.payload.get("entryId"))
+        return f"Runtime compaction {entry_id}".strip()
+    return _trace_event_type(event).replace("_", " ")
+
+
+def _generation_index(event: RuntimeSessionEvent) -> int:
+    value = _finite_number(event.payload.get("generation"))
+    return int(value) if value is not None else 0
+
+
+def _is_error(event: RuntimeSessionEvent) -> bool:
+    return event.payload.get("isError") is True or _read_str(event.payload.get("phase")) == "error"
+
+
+def _infer_run_id(log: RuntimeSessionEventLog) -> str:
+    metadata_run_id = _read_str(log.metadata.get("runId"))
+    if metadata_run_id:
+        return metadata_run_id
+    for event in log.events:
+        event_run_id = _read_str(event.payload.get("runId"))
+        if event_run_id:
+            return event_run_id
+    prefix = "run:"
+    suffix = ":runtime"
+    if log.session_id.startswith(prefix) and log.session_id.endswith(suffix):
+        return log.session_id[len(prefix):-len(suffix)]
+    return log.session_id
+
+
+def _infer_scenario_name(log: RuntimeSessionEventLog) -> str:
+    return _read_str(log.metadata.get("scenarioName")) or _read_str(log.metadata.get("scenario")) or "runtime_session"
+
+
+def _copy_str(source: dict[str, Any], target: dict[str, Any], source_key: str, target_key: str) -> None:
+    value = _read_str(source.get(source_key))
+    if value and target_key not in target:
+        target[target_key] = value
+
+
+def _copy_number(source: dict[str, Any], target: dict[str, Any], source_key: str, target_key: str) -> None:
+    value = _finite_number(source.get(source_key))
+    if value is not None:
+        target[target_key] = value
+
+
+def _copy_bool(source: dict[str, Any], target: dict[str, Any], source_key: str, target_key: str) -> None:
+    value = source.get(source_key)
+    if isinstance(value, bool):
+        target[target_key] = value
+
+
+def _copy_str_list(source: dict[str, Any], target: dict[str, Any], source_key: str, target_key: str) -> None:
+    value = source.get(source_key)
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        target[target_key] = list(value)
+
+
+def _json_safe_record(value: dict[str, Any]) -> dict[str, Any]:
+    parsed = json.loads(json.dumps(value, default=str))
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _read_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _finite_number(value: Any) -> int | float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and isfinite(float(value)):
+        return value
+    return None

--- a/autocontext/tests/test_runtime_session_run_trace.py
+++ b/autocontext/tests/test_runtime_session_run_trace.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+
+from autocontext.session.runtime_events import RuntimeSessionEventLog, RuntimeSessionEventType
+
+
+def test_runtime_session_log_to_run_trace_maps_allowlisted_events() -> None:
+    from autocontext.analytics.runtime_session_run_trace import runtime_session_log_to_run_trace
+
+    parent_log = RuntimeSessionEventLog.from_dict(
+        {
+            "sessionId": "run:run-1:runtime",
+            "parentSessionId": "",
+            "taskId": "",
+            "workerId": "",
+            "metadata": {
+                "runId": "run-1",
+                "scenarioName": "grid_ctf",
+                "secret": "do-not-export",
+            },
+            "createdAt": "2026-05-10T10:00:00.000Z",
+            "updatedAt": "2026-05-10T10:00:05.000Z",
+            "events": [
+                {
+                    "eventId": "prompt-1",
+                    "sessionId": "run:run-1:runtime",
+                    "sequence": 0,
+                    "eventType": RuntimeSessionEventType.PROMPT_SUBMITTED.value,
+                    "timestamp": "2026-05-10T10:00:00.000Z",
+                    "payload": {
+                        "requestId": "req-1",
+                        "role": "analyst",
+                        "cwd": "/workspace",
+                        "prompt": "secret prompt text",
+                    },
+                },
+                {
+                    "eventId": "shell-1",
+                    "sessionId": "run:run-1:runtime",
+                    "sequence": 1,
+                    "eventType": RuntimeSessionEventType.SHELL_COMMAND.value,
+                    "timestamp": "2026-05-10T10:00:01.000Z",
+                    "payload": {
+                        "requestId": "req-1",
+                        "promptEventId": "prompt-1",
+                        "commandName": "verify",
+                        "phase": "end",
+                        "cwd": "/workspace",
+                        "exitCode": 0,
+                        "argsSummary": "verify --quick",
+                        "stdout": "do-not-export",
+                    },
+                },
+                {
+                    "eventId": "child-start",
+                    "sessionId": "run:run-1:runtime",
+                    "sequence": 2,
+                    "eventType": RuntimeSessionEventType.CHILD_TASK_STARTED.value,
+                    "timestamp": "2026-05-10T10:00:02.000Z",
+                    "payload": {
+                        "taskId": "retry",
+                        "childSessionId": "task:run:run-1:runtime:retry:w-1",
+                        "workerId": "w-1",
+                        "role": "coach",
+                        "cwd": "/workspace",
+                        "depth": 1,
+                    },
+                },
+                {
+                    "eventId": "child-done",
+                    "sessionId": "run:run-1:runtime",
+                    "sequence": 3,
+                    "eventType": RuntimeSessionEventType.CHILD_TASK_COMPLETED.value,
+                    "timestamp": "2026-05-10T10:00:04.000Z",
+                    "payload": {
+                        "taskId": "retry",
+                        "childSessionId": "task:run:run-1:runtime:retry:w-1",
+                        "workerId": "w-1",
+                        "role": "coach",
+                        "result": "do-not-export",
+                        "isError": False,
+                    },
+                },
+                {
+                    "eventId": "cmp-1",
+                    "sessionId": "run:run-1:runtime",
+                    "sequence": 4,
+                    "eventType": RuntimeSessionEventType.COMPACTION.value,
+                    "timestamp": "2026-05-10T10:00:05.000Z",
+                    "payload": {
+                        "runId": "run-1",
+                        "entryId": "entry-redacted",
+                        "entryIds": ["entry-redacted"],
+                        "entryCount": 1,
+                        "components": "session_reports",
+                        "ledgerPath": "/runs/run-1/compactions.jsonl",
+                        "latestEntryPath": "/runs/run-1/compactions.latest",
+                        "generation": 2,
+                        "summary": "do-not-export",
+                    },
+                },
+            ],
+        }
+    )
+    child_log = RuntimeSessionEventLog.from_dict(
+        {
+            "sessionId": "task:run:run-1:runtime:retry:w-1",
+            "parentSessionId": "run:run-1:runtime",
+            "taskId": "retry",
+            "workerId": "w-1",
+            "metadata": {"role": "coach", "secret": "do-not-export"},
+            "createdAt": "2026-05-10T10:00:02.500Z",
+            "updatedAt": "2026-05-10T10:00:03.000Z",
+            "events": [
+                {
+                    "eventId": "child-prompt",
+                    "sessionId": "task:run:run-1:runtime:retry:w-1",
+                    "sequence": 0,
+                    "eventType": RuntimeSessionEventType.PROMPT_SUBMITTED.value,
+                    "timestamp": "2026-05-10T10:00:02.500Z",
+                    "parentSessionId": "run:run-1:runtime",
+                    "taskId": "retry",
+                    "workerId": "w-1",
+                    "payload": {
+                        "role": "coach",
+                        "prompt": "child prompt text",
+                        "cwd": "/workspace",
+                    },
+                },
+                {
+                    "eventId": "child-answer",
+                    "sessionId": "task:run:run-1:runtime:retry:w-1",
+                    "sequence": 1,
+                    "eventType": RuntimeSessionEventType.ASSISTANT_MESSAGE.value,
+                    "timestamp": "2026-05-10T10:00:03.000Z",
+                    "parentSessionId": "run:run-1:runtime",
+                    "taskId": "retry",
+                    "workerId": "w-1",
+                    "payload": {
+                        "role": "coach",
+                        "text": "child answer text",
+                        "metadata": {"secret": "do-not-export"},
+                    },
+                },
+            ],
+        }
+    )
+
+    trace = runtime_session_log_to_run_trace(parent_log, child_logs=[child_log])
+
+    assert trace.run_id == "run-1"
+    assert trace.metadata["scenario"] == "grid_ctf"
+    assert trace.created_at == "2026-05-10T10:00:00.000Z"
+    assert [event.event_type for event in trace.events] == [
+        "runtime_prompt_submitted",
+        "runtime_shell_command",
+        "runtime_child_task_started",
+        "runtime_prompt_submitted",
+        "runtime_assistant_message",
+        "runtime_child_task_completed",
+        "runtime_compaction",
+    ]
+
+    prompt_event = trace.events[0]
+    assert prompt_event.actor.actor_type == "role"
+    assert prompt_event.actor.actor_id == "analyst"
+    assert prompt_event.detail["runtime_session_id"] == "run:run-1:runtime"
+    assert prompt_event.detail["runtime_event_id"] == "prompt-1"
+    assert prompt_event.detail["request_id"] == "req-1"
+    assert "prompt" not in prompt_event.detail
+
+    shell_event = trace.events[1]
+    assert shell_event.category == "tool_invocation"
+    assert shell_event.detail["command_name"] == "verify"
+    assert shell_event.detail["exit_code"] == 0
+    assert "stdout" not in shell_event.detail
+
+    child_prompt = trace.events[3]
+    assert child_prompt.parent_event_id == "runtime-child-start"
+    assert child_prompt.detail["parent_session_id"] == "run:run-1:runtime"
+    assert child_prompt.detail["task_id"] == "retry"
+    assert child_prompt.detail["worker_id"] == "w-1"
+
+    compaction_event = trace.events[-1]
+    assert compaction_event.category == "checkpoint"
+    assert compaction_event.detail["entry_id"] == "entry-redacted"
+    assert compaction_event.detail["entry_ids"] == ["entry-redacted"]
+    assert compaction_event.detail["ledger_path"] == "/runs/run-1/compactions.jsonl"
+    assert compaction_event.resources[0].resource_type == "artifact"
+    assert compaction_event.resources[0].resource_id == "entry-redacted"
+
+    serialized = json.dumps(trace.to_dict(), sort_keys=True)
+    assert "do-not-export" not in serialized
+    assert "secret prompt text" not in serialized
+    assert "child answer text" not in serialized

--- a/autocontext/tests/test_runtime_session_run_trace.py
+++ b/autocontext/tests/test_runtime_session_run_trace.py
@@ -176,11 +176,21 @@ def test_runtime_session_log_to_run_trace_maps_allowlisted_events() -> None:
     assert shell_event.detail["exit_code"] == 0
     assert "stdout" not in shell_event.detail
 
+    child_start = trace.events[2]
+    assert child_start.detail["task_id"] == "retry"
+    assert child_start.detail["worker_id"] == "w-1"
+    assert child_start.detail["child_session_id"] == "task:run:run-1:runtime:retry:w-1"
+
     child_prompt = trace.events[3]
     assert child_prompt.parent_event_id == "runtime-child-start"
     assert child_prompt.detail["parent_session_id"] == "run:run-1:runtime"
     assert child_prompt.detail["task_id"] == "retry"
     assert child_prompt.detail["worker_id"] == "w-1"
+
+    child_done = trace.events[5]
+    assert child_done.detail["task_id"] == "retry"
+    assert child_done.detail["worker_id"] == "w-1"
+    assert child_done.detail["child_session_id"] == "task:run:run-1:runtime:retry:w-1"
 
     compaction_event = trace.events[-1]
     assert compaction_event.category == "checkpoint"
@@ -194,3 +204,76 @@ def test_runtime_session_log_to_run_trace_maps_allowlisted_events() -> None:
     assert "do-not-export" not in serialized
     assert "secret prompt text" not in serialized
     assert "child answer text" not in serialized
+
+
+def test_runtime_session_log_to_run_trace_correlates_concurrent_prompt_responses() -> None:
+    from autocontext.analytics.runtime_session_run_trace import runtime_session_log_to_run_trace
+
+    log = RuntimeSessionEventLog.from_dict(
+        {
+            "sessionId": "run:run-2:runtime",
+            "metadata": {"runId": "run-2", "scenarioName": "grid_ctf"},
+            "createdAt": "2026-05-10T10:00:00.000Z",
+            "updatedAt": "2026-05-10T10:00:03.000Z",
+            "events": [
+                {
+                    "eventId": "prompt-a",
+                    "sessionId": "run:run-2:runtime",
+                    "sequence": 0,
+                    "eventType": RuntimeSessionEventType.PROMPT_SUBMITTED.value,
+                    "timestamp": "2026-05-10T10:00:00.000Z",
+                    "payload": {
+                        "requestId": "req-a",
+                        "role": "analyst",
+                        "prompt": "prompt a",
+                    },
+                },
+                {
+                    "eventId": "prompt-b",
+                    "sessionId": "run:run-2:runtime",
+                    "sequence": 1,
+                    "eventType": RuntimeSessionEventType.PROMPT_SUBMITTED.value,
+                    "timestamp": "2026-05-10T10:00:01.000Z",
+                    "payload": {
+                        "requestId": "req-b",
+                        "role": "coach",
+                        "prompt": "prompt b",
+                    },
+                },
+                {
+                    "eventId": "assistant-b",
+                    "sessionId": "run:run-2:runtime",
+                    "sequence": 2,
+                    "eventType": RuntimeSessionEventType.ASSISTANT_MESSAGE.value,
+                    "timestamp": "2026-05-10T10:00:02.000Z",
+                    "payload": {
+                        "requestId": "req-b",
+                        "promptEventId": "prompt-b",
+                        "role": "coach",
+                        "text": "answer b",
+                    },
+                },
+                {
+                    "eventId": "assistant-a",
+                    "sessionId": "run:run-2:runtime",
+                    "sequence": 3,
+                    "eventType": RuntimeSessionEventType.ASSISTANT_MESSAGE.value,
+                    "timestamp": "2026-05-10T10:00:03.000Z",
+                    "payload": {
+                        "requestId": "req-a",
+                        "promptEventId": "prompt-a",
+                        "role": "analyst",
+                        "text": "answer a",
+                    },
+                },
+            ],
+        }
+    )
+
+    trace = runtime_session_log_to_run_trace(log)
+    by_id = {event.event_id: event for event in trace.events}
+
+    assert by_id["runtime-assistant-b"].parent_event_id == "runtime-prompt-b"
+    assert by_id["runtime-assistant-a"].parent_event_id == "runtime-prompt-a"
+    assert by_id["runtime-assistant-a"].detail["prompt_event_id"] == "prompt-a"
+    assert by_id["runtime-assistant-a"].detail["request_id"] == "req-a"

--- a/docs/concept-model.md
+++ b/docs/concept-model.md
@@ -86,12 +86,10 @@ Replay requirements are observational, not deterministic re-execution. A replay 
 
 Compaction requirements are deliberately separate from prompt history mutation. The runtime may append `COMPACTION` events that point at compaction artifacts or ledger entries, but the source events remain durable. A compaction summary can become `Knowledge` only through the same validation or promotion path as playbooks, hints, and lessons.
 
-Runtime sessions complement `RunTrace` and the external production trace contract; they should not duplicate either schema by default. `RunTrace` remains the causal run-state artifact used by analytics. A production trace remains the customer-facing emit/ingest privacy contract. Runtime-session logs are operator-facing observability artifacts; they can later export into either surface through an adapter when that reuse is intentional.
+Runtime sessions complement `RunTrace` and the external production trace contract; they should not duplicate either schema by default. `RunTrace` remains the causal run-state artifact used by analytics. A production trace remains the customer-facing emit/ingest privacy contract. Runtime-session logs are operator-facing observability artifacts; Python and TypeScript expose explicit runtime-session-to-`RunTrace` adapters for analytics reuse, and those adapters intentionally map only allowlisted lineage, status, command/tool, child-task, and compaction reference fields rather than copying raw prompts, responses, stdout, stderr, or arbitrary handler metadata.
 
-Follow-up implementation issues should stay scoped to adapter work rather than changing the vocabulary model:
+Remaining implementation issues should stay scoped to adapter work rather than changing the vocabulary model:
 
-- Emit and persist `COMPACTION` events from the compaction ledger path once compaction artifacts are normalized.
-- Add an explicit runtime-session to `RunTrace` export adapter if analytics needs session-derived events.
 - Keep Python and TypeScript command/tool grant event parity as scoped grant recording expands.
 
 ## Current Gaps And Risks

--- a/ts/src/analytics/runtime-session-run-trace.ts
+++ b/ts/src/analytics/runtime-session-run-trace.ts
@@ -160,7 +160,7 @@ function copyString(
   targetKey: string,
 ): void {
   const value = readString(source[sourceKey]);
-  if (value && target[targetKey] === undefined) {
+  if (value && !readString(target[targetKey])) {
     target[targetKey] = value;
   }
 }

--- a/ts/src/analytics/runtime-session-run-trace.ts
+++ b/ts/src/analytics/runtime-session-run-trace.ts
@@ -1,0 +1,210 @@
+import {
+  ActorRef,
+  RunTrace,
+  TraceEvent,
+} from "./run-trace.js";
+import {
+  RuntimeSessionEventType,
+  type RuntimeSessionEvent,
+  type RuntimeSessionEventLog,
+} from "../session/runtime-events.js";
+import { jsonSafeRecord } from "../session/runtime-json.js";
+
+export interface RuntimeSessionRunTraceOpts {
+  runId?: string;
+  scenarioType?: string;
+  childLogs?: readonly RuntimeSessionEventLog[];
+  createdAt?: string;
+}
+
+interface RuntimeEventRecord {
+  event: RuntimeSessionEvent;
+  log: RuntimeSessionEventLog;
+  logIndex: number;
+}
+
+export function runtimeSessionLogToRunTrace(
+  log: RuntimeSessionEventLog,
+  opts: RuntimeSessionRunTraceOpts = {},
+): RunTrace {
+  const records = flattenRuntimeEvents(log, opts.childLogs ?? []);
+  const trace = new RunTrace(
+    opts.runId ?? inferRunId(log),
+    opts.scenarioType ?? inferScenarioType(log),
+    opts.createdAt ?? records[0]?.event.timestamp ?? log.createdAt,
+  );
+
+  for (const record of records) {
+    trace.addEvent(new TraceEvent({
+      eventType: traceEventType(record.event),
+      actor: actorFor(record),
+      payload: detailFor(record),
+      timestamp: record.event.timestamp,
+    }));
+  }
+  return trace;
+}
+
+function flattenRuntimeEvents(
+  log: RuntimeSessionEventLog,
+  childLogs: readonly RuntimeSessionEventLog[],
+): RuntimeEventRecord[] {
+  const logs = [log, ...childLogs];
+  return logs
+    .flatMap((currentLog, logIndex) =>
+      currentLog.events.map((event) => ({ event, log: currentLog, logIndex })))
+    .sort(compareRuntimeEventRecords);
+}
+
+function compareRuntimeEventRecords(a: RuntimeEventRecord, b: RuntimeEventRecord): number {
+  return compareString(a.event.timestamp, b.event.timestamp)
+    || a.logIndex - b.logIndex
+    || a.event.sequence - b.event.sequence
+    || compareString(a.event.eventId, b.event.eventId);
+}
+
+function traceEventType(event: RuntimeSessionEvent): string {
+  return `runtime_${event.eventType}`;
+}
+
+function actorFor(record: RuntimeEventRecord): ActorRef {
+  const { event, log } = record;
+  const payload = event.payload;
+  if (event.eventType === RuntimeSessionEventType.SHELL_COMMAND) {
+    const commandName = readString(payload.commandName) || readString(payload.command) || "command";
+    return new ActorRef("tool", commandName, commandName);
+  }
+  if (event.eventType === RuntimeSessionEventType.TOOL_CALL) {
+    const toolName = readString(payload.toolName) || readString(payload.tool) || "tool";
+    return new ActorRef("tool", toolName, toolName);
+  }
+  if (
+    event.eventType === RuntimeSessionEventType.CHILD_TASK_STARTED
+    || event.eventType === RuntimeSessionEventType.CHILD_TASK_COMPLETED
+  ) {
+    return new ActorRef("system", "runtime_session", "runtime_session");
+  }
+  if (event.eventType === RuntimeSessionEventType.COMPACTION) {
+    return new ActorRef("system", "compaction_ledger", "compaction_ledger");
+  }
+  const role = readString(payload.role) || readString(log.metadata.role) || "runtime";
+  return new ActorRef("role", role, role);
+}
+
+function detailFor(record: RuntimeEventRecord): Record<string, unknown> {
+  const { event, log } = record;
+  const payload = event.payload;
+  const detail: Record<string, unknown> = {
+    runtime_session_id: event.sessionId || log.sessionId,
+    runtime_event_id: event.eventId,
+    runtime_event_type: event.eventType,
+    sequence: event.sequence,
+    parent_session_id: event.parentSessionId || log.parentSessionId,
+    task_id: event.taskId || log.taskId,
+    worker_id: event.workerId || log.workerId,
+  };
+
+  copyString(payload, detail, "requestId", "request_id");
+  copyString(payload, detail, "promptEventId", "prompt_event_id");
+  copyString(payload, detail, "role", "role");
+  copyString(payload, detail, "cwd", "cwd");
+  copyString(payload, detail, "phase", "phase");
+  copyString(payload, detail, "commandName", "command_name");
+  copyString(payload, detail, "command", "command_name");
+  copyString(payload, detail, "toolName", "tool_name");
+  copyString(payload, detail, "tool", "tool_name");
+  copyString(payload, detail, "argsSummary", "args_summary");
+  copyString(payload, detail, "taskId", "task_id");
+  copyString(payload, detail, "childSessionId", "child_session_id");
+  copyString(payload, detail, "workerId", "worker_id");
+  copyString(payload, detail, "entryId", "entry_id");
+  copyString(payload, detail, "components", "components");
+  copyString(payload, detail, "ledgerPath", "ledger_path");
+  copyString(payload, detail, "latestEntryPath", "latest_entry_path");
+  copyString(payload, detail, "firstKeptEntryId", "first_kept_entry_id");
+  copyString(payload, detail, "promotedKnowledgeId", "promoted_knowledge_id");
+  copyString(payload, detail, "runId", "run_id");
+  copyNumber(payload, detail, "exitCode", "exit_code");
+  copyNumber(payload, detail, "depth", "depth");
+  copyNumber(payload, detail, "maxDepth", "max_depth");
+  copyNumber(payload, detail, "entryCount", "entry_count");
+  copyNumber(payload, detail, "generation", "generation");
+  copyNumber(payload, detail, "tokensBefore", "tokens_before");
+  copyBoolean(payload, detail, "isError", "is_error");
+  copyStringArray(payload, detail, "entryIds", "entry_ids");
+
+  return jsonSafeRecord(detail);
+}
+
+function inferRunId(log: RuntimeSessionEventLog): string {
+  const metadataRunId = readString(log.metadata.runId);
+  if (metadataRunId) return metadataRunId;
+  for (const event of log.events) {
+    const eventRunId = readString(event.payload.runId);
+    if (eventRunId) return eventRunId;
+  }
+  const match = /^run:(.+):runtime$/.exec(log.sessionId);
+  return match?.[1] ?? log.sessionId;
+}
+
+function inferScenarioType(log: RuntimeSessionEventLog): string {
+  return readString(log.metadata.scenarioName)
+    || readString(log.metadata.scenario)
+    || "runtime_session";
+}
+
+function copyString(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+  sourceKey: string,
+  targetKey: string,
+): void {
+  const value = readString(source[sourceKey]);
+  if (value && target[targetKey] === undefined) {
+    target[targetKey] = value;
+  }
+}
+
+function copyNumber(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+  sourceKey: string,
+  targetKey: string,
+): void {
+  const value = source[sourceKey];
+  if (typeof value === "number" && Number.isFinite(value)) {
+    target[targetKey] = value;
+  }
+}
+
+function copyBoolean(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+  sourceKey: string,
+  targetKey: string,
+): void {
+  const value = source[sourceKey];
+  if (typeof value === "boolean") {
+    target[targetKey] = value;
+  }
+}
+
+function copyStringArray(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+  sourceKey: string,
+  targetKey: string,
+): void {
+  const value = source[sourceKey];
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    target[targetKey] = [...value];
+  }
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function compareString(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -483,6 +483,12 @@ export type {
 export { ActorRef, TraceEvent, RunTrace } from "./analytics/run-trace.js";
 export type { TraceEventInit } from "./analytics/run-trace.js";
 export {
+  runtimeSessionLogToRunTrace,
+} from "./analytics/runtime-session-run-trace.js";
+export type {
+  RuntimeSessionRunTraceOpts,
+} from "./analytics/runtime-session-run-trace.js";
+export {
   SCHEMA_VERSION,
   ToolCallSchema,
   TraceMessageSchema,

--- a/ts/tests/runtime-session-run-trace.test.ts
+++ b/ts/tests/runtime-session-run-trace.test.ts
@@ -204,10 +204,21 @@ describe("runtime-session to RunTrace adapter", () => {
     });
     expect(trace.events[1].payload).not.toHaveProperty("stdout");
 
+    expect(trace.events[2].payload).toMatchObject({
+      task_id: "retry",
+      worker_id: "w-1",
+      child_session_id: "task:run:run-1:runtime:retry:w-1",
+    });
+
     expect(trace.events[3].payload).toMatchObject({
       parent_session_id: "run:run-1:runtime",
       task_id: "retry",
       worker_id: "w-1",
+    });
+    expect(trace.events[5].payload).toMatchObject({
+      task_id: "retry",
+      worker_id: "w-1",
+      child_session_id: "task:run:run-1:runtime:retry:w-1",
     });
     expect(trace.events[6].payload).toMatchObject({
       entry_id: "entry-redacted",

--- a/ts/tests/runtime-session-run-trace.test.ts
+++ b/ts/tests/runtime-session-run-trace.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  runtimeSessionLogToRunTrace,
+} from "../src/analytics/runtime-session-run-trace.js";
+import {
+  RuntimeSessionEventLog,
+  RuntimeSessionEventType,
+} from "../src/session/runtime-events.js";
+
+describe("runtime-session to RunTrace adapter", () => {
+  it("is exported from the package entrypoint", async () => {
+    const mod = await import("../src/index.js");
+    expect(typeof mod.runtimeSessionLogToRunTrace).toBe("function");
+  });
+
+  it("maps selected runtime-session events without leaking raw observability metadata", () => {
+    const parentLog = RuntimeSessionEventLog.fromJSON({
+      sessionId: "run:run-1:runtime",
+      parentSessionId: "",
+      taskId: "",
+      workerId: "",
+      metadata: {
+        runId: "run-1",
+        scenarioName: "grid_ctf",
+        secret: "do-not-export",
+      },
+      createdAt: "2026-05-10T10:00:00.000Z",
+      updatedAt: "2026-05-10T10:00:05.000Z",
+      events: [
+        {
+          eventId: "prompt-1",
+          sessionId: "run:run-1:runtime",
+          sequence: 0,
+          eventType: RuntimeSessionEventType.PROMPT_SUBMITTED,
+          timestamp: "2026-05-10T10:00:00.000Z",
+          parentSessionId: "",
+          taskId: "",
+          workerId: "",
+          payload: {
+            requestId: "req-1",
+            role: "analyst",
+            cwd: "/workspace",
+            prompt: "secret prompt text",
+          },
+        },
+        {
+          eventId: "shell-1",
+          sessionId: "run:run-1:runtime",
+          sequence: 1,
+          eventType: RuntimeSessionEventType.SHELL_COMMAND,
+          timestamp: "2026-05-10T10:00:01.000Z",
+          parentSessionId: "",
+          taskId: "",
+          workerId: "",
+          payload: {
+            requestId: "req-1",
+            promptEventId: "prompt-1",
+            commandName: "verify",
+            phase: "end",
+            cwd: "/workspace",
+            exitCode: 0,
+            argsSummary: "verify --quick",
+            stdout: "do-not-export",
+          },
+        },
+        {
+          eventId: "child-start",
+          sessionId: "run:run-1:runtime",
+          sequence: 2,
+          eventType: RuntimeSessionEventType.CHILD_TASK_STARTED,
+          timestamp: "2026-05-10T10:00:02.000Z",
+          parentSessionId: "",
+          taskId: "",
+          workerId: "",
+          payload: {
+            taskId: "retry",
+            childSessionId: "task:run:run-1:runtime:retry:w-1",
+            workerId: "w-1",
+            role: "coach",
+            cwd: "/workspace",
+            depth: 1,
+          },
+        },
+        {
+          eventId: "child-done",
+          sessionId: "run:run-1:runtime",
+          sequence: 3,
+          eventType: RuntimeSessionEventType.CHILD_TASK_COMPLETED,
+          timestamp: "2026-05-10T10:00:04.000Z",
+          parentSessionId: "",
+          taskId: "",
+          workerId: "",
+          payload: {
+            taskId: "retry",
+            childSessionId: "task:run:run-1:runtime:retry:w-1",
+            workerId: "w-1",
+            role: "coach",
+            result: "do-not-export",
+            isError: false,
+          },
+        },
+        {
+          eventId: "cmp-1",
+          sessionId: "run:run-1:runtime",
+          sequence: 4,
+          eventType: RuntimeSessionEventType.COMPACTION,
+          timestamp: "2026-05-10T10:00:05.000Z",
+          parentSessionId: "",
+          taskId: "",
+          workerId: "",
+          payload: {
+            runId: "run-1",
+            entryId: "entry-redacted",
+            entryIds: ["entry-redacted"],
+            entryCount: 1,
+            components: "session_reports",
+            ledgerPath: "/runs/run-1/compactions.jsonl",
+            latestEntryPath: "/runs/run-1/compactions.latest",
+            generation: 2,
+            summary: "do-not-export",
+          },
+        },
+      ],
+    });
+    const childLog = RuntimeSessionEventLog.fromJSON({
+      sessionId: "task:run:run-1:runtime:retry:w-1",
+      parentSessionId: "run:run-1:runtime",
+      taskId: "retry",
+      workerId: "w-1",
+      metadata: { role: "coach", secret: "do-not-export" },
+      createdAt: "2026-05-10T10:00:02.500Z",
+      updatedAt: "2026-05-10T10:00:03.000Z",
+      events: [
+        {
+          eventId: "child-prompt",
+          sessionId: "task:run:run-1:runtime:retry:w-1",
+          sequence: 0,
+          eventType: RuntimeSessionEventType.PROMPT_SUBMITTED,
+          timestamp: "2026-05-10T10:00:02.500Z",
+          parentSessionId: "run:run-1:runtime",
+          taskId: "retry",
+          workerId: "w-1",
+          payload: {
+            role: "coach",
+            prompt: "child prompt text",
+            cwd: "/workspace",
+          },
+        },
+        {
+          eventId: "child-answer",
+          sessionId: "task:run:run-1:runtime:retry:w-1",
+          sequence: 1,
+          eventType: RuntimeSessionEventType.ASSISTANT_MESSAGE,
+          timestamp: "2026-05-10T10:00:03.000Z",
+          parentSessionId: "run:run-1:runtime",
+          taskId: "retry",
+          workerId: "w-1",
+          payload: {
+            role: "coach",
+            text: "child answer text",
+            metadata: { secret: "do-not-export" },
+          },
+        },
+      ],
+    });
+
+    const trace = runtimeSessionLogToRunTrace(parentLog, { childLogs: [childLog] });
+
+    expect(trace.runId).toBe("run-1");
+    expect(trace.scenarioType).toBe("grid_ctf");
+    expect(trace.createdAt).toBe("2026-05-10T10:00:00.000Z");
+    expect(trace.events.map((event) => event.eventType)).toEqual([
+      "runtime_prompt_submitted",
+      "runtime_shell_command",
+      "runtime_child_task_started",
+      "runtime_prompt_submitted",
+      "runtime_assistant_message",
+      "runtime_child_task_completed",
+      "runtime_compaction",
+    ]);
+
+    expect(trace.events[0].actor.toDict()).toEqual({
+      actor_type: "role",
+      actor_id: "analyst",
+      actor_name: "analyst",
+    });
+    expect(trace.events[0].payload).toMatchObject({
+      runtime_session_id: "run:run-1:runtime",
+      runtime_event_id: "prompt-1",
+      runtime_event_type: "prompt_submitted",
+      sequence: 0,
+      request_id: "req-1",
+      role: "analyst",
+      cwd: "/workspace",
+    });
+    expect(trace.events[0].payload).not.toHaveProperty("prompt");
+
+    expect(trace.events[1].payload).toMatchObject({
+      command_name: "verify",
+      phase: "end",
+      exit_code: 0,
+      args_summary: "verify --quick",
+    });
+    expect(trace.events[1].payload).not.toHaveProperty("stdout");
+
+    expect(trace.events[3].payload).toMatchObject({
+      parent_session_id: "run:run-1:runtime",
+      task_id: "retry",
+      worker_id: "w-1",
+    });
+    expect(trace.events[6].payload).toMatchObject({
+      entry_id: "entry-redacted",
+      entry_ids: ["entry-redacted"],
+      entry_count: 1,
+      components: "session_reports",
+      ledger_path: "/runs/run-1/compactions.jsonl",
+      latest_entry_path: "/runs/run-1/compactions.latest",
+      generation: 2,
+    });
+
+    expect(JSON.stringify(trace.toDict())).not.toContain("do-not-export");
+    expect(JSON.stringify(trace.toDict())).not.toContain("secret prompt text");
+    expect(JSON.stringify(trace.toDict())).not.toContain("child answer text");
+  });
+});


### PR DESCRIPTION
## Summary
- add TypeScript and Python adapters from runtime-session logs into RunTrace analytics artifacts
- map only allowlisted lineage/status/command/tool/child-task/compaction fields so raw prompts, responses, stdout/stderr, and arbitrary handler metadata do not leak
- document the adapter boundary in the concept model and changelog

## Verification
- npm test -- runtime-session-run-trace.test.ts concept-model-durable-session-events.test.ts analytics.test.ts
- npm test -- runtime-session-run-trace.test.ts runtime-session.test.ts runtime-session-read-model.test.ts package-export-catalogs.test.ts
- npm run lint
- uv run --frozen pytest tests/test_runtime_session_run_trace.py tests/test_run_trace.py -q
- uv run --frozen pytest tests/test_runtime_session_run_trace.py tests/test_runtime_session_events.py tests/test_run_trace.py -q
- uv run --frozen ruff check src tests
- uv run --frozen mypy src
- git diff --check

Linear: AC-744