### PR TITLE
fix(loop): bound Lean error body on warning preambles (AC-775)

### DIFF
--- a/autocontext/src/autocontext/loop/remediation_router.py
+++ b/autocontext/src/autocontext/loop/remediation_router.py
@@ -508,10 +508,13 @@ def rule_indexing_base(
 #   ``<path>:<line>:<col>: error(lean.<code>): <body>``     (Lean 4.29+ diagnostic codes)
 # We use this single preamble regex both to extract line numbers and to bound
 # each error body — the next preamble marks where the current error ends.
+# AC-775: the body-bound lookahead also matches ``warning:`` preambles so a
+# following ``warning: declaration uses 'sorry'`` line does NOT bleed into
+# captures like the type-mismatch ``expected`` field.
 
 _LEAN_PREAMBLE = re.compile(
     r"^[^\s:][^\n:]*:(?P<line>\d+):\d+:\s*error(?:\(lean\.\w+\))?:\s*(?P<body>.*?)"
-    r"(?=^[^\s:][^\n:]*:\d+:\d+:\s*error(?:\(lean\.\w+\))?:|\Z)",
+    r"(?=^[^\s:][^\n:]*:\d+:\d+:\s*(?:error(?:\(lean\.\w+\))?|warning):|\Z)",
     re.DOTALL | re.MULTILINE,
 )
 

--- a/autocontext/src/autocontext/loop/remediation_router.py
+++ b/autocontext/src/autocontext/loop/remediation_router.py
@@ -510,11 +510,12 @@ def rule_indexing_base(
 # each error body — the next preamble marks where the current error ends.
 # AC-775: the body-bound lookahead also matches ``warning:`` preambles so a
 # following ``warning: declaration uses 'sorry'`` line does NOT bleed into
-# captures like the type-mismatch ``expected`` field.
+# captures like the type-mismatch ``expected`` field. Warning preambles may also
+# carry Lean diagnostic codes, mirroring ``error(lean.<code>)``.
 
 _LEAN_PREAMBLE = re.compile(
     r"^[^\s:][^\n:]*:(?P<line>\d+):\d+:\s*error(?:\(lean\.\w+\))?:\s*(?P<body>.*?)"
-    r"(?=^[^\s:][^\n:]*:\d+:\d+:\s*(?:error(?:\(lean\.\w+\))?|warning):|\Z)",
+    r"(?=^[^\s:][^\n:]*:\d+:\d+:\s*(?:error|warning)(?:\(lean\.\w+\))?:|\Z)",
     re.DOTALL | re.MULTILINE,
 )
 

--- a/autocontext/tests/test_remediation_router.py
+++ b/autocontext/tests/test_remediation_router.py
@@ -694,6 +694,31 @@ class TestRuleLeanCompileError:
         hints = rule_lean_compile_error(_report([err]))
         assert any(isinstance(h, TacticFailure) and h.tactic == "simp" for h in hints)
 
+    # AC-775: a body followed by ``warning: declaration uses 'sorry'`` lines
+    # must NOT include those warning lines in the captured ``expected`` field.
+    # Surfaced by the Erdős #986 (Spencer k=3) loop driver on 2026-05-22 where
+    # iterations 0 and 2 emitted hints whose `expected` bled into trailing
+    # sorry warnings; AC-773's per-error split only bounded on `error:`.
+
+    def test_type_mismatch_expected_does_not_bleed_into_warning(self) -> None:
+        err = (
+            "MathlibScratch/Erdos986.lean:106:4: error: type mismatch\n"
+            "  hwit\n"
+            "has type\n"
+            "  sInf ?m.230 ∈ ?m.230\n"
+            "but is expected to have type\n"
+            "  IsRamseyWitness m 2 n\n"
+            "MathlibScratch/Erdos986.lean:117:8: warning: declaration uses `sorry`\n"
+            "MathlibScratch/Erdos986.lean:122:8: warning: declaration uses `sorry`\n"
+        )
+        hints = rule_lean_compile_error(_report([err]))
+        tms = [h for h in hints if isinstance(h, TypeMismatch)]
+        assert tms, "expected at least one TypeMismatch hint"
+        first = tms[0]
+        assert "warning" not in first.expected
+        assert "sorry" not in first.expected
+        assert first.expected.strip() == "IsRamseyWitness m 2 n"
+
 
 class TestRenderTacticFailure:
     def test_render_tactic_failure(self) -> None:


### PR DESCRIPTION
## Summary

- Extend `_LEAN_PREAMBLE`'s body-bound lookahead to terminate on `warning:` preambles in addition to `error:`, so trailing `warning: declaration uses 'sorry'` lines don't bleed into `TypeMismatch.expected` captures.
- Add regression test using the actual stderr shape produced by the Erdős #986 (Spencer k=3) autocontext loop.

## Why

PR #982 (AC-773) bounded each Lean error body on the NEXT `error:` preamble. Reasonable, except Lean also emits `warning: declaration uses 'sorry'` lines for unrelated sorrys in the same file, and the body-bound regex didn't recognise them as a stop. The type-mismatch `expected` capture (`.*?\Z`) then read straight through the warnings until end-of-body.

Surfaced empirically by the Erdős #986 autocontext loop on 2026-05-22: iterations 0 and 2 emitted `TypeMismatch` hints whose `expected` field contained:

```
expected `IsRamseyWitness m 2 n
MathlibScratch/Erdos986.lean:117:8: warning: declaration uses `sorry`
MathlibScratch/Erdos986.lean:122:8: warning: declaration uses `sorry``
```

instead of just `IsRamseyWitness m 2 n`. Cosmetic to the rendered hint, but pollutes the refinement prompt sent back to the model.

## Test plan

- [x] `uv run pytest tests/test_remediation_router.py -x -q` — 67/67 pass (was 66; +1 regression test)
- [x] `runs/erdos-986-spencer-k3/validate_ac773.py` — 5/5 probes still pass against real `lake env lean` stderr
- [x] Manual: feed the actual Erdős iter-0 stderr through the router → `TypeMismatch.expected` is now `"IsRamseyWitness m 2 n"` (clean)

## Related

- AC-775 (this issue) — also tracks per-iteration stderr persistence in the campaign loop driver (separate, lives in `runs/`)
- AC-773 / PR #982 — original Lean compile-error rule
- PR #986 — TacticFailure follow-up