### PR TITLE
Add context selection metrics artifacts

### DIFF
--- a/autocontext/src/autocontext/knowledge/context_selection.py
+++ b/autocontext/src/autocontext/knowledge/context_selection.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import hashlib
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from autocontext.prompts.context_budget import estimate_tokens
+
+SCHEMA_VERSION = 1
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass(frozen=True)
+class ContextSelectionCandidate:
+    """One context artifact considered for a prompt or runtime namespace."""
+
+    artifact_id: str
+    artifact_type: str
+    source: str
+    candidate_token_estimate: int
+    selected_token_estimate: int
+    selected: bool
+    selection_reason: str
+    candidate_content_hash: str
+    selected_content_hash: str = ""
+    useful: bool | None = None
+    freshness_generation_delta: int | None = None
+
+    @classmethod
+    def from_contents(
+        cls,
+        *,
+        artifact_id: str,
+        artifact_type: str,
+        source: str,
+        candidate_content: str,
+        selected_content: str,
+        selection_reason: str,
+        useful: bool | None = None,
+        freshness_generation_delta: int | None = None,
+    ) -> ContextSelectionCandidate:
+        selected = bool(selected_content.strip())
+        return cls(
+            artifact_id=artifact_id,
+            artifact_type=artifact_type,
+            source=source,
+            candidate_token_estimate=estimate_tokens(candidate_content),
+            selected_token_estimate=estimate_tokens(selected_content) if selected else 0,
+            selected=selected,
+            selection_reason=selection_reason,
+            candidate_content_hash=_content_hash(candidate_content),
+            selected_content_hash=_content_hash(selected_content) if selected else "",
+            useful=useful,
+            freshness_generation_delta=freshness_generation_delta,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact_id,
+            "artifact_type": self.artifact_type,
+            "source": self.source,
+            "candidate_token_estimate": self.candidate_token_estimate,
+            "selected_token_estimate": self.selected_token_estimate,
+            "selected": self.selected,
+            "selection_reason": self.selection_reason,
+            "candidate_content_hash": self.candidate_content_hash,
+            "selected_content_hash": self.selected_content_hash,
+            "useful": self.useful,
+            "freshness_generation_delta": self.freshness_generation_delta,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> ContextSelectionCandidate:
+        return cls(
+            artifact_id=str(data.get("artifact_id", "")),
+            artifact_type=str(data.get("artifact_type", "")),
+            source=str(data.get("source", "")),
+            candidate_token_estimate=_coerce_int(data.get("candidate_token_estimate")),
+            selected_token_estimate=_coerce_int(data.get("selected_token_estimate")),
+            selected=bool(data.get("selected", False)),
+            selection_reason=str(data.get("selection_reason", "")),
+            candidate_content_hash=str(data.get("candidate_content_hash", "")),
+            selected_content_hash=str(data.get("selected_content_hash", "")),
+            useful=_coerce_optional_bool(data.get("useful")),
+            freshness_generation_delta=_coerce_optional_int(data.get("freshness_generation_delta")),
+        )
+
+
+@dataclass(frozen=True)
+class ContextSelectionDecision:
+    """Context-selection trace for one run stage."""
+
+    run_id: str
+    scenario_name: str
+    generation: int
+    stage: str
+    candidates: tuple[ContextSelectionCandidate, ...]
+    created_at: str = field(default_factory=_utc_now)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def metrics(self) -> dict[str, Any]:
+        candidates = list(self.candidates)
+        selected = [candidate for candidate in candidates if candidate.selected]
+        useful_candidates = [candidate for candidate in candidates if candidate.useful is True]
+        useful_selected = [candidate for candidate in selected if candidate.useful is True]
+        freshness_values = [
+            candidate.freshness_generation_delta
+            for candidate in selected
+            if candidate.freshness_generation_delta is not None
+        ]
+        duplicate_count = _duplicate_selected_hash_count(selected)
+        useful_recall = (
+            len(useful_selected) / len(useful_candidates)
+            if useful_candidates
+            else None
+        )
+        mean_freshness = (
+            sum(freshness_values) / len(freshness_values)
+            if freshness_values
+            else None
+        )
+        return {
+            "candidate_count": len(candidates),
+            "selected_count": len(selected),
+            "candidate_token_estimate": sum(candidate.candidate_token_estimate for candidate in candidates),
+            "selected_token_estimate": sum(candidate.selected_token_estimate for candidate in selected),
+            "selection_rate": len(selected) / len(candidates) if candidates else 0.0,
+            "duplicate_content_rate": duplicate_count / len(selected) if selected else 0.0,
+            "useful_candidate_count": len(useful_candidates),
+            "useful_selected_count": len(useful_selected),
+            "useful_artifact_recall": useful_recall,
+            "mean_selected_freshness_generation_delta": mean_freshness,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "scenario_name": self.scenario_name,
+            "generation": self.generation,
+            "stage": self.stage,
+            "created_at": self.created_at,
+            "metadata": dict(self.metadata),
+            "metrics": self.metrics(),
+            "candidates": [candidate.to_dict() for candidate in self.candidates],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> ContextSelectionDecision:
+        raw_candidates = data.get("candidates", ())
+        candidate_items = raw_candidates if isinstance(raw_candidates, list | tuple) else ()
+        candidates = (
+            ContextSelectionCandidate.from_dict(candidate)
+            for candidate in candidate_items
+            if isinstance(candidate, Mapping)
+        )
+        raw_metadata = data.get("metadata", {})
+        metadata = (
+            {str(key): value for key, value in raw_metadata.items()}
+            if isinstance(raw_metadata, Mapping)
+            else {}
+        )
+        return cls(
+            run_id=str(data.get("run_id", "")),
+            scenario_name=str(data.get("scenario_name", "")),
+            generation=_coerce_int(data.get("generation")),
+            stage=str(data.get("stage", "")),
+            created_at=str(data.get("created_at", "")),
+            candidates=tuple(candidates),
+            metadata=metadata,
+        )
+
+
+def build_prompt_context_selection_decision(
+    *,
+    run_id: str,
+    scenario_name: str,
+    generation: int,
+    stage: str,
+    candidate_components: Mapping[str, str],
+    selected_components: Mapping[str, str],
+    metadata: Mapping[str, Any] | None = None,
+) -> ContextSelectionDecision:
+    """Create a decision from raw prompt components and retained components."""
+    candidate_names = list(candidate_components)
+    extra_selected_names = [name for name in selected_components if name not in candidate_components]
+    candidates: list[ContextSelectionCandidate] = []
+    for name in [*candidate_names, *extra_selected_names]:
+        candidate_content = str(candidate_components.get(name, ""))
+        selected_content = str(selected_components.get(name, ""))
+        candidates.append(
+            ContextSelectionCandidate.from_contents(
+                artifact_id=name,
+                artifact_type="prompt_component",
+                source="prompt_assembly",
+                candidate_content=candidate_content,
+                selected_content=selected_content,
+                selection_reason=_selection_reason(
+                    candidate_content=candidate_content,
+                    selected_content=selected_content,
+                ),
+            )
+        )
+    return ContextSelectionDecision(
+        run_id=run_id,
+        scenario_name=scenario_name,
+        generation=generation,
+        stage=stage,
+        candidates=tuple(candidates),
+        metadata=dict(metadata or {}),
+    )
+
+
+def _selection_reason(*, candidate_content: str, selected_content: str) -> str:
+    if selected_content.strip():
+        return "retained_after_prompt_assembly"
+    if candidate_content.strip():
+        return "removed_by_prompt_assembly"
+    return "empty_component"
+
+
+def _duplicate_selected_hash_count(candidates: list[ContextSelectionCandidate]) -> int:
+    hashes = [candidate.selected_content_hash for candidate in candidates if candidate.selected_content_hash]
+    return sum(count - 1 for count in Counter(hashes).values() if count > 1)
+
+
+def _content_hash(text: str) -> str:
+    if not text:
+        return ""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _coerce_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _coerce_optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return True
+        if normalized in {"false", "0", "no"}:
+            return False
+    return None

--- a/autocontext/src/autocontext/loop/stage_helpers/semantic_benchmark.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/semantic_benchmark.py
@@ -1,20 +1,25 @@
 from __future__ import annotations
 
+import logging
 import time
 from typing import TYPE_CHECKING, Any
 
 from autocontext.extensions import HookEvents
 from autocontext.knowledge.compaction import CompactionEntry
+from autocontext.knowledge.context_selection import build_prompt_context_selection_decision
 from autocontext.knowledge.semantic_compaction_benchmark import (
     build_semantic_compaction_benchmark_report,
 )
 from autocontext.prompts.templates import PromptBundle, build_prompt_bundle
+from autocontext.storage.context_selection_store import persist_context_selection_decision
 from autocontext.util.json_io import write_json
 
 if TYPE_CHECKING:
     from autocontext.loop.stage_types import GenerationContext
     from autocontext.scenarios.base import Observation
     from autocontext.storage import ArtifactStore
+
+logger = logging.getLogger(__name__)
 
 
 def _latest_compaction_parent_id(artifacts: ArtifactStore, run_id: str) -> str:
@@ -257,42 +262,56 @@ def prepare_generation_prompts(
     }
     prompt_kwargs["compaction_entry_parent_id"] = _latest_compaction_parent_id(artifacts, ctx.run_id)
     prompt_kwargs["compaction_entry_sink"] = lambda entries: _append_compaction_entries_for_context(ctx, artifacts, entries)
+    raw_context_components = _benchmarkable_prompt_components(
+        current_playbook=current_playbook,
+        score_trajectory=score_trajectory,
+        operational_lessons=operational_lessons,
+        available_tools=available_tools,
+        recent_analysis=recent_analysis,
+        analyst_feedback=analyst_feedback,
+        analyst_attribution=analyst_attribution,
+        coach_attribution=coach_attribution,
+        architect_attribution=architect_attribution,
+        coach_competitor_hints=coach_competitor_hints,
+        coach_hint_feedback=coach_hint_feedback,
+        experiment_log=experiment_log,
+        dead_ends=dead_ends,
+        research_protocol=research_protocol,
+        session_reports=session_reports,
+        architect_tool_usage_report=architect_tool_usage_report,
+        environment_snapshot=environment_snapshot,
+        evidence_manifest=evidence_manifest,
+        evidence_manifests=evidence_manifests,
+        notebook_contexts=notebook_contexts,
+    )
+    selected_context_components: dict[str, str] = {}
+    prompt_kwargs["context_component_sink"] = selected_context_components.update
     build_start = time.perf_counter()
     prompts = build_prompt_bundle(**prompt_kwargs)
     semantic_build_latency_ms = (time.perf_counter() - build_start) * 1000.0
+    _persist_generation_context_selection(
+        ctx,
+        artifacts=artifacts,
+        candidate_components=raw_context_components,
+        selected_components=selected_context_components,
+        context_budget_tokens=context_budget_tokens,
+        evidence_cache_hits=evidence_cache_hits,
+        evidence_cache_lookups=evidence_cache_lookups,
+    )
     if not ctx.settings.semantic_compaction_benchmark_enabled:
         return prompts, None
 
     baseline_start = time.perf_counter()
-    budget_only_prompts = build_prompt_bundle(**prompt_kwargs, semantic_compaction=False)
+    baseline_prompt_kwargs = dict(prompt_kwargs)
+    baseline_prompt_kwargs.pop("context_component_sink", None)
+    budget_only_prompts = build_prompt_bundle(**baseline_prompt_kwargs, semantic_compaction=False)
     budget_only_build_latency_ms = (time.perf_counter() - baseline_start) * 1000.0
     benchmark_report = build_semantic_compaction_benchmark_report(
         scenario_name=ctx.scenario_name,
         run_id=ctx.run_id,
         generation=ctx.generation,
         context_budget_tokens=context_budget_tokens,
-        raw_components=_benchmarkable_prompt_components(
-            current_playbook=current_playbook,
-            score_trajectory=score_trajectory,
-            operational_lessons=operational_lessons,
-            available_tools=available_tools,
-            recent_analysis=recent_analysis,
-            analyst_feedback=analyst_feedback,
-            analyst_attribution=analyst_attribution,
-            coach_attribution=coach_attribution,
-            architect_attribution=architect_attribution,
-            coach_competitor_hints=coach_competitor_hints,
-            coach_hint_feedback=coach_hint_feedback,
-            experiment_log=experiment_log,
-            dead_ends=dead_ends,
-            research_protocol=research_protocol,
-            session_reports=session_reports,
-            architect_tool_usage_report=architect_tool_usage_report,
-            environment_snapshot=environment_snapshot,
-            evidence_manifest=evidence_manifest,
-            evidence_manifests=evidence_manifests,
-            notebook_contexts=notebook_contexts,
-        ),
+        raw_components=raw_context_components,
         semantic_prompts=prompts,
         budget_only_prompts=budget_only_prompts,
         semantic_build_latency_ms=semantic_build_latency_ms,
@@ -309,3 +328,33 @@ def prepare_generation_prompts(
     )
     write_json(report_path, report_payload)
     return prompts, report_payload
+
+
+def _persist_generation_context_selection(
+    ctx: GenerationContext,
+    *,
+    artifacts: ArtifactStore,
+    candidate_components: dict[str, str],
+    selected_components: dict[str, str],
+    context_budget_tokens: int,
+    evidence_cache_hits: int,
+    evidence_cache_lookups: int,
+) -> None:
+    decision = build_prompt_context_selection_decision(
+        run_id=ctx.run_id,
+        scenario_name=ctx.scenario_name,
+        generation=ctx.generation,
+        stage="generation_prompt_context",
+        candidate_components=candidate_components,
+        selected_components=selected_components,
+        metadata={
+            "context_budget_tokens": context_budget_tokens,
+            "semantic_compaction": True,
+            "evidence_cache_hits": evidence_cache_hits,
+            "evidence_cache_lookups": evidence_cache_lookups,
+        },
+    )
+    try:
+        persist_context_selection_decision(artifacts, decision)
+    except Exception:
+        logger.debug("failed to persist context selection decision", exc_info=True)

--- a/autocontext/src/autocontext/loop/stage_helpers/semantic_benchmark.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/semantic_benchmark.py
@@ -170,6 +170,45 @@ def _benchmarkable_prompt_components(
     }
 
 
+def _benchmarkable_prompt_components_from_kwargs(prompt_kwargs: dict[str, Any]) -> dict[str, str]:
+    return _benchmarkable_prompt_components(
+        current_playbook=_as_str(prompt_kwargs.get("current_playbook")),
+        score_trajectory=_as_str(prompt_kwargs.get("score_trajectory")),
+        operational_lessons=_as_str(prompt_kwargs.get("operational_lessons")),
+        available_tools=_as_str(prompt_kwargs.get("available_tools")),
+        recent_analysis=_as_str(prompt_kwargs.get("recent_analysis")),
+        analyst_feedback=_as_str(prompt_kwargs.get("analyst_feedback")),
+        analyst_attribution=_as_str(prompt_kwargs.get("analyst_attribution")),
+        coach_attribution=_as_str(prompt_kwargs.get("coach_attribution")),
+        architect_attribution=_as_str(prompt_kwargs.get("architect_attribution")),
+        coach_competitor_hints=_as_str(prompt_kwargs.get("coach_competitor_hints")),
+        coach_hint_feedback=_as_str(prompt_kwargs.get("coach_hint_feedback")),
+        experiment_log=_as_str(prompt_kwargs.get("experiment_log")),
+        dead_ends=_as_str(prompt_kwargs.get("dead_ends")),
+        research_protocol=_as_str(prompt_kwargs.get("research_protocol")),
+        session_reports=_as_str(prompt_kwargs.get("session_reports")),
+        architect_tool_usage_report=_as_str(prompt_kwargs.get("architect_tool_usage_report")),
+        environment_snapshot=_as_str(prompt_kwargs.get("environment_snapshot")),
+        evidence_manifest=_as_str(prompt_kwargs.get("evidence_manifest")),
+        evidence_manifests=_as_str_dict(prompt_kwargs.get("evidence_manifests")),
+        notebook_contexts=_as_str_dict(prompt_kwargs.get("notebook_contexts")),
+    )
+
+
+def _as_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _as_str_dict(value: Any) -> dict[str, str] | None:
+    if not isinstance(value, dict):
+        return None
+    return {
+        str(key): str(item)
+        for key, item in value.items()
+        if isinstance(key, str) and isinstance(item, str)
+    }
+
+
 def prepare_generation_prompts(
     ctx: GenerationContext,
     *,
@@ -262,28 +301,7 @@ def prepare_generation_prompts(
     }
     prompt_kwargs["compaction_entry_parent_id"] = _latest_compaction_parent_id(artifacts, ctx.run_id)
     prompt_kwargs["compaction_entry_sink"] = lambda entries: _append_compaction_entries_for_context(ctx, artifacts, entries)
-    raw_context_components = _benchmarkable_prompt_components(
-        current_playbook=current_playbook,
-        score_trajectory=score_trajectory,
-        operational_lessons=operational_lessons,
-        available_tools=available_tools,
-        recent_analysis=recent_analysis,
-        analyst_feedback=analyst_feedback,
-        analyst_attribution=analyst_attribution,
-        coach_attribution=coach_attribution,
-        architect_attribution=architect_attribution,
-        coach_competitor_hints=coach_competitor_hints,
-        coach_hint_feedback=coach_hint_feedback,
-        experiment_log=experiment_log,
-        dead_ends=dead_ends,
-        research_protocol=research_protocol,
-        session_reports=session_reports,
-        architect_tool_usage_report=architect_tool_usage_report,
-        environment_snapshot=environment_snapshot,
-        evidence_manifest=evidence_manifest,
-        evidence_manifests=evidence_manifests,
-        notebook_contexts=notebook_contexts,
-    )
+    raw_context_components = _benchmarkable_prompt_components_from_kwargs(prompt_kwargs)
     selected_context_components: dict[str, str] = {}
     prompt_kwargs["context_component_sink"] = selected_context_components.update
     build_start = time.perf_counter()
@@ -350,6 +368,7 @@ def _persist_generation_context_selection(
         metadata={
             "context_budget_tokens": context_budget_tokens,
             "semantic_compaction": True,
+            "selected_component_scope": "final_role_prompts_after_context_hook",
             "evidence_cache_hits": evidence_cache_hits,
             "evidence_cache_lookups": evidence_cache_lookups,
         },

--- a/autocontext/src/autocontext/prompts/templates.py
+++ b/autocontext/src/autocontext/prompts/templates.py
@@ -112,6 +112,7 @@ def build_prompt_bundle(
     compaction_entry_context: Mapping[str, Any] | None = None,
     compaction_entry_parent_id: str = "",
     compaction_entry_sink: Callable[[list[CompactionEntry]], None] | None = None,
+    context_component_sink: Callable[[dict[str, str]], None] | None = None,
 ) -> PromptBundle:
     _nb = dict(notebook_contexts or {})
     _evidence = dict(evidence_manifests or {})
@@ -169,35 +170,35 @@ def build_prompt_bundle(
         experiment_log = compacted["experiment_log"]
         research_protocol = compacted["research_protocol"]
         session_reports = compacted["session_reports"]
+    context_components = {
+        "playbook": current_playbook,
+        "trajectory": score_trajectory,
+        "lessons": operational_lessons,
+        "tools": available_tools,
+        "analysis": recent_analysis,
+        "analyst_feedback": analyst_feedback,
+        "analyst_attribution": analyst_attribution,
+        "coach_attribution": coach_attribution,
+        "architect_attribution": architect_attribution,
+        "hints": coach_competitor_hints,
+        "coach_hint_feedback": coach_hint_feedback,
+        "experiment_log": experiment_log,
+        "dead_ends": dead_ends,
+        "research_protocol": research_protocol,
+        "session_reports": session_reports,
+        "tool_usage_report": architect_tool_usage_report,
+        "environment_snapshot": environment_snapshot,
+        "evidence_manifest_analyst": analyst_evidence_manifest,
+        "evidence_manifest_architect": architect_evidence_manifest,
+        "notebook_competitor": _nb.get("competitor", ""),
+        "notebook_analyst": _nb.get("analyst", ""),
+        "notebook_coach": _nb.get("coach", ""),
+        "notebook_architect": _nb.get("architect", ""),
+    }
     if context_budget_tokens > 0:
         budget = ContextBudget(max_tokens=context_budget_tokens)
-        budgeted = budget.apply(
-            {
-                "playbook": current_playbook,
-                "trajectory": score_trajectory,
-                "lessons": operational_lessons,
-                "tools": available_tools,
-                "analysis": recent_analysis,
-                "analyst_feedback": analyst_feedback,
-                "analyst_attribution": analyst_attribution,
-                "coach_attribution": coach_attribution,
-                "architect_attribution": architect_attribution,
-                "hints": coach_competitor_hints,
-                "coach_hint_feedback": coach_hint_feedback,
-                "experiment_log": experiment_log,
-                "dead_ends": dead_ends,
-                "research_protocol": research_protocol,
-                "session_reports": session_reports,
-                "tool_usage_report": architect_tool_usage_report,
-                "environment_snapshot": environment_snapshot,
-                "evidence_manifest_analyst": analyst_evidence_manifest,
-                "evidence_manifest_architect": architect_evidence_manifest,
-                "notebook_competitor": _nb.get("competitor", ""),
-                "notebook_analyst": _nb.get("analyst", ""),
-                "notebook_coach": _nb.get("coach", ""),
-                "notebook_architect": _nb.get("architect", ""),
-            }
-        )
+        budgeted = budget.apply(context_components)
+        context_components = budgeted
         current_playbook = budgeted["playbook"]
         score_trajectory = budgeted["trajectory"]
         operational_lessons = budgeted["lessons"]
@@ -223,6 +224,8 @@ def build_prompt_bundle(
             "coach": budgeted["notebook_coach"],
             "architect": budgeted["notebook_architect"],
         }
+    if context_component_sink is not None:
+        context_component_sink(dict(context_components))
 
     lessons_block = f"Operational lessons (from prior generations):\n{operational_lessons}\n\n" if operational_lessons else ""
     analysis_block = f"Most recent generation analysis:\n{recent_analysis}\n\n" if recent_analysis else ""

--- a/autocontext/src/autocontext/prompts/templates.py
+++ b/autocontext/src/autocontext/prompts/templates.py
@@ -41,6 +41,18 @@ def _prompt_bundle_from_roles(roles: dict[str, Any], fallback: PromptBundle) -> 
     )
 
 
+def _selected_context_components(
+    components: Mapping[str, Any],
+    roles: Mapping[str, str],
+) -> dict[str, str]:
+    role_text = "\n\n".join(roles.values())
+    return {
+        key: value
+        for key, value in components.items()
+        if isinstance(value, str) and value.strip() and value in role_text
+    }
+
+
 # Analyst/architect constraint bullets shared with rlm/prompts.py — keep in sync
 _COMPETITOR_CONSTRAINT_SUFFIX = (
     "\n\nConstraints:\n"
@@ -224,9 +236,6 @@ def build_prompt_bundle(
             "coach": budgeted["notebook_coach"],
             "architect": budgeted["notebook_architect"],
         }
-    if context_component_sink is not None:
-        context_component_sink(dict(context_components))
-
     lessons_block = f"Operational lessons (from prior generations):\n{operational_lessons}\n\n" if operational_lessons else ""
     analysis_block = f"Most recent generation analysis:\n{recent_analysis}\n\n" if recent_analysis else ""
     analyst_feedback_block = f"{analyst_feedback.strip()}\n\n" if analyst_feedback else ""
@@ -352,20 +361,27 @@ def build_prompt_bundle(
             "If no harness mutations, omit the MUTATIONS markers entirely."
         ),
     )
-    if hook_bus is None:
-        return bundle
-    context_event = hook_bus.emit(
-        HookEvents.CONTEXT,
-        {
-            "roles": _prompt_bundle_roles(bundle),
-            "stage": "after_prompt_bundle",
-        },
-    )
-    context_event.raise_if_blocked()
-    maybe_roles = context_event.payload.get("roles")
-    if not isinstance(maybe_roles, dict):
-        return bundle
-    return _prompt_bundle_from_roles(maybe_roles, bundle)
+    final_bundle = bundle
+    if hook_bus is not None:
+        context_event = hook_bus.emit(
+            HookEvents.CONTEXT,
+            {
+                "roles": _prompt_bundle_roles(bundle),
+                "stage": "after_prompt_bundle",
+            },
+        )
+        context_event.raise_if_blocked()
+        maybe_roles = context_event.payload.get("roles")
+        if isinstance(maybe_roles, dict):
+            final_bundle = _prompt_bundle_from_roles(maybe_roles, bundle)
+    if context_component_sink is not None:
+        context_component_sink(
+            _selected_context_components(
+                context_components,
+                _prompt_bundle_roles(final_bundle),
+            )
+        )
+    return final_bundle
 
 
 def code_strategy_competitor_suffix(strategy_interface: str) -> str:

--- a/autocontext/src/autocontext/storage/context_selection_store.py
+++ b/autocontext/src/autocontext/storage/context_selection_store.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from autocontext.knowledge.context_selection import ContextSelectionDecision
+from autocontext.storage.run_paths import resolve_run_root
+
+if TYPE_CHECKING:
+    from autocontext.storage.artifacts import ArtifactStore
+
+_SAFE_STAGE_RE = re.compile(r"[A-Za-z0-9_.-]+")
+
+
+def context_selection_decision_path(
+    runs_root: Path,
+    decision: ContextSelectionDecision,
+) -> Path:
+    run_root = resolve_run_root(runs_root, decision.run_id)
+    if decision.generation < 0:
+        raise ValueError(f"generation must be non-negative: {decision.generation!r}")
+    if not _SAFE_STAGE_RE.fullmatch(decision.stage):
+        raise ValueError(f"stage must be a single safe path segment: {decision.stage!r}")
+    return run_root / "context_selection" / f"gen_{decision.generation}_{decision.stage}.json"
+
+
+def persist_context_selection_decision(
+    artifacts: ArtifactStore,
+    decision: ContextSelectionDecision,
+) -> Path:
+    path = context_selection_decision_path(artifacts.runs_root, decision)
+    artifacts.write_json(path, decision.to_dict())
+    return path

--- a/autocontext/tests/test_context_selection.py
+++ b/autocontext/tests/test_context_selection.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
 from autocontext.config.settings import AppSettings
+from autocontext.extensions import HookBus, HookEvents, HookResult
 from autocontext.loop.stage_helpers.semantic_benchmark import prepare_generation_prompts
 from autocontext.loop.stage_types import GenerationContext
 from autocontext.scenarios.base import Observation, ScenarioInterface
@@ -20,6 +21,73 @@ def _artifact_store(tmp_path: Path) -> ArtifactStore:
         tmp_path / "skills",
         tmp_path / ".claude" / "skills",
     )
+
+
+def _generation_context(tmp_path: Path, *, hook_bus: HookBus | None = None) -> tuple[ArtifactStore, GenerationContext]:
+    artifacts = _artifact_store(tmp_path)
+    settings = AppSettings(
+        runs_root=artifacts.runs_root,
+        knowledge_root=artifacts.knowledge_root,
+        skills_root=artifacts.skills_root,
+        claude_skills_path=artifacts.claude_skills_path,
+    )
+    return artifacts, GenerationContext(
+        run_id="run-1",
+        scenario_name="grid_ctf",
+        scenario=cast(ScenarioInterface, object()),
+        generation=2,
+        settings=settings,
+        previous_best=0.4,
+        challenger_elo=1000.0,
+        score_history=[],
+        gate_decision_history=[],
+        coach_competitor_hints="hint text",
+        replay_narrative="",
+        hook_bus=hook_bus,
+    )
+
+
+def _prepare_generation_prompts(ctx: GenerationContext, artifacts: ArtifactStore, *, current_playbook: str = "abcd") -> None:
+    prepare_generation_prompts(
+        ctx,
+        artifacts=artifacts,
+        scenario_rules="rules",
+        strategy_interface="interface",
+        evaluation_criteria="criteria",
+        previous_summary="summary",
+        observation=Observation(narrative="obs", state={}, constraints=[]),
+        current_playbook=current_playbook,
+        available_tools="efgh",
+        operational_lessons="abcd",
+        replay_narrative="",
+        coach_competitor_hints="hint text",
+        coach_hint_feedback="",
+        recent_analysis="",
+        analyst_feedback="",
+        analyst_attribution="",
+        coach_attribution="",
+        architect_attribution="",
+        score_trajectory="",
+        strategy_registry="",
+        progress_json="",
+        experiment_log="",
+        dead_ends="",
+        research_protocol="",
+        session_reports="",
+        architect_tool_usage_report="",
+        constraint_mode=False,
+        context_budget_tokens=0,
+        notebook_contexts=None,
+        environment_snapshot="",
+        evidence_manifest="",
+        evidence_manifests=None,
+        evidence_cache_hits=0,
+        evidence_cache_lookups=0,
+    )
+
+
+def _context_selection_payload(artifacts: ArtifactStore) -> dict[str, Any]:
+    return read_json(artifacts.runs_root / "run-1" / "context_selection" / "gen_2_generation_prompt_context.json")
 
 
 def test_context_selection_decision_calculates_selection_quality_metrics() -> None:
@@ -182,68 +250,49 @@ def test_persist_context_selection_decision_rejects_unsafe_names(tmp_path: Path)
 
 
 def test_prepare_generation_prompts_persists_context_selection_artifact(tmp_path: Path) -> None:
-    artifacts = _artifact_store(tmp_path)
-    settings = AppSettings(
-        runs_root=artifacts.runs_root,
-        knowledge_root=artifacts.knowledge_root,
-        skills_root=artifacts.skills_root,
-        claude_skills_path=artifacts.claude_skills_path,
-    )
-    ctx = GenerationContext(
-        run_id="run-1",
-        scenario_name="grid_ctf",
-        scenario=cast(ScenarioInterface, object()),
-        generation=2,
-        settings=settings,
-        previous_best=0.4,
-        challenger_elo=1000.0,
-        score_history=[],
-        gate_decision_history=[],
-        coach_competitor_hints="hint text",
-        replay_narrative="",
-    )
+    artifacts, ctx = _generation_context(tmp_path)
 
-    prepare_generation_prompts(
-        ctx,
-        artifacts=artifacts,
-        scenario_rules="rules",
-        strategy_interface="interface",
-        evaluation_criteria="criteria",
-        previous_summary="summary",
-        observation=Observation(narrative="obs", state={}, constraints=[]),
-        current_playbook="abcd",
-        available_tools="efgh",
-        operational_lessons="abcd",
-        replay_narrative="",
-        coach_competitor_hints="hint text",
-        coach_hint_feedback="",
-        recent_analysis="",
-        analyst_feedback="",
-        analyst_attribution="",
-        coach_attribution="",
-        architect_attribution="",
-        score_trajectory="",
-        strategy_registry="",
-        progress_json="",
-        experiment_log="",
-        dead_ends="",
-        research_protocol="",
-        session_reports="",
-        architect_tool_usage_report="",
-        constraint_mode=False,
-        context_budget_tokens=0,
-        notebook_contexts=None,
-        environment_snapshot="",
-        evidence_manifest="",
-        evidence_manifests=None,
-        evidence_cache_hits=0,
-        evidence_cache_lookups=0,
-    )
+    _prepare_generation_prompts(ctx, artifacts)
 
-    payload = read_json(artifacts.runs_root / "run-1" / "context_selection" / "gen_2_generation_prompt_context.json")
+    payload = _context_selection_payload(artifacts)
 
     assert payload["run_id"] == "run-1"
     assert payload["stage"] == "generation_prompt_context"
     assert payload["metrics"]["selected_count"] >= 3
     assert payload["metrics"]["selected_token_estimate"] > 0
     assert payload["metrics"]["duplicate_content_rate"] > 0
+
+
+def test_context_selection_candidates_reflect_context_components_hook(tmp_path: Path) -> None:
+    bus = HookBus()
+    expanded_playbook = "x" * 400
+
+    def expand_playbook(event: Any) -> HookResult:
+        components = dict(event.payload["components"])
+        components["current_playbook"] = expanded_playbook
+        return HookResult(payload={"components": components})
+
+    bus.on(HookEvents.CONTEXT_COMPONENTS, expand_playbook)
+    artifacts, ctx = _generation_context(tmp_path, hook_bus=bus)
+
+    _prepare_generation_prompts(ctx, artifacts, current_playbook="abcd")
+
+    payload = _context_selection_payload(artifacts)
+    playbook = next(candidate for candidate in payload["candidates"] if candidate["artifact_id"] == "playbook")
+    assert playbook["candidate_token_estimate"] == 100
+
+
+def test_context_selection_selected_components_reflect_final_context_hook(tmp_path: Path) -> None:
+    bus = HookBus()
+
+    def redact_roles(event: Any) -> HookResult:
+        return HookResult(payload={"roles": {role: "redacted" for role in event.payload["roles"]}})
+
+    bus.on(HookEvents.CONTEXT, redact_roles)
+    artifacts, ctx = _generation_context(tmp_path, hook_bus=bus)
+
+    _prepare_generation_prompts(ctx, artifacts)
+
+    payload = _context_selection_payload(artifacts)
+    assert payload["metrics"]["candidate_count"] > 0
+    assert payload["metrics"]["selected_count"] == 0

--- a/autocontext/tests/test_context_selection.py
+++ b/autocontext/tests/test_context_selection.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from autocontext.config.settings import AppSettings
+from autocontext.loop.stage_helpers.semantic_benchmark import prepare_generation_prompts
+from autocontext.loop.stage_types import GenerationContext
+from autocontext.scenarios.base import Observation, ScenarioInterface
+from autocontext.storage.artifacts import ArtifactStore
+from autocontext.util.json_io import read_json
+
+
+def _artifact_store(tmp_path: Path) -> ArtifactStore:
+    return ArtifactStore(
+        tmp_path / "runs",
+        tmp_path / "knowledge",
+        tmp_path / "skills",
+        tmp_path / ".claude" / "skills",
+    )
+
+
+def test_context_selection_decision_calculates_selection_quality_metrics() -> None:
+    from autocontext.knowledge.context_selection import (
+        ContextSelectionCandidate,
+        ContextSelectionDecision,
+    )
+
+    duplicate_content = "abcdefgh"
+    decision = ContextSelectionDecision(
+        run_id="run-1",
+        scenario_name="grid_ctf",
+        generation=3,
+        stage="prompt_context",
+        created_at="2026-01-02T03:04:05+00:00",
+        candidates=(
+            ContextSelectionCandidate.from_contents(
+                artifact_id="playbook",
+                artifact_type="prompt_component",
+                source="knowledge",
+                candidate_content=duplicate_content,
+                selected_content=duplicate_content,
+                selection_reason="retained",
+                useful=True,
+                freshness_generation_delta=1,
+            ),
+            ContextSelectionCandidate.from_contents(
+                artifact_id="lessons",
+                artifact_type="prompt_component",
+                source="knowledge",
+                candidate_content=duplicate_content,
+                selected_content=duplicate_content,
+                selection_reason="retained",
+                freshness_generation_delta=2,
+            ),
+            ContextSelectionCandidate.from_contents(
+                artifact_id="analysis",
+                artifact_type="prompt_component",
+                source="knowledge",
+                candidate_content="ijklmnop",
+                selected_content="",
+                selection_reason="empty after budget",
+                useful=True,
+            ),
+            ContextSelectionCandidate.from_contents(
+                artifact_id="tools",
+                artifact_type="prompt_component",
+                source="knowledge",
+                candidate_content="qrst",
+                selected_content="qrst",
+                selection_reason="retained",
+            ),
+        ),
+    )
+
+    metrics = decision.metrics()
+
+    assert metrics["candidate_count"] == 4
+    assert metrics["selected_count"] == 3
+    assert metrics["candidate_token_estimate"] == 7
+    assert metrics["selected_token_estimate"] == 5
+    assert metrics["selection_rate"] == pytest.approx(0.75)
+    assert metrics["duplicate_content_rate"] == pytest.approx(1 / 3)
+    assert metrics["useful_candidate_count"] == 2
+    assert metrics["useful_selected_count"] == 1
+    assert metrics["useful_artifact_recall"] == pytest.approx(0.5)
+    assert metrics["mean_selected_freshness_generation_delta"] == pytest.approx(1.5)
+
+
+def test_context_selection_decision_round_trips_without_prompt_content() -> None:
+    from autocontext.knowledge.context_selection import (
+        ContextSelectionCandidate,
+        ContextSelectionDecision,
+    )
+
+    decision = ContextSelectionDecision(
+        run_id="run-1",
+        scenario_name="grid_ctf",
+        generation=2,
+        stage="prompt_context",
+        created_at="2026-01-02T03:04:05+00:00",
+        candidates=(
+            ContextSelectionCandidate.from_contents(
+                artifact_id="playbook",
+                artifact_type="prompt_component",
+                source="knowledge",
+                candidate_content="secret strategy text",
+                selected_content="secret",
+                selection_reason="trimmed",
+            ),
+        ),
+        metadata={"context_budget_tokens": 1200},
+    )
+
+    payload = decision.to_dict()
+    restored = ContextSelectionDecision.from_dict(payload)
+
+    assert restored == decision
+    assert "secret strategy text" not in str(payload)
+    assert payload["metrics"]["selected_token_estimate"] == 1
+
+
+def test_persist_context_selection_decision_writes_under_run_root(tmp_path: Path) -> None:
+    from autocontext.knowledge.context_selection import (
+        ContextSelectionCandidate,
+        ContextSelectionDecision,
+    )
+    from autocontext.storage.context_selection_store import persist_context_selection_decision
+
+    artifacts = _artifact_store(tmp_path)
+    decision = ContextSelectionDecision(
+        run_id="run-1",
+        scenario_name="grid_ctf",
+        generation=4,
+        stage="prompt_context",
+        created_at="2026-01-02T03:04:05+00:00",
+        candidates=(
+            ContextSelectionCandidate.from_contents(
+                artifact_id="playbook",
+                artifact_type="prompt_component",
+                source="knowledge",
+                candidate_content="abcd",
+                selected_content="abcd",
+                selection_reason="retained",
+            ),
+        ),
+    )
+
+    path = persist_context_selection_decision(artifacts, decision)
+
+    assert path == artifacts.runs_root / "run-1" / "context_selection" / "gen_4_prompt_context.json"
+    assert read_json(path)["metrics"]["selected_count"] == 1
+
+
+def test_persist_context_selection_decision_rejects_unsafe_names(tmp_path: Path) -> None:
+    from autocontext.knowledge.context_selection import ContextSelectionDecision
+    from autocontext.storage.context_selection_store import persist_context_selection_decision
+
+    artifacts = _artifact_store(tmp_path)
+    unsafe_run = ContextSelectionDecision(
+        run_id="../outside",
+        scenario_name="grid_ctf",
+        generation=1,
+        stage="prompt_context",
+        candidates=(),
+    )
+    unsafe_stage = ContextSelectionDecision(
+        run_id="run-1",
+        scenario_name="grid_ctf",
+        generation=1,
+        stage="../prompt_context",
+        candidates=(),
+    )
+
+    with pytest.raises(ValueError):
+        persist_context_selection_decision(artifacts, unsafe_run)
+    with pytest.raises(ValueError):
+        persist_context_selection_decision(artifacts, unsafe_stage)
+    assert not (tmp_path / "outside").exists()
+
+
+def test_prepare_generation_prompts_persists_context_selection_artifact(tmp_path: Path) -> None:
+    artifacts = _artifact_store(tmp_path)
+    settings = AppSettings(
+        runs_root=artifacts.runs_root,
+        knowledge_root=artifacts.knowledge_root,
+        skills_root=artifacts.skills_root,
+        claude_skills_path=artifacts.claude_skills_path,
+    )
+    ctx = GenerationContext(
+        run_id="run-1",
+        scenario_name="grid_ctf",
+        scenario=cast(ScenarioInterface, object()),
+        generation=2,
+        settings=settings,
+        previous_best=0.4,
+        challenger_elo=1000.0,
+        score_history=[],
+        gate_decision_history=[],
+        coach_competitor_hints="hint text",
+        replay_narrative="",
+    )
+
+    prepare_generation_prompts(
+        ctx,
+        artifacts=artifacts,
+        scenario_rules="rules",
+        strategy_interface="interface",
+        evaluation_criteria="criteria",
+        previous_summary="summary",
+        observation=Observation(narrative="obs", state={}, constraints=[]),
+        current_playbook="abcd",
+        available_tools="efgh",
+        operational_lessons="abcd",
+        replay_narrative="",
+        coach_competitor_hints="hint text",
+        coach_hint_feedback="",
+        recent_analysis="",
+        analyst_feedback="",
+        analyst_attribution="",
+        coach_attribution="",
+        architect_attribution="",
+        score_trajectory="",
+        strategy_registry="",
+        progress_json="",
+        experiment_log="",
+        dead_ends="",
+        research_protocol="",
+        session_reports="",
+        architect_tool_usage_report="",
+        constraint_mode=False,
+        context_budget_tokens=0,
+        notebook_contexts=None,
+        environment_snapshot="",
+        evidence_manifest="",
+        evidence_manifests=None,
+        evidence_cache_hits=0,
+        evidence_cache_lookups=0,
+    )
+
+    payload = read_json(artifacts.runs_root / "run-1" / "context_selection" / "gen_2_generation_prompt_context.json")
+
+    assert payload["run_id"] == "run-1"
+    assert payload["stage"] == "generation_prompt_context"
+    assert payload["metrics"]["selected_count"] >= 3
+    assert payload["metrics"]["selected_token_estimate"] > 0
+    assert payload["metrics"]["duplicate_content_rate"] > 0


### PR DESCRIPTION
## Summary
- add a context-selection domain model that records candidate/selected token estimates, duplicate selected content rate, useful-artifact recall fields, and freshness metrics without storing raw prompt text
- persist one generation prompt-context decision artifact under the run root with safe run/stage path handling
- expose the final prompt context components from prompt assembly so metrics reflect compaction/budget retention, while reusing the same raw component collection used by the semantic benchmark

## Verification
- uv run --frozen ruff check src tests
- uv run --frozen mypy src
- uv run --frozen pytest tests/test_context_selection.py tests/test_semantic_compaction_benchmark.py
- uv run --frozen pytest tests/test_build_prompt_bundle_semantic_compaction.py tests/test_generation_stages.py tests/test_runtime_session_run_wiring.py tests/test_context_selection.py
- uv run --frozen pytest (6356 passed, 42 skipped)