### PR TITLE
Add derived HTML artifact renderers

### DIFF
--- a/autocontext/src/autocontext/analytics/artifact_rendering.py
+++ b/autocontext/src/autocontext/analytics/artifact_rendering.py
@@ -1,0 +1,677 @@
+"""Shared renderers for human-facing analytics artifacts.
+
+Structured reports and traces remain the source of truth. This module owns the
+presentation view models and deterministic Markdown/HTML rendering used by
+operator-facing surfaces.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from html import escape
+from typing import Any
+
+from autocontext.analytics.html_artifact_shell import TIMELINE_FILTER_SCRIPT, html_document
+
+
+@dataclass(frozen=True, slots=True)
+class FindingView:
+    title: str
+    description: str
+    finding_type: str
+    severity: str
+    category: str
+    evidence_event_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class FailureMotifView:
+    pattern_name: str
+    occurrence_count: int
+    evidence_event_ids: tuple[str, ...] = ()
+    description: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryPathView:
+    failure_event_id: str
+    recovery_event_id: str
+    path_event_ids: tuple[str, ...] = ()
+    description: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class TraceWriteupView:
+    run_id: str
+    summary: str
+    scenario: str = ""
+    scenario_family: str = ""
+    findings: tuple[FindingView, ...] = ()
+    failure_motifs: tuple[FailureMotifView, ...] = ()
+    recovery_paths: tuple[RecoveryPathView, ...] = ()
+
+    @property
+    def context(self) -> str:
+        return " | ".join(part for part in [self.scenario, self.scenario_family] if part)
+
+
+@dataclass(frozen=True, slots=True)
+class WeaknessReportView:
+    run_id: str
+    scenario: str
+    weaknesses: tuple[FindingView, ...] = ()
+    failure_motifs: tuple[FailureMotifView, ...] = ()
+    recovery_analysis: str = ""
+    recommendations: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class TimelineEventView:
+    event_id: str
+    sequence_number: int
+    generation_index: int | None
+    timestamp: str
+    category: str
+    stage: str
+    event_type: str
+    actor_id: str
+    severity: str
+    summary: str
+    outcome: str
+    artifact_links: tuple[str, ...] = ()
+    evidence_ids: tuple[str, ...] = ()
+    children_count: int = 0
+    highlight: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TimelineInspectionView:
+    trace_id: str
+    run_id: str
+    created_at: str
+    summary: str
+    item_count: int
+    error_count: int
+    recovery_count: int
+    events: tuple[TimelineEventView, ...] = ()
+    failure_paths: tuple[tuple[str, ...], ...] = ()
+    recovery_paths: tuple[tuple[str, ...], ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CurationItemView:
+    title: str
+    body: str
+    source: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioCurationView:
+    scenario_name: str
+    active_lessons: list[CurationItemView] = field(default_factory=list)
+    stale_lessons: list[CurationItemView] = field(default_factory=list)
+    superseded_lessons: list[CurationItemView] = field(default_factory=list)
+    hints: list[CurationItemView] = field(default_factory=list)
+    dead_ends: list[CurationItemView] = field(default_factory=list)
+    weakness_findings: list[CurationItemView] = field(default_factory=list)
+    progress_reports: list[CurationItemView] = field(default_factory=list)
+
+
+def trace_writeup_view(writeup: Any) -> TraceWriteupView:
+    metadata = _metadata(writeup)
+    return TraceWriteupView(
+        run_id=str(getattr(writeup, "run_id", "")),
+        summary=str(getattr(writeup, "summary", "")),
+        scenario=str(metadata.get("scenario", "")),
+        scenario_family=str(metadata.get("scenario_family", "")),
+        findings=tuple(_finding_view(finding) for finding in getattr(writeup, "findings", [])),
+        failure_motifs=tuple(_failure_motif_view(motif) for motif in getattr(writeup, "failure_motifs", [])),
+        recovery_paths=tuple(_recovery_path_view(path) for path in getattr(writeup, "recovery_paths", [])),
+    )
+
+
+def weakness_report_view(report: Any) -> WeaknessReportView:
+    metadata = _metadata(report)
+    return WeaknessReportView(
+        run_id=str(getattr(report, "run_id", "")),
+        scenario=str(metadata.get("scenario", "")),
+        weaknesses=tuple(_finding_view(finding) for finding in getattr(report, "weaknesses", [])),
+        failure_motifs=tuple(_failure_motif_view(motif) for motif in getattr(report, "failure_motifs", [])),
+        recovery_analysis=str(getattr(report, "recovery_analysis", "")),
+        recommendations=tuple(str(rec) for rec in getattr(report, "recommendations", [])),
+    )
+
+
+def timeline_inspection_view(trace: Any) -> TimelineInspectionView:
+    from autocontext.analytics.timeline_inspector import StateInspector, TimelineBuilder
+
+    inspector = StateInspector()
+    builder = TimelineBuilder()
+    run_inspection = inspector.inspect_run(trace)
+    entries = builder.build(trace)
+    event_views = tuple(
+        TimelineEventView(
+            event_id=entry.event.event_id,
+            sequence_number=entry.event.sequence_number,
+            generation_index=entry.event.generation_index,
+            timestamp=entry.event.timestamp,
+            category=entry.event.category,
+            stage=entry.event.stage,
+            event_type=entry.event.event_type,
+            actor_id=entry.event.actor.actor_id,
+            severity=entry.event.severity,
+            summary=entry.event.summary,
+            outcome=str(entry.event.outcome or ""),
+            artifact_links=tuple(entry.artifact_links),
+            evidence_ids=tuple(entry.event.evidence_ids),
+            children_count=entry.children_count,
+            highlight=entry.highlight,
+        )
+        for entry in entries
+    )
+    return TimelineInspectionView(
+        trace_id=str(trace.trace_id),
+        run_id=str(trace.run_id),
+        created_at=str(trace.created_at),
+        summary=run_inspection.summary,
+        item_count=len(event_views),
+        error_count=run_inspection.failure_count,
+        recovery_count=run_inspection.recovery_count,
+        events=event_views,
+        failure_paths=tuple(tuple(event.event_id for event in path) for path in inspector.find_failure_paths(trace)),
+        recovery_paths=tuple(tuple(event.event_id for event in path) for path in inspector.find_recovery_paths(trace)),
+    )
+
+
+def scenario_curation_view_from_artifacts(artifacts: Any, scenario_name: str, *, max_reports: int = 2) -> ScenarioCurationView:
+    lessons = artifacts.lesson_store.read_lessons(scenario_name)
+    current_generation = artifacts.lesson_store.current_generation(scenario_name)
+    active_lessons = [
+        CurationItemView(
+            title=lesson.id,
+            body=lesson.text,
+            source=f"lessons.json:generation={lesson.meta.generation}",
+        )
+        for lesson in artifacts.lesson_store.get_applicable_lessons(scenario_name, current_generation=current_generation)
+    ]
+    stale_lessons = [
+        CurationItemView(
+            title=lesson.id,
+            body=lesson.text,
+            source=f"lessons.json:last_validated_gen={lesson.meta.last_validated_gen}",
+        )
+        for lesson in artifacts.lesson_store.get_stale_lessons(scenario_name, current_generation=current_generation)
+    ]
+    superseded_lessons = [
+        CurationItemView(
+            title=lesson.id,
+            body=lesson.text,
+            source=f"lessons.json:superseded_by={lesson.meta.superseded_by}",
+        )
+        for lesson in lessons
+        if lesson.is_superseded()
+    ]
+    hints = _markdown_items("Hints", artifacts.read_hints(scenario_name), "hints.md")
+    dead_ends = _markdown_items("Dead ends", artifacts.read_dead_ends(scenario_name), "dead_ends.md")
+    weakness_findings = _weakness_items(artifacts.read_latest_weakness_reports(scenario_name, max_reports=max_reports))
+    progress_reports = _markdown_report_items(
+        "Progress report",
+        artifacts.read_latest_progress_reports(scenario_name, max_reports=max_reports),
+    )
+    return ScenarioCurationView(
+        scenario_name=scenario_name,
+        active_lessons=active_lessons,
+        stale_lessons=stale_lessons,
+        superseded_lessons=superseded_lessons,
+        hints=hints,
+        dead_ends=dead_ends,
+        weakness_findings=weakness_findings,
+        progress_reports=progress_reports,
+    )
+
+
+def render_trace_writeup_markdown(view: TraceWriteupView) -> str:
+    lines = [f"# Run Summary: {view.run_id}", ""]
+    if view.context:
+        lines.append(f"**Context:** {view.context}")
+        lines.append("")
+
+    lines.append("## Trace Summary")
+    lines.append(view.summary)
+    lines.append("")
+
+    lines.append("## Findings")
+    if view.findings:
+        for finding in view.findings:
+            evidence = ", ".join(finding.evidence_event_ids) or "none"
+            lines.append(
+                f"- **{finding.title}** [{finding.finding_type}/{finding.severity}] "
+                f"{finding.description} (evidence: {evidence})"
+            )
+    else:
+        lines.append("No notable findings.")
+    lines.append("")
+
+    lines.append("## Failure Motifs")
+    if view.failure_motifs:
+        for motif in view.failure_motifs:
+            lines.append(f"- **{motif.pattern_name}**: {motif.occurrence_count} occurrence(s)")
+    else:
+        lines.append("No recurring failure motifs.")
+    lines.append("")
+
+    lines.append("## Recovery Paths")
+    if view.recovery_paths:
+        for recovery in view.recovery_paths:
+            lines.append(
+                f"- {recovery.failure_event_id} -> {recovery.recovery_event_id} "
+                f"({len(recovery.path_event_ids)} events)"
+            )
+    else:
+        lines.append("No recovery paths observed.")
+
+    return "\n".join(lines)
+
+
+def render_weakness_report_markdown(view: WeaknessReportView) -> str:
+    lines = [
+        f"# Weakness Report: {view.run_id}",
+        f"**Scenario:** {view.scenario or 'unknown'}",
+        "",
+    ]
+    if not view.weaknesses:
+        lines.append("No weaknesses identified.")
+    else:
+        lines.append(f"**Summary:** {len(view.weaknesses)} weakness(es) detected")
+        lines.append("")
+        for weakness in view.weaknesses:
+            evidence = ", ".join(weakness.evidence_event_ids) or "none"
+            lines.append(f"## [{weakness.severity.upper()}] {weakness.title}")
+            lines.append(weakness.description)
+            lines.append(f"- Category: {weakness.category}")
+            lines.append(f"- Evidence events: {evidence}")
+            lines.append("")
+
+    lines.append("## Recovery Analysis")
+    lines.append(view.recovery_analysis or "No recovery analysis available.")
+    lines.append("")
+    lines.append("## Recommendations")
+    if view.recommendations:
+        for recommendation in view.recommendations:
+            lines.append(f"- {recommendation}")
+    else:
+        lines.append("- No immediate recommendations.")
+    return "\n".join(lines)
+
+
+def render_trace_writeup_html(view: TraceWriteupView) -> str:
+    context = f'<p class="muted">{_h(view.context)}</p>' if view.context else ""
+    findings = _render_findings_html(view.findings, empty="No notable findings.")
+    motifs = _render_motifs_html(view.failure_motifs)
+    recoveries = _render_recovery_paths_html(view.recovery_paths)
+    body = f"""
+<header>
+  <p class="eyebrow">Trace writeup</p>
+  <h1>Run Summary: {_h(view.run_id)}</h1>
+  {context}
+</header>
+<section>
+  <h2>Trace Summary</h2>
+  <p>{_h(view.summary)}</p>
+</section>
+<section>
+  <h2>Findings</h2>
+  {findings}
+</section>
+<section>
+  <h2>Failure Motifs</h2>
+  {motifs}
+</section>
+<section>
+  <h2>Recovery Paths</h2>
+  {recoveries}
+</section>
+"""
+    return html_document(f"Run Summary: {view.run_id}", body)
+
+
+def render_weakness_report_html(view: WeaknessReportView) -> str:
+    weaknesses = _render_findings_html(view.weaknesses, empty="No weaknesses identified.")
+    motifs = _render_motifs_html(view.failure_motifs)
+    recommendations = _render_list_html(view.recommendations, empty="No immediate recommendations.")
+    body = f"""
+<header>
+  <p class="eyebrow">Weakness report</p>
+  <h1>Weakness Report: {_h(view.run_id)}</h1>
+  <p class="muted">Scenario: {_h(view.scenario or 'unknown')}</p>
+</header>
+<section>
+  <h2>Weaknesses</h2>
+  {weaknesses}
+</section>
+<section>
+  <h2>Failure Motifs</h2>
+  {motifs}
+</section>
+<section>
+  <h2>Recovery Analysis</h2>
+  <p>{_h(view.recovery_analysis or 'No recovery analysis available.')}</p>
+</section>
+<section>
+  <h2>Recommendations</h2>
+  {recommendations}
+</section>
+"""
+    return html_document(f"Weakness Report: {view.run_id}", body)
+
+
+def render_markdown_document_html(title: str, markdown: str) -> str:
+    body = f"""
+<header>
+  <p class="eyebrow">Markdown fallback</p>
+  <h1>{_h(title)}</h1>
+</header>
+<section>
+  <pre class="markdown-fallback">{_h(markdown)}</pre>
+</section>
+"""
+    return html_document(title, body)
+
+
+def render_timeline_inspection_html(view: TimelineInspectionView) -> str:
+    events = "\n".join(_render_timeline_event_html(event) for event in view.events)
+    if not events:
+        events = '<p class="empty">No timeline events.</p>'
+    failure_paths = _render_path_list(view.failure_paths, "No failure paths.")
+    recovery_paths = _render_path_list(view.recovery_paths, "No recovery paths.")
+    body = f"""
+<header>
+  <p class="eyebrow">Timeline inspection</p>
+  <h1>Runtime Timeline: {_h(view.run_id)}</h1>
+  <p class="muted">Trace {_h(view.trace_id)} | {_h(view.created_at)}</p>
+</header>
+<section class="metric-row">
+  <div><strong>{view.item_count}</strong><span>events</span></div>
+  <div><strong>{view.error_count}</strong><span>failures</span></div>
+  <div><strong>{view.recovery_count}</strong><span>recoveries</span></div>
+</section>
+<section>
+  <h2>Summary</h2>
+  <p>{_h(view.summary)}</p>
+</section>
+<section>
+  <h2>Filters</h2>
+  <div class="filters" aria-label="Timeline filters">
+    <label>Category <input data-filter="category" placeholder="failure"></label>
+    <label>Stage <input data-filter="stage" placeholder="match"></label>
+    <label>Severity <input data-filter="severity" placeholder="error"></label>
+    <label>Generation <input data-filter="generation" placeholder="1"></label>
+  </div>
+</section>
+<section>
+  <h2>Events</h2>
+  <div class="timeline">{events}</div>
+</section>
+<section class="grid-two">
+  <div>
+    <h2>Failure Paths</h2>
+    {failure_paths}
+  </div>
+  <div>
+    <h2>Recovery Paths</h2>
+    {recovery_paths}
+  </div>
+</section>
+"""
+    return html_document(f"Runtime Timeline: {view.run_id}", body, script=TIMELINE_FILTER_SCRIPT)
+
+
+def render_scenario_curation_html(view: ScenarioCurationView) -> str:
+    export_text = _curation_export_markdown(view)
+    body = f"""
+<header>
+  <p class="eyebrow">Read-only derived artifact</p>
+  <h1>Scenario Curation: {_h(view.scenario_name)}</h1>
+  <p class="muted">Review accumulated scenario knowledge without mutating source artifacts.</p>
+</header>
+{_render_curation_section("Active Lessons", view.active_lessons)}
+{_render_curation_section("Stale Lessons", view.stale_lessons)}
+{_render_curation_section("Superseded Lessons", view.superseded_lessons)}
+{_render_curation_section("Hints", view.hints)}
+{_render_curation_section("Dead Ends", view.dead_ends)}
+{_render_curation_section("Weakness Findings", view.weakness_findings)}
+{_render_curation_section("Progress Reports", view.progress_reports)}
+<section>
+  <h2>Export</h2>
+  <pre data-export-format="markdown">{_h(export_text)}</pre>
+</section>
+"""
+    return html_document(f"Scenario Curation: {view.scenario_name}", body)
+
+
+def _finding_view(finding: Any) -> FindingView:
+    return FindingView(
+        title=str(getattr(finding, "title", "")),
+        description=str(getattr(finding, "description", "")),
+        finding_type=str(getattr(finding, "finding_type", "")),
+        severity=str(getattr(finding, "severity", "")),
+        category=str(getattr(finding, "category", "")),
+        evidence_event_ids=tuple(str(eid) for eid in getattr(finding, "evidence_event_ids", [])),
+    )
+
+
+def _failure_motif_view(motif: Any) -> FailureMotifView:
+    return FailureMotifView(
+        pattern_name=str(getattr(motif, "pattern_name", "")),
+        occurrence_count=int(getattr(motif, "occurrence_count", 0) or 0),
+        evidence_event_ids=tuple(str(eid) for eid in getattr(motif, "evidence_event_ids", [])),
+        description=str(getattr(motif, "description", "")),
+    )
+
+
+def _recovery_path_view(path: Any) -> RecoveryPathView:
+    return RecoveryPathView(
+        failure_event_id=str(getattr(path, "failure_event_id", "")),
+        recovery_event_id=str(getattr(path, "recovery_event_id", "")),
+        path_event_ids=tuple(str(eid) for eid in getattr(path, "path_event_ids", [])),
+        description=str(getattr(path, "description", "")),
+    )
+
+
+def _metadata(obj: Any) -> dict[str, Any]:
+    metadata = getattr(obj, "metadata", {})
+    return dict(metadata) if isinstance(metadata, dict) else {}
+
+
+def _h(value: object) -> str:
+    return escape(str(value), quote=True)
+
+
+def _safe_id(raw: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_-]+", "-", raw).strip("-")
+    return safe or "item"
+
+
+def _render_findings_html(findings: tuple[FindingView, ...], *, empty: str) -> str:
+    if not findings:
+        return f'<p class="empty">{_h(empty)}</p>'
+    return "\n".join(
+        f"""
+<article class="finding">
+  <h3>{_h(finding.title)}</h3>
+  <p>
+    <span class="badge">{_h(finding.finding_type)}</span>
+    <span class="badge severity-{_h(finding.severity)}">{_h(finding.severity)}</span>
+    <span class="badge">{_h(finding.category)}</span>
+  </p>
+  <p>{_h(finding.description)}</p>
+  {_render_evidence_html(finding.evidence_event_ids)}
+</article>
+"""
+        for finding in findings
+    )
+
+
+def _render_evidence_html(evidence_ids: tuple[str, ...]) -> str:
+    if not evidence_ids:
+        return '<p class="muted">Evidence: none</p>'
+    items = "".join(f'<li id="evidence-{_safe_id(eid)}"><code>{_h(eid)}</code></li>' for eid in evidence_ids)
+    return f'<p class="muted">Evidence</p><ul>{items}</ul>'
+
+
+def _render_motifs_html(motifs: tuple[FailureMotifView, ...]) -> str:
+    if not motifs:
+        return '<p class="empty">No recurring failure motifs.</p>'
+    return "\n".join(
+        f"""
+<article class="finding">
+  <h3>{_h(motif.pattern_name)}</h3>
+  <p>{motif.occurrence_count} occurrence(s)</p>
+  {_render_evidence_html(motif.evidence_event_ids)}
+</article>
+"""
+        for motif in motifs
+    )
+
+
+def _render_recovery_paths_html(paths: tuple[RecoveryPathView, ...]) -> str:
+    if not paths:
+        return '<p class="empty">No recovery paths observed.</p>'
+    return "\n".join(
+        f"""
+<article class="finding">
+  <h3><code>{_h(path.failure_event_id)}</code> -> <code>{_h(path.recovery_event_id)}</code></h3>
+  <p>{len(path.path_event_ids)} events</p>
+  {_render_path_list((path.path_event_ids,), "No path events.")}
+</article>
+"""
+        for path in paths
+    )
+
+
+def _render_list_html(items: tuple[str, ...], *, empty: str) -> str:
+    if not items:
+        return f'<p class="empty">{_h(empty)}</p>'
+    return "<ul>" + "".join(f"<li>{_h(item)}</li>" for item in items) + "</ul>"
+
+
+def _render_timeline_event_html(event: TimelineEventView) -> str:
+    artifact_links = _render_artifact_links(event.artifact_links)
+    evidence = _render_evidence_html(event.evidence_ids)
+    generation = "" if event.generation_index is None else str(event.generation_index)
+    return f"""
+<article class="event" data-category="{_h(event.category)}" data-stage="{_h(event.stage)}"
+    data-severity="{_h(event.severity)}" data-generation="{_h(generation)}">
+  <h3>#{event.sequence_number} {_h(event.event_type)}</h3>
+  <p>
+    <span class="badge">{_h(event.stage)}</span>
+    <span class="badge">{_h(event.category)}</span>
+    <span class="badge severity-{_h(event.severity)}">{_h(event.severity)}</span>
+    <span class="badge">{_h(event.actor_id)}</span>
+  </p>
+  <p>{_h(event.summary)}</p>
+  <p class="muted">Event <code>{_h(event.event_id)}</code> | Outcome {_h(event.outcome or "unknown")}</p>
+  {artifact_links}
+  {evidence}
+</article>
+"""
+
+
+def _render_artifact_links(links: tuple[str, ...]) -> str:
+    if not links:
+        return ""
+    items = "".join(f"<li><code>{_h(link)}</code></li>" for link in links)
+    return f'<p class="muted">Artifacts</p><ul>{items}</ul>'
+
+
+def _render_path_list(paths: tuple[tuple[str, ...], ...], empty: str) -> str:
+    if not paths:
+        return f'<p class="empty">{_h(empty)}</p>'
+    return "<ul>" + "".join(
+        "<li>" + " -> ".join(f"<code>{_h(event_id)}</code>" for event_id in path) + "</li>"
+        for path in paths
+    ) + "</ul>"
+
+
+def _render_curation_section(title: str, items: list[CurationItemView]) -> str:
+    if not items:
+        content = '<p class="empty">No items.</p>'
+    else:
+        content = "\n".join(
+            f"""
+<article class="curation-item">
+  <h3>{_h(item.title)}</h3>
+  <p>{_h(item.body)}</p>
+  <p class="muted">{_h(item.source)}</p>
+</article>
+"""
+            for item in items
+        )
+    return f"""
+<section>
+  <h2>{_h(title)}</h2>
+  {content}
+</section>
+"""
+
+
+def _curation_export_markdown(view: ScenarioCurationView) -> str:
+    sections = [
+        ("Active Lessons", view.active_lessons),
+        ("Stale Lessons", view.stale_lessons),
+        ("Superseded Lessons", view.superseded_lessons),
+        ("Hints", view.hints),
+        ("Dead Ends", view.dead_ends),
+        ("Weakness Findings", view.weakness_findings),
+        ("Progress Reports", view.progress_reports),
+    ]
+    lines = [f"# Scenario Curation: {view.scenario_name}", "", "Read-only derived artifact.", ""]
+    for title, items in sections:
+        lines.append(f"## {title}")
+        if not items:
+            lines.append("No items.")
+        else:
+            for item in items:
+                source = f" [{item.source}]" if item.source else ""
+                lines.append(f"- **{item.title}**{source}: {item.body}")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+def _markdown_items(title: str, content: str, source: str) -> list[CurationItemView]:
+    rendered = content.strip()
+    if not rendered:
+        return []
+    return [CurationItemView(title=title, body=rendered, source=source)]
+
+
+def _weakness_items(reports: list[object]) -> list[CurationItemView]:
+    items: list[CurationItemView] = []
+    for report in reports:
+        run_id = str(getattr(report, "run_id", "unknown"))
+        weaknesses = getattr(report, "weaknesses", None)
+        if isinstance(weaknesses, list):
+            for weakness in weaknesses:
+                items.append(
+                    CurationItemView(
+                        title=str(getattr(weakness, "title", "Weakness")),
+                        body=str(getattr(weakness, "description", "")),
+                        source=run_id,
+                    )
+                )
+            continue
+        to_markdown = getattr(report, "to_markdown", None)
+        if callable(to_markdown):
+            items.append(CurationItemView(title=f"Weakness report {run_id}", body=str(to_markdown()), source=run_id))
+    return items
+
+
+def _markdown_report_items(title: str, reports: list[object]) -> list[CurationItemView]:
+    items: list[CurationItemView] = []
+    for report in reports:
+        run_id = str(getattr(report, "run_id", "unknown"))
+        to_markdown = getattr(report, "to_markdown", None)
+        if callable(to_markdown):
+            items.append(CurationItemView(title=f"{title} {run_id}", body=str(to_markdown()), source=run_id))
+    return items

--- a/autocontext/src/autocontext/analytics/html_artifact_shell.py
+++ b/autocontext/src/autocontext/analytics/html_artifact_shell.py
@@ -1,0 +1,183 @@
+"""Shared HTML document shell for derived analytics artifacts."""
+
+from __future__ import annotations
+
+from html import escape
+
+
+def html_document(title: str, body: str, *, script: str = "") -> str:
+    script_block = f"<script>{script}</script>" if script else ""
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{_h(title)}</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      --bg: #f8fafc;
+      --panel: #ffffff;
+      --text: #172033;
+      --muted: #64748b;
+      --border: #d8e0ea;
+      --accent: #2563eb;
+      --danger: #b42318;
+      --warn: #9a6700;
+      --ok: #047857;
+    }}
+    body {{
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 15px;
+      line-height: 1.5;
+    }}
+    main {{
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 32px 20px 48px;
+    }}
+    header, section {{
+      margin-bottom: 18px;
+    }}
+    section {{
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 18px;
+    }}
+    h1, h2, h3, p {{
+      margin-top: 0;
+    }}
+    h1 {{
+      font-size: 28px;
+      line-height: 1.2;
+      margin-bottom: 8px;
+    }}
+    h2 {{
+      font-size: 17px;
+      margin-bottom: 10px;
+    }}
+    h3 {{
+      font-size: 15px;
+      margin-bottom: 4px;
+    }}
+    ul {{
+      padding-left: 20px;
+    }}
+    pre {{
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      background: #f1f5f9;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 12px;
+    }}
+    .eyebrow {{
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0;
+      margin-bottom: 4px;
+      text-transform: uppercase;
+    }}
+    .muted, .empty {{
+      color: var(--muted);
+    }}
+    .finding, .event, .curation-item {{
+      border-top: 1px solid var(--border);
+      padding-top: 12px;
+      margin-top: 12px;
+    }}
+    .finding:first-child, .event:first-child, .curation-item:first-child {{
+      border-top: 0;
+      padding-top: 0;
+      margin-top: 0;
+    }}
+    .badge {{
+      display: inline-block;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      color: var(--muted);
+      font-size: 12px;
+      padding: 1px 8px;
+      margin-right: 4px;
+    }}
+    .severity-high, .severity-critical, .severity-error {{
+      color: var(--danger);
+    }}
+    .severity-medium, .severity-warning {{
+      color: var(--warn);
+    }}
+    .severity-low, .severity-info {{
+      color: var(--ok);
+    }}
+    .metric-row {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 10px;
+    }}
+    .metric-row div {{
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 14px;
+    }}
+    .metric-row strong {{
+      display: block;
+      font-size: 24px;
+    }}
+    .metric-row span {{
+      color: var(--muted);
+    }}
+    .filters {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 10px;
+    }}
+    input {{
+      box-sizing: border-box;
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 8px;
+      margin-top: 4px;
+    }}
+    .grid-two {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 16px;
+    }}
+  </style>
+</head>
+<body>
+  <main>
+{body}
+  </main>
+  {script_block}
+</body>
+</html>
+"""
+
+
+TIMELINE_FILTER_SCRIPT = """
+const inputs = Array.from(document.querySelectorAll("[data-filter]"));
+const events = Array.from(document.querySelectorAll(".event"));
+function applyFilters() {
+  const filters = Object.fromEntries(inputs.map((input) => [input.dataset.filter, input.value.trim().toLowerCase()]));
+  for (const event of events) {
+    const visible = Object.entries(filters).every(([key, value]) => {
+      if (!value) return true;
+      return (event.dataset[key] || "").toLowerCase().includes(value);
+    });
+    event.hidden = !visible;
+  }
+}
+inputs.forEach((input) => input.addEventListener("input", applyFilters));
+"""
+
+
+def _h(value: object) -> str:
+    return escape(str(value), quote=True)

