### PR TITLE
Add context telemetry visibility

### DIFF
--- a/autocontext/src/autocontext/knowledge/context_selection_report.py
+++ b/autocontext/src/autocontext/knowledge/context_selection_report.py
@@ -43,6 +43,26 @@ class ContextSelectionDiagnostic:
 
 
 @dataclass(frozen=True)
+class ContextSelectionTelemetryCard:
+    """Operator-facing summary tile for context-selection observability."""
+
+    key: str
+    label: str
+    value: str
+    severity: str
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "label": self.label,
+            "value": self.value,
+            "severity": self.severity,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
 class ContextSelectionStageSummary:
     run_id: str
     scenario_name: str
@@ -264,6 +284,20 @@ class ContextSelectionReport:
                 )
         return tuple(diagnostics)
 
+    def telemetry_cards(
+        self,
+        policy: ContextSelectionDiagnosticPolicy | None = None,
+    ) -> tuple[ContextSelectionTelemetryCard, ...]:
+        summary = self.summary()
+        diagnostics = self.diagnostics(policy)
+        diagnostic_codes = {diagnostic.code for diagnostic in diagnostics}
+        return (
+            _selected_context_card(summary, diagnostic_codes),
+            _context_budget_card(summary),
+            _semantic_compaction_cache_card(summary, diagnostic_codes),
+            _diagnostics_card(diagnostics),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         generations = {stage.generation for stage in self.stages}
         diagnostics = self.diagnostics()
@@ -274,6 +308,7 @@ class ContextSelectionReport:
             "decision_count": len(self.stages),
             "generation_count": len(generations),
             "summary": self.summary(),
+            "telemetry_cards": [card.to_dict() for card in self.telemetry_cards()],
             "diagnostic_count": len(diagnostics),
             "diagnostics": [diagnostic.to_dict() for diagnostic in diagnostics],
             "stages": [stage.to_dict() for stage in self.stages],
@@ -293,6 +328,24 @@ class ContextSelectionReport:
         freshness = summary["mean_selected_freshness_generation_delta"]
         if freshness is not None:
             lines.append(f"- Mean selected freshness delta: {freshness:.2f} generation(s)")
+        lines.extend(
+            [
+                "",
+                "## Context Budget",
+                f"- Input estimate: {summary['budget_input_token_estimate']}",
+                f"- Output estimate: {summary['budget_output_token_estimate']}",
+                f"- Token reduction: {summary['budget_token_reduction']}",
+                f"- Dedupe hits: {summary['budget_dedupe_hit_count']}",
+                f"- Component caps: {summary['budget_component_cap_hit_count']}",
+                f"- Global trims: {summary['budget_trimmed_component_count']}",
+                "",
+                "## Semantic Compaction Cache",
+                f"- Hit rate: {_format_optional_percent(summary['compaction_cache_hit_rate'])}",
+                f"- Hits: {summary['compaction_cache_hits']}",
+                f"- Misses: {summary['compaction_cache_misses']}",
+                f"- Lookups: {summary['compaction_cache_lookups']}",
+            ]
+        )
         diagnostics = self.diagnostics()
         if diagnostics:
             lines.extend(["", "## Diagnostics"])
@@ -353,3 +406,94 @@ def _mean(values: Iterable[float]) -> float:
 def _mean_optional(values: Iterable[float | None]) -> float | None:
     items = [value for value in values if value is not None]
     return sum(items) / len(items) if items else None
+
+
+def _selected_context_card(
+    summary: dict[str, Any],
+    diagnostic_codes: set[str],
+) -> ContextSelectionTelemetryCard:
+    severity = "warning" if "SELECTED_TOKEN_BLOAT" in diagnostic_codes else "ok"
+    return ContextSelectionTelemetryCard(
+        key="selected_context",
+        label="Selected context",
+        value=f"{_int_metric(summary, 'selected_token_estimate')} est. tokens",
+        severity=severity,
+        detail=(
+            f"{_int_metric(summary, 'selected_count')}/{_int_metric(summary, 'candidate_count')} components "
+            f"selected ({_float_metric(summary, 'selection_rate'):.1%})"
+        ),
+    )
+
+
+def _context_budget_card(summary: dict[str, Any]) -> ContextSelectionTelemetryCard:
+    input_tokens = _int_metric(summary, "budget_input_token_estimate")
+    output_tokens = _int_metric(summary, "budget_output_token_estimate")
+    token_reduction = _int_metric(summary, "budget_token_reduction")
+    dedupe_hits = _int_metric(summary, "budget_dedupe_hit_count")
+    cap_hits = _int_metric(summary, "budget_component_cap_hit_count")
+    trim_hits = _int_metric(summary, "budget_trimmed_component_count")
+    if input_tokens <= 0:
+        return ContextSelectionTelemetryCard(
+            key="context_budget",
+            label="Context budget",
+            value="No telemetry",
+            severity="info",
+            detail="No context budget telemetry recorded.",
+        )
+    severity = "warning" if trim_hits > 0 else "ok"
+    return ContextSelectionTelemetryCard(
+        key="context_budget",
+        label="Context budget",
+        value=f"{token_reduction} est. tokens reduced",
+        severity=severity,
+        detail=(
+            f"{input_tokens}->{output_tokens} est. tokens; "
+            f"{dedupe_hits} dedupe, {cap_hits} caps, {trim_hits} trims"
+        ),
+    )
+
+
+def _semantic_compaction_cache_card(
+    summary: dict[str, Any],
+    diagnostic_codes: set[str],
+) -> ContextSelectionTelemetryCard:
+    lookups = _int_metric(summary, "compaction_cache_lookups")
+    hit_rate = _optional_float_metric(summary, "compaction_cache_hit_rate")
+    if lookups <= 0 or hit_rate is None:
+        return ContextSelectionTelemetryCard(
+            key="semantic_compaction_cache",
+            label="Semantic compaction cache",
+            value="No lookups",
+            severity="info",
+            detail="No semantic compaction cache lookups recorded.",
+        )
+    severity = "warning" if "LOW_COMPACTION_CACHE_HIT_RATE" in diagnostic_codes else "ok"
+    return ContextSelectionTelemetryCard(
+        key="semantic_compaction_cache",
+        label="Semantic compaction cache",
+        value=f"{hit_rate:.1%} hit rate",
+        severity=severity,
+        detail=(
+            f"{_int_metric(summary, 'compaction_cache_hits')} hits, "
+            f"{_int_metric(summary, 'compaction_cache_misses')} misses, {lookups} lookups"
+        ),
+    )
+
+
+def _diagnostics_card(diagnostics: tuple[ContextSelectionDiagnostic, ...]) -> ContextSelectionTelemetryCard:
+    severity = "warning" if diagnostics else "ok"
+    detail = ", ".join(diagnostic.code for diagnostic in diagnostics) if diagnostics else "No diagnostics."
+    return ContextSelectionTelemetryCard(
+        key="diagnostics",
+        label="Diagnostics",
+        value=f"{len(diagnostics)} finding(s)",
+        severity=severity,
+        detail=detail,
+    )
+
+
+def _format_optional_percent(value: Any) -> str:
+    try:
+        return f"{float(value):.1%}" if value is not None else "n/a"
+    except (TypeError, ValueError):
+        return "n/a"

--- a/autocontext/src/autocontext/server/cockpit_api.py
+++ b/autocontext/src/autocontext/server/cockpit_api.py
@@ -12,6 +12,7 @@ from autocontext.analytics.artifact_rendering import render_scenario_curation_ht
 from autocontext.consultation.runner import ConsultationRunner
 from autocontext.consultation.types import ConsultationRequest as ConsReq
 from autocontext.consultation.types import ConsultationTrigger
+from autocontext.knowledge.context_selection_report import build_context_selection_report
 from autocontext.notebook.context_provider import NotebookContextProvider
 from autocontext.notebook.types import SessionNotebook
 from autocontext.providers.base import LLMProvider
@@ -33,6 +34,7 @@ from autocontext.session.runtime_session_timeline import (
     read_runtime_session_timeline_by_run_id,
 )
 from autocontext.storage import ArtifactStore, SQLiteStore, artifact_store_from_settings
+from autocontext.storage.context_selection_store import load_context_selection_decisions
 from autocontext.storage.scenario_paths import normalize_scenario_name_segment
 
 logger = logging.getLogger(__name__)
@@ -418,6 +420,24 @@ def run_status(run_id: str, request: Request) -> dict[str, Any]:
         "generations": generations,
         **runtime_session_discovery,
     }
