### PR TITLE
AC-724: Plan agent app build target boundary

### DIFF
--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -66,6 +66,91 @@ The umbrella packages preserve the default install and CLI experience. The new
 core/control artifacts make the dependency boundary explicit at the artifact
 level while remaining Apache-2.0 in this repo.
 
+## Agent App Build Targets
+
+The Flue-style `build --target node|cloudflare` idea is useful, but
+AutoContext should treat deployment targets as control-plane packaging around
+stable core contracts, not as new runtime contracts themselves. The
+machine-readable target boundary lives in
+[`packages/package-topology.json`](../packages/package-topology.json) under
+`agentApps`.
+
+Ownership:
+
+- Runtime contracts belong in the Apache core artifact. This includes handler
+  loading contracts, runtime workspace/session environment contracts, scoped
+  command/tool grants, child-task contracts, context-layer discovery contracts,
+  provider/runtime interfaces, and runtime-session event contracts.
+- Build and deploy workflows belong in the Apache control-plane artifact. This
+  includes target selection, bundle planning, generated server/worker templates,
+  target-specific adapters, packaging checks, and operator-facing CLI/API
+  commands.
+- The umbrella `autoctx` CLI may dispatch build commands while package splitting
+  is in progress, but it should delegate to the control-plane implementation.
+- Hosted fleet orchestration is out of scope for this Apache repo. Multi-tenant
+  worker scheduling, hosted secret brokering, billing, organization policy
+  rollout, remote execution fleets, and production deployment control rooms are
+  separate proprietary product work.
+
+### Node Target MVP
+
+The first target should be a local or self-hosted Node server generator. It
+should load handlers through the public `agent-runtime` surface already used by
+`.autoctx/agents`, expose a small manifest/invoke HTTP shape, and wire
+runtime-session recording through the same event contracts used by local
+execution. It may generate a minimal server entrypoint and package manifest, but
+should not invent a second handler API or bypass the runtime workspace/session
+contracts.
+
+The MVP is approved only as a packaging/control-plane layer around existing
+contracts:
+
+- discover handlers from `.autoctx/agents` using the public loader;
+- bind request ids, payload, explicit env, runtime, workspace, commands, and
+  tools through the existing invocation context;
+- persist local sessions with the current runtime-session store contract;
+- treat shell command grants as host-created capabilities, not app-provided
+  ambient authority;
+- keep deployment, service hosting, process supervision, and remote secret
+  management out of scope.
+
+### Cloudflare Target Spike
+
+The Cloudflare target should stay a spike until the Node target proves the
+handler/server boundary. The spike can explore Workers for request routing and
+Durable Objects for session/event persistence, but it should report contract
+gaps before adding a production build path.
+
+The spike should answer:
+
+- how a Worker bundle loads or embeds agent handlers without depending on
+  Node-only dynamic import behavior;
+- how Durable Objects map onto runtime-session ids, append/replay semantics, and
+  child-session links;
+- how tool grants are represented when local process execution and filesystem
+  access are unavailable;
+- which runtime workspace adapters are valid in an edge environment;
+- which pieces must remain target adapters in the control-plane package instead
+  of leaking into core.
+
+### Risks
+
+- Bundling: TypeScript handler loading, ESM/CJS interop, native dependencies,
+  optional provider SDKs, source maps, and dynamic imports can diverge between
+  Node and edge runtimes.
+- Environment variables: build targets must preserve explicit env loading and
+  redaction semantics. They must not capture the full host environment or bake
+  secrets into generated artifacts.
+- Session persistence: Node can start with local SQLite/file stores, while
+  Cloudflare needs a Durable Object or other edge-native event store. Replay
+  semantics must stay compatible before sessions move between targets.
+- Sandbox providers: local shell grants, filesystem adapters, and subprocess
+  runtimes do not automatically exist in Workers. Target adapters must degrade
+  explicitly or require remote tools rather than silently broadening authority.
+- Product boundary: hosted scheduling, policy rollout, tenant isolation,
+  observability cockpit features, and managed deployment are not open-source
+  build-target responsibilities.
+
 ## Path Map
 
 This map is the starting point for implementation. It should be updated if code

