### PR TITLE
fix(improve): strip outer markdown code fence before verifier sees output (AC-754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- AC-754: `ImprovementLoop` now peels off an outer markdown code fence (e.g. ` ```lean ... ``` `) when cleaning agent output, so verifiers that compile the output directly (`lake env lean`, `mypy`, `cargo check`, ...) no longer reject otherwise-valid content on the literal fence lines. Applied to both the seed (round 1's input) and the result of every `task.revise_output()` call. The strip is conservative: only the outer wrapper is removed, inner nested fences and unbalanced fences are preserved.
 - AC-750: `ImprovementLoop` no longer fires a misleading `max_score_delta` warning when the previous round was zeroed by the external `--verify-cmd` verifier. The loop now tracks `last_unvetoed_score` separately from `prev_valid_score`; the delta check compares against the last legitimate judge score, while plateau detection still treats consecutive verifier vetoes as a stall.
 - Runtime-session event stores now preserve existing events when saving stale or partial logs, and the TypeScript timeline pairs repeated child-task completions by child session id before falling back to task aliases.
 - Worker commands now clamp concurrency to one for stateful persistent runtimes, and Python runtime-bridge providers close underlying runtimes on shutdown.

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -954,6 +954,8 @@ Provider errors during a streaming run emit a single `{"event":"error","message"
 
 For lean streams pass `--no-ndjson-include-output`: this drops `revision_done` events entirely (their only payload is the output) and never writes the output payload anywhere on stdout. Default is `--ndjson-include-output`.
 
+The output the loop carries through `revision_done`, the judge call, and `--verify-cmd` is already passed through `clean_revision_output`: revision metadata sections (`## Revised Output`, `## Key Changes Made`, etc.) and a single outer markdown code fence (e.g. ` ```lean ... ``` `) are stripped automatically. This means `--verify-cmd <compiler>` doesn't see literal fence lines on round 1 or after any revision (AC-754).
+
 ## TypeScript CLI
 
 The TypeScript package also publishes a narrower `autoctx` CLI for Node.js environments. It focuses on judge-based evaluation, improvement loops, task queueing, worker execution, and MCP serving rather than the full multi-generation control plane:

--- a/autocontext/src/autocontext/execution/improvement_loop.py
+++ b/autocontext/src/autocontext/execution/improvement_loop.py
@@ -150,8 +150,11 @@ class ImprovementLoop:
         loop_start = time.monotonic()
         judge_calls = 0
         rounds: list[RoundResult] = []
-        current_output = initial_output
-        best_output = initial_output
+        # AC-754: strip markdown fence wrappers (and other metadata) from the
+        # seed too, so a fenced seed doesn't break a round-1 verifier run
+        # before any revision has a chance to clean it up.
+        current_output = clean_revision_output(initial_output)
+        best_output = current_output
         best_score = 0.0
         best_round = 1
         judge_failures = 0

--- a/autocontext/src/autocontext/execution/output_cleaner.py
+++ b/autocontext/src/autocontext/execution/output_cleaner.py
@@ -10,6 +10,41 @@ from __future__ import annotations
 import re
 
 
+def _strip_markdown_fence_wrapper(text: str) -> str:
+    """Strip a single outer markdown code fence around the whole output.
+
+    Some LLM providers (notably claude-cli on Lean / Python prompts) return
+    output wrapped in a single ``` ... ``` block, optionally tagged with a
+    language: ``` ```lean ... ``` ```. Verifiers that compile the output
+    directly (`lake env lean`, `mypy`, `cargo check`, ...) choke on the
+    literal fence lines and reject otherwise-valid content. AC-754.
+
+    The strip is conservative: only an outer wrapper that opens on the
+    first non-blank line with ``` (optionally followed by a single language
+    token) AND closes on the last non-blank line with ``` is removed.
+    Unbalanced fences, inline triple-backticks, and nested code blocks
+    inside an outer wrapper are preserved so we never silently mangle
+    content the verifier might actually need.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return text
+    lines = stripped.splitlines()
+    if len(lines) < 2:
+        return text
+    first = lines[0].rstrip()
+    last = lines[-1].rstrip()
+    if not first.startswith("```"):
+        return text
+    lang_token = first[3:]
+    # The opening fence allows at most a single language tag (no whitespace).
+    if lang_token and any(ch.isspace() for ch in lang_token):
+        return text
+    if last != "```":
+        return text
+    return "\n".join(lines[1:-1])
+
+
 def _strip_last_section(text: str, header: str) -> str:
     """Strip from the last occurrence of *header* to the end of *text*.
 
@@ -35,6 +70,9 @@ def clean_revision_output(output: str) -> str:
     - ``## Analysis``, ``## Changes``, ``## Improvements``, ``## Self-Assessment`` sections
       (from the *last* occurrence only, to avoid destroying legitimate content)
     - Trailing "This revision transforms/improves/addresses/fixes..." paragraphs
+    - A single outer markdown code fence (e.g. ``` ```lean ... ``` ```) when
+      the whole output is wrapped in one, so verifiers that compile the
+      content directly do not choke on fence lines (AC-754).
     """
     cleaned = output
 
@@ -61,5 +99,10 @@ def clean_revision_output(output: str) -> str:
         "",
         cleaned,
     )
+
+    # AC-754: peel off an outer markdown fence wrapper after metadata
+    # sections are gone, so a `## Revised Output` header above a fenced
+    # block doesn't prevent the strip.
+    cleaned = _strip_markdown_fence_wrapper(cleaned)
 
     return cleaned.strip()

--- a/autocontext/tests/test_improvement_loop_verifier.py
+++ b/autocontext/tests/test_improvement_loop_verifier.py
@@ -234,6 +234,40 @@ class TestVerifierIntegration:
         assert result.best_score == 1.0
         assert result.met_threshold is True
 
+    def test_fenced_seed_is_stripped_before_verifier_sees_it(self):
+        # AC-754: a markdown-fenced seed must be unwrapped before round 1's
+        # verifier runs, so the verifier never sees the literal ```lang lines.
+        # A picky verifier that fails on any line starting with ``` would
+        # otherwise reject the round; with the fence strip, it passes.
+        script = textwrap.dedent(
+            """
+            import sys
+            data = sys.stdin.read()
+            for line in data.splitlines():
+                if line.lstrip().startswith('```'):
+                    print('found unexpected fence: ' + line, file=sys.stderr)
+                    sys.exit(2)
+            sys.exit(0)
+            """
+        ).strip()
+        no_fence_verifier = OutputVerifier(command=[sys.executable, "-c", script])
+
+        task = _AlwaysPerfectTask()
+        loop = ImprovementLoop(
+            task=task,
+            max_rounds=1,
+            quality_threshold=0.9,
+            output_verifier=no_fence_verifier,
+        )
+        fenced_seed = "```lean\ntheorem foo : 1 = 1 := rfl\n```"
+        result = loop.run(fenced_seed, {})
+
+        # Verifier passed -> effective score not zeroed -> best_score == 1.0.
+        assert result.best_score == 1.0
+        assert result.met_threshold is True
+        # And the stored output should be the unwrapped form.
+        assert result.best_output == "theorem foo : 1 = 1 := rfl"
+
 
 # -- AC-750: max_score_delta warning vs verifier-veto provenance --
 

--- a/autocontext/tests/test_output_cleaner.py
+++ b/autocontext/tests/test_output_cleaner.py
@@ -26,10 +26,7 @@ def test_passthrough_clean_content() -> None:
 
 
 def test_combined_header_analysis_key_changes() -> None:
-    text = (
-        "## Revised Output\n\nGood content\n\n"
-        "**Analysis:**\n- Note\n\n## Key Changes Made\n- Change"
-    )
+    text = "## Revised Output\n\nGood content\n\n**Analysis:**\n- Note\n\n## Key Changes Made\n- Change"
     assert clean_revision_output(text) == "Good content"
 
 
@@ -81,3 +78,58 @@ def test_metadata_only_returns_empty() -> None:
 def test_no_trailing_newline() -> None:
     text = "Clean content"
     assert clean_revision_output(text) == "Clean content"
+
+
+# -- AC-754: strip markdown code fences before verifier sees output --
+
+
+def test_strips_lang_tagged_code_fence_wrapper() -> None:
+    # The common case: claude-cli returns lean wrapped in ```lean ... ```.
+    text = "```lean\ntheorem foo : 1 = 1 := rfl\n```"
+    assert clean_revision_output(text) == "theorem foo : 1 = 1 := rfl"
+
+
+def test_strips_bare_code_fence_wrapper() -> None:
+    # Some prompts elicit a ``` ... ``` block without a language tag.
+    text = "```\nx = 1\nprint(x)\n```"
+    assert clean_revision_output(text) == "x = 1\nprint(x)"
+
+
+def test_strips_fence_wrapper_with_surrounding_whitespace() -> None:
+    # Leading / trailing whitespace around the fence wrapper is common.
+    text = "\n  ```python\nprint('ok')\n```  \n"
+    assert clean_revision_output(text) == "print('ok')"
+
+
+def test_passthrough_when_no_outer_fence() -> None:
+    # Inline ``` markers inside otherwise-unwrapped content must not be
+    # touched. Only an outer wrapper is stripped.
+    text = "Some text with `inline` and ``` not a fence opener inline."
+    assert clean_revision_output(text) == text
+
+
+def test_passthrough_when_only_opening_fence() -> None:
+    # Unbalanced fences are not a "wrapper" and must be preserved (better to
+    # let the verifier complain than silently mangle non-fence content).
+    text = "```lean\ntheorem foo : 1 = 1 := rfl"
+    assert clean_revision_output(text) == "```lean\ntheorem foo : 1 = 1 := rfl"
+
+
+def test_passthrough_when_only_closing_fence() -> None:
+    text = "theorem foo : 1 = 1 := rfl\n```"
+    assert clean_revision_output(text) == "theorem foo : 1 = 1 := rfl\n```"
+
+
+def test_preserves_inner_fences_inside_outer_wrapper() -> None:
+    # If the wrapper holds a doc-string with nested fence markers, only the
+    # outer wrapper is stripped; inner markers stay intact.
+    text = "```markdown\nExample block:\n```python\nx = 1\n```\nEnd.\n```"
+    expected = "Example block:\n```python\nx = 1\n```\nEnd."
+    assert clean_revision_output(text) == expected
+
+
+def test_fence_strip_runs_after_metadata_strip() -> None:
+    # When both metadata and fences are present, the cleaner removes both
+    # in a single pass and returns just the code.
+    text = "## Revised Output\n\n```lean\ntheorem foo : 1 = 1 := rfl\n```\n\n## Key Changes Made\n- did stuff"
+    assert clean_revision_output(text) == "theorem foo : 1 = 1 := rfl"


### PR DESCRIPTION
claude-cli often returns output wrapped in ` ```lang ... ``` ` even when the prompt asks for raw code. Verifiers that compile the output directly (`lake env lean`, `mypy`, `cargo check`, ...) choke on the literal fence lines and reject otherwise-valid content; `effective_score` is zeroed and the near-miss is lost.

## Concrete repros (2026-05-11)

- Step 1A weight-integral Lean sub-lemma: round-2 judge scored 0.93 but the verifier rejected the literal ` ```lean ` line. Manually stripping fences + one trivial rename produced a clean compile.
- ConvexHullTriangle mathlib-master port: autoctx wrote a file with ` ```lean ` at the top and ` ``` ` at the bottom, corrupting the verifier input until restored by hand.

## Fix

New `_strip_markdown_fence_wrapper` in `output_cleaner.py`. Conservative: only removes a single outer wrapper that opens on the first non-blank line with ` ``` ` (optionally with a single language token) AND closes on the last non-blank line with ` ``` `. Unbalanced fences, inline triple-backticks, and fences nested inside an outer wrapper are preserved so we never silently mangle content.

Wired into `clean_revision_output` as the final step, so all existing call sites pick it up automatically. The seed is also cleaned at the top of `loop.run()` so round-1 verifiers don't see a fenced input.

## Tests

- 7 unit cases on the cleaner (lang-tagged wrapper, bare wrapper, surrounding whitespace, inline `` ``` `` passthrough, unbalanced fences passthrough, nested fences preserved, fence strip after metadata strip)
- 1 integration test `test_fenced_seed_is_stripped_before_verifier_sees_it` using a picky verifier that rejects any line starting with ` ``` ` to pin the contract end-to-end through `ImprovementLoop.run`

110 improvement-loop / cleaner / verifier tests pass; ruff + mypy clean.

## Docs

CHANGELOG `[Unreleased] / ### Fixed` entry; `docs/agent-integration.md` notes that the ndjson stream and `--verify-cmd` see the unwrapped output.

## Test plan

- [ ] CI green
- [ ] Re-run a real claude-cli Lean loop with `--verify-cmd 'lake env lean {file}'` and confirm fence-wrapped rounds now pass the verifier