### PR TITLE
fix(cli): route probes-check errors to stderr + document in README

### DIFF
--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -198,6 +198,8 @@ uv run autoctx analytics trace-findings --trace-id <trace_id> --kind writeup --j
 uv run autoctx analytics trace-findings --trace-id <trace_id> --kind weakness
 uv run autoctx serve --host 127.0.0.1 --port 8000
 uv run autoctx mcp-serve
+uv run autoctx probes check --suite contract-probes.json
+uv run autoctx probes check --suite contract-probes.json --json
 uv run autoctx wait <condition_id> --json
 ```
 
@@ -227,6 +229,50 @@ uv run autoctx solve "improve customer-support replies for billing disputes" --i
 AUTOCONTEXT_AGENT_PROVIDER=deterministic AUTOCONTEXT_RLM_ENABLED=true \
 uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
+
+## Contract Probes
+
+`uv run autoctx probes check --suite <path>` runs the AC-728 contract-probe suite against observed harness state and reports per-probe pass/fail. It exits 0 on a full pass and 1 on any failure or any load / parse error. Default output is human-readable; pass `--json` to emit a structured `ContractProbeSuiteResult` payload (`{passed, results: [{kind, label?, passed, failures: [{kind, message, ...}]}]}`) that downstream tools can consume. On load / parse / validation failure, the typer wrapper writes the actionable error to stderr so `--json` consumers can safely parse stdout.
+
+The suite file is a JSON document validated by `ContractProbeSuiteSchema`. Every nested model is strict: unknown keys (for example a typo like `requiredStdoutPattern` missing the trailing `s`) fail validation rather than silently disappearing. Required observation fields (`presentFiles`, `observed`, `entries`, `ranks`) must be present and primitives are not coerced (`"exitCode": "0"` rejects). Optional expectation fields accept omission but not explicit `null`.
+
+Stdin form lets the canonical pipe pattern stay cross-platform:
+
+```bash
+uv run autoctx probes check --suite contract-probes.json --json
+cat contract-probes.json | uv run autoctx probes check --suite -
+```
+
+Minimal suite example:
+
+```json
+{
+  "schema_version": 1,
+  "probes": [
+    {
+      "kind": "terminal",
+      "label": "solve-cli",
+      "inputs": {
+        "exitCode": 0,
+        "stdout": "solution.txt written",
+        "stderr": "",
+        "requiredStdoutPatterns": ["solution\\.txt"]
+      }
+    },
+    {
+      "kind": "directory",
+      "label": "final-workdir",
+      "inputs": {
+        "presentFiles": ["solution.txt"],
+        "requiredFiles": ["solution.txt"],
+        "allowedFiles": ["solution.txt"]
+      }
+    }
+  ]
+}
+```
+
+The seven probe kinds (`directory`, `terminal`, `service`, `artifact`, `cleanup`, `media`, `distributed`) each verify a different facet of observed harness state. RegExp values accept a bare pattern string or `{"source": ..., "flags": ...}`; ISO-8601 strings parse to `datetime`. Every declared expectation must carry a corresponding observation; missing observations fail with kind `missing-observation` rather than silently passing.
 
 ## Training Workflow
 

--- a/autocontext/src/autocontext/cli_probes.py
+++ b/autocontext/src/autocontext/cli_probes.py
@@ -244,7 +244,14 @@ def register_probes_command(app: typer.Typer, *, console: Console) -> None:
             # console adds ANSI codes that break JSON consumers.
             print(result.stdout)
         if result.stderr:
-            console.print(result.stderr, style="red")
+            # PR #1008 review (P2): the parent `console` writes to
+            # stdout by default, so routing errors through it would
+            # contaminate `--json` output on load / parse / validation
+            # failures. Write directly to stderr instead.
+            sys.stderr.write(result.stderr)
+            if not result.stderr.endswith("\n"):
+                sys.stderr.write("\n")
+            sys.stderr.flush()
         raise typer.Exit(code=result.exit_code)
 
     app.add_typer(probes_app, name="probes")

--- a/autocontext/tests/control_plane/test_cli_probes.py
+++ b/autocontext/tests/control_plane/test_cli_probes.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from autocontext.cli import app
@@ -220,6 +221,39 @@ def test_typer_probes_check_json_emits_parseable_payload(tmp_path: Path) -> None
 def test_typer_probes_check_missing_suite_exits_nonzero() -> None:
     result = CliRunner().invoke(app, ["probes", "check"])
     assert result.exit_code == 1
+
+
+def test_typer_probes_check_json_failure_leaves_stdout_parseable(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """PR #1008 review (P2): errors used to flow through the rich
+    `console`, which writes to stdout by default. That contaminated
+    `--json` output on load / parse / validation failures, so
+    JSON-mode consumers could not safely parse stdout. The typer
+    wrapper now routes errors to real stderr.
+    """
+    missing = tmp_path / "nope.json"
+    # Use the in-process handler + capsys to assert the stdout / stderr
+    # split directly; CliRunner across click versions disagrees on
+    # `mix_stderr` so we exercise the typer wrapper via the typer app
+    # but inspect the raw streams via capsys.
+    import typer as _typer
+    from rich.console import Console as _Console
+
+    from autocontext.cli_probes import register_probes_command
+
+    local_app = _typer.Typer()
+    register_probes_command(local_app, console=_Console())
+    # Run the typer app directly; it raises typer.Exit on completion.
+    with pytest.raises(SystemExit):
+        local_app(["probes", "check", "--suite", str(missing), "--json"], standalone_mode=True)
+    captured = capsys.readouterr()
+    # stdout must be empty so JSON consumers do not choke on a
+    # human-readable error message.
+    assert captured.out == ""
+    # stderr carries the actionable error.
+    assert "failed to load suite" in captured.err
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two follow-ups to PR #1008 (AC-728 Python parity slice 4):

- **P2 (stderr routing)**: the typer wrapper routed `result.stderr` through the parent rich `Console`, which writes to stdout by default. That contaminated `--json` output on load/parse/validation failures. The wrapper now writes errors directly to `sys.stderr` (with a trailing newline if the rendered message lacks one), so JSON-mode consumers can safely parse stdout.
- **P3 (README)**: `cli_probes.py` claimed the suite format was documented in the autocontext README, but the Python README had no Contract Probes section. Adds two `probes check` lines to Main CLI Commands and a Contract Probes section with the canonical `--suite` / `--suite -` / `--json` forms, the strict schema invariants, a minimal two-probe example, and the seven probe kinds.

## Test plan

- [x] `uv run pytest tests/control_plane/` (92 passed: 91 prior + 1 new regression)
- [x] `uv run ruff check` clean
- [x] `uv run mypy src/autocontext/cli_probes.py` clean
- [ ] CI: green