### PR TITLE
feat(improve): emit revision_done events with per-round output content (AC-753)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- AC-752: `autoctx improve --ndjson` streams per-round events as newline-delimited JSON to stdout for visibility into long-running loops. Event kinds: `round_start`, `judge_done`, `verifier_done` (only when `--verify-cmd` is set), `round_summary`, and a final summary line. Under `--ndjson` the Rich human-readable summary is suppressed so stdout is pure JSON. `--json` and `--ndjson` are mutually exclusive output modes and are rejected up front when both are passed.
+- AC-753: the ndjson stream now also emits a `revision_done(round=N, output=<content>)` event right after `round_start` for every round, carrying the exact output the loop is about to evaluate. For round 1 the payload is the seed; for round N>1 it is the result of `task.revise_output()` from round N-1. Lets consumers salvage near-miss verifier-vetoed rounds. Pass `--no-ndjson-include-output` (default `--ndjson-include-output`) to suppress these events when the bulk output is unwanted; that flag drops the `revision_done` event entirely and never writes the output payload anywhere on stdout.
+- AC-751: `autoctx improve --claude-max-total-seconds FLOAT` exposes `settings.claude_max_total_seconds` (the wall-clock ceiling on total claude-cli runtime in a single run; env: `AUTOCONTEXT_CLAUDE_MAX_TOTAL_SECONDS`). Only applied when the effectively-resolved judge provider is claude-cli; `judge_provider='auto'` paths that inherit `agent_provider='claude-cli'` are honored. `--timeout` help on `improve` now explicitly names the per-provider setting it writes (`claude_timeout`/`codex_timeout`/`pi_timeout`).
 - Python and TypeScript now expose `autoctx worker` to run the existing task queue `TaskRunner` as a daemon or one-shot batch worker, with persistent-host deployment docs for `serve + worker`.
 - Added narrow Python/TypeScript task queue store contracts so future hosted storage adapters can provide Postgres-backed claim/complete/fail/enqueue semantics without changing `TaskRunner`.
 - Gondolin is documented as a reserved optional microVM sandbox backend, fails closed until a real adapter is configured, and now has public request/policy/backend contracts for out-of-tree adapters.
