### PR TITLE
feat(cli): AC-728 Python parity slice 4 (autoctx probes check)

### DIFF
--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -24,6 +24,7 @@ from autocontext.cli_hermes import register_hermes_command
 from autocontext.cli_improve import register_improve_command
 from autocontext.cli_investigate import run_investigate_command
 from autocontext.cli_new_scenario import register_new_scenario_command
+from autocontext.cli_probes import register_probes_command
 from autocontext.cli_queue import register_queue_command
 from autocontext.cli_role_runtime import resolve_role_runtime
 from autocontext.cli_run_inspect import register_run_inspect_commands
@@ -1558,6 +1559,7 @@ register_improve_command(app, console=console)
 register_new_scenario_command(app, console=console)
 register_run_inspect_commands(app, console=console)
 register_solve_command(app, console=console)
+register_probes_command(app, console=console)
 register_queue_command(app, console=console)
 register_worker_command(app, console=console)
 

--- a/autocontext/src/autocontext/cli_probes.py
+++ b/autocontext/src/autocontext/cli_probes.py
@@ -1,0 +1,250 @@
+"""AC-728 `autoctx probes` CLI surface (Python parity, slice 4).
+
+Mirrors ``ts/src/control-plane/contract-probes/cli/check.ts`` (TS
+PR #991). In-process handler:
+
+- ``run_probes_check(args)`` parses args, loads the suite (file path
+  or stdin via ``-``), runs ``run_contract_probe_suite``, and returns
+  ``{stdout, stderr, exit_code}``. Tests consume this directly so
+  there is no need to spawn a subprocess.
+- ``register_probes_command(app, *, console)`` mounts a ``probes``
+  sub-Typer with ``check`` as the first subcommand. The outer typer
+  command translates the in-process result to stdout / stderr /
+  ``typer.Exit``.
+
+Schema-invalid suites surface every Pydantic issue line by line so
+operators can fix typos at parse time rather than discover the
+missing expectation in a green-but-wrong run.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+
+import typer
+from pydantic import ValidationError
+from rich.console import Console
+
+from autocontext.control_plane.contract_probes import (
+    ContractProbeSuiteResult,
+    ContractProbeSuiteSchema,
+    load_contract_probe_suite,
+    run_contract_probe_suite,
+)
+
+__all__ = [
+    "CHECK_HELP_TEXT",
+    "ProbesCheckResult",
+    "register_probes_command",
+    "run_probes_check",
+]
+
+
+CHECK_HELP_TEXT = """autoctx probes check -- run a contract-probe suite against observed harness state.
+
+Usage:
+  autoctx probes check --suite <path> [--json]
+  autoctx probes extract --trace <trace> | autoctx probes check --suite -
+  autoctx probes check --help
+
+Options:
+  --suite <path>   Path to a JSON probe suite (validated against
+                   ContractProbeSuiteSchema). Use `-` to read the suite
+                   from stdin (cross-platform; the documented pipe form
+                   for `autoctx probes extract | autoctx probes check`).
+                   Required.
+  --json           Emit a structured JSON report instead of human-readable
+                   text. The JSON shape mirrors ContractProbeSuiteResult:
+                     {
+                       "passed": boolean,
+                       "results": [
+                         {
+                           "kind": <probe kind>,
+                           "label": <optional caller-supplied attribution>,
+                           "passed": boolean,
+                           "failures": [ { "kind", "message", ... } ]
+                         },
+                         ...
+                       ]
+                     }
+  -h, --help       Show this help text.
+
+Exit codes:
+  0   every probe in the suite passed.
+  1   at least one probe failed, or the suite failed to load / parse.
+
+The JSON suite-file format (with a minimal example and the seven
+probe kinds) is documented under the "Contract Probes" section of
+the autocontext README. Every input field that the suite declares an
+expectation about must carry a corresponding observation; missing
+observations fail with kind `missing-observation` rather than
+silently passing.
+"""
+
+
+@dataclass(frozen=True)
+class ProbesCheckResult:
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+def _render_text_report(result: ContractProbeSuiteResult) -> str:
+    lines: list[str] = []
+    lines.append("probes check: PASS" if result.passed else "probes check: FAIL")
+    for probe in result.results:
+        label = f" [{probe.label}]" if probe.label else ""
+        status = "pass" if probe.passed else "fail"
+        lines.append(f"  {probe.kind}{label}: {status}")
+        if not probe.passed:
+            for failure in probe.failures:
+                lines.append(f"    - {failure.kind}: {failure.message}")
+    return "\n".join(lines)
+
+
+def _render_validation_error(err: ValidationError) -> str:
+    issues: list[str] = []
+    for issue in err.errors():
+        loc = ".".join(str(p) for p in issue["loc"]) if issue["loc"] else "<root>"
+        issues.append(f"  - {loc}: {issue['msg']}")
+    return "\n".join(issues)
+
+
+def _result_to_json(result: ContractProbeSuiteResult) -> str:
+    payload = result.model_dump(mode="json")
+    return json.dumps(payload, indent=2)
+
+
+def run_probes_check(
+    args: list[str],
+    *,
+    stdin_text: str | None = None,
+) -> ProbesCheckResult:
+    """Pure in-process entry point for `autoctx probes check`.
+
+    Mirrors the TS handler shape: parse args, load + validate the
+    suite, run it, render the report. Returns
+    ``{stdout, stderr, exit_code}`` so the typer wrapper (or a test)
+    can route it to the appropriate sink without coupling to global
+    process state.
+
+    ``stdin_text`` is an optional override used by tests; if
+    ``None`` and ``--suite -`` is requested, the function reads from
+    ``sys.stdin``.
+    """
+    suite_path: str | None = None
+    json_output = False
+    help_flag = False
+
+    it = iter(args)
+    for arg in it:
+        if arg in ("-h", "--help"):
+            help_flag = True
+        elif arg == "--json":
+            json_output = True
+        elif arg == "--suite":
+            try:
+                suite_path = next(it)
+            except StopIteration:
+                return ProbesCheckResult(
+                    stdout="",
+                    stderr=f"autoctx probes check: --suite requires a value\n\n{CHECK_HELP_TEXT}",
+                    exit_code=1,
+                )
+        elif arg.startswith("--suite="):
+            suite_path = arg.split("=", 1)[1]
+        else:
+            return ProbesCheckResult(
+                stdout="",
+                stderr=f"autoctx probes check: unknown argument {arg!r}\n\n{CHECK_HELP_TEXT}",
+                exit_code=1,
+            )
+
+    if help_flag:
+        return ProbesCheckResult(stdout=CHECK_HELP_TEXT, stderr="", exit_code=0)
+
+    if not suite_path:
+        return ProbesCheckResult(
+            stdout="",
+            stderr=f"autoctx probes check: --suite <path> is required\n\n{CHECK_HELP_TEXT}",
+            exit_code=1,
+        )
+
+    try:
+        if suite_path == "-":
+            # PR #992 review (P3 equivalent) on the TS side: support
+            # stdin so the documented `extract | check` pipe works
+            # cross-platform.
+            raw = stdin_text if stdin_text is not None else sys.stdin.read()
+            parsed_json = json.loads(raw)
+            suite = ContractProbeSuiteSchema.model_validate(parsed_json)
+        else:
+            suite = load_contract_probe_suite(suite_path)
+    except FileNotFoundError as err:
+        return ProbesCheckResult(
+            stdout="",
+            stderr=f"autoctx probes check: failed to load suite from {suite_path}: {err}",
+            exit_code=1,
+        )
+    except json.JSONDecodeError as err:
+        return ProbesCheckResult(
+            stdout="",
+            stderr=f"autoctx probes check: failed to load suite from {suite_path}: {err.msg}",
+            exit_code=1,
+        )
+    except ValidationError as err:
+        rendered = _render_validation_error(err)
+        return ProbesCheckResult(
+            stdout="",
+            stderr=f"autoctx probes check: suite validation failed\n{rendered}",
+            exit_code=1,
+        )
+
+    result = run_contract_probe_suite(suite)
+    if json_output:
+        return ProbesCheckResult(
+            stdout=_result_to_json(result),
+            stderr="",
+            exit_code=0 if result.passed else 1,
+        )
+    return ProbesCheckResult(
+        stdout=_render_text_report(result),
+        stderr="",
+        exit_code=0 if result.passed else 1,
+    )
+
+
+def register_probes_command(app: typer.Typer, *, console: Console) -> None:
+    """Mount the `probes` sub-Typer on ``app`` with `check` as the
+    first subcommand."""
+    probes_app = typer.Typer(help="AC-728 contract probes.")
+
+    @probes_app.command("check")
+    def _check(
+        suite: str = typer.Option(
+            "",
+            "--suite",
+            help="Path to a JSON probe suite; use `-` to read from stdin.",
+        ),
+        json_output: bool = typer.Option(False, "--json", help="Emit a structured JSON report instead of text."),
+    ) -> None:
+        """Run a contract-probe suite and report per-probe pass/fail."""
+        # Reconstruct argv-style args so the in-process handler stays
+        # the single source of truth for parsing + dispatch.
+        args: list[str] = []
+        if suite:
+            args.extend(["--suite", suite])
+        if json_output:
+            args.append("--json")
+        result = run_probes_check(args)
+        if result.stdout:
+            # Plain stdout so `--json` output is parseable; the rich
+            # console adds ANSI codes that break JSON consumers.
+            print(result.stdout)
+        if result.stderr:
+            console.print(result.stderr, style="red")
+        raise typer.Exit(code=result.exit_code)
+
+    app.add_typer(probes_app, name="probes")

--- a/autocontext/tests/control_plane/test_cli_probes.py
+++ b/autocontext/tests/control_plane/test_cli_probes.py
@@ -1,0 +1,240 @@
+"""AC-728 `autoctx probes check` CLI parity tests (slice 4).
+
+Mirrors the test surface of TS PR #991's `cli-check.test.ts`. The
+in-process handler ``run_probes_check`` returns
+``{stdout, stderr, exit_code}`` so the tests consume it directly
+without spawning a subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from autocontext.cli import app
+from autocontext.cli_probes import (
+    CHECK_HELP_TEXT,
+    ProbesCheckResult,
+    run_probes_check,
+)
+
+
+def _passing_suite_dict() -> dict:
+    return {
+        "schema_version": 1,
+        "probes": [
+            {
+                "kind": "terminal",
+                "label": "demo",
+                "inputs": {"exitCode": 0, "stdout": "ok", "stderr": ""},
+            }
+        ],
+    }
+
+
+def _failing_suite_dict() -> dict:
+    return {
+        "schema_version": 1,
+        "probes": [
+            {
+                "kind": "terminal",
+                "inputs": {"exitCode": 1, "stdout": "", "stderr": ""},
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# argv parsing
+# ---------------------------------------------------------------------------
+
+
+def test_help_flag_emits_help_text_and_exits_zero() -> None:
+    result = run_probes_check(["--help"])
+    assert result.exit_code == 0
+    assert "autoctx probes check" in result.stdout
+
+
+def test_short_help_flag_works() -> None:
+    result = run_probes_check(["-h"])
+    assert result.exit_code == 0
+    assert "Usage" in result.stdout
+
+
+def test_missing_suite_arg_emits_actionable_error_and_exits_one() -> None:
+    result = run_probes_check([])
+    assert result.exit_code == 1
+    assert "--suite" in result.stderr
+
+
+def test_unknown_argument_rejected_with_help_text() -> None:
+    result = run_probes_check(["--bogus"])
+    assert result.exit_code == 1
+    assert "unknown argument" in result.stderr
+
+
+def test_suite_equal_form_accepted(tmp_path: Path) -> None:
+    suite_path = tmp_path / "suite.json"
+    suite_path.write_text(json.dumps(_passing_suite_dict()))
+    result = run_probes_check([f"--suite={suite_path}"])
+    assert result.exit_code == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# file loading + parse errors
+# ---------------------------------------------------------------------------
+
+
+def test_missing_file_surfaces_load_error(tmp_path: Path) -> None:
+    result = run_probes_check(["--suite", str(tmp_path / "nope.json")])
+    assert result.exit_code == 1
+    assert "failed to load suite" in result.stderr
+
+
+def test_malformed_json_surfaces_load_error(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    result = run_probes_check(["--suite", str(bad)])
+    assert result.exit_code == 1
+    assert "failed to load suite" in result.stderr
+
+
+def test_schema_invalid_suite_surfaces_validation_issues(tmp_path: Path) -> None:
+    """A typo like `requiredStdoutPattern` (missing `s`) must fail
+    validation and print the path of the offending issue, not be
+    silently dropped."""
+    bad = tmp_path / "typo.json"
+    bad.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "probes": [
+                    {
+                        "kind": "terminal",
+                        "inputs": {
+                            "exitCode": 0,
+                            "stdout": "",
+                            "stderr": "",
+                            "requiredStdoutPattern": "x",  # typo
+                        },
+                    }
+                ],
+            }
+        )
+    )
+    result = run_probes_check(["--suite", str(bad)])
+    assert result.exit_code == 1
+    assert "suite validation failed" in result.stderr
+    # path of the offending issue is included in the rendered list
+    assert "requiredStdoutPattern" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# stdin pipe form
+# ---------------------------------------------------------------------------
+
+
+def test_suite_dash_reads_from_stdin_text() -> None:
+    stdin_text = json.dumps(_passing_suite_dict())
+    result = run_probes_check(["--suite", "-"], stdin_text=stdin_text)
+    assert result.exit_code == 0
+    assert "PASS" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# text report
+# ---------------------------------------------------------------------------
+
+
+def test_text_report_for_passing_suite(tmp_path: Path) -> None:
+    suite_path = tmp_path / "suite.json"
+    suite_path.write_text(json.dumps(_passing_suite_dict()))
+    result = run_probes_check(["--suite", str(suite_path)])
+    assert result.exit_code == 0
+    assert "probes check: PASS" in result.stdout
+    assert "terminal [demo]: pass" in result.stdout
+
+
+def test_text_report_for_failing_suite_lists_failure_kinds(tmp_path: Path) -> None:
+    suite_path = tmp_path / "suite.json"
+    suite_path.write_text(json.dumps(_failing_suite_dict()))
+    result = run_probes_check(["--suite", str(suite_path)])
+    assert result.exit_code == 1
+    assert "probes check: FAIL" in result.stdout
+    assert "terminal: fail" in result.stdout
+    assert "unexpected-exit-code" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# JSON report
+# ---------------------------------------------------------------------------
+
+
+def test_json_report_round_trips(tmp_path: Path) -> None:
+    suite_path = tmp_path / "suite.json"
+    suite_path.write_text(json.dumps(_passing_suite_dict()))
+    result = run_probes_check(["--suite", str(suite_path), "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["passed"] is True
+    assert payload["results"][0]["kind"] == "terminal"
+    assert payload["results"][0]["label"] == "demo"
+    assert payload["results"][0]["passed"] is True
+
+
+def test_json_report_for_failing_suite_carries_failures(tmp_path: Path) -> None:
+    suite_path = tmp_path / "suite.json"
+    suite_path.write_text(json.dumps(_failing_suite_dict()))
+    result = run_probes_check(["--suite", str(suite_path), "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["passed"] is False
+    failures = payload["results"][0]["failures"]
+    assert any(f["kind"] == "unexpected-exit-code" for f in failures)
+
+
+# ---------------------------------------------------------------------------
+# typer integration
+# ---------------------------------------------------------------------------
+
+
+def test_typer_probes_check_registered_at_canonical_path(tmp_path: Path) -> None:
+    suite_path = tmp_path / "suite.json"
+    suite_path.write_text(json.dumps(_passing_suite_dict()))
+    result = CliRunner().invoke(app, ["probes", "check", "--suite", str(suite_path)])
+    assert result.exit_code == 0, result.output
+    assert "probes check: PASS" in result.output
+
+
+def test_typer_probes_check_json_emits_parseable_payload(tmp_path: Path) -> None:
+    suite_path = tmp_path / "suite.json"
+    suite_path.write_text(json.dumps(_passing_suite_dict()))
+    result = CliRunner().invoke(app, ["probes", "check", "--suite", str(suite_path), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip())
+    assert payload["passed"] is True
+
+
+def test_typer_probes_check_missing_suite_exits_nonzero() -> None:
+    result = CliRunner().invoke(app, ["probes", "check"])
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# help text exposed for downstream consumers
+# ---------------------------------------------------------------------------
+
+
+def test_help_text_documents_canonical_pipe_form() -> None:
+    assert "autoctx probes check --suite -" in CHECK_HELP_TEXT
+    assert "probes extract" in CHECK_HELP_TEXT
+
+
+def test_result_dataclass_is_frozen() -> None:
+    result = ProbesCheckResult(stdout="x", stderr="y", exit_code=0)
+    import pytest
+
+    with pytest.raises(AttributeError):
+        result.stdout = "z"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Mirrors `ts/src/control-plane/contract-probes/cli/check.ts` (TS PR #991). New `autocontext.cli_probes` module exposes `run_probes_check(args)` as the pure in-process handler returning `ProbesCheckResult(stdout, stderr, exit_code)` and `register_probes_command(app, *, console)` mounting `autoctx probes check` on the main typer app.
- `--suite <path>` loads the JSON suite; `--suite -` reads from stdin (cross-platform). Schema-invalid suites surface every Pydantic issue line by line; `--json` emits a parseable `ContractProbeSuiteResult` payload.
- Exit 0 on full pass; exit 1 on any failure or load/parse/validation error.

## Test plan

- [x] `uv run pytest tests/control_plane/` (91 passed: 73 prior + 18 new)
- [x] `uv run pytest tests/test_module_size_limits.py` clean (`cli_probes.py` 250 lines)
- [x] `uv run ruff check` clean
- [x] `uv run mypy src/autocontext/cli_probes.py` clean
- [ ] CI: green

## Slice plan (7 total)

- slice 1 (#1004, merged): 4 base probes
- slice 2 (#1005, merged): 3 advanced probes + missing-observation invariant
- slice 3 (#1006, merged): suite runner + Pydantic schema
- **slice 4 (this PR)**: `autoctx probes check` CLI
- slice 5: `autoctx probes extract` for 4 base probes (mirrors TS PR #992)
- slice 6: extend extract to cleanup / media / distributed (mirrors TS PR #993)
- slice 7: missing-observation audit close-out