### PR TITLE
fix(contract-probes): rank-scoped missing-observation when ranks are empty (TS parity)

### DIFF
--- a/ts/src/control-plane/contract-probes/index.ts
+++ b/ts/src/control-plane/contract-probes/index.ts
@@ -652,6 +652,16 @@ export function probeDistributedContract(
   }
 
   if (inputs.expectedSteps !== undefined) {
+    // AC-728 Python parity PR #1005 review (P2) backport: a declared
+    // rank-scoped expectation without any rank reports must fail
+    // loudly. Iterating `seenRanks.values()` alone would let a broken
+    // extractor satisfy `expectedSteps` by omitting every rank report.
+    if (seenRanks.size === 0) {
+      failures.push({
+        kind: "missing-observation",
+        message: "declared expectation on expectedSteps but no rank reports were supplied",
+      });
+    }
     for (const report of seenRanks.values()) {
       if (report.steps === undefined) {
         failures.push({
@@ -666,6 +676,19 @@ export function probeDistributedContract(
           message: `rank ${report.rank} ran ${report.steps} steps; expected ${inputs.expectedSteps}`,
         });
       }
+    }
+  }
+
+  if (inputs.mustMatchAcrossRanks !== undefined && seenRanks.size === 0) {
+    // AC-728 Python parity PR #1005 review (P2) backport: same shape
+    // as expectedSteps above. Emit one failure per declared key so
+    // multi-key expectations do not collapse to a single failure.
+    for (const key of inputs.mustMatchAcrossRanks) {
+      failures.push({
+        kind: "missing-observation",
+        key,
+        message: `declared mustMatchAcrossRanks expectation on '${key}' but no rank reports were supplied`,
+      });
     }
   }
 

--- a/ts/tests/control-plane/contract-probes/contract-probes.test.ts
+++ b/ts/tests/control-plane/contract-probes/contract-probes.test.ts
@@ -582,6 +582,35 @@ describe("probeDistributedContract", () => {
     expect(result.passed).toBe(true);
   });
 
+  test("rank-scoped expectedSteps with zero rank reports fails loudly with missing-observation", () => {
+    // AC-728 Python parity PR #1005 review (P2) backport: a declared
+    // rank-scoped expectation without any rank reports must fail
+    // loudly. Iterating `seenRanks.values()` alone would let a broken
+    // extractor satisfy `expectedSteps` by omitting every rank report.
+    const result = probeDistributedContract({
+      ranks: [],
+      expectedSteps: 100,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.failures).toContainEqual({
+      kind: "missing-observation",
+      message: "declared expectation on expectedSteps but no rank reports were supplied",
+    });
+  });
+
+  test("rank-scoped mustMatchAcrossRanks with zero rank reports fails loudly per key", () => {
+    // PR #1005 review (P2) backport: same shape as expectedSteps. Emit
+    // one failure per declared key so multi-key expectations do not
+    // collapse to a single failure.
+    const result = probeDistributedContract({
+      ranks: [],
+      mustMatchAcrossRanks: ["hash", "loss"],
+    });
+    expect(result.passed).toBe(false);
+    const keys = result.failures.filter((f) => f.kind === "missing-observation").map((f) => f.key);
+    expect(new Set(keys)).toEqual(new Set(["hash", "loss"]));
+  });
+
   test("treats a single-rank report with expectedWorldSize=1 as valid", () => {
     // World size 1 is degenerate but lawful: parity-with-self holds and the
     // probe should treat the trivial case as passing.


### PR DESCRIPTION
## Summary

AC-728 Python parity PR #1005 review (P2) backport. The Python distributed probe was tightened so `expectedSteps` and `mustMatchAcrossRanks` declared against zero rank reports surface a loud `missing-observation` failure; the TS probe had the same gap. This PR closes it so both runtimes converge on the same missing-observation invariant.

- Before this fix, a broken extractor that omitted every rank report could silently satisfy declared rank-scoped expectations because the per-rank loop is vacuous over `seenRanks.size === 0`.
- The `expectedWorldSize` branch was already protected via the worldSize observation check; the parity gap was specific to the two rank-scoped expectations.
- `mustMatchAcrossRanks` emits one failure per declared key so multi-key expectations do not collapse to a single failure (matches the Python implementation).

## Test plan

- [x] `bun test tests/control-plane/contract-probes/contract-probes.test.ts` (62 passed: 60 prior + 2 new regression)
- [x] `bun run lint` (`tsc --noEmit`) clean
- [ ] CI: green