### PR TITLE
feat(control-plane): AC-728 Python parity slice 2 (3 advanced probes)

### DIFF
--- a/autocontext/src/autocontext/control_plane/contract_probes/__init__.py
+++ b/autocontext/src/autocontext/control_plane/contract_probes/__init__.py
@@ -1,37 +1,87 @@
-"""AC-728 contract probes, Python parity (slice 1).
+"""AC-728 contract probes, Python parity.
 
-Mirrors ``ts/src/control-plane/contract-probes/index.ts`` at the
-PR #957 shape: four base probes (directory, terminal, service,
-artifact). Each probe is a pure function returning a Pydantic
-result model so it composes with the same trace-replay surfaces
-the TS probes use.
+Mirrors ``ts/src/control-plane/contract-probes/index.ts``. Probes are
+pure functions returning Pydantic result models so they compose with
+the same trace-replay surfaces the TS probes use.
 
-Missing-observation invariant
------------------------------
-Every observation field on these four probes is non-optional, so the
-silent-pass shape simply does not arise here. The follow-up slice-2
-cleanup / media / distributed probes (mirroring TS PRs #983, #985,
-#987) emit explicit ``missing-observation`` failure kinds; this
-slice does not need that surface.
+Two module groups:
+
+- ``_base``: directory / terminal / service / artifact (slice 1, PR
+  #957). Every observation field is non-optional so the silent-pass
+  shape cannot arise on these four.
+- ``_advanced``: cleanup / distributed / media (slice 2, TS PRs
+  #983 / #985 / #987). Each emits explicit ``missing-observation``
+  failure kinds: a declared expectation without its matching
+  observation must fail loudly.
 """
 
-from __future__ import annotations
-
-import json
-import re
-from typing import Literal
-
-from pydantic import BaseModel, ConfigDict, Field
+from ._advanced import (
+    CleanupContractFailure,
+    CleanupContractFailureKind,
+    CleanupContractProbeInputs,
+    CleanupContractProbeResult,
+    CleanupFileEntry,
+    DistributedContractFailure,
+    DistributedContractFailureKind,
+    DistributedContractProbeInputs,
+    DistributedContractProbeResult,
+    DistributedRankReport,
+    MediaContractFailure,
+    MediaContractFailureKind,
+    MediaContractProbeInputs,
+    MediaContractProbeResult,
+    probe_cleanup_contract,
+    probe_distributed_contract,
+    probe_media_contract,
+)
+from ._base import (
+    ArtifactContractFailure,
+    ArtifactContractFailureKind,
+    ArtifactContractProbeInputs,
+    ArtifactContractProbeResult,
+    DirectoryContractFailure,
+    DirectoryContractFailureKind,
+    DirectoryContractProbeInputs,
+    DirectoryContractProbeResult,
+    ServiceContractFailure,
+    ServiceContractFailureKind,
+    ServiceContractProbeInputs,
+    ServiceContractProbeResult,
+    ServiceEndpointObservation,
+    ServiceEndpointProtocol,
+    TerminalContractFailure,
+    TerminalContractFailureKind,
+    TerminalContractProbeInputs,
+    TerminalContractProbeResult,
+    probe_artifact_contract,
+    probe_directory_contract,
+    probe_service_contract,
+    probe_terminal_contract,
+)
 
 __all__ = [
     "ArtifactContractFailure",
     "ArtifactContractFailureKind",
     "ArtifactContractProbeInputs",
     "ArtifactContractProbeResult",
+    "CleanupContractFailure",
+    "CleanupContractFailureKind",
+    "CleanupContractProbeInputs",
+    "CleanupContractProbeResult",
+    "CleanupFileEntry",
     "DirectoryContractFailure",
     "DirectoryContractFailureKind",
     "DirectoryContractProbeInputs",
     "DirectoryContractProbeResult",
+    "DistributedContractFailure",
+    "DistributedContractFailureKind",
+    "DistributedContractProbeInputs",
+    "DistributedContractProbeResult",
+    "DistributedRankReport",
+    "MediaContractFailure",
+    "MediaContractFailureKind",
+    "MediaContractProbeInputs",
+    "MediaContractProbeResult",
     "ServiceContractFailure",
     "ServiceContractFailureKind",
     "ServiceContractProbeInputs",
@@ -43,371 +93,10 @@ __all__ = [
     "TerminalContractProbeInputs",
     "TerminalContractProbeResult",
     "probe_artifact_contract",
+    "probe_cleanup_contract",
     "probe_directory_contract",
+    "probe_distributed_contract",
+    "probe_media_contract",
     "probe_service_contract",
     "probe_terminal_contract",
 ]
-
-
-class _Frozen(BaseModel):
-    model_config = ConfigDict(frozen=True, extra="forbid", arbitrary_types_allowed=True)
-
-
-# ---------------------------------------------------------------------------
-# directory contract probe
-# ---------------------------------------------------------------------------
-
-DirectoryContractFailureKind = Literal["unexpected-file", "missing-file"]
-
-
-class DirectoryContractFailure(_Frozen):
-    kind: DirectoryContractFailureKind
-    path: str
-    message: str
-
-
-class DirectoryContractProbeInputs(_Frozen):
-    present_files: tuple[str, ...] = Field(default=())
-    required_files: tuple[str, ...] = Field(default=())
-    allowed_files: tuple[str, ...] = Field(default=())
-    ignored_patterns: tuple[re.Pattern[str], ...] = Field(default=())
-
-
-class DirectoryContractProbeResult(_Frozen):
-    passed: bool
-    failures: tuple[DirectoryContractFailure, ...]
-
-
-def _is_ignored(path: str, ignored_patterns: tuple[re.Pattern[str], ...]) -> bool:
-    return any(pattern.search(path) is not None for pattern in ignored_patterns)
-
-
-def probe_directory_contract(
-    inputs: DirectoryContractProbeInputs,
-) -> DirectoryContractProbeResult:
-    present_files = tuple(path for path in inputs.present_files if not _is_ignored(path, inputs.ignored_patterns))
-    present = set(present_files)
-    allowed = set(inputs.allowed_files)
-    failures: list[DirectoryContractFailure] = []
-
-    for path in present_files:
-        if path not in allowed:
-            failures.append(
-                DirectoryContractFailure(
-                    kind="unexpected-file",
-                    path=path,
-                    message=f"unexpected file {path}",
-                )
-            )
-
-    for path in inputs.required_files:
-        if path not in present:
-            failures.append(
-                DirectoryContractFailure(
-                    kind="missing-file",
-                    path=path,
-                    message=f"required file {path} is missing",
-                )
-            )
-
-    return DirectoryContractProbeResult(passed=not failures, failures=tuple(failures))
-
-
-# ---------------------------------------------------------------------------
-# terminal contract probe
-# ---------------------------------------------------------------------------
-
-TerminalContractFailureKind = Literal[
-    "unexpected-exit-code",
-    "missing-stdout-pattern",
-    "forbidden-stdout-pattern",
-    "missing-stderr-pattern",
-    "forbidden-stderr-pattern",
-]
-
-
-class TerminalContractFailure(_Frozen):
-    kind: TerminalContractFailureKind
-    message: str
-
-
-class TerminalContractProbeInputs(_Frozen):
-    exit_code: int
-    stdout: str
-    stderr: str
-    expected_exit_code: int | None = None
-    required_stdout_patterns: tuple[re.Pattern[str], ...] = Field(default=())
-    forbidden_stdout_patterns: tuple[re.Pattern[str], ...] = Field(default=())
-    required_stderr_patterns: tuple[re.Pattern[str], ...] = Field(default=())
-    forbidden_stderr_patterns: tuple[re.Pattern[str], ...] = Field(default=())
-
-
-class TerminalContractProbeResult(_Frozen):
-    passed: bool
-    failures: tuple[TerminalContractFailure, ...]
-
-
-def probe_terminal_contract(
-    inputs: TerminalContractProbeInputs,
-) -> TerminalContractProbeResult:
-    failures: list[TerminalContractFailure] = []
-    expected_exit_code = inputs.expected_exit_code if inputs.expected_exit_code is not None else 0
-    if inputs.exit_code != expected_exit_code:
-        failures.append(
-            TerminalContractFailure(
-                kind="unexpected-exit-code",
-                message=f"expected exit code {expected_exit_code}, got {inputs.exit_code}",
-            )
-        )
-    for pattern in inputs.required_stdout_patterns:
-        if pattern.search(inputs.stdout) is None:
-            failures.append(
-                TerminalContractFailure(
-                    kind="missing-stdout-pattern",
-                    message=f"stdout did not match {pattern.pattern}",
-                )
-            )
-    for pattern in inputs.forbidden_stdout_patterns:
-        if pattern.search(inputs.stdout) is not None:
-            failures.append(
-                TerminalContractFailure(
-                    kind="forbidden-stdout-pattern",
-                    message=f"stdout matched forbidden {pattern.pattern}",
-                )
-            )
-    for pattern in inputs.required_stderr_patterns:
-        if pattern.search(inputs.stderr) is None:
-            failures.append(
-                TerminalContractFailure(
-                    kind="missing-stderr-pattern",
-                    message=f"stderr did not match {pattern.pattern}",
-                )
-            )
-    for pattern in inputs.forbidden_stderr_patterns:
-        if pattern.search(inputs.stderr) is not None:
-            failures.append(
-                TerminalContractFailure(
-                    kind="forbidden-stderr-pattern",
-                    message=f"stderr matched forbidden {pattern.pattern}",
-                )
-            )
-    return TerminalContractProbeResult(passed=not failures, failures=tuple(failures))
-
-
-# ---------------------------------------------------------------------------
-# service contract probe
-# ---------------------------------------------------------------------------
-
-ServiceEndpointProtocol = Literal["tcp", "udp"]
-ServiceContractFailureKind = Literal[
-    "missing-endpoint",
-    "unexpected-endpoint",
-    "wrong-interface",
-]
-
-
-class ServiceEndpointObservation(_Frozen):
-    host: str
-    port: int
-    protocol: ServiceEndpointProtocol | None = None
-
-
-class ServiceContractFailure(_Frozen):
-    kind: ServiceContractFailureKind
-    endpoint: ServiceEndpointObservation
-    message: str
-
-
-class ServiceContractProbeInputs(_Frozen):
-    observed: tuple[ServiceEndpointObservation, ...] = Field(default=())
-    required: tuple[ServiceEndpointObservation, ...] = Field(default=())
-    allowed: tuple[ServiceEndpointObservation, ...] | None = None
-
-
-class ServiceContractProbeResult(_Frozen):
-    passed: bool
-    failures: tuple[ServiceContractFailure, ...]
-
-
-def _normalize_protocol(endpoint: ServiceEndpointObservation) -> ServiceEndpointProtocol:
-    return endpoint.protocol if endpoint.protocol is not None else "tcp"
-
-
-def _endpoint_key(endpoint: ServiceEndpointObservation) -> str:
-    return f"{_normalize_protocol(endpoint)}://{endpoint.host}:{endpoint.port}"
-
-
-def _endpoint_matches_any_host(
-    required: ServiceEndpointObservation,
-    observed: tuple[ServiceEndpointObservation, ...],
-) -> ServiceEndpointObservation | None:
-    required_protocol = _normalize_protocol(required)
-    for candidate in observed:
-        if candidate.port == required.port and _normalize_protocol(candidate) == required_protocol:
-            return candidate
-    return None
-
-
-def probe_service_contract(
-    inputs: ServiceContractProbeInputs,
-) -> ServiceContractProbeResult:
-    failures: list[ServiceContractFailure] = []
-    observed_keys = {_endpoint_key(endpoint) for endpoint in inputs.observed}
-
-    for required in inputs.required:
-        required_key = _endpoint_key(required)
-        if required_key in observed_keys:
-            continue
-        port_match = _endpoint_matches_any_host(required, inputs.observed)
-        if port_match is not None:
-            failures.append(
-                ServiceContractFailure(
-                    kind="wrong-interface",
-                    endpoint=required,
-                    message=(f"required {required_key} but observed {_endpoint_key(port_match)}"),
-                )
-            )
-        else:
-            failures.append(
-                ServiceContractFailure(
-                    kind="missing-endpoint",
-                    endpoint=required,
-                    message=f"required endpoint {required_key} not observed",
-                )
-            )
-
-    if inputs.allowed is not None:
-        allowed_keys = {_endpoint_key(endpoint) for endpoint in inputs.allowed}
-        for observed in inputs.observed:
-            if _endpoint_key(observed) not in allowed_keys:
-                failures.append(
-                    ServiceContractFailure(
-                        kind="unexpected-endpoint",
-                        endpoint=observed,
-                        message=(f"observed endpoint {_endpoint_key(observed)} not in allowed list"),
-                    )
-                )
-
-    return ServiceContractProbeResult(passed=not failures, failures=tuple(failures))
-
-
-# ---------------------------------------------------------------------------
-# artifact contract probe
-# ---------------------------------------------------------------------------
-
-ArtifactContractFailureKind = Literal[
-    "missing-substring",
-    "forbidden-substring",
-    "wrong-line-ending",
-    "invalid-json",
-    "missing-json-field",
-]
-
-
-class ArtifactContractFailure(_Frozen):
-    kind: ArtifactContractFailureKind
-    path: str
-    message: str
-
-
-class ArtifactContractProbeInputs(_Frozen):
-    path: str
-    content: str
-    expected_line_ending: Literal["lf", "crlf"] | None = None
-    required_substrings: tuple[str, ...] = Field(default=())
-    forbidden_substrings: tuple[str, ...] = Field(default=())
-    required_json_fields: tuple[str, ...] = Field(default=())
-
-
-class ArtifactContractProbeResult(_Frozen):
-    passed: bool
-    failures: tuple[ArtifactContractFailure, ...]
-
-
-_BARE_LF_RE = re.compile(r"(?<!\r)\n")
-
-# Sentinel distinguishing "JSON key absent" from "JSON key present with
-# null value". The TS probe treats `undefined` as missing but accepts
-# `null` as a present-but-null value; mirroring that here requires a
-# sentinel because Python `json.loads` decodes JSON `null` to `None`.
-_MISSING = object()
-
-
-def _read_json_dot_path(value: object, path: str) -> object:
-    cursor: object = value
-    for segment in path.split("."):
-        if not isinstance(cursor, dict):
-            return _MISSING
-        if segment not in cursor:
-            return _MISSING
-        cursor = cursor[segment]
-    return cursor
-
-
-def probe_artifact_contract(
-    inputs: ArtifactContractProbeInputs,
-) -> ArtifactContractProbeResult:
-    failures: list[ArtifactContractFailure] = []
-
-    for required in inputs.required_substrings:
-        if required not in inputs.content:
-            failures.append(
-                ArtifactContractFailure(
-                    kind="missing-substring",
-                    path=inputs.path,
-                    message=(f"{inputs.path} is missing required substring {json.dumps(required)}"),
-                )
-            )
-
-    for forbidden in inputs.forbidden_substrings:
-        if forbidden in inputs.content:
-            failures.append(
-                ArtifactContractFailure(
-                    kind="forbidden-substring",
-                    path=inputs.path,
-                    message=(f"{inputs.path} contains forbidden substring {json.dumps(forbidden)}"),
-                )
-            )
-
-    if inputs.expected_line_ending == "lf":
-        if "\r\n" in inputs.content:
-            failures.append(
-                ArtifactContractFailure(
-                    kind="wrong-line-ending",
-                    path=inputs.path,
-                    message=f"{inputs.path} contains CRLF but LF was required",
-                )
-            )
-    elif inputs.expected_line_ending == "crlf":
-        if _BARE_LF_RE.search(inputs.content) is not None:
-            failures.append(
-                ArtifactContractFailure(
-                    kind="wrong-line-ending",
-                    path=inputs.path,
-                    message=f"{inputs.path} contains bare LF but CRLF was required",
-                )
-            )
-
-    if inputs.required_json_fields:
-        try:
-            parsed = json.loads(inputs.content)
-        except json.JSONDecodeError as err:
-            failures.append(
-                ArtifactContractFailure(
-                    kind="invalid-json",
-                    path=inputs.path,
-                    message=f"{inputs.path} is not valid JSON: {err.msg}",
-                )
-            )
-            return ArtifactContractProbeResult(passed=False, failures=tuple(failures))
-        for field in inputs.required_json_fields:
-            if _read_json_dot_path(parsed, field) is _MISSING:
-                failures.append(
-                    ArtifactContractFailure(
-                        kind="missing-json-field",
-                        path=field,
-                        message=f"{inputs.path} is missing required JSON field {field}",
-                    )
-                )
-
-    return ArtifactContractProbeResult(passed=not failures, failures=tuple(failures))

--- a/autocontext/src/autocontext/control_plane/contract_probes/_advanced.py
+++ b/autocontext/src/autocontext/control_plane/contract_probes/_advanced.py
@@ -1,0 +1,527 @@
+"""AC-728 advanced contract probes (Python parity, slice 2).
+
+Mirrors the cleanup / distributed / media surfaces from
+``ts/src/control-plane/contract-probes/index.ts`` (TS PRs #983 / #985
+/ #987). All three probes carry explicit ``missing-observation``
+failure kinds: a declared expectation without its matching
+observation must fail loudly rather than silently pass.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import Field
+
+from ._base import _Frozen
+
+__all__ = [
+    "CleanupContractFailure",
+    "CleanupContractFailureKind",
+    "CleanupContractProbeInputs",
+    "CleanupContractProbeResult",
+    "CleanupFileEntry",
+    "DistributedContractFailure",
+    "DistributedContractFailureKind",
+    "DistributedContractProbeInputs",
+    "DistributedContractProbeResult",
+    "DistributedRankReport",
+    "MediaContractFailure",
+    "MediaContractFailureKind",
+    "MediaContractProbeInputs",
+    "MediaContractProbeResult",
+    "probe_cleanup_contract",
+    "probe_distributed_contract",
+    "probe_media_contract",
+]
+
+
+def _is_ignored(path: str, patterns: tuple[re.Pattern[str], ...]) -> bool:
+    return any(pattern.search(path) is not None for pattern in patterns)
+
+
+def _matches_any(path: str, patterns: tuple[re.Pattern[str], ...]) -> bool:
+    return any(pattern.search(path) is not None for pattern in patterns)
+
+
+# ---------------------------------------------------------------------------
+# cleanup contract probe
+# ---------------------------------------------------------------------------
+
+CleanupContractFailureKind = Literal[
+    "stray-symlink",
+    "broken-symlink",
+    "stale-lockfile",
+    "stray-sidecar",
+    "stray-backup",
+    "missing-observation",
+]
+
+
+class CleanupContractFailure(_Frozen):
+    kind: CleanupContractFailureKind
+    path: str
+    message: str
+
+
+class CleanupFileEntry(_Frozen):
+    path: str
+    is_symlink: bool = False
+    symlink_target: str | None = None
+    symlink_broken: bool = False
+    mtime: datetime | None = None
+
+
+class CleanupContractProbeInputs(_Frozen):
+    entries: tuple[CleanupFileEntry, ...] = Field(default=())
+    now: datetime | None = None
+    max_lockfile_age_ms: int | None = None
+    lockfile_patterns: tuple[re.Pattern[str], ...] | None = None
+    sidecar_patterns: tuple[re.Pattern[str], ...] | None = None
+    backup_patterns: tuple[re.Pattern[str], ...] | None = None
+    forbid_symlinks: bool = False
+    allowed_symlink_targets: tuple[str, ...] | None = None
+    ignored_patterns: tuple[re.Pattern[str], ...] = Field(default=())
+
+
+class CleanupContractProbeResult(_Frozen):
+    passed: bool
+    failures: tuple[CleanupContractFailure, ...]
+
+
+_DEFAULT_LOCKFILE_PATTERNS: tuple[re.Pattern[str], ...] = (re.compile(r"\.(lock|lck|pid)$", re.IGNORECASE),)
+_DEFAULT_SIDECAR_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\.sw[op]$", re.IGNORECASE),
+    re.compile(r"~$"),
+    re.compile(r"(^|/)\.DS_Store$"),
+    re.compile(r"(^|/)\.~lock\..*#$"),
+)
+_DEFAULT_BACKUP_PATTERNS: tuple[re.Pattern[str], ...] = (re.compile(r"\.(bak|orig)$", re.IGNORECASE),)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _epoch_ms(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+
+def probe_cleanup_contract(
+    inputs: CleanupContractProbeInputs,
+) -> CleanupContractProbeResult:
+    ignored = inputs.ignored_patterns
+    lockfile_patterns = inputs.lockfile_patterns if inputs.lockfile_patterns is not None else _DEFAULT_LOCKFILE_PATTERNS
+    sidecar_patterns = inputs.sidecar_patterns if inputs.sidecar_patterns is not None else _DEFAULT_SIDECAR_PATTERNS
+    backup_patterns = inputs.backup_patterns if inputs.backup_patterns is not None else _DEFAULT_BACKUP_PATTERNS
+    allowed_symlink_targets = inputs.allowed_symlink_targets
+    now = inputs.now if inputs.now is not None else _utc_now()
+    max_lockfile_age_ms = inputs.max_lockfile_age_ms
+    failures: list[CleanupContractFailure] = []
+
+    for entry in inputs.entries:
+        if _is_ignored(entry.path, ignored):
+            continue
+
+        if entry.is_symlink:
+            if entry.symlink_broken:
+                failures.append(
+                    CleanupContractFailure(
+                        kind="broken-symlink",
+                        path=entry.path,
+                        message=f"{entry.path} is a broken symlink (target missing)",
+                    )
+                )
+                continue
+            if inputs.forbid_symlinks:
+                target = entry.symlink_target if entry.symlink_target is not None else "<unknown>"
+                failures.append(
+                    CleanupContractFailure(
+                        kind="stray-symlink",
+                        path=entry.path,
+                        message=(f"{entry.path} is a symlink (target {target}); symlinks are forbidden by contract"),
+                    )
+                )
+                continue
+            if allowed_symlink_targets is not None:
+                if entry.symlink_target is None:
+                    failures.append(
+                        CleanupContractFailure(
+                            kind="missing-observation",
+                            path=entry.path,
+                            message=(
+                                f"{entry.path} is a symlink but no symlink_target was supplied; "
+                                "cannot evaluate allowed_symlink_targets contract"
+                            ),
+                        )
+                    )
+                elif entry.symlink_target not in allowed_symlink_targets:
+                    failures.append(
+                        CleanupContractFailure(
+                            kind="stray-symlink",
+                            path=entry.path,
+                            message=(f"{entry.path} is a symlink to {entry.symlink_target}; target is not in the allowlist"),
+                        )
+                    )
+            continue
+
+        if _matches_any(entry.path, lockfile_patterns):
+            if max_lockfile_age_ms is None:
+                failures.append(
+                    CleanupContractFailure(
+                        kind="stale-lockfile",
+                        path=entry.path,
+                        message=f"{entry.path} is a leftover lockfile",
+                    )
+                )
+            elif entry.mtime is None:
+                failures.append(
+                    CleanupContractFailure(
+                        kind="missing-observation",
+                        path=entry.path,
+                        message=(
+                            f"{entry.path} matched a lockfile pattern but no mtime was supplied; "
+                            "cannot evaluate max_lockfile_age_ms contract"
+                        ),
+                    )
+                )
+            elif _epoch_ms(now) - _epoch_ms(entry.mtime) > max_lockfile_age_ms:
+                failures.append(
+                    CleanupContractFailure(
+                        kind="stale-lockfile",
+                        path=entry.path,
+                        message=f"{entry.path} is a lockfile older than {max_lockfile_age_ms}ms",
+                    )
+                )
+            continue
+
+        if _matches_any(entry.path, sidecar_patterns):
+            failures.append(
+                CleanupContractFailure(
+                    kind="stray-sidecar",
+                    path=entry.path,
+                    message=f"{entry.path} is an editor/OS sidecar leftover",
+                )
+            )
+            continue
+
+        if _matches_any(entry.path, backup_patterns):
+            failures.append(
+                CleanupContractFailure(
+                    kind="stray-backup",
+                    path=entry.path,
+                    message=f"{entry.path} is a backup copy leftover",
+                )
+            )
+            continue
+
+    return CleanupContractProbeResult(passed=not failures, failures=tuple(failures))
+
+
+# ---------------------------------------------------------------------------
+# distributed contract probe
+# ---------------------------------------------------------------------------
+
+DistributedContractFailureKind = Literal[
+    "wrong-world-size",
+    "missing-rank",
+    "duplicate-rank",
+    "rank-divergence",
+    "wrong-step-count",
+    "missing-observation",
+]
+
+
+class DistributedContractFailure(_Frozen):
+    kind: DistributedContractFailureKind
+    message: str
+    rank: int | None = None
+    key: str | None = None
+
+
+class DistributedRankReport(_Frozen):
+    rank: int
+    steps: int | None = None
+    observations: dict[str, str] | None = None
+
+
+class DistributedContractProbeInputs(_Frozen):
+    ranks: tuple[DistributedRankReport, ...] = Field(default=())
+    world_size: int | None = None
+    expected_world_size: int | None = None
+    expected_steps: int | None = None
+    must_match_across_ranks: tuple[str, ...] | None = None
+
+
+class DistributedContractProbeResult(_Frozen):
+    passed: bool
+    failures: tuple[DistributedContractFailure, ...]
+
+
+def probe_distributed_contract(
+    inputs: DistributedContractProbeInputs,
+) -> DistributedContractProbeResult:
+    failures: list[DistributedContractFailure] = []
+
+    if inputs.expected_world_size is not None:
+        if inputs.world_size is None:
+            failures.append(
+                DistributedContractFailure(
+                    kind="missing-observation",
+                    message="declared expectation on world_size but no observation was supplied",
+                )
+            )
+        elif inputs.world_size != inputs.expected_world_size:
+            failures.append(
+                DistributedContractFailure(
+                    kind="wrong-world-size",
+                    message=(f"observed world size {inputs.world_size} does not match expected {inputs.expected_world_size}"),
+                )
+            )
+
+    seen_ranks: dict[int, DistributedRankReport] = {}
+    for report in inputs.ranks:
+        if report.rank in seen_ranks:
+            failures.append(
+                DistributedContractFailure(
+                    kind="duplicate-rank",
+                    rank=report.rank,
+                    message=f"rank {report.rank} reported more than once",
+                )
+            )
+            continue
+        seen_ranks[report.rank] = report
+
+    if inputs.world_size is not None:
+        for r in range(inputs.world_size):
+            if r not in seen_ranks:
+                failures.append(
+                    DistributedContractFailure(
+                        kind="missing-rank",
+                        rank=r,
+                        message=f"rank {r} did not report (world size {inputs.world_size})",
+                    )
+                )
+
+    if inputs.expected_steps is not None:
+        for report in seen_ranks.values():
+            if report.steps is None:
+                failures.append(
+                    DistributedContractFailure(
+                        kind="missing-observation",
+                        rank=report.rank,
+                        message=(f"rank {report.rank} declared step-count expectation but no steps observation was supplied"),
+                    )
+                )
+            elif report.steps != inputs.expected_steps:
+                failures.append(
+                    DistributedContractFailure(
+                        kind="wrong-step-count",
+                        rank=report.rank,
+                        message=(f"rank {report.rank} ran {report.steps} steps; expected {inputs.expected_steps}"),
+                    )
+                )
+
+    if inputs.must_match_across_ranks is not None and seen_ranks:
+        for key in inputs.must_match_across_ranks:
+            values_by_rank: dict[int, str] = {}
+            any_missing = False
+            for report in seen_ranks.values():
+                observations = report.observations or {}
+                value = observations.get(key)
+                if value is None:
+                    failures.append(
+                        DistributedContractFailure(
+                            kind="missing-observation",
+                            rank=report.rank,
+                            key=key,
+                            message=f"rank {report.rank} did not report observation '{key}'",
+                        )
+                    )
+                    any_missing = True
+                    continue
+                values_by_rank[report.rank] = value
+            if any_missing:
+                continue
+            distinct_values = set(values_by_rank.values())
+            if len(distinct_values) > 1:
+                rendered = ", ".join(json.dumps(v) for v in sorted(distinct_values))
+                failures.append(
+                    DistributedContractFailure(
+                        kind="rank-divergence",
+                        key=key,
+                        message=f"ranks disagree on '{key}': observed distinct values {rendered}",
+                    )
+                )
+
+    return DistributedContractProbeResult(passed=not failures, failures=tuple(failures))
+
+
+# ---------------------------------------------------------------------------
+# media / tabular contract probe
+# ---------------------------------------------------------------------------
+
+MediaContractFailureKind = Literal[
+    "wrong-magic-bytes",
+    "wrong-dimensions",
+    "wrong-byte-size",
+    "wrong-column-count",
+    "missing-column",
+    "wrong-line-count",
+    "missing-observation",
+]
+
+
+class MediaContractFailure(_Frozen):
+    kind: MediaContractFailureKind
+    path: str
+    message: str
+
+
+class MediaContractProbeInputs(_Frozen):
+    path: str
+    header_bytes: tuple[int, ...] | None = None
+    expected_magic_bytes: tuple[int, ...] | None = None
+    width: int | None = None
+    height: int | None = None
+    expected_width: int | None = None
+    expected_height: int | None = None
+    byte_size: int | None = None
+    min_byte_size: int | None = None
+    max_byte_size: int | None = None
+    column_count: int | None = None
+    expected_column_count: int | None = None
+    column_names: tuple[str, ...] | None = None
+    required_column_names: tuple[str, ...] | None = None
+    line_count: int | None = None
+    expected_line_count: int | None = None
+
+
+class MediaContractProbeResult(_Frozen):
+    passed: bool
+    failures: tuple[MediaContractFailure, ...]
+
+
+def _format_bytes(bytes_seq: tuple[int, ...]) -> str:
+    return " ".join(f"{b:02x}" for b in bytes_seq)
+
+
+def probe_media_contract(inputs: MediaContractProbeInputs) -> MediaContractProbeResult:
+    failures: list[MediaContractFailure] = []
+
+    def missing_observation(field: str) -> None:
+        failures.append(
+            MediaContractFailure(
+                kind="missing-observation",
+                path=inputs.path,
+                message=f"{inputs.path} declared expectation on {field} but no observation was supplied",
+            )
+        )
+
+    if inputs.expected_magic_bytes is not None:
+        if inputs.header_bytes is None:
+            missing_observation("header_bytes")
+        else:
+            expected = inputs.expected_magic_bytes
+            header = inputs.header_bytes
+            matched = len(header) >= len(expected) and all(header[i] == byte for i, byte in enumerate(expected))
+            if not matched:
+                failures.append(
+                    MediaContractFailure(
+                        kind="wrong-magic-bytes",
+                        path=inputs.path,
+                        message=(
+                            f"{inputs.path} header {_format_bytes(header[: len(expected)])} "
+                            f"does not match expected magic {_format_bytes(expected)}"
+                        ),
+                    )
+                )
+
+    if inputs.expected_width is not None:
+        if inputs.width is None:
+            missing_observation("width")
+        elif inputs.width != inputs.expected_width:
+            failures.append(
+                MediaContractFailure(
+                    kind="wrong-dimensions",
+                    path=inputs.path,
+                    message=f"{inputs.path} width {inputs.width} does not match expected {inputs.expected_width}",
+                )
+            )
+
+    if inputs.expected_height is not None:
+        if inputs.height is None:
+            missing_observation("height")
+        elif inputs.height != inputs.expected_height:
+            failures.append(
+                MediaContractFailure(
+                    kind="wrong-dimensions",
+                    path=inputs.path,
+                    message=f"{inputs.path} height {inputs.height} does not match expected {inputs.expected_height}",
+                )
+            )
+
+    if inputs.min_byte_size is not None or inputs.max_byte_size is not None:
+        if inputs.byte_size is None:
+            missing_observation("byte_size")
+        else:
+            if inputs.min_byte_size is not None and inputs.byte_size < inputs.min_byte_size:
+                failures.append(
+                    MediaContractFailure(
+                        kind="wrong-byte-size",
+                        path=inputs.path,
+                        message=(f"{inputs.path} byte size {inputs.byte_size} is below minimum {inputs.min_byte_size}"),
+                    )
+                )
+            if inputs.max_byte_size is not None and inputs.byte_size > inputs.max_byte_size:
+                failures.append(
+                    MediaContractFailure(
+                        kind="wrong-byte-size",
+                        path=inputs.path,
+                        message=(f"{inputs.path} byte size {inputs.byte_size} is above maximum {inputs.max_byte_size}"),
+                    )
+                )
+
+    if inputs.expected_column_count is not None:
+        if inputs.column_count is None:
+            missing_observation("column_count")
+        elif inputs.column_count != inputs.expected_column_count:
+            failures.append(
+                MediaContractFailure(
+                    kind="wrong-column-count",
+                    path=inputs.path,
+                    message=(f"{inputs.path} has {inputs.column_count} columns; expected {inputs.expected_column_count}"),
+                )
+            )
+
+    if inputs.required_column_names is not None:
+        if inputs.column_names is None:
+            missing_observation("column_names")
+        else:
+            observed = set(inputs.column_names)
+            for required in inputs.required_column_names:
+                if required not in observed:
+                    failures.append(
+                        MediaContractFailure(
+                            kind="missing-column",
+                            path=required,
+                            message=f"{inputs.path} is missing required column {json.dumps(required)}",
+                        )
+                    )
+
+    if inputs.expected_line_count is not None:
+        if inputs.line_count is None:
+            missing_observation("line_count")
+        elif inputs.line_count != inputs.expected_line_count:
+            failures.append(
+                MediaContractFailure(
+                    kind="wrong-line-count",
+                    path=inputs.path,
+                    message=(f"{inputs.path} has {inputs.line_count} lines; expected {inputs.expected_line_count}"),
+                )
+            )
+
+    return MediaContractProbeResult(passed=not failures, failures=tuple(failures))

--- a/autocontext/src/autocontext/control_plane/contract_probes/_advanced.py
+++ b/autocontext/src/autocontext/control_plane/contract_probes/_advanced.py
@@ -307,6 +307,17 @@ def probe_distributed_contract(
                 )
 
     if inputs.expected_steps is not None:
+        # PR #1005 review (P2): a declared rank-scoped expectation
+        # without any rank reports must fail loudly. Iterating
+        # `seen_ranks.values()` alone would let a broken extractor
+        # satisfy `expected_steps` by omitting every rank report.
+        if not seen_ranks:
+            failures.append(
+                DistributedContractFailure(
+                    kind="missing-observation",
+                    message=("declared expectation on expected_steps but no rank reports were supplied"),
+                )
+            )
         for report in seen_ranks.values():
             if report.steps is None:
                 failures.append(
@@ -324,6 +335,19 @@ def probe_distributed_contract(
                         message=(f"rank {report.rank} ran {report.steps} steps; expected {inputs.expected_steps}"),
                     )
                 )
+
+    if inputs.must_match_across_ranks is not None and not seen_ranks:
+        # PR #1005 review (P2): same shape as expected_steps above.
+        # Declared cross-rank expectations with zero rank reports must
+        # fail loudly, not pass silently.
+        for key in inputs.must_match_across_ranks:
+            failures.append(
+                DistributedContractFailure(
+                    kind="missing-observation",
+                    key=key,
+                    message=(f"declared must_match_across_ranks expectation on '{key}' but no rank reports were supplied"),
+                )
+            )
 
     if inputs.must_match_across_ranks is not None and seen_ranks:
         for key in inputs.must_match_across_ranks:

--- a/autocontext/src/autocontext/control_plane/contract_probes/_base.py
+++ b/autocontext/src/autocontext/control_plane/contract_probes/_base.py
@@ -1,0 +1,413 @@
+"""AC-728 contract probes, Python parity (slice 1).
+
+Mirrors ``ts/src/control-plane/contract-probes/index.ts`` at the
+PR #957 shape: four base probes (directory, terminal, service,
+artifact). Each probe is a pure function returning a Pydantic
+result model so it composes with the same trace-replay surfaces
+the TS probes use.
+
+Missing-observation invariant
+-----------------------------
+Every observation field on these four probes is non-optional, so the
+silent-pass shape simply does not arise here. The follow-up slice-2
+cleanup / media / distributed probes (mirroring TS PRs #983, #985,
+#987) emit explicit ``missing-observation`` failure kinds; this
+slice does not need that surface.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "ArtifactContractFailure",
+    "ArtifactContractFailureKind",
+    "ArtifactContractProbeInputs",
+    "ArtifactContractProbeResult",
+    "DirectoryContractFailure",
+    "DirectoryContractFailureKind",
+    "DirectoryContractProbeInputs",
+    "DirectoryContractProbeResult",
+    "ServiceContractFailure",
+    "ServiceContractFailureKind",
+    "ServiceContractProbeInputs",
+    "ServiceContractProbeResult",
+    "ServiceEndpointObservation",
+    "ServiceEndpointProtocol",
+    "TerminalContractFailure",
+    "TerminalContractFailureKind",
+    "TerminalContractProbeInputs",
+    "TerminalContractProbeResult",
+    "probe_artifact_contract",
+    "probe_directory_contract",
+    "probe_service_contract",
+    "probe_terminal_contract",
+]
+
+
+class _Frozen(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", arbitrary_types_allowed=True)
+
+
+# ---------------------------------------------------------------------------
+# directory contract probe
+# ---------------------------------------------------------------------------
+
+DirectoryContractFailureKind = Literal["unexpected-file", "missing-file"]
+
+
+class DirectoryContractFailure(_Frozen):
+    kind: DirectoryContractFailureKind
+    path: str
+    message: str
+
+
+class DirectoryContractProbeInputs(_Frozen):
+    present_files: tuple[str, ...] = Field(default=())
+    required_files: tuple[str, ...] = Field(default=())
+    allowed_files: tuple[str, ...] = Field(default=())
+    ignored_patterns: tuple[re.Pattern[str], ...] = Field(default=())
+
+
+class DirectoryContractProbeResult(_Frozen):
+    passed: bool
+    failures: tuple[DirectoryContractFailure, ...]
+
+
+def _is_ignored(path: str, ignored_patterns: tuple[re.Pattern[str], ...]) -> bool:
+    return any(pattern.search(path) is not None for pattern in ignored_patterns)
+
+
+def probe_directory_contract(
+    inputs: DirectoryContractProbeInputs,
+) -> DirectoryContractProbeResult:
+    present_files = tuple(path for path in inputs.present_files if not _is_ignored(path, inputs.ignored_patterns))
+    present = set(present_files)
+    allowed = set(inputs.allowed_files)
+    failures: list[DirectoryContractFailure] = []
+
+    for path in present_files:
+        if path not in allowed:
+            failures.append(
+                DirectoryContractFailure(
+                    kind="unexpected-file",
+                    path=path,
+                    message=f"unexpected file {path}",
+                )
+            )
+
+    for path in inputs.required_files:
+        if path not in present:
+            failures.append(
+                DirectoryContractFailure(
+                    kind="missing-file",
+                    path=path,
+                    message=f"required file {path} is missing",
+                )
+            )
+
+    return DirectoryContractProbeResult(passed=not failures, failures=tuple(failures))
+
+
+# ---------------------------------------------------------------------------
+# terminal contract probe
+# ---------------------------------------------------------------------------
+
+TerminalContractFailureKind = Literal[
+    "unexpected-exit-code",
+    "missing-stdout-pattern",
+    "forbidden-stdout-pattern",
+    "missing-stderr-pattern",
+    "forbidden-stderr-pattern",
+]
+
+
+class TerminalContractFailure(_Frozen):
+    kind: TerminalContractFailureKind
+    message: str
+
+
+class TerminalContractProbeInputs(_Frozen):
+    exit_code: int
+    stdout: str
+    stderr: str
+    expected_exit_code: int | None = None
+    required_stdout_patterns: tuple[re.Pattern[str], ...] = Field(default=())
+    forbidden_stdout_patterns: tuple[re.Pattern[str], ...] = Field(default=())
+    required_stderr_patterns: tuple[re.Pattern[str], ...] = Field(default=())
+    forbidden_stderr_patterns: tuple[re.Pattern[str], ...] = Field(default=())
+
+
+class TerminalContractProbeResult(_Frozen):
+    passed: bool
+    failures: tuple[TerminalContractFailure, ...]
+
+
+def probe_terminal_contract(
+    inputs: TerminalContractProbeInputs,
+) -> TerminalContractProbeResult:
+    failures: list[TerminalContractFailure] = []
+    expected_exit_code = inputs.expected_exit_code if inputs.expected_exit_code is not None else 0
+    if inputs.exit_code != expected_exit_code:
+        failures.append(
+            TerminalContractFailure(
+                kind="unexpected-exit-code",
+                message=f"expected exit code {expected_exit_code}, got {inputs.exit_code}",
+            )
+        )
+    for pattern in inputs.required_stdout_patterns:
+        if pattern.search(inputs.stdout) is None:
+            failures.append(
+                TerminalContractFailure(
+                    kind="missing-stdout-pattern",
+                    message=f"stdout did not match {pattern.pattern}",
+                )
+            )
+    for pattern in inputs.forbidden_stdout_patterns:
+        if pattern.search(inputs.stdout) is not None:
+            failures.append(
+                TerminalContractFailure(
+                    kind="forbidden-stdout-pattern",
+                    message=f"stdout matched forbidden {pattern.pattern}",
+                )
+            )
+    for pattern in inputs.required_stderr_patterns:
+        if pattern.search(inputs.stderr) is None:
+            failures.append(
+                TerminalContractFailure(
+                    kind="missing-stderr-pattern",
+                    message=f"stderr did not match {pattern.pattern}",
+                )
+            )
+    for pattern in inputs.forbidden_stderr_patterns:
+        if pattern.search(inputs.stderr) is not None:
+            failures.append(
+                TerminalContractFailure(
+                    kind="forbidden-stderr-pattern",
+                    message=f"stderr matched forbidden {pattern.pattern}",
+                )
+            )
+    return TerminalContractProbeResult(passed=not failures, failures=tuple(failures))
+
+
+# ---------------------------------------------------------------------------
+# service contract probe
+# ---------------------------------------------------------------------------
+
+ServiceEndpointProtocol = Literal["tcp", "udp"]
+ServiceContractFailureKind = Literal[
+    "missing-endpoint",
+    "unexpected-endpoint",
+    "wrong-interface",
+]
+
+
+class ServiceEndpointObservation(_Frozen):
+    host: str
+    port: int
+    protocol: ServiceEndpointProtocol | None = None
+
+
+class ServiceContractFailure(_Frozen):
+    kind: ServiceContractFailureKind
+    endpoint: ServiceEndpointObservation
+    message: str
+
+
+class ServiceContractProbeInputs(_Frozen):
+    observed: tuple[ServiceEndpointObservation, ...] = Field(default=())
+    required: tuple[ServiceEndpointObservation, ...] = Field(default=())
+    allowed: tuple[ServiceEndpointObservation, ...] | None = None
+
+
+class ServiceContractProbeResult(_Frozen):
+    passed: bool
+    failures: tuple[ServiceContractFailure, ...]
+
+
+def _normalize_protocol(endpoint: ServiceEndpointObservation) -> ServiceEndpointProtocol:
+    return endpoint.protocol if endpoint.protocol is not None else "tcp"
+
+
+def _endpoint_key(endpoint: ServiceEndpointObservation) -> str:
+    return f"{_normalize_protocol(endpoint)}://{endpoint.host}:{endpoint.port}"
+
+
+def _endpoint_matches_any_host(
+    required: ServiceEndpointObservation,
+    observed: tuple[ServiceEndpointObservation, ...],
+) -> ServiceEndpointObservation | None:
+    required_protocol = _normalize_protocol(required)
+    for candidate in observed:
+        if candidate.port == required.port and _normalize_protocol(candidate) == required_protocol:
+            return candidate
+    return None
+
+
+def probe_service_contract(
+    inputs: ServiceContractProbeInputs,
+) -> ServiceContractProbeResult:
+    failures: list[ServiceContractFailure] = []
+    observed_keys = {_endpoint_key(endpoint) for endpoint in inputs.observed}
+
+    for required in inputs.required:
+        required_key = _endpoint_key(required)
+        if required_key in observed_keys:
+            continue
+        port_match = _endpoint_matches_any_host(required, inputs.observed)
+        if port_match is not None:
+            failures.append(
+                ServiceContractFailure(
+                    kind="wrong-interface",
+                    endpoint=required,
+                    message=(f"required {required_key} but observed {_endpoint_key(port_match)}"),
+                )
+            )
+        else:
+            failures.append(
+                ServiceContractFailure(
+                    kind="missing-endpoint",
+                    endpoint=required,
+                    message=f"required endpoint {required_key} not observed",
+                )
+            )
+
+    if inputs.allowed is not None:
+        allowed_keys = {_endpoint_key(endpoint) for endpoint in inputs.allowed}
+        for observed in inputs.observed:
+            if _endpoint_key(observed) not in allowed_keys:
+                failures.append(
+                    ServiceContractFailure(
+                        kind="unexpected-endpoint",
+                        endpoint=observed,
+                        message=(f"observed endpoint {_endpoint_key(observed)} not in allowed list"),
+                    )
+                )
+
+    return ServiceContractProbeResult(passed=not failures, failures=tuple(failures))
+
+
+# ---------------------------------------------------------------------------
+# artifact contract probe
+# ---------------------------------------------------------------------------
+
+ArtifactContractFailureKind = Literal[
+    "missing-substring",
+    "forbidden-substring",
+    "wrong-line-ending",
+    "invalid-json",
+    "missing-json-field",
+]
+
+
+class ArtifactContractFailure(_Frozen):
+    kind: ArtifactContractFailureKind
+    path: str
+    message: str
+
+
+class ArtifactContractProbeInputs(_Frozen):
+    path: str
+    content: str
+    expected_line_ending: Literal["lf", "crlf"] | None = None
+    required_substrings: tuple[str, ...] = Field(default=())
+    forbidden_substrings: tuple[str, ...] = Field(default=())
+    required_json_fields: tuple[str, ...] = Field(default=())
+
+
+class ArtifactContractProbeResult(_Frozen):
+    passed: bool
+    failures: tuple[ArtifactContractFailure, ...]
+
+
+_BARE_LF_RE = re.compile(r"(?<!\r)\n")
+
+# Sentinel distinguishing "JSON key absent" from "JSON key present with
+# null value". The TS probe treats `undefined` as missing but accepts
+# `null` as a present-but-null value; mirroring that here requires a
+# sentinel because Python `json.loads` decodes JSON `null` to `None`.
+_MISSING = object()
+
+
+def _read_json_dot_path(value: object, path: str) -> object:
+    cursor: object = value
+    for segment in path.split("."):
+        if not isinstance(cursor, dict):
+            return _MISSING
+        if segment not in cursor:
+            return _MISSING
+        cursor = cursor[segment]
+    return cursor
+
+
+def probe_artifact_contract(
+    inputs: ArtifactContractProbeInputs,
+) -> ArtifactContractProbeResult:
+    failures: list[ArtifactContractFailure] = []
+
+    for required in inputs.required_substrings:
+        if required not in inputs.content:
+            failures.append(
+                ArtifactContractFailure(
+                    kind="missing-substring",
+                    path=inputs.path,
+                    message=(f"{inputs.path} is missing required substring {json.dumps(required)}"),
+                )
+            )
+
+    for forbidden in inputs.forbidden_substrings:
+        if forbidden in inputs.content:
+            failures.append(
+                ArtifactContractFailure(
+                    kind="forbidden-substring",
+                    path=inputs.path,
+                    message=(f"{inputs.path} contains forbidden substring {json.dumps(forbidden)}"),
+                )
+            )
+
+    if inputs.expected_line_ending == "lf":
+        if "\r\n" in inputs.content:
+            failures.append(
+                ArtifactContractFailure(
+                    kind="wrong-line-ending",
+                    path=inputs.path,
+                    message=f"{inputs.path} contains CRLF but LF was required",
+                )
+            )
+    elif inputs.expected_line_ending == "crlf":
+        if _BARE_LF_RE.search(inputs.content) is not None:
+            failures.append(
+                ArtifactContractFailure(
+                    kind="wrong-line-ending",
+                    path=inputs.path,
+                    message=f"{inputs.path} contains bare LF but CRLF was required",
+                )
+            )
+
+    if inputs.required_json_fields:
+        try:
+            parsed = json.loads(inputs.content)
+        except json.JSONDecodeError as err:
+            failures.append(
+                ArtifactContractFailure(
+                    kind="invalid-json",
+                    path=inputs.path,
+                    message=f"{inputs.path} is not valid JSON: {err.msg}",
+                )
+            )
+            return ArtifactContractProbeResult(passed=False, failures=tuple(failures))
+        for field in inputs.required_json_fields:
+            if _read_json_dot_path(parsed, field) is _MISSING:
+                failures.append(
+                    ArtifactContractFailure(
+                        kind="missing-json-field",
+                        path=field,
+                        message=f"{inputs.path} is missing required JSON field {field}",
+                    )
+                )
+
+    return ArtifactContractProbeResult(passed=not failures, failures=tuple(failures))

--- a/autocontext/tests/control_plane/test_contract_probes_advanced.py
+++ b/autocontext/tests/control_plane/test_contract_probes_advanced.py
@@ -1,0 +1,325 @@
+"""AC-728 advanced contract probes (Python parity, slice 2) tests.
+
+Mirrors the cleanup / distributed / media test surfaces from
+``ts/tests/control-plane/contract-probes/contract-probes.test.ts``.
+The missing-observation invariant gets specific pinning tests for
+each probe (a declared expectation without its matching observation
+must fail loudly).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+
+from autocontext.control_plane.contract_probes import (
+    CleanupContractProbeInputs,
+    CleanupFileEntry,
+    DistributedContractProbeInputs,
+    DistributedRankReport,
+    MediaContractProbeInputs,
+    probe_cleanup_contract,
+    probe_distributed_contract,
+    probe_media_contract,
+)
+
+# ---------------------------------------------------------------------------
+# cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_probe_passes_clean_workdir() -> None:
+    result = probe_cleanup_contract(
+        CleanupContractProbeInputs(
+            entries=(CleanupFileEntry(path="solution.txt"),),
+        )
+    )
+    assert result.passed is True
+
+
+def test_cleanup_probe_flags_broken_symlinks() -> None:
+    result = probe_cleanup_contract(
+        CleanupContractProbeInputs(
+            entries=(CleanupFileEntry(path="link", is_symlink=True, symlink_broken=True),),
+        )
+    )
+    assert result.failures[0].kind == "broken-symlink"
+
+
+def test_cleanup_probe_flags_forbidden_symlinks() -> None:
+    result = probe_cleanup_contract(
+        CleanupContractProbeInputs(
+            entries=(CleanupFileEntry(path="link", is_symlink=True, symlink_target="/tmp/x"),),
+            forbid_symlinks=True,
+        )
+    )
+    assert result.failures[0].kind == "stray-symlink"
+
+
+def test_cleanup_probe_emits_missing_observation_for_symlink_without_target() -> None:
+    """PR #985 review lesson, retrofitted: a declared allowlist
+    expectation without its symlink_target observation must fail
+    loudly, not pass silently against a broken extractor."""
+    result = probe_cleanup_contract(
+        CleanupContractProbeInputs(
+            entries=(CleanupFileEntry(path="link", is_symlink=True),),
+            allowed_symlink_targets=("/var/run/known",),
+        )
+    )
+    assert result.failures[0].kind == "missing-observation"
+
+
+def test_cleanup_probe_flags_stale_lockfile_when_mtime_older_than_max_age() -> None:
+    now = datetime(2026, 5, 29, tzinfo=UTC)
+    result = probe_cleanup_contract(
+        CleanupContractProbeInputs(
+            entries=(CleanupFileEntry(path="a.lock", mtime=now - timedelta(hours=1)),),
+            now=now,
+            max_lockfile_age_ms=60_000,
+        )
+    )
+    assert result.failures[0].kind == "stale-lockfile"
+
+
+def test_cleanup_probe_emits_missing_observation_for_lockfile_without_mtime() -> None:
+    """PR #985 review lesson: a declared max_lockfile_age_ms contract
+    against a lockfile entry without mtime fails loudly, not silently
+    via a stat-failing extractor."""
+    result = probe_cleanup_contract(
+        CleanupContractProbeInputs(
+            entries=(CleanupFileEntry(path="a.lock"),),
+            max_lockfile_age_ms=60_000,
+        )
+    )
+    assert result.failures[0].kind == "missing-observation"
+
+
+def test_cleanup_probe_flags_sidecars_and_backups() -> None:
+    result = probe_cleanup_contract(
+        CleanupContractProbeInputs(
+            entries=(
+                CleanupFileEntry(path=".DS_Store"),
+                CleanupFileEntry(path="notes.bak"),
+            ),
+        )
+    )
+    kinds = {f.kind for f in result.failures}
+    assert {"stray-sidecar", "stray-backup"}.issubset(kinds)
+
+
+def test_cleanup_probe_ignored_patterns_short_circuit_before_classification() -> None:
+    result = probe_cleanup_contract(
+        CleanupContractProbeInputs(
+            entries=(CleanupFileEntry(path=".DS_Store"),),
+            ignored_patterns=(re.compile(r"\.DS_Store$"),),
+        )
+    )
+    assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# distributed
+# ---------------------------------------------------------------------------
+
+
+def test_distributed_probe_passes_when_all_ranks_report() -> None:
+    result = probe_distributed_contract(
+        DistributedContractProbeInputs(
+            ranks=(
+                DistributedRankReport(rank=0, steps=10),
+                DistributedRankReport(rank=1, steps=10),
+            ),
+            world_size=2,
+            expected_steps=10,
+        )
+    )
+    assert result.passed is True
+
+
+def test_distributed_probe_flags_wrong_world_size() -> None:
+    result = probe_distributed_contract(
+        DistributedContractProbeInputs(
+            ranks=(),
+            world_size=4,
+            expected_world_size=8,
+        )
+    )
+    assert any(f.kind == "wrong-world-size" for f in result.failures)
+
+
+def test_distributed_probe_flags_missing_rank_when_world_size_known() -> None:
+    result = probe_distributed_contract(
+        DistributedContractProbeInputs(
+            ranks=(DistributedRankReport(rank=0),),
+            world_size=2,
+        )
+    )
+    assert any(f.kind == "missing-rank" and f.rank == 1 for f in result.failures)
+
+
+def test_distributed_probe_flags_duplicate_rank() -> None:
+    result = probe_distributed_contract(
+        DistributedContractProbeInputs(
+            ranks=(
+                DistributedRankReport(rank=0),
+                DistributedRankReport(rank=0),
+            ),
+        )
+    )
+    assert any(f.kind == "duplicate-rank" for f in result.failures)
+
+
+def test_distributed_probe_flags_rank_divergence_with_distinct_values() -> None:
+    result = probe_distributed_contract(
+        DistributedContractProbeInputs(
+            ranks=(
+                DistributedRankReport(rank=0, observations={"loss": "0.1"}),
+                DistributedRankReport(rank=1, observations={"loss": "0.2"}),
+            ),
+            must_match_across_ranks=("loss",),
+        )
+    )
+    diverge = [f for f in result.failures if f.kind == "rank-divergence"]
+    assert diverge and "0.1" in diverge[0].message and "0.2" in diverge[0].message
+
+
+def test_distributed_probe_emits_missing_observation_for_steps_when_expected() -> None:
+    result = probe_distributed_contract(
+        DistributedContractProbeInputs(
+            ranks=(DistributedRankReport(rank=0),),
+            expected_steps=100,
+        )
+    )
+    assert result.failures[0].kind == "missing-observation"
+
+
+def test_distributed_probe_emits_missing_observation_for_must_match_key() -> None:
+    result = probe_distributed_contract(
+        DistributedContractProbeInputs(
+            ranks=(DistributedRankReport(rank=0),),
+            must_match_across_ranks=("hash",),
+        )
+    )
+    assert result.failures[0].kind == "missing-observation"
+
+
+def test_distributed_probe_emits_missing_observation_for_world_size() -> None:
+    result = probe_distributed_contract(
+        DistributedContractProbeInputs(
+            ranks=(),
+            expected_world_size=4,
+        )
+    )
+    assert result.failures[0].kind == "missing-observation"
+
+
+def test_distributed_probe_passes_world_size_one_degenerate_case() -> None:
+    result = probe_distributed_contract(
+        DistributedContractProbeInputs(
+            ranks=(DistributedRankReport(rank=0, steps=1),),
+            world_size=1,
+            expected_world_size=1,
+            expected_steps=1,
+        )
+    )
+    assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# media
+# ---------------------------------------------------------------------------
+
+
+def test_media_probe_passes_when_all_expectations_match() -> None:
+    result = probe_media_contract(
+        MediaContractProbeInputs(
+            path="img.png",
+            header_bytes=(0x89, 0x50, 0x4E, 0x47),
+            expected_magic_bytes=(0x89, 0x50, 0x4E, 0x47),
+            width=10,
+            height=10,
+            expected_width=10,
+            expected_height=10,
+            byte_size=512,
+            min_byte_size=1,
+            max_byte_size=1024,
+        )
+    )
+    assert result.passed is True
+
+
+def test_media_probe_flags_wrong_magic_bytes() -> None:
+    result = probe_media_contract(
+        MediaContractProbeInputs(
+            path="img.png",
+            header_bytes=(0x00, 0x00, 0x00, 0x00),
+            expected_magic_bytes=(0x89, 0x50, 0x4E, 0x47),
+        )
+    )
+    assert result.failures[0].kind == "wrong-magic-bytes"
+
+
+def test_media_probe_flags_byte_size_bounds_violation() -> None:
+    too_small = probe_media_contract(
+        MediaContractProbeInputs(
+            path="x.bin",
+            byte_size=10,
+            min_byte_size=100,
+        )
+    )
+    assert too_small.failures[0].kind == "wrong-byte-size"
+
+    too_big = probe_media_contract(
+        MediaContractProbeInputs(
+            path="x.bin",
+            byte_size=10_000,
+            max_byte_size=100,
+        )
+    )
+    assert too_big.failures[0].kind == "wrong-byte-size"
+
+
+def test_media_probe_flags_missing_required_columns() -> None:
+    result = probe_media_contract(
+        MediaContractProbeInputs(
+            path="data.csv",
+            column_names=("id", "name"),
+            required_column_names=("id", "missing"),
+        )
+    )
+    missing = [f for f in result.failures if f.kind == "missing-column"]
+    assert {f.path for f in missing} == {"missing"}
+
+
+def test_media_probe_flags_wrong_line_count() -> None:
+    result = probe_media_contract(
+        MediaContractProbeInputs(
+            path="data.jsonl",
+            line_count=3,
+            expected_line_count=5,
+        )
+    )
+    assert result.failures[0].kind == "wrong-line-count"
+
+
+def test_media_probe_emits_missing_observation_when_expectation_lacks_observation() -> None:
+    """Every declared expectation without its observation must fail."""
+    cases = [
+        MediaContractProbeInputs(path="x", expected_magic_bytes=(0x89,)),
+        MediaContractProbeInputs(path="x", expected_width=10),
+        MediaContractProbeInputs(path="x", expected_height=10),
+        MediaContractProbeInputs(path="x", min_byte_size=10),
+        MediaContractProbeInputs(path="x", max_byte_size=10),
+        MediaContractProbeInputs(path="x", expected_column_count=5),
+        MediaContractProbeInputs(path="x", required_column_names=("id",)),
+        MediaContractProbeInputs(path="x", expected_line_count=5),
+    ]
+    for inputs in cases:
+        result = probe_media_contract(inputs)
+        assert result.passed is False
+        assert result.failures[0].kind == "missing-observation"
+
+
+def test_media_probe_no_expectations_declared_passes() -> None:
+    result = probe_media_contract(MediaContractProbeInputs(path="x"))
+    assert result.passed is True

--- a/autocontext/tests/control_plane/test_contract_probes_advanced.py
+++ b/autocontext/tests/control_plane/test_contract_probes_advanced.py
@@ -203,6 +203,32 @@ def test_distributed_probe_emits_missing_observation_for_must_match_key() -> Non
     assert result.failures[0].kind == "missing-observation"
 
 
+def test_distributed_probe_emits_missing_observation_when_expected_steps_declared_without_any_ranks() -> None:
+    """PR #1005 review (P2): a broken extractor that omits all rank
+    reports must not be able to satisfy declared rank-scoped
+    expectations by silence. `expected_steps` against zero rank
+    reports fails loudly with `missing-observation`.
+    """
+    result = probe_distributed_contract(DistributedContractProbeInputs(ranks=(), expected_steps=100))
+    assert result.passed is False
+    assert any(f.kind == "missing-observation" for f in result.failures)
+
+
+def test_distributed_probe_emits_missing_observation_when_must_match_declared_without_any_ranks() -> None:
+    """PR #1005 review (P2): same shape for `must_match_across_ranks`.
+    Each declared key surfaces its own `missing-observation` so a
+    multi-key expectation does not collapse to a single failure."""
+    result = probe_distributed_contract(
+        DistributedContractProbeInputs(
+            ranks=(),
+            must_match_across_ranks=("hash", "loss"),
+        )
+    )
+    assert result.passed is False
+    keys_with_missing = {f.key for f in result.failures if f.kind == "missing-observation"}
+    assert keys_with_missing == {"hash", "loss"}
+
+
 def test_distributed_probe_emits_missing_observation_for_world_size() -> None:
     result = probe_distributed_contract(
         DistributedContractProbeInputs(


### PR DESCRIPTION
## Summary

- Mirrors `ts/src/control-plane/contract-probes/index.ts` cleanup / distributed / media surfaces from TS PRs #983 / #985 / #987: `probe_cleanup_contract`, `probe_distributed_contract`, `probe_media_contract`. Each emits explicit `missing-observation` failure kinds so a declared expectation without its matching observation fails loudly.
- The slice-1 `__init__.py` body moves to `_base.py` and the new slice-2 probes land in `_advanced.py` to stay under the 800-line module guard. The package `__init__.py` re-exports the public surface from both modules.

## Test plan

- [x] `uv run pytest tests/control_plane/` (50 passed: 26 prior + 24 new)
- [x] `uv run pytest tests/test_module_size_limits.py` clean (largest module is `_advanced.py` at 527 lines)
- [x] `uv run ruff check` clean
- [x] `uv run mypy` clean
- [ ] CI: green

## Slice plan (7 total)

- slice 1 (#1004, merged): 4 base probes
- **slice 2 (this PR)**: 3 advanced probes (cleanup / distributed / media) with `missing-observation` failure kinds
- slice 3: suite runner + Pydantic schema (mirrors TS PR #990)
- slice 4: `autoctx probes check` Python CLI (mirrors TS PR #991)
- slice 5: `autoctx probes extract` for 4 base probes (mirrors TS PR #992)
- slice 6: extend extract to cleanup / media / distributed (mirrors TS PR #993)
- slice 7: missing-observation audit close-out