### PR TITLE
feat(loop): TacticFailure hint + Lean tactic-failed rule branch

### DIFF
--- a/autocontext/src/autocontext/loop/remediation_router.py
+++ b/autocontext/src/autocontext/loop/remediation_router.py
@@ -132,6 +132,23 @@ class TypeclassSearch:
     reason: str
 
 
+@dataclass(frozen=True, slots=True)
+class TacticFailure:
+    """``Tactic '<name>' failed: <reason>`` — distinct from ``unsolved goals``.
+
+    Lean 4 fires this when a specific tactic refuses to close the current
+    proof step (e.g., ``rfl`` against a non-definitionally-equal goal,
+    ``simp`` with no progress). Surfaced by the AC-773 deterministic
+    validation harness on 2026-05-21; the most common Lean error class
+    on incorrect proofs.
+    """
+
+    tactic: str
+    reason_text: str
+    line: int
+    reason: str
+
+
 RemediationHint = (
     RefreshFixture
     | SurfaceSignatures
@@ -143,6 +160,7 @@ RemediationHint = (
     | TypeMismatch
     | UnsolvedGoals
     | TypeclassSearch
+    | TacticFailure
 )
 
 
@@ -523,6 +541,13 @@ _LEAN_FUNCTION_EXPECTED = re.compile(
     re.DOTALL,
 )
 _LEAN_UNSOLVED_GOALS = re.compile(r"[Uu]nsolved\s+goals\s*\n(?P<body>.*?)\Z", re.DOTALL)
+# AC-773 follow-up: Lean 4 emits ``Tactic `name` failed: <reason>`` with a
+# capital T and backtick-quoted tactic name; mathlib historically used
+# ``tactic 'name' failed[, <reason>]``. Accept both.
+_LEAN_TACTIC_FAILED = re.compile(
+    r"[Tt]actic\s+[`']?(?P<tactic>[\w.]+)[`']?\s+failed[,:\s]+(?P<rest>.*?)(?:\n\n|\Z)",
+    re.DOTALL,
+)
 _LEAN_TYPECLASS_FAIL = re.compile(
     # Old: ``failed to synthesize instance`` — new (Lean 4.29+):
     # ``type class instance expected``. Both are followed by the unresolved
@@ -594,6 +619,17 @@ def rule_lean_compile_error(report: FailureReport, **_: Any) -> list[Remediation
                         TypeclassSearch(
                             typeclass=m.group("typeclass").strip(),
                             context=(m.group("context") or "").strip(),
+                            line=line,
+                            reason=reason,
+                        )
+                    )
+
+                # AC-773 follow-up: tactic-level failures.
+                for m in _LEAN_TACTIC_FAILED.finditer(body):
+                    hints.append(
+                        TacticFailure(
+                            tactic=m.group("tactic").strip(),
+                            reason_text=m.group("rest").strip()[:200],
                             line=line,
                             reason=reason,
                         )
@@ -683,6 +719,9 @@ def _describe(hint: RemediationHint) -> str:
         loc = f" at line {hint.line}" if hint.line else ""
         ctx = f" for `{hint.context}`" if hint.context else ""
         return f"Lean typeclass search failed{loc}: `{hint.typeclass}`{ctx} ({hint.reason})"
+    if isinstance(hint, TacticFailure):
+        loc = f" at line {hint.line}" if hint.line else ""
+        return f"Lean tactic `{hint.tactic}` failed{loc}: {hint.reason_text} ({hint.reason})"
     return repr(hint)  # unreachable
 
 

--- a/autocontext/tests/test_remediation_router.py
+++ b/autocontext/tests/test_remediation_router.py
@@ -664,6 +664,45 @@ class TestRuleLeanCompileError:
         assert "test.lean" not in first.expected
         assert "function expected" not in first.expected.lower()
 
+    # Surfaced by the AC-773 deterministic validation harness
+    # (`runs/erdos-986-spencer-k3/validate_ac773.py`, 2026-05-21): Lean 4
+    # emits a distinct ``Tactic '<name>' failed: <reason>`` error class
+    # for tactic-level failures (e.g., `rfl` against a non-definitionally-
+    # equal goal). The validation found this is the most common shape on
+    # incorrect proofs and AC-773 wasn't covering it.
+
+    def test_tactic_failed_emits_tactic_failure_hint(self) -> None:
+        from autocontext.loop.remediation_router import TacticFailure
+
+        err = (
+            "test.lean:6:2: error: Tactic `rfl` failed: The left-hand side\n"
+            "  n + 1\n"
+            "is not definitionally equal to the right-hand side\n"
+            "  n\n"
+        )
+        hints = rule_lean_compile_error(_report([err]))
+        assert any(isinstance(h, TacticFailure) for h in hints)
+        tf = next(h for h in hints if isinstance(h, TacticFailure))
+        assert tf.tactic == "rfl"
+        assert "definitionally equal" in tf.reason_text
+
+    def test_tactic_failed_lowercase_tactic_form(self) -> None:
+        """Older mathlib emits ``tactic 'simp' failed``."""
+        from autocontext.loop.remediation_router import TacticFailure
+
+        err = "test.lean:10:0: error: tactic 'simp' failed, nothing to simplify\n"
+        hints = rule_lean_compile_error(_report([err]))
+        assert any(isinstance(h, TacticFailure) and h.tactic == "simp" for h in hints)
+
+
+class TestRenderTacticFailure:
+    def test_render_tactic_failure(self) -> None:
+        from autocontext.loop.remediation_router import TacticFailure
+
+        block = render_hints([TacticFailure(tactic="rfl", reason_text="not definitionally equal", line=6, reason="match 0")])
+        assert "rfl" in block
+        assert "tactic" in block.lower()
+
 
 class TestRenderLeanHints:
     def test_render_unknown_identifier(self) -> None:


### PR DESCRIPTION
## Summary

Follow-up to AC-773 (PR #982). The deterministic validation harness (`runs/erdos-986-spencer-k3/validate_ac773.py`) confirmed all four originally-shipped hint kinds emit against real `lake env lean` stderr, but surfaced a fifth Lean 4 error class the rule didn't cover:

```
Tactic `rfl` failed: The left-hand side
  n + 1
is not definitionally equal to the right-hand side
  n
```

This is distinct from `unsolved goals` — Lean fires it when a specific tactic refuses to close its step, not when the goal remains unattacked. It's the most common shape on incorrect proofs.

## Adds

- `TacticFailure(tactic, reason_text, line, reason)` — new frozen-slot hint kind in the `RemediationHint` union.
- `_LEAN_TACTIC_FAILED` regex accepting Lean 4's `Tactic \`name\` failed:` AND mathlib's `tactic 'name' failed[,]` forms.
- New branch in `rule_lean_compile_error` per-body loop.
- `_describe` branch for `TacticFailure`.

## Empirical validation

`runs/erdos-986-spencer-k3/validate_ac773.py` extended with a fifth probe (`rfl` against a non-definitionally-equal goal). All five probes now pass:

```
unknown_identifier     UnknownIdentifier  PASS
type_mismatch          TypeMismatch       PASS
function_expected      TypeMismatch       PASS
unsolved_goals         UnsolvedGoals      PASS
tactic_failed          TacticFailure      PASS (new)
```

With this PR, AC-773 covers the five most-common Lean 4 / mathlib compile-error classes.

## Tests

- 3 new tests in `test_remediation_router.py`: rule fires on Lean 4 form, rule fires on mathlib lowercase form, render path.
- 66/66 router tests pass (was 63).
- Ruff + mypy clean.

## Related

- AC-773 (#982) — the original Lean compile-error rule.
- `runs/erdos-986-spencer-k3/validate_ac773.py` — deterministic empirical harness against real `lake env lean` stderr, no LLM dependency.