--- a/autocontext/src/autocontext/analytics/trace_reporter.py
+++ b/autocontext/src/autocontext/analytics/trace_reporter.py
@@ -105,51 +105,14 @@ class TraceWriteup(BaseModel):
         return cls.model_validate(data)
 
     def to_markdown(self) -> str:
-        scenario = str(self.metadata.get("scenario", ""))
-        family = str(self.metadata.get("scenario_family", ""))
-        lines = [f"# Run Summary: {self.run_id}", ""]
-        if scenario or family:
-            context = " | ".join(part for part in [scenario, family] if part)
-            lines.append(f"**Context:** {context}")
-            lines.append("")
+        from autocontext.analytics.artifact_rendering import render_trace_writeup_markdown, trace_writeup_view
 
-        lines.append("## Trace Summary")
-        lines.append(self.summary)
-        lines.append("")
+        return render_trace_writeup_markdown(trace_writeup_view(self))
 
-        lines.append("## Findings")
-        if self.findings:
-            for finding in self.findings:
-                evidence = ", ".join(finding.evidence_event_ids) or "none"
-                lines.append(
-                    f"- **{finding.title}** [{finding.finding_type}/{finding.severity}] "
-                    f"{finding.description} (evidence: {evidence})"
-                )
-        else:
-            lines.append("No notable findings.")
-        lines.append("")
+    def to_html(self) -> str:
+        from autocontext.analytics.artifact_rendering import render_trace_writeup_html, trace_writeup_view
 
