### PR TITLE
feat(cli): AC-697 mission Python parity slice 5 (pause/resume/cancel + README)

### DIFF
--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -351,7 +351,7 @@ uv run autoctx mission create \
 uv run autoctx mission run --id <mission_id> --max-iterations 5 --json
 ```
 
-Status transitions are enforced by the slice-2 transition table (e.g. `paused -> completed` rejects; `canceled` and `completed` are terminal). An invalid transition surfaces a clear error and does not mutate state. Async verifiers and async step executors are supported; the CLI is a sync entry point so they cannot be combined with a running event loop (calling from inside an active loop raises `AsyncContextError` before any state mutation).
+Status transitions are enforced by the slice-2 transition table. Only `completed` is truly terminal (self-loop only). `canceled` can be reopened via `resume` (e.g. an operator who changes their mind), so a `mission cancel` followed by `mission resume` returns the mission to `active`. `paused -> completed` rejects because the verifier must observe a live mission. An invalid transition surfaces a clear error and does not mutate state. Async verifiers and async step executors are supported; the CLI is a sync entry point so they cannot be combined with a running event loop (calling from inside an active loop raises `AsyncContextError` before any state mutation).
 
 ## Training Workflow
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -202,6 +202,14 @@ uv run autoctx probes check --suite contract-probes.json
 uv run autoctx probes check --suite contract-probes.json --json
 uv run autoctx probes extract --trace harness-trace.json
 uv run autoctx probes extract --trace harness-trace.json --output contract-probes.json
+uv run autoctx mission create --name "Ship login" --goal "Implement OAuth"
+uv run autoctx mission run --id <mission_id> --max-iterations 3 --json
+uv run autoctx mission status --id <mission_id> --json
+uv run autoctx mission list --status active --json
+uv run autoctx mission pause --id <mission_id>
+uv run autoctx mission resume --id <mission_id>
+uv run autoctx mission cancel --id <mission_id>
+uv run autoctx mission artifacts --id <mission_id> --json
 uv run autoctx wait <condition_id> --json
 ```
 