--- a/packages/package-topology.json
+++ b/packages/package-topology.json
@@ -26,6 +26,24 @@
     "compatibilityShell": "Thin package layer that re-exports or dispatches into the new internal artifacts while the migration is in progress.",
     "packageTopology": "The path and artifact map that defines which package owns each ecosystem role during the migration."
   },
+  "agentApps": {
+    "runtimeContractsPackage": "@autocontext/core",
+    "buildDeployPackage": "@autocontext/control-plane",
+    "umbrellaCliCompatibility": "autoctx may dispatch build commands while the package split is in progress",
+    "hostedFleetOrchestration": "out-of-scope-proprietary-product",
+    "targets": {
+      "node": {
+        "phase": "mvp",
+        "owner": "@autocontext/control-plane",
+        "runtime": "load local agent handlers through the public agent-runtime contract"
+      },
+      "cloudflare": {
+        "phase": "spike",
+        "owner": "@autocontext/control-plane",
+        "runtime": "prototype Worker and Durable Object session persistence after Node target contracts stabilize"
+      }
+    }
+  },
   "python": {
     "umbrella": {
       "name": "autocontext",

--- a/ts/tests/package-topology.test.ts
+++ b/ts/tests/package-topology.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 const repoRoot = join(import.meta.dirname, "..", "..");
 const topologyPath = join(repoRoot, "packages", "package-topology.json");
 const boundariesPath = join(repoRoot, "packages", "package-boundaries.json");
+const packageSplitDocPath = join(repoRoot, "docs", "core-control-package-split.md");
 
 type PackageEntry = {
   name: string;
@@ -18,6 +19,15 @@ type TsPackageEntry = PackageEntry & {
 type Topology = {
   status: string;
   guardrails: Record<string, string>;
+  agentApps?: {
+    runtimeContractsPackage: string;
+    buildDeployPackage: string;
+    hostedFleetOrchestration: string;
+    targets: Record<string, {
+      phase: string;
+      owner: string;
+    }>;
+  };
   typescript: {
     umbrella: PackageEntry & { bin: string };
     core: TsPackageEntry;
@@ -99,6 +109,39 @@ describe("package topology", () => {
       futureProprietaryWork: "separate-repository",
       defaultInstallCompatibility: "preserve-autocontext-autoctx-and-autoctx-cli",
     });
+  });
+
+  it("records the agent app build target boundary", () => {
+    const topology = loadTopology();
+
+    expect(topology.agentApps).toMatchObject({
+      runtimeContractsPackage: "@autocontext/core",
+      buildDeployPackage: "@autocontext/control-plane",
+      hostedFleetOrchestration: "out-of-scope-proprietary-product",
+      targets: {
+        node: {
+          phase: "mvp",
+          owner: "@autocontext/control-plane",
+        },
+        cloudflare: {
+          phase: "spike",
+          owner: "@autocontext/control-plane",
+        },
+      },
+    });
+  });
+
+  it("documents the agent app deployment boundary and risks", () => {
+    const doc = readFileSync(packageSplitDocPath, "utf-8");
+
+    expect(doc).toContain("## Agent App Build Targets");
+    expect(doc).toContain("Node Target MVP");
+    expect(doc).toContain("Cloudflare Target Spike");
+    expect(doc).toContain("Hosted fleet orchestration");
+    expect(doc).toContain("Bundling");
+    expect(doc).toContain("Environment variables");
+    expect(doc).toContain("Session persistence");
+    expect(doc).toContain("Sandbox providers");
   });
 
   it("matches TypeScript package names to the topology", () => {


### PR DESCRIPTION
## Summary
- document the agent app build-target boundary in the core/control package split guide
- record Node MVP vs Cloudflare spike ownership in the package topology manifest
- add topology/doc regression coverage for the AC-724 boundary terms
- created Linear follow-ups AC-762 and AC-763 for the approved Node MVP and Cloudflare spike

## Verification
- npm test -- package-topology.test.ts --testTimeout=30000
- npm run lint
- npm test -- package-topology.test.ts package-boundaries.test.ts package-parity.test.ts --testTimeout=30000

Linear: AC-724