-        lines.append("## Failure Motifs")
-        if self.failure_motifs:
-            for motif in self.failure_motifs:
-                lines.append(
-                    f"- **{motif.pattern_name}**: {motif.occurrence_count} occurrence(s)"
-                )
-        else:
-            lines.append("No recurring failure motifs.")
-        lines.append("")
-
-        lines.append("## Recovery Paths")
-        if self.recovery_paths:
-            for recovery in self.recovery_paths:
-                lines.append(
-                    f"- {recovery.failure_event_id} -> {recovery.recovery_event_id} "
-                    f"({len(recovery.path_event_ids)} events)"
-                )
-        else:
-            lines.append("No recovery paths observed.")
-
-        return "\n".join(lines)
+        return render_trace_writeup_html(trace_writeup_view(self))
 
 
 class WeaknessReport(BaseModel):
@@ -172,35 +135,14 @@ class WeaknessReport(BaseModel):
         return cls.model_validate(data)
 
     def to_markdown(self) -> str:
-        scenario = str(self.metadata.get("scenario", ""))
-        lines = [
-            f"# Weakness Report: {self.run_id}",
-            f"**Scenario:** {scenario or 'unknown'}",
-            "",
-        ]
-        if not self.weaknesses:
-            lines.append("No weaknesses identified.")
-        else:
-            lines.append(f"**Summary:** {len(self.weaknesses)} weakness(es) detected")
-            lines.append("")
-            for weakness in self.weaknesses:
-                evidence = ", ".join(weakness.evidence_event_ids) or "none"
-                lines.append(f"## [{weakness.severity.upper()}] {weakness.title}")
-                lines.append(weakness.description)
-                lines.append(f"- Category: {weakness.category}")
-                lines.append(f"- Evidence events: {evidence}")
-                lines.append("")
+        from autocontext.analytics.artifact_rendering import render_weakness_report_markdown, weakness_report_view
 
