### PR TITLE
Add context budget telemetry

### DIFF
--- a/autocontext/src/autocontext/knowledge/context_selection.py
+++ b/autocontext/src/autocontext/knowledge/context_selection.py
@@ -125,6 +125,18 @@ class ContextSelectionDecision:
             if freshness_values
             else None
         )
+        budget_telemetry = _coerce_mapping(self.metadata.get("context_budget_telemetry"))
+        budget_input_tokens = _coerce_int(budget_telemetry.get("input_token_estimate"))
+        budget_output_tokens = _coerce_int(budget_telemetry.get("output_token_estimate"))
+        compaction_cache = _coerce_mapping(self.metadata.get("prompt_compaction_cache"))
+        compaction_hits = _coerce_int(compaction_cache.get("hits"))
+        compaction_misses = _coerce_int(compaction_cache.get("misses"))
+        compaction_lookups = _coerce_int(compaction_cache.get("lookups")) or compaction_hits + compaction_misses
+        compaction_hit_rate = (
+            compaction_hits / compaction_lookups
+            if compaction_lookups
+            else None
+        )
         return {
             "candidate_count": len(candidates),
             "selected_count": len(selected),
@@ -136,6 +148,16 @@ class ContextSelectionDecision:
             "useful_selected_count": len(useful_selected),
             "useful_artifact_recall": useful_recall,
             "mean_selected_freshness_generation_delta": mean_freshness,
+            "budget_input_token_estimate": budget_input_tokens,
+            "budget_output_token_estimate": budget_output_tokens,
+            "budget_token_reduction": max(0, budget_input_tokens - budget_output_tokens),
+            "budget_dedupe_hit_count": _coerce_int(budget_telemetry.get("dedupe_hit_count")),
+            "budget_component_cap_hit_count": _coerce_int(budget_telemetry.get("component_cap_hit_count")),
+            "budget_trimmed_component_count": _coerce_int(budget_telemetry.get("trimmed_component_count")),
+            "compaction_cache_hits": compaction_hits,
+            "compaction_cache_misses": compaction_misses,
+            "compaction_cache_lookups": compaction_lookups,
+            "compaction_cache_hit_rate": compaction_hit_rate,
         }
 
     def to_dict(self) -> dict[str, Any]:
@@ -264,3 +286,9 @@ def _coerce_optional_bool(value: Any) -> bool | None:
         if normalized in {"false", "0", "no"}:
             return False
     return None
+
+
+def _coerce_mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/autocontext/src/autocontext/knowledge/context_selection_report.py
+++ b/autocontext/src/autocontext/knowledge/context_selection_report.py
@@ -12,6 +12,8 @@ class ContextSelectionDiagnosticPolicy:
     duplicate_content_rate_threshold: float = 0.25
     useful_artifact_recall_floor: float = 0.70
     selected_token_estimate_threshold: int = 8000
+    compaction_cache_hit_rate_floor: float = 0.50
+    compaction_cache_min_lookups: int = 5
 
 
 @dataclass(frozen=True)
@@ -55,6 +57,16 @@ class ContextSelectionStageSummary:
     duplicate_content_rate: float
     useful_artifact_recall: float | None
     mean_selected_freshness_generation_delta: float | None
+    budget_input_token_estimate: int
+    budget_output_token_estimate: int
+    budget_token_reduction: int
+    budget_dedupe_hit_count: int
+    budget_component_cap_hit_count: int
+    budget_trimmed_component_count: int
+    compaction_cache_hits: int
+    compaction_cache_misses: int
+    compaction_cache_lookups: int
+    compaction_cache_hit_rate: float | None
 
     @classmethod
     def from_decision(cls, decision: ContextSelectionDecision) -> ContextSelectionStageSummary:
@@ -76,6 +88,16 @@ class ContextSelectionStageSummary:
                 metrics,
                 "mean_selected_freshness_generation_delta",
             ),
+            budget_input_token_estimate=_int_metric(metrics, "budget_input_token_estimate"),
+            budget_output_token_estimate=_int_metric(metrics, "budget_output_token_estimate"),
+            budget_token_reduction=_int_metric(metrics, "budget_token_reduction"),
+            budget_dedupe_hit_count=_int_metric(metrics, "budget_dedupe_hit_count"),
+            budget_component_cap_hit_count=_int_metric(metrics, "budget_component_cap_hit_count"),
+            budget_trimmed_component_count=_int_metric(metrics, "budget_trimmed_component_count"),
+            compaction_cache_hits=_int_metric(metrics, "compaction_cache_hits"),
+            compaction_cache_misses=_int_metric(metrics, "compaction_cache_misses"),
+            compaction_cache_lookups=_int_metric(metrics, "compaction_cache_lookups"),
+            compaction_cache_hit_rate=_optional_float_metric(metrics, "compaction_cache_hit_rate"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -93,6 +115,16 @@ class ContextSelectionStageSummary:
             "duplicate_content_rate": self.duplicate_content_rate,
             "useful_artifact_recall": self.useful_artifact_recall,
             "mean_selected_freshness_generation_delta": self.mean_selected_freshness_generation_delta,
+            "budget_input_token_estimate": self.budget_input_token_estimate,
+            "budget_output_token_estimate": self.budget_output_token_estimate,
+            "budget_token_reduction": self.budget_token_reduction,
+            "budget_dedupe_hit_count": self.budget_dedupe_hit_count,
+            "budget_component_cap_hit_count": self.budget_component_cap_hit_count,
+            "budget_trimmed_component_count": self.budget_trimmed_component_count,
+            "compaction_cache_hits": self.compaction_cache_hits,
+            "compaction_cache_misses": self.compaction_cache_misses,
+            "compaction_cache_lookups": self.compaction_cache_lookups,
+            "compaction_cache_hit_rate": self.compaction_cache_hit_rate,
         }
 
 
@@ -107,6 +139,8 @@ class ContextSelectionReport:
         selected_count = sum(stage.selected_count for stage in self.stages)
         candidate_tokens = sum(stage.candidate_token_estimate for stage in self.stages)
         selected_tokens = sum(stage.selected_token_estimate for stage in self.stages)
