### PR TITLE
Improve external-eval verifier signal detection

### DIFF
--- a/ts/src/control-plane/external-evals/index.ts
+++ b/ts/src/control-plane/external-evals/index.ts
@@ -705,14 +705,22 @@ function isSetupEnvironmentFailure(verifierOutput: string): boolean {
 }
 
 function isVerifierContractMismatch(verifierOutput: string): boolean {
-  return [
+  const contractMismatchSignatures = [
     "missing required",
     "required fields",
     "not configured",
     "could not find",
     "no such file or directory",
     "can't open file",
-  ].some((signature) => verifierOutput.includes(signature));
+  ];
+  return (
+    contractMismatchSignatures.some((signature) => verifierOutput.includes(signature)) ||
+    hasArtifactExistenceFailure(verifierOutput)
+  );
+}
+
+function hasArtifactExistenceFailure(text: string): boolean {
+  return artifactExistenceFailurePatterns.some((pattern) => pattern.test(text));
 }
 
 function diagnosticConfidence(
@@ -1222,14 +1230,7 @@ function detectImprovementSignalKinds(
   ].join("\n"));
   const kinds = new Set<ExternalEvalImprovementSignalKind>();
 
-  if (
-    /(?:test_[a-z0-9_]*(?:file|artifact|output)(?:_[a-z0-9]+)*|(?:file|artifact|output)_exists)["']?\s*[:=]\s*["']?failed/.test(
-      text,
-    ) ||
-    /missing.{0,60}(?:file|artifact|output)/.test(text) ||
-    /(?:model|tokenizer|vocab|artifact|output)?\s*file\s+["']?[a-z0-9_.\-/]+["']?\s+not found/.test(text) ||
-    /(?:artifact|output|model|tokenizer|vocab)[^,\n}]{0,80}not found/.test(text)
-  ) {
+  if (hasRequiredArtifactContractSignal(text)) {
     kinds.add("required-artifact-contract");
   }
   if (
@@ -1263,7 +1264,10 @@ function detectImprovementSignalKinds(
   }
   if (
     /(?:compile|compiles|compilation|build|linker|gcc|rustc)[^,\n}]{0,120}failed/.test(text) ||
-    /failed[^,\n}]{0,120}(?:compile|compiles|compilation|build|linker|gcc|rustc)/.test(text)
+    /failed[^,\n}]{0,120}(?:compile|compiles|compilation|build|linker|gcc|rustc)/.test(text) ||
+    /(?:script|macro|command|program|source)[^,\n}]{0,120}(?:well-formed|malformed|syntax|parse)/.test(text) ||
+    /(?:syntax|parse)[^,\n}]{0,120}(?:error|failed|failure)/.test(text) ||
+    /missing\s+:(?:wq|x)\b/.test(text)
   ) {
     kinds.add("exact-verifier-command");
   }
@@ -1272,6 +1276,25 @@ function detectImprovementSignalKinds(
   }
 
   return improvementSignalKindOrder.filter((kind) => kinds.has(kind));
