### PR TITLE
Expose context selection telemetry in TS operator surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ pi install npm:pi-autocontext
 | `worker`           | `autoctx worker --poll-interval 5`                     | Process queued tasks on a persistent host beside `autoctx serve`                       |
 | `export`           | `autoctx export <run-id>`                              | Share solved knowledge as JSON, skills, or Pi-local package directories                |
 | `train`            | `autoctx train --scenario <name> --data <jsonl>`       | Distill stable exported data into a cheaper local runtime                              |
+| `context-selection` | `bunx autoctx context-selection --run-id <run-id> --json` (TypeScript CLI) | Inspect persisted prompt context budget, cache, diagnostics, and selection telemetry   |
 | `runtime-sessions` | `bunx autoctx runtime-sessions timeline --run-id <run-id>` (TypeScript CLI) | Inspect persisted provider prompts, messages, child-task events, and operator-facing timelines from runtime-backed runs; also exposed through Python and TypeScript MCP/cockpit HTTP, the TypeScript TUI `/timeline` plus persisted filterable and resettable `/activity` live feed, and `/ws/events` updates |
 | `agent`            | `bunx autoctx agent run support --id ticket-123 --payload '{"message":"..."}' --json` (TypeScript CLI) | Invoke experimental `.autoctx/agents` handlers locally, or run `autoctx agent dev` for `/manifest` and `/agents/<name>/invoke` routes |
 | `hermes`           | `uv run autoctx hermes inspect --json` (Python)        | Inspect Hermes v0.12 skill usage and Curator reports, or export the Hermes skill       |

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - **`simulate`** — modeled-world exploration with sweeps, replay, compare, export
 - **`investigate`** — evidence-driven diagnosis in synthetic harness or iterative LLM modes
 - **`analyze`** — interpret and compare outputs from all surfaces
