### PR TITLE
Gate external eval memory context application

### DIFF
--- a/ts/src/control-plane/external-evals/index.ts
+++ b/ts/src/control-plane/external-evals/index.ts
@@ -4,7 +4,9 @@ import type {
   EvalTrialStatus,
   ValidationResult,
 } from "../contract/types.js";
+import { reconcileEvalTrials } from "../eval-ledger/index.js";
 import type {
+  OperationalMemoryContextApplication,
   OperationalMemoryFinding,
   OperationalMemoryPack,
 } from "../memory-packs/index.js";
@@ -171,6 +173,7 @@ export interface ExternalEvalDiagnosticReport {
   readonly createdAt: string;
   readonly diagnostics: readonly ExternalEvalTrialDiagnostic[];
   readonly improvementSignals?: readonly ExternalEvalImprovementSignal[];
+  readonly contextApplication?: OperationalMemoryContextApplication;
   readonly summary: {
     readonly totalTrials: number;
     readonly unresolvedTrials: number;
@@ -184,6 +187,7 @@ export interface BuildExternalEvalDiagnosticReportInputs {
   readonly createdAt: string;
   readonly trials: readonly EvalTrial[];
   readonly evidence?: readonly ExternalEvalTrialEvidence[];
+  readonly contextApplication?: OperationalMemoryContextApplication;
 }
 
 export interface BuildOperationalMemoryPackFromDiagnosticsInputs {
@@ -191,6 +195,35 @@ export interface BuildOperationalMemoryPackFromDiagnosticsInputs {
   readonly version: string;
   readonly createdAt: string;
   readonly report: ExternalEvalDiagnosticReport;
+}
+
+export type ExternalEvalContextPromotionStatus =
+  | "eligible-for-heldout"
+  | "hold-for-dev"
+  | "reject-regression"
+  | "invalid-task-set";
+
+export interface DecideExternalEvalContextPromotionInputs {
+  readonly baselineRunId: string;
+  readonly candidateRunId: string;
+  readonly baselineTrials: readonly EvalTrial[];
+  readonly candidateTrials: readonly EvalTrial[];
+  readonly minResolvedTaskGain?: number;
+  readonly maxRegressedTasks?: number;
+}
+
+export interface ExternalEvalContextPromotionDecision {
+  readonly pass: boolean;
+  readonly status: ExternalEvalContextPromotionStatus;
+  readonly baselineRunId: string;
+  readonly candidateRunId: string;
+  readonly baselinePassedTaskCount: number;
+  readonly candidatePassedTaskCount: number;
+  readonly improvedTaskIds: readonly string[];
+  readonly regressedTaskIds: readonly string[];
+  readonly missingBaselineTaskIds: readonly string[];
+  readonly missingCandidateTaskIds: readonly string[];
+  readonly notes: readonly string[];
 }
 
 export function validateExternalEvalAdapterLifecycle(input: unknown): ValidationResult {
@@ -336,6 +369,7 @@ export function buildExternalEvalDiagnosticReport(
     createdAt: inputs.createdAt,
     diagnostics,
     improvementSignals,
+    ...(inputs.contextApplication !== undefined ? { contextApplication: inputs.contextApplication } : {}),
     summary: {
       totalTrials: inputs.trials.length,
       unresolvedTrials: inputs.trials.filter((trial) => trial.status !== "passed").length,
@@ -351,6 +385,140 @@ export function buildExternalEvalImprovementSignals(
   report: Pick<ExternalEvalDiagnosticReport, "runId" | "diagnostics">,
 ): readonly ExternalEvalImprovementSignal[] {
   return buildImprovementSignals(report.runId, report.diagnostics);
+}
+
+export function decideExternalEvalContextPromotion(
+  inputs: DecideExternalEvalContextPromotionInputs,
+): ExternalEvalContextPromotionDecision {
+  const minResolvedTaskGain = inputs.minResolvedTaskGain ?? 1;
+  const maxRegressedTasks = inputs.maxRegressedTasks ?? 0;
+  const baselineTaskStatus = firstStatusByTask(inputs.baselineTrials);
+  const candidateTaskStatus = firstStatusByTask(inputs.candidateTrials);
+  const missingBaselineTaskIds = sortedDifference(candidateTaskStatus.keys(), baselineTaskStatus);
+  const missingCandidateTaskIds = sortedDifference(baselineTaskStatus.keys(), candidateTaskStatus);
+
+  const sharedTaskIds = [...baselineTaskStatus.keys()].filter((taskId) => candidateTaskStatus.has(taskId));
+  const improvedTaskIds = sharedTaskIds
+    .filter((taskId) => baselineTaskStatus.get(taskId) !== "passed" && candidateTaskStatus.get(taskId) === "passed")
+    .sort();
+  const regressedTaskIds = sharedTaskIds
+    .filter((taskId) => baselineTaskStatus.get(taskId) === "passed" && candidateTaskStatus.get(taskId) !== "passed")
+    .sort();
+  const baselinePassedTaskCount = countPassedTasks(baselineTaskStatus);
+  const candidatePassedTaskCount = countPassedTasks(candidateTaskStatus);
+  const notes: string[] = [
+    `baseline_passed=${baselinePassedTaskCount}`,
+    `candidate_passed=${candidatePassedTaskCount}`,
+    `improved=${improvedTaskIds.length}`,
+    `regressed=${regressedTaskIds.length}`,
+  ];
+
+  if (missingBaselineTaskIds.length > 0 || missingCandidateTaskIds.length > 0) {
+    return {
+      pass: false,
+      status: "invalid-task-set",
+      baselineRunId: inputs.baselineRunId,
+      candidateRunId: inputs.candidateRunId,
+      baselinePassedTaskCount,
+      candidatePassedTaskCount,
+      improvedTaskIds,
+      regressedTaskIds,
+      missingBaselineTaskIds,
+      missingCandidateTaskIds,
+      notes: [
+        ...notes,
+        "Baseline and candidate context runs must cover the same development task IDs before held-out eligibility.",
+      ],
+    };
+  }
+
+  if (regressedTaskIds.length > maxRegressedTasks) {
+    return {
+      pass: false,
+      status: "reject-regression",
+      baselineRunId: inputs.baselineRunId,
+      candidateRunId: inputs.candidateRunId,
+      baselinePassedTaskCount,
+      candidatePassedTaskCount,
+      improvedTaskIds,
+      regressedTaskIds,
+      missingBaselineTaskIds,
+      missingCandidateTaskIds,
+      notes: [
+        ...notes,
+        `Regressed task count exceeded maxRegressedTasks=${maxRegressedTasks}.`,
+      ],
+    };
+  }
+
+  if (candidatePassedTaskCount - baselinePassedTaskCount < minResolvedTaskGain) {
+    return {
+      pass: false,
+      status: "hold-for-dev",
+      baselineRunId: inputs.baselineRunId,
+      candidateRunId: inputs.candidateRunId,
+      baselinePassedTaskCount,
+      candidatePassedTaskCount,
+      improvedTaskIds,
+      regressedTaskIds,
+      missingBaselineTaskIds,
+      missingCandidateTaskIds,
+      notes: [
+        ...notes,
+        `Resolved task gain did not meet minResolvedTaskGain=${minResolvedTaskGain}.`,
+      ],
+    };
+  }
+
+  return {
+    pass: true,
+    status: "eligible-for-heldout",
+    baselineRunId: inputs.baselineRunId,
+    candidateRunId: inputs.candidateRunId,
+    baselinePassedTaskCount,
+    candidatePassedTaskCount,
+    improvedTaskIds,
+    regressedTaskIds,
+    missingBaselineTaskIds,
+    missingCandidateTaskIds,
+    notes: [
+      ...notes,
+      "Candidate context cleared development-set promotion gates and is eligible for held-out evaluation.",
+    ],
+  };
+}
+
+function firstStatusByTask(trials: readonly EvalTrial[]): ReadonlyMap<string, EvalTrialStatus> {
+  const reconciliation = reconcileEvalTrials(trials, { view: "first-completed-per-task" });
+  const selectedTrialIdsByTask = reconciliation.selectedTrialIdsByTask;
+  const trialById = new Map(trials.map((trial) => [trial.trialId, trial]));
+  const fallbackTrialByTask = new Map<string, EvalTrial>();
+
+  for (const trial of trials) {
+    if (!fallbackTrialByTask.has(trial.taskId)) {
+      fallbackTrialByTask.set(trial.taskId, trial);
+    }
+  }
+
+  const statusByTask = new Map<string, EvalTrialStatus>();
+  for (const [taskId, fallbackTrial] of fallbackTrialByTask.entries()) {
+    const selectedTrialId = selectedTrialIdsByTask[taskId];
+    const selectedTrial = selectedTrialId !== undefined ? trialById.get(selectedTrialId) : undefined;
+    statusByTask.set(taskId, selectedTrial?.status ?? fallbackTrial.status);
+  }
+
+  return statusByTask;
+}
+
+function sortedDifference(
+  taskIds: Iterable<string>,
+  comparison: ReadonlyMap<string, EvalTrialStatus>,
+): readonly string[] {
+  return [...taskIds].filter((taskId) => !comparison.has(taskId)).sort();
+}
+
+function countPassedTasks(taskStatus: ReadonlyMap<string, EvalTrialStatus>): number {
+  return [...taskStatus.values()].filter((status) => status === "passed").length;
 }
 
 export function buildOperationalMemoryPackFromDiagnostics(

--- a/ts/src/control-plane/external-evals/index.ts
+++ b/ts/src/control-plane/external-evals/index.ts
@@ -491,19 +491,25 @@ export function decideExternalEvalContextPromotion(
 function firstStatusByTask(trials: readonly EvalTrial[]): ReadonlyMap<string, EvalTrialStatus> {
   const reconciliation = reconcileEvalTrials(trials, { view: "first-completed-per-task" });
   const selectedTrialIdsByTask = reconciliation.selectedTrialIdsByTask;
-  const trialById = new Map(trials.map((trial) => [trial.trialId, trial]));
   const fallbackTrialByTask = new Map<string, EvalTrial>();
+  const trialByTaskAndId = new Map<string, Map<string, EvalTrial>>();
 
   for (const trial of trials) {
     if (!fallbackTrialByTask.has(trial.taskId)) {
       fallbackTrialByTask.set(trial.taskId, trial);
     }
+    const taskTrials = trialByTaskAndId.get(trial.taskId) ?? new Map<string, EvalTrial>();
+    if (!taskTrials.has(trial.trialId)) {
+      taskTrials.set(trial.trialId, trial);
+    }
+    trialByTaskAndId.set(trial.taskId, taskTrials);
   }
 
   const statusByTask = new Map<string, EvalTrialStatus>();
   for (const [taskId, fallbackTrial] of fallbackTrialByTask.entries()) {
     const selectedTrialId = selectedTrialIdsByTask[taskId];
-    const selectedTrial = selectedTrialId !== undefined ? trialById.get(selectedTrialId) : undefined;
+    const selectedTrial =
+      selectedTrialId !== undefined ? trialByTaskAndId.get(taskId)?.get(selectedTrialId) : undefined;
     statusByTask.set(taskId, selectedTrial?.status ?? fallbackTrial.status);
   }
 

--- a/ts/src/control-plane/memory-packs/index.ts
+++ b/ts/src/control-plane/memory-packs/index.ts
@@ -2,6 +2,14 @@ import type { EvalRunIntegrity, ValidationResult } from "../contract/types.js";
 
 export type OperationalMemoryPackStatus = "draft" | "sanitized" | "active" | "deprecated";
 export type OperationalMemoryRisk = "low" | "medium" | "high";
+export type OperationalMemoryContextSkipReason =
+  | "pack-status-not-eligible"
+  | "pack-integrity-not-clean"
+  | "leakage-risk"
+  | "duplicate-finding"
+  | "target-family-mismatch"
+  | "risk-too-high"
+  | "capacity-limit";
 
 export interface OperationalMemoryFinding {
   readonly id: string;
@@ -21,6 +29,160 @@ export interface OperationalMemoryPack {
   readonly status: OperationalMemoryPackStatus;
   readonly integrity?: EvalRunIntegrity;
   readonly findings: readonly OperationalMemoryFinding[];
+}
+
+export interface CompileOperationalMemoryContextInputs {
+  readonly contextId: string;
+  readonly createdAt: string;
+  readonly packs: readonly OperationalMemoryPack[];
+  readonly targetFamilies: readonly string[];
+  readonly taskId?: string;
+  readonly maxFindings?: number;
+  readonly riskTolerance?: OperationalMemoryRisk;
+}
+
+export interface OperationalMemorySelectedFinding {
+  readonly packId: string;
+  readonly findingId: string;
+  readonly summary: string;
+  readonly evidenceRefs: readonly string[];
+  readonly reusableBehavior: string;
+  readonly targetFamilies: readonly string[];
+  readonly matchedTargetFamilies: readonly string[];
+  readonly risk: OperationalMemoryRisk;
+}
+
+export interface OperationalMemorySkippedFinding {
+  readonly packId: string;
+  readonly findingId: string;
+  readonly reason: OperationalMemoryContextSkipReason;
+  readonly detail?: string;
+}
+
+export interface OperationalMemoryContextApplication {
+  readonly schemaVersion: "operational-memory-context/v1";
+  readonly contextId: string;
+  readonly createdAt: string;
+  readonly taskId?: string;
+  readonly targetFamilies: readonly string[];
+  readonly maxFindings: number;
+  readonly riskTolerance: OperationalMemoryRisk;
+  readonly selectedFindings: readonly OperationalMemorySelectedFinding[];
+  readonly skippedFindings: readonly OperationalMemorySkippedFinding[];
+  readonly prompt: string;
+}
+
+interface CandidateFinding {
+  readonly originalIndex: number;
+  readonly score: number;
+  readonly finding: OperationalMemorySelectedFinding;
+}
+
+export function compileOperationalMemoryContext(
+  inputs: CompileOperationalMemoryContextInputs,
+): OperationalMemoryContextApplication {
+  const targetFamilies = uniqueNormalizedStrings(inputs.targetFamilies);
+  const maxFindings = normalizedMaxFindings(inputs.maxFindings);
+  const riskTolerance = inputs.riskTolerance ?? "medium";
+  const skippedFindings: OperationalMemorySkippedFinding[] = [];
+  const candidates: CandidateFinding[] = [];
+  const candidateIds = new Set<string>();
+  let originalIndex = 0;
+
+  for (const pack of inputs.packs) {
+    if (!isEligiblePackStatus(pack.status)) {
+      skipPackFindings(skippedFindings, pack, "pack-status-not-eligible", `status=${pack.status}`);
+      continue;
+    }
+    if (pack.integrity !== undefined && pack.integrity.status !== "clean") {
+      skipPackFindings(
+        skippedFindings,
+        pack,
+        "pack-integrity-not-clean",
+        `integrity=${pack.integrity.status}`,
+      );
+      continue;
+    }
+
+    for (const finding of pack.findings) {
+      originalIndex += 1;
+      if (candidateIds.has(finding.id)) {
+        skippedFindings.push({
+          packId: pack.packId,
+          findingId: finding.id,
+          reason: "duplicate-finding",
+        });
+        continue;
+      }
+      if (finding.containsTaskAnswer === true || finding.containsSecret === true) {
+        skippedFindings.push({
+          packId: pack.packId,
+          findingId: finding.id,
+          reason: "leakage-risk",
+        });
+        continue;
+      }
+      if (riskRank(finding.risk) > riskRank(riskTolerance)) {
+        skippedFindings.push({
+          packId: pack.packId,
+          findingId: finding.id,
+          reason: "risk-too-high",
+          detail: `risk=${finding.risk}; tolerance=${riskTolerance}`,
+        });
+        continue;
+      }
+
+      const matchedTargetFamilies = intersectNormalizedFamilies(targetFamilies, finding.targetFamilies);
+      if (matchedTargetFamilies.length === 0) {
+        skippedFindings.push({
+          packId: pack.packId,
+          findingId: finding.id,
+          reason: "target-family-mismatch",
+        });
+        continue;
+      }
+
+      candidateIds.add(finding.id);
+      candidates.push({
+        originalIndex,
+        score: matchedTargetFamilies.length,
+        finding: {
+          packId: pack.packId,
+          findingId: finding.id,
+          summary: finding.summary,
+          evidenceRefs: finding.evidenceRefs,
+          reusableBehavior: finding.reusableBehavior,
+          targetFamilies: finding.targetFamilies,
+          matchedTargetFamilies,
+          risk: finding.risk,
+        },
+      });
+    }
+  }
+
+  const rankedCandidates = [...candidates].sort(compareCandidates);
+  const selectedFindings = rankedCandidates.slice(0, maxFindings).map((candidate) => candidate.finding);
+  for (const candidate of rankedCandidates.slice(maxFindings)) {
+    skippedFindings.push({
+      packId: candidate.finding.packId,
+      findingId: candidate.finding.findingId,
+      reason: "capacity-limit",
+      detail: `maxFindings=${maxFindings}`,
+    });
+  }
+
+  return {
+    schemaVersion: "operational-memory-context/v1",
+    contextId: inputs.contextId,
+    createdAt: inputs.createdAt,
+    ...(inputs.taskId !== undefined ? { taskId: inputs.taskId } : {}),
+    targetFamilies,
+    maxFindings,
+    riskTolerance,
+    selectedFindings,
+    skippedFindings,
+    prompt: renderOperationalMemoryPrompt(selectedFindings),
+  };
 }
 
 export function validateOperationalMemoryPack(input: unknown): ValidationResult {
@@ -144,4 +306,78 @@ function requireEnum(
 
 function isRecord(input: unknown): input is Readonly<Record<string, unknown>> {
   return typeof input === "object" && input !== null && !Array.isArray(input);
+}
+
+function normalizedMaxFindings(maxFindings: number | undefined): number {
+  if (maxFindings === undefined) return 4;
+  if (!Number.isFinite(maxFindings)) return 0;
+  return Math.max(0, Math.floor(maxFindings));
+}
+
+function isEligiblePackStatus(status: OperationalMemoryPackStatus): boolean {
+  return status === "sanitized" || status === "active";
+}
+
+function skipPackFindings(
+  skippedFindings: OperationalMemorySkippedFinding[],
+  pack: OperationalMemoryPack,
+  reason: OperationalMemoryContextSkipReason,
+  detail: string,
+): void {
+  for (const finding of pack.findings) {
+    skippedFindings.push({
+      packId: pack.packId,
+      findingId: finding.id,
+      reason,
+      detail,
+    });
+  }
+}
+
+function compareCandidates(a: CandidateFinding, b: CandidateFinding): number {
+  if (a.score !== b.score) return b.score - a.score;
+  const riskDelta = riskRank(a.finding.risk) - riskRank(b.finding.risk);
+  if (riskDelta !== 0) return riskDelta;
+  return a.originalIndex - b.originalIndex;
+}
+
+function riskRank(risk: OperationalMemoryRisk): number {
+  switch (risk) {
+    case "low":
+      return 0;
+    case "medium":
+      return 1;
+    case "high":
+      return 2;
+  }
+}
+
+function intersectNormalizedFamilies(
+  targetFamilies: readonly string[],
+  findingFamilies: readonly string[],
+): readonly string[] {
+  const targetSet = new Set(targetFamilies);
+  return uniqueNormalizedStrings(findingFamilies).filter((family) => targetSet.has(family));
+}
+
+function uniqueNormalizedStrings(values: readonly string[]): readonly string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const value of values) {
+    const item = value.trim().toLowerCase();
+    if (item.length === 0 || seen.has(item)) continue;
+    seen.add(item);
+    normalized.push(item);
+  }
+  return normalized;
+}
+
+function renderOperationalMemoryPrompt(findings: readonly OperationalMemorySelectedFinding[]): string {
+  if (findings.length === 0) return "";
+  return [
+    "Operational memory to apply:",
+    ...findings.map(
+      (finding, index) => `${index + 1}. ${finding.summary}\n   ${finding.reusableBehavior}`,
+    ),
+  ].join("\n");
 }

--- a/ts/src/control-plane/memory-packs/index.ts
+++ b/ts/src/control-plane/memory-packs/index.ts
@@ -114,11 +114,13 @@ export function compileOperationalMemoryContext(
         });
         continue;
       }
-      if (finding.containsTaskAnswer === true || finding.containsSecret === true) {
+      const leakageDetail = findingLeakageRiskDetail(finding);
+      if (leakageDetail !== undefined) {
         skippedFindings.push({
           packId: pack.packId,
           findingId: finding.id,
           reason: "leakage-risk",
+          detail: leakageDetail,
         });
         continue;
       }
@@ -248,6 +250,24 @@ function validateFinding(input: unknown, errors: string[]): void {
   if (input.containsSecret === true) {
     errors.push(`finding ${id} contains secret material`);
   }
+}
+
+function findingLeakageRiskDetail(finding: OperationalMemoryFinding): string | undefined {
+  const record = finding as unknown as Readonly<Record<string, unknown>>;
+  const details = [
+    leakageFlagRiskDetail(record, "containsTaskAnswer"),
+    leakageFlagRiskDetail(record, "containsSecret"),
+  ].filter((detail): detail is string => detail !== undefined);
+  return details.length === 0 ? undefined : details.join("; ");
+}
+
+function leakageFlagRiskDetail(
+  input: Readonly<Record<string, unknown>>,
+  field: "containsTaskAnswer" | "containsSecret",
+): string | undefined {
+  if (!Object.prototype.hasOwnProperty.call(input, field)) return undefined;
+  if (typeof input[field] !== "boolean") return `${field} must be boolean when present`;
+  return input[field] === true ? `${field}=true` : undefined;
 }
 
 function requireOptionalBoolean(

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -719,12 +719,20 @@ export type {
   DirectoryContractProbeInputs,
   DirectoryContractProbeResult,
 } from "./control-plane/contract-probes/index.js";
-export { validateOperationalMemoryPack } from "./control-plane/memory-packs/index.js";
+export {
+  compileOperationalMemoryContext,
+  validateOperationalMemoryPack,
+} from "./control-plane/memory-packs/index.js";
 export type {
+  CompileOperationalMemoryContextInputs,
+  OperationalMemoryContextApplication,
+  OperationalMemoryContextSkipReason,
   OperationalMemoryFinding,
   OperationalMemoryPack,
   OperationalMemoryPackStatus,
   OperationalMemoryRisk,
+  OperationalMemorySelectedFinding,
+  OperationalMemorySkippedFinding,
 } from "./control-plane/memory-packs/index.js";
 export {
   assessExternalEvalBoundaryPolicy,
@@ -732,6 +740,7 @@ export {
   buildExternalEvalImprovementSignals,
   buildOperationalMemoryPackFromDiagnostics,
   classifyExternalEvalTrial,
+  decideExternalEvalContextPromotion,
   validateExternalEvalAdapterLifecycle,
   validateExternalEvalBoundaryPolicy,
 } from "./control-plane/external-evals/index.js";
@@ -740,6 +749,7 @@ export type {
   BuildExternalEvalDiagnosticReportInputs,
   BuildOperationalMemoryPackFromDiagnosticsInputs,
   ClassifyExternalEvalTrialInputs,
+  DecideExternalEvalContextPromotionInputs,
   ExternalEvalAdapterArtifacts,
   ExternalEvalAdapterCommand,
   ExternalEvalAdapterLifecycle,
@@ -752,6 +762,8 @@ export type {
   ExternalEvalBoundaryPolicyMode,
   ExternalEvalBoundaryViolation,
   ExternalEvalBoundaryViolationReason,
+  ExternalEvalContextPromotionDecision,
+  ExternalEvalContextPromotionStatus,
   ExternalEvalDiagnosticCategory,
   ExternalEvalDiagnosticReport,
   ExternalEvalImprovementSignal,

--- a/ts/tests/control-plane/external-evals/diagnostics.test.ts
+++ b/ts/tests/control-plane/external-evals/diagnostics.test.ts
@@ -830,6 +830,54 @@ describe("external eval diagnostics", () => {
       regressedTaskIds: ["fibonacci-server"],
     });
   });
+
+  test("scores promotion by task when imported trial IDs are duplicated", () => {
+    const decision = decideExternalEvalContextPromotion({
+      baselineRunId: "baseline",
+      candidateRunId: "context-duplicated-trial-ids",
+      baselineTrials: [
+        {
+          taskId: "task-a",
+          trialId: "task-a.baseline",
+          attempt: 1,
+          status: "passed",
+          reward: 1,
+        },
+        {
+          taskId: "task-b",
+          trialId: "task-b.baseline",
+          attempt: 1,
+          status: "failed",
+          reward: 0,
+        },
+      ],
+      candidateTrials: [
+        {
+          taskId: "task-a",
+          trialId: "dup",
+          attempt: 1,
+          status: "failed",
+          reward: 0,
+        },
+        {
+          taskId: "task-b",
+          trialId: "dup",
+          attempt: 1,
+          status: "passed",
+          reward: 1,
+        },
+      ],
+    });
+
+    expect(decision).toMatchObject({
+      pass: false,
+      status: "reject-regression",
+      baselinePassedTaskCount: 1,
+      candidatePassedTaskCount: 1,
+      improvedTaskIds: ["task-b"],
+      regressedTaskIds: ["task-a"],
+    });
+  });
 });
 
 function prettyVerifierOutput(parserResults: Record<string, string>): string {

--- a/ts/tests/control-plane/external-evals/diagnostics.test.ts
+++ b/ts/tests/control-plane/external-evals/diagnostics.test.ts
@@ -3,8 +3,12 @@ import {
   buildExternalEvalDiagnosticReport,
   buildExternalEvalImprovementSignals,
   buildOperationalMemoryPackFromDiagnostics,
+  decideExternalEvalContextPromotion,
 } from "../../../src/control-plane/external-evals/index.js";
-import { validateOperationalMemoryPack } from "../../../src/control-plane/memory-packs/index.js";
+import {
+  compileOperationalMemoryContext,
+  validateOperationalMemoryPack,
+} from "../../../src/control-plane/memory-packs/index.js";
 import type { EvalTrial } from "../../../src/control-plane/contract/types.js";
 
 const trials: EvalTrial[] = [
@@ -690,6 +694,141 @@ describe("external eval diagnostics", () => {
       "unique noise line 2",
     ]);
     expect(report.diagnostics[0]?.failureExcerpts).not.toContain(lateFailure);
+  });
+
+  test("records the applied operational-memory context on diagnostic reports", () => {
+    const contextApplication = compileOperationalMemoryContext({
+      contextId: "tb-dev10-selected-v1",
+      createdAt: "2026-05-11T16:00:00.000Z",
+      taskId: "hf-model-inference",
+      targetFamilies: ["terminal", "artifact-contract"],
+      maxFindings: 1,
+      packs: [
+        {
+          packId: "tb-dev10-memory",
+          version: "1.0.0",
+          createdAt: "2026-05-11T15:00:00.000Z",
+          status: "sanitized",
+          integrity: { status: "clean" },
+          findings: [
+            {
+              id: "required-artifact-contract",
+              summary: "Verify required output artifacts at checked paths.",
+              evidenceRefs: ["runs/dev10/hf-model-inference/tests.log"],
+              reusableBehavior: "Read every required artifact from its checked path before finishing.",
+              targetFamilies: ["terminal", "artifact-contract"],
+              risk: "low",
+              containsTaskAnswer: false,
+              containsSecret: false,
+            },
+            {
+              id: "schema-key-contract",
+              summary: "Validate exact schema keys.",
+              evidenceRefs: ["runs/dev10/schema/tests.log"],
+              reusableBehavior: "Read structured outputs back and compare field names.",
+              targetFamilies: ["terminal", "structured-output"],
+              risk: "low",
+              containsTaskAnswer: false,
+              containsSecret: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-dev10-context-selected",
+      createdAt: "2026-05-11T16:05:00.000Z",
+      trials: [],
+      evidence: [],
+      contextApplication,
+    });
+
+    expect(report.contextApplication?.contextId).toBe("tb-dev10-selected-v1");
+    expect(report.contextApplication?.selectedFindings.map((finding) => finding.findingId)).toEqual([
+      "required-artifact-contract",
+    ]);
+    expect(report.contextApplication?.skippedFindings.map((finding) => finding.reason)).toEqual([
+      "capacity-limit",
+    ]);
+  });
+
+  test("holds context variants without dev-set gain and rejects regressions", () => {
+    const baselineTrials: EvalTrial[] = [
+      {
+        taskId: "fibonacci-server",
+        trialId: "fibonacci-server.1-of-1.baseline",
+        attempt: 1,
+        status: "passed",
+        reward: 1,
+      },
+      {
+        taskId: "hf-model-inference",
+        trialId: "hf-model-inference.1-of-1.baseline",
+        attempt: 1,
+        status: "failed",
+        reward: 0,
+      },
+    ];
+
+    expect(
+      decideExternalEvalContextPromotion({
+        baselineRunId: "baseline",
+        candidateRunId: "context-v1",
+        baselineTrials,
+        candidateTrials: [
+          {
+            taskId: "fibonacci-server",
+            trialId: "fibonacci-server.1-of-1.context-v1",
+            attempt: 1,
+            status: "passed",
+            reward: 1,
+          },
+          {
+            taskId: "hf-model-inference",
+            trialId: "hf-model-inference.1-of-1.context-v1",
+            attempt: 1,
+            status: "failed",
+            reward: 0,
+          },
+        ],
+      }),
+    ).toMatchObject({
+      pass: false,
+      status: "hold-for-dev",
+      baselinePassedTaskCount: 1,
+      candidatePassedTaskCount: 1,
+      improvedTaskIds: [],
+      regressedTaskIds: [],
+    });
+
+    expect(
+      decideExternalEvalContextPromotion({
+        baselineRunId: "baseline",
+        candidateRunId: "context-v2",
+        baselineTrials,
+        candidateTrials: [
+          {
+            taskId: "fibonacci-server",
+            trialId: "fibonacci-server.1-of-1.context-v2",
+            attempt: 1,
+            status: "failed",
+            reward: 0,
+          },
+          {
+            taskId: "hf-model-inference",
+            trialId: "hf-model-inference.1-of-1.context-v2",
+            attempt: 1,
+            status: "failed",
+            reward: 0,
+          },
+        ],
+      }),
+    ).toMatchObject({
+      pass: false,
+      status: "reject-regression",
+      regressedTaskIds: ["fibonacci-server"],
+    });
   });
 });
 

--- a/ts/tests/control-plane/memory-packs/memory-pack.test.ts
+++ b/ts/tests/control-plane/memory-packs/memory-pack.test.ts
@@ -224,4 +224,44 @@ describe("compileOperationalMemoryContext", () => {
     ]);
     expect(context.prompt).toBe("");
   });
+
+  test("quarantines malformed leakage flags before rendering context", () => {
+    const context = compileOperationalMemoryContext({
+      contextId: "malformed-leakage-context",
+      createdAt: "2026-05-11T15:10:00.000Z",
+      targetFamilies: ["terminal"],
+      packs: [
+        {
+          packId: "malformed-pack",
+          version: "1.0.0",
+          createdAt: "2026-05-11T14:00:00.000Z",
+          status: "sanitized",
+          integrity: { status: "clean" },
+          findings: [
+            {
+              id: "string-secret-flag",
+              summary: "Malformed producer output.",
+              evidenceRefs: ["runs/dev10/leaky/tests.log"],
+              reusableBehavior: "FLAG{secret} should never be rendered.",
+              targetFamilies: ["terminal"],
+              risk: "low",
+              containsSecret: "true" as unknown as boolean,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(context.selectedFindings).toEqual([]);
+    expect(context.skippedFindings).toEqual([
+      {
+        packId: "malformed-pack",
+        findingId: "string-secret-flag",
+        reason: "leakage-risk",
+        detail: "containsSecret must be boolean when present",
+      },
+    ]);
+    expect(context.prompt).not.toContain("FLAG{secret}");
+    expect(context.prompt).toBe("");
+  });
 });

--- a/ts/tests/control-plane/memory-packs/memory-pack.test.ts
+++ b/ts/tests/control-plane/memory-packs/memory-pack.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { validateOperationalMemoryPack } from "../../../src/control-plane/memory-packs/index.js";
+import {
+  compileOperationalMemoryContext,
+  validateOperationalMemoryPack,
+} from "../../../src/control-plane/memory-packs/index.js";
 
 describe("validateOperationalMemoryPack", () => {
   test("accepts sanitized reusable operational findings", () => {
@@ -79,5 +82,146 @@ describe("validateOperationalMemoryPack", () => {
       expect(result.errors).toContain("finding leaky containsTaskAnswer must be a boolean when present");
       expect(result.errors).toContain("finding leaky containsSecret must be a boolean when present");
     }
+  });
+});
+
+describe("compileOperationalMemoryContext", () => {
+  test("selects bounded family-matched findings and records skipped findings", () => {
+    const context = compileOperationalMemoryContext({
+      contextId: "tb-dev10-selected-v1",
+      createdAt: "2026-05-11T15:00:00.000Z",
+      taskId: "hf-model-inference",
+      targetFamilies: ["terminal", "artifact-contract"],
+      maxFindings: 1,
+      riskTolerance: "medium",
+      packs: [
+        {
+          packId: "tb-dev10-memory",
+          version: "1.0.0",
+          createdAt: "2026-05-11T14:00:00.000Z",
+          status: "sanitized",
+          integrity: { status: "clean" },
+          findings: [
+            {
+              id: "required-artifact-contract",
+              summary: "Verify required output artifacts at checked paths.",
+              evidenceRefs: ["runs/dev10/hf-model-inference/tests.log"],
+              reusableBehavior: "Read every required artifact from its checked path before finishing.",
+              targetFamilies: ["terminal", "artifact-contract"],
+              risk: "low",
+              containsTaskAnswer: false,
+              containsSecret: false,
+            },
+            {
+              id: "schema-key-contract",
+              summary: "Validate exact output schema keys.",
+              evidenceRefs: ["runs/dev10/structured-output/tests.log"],
+              reusableBehavior: "Read structured output back and compare required key names.",
+              targetFamilies: ["terminal", "structured-output"],
+              risk: "low",
+              containsTaskAnswer: false,
+              containsSecret: false,
+            },
+            {
+              id: "domain-correctness-validation",
+              summary: "Validate numeric quality.",
+              evidenceRefs: ["runs/dev10/raman-fitting/tests.log"],
+              reusableBehavior: "Add an independent numeric reasonableness check.",
+              targetFamilies: ["numeric-analysis"],
+              risk: "medium",
+              containsTaskAnswer: false,
+              containsSecret: false,
+            },
+            {
+              id: "high-risk-terminal",
+              summary: "Use only when explicitly requested.",
+              evidenceRefs: ["runs/dev10/high-risk/tests.log"],
+              reusableBehavior: "Apply a broad terminal workflow rewrite.",
+              targetFamilies: ["terminal"],
+              risk: "high",
+              containsTaskAnswer: false,
+              containsSecret: false,
+            },
+            {
+              id: "leaky-finding",
+              summary: "Leaky finding.",
+              evidenceRefs: ["runs/dev10/leaky/tests.log"],
+              reusableBehavior: "Contains secret material.",
+              targetFamilies: ["terminal"],
+              risk: "low",
+              containsTaskAnswer: false,
+              containsSecret: true,
+            },
+            {
+              id: "required-artifact-contract",
+              summary: "Duplicate artifact guidance.",
+              evidenceRefs: ["runs/dev10/duplicate/tests.log"],
+              reusableBehavior: "Duplicate guidance should not be repeated.",
+              targetFamilies: ["terminal", "artifact-contract"],
+              risk: "low",
+              containsTaskAnswer: false,
+              containsSecret: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(context.selectedFindings.map((finding) => finding.findingId)).toEqual([
+      "required-artifact-contract",
+    ]);
+    expect(context.selectedFindings[0]).toMatchObject({
+      packId: "tb-dev10-memory",
+      matchedTargetFamilies: ["terminal", "artifact-contract"],
+    });
+    expect(context.prompt).toContain("Read every required artifact from its checked path");
+    expect(context.prompt).not.toContain("Read structured output back");
+    expect(context.skippedFindings.map((finding) => [finding.findingId, finding.reason])).toEqual([
+      ["domain-correctness-validation", "target-family-mismatch"],
+      ["high-risk-terminal", "risk-too-high"],
+      ["leaky-finding", "leakage-risk"],
+      ["required-artifact-contract", "duplicate-finding"],
+      ["schema-key-contract", "capacity-limit"],
+    ]);
+  });
+
+  test("quarantines findings from non-clean memory packs", () => {
+    const context = compileOperationalMemoryContext({
+      contextId: "contaminated-context",
+      createdAt: "2026-05-11T15:05:00.000Z",
+      targetFamilies: ["terminal"],
+      packs: [
+        {
+          packId: "contaminated-pack",
+          version: "1.0.0",
+          createdAt: "2026-05-11T14:00:00.000Z",
+          status: "sanitized",
+          integrity: { status: "contaminated", notes: ["read held-out answer"] },
+          findings: [
+            {
+              id: "do-not-apply",
+              summary: "Should not be applied.",
+              evidenceRefs: ["runs/heldout/trace.jsonl"],
+              reusableBehavior: "This pack is contaminated.",
+              targetFamilies: ["terminal"],
+              risk: "low",
+              containsTaskAnswer: false,
+              containsSecret: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(context.selectedFindings).toEqual([]);
+    expect(context.skippedFindings).toEqual([
+      {
+        packId: "contaminated-pack",
+        findingId: "do-not-apply",
+        reason: "pack-integrity-not-clean",
+        detail: "integrity=contaminated",
+      },
+    ]);
+    expect(context.prompt).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- add a bounded operational-memory context compiler with family matching, risk filtering, leakage/integrity quarantine, dedupe, and selected/skipped audit output
- let external-eval diagnostic reports record the context application used for a run
- add a dev-set promotion gate for context variants so held-out runs require same task coverage, no disallowed regressions, and a configurable resolved-task gain

## Benchmark context
Terminal-Bench dev10 showed that broader extracted memory can over-constrain the agent: baseline 7/10, context v1 7/10, richer context v2 6/10 with a Fibonacci regression. This change addresses the application side before any held-out run is promoted.

## Verification
- npm test -- tests/control-plane/memory-packs/memory-pack.test.ts tests/control-plane/external-evals/diagnostics.test.ts
- npm run lint
- npm run build
- npm test (728 files, 5027 tests)