### PR TITLE
ci: disable caches in public workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
+env:
+  # Delay fresh npm versions in CI during supply-chain incidents.
+  NPM_CONFIG_MIN_RELEASE_AGE: "7"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -25,7 +32,7 @@ jobs:
         with:
           enable-cache: false
       - name: Install
-        run: uv sync --group dev
+        run: uv sync --locked --group dev
       - name: Ruff
         run: uv run ruff check src tests
       - name: Mypy
@@ -48,7 +55,7 @@ jobs:
         with:
           enable-cache: false
       - name: Install
-        run: uv sync --group dev
+        run: uv sync --locked --group dev
       - name: Tests
         run: uv run pytest --cov=src/autocontext --cov-report=html:htmlcov -m "not live"
       - name: Upload coverage
@@ -75,10 +82,10 @@ jobs:
           enable-cache: false
       - name: Install Python deps
         working-directory: autocontext
-        run: uv sync --group dev
+        run: uv sync --locked --group dev
       - name: Install TypeScript deps
         working-directory: ts
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Python package boundary checks
         working-directory: autocontext
         run: uv run pytest tests/test_package_topology.py tests/test_package_boundaries.py -q
@@ -102,7 +109,7 @@ jobs:
         with:
           enable-cache: false
       - name: Install
-        run: uv sync --group dev
+        run: uv sync --locked --group dev
       - name: Deterministic scenario runs
         env:
           AUTOCONTEXT_AGENT_PROVIDER: deterministic
@@ -150,9 +157,9 @@ jobs:
         with:
           enable-cache: false
       - name: Install base deps
-        run: uv sync --group dev
+        run: uv sync --locked --group dev
       - name: Pin openai to matrix version
-        run: uv pip install "openai==$OPENAI_VERSION"
+        run: uv pip install --exclude-newer 2026-05-05T00:00:00Z "openai==$OPENAI_VERSION"
       - name: Run OpenAI integration tests
         run: uv run pytest tests/production_traces/ tests/integrations/ -q -m "not live"
 
@@ -187,11 +194,11 @@ jobs:
           enable-cache: false
       - name: Install Python parity deps
         working-directory: autocontext
-        run: uv sync --group dev
+        run: uv sync --locked --group dev
       - name: Install base deps
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Pin openai to matrix version
-        run: npm install "openai@$OPENAI_VERSION"
+        run: npm install --ignore-scripts --no-save "openai@$OPENAI_VERSION"
       - name: Run OpenAI integration tests
         run: npm test -- --run --reporter=verbose tests/integrations/ tests/control-plane/instrument/
 
@@ -224,9 +231,9 @@ jobs:
         with:
           enable-cache: false
       - name: Install base deps
-        run: uv sync --group dev
+        run: uv sync --locked --group dev
       - name: Pin anthropic to matrix version
-        run: uv pip install "anthropic==$ANTHROPIC_VERSION"
+        run: uv pip install --exclude-newer 2026-05-05T00:00:00Z "anthropic==$ANTHROPIC_VERSION"
       - name: Run Anthropic integration tests
         run: uv run pytest tests/production_traces/ tests/integrations/ -q -m "not live"
 
@@ -255,11 +262,11 @@ jobs:
           enable-cache: false
       - name: Install Python parity deps
         working-directory: autocontext
-        run: uv sync --group dev
+        run: uv sync --locked --group dev
       - name: Install base deps
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Pin anthropic to matrix version
-        run: npm install "@anthropic-ai/sdk@$ANTHROPIC_VERSION"
+        run: npm install --ignore-scripts --no-save "@anthropic-ai/sdk@$ANTHROPIC_VERSION"
       - name: Run Anthropic integration tests
         run: npm test -- --run --reporter=verbose tests/integrations/ tests/control-plane/instrument/
 
@@ -281,7 +288,7 @@ jobs:
         with:
           enable-cache: false
       - name: Install