+
+
+@cockpit_router.get("/runs/{run_id}/context-selection")
+def run_context_selection_report(run_id: str, request: Request) -> dict[str, Any]:
+    """Context-selection telemetry report for cockpit inspection."""
+    settings = getattr(request.app.state, "app_settings", None)
+    if settings is None:
+        raise HTTPException(status_code=500, detail="Application settings are not configured")
+    clean_run_id = run_id.strip()
+    if not clean_run_id:
+        raise HTTPException(status_code=422, detail="run_id is required")
+    try:
+        decisions = load_context_selection_decisions(settings.runs_root, clean_run_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if not decisions:
+        raise HTTPException(status_code=404, detail=f"No context selection artifacts found for run '{clean_run_id}'")
+    return build_context_selection_report(decisions).to_dict()
 
 
 @cockpit_router.get("/runs/{run_id}/changelog")

--- a/autocontext/tests/test_cockpit.py
+++ b/autocontext/tests/test_cockpit.py
@@ -378,6 +378,59 @@ class TestCockpitRunStatus:
         assert gen1["elo"] == 1000.0
         assert gen1["gate_decision"] == "advance"
 
+    def test_run_context_selection_report(self, cockpit_env: dict[str, Any]) -> None:
+        from autocontext.knowledge.context_selection import (
+            ContextSelectionCandidate,
+            ContextSelectionDecision,
+        )
+        from autocontext.storage.context_selection_store import persist_context_selection_decision
+
+        client: TestClient = cockpit_env["client"]
+        artifacts: ArtifactStore = cockpit_env["artifacts"]
+        persist_context_selection_decision(
+            artifacts,
+            ContextSelectionDecision(
+                run_id="run1",
+                scenario_name="grid_ctf",
+                generation=1,
+                stage="generation_prompt_context",
+                candidates=(
+                    ContextSelectionCandidate.from_contents(
+                        artifact_id="playbook",
+                        artifact_type="prompt_component",
+                        source="prompt_assembly",
+                        candidate_content="x" * 400,
+                        selected_content="x" * 80,
+                        selection_reason="trimmed",
+                    ),
+                ),
+                metadata={
+                    "context_budget_telemetry": {
+                        "input_token_estimate": 120,
+                        "output_token_estimate": 20,
+                        "trimmed_component_count": 1,
+                    },
+                    "prompt_compaction_cache": {"hits": 0, "misses": 10, "lookups": 10},
+                },
+            ),
+        )
+
+        resp = client.get("/api/cockpit/runs/run1/context-selection")
+
+        assert resp.status_code == 200
+        payload = resp.json()
+        cards = {card["key"]: card for card in payload["telemetry_cards"]}
+        assert payload["run_id"] == "run1"
+        assert payload["summary"]["budget_token_reduction"] == 100
+        assert cards["context_budget"]["severity"] == "warning"
+        assert cards["semantic_compaction_cache"]["value"] == "0.0% hit rate"
+
+    def test_run_context_selection_report_missing(self, cockpit_env: dict[str, Any]) -> None:
+        resp = cockpit_env["client"].get("/api/cockpit/runs/missing/context-selection")
+
+        assert resp.status_code == 404
+        assert "No context selection artifacts" in resp.json()["detail"]
+
 
 class TestCockpitChangelog:
     def test_changelog_endpoint(self, cockpit_env: dict[str, Any]) -> None:

--- a/autocontext/tests/test_context_selection.py
+++ b/autocontext/tests/test_context_selection.py
@@ -516,6 +516,64 @@ def test_context_selection_report_summarizes_budget_and_cache_regression_gates()
     assert "cache" in diagnostics["LOW_COMPACTION_CACHE_HIT_RATE"]["recommendation"].lower()
 
 
+def test_context_selection_report_exposes_budget_cache_visibility_cards_and_markdown() -> None:
+    from autocontext.knowledge.context_selection import (
+        ContextSelectionCandidate,
+        ContextSelectionDecision,
+    )
+    from autocontext.knowledge.context_selection_report import build_context_selection_report
+
+    report = build_context_selection_report(
+        (
+            ContextSelectionDecision(
+                run_id="run-1",
+                scenario_name="grid_ctf",
+                generation=4,
+                stage="generation_prompt_context",
+                candidates=(
+                    ContextSelectionCandidate.from_contents(
+                        artifact_id="playbook",
+                        artifact_type="prompt_component",
+                        source="prompt_assembly",
+                        candidate_content="x" * 400,
+                        selected_content="x" * 80,
+                        selection_reason="trimmed",
+                    ),
+                ),
+                metadata={
+                    "context_budget_telemetry": {
+                        "input_token_estimate": 120,
+                        "output_token_estimate": 20,
+                        "dedupe_hit_count": 1,
+                        "component_cap_hit_count": 2,
+                        "trimmed_component_count": 1,
+                    },
+                    "prompt_compaction_cache": {
+                        "hits": 0,
+                        "misses": 10,
+                        "lookups": 10,
+                    },
+                },
+            ),
+        )
+    )
+
+    payload = report.to_dict()
+    cards = {card["key"]: card for card in payload["telemetry_cards"]}
+    markdown = report.to_markdown()
+
+    assert cards["context_budget"]["severity"] == "warning"
+    assert cards["context_budget"]["value"] == "100 est. tokens reduced"
+    assert "1 trims" in cards["context_budget"]["detail"]
+    assert cards["semantic_compaction_cache"]["severity"] == "warning"
+    assert cards["semantic_compaction_cache"]["value"] == "0.0% hit rate"
+    assert cards["diagnostics"]["severity"] == "warning"
+    assert "## Context Budget" in markdown
+    assert "- Token reduction: 100" in markdown
+    assert "## Semantic Compaction Cache" in markdown
+    assert "- Hit rate: 0.0%" in markdown
+
+
 def _diagnostic_by_code(payload: dict[str, Any], code: str) -> dict[str, Any]:
     return next(diagnostic for diagnostic in payload["diagnostics"] if diagnostic["code"] == code)
 

--- a/autocontext/tests/test_events_to_trace.py
+++ b/autocontext/tests/test_events_to_trace.py
@@ -192,6 +192,7 @@ def test_analytics_context_selection_cli_reports_run_summary(tmp_path: Path) -> 
     assert payload["run_id"] == "run-1"
     assert payload["diagnostics"] == []
     assert payload["summary"]["selected_token_estimate"] == 1
+    assert payload["telemetry_cards"][0]["key"] == "selected_context"
 
 
 def test_analytics_context_selection_cli_rejects_missing_artifacts(tmp_path: Path) -> None:

--- a/autocontext/tests/test_python_core_package.py
+++ b/autocontext/tests/test_python_core_package.py
@@ -16,9 +16,12 @@ ContextBudget = core_package.ContextBudget
 ContextBudgetPolicy = core_package.ContextBudgetPolicy
 ContextBudgetResult = core_package.ContextBudgetResult
 ContextBudgetTelemetry = core_package.ContextBudgetTelemetry
+ContextSelectionReport = core_package.ContextSelectionReport
+ContextSelectionTelemetryCard = core_package.ContextSelectionTelemetryCard
 PromptBundle = core_package.PromptBundle
 ProviderError = core_package.ProviderError
 build_prompt_bundle = core_package.build_prompt_bundle
+build_context_selection_report = core_package.build_context_selection_report
 estimate_tokens = core_package.estimate_tokens
 expected_score = core_package.expected_score
 package_role = core_package.package_role
@@ -48,6 +51,15 @@ def test_python_core_reexports_prompt_budget_helpers() -> None:
     assert isinstance(telemetry_result, ContextBudgetResult)
     assert isinstance(telemetry_result.telemetry, ContextBudgetTelemetry)
     assert telemetry_result.telemetry.token_reduction > 0
+
+
+def test_python_core_reexports_context_selection_report_helpers() -> None:
+    report = build_context_selection_report(())
+
+    assert isinstance(report, ContextSelectionReport)
+    card = report.telemetry_cards()[0]
+    assert isinstance(card, ContextSelectionTelemetryCard)
+    assert card.key == "selected_context"
 
 
 def test_python_core_reexports_prompt_bundle_assembly() -> None:

--- a/packages/package-boundaries.json
+++ b/packages/package-boundaries.json
@@ -62,7 +62,6 @@
 			"blockedImportPrefixes": [
 				"autocontext.cli",
 				"autocontext.consultation",
-				"autocontext.knowledge",
 				"autocontext.mcp",
 				"autocontext.monitor",
 				"autocontext.notebook",
@@ -76,6 +75,7 @@
 			"allowedImports": [
 				"autocontext.harness.scoring.elo",
 				"autocontext.prompts.context_budget",
+				"autocontext.knowledge.context_selection_report",
 				"autocontext.prompts.templates",
 				"autocontext.providers.base",
 				"autocontext.execution.judge",
@@ -119,6 +119,7 @@
 				"../../../ts/src/execution/elo.ts",
 				"../../../ts/src/judge/parse.ts",
 				"../../../ts/src/judge/rubric-coherence.ts",
+				"../../../ts/src/knowledge/context-selection-report.ts",
 				"../../../ts/src/prompts/context-budget.ts",
 				"../../../ts/src/prompts/templates.ts",
 				"../../../ts/src/runtimes/workspace-env.ts",

--- a/packages/python/core/src/autocontext_core/__init__.py
+++ b/packages/python/core/src/autocontext_core/__init__.py
@@ -5,6 +5,7 @@ from typing import Any
 
 _elo = import_module("autocontext.harness.scoring.elo")
 _context_budget = import_module("autocontext.prompts.context_budget")
+_context_selection_report = import_module("autocontext.knowledge.context_selection_report")
 _templates = import_module("autocontext.prompts.templates")
 _providers_base = import_module("autocontext.providers.base")
 _execution_judge = import_module("autocontext.execution.judge")
@@ -28,6 +29,9 @@ ContextBudget = _context_budget.ContextBudget
 ContextBudgetPolicy = _context_budget.ContextBudgetPolicy
 ContextBudgetResult = _context_budget.ContextBudgetResult
 ContextBudgetTelemetry = _context_budget.ContextBudgetTelemetry
+ContextSelectionReport = _context_selection_report.ContextSelectionReport
+ContextSelectionTelemetryCard = _context_selection_report.ContextSelectionTelemetryCard
+build_context_selection_report = _context_selection_report.build_context_selection_report
 estimate_tokens = _context_budget.estimate_tokens
 PromptBundle = _templates.PromptBundle
 build_prompt_bundle = _templates.build_prompt_bundle
@@ -127,6 +131,8 @@ __all__ = [
     "ContextBudgetPolicy",
     "ContextBudgetResult",
     "ContextBudgetTelemetry",
+    "ContextSelectionReport",
+    "ContextSelectionTelemetryCard",
     "DisagreementMetrics",
     "EnvironmentSpec",
     "CoordinationInterface",
@@ -180,6 +186,7 @@ __all__ = [
     "WorkflowResult",
     "WorkflowStep",
     "build_prompt_bundle",
+    "build_context_selection_report",
     "check_rubric_coherence",
     "estimate_tokens",
     "expected_score",

--- a/packages/ts/core/src/index.ts
+++ b/packages/ts/core/src/index.ts
@@ -118,6 +118,20 @@ export type {
 	PromptContext,
 } from "../../../../ts/src/prompts/templates.js";
 export { buildPromptBundle } from "../../../../ts/src/prompts/templates.js";
+export {
+	buildContextSelectionReport,
+	ContextSelectionReport,
+} from "../../../../ts/src/knowledge/context-selection-report.js";
+export type {
+	ContextSelectionCandidateInput,
+	ContextSelectionDecisionInput,
+	ContextSelectionDiagnostic,
+	ContextSelectionDiagnosticPolicy,
+	ContextSelectionReportPayload,
+	ContextSelectionReportSummary,
+	ContextSelectionStageSummary,
+	ContextSelectionTelemetryCard,
+} from "../../../../ts/src/knowledge/context-selection-report.js";
 export type {
 	ExecutionLimits,
 	LegalAction,

--- a/packages/ts/core/tsconfig.json
+++ b/packages/ts/core/tsconfig.json
@@ -12,6 +12,7 @@
 		"../../../ts/src/execution/elo.ts",
 		"../../../ts/src/judge/parse.ts",
 		"../../../ts/src/judge/rubric-coherence.ts",
+		"../../../ts/src/knowledge/context-selection-report.ts",
 		"../../../ts/src/prompts/context-budget.ts",
 		"../../../ts/src/prompts/templates.ts",
 		"../../../ts/src/runtimes/workspace-env.ts",

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -88,6 +88,19 @@ export type {
 export { buildPromptBundle } from "./prompts/templates.js";
 export type { PromptBundle, PromptContext } from "./prompts/templates.js";
 
+// Context selection reports
+export { buildContextSelectionReport, ContextSelectionReport } from "./knowledge/context-selection-report.js";
+export type {
+  ContextSelectionCandidateInput,
+  ContextSelectionDecisionInput,
+  ContextSelectionDiagnostic,
+  ContextSelectionDiagnosticPolicy,
+  ContextSelectionReportPayload,
+  ContextSelectionReportSummary,
+  ContextSelectionStageSummary,
+  ContextSelectionTelemetryCard,
+} from "./knowledge/context-selection-report.js";
+
 // Config
 export { AppSettingsSchema, loadSettings, applyPreset, PRESETS } from "./config/index.js";
 export type { AppSettings } from "./config/index.js";

--- a/ts/src/knowledge/context-selection-report.ts
+++ b/ts/src/knowledge/context-selection-report.ts
@@ -1,0 +1,539 @@
+export interface ContextSelectionCandidateInput {
+  artifact_id?: string;
+  artifact_type?: string;
+  source?: string;
+  candidate_token_estimate?: number;
+  selected_token_estimate?: number;
+  selected?: boolean;
+  selection_reason?: string;
+  candidate_content_hash?: string;
+  selected_content_hash?: string;
+  useful?: boolean | null;
+  freshness_generation_delta?: number | null;
+}
+
+export interface ContextSelectionDecisionInput {
+  run_id?: string;
+  scenario_name?: string;
+  generation?: number;
+  stage?: string;
+  created_at?: string;
+  candidates?: ContextSelectionCandidateInput[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface ContextSelectionDiagnosticPolicy {
+  duplicate_content_rate_threshold: number;
+  useful_artifact_recall_floor: number;
+  selected_token_estimate_threshold: number;
+  compaction_cache_hit_rate_floor: number;
+  compaction_cache_min_lookups: number;
+}
+
+export interface ContextSelectionDiagnostic {
+  code: string;
+  severity: "info" | "warning";
+  metric_name: string;
+  value: number;
+  threshold: number;
+  message: string;
+  recommendation: string;
+  generation: number;
+  stage: string;
+}
+
+export interface ContextSelectionTelemetryCard {
+  key: string;
+  label: string;
+  value: string;
+  severity: "ok" | "info" | "warning";
+  detail: string;
+}
+
+export interface ContextSelectionStageSummary {
+  run_id: string;
+  scenario_name: string;
+  generation: number;
+  stage: string;
+  created_at: string;
+  candidate_count: number;
+  selected_count: number;
+  candidate_token_estimate: number;
+  selected_token_estimate: number;
+  selection_rate: number;
+  duplicate_content_rate: number;
+  useful_artifact_recall: number | null;
+  mean_selected_freshness_generation_delta: number | null;
+  budget_input_token_estimate: number;
+  budget_output_token_estimate: number;
+  budget_token_reduction: number;
+  budget_dedupe_hit_count: number;
+  budget_component_cap_hit_count: number;
+  budget_trimmed_component_count: number;
+  compaction_cache_hits: number;
+  compaction_cache_misses: number;
+  compaction_cache_lookups: number;
+  compaction_cache_hit_rate: number | null;
+}
+
+export interface ContextSelectionReportPayload {
+  status: "completed";
+  run_id: string;
+  scenario_name: string;
+  decision_count: number;
+  generation_count: number;
+  summary: ContextSelectionReportSummary;
+  telemetry_cards: ContextSelectionTelemetryCard[];
+  diagnostic_count: number;
+  diagnostics: ContextSelectionDiagnostic[];
+  stages: ContextSelectionStageSummary[];
+}
+
+export interface ContextSelectionReportSummary {
+  candidate_count: number;
+  selected_count: number;
+  candidate_token_estimate: number;
+  selected_token_estimate: number;
+  selection_rate: number;
+  mean_selection_rate: number;
+  mean_duplicate_content_rate: number;
+  mean_selected_token_estimate: number;
+  max_selected_token_estimate: number;
+  mean_useful_artifact_recall: number | null;
+  mean_selected_freshness_generation_delta: number | null;
+  budget_input_token_estimate: number;
+  budget_output_token_estimate: number;
+  budget_token_reduction: number;
+  budget_dedupe_hit_count: number;
+  budget_component_cap_hit_count: number;
+  budget_trimmed_component_count: number;
+  compaction_cache_hits: number;
+  compaction_cache_misses: number;
+  compaction_cache_lookups: number;
+  compaction_cache_hit_rate: number | null;
+}
+
+const DEFAULT_POLICY: ContextSelectionDiagnosticPolicy = {
+  duplicate_content_rate_threshold: 0.25,
+  useful_artifact_recall_floor: 0.70,
+  selected_token_estimate_threshold: 8000,
+  compaction_cache_hit_rate_floor: 0.50,
+  compaction_cache_min_lookups: 5,
+};
+
+export class ContextSelectionReport {
+  readonly runId: string;
+  readonly scenarioName: string;
+  readonly stages: ContextSelectionStageSummary[];
+
+  constructor(runId: string, scenarioName: string, stages: ContextSelectionStageSummary[]) {
+    this.runId = runId;
+    this.scenarioName = scenarioName;
+    this.stages = stages;
+  }
+
+  summary(): ContextSelectionReportSummary {
+    const candidateCount = sum(this.stages.map((stage) => stage.candidate_count));
+    const selectedCount = sum(this.stages.map((stage) => stage.selected_count));
+    const candidateTokens = sum(this.stages.map((stage) => stage.candidate_token_estimate));
+    const selectedTokens = sum(this.stages.map((stage) => stage.selected_token_estimate));
+    const compactionCacheHits = sum(this.stages.map((stage) => stage.compaction_cache_hits));
+    const compactionCacheLookups = sum(this.stages.map((stage) => stage.compaction_cache_lookups));
+    return {
+      candidate_count: candidateCount,
+      selected_count: selectedCount,
+      candidate_token_estimate: candidateTokens,
+      selected_token_estimate: selectedTokens,
+      selection_rate: candidateCount ? selectedCount / candidateCount : 0,
+      mean_selection_rate: mean(this.stages.map((stage) => stage.selection_rate)),
+      mean_duplicate_content_rate: mean(this.stages.map((stage) => stage.duplicate_content_rate)),
+      mean_selected_token_estimate: this.stages.length ? selectedTokens / this.stages.length : 0,
+      max_selected_token_estimate: Math.max(0, ...this.stages.map((stage) => stage.selected_token_estimate)),
+      mean_useful_artifact_recall: meanOptional(this.stages.map((stage) => stage.useful_artifact_recall)),
+      mean_selected_freshness_generation_delta: meanOptional(
+        this.stages.map((stage) => stage.mean_selected_freshness_generation_delta),
+      ),
+      budget_input_token_estimate: sum(this.stages.map((stage) => stage.budget_input_token_estimate)),
+      budget_output_token_estimate: sum(this.stages.map((stage) => stage.budget_output_token_estimate)),
+      budget_token_reduction: sum(this.stages.map((stage) => stage.budget_token_reduction)),
+      budget_dedupe_hit_count: sum(this.stages.map((stage) => stage.budget_dedupe_hit_count)),
+      budget_component_cap_hit_count: sum(this.stages.map((stage) => stage.budget_component_cap_hit_count)),
+      budget_trimmed_component_count: sum(this.stages.map((stage) => stage.budget_trimmed_component_count)),
+      compaction_cache_hits: compactionCacheHits,
+      compaction_cache_misses: sum(this.stages.map((stage) => stage.compaction_cache_misses)),
+      compaction_cache_lookups: compactionCacheLookups,
+      compaction_cache_hit_rate: compactionCacheLookups ? compactionCacheHits / compactionCacheLookups : null,
+    };
+  }
+
+  diagnostics(policy: ContextSelectionDiagnosticPolicy = DEFAULT_POLICY): ContextSelectionDiagnostic[] {
+    if (this.stages.length === 0) return [];
+
+    const diagnostics: ContextSelectionDiagnostic[] = [];
+    const duplicateStage = maxBy(this.stages, (stage) => stage.duplicate_content_rate);
+    if (duplicateStage.duplicate_content_rate >= policy.duplicate_content_rate_threshold) {
+      diagnostics.push({
+        code: "HIGH_DUPLICATE_CONTENT_RATE",
+        severity: "warning",
+        metric_name: "duplicate_content_rate",
+        value: duplicateStage.duplicate_content_rate,
+        threshold: policy.duplicate_content_rate_threshold,
+        message: "Selected context contains repeated content in a single prompt assembly stage.",
+        recommendation: "Deduplicate equivalent prompt components before selection and keep one canonical source.",
+        generation: duplicateStage.generation,
+        stage: duplicateStage.stage,
+      });
+    }
+
+    const usefulStages = this.stages.filter((stage) => stage.useful_artifact_recall !== null);
+    if (usefulStages.length > 0) {
+      const recallStage = minBy(usefulStages, (stage) => stage.useful_artifact_recall ?? 0);
+      const recall = recallStage.useful_artifact_recall;
+      if (recall !== null && recall < policy.useful_artifact_recall_floor) {
+        diagnostics.push({
+          code: "LOW_USEFUL_ARTIFACT_RECALL",
+          severity: "warning",
+          metric_name: "useful_artifact_recall",
+          value: recall,
+          threshold: policy.useful_artifact_recall_floor,
+          message: "Useful artifacts were available but omitted from selected context.",
+          recommendation: "Promote useful artifacts earlier in context ranking or lower-priority noisy components.",
+          generation: recallStage.generation,
+          stage: recallStage.stage,
+        });
+      }
+    }
+
+    const tokenStage = maxBy(this.stages, (stage) => stage.selected_token_estimate);
+    if (tokenStage.selected_token_estimate > policy.selected_token_estimate_threshold) {
+      diagnostics.push({
+        code: "SELECTED_TOKEN_BLOAT",
+        severity: "warning",
+        metric_name: "selected_token_estimate",
+        value: tokenStage.selected_token_estimate,
+        threshold: policy.selected_token_estimate_threshold,
+        message: "One prompt assembly stage selected an unusually large context payload.",
+        recommendation: "Reduce selected context by tightening budget filters and summarizing bulky artifacts.",
+        generation: tokenStage.generation,
+        stage: tokenStage.stage,
+      });
+    }
+
+    const cacheStages = this.stages.filter(
+      (stage) =>
+        stage.compaction_cache_hit_rate !== null &&
+        stage.compaction_cache_lookups >= policy.compaction_cache_min_lookups,
+    );
+    if (cacheStages.length > 0) {
+      const cacheStage = minBy(cacheStages, (stage) => stage.compaction_cache_hit_rate ?? 0);
+      const hitRate = cacheStage.compaction_cache_hit_rate;
+      if (hitRate !== null && hitRate < policy.compaction_cache_hit_rate_floor) {
+        diagnostics.push({
+          code: "LOW_COMPACTION_CACHE_HIT_RATE",
+          severity: "info",
+          metric_name: "compaction_cache_hit_rate",
+          value: hitRate,
+          threshold: policy.compaction_cache_hit_rate_floor,
+          message: "Semantic compaction cache reuse was low for a prompt assembly stage.",
+          recommendation: "Check whether repeated prompt components use stable canonical text before cache lookup.",
+          generation: cacheStage.generation,
+          stage: cacheStage.stage,
+        });
+      }
+    }
+    return diagnostics;
+  }
+
+  telemetryCards(policy: ContextSelectionDiagnosticPolicy = DEFAULT_POLICY): ContextSelectionTelemetryCard[] {
+    const summary = this.summary();
+    const diagnostics = this.diagnostics(policy);
+    const diagnosticCodes = new Set(diagnostics.map((diagnostic) => diagnostic.code));
+    return [
+      selectedContextCard(summary, diagnosticCodes),
+      contextBudgetCard(summary),
+      semanticCompactionCacheCard(summary, diagnosticCodes),
+      diagnosticsCard(diagnostics),
+    ];
+  }
+
+  toDict(): ContextSelectionReportPayload {
+    const generations = new Set(this.stages.map((stage) => stage.generation));
+    const diagnostics = this.diagnostics();
+    return {
+      status: "completed",
+      run_id: this.runId,
+      scenario_name: this.scenarioName,
+      decision_count: this.stages.length,
+      generation_count: generations.size,
+      summary: this.summary(),
+      telemetry_cards: this.telemetryCards(),
+      diagnostic_count: diagnostics.length,
+      diagnostics,
+      stages: this.stages,
+    };
+  }
+
+  toMarkdown(): string {
+    const summary = this.summary();
+    const lines = [
+      `# Context Selection Report: ${this.runId}`,
+      "",
+      `- Scenario: ${this.scenarioName}`,
+      `- Decisions: ${this.stages.length}`,
+      `- Selected tokens: ${summary.selected_token_estimate}`,
+      `- Selection rate: ${formatPercent(summary.selection_rate, 2)}`,
+      `- Mean duplicate content rate: ${formatPercent(summary.mean_duplicate_content_rate, 2)}`,
+    ];
+    if (summary.mean_selected_freshness_generation_delta !== null) {
+      lines.push(
+        `- Mean selected freshness delta: ${summary.mean_selected_freshness_generation_delta.toFixed(2)} generation(s)`,
+      );
+    }
+    lines.push(
+      "",
+      "## Context Budget",
+      `- Input estimate: ${summary.budget_input_token_estimate}`,
+      `- Output estimate: ${summary.budget_output_token_estimate}`,
+      `- Token reduction: ${summary.budget_token_reduction}`,
+      `- Dedupe hits: ${summary.budget_dedupe_hit_count}`,
+      `- Component caps: ${summary.budget_component_cap_hit_count}`,
+      `- Global trims: ${summary.budget_trimmed_component_count}`,
+      "",
+      "## Semantic Compaction Cache",
+      `- Hit rate: ${formatOptionalPercent(summary.compaction_cache_hit_rate)}`,
+      `- Hits: ${summary.compaction_cache_hits}`,
+      `- Misses: ${summary.compaction_cache_misses}`,
+      `- Lookups: ${summary.compaction_cache_lookups}`,
+    );
+    const diagnostics = this.diagnostics();
+    if (diagnostics.length > 0) {
+      lines.push("", "## Diagnostics");
+      for (const diagnostic of diagnostics) {
+        lines.push(`- ${diagnostic.code}: ${diagnostic.recommendation}`);
+      }
+    }
+    return lines.join("\n");
+  }
+}
+
+export function buildContextSelectionReport(decisions: ContextSelectionDecisionInput[]): ContextSelectionReport {
+  const stages = [...decisions]
+    .sort((a, b) => coerceNumber(a.generation) - coerceNumber(b.generation) || String(a.stage ?? "").localeCompare(String(b.stage ?? "")))
+    .map(stageSummaryFromDecision);
+  const runIds = new Set(stages.map((stage) => stage.run_id).filter(Boolean));
+  const scenarioNames = new Set(stages.map((stage) => stage.scenario_name).filter(Boolean));
+  if (runIds.size > 1) throw new Error("context selection report requires a single run_id");
+  if (scenarioNames.size > 1) throw new Error("context selection report requires a single scenario_name");
+  return new ContextSelectionReport([...runIds][0] ?? "", [...scenarioNames][0] ?? "", stages);
+}
+
+function stageSummaryFromDecision(decision: ContextSelectionDecisionInput): ContextSelectionStageSummary {
+  const metrics = decisionMetrics(decision);
+  return {
+    run_id: String(decision.run_id ?? ""),
+    scenario_name: String(decision.scenario_name ?? ""),
+    generation: coerceNumber(decision.generation),
+    stage: String(decision.stage ?? ""),
+    created_at: String(decision.created_at ?? ""),
+    candidate_count: intMetric(metrics, "candidate_count"),
+    selected_count: intMetric(metrics, "selected_count"),
+    candidate_token_estimate: intMetric(metrics, "candidate_token_estimate"),
+    selected_token_estimate: intMetric(metrics, "selected_token_estimate"),
+    selection_rate: floatMetric(metrics, "selection_rate"),
+    duplicate_content_rate: floatMetric(metrics, "duplicate_content_rate"),
+    useful_artifact_recall: optionalFloatMetric(metrics, "useful_artifact_recall"),
+    mean_selected_freshness_generation_delta: optionalFloatMetric(
+      metrics,
+      "mean_selected_freshness_generation_delta",
+    ),
+    budget_input_token_estimate: intMetric(metrics, "budget_input_token_estimate"),
+    budget_output_token_estimate: intMetric(metrics, "budget_output_token_estimate"),
+    budget_token_reduction: intMetric(metrics, "budget_token_reduction"),
+    budget_dedupe_hit_count: intMetric(metrics, "budget_dedupe_hit_count"),
+    budget_component_cap_hit_count: intMetric(metrics, "budget_component_cap_hit_count"),
+    budget_trimmed_component_count: intMetric(metrics, "budget_trimmed_component_count"),
+    compaction_cache_hits: intMetric(metrics, "compaction_cache_hits"),
+    compaction_cache_misses: intMetric(metrics, "compaction_cache_misses"),
+    compaction_cache_lookups: intMetric(metrics, "compaction_cache_lookups"),
+    compaction_cache_hit_rate: optionalFloatMetric(metrics, "compaction_cache_hit_rate"),
+  };
+}
+
+function decisionMetrics(decision: ContextSelectionDecisionInput): Record<string, number | null> {
+  const candidates = decision.candidates ?? [];
+  const selected = candidates.filter((candidate) => candidate.selected === true);
+  const usefulCandidates = candidates.filter((candidate) => candidate.useful === true);
+  const usefulSelected = selected.filter((candidate) => candidate.useful === true);
+  const freshness = selected
+    .map((candidate) => candidate.freshness_generation_delta)
+    .filter((value): value is number => typeof value === "number");
+  const duplicateCount = duplicateSelectedHashCount(selected);
+  const budgetTelemetry = coerceRecord(decision.metadata?.context_budget_telemetry);
+  const budgetInputTokens = coerceNumber(budgetTelemetry.input_token_estimate);
+  const budgetOutputTokens = coerceNumber(budgetTelemetry.output_token_estimate);
+  const compactionCache = coerceRecord(decision.metadata?.prompt_compaction_cache);
+  const compactionHits = coerceNumber(compactionCache.hits);
+  const compactionMisses = coerceNumber(compactionCache.misses);
+  const rawLookups = coerceNumber(compactionCache.lookups);
+  const compactionLookups = rawLookups || compactionHits + compactionMisses;
+  return {
+    candidate_count: candidates.length,
+    selected_count: selected.length,
+    candidate_token_estimate: sum(candidates.map((candidate) => coerceNumber(candidate.candidate_token_estimate))),
+    selected_token_estimate: sum(selected.map((candidate) => coerceNumber(candidate.selected_token_estimate))),
+    selection_rate: candidates.length ? selected.length / candidates.length : 0,
+    duplicate_content_rate: selected.length ? duplicateCount / selected.length : 0,
+    useful_candidate_count: usefulCandidates.length,
+    useful_selected_count: usefulSelected.length,
+    useful_artifact_recall: usefulCandidates.length ? usefulSelected.length / usefulCandidates.length : null,
+    mean_selected_freshness_generation_delta: freshness.length ? sum(freshness) / freshness.length : null,
+    budget_input_token_estimate: budgetInputTokens,
+    budget_output_token_estimate: budgetOutputTokens,
+    budget_token_reduction: Math.max(0, budgetInputTokens - budgetOutputTokens),
+    budget_dedupe_hit_count: coerceNumber(budgetTelemetry.dedupe_hit_count),
+    budget_component_cap_hit_count: coerceNumber(budgetTelemetry.component_cap_hit_count),
+    budget_trimmed_component_count: coerceNumber(budgetTelemetry.trimmed_component_count),
+    compaction_cache_hits: compactionHits,
+    compaction_cache_misses: compactionMisses,
+    compaction_cache_lookups: compactionLookups,
+    compaction_cache_hit_rate: compactionLookups ? compactionHits / compactionLookups : null,
+  };
+}
+
+function selectedContextCard(
+  summary: ContextSelectionReportSummary,
+  diagnosticCodes: Set<string>,
+): ContextSelectionTelemetryCard {
+  return {
+    key: "selected_context",
+    label: "Selected context",
+    value: `${summary.selected_token_estimate} est. tokens`,
+    severity: diagnosticCodes.has("SELECTED_TOKEN_BLOAT") ? "warning" : "ok",
+    detail: `${summary.selected_count}/${summary.candidate_count} components selected (${formatPercent(summary.selection_rate, 1)})`,
+  };
+}
+
+function contextBudgetCard(summary: ContextSelectionReportSummary): ContextSelectionTelemetryCard {
+  if (summary.budget_input_token_estimate <= 0) {
+    return {
+      key: "context_budget",
+      label: "Context budget",
+      value: "No telemetry",
+      severity: "info",
+      detail: "No context budget telemetry recorded.",
+    };
+  }
+  return {
+    key: "context_budget",
+    label: "Context budget",
+    value: `${summary.budget_token_reduction} est. tokens reduced`,
+    severity: summary.budget_trimmed_component_count > 0 ? "warning" : "ok",
+    detail:
+      `${summary.budget_input_token_estimate}->${summary.budget_output_token_estimate} est. tokens; ` +
+      `${summary.budget_dedupe_hit_count} dedupe, ${summary.budget_component_cap_hit_count} caps, ` +
+      `${summary.budget_trimmed_component_count} trims`,
+  };
+}
+
+function semanticCompactionCacheCard(
+  summary: ContextSelectionReportSummary,
+  diagnosticCodes: Set<string>,
+): ContextSelectionTelemetryCard {
+  if (summary.compaction_cache_lookups <= 0 || summary.compaction_cache_hit_rate === null) {
+    return {
+      key: "semantic_compaction_cache",
+      label: "Semantic compaction cache",
+      value: "No lookups",
+      severity: "info",
+      detail: "No semantic compaction cache lookups recorded.",
+    };
+  }
+  return {
+    key: "semantic_compaction_cache",
+    label: "Semantic compaction cache",
+    value: `${formatPercent(summary.compaction_cache_hit_rate, 1)} hit rate`,
+    severity: diagnosticCodes.has("LOW_COMPACTION_CACHE_HIT_RATE") ? "warning" : "ok",
+    detail:
+      `${summary.compaction_cache_hits} hits, ${summary.compaction_cache_misses} misses, ` +
+      `${summary.compaction_cache_lookups} lookups`,
+  };
+}
+
+function diagnosticsCard(diagnostics: ContextSelectionDiagnostic[]): ContextSelectionTelemetryCard {
+  return {
+    key: "diagnostics",
+    label: "Diagnostics",
+    value: `${diagnostics.length} finding(s)`,
+    severity: diagnostics.length > 0 ? "warning" : "ok",
+    detail: diagnostics.length ? diagnostics.map((diagnostic) => diagnostic.code).join(", ") : "No diagnostics.",
+  };
+}
+
+function duplicateSelectedHashCount(candidates: ContextSelectionCandidateInput[]): number {
+  const counts = new Map<string, number>();
+  for (const candidate of candidates) {
+    const hash = candidate.selected_content_hash;
+    if (!hash) continue;
+    counts.set(hash, (counts.get(hash) ?? 0) + 1);
+  }
+  return [...counts.values()].reduce((total, count) => total + (count > 1 ? count - 1 : 0), 0);
+}
+
+function coerceRecord(value: unknown): Record<string, unknown> {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+function coerceNumber(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return Math.trunc(value);
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function intMetric(metrics: Record<string, number | null>, key: string): number {
+  return coerceNumber(metrics[key]);
+}
+
+function floatMetric(metrics: Record<string, number | null>, key: string): number {
+  const value = metrics[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function optionalFloatMetric(metrics: Record<string, number | null>, key: string): number | null {
+  const value = metrics[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function sum(values: number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+function mean(values: number[]): number {
+  return values.length ? sum(values) / values.length : 0;
+}
+
+function meanOptional(values: Array<number | null>): number | null {
+  const items = values.filter((value): value is number => value !== null);
+  return items.length ? sum(items) / items.length : null;
+}
+
+function maxBy<T>(items: T[], score: (item: T) => number): T {
+  return items.reduce((best, item) => (score(item) > score(best) ? item : best), items[0]!);
+}
+
+function minBy<T>(items: T[], score: (item: T) => number): T {
+  return items.reduce((best, item) => (score(item) < score(best) ? item : best), items[0]!);
+}
+
+function formatPercent(value: number, digits: number): string {
+  return `${(value * 100).toFixed(digits)}%`;
+}
+
+function formatOptionalPercent(value: number | null): string {
+  return value === null ? "n/a" : formatPercent(value, 1);
+}

--- a/ts/src/knowledge/index.ts
+++ b/ts/src/knowledge/index.ts
@@ -27,6 +27,17 @@ export {
   promptCompactionCacheStats,
 } from "./semantic-compaction.js";
 export type { PromptCompactionOptions, PromptCompactionResult } from "./semantic-compaction.js";
+export { buildContextSelectionReport, ContextSelectionReport } from "./context-selection-report.js";
+export type {
+  ContextSelectionCandidateInput,
+  ContextSelectionDecisionInput,
+  ContextSelectionDiagnostic,
+  ContextSelectionDiagnosticPolicy,
+  ContextSelectionReportPayload,
+  ContextSelectionReportSummary,
+  ContextSelectionStageSummary,
+  ContextSelectionTelemetryCard,
+} from "./context-selection-report.js";
 export { ScoreTrajectoryBuilder } from "./trajectory.js";
 export type { TrajectoryRow } from "./trajectory.js";
 export { exportStrategyPackage, importStrategyPackage } from "./package.js";

--- a/ts/tests/context-selection-report.test.ts
+++ b/ts/tests/context-selection-report.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildContextSelectionReport,
+  type ContextSelectionDecisionInput,
+} from "../src/knowledge/context-selection-report.js";
+
+function decision(overrides: Partial<ContextSelectionDecisionInput> = {}): ContextSelectionDecisionInput {
+  return {
+    run_id: "run-1",
+    scenario_name: "grid_ctf",
+    generation: 4,
+    stage: "generation_prompt_context",
+    created_at: "2026-01-02T03:04:05+00:00",
+    candidates: [
+      {
+        artifact_id: "playbook",
+        artifact_type: "prompt_component",
+        source: "prompt_assembly",
+        candidate_token_estimate: 100,
+        selected_token_estimate: 20,
+        selected: true,
+        selection_reason: "trimmed",
+        candidate_content_hash: "candidate",
+        selected_content_hash: "selected",
+      },
+    ],
+    metadata: {
+      context_budget_telemetry: {
+        input_token_estimate: 120,
+        output_token_estimate: 20,
+        dedupe_hit_count: 1,
+        component_cap_hit_count: 2,
+        trimmed_component_count: 1,
+      },
+      prompt_compaction_cache: {
+        hits: 0,
+        misses: 10,
+        lookups: 10,
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("context selection report", () => {
+  it("builds Python-parity budget/cache telemetry cards and markdown", () => {
+    const report = buildContextSelectionReport([decision()]);
+    const payload = report.toDict();
+    const cards = Object.fromEntries(payload.telemetry_cards.map((card) => [card.key, card]));
+    const markdown = report.toMarkdown();
+
+    expect(payload.summary.budget_token_reduction).toBe(100);
+    expect(cards.context_budget.severity).toBe("warning");
+    expect(cards.context_budget.value).toBe("100 est. tokens reduced");
+    expect(cards.context_budget.detail).toContain("1 trims");
+    expect(cards.semantic_compaction_cache.severity).toBe("warning");
+    expect(cards.semantic_compaction_cache.value).toBe("0.0% hit rate");
+    expect(cards.diagnostics.severity).toBe("warning");
+    expect(markdown).toContain("## Context Budget");
+    expect(markdown).toContain("- Token reduction: 100");
+    expect(markdown).toContain("## Semantic Compaction Cache");
+    expect(markdown).toContain("- Hit rate: 0.0%");
+  });
+
+  it("rejects mixed run reports like the Python report builder", () => {
+    expect(() =>
+      buildContextSelectionReport([
+        decision(),
+        decision({ run_id: "run-2" }),
+      ]),
+    ).toThrow(/single run_id/);
+  });
+});


### PR DESCRIPTION
Summary:
- Add Python context-selection telemetry cards plus budget/cache markdown sections.
- Add matching TypeScript context-selection report builder and exports for package/core parity.
- Add cockpit run context-selection report endpoint backed by validated persisted decisions.

Tests:
- uv run --frozen pytest tests/test_context_selection.py::test_context_selection_report_exposes_budget_cache_visibility_cards_and_markdown tests/test_events_to_trace.py::test_analytics_context_selection_cli_reports_run_summary tests/test_cockpit.py::TestCockpitRunStatus::test_run_context_selection_report tests/test_cockpit.py::TestCockpitRunStatus::test_run_context_selection_report_missing tests/test_python_core_package.py::test_python_core_reexports_context_selection_report_helpers
- uv run --frozen pytest tests/test_context_selection.py tests/test_events_to_trace.py tests/test_cockpit.py tests/test_python_core_package.py
- uv run --frozen ruff check src tests/test_context_selection.py tests/test_events_to_trace.py tests/test_cockpit.py tests/test_python_core_package.py ../packages/python/core/src/autocontext_core/__init__.py
- uv run --frozen mypy src/autocontext/knowledge/context_selection_report.py src/autocontext/server/cockpit_api.py
- npm test -- context-selection-report.test.ts
- npm test -- context-selection-report.test.ts core-package.test.ts knowledge-system.test.ts
- npm run lint
- git diff --check