+}
+
+const artifactExistenceFailurePatterns: readonly RegExp[] = [
+  /\b(?:required\s+)?(?:model|tokenizer|vocab|artifact|output|result|submission)?\s*file\s+["']?[a-z0-9_.\-/]+["']?\s+does not exist\b/,
+  /\b(?:required\s+)?(?:model|tokenizer|vocab|artifact|output|result|submission)?\s*file\s+does not exist\s+at\s+["']?[a-z0-9_.\-/]+["']?/,
+  /\bpath\s+["']?[a-z0-9_.\-/]+["']?\s+does not exist\b/,
+  /\b(?:artifact|output|result|submission|model|tokenizer|vocab)[^,\n}]{0,80}\bdoes not exist\b/,
+];
+
+function hasRequiredArtifactContractSignal(text: string): boolean {
+  return (
+    hasArtifactExistenceFailure(text) ||
+    /(?:test_[a-z0-9_]*(?:file|artifact|output)(?:_[a-z0-9]+)*|(?:file|artifact|output)_exists)["']?\s*[:=]\s*["']?failed/.test(
+      text,
+    ) ||
+    /missing.{0,60}(?:file|artifact|output)/.test(text) ||
+    /(?:model|tokenizer|vocab|artifact|output)?\s*file\s+["']?[a-z0-9_.\-/]+["']?\s+not found/.test(text) ||
+    /(?:artifact|output|model|tokenizer|vocab)[^,\n}]{0,80}not found/.test(text)
+  );
 }
 
 function improvementSignalMetadata(kind: ExternalEvalImprovementSignalKind): Omit<

--- a/ts/tests/control-plane/external-evals/diagnostics.test.ts
+++ b/ts/tests/control-plane/external-evals/diagnostics.test.ts
@@ -621,6 +621,128 @@ describe("external eval diagnostics", () => {
     expect(validateOperationalMemoryPack(pack)).toEqual({ valid: true });
   });
 
+  test("derives reusable signals from natural-language verifier failures", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-natural-language-verifier",
+      createdAt: "2026-05-11T20:00:00.000Z",
+      trials: [
+        {
+          taskId: "artifact-path-task",
+          trialId: "artifact-path-task.1-of-1.tb-natural-language-verifier",
+          attempt: 1,
+          status: "failed",
+          reward: 0,
+        },
+        {
+          taskId: "generated-script-task",
+          trialId: "generated-script-task.1-of-1.tb-natural-language-verifier",
+          attempt: 1,
+          status: "failed",
+          reward: 0,
+        },
+      ],
+      evidence: [
+        {
+          trialId: "artifact-path-task.1-of-1.tb-natural-language-verifier",
+          evidenceRefs: ["artifact-path-task/results.json"],
+          verifierOutput: "AssertionError: File /app/output.txt does not exist.",
+        },
+        {
+          trialId: "generated-script-task.1-of-1.tb-natural-language-verifier",
+          evidenceRefs: ["generated-script-task/results.json"],
+          verifierOutput: [
+            "Ensure the generated macro script is well-formed before finishing.",
+            "Missing :wq or :x",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    const signals = buildExternalEvalImprovementSignals(report);
+
+    expect(signals.map((signal) => signal.kind)).toEqual([
+      "required-artifact-contract",
+      "exact-verifier-command",
+    ]);
+    expect(signals.map((signal) => signal.taskIds)).toEqual([
+      ["artifact-path-task"],
+      ["generated-script-task"],
+    ]);
+
+    const pack = buildOperationalMemoryPackFromDiagnostics({
+      packId: "tb-natural-language-verifier-operational-checklists",
+      version: "1.0.0",
+      createdAt: "2026-05-11T20:05:00.000Z",
+      report,
+    });
+
+    expect(pack.findings.map((finding) => finding.id)).toEqual([
+      "tb-natural-language-verifier-verifier-contract-mismatch",
+      "tb-natural-language-verifier-required-artifact-contract",
+      "tb-natural-language-verifier-exact-verifier-command",
+    ]);
+    expect(pack.findings.every((finding) => finding.containsTaskAnswer === false)).toBe(true);
+    expect(validateOperationalMemoryPack(pack)).toEqual({ valid: true });
+  });
+
+  test("keeps domain existence failures out of verifier-contract diagnostics", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-domain-existence",
+      createdAt: "2026-05-11T20:10:00.000Z",
+      trials: [
+        {
+          taskId: "exported-database-task",
+          trialId: "exported-database-task.1-of-1.tb-domain-existence",
+          attempt: 1,
+          status: "failed",
+          reward: 0,
+        },
+      ],
+      evidence: [
+        {
+          trialId: "exported-database-task.1-of-1.tb-domain-existence",
+          evidenceRefs: ["exported-database-task/results.json"],
+          verifierOutput: "AssertionError: user alice does not exist in the exported database",
+        },
+      ],
+    });
+
+    expect(report.diagnostics.map((diagnostic) => diagnostic.category)).toEqual([
+      "agent-task-failure",
+    ]);
+    expect(buildExternalEvalImprovementSignals(report)).toEqual([]);
+  });
+
+  test("detects artifact signals when verifier says a required output file does not exist at a path", () => {
+    const report = buildExternalEvalDiagnosticReport({
+      runId: "tb-artifact-existence",
+      createdAt: "2026-05-11T20:15:00.000Z",
+      trials: [
+        {
+          taskId: "artifact-path-task",
+          trialId: "artifact-path-task.1-of-1.tb-artifact-existence",
+          attempt: 1,
+          status: "failed",
+          reward: 0,
+        },
+      ],
+      evidence: [
+        {
+          trialId: "artifact-path-task.1-of-1.tb-artifact-existence",
+          evidenceRefs: ["artifact-path-task/results.json"],
+          verifierOutput: "AssertionError: The required output file does not exist at /app/output.txt",
+        },
+      ],
+    });
+
+    expect(report.diagnostics.map((diagnostic) => diagnostic.category)).toEqual([
+      "verifier-contract-mismatch",
+    ]);
+    expect(buildExternalEvalImprovementSignals(report).map((signal) => signal.kind)).toEqual([
+      "required-artifact-contract",
+    ]);
+  });
+
   test("recomputes memory-pack improvement signals from diagnostics", () => {
     const report = buildExternalEvalDiagnosticReport({
       runId: "tb-clean-1",


### PR DESCRIPTION
## Summary
- recognize natural-language missing-artifact verifier output as verifier-contract / artifact-contract evidence
- classify malformed generated verifier scripts/macros and missing :wq/:x guidance as exact-verifier-command signals
- add regression coverage that builds safe operational memory from these diagnostics

## Verification
- npm test -- tests/control-plane/external-evals/diagnostics.test.ts
- npm run lint
- npm test

## Benchmark context
- Terminal-Bench 2.0 held-out, Codex gpt-5.4, same 79-task split
- baseline raw: 45/79 (0.570), selected: 45/72 (0.625)
- package-context raw: 50/79 (0.633), selected: 50/71 (0.704)
- task delta: +10 improvements, -5 regressions