### PR TITLE
feat(improve): claude-max-total-seconds flag, verifier-veto-aware delta warning, --ndjson event streaming (AC-750..752)

### DIFF
--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -8,7 +8,6 @@ import sys
 import threading
 import time
 import uuid
-from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
@@ -21,6 +20,7 @@ from rich.table import Table
 from autocontext.agents.orchestrator import AgentOrchestrator
 from autocontext.cli_analytics import register_analytics_command
 from autocontext.cli_hermes import register_hermes_command
+from autocontext.cli_improve import register_improve_command
 from autocontext.cli_investigate import run_investigate_command
 from autocontext.cli_new_scenario import register_new_scenario_command
 from autocontext.cli_queue import register_queue_command
@@ -1470,167 +1470,9 @@ def judge(
         console.print(f"[bold]Reasoning:[/bold] {result.reasoning}")
 
 
-@app.command()
-def improve(
-    task_prompt: str = typer.Option(..., "--task-prompt", "-p", help="The task prompt"),
-    rubric: str = typer.Option(..., "--rubric", "-r", help="Evaluation rubric"),
-    initial_output: str = typer.Option("", "--output", "-o", help="Starting output to improve"),
-    max_rounds: int = typer.Option(5, "--rounds", "-n", help="Maximum improvement rounds"),
-    threshold: float = typer.Option(0.9, "--threshold", "-t", help="Quality threshold to stop"),
-    provider_override: str = typer.Option("", "--provider", help="Provider override"),
-    timeout: float | None = typer.Option(
-        None,
-        "--timeout",
-        min=1.0,
-        help=(
-            "Override per-call provider timeout in seconds. For claude-cli this "
-            "writes claude_timeout (env: AUTOCONTEXT_CLAUDE_TIMEOUT, default 600s); "
-            "for codex it writes codex_timeout; for pi/pi-rpc it writes pi_timeout. "
-            "For the overall claude-cli wall-clock budget, see --claude-max-total-seconds."
-        ),
-    ),
-    claude_max_total_seconds: float | None = typer.Option(
-        None,
-        "--claude-max-total-seconds",
-        min=0.0,
-        help=(
-            "Override the wall-clock ceiling on total claude-cli runtime across all "
-            "invocations during this run (env: AUTOCONTEXT_CLAUDE_MAX_TOTAL_SECONDS, "
-            "default 0=off). Only applied when the resolved judge provider is claude-cli."
-        ),
-    ),
-    json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
-    ndjson_output: bool = typer.Option(
-        False,
-        "--ndjson",
-        help=(
-            "Stream per-round events as newline-delimited JSON to stdout (AC-752). "
-            "Useful for long-running loops where --json would buffer all output until "
-            "completion. Emits one JSON line per event: round_start, judge_done, "
-            "verifier_done, round_summary, and a final summary line."
-        ),
-    ),
-    verify_cmd: str = typer.Option(
-        "",
-        "--verify-cmd",
-        help=(
-            "External command to verify each round's output (AC-733). "
-            "Non-zero exit forces the round score to 0 and feeds the "
-            "command's stderr/stdout into the next revision prompt. "
-            "Use the literal `{file}` placeholder to receive the output as a "
-            "temp-file path; otherwise the output is piped to stdin. "
-            "Examples: 'lake env lean {file}', 'mypy {file}', 'cargo check'."
-        ),
-    ),
-    verify_suffix: str = typer.Option(
-        ".txt",
-        "--verify-suffix",
-        help="Suffix for the temp file passed to --verify-cmd (e.g. '.lean', '.py').",
-    ),
-    verify_timeout: float = typer.Option(
-        300.0,
-        "--verify-timeout",
-        min=1.0,
-        help="Timeout in seconds for each --verify-cmd invocation.",
-    ),
-) -> None:
-    """Run multi-round improvement loop on agent output.
-
-    Creates a simple agent task from the prompt and rubric, then runs
-    the improvement loop with judge-guided iteration.
-    """
-
-    from autocontext.execution.improvement_events import ImprovementLoopEvent
-    from autocontext.execution.improvement_loop import ImprovementLoop
-    from autocontext.execution.output_verifier import make_verifier
-    from autocontext.execution.task_runner import SimpleAgentTask
-    from autocontext.providers.registry import get_provider as get_judge_provider
-
-    # AC-752 (P3 follow-up): --json (single final blob) and --ndjson (streaming
-    # events) are mutually exclusive output modes. Passing both produces a
-    # mixed, un-parseable stream. Reject up front with a clear error.
-    if json_output and ndjson_output:
-        typer.echo(
-            "Error: --json and --ndjson are mutually exclusive output modes; pick one.",
-            err=True,
-        )
-        raise typer.Exit(code=2)
-
-    settings = apply_judge_runtime_overrides(
-        load_settings(),
-        provider_name=provider_override,
-        timeout=timeout,
-        claude_max_total_seconds=claude_max_total_seconds,
-    )
-
-    try:
-        provider = get_judge_provider(settings)
-        task = SimpleAgentTask(
-            task_prompt=task_prompt,
-            rubric=rubric,
-            provider=provider,
-            model=settings.judge_model,
-        )
-        state = task.initial_state()
-        verifier = make_verifier(
-            verify_cmd or None,
-            file_suffix=verify_suffix,
-            timeout_s=verify_timeout,
-        )
-        # AC-752: when --ndjson is set, stream per-round events as JSON lines
-        # so long-running loops have progress visibility before --json's final
-        # blob lands. The event sink writes one compact JSON line per event.
-        on_event: Callable[[ImprovementLoopEvent], None] | None = None
-        if ndjson_output:
-
-            def _emit_ndjson(event: ImprovementLoopEvent) -> None:
-                payload = {k: v for k, v in dataclasses.asdict(event).items() if v is not None}
-                typer.echo(json.dumps(payload))
-
-            on_event = _emit_ndjson
-        loop = ImprovementLoop(
-            task=task,
-            max_rounds=max_rounds,
-            quality_threshold=threshold,
-            output_verifier=verifier,
-            on_event=on_event,
-        )
-        starting_output = initial_output or task.generate_output(state)
-        result = loop.run(initial_output=starting_output, state=state)
-    except ProviderError as exc:
-        _exit_provider_error(
-            exc,
-            provider_name=settings.judge_provider,
-            settings=settings,
-            json_output=json_output,
-            ndjson_output=ndjson_output,
-        )
-
-    if ndjson_output:
-        # AC-752: under --ndjson, stdout is pure newline-delimited JSON
-        # (already streamed via on_event). Suppress the Rich human-readable
-        # summary so consumers can reliably parse each stdout line as JSON.
-        # --json + --ndjson is rejected up front, so we don't need to handle
-        # the both-set case here.
-        pass
-    elif json_output:
-        _write_json_stdout(
-            {
-                "best_score": result.best_score,
-                "best_round": result.best_round,
-                "total_rounds": result.total_rounds,
-                "met_threshold": result.met_threshold,
-                "best_output": result.best_output,
-            }
-        )
-    else:
-        console.print(f"[bold]Best score:[/bold] {result.best_score:.4f} (round {result.best_round})")
-        console.print(f"[bold]Rounds:[/bold] {result.total_rounds}")
-        console.print(f"[bold]Met threshold:[/bold] {result.met_threshold}")
-
-
 register_analytics_command(app, console=console)
 register_hermes_command(app, console=console)
+register_improve_command(app, console=console)
 register_new_scenario_command(app, console=console)
 register_solve_command(app, console=console)
 register_queue_command(app, console=console)

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -8,6 +8,7 @@ import sys
 import threading
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
@@ -1493,6 +1494,16 @@ def improve(
         ),
     ),
     json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