-        lines.append("## Recovery Analysis")
-        lines.append(self.recovery_analysis or "No recovery analysis available.")
-        lines.append("")
-        lines.append("## Recommendations")
-        if self.recommendations:
-            for recommendation in self.recommendations:
-                lines.append(f"- {recommendation}")
-        else:
-            lines.append("- No immediate recommendations.")
-        return "\n".join(lines)
+        return render_weakness_report_markdown(weakness_report_view(self))
+
+    def to_html(self) -> str:
+        from autocontext.analytics.artifact_rendering import render_weakness_report_html, weakness_report_view
+
+        return render_weakness_report_html(weakness_report_view(self))
 
 
 def _uid() -> str:

--- a/autocontext/src/autocontext/loop/trace_artifacts.py
+++ b/autocontext/src/autocontext/loop/trace_artifacts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from autocontext.analytics.artifact_rendering import render_timeline_inspection_html, timeline_inspection_view
 from autocontext.analytics.run_trace import RunTrace
 from autocontext.analytics.timeline_inspector import StateInspector, TimelineBuilder
 
@@ -40,5 +41,9 @@ def persist_run_inspection(trace: RunTrace, analytics_root: Path, trace_path: Pa
     }
     (inspection_dir / f"{trace.trace_id}.json").write_text(
         json.dumps(payload, indent=2),
+        encoding="utf-8",
+    )
+    (inspection_dir / f"{trace.trace_id}.html").write_text(
+        render_timeline_inspection_html(timeline_inspection_view(trace)),
         encoding="utf-8",
     )

