### PR TITLE
feat(mission): AC-697 mission Python parity slice 3 (control-plane workflows)

### DIFF
--- a/autocontext/src/autocontext/mission/__init__.py
+++ b/autocontext/src/autocontext/mission/__init__.py
@@ -1,4 +1,4 @@
-"""AC-697 mission Python parity surface (slices 1 + 2).
+"""AC-697 mission Python parity surface (slices 1 + 2 + 3).
 
 Mirrors ``ts/src/mission/`` step-by-step.
 
@@ -6,16 +6,40 @@ Mirrors ``ts/src/mission/`` step-by-step.
 - slice 2: MissionManager + verifiers + planner + lifecycle helpers
   (``manager``, ``verifiers``, ``planner``, ``lifecycle``,
   ``verification``, ``events``).
-- slice 3: control-plane workflows (checkpoint, status payloads).
+- slice 3: control-plane workflows (``checkpoint``, ``executor``,
+  ``control_plane``).
 - slice 4 / 5: ``autoctx mission`` CLI.
 """
 
+from autocontext.mission.checkpoint import (
+    CHECKPOINT_VERSION,
+    load_checkpoint,
+    save_checkpoint,
+)
+from autocontext.mission.control_plane import (
+    build_fallback_verifier,
+    build_mission_artifacts_payload,
+    build_mission_result_payload,
+    build_mission_status_payload,
+    mission_checkpoint_dir,
+    require_mission,
+    run_mission_loop,
+    write_mission_checkpoint,
+)
 from autocontext.mission.events import (
     MissionCreatedEvent,
     MissionEventEmitter,
     MissionStatusChangedEvent,
     MissionStepEvent,
     MissionVerifiedEvent,
+)
+from autocontext.mission.executor import (
+    RunStepResult,
+    RunUntilDoneResult,
+    StepExecutor,
+    StepResult,
+    run_step,
+    run_until_done,
 )
 from autocontext.mission.lifecycle import (
     MissionStatusTransition,
@@ -66,6 +90,7 @@ from autocontext.mission.verifiers import (
 )
 
 __all__ = [
+    "CHECKPOINT_VERSION",
     "BudgetUsage",
     "CodeMissionSpec",
     "CommandVerifier",
@@ -92,7 +117,11 @@ __all__ = [
     "MissionVerifierCallable",
     "PlanNextStepOpts",
     "PlanResult",
+    "RunStepResult",
+    "RunUntilDoneResult",
+    "StepExecutor",
     "StepPlan",
+    "StepResult",
     "StepStatus",
     "SubgoalPlan",
     "SubgoalStatus",
@@ -100,13 +129,25 @@ __all__ = [
     "VerifierFeedback",
     "VerifierResult",
     "attach_code_mission_verifier",
+    "build_fallback_verifier",
+    "build_mission_artifacts_payload",
+    "build_mission_result_payload",
+    "build_mission_status_payload",
     "build_missing_verifier_outcome",
     "build_verifier_error_result",
     "can_transition_mission_status",
     "create_code_mission",
     "derive_mission_status_from_verifier_result",
+    "load_checkpoint",
+    "mission_checkpoint_dir",
     "rehydrate_mission_verifier",
+    "require_mission",
     "resolve_mission_status_transition",
     "resolve_mission_verification_error_outcome",
     "resolve_mission_verification_outcome",
+    "run_mission_loop",
+    "run_step",
+    "run_until_done",
+    "save_checkpoint",
+    "write_mission_checkpoint",
 ]

--- a/autocontext/src/autocontext/mission/_async_bridge.py
+++ b/autocontext/src/autocontext/mission/_async_bridge.py
@@ -1,0 +1,30 @@
+"""Internal helpers for bridging sync mission entry points to async
+verifier / step-executor callables.
+
+PR #1016 review (P2): a sync entry point that receives a coroutine
+while a running event loop is active must NOT mutate mission state.
+``asyncio.run`` raises ``RuntimeError`` from inside an active loop,
+which the catch-all in ``run_step`` and ``MissionManager.verify``
+would otherwise swallow into a falsely-failing step / verification
+record. ``AsyncContextError`` propagates instead so the caller can
+react without leaving the mission in an inconsistent state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+__all__ = ["AsyncContextError", "has_running_loop"]
+
+
+class AsyncContextError(RuntimeError):
+    """Raised when a sync mission entry point receives a coroutine
+    while a running event loop is active."""
+
+
+def has_running_loop() -> bool:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True

--- a/autocontext/src/autocontext/mission/checkpoint.py
+++ b/autocontext/src/autocontext/mission/checkpoint.py
@@ -5,12 +5,20 @@ the full mission state (mission metadata, steps, subgoals,
 verifications, budget usage) so a restart can pick up where the
 previous process left off.
 
-``save_checkpoint`` writes ``<mission_id>-<unix_ms>.json`` to the
-caller-supplied directory and returns the resulting path.
+``save_checkpoint`` writes ``<mission_id>-<unix_ns>-<uuid8>.json``
+to the caller-supplied directory and returns the resulting path.
+The nanosecond timestamp + uuid suffix make the path collision-free
+even on fast hardware and across concurrent writers, and the
+ns-prefixed name still sorts newest-first lexicographically.
 ``load_checkpoint`` re-creates a mission row + child rows with the
-original ids; the operator can then ``rehydrate_mission_verifier``
-to rebind the verifier from the metadata blob (see
-``autocontext.mission.verifiers``).
+original ids inside a single SQLite transaction (an insert failure
+rolls back the partial restore so the operator can retry without
+first cleaning up). Both TS-shaped (camelCase ``createdAt`` /
+``budget.maxSteps`` / ...) and Python-shaped (snake_case) inputs
+are accepted on restore so a shared ``AUTOCONTEXT_DB_PATH`` can
+resume from either runtime's checkpoints. The operator can then
+``rehydrate_mission_verifier`` to rebind the verifier from the
+metadata blob (see ``autocontext.mission.verifiers``).
 """
 
 from __future__ import annotations
@@ -47,19 +55,6 @@ def _serialise(value: Any) -> Any:
     return value
 
 
-def _budget_snake_to_camel(payload: dict[str, Any]) -> dict[str, Any]:
-    out: dict[str, Any] = {}
-    mapping = {
-        "max_steps": "maxSteps",
-        "max_cost_usd": "maxCostUsd",
-        "max_duration_minutes": "maxDurationMinutes",
-    }
-    for snake, camel in mapping.items():
-        if snake in payload and payload[snake] is not None:
-            out[camel] = payload[snake]
-    return out
-
-
 def save_checkpoint(store: MissionStore, mission_id: str, checkpoint_dir: str | Path) -> str:
     """Persist the full mission state to
     ``<checkpoint_dir>/<mission_id>-<unix_ms>.json``.
@@ -89,15 +84,68 @@ def save_checkpoint(store: MissionStore, mission_id: str, checkpoint_dir: str | 
         "budgetUsage": _serialise(budget_usage),
     }
 
-    filename = f"{mission_id}-{int(time.time() * 1000)}.json"
+    # PR #1016 review (P3): two saves landing in the same
+    # millisecond overwrote each other because the filename was only
+    # ``<mission_id>-<unix_ms>.json``. Use nanosecond resolution +
+    # an 8-char uuid suffix so the path is unique even on fast
+    # hardware and across concurrent writers. Newest-first ordering
+    # by filename still works because the nanosecond prefix sorts
+    # lexicographically.
+    filename = f"{mission_id}-{time.time_ns()}-{uuid.uuid4().hex[:8]}.json"
     out_path = target_dir / filename
     out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     return str(out_path)
 
 
