### PR TITLE
Add scoped MCP runtime tool adapter

### DIFF
--- a/ts/README.md
+++ b/ts/README.md
@@ -32,6 +32,30 @@ grants only when the caller passes grants to `runChildTask()` or when an
 already-granted workspace contains grants whose policy allows child-task
 inheritance.
 
+TypeScript callers can also adapt remote streamable-HTTP MCP servers into
+scoped runtime tool grants with `connectMcpRuntimeTools()`. The trusted host
+code owns the MCP URL and headers, discovered tool names are normalized with
+collision suffixes, input schemas are preserved, and tool results are converted
+to model-safe text while keeping structured content available to callers:
+
+```ts
+import { createInMemoryWorkspaceEnv } from "autoctx";
+import { connectMcpRuntimeTools } from "autoctx/runtimes/mcp";
+
+const mcpTools = await connectMcpRuntimeTools({
+  url: "https://mcp.example.com/rpc",
+  headers: { Authorization: `Bearer ${process.env.MCP_TOKEN ?? ""}` },
+  namePrefix: "docs",
+});
+
+const workspace = await createInMemoryWorkspaceEnv({ cwd: "/repo" }).scope({
+  tools: mcpTools.tools,
+});
+
+const result = await workspace.tools?.[0]?.execute?.({ q: "runtime sessions" });
+await mcpTools.close();
+```
+
 The TypeScript package includes mirrored deterministic semantic prompt
 compaction for long-lived playbooks, trajectories, and session reports.
 Standalone npm runs compact prompt context before the coarse budget fallback,

--- a/ts/package.json
+++ b/ts/package.json
@@ -81,6 +81,10 @@
       "types": "./dist/integrations/browser/index.d.ts",
       "import": "./dist/integrations/browser/index.js"
     },
