### PR TITLE
feat(control-plane): AC-728 Python parity slice 3 (suite runner + schema)

### DIFF
--- a/autocontext/src/autocontext/control_plane/contract_probes/__init__.py
+++ b/autocontext/src/autocontext/control_plane/contract_probes/__init__.py
@@ -58,9 +58,25 @@ from ._base import (
     probe_service_contract,
     probe_terminal_contract,
 )
+from .runner import (
+    ContractProbeInvocation,
+    ContractProbeKind,
+    ContractProbeRunResult,
+    ContractProbeSuite,
+    ContractProbeSuiteResult,
+    ContractProbeSuiteSchema,
+    load_contract_probe_suite,
+    run_contract_probe_suite,
+)
 
 __all__ = [
     "ArtifactContractFailure",
+    "ContractProbeInvocation",
+    "ContractProbeKind",
+    "ContractProbeRunResult",
+    "ContractProbeSuite",
+    "ContractProbeSuiteResult",
+    "ContractProbeSuiteSchema",
     "ArtifactContractFailureKind",
     "ArtifactContractProbeInputs",
     "ArtifactContractProbeResult",
@@ -92,6 +108,7 @@ __all__ = [
     "TerminalContractFailureKind",
     "TerminalContractProbeInputs",
     "TerminalContractProbeResult",
+    "load_contract_probe_suite",
     "probe_artifact_contract",
     "probe_cleanup_contract",
     "probe_directory_contract",
@@ -99,4 +116,5 @@ __all__ = [
     "probe_media_contract",
     "probe_service_contract",
     "probe_terminal_contract",
+    "run_contract_probe_suite",
 ]

--- a/autocontext/src/autocontext/control_plane/contract_probes/runner.py
+++ b/autocontext/src/autocontext/control_plane/contract_probes/runner.py
@@ -1,0 +1,533 @@
+"""AC-728 contract-probe suite runner (Python parity, slice 3).
+
+Mirrors ``ts/src/control-plane/contract-probes/runner.ts`` (PR #990).
+Library-level entry point that dispatches a JSON-defined probe suite
+across all seven AC-728 probes and aggregates results. Pure function:
+callers do the IO to populate observations; the runner verifies.
+
+The suite schema is intentionally separate from the probe Inputs
+models (mirroring the TS Zod / interface split):
+
+- ``ContractProbeSuiteSchema`` validates the JSON wire format with
+  every nested object set to ``extra="forbid"``, so a typo like
+  ``requiredStdoutPattern`` (missing ``s``) fails validation rather
+  than silently being dropped.
+- RegExp values can arrive as either a bare pattern string or
+  ``{"source": ..., "flags": ...}``; invalid regexes surface as
+  ``ValidationError``, not raw ``re.error``.
+- ISO-8601 strings parse to ``datetime`` automatically.
+- ``run_contract_probe_suite(suite)`` dispatches via ``kind`` and
+  returns a discriminated-union list of per-probe results, each
+  preserving the probe's typed failure shape.
+- ``load_contract_probe_suite(path)`` is the JSON file loader.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    ValidationInfo,
+    field_validator,
+)
+
+from ._advanced import (
+    CleanupContractFailure,
+    CleanupContractProbeInputs,
+    CleanupFileEntry,
+    DistributedContractFailure,
+    DistributedContractProbeInputs,
+    DistributedRankReport,
+    MediaContractFailure,
+    MediaContractProbeInputs,
+    probe_cleanup_contract,
+    probe_distributed_contract,
+    probe_media_contract,
+)
+from ._base import (
+    ArtifactContractFailure,
+    ArtifactContractProbeInputs,
+    DirectoryContractFailure,
+    DirectoryContractProbeInputs,
+    ServiceContractFailure,
+    ServiceContractProbeInputs,
+    ServiceEndpointObservation,
+    TerminalContractFailure,
+    TerminalContractProbeInputs,
+    probe_artifact_contract,
+    probe_directory_contract,
+    probe_service_contract,
+    probe_terminal_contract,
+)
+
+__all__ = [
+    "ContractProbeInvocation",
+    "ContractProbeKind",
+    "ContractProbeRunResult",
+    "ContractProbeSuite",
+    "ContractProbeSuiteResult",
+    "load_contract_probe_suite",
+    "run_contract_probe_suite",
+]
+
+
+# ---------------------------------------------------------------------------
+# JSON-side helpers: RegExp + Date coercion
+# ---------------------------------------------------------------------------
+
+ContractProbeKind = Literal[
+    "directory",
+    "terminal",
+    "service",
+    "artifact",
+    "cleanup",
+    "media",
+    "distributed",
+]
+
+
+def _coerce_pattern(value: object) -> re.Pattern[str]:
+    """Accept a string, a dict ``{"source": ..., "flags": ...}``, or
+    a pre-compiled ``re.Pattern[str]``. Invalid patterns raise
+    ``ValueError`` so Pydantic surfaces them as ``ValidationError``
+    rather than letting raw ``re.error`` escape.
+    """
+    if isinstance(value, re.Pattern):
+        return value
+    if isinstance(value, str):
+        try:
+            return re.compile(value)
+        except re.error as err:
+            raise ValueError(f"invalid regular expression {value!r}: {err}") from None
+    if isinstance(value, dict):
+        source = value.get("source")
+        if not isinstance(source, str):
+            raise ValueError("RegExp object missing 'source' string")
+        flags_str = value.get("flags", "")
+        if not isinstance(flags_str, str):
+            raise ValueError("RegExp object 'flags' must be a string")
+        flags = 0
+        for ch in flags_str:
+            mapping = {
+                "i": re.IGNORECASE,
+                "m": re.MULTILINE,
+                "s": re.DOTALL,
+                "x": re.VERBOSE,
+                "u": re.UNICODE,
+            }
+            if ch not in mapping:
+                raise ValueError(f"unknown RegExp flag {ch!r}")
+            flags |= mapping[ch]
+        try:
+            return re.compile(source, flags)
+        except re.error as err:
+            raise ValueError(f"invalid regular expression {source!r}: {err}") from None
+    raise ValueError(
+        f"RegExp value must be a string, a {{source, flags?}} object, or a compiled pattern; got {type(value).__name__}"
+    )
+
+
+def _coerce_patterns(value: object) -> tuple[re.Pattern[str], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, (list, tuple)):
+        raise ValueError("expected a list of RegExp values")
+    return tuple(_coerce_pattern(item) for item in value)
+
+
+_PatternList = Annotated[tuple[re.Pattern[str], ...], BeforeValidator(_coerce_patterns)]
+
+
+# ---------------------------------------------------------------------------
+# Per-probe JSON-shape schemas
+# ---------------------------------------------------------------------------
+#
+# Every model is `extra="forbid"`: unknown keys fail validation rather than
+# being silently stripped. This catches typos like `requiredStdoutPattern`
+# (missing `s`) at parse time -- otherwise the field would disappear and
+# the runner would silently skip the expectation, returning passed=True
+# for what was supposed to be a stronger contract.
+
+
+class _Strict(BaseModel):
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+
+class _DirectoryInputsSchema(_Strict):
+    presentFiles: tuple[str, ...] = ()
+    requiredFiles: tuple[str, ...] = ()
+    allowedFiles: tuple[str, ...] = ()
+    ignoredPatterns: _PatternList | None = None
+
+    def to_inputs(self) -> DirectoryContractProbeInputs:
+        return DirectoryContractProbeInputs(
+            present_files=self.presentFiles,
+            required_files=self.requiredFiles,
+            allowed_files=self.allowedFiles,
+            ignored_patterns=self.ignoredPatterns or (),
+        )
+
+
+class _TerminalInputsSchema(_Strict):
+    exitCode: int
+    stdout: str
+    stderr: str
+    expectedExitCode: int | None = None
+    requiredStdoutPatterns: _PatternList | None = None
+    forbiddenStdoutPatterns: _PatternList | None = None
+    requiredStderrPatterns: _PatternList | None = None
+    forbiddenStderrPatterns: _PatternList | None = None
+
+    def to_inputs(self) -> TerminalContractProbeInputs:
+        return TerminalContractProbeInputs(
+            exit_code=self.exitCode,
+            stdout=self.stdout,
+            stderr=self.stderr,
+            expected_exit_code=self.expectedExitCode,
+            required_stdout_patterns=self.requiredStdoutPatterns or (),
+            forbidden_stdout_patterns=self.forbiddenStdoutPatterns or (),
+            required_stderr_patterns=self.requiredStderrPatterns or (),
+            forbidden_stderr_patterns=self.forbiddenStderrPatterns or (),
+        )
+
+
+class _ServiceEndpointSchema(_Strict):
+    host: str
+    port: int
+    protocol: Literal["tcp", "udp"] | None = None
+
+    def to_inputs(self) -> ServiceEndpointObservation:
+        return ServiceEndpointObservation(host=self.host, port=self.port, protocol=self.protocol)
+
+
+class _ServiceInputsSchema(_Strict):
+    observed: tuple[_ServiceEndpointSchema, ...] = ()
+    required: tuple[_ServiceEndpointSchema, ...] = ()
+    allowed: tuple[_ServiceEndpointSchema, ...] | None = None
+
+    def to_inputs(self) -> ServiceContractProbeInputs:
+        return ServiceContractProbeInputs(
+            observed=tuple(e.to_inputs() for e in self.observed),
+            required=tuple(e.to_inputs() for e in self.required),
+            allowed=None if self.allowed is None else tuple(e.to_inputs() for e in self.allowed),
+        )
+
+
+class _ArtifactInputsSchema(_Strict):
+    path: str
+    content: str
+    expectedLineEnding: Literal["lf", "crlf"] | None = None
+    requiredSubstrings: tuple[str, ...] | None = None
+    forbiddenSubstrings: tuple[str, ...] | None = None
+    requiredJsonFields: tuple[str, ...] | None = None
+
+    def to_inputs(self) -> ArtifactContractProbeInputs:
+        return ArtifactContractProbeInputs(
+            path=self.path,
+            content=self.content,
+            expected_line_ending=self.expectedLineEnding,
+            required_substrings=self.requiredSubstrings or (),
+            forbidden_substrings=self.forbiddenSubstrings or (),
+            required_json_fields=self.requiredJsonFields or (),
+        )
+
+
+class _CleanupEntrySchema(_Strict):
+    path: str
+    isSymlink: bool | None = None
+    symlinkTarget: str | None = None
+    symlinkBroken: bool | None = None
+    mtime: datetime | None = None
+
+    def to_inputs(self) -> CleanupFileEntry:
+        return CleanupFileEntry(
+            path=self.path,
+            is_symlink=bool(self.isSymlink),
+            symlink_target=self.symlinkTarget,
+            symlink_broken=bool(self.symlinkBroken),
+            mtime=self.mtime,
+        )
+
+
+class _CleanupInputsSchema(_Strict):
+    entries: tuple[_CleanupEntrySchema, ...] = ()
+    now: datetime | None = None
+    maxLockfileAgeMs: int | None = None
+    lockfilePatterns: _PatternList | None = None
+    sidecarPatterns: _PatternList | None = None
+    backupPatterns: _PatternList | None = None
+    forbidSymlinks: bool | None = None
+    allowedSymlinkTargets: tuple[str, ...] | None = None
+    ignoredPatterns: _PatternList | None = None
+
+    def to_inputs(self) -> CleanupContractProbeInputs:
+        return CleanupContractProbeInputs(
+            entries=tuple(e.to_inputs() for e in self.entries),
+            now=self.now,
+            max_lockfile_age_ms=self.maxLockfileAgeMs,
+            lockfile_patterns=self.lockfilePatterns,
+            sidecar_patterns=self.sidecarPatterns,
+            backup_patterns=self.backupPatterns,
+            forbid_symlinks=bool(self.forbidSymlinks),
+            allowed_symlink_targets=self.allowedSymlinkTargets,
+            ignored_patterns=self.ignoredPatterns or (),
+        )
+
+
+class _MediaInputsSchema(_Strict):
+    path: str
+    headerBytes: tuple[int, ...] | None = None
+    expectedMagicBytes: tuple[int, ...] | None = None
+    width: int | None = None
+    height: int | None = None
+    expectedWidth: int | None = None
+    expectedHeight: int | None = None
+    byteSize: int | None = None
+    minByteSize: int | None = None
+    maxByteSize: int | None = None
+    columnCount: int | None = None
+    expectedColumnCount: int | None = None
+    columnNames: tuple[str, ...] | None = None
+    requiredColumnNames: tuple[str, ...] | None = None
+    lineCount: int | None = None
+    expectedLineCount: int | None = None
+
+    def to_inputs(self) -> MediaContractProbeInputs:
+        return MediaContractProbeInputs(
+            path=self.path,
+            header_bytes=self.headerBytes,
+            expected_magic_bytes=self.expectedMagicBytes,
+            width=self.width,
+            height=self.height,
+            expected_width=self.expectedWidth,
+            expected_height=self.expectedHeight,
+            byte_size=self.byteSize,
+            min_byte_size=self.minByteSize,
+            max_byte_size=self.maxByteSize,
+            column_count=self.columnCount,
+            expected_column_count=self.expectedColumnCount,
+            column_names=self.columnNames,
+            required_column_names=self.requiredColumnNames,
+            line_count=self.lineCount,
+            expected_line_count=self.expectedLineCount,
+        )
+
+
+class _DistributedRankSchema(_Strict):
+    rank: int
+    steps: int | None = None
+    observations: dict[str, str] | None = None
+
+    def to_inputs(self) -> DistributedRankReport:
+        return DistributedRankReport(rank=self.rank, steps=self.steps, observations=self.observations)
+
+
+class _DistributedInputsSchema(_Strict):
+    ranks: tuple[_DistributedRankSchema, ...] = ()
+    worldSize: int | None = None
+    expectedWorldSize: int | None = None
+    expectedSteps: int | None = None
+    mustMatchAcrossRanks: tuple[str, ...] | None = None
+
+    def to_inputs(self) -> DistributedContractProbeInputs:
+        return DistributedContractProbeInputs(
+            ranks=tuple(r.to_inputs() for r in self.ranks),
+            world_size=self.worldSize,
+            expected_world_size=self.expectedWorldSize,
+            expected_steps=self.expectedSteps,
+            must_match_across_ranks=self.mustMatchAcrossRanks,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Discriminated invocation envelope
+# ---------------------------------------------------------------------------
+
+
+class _DirectoryInvocation(_Strict):
+    kind: Literal["directory"]
+    label: str | None = None
+    inputs: _DirectoryInputsSchema
+
+
+class _TerminalInvocation(_Strict):
+    kind: Literal["terminal"]
+    label: str | None = None
+    inputs: _TerminalInputsSchema
+
+
+class _ServiceInvocation(_Strict):
+    kind: Literal["service"]
+    label: str | None = None
+    inputs: _ServiceInputsSchema
+
+
+class _ArtifactInvocation(_Strict):
+    kind: Literal["artifact"]
+    label: str | None = None
+    inputs: _ArtifactInputsSchema
+
+
+class _CleanupInvocation(_Strict):
+    kind: Literal["cleanup"]
+    label: str | None = None
+    inputs: _CleanupInputsSchema
+
+
+class _MediaInvocation(_Strict):
+    kind: Literal["media"]
+    label: str | None = None
+    inputs: _MediaInputsSchema
+
+
+class _DistributedInvocation(_Strict):
+    kind: Literal["distributed"]
+    label: str | None = None
+    inputs: _DistributedInputsSchema
+
+
+_InvocationUnion = (
+    _DirectoryInvocation
+    | _TerminalInvocation
+    | _ServiceInvocation
+    | _ArtifactInvocation
+    | _CleanupInvocation
+    | _MediaInvocation
+    | _DistributedInvocation
+)
+ContractProbeInvocation = Annotated[_InvocationUnion, Field(discriminator="kind")]
+
+
+class ContractProbeSuite(_Strict):
+    """JSON wire-format suite envelope."""
+
+    schema_version: Literal[1]
+    probes: tuple[ContractProbeInvocation, ...]
+
+    @field_validator("probes", mode="before")
+    @classmethod
+    def _coerce_probes(cls, value: object, _info: ValidationInfo) -> object:
+        # Pydantic accepts list-of-dicts directly; this validator only
+        # exists to surface a clear error if the field is missing entirely.
+        if value is None:
+            return ()
+        return value
+
+
+ContractProbeSuiteSchema = ContractProbeSuite
+
+
+# ---------------------------------------------------------------------------
+# Run-result discriminated union
+# ---------------------------------------------------------------------------
+
+
+class _ResultBase(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", arbitrary_types_allowed=True)
+    label: str | None = None
+    passed: bool
+
+
+class DirectoryRunResult(_ResultBase):
+    kind: Literal["directory"] = "directory"
+    failures: tuple[DirectoryContractFailure, ...]
+
+
+class TerminalRunResult(_ResultBase):
+    kind: Literal["terminal"] = "terminal"
+    failures: tuple[TerminalContractFailure, ...]
+
+
+class ServiceRunResult(_ResultBase):
+    kind: Literal["service"] = "service"
+    failures: tuple[ServiceContractFailure, ...]
+
+
+class ArtifactRunResult(_ResultBase):
+    kind: Literal["artifact"] = "artifact"
+    failures: tuple[ArtifactContractFailure, ...]
+
+
+class CleanupRunResult(_ResultBase):
+    kind: Literal["cleanup"] = "cleanup"
+    failures: tuple[CleanupContractFailure, ...]
+
+
+class MediaRunResult(_ResultBase):
+    kind: Literal["media"] = "media"
+    failures: tuple[MediaContractFailure, ...]
+
+
+class DistributedRunResult(_ResultBase):
+    kind: Literal["distributed"] = "distributed"
+    failures: tuple[DistributedContractFailure, ...]
+
+
+ContractProbeRunResult = Annotated[
+    DirectoryRunResult
+    | TerminalRunResult
+    | ServiceRunResult
+    | ArtifactRunResult
+    | CleanupRunResult
+    | MediaRunResult
+    | DistributedRunResult,
+    Field(discriminator="kind"),
+]
+
+
+class ContractProbeSuiteResult(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", arbitrary_types_allowed=True)
+    passed: bool
+    results: tuple[ContractProbeRunResult, ...]
+
+
+# ---------------------------------------------------------------------------
+# Runner + loader
+# ---------------------------------------------------------------------------
+
+
+def run_contract_probe_suite(suite: ContractProbeSuite) -> ContractProbeSuiteResult:
+    """Dispatch each invocation through the matching probe and aggregate."""
+    results: list[ContractProbeRunResult] = []
+    for invocation in suite.probes:
+        match invocation:
+            case _DirectoryInvocation():
+                r = probe_directory_contract(invocation.inputs.to_inputs())
+                results.append(DirectoryRunResult(label=invocation.label, passed=r.passed, failures=r.failures))
+            case _TerminalInvocation():
+                tr = probe_terminal_contract(invocation.inputs.to_inputs())
+                results.append(TerminalRunResult(label=invocation.label, passed=tr.passed, failures=tr.failures))
+            case _ServiceInvocation():
+                sr = probe_service_contract(invocation.inputs.to_inputs())
+                results.append(ServiceRunResult(label=invocation.label, passed=sr.passed, failures=sr.failures))
+            case _ArtifactInvocation():
+                ar = probe_artifact_contract(invocation.inputs.to_inputs())
+                results.append(ArtifactRunResult(label=invocation.label, passed=ar.passed, failures=ar.failures))
+            case _CleanupInvocation():
+                cr = probe_cleanup_contract(invocation.inputs.to_inputs())
+                results.append(CleanupRunResult(label=invocation.label, passed=cr.passed, failures=cr.failures))
+            case _MediaInvocation():
+                mr = probe_media_contract(invocation.inputs.to_inputs())
+                results.append(MediaRunResult(label=invocation.label, passed=mr.passed, failures=mr.failures))
+            case _DistributedInvocation():
+                dr = probe_distributed_contract(invocation.inputs.to_inputs())
+                results.append(DistributedRunResult(label=invocation.label, passed=dr.passed, failures=dr.failures))
+    return ContractProbeSuiteResult(
+        passed=all(r.passed for r in results),
+        results=tuple(results),
+    )
+
+
+def load_contract_probe_suite(path: str | Path) -> ContractProbeSuite:
+    """Load a JSON file and validate it against the suite schema."""
+    raw = Path(path).read_text(encoding="utf-8")
+    parsed = json.loads(raw)
+    return ContractProbeSuite.model_validate(parsed)

--- a/autocontext/src/autocontext/control_plane/contract_probes/runner.py
+++ b/autocontext/src/autocontext/control_plane/contract_probes/runner.py
@@ -35,8 +35,9 @@ from pydantic import (
     BeforeValidator,
     ConfigDict,
     Field,
-    ValidationInfo,
-    field_validator,
+    StrictBool,
+    StrictInt,
+    model_validator,
 )
 
 from ._advanced import (
@@ -158,13 +159,44 @@ _PatternList = Annotated[tuple[re.Pattern[str], ...], BeforeValidator(_coerce_pa
 
 
 class _Strict(BaseModel):
+    """Base for every JSON-shape model.
+
+    - ``extra="forbid"``: unknown keys reject. Mirrors TS `.strict()`.
+    - ``arbitrary_types_allowed=True``: lets compiled ``re.Pattern[str]``
+      ride through after the ``_coerce_patterns`` BeforeValidator.
+
+    Primitive coercion is blocked per-field via ``StrictInt`` /
+    ``StrictBool`` (PR #1006 review P3). String -> string is a no-op
+    so plain ``str`` is fine; we want lists -> tuples to keep
+    working, so the model is not blanket-strict.
+    """
+
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_explicit_null(cls, data: object) -> object:
+        # PR #1006 review P2: TS `.optional()` accepts omission but
+        # not `null`. Python should reject explicit nulls so a
+        # broken extractor cannot weaken declared expectations by
+        # writing `requiredStdoutPatterns: null`.
+        if isinstance(data, dict):
+            nulls = [k for k, v in data.items() if v is None and k in cls.model_fields]
+            if nulls:
+                fields = ", ".join(sorted(nulls))
+                raise ValueError(
+                    f"explicit null not allowed for optional field(s): {fields}; omit the key to disable the expectation"
+                )
+        return data
 
 
 class _DirectoryInputsSchema(_Strict):
-    presentFiles: tuple[str, ...] = ()
-    requiredFiles: tuple[str, ...] = ()
-    allowedFiles: tuple[str, ...] = ()
+    # PR #1006 review P2: TS marks these fields required (not optional).
+    # A broken extractor that omits observations should fail validation,
+    # not silently turn into an empty-passing suite.
+    presentFiles: tuple[str, ...]
+    requiredFiles: tuple[str, ...]
+    allowedFiles: tuple[str, ...]
     ignoredPatterns: _PatternList | None = None
 
     def to_inputs(self) -> DirectoryContractProbeInputs:
@@ -177,10 +209,12 @@ class _DirectoryInputsSchema(_Strict):
 
 
 class _TerminalInputsSchema(_Strict):
-    exitCode: int
+    # PR #1006 review P3: use Strict* so the JSON schema rejects
+    # `"exitCode": "0"` etc rather than coercing them silently.
+    exitCode: StrictInt
     stdout: str
     stderr: str
-    expectedExitCode: int | None = None
+    expectedExitCode: StrictInt | None = None
     requiredStdoutPatterns: _PatternList | None = None
     forbiddenStdoutPatterns: _PatternList | None = None
     requiredStderrPatterns: _PatternList | None = None
@@ -201,7 +235,7 @@ class _TerminalInputsSchema(_Strict):
 
 class _ServiceEndpointSchema(_Strict):
     host: str
-    port: int
+    port: StrictInt
     protocol: Literal["tcp", "udp"] | None = None
 
     def to_inputs(self) -> ServiceEndpointObservation:
@@ -209,8 +243,9 @@ class _ServiceEndpointSchema(_Strict):
 
 
 class _ServiceInputsSchema(_Strict):
-    observed: tuple[_ServiceEndpointSchema, ...] = ()
-    required: tuple[_ServiceEndpointSchema, ...] = ()
+    # PR #1006 review P2: TS marks `observed` + `required` required.
+    observed: tuple[_ServiceEndpointSchema, ...]
+    required: tuple[_ServiceEndpointSchema, ...]
     allowed: tuple[_ServiceEndpointSchema, ...] | None = None
 
     def to_inputs(self) -> ServiceContractProbeInputs:
@@ -242,9 +277,9 @@ class _ArtifactInputsSchema(_Strict):
 
 class _CleanupEntrySchema(_Strict):
     path: str
-    isSymlink: bool | None = None
+    isSymlink: StrictBool | None = None
     symlinkTarget: str | None = None
-    symlinkBroken: bool | None = None
+    symlinkBroken: StrictBool | None = None
     mtime: datetime | None = None
 
     def to_inputs(self) -> CleanupFileEntry:
@@ -258,13 +293,14 @@ class _CleanupEntrySchema(_Strict):
 
 
 class _CleanupInputsSchema(_Strict):
-    entries: tuple[_CleanupEntrySchema, ...] = ()
+    # PR #1006 review P2: TS marks `entries` required.
+    entries: tuple[_CleanupEntrySchema, ...]
     now: datetime | None = None
-    maxLockfileAgeMs: int | None = None
+    maxLockfileAgeMs: StrictInt | None = None
     lockfilePatterns: _PatternList | None = None
     sidecarPatterns: _PatternList | None = None
     backupPatterns: _PatternList | None = None
-    forbidSymlinks: bool | None = None
+    forbidSymlinks: StrictBool | None = None
     allowedSymlinkTargets: tuple[str, ...] | None = None
     ignoredPatterns: _PatternList | None = None
 
@@ -284,21 +320,21 @@ class _CleanupInputsSchema(_Strict):
 
 class _MediaInputsSchema(_Strict):
     path: str
-    headerBytes: tuple[int, ...] | None = None
-    expectedMagicBytes: tuple[int, ...] | None = None
-    width: int | None = None
-    height: int | None = None
-    expectedWidth: int | None = None
-    expectedHeight: int | None = None
-    byteSize: int | None = None
-    minByteSize: int | None = None
-    maxByteSize: int | None = None
-    columnCount: int | None = None
-    expectedColumnCount: int | None = None
+    headerBytes: tuple[StrictInt, ...] | None = None
+    expectedMagicBytes: tuple[StrictInt, ...] | None = None
+    width: StrictInt | None = None
+    height: StrictInt | None = None
+    expectedWidth: StrictInt | None = None
+    expectedHeight: StrictInt | None = None
+    byteSize: StrictInt | None = None
+    minByteSize: StrictInt | None = None
+    maxByteSize: StrictInt | None = None
+    columnCount: StrictInt | None = None
+    expectedColumnCount: StrictInt | None = None
     columnNames: tuple[str, ...] | None = None
     requiredColumnNames: tuple[str, ...] | None = None
-    lineCount: int | None = None
-    expectedLineCount: int | None = None
+    lineCount: StrictInt | None = None
+    expectedLineCount: StrictInt | None = None
 
     def to_inputs(self) -> MediaContractProbeInputs:
         return MediaContractProbeInputs(
@@ -322,8 +358,8 @@ class _MediaInputsSchema(_Strict):
 
 
 class _DistributedRankSchema(_Strict):
-    rank: int
-    steps: int | None = None
+    rank: StrictInt
+    steps: StrictInt | None = None
     observations: dict[str, str] | None = None
 
     def to_inputs(self) -> DistributedRankReport:
@@ -331,10 +367,11 @@ class _DistributedRankSchema(_Strict):
 
 
 class _DistributedInputsSchema(_Strict):
-    ranks: tuple[_DistributedRankSchema, ...] = ()
-    worldSize: int | None = None
-    expectedWorldSize: int | None = None
-    expectedSteps: int | None = None
+    # PR #1006 review P2: TS marks `ranks` required.
+    ranks: tuple[_DistributedRankSchema, ...]
+    worldSize: StrictInt | None = None
+    expectedWorldSize: StrictInt | None = None
+    expectedSteps: StrictInt | None = None
     mustMatchAcrossRanks: tuple[str, ...] | None = None
 
     def to_inputs(self) -> DistributedContractProbeInputs:
@@ -407,19 +444,17 @@ ContractProbeInvocation = Annotated[_InvocationUnion, Field(discriminator="kind"
 
 
 class ContractProbeSuite(_Strict):
-    """JSON wire-format suite envelope."""
+    """JSON wire-format suite envelope.
+
+    Both fields are required. PR #1006 review P2: ``probes: null``
+    used to coerce to an empty passing suite; the explicit-null
+    rejection in ``_Strict._reject_explicit_null`` plus the lack of
+    a default here makes ``null`` and omission both fail validation
+    (TS rejects ``null`` the same way).
+    """
 
     schema_version: Literal[1]
     probes: tuple[ContractProbeInvocation, ...]
-
-    @field_validator("probes", mode="before")
-    @classmethod
-    def _coerce_probes(cls, value: object, _info: ValidationInfo) -> object:
-        # Pydantic accepts list-of-dicts directly; this validator only
-        # exists to surface a clear error if the field is missing entirely.
-        if value is None:
-            return ()
-        return value
 
 
 ContractProbeSuiteSchema = ContractProbeSuite

--- a/autocontext/tests/control_plane/test_contract_probes_runner.py
+++ b/autocontext/tests/control_plane/test_contract_probes_runner.py
@@ -1,0 +1,303 @@
+"""AC-728 contract-probe suite runner (Python parity, slice 3) tests.
+
+Mirrors the test surface of
+``ts/tests/control-plane/contract-probes/contract-probes.test.ts``
+for the runner / schema split shipped in TS PR #990.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from autocontext.control_plane.contract_probes import (
+    ContractProbeSuite,
+    ContractProbeSuiteSchema,
+    load_contract_probe_suite,
+    run_contract_probe_suite,
+)
+
+
+def _suite(*probes: dict) -> ContractProbeSuite:
+    return ContractProbeSuiteSchema.model_validate({"schema_version": 1, "probes": probes})
+
+
+# ---------------------------------------------------------------------------
+# schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_suite_passes() -> None:
+    result = run_contract_probe_suite(_suite())
+    assert result.passed is True
+    assert result.results == ()
+
+
+def test_unknown_probe_kind_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _suite({"kind": "unknown", "inputs": {}})
+
+
+def test_schema_version_must_be_one() -> None:
+    with pytest.raises(ValidationError):
+        ContractProbeSuiteSchema.model_validate({"schema_version": 2, "probes": []})
+
+
+def test_extra_keys_at_invocation_level_rejected() -> None:
+    """Mirrors TS `.strict()`: a typo at the invocation envelope (e.g.
+    `inputs2`) must fail validation rather than be silently dropped."""
+    with pytest.raises(ValidationError):
+        _suite({"kind": "terminal", "inputs": {"exitCode": 0, "stdout": "", "stderr": ""}, "inputs2": {}})
+
+
+def test_extra_keys_inside_probe_inputs_rejected() -> None:
+    """`requiredStdoutPattern` (missing the trailing `s`) must reject,
+    not silently disappear with an `passed: true` outcome."""
+    with pytest.raises(ValidationError):
+        _suite(
+            {
+                "kind": "terminal",
+                "inputs": {
+                    "exitCode": 0,
+                    "stdout": "",
+                    "stderr": "",
+                    "requiredStdoutPattern": "x",  # typo
+                },
+            }
+        )
+
+
+def test_regexp_string_form_compiles() -> None:
+    suite = _suite(
+        {
+            "kind": "terminal",
+            "inputs": {
+                "exitCode": 0,
+                "stdout": "trace.foo",
+                "stderr": "",
+                "requiredStdoutPatterns": [r"^trace\."],
+            },
+        }
+    )
+    result = run_contract_probe_suite(suite)
+    assert result.passed is True
+
+
+def test_regexp_object_form_with_flags_compiles() -> None:
+    suite = _suite(
+        {
+            "kind": "terminal",
+            "inputs": {
+                "exitCode": 0,
+                "stdout": "TRACE.foo",
+                "stderr": "",
+                "requiredStdoutPatterns": [{"source": "trace", "flags": "i"}],
+            },
+        }
+    )
+    result = run_contract_probe_suite(suite)
+    assert result.passed is True
+
+
+def test_invalid_regexp_surfaces_validation_error() -> None:
+    with pytest.raises(ValidationError):
+        _suite(
+            {
+                "kind": "terminal",
+                "inputs": {
+                    "exitCode": 0,
+                    "stdout": "",
+                    "stderr": "",
+                    "requiredStdoutPatterns": ["[invalid"],
+                },
+            }
+        )
+
+
+def test_iso_date_string_parses_to_datetime() -> None:
+    suite = _suite(
+        {
+            "kind": "cleanup",
+            "inputs": {
+                "entries": [{"path": "a.lock", "mtime": "2026-01-01T00:00:00Z"}],
+                "now": "2026-06-01T00:00:00Z",
+                "maxLockfileAgeMs": 1_000,
+            },
+        }
+    )
+    result = run_contract_probe_suite(suite)
+    assert result.passed is False
+    assert result.results[0].kind == "cleanup"
+    assert any(f.kind == "stale-lockfile" for f in result.results[0].failures)
+
+
+def test_malformed_date_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _suite(
+            {
+                "kind": "cleanup",
+                "inputs": {
+                    "entries": [{"path": "a.lock", "mtime": "not-a-date"}],
+                },
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# exhaustive 7-kind dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_exhaustive_seven_kind_dispatch_all_pass() -> None:
+    suite = _suite(
+        {
+            "kind": "directory",
+            "label": "d",
+            "inputs": {"presentFiles": ["a"], "requiredFiles": ["a"], "allowedFiles": ["a"]},
+        },
+        {
+            "kind": "terminal",
+            "label": "t",
+            "inputs": {"exitCode": 0, "stdout": "ok", "stderr": ""},
+        },
+        {
+            "kind": "service",
+            "label": "svc",
+            "inputs": {
+                "observed": [{"host": "127.0.0.1", "port": 8000}],
+                "required": [{"host": "127.0.0.1", "port": 8000}],
+            },
+        },
+        {
+            "kind": "artifact",
+            "label": "art",
+            "inputs": {"path": "out.json", "content": '{"ok": true}'},
+        },
+        {"kind": "cleanup", "label": "cl", "inputs": {"entries": [{"path": "a.txt"}]}},
+        {"kind": "media", "label": "m", "inputs": {"path": "x.bin"}},
+        {
+            "kind": "distributed",
+            "label": "dist",
+            "inputs": {"ranks": [{"rank": 0}], "worldSize": 1},
+        },
+    )
+    result = run_contract_probe_suite(suite)
+    assert result.passed is True
+    kinds = [r.kind for r in result.results]
+    assert kinds == [
+        "directory",
+        "terminal",
+        "service",
+        "artifact",
+        "cleanup",
+        "media",
+        "distributed",
+    ]
+    # Labels round-trip into the result envelope.
+    assert [r.label for r in result.results] == ["d", "t", "svc", "art", "cl", "m", "dist"]
+
+
+def test_suite_passed_is_and_across_probes() -> None:
+    suite = _suite(
+        {
+            "kind": "terminal",
+            "inputs": {"exitCode": 0, "stdout": "", "stderr": ""},
+        },
+        {
+            "kind": "terminal",
+            "inputs": {"exitCode": 1, "stdout": "", "stderr": ""},  # fails
+        },
+    )
+    result = run_contract_probe_suite(suite)
+    assert result.passed is False
+    assert result.results[0].passed is True
+    assert result.results[1].passed is False
+
+
+def test_failure_entries_preserve_kind_specific_typed_fields() -> None:
+    """Each result variant preserves the probe's typed failure fields.
+    Mirrors the TS discriminated-union shape."""
+    suite = _suite(
+        {
+            "kind": "distributed",
+            "label": "x",
+            "inputs": {
+                "ranks": [
+                    {"rank": 0, "observations": {"loss": "0.1"}},
+                    {"rank": 1, "observations": {"loss": "0.2"}},
+                ],
+                "mustMatchAcrossRanks": ["loss"],
+            },
+        }
+    )
+    result = run_contract_probe_suite(suite)
+    distributed = result.results[0]
+    assert distributed.kind == "distributed"
+    diverge = [f for f in distributed.failures if f.kind == "rank-divergence"]
+    assert diverge and diverge[0].key == "loss"
+
+
+# ---------------------------------------------------------------------------
+# file loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_contract_probe_suite_round_trips_a_json_file(tmp_path: Path) -> None:
+    suite_path = tmp_path / "suite.json"
+    suite_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "probes": [
+                    {
+                        "kind": "terminal",
+                        "inputs": {"exitCode": 0, "stdout": "ok", "stderr": ""},
+                    }
+                ],
+            }
+        )
+    )
+    suite = load_contract_probe_suite(suite_path)
+    result = run_contract_probe_suite(suite)
+    assert result.passed is True
+
+
+def test_load_contract_probe_suite_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_contract_probe_suite(tmp_path / "nope.json")
+
+
+def test_load_contract_probe_suite_malformed_json_raises(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    with pytest.raises(json.JSONDecodeError):
+        load_contract_probe_suite(bad)
+
+
+# ---------------------------------------------------------------------------
+# helpers anchor
+# ---------------------------------------------------------------------------
+
+
+def test_utc_datetime_round_trips() -> None:
+    """Sanity: cleanup mtime parsing actually puts a tz-aware datetime
+    into the underlying probe inputs."""
+    suite = _suite(
+        {
+            "kind": "cleanup",
+            "inputs": {
+                "entries": [{"path": "a.lock", "mtime": "2026-01-01T00:00:00Z"}],
+                "now": "2026-01-01T00:00:00Z",
+                "maxLockfileAgeMs": 60_000,
+            },
+        }
+    )
+    result = run_contract_probe_suite(suite)
+    # mtime equals now -> no stale-lockfile failure.
+    assert result.passed is True
+    # And the round-trip preserved tz-awareness.
+    assert datetime(2026, 1, 1, tzinfo=UTC).tzinfo is not None

--- a/autocontext/tests/control_plane/test_contract_probes_runner.py
+++ b/autocontext/tests/control_plane/test_contract_probes_runner.py
@@ -135,6 +135,113 @@ def test_iso_date_string_parses_to_datetime() -> None:
     assert any(f.kind == "stale-lockfile" for f in result.results[0].failures)
 
 
+def test_probes_null_rejected() -> None:
+    """PR #1006 review (P2): a `probes: null` envelope used to coerce
+    to an empty passing suite. The schema now rejects it loudly so
+    corrupted JSON cannot present as a green empty run.
+    """
+    with pytest.raises(ValidationError):
+        ContractProbeSuiteSchema.model_validate({"schema_version": 1, "probes": None})
+
+
+def test_required_observation_fields_must_be_present() -> None:
+    """PR #1006 review (P2): TS-required fields like `presentFiles`,
+    `observed`, `entries`, `ranks` were optional in the Python
+    schema. A broken extractor that omitted them would silently
+    produce passing suites. They now reject as missing.
+    """
+    # directory: presentFiles / requiredFiles / allowedFiles
+    with pytest.raises(ValidationError):
+        _suite(
+            {
+                "kind": "directory",
+                "inputs": {"requiredFiles": [], "allowedFiles": []},
+            }
+        )
+    # service: observed / required
+    with pytest.raises(ValidationError):
+        _suite({"kind": "service", "inputs": {"required": []}})
+    # cleanup: entries
+    with pytest.raises(ValidationError):
+        _suite({"kind": "cleanup", "inputs": {}})
+    # distributed: ranks
+    with pytest.raises(ValidationError):
+        _suite({"kind": "distributed", "inputs": {}})
+
+
+def test_explicit_null_for_optional_expectation_fields_rejected() -> None:
+    """PR #1006 review (P2): TS `.optional()` accepts omission but
+    not `null`. Writing an explicit `null` for an optional expectation
+    used to disable the expectation silently; the schema now rejects
+    explicit nulls on every declared field.
+    """
+    # terminal optional pattern list
+    with pytest.raises(ValidationError):
+        _suite(
+            {
+                "kind": "terminal",
+                "inputs": {
+                    "exitCode": 0,
+                    "stdout": "",
+                    "stderr": "",
+                    "requiredStdoutPatterns": None,
+                },
+            }
+        )
+    # artifact optional substrings
+    with pytest.raises(ValidationError):
+        _suite(
+            {
+                "kind": "artifact",
+                "inputs": {"path": "x", "content": "", "requiredSubstrings": None},
+            }
+        )
+    # distributed optional must-match
+    with pytest.raises(ValidationError):
+        _suite(
+            {
+                "kind": "distributed",
+                "inputs": {"ranks": [], "mustMatchAcrossRanks": None},
+            }
+        )
+
+
+def test_strict_typing_rejects_coerced_primitives() -> None:
+    """PR #1006 review (P3): the schema used to coerce
+    `"exitCode": "0"`, `"port": "8000"`, `"forbidSymlinks": "false"`
+    and so on, mirroring lax Pydantic behaviour. Strict types now
+    reject these forms so bad suite generation surfaces at parse
+    time.
+    """
+    # terminal exitCode must be a real int
+    with pytest.raises(ValidationError):
+        _suite(
+            {
+                "kind": "terminal",
+                "inputs": {"exitCode": "0", "stdout": "", "stderr": ""},
+            }
+        )
+    # service port must be a real int
+    with pytest.raises(ValidationError):
+        _suite(
+            {
+                "kind": "service",
+                "inputs": {
+                    "observed": [{"host": "127.0.0.1", "port": "8000"}],
+                    "required": [],
+                },
+            }
+        )
+    # cleanup forbidSymlinks must be a real bool
+    with pytest.raises(ValidationError):
+        _suite(
+            {
+                "kind": "cleanup",
+                "inputs": {"entries": [], "forbidSymlinks": "false"},
+            }
+        )
+
+
 def test_malformed_date_rejected() -> None:
     with pytest.raises(ValidationError):
         _suite(


### PR DESCRIPTION
## Summary

- Mirrors `ts/src/control-plane/contract-probes/runner.ts` (TS PR #990). New `runner.py` adds `ContractProbeSuiteSchema`, `run_contract_probe_suite`, `load_contract_probe_suite` and the discriminated-union result types.
- JSON wire format: every Pydantic model is `extra="forbid"` so typos like `requiredStdoutPattern` (missing `s`) reject rather than silently disappear. RegExp values accept string or `{source, flags?}`; invalid patterns surface as ValidationError. ISO-8601 dates parse to `datetime`.
- Schema is intentionally separate from the slice-1/2 probe Inputs models (mirroring the TS Zod / interface split). Each JSON-shape schema has a `to_inputs()` method that constructs the canonical `XxxContractProbeInputs`.

## Test plan

- [x] `uv run pytest tests/control_plane/` (69 passed: 47 prior + 22 new)
- [x] `uv run pytest tests/test_module_size_limits.py` clean (runner.py at 533 lines)
- [x] `uv run ruff check` clean
- [x] `uv run mypy src/autocontext/control_plane/` clean
- [ ] CI: green

## Slice plan (7 total)

- slice 1 (#1004, merged): 4 base probes
- slice 2 (#1005, merged): 3 advanced probes + missing-observation invariant
- **slice 3 (this PR)**: suite runner + Pydantic schema
- slice 4: `autoctx probes check` Python CLI (mirrors TS PR #991)
- slice 5: `autoctx probes extract` for 4 base probes (mirrors TS PR #992)
- slice 6: extend extract to cleanup / media / distributed (mirrors TS PR #993)
- slice 7: missing-observation audit close-out