### PR TITLE
AC-720: Formalize runtime context layering

### DIFF
--- a/autocontext/src/autocontext/session/__init__.py
+++ b/autocontext/src/autocontext/session/__init__.py
@@ -1,3 +1,15 @@
+from autocontext.session.runtime_context import (
+    RUNTIME_CONTEXT_LAYER_KEYS,
+    RUNTIME_CONTEXT_LAYERS,
+    RepoInstruction,
+    RuntimeContextDiscoveryRequest,
+    RuntimeContextLayer,
+    RuntimeContextLayerKey,
+    discover_repo_instructions,
+    discover_runtime_skills,
+    runtime_skill_discovery_roots,
+    select_runtime_knowledge_components,
+)
 from autocontext.session.runtime_events import (
     RuntimeSessionEvent,
     RuntimeSessionEventLog,
@@ -38,9 +50,15 @@ from autocontext.session.runtime_session_timeline import (
 
 __all__ = [
     "DEFAULT_CHILD_TASK_MAX_DEPTH",
+    "RUNTIME_CONTEXT_LAYER_KEYS",
+    "RUNTIME_CONTEXT_LAYERS",
+    "RepoInstruction",
     "RuntimeChildTaskHandlerInput",
     "RuntimeChildTaskHandlerOutput",
     "RuntimeChildTaskResult",
+    "RuntimeContextDiscoveryRequest",
+    "RuntimeContextLayer",
+    "RuntimeContextLayerKey",
     "RuntimeChildTaskRunner",
     "RuntimeSession",
     "RuntimeSessionCompactionInput",
@@ -56,6 +74,8 @@ __all__ = [
     "build_runtime_session_timeline",
     "create_runtime_session_grant_event_sink",
     "create_runtime_session_for_run",
+    "discover_repo_instructions",
+    "discover_runtime_skills",
     "open_runtime_session_for_run",
     "read_runtime_session_by_id",
     "read_runtime_session_by_run_id",
@@ -63,5 +83,7 @@ __all__ = [
     "read_runtime_session_timeline_by_id",
     "read_runtime_session_timeline_by_run_id",
     "runtime_session_id_for_run",
+    "runtime_skill_discovery_roots",
+    "select_runtime_knowledge_components",
     "summarize_runtime_session",
 ]

--- a/autocontext/src/autocontext/session/runtime_context.py
+++ b/autocontext/src/autocontext/session/runtime_context.py
@@ -1,0 +1,226 @@
+"""Runtime context layering and cwd-scoped discovery contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+from autocontext.session.skill_registry import SkillRegistry
+
+REPO_INSTRUCTION_FILENAMES = ("AGENTS.md", "CLAUDE.md")
+RUNTIME_SKILL_DIRS = (".autoctx/skills", ".claude/skills", ".codex/skills", "skills")
+
+
+class RuntimeContextLayerKey(StrEnum):
+    SYSTEM_POLICY = "system_policy"
+    REPO_INSTRUCTIONS = "repo_instructions"
+    ROLE_INSTRUCTIONS = "role_instructions"
+    SCENARIO_CONTEXT = "scenario_context"
+    KNOWLEDGE = "knowledge"
+    RUNTIME_SKILLS = "runtime_skills"
+    TOOL_AFFORDANCES = "tool_affordances"
+    SESSION_HISTORY = "session_history"
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeContextLayer:
+    key: RuntimeContextLayerKey
+    order: int
+    owner: str
+    persistence: str
+    budget: str
+    child_task_behavior: str
+
+
+@dataclass(frozen=True, slots=True)
+class RepoInstruction:
+    path: Path
+    relative_path: str
+    content: str
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeContextDiscoveryRequest:
+    workspace_root: Path
+    cwd: str | Path = "/"
+    configured_skill_roots: Sequence[Path] = field(default_factory=tuple)
+
+    def for_child_task(self, cwd: str | Path) -> RuntimeContextDiscoveryRequest:
+        return RuntimeContextDiscoveryRequest(
+            workspace_root=self.workspace_root,
+            cwd=cwd,
+            configured_skill_roots=tuple(self.configured_skill_roots),
+        )
+
+
+RUNTIME_CONTEXT_LAYERS = (
+    RuntimeContextLayer(
+        key=RuntimeContextLayerKey.SYSTEM_POLICY,
+        order=1,
+        owner="runtime",
+        persistence="bundled",
+        budget="protected",
+        child_task_behavior="inherit",
+    ),
+    RuntimeContextLayer(
+        key=RuntimeContextLayerKey.REPO_INSTRUCTIONS,
+        order=2,
+        owner="workspace",
+        persistence="repo",
+        budget="protected",
+        child_task_behavior="recompute_from_child_cwd",
+    ),
+    RuntimeContextLayer(
+        key=RuntimeContextLayerKey.ROLE_INSTRUCTIONS,
+        order=3,
+        owner="autocontext",
+        persistence="bundled",
+        budget="protected",
+        child_task_behavior="inherit_or_override_by_role",
+    ),
+    RuntimeContextLayer(
+        key=RuntimeContextLayerKey.SCENARIO_CONTEXT,
+        order=4,
+        owner="scenario",
+        persistence="run",
+        budget="protected",
+        child_task_behavior="inherit_task_slice",
+    ),
+    RuntimeContextLayer(
+        key=RuntimeContextLayerKey.KNOWLEDGE,
+        order=5,
+        owner="knowledge",
+        persistence="knowledge",
+        budget="compress",
+        child_task_behavior="include_applicable_knowledge",
+    ),
+    RuntimeContextLayer(
+        key=RuntimeContextLayerKey.RUNTIME_SKILLS,
+        order=6,
+        owner="workspace",
+        persistence="repo_or_skill_store",
+        budget="manifest_first",
+        child_task_behavior="recompute_from_child_cwd",
+    ),
+    RuntimeContextLayer(
+        key=RuntimeContextLayerKey.TOOL_AFFORDANCES,
+        order=7,
+        owner="runtime",
+        persistence="ephemeral",
+        budget="summarize",
+        child_task_behavior="inherit_scoped_grants",
+    ),
+    RuntimeContextLayer(
+        key=RuntimeContextLayerKey.SESSION_HISTORY,
+        order=8,
+        owner="runtime_session",
+        persistence="runtime_session_log",
+        budget="compact",
+        child_task_behavior="recompute_from_child_session",
+    ),
+)
+RUNTIME_CONTEXT_LAYER_KEYS = tuple(layer.key for layer in RUNTIME_CONTEXT_LAYERS)
+
+
+def discover_repo_instructions(request: RuntimeContextDiscoveryRequest) -> tuple[RepoInstruction, ...]:
+    root = _workspace_root(request)
+    cwd = _resolve_cwd(root, request.cwd)
+    instructions: list[RepoInstruction] = []
+    for directory in _ancestor_dirs(root, cwd, nearest_first=False):
+        for filename in REPO_INSTRUCTION_FILENAMES:
+            path = directory / filename
+            if not path.is_file():
+                continue
+            instructions.append(
+                RepoInstruction(
+                    path=path,
+                    relative_path=_relative_posix(path, root),
+                    content=path.read_text(encoding="utf-8"),
+                )
+            )
+    return tuple(instructions)
+
+
+def runtime_skill_discovery_roots(request: RuntimeContextDiscoveryRequest) -> tuple[Path, ...]:
+    root = _workspace_root(request)
+    cwd = _resolve_cwd(root, request.cwd)
+    roots: list[Path] = []
+    seen: set[Path] = set()
+
+    for configured_root in request.configured_skill_roots:
+        _append_existing_unique_dir(roots, seen, _resolve_configured_root(root, configured_root))
+
+    for directory in _ancestor_dirs(root, cwd, nearest_first=True):
+        for skill_dir in RUNTIME_SKILL_DIRS:
+            _append_existing_unique_dir(roots, seen, directory / skill_dir)
+    return tuple(roots)
+
+
+def discover_runtime_skills(request: RuntimeContextDiscoveryRequest) -> SkillRegistry:
+    registry = SkillRegistry()
+    for root in runtime_skill_discovery_roots(request):
+        registry.discover(root)
+    return registry
+
+
+def select_runtime_knowledge_components(
+    components: Mapping[str, str],
+    *,
+    include: Sequence[str] | None = None,
+    exclude: Sequence[str] = (),
+) -> dict[str, str]:
+    allowed = set(include) if include is not None else None
+    blocked = set(exclude)
+    selected: dict[str, str] = {}
+    for key, value in components.items():
+        if allowed is not None and key not in allowed:
+            continue
+        if key in blocked or not value:
+            continue
+        selected[key] = value
+    return selected
+
+
+def _workspace_root(request: RuntimeContextDiscoveryRequest) -> Path:
+    return request.workspace_root.resolve()
+
+
+def _resolve_cwd(root: Path, cwd: str | Path) -> Path:
+    raw_cwd = str(cwd)
+    candidate = root / raw_cwd.lstrip("/") if raw_cwd.startswith("/") else root / raw_cwd
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"Runtime context cwd escapes workspace root: {cwd}") from exc
+    return resolved
+
+
+def _resolve_configured_root(root: Path, skill_root: Path) -> Path:
+    if skill_root.is_absolute():
+        return skill_root.resolve()
+    return (root / skill_root).resolve()
+
+
+def _ancestor_dirs(root: Path, cwd: Path, *, nearest_first: bool) -> tuple[Path, ...]:
+    dirs: list[Path] = []
+    current = cwd
+    while True:
+        dirs.append(current)
+        if current == root:
+            break
+        current = current.parent
+    return tuple(dirs if nearest_first else reversed(dirs))
+
+
+def _append_existing_unique_dir(roots: list[Path], seen: set[Path], path: Path) -> None:
+    if path in seen or not path.is_dir():
+        return
+    seen.add(path)
+    roots.append(path)
+
+
+def _relative_posix(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()

--- a/autocontext/tests/test_runtime_context_layers.py
+++ b/autocontext/tests/test_runtime_context_layers.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _write_skill(root: Path, name: str, description: str) -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"""---
+name: {name}
+description: {description}
+---
+
+# {name}
+
+Instructions for {name}.
+""",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def test_runtime_context_layer_order_is_canonical() -> None:
+    from autocontext.session.runtime_context import (
+        RUNTIME_CONTEXT_LAYER_KEYS,
+        RUNTIME_CONTEXT_LAYERS,
+        RuntimeContextLayerKey,
+    )
+
+    assert RUNTIME_CONTEXT_LAYER_KEYS == (
+        RuntimeContextLayerKey.SYSTEM_POLICY,
+        RuntimeContextLayerKey.REPO_INSTRUCTIONS,
+        RuntimeContextLayerKey.ROLE_INSTRUCTIONS,
+        RuntimeContextLayerKey.SCENARIO_CONTEXT,
+        RuntimeContextLayerKey.KNOWLEDGE,
+        RuntimeContextLayerKey.RUNTIME_SKILLS,
+        RuntimeContextLayerKey.TOOL_AFFORDANCES,
+        RuntimeContextLayerKey.SESSION_HISTORY,
+    )
+    assert [layer.order for layer in RUNTIME_CONTEXT_LAYERS] == list(range(1, 9))
+    assert {layer.key for layer in RUNTIME_CONTEXT_LAYERS} == set(RUNTIME_CONTEXT_LAYER_KEYS)
+    assert next(layer for layer in RUNTIME_CONTEXT_LAYERS if layer.key == RuntimeContextLayerKey.KNOWLEDGE).budget == "compress"
+    assert next(
+        layer for layer in RUNTIME_CONTEXT_LAYERS if layer.key == RuntimeContextLayerKey.SESSION_HISTORY
+    ).child_task_behavior == "recompute_from_child_session"
+
+
+def test_repo_instruction_discovery_is_missing_safe_and_child_cwd_specific(tmp_path: Path) -> None:
+    from autocontext.session.runtime_context import (
+        RuntimeContextDiscoveryRequest,
+        discover_repo_instructions,
+    )
+
+    request = RuntimeContextDiscoveryRequest(workspace_root=tmp_path, cwd="/pkg")
+    assert discover_repo_instructions(request) == ()
+
+    (tmp_path / "AGENTS.md").write_text("root agents\n", encoding="utf-8")
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "CLAUDE.md").write_text("pkg claude\n", encoding="utf-8")
+    (tmp_path / "other").mkdir()
+    (tmp_path / "other" / "AGENTS.md").write_text("other agents\n", encoding="utf-8")
+
+    parent_instructions = discover_repo_instructions(request)
+    child_instructions = discover_repo_instructions(request.for_child_task(cwd="/other"))
+
+    assert tuple(instruction.relative_path for instruction in parent_instructions) == ("AGENTS.md", "pkg/CLAUDE.md")
+    assert tuple(instruction.content for instruction in parent_instructions) == ("root agents\n", "pkg claude\n")
+    assert tuple(instruction.relative_path for instruction in child_instructions) == ("AGENTS.md", "other/AGENTS.md")
+
+
+def test_runtime_skill_discovery_is_cwd_specific_and_deduplicates(tmp_path: Path) -> None:
+    from autocontext.session.runtime_context import RuntimeContextDiscoveryRequest, discover_runtime_skills
+
+    root_skills = tmp_path / ".claude" / "skills"
+    pkg_skills = tmp_path / "pkg" / ".claude" / "skills"
+    _write_skill(root_skills, "shared", "root shared")
+    _write_skill(root_skills, "root-only", "root only")
+    pkg_shared = _write_skill(pkg_skills, "shared", "package shared")
+    _write_skill(pkg_skills, "pkg-only", "package only")
+
+    registry = discover_runtime_skills(RuntimeContextDiscoveryRequest(workspace_root=tmp_path, cwd="/pkg"))
+    manifests = registry.all_manifests()
+
+    assert [manifest.name for manifest in manifests] == ["pkg-only", "shared", "root-only"]
+    assert registry.get("shared") is not None
+    assert registry.get("shared").manifest.skill_path == pkg_shared
+
+    root_registry = discover_runtime_skills(RuntimeContextDiscoveryRequest(workspace_root=tmp_path, cwd="/"))
+    assert [manifest.name for manifest in root_registry.all_manifests()] == ["root-only", "shared"]
+
+
+def test_knowledge_components_respect_include_exclude_and_empty_values() -> None:
+    from autocontext.session.runtime_context import select_runtime_knowledge_components
+
+    selected = select_runtime_knowledge_components(
+        {
+            "playbook": "Use validated strategy.",
+            "hints": "",
+            "lessons": "Lesson one.",
+            "dead_ends": "Avoid stale path.",
+            "private_notes": "do not include",
+        },
+        include=("playbook", "hints", "lessons", "dead_ends"),
+        exclude=("lessons",),
+    )
+
+    assert selected == {
+        "playbook": "Use validated strategy.",
+        "dead_ends": "Avoid stale path.",
+    }

--- a/docs/concept-model.md
+++ b/docs/concept-model.md
@@ -68,6 +68,25 @@ These are the execution nouns we should use when describing how the system actua
 | artifacts | Umbrella category over runtime outputs | Use as a collection term, not a peer to `Scenario` or `Mission`. |
 | runtime-session event log | `Artifact` emitted by a `Run` or child task | Durable observability and replay source for provider turns, shell/tool activity, child-task lineage, and compaction summaries. |
 
+## Runtime Context Assembly
+
+Runtime context is not a new top-level product noun. It is the ordered prompt/runtime material assembled for a `Run`, `Step`, or child task from `Policy`, workspace files, AutoContext roles, `Scenario`/`Task` inputs, `Knowledge`, skills, tools, and runtime-session history.
+
+The canonical layer order is exposed in Python as `autocontext.session.RUNTIME_CONTEXT_LAYERS` and in TypeScript as `RUNTIME_CONTEXT_LAYERS` from `@greyhaven/autoctx`. Implementations may render the layers differently, but they should keep this order observable:
+
+| Order | Layer | Owner | Persistence | Budget / compaction behavior | Child-task behavior |
+| --- | --- | --- | --- | --- | --- |
+| 1 | system/runtime policy | Runtime | Bundled | Protected; never trimmed by prompt budget. | Inherited. |
+| 2 | repo-local instructions (`AGENTS.md`, `CLAUDE.md`) | Workspace | Repo files | Protected; missing files are allowed. | Recomputed from the child task `cwd`. |
+| 3 | AutoContext role instructions | AutoContext | Bundled | Protected; role-specific overrides should replace, not duplicate, base role text. | Inherited or overridden by the child role. |
+| 4 | `Scenario`/`Task` prompt context | Scenario / Task | Run input | Protected task slice; too-large user context should fail or be summarized before execution. | Parent passes only the child task slice. |
+| 5 | persisted `Knowledge` (playbooks, hints, lessons, dead ends) | Knowledge store | Knowledge artifacts | Compressible/promotable; include only applicable, non-empty, non-excluded components. | Re-selected for the child task and scenario. |
+| 6 | runtime-discovered skills | Workspace / skill store | Repo or skill store | Manifest-first; load full bodies lazily and deduplicate by skill name. | Recomputed from the child `cwd`; nearest cwd skill roots win duplicate names. |
+| 7 | tool affordances and scoped grants | Runtime | Ephemeral grant scope | Summarize tool metadata and redact secrets; scoped grants carry explicit inheritance policy. | Inherit only grants allowed by policy. |
+| 8 | recent session history and compaction summaries | Runtime session | Runtime-session log and compaction artifacts | Compact when pressure crosses policy thresholds; summaries point back to source events. | Child tasks use their own session log and linked parent lineage. |
+
+Repo instruction discovery walks from workspace root to the current `cwd`, loading `AGENTS.md` and `CLAUDE.md` when present. Skill discovery walks from the current `cwd` back to the root so more specific skill roots can override broad ones by name while still falling back to shared root skills. This intentionally borrows the useful Flue distinction between bundled role behavior and runtime workspace discovery without replacing AutoContext's `Scenario`, `Task`, `Mission`, `Run`, `Artifact`, or `Knowledge` vocabulary.
+
 ## Durable Session Event Storage
 
 A durable `runtime-session event log` is an append-only `Artifact` for one `Run` or child task. It is not a new top-level product noun; it is the storage bridge that lets operators replay what happened while still mapping every event back to `Run`, `Step`, `Artifact`, `Knowledge`, `Budget`, and `Policy`.

--- a/docs/concept-model.md
+++ b/docs/concept-model.md
@@ -72,7 +72,7 @@ These are the execution nouns we should use when describing how the system actua
 
 Runtime context is not a new top-level product noun. It is the ordered prompt/runtime material assembled for a `Run`, `Step`, or child task from `Policy`, workspace files, AutoContext roles, `Scenario`/`Task` inputs, `Knowledge`, skills, tools, and runtime-session history.
 
-The canonical layer order is exposed in Python as `autocontext.session.RUNTIME_CONTEXT_LAYERS` and in TypeScript as `RUNTIME_CONTEXT_LAYERS` from `@greyhaven/autoctx`. Implementations may render the layers differently, but they should keep this order observable:
+The canonical layer order is exposed in Python as `autocontext.session.RUNTIME_CONTEXT_LAYERS` and in TypeScript as `RUNTIME_CONTEXT_LAYERS` from `autoctx`. Implementations may render the layers differently, but they should keep this order observable:
 
 | Order | Layer | Owner | Persistence | Budget / compaction behavior | Child-task behavior |
 | --- | --- | --- | --- | --- | --- |

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -287,6 +287,21 @@ export {
   summarizeRuntimeSession,
 } from "./session/runtime-session-read-model.js";
 export {
+  RUNTIME_CONTEXT_LAYER_KEYS,
+  RUNTIME_CONTEXT_LAYERS,
+  RuntimeContextDiscoveryRequest,
+  RuntimeContextLayerKey,
+  discoverRepoInstructions,
+  discoverRuntimeSkills,
+  runtimeSkillDiscoveryRoots,
+  selectRuntimeKnowledgeComponents,
+} from "./session/runtime-context.js";
+export type {
+  RepoInstruction,
+  RuntimeContextLayer,
+  RuntimeContextDiscoveryRequestOptions,
+} from "./session/runtime-context.js";
+export {
   buildRuntimeSessionTimeline,
   readRuntimeSessionTimelineById,
   readRuntimeSessionTimelineByRunId,

--- a/ts/src/session/runtime-context.ts
+++ b/ts/src/session/runtime-context.ts
@@ -1,0 +1,232 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { relative, resolve } from "node:path";
+
+import { SkillRegistry } from "./skill-registry.js";
+
+export const REPO_INSTRUCTION_FILENAMES = ["AGENTS.md", "CLAUDE.md"] as const;
+export const RUNTIME_SKILL_DIRS = [".autoctx/skills", ".claude/skills", ".codex/skills", "skills"] as const;
+
+export const RuntimeContextLayerKey = {
+  SYSTEM_POLICY: "system_policy",
+  REPO_INSTRUCTIONS: "repo_instructions",
+  ROLE_INSTRUCTIONS: "role_instructions",
+  SCENARIO_CONTEXT: "scenario_context",
+  KNOWLEDGE: "knowledge",
+  RUNTIME_SKILLS: "runtime_skills",
+  TOOL_AFFORDANCES: "tool_affordances",
+  SESSION_HISTORY: "session_history",
+} as const;
+export type RuntimeContextLayerKey = (typeof RuntimeContextLayerKey)[keyof typeof RuntimeContextLayerKey];
+
+export interface RuntimeContextLayer {
+  readonly key: RuntimeContextLayerKey;
+  readonly order: number;
+  readonly owner: string;
+  readonly persistence: string;
+  readonly budget: string;
+  readonly childTaskBehavior: string;
+}
+
+export interface RepoInstruction {
+  readonly path: string;
+  readonly relativePath: string;
+  readonly content: string;
+}
+
+export interface RuntimeContextDiscoveryRequestOptions {
+  readonly workspaceRoot: string;
+  readonly cwd?: string;
+  readonly configuredSkillRoots?: readonly string[];
+}
+
+export class RuntimeContextDiscoveryRequest {
+  readonly workspaceRoot: string;
+  readonly cwd: string;
+  readonly configuredSkillRoots: readonly string[];
+
+  constructor(opts: RuntimeContextDiscoveryRequestOptions) {
+    this.workspaceRoot = opts.workspaceRoot;
+    this.cwd = opts.cwd ?? "/";
+    this.configuredSkillRoots = opts.configuredSkillRoots ?? [];
+  }
+
+  forChildTask(cwd: string): RuntimeContextDiscoveryRequest {
+    return new RuntimeContextDiscoveryRequest({
+      workspaceRoot: this.workspaceRoot,
+      cwd,
+      configuredSkillRoots: this.configuredSkillRoots,
+    });
+  }
+}
+
+export const RUNTIME_CONTEXT_LAYERS: readonly RuntimeContextLayer[] = [
+  {
+    key: RuntimeContextLayerKey.SYSTEM_POLICY,
+    order: 1,
+    owner: "runtime",
+    persistence: "bundled",
+    budget: "protected",
+    childTaskBehavior: "inherit",
+  },
+  {
+    key: RuntimeContextLayerKey.REPO_INSTRUCTIONS,
+    order: 2,
+    owner: "workspace",
+    persistence: "repo",
+    budget: "protected",
+    childTaskBehavior: "recompute_from_child_cwd",
+  },
+  {
+    key: RuntimeContextLayerKey.ROLE_INSTRUCTIONS,
+    order: 3,
+    owner: "autocontext",
+    persistence: "bundled",
+    budget: "protected",
+    childTaskBehavior: "inherit_or_override_by_role",
+  },
+  {
+    key: RuntimeContextLayerKey.SCENARIO_CONTEXT,
+    order: 4,
+    owner: "scenario",
+    persistence: "run",
+    budget: "protected",
+    childTaskBehavior: "inherit_task_slice",
+  },
+  {
+    key: RuntimeContextLayerKey.KNOWLEDGE,
+    order: 5,
+    owner: "knowledge",
+    persistence: "knowledge",
+    budget: "compress",
+    childTaskBehavior: "include_applicable_knowledge",
+  },
+  {
+    key: RuntimeContextLayerKey.RUNTIME_SKILLS,
+    order: 6,
+    owner: "workspace",
+    persistence: "repo_or_skill_store",
+    budget: "manifest_first",
+    childTaskBehavior: "recompute_from_child_cwd",
+  },
+  {
+    key: RuntimeContextLayerKey.TOOL_AFFORDANCES,
+    order: 7,
+    owner: "runtime",
+    persistence: "ephemeral",
+    budget: "summarize",
+    childTaskBehavior: "inherit_scoped_grants",
+  },
+  {
+    key: RuntimeContextLayerKey.SESSION_HISTORY,
+    order: 8,
+    owner: "runtime_session",
+    persistence: "runtime_session_log",
+    budget: "compact",
+    childTaskBehavior: "recompute_from_child_session",
+  },
+] as const;
+
+export const RUNTIME_CONTEXT_LAYER_KEYS = RUNTIME_CONTEXT_LAYERS.map((layer) => layer.key);
+
+export function discoverRepoInstructions(request: RuntimeContextDiscoveryRequest): RepoInstruction[] {
+  const root = workspaceRoot(request);
+  const cwd = resolveCwd(root, request.cwd);
+  const instructions: RepoInstruction[] = [];
+  for (const dir of ancestorDirs(root, cwd, false)) {
+    for (const filename of REPO_INSTRUCTION_FILENAMES) {
+      const path = resolve(dir, filename);
+      if (!isFile(path)) continue;
+      instructions.push({
+        path,
+        relativePath: relative(root, path).split("\\").join("/"),
+        content: readFileSync(path, "utf-8"),
+      });
+    }
+  }
+  return instructions;
+}
+
+export function runtimeSkillDiscoveryRoots(request: RuntimeContextDiscoveryRequest): string[] {
+  const root = workspaceRoot(request);
+  const cwd = resolveCwd(root, request.cwd);
+  const roots: string[] = [];
+  const seen = new Set<string>();
+
+  for (const configuredRoot of request.configuredSkillRoots) {
+    appendExistingUniqueDir(roots, seen, resolveConfiguredRoot(root, configuredRoot));
+  }
+
+  for (const dir of ancestorDirs(root, cwd, true)) {
+    for (const skillDir of RUNTIME_SKILL_DIRS) {
+      appendExistingUniqueDir(roots, seen, resolve(dir, skillDir));
+    }
+  }
+  return roots;
+}
+
+export function discoverRuntimeSkills(request: RuntimeContextDiscoveryRequest): SkillRegistry {
+  const registry = new SkillRegistry();
+  for (const root of runtimeSkillDiscoveryRoots(request)) {
+    registry.discover(root);
+  }
+  return registry;
+}
+
+export function selectRuntimeKnowledgeComponents(
+  components: Record<string, string>,
+  opts: { include?: readonly string[]; exclude?: readonly string[] } = {},
+): Record<string, string> {
+  const allowed = opts.include ? new Set(opts.include) : null;
+  const blocked = new Set(opts.exclude ?? []);
+  const selected: Record<string, string> = {};
+  for (const [key, value] of Object.entries(components)) {
+    if (allowed && !allowed.has(key)) continue;
+    if (blocked.has(key) || !value) continue;
+    selected[key] = value;
+  }
+  return selected;
+}
+
+function workspaceRoot(request: RuntimeContextDiscoveryRequest): string {
+  return resolve(request.workspaceRoot);
+}
+
+function resolveCwd(root: string, cwd: string): string {
+  const candidate = cwd.startsWith("/") ? resolve(root, cwd.slice(1)) : resolve(root, cwd);
+  const resolved = resolve(candidate);
+  const rel = relative(root, resolved);
+  if (rel === "") return resolved;
+  if (rel === ".." || rel.startsWith("../") || rel.startsWith("..\\")) {
+    throw new Error(`Runtime context cwd escapes workspace root: ${cwd}`);
+  }
+  return resolved;
+}
+
+function resolveConfiguredRoot(root: string, skillRoot: string): string {
+  return skillRoot.startsWith("/") ? resolve(skillRoot) : resolve(root, skillRoot);
+}
+
+function ancestorDirs(root: string, cwd: string, nearestFirst: boolean): string[] {
+  const dirs: string[] = [];
+  let current = cwd;
+  while (true) {
+    dirs.push(current);
+    if (current === root) break;
+    current = resolve(current, "..");
+  }
+  return nearestFirst ? dirs : dirs.reverse();
+}
+
+function appendExistingUniqueDir(roots: string[], seen: Set<string>, path: string): void {
+  if (seen.has(path) || !isDirectory(path)) return;
+  seen.add(path);
+  roots.push(path);
+}
+
+function isDirectory(path: string): boolean {
+  return existsSync(path) && statSync(path).isDirectory();
+}
+
+function isFile(path: string): boolean {
+  return existsSync(path) && statSync(path).isFile();
+}

--- a/ts/src/session/runtime-context.ts
+++ b/ts/src/session/runtime-context.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
-import { relative, resolve } from "node:path";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { basename, dirname, relative, resolve } from "node:path";
 
 import { SkillRegistry } from "./skill-registry.js";
 
@@ -188,18 +188,35 @@ export function selectRuntimeKnowledgeComponents(
 }
 
 function workspaceRoot(request: RuntimeContextDiscoveryRequest): string {
-  return resolve(request.workspaceRoot);
+  return realpathSync(resolve(request.workspaceRoot));
 }
 
 function resolveCwd(root: string, cwd: string): string {
   const candidate = cwd.startsWith("/") ? resolve(root, cwd.slice(1)) : resolve(root, cwd);
-  const resolved = resolve(candidate);
-  const rel = relative(root, resolved);
-  if (rel === "") return resolved;
-  if (rel === ".." || rel.startsWith("../") || rel.startsWith("..\\")) {
+  const resolved = resolvePossiblyMissingPath(candidate);
+  if (!isPathWithinRoot(root, resolved)) {
     throw new Error(`Runtime context cwd escapes workspace root: ${cwd}`);
   }
   return resolved;
+}
+
+function resolvePossiblyMissingPath(path: string): string {
+  let existing = resolve(path);
+  const missingParts: string[] = [];
+
+  while (!existsSync(existing)) {
+    const parent = dirname(existing);
+    if (parent === existing) break;
+    missingParts.unshift(basename(existing));
+    existing = parent;
+  }
+
+  return resolve(realpathSync(existing), ...missingParts);
+}
+
+function isPathWithinRoot(root: string, path: string): boolean {
+  const rel = relative(root, path);
+  return rel === "" || (rel !== ".." && !rel.startsWith("../") && !rel.startsWith("..\\"));
 }
 
 function resolveConfiguredRoot(root: string, skillRoot: string): string {

--- a/ts/tests/runtime-context-layers.test.ts
+++ b/ts/tests/runtime-context-layers.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -62,6 +62,19 @@ describe("runtime context layers", () => {
     expect(childInstructions.map((instruction) => instruction.relativePath)).toEqual(["AGENTS.md", "other/AGENTS.md"]);
   });
 
+  it("rejects cwd symlinks that resolve outside the workspace", () => {
+    const root = mkdtempSync(join(tmpdir(), "autoctx-context-"));
+    const outside = mkdtempSync(join(tmpdir(), "autoctx-outside-"));
+    writeFileSync(join(outside, "AGENTS.md"), "outside agents\n");
+    writeSkill(join(outside, ".claude", "skills"), "outside-only", "outside skill");
+    symlinkSync(outside, join(root, "link"), "dir");
+
+    const request = new RuntimeContextDiscoveryRequest({ workspaceRoot: root, cwd: "/link" });
+
+    expect(() => discoverRepoInstructions(request)).toThrow(/escapes workspace root/);
+    expect(() => discoverRuntimeSkills(request)).toThrow(/escapes workspace root/);
+  });
+
   it("discovers cwd-specific skills and deduplicates by nearest cwd", () => {
     const root = mkdtempSync(join(tmpdir(), "autoctx-context-"));
     const rootSkills = join(root, ".claude", "skills");
@@ -74,7 +87,7 @@ describe("runtime context layers", () => {
     const registry = discoverRuntimeSkills(new RuntimeContextDiscoveryRequest({ workspaceRoot: root, cwd: "/pkg" }));
 
     expect(registry.allManifests().map((manifest) => manifest.name)).toEqual(["pkg-only", "shared", "root-only"]);
-    expect(registry.get("shared")?.manifest.skillPath).toBe(pkgShared);
+    expect(registry.get("shared")?.manifest.skillPath).toBe(realpathSync(pkgShared));
     expect(
       discoverRuntimeSkills(new RuntimeContextDiscoveryRequest({ workspaceRoot: root, cwd: "/" }))
         .allManifests()

--- a/ts/tests/runtime-context-layers.test.ts
+++ b/ts/tests/runtime-context-layers.test.ts
@@ -1,0 +1,102 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  RUNTIME_CONTEXT_LAYER_KEYS,
+  RUNTIME_CONTEXT_LAYERS,
+  RuntimeContextLayerKey,
+  RuntimeContextDiscoveryRequest,
+  discoverRepoInstructions,
+  discoverRuntimeSkills,
+  selectRuntimeKnowledgeComponents,
+} from "../src/session/runtime-context.js";
+
+function writeSkill(root: string, name: string, description: string): string {
+  const dir = join(root, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n\nInstructions for ${name}.\n`,
+  );
+  return dir;
+}
+
+describe("runtime context layers", () => {
+  it("exposes canonical assembly order", () => {
+    expect(RUNTIME_CONTEXT_LAYER_KEYS).toEqual([
+      RuntimeContextLayerKey.SYSTEM_POLICY,
+      RuntimeContextLayerKey.REPO_INSTRUCTIONS,
+      RuntimeContextLayerKey.ROLE_INSTRUCTIONS,
+      RuntimeContextLayerKey.SCENARIO_CONTEXT,
+      RuntimeContextLayerKey.KNOWLEDGE,
+      RuntimeContextLayerKey.RUNTIME_SKILLS,
+      RuntimeContextLayerKey.TOOL_AFFORDANCES,
+      RuntimeContextLayerKey.SESSION_HISTORY,
+    ]);
+    expect(RUNTIME_CONTEXT_LAYERS.map((layer) => layer.order)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(RUNTIME_CONTEXT_LAYERS.find((layer) => layer.key === RuntimeContextLayerKey.KNOWLEDGE)?.budget).toBe("compress");
+    expect(
+      RUNTIME_CONTEXT_LAYERS.find((layer) => layer.key === RuntimeContextLayerKey.SESSION_HISTORY)?.childTaskBehavior,
+    ).toBe("recompute_from_child_session");
+  });
+
+  it("discovers repo instructions safely and recomputes for child cwd", () => {
+    const root = mkdtempSync(join(tmpdir(), "autoctx-context-"));
+    const request = new RuntimeContextDiscoveryRequest({ workspaceRoot: root, cwd: "/pkg" });
+
+    expect(discoverRepoInstructions(request)).toEqual([]);
+
+    writeFileSync(join(root, "AGENTS.md"), "root agents\n");
+    mkdirSync(join(root, "pkg"), { recursive: true });
+    writeFileSync(join(root, "pkg", "CLAUDE.md"), "pkg claude\n");
+    mkdirSync(join(root, "other"), { recursive: true });
+    writeFileSync(join(root, "other", "AGENTS.md"), "other agents\n");
+
+    const parentInstructions = discoverRepoInstructions(request);
+    const childInstructions = discoverRepoInstructions(request.forChildTask("/other"));
+
+    expect(parentInstructions.map((instruction) => instruction.relativePath)).toEqual(["AGENTS.md", "pkg/CLAUDE.md"]);
+    expect(parentInstructions.map((instruction) => instruction.content)).toEqual(["root agents\n", "pkg claude\n"]);
+    expect(childInstructions.map((instruction) => instruction.relativePath)).toEqual(["AGENTS.md", "other/AGENTS.md"]);
+  });
+
+  it("discovers cwd-specific skills and deduplicates by nearest cwd", () => {
+    const root = mkdtempSync(join(tmpdir(), "autoctx-context-"));
+    const rootSkills = join(root, ".claude", "skills");
+    const pkgSkills = join(root, "pkg", ".claude", "skills");
+    writeSkill(rootSkills, "shared", "root shared");
+    writeSkill(rootSkills, "root-only", "root only");
+    const pkgShared = writeSkill(pkgSkills, "shared", "package shared");
+    writeSkill(pkgSkills, "pkg-only", "package only");
+
+    const registry = discoverRuntimeSkills(new RuntimeContextDiscoveryRequest({ workspaceRoot: root, cwd: "/pkg" }));
+
+    expect(registry.allManifests().map((manifest) => manifest.name)).toEqual(["pkg-only", "shared", "root-only"]);
+    expect(registry.get("shared")?.manifest.skillPath).toBe(pkgShared);
+    expect(
+      discoverRuntimeSkills(new RuntimeContextDiscoveryRequest({ workspaceRoot: root, cwd: "/" }))
+        .allManifests()
+        .map((manifest) => manifest.name),
+    ).toEqual(["root-only", "shared"]);
+  });
+
+  it("selects knowledge by include/exclude policy and skips empty values", () => {
+    expect(
+      selectRuntimeKnowledgeComponents(
+        {
+          playbook: "Use validated strategy.",
+          hints: "",
+          lessons: "Lesson one.",
+          dead_ends: "Avoid stale path.",
+          private_notes: "do not include",
+        },
+        { include: ["playbook", "hints", "lessons", "dead_ends"], exclude: ["lessons"] },
+      ),
+    ).toEqual({
+      playbook: "Use validated strategy.",
+      dead_ends: "Avoid stale path.",
+    });
+  });
+});


### PR DESCRIPTION
Summary
- Add shared runtime context layer contracts in Python and TypeScript.
- Add cwd-aware repo instruction and runtime skill discovery plus knowledge selection helpers.
- Document canonical assembly order, budget/compaction behavior, and child-task recomputation without changing the Scenario/Run/Mission vocabulary.

Verification
- uv run --frozen pytest tests/test_runtime_context_layers.py tests/test_skill_registry.py tests/test_context_budget.py tests/test_module_size_limits.py tests/test_dict_type_consistency.py
- uv run --frozen pytest tests/test_concept_model_parity.py tests/test_runtime_context_layers.py
- uv run --frozen ruff check src tests
- uv run --frozen mypy src
- uv run --frozen pytest: 6220 passed, 42 skipped
- npm test -- runtime-context-layers.test.ts skill-registry.test.ts context-pressure.test.ts
- npm test -- concept-model-parity.test.ts concept-model-durable-session-events.test.ts runtime-context-layers.test.ts
- npm run lint
- npm test: 729 files / 5031 tests passed
- git diff --check