+    "./runtimes/mcp": {
+      "types": "./dist/runtimes/mcp-runtime-tools.d.ts",
+      "import": "./dist/runtimes/mcp-runtime-tools.js"
+    },
     "./detectors/openai-python": {
       "types": "./dist/control-plane/instrument/detectors/openai-python/index.d.ts",
       "import": "./dist/control-plane/instrument/detectors/openai-python/index.js",

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -232,7 +232,10 @@ export type {
   RuntimeGrantScopePolicy,
   RuntimeScopeOptions,
   RuntimeScopedGrant,
+  RuntimeToolCallContext,
+  RuntimeToolCallResult,
   RuntimeToolGrant,
+  RuntimeToolHandler,
   RuntimeWorkspaceEnv,
 } from "./runtimes/index.js";
 export {

--- a/ts/src/runtimes/index.ts
+++ b/ts/src/runtimes/index.ts
@@ -29,7 +29,10 @@ export type {
   RuntimeGrantScopePolicy,
   RuntimeScopeOptions,
   RuntimeScopedGrant,
+  RuntimeToolCallContext,
+  RuntimeToolCallResult,
   RuntimeToolGrant,
+  RuntimeToolHandler,
   RuntimeWorkspaceEnv,
 } from "./workspace-env.js";
 export { DirectAPIRuntime } from "./direct-api.js";

--- a/ts/src/runtimes/mcp-runtime-tools.ts
+++ b/ts/src/runtimes/mcp-runtime-tools.ts
@@ -1,0 +1,431 @@
+import { Buffer } from "node:buffer";
+
+import type {
+  RuntimeGrantProvenance,
+  RuntimeGrantScopePolicy,
+  RuntimeToolCallContext,
+  RuntimeToolCallResult,
+  RuntimeToolGrant,
+} from "./workspace-env.js";
+
+export interface ConnectMcpRuntimeToolsOptions {
+  url: string | URL;
+  headers?: Record<string, string>;
+  namePrefix?: string;
+  provenance?: RuntimeGrantProvenance;
+  scope?: RuntimeGrantScopePolicy;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  clientName?: string;
+  clientVersion?: string;
+  clientFactory?: McpRuntimeToolClientFactory;
+}
+
+export interface McpRuntimeToolClientFactoryInput {
+  url: URL;
+  headers: Record<string, string>;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+export type McpRuntimeToolClientFactory = (
+  input: McpRuntimeToolClientFactoryInput,
+) => Promise<McpRuntimeToolClient> | McpRuntimeToolClient;
+
+export interface McpRuntimeToolRequestOptions {
+  signal?: AbortSignal;
+  timeout?: number;
+}
+
+export interface McpRuntimeToolClient {
+  listTools(
+    params?: { cursor?: string },
+    options?: McpRuntimeToolRequestOptions,
+  ): Promise<McpListToolsResult>;
+  callTool(
+    params: { name: string; arguments?: Record<string, unknown> },
+    options?: McpRuntimeToolRequestOptions,
+  ): Promise<McpToolCallResponse>;
+  close(): Promise<void> | void;
+}
+
+export interface McpListToolsResult {
+  tools: McpToolDescription[];
+  nextCursor?: string;
+}
+
+export interface McpToolDescription {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface McpToolCallResponse {
+  content?: McpToolContent[];
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+  toolResult?: unknown;
+}
+
+export type McpToolContent =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string }
+  | { type: "audio"; data: string; mimeType: string }
+  | { type: "resource"; resource: McpEmbeddedResource }
+  | { type: "resource_link"; uri: string; name: string; mimeType?: string; description?: string }
+  | Record<string, unknown>;
+
+export type McpEmbeddedResource =
+  | { uri: string; text: string; mimeType?: string }
+  | { uri: string; blob: string; mimeType?: string };
+
+interface McpSdkClientLike {
+  listTools(
+    params?: { cursor?: string },
+    options?: McpRuntimeToolRequestOptions,
+  ): Promise<McpListToolsResult>;
+  callTool(
+    params: { name: string; arguments?: Record<string, unknown> },
+    resultSchema?: unknown,
+    options?: McpRuntimeToolRequestOptions,
+  ): Promise<unknown>;
+  close(): Promise<void>;
+}
+
+export async function connectMcpRuntimeTools(
+  options: ConnectMcpRuntimeToolsOptions,
+): Promise<McpRuntimeToolSet> {
+  const url = normalizeMcpUrl(options.url);
+  const headers = { ...(options.headers ?? {}) };
+  const client = options.clientFactory
+    ? await options.clientFactory({
+        url,
+        headers,
+        signal: options.signal,
+        timeoutMs: options.timeoutMs,
+      })
+    : await createStreamableHttpMcpRuntimeToolClient({
+        url,
+        headers,
+        signal: options.signal,
+        timeoutMs: options.timeoutMs,
+        clientName: options.clientName,
+        clientVersion: options.clientVersion,
+      });
+  let tools: McpToolDescription[];
+  try {
+    tools = await listAllMcpTools(client, {
+      signal: options.signal,
+      timeoutMs: options.timeoutMs,
+    });
+  } catch (error) {
+    await closeQuietly(client);
+    throw error;
+  }
+  return new McpRuntimeToolSet({
+    url,
+    client,
+    tools,
+    namePrefix: options.namePrefix,
+    provenance: options.provenance,
+    scope: options.scope,
+  });
+}
+
+export class McpRuntimeToolSet {
+  readonly tools: readonly RuntimeToolGrant[];
+  readonly url: URL;
+
+  #client: McpRuntimeToolClient;
+  #closed = false;
+  #originalByRuntimeName = new Map<string, string>();
+
+  constructor(options: {
+    url: URL;
+    client: McpRuntimeToolClient;
+    tools: readonly McpToolDescription[];
+    namePrefix?: string;
+    provenance?: RuntimeGrantProvenance;
+    scope?: RuntimeGrantScopePolicy;
+  }) {
+    this.url = options.url;
+    this.#client = options.client;
+    this.tools = this.#defineRuntimeTools(options);
+  }
+
+  originalNameFor(runtimeToolName: string): string | undefined {
+    return this.#originalByRuntimeName.get(runtimeToolName);
+  }
+
+  async callTool(
+    runtimeToolName: string,
+    args: Record<string, unknown> = {},
+    context: RuntimeToolCallContext = {},
+  ): Promise<RuntimeToolCallResult> {
+    if (this.#closed) {
+      throw new Error("MCP runtime tool set is closed");
+    }
+    const remoteName = this.#originalByRuntimeName.get(runtimeToolName);
+    if (!remoteName) {
+      throw new Error(`Unknown MCP runtime tool: ${runtimeToolName}`);
+    }
+    const response = await this.#client.callTool(
+      { name: remoteName, arguments: args },
+      requestOptionsFromRuntime(context),
+    );
+    return mcpToolCallResponseToRuntimeResult(response);
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    await this.#client.close();
+  }
+
+  #defineRuntimeTools(options: {
+    url: URL;
+    tools: readonly McpToolDescription[];
+    namePrefix?: string;
+    provenance?: RuntimeGrantProvenance;
+    scope?: RuntimeGrantScopePolicy;
+  }): RuntimeToolGrant[] {
+    const names = uniqueRuntimeToolNames(options.tools, options.namePrefix);
+    return options.tools.map((tool, index) => {
+      const name = names[index]!;
+      this.#originalByRuntimeName.set(name, tool.name);
+      return {
+        kind: "tool",
+        name,
+        description: tool.description,
+        inputSchema: copyRecord(tool.inputSchema),
+        execute: (args, context) => this.callTool(name, args, context),
+        provenance: {
+          ...options.provenance,
+          source: `mcp:${publicMcpUrl(options.url)}`,
+          description: options.provenance?.description ?? `Remote MCP tool ${tool.name}`,
+        },
+        scope: options.scope,
+      };
+    });
+  }
+}
+
+export function normalizeMcpRuntimeToolName(name: string): string {
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  const fallback = normalized || "tool";
+  return /^[a-z_]/.test(fallback) ? fallback : `tool_${fallback}`;
+}
+
+export function mcpToolCallResponseToRuntimeResult(
+  response: McpToolCallResponse,
+): RuntimeToolCallResult {
+  const parts: string[] = [];
+  if ("toolResult" in response && response.toolResult !== undefined) {
+    parts.push(safeJsonOrString(response.toolResult));
+  }
+  for (const item of response.content ?? []) {
+    parts.push(mcpContentToText(item));
+  }
+  if (response.structuredContent !== undefined) {
+    parts.push(`structuredContent:\n${safeJsonOrString(response.structuredContent, 2)}`);
+  }
+  return {
+    text: parts.filter((part) => part.length > 0).join("\n\n"),
+    isError: response.isError === true,
+    content: response.content,
+    structuredContent: response.structuredContent,
+  };
+}
+
+async function createStreamableHttpMcpRuntimeToolClient(options: {
+  url: URL;
+  headers: Record<string, string>;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  clientName?: string;
+  clientVersion?: string;
+}): Promise<McpRuntimeToolClient> {
+  const [{ Client }, { StreamableHTTPClientTransport }] = await Promise.all([
+    import("@modelcontextprotocol/sdk/client/index.js"),
+    import("@modelcontextprotocol/sdk/client/streamableHttp.js"),
+  ]);
+  const transport = new StreamableHTTPClientTransport(options.url, {
+    requestInit: { headers: options.headers },
+  });
+  const client = new Client({
+    name: options.clientName ?? "autoctx-runtime-tools",
+    version: options.clientVersion ?? "0.5.0",
+  });
+  await client.connect(transport, requestOptionsFromRuntime({
+    signal: options.signal,
+    timeoutMs: options.timeoutMs,
+  }));
+  return new SdkMcpRuntimeToolClient(client);
+}
+
+class SdkMcpRuntimeToolClient implements McpRuntimeToolClient {
+  #client: McpSdkClientLike;
+
+  constructor(client: McpSdkClientLike) {
+    this.#client = client;
+  }
+
+  async listTools(
+    params?: { cursor?: string },
+    options?: McpRuntimeToolRequestOptions,
+  ): Promise<McpListToolsResult> {
+    return this.#client.listTools(params, options);
+  }
+
+  async callTool(
+    params: { name: string; arguments?: Record<string, unknown> },
+    options?: McpRuntimeToolRequestOptions,
+  ): Promise<McpToolCallResponse> {
+    const response = await this.#client.callTool(params, undefined, options);
+    return response as McpToolCallResponse;
+  }
+
+  close(): Promise<void> {
+    return this.#client.close();
+  }
+}
+
+async function listAllMcpTools(
+  client: McpRuntimeToolClient,
+  context: RuntimeToolCallContext,
+): Promise<McpToolDescription[]> {
+  const tools: McpToolDescription[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await client.listTools(
+      cursor ? { cursor } : undefined,
+      requestOptionsFromRuntime(context),
+    );
+    tools.push(...page.tools);
+    cursor = page.nextCursor;
+  } while (cursor);
+  return tools;
+}
+
+async function closeQuietly(client: McpRuntimeToolClient): Promise<void> {
+  try {
+    await client.close();
+  } catch {
+    // Discovery failure should remain the reported failure.
+  }
+}
+
+function requestOptionsFromRuntime(
+  context: RuntimeToolCallContext,
+): McpRuntimeToolRequestOptions | undefined {
+  const options: McpRuntimeToolRequestOptions = {};
+  if (context.signal) options.signal = context.signal;
+  if (context.timeoutMs !== undefined) options.timeout = context.timeoutMs;
+  return Object.keys(options).length > 0 ? options : undefined;
+}
+
+function uniqueRuntimeToolNames(
+  tools: readonly McpToolDescription[],
+  namePrefix?: string,
+): string[] {
+  const prefix = namePrefix ? normalizeMcpRuntimeToolName(namePrefix) : "";
+  const used = new Set<string>();
+  return tools.map((tool) => {
+    const base = [prefix, normalizeMcpRuntimeToolName(tool.name)]
+      .filter(Boolean)
+      .join("_");
+    let name = base;
+    let suffix = 2;
+    while (used.has(name)) {
+      name = `${base}_${suffix}`;
+      suffix += 1;
+    }
+    used.add(name);
+    return name;
+  });
+}
+
+function mcpContentToText(content: McpToolContent): string {
+  if (content.type === "text" && typeof content.text === "string") {
+    return content.text;
+  }
+  if (content.type === "image" && typeof content.data === "string") {
+    return `[image ${readString(content.mimeType, "application/octet-stream")} ${base64Bytes(content.data)} bytes]`;
+  }
+  if (content.type === "audio" && typeof content.data === "string") {
+    return `[audio ${readString(content.mimeType, "application/octet-stream")} ${base64Bytes(content.data)} bytes]`;
+  }
+  if (content.type === "resource" && isRecord(content.resource)) {
+    return embeddedResourceToText(content.resource);
+  }
+  if (content.type === "resource_link") {
+    const mimeType = readString(content.mimeType);
+    const suffix = mimeType ? ` ${mimeType}` : "";
+    return `[resource_link ${readString(content.name, "resource")} ${readString(content.uri)}${suffix}]`;
+  }
+  return safeJsonOrString(content);
+}
+
+function embeddedResourceToText(resource: Record<string, unknown>): string {
+  const uri = readString(resource.uri);
+  const mimeType = readString(resource.mimeType);
+  if (typeof resource.text === "string") {
+    const suffix = mimeType ? ` ${mimeType}` : "";
+    return `resource ${uri}${suffix}\n${resource.text}`;
+  }
+  if (typeof resource.blob === "string") {
+    const suffix = mimeType ? ` ${mimeType}` : "";
+    return `[resource ${uri}${suffix} ${base64Bytes(resource.blob)} bytes]`;
+  }
+  return safeJsonOrString(resource);
+}
+
+function base64Bytes(value: string): number {
+  return Buffer.from(value, "base64").byteLength;
+}
+
+function normalizeMcpUrl(value: string | URL): URL {
+  const url = value instanceof URL ? value : new URL(value);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("MCP runtime tool URL must use http: or https:");
+  }
+  return url;
+}
+
+function publicMcpUrl(url: URL): string {
+  const copy = new URL(url.toString());
+  copy.username = "";
+  copy.password = "";
+  copy.search = "";
+  copy.hash = "";
+  return copy.toString();
+}
+
+function copyRecord(value: Record<string, unknown>): Record<string, unknown> {
+  return { ...value };
+}
+
+function readString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function safeJsonOrString(value: unknown, space?: number): string {
+  try {
+    return JSON.stringify(value, null, space) ?? String(value);
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return "[unserializable]";
+    }
+  }
+}

