### PR TITLE
Clarify agent app runtime contract ownership

### DIFF
--- a/autocontext/tests/test_package_topology.py
+++ b/autocontext/tests/test_package_topology.py
@@ -78,6 +78,22 @@ def test_package_topology_declares_apache_boundary_wrap_up_guardrails() -> None:
     )
 
 
+def test_agent_app_runtime_contracts_remain_umbrella_owned_until_extracted() -> None:
+    topology = _load_topology()
+    agent_apps = topology["agentApps"]
+    assert isinstance(agent_apps, dict)
+
+    assert agent_apps["runtimeContractsStatus"] == "umbrella-owned-until-core-extraction"
+    assert agent_apps["currentRuntimeContractsPackage"] == "autoctx/agent-runtime"
+    assert agent_apps["plannedRuntimeContractsPackage"] == "@autocontext/core"
+    assert agent_apps["unextractedCoreContracts"] == [
+        "ts/src/agent-runtime/index.ts",
+        "ts/src/session/runtime-session.ts",
+        "ts/src/session/runtime-session-notifications.ts",
+        "tsx dependency for TypeScript handler loading",
+    ]
+
+
 def test_python_package_shells_exist() -> None:
     for shell in _python_shells():
         assert shell.path.exists(), shell.path

--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -70,17 +70,24 @@ level while remaining Apache-2.0 in this repo.
 
 The Flue-style `build --target node|cloudflare` idea is useful, but
 AutoContext should treat deployment targets as control-plane packaging around
-stable core contracts, not as new runtime contracts themselves. The
+stable runtime contracts, not as new runtime contracts themselves. The
 machine-readable target boundary lives in
 [`packages/package-topology.json`](../packages/package-topology.json) under
 `agentApps`.
 
 Ownership:
 
-- Runtime contracts belong in the Apache core artifact. This includes handler
-  loading contracts, runtime workspace/session environment contracts, scoped
-  command/tool grants, child-task contracts, context-layer discovery contracts,
-  provider/runtime interfaces, and runtime-session event contracts.
+- Runtime contracts are still umbrella-owned until the extraction work adds
+  those exports to `@autocontext/core`. Today, the Node build target must use
+  the public `autoctx/agent-runtime` surface, plus the runtime-session exports
+  already available from `autoctx`, instead of importing missing core package
+  contracts.
+- The planned home for reusable runtime contracts remains the Apache core
+  artifact once the boundary explicitly exports handler loading contracts,
+  runtime workspace/session environment contracts, scoped command/tool grants,
+  child-task contracts, context-layer discovery contracts, provider/runtime
+  interfaces, runtime-session event contracts, and the dependencies needed by
+  those contracts.
 - Build and deploy workflows belong in the Apache control-plane artifact. This
   includes target selection, bundle planning, generated server/worker templates,
   target-specific adapters, packaging checks, and operator-facing CLI/API
@@ -95,12 +102,12 @@ Ownership:
 ### Node Target MVP
 
 The first target should be a local or self-hosted Node server generator. It
-should load handlers through the public `agent-runtime` surface already used by
-`.autoctx/agents`, expose a small manifest/invoke HTTP shape, and wire
-runtime-session recording through the same event contracts used by local
-execution. It may generate a minimal server entrypoint and package manifest, but
-should not invent a second handler API or bypass the runtime workspace/session
-contracts.
+should load handlers through the public `autoctx/agent-runtime` surface already
+used by `.autoctx/agents`, expose a small manifest/invoke HTTP shape, and wire
+runtime-session recording through the same umbrella-owned event contracts used
+by local execution until those contracts are extracted into `@autocontext/core`.
+It may generate a minimal server entrypoint and package manifest, but should not
+invent a second handler API or bypass the runtime workspace/session contracts.
 
 The MVP is approved only as a packaging/control-plane layer around existing
 contracts:
@@ -109,6 +116,9 @@ contracts:
 - bind request ids, payload, explicit env, runtime, workspace, commands, and
   tools through the existing invocation context;
 - persist local sessions with the current runtime-session store contract;
+- keep `ts/src/agent-runtime/index.ts`, runtime-session storage/notification
+  contracts, and TypeScript handler-loading support umbrella-owned until the
+  core package boundary grows matching exports and dependencies;
 - treat shell command grants as host-created capabilities, not app-provided
   ambient authority;
 - keep deployment, service hosting, process supervision, and remote secret