@@ -20,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- AC-750: `ImprovementLoop` no longer fires a misleading `max_score_delta` warning when the previous round was zeroed by the external `--verify-cmd` verifier. The loop now tracks `last_unvetoed_score` separately from `prev_valid_score`; the delta check compares against the last legitimate judge score, while plateau detection still treats consecutive verifier vetoes as a stall.
 - Runtime-session event stores now preserve existing events when saving stale or partial logs, and the TypeScript timeline pairs repeated child-task completions by child session id before falling back to task aliases.
 - Worker commands now clamp concurrency to one for stateful persistent runtimes, and Python runtime-bridge providers close underlying runtimes on shutdown.
 - TypeScript task runners now await queue-store methods so hosted Postgres adapters can implement the queue contract asynchronously.

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -926,6 +926,34 @@ print(f"Best score: {result.best_score}")
 package = ac.export_package("grid_ctf")
 ```
 
+## `autoctx improve --ndjson` event stream
+
+`autoctx improve` supports two stdout output modes:
+
+- `--json` (default off): a single JSON object written once at the end with `best_score`, `best_round`, `total_rounds`, `met_threshold`, and `best_output`.
+- `--ndjson` (default off): newline-delimited JSON, one event per line, streamed as the loop progresses. Useful for long-running compile-gated loops where `--json` would buffer everything until the final blob lands.
+
+The two modes are mutually exclusive; passing both exits non-zero.
+
+Under `--ndjson`, the per-round event sequence (with a configured `--verify-cmd`) is:
+
+```
+round_start  -> revision_done -> judge_done -> verifier_done -> round_summary
+```
+
+repeated per round, followed by a single `final` event. Without a verifier the `verifier_done` event is omitted. Field semantics:
+
+- `round_start` carries `round`.
+- `revision_done` carries `round` and `output` (the exact content the round is about to evaluate; for round 1 this is the seed, for round N>1 it is the result of `task.revise_output()` from round N-1). Lets consumers salvage near-miss verifier-vetoed rounds.
+- `judge_done` carries `round` and `score` (the judge's evaluation before any post-processing or veto).
+- `verifier_done` carries `round`, `verifier_ok`, and `verifier_exit_code`.
+- `round_summary` carries `round` and `effective_score` (post-veto, after fact-check penalty).
+- `final` carries `best_score`, `best_round`, `total_rounds`, and `met_threshold`.
+
+Provider errors during a streaming run emit a single `{"event":"error","message":"..."}` line on stdout so the stream stays parseable.
+
+For lean streams pass `--no-ndjson-include-output`: this drops `revision_done` events entirely (their only payload is the output) and never writes the output payload anywhere on stdout. Default is `--ndjson-include-output`.
+
 ## TypeScript CLI
 
 The TypeScript package also publishes a narrower `autoctx` CLI for Node.js environments. It focuses on judge-based evaluation, improvement loops, task queueing, worker execution, and MCP serving rather than the full multi-generation control plane:

--- a/autocontext/src/autocontext/cli_improve.py
+++ b/autocontext/src/autocontext/cli_improve.py
@@ -82,8 +82,18 @@ def register_improve_command(
             help=(
                 "Stream per-round events as newline-delimited JSON to stdout (AC-752). "
                 "Useful for long-running loops where --json would buffer all output until "
-                "completion. Emits one JSON line per event: round_start, judge_done, "
-                "verifier_done, round_summary, and a final summary line."
+                "completion. Emits one JSON line per event: round_start, revision_done, "
+                "judge_done, verifier_done, round_summary, and a final summary line."
+            ),
+        ),
+        ndjson_include_output: bool = typer.Option(
+            True,
+            "--ndjson-include-output/--no-ndjson-include-output",
+            help=(
+                "Include per-round model output in ndjson stream as `revision_done` events "
+                "(default true, AC-753). Lets consumers salvage near-miss verifier-vetoed "
+                "rounds. Pass `--no-ndjson-include-output` for lean events when output content "
+                "is large or unnecessary."
             ),
         ),
         verify_cmd: str = typer.Option(
@@ -158,10 +168,14 @@ def register_improve_command(
             # AC-752: when --ndjson is set, stream per-round events as JSON lines
             # so long-running loops have progress visibility before --json's final
             # blob lands. The event sink writes one compact JSON line per event.
+            # AC-753: revision_done events carry the bulk output content; users
+            # can opt out via --no-ndjson-include-output to keep streams lean.
             on_event: Callable[[ImprovementLoopEvent], None] | None = None
             if ndjson_output:
 
                 def _emit_ndjson(event: ImprovementLoopEvent) -> None:
+                    if event.event == "revision_done" and not ndjson_include_output:
+                        return
                     payload = {k: v for k, v in dataclasses.asdict(event).items() if v is not None}
                     typer.echo(json.dumps(payload))
 

--- a/autocontext/src/autocontext/execution/improvement_events.py
+++ b/autocontext/src/autocontext/execution/improvement_events.py
@@ -34,9 +34,13 @@ class ImprovementLoopEvent:
     - `final`: best_score, best_round, total_rounds, met_threshold
     """
 
+    # NB: field order is part of the public contract for positional construction.
+    # Existing callers may construct events positionally as
+    # `ImprovementLoopEvent("judge_done", 1, 0.95)`; new fields go at the END so
+    # they don't shift the meaning of trailing positional arguments. AC-753 added
+    # `output` and intentionally appends it after the older fields.
     event: str
     round: int | None = None
-    output: str | None = None
     score: float | None = None
     effective_score: float | None = None
     verifier_ok: bool | None = None
@@ -45,3 +49,4 @@ class ImprovementLoopEvent:
     best_round: int | None = None
     total_rounds: int | None = None
     met_threshold: bool | None = None
+    output: str | None = None

--- a/autocontext/src/autocontext/execution/improvement_events.py
+++ b/autocontext/src/autocontext/execution/improvement_events.py
@@ -23,6 +23,11 @@ class ImprovementLoopEvent:
     only meaningful for certain event kinds:
 
     - `round_start`: round
+    - `revision_done`: round, output -- carries the output content the loop
+      is about to evaluate. For round 1 this is the seed; for round N>1 it
+      is the result of task.revise_output() at the end of round N-1.
+      Lets consumers salvage near-miss outputs from verifier-vetoed rounds
+      (AC-753).
     - `judge_done`: round, score
     - `verifier_done`: round, verifier_ok, verifier_exit_code
     - `round_summary`: round, effective_score
@@ -31,6 +36,7 @@ class ImprovementLoopEvent:
 
     event: str
     round: int | None = None
+    output: str | None = None
     score: float | None = None
     effective_score: float | None = None
     verifier_ok: bool | None = None

--- a/autocontext/src/autocontext/execution/improvement_loop.py
+++ b/autocontext/src/autocontext/execution/improvement_loop.py
@@ -230,6 +230,11 @@ class ImprovementLoop:
         for round_num in range(1, self.max_rounds + 1):
             logger.info("improvement loop round %d/%d", round_num, self.max_rounds)
             self._on_event(ImprovementLoopEvent(event="round_start", round=round_num))
+            # AC-753: emit the output content being evaluated so consumers can
+            # salvage near-miss verifier-vetoed rounds. For round 1, current_output
+            # is the seed; for round N>1, it's the result of task.revise_output()
+            # at the end of round N-1.
+            self._on_event(ImprovementLoopEvent(event="revision_done", round=round_num, output=current_output))
 
             round_start = time.monotonic()
             result = self.task.evaluate_output(

--- a/autocontext/tests/test_improvement_loop_events.py
+++ b/autocontext/tests/test_improvement_loop_events.py
@@ -58,7 +58,8 @@ def _failing_verifier() -> OutputVerifier:
 class TestImprovementLoopEventStream:
     def test_loop_emits_minimum_event_sequence_for_single_round(self) -> None:
         # Single round, no verifier. Expected sequence:
-        #   round_start, judge_done, round_summary, final
+        #   round_start, revision_done, judge_done, round_summary, final
+        # (AC-753: revision_done carries the output being evaluated)
         events: list[ImprovementLoopEvent] = []
         loop = ImprovementLoop(
             task=_OneShotPerfectTask(),
@@ -69,11 +70,17 @@ class TestImprovementLoopEventStream:
         loop.run("initial", {})
 
         event_types = [e.event for e in events]
-        assert event_types == ["round_start", "judge_done", "round_summary", "final"]
+        assert event_types == [
+            "round_start",
+            "revision_done",
+            "judge_done",
+            "round_summary",
+            "final",
+        ]
 
     def test_loop_emits_verifier_event_when_verifier_configured(self) -> None:
-        # With a passing verifier: round_start, judge_done, verifier_done,
-        # round_summary, final.
+        # With a passing verifier: round_start, revision_done, judge_done,
+        # verifier_done, round_summary, final.
         events: list[ImprovementLoopEvent] = []
         loop = ImprovementLoop(
             task=_OneShotPerfectTask(),
@@ -87,6 +94,7 @@ class TestImprovementLoopEventStream:
         event_types = [e.event for e in events]
         assert event_types == [
             "round_start",
+            "revision_done",
             "judge_done",
             "verifier_done",
             "round_summary",
@@ -151,6 +159,91 @@ class TestImprovementLoopEventStream:
         )
         result = loop.run("initial", {})
         assert result.best_score == 1.0
+
+
+# -- AC-753: revision_done events carry per-round output content --
+
+
+class _TwoRoundUpgradingTask(AgentTaskInterface):
+    """Round 1 returns a low score (forces a revision), round 2 returns high.
+    The revision appends a marker so tests can distinguish round-1 output
+    (the seed) from round-2 output (the revision)."""
+
+    def get_task_prompt(self, state):
+        return "."
+
+    def evaluate_output(self, output, state, **kwargs):
+        score = 0.95 if "REVISED" in output else 0.1
+        return AgentTaskResult(score=score, reasoning="x", dimension_scores={})
+
+    def revise_output(self, current_output, judge_result, state):
+        return current_output + "\nREVISED"
+
+    def get_rubric(self):
+        return "."
+
+    def initial_state(self, seed=None):
+        return {}
+
+    def describe_task(self):
+        return "."
+
+
+class TestRevisionDoneEvent:
+    """AC-753: each round emits a revision_done event carrying the output
+    being evaluated, so consumers can salvage verifier-vetoed near-misses
+    without rerunning."""
+
+    def test_revision_done_carries_seed_on_round_one(self) -> None:
+        events: list[ImprovementLoopEvent] = []
+        loop = ImprovementLoop(
+            task=_OneShotPerfectTask(),
+            max_rounds=1,
+            quality_threshold=0.9,
+            on_event=events.append,
+        )
+        loop.run("initial-seed", {})
+
+        rev_events = [e for e in events if e.event == "revision_done"]
+        assert len(rev_events) == 1
+        assert rev_events[0].round == 1
+        assert rev_events[0].output == "initial-seed"
+
+    def test_revision_done_carries_revised_output_on_subsequent_rounds(self) -> None:
+        events: list[ImprovementLoopEvent] = []
+        loop = ImprovementLoop(
+            task=_TwoRoundUpgradingTask(),
+            max_rounds=2,
+            quality_threshold=0.9,
+            on_event=events.append,
+        )
+        loop.run("seed", {})
+
+        rev_events = [e for e in events if e.event == "revision_done"]
+        assert [e.round for e in rev_events] == [1, 2]
+        assert rev_events[0].output == "seed"
+        # Round 2's revision_done carries the revised content produced by
+        # task.revise_output() at the end of round 1.
+        assert rev_events[1].output is not None
+        assert "REVISED" in rev_events[1].output
+
+    def test_revision_done_fires_immediately_after_round_start(self) -> None:
+        # Strict ordering: revision_done must come right after round_start
+        # for the same round, before judge_done. This lets consumers see
+        # the input the judge is about to evaluate.
+        events: list[ImprovementLoopEvent] = []
+        loop = ImprovementLoop(
+            task=_TwoRoundUpgradingTask(),
+            max_rounds=2,
+            quality_threshold=0.9,
+            on_event=events.append,
+        )
+        loop.run("seed", {})
+
+        # Look at the first three events of each round:
+        types = [e.event for e in events]
+        first_round = types[: types.index("round_summary") + 1]
+        assert first_round[:3] == ["round_start", "revision_done", "judge_done"]
 
 
 # -- AC-752: CLI `--ndjson` streams events as JSON lines --
@@ -336,3 +429,154 @@ class TestImproveNdjsonFlag:
         # The error message should mention both flags so the user knows why.
         combined = (result.stdout + (result.stderr or "")).lower()
         assert "--json" in combined and "--ndjson" in combined
+
+    def test_ndjson_includes_revision_done_with_output_by_default(self, tmp_path) -> None:
+        # AC-753: by default, --ndjson emits revision_done events carrying
+        # the per-round output content so consumers can salvage near-misses.
+        import json as _json
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from autocontext.cli import app
+        from autocontext.config.settings import AppSettings
+        from autocontext.providers.base import CompletionResult
+
+        runner = CliRunner()
+
+        class _Provider:
+            def complete(self, *args, **kwargs):
+                return CompletionResult(text="x", model=None)
+
+            def default_model(self):
+                return "m"
+
+        settings = AppSettings(
+            db_path=tmp_path / "runs" / "autocontext.sqlite3",
+            runs_root=tmp_path / "runs",
+            knowledge_root=tmp_path / "knowledge",
+            skills_root=tmp_path / "skills",
+            claude_skills_path=tmp_path / ".claude" / "skills",
+            judge_provider="anthropic",
+        )
+
+        class _FakeLoop:
+            def __init__(self, **kwargs):
+                self._on_event = kwargs.get("on_event") or (lambda _e: None)
+
+            def run(self, **_kwargs):
+                self._on_event(ImprovementLoopEvent(event="round_start", round=1))
+                self._on_event(ImprovementLoopEvent(event="revision_done", round=1, output="lean code v1"))
+                self._on_event(ImprovementLoopEvent(event="judge_done", round=1, score=0.9))
+                self._on_event(ImprovementLoopEvent(event="round_summary", round=1, effective_score=0.9))
+                self._on_event(
+                    ImprovementLoopEvent(
+                        event="final",
+                        best_score=0.9,
+                        best_round=1,
+                        total_rounds=1,
+                        met_threshold=True,
+                    )
+                )
+                return SimpleNamespace(
+                    best_score=0.9,
+                    best_round=1,
+                    total_rounds=1,
+                    met_threshold=True,
+                    best_output="x",
+                )
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.providers.registry.get_provider", return_value=_Provider()),
+            patch("autocontext.execution.improvement_loop.ImprovementLoop", _FakeLoop),
+        ):
+            result = runner.invoke(app, ["improve", "-p", "x", "-r", "y", "--ndjson"])
+
+        assert result.exit_code == 0, result.output
+        events = [_json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+        rev = next(e for e in events if e["event"] == "revision_done")
+        assert rev["round"] == 1
+        assert rev["output"] == "lean code v1"
+
+    def test_no_ndjson_include_output_suppresses_revision_done(self, tmp_path) -> None:
+        # AC-753: --no-ndjson-include-output drops revision_done events
+        # entirely (their only payload is the output content). Other events
+        # are still emitted unchanged.
+        import json as _json
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from autocontext.cli import app
+        from autocontext.config.settings import AppSettings
+        from autocontext.providers.base import CompletionResult
+
+        runner = CliRunner()
+
+        class _Provider:
+            def complete(self, *args, **kwargs):
+                return CompletionResult(text="x", model=None)
+
+            def default_model(self):
+                return "m"
+
+        settings = AppSettings(
+            db_path=tmp_path / "runs" / "autocontext.sqlite3",
+            runs_root=tmp_path / "runs",
+            knowledge_root=tmp_path / "knowledge",
+            skills_root=tmp_path / "skills",
+            claude_skills_path=tmp_path / ".claude" / "skills",
+            judge_provider="anthropic",
+        )
+
+        class _FakeLoop:
+            def __init__(self, **kwargs):
+                self._on_event = kwargs.get("on_event") or (lambda _e: None)
+
+            def run(self, **_kwargs):
+                self._on_event(ImprovementLoopEvent(event="round_start", round=1))
+                self._on_event(ImprovementLoopEvent(event="revision_done", round=1, output="bulky-lean-code"))
+                self._on_event(ImprovementLoopEvent(event="judge_done", round=1, score=0.9))
+                self._on_event(ImprovementLoopEvent(event="round_summary", round=1, effective_score=0.9))
+                self._on_event(
+                    ImprovementLoopEvent(
+                        event="final",
+                        best_score=0.9,
+                        best_round=1,
+                        total_rounds=1,
+                        met_threshold=True,
+                    )
+                )
+                return SimpleNamespace(
+                    best_score=0.9,
+                    best_round=1,
+                    total_rounds=1,
+                    met_threshold=True,
+                    best_output="x",
+                )
+
+        with (
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.providers.registry.get_provider", return_value=_Provider()),
+            patch("autocontext.execution.improvement_loop.ImprovementLoop", _FakeLoop),
+        ):
+            result = runner.invoke(
+                app,
+                ["improve", "-p", "x", "-r", "y", "--ndjson", "--no-ndjson-include-output"],
+            )
+
+        assert result.exit_code == 0, result.output
+        events = [_json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+        types = [e["event"] for e in events]
+        assert "revision_done" not in types
+        # Other events still present.
+        assert "round_start" in types
+        assert "judge_done" in types
+        assert "round_summary" in types
+        assert "final" in types
+        # Defense-in-depth: the suppressed-output mode must not leak the
+        # bulk-output payload anywhere in stdout.
+        assert "bulky-lean-code" not in result.stdout

--- a/autocontext/tests/test_improvement_loop_events.py
+++ b/autocontext/tests/test_improvement_loop_events.py
@@ -55,6 +55,22 @@ def _failing_verifier() -> OutputVerifier:
     return OutputVerifier(command=[sys.executable, "-c", script])
 
 
+class TestImprovementLoopEventFieldOrder:
+    """AC-753 PR #925 review: keep positional construction backwards-compatible.
+
+    The dataclass is not keyword-only, so the order of fields matters for any
+    external code constructing events positionally. `event, round, score, ...`
+    was the contract before `output` was added; `output` must come after the
+    existing fields so positional construction keeps working.
+    """
+
+    def test_positional_score_argument_still_lands_on_score(self) -> None:
+        e = ImprovementLoopEvent("judge_done", 1, 0.95)
+        # Before the field-order fix, 0.95 silently landed on `output`.
+        assert e.score == 0.95
+        assert e.output is None
+
+
 class TestImprovementLoopEventStream:
     def test_loop_emits_minimum_event_sequence_for_single_round(self) -> None:
         # Single round, no verifier. Expected sequence:


### PR DESCRIPTION
Follow-up to AC-752. The per-round event stream from `autoctx improve --ndjson` now includes a `revision_done` event per round that carries the model's actual output content, so consumers can salvage near-miss attempts when the external verifier vetoes a round.

## Motivation

AC-752 streamed scores and timings, but the model's per-round output content was not exposed. For Lean / compiled-language tasks where the verifier rejects on small bugs, users had no way to salvage near-correct attempts and had to re-run from the seed.

Concrete repro from 2026-05-11 on a Lean sub-lemma: round 2 judge scored 0.9, verifier vetoed for small bugs, the proof was rewritten manually because there was no exposed starting point. With `revision_done` carrying the output, the bug would have been an edit away.

## Changes

- `ImprovementLoopEvent` gains an `output: str | None` field.
- `ImprovementLoop` emits `revision_done(round=N, output=<content>)` right after `round_start` for every round. Round 1 carries the seed; round N>1 carries the result of `task.revise_output()` from round N-1.
- `autoctx improve` gains `--ndjson-include-output/--no-ndjson-include-output` (default true). Under `--no-ndjson-include-output`, revision_done events are dropped (their only payload is the output) for callers who want lean streams.

## Event sequence (with verifier)

```
round_start -> revision_done -> judge_done -> verifier_done -> round_summary
```

repeated per round, then a single `final` event.

## Tests

Five new tests cover: round-1 seed payload, round-N revised payload, ordering relative to round_start/judge_done, default-on behavior at CLI level, and `--no-ndjson-include-output` suppression including a defense-in-depth check that the suppressed output content never leaks to stdout.

## Test plan

- [ ] CI green
- [ ] Try `autoctx improve --ndjson --verify-cmd ...` on a real Lean loop and confirm a verifier-vetoed round's output is visible in the stream