--- a/ts/src/runtimes/mcp-runtime-tools.ts
+++ b/ts/src/runtimes/mcp-runtime-tools.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 
+import { registerRuntimeToolGrantSecrets } from "./workspace-env.js";
 import type {
   RuntimeGrantProvenance,
   RuntimeGrantScopePolicy,
@@ -92,6 +93,9 @@ interface McpSdkClientLike {
   close(): Promise<void>;
 }
 
+const MAX_MCP_TOOL_DISCOVERY_PAGES = 100;
+const MAX_MCP_TOOL_DISCOVERY_TOOLS = 10_000;
+
 export async function connectMcpRuntimeTools(
   options: ConnectMcpRuntimeToolsOptions,
 ): Promise<McpRuntimeToolSet> {
@@ -129,6 +133,7 @@ export async function connectMcpRuntimeTools(
     namePrefix: options.namePrefix,
     provenance: options.provenance,
     scope: options.scope,
+    trustedSecrets: trustedHeaderSecrets(headers),
   });
 }
 
@@ -147,6 +152,7 @@ export class McpRuntimeToolSet {
     namePrefix?: string;
     provenance?: RuntimeGrantProvenance;
     scope?: RuntimeGrantScopePolicy;
+    trustedSecrets?: string[];
   }) {
     this.url = options.url;
     this.#client = options.client;
@@ -188,12 +194,13 @@ export class McpRuntimeToolSet {
     namePrefix?: string;
     provenance?: RuntimeGrantProvenance;
     scope?: RuntimeGrantScopePolicy;
+    trustedSecrets?: string[];
   }): RuntimeToolGrant[] {
     const names = uniqueRuntimeToolNames(options.tools, options.namePrefix);
     return options.tools.map((tool, index) => {
       const name = names[index]!;
       this.#originalByRuntimeName.set(name, tool.name);
-      return {
+      const runtimeTool: RuntimeToolGrant = {
         kind: "tool",
         name,
         description: tool.description,
@@ -206,6 +213,7 @@ export class McpRuntimeToolSet {
         },
         scope: options.scope,
       };
+      return registerRuntimeToolGrantSecrets(runtimeTool, options.trustedSecrets ?? []);
     });
   }
 }