+        compaction_cache_hits = sum(stage.compaction_cache_hits for stage in self.stages)
+        compaction_cache_lookups = sum(stage.compaction_cache_lookups for stage in self.stages)
         return {
             "candidate_count": candidate_count,
             "selected_count": selected_count,
@@ -123,6 +157,20 @@ class ContextSelectionReport:
             "mean_useful_artifact_recall": _mean_optional(stage.useful_artifact_recall for stage in self.stages),
             "mean_selected_freshness_generation_delta": _mean_optional(
                 stage.mean_selected_freshness_generation_delta for stage in self.stages
+            ),
+            "budget_input_token_estimate": sum(stage.budget_input_token_estimate for stage in self.stages),
+            "budget_output_token_estimate": sum(stage.budget_output_token_estimate for stage in self.stages),
+            "budget_token_reduction": sum(stage.budget_token_reduction for stage in self.stages),
+            "budget_dedupe_hit_count": sum(stage.budget_dedupe_hit_count for stage in self.stages),
+            "budget_component_cap_hit_count": sum(stage.budget_component_cap_hit_count for stage in self.stages),
+            "budget_trimmed_component_count": sum(stage.budget_trimmed_component_count for stage in self.stages),
+            "compaction_cache_hits": compaction_cache_hits,
+            "compaction_cache_misses": sum(stage.compaction_cache_misses for stage in self.stages),
+            "compaction_cache_lookups": compaction_cache_lookups,
+            "compaction_cache_hit_rate": (
+                compaction_cache_hits / compaction_cache_lookups
+                if compaction_cache_lookups
+                else None
             ),
         }
 
@@ -189,6 +237,31 @@ class ContextSelectionReport:
                     stage=token_stage.stage,
                 )
             )
+        cache_stages = [
+            stage
+            for stage in self.stages
+            if stage.compaction_cache_hit_rate is not None
+            and stage.compaction_cache_lookups >= policy.compaction_cache_min_lookups
+        ]
+        if cache_stages:
+            cache_stage = min(cache_stages, key=lambda stage: stage.compaction_cache_hit_rate or 0.0)
+            hit_rate = cache_stage.compaction_cache_hit_rate
+            if hit_rate is not None and hit_rate < policy.compaction_cache_hit_rate_floor:
+                diagnostics.append(
+                    ContextSelectionDiagnostic(
+                        code="LOW_COMPACTION_CACHE_HIT_RATE",
+                        severity="info",
+                        metric_name="compaction_cache_hit_rate",
+                        value=hit_rate,
+                        threshold=policy.compaction_cache_hit_rate_floor,
+                        message="Semantic compaction cache reuse was low for a prompt assembly stage.",
+                        recommendation=(
+                            "Check whether repeated prompt components use stable canonical text before cache lookup."
+                        ),
+                        generation=cache_stage.generation,
+                        stage=cache_stage.stage,
+                    )
+                )
         return tuple(diagnostics)
 
     def to_dict(self) -> dict[str, Any]:

--- a/autocontext/src/autocontext/loop/stage_helpers/semantic_benchmark.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/semantic_benchmark.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from autocontext.extensions import HookEvents
-from autocontext.knowledge.compaction import CompactionEntry
+from autocontext.knowledge.compaction import CompactionEntry, prompt_compaction_cache_stats
 from autocontext.knowledge.context_selection import build_prompt_context_selection_decision
 from autocontext.knowledge.semantic_compaction_benchmark import (
     build_semantic_compaction_benchmark_report,
@@ -20,6 +21,31 @@ if TYPE_CHECKING:
     from autocontext.storage import ArtifactStore
 
 logger = logging.getLogger(__name__)
+
+
+def _cache_counter_delta(before: Mapping[str, int], after: Mapping[str, int], key: str) -> int:
+    return max(0, _coerce_cache_int(after.get(key)) - _coerce_cache_int(before.get(key)))
+
+
+def _coerce_cache_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return 0
+
+
+def _prompt_compaction_cache_delta(before: Mapping[str, int], after: Mapping[str, int]) -> dict[str, int]:
+    hits = _cache_counter_delta(before, after, "hits")
+    misses = _cache_counter_delta(before, after, "misses")
+    return {
+        "hits": hits,
+        "misses": misses,
+        "lookups": hits + misses,
+        "entries": _coerce_cache_int(after.get("entries")),
+    }
 
 
 def _latest_compaction_parent_id(artifacts: ArtifactStore, run_id: str) -> str:
@@ -303,16 +329,22 @@ def prepare_generation_prompts(
     prompt_kwargs["compaction_entry_sink"] = lambda entries: _append_compaction_entries_for_context(ctx, artifacts, entries)
     raw_context_components = _benchmarkable_prompt_components_from_kwargs(prompt_kwargs)
     selected_context_components: dict[str, str] = {}
+    context_budget_telemetry: list[dict[str, Any]] = []
     prompt_kwargs["context_component_sink"] = selected_context_components.update
+    prompt_kwargs["context_budget_telemetry_sink"] = lambda telemetry: context_budget_telemetry.append(telemetry.to_dict())
+    compaction_cache_before = prompt_compaction_cache_stats()
     build_start = time.perf_counter()
     prompts = build_prompt_bundle(**prompt_kwargs)
     semantic_build_latency_ms = (time.perf_counter() - build_start) * 1000.0
+    compaction_cache_after = prompt_compaction_cache_stats()
     _persist_generation_context_selection(
         ctx,
         artifacts=artifacts,
         candidate_components=raw_context_components,
         selected_components=selected_context_components,
         context_budget_tokens=context_budget_tokens,
+        context_budget_telemetry=context_budget_telemetry[-1] if context_budget_telemetry else None,
+        prompt_compaction_cache=_prompt_compaction_cache_delta(compaction_cache_before, compaction_cache_after),
         evidence_cache_hits=evidence_cache_hits,
         evidence_cache_lookups=evidence_cache_lookups,
     )
@@ -322,6 +354,7 @@ def prepare_generation_prompts(
     baseline_start = time.perf_counter()
     baseline_prompt_kwargs = dict(prompt_kwargs)
     baseline_prompt_kwargs.pop("context_component_sink", None)
+    baseline_prompt_kwargs.pop("context_budget_telemetry_sink", None)
     budget_only_prompts = build_prompt_bundle(**baseline_prompt_kwargs, semantic_compaction=False)
     budget_only_build_latency_ms = (time.perf_counter() - baseline_start) * 1000.0
     benchmark_report = build_semantic_compaction_benchmark_report(
@@ -355,9 +388,21 @@ def _persist_generation_context_selection(
     candidate_components: dict[str, str],
     selected_components: dict[str, str],
     context_budget_tokens: int,
+    context_budget_telemetry: dict[str, Any] | None,
+    prompt_compaction_cache: Mapping[str, int],
     evidence_cache_hits: int,
     evidence_cache_lookups: int,
 ) -> None:
+    metadata: dict[str, Any] = {
+        "context_budget_tokens": context_budget_tokens,
+        "semantic_compaction": True,
+        "selected_component_scope": "final_role_prompts_after_context_hook",
+        "prompt_compaction_cache": dict(prompt_compaction_cache),
+        "evidence_cache_hits": evidence_cache_hits,
+        "evidence_cache_lookups": evidence_cache_lookups,
+    }
+    if context_budget_telemetry is not None:
+        metadata["context_budget_telemetry"] = dict(context_budget_telemetry)
     decision = build_prompt_context_selection_decision(
         run_id=ctx.run_id,
         scenario_name=ctx.scenario_name,
@@ -365,13 +410,7 @@ def _persist_generation_context_selection(
         stage="generation_prompt_context",
         candidate_components=candidate_components,
         selected_components=selected_components,
-        metadata={
-            "context_budget_tokens": context_budget_tokens,
-            "semantic_compaction": True,
-            "selected_component_scope": "final_role_prompts_after_context_hook",
-            "evidence_cache_hits": evidence_cache_hits,
-            "evidence_cache_lookups": evidence_cache_lookups,
-        },
+        metadata=metadata,
     )
     try:
         persist_context_selection_decision(artifacts, decision)

--- a/autocontext/src/autocontext/prompts/__init__.py
+++ b/autocontext/src/autocontext/prompts/__init__.py
@@ -1,3 +1,12 @@
+from .context_budget import ContextBudget, ContextBudgetPolicy, ContextBudgetResult, ContextBudgetTelemetry, estimate_tokens
 from .templates import PromptBundle, build_prompt_bundle
 
-__all__ = ["PromptBundle", "build_prompt_bundle"]
+__all__ = [
+    "ContextBudget",
+    "ContextBudgetPolicy",
+    "ContextBudgetResult",
+    "ContextBudgetTelemetry",
+    "PromptBundle",
+    "build_prompt_bundle",
+    "estimate_tokens",
+]

--- a/autocontext/src/autocontext/prompts/context_budget.py
+++ b/autocontext/src/autocontext/prompts/context_budget.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +109,69 @@ class ContextBudgetPolicy:
     canonical_component_order: tuple[str, ...] = _CANONICAL_COMPONENT_ORDER
 
 
+@dataclass(frozen=True)
+class ContextBudgetTelemetry:
+    """Structured telemetry for one prompt budget application."""
+
+    max_tokens: int
+    input_token_estimate: int
+    output_token_estimate: int
+    component_tokens_before: dict[str, int]
+    component_tokens_after: dict[str, int]
+    deduplicated_components: tuple[str, ...] = ()
+    role_scoped_dedupe_skip_count: int = 0
+    protected_dedupe_skip_count: int = 0
+    component_cap_hits: tuple[dict[str, Any], ...] = ()
+    global_trim_hits: tuple[dict[str, Any], ...] = ()
+
+    @property
+    def dedupe_hit_count(self) -> int:
+        return len(self.deduplicated_components)
+
+    @property
+    def component_cap_hit_count(self) -> int:
+        return len(self.component_cap_hits)
+
+    @property
+    def trimmed_components(self) -> tuple[str, ...]:
+        return tuple(str(hit.get("component", "")) for hit in self.global_trim_hits if hit.get("component"))
+
+    @property
+    def trimmed_component_count(self) -> int:
+        return len(self.global_trim_hits)
+
+    @property
+    def token_reduction(self) -> int:
+        return max(0, self.input_token_estimate - self.output_token_estimate)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "max_tokens": self.max_tokens,
+            "input_token_estimate": self.input_token_estimate,
+            "output_token_estimate": self.output_token_estimate,
+            "token_reduction": self.token_reduction,
+            "component_tokens_before": dict(self.component_tokens_before),
+            "component_tokens_after": dict(self.component_tokens_after),
+            "dedupe_hit_count": self.dedupe_hit_count,
+            "deduplicated_components": list(self.deduplicated_components),
+            "role_scoped_dedupe_skip_count": self.role_scoped_dedupe_skip_count,
+            "protected_dedupe_skip_count": self.protected_dedupe_skip_count,
+            "component_cap_hit_count": self.component_cap_hit_count,
+            "component_cap_hits": [dict(hit) for hit in self.component_cap_hits],
+            "trimmed_component_count": self.trimmed_component_count,
+            "trimmed_components": list(self.trimmed_components),
+            "global_trim_hits": [dict(hit) for hit in self.global_trim_hits],
+        }
+
+
+@dataclass(frozen=True)
+class ContextBudgetResult:
+    """Budgeted prompt components plus decision telemetry."""
+
+    components: dict[str, str]
+    telemetry: ContextBudgetTelemetry
+
+
 def estimate_tokens(text: str) -> int:
     """Estimate token count using char/4 heuristic."""
     return len(text) // 4
@@ -149,61 +213,104 @@ class ContextBudget:
 
     def apply(self, components: dict[str, str]) -> dict[str, str]:
         """Apply budget to components dict, returning trimmed copy."""
-        if self.max_tokens <= 0:
-            return dict(components)
+        return self.apply_with_telemetry(components).components
 
-        result = _deduplicate_equivalent_components(dict(components), self.policy)
-        result = _apply_component_caps(result, self.policy)
+    def apply_with_telemetry(self, components: dict[str, str]) -> ContextBudgetResult:
+        """Apply budget and return telemetry describing the reduction path."""
+        input_components = dict(components)
+        before_tokens = _component_token_counts(input_components)
+        input_total = sum(before_tokens.values())
+        if self.max_tokens <= 0:
+            telemetry = ContextBudgetTelemetry(
+                max_tokens=self.max_tokens,
+                input_token_estimate=input_total,
+                output_token_estimate=input_total,
+                component_tokens_before=before_tokens,
+                component_tokens_after=dict(before_tokens),
+            )
+            return ContextBudgetResult(components=input_components, telemetry=telemetry)
+
+        result, deduplicated, role_scoped_skips, protected_skips = _deduplicate_equivalent_components(
+            input_components,
+            self.policy,
+        )
+        result, cap_hits = _apply_component_caps(result, self.policy)
 
         total = sum(estimate_tokens(v) for v in result.values())
-        if total <= self.max_tokens:
-            return result
-
-        logger.info(
-            "context budget exceeded: %d estimated tokens > %d max, trimming",
-            total,
-            self.max_tokens,
-        )
-
+        trim_hits: list[dict[str, Any]] = []
         remaining = total
-        for key in self.policy.trim_order:
-            if key not in result or key in self.policy.protected_components:
-                continue
-            if remaining <= self.max_tokens:
-                break
-            overshoot = remaining - self.max_tokens
-            old_tokens = estimate_tokens(result[key])
-            target_tokens = max(0, old_tokens - overshoot)
-            if target_tokens < old_tokens:
-                result[key] = _truncate_to_tokens(result[key], target_tokens)
-                new_tokens = estimate_tokens(result[key])
-                remaining -= old_tokens - new_tokens
-                logger.debug(
-                    "trimmed %s from %d to %d est. tokens",
-                    key,
-                    old_tokens,
-                    new_tokens,
-                )
+        if total > self.max_tokens:
+            logger.info(
+                "context budget exceeded: %d estimated tokens > %d max, trimming",
+                total,
+                self.max_tokens,
+            )
 
-        return result
+            for key in self.policy.trim_order:
+                if key not in result or key in self.policy.protected_components:
+                    continue
+                if remaining <= self.max_tokens:
+                    break
+                overshoot = remaining - self.max_tokens
+                old_tokens = estimate_tokens(result[key])
+                target_tokens = max(0, old_tokens - overshoot)
+                if target_tokens < old_tokens:
+                    result[key] = _truncate_to_tokens(result[key], target_tokens)
+                    new_tokens = estimate_tokens(result[key])
+                    remaining -= old_tokens - new_tokens
+                    trim_hits.append(
+                        {
+                            "component": key,
+                            "before_tokens": old_tokens,
+                            "after_tokens": new_tokens,
+                            "target_tokens": target_tokens,
+                        }
+                    )
+                    logger.debug(
+                        "trimmed %s from %d to %d est. tokens",
+                        key,
+                        old_tokens,
+                        new_tokens,
+                    )
+
+        after_tokens = _component_token_counts(result)
+        telemetry = ContextBudgetTelemetry(
+            max_tokens=self.max_tokens,
+            input_token_estimate=input_total,
+            output_token_estimate=sum(after_tokens.values()),
+            component_tokens_before=before_tokens,
+            component_tokens_after=after_tokens,
+            deduplicated_components=tuple(deduplicated),
+            role_scoped_dedupe_skip_count=role_scoped_skips,
+            protected_dedupe_skip_count=protected_skips,
+            component_cap_hits=tuple(cap_hits),
+            global_trim_hits=tuple(trim_hits),
+        )
+        return ContextBudgetResult(components=result, telemetry=telemetry)
 
 
 def _deduplicate_equivalent_components(
     components: dict[str, str],
     policy: ContextBudgetPolicy,
-) -> dict[str, str]:
+) -> tuple[dict[str, str], list[str], int, int]:
     groups: dict[str, list[str]] = {}
+    role_scoped_skips = 0
     for key, value in components.items():
         if key in policy.role_scoped_components:
+            if _duplicate_key(value):
+                role_scoped_skips += 1
             continue
         duplicate_key = _duplicate_key(value)
         if duplicate_key:
             groups.setdefault(duplicate_key, []).append(key)
 
     rank = _canonical_rank(policy.canonical_component_order)
+    deduplicated: list[str] = []
+    protected_skips = 0
     for keys in groups.values():
         if len(keys) < 2:
             continue
+        protected_skips += sum(1 for key in keys if key in policy.protected_components)
         unprotected = [key for key in keys if key not in policy.protected_components]
         if not unprotected:
             continue
@@ -211,15 +318,17 @@ def _deduplicate_equivalent_components(
         for key in unprotected:
             if key != keep:
                 components[key] = ""
+                deduplicated.append(key)
                 logger.debug("deduplicated prompt component %s in favor of %s", key, keep)
-    return components
+    return components, deduplicated, role_scoped_skips, protected_skips
 
 
 def _apply_component_caps(
     components: dict[str, str],
     policy: ContextBudgetPolicy,
-) -> dict[str, str]:
+) -> tuple[dict[str, str], list[dict[str, Any]]]:
     result = dict(components)
+    hits: list[dict[str, Any]] = []
     for key, raw_cap in policy.component_token_caps.items():
         if key not in result or key in policy.protected_components:
             continue
@@ -228,15 +337,29 @@ def _apply_component_caps(
         except (TypeError, ValueError):
             continue
         value = result[key]
-        if estimate_tokens(value) > cap:
+        old_tokens = estimate_tokens(value)
+        if old_tokens > cap:
             result[key] = _truncate_to_tokens(value, cap)
+            new_tokens = estimate_tokens(result[key])
+            hits.append(
+                {
+                    "component": key,
+                    "before_tokens": old_tokens,
+                    "after_tokens": new_tokens,
+                    "cap_tokens": cap,
+                }
+            )
             logger.debug("capped prompt component %s at %d estimated tokens", key, cap)
-    return result
+    return result, hits
 
 
 def _duplicate_key(value: str) -> str:
     normalized = " ".join(value.split())
     return normalized if normalized else ""
+
+
+def _component_token_counts(components: Mapping[str, str]) -> dict[str, int]:
+    return {key: estimate_tokens(value) for key, value in components.items()}
 
 
 def _canonical_rank(order: tuple[str, ...]) -> Callable[[str], int]:

--- a/autocontext/src/autocontext/prompts/templates.py
+++ b/autocontext/src/autocontext/prompts/templates.py
@@ -10,7 +10,7 @@ from autocontext.knowledge.compaction import (
     compact_prompt_components,
     compaction_entries_for_components,
 )
-from autocontext.prompts.context_budget import ContextBudget
+from autocontext.prompts.context_budget import ContextBudget, ContextBudgetTelemetry
 from autocontext.scenarios.base import Observation
 from autocontext.strategy_interface import is_action_plan_interface
 
@@ -125,6 +125,7 @@ def build_prompt_bundle(
     compaction_entry_parent_id: str = "",
     compaction_entry_sink: Callable[[list[CompactionEntry]], None] | None = None,
     context_component_sink: Callable[[dict[str, str]], None] | None = None,
+    context_budget_telemetry_sink: Callable[[ContextBudgetTelemetry], None] | None = None,
 ) -> PromptBundle:
     _nb = dict(notebook_contexts or {})
     _evidence = dict(evidence_manifests or {})
@@ -209,7 +210,10 @@ def build_prompt_bundle(
     }
     if context_budget_tokens > 0:
         budget = ContextBudget(max_tokens=context_budget_tokens)
-        budgeted = budget.apply(context_components)
+        budget_result = budget.apply_with_telemetry(context_components)
+        budgeted = budget_result.components
+        if context_budget_telemetry_sink is not None:
+            context_budget_telemetry_sink(budget_result.telemetry)
         context_components = budgeted
         current_playbook = budgeted["playbook"]
         score_trajectory = budgeted["trajectory"]

--- a/autocontext/tests/test_context_budget.py
+++ b/autocontext/tests/test_context_budget.py
@@ -142,3 +142,49 @@ def test_budget_policy_overrides_trim_order_and_protected_components() -> None:
 
     assert len(trimmed["playbook"]) < len(components["playbook"])
     assert trimmed["analysis"] == components["analysis"]
+
+
+def test_budget_apply_with_telemetry_records_dedupe_caps_and_trims() -> None:
+    """Budget telemetry explains the reduction path without exposing raw content."""
+    budget = ContextBudget(
+        max_tokens=20,
+        policy=ContextBudgetPolicy(component_token_caps={"tools": 5}),
+    )
+    duplicate = "Use the stable rollback guard."
+
+    result = budget.apply_with_telemetry(
+        {
+            "playbook": duplicate,
+            "analysis": duplicate,
+            "tools": "T" * 200,
+            "trajectory": "R" * 200,
+            "hints": "keep this hint",
+        }
+    )
+
+    telemetry = result.telemetry
+    assert result.components == budget.apply(
+        {
+            "playbook": duplicate,
+            "analysis": duplicate,
+            "tools": "T" * 200,
+            "trajectory": "R" * 200,
+            "hints": "keep this hint",
+        }
+    )
+    assert telemetry.max_tokens == 20
+    assert telemetry.input_token_estimate > telemetry.output_token_estimate
+    assert telemetry.component_tokens_before["analysis"] > 0
+    assert telemetry.component_tokens_after["analysis"] == 0
+    assert telemetry.dedupe_hit_count == 1
+    assert telemetry.deduplicated_components == ("analysis",)
+    assert telemetry.component_cap_hit_count == 1
+    assert telemetry.component_cap_hits[0]["component"] == "tools"
+    assert telemetry.component_cap_hits[0]["cap_tokens"] == 5
+    assert telemetry.trimmed_component_count >= 1
+    assert "trajectory" in telemetry.trimmed_components
+
+    payload = telemetry.to_dict()
+    assert payload["input_token_estimate"] == telemetry.input_token_estimate
+    assert payload["dedupe_hit_count"] == 1
+    assert payload["component_cap_hit_count"] == 1

--- a/autocontext/tests/test_context_selection.py
+++ b/autocontext/tests/test_context_selection.py
@@ -47,7 +47,13 @@ def _generation_context(tmp_path: Path, *, hook_bus: HookBus | None = None) -> t
     )
 
 
-def _prepare_generation_prompts(ctx: GenerationContext, artifacts: ArtifactStore, *, current_playbook: str = "abcd") -> None:
+def _prepare_generation_prompts(
+    ctx: GenerationContext,
+    artifacts: ArtifactStore,
+    *,
+    current_playbook: str = "abcd",
+    context_budget_tokens: int = 0,
+) -> None:
     prepare_generation_prompts(
         ctx,
         artifacts=artifacts,
@@ -76,7 +82,7 @@ def _prepare_generation_prompts(ctx: GenerationContext, artifacts: ArtifactStore
         session_reports="",
         architect_tool_usage_report="",
         constraint_mode=False,
-        context_budget_tokens=0,
+        context_budget_tokens=context_budget_tokens,
         notebook_contexts=None,
         environment_snapshot="",
         evidence_manifest="",
@@ -188,6 +194,57 @@ def test_context_selection_decision_round_trips_without_prompt_content() -> None
     assert restored == decision
     assert "secret strategy text" not in str(payload)
     assert payload["metrics"]["selected_token_estimate"] == 1
+
+
+def test_context_selection_decision_metrics_include_budget_and_compaction_telemetry() -> None:
+    from autocontext.knowledge.context_selection import (
+        ContextSelectionCandidate,
+        ContextSelectionDecision,
+    )
+
+    decision = ContextSelectionDecision(
+        run_id="run-1",
+        scenario_name="grid_ctf",
+        generation=2,
+        stage="prompt_context",
+        candidates=(
+            ContextSelectionCandidate.from_contents(
+                artifact_id="playbook",
+                artifact_type="prompt_component",
+                source="prompt_assembly",
+                candidate_content="x" * 200,
+                selected_content="x" * 40,
+                selection_reason="trimmed",
+            ),
+        ),
+        metadata={
+            "context_budget_telemetry": {
+                "input_token_estimate": 120,
+                "output_token_estimate": 40,
+                "dedupe_hit_count": 2,
+                "component_cap_hit_count": 1,
+                "trimmed_component_count": 3,
+            },
+            "prompt_compaction_cache": {
+                "hits": 4,
+                "misses": 6,
+                "lookups": 10,
+            },
+        },
+    )
+
+    metrics = decision.metrics()
+
+    assert metrics["budget_input_token_estimate"] == 120
+    assert metrics["budget_output_token_estimate"] == 40
+    assert metrics["budget_token_reduction"] == 80
+    assert metrics["budget_dedupe_hit_count"] == 2
+    assert metrics["budget_component_cap_hit_count"] == 1
+    assert metrics["budget_trimmed_component_count"] == 3
+    assert metrics["compaction_cache_hits"] == 4
+    assert metrics["compaction_cache_misses"] == 6
+    assert metrics["compaction_cache_lookups"] == 10
+    assert metrics["compaction_cache_hit_rate"] == 0.4
 
 
 def test_persist_context_selection_decision_writes_under_run_root(tmp_path: Path) -> None:
@@ -404,6 +461,61 @@ def test_context_selection_report_emits_actionable_diagnostics() -> None:
     assert "Diagnostics" in report.to_markdown()
 
 
+def test_context_selection_report_summarizes_budget_and_cache_regression_gates() -> None:
+    from autocontext.knowledge.context_selection import (
+        ContextSelectionCandidate,
+        ContextSelectionDecision,
+    )
+    from autocontext.knowledge.context_selection_report import build_context_selection_report
+
+    report = build_context_selection_report(
+        (
+            ContextSelectionDecision(
+                run_id="run-1",
+                scenario_name="grid_ctf",
+                generation=3,
+                stage="generation_prompt_context",
+                candidates=(
+                    ContextSelectionCandidate.from_contents(
+                        artifact_id="playbook",
+                        artifact_type="prompt_component",
+                        source="prompt_assembly",
+                        candidate_content="x" * 400,
+                        selected_content="x" * 80,
+                        selection_reason="trimmed",
+                    ),
+                ),
+                metadata={
+                    "context_budget_telemetry": {
+                        "input_token_estimate": 120,
+                        "output_token_estimate": 20,
+                        "dedupe_hit_count": 1,
+                        "component_cap_hit_count": 2,
+                        "trimmed_component_count": 1,
+                    },
+                    "prompt_compaction_cache": {
+                        "hits": 0,
+                        "misses": 10,
+                        "lookups": 10,
+                    },
+                },
+            ),
+        )
+    )
+
+    payload = report.to_dict()
+    summary = payload["summary"]
+    diagnostics = {diagnostic["code"]: diagnostic for diagnostic in payload["diagnostics"]}
+
+    assert summary["budget_token_reduction"] == 100
+    assert summary["budget_dedupe_hit_count"] == 1
+    assert summary["budget_component_cap_hit_count"] == 2
+    assert summary["budget_trimmed_component_count"] == 1
+    assert summary["compaction_cache_hit_rate"] == 0.0
+    assert "LOW_COMPACTION_CACHE_HIT_RATE" in diagnostics
+    assert "cache" in diagnostics["LOW_COMPACTION_CACHE_HIT_RATE"]["recommendation"].lower()
+
+
 def _diagnostic_by_code(payload: dict[str, Any], code: str) -> dict[str, Any]:
     return next(diagnostic for diagnostic in payload["diagnostics"] if diagnostic["code"] == code)
 
@@ -544,6 +656,29 @@ def test_prepare_generation_prompts_persists_context_selection_artifact(tmp_path
     assert payload["metrics"]["selected_count"] >= 3
     assert payload["metrics"]["selected_token_estimate"] > 0
     assert payload["metrics"]["duplicate_content_rate"] > 0
+
+
+def test_prepare_generation_prompts_persists_budget_and_compaction_telemetry(tmp_path: Path) -> None:
+    from autocontext.knowledge.compaction import clear_prompt_compaction_cache
+
+    clear_prompt_compaction_cache()
+    artifacts, ctx = _generation_context(tmp_path)
+
+    _prepare_generation_prompts(
+        ctx,
+        artifacts,
+        current_playbook="x" * 400,
+        context_budget_tokens=50,
+    )
+
+    payload = _context_selection_payload(artifacts)
+    metadata = payload["metadata"]
+
+    assert metadata["context_budget_telemetry"]["max_tokens"] == 50
+    assert payload["metrics"]["budget_input_token_estimate"] > payload["metrics"]["budget_output_token_estimate"]
+    assert payload["metrics"]["budget_trimmed_component_count"] >= 1
+    assert metadata["prompt_compaction_cache"]["lookups"] > 0
+    assert payload["metrics"]["compaction_cache_misses"] > 0
 
 
 def test_context_selection_candidates_reflect_context_components_hook(tmp_path: Path) -> None:

--- a/autocontext/tests/test_python_core_package.py
+++ b/autocontext/tests/test_python_core_package.py
@@ -13,6 +13,9 @@ if str(PY_CORE_SRC) not in sys.path:
 core_package = import_module("autocontext_core")
 CompletionResult = core_package.CompletionResult
 ContextBudget = core_package.ContextBudget
+ContextBudgetPolicy = core_package.ContextBudgetPolicy
+ContextBudgetResult = core_package.ContextBudgetResult
+ContextBudgetTelemetry = core_package.ContextBudgetTelemetry
 PromptBundle = core_package.PromptBundle
 ProviderError = core_package.ProviderError
 build_prompt_bundle = core_package.build_prompt_bundle
@@ -36,11 +39,15 @@ def test_python_core_reexports_elo_primitives() -> None:
 def test_python_core_reexports_prompt_budget_helpers() -> None:
     assert estimate_tokens("abcdabcd") == 2
 
-    budget = ContextBudget(max_tokens=20)
-    result = budget.apply({"playbook": "12345678901234567890" * 20, "hints": "keep-me"})
+    budget = ContextBudget(max_tokens=20, policy=ContextBudgetPolicy(component_token_caps={}))
+    telemetry_result = budget.apply_with_telemetry({"playbook": "12345678901234567890" * 20, "hints": "keep-me"})
+    result = telemetry_result.components
 
     assert result["hints"] == "keep-me"
     assert "truncated for context budget" in result["playbook"]
+    assert isinstance(telemetry_result, ContextBudgetResult)
+    assert isinstance(telemetry_result.telemetry, ContextBudgetTelemetry)
+    assert telemetry_result.telemetry.token_reduction > 0
 
 
 def test_python_core_reexports_prompt_bundle_assembly() -> None:

--- a/packages/python/core/src/autocontext_core/__init__.py
+++ b/packages/python/core/src/autocontext_core/__init__.py
@@ -25,6 +25,9 @@ _storage_row_types = import_module("autocontext.storage.row_types")
 expected_score = _elo.expected_score
 update_elo = _elo.update_elo
 ContextBudget = _context_budget.ContextBudget
+ContextBudgetPolicy = _context_budget.ContextBudgetPolicy
+ContextBudgetResult = _context_budget.ContextBudgetResult
+ContextBudgetTelemetry = _context_budget.ContextBudgetTelemetry
 estimate_tokens = _context_budget.estimate_tokens
 PromptBundle = _templates.PromptBundle
 build_prompt_bundle = _templates.build_prompt_bundle
@@ -121,6 +124,9 @@ __all__ = [
     "CompletionResult",
     "ContextValidity",
     "ContextBudget",
+    "ContextBudgetPolicy",
+    "ContextBudgetResult",
+    "ContextBudgetTelemetry",
     "DisagreementMetrics",
     "EnvironmentSpec",
     "CoordinationInterface",

--- a/packages/ts/core/src/index.ts
+++ b/packages/ts/core/src/index.ts
@@ -106,7 +106,12 @@ export {
 	estimateTokens,
 } from "../../../../ts/src/prompts/context-budget.js";
 export type {
+	ComponentBudgetHit,
+	ComponentCapHit,
 	ContextBudgetPolicyOptions,
+	ContextBudgetResult,
+	ContextBudgetTelemetry,
+	GlobalTrimHit,
 } from "../../../../ts/src/prompts/context-budget.js";
 export type {
 	PromptBundle,

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -77,7 +77,14 @@ export type {
 
 // Prompts
 export { ContextBudget, ContextBudgetPolicy, estimateTokens } from "./prompts/context-budget.js";
-export type { ContextBudgetPolicyOptions } from "./prompts/context-budget.js";
+export type {
+  ComponentBudgetHit,
+  ComponentCapHit,
+  ContextBudgetPolicyOptions,
+  ContextBudgetResult,
+  ContextBudgetTelemetry,
+  GlobalTrimHit,
+} from "./prompts/context-budget.js";
 export { buildPromptBundle } from "./prompts/templates.js";
 export type { PromptBundle, PromptContext } from "./prompts/templates.js";
 

--- a/ts/src/prompts/context-budget.ts
+++ b/ts/src/prompts/context-budget.ts
@@ -107,6 +107,43 @@ export class ContextBudgetPolicy {
   }
 }
 
+export interface ComponentBudgetHit {
+  component: string;
+  beforeTokens: number;
+  afterTokens: number;
+}
+
+export interface ComponentCapHit extends ComponentBudgetHit {
+  capTokens: number;
+}
+
+export interface GlobalTrimHit extends ComponentBudgetHit {
+  targetTokens: number;
+}
+
+export interface ContextBudgetTelemetry {
+  maxTokens: number;
+  inputTokenEstimate: number;
+  outputTokenEstimate: number;
+  tokenReduction: number;
+  componentTokensBefore: Record<string, number>;
+  componentTokensAfter: Record<string, number>;
+  dedupeHitCount: number;
+  deduplicatedComponents: string[];
+  roleScopedDedupeSkipCount: number;
+  protectedDedupeSkipCount: number;
+  componentCapHitCount: number;
+  componentCapHits: ComponentCapHit[];
+  trimmedComponentCount: number;
+  trimmedComponents: string[];
+  globalTrimHits: GlobalTrimHit[];
+}
+
+export interface ContextBudgetResult {
+  components: Record<string, string>;
+  telemetry: ContextBudgetTelemetry;
+}
+
 export function estimateTokens(text: string): number {
   return Math.floor(text.length / 4);
 }
@@ -135,81 +172,181 @@ export class ContextBudget {
   }
 
   apply(components: Record<string, string>): Record<string, string> {
-    if (this.maxTokens <= 0) return { ...components };
+    return this.applyWithTelemetry(components).components;
+  }
 
-    const result = applyComponentCaps(
-      deduplicateEquivalentComponents({ ...components }, this.policy),
+  applyWithTelemetry(components: Record<string, string>): ContextBudgetResult {
+    const inputComponents = { ...components };
+    const componentTokensBefore = componentTokenCounts(inputComponents);
+    const inputTokenEstimate = sumTokens(componentTokensBefore);
+    if (this.maxTokens <= 0) {
+      return {
+        components: inputComponents,
+        telemetry: buildTelemetry({
+          maxTokens: this.maxTokens,
+          inputTokenEstimate,
+          componentTokensBefore,
+          componentTokensAfter: { ...componentTokensBefore },
+        }),
+      };
+    }
+
+    const deduped = deduplicateEquivalentComponents(inputComponents, this.policy);
+    const capped = applyComponentCaps(
+      deduped.components,
       this.policy,
     );
+    const result = capped.components;
 
     let total = 0;
     for (const v of Object.values(result)) {
       total += estimateTokens(v);
     }
-    if (total <= this.maxTokens) return result;
-
+    const globalTrimHits: GlobalTrimHit[] = [];
     let remaining = total;
 
-    for (const key of this.policy.trimOrder) {
-      if (!(key in result) || this.policy.protectedComponents.has(key)) continue;
-      if (remaining <= this.maxTokens) break;
+    if (total > this.maxTokens) {
+      for (const key of this.policy.trimOrder) {
+        if (!(key in result) || this.policy.protectedComponents.has(key)) continue;
+        if (remaining <= this.maxTokens) break;
 
-      const overshoot = remaining - this.maxTokens;
-      const oldTokens = estimateTokens(result[key]);
-      const targetTokens = Math.max(0, oldTokens - overshoot);
+        const overshoot = remaining - this.maxTokens;
+        const oldTokens = estimateTokens(result[key]);
+        const targetTokens = Math.max(0, oldTokens - overshoot);
 
-      if (targetTokens < oldTokens) {
-        result[key] = truncateToTokens(result[key], targetTokens);
-        const newTokens = estimateTokens(result[key]);
-        remaining -= oldTokens - newTokens;
+        if (targetTokens < oldTokens) {
+          result[key] = truncateToTokens(result[key], targetTokens);
+          const newTokens = estimateTokens(result[key]);
+          remaining -= oldTokens - newTokens;
+          globalTrimHits.push({
+            component: key,
+            beforeTokens: oldTokens,
+            afterTokens: newTokens,
+            targetTokens,
+          });
+        }
       }
     }
 
-    return result;
+    return {
+      components: result,
+      telemetry: buildTelemetry({
+        maxTokens: this.maxTokens,
+        inputTokenEstimate,
+        componentTokensBefore,
+        componentTokensAfter: componentTokenCounts(result),
+        deduplicatedComponents: deduped.deduplicatedComponents,
+        roleScopedDedupeSkipCount: deduped.roleScopedDedupeSkipCount,
+        protectedDedupeSkipCount: deduped.protectedDedupeSkipCount,
+        componentCapHits: capped.componentCapHits,
+        globalTrimHits,
+      }),
+    };
   }
+}
+
+interface TelemetryInput {
+  maxTokens: number;
+  inputTokenEstimate: number;
+  componentTokensBefore: Record<string, number>;
+  componentTokensAfter: Record<string, number>;
+  deduplicatedComponents?: string[];
+  roleScopedDedupeSkipCount?: number;
+  protectedDedupeSkipCount?: number;
+  componentCapHits?: ComponentCapHit[];
+  globalTrimHits?: GlobalTrimHit[];
+}
+
+function buildTelemetry(input: TelemetryInput): ContextBudgetTelemetry {
+  const componentCapHits = input.componentCapHits ?? [];
+  const globalTrimHits = input.globalTrimHits ?? [];
+  const outputTokenEstimate = sumTokens(input.componentTokensAfter);
+  return {
+    maxTokens: input.maxTokens,
+    inputTokenEstimate: input.inputTokenEstimate,
+    outputTokenEstimate,
+    tokenReduction: Math.max(0, input.inputTokenEstimate - outputTokenEstimate),
+    componentTokensBefore: { ...input.componentTokensBefore },
+    componentTokensAfter: { ...input.componentTokensAfter },
+    dedupeHitCount: input.deduplicatedComponents?.length ?? 0,
+    deduplicatedComponents: [...(input.deduplicatedComponents ?? [])],
+    roleScopedDedupeSkipCount: input.roleScopedDedupeSkipCount ?? 0,
+    protectedDedupeSkipCount: input.protectedDedupeSkipCount ?? 0,
+    componentCapHitCount: componentCapHits.length,
+    componentCapHits: componentCapHits.map((hit) => ({ ...hit })),
+    trimmedComponentCount: globalTrimHits.length,
+    trimmedComponents: globalTrimHits.map((hit) => hit.component),
+    globalTrimHits: globalTrimHits.map((hit) => ({ ...hit })),
+  };
 }
 
 function deduplicateEquivalentComponents(
   components: Record<string, string>,
   policy: ContextBudgetPolicy,
-): Record<string, string> {
+): {
+  components: Record<string, string>;
+  deduplicatedComponents: string[];
+  roleScopedDedupeSkipCount: number;
+  protectedDedupeSkipCount: number;
+} {
   const groups = new Map<string, string[]>();
+  let roleScopedDedupeSkipCount = 0;
   for (const [key, value] of Object.entries(components)) {
-    if (policy.roleScopedComponents.has(key)) continue;
+    if (policy.roleScopedComponents.has(key)) {
+      if (duplicateKey(value)) roleScopedDedupeSkipCount += 1;
+      continue;
+    }
     const normalized = duplicateKey(value);
     if (!normalized) continue;
     groups.set(normalized, [...(groups.get(normalized) ?? []), key]);
   }
 
   const rank = canonicalRank(policy.canonicalComponentOrder);
+  const deduplicatedComponents: string[] = [];
+  let protectedDedupeSkipCount = 0;
   for (const keys of groups.values()) {
     if (keys.length < 2) continue;
+    protectedDedupeSkipCount += keys.filter((key) => policy.protectedComponents.has(key)).length;
     const unprotected = keys.filter((key) => !policy.protectedComponents.has(key));
     if (unprotected.length === 0) continue;
     const keep = [...unprotected].sort((a, b) => rank(a) - rank(b))[0];
     for (const key of unprotected) {
       if (key !== keep) {
         components[key] = "";
+        deduplicatedComponents.push(key);
       }
     }
   }
-  return components;
+  return {
+    components,
+    deduplicatedComponents,
+    roleScopedDedupeSkipCount,
+    protectedDedupeSkipCount,
+  };
 }
 
 function applyComponentCaps(
   components: Record<string, string>,
   policy: ContextBudgetPolicy,
-): Record<string, string> {
+): { components: Record<string, string>; componentCapHits: ComponentCapHit[] } {
   const result = { ...components };
+  const componentCapHits: ComponentCapHit[] = [];
   for (const [key, cap] of Object.entries(policy.componentTokenCaps)) {
     if (!(key in result) || policy.protectedComponents.has(key)) continue;
     if (!Number.isFinite(cap)) continue;
     const value = result[key];
-    if (estimateTokens(value) > cap) {
+    const beforeTokens = estimateTokens(value);
+    if (beforeTokens > cap) {
       result[key] = truncateToTokens(value, cap);
+      componentCapHits.push({
+        component: key,
+        beforeTokens,
+        afterTokens: estimateTokens(result[key]),
+        capTokens: cap,
+      });
     }
   }
-  return result;
+  return { components: result, componentCapHits };
 }
 
 function duplicateKey(value: string): string {
@@ -219,4 +356,14 @@ function duplicateKey(value: string): string {
 function canonicalRank(order: readonly string[]): (key: string) => number {
   const ranks = new Map(order.map((key, index) => [key, index]));
   return (key: string) => ranks.get(key) ?? ranks.size;
+}
+
+function componentTokenCounts(components: Record<string, string>): Record<string, number> {
+  return Object.fromEntries(
+    Object.entries(components).map(([key, value]) => [key, estimateTokens(value)]),
+  );
+}
+
+function sumTokens(counts: Record<string, number>): number {
+  return Object.values(counts).reduce((total, value) => total + value, 0);
 }

--- a/ts/tests/core-package.test.ts
+++ b/ts/tests/core-package.test.ts
@@ -8,6 +8,8 @@ import type {
   AppId,
   ArtifactEditingInterface,
   CreateProductionTraceInputs,
+  ContextBudgetResult,
+  ContextBudgetTelemetry,
   EnvironmentTag,
   ExecutionLimits,
   FeedbackRefId,
@@ -255,13 +257,16 @@ describe("@autocontext/core facade", () => {
     expect(estimateTokens("abcdabcd")).toBe(2);
 
     const budget = new ContextBudget(20, new ContextBudgetPolicy({ componentTokenCaps: {} }));
-    const result = budget.apply({
+    const telemetryResult: ContextBudgetResult = budget.applyWithTelemetry({
       playbook: "12345678901234567890".repeat(20),
       hints: "keep-me",
     });
+    const telemetry: ContextBudgetTelemetry = telemetryResult.telemetry;
+    const result = telemetryResult.components;
 
     expect(result.hints).toBe("keep-me");
     expect(result.playbook).toContain("truncated for context budget");
+    expect(telemetry.tokenReduction).toBeGreaterThan(0);
   });
 
   it("re-exports prompt bundle assembly", () => {

--- a/ts/tests/knowledge-system.test.ts
+++ b/ts/tests/knowledge-system.test.ts
@@ -530,4 +530,37 @@ describe("ContextBudget", () => {
     expect(result.playbook.length).toBeLessThan(200);
     expect(result.analysis).toBe("A".repeat(200));
   });
+
+  it("records telemetry for dedupe, component caps, and global trims", async () => {
+    const { ContextBudget, ContextBudgetPolicy } = await import("../src/prompts/context-budget.js");
+    const budget = new ContextBudget(
+      20,
+      new ContextBudgetPolicy({ componentTokenCaps: { tools: 5 } }),
+    );
+    const duplicate = "Use the stable rollback guard.";
+    const components = {
+      playbook: duplicate,
+      analysis: duplicate,
+      tools: "T".repeat(200),
+      trajectory: "R".repeat(200),
+      hints: "keep this hint",
+    };
+
+    const result = budget.applyWithTelemetry(components);
+
+    expect(result.components).toEqual(budget.apply(components));
+    expect(result.telemetry.maxTokens).toBe(20);
+    expect(result.telemetry.inputTokenEstimate).toBeGreaterThan(result.telemetry.outputTokenEstimate);
+    expect(result.telemetry.componentTokensBefore.analysis).toBeGreaterThan(0);
+    expect(result.telemetry.componentTokensAfter.analysis).toBe(0);
+    expect(result.telemetry.dedupeHitCount).toBe(1);
+    expect(result.telemetry.deduplicatedComponents).toEqual(["analysis"]);
+    expect(result.telemetry.componentCapHitCount).toBe(1);
+    expect(result.telemetry.componentCapHits[0]).toMatchObject({
+      component: "tools",
+      capTokens: 5,
+    });
+    expect(result.telemetry.trimmedComponentCount).toBeGreaterThanOrEqual(1);
+    expect(result.telemetry.trimmedComponents).toContain("trajectory");
+  });
 });


### PR DESCRIPTION
## Summary
- Add structured Python/TS context-budget telemetry for dedupe, component caps, and global trims.
- Persist prompt budget telemetry and semantic compaction cache deltas into context-selection decisions.
- Roll budget/cache metrics into context-selection reports and export the new public budget types from Python and TS core facades.

## Validation
- uv run --frozen pytest tests/test_context_budget.py tests/test_context_selection.py tests/test_python_core_package.py
- uv run --frozen ruff check src tests/test_context_budget.py tests/test_context_selection.py tests/test_python_core_package.py ../packages/python/core/src/autocontext_core/__init__.py
- uv run --frozen mypy src/autocontext/prompts/context_budget.py src/autocontext/prompts/templates.py src/autocontext/knowledge/context_selection.py src/autocontext/knowledge/context_selection_report.py src/autocontext/loop/stage_helpers/semantic_benchmark.py
- npm test -- knowledge-system.test.ts core-package.test.ts
- npm run lint
- git diff --check

## Notes
- Full Python pytest had two flaky failures in unrelated tests; both passed on focused rerun.
- Full npm test had two unrelated cross-runtime property failures because the helper Python process could not import pydantic.