### PR TITLE
feat(mission): AC-697 mission Python parity slice 2 (manager + verifiers + planner)

### DIFF
--- a/autocontext/src/autocontext/mission/__init__.py
+++ b/autocontext/src/autocontext/mission/__init__.py
@@ -1,11 +1,41 @@
-"""AC-697 mission Python parity surface (slice 1).
+"""AC-697 mission Python parity surface (slices 1 + 2).
 
-Mirrors ``ts/src/mission/`` step-by-step. Slice 1 covers the
-SQLite store + Pydantic models. Subsequent slices add the
-mission manager, verifiers, control-plane workflows, and the
-``autoctx mission`` CLI surface.
+Mirrors ``ts/src/mission/`` step-by-step.
+
+- slice 1: SQLite store + Pydantic models (``store``, ``types``).
+- slice 2: MissionManager + verifiers + planner + lifecycle helpers
+  (``manager``, ``verifiers``, ``planner``, ``lifecycle``,
+  ``verification``, ``events``).
+- slice 3: control-plane workflows (checkpoint, status payloads).
+- slice 4 / 5: ``autoctx mission`` CLI.
 """
 
+from autocontext.mission.events import (
+    MissionCreatedEvent,
+    MissionEventEmitter,
+    MissionStatusChangedEvent,
+    MissionStepEvent,
+    MissionVerifiedEvent,
+)
+from autocontext.mission.lifecycle import (
+    MissionStatusTransition,
+    build_verifier_error_result,
+    can_transition_mission_status,
+    derive_mission_status_from_verifier_result,
+    resolve_mission_status_transition,
+)
+from autocontext.mission.manager import MissionManager, MissionVerifierCallable
+from autocontext.mission.planner import (
+    LLMCompletion,
+    LLMCompletionRequest,
+    LLMProvider,
+    MissionPlanner,
+    PlanNextStepOpts,
+    PlanResult,
+    StepPlan,
+    SubgoalPlan,
+    VerifierFeedback,
+)
 from autocontext.mission.store import MissionStore
 from autocontext.mission.types import (
     BudgetUsage,
@@ -19,17 +49,64 @@ from autocontext.mission.types import (
     SubgoalStatus,
     VerifierResult,
 )
+from autocontext.mission.verification import (
+    MissionVerificationOutcome,
+    build_missing_verifier_outcome,
+    resolve_mission_verification_error_outcome,
+    resolve_mission_verification_outcome,
+)
+from autocontext.mission.verifiers import (
+    CodeMissionSpec,
+    CommandVerifier,
+    CompositeVerifier,
+    Verifier,
+    attach_code_mission_verifier,
+    create_code_mission,
+    rehydrate_mission_verifier,
+)
 
 __all__ = [
     "BudgetUsage",
+    "CodeMissionSpec",
+    "CommandVerifier",
+    "CompositeVerifier",
+    "LLMCompletion",
+    "LLMCompletionRequest",
+    "LLMProvider",
     "Mission",
     "MissionBudget",
+    "MissionCreatedEvent",
+    "MissionEventEmitter",
+    "MissionManager",
+    "MissionPlanner",
     "MissionStatus",
+    "MissionStatusChangedEvent",
+    "MissionStatusTransition",
     "MissionStep",
+    "MissionStepEvent",
     "MissionStore",
     "MissionSubgoal",
+    "MissionVerificationOutcome",
     "MissionVerificationRecord",
+    "MissionVerifiedEvent",
+    "MissionVerifierCallable",
+    "PlanNextStepOpts",
+    "PlanResult",
+    "StepPlan",
     "StepStatus",
+    "SubgoalPlan",
     "SubgoalStatus",
+    "Verifier",
+    "VerifierFeedback",
     "VerifierResult",
+    "attach_code_mission_verifier",
+    "build_missing_verifier_outcome",
+    "build_verifier_error_result",
+    "can_transition_mission_status",
+    "create_code_mission",
+    "derive_mission_status_from_verifier_result",
+    "rehydrate_mission_verifier",
+    "resolve_mission_status_transition",
+    "resolve_mission_verification_error_outcome",
+    "resolve_mission_verification_outcome",
 ]

--- a/autocontext/src/autocontext/mission/events.py
+++ b/autocontext/src/autocontext/mission/events.py
@@ -1,0 +1,132 @@
+"""AC-697 mission event emitter (slice 2).
+
+Mirrors ``ts/src/mission/events.ts``. Callback-based pub/sub so the
+mission manager can broadcast lifecycle events without coupling to
+any specific transport. The TS implementation extends Node's
+``EventEmitter``; the Python equivalent uses a plain listener
+registry per event kind because Python's built-in ``Observer``
+patterns are heavyweight and the surface is small.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, StrictStr
+
+__all__ = [
+    "MissionCreatedEvent",
+    "MissionEventEmitter",
+    "MissionStatusChangedEvent",
+    "MissionStepEvent",
+    "MissionVerifiedEvent",
+]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+class _Event(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class MissionCreatedEvent(_Event):
+    mission_id: StrictStr
+    name: StrictStr
+    goal: StrictStr
+    timestamp: StrictStr
+
+
+class MissionStepEvent(_Event):
+    mission_id: StrictStr
+    description: StrictStr
+    step_number: int
+    timestamp: StrictStr
+
+
+class MissionStatusChangedEvent(_Event):
+    mission_id: StrictStr
+    from_status: StrictStr
+    to_status: StrictStr
+    timestamp: StrictStr
+
+
+class MissionVerifiedEvent(_Event):
+    mission_id: StrictStr
+    passed: bool
+    reason: StrictStr
+    timestamp: StrictStr
+
+
+_EVENT_KINDS = (
+    "mission_created",
+    "mission_step",
+    "mission_status_changed",
+    "mission_verified",
+)
+
+
+class MissionEventEmitter:
+    """Tiny callback registry for mission lifecycle events.
+
+    Listeners are subscribed via ``on(event_name, callback)`` and
+    called synchronously when an emit-method fires. Exceptions
+    raised by a listener bubble up (the caller decides whether to
+    swallow them); the manager calls listeners after the SQL
+    commit, so a throwing listener does not corrupt persisted
+    state.
+    """
+
+    def __init__(self) -> None:
+        self._listeners: dict[str, list[Callable[[Any], None]]] = {kind: [] for kind in _EVENT_KINDS}
+
+    def on(self, event: str, callback: Callable[[Any], None]) -> None:
+        if event not in self._listeners:
+            raise ValueError(f"unknown mission event {event!r}; expected one of {list(self._listeners)}")
+        self._listeners[event].append(callback)
+
+    def _emit(self, event: str, payload: Any) -> None:
+        for callback in list(self._listeners[event]):
+            callback(payload)
+
+    def emit_created(self, mission_id: str, name: str, goal: str) -> None:
+        self._emit(
+            "mission_created",
+            MissionCreatedEvent(mission_id=mission_id, name=name, goal=goal, timestamp=_utc_now_iso()),
+        )
+
+    def emit_step(self, mission_id: str, description: str, step_number: int) -> None:
+        self._emit(
+            "mission_step",
+            MissionStepEvent(
+                mission_id=mission_id,
+                description=description,
+                step_number=step_number,
+                timestamp=_utc_now_iso(),
+            ),
+        )
+
+    def emit_status_change(self, mission_id: str, from_status: str, to_status: str) -> None:
+        self._emit(
+            "mission_status_changed",
+            MissionStatusChangedEvent(
+                mission_id=mission_id,
+                from_status=from_status,
+                to_status=to_status,
+                timestamp=_utc_now_iso(),
+            ),
+        )
+
+    def emit_verified(self, mission_id: str, passed: bool, reason: str) -> None:
+        self._emit(
+            "mission_verified",
+            MissionVerifiedEvent(
+                mission_id=mission_id,
+                passed=passed,
+                reason=reason,
+                timestamp=_utc_now_iso(),
+            ),
+        )

--- a/autocontext/src/autocontext/mission/lifecycle.py
+++ b/autocontext/src/autocontext/mission/lifecycle.py
@@ -1,0 +1,93 @@
+"""AC-697 mission lifecycle helpers (slice 2).
+
+Mirrors ``ts/src/mission/lifecycle.ts`` + ``status-transitions.ts``.
+Pure functions: status-transition table, derive next status from a
+verifier result, and the "verifier threw" error-result builder.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from autocontext.mission.types import MissionStatus, VerifierResult
+
+__all__ = [
+    "MissionStatusTransition",
+    "build_verifier_error_result",
+    "can_transition_mission_status",
+    "derive_mission_status_from_verifier_result",
+    "resolve_mission_status_transition",
+]
+
+
+# Transition table. Each row maps a previous status to the set of
+# statuses the manager may transition into; mirrors the TS
+# `ALLOWED_MISSION_STATUS_TRANSITIONS` table.
+_ALLOWED_TRANSITIONS: dict[MissionStatus, frozenset[MissionStatus]] = {
+    "active": frozenset(
+        {
+            "active",
+            "paused",
+            "completed",
+            "failed",
+            "canceled",
+            "blocked",
+            "budget_exhausted",
+            "verifier_failed",
+        }
+    ),
+    "paused": frozenset({"paused", "active", "canceled", "failed"}),
+    "completed": frozenset({"completed"}),
+    "failed": frozenset({"failed", "active", "canceled"}),
+    "canceled": frozenset({"canceled", "active"}),
+    "blocked": frozenset({"blocked", "active", "canceled", "failed"}),
+    "budget_exhausted": frozenset({"budget_exhausted", "active", "canceled"}),
+    "verifier_failed": frozenset({"verifier_failed", "active", "failed", "canceled"}),
+}
+
+
+@dataclass(frozen=True)
+class MissionStatusTransition:
+    next_status: MissionStatus
+    should_emit_status_change: bool
+
+
+def can_transition_mission_status(previous_status: MissionStatus | None, next_status: MissionStatus) -> bool:
+    if previous_status is None:
+        return True
+    return next_status in _ALLOWED_TRANSITIONS[previous_status]
+
+
+def resolve_mission_status_transition(
+    previous_status: MissionStatus | None, next_status: MissionStatus
+) -> MissionStatusTransition:
+    if not can_transition_mission_status(previous_status, next_status):
+        raise ValueError(f"Invalid mission status transition: {previous_status} -> {next_status}")
+    return MissionStatusTransition(
+        next_status=next_status,
+        should_emit_status_change=(previous_status is not None and previous_status != next_status),
+    )
+
+
+def derive_mission_status_from_verifier_result(
+    result: VerifierResult,
+) -> MissionStatus | None:
+    """Mirrors TS `deriveMissionStatusFromVerifierResult`: a passing
+    verifier closes the mission as `completed`; a failing verifier
+    leaves the status untouched so the operator can decide whether
+    to retry, pause, or cancel."""
+    return "completed" if result.passed else None
+
+
+def build_verifier_error_result(message: str, error_name: str) -> VerifierResult:
+    """Mirrors TS `buildVerifierErrorResult`. A verifier that throws
+    yields a failing result tagged with the original exception
+    class name so log triage can route the failure category."""
+    metadata: dict[str, Any] = {"verifierThrew": True, "errorName": error_name}
+    return VerifierResult(
+        passed=False,
+        reason=f"Verifier error: {message}",
+        suggestions=(),
+        metadata=metadata,
+    )

--- a/autocontext/src/autocontext/mission/manager.py
+++ b/autocontext/src/autocontext/mission/manager.py
@@ -1,0 +1,195 @@
+"""AC-697 mission manager (slice 2).
+
+Mirrors ``ts/src/mission/manager.ts`` (AC-410). High-level mission
+lifecycle facade over the slice-1 ``MissionStore``: create, advance,
+verify, pause / resume / cancel, and budget-usage lookups. Verifiers
+are registered per-mission and called via ``verify(mission_id)``
+which records the result + transitions the mission status (passing
+verifier -> completed; failing verifier leaves status untouched).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from autocontext.mission.events import MissionEventEmitter
+from autocontext.mission.lifecycle import resolve_mission_status_transition
+from autocontext.mission.store import MissionStore
+from autocontext.mission.types import (
+    BudgetUsage,
+    Mission,
+    MissionBudget,
+    MissionStatus,
+    MissionStep,
+    MissionSubgoal,
+    MissionVerificationRecord,
+    StepStatus,
+    SubgoalStatus,
+    VerifierResult,
+)
+from autocontext.mission.verification import (
+    build_missing_verifier_outcome,
+    resolve_mission_verification_error_outcome,
+    resolve_mission_verification_outcome,
+)
+
+__all__ = ["MissionManager", "MissionVerifierCallable"]
+
+
+MissionVerifierCallable = Callable[[str], VerifierResult]
+"""Signature for per-mission verifier callbacks; matches TS
+``MissionVerifier``."""
+
+
+class MissionManager:
+    """Lifecycle facade. Owns a ``MissionStore`` connection plus
+    optional event emitter; verifier callbacks live in an in-memory
+    map keyed by mission id."""
+
+    def __init__(self, db_path: str, *, events: MissionEventEmitter | None = None) -> None:
+        self._store = MissionStore(db_path)
+        self._verifiers: dict[str, MissionVerifierCallable] = {}
+        self._events = events
+
+    # -------------------------------------------------------------------
+    # Mission CRUD
+    # -------------------------------------------------------------------
+
+    def create(
+        self,
+        *,
+        name: str,
+        goal: str,
+        budget: MissionBudget | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        mission_id = self._store.create_mission(name=name, goal=goal, budget=budget, metadata=metadata)
+        if self._events is not None:
+            self._events.emit_created(mission_id, name, goal)
+        return mission_id
+
+    def get(self, mission_id: str) -> Mission | None:
+        return self._store.get_mission(mission_id)
+
+    def list_missions(self, status: MissionStatus | None = None) -> list[Mission]:
+        return self._store.list_missions(status)
+
+    # -------------------------------------------------------------------
+    # Steps
+    # -------------------------------------------------------------------
+
+    def advance(self, mission_id: str, description: str) -> str:
+        step_id = self._store.add_step(mission_id, description=description)
+        if self._events is not None:
+            self._events.emit_step(mission_id, description, len(self._store.get_steps(mission_id)))
+        return step_id
+
+    def steps(self, mission_id: str) -> list[MissionStep]:
+        return self._store.get_steps(mission_id)
+
+    def update_step(
+        self,
+        step_id: str,
+        status: StepStatus,
+        result: str | None = None,
+    ) -> None:
+        self._store.update_step_status(step_id, status, result)
+
+    # -------------------------------------------------------------------
+    # Subgoals
+    # -------------------------------------------------------------------
+
+    def subgoals(self, mission_id: str) -> list[MissionSubgoal]:
+        return self._store.get_subgoals(mission_id)
+
+    def add_subgoal(self, mission_id: str, *, description: str, priority: int = 1) -> str:
+        return self._store.add_subgoal(mission_id, description=description, priority=priority)
+
+    def update_subgoal_status(self, subgoal_id: str, status: SubgoalStatus) -> None:
+        self._store.update_subgoal_status(subgoal_id, status)
+
+    # -------------------------------------------------------------------
+    # Verifiers
+    # -------------------------------------------------------------------
+
+    def set_verifier(self, mission_id: str, verifier: MissionVerifierCallable) -> None:
+        self._verifiers[mission_id] = verifier
+
+    def has_verifier(self, mission_id: str) -> bool:
+        return mission_id in self._verifiers
+
+    def verify(self, mission_id: str) -> VerifierResult:
+        """Run the registered verifier (or surface "no verifier" when
+        none is registered), persist the outcome, transition the
+        mission status if the outcome demands it, and return the
+        result."""
+        verifier = self._verifiers.get(mission_id)
+        if verifier is None:
+            outcome = build_missing_verifier_outcome()
+        else:
+            try:
+                outcome = resolve_mission_verification_outcome(verifier(mission_id))
+            except Exception as err:
+                outcome = resolve_mission_verification_error_outcome(str(err), type(err).__name__)
+
+        self._store.record_verification(mission_id, outcome.result)
+        if self._events is not None:
+            self._events.emit_verified(mission_id, outcome.result.passed, outcome.result.reason)
+        if outcome.next_status is not None:
+            self._transition_mission_status(mission_id, outcome.next_status)
+        return outcome.result
+
+    def verifications(self, mission_id: str) -> list[MissionVerificationRecord]:
+        return self._store.get_verifications(mission_id)
+
+    # -------------------------------------------------------------------
+    # Status transitions
+    # -------------------------------------------------------------------
+
+    def pause(self, mission_id: str) -> None:
+        self._transition_mission_status(mission_id, "paused")
+
+    def resume(self, mission_id: str) -> None:
+        self._transition_mission_status(mission_id, "active")
+
+    def cancel(self, mission_id: str) -> None:
+        self._transition_mission_status(mission_id, "canceled")
+
+    def set_status(self, mission_id: str, status: MissionStatus) -> None:
+        self._transition_mission_status(mission_id, status)
+
+    # -------------------------------------------------------------------
+    # Budget usage
+    # -------------------------------------------------------------------
+
+    def budget_usage(self, mission_id: str) -> BudgetUsage:
+        return self._store.get_budget_usage(mission_id)
+
+    # -------------------------------------------------------------------
+    # Bookkeeping
+    # -------------------------------------------------------------------
+
+    def get_db_path(self) -> str:
+        return self._store.get_db_path()
+
+    def close(self) -> None:
+        self._store.close()
+
+    def __enter__(self) -> MissionManager:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
+    # -------------------------------------------------------------------
+    # internal
+    # -------------------------------------------------------------------
+
+    def _transition_mission_status(self, mission_id: str, status: MissionStatus) -> None:
+        mission = self._store.get_mission(mission_id)
+        previous_status = mission.status if mission is not None else None
+        transition = resolve_mission_status_transition(previous_status, status)
+        self._store.update_mission_status(mission_id, transition.next_status)
+        if previous_status is not None and transition.should_emit_status_change and self._events is not None:
+            self._events.emit_status_change(mission_id, previous_status, transition.next_status)

--- a/autocontext/src/autocontext/mission/manager.py
+++ b/autocontext/src/autocontext/mission/manager.py
@@ -10,6 +10,8 @@ verifier -> completed; failing verifier leaves status untouched).
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 from collections.abc import Callable
 from typing import Any
 
@@ -123,21 +125,60 @@ class MissionManager:
         """Run the registered verifier (or surface "no verifier" when
         none is registered), persist the outcome, transition the
         mission status if the outcome demands it, and return the
-        result."""
+        result.
+
+        PR #1015 review:
+
+        - P2 (async verifiers): the TS `MissionVerifier` contract is
+          promise-based; an `async def` Python verifier returns a
+          coroutine. We detect coroutines via ``inspect.iscoroutine``
+          and run them to completion via ``asyncio.run`` so an async
+          verifier resolves into a real ``VerifierResult`` instead of
+          flowing through the error path as `'coroutine' object has
+          no attribute 'passed'`. Sync verifiers are unchanged. The
+          caller must not be inside a running event loop (matches
+          the standard sync-to-async bridge limitation).
+
+        - P2 (transition ordering): a verifier outcome that demands a
+          status transition (passing -> completed) must validate the
+          transition BEFORE persisting the verification record or
+          emitting events. Otherwise a `paused` mission with a
+          passing verifier would persist a passing record + emit
+          `mission_verified`, then raise on the invalid
+          `paused -> completed` transition and leave the mission in
+          an inconsistent state. We resolve + apply the transition,
+          then record the verification, then emit events.
+        """
         verifier = self._verifiers.get(mission_id)
         if verifier is None:
             outcome = build_missing_verifier_outcome()
         else:
             try:
-                outcome = resolve_mission_verification_outcome(verifier(mission_id))
+                raw = verifier(mission_id)
+                if inspect.iscoroutine(raw):
+                    raw = asyncio.run(raw)
+                outcome = resolve_mission_verification_outcome(raw)
             except Exception as err:
                 outcome = resolve_mission_verification_error_outcome(str(err), type(err).__name__)
 
+        # Pre-validate the status transition so an invalid one does not
+        # leave a stranded verification record + status-change event.
+        transition = None
+        previous_status: MissionStatus | None = None
+        if outcome.next_status is not None:
+            mission = self._store.get_mission(mission_id)
+            previous_status = mission.status if mission is not None else None
+            transition = resolve_mission_status_transition(previous_status, outcome.next_status)
+
+        # Validation passed: persist verification + transition together,
+        # then emit best-effort notifications.
         self._store.record_verification(mission_id, outcome.result)
+        if transition is not None:
+            self._store.update_mission_status(mission_id, transition.next_status)
         if self._events is not None:
             self._events.emit_verified(mission_id, outcome.result.passed, outcome.result.reason)
-        if outcome.next_status is not None:
-            self._transition_mission_status(mission_id, outcome.next_status)
+            if transition is not None and previous_status is not None and transition.should_emit_status_change:
+                self._events.emit_status_change(mission_id, previous_status, transition.next_status)
         return outcome.result
 
     def verifications(self, mission_id: str) -> list[MissionVerificationRecord]:

--- a/autocontext/src/autocontext/mission/planner.py
+++ b/autocontext/src/autocontext/mission/planner.py
@@ -1,0 +1,319 @@
+"""AC-697 mission planner (slice 2).
+
+Mirrors ``ts/src/mission/planner.ts`` (AC-435). Adaptive mission
+planning over a pluggable LLM provider:
+
+- ``decompose(goal)`` returns prioritised subgoals.
+- ``plan_next_step(opts)`` decides the next action given the goal,
+  completed steps, remaining subgoals, and verifier feedback.
+
+The TS implementation depends on the codebase-wide ``LLMProvider``
+interface; the Python port defines a minimal ``LLMProvider``
+``Protocol`` here so slice-2 callers can drive the planner with any
+shape (real provider, stub, recorded fixture). Future slices wire
+the production provider.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from autocontext.mission.events import _utc_now_iso as _now  # noqa: F401  # parity import marker
+
+__all__ = [
+    "LLMCompletion",
+    "LLMCompletionRequest",
+    "LLMProvider",
+    "MissionPlanner",
+    "PlanNextStepOpts",
+    "PlanResult",
+    "StepPlan",
+    "SubgoalPlan",
+    "VerifierFeedback",
+]
+
+
+# ---------------------------------------------------------------------------
+# Provider abstraction
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LLMCompletionRequest:
+    system_prompt: str
+    user_prompt: str
+
+
+@dataclass(frozen=True)
+class LLMCompletion:
+    text: str
+
+
+class LLMProvider(Protocol):
+    """Minimal LLM provider shape used by the planner.
+
+    Slice 2 keeps this local so the planner can be unit-tested
+    against a deterministic stub. A later slice can wire it to the
+    package-wide LLM provider once the rest of the mission CLI is
+    in place."""
+
+    def complete(self, request: LLMCompletionRequest) -> LLMCompletion: ...
+
+
+# ---------------------------------------------------------------------------
+# Plan + step data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SubgoalPlan:
+    description: str
+    priority: int
+
+
+@dataclass(frozen=True)
+class PlanResult:
+    subgoals: tuple[SubgoalPlan, ...]
+    reasoning: str | None = None
+
+
+@dataclass(frozen=True)
+class VerifierFeedback:
+    passed: bool
+    reason: str
+    suggestions: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PlanNextStepOpts:
+    goal: str
+    completed_steps: tuple[str, ...]
+    remaining_subgoals: tuple[str, ...]
+    verifier_feedback: VerifierFeedback | None = None
+
+
+@dataclass(frozen=True)
+class StepPlan:
+    description: str
+    reasoning: str
+    should_revise: bool
+    target_subgoal: str | None = None
+    revised_subgoals: tuple[SubgoalPlan, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Prompts (TS parity)
+# ---------------------------------------------------------------------------
+
+
+_DECOMPOSE_SYSTEM = """You are a mission planner. Given a plain-language goal, decompose it into concrete, prioritized subgoals.
+
+Output a JSON object with this shape:
+{
+  "subgoals": [
+    { "description": "Concrete step description", "priority": 1 },
+    { "description": "Next step", "priority": 2 }
+  ],
+  "reasoning": "Why this decomposition"
+}
+
+Rules:
+- Priority 1 is highest (do first)
+- Each subgoal should be specific and actionable
+- Order by dependency: if B depends on A, A gets lower priority number
+- 2-7 subgoals is ideal; avoid over-decomposition
+- Output ONLY the JSON object, no markdown fences"""
+
+
+_PLAN_STEP_SYSTEM_HEADER = (
+    "You are an adaptive mission executor. Given the mission goal, "
+    "completed steps, remaining subgoals, and verifier feedback, "
+    "plan the next action."
+)
+
+_PLAN_STEP_SYSTEM = (
+    _PLAN_STEP_SYSTEM_HEADER
+    + """
+
+Output a JSON object with this shape:
+{
+  "nextStep": "What to do next",
+  "reasoning": "Why this is the right next step",
+  "shouldRevise": false,
+  "targetSubgoal": "Exact string from Remaining Subgoals"
+}
+
+If verifier feedback suggests the current plan is wrong, set shouldRevise: true and include revised subgoals:
+{
+  "nextStep": "What to do next",
+  "reasoning": "Why we need to change approach",
+  "shouldRevise": true,
+  "revisedSubgoals": [
+    { "description": "New step", "priority": 1 }
+  ]
+}
+
+Rules:
+- Base your decision on verifier feedback and completed work
+- If feedback has suggestions, incorporate them
+- Don't repeat already-completed steps
+- When the next step advances an existing remaining subgoal, set targetSubgoal to the exact subgoal text from Remaining Subgoals
+- If you are revising the plan instead of completing a current subgoal, omit targetSubgoal
+- Be specific about what to do, not generic
+- Output ONLY the JSON object"""
+)  # noqa: E501
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_json(text: str) -> dict[str, Any] | None:
+    """Mirror TS `parseJSON`: try the trimmed text first, then walk
+    inward to find the outermost `{ ... }` block. Any failure
+    returns None so the planner can fall back to a deterministic
+    plan."""
+    trimmed = text.strip()
+    try:
+        loaded = json.loads(trimmed)
+        return loaded if isinstance(loaded, dict) else None
+    except json.JSONDecodeError:
+        pass
+    start = trimmed.find("{")
+    end = trimmed.rfind("}")
+    if start != -1 and end > start:
+        try:
+            loaded = json.loads(trimmed[start : end + 1])
+            return loaded if isinstance(loaded, dict) else None
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _coerce_subgoals(payload: list[Any]) -> tuple[SubgoalPlan, ...]:
+    out: list[SubgoalPlan] = []
+    for index, entry in enumerate(payload):
+        if not isinstance(entry, dict):
+            continue
+        desc = entry.get("description")
+        if not isinstance(desc, str) or not desc.strip():
+            continue
+        priority_value = entry.get("priority")
+        priority = (
+            priority_value if isinstance(priority_value, (int, float)) and not isinstance(priority_value, bool) else index + 1
+        )
+        out.append(SubgoalPlan(description=desc.strip(), priority=int(priority)))
+    return tuple(sorted(out, key=lambda s: s.priority))
+
+
+# ---------------------------------------------------------------------------
+# MissionPlanner
+# ---------------------------------------------------------------------------
+
+
+class MissionPlanner:
+    def __init__(self, provider: LLMProvider) -> None:
+        self._provider = provider
+
+    def decompose(self, goal: str) -> PlanResult:
+        try:
+            response = self._provider.complete(
+                LLMCompletionRequest(
+                    system_prompt=_DECOMPOSE_SYSTEM,
+                    user_prompt=f"Mission goal: {goal}",
+                )
+            )
+        except Exception:
+            return self._fallback_plan(goal)
+
+        parsed = _parse_json(response.text)
+        if parsed is None or not isinstance(parsed.get("subgoals"), list):
+            return self._fallback_plan(goal)
+
+        subgoals = _coerce_subgoals(parsed["subgoals"])
+        if not subgoals:
+            return self._fallback_plan(goal)
+
+        reasoning_raw = parsed.get("reasoning")
+        reasoning = reasoning_raw if isinstance(reasoning_raw, str) else None
+        return PlanResult(subgoals=subgoals, reasoning=reasoning)
+
+    def plan_next_step(self, opts: PlanNextStepOpts) -> StepPlan:
+        user_prompt = self._build_step_prompt(opts)
+        try:
+            response = self._provider.complete(LLMCompletionRequest(system_prompt=_PLAN_STEP_SYSTEM, user_prompt=user_prompt))
+        except Exception:
+            return self._fallback_step(opts)
+
+        parsed = _parse_json(response.text)
+        if parsed is None or not isinstance(parsed.get("nextStep"), str):
+            return self._fallback_step(opts)
+
+        description = str(parsed["nextStep"]).strip()
+        reasoning_raw = parsed.get("reasoning")
+        reasoning = str(reasoning_raw) if isinstance(reasoning_raw, str) else "Continuing mission"
+        should_revise = parsed.get("shouldRevise") is True
+
+        target_subgoal: str | None = None
+        target_raw = parsed.get("targetSubgoal")
+        if isinstance(target_raw, str) and target_raw in opts.remaining_subgoals:
+            target_subgoal = target_raw
+        elif not should_revise and len(opts.remaining_subgoals) == 1:
+            target_subgoal = opts.remaining_subgoals[0]
+
+        revised_subgoals: tuple[SubgoalPlan, ...] = ()
+        if should_revise and isinstance(parsed.get("revisedSubgoals"), list):
+            revised_subgoals = _coerce_subgoals(parsed["revisedSubgoals"])
+
+        return StepPlan(
+            description=description,
+            reasoning=reasoning,
+            should_revise=should_revise,
+            target_subgoal=target_subgoal,
+            revised_subgoals=revised_subgoals,
+        )
+
+    # ----------------------- prompt + fallbacks --------------------------
+
+    def _build_step_prompt(self, opts: PlanNextStepOpts) -> str:
+        sections: list[str] = [f"## Mission Goal\n{opts.goal}"]
+        if opts.completed_steps:
+            steps = "\n".join(f"{i + 1}. {description}" for i, description in enumerate(opts.completed_steps))
+            sections.append(f"## Completed Steps\n{steps}")
+        if opts.remaining_subgoals:
+            bullets = "\n".join(f"- {sg}" for sg in opts.remaining_subgoals)
+            sections.append(f"## Remaining Subgoals\n{bullets}")
+        feedback = opts.verifier_feedback
+        if feedback is not None:
+            sections.append(f"## Verifier Feedback\nPassed: {str(feedback.passed).lower()}\nReason: {feedback.reason}")
+            if feedback.suggestions:
+                bullets = "\n".join(f"- {s}" for s in feedback.suggestions)
+                sections.append(f"Suggestions:\n{bullets}")
+        return "\n\n".join(sections)
+
+    @staticmethod
+    def _fallback_plan(goal: str) -> PlanResult:
+        return PlanResult(
+            subgoals=(SubgoalPlan(description=f"Work toward: {goal}", priority=1),),
+            reasoning="Fallback: could not decompose goal via LLM",
+        )
+
+    @staticmethod
+    def _fallback_step(opts: PlanNextStepOpts) -> StepPlan:
+        if opts.remaining_subgoals:
+            next_subgoal = opts.remaining_subgoals[0]
+            return StepPlan(
+                description=f"Work on: {next_subgoal}",
+                reasoning="Fallback: could not plan step via LLM",
+                should_revise=False,
+                target_subgoal=next_subgoal,
+            )
+        return StepPlan(
+            description=f"Continue: {opts.goal}",
+            reasoning="Fallback: could not plan step via LLM",
+            should_revise=False,
+            target_subgoal=None,
+        )

--- a/autocontext/src/autocontext/mission/verification.py
+++ b/autocontext/src/autocontext/mission/verification.py
@@ -1,0 +1,57 @@
+"""AC-697 mission verification workflow (slice 2).
+
+Mirrors ``ts/src/mission/verification-workflow.ts``. Pure functions
+that classify a verifier outcome into a (``result``, ``next_status``)
+pair the manager can then persist + apply.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from autocontext.mission.lifecycle import (
+    build_verifier_error_result,
+    derive_mission_status_from_verifier_result,
+)
+from autocontext.mission.types import MissionStatus, VerifierResult
+
+__all__ = [
+    "MissionVerificationOutcome",
+    "build_missing_verifier_outcome",
+    "resolve_mission_verification_error_outcome",
+    "resolve_mission_verification_outcome",
+]
+
+
+@dataclass(frozen=True)
+class MissionVerificationOutcome:
+    result: VerifierResult
+    next_status: MissionStatus | None
+
+
+def build_missing_verifier_outcome() -> MissionVerificationOutcome:
+    return MissionVerificationOutcome(
+        result=VerifierResult(
+            passed=False,
+            reason="No verifier registered",
+            suggestions=(),
+            metadata={},
+        ),
+        next_status=None,
+    )
+
+
+def resolve_mission_verification_outcome(
+    result: VerifierResult,
+) -> MissionVerificationOutcome:
+    return MissionVerificationOutcome(
+        result=result,
+        next_status=derive_mission_status_from_verifier_result(result),
+    )
+
+
+def resolve_mission_verification_error_outcome(message: str, error_name: str) -> MissionVerificationOutcome:
+    return MissionVerificationOutcome(
+        result=build_verifier_error_result(message, error_name),
+        next_status=None,
+    )

--- a/autocontext/src/autocontext/mission/verifiers.py
+++ b/autocontext/src/autocontext/mission/verifiers.py
@@ -1,0 +1,263 @@
+"""AC-697 mission verifiers (slice 2).
+
+Mirrors ``ts/src/mission/verifiers.ts`` (AC-415). Hard external
+verifiers that run shell commands (test, lint, build) and decide
+mission success from the exit code.
+
+- ``CommandVerifier`` runs a single shell command via ``/bin/sh -c``;
+  exit 0 = pass.
+- ``CompositeVerifier`` short-circuits on the first failing verifier
+  (matches the TS behaviour).
+- ``CodeMissionSpec`` is the Pydantic spec for the
+  ``create_code_mission`` factory; required + optional commands are
+  composed into a single ``Verifier``.
+- ``create_code_mission`` registers the mission via the manager and
+  attaches the verifier.
+- ``rehydrate_mission_verifier`` rebinds the verifier from the
+  mission's stored ``metadata`` so a process restart picks the
+  verifier up without re-running ``create_code_mission``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, StrictStr
+
+from autocontext.mission.types import Mission, MissionBudget, VerifierResult
+
+if TYPE_CHECKING:
+    from autocontext.mission.manager import MissionManager
+
+__all__ = [
+    "CodeMissionSpec",
+    "CommandVerifier",
+    "CompositeVerifier",
+    "Verifier",
+    "attach_code_mission_verifier",
+    "create_code_mission",
+    "rehydrate_mission_verifier",
+]
+
+
+_COMMAND_TIMEOUT_SECONDS = 120
+_STDERR_SUGGESTION_LIMIT = 500
+_OUTPUT_METADATA_LIMIT = 2000
+
+
+class Verifier(Protocol):
+    """Mirrors TS `Verifier` interface."""
+
+    label: str
+
+    def verify(self, mission_id: str) -> VerifierResult: ...
+
+
+class CommandVerifier:
+    """Runs a single shell command via ``/bin/sh -c`` and reports the
+    result. Mirrors TS ``CommandVerifier`` shape: exit 0 -> pass;
+    non-zero exit (or timeout / spawn failure) -> fail with stderr
+    snippet surfaced as a suggestion."""
+
+    def __init__(self, command: str, cwd: str) -> None:
+        self._command = command
+        self._cwd = cwd
+        self.label = command
+
+    def verify(self, _mission_id: str) -> VerifierResult:
+        try:
+            proc = subprocess.run(
+                ["/bin/sh", "-c", self._command],
+                cwd=self._cwd,
+                capture_output=True,
+                text=True,
+                timeout=_COMMAND_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as err:
+            return VerifierResult(
+                passed=False,
+                reason=f"Command {self._command!r} timed out after {_COMMAND_TIMEOUT_SECONDS}s",
+                suggestions=(),
+                metadata={
+                    "command": self._command,
+                    "timeout": True,
+                    "exitCode": -1,
+                    "stdout": _truncate(_coerce_str(err.stdout), _OUTPUT_METADATA_LIMIT),
+                    "stderr": _truncate(_coerce_str(err.stderr), _OUTPUT_METADATA_LIMIT),
+                },
+            )
+        except OSError as err:
+            return VerifierResult(
+                passed=False,
+                reason=f"Command {self._command!r} could not start: {err}",
+                suggestions=(),
+                metadata={
+                    "command": self._command,
+                    "spawnFailed": True,
+                },
+            )
+
+        if proc.returncode == 0:
+            return VerifierResult(
+                passed=True,
+                reason=f"Command '{self._command}' passed (exit 0)",
+                suggestions=(),
+                metadata={"stdout": proc.stdout.strip(), "command": self._command},
+            )
+
+        stderr = proc.stderr or ""
+        suggestions: tuple[str, ...] = ()
+        if stderr.strip():
+            suggestions = (f"stderr: {stderr.strip()[:_STDERR_SUGGESTION_LIMIT]}",)
+        return VerifierResult(
+            passed=False,
+            reason=f"Command '{self._command}' failed (exit {proc.returncode})",
+            suggestions=suggestions,
+            metadata={
+                "command": self._command,
+                "exitCode": proc.returncode,
+                "stdout": _truncate(proc.stdout or "", _OUTPUT_METADATA_LIMIT),
+                "stderr": _truncate(stderr, _OUTPUT_METADATA_LIMIT),
+            },
+        )
+
+
+class CompositeVerifier:
+    """All-must-pass composite. Mirrors TS short-circuit shape:
+    iterate verifiers in declaration order, return the first
+    failure with `failedVerifier` set on the metadata; otherwise
+    aggregate to a single passing result with the verifier count."""
+
+    def __init__(self, verifiers: list[Verifier]) -> None:
+        self._verifiers = list(verifiers)
+        self.label = " && ".join(v.label for v in verifiers)
+
+    def verify(self, mission_id: str) -> VerifierResult:
+        for verifier in self._verifiers:
+            result = verifier.verify(mission_id)
+            if not result.passed:
+                metadata = dict(result.metadata)
+                metadata["failedVerifier"] = verifier.label
+                return VerifierResult(
+                    passed=False,
+                    reason=result.reason,
+                    suggestions=result.suggestions,
+                    metadata=metadata,
+                )
+        return VerifierResult(
+            passed=True,
+            reason=f"All {len(self._verifiers)} verifier(s) passed",
+            suggestions=(),
+            metadata={"verifierCount": len(self._verifiers)},
+        )
+
+
+class CodeMissionSpec(BaseModel):
+    """Pydantic v2 mirror of TS ``CodeMissionSpecSchema``.
+
+    ``extra="forbid"`` so a misspelled field rejects at parse time;
+    primitive coercion blocked via Strict types (PR #1014 review P2
+    parity)."""
+
+    model_config = ConfigDict(extra="forbid")
+    name: StrictStr
+    goal: StrictStr
+    repo_path: StrictStr
+    test_command: StrictStr
+    lint_command: StrictStr | None = None
+    build_command: StrictStr | None = None
+    budget: MissionBudget | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+def _build_code_mission_verifier(spec: CodeMissionSpec) -> Verifier:
+    verifiers: list[Verifier] = [CommandVerifier(spec.test_command, spec.repo_path)]
+    if spec.lint_command:
+        verifiers.append(CommandVerifier(spec.lint_command, spec.repo_path))
+    if spec.build_command:
+        verifiers.append(CommandVerifier(spec.build_command, spec.repo_path))
+    if len(verifiers) == 1:
+        return verifiers[0]
+    return CompositeVerifier(verifiers)
+
+
+def attach_code_mission_verifier(manager: MissionManager, mission_id: str, spec: CodeMissionSpec) -> None:
+    verifier = _build_code_mission_verifier(spec)
+    manager.set_verifier(mission_id, verifier.verify)
+
+
+def rehydrate_mission_verifier(manager: MissionManager, mission: Mission) -> bool:
+    """Rebind a verifier from the mission's stored ``metadata`` blob.
+
+    Returns True when the metadata carries enough state to rebuild
+    the verifier (mission_type == "code" + repo_path + test_command);
+    False otherwise. Optional commands ride through when present.
+    """
+    metadata = mission.metadata
+    if metadata.get("missionType") != "code":
+        return False
+
+    repo_path = metadata.get("repoPath")
+    test_command = metadata.get("testCommand")
+    if not isinstance(repo_path, str) or not isinstance(test_command, str):
+        return False
+
+    lint = metadata.get("lintCommand")
+    build = metadata.get("buildCommand")
+    attach_code_mission_verifier(
+        manager,
+        mission.id,
+        CodeMissionSpec(
+            name=mission.name,
+            goal=mission.goal,
+            repo_path=repo_path,
+            test_command=test_command,
+            lint_command=lint if isinstance(lint, str) else None,
+            build_command=build if isinstance(build, str) else None,
+        ),
+    )
+    return True
+
+
+def create_code_mission(manager: MissionManager, spec: CodeMissionSpec) -> str:
+    """Mirror TS ``createCodeMission``: register the mission with
+    ``missionType == "code"`` plus the verifier commands on the
+    metadata blob, then attach the matching verifier."""
+    parsed = CodeMissionSpec.model_validate(spec.model_dump())
+    metadata: dict[str, Any] = {
+        **parsed.metadata,
+        "missionType": "code",
+        "repoPath": parsed.repo_path,
+        "testCommand": parsed.test_command,
+    }
+    if parsed.lint_command is not None:
+        metadata["lintCommand"] = parsed.lint_command
+    if parsed.build_command is not None:
+        metadata["buildCommand"] = parsed.build_command
+
+    mission_id = manager.create(
+        name=parsed.name,
+        goal=parsed.goal,
+        budget=parsed.budget,
+        metadata=metadata,
+    )
+    attach_code_mission_verifier(manager, mission_id, parsed)
+    return mission_id
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = text.strip()
+    return text[:limit]
+
+
+def _coerce_str(value: bytes | str | None) -> str:
+    """``subprocess.TimeoutExpired.stdout`` / ``stderr`` are typed as
+    ``bytes | str | None`` even with ``text=True``. Coerce to ``str``
+    so the downstream ``_truncate`` call is type-safe."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value

--- a/autocontext/tests/mission/test_mission_lifecycle.py
+++ b/autocontext/tests/mission/test_mission_lifecycle.py
@@ -1,0 +1,126 @@
+"""AC-697 mission lifecycle helper tests (slice 2).
+
+Mirrors the unit-test surface for ``ts/src/mission/lifecycle.ts`` +
+``status-transitions.ts`` + ``verification-workflow.ts``: pure
+function tests covering the transition table, verifier-result -> next
+status derivation, and the workflow outcome builders.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autocontext.mission import (
+    VerifierResult,
+    build_missing_verifier_outcome,
+    build_verifier_error_result,
+    can_transition_mission_status,
+    derive_mission_status_from_verifier_result,
+    resolve_mission_status_transition,
+    resolve_mission_verification_error_outcome,
+    resolve_mission_verification_outcome,
+)
+
+# ---------------------------------------------------------------------------
+# transition table
+# ---------------------------------------------------------------------------
+
+
+def test_no_previous_status_always_transitions() -> None:
+    """The TS table treats ``previousStatus === undefined`` as a
+    wildcard so new missions can land in any state. The Python port
+    mirrors that."""
+    for next_status in (
+        "active",
+        "paused",
+        "completed",
+        "failed",
+        "canceled",
+        "blocked",
+        "budget_exhausted",
+        "verifier_failed",
+    ):
+        assert can_transition_mission_status(None, next_status) is True
+
+
+def test_active_to_paused_is_allowed() -> None:
+    transition = resolve_mission_status_transition("active", "paused")
+    assert transition.next_status == "paused"
+    assert transition.should_emit_status_change is True
+
+
+def test_paused_to_completed_is_rejected() -> None:
+    with pytest.raises(ValueError, match="paused -> completed"):
+        resolve_mission_status_transition("paused", "completed")
+
+
+def test_completed_is_terminal() -> None:
+    """The TS table only allows completed -> completed (self-loop, no
+    re-open)."""
+    for forbidden in ("active", "paused", "canceled", "failed"):
+        assert can_transition_mission_status("completed", forbidden) is False
+    transition = resolve_mission_status_transition("completed", "completed")
+    assert transition.should_emit_status_change is False
+
+
+def test_self_loop_does_not_emit_status_change() -> None:
+    transition = resolve_mission_status_transition("active", "active")
+    assert transition.next_status == "active"
+    assert transition.should_emit_status_change is False
+
+
+# ---------------------------------------------------------------------------
+# verifier result -> status derivation
+# ---------------------------------------------------------------------------
+
+
+def test_passing_verifier_result_completes_the_mission() -> None:
+    result = VerifierResult(passed=True, reason="green")
+    assert derive_mission_status_from_verifier_result(result) == "completed"
+
+
+def test_failing_verifier_result_leaves_status_untouched() -> None:
+    result = VerifierResult(passed=False, reason="tests failed")
+    assert derive_mission_status_from_verifier_result(result) is None
+
+
+# ---------------------------------------------------------------------------
+# error result builder
+# ---------------------------------------------------------------------------
+
+
+def test_verifier_error_result_carries_error_name_and_message() -> None:
+    result = build_verifier_error_result("boom", "RuntimeError")
+    assert result.passed is False
+    assert "Verifier error: boom" in result.reason
+    assert result.metadata["verifierThrew"] is True
+    assert result.metadata["errorName"] == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# verification workflow outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_missing_verifier_outcome_is_failing_with_no_next_status() -> None:
+    outcome = build_missing_verifier_outcome()
+    assert outcome.result.passed is False
+    assert outcome.result.reason == "No verifier registered"
+    assert outcome.next_status is None
+
+
+def test_pass_outcome_derives_completed_next_status() -> None:
+    outcome = resolve_mission_verification_outcome(VerifierResult(passed=True, reason="green"))
+    assert outcome.next_status == "completed"
+
+
+def test_fail_outcome_keeps_next_status_none() -> None:
+    outcome = resolve_mission_verification_outcome(VerifierResult(passed=False, reason="red"))
+    assert outcome.next_status is None
+
+
+def test_error_outcome_wraps_thrown_error_and_keeps_next_status_none() -> None:
+    outcome = resolve_mission_verification_error_outcome("boom", "OSError")
+    assert outcome.result.passed is False
+    assert outcome.result.metadata["errorName"] == "OSError"
+    assert outcome.next_status is None

--- a/autocontext/tests/mission/test_mission_manager.py
+++ b/autocontext/tests/mission/test_mission_manager.py
@@ -179,6 +179,94 @@ def test_events_emit_created_step_status_and_verified(tmp_path: Path) -> None:
     ]
 
 
+# ---------------------------------------------------------------------------
+# PR #1015 review (P2): async verifier support
+# ---------------------------------------------------------------------------
+
+
+def test_async_verifier_is_awaited_and_completes_mission(tmp_path: Path) -> None:
+    """The TS `MissionVerifier` contract is promise-based; an
+    `async def` Python verifier returns a coroutine. The manager now
+    detects coroutines and runs them via `asyncio.run` so an async
+    verifier resolves into a real `VerifierResult` instead of
+    flowing through the error path as a coroutine-attribute error.
+    """
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+
+        async def passing(_mid: str) -> VerifierResult:
+            return VerifierResult(passed=True, reason="green")
+
+        mgr.set_verifier(mid, passing)
+        result = mgr.verify(mid)
+        assert result.passed is True
+        assert mgr.get(mid).status == "completed"
+
+
+def test_async_verifier_that_raises_yields_failing_result(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+
+        async def boom(_mid: str) -> VerifierResult:
+            raise RuntimeError("kaboom")
+
+        mgr.set_verifier(mid, boom)
+        result = mgr.verify(mid)
+        assert result.passed is False
+        assert result.metadata["errorName"] == "RuntimeError"
+        assert "kaboom" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# PR #1015 review (P2): transition ordering
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_transition_under_verify_does_not_persist_verification(
+    tmp_path: Path,
+) -> None:
+    """A paused mission with a passing verifier raises
+    `paused -> completed`. Before this fix the verification record
+    was already persisted and the `mission_verified` event already
+    emitted, leaving an inconsistent state. After the fix the
+    transition is pre-validated so the rejection short-circuits
+    before either side effect.
+    """
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.pause(mid)
+        mgr.set_verifier(mid, lambda _mid: VerifierResult(passed=True, reason="green"))
+        with pytest.raises(ValueError, match="paused -> completed"):
+            mgr.verify(mid)
+        # No verification record persisted because the transition
+        # rejection short-circuited first.
+        assert mgr.verifications(mid) == []
+        # Mission still paused.
+        assert mgr.get(mid).status == "paused"
+
+
+def test_verified_listener_raising_does_not_block_status_completion(
+    tmp_path: Path,
+) -> None:
+    """Status transitions are durable state; events are
+    best-effort. If a `mission_verified` listener raises, the
+    status update is already persisted so the mission stays
+    completed."""
+    events = MissionEventEmitter()
+    events.on(
+        "mission_verified",
+        lambda _payload: (_ for _ in ()).throw(RuntimeError("listener boom")),
+    )
+    with MissionManager(str(tmp_path / "m.sqlite3"), events=events) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.set_verifier(mid, lambda _mid: VerifierResult(passed=True, reason="green"))
+        with pytest.raises(RuntimeError, match="listener boom"):
+            mgr.verify(mid)
+        # The status transition is already persisted; the listener
+        # exception did not block it.
+        assert mgr.get(mid).status == "completed"
+
+
 def test_status_change_event_carries_from_and_to(tmp_path: Path) -> None:
     events = MissionEventEmitter()
     payloads: list[object] = []

--- a/autocontext/tests/mission/test_mission_manager.py
+++ b/autocontext/tests/mission/test_mission_manager.py
@@ -1,0 +1,193 @@
+"""AC-697 mission manager tests (slice 2).
+
+Mirrors the unit-test surface for ``ts/src/mission/manager.ts``.
+Covers CRUD facade, verifier registration + run, status transitions,
+event emission, budget usage, and the error-tolerant verifier path
+(a thrown exception lands as a failing result tagged with the
+exception class name).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autocontext.mission import (
+    MissionBudget,
+    MissionEventEmitter,
+    MissionManager,
+    VerifierResult,
+)
+
+
+def _manager(tmp_path: Path) -> MissionManager:
+    return MissionManager(str(tmp_path / "mission.sqlite3"))
+
+
+# ---------------------------------------------------------------------------
+# CRUD facade
+# ---------------------------------------------------------------------------
+
+
+def test_create_returns_id_and_persists_mission(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mission = mgr.get(mid)
+        assert mission is not None and mission.status == "active"
+
+
+def test_advance_records_a_completed_step(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        sid = mgr.advance(mid, "ran cli")
+        steps = mgr.steps(mid)
+        assert len(steps) == 1 and steps[0].id == sid
+        assert steps[0].status == "completed"
+
+
+def test_subgoals_add_and_update_status(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        sgid = mgr.add_subgoal(mid, description="first")
+        mgr.update_subgoal_status(sgid, "completed")
+        assert mgr.subgoals(mid)[0].status == "completed"
+
+
+def test_budget_usage_reflects_step_count_against_budget(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g", budget=MissionBudget(max_steps=2))
+        mgr.advance(mid, "s1")
+        usage = mgr.budget_usage(mid)
+        assert usage.steps_used == 1 and usage.exhausted is False
+        mgr.advance(mid, "s2")
+        assert mgr.budget_usage(mid).exhausted is True
+
+
+# ---------------------------------------------------------------------------
+# Verifier
+# ---------------------------------------------------------------------------
+
+
+def test_verify_without_registered_verifier_records_failing_result(
+    tmp_path: Path,
+) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        result = mgr.verify(mid)
+        assert result.passed is False
+        assert result.reason == "No verifier registered"
+        assert mgr.get(mid).status == "active"  # status unchanged
+        assert mgr.verifications(mid)[0].passed is False
+
+
+def test_passing_verifier_completes_mission_and_records_result(
+    tmp_path: Path,
+) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.set_verifier(mid, lambda _mid: VerifierResult(passed=True, reason="green"))
+        result = mgr.verify(mid)
+        assert result.passed is True
+        assert mgr.get(mid).status == "completed"
+
+
+def test_failing_verifier_leaves_status_unchanged_but_records_result(
+    tmp_path: Path,
+) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.set_verifier(mid, lambda _mid: VerifierResult(passed=False, reason="tests failed"))
+        result = mgr.verify(mid)
+        assert result.passed is False
+        assert mgr.get(mid).status == "active"
+
+
+def test_verifier_that_throws_yields_failing_result_with_error_metadata(
+    tmp_path: Path,
+) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+
+        def boom(_mid: str) -> VerifierResult:
+            raise RuntimeError("kaboom")
+
+        mgr.set_verifier(mid, boom)
+        result = mgr.verify(mid)
+        assert result.passed is False
+        assert result.metadata["errorName"] == "RuntimeError"
+        assert "kaboom" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Status transitions
+# ---------------------------------------------------------------------------
+
+
+def test_pause_resume_cancel_round_trip(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.pause(mid)
+        assert mgr.get(mid).status == "paused"
+        mgr.resume(mid)
+        assert mgr.get(mid).status == "active"
+        mgr.cancel(mid)
+        assert mgr.get(mid).status == "canceled"
+
+
+def test_invalid_transition_rejects(tmp_path: Path) -> None:
+    """The transition table forbids paused -> completed; the manager
+    surfaces the error from the lifecycle helper rather than silently
+    persisting the change."""
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.pause(mid)
+        with pytest.raises(ValueError, match="paused -> completed"):
+            mgr.set_status(mid, "completed")
+        assert mgr.get(mid).status == "paused"
+
+
+# ---------------------------------------------------------------------------
+# Event emission
+# ---------------------------------------------------------------------------
+
+
+def test_events_emit_created_step_status_and_verified(tmp_path: Path) -> None:
+    events = MissionEventEmitter()
+    captured: list[tuple[str, object]] = []
+    for kind in (
+        "mission_created",
+        "mission_step",
+        "mission_status_changed",
+        "mission_verified",
+    ):
+        events.on(kind, lambda payload, k=kind: captured.append((k, payload)))
+
+    with MissionManager(str(tmp_path / "m.sqlite3"), events=events) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.advance(mid, "s1")
+        mgr.pause(mid)
+        mgr.set_verifier(mid, lambda _mid: VerifierResult(passed=False, reason="r"))
+        mgr.verify(mid)
+
+    kinds = [k for k, _ in captured]
+    assert kinds == [
+        "mission_created",
+        "mission_step",
+        "mission_status_changed",
+        "mission_verified",
+    ]
+
+
+def test_status_change_event_carries_from_and_to(tmp_path: Path) -> None:
+    events = MissionEventEmitter()
+    payloads: list[object] = []
+    events.on("mission_status_changed", payloads.append)
+    with MissionManager(str(tmp_path / "m.sqlite3"), events=events) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.pause(mid)
+
+    assert len(payloads) == 1
+    payload = payloads[0]
+    assert payload.from_status == "active"  # type: ignore[union-attr]
+    assert payload.to_status == "paused"  # type: ignore[union-attr]

--- a/autocontext/tests/mission/test_mission_planner.py
+++ b/autocontext/tests/mission/test_mission_planner.py
@@ -1,0 +1,212 @@
+"""AC-697 mission planner tests (slice 2).
+
+Mirrors the unit-test surface for ``ts/src/mission/planner.ts``.
+Uses a deterministic stub provider so the planner can be exercised
+without a real LLM. Covers happy-path decomposition + step planning,
+JSON-with-markdown-fence parsing, fallback when the provider throws
+or returns garbage, target subgoal binding, and the single-remaining
+subgoal auto-bind branch.
+"""
+
+from __future__ import annotations
+
+from autocontext.mission import (
+    LLMCompletion,
+    LLMCompletionRequest,
+    LLMProvider,
+    MissionPlanner,
+    PlanNextStepOpts,
+    VerifierFeedback,
+)
+
+
+class _StubProvider:
+    """Deterministic stub. Either returns a fixed response or raises
+    a configured exception."""
+
+    def __init__(
+        self,
+        response_text: str = "",
+        exc: Exception | None = None,
+    ) -> None:
+        self._response_text = response_text
+        self._exc = exc
+        self.calls: list[LLMCompletionRequest] = []
+
+    def complete(self, request: LLMCompletionRequest) -> LLMCompletion:
+        self.calls.append(request)
+        if self._exc is not None:
+            raise self._exc
+        return LLMCompletion(text=self._response_text)
+
+
+def test_stub_provider_satisfies_protocol() -> None:
+    """Protocol parity check."""
+    provider: LLMProvider = _StubProvider("{}")
+    assert provider.complete(LLMCompletionRequest(system_prompt="x", user_prompt="y")).text == "{}"
+
+
+# ---------------------------------------------------------------------------
+# decompose
+# ---------------------------------------------------------------------------
+
+
+def test_decompose_happy_path_sorts_by_priority() -> None:
+    provider = _StubProvider(
+        '{"subgoals": [{"description": "B", "priority": 2}, {"description": "A", "priority": 1}], "reasoning": "ok"}'
+    )
+    planner = MissionPlanner(provider)
+    result = planner.decompose("ship login")
+    assert [s.description for s in result.subgoals] == ["A", "B"]
+    assert result.reasoning == "ok"
+
+
+def test_decompose_strips_markdown_fence_around_json() -> None:
+    provider = _StubProvider('```json\n{"subgoals": [{"description": "only", "priority": 1}]}\n```')
+    planner = MissionPlanner(provider)
+    result = planner.decompose("ship login")
+    assert [s.description for s in result.subgoals] == ["only"]
+
+
+def test_decompose_falls_back_when_provider_throws() -> None:
+    provider = _StubProvider(exc=RuntimeError("boom"))
+    planner = MissionPlanner(provider)
+    result = planner.decompose("ship login")
+    assert len(result.subgoals) == 1
+    assert "Fallback" in (result.reasoning or "")
+    assert result.subgoals[0].description == "Work toward: ship login"
+
+
+def test_decompose_falls_back_when_subgoals_field_missing() -> None:
+    provider = _StubProvider('{"reasoning": "x"}')
+    planner = MissionPlanner(provider)
+    result = planner.decompose("ship login")
+    assert "Fallback" in (result.reasoning or "")
+
+
+def test_decompose_drops_invalid_subgoal_entries() -> None:
+    """Entries without a string description are filtered out; the
+    rest survive (TS parity)."""
+    provider = _StubProvider('{"subgoals": [{"description": "keep"}, {"description": "  "}, "bogus", {"priority": 1}]}')
+    planner = MissionPlanner(provider)
+    result = planner.decompose("ship login")
+    assert [s.description for s in result.subgoals] == ["keep"]
+
+
+# ---------------------------------------------------------------------------
+# plan_next_step
+# ---------------------------------------------------------------------------
+
+
+def test_plan_next_step_happy_path_binds_target_subgoal() -> None:
+    provider = _StubProvider(
+        '{"nextStep": "configure oauth", "reasoning": "first", "shouldRevise": false, "targetSubgoal": "set up oauth"}'
+    )
+    planner = MissionPlanner(provider)
+    plan = planner.plan_next_step(
+        PlanNextStepOpts(
+            goal="ship login",
+            completed_steps=(),
+            remaining_subgoals=("set up oauth", "wire callback"),
+        )
+    )
+    assert plan.description == "configure oauth"
+    assert plan.target_subgoal == "set up oauth"
+    assert plan.should_revise is False
+
+
+def test_plan_next_step_auto_binds_single_remaining_subgoal() -> None:
+    """If the model omits targetSubgoal and only one subgoal remains,
+    the planner pins that subgoal automatically (TS parity)."""
+    provider = _StubProvider('{"nextStep": "ship", "reasoning": "last one", "shouldRevise": false}')
+    planner = MissionPlanner(provider)
+    plan = planner.plan_next_step(
+        PlanNextStepOpts(
+            goal="ship login",
+            completed_steps=("wire oauth",),
+            remaining_subgoals=("final QA",),
+        )
+    )
+    assert plan.target_subgoal == "final QA"
+
+
+def test_plan_next_step_should_revise_carries_revised_subgoals() -> None:
+    provider = _StubProvider(
+        '{"nextStep": "pivot", "reasoning": "wrong direction",'
+        ' "shouldRevise": true,'
+        ' "revisedSubgoals": [{"description": "new", "priority": 1}]}'
+    )
+    planner = MissionPlanner(provider)
+    plan = planner.plan_next_step(
+        PlanNextStepOpts(
+            goal="ship login",
+            completed_steps=(),
+            remaining_subgoals=("old",),
+        )
+    )
+    assert plan.should_revise is True
+    assert [s.description for s in plan.revised_subgoals] == ["new"]
+    # On revise we drop the auto-bind branch
+    assert plan.target_subgoal is None
+
+
+def test_plan_next_step_ignores_target_subgoal_not_in_remaining_list() -> None:
+    provider = _StubProvider('{"nextStep": "do x", "reasoning": "x", "shouldRevise": false, "targetSubgoal": "unknown"}')
+    planner = MissionPlanner(provider)
+    plan = planner.plan_next_step(
+        PlanNextStepOpts(
+            goal="g",
+            completed_steps=(),
+            remaining_subgoals=("known1", "known2"),
+        )
+    )
+    assert plan.target_subgoal is None
+
+
+def test_plan_next_step_falls_back_when_response_missing_next_step() -> None:
+    provider = _StubProvider('{"reasoning": "no next step"}')
+    planner = MissionPlanner(provider)
+    plan = planner.plan_next_step(
+        PlanNextStepOpts(
+            goal="g",
+            completed_steps=(),
+            remaining_subgoals=("only",),
+        )
+    )
+    assert "Fallback" in plan.reasoning
+    assert plan.description == "Work on: only"
+    assert plan.target_subgoal == "only"
+
+
+def test_plan_next_step_falls_back_when_provider_throws() -> None:
+    provider = _StubProvider(exc=RuntimeError("boom"))
+    planner = MissionPlanner(provider)
+    plan = planner.plan_next_step(
+        PlanNextStepOpts(
+            goal="g",
+            completed_steps=(),
+            remaining_subgoals=(),
+        )
+    )
+    assert "Fallback" in plan.reasoning
+    assert plan.description == "Continue: g"
+    assert plan.target_subgoal is None
+
+
+def test_plan_next_step_prompt_carries_completed_steps_and_feedback() -> None:
+    provider = _StubProvider('{"nextStep": "next", "reasoning": "x", "shouldRevise": false}')
+    planner = MissionPlanner(provider)
+    planner.plan_next_step(
+        PlanNextStepOpts(
+            goal="ship login",
+            completed_steps=("did a",),
+            remaining_subgoals=("do b",),
+            verifier_feedback=VerifierFeedback(passed=False, reason="r", suggestions=("hint",)),
+        )
+    )
+    prompt = provider.calls[0].user_prompt
+    assert "## Mission Goal\nship login" in prompt
+    assert "## Completed Steps\n1. did a" in prompt
+    assert "## Remaining Subgoals\n- do b" in prompt
+    assert "## Verifier Feedback" in prompt
+    assert "Suggestions:\n- hint" in prompt

--- a/autocontext/tests/mission/test_mission_verifiers.py
+++ b/autocontext/tests/mission/test_mission_verifiers.py
@@ -1,0 +1,214 @@
+"""AC-697 mission verifier tests (slice 2).
+
+Mirrors the unit-test surface for ``ts/src/mission/verifiers.ts``.
+Covers CommandVerifier exit-0 / exit-non-zero / stderr-into-suggestion,
+CompositeVerifier short-circuit, the CodeMissionSpec strict schema,
+``create_code_mission`` factory, and rehydration from stored metadata.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from autocontext.mission import (
+    CodeMissionSpec,
+    CommandVerifier,
+    CompositeVerifier,
+    MissionManager,
+    VerifierResult,
+    create_code_mission,
+    rehydrate_mission_verifier,
+)
+
+# ---------------------------------------------------------------------------
+# CommandVerifier
+# ---------------------------------------------------------------------------
+
+
+def test_command_verifier_passes_on_exit_zero(tmp_path: Path) -> None:
+    cv = CommandVerifier("true", str(tmp_path))
+    result = cv.verify("mission-x")
+    assert result.passed is True
+    assert "exit 0" in result.reason
+    assert result.metadata["command"] == "true"
+
+
+def test_command_verifier_fails_on_non_zero_exit_with_stderr_suggestion(
+    tmp_path: Path,
+) -> None:
+    cv = CommandVerifier("echo boom 1>&2; false", str(tmp_path))
+    result = cv.verify("mission-x")
+    assert result.passed is False
+    assert "exit 1" in result.reason
+    assert any("stderr: boom" in s for s in result.suggestions)
+    assert result.metadata["exitCode"] == 1
+
+
+def test_command_verifier_label_is_the_command(tmp_path: Path) -> None:
+    cv = CommandVerifier("ls -la", str(tmp_path))
+    assert cv.label == "ls -la"
+
+
+# ---------------------------------------------------------------------------
+# CompositeVerifier
+# ---------------------------------------------------------------------------
+
+
+class _StaticVerifier:
+    def __init__(self, label: str, result: VerifierResult) -> None:
+        self.label = label
+        self._result = result
+
+    def verify(self, _mission_id: str) -> VerifierResult:
+        return self._result
+
+
+def test_composite_verifier_passes_when_all_inner_pass() -> None:
+    cv = CompositeVerifier(
+        [
+            _StaticVerifier("a", VerifierResult(passed=True, reason="a")),
+            _StaticVerifier("b", VerifierResult(passed=True, reason="b")),
+        ]
+    )
+    result = cv.verify("mission-x")
+    assert result.passed is True
+    assert result.metadata["verifierCount"] == 2
+
+
+def test_composite_verifier_short_circuits_on_first_failure() -> None:
+    cv = CompositeVerifier(
+        [
+            _StaticVerifier("a", VerifierResult(passed=False, reason="a failed")),
+            _StaticVerifier("b", VerifierResult(passed=True, reason="b ok")),
+        ]
+    )
+    result = cv.verify("mission-x")
+    assert result.passed is False
+    assert result.reason == "a failed"
+    assert result.metadata["failedVerifier"] == "a"
+
+
+def test_composite_verifier_label_joins_inner_labels() -> None:
+    cv = CompositeVerifier(
+        [
+            _StaticVerifier("first", VerifierResult(passed=True, reason="")),
+            _StaticVerifier("second", VerifierResult(passed=True, reason="")),
+        ]
+    )
+    assert cv.label == "first && second"
+
+
+# ---------------------------------------------------------------------------
+# CodeMissionSpec schema strictness
+# ---------------------------------------------------------------------------
+
+
+def test_code_mission_spec_extra_keys_rejected() -> None:
+    """Slice 1 strictness applied to slice 2: a typo in the spec
+    rejects rather than being silently dropped."""
+    with pytest.raises(ValidationError):
+        CodeMissionSpec.model_validate(
+            {
+                "name": "x",
+                "goal": "g",
+                "repo_path": "/tmp",
+                "test_command": "true",
+                "lint_commands": "oops",  # typo
+            }
+        )
+
+
+def test_code_mission_spec_rejects_string_for_priority_via_strict_str() -> None:
+    """Primitive coercion off across the spec."""
+    with pytest.raises(ValidationError):
+        CodeMissionSpec.model_validate(
+            {
+                "name": 5,  # int, not str
+                "goal": "g",
+                "repo_path": "/tmp",
+                "test_command": "true",
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# create_code_mission factory
+# ---------------------------------------------------------------------------
+
+
+def test_create_code_mission_registers_metadata_and_verifier(tmp_path: Path) -> None:
+    with MissionManager(str(tmp_path / "m.sqlite3")) as mgr:
+        mid = create_code_mission(
+            mgr,
+            CodeMissionSpec(
+                name="ship login",
+                goal="OAuth passes",
+                repo_path=str(tmp_path),
+                test_command="true",
+                lint_command="true",
+            ),
+        )
+        mission = mgr.get(mid)
+        assert mission is not None
+        assert mission.metadata["missionType"] == "code"
+        assert mission.metadata["repoPath"] == str(tmp_path)
+        assert mission.metadata["testCommand"] == "true"
+        assert mission.metadata["lintCommand"] == "true"
+        assert mgr.has_verifier(mid) is True
+
+
+def test_create_code_mission_test_pass_completes_mission(tmp_path: Path) -> None:
+    with MissionManager(str(tmp_path / "m.sqlite3")) as mgr:
+        mid = create_code_mission(
+            mgr,
+            CodeMissionSpec(
+                name="x",
+                goal="g",
+                repo_path=str(tmp_path),
+                test_command="true",
+            ),
+        )
+        result = mgr.verify(mid)
+        assert result.passed is True
+        assert mgr.get(mid).status == "completed"
+
+
+# ---------------------------------------------------------------------------
+# rehydrate_mission_verifier
+# ---------------------------------------------------------------------------
+
+
+def test_rehydrate_attaches_verifier_when_metadata_carries_state(
+    tmp_path: Path,
+) -> None:
+    """Slice-3 control-plane will call this on process restart; the
+    helper must rebind the verifier without re-running
+    `create_code_mission`."""
+    with MissionManager(str(tmp_path / "m.sqlite3")) as mgr:
+        mid = mgr.create(
+            name="x",
+            goal="g",
+            metadata={
+                "missionType": "code",
+                "repoPath": str(tmp_path),
+                "testCommand": "true",
+            },
+        )
+        mission = mgr.get(mid)
+        assert mission is not None
+        assert mgr.has_verifier(mid) is False
+        assert rehydrate_mission_verifier(mgr, mission) is True
+        assert mgr.has_verifier(mid) is True
+
+
+def test_rehydrate_returns_false_when_metadata_missing(tmp_path: Path) -> None:
+    with MissionManager(str(tmp_path / "m.sqlite3")) as mgr:
+        mid = mgr.create(name="x", goal="g", metadata={"missionType": "code"})
+        mission = mgr.get(mid)
+        assert mission is not None
+        # missing repoPath + testCommand -> rehydrate refuses
+        assert rehydrate_mission_verifier(mgr, mission) is False
+        assert mgr.has_verifier(mid) is False


### PR DESCRIPTION
## Summary

Mirrors `ts/src/mission/` slice 2 of 5. Adds the mission lifecycle facade on top of the slice-1 store:

- `events.py` — callback registry for mission lifecycle events; Pydantic frozen payloads with `extra="forbid"`.
- `lifecycle.py` — status-transition table + `derive_mission_status_from_verifier_result` + `build_verifier_error_result`. `paused -> completed` rejects; `completed` is terminal.
- `verification.py` — pure outcome builders.
- `verifiers.py` — `Verifier` Protocol, `CommandVerifier` (120s timeout, stderr -> suggestion), `CompositeVerifier` short-circuit, `CodeMissionSpec` strict schema, `create_code_mission` factory, `rehydrate_mission_verifier`.
- `planner.py` — `MissionPlanner.decompose` + `plan_next_step` over a minimal `LLMProvider` Protocol. Same prompts, JSON parser (markdown-fence stripping), and fallback shapes as TS.
- `manager.py` — `MissionManager` facade. `list_missions` (renamed from TS `list()` to avoid shadowing the Python `list` builtin).

## Test plan

- [x] `uv run pytest tests/mission/` (107 passed: 29 prior + 78 new)
- [x] `uv run pytest tests/test_module_size_limits.py` clean (all modules < 800 lines)
- [x] `uv run ruff check` clean
- [x] `uv run mypy src/autocontext/mission/` clean
- [ ] CI: green

## Slice plan (5 PRs total)

- slice 1 (#1014, merged): SQLite store + Pydantic models
- **slice 2 (this PR)**: MissionManager + verifiers + planner
- slice 3: control-plane workflows (checkpoint, status payloads)
- slice 4: CLI subcommands (create / run / status / artifacts)
- slice 5: lifecycle subcommands + contract flip + README