### PR TITLE
Bridge runtime child task lineage into coordinator events

### DIFF
--- a/autocontext/src/autocontext/session/coordinator.py
+++ b/autocontext/src/autocontext/session/coordinator.py
@@ -206,13 +206,7 @@ class Coordinator(BaseModel):
         """Mark a running worker as failed."""
         worker = self._get_worker(worker_id)
         worker.fail(error=error)
-        self._emit(
-            CoordinatorEventType.WORKER_FAILED,
-            {
-                **_worker_event_payload(worker_id, details),
-                "error": error,
-            },
-        )
+        self._emit(CoordinatorEventType.WORKER_FAILED, _failed_worker_event_payload(worker_id, error, details))
 
     def stop_worker(self, worker_id: str, reason: str = "") -> None:
         """Redirect a worker away from its current task."""
@@ -265,4 +259,17 @@ def _worker_event_payload(
     worker_id: str,
     details: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    return {**dict(details or {}), "worker_id": worker_id}
+    payload = {"worker_id": worker_id, **dict(details or {})}
+    payload["worker_id"] = worker_id
+    return payload
+
+
+def _failed_worker_event_payload(
+    worker_id: str,
+    error: str,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload = {"worker_id": worker_id, "error": error, **dict(details or {})}
+    payload["worker_id"] = worker_id
+    payload["error"] = error
+    return payload

--- a/autocontext/src/autocontext/session/coordinator.py
+++ b/autocontext/src/autocontext/session/coordinator.py
@@ -10,6 +10,7 @@ Domain concepts:
 from __future__ import annotations
 
 import uuid
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any
@@ -175,30 +176,43 @@ class Coordinator(BaseModel):
         })
         return results
 
-    def complete_worker(self, worker_id: str, result: str) -> None:
+    def complete_worker(
+        self,
+        worker_id: str,
+        result: str,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
         """Mark a worker as completed with its result."""
         worker = self._get_worker(worker_id)
         worker.complete(result=result)
-        self._emit(CoordinatorEventType.WORKER_COMPLETED, {
-            "worker_id": worker_id,
-        })
+        self._emit(CoordinatorEventType.WORKER_COMPLETED, _worker_event_payload(worker_id, details))
 
-    def start_worker(self, worker_id: str) -> None:
+    def start_worker(
+        self,
+        worker_id: str,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
         """Mark a delegated worker as running."""
         worker = self._get_worker(worker_id)
         worker.start()
-        self._emit(CoordinatorEventType.WORKER_STARTED, {
-            "worker_id": worker_id,
-        })
+        self._emit(CoordinatorEventType.WORKER_STARTED, _worker_event_payload(worker_id, details))
 
-    def fail_worker(self, worker_id: str, error: str = "") -> None:
+    def fail_worker(
+        self,
+        worker_id: str,
+        error: str = "",
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
         """Mark a running worker as failed."""
         worker = self._get_worker(worker_id)
         worker.fail(error=error)
-        self._emit(CoordinatorEventType.WORKER_FAILED, {
-            "worker_id": worker_id,
-            "error": error,
-        })
+        self._emit(
+            CoordinatorEventType.WORKER_FAILED,
+            {
+                **_worker_event_payload(worker_id, details),
+                "error": error,
+            },
+        )
 
     def stop_worker(self, worker_id: str, reason: str = "") -> None:
         """Redirect a worker away from its current task."""
@@ -245,3 +259,10 @@ class Coordinator(BaseModel):
             event_type=event_type,
             payload={"coordinator_id": self.coordinator_id, **payload},
         ))
+
+
+def _worker_event_payload(
+    worker_id: str,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {**dict(details or {}), "worker_id": worker_id}

--- a/autocontext/src/autocontext/session/runtime_session.py
+++ b/autocontext/src/autocontext/session/runtime_session.py
@@ -365,7 +365,6 @@ class RuntimeChildTaskRunner:
     ) -> RuntimeChildTaskResult:
         clean_task_id = task_id or uuid.uuid4().hex[:12]
         worker = self._coordinator.delegate(prompt, role)
-        self._coordinator.start_worker(worker.worker_id)
         child_depth = self._depth + 1
         child_cwd = self._workspace.resolve_path(cwd) if self._workspace is not None and cwd else (
             self._workspace.cwd if self._workspace is not None else cwd
@@ -402,6 +401,16 @@ class RuntimeChildTaskRunner:
             else None
         )
         child_cwd = child_workspace.cwd if child_workspace is not None else child_cwd
+        coordinator_lineage = _child_task_coordinator_lineage(
+            task_id=clean_task_id,
+            child_session_id=child_session_id,
+            parent_session_id=self._parent_log.session_id,
+            role=role,
+            cwd=child_cwd,
+            depth=child_depth,
+            max_depth=self._max_depth,
+        )
+        self._coordinator.start_worker(worker.worker_id, coordinator_lineage)
 
         self._parent_log.append(
             RuntimeSessionEventType.CHILD_TASK_STARTED,
@@ -465,7 +474,11 @@ class RuntimeChildTaskRunner:
                     "maxDepth": self._max_depth,
                 },
             )
