### PR TITLE
Broaden external eval improvement signals

### DIFF
--- a/ts/src/control-plane/external-evals/index.ts
+++ b/ts/src/control-plane/external-evals/index.ts
@@ -45,6 +45,8 @@ export type ExternalEvalDiagnosticCategory =
 
 export type ExternalEvalImprovementSignalKind =
   | "required-artifact-contract"
+  | "schema-key-contract"
+  | "required-input-source-usage"
   | "change-surface-discipline"
   | "domain-correctness-validation"
   | "exact-verifier-command"
@@ -982,6 +984,8 @@ function buildOperationalFindings(
 
 const improvementSignalKindOrder: readonly ExternalEvalImprovementSignalKind[] = [
   "required-artifact-contract",
+  "schema-key-contract",
+  "required-input-source-usage",
   "change-surface-discipline",
   "domain-correctness-validation",
   "exact-verifier-command",
@@ -1048,9 +1052,27 @@ function detectImprovementSignalKinds(
     /(?:test_[a-z0-9_]*(?:file|artifact|output)(?:_[a-z0-9]+)*|(?:file|artifact|output)_exists)["']?\s*[:=]\s*["']?failed/.test(
       text,
     ) ||
-    /missing.{0,60}(?:file|artifact|output)/.test(text)
+    /missing.{0,60}(?:file|artifact|output)/.test(text) ||
+    /(?:model|tokenizer|vocab|artifact|output)?\s*file\s+["']?[a-z0-9_.\-/]+["']?\s+not found/.test(text) ||
+    /(?:artifact|output|model|tokenizer|vocab)[^,\n}]{0,80}not found/.test(text)
   ) {
     kinds.add("required-artifact-contract");
+  }
+  if (
+    /keyerror:\s*["']?[a-z0-9_.-]+["']?/.test(text) ||
+    /missing.{0,80}(?:json )?(?:key|field|property)/.test(text) ||
+    /(?:key|field|property)[^,\n}]{0,80}(?:missing|not found|required)/.test(text)
+  ) {
+    kinds.add("schema-key-contract");
+  }
+  if (
+    /should use the (?:rules?|config|configuration|data|input) file/.test(text) ||
+    /(?:rules?|config|configuration|data|input) file[^,\n}]{0,120}(?:not used|must be used|should be used|was ignored)/.test(
+      text,
+    ) ||
+    /(?:hardcoded|hard-coded)[^,\n}]{0,120}(?:rules?|config|configuration|data|input)/.test(text)
+  ) {
+    kinds.add("required-input-source-usage");
   }
   if (
     /no_other_files_changed|other files changed|unrelated files|unexpected (?:file|change)|change surface/.test(
@@ -1091,6 +1113,24 @@ function improvementSignalMetadata(kind: ExternalEvalImprovementSignalKind): Omi
           "Before finishing, independently confirm every required file or output artifact exists at the exact checked path and that its contents can be read back from that path.",
         targetFamilies: ["terminal", "artifact-contract", "file-output"],
         risk: "low",
+      };
+    case "schema-key-contract":
+      return {
+        confidence: 0.8,
+        summary: "Validate exact output schema keys and field names.",
+        reusableBehavior:
+          "When a task requires structured output, verify the exact key names, aliases, nesting, and required fields by reading the final artifact back before finishing.",
+        targetFamilies: ["terminal", "artifact-contract", "structured-output"],
+        risk: "low",
+      };
+    case "required-input-source-usage":
+      return {
+        confidence: 0.8,
+        summary: "Use required visible input, rule, and config sources directly.",
+        reusableBehavior:
+          "When a task provides rule, config, model, data, or input files, wire the final script or service to consume those sources directly instead of hardcoding behavior from examples.",
+        targetFamilies: ["terminal", "config-driven-workflow", "file-input"],
+        risk: "medium",
       };
     case "change-surface-discipline":
       return {

--- a/ts/tests/control-plane/external-evals/diagnostics.test.ts
+++ b/ts/tests/control-plane/external-evals/diagnostics.test.ts
@@ -124,10 +124,11 @@ describe("external eval diagnostics", () => {
 
     expect(pack.status).toBe("sanitized");
     expect(pack.integrity).toMatchObject({ status: "clean" });
-    expect(pack.findings).toHaveLength(2);
+    expect(pack.findings).toHaveLength(3);
     expect(pack.findings.map((finding) => finding.id)).toEqual([
       "tb-run-1-setup-environment-failure",
       "tb-run-1-verifier-contract-mismatch",
+      "tb-run-1-schema-key-contract",
     ]);
     expect(pack.findings.every((finding) => finding.containsTaskAnswer === false)).toBe(true);
     expect(pack.findings.every((finding) => finding.containsSecret === false)).toBe(true);
@@ -527,6 +528,90 @@ describe("external eval diagnostics", () => {
       "tb-heldout-1-domain-correctness-validation",
       "tb-heldout-1-exact-verifier-command",
       "tb-heldout-1-consumer-path-parity",
+    ]);
+    expect(pack.findings.every((finding) => finding.containsTaskAnswer === false)).toBe(true);
+    expect(validateOperationalMemoryPack(pack)).toEqual({ valid: true });
+  });
+
+  test("derives artifact, schema, and input-source signals from verifier excerpts", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-dev-signal-1",
+      createdAt: "2026-05-07T18:56:00.000Z",
+      trials: [
+        {
+          taskId: "model-artifact-task",
+          trialId: "model-artifact-task.1-of-1.tb-dev-signal-1",
+          attempt: 1,
+          status: "failed",
+          reward: 0,
+        },
+        {
+          taskId: "structured-output-task",
+          trialId: "structured-output-task.1-of-1.tb-dev-signal-1",
+          attempt: 1,
+          status: "failed",
+          reward: 0,
+        },
+        {
+          taskId: "rule-driven-script-task",
+          trialId: "rule-driven-script-task.1-of-1.tb-dev-signal-1",
+          attempt: 1,
+          status: "failed",
+          reward: 0,
+        },
+      ],
+      evidence: [
+        {
+          trialId: "model-artifact-task.1-of-1.tb-dev-signal-1",
+          evidenceRefs: ["model-artifact-task/results.json"],
+          verifierOutput: [
+            '"test_model_downloaded": "failed"',
+            "AssertionError: Model file tokenizer.json not found",
+          ].join("\n"),
+        },
+        {
+          trialId: "structured-output-task.1-of-1.tb-dev-signal-1",
+          evidenceRefs: ["structured-output-task/results.json"],
+          verifierOutput: [
+            '"test_output_schema": "failed"',
+            "FAILED ../tests/test_outputs.py::test_output_schema - KeyError: 'A'",
+          ].join("\n"),
+        },
+        {
+          trialId: "rule-driven-script-task.1-of-1.tb-dev-signal-1",
+          evidenceRefs: ["rule-driven-script-task/results.json"],
+          verifierOutput: [
+            '"test_detector_content": "failed"',
+            "AssertionError: Script should use the rules file",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    const signals = buildExternalEvalImprovementSignals(report);
+
+    expect(signals.map((signal) => signal.kind)).toEqual([
+      "required-artifact-contract",
+      "schema-key-contract",
+      "required-input-source-usage",
+    ]);
+    expect(signals.map((signal) => signal.summary)).toEqual([
+      "Verify required output artifacts at their checked paths before completion.",
+      "Validate exact output schema keys and field names.",
+      "Use required visible input, rule, and config sources directly.",
+    ]);
+
+    const pack = buildOperationalMemoryPackFromDiagnostics({
+      packId: "tb-dev-signal-1-operational-checklists",
+      version: "1.0.0",
+      createdAt: "2026-05-07T18:57:00.000Z",
+      report,
+    });
+
+    expect(pack.findings.map((finding) => finding.id)).toEqual([
+      "tb-dev-signal-1-required-artifact-contract",
+      "tb-dev-signal-1-schema-key-contract",
+      "tb-dev-signal-1-required-input-source-usage",
     ]);
     expect(pack.findings.every((finding) => finding.containsTaskAnswer === false)).toBe(true);
     expect(validateOperationalMemoryPack(pack)).toEqual({ valid: true });


### PR DESCRIPTION
## Summary
- add signal kinds for schema-key mismatches and required input/rule/config source usage
- broaden required-artifact detection for model/tokenizer/vocab files reported missing by verifier output
- add regression coverage using Terminal-Bench-style verifier excerpts

## Benchmark context
Terminal-Bench dev10 diagnostics surfaced failures that the memory pack collapsed into a generic domain-correctness signal. This PR improves extraction quality only; it does not claim a held-out benchmark improvement. Dev gating remained conservative: baseline 7/10, context v1 7/10, richer context v2 6/10, so no held-out run was promoted from that context.

## Verification
- npm test -- tests/control-plane/external-evals/diagnostics.test.ts
- npm run lint
- npm run build
- npm test