--- a/packages/package-topology.json
+++ b/packages/package-topology.json
@@ -27,15 +27,23 @@
     "packageTopology": "The path and artifact map that defines which package owns each ecosystem role during the migration."
   },
   "agentApps": {
-    "runtimeContractsPackage": "@autocontext/core",
+    "runtimeContractsStatus": "umbrella-owned-until-core-extraction",
+    "currentRuntimeContractsPackage": "autoctx/agent-runtime",
+    "plannedRuntimeContractsPackage": "@autocontext/core",
     "buildDeployPackage": "@autocontext/control-plane",
     "umbrellaCliCompatibility": "autoctx may dispatch build commands while the package split is in progress",
     "hostedFleetOrchestration": "out-of-scope-proprietary-product",
+    "unextractedCoreContracts": [
+      "ts/src/agent-runtime/index.ts",
+      "ts/src/session/runtime-session.ts",
+      "ts/src/session/runtime-session-notifications.ts",
+      "tsx dependency for TypeScript handler loading"
+    ],
     "targets": {
       "node": {
         "phase": "mvp",
         "owner": "@autocontext/control-plane",
-        "runtime": "load local agent handlers through the public agent-runtime contract"
+        "runtime": "load local agent handlers through autoctx/agent-runtime until the surface is extracted into @autocontext/core"
       },
       "cloudflare": {
         "phase": "spike",

--- a/ts/tests/package-topology.test.ts
+++ b/ts/tests/package-topology.test.ts
@@ -20,9 +20,12 @@ type Topology = {
   status: string;
   guardrails: Record<string, string>;
   agentApps?: {
-    runtimeContractsPackage: string;
+    runtimeContractsStatus: string;
+    currentRuntimeContractsPackage: string;
+    plannedRuntimeContractsPackage: string;
     buildDeployPackage: string;
     hostedFleetOrchestration: string;
+    unextractedCoreContracts: string[];
     targets: Record<string, {
       phase: string;
       owner: string;
@@ -115,7 +118,9 @@ describe("package topology", () => {
     const topology = loadTopology();
 
     expect(topology.agentApps).toMatchObject({
-      runtimeContractsPackage: "@autocontext/core",
+      runtimeContractsStatus: "umbrella-owned-until-core-extraction",
+      currentRuntimeContractsPackage: "autoctx/agent-runtime",
+      plannedRuntimeContractsPackage: "@autocontext/core",
       buildDeployPackage: "@autocontext/control-plane",
       hostedFleetOrchestration: "out-of-scope-proprietary-product",
       targets: {
@@ -131,10 +136,32 @@ describe("package topology", () => {
     });
   });
 
+  it("does not advertise unextracted agent runtime contracts as core-owned", () => {
+    const topology = loadTopology();
+    const coreConfig = loadTsConfig(topology.typescript.core.path);
+    const coreIncludes = new Set(coreConfig.include ?? []);
+
+    expect(topology.agentApps?.runtimeContractsStatus).toBe("umbrella-owned-until-core-extraction");
+    expect(topology.agentApps?.currentRuntimeContractsPackage).toBe("autoctx/agent-runtime");
+    expect(topology.agentApps?.plannedRuntimeContractsPackage).toBe(topology.typescript.core.name);
+    expect(topology.agentApps?.unextractedCoreContracts).toEqual([
+      "ts/src/agent-runtime/index.ts",
+      "ts/src/session/runtime-session.ts",
+      "ts/src/session/runtime-session-notifications.ts",
+      "tsx dependency for TypeScript handler loading",
+    ]);
+    expect(coreIncludes.has("../../../ts/src/agent-runtime/index.ts")).toBe(false);
+    expect(coreIncludes.has("../../../ts/src/session/runtime-session.ts")).toBe(false);
+    expect(coreIncludes.has("../../../ts/src/session/runtime-session-notifications.ts")).toBe(false);
+  });
+
   it("documents the agent app deployment boundary and risks", () => {
     const doc = readFileSync(packageSplitDocPath, "utf-8");
 
     expect(doc).toContain("## Agent App Build Targets");
+    expect(doc).toContain("Runtime contracts are still umbrella-owned");
+    expect(doc).toContain("autoctx/agent-runtime");
+    expect(doc).toContain("importing missing core package");
     expect(doc).toContain("Node Target MVP");
     expect(doc).toContain("Cloudflare Target Spike");
     expect(doc).toContain("Hosted fleet orchestration");


### PR DESCRIPTION
## Summary
- Mark agent app runtime contracts as umbrella-owned until extraction instead of current @autocontext/core ownership
- Point the Node target at the existing public autoctx/agent-runtime surface and list the unextracted core contracts
- Add TS and Python package-topology tests so future build-target work cannot follow a missing core package surface

## Verification
- npm test -- package-topology.test.ts package-boundaries.test.ts package-parity.test.ts --testTimeout=30000
- npm run lint
- uv run --frozen pytest tests/test_package_topology.py tests/test_package_boundaries.py
- uv run --frozen ruff check tests/test_package_topology.py tests/test_package_boundaries.py
- git diff --cached --check