### PR TITLE
Refine external eval diagnostic categories

### DIFF
--- a/ts/src/control-plane/external-evals/index.ts
+++ b/ts/src/control-plane/external-evals/index.ts
@@ -503,28 +503,40 @@ function classifyDiagnosticCategory(
     return "adapter-runtime-failure";
   }
 
-  const verifierOutput = stripAnsi(evidence?.verifierOutput ?? "").toLowerCase();
-  if (
-    verifierOutput.includes("branch yet to be born") ||
-    verifierOutput.includes("src refspec") ||
-    verifierOutput.includes("failed to push") ||
-    verifierOutput.includes("failed to clone") ||
-    verifierOutput.includes("connection refused") ||
-    verifierOutput.includes("permission denied")
-  ) {
+  const verifierOutput = normalizeDiagnosticOutput(evidence?.verifierOutput ?? "");
+  if (isSetupEnvironmentFailure(verifierOutput)) {
     return "setup-environment-failure";
   }
-  if (
-    verifierOutput.includes("missing required") ||
-    verifierOutput.includes("required fields") ||
-    verifierOutput.includes("not configured") ||
-    verifierOutput.includes("could not find") ||
-    verifierOutput.includes("expected") ||
-    verifierOutput.includes("assertionerror")
-  ) {
+  if (isVerifierContractMismatch(verifierOutput)) {
     return "verifier-contract-mismatch";
   }
   return trial.status === "failed" ? "agent-task-failure" : "unknown";
+}
+
+function normalizeDiagnosticOutput(output: string): string {
+  return stripAnsi(output).toLowerCase();
+}
+
+function isSetupEnvironmentFailure(verifierOutput: string): boolean {
+  return [
+    "branch yet to be born",
+    "src refspec",
+    "failed to push",
+    "failed to clone",
+    "connection refused",
+    "permission denied",
+  ].some((signature) => verifierOutput.includes(signature));
+}
+
+function isVerifierContractMismatch(verifierOutput: string): boolean {
+  return [
+    "missing required",
+    "required fields",
+    "not configured",
+    "could not find",
+    "no such file or directory",
+    "can't open file",
+  ].some((signature) => verifierOutput.includes(signature));
 }
 
 function diagnosticConfidence(

--- a/ts/tests/control-plane/external-evals/diagnostics.test.ts
+++ b/ts/tests/control-plane/external-evals/diagnostics.test.ts
@@ -207,6 +207,77 @@ describe("external eval diagnostics", () => {
     });
   });
 
+  test("does not treat ordinary assertion mismatches as verifier contracts", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-assertion-1",
+      createdAt: "2026-05-07T15:13:00.000Z",
+      trials: [
+        {
+          taskId: "csv-to-parquet",
+          trialId: "csv-to-parquet.1-of-1.tb-assertion-1",
+          attempt: 1,
+          status: "failed",
+          reward: 0,
+        },
+      ],
+      evidence: [
+        {
+          trialId: "csv-to-parquet.1-of-1.tb-assertion-1",
+          evidenceRefs: ["csv-to-parquet/sessions/tests.log"],
+          verifierOutput: [
+            '"test_data_matches": "failed"',
+            'AssertionError: Attributes of DataFrame.iloc[:, 1] (column name="age") are different',
+            'Expected: int64',
+            'Actual: int32',
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      category: "agent-task-failure",
+    });
+    expect(report.summary.countsByCategory).toEqual({
+      "agent-task-failure": 1,
+    });
+  });
+
+  test("classifies missing checked files as verifier contracts", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-missing-file-1",
+      createdAt: "2026-05-07T15:14:00.000Z",
+      trials: [
+        {
+          taskId: "polyglot-c-py",
+          trialId: "polyglot-c-py.1-of-1.tb-missing-file-1",
+          attempt: 1,
+          status: "failed",
+          reward: 0,
+        },
+      ],
+      evidence: [
+        {
+          trialId: "polyglot-c-py.1-of-1.tb-missing-file-1",
+          evidenceRefs: ["polyglot-c-py/sessions/tests.log"],
+          verifierOutput: [
+            '"test_fibonacci_polyglot": "failed"',
+            "python3: can't open file '/app/main.py.c': [Errno 2] No such file or directory",
+            "cc1: fatal error: /app/main.py.c: No such file or directory",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      category: "verifier-contract-mismatch",
+    });
+    expect(report.summary.countsByCategory).toEqual({
+      "verifier-contract-mismatch": 1,
+    });
+  });
+
   test("keeps resolved trials with adapter runtime issues visible without counting them unresolved", () => {
     const report = buildExternalEvalDiagnosticReport({
       runId: "tb-run-1",


### PR DESCRIPTION
## Summary
- stop treating generic AssertionError/expected verifier text as artifact-contract mismatches
- keep missing checked-file/path failures in verifier-contract diagnostics
- add focused regression coverage from the Terminal-Bench ingestion pass

## Verification
- npm test -- tests/control-plane/external-evals/diagnostics.test.ts
- npm run lint
- npm run build
- npm test