### PR TITLE
feat(improve): add --checkpoint-cmd for per-round partial-progress capture (AC-727 slice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- AC-727 (slice): `autoctx improve --checkpoint-cmd` runs a user-supplied command after each round to preserve partial progress (e.g. `git -C /repo commit -am 'round checkpoint'` or `cp {file} /tmp/round.lean`). Same `{file}` placeholder semantics as `--verify-cmd`, plus `--checkpoint-suffix` and `--checkpoint-timeout` companions. Unlike the verifier, a checkpoint command's non-zero exit is logged but does NOT veto the round; it surfaces as a new `checkpoint_done(round=N, checkpoint_ok=..., checkpoint_exit_code=...)` event in the `--ndjson` stream. Lets long-running improve loops salvage near-miss artifacts before later rounds overshoot or time out.
 - AC-723: the TypeScript CLI now exposes `autoctx agent run <agent>` and `autoctx agent dev` for experimental `.autoctx/agents` handlers. The one-shot runner accepts `--id`, JSON `--payload`, explicit `--env` files with shell env precedence, provider/model overrides for runtime-backed handlers, and `--json` output; the dev server exposes `GET /manifest` and `POST /agents/<name>/invoke`.
 - Context-selection analytics reports now include actionable diagnostics for duplicate selected content, low useful-artifact recall, and selected-token bloat.
 - Python analytics now includes `autoctx analytics context-selection --run-id <run-id> [--json]` to summarize persisted context-selection artifacts by selected tokens, selection rate, duplicate-content rate, useful-artifact recall, and freshness.

--- a/autocontext/docs/agent-integration.md
+++ b/autocontext/docs/agent-integration.md
@@ -935,19 +935,20 @@ package = ac.export_package("grid_ctf")
 
 The two modes are mutually exclusive; passing both exits non-zero.
 
-Under `--ndjson`, the per-round event sequence (with a configured `--verify-cmd`) is:
+Under `--ndjson`, the per-round event sequence (with both a configured `--verify-cmd` and `--checkpoint-cmd`) is:
 
 ```
-round_start  -> revision_done -> judge_done -> verifier_done -> round_summary
+round_start  -> revision_done -> judge_done -> verifier_done -> round_summary -> checkpoint_done
 ```
 
-repeated per round, followed by a single `final` event. Without a verifier the `verifier_done` event is omitted. Field semantics:
+repeated per round, followed by a single `final` event. Without a verifier the `verifier_done` event is omitted; without a checkpointer the `checkpoint_done` event is omitted. Field semantics:
 
 - `round_start` carries `round`.
 - `revision_done` carries `round` and `output` (the exact content the round is about to evaluate; for round 1 this is the seed, for round N>1 it is the result of `task.revise_output()` from round N-1). Lets consumers salvage near-miss verifier-vetoed rounds.
 - `judge_done` carries `round` and `score` (the judge's evaluation before any post-processing or veto).
 - `verifier_done` carries `round`, `verifier_ok`, and `verifier_exit_code`.
 - `round_summary` carries `round` and `effective_score` (post-veto, after fact-check penalty).
+- `checkpoint_done` carries `round`, `checkpoint_ok`, and `checkpoint_exit_code`. Unlike `verifier_done`, a failed checkpoint does NOT veto the round -- it is a side effect that preserves partial progress (e.g. a `git commit` or `cp` of the per-round output) before later rounds might overshoot or time out (AC-727).
 - `final` carries `best_score`, `best_round`, `total_rounds`, and `met_threshold`.
 
 Provider errors during a streaming run emit a single `{"event":"error","message":"..."}` line on stdout so the stream stays parseable.

--- a/autocontext/src/autocontext/cli_improve.py
+++ b/autocontext/src/autocontext/cli_improve.py
@@ -119,6 +119,30 @@ def register_improve_command(
             min=1.0,
             help="Timeout in seconds for each --verify-cmd invocation.",
         ),
+        checkpoint_cmd: str = typer.Option(
+            "",
+            "--checkpoint-cmd",
+            help=(
+                "External command to checkpoint each round's output (AC-727). "
+                "Runs after the round is judged and verified; non-zero exit is "
+                "logged but does NOT veto the round (unlike --verify-cmd). "
+                "Use this to preserve partial progress -- e.g. "
+                "'git -C /repo commit -am round-checkpoint' or "
+                "'cp {file} /tmp/round.lean'. Same `{file}` placeholder "
+                "semantics as --verify-cmd."
+            ),
+        ),
+        checkpoint_suffix: str = typer.Option(
+            ".txt",
+            "--checkpoint-suffix",
+            help="Suffix for the temp file passed to --checkpoint-cmd (e.g. '.lean', '.py').",
+        ),
+        checkpoint_timeout: float = typer.Option(
+            300.0,
+            "--checkpoint-timeout",
+            min=1.0,
+            help="Timeout in seconds for each --checkpoint-cmd invocation.",
+        ),
     ) -> None:
         """Run multi-round improvement loop on agent output.
 
@@ -126,7 +150,10 @@ def register_improve_command(
         the improvement loop with judge-guided iteration.
         """
         from autocontext.execution.improvement_loop import ImprovementLoop
-        from autocontext.execution.output_verifier import make_verifier
+        from autocontext.execution.output_verifier import (
+            make_checkpointer,
+            make_verifier,
+        )
         from autocontext.execution.task_runner import SimpleAgentTask
         from autocontext.providers.registry import get_provider as get_judge_provider
 
@@ -165,6 +192,12 @@ def register_improve_command(
                 file_suffix=verify_suffix,
                 timeout_s=verify_timeout,
             )
+            # AC-727: optional non-vetoing per-round checkpoint command.
+            checkpointer = make_checkpointer(
+                checkpoint_cmd or None,
+                file_suffix=checkpoint_suffix,
+                timeout_s=checkpoint_timeout,
+            )
             # AC-752: when --ndjson is set, stream per-round events as JSON lines
             # so long-running loops have progress visibility before --json's final
             # blob lands. The event sink writes one compact JSON line per event.
@@ -185,6 +218,7 @@ def register_improve_command(
                 max_rounds=max_rounds,
                 quality_threshold=threshold,
                 output_verifier=verifier,
+                output_checkpointer=checkpointer,
                 on_event=on_event,
             )
             starting_output = initial_output or task.generate_output(state)

--- a/autocontext/src/autocontext/execution/improvement_events.py
+++ b/autocontext/src/autocontext/execution/improvement_events.py
@@ -30,6 +30,11 @@ class ImprovementLoopEvent:
       (AC-753).
     - `judge_done`: round, score
     - `verifier_done`: round, verifier_ok, verifier_exit_code
+    - `checkpoint_done`: round, checkpoint_ok, checkpoint_exit_code -- the
+      external `--checkpoint-cmd` ran after the round and either succeeded
+      (ok=True) or failed (ok=False). Unlike `verifier_done`, a failed
+      checkpoint does NOT veto the round's score; checkpointing is a
+      side-effect for preserving partial progress (AC-727).
     - `round_summary`: round, effective_score
     - `final`: best_score, best_round, total_rounds, met_threshold
     """
@@ -38,7 +43,7 @@ class ImprovementLoopEvent:
     # Existing callers may construct events positionally as
     # `ImprovementLoopEvent("judge_done", 1, 0.95)`; new fields go at the END so
     # they don't shift the meaning of trailing positional arguments. AC-753 added
-    # `output` and intentionally appends it after the older fields.
+    # `output`, AC-727 added the `checkpoint_*` fields, intentionally appended.
     event: str
     round: int | None = None
     score: float | None = None
@@ -50,3 +55,5 @@ class ImprovementLoopEvent:
     total_rounds: int | None = None
     met_threshold: bool | None = None
     output: str | None = None
+    checkpoint_ok: bool | None = None
+    checkpoint_exit_code: int | None = None

--- a/autocontext/src/autocontext/execution/improvement_loop.py
+++ b/autocontext/src/autocontext/execution/improvement_loop.py
@@ -116,6 +116,7 @@ class ImprovementLoop:
         cap_score_jumps: bool = False,
         dimension_threshold: float | None = None,
         output_verifier: OutputVerifier | None = None,
+        output_checkpointer: OutputVerifier | None = None,
         on_event: Callable[[ImprovementLoopEvent], None] | None = None,
     ) -> None:
         self.task = task
@@ -129,6 +130,13 @@ class ImprovementLoop:
         # When set, a non-passing verifier round forces effective_score to 0
         # and feeds the verifier's stderr/stdout into the next revision prompt.
         self.output_verifier = output_verifier if (output_verifier and output_verifier.enabled) else None
+        # AC-727: optional per-round checkpoint command. Same OutputVerifier
+        # plumbing but used as a non-vetoing side effect -- runs after each
+        # round and lets the operator preserve partial progress (e.g. git
+        # commit, copy output to a salvage location) before later rounds
+        # might overshoot or time out. Checkpoint failures are logged and
+        # surface as a `checkpoint_done` event but do NOT zero the score.
+        self.output_checkpointer = output_checkpointer if (output_checkpointer and output_checkpointer.enabled) else None
         # AC-752: optional per-round event sink so callers (e.g. `--ndjson`)
         # can stream progress without waiting for the final result blob.
         self._on_event: Callable[[ImprovementLoopEvent], None] = on_event or (lambda _e: None)
@@ -412,6 +420,28 @@ class ImprovementLoop:
                     effective_score=effective_score,
                 )
             )
+
+            # AC-727: run the optional checkpoint command after the round
+            # has been judged + (optionally) verified. Non-vetoing -- a
+            # failed checkpoint logs a warning and emits an event but does
+            # not influence the round's score or termination.
+            if self.output_checkpointer is not None:
+                checkpoint_outcome = self.output_checkpointer.run(current_output)
+                if not checkpoint_outcome.ok:
+                    logger.warning(
+                        "round %d: checkpoint command failed (exit %d): %s",
+                        round_num,
+                        checkpoint_outcome.exit_code,
+                        (checkpoint_outcome.stderr or checkpoint_outcome.stdout or "").strip()[:200],
+                    )
+                self._on_event(
+                    ImprovementLoopEvent(
+                        event="checkpoint_done",
+                        round=round_num,
+                        checkpoint_ok=checkpoint_outcome.ok,
+                        checkpoint_exit_code=checkpoint_outcome.exit_code,
+                    )
+                )
 
             # Dimension threshold gate is computed up front so the same
             # `dims_ok` value can be used by both the best-tracking update

--- a/autocontext/src/autocontext/execution/output_verifier.py
+++ b/autocontext/src/autocontext/execution/output_verifier.py
@@ -226,3 +226,35 @@ def make_verifier(
         timeout_s=timeout_s,
     )
     return verifier if verifier.enabled else None
+
+
+def make_checkpointer(
+    command: str | Sequence[str] | None,
+    *,
+    file_suffix: str = ".txt",
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+) -> OutputVerifier | None:
+    """Convenience constructor for the per-round checkpoint command (AC-727).
+
+    Structurally identical to :func:`make_verifier` -- both build an
+    `OutputVerifier` runner around a user-supplied command -- but the
+    *semantic* role is different: a checkpoint is a non-vetoing side
+    effect that preserves partial progress (e.g.
+    ``git commit -am 'round N checkpoint'`` or
+    ``cp {file} /tmp/round-N.lean``). The improvement loop runs it after
+    each round and logs failures rather than zeroing the round's score.
+
+    Returns ``None`` for falsy commands so callers can write::
+
+        checkpointer = make_checkpointer(settings.checkpoint_command)
+        if checkpointer and checkpointer.enabled:
+            ...
+    """
+    if not command:
+        return None
+    checkpointer = OutputVerifier(
+        command=command,
+        file_suffix=file_suffix,
+        timeout_s=timeout_s,
+    )
+    return checkpointer if checkpointer.enabled else None

--- a/autocontext/tests/test_improvement_loop_verifier.py
+++ b/autocontext/tests/test_improvement_loop_verifier.py
@@ -373,3 +373,139 @@ class TestVerifierVetoProvenance:
         assert score_jump_warnings, (
             "genuine score jump (no verifier veto on previous round) should still trigger the max_score_delta warning"
         )
+
+
+# -- AC-727 slice: per-round checkpoint command --
+
+
+class _RecordingTask(AgentTaskInterface):
+    """Two-round task. Each round produces a slightly different output so
+    we can assert the checkpoint command sees each one."""
+
+    def get_task_prompt(self, state):
+        return "."
+
+    def evaluate_output(self, output, state, **kwargs):
+        # Sub-threshold for both rounds so the loop runs to max_rounds.
+        return AgentTaskResult(score=0.5, reasoning="x", dimension_scores={})
+
+    def revise_output(self, current_output, judge_result, state):
+        return current_output + "-rev"
+
+    def get_rubric(self):
+        return "."
+
+    def initial_state(self, seed=None):
+        return {}
+
+    def describe_task(self):
+        return "."
+
+
+def _capturing_checkpoint(tmp_path):
+    """Build a checkpoint command that appends the per-round output to a
+    capture file, plus the path so the test can read it back. The command
+    uses `{file}` so we exercise the file-mode placeholder path.
+
+    Returns (command_template, captured_outputs_callable).
+    """
+    capture = tmp_path / "checkpoint-captures.log"
+    capture.write_text("")
+    script = textwrap.dedent(
+        f"""
+        import sys
+        from pathlib import Path
+        src = Path(sys.argv[1])
+        Path({str(capture)!r}).open("a", encoding="utf-8").write(src.read_text() + "\\n---\\n")
+        sys.exit(0)
+        """
+    ).strip()
+    return ([sys.executable, "-c", script, "{file}"], capture)
+
+
+def _failing_checkpoint():
+    """Checkpoint command that always exits non-zero."""
+    script = textwrap.dedent(
+        """
+        import sys
+        print('checkpoint script blew up', file=sys.stderr)
+        sys.exit(7)
+        """
+    ).strip()
+    return OutputVerifier(command=[sys.executable, "-c", script])
+
+
+class TestCheckpointer:
+    """AC-727: a per-round checkpoint command preserves partial progress
+    before later rounds overshoot. Unlike `--verify-cmd`, a checkpoint
+    failure must NOT veto the round."""
+
+    def test_checkpointer_invoked_each_round_with_output(self, tmp_path) -> None:
+        command, capture = _capturing_checkpoint(tmp_path)
+        checkpointer = OutputVerifier(command=command, file_suffix=".txt")
+
+        loop = ImprovementLoop(
+            task=_RecordingTask(),
+            max_rounds=2,
+            quality_threshold=0.9,
+            output_checkpointer=checkpointer,
+        )
+        loop.run("seed", {})
+
+        snapshots = [s for s in capture.read_text().split("\n---\n") if s]
+        assert snapshots == ["seed", "seed-rev"], f"checkpointer did not capture per-round output; got {snapshots!r}"
+
+    def test_checkpointer_failure_does_not_abort_loop(self) -> None:
+        # Failing checkpointer must not veto the run. The loop continues to
+        # max_rounds and the result reflects the judge's view, unchanged.
+        loop = ImprovementLoop(
+            task=_RecordingTask(),
+            max_rounds=2,
+            quality_threshold=0.9,
+            output_checkpointer=_failing_checkpoint(),
+        )
+        result = loop.run("seed", {})
+        assert result.total_rounds == 2
+        assert result.best_score == 0.5  # judge score, not 0; no veto
+
+    def test_checkpoint_done_event_emitted(self, tmp_path) -> None:
+        from autocontext.execution.improvement_events import ImprovementLoopEvent
+
+        events: list[ImprovementLoopEvent] = []
+        command, _capture = _capturing_checkpoint(tmp_path)
+        checkpointer = OutputVerifier(command=command, file_suffix=".txt")
+
+        loop = ImprovementLoop(
+            task=_RecordingTask(),
+            max_rounds=1,
+            quality_threshold=0.9,
+            output_checkpointer=checkpointer,
+            on_event=events.append,
+        )
+        loop.run("seed", {})
+
+        checkpoint_events = [e for e in events if e.event == "checkpoint_done"]
+        assert len(checkpoint_events) == 1
+        ev = checkpoint_events[0]
+        assert ev.round == 1
+        assert ev.checkpoint_ok is True
+        assert ev.checkpoint_exit_code == 0
+
+    def test_checkpoint_done_event_records_failure(self) -> None:
+        from autocontext.execution.improvement_events import ImprovementLoopEvent
+
+        events: list[ImprovementLoopEvent] = []
+        loop = ImprovementLoop(
+            task=_RecordingTask(),
+            max_rounds=1,
+            quality_threshold=0.9,
+            output_checkpointer=_failing_checkpoint(),
+            on_event=events.append,
+        )
+        loop.run("seed", {})
+
+        checkpoint_events = [e for e in events if e.event == "checkpoint_done"]
+        assert len(checkpoint_events) == 1
+        ev = checkpoint_events[0]
+        assert ev.checkpoint_ok is False
+        assert ev.checkpoint_exit_code == 7


### PR DESCRIPTION
Bounded slice of **AC-727** (long-running tasks need partial-progress preservation before later rounds overshoot or time out). Adds a non-vetoing per-round side-effect command alongside the existing `--verify-cmd`.

## Usage

```bash
autoctx improve \
  --verify-cmd 'lake env lean {file}' \
  --checkpoint-cmd 'cp {file} /tmp/round-checkpoint.lean'
```

After each round is judged and (optionally) verified, the loop runs the checkpoint command on the round's output. A non-zero exit is **logged but does NOT zero the round's score** (the distinction from `--verify-cmd`). The outcome surfaces as a new `checkpoint_done(round=N, checkpoint_ok=..., checkpoint_exit_code=...)` event in the `--ndjson` stream.

## DDD / DRY

The existing `OutputVerifier` is already a generic external-command runner. A new `make_checkpointer` factory returns the same class, with `ImprovementLoop` using it in a separate non-vetoing slot. Both share infrastructure (file/stdin placeholder, timeout handling, exception swallowing); the loop differs by which slot each lives in.

## CLI surface

- `--checkpoint-cmd <command>` (default off)
- `--checkpoint-suffix <ext>` (default `.txt`)
- `--checkpoint-timeout <seconds>` (default 300)

## Event addition

`ImprovementLoopEvent` now has optional `checkpoint_ok` and `checkpoint_exit_code` fields, **appended** at the end of the dataclass per the AC-756 PR #935 review note on positional-construction ordering.

## Tests

- `test_checkpointer_invoked_each_round_with_output` -- per-round capture file accumulates the right outputs across two rounds.
- `test_checkpointer_failure_does_not_abort_loop` -- exit=7 checkpoint still leaves the run with `best_score=0.5` (judge score), not 0.
- `test_checkpoint_done_event_emitted` -- success path emits one event with `checkpoint_ok=True`.
- `test_checkpoint_done_event_records_failure` -- failure path emits `ok=False, exit_code=7`.

125 improvement-loop / verifier / events / output-cleaner / output-verifier / CLI / module-size tests pass. Ruff + mypy clean.

## Out of scope

The deferred AC-727 R&D pieces: generated-context "artifact-first" guidance and stop-condition heuristics. This slice is a primitive that the larger AC-727 work can later compose with.

## Test plan

- [ ] CI green
- [ ] Try `autoctx improve --checkpoint-cmd 'cp {file} /tmp/round.lean' --verify-cmd 'lake env lean {file}'` on a real Lean run and confirm `/tmp/round.lean` updates per round