### PR TITLE
feat(cli): AC-728 Python parity slice 6 (extract cleanup/media/distributed)

### DIFF
--- a/autocontext/src/autocontext/cli_probes.py
+++ b/autocontext/src/autocontext/cli_probes.py
@@ -126,12 +126,13 @@ Exit codes:
   0   the trace parsed and a suite was emitted.
   1   the trace failed to load / parse, or a write to --output failed.
 
-Slice 5 covers the four base probe kinds (terminal, directory,
-service, artifact); cleanup / media / distributed extraction lands
-in slice 6. Per-section observations and expectations must both be
-supplied for any kind the suite asserts on; orphan expectations
-fail validation at parse time rather than silently producing a
-vacuously-passing suite.
+Covers all seven AC-728 probe kinds: terminal, directory, service,
+artifact, cleanup, media, distributed. Per-section observations and
+expectations must both be supplied for any kind the suite asserts
+on; orphan expectations fail validation at parse time rather than
+silently producing a vacuously-passing suite. Rank-scoped
+distributed expectations (`expectedSteps`, `mustMatchAcrossRanks`)
+require at least one rank report to be present.
 """
 
 

--- a/autocontext/src/autocontext/control_plane/contract_probes/extract.py
+++ b/autocontext/src/autocontext/control_plane/contract_probes/extract.py
@@ -1,11 +1,11 @@
-"""AC-728 `autoctx probes extract` library surface (Python parity, slice 5).
+"""AC-728 `autoctx probes extract` library surface (Python parity, slices 5 + 6).
 
-Mirrors the slice-1 / TS PR #992 portion of
-``ts/src/control-plane/contract-probes/cli/extract.ts``: reads a
-harness-trace JSON envelope and synthesises a runnable
-``ContractProbeSuite`` covering the four slice-1 probe kinds
-(terminal / directory / service / artifact). The advanced kinds
-(cleanup / media / distributed) land in slice 6.
+Mirrors ``ts/src/control-plane/contract-probes/cli/extract.ts`` (TS
+PRs #992 + #993): reads a harness-trace JSON envelope and
+synthesises a runnable ``ContractProbeSuite`` covering all seven
+AC-728 probe kinds. Slice 5 shipped the four base kinds (terminal /
+directory / service / artifact); slice 6 extends coverage to
+cleanup / media / distributed.
 
 A harness trace bundles two halves:
 
@@ -15,7 +15,11 @@ A harness trace bundles two halves:
 The extractor joins them. Per the slice-1 audit invariant, every
 declared expectation must have a matching observation; orphan
 expectations fail validation at parse time rather than silently
-producing a vacuously-passing suite.
+producing a vacuously-passing suite. Per the slice-2 P2 fix,
+rank-scoped distributed expectations (``expectedSteps``,
+``mustMatchAcrossRanks``) reject when the trace records zero ranks;
+the non-rank-scoped ``expectedWorldSize`` is fine to declare even
+against an empty rank list.
 
 Module split lives next to ``runner.py`` so both load the same
 ``ContractProbeSuite`` and ``_PatternList`` helpers.
@@ -24,10 +28,12 @@ Module split lives next to ``runner.py`` so both load the same
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
 from pydantic import (
+    StrictBool,
     StrictInt,
     model_validator,
 )
@@ -101,6 +107,75 @@ class _ArtifactExpectations(_Strict):
 
 
 # ---------------------------------------------------------------------------
+# slice 6: cleanup / media / distributed observation + expectation schemas
+# ---------------------------------------------------------------------------
+
+
+class _CleanupEntrySchema(_Strict):
+    path: str
+    isSymlink: StrictBool | None = None
+    symlinkTarget: str | None = None
+    symlinkBroken: StrictBool | None = None
+    mtime: datetime | None = None
+
+
+class _CleanupObservation(_Strict):
+    entries: tuple[_CleanupEntrySchema, ...]
+
+
+class _CleanupExpectations(_Strict):
+    now: datetime | None = None
+    maxLockfileAgeMs: StrictInt | None = None
+    lockfilePatterns: _PatternList | None = None
+    sidecarPatterns: _PatternList | None = None
+    backupPatterns: _PatternList | None = None
+    forbidSymlinks: StrictBool | None = None
+    allowedSymlinkTargets: tuple[str, ...] | None = None
+    ignoredPatterns: _PatternList | None = None
+
+
+class _MediaObservation(_Strict):
+    path: str
+    headerBytes: tuple[StrictInt, ...] | None = None
+    width: StrictInt | None = None
+    height: StrictInt | None = None
+    byteSize: StrictInt | None = None
+    columnCount: StrictInt | None = None
+    columnNames: tuple[str, ...] | None = None
+    lineCount: StrictInt | None = None
+
+
+class _MediaExpectations(_Strict):
+    path: str
+    label: str | None = None
+    expectedMagicBytes: tuple[StrictInt, ...] | None = None
+    expectedWidth: StrictInt | None = None
+    expectedHeight: StrictInt | None = None
+    minByteSize: StrictInt | None = None
+    maxByteSize: StrictInt | None = None
+    expectedColumnCount: StrictInt | None = None
+    requiredColumnNames: tuple[str, ...] | None = None
+    expectedLineCount: StrictInt | None = None
+
+
+class _DistributedRankSchema(_Strict):
+    rank: StrictInt
+    steps: StrictInt | None = None
+    observations: dict[str, str] | None = None
+
+
+class _DistributedObservation(_Strict):
+    worldSize: StrictInt | None = None
+    ranks: tuple[_DistributedRankSchema, ...]
+
+
+class _DistributedExpectations(_Strict):
+    expectedWorldSize: StrictInt | None = None
+    expectedSteps: StrictInt | None = None
+    mustMatchAcrossRanks: tuple[str, ...] | None = None
+
+
+# ---------------------------------------------------------------------------
 # Trace envelope
 # ---------------------------------------------------------------------------
 
@@ -110,6 +185,9 @@ class _HarnessObservations(_Strict):
     workdir: _WorkdirObservation | None = None
     services: tuple[_ServiceEndpointSchema, ...] | None = None
     artifacts: tuple[_ArtifactObservation, ...] | None = None
+    cleanup: _CleanupObservation | None = None
+    media: tuple[_MediaObservation, ...] | None = None
+    distributed: _DistributedObservation | None = None
 
 
 class _HarnessExpectations(_Strict):
@@ -117,6 +195,9 @@ class _HarnessExpectations(_Strict):
     directory: _DirectoryExpectations | None = None
     services: _ServiceExpectations | None = None
     artifacts: tuple[_ArtifactExpectations, ...] | None = None
+    cleanup: _CleanupExpectations | None = None
+    media: tuple[_MediaExpectations, ...] | None = None
+    distributed: _DistributedExpectations | None = None
 
 
 class HarnessTrace(_Strict):
@@ -182,6 +263,66 @@ class HarnessTrace(_Strict):
                             "merge into a single entry"
                         )
                     seen_paths.add(art_exp.path)
+
+        # ---- slice 6: cleanup / media / distributed ----------------------
+
+        if exp.cleanup is not None and obs.cleanup is None:
+            violations.append("expectations.cleanup: declared without observations.cleanup.entries; add the directory listing")
+
+        if exp.media is not None:
+            if obs.media is None:
+                violations.append(
+                    "expectations.media: per-media expectations declared "
+                    "without observations.media; add the matching observations"
+                )
+            else:
+                observed_media_paths = {m.path for m in obs.media}
+                seen_media_paths: set[str] = set()
+                for index, m_exp in enumerate(exp.media):
+                    if m_exp.path not in observed_media_paths:
+                        violations.append(
+                            f"expectations.media.{index}.path: expectation "
+                            f"references {m_exp.path!r} but no observation "
+                            "with that path was recorded"
+                        )
+                    if m_exp.path in seen_media_paths:
+                        # PR #993 review (P2) parity: duplicate per-media
+                        # expectations silently lost assertions because the
+                        # extractor stored them in a path-keyed dict. Reject
+                        # at parse time rather than overwrite.
+                        violations.append(
+                            f"expectations.media.{index}.path: duplicate "
+                            f"per-media expectation for {m_exp.path!r}; "
+                            "merge into a single entry"
+                        )
+                    seen_media_paths.add(m_exp.path)
+
+        if exp.distributed is not None:
+            if obs.distributed is None:
+                violations.append(
+                    "expectations.distributed: declared without observations.distributed.ranks; add the rank reports"
+                )
+            elif len(obs.distributed.ranks) == 0:
+                # PR #1005 review (P2) parity: rank-scoped expectations
+                # (`expectedSteps`, `mustMatchAcrossRanks`) silently pass
+                # when there are zero rank reports because the slice-2
+                # distributed probe's per-rank loop is vacuous. The
+                # non-rank-scoped `expectedWorldSize` is fine to declare
+                # against an empty rank list, so we reject only the two
+                # rank-scoped expectations here.
+                if exp.distributed.expectedSteps is not None:
+                    violations.append(
+                        "expectations.distributed.expectedSteps: rank-scoped "
+                        "expectation requires observations.distributed.ranks "
+                        "to contain at least one report"
+                    )
+                if exp.distributed.mustMatchAcrossRanks is not None:
+                    violations.append(
+                        "expectations.distributed.mustMatchAcrossRanks: "
+                        "rank-scoped expectation requires "
+                        "observations.distributed.ranks to contain at least "
+                        "one report"
+                    )
 
         if violations:
             raise ValueError("\n".join(violations))
@@ -318,7 +459,122 @@ def extract_contract_probe_suite(trace: HarnessTrace) -> dict:
                 probe["label"] = probe_label
             probes.append(probe)
 
+    # ---- slice 6: cleanup / media / distributed emission --------------------
+
+    if trace.observations.cleanup is not None:
+        cln_exp = expectations.cleanup if expectations else None
+        inputs = {
+            "entries": [_cleanup_entry_dict(e) for e in trace.observations.cleanup.entries],
+        }
+        if cln_exp is not None:
+            if cln_exp.now is not None:
+                inputs["now"] = cln_exp.now.isoformat()
+            if cln_exp.maxLockfileAgeMs is not None:
+                inputs["maxLockfileAgeMs"] = cln_exp.maxLockfileAgeMs
+            if cln_exp.lockfilePatterns is not None:
+                inputs["lockfilePatterns"] = _patterns_dict_list(cln_exp.lockfilePatterns)
+            if cln_exp.sidecarPatterns is not None:
+                inputs["sidecarPatterns"] = _patterns_dict_list(cln_exp.sidecarPatterns)
+            if cln_exp.backupPatterns is not None:
+                inputs["backupPatterns"] = _patterns_dict_list(cln_exp.backupPatterns)
+            if cln_exp.forbidSymlinks is not None:
+                inputs["forbidSymlinks"] = cln_exp.forbidSymlinks
+            if cln_exp.allowedSymlinkTargets is not None:
+                inputs["allowedSymlinkTargets"] = list(cln_exp.allowedSymlinkTargets)
+            if cln_exp.ignoredPatterns is not None:
+                inputs["ignoredPatterns"] = _patterns_dict_list(cln_exp.ignoredPatterns)
+        probe = {"kind": "cleanup", "inputs": inputs}
+        if label is not None:
+            probe["label"] = label
+        probes.append(probe)
+
+    if trace.observations.media is not None:
+        media_exp_by_path: dict[str, _MediaExpectations] = {}
+        if expectations is not None and expectations.media is not None:
+            for declared_m_exp in expectations.media:
+                media_exp_by_path[declared_m_exp.path] = declared_m_exp
+        for observation in trace.observations.media:
+            m_exp = media_exp_by_path.get(observation.path)
+            inputs = {"path": observation.path}
+            if observation.headerBytes is not None:
+                inputs["headerBytes"] = list(observation.headerBytes)
+            if observation.width is not None:
+                inputs["width"] = observation.width
+            if observation.height is not None:
+                inputs["height"] = observation.height
+            if observation.byteSize is not None:
+                inputs["byteSize"] = observation.byteSize
+            if observation.columnCount is not None:
+                inputs["columnCount"] = observation.columnCount
+            if observation.columnNames is not None:
+                inputs["columnNames"] = list(observation.columnNames)
+            if observation.lineCount is not None:
+                inputs["lineCount"] = observation.lineCount
+            if m_exp is not None:
+                if m_exp.expectedMagicBytes is not None:
+                    inputs["expectedMagicBytes"] = list(m_exp.expectedMagicBytes)
+                if m_exp.expectedWidth is not None:
+                    inputs["expectedWidth"] = m_exp.expectedWidth
+                if m_exp.expectedHeight is not None:
+                    inputs["expectedHeight"] = m_exp.expectedHeight
+                if m_exp.minByteSize is not None:
+                    inputs["minByteSize"] = m_exp.minByteSize
+                if m_exp.maxByteSize is not None:
+                    inputs["maxByteSize"] = m_exp.maxByteSize
+                if m_exp.expectedColumnCount is not None:
+                    inputs["expectedColumnCount"] = m_exp.expectedColumnCount
+                if m_exp.requiredColumnNames is not None:
+                    inputs["requiredColumnNames"] = list(m_exp.requiredColumnNames)
+                if m_exp.expectedLineCount is not None:
+                    inputs["expectedLineCount"] = m_exp.expectedLineCount
+            probe = {"kind": "media", "inputs": inputs}
+            probe_label = m_exp.label if m_exp is not None and m_exp.label is not None else label
+            if probe_label is not None:
+                probe["label"] = probe_label
+            probes.append(probe)
+
+    if trace.observations.distributed is not None:
+        dist_exp = expectations.distributed if expectations else None
+        inputs = {
+            "ranks": [_distributed_rank_dict(r) for r in trace.observations.distributed.ranks],
+        }
+        if trace.observations.distributed.worldSize is not None:
+            inputs["worldSize"] = trace.observations.distributed.worldSize
+        if dist_exp is not None:
+            if dist_exp.expectedWorldSize is not None:
+                inputs["expectedWorldSize"] = dist_exp.expectedWorldSize
+            if dist_exp.expectedSteps is not None:
+                inputs["expectedSteps"] = dist_exp.expectedSteps
+            if dist_exp.mustMatchAcrossRanks is not None:
+                inputs["mustMatchAcrossRanks"] = list(dist_exp.mustMatchAcrossRanks)
+        probe = {"kind": "distributed", "inputs": inputs}
+        if label is not None:
+            probe["label"] = label
+        probes.append(probe)
+
     return {"schema_version": 1, "probes": probes}
+
+
+def _cleanup_entry_dict(entry: _CleanupEntrySchema) -> dict:
+    payload: dict = {"path": entry.path}
+    if entry.isSymlink is not None:
+        payload["isSymlink"] = entry.isSymlink
+    if entry.symlinkTarget is not None:
+        payload["symlinkTarget"] = entry.symlinkTarget
+    if entry.symlinkBroken is not None:
+        payload["symlinkBroken"] = entry.symlinkBroken
+    if entry.mtime is not None:
+        payload["mtime"] = entry.mtime.isoformat()
+    return payload
+
+
+def _distributed_rank_dict(rank: _DistributedRankSchema) -> dict:
+    payload: dict = {"rank": rank.rank}
+    if rank.steps is not None:
+        payload["steps"] = rank.steps
+    if rank.observations is not None:
+        payload["observations"] = dict(rank.observations)
+    return payload
 
 
 def serialize_suite(suite: dict) -> str:

--- a/autocontext/src/autocontext/control_plane/contract_probes/extract.py
+++ b/autocontext/src/autocontext/control_plane/contract_probes/extract.py
@@ -28,7 +28,6 @@ Module split lives next to ``runner.py`` so both load the same
 from __future__ import annotations
 
 import json
-from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
@@ -41,6 +40,7 @@ from pydantic import (
 from .runner import (
     _PatternList,
     _Strict,
+    _StrictDate,
 )
 
 __all__ = [
@@ -116,7 +116,10 @@ class _CleanupEntrySchema(_Strict):
     isSymlink: StrictBool | None = None
     symlinkTarget: str | None = None
     symlinkBroken: StrictBool | None = None
-    mtime: datetime | None = None
+    # PR #1011 review (P2): plain `datetime` coerced JSON ints
+    # (Unix timestamps); reject non-string / non-datetime inputs so
+    # the trace JSON wire format matches TS `DateJson`.
+    mtime: _StrictDate | None = None
 
 
 class _CleanupObservation(_Strict):
@@ -124,7 +127,8 @@ class _CleanupObservation(_Strict):
 
 
 class _CleanupExpectations(_Strict):
-    now: datetime | None = None
+    # PR #1011 review (P2): same strict-date guard as `mtime` above.
+    now: _StrictDate | None = None
     maxLockfileAgeMs: StrictInt | None = None
     lockfilePatterns: _PatternList | None = None
     sidecarPatterns: _PatternList | None = None

--- a/autocontext/src/autocontext/control_plane/contract_probes/runner.py
+++ b/autocontext/src/autocontext/control_plane/contract_probes/runner.py
@@ -147,6 +147,33 @@ def _coerce_patterns(value: object) -> tuple[re.Pattern[str], ...]:
 _PatternList = Annotated[tuple[re.Pattern[str], ...], BeforeValidator(_coerce_patterns)]
 
 
+def _require_string_or_datetime(value: object) -> object:
+    """Reject non-string / non-datetime JSON inputs for datetime fields.
+
+    PR #1011 review (P2): without this guard, Pydantic happily
+    coerced ``{"mtime": 0}`` into ``1970-01-01T00:00:00+00:00`` via
+    Unix-timestamp interpretation, which bypasses the advertised
+    ISO-8601 contract and diverges from the TS `DateJson` parser
+    that accepts only strings or `Date` objects. Letting the
+    BeforeValidator pass through valid inputs (``datetime`` instances
+    or ISO-8601 strings) keeps the downstream ``datetime`` field
+    type intact; everything else (numbers, booleans, dicts) raises.
+    """
+    from datetime import datetime as _dt
+
+    if isinstance(value, (str, _dt)):
+        return value
+    raise ValueError(f"datetime fields require an ISO-8601 string or a datetime instance; got {type(value).__name__}")
+
+
+# Use this for any datetime field where the JSON wire format should
+# reject numeric inputs (the TS extractor's `DateJson` only accepts
+# strings or Date objects). The BeforeValidator gates input so only
+# strings or `datetime` instances flow through to Pydantic's normal
+# datetime parsing; ints / floats / dicts / lists raise.
+_StrictDate = Annotated[datetime, BeforeValidator(_require_string_or_datetime)]
+
+
 # ---------------------------------------------------------------------------
 # Per-probe JSON-shape schemas
 # ---------------------------------------------------------------------------
@@ -280,7 +307,10 @@ class _CleanupEntrySchema(_Strict):
     isSymlink: StrictBool | None = None
     symlinkTarget: str | None = None
     symlinkBroken: StrictBool | None = None
-    mtime: datetime | None = None
+    # PR #1011 review (P2): plain `datetime` coerced JSON ints
+    # (Unix timestamps); reject non-string / non-datetime inputs at
+    # the field boundary so the JSON wire format matches TS DateJson.
+    mtime: _StrictDate | None = None
 
     def to_inputs(self) -> CleanupFileEntry:
         return CleanupFileEntry(
@@ -295,7 +325,8 @@ class _CleanupEntrySchema(_Strict):
 class _CleanupInputsSchema(_Strict):
     # PR #1006 review P2: TS marks `entries` required.
     entries: tuple[_CleanupEntrySchema, ...]
-    now: datetime | None = None
+    # PR #1011 review (P2): same strict-date guard as `mtime` above.
+    now: _StrictDate | None = None
     maxLockfileAgeMs: StrictInt | None = None
     lockfilePatterns: _PatternList | None = None
     sidecarPatterns: _PatternList | None = None

--- a/autocontext/tests/control_plane/test_cli_probes_extract.py
+++ b/autocontext/tests/control_plane/test_cli_probes_extract.py
@@ -405,9 +405,18 @@ def test_extract_then_check_pipe_round_trip(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_help_text_documents_slice_5_scope() -> None:
-    assert "terminal" in EXTRACT_HELP_TEXT
-    assert "artifact" in EXTRACT_HELP_TEXT
+def test_help_text_documents_seven_probe_kinds() -> None:
+    """Slice 6 broadened the help text to advertise full 7-kind coverage."""
+    for kind in (
+        "terminal",
+        "directory",
+        "service",
+        "artifact",
+        "cleanup",
+        "media",
+        "distributed",
+    ):
+        assert kind in EXTRACT_HELP_TEXT
 
 
 def test_result_dataclass_is_frozen() -> None:

--- a/autocontext/tests/control_plane/test_cli_probes_extract_advanced.py
+++ b/autocontext/tests/control_plane/test_cli_probes_extract_advanced.py
@@ -52,6 +52,74 @@ def test_cleanup_expectation_without_observation_rejected() -> None:
     assert "expectations.cleanup" in str(excinfo.value)
 
 
+def test_cleanup_numeric_mtime_rejected_at_trace_layer() -> None:
+    """PR #1011 review (P2): plain `datetime` coerced JSON ints
+    (Unix timestamps) so `{"mtime": 0}` became 1970-01-01T00:00:00Z,
+    bypassing the advertised ISO-8601 trace contract. The
+    BeforeValidator now rejects anything that is not a string or a
+    `datetime` instance.
+    """
+    with pytest.raises(ValidationError):
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {
+                    "cleanup": {"entries": [{"path": "x", "mtime": 0}]},
+                },
+            }
+        )
+
+
+def test_cleanup_numeric_now_rejected_at_trace_layer() -> None:
+    with pytest.raises(ValidationError):
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {"cleanup": {"entries": [{"path": "x"}]}},
+                "expectations": {"cleanup": {"now": 1234567890}},
+            }
+        )
+
+
+def test_cleanup_numeric_mtime_rejected_at_runner_layer() -> None:
+    """PR #1011 review (P2) parity: the same coercion gap existed in
+    the runner suite schema, so a hand-written check-only suite could
+    declare `{"mtime": 0}` and pass validation. The strict-date guard
+    applies there too."""
+    from autocontext.control_plane.contract_probes import ContractProbeSuiteSchema
+
+    with pytest.raises(ValidationError):
+        ContractProbeSuiteSchema.model_validate(
+            {
+                "schema_version": 1,
+                "probes": [
+                    {
+                        "kind": "cleanup",
+                        "inputs": {"entries": [{"path": "x", "mtime": 0}]},
+                    }
+                ],
+            }
+        )
+
+
+def test_cleanup_iso_string_mtime_still_accepted() -> None:
+    """The strict-date guard lets valid ISO-8601 strings flow through."""
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {
+                "cleanup": {
+                    "entries": [
+                        {"path": "x", "mtime": "2026-01-01T00:00:00Z"},
+                    ]
+                },
+            },
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    assert suite_dict["probes"][0]["kind"] == "cleanup"
+
+
 def test_cleanup_full_join_round_trip_through_runner() -> None:
     trace = HarnessTraceSchema.model_validate(
         {

--- a/autocontext/tests/control_plane/test_cli_probes_extract_advanced.py
+++ b/autocontext/tests/control_plane/test_cli_probes_extract_advanced.py
@@ -1,0 +1,343 @@
+"""AC-728 `autoctx probes extract` advanced kinds parity tests (slice 6).
+
+Mirrors the slice-6/TS PR #993 test surface. Covers
+cleanup / media / distributed observation+expectation join, orphan
+rejection, duplicate-per-path rejection (media), and the slice-2 P2
+parity rank-scoped empty-ranks rejection.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from autocontext.control_plane.contract_probes import (
+    ContractProbeSuiteSchema,
+    run_contract_probe_suite,
+)
+from autocontext.control_plane.contract_probes.extract import (
+    HarnessTraceSchema,
+    extract_contract_probe_suite,
+)
+
+# ---------------------------------------------------------------------------
+# cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_observation_only_emits_default_probe() -> None:
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {"cleanup": {"entries": [{"path": "src/main.py"}]}},
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    assert suite_dict["probes"][0]["kind"] == "cleanup"
+    # No expectation-side fields injected.
+    inputs = suite_dict["probes"][0]["inputs"]
+    assert "maxLockfileAgeMs" not in inputs
+    assert "forbidSymlinks" not in inputs
+
+
+def test_cleanup_expectation_without_observation_rejected() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {},
+                "expectations": {"cleanup": {"forbidSymlinks": True}},
+            }
+        )
+    assert "expectations.cleanup" in str(excinfo.value)
+
+
+def test_cleanup_full_join_round_trip_through_runner() -> None:
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {
+                "cleanup": {
+                    "entries": [
+                        {"path": "data/run.lock", "mtime": "2026-01-01T00:00:00Z"},
+                        {"path": "solution.txt"},
+                    ]
+                }
+            },
+            "expectations": {
+                "cleanup": {
+                    "now": "2026-01-01T00:00:30Z",
+                    "maxLockfileAgeMs": 60_000,
+                    "forbidSymlinks": False,
+                }
+            },
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    suite = ContractProbeSuiteSchema.model_validate(suite_dict)
+    result = run_contract_probe_suite(suite)
+    assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# media
+# ---------------------------------------------------------------------------
+
+
+def test_media_observation_only_emits_no_op_probe() -> None:
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {
+                "media": [{"path": "img.png", "width": 100, "height": 50}],
+            },
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    inputs = suite_dict["probes"][0]["inputs"]
+    assert inputs["path"] == "img.png"
+    assert inputs["width"] == 100
+    # No expectation fields populated.
+    assert "expectedWidth" not in inputs
+    assert "minByteSize" not in inputs
+
+
+def test_media_expectation_without_observation_rejected() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {},
+                "expectations": {"media": [{"path": "img.png", "expectedWidth": 100}]},
+            }
+        )
+    assert "expectations.media" in str(excinfo.value)
+
+
+def test_media_expectation_with_unknown_path_rejected() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {"media": [{"path": "img.png"}]},
+                "expectations": {"media": [{"path": "other.png", "expectedWidth": 10}]},
+            }
+        )
+    assert "other.png" in str(excinfo.value)
+
+
+def test_duplicate_per_media_expectation_rejected() -> None:
+    """Same Map-keyed-by-path collision as artifacts; reject at parse
+    time rather than silently overwriting an earlier entry."""
+    with pytest.raises(ValidationError) as excinfo:
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {"media": [{"path": "img.png"}]},
+                "expectations": {
+                    "media": [
+                        {"path": "img.png", "expectedWidth": 100},
+                        {"path": "img.png", "expectedWidth": 200},
+                    ],
+                },
+            }
+        )
+    assert "duplicate" in str(excinfo.value).lower()
+
+
+def test_media_full_join_round_trip_through_runner() -> None:
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {
+                "media": [
+                    {
+                        "path": "img.png",
+                        "headerBytes": [137, 80, 78, 71],
+                        "width": 100,
+                        "height": 50,
+                        "byteSize": 4096,
+                    }
+                ]
+            },
+            "expectations": {
+                "media": [
+                    {
+                        "path": "img.png",
+                        "expectedMagicBytes": [137, 80, 78, 71],
+                        "expectedWidth": 100,
+                        "expectedHeight": 50,
+                        "minByteSize": 1,
+                        "maxByteSize": 8192,
+                    }
+                ]
+            },
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    suite = ContractProbeSuiteSchema.model_validate(suite_dict)
+    result = run_contract_probe_suite(suite)
+    assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# distributed
+# ---------------------------------------------------------------------------
+
+
+def test_distributed_observation_only_emits_probe_with_ranks() -> None:
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {
+                "distributed": {"worldSize": 2, "ranks": [{"rank": 0}, {"rank": 1}]},
+            },
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    inputs = suite_dict["probes"][0]["inputs"]
+    assert inputs["worldSize"] == 2
+    assert [r["rank"] for r in inputs["ranks"]] == [0, 1]
+    assert "expectedSteps" not in inputs
+
+
+def test_distributed_expectation_without_observation_rejected() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {},
+                "expectations": {"distributed": {"expectedWorldSize": 2}},
+            }
+        )
+    assert "expectations.distributed" in str(excinfo.value)
+
+
+def test_rank_scoped_expected_steps_with_zero_ranks_rejected() -> None:
+    """PR #1005 review (P2) parity at the trace-extraction layer.
+
+    A rank-scoped expectation with zero rank reports would otherwise
+    pass vacuously when run; the extractor surfaces this at parse
+    time so a broken extractor cannot silently weaken the contract.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {"distributed": {"ranks": []}},
+                "expectations": {"distributed": {"expectedSteps": 100}},
+            }
+        )
+    assert "expectedSteps" in str(excinfo.value)
+
+
+def test_rank_scoped_must_match_with_zero_ranks_rejected() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        HarnessTraceSchema.model_validate(
+            {
+                "schema_version": 1,
+                "observations": {"distributed": {"ranks": []}},
+                "expectations": {"distributed": {"mustMatchAcrossRanks": ["hash"]}},
+            }
+        )
+    assert "mustMatchAcrossRanks" in str(excinfo.value)
+
+
+def test_non_rank_scoped_expected_world_size_with_zero_ranks_accepted_at_extraction() -> None:
+    """The extractor accepts `expectedWorldSize` without ranks (the
+    non-rank-scoped expectation does not require rank reports). The
+    resulting suite still verifies rank coverage at run time; this
+    test only asserts the trace-validation layer does not reject the
+    extraction.
+    """
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {"distributed": {"worldSize": 4, "ranks": []}},
+            "expectations": {"distributed": {"expectedWorldSize": 4}},
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    # The suite parses cleanly: the rank-scoped expectations
+    # (`expectedSteps`, `mustMatchAcrossRanks`) are absent so the
+    # slice-1 audit invariant is satisfied at extraction.
+    suite = ContractProbeSuiteSchema.model_validate(suite_dict)
+    assert suite.probes[0].kind == "distributed"
+
+
+def test_distributed_full_join_round_trip_through_runner() -> None:
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "observations": {
+                "distributed": {
+                    "worldSize": 2,
+                    "ranks": [
+                        {"rank": 0, "steps": 10, "observations": {"loss": "0.1"}},
+                        {"rank": 1, "steps": 10, "observations": {"loss": "0.1"}},
+                    ],
+                }
+            },
+            "expectations": {
+                "distributed": {
+                    "expectedWorldSize": 2,
+                    "expectedSteps": 10,
+                    "mustMatchAcrossRanks": ["loss"],
+                }
+            },
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    suite = ContractProbeSuiteSchema.model_validate(suite_dict)
+    result = run_contract_probe_suite(suite)
+    assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# end-to-end seven-kind round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_seven_kind_extraction_round_trip_passes_runner() -> None:
+    """Slice-6 exit invariant: every probe kind extractable end-to-end
+    in one trace."""
+    trace = HarnessTraceSchema.model_validate(
+        {
+            "schema_version": 1,
+            "label": "demo",
+            "observations": {
+                "terminal": {"exitCode": 0, "stdout": "solution.txt", "stderr": ""},
+                "workdir": {"presentFiles": ["solution.txt"]},
+                "services": [{"host": "127.0.0.1", "port": 8000}],
+                "artifacts": [{"path": "solution.txt", "content": "answer\n"}],
+                "cleanup": {"entries": [{"path": "solution.txt"}]},
+                "media": [{"path": "img.png", "width": 100}],
+                "distributed": {"worldSize": 1, "ranks": [{"rank": 0, "steps": 1}]},
+            },
+            "expectations": {
+                "terminal": {"requiredStdoutPatterns": [r"solution\.txt"]},
+                "directory": {
+                    "requiredFiles": ["solution.txt"],
+                    "allowedFiles": ["solution.txt"],
+                },
+                "services": {"required": [{"host": "127.0.0.1", "port": 8000}]},
+                "artifacts": [{"path": "solution.txt", "requiredSubstrings": ["answer"]}],
+                "cleanup": {"maxLockfileAgeMs": 1000},
+                "media": [{"path": "img.png", "expectedWidth": 100}],
+                "distributed": {"expectedWorldSize": 1, "expectedSteps": 1},
+            },
+        }
+    )
+    suite_dict = extract_contract_probe_suite(trace)
+    assert [p["kind"] for p in suite_dict["probes"]] == [
+        "terminal",
+        "directory",
+        "service",
+        "artifact",
+        "cleanup",
+        "media",
+        "distributed",
+    ]
+    suite = ContractProbeSuiteSchema.model_validate(suite_dict)
+    result = run_contract_probe_suite(suite)
+    assert result.passed is True


### PR DESCRIPTION
## Summary

- Mirrors TS PR #993 portion of `ts/src/control-plane/contract-probes/cli/extract.ts`. Extends `HarnessTraceSchema` + `extract_contract_probe_suite` to cover all seven AC-728 probe kinds.
- New cleanup / media / distributed observation+expectation schemas follow slice-3 strictness (`extra=forbid`, `StrictInt` / `StrictBool`, explicit-null rejection, ISO-8601 datetime parsing).
- Orphan-expectation guard extended: cleanup/media/distributed orphan rejection, per-media unknown-path rejection, duplicate-per-media-path rejection (PR #993 P2 parity), rank-scoped empty-ranks rejection for `expectedSteps` and `mustMatchAcrossRanks` (PR #1005 P2 parity). Non-rank-scoped `expectedWorldSize` is fine to declare against an empty rank list.
- `EXTRACT_HELP_TEXT` advertises full 7-kind coverage.

## Test plan

- [x] `uv run pytest tests/control_plane/` (135 passed: 120 prior + 15 new)
- [x] `uv run pytest tests/test_module_size_limits.py` clean (`extract.py` 589 lines)
- [x] `uv run ruff check` clean
- [x] `uv run mypy src/autocontext/control_plane/ src/autocontext/cli_probes.py` clean
- [ ] CI: green

## Slice plan (7 total)

- slice 1 (#1004, merged): 4 base probes
- slice 2 (#1005, merged): 3 advanced probes + missing-observation invariant
- slice 3 (#1006, merged): suite runner + Pydantic schema
- slice 4 (#1008, merged): `autoctx probes check` CLI
- slice 4 follow-up (#1009, merged): stderr routing + README
- slice 5 (#1010, merged): `autoctx probes extract` for 4 base
- **slice 6 (this PR)**: extend extract to cleanup / media / distributed
- slice 7: missing-observation audit close-out