@@ -305,6 +313,45 @@ Slice 5 covers the four base probe kinds (`terminal`, `directory`, `service`, `a
   }
 }
 ```
+
+## Missions
+
+`uv run autoctx mission ...` manages long-running, verifier-driven missions. A mission bundles a goal, a budget, a status that follows the state-machine table (active / paused / blocked / completed / failed / canceled / budget_exhausted / verifier_failed), and an optional verifier that gates completion. Two flavours land:
+
+- Generic missions advance via a subgoal-stepping loop; the fallback verifier passes once every subgoal reaches a terminal state.
+- Code missions register a `CodeMissionSpec` whose `test_command` (and optional `lint_command` / `build_command`) is wrapped in a `CommandVerifier` (composite when multiple commands are supplied). A code mission rejected by its verifier is downgraded from `active` to `failed` when the run loop returns.
+
+Every subcommand emits human-readable text by default and a structured JSON payload under `--json`. Errors route to stderr so JSON consumers can safely parse stdout on failure paths. State persists under `settings.db_path`; each `create` / `run` / `pause` / `resume` / `cancel` action writes a fresh checkpoint under `<settings.runs_root>/missions/<mission_id>/checkpoints/`. The checkpoint filename embeds nanosecond resolution + an 8-char uuid suffix so concurrent writes never collide; loaders accept both Python-shaped (snake_case) and TS-shaped (camelCase) checkpoints so a shared `AUTOCONTEXT_DB_PATH` can resume from either runtime.
+
+Minimal end-to-end (generic mission):
+
+```bash
+uv run autoctx mission create --name "Ship login" --goal "Implement OAuth" --json
+# -> {"id": "mission-abc12345", "status": "active", ...}
+uv run autoctx mission run --id mission-abc12345 --max-iterations 3 --json
+# -> {"id": "...", "finalStatus": "active", "stepsExecuted": 3, "verifierPassed": false, ...}
+uv run autoctx mission status --id mission-abc12345 --json
+uv run autoctx mission pause --id mission-abc12345 --json
+uv run autoctx mission cancel --id mission-abc12345 --json
+uv run autoctx mission artifacts --id mission-abc12345 --json
+```
+
+Code mission example:
+
+```bash
+uv run autoctx mission create \
+  --type code \
+  --name "Fix login" \
+  --goal "Tests pass" \
+  --repo-path . \
+  --test-command "pytest -x" \
+  --lint-command "ruff check src" \
+  --max-steps 5 \
+  --json
+uv run autoctx mission run --id <mission_id> --max-iterations 5 --json
+```
+
+Status transitions are enforced by the slice-2 transition table (e.g. `paused -> completed` rejects; `canceled` and `completed` are terminal). An invalid transition surfaces a clear error and does not mutate state. Async verifiers and async step executors are supported; the CLI is a sync entry point so they cannot be combined with a running event loop (calling from inside an active loop raises `AsyncContextError` before any state mutation).
 
 ## Training Workflow
 

--- a/autocontext/src/autocontext/cli_mission.py
+++ b/autocontext/src/autocontext/cli_mission.py
@@ -57,6 +57,9 @@ Subcommands:
   run        Advance a mission and write a checkpoint
   status     Show mission details
   list       List all missions
+  pause      Pause an active mission
+  resume     Resume a paused mission
+  cancel     Cancel a mission (terminal)
   artifacts  Inspect saved mission checkpoints
 
 Examples:
@@ -65,6 +68,9 @@ Examples:
   autoctx mission run --id mission-abc123 --max-iterations 3
   autoctx mission list --status active
   autoctx mission status --id mission-abc123
+  autoctx mission pause --id mission-abc123
+  autoctx mission resume --id mission-abc123
+  autoctx mission cancel --id mission-abc123
   autoctx mission artifacts --id mission-abc123
 """
 
@@ -422,5 +428,64 @@ def register_mission_command(app: typer.Typer, *, console: Console) -> None:
             print(json.dumps(payload, indent=2))
         else:
             console.print(_render_mission_artifacts_text(payload))
+
+    def _lifecycle(
+        action: str,
+        *,
+        mission_id: str,
+        json_output: bool,
+    ) -> None:
+        """Slice-5 shared lifecycle body. ``action`` is one of
+        ``pause`` / ``resume`` / ``cancel``; mirrors the TS
+        `executeMissionLifecycleCommand` shape: the manager applies
+        the transition (which raises on an invalid one), a fresh
+        checkpoint is written under the canonical mission directory,
+        and the status payload is emitted with `checkpointPath`
+        appended.
+        """
+        if not mission_id:
+            _write_error_stderr(f"autoctx mission {action}: --id <mission-id> is required")
+            raise typer.Exit(code=1)
+        settings = load_settings()
+        with _mission_manager(settings) as mgr:
+            try:
+                getattr(mgr, action)(mission_id)
+            except ValueError as err:
+                _write_error_stderr(f"autoctx mission {action}: {err}")
+                raise typer.Exit(code=1) from err
+            try:
+                payload = _checkpoint_payload(mgr, mission_id, _checkpoint_runs_root(settings))
+            except ValueError as err:
+                _write_error_stderr(f"autoctx mission {action}: {err}")
+                raise typer.Exit(code=1) from err
+        if json_output:
+            print(json.dumps(payload, indent=2))
+        else:
+            console.print(_render_mission_status_text(payload))
+
+    @mission_app.command("pause")
+    def _pause(
+        mission_id: str = typer.Option("", "--id", help="Mission id."),
+        json_output: bool = typer.Option(False, "--json", help="Emit a structured JSON payload."),
+    ) -> None:
+        """Pause an active mission. Writes a fresh checkpoint after the
+        transition so the artifacts surface stays in sync."""
+        _lifecycle("pause", mission_id=mission_id, json_output=json_output)
+
+    @mission_app.command("resume")
+    def _resume(
+        mission_id: str = typer.Option("", "--id", help="Mission id."),
+        json_output: bool = typer.Option(False, "--json", help="Emit a structured JSON payload."),
+    ) -> None:
+        """Resume a paused mission back to ``active``."""
+        _lifecycle("resume", mission_id=mission_id, json_output=json_output)
+
+    @mission_app.command("cancel")
+    def _cancel(
+        mission_id: str = typer.Option("", "--id", help="Mission id."),
+        json_output: bool = typer.Option(False, "--json", help="Emit a structured JSON payload."),
+    ) -> None:
+        """Cancel a mission. Terminal: the mission cannot be reopened."""
+        _lifecycle("cancel", mission_id=mission_id, json_output=json_output)
 
     app.add_typer(mission_app, name="mission")

--- a/autocontext/src/autocontext/cli_mission.py
+++ b/autocontext/src/autocontext/cli_mission.py
@@ -58,8 +58,8 @@ Subcommands:
   status     Show mission details
   list       List all missions
   pause      Pause an active mission
-  resume     Resume a paused mission
-  cancel     Cancel a mission (terminal)
+  resume     Resume a paused, blocked, or canceled mission back to active
+  cancel     Cancel a mission (reopen with `resume` if needed)
   artifacts  Inspect saved mission checkpoints
 
 Examples:
@@ -485,7 +485,9 @@ def register_mission_command(app: typer.Typer, *, console: Console) -> None:
         mission_id: str = typer.Option("", "--id", help="Mission id."),
         json_output: bool = typer.Option(False, "--json", help="Emit a structured JSON payload."),
     ) -> None:
-        """Cancel a mission. Terminal: the mission cannot be reopened."""
+        """Cancel a mission. Per the slice-2 transition table only
+        ``completed`` is truly terminal; ``canceled`` can be reopened
+        via ``resume`` if the operator changes their mind."""
         _lifecycle("cancel", mission_id=mission_id, json_output=json_output)
 
     app.add_typer(mission_app, name="mission")

--- a/autocontext/tests/mission/test_cli_mission.py
+++ b/autocontext/tests/mission/test_cli_mission.py
@@ -303,6 +303,85 @@ def test_help_text_lists_slice_4_subcommands() -> None:
         assert sub in MISSION_HELP_TEXT
 
 
+# ---------------------------------------------------------------------------
+# slice 5: pause / resume / cancel
+# ---------------------------------------------------------------------------
+
+
+def _create_mission(runner: CliRunner) -> str:
+    result = runner.invoke(app, ["mission", "create", "--name", "x", "--goal", "g", "--json"])
+    assert result.exit_code == 0, result.output
+    return json.loads(result.stdout)["id"]
+
+
+def test_cli_pause_then_resume_round_trips_status(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _env_isolated(monkeypatch, tmp_path)
+    runner = CliRunner()
+    mid = _create_mission(runner)
+
+    paused = runner.invoke(app, ["mission", "pause", "--id", mid, "--json"])
+    assert paused.exit_code == 0, paused.output
+    paused_payload = json.loads(paused.stdout)
+    assert paused_payload["status"] == "paused"
+    assert Path(paused_payload["checkpointPath"]).is_file()
+
+    resumed = runner.invoke(app, ["mission", "resume", "--id", mid, "--json"])
+    assert resumed.exit_code == 0
+    assert json.loads(resumed.stdout)["status"] == "active"
+
+
+def test_cli_cancel_marks_mission_canceled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _env_isolated(monkeypatch, tmp_path)
+    runner = CliRunner()
+    mid = _create_mission(runner)
+    result = runner.invoke(app, ["mission", "cancel", "--id", mid, "--json"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["status"] == "canceled"
+
+
+def test_cli_resume_from_active_is_a_lawful_self_loop(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The slice-2 transition table allows ``active -> active`` as a
+    self-loop; resume on an active mission should be a clean no-op
+    rather than raising."""
+    _env_isolated(monkeypatch, tmp_path)
+    runner = CliRunner()
+    mid = _create_mission(runner)
+    result = runner.invoke(app, ["mission", "resume", "--id", mid, "--json"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["status"] == "active"
+
+
+def test_cli_pause_after_cancel_rejects_with_clear_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`canceled -> paused` is not allowed; the manager raises and the
+    CLI surfaces the slice-2 transition error rather than silently
+    persisting an invalid state change."""
+    _env_isolated(monkeypatch, tmp_path)
+    runner = CliRunner()
+    mid = _create_mission(runner)
+    runner.invoke(app, ["mission", "cancel", "--id", mid, "--json"])
+    result = runner.invoke(app, ["mission", "pause", "--id", mid])
+    assert result.exit_code == 1
+
+
+@pytest.mark.parametrize("action", ["pause", "resume", "cancel"])
+def test_cli_lifecycle_rejects_missing_id(action: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _env_isolated(monkeypatch, tmp_path)
+    result = CliRunner().invoke(app, ["mission", action])
+    assert result.exit_code == 1
+
+
+@pytest.mark.parametrize("action", ["pause", "resume", "cancel"])
+def test_cli_lifecycle_rejects_unknown_id(action: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _env_isolated(monkeypatch, tmp_path)
+    result = CliRunner().invoke(app, ["mission", action, "--id", "mission-nope"])
+    assert result.exit_code == 1
+
+
+def test_help_text_lists_slice_5_subcommands() -> None:
+    for sub in ("pause", "resume", "cancel"):
+        assert sub in MISSION_HELP_TEXT
+
+
 def test_contract_marks_mission_python_yes() -> None:
     """PR #1017 review (P3): registering the public command without
     flipping the contract entry would leave capability/contract

--- a/autocontext/tests/mission/test_cli_mission.py
+++ b/autocontext/tests/mission/test_cli_mission.py
@@ -339,6 +339,40 @@ def test_cli_cancel_marks_mission_canceled(monkeypatch: pytest.MonkeyPatch, tmp_
     assert json.loads(result.stdout)["status"] == "canceled"
 
 
+def test_cli_resume_after_cancel_reopens_mission(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """PR #1018 review (P2) alignment: the slice-2 transition table
+    allows ``canceled -> active``, so an operator can ``resume`` a
+    canceled mission. Only ``completed`` is truly terminal. Pin the
+    intended contract so docs and code stay aligned."""
+    _env_isolated(monkeypatch, tmp_path)
+    runner = CliRunner()
+    mid = _create_mission(runner)
+    runner.invoke(app, ["mission", "cancel", "--id", mid, "--json"])
+    result = runner.invoke(app, ["mission", "resume", "--id", mid, "--json"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["status"] == "active"
+
+
+def test_cli_completed_mission_cannot_be_reopened(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`completed` is the only truly-terminal status: the transition
+    table allows only ``completed -> completed`` so ``resume`` /
+    ``pause`` / ``cancel`` all reject."""
+    from autocontext.config import load_settings
+    from autocontext.mission import MissionManager
+
+    _env_isolated(monkeypatch, tmp_path)
+    runner = CliRunner()
+    mid = _create_mission(runner)
+    # Directly force the mission to `completed` to exercise the
+    # rejection branch; the CLI doesn't surface a manual
+    # "complete" affordance.
+    with MissionManager(str(load_settings().db_path)) as mgr:
+        mgr.set_status(mid, "completed")
+    for action in ("pause", "resume", "cancel"):
+        result = runner.invoke(app, ["mission", action, "--id", mid])
+        assert result.exit_code == 1, f"{action} should reject on completed mission"
+
+
 def test_cli_resume_from_active_is_a_lawful_self_loop(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """The slice-2 transition table allows ``active -> active`` as a
     self-loop; resume on an active mission should be a clean no-op

--- a/docs/concept-model.md
+++ b/docs/concept-model.md
@@ -13,7 +13,7 @@ The repo already has strong runtime primitives, but the vocabulary is not yet un
 
 - `Task` means at least three different things today: an agent-task spec, a queued evaluation job, and a generic prompt.
 - `Scenario` is sometimes a simulation environment and sometimes the saved wrapper around an agent task.
-- `Mission` exists as a real TypeScript control-plane concept, but not yet as a shared repo-wide one.
+- `Mission` is a shared control-plane concept in both TypeScript and Python; Python parity shipped under AC-697 (`autoctx mission create / run / status / list / pause / resume / cancel / artifacts`).
 - `Campaign` now has partial TypeScript CLI/API/MCP support, but it is not yet a Python package surface.
 - `solve`, `sandbox`, `replay`, `playbook`, and `artifacts` are often presented like peer concepts even though they are better understood as operations or runtime outputs.
 
@@ -23,12 +23,12 @@ The repo already has strong runtime primitives, but the vocabulary is not yet un
 
 These are the nouns we should prefer in docs, APIs, and product copy when describing what the system helps a person do.
 
-| Concept    | Definition                                                                                                                  | Current status                                                                                                                                   |
-| ---------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Scenario` | A reusable environment, simulation, or evaluation context with stable rules and scoring.                                    | Implemented across Python, TypeScript, CLI, MCP, API/TUI surfaces, and docs.                                                                     |
-| `Task`     | A user-authored unit of work or prompt-centric objective that can be evaluated directly or embedded inside another surface. | Partial: prompt-centric task support exists, but the name is still overloaded across agent-task specs, queued runtime jobs, and generic prompts. |
-| `Mission`  | A long-running goal advanced step by step until a verifier says it is complete.                                             | Partial: implemented in TypeScript CLI/MCP/API/TUI surfaces, but not yet a shared Python package concept.                                        |
-| `Campaign` | A planned grouping of missions, runs, and/or scenarios used to coordinate broader work over time.                           | Partially implemented through TypeScript CLI/API/MCP surfaces. Not yet a Python package surface.                                                 |
+| Concept    | Definition                                                                                                                  | Current status                                                                                                                                                                                |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Scenario` | A reusable environment, simulation, or evaluation context with stable rules and scoring.                                    | Implemented across Python, TypeScript, CLI, MCP, API/TUI surfaces, and docs.                                                                                                                  |
+| `Task`     | A user-authored unit of work or prompt-centric objective that can be evaluated directly or embedded inside another surface. | Partial: prompt-centric task support exists, but the name is still overloaded across agent-task specs, queued runtime jobs, and generic prompts.                                              |
+| `Mission`  | A long-running goal advanced step by step until a verifier says it is complete.                                             | Implemented across both TypeScript and Python (Python parity under AC-697: `autocontext.mission` package + `autoctx mission ...` CLI). MCP / API / TUI surfaces remain TypeScript-only today. |
+| `Campaign` | A planned grouping of missions, runs, and/or scenarios used to coordinate broader work over time.                           | Partially implemented through TypeScript CLI/API/MCP surfaces. Not yet a Python package surface.                                                                                              |
 
 ### Runtime concepts
 
@@ -116,8 +116,7 @@ Python and TypeScript command grants use the same runtime-session event vocabula
 ## Current Gaps And Risks
 
 - `Campaign` now has a TypeScript storage model plus API/MCP surfaces, but it still lacks a shared CLI workflow and Python package support.
-- Python and TypeScript both have strong `Scenario` and `Run` surfaces, but only TypeScript currently has a first-class `Mission` model.
-- The TypeScript package exposes both `Scenario` execution and `Mission` control-plane features, while the Python package is still more `Scenario`/`Run`/`Knowledge` centric.
+- Python and TypeScript both have strong `Scenario`, `Run`, and `Mission` surfaces. Python `Mission` parity shipped under AC-697 (`autocontext.mission` package + `autoctx mission ...` CLI); the MCP / API / TUI mission surfaces are TypeScript-only today.
 - Queueing and evaluation code use `Task` for runtime jobs, which collides with the intended user-facing `Task` concept.
 - `Policy` exists in many specific forms, but not yet as a discoverable shared runtime concept.
 


### PR DESCRIPTION
## Summary

Final slice (5 of 5) in the AC-697 mission Python parity plan.

- `mission pause` / `mission resume` / `mission cancel` route through a shared `_lifecycle` body mirroring TS `executeMissionLifecycleCommand`: manager applies the transition (raises on invalid via the slice-2 transition table), checkpoint written, status payload emitted with `checkpointPath`.
- `MISSION_HELP_TEXT` lists all eight subcommands.
- `autocontext/README.md` Main CLI Commands block lists the eight new mission lines; a new "Missions" section documents the state-machine, generic vs code missions, `--json` contract, checkpoint dir, slice-3 collision-free filenames + camelCase compat, slice-2 async support + `AsyncContextError` guard.

## Test plan

- [x] `uv run pytest tests/mission/` (154 passed: 143 prior + 11 new)
- [x] `uv run pytest tests/test_module_size_limits.py` clean (`cli_mission.py` 491 lines)
- [x] `uv run ruff check` clean
- [x] `uv run mypy src/autocontext/cli_mission.py` clean
- [ ] CI: green

## AC-697 mission Python parity (closed with this PR)

- slice 1 (#1014, merged): SQLite store + Pydantic models
- slice 2 (#1015, merged): MissionManager + verifiers + planner
- slice 3 (#1016, merged): control-plane workflows
- slice 4 (#1017, merged): CLI subcommands create / run / status / list / artifacts + contract flip
- **slice 5 (this PR)**: lifecycle subcommands pause / resume / cancel + README

The mission contract entry is already at `python: yes` from the slice-4 follow-up. Closes the last AC-697 contract gap.