### PR TITLE
feat(loop): import-signature surfacer (AC-768)

### DIFF
--- a/autocontext/src/autocontext/loop/refinement_prompt.py
+++ b/autocontext/src/autocontext/loop/refinement_prompt.py
@@ -12,27 +12,22 @@ def build_refinement_prompt(
     current_playbook: str = "",
     score_trajectory: str = "",
     operational_lessons: str = "",
+    imported_signatures: str = "",
 ) -> str:
     """Build a prompt for refining an existing strategy (tree search mode).
 
     Unlike the initial competitor prompt, this asks the LLM to improve an
     existing strategy based on match results rather than generating from scratch.
+
+    ``imported_signatures`` is the rendered output of
+    :func:`autocontext.loop.signature_surfacer.render_signatures` (AC-768) — a
+    prompt block listing the signatures of local-module symbols actually imported
+    by ``parent_strategy``. Empty string omits the block.
     """
-    playbook_block = (
-        f"Current playbook:\n{current_playbook}\n\n"
-        if current_playbook
-        else ""
-    )
-    trajectory_block = (
-        f"Score trajectory:\n{score_trajectory}\n\n"
-        if score_trajectory
-        else ""
-    )
-    lessons_block = (
-        f"Operational lessons:\n{operational_lessons}\n\n"
-        if operational_lessons
-        else ""
-    )
+    playbook_block = f"Current playbook:\n{current_playbook}\n\n" if current_playbook else ""
+    trajectory_block = f"Score trajectory:\n{score_trajectory}\n\n" if score_trajectory else ""
+    lessons_block = f"Operational lessons:\n{operational_lessons}\n\n" if operational_lessons else ""
+    signatures_block = f"{imported_signatures}\n\n" if imported_signatures else ""
     return (
         f"Scenario rules:\n{scenario_rules}\n\n"
         f"Strategy interface:\n{strategy_interface}\n\n"
@@ -40,6 +35,7 @@ def build_refinement_prompt(
         f"{playbook_block}"
         f"{trajectory_block}"
         f"{lessons_block}"
+        f"{signatures_block}"
         "--- STRATEGY REFINEMENT ---\n\n"
         "You are refining an existing strategy, not creating one from scratch.\n\n"
         f"Current strategy to refine:\n<strategy>\n{parent_strategy}\n</strategy>\n\n"

--- a/autocontext/src/autocontext/loop/signature_surfacer.py
+++ b/autocontext/src/autocontext/loop/signature_surfacer.py
@@ -18,7 +18,7 @@ import ast
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 SymbolKind = Literal["function", "class", "method"]
 
@@ -187,22 +187,29 @@ def _imports(source: str) -> tuple[list[str], list[tuple[str, list[str], bool]]]
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                bare.append(alias.name.split(".", 1)[0])
+                # Preserve dotted names so `import pkg.helpers` can resolve
+                # to `pkg/helpers.py` rather than the package root.
+                bare.append(alias.name)
         elif isinstance(node, ast.ImportFrom):
             if node.module is None or node.level != 0:
                 continue
             star = any(alias.name == "*" for alias in node.names)
             names = [alias.name for alias in node.names if alias.name != "*"]
-            froms.append((node.module.split(".", 1)[0], names, star))
+            froms.append((node.module, names, star))
     return bare, froms
 
 
 def _locate(module_name: str, search_roots: Sequence[Path]) -> Path | None:
+    """Resolve ``module_name`` (possibly dotted, e.g. ``pkg.helpers``) to a
+    Python file. Tries ``<root>/<a>/<b>.py`` first, then
+    ``<root>/<a>/<b>/__init__.py``."""
+    parts = module_name.split(".")
     for root in search_roots:
-        candidate = root / f"{module_name}.py"
+        leaf = root.joinpath(*parts)
+        candidate = leaf.with_suffix(".py")
         if candidate.is_file():
             return candidate
-        pkg_init = root / module_name / "__init__.py"
+        pkg_init = leaf / "__init__.py"
         if pkg_init.is_file():
             return pkg_init
     return None
@@ -236,18 +243,29 @@ def _filter_for_imports(
     froms: list[tuple[str, list[str], bool]],
     bare_imports: list[str],
 ) -> list[Symbol]:
-    """Filter ``symbols`` from ``module`` to those actually imported by source."""
-    # `from module import *` or `import module` → all public.
+    """Filter ``symbols`` from ``module`` to those actually imported by source.
+
+    Accumulates wanted names across ALL `from module import …` statements that
+    target the same module — a `*` import unions in all public symbols."""
+    # `import module` (or any nested form) surfaces everything public.
     if module in bare_imports:
         return list(symbols)
+
+    wanted: set[str] = set()
+    star = False
     for from_module, names, is_star in froms:
         if from_module != module:
             continue
         if is_star:
-            return list(symbols)
-        wanted = set(names)
-        return [s for s in symbols if s.name in wanted or (s.qualified_name and s.qualified_name.split(".", 1)[0] in wanted)]
-    return []
+            star = True
+        else:
+            wanted.update(names)
+    if star:
+        return list(symbols)
+    if not wanted:
+        return []
+    symbols_list = list(symbols)
+    return [s for s in symbols_list if s.name in wanted or (s.qualified_name and s.qualified_name.split(".", 1)[0] in wanted)]
 
 
 def surface_signatures(source: str, search_roots: Sequence[Path]) -> list[Symbol]:
@@ -268,6 +286,26 @@ def surface_signatures(source: str, search_roots: Sequence[Path]) -> list[Symbol
 
 
 # --- Rendering -------------------------------------------------------------
+
+
+def surface_for_strategy(
+    strategy: dict[str, Any] | object,
+    *,
+    code_strategies_enabled: bool,
+    search_roots: Sequence[Path],
+) -> str:
+    """High-level wiring for ``stage_tree_search``: given a tree-search strategy
+    dict, surface signatures for any local imports in its ``__code__`` payload
+    and return a rendered prompt block. Returns ``""`` for non-code strategies
+    or when nothing local resolves."""
+    if not code_strategies_enabled:
+        return ""
+    if not isinstance(strategy, dict):
+        return ""
+    code = strategy.get("__code__")
+    if not isinstance(code, str) or not code:
+        return ""
+    return render_signatures(surface_signatures(code, search_roots))
 
 
 def render_signatures(symbols: Sequence[Symbol]) -> str:

--- a/autocontext/src/autocontext/loop/signature_surfacer.py
+++ b/autocontext/src/autocontext/loop/signature_surfacer.py
@@ -1,0 +1,292 @@
+"""Import-signature surfacing for local-module symbols (AC-768).
+
+When generated code does ``from x import y``, this module statically extracts
+``y``'s signature from ``x`` and emits a compact prompt block. No LLM call.
+
+Three concerns, each independently testable:
+  1. :func:`extract_symbols` — walk a Python source string for public symbols.
+  2. :func:`resolve_imports` — locate referenced modules on disk.
+  3. :func:`surface_signatures` — end-to-end orchestration.
+  4. :func:`render_signatures` — prompt-block emission.
+
+Sister to AC-728 contract-probes: probes verify outputs, this surfaces inputs.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+SymbolKind = Literal["function", "class", "method"]
+
+
+@dataclass(frozen=True, slots=True)
+class Symbol:
+    """A single public symbol surfaced from an imported module."""
+
+    name: str
+    kind: SymbolKind
+    signature: str
+    docstring_first_line: str | None
+    qualified_name: str | None = None
+
+
+# --- Symbol extraction -----------------------------------------------------
+
+
+def _is_public(name: str) -> bool:
+    return not name.startswith("_")
+
+
+def _unparse(node: ast.AST | None) -> str:
+    if node is None:
+        return ""
+    try:
+        return ast.unparse(node)
+    except Exception:
+        return ""
+
+
+def _format_args(args: ast.arguments) -> str:
+    """Render an ``ast.arguments`` as a parameter list ``(a, b: int = 1, *c, **d)``."""
+    parts: list[str] = []
+
+    posonly = list(args.posonlyargs)
+    regular = list(args.args)
+    defaults = list(args.defaults)
+    # Defaults align to the *tail* of (posonly + regular).
+    all_positional = posonly + regular
+    n_defaults = len(defaults)
+    default_offset = len(all_positional) - n_defaults
+
+    for i, a in enumerate(all_positional):
+        rendered = a.arg
+        if a.annotation is not None:
+            rendered += f": {_unparse(a.annotation)}"
+        if i >= default_offset:
+            d = defaults[i - default_offset]
+            rendered += f" = {_unparse(d)}"
+        parts.append(rendered)
+        if posonly and a is posonly[-1]:
+            parts.append("/")
+
+    if args.vararg is not None:
+        rendered = f"*{args.vararg.arg}"
+        if args.vararg.annotation is not None:
+            rendered += f": {_unparse(args.vararg.annotation)}"
+        parts.append(rendered)
+    elif args.kwonlyargs:
+        parts.append("*")
+
+    for kw_arg, kw_default in zip(args.kwonlyargs, args.kw_defaults, strict=True):
+        rendered = kw_arg.arg
+        if kw_arg.annotation is not None:
+            rendered += f": {_unparse(kw_arg.annotation)}"
+        if kw_default is not None:
+            rendered += f" = {_unparse(kw_default)}"
+        parts.append(rendered)
+
+    if args.kwarg is not None:
+        rendered = f"**{args.kwarg.arg}"
+        if args.kwarg.annotation is not None:
+            rendered += f": {_unparse(args.kwarg.annotation)}"
+        parts.append(rendered)
+
+    return "(" + ", ".join(parts) + ")"
+
+
+def _signature(func: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    sig = _format_args(func.args)
+    if func.returns is not None:
+        sig += f" -> {_unparse(func.returns)}"
+    return sig
+
+
+def _docstring_first_line(
+    node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef | ast.Module,
+) -> str | None:
+    doc = ast.get_docstring(node)
+    if not doc:
+        return None
+    return doc.strip().splitlines()[0].strip()
+
+
+def _symbol_from_func(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+    *,
+    kind: SymbolKind,
+    qualified_name: str | None = None,
+) -> Symbol:
+    return Symbol(
+        name=func.name,
+        kind=kind,
+        signature=_signature(func),
+        docstring_first_line=_docstring_first_line(func),
+        qualified_name=qualified_name,
+    )
+
+
+def extract_symbols(source: str) -> list[Symbol]:
+    """Walk Python source, return public symbols (functions, classes, methods).
+
+    Malformed source returns ``[]`` — we may run on partial code.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    out: list[Symbol] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if _is_public(node.name):
+                out.append(_symbol_from_func(node, kind="function"))
+        elif isinstance(node, ast.ClassDef):
+            if not _is_public(node.name):
+                continue
+            out.append(
+                Symbol(
+                    name=node.name,
+                    kind="class",
+                    signature="",
+                    docstring_first_line=_docstring_first_line(node),
+                    qualified_name=node.name,
+                )
+            )
+            for sub in node.body:
+                if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)) and _is_public(sub.name):
+                    out.append(
+                        _symbol_from_func(
+                            sub,
+                            kind="method",
+                            qualified_name=f"{node.name}.{sub.name}",
+                        )
+                    )
+    return out
+
+
+# --- Import resolution -----------------------------------------------------
+
+
+def _imports(source: str) -> tuple[list[str], list[tuple[str, list[str], bool]]]:
+    """Return (bare_imports, from_imports).
+
+    bare_imports: module names from ``import x`` / ``import x.y``.
+    from_imports: list of (module, [names], is_star) for each ``from x import …``.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return [], []
+
+    bare: list[str] = []
+    froms: list[tuple[str, list[str], bool]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                bare.append(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is None or node.level != 0:
+                continue
+            star = any(alias.name == "*" for alias in node.names)
+            names = [alias.name for alias in node.names if alias.name != "*"]
+            froms.append((node.module.split(".", 1)[0], names, star))
+    return bare, froms
+
+
+def _locate(module_name: str, search_roots: Sequence[Path]) -> Path | None:
+    for root in search_roots:
+        candidate = root / f"{module_name}.py"
+        if candidate.is_file():
+            return candidate
+        pkg_init = root / module_name / "__init__.py"
+        if pkg_init.is_file():
+            return pkg_init
+    return None
+
+
+def resolve_imports(source: str, search_roots: Sequence[Path]) -> dict[str, Path]:
+    """Resolve local imports in ``source`` to on-disk module files.
+
+    Stdlib and third-party imports are silently skipped (no matching file in
+    the given roots).
+    """
+    bare, froms = _imports(source)
+    out: dict[str, Path] = {}
+    for name in bare:
+        path = _locate(name, search_roots)
+        if path is not None:
+            out[name] = path
+    for module, _names, _star in froms:
+        path = _locate(module, search_roots)
+        if path is not None:
+            out[module] = path
+    return out
+
+
+# --- End-to-end orchestration ----------------------------------------------
+
+
+def _filter_for_imports(
+    module: str,
+    symbols: Iterable[Symbol],
+    froms: list[tuple[str, list[str], bool]],
+    bare_imports: list[str],
+) -> list[Symbol]:
+    """Filter ``symbols`` from ``module`` to those actually imported by source."""
+    # `from module import *` or `import module` → all public.
+    if module in bare_imports:
+        return list(symbols)
+    for from_module, names, is_star in froms:
+        if from_module != module:
+            continue
+        if is_star:
+            return list(symbols)
+        wanted = set(names)
+        return [s for s in symbols if s.name in wanted or (s.qualified_name and s.qualified_name.split(".", 1)[0] in wanted)]
+    return []
+
+
+def surface_signatures(source: str, search_roots: Sequence[Path]) -> list[Symbol]:
+    """Resolve local imports in ``source``, extract symbols from each module,
+    filter to those actually requested, return the surfaced list."""
+    bare, froms = _imports(source)
+    resolved = resolve_imports(source, search_roots)
+
+    out: list[Symbol] = []
+    for module, path in resolved.items():
+        try:
+            module_source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        symbols = extract_symbols(module_source)
+        out.extend(_filter_for_imports(module, symbols, froms, bare))
+    return out
+
+
+# --- Rendering -------------------------------------------------------------
+
+
+def render_signatures(symbols: Sequence[Symbol]) -> str:
+    """Emit a compact prompt block for the surfaced symbols."""
+    if not symbols:
+        return ""
+    lines: list[str] = ["## Imported symbols available", ""]
+    for s in symbols:
+        if s.kind == "class":
+            label = s.name
+            sig_part = ""
+        elif s.kind == "method":
+            label = s.qualified_name or s.name
+            sig_part = s.signature
+        else:
+            label = s.name
+            sig_part = s.signature
+        bullet = f"- `{label}{sig_part}`"
+        if s.docstring_first_line:
+            bullet += f" — {s.docstring_first_line}"
+        lines.append(bullet)
+    return "\n".join(lines)

--- a/autocontext/src/autocontext/loop/stage_tree_search.py
+++ b/autocontext/src/autocontext/loop/stage_tree_search.py
@@ -17,6 +17,7 @@ from autocontext.harness.mutations.parser import parse_mutations
 from autocontext.knowledge.rapid_gate import rapid_gate
 from autocontext.loop.hypothesis_tree import HypothesisTree
 from autocontext.loop.refinement_prompt import build_refinement_prompt
+from autocontext.loop.signature_surfacer import surface_for_strategy
 from autocontext.loop.stage_helpers.harness_mutations import persist_approved_harness_mutations
 from autocontext.loop.stage_types import GenerationContext
 
@@ -60,11 +61,14 @@ def stage_tree_search(
         temperature=settings.tree_sampling_temperature,
     )
 
-    events.emit("tree_search_start", {
-        "run_id": ctx.run_id,
-        "generation": ctx.generation,
-        "max_hypotheses": settings.tree_max_hypotheses,
-    })
+    events.emit(
+        "tree_search_start",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "max_hypotheses": settings.tree_max_hypotheses,
+        },
+    )
 
     # ── Phase 1: Seed hypotheses ─────────────────────────────────────
     initial_seeds = min(settings.tree_max_hypotheses, _MAX_INITIAL_SEEDS)
@@ -73,8 +77,11 @@ def stage_tree_search(
     for seed_idx in range(initial_seeds):
         try:
             strategy = _generate_and_translate(
-                orchestrator, ctx.prompts.competitor, strategy_interface,
-                ctx.tool_context, settings.code_strategies_enabled,
+                orchestrator,
+                ctx.prompts.competitor,
+                strategy_interface,
+                ctx.tool_context,
+                settings.code_strategies_enabled,
             )
         except Exception:
             logger.debug("seed %d generation failed", seed_idx, exc_info=True)
@@ -85,7 +92,9 @@ def stage_tree_search(
 
         node = tree.add(strategy, generation=ctx.generation)
         tournament = _run_mini_tournament(
-            scenario, supervisor, strategy,
+            scenario,
+            supervisor,
+            strategy,
             seed_base=settings.seed_base + (ctx.generation * 100) + (seed_idx * 10),
             trials=trials_per_seed,
             challenger_elo=ctx.challenger_elo,
@@ -99,7 +108,8 @@ def stage_tree_search(
     if tree.size() == 0:
         logger.warning("all seed hypotheses failed; falling back to single attempt")
         raw_text, competitor_exec = orchestrator.competitor.run(
-            ctx.prompts.competitor, tool_context=ctx.tool_context,
+            ctx.prompts.competitor,
+            tool_context=ctx.tool_context,
         )
         if settings.code_strategies_enabled:
             strategy, _ = orchestrator.translator.translate_code(raw_text)
@@ -111,36 +121,57 @@ def stage_tree_search(
     max_rounds = settings.tree_max_hypotheses * 2
     for round_idx in range(max_rounds):
         if tree.converged() or tree.size() < 2:
-            events.emit("tree_converged", {
-                "run_id": ctx.run_id,
-                "generation": ctx.generation,
-                "round": round_idx,
-            })
+            events.emit(
+                "tree_converged",
+                {
+                    "run_id": ctx.run_id,
+                    "generation": ctx.generation,
+                    "round": round_idx,
+                },
+            )
             break
 
         selected = tree.select()
-        events.emit("hypothesis_selected", {
-            "run_id": ctx.run_id,
-            "generation": ctx.generation,
-            "node_id": selected.id,
-            "elo": selected.elo,
-        })
+        events.emit(
+            "hypothesis_selected",
+            {
+                "run_id": ctx.run_id,
+                "generation": ctx.generation,
+                "node_id": selected.id,
+                "elo": selected.elo,
+            },
+        )
 
         # Build refinement prompt
         recent_scores = selected.scores[-5:] if selected.scores else []
         match_feedback = f"Recent scores: {recent_scores}, Elo: {selected.elo:.0f}"
+        # AC-768: when the strategy is Python source (code_strategies_enabled),
+        # statically surface the signatures of any local helpers it imports so
+        # the refinement model sees the call-site contract.
+        imported_signatures = surface_for_strategy(
+            selected.strategy,
+            code_strategies_enabled=settings.code_strategies_enabled,
+            search_roots=[
+                artifacts.tools_dir(ctx.scenario_name),
+                artifacts.harness_dir(ctx.scenario_name),
+            ],
+        )
         refinement_prompt = build_refinement_prompt(
             scenario_rules=scenario.describe_rules(),
             strategy_interface=strategy_interface,
             evaluation_criteria=scenario.describe_evaluation_criteria(),
             parent_strategy=json.dumps(selected.strategy, sort_keys=True),
             match_feedback=match_feedback,
+            imported_signatures=imported_signatures,
         )
 
         try:
             refined_strategy = _generate_and_translate(
-                orchestrator, refinement_prompt, strategy_interface,
-                ctx.tool_context, settings.code_strategies_enabled,
+                orchestrator,
+                refinement_prompt,
+                strategy_interface,
+                ctx.tool_context,
+                settings.code_strategies_enabled,
             )
         except Exception:
             logger.debug("refinement round %d failed", round_idx, exc_info=True)
@@ -151,7 +182,9 @@ def stage_tree_search(
 
         refined_node = tree.add(refined_strategy, parent_id=selected.id, generation=ctx.generation)
         tournament = _run_mini_tournament(
-            scenario, supervisor, refined_strategy,
+            scenario,
+            supervisor,
+            refined_strategy,
             seed_base=settings.seed_base + (ctx.generation * 100) + 50 + round_idx,
             trials=trials_per_seed,
             challenger_elo=ctx.challenger_elo,
@@ -161,13 +194,16 @@ def stage_tree_search(
         )
         tree.update(refined_node.id, [r.score for r in tournament.results], tournament.elo_after)
 
-        events.emit("hypothesis_refined", {
-            "run_id": ctx.run_id,
-            "generation": ctx.generation,
-            "parent_id": selected.id,
-            "child_id": refined_node.id,
-            "score": tournament.best_score,
-        })
+        events.emit(
+            "hypothesis_refined",
+            {
+                "run_id": ctx.run_id,
+                "generation": ctx.generation,
+                "parent_id": selected.id,
+                "child_id": refined_node.id,
+                "score": tournament.best_score,
+            },
+        )
 
     # ── Phase 3: Final tournament with best strategy ─────────────────
     best_node = tree.best()
@@ -177,12 +213,15 @@ def stage_tree_search(
     runner = EvaluationRunner(evaluator, scoring_backend=settings.scoring_backend)
 
     def _on_match(match_index: int, result: Any) -> None:
-        events.emit("match_completed", {
-            "run_id": ctx.run_id,
-            "generation": ctx.generation,
-            "match_index": match_index,
-            "score": result.score,
-        })
+        events.emit(
+            "match_completed",
+            {
+                "run_id": ctx.run_id,
+                "generation": ctx.generation,
+                "match_index": match_index,
+                "score": result.score,
+            },
+        )
 
     final_tournament = runner.run(
         candidate=best_strategy,
@@ -199,24 +238,30 @@ def stage_tree_search(
     gate_decision = gate_result.decision
     gate_delta = round(final_tournament.best_score - ctx.previous_best, 6)
 
-    events.emit("tournament_completed", {
-        "run_id": ctx.run_id,
-        "generation": ctx.generation,
-        "mean_score": final_tournament.mean_score,
-        "best_score": final_tournament.best_score,
-        "wins": final_tournament.wins,
-        "losses": final_tournament.losses,
-        "scoring_backend": final_tournament.scoring_backend,
-        "rating_uncertainty": final_tournament.uncertainty_after,
-    })
-    events.emit("gate_decided", {
-        "run_id": ctx.run_id,
-        "generation": ctx.generation,
-        "decision": gate_decision,
-        "delta": gate_delta,
-        "scoring_backend": final_tournament.scoring_backend,
-        "rating_uncertainty": final_tournament.uncertainty_after,
-    })
+    events.emit(
+        "tournament_completed",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "mean_score": final_tournament.mean_score,
+            "best_score": final_tournament.best_score,
+            "wins": final_tournament.wins,
+            "losses": final_tournament.losses,
+            "scoring_backend": final_tournament.scoring_backend,
+            "rating_uncertainty": final_tournament.uncertainty_after,
+        },
+    )
+    events.emit(
+        "gate_decided",
+        {
+            "run_id": ctx.run_id,
+            "generation": ctx.generation,
+            "decision": gate_decision,
+            "delta": gate_delta,
+            "scoring_backend": final_tournament.scoring_backend,
+            "rating_uncertainty": final_tournament.uncertainty_after,
+        },
+    )
 
     # ── Phase 5: Run analyst / coach / architect ─────────────────────
     def _notify(role: str, status: str) -> None:
@@ -244,7 +289,8 @@ def stage_tree_search(
     coach_playbook, coach_lessons, coach_hints = parse_coach_sections(coach_exec.content)
 
     competitor_typed = parse_competitor_output(
-        json.dumps(best_strategy, sort_keys=True), best_strategy,
+        json.dumps(best_strategy, sort_keys=True),
+        best_strategy,
         is_code_strategy=settings.code_strategies_enabled,
     )
     analyst_typed = parse_analyst_output(analyst_exec.content)

--- a/autocontext/tests/test_signature_surfacer.py
+++ b/autocontext/tests/test_signature_surfacer.py
@@ -17,6 +17,7 @@ from autocontext.loop.signature_surfacer import (
     extract_symbols,
     render_signatures,
     resolve_imports,
+    surface_for_strategy,
     surface_signatures,
 )
 
@@ -180,6 +181,43 @@ class TestSurfaceSignatures:
     def test_no_imports_returns_empty(self, tmp_path: Path) -> None:
         assert surface_signatures("x = 1\nprint(x)", [tmp_path]) == []
 
+    def test_multiple_from_statements_for_same_module_union(self, tmp_path: Path) -> None:
+        """Reviewer finding (PR #969): two separate `from many import …`
+        statements for the same module should surface symbols from BOTH,
+        not just the first."""
+        (tmp_path / "many.py").write_text(
+            textwrap.dedent("""\
+            def needed(): pass
+            def also_needed(): pass
+            def unused(): pass
+        """)
+        )
+        source = "from many import needed\nfrom many import also_needed\n"
+        surfaced = surface_signatures(source, [tmp_path])
+        names = {s.name for s in surfaced}
+        assert names == {"needed", "also_needed"}
+
+    def test_dotted_import_resolves_submodule(self, tmp_path: Path) -> None:
+        """Reviewer finding (PR #969): `from pkg.helpers import foo` should
+        resolve to `pkg/helpers.py`, not truncate to `pkg/__init__.py`."""
+        (tmp_path / "pkg").mkdir()
+        (tmp_path / "pkg" / "__init__.py").write_text("")
+        (tmp_path / "pkg" / "helpers.py").write_text("def foo(x: int) -> int: return x\n")
+        source = "from pkg.helpers import foo"
+        surfaced = surface_signatures(source, [tmp_path])
+        names = {s.name for s in surfaced}
+        assert names == {"foo"}
+
+    def test_bare_dotted_import_resolves_submodule(self, tmp_path: Path) -> None:
+        """`import pkg.helpers` should surface symbols from pkg/helpers.py."""
+        (tmp_path / "pkg").mkdir()
+        (tmp_path / "pkg" / "__init__.py").write_text("")
+        (tmp_path / "pkg" / "helpers.py").write_text("def bar(): pass\n")
+        source = "import pkg.helpers"
+        surfaced = surface_signatures(source, [tmp_path])
+        names = {s.name for s in surfaced}
+        assert names == {"bar"}
+
 
 class TestRefinementPromptIntegration:
     def test_signature_block_included_in_refinement_prompt(self, tmp_path: Path) -> None:
@@ -258,3 +296,42 @@ class TestRenderSignatures:
             ),
         ]
         assert "CBCCipher.encrypt" in render_signatures(symbols)
+
+
+class TestSurfaceForStrategy:
+    """High-level wiring used by stage_tree_search (PR #969 finding 1).
+
+    Confirms that when ``code_strategies_enabled`` is true and the strategy
+    dict carries a ``__code__`` payload, the helper surfaces a non-empty
+    prompt block from local imports."""
+
+    def test_code_strategy_with_local_imports(self, tmp_path: Path) -> None:
+        (tmp_path / "helpers.py").write_text(
+            textwrap.dedent('''\
+            def cbc_decrypt(key: bytes, iv: bytes, ciphertext: bytes) -> bytes:
+                """Decrypt CBC ciphertext."""
+                return b""
+        ''')
+        )
+        strategy = {"__code__": "from helpers import cbc_decrypt\nresult = cbc_decrypt(k, ct, iv)"}
+        block = surface_for_strategy(strategy, code_strategies_enabled=True, search_roots=[tmp_path])
+        assert "## Imported symbols available" in block
+        assert "cbc_decrypt(key: bytes, iv: bytes, ciphertext: bytes) -> bytes" in block
+
+    def test_disabled_returns_empty(self, tmp_path: Path) -> None:
+        strategy = {"__code__": "from x import y"}
+        assert surface_for_strategy(strategy, code_strategies_enabled=False, search_roots=[tmp_path]) == ""
+
+    def test_non_code_strategy_returns_empty(self, tmp_path: Path) -> None:
+        # JSON-shaped strategies (no ``__code__`` field) yield no signatures.
+        strategy = {"action": "move", "x": 0}
+        assert surface_for_strategy(strategy, code_strategies_enabled=True, search_roots=[tmp_path]) == ""
+
+    def test_non_dict_strategy_returns_empty(self, tmp_path: Path) -> None:
+        # Defensive against odd shapes.
+        assert surface_for_strategy("not a dict", code_strategies_enabled=True, search_roots=[tmp_path]) == ""
+
+    def test_code_with_no_local_imports_returns_empty(self, tmp_path: Path) -> None:
+        strategy = {"__code__": "import os\nx = 1"}
+        # stdlib import isn't in search_roots → empty block.
+        assert surface_for_strategy(strategy, code_strategies_enabled=True, search_roots=[tmp_path]) == ""

--- a/autocontext/tests/test_signature_surfacer.py
+++ b/autocontext/tests/test_signature_surfacer.py
@@ -1,0 +1,260 @@
+"""Tests for AC-768 import-signature surfacer.
+
+Three concerns under test, each isolated:
+  1. `extract_symbols`: walk a Python source string, collect public symbols.
+  2. `resolve_imports`: parse imports, locate referenced module files on disk.
+  3. `surface_signatures`: end-to-end orchestration.
+  4. `render_signatures`: prompt-block emission.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from autocontext.loop.signature_surfacer import (
+    Symbol,
+    extract_symbols,
+    render_signatures,
+    resolve_imports,
+    surface_signatures,
+)
+
+
+class TestExtractSymbols:
+    def test_single_function_with_annotations(self) -> None:
+        code = textwrap.dedent("""\
+            def cbc_decrypt(key: bytes, iv: bytes, ciphertext: bytes) -> bytes:
+                return b""
+        """)
+        symbols = extract_symbols(code)
+        assert len(symbols) == 1
+        s = symbols[0]
+        assert s.name == "cbc_decrypt"
+        assert s.kind == "function"
+        assert s.signature == "(key: bytes, iv: bytes, ciphertext: bytes) -> bytes"
+        assert s.docstring_first_line is None
+
+    def test_unannotated_function(self) -> None:
+        code = "def foo(x, y): return x + y"
+        symbols = extract_symbols(code)
+        assert len(symbols) == 1
+        assert symbols[0].signature == "(x, y)"
+
+    def test_docstring_first_line_captured(self) -> None:
+        code = textwrap.dedent('''\
+            def encode(data: bytes) -> str:
+                """Encode bytes to base64.
+
+                Drops padding when ``strip_padding`` is true.
+                """
+                return ""
+        ''')
+        symbols = extract_symbols(code)
+        assert symbols[0].docstring_first_line == "Encode bytes to base64."
+
+    def test_private_symbols_skipped(self) -> None:
+        code = textwrap.dedent("""\
+            def public_one(): pass
+            def _private(): pass
+            def __dunder__(): pass
+        """)
+        names = {s.name for s in extract_symbols(code)}
+        assert names == {"public_one"}
+
+    def test_class_with_public_methods(self) -> None:
+        code = textwrap.dedent("""\
+            class CBCCipher:
+                def encrypt(self, plaintext: bytes) -> bytes: ...
+                def decrypt(self, ciphertext: bytes) -> bytes: ...
+                def _internal(self) -> None: ...
+        """)
+        symbols = extract_symbols(code)
+        kinds = {(s.kind, s.qualified_name or s.name) for s in symbols}
+        assert ("class", "CBCCipher") in kinds
+        assert ("method", "CBCCipher.encrypt") in kinds
+        assert ("method", "CBCCipher.decrypt") in kinds
+        # private method excluded
+        assert not any(s.name == "_internal" for s in symbols)
+
+    def test_async_function(self) -> None:
+        code = "async def fetch(url: str) -> bytes: return b''"
+        symbols = extract_symbols(code)
+        assert symbols[0].signature == "(url: str) -> bytes"
+
+    def test_function_with_defaults(self) -> None:
+        code = "def pad(data: bytes, block_size: int = 16) -> bytes: return data"
+        symbols = extract_symbols(code)
+        assert symbols[0].signature == "(data: bytes, block_size: int = 16) -> bytes"
+
+    def test_function_with_star_args(self) -> None:
+        code = "def f(*args: int, **kwargs: str) -> None: ..."
+        symbols = extract_symbols(code)
+        assert symbols[0].signature == "(*args: int, **kwargs: str) -> None"
+
+    def test_invalid_syntax_returns_empty(self) -> None:
+        # Don't blow up on malformed source — we may run on partial code.
+        assert extract_symbols("def broken(:::") == []
+
+
+class TestResolveImports:
+    def test_from_import_resolves_to_sibling_file(self, tmp_path: Path) -> None:
+        (tmp_path / "c10_cbc_mode.py").write_text("def cbc_decrypt(): pass")
+        source = "from c10_cbc_mode import cbc_decrypt"
+        resolved = resolve_imports(source, [tmp_path])
+        assert "c10_cbc_mode" in resolved
+        assert resolved["c10_cbc_mode"] == tmp_path / "c10_cbc_mode.py"
+
+    def test_import_x_resolves(self, tmp_path: Path) -> None:
+        (tmp_path / "helpers.py").write_text("")
+        source = "import helpers"
+        resolved = resolve_imports(source, [tmp_path])
+        assert resolved["helpers"] == tmp_path / "helpers.py"
+
+    def test_unresolvable_import_is_skipped(self, tmp_path: Path) -> None:
+        # stdlib and missing modules: silently absent.
+        source = "import os\nfrom hashlib import sha256\nfrom no_such_pkg import foo"
+        resolved = resolve_imports(source, [tmp_path])
+        assert resolved == {}
+
+    def test_multiple_search_roots(self, tmp_path: Path) -> None:
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        (a / "alpha.py").write_text("")
+        (b / "beta.py").write_text("")
+        source = "from alpha import x\nfrom beta import y"
+        resolved = resolve_imports(source, [a, b])
+        assert set(resolved) == {"alpha", "beta"}
+
+    def test_invalid_syntax_returns_empty(self, tmp_path: Path) -> None:
+        assert resolve_imports("from :::: broken", [tmp_path]) == {}
+
+
+class TestSurfaceSignatures:
+    def test_end_to_end(self, tmp_path: Path) -> None:
+        (tmp_path / "crypt.py").write_text(
+            textwrap.dedent('''\
+            def cbc_decrypt(key: bytes, iv: bytes, ciphertext: bytes) -> bytes:
+                """Decrypt CBC ciphertext under (key, iv)."""
+                return b""
+
+            def _helper(): pass
+        ''')
+        )
+        source = "from crypt import cbc_decrypt"
+        surfaced = surface_signatures(source, [tmp_path])
+        # Only the cbc_decrypt symbol is surfaced — _helper is private.
+        names = [s.name for s in surfaced]
+        assert names == ["cbc_decrypt"]
+        assert surfaced[0].docstring_first_line == "Decrypt CBC ciphertext under (key, iv)."
+
+    def test_from_import_specific_filters_to_imported_names(self, tmp_path: Path) -> None:
+        (tmp_path / "many.py").write_text(
+            textwrap.dedent("""\
+            def needed(): pass
+            def also_needed(): pass
+            def unused(): pass
+        """)
+        )
+        source = "from many import needed, also_needed"
+        surfaced = surface_signatures(source, [tmp_path])
+        names = {s.name for s in surfaced}
+        assert names == {"needed", "also_needed"}
+        # `unused` not requested; not surfaced even though it's public.
+
+    def test_from_import_star_surfaces_all_public(self, tmp_path: Path) -> None:
+        (tmp_path / "many.py").write_text(
+            textwrap.dedent("""\
+            def a(): pass
+            def b(): pass
+            def _hidden(): pass
+        """)
+        )
+        source = "from many import *"
+        surfaced = surface_signatures(source, [tmp_path])
+        names = {s.name for s in surfaced}
+        assert names == {"a", "b"}
+
+    def test_no_imports_returns_empty(self, tmp_path: Path) -> None:
+        assert surface_signatures("x = 1\nprint(x)", [tmp_path]) == []
+
+
+class TestRefinementPromptIntegration:
+    def test_signature_block_included_in_refinement_prompt(self, tmp_path: Path) -> None:
+        from autocontext.loop.refinement_prompt import build_refinement_prompt
+
+        (tmp_path / "crypt.py").write_text(
+            textwrap.dedent('''\
+            def cbc_decrypt(key: bytes, iv: bytes, ciphertext: bytes) -> bytes:
+                """Decrypt CBC ciphertext."""
+                return b""
+        ''')
+        )
+        parent = "from crypt import cbc_decrypt\nresult = cbc_decrypt(k, ct, iv)"
+        surfaced = surface_signatures(parent, [tmp_path])
+        signatures_block = render_signatures(surfaced)
+
+        prompt = build_refinement_prompt(
+            scenario_rules="rules",
+            strategy_interface="iface",
+            evaluation_criteria="crit",
+            parent_strategy=parent,
+            match_feedback="wrong output",
+            imported_signatures=signatures_block,
+        )
+        assert "## Imported symbols available" in prompt
+        assert "cbc_decrypt(key: bytes, iv: bytes, ciphertext: bytes) -> bytes" in prompt
+        assert "Decrypt CBC ciphertext." in prompt
+
+    def test_no_signatures_means_no_block(self) -> None:
+        from autocontext.loop.refinement_prompt import build_refinement_prompt
+
+        prompt = build_refinement_prompt(
+            scenario_rules="rules",
+            strategy_interface="iface",
+            evaluation_criteria="crit",
+            parent_strategy="x = 1",
+            match_feedback="wrong",
+        )
+        # Default empty: section header must not appear.
+        assert "Imported symbols available" not in prompt
+
+
+class TestRenderSignatures:
+    def test_renders_compact_block(self) -> None:
+        symbols = [
+            Symbol(
+                name="cbc_decrypt",
+                kind="function",
+                signature="(key: bytes, iv: bytes, ciphertext: bytes) -> bytes",
+                docstring_first_line="Decrypt CBC ciphertext under (key, iv).",
+            ),
+            Symbol(
+                name="pkcs7_pad",
+                kind="function",
+                signature="(data: bytes, block_size: int) -> bytes",
+                docstring_first_line=None,
+            ),
+        ]
+        block = render_signatures(symbols)
+        assert "## Imported symbols available" in block
+        assert "cbc_decrypt(key: bytes, iv: bytes, ciphertext: bytes) -> bytes" in block
+        assert "Decrypt CBC ciphertext under (key, iv)." in block
+        assert "pkcs7_pad(data: bytes, block_size: int) -> bytes" in block
+
+    def test_empty_list_renders_nothing(self) -> None:
+        assert render_signatures([]) == ""
+
+    def test_methods_qualified(self) -> None:
+        symbols = [
+            Symbol(
+                name="encrypt",
+                kind="method",
+                signature="(self, plaintext: bytes) -> bytes",
+                docstring_first_line=None,
+                qualified_name="CBCCipher.encrypt",
+            ),
+        ]
+        assert "CBCCipher.encrypt" in render_signatures(symbols)


### PR DESCRIPTION
## Summary

- Adds `autocontext/loop/signature_surfacer.py` — static AST analysis that, when generated code does `from x import y`, extracts y's signature from x and emits a compact prompt block. No LLM call.
- Adds `imported_signatures: str = ""` opt-in kwarg to `build_refinement_prompt` so existing callers continue to work unchanged.

## Why

Cryptopals 1–7 campaign (see [project memory](https://linear.app/greyhaven/issue/AC-768)) showed that plumbing / API-misuse accounts for 4 of 12 iteration-required failures: arg-order (c35), stale placeholder import (c42), block-alignment (c49.1), test-setup precondition (c41). In each case the function lived 10 lines away in a sibling file, but a fresh subagent didn't have the signature in working memory. Static surfacing fixes the whole class at near-zero cost.

## Surface

- `Symbol` value type (frozen-slot).
- `extract_symbols(source)` — walk a module AST, public symbols only.
- `resolve_imports(source, search_roots)` — locate referenced module files on disk. Stdlib / third-party silently skipped.
- `surface_signatures(source, search_roots)` — end-to-end orchestrator that filters to what was actually imported (`from x import a, b` only surfaces a, b; `from x import *` surfaces all public; `import x` surfaces all public).
- `render_signatures(symbols)` — compact prompt block.

## DDD / DRY

- Four pure functions, each independently testable. `Symbol` is the only shared structure.
- Reuses stdlib `ast.unparse` and `ast.get_docstring`. No new deps.
- Sister to AC-728 contract-probes: probes verify outputs, this surfaces inputs.

## Test plan

- [x] 23 new tests across 5 `TestX` classes mirroring the function decomposition
- [x] Integration test through `build_refinement_prompt` confirms opt-in block flows end-to-end
- [x] 81 related tests pass on this branch
- [x] Ruff + mypy clean
- [ ] Reviewer: try the surfacer on a sample multi-file scenario in your local dev (\`from autocontext.loop.signature_surfacer import surface_signatures; print(render_signatures(surface_signatures(...)))\`)