### PR TITLE
feat(loop): Lean compile-error router rule + four hint kinds (AC-773)

### DIFF
--- a/autocontext/src/autocontext/loop/remediation_router.py
+++ b/autocontext/src/autocontext/loop/remediation_router.py
@@ -485,111 +485,119 @@ def rule_indexing_base(
 # because Python-ecosystem patterns don't match Lean's error vocabulary.
 # Pure regex, pluggable into ``DEFAULT_RULES``.
 
-# Lean errors carry a ``<path>:<line>:<col>: error:`` preamble. We don't
-# require it: the patterns below operate on whatever line(s) carry the
-# error keyword, falling back to line 0 when not present.
+# Lean errors carry a preamble. Two shapes seen in the wild:
+#   ``<path>:<line>:<col>: error: <body>``                  (classic / mathlib)
+#   ``<path>:<line>:<col>: error(lean.<code>): <body>``     (Lean 4.29+ diagnostic codes)
+# We use this single preamble regex both to extract line numbers and to bound
+# each error body — the next preamble marks where the current error ends.
 
-_LEAN_LINE = re.compile(r":(?P<line>\d+):\d+:\s*error:")
-_LEAN_UNKNOWN_IDENT = re.compile(r"unknown (?:identifier|constant) '(?P<name>[^']+)'")
+_LEAN_PREAMBLE = re.compile(
+    r"^[^\s:][^\n:]*:(?P<line>\d+):\d+:\s*error(?:\(lean\.\w+\))?:\s*(?P<body>.*?)"
+    r"(?=^[^\s:][^\n:]*:\d+:\d+:\s*error(?:\(lean\.\w+\))?:|\Z)",
+    re.DOTALL | re.MULTILINE,
+)
+
+# Body-level patterns. PR #982 review (P2): broadened to match Lean 4.29+
+# stderr forms (capital initial, backtick-quoted names, ``but this term has
+# type`` phrasing, ``type class instance expected``) alongside the older
+# mathlib forms.
+
+_LEAN_UNKNOWN_IDENT = re.compile(r"[Uu]nknown\s+(?:identifier|constant)\s+[`']?(?P<name>[A-Za-z_][\w.]*)[`']?")
 _LEAN_TYPE_MISMATCH = re.compile(
-    r"(?:type mismatch|function expected at).*?\n(?P<got_or_subject>.*?)\n"
-    r"(?:has type|term has type)\n"
+    # Capture the subject between the opening line and the ``has type`` divider.
+    r"[Tt]ype\s+mismatch\b.*?\n"
+    r"(?P<subject>.*?)\n"
+    r"(?:has type|term has type)\s*\n"
     r"(?P<got>.*?)\n"
-    r"(?:but is expected to have type|expected type:)\s*\n?"
-    r"(?P<expected>.*?)(?:\n\n|\Z)",
+    r"(?:but is expected to have type|but this term has type|expected type:?)\s*\n?"
+    r"(?P<expected>.*?)\Z",
     re.DOTALL,
 )
 _LEAN_FUNCTION_EXPECTED = re.compile(
-    r"function expected at\n(?P<subject>.*?)\nterm has type\n(?P<got>.*?)(?:\n\n|\Z)",
+    # Accept both ``term has type`` (classic) and ``but this term has type``
+    # (Lean 4.29+).
+    r"[Ff]unction\s+expected(?:\s+at)?\s*\n"
+    r"(?P<subject>.*?)\n"
+    r"(?:but this term has type|term has type|has type)\s*\n"
+    r"(?P<got>.*?)\Z",
     re.DOTALL,
 )
-_LEAN_UNSOLVED_GOALS = re.compile(
-    r"unsolved goals\n(?P<body>.*?)(?=\n\S+:\d+:\d+:|\Z)",
-    re.DOTALL,
-)
+_LEAN_UNSOLVED_GOALS = re.compile(r"[Uu]nsolved\s+goals\s*\n(?P<body>.*?)\Z", re.DOTALL)
 _LEAN_TYPECLASS_FAIL = re.compile(
-    r"failed to synthesize instance\n\s*(?P<typeclass>\S+)(?:\s+(?P<context>.+?))?(?:\n|$)",
+    # Old: ``failed to synthesize instance`` — new (Lean 4.29+):
+    # ``type class instance expected``. Both are followed by the unresolved
+    # typeclass on the next indented line.
+    r"(?:failed to synthesize(?: instance)?|type\s*class\s+instance\s+expected)\s*\n"
+    r"\s*(?P<typeclass>\S+)(?:\s+(?P<context>.+?))?(?:\n|\Z)"
 )
-
-
-def _nearest_line(error: str, offset: int) -> int:
-    """Return the line number from the nearest preceding ``:N:C: error:``
-    marker, or 0 if none."""
-    last = 0
-    for m in _LEAN_LINE.finditer(error[:offset]):
-        last = int(m.group("line"))
-    return last
 
 
 def rule_lean_compile_error(report: FailureReport, **_: Any) -> list[RemediationHint]:
     """Pattern-match ``lake env lean`` stderr into typed hints.
 
-    Emits :class:`UnknownIdentifier`, :class:`TypeMismatch`,
-    :class:`UnsolvedGoals`, or :class:`TypeclassSearch` per matched error.
-    Errors that don't match any Lean pattern produce no hint (Python
-    tracebacks and similar are routed by other rules).
+    The error string is split into per-error bodies via :data:`_LEAN_PREAMBLE`,
+    so each body's regex captures cannot bleed past the next ``:line:col: error``
+    marker (PR #982 review P2). Each body is then scanned for the four
+    recognised error classes; non-Lean errors (Python tracebacks etc.)
+    yield no preamble matches and produce no hints.
     """
     hints: list[RemediationHint] = []
     for diagnosis in report.match_diagnoses:
         for error in diagnosis.errors:
             reason = f"match {diagnosis.match_index}"
 
-            for m in _LEAN_UNKNOWN_IDENT.finditer(error):
-                hints.append(
-                    UnknownIdentifier(
-                        name=m.group("name"),
-                        line=_nearest_line(error, m.start()),
-                        reason=reason,
-                    )
+            # Split into per-error bodies bounded by the next preamble.
+            for pre in _LEAN_PREAMBLE.finditer(error):
+                line = int(pre.group("line"))
+                body = pre.group("body")
+
+                hints.extend(
+                    UnknownIdentifier(name=m.group("name"), line=line, reason=reason) for m in _LEAN_UNKNOWN_IDENT.finditer(body)
                 )
 
-            for m in _LEAN_TYPE_MISMATCH.finditer(error):
-                hints.append(
-                    TypeMismatch(
-                        expected=m.group("expected").strip(),
-                        got=m.group("got").strip(),
-                        line=_nearest_line(error, m.start()),
-                        reason=reason,
-                    )
-                )
-
-            # ``function expected at ... term has type ...`` is a sub-case of
-            # type mismatch; route to the same hint kind but only when the
-            # full type-mismatch pattern didn't fire to avoid duplicates.
-            if not any(isinstance(h, TypeMismatch) for h in hints[-3:]):
-                for m in _LEAN_FUNCTION_EXPECTED.finditer(error):
+                # Each body usually has at most ONE structural error. We try
+                # type-mismatch first; only fall through to function-expected
+                # if no type-mismatch matched THIS body (anchored dedup, not
+                # the global last-three-hints heuristic the reviewer flagged).
+                tm_match = _LEAN_TYPE_MISMATCH.search(body)
+                if tm_match is not None:
                     hints.append(
                         TypeMismatch(
-                            expected="<callable>",
-                            got=m.group("got").strip(),
-                            line=_nearest_line(error, m.start()),
+                            expected=tm_match.group("expected").strip(),
+                            got=tm_match.group("got").strip(),
+                            line=line,
                             reason=reason,
                         )
                     )
+                else:
+                    fe_match = _LEAN_FUNCTION_EXPECTED.search(body)
+                    if fe_match is not None:
+                        hints.append(
+                            TypeMismatch(
+                                expected="<callable>",
+                                got=fe_match.group("got").strip(),
+                                line=line,
+                                reason=reason,
+                            )
+                        )
 
-            for m in _LEAN_UNSOLVED_GOALS.finditer(error):
-                body = m.group("body").strip()
-                # Each goal usually starts with ⊢; split on it.
-                goals = ["⊢ " + part.strip() for part in re.split(r"⊢\s*", body) if part.strip()]
-                if not goals:
-                    goals = [body[:200]]
-                hints.append(
-                    UnsolvedGoals(
-                        goals=tuple(goals),
-                        line=_nearest_line(error, m.start()),
-                        reason=reason,
-                    )
-                )
+                ug_match = _LEAN_UNSOLVED_GOALS.search(body)
+                if ug_match is not None:
+                    body_text = ug_match.group("body").strip()
+                    goals = ["⊢ " + part.strip() for part in re.split(r"⊢\s*", body_text) if part.strip()]
+                    if not goals:
+                        goals = [body_text[:200]]
+                    hints.append(UnsolvedGoals(goals=tuple(goals), line=line, reason=reason))
 
-            for m in _LEAN_TYPECLASS_FAIL.finditer(error):
-                hints.append(
-                    TypeclassSearch(
-                        typeclass=m.group("typeclass").strip(),
-                        context=(m.group("context") or "").strip(),
-                        line=_nearest_line(error, m.start()),
-                        reason=reason,
+                for m in _LEAN_TYPECLASS_FAIL.finditer(body):
+                    hints.append(
+                        TypeclassSearch(
+                            typeclass=m.group("typeclass").strip(),
+                            context=(m.group("context") or "").strip(),
+                            line=line,
+                            reason=reason,
+                        )
                     )
-                )
 
     return hints
 

--- a/autocontext/src/autocontext/loop/remediation_router.py
+++ b/autocontext/src/autocontext/loop/remediation_router.py
@@ -90,6 +90,48 @@ class IndexingCheck:
     reason: str
 
 
+# AC-773: typed hints for Lean 4 / mathlib ``lake env lean`` compile errors.
+
+
+@dataclass(frozen=True, slots=True)
+class UnknownIdentifier:
+    """``unknown identifier '<name>'`` or ``unknown constant '<Name>'``."""
+
+    name: str
+    line: int
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class TypeMismatch:
+    """``type mismatch`` or ``function expected, term has type ...``."""
+
+    expected: str
+    got: str
+    line: int
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class UnsolvedGoals:
+    """``unsolved goals`` — proof structurally complete but doesn't close
+    the remaining proof obligations."""
+
+    goals: tuple[str, ...]
+    line: int
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class TypeclassSearch:
+    """``failed to synthesize instance ...`` — typeclass resolution gap."""
+
+    typeclass: str
+    context: str
+    line: int
+    reason: str
+
+
 RemediationHint = (
     RefreshFixture
     | SurfaceSignatures
@@ -97,6 +139,10 @@ RemediationHint = (
     | AssertionMismatch
     | BudgetIncrease
     | IndexingCheck
+    | UnknownIdentifier
+    | TypeMismatch
+    | UnsolvedGoals
+    | TypeclassSearch
 )
 
 
@@ -432,12 +478,129 @@ def rule_indexing_base(
     return hints
 
 
+# --- AC-773: Lean 4 / mathlib compile-error rule --------------------------
+#
+# Surfaced by the Erdős #986 (Spencer k=3) campaign (2026-05-21): the
+# existing rules emitted 0 hints across 4 ``lake env lean`` failures
+# because Python-ecosystem patterns don't match Lean's error vocabulary.
+# Pure regex, pluggable into ``DEFAULT_RULES``.
+
+# Lean errors carry a ``<path>:<line>:<col>: error:`` preamble. We don't
+# require it: the patterns below operate on whatever line(s) carry the
+# error keyword, falling back to line 0 when not present.
+
+_LEAN_LINE = re.compile(r":(?P<line>\d+):\d+:\s*error:")
+_LEAN_UNKNOWN_IDENT = re.compile(r"unknown (?:identifier|constant) '(?P<name>[^']+)'")
+_LEAN_TYPE_MISMATCH = re.compile(
+    r"(?:type mismatch|function expected at).*?\n(?P<got_or_subject>.*?)\n"
+    r"(?:has type|term has type)\n"
+    r"(?P<got>.*?)\n"
+    r"(?:but is expected to have type|expected type:)\s*\n?"
+    r"(?P<expected>.*?)(?:\n\n|\Z)",
+    re.DOTALL,
+)
+_LEAN_FUNCTION_EXPECTED = re.compile(
+    r"function expected at\n(?P<subject>.*?)\nterm has type\n(?P<got>.*?)(?:\n\n|\Z)",
+    re.DOTALL,
+)
+_LEAN_UNSOLVED_GOALS = re.compile(
+    r"unsolved goals\n(?P<body>.*?)(?=\n\S+:\d+:\d+:|\Z)",
+    re.DOTALL,
+)
+_LEAN_TYPECLASS_FAIL = re.compile(
+    r"failed to synthesize instance\n\s*(?P<typeclass>\S+)(?:\s+(?P<context>.+?))?(?:\n|$)",
+)
+
+
+def _nearest_line(error: str, offset: int) -> int:
+    """Return the line number from the nearest preceding ``:N:C: error:``
+    marker, or 0 if none."""
+    last = 0
+    for m in _LEAN_LINE.finditer(error[:offset]):
+        last = int(m.group("line"))
+    return last
+
+
+def rule_lean_compile_error(report: FailureReport, **_: Any) -> list[RemediationHint]:
+    """Pattern-match ``lake env lean`` stderr into typed hints.
+
+    Emits :class:`UnknownIdentifier`, :class:`TypeMismatch`,
+    :class:`UnsolvedGoals`, or :class:`TypeclassSearch` per matched error.
+    Errors that don't match any Lean pattern produce no hint (Python
+    tracebacks and similar are routed by other rules).
+    """
+    hints: list[RemediationHint] = []
+    for diagnosis in report.match_diagnoses:
+        for error in diagnosis.errors:
+            reason = f"match {diagnosis.match_index}"
+
+            for m in _LEAN_UNKNOWN_IDENT.finditer(error):
+                hints.append(
+                    UnknownIdentifier(
+                        name=m.group("name"),
+                        line=_nearest_line(error, m.start()),
+                        reason=reason,
+                    )
+                )
+
+            for m in _LEAN_TYPE_MISMATCH.finditer(error):
+                hints.append(
+                    TypeMismatch(
+                        expected=m.group("expected").strip(),
+                        got=m.group("got").strip(),
+                        line=_nearest_line(error, m.start()),
+                        reason=reason,
+                    )
+                )
+
+            # ``function expected at ... term has type ...`` is a sub-case of
+            # type mismatch; route to the same hint kind but only when the
+            # full type-mismatch pattern didn't fire to avoid duplicates.
+            if not any(isinstance(h, TypeMismatch) for h in hints[-3:]):
+                for m in _LEAN_FUNCTION_EXPECTED.finditer(error):
+                    hints.append(
+                        TypeMismatch(
+                            expected="<callable>",
+                            got=m.group("got").strip(),
+                            line=_nearest_line(error, m.start()),
+                            reason=reason,
+                        )
+                    )
+
+            for m in _LEAN_UNSOLVED_GOALS.finditer(error):
+                body = m.group("body").strip()
+                # Each goal usually starts with ⊢; split on it.
+                goals = ["⊢ " + part.strip() for part in re.split(r"⊢\s*", body) if part.strip()]
+                if not goals:
+                    goals = [body[:200]]
+                hints.append(
+                    UnsolvedGoals(
+                        goals=tuple(goals),
+                        line=_nearest_line(error, m.start()),
+                        reason=reason,
+                    )
+                )
+
+            for m in _LEAN_TYPECLASS_FAIL.finditer(error):
+                hints.append(
+                    TypeclassSearch(
+                        typeclass=m.group("typeclass").strip(),
+                        context=(m.group("context") or "").strip(),
+                        line=_nearest_line(error, m.start()),
+                        reason=reason,
+                    )
+                )
+
+    return hints
+
+
 DEFAULT_RULES: list[Rule] = [
     rule_off_by_one,
     rule_positional_typerror,
     rule_stale_fixture,
     rule_threshold_budget,
     rule_invariant_violation,
+    rule_lean_compile_error,
     # PR #979 review (P2): rule_indexing_base is intentionally NOT in
     # the default set. It fires on 0/N failures, which equally describe
     # AC-770 budget problems; mixing both in the default path sends
@@ -493,12 +656,25 @@ def _describe(hint: RemediationHint) -> str:
         return f"invariant `{hint.invariant}` failed; observed `{hint.observed}` ({hint.reason})"
     if isinstance(hint, BudgetIncrease):
         scope = f"`{hint.parameter}`"
-        return (
-            f"increase {scope} budget by {hint.suggested_factor}x "
-            f"(currently {hint.current}; {hint.reason})"
-        )
+        return f"increase {scope} budget by {hint.suggested_factor}x (currently {hint.current}; {hint.reason})"
     if isinstance(hint, IndexingCheck):
         return f"check 0-vs-1 indexing-base ({hint.reason})"
+    if isinstance(hint, UnknownIdentifier):
+        loc = f" at line {hint.line}" if hint.line else ""
+        return f"unknown Lean identifier `{hint.name}`{loc}: check imports / typo ({hint.reason})"
+    if isinstance(hint, TypeMismatch):
+        loc = f" at line {hint.line}" if hint.line else ""
+        return f"Lean type mismatch{loc}: expected `{hint.expected}`, got `{hint.got}` ({hint.reason})"
+    if isinstance(hint, UnsolvedGoals):
+        loc = f" at line {hint.line}" if hint.line else ""
+        goals_str = "; ".join(hint.goals[:3])
+        if len(hint.goals) > 3:
+            goals_str += f"; (+{len(hint.goals) - 3} more)"
+        return f"Lean unsolved goals{loc}: {goals_str} ({hint.reason})"
+    if isinstance(hint, TypeclassSearch):
+        loc = f" at line {hint.line}" if hint.line else ""
+        ctx = f" for `{hint.context}`" if hint.context else ""
+        return f"Lean typeclass search failed{loc}: `{hint.typeclass}`{ctx} ({hint.reason})"
     return repr(hint)  # unreachable
 
 

--- a/autocontext/tests/test_remediation_router.py
+++ b/autocontext/tests/test_remediation_router.py
@@ -477,3 +477,107 @@ class TestRenderNewHints:
         )
         block = render_hints([hint])
         assert "indexing" in block.lower() or "Z_16" in block
+
+
+# --- AC-773: Lean compile-error router rule -------------------------------
+#
+# Pattern-match common Lean 4 / mathlib compile errors from ``lake env lean``
+# stderr into typed hints. Surfaced by the Erdős #986 (Spencer k=3) campaign
+# (2026-05-21): the existing rules emitted 0 hints across 4 Lean failures
+# because none of them match Lean's error vocabulary.
+
+
+from autocontext.loop.remediation_router import (  # noqa: E402
+    TypeclassSearch,
+    TypeMismatch,
+    UnknownIdentifier,
+    UnsolvedGoals,
+    rule_lean_compile_error,
+)
+
+
+class TestRuleLeanCompileError:
+    def test_unknown_identifier_emits_typed_hint(self) -> None:
+        err = (
+            "MathlibScratch/Erdos986.lean:84:8: error: unknown identifier 'foo_bar'\n"
+            "MathlibScratch/Erdos986.lean:84:14: error: unknown identifier 'baz'\n"
+        )
+        hints = rule_lean_compile_error(_report([err]))
+        kinds = {(type(h).__name__, getattr(h, "name", None)) for h in hints}
+        assert ("UnknownIdentifier", "foo_bar") in kinds
+        assert ("UnknownIdentifier", "baz") in kinds
+
+    def test_unknown_constant_also_routes_to_unknown_identifier(self) -> None:
+        err = "MathlibScratch/Erdos986.lean:84:8: error: unknown constant 'SimpleGraph.Foo'\n"
+        hints = rule_lean_compile_error(_report([err]))
+        assert any(isinstance(h, UnknownIdentifier) and h.name == "SimpleGraph.Foo" for h in hints)
+
+    def test_type_mismatch_extracts_expected_and_got(self) -> None:
+        err = (
+            "MathlibScratch/Erdos986.lean:120:4: error: type mismatch\n"
+            "  Finset.card s\n"
+            "has type\n"
+            "  ℕ : Type\n"
+            "but is expected to have type\n"
+            "  Prop : Type\n"
+        )
+        hints = rule_lean_compile_error(_report([err]))
+        assert any(isinstance(h, TypeMismatch) for h in hints)
+        tm = next(h for h in hints if isinstance(h, TypeMismatch))
+        assert "ℕ" in tm.got or "Nat" in tm.got
+        assert "Prop" in tm.expected
+
+    def test_function_expected_routes_to_type_mismatch(self) -> None:
+        err = "MathlibScratch/Erdos986.lean:90:8: error: function expected at\n  Foo\nterm has type\n  Nat\n"
+        hints = rule_lean_compile_error(_report([err]))
+        assert any(isinstance(h, TypeMismatch) for h in hints)
+
+    def test_unsolved_goals_extracts_goal_text(self) -> None:
+        err = "MathlibScratch/Erdos986.lean:115:4: error: unsolved goals\ncase pos\nn : ℕ\n⊢ ramseyNumber 2 n ≤ n\n"
+        hints = rule_lean_compile_error(_report([err]))
+        assert any(isinstance(h, UnsolvedGoals) for h in hints)
+
+    def test_failed_to_synthesize_instance_routes_to_typeclass_search(self) -> None:
+        err = "MathlibScratch/Erdos986.lean:50:0: error: failed to synthesize instance\n  DecidableEq (SimpleGraph (Fin n))\n"
+        hints = rule_lean_compile_error(_report([err]))
+        assert any(isinstance(h, TypeclassSearch) for h in hints)
+        ts = next(h for h in hints if isinstance(h, TypeclassSearch))
+        assert "DecidableEq" in ts.typeclass
+
+    def test_no_lean_pattern_no_hint(self) -> None:
+        """Python TypeErrors and other non-Lean errors must not falsely fire."""
+        err = 'Traceback (most recent call last):\n  File "x.py"\nTypeError: foo() missing'
+        assert rule_lean_compile_error(_report([err])) == []
+
+    def test_empty_errors_no_hint(self) -> None:
+        assert rule_lean_compile_error(_report()) == []
+
+    def test_default_rules_includes_lean(self) -> None:
+        assert rule_lean_compile_error in DEFAULT_RULES
+
+    def test_route_remediations_picks_up_lean_errors(self) -> None:
+        """End-to-end: the high-level orchestrator routes Lean errors when
+        rule_lean_compile_error is in DEFAULT_RULES."""
+        err = "MathlibScratch/Erdos986.lean:84:8: error: unknown identifier 'foo'\n"
+        hints = route_remediations(_report([err]))
+        assert any(isinstance(h, UnknownIdentifier) for h in hints)
+
+
+class TestRenderLeanHints:
+    def test_render_unknown_identifier(self) -> None:
+        block = render_hints([UnknownIdentifier(name="ramseyNumber", line=84, reason="match 0")])
+        assert "## Suggested next moves" in block
+        assert "ramseyNumber" in block
+
+    def test_render_type_mismatch(self) -> None:
+        block = render_hints([TypeMismatch(expected="Prop", got="ℕ", line=120, reason="match 0")])
+        assert "Prop" in block and "ℕ" in block
+
+    def test_render_unsolved_goals(self) -> None:
+        block = render_hints([UnsolvedGoals(goals=["⊢ ramseyNumber 2 n ≤ n"], line=115, reason="match 0")])
+        assert "ramseyNumber 2 n" in block
+
+    def test_render_typeclass_search(self) -> None:
+        block = render_hints([TypeclassSearch(typeclass="DecidableEq", context="SimpleGraph", line=50, reason="match 0")])
+        assert "DecidableEq" in block
+        assert "SimpleGraph" in block

--- a/autocontext/tests/test_remediation_router.py
+++ b/autocontext/tests/test_remediation_router.py
@@ -562,6 +562,108 @@ class TestRuleLeanCompileError:
         hints = route_remediations(_report([err]))
         assert any(isinstance(h, UnknownIdentifier) for h in hints)
 
+    # PR #982 review (P2): the original regexes only matched mathlib-style
+    # lowercase forms with single-quoted identifiers and required the
+    # ``failed to synthesize instance`` phrasing. Modern Lean 4 (4.29+)
+    # also emits ``Unknown identifier`` with backticks, ``error(lean.X):``
+    # diagnostic-code prefixes, ``Function expected ... but this term has
+    # type``, and ``type class instance expected``. The reviewer reproduced
+    # these on Lean 4.29.1; without these forms covered the default router
+    # still emits zero hints on real Lean output.
+
+    def test_unknown_identifier_with_diagnostic_code_prefix(self) -> None:
+        """Modern Lean 4 form: ``error(lean.unknownIdentifier): Unknown
+        identifier \\`name\\```."""
+        err = "test.lean:5:0: error(lean.unknownIdentifier): Unknown identifier `unknownFoo`\n"
+        hints = rule_lean_compile_error(_report([err]))
+        assert any(isinstance(h, UnknownIdentifier) and h.name == "unknownFoo" for h in hints)
+
+    def test_unknown_identifier_capital_U_form(self) -> None:
+        """Lean 4 emits ``Unknown identifier`` (capital U), the old form
+        used lowercase."""
+        err = "test.lean:5:0: error: Unknown identifier `unknownFoo`\n"
+        hints = rule_lean_compile_error(_report([err]))
+        assert any(isinstance(h, UnknownIdentifier) and h.name == "unknownFoo" for h in hints)
+
+    def test_type_mismatch_capital_T_form(self) -> None:
+        """Lean 4 emits ``Type mismatch`` (capital T)."""
+        err = "test.lean:10:0: error: Type mismatch\n  x\nhas type\n  Nat\nbut is expected to have type\n  String\n"
+        hints = rule_lean_compile_error(_report([err]))
+        assert any(isinstance(h, TypeMismatch) for h in hints)
+
+    def test_function_expected_but_this_term_form(self) -> None:
+        """Lean 4 actual phrasing: ``Function expected at ... but this term
+        has type ...`` (the old form was ``term has type`` without ``but
+        this``)."""
+        err = "test.lean:15:0: error: Function expected at\n  Foo\nbut this term has type\n  Nat\n"
+        hints = rule_lean_compile_error(_report([err]))
+        assert any(isinstance(h, TypeMismatch) for h in hints)
+
+    def test_type_class_instance_expected_form(self) -> None:
+        """Lean 4 emits ``type class instance expected`` for typeclass
+        resolution failures alongside the older ``failed to synthesize
+        instance`` form."""
+        err = "test.lean:20:0: error: type class instance expected\n  DecidableEq Foo\n"
+        hints = rule_lean_compile_error(_report([err]))
+        assert any(isinstance(h, TypeclassSearch) for h in hints)
+        ts = next(h for h in hints if isinstance(h, TypeclassSearch))
+        assert "DecidableEq" in ts.typeclass
+
+    def test_real_combined_stderr_from_reviewer_reproduction(self) -> None:
+        """End-to-end against the reviewer's actual Lean 4.29.1 stderr.
+
+        Catches the failure mode the reviewer found: zero hints emitted for
+        a realistic combined stderr containing all four error classes."""
+        err = (
+            "test.lean:5:0: error(lean.unknownIdentifier): Unknown identifier `unknownFoo`\n"
+            "test.lean:10:0: error: Type mismatch\n"
+            "  x\n"
+            "has type\n"
+            "  Nat\n"
+            "but is expected to have type\n"
+            "  String\n"
+            "test.lean:15:0: error: Function expected at\n"
+            "  Foo\n"
+            "but this term has type\n"
+            "  Nat\n"
+            "test.lean:20:0: error: type class instance expected\n"
+            "  DecidableEq Foo\n"
+        )
+        hints = rule_lean_compile_error(_report([err]))
+        kinds = {type(h).__name__ for h in hints}
+        # All four classes must produce at least one hint.
+        assert "UnknownIdentifier" in kinds
+        assert "TypeMismatch" in kinds
+        assert "TypeclassSearch" in kinds
+
+    def test_adjacent_type_mismatch_and_function_expected_dont_bleed(self) -> None:
+        """PR #982 review (P2): the type-mismatch capture was greedy across
+        blank-line boundaries. Adjacent errors without a blank gap should
+        each yield their own typed hint, and the captured ``expected``
+        must NOT contain the next error preamble."""
+        err = (
+            "test.lean:10:0: error: type mismatch\n"
+            "  x\n"
+            "has type\n"
+            "  Nat\n"
+            "but is expected to have type\n"
+            "  String\n"
+            "test.lean:15:0: error: function expected at\n"
+            "  Foo\n"
+            "term has type\n"
+            "  Nat\n"
+        )
+        hints = rule_lean_compile_error(_report([err]))
+        type_mismatches = [h for h in hints if isinstance(h, TypeMismatch)]
+        # Two TypeMismatches expected (one from type-mismatch, one from
+        # function-expected fallback).
+        assert len(type_mismatches) >= 2
+        # First TypeMismatch's expected must NOT contain the second error's
+        # preamble.
+        first = type_mismatches[0]
+        assert "test.lean" not in first.expected
+        assert "function expected" not in first.expected.lower()
+
 
 class TestRenderLeanHints:
     def test_render_unknown_identifier(self) -> None:


### PR DESCRIPTION
## Summary

- Adds `rule_lean_compile_error` to `loop/remediation_router.py` plus four typed hint kinds: `UnknownIdentifier`, `TypeMismatch`, `UnsolvedGoals`, `TypeclassSearch`.
- Wired into `DEFAULT_RULES` so `route_remediations` picks up Lean errors automatically.
- 14 new tests; 56 in the router suite total; 152 across the wider router + verifier + surfacer + loader surface.

## Why

The first Erdős #986 (Spencer k=3) campaign run on 2026-05-21 exercised the AC-769 router against `lake env lean` stderr. The router emitted **zero hints across 4 Lean compile failures** because its existing rules pattern-match Python-ecosystem failures only. Lean's vocabulary (`unknown identifier`, `type mismatch`, `unsolved goals`, `failed to synthesize instance`) doesn't match any of them. Without this rule, the router is dead weight on Lean / mathlib campaigns.

## Surface

Four new hint kinds, frozen-slot, sibling to the existing six in `remediation_router.py`:

```python
UnknownIdentifier(name, line, reason)
TypeMismatch(expected, got, line, reason)
UnsolvedGoals(goals: tuple[str, ...], line, reason)
TypeclassSearch(typeclass, context, line, reason)
```

`rule_lean_compile_error(report)` runs regexes over `MatchDiagnosis.errors`:
- `unknown (identifier|constant) '<name>'` → `UnknownIdentifier`
- `type mismatch ... has type ... but is expected to have type ...` → `TypeMismatch`
- `function expected at ... term has type ...` → `TypeMismatch` (fallback)
- `unsolved goals\n<body>` → `UnsolvedGoals` (splits `body` on `⊢`)
- `failed to synthesize instance\n<class>` → `TypeclassSearch`

Non-Lean errors (Python tracebacks etc.) produce no hint so the existing rules retain coverage.

`_describe` extended for each new kind; each includes the line number (when extractable) and prefixes with `Lean ...` so the model can tell them apart from Python-flavoured hints.

## DDD / DRY

- Hint kinds live next to the existing six in `remediation_router.py`. The `RemediationHint` union remains the single source of truth (same pattern as AC-772's `AssertionMismatch`).
- Pure-regex rule; no new dependencies.
- Test layout mirrors existing `TestRuleX` classes; same file, no new test module.

## Test plan

- [x] `TestRuleLeanCompileError` (9 tests): each error shape, multi-error case, non-Lean errors yield nothing, empty report, default-rule inclusion, end-to-end through `route_remediations`.
- [x] `TestRenderLeanHints` (4 tests): each hint kind has a sensible render path through `render_hints`.
- [x] 152/152 tests pass across the full router + verifier + surfacer + loader surface.
- [x] Ruff + mypy clean.
- [ ] Reviewer: feed the actual stderr from `runs/erdos-986-spencer-k3/loop_driver.py` iter-2 / iter-3 in a follow-up integration test once campaign logs are captured cleanly.

## Related

- Surfaced by `runs/erdos-986-spencer-k3/loop_driver.py` (Erdős #986 Spencer k=3 campaign).
- Sibling to AC-770 / AC-771 (already on main) and AC-772 (#977). Same router, same shape.