### PR TITLE
Use AutoContext-native runtime vocabulary

### DIFF
--- a/docs/concept-model.md
+++ b/docs/concept-model.md
@@ -89,7 +89,7 @@ Child assembly helpers recompute workspace-discovered layers from the child `cwd
 | 7 | tool affordances and scoped grants | Runtime | Ephemeral grant scope | Summarize tool metadata and redact secrets; scoped grants carry explicit inheritance policy. | Inherit only grants allowed by policy. |
 | 8 | recent session history and compaction summaries | Runtime session | Runtime-session log and compaction artifacts | Compact when pressure crosses policy thresholds; summaries point back to source events. | Child tasks use their own session log and linked parent lineage. |
 
-Repo instruction discovery walks from workspace root to the current `cwd`, loading `AGENTS.md` and `CLAUDE.md` when present. Skill discovery walks from the current `cwd` back to the root so more specific skill roots can override broad ones by name while still falling back to shared root skills. This intentionally borrows the useful Flue distinction between bundled role behavior and runtime workspace discovery without replacing AutoContext's `Scenario`, `Task`, `Mission`, `Run`, `Artifact`, or `Knowledge` vocabulary.
+Repo instruction discovery walks from workspace root to the current `cwd`, loading `AGENTS.md` and `CLAUDE.md` when present. Skill discovery walks from the current `cwd` back to the root so more specific skill roots can override broad ones by name while still falling back to shared root skills. Bundled role behavior stays separate from runtime workspace discovery, without replacing AutoContext's `Scenario`, `Task`, `Mission`, `Run`, `Artifact`, or `Knowledge` vocabulary.
 
 ## Durable Session Event Storage
 

--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -68,10 +68,9 @@ level while remaining Apache-2.0 in this repo.
 
 ## Agent App Build Targets
 
-The Flue-style `build --target node|cloudflare` idea is useful, but
-AutoContext should treat deployment targets as control-plane packaging around
-stable runtime contracts, not as new runtime contracts themselves. The
-machine-readable target boundary lives in
+AutoContext should treat `build --target node|cloudflare` deployment targets as
+control-plane packaging around stable runtime contracts, not as new runtime
+contracts themselves. The machine-readable target boundary lives in
 [`packages/package-topology.json`](../packages/package-topology.json) under
 `agentApps`.
 

--- a/ts/tests/package-topology.test.ts
+++ b/ts/tests/package-topology.test.ts
@@ -6,6 +6,7 @@ const repoRoot = join(import.meta.dirname, "..", "..");
 const topologyPath = join(repoRoot, "packages", "package-topology.json");
 const boundariesPath = join(repoRoot, "packages", "package-boundaries.json");
 const packageSplitDocPath = join(repoRoot, "docs", "core-control-package-split.md");
+const conceptModelDocPath = join(repoRoot, "docs", "concept-model.md");
 
 type PackageEntry = {
   name: string;
@@ -169,6 +170,18 @@ describe("package topology", () => {
     expect(doc).toContain("Environment variables");
     expect(doc).toContain("Session persistence");
     expect(doc).toContain("Sandbox providers");
+  });
+
+  it("uses AutoContext-native vocabulary in public runtime decision docs", () => {
+    const publicDecisionDocs = [
+      packageSplitDocPath,
+      conceptModelDocPath,
+    ];
+
+    for (const docPath of publicDecisionDocs) {
+      const doc = readFileSync(docPath, "utf-8");
+      expect(doc).not.toMatch(/\b[Ff]lue\b/);
+    }
   });
 
   it("matches TypeScript package names to the topology", () => {


### PR DESCRIPTION
## Summary
- Remove external runtime inspiration mentions from public AutoContext docs
- Reword runtime context and build-target docs in AutoContext-native terms
- Add a package-topology regression test to keep public runtime decision docs from reintroducing that external vocabulary

## Verification
- npm test -- package-topology.test.ts --testTimeout=30000
- npm run lint
- git diff --check