### PR TITLE
feat(mission): AC-697 mission Python parity slice 1 (SQLite store + types)

### DIFF
--- a/autocontext/src/autocontext/mission/__init__.py
+++ b/autocontext/src/autocontext/mission/__init__.py
@@ -1,0 +1,35 @@
+"""AC-697 mission Python parity surface (slice 1).
+
+Mirrors ``ts/src/mission/`` step-by-step. Slice 1 covers the
+SQLite store + Pydantic models. Subsequent slices add the
+mission manager, verifiers, control-plane workflows, and the
+``autoctx mission`` CLI surface.
+"""
+
+from autocontext.mission.store import MissionStore
+from autocontext.mission.types import (
+    BudgetUsage,
+    Mission,
+    MissionBudget,
+    MissionStatus,
+    MissionStep,
+    MissionSubgoal,
+    MissionVerificationRecord,
+    StepStatus,
+    SubgoalStatus,
+    VerifierResult,
+)
+
+__all__ = [
+    "BudgetUsage",
+    "Mission",
+    "MissionBudget",
+    "MissionStatus",
+    "MissionStep",
+    "MissionStore",
+    "MissionSubgoal",
+    "MissionVerificationRecord",
+    "StepStatus",
+    "SubgoalStatus",
+    "VerifierResult",
+]

--- a/autocontext/src/autocontext/mission/store.py
+++ b/autocontext/src/autocontext/mission/store.py
@@ -21,6 +21,9 @@ from datetime import UTC, datetime
 from typing import Any
 
 from autocontext.mission.types import (
+    MISSION_STATUSES,
+    STEP_STATUSES,
+    SUBGOAL_STATUSES,
     BudgetUsage,
     Mission,
     MissionBudget,
@@ -34,6 +37,16 @@ from autocontext.mission.types import (
 )
 
 __all__ = ["MissionStore"]
+
+
+def _require_status(value: str, allowed: frozenset[str], kind: str) -> None:
+    """PR #1014 review (P2): ``Literal`` is a static-analysis hint
+    only; the store must guard updates at runtime so a typo cannot
+    persist an unreadable row that later raises ``ValidationError``
+    on read. Mirrors the TS Zod ``StatusSchema.parse(status)``
+    pre-write guard."""
+    if value not in allowed:
+        raise ValueError(f"invalid {kind} status {value!r}; expected one of {sorted(allowed)}")
 
 
 _MISSION_TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "failed", "canceled"})
@@ -163,6 +176,7 @@ class MissionStore:
         return [self._mission_from_row(row) for row in rows]
 
     def update_mission_status(self, mission_id: str, status: MissionStatus) -> None:
+        _require_status(status, MISSION_STATUSES, "mission")
         completed_at = _completion_timestamp(status, _MISSION_TERMINAL_STATUSES)
         self._db.execute(
             "UPDATE missions SET status = ?, updated_at = datetime('now'), completed_at = ? WHERE id = ?",
@@ -192,6 +206,7 @@ class MissionStore:
         return [self._step_from_row(row) for row in rows]
 
     def update_step_status(self, step_id: str, status: StepStatus, result: str | None = None) -> None:
+        _require_status(status, STEP_STATUSES, "step")
         completed_at = _completion_timestamp(status, _STEP_TERMINAL_STATUSES)
         self._db.execute(
             "UPDATE mission_steps SET status = ?, result = COALESCE(?, result), completed_at = ? WHERE id = ?",
@@ -243,6 +258,7 @@ class MissionStore:
         return [self._subgoal_from_row(row) for row in rows]
 
     def update_subgoal_status(self, subgoal_id: str, status: SubgoalStatus) -> None:
+        _require_status(status, SUBGOAL_STATUSES, "subgoal")
         completed_at = _completion_timestamp(status, _SUBGOAL_TERMINAL_STATUSES)
         self._db.execute(
             "UPDATE mission_subgoals SET status = ?, completed_at = ? WHERE id = ?",

--- a/autocontext/src/autocontext/mission/store.py
+++ b/autocontext/src/autocontext/mission/store.py
@@ -1,0 +1,369 @@
+"""AC-697 mission Python parity SQLite store (slice 1).
+
+Mirrors ``ts/src/mission/store.ts`` + ``store-schema-workflow.ts`` +
+``store-mappers.ts`` + ``store-lifecycle-workflow.ts``. Persists
+missions, steps, subgoals, and verification records to SQLite using
+the same table layout the TS runtime uses, so both runtimes can
+read the same on-disk database when ``AUTOCONTEXT_DB_PATH`` is
+shared.
+
+Subsequent slices add the higher-level mission manager, verifiers,
+control-plane workflows, and the typer CLI surface that calls into
+this store.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from autocontext.mission.types import (
+    BudgetUsage,
+    Mission,
+    MissionBudget,
+    MissionStatus,
+    MissionStep,
+    MissionSubgoal,
+    MissionVerificationRecord,
+    StepStatus,
+    SubgoalStatus,
+    VerifierResult,
+)
+
+__all__ = ["MissionStore"]
+
+
+_MISSION_TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "failed", "canceled"})
+_STEP_TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "failed", "blocked", "skipped"})
+_SUBGOAL_TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "failed", "skipped"})
+
+
+def _generate_record_id(prefix: str) -> str:
+    """Same shape as TS `generateMissionRecordId`: ``<prefix>-<8 hex>``."""
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def _utc_now_iso() -> str:
+    """ISO-8601 timestamp matching TS `new Date().toISOString()`."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _completion_timestamp(status: str, terminal: frozenset[str]) -> str | None:
+    return _utc_now_iso() if status in terminal else None
+
+
+class MissionStore:
+    """SQLite-backed mission store mirroring the TS ``MissionStore``.
+
+    Same table layout, same JSON encoding for the budget / metadata
+    blobs, same `prefix-<short uuid>` id shape so cross-runtime
+    reads work against a shared database file.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._db = sqlite3.connect(db_path, isolation_level=None)
+        # Match the TS pragma settings.
+        self._db.execute("PRAGMA journal_mode = WAL")
+        self._db.execute("PRAGMA foreign_keys = ON")
+        self._db.row_factory = sqlite3.Row
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        # Identical DDL to ts/src/mission/store-schema-workflow.ts so
+        # both runtimes share the on-disk schema. Each statement runs
+        # under its own execute() call so sqlite3 can prepare them
+        # individually.
+        self._db.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS missions (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                goal TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'active',
+                budget TEXT,
+                metadata TEXT DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT,
+                completed_at TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS mission_steps (
+                id TEXT PRIMARY KEY,
+                mission_id TEXT NOT NULL REFERENCES missions(id),
+                description TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                result TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                completed_at TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS mission_verifications (
+                id TEXT PRIMARY KEY,
+                mission_id TEXT NOT NULL REFERENCES missions(id),
+                passed INTEGER NOT NULL,
+                reason TEXT NOT NULL,
+                suggestions TEXT DEFAULT '[]',
+                metadata TEXT DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS mission_subgoals (
+                id TEXT PRIMARY KEY,
+                mission_id TEXT NOT NULL REFERENCES missions(id),
+                description TEXT NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 1,
+                status TEXT NOT NULL DEFAULT 'pending',
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                completed_at TEXT
+            );
+            """
+        )
+
+    # -------------------------------------------------------------------
+    # Mission CRUD
+    # -------------------------------------------------------------------
+
+    def create_mission(
+        self,
+        *,
+        name: str,
+        goal: str,
+        budget: MissionBudget | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        record_id = _generate_record_id("mission")
+        # The TS store stores budget under camelCase keys
+        # (`maxSteps`, `maxCostUsd`, `maxDurationMinutes`); mirror that
+        # serialisation so cross-runtime reads agree.
+        budget_json = json.dumps(self._budget_to_camel(budget)) if budget else None
+        self._db.execute(
+            "INSERT INTO missions (id, name, goal, budget, metadata) VALUES (?, ?, ?, ?, ?)",
+            (record_id, name, goal, budget_json, json.dumps(metadata or {})),
+        )
+        return record_id
+
+    def get_mission(self, mission_id: str) -> Mission | None:
+        row = self._db.execute("SELECT * FROM missions WHERE id = ?", (mission_id,)).fetchone()
+        if row is None:
+            return None
+        return self._mission_from_row(row)
+
+    def list_missions(self, status: MissionStatus | None = None) -> list[Mission]:
+        if status is not None:
+            rows = self._db.execute(
+                "SELECT * FROM missions WHERE status = ? ORDER BY created_at DESC",
+                (status,),
+            ).fetchall()
+        else:
+            rows = self._db.execute("SELECT * FROM missions ORDER BY created_at DESC").fetchall()
+        return [self._mission_from_row(row) for row in rows]
+
+    def update_mission_status(self, mission_id: str, status: MissionStatus) -> None:
+        completed_at = _completion_timestamp(status, _MISSION_TERMINAL_STATUSES)
+        self._db.execute(
+            "UPDATE missions SET status = ?, updated_at = datetime('now'), completed_at = ? WHERE id = ?",
+            (status, completed_at, mission_id),
+        )
+
+    # -------------------------------------------------------------------
+    # Steps
+    # -------------------------------------------------------------------
+
+    def add_step(self, mission_id: str, *, description: str) -> str:
+        """Append a completed step. Mirrors the TS default of `completed`
+        because mission steps are recorded after the agent finished
+        them."""
+        record_id = _generate_record_id("step")
+        self._db.execute(
+            "INSERT INTO mission_steps (id, mission_id, description, status) VALUES (?, ?, ?, 'completed')",
+            (record_id, mission_id, description),
+        )
+        return record_id
+
+    def get_steps(self, mission_id: str) -> list[MissionStep]:
+        rows = self._db.execute(
+            "SELECT * FROM mission_steps WHERE mission_id = ? ORDER BY created_at",
+            (mission_id,),
+        ).fetchall()
+        return [self._step_from_row(row) for row in rows]
+
+    def update_step_status(self, step_id: str, status: StepStatus, result: str | None = None) -> None:
+        completed_at = _completion_timestamp(status, _STEP_TERMINAL_STATUSES)
+        self._db.execute(
+            "UPDATE mission_steps SET status = ?, result = COALESCE(?, result), completed_at = ? WHERE id = ?",
+            (status, result, completed_at, step_id),
+        )
+
+    # -------------------------------------------------------------------
+    # Verifications
+    # -------------------------------------------------------------------
+
+    def record_verification(self, mission_id: str, result: VerifierResult) -> None:
+        record_id = _generate_record_id("verify")
+        self._db.execute(
+            "INSERT INTO mission_verifications (id, mission_id, passed, reason, suggestions, metadata) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                record_id,
+                mission_id,
+                1 if result.passed else 0,
+                result.reason,
+                json.dumps(list(result.suggestions)),
+                json.dumps(result.metadata),
+            ),
+        )
+
+    def get_verifications(self, mission_id: str) -> list[MissionVerificationRecord]:
+        rows = self._db.execute(
+            "SELECT * FROM mission_verifications WHERE mission_id = ? ORDER BY created_at",
+            (mission_id,),
+        ).fetchall()
+        return [self._verification_from_row(row) for row in rows]
+
+    # -------------------------------------------------------------------
+    # Subgoals
+    # -------------------------------------------------------------------
+
+    def add_subgoal(self, mission_id: str, *, description: str, priority: int = 1) -> str:
+        record_id = _generate_record_id("subgoal")
+        self._db.execute(
+            "INSERT INTO mission_subgoals (id, mission_id, description, priority) VALUES (?, ?, ?, ?)",
+            (record_id, mission_id, description, priority),
+        )
+        return record_id
+
+    def get_subgoals(self, mission_id: str) -> list[MissionSubgoal]:
+        rows = self._db.execute(
+            "SELECT * FROM mission_subgoals WHERE mission_id = ? ORDER BY priority ASC, created_at ASC",
+            (mission_id,),
+        ).fetchall()
+        return [self._subgoal_from_row(row) for row in rows]
+
+    def update_subgoal_status(self, subgoal_id: str, status: SubgoalStatus) -> None:
+        completed_at = _completion_timestamp(status, _SUBGOAL_TERMINAL_STATUSES)
+        self._db.execute(
+            "UPDATE mission_subgoals SET status = ?, completed_at = ? WHERE id = ?",
+            (status, completed_at, subgoal_id),
+        )
+
+    # -------------------------------------------------------------------
+    # Budget usage
+    # -------------------------------------------------------------------
+
+    def get_budget_usage(self, mission_id: str) -> BudgetUsage:
+        mission = self.get_mission(mission_id)
+        row = self._db.execute(
+            "SELECT COUNT(*) AS count FROM mission_steps WHERE mission_id = ?",
+            (mission_id,),
+        ).fetchone()
+        steps_used = int(row["count"]) if row is not None else 0
+        max_steps = mission.budget.max_steps if mission and mission.budget else None
+        max_cost_usd = mission.budget.max_cost_usd if mission and mission.budget else None
+        exhausted = max_steps is not None and steps_used >= max_steps
+        return BudgetUsage(
+            steps_used=steps_used,
+            max_steps=max_steps,
+            max_cost_usd=max_cost_usd,
+            exhausted=exhausted,
+        )
+
+    # -------------------------------------------------------------------
+    # Bookkeeping
+    # -------------------------------------------------------------------
+
+    def get_db_path(self) -> str:
+        return self._db_path
+
+    def close(self) -> None:
+        self._db.close()
+
+    def __enter__(self) -> MissionStore:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
+    # -------------------------------------------------------------------
+    # Row mapping (mirrors TS store-mappers.ts)
+    # -------------------------------------------------------------------
+
+    @staticmethod
+    def _budget_to_camel(budget: MissionBudget) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if budget.max_steps is not None:
+            payload["maxSteps"] = budget.max_steps
+        if budget.max_cost_usd is not None:
+            payload["maxCostUsd"] = budget.max_cost_usd
+        if budget.max_duration_minutes is not None:
+            payload["maxDurationMinutes"] = budget.max_duration_minutes
+        return payload
+
+    @staticmethod
+    def _budget_from_camel(payload: dict[str, Any] | None) -> MissionBudget | None:
+        if not payload:
+            return None
+        return MissionBudget(
+            max_steps=payload.get("maxSteps"),
+            max_cost_usd=payload.get("maxCostUsd"),
+            max_duration_minutes=payload.get("maxDurationMinutes"),
+        )
+
+    def _mission_from_row(self, row: sqlite3.Row) -> Mission:
+        budget_blob = row["budget"]
+        budget = self._budget_from_camel(json.loads(budget_blob)) if budget_blob is not None else None
+        metadata_blob = row["metadata"] or "{}"
+        return Mission(
+            id=row["id"],
+            name=row["name"],
+            goal=row["goal"],
+            status=row["status"],
+            budget=budget,
+            metadata=json.loads(metadata_blob),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            completed_at=row["completed_at"],
+        )
+
+    @staticmethod
+    def _step_from_row(row: sqlite3.Row) -> MissionStep:
+        status: StepStatus = (
+            row["status"] if row["status"] in ("pending", "running", "completed", "failed", "skipped", "blocked") else "pending"
+        )
+        return MissionStep(
+            id=row["id"],
+            mission_id=row["mission_id"],
+            description=row["description"],
+            status=status,
+            result=row["result"],
+            created_at=row["created_at"],
+            completed_at=row["completed_at"],
+        )
+
+    @staticmethod
+    def _subgoal_from_row(row: sqlite3.Row) -> MissionSubgoal:
+        status: SubgoalStatus = (
+            row["status"] if row["status"] in ("pending", "active", "completed", "failed", "skipped") else "pending"
+        )
+        return MissionSubgoal(
+            id=row["id"],
+            mission_id=row["mission_id"],
+            description=row["description"],
+            priority=int(row["priority"]),
+            status=status,
+            created_at=row["created_at"],
+            completed_at=row["completed_at"],
+        )
+
+    @staticmethod
+    def _verification_from_row(row: sqlite3.Row) -> MissionVerificationRecord:
+        return MissionVerificationRecord(
+            id=row["id"],
+            passed=bool(row["passed"]),
+            reason=row["reason"],
+            suggestions=tuple(json.loads(row["suggestions"] or "[]")),
+            metadata=json.loads(row["metadata"] or "{}"),
+            created_at=row["created_at"],
+        )

--- a/autocontext/src/autocontext/mission/types.py
+++ b/autocontext/src/autocontext/mission/types.py
@@ -1,0 +1,121 @@
+"""AC-697 mission Python parity types (slice 1).
+
+Mirrors ``ts/src/mission/types.ts`` (AC-410 + AC-411 data model).
+Pydantic v2 frozen models with ``extra="forbid"`` so unknown keys
+reject at parse time.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "BudgetUsage",
+    "Mission",
+    "MissionBudget",
+    "MissionStatus",
+    "MissionStep",
+    "MissionSubgoal",
+    "MissionVerificationRecord",
+    "StepStatus",
+    "SubgoalStatus",
+    "VerifierResult",
+]
+
+
+MissionStatus = Literal[
+    "active",
+    "paused",
+    "completed",
+    "failed",
+    "canceled",
+    "blocked",
+    "budget_exhausted",
+    "verifier_failed",
+]
+
+
+StepStatus = Literal[
+    "pending",
+    "running",
+    "completed",
+    "failed",
+    "skipped",
+    "blocked",
+]
+
+
+SubgoalStatus = Literal[
+    "pending",
+    "active",
+    "completed",
+    "failed",
+    "skipped",
+]
+
+
+class _Frozen(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class MissionBudget(_Frozen):
+    max_steps: int | None = Field(default=None, gt=0)
+    max_cost_usd: float | None = Field(default=None, gt=0)
+    max_duration_minutes: float | None = Field(default=None, gt=0)
+
+
+class Mission(_Frozen):
+    id: str
+    name: str
+    goal: str
+    status: MissionStatus
+    budget: MissionBudget | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+    updated_at: str | None = None
+    completed_at: str | None = None
+
+
+class MissionStep(_Frozen):
+    id: str
+    mission_id: str
+    description: str
+    status: StepStatus
+    result: str | None = None
+    created_at: str
+    completed_at: str | None = None
+
+
+class VerifierResult(_Frozen):
+    passed: bool
+    reason: str
+    suggestions: tuple[str, ...] = ()
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class MissionVerificationRecord(_Frozen):
+    id: str
+    passed: bool
+    reason: str
+    suggestions: tuple[str, ...]
+    metadata: dict[str, Any]
+    created_at: str
+
+
+class MissionSubgoal(_Frozen):
+    id: str
+    mission_id: str
+    description: str
+    priority: int
+    status: SubgoalStatus
+    created_at: str
+    completed_at: str | None = None
+
+
+class BudgetUsage(_Frozen):
+    steps_used: int
+    max_steps: int | None = None
+    max_cost_usd: float | None = None
+    exhausted: bool

--- a/autocontext/src/autocontext/mission/types.py
+++ b/autocontext/src/autocontext/mission/types.py
@@ -3,15 +3,33 @@
 Mirrors ``ts/src/mission/types.ts`` (AC-410 + AC-411 data model).
 Pydantic v2 frozen models with ``extra="forbid"`` so unknown keys
 reject at parse time.
+
+PR #1014 review (P2): primitive coercion is blocked per-field via
+``StrictInt`` / ``StrictBool`` / ``StrictFloat`` / ``StrictStr`` so
+the parity models reject the same shapes the TS Zod schemas
+reject. Without these, ``MissionBudget(max_steps=True)`` would
+coerce to ``1``, ``MissionBudget(max_steps="5")`` to ``5``, and
+``VerifierResult(passed="no")`` to ``False``.
 """
 
 from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+)
 
 __all__ = [
+    "MISSION_STATUSES",
+    "STEP_STATUSES",
+    "SUBGOAL_STATUSES",
     "BudgetUsage",
     "Mission",
     "MissionBudget",
@@ -56,66 +74,74 @@ SubgoalStatus = Literal[
 ]
 
 
+# Runtime-checkable status sets so the store layer can reject
+# unknown values before persisting them (PR #1014 review P2):
+# `Literal` is a static-analysis hint only, not a runtime guard.
+MISSION_STATUSES: frozenset[str] = frozenset(MissionStatus.__args__)  # type: ignore[attr-defined]
+STEP_STATUSES: frozenset[str] = frozenset(StepStatus.__args__)  # type: ignore[attr-defined]
+SUBGOAL_STATUSES: frozenset[str] = frozenset(SubgoalStatus.__args__)  # type: ignore[attr-defined]
+
+
 class _Frozen(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
 
 class MissionBudget(_Frozen):
-    max_steps: int | None = Field(default=None, gt=0)
-    max_cost_usd: float | None = Field(default=None, gt=0)
-    max_duration_minutes: float | None = Field(default=None, gt=0)
+    max_steps: StrictInt | None = Field(default=None, gt=0)
+    max_cost_usd: StrictFloat | None = Field(default=None, gt=0)
+    max_duration_minutes: StrictFloat | None = Field(default=None, gt=0)
 
 
 class Mission(_Frozen):
-    id: str
-    name: str
-    goal: str
+    id: StrictStr
+    name: StrictStr
+    goal: StrictStr
     status: MissionStatus
     budget: MissionBudget | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
-    created_at: str
-    updated_at: str | None = None
-    completed_at: str | None = None
+    created_at: StrictStr
+    updated_at: StrictStr | None = None
+    completed_at: StrictStr | None = None
 
 
 class MissionStep(_Frozen):
-    id: str
-    mission_id: str
-    description: str
+    id: StrictStr
+    mission_id: StrictStr
+    description: StrictStr
     status: StepStatus
-    result: str | None = None
-    created_at: str
-    completed_at: str | None = None
+    result: StrictStr | None = None
+    created_at: StrictStr
+    completed_at: StrictStr | None = None
 
 
 class VerifierResult(_Frozen):
-    passed: bool
-    reason: str
-    suggestions: tuple[str, ...] = ()
+    passed: StrictBool
+    reason: StrictStr
+    suggestions: tuple[StrictStr, ...] = ()
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 class MissionVerificationRecord(_Frozen):
-    id: str
-    passed: bool
-    reason: str
-    suggestions: tuple[str, ...]
+    id: StrictStr
+    passed: StrictBool
+    reason: StrictStr
+    suggestions: tuple[StrictStr, ...]
     metadata: dict[str, Any]
-    created_at: str
+    created_at: StrictStr
 
 
 class MissionSubgoal(_Frozen):
-    id: str
-    mission_id: str
-    description: str
-    priority: int
+    id: StrictStr
+    mission_id: StrictStr
+    description: StrictStr
+    priority: StrictInt
     status: SubgoalStatus
-    created_at: str
-    completed_at: str | None = None
+    created_at: StrictStr
+    completed_at: StrictStr | None = None
 
 
 class BudgetUsage(_Frozen):
-    steps_used: int
-    max_steps: int | None = None
-    max_cost_usd: float | None = None
-    exhausted: bool
+    steps_used: StrictInt
+    max_steps: StrictInt | None = None
+    max_cost_usd: StrictFloat | None = None
+    exhausted: StrictBool

--- a/autocontext/tests/mission/test_mission_store.py
+++ b/autocontext/tests/mission/test_mission_store.py
@@ -1,0 +1,399 @@
+"""AC-697 mission Python parity store tests (slice 1).
+
+Mirrors the unit-test surface from ``ts/tests/mission/store.test.ts``
+plus the slice-1 contract pinning tests: SQLite tables created on
+open; mission CRUD round-trip; step + subgoal + verification CRUD
+round-trip; budget usage; status terminal-completion timestamps.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from autocontext.mission import (
+    BudgetUsage,
+    MissionBudget,
+    VerifierResult,
+)
+from autocontext.mission.store import MissionStore
+
+
+def _store(tmp_path: Path) -> MissionStore:
+    return MissionStore(str(tmp_path / "mission.sqlite3"))
+
+
+# ---------------------------------------------------------------------------
+# schema bootstrap
+# ---------------------------------------------------------------------------
+
+
+def test_open_creates_all_four_tables(tmp_path: Path) -> None:
+    """The TS and Python stores share the same on-disk schema so a
+    shared `AUTOCONTEXT_DB_PATH` can be read from either runtime."""
+    store = _store(tmp_path)
+    try:
+        rows = store._db.execute("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").fetchall()
+        names = {row["name"] for row in rows}
+        assert {
+            "missions",
+            "mission_steps",
+            "mission_verifications",
+            "mission_subgoals",
+        }.issubset(names)
+    finally:
+        store.close()
+
+
+def test_open_enables_foreign_keys_and_wal(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        fk = store._db.execute("PRAGMA foreign_keys").fetchone()[0]
+        assert fk == 1
+        journal = store._db.execute("PRAGMA journal_mode").fetchone()[0]
+        # wal mode persists across opens on the same db file.
+        assert str(journal).lower() == "wal"
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# mission CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_create_and_get_mission_round_trips_all_fields(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(
+            name="ship login",
+            goal="OAuth handshake passes",
+            budget=MissionBudget(max_steps=10, max_cost_usd=5.0),
+            metadata={"label": "demo"},
+        )
+        assert mid.startswith("mission-")
+        mission = store.get_mission(mid)
+        assert mission is not None
+        assert mission.name == "ship login"
+        assert mission.goal == "OAuth handshake passes"
+        assert mission.status == "active"
+        assert mission.budget == MissionBudget(max_steps=10, max_cost_usd=5.0)
+        assert mission.metadata == {"label": "demo"}
+        assert mission.created_at  # set by sqlite default
+    finally:
+        store.close()
+
+
+def test_get_mission_returns_none_for_unknown_id(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        assert store.get_mission("mission-deadbeef") is None
+    finally:
+        store.close()
+
+
+def test_list_missions_returns_all_inserts(tmp_path: Path) -> None:
+    """SQLite `datetime('now')` has second resolution, so inserts in
+    the same test tick share a `created_at`. We pin the set of ids
+    returned rather than the order, because the order tie-break is
+    sqlite's internal rowid which is not part of the contract."""
+    store = _store(tmp_path)
+    try:
+        ids = {store.create_mission(name=f"m{i}", goal=f"g{i}") for i in range(3)}
+        missions = store.list_missions()
+        assert {m.id for m in missions} == ids
+    finally:
+        store.close()
+
+
+def test_list_missions_filters_by_status(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        m1 = store.create_mission(name="a", goal="g")
+        store.create_mission(name="b", goal="g")
+        store.update_mission_status(m1, "completed")
+        active = store.list_missions(status="active")
+        assert [m.name for m in active] == ["b"]
+        completed = store.list_missions(status="completed")
+        assert [m.name for m in completed] == ["a"]
+    finally:
+        store.close()
+
+
+def test_terminal_status_sets_completed_at(tmp_path: Path) -> None:
+    """Mirrors the TS `buildMissionCompletionTimestamp` shape."""
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        store.update_mission_status(mid, "completed")
+        mission = store.get_mission(mid)
+        assert mission is not None
+        assert mission.completed_at is not None
+        assert mission.updated_at is not None
+    finally:
+        store.close()
+
+
+def test_non_terminal_status_does_not_set_completed_at(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        store.update_mission_status(mid, "paused")
+        mission = store.get_mission(mid)
+        assert mission is not None
+        assert mission.completed_at is None
+        assert mission.updated_at is not None
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# steps
+# ---------------------------------------------------------------------------
+
+
+def test_add_step_defaults_to_completed_status(tmp_path: Path) -> None:
+    """Matches the TS default: steps are recorded after the agent
+    finished them, so the row inserts as `completed`."""
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        sid = store.add_step(mid, description="ran cli")
+        steps = store.get_steps(mid)
+        assert len(steps) == 1
+        assert steps[0].id == sid
+        assert steps[0].status == "completed"
+        assert steps[0].description == "ran cli"
+    finally:
+        store.close()
+
+
+def test_update_step_status_terminal_sets_completed_at(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        sid = store.add_step(mid, description="ran cli")
+        store.update_step_status(sid, "failed", result="exit 1")
+        step = store.get_steps(mid)[0]
+        assert step.status == "failed"
+        assert step.result == "exit 1"
+        assert step.completed_at is not None
+    finally:
+        store.close()
+
+
+def test_update_step_status_preserves_existing_result_when_omitted(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        sid = store.add_step(mid, description="ran cli")
+        store.update_step_status(sid, "failed", result="first")
+        store.update_step_status(sid, "running", result=None)
+        step = store.get_steps(mid)[0]
+        # status update with `None` result keeps the previously
+        # recorded result.
+        assert step.result == "first"
+        assert step.status == "running"
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# verifications
+# ---------------------------------------------------------------------------
+
+
+def test_record_and_get_verifications_round_trip(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        store.record_verification(
+            mid,
+            VerifierResult(
+                passed=True,
+                reason="green",
+                suggestions=("ship it",),
+                metadata={"score": 0.95},
+            ),
+        )
+        records = store.get_verifications(mid)
+        assert len(records) == 1
+        record = records[0]
+        assert record.passed is True
+        assert record.reason == "green"
+        assert record.suggestions == ("ship it",)
+        assert record.metadata == {"score": 0.95}
+        assert record.id.startswith("verify-")
+    finally:
+        store.close()
+
+
+def test_record_verification_persists_failure_with_suggestions(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        store.record_verification(
+            mid,
+            VerifierResult(
+                passed=False,
+                reason="tests failed",
+                suggestions=("run pytest -x", "check fixtures"),
+            ),
+        )
+        record = store.get_verifications(mid)[0]
+        assert record.passed is False
+        assert record.suggestions == ("run pytest -x", "check fixtures")
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# subgoals
+# ---------------------------------------------------------------------------
+
+
+def test_add_subgoal_and_order_by_priority_then_created_at(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        store.add_subgoal(mid, description="lower", priority=2)
+        store.add_subgoal(mid, description="higher", priority=1)
+        store.add_subgoal(mid, description="lowest", priority=3)
+        subgoals = store.get_subgoals(mid)
+        assert [s.priority for s in subgoals] == [1, 2, 3]
+        assert [s.description for s in subgoals] == [
+            "higher",
+            "lower",
+            "lowest",
+        ]
+    finally:
+        store.close()
+
+
+def test_update_subgoal_terminal_sets_completed_at(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        sgid = store.add_subgoal(mid, description="x")
+        store.update_subgoal_status(sgid, "completed")
+        subgoal = store.get_subgoals(mid)[0]
+        assert subgoal.status == "completed"
+        assert subgoal.completed_at is not None
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# budget usage
+# ---------------------------------------------------------------------------
+
+
+def test_budget_usage_counts_steps(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g", budget=MissionBudget(max_steps=2))
+        store.add_step(mid, description="s1")
+        usage = store.get_budget_usage(mid)
+        assert usage.steps_used == 1
+        assert usage.max_steps == 2
+        assert usage.exhausted is False
+        store.add_step(mid, description="s2")
+        usage = store.get_budget_usage(mid)
+        assert usage.steps_used == 2
+        assert usage.exhausted is True
+    finally:
+        store.close()
+
+
+def test_budget_usage_without_budget_returns_unexhausted(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        store.add_step(mid, description="s1")
+        usage = store.get_budget_usage(mid)
+        assert usage == BudgetUsage(steps_used=1, exhausted=False)
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# cross-runtime DB compatibility (camelCase budget keys)
+# ---------------------------------------------------------------------------
+
+
+def test_budget_serialises_with_camel_case_keys_for_ts_compat(
+    tmp_path: Path,
+) -> None:
+    """The TS store persists budget fields under camelCase keys
+    (`maxSteps`, `maxCostUsd`, `maxDurationMinutes`). Mirror exactly
+    so a shared db file round-trips across runtimes."""
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(
+            name="x",
+            goal="g",
+            budget=MissionBudget(max_steps=10, max_cost_usd=1.0, max_duration_minutes=60.0),
+        )
+        row = store._db.execute("SELECT budget FROM missions WHERE id = ?", (mid,)).fetchone()
+        payload = json.loads(row["budget"])
+        assert payload == {
+            "maxSteps": 10,
+            "maxCostUsd": 1.0,
+            "maxDurationMinutes": 60.0,
+        }
+    finally:
+        store.close()
+
+
+def test_budget_camel_keys_round_trip_to_snake_case_model(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        # Insert a row using the camelCase keys the TS runtime writes;
+        # the Python loader must surface them as the snake_case model
+        # fields without losing data.
+        store._db.execute(
+            "INSERT INTO missions (id, name, goal, budget) VALUES (?, ?, ?, ?)",
+            (
+                "mission-fromtso",
+                "ts-mission",
+                "g",
+                json.dumps({"maxSteps": 4, "maxCostUsd": 2.5}),
+            ),
+        )
+        mission = store.get_mission("mission-fromtso")
+        assert mission is not None
+        assert mission.budget == MissionBudget(max_steps=4, max_cost_usd=2.5)
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def test_get_db_path_returns_constructor_arg(tmp_path: Path) -> None:
+    path = str(tmp_path / "x.sqlite3")
+    store = MissionStore(path)
+    try:
+        assert store.get_db_path() == path
+    finally:
+        store.close()
+
+
+def test_context_manager_closes(tmp_path: Path) -> None:
+    path = str(tmp_path / "ctx.sqlite3")
+    with MissionStore(path) as store:
+        assert store.get_mission("nope") is None
+    # connection closed
+    with pytest.raises(sqlite3.ProgrammingError):
+        store._db.execute("SELECT 1")

--- a/autocontext/tests/mission/test_mission_store.py
+++ b/autocontext/tests/mission/test_mission_store.py
@@ -397,3 +397,115 @@ def test_context_manager_closes(tmp_path: Path) -> None:
     # connection closed
     with pytest.raises(sqlite3.ProgrammingError):
         store._db.execute("SELECT 1")
+
+
+# ---------------------------------------------------------------------------
+# PR #1014 review (P2): runtime status validation
+# ---------------------------------------------------------------------------
+
+
+def test_update_mission_status_rejects_unknown_value_before_write(
+    tmp_path: Path,
+) -> None:
+    """`Literal` is a static-analysis hint only. Without the runtime
+    guard a typo would persist an unreadable row that later raises
+    `ValidationError` on read. Mirrors the TS Zod
+    `StatusSchema.parse(status)` pre-write guard."""
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        with pytest.raises(ValueError, match="invalid mission status 'banana'"):
+            store.update_mission_status(mid, "banana")  # type: ignore[arg-type]
+        # Row is still readable; the existing status is unchanged.
+        mission = store.get_mission(mid)
+        assert mission is not None
+        assert mission.status == "active"
+    finally:
+        store.close()
+
+
+def test_update_step_status_rejects_unknown_value_before_write(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        sid = store.add_step(mid, description="x")
+        with pytest.raises(ValueError, match="invalid step status 'banana'"):
+            store.update_step_status(sid, "banana")  # type: ignore[arg-type]
+        step = store.get_steps(mid)[0]
+        # original status preserved
+        assert step.status == "completed"
+    finally:
+        store.close()
+
+
+def test_update_subgoal_status_rejects_unknown_value_before_write(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        sgid = store.add_subgoal(mid, description="x")
+        with pytest.raises(ValueError, match="invalid subgoal status 'banana'"):
+            store.update_subgoal_status(sgid, "banana")  # type: ignore[arg-type]
+        subgoal = store.get_subgoals(mid)[0]
+        assert subgoal.status == "pending"
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# PR #1014 review (P2): primitive coercion blocked via StrictInt / StrictBool
+# ---------------------------------------------------------------------------
+
+
+def test_mission_budget_rejects_bool_for_max_steps() -> None:
+    """`MissionBudget(max_steps=True)` used to coerce to 1; strict
+    typing now rejects it. Mirrors the TS Zod schema's int-only
+    contract."""
+    from pydantic import ValidationError
+
+    from autocontext.mission import MissionBudget
+
+    with pytest.raises(ValidationError):
+        MissionBudget(max_steps=True)  # type: ignore[arg-type]
+
+
+def test_mission_budget_rejects_string_for_max_steps() -> None:
+    from pydantic import ValidationError
+
+    from autocontext.mission import MissionBudget
+
+    with pytest.raises(ValidationError):
+        MissionBudget(max_steps="5")  # type: ignore[arg-type]
+
+
+def test_mission_budget_rejects_string_for_max_cost_usd() -> None:
+    from pydantic import ValidationError
+
+    from autocontext.mission import MissionBudget
+
+    with pytest.raises(ValidationError):
+        MissionBudget(max_cost_usd="2.5")  # type: ignore[arg-type]
+
+
+def test_verifier_result_rejects_string_for_passed() -> None:
+    """`VerifierResult(passed="no")` used to coerce to False; strict
+    typing now rejects it. Mirrors the TS Zod boolean contract."""
+    from pydantic import ValidationError
+
+    from autocontext.mission import VerifierResult
+
+    with pytest.raises(ValidationError):
+        VerifierResult(passed="no", reason="x")  # type: ignore[arg-type]
+
+
+def test_verifier_result_accepts_real_booleans() -> None:
+    """The strict guard must not break the happy path."""
+    from autocontext.mission import VerifierResult
+
+    ok = VerifierResult(passed=True, reason="ok")
+    assert ok.passed is True
+    bad = VerifierResult(passed=False, reason="fail")
+    assert bad.passed is False


### PR DESCRIPTION
## Summary

Opens the AC-697 mission Python parity series. Mission is the last remaining `intentional_gap` contract entry; this slice ports the SQLite store + data model so subsequent slices can add MissionManager, verifiers, control-plane workflows, and the typer CLI on top.

- `types.py` mirrors `ts/src/mission/types.ts`: Pydantic v2 frozen models with `extra="forbid"`. Field names are snake_case on the Python side; budget fields serialise under TS-compatible camelCase keys (`maxSteps`, `maxCostUsd`, `maxDurationMinutes`) for cross-runtime DB compatibility.
- `store.py` mirrors `ts/src/mission/store.ts` + `store-schema-workflow.ts` + `store-mappers.ts` + `store-lifecycle-workflow.ts`. Identical DDL for the four tables so a shared `AUTOCONTEXT_DB_PATH` round-trips between runtimes. Same `<prefix>-<8 hex>` record-id shape and `buildXxxCompletionTimestamp` semantics. Context-manager support.

## Test plan

- [x] `uv run pytest tests/mission/` (21 passed)
- [x] `uv run pytest tests/test_module_size_limits.py` clean (`store.py` 369 lines)
- [x] `uv run ruff check` clean
- [x] `uv run mypy src/autocontext/mission/` clean
- [ ] CI: green

## Slice plan (5 PRs total)

- **slice 1 (this PR)**: SQLite store + Pydantic models
- slice 2: MissionManager + verifiers + planner
- slice 3: control-plane workflows
- slice 4: CLI subcommands (create / run / status / artifacts)
- slice 5: lifecycle subcommands (pause / resume / cancel / list) + contract flip + README

Closes the last remaining AC-697 contract `intentional_gap` once slice 5 ships.