--- a/autocontext/src/autocontext/server/cockpit_api.py
+++ b/autocontext/src/autocontext/server/cockpit_api.py
@@ -33,6 +33,7 @@ from autocontext.session.runtime_session_timeline import (
     read_runtime_session_timeline_by_run_id,
 )
 from autocontext.storage import ArtifactStore, SQLiteStore, artifact_store_from_settings
+from autocontext.storage.scenario_paths import normalize_scenario_name_segment
 
 logger = logging.getLogger(__name__)
 
@@ -562,9 +563,10 @@ def writeup(run_id: str, request: Request) -> dict[str, Any]:
 @cockpit_router.get("/scenarios/{scenario_name}/curation")
 def scenario_curation(scenario_name: str, request: Request) -> dict[str, Any]:
     """Render and persist a read-only scenario curation HTML artifact."""
-    clean_scenario = scenario_name.strip()
-    if not clean_scenario:
-        raise HTTPException(status_code=422, detail="scenario_name is required")
+    try:
+        clean_scenario = normalize_scenario_name_segment(scenario_name)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     artifacts = _get_artifacts(request)
     view = scenario_curation_view_from_artifacts(artifacts, clean_scenario)

--- a/autocontext/src/autocontext/server/cockpit_api.py
+++ b/autocontext/src/autocontext/server/cockpit_api.py
@@ -17,7 +17,7 @@ from autocontext.providers.base import LLMProvider
 from autocontext.providers.registry import create_provider
 from autocontext.providers.retry import RetryProvider
 from autocontext.server.changelog import build_changelog