+    ndjson_output: bool = typer.Option(
+        False,
+        "--ndjson",
+        help=(
+            "Stream per-round events as newline-delimited JSON to stdout (AC-752). "
+            "Useful for long-running loops where --json would buffer all output until "
+            "completion. Emits one JSON line per event: round_start, judge_done, "
+            "verifier_done, round_summary, and a final summary line."
+        ),
+    ),
     verify_cmd: str = typer.Option(
         "",
         "--verify-cmd",
@@ -1522,6 +1533,8 @@ def improve(
     Creates a simple agent task from the prompt and rubric, then runs
     the improvement loop with judge-guided iteration.
     """
+
+    from autocontext.execution.improvement_events import ImprovementLoopEvent
     from autocontext.execution.improvement_loop import ImprovementLoop
     from autocontext.execution.output_verifier import make_verifier
     from autocontext.execution.task_runner import SimpleAgentTask
@@ -1548,11 +1561,23 @@ def improve(
             file_suffix=verify_suffix,
             timeout_s=verify_timeout,
         )
+        # AC-752: when --ndjson is set, stream per-round events as JSON lines
+        # so long-running loops have progress visibility before --json's final
+        # blob lands. The event sink writes one compact JSON line per event.
+        on_event: Callable[[ImprovementLoopEvent], None] | None = None
+        if ndjson_output:
+
+            def _emit_ndjson(event: ImprovementLoopEvent) -> None:
+                payload = {k: v for k, v in dataclasses.asdict(event).items() if v is not None}
+                typer.echo(json.dumps(payload))
+
+            on_event = _emit_ndjson
         loop = ImprovementLoop(
             task=task,
             max_rounds=max_rounds,
             quality_threshold=threshold,
             output_verifier=verifier,
+            on_event=on_event,
         )
         starting_output = initial_output or task.generate_output(state)
         result = loop.run(initial_output=starting_output, state=state)
@@ -1574,6 +1599,11 @@ def improve(
                 "best_output": result.best_output,
             }
         )
+    elif ndjson_output:
+        # AC-752: under --ndjson, stdout is pure newline-delimited JSON
+        # (already streamed via on_event). Suppress the Rich human-readable
+        # summary so consumers can reliably parse each stdout line as JSON.
+        pass
     else:
         console.print(f"[bold]Best score:[/bold] {result.best_score:.4f} (round {result.best_round})")
         console.print(f"[bold]Rounds:[/bold] {result.total_rounds}")

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -167,9 +167,15 @@ def _exit_provider_error(
     provider_name: str,
     settings: AppSettings,
     json_output: bool,
+    ndjson_output: bool = False,
 ) -> NoReturn:
     message = format_runtime_provider_error(exc, provider_name=provider_name, settings=settings)
-    if json_output:
+    if ndjson_output:
+        # AC-752 (P2 follow-up): under --ndjson, stdout is contract-bound to be
+        # newline-delimited JSON. Emit a single structured error event on
+        # stdout so ndjson consumers don't get a non-JSON line in the stream.
+        typer.echo(json.dumps({"event": "error", "message": message}))
+    elif json_output:
         _write_json_stderr(message)
     else:
         console.print(f"[red]{message}[/red]")
@@ -1540,6 +1546,16 @@ def improve(
     from autocontext.execution.task_runner import SimpleAgentTask
     from autocontext.providers.registry import get_provider as get_judge_provider
 
+    # AC-752 (P3 follow-up): --json (single final blob) and --ndjson (streaming
+    # events) are mutually exclusive output modes. Passing both produces a
+    # mixed, un-parseable stream. Reject up front with a clear error.
+    if json_output and ndjson_output:
+        typer.echo(
+            "Error: --json and --ndjson are mutually exclusive output modes; pick one.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
     settings = apply_judge_runtime_overrides(
         load_settings(),
         provider_name=provider_override,
@@ -1587,9 +1603,17 @@ def improve(
             provider_name=settings.judge_provider,
             settings=settings,
             json_output=json_output,
+            ndjson_output=ndjson_output,
         )
 
-    if json_output:
+    if ndjson_output:
+        # AC-752: under --ndjson, stdout is pure newline-delimited JSON
+        # (already streamed via on_event). Suppress the Rich human-readable
+        # summary so consumers can reliably parse each stdout line as JSON.
+        # --json + --ndjson is rejected up front, so we don't need to handle
+        # the both-set case here.
+        pass
+    elif json_output:
         _write_json_stdout(
             {
                 "best_score": result.best_score,
@@ -1599,11 +1623,6 @@ def improve(
                 "best_output": result.best_output,
             }
         )
-    elif ndjson_output:
-        # AC-752: under --ndjson, stdout is pure newline-delimited JSON
-        # (already streamed via on_event). Suppress the Rich human-readable
-        # summary so consumers can reliably parse each stdout line as JSON.
-        pass
     else:
         console.print(f"[bold]Best score:[/bold] {result.best_score:.4f} (round {result.best_round})")
         console.print(f"[bold]Rounds:[/bold] {result.total_rounds}")

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -1475,7 +1475,22 @@ def improve(
         None,
         "--timeout",
         min=1.0,
-        help="Override runtime timeout in seconds for CLI-backed providers",
+        help=(
+            "Override per-call provider timeout in seconds. For claude-cli this "
+            "writes claude_timeout (env: AUTOCONTEXT_CLAUDE_TIMEOUT, default 600s); "
+            "for codex it writes codex_timeout; for pi/pi-rpc it writes pi_timeout. "
+            "For the overall claude-cli wall-clock budget, see --claude-max-total-seconds."
+        ),
+    ),
+    claude_max_total_seconds: float | None = typer.Option(
+        None,
+        "--claude-max-total-seconds",
+        min=0.0,
+        help=(
+            "Override the wall-clock ceiling on total claude-cli runtime across all "
+            "invocations during this run (env: AUTOCONTEXT_CLAUDE_MAX_TOTAL_SECONDS, "
+            "default 0=off). Only applied when the resolved judge provider is claude-cli."
+        ),
     ),
     json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
     verify_cmd: str = typer.Option(
@@ -1516,6 +1531,7 @@ def improve(
         load_settings(),
         provider_name=provider_override,
         timeout=timeout,
+        claude_max_total_seconds=claude_max_total_seconds,
     )
 
     try:

--- a/autocontext/src/autocontext/cli_improve.py
+++ b/autocontext/src/autocontext/cli_improve.py
@@ -1,0 +1,205 @@
+"""Registration of the `autoctx improve` command.
+
+Extracted from `cli.py` to keep that file under the grandfathered module-size
+limit. Mirrors the `register_*_command` pattern used by analytics, hermes,
+new-scenario, solve, queue, and worker commands.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import json
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+import typer
+
+from autocontext.cli_runtime_overrides import apply_judge_runtime_overrides
+from autocontext.execution.improvement_events import ImprovementLoopEvent
+from autocontext.providers.base import ProviderError
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+def _cli_attr(dependency_module: str, name: str) -> Any:
+    """Fetch a symbol from the host CLI module without importing at top level.
+
+    The host CLI module (`autocontext.cli`) defines `load_settings`,
+    `_exit_provider_error`, and `_write_json_stdout`. Reaching them through
+    `importlib.import_module` keeps this module decoupled and lets tests
+    patch those symbols on the host module path.
+    """
+    return getattr(importlib.import_module(dependency_module), name)
+
+
+def register_improve_command(
+    app: typer.Typer,
+    *,
+    console: Console,
+    dependency_module: str = "autocontext.cli",
+) -> None:
+    """Register the `improve` command on the host Typer app.
+
+    Splits out of `cli.py` (AC-752 follow-up) so that file stays under its
+    grandfathered module-size limit.
+    """
+
+    @app.command()
+    def improve(  # noqa: D401  -- Typer command surface; keep imperative
+        task_prompt: str = typer.Option(..., "--task-prompt", "-p", help="The task prompt"),
+        rubric: str = typer.Option(..., "--rubric", "-r", help="Evaluation rubric"),
+        initial_output: str = typer.Option("", "--output", "-o", help="Starting output to improve"),
+        max_rounds: int = typer.Option(5, "--rounds", "-n", help="Maximum improvement rounds"),
+        threshold: float = typer.Option(0.9, "--threshold", "-t", help="Quality threshold to stop"),
+        provider_override: str = typer.Option("", "--provider", help="Provider override"),
+        timeout: float | None = typer.Option(
+            None,
+            "--timeout",
+            min=1.0,
+            help=(
+                "Override per-call provider timeout in seconds. For claude-cli this "
+                "writes claude_timeout (env: AUTOCONTEXT_CLAUDE_TIMEOUT, default 600s); "
+                "for codex it writes codex_timeout; for pi/pi-rpc it writes pi_timeout. "
+                "For the overall claude-cli wall-clock budget, see --claude-max-total-seconds."
+            ),
+        ),
+        claude_max_total_seconds: float | None = typer.Option(
+            None,
+            "--claude-max-total-seconds",
+            min=0.0,
+            help=(
+                "Override the wall-clock ceiling on total claude-cli runtime across all "
+                "invocations during this run (env: AUTOCONTEXT_CLAUDE_MAX_TOTAL_SECONDS, "
+                "default 0=off). Only applied when the resolved judge provider is claude-cli."
+            ),
+        ),
+        json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
+        ndjson_output: bool = typer.Option(
+            False,
+            "--ndjson",
+            help=(
+                "Stream per-round events as newline-delimited JSON to stdout (AC-752). "
+                "Useful for long-running loops where --json would buffer all output until "
+                "completion. Emits one JSON line per event: round_start, judge_done, "
+                "verifier_done, round_summary, and a final summary line."
+            ),
+        ),
+        verify_cmd: str = typer.Option(
+            "",
+            "--verify-cmd",
+            help=(
+                "External command to verify each round's output (AC-733). "
+                "Non-zero exit forces the round score to 0 and feeds the "
+                "command's stderr/stdout into the next revision prompt. "
+                "Use the literal `{file}` placeholder to receive the output as a "
+                "temp-file path; otherwise the output is piped to stdin. "
+                "Examples: 'lake env lean {file}', 'mypy {file}', 'cargo check'."
+            ),
+        ),
+        verify_suffix: str = typer.Option(
+            ".txt",
+            "--verify-suffix",
+            help="Suffix for the temp file passed to --verify-cmd (e.g. '.lean', '.py').",
+        ),
+        verify_timeout: float = typer.Option(
+            300.0,
+            "--verify-timeout",
+            min=1.0,
+            help="Timeout in seconds for each --verify-cmd invocation.",
+        ),
+    ) -> None:
+        """Run multi-round improvement loop on agent output.
+
+        Creates a simple agent task from the prompt and rubric, then runs
+        the improvement loop with judge-guided iteration.
+        """
+        from autocontext.execution.improvement_loop import ImprovementLoop
+        from autocontext.execution.output_verifier import make_verifier
+        from autocontext.execution.task_runner import SimpleAgentTask
+        from autocontext.providers.registry import get_provider as get_judge_provider
+
+        load_settings = _cli_attr(dependency_module, "load_settings")
+        write_json_stdout = _cli_attr(dependency_module, "_write_json_stdout")
+        exit_provider_error = _cli_attr(dependency_module, "_exit_provider_error")
+
+        # AC-752 (P3 follow-up): --json (single final blob) and --ndjson (streaming
+        # events) are mutually exclusive output modes. Passing both produces a
+        # mixed, un-parseable stream. Reject up front with a clear error.
+        if json_output and ndjson_output:
+            typer.echo(
+                "Error: --json and --ndjson are mutually exclusive output modes; pick one.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+
+        settings = apply_judge_runtime_overrides(
+            load_settings(),
+            provider_name=provider_override,
+            timeout=timeout,
+            claude_max_total_seconds=claude_max_total_seconds,
+        )
+
+        try:
+            provider = get_judge_provider(settings)
+            task = SimpleAgentTask(
+                task_prompt=task_prompt,
+                rubric=rubric,
+                provider=provider,
+                model=settings.judge_model,
+            )
+            state = task.initial_state()
+            verifier = make_verifier(
+                verify_cmd or None,
+                file_suffix=verify_suffix,
+                timeout_s=verify_timeout,
+            )
+            # AC-752: when --ndjson is set, stream per-round events as JSON lines
+            # so long-running loops have progress visibility before --json's final
+            # blob lands. The event sink writes one compact JSON line per event.
+            on_event: Callable[[ImprovementLoopEvent], None] | None = None
+            if ndjson_output:
+
+                def _emit_ndjson(event: ImprovementLoopEvent) -> None:
+                    payload = {k: v for k, v in dataclasses.asdict(event).items() if v is not None}
+                    typer.echo(json.dumps(payload))
+
+                on_event = _emit_ndjson
+            loop = ImprovementLoop(
+                task=task,
+                max_rounds=max_rounds,
+                quality_threshold=threshold,
+                output_verifier=verifier,
+                on_event=on_event,
+            )
+            starting_output = initial_output or task.generate_output(state)
+            result = loop.run(initial_output=starting_output, state=state)
+        except ProviderError as exc:
+            exit_provider_error(
+                exc,
+                provider_name=settings.judge_provider,
+                settings=settings,
+                json_output=json_output,
+                ndjson_output=ndjson_output,
+            )
+
+        if ndjson_output:
+            # Pure newline-delimited JSON on stdout (already streamed via on_event).
+            # Suppress the Rich human-readable summary so consumers can parse each
+            # stdout line as JSON. --json + --ndjson is rejected up front.
+            pass
+        elif json_output:
+            write_json_stdout(
+                {
+                    "best_score": result.best_score,
+                    "best_round": result.best_round,
+                    "total_rounds": result.total_rounds,
+                    "met_threshold": result.met_threshold,
+                    "best_output": result.best_output,
+                }
+            )
+        else:
+            console.print(f"[bold]Best score:[/bold] {result.best_score:.4f} (round {result.best_round})")
+            console.print(f"[bold]Rounds:[/bold] {result.total_rounds}")
+            console.print(f"[bold]Met threshold:[/bold] {result.met_threshold}")

--- a/autocontext/src/autocontext/cli_runtime_overrides.py
+++ b/autocontext/src/autocontext/cli_runtime_overrides.py
@@ -90,15 +90,27 @@ def apply_judge_runtime_overrides(
     if model:
         updates["judge_model"] = model
 
-    resolved_provider = (provider_name or settings.judge_provider).strip().lower()
+    # AC-751 (P1 follow-up): resolve "auto" the same way get_provider() does,
+    # so provider-specific flags (like --claude-max-total-seconds) gate on the
+    # effective provider rather than the literal "auto" string. Otherwise
+    # subscription-tier users with judge_provider='auto' + agent_provider='claude-cli'
+    # would have their claude budget override silently dropped.
+    from autocontext.providers.registry import resolve_auto_judge_provider
+
+    declared_provider = (provider_name or settings.judge_provider).strip().lower()
+    if declared_provider == "auto":
+        resolved_provider = resolve_auto_judge_provider(settings)
+    else:
+        resolved_provider = declared_provider
+
     _apply_timeout_overrides(
         updates,
         provider_names=[resolved_provider],
         timeout=timeout,
     )
 
-    # AC-751: only meaningful for claude-cli; gated on provider so other
-    # providers don't silently absorb a budget that does not apply to them.
+    # AC-751: only meaningful for claude-cli; gated on the effective provider
+    # so other providers don't silently absorb a budget that does not apply.
     if claude_max_total_seconds is not None and resolved_provider == "claude-cli":
         updates["claude_max_total_seconds"] = claude_max_total_seconds
 

--- a/autocontext/src/autocontext/cli_runtime_overrides.py
+++ b/autocontext/src/autocontext/cli_runtime_overrides.py
@@ -82,6 +82,7 @@ def apply_judge_runtime_overrides(
     provider_name: str = "",
     model: str = "",
     timeout: float | None = None,
+    claude_max_total_seconds: float | None = None,
 ) -> AppSettings:
     updates: dict[str, Any] = {}
     if provider_name:
@@ -95,6 +96,11 @@ def apply_judge_runtime_overrides(
         provider_names=[resolved_provider],
         timeout=timeout,
     )
+
+    # AC-751: only meaningful for claude-cli; gated on provider so other
+    # providers don't silently absorb a budget that does not apply to them.
+    if claude_max_total_seconds is not None and resolved_provider == "claude-cli":
+        updates["claude_max_total_seconds"] = claude_max_total_seconds
 
     if not updates:
         return settings
@@ -132,10 +138,7 @@ def format_runtime_provider_error(
         return message
 
     if "generation time budget" in message_lower or "time budget exhausted" in message_lower:
-        return (
-            f"{message}. Retry with --generation-time-budget <seconds> to allow a longer "
-            "per-generation solve budget."
-        )
+        return f"{message}. Retry with --generation-time-budget <seconds> to allow a longer per-generation solve budget."
 
     provider = provider_name.strip().lower()
     timeout_help = {
@@ -163,7 +166,4 @@ def format_runtime_provider_error(
             f"Original error: {message}"
         )
 
-    return (
-        f"{label} timed out after {effective}. "
-        f"Retry with --timeout <seconds> or set {env_var}. Original error: {message}"
-    )
+    return f"{label} timed out after {effective}. Retry with --timeout <seconds> or set {env_var}. Original error: {message}"

--- a/autocontext/src/autocontext/execution/improvement_events.py
+++ b/autocontext/src/autocontext/execution/improvement_events.py
@@ -1,0 +1,41 @@
+"""Per-round event value objects emitted by `ImprovementLoop` (AC-752).
+
+These exist so callers (CLI `--ndjson`, dashboards, structured logs) can
+stream progress from long-running improvement loops without waiting for
+the final result blob.
+
+Design: a single frozen-slots dataclass with all-optional event-specific
+fields tagged by an `event` discriminator. Easy to construct, easy to
+JSON-serialize via `dataclasses.asdict`, and adding new event kinds is
+non-breaking (existing consumers only inspect fields they care about).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ImprovementLoopEvent:
+    """A single event emitted by `ImprovementLoop.run`.
+
+    The `event` field is the discriminator. Other fields are optional and
+    only meaningful for certain event kinds:
+
+    - `round_start`: round
+    - `judge_done`: round, score
+    - `verifier_done`: round, verifier_ok, verifier_exit_code
+    - `round_summary`: round, effective_score
+    - `final`: best_score, best_round, total_rounds, met_threshold
+    """
+
+    event: str
+    round: int | None = None
+    score: float | None = None
+    effective_score: float | None = None
+    verifier_ok: bool | None = None
+    verifier_exit_code: int | None = None
+    best_score: float | None = None
+    best_round: int | None = None
+    total_rounds: int | None = None
+    met_threshold: bool | None = None

--- a/autocontext/src/autocontext/execution/improvement_loop.py
+++ b/autocontext/src/autocontext/execution/improvement_loop.py
@@ -175,6 +175,11 @@ class ImprovementLoop:
         # Plateau detection state
         prev_valid_score: float | None = None
         plateau_count = 0
+        # AC-750: track the last judge score that was NOT zeroed by the external
+        # verifier, so the max_score_delta warning isn't misled by veto-zeroed
+        # rounds. A round whose effective_score was forced to 0 by the verifier
+        # is not a legitimate baseline for the next round's delta comparison.
+        last_unvetoed_score: float | None = None
 
         def _apply_revision_feedback(
             current_text: str,
@@ -296,25 +301,26 @@ class ImprovementLoop:
 
             effective_score = result.score
 
-            # Max score delta warning + optional cap
-            if prev_valid_score is not None:
-                delta = abs(result.score - prev_valid_score)
+            # Max score delta warning + optional cap (AC-750: compare against
+            # the last non-vetoed score, not against post-veto zeros).
+            if last_unvetoed_score is not None:
+                delta = abs(result.score - last_unvetoed_score)
                 if delta > self.max_score_delta:
                     logger.warning(
                         "Score jump of %.3f exceeds max_score_delta %.3f (round %d: %.3f -> %.3f)",
                         delta,
                         self.max_score_delta,
                         round_num,
-                        prev_valid_score,
+                        last_unvetoed_score,
                         result.score,
                     )
                     if self.cap_score_jumps:
                         effective_score = max(
                             0.0,
                             (
-                                prev_valid_score + self.max_score_delta
-                                if result.score > prev_valid_score
-                                else prev_valid_score - self.max_score_delta
+                                last_unvetoed_score + self.max_score_delta
+                                if result.score > last_unvetoed_score
+                                else last_unvetoed_score - self.max_score_delta
                             ),
                         )
 
@@ -335,6 +341,7 @@ class ImprovementLoop:
             # The verifier's message is appended to the round reasoning so the
             # next revision prompt sees the actual error rather than the
             # judge's prose impression.
+            verifier_vetoed = False
             if self.output_verifier is not None:
                 verifier_outcome = self.output_verifier.run(current_output)
                 if not verifier_outcome.ok:
@@ -348,6 +355,7 @@ class ImprovementLoop:
                     )
                     effective_score = 0.0
                     round_result.score = 0.0
+                    verifier_vetoed = True
                     logger.info(
                         "round %d: external verifier rejected output (exit %d), score forced to 0",
                         round_num,
@@ -408,6 +416,10 @@ class ImprovementLoop:
             else:
                 plateau_count = 0
             prev_valid_score = result.score
+            # AC-750: only the judge's view from a non-vetoed round counts as a
+            # legitimate baseline for the next round's max_score_delta check.
+            if not verifier_vetoed:
+                last_unvetoed_score = result.score
 
             # Dimension threshold gate: all dimensions must meet minimum
             dims_ok = True

--- a/autocontext/src/autocontext/execution/improvement_loop.py
+++ b/autocontext/src/autocontext/execution/improvement_loop.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from autocontext.execution.improvement_events import ImprovementLoopEvent
 from autocontext.execution.output_cleaner import clean_revision_output
 from autocontext.execution.output_verifier import OutputVerifier
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
@@ -114,6 +116,7 @@ class ImprovementLoop:
         cap_score_jumps: bool = False,
         dimension_threshold: float | None = None,
         output_verifier: OutputVerifier | None = None,
+        on_event: Callable[[ImprovementLoopEvent], None] | None = None,
     ) -> None:
         self.task = task
         self.max_rounds = max(1, max_rounds)
@@ -126,6 +129,9 @@ class ImprovementLoop:
         # When set, a non-passing verifier round forces effective_score to 0
         # and feeds the verifier's stderr/stdout into the next revision prompt.
         self.output_verifier = output_verifier if (output_verifier and output_verifier.enabled) else None
+        # AC-752: optional per-round event sink so callers (e.g. `--ndjson`)
+        # can stream progress without waiting for the final result blob.
+        self._on_event: Callable[[ImprovementLoopEvent], None] = on_event or (lambda _e: None)
 
     def run(
         self,
@@ -207,8 +213,23 @@ class ImprovementLoop:
                 internal_retries=judge_result.internal_retries,
             )
 
+        def _emit_final(final_result: ImprovementResult) -> ImprovementResult:
+            # AC-752: emit a single `final` event right before returning so
+            # streaming consumers (CLI --ndjson) see the run's summary fields.
+            self._on_event(
+                ImprovementLoopEvent(
+                    event="final",
+                    best_score=final_result.best_score,
+                    best_round=final_result.best_round,
+                    total_rounds=final_result.total_rounds,
+                    met_threshold=final_result.met_threshold,
+                )
+            )
+            return final_result
+
         for round_num in range(1, self.max_rounds + 1):
             logger.info("improvement loop round %d/%d", round_num, self.max_rounds)
+            self._on_event(ImprovementLoopEvent(event="round_start", round=round_num))
 
             round_start = time.monotonic()
             result = self.task.evaluate_output(
@@ -222,6 +243,7 @@ class ImprovementLoop:
             judge_calls += 1
             round_ms = int((time.monotonic() - round_start) * 1000)
             total_internal_retries += result.internal_retries
+            self._on_event(ImprovementLoopEvent(event="judge_done", round=round_num, score=result.score))
 
             failed = _is_parse_failure(result.score, result.reasoning)
 
@@ -361,6 +383,22 @@ class ImprovementLoop:
                         round_num,
                         verifier_outcome.exit_code,
                     )
+                self._on_event(
+                    ImprovementLoopEvent(
+                        event="verifier_done",
+                        round=round_num,
+                        verifier_ok=verifier_outcome.ok,
+                        verifier_exit_code=verifier_outcome.exit_code,
+                    )
+                )
+
+            self._on_event(
+                ImprovementLoopEvent(
+                    event="round_summary",
+                    round=round_num,
+                    effective_score=effective_score,
+                )
+            )
 
             if effective_score > best_score:
                 best_score = effective_score
@@ -433,24 +471,26 @@ class ImprovementLoop:
                     # Threshold was met on a previous round too — confirmed stable
                     logger.info("quality threshold %.2f confirmed stable at round %d", self.quality_threshold, round_num)
                     duration_ms = int((time.monotonic() - loop_start) * 1000)
-                    return ImprovementResult(
-                        rounds=rounds,
-                        best_output=best_output,
-                        best_score=best_score,
-                        best_round=best_round,
-                        total_rounds=round_num,
-                        met_threshold=True,
-                        judge_failures=judge_failures,
-                        termination_reason="threshold_met",
-                        dimension_trajectory=dimension_trajectory,
-                        total_internal_retries=total_internal_retries,
-                        duration_ms=duration_ms,
-                        judge_calls=judge_calls,
-                        pareto_frontier=[
-                            {"candidate_id": c.candidate_id, "scores": c.scores, "artifact_len": len(c.artifact)}
-                            for c in _pareto_frontier.candidates
-                        ],
-                        actionable_side_info=[a.to_dict() for a in _collected_asi],
+                    return _emit_final(
+                        ImprovementResult(
+                            rounds=rounds,
+                            best_output=best_output,
+                            best_score=best_score,
+                            best_round=best_round,
+                            total_rounds=round_num,
+                            met_threshold=True,
+                            judge_failures=judge_failures,
+                            termination_reason="threshold_met",
+                            dimension_trajectory=dimension_trajectory,
+                            total_internal_retries=total_internal_retries,
+                            duration_ms=duration_ms,
+                            judge_calls=judge_calls,
+                            pareto_frontier=[
+                                {"candidate_id": c.candidate_id, "scores": c.scores, "artifact_len": len(c.artifact)}
+                                for c in _pareto_frontier.candidates
+                            ],
+                            actionable_side_info=[a.to_dict() for a in _collected_asi],
+                        )
                     )
 
                 if near_threshold and round_num < self.max_rounds:
@@ -466,24 +506,26 @@ class ImprovementLoop:
                     # Clearly above threshold — stop immediately
                     logger.info("quality threshold %.2f met at round %d", self.quality_threshold, round_num)
                     duration_ms = int((time.monotonic() - loop_start) * 1000)
-                    return ImprovementResult(
-                        rounds=rounds,
-                        best_output=best_output,
-                        best_score=best_score,
-                        best_round=best_round,
-                        total_rounds=round_num,
-                        met_threshold=True,
-                        judge_failures=judge_failures,
-                        termination_reason="threshold_met",
-                        dimension_trajectory=dimension_trajectory,
-                        total_internal_retries=total_internal_retries,
-                        duration_ms=duration_ms,
-                        judge_calls=judge_calls,
-                        pareto_frontier=[
-                            {"candidate_id": c.candidate_id, "scores": c.scores, "artifact_len": len(c.artifact)}
-                            for c in _pareto_frontier.candidates
-                        ],
-                        actionable_side_info=[a.to_dict() for a in _collected_asi],
+                    return _emit_final(
+                        ImprovementResult(
+                            rounds=rounds,
+                            best_output=best_output,
+                            best_score=best_score,
+                            best_round=best_round,
+                            total_rounds=round_num,
+                            met_threshold=True,
+                            judge_failures=judge_failures,
+                            termination_reason="threshold_met",
+                            dimension_trajectory=dimension_trajectory,
+                            total_internal_retries=total_internal_retries,
+                            duration_ms=duration_ms,
+                            judge_calls=judge_calls,
+                            pareto_frontier=[
+                                {"candidate_id": c.candidate_id, "scores": c.scores, "artifact_len": len(c.artifact)}
+                                for c in _pareto_frontier.candidates
+                            ],
+                            actionable_side_info=[a.to_dict() for a in _collected_asi],
+                        )
                     )
             else:
                 # Score dropped below threshold after previously meeting it
@@ -522,22 +564,24 @@ class ImprovementLoop:
                 current_output = revised
 
         duration_ms = int((time.monotonic() - loop_start) * 1000)
-        return ImprovementResult(
-            rounds=rounds,
-            best_output=best_output,
-            best_score=best_score,
-            best_round=best_round,
-            total_rounds=len(rounds),
-            met_threshold=False,
-            judge_failures=judge_failures,
-            termination_reason=termination_reason,
-            dimension_trajectory=dimension_trajectory,
-            total_internal_retries=total_internal_retries,
-            duration_ms=duration_ms,
-            judge_calls=judge_calls,
-            pareto_frontier=[
-                {"candidate_id": c.candidate_id, "scores": c.scores, "artifact_len": len(c.artifact)}
-                for c in _pareto_frontier.candidates
-            ],
-            actionable_side_info=[a.to_dict() for a in _collected_asi],
+        return _emit_final(
+            ImprovementResult(
+                rounds=rounds,
+                best_output=best_output,
+                best_score=best_score,
+                best_round=best_round,
+                total_rounds=len(rounds),
+                met_threshold=False,
+                judge_failures=judge_failures,
+                termination_reason=termination_reason,
+                dimension_trajectory=dimension_trajectory,
+                total_internal_retries=total_internal_retries,
+                duration_ms=duration_ms,
+                judge_calls=judge_calls,
+                pareto_frontier=[
+                    {"candidate_id": c.candidate_id, "scores": c.scores, "artifact_len": len(c.artifact)}
+                    for c in _pareto_frontier.candidates
+                ],
+                actionable_side_info=[a.to_dict() for a in _collected_asi],
+            )
         )

--- a/autocontext/src/autocontext/providers/registry.py
+++ b/autocontext/src/autocontext/providers/registry.py
@@ -113,7 +113,7 @@ def _configured_provider(settings: AppSettings, field_name: str) -> str:
     return value.lower().strip() if isinstance(value, str) else ""
 
 
-def _resolve_auto_judge_provider(settings: AppSettings) -> str:
+def resolve_auto_judge_provider(settings: AppSettings) -> str:
     """Map judge_provider='auto' to an effective provider type (AC-586).
 
     Prefer the first explicitly configured execution provider in priority order:
@@ -123,6 +123,9 @@ def _resolve_auto_judge_provider(settings: AppSettings) -> str:
     have local CLI auth don't hit the Anthropic SDK's "Could not resolve
     authentication method" error downstream. For any other provider, preserve
     the historical anthropic default.
+
+    Public so CLI override-application logic can gate provider-specific flags
+    on the same effective provider that `get_provider()` will dispatch to.
     """
     for field_name in _AUTO_JUDGE_PROVIDER_PRIORITY:
         provider = _configured_provider(settings, field_name)
@@ -146,7 +149,7 @@ def get_provider(settings: AppSettings) -> LLMProvider:
     """
     provider_type = settings.judge_provider.lower().strip()
     if provider_type == "auto":
-        provider_type = _resolve_auto_judge_provider(settings)
+        provider_type = resolve_auto_judge_provider(settings)
     base_url = settings.judge_base_url
 
     # MLX provider has its own construction path using mlx_* settings

--- a/autocontext/tests/test_cli_runtime_timeout_overrides.py
+++ b/autocontext/tests/test_cli_runtime_timeout_overrides.py
@@ -273,6 +273,44 @@ class TestImproveRuntimeTimeoutOverrides:
         # Baseline preserved because the resolved judge provider is not claude-cli.
         assert captured["settings"].claude_max_total_seconds == settings.claude_max_total_seconds
 
+    def test_improve_applies_claude_max_total_seconds_under_auto_judge_provider(self, tmp_path: Path) -> None:
+        # AC-751 (P1 follow-up): when judge_provider='auto' resolves to claude-cli
+        # via agent_provider, the flag should still write claude_max_total_seconds.
+        # Previously the gate compared against the literal 'auto' string and
+        # silently dropped the override on the subscription-tier default path.
+        settings = _settings(tmp_path).model_copy(update={"judge_provider": "auto", "agent_provider": "claude-cli"})
+        captured: dict[str, AppSettings] = {}
+
+        def _fake_get_provider(current: AppSettings) -> _RecordingProvider:
+            captured["settings"] = current
+            return _RecordingProvider()
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.providers.registry.get_provider", side_effect=_fake_get_provider),
+            patch("autocontext.execution.improvement_loop.ImprovementLoop") as mock_loop,
+        ):
+            mock_loop.return_value.run.return_value = _FakeLoopResult()
+            result = runner.invoke(
+                app,
+                [
+                    "improve",
+                    "-p",
+                    "x",
+                    "-r",
+                    "y",
+                    "--claude-max-total-seconds",
+                    "1800",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # The judge_provider stays 'auto' (we don't rewrite it); only the
+        # claude budget should land on settings since auto resolves to claude-cli.
+        assert captured["settings"].judge_provider == "auto"
+        assert captured["settings"].claude_max_total_seconds == 1800.0
+
     def test_improve_timeout_help_mentions_provider_setting(self) -> None:
         # AC-751: `--timeout` help text should call out the specific provider
         # setting it writes to (e.g. `claude_timeout`) so users discover the

--- a/autocontext/tests/test_cli_runtime_timeout_overrides.py
+++ b/autocontext/tests/test_cli_runtime_timeout_overrides.py
@@ -198,6 +198,92 @@ class TestImproveRuntimeTimeoutOverrides:
         assert "--timeout" in payload["error"]
         assert "AUTOCONTEXT_CLAUDE_TIMEOUT" in payload["error"]
 
+    def test_improve_applies_claude_max_total_seconds_override(self, tmp_path: Path) -> None:
+        # AC-751: `--claude-max-total-seconds` exposes settings.claude_max_total_seconds
+        # (the wall-clock budget across all claude-cli invocations in a run).
+        # Mirrors the existing --timeout / claude_timeout test pattern.
+        settings = _settings(tmp_path)
+        captured: dict[str, AppSettings] = {}
+        provider = _RecordingProvider()
+
+        def _fake_get_provider(current: AppSettings) -> _RecordingProvider:
+            captured["settings"] = current
+            return provider
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.providers.registry.get_provider", side_effect=_fake_get_provider),
+            patch("autocontext.execution.improvement_loop.ImprovementLoop") as mock_loop,
+        ):
+            mock_loop.return_value.run.return_value = _FakeLoopResult()
+            result = runner.invoke(
+                app,
+                [
+                    "improve",
+                    "-p",
+                    "Draft a trial design",
+                    "-r",
+                    "Score rigor 0-1.",
+                    "--provider",
+                    "claude-cli",
+                    "--claude-max-total-seconds",
+                    "1800",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured["settings"].judge_provider == "claude-cli"
+        assert captured["settings"].claude_max_total_seconds == 1800.0
+
+    def test_improve_claude_max_total_seconds_ignored_for_non_claude_provider(self, tmp_path: Path) -> None:
+        # AC-751: the flag is claude-cli-specific (it writes settings.claude_max_total_seconds,
+        # which is only consumed by the claude-cli runtime). Passing it with a different
+        # judge provider should leave the setting at its baseline rather than silently
+        # writing a value that has no effect.
+        settings = _settings(tmp_path)  # judge_provider="anthropic"
+        captured: dict[str, AppSettings] = {}
+
+        def _fake_get_provider(current: AppSettings) -> _RecordingProvider:
+            captured["settings"] = current
+            return _RecordingProvider()
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.providers.registry.get_provider", side_effect=_fake_get_provider),
+            patch("autocontext.execution.improvement_loop.ImprovementLoop") as mock_loop,
+        ):
+            mock_loop.return_value.run.return_value = _FakeLoopResult()
+            result = runner.invoke(
+                app,
+                [
+                    "improve",
+                    "-p",
+                    "x",
+                    "-r",
+                    "y",
+                    "--claude-max-total-seconds",
+                    "1800",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert captured["settings"].judge_provider == "anthropic"
+        # Baseline preserved because the resolved judge provider is not claude-cli.
+        assert captured["settings"].claude_max_total_seconds == settings.claude_max_total_seconds
+
+    def test_improve_timeout_help_mentions_provider_setting(self) -> None:
+        # AC-751: `--timeout` help text should call out the specific provider
+        # setting it writes to (e.g. `claude_timeout`) so users discover the
+        # mapping without reading source.
+        result = runner.invoke(app, ["improve", "--help"])
+
+        assert result.exit_code == 0, result.output
+        # The help should at least mention claude_timeout (or its env var) so
+        # users grepping for "claude" land on the right flag.
+        assert "claude_timeout" in result.output or "AUTOCONTEXT_CLAUDE_TIMEOUT" in result.output
+
 
 class TestPiRpcRuntimeTimeoutOverrides:
     def test_pi_rpc_provider_uses_runtime_timeout_override(self, tmp_path: Path) -> None:

--- a/autocontext/tests/test_improvement_loop_events.py
+++ b/autocontext/tests/test_improvement_loop_events.py
@@ -258,3 +258,81 @@ class TestImproveNdjsonFlag:
         assert final["best_round"] == 1
         assert final["total_rounds"] == 1
         assert final["met_threshold"] is True
+
+    def test_ndjson_keeps_stdout_parseable_on_provider_error(self, tmp_path) -> None:
+        # AC-752 (P2 follow-up): when --ndjson is set and a provider raises, the
+        # CLI must not write Rich/plain text to stdout (would poison the ndjson
+        # stream). Either an error event line on stdout, or write to stderr.
+        import json as _json
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from autocontext.cli import app
+        from autocontext.config.settings import AppSettings
+        from autocontext.providers.base import ProviderError
+
+        runner = CliRunner()
+
+        class _BoomProvider:
+            def complete(self, *_args, **_kwargs):
+                raise ProviderError("ClaudeCLIRuntime failed: timeout")
+
+            def default_model(self):
+                return "claude-cli"
+
+        settings = AppSettings(
+            db_path=tmp_path / "runs" / "autocontext.sqlite3",
+            runs_root=tmp_path / "runs",
+            knowledge_root=tmp_path / "knowledge",
+            skills_root=tmp_path / "skills",
+            claude_skills_path=tmp_path / ".claude" / "skills",
+            judge_provider="claude-cli",
+        )
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.providers.registry.get_provider", return_value=_BoomProvider()),
+        ):
+            result = runner.invoke(
+                app,
+                ["improve", "-p", "x", "-r", "y", "--provider", "claude-cli", "--ndjson"],
+            )
+
+        assert result.exit_code == 1
+        # Every non-empty stdout line must be valid JSON, so ndjson consumers
+        # can parse uniformly. An error event is fine; raw text is not.
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            _json.loads(line)  # raises if any stdout line is non-JSON
+
+    def test_json_and_ndjson_combination_is_rejected(self, tmp_path) -> None:
+        # AC-752 (P3 follow-up): --json (final-blob) and --ndjson (streaming) are
+        # mutually exclusive output modes. Passing both produces a mixed,
+        # un-parseable stream. The CLI should reject the combination up front.
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from autocontext.cli import app
+        from autocontext.config.settings import AppSettings
+
+        runner = CliRunner()
+
+        settings = AppSettings(
+            db_path=tmp_path / "runs" / "autocontext.sqlite3",
+            runs_root=tmp_path / "runs",
+            knowledge_root=tmp_path / "knowledge",
+            skills_root=tmp_path / "skills",
+            claude_skills_path=tmp_path / ".claude" / "skills",
+            judge_provider="anthropic",
+        )
+
+        with patch("autocontext.cli.load_settings", return_value=settings):
+            result = runner.invoke(app, ["improve", "-p", "x", "-r", "y", "--json", "--ndjson"])
+
+        assert result.exit_code != 0
+        # The error message should mention both flags so the user knows why.
+        combined = (result.stdout + (result.stderr or "")).lower()
+        assert "--json" in combined and "--ndjson" in combined

--- a/autocontext/tests/test_improvement_loop_events.py
+++ b/autocontext/tests/test_improvement_loop_events.py
@@ -1,0 +1,260 @@
+"""Tests for AC-752: per-round event streaming from ImprovementLoop.
+
+Long-running improvement loops can run silently for many minutes when
+`--json` buffers everything until completion. The loop should emit
+structured per-round events through an optional `on_event` callback so
+callers (e.g. `autoctx improve --ndjson`) can stream progress.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+
+from autocontext.execution.improvement_events import ImprovementLoopEvent
+from autocontext.execution.improvement_loop import ImprovementLoop
+from autocontext.execution.output_verifier import OutputVerifier
+from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
+
+
+class _OneShotPerfectTask(AgentTaskInterface):
+    """Judge returns 1.0 on first round, terminating the loop after one
+    round when threshold=0.9. Useful for shape-of-event-stream tests."""
+
+    def get_task_prompt(self, state):
+        return "."
+
+    def evaluate_output(self, output, state, **kwargs):
+        return AgentTaskResult(score=1.0, reasoning="ok", dimension_scores={})
+
+    def revise_output(self, current_output, judge_result, state):
+        return current_output + "\nrev"
+
+    def get_rubric(self):
+        return "."
+
+    def initial_state(self, seed=None):
+        return {}
+
+    def describe_task(self):
+        return "."
+
+
+def _passing_verifier() -> OutputVerifier:
+    return OutputVerifier(command=[sys.executable, "-c", "pass"])
+
+
+def _failing_verifier() -> OutputVerifier:
+    script = textwrap.dedent(
+        """
+        import sys
+        print('boom', file=sys.stderr)
+        sys.exit(2)
+        """
+    ).strip()
+    return OutputVerifier(command=[sys.executable, "-c", script])
+
+
+class TestImprovementLoopEventStream:
+    def test_loop_emits_minimum_event_sequence_for_single_round(self) -> None:
+        # Single round, no verifier. Expected sequence:
+        #   round_start, judge_done, round_summary, final
+        events: list[ImprovementLoopEvent] = []
+        loop = ImprovementLoop(
+            task=_OneShotPerfectTask(),
+            max_rounds=1,
+            quality_threshold=0.9,
+            on_event=events.append,
+        )
+        loop.run("initial", {})
+
+        event_types = [e.event for e in events]
+        assert event_types == ["round_start", "judge_done", "round_summary", "final"]
+
+    def test_loop_emits_verifier_event_when_verifier_configured(self) -> None:
+        # With a passing verifier: round_start, judge_done, verifier_done,
+        # round_summary, final.
+        events: list[ImprovementLoopEvent] = []
+        loop = ImprovementLoop(
+            task=_OneShotPerfectTask(),
+            max_rounds=1,
+            quality_threshold=0.9,
+            output_verifier=_passing_verifier(),
+            on_event=events.append,
+        )
+        loop.run("initial", {})
+
+        event_types = [e.event for e in events]
+        assert event_types == [
+            "round_start",
+            "judge_done",
+            "verifier_done",
+            "round_summary",
+            "final",
+        ]
+        verifier_event = next(e for e in events if e.event == "verifier_done")
+        assert verifier_event.verifier_ok is True
+
+    def test_verifier_event_records_veto_when_verifier_rejects(self) -> None:
+        # A failing verifier should emit verifier_done with verifier_ok=False
+        # and a non-zero exit code.
+        events: list[ImprovementLoopEvent] = []
+        loop = ImprovementLoop(
+            task=_OneShotPerfectTask(),
+            max_rounds=1,
+            quality_threshold=0.9,
+            output_verifier=_failing_verifier(),
+            on_event=events.append,
+        )
+        loop.run("initial", {})
+
+        verifier_event = next(e for e in events if e.event == "verifier_done")
+        assert verifier_event.verifier_ok is False
+        assert verifier_event.verifier_exit_code == 2
+
+    def test_judge_event_carries_round_and_score(self) -> None:
+        events: list[ImprovementLoopEvent] = []
+        loop = ImprovementLoop(
+            task=_OneShotPerfectTask(),
+            max_rounds=1,
+            quality_threshold=0.9,
+            on_event=events.append,
+        )
+        loop.run("initial", {})
+
+        judge_event = next(e for e in events if e.event == "judge_done")
+        assert judge_event.round == 1
+        assert judge_event.score == 1.0
+
+    def test_final_event_carries_summary_fields(self) -> None:
+        events: list[ImprovementLoopEvent] = []
+        loop = ImprovementLoop(
+            task=_OneShotPerfectTask(),
+            max_rounds=1,
+            quality_threshold=0.9,
+            on_event=events.append,
+        )
+        result = loop.run("initial", {})
+
+        final = next(e for e in events if e.event == "final")
+        assert final.best_score == result.best_score
+        assert final.best_round == result.best_round
+        assert final.total_rounds == result.total_rounds
+        assert final.met_threshold == result.met_threshold
+
+    def test_no_event_callback_means_no_emission_or_breakage(self) -> None:
+        # Backward compatibility: omitting on_event must not break anything.
+        loop = ImprovementLoop(
+            task=_OneShotPerfectTask(),
+            max_rounds=1,
+            quality_threshold=0.9,
+        )
+        result = loop.run("initial", {})
+        assert result.best_score == 1.0
+
+
+# -- AC-752: CLI `--ndjson` streams events as JSON lines --
+
+
+class TestImproveNdjsonFlag:
+    """End-to-end check that `autoctx improve --ndjson` writes one JSON line
+    per event from the loop (round_start, judge_done, round_summary, final).
+    """
+
+    def test_ndjson_emits_one_json_line_per_event(self, tmp_path) -> None:
+        import json as _json
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from autocontext.cli import app
+        from autocontext.config.settings import AppSettings
+        from autocontext.providers.base import CompletionResult
+
+        runner = CliRunner()
+
+        class _Provider:
+            def complete(self, system_prompt, user_prompt, model=None, **_):
+                return CompletionResult(text="x", model=model)
+
+            def default_model(self):
+                return "m"
+
+        settings = AppSettings(
+            db_path=tmp_path / "runs" / "autocontext.sqlite3",
+            runs_root=tmp_path / "runs",
+            knowledge_root=tmp_path / "knowledge",
+            skills_root=tmp_path / "skills",
+            claude_skills_path=tmp_path / ".claude" / "skills",
+            judge_provider="anthropic",
+        )
+
+        # Build a fake ImprovementLoop that records the on_event callback and
+        # exercises it with the expected event sequence, then returns a stub
+        # result. This isolates the CLI-side --ndjson wiring from the real
+        # loop logic (which already has dedicated tests above).
+        captured: dict[str, object] = {"on_event_truthy": None}
+
+        class _FakeLoop:
+            def __init__(self, **kwargs):
+                captured["init_called"] = True
+                captured["init_kwargs_keys"] = sorted(kwargs.keys())
+                self._on_event = kwargs.get("on_event")
+                captured["on_event_truthy"] = self._on_event is not None
+
+            def run(self, **_kwargs):
+                captured["run_called"] = True
+                if self._on_event is not None:
+                    self._on_event(ImprovementLoopEvent(event="round_start", round=1))
+                    self._on_event(ImprovementLoopEvent(event="judge_done", round=1, score=0.95))
+                    self._on_event(ImprovementLoopEvent(event="round_summary", round=1, effective_score=0.95))
+                    self._on_event(
+                        ImprovementLoopEvent(
+                            event="final",
+                            best_score=0.95,
+                            best_round=1,
+                            total_rounds=1,
+                            met_threshold=True,
+                        )
+                    )
+                return SimpleNamespace(
+                    best_score=0.95,
+                    best_round=1,
+                    total_rounds=1,
+                    met_threshold=True,
+                    best_output="x",
+                )
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.providers.registry.get_provider", return_value=_Provider()),
+            patch("autocontext.execution.improvement_loop.ImprovementLoop", _FakeLoop),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "improve",
+                    "-p",
+                    "x",
+                    "-r",
+                    "y",
+                    "--ndjson",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # Sanity: the patched loop was used and received the on_event callback.
+        assert captured.get("init_called")
+        assert captured.get("on_event_truthy")
+        # Every non-empty stdout line is a JSON event (Rich summary is suppressed
+        # under --ndjson so stdout is pure newline-delimited JSON).
+        lines = [line for line in result.stdout.splitlines() if line.strip()]
+        events = [_json.loads(line) for line in lines]
+        event_types = [e["event"] for e in events]
+        assert event_types == ["round_start", "judge_done", "round_summary", "final"]
+        final = events[-1]
+        assert final["best_score"] == 0.95
+        assert final["best_round"] == 1
+        assert final["total_rounds"] == 1
+        assert final["met_threshold"] is True

--- a/autocontext/tests/test_improvement_loop_verifier.py
+++ b/autocontext/tests/test_improvement_loop_verifier.py
@@ -233,3 +233,109 @@ class TestVerifierIntegration:
         result = loop.run("initial", {})
         assert result.best_score == 1.0
         assert result.met_threshold is True
+
+
+# -- AC-750: max_score_delta warning vs verifier-veto provenance --
+
+
+class _StagedJudgeTask(AgentTaskInterface):
+    """Task whose judge returns a different score depending on whether the
+    output has been revised (i.e. contains the 'FIX' marker).
+
+    This pairs with `_picky_verifier` so we can simulate:
+      round 1: judge=initial_score, verifier vetoes (no FIX yet) -> effective 0
+      round 2: judge=revised_score,  verifier passes (FIX added) -> effective revised_score
+    """
+
+    def __init__(self, *, initial_score: float, revised_score: float) -> None:
+        self._initial_score = initial_score
+        self._revised_score = revised_score
+
+    def get_task_prompt(self, state):
+        return "Produce a clean Lean file."
+
+    def evaluate_output(self, output, state, **kwargs):
+        if "FIX" in output:
+            return AgentTaskResult(
+                score=self._revised_score,
+                reasoning="judge: revised output looks good",
+                dimension_scores={},
+            )
+        return AgentTaskResult(
+            score=self._initial_score,
+            reasoning="judge: initial output is weak",
+            dimension_scores={},
+        )
+
+    def revise_output(self, current_output, judge_result, state):
+        return current_output + "\nFIX"
+
+    def get_rubric(self):
+        return "Score 0-1."
+
+    def initial_state(self, seed=None):
+        return {}
+
+    def describe_task(self):
+        return "."
+
+
+class TestVerifierVetoProvenance:
+    """When the external verifier vetoes a round, `prev_valid_score` becomes 0
+    -- but that 0 is NOT a real judge baseline. The next round's legitimate
+    judge score (e.g. 0.6) should not trigger a misleading
+    `max_score_delta` warning against the veto-zeroed 0.0.
+
+    Concrete repro (2026-05-11): a 3-round Opus run against `lake env lean`.
+    Round 1 timed out -> verifier vetoed -> score 0. Round 2's judge honestly
+    scored 0.6 (the model had fixed several issues) but the warning fired:
+        `Score jump of 0.600 exceeds max_score_delta 0.500 (round 2: 0.000 -> 0.600)`
+    The warning is misleading; round 1's 0 was a veto, not a judge score.
+    """
+
+    def test_no_warning_when_previous_round_was_verifier_vetoed(self, caplog) -> None:
+        import logging
+
+        # Round 1: judge=0.4, verifier vetoes (no FIX) -> effective 0
+        # Round 2: judge=0.6, verifier passes (FIX added) -> effective 0.6
+        # Under the buggy logic this fires "score jump 0.600 vs 0.000".
+        # After the fix the warning is suppressed because round 1's 0 was a veto.
+        task = _StagedJudgeTask(initial_score=0.4, revised_score=0.6)
+        loop = ImprovementLoop(
+            task=task,
+            max_rounds=2,
+            quality_threshold=0.9,
+            max_score_delta=0.5,
+            output_verifier=_picky_verifier(),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="autocontext.execution.improvement_loop"):
+            loop.run("initial", {})
+
+        score_jump_warnings = [record for record in caplog.records if "Score jump" in record.getMessage()]
+        assert score_jump_warnings == [], (
+            "verifier-vetoed previous round should not be a baseline for the "
+            f"max_score_delta warning; got: {[r.getMessage() for r in score_jump_warnings]}"
+        )
+
+    def test_warning_still_fires_for_genuine_judge_score_jump(self, caplog) -> None:
+        import logging
+
+        # No verifier. Round 1 judge=0.1, round 2 judge=0.7. Genuine jump
+        # exceeding max_score_delta=0.5 -- warning should still fire because
+        # the previous score is a real judge baseline.
+        task = _StagedJudgeTask(initial_score=0.1, revised_score=0.7)
+        loop = ImprovementLoop(
+            task=task,
+            max_rounds=2,
+            quality_threshold=0.9,
+            max_score_delta=0.5,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="autocontext.execution.improvement_loop"):
+            loop.run("initial", {})
+
+        score_jump_warnings = [record for record in caplog.records if "Score jump" in record.getMessage()]
+        assert score_jump_warnings, (
+            "genuine score jump (no verifier veto on previous round) should still trigger the max_score_delta warning"
+        )


### PR DESCRIPTION
Three small improvements to `autoctx improve` ergonomics found while running a 3-round Opus loop against `lake env lean` for a Lean port on 2026-05-11. Each commit stands on its own; bundled here because they all touch `improve` and its surrounding plumbing.

## AC-751 — `--claude-max-total-seconds` flag + sharper `--timeout` help

`claude_max_total_seconds` (the wall-clock budget across all claude-cli invocations during a run) had no CLI flag; only the env var worked. Adds `--claude-max-total-seconds FLOAT` on `improve`, propagated through `apply_judge_runtime_overrides` (only writes when the resolved judge provider is claude-cli, so other providers don't silently absorb it).

Also tightens `--timeout`'s help text to call out the per-provider setting it actually writes (`claude_timeout`/`codex_timeout`/`pi_timeout`), so the mapping is discoverable without reading source.

## AC-750 — `max_score_delta` warning ignores verifier vetos

When the external verifier vetoes a round, `prev_valid_score` was 0.0 for the next round's delta check. A legitimate next-round judge score of 0.6 would then trip `Score jump of 0.600 exceeds max_score_delta 0.500 (round N: 0.000 -> 0.600)`. That 0 wasn't a judge baseline, it was a veto.

Now tracks `last_unvetoed_score` separately and compares against that. Plateau detection still uses `prev_valid_score` because a run of post-veto zeros is a legitimate "we keep producing broken output" stall.

## AC-752 — `--ndjson` event streaming

`--json` buffered everything until completion; long runs were silent for 20+ minutes. Adds an `on_event` callback to `ImprovementLoop` and a new `ImprovementLoopEvent` value object (frozen-slots dataclass) in `execution/improvement_events.py`. Five event kinds: `round_start`, `judge_done`, `verifier_done` (only when verifier configured), `round_summary`, `final`.

`autoctx improve --ndjson` wires up an event sink that writes one compact JSON line per event to stdout. Under `--ndjson` the Rich human-readable summary is suppressed so stdout is pure newline-delimited JSON. Existing `--json` (single final blob) behavior is unchanged.

## Tests

- 3 new tests for the `--claude-max-total-seconds` flag (positive + provider-gating + help discoverability)
- 2 new tests for the verifier-veto-aware delta warning (suppress on veto, regression-guard for genuine jumps)
- 7 new tests for event streaming (loop sequence, verifier event payload, score / final summary fields, no-op when callback omitted, end-to-end CLI ndjson)

85 improvement-loop+CLI tests pass; 101 CLI tests pass overall.

## Test plan

- [ ] CI green
- [ ] Try `autoctx improve --ndjson --verify-cmd ...` on a real loop to confirm streaming works in practice