+def _pick(payload: dict[str, Any], *keys: str) -> Any:
+    """Return the first non-None value among ``keys``. PR #1016 review
+    (P2): a TS-shaped checkpoint stores fields in camelCase
+    (``createdAt`` / ``maxSteps`` / ...) while a Python-shaped
+    checkpoint stores them in snake_case (``created_at`` /
+    ``max_steps`` / ...). The loader accepts both so a shared
+    ``AUTOCONTEXT_DB_PATH`` resumes from either runtime's
+    checkpoints without dropping budget caps or provenance."""
+    for key in keys:
+        if key in payload and payload[key] is not None:
+            return payload[key]
+    return None
+
+
+def _budget_to_camel(payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Normalise budget payload to camelCase DB shape, accepting
+    either camelCase (TS) or snake_case (Python) keys on input.
+    Returns ``None`` if the payload carries no recognised fields."""
+    if not payload:
+        return None
+    mapping = {
+        "maxSteps": ("maxSteps", "max_steps"),
+        "maxCostUsd": ("maxCostUsd", "max_cost_usd"),
+        "maxDurationMinutes": ("maxDurationMinutes", "max_duration_minutes"),
+    }
+    out: dict[str, Any] = {}
+    for camel, candidates in mapping.items():
+        value = _pick(payload, *candidates)
+        if value is not None:
+            out[camel] = value
+    return out or None
+
+
 def load_checkpoint(store: MissionStore, checkpoint_path: str | Path) -> str:
     """Re-create a mission from its checkpoint JSON. Returns the
-    restored mission id (same id as the original)."""
+    restored mission id (same id as the original).
+
+    PR #1016 review (P2 + P2):
+
+    - Accepts both TS-shaped (camelCase ``createdAt`` /
+      ``budget.maxSteps`` / ...) and Python-shaped (snake_case)
+      checkpoints so a shared ``AUTOCONTEXT_DB_PATH`` can resume
+      from either runtime's saves without dropping budget caps or
+      timestamps.
+    - Restore is wrapped in a single SQLite transaction. A row-level
+      failure (duplicate step id, FK violation, etc.) rolls back the
+      partial restore so the operator can retry without first having
+      to clean up a half-loaded mission row.
+    """
     raw = json.loads(Path(checkpoint_path).read_text(encoding="utf-8"))
     mission = raw["mission"]
     original_id = str(mission["id"])
@@ -108,77 +156,88 @@ def load_checkpoint(store: MissionStore, checkpoint_path: str | Path) -> str:
         raise ValueError(f"Cannot restore checkpoint: mission {original_id} already exists")
 
     budget_blob: str | None = None
-    if mission.get("budget"):
-        # Mission was Pydantic-dumped before serialisation so the
-        # budget keys arrive in snake_case. The store persists them in
-        # the TS-compatible camelCase shape for cross-runtime DB
-        # reads, so we convert here before re-inserting.
-        budget_blob = json.dumps(_budget_snake_to_camel(mission["budget"]))
+    budget_dict = _budget_to_camel(mission.get("budget"))
+    if budget_dict is not None:
+        budget_blob = json.dumps(budget_dict)
     metadata_blob = json.dumps(mission.get("metadata") or {})
 
-    db.execute(
-        "INSERT INTO missions (id, name, goal, status, budget, metadata, created_at, updated_at, completed_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        (
-            original_id,
-            mission["name"],
-            mission["goal"],
-            mission["status"],
-            budget_blob,
-            metadata_blob,
-            mission.get("created_at") or _utc_now_iso(),
-            mission.get("updated_at"),
-            mission.get("completed_at"),
-        ),
-    )
-
-    for step in raw.get("steps", []):
+    # PR #1016 review (P2): wrap the multi-row restore in a single
+    # transaction. The store opens its connection with
+    # ``isolation_level=None`` (autocommit), so we drive BEGIN /
+    # COMMIT / ROLLBACK explicitly. Any insert error during restore
+    # rolls back the mission row + every child row inserted so far,
+    # which leaves the DB free for a retry.
+    db.execute("BEGIN")
+    try:
         db.execute(
-            "INSERT INTO mission_steps (id, mission_id, description, status, result, created_at, completed_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO missions (id, name, goal, status, budget, metadata, "
+            "created_at, updated_at, completed_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
-                step["id"],
                 original_id,
-                step["description"],
-                step["status"],
-                step.get("result"),
-                step.get("created_at") or _utc_now_iso(),
-                step.get("completed_at"),
+                mission["name"],
+                mission["goal"],
+                mission["status"],
+                budget_blob,
+                metadata_blob,
+                _pick(mission, "createdAt", "created_at") or _utc_now_iso(),
+                _pick(mission, "updatedAt", "updated_at"),
+                _pick(mission, "completedAt", "completed_at"),
             ),
         )
 
-    for subgoal in raw.get("subgoals", []):
-        db.execute(
-            "INSERT INTO mission_subgoals (id, mission_id, description, priority, status, created_at, completed_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                subgoal["id"],
-                original_id,
-                subgoal["description"],
-                subgoal["priority"],
-                subgoal["status"],
-                subgoal.get("created_at") or _utc_now_iso(),
-                subgoal.get("completed_at"),
-            ),
-        )
+        for step in raw.get("steps", []):
+            db.execute(
+                "INSERT INTO mission_steps (id, mission_id, description, status, result, created_at, completed_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    step["id"],
+                    original_id,
+                    step["description"],
+                    step["status"],
+                    step.get("result"),
+                    _pick(step, "createdAt", "created_at") or _utc_now_iso(),
+                    _pick(step, "completedAt", "completed_at"),
+                ),
+            )
 
-    for verification in raw.get("verifications", []):
-        record_id = verification.get("id")
-        if not isinstance(record_id, str) or not record_id:
-            record_id = f"verify-restored-{uuid.uuid4().hex[:8]}"
-        db.execute(
-            "INSERT INTO mission_verifications "
-            "(id, mission_id, passed, reason, suggestions, metadata, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                record_id,
-                original_id,
-                1 if verification["passed"] else 0,
-                verification["reason"],
-                json.dumps(verification.get("suggestions") or []),
-                json.dumps(verification.get("metadata") or {}),
-                verification.get("created_at") or _utc_now_iso(),
-            ),
-        )
+        for subgoal in raw.get("subgoals", []):
+            db.execute(
+                "INSERT INTO mission_subgoals (id, mission_id, description, priority, status, created_at, completed_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    subgoal["id"],
+                    original_id,
+                    subgoal["description"],
+                    subgoal["priority"],
+                    subgoal["status"],
+                    _pick(subgoal, "createdAt", "created_at") or _utc_now_iso(),
+                    _pick(subgoal, "completedAt", "completed_at"),
+                ),
+            )
+
+        for verification in raw.get("verifications", []):
+            record_id = verification.get("id")
+            if not isinstance(record_id, str) or not record_id:
+                record_id = f"verify-restored-{uuid.uuid4().hex[:8]}"
+            db.execute(
+                "INSERT INTO mission_verifications "
+                "(id, mission_id, passed, reason, suggestions, metadata, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    record_id,
+                    original_id,
+                    1 if verification["passed"] else 0,
+                    verification["reason"],
+                    json.dumps(verification.get("suggestions") or []),
+                    json.dumps(verification.get("metadata") or {}),
+                    _pick(verification, "createdAt", "created_at") or _utc_now_iso(),
+                ),
+            )
+    except Exception:
+        db.execute("ROLLBACK")
+        raise
+    else:
+        db.execute("COMMIT")
 
     return original_id