-from autocontext.server.writeup import generate_writeup
+from autocontext.server.writeup import generate_writeup, generate_writeup_html
 from autocontext.session.runtime_events import RuntimeSessionEventStore
 from autocontext.session.runtime_session_ids import runtime_session_id_for_run
 from autocontext.session.runtime_session_read_model import (
@@ -546,11 +546,13 @@ def writeup(run_id: str, request: Request) -> dict[str, Any]:
 
     run_dict = dict(run_row)
     md = generate_writeup(run_id, store, artifacts)
+    html = generate_writeup_html(run_id, store, artifacts)
 
     return {
         "run_id": run_id,
         "scenario_name": run_dict["scenario"],
         "writeup_markdown": md,
+        "writeup_html": html,
     }
 
 

--- a/autocontext/src/autocontext/server/cockpit_api.py
+++ b/autocontext/src/autocontext/server/cockpit_api.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from autocontext.analytics.artifact_rendering import render_scenario_curation_html, scenario_curation_view_from_artifacts
 from autocontext.consultation.runner import ConsultationRunner
 from autocontext.consultation.types import ConsultationRequest as ConsReq
 from autocontext.consultation.types import ConsultationTrigger
@@ -547,12 +548,33 @@ def writeup(run_id: str, request: Request) -> dict[str, Any]:
     run_dict = dict(run_row)
     md = generate_writeup(run_id, store, artifacts)
     html = generate_writeup_html(run_id, store, artifacts)
+    html_path = artifacts.write_run_writeup_html(run_dict["scenario"], run_id, html)
 
     return {
         "run_id": run_id,
         "scenario_name": run_dict["scenario"],
         "writeup_markdown": md,
         "writeup_html": html,
+        "writeup_html_path": str(html_path),
+    }
+
+
+@cockpit_router.get("/scenarios/{scenario_name}/curation")
+def scenario_curation(scenario_name: str, request: Request) -> dict[str, Any]:
+    """Render and persist a read-only scenario curation HTML artifact."""
+    clean_scenario = scenario_name.strip()
+    if not clean_scenario:
+        raise HTTPException(status_code=422, detail="scenario_name is required")
+
+    artifacts = _get_artifacts(request)
+    view = scenario_curation_view_from_artifacts(artifacts, clean_scenario)
+    html = render_scenario_curation_html(view)
+    html_path = artifacts.write_scenario_curation_html(clean_scenario, html)
+
+    return {
+        "scenario_name": clean_scenario,
+        "curation_html": html,
+        "curation_html_path": str(html_path),
     }
 
 

--- a/autocontext/src/autocontext/server/writeup.py
+++ b/autocontext/src/autocontext/server/writeup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from autocontext.analytics.artifact_rendering import render_markdown_document_html
 from autocontext.analytics.run_trace import TraceStore
 from autocontext.analytics.trace_reporter import ReportStore, TraceReporter
 from autocontext.storage.artifacts import ArtifactStore
@@ -27,6 +28,28 @@ def generate_writeup(
         return writeup.to_markdown()
 
     return _generate_legacy_writeup(run_id, sqlite, artifacts)
+
+
+def generate_writeup_html(
+    run_id: str,
+    sqlite: SQLiteStore,
+    artifacts: ArtifactStore,
+) -> str:
+    """Assemble an HTML writeup from the same structured source as Markdown."""
+    analytics_root = artifacts.knowledge_root / "analytics"
+    report_store = ReportStore(analytics_root)
+    persisted = report_store.latest_writeup_for_run(run_id)
+    if persisted is not None:
+        return persisted.to_html()
+
+    trace = TraceStore(analytics_root).load(f"trace-{run_id}")
+    if trace is not None:
+        writeup = TraceReporter().generate_writeup(trace)
+        report_store.persist_writeup(writeup)
+        return writeup.to_html()
+
+    markdown = _generate_legacy_writeup(run_id, sqlite, artifacts)
+    return render_markdown_document_html(f"Run Summary: {run_id}", markdown)
 
 
 def _generate_legacy_writeup(

--- a/autocontext/src/autocontext/storage/artifact_write_methods.py
+++ b/autocontext/src/autocontext/storage/artifact_write_methods.py
@@ -20,6 +20,7 @@ class _ArtifactWriteHost(Protocol):
     def _mirror_bytes(self, path: Path, data: bytes) -> None: ...
     def write_json(self, path: Path, payload: dict[str, Any]) -> None: ...
     def write_markdown(self, path: Path, content: str) -> None: ...
+    def write_html(self, path: Path, content: str) -> None: ...
     def append_markdown(self, path: Path, content: str, heading: str) -> None: ...
 
 
@@ -46,6 +47,16 @@ class ArtifactWriteMethods:
         content = hook_content or ""
         path.parent.mkdir(parents=True, exist_ok=True)
         rendered = content.strip() + "\n"
+        path.write_text(rendered, encoding="utf-8")
+        self._mirror_bytes(path, rendered.encode("utf-8"))
+
+    def write_html(self: _ArtifactWriteHost, path: Path, content: str) -> None:
+        path, hook_content, _, _ = emit_artifact_write(
+            self._hook_bus, path=path, format="html", content=content, managed_roots=_managed_roots(self)
+        )
+        content = hook_content if hook_content is not None else ""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        rendered = content.rstrip() + "\n"
         path.write_text(rendered, encoding="utf-8")
         self._mirror_bytes(path, rendered.encode("utf-8"))
 

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -1013,6 +1013,18 @@ class ArtifactStore(ArtifactWriteMethods):
         path.write_text(content, encoding="utf-8")
         return path
 
+    def write_run_writeup_html(self, scenario_name: str, run_id: str, content: str) -> Path:
+        """Write a derived HTML run writeup for operator review."""
+        path = self.knowledge_root / scenario_name / "reports" / f"{run_id}.html"
+        self.write_html(path, content)
+        return path
+
+    def write_scenario_curation_html(self, scenario_name: str, content: str) -> Path:
+        """Write a read-only derived scenario curation artifact."""
+        path = self.knowledge_root / scenario_name / "curation.html"
+        self.write_html(path, content)
+        return path
+
     # --- Normalized progress reports (AC-190) ---------------------------------
 
     def _progress_report_dir(self, scenario_name: str) -> Path:

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -29,6 +29,7 @@ from autocontext.storage.artifact_write_methods import ArtifactWriteMethods
 from autocontext.storage.blob_integration import BlobAwareWriter, mirror_path_append_bytes, mirror_path_bytes
 from autocontext.storage.buffered_writer import BufferedWriter
 from autocontext.storage.compaction_ledger import CompactionLedgerStore
+from autocontext.storage.scenario_paths import resolve_scenario_root
 from autocontext.util.json_io import read_json, write_json
 
 logger = logging.getLogger(__name__)
@@ -1015,13 +1016,13 @@ class ArtifactStore(ArtifactWriteMethods):
 
     def write_run_writeup_html(self, scenario_name: str, run_id: str, content: str) -> Path:
         """Write a derived HTML run writeup for operator review."""
-        path = self.knowledge_root / scenario_name / "reports" / f"{run_id}.html"
+        path = resolve_scenario_root(self.knowledge_root, scenario_name) / "reports" / f"{run_id}.html"
         self.write_html(path, content)
         return path
 
     def write_scenario_curation_html(self, scenario_name: str, content: str) -> Path:
         """Write a read-only derived scenario curation artifact."""
-        path = self.knowledge_root / scenario_name / "curation.html"
+        path = resolve_scenario_root(self.knowledge_root, scenario_name) / "curation.html"
         self.write_html(path, content)
         return path
 

--- a/autocontext/src/autocontext/storage/scenario_paths.py
+++ b/autocontext/src/autocontext/storage/scenario_paths.py
@@ -1,0 +1,34 @@
+"""Helpers for resolving per-scenario filesystem paths."""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+
+def normalize_scenario_name_segment(scenario_name: str) -> str:
+    """Return a stripped single path segment or raise for unsafe names."""
+    normalized = scenario_name.strip()
+    if not normalized:
+        raise ValueError("scenario_name is required")
+    if "/" in normalized or "\\" in normalized:
+        raise ValueError(f"scenario_name must be a single path segment: {scenario_name!r}")
+
+    for path_cls in (PurePosixPath, PureWindowsPath):
+        candidate = path_cls(normalized)
+        if candidate.is_absolute() or len(candidate.parts) != 1 or candidate.parts[0] in {".", ".."}:
+            raise ValueError(f"scenario_name must be a single path segment: {scenario_name!r}")
+    return normalized
+
+
+def resolve_scenario_root(knowledge_root: Path, scenario_name: str) -> Path:
+    """Resolve a scenario directory and ensure it stays under knowledge_root."""
+    normalized = normalize_scenario_name_segment(scenario_name)
+    root = knowledge_root.resolve(strict=False)
+    candidate = (knowledge_root / normalized).resolve(strict=False)
+    if candidate == root:
+        raise ValueError(f"scenario_name must name a scenario subdirectory: {scenario_name!r}")
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"scenario_name escapes knowledge root: {scenario_name!r}") from exc
+    return candidate

--- a/autocontext/tests/test_artifact_rendering.py
+++ b/autocontext/tests/test_artifact_rendering.py
@@ -1,0 +1,231 @@
+"""Tests for shared human-facing artifact rendering."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _finding(title: str = "Validation <failed>") -> Any:
+    from autocontext.analytics.trace_reporter import TraceFinding
+
+    return TraceFinding(
+        finding_id="finding-1",
+        finding_type="weakness",
+        title=title,
+        description="The strategy emitted <bad> output.",
+        evidence_event_ids=["e-1", "e-2"],
+        severity="high",
+        category="failure_motif",
+    )
+
+
+def test_trace_writeup_markdown_is_rendered_from_shared_view_model() -> None:
+    from autocontext.analytics.artifact_rendering import (
+        render_trace_writeup_markdown,
+        trace_writeup_view,
+    )
+    from autocontext.analytics.trace_reporter import FailureMotif, RecoveryPath, TraceWriteup
+
+    writeup = TraceWriteup(
+        writeup_id="writeup-1",
+        run_id="run-1",
+        generation_index=None,
+        findings=[_finding()],
+        failure_motifs=[
+            FailureMotif(
+                motif_id="motif-1",
+                pattern_name="validation_failure",
+                occurrence_count=2,
+                evidence_event_ids=["e-1", "e-2"],
+                description="Repeated validation failures.",
+            ),
+        ],
+        recovery_paths=[
+            RecoveryPath(
+                recovery_id="recovery-1",
+                failure_event_id="e-1",
+                recovery_event_id="e-3",
+                path_event_ids=["e-1", "e-2", "e-3"],
+                description="Retry recovered the run.",
+            ),
+        ],
+        summary="Trace-grounded summary.",
+        created_at="2026-05-11T12:00:00Z",
+        metadata={"scenario": "billing_bot", "scenario_family": "agent_task"},
+    )
+
+    view = trace_writeup_view(writeup)
+
+    assert view.run_id == "run-1"
+    assert view.context == "billing_bot | agent_task"
+    assert render_trace_writeup_markdown(view) == writeup.to_markdown()
+
+
+def test_trace_writeup_html_escapes_model_content_and_links_evidence() -> None:
+    from autocontext.analytics.trace_reporter import TraceWriteup
+
+    writeup = TraceWriteup(
+        writeup_id="writeup-1",
+        run_id="run-<1>",
+        generation_index=None,
+        findings=[_finding("Dangerous <script> title")],
+        failure_motifs=[],
+        recovery_paths=[],
+        summary="Summary with <script>alert(1)</script>",
+        created_at="2026-05-11T12:00:00Z",
+        metadata={"scenario": "billing_bot"},
+    )
+
+    html = writeup.to_html()
+
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+    assert 'id="evidence-e-1"' in html
+    assert "Dangerous &lt;script&gt; title" in html
+
+
+def test_weakness_report_html_uses_same_domain_view() -> None:
+    from autocontext.analytics.artifact_rendering import (
+        render_weakness_report_html,
+        weakness_report_view,
+    )
+    from autocontext.analytics.trace_reporter import WeaknessReport
+
+    report = WeaknessReport(
+        report_id="weakness-1",
+        run_id="run-1",
+        weaknesses=[_finding()],
+        failure_motifs=[],
+        recovery_analysis="Recovered via retry.",
+        recommendations=["Add a validator", "Review <unsafe> summaries"],
+        created_at="2026-05-11T12:00:00Z",
+        metadata={"scenario": "billing_bot"},
+    )
+
+    view = weakness_report_view(report)
+    html = render_weakness_report_html(view)
+
+    assert "Weakness Report: run-1" in html
+    assert "Add a validator" in html
+    assert "Review &lt;unsafe&gt; summaries" in html
+    assert report.to_html() == html
+
+
+def _trace_for_timeline() -> Any:
+    from autocontext.analytics.run_trace import ActorRef, CausalEdge, ResourceRef, RunTrace, TraceEvent
+
+    actor = ActorRef(actor_type="role", actor_id="analyst", actor_name="Analyst")
+    resource = ResourceRef(
+        resource_type="artifact",
+        resource_id="analysis-1",
+        resource_name="analysis",
+        resource_path="knowledge/billing/analysis/gen_1.md",
+    )
+    events = [
+        TraceEvent(
+            event_id="e-1",
+            run_id="run-1",
+            generation_index=1,
+            sequence_number=1,
+            timestamp="2026-05-11T12:00:01Z",
+            category="failure",
+            event_type="validation_failure",
+            actor=actor,
+            resources=[resource],
+            summary="Validation failed <badly>",
+            detail={},
+            parent_event_id=None,
+            cause_event_ids=[],
+            evidence_ids=[],
+            severity="error",
+            stage="match",
+            outcome="failed",
+            duration_ms=10,
+        ),
+        TraceEvent(
+            event_id="e-2",
+            run_id="run-1",
+            generation_index=1,
+            sequence_number=2,
+            timestamp="2026-05-11T12:00:02Z",
+            category="recovery",
+            event_type="retry_recovered",
+            actor=actor,
+            resources=[resource],
+            summary="Retry recovered",
+            detail={},
+            parent_event_id=None,
+            cause_event_ids=["e-1"],
+            evidence_ids=["e-1"],
+            severity="info",
+            stage="match",
+            outcome="success",
+            duration_ms=12,
+        ),
+    ]
+    return RunTrace(
+        trace_id="trace-run-1",
+        run_id="run-1",
+        generation_index=None,
+        schema_version="1.0.0",
+        events=events,
+        causal_edges=[CausalEdge(source_event_id="e-1", target_event_id="e-2", relation="recovers")],
+        created_at="2026-05-11T12:00:00Z",
+        metadata={"scenario": "billing_bot"},
+    )
+
+
+def test_persist_run_inspection_writes_json_and_html(tmp_path: Path) -> None:
+    from autocontext.loop.trace_artifacts import persist_run_inspection
+
+    trace = _trace_for_timeline()
+    analytics_root = tmp_path / "analytics"
+    trace_path = analytics_root / "traces" / "trace-run-1.json"
+
+    persist_run_inspection(trace, analytics_root, trace_path)
+
+    json_path = analytics_root / "inspections" / "trace-run-1.json"
+    html_path = analytics_root / "inspections" / "trace-run-1.html"
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    html = html_path.read_text(encoding="utf-8")
+
+    assert payload["run_id"] == "run-1"
+    assert "Runtime Timeline: run-1" in html
+    assert "Validation failed &lt;badly&gt;" in html
+    assert "data-category=\"failure\"" in html
+
+
+def test_scenario_curation_html_is_read_only_and_exportable() -> None:
+    from autocontext.analytics.artifact_rendering import (
+        CurationItemView,
+        ScenarioCurationView,
+        render_scenario_curation_html,
+    )
+
+    view = ScenarioCurationView(
+        scenario_name="billing_bot",
+        active_lessons=[
+            CurationItemView(
+                title="lesson_1",
+                body="Always verify posted charges.",
+                source="lessons.json:generation=3",
+            ),
+        ],
+        stale_lessons=[],
+        superseded_lessons=[],
+        hints=[CurationItemView(title="Hints", body="Prefer concise escalation.", source="hints.md")],
+        dead_ends=[],
+        weakness_findings=[
+            CurationItemView(title="Validation Failure", body="Missing account state.", source="run-1"),
+        ],
+        progress_reports=[],
+    )
+
+    html = render_scenario_curation_html(view)
+
+    assert "Scenario Curation: billing_bot" in html
+    assert "Read-only derived artifact" in html
+    assert "Always verify posted charges." in html
+    assert "data-export-format=\"markdown\"" in html

--- a/autocontext/tests/test_cockpit.py
+++ b/autocontext/tests/test_cockpit.py
@@ -231,6 +231,24 @@ class TestWriteup:
         assert "Always verify posted charges before refunding." in payload["curation_html"]
         assert Path(payload["curation_html_path"]).read_text(encoding="utf-8") == payload["curation_html"]
 
+    def test_scenario_curation_endpoint_rejects_dot_segments(self, cockpit_env: dict[str, Any]) -> None:
+        client: TestClient = cockpit_env["client"]
+        tmp_path: Path = cockpit_env["tmp_path"]
+
+        response = client.get("/api/cockpit/scenarios/%2E%2E/curation")
+
+        assert response.status_code == 422
+        assert not (tmp_path / "curation.html").exists()
+
+    @pytest.mark.parametrize("scenario_name", [".", "..", "nested/name", r"nested\name"])
+    def test_scenario_curation_writer_rejects_path_escape(self, tmp_path: Path, scenario_name: str) -> None:
+        artifacts = _make_artifacts(tmp_path)
+
+        with pytest.raises(ValueError, match="single path segment"):
+            artifacts.write_scenario_curation_html(scenario_name, "<html></html>")
+
+        assert not (tmp_path / "curation.html").exists()
+
 
 # ---------------------------------------------------------------------------
 # Changelog builder

--- a/autocontext/tests/test_cockpit.py
+++ b/autocontext/tests/test_cockpit.py
@@ -13,7 +13,7 @@ from fastapi.testclient import TestClient
 from autocontext.config.settings import AppSettings
 from autocontext.server.changelog import build_changelog
 from autocontext.server.cockpit_api import cockpit_router
-from autocontext.server.writeup import generate_writeup
+from autocontext.server.writeup import generate_writeup, generate_writeup_html
 from autocontext.storage.artifacts import ArtifactStore
 from autocontext.storage.sqlite_store import SQLiteStore
 
@@ -155,6 +155,55 @@ class TestWriteup:
         result = generate_writeup("run1", store, artifacts)
         assert "Trace-grounded summary from canonical events." in result
         assert "# Run Summary: run1" in result
+
+    def test_generates_html_from_persisted_trace_grounded_writeup(self, tmp_path: Path) -> None:
+        from autocontext.analytics.trace_reporter import ReportStore, TraceFinding, TraceWriteup
+
+        store = _make_store(tmp_path)
+        artifacts = _make_artifacts(tmp_path)
+        _seed_run(store)
+
+        report_store = ReportStore(tmp_path / "knowledge" / "analytics")
+        report_store.persist_writeup(TraceWriteup(
+            writeup_id="trace-writeup-1",
+            run_id="run1",
+            generation_index=None,
+            findings=[
+                TraceFinding(
+                    finding_id="finding-1",
+                    finding_type="weakness",
+                    title="Escaped <finding>",
+                    description="Needs review.",
+                    evidence_event_ids=["event-1"],
+                    severity="medium",
+                    category="failure_motif",
+                ),
+            ],
+            failure_motifs=[],
+            recovery_paths=[],
+            summary="Trace-grounded <summary>.",
+            created_at="2026-03-15T12:00:00Z",
+            metadata={"scenario": "grid_ctf"},
+        ))
+
+        html = generate_writeup_html("run1", store, artifacts)
+
+        assert "Run Summary: run1" in html
+        assert "Trace-grounded &lt;summary&gt;." in html
+        assert "Escaped &lt;finding&gt;" in html
+
+    def test_cockpit_writeup_endpoint_returns_html_additively(self, cockpit_env: dict[str, Any]) -> None:
+        client: TestClient = cockpit_env["client"]
+        store: SQLiteStore = cockpit_env["store"]
+        _seed_run(store)
+
+        response = client.get("/api/cockpit/writeup/run1")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert "writeup_markdown" in payload
+        assert "writeup_html" in payload
+        assert "Run Summary: run1" in payload["writeup_html"]
 
 
 # ---------------------------------------------------------------------------

--- a/autocontext/tests/test_cockpit.py
+++ b/autocontext/tests/test_cockpit.py
@@ -203,7 +203,33 @@ class TestWriteup:
         payload = response.json()
         assert "writeup_markdown" in payload
         assert "writeup_html" in payload
+        assert payload["writeup_html_path"].endswith("knowledge/grid_ctf/reports/run1.html")
         assert "Run Summary: run1" in payload["writeup_html"]
+        assert Path(payload["writeup_html_path"]).read_text(encoding="utf-8") == payload["writeup_html"]
+
+    def test_scenario_curation_endpoint_persists_read_only_html(self, cockpit_env: dict[str, Any]) -> None:
+        from autocontext.knowledge.lessons import ApplicabilityMeta
+
+        client: TestClient = cockpit_env["client"]
+        artifacts: ArtifactStore = cockpit_env["artifacts"]
+
+        artifacts.lesson_store.add_lesson(
+            "grid_ctf",
+            "Always verify posted charges before refunding.",
+            ApplicabilityMeta(created_at="2026-05-11T12:00:00Z", generation=3, best_score=0.72),
+        )
+        artifacts.write_hints("grid_ctf", "Prefer concise escalation.")
+        artifacts.append_dead_end("grid_ctf", "Do not retry invalid account states.")
+
+        response = client.get("/api/cockpit/scenarios/grid_ctf/curation")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["scenario_name"] == "grid_ctf"
+        assert payload["curation_html_path"].endswith("knowledge/grid_ctf/curation.html")
+        assert "Read-only derived artifact" in payload["curation_html"]
+        assert "Always verify posted charges before refunding." in payload["curation_html"]
+        assert Path(payload["curation_html_path"]).read_text(encoding="utf-8") == payload["curation_html"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add shared view-model based renderers for trace writeups, weakness reports, timeline inspections, and scenario curation HTML
- expose additive cockpit writeup HTML and persist it under scenario reports
- emit derived timeline inspection HTML beside existing inspection JSON
- add a read-only cockpit scenario curation endpoint that persists curation.html

## Design Notes

- JSON/structured reports remain canonical; HTML is derived presentation only
- Markdown and HTML render from the same renderer view models to avoid divergent string assembly
- artifact persistence stays behind ArtifactStore, including the new HTML write path

## Linear

Covers the foundation of AC-746 and advances AC-747, AC-748, and AC-749.

## Tests

- uv run pytest — 6224 passed, 42 skipped
- uv run ruff check src tests/test_artifact_rendering.py tests/test_cockpit.py
- uv run mypy src