### PR TITLE
feat(cli): AC-728 Python parity slice 5 (autoctx probes extract, 4 base)

### DIFF
--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -200,6 +200,8 @@ uv run autoctx serve --host 127.0.0.1 --port 8000
 uv run autoctx mcp-serve
 uv run autoctx probes check --suite contract-probes.json
 uv run autoctx probes check --suite contract-probes.json --json
+uv run autoctx probes extract --trace harness-trace.json
+uv run autoctx probes extract --trace harness-trace.json --output contract-probes.json
 uv run autoctx wait <condition_id> --json
 ```
 
@@ -273,6 +275,36 @@ Minimal suite example:
 ```
 
 The seven probe kinds (`directory`, `terminal`, `service`, `artifact`, `cleanup`, `media`, `distributed`) each verify a different facet of observed harness state. RegExp values accept a bare pattern string or `{"source": ..., "flags": ...}`; ISO-8601 strings parse to `datetime`. Every declared expectation must carry a corresponding observation; missing observations fail with kind `missing-observation` rather than silently passing.
+
+### Synthesizing a suite from a harness trace
+
+`uv run autoctx probes extract --trace <path>` reads a harness-trace JSON envelope that bundles two halves:
+
+- `observations`: what actually happened in a recorded run (terminal exit code / stdout / stderr; the workdir's present files; observed service endpoints; emitted artifacts and their content).
+- `expectations`: what the operator declared should have happened (expected exit code, required / allowed files, required endpoints, per-artifact JSON-field / substring / line-ending expectations).
+
+The extractor joins them into a runnable `ContractProbeSuite` that `autoctx probes check` can execute. Per-artifact expectations join observations by `path`; observations without a matching expectation are still encoded as no-op artifact probes (path + content only, no assertions). Orphan expectations (declared without a matching observation) fail validation at parse time rather than producing a vacuously-passing suite.
+
+Pipe form: `autoctx probes extract --trace t.json | autoctx probes check --suite -` works cross-platform; the typer wrapper writes parse / validation errors to stderr so JSON consumers can parse stdout cleanly. `--output <path>` writes the suite to a file (parent directories are created); omit it to emit to stdout.
+
+Slice 5 covers the four base probe kinds (`terminal`, `directory`, `service`, `artifact`); cleanup / media / distributed extraction lands in a follow-up slice. Minimal trace example:
+
+```json
+{
+  "schema_version": 1,
+  "label": "solve-cli",
+  "observations": {
+    "terminal": { "exitCode": 0, "stdout": "solution.txt written", "stderr": "" },
+    "workdir": { "presentFiles": ["solution.txt"] },
+    "artifacts": [{ "path": "solution.txt", "content": "answer\n" }]
+  },
+  "expectations": {
+    "terminal": { "requiredStdoutPatterns": ["solution\\.txt"] },
+    "directory": { "requiredFiles": ["solution.txt"], "allowedFiles": ["solution.txt"] },
+    "artifacts": [{ "path": "solution.txt", "requiredSubstrings": ["answer"] }]
+  }
+}
+```
 
 ## Training Workflow
 

--- a/autocontext/src/autocontext/cli_probes.py
+++ b/autocontext/src/autocontext/cli_probes.py
@@ -1,20 +1,29 @@
-"""AC-728 `autoctx probes` CLI surface (Python parity, slice 4).
+"""AC-728 `autoctx probes` CLI surface (Python parity, slices 4 + 5).
 
 Mirrors ``ts/src/control-plane/contract-probes/cli/check.ts`` (TS
-PR #991). In-process handler:
+PR #991) for ``check`` and the slice-1 portion of
+``ts/src/control-plane/contract-probes/cli/extract.ts`` (TS PR #992)
+for ``extract``. In-process handlers:
 
 - ``run_probes_check(args)`` parses args, loads the suite (file path
   or stdin via ``-``), runs ``run_contract_probe_suite``, and returns
-  ``{stdout, stderr, exit_code}``. Tests consume this directly so
-  there is no need to spawn a subprocess.
+  ``{stdout, stderr, exit_code}``.
+- ``run_probes_extract(args)`` parses args, loads + validates a
+  harness trace via ``HarnessTraceSchema``, joins observations with
+  expectations into a ``ContractProbeSuite``, and returns
+  ``{stdout, stderr, exit_code}``. The suite is emitted to stdout
+  by default; ``--output <path>`` writes it to a file (parent
+  directories created).
 - ``register_probes_command(app, *, console)`` mounts a ``probes``
-  sub-Typer with ``check`` as the first subcommand. The outer typer
-  command translates the in-process result to stdout / stderr /
-  ``typer.Exit``.
+  sub-Typer with ``check`` and ``extract`` subcommands. The outer
+  typer commands translate the in-process result to stdout / stderr
+  / ``typer.Exit``.
 
-Schema-invalid suites surface every Pydantic issue line by line so
-operators can fix typos at parse time rather than discover the
-missing expectation in a green-but-wrong run.
+Tests consume the in-process handlers directly so there is no need
+to spawn a subprocess. Schema-invalid suites or traces surface every
+Pydantic issue line by line so operators can fix typos at parse
+time rather than discover the missing expectation in a green-but-
+wrong run.
 """
 
 from __future__ import annotations
@@ -22,6 +31,7 @@ from __future__ import annotations
 import json
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 import typer
 from pydantic import ValidationError
@@ -33,12 +43,20 @@ from autocontext.control_plane.contract_probes import (
     load_contract_probe_suite,
     run_contract_probe_suite,
 )
+from autocontext.control_plane.contract_probes.extract import (
+    HarnessTraceSchema,
+    extract_contract_probe_suite,
+    serialize_suite,
+)
 
 __all__ = [
     "CHECK_HELP_TEXT",
+    "EXTRACT_HELP_TEXT",
     "ProbesCheckResult",
+    "ProbesExtractResult",
     "register_probes_command",
     "run_probes_check",
+    "run_probes_extract",
 ]
 
 
@@ -84,8 +102,48 @@ silently passing.
 """
 
 
+EXTRACT_HELP_TEXT = """autoctx probes extract -- synthesize a contract-probe suite from a harness trace.
+
+Usage:
+  autoctx probes extract --trace <path> [--output <path>]
+  autoctx probes extract --help
+
+A harness trace bundles observations (what happened in a recorded run)
+and expectations (what the operator declared should have happened). The
+extractor joins them into a runnable probe suite that `autoctx probes
+check` can execute. See the "Contract Probes" section of the autocontext
+README for the harness-trace JSON format and a minimal example.
+
+Options:
+  --trace <path>   Path to a harness-trace JSON file. Required.
+  --output <path>  Write the resulting suite to this path. Parent
+                   directories are created. If omitted, the suite is
+                   emitted to stdout so it can be piped to
+                   `autoctx probes check --suite -`.
+  -h, --help       Show this help text.
+
+Exit codes:
+  0   the trace parsed and a suite was emitted.
+  1   the trace failed to load / parse, or a write to --output failed.
+
+Slice 5 covers the four base probe kinds (terminal, directory,
+service, artifact); cleanup / media / distributed extraction lands
+in slice 6. Per-section observations and expectations must both be
+supplied for any kind the suite asserts on; orphan expectations
+fail validation at parse time rather than silently producing a
+vacuously-passing suite.
+"""
+
+
 @dataclass(frozen=True)
 class ProbesCheckResult:
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+@dataclass(frozen=True)
+class ProbesExtractResult:
     stdout: str
     stderr: str
     exit_code: int
@@ -216,9 +274,112 @@ def run_probes_check(
     )
 
 
+def run_probes_extract(args: list[str]) -> ProbesExtractResult:
+    """Pure in-process entry point for `autoctx probes extract`.
+
+    Parses argv, loads + validates a harness trace via
+    ``HarnessTraceSchema``, joins observations with expectations into
+    a ``ContractProbeSuite`` dict, and returns
+    ``{stdout, stderr, exit_code}``. Mirrors the TS handler shape so
+    tests can consume it directly without spawning a subprocess.
+    """
+    trace_path: str | None = None
+    output_path: str | None = None
+    help_flag = False
+
+    it = iter(args)
+    for arg in it:
+        if arg in ("-h", "--help"):
+            help_flag = True
+        elif arg == "--trace":
+            try:
+                trace_path = next(it)
+            except StopIteration:
+                return ProbesExtractResult(
+                    stdout="",
+                    stderr=f"autoctx probes extract: --trace requires a value\n\n{EXTRACT_HELP_TEXT}",
+                    exit_code=1,
+                )
+        elif arg.startswith("--trace="):
+            trace_path = arg.split("=", 1)[1]
+        elif arg == "--output":
+            try:
+                output_path = next(it)
+            except StopIteration:
+                return ProbesExtractResult(
+                    stdout="",
+                    stderr=f"autoctx probes extract: --output requires a value\n\n{EXTRACT_HELP_TEXT}",
+                    exit_code=1,
+                )
+        elif arg.startswith("--output="):
+            output_path = arg.split("=", 1)[1]
+        else:
+            return ProbesExtractResult(
+                stdout="",
+                stderr=f"autoctx probes extract: unknown argument {arg!r}\n\n{EXTRACT_HELP_TEXT}",
+                exit_code=1,
+            )
+
+    if help_flag:
+        return ProbesExtractResult(stdout=EXTRACT_HELP_TEXT, stderr="", exit_code=0)
+
+    if not trace_path:
+        return ProbesExtractResult(
+            stdout="",
+            stderr=f"autoctx probes extract: --trace <path> is required\n\n{EXTRACT_HELP_TEXT}",
+            exit_code=1,
+        )
+
+    try:
+        raw = Path(trace_path).read_text(encoding="utf-8")
+    except FileNotFoundError as err:
+        return ProbesExtractResult(
+            stdout="",
+            stderr=f"autoctx probes extract: failed to read trace from {trace_path}: {err}",
+            exit_code=1,
+        )
+
+    try:
+        parsed_json = json.loads(raw)
+    except json.JSONDecodeError as err:
+        return ProbesExtractResult(
+            stdout="",
+            stderr=f"autoctx probes extract: invalid JSON in {trace_path}: {err.msg}",
+            exit_code=1,
+        )
+
+    try:
+        trace = HarnessTraceSchema.model_validate(parsed_json)
+    except ValidationError as err:
+        rendered = _render_validation_error(err)
+        return ProbesExtractResult(
+            stdout="",
+            stderr=f"autoctx probes extract: trace validation failed\n{rendered}",
+            exit_code=1,
+        )
+
+    suite_dict = extract_contract_probe_suite(trace)
+    serialized = serialize_suite(suite_dict)
+
+    if output_path:
+        try:
+            out = Path(output_path)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(serialized + "\n", encoding="utf-8")
+        except OSError as err:
+            return ProbesExtractResult(
+                stdout="",
+                stderr=f"autoctx probes extract: failed to write suite to {output_path}: {err}",
+                exit_code=1,
+            )
+        return ProbesExtractResult(stdout=f"wrote suite to {output_path}", stderr="", exit_code=0)
+
+    return ProbesExtractResult(stdout=serialized, stderr="", exit_code=0)
+
+
 def register_probes_command(app: typer.Typer, *, console: Console) -> None:
-    """Mount the `probes` sub-Typer on ``app`` with `check` as the
-    first subcommand."""
+    """Mount the `probes` sub-Typer on ``app`` with `check` and
+    `extract` as the first two subcommands."""
     probes_app = typer.Typer(help="AC-728 contract probes.")
 
     @probes_app.command("check")
@@ -248,6 +409,40 @@ def register_probes_command(app: typer.Typer, *, console: Console) -> None:
             # stdout by default, so routing errors through it would
             # contaminate `--json` output on load / parse / validation
             # failures. Write directly to stderr instead.
+            sys.stderr.write(result.stderr)
+            if not result.stderr.endswith("\n"):
+                sys.stderr.write("\n")
+            sys.stderr.flush()
+        raise typer.Exit(code=result.exit_code)
+
+    @probes_app.command("extract")
+    def _extract(
+        trace: str = typer.Option(
+            "",
+            "--trace",
+            help="Path to a harness-trace JSON file.",
+        ),
+        output: str = typer.Option(
+            "",
+            "--output",
+            help="Write the resulting suite to this path (parent dirs created); omit to emit to stdout.",
+        ),
+    ) -> None:
+        """Synthesize a contract-probe suite from a harness trace."""
+        args: list[str] = []
+        if trace:
+            args.extend(["--trace", trace])
+        if output:
+            args.extend(["--output", output])
+        result = run_probes_extract(args)
+        if result.stdout:
+            # Plain stdout so the JSON suite is parseable; the rich
+            # console adds ANSI codes that break JSON consumers.
+            print(result.stdout)
+        if result.stderr:
+            # PR #1008 review (P2): same stderr-routing fix as `check`
+            # so the documented `extract | check` pipe pattern stays
+            # parseable even on parse / validation failures.
             sys.stderr.write(result.stderr)
             if not result.stderr.endswith("\n"):
                 sys.stderr.write("\n")

--- a/autocontext/src/autocontext/cli_probes.py
+++ b/autocontext/src/autocontext/cli_probes.py
@@ -332,7 +332,18 @@ def run_probes_extract(args: list[str]) -> ProbesExtractResult:
 
     try:
         raw = Path(trace_path).read_text(encoding="utf-8")
-    except FileNotFoundError as err:
+    except (OSError, UnicodeDecodeError) as err:
+        # PR #1010 review (P2): the previous `except FileNotFoundError`
+        # only handled the missing-file case. Passing a directory
+        # raised `IsADirectoryError`, permission errors raised
+        # `PermissionError`, and non-UTF8 files raised
+        # `UnicodeDecodeError` — all of which escaped as Rich
+        # tracebacks instead of returning a `ProbesExtractResult` with
+        # a friendly stderr message. Catching `OSError` covers the
+        # full filesystem-error family (it is the base of
+        # `FileNotFoundError`, `IsADirectoryError`,
+        # `PermissionError`, etc.) and `UnicodeDecodeError` covers
+        # the encoding case.
         return ProbesExtractResult(
             stdout="",
             stderr=f"autoctx probes extract: failed to read trace from {trace_path}: {err}",

--- a/autocontext/src/autocontext/control_plane/contract_probes/extract.py
+++ b/autocontext/src/autocontext/control_plane/contract_probes/extract.py
@@ -1,0 +1,333 @@
+"""AC-728 `autoctx probes extract` library surface (Python parity, slice 5).
+
+Mirrors the slice-1 / TS PR #992 portion of
+``ts/src/control-plane/contract-probes/cli/extract.ts``: reads a
+harness-trace JSON envelope and synthesises a runnable
+``ContractProbeSuite`` covering the four slice-1 probe kinds
+(terminal / directory / service / artifact). The advanced kinds
+(cleanup / media / distributed) land in slice 6.
+
+A harness trace bundles two halves:
+
+- ``observations``: what actually happened in a recorded run.
+- ``expectations``: what the operator declared should have happened.
+
+The extractor joins them. Per the slice-1 audit invariant, every
+declared expectation must have a matching observation; orphan
+expectations fail validation at parse time rather than silently
+producing a vacuously-passing suite.
+
+Module split lives next to ``runner.py`` so both load the same
+``ContractProbeSuite`` and ``_PatternList`` helpers.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal
+
+from pydantic import (
+    StrictInt,
+    model_validator,
+)
+
+from .runner import (
+    _PatternList,
+    _Strict,
+)
+
+__all__ = [
+    "HarnessTrace",
+    "HarnessTraceSchema",
+    "extract_contract_probe_suite",
+    "load_harness_trace",
+    "serialize_suite",
+]
+
+
+# ---------------------------------------------------------------------------
+# Per-kind observation + expectation schemas
+# ---------------------------------------------------------------------------
+
+
+class _TerminalObservation(_Strict):
+    exitCode: StrictInt
+    stdout: str = ""
+    stderr: str = ""
+
+
+class _TerminalExpectations(_Strict):
+    expectedExitCode: StrictInt | None = None
+    requiredStdoutPatterns: _PatternList | None = None
+    forbiddenStdoutPatterns: _PatternList | None = None
+    requiredStderrPatterns: _PatternList | None = None
+    forbiddenStderrPatterns: _PatternList | None = None
+
+
+class _WorkdirObservation(_Strict):
+    presentFiles: tuple[str, ...]
+
+
+class _DirectoryExpectations(_Strict):
+    requiredFiles: tuple[str, ...] = ()
+    allowedFiles: tuple[str, ...] = ()
+    ignoredPatterns: _PatternList | None = None
+
+
+class _ServiceEndpointSchema(_Strict):
+    host: str
+    port: StrictInt
+    protocol: Literal["tcp", "udp"] | None = None
+
+
+class _ServiceExpectations(_Strict):
+    required: tuple[_ServiceEndpointSchema, ...] = ()
+    allowed: tuple[_ServiceEndpointSchema, ...] | None = None
+
+
+class _ArtifactObservation(_Strict):
+    path: str
+    content: str
+
+
+class _ArtifactExpectations(_Strict):
+    path: str
+    label: str | None = None
+    expectedLineEnding: Literal["lf", "crlf"] | None = None
+    requiredSubstrings: tuple[str, ...] | None = None
+    forbiddenSubstrings: tuple[str, ...] | None = None
+    requiredJsonFields: tuple[str, ...] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Trace envelope
+# ---------------------------------------------------------------------------
+
+
+class _HarnessObservations(_Strict):
+    terminal: _TerminalObservation | None = None
+    workdir: _WorkdirObservation | None = None
+    services: tuple[_ServiceEndpointSchema, ...] | None = None
+    artifacts: tuple[_ArtifactObservation, ...] | None = None
+
+
+class _HarnessExpectations(_Strict):
+    terminal: _TerminalExpectations | None = None
+    directory: _DirectoryExpectations | None = None
+    services: _ServiceExpectations | None = None
+    artifacts: tuple[_ArtifactExpectations, ...] | None = None
+
+
+class HarnessTrace(_Strict):
+    """Slice-5 harness-trace envelope: 4 base probe kinds only.
+
+    Slice 6 will extend ``observations`` / ``expectations`` with
+    cleanup / media / distributed sections. The envelope itself
+    forbids unknown keys today, so adding sections in slice 6 is a
+    visible source change.
+    """
+
+    schema_version: Literal[1]
+    label: str | None = None
+    observations: _HarnessObservations
+    expectations: _HarnessExpectations | None = None
+
+    @model_validator(mode="after")
+    def _check_orphan_expectations(self) -> HarnessTrace:
+        """Every declared expectation must have its matching observation.
+
+        Mirrors the TS ``superRefine`` (PR #992 review P2): without
+        this guard an expectation-only section would be silently
+        dropped at extraction time and the resulting suite would
+        pass vacuously. The slice-1 audit invariant says: corrupted
+        traces fail loudly, not silently.
+        """
+        if self.expectations is None:
+            return self
+
+        violations: list[str] = []
+        obs = self.observations
+        exp = self.expectations
+
+        if exp.terminal is not None and obs.terminal is None:
+            violations.append(
+                "expectations.terminal: declared without observations.terminal; add terminal exit code / stdout / stderr"
+            )
+        if exp.directory is not None and obs.workdir is None:
+            violations.append("expectations.directory: declared without observations.workdir; add the present-files list")
+        if exp.services is not None and obs.services is None:
+            violations.append("expectations.services: declared without observations.services; add the observed endpoints list")
+
+        if exp.artifacts is not None:
+            if obs.artifacts is None:
+                violations.append(
+                    "expectations.artifacts: per-artifact expectations declared "
+                    "without observations.artifacts; add the matching observations"
+                )
+            else:
+                observed_paths = {a.path for a in obs.artifacts}
+                seen_paths: set[str] = set()
+                for index, art_exp in enumerate(exp.artifacts):
+                    if art_exp.path not in observed_paths:
+                        violations.append(
+                            f"expectations.artifacts.{index}.path: expectation "
+                            f"references {art_exp.path!r} but no observation "
+                            "with that path was recorded"
+                        )
+                    if art_exp.path in seen_paths:
+                        violations.append(
+                            f"expectations.artifacts.{index}.path: duplicate "
+                            f"per-artifact expectation for {art_exp.path!r}; "
+                            "merge into a single entry"
+                        )
+                    seen_paths.add(art_exp.path)
+
+        if violations:
+            raise ValueError("\n".join(violations))
+        return self
+
+
+HarnessTraceSchema = HarnessTrace
+
+
+# ---------------------------------------------------------------------------
+# Extractor
+# ---------------------------------------------------------------------------
+
+
+def _service_endpoint_dict(endpoint: _ServiceEndpointSchema) -> dict:
+    payload = {"host": endpoint.host, "port": endpoint.port}
+    if endpoint.protocol is not None:
+        payload["protocol"] = endpoint.protocol
+    return payload
+
+
+def _patterns_dict_list(patterns: tuple) -> list[dict]:
+    """Serialise a ``_PatternList`` as a list of ``{source, flags}`` dicts.
+
+    The runner schema accepts either bare strings or ``{source, flags}``
+    objects. Emitting the dict form preserves any flags set on the
+    compiled pattern.
+    """
+    out: list[dict] = []
+    flag_chars = {
+        2: "i",  # re.IGNORECASE
+        8: "m",  # re.MULTILINE
+        16: "s",  # re.DOTALL
+        64: "x",  # re.VERBOSE
+        32: "u",  # re.UNICODE
+    }
+    for pat in patterns:
+        flags = ""
+        for bit, ch in flag_chars.items():
+            if pat.flags & bit:
+                flags += ch
+        # re.UNICODE is set by default in Python 3 for str patterns; drop
+        # it from the serialised flag string so round-trips do not gain
+        # a spurious `u`.
+        flags = flags.replace("u", "")
+        entry: dict = {"source": pat.pattern}
+        if flags:
+            entry["flags"] = flags
+        out.append(entry)
+    return out
+
+
+def extract_contract_probe_suite(trace: HarnessTrace) -> dict:
+    """Build a ``ContractProbeSuite`` dict from a harness trace.
+
+    Returns a plain dict matching the slice-3 suite wire format so
+    callers can serialise it directly via ``json.dumps`` without an
+    intermediate model dump. Pure function; no IO.
+    """
+    probes: list[dict] = []
+    label = trace.label
+    expectations = trace.expectations
+
+    if trace.observations.terminal is not None:
+        term_exp = expectations.terminal if expectations else None
+        inputs: dict = {
+            "exitCode": trace.observations.terminal.exitCode,
+            "stdout": trace.observations.terminal.stdout,
+            "stderr": trace.observations.terminal.stderr,
+        }
+        if term_exp is not None:
+            if term_exp.expectedExitCode is not None:
+                inputs["expectedExitCode"] = term_exp.expectedExitCode
+            if term_exp.requiredStdoutPatterns is not None:
+                inputs["requiredStdoutPatterns"] = _patterns_dict_list(term_exp.requiredStdoutPatterns)
+            if term_exp.forbiddenStdoutPatterns is not None:
+                inputs["forbiddenStdoutPatterns"] = _patterns_dict_list(term_exp.forbiddenStdoutPatterns)
+            if term_exp.requiredStderrPatterns is not None:
+                inputs["requiredStderrPatterns"] = _patterns_dict_list(term_exp.requiredStderrPatterns)
+            if term_exp.forbiddenStderrPatterns is not None:
+                inputs["forbiddenStderrPatterns"] = _patterns_dict_list(term_exp.forbiddenStderrPatterns)
+        probe: dict = {"kind": "terminal", "inputs": inputs}
+        if label is not None:
+            probe["label"] = label
+        probes.append(probe)
+
+    if trace.observations.workdir is not None:
+        dir_exp = expectations.directory if expectations else None
+        inputs = {
+            "presentFiles": list(trace.observations.workdir.presentFiles),
+            "requiredFiles": list(dir_exp.requiredFiles) if dir_exp else [],
+            "allowedFiles": list(dir_exp.allowedFiles) if dir_exp else [],
+        }
+        if dir_exp is not None and dir_exp.ignoredPatterns is not None:
+            inputs["ignoredPatterns"] = _patterns_dict_list(dir_exp.ignoredPatterns)
+        probe = {"kind": "directory", "inputs": inputs}
+        if label is not None:
+            probe["label"] = label
+        probes.append(probe)
+
+    if trace.observations.services is not None:
+        svc_exp = expectations.services if expectations else None
+        inputs = {
+            "observed": [_service_endpoint_dict(e) for e in trace.observations.services],
+            "required": [_service_endpoint_dict(e) for e in svc_exp.required] if svc_exp is not None else [],
+        }
+        if svc_exp is not None and svc_exp.allowed is not None:
+            inputs["allowed"] = [_service_endpoint_dict(e) for e in svc_exp.allowed]
+        probe = {"kind": "service", "inputs": inputs}
+        if label is not None:
+            probe["label"] = label
+        probes.append(probe)
+
+    if trace.observations.artifacts is not None:
+        artifact_exp_by_path: dict[str, _ArtifactExpectations] = {}
+        if expectations is not None and expectations.artifacts is not None:
+            for declared_exp in expectations.artifacts:
+                artifact_exp_by_path[declared_exp.path] = declared_exp
+        for artifact in trace.observations.artifacts:
+            art_exp = artifact_exp_by_path.get(artifact.path)
+            inputs = {"path": artifact.path, "content": artifact.content}
+            if art_exp is not None:
+                if art_exp.expectedLineEnding is not None:
+                    inputs["expectedLineEnding"] = art_exp.expectedLineEnding
+                if art_exp.requiredSubstrings is not None:
+                    inputs["requiredSubstrings"] = list(art_exp.requiredSubstrings)
+                if art_exp.forbiddenSubstrings is not None:
+                    inputs["forbiddenSubstrings"] = list(art_exp.forbiddenSubstrings)
+                if art_exp.requiredJsonFields is not None:
+                    inputs["requiredJsonFields"] = list(art_exp.requiredJsonFields)
+            probe = {"kind": "artifact", "inputs": inputs}
+            probe_label = art_exp.label if art_exp is not None and art_exp.label is not None else label
+            if probe_label is not None:
+                probe["label"] = probe_label
+            probes.append(probe)
+
+    return {"schema_version": 1, "probes": probes}
+
+
+def serialize_suite(suite: dict) -> str:
+    """Serialise an extracted suite to JSON suitable for the suite runner."""
+    return json.dumps(suite, indent=2)
+
+
+def load_harness_trace(path: str | Path) -> HarnessTrace:
+    """Load a harness trace JSON file and validate it."""
+    raw = Path(path).read_text(encoding="utf-8")
+    parsed = json.loads(raw)
+    return HarnessTraceSchema.model_validate(parsed)

--- a/autocontext/tests/control_plane/test_cli_probes_extract.py
+++ b/autocontext/tests/control_plane/test_cli_probes_extract.py
@@ -1,0 +1,392 @@
+"""AC-728 `autoctx probes extract` parity tests (slice 5).
+
+Mirrors the slice-5/TS PR #992 test surface from
+``ts/tests/control-plane/contract-probes/contract-probes.test.ts``.
+Covers the four base probe kinds (terminal, directory, service,
+artifact). Cleanup / media / distributed land in slice 6.
+
+The in-process handler ``run_probes_extract`` returns
+``{stdout, stderr, exit_code}`` so the tests consume it directly
+without spawning a subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from autocontext.cli_probes import (
+    EXTRACT_HELP_TEXT,
+    ProbesExtractResult,
+    run_probes_check,
+    run_probes_extract,
+)
+from autocontext.control_plane.contract_probes import (
+    ContractProbeSuiteSchema,
+    run_contract_probe_suite,
+)
+from autocontext.control_plane.contract_probes.extract import (
+    HarnessTraceSchema,
+    extract_contract_probe_suite,
+)
+
+
+def _write(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload))
+    return path
+
+
+def _terminal_trace() -> dict:
+    return {
+        "schema_version": 1,
+        "observations": {"terminal": {"exitCode": 0, "stdout": "solution.txt", "stderr": ""}},
+        "expectations": {
+            "terminal": {"requiredStdoutPatterns": [r"solution\.txt"]},
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# argv parsing
+# ---------------------------------------------------------------------------
+
+
+def test_help_flag_emits_help_text() -> None:
+    result = run_probes_extract(["--help"])
+    assert result.exit_code == 0
+    assert "autoctx probes extract" in result.stdout
+
+
+def test_missing_trace_arg_rejected() -> None:
+    result = run_probes_extract([])
+    assert result.exit_code == 1
+    assert "--trace" in result.stderr
+
+
+def test_unknown_flag_rejected() -> None:
+    result = run_probes_extract(["--nope"])
+    assert result.exit_code == 1
+    assert "unknown argument" in result.stderr
+
+
+def test_trace_equal_form_accepted(tmp_path: Path) -> None:
+    trace_path = _write(tmp_path / "t.json", _terminal_trace())
+    result = run_probes_extract([f"--trace={trace_path}"])
+    assert result.exit_code == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# load + parse errors
+# ---------------------------------------------------------------------------
+
+
+def test_missing_file_surfaces_load_error(tmp_path: Path) -> None:
+    result = run_probes_extract(["--trace", str(tmp_path / "nope.json")])
+    assert result.exit_code == 1
+    assert "failed to read trace" in result.stderr
+
+
+def test_malformed_json_rejected(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    result = run_probes_extract(["--trace", str(bad)])
+    assert result.exit_code == 1
+    assert "invalid JSON" in result.stderr
+
+
+def test_schema_invalid_trace_surfaces_validation_issues(tmp_path: Path) -> None:
+    """A typo at the trace envelope must reject with the dotted path."""
+    trace = tmp_path / "bad.json"
+    _write(trace, {"schema_version": 1, "observations": {"terminalx": {}}})
+    result = run_probes_extract(["--trace", str(trace)])
+    assert result.exit_code == 1
+    assert "trace validation failed" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# orphan-expectation rejection (slice-1 audit invariant)
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_expectation_without_observation_rejected() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {},
+                "expectations": {"terminal": {"expectedExitCode": 0}},
+            }
+        )
+    assert "expectations.terminal" in str(excinfo.value)
+
+
+def test_directory_expectation_without_workdir_observation_rejected() -> None:
+    with pytest.raises(ValidationError):
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {},
+                "expectations": {"directory": {"requiredFiles": ["solution.txt"]}},
+            }
+        )
+
+
+def test_services_expectation_without_observation_rejected() -> None:
+    with pytest.raises(ValidationError):
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {},
+                "expectations": {"services": {"required": [{"host": "127.0.0.1", "port": 8000}]}},
+            }
+        )
+
+
+def test_artifact_expectation_without_observation_rejected() -> None:
+    with pytest.raises(ValidationError):
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {},
+                "expectations": {"artifacts": [{"path": "out.json"}]},
+            }
+        )
+
+
+def test_artifact_expectation_with_unknown_path_rejected() -> None:
+    """Per-artifact expectations must reference an observed path."""
+    with pytest.raises(ValidationError) as excinfo:
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {
+                    "artifacts": [{"path": "out.json", "content": "{}"}],
+                },
+                "expectations": {
+                    "artifacts": [{"path": "missing.json"}],
+                },
+            }
+        )
+    assert "missing.json" in str(excinfo.value)
+
+
+def test_duplicate_per_artifact_expectation_rejected() -> None:
+    """PR #993 review (P2): duplicate per-path expectations silently
+    lost assertions because the extractor stored them in a Map keyed
+    by path. Reject duplicates at parse time."""
+    with pytest.raises(ValidationError) as excinfo:
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {
+                    "artifacts": [{"path": "out.json", "content": "{}"}],
+                },
+                "expectations": {
+                    "artifacts": [
+                        {"path": "out.json", "requiredSubstrings": ["a"]},
+                        {"path": "out.json", "requiredSubstrings": ["b"]},
+                    ],
+                },
+            }
+        )
+    assert "duplicate" in str(excinfo.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# extractor join shape
+# ---------------------------------------------------------------------------
+
+
+def test_observation_only_terminal_passes_default() -> None:
+    """A terminal observation with no expectations produces a probe
+    that checks the default exit-code-0 contract (no patterns)."""
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {"terminal": {"exitCode": 0, "stdout": "", "stderr": ""}},
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    assert suite_dict["probes"][0]["kind"] == "terminal"
+    # No expectation-side fields injected.
+    assert "expectedExitCode" not in suite_dict["probes"][0]["inputs"]
+
+
+def test_observation_only_workdir_passes_with_empty_required_and_allowed() -> None:
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {"workdir": {"presentFiles": ["solution.txt"]}},
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    inputs = suite_dict["probes"][0]["inputs"]
+    assert inputs["presentFiles"] == ["solution.txt"]
+    # No expectations -> empty required/allowed lists; the suite-runner
+    # schema requires these fields, so the extractor populates them.
+    assert inputs["requiredFiles"] == []
+    assert inputs["allowedFiles"] == []
+
+
+def test_terminal_join_with_required_pattern_succeeds() -> None:
+    trace = HarnessTraceSchema.model_validate(_terminal_trace())
+    suite_dict = extract_contract_probe_suite(trace)
+    suite = ContractProbeSuiteSchema.model_validate(suite_dict)
+    result = run_contract_probe_suite(suite)
+    assert result.passed is True
+
+
+def test_directory_join_required_and_allowed_files_succeeds() -> None:
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {"workdir": {"presentFiles": ["solution.txt"]}},
+            "expectations": {
+                "directory": {
+                    "requiredFiles": ["solution.txt"],
+                    "allowedFiles": ["solution.txt"],
+                }
+            },
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    suite = ContractProbeSuiteSchema.model_validate(suite_dict)
+    result = run_contract_probe_suite(suite)
+    assert result.passed is True
+
+
+def test_service_join_required_and_allowed_succeeds() -> None:
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {"services": [{"host": "127.0.0.1", "port": 8000}]},
+            "expectations": {
+                "services": {
+                    "required": [{"host": "127.0.0.1", "port": 8000}],
+                    "allowed": [{"host": "127.0.0.1", "port": 8000}],
+                }
+            },
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    suite = ContractProbeSuiteSchema.model_validate(suite_dict)
+    result = run_contract_probe_suite(suite)
+    assert result.passed is True
+
+
+def test_artifact_join_by_path_and_no_expectation_path_emits_no_op() -> None:
+    """An artifact observation with no matching expectation is still
+    encoded as a probe (path + content). Mirrors TS."""
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {
+                "artifacts": [
+                    {"path": "out.json", "content": '{"ok": true}'},
+                    {"path": "noexp.txt", "content": "hi"},
+                ]
+            },
+            "expectations": {
+                "artifacts": [{"path": "out.json", "requiredSubstrings": ["ok"]}],
+            },
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    paths = [p["inputs"]["path"] for p in suite_dict["probes"]]
+    assert paths == ["out.json", "noexp.txt"]
+    # First probe has the substring assertion; second has no assertions.
+    assert suite_dict["probes"][0]["inputs"]["requiredSubstrings"] == ["ok"]
+    assert "requiredSubstrings" not in suite_dict["probes"][1]["inputs"]
+
+
+def test_extracted_suite_passes_runner_validation_round_trip(tmp_path: Path) -> None:
+    """Every extracted suite must parse cleanly against the runner
+    schema. This is the slice-1 round-trip invariant."""
+    trace_path = _write(tmp_path / "t.json", _terminal_trace())
+    result = run_probes_extract(["--trace", str(trace_path)])
+    assert result.exit_code == 0
+    suite_dict = json.loads(result.stdout)
+    suite = ContractProbeSuiteSchema.model_validate(suite_dict)
+    run = run_contract_probe_suite(suite)
+    assert run.passed is True
+
+
+# ---------------------------------------------------------------------------
+# label propagation
+# ---------------------------------------------------------------------------
+
+
+def test_label_propagates_to_emitted_probes() -> None:
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "label": "demo",
+            "observations": {"terminal": {"exitCode": 0}},
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    assert suite_dict["probes"][0]["label"] == "demo"
+
+
+def test_per_artifact_label_overrides_trace_label() -> None:
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "label": "trace-label",
+            "observations": {"artifacts": [{"path": "x", "content": ""}]},
+            "expectations": {"artifacts": [{"path": "x", "label": "per-artifact"}]},
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    assert suite_dict["probes"][0]["label"] == "per-artifact"
+
+
+# ---------------------------------------------------------------------------
+# --output writes a file
+# ---------------------------------------------------------------------------
+
+
+def test_output_writes_suite_to_file_and_creates_parents(tmp_path: Path) -> None:
+    trace_path = _write(tmp_path / "t.json", _terminal_trace())
+    out_path = tmp_path / "nested" / "dir" / "suite.json"
+    result = run_probes_extract(["--trace", str(trace_path), "--output", str(out_path)])
+    assert result.exit_code == 0, result.stderr
+    assert "wrote suite" in result.stdout
+    assert out_path.exists()
+    # The written file is a valid suite.
+    suite_dict = json.loads(out_path.read_text())
+    suite = ContractProbeSuiteSchema.model_validate(suite_dict)
+    assert suite.schema_version == 1
+
+
+# ---------------------------------------------------------------------------
+# extract | check pipe round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_extract_then_check_pipe_round_trip(tmp_path: Path) -> None:
+    trace_path = _write(tmp_path / "t.json", _terminal_trace())
+    extract_result = run_probes_extract(["--trace", str(trace_path)])
+    assert extract_result.exit_code == 0
+    check_result = run_probes_check(["--suite", "-"], stdin_text=extract_result.stdout)
+    assert check_result.exit_code == 0
+    assert "probes check: PASS" in check_result.stdout
+
+
+# ---------------------------------------------------------------------------
+# dataclass + help text invariants
+# ---------------------------------------------------------------------------
+
+
+def test_help_text_documents_slice_5_scope() -> None:
+    assert "terminal" in EXTRACT_HELP_TEXT
+    assert "artifact" in EXTRACT_HELP_TEXT
+
+
+def test_result_dataclass_is_frozen() -> None:
+    result = ProbesExtractResult(stdout="x", stderr="y", exit_code=0)
+    with pytest.raises(AttributeError):
+        result.stdout = "z"  # type: ignore[misc]

--- a/autocontext/tests/control_plane/test_cli_probes_extract.py
+++ b/autocontext/tests/control_plane/test_cli_probes_extract.py
@@ -89,6 +89,30 @@ def test_missing_file_surfaces_load_error(tmp_path: Path) -> None:
     assert "failed to read trace" in result.stderr
 
 
+def test_passing_a_directory_surfaces_load_error_not_traceback(tmp_path: Path) -> None:
+    """PR #1010 review (P2): the previous `except FileNotFoundError`
+    only handled the missing-file case. Passing a directory raised
+    `IsADirectoryError`, which escaped as a Rich traceback instead of
+    a friendly stderr message. Catching `OSError` covers the family.
+    """
+    result = run_probes_extract(["--trace", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "failed to read trace" in result.stderr
+
+
+def test_non_utf8_trace_file_surfaces_load_error(tmp_path: Path) -> None:
+    """PR #1010 review (P2): a non-UTF8 trace file raised
+    `UnicodeDecodeError` from `read_text(encoding="utf-8")`. Catch it
+    too so the error returns through the same `failed to read trace`
+    stderr path.
+    """
+    bad = tmp_path / "binary.json"
+    bad.write_bytes(b"\xff\xfe\x00\x00not valid utf-8")
+    result = run_probes_extract(["--trace", str(bad)])
+    assert result.exit_code == 1
+    assert "failed to read trace" in result.stderr
+
+
 def test_malformed_json_rejected(tmp_path: Path) -> None:
     bad = tmp_path / "bad.json"
     bad.write_text("{not json")


### PR DESCRIPTION
## Summary

- Mirrors the slice-1 portion of `ts/src/control-plane/contract-probes/cli/extract.ts` (TS PR #992). New `autocontext.control_plane.contract_probes.extract` module exposes `HarnessTraceSchema` (Pydantic v2) and `extract_contract_probe_suite(trace)` that joins observations with expectations into a runnable `ContractProbeSuite` dict.
- Slice-1 audit invariant: orphan expectations reject at parse time via `model_validator(mode="after")`. Per-artifact expectations join observations by `path`; unknown paths and duplicate per-path entries reject (PR #993 review P2 parity).
- `autocontext.cli_probes` extended with `EXTRACT_HELP_TEXT`, `ProbesExtractResult`, `run_probes_extract(args)`, and an `extract` typer subcommand. Errors route to `sys.stderr` so the `extract | check` pipe stays parseable on parse/validation failure.

## Test plan

- [x] `uv run pytest tests/control_plane/` (118 passed: 92 prior + 26 new)
- [x] `uv run pytest tests/test_module_size_limits.py` clean (`extract.py` 333 lines, `cli_probes.py` 452 lines)
- [x] `uv run ruff check` clean
- [x] `uv run mypy src/autocontext/control_plane/ src/autocontext/cli_probes.py` clean
- [ ] CI: green

## Slice plan (7 total)

- slice 1 (#1004, merged): 4 base probes
- slice 2 (#1005, merged): 3 advanced probes + missing-observation invariant
- slice 3 (#1006, merged): suite runner + Pydantic schema
- slice 4 (#1008, merged): `autoctx probes check` CLI
- slice 4 follow-up (#1009, merged): stderr routing + README
- **slice 5 (this PR)**: `autoctx probes extract` for 4 base probes
- slice 6: extend extract to cleanup / media / distributed (mirrors TS PR #993)
- slice 7: missing-observation audit close-out