### PR TITLE
Add experimental agent handler runtime surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ANTHROPIC_API_KEY=sk-ant-... \
 uv run autoctx solve "..." --iterations 3
 ```
 
-See [`.env.example`](.env.example) for every provider's variables. Prefer to clone and run a starter? [`examples/README.md`](examples/README.md) has copy-paste recipes for Python CLI, Claude Code MCP, Python SDK, and TypeScript library usage.
+See [`.env.example`](.env.example) for every provider's variables. Prefer to clone and run a starter? [`examples/README.md`](examples/README.md) has copy-paste recipes for Python CLI, Claude Code MCP, Python SDK, TypeScript library usage, and the experimental TypeScript agent handler surface.
 
 ## Or Just Talk To Your Agent
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -175,7 +175,8 @@ export ANTHROPIC_API_KEY=sk-ant-...
 ## Experimental TypeScript Agent Handler
 
 The TypeScript package exposes an experimental `autoctx/agent-runtime` subpath
-for local programmable handlers in `.autoctx/agents/*.ts`. This is an
+for local programmable handlers in `.autoctx/agents/*.ts`. It uses the bundled
+`tsx` loader for `.ts`, `.tsx`, and `.mts` files on Node 18+. This is an
 open-source local authoring surface, not the hosted deployment/orchestration
 layer.
 
@@ -195,7 +196,7 @@ export const triggers = { webhook: true };
 export default async function supportAgent(
   { init, payload }: AutoctxAgentContext<SupportPayload>,
 ) {
-  const runtime = await init({ model: "anthropic/claude-sonnet-4-6" });
+  const runtime = await init();
   const session = await runtime.session(payload.threadId ?? "default");
   return session.prompt(payload.message, { role: "support-triager" });
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ These are copy-paste starting points for people evaluating the repo, integrating
 - Want to wire Claude Code or another MCP client? Use the MCP config snippet.
 - Want a typed Python integration? Use the Python SDK example.
 - Want a Node/TypeScript integration? Use the TypeScript library example.
+- Want to prototype a reusable TypeScript agent handler? Use the experimental agent-runtime example.
 - Want always-on queued work? Use the persistent host worker recipe.
 
 ## Python CLI From Source
@@ -169,6 +170,35 @@ Example provider setup:
 ```bash
 export AUTOCONTEXT_PROVIDER=anthropic
 export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+## Experimental TypeScript Agent Handler
+
+The TypeScript package exposes an experimental `autoctx/agent-runtime` subpath
+for local programmable handlers in `.autoctx/agents/*.ts`. This is an
+open-source local authoring surface, not the hosted deployment/orchestration
+layer.
+
+See [`examples/agent-runtime/.autoctx/agents/support.ts`](agent-runtime/.autoctx/agents/support.ts)
+for a minimal handler:
+
+```ts
+import type { AutoctxAgentContext } from "autoctx/agent-runtime";
+
+type SupportPayload = {
+  threadId?: string;
+  message: string;
+};
+
+export const triggers = { webhook: true };
+
+export default async function supportAgent(
+  { init, payload }: AutoctxAgentContext<SupportPayload>,
+) {
+  const runtime = await init({ model: "anthropic/claude-sonnet-4-6" });
+  const session = await runtime.session(payload.threadId ?? "default");
+  return session.prompt(payload.message, { role: "support-triager" });
+}
 ```
 
 ## Hermes CLI-First Workflow

--- a/examples/agent-runtime/.autoctx/agents/support.ts
+++ b/examples/agent-runtime/.autoctx/agents/support.ts
@@ -1,0 +1,16 @@
+import type { AutoctxAgentContext } from "autoctx/agent-runtime";
+
+type SupportPayload = {
+  threadId?: string;
+  message: string;
+};
+
+export const triggers = { webhook: true };
+
+export default async function supportAgent(
+  { init, payload }: AutoctxAgentContext<SupportPayload>,
+) {
+  const runtime = await init({ model: "anthropic/claude-sonnet-4-6" });
+  const session = await runtime.session(payload.threadId ?? "default");
+  return session.prompt(payload.message, { role: "support-triager" });
+}

--- a/examples/agent-runtime/.autoctx/agents/support.ts
+++ b/examples/agent-runtime/.autoctx/agents/support.ts
@@ -10,7 +10,7 @@ export const triggers = { webhook: true };
 export default async function supportAgent(
   { init, payload }: AutoctxAgentContext<SupportPayload>,
 ) {
-  const runtime = await init({ model: "anthropic/claude-sonnet-4-6" });
+  const runtime = await init();
   const session = await runtime.session(payload.threadId ?? "default");
   return session.prompt(payload.message, { role: "support-triager" });
 }

--- a/ts/README.md
+++ b/ts/README.md
@@ -19,6 +19,7 @@ Need the canonical product/runtime vocabulary first? Start with [docs/concept-mo
 - **Package management**: strategy package export/import, training data export
 - **Training hook surface**: dataset validation and executor-backed `train` entry point
 - **Runtime workspace/session primitives**: workspace-scoped filesystem/shell contracts, scoped command/tool grants with redacted lifecycle events, runtime session event logs, child-task lineage helpers, a runtime-session facade, and AgentRuntime session recording
+- **Experimental agent handler surface** at `autoctx/agent-runtime`: discover and invoke `.autoctx/agents/*.ts` handlers backed by runtime sessions
 - **Production-traces emit SDK** at `autoctx/production-traces` — customer-facing emit APIs mirroring the Python SDK (A2-II-a)
 
 Runtime command grants are host-created capability handles, not prompt text.
@@ -54,6 +55,47 @@ const workspace = await createInMemoryWorkspaceEnv({ cwd: "/repo" }).scope({
 
 const result = await workspace.tools?.[0]?.execute?.({ q: "runtime sessions" });
 await mcpTools.close();
+```
+
+The package also includes an experimental programmable-agent authoring surface
+at `autoctx/agent-runtime`. It discovers handlers from `.autoctx/agents` only
+and avoids colliding with `.autoctx/skills`, scenario directories, or hosted
+deployment concerns. The invoker supplies payload, env, workspace, and an
+`AgentRuntime`; env values are available to trusted handler code but are not
+automatically inserted into prompts.
+
+```ts
+// .autoctx/agents/support.ts
+import type { AutoctxAgentContext } from "autoctx/agent-runtime";
+
+type Payload = { threadId?: string; message: string };
+
+export const triggers = { webhook: true };
+
+export default async function ({ init, payload }: AutoctxAgentContext<Payload>) {
+  const runtime = await init({ model: "anthropic/claude-sonnet-4-6" });
+  const session = await runtime.session(payload.threadId ?? "default");
+  return session.prompt(payload.message, { role: "support-triager" });
+}
+```
+
+```ts
+import {
+  discoverAutoctxAgents,
+  invokeAutoctxAgent,
+  loadAutoctxAgent,
+} from "autoctx/agent-runtime";
+import { createInMemoryWorkspaceEnv } from "autoctx";
+
+const [entry] = await discoverAutoctxAgents({ cwd: process.cwd() });
+const agent = await loadAutoctxAgent(entry);
+
+const result = await invokeAutoctxAgent(agent, {
+  payload: { threadId: "ticket-123", message: "Please triage this ticket." },
+  env: { SUPPORT_TOKEN: process.env.SUPPORT_TOKEN },
+  runtime: myAgentRuntime,
+  workspace: createInMemoryWorkspaceEnv({ cwd: "/repo" }),
+});
 ```
 
 The TypeScript package includes mirrored deterministic semantic prompt

--- a/ts/README.md
+++ b/ts/README.md
@@ -62,7 +62,8 @@ at `autoctx/agent-runtime`. It discovers handlers from `.autoctx/agents` only
 and avoids colliding with `.autoctx/skills`, scenario directories, or hosted
 deployment concerns. The invoker supplies payload, env, workspace, and an
 `AgentRuntime`; env values are available to trusted handler code but are not
-automatically inserted into prompts.
+automatically inserted into prompts. The package uses its bundled `tsx` loader
+for `.ts`, `.tsx`, and `.mts` agent files on Node 18+.
 
 ```ts
 // .autoctx/agents/support.ts
@@ -73,7 +74,7 @@ type Payload = { threadId?: string; message: string };
 export const triggers = { webhook: true };
 
 export default async function ({ init, payload }: AutoctxAgentContext<Payload>) {
-  const runtime = await init({ model: "anthropic/claude-sonnet-4-6" });
+  const runtime = await init();
   const session = await runtime.session(payload.threadId ?? "default");
   return session.prompt(payload.message, { role: "support-triager" });
 }

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -26,6 +26,7 @@
         "tree-sitter-javascript": "0.21.4",
         "tree-sitter-python": "0.21.0",
         "tree-sitter-typescript": "0.21.2",
+        "tsx": "^4.21.0",
         "ulid": "^3.0.2",
         "ws": "^8.18.0",
         "zod": "^3.24.0"
@@ -41,7 +42,6 @@
         "@types/ws": "^8.5.13",
         "fast-check": "^4.7.0",
         "json-schema-to-typescript": "^15.0.4",
-        "tsx": "^4.21.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
       },
@@ -2701,7 +2701,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -2779,7 +2778,6 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -4384,7 +4382,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -5281,7 +5278,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"

--- a/ts/package.json
+++ b/ts/package.json
@@ -85,6 +85,10 @@
       "types": "./dist/runtimes/mcp-runtime-tools.d.ts",
       "import": "./dist/runtimes/mcp-runtime-tools.js"
     },
+    "./agent-runtime": {
+      "types": "./dist/agent-runtime/index.d.ts",
+      "import": "./dist/agent-runtime/index.js"
+    },
     "./detectors/openai-python": {
       "types": "./dist/control-plane/instrument/detectors/openai-python/index.d.ts",
       "import": "./dist/control-plane/instrument/detectors/openai-python/index.js",

--- a/ts/package.json
+++ b/ts/package.json
@@ -171,7 +171,6 @@
     "@types/ws": "^8.5.13",
     "fast-check": "^4.7.0",
     "json-schema-to-typescript": "^15.0.4",
-    "tsx": "^4.21.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
@@ -193,6 +192,7 @@
     "tree-sitter-javascript": "0.21.4",
     "tree-sitter-python": "0.21.0",
     "tree-sitter-typescript": "0.21.2",
+    "tsx": "^4.21.0",
     "ulid": "^3.0.2",
     "ws": "^8.18.0",
     "zod": "^3.24.0"

--- a/ts/src/agent-runtime/index.ts
+++ b/ts/src/agent-runtime/index.ts
@@ -2,6 +2,7 @@ import { promises as fs, type Dirent } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { agentOutputMetadata } from "../runtimes/agent-output-metadata.js";
 import type { AgentOutput, AgentRuntime } from "../runtimes/base.js";
 import {
   createInMemoryWorkspaceEnv,
@@ -69,7 +70,6 @@ export interface AutoctxLoadedAgent<
 
 export interface AutoctxAgentInitOptions {
   runtime?: AgentRuntime;
-  model?: string;
   goal?: string;
   cwd?: string;
   commands?: RuntimeCommandGrant[];
@@ -166,12 +166,12 @@ export async function loadAutoctxAgent<
   entry: AutoctxAgentEntry | string,
 ): Promise<AutoctxLoadedAgent<Payload, Result>> {
   const agentPath = typeof entry === "string" ? path.resolve(entry) : entry.path;
-  const imported = await import(pathToFileURL(agentPath).href);
+  const extension = autoctxAgentExtension(agentPath);
+  const imported = unwrapAgentModule(await importAgentModule(agentPath, extension));
   const handler = imported.default;
   if (!isAutoctxAgentHandler<Payload, Result>(handler)) {
     throw new Error(`AutoContext agent '${agentPath}' must export a default handler function`);
   }
-  const extension = autoctxAgentExtension(agentPath);
   const name = typeof entry === "string"
     ? path.basename(agentPath, extension ?? path.extname(agentPath))
     : entry.name;
@@ -220,7 +220,6 @@ export function createAutoctxAgentContext<
         agent,
         workspace,
         runtime: initOptions.runtime ?? options.runtime,
-        model: initOptions.model,
         cwd: initOptions.cwd,
         commands: [...(options.commands ?? []), ...(initOptions.commands ?? [])],
         tools: [...(options.tools ?? []), ...(initOptions.tools ?? [])],
@@ -236,7 +235,6 @@ interface RuntimeBackedAutoctxAgentOptions {
   agent: AutoctxAgentDescriptor;
   workspace: RuntimeWorkspaceEnv;
   runtime?: AgentRuntime;
-  model?: string;
   goal?: string;
   cwd?: string;
   commands?: RuntimeCommandGrant[];
@@ -250,7 +248,6 @@ class RuntimeBackedAutoctxAgent implements AutoctxAgentRuntime {
   readonly #agent: AutoctxAgentDescriptor;
   readonly #workspace: RuntimeWorkspaceEnv;
   readonly #runtime?: AgentRuntime;
-  readonly #model?: string;
   readonly #goal?: string;
   readonly #cwd?: string;
   readonly #commands: RuntimeCommandGrant[];
@@ -264,7 +261,6 @@ class RuntimeBackedAutoctxAgent implements AutoctxAgentRuntime {
     this.#agent = options.agent;
     this.#workspace = options.workspace;
     this.#runtime = options.runtime;
-    this.#model = options.model;
     this.#goal = options.goal;
     this.#cwd = options.cwd;
     this.#commands = options.commands ?? [];
@@ -293,14 +289,12 @@ class RuntimeBackedAutoctxAgent implements AutoctxAgentRuntime {
         agentName: this.#agent.name,
         agentPath: this.#agent.path,
         agentSessionKey: sessionKey,
-        runtimeModel: this.#model,
         experimentalAgentRuntime: true,
       },
     });
     const handle = new RuntimeBackedAutoctxAgentSession({
       session,
       runtime: this.#runtime,
-      model: this.#model,
       cwd: options.cwd ?? this.#cwd,
       commands: [...this.#commands, ...(options.commands ?? [])],
       tools: [...this.#tools, ...(options.tools ?? [])],
@@ -317,7 +311,6 @@ class RuntimeBackedAutoctxAgent implements AutoctxAgentRuntime {
 class RuntimeBackedAutoctxAgentSession implements AutoctxAgentSession {
   readonly session: RuntimeSession;
   readonly #runtime?: AgentRuntime;
-  readonly #model?: string;
   readonly #cwd?: string;
   readonly #commands: RuntimeCommandGrant[];
   readonly #tools: RuntimeToolGrant[];
@@ -325,14 +318,12 @@ class RuntimeBackedAutoctxAgentSession implements AutoctxAgentSession {
   constructor(options: {
     session: RuntimeSession;
     runtime?: AgentRuntime;
-    model?: string;
     cwd?: string;
     commands?: RuntimeCommandGrant[];
     tools?: RuntimeToolGrant[];
   }) {
     this.session = options.session;
     this.#runtime = options.runtime;
-    this.#model = options.model;
     this.#cwd = options.cwd;
     this.#commands = options.commands ?? [];
     this.#tools = options.tools ?? [];
@@ -360,7 +351,7 @@ class RuntimeBackedAutoctxAgentSession implements AutoctxAgentSession {
         });
         return {
           text: output.text,
-          metadata: agentPromptMetadata(runtime, output, this.#model, this.session.sessionId),
+          metadata: agentPromptMetadata(runtime, output, this.session.sessionId),
         };
       },
     });
@@ -397,9 +388,34 @@ function autoctxAgentExtension(filePath: string): AutoctxAgentExtension | undefi
   return AUTOCTX_AGENT_EXTENSIONS.find((extension) => filePath.endsWith(extension));
 }
 
+async function importAgentModule(
+  agentPath: string,
+  extension: AutoctxAgentExtension | undefined,
+): Promise<Record<string, unknown>> {
+  const agentUrl = pathToFileURL(agentPath).href;
+  if (isTypeScriptAgentExtension(extension)) {
+    const { tsImport } = await import("tsx/esm/api");
+    return await tsImport(agentUrl, { parentURL: import.meta.url });
+  }
+  return await import(agentUrl);
+}
+
+function isTypeScriptAgentExtension(
+  extension: AutoctxAgentExtension | undefined,
+): extension is ".ts" | ".tsx" | ".mts" {
+  return extension === ".ts" || extension === ".tsx" || extension === ".mts";
+}
+
 function readRecord(value: unknown): Record<string, unknown> | undefined {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
   return Object.fromEntries(Object.entries(value));
+}
+
+function unwrapAgentModule(imported: Record<string, unknown>): Record<string, unknown> {
+  if (isAutoctxAgentHandler<unknown, unknown>(imported.default)) return imported;
+  const nested = readRecord(imported.default);
+  if (!nested || !isAutoctxAgentHandler<unknown, unknown>(nested.default)) return imported;
+  return nested;
 }
 
 function isMissingPathError(error: unknown): boolean {
@@ -423,17 +439,10 @@ function toPosixPath(value: string): string {
 function agentPromptMetadata(
   runtime: AgentRuntime,
   output: AgentOutput,
-  model: string | undefined,
   runtimeSessionId: string,
 ): Record<string, unknown> {
   return {
-    ...(output.metadata ?? {}),
-    runtime: runtime.name,
-    model: output.model ?? model,
-    costUsd: output.costUsd,
-    structured: output.structured,
-    runtimeSessionId,
-    providerSessionId: output.sessionId,
+    ...agentOutputMetadata(runtime.name, output, { runtimeSessionId }),
     experimentalAgentRuntime: true,
   };
 }

--- a/ts/src/agent-runtime/index.ts
+++ b/ts/src/agent-runtime/index.ts
@@ -1,0 +1,439 @@
+import { promises as fs, type Dirent } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { AgentOutput, AgentRuntime } from "../runtimes/base.js";
+import {
+  createInMemoryWorkspaceEnv,
+  type RuntimeCommandGrant,
+  type RuntimeToolGrant,
+  type RuntimeWorkspaceEnv,
+} from "../runtimes/workspace-env.js";
+import {
+  RuntimeSession,
+  type RuntimeSessionPromptResult,
+} from "../session/runtime-session.js";
+import type { RuntimeSessionEventStore } from "../session/runtime-events.js";
+import type { RuntimeSessionEventSink } from "../session/runtime-session-notifications.js";
+
+export const AUTOCTX_AGENT_DIR = ".autoctx/agents";
+export const AUTOCTX_AGENT_RUNTIME_EXPERIMENTAL = true;
+
+type AutoctxAgentExtension = ".ts" | ".tsx" | ".mts" | ".js" | ".mjs";
+const AUTOCTX_AGENT_EXTENSIONS: readonly AutoctxAgentExtension[] = [
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".js",
+  ".mjs",
+];
+
+export interface AutoctxAgentDescriptor {
+  name: string;
+  path?: string;
+  relativePath?: string;
+}
+
+export interface AutoctxAgentEntry extends AutoctxAgentDescriptor {
+  path: string;
+  relativePath: string;
+  extension: AutoctxAgentExtension;
+}
+
+export type AutoctxAgentTriggers = Record<string, unknown>;
+export type AutoctxAgentEnv = Record<string, string | undefined>;
+export type MaybePromise<T> = T | Promise<T>;
+
+export interface AutoctxAgentContext<
+  Payload = Record<string, unknown>,
+> {
+  payload: Payload;
+  env: Readonly<AutoctxAgentEnv>;
+  workspace: RuntimeWorkspaceEnv;
+  agent: AutoctxAgentDescriptor;
+  init(options?: AutoctxAgentInitOptions): Promise<AutoctxAgentRuntime>;
+}
+
+export type AutoctxAgentHandler<
+  Payload = Record<string, unknown>,
+  Result = unknown,
+> = (context: AutoctxAgentContext<Payload>) => MaybePromise<Result>;
+
+export interface AutoctxLoadedAgent<
+  Payload = Record<string, unknown>,
+  Result = unknown,
+> extends AutoctxAgentDescriptor {
+  handler: AutoctxAgentHandler<Payload, Result>;
+  triggers?: AutoctxAgentTriggers;
+}
+
+export interface AutoctxAgentInitOptions {
+  runtime?: AgentRuntime;
+  model?: string;
+  goal?: string;
+  cwd?: string;
+  commands?: RuntimeCommandGrant[];
+  tools?: RuntimeToolGrant[];
+  eventStore?: RuntimeSessionEventStore;
+  eventSink?: RuntimeSessionEventSink;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AutoctxAgentSessionOptions {
+  sessionId?: string;
+  goal?: string;
+  cwd?: string;
+  commands?: RuntimeCommandGrant[];
+  tools?: RuntimeToolGrant[];
+  eventStore?: RuntimeSessionEventStore;
+  eventSink?: RuntimeSessionEventSink;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AutoctxAgentPromptOptions {
+  role?: string;
+  cwd?: string;
+  system?: string;
+  schema?: Record<string, unknown>;
+  commands?: RuntimeCommandGrant[];
+  tools?: RuntimeToolGrant[];
+  runtime?: AgentRuntime;
+}
+
+export interface AutoctxAgentSession {
+  readonly session: RuntimeSession;
+  prompt(prompt: string, options?: AutoctxAgentPromptOptions): Promise<RuntimeSessionPromptResult>;
+}
+
+export interface AutoctxAgentRuntime {
+  session(sessionKey?: string, options?: AutoctxAgentSessionOptions): Promise<AutoctxAgentSession>;
+  close(): void;
+}
+
+export interface AutoctxAgentDiscoveryOptions {
+  cwd: string;
+}
+
+export interface AutoctxAgentInvocationOptions<
+  Payload,
+> {
+  payload: Payload;
+  env?: AutoctxAgentEnv;
+  workspace?: RuntimeWorkspaceEnv;
+  runtime?: AgentRuntime;
+  agentName?: string;
+  agentPath?: string;
+  commands?: RuntimeCommandGrant[];
+  tools?: RuntimeToolGrant[];
+  eventStore?: RuntimeSessionEventStore;
+  eventSink?: RuntimeSessionEventSink;
+}
+
+export async function discoverAutoctxAgents(
+  options: AutoctxAgentDiscoveryOptions,
+): Promise<AutoctxAgentEntry[]> {
+  const cwd = path.resolve(options.cwd);
+  const agentDir = path.join(cwd, AUTOCTX_AGENT_DIR);
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(agentDir, { withFileTypes: true });
+  } catch (error) {
+    if (isMissingPathError(error)) return [];
+    throw error;
+  }
+  const agents: AutoctxAgentEntry[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (entry.name.startsWith(".")) continue;
+    if (entry.name.endsWith(".d.ts")) continue;
+    const extension = autoctxAgentExtension(entry.name);
+    if (!extension) continue;
+    const absolutePath = path.join(agentDir, entry.name);
+    agents.push({
+      name: path.basename(entry.name, extension),
+      path: absolutePath,
+      relativePath: toPosixPath(path.relative(cwd, absolutePath)),
+      extension,
+    });
+  }
+  return agents.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export async function loadAutoctxAgent<
+  Payload = Record<string, unknown>,
+  Result = unknown,
+>(
+  entry: AutoctxAgentEntry | string,
+): Promise<AutoctxLoadedAgent<Payload, Result>> {
+  const agentPath = typeof entry === "string" ? path.resolve(entry) : entry.path;
+  const imported = await import(pathToFileURL(agentPath).href);
+  const handler = imported.default;
+  if (!isAutoctxAgentHandler<Payload, Result>(handler)) {
+    throw new Error(`AutoContext agent '${agentPath}' must export a default handler function`);
+  }
+  const extension = autoctxAgentExtension(agentPath);
+  const name = typeof entry === "string"
+    ? path.basename(agentPath, extension ?? path.extname(agentPath))
+    : entry.name;
+  return {
+    name,
+    path: agentPath,
+    relativePath: typeof entry === "string" ? undefined : entry.relativePath,
+    handler,
+    triggers: readRecord(imported.triggers),
+  };
+}
+
+export async function invokeAutoctxAgent<
+  Payload,
+  Result = unknown,
+>(
+  agent: AutoctxLoadedAgent<Payload, Result> | AutoctxAgentHandler<Payload, Result>,
+  options: AutoctxAgentInvocationOptions<Payload>,
+): Promise<Awaited<Result>> {
+  const loaded = normalizeLoadedAgent(agent, options);
+  const context = createAutoctxAgentContext<Payload>({
+    ...options,
+    agentName: loaded.name,
+    agentPath: loaded.path,
+  });
+  return await loaded.handler(context);
+}
+
+export function createAutoctxAgentContext<
+  Payload,
+>(
+  options: AutoctxAgentInvocationOptions<Payload>,
+): AutoctxAgentContext<Payload> {
+  const workspace = options.workspace ?? createInMemoryWorkspaceEnv();
+  const agent: AutoctxAgentDescriptor = {
+    name: options.agentName ?? "agent",
+    path: options.agentPath,
+  };
+  return {
+    payload: options.payload,
+    env: Object.freeze({ ...(options.env ?? {}) }),
+    workspace,
+    agent,
+    init: async (initOptions = {}) =>
+      new RuntimeBackedAutoctxAgent({
+        agent,
+        workspace,
+        runtime: initOptions.runtime ?? options.runtime,
+        model: initOptions.model,
+        cwd: initOptions.cwd,
+        commands: [...(options.commands ?? []), ...(initOptions.commands ?? [])],
+        tools: [...(options.tools ?? []), ...(initOptions.tools ?? [])],
+        eventStore: initOptions.eventStore ?? options.eventStore,
+        eventSink: initOptions.eventSink ?? options.eventSink,
+        metadata: initOptions.metadata,
+        goal: initOptions.goal,
+      }),
+  };
+}
+
+interface RuntimeBackedAutoctxAgentOptions {
+  agent: AutoctxAgentDescriptor;
+  workspace: RuntimeWorkspaceEnv;
+  runtime?: AgentRuntime;
+  model?: string;
+  goal?: string;
+  cwd?: string;
+  commands?: RuntimeCommandGrant[];
+  tools?: RuntimeToolGrant[];
+  eventStore?: RuntimeSessionEventStore;
+  eventSink?: RuntimeSessionEventSink;
+  metadata?: Record<string, unknown>;
+}
+
+class RuntimeBackedAutoctxAgent implements AutoctxAgentRuntime {
+  readonly #agent: AutoctxAgentDescriptor;
+  readonly #workspace: RuntimeWorkspaceEnv;
+  readonly #runtime?: AgentRuntime;
+  readonly #model?: string;
+  readonly #goal?: string;
+  readonly #cwd?: string;
+  readonly #commands: RuntimeCommandGrant[];
+  readonly #tools: RuntimeToolGrant[];
+  readonly #eventStore?: RuntimeSessionEventStore;
+  readonly #eventSink?: RuntimeSessionEventSink;
+  readonly #metadata?: Record<string, unknown>;
+  readonly #sessions = new Map<string, AutoctxAgentSession>();
+
+  constructor(options: RuntimeBackedAutoctxAgentOptions) {
+    this.#agent = options.agent;
+    this.#workspace = options.workspace;
+    this.#runtime = options.runtime;
+    this.#model = options.model;
+    this.#goal = options.goal;
+    this.#cwd = options.cwd;
+    this.#commands = options.commands ?? [];
+    this.#tools = options.tools ?? [];
+    this.#eventStore = options.eventStore;
+    this.#eventSink = options.eventSink;
+    this.#metadata = options.metadata;
+  }
+
+  async session(
+    sessionKey = "default",
+    options: AutoctxAgentSessionOptions = {},
+  ): Promise<AutoctxAgentSession> {
+    const cacheKey = options.sessionId ?? sessionKey;
+    const existing = this.#sessions.get(cacheKey);
+    if (existing) return existing;
+    const session = RuntimeSession.create({
+      sessionId: options.sessionId ?? autoctxAgentSessionId(this.#agent.name, sessionKey),
+      goal: options.goal ?? this.#goal ?? `AutoContext agent ${this.#agent.name}`,
+      workspace: this.#workspace,
+      eventStore: options.eventStore ?? this.#eventStore,
+      eventSink: options.eventSink ?? this.#eventSink,
+      metadata: {
+        ...(this.#metadata ?? {}),
+        ...(options.metadata ?? {}),
+        agentName: this.#agent.name,
+        agentPath: this.#agent.path,
+        agentSessionKey: sessionKey,
+        runtimeModel: this.#model,
+        experimentalAgentRuntime: true,
+      },
+    });
+    const handle = new RuntimeBackedAutoctxAgentSession({
+      session,
+      runtime: this.#runtime,
+      model: this.#model,
+      cwd: options.cwd ?? this.#cwd,
+      commands: [...this.#commands, ...(options.commands ?? [])],
+      tools: [...this.#tools, ...(options.tools ?? [])],
+    });
+    this.#sessions.set(cacheKey, handle);
+    return handle;
+  }
+
+  close(): void {
+    this.#runtime?.close?.();
+  }
+}
+
+class RuntimeBackedAutoctxAgentSession implements AutoctxAgentSession {
+  readonly session: RuntimeSession;
+  readonly #runtime?: AgentRuntime;
+  readonly #model?: string;
+  readonly #cwd?: string;
+  readonly #commands: RuntimeCommandGrant[];
+  readonly #tools: RuntimeToolGrant[];
+
+  constructor(options: {
+    session: RuntimeSession;
+    runtime?: AgentRuntime;
+    model?: string;
+    cwd?: string;
+    commands?: RuntimeCommandGrant[];
+    tools?: RuntimeToolGrant[];
+  }) {
+    this.session = options.session;
+    this.#runtime = options.runtime;
+    this.#model = options.model;
+    this.#cwd = options.cwd;
+    this.#commands = options.commands ?? [];
+    this.#tools = options.tools ?? [];
+  }
+
+  async prompt(
+    prompt: string,
+    options: AutoctxAgentPromptOptions = {},
+  ): Promise<RuntimeSessionPromptResult> {
+    const runtime = options.runtime ?? this.#runtime;
+    if (!runtime) {
+      throw new Error("AutoContext agent session prompt requires an AgentRuntime");
+    }
+    return this.session.submitPrompt({
+      prompt,
+      role: options.role,
+      cwd: options.cwd ?? this.#cwd,
+      commands: [...this.#commands, ...(options.commands ?? [])],
+      tools: [...this.#tools, ...(options.tools ?? [])],
+      handler: async () => {
+        const output = await runtime.generate({
+          prompt,
+          system: options.system,
+          schema: options.schema,
+        });
+        return {
+          text: output.text,
+          metadata: agentPromptMetadata(runtime, output, this.#model, this.session.sessionId),
+        };
+      },
+    });
+  }
+}
+
+function normalizeLoadedAgent<
+  Payload,
+  Result,
+>(
+  agent: AutoctxLoadedAgent<Payload, Result> | AutoctxAgentHandler<Payload, Result>,
+  options: AutoctxAgentInvocationOptions<Payload>,
+): AutoctxLoadedAgent<Payload, Result> {
+  if (typeof agent === "function") {
+    return {
+      name: options.agentName ?? "agent",
+      path: options.agentPath,
+      handler: agent,
+    };
+  }
+  return agent;
+}
+
+function autoctxAgentSessionId(agentName: string, sessionKey: string): string {
+  return `agent:${safeSessionSegment(agentName)}:${safeSessionSegment(sessionKey)}`;
+}
+
+function safeSessionSegment(value: string): string {
+  const normalized = value.trim().replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return normalized || "default";
+}
+
+function autoctxAgentExtension(filePath: string): AutoctxAgentExtension | undefined {
+  return AUTOCTX_AGENT_EXTENSIONS.find((extension) => filePath.endsWith(extension));
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  return Object.fromEntries(Object.entries(value));
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return hasErrorCode(error) && error.code === "ENOENT";
+}
+
+function hasErrorCode(error: unknown): error is { code: unknown } {
+  return typeof error === "object" && error !== null && "code" in error;
+}
+
+function isAutoctxAgentHandler<Payload, Result>(
+  value: unknown,
+): value is AutoctxAgentHandler<Payload, Result> {
+  return typeof value === "function";
+}
+
+function toPosixPath(value: string): string {
+  return value.split(path.sep).join("/");
+}
+
+function agentPromptMetadata(
+  runtime: AgentRuntime,
+  output: AgentOutput,
+  model: string | undefined,
+  runtimeSessionId: string,
+): Record<string, unknown> {
+  return {
+    ...(output.metadata ?? {}),
+    runtime: runtime.name,
+    model: output.model ?? model,
+    costUsd: output.costUsd,
+    structured: output.structured,
+    runtimeSessionId,
+    providerSessionId: output.sessionId,
+    experimentalAgentRuntime: true,
+  };
+}

--- a/ts/src/config/credential-store.ts
+++ b/ts/src/config/credential-store.ts
@@ -37,14 +37,16 @@ export function resolveApiKeyValue(value: string): string {
   return result.trim();
 }
 
-function isLegacyCredentialStore(data: Record<string, unknown>): boolean {
+function isLegacyCredentialStore(
+  data: Record<string, unknown>,
+): data is Record<string, unknown> & { provider: string } {
   return typeof data.provider === "string" && !data.providers;
 }
 
 function readLegacyProviderCredentials(
-  data: Record<string, unknown>,
+  data: Record<string, unknown> & { provider: string },
 ): CredentialStore {
-  const provider = (data.provider as string).trim();
+  const provider = data.provider.trim();
   const credentials: ProviderCredentials = {};
   if (typeof data.apiKey === "string" && data.apiKey.trim()) {
     credentials.apiKey = data.apiKey.trim();

--- a/ts/tests/agent-runtime.test.ts
+++ b/ts/tests/agent-runtime.test.ts
@@ -48,6 +48,23 @@ describe("experimental agent runtime surface", () => {
     ]);
   });
 
+  it("loads discovered TypeScript-family handlers through the bundled loader", async () => {
+    const root = mkdtempSync(join(tmpdir(), "autoctx-tsx-agent-"));
+    mkdirSync(join(root, ".autoctx", "agents"), { recursive: true });
+    writeFileSync(
+      join(root, ".autoctx", "agents", "panel.tsx"),
+      "export const triggers = { ui: true };\nexport default () => 'tsx-agent';\n",
+    );
+
+    const [entry] = await discoverAutoctxAgents({ cwd: root });
+    const loaded = await loadAutoctxAgent(entry!);
+    const result = await invokeAutoctxAgent(loaded, { payload: {} });
+
+    expect(entry?.extension).toBe(".tsx");
+    expect(loaded.triggers).toEqual({ ui: true });
+    expect(result).toBe("tsx-agent");
+  });
+
   it("loads and invokes a typed .autoctx/agents handler through a runtime session", async () => {
     const root = join(import.meta.dirname, "fixtures", "autoctx-agent-project");
     const [entry] = await discoverAutoctxAgents({ cwd: root });
@@ -85,6 +102,14 @@ describe("experimental agent runtime surface", () => {
       runtimeSessionId: "agent:support:ticket-123",
       experimentalAgentRuntime: true,
     });
+    expect(result.sessionLog.events[1]!.payload.metadata).not.toHaveProperty("costUsd");
+    expect(result.sessionLog.events[1]!.payload.metadata).not.toHaveProperty("structured");
+    expect(result.sessionLog.events[1]!.payload.metadata).not.toHaveProperty(
+      "agentRuntimeSessionId",
+    );
+    expect(JSON.stringify(result.sessionLog.events[1]!.payload.metadata)).not.toContain(
+      "undefined",
+    );
     expect(JSON.stringify(result.sessionLog.toJSON())).not.toContain("secret-token");
   });
 });

--- a/ts/tests/agent-runtime.test.ts
+++ b/ts/tests/agent-runtime.test.ts
@@ -1,0 +1,90 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  discoverAutoctxAgents,
+  invokeAutoctxAgent,
+  loadAutoctxAgent,
+} from "../src/agent-runtime/index.js";
+import type { AgentOutput, AgentRuntime } from "../src/runtimes/base.js";
+import { createInMemoryWorkspaceEnv } from "../src/runtimes/workspace-env.js";
+import { RuntimeSessionEventType } from "../src/session/runtime-events.js";
+
+class FakeRuntime implements AgentRuntime {
+  readonly name = "fake-runtime";
+  readonly prompts: string[] = [];
+
+  async generate(opts: { prompt: string }): Promise<AgentOutput> {
+    this.prompts.push(opts.prompt);
+    return { text: `triaged:${opts.prompt}` };
+  }
+
+  async revise(): Promise<AgentOutput> {
+    throw new Error("not used");
+  }
+}
+
+describe("experimental agent runtime surface", () => {
+  it("discovers handlers only from .autoctx/agents", async () => {
+    const root = mkdtempSync(join(tmpdir(), "autoctx-agents-"));
+    mkdirSync(join(root, ".autoctx", "agents"), { recursive: true });
+    mkdirSync(join(root, ".autoctx", "skills"), { recursive: true });
+    mkdirSync(join(root, "scenarios"), { recursive: true });
+    writeFileSync(join(root, ".autoctx", "agents", "support.ts"), "export default () => null;\n");
+    writeFileSync(join(root, ".autoctx", "agents", "admin.mjs"), "export default () => null;\n");
+    writeFileSync(join(root, ".autoctx", "agents", ".hidden.ts"), "export default () => null;\n");
+    writeFileSync(join(root, ".autoctx", "agents", "README.md"), "# ignored\n");
+    writeFileSync(join(root, ".autoctx", "skills", "skill.ts"), "export default () => null;\n");
+    writeFileSync(join(root, "scenarios", "scenario.ts"), "export default () => null;\n");
+
+    const agents = await discoverAutoctxAgents({ cwd: root });
+
+    expect(agents.map((agent) => agent.name)).toEqual(["admin", "support"]);
+    expect(agents.map((agent) => agent.relativePath)).toEqual([
+      ".autoctx/agents/admin.mjs",
+      ".autoctx/agents/support.ts",
+    ]);
+  });
+
+  it("loads and invokes a typed .autoctx/agents handler through a runtime session", async () => {
+    const root = join(import.meta.dirname, "fixtures", "autoctx-agent-project");
+    const [entry] = await discoverAutoctxAgents({ cwd: root });
+    const loaded = await loadAutoctxAgent(entry!);
+    const runtime = new FakeRuntime();
+    const workspace = createInMemoryWorkspaceEnv({ cwd: "/repo" });
+
+    const result = await invokeAutoctxAgent(loaded, {
+      payload: {
+        threadId: "ticket-123",
+        message: "please triage",
+      },
+      env: {
+        SUPPORT_TOKEN: "secret-token",
+      },
+      runtime,
+      workspace,
+    });
+
+    expect(loaded.name).toBe("support");
+    expect(loaded.triggers).toEqual({ webhook: true });
+    expect(runtime.prompts).toEqual(["please triage"]);
+    expect(result).toMatchObject({
+      sessionId: "agent:support:ticket-123",
+      role: "support-triager",
+      text: "triaged:please triage",
+      isError: false,
+    });
+    expect(result.sessionLog.events.map((event) => event.eventType)).toEqual([
+      RuntimeSessionEventType.PROMPT_SUBMITTED,
+      RuntimeSessionEventType.ASSISTANT_MESSAGE,
+    ]);
+    expect(result.sessionLog.events[1]!.payload.metadata).toMatchObject({
+      runtime: "fake-runtime",
+      runtimeSessionId: "agent:support:ticket-123",
+      experimentalAgentRuntime: true,
+    });
+    expect(JSON.stringify(result.sessionLog.toJSON())).not.toContain("secret-token");
+  });
+});

--- a/ts/tests/fixtures/autoctx-agent-project/.autoctx/agents/support.ts
+++ b/ts/tests/fixtures/autoctx-agent-project/.autoctx/agents/support.ts
@@ -1,0 +1,11 @@
+import type { AutoctxAgentContext } from "../../../../../src/agent-runtime/index.js";
+
+export const triggers = { webhook: true };
+
+export default async function supportAgent(
+  { init, payload }: AutoctxAgentContext<{ threadId?: string; message: string }>,
+) {
+  const runtime = await init({ model: "test/fake-runtime" });
+  const session = await runtime.session(payload.threadId ?? "default");
+  return session.prompt(payload.message, { role: "support-triager" });
+}

--- a/ts/tests/fixtures/autoctx-agent-project/.autoctx/agents/support.ts
+++ b/ts/tests/fixtures/autoctx-agent-project/.autoctx/agents/support.ts
@@ -5,7 +5,7 @@ export const triggers = { webhook: true };
 export default async function supportAgent(
   { init, payload }: AutoctxAgentContext<{ threadId?: string; message: string }>,
 ) {
-  const runtime = await init({ model: "test/fake-runtime" });
+  const runtime = await init();
   const session = await runtime.session(payload.threadId ?? "default");
   return session.prompt(payload.message, { role: "support-triager" });
 }

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -106,4 +106,15 @@ describe("package root exports", () => {
       types: "./dist/runtimes/mcp-runtime-tools.d.ts",
     });
   });
+
+  it("publishes the experimental agent runtime handler subpath", () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(import.meta.dirname, "..", "package.json"), "utf-8"),
+    ) as { exports?: Record<string, { import?: string; types?: string }> };
+
+    expect(packageJson.exports?.["./agent-runtime"]).toEqual({
+      import: "./dist/agent-runtime/index.js",
+      types: "./dist/agent-runtime/index.d.ts",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add experimental autoctx/agent-runtime subpath for discovering, loading, and invoking .autoctx/agents handlers
- back handler init/session/prompt with RuntimeSession while keeping env as trusted handler context, not prompt material
- add fixture/example docs and package export coverage; remove one legacy credential parser cast to keep the TS assertion budget flat

## Verification
- npm run lint
- npm test -- agent-runtime.test.ts runtime-session.test.ts runtime-session-agent-runtime.test.ts type-assertions.test.ts package-export-catalogs.test.ts package-boundaries.test.ts --testTimeout=30000
- npm test -- --testTimeout=30000
- git diff --check