@@ -300,16 +308,32 @@ async function listAllMcpTools(
   context: RuntimeToolCallContext,
 ): Promise<McpToolDescription[]> {
   const tools: McpToolDescription[] = [];
+  const seenCursors = new Set<string>();
   let cursor: string | undefined;
-  do {
+  for (let pageCount = 0; pageCount < MAX_MCP_TOOL_DISCOVERY_PAGES; pageCount += 1) {
     const page = await client.listTools(
       cursor ? { cursor } : undefined,
       requestOptionsFromRuntime(context),
     );
     tools.push(...page.tools);
-    cursor = page.nextCursor;
-  } while (cursor);
-  return tools;
+    if (tools.length > MAX_MCP_TOOL_DISCOVERY_TOOLS) {
+      throw new Error(
+        `MCP tool discovery exceeded ${MAX_MCP_TOOL_DISCOVERY_TOOLS} tools`,
+      );
+    }
+    const nextCursor = page.nextCursor;
+    if (!nextCursor) return tools;
+    if (seenCursors.has(nextCursor)) {
+      throw new Error(`MCP tool discovery returned a repeated cursor: ${nextCursor}`);
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+  throw new Error(`MCP tool discovery exceeded ${MAX_MCP_TOOL_DISCOVERY_PAGES} pages`);
+}
+
+function trustedHeaderSecrets(headers: Record<string, string>): string[] {
+  return Object.values(headers);
 }
 
 async function closeQuietly(client: McpRuntimeToolClient): Promise<void> {

--- a/ts/src/runtimes/workspace-env.ts
+++ b/ts/src/runtimes/workspace-env.ts
@@ -26,12 +26,14 @@ export interface RuntimeFileStat {
 export interface RuntimeScopeOptions {
   cwd?: string;
   commands?: RuntimeCommandGrant[];
+  tools?: RuntimeToolGrant[];
   grantEventSink?: RuntimeGrantEventSink;
   grantInheritance?: RuntimeGrantInheritanceMode;
 }
 
 export interface RuntimeWorkspaceEnv {
   readonly cwd: string;
+  readonly tools?: readonly RuntimeToolGrant[];
 
   exec(command: string, options?: RuntimeExecOptions): Promise<RuntimeExecResult>;
   scope(options?: RuntimeScopeOptions): Promise<RuntimeWorkspaceEnv>;
@@ -102,9 +104,28 @@ export interface RuntimeToolGrant {
   name: string;
   description?: string;
   inputSchema?: Record<string, unknown>;
+  execute?: RuntimeToolHandler;
   provenance?: RuntimeGrantProvenance;
   scope?: RuntimeGrantScopePolicy;
 }
+
+export interface RuntimeToolCallContext {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+export interface RuntimeToolCallResult {
+  text: string;
+  isError?: boolean;
+  content?: unknown[];
+  structuredContent?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export type RuntimeToolHandler = (
+  args: Record<string, unknown>,
+  context?: RuntimeToolCallContext,
+) => Promise<RuntimeToolCallResult> | RuntimeToolCallResult;
 
 export type RuntimeScopedGrant = RuntimeCommandGrant | RuntimeToolGrant;
 export type RuntimeGrantKind = "command" | "tool";
@@ -316,6 +337,7 @@ class InMemoryWorkspaceEnv implements RuntimeWorkspaceEnv {
   readonly cwd: string;
   #closed = false;
   #commands: Map<string, RuntimeCommandGrant>;
+  #tools: Map<string, RuntimeToolGrant>;
   #grantEventSink?: RuntimeGrantEventSink;
   #state: MemoryState;
 
@@ -323,13 +345,19 @@ class InMemoryWorkspaceEnv implements RuntimeWorkspaceEnv {
     state: MemoryState,
     cwd: string,
     commands: RuntimeCommandGrant[] = [],
+    tools: RuntimeToolGrant[] = [],
     grantEventSink?: RuntimeGrantEventSink,
   ) {
     this.#state = state;
     this.cwd = normalizeVirtualPath(cwd, "/");
     this.#commands = commandMap(commands);
+    this.#tools = toolMap(tools);
     this.#grantEventSink = grantEventSink;
     ensureMemoryParentDirs(this.#state, this.cwd);
+  }
+
+  get tools(): readonly RuntimeToolGrant[] {
+    return [...this.#tools.values()];
   }
 
   async exec(command: string, options: RuntimeExecOptions = {}): Promise<RuntimeExecResult> {
@@ -358,6 +386,10 @@ class InMemoryWorkspaceEnv implements RuntimeWorkspaceEnv {
       mergeCommandGrants(
         inheritedCommandGrants([...this.#commands.values()], options.grantInheritance),
         options.commands ?? [],
+      ),
+      mergeToolGrants(
+        inheritedToolGrants([...this.#tools.values()], options.grantInheritance),
+        options.tools ?? [],
       ),
       options.grantEventSink ?? this.#grantEventSink,
     );
@@ -467,18 +499,25 @@ class LocalWorkspaceEnv implements RuntimeWorkspaceEnv {
   readonly cwd: string;
   #root: string;
   #commands: Map<string, RuntimeCommandGrant>;
+  #tools: Map<string, RuntimeToolGrant>;
   #grantEventSink?: RuntimeGrantEventSink;
 
   constructor(
     root: string,
     cwd: string,
     commands: RuntimeCommandGrant[] = [],
+    tools: RuntimeToolGrant[] = [],
     grantEventSink?: RuntimeGrantEventSink,
   ) {
     this.#root = path.resolve(root);
     this.cwd = normalizeVirtualPath(cwd, "/");
     this.#commands = commandMap(commands);
+    this.#tools = toolMap(tools);
     this.#grantEventSink = grantEventSink;
+  }
+
+  get tools(): readonly RuntimeToolGrant[] {
+    return [...this.#tools.values()];
   }
 
   async exec(command: string, options: RuntimeExecOptions = {}): Promise<RuntimeExecResult> {
@@ -506,6 +545,10 @@ class LocalWorkspaceEnv implements RuntimeWorkspaceEnv {
       mergeCommandGrants(
         inheritedCommandGrants([...this.#commands.values()], options.grantInheritance),
         options.commands ?? [],
+      ),
+      mergeToolGrants(
+        inheritedToolGrants([...this.#tools.values()], options.grantInheritance),
+        options.tools ?? [],
       ),
       options.grantEventSink ?? this.#grantEventSink,
     );
@@ -588,6 +631,14 @@ function commandMap(commands: RuntimeCommandGrant[]): Map<string, RuntimeCommand
   return result;
 }
 
+function toolMap(tools: RuntimeToolGrant[]): Map<string, RuntimeToolGrant> {
+  const result = new Map<string, RuntimeToolGrant>();
+  for (const tool of tools) {
+    result.set(tool.name, tool);
+  }
+  return result;
+}
+
 function mergeCommandGrants(
   base: RuntimeCommandGrant[],
   overrides: RuntimeCommandGrant[],
@@ -599,12 +650,31 @@ function mergeCommandGrants(
   return [...result.values()];
 }
 
+function mergeToolGrants(
+  base: RuntimeToolGrant[],
+  overrides: RuntimeToolGrant[],
+): RuntimeToolGrant[] {
+  const result = toolMap(base);
+  for (const tool of overrides) {
+    result.set(tool.name, tool);
+  }
+  return [...result.values()];
+}
+
 function inheritedCommandGrants(
   commands: RuntimeCommandGrant[],
   mode: RuntimeGrantInheritanceMode = "scope",
 ): RuntimeCommandGrant[] {
   if (mode !== "child_task") return commands;
   return commands.filter((command) => command.scope?.inheritToChildTasks !== false);
+}
+
+function inheritedToolGrants(
+  tools: RuntimeToolGrant[],
+  mode: RuntimeGrantInheritanceMode = "scope",
+): RuntimeToolGrant[] {
+  if (mode !== "child_task") return tools;
+  return tools.filter((tool) => tool.scope?.inheritToChildTasks !== false);
 }
 
 async function maybeRunGrantedCommand(

--- a/ts/src/runtimes/workspace-env.ts
+++ b/ts/src/runtimes/workspace-env.ts
@@ -191,6 +191,12 @@ type MemoryState = {
 const DEFAULT_RUNTIME_COMMAND_OUTPUT_LIMIT_BYTES = 4096;
 const DEFAULT_RUNTIME_COMMAND_ARG_LIMIT = 12;
 const DEFAULT_RUNTIME_COMMAND_ARG_BYTES = 160;
+const RUNTIME_TOOL_EVENT_SOURCE = Symbol("runtimeToolEventSource");
+const runtimeToolSecretValues = new WeakMap<RuntimeToolGrant, string[]>();
+
+type RuntimeToolGrantEventWrapper = RuntimeToolGrant & {
+  [RUNTIME_TOOL_EVENT_SOURCE]?: RuntimeToolGrant;
+};
 
 export function createInMemoryWorkspaceEnv(
   options: InMemoryWorkspaceEnvOptions = {},
@@ -221,6 +227,17 @@ export function defineRuntimeCommand(
     scope: options.scope,
     outputLimitBytes: normalizeOutputLimit(options.outputLimitBytes),
   };
+}
+
+export function registerRuntimeToolGrantSecrets(
+  tool: RuntimeToolGrant,
+  secrets: string[],
+): RuntimeToolGrant {
+  const redactionSecrets = uniqueSecretValues(secrets);
+  if (redactionSecrets.length > 0) {
+    runtimeToolSecretValues.set(rawRuntimeToolGrant(tool), redactionSecrets);
+  }
+  return tool;
 }
 
 export function createLocalRuntimeCommandGrant(
@@ -357,7 +374,7 @@ class InMemoryWorkspaceEnv implements RuntimeWorkspaceEnv {
   }
 
   get tools(): readonly RuntimeToolGrant[] {
-    return [...this.#tools.values()];
+    return runtimeToolsForWorkspace([...this.#tools.values()], this.cwd, this.#grantEventSink);
   }
 
   async exec(command: string, options: RuntimeExecOptions = {}): Promise<RuntimeExecResult> {
@@ -517,7 +534,7 @@ class LocalWorkspaceEnv implements RuntimeWorkspaceEnv {
   }
 
   get tools(): readonly RuntimeToolGrant[] {
-    return [...this.#tools.values()];
+    return runtimeToolsForWorkspace([...this.#tools.values()], this.cwd, this.#grantEventSink);
   }
 
   async exec(command: string, options: RuntimeExecOptions = {}): Promise<RuntimeExecResult> {
@@ -634,7 +651,8 @@ function commandMap(commands: RuntimeCommandGrant[]): Map<string, RuntimeCommand
 function toolMap(tools: RuntimeToolGrant[]): Map<string, RuntimeToolGrant> {
   const result = new Map<string, RuntimeToolGrant>();
   for (const tool of tools) {
-    result.set(tool.name, tool);
+    const rawTool = rawRuntimeToolGrant(tool);
+    result.set(rawTool.name, rawTool);
   }
   return result;
 }
@@ -656,7 +674,8 @@ function mergeToolGrants(
 ): RuntimeToolGrant[] {
   const result = toolMap(base);
   for (const tool of overrides) {
-    result.set(tool.name, tool);
+    const rawTool = rawRuntimeToolGrant(tool);
+    result.set(rawTool.name, rawTool);
   }
   return [...result.values()];
 }
@@ -748,6 +767,96 @@ async function maybeRunGrantedCommand(
     });
     throw error;
   }
+}
+
+function runtimeToolsForWorkspace(
+  tools: RuntimeToolGrant[],
+  cwd: string,
+  grantEventSink: RuntimeGrantEventSink | undefined,
+): RuntimeToolGrant[] {
+  if (!grantEventSink) return tools;
+  return tools.map((tool) => runtimeToolWithGrantEvents(tool, cwd, grantEventSink));
+}
+
+function runtimeToolWithGrantEvents(
+  tool: RuntimeToolGrant,
+  cwd: string,
+  grantEventSink: RuntimeGrantEventSink,
+): RuntimeToolGrant {
+  const rawTool = rawRuntimeToolGrant(tool);
+  if (!rawTool.execute) return rawTool;
+  const wrapped: RuntimeToolGrantEventWrapper = {
+    ...rawTool,
+    execute: (args, context) =>
+      executeRuntimeToolWithGrantEvents(rawTool, args, context, cwd, grantEventSink),
+  };
+  Object.defineProperty(wrapped, RUNTIME_TOOL_EVENT_SOURCE, { value: rawTool });
+  return wrapped;
+}
+
+async function executeRuntimeToolWithGrantEvents(
+  tool: RuntimeToolGrant,
+  args: Record<string, unknown>,
+  context: RuntimeToolCallContext | undefined,
+  cwd: string,
+  grantEventSink: RuntimeGrantEventSink,
+): Promise<RuntimeToolCallResult> {
+  const secrets = runtimeToolRedactionSecrets(tool);
+  const argsSummary = summarizeArgs([safeJsonOrString(args)], secrets);
+  const redaction = baseGrantRedaction({}, argsSummary);
+  emitRuntimeGrantEvent(grantEventSink, {
+    kind: "tool",
+    phase: "start",
+    name: tool.name,
+    cwd,
+    argsSummary: argsSummary.summary,
+    redaction,
+    provenance: tool.provenance,
+  });
+  try {
+    const result = await tool.execute!(args, context);
+    const stdout = previewText(result.text, secrets, DEFAULT_RUNTIME_COMMAND_OUTPUT_LIMIT_BYTES);
+    emitRuntimeGrantEvent(grantEventSink, {
+      kind: "tool",
+      phase: "end",
+      name: tool.name,
+      cwd,
+      argsSummary: argsSummary.summary,
+      exitCode: result.isError ? 1 : 0,
+      stdout: stdout.text,
+      redaction: {
+        ...redaction,
+        stdout: stdout.metadata,
+      },
+      provenance: tool.provenance,
+    });
+    return result;
+  } catch (error) {
+    const rawMessage = error instanceof Error ? error.message : String(error);
+    const message = previewText(rawMessage, secrets, DEFAULT_RUNTIME_COMMAND_OUTPUT_LIMIT_BYTES);
+    emitRuntimeGrantEvent(grantEventSink, {
+      kind: "tool",
+      phase: "error",
+      name: tool.name,
+      cwd,
+      argsSummary: argsSummary.summary,
+      error: message.text,
+      redaction: {
+        ...redaction,
+        error: message.metadata,
+      },
+      provenance: tool.provenance,
+    });
+    throw error;
+  }
+}
+
+function rawRuntimeToolGrant(tool: RuntimeToolGrant): RuntimeToolGrant {
+  return (tool as RuntimeToolGrantEventWrapper)[RUNTIME_TOOL_EVENT_SOURCE] ?? tool;
+}
+
+function runtimeToolRedactionSecrets(tool: RuntimeToolGrant): string[] {
+  return runtimeToolSecretValues.get(rawRuntimeToolGrant(tool)) ?? [];
 }
 
 function parseCommandLine(commandLine: string): { name: string; args: string[] } | null {
@@ -875,7 +984,13 @@ function runtimeCommandOutputLimit(grant: RuntimeCommandGrant): number {
 }
 
 function secretValues(env: Record<string, string>): string[] {
-  return [...new Set(Object.values(env).filter((value) => value.length > 0))];
+  return uniqueSecretValues(Object.values(env));
+}
+
+function uniqueSecretValues(values: readonly string[]): string[] {
+  return [...new Set(values.filter((value) => value.length > 0))].sort(
+    (left, right) => right.length - left.length,
+  );
 }
 
 function baseGrantRedaction(
@@ -955,6 +1070,27 @@ function redactSecrets(value: string, secrets: string[]): { text: string; redact
     redacted = true;
   }
   return { text, redacted };
+}
+
+function safeJsonOrString(value: unknown): string {
+  try {
+    const json = JSON.stringify(value, (_key, candidate) => {
+      if (typeof candidate === "bigint") return candidate.toString();
+      if (typeof candidate === "symbol") return String(candidate);
+      if (typeof candidate === "function") {
+        return `[Function ${candidate.name || "anonymous"}]`;
+      }
+      return candidate;
+    });
+    if (json !== undefined) return json;
+  } catch {
+    // Fall through to string coercion.
+  }
+  try {
+    return String(value);
+  } catch {
+    return "[unserializable]";
+  }
 }
 
 function truncateUtf8(value: string, limitBytes: number): { text: string; truncated: boolean } {

--- a/ts/src/session/runtime-session.ts
+++ b/ts/src/session/runtime-session.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
-import type { RuntimeCommandGrant, RuntimeWorkspaceEnv } from "../runtimes/workspace-env.js";
+import type {
+  RuntimeCommandGrant,
+  RuntimeToolGrant,
+  RuntimeWorkspaceEnv,
+} from "../runtimes/workspace-env.js";
 import { Coordinator } from "./coordinator.js";
 import {
   RuntimeChildTaskRunner,
@@ -58,6 +62,7 @@ export interface RuntimeSessionSubmitPromptOpts {
   role?: string;
   cwd?: string;
   commands?: RuntimeCommandGrant[];
+  tools?: RuntimeToolGrant[];
   handler: RuntimeSessionPromptHandler;
 }
 
@@ -167,6 +172,7 @@ export class RuntimeSession {
     const scopedWorkspace = await this.workspace.scope({
       cwd: opts.cwd,
       commands: opts.commands,
+      tools: opts.tools,
       grantEventSink: createRuntimeSessionGrantEventSink(this.log, () => ({
         requestId,
         promptEventId,

--- a/ts/tests/mcp-runtime-tools.test.ts
+++ b/ts/tests/mcp-runtime-tools.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  connectMcpRuntimeTools,
+  type McpRuntimeToolClient,
+} from "../src/runtimes/mcp-runtime-tools.js";
+import { createInMemoryWorkspaceEnv } from "../src/runtimes/workspace-env.js";
+
+function mockClient(overrides: Partial<McpRuntimeToolClient> = {}): McpRuntimeToolClient {
+  return {
+    listTools: async () => ({ tools: [] }),
+    callTool: async () => ({ content: [] }),
+    close: async () => {},
+    ...overrides,
+  };
+}
+
+describe("MCP runtime tools", () => {
+  it("connects with trusted headers and normalizes duplicate tool names", async () => {
+    const seen: Array<{ url: string; headers: Record<string, string> }> = [];
+    let closed = false;
+
+    const toolSet = await connectMcpRuntimeTools({
+      url: "https://mcp.example.test/rpc",
+      headers: { Authorization: "Bearer trusted-token" },
+      clientFactory: async ({ url, headers }) => {
+        seen.push({ url: String(url), headers });
+        return mockClient({
+          listTools: async () => ({
+            tools: [
+              {
+                name: "Search API",
+                description: "Search docs",
+                inputSchema: {
+                  type: "object",
+                  properties: { q: { type: "string" } },
+                  required: ["q"],
+                },
+              },
+              {
+                name: "search-api",
+                description: "Search tickets",
+                inputSchema: { type: "object" },
+              },
+            ],
+          }),
+          close: async () => {
+            closed = true;
+          },
+        });
+      },
+    });
+
+    expect(seen).toEqual([
+      {
+        url: "https://mcp.example.test/rpc",
+        headers: { Authorization: "Bearer trusted-token" },
+      },
+    ]);
+    expect(toolSet.tools.map((tool) => tool.name)).toEqual([
+      "search_api",
+      "search_api_2",
+    ]);
+    expect(toolSet.tools[0]).toMatchObject({
+      kind: "tool",
+      description: "Search docs",
+      inputSchema: {
+        type: "object",
+        properties: { q: { type: "string" } },
+        required: ["q"],
+      },
+      provenance: {
+        source: "mcp:https://mcp.example.test/rpc",
+      },
+    });
+    expect(toolSet.originalNameFor("search_api_2")).toBe("search-api");
+
+    await toolSet.close();
+    expect(closed).toBe(true);
+  });
+
+  it("redacts URL credentials and query strings from tool provenance", async () => {
+    const toolSet = await connectMcpRuntimeTools({
+      url: "https://user:password@mcp.example.test/rpc?token=url-secret#frag",
+      clientFactory: async () =>
+        mockClient({
+          listTools: async () => ({
+            tools: [{ name: "lookup", inputSchema: { type: "object" } }],
+          }),
+        }),
+    });
+
+    expect(toolSet.tools[0]!.provenance?.source).toBe("mcp:https://mcp.example.test/rpc");
+    expect(JSON.stringify(toolSet.tools)).not.toContain("url-secret");
+    expect(JSON.stringify(toolSet.tools)).not.toContain("password");
+  });
+
+  it("converts MCP content and structured results into model-safe text", async () => {
+    const toolSet = await connectMcpRuntimeTools({
+      url: "https://mcp.example.test/rpc",
+      clientFactory: async () =>
+        mockClient({
+          listTools: async () => ({
+            tools: [{ name: "render", inputSchema: { type: "object" } }],
+          }),
+          callTool: async () => ({
+            structuredContent: { id: 42, ok: true },
+            content: [
+              { type: "text", text: "Rendered report" },
+              { type: "image", data: "aGVsbG8=", mimeType: "image/png" },
+              {
+                type: "resource",
+                resource: {
+                  uri: "file:///report.md",
+                  mimeType: "text/markdown",
+                  text: "# Report",
+                },
+              },
+              {
+                type: "resource",
+                resource: {
+                  uri: "file:///raw.bin",
+                  mimeType: "application/octet-stream",
+                  blob: "aGVsbG8=",
+                },
+              },
+              {
+                type: "resource_link",
+                uri: "https://example.test/report",
+                name: "report-link",
+                mimeType: "text/html",
+              },
+            ],
+          }),
+        }),
+    });
+
+    const result = await toolSet.tools[0]!.execute!({ id: 42 });
+
+    expect(result).toMatchObject({
+      isError: false,
+      structuredContent: { id: 42, ok: true },
+    });
+    expect(result.text).toContain("Rendered report");
+    expect(result.text).toContain("[image image/png 5 bytes]");
+    expect(result.text).toContain("resource file:///report.md text/markdown");
+    expect(result.text).toContain("# Report");
+    expect(result.text).toContain("[resource file:///raw.bin application/octet-stream 5 bytes]");
+    expect(result.text).toContain("[resource_link report-link https://example.test/report text/html]");
+    expect(result.text).toContain('"ok": true');
+  });
+
+  it("preserves MCP tool failures and propagates transport failures", async () => {
+    const toolSet = await connectMcpRuntimeTools({
+      url: "https://mcp.example.test/rpc",
+      clientFactory: async () =>
+        mockClient({
+          listTools: async () => ({
+            tools: [
+              { name: "fails_cleanly", inputSchema: { type: "object" } },
+              { name: "throws", inputSchema: { type: "object" } },
+            ],
+          }),
+          callTool: async ({ name }) => {
+            if (name === "throws") throw new Error("transport down");
+            return {
+              isError: true,
+              content: [{ type: "text", text: "tool rejected the request" }],
+            };
+          },
+        }),
+    });
+
+    await expect(toolSet.tools[0]!.execute!({})).resolves.toMatchObject({
+      isError: true,
+      text: "tool rejected the request",
+    });
+    await expect(toolSet.tools[1]!.execute!({})).rejects.toThrow("transport down");
+  });
+
+  it("passes abort signals and timeouts through tool calls", async () => {
+    const abortController = new AbortController();
+    const seenOptions: unknown[] = [];
+    const toolSet = await connectMcpRuntimeTools({
+      url: "https://mcp.example.test/rpc",
+      clientFactory: async () =>
+        mockClient({
+          listTools: async () => ({
+            tools: [{ name: "slow_tool", inputSchema: { type: "object" } }],
+          }),
+          callTool: async (_params, options) => {
+            seenOptions.push(options);
+            return { content: [{ type: "text", text: "done" }] };
+          },
+        }),
+    });
+
+    await toolSet.tools[0]!.execute!({}, {
+      signal: abortController.signal,
+      timeoutMs: 25,
+    });
+
+    expect(seenOptions).toEqual([
+      {
+        signal: abortController.signal,
+        timeout: 25,
+      },
+    ]);
+  });
+
+  it("closes an opened client when tool discovery fails", async () => {
+    let closed = false;
+
+    await expect(connectMcpRuntimeTools({
+      url: "https://mcp.example.test/rpc",
+      clientFactory: async () =>
+        mockClient({
+          listTools: async () => {
+            throw new Error("discovery failed");
+          },
+          close: async () => {
+            closed = true;
+          },
+        }),
+    })).rejects.toThrow("discovery failed");
+
+    expect(closed).toBe(true);
+  });
+
+  it("scopes MCP tool grants through workspace environments", async () => {
+    const toolSet = await connectMcpRuntimeTools({
+      url: "https://mcp.example.test/rpc",
+      scope: { inheritToChildTasks: false },
+      clientFactory: async () =>
+        mockClient({
+          listTools: async () => ({
+            tools: [{ name: "lookup", inputSchema: { type: "object" } }],
+          }),
+        }),
+    });
+    const inheritableToolSet = await connectMcpRuntimeTools({
+      url: "https://mcp.example.test/rpc",
+      clientFactory: async () =>
+        mockClient({
+          listTools: async () => ({
+            tools: [{ name: "shared_lookup", inputSchema: { type: "object" } }],
+          }),
+        }),
+    });
+    const env = createInMemoryWorkspaceEnv({ cwd: "/project" });
+
+    const scoped = await env.scope({
+      tools: [...toolSet.tools, ...inheritableToolSet.tools],
+    });
+    const child = await scoped.scope({ grantInheritance: "child_task" });
+
+    expect(env.tools ?? []).toEqual([]);
+    expect(scoped.tools?.map((tool) => tool.name)).toEqual(["lookup", "shared_lookup"]);
+    expect(child.tools?.map((tool) => tool.name)).toEqual(["shared_lookup"]);
+  });
+});

--- a/ts/tests/mcp-runtime-tools.test.ts
+++ b/ts/tests/mcp-runtime-tools.test.ts
@@ -5,6 +5,8 @@ import {
   type McpRuntimeToolClient,
 } from "../src/runtimes/mcp-runtime-tools.js";
 import { createInMemoryWorkspaceEnv } from "../src/runtimes/workspace-env.js";
+import { RuntimeSession } from "../src/session/runtime-session.js";
+import { RuntimeSessionEventType } from "../src/session/runtime-events.js";
 
 function mockClient(overrides: Partial<McpRuntimeToolClient> = {}): McpRuntimeToolClient {
   return {
@@ -227,6 +229,26 @@ describe("MCP runtime tools", () => {
     expect(closed).toBe(true);
   });
 
+  it("fails closed when tool discovery repeats a pagination cursor", async () => {
+    let closed = false;
+
+    await expect(connectMcpRuntimeTools({
+      url: "https://mcp.example.test/rpc",
+      clientFactory: async () =>
+        mockClient({
+          listTools: async () => ({
+            tools: [{ name: "lookup", inputSchema: { type: "object" } }],
+            nextCursor: "again",
+          }),
+          close: async () => {
+            closed = true;
+          },
+        }),
+    })).rejects.toThrow("repeated cursor");
+
+    expect(closed).toBe(true);
+  });
+
   it("scopes MCP tool grants through workspace environments", async () => {
     const toolSet = await connectMcpRuntimeTools({
       url: "https://mcp.example.test/rpc",
@@ -257,5 +279,65 @@ describe("MCP runtime tools", () => {
     expect(env.tools ?? []).toEqual([]);
     expect(scoped.tools?.map((tool) => tool.name)).toEqual(["lookup", "shared_lookup"]);
     expect(child.tools?.map((tool) => tool.name)).toEqual(["shared_lookup"]);
+  });
+
+  it("records scoped MCP tool calls in runtime-session grant events", async () => {
+    const toolSet = await connectMcpRuntimeTools({
+      url: "https://mcp.example.test/rpc",
+      headers: { Authorization: "Bearer trusted-token" },
+      clientFactory: async () =>
+        mockClient({
+          listTools: async () => ({
+            tools: [{ name: "lookup", inputSchema: { type: "object" } }],
+          }),
+          callTool: async () => ({
+            content: [{ type: "text", text: "Bearer trusted-token" }],
+          }),
+        }),
+    });
+    const workspace = await createInMemoryWorkspaceEnv({ cwd: "/workspace" }).scope({
+      tools: [...toolSet.tools],
+    });
+    const session = RuntimeSession.create({
+      sessionId: "runtime-mcp-tools",
+      goal: "audit mcp tool use",
+      workspace,
+    });
+
+    const result = await session.submitPrompt({
+      prompt: "Use the MCP tool",
+      handler: async ({ workspace: scopedWorkspace }) => {
+        const tool = scopedWorkspace.tools?.[0];
+        expect(tool).toBeDefined();
+        const call = await tool!.execute!({ token: "Bearer trusted-token" });
+        expect(call.text).toBe("Bearer trusted-token");
+        return { text: "handled" };
+      },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(JSON.stringify(session.log.toJSON())).not.toContain("trusted-token");
+    expect(session.log.events.map((event) => event.eventType)).toEqual([
+      RuntimeSessionEventType.PROMPT_SUBMITTED,
+      RuntimeSessionEventType.TOOL_CALL,
+      RuntimeSessionEventType.TOOL_CALL,
+      RuntimeSessionEventType.ASSISTANT_MESSAGE,
+    ]);
+    expect(session.log.events[1].payload).toMatchObject({
+      phase: "start",
+      toolName: "lookup",
+      argsSummary: ['{"token":"[redacted]"}'],
+      redaction: { envKeys: [] },
+    });
+    expect(session.log.events[2].payload).toMatchObject({
+      phase: "end",
+      toolName: "lookup",
+      exitCode: 0,
+      stdout: "[redacted]",
+      redaction: {
+        envKeys: [],
+        stdout: { redacted: true, truncated: false },
+      },
+    });
   });
 });

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -95,4 +95,15 @@ describe("package root exports", () => {
       types: "./dist/integrations/browser/index.d.ts",
     });
   });
+
+  it("publishes the MCP runtime tool adapter subpath", () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(import.meta.dirname, "..", "package.json"), "utf-8"),
+    ) as { exports?: Record<string, { import?: string; types?: string }> };
+
+    expect(packageJson.exports?.["./runtimes/mcp"]).toEqual({
+      import: "./dist/runtimes/mcp-runtime-tools.js",
+      types: "./dist/runtimes/mcp-runtime-tools.d.ts",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add a TypeScript streamable-HTTP MCP adapter that exposes remote tools as scoped runtime tool grants
- normalize duplicate MCP tool names, preserve input schemas, sanitize provenance URLs, and convert MCP text/image/audio/resource/structured results into model-safe text
- let workspace scopes carry runtime tool grants with child-task inheritance policy and publish the adapter as autoctx/runtimes/mcp

## Verification
- npm run lint
- npm test -- mcp-runtime-tools.test.ts runtime-workspace-env.test.ts type-assertions.test.ts
- npm test -- package-export-catalogs.test.ts --testTimeout=20000
- npm test -- package-boundaries.test.ts --testTimeout=30000
- git diff --check

## Notes
- Full TS suite was attempted with a larger local timeout and hit unrelated timeout-only failures in existing campaign/production-trace property tests; the focused campaign timeout repro passed when run alone.

Linear: AC-721