+- **`context-selection`** — inspect persisted prompt context telemetry for run budget/cache tuning
 - **`mission`** — real-world goal execution with adaptive planning and campaigns
 - **`agent`** — TypeScript local runner/dev server for experimental `.autoctx/agents` handlers
 - **`train`** — distill curated datasets into scenario-local models

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -17,6 +17,14 @@ uv run autoctx analytics context-selection --run-id <run_id>
 uv run autoctx analytics context-selection --run-id <run_id> --json
 ```
 
+The TypeScript CLI exposes the same persisted report shape for npm-backed
+operator workflows:
+
+```bash
+autoctx context-selection --run-id <run_id>
+autoctx context-selection --run-id <run_id> --json
+```
+
 For completed runs with persisted `RunTrace` artifacts, emit trace-grounded
 findings from the same reporter used by run-end writeups. Trace ids are the
 filenames under `knowledge/analytics/traces/` without the `.json` suffix

--- a/ts/README.md
+++ b/ts/README.md
@@ -264,6 +264,7 @@ autoctx list --json
 autoctx runtime-sessions list --limit 10
 autoctx runtime-sessions show --run-id <run-id> --json
 autoctx runtime-sessions timeline --run-id <run-id> --json
+autoctx context-selection --run-id <run-id> --json
 autoctx agent run support --id ticket-123 --payload '{"message":"Please triage this."}' --env .env.local --json
 autoctx agent dev --port 3583 --env .env.local
 autoctx status <run-id>
@@ -656,11 +657,16 @@ The TypeScript package includes the current 0.4.x operator-facing surfaces:
 - `simulate`
 - `investigate`
 - `analyze`
+- `context-selection`
 - `trace-findings` — extract structured findings (`TraceFindingReport`) from a `PublicTrace` JSON file (AC-679)
 - `mission`
 - `train` as a validation plus executor-hook surface
 
 `campaign` now ships as a first-class TypeScript CLI/API/MCP workflow for multi-mission coordination.
+
+`context-selection` reads persisted per-run context-selection artifacts and
+renders the same budget, semantic compaction cache, diagnostics, and selected
+context telemetry cards exposed through Cockpit HTTP.
 
 For end-to-end local MLX/CUDA training, the Python package is still the canonical out-of-the-box runtime.
 

--- a/ts/src/cli/command-registry.ts
+++ b/ts/src/cli/command-registry.ts
@@ -21,6 +21,7 @@ export type NoDbCommandName =
   | "simulate"
   | "investigate"
   | "analyze"
+  | "context-selection"
   | "blob"
   | "production-traces"
   | "instrument"
@@ -271,6 +272,12 @@ const COMMANDS: readonly CommandDescriptor[] = [
     description: "Analyze and compare runs, simulations, investigations, and missions",
     group: "primary",
     route: { kind: "no-db", command: "analyze" },
+  },
+  {
+    name: "context-selection",
+    description: "Inspect persisted context-selection telemetry",
+    group: "primary",
+    route: { kind: "no-db", command: "context-selection" },
   },
   {
     name: "mcp-serve",

--- a/ts/src/cli/context-selection-command-workflow.ts
+++ b/ts/src/cli/context-selection-command-workflow.ts
@@ -1,0 +1,88 @@
+import { resolve } from "node:path";
+
+import { buildContextSelectionReport } from "../knowledge/context-selection-report.js";
+import { loadContextSelectionDecisions } from "../knowledge/context-selection-store.js";
+
+export const CONTEXT_SELECTION_HELP_TEXT = `autoctx context-selection — Inspect persisted context-selection telemetry
+
+Usage:
+  autoctx context-selection --run-id <run-id> [--json]
+  autoctx context-selection <run-id> [--json]
+
+Options:
+  --run-id <id>        Run id to inspect
+  --json              Output as JSON
+  -h, --help          Show this help
+
+Examples:
+  autoctx context-selection --run-id run-123
+  autoctx context-selection --run-id run-123 --json`;
+
+export interface ContextSelectionCommandPlan {
+  runId: string;
+  json: boolean;
+}
+
+export interface ContextSelectionCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export function planContextSelectionCommand(
+  values: { "run-id"?: string; json?: boolean },
+  positionals: string[],
+): ContextSelectionCommandPlan {
+  const runId = String(values["run-id"] ?? positionals[0] ?? "").trim();
+  if (!runId) {
+    throw new Error("Error: context-selection requires --run-id <run-id>");
+  }
+  const extra = positionals.slice(values["run-id"] ? 0 : 1);
+  if (extra.length > 0) {
+    throw new Error(`Unexpected context-selection arguments: ${extra.join(" ")}`);
+  }
+  return {
+    runId,
+    json: values.json === true,
+  };
+}
+
+export function executeContextSelectionCommandWorkflow(opts: {
+  runsRoot: string;
+  plan: ContextSelectionCommandPlan;
+}): ContextSelectionCommandResult {
+  const runsRoot = resolve(opts.runsRoot);
+  let decisions;
+  try {
+    decisions = loadContextSelectionDecisions(runsRoot, opts.plan.runId);
+  } catch (error) {
+    return renderFailure(opts.plan.runId, errorMessage(error), opts.plan.json);
+  }
+  if (decisions.length === 0) {
+    return renderFailure(
+      opts.plan.runId,
+      `No context selection artifacts found for '${opts.plan.runId}'`,
+      opts.plan.json,
+    );
+  }
+  const report = buildContextSelectionReport(decisions);
+  return {
+    exitCode: 0,
+    stdout: opts.plan.json
+      ? JSON.stringify(report.toDict(), null, 2)
+      : report.toMarkdown(),
+    stderr: "",
+  };
+}
+
+function renderFailure(runId: string, error: string, json: boolean): ContextSelectionCommandResult {
+  return {
+    exitCode: 1,
+    stdout: json ? JSON.stringify({ status: "failed", error, run_id: runId }, null, 2) : "",
+    stderr: json ? "" : error,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -47,6 +47,7 @@ const NO_DB_COMMAND_HANDLERS: Record<NoDbCommandName, () => Promise<void>> = {
   simulate: cmdSimulate,
   investigate: cmdInvestigate,
   analyze: cmdAnalyze,
+  "context-selection": cmdContextSelection,
   blob: cmdBlob,
   "production-traces": cmdProductionTraces,
   instrument: cmdInstrument,
@@ -3134,6 +3135,52 @@ Examples:
       console.log(`\nLimitations:`);
       for (const l of result.limitations) console.log(`  ⚠ ${l}`);
     }
+  }
+}
+
+async function cmdContextSelection(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(3),
+    allowPositionals: true,
+    options: {
+      "run-id": { type: "string" },
+      json: { type: "boolean" },
+      help: { type: "boolean", short: "h" },
+    },
+  });
+  const {
+    CONTEXT_SELECTION_HELP_TEXT,
+    executeContextSelectionCommandWorkflow,
+    planContextSelectionCommand,
+  } = await import("./context-selection-command-workflow.js");
+
+  if (values.help) {
+    console.log(CONTEXT_SELECTION_HELP_TEXT);
+    process.exit(0);
+  }
+
+  let plan;
+  try {
+    plan = planContextSelectionCommand(values, positionals);
+  } catch (error) {
+    console.error(errorMessage(error));
+    process.exit(1);
+  }
+
+  const { loadSettings } = await import("../config/index.js");
+  const settings = loadSettings();
+  const result = executeContextSelectionCommandWorkflow({
+    runsRoot: resolve(settings.runsRoot),
+    plan,
+  });
+  if (result.stdout) {
+    console.log(result.stdout);
+  }
+  if (result.stderr) {
+    console.error(result.stderr);
+  }
+  if (result.exitCode !== 0) {
+    process.exit(result.exitCode);
   }
 }
 

--- a/ts/src/knowledge/context-selection-store.ts
+++ b/ts/src/knowledge/context-selection-store.ts
@@ -1,0 +1,86 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
+
+import type { ContextSelectionDecisionInput } from "./context-selection-report.js";
+
+const SCHEMA_VERSION = 1;
+const SAFE_STAGE_RE = /^[A-Za-z0-9_.-]+$/;
+const DECISION_FILE_RE = /^gen_(?<generation>[0-9]+)_(?<stage>[A-Za-z0-9_.-]+)\.json$/;
+
+export function loadContextSelectionDecisions(
+  runsRoot: string,
+  runId: string,
+): ContextSelectionDecisionInput[] {
+  const cleanRunId = runId.trim();
+  const contextDir = join(resolveRunRoot(runsRoot, cleanRunId), "context_selection");
+  if (!existsSync(contextDir)) {
+    return [];
+  }
+  const decisions: ContextSelectionDecisionInput[] = [];
+  for (const fileName of readdirSync(contextDir).sort()) {
+    const match = DECISION_FILE_RE.exec(fileName);
+    if (!match?.groups) continue;
+    const data = JSON.parse(readFileSync(join(contextDir, fileName), "utf-8"));
+    const decision = decisionFromPayload(data, {
+      runId: cleanRunId,
+      generation: Number.parseInt(match.groups.generation!, 10),
+      stage: match.groups.stage!,
+    });
+    if (decision) {
+      decisions.push(decision);
+    }
+  }
+  return decisions.sort((a, b) =>
+    coerceNumber(a.generation) - coerceNumber(b.generation) ||
+    String(a.stage ?? "").localeCompare(String(b.stage ?? "")));
+}
+
+function resolveRunRoot(runsRoot: string, runId: string): string {
+  const normalized = runId.trim();
+  if (!normalized) {
+    throw new Error("run_id is required");
+  }
+  const root = resolve(runsRoot);
+  const candidate = resolve(root, normalized);
+  if (candidate === root) {
+    throw new Error(`run_id must name a run subdirectory: ${runId}`);
+  }
+  const relativePath = relative(root, candidate);
+  if (relativePath === "" || relativePath.startsWith("..") || isAbsolute(relativePath)) {
+    throw new Error(`run_id escapes runs root: ${runId}`);
+  }
+  return candidate;
+}
+
+function decisionFromPayload(
+  data: unknown,
+  expected: { runId: string; generation: number; stage: string },
+): ContextSelectionDecisionInput | null {
+  if (!isRecord(data)) return null;
+  if (data.schema_version !== SCHEMA_VERSION) return null;
+  if (data.run_id !== expected.runId) return null;
+  if (!Number.isInteger(data.generation) || data.generation !== expected.generation) return null;
+  if (data.stage !== expected.stage || !SAFE_STAGE_RE.test(expected.stage)) return null;
+  if (typeof data.scenario_name !== "string") return null;
+  if (!Array.isArray(data.candidates)) return null;
+  if (!hasDecisionMetrics(data.metrics)) return null;
+  return data as ContextSelectionDecisionInput;
+}
+
+function hasDecisionMetrics(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return [
+    "candidate_count",
+    "selected_count",
+    "candidate_token_estimate",
+    "selected_token_estimate",
+  ].every((key) => Object.prototype.hasOwnProperty.call(value, key));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function coerceNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}

--- a/ts/src/knowledge/context-selection-store.ts
+++ b/ts/src/knowledge/context-selection-store.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 import type { ContextSelectionDecisionInput } from "./context-selection-report.js";
@@ -12,7 +12,8 @@ export function loadContextSelectionDecisions(
   runId: string,
 ): ContextSelectionDecisionInput[] {
   const cleanRunId = runId.trim();
-  const contextDir = join(resolveRunRoot(runsRoot, cleanRunId), "context_selection");
+  const runRoot = resolveRunRoot(runsRoot, cleanRunId);
+  const contextDir = resolveContextSelectionDir(runRoot);
   if (!existsSync(contextDir)) {
     return [];
   }
@@ -20,7 +21,7 @@ export function loadContextSelectionDecisions(
   for (const fileName of readdirSync(contextDir).sort()) {
     const match = DECISION_FILE_RE.exec(fileName);
     if (!match?.groups) continue;
-    const data = JSON.parse(readFileSync(join(contextDir, fileName), "utf-8"));
+    const data = JSON.parse(readFileSync(resolveContextSelectionFile(contextDir, fileName), "utf-8"));
     const decision = decisionFromPayload(data, {
       runId: cleanRunId,
       generation: Number.parseInt(match.groups.generation!, 10),
@@ -49,7 +50,43 @@ function resolveRunRoot(runsRoot: string, runId: string): string {
   if (relativePath === "" || relativePath.startsWith("..") || isAbsolute(relativePath)) {
     throw new Error(`run_id escapes runs root: ${runId}`);
   }
+  if (existsSync(candidate)) {
+    const realRoot = realpathSync(root);
+    const realCandidate = realpathSync(candidate);
+    if (!isContainedPath(realRoot, realCandidate)) {
+      throw new Error(`run_id escapes runs root: ${runId}`);
+    }
+    return realCandidate;
+  }
   return candidate;
+}
+
+function resolveContextSelectionDir(runRoot: string): string {
+  const contextDir = join(runRoot, "context_selection");
+  if (!existsSync(contextDir)) {
+    return contextDir;
+  }
+  const realRunRoot = realpathSync(runRoot);
+  const realContextDir = realpathSync(contextDir);
+  if (!isContainedPath(realRunRoot, realContextDir)) {
+    throw new Error("context_selection directory escapes run root");
+  }
+  return realContextDir;
+}
+
+function isContainedPath(root: string, candidate: string): boolean {
+  const relativePath = relative(root, candidate);
+  return relativePath !== "" && !relativePath.startsWith("..") && !isAbsolute(relativePath);
+}
+
+function resolveContextSelectionFile(contextDir: string, fileName: string): string {
+  const filePath = join(contextDir, fileName);
+  const realContextDir = realpathSync(contextDir);
+  const realFilePath = realpathSync(filePath);
+  if (!isContainedPath(realContextDir, realFilePath)) {
+    throw new Error("context_selection decision file escapes context-selection directory");
+  }
+  return realFilePath;
 }
 
 function decisionFromPayload(

--- a/ts/src/server/cockpit-api.ts
+++ b/ts/src/server/cockpit-api.ts
@@ -1,6 +1,8 @@
 import type { AppSettings } from "../config/index.js";
 import { createProvider as defaultCreateProvider } from "../providers/provider-factory.js";
 import type { CreateProviderOpts } from "../providers/provider-factory.js";
+import { buildContextSelectionReport } from "../knowledge/context-selection-report.js";
+import { loadContextSelectionDecisions } from "../knowledge/context-selection-store.js";
 import type {
   GenerationRow,
   NotebookRow,
@@ -31,6 +33,7 @@ export interface CockpitApiRoutes {
   listRuns(): CockpitApiResponse;
   runStatus(runId: string): CockpitApiResponse;
   changelog(runId: string): CockpitApiResponse;
+  contextSelection(runId: string): CockpitApiResponse;
   compareGenerations(runId: string, genA: number, genB: number): CockpitApiResponse;
   resumeInfo(runId: string): CockpitApiResponse;
   writeup(runId: string): CockpitApiResponse;
@@ -121,6 +124,21 @@ export function buildCockpitApiRoutes(opts: {
       }
       return { status: 200, body: buildChangelog(store, runId) };
     }),
+    contextSelection: (runId) => {
+      let decisions;
+      try {
+        decisions = loadContextSelectionDecisions(opts.runsRoot, runId.trim());
+      } catch (error) {
+        return { status: 422, body: { detail: errorMessage(error) } };
+      }
+      if (decisions.length === 0) {
+        return {
+          status: 404,
+          body: { detail: `No context selection artifacts found for run '${runId.trim()}'` },
+        };
+      }
+      return { status: 200, body: buildContextSelectionReport(decisions).toDict() };
+    },
     compareGenerations: (runId, genA, genB) => withStore(opts.openStore, (store) => {
       const generations = store.getGenerations(runId);
       const rowA = generations.find((generation) => generation.generation_index === genA);
@@ -246,6 +264,10 @@ function withRuntimeSessionStore<T>(
   } finally {
     store.close?.();
   }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function summarizeRun(store: SQLiteStore, run: RunRow): Record<string, unknown> {

--- a/ts/src/server/http-api-parity.ts
+++ b/ts/src/server/http-api-parity.ts
@@ -210,6 +210,7 @@ export const HTTP_API_PARITY_ROUTES: readonly HttpApiParityEntry[] = [
   both("cockpit", "GET", "/api/cockpit/runs", PY_COCKPIT_API),
   both("cockpit", "GET", "/api/cockpit/runs/:run_id/status", PY_COCKPIT_API),
   both("cockpit", "GET", "/api/cockpit/runs/:run_id/changelog", PY_COCKPIT_API),
+  both("cockpit", "GET", "/api/cockpit/runs/:run_id/context-selection", PY_COCKPIT_API),
   both("cockpit", "GET", "/api/cockpit/runs/:run_id/compare/:gen_a/:gen_b", PY_COCKPIT_API),
   both("cockpit", "GET", "/api/cockpit/runs/:run_id/resume", PY_COCKPIT_API),
   both("cockpit", "GET", "/api/cockpit/writeup/:run_id", PY_COCKPIT_API),

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -279,6 +279,7 @@ export class InteractiveServer {
           notebooks: "/api/notebooks",
           openclaw: "/api/openclaw",
           cockpit: "/api/cockpit",
+          context_selection: "/api/cockpit/runs/:run_id/context-selection",
           runtime_sessions: {
             list: "/api/cockpit/runtime-sessions",
             show: "/api/cockpit/runtime-sessions/:session_id",
@@ -583,6 +584,16 @@ export class InteractiveServer {
     if (method === "GET" && cockpitRunRuntimeSessionMatch) {
       const [, rawRunId] = cockpitRunRuntimeSessionMatch;
       const response = runtimeSessionApi.getByRunId(decodeURIComponent(rawRunId!));
+      json(response.status, response.body);
+      return;
+    }
+
+    const cockpitContextSelectionMatch = url.match(
+      /^\/api\/cockpit\/runs\/([^/]+)\/context-selection$/,
+    );
+    if (method === "GET" && cockpitContextSelectionMatch) {
+      const [, rawRunId] = cockpitContextSelectionMatch;
+      const response = cockpitApi.contextSelection(decodeURIComponent(rawRunId!));
       json(response.status, response.body);
       return;
     }

--- a/ts/tests/capabilities-command-workflow.test.ts
+++ b/ts/tests/capabilities-command-workflow.test.ts
@@ -49,6 +49,7 @@ describe("capabilities command workflow", () => {
         "simulate",
         "investigate",
         "analyze",
+        "context-selection",
         "candidate",
         "eval",
         "promotion",

--- a/ts/tests/cli-command-registry.test.ts
+++ b/ts/tests/cli-command-registry.test.ts
@@ -45,6 +45,10 @@ describe("CLI command registry", () => {
       kind: "db",
       command: "runtime-sessions",
     });
+    expect(resolveCliCommand("context-selection")).toEqual({
+      kind: "no-db",
+      command: "context-selection",
+    });
     expect(resolveCliCommand("mission")).toEqual({
       kind: "db",
       command: "mission",

--- a/ts/tests/context-selection-command-workflow.test.ts
+++ b/ts/tests/context-selection-command-workflow.test.ts
@@ -1,0 +1,117 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const CLI = join(import.meta.dirname, "..", "src", "cli", "index.ts");
+
+let dir: string;
+
+function persistDecision(): void {
+  const contextDir = join(dir, "runs", "run-cli", "context_selection");
+  mkdirSync(contextDir, { recursive: true });
+  writeFileSync(
+    join(contextDir, "gen_1_generation_prompt_context.json"),
+    JSON.stringify({
+      schema_version: 1,
+      run_id: "run-cli",
+      scenario_name: "grid_ctf",
+      generation: 1,
+      stage: "generation_prompt_context",
+      created_at: "2026-01-02T03:04:05.000Z",
+      metadata: {
+        context_budget_telemetry: {
+          input_token_estimate: 120,
+          output_token_estimate: 20,
+          dedupe_hit_count: 1,
+          component_cap_hit_count: 2,
+          trimmed_component_count: 1,
+        },
+        prompt_compaction_cache: {
+          hits: 0,
+          misses: 10,
+          lookups: 10,
+        },
+      },
+      metrics: {
+        candidate_count: 1,
+        selected_count: 1,
+        candidate_token_estimate: 100,
+        selected_token_estimate: 20,
+      },
+      candidates: [{
+        artifact_id: "playbook",
+        artifact_type: "prompt_component",
+        source: "prompt_assembly",
+        candidate_token_estimate: 100,
+        selected_token_estimate: 20,
+        selected: true,
+        selection_reason: "retained_after_prompt_assembly",
+        candidate_content_hash: "candidate",
+        selected_content_hash: "selected",
+      }],
+    }, null, 2),
+    "utf-8",
+  );
+}
+
+describe("context-selection CLI", () => {
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "context-selection-cli-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("renders JSON telemetry from persisted run artifacts", () => {
+    persistDecision();
+
+    const result = spawnSync(
+      "npx",
+      ["tsx", CLI, "context-selection", "--run-id", "run-cli", "--json"],
+      {
+        cwd: dir,
+        encoding: "utf-8",
+        timeout: 15000,
+        env: { ...process.env, NODE_NO_WARNINGS: "1" },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toMatchObject({
+      status: "completed",
+      run_id: "run-cli",
+      summary: expect.objectContaining({
+        budget_token_reduction: 100,
+      }),
+      telemetry_cards: expect.arrayContaining([
+        expect.objectContaining({ key: "context_budget", severity: "warning" }),
+      ]),
+    });
+  }, 15000);
+
+  it("fails clearly when no persisted context-selection artifacts exist", () => {
+    const result = spawnSync(
+      "npx",
+      ["tsx", CLI, "context-selection", "--run-id", "missing-run", "--json"],
+      {
+        cwd: dir,
+        encoding: "utf-8",
+        timeout: 15000,
+        env: { ...process.env, NODE_NO_WARNINGS: "1" },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toMatchObject({
+      status: "failed",
+      run_id: "missing-run",
+      error: expect.stringContaining("No context selection artifacts"),
+    });
+  }, 15000);
+});

--- a/ts/tests/context-selection-store.test.ts
+++ b/ts/tests/context-selection-store.test.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadContextSelectionDecisions } from "../src/knowledge/context-selection-store.js";
+
+let dir: string;
+
+function decisionPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    run_id: "run-1",
+    scenario_name: "grid_ctf",
+    generation: 1,
+    stage: "generation_prompt_context",
+    created_at: "2026-01-02T03:04:05.000Z",
+    metadata: {
+      context_budget_telemetry: {
+        input_token_estimate: 120,
+        output_token_estimate: 20,
+        dedupe_hit_count: 1,
+        component_cap_hit_count: 2,
+        trimmed_component_count: 1,
+      },
+      prompt_compaction_cache: {
+        hits: 0,
+        misses: 10,
+        lookups: 10,
+      },
+    },
+    metrics: {
+      candidate_count: 1,
+      selected_count: 1,
+      candidate_token_estimate: 100,
+      selected_token_estimate: 20,
+    },
+    candidates: [{
+      artifact_id: "playbook",
+      artifact_type: "prompt_component",
+      source: "prompt_assembly",
+      candidate_token_estimate: 100,
+      selected_token_estimate: 20,
+      selected: true,
+      selection_reason: "retained_after_prompt_assembly",
+      candidate_content_hash: "candidate",
+      selected_content_hash: "selected",
+    }],
+    ...overrides,
+  };
+}
+
+function writeDecision(name: string, payload: Record<string, unknown>): void {
+  const contextDir = join(dir, "runs", "run-1", "context_selection");
+  mkdirSync(contextDir, { recursive: true });
+  writeFileSync(join(contextDir, name), JSON.stringify(payload, null, 2), "utf-8");
+}
+
+describe("context selection store", () => {
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "context-selection-store-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("loads only validated persisted decision files for one run", () => {
+    writeDecision("gen_1_generation_prompt_context.json", decisionPayload());
+    writeDecision("summary.json", decisionPayload({ generation: 99 }));
+    writeDecision("gen_2_generation_prompt_context.json", decisionPayload({
+      generation: 2,
+      schema_version: 999,
+    }));
+
+    const decisions = loadContextSelectionDecisions(join(dir, "runs"), "run-1");
+
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      run_id: "run-1",
+      scenario_name: "grid_ctf",
+      generation: 1,
+      stage: "generation_prompt_context",
+    });
+  });
+
+  it("rejects run ids that escape the runs root", () => {
+    expect(() => loadContextSelectionDecisions(join(dir, "runs"), "../outside")).toThrow(
+      /escapes runs root/,
+    );
+  });
+});

--- a/ts/tests/context-selection-store.test.ts
+++ b/ts/tests/context-selection-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -57,6 +57,12 @@ function writeDecision(name: string, payload: Record<string, unknown>): void {
   writeFileSync(join(contextDir, name), JSON.stringify(payload, null, 2), "utf-8");
 }
 
+function writeDecisionUnder(root: string, name: string, payload: Record<string, unknown>): void {
+  const contextDir = join(root, "context_selection");
+  mkdirSync(contextDir, { recursive: true });
+  writeFileSync(join(contextDir, name), JSON.stringify(payload, null, 2), "utf-8");
+}
+
 describe("context selection store", () => {
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "context-selection-store-"));
@@ -88,6 +94,50 @@ describe("context selection store", () => {
   it("rejects run ids that escape the runs root", () => {
     expect(() => loadContextSelectionDecisions(join(dir, "runs"), "../outside")).toThrow(
       /escapes runs root/,
+    );
+  });
+
+  it("rejects run directory symlinks that escape the runs root", () => {
+    const runsRoot = join(dir, "runs");
+    const outsideRun = join(dir, "outside-run");
+    mkdirSync(runsRoot, { recursive: true });
+    writeDecisionUnder(outsideRun, "gen_1_generation_prompt_context.json", decisionPayload({
+      run_id: "link",
+    }));
+    symlinkSync(outsideRun, join(runsRoot, "link"), "dir");
+
+    expect(() => loadContextSelectionDecisions(runsRoot, "link")).toThrow(
+      /escapes runs root/,
+    );
+  });
+
+  it("rejects context-selection directory symlinks that escape the run root", () => {
+    const runsRoot = join(dir, "runs");
+    const runRoot = join(runsRoot, "run-1");
+    const outsideContextRoot = join(dir, "outside-context");
+    mkdirSync(runRoot, { recursive: true });
+    writeDecisionUnder(outsideContextRoot, "gen_1_generation_prompt_context.json", decisionPayload());
+    symlinkSync(join(outsideContextRoot, "context_selection"), join(runRoot, "context_selection"), "dir");
+
+    expect(() => loadContextSelectionDecisions(runsRoot, "run-1")).toThrow(
+      /escapes run root/,
+    );
+  });
+
+  it("rejects decision file symlinks that escape the context-selection directory", () => {
+    const runsRoot = join(dir, "runs");
+    const contextDir = join(runsRoot, "run-1", "context_selection");
+    const outsideFile = join(dir, "outside-decision.json");
+    mkdirSync(contextDir, { recursive: true });
+    writeFileSync(
+      outsideFile,
+      JSON.stringify(decisionPayload(), null, 2),
+      "utf-8",
+    );
+    symlinkSync(outsideFile, join(contextDir, "gen_1_generation_prompt_context.json"));
+
+    expect(() => loadContextSelectionDecisions(runsRoot, "run-1")).toThrow(
+      /escapes context-selection directory/,
     );
   });
 });

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -274,6 +274,54 @@ function expectTestRunRuntimeSessionDiscovery(value: unknown): void {
   });
 }
 
+function persistContextSelectionDecision(dir: string): void {
+  const contextDir = join(dir, "runs", "test-run-1", "context_selection");
+  mkdirSync(contextDir, { recursive: true });
+  writeFileSync(
+    join(contextDir, "gen_1_generation_prompt_context.json"),
+    JSON.stringify({
+      schema_version: 1,
+      run_id: "test-run-1",
+      scenario_name: "grid_ctf",
+      generation: 1,
+      stage: "generation_prompt_context",
+      created_at: "2026-01-02T03:04:05.000Z",
+      metadata: {
+        context_budget_telemetry: {
+          input_token_estimate: 120,
+          output_token_estimate: 20,
+          dedupe_hit_count: 1,
+          component_cap_hit_count: 2,
+          trimmed_component_count: 1,
+        },
+        prompt_compaction_cache: {
+          hits: 0,
+          misses: 10,
+          lookups: 10,
+        },
+      },
+      metrics: {
+        candidate_count: 1,
+        selected_count: 1,
+        candidate_token_estimate: 100,
+        selected_token_estimate: 20,
+      },
+      candidates: [{
+        artifact_id: "playbook",
+        artifact_type: "prompt_component",
+        source: "prompt_assembly",
+        candidate_token_estimate: 100,
+        selected_token_estimate: 20,
+        selected: true,
+        selection_reason: "retained_after_prompt_assembly",
+        candidate_content_hash: "candidate",
+        selected_content_hash: "selected",
+      }],
+    }, null, 2),
+    "utf-8",
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Health endpoint (already exists — regression check)
 // ---------------------------------------------------------------------------
@@ -314,6 +362,7 @@ describe("HTTP API — health", () => {
     expect(endpoints.notebooks).toBe("/api/notebooks");
     expect(endpoints.openclaw).toBe("/api/openclaw");
     expect(endpoints.cockpit).toBe("/api/cockpit");
+    expect(endpoints.context_selection).toBe("/api/cockpit/runs/:run_id/context-selection");
     expect(endpoints.hub).toBe("/api/hub");
     expect(endpoints.knowledge).toMatchObject({
       scenarios: "/api/knowledge/scenarios",
@@ -382,6 +431,11 @@ describe("HTTP API — health", () => {
     expect(matrix.routes).toContainEqual(expect.objectContaining({
       method: "GET",
       path: "/api/cockpit/runs",
+      status: "aligned",
+    }));
+    expect(matrix.routes).toContainEqual(expect.objectContaining({
+      method: "GET",
+      path: "/api/cockpit/runs/:run_id/context-selection",
       status: "aligned",
     }));
     expect(matrix.routes).toContainEqual(expect.objectContaining({
@@ -884,6 +938,53 @@ describe("HTTP API — cockpit", () => {
       })],
     });
     expectTestRunRuntimeSessionDiscovery(body);
+  });
+
+  it("GET /api/cockpit/runs/:run_id/context-selection returns telemetry cards", async () => {
+    persistContextSelectionDecision(dir);
+
+    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/context-selection`);
+
+    expect(status).toBe(200);
+    expect(body).toMatchObject({
+      status: "completed",
+      run_id: "test-run-1",
+      scenario_name: "grid_ctf",
+      summary: expect.objectContaining({
+        budget_token_reduction: 100,
+        compaction_cache_hit_rate: 0,
+      }),
+      telemetry_cards: expect.arrayContaining([
+        expect.objectContaining({
+          key: "context_budget",
+          severity: "warning",
+          value: "100 est. tokens reduced",
+        }),
+        expect.objectContaining({
+          key: "semantic_compaction_cache",
+          severity: "warning",
+          value: "0.0% hit rate",
+        }),
+      ]),
+    });
+  });
+
+  it("GET /api/cockpit/runs/:run_id/context-selection handles missing artifacts", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/test-run-1/context-selection`);
+
+    expect(status).toBe(404);
+    expect(body).toMatchObject({
+      detail: expect.stringContaining("No context selection artifacts"),
+    });
+  });
+
+  it("GET /api/cockpit/runs/:run_id/context-selection rejects escaped run ids", async () => {
+    const { status, body } = await fetchJson(`${baseUrl}/api/cockpit/runs/%2E%2E%2Foutside/context-selection`);
+
+    expect(status).toBe(422);
+    expect(body).toMatchObject({
+      detail: expect.stringContaining("escapes runs root"),
+    });
   });
 
   it("GET /api/cockpit/runs/:run_id/compare/:gen_a/:gen_b compares generations", async () => {


### PR DESCRIPTION
Summary:
- Add a validated TypeScript loader for persisted context-selection decision artifacts.
- Expose context-selection telemetry through the TypeScript Cockpit API and HTTP parity matrix.
- Add a TypeScript CLI command for persisted context-selection reports and document the operator workflow.

Tests:
- npm test -- context-selection-store.test.ts context-selection-report.test.ts context-selection-command-workflow.test.ts http-api.test.ts cli-command-registry.test.ts capabilities-command-workflow.test.ts
- npm run lint
- uv run --frozen pytest tests/test_context_selection.py tests/test_cockpit.py::TestCockpitRunStatus::test_run_context_selection_report tests/test_cockpit.py::TestCockpitRunStatus::test_run_context_selection_report_missing
- git diff --check