--- a/autocontext/src/autocontext/mission/checkpoint.py
+++ b/autocontext/src/autocontext/mission/checkpoint.py
@@ -1,0 +1,184 @@
+"""AC-697 mission checkpointing (slice 3).
+
+Mirrors ``ts/src/mission/checkpoint.ts`` (AC-411). JSON snapshot of
+the full mission state (mission metadata, steps, subgoals,
+verifications, budget usage) so a restart can pick up where the
+previous process left off.
+
+``save_checkpoint`` writes ``<mission_id>-<unix_ms>.json`` to the
+caller-supplied directory and returns the resulting path.
+``load_checkpoint`` re-creates a mission row + child rows with the
+original ids; the operator can then ``rehydrate_mission_verifier``
+to rebind the verifier from the metadata blob (see
+``autocontext.mission.verifiers``).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from autocontext.mission.store import MissionStore
+
+__all__ = [
+    "CHECKPOINT_VERSION",
+    "load_checkpoint",
+    "save_checkpoint",
+]
+
+
+CHECKPOINT_VERSION = 1
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _serialise(value: Any) -> Any:
+    """``model_dump(mode="json")`` for Pydantic models, plain
+    pass-through otherwise. Used to serialise per-row records into
+    the checkpoint payload without hand-mapping every field."""
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    return value
+
+
+def _budget_snake_to_camel(payload: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    mapping = {
+        "max_steps": "maxSteps",
+        "max_cost_usd": "maxCostUsd",
+        "max_duration_minutes": "maxDurationMinutes",
+    }
+    for snake, camel in mapping.items():
+        if snake in payload and payload[snake] is not None:
+            out[camel] = payload[snake]
+    return out
+
+
+def save_checkpoint(store: MissionStore, mission_id: str, checkpoint_dir: str | Path) -> str:
+    """Persist the full mission state to
+    ``<checkpoint_dir>/<mission_id>-<unix_ms>.json``.
+
+    Mirrors the TS shape: parent dir is created on demand; the
+    returned path is the absolute checkpoint file path.
+    """
+    target_dir = Path(checkpoint_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    mission = store.get_mission(mission_id)
+    if mission is None:
+        raise ValueError(f"Mission not found: {mission_id}")
+
+    steps = store.get_steps(mission_id)
+    subgoals = store.get_subgoals(mission_id)
+    verifications = store.get_verifications(mission_id)
+    budget_usage = store.get_budget_usage(mission_id)
+
+    payload: dict[str, Any] = {
+        "version": CHECKPOINT_VERSION,
+        "checkpointedAt": _utc_now_iso(),
+        "mission": _serialise(mission),
+        "steps": [_serialise(s) for s in steps],
+        "subgoals": [_serialise(s) for s in subgoals],
+        "verifications": [_serialise(v) for v in verifications],
+        "budgetUsage": _serialise(budget_usage),
+    }
+
+    filename = f"{mission_id}-{int(time.time() * 1000)}.json"
+    out_path = target_dir / filename
+    out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return str(out_path)
+
+
+def load_checkpoint(store: MissionStore, checkpoint_path: str | Path) -> str:
+    """Re-create a mission from its checkpoint JSON. Returns the
+    restored mission id (same id as the original)."""
+    raw = json.loads(Path(checkpoint_path).read_text(encoding="utf-8"))
+    mission = raw["mission"]
+    original_id = str(mission["id"])
+
+    db = store._db  # noqa: SLF001 — checkpoint restore needs raw write access
+    cursor = db.execute("SELECT id FROM missions WHERE id = ?", (original_id,))
+    if cursor.fetchone() is not None:
+        raise ValueError(f"Cannot restore checkpoint: mission {original_id} already exists")
+
+    budget_blob: str | None = None
+    if mission.get("budget"):
+        # Mission was Pydantic-dumped before serialisation so the
+        # budget keys arrive in snake_case. The store persists them in
+        # the TS-compatible camelCase shape for cross-runtime DB
+        # reads, so we convert here before re-inserting.
+        budget_blob = json.dumps(_budget_snake_to_camel(mission["budget"]))
+    metadata_blob = json.dumps(mission.get("metadata") or {})
+
+    db.execute(
+        "INSERT INTO missions (id, name, goal, status, budget, metadata, created_at, updated_at, completed_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            original_id,
+            mission["name"],
+            mission["goal"],
+            mission["status"],
+            budget_blob,
+            metadata_blob,
+            mission.get("created_at") or _utc_now_iso(),
+            mission.get("updated_at"),
+            mission.get("completed_at"),
+        ),
+    )
+
+    for step in raw.get("steps", []):
+        db.execute(
+            "INSERT INTO mission_steps (id, mission_id, description, status, result, created_at, completed_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                step["id"],
+                original_id,
+                step["description"],
+                step["status"],
+                step.get("result"),
+                step.get("created_at") or _utc_now_iso(),
+                step.get("completed_at"),
+            ),
+        )
+
+    for subgoal in raw.get("subgoals", []):
+        db.execute(
+            "INSERT INTO mission_subgoals (id, mission_id, description, priority, status, created_at, completed_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                subgoal["id"],
+                original_id,
+                subgoal["description"],
+                subgoal["priority"],
+                subgoal["status"],
+                subgoal.get("created_at") or _utc_now_iso(),
+                subgoal.get("completed_at"),
+            ),
+        )
+
+    for verification in raw.get("verifications", []):
+        record_id = verification.get("id")
+        if not isinstance(record_id, str) or not record_id:
+            record_id = f"verify-restored-{uuid.uuid4().hex[:8]}"
+        db.execute(
+            "INSERT INTO mission_verifications "
+            "(id, mission_id, passed, reason, suggestions, metadata, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                record_id,
+                original_id,
+                1 if verification["passed"] else 0,
+                verification["reason"],
+                json.dumps(verification.get("suggestions") or []),
+                json.dumps(verification.get("metadata") or {}),
+                verification.get("created_at") or _utc_now_iso(),
+            ),
+        )
+
+    return original_id

--- a/autocontext/src/autocontext/mission/control_plane.py
+++ b/autocontext/src/autocontext/mission/control_plane.py
@@ -1,0 +1,281 @@
+"""AC-697 mission control-plane workflows (slice 3).
+
+Mirrors ``ts/src/mission/control-plane.ts`` (slice 3). High-level
+operator-facing helpers used by the CLI surface that lands in
+slices 4 + 5:
+
+- ``mission_checkpoint_dir`` returns the canonical checkpoint
+  directory for a mission under ``<runs_root>/missions/<id>/checkpoints``.
+- ``require_mission`` raises a clear error when the mission id is
+  missing so the CLI does not later choke on a None.
+- ``build_mission_status_payload`` / ``build_mission_result_payload``
+  / ``build_mission_artifacts_payload`` return JSON-serialisable
+  dicts so the CLI can emit them under ``--json`` without
+  reformatting downstream.
+- ``write_mission_checkpoint`` writes a checkpoint to the canonical
+  directory and returns the file path.
+- ``build_fallback_verifier`` rebuilds the same subgoal-coverage
+  fallback the TS `control-plane.ts` uses when the mission has no
+  registered verifier.
+- ``run_mission_loop`` is the legacy mission loop (subgoal-stepping
+  + verifier). Adaptive LLM-driven mode lands in a follow-up slice
+  once the package-wide LLM provider plumbing is in place.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from autocontext.mission.checkpoint import save_checkpoint
+from autocontext.mission.executor import (
+    RunUntilDoneResult,
+    StepResult,
+    run_until_done,
+)
+from autocontext.mission.types import Mission, MissionStatus, VerifierResult
+from autocontext.mission.verifiers import rehydrate_mission_verifier
+
+if TYPE_CHECKING:
+    from autocontext.mission.manager import MissionManager
+
+
+__all__ = [
+    "build_fallback_verifier",
+    "build_mission_artifacts_payload",
+    "build_mission_result_payload",
+    "build_mission_status_payload",
+    "mission_checkpoint_dir",
+    "require_mission",
+    "run_mission_loop",
+    "write_mission_checkpoint",
+]
+
+
+def mission_checkpoint_dir(runs_root: str | Path, mission_id: str) -> str:
+    return str(Path(runs_root) / "missions" / mission_id / "checkpoints")
+
+
+def require_mission(manager: MissionManager, mission_id: str) -> Mission:
+    mission = manager.get(mission_id)
+    if mission is None:
+        raise ValueError(f"Mission not found: {mission_id}")
+    return mission
+
+
+def _model_dump(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    return value
+
+
+def build_mission_status_payload(manager: MissionManager, mission_id: str) -> dict[str, Any]:
+    mission = require_mission(manager, mission_id)
+    steps = manager.steps(mission_id)
+    subgoals = manager.subgoals(mission_id)
+    verifications = manager.verifications(mission_id)
+    payload: dict[str, Any] = dict(_model_dump(mission))
+    payload["stepsCount"] = len(steps)
+    payload["subgoalCount"] = len(subgoals)
+    payload["verificationCount"] = len(verifications)
+    payload["budgetUsage"] = _model_dump(manager.budget_usage(mission_id))
+    payload["latestVerification"] = _model_dump(verifications[-1]) if verifications else None
+    return payload
+
+
+def build_mission_result_payload(manager: MissionManager, mission_id: str) -> dict[str, Any]:
+    mission = require_mission(manager, mission_id)
+    steps = manager.steps(mission_id)
+    subgoals = manager.subgoals(mission_id)
+    verifications = manager.verifications(mission_id)
+    return {
+        "mission": _model_dump(mission),
+        "steps": [_model_dump(s) for s in steps],
+        "subgoals": [_model_dump(s) for s in subgoals],
+        "verifications": [_model_dump(v) for v in verifications],
+        "budgetUsage": _model_dump(manager.budget_usage(mission_id)),
+        "latestVerification": (_model_dump(verifications[-1]) if verifications else None),
+    }
+
+
+def build_mission_artifacts_payload(manager: MissionManager, mission_id: str, runs_root: str | Path) -> dict[str, Any]:
+    mission = require_mission(manager, mission_id)
+    checkpoint_dir = mission_checkpoint_dir(runs_root, mission_id)
+    checkpoints: list[dict[str, Any]] = []
+    cp_dir_path = Path(checkpoint_dir)
+    if cp_dir_path.is_dir():
+        for entry in sorted(cp_dir_path.iterdir(), reverse=True):
+            if not entry.name.endswith(".json"):
+                continue
+            stats = entry.stat()
+            mtime = datetime.fromtimestamp(stats.st_mtime, tz=UTC).isoformat().replace("+00:00", "Z")
+            checkpoints.append(
+                {
+                    "name": entry.name,
+                    "path": str(entry),
+                    "sizeBytes": stats.st_size,
+                    "updatedAt": mtime,
+                }
+            )
+    latest_checkpoint: dict[str, Any] | None = None
+    if checkpoints:
+        latest_checkpoint = _load_checkpoint_payload(Path(checkpoints[0]["path"]))
+    return {
+        "missionId": mission.id,
+        "status": mission.status,
+        "checkpointDir": checkpoint_dir,
+        "checkpoints": checkpoints,
+        "latestCheckpoint": latest_checkpoint,
+    }
+
+
+def _load_checkpoint_payload(path: Path) -> dict[str, Any]:
+    import json
+
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError(f"checkpoint payload at {path} is not a JSON object")
+    return loaded
+
+
+def write_mission_checkpoint(manager: MissionManager, mission_id: str, runs_root: str | Path) -> str:
+    require_mission(manager, mission_id)
+    return save_checkpoint(
+        manager._store,  # noqa: SLF001 — control-plane intentionally reaches into the store
+        mission_id,
+        mission_checkpoint_dir(runs_root, mission_id),
+    )
+
+
+def build_fallback_verifier(manager: MissionManager, mission_id: str) -> Callable[[str], VerifierResult]:
+    """Returns a sync verifier that passes iff every subgoal is in a
+    terminal state, fails with the remaining subgoals listed
+    otherwise, and falls back to "no verifier registered" when the
+    mission has no subgoals at all. Mirrors TS ``buildFallbackVerifier``.
+    """
+
+    def _fallback(_mid: str) -> VerifierResult:
+        subgoals = manager.subgoals(mission_id)
+        if not subgoals:
+            return VerifierResult(
+                passed=False,
+                reason="No verifier registered",
+                suggestions=(),
+                metadata={"autoVerifier": "none"},
+            )
+        remaining = [sg for sg in subgoals if sg.status not in ("completed", "skipped")]
+        if not remaining:
+            return VerifierResult(
+                passed=True,
+                reason="All subgoals completed",
+                suggestions=(),
+                metadata={"autoVerifier": "subgoals"},
+            )
+        suggestions = tuple(sg.description for sg in remaining[:3])
+        return VerifierResult(
+            passed=False,
+            reason=f"{len(remaining)} subgoal(s) remaining",
+            suggestions=suggestions,
+            metadata={
+                "autoVerifier": "subgoals",
+                "remainingSubgoalIds": [sg.id for sg in remaining],
+            },
+        )
+
+    return _fallback
+
+
+def run_mission_loop(
+    manager: MissionManager,
+    mission_id: str,
+    runs_root: str | Path,
+    *,
+    max_iterations: int = 1,
+    step_description: str | None = None,
+) -> dict[str, Any]:
+    """Run the mission loop until verifier-pass / budget-exhaust /
+    blocked / max_iterations. Mirrors TS legacy loop; the adaptive
+    LLM-driven branch lands in a follow-up slice once the
+    package-wide LLM provider plumbing is in place.
+
+    Side effects: writes a checkpoint to the canonical
+    ``mission_checkpoint_dir`` path before returning so the CLI can
+    surface it as a stable artifact reference.
+    """
+    mission = require_mission(manager, mission_id)
+    metadata = mission.metadata
+    mission_type = metadata.get("missionType")
+
+    if not manager.has_verifier(mission_id):
+        rehydrate_mission_verifier(manager, mission)
+
+    if not manager.has_verifier(mission_id):
+        manager.set_verifier(mission_id, build_fallback_verifier(manager, mission_id))
+
+    loop_result = _run_legacy_mission_loop(
+        manager,
+        mission_id,
+        mission.goal,
+        max_iterations=max_iterations,
+        step_description=step_description,
+    )
+
+    latest_verifications = manager.verifications(mission_id)
+    latest_verification = latest_verifications[-1] if latest_verifications else None
+    final_status: MissionStatus = loop_result.final_status
+    if (
+        mission_type == "code"
+        and latest_verification is not None
+        and latest_verification.passed is False
+        and loop_result.final_status == "active"
+    ):
+        manager.set_status(mission_id, "failed")
+        final_status = "failed"
+
+    checkpoint_path = write_mission_checkpoint(manager, mission_id, runs_root)
+    return {
+        "id": mission_id,
+        "finalStatus": final_status,
+        "stepsExecuted": loop_result.steps_executed,
+        "verifierPassed": loop_result.verifier_passed,
+        "latestVerification": (_model_dump(latest_verification) if latest_verification is not None else None),
+        "checkpointPath": checkpoint_path,
+    }
+
+
+def _run_legacy_mission_loop(
+    manager: MissionManager,
+    mission_id: str,
+    goal: str,
+    *,
+    max_iterations: int,
+    step_description: str | None,
+) -> RunUntilDoneResult:
+    iteration = 0
+    explicit_description = step_description.strip() if step_description and step_description.strip() else None
+
+    def _executor(current_mission_id: str) -> StepResult:
+        nonlocal iteration
+        iteration += 1
+        next_subgoal = next(
+            (sg for sg in manager.subgoals(current_mission_id) if sg.status in ("pending", "active")),
+            None,
+        )
+        if next_subgoal is not None:
+            manager.update_subgoal_status(next_subgoal.id, "completed")
+            return StepResult(
+                description=f"Completed subgoal: {next_subgoal.description}",
+                status="completed",
+            )
+
+        if explicit_description is not None:
+            description = explicit_description
+        elif max_iterations == 1:
+            description = f"Advance mission toward goal: {goal}"
+        else:
+            description = f"Advance mission toward goal ({iteration}/{max_iterations}): {goal}"
+        return StepResult(description=description, status="completed")
+
+    return run_until_done(manager, mission_id, _executor, max_iterations=max_iterations)

--- a/autocontext/src/autocontext/mission/executor.py
+++ b/autocontext/src/autocontext/mission/executor.py
@@ -1,0 +1,220 @@
+"""AC-697 mission step executor (slice 3).
+
+Mirrors ``ts/src/mission/executor.ts`` (AC-412). Bounded step loop:
+``run_step`` runs one operator-supplied step (sync or async),
+``run_until_done`` keeps running until the verifier passes, the
+budget is exhausted, or a step blocks.
+
+Same status-state contract as TS: the mission must be ``active`` to
+accept a step; budget is checked before AND after every step so a
+single-step burst that consumes the last budget slot still
+transitions to ``budget_exhausted``; verifier outcomes that come
+back with ``verifierThrew=True`` mark the mission ``verifier_failed``
+instead of leaving it half-run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from autocontext.mission.types import MissionStatus
+
+if TYPE_CHECKING:
+    from autocontext.mission.manager import MissionManager
+
+
+__all__ = [
+    "RunStepResult",
+    "RunUntilDoneResult",
+    "StepExecutor",
+    "StepResult",
+    "run_step",
+    "run_until_done",
+]
+
+
+@dataclass(frozen=True)
+class StepResult:
+    description: str
+    status: Literal["completed", "failed", "blocked"]
+    block_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class RunStepResult:
+    step_recorded: bool
+    budget_exhausted: bool
+    blocked: bool
+    final_status: MissionStatus | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class RunUntilDoneResult:
+    final_status: MissionStatus
+    steps_executed: int
+    verifier_passed: bool
+
+
+StepExecutor = Callable[[str], StepResult | Awaitable[StepResult]]
+"""Step executor signature. The TS contract is promise-based
+(`Promise<StepResult>`); the Python version accepts both sync and
+async callables, mirroring the slice-2 verifier shape."""
+
+
+def _await_if_needed(value: StepResult | Awaitable[StepResult]) -> StepResult:
+    """Drive an awaitable step executor to completion. Same
+    sync-to-async bridge as ``MissionManager.verify``."""
+    if inspect.isawaitable(value):
+        return asyncio.run(value)  # type: ignore[arg-type]
+    return value
+
+
+def run_step(manager: MissionManager, mission_id: str, executor: StepExecutor) -> RunStepResult:
+    """Run a single bounded step. Mirrors TS ``runStep``."""
+    mission = manager.get(mission_id)
+    if mission is None:
+        raise ValueError(f"Mission not found: {mission_id}")
+
+    if mission.status != "active":
+        return RunStepResult(
+            step_recorded=False,
+            budget_exhausted=mission.status == "budget_exhausted",
+            blocked=mission.status == "blocked",
+            final_status=mission.status,
+            error=f"Mission is {mission.status}",
+        )
+
+    budget = manager.budget_usage(mission_id)
+    if budget.exhausted:
+        manager.set_status(mission_id, "budget_exhausted")
+        return RunStepResult(
+            step_recorded=False,
+            budget_exhausted=True,
+            blocked=False,
+            final_status="budget_exhausted",
+        )
+
+    try:
+        result = _await_if_needed(executor(mission_id))
+    except Exception as err:  # noqa: BLE001 — executor exceptions become a failing step
+        message = str(err)
+        step_id = manager.advance(mission_id, f"Error: {message}")
+        manager.update_step(step_id, "failed", message)
+        return RunStepResult(
+            step_recorded=True,
+            budget_exhausted=False,
+            blocked=False,
+            error=message,
+        )
+
+    step_id = manager.advance(mission_id, result.description)
+
+    if result.status == "failed":
+        manager.update_step(step_id, "failed", result.description)
+        return RunStepResult(
+            step_recorded=True,
+            budget_exhausted=False,
+            blocked=False,
+            error=result.description,
+        )
+
+    if result.status == "blocked":
+        block_reason = result.block_reason or result.description
+        manager.update_step(step_id, "blocked", block_reason)
+        manager.set_status(mission_id, "blocked")
+        return RunStepResult(
+            step_recorded=True,
+            budget_exhausted=False,
+            blocked=True,
+            final_status="blocked",
+            error=block_reason,
+        )
+
+    updated_budget = manager.budget_usage(mission_id)
+    if updated_budget.exhausted:
+        manager.set_status(mission_id, "budget_exhausted")
+        return RunStepResult(
+            step_recorded=True,
+            budget_exhausted=True,
+            blocked=False,
+            final_status="budget_exhausted",
+        )
+
+    return RunStepResult(step_recorded=True, budget_exhausted=False, blocked=False)
+
+
+def run_until_done(
+    manager: MissionManager,
+    mission_id: str,
+    executor: StepExecutor,
+    *,
+    max_iterations: int = 100,
+) -> RunUntilDoneResult:
+    """Run steps + verify until the verifier passes, the budget is
+    exhausted, a step blocks, or ``max_iterations`` is hit. Mirrors
+    TS ``runUntilDone``."""
+    steps_executed = 0
+    for _iteration in range(max_iterations):
+        mission = manager.get(mission_id)
+        if mission is None:
+            raise ValueError(f"Mission not found: {mission_id}")
+        if mission.status != "active":
+            return RunUntilDoneResult(
+                final_status=mission.status,
+                steps_executed=steps_executed,
+                verifier_passed=False,
+            )
+
+        step_result = run_step(manager, mission_id, executor)
+        if step_result.step_recorded:
+            steps_executed += 1
+
+        if step_result.final_status is not None and step_result.final_status != "active":
+            return RunUntilDoneResult(
+                final_status=step_result.final_status,
+                steps_executed=steps_executed,
+                verifier_passed=False,
+            )
+
+        if step_result.budget_exhausted:
+            return RunUntilDoneResult(
+                final_status="budget_exhausted",
+                steps_executed=steps_executed,
+                verifier_passed=False,
+            )
+
+        if step_result.blocked:
+            return RunUntilDoneResult(
+                final_status="blocked",
+                steps_executed=steps_executed,
+                verifier_passed=False,
+            )
+
+        verify_result = manager.verify(mission_id)
+        if verify_result.passed:
+            return RunUntilDoneResult(
+                final_status="completed",
+                steps_executed=steps_executed,
+                verifier_passed=True,
+            )
+        if verify_result.metadata.get("verifierThrew") is True:
+            manager.set_status(mission_id, "verifier_failed")
+            return RunUntilDoneResult(
+                final_status="verifier_failed",
+                steps_executed=steps_executed,
+                verifier_passed=False,
+            )
+
+    # Max iterations reached without completion.
+    final_mission = manager.get(mission_id)
+    final_status: MissionStatus = final_mission.status if final_mission is not None else "active"
+    return RunUntilDoneResult(
+        final_status=final_status,
+        steps_executed=steps_executed,
+        verifier_passed=False,
+    )

--- a/autocontext/src/autocontext/mission/executor.py
+++ b/autocontext/src/autocontext/mission/executor.py
@@ -21,6 +21,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
+from autocontext.mission._async_bridge import AsyncContextError, has_running_loop
 from autocontext.mission.types import MissionStatus
 
 if TYPE_CHECKING:
@@ -68,10 +69,27 @@ async callables, mirroring the slice-2 verifier shape."""
 
 def _await_if_needed(value: StepResult | Awaitable[StepResult]) -> StepResult:
     """Drive an awaitable step executor to completion. Same
-    sync-to-async bridge as ``MissionManager.verify``."""
-    if inspect.isawaitable(value):
-        return asyncio.run(value)  # type: ignore[arg-type]
-    return value
+    sync-to-async bridge as ``MissionManager.verify``.
+
+    PR #1016 review (P2): when called from inside a running event
+    loop with an awaitable value, raise ``AsyncContextError`` so the
+    caller (``run_step``) knows not to record a failed step. Calling
+    ``asyncio.run`` from inside a running loop raises
+    ``RuntimeError`` — without this guard the exception would be
+    swallowed by the catch-all in ``run_step`` and a spurious failed
+    step would be persisted.
+    """
+    if not inspect.isawaitable(value):
+        return value
+    if has_running_loop():
+        if hasattr(value, "close"):
+            value.close()  # avoid an unawaited-coroutine warning
+        raise AsyncContextError(
+            "run_step received an async executor while a running event loop is "
+            "active. Run from sync code, or call the step executor yourself and "
+            "pass the resolved StepResult into run_step."
+        )
+    return asyncio.run(value)  # type: ignore[arg-type]
 
 
 def run_step(manager: MissionManager, mission_id: str, executor: StepExecutor) -> RunStepResult:
@@ -101,6 +119,10 @@ def run_step(manager: MissionManager, mission_id: str, executor: StepExecutor) -
 
     try:
         result = _await_if_needed(executor(mission_id))
+    except AsyncContextError:
+        # PR #1016 review (P2): propagate the async-context guard so
+        # the caller can react. State has not been mutated yet.
+        raise
     except Exception as err:  # noqa: BLE001 — executor exceptions become a failing step
         message = str(err)
         step_id = manager.advance(mission_id, f"Error: {message}")

--- a/autocontext/src/autocontext/mission/manager.py
+++ b/autocontext/src/autocontext/mission/manager.py
@@ -208,6 +208,20 @@ class MissionManager:
         return self._store.get_budget_usage(mission_id)
 
     # -------------------------------------------------------------------
+    # Checkpoint
+    # -------------------------------------------------------------------
+
+    def save_checkpoint(self, mission_id: str, checkpoint_dir: str) -> str:
+        """Persist a full mission snapshot to ``checkpoint_dir``.
+        Returns the resulting file path. Mirrors TS
+        ``manager.saveCheckpoint``."""
+        # Local import keeps the slice-1/2 manager free of the
+        # slice-3 checkpoint dependency until callers actually use it.
+        from autocontext.mission.checkpoint import save_checkpoint
+
+        return save_checkpoint(self._store, mission_id, checkpoint_dir)
+
+    # -------------------------------------------------------------------
     # Bookkeeping
     # -------------------------------------------------------------------
 

--- a/autocontext/src/autocontext/mission/manager.py
+++ b/autocontext/src/autocontext/mission/manager.py
@@ -15,6 +15,7 @@ import inspect
 from collections.abc import Callable
 from typing import Any
 
+from autocontext.mission._async_bridge import AsyncContextError, has_running_loop
 from autocontext.mission.events import MissionEventEmitter
 from autocontext.mission.lifecycle import resolve_mission_status_transition
 from autocontext.mission.store import MissionStore
@@ -156,8 +157,25 @@ class MissionManager:
             try:
                 raw = verifier(mission_id)
                 if inspect.iscoroutine(raw):
+                    # PR #1016 review (P2) parity for executor.py: refuse
+                    # the async-in-running-loop case BEFORE recording any
+                    # state. Without the pre-check, `asyncio.run` would
+                    # raise `RuntimeError` from inside an active loop, the
+                    # catch-all would persist a failing verification, and
+                    # the mission would stay open even though the verifier
+                    # would have passed.
+                    if has_running_loop():
+                        raw.close()  # avoid an unawaited-coroutine warning
+                        raise AsyncContextError(
+                            "MissionManager.verify received an async verifier while a "
+                            "running event loop is active. Run from sync code, or "
+                            "await the verifier yourself and pass the resolved "
+                            "VerifierResult into a future async-aware verify API."
+                        )
                     raw = asyncio.run(raw)
                 outcome = resolve_mission_verification_outcome(raw)
+            except AsyncContextError:
+                raise
             except Exception as err:
                 outcome = resolve_mission_verification_error_outcome(str(err), type(err).__name__)
 

--- a/autocontext/tests/mission/test_mission_checkpoint.py
+++ b/autocontext/tests/mission/test_mission_checkpoint.py
@@ -1,0 +1,184 @@
+"""AC-697 mission checkpoint tests (slice 3).
+
+Covers ``save_checkpoint`` round-trip + ``load_checkpoint`` shape
+parity with TS, plus the defensive guards (missing mission, restore
+into a db that already has the id).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from autocontext.mission import (
+    CHECKPOINT_VERSION,
+    MissionBudget,
+    MissionStore,
+    VerifierResult,
+    load_checkpoint,
+    save_checkpoint,
+)
+
+
+def _store(tmp_path: Path) -> MissionStore:
+    return MissionStore(str(tmp_path / "m.sqlite3"))
+
+
+def test_save_checkpoint_writes_canonical_payload_shape(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(
+            name="ship login",
+            goal="OAuth handshake",
+            budget=MissionBudget(max_steps=4),
+            metadata={"label": "demo"},
+        )
+        store.add_step(mid, description="ran cli")
+        store.add_subgoal(mid, description="step 1")
+        store.record_verification(
+            mid,
+            VerifierResult(passed=False, reason="not yet"),
+        )
+
+        path = save_checkpoint(store, mid, tmp_path / "checkpoints")
+        payload = json.loads(Path(path).read_text())
+        assert payload["version"] == CHECKPOINT_VERSION
+        assert payload["mission"]["id"] == mid
+        assert payload["mission"]["name"] == "ship login"
+        # Pydantic dump uses snake_case keys for the budget.
+        assert payload["mission"]["budget"] == {
+            "max_steps": 4,
+            "max_cost_usd": None,
+            "max_duration_minutes": None,
+        }
+        assert len(payload["steps"]) == 1
+        assert len(payload["subgoals"]) == 1
+        assert len(payload["verifications"]) == 1
+        assert payload["budgetUsage"]["steps_used"] == 1
+    finally:
+        store.close()
+
+
+def test_save_checkpoint_creates_target_directory(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        nested = tmp_path / "a" / "b" / "c"
+        path = save_checkpoint(store, mid, nested)
+        assert nested.is_dir()
+        assert Path(path).is_file()
+    finally:
+        store.close()
+
+
+def test_save_checkpoint_missing_mission_raises(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    try:
+        with pytest.raises(ValueError, match="Mission not found"):
+            save_checkpoint(store, "mission-nope", tmp_path / "cp")
+    finally:
+        store.close()
+
+
+def test_load_checkpoint_round_trips_mission_with_children(tmp_path: Path) -> None:
+    src_store = MissionStore(str(tmp_path / "src.sqlite3"))
+    try:
+        mid = src_store.create_mission(
+            name="x",
+            goal="g",
+            budget=MissionBudget(max_steps=3, max_cost_usd=1.5),
+            metadata={"label": "demo"},
+        )
+        src_store.add_step(mid, description="s1")
+        src_store.add_subgoal(mid, description="sg1", priority=1)
+        src_store.record_verification(mid, VerifierResult(passed=True, reason="green"))
+        checkpoint_path = save_checkpoint(src_store, mid, tmp_path / "cp")
+    finally:
+        src_store.close()
+
+    # Fresh store -> load into it.
+    dest_path = tmp_path / "dest.sqlite3"
+    dest_store = MissionStore(str(dest_path))
+    try:
+        restored_id = load_checkpoint(dest_store, checkpoint_path)
+        assert restored_id == mid
+
+        mission = dest_store.get_mission(restored_id)
+        assert mission is not None
+        assert mission.name == "x"
+        assert mission.budget == MissionBudget(max_steps=3, max_cost_usd=1.5)
+        assert dest_store.get_steps(restored_id)[0].description == "s1"
+        assert dest_store.get_subgoals(restored_id)[0].priority == 1
+        verifications = dest_store.get_verifications(restored_id)
+        assert verifications[0].passed is True
+    finally:
+        dest_store.close()
+
+
+def test_load_checkpoint_into_db_with_existing_id_rejects(tmp_path: Path) -> None:
+    """Restore guards against silently clobbering an existing
+    mission row that happens to share the original id."""
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        checkpoint_path = save_checkpoint(store, mid, tmp_path / "cp")
+        with pytest.raises(ValueError, match="already exists"):
+            load_checkpoint(store, checkpoint_path)
+    finally:
+        store.close()
+
+
+def test_load_checkpoint_assigns_id_for_verifications_missing_one(
+    tmp_path: Path,
+) -> None:
+    """Mirror TS guard: a checkpoint produced by an older version
+    that didn't persist verification ids still loads, with a fresh
+    `verify-restored-<8 hex>` id assigned."""
+    src_store = MissionStore(str(tmp_path / "src2.sqlite3"))
+    try:
+        mid = src_store.create_mission(name="x", goal="g")
+        # Build a checkpoint payload with a verification missing an id.
+        payload = {
+            "version": 1,
+            "checkpointedAt": "2026-06-02T00:00:00Z",
+            "mission": {
+                "id": mid,
+                "name": "x",
+                "goal": "g",
+                "status": "active",
+                "budget": None,
+                "metadata": {},
+                "created_at": f"2026-06-02T00:00:0{int(time.time()) % 9}Z",
+                "updated_at": None,
+                "completed_at": None,
+            },
+            "steps": [],
+            "subgoals": [],
+            "verifications": [
+                {
+                    "passed": True,
+                    "reason": "from-old-format",
+                    "suggestions": [],
+                    "metadata": {},
+                    "created_at": "2026-06-02T00:00:00Z",
+                }
+            ],
+            "budgetUsage": {"steps_used": 0, "exhausted": False},
+        }
+        path = tmp_path / "legacy.json"
+        path.write_text(json.dumps(payload))
+    finally:
+        src_store.close()
+
+    dest = MissionStore(str(tmp_path / "dest2.sqlite3"))
+    try:
+        restored_id = load_checkpoint(dest, path)
+        records = dest.get_verifications(restored_id)
+        assert len(records) == 1
+        assert records[0].id.startswith("verify-restored-")
+        assert records[0].passed is True
+    finally:
+        dest.close()

--- a/autocontext/tests/mission/test_mission_checkpoint.py
+++ b/autocontext/tests/mission/test_mission_checkpoint.py
@@ -131,6 +131,176 @@ def test_load_checkpoint_into_db_with_existing_id_rejects(tmp_path: Path) -> Non
         store.close()
 
 
+# ---------------------------------------------------------------------------
+# PR #1016 review (P2): camelCase TS-shaped checkpoint compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_load_checkpoint_accepts_ts_camelcase_budget_and_timestamps(
+    tmp_path: Path,
+) -> None:
+    """PR #1016 review (P2): the TS checkpoint format uses camelCase
+    (`createdAt`, `budget.maxSteps`, ...). Before the fix the Python
+    loader only read snake_case, so a TS-shaped checkpoint dropped
+    the budget caps and regenerated timestamps. The fix accepts
+    either shape so a shared `AUTOCONTEXT_DB_PATH` resumes cleanly.
+    """
+    ts_checkpoint = {
+        "version": 1,
+        "checkpointedAt": "2026-06-02T00:00:00Z",
+        "mission": {
+            "id": "mission-tscamel",
+            "name": "ts-shaped",
+            "goal": "g",
+            "status": "active",
+            "budget": {"maxSteps": 7, "maxCostUsd": 3.5},
+            "metadata": {"missionType": "code"},
+            "createdAt": "2026-06-02T01:00:00Z",
+            "updatedAt": "2026-06-02T02:00:00Z",
+            "completedAt": None,
+        },
+        "steps": [
+            {
+                "id": "step-1",
+                "mission_id": "mission-tscamel",
+                "description": "did a",
+                "status": "completed",
+                "result": None,
+                "createdAt": "2026-06-02T03:00:00Z",
+                "completedAt": "2026-06-02T03:01:00Z",
+            }
+        ],
+        "subgoals": [],
+        "verifications": [],
+        "budgetUsage": {"steps_used": 1, "exhausted": False},
+    }
+    path = tmp_path / "ts-checkpoint.json"
+    path.write_text(json.dumps(ts_checkpoint))
+
+    dest = MissionStore(str(tmp_path / "dest.sqlite3"))
+    try:
+        restored_id = load_checkpoint(dest, path)
+        assert restored_id == "mission-tscamel"
+        mission = dest.get_mission(restored_id)
+        assert mission is not None
+        assert mission.budget == MissionBudget(max_steps=7, max_cost_usd=3.5)
+        assert mission.created_at == "2026-06-02T01:00:00Z"
+        assert mission.updated_at == "2026-06-02T02:00:00Z"
+        # Steps inherited their TS-shaped createdAt too.
+        step = dest.get_steps(restored_id)[0]
+        assert step.created_at == "2026-06-02T03:00:00Z"
+    finally:
+        dest.close()
+
+
+# ---------------------------------------------------------------------------
+# PR #1016 review (P2): atomic restore
+# ---------------------------------------------------------------------------
+
+
+def test_load_checkpoint_rolls_back_on_duplicate_child_row(tmp_path: Path) -> None:
+    """PR #1016 review (P2): a child-row failure used to leave a
+    partial mission + first step behind; a retry then choked on the
+    already-existing mission row. The transaction wrapper rolls back
+    the partial restore so the operator can retry without first
+    cleaning up."""
+    duplicate_step_id = "step-dup"
+    payload = {
+        "version": 1,
+        "checkpointedAt": "2026-06-02T00:00:00Z",
+        "mission": {
+            "id": "mission-rb",
+            "name": "x",
+            "goal": "g",
+            "status": "active",
+            "budget": None,
+            "metadata": {},
+            "created_at": "2026-06-02T00:00:00Z",
+            "updated_at": None,
+            "completed_at": None,
+        },
+        "steps": [
+            {
+                "id": duplicate_step_id,
+                "mission_id": "mission-rb",
+                "description": "first",
+                "status": "completed",
+                "result": None,
+                "created_at": "2026-06-02T00:01:00Z",
+                "completed_at": None,
+            },
+            # Duplicate id triggers UNIQUE constraint failure on the
+            # second insert; the rollback should drop the mission row
+            # AND the first step.
+            {
+                "id": duplicate_step_id,
+                "mission_id": "mission-rb",
+                "description": "second",
+                "status": "completed",
+                "result": None,
+                "created_at": "2026-06-02T00:02:00Z",
+                "completed_at": None,
+            },
+        ],
+        "subgoals": [],
+        "verifications": [],
+        "budgetUsage": {"steps_used": 2, "exhausted": False},
+    }
+    path = tmp_path / "rb.json"
+    path.write_text(json.dumps(payload))
+
+    dest = MissionStore(str(tmp_path / "dest_rb.sqlite3"))
+    try:
+        import sqlite3
+
+        with pytest.raises(sqlite3.IntegrityError):
+            load_checkpoint(dest, path)
+        # Mission row was rolled back.
+        assert dest.get_mission("mission-rb") is None
+        # First step was rolled back.
+        assert (
+            dest._db.execute(
+                "SELECT COUNT(*) AS c FROM mission_steps WHERE mission_id = ?",
+                ("mission-rb",),
+            ).fetchone()["c"]
+            == 0
+        )
+        # A retry succeeds after the operator dedupes the steps.
+        payload["steps"][1]["id"] = "step-dup-2"  # type: ignore[index]
+        path.write_text(json.dumps(payload))
+        restored_id = load_checkpoint(dest, path)
+        assert restored_id == "mission-rb"
+    finally:
+        dest.close()
+
+
+# ---------------------------------------------------------------------------
+# PR #1016 review (P3): filename collision
+# ---------------------------------------------------------------------------
+
+
+def test_save_checkpoint_two_saves_in_same_millisecond_do_not_collide(
+    tmp_path: Path,
+) -> None:
+    """PR #1016 review (P3): `<mid>-<unix_ms>.json` collided when two
+    saves landed in the same millisecond. The new `<mid>-<ns>-<uuid8>.json`
+    layout makes the path unique even on fast hardware and across
+    concurrent writers.
+    """
+    store = _store(tmp_path)
+    try:
+        mid = store.create_mission(name="x", goal="g")
+        cp_dir = tmp_path / "cp"
+        # Save 10 in a tight loop — millisecond ties are likely.
+        paths = {save_checkpoint(store, mid, cp_dir) for _ in range(10)}
+        assert len(paths) == 10
+        # All files actually exist (no overwrites).
+        for p in paths:
+            assert Path(p).is_file()
+    finally:
+        store.close()
+
+
 def test_load_checkpoint_assigns_id_for_verifications_missing_one(
     tmp_path: Path,
 ) -> None:

--- a/autocontext/tests/mission/test_mission_control_plane.py
+++ b/autocontext/tests/mission/test_mission_control_plane.py
@@ -1,0 +1,231 @@
+"""AC-697 mission control-plane tests (slice 3).
+
+Mirrors ``ts/src/mission/control-plane.ts`` test surface: status /
+result / artifact payload shape; checkpoint write; fallback verifier
+behaviour; legacy run_mission_loop with subgoals + max_iterations +
+code-mission failing-verifier downgrade-to-failed branch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autocontext.mission import (
+    CodeMissionSpec,
+    MissionBudget,
+    MissionManager,
+    VerifierResult,
+    build_fallback_verifier,
+    build_mission_artifacts_payload,
+    build_mission_result_payload,
+    build_mission_status_payload,
+    create_code_mission,
+    mission_checkpoint_dir,
+    require_mission,
+    run_mission_loop,
+    write_mission_checkpoint,
+)
+
+
+def _manager(tmp_path: Path) -> MissionManager:
+    return MissionManager(str(tmp_path / "m.sqlite3"))
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def test_mission_checkpoint_dir_uses_canonical_layout(tmp_path: Path) -> None:
+    path = mission_checkpoint_dir(tmp_path, "mission-abc")
+    assert path == str(tmp_path / "missions" / "mission-abc" / "checkpoints")
+
+
+def test_require_mission_raises_for_unknown_id(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        with pytest.raises(ValueError, match="Mission not found"):
+            require_mission(mgr, "mission-nope")
+
+
+# ---------------------------------------------------------------------------
+# Payloads
+# ---------------------------------------------------------------------------
+
+
+def test_status_payload_carries_counts_and_latest_verification(
+    tmp_path: Path,
+) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g", budget=MissionBudget(max_steps=4))
+        mgr.advance(mid, "s1")
+        mgr.add_subgoal(mid, description="sg1")
+        mgr.set_verifier(mid, lambda _mid: VerifierResult(passed=False, reason="not yet"))
+        mgr.verify(mid)
+
+        payload = build_mission_status_payload(mgr, mid)
+        assert payload["id"] == mid
+        assert payload["stepsCount"] == 1
+        assert payload["subgoalCount"] == 1
+        assert payload["verificationCount"] == 1
+        assert payload["budgetUsage"]["steps_used"] == 1
+        assert payload["latestVerification"]["reason"] == "not yet"
+
+
+def test_result_payload_serialises_every_section(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.add_subgoal(mid, description="sg1")
+        payload = build_mission_result_payload(mgr, mid)
+        assert payload["mission"]["id"] == mid
+        assert payload["steps"] == []
+        assert payload["subgoals"][0]["description"] == "sg1"
+        assert payload["latestVerification"] is None
+
+
+def test_artifacts_payload_returns_empty_checkpoint_list_when_dir_missing(
+    tmp_path: Path,
+) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        payload = build_mission_artifacts_payload(mgr, mid, tmp_path / "runs")
+        assert payload["missionId"] == mid
+        assert payload["status"] == "active"
+        assert payload["checkpoints"] == []
+        assert payload["latestCheckpoint"] is None
+
+
+def test_artifacts_payload_lists_checkpoints_newest_first(tmp_path: Path) -> None:
+    import time
+
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        first = write_mission_checkpoint(mgr, mid, tmp_path / "runs")
+        # Checkpoint filenames embed unix-ms timestamps. A second
+        # write inside the same ms would overwrite the first file.
+        # Sleep 2ms so the second checkpoint gets a distinct name.
+        time.sleep(0.002)
+        mgr.advance(mid, "step")
+        second = write_mission_checkpoint(mgr, mid, tmp_path / "runs")
+        assert first != second
+
+        payload = build_mission_artifacts_payload(mgr, mid, tmp_path / "runs")
+        names = [c["name"] for c in payload["checkpoints"]]
+        # Reverse-sorted file names; newest first.
+        assert names == sorted(names, reverse=True)
+        assert payload["latestCheckpoint"]["mission"]["id"] == mid
+
+
+# ---------------------------------------------------------------------------
+# Fallback verifier
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_verifier_returns_no_verifier_when_no_subgoals(
+    tmp_path: Path,
+) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        verifier = build_fallback_verifier(mgr, mid)
+        result = verifier(mid)
+        assert result.passed is False
+        assert result.reason == "No verifier registered"
+        assert result.metadata["autoVerifier"] == "none"
+
+
+def test_fallback_verifier_passes_when_every_subgoal_terminal(
+    tmp_path: Path,
+) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        sgid = mgr.add_subgoal(mid, description="finish")
+        mgr.update_subgoal_status(sgid, "completed")
+        verifier = build_fallback_verifier(mgr, mid)
+        result = verifier(mid)
+        assert result.passed is True
+        assert result.metadata["autoVerifier"] == "subgoals"
+
+
+def test_fallback_verifier_lists_remaining_subgoals(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.add_subgoal(mid, description="A")
+        mgr.add_subgoal(mid, description="B")
+        verifier = build_fallback_verifier(mgr, mid)
+        result = verifier(mid)
+        assert result.passed is False
+        assert "2 subgoal(s) remaining" in result.reason
+        assert set(result.suggestions) == {"A", "B"}
+
+
+# ---------------------------------------------------------------------------
+# run_mission_loop
+# ---------------------------------------------------------------------------
+
+
+def test_run_mission_loop_uses_subgoal_executor_and_writes_checkpoint(
+    tmp_path: Path,
+) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.add_subgoal(mid, description="A")
+        mgr.add_subgoal(mid, description="B")
+        # No verifier registered -> fallback verifier kicks in; when
+        # all subgoals complete it passes.
+        result = run_mission_loop(mgr, mid, tmp_path / "runs", max_iterations=5)
+        assert result["finalStatus"] == "completed"
+        assert result["verifierPassed"] is True
+        assert result["stepsExecuted"] == 2
+        # Checkpoint was written.
+        assert Path(result["checkpointPath"]).is_file()
+
+
+def test_run_mission_loop_caps_at_max_iterations_with_no_subgoals(
+    tmp_path: Path,
+) -> None:
+    """Without subgoals or a verifier, the fallback verifier reports
+    `No verifier registered` and never passes; the loop should still
+    return cleanly after `max_iterations` steps."""
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        result = run_mission_loop(mgr, mid, tmp_path / "runs", max_iterations=2)
+        assert result["stepsExecuted"] == 2
+        assert result["finalStatus"] == "active"
+        assert result["verifierPassed"] is False
+
+
+def test_run_mission_loop_downgrades_code_mission_to_failed_when_verifier_fails(
+    tmp_path: Path,
+) -> None:
+    """Code missions that the verifier rejects but the loop left
+    `active` are downgraded to `failed` (TS parity branch)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with _manager(tmp_path) as mgr:
+        mid = create_code_mission(
+            mgr,
+            CodeMissionSpec(
+                name="x",
+                goal="g",
+                repo_path=str(repo),
+                test_command="false",  # always fails
+            ),
+        )
+        result = run_mission_loop(mgr, mid, tmp_path / "runs", max_iterations=1)
+        assert result["finalStatus"] == "failed"
+
+
+def test_run_mission_loop_writes_checkpoint_under_canonical_dir(
+    tmp_path: Path,
+) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        result = run_mission_loop(mgr, mid, tmp_path / "runs", max_iterations=1)
+        expected_dir = Path(mission_checkpoint_dir(tmp_path / "runs", mid))
+        assert Path(result["checkpointPath"]).parent == expected_dir
+        # The checkpoint is valid JSON with the canonical version field.
+        payload = json.loads(Path(result["checkpointPath"]).read_text())
+        assert payload["version"] == 1
+        assert payload["mission"]["id"] == mid

--- a/autocontext/tests/mission/test_mission_executor.py
+++ b/autocontext/tests/mission/test_mission_executor.py
@@ -161,6 +161,36 @@ def test_run_step_supports_async_executor(tmp_path: Path) -> None:
         assert mgr.steps(mid)[0].description == "async did a"
 
 
+def test_run_step_async_inside_running_loop_raises_without_mutating_state(
+    tmp_path: Path,
+) -> None:
+    """PR #1016 review (P2): the sync `run_step` API cannot bridge
+    async executors from inside a running event loop because
+    `asyncio.run` rejects a nested call. Without the guard the
+    catch-all would have persisted a falsely-failed step. The fix
+    raises `AsyncContextError` BEFORE recording any step, so the
+    caller can react and the mission state stays untouched.
+    """
+    import asyncio
+
+    from autocontext.mission._async_bridge import AsyncContextError
+
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+
+        async def driver() -> None:
+            async def step(_mid: str) -> StepResult:
+                return StepResult(description="never recorded", status="completed")
+
+            with pytest.raises(AsyncContextError):
+                run_step(mgr, mid, step)
+
+        asyncio.run(driver())
+        # No step was recorded — the guard fired before any state mutation.
+        assert mgr.steps(mid) == []
+        assert mgr.get(mid).status == "active"
+
+
 # ---------------------------------------------------------------------------
 # run_until_done
 # ---------------------------------------------------------------------------

--- a/autocontext/tests/mission/test_mission_executor.py
+++ b/autocontext/tests/mission/test_mission_executor.py
@@ -1,0 +1,252 @@
+"""AC-697 mission executor tests (slice 3).
+
+Mirrors the unit-test surface for ``ts/src/mission/executor.ts``.
+Covers happy-path step run, mission-not-active short-circuit,
+budget exhaustion before AND after step, blocked path, failed
+step, executor exception turning into failing step, and the
+verifier-pass / verifier-fail / verifier-threw branches in
+``run_until_done``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autocontext.mission import (
+    MissionBudget,
+    MissionManager,
+    StepResult,
+    VerifierResult,
+    run_step,
+    run_until_done,
+)
+
+
+def _manager(tmp_path: Path) -> MissionManager:
+    return MissionManager(str(tmp_path / "m.sqlite3"))
+
+
+# ---------------------------------------------------------------------------
+# run_step happy path + guards
+# ---------------------------------------------------------------------------
+
+
+def test_run_step_records_completed_step(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        result = run_step(
+            mgr,
+            mid,
+            lambda _mid: StepResult(description="did a", status="completed"),
+        )
+        assert result.step_recorded is True
+        steps = mgr.steps(mid)
+        assert steps[0].description == "did a"
+
+
+def test_run_step_rejects_when_mission_not_active(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.pause(mid)
+        result = run_step(
+            mgr,
+            mid,
+            lambda _mid: StepResult(description="d", status="completed"),
+        )
+        assert result.step_recorded is False
+        assert result.final_status == "paused"
+        assert "Mission is paused" in (result.error or "")
+
+
+def test_run_step_unknown_mission_raises(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        with pytest.raises(ValueError, match="Mission not found"):
+            run_step(
+                mgr,
+                "mission-nope",
+                lambda _mid: StepResult(description="d", status="completed"),
+            )
+
+
+def test_run_step_budget_exhausted_before_execution(tmp_path: Path) -> None:
+    """Budget is checked before executing the step; an already-exhausted
+    budget transitions the mission to ``budget_exhausted``."""
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g", budget=MissionBudget(max_steps=1))
+        mgr.advance(mid, "ate the budget")
+        result = run_step(
+            mgr,
+            mid,
+            lambda _mid: StepResult(description="d", status="completed"),
+        )
+        assert result.budget_exhausted is True
+        assert result.final_status == "budget_exhausted"
+        assert mgr.get(mid).status == "budget_exhausted"
+
+
+def test_run_step_budget_exhausted_after_execution(tmp_path: Path) -> None:
+    """A step that consumes the last budget slot still records but
+    transitions ``budget_exhausted`` for the next iteration."""
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g", budget=MissionBudget(max_steps=1))
+        result = run_step(
+            mgr,
+            mid,
+            lambda _mid: StepResult(description="d", status="completed"),
+        )
+        assert result.step_recorded is True
+        assert result.budget_exhausted is True
+        assert mgr.get(mid).status == "budget_exhausted"
+
+
+def test_run_step_failed_step_records_failure(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        result = run_step(
+            mgr,
+            mid,
+            lambda _mid: StepResult(description="failed thing", status="failed"),
+        )
+        assert result.step_recorded is True
+        assert result.error == "failed thing"
+        assert mgr.steps(mid)[0].status == "failed"
+
+
+def test_run_step_blocked_step_transitions_blocked(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        result = run_step(
+            mgr,
+            mid,
+            lambda _mid: StepResult(
+                description="needs human",
+                status="blocked",
+                block_reason="waiting for review",
+            ),
+        )
+        assert result.blocked is True
+        assert mgr.get(mid).status == "blocked"
+        assert mgr.steps(mid)[0].status == "blocked"
+        assert mgr.steps(mid)[0].result == "waiting for review"
+
+
+def test_run_step_executor_exception_records_failed_step(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+
+        def boom(_mid: str) -> StepResult:
+            raise RuntimeError("kaboom")
+
+        result = run_step(mgr, mid, boom)
+        assert result.step_recorded is True
+        assert "kaboom" in (result.error or "")
+        steps = mgr.steps(mid)
+        assert steps[0].status == "failed"
+        assert "kaboom" in steps[0].description
+
+
+def test_run_step_supports_async_executor(tmp_path: Path) -> None:
+    """Parity with the slice-2 async-verifier fix: the executor
+    callable can be async too."""
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+
+        async def step(_mid: str) -> StepResult:
+            return StepResult(description="async did a", status="completed")
+
+        result = run_step(mgr, mid, step)
+        assert result.step_recorded is True
+        assert mgr.steps(mid)[0].description == "async did a"
+
+
+# ---------------------------------------------------------------------------
+# run_until_done
+# ---------------------------------------------------------------------------
+
+
+def test_run_until_done_completes_when_verifier_passes(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.set_verifier(mid, lambda _mid: VerifierResult(passed=True, reason="green"))
+        result = run_until_done(
+            mgr,
+            mid,
+            lambda _mid: StepResult(description="d", status="completed"),
+            max_iterations=5,
+        )
+        assert result.final_status == "completed"
+        assert result.verifier_passed is True
+        assert result.steps_executed == 1
+
+
+def test_run_until_done_stops_on_budget_exhaustion(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g", budget=MissionBudget(max_steps=2))
+        # Verifier never passes so the loop runs until budget runs out.
+        mgr.set_verifier(mid, lambda _mid: VerifierResult(passed=False, reason="not yet"))
+        result = run_until_done(
+            mgr,
+            mid,
+            lambda _mid: StepResult(description="d", status="completed"),
+            max_iterations=10,
+        )
+        assert result.final_status == "budget_exhausted"
+        assert result.steps_executed == 2
+
+
+def test_run_until_done_stops_on_blocked(tmp_path: Path) -> None:
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        result = run_until_done(
+            mgr,
+            mid,
+            lambda _mid: StepResult(
+                description="needs human",
+                status="blocked",
+                block_reason="waiting",
+            ),
+            max_iterations=3,
+        )
+        assert result.final_status == "blocked"
+
+
+def test_run_until_done_marks_verifier_failed_when_verifier_throws(
+    tmp_path: Path,
+) -> None:
+    """A verifier that throws lands as a failing result with
+    ``verifierThrew=True``; the loop marks the mission
+    ``verifier_failed`` and stops."""
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+
+        def boom(_mid: str) -> VerifierResult:
+            raise RuntimeError("kaboom")
+
+        mgr.set_verifier(mid, boom)
+        result = run_until_done(
+            mgr,
+            mid,
+            lambda _mid: StepResult(description="d", status="completed"),
+            max_iterations=3,
+        )
+        assert result.final_status == "verifier_failed"
+
+
+def test_run_until_done_caps_at_max_iterations(tmp_path: Path) -> None:
+    """If the verifier never passes and nothing else short-circuits,
+    the loop returns the live mission status after exactly
+    ``max_iterations`` steps."""
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+        mgr.set_verifier(mid, lambda _mid: VerifierResult(passed=False, reason="not yet"))
+        result = run_until_done(
+            mgr,
+            mid,
+            lambda _mid: StepResult(description="d", status="completed"),
+            max_iterations=3,
+        )
+        assert result.steps_executed == 3
+        assert result.final_status == "active"
+        assert result.verifier_passed is False

--- a/autocontext/tests/mission/test_mission_manager.py
+++ b/autocontext/tests/mission/test_mission_manager.py
@@ -217,6 +217,36 @@ def test_async_verifier_that_raises_yields_failing_result(tmp_path: Path) -> Non
         assert "kaboom" in result.reason
 
 
+def test_async_verifier_inside_running_loop_raises_without_persisting(
+    tmp_path: Path,
+) -> None:
+    """PR #1016 review (P2) parity with the executor fix: the sync
+    `verify()` API cannot bridge an async verifier from inside a
+    running event loop because `asyncio.run` rejects a nested call.
+    The fix raises `AsyncContextError` BEFORE recording any
+    verification so the mission stays state-consistent.
+    """
+    import asyncio
+
+    from autocontext.mission._async_bridge import AsyncContextError
+
+    with _manager(tmp_path) as mgr:
+        mid = mgr.create(name="x", goal="g")
+
+        async def passing(_mid: str) -> VerifierResult:
+            return VerifierResult(passed=True, reason="green")
+
+        mgr.set_verifier(mid, passing)
+
+        async def driver() -> None:
+            with pytest.raises(AsyncContextError):
+                mgr.verify(mid)
+
+        asyncio.run(driver())
+        assert mgr.verifications(mid) == []
+        assert mgr.get(mid).status == "active"
+
+
 # ---------------------------------------------------------------------------
 # PR #1015 review (P2): transition ordering
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Mirrors `ts/src/mission/{checkpoint,executor,control-plane}.ts` (slice 3 of 5). Adds the operator-facing control-plane workflows on top of the slice-2 manager + verifiers + planner. The slice-4/5 CLI lands on top of these.

- `checkpoint.py` — `save_checkpoint` writes `<mission_id>-<unix_ms>.json` (full mission state + parent dir on demand). `load_checkpoint` re-inserts the rows with their original ids, guards against existing-id clobbering, and assigns fresh ids for older verification records that omit them. Budget keys round-trip from snake-case Pydantic dumps to camelCase on-disk blobs for cross-runtime DB compat.
- `executor.py` — `run_step` (sync or async via coroutine detection; budget checked before AND after every step; failed/blocked outcomes recorded on the step row; executor exceptions become a failing step). `run_until_done` drives the loop (`completed` on verifier-pass; `verifier_failed` on verifier-throw; `budget_exhausted` / `blocked` from the underlying step; live status after `max_iterations`).
- `control_plane.py` — `mission_checkpoint_dir`, `require_mission`, `build_mission_{status,result,artifacts}_payload` (JSON-serialisable dicts for the slice-4/5 CLI), `build_fallback_verifier` (subgoal-coverage shape with `autoVerifier=none/subgoals`), `run_mission_loop` (legacy subgoal-stepping with rehydrate + fallback; code-mission verifier-rejected -> downgrade to `failed`; canonical checkpoint write before return).
- `manager.py` — new `save_checkpoint(mission_id, checkpoint_dir)` method delegating to the checkpoint module via a local import.

The adaptive LLM-driven mission loop (TS `adaptive-executor.ts`) is deferred until the package-wide LLM provider plumbing lands in a follow-up slice; the legacy loop already covers the slice-4 `autoctx mission run` path.

## Test plan

- [x] `uv run pytest tests/mission/` (115 passed: 74 prior + 41 new)
- [x] `uv run pytest tests/test_module_size_limits.py` clean
- [x] `uv run ruff check` clean
- [x] `uv run mypy src/autocontext/mission/` clean
- [ ] CI: green

## Slice plan (5 PRs total)

- slice 1 (#1014, merged): SQLite store + Pydantic models
- slice 2 (#1015, merged): MissionManager + verifiers + planner
- **slice 3 (this PR)**: control-plane workflows
- slice 4: CLI subcommands (create / run / status / artifacts)
- slice 5: lifecycle subcommands + contract flip + README