-        run: uv sync --group dev
+        run: uv sync --locked --group dev
       - name: Live PrimeIntellect verification
         if: ${{ env.AUTOCONTEXT_PRIMEINTELLECT_API_KEY != '' && env.AUTOCONTEXT_ANTHROPIC_API_KEY != '' }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Install
         run: uv sync --group dev
       - name: Ruff
@@ -46,7 +46,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Install
         run: uv sync --group dev
       - name: Tests
@@ -69,12 +69,10 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
-          cache: "npm"
-          cache-dependency-path: ts/package-lock.json
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Install Python deps
         working-directory: autocontext
         run: uv sync --group dev
@@ -102,7 +100,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Install
         run: uv sync --group dev
       - name: Deterministic scenario runs
@@ -150,7 +148,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Install base deps
         run: uv sync --group dev
       - name: Pin openai to matrix version
@@ -177,8 +175,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
-          cache: "npm"
-          cache-dependency-path: ts/package-lock.json
       - name: Reuse setup-node headers for native addons
         shell: bash
         run: |
@@ -188,7 +184,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Install Python parity deps
         working-directory: autocontext
         run: uv sync --group dev
@@ -226,7 +222,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Install base deps
         run: uv sync --group dev
       - name: Pin anthropic to matrix version
@@ -253,12 +249,10 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
-          cache: "npm"
-          cache-dependency-path: ts/package-lock.json
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Install Python parity deps
         working-directory: autocontext
         run: uv sync --group dev
@@ -285,7 +279,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Install
         run: uv sync --group dev
       - name: Live PrimeIntellect verification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ permissions:
 env:
   # Delay fresh npm versions in CI during supply-chain incidents.
   NPM_CONFIG_MIN_RELEASE_AGE: "7"
+  # Match autocontext/uv.lock so `uv sync --locked` does not re-resolve.
+  UV_EXCLUDE_NEWER: "2026-04-10T14:55:41Z"
 
 jobs:
   lint:

--- a/.github/workflows/publish-pi-autocontext.yml
+++ b/.github/workflows/publish-pi-autocontext.yml
@@ -20,6 +20,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      # Delay fresh npm versions during publish workflow dependency installs.
+      NPM_CONFIG_MIN_RELEASE_AGE: "7"
     defaults:
       run:
         working-directory: pi
@@ -39,7 +42,7 @@ jobs:
             exit 1
           fi
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Show npm version
         run: npm --version
       - name: Lint package
@@ -49,4 +52,4 @@ jobs:
       - name: Build package
         run: npm run build
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: npm publish --ignore-scripts --access public --provenance

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Avoid resolving freshly uploaded PyPI artifacts during active supply-chain incidents.
-      UV_EXCLUDE_NEWER: "2026-05-05T00:00:00Z"
+      UV_EXCLUDE_NEWER: "2026-04-10T14:55:41Z"
     defaults:
       run:
         working-directory: autocontext

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -16,6 +16,9 @@ permissions:
 jobs:
   build-python:
     runs-on: ubuntu-latest
+    env:
+      # Avoid resolving freshly uploaded PyPI artifacts during active supply-chain incidents.
+      UV_EXCLUDE_NEWER: "2026-05-05T00:00:00Z"
     defaults:
       run:
         working-directory: autocontext
@@ -47,7 +50,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Build Python package
         run: uv build
       - name: Upload Python dist

--- a/.github/workflows/publish-ts.yml
+++ b/.github/workflows/publish-ts.yml
@@ -20,6 +20,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      # Delay fresh npm versions during publish workflow dependency installs.
+      NPM_CONFIG_MIN_RELEASE_AGE: "7"
     defaults:
       run:
         working-directory: ts
@@ -39,10 +42,10 @@ jobs:
             exit 1
           fi
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Show npm version
         run: npm --version
       - name: Build package
         run: npm run build
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: npm publish --ignore-scripts --access public --provenance


### PR DESCRIPTION
Disables setup-uv and setup-node caching in public CI to avoid sharing dependency caches with public PR pipelines.