-            self._coordinator.complete_worker(worker.worker_id, output.text)
+            self._coordinator.complete_worker(
+                worker.worker_id,
+                output.text,
+                {**coordinator_lineage, "isError": False},
+            )
             self._parent_log.append(
                 RuntimeSessionEventType.CHILD_TASK_COMPLETED,
                 {
@@ -518,7 +531,22 @@ class RuntimeChildTaskRunner:
         child_log: RuntimeSessionEventLog,
         message: str,
     ) -> RuntimeChildTaskResult:
-        self._coordinator.fail_worker(worker_id, message)
+        self._coordinator.fail_worker(
+            worker_id,
+            message,
+            {
+                **_child_task_coordinator_lineage(
+                    task_id=task_id,
+                    child_session_id=child_session_id,
+                    parent_session_id=self._parent_log.session_id,
+                    role=role,
+                    cwd=cwd,
+                    depth=depth,
+                    max_depth=self._max_depth,
+                ),
+                "isError": True,
+            },
+        )
         child_log.append(
             RuntimeSessionEventType.ASSISTANT_MESSAGE,
             {
@@ -625,6 +653,27 @@ def _normalize_child_output(output: RuntimeChildTaskHandlerOutput | str) -> Runt
     if isinstance(output, RuntimeChildTaskHandlerOutput):
         return output
     return RuntimeChildTaskHandlerOutput(text=output)
+
+
+def _child_task_coordinator_lineage(
+    *,
+    task_id: str,
+    child_session_id: str,
+    parent_session_id: str,
+    role: str,
+    cwd: str,
+    depth: int,
+    max_depth: int,
+) -> dict[str, Any]:
+    return {
+        "taskId": task_id,
+        "childSessionId": child_session_id,
+        "parentSessionId": parent_session_id,
+        "role": role,
+        "cwd": cwd,
+        "depth": depth,
+        "maxDepth": max_depth,
+    }
 
 
 def _json_safe_record(value: Mapping[str, Any] | None) -> dict[str, Any]:

--- a/autocontext/tests/test_progress_digests.py
+++ b/autocontext/tests/test_progress_digests.py
@@ -101,6 +101,33 @@ class TestProgressDigest:
         assert len(digest.worker_digests) == 1
         assert digest.worker_digests[0].status == "redirected"
 
+    def test_child_task_failure_recent_change_keeps_error_visible(self) -> None:
+        from autocontext.session.coordinator import Coordinator
+        from autocontext.session.progress_digest import ProgressDigest
+
+        coord = Coordinator.create(session_id="parent-session", goal="test")
+        worker = coord.delegate(task="Too deep", role="analyst")
+        coord.start_worker(worker.worker_id)
+        coord.fail_worker(
+            worker.worker_id,
+            "Maximum child task depth (1) exceeded",
+            {
+                "taskId": "depth",
+                "childSessionId": f"task:parent-session:depth:{worker.worker_id}",
+                "parentSessionId": "parent-session",
+                "role": "analyst",
+                "cwd": "/workspace",
+                "depth": 2,
+                "maxDepth": 1,
+                "isError": True,
+            },
+        )
+
+        digest = ProgressDigest.from_coordinator(coord)
+        failure_change = next(change for change in digest.recent_changes if change.startswith("worker failed"))
+        assert f"worker_id={worker.worker_id}" in failure_change
+        assert "error=Maximum child task depth (1) exceeded" in failure_change
+
 
 class TestDigestDegradation:
     """Digests degrade gracefully with insufficient signal."""

--- a/autocontext/tests/test_runtime_session_events.py
+++ b/autocontext/tests/test_runtime_session_events.py
@@ -455,6 +455,28 @@ def test_runtime_session_records_child_task_lineage(tmp_path: Path) -> None:
         assert result.error == ""
         assert result.depth == 1
         assert result.max_depth == 4
+        started_event = next(
+            event for event in session.coordinator.events if event.event_type == "worker_started"
+        )
+        completed_event = next(
+            event for event in session.coordinator.events if event.event_type == "worker_completed"
+        )
+        assert started_event.payload == {
+            "coordinator_id": session.coordinator.coordinator_id,
+            "worker_id": result.worker_id,
+            "taskId": "retry",
+            "childSessionId": result.child_session_id,
+            "parentSessionId": "run:abc:runtime",
+            "role": "analyst",
+            "cwd": "/workspace",
+            "depth": 1,
+            "maxDepth": 4,
+        }
+        assert completed_event.payload["worker_id"] == result.worker_id
+        assert completed_event.payload["taskId"] == "retry"
+        assert completed_event.payload["childSessionId"] == result.child_session_id
+        assert completed_event.payload["parentSessionId"] == "run:abc:runtime"
+        assert completed_event.payload["isError"] is False
 
         parent = store.load("run:abc:runtime")
         child = store.load(result.child_session_id)
@@ -659,6 +681,17 @@ def test_runtime_session_child_task_depth_limit_is_recorded(tmp_path: Path) -> N
         assert result.is_error is True
         assert result.text == ""
         assert result.error == "Maximum child task depth (1) exceeded"
+        failed_event = next(
+            event for event in session.coordinator.events if event.event_type == "worker_failed"
+        )
+        assert failed_event.payload["worker_id"] == result.worker_id
+        assert failed_event.payload["taskId"] == "depth"
+        assert failed_event.payload["childSessionId"] == result.child_session_id
+        assert failed_event.payload["parentSessionId"] == "run:abc:runtime"
+        assert failed_event.payload["isError"] is True
+        assert failed_event.payload["error"] == "Maximum child task depth (1) exceeded"
+        assert failed_event.payload["depth"] == 2
+        assert failed_event.payload["maxDepth"] == 1
         child = store.load(result.child_session_id)
         assert child is not None
         assert child.events[1].payload["isError"] is True

--- a/ts/src/session/coordinator.ts
+++ b/ts/src/session/coordinator.ts
@@ -130,19 +130,19 @@ export class Coordinator {
     return results;
   }
 
-  startWorker(workerId: string): void {
+  startWorker(workerId: string, details: Record<string, unknown> = {}): void {
     this.getWorker(workerId).start();
-    this.emit(CoordinatorEventType.WORKER_STARTED, { workerId });
+    this.emit(CoordinatorEventType.WORKER_STARTED, { ...details, workerId });
   }
 
-  completeWorker(workerId: string, result: string): void {
+  completeWorker(workerId: string, result: string, details: Record<string, unknown> = {}): void {
     this.getWorker(workerId).complete(result);
-    this.emit(CoordinatorEventType.WORKER_COMPLETED, { workerId });
+    this.emit(CoordinatorEventType.WORKER_COMPLETED, { ...details, workerId });
   }
 
-  failWorker(workerId: string, error: string = ""): void {
+  failWorker(workerId: string, error: string = "", details: Record<string, unknown> = {}): void {
     this.getWorker(workerId).fail(error);
-    this.emit(CoordinatorEventType.WORKER_FAILED, { workerId, error });
+    this.emit(CoordinatorEventType.WORKER_FAILED, { ...details, workerId, error });
   }
 
   stopWorker(workerId: string, reason: string = ""): void {

--- a/ts/src/session/coordinator.ts
+++ b/ts/src/session/coordinator.ts
@@ -132,17 +132,17 @@ export class Coordinator {
 
   startWorker(workerId: string, details: Record<string, unknown> = {}): void {
     this.getWorker(workerId).start();
-    this.emit(CoordinatorEventType.WORKER_STARTED, { ...details, workerId });
+    this.emit(CoordinatorEventType.WORKER_STARTED, workerEventPayload(workerId, details));
   }
 
   completeWorker(workerId: string, result: string, details: Record<string, unknown> = {}): void {
     this.getWorker(workerId).complete(result);
-    this.emit(CoordinatorEventType.WORKER_COMPLETED, { ...details, workerId });
+    this.emit(CoordinatorEventType.WORKER_COMPLETED, workerEventPayload(workerId, details));
   }
 
   failWorker(workerId: string, error: string = "", details: Record<string, unknown> = {}): void {
     this.getWorker(workerId).fail(error);
-    this.emit(CoordinatorEventType.WORKER_FAILED, { ...details, workerId, error });
+    this.emit(CoordinatorEventType.WORKER_FAILED, failedWorkerEventPayload(workerId, error, details));
   }
 
   stopWorker(workerId: string, reason: string = ""): void {
@@ -178,4 +178,21 @@ export class Coordinator {
       payload: { coordinatorId: this.coordinatorId, ...payload },
     });
   }
+}
+
+function workerEventPayload(workerId: string, details: Record<string, unknown>): Record<string, unknown> {
+  const payload = { workerId, ...details };
+  payload.workerId = workerId;
+  return payload;
+}
+
+function failedWorkerEventPayload(
+  workerId: string,
+  error: string,
+  details: Record<string, unknown>,
+): Record<string, unknown> {
+  const payload = { workerId, error, ...details };
+  payload.workerId = workerId;
+  payload.error = error;
+  return payload;
 }

--- a/ts/src/session/runtime-child-tasks.ts
+++ b/ts/src/session/runtime-child-tasks.ts
@@ -115,7 +115,6 @@ export class RuntimeChildTaskRunner {
   async run(opts: RuntimeChildTaskRunOpts): Promise<RuntimeChildTaskResult> {
     const taskId = opts.taskId ?? randomUUID().slice(0, 12);
     const worker = this.coordinator.delegate(opts.prompt, opts.role);
-    this.coordinator.startWorker(worker.workerId);
     const childDepth = this.depth + 1;
     const childCwd = opts.cwd ? this.workspace.resolvePath(opts.cwd) : this.workspace.cwd;
     const childSessionId = `task:${this.parentLog.sessionId}:${taskId}:${worker.workerId}`;
@@ -142,6 +141,16 @@ export class RuntimeChildTaskRunner {
         workerId: worker.workerId,
       }),
     });
+    const coordinatorLineage = childTaskCoordinatorLineage({
+      taskId,
+      childSessionId,
+      parentSessionId: this.parentLog.sessionId,
+      role: opts.role,
+      cwd: childWorkspace.cwd,
+      depth: childDepth,
+      maxDepth: this.maxDepth,
+    });
+    this.coordinator.startWorker(worker.workerId, coordinatorLineage);
 
     this.parentLog.append(RuntimeSessionEventType.CHILD_TASK_STARTED, {
       taskId,
@@ -194,7 +203,11 @@ export class RuntimeChildTaskRunner {
         depth: childDepth,
         maxDepth: this.maxDepth,
       });
-      this.coordinator.completeWorker(worker.workerId, text);
+      this.coordinator.completeWorker(
+        worker.workerId,
+        text,
+        { ...coordinatorLineage, isError: false },
+      );
       this.parentLog.append(RuntimeSessionEventType.CHILD_TASK_COMPLETED, {
         taskId,
         childSessionId,
@@ -245,7 +258,18 @@ export class RuntimeChildTaskRunner {
     childLog: RuntimeSessionEventLog;
     message: string;
   }): RuntimeChildTaskResult {
-    this.coordinator.failWorker(opts.workerId, opts.message);
+    this.coordinator.failWorker(opts.workerId, opts.message, {
+      ...childTaskCoordinatorLineage({
+        taskId: opts.taskId,
+        childSessionId: opts.childSessionId,
+        parentSessionId: this.parentLog.sessionId,
+        role: opts.role,
+        cwd: opts.cwd,
+        depth: opts.depth,
+        maxDepth: this.maxDepth,
+      }),
+      isError: true,
+    });
     opts.childLog.append(RuntimeSessionEventType.ASSISTANT_MESSAGE, {
       text: "",
       error: opts.message,
@@ -332,6 +356,26 @@ function resolveSystemPrompt(
   input: RuntimeChildTaskHandlerInput,
 ): string | undefined {
   return typeof system === "function" ? system(input) : system;
+}
+
+function childTaskCoordinatorLineage(opts: {
+  taskId: string;
+  childSessionId: string;
+  parentSessionId: string;
+  role: string;
+  cwd: string;
+  depth: number;
+  maxDepth: number;
+}): Record<string, unknown> {
+  return {
+    taskId: opts.taskId,
+    childSessionId: opts.childSessionId,
+    parentSessionId: opts.parentSessionId,
+    role: opts.role,
+    cwd: opts.cwd,
+    depth: opts.depth,
+    maxDepth: opts.maxDepth,
+  };
 }
 
 function normalizeDepth(value: number, name: string): number {

--- a/ts/tests/progress-digest.test.ts
+++ b/ts/tests/progress-digest.test.ts
@@ -40,6 +40,31 @@ describe("ProgressDigest", () => {
     expect(digest.workerDigests[0].status).toBe("redirected");
   });
 
+  it("keeps child task failure reasons visible in recent changes", () => {
+    const coord = Coordinator.create("parent-session", "Build API");
+    const worker = coord.delegate("Too deep", "analyst");
+    coord.startWorker(worker.workerId);
+    coord.failWorker(
+      worker.workerId,
+      "Maximum child task depth (1) exceeded",
+      {
+        taskId: "depth",
+        childSessionId: `task:parent-session:depth:${worker.workerId}`,
+        parentSessionId: "parent-session",
+        role: "analyst",
+        cwd: "/workspace",
+        depth: 2,
+        maxDepth: 1,
+        isError: true,
+      },
+    );
+
+    const digest = ProgressDigest.fromCoordinator(coord);
+    const failureChange = digest.recentChanges.find((change) => change.startsWith("worker failed"));
+    expect(failureChange).toContain(`workerId=${worker.workerId}`);
+    expect(failureChange).toContain("error=Maximum child task depth (1) exceeded");
+  });
+
   it("from session without coordinator", () => {
     const session = Session.create({ goal: "Simple task" });
     session.submitTurn({ prompt: "do it", role: "competitor" });

--- a/ts/tests/runtime-child-tasks.test.ts
+++ b/ts/tests/runtime-child-tasks.test.ts
@@ -57,6 +57,29 @@ describe("RuntimeChildTaskRunner", () => {
     expect(coordinator.events.map((event) => event.eventType)).toContain(
       CoordinatorEventType.WORKER_STARTED,
     );
+    expect(
+      coordinator.events.find((event) => event.eventType === CoordinatorEventType.WORKER_STARTED)
+        ?.payload,
+    ).toMatchObject({
+      workerId: result.workerId,
+      taskId: "task-1",
+      childSessionId: result.childSessionId,
+      parentSessionId: "parent-session",
+      role: "researcher",
+      cwd: "/workspace/project",
+      depth: 1,
+      maxDepth: 4,
+    });
+    expect(
+      coordinator.events.find((event) => event.eventType === CoordinatorEventType.WORKER_COMPLETED)
+        ?.payload,
+    ).toMatchObject({
+      workerId: result.workerId,
+      taskId: "task-1",
+      childSessionId: result.childSessionId,
+      parentSessionId: "parent-session",
+      isError: false,
+    });
 
     expect(parentLog.events.map((event) => event.eventType)).toEqual([
       RuntimeSessionEventType.CHILD_TASK_STARTED,
@@ -167,6 +190,19 @@ describe("RuntimeChildTaskRunner", () => {
       maxDepth: 1,
     });
     expect(coordinator.workers[0].status).toBe(WorkerStatus.FAILED);
+    expect(
+      coordinator.events.find((event) => event.eventType === CoordinatorEventType.WORKER_FAILED)
+        ?.payload,
+    ).toMatchObject({
+      workerId: result.workerId,
+      taskId: "task-too-deep",
+      childSessionId: result.childSessionId,
+      parentSessionId: "parent-session",
+      isError: true,
+      error: "Maximum child task depth (1) exceeded",
+      depth: 2,
+      maxDepth: 1,
+    });
     expect(parentLog.events.map((event) => event.eventType)).toEqual([
       RuntimeSessionEventType.CHILD_TASK_STARTED,
       RuntimeSessionEventType.CHILD_TASK_COMPLETED,


### PR DESCRIPTION
## Summary
- add optional coordinator event detail payloads in TypeScript and Python
- attach runtime child-task lineage to worker start/completion/failure events
- cover success and depth-limit failure lineage in TS/Python runtime-session tests

## Verification
- npm run lint
- npm test -- runtime-child-tasks.test.ts coordinator.test.ts runtime-session.test.ts
- npm test -- production-traces/sdk/cross-runtime-parity.property.test.ts production-traces/sdk/hashing-parity.property.test.ts
- uv run --frozen ruff check src tests
- uv run --frozen mypy src
- uv run --frozen pytest tests/test_runtime_session_events.py tests/test_coordinator.py
- uv run --frozen pytest