### PR TITLE
feat(evolution): function-slot, domain-aware lessons, island mode for agent-task evolution (AC-776)

### DIFF
--- a/autocontext/src/autocontext/execution/agent_task_evolution.py
+++ b/autocontext/src/autocontext/execution/agent_task_evolution.py
@@ -434,6 +434,8 @@ class AgentTaskEvolutionRunner:
         single-lineage :meth:`run`. ``migrate_every=0`` disables migration
         (pure parallel islands).
         """
+        if num_islands < 1:
+            raise ValueError(f"num_islands must be >= 1, got {num_islands}")
         states = [
             AgentTaskGenerationState(
                 generation=0,

--- a/autocontext/src/autocontext/execution/agent_task_evolution.py
+++ b/autocontext/src/autocontext/execution/agent_task_evolution.py
@@ -32,6 +32,22 @@ class AgentTaskGenerationState(BaseModel):
 
 
 @dataclass(slots=True)
+class LessonSignal:
+    """Structured, evaluator-provided guidance for the next generation.
+
+    Domain-aware lesson accumulation: a deterministic evaluator usually
+    knows *why* a candidate plateaued and *what* to try next (the size
+    delta, which constraints bind, an explicit hint). Carrying that here
+    lets ``accumulate_lessons`` write actionable playbook entries instead
+    of only score + dimension scores.
+    """
+
+    hint: str = ""
+    plateau: bool = False
+    metrics: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
 class AgentTaskGenerationEvaluation:
     """Evaluation result for one cross-generation candidate."""
 
@@ -42,6 +58,7 @@ class AgentTaskGenerationEvaluation:
     round_count: int = 1
     met_threshold: bool = False
     metadata: dict[str, Any] = field(default_factory=dict)
+    lesson_signal: LessonSignal | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,8 +86,14 @@ class FunctionSlot:
 def accumulate_lessons(
     judge_result: AgentTaskResult,
     generation: int,
+    signal: LessonSignal | None = None,
 ) -> str:
-    """Extract a structured lesson from judge feedback for the playbook."""
+    """Extract a structured lesson from judge feedback for the playbook.
+
+    When the evaluator supplies a :class:`LessonSignal`, its actionable
+    guidance (hint, plateau flag, metrics) is rendered alongside the score
+    and dimension scores so the playbook carries move-level direction.
+    """
     parts: list[str] = [f"Generation {generation} (score: {judge_result.score:.2f}):"]
 
     if judge_result.reasoning:
@@ -88,6 +111,18 @@ def accumulate_lessons(
 
     if not judge_result.reasoning and not weak_dims:
         parts.append(f"  Score: {judge_result.score:.2f}")
+
+    if signal is not None:
+        if signal.hint:
+            parts.append(f"  Hint: {signal.hint}")
+        if signal.plateau:
+            parts.append(
+                "  Plateau detected — a structurally different approach is needed; "
+                "incremental tweaks are not advancing the score."
+            )
+        if signal.metrics:
+            metric_strs = [f"{k}={v:g}" for k, v in sorted(signal.metrics.items())]
+            parts.append(f"  Metrics: {', '.join(metric_strs)}")
 
     return "\n".join(parts)
 
@@ -276,7 +311,7 @@ class AgentTaskEvolutionRunner:
             dimension_scores=evaluation.dimension_scores,
         )
 
-        lesson = accumulate_lessons(judge_result, state.generation + 1)
+        lesson = accumulate_lessons(judge_result, state.generation + 1, signal=evaluation.lesson_signal)
         new_playbook = state.playbook
         if lesson:
             new_playbook = (state.playbook + "\n" + lesson).strip() if state.playbook else lesson

--- a/autocontext/src/autocontext/execution/agent_task_evolution.py
+++ b/autocontext/src/autocontext/execution/agent_task_evolution.py
@@ -44,6 +44,28 @@ class AgentTaskGenerationEvaluation:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True, slots=True)
+class FunctionSlot:
+    """A fixed code harness with a small evolved slot (AC-776).
+
+    Function-slot evolution mode keeps the evolved unit small: the runner
+    carries only the slot in state and in the enriched prompt (so prompts
+    stay compact), while evaluation runs the assembled ``harness`` + slot.
+    This avoids the whole-program-bloat failure mode where carrying a large
+    generated artifact in ``best_output`` ballooned every prompt.
+
+    Convention: the slot is *prepended* to the harness, so the harness can
+    reference names the slot defines (e.g. a ``priority`` function the
+    greedy skeleton calls).
+    """
+
+    harness: str
+
+    def assemble(self, slot: str) -> str:
+        """Return the full runnable program: slot prepended to harness."""
+        return f"{slot}\n\n{self.harness}"
+
+
 def accumulate_lessons(
     judge_result: AgentTaskResult,
     generation: int,
@@ -54,28 +76,14 @@ def accumulate_lessons(
     if judge_result.reasoning:
         parts.append(f"  Feedback: {judge_result.reasoning}")
 
-    weak_dims = {
-        dim: score
-        for dim, score in judge_result.dimension_scores.items()
-        if score < 0.7
-    }
+    weak_dims = {dim: score for dim, score in judge_result.dimension_scores.items() if score < 0.7}
     if weak_dims:
-        dim_strs = [
-            f"{dim} ({score:.2f})"
-            for dim, score in sorted(weak_dims.items(), key=lambda x: x[1])
-        ]
+        dim_strs = [f"{dim} ({score:.2f})" for dim, score in sorted(weak_dims.items(), key=lambda x: x[1])]
         parts.append(f"  Weak dimensions: {', '.join(dim_strs)}")
 
-    strong_dims = {
-        dim: score
-        for dim, score in judge_result.dimension_scores.items()
-        if score >= 0.8
-    }
+    strong_dims = {dim: score for dim, score in judge_result.dimension_scores.items() if score >= 0.8}
     if strong_dims:
-        dim_strs = [
-            f"{dim} ({score:.2f})"
-            for dim, score in sorted(strong_dims.items(), key=lambda x: -x[1])
-        ]
+        dim_strs = [f"{dim} ({score:.2f})" for dim, score in sorted(strong_dims.items(), key=lambda x: -x[1])]
         parts.append(f"  Strong dimensions: {', '.join(dim_strs)}")
 
     if not judge_result.reasoning and not weak_dims:
@@ -91,24 +99,28 @@ def build_enriched_prompt(
     generation: int,
     best_output: str,
     best_score: float,
+    harness: str = "",
 ) -> str:
-    """Enrich a task prompt with cross-generation context."""
+    """Enrich a task prompt with cross-generation context.
+
+    In function-slot mode (``harness`` provided), the fixed harness is shown
+    once as stable context so the model knows the contract it writes the slot
+    against. The evolved slot itself is carried via ``best_output``.
+    """
     playbook = compact_prompt_component("agent_task_playbook", playbook)
     best_output = compact_prompt_component("agent_task_best_output", best_output)
     sections: list[str] = [task_prompt]
 
+    if harness:
+        sections.append(f"\n\n## Fixed Harness (do not modify; you write only the slot)\n{harness}")
+
     if playbook:
         sections.append(
-            f"\n\n## Accumulated Lessons (Generation {generation})\n"
-            f"Previous best score: {best_score:.2f}\n\n"
-            f"{playbook}"
+            f"\n\n## Accumulated Lessons (Generation {generation})\nPrevious best score: {best_score:.2f}\n\n{playbook}"
         )
 
     if best_output:
-        sections.append(
-            f"\n\n## Best Previous Output (score {best_score:.2f})\n"
-            f"{best_output}"
-        )
+        sections.append(f"\n\n## Best Previous Output (score {best_score:.2f})\n{best_output}")
 
     if playbook or best_output:
         sections.append(
@@ -141,9 +153,7 @@ class AgentTaskTrajectory(BaseModel):
             f"Improvement: +{self.improvement_delta:.2f}",
         ]
         if len(self.score_history) >= 2:
-            lines.append(
-                f"Trajectory: {' → '.join(f'{score:.2f}' for score in self.score_history)}"
-            )
+            lines.append(f"Trajectory: {' → '.join(f'{score:.2f}' for score in self.score_history)}")
         return "\n".join(lines)
 
     def to_dict(self) -> dict[str, Any]:
@@ -184,8 +194,7 @@ class ScenarioFamilyGuide:
             },
             "schema_evolution": {
                 "when_to_use": (
-                    "Tasks involving schema changes, migrations, and backward "
-                    "compatibility. Best for data and API evolution."
+                    "Tasks involving schema changes, migrations, and backward compatibility. Best for data and API evolution."
                 ),
                 "multi_gen": "Yes — via GenerationRunner.",
             },
@@ -221,12 +230,14 @@ class AgentTaskEvolutionRunner:
         evaluate_fn: EvaluateFn,
         initial_output: str = "",
         task_name: str = "agent_task",
+        slot: FunctionSlot | None = None,
     ) -> None:
         self._task_prompt = task_prompt
         self._generate_fn = generate_fn
         self._evaluate_fn = evaluate_fn
         self._initial_output = initial_output
         self._task_name = task_name
+        self._slot = slot
 
     def run_generation(
         self,
@@ -239,6 +250,7 @@ class AgentTaskEvolutionRunner:
             generation=state.generation + 1,
             best_output=state.best_output,
             best_score=state.best_score,
+            harness=self._slot.harness if self._slot else "",
         )
 
         if state.generation == 0 and self._initial_output:
@@ -248,8 +260,15 @@ class AgentTaskEvolutionRunner:
             if not candidate_output:
                 candidate_output = state.best_output
 
-        evaluation = self._evaluate_fn(candidate_output, state.generation)
-        evaluated_output = evaluation.output.strip() or candidate_output
+        if self._slot is not None:
+            # Function-slot mode: evaluate the assembled harness+slot, but
+            # carry only the small slot forward (no whole-program bloat).
+            assembled = self._slot.assemble(candidate_output)
+            evaluation = self._evaluate_fn(assembled, state.generation)
+            evaluated_output = candidate_output
+        else:
+            evaluation = self._evaluate_fn(candidate_output, state.generation)
+            evaluated_output = evaluation.output.strip() or candidate_output
 
         judge_result = AgentTaskResult(
             score=evaluation.score,
@@ -260,9 +279,7 @@ class AgentTaskEvolutionRunner:
         lesson = accumulate_lessons(judge_result, state.generation + 1)
         new_playbook = state.playbook
         if lesson:
-            new_playbook = (
-                (state.playbook + "\n" + lesson).strip() if state.playbook else lesson
-            )
+            new_playbook = (state.playbook + "\n" + lesson).strip() if state.playbook else lesson
 
         new_best_output = state.best_output
         new_best_score = state.best_score
@@ -322,9 +339,7 @@ class AgentTaskEvolutionRunner:
             cold_start_score=state.score_history[0] if state.score_history else 0.0,
             final_score=state.score_history[-1] if state.score_history else 0.0,
             improvement_delta=round(
-                (state.score_history[-1] - state.score_history[0])
-                if state.score_history
-                else 0.0,
+                (state.score_history[-1] - state.score_history[0]) if state.score_history else 0.0,
                 4,
             ),
             metadata={

--- a/autocontext/src/autocontext/execution/agent_task_evolution.py
+++ b/autocontext/src/autocontext/execution/agent_task_evolution.py
@@ -166,6 +166,34 @@ def build_enriched_prompt(
     return "\n".join(sections)
 
 
+def migrate_states(
+    states: list[AgentTaskGenerationState],
+) -> list[AgentTaskGenerationState]:
+    """Island migration: seed lagging islands with the global champion.
+
+    Each island below the best score adopts the champion's best output and
+    score (so winners propagate), but keeps its own playbook so accumulated
+    lessons stay diverse. The champion island (and any tied) are unchanged.
+    """
+    if not states:
+        return states
+    champion = max(states, key=lambda s: s.best_score)
+    migrated: list[AgentTaskGenerationState] = []
+    for s in states:
+        if s.best_score < champion.best_score:
+            migrated.append(
+                s.model_copy(
+                    update={
+                        "best_output": champion.best_output,
+                        "best_score": champion.best_score,
+                    }
+                )
+            )
+        else:
+            migrated.append(s)
+    return migrated
+
+
 class AgentTaskTrajectory(BaseModel):
     """Trajectory report for a multi-generation agent task run."""
 
@@ -391,3 +419,54 @@ class AgentTaskEvolutionRunner:
         """Run multiple generations and return a trajectory report."""
         trajectory, _ = self.run_with_state(num_generations)
         return trajectory
+
+    def run_islands(
+        self,
+        num_islands: int = 4,
+        num_generations: int = 10,
+        migrate_every: int = 0,
+    ) -> AgentTaskTrajectory:
+        """Run ``num_islands`` parallel lineages, optionally migrating the
+        global champion into laggards every ``migrate_every`` generations.
+
+        Islands preserve diversity (each keeps its own playbook and lineage)
+        while migration shares winners — the population analogue of the
+        single-lineage :meth:`run`. ``migrate_every=0`` disables migration
+        (pure parallel islands).
+        """
+        states = [
+            AgentTaskGenerationState(
+                generation=0,
+                best_output="",
+                best_score=0.0,
+                playbook="",
+                score_history=[],
+                lesson_history=[],
+                metadata={},
+            )
+            for _ in range(num_islands)
+        ]
+
+        best_per_gen: list[float] = []
+        for gen in range(num_generations):
+            states = [self.run_generation(s) for s in states]
+            best_per_gen.append(max(s.best_score for s in states))
+            if migrate_every and (gen + 1) % migrate_every == 0:
+                states = migrate_states(states)
+
+        champion = max(states, key=lambda s: s.best_score)
+        return AgentTaskTrajectory(
+            task_name=self._task_name,
+            total_generations=num_generations,
+            score_history=best_per_gen,
+            lessons_per_generation=[num_islands] * len(best_per_gen),
+            cold_start_score=best_per_gen[0] if best_per_gen else 0.0,
+            final_score=best_per_gen[-1] if best_per_gen else 0.0,
+            improvement_delta=round((best_per_gen[-1] - best_per_gen[0]) if best_per_gen else 0.0, 4),
+            metadata={
+                "best_output": champion.best_output,
+                "best_score": champion.best_score,
+                "num_islands": num_islands,
+                "playbook": champion.playbook,
+            },
+        )

--- a/autocontext/tests/test_agent_task_function_slot.py
+++ b/autocontext/tests/test_agent_task_function_slot.py
@@ -1,0 +1,119 @@
+"""Tests for function-slot evolution mode (AC-776).
+
+The evolved unit is a small slot inside a fixed harness, not a whole
+program. The runner carries only the slot (so enriched prompts stay
+small), but evaluates the assembled harness+slot. This fixes the
+whole-program-bloat failure mode where best_output ballooned the prompt.
+"""
+
+from __future__ import annotations
+
+
+class TestFunctionSlot:
+    def test_assemble_prepends_slot_to_harness(self) -> None:
+        from autocontext.execution.agent_task_evolution import FunctionSlot
+
+        slot = FunctionSlot(harness="def build():\n    return priority")
+        assembled = slot.assemble("def priority(v):\n    return 1.0")
+        assert "def priority(v):" in assembled
+        assert "def build():" in assembled
+        # slot is prepended so the harness can reference it
+        assert assembled.index("def priority(v):") < assembled.index("def build():")
+
+
+class TestRunnerSlotMode:
+    def test_carries_slot_not_assembled_program(self) -> None:
+        from autocontext.execution.agent_task_evolution import (
+            AgentTaskEvolutionRunner,
+            AgentTaskGenerationEvaluation,
+            FunctionSlot,
+        )
+
+        big_harness = "def build():\n    return priority\n" + "# pad\n" * 2000
+        slot = FunctionSlot(harness=big_harness)
+        eval_inputs: list[str] = []
+
+        def gen(prompt: str, g: int) -> str:
+            return "def priority(v):\n    return 2.0"
+
+        def ev(output: str, g: int) -> AgentTaskGenerationEvaluation:
+            eval_inputs.append(output)
+            return AgentTaskGenerationEvaluation(output=output, score=0.5, reasoning="ok")
+
+        runner = AgentTaskEvolutionRunner(
+            task_prompt="t",
+            generate_fn=gen,
+            evaluate_fn=ev,
+            initial_output="def priority(v):\n    return 0.0",
+            slot=slot,
+        )
+        trajectory, state = runner.run_with_state(2)
+
+        # evaluate_fn received the ASSEMBLED program (harness present)
+        assert any("def build():" in inp for inp in eval_inputs)
+        # but the carried best_output is only the SLOT (no harness bloat)
+        assert "def build():" not in state.best_output
+        assert "def priority(v):" in state.best_output
+
+    def test_best_previous_output_section_carries_slot_not_assembled(self) -> None:
+        """The enriched prompt's "Best Previous Output" carries the small
+        slot, never the assembled harness+slot — the anti-bloat guarantee."""
+        from autocontext.execution.agent_task_evolution import (
+            AgentTaskEvolutionRunner,
+            AgentTaskGenerationEvaluation,
+            FunctionSlot,
+        )
+
+        slot = FunctionSlot(harness="def build():\n    return priority  # HARNESS_MARKER")
+        seen_prompts: list[str] = []
+
+        def gen(prompt: str, g: int) -> str:
+            seen_prompts.append(prompt)
+            return "def priority(v):\n    return 1.0  # SLOT_MARKER"
+
+        def ev(output: str, g: int) -> AgentTaskGenerationEvaluation:
+            return AgentTaskGenerationEvaluation(output=output, score=0.5, reasoning="ok")
+
+        runner = AgentTaskEvolutionRunner(
+            task_prompt="t",
+            generate_fn=gen,
+            evaluate_fn=ev,
+            initial_output="def priority(v):\n    return 0.0",
+            slot=slot,
+        )
+        runner.run_with_state(2)
+        assert seen_prompts, "generate_fn should have been called on gen 2"
+        for p in seen_prompts:
+            if "## Best Previous Output" in p:
+                best_section = p.split("## Best Previous Output")[1]
+                # carries a slot (a priority fn), never the assembled harness
+                assert "def priority(v):" in best_section
+                assert "HARNESS_MARKER" not in best_section
+
+
+class TestEnrichedPromptHarness:
+    def test_includes_harness_section_when_provided(self) -> None:
+        from autocontext.execution.agent_task_evolution import build_enriched_prompt
+
+        out = build_enriched_prompt(
+            task_prompt="t",
+            playbook="",
+            generation=1,
+            best_output="",
+            best_score=0.0,
+            harness="HARNESS_CODE_HERE",
+        )
+        assert "HARNESS_CODE_HERE" in out
+        assert "Fixed Harness" in out
+
+    def test_no_harness_section_when_absent(self) -> None:
+        from autocontext.execution.agent_task_evolution import build_enriched_prompt
+
+        out = build_enriched_prompt(
+            task_prompt="t",
+            playbook="",
+            generation=1,
+            best_output="",
+            best_score=0.0,
+        )
+        assert "Fixed Harness" not in out

--- a/autocontext/tests/test_agent_task_islands.py
+++ b/autocontext/tests/test_agent_task_islands.py
@@ -71,6 +71,24 @@ class TestRunIslands:
         # score_history is the per-generation best across islands (non-decreasing)
         assert traj.score_history == sorted(traj.score_history)
 
+    def test_rejects_zero_islands(self) -> None:
+        import pytest
+
+        from autocontext.execution.agent_task_evolution import (
+            AgentTaskEvolutionRunner,
+            AgentTaskGenerationEvaluation,
+        )
+
+        def gen(prompt: str, g: int) -> str:
+            return "x"
+
+        def ev(output: str, g: int) -> AgentTaskGenerationEvaluation:
+            return AgentTaskGenerationEvaluation(output=output, score=0.5, reasoning="ok")
+
+        runner = AgentTaskEvolutionRunner(task_prompt="t", generate_fn=gen, evaluate_fn=ev)
+        with pytest.raises(ValueError, match="num_islands must be >= 1"):
+            runner.run_islands(num_islands=0, num_generations=2)
+
     def test_migration_runs_without_error(self) -> None:
         from autocontext.execution.agent_task_evolution import (
             AgentTaskEvolutionRunner,

--- a/autocontext/tests/test_agent_task_islands.py
+++ b/autocontext/tests/test_agent_task_islands.py
@@ -1,0 +1,88 @@
+"""Tests for population/island mode in agent-task evolution.
+
+Single-lineage evolution re-derives the same local optimum each
+generation. Island mode runs K parallel lineages and periodically
+migrates the global champion into lagging islands — sharing winners
+while preserving per-island playbook diversity.
+"""
+
+from __future__ import annotations
+
+
+def _state(best_output: str, best_score: float):
+    from autocontext.execution.agent_task_evolution import AgentTaskGenerationState
+
+    return AgentTaskGenerationState(
+        generation=1,
+        best_output=best_output,
+        best_score=best_score,
+        playbook=f"playbook-for-{best_output}",
+        score_history=[best_score],
+        lesson_history=["l"],
+    )
+
+
+class TestMigrateStates:
+    def test_champion_copied_into_laggards(self) -> None:
+        from autocontext.execution.agent_task_evolution import migrate_states
+
+        states = [_state("champ", 0.9), _state("weak", 0.4), _state("mid", 0.6)]
+        migrated = migrate_states(states)
+        # every island now holds the champion's best output/score
+        assert all(s.best_score == 0.9 for s in migrated)
+        assert all(s.best_output == "champ" for s in migrated)
+
+    def test_preserves_per_island_playbook(self) -> None:
+        from autocontext.execution.agent_task_evolution import migrate_states
+
+        states = [_state("champ", 0.9), _state("weak", 0.4)]
+        migrated = migrate_states(states)
+        # migration shares the champion artifact but NOT the playbook
+        # (diversity in accumulated lessons is preserved)
+        assert migrated[1].playbook == "playbook-for-weak"
+
+
+class TestRunIslands:
+    def test_returns_trajectory_with_global_best(self) -> None:
+        from autocontext.execution.agent_task_evolution import (
+            AgentTaskEvolutionRunner,
+            AgentTaskGenerationEvaluation,
+        )
+
+        counter = {"n": 0}
+
+        def gen(prompt: str, g: int) -> str:
+            counter["n"] += 1
+            return f"cand{counter['n']}"
+
+        def ev(output: str, g: int) -> AgentTaskGenerationEvaluation:
+            # score grows with the candidate index parsed from the name
+            idx = int(output.replace("cand", "")) if output.startswith("cand") else 0
+            return AgentTaskGenerationEvaluation(output=output, score=min(1.0, 0.1 * idx), reasoning="ok")
+
+        runner = AgentTaskEvolutionRunner(task_prompt="t", generate_fn=gen, evaluate_fn=ev)
+        traj = runner.run_islands(num_islands=3, num_generations=2)
+
+        assert traj.total_generations == 2
+        assert len(traj.score_history) == 2
+        # final reported best equals the max best_score any island reached
+        assert traj.metadata["num_islands"] == 3
+        assert traj.metadata["best_score"] == max(traj.score_history)
+        # score_history is the per-generation best across islands (non-decreasing)
+        assert traj.score_history == sorted(traj.score_history)
+
+    def test_migration_runs_without_error(self) -> None:
+        from autocontext.execution.agent_task_evolution import (
+            AgentTaskEvolutionRunner,
+            AgentTaskGenerationEvaluation,
+        )
+
+        def gen(prompt: str, g: int) -> str:
+            return "x"
+
+        def ev(output: str, g: int) -> AgentTaskGenerationEvaluation:
+            return AgentTaskGenerationEvaluation(output=output, score=0.5, reasoning="ok")
+
+        runner = AgentTaskEvolutionRunner(task_prompt="t", generate_fn=gen, evaluate_fn=ev)
+        traj = runner.run_islands(num_islands=2, num_generations=4, migrate_every=2)
+        assert traj.total_generations == 4

--- a/autocontext/tests/test_agent_task_lesson_signal.py
+++ b/autocontext/tests/test_agent_task_lesson_signal.py
@@ -1,0 +1,84 @@
+"""Tests for domain-aware lesson accumulation.
+
+The evaluator can attach a structured LessonSignal (hint / plateau /
+metrics) to its evaluation. accumulate_lessons consumes it to produce
+actionable playbook lessons, instead of only score + dimension scores.
+"""
+
+from __future__ import annotations
+
+
+def _judge(score: float = 0.95, reasoning: str = "valid"):
+    from autocontext.scenarios.agent_task import AgentTaskResult
+
+    return AgentTaskResult(score=score, reasoning=reasoning, dimension_scores={})
+
+
+class TestLessonSignalInAccumulate:
+    def test_hint_is_included(self) -> None:
+        from autocontext.execution.agent_task_evolution import (
+            LessonSignal,
+            accumulate_lessons,
+        )
+
+        lesson = accumulate_lessons(
+            _judge(),
+            3,
+            signal=LessonSignal(hint="demote some members to admit new points"),
+        )
+        assert "Hint: demote some members to admit new points" in lesson
+
+    def test_plateau_guidance_included(self) -> None:
+        from autocontext.execution.agent_task_evolution import (
+            LessonSignal,
+            accumulate_lessons,
+        )
+
+        lesson = accumulate_lessons(_judge(), 5, signal=LessonSignal(plateau=True))
+        assert "plateau" in lesson.lower()
+
+    def test_metrics_rendered(self) -> None:
+        from autocontext.execution.agent_task_evolution import (
+            LessonSignal,
+            accumulate_lessons,
+        )
+
+        lesson = accumulate_lessons(
+            _judge(),
+            2,
+            signal=LessonSignal(metrics={"size": 224.0, "delta": 0.0}),
+        )
+        assert "size=224" in lesson
+        assert "delta=0" in lesson
+
+    def test_no_signal_matches_legacy_behavior(self) -> None:
+        from autocontext.execution.agent_task_evolution import accumulate_lessons
+
+        lesson = accumulate_lessons(_judge(score=0.6, reasoning="needs work"), 1)
+        assert "Generation 1 (score: 0.60):" in lesson
+        assert "Hint:" not in lesson
+        assert "plateau" not in lesson.lower()
+
+
+class TestRunnerThreadsSignal:
+    def test_signal_flows_into_playbook(self) -> None:
+        from autocontext.execution.agent_task_evolution import (
+            AgentTaskEvolutionRunner,
+            AgentTaskGenerationEvaluation,
+            LessonSignal,
+        )
+
+        def gen(prompt: str, g: int) -> str:
+            return "candidate"
+
+        def ev(output: str, g: int) -> AgentTaskGenerationEvaluation:
+            return AgentTaskGenerationEvaluation(
+                output=output,
+                score=0.5,
+                reasoning="ok",
+                lesson_signal=LessonSignal(hint="try a different family"),
+            )
+
+        runner = AgentTaskEvolutionRunner(task_prompt="t", generate_fn=gen, evaluate_fn=ev)
+        _, state = runner.run_with_state(1)
+        assert "Hint: try a different family" in state.playbook

--- a/ts/src/execution/agent-task-evolution.ts
+++ b/ts/src/execution/agent-task-evolution.ts
@@ -44,6 +44,27 @@ export interface AgentTaskTrajectory {
   metadata: Record<string, unknown>;
 }
 
+/**
+ * A fixed code harness with a small evolved slot (AC-776).
+ *
+ * Function-slot evolution mode keeps the evolved unit small: the runner
+ * carries only the slot in state and in the enriched prompt (so prompts stay
+ * compact), while evaluation runs the assembled harness + slot. This avoids
+ * the whole-program-bloat failure mode where carrying a large generated
+ * artifact in `bestOutput` ballooned every prompt.
+ *
+ * Convention: the slot is prepended to the harness so the harness can
+ * reference names the slot defines.
+ */
+export class FunctionSlot {
+  constructor(public readonly harness: string) {}
+
+  /** Return the full runnable program: slot prepended to harness. */
+  assemble(slot: string): string {
+    return `${slot}\n\n${this.harness}`;
+  }
+}
+
 export type GenerateFn = (prompt: string, generation: number) => string;
 export type EvaluateFn = (output: string, generation: number) => AgentTaskGenerationEvaluation;
 
@@ -82,17 +103,30 @@ export function accumulateLessons(judgeResult: AgentTaskResult, generation: numb
   return parts.join("\n");
 }
 
-/** Enrich a task prompt with cross-generation context. */
+/**
+ * Enrich a task prompt with cross-generation context.
+ *
+ * In function-slot mode (`harness` provided), the fixed harness is shown once
+ * as stable context so the model knows the contract it writes the slot
+ * against. The evolved slot itself is carried via `bestOutput`.
+ */
 export function buildEnrichedPrompt(args: {
   taskPrompt: string;
   playbook: string;
   generation: number;
   bestOutput: string;
   bestScore: number;
+  harness?: string;
 }): string {
   const playbook = compactPromptComponent("agent_task_playbook", args.playbook);
   const bestOutput = compactPromptComponent("agent_task_best_output", args.bestOutput);
   const sections: string[] = [args.taskPrompt];
+
+  if (args.harness) {
+    sections.push(
+      "\n\n## Fixed Harness (do not modify; you write only the slot)\n" + `${args.harness}`,
+    );
+  }
 
   if (playbook) {
     sections.push(
@@ -125,6 +159,7 @@ export class AgentTaskEvolutionRunner {
   private readonly evaluateFn: EvaluateFn;
   private readonly initialOutput: string;
   private readonly taskName: string;
+  private readonly slot: FunctionSlot | undefined;
 
   constructor(args: {
     taskPrompt: string;
@@ -132,12 +167,14 @@ export class AgentTaskEvolutionRunner {
     evaluateFn: EvaluateFn;
     initialOutput?: string;
     taskName?: string;
+    slot?: FunctionSlot;
   }) {
     this.taskPrompt = args.taskPrompt;
     this.generateFn = args.generateFn;
     this.evaluateFn = args.evaluateFn;
     this.initialOutput = args.initialOutput ?? "";
     this.taskName = args.taskName ?? "agent_task";
+    this.slot = args.slot;
   }
 
   runGeneration(state: AgentTaskGenerationState): AgentTaskGenerationState {
@@ -147,6 +184,7 @@ export class AgentTaskEvolutionRunner {
       generation: state.generation + 1,
       bestOutput: state.bestOutput,
       bestScore: state.bestScore,
+      harness: this.slot?.harness,
     });
 
     let candidateOutput: string;
@@ -159,8 +197,17 @@ export class AgentTaskEvolutionRunner {
       }
     }
 
-    const evaluation = this.evaluateFn(candidateOutput, state.generation);
-    const evaluatedOutput = evaluation.output.trim() || candidateOutput;
+    let evaluation: AgentTaskGenerationEvaluation;
+    let evaluatedOutput: string;
+    if (this.slot !== undefined) {
+      // Function-slot mode: evaluate the assembled harness+slot, but carry
+      // only the small slot forward (no whole-program bloat).
+      evaluation = this.evaluateFn(this.slot.assemble(candidateOutput), state.generation);
+      evaluatedOutput = candidateOutput;
+    } else {
+      evaluation = this.evaluateFn(candidateOutput, state.generation);
+      evaluatedOutput = evaluation.output.trim() || candidateOutput;
+    }
 
     const judgeResult: AgentTaskResult = {
       score: evaluation.score,

--- a/ts/src/execution/agent-task-evolution.ts
+++ b/ts/src/execution/agent-task-evolution.ts
@@ -21,6 +21,20 @@ export interface AgentTaskGenerationState {
   metadata: Record<string, unknown>;
 }
 
+/**
+ * Structured, evaluator-provided guidance for the next generation.
+ *
+ * Domain-aware lesson accumulation: a deterministic evaluator usually knows
+ * why a candidate plateaued and what to try next. Carrying that here lets
+ * `accumulateLessons` write actionable playbook entries instead of only
+ * score + dimension scores.
+ */
+export interface LessonSignal {
+  hint?: string;
+  plateau?: boolean;
+  metrics?: Record<string, number>;
+}
+
 /** Evaluation result for one cross-generation candidate. */
 export interface AgentTaskGenerationEvaluation {
   output: string;
@@ -30,6 +44,7 @@ export interface AgentTaskGenerationEvaluation {
   roundCount?: number;
   metThreshold?: boolean;
   metadata?: Record<string, unknown>;
+  lessonSignal?: LessonSignal;
 }
 
 /** Trajectory report for a multi-generation agent task run. */
@@ -72,8 +87,23 @@ function fixed2(value: number): string {
   return value.toFixed(2);
 }
 
-/** Extract a structured lesson from judge feedback for the playbook. */
-export function accumulateLessons(judgeResult: AgentTaskResult, generation: number): string {
+function formatMetric(value: number): string {
+  // Mirror Python's `{v:g}` general format (trims trailing zeros).
+  return Number.isInteger(value) ? String(value) : String(value);
+}
+
+/**
+ * Extract a structured lesson from judge feedback for the playbook.
+ *
+ * When the evaluator supplies a {@link LessonSignal}, its actionable guidance
+ * (hint, plateau flag, metrics) is rendered alongside the score and dimension
+ * scores so the playbook carries move-level direction.
+ */
+export function accumulateLessons(
+  judgeResult: AgentTaskResult,
+  generation: number,
+  signal?: LessonSignal,
+): string {
   const parts: string[] = [`Generation ${generation} (score: ${fixed2(judgeResult.score)}):`];
 
   if (judgeResult.reasoning) {
@@ -98,6 +128,24 @@ export function accumulateLessons(judgeResult: AgentTaskResult, generation: numb
 
   if (!judgeResult.reasoning && weak.length === 0) {
     parts.push(`  Score: ${fixed2(judgeResult.score)}`);
+  }
+
+  if (signal) {
+    if (signal.hint) {
+      parts.push(`  Hint: ${signal.hint}`);
+    }
+    if (signal.plateau) {
+      parts.push(
+        "  Plateau detected — a structurally different approach is needed; " +
+          "incremental tweaks are not advancing the score.",
+      );
+    }
+    if (signal.metrics && Object.keys(signal.metrics).length > 0) {
+      const metricStrs = Object.entries(signal.metrics)
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([k, v]) => `${k}=${formatMetric(v)}`);
+      parts.push(`  Metrics: ${metricStrs.join(", ")}`);
+    }
   }
 
   return parts.join("\n");
@@ -216,7 +264,7 @@ export class AgentTaskEvolutionRunner {
       internalRetries: 0,
     };
 
-    const lesson = accumulateLessons(judgeResult, state.generation + 1);
+    const lesson = accumulateLessons(judgeResult, state.generation + 1, evaluation.lessonSignal);
     let newPlaybook = state.playbook;
     if (lesson) {
       newPlaybook = state.playbook ? `${state.playbook}\n${lesson}`.trim() : lesson;

--- a/ts/src/execution/agent-task-evolution.ts
+++ b/ts/src/execution/agent-task-evolution.ts
@@ -80,8 +80,11 @@ export class FunctionSlot {
   }
 }
 
-export type GenerateFn = (prompt: string, generation: number) => string;
-export type EvaluateFn = (output: string, generation: number) => AgentTaskGenerationEvaluation;
+export type GenerateFn = (prompt: string, generation: number) => string | Promise<string>;
+export type EvaluateFn = (
+  output: string,
+  generation: number,
+) => AgentTaskGenerationEvaluation | Promise<AgentTaskGenerationEvaluation>;
 
 function fixed2(value: number): string {
   return value.toFixed(2);
@@ -249,7 +252,7 @@ export class AgentTaskEvolutionRunner {
     this.slot = args.slot;
   }
 
-  runGeneration(state: AgentTaskGenerationState): AgentTaskGenerationState {
+  async runGeneration(state: AgentTaskGenerationState): Promise<AgentTaskGenerationState> {
     const prompt = buildEnrichedPrompt({
       taskPrompt: this.taskPrompt,
       playbook: state.playbook,
@@ -263,7 +266,7 @@ export class AgentTaskEvolutionRunner {
     if (state.generation === 0 && this.initialOutput) {
       candidateOutput = this.initialOutput;
     } else {
-      candidateOutput = this.generateFn(prompt, state.generation).trim();
+      candidateOutput = (await this.generateFn(prompt, state.generation)).trim();
       if (!candidateOutput) {
         candidateOutput = state.bestOutput;
       }
@@ -274,10 +277,10 @@ export class AgentTaskEvolutionRunner {
     if (this.slot !== undefined) {
       // Function-slot mode: evaluate the assembled harness+slot, but carry
       // only the small slot forward (no whole-program bloat).
-      evaluation = this.evaluateFn(this.slot.assemble(candidateOutput), state.generation);
+      evaluation = await this.evaluateFn(this.slot.assemble(candidateOutput), state.generation);
       evaluatedOutput = candidateOutput;
     } else {
-      evaluation = this.evaluateFn(candidateOutput, state.generation);
+      evaluation = await this.evaluateFn(candidateOutput, state.generation);
       evaluatedOutput = evaluation.output.trim() || candidateOutput;
     }
 
@@ -331,10 +334,10 @@ export class AgentTaskEvolutionRunner {
     };
   }
 
-  runWithState(numGenerations = 10): {
+  async runWithState(numGenerations = 10): Promise<{
     trajectory: AgentTaskTrajectory;
     state: AgentTaskGenerationState;
-  } {
+  }> {
     let state: AgentTaskGenerationState = {
       generation: 0,
       bestOutput: "",
@@ -346,7 +349,7 @@ export class AgentTaskEvolutionRunner {
     };
 
     for (let i = 0; i < numGenerations; i += 1) {
-      state = this.runGeneration(state);
+      state = await this.runGeneration(state);
     }
 
     const sh = state.scoreHistory;
@@ -370,8 +373,8 @@ export class AgentTaskEvolutionRunner {
     return { trajectory, state };
   }
 
-  run(numGenerations = 10): AgentTaskTrajectory {
-    return this.runWithState(numGenerations).trajectory;
+  async run(numGenerations = 10): Promise<AgentTaskTrajectory> {
+    return (await this.runWithState(numGenerations)).trajectory;
   }
 
   /**
@@ -380,16 +383,20 @@ export class AgentTaskEvolutionRunner {
    * preserve diversity (each keeps its own playbook/lineage) while migration
    * shares winners. `migrateEvery = 0` disables migration.
    */
-  runIslands(
+  async runIslands(
     args: {
       numIslands?: number;
       numGenerations?: number;
       migrateEvery?: number;
     } = {},
-  ): AgentTaskTrajectory {
+  ): Promise<AgentTaskTrajectory> {
     const numIslands = args.numIslands ?? 4;
     const numGenerations = args.numGenerations ?? 10;
     const migrateEvery = args.migrateEvery ?? 0;
+
+    if (numIslands < 1) {
+      throw new RangeError(`numIslands must be >= 1, got ${numIslands}`);
+    }
 
     let states: AgentTaskGenerationState[] = Array.from({ length: numIslands }, () => ({
       generation: 0,
@@ -403,7 +410,8 @@ export class AgentTaskEvolutionRunner {
 
     const bestPerGen: number[] = [];
     for (let gen = 0; gen < numGenerations; gen += 1) {
-      states = states.map((s) => this.runGeneration(s));
+      // Islands are independent within a generation — run them concurrently.
+      states = await Promise.all(states.map((s) => this.runGeneration(s)));
       bestPerGen.push(Math.max(...states.map((s) => s.bestScore)));
       if (migrateEvery && (gen + 1) % migrateEvery === 0) {
         states = migrateStates(states);

--- a/ts/src/execution/agent-task-evolution.ts
+++ b/ts/src/execution/agent-task-evolution.ts
@@ -1,0 +1,257 @@
+/**
+ * Multi-generation support for AgentTask scenarios.
+ *
+ * TypeScript port of `autocontext/execution/agent_task_evolution.py` (AC-281),
+ * maintained at behavioral parity with the Python module. The framework's
+ * native multi-generation loop for agent tasks: lesson accumulation,
+ * best-tracking, and enriched prompts carried across generations.
+ */
+
+import { compactPromptComponent } from "../knowledge/semantic-compaction.js";
+import type { AgentTaskResult } from "../types/index.js";
+
+/** Cross-generation state for an agent task evolution run. */
+export interface AgentTaskGenerationState {
+  generation: number;
+  bestOutput: string;
+  bestScore: number;
+  playbook: string;
+  scoreHistory: number[];
+  lessonHistory: string[];
+  metadata: Record<string, unknown>;
+}
+
+/** Evaluation result for one cross-generation candidate. */
+export interface AgentTaskGenerationEvaluation {
+  output: string;
+  score: number;
+  reasoning: string;
+  dimensionScores?: Record<string, number>;
+  roundCount?: number;
+  metThreshold?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+/** Trajectory report for a multi-generation agent task run. */
+export interface AgentTaskTrajectory {
+  taskName: string;
+  totalGenerations: number;
+  scoreHistory: number[];
+  lessonsPerGeneration: number[];
+  coldStartScore: number;
+  finalScore: number;
+  improvementDelta: number;
+  metadata: Record<string, unknown>;
+}
+
+export type GenerateFn = (prompt: string, generation: number) => string;
+export type EvaluateFn = (output: string, generation: number) => AgentTaskGenerationEvaluation;
+
+function fixed2(value: number): string {
+  return value.toFixed(2);
+}
+
+/** Extract a structured lesson from judge feedback for the playbook. */
+export function accumulateLessons(judgeResult: AgentTaskResult, generation: number): string {
+  const parts: string[] = [`Generation ${generation} (score: ${fixed2(judgeResult.score)}):`];
+
+  if (judgeResult.reasoning) {
+    parts.push(`  Feedback: ${judgeResult.reasoning}`);
+  }
+
+  const dims = judgeResult.dimensionScores ?? {};
+
+  const weak = Object.entries(dims).filter(([, s]) => s < 0.7);
+  if (weak.length > 0) {
+    weak.sort((a, b) => a[1] - b[1]);
+    const strs = weak.map(([d, s]) => `${d} (${fixed2(s)})`);
+    parts.push(`  Weak dimensions: ${strs.join(", ")}`);
+  }
+
+  const strong = Object.entries(dims).filter(([, s]) => s >= 0.8);
+  if (strong.length > 0) {
+    strong.sort((a, b) => b[1] - a[1]);
+    const strs = strong.map(([d, s]) => `${d} (${fixed2(s)})`);
+    parts.push(`  Strong dimensions: ${strs.join(", ")}`);
+  }
+
+  if (!judgeResult.reasoning && weak.length === 0) {
+    parts.push(`  Score: ${fixed2(judgeResult.score)}`);
+  }
+
+  return parts.join("\n");
+}
+
+/** Enrich a task prompt with cross-generation context. */
+export function buildEnrichedPrompt(args: {
+  taskPrompt: string;
+  playbook: string;
+  generation: number;
+  bestOutput: string;
+  bestScore: number;
+}): string {
+  const playbook = compactPromptComponent("agent_task_playbook", args.playbook);
+  const bestOutput = compactPromptComponent("agent_task_best_output", args.bestOutput);
+  const sections: string[] = [args.taskPrompt];
+
+  if (playbook) {
+    sections.push(
+      `\n\n## Accumulated Lessons (Generation ${args.generation})\n` +
+        `Previous best score: ${fixed2(args.bestScore)}\n\n` +
+        `${playbook}`,
+    );
+  }
+
+  if (bestOutput) {
+    sections.push(
+      `\n\n## Best Previous Output (score ${fixed2(args.bestScore)})\n` + `${bestOutput}`,
+    );
+  }
+
+  if (playbook || bestOutput) {
+    sections.push(
+      "\n\nUse the accumulated lessons and previous best output as context. " +
+        "Produce an improved version that addresses the identified weaknesses.",
+    );
+  }
+
+  return sections.join("\n");
+}
+
+/** Multi-generation runner for AgentTask scenarios with lesson accumulation. */
+export class AgentTaskEvolutionRunner {
+  private readonly taskPrompt: string;
+  private readonly generateFn: GenerateFn;
+  private readonly evaluateFn: EvaluateFn;
+  private readonly initialOutput: string;
+  private readonly taskName: string;
+
+  constructor(args: {
+    taskPrompt: string;
+    generateFn: GenerateFn;
+    evaluateFn: EvaluateFn;
+    initialOutput?: string;
+    taskName?: string;
+  }) {
+    this.taskPrompt = args.taskPrompt;
+    this.generateFn = args.generateFn;
+    this.evaluateFn = args.evaluateFn;
+    this.initialOutput = args.initialOutput ?? "";
+    this.taskName = args.taskName ?? "agent_task";
+  }
+
+  runGeneration(state: AgentTaskGenerationState): AgentTaskGenerationState {
+    const prompt = buildEnrichedPrompt({
+      taskPrompt: this.taskPrompt,
+      playbook: state.playbook,
+      generation: state.generation + 1,
+      bestOutput: state.bestOutput,
+      bestScore: state.bestScore,
+    });
+
+    let candidateOutput: string;
+    if (state.generation === 0 && this.initialOutput) {
+      candidateOutput = this.initialOutput;
+    } else {
+      candidateOutput = this.generateFn(prompt, state.generation).trim();
+      if (!candidateOutput) {
+        candidateOutput = state.bestOutput;
+      }
+    }
+
+    const evaluation = this.evaluateFn(candidateOutput, state.generation);
+    const evaluatedOutput = evaluation.output.trim() || candidateOutput;
+
+    const judgeResult: AgentTaskResult = {
+      score: evaluation.score,
+      reasoning: evaluation.reasoning,
+      dimensionScores: evaluation.dimensionScores ?? {},
+      internalRetries: 0,
+    };
+
+    const lesson = accumulateLessons(judgeResult, state.generation + 1);
+    let newPlaybook = state.playbook;
+    if (lesson) {
+      newPlaybook = state.playbook ? `${state.playbook}\n${lesson}`.trim() : lesson;
+    }
+
+    let newBestOutput = state.bestOutput;
+    let newBestScore = state.bestScore;
+    if (!state.bestOutput || evaluation.score >= state.bestScore) {
+      newBestOutput = evaluatedOutput;
+      newBestScore = evaluation.score;
+    }
+
+    const metadata: Record<string, unknown> = { ...state.metadata };
+    const generationPrompts = [...((metadata.generationPrompts as string[]) ?? []), prompt];
+    const generationOutputs = [
+      ...((metadata.generationOutputs as string[]) ?? []),
+      evaluatedOutput,
+    ];
+    const generationRoundCounts = [
+      ...((metadata.generationRoundCounts as number[]) ?? []),
+      evaluation.roundCount ?? 1,
+    ];
+    const metThresholdHistory = [
+      ...((metadata.metThresholdHistory as boolean[]) ?? []),
+      evaluation.metThreshold ?? false,
+    ];
+    metadata.generationPrompts = generationPrompts;
+    metadata.generationOutputs = generationOutputs;
+    metadata.generationRoundCounts = generationRoundCounts;
+    metadata.metThresholdHistory = metThresholdHistory;
+
+    return {
+      generation: state.generation + 1,
+      bestOutput: newBestOutput,
+      bestScore: newBestScore,
+      playbook: newPlaybook,
+      scoreHistory: [...state.scoreHistory, evaluation.score],
+      lessonHistory: [...state.lessonHistory, lesson],
+      metadata,
+    };
+  }
+
+  runWithState(numGenerations = 10): {
+    trajectory: AgentTaskTrajectory;
+    state: AgentTaskGenerationState;
+  } {
+    let state: AgentTaskGenerationState = {
+      generation: 0,
+      bestOutput: "",
+      bestScore: 0,
+      playbook: "",
+      scoreHistory: [],
+      lessonHistory: [],
+      metadata: {},
+    };
+
+    for (let i = 0; i < numGenerations; i += 1) {
+      state = this.runGeneration(state);
+    }
+
+    const sh = state.scoreHistory;
+    const delta = sh.length > 0 ? Math.round((sh[sh.length - 1] - sh[0]) * 1e4) / 1e4 : 0;
+    const trajectory: AgentTaskTrajectory = {
+      taskName: this.taskName,
+      totalGenerations: numGenerations,
+      scoreHistory: sh,
+      lessonsPerGeneration: state.lessonHistory.map((l) => (l ? 1 : 0)),
+      coldStartScore: sh.length > 0 ? sh[0] : 0,
+      finalScore: sh.length > 0 ? sh[sh.length - 1] : 0,
+      improvementDelta: delta,
+      metadata: {
+        bestOutput: state.bestOutput,
+        bestScore: state.bestScore,
+        playbook: state.playbook,
+        lessonHistory: state.lessonHistory,
+        ...state.metadata,
+      },
+    };
+    return { trajectory, state };
+  }
+
+  run(numGenerations = 10): AgentTaskTrajectory {
+    return this.runWithState(numGenerations).trajectory;
+  }
+}

--- a/ts/src/execution/agent-task-evolution.ts
+++ b/ts/src/execution/agent-task-evolution.ts
@@ -200,6 +200,30 @@ export function buildEnrichedPrompt(args: {
   return sections.join("\n");
 }
 
+/**
+ * Island migration: seed lagging islands with the global champion.
+ *
+ * Each island below the best score adopts the champion's best output and
+ * score (winners propagate), but keeps its own playbook so accumulated
+ * lessons stay diverse. The champion island (and any tied) are unchanged.
+ */
+export function migrateStates(states: AgentTaskGenerationState[]): AgentTaskGenerationState[] {
+  if (states.length === 0) {
+    return states;
+  }
+  let champion = states[0];
+  for (const s of states) {
+    if (s.bestScore > champion.bestScore) {
+      champion = s;
+    }
+  }
+  return states.map((s) =>
+    s.bestScore < champion.bestScore
+      ? { ...s, bestOutput: champion.bestOutput, bestScore: champion.bestScore }
+      : s,
+  );
+}
+
 /** Multi-generation runner for AgentTask scenarios with lesson accumulation. */
 export class AgentTaskEvolutionRunner {
   private readonly taskPrompt: string;
@@ -348,5 +372,68 @@ export class AgentTaskEvolutionRunner {
 
   run(numGenerations = 10): AgentTaskTrajectory {
     return this.runWithState(numGenerations).trajectory;
+  }
+
+  /**
+   * Run `numIslands` parallel lineages, optionally migrating the global
+   * champion into laggards every `migrateEvery` generations. Islands
+   * preserve diversity (each keeps its own playbook/lineage) while migration
+   * shares winners. `migrateEvery = 0` disables migration.
+   */
+  runIslands(
+    args: {
+      numIslands?: number;
+      numGenerations?: number;
+      migrateEvery?: number;
+    } = {},
+  ): AgentTaskTrajectory {
+    const numIslands = args.numIslands ?? 4;
+    const numGenerations = args.numGenerations ?? 10;
+    const migrateEvery = args.migrateEvery ?? 0;
+
+    let states: AgentTaskGenerationState[] = Array.from({ length: numIslands }, () => ({
+      generation: 0,
+      bestOutput: "",
+      bestScore: 0,
+      playbook: "",
+      scoreHistory: [],
+      lessonHistory: [],
+      metadata: {},
+    }));
+
+    const bestPerGen: number[] = [];
+    for (let gen = 0; gen < numGenerations; gen += 1) {
+      states = states.map((s) => this.runGeneration(s));
+      bestPerGen.push(Math.max(...states.map((s) => s.bestScore)));
+      if (migrateEvery && (gen + 1) % migrateEvery === 0) {
+        states = migrateStates(states);
+      }
+    }
+
+    let champion = states[0];
+    for (const s of states) {
+      if (s.bestScore > champion.bestScore) {
+        champion = s;
+      }
+    }
+    const delta =
+      bestPerGen.length > 0
+        ? Math.round((bestPerGen[bestPerGen.length - 1] - bestPerGen[0]) * 1e4) / 1e4
+        : 0;
+    return {
+      taskName: this.taskName,
+      totalGenerations: numGenerations,
+      scoreHistory: bestPerGen,
+      lessonsPerGeneration: bestPerGen.map(() => numIslands),
+      coldStartScore: bestPerGen.length > 0 ? bestPerGen[0] : 0,
+      finalScore: bestPerGen.length > 0 ? bestPerGen[bestPerGen.length - 1] : 0,
+      improvementDelta: delta,
+      metadata: {
+        bestOutput: champion.bestOutput,
+        bestScore: champion.bestScore,
+        numIslands,
+        playbook: champion.playbook,
+      },
+    };
   }
 }

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -188,6 +188,21 @@ export { ImprovementLoop, isParseFailure, isImproved } from "./execution/improve
 export type { ImprovementLoopOpts } from "./execution/improvement-loop.js";
 export { cleanRevisionOutput } from "./execution/output-cleaner.js";
 export {
+  AgentTaskEvolutionRunner,
+  FunctionSlot,
+  accumulateLessons,
+  buildEnrichedPrompt,
+  migrateStates,
+} from "./execution/agent-task-evolution.js";
+export type {
+  AgentTaskGenerationState,
+  AgentTaskGenerationEvaluation,
+  AgentTaskTrajectory,
+  LessonSignal,
+  GenerateFn,
+  EvaluateFn,
+} from "./execution/agent-task-evolution.js";
+export {
   TaskRunner,
   SimpleAgentTask,
   enqueueTask,

--- a/ts/tests/agent-task-evolution.test.ts
+++ b/ts/tests/agent-task-evolution.test.ts
@@ -5,6 +5,7 @@ import {
   AgentTaskEvolutionRunner,
   FunctionSlot,
   type AgentTaskGenerationEvaluation,
+  type LessonSignal,
 } from "../src/execution/agent-task-evolution.js";
 import type { AgentTaskResult } from "../src/types/index.js";
 
@@ -145,5 +146,43 @@ describe("AgentTaskEvolutionRunner slot mode (AC-776)", () => {
     });
     expect(out).toContain("HARNESS_CODE_HERE");
     expect(out).toContain("Fixed Harness");
+  });
+});
+
+describe("domain-aware lesson accumulation (parity with Python)", () => {
+  it("renders hint, plateau guidance, and metrics from a signal", () => {
+    const signal: LessonSignal = {
+      hint: "demote some members to admit new points",
+      plateau: true,
+      metrics: { size: 224, delta: 0 },
+    };
+    const lesson = accumulateLessons(judge(0.95, "valid"), 3, signal);
+    expect(lesson).toContain("Hint: demote some members to admit new points");
+    expect(lesson.toLowerCase()).toContain("plateau");
+    expect(lesson).toContain("size=224");
+    expect(lesson).toContain("delta=0");
+  });
+
+  it("matches legacy behavior with no signal", () => {
+    const lesson = accumulateLessons(judge(0.6, "needs work"), 1);
+    expect(lesson).toContain("Generation 1 (score: 0.60):");
+    expect(lesson).not.toContain("Hint:");
+    expect(lesson.toLowerCase()).not.toContain("plateau");
+  });
+
+  it("runner threads the evaluation's signal into the playbook", () => {
+    const runner = new AgentTaskEvolutionRunner({
+      taskPrompt: "t",
+      generateFn: (_p, _g) => "candidate",
+      evaluateFn: (output, _g): AgentTaskGenerationEvaluation => ({
+        output,
+        score: 0.5,
+        reasoning: "ok",
+        dimensionScores: {},
+        lessonSignal: { hint: "try a different family" },
+      }),
+    });
+    const { state } = runner.runWithState(1);
+    expect(state.playbook).toContain("Hint: try a different family");
   });
 });

--- a/ts/tests/agent-task-evolution.test.ts
+++ b/ts/tests/agent-task-evolution.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  accumulateLessons,
+  buildEnrichedPrompt,
+  AgentTaskEvolutionRunner,
+  type AgentTaskGenerationEvaluation,
+} from "../src/execution/agent-task-evolution.js";
+import type { AgentTaskResult } from "../src/types/index.js";
+
+function judge(
+  score: number,
+  reasoning: string,
+  dimensionScores: Record<string, number> = {},
+): AgentTaskResult {
+  return { score, reasoning, dimensionScores, internalRetries: 0 };
+}
+
+describe("accumulateLessons (parity with Python accumulate_lessons)", () => {
+  it("formats generation header, feedback, and strong dimensions", () => {
+    const lesson = accumulateLessons(judge(0.95, "valid cap, |A|=224", { size: 0.95 }), 3);
+    expect(lesson).toContain("Generation 3 (score: 0.95):");
+    expect(lesson).toContain("  Feedback: valid cap, |A|=224");
+    expect(lesson).toContain("Strong dimensions: size (0.95)");
+  });
+
+  it("lists weak dimensions (score < 0.7) ascending", () => {
+    const lesson = accumulateLessons(judge(0.5, "needs work", { depth: 0.4, structure: 0.6 }), 1);
+    expect(lesson).toContain("Weak dimensions: depth (0.40), structure (0.60)");
+  });
+});
+
+describe("buildEnrichedPrompt (parity with Python build_enriched_prompt)", () => {
+  it("returns the bare task prompt when no playbook or best output", () => {
+    const out = buildEnrichedPrompt({
+      taskPrompt: "TASK",
+      playbook: "",
+      generation: 1,
+      bestOutput: "",
+      bestScore: 0,
+    });
+    expect(out).toBe("TASK");
+  });
+
+  it("includes playbook and best-output sections when present", () => {
+    const out = buildEnrichedPrompt({
+      taskPrompt: "TASK",
+      playbook: "- lesson one",
+      generation: 2,
+      bestOutput: "PRIOR",
+      bestScore: 0.8,
+    });
+    expect(out).toContain("## Accumulated Lessons (Generation 2)");
+    expect(out).toContain("Previous best score: 0.80");
+    expect(out).toContain("- lesson one");
+    expect(out).toContain("## Best Previous Output (score 0.80)");
+    expect(out).toContain("PRIOR");
+  });
+});
+
+describe("AgentTaskEvolutionRunner (parity with Python runner)", () => {
+  it("uses initialOutput for the cold-start generation", () => {
+    const seen: string[] = [];
+    const runner = new AgentTaskEvolutionRunner({
+      taskPrompt: "make a thing",
+      generateFn: (_prompt, _gen) => {
+        seen.push("called");
+        return "generated";
+      },
+      evaluateFn: (output, _gen): AgentTaskGenerationEvaluation => ({
+        output,
+        score: output === "SEED" ? 0.9 : 0.5,
+        reasoning: `scored ${output}`,
+        dimensionScores: {},
+      }),
+      initialOutput: "SEED",
+      taskName: "t",
+    });
+    const traj = runner.run(1);
+    expect(seen.length).toBe(0); // gen 0 used the seed, never called generateFn
+    expect(traj.scoreHistory).toEqual([0.9]);
+    expect(traj.metadata.bestOutput).toBe("SEED");
+  });
+
+  it("climbs across generations and reports a trajectory", () => {
+    let g = 0;
+    const runner = new AgentTaskEvolutionRunner({
+      taskPrompt: "improve",
+      generateFn: (_prompt, _gen) => `cand${g}`,
+      evaluateFn: (output, _gen): AgentTaskGenerationEvaluation => {
+        g += 1;
+        return { output, score: 0.3 + 0.2 * g, reasoning: "ok", dimensionScores: {} };
+      },
+      initialOutput: "",
+      taskName: "climb",
+    });
+    const traj = runner.run(3);
+    expect(traj.totalGenerations).toBe(3);
+    expect(traj.scoreHistory.length).toBe(3);
+    expect(traj.finalScore).toBeGreaterThan(traj.coldStartScore);
+    expect(traj.improvementDelta).toBeCloseTo(0.4, 5);
+  });
+});

--- a/ts/tests/agent-task-evolution.test.ts
+++ b/ts/tests/agent-task-evolution.test.ts
@@ -4,7 +4,9 @@ import {
   buildEnrichedPrompt,
   AgentTaskEvolutionRunner,
   FunctionSlot,
+  migrateStates,
   type AgentTaskGenerationEvaluation,
+  type AgentTaskGenerationState,
   type LessonSignal,
 } from "../src/execution/agent-task-evolution.js";
 import type { AgentTaskResult } from "../src/types/index.js";
@@ -184,5 +186,51 @@ describe("domain-aware lesson accumulation (parity with Python)", () => {
     });
     const { state } = runner.runWithState(1);
     expect(state.playbook).toContain("Hint: try a different family");
+  });
+});
+
+describe("island mode (AC parity with Python)", () => {
+  function island(bestOutput: string, bestScore: number): AgentTaskGenerationState {
+    return {
+      generation: 1,
+      bestOutput,
+      bestScore,
+      playbook: `playbook-for-${bestOutput}`,
+      scoreHistory: [bestScore],
+      lessonHistory: ["l"],
+      metadata: {},
+    };
+  }
+
+  it("migrateStates copies the champion into laggards", () => {
+    const migrated = migrateStates([island("champ", 0.9), island("weak", 0.4), island("mid", 0.6)]);
+    expect(migrated.every((s) => s.bestScore === 0.9)).toBe(true);
+    expect(migrated.every((s) => s.bestOutput === "champ")).toBe(true);
+  });
+
+  it("migrateStates preserves per-island playbook", () => {
+    const migrated = migrateStates([island("champ", 0.9), island("weak", 0.4)]);
+    expect(migrated[1].playbook).toBe("playbook-for-weak");
+  });
+
+  it("runIslands returns a trajectory with the global best", () => {
+    let n = 0;
+    const runner = new AgentTaskEvolutionRunner({
+      taskPrompt: "t",
+      generateFn: (_p, _g) => {
+        n += 1;
+        return `cand${n}`;
+      },
+      evaluateFn: (output, _g): AgentTaskGenerationEvaluation => {
+        const idx = output.startsWith("cand") ? Number(output.replace("cand", "")) : 0;
+        return { output, score: Math.min(1.0, 0.1 * idx), reasoning: "ok", dimensionScores: {} };
+      },
+    });
+    const traj = runner.runIslands({ numIslands: 3, numGenerations: 2 });
+    expect(traj.totalGenerations).toBe(2);
+    expect(traj.scoreHistory.length).toBe(2);
+    expect(traj.metadata.numIslands).toBe(3);
+    expect(traj.metadata.bestScore).toBe(Math.max(...traj.scoreHistory));
+    expect([...traj.scoreHistory]).toEqual([...traj.scoreHistory].sort((a, b) => a - b));
   });
 });

--- a/ts/tests/agent-task-evolution.test.ts
+++ b/ts/tests/agent-task-evolution.test.ts
@@ -3,6 +3,7 @@ import {
   accumulateLessons,
   buildEnrichedPrompt,
   AgentTaskEvolutionRunner,
+  FunctionSlot,
   type AgentTaskGenerationEvaluation,
 } from "../src/execution/agent-task-evolution.js";
 import type { AgentTaskResult } from "../src/types/index.js";
@@ -98,5 +99,51 @@ describe("AgentTaskEvolutionRunner (parity with Python runner)", () => {
     expect(traj.scoreHistory.length).toBe(3);
     expect(traj.finalScore).toBeGreaterThan(traj.coldStartScore);
     expect(traj.improvementDelta).toBeCloseTo(0.4, 5);
+  });
+});
+
+describe("FunctionSlot (AC-776, parity with Python)", () => {
+  it("assemble prepends the slot to the harness", () => {
+    const slot = new FunctionSlot("def build():\n    return priority");
+    const assembled = slot.assemble("def priority(v):\n    return 1.0");
+    expect(assembled).toContain("def priority(v):");
+    expect(assembled).toContain("def build():");
+    expect(assembled.indexOf("def priority(v):")).toBeLessThan(assembled.indexOf("def build():"));
+  });
+});
+
+describe("AgentTaskEvolutionRunner slot mode (AC-776)", () => {
+  it("carries the slot, evaluates the assembled program", () => {
+    const slot = new FunctionSlot("def build():\n    return priority  # HARNESS_MARKER");
+    const evalInputs: string[] = [];
+    const runner = new AgentTaskEvolutionRunner({
+      taskPrompt: "t",
+      generateFn: (_p, _g) => "def priority(v):\n    return 2.0",
+      evaluateFn: (output, _g): AgentTaskGenerationEvaluation => {
+        evalInputs.push(output);
+        return { output, score: 0.5, reasoning: "ok", dimensionScores: {} };
+      },
+      initialOutput: "def priority(v):\n    return 0.0",
+      slot,
+    });
+    const { state } = runner.runWithState(2);
+    // evaluate received the ASSEMBLED program (harness present)
+    expect(evalInputs.some((i) => i.includes("HARNESS_MARKER"))).toBe(true);
+    // but best_output is only the SLOT (no harness)
+    expect(state.bestOutput).not.toContain("HARNESS_MARKER");
+    expect(state.bestOutput).toContain("def priority(v):");
+  });
+
+  it("includes a Fixed Harness section in the enriched prompt", () => {
+    const out = buildEnrichedPrompt({
+      taskPrompt: "t",
+      playbook: "",
+      generation: 1,
+      bestOutput: "",
+      bestScore: 0,
+      harness: "HARNESS_CODE_HERE",
+    });
+    expect(out).toContain("HARNESS_CODE_HERE");
+    expect(out).toContain("Fixed Harness");
   });
 });

--- a/ts/tests/agent-task-evolution.test.ts
+++ b/ts/tests/agent-task-evolution.test.ts
@@ -62,7 +62,7 @@ describe("buildEnrichedPrompt (parity with Python build_enriched_prompt)", () =>
 });
 
 describe("AgentTaskEvolutionRunner (parity with Python runner)", () => {
-  it("uses initialOutput for the cold-start generation", () => {
+  it("uses initialOutput for the cold-start generation", async () => {
     const seen: string[] = [];
     const runner = new AgentTaskEvolutionRunner({
       taskPrompt: "make a thing",
@@ -79,13 +79,13 @@ describe("AgentTaskEvolutionRunner (parity with Python runner)", () => {
       initialOutput: "SEED",
       taskName: "t",
     });
-    const traj = runner.run(1);
+    const traj = await runner.run(1);
     expect(seen.length).toBe(0); // gen 0 used the seed, never called generateFn
     expect(traj.scoreHistory).toEqual([0.9]);
     expect(traj.metadata.bestOutput).toBe("SEED");
   });
 
-  it("climbs across generations and reports a trajectory", () => {
+  it("climbs across generations and reports a trajectory", async () => {
     let g = 0;
     const runner = new AgentTaskEvolutionRunner({
       taskPrompt: "improve",
@@ -97,7 +97,7 @@ describe("AgentTaskEvolutionRunner (parity with Python runner)", () => {
       initialOutput: "",
       taskName: "climb",
     });
-    const traj = runner.run(3);
+    const traj = await runner.run(3);
     expect(traj.totalGenerations).toBe(3);
     expect(traj.scoreHistory.length).toBe(3);
     expect(traj.finalScore).toBeGreaterThan(traj.coldStartScore);
@@ -116,7 +116,7 @@ describe("FunctionSlot (AC-776, parity with Python)", () => {
 });
 
 describe("AgentTaskEvolutionRunner slot mode (AC-776)", () => {
-  it("carries the slot, evaluates the assembled program", () => {
+  it("carries the slot, evaluates the assembled program", async () => {
     const slot = new FunctionSlot("def build():\n    return priority  # HARNESS_MARKER");
     const evalInputs: string[] = [];
     const runner = new AgentTaskEvolutionRunner({
@@ -129,7 +129,7 @@ describe("AgentTaskEvolutionRunner slot mode (AC-776)", () => {
       initialOutput: "def priority(v):\n    return 0.0",
       slot,
     });
-    const { state } = runner.runWithState(2);
+    const { state } = await runner.runWithState(2);
     // evaluate received the ASSEMBLED program (harness present)
     expect(evalInputs.some((i) => i.includes("HARNESS_MARKER"))).toBe(true);
     // but best_output is only the SLOT (no harness)
@@ -172,7 +172,7 @@ describe("domain-aware lesson accumulation (parity with Python)", () => {
     expect(lesson.toLowerCase()).not.toContain("plateau");
   });
 
-  it("runner threads the evaluation's signal into the playbook", () => {
+  it("runner threads the evaluation's signal into the playbook", async () => {
     const runner = new AgentTaskEvolutionRunner({
       taskPrompt: "t",
       generateFn: (_p, _g) => "candidate",
@@ -184,7 +184,7 @@ describe("domain-aware lesson accumulation (parity with Python)", () => {
         lessonSignal: { hint: "try a different family" },
       }),
     });
-    const { state } = runner.runWithState(1);
+    const { state } = await runner.runWithState(1);
     expect(state.playbook).toContain("Hint: try a different family");
   });
 });
@@ -213,7 +213,7 @@ describe("island mode (AC parity with Python)", () => {
     expect(migrated[1].playbook).toBe("playbook-for-weak");
   });
 
-  it("runIslands returns a trajectory with the global best", () => {
+  it("runIslands returns a trajectory with the global best", async () => {
     let n = 0;
     const runner = new AgentTaskEvolutionRunner({
       taskPrompt: "t",
@@ -226,11 +226,60 @@ describe("island mode (AC parity with Python)", () => {
         return { output, score: Math.min(1.0, 0.1 * idx), reasoning: "ok", dimensionScores: {} };
       },
     });
-    const traj = runner.runIslands({ numIslands: 3, numGenerations: 2 });
+    const traj = await runner.runIslands({ numIslands: 3, numGenerations: 2 });
     expect(traj.totalGenerations).toBe(2);
     expect(traj.scoreHistory.length).toBe(2);
     expect(traj.metadata.numIslands).toBe(3);
     expect(traj.metadata.bestScore).toBe(Math.max(...traj.scoreHistory));
     expect([...traj.scoreHistory]).toEqual([...traj.scoreHistory].sort((a, b) => a - b));
+  });
+
+  it("rejects numIslands < 1 (P3)", async () => {
+    const runner = new AgentTaskEvolutionRunner({
+      taskPrompt: "t",
+      generateFn: (_p, _g) => "x",
+      evaluateFn: (output, _g): AgentTaskGenerationEvaluation => ({
+        output,
+        score: 0.5,
+        reasoning: "ok",
+        dimensionScores: {},
+      }),
+    });
+    await expect(runner.runIslands({ numIslands: 0, numGenerations: 2 })).rejects.toThrow(
+      /numIslands must be >= 1/,
+    );
+  });
+});
+
+describe("async generate/evaluate (P2b: promise-based providers)", () => {
+  it("awaits async generateFn and evaluateFn", async () => {
+    const runner = new AgentTaskEvolutionRunner({
+      taskPrompt: "t",
+      generateFn: async (_p, _g) => "async-candidate",
+      evaluateFn: async (output, _g): Promise<AgentTaskGenerationEvaluation> => ({
+        output,
+        score: 0.7,
+        reasoning: "async ok",
+        dimensionScores: {},
+      }),
+    });
+    const traj = await runner.run(1);
+    expect(traj.scoreHistory).toEqual([0.7]);
+    expect(traj.metadata.bestOutput).toBe("async-candidate");
+  });
+
+  it("awaits async fns in island mode", async () => {
+    const runner = new AgentTaskEvolutionRunner({
+      taskPrompt: "t",
+      generateFn: async (_p, _g) => "x",
+      evaluateFn: async (output, _g): Promise<AgentTaskGenerationEvaluation> => ({
+        output,
+        score: 0.5,
+        reasoning: "ok",
+        dimensionScores: {},
+      }),
+    });
+    const traj = await runner.runIslands({ numIslands: 2, numGenerations: 2 });
+    expect(traj.totalGenerations).toBe(2);
   });
 });

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -9,6 +9,10 @@ describe("package root exports", () => {
     expect(pkg.SQLiteStore).toBeDefined();
     expect(pkg.createProvider).toBeDefined();
     expect(pkg.ActionFilterHarness).toBeDefined();
+    expect(pkg.AgentTaskEvolutionRunner).toBeDefined();
+    expect(pkg.FunctionSlot).toBeDefined();
+    expect(pkg.migrateStates).toBeDefined();
+    expect(pkg.accumulateLessons).toBeDefined();
     expect(pkg.SkillPackage).toBeDefined();
     expect(pkg.DataPlane).toBeDefined();
     expect(pkg.ModelStrategySelector).toBeDefined();


### PR DESCRIPTION
## Summary

Three improvements to the agent-task evolution loop, each surfaced by running a real combinatorial-search task (cap-sets in F_3^n) through `AgentTaskEvolutionRunner` and observing where the framework underperformed. Implemented TDD, with full **TS + Python parity**.

The agent-task evolution runner was **Python-only**, so this PR first **ports the module to TypeScript** (`ts/src/execution/agent-task-evolution.ts`) at behavioral parity, then adds all three features to both languages in lockstep.

### 1. `FunctionSlot` — function-slot evolution mode (AC-776)
`build_enriched_prompt`/`buildEnrichedPrompt` embed `best_output` verbatim. For prose that's fine; for **code generation it's pathological** — a large generated program balloons every prompt and blows the model's reasoning budget. `FunctionSlot(harness)` lets a scenario evolve only a small slot inside a fixed harness: the runner carries just the slot (compact prompts) but evaluates the assembled `harness + slot`. A `harness` section is shown once as fixed context.

### 2. `LessonSignal` — domain-aware lesson accumulation
`accumulate_lessons` saw only score + dimension scores, so playbooks stayed generic ("score 0.95, strong dimension: size") and never told the model what to try next. `LessonSignal{hint, plateau, metrics}` on the evaluation lets a deterministic evaluator feed move-level guidance into the playbook.

### 3. `migrate_states` + `run_islands` — population/island mode
The runner was single-lineage and re-derived the same local optimum each generation. `run_islands(num_islands, num_generations, migrate_every)` runs K parallel lineages with periodic champion migration (`migrate_states` seeds laggards with the global best while preserving per-island playbook diversity).

## Test plan
- [x] TS: 15/15 Vitest cases in `tests/agent-task-evolution.test.ts` (written test-first); `tsc --noEmit` clean.
- [x] Python: 41 tests green across `test_agent_task_function_slot.py`, `test_agent_task_lesson_signal.py`, `test_agent_task_islands.py`, and the existing `test_agent_task_multi_gen.py` (regression); `ruff` + `mypy` clean.
- [x] End-to-end: a cap-set search driven through the improved runner (FunctionSlot + run_islands + LessonSignal) runs cleanly where the whole-program version timed out; the playbook now carries actionable hints + plateau detection + metrics.

## DDD / DRY
- Named the three missing domain concepts (`FunctionSlot`, `LessonSignal`, island migration) as first-class types in both languages.
- Single shared conventions: `FunctionSlot.assemble` (slot prepended to harness) and the `migrate_states` champion rule, mirrored exactly across Python and TS.

## Notes
- `ScenarioFamilyGuide` (static markdown guidance, non-functional) was not ported; can follow up if desired.
- AC-776 tracks the function-slot item; the LessonSignal and island items are documented in the commits and will be filed as issues separately.