### PR TITLE
docs: Fumadocs-ready developer documentation (content)

### DIFF
--- a/apps/docs/content/docs/VERIFICATION.md
+++ b/apps/docs/content/docs/VERIFICATION.md
@@ -1,0 +1,57 @@
+# Documentation verification log
+
+This documentation tree was authored Fumadocs-ready (MDX + per-folder `meta.json`)
+and verified section by section against the autocontext repo source. The Next.js +
+Fumadocs application is intentionally not built here; this is content only.
+
+## Site-wide audits (final consistency pass)
+
+- Page count: 43 `.mdx` pages.
+- Frontmatter: every page begins with valid frontmatter carrying `title` and `description`.
+- Style: zero em dashes across the tree (house rule); "autocontext" lowercase in prose,
+  with `AutoContext` retained only as the literal Python class identifier.
+- Navigation: every section directory has a `meta.json`; all are valid JSON and list every
+  sibling page and subdirectory (no orphan pages).
+- Links: all 37 distinct internal `/docs/...` links resolve to an existing page or folder index.
+
+## Per-section source verification
+
+- **Get Started / Concepts / CLI**: command and flag claims verified against the repo CLI
+  source (`autocontext/src/autocontext/cli.py`, `cli_run_inspect.py`, `cli_solve.py`,
+  `cli_queue.py`, `ts/src/cli/index.ts`, `ts/src/cli/command-registry.ts`). The installed
+  `autoctx` binary is a stale older version, so the repo source was treated as the source of
+  truth. Corrections made during authoring: `queue add` uses `--rounds`/`-n` (not
+  `--max-rounds`); `show`/`watch` exist on both runtimes; `ab-test` uses `--baseline`/
+  `--treatment` env-override flags; redundant identical Python/TS tabs were collapsed.
+- **On-disk layout** (concepts, get-started): verified against `storage/artifacts.py`,
+  `knowledge/lessons.py`, `knowledge/research_hub.py`. Per-generation artifacts at
+  `runs/<run_id>/generations/gen_<N>/`; knowledge at `knowledge/<scenario>/` with
+  `playbook.md`, `hints.md`, `lessons.json` (JSON), `snapshots/<run_id>/`, and
+  `reports/<run_id>.md`. There is no top-level `runs/<run_id>/trace.jsonl` or `report.md`.
+- **Providers**: provider enum, defaults, and env vars verified against
+  `agents/llm_client.py` (`build_client_from_settings`), `providers/registry.py`,
+  `config/settings.py`, `.env.example`, and `runtimes/pi_cli.py` / `pi_rpc.py`. The code
+  default provider is `anthropic` (`.env.example` ships `deterministic` as a template only).
+  `pi-rpc` is a JSONL subprocess, not HTTP (the docs match source over a stale CLAUDE.md).
+  gemini/mistral/groq/openrouter/azure are reachable via `openai-compatible`, not enum values.
+- **Agent integration**: MCP tool names verified against `autocontext/src/autocontext/mcp/`
+  and `ts/src/mcp/`; `pi install npm:pi-autocontext` verified against `pi/package.json`; the
+  Claude Code `mcpServers` JSON verified runnable.
+- **SDK**: `AutoContext` method signatures verified against `sdk.py` / `sdk_models.py`; TS
+  exports verified against `ts/src/index.ts`; all 12 hook events verified against the
+  `HookEvents` enum in `extensions/hooks.py`.
+- **Guides**: faithful rewrites of `docs/mlx-training.md`, `docs/sandbox.md`,
+  `docs/persistent-host.md`, `docs/fixture-loader.md` (scripts, systemd units, plists, and
+  manifests reproduced); `production-traces` subcommands verified against
+  `ts/src/production-traces/cli/index.ts` (init, ingest, list, show, stats, build-dataset,
+  datasets, export, policy, rotate-salt, prune).
+- **Reference**: 46 environment variables generated row-by-row from `.env.example` (names and
+  defaults match the file 1:1); MCP tool catalog generated from source (72 Python tools, 76
+  TypeScript tools, cross-checked against the registrations); glossary terms link to their
+  fuller treatments.
+
+## Deferred (out of scope for this pass)
+
+- The Next.js + Fumadocs application (`source.config.ts`, theming, search, deploy).
+- Marketing-site linking.
+- Auto-generated API reference tooling and versioned docs.

--- a/apps/docs/content/docs/agents/claude-code.mdx
+++ b/apps/docs/content/docs/agents/claude-code.mdx
@@ -5,6 +5,16 @@ description: Add autocontext to Claude Code as an MCP server.
 
 Claude Code connects to autocontext through the [MCP server](/docs/agents/mcp). You register the server once in your project settings, and Claude Code launches it on stdio whenever it needs an autocontext tool.
 
+## Prerequisites
+
+The command in the configuration below runs `autoctx mcp-serve` from your autocontext checkout, which requires the Python MCP extra to be installed in that checkout first:
+
+```bash
+uv sync --group dev --extra mcp
+```
+
+See [MCP Server](/docs/agents/mcp) for more on starting the server.
+
 ## Configure the MCP server
 
 Add an entry to your project's `.claude/settings.json` under `mcpServers`:
@@ -24,7 +34,7 @@ Add an entry to your project's `.claude/settings.json` under `mcpServers`:
 }
 ```
 
-Replace `/path/to/autocontext` with the absolute path to your autocontext checkout. The `env` block sets the provider that decides where your agent roles run. The example above routes to a local Pi runtime, but you can use any provider: see [Providers](/docs/providers) for the full set of `env` choices (hosted API, local server, MLX, or another coding-agent CLI).
+Replace `/path/to/autocontext` with the absolute path to your autocontext checkout. The `env` block sets the provider that decides where your agent roles run. The example above routes to a local Pi runtime, which assumes the `pi` CLI is installed and on your PATH. You can swap in any provider: see [Providers](/docs/providers) for the full set of `env` choices (hosted API, local server, MLX, or another coding-agent CLI), and set the matching env vars there.
 
 <Callout type="info">
 The `mcp-serve` and `serve mcp` commands are equivalent. The configuration above uses `mcp-serve`; `serve mcp` works identically if you prefer the canonical form.

--- a/apps/docs/content/docs/agents/claude-code.mdx
+++ b/apps/docs/content/docs/agents/claude-code.mdx
@@ -60,4 +60,4 @@ Claude Code exposes the autocontext tools under their published, `autocontext_`-
 - `autocontext_run_status`
 - `autocontext_list_scenarios`
 
-The Python server publishes roughly 60 tools in total. For the full catalog see [the MCP tool reference](/docs/reference/mcp-tools), and for the tool families and how to start the server see [MCP Server](/docs/agents/mcp).
+The Python server publishes more than 70 tools in total. For the full catalog see [the MCP tool reference](/docs/reference/mcp-tools), and for the tool families and how to start the server see [MCP Server](/docs/agents/mcp).

--- a/apps/docs/content/docs/agents/claude-code.mdx
+++ b/apps/docs/content/docs/agents/claude-code.mdx
@@ -1,0 +1,53 @@
+---
+title: Claude Code
+description: Add autocontext to Claude Code as an MCP server.
+---
+
+Claude Code connects to autocontext through the [MCP server](/docs/agents/mcp). You register the server once in your project settings, and Claude Code launches it on stdio whenever it needs an autocontext tool.
+
+## Configure the MCP server
+
+Add an entry to your project's `.claude/settings.json` under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "autocontext": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/autocontext", "autoctx", "mcp-serve"],
+      "env": {
+        "AUTOCONTEXT_AGENT_PROVIDER": "pi",
+        "AUTOCONTEXT_PI_COMMAND": "pi"
+      }
+    }
+  }
+}
+```
+
+Replace `/path/to/autocontext` with the absolute path to your autocontext checkout. The `env` block sets the provider that decides where your agent roles run. The example above routes to a local Pi runtime, but you can use any provider: see [Providers](/docs/providers) for the full set of `env` choices (hosted API, local server, MLX, or another coding-agent CLI).
+
+<Callout type="info">
+The `mcp-serve` and `serve mcp` commands are equivalent. The configuration above uses `mcp-serve`; `serve mcp` works identically if you prefer the canonical form.
+</Callout>
+
+## Use it in natural language
+
+Once the server is registered, Claude Code discovers the autocontext tools and you can drive them with plain requests:
+
+> Solve: improve customer-support replies for billing disputes.
+
+> Judge this output against this rubric and improve it until it scores 0.85.
+
+Claude Code maps these to the underlying tools (`autocontext_solve_scenario`, `autocontext_evaluate_output`, `autocontext_run_improvement_loop`) and reads the JSON results back into the conversation.
+
+## Tool names you will see
+
+Claude Code exposes the autocontext tools under their published, `autocontext_`-prefixed names. The headline ones:
+
+- `autocontext_solve_scenario`
+- `autocontext_evaluate_output`
+- `autocontext_run_improvement_loop`
+- `autocontext_run_status`
+- `autocontext_list_scenarios`
+
+The Python server publishes roughly 60 tools in total. For the full catalog see [the MCP tool reference](/docs/reference/mcp-tools), and for the tool families and how to start the server see [MCP Server](/docs/agents/mcp).

--- a/apps/docs/content/docs/agents/hermes.mdx
+++ b/apps/docs/content/docs/agents/hermes.mdx
@@ -1,0 +1,52 @@
+---
+title: Hermes
+description: Use autocontext from Hermes with a CLI-first skill.
+---
+
+Hermes drives autocontext through a CLI-first skill. Rather than wiring up a tool catalog, you install an autocontext skill into the active Hermes profile and Hermes drives `autoctx` commands directly, using `--json` output and standard shell primitives. This keeps the integration simple: text in, JSON out, explicit exit codes.
+
+<Callout type="info">
+The CLI-first path is recommended for getting started with Hermes. autocontext also ships an MCP server and an OpenAI-compatible provider for Hermes if your environment specifically needs them, but the skill is the lowest-complexity option. See the canonical agent integration guide at `docs/agent-integration.md` in the autocontext repository for those alternatives.
+</Callout>
+
+## Install the skill
+
+Export the Hermes-facing autocontext skill into the active Hermes profile:
+
+```bash
+autoctx hermes export-skill --output ~/.hermes/skills/autocontext/SKILL.md --json
+```
+
+To also write the progressive-disclosure reference files alongside `SKILL.md`, add `--with-references`:
+
+```bash
+autoctx hermes export-skill \
+  --output ~/.hermes/skills/autocontext/SKILL.md \
+  --with-references --json
+```
+
+Once the skill is in place, the Hermes agent can drive autocontext through the same `autoctx` commands a human would run: `autoctx solve`, `autoctx run`, `autoctx status`, and `autoctx export`, each with `--json` for machine-readable output.
+
+## Inspect Hermes Curator state
+
+The skill can read Hermes state without an MCP connection. `autoctx hermes inspect` produces a read-only inventory of the Hermes profile's skills, usage telemetry, and Curator reports:
+
+```bash
+# Inventory of the default Hermes home
+autoctx hermes inspect --json
+
+# Inspect a non-default profile
+autoctx hermes inspect --home "$HERMES_HOME" --json
+```
+
+This is read-only against the Hermes home, so it is safe to run before any autocontext run that consumes local Hermes data.
+
+## Skill export and distribution
+
+`export-skill` writes the rendered `SKILL.md` (and optional `references/` files) so Hermes can load it directly. autocontext also commits a snapshot of the skill at the repository root, which you can install instead of regenerating it.
+
+For installation alternatives (including `curl` and sparse-clone approaches for distributing the skill without a full checkout), see `docs/hermes-skill-distribution.md` in the autocontext repository.
+
+<Callout type="info">
+The full Hermes integration, including the CLI-first starter workflow, Curator dataset ingestion, and the OpenAI-compatible and MCP alternatives, is documented in `docs/agent-integration.md` in the autocontext repository.
+</Callout>

--- a/apps/docs/content/docs/agents/index.mdx
+++ b/apps/docs/content/docs/agents/index.mdx
@@ -1,0 +1,41 @@
+---
+title: Agent Integration
+description: Wire autocontext into your coding agent via CLI skill or MCP.
+---
+
+autocontext is built to be driven by another agent. Your coding agent (Claude Code, Pi, Hermes, or anything that can run a shell command) calls autocontext to solve a scenario, judge an output against a rubric, or run an improvement loop, then reads the result back. There are two ways to wire this up.
+
+## Why CLI-first
+
+The `autoctx` CLI is the default integration surface, and Unix-style command-line interfaces turn out to be a natural fit for LLM agents:
+
+- **Everything is text.** Commands take text arguments and return text output. There is no serialization protocol to negotiate.
+- **Commands compose cleanly.** Pipe, redirect, and chain with `&&`: standard shell patterns that agents already handle well.
+- **Success and failure are explicit.** Exit code 0 means success, non-zero means failure. There are no ambiguous status fields to parse.
+- **stdout and stderr separation is a proven contract.** Data goes to stdout (use `--json` for a machine-readable payload), diagnostics and errors go to stderr.
+- **Agents already perform well with shell-style interaction.** Most LLM agents have extensive training on CLI usage.
+
+In practice, users report smoother integrations via the CLI than via MCP: it is simpler to set up, easier to debug, and more predictable.
+
+<Callout type="info">
+If your agent can run shell commands, start with a CLI-backed skill. Reach for MCP only when your runtime specifically wants a typed tool catalog or when host policy makes discovery worth the extra setup.
+</Callout>
+
+## Two integration patterns
+
+### CLI-backed skill
+
+A skill is a set of natural-language wrappers over the `autoctx` CLI. Your agent reads short instructions ("to solve a scenario, run `autoctx solve ... --json`") and drives autocontext through the same commands a human would type. This keeps the contract simple: text in, JSON out, explicit exit codes. The [Pi skill](/docs/agents/pi-skill) and the [Hermes](/docs/agents/hermes) integration both follow this pattern.
+
+### MCP tool catalog
+
+The [MCP server](/docs/agents/mcp) exposes autocontext as a catalog of typed tools over stdio. Your agent discovers tools (`autocontext_solve_scenario`, `autocontext_evaluate_output`, and the rest) and invokes them through the MCP protocol instead of through a shell. Use this when your runtime expects MCP discovery, or when you want autocontext to appear alongside other tool providers in a multi-tool agent. [Claude Code](/docs/agents/claude-code) connects this way.
+
+## Pick your agent
+
+- **[MCP Server](/docs/agents/mcp)**: start the server, understand the tool families, both runtimes.
+- **[Claude Code](/docs/agents/claude-code)**: add autocontext to `.claude/settings.json` as an MCP server.
+- **[Pi Skill](/docs/agents/pi-skill)**: `pi install npm:pi-autocontext` for a natural-language entry point.
+- **[Hermes](/docs/agents/hermes)**: a CLI-first skill that also inspects Hermes Curator state.
+
+For the environment variables that decide where your agent roles run, see [Providers](/docs/providers).

--- a/apps/docs/content/docs/agents/mcp.mdx
+++ b/apps/docs/content/docs/agents/mcp.mdx
@@ -32,7 +32,7 @@ The server inherits its provider configuration from the environment it is launch
 
 ## Python tools
 
-The Python server exposes roughly 60 tools, all carrying the `autocontext_` prefix. Rather than enumerate them here, the headline tools grouped by purpose:
+The Python server exposes more than 70 tools (the full catalog is in [the MCP tools reference](/docs/reference/mcp-tools)), all carrying the `autocontext_` prefix. Rather than enumerate them here, the headline tools grouped by purpose:
 
 ### Solve, evaluate, improve, status
 

--- a/apps/docs/content/docs/agents/mcp.mdx
+++ b/apps/docs/content/docs/agents/mcp.mdx
@@ -1,0 +1,93 @@
+---
+title: MCP Server
+description: Expose autocontext as MCP tools over stdio.
+---
+
+The MCP server presents autocontext as a catalog of typed tools that an MCP-aware agent can discover and invoke. Both the Python and TypeScript runtimes ship an MCP server, and both speak the stdio transport.
+
+## Starting the server
+
+The canonical command is `serve mcp`, with `mcp-serve` kept as an alias. Either works on both runtimes:
+
+```bash
+# Canonical
+autoctx serve mcp
+
+# Alias
+autoctx mcp-serve
+```
+
+On the Python runtime, install the MCP extras first, then start the server:
+
+```bash
+uv sync --group dev --extra mcp
+uv run autoctx mcp-serve
+```
+
+The server communicates over stdio, so you do not run it standalone in a terminal for normal use. Instead, your agent host (Claude Code, Hermes, or another MCP client) launches the command and connects to its stdin/stdout. See [Claude Code](/docs/agents/claude-code) for the host configuration.
+
+<Callout type="info">
+The server inherits its provider configuration from the environment it is launched in. Set `AUTOCONTEXT_AGENT_PROVIDER` and the related variables in the host's `env` block. See [Providers](/docs/providers).
+</Callout>
+
+## Python tools
+
+The Python server exposes roughly 60 tools, all carrying the `autocontext_` prefix. Rather than enumerate them here, the headline tools grouped by purpose:
+
+### Solve, evaluate, improve, status
+
+The core production-loop entry points:
+
+- `autocontext_solve_scenario`: solve a scenario on demand.
+- `autocontext_evaluate_output`: judge an output against a rubric.
+- `autocontext_run_improvement_loop`: run an iterative improvement loop.
+- `autocontext_run_status`: check the status of a run.
+- `autocontext_list_scenarios` and `autocontext_describe_scenario`: discover and inspect scenarios.
+
+### Knowledge readers
+
+Read the artifacts autocontext produces and consumes:
+
+- `autocontext_read_playbook`, `autocontext_read_hints`: read the strategy knowledge for a scenario.
+- `autocontext_search_strategies`: search across banked strategies.
+- `autocontext_export_skill`: export a scenario as an agent-loadable skill.
+
+### Runtime-session readers
+
+Inspect live and historical runtime sessions:
+
+- `autocontext_list_runs`, `autocontext_list_runtime_sessions`.
+- `autocontext_get_runtime_session`, `autocontext_get_runtime_session_timeline`.
+
+### Additional families
+
+The catalog also includes several families for more advanced workflows:
+
+- **Sandbox** (`autocontext_sandbox_create`, `autocontext_sandbox_run`, `autocontext_sandbox_destroy`, and more): stateful sandbox sessions.
+- **Monitors** (`autocontext_create_monitor`, `autocontext_list_monitors`, `autocontext_wait_for_monitor`, and more): production monitoring.
+- **Agent tasks** (`autocontext_create_agent_task`, `autocontext_get_agent_task`, `autocontext_export_agent_task_skill`, and more): judge-based agent task scenarios.
+- **Evidence** (`autocontext_evidence_list`, `autocontext_evidence_artifact`): evidence and artifact retrieval.
+
+For the complete, parameter-level catalog of all tools, see [the full MCP tool reference](/docs/reference/mcp-tools).
+
+## TypeScript tools
+
+The TypeScript server exposes a smaller, focused catalog organized into two families.
+
+### Solve family
+
+Submit a solve job, poll it, and retrieve the result:
+
+- `solve_scenario`, `solve_status`, `solve_result`.
+- The same operations are also published under the prefixed names `autocontext_solve_scenario`, `autocontext_solve_status`, and `autocontext_solve_result` for hosts that expect the `autocontext_` prefix.
+
+### Campaign and mission family
+
+Orchestrate multi-run campaigns and their missions:
+
+- `create_campaign`, `list_campaigns`, `campaign_status`, `campaign_progress`, `add_campaign_mission`, `pause_campaign`, `resume_campaign`, `cancel_campaign`.
+- `create_mission`, `mission_status`, `mission_result`, `mission_artifacts`, `pause_mission`, `resume_mission`, `cancel_mission`.
+
+<Callout type="info">
+Tool names appear differently depending on the host. Claude Code uses the names as published. Hermes registers MCP tools as `mcp_<server_name>_<tool_name>`, so `autocontext_list_scenarios` appears as `mcp_autocontext_list_scenarios`.
+</Callout>

--- a/apps/docs/content/docs/agents/meta.json
+++ b/apps/docs/content/docs/agents/meta.json
@@ -1,0 +1,1 @@
+{ "title": "Agent Integration", "pages": ["index", "mcp", "claude-code", "pi-skill", "hermes"] }

--- a/apps/docs/content/docs/agents/pi-skill.mdx
+++ b/apps/docs/content/docs/agents/pi-skill.mdx
@@ -1,0 +1,50 @@
+---
+title: Pi Skill
+description: Give Pi a natural-language entry point to autocontext.
+---
+
+The Pi skill gives a Pi agent a natural-language entry point to autocontext. It is a set of wrappers over autocontext's live tools, so Pi can solve scenarios, judge outputs, and run improvement loops by asking in plain language rather than constructing tool calls by hand.
+
+## Install
+
+Install the skill from npm with the Pi package manager:
+
+```bash
+pi install npm:pi-autocontext
+```
+
+You can also declare it in your Pi configuration:
+
+```json
+{
+  "packages": ["npm:pi-autocontext"]
+}
+```
+
+Once installed, Pi loads the natural-language wrappers and the underlying tools become available to the agent.
+
+## Wrapped tools
+
+The skill wraps autocontext's headline live tools:
+
+- `autocontext_solve_scenario`: solve a scenario on demand.
+- `autocontext_evaluate_output`: judge an output against a rubric.
+- `autocontext_run_improvement_loop`: run an iterative improvement loop.
+- `autocontext_run_status`: check the status of a run.
+- `autocontext_list_scenarios`: discover available scenarios.
+
+## Ask-style invocation
+
+Because the tools are wrapped in natural language, you drive them by asking:
+
+> Ask autocontext to solve: write a regression-safe migration plan for the billing schema.
+
+> Have autocontext judge this draft against the rubric and improve it until it scores at least 0.8.
+
+> List the scenarios autocontext knows about, then check the status of the last run.
+
+Pi translates each request into the matching wrapped tool and reads the result back.
+
+<Callout type="info">
+Pi handles its own authentication and model routing, so you do not set autocontext provider credentials for the skill to call Pi. For how the Pi runtime is configured, see [the Pi runtime](/docs/providers/pi).
+</Callout>

--- a/apps/docs/content/docs/cli/auth.mdx
+++ b/apps/docs/content/docs/cli/auth.mdx
@@ -5,6 +5,10 @@ description: Manage provider credentials and discover capabilities.
 
 These commands manage who autocontext talks to (provider credentials) and let you discover what your install can do (capabilities, scenarios, and a fresh project skeleton).
 
+<Callout type="warn">
+The credential-store and discovery commands on this page (`login`, `whoami`, `logout`, `providers`, `models`, `init`) are part of the TypeScript CLI (the npm `autoctx` build). They are not available on the Python CLI. On Python you configure providers through environment variables instead: set your credentials in the shell or a `.env` file and select a provider with `AUTOCONTEXT_AGENT_PROVIDER`. See [Providers](/docs/providers) and [Per-role and judge providers](/docs/providers/per-role-and-judge). The `capabilities` command works on both runtimes.
+</Callout>
+
 ## login
 
 `login` stores provider credentials persistently, so you do not have to keep setting environment variables:
@@ -12,6 +16,8 @@ These commands manage who autocontext talks to (provider credentials) and let yo
 ```bash
 autoctx login
 ```
+
+This is a TypeScript CLI command. Python users set credentials via environment variables (for example `ANTHROPIC_API_KEY`); there is no `autoctx login` on the Python runtime.
 
 ## whoami
 
@@ -21,6 +27,8 @@ autoctx login
 autoctx whoami
 ```
 
+TypeScript CLI command.
+
 ## logout
 
 `logout` clears stored provider credentials:
@@ -28,6 +36,8 @@ autoctx whoami
 ```bash
 autoctx logout
 ```
+
+TypeScript CLI command.
 
 ## providers
 
@@ -37,6 +47,8 @@ autoctx logout
 autoctx providers
 ```
 
+TypeScript CLI command.
+
 ## models
 
 `models` lists the available models for the providers you are authenticated against, as JSON:
@@ -45,13 +57,15 @@ autoctx providers
 autoctx models
 ```
 
+TypeScript CLI command.
+
 <Callout type="info">
 `providers` and `models` emit JSON by design, which makes them convenient to script against when selecting a model for a run.
 </Callout>
 
 ## capabilities
 
-`capabilities` shows the canonical command list, aliases, and per-runtime support. It is the authoritative way to see exactly which commands your install supports and whether each is implemented in Python, TypeScript, or both.
+`capabilities` shows the canonical command list, aliases, and per-runtime support. It is the authoritative way to see exactly which commands your install supports and whether each is implemented in Python, TypeScript, or both. It works on both runtimes.
 
 ```bash
 # Human-readable summary
@@ -69,6 +83,24 @@ autoctx capabilities --json
 autoctx init
 ```
 
+TypeScript CLI command.
+
+## Configuring providers on Python
+
+Python users do not use `login`, `whoami`, `logout`, `providers`, `models`, or `init`. Instead, select a provider and supply its credentials through environment variables:
+
+```bash
+# Anthropic API
+export ANTHROPIC_API_KEY=sk-...
+AUTOCONTEXT_AGENT_PROVIDER=anthropic autoctx run --scenario grid_ctf --gens 1
+
+# Offline, no credentials
+AUTOCONTEXT_AGENT_PROVIDER=deterministic autoctx run --scenario grid_ctf --gens 1
+```
+
+See [Providers](/docs/providers) for the full list of accepted provider values and [Per-role and judge providers](/docs/providers/per-role-and-judge) for pointing individual roles or the judge at independent models.
+
 ## Related
 
 - [Providers](/docs/providers): configuring `anthropic`, `pi`, `deterministic`, and per-role providers.
+- [Per-role and judge providers](/docs/providers/per-role-and-judge): role-scoped and judge credentials via env vars.

--- a/apps/docs/content/docs/cli/auth.mdx
+++ b/apps/docs/content/docs/cli/auth.mdx
@@ -1,0 +1,74 @@
+---
+title: Auth & Discovery
+description: Manage provider credentials and discover capabilities.
+---
+
+These commands manage who autocontext talks to (provider credentials) and let you discover what your install can do (capabilities, scenarios, and a fresh project skeleton).
+
+## login
+
+`login` stores provider credentials persistently, so you do not have to keep setting environment variables:
+
+```bash
+autoctx login
+```
+
+## whoami
+
+`whoami` shows the current auth status and which provider is active:
+
+```bash
+autoctx whoami
+```
+
+## logout
+
+`logout` clears stored provider credentials:
+
+```bash
+autoctx logout
+```
+
+## providers
+
+`providers` lists all known providers along with their auth status, as JSON:
+
+```bash
+autoctx providers
+```
+
+## models
+
+`models` lists the available models for the providers you are authenticated against, as JSON:
+
+```bash
+autoctx models
+```
+
+<Callout type="info">
+`providers` and `models` emit JSON by design, which makes them convenient to script against when selecting a model for a run.
+</Callout>
+
+## capabilities
+
+`capabilities` shows the canonical command list, aliases, and per-runtime support. It is the authoritative way to see exactly which commands your install supports and whether each is implemented in Python, TypeScript, or both.
+
+```bash
+# Human-readable summary
+autoctx capabilities
+
+# Full structured payload
+autoctx capabilities --json
+```
+
+## init
+
+`init` scaffolds project configuration and agent guidance into the current directory, giving you a starting point for `.autoctx` config and AGENTS instructions:
+
+```bash
+autoctx init
+```
+
+## Related
+
+- [Providers](/docs/providers): configuring `anthropic`, `pi`, `deterministic`, and per-role providers.

--- a/apps/docs/content/docs/cli/evaluation-cmds.mdx
+++ b/apps/docs/content/docs/cli/evaluation-cmds.mdx
@@ -1,0 +1,105 @@
+---
+title: Evaluation Commands
+description: Score and iteratively improve agent output.
+---
+
+These commands operate on the evaluation side of autocontext: scoring a single output, looping to improve it, working interactively, and comparing configurations. They build on the same judge-and-rubric machinery described in [evaluation concepts](/docs/concepts/evaluation).
+
+## judge
+
+`judge` is a one-shot evaluation. It scores a candidate output against a task prompt and a rubric, then reports the score.
+
+<Tabs items={['Python','TypeScript']}>
+<Tab value="Python">
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx judge \
+  --task-prompt "Summarize the incident report" \
+  --output "The outage lasted 12 minutes due to a bad deploy." \
+  --rubric "Accurate, concise, mentions root cause" \
+  --json
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx judge \
+  --task-prompt "Summarize the incident report" \
+  --output "The outage lasted 12 minutes due to a bad deploy." \
+  --rubric "Accurate, concise, mentions root cause" \
+  --json
+```
+
+</Tab>
+</Tabs>
+
+Flags:
+
+- `--task-prompt` / `-p`: the task prompt (required).
+- `--output` / `-o`: the agent output to evaluate (required).
+- `--rubric` / `-r`: the evaluation rubric (required).
+- `--provider`: provider override for the judge.
+- `--model`: model override for the judge.
+- `--timeout`: provider timeout override in seconds.
+- `--json`: structured output.
+
+## improve
+
+`improve` runs a multi-round improvement loop: it generates, judges against the rubric, and revises until it hits a quality threshold or runs out of rounds.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx improve \
+  --task-prompt "Write a clear release note for v2.0" \
+  --rubric "Clear, accurate, well-structured" \
+  --rounds 5 \
+  --threshold 0.9
+```
+
+Flags:
+
+- `--task-prompt` / `-p`: the task prompt (required).
+- `--rubric` / `-r`: the evaluation rubric (required).
+- `--output` / `-o`: a starting output to improve from.
+- `--rounds` / `-n`: maximum improvement rounds (default 5).
+- `--threshold` / `-t`: quality threshold that stops the loop early (default 0.9).
+- `--provider`: provider override.
+- `--timeout`: provider timeout override in seconds.
+- `--json`: structured output. `improve` also supports NDJSON streaming and an optional verification command for closed-loop checks.
+
+## repl
+
+`repl` runs a direct REPL-loop session, useful for interactively iterating on a task without leaving the terminal:
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx repl
+```
+
+## benchmark
+
+`benchmark` is also an evaluation tool: it runs repeated one-generation trials and aggregates the scores, which is the quickest way to get a stable read on a scenario.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx benchmark --scenario grid_ctf --runs 3
+```
+
+See [Solve & Run](/docs/cli/solve-run) for the full benchmark flags.
+
+## ab-test
+
+<Callout type="info">
+`ab-test` is a Python-only command. It is not available in the npm (TypeScript) package.
+</Callout>
+
+`ab-test` compares two configurations of the same scenario (a baseline against a variant) to measure the effect of a change:
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx ab-test --scenario grid_ctf
+```
+
+The baseline and variant are expressed as environment-variable overrides, so you can A/B toggles like enabling or disabling a feature.
+
+## Related
+
+- [Evaluation concepts](/docs/concepts/evaluation): rubrics, judges, and tournament scoring.
+- [Per-role and judge providers](/docs/providers): pointing the judge at an independent model.

--- a/apps/docs/content/docs/cli/evaluation-cmds.mdx
+++ b/apps/docs/content/docs/cli/evaluation-cmds.mdx
@@ -58,6 +58,10 @@ Flags:
 AUTOCONTEXT_AGENT_PROVIDER=pi autoctx repl
 ```
 
+<Callout type="info">
+`repl` is a TypeScript CLI command and is not available on the Python runtime. `judge`, `improve`, and `benchmark` run on both runtimes.
+</Callout>
+
 ## benchmark
 
 `benchmark` is also an evaluation tool: it runs repeated one-generation trials and aggregates the scores, which is the quickest way to get a stable read on a scenario.

--- a/apps/docs/content/docs/cli/evaluation-cmds.mdx
+++ b/apps/docs/content/docs/cli/evaluation-cmds.mdx
@@ -9,9 +9,6 @@ These commands operate on the evaluation side of autocontext: scoring a single o
 
 `judge` is a one-shot evaluation. It scores a candidate output against a task prompt and a rubric, then reports the score.
 
-<Tabs items={['Python','TypeScript']}>
-<Tab value="Python">
-
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=pi autoctx judge \
   --task-prompt "Summarize the incident report" \
@@ -19,20 +16,6 @@ AUTOCONTEXT_AGENT_PROVIDER=pi autoctx judge \
   --rubric "Accurate, concise, mentions root cause" \
   --json
 ```
-
-</Tab>
-<Tab value="TypeScript">
-
-```bash
-AUTOCONTEXT_AGENT_PROVIDER=pi autoctx judge \
-  --task-prompt "Summarize the incident report" \
-  --output "The outage lasted 12 minutes due to a bad deploy." \
-  --rubric "Accurate, concise, mentions root cause" \
-  --json
-```
-
-</Tab>
-</Tabs>
 
 Flags:
 
@@ -91,13 +74,25 @@ See [Solve & Run](/docs/cli/solve-run) for the full benchmark flags.
 `ab-test` is a Python-only command. It is not available in the npm (TypeScript) package.
 </Callout>
 
-`ab-test` compares two configurations of the same scenario (a baseline against a variant) to measure the effect of a change:
+`ab-test` runs a paired A/B test comparing two configurations of the same scenario, reporting per-run scores, the mean delta, and a McNemar significance test. The baseline and treatment are each expressed as comma-separated `KEY=VALUE` environment overrides, so you can A/B a toggle like enabling or disabling a feature:
 
 ```bash
-AUTOCONTEXT_AGENT_PROVIDER=pi autoctx ab-test --scenario grid_ctf
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx ab-test \
+  --scenario grid_ctf \
+  --baseline "AUTOCONTEXT_RLM_ENABLED=false" \
+  --treatment "AUTOCONTEXT_RLM_ENABLED=true" \
+  --runs 5 \
+  --gens 3
 ```
 
-The baseline and variant are expressed as environment-variable overrides, so you can A/B toggles like enabling or disabling a feature.
+Flags:
+
+- `--scenario`: scenario to test (default `grid_ctf`).
+- `--baseline`: comma-separated `KEY=VALUE` env overrides for the baseline condition (default `AUTOCONTEXT_RLM_ENABLED=false`).
+- `--treatment`: comma-separated `KEY=VALUE` env overrides for the treatment condition (default `AUTOCONTEXT_RLM_ENABLED=true`).
+- `--runs`: runs per condition (default 5).
+- `--gens`: generations per run (default 3).
+- `--seed`: random seed for condition ordering (default 42).
 
 ## Related
 

--- a/apps/docs/content/docs/cli/export-import.mdx
+++ b/apps/docs/content/docs/cli/export-import.mdx
@@ -1,0 +1,90 @@
+---
+title: Export & Import
+description: Move strategies, training data, and distilled models between projects.
+---
+
+autocontext accumulates value over time: curated strategies, training data, and distilled models. These commands move that value between projects, whether you are packaging a strategy to share, exporting data to fine-tune on, or training a distilled model from a curated dataset.
+
+## export
+
+`export` produces a portable strategy package for a scenario or run. It supports two formats.
+
+```bash
+# Default: a strategy JSON package
+autoctx export <run-id>
+
+# A pi-package directory
+autoctx export <run-id> --format pi-package
+```
+
+Flags:
+
+- A positional run id, or `--run-id`, or `--scenario` to select what to export.
+- `--format`: `strategy` (default, a JSON package) or `pi-package` (a directory).
+- `--output`: output path. Defaults to `<scenario-or-run-id>_package.json` for the strategy format, or `<scenario>-pi-package` for a pi-package directory.
+- `--db-path`, `--runs-root`, `--knowledge-root`, `--skills-root`, `--claude-skills-path`: override the source artifact locations.
+- `--json`: structured output.
+
+## export-training-data
+
+`export-training-data` exports runs as JSONL training data, suitable for downstream fine-tuning or analysis.
+
+```bash
+# Export a single run
+autoctx export-training-data --run-id <run-id>
+
+# Export every run for a scenario (requires the confirmation flag)
+autoctx export-training-data --scenario grid_ctf --all-runs
+```
+
+Flags:
+
+- `--run-id`: export a specific run.
+- `--scenario`: export all runs for a scenario.
+- `--all-runs`: required together with `--scenario` to confirm a multi-run export.
+
+## import-package
+
+`import-package` imports a strategy package from a file into the current project.
+
+```bash
+autoctx import-package ./grid_ctf_package.json --conflict merge
+```
+
+Flags:
+
+- A positional path to the strategy package JSON file (required).
+- `--scenario`: override the target scenario name.
+- `--conflict`: conflict policy, one of `overwrite`, `merge` (default), or `skip`.
+- `--db-path`, `--knowledge-root`, `--skills-root`, `--claude-skills-path`: override the target artifact locations.
+
+## train
+
+`train` launches the training loop to distill a model from a curated dataset.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx train \
+  --scenario grid_ctf \
+  --data training_data.jsonl \
+  --backend mlx
+```
+
+Flags:
+
+- `--scenario`: scenario to train on (default `grid_ctf`).
+- `--data`: path to the JSONL training data (default `training_data.jsonl`).
+- `--time-budget`: training time budget in seconds (default 300).
+- `--max-experiments`: max iterations (0 = unlimited).
+- `--memory-limit`: peak memory cap in MB (default 16384).
+- `--backend`: training backend to publish and activate, `mlx` (default) or `cuda`.
+- `--agent-provider`: LLM provider for the training agent (default `anthropic`).
+- `--agent-model`: model for the training agent (empty = provider default).
+- `--json`: structured output.
+
+<Callout type="info">
+`train` requires a configured training executor and a curated dataset (for example one produced by `export-training-data`). See the distillation guide for the end-to-end workflow.
+</Callout>
+
+## Related
+
+- [The distillation guide](/docs/guides/distillation-mlx): turning exported data into a distilled model on MLX.

--- a/apps/docs/content/docs/cli/index.mdx
+++ b/apps/docs/content/docs/cli/index.mdx
@@ -34,25 +34,27 @@ The two runtimes are not identical. Commands fall into three buckets, and you ca
 
 ### Shared core
 
-The bulk of the surface is available in both Python and TypeScript: `solve`, `run`, `replay`, `list`, `show`, `watch`, `status`, `benchmark`, `export`, `export-training-data`, `import-package`, `scenario create`, `simulate`, `investigate`, `analyze`, `judge`, `improve`, `repl`, `tui`, `capabilities`, `init`, `login`, `whoami`, `logout`, `providers`, `models`, `agent`, `queue`, `worker`, `serve` (with `serve http` / `serve mcp`), `mcp-serve`, `train`, `probes check`, `runtime-sessions`, `production-traces`, `instrument`, `trace-findings`, and `version`.
-
-<Callout type="info">
-A few shared-name commands have a deeper home on one runtime. `mission` and `campaign` orchestration is richer on the TypeScript CLI, and `mission` is recorded as an intentional gap on the Python side in the command contract.
-</Callout>
+The bulk of the surface is available in both Python and TypeScript: `solve`, `run`, `status`, `show`, `watch`, `list`, `replay`, `export`, `export-training-data`, `import-package`, `judge`, `improve`, `queue` (with `queue add` / `queue status`), `worker`, `scenario create`, `serve` (with `serve http` / `serve mcp`), `mcp-serve`, `train`, `capabilities`, `probes check`, `benchmark`, `simulate`, `investigate`, `new-scenario`, and `tui`.
 
 ### Python-only
 
-These exist only in the Python CLI and are not shipped in the npm package: `resume`, `ecosystem`, `ab-test`, `wait`, and `trigger-distillation`.
+These exist only in the Python CLI and are not shipped in the npm package: `resume`, `ecosystem`, `ab-test`, `wait`, `hermes`, and `analytics` (with subcommands `rebuild-traces`, `drift`, `context-selection`, `render-timeline`, `trace-findings`).
 
-### TypeScript-only control plane
+### TypeScript-only
 
-The control-plane commands live only in the TypeScript CLI: `candidate`, `eval`, `promotion`, `harness`, `registry`, and `emit-pr`. These manage candidate artifacts, evaluation runs, promotion transitions, harness proposals, the registry, and promotion PRs.
+These live only in the TypeScript CLI (the npm `autoctx` build) and are not top-level Python commands. They fall into a few groups:
+
+- Auth and discovery: `login`, `whoami`, `logout`, `providers`, `models`, `init`. Python users authenticate via environment variables (see [Providers](/docs/providers)).
+- Interactive and inspection: `repl`, `agent`, `analyze`, `runtime-sessions`, `version`.
+- Missions and campaigns: `mission`, `campaign`. `mission` is recorded as an intentional gap on the Python side in the command contract.
+- Production traces: `production-traces`, `instrument`, `trace-findings`. On Python, the findings equivalent is the nested `autoctx analytics trace-findings` (with different flags), and `context-selection` is likewise nested under `autoctx analytics`. The TypeScript CLI also exposes a top-level `context-selection`.
+- Control plane: `candidate`, `eval`, `promotion`, `harness`, `registry`, `emit-pr`, `trigger-distillation`. These manage candidate artifacts, evaluation runs, promotion transitions, harness proposals, the registry, and promotion PRs.
 
 ## Where to go next
 
 - [Solve & Run](/docs/cli/solve-run): create and run scenarios, then inspect results.
 - [Evaluation Commands](/docs/cli/evaluation-cmds): score and iteratively improve output.
-- [Plain-Language Workflows](/docs/cli/plain-language): `simulate`, `investigate`, and `analyze`.
+- [Plain-Language Workflows](/docs/cli/plain-language): `simulate`, `investigate`, and `analyze` (TypeScript-only).
 - [Missions & Campaigns](/docs/cli/missions-campaigns): coordinate multi-step work.
 - [Background Queue](/docs/cli/queue-worker): queue tasks and run a worker.
 - [Auth & Discovery](/docs/cli/auth): credentials and capability discovery.

--- a/apps/docs/content/docs/cli/index.mdx
+++ b/apps/docs/content/docs/cli/index.mdx
@@ -1,0 +1,60 @@
+---
+title: CLI Overview
+description: How the autoctx command line is organized across Python and TypeScript.
+---
+
+autocontext ships two implementations of the same command line, both exposing the `autoctx` binary: a Python CLI (built on Typer) and a TypeScript CLI (built on Commander). The two share most of their command surface, so the workflows you learn here apply whichever runtime you install.
+
+<Callout type="info">
+The npm package is named `autoctx`, not `autocontext` (that is a different package). The Python distribution also installs the `autoctx` entry point. Both put the same command on your PATH.
+</Callout>
+
+## Invocation model
+
+Every command follows the same shape:
+
+```bash
+autoctx <command> [arguments] [flags]
+```
+
+Commands group into subcommands where it makes sense (for example `autoctx serve http`, `autoctx serve mcp`, `autoctx queue add`, `autoctx queue status`, `autoctx probes check`, and `autoctx scenario create`).
+
+Most read or report-style commands accept `--json` for structured, machine-readable output on stdout. This is the flag to reach for when you are scripting against autoctx or feeding its output into another tool. Human-readable tables are the default when `--json` is omitted.
+
+Examples in these pages set `AUTOCONTEXT_AGENT_PROVIDER` explicitly. The default provider is `anthropic`, which needs an API key. The `pi` provider is the zero-config path, and `deterministic` runs fully offline. See [Providers](/docs/providers) for the full picture.
+
+```bash
+# Zero-config: no key required
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx run grid_ctf --iterations 1
+```
+
+## Parity buckets
+
+The two runtimes are not identical. Commands fall into three buckets, and you can always check the live picture for your install with `autoctx capabilities --json`.
+
+### Shared core
+
+The bulk of the surface is available in both Python and TypeScript: `solve`, `run`, `replay`, `list`, `show`, `watch`, `status`, `benchmark`, `export`, `export-training-data`, `import-package`, `scenario create`, `simulate`, `investigate`, `analyze`, `judge`, `improve`, `repl`, `tui`, `capabilities`, `init`, `login`, `whoami`, `logout`, `providers`, `models`, `agent`, `queue`, `worker`, `serve` (with `serve http` / `serve mcp`), `mcp-serve`, `train`, `probes check`, `runtime-sessions`, `production-traces`, `instrument`, `trace-findings`, and `version`.
+
+<Callout type="info">
+A few shared-name commands have a deeper home on one runtime. `mission` and `campaign` orchestration is richer on the TypeScript CLI, and `mission` is recorded as an intentional gap on the Python side in the command contract.
+</Callout>
+
+### Python-only
+
+These exist only in the Python CLI and are not shipped in the npm package: `resume`, `ecosystem`, `ab-test`, `wait`, and `trigger-distillation`.
+
+### TypeScript-only control plane
+
+The control-plane commands live only in the TypeScript CLI: `candidate`, `eval`, `promotion`, `harness`, `registry`, and `emit-pr`. These manage candidate artifacts, evaluation runs, promotion transitions, harness proposals, the registry, and promotion PRs.
+
+## Where to go next
+
+- [Solve & Run](/docs/cli/solve-run): create and run scenarios, then inspect results.
+- [Evaluation Commands](/docs/cli/evaluation-cmds): score and iteratively improve output.
+- [Plain-Language Workflows](/docs/cli/plain-language): `simulate`, `investigate`, and `analyze`.
+- [Missions & Campaigns](/docs/cli/missions-campaigns): coordinate multi-step work.
+- [Background Queue](/docs/cli/queue-worker): queue tasks and run a worker.
+- [Auth & Discovery](/docs/cli/auth): credentials and capability discovery.
+- [Export & Import](/docs/cli/export-import): move strategies, data, and models.
+- [The full reference](/docs/cli/reference): every command at a glance.

--- a/apps/docs/content/docs/cli/meta.json
+++ b/apps/docs/content/docs/cli/meta.json
@@ -1,0 +1,14 @@
+{
+  "title": "CLI",
+  "pages": [
+    "index",
+    "solve-run",
+    "evaluation-cmds",
+    "plain-language",
+    "missions-campaigns",
+    "queue-worker",
+    "auth",
+    "export-import",
+    "reference"
+  ]
+}

--- a/apps/docs/content/docs/cli/missions-campaigns.mdx
+++ b/apps/docs/content/docs/cli/missions-campaigns.mdx
@@ -1,0 +1,35 @@
+---
+title: Missions & Campaigns
+description: Coordinate multi-step and multi-mission work.
+---
+
+When a single run is not enough, autocontext offers two levels of coordination: a `mission` groups multiple steps toward one objective, and a `campaign` groups multiple missions. Both are managed through subcommands.
+
+## mission
+
+`mission` manages multi-step task missions: creating them, listing them, and driving them through their steps.
+
+```bash
+autoctx mission --help
+```
+
+A mission is the unit you reach for when a goal naturally breaks into ordered steps that should share state and be tracked together, rather than as independent one-off runs.
+
+## campaign
+
+`campaign` manages multi-mission campaigns, coordinating several missions toward a larger objective.
+
+```bash
+autoctx campaign --help
+```
+
+<Callout type="info">
+Mission and campaign orchestration is richer on the TypeScript CLI. In the command contract, `mission` on the Python runtime is recorded as an intentional gap, so prefer the npm (`autoctx`) build when you are doing serious mission or campaign work. Run `autoctx capabilities --json` to confirm the support level for your install.
+</Callout>
+
+Because the available subcommands and selectors evolve, the most reliable reference for your installed version is the built-in help: `autoctx mission --help` and `autoctx campaign --help`.
+
+## Related
+
+- [Scenarios and tasks](/docs/concepts/scenarios-tasks): the building blocks a mission coordinates.
+- [Solve & Run](/docs/cli/solve-run): the single-run commands a mission composes.

--- a/apps/docs/content/docs/cli/missions-campaigns.mdx
+++ b/apps/docs/content/docs/cli/missions-campaigns.mdx
@@ -5,6 +5,10 @@ description: Coordinate multi-step and multi-mission work.
 
 When a single run is not enough, autocontext offers two levels of coordination: a `mission` groups multiple steps toward one objective, and a `campaign` groups multiple missions. Both are managed through subcommands.
 
+<Callout type="warn">
+`mission` and `campaign` are TypeScript CLI commands (the npm `autoctx` build). They are not top-level Python commands: `mission` is recorded as an intentional gap on the Python runtime in the command contract. Use the npm build for mission and campaign work. The mission and campaign MCP tools are a separate surface; see [MCP tools](/docs/reference/mcp-tools).
+</Callout>
+
 ## mission
 
 `mission` manages multi-step task missions: creating them, listing them, and driving them through their steps.
@@ -24,7 +28,7 @@ autoctx campaign --help
 ```
 
 <Callout type="info">
-Mission and campaign orchestration is richer on the TypeScript CLI. In the command contract, `mission` on the Python runtime is recorded as an intentional gap, so prefer the npm (`autoctx`) build when you are doing serious mission or campaign work. Run `autoctx capabilities --json` to confirm the support level for your install.
+Mission and campaign orchestration lives in the TypeScript CLI. In the command contract, `mission` on the Python runtime is recorded as an intentional gap, so use the npm (`autoctx`) build for mission or campaign work. Run `autoctx capabilities --json` to confirm the support level for your install.
 </Callout>
 
 Because the available subcommands and selectors evolve, the most reliable reference for your installed version is the built-in help: `autoctx mission --help` and `autoctx campaign --help`.

--- a/apps/docs/content/docs/cli/plain-language.mdx
+++ b/apps/docs/content/docs/cli/plain-language.mdx
@@ -3,7 +3,7 @@ title: Plain-Language Workflows
 description: simulate, investigate, and analyze from a description.
 ---
 
-Three commands let you drive autocontext from a plain-language description rather than a hand-written scenario: `simulate` models a system and sweeps parameters, `investigate` chases down a problem with evidence and hypotheses, and `analyze` compares the results of prior work.
+Three commands let you drive autocontext from a plain-language description rather than a hand-written scenario: `simulate` models a system and sweeps parameters, `investigate` chases down a problem with evidence and hypotheses, and `analyze` compares the results of prior work. `simulate` and `investigate` are available on both runtimes; `analyze` is a TypeScript CLI command.
 
 ## simulate
 
@@ -58,6 +58,10 @@ Flags:
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=pi autoctx analyze --help
 ```
+
+<Callout type="warn">
+`autoctx analyze` is a TypeScript CLI command and is not available on the Python runtime. Python users inspect prior work through `autoctx analytics` (with subcommands such as `render-timeline`, `drift`, and `trace-findings`) and the runtime-session readers. Do not run `autoctx analyze` on a Python install.
+</Callout>
 
 <Callout type="info">
 `analyze` reads existing artifacts rather than generating new ones, so it does not need a provider key for the comparison itself. Run `autoctx analyze --help` for the exact subjects and selectors your installed version exposes.

--- a/apps/docs/content/docs/cli/plain-language.mdx
+++ b/apps/docs/content/docs/cli/plain-language.mdx
@@ -1,0 +1,69 @@
+---
+title: Plain-Language Workflows
+description: simulate, investigate, and analyze from a description.
+---
+
+Three commands let you drive autocontext from a plain-language description rather than a hand-written scenario: `simulate` models a system and sweeps parameters, `investigate` chases down a problem with evidence and hypotheses, and `analyze` compares the results of prior work.
+
+## simulate
+
+`simulate` turns a description into a runnable simulation, optionally sweeping variables and comparing outcomes.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx simulate \
+  --description "queue with arrival rate lambda and service rate mu" \
+  --variables "lambda=3,mu=5" \
+  --runs 1
+```
+
+Flags:
+
+- `--description` / `-d`: plain-language description of what to simulate.
+- `--variables`: variable overrides in `key=val,key2=val2` form.
+- `--sweep`: a sweep spec in `key=min:max:step` form, run across the range.
+- `--runs`: number of runs (default 1).
+- `--max-steps`: max steps per run (0 = auto).
+- `--provider`: provider override.
+- `--save-as`: name to save the simulation under.
+- `--replay`: replay a saved simulation by name.
+- `--compare-left` and `--compare-right`: two saved simulations to compare (must be supplied together).
+- `--export`: export a saved simulation by name, with `--format` choosing `json`, `markdown`, or `csv`.
+- `--json`: structured output.
+
+## investigate
+
+`investigate` runs a plain-language investigation, gathering evidence and generating hypotheses about a problem.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx investigate \
+  --description "checkout latency spikes every afternoon" \
+  --max-steps 8 \
+  --hypotheses 5
+```
+
+Flags:
+
+- `--description` / `-d`: the plain-language problem to investigate.
+- `--max-steps`: maximum investigation steps (default 8).
+- `--hypotheses`: maximum hypotheses to generate (default 5).
+- `--mode`: investigation mode, `synthetic` (default) or `iterative`.
+- `--browser-url`: an optional browser URL to capture before investigating.
+- `--save-as`: name to save the investigation under.
+- `--json`: structured output.
+
+## analyze
+
+`analyze` compares and reports across prior work: runs, simulations, investigations, and missions. It is the read-and-compare counterpart to the commands that produce those artifacts.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx analyze --help
+```
+
+<Callout type="info">
+`analyze` reads existing artifacts rather than generating new ones, so it does not need a provider key for the comparison itself. Run `autoctx analyze --help` for the exact subjects and selectors your installed version exposes.
+</Callout>
+
+## Related
+
+- [Scenarios and tasks](/docs/concepts/scenarios-tasks): how a description becomes something runnable.
+- [Runs, traces, and artifacts](/docs/concepts/runs-traces-artifacts): what `analyze` compares.

--- a/apps/docs/content/docs/cli/queue-worker.mdx
+++ b/apps/docs/content/docs/cli/queue-worker.mdx
@@ -1,0 +1,87 @@
+---
+title: Background Queue
+description: Queue tasks and process them with a worker.
+---
+
+autocontext can run improvement tasks in the background. You enqueue work with `queue add`, check depth with `queue status`, and process the queue with a long-running `worker`.
+
+## queue add
+
+`queue add` puts a task on the background runner queue.
+
+<Tabs items={['Python','TypeScript']}>
+<Tab value="Python">
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx queue add \
+  --task-prompt "Write a clear changelog entry for v2.0" \
+  --rubric "Clear, accurate, well-structured" \
+  --rounds 5 \
+  --threshold 0.9
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx queue add \
+  --task-prompt "Write a clear changelog entry for v2.0" \
+  --rubric "Clear, accurate, well-structured" \
+  --rounds 5 \
+  --threshold 0.9
+```
+
+</Tab>
+</Tabs>
+
+Flags:
+
+- `--spec` / `-s`: the task spec name (derived from the prompt if omitted).
+- `--task-prompt` / `--prompt` / `-p`: the queued task prompt.
+- `--rubric` / `-r`: the evaluation rubric.
+- `--browser-url`: an optional browser URL to capture before execution.
+- `--rounds` / `-n`: maximum improvement rounds (default 5).
+- `--threshold` / `-t`: quality threshold to stop (default 0.9).
+- `--min-rounds`: minimum rounds before the threshold can stop the loop (default 1).
+- `--priority`: task priority (default 0).
+- `--provider`: provider override accepted for queue-script compatibility.
+- `--json`: structured output.
+
+<Callout type="info">
+The flag for the round cap is `--rounds` (with the `-n` short form), matching `improve`. There is no `--max-rounds` flag.
+</Callout>
+
+## queue status
+
+`queue status` shows the count of pending tasks in the background queue:
+
+```bash
+autoctx queue status
+autoctx queue status --json
+```
+
+## worker
+
+`worker` runs the background task queue worker, pulling queued tasks and executing the improvement loop on each.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx worker
+```
+
+Flags:
+
+- `--poll-interval`: how often the worker polls for new tasks, in seconds.
+- `--concurrency`: how many tasks to process concurrently.
+- `--max-empty-polls`: stop after this many consecutive empty polls.
+- `--model`: judge model override for queued tasks.
+- `--once`: process one batch and exit, instead of running continuously.
+- `--json`: structured output on exit.
+
+## status
+
+The top-level `status` command reports run state when given a run id; `queue status` reports queue depth. Keep the two straight: `autoctx status <run-id>` versus `autoctx queue status`.
+
+## Related
+
+- [Evaluation Commands](/docs/cli/evaluation-cmds): `improve` runs the same loop the worker executes per task.
+- [Solve & Run](/docs/cli/solve-run): inspecting the runs a worker produces.

--- a/apps/docs/content/docs/cli/queue-worker.mdx
+++ b/apps/docs/content/docs/cli/queue-worker.mdx
@@ -9,9 +9,6 @@ autocontext can run improvement tasks in the background. You enqueue work with `
 
 `queue add` puts a task on the background runner queue.
 
-<Tabs items={['Python','TypeScript']}>
-<Tab value="Python">
-
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=pi autoctx queue add \
   --task-prompt "Write a clear changelog entry for v2.0" \
@@ -19,20 +16,6 @@ AUTOCONTEXT_AGENT_PROVIDER=pi autoctx queue add \
   --rounds 5 \
   --threshold 0.9
 ```
-
-</Tab>
-<Tab value="TypeScript">
-
-```bash
-AUTOCONTEXT_AGENT_PROVIDER=pi autoctx queue add \
-  --task-prompt "Write a clear changelog entry for v2.0" \
-  --rubric "Clear, accurate, well-structured" \
-  --rounds 5 \
-  --threshold 0.9
-```
-
-</Tab>
-</Tabs>
 
 Flags:
 

--- a/apps/docs/content/docs/cli/reference.mdx
+++ b/apps/docs/content/docs/cli/reference.mdx
@@ -3,10 +3,10 @@ title: Command Reference
 description: Every autoctx command at a glance.
 ---
 
-Every `autoctx` command, grouped by purpose. The **Runtime** column records whether a command is available in both runtimes, Python-only, or in the TypeScript-only control plane. For the authoritative, install-specific picture, run `autoctx capabilities --json`.
+Every `autoctx` command, grouped by purpose. The **Runtime** column records whether a command is available on both runtimes (`both`), Python-only (`Python`), or TypeScript-only (`TypeScript`). For the authoritative, install-specific picture, run `autoctx capabilities --json`.
 
 <Callout type="info">
-A few commands marked "both" have a deeper implementation on one runtime. `mission` and `campaign` orchestration is richer on TypeScript, and `mission` is recorded as an intentional gap on Python in the command contract.
+Auth and discovery (`login`, `whoami`, `logout`, `providers`, `models`, `init`), the interactive `repl`, `agent`, `analyze`, `runtime-sessions`, `version`, the mission and campaign commands, the production-traces commands, and the control plane are TypeScript-only. `mission` is recorded as an intentional gap on Python in the command contract. On Python, `trace-findings` and `context-selection` live under `autoctx analytics` (with different flags). Python users authenticate via environment variables, not `autoctx login`; see [Providers](/docs/providers).
 </Callout>
 
 ## Core: solve, run, and inspect
@@ -22,7 +22,7 @@ A few commands marked "both" have a deeper implementation on one runtime. `missi
 | `list` | List recent runs | both | `--json` |
 | `status` | Report the state of a run | both | run id argument, `--json` |
 | `benchmark` | Repeated one-generation trials with aggregate stats | both | `--scenario`, `--runs` |
-| `runtime-sessions` | Inspect recorded runtime sessions | both | varies (see `--help`) |
+| `runtime-sessions` | Inspect recorded runtime sessions | TypeScript | varies (see `--help`) |
 
 ## Evaluation
 
@@ -30,7 +30,7 @@ A few commands marked "both" have a deeper implementation on one runtime. `missi
 | --- | --- | --- | --- |
 | `judge` | One-shot evaluation against a rubric | both | `--task-prompt`/`-p`, `--output`/`-o`, `--rubric`/`-r`, `--provider`, `--model`, `--timeout`, `--json` |
 | `improve` | Multi-round improvement loop | both | `--task-prompt`/`-p`, `--rubric`/`-r`, `--output`/`-o`, `--rounds`/`-n`, `--threshold`/`-t`, `--provider`, `--json` |
-| `repl` | Direct REPL-loop session | both | (interactive) |
+| `repl` | Direct REPL-loop session | TypeScript | (interactive) |
 | `ab-test` | Paired A/B test comparing two configurations | Python | `--scenario`, `--baseline`, `--treatment`, `--runs`, `--gens`, `--seed` |
 
 ## Plain-language
@@ -39,14 +39,14 @@ A few commands marked "both" have a deeper implementation on one runtime. `missi
 | --- | --- | --- | --- |
 | `simulate` | Plain-language simulation with sweeps | both | `--description`/`-d`, `--variables`, `--sweep`, `--runs`, `--max-steps`, `--replay`, `--compare-left`, `--compare-right`, `--export`, `--format`, `--save-as`, `--json` |
 | `investigate` | Plain-language investigation | both | `--description`/`-d`, `--max-steps`, `--hypotheses`, `--mode`, `--browser-url`, `--save-as`, `--json` |
-| `analyze` | Compare runs, simulations, investigations, missions | both | varies (see `--help`) |
+| `analyze` | Compare runs, simulations, investigations, missions | TypeScript | varies (see `--help`) |
 
 ## Missions
 
 | Command | Description | Runtime | Key flags |
 | --- | --- | --- | --- |
-| `mission` | Manage multi-step task missions | both (richer on TS) | subcommands (see `--help`) |
-| `campaign` | Manage multi-mission campaigns | both (richer on TS) | subcommands (see `--help`) |
+| `mission` | Manage multi-step task missions | TypeScript | subcommands (see `--help`); Python records this as an intentional gap |
+| `campaign` | Manage multi-mission campaigns | TypeScript | subcommands (see `--help`) |
 
 ## Background queue
 
@@ -60,14 +60,14 @@ A few commands marked "both" have a deeper implementation on one runtime. `missi
 
 | Command | Description | Runtime | Key flags |
 | --- | --- | --- | --- |
-| `login` | Store provider credentials | both | (interactive) |
-| `whoami` | Show current auth status and provider | both | |
-| `logout` | Clear stored provider credentials | both | |
-| `providers` | List known providers with auth status (JSON) | both | |
-| `models` | List available models for authed providers (JSON) | both | |
+| `login` | Store provider credentials | TypeScript | (interactive); Python uses env vars |
+| `whoami` | Show current auth status and provider | TypeScript | |
+| `logout` | Clear stored provider credentials | TypeScript | |
+| `providers` | List known providers with auth status (JSON) | TypeScript | |
+| `models` | List available models for authed providers (JSON) | TypeScript | |
 | `capabilities` | Show commands, aliases, per-runtime support | both | `--json` |
-| `init` | Scaffold project config and agent guidance | both | |
-| `agent` | Run or dev-serve local `.autoctx/agents` handlers | both | varies (see `--help`) |
+| `init` | Scaffold project config and agent guidance | TypeScript | |
+| `agent` | Run or dev-serve local `.autoctx/agents` handlers | TypeScript | varies (see `--help`) |
 
 ## Export, import, and training
 
@@ -78,6 +78,7 @@ A few commands marked "both" have a deeper implementation on one runtime. `missi
 | `import-package` | Import a strategy package from a file | both | path argument, `--scenario`, `--conflict` (`overwrite`/`merge`/`skip`) |
 | `train` | Train a distilled model from a curated dataset | both | `--scenario`, `--data`, `--time-budget`, `--max-experiments`, `--memory-limit`, `--backend`, `--agent-provider`, `--agent-model`, `--json` |
 | `scenario create` | Create or scaffold a scenario | both | varies (see `--help`) |
+| `new-scenario` | Scaffold a scenario from a description or template | both | `--description`, `--template`, `--name` |
 
 ## Serve, MCP, and TUI
 
@@ -105,19 +106,21 @@ The bare `autoctx serve` (with `--host` and `--port`) is the legacy equivalent o
 
 | Command | Description | Runtime | Key flags |
 | --- | --- | --- | --- |
-| `production-traces` | Ingest, list, show, stats, build-dataset, export, policy, and prune production traces | both | subcommands (see `--help`) |
-| `instrument` | Scan a repo for LLM clients and propose wrappers | both | varies (see `--help`) |
-| `trace-findings` | Extract structured findings from a trace JSON file | both | varies (see `--help`) |
+| `production-traces` | Ingest, list, show, stats, build-dataset, export, policy, and prune production traces | TypeScript | subcommands (see `--help`) |
+| `instrument` | Scan a repo for LLM clients and propose wrappers | TypeScript | varies (see `--help`) |
+| `trace-findings` | Extract structured findings from a trace JSON file | TypeScript | varies (see `--help`); Python uses `analytics trace-findings` |
 | `probes check` | Run contract probes against observed harness state | both | `--suite`, `--json` |
 
 ## Utility and Python-only
 
 | Command | Description | Runtime | Key flags |
 | --- | --- | --- | --- |
-| `version` | Show the version | both | |
+| `version` | Show the version | TypeScript | |
 | `ecosystem` | Run a multi-cycle ecosystem loop | Python | `--scenario`, `--cycles`, `--gens-per-cycle` |
 | `wait` | Wait on a monitor condition | Python | condition id argument, `--timeout`, `--json` |
-| `trigger-distillation` | Trigger a distillation job | Python | varies (see `--help`) |
+| `hermes` | Drive autocontext with the Hermes CLI runtime | Python | varies (see `--help`) |
+| `analytics` | Analytics subcommands (`rebuild-traces`, `drift`, `context-selection`, `render-timeline`, `trace-findings`) | Python | subcommands (see `--help`) |
+| `trigger-distillation` | Trigger a distillation job | TypeScript | varies (see `--help`) |
 
 ## Related
 

--- a/apps/docs/content/docs/cli/reference.mdx
+++ b/apps/docs/content/docs/cli/reference.mdx
@@ -1,0 +1,123 @@
+---
+title: Command Reference
+description: Every autoctx command at a glance.
+---
+
+Every `autoctx` command, grouped by purpose. The **Runtime** column records whether a command is available in both runtimes, Python-only, or in the TypeScript-only control plane. For the authoritative, install-specific picture, run `autoctx capabilities --json`.
+
+<Callout type="info">
+A few commands marked "both" have a deeper implementation on one runtime. `mission` and `campaign` orchestration is richer on TypeScript, and `mission` is recorded as an intentional gap on Python in the command contract.
+</Callout>
+
+## Core: solve, run, and inspect
+
+| Command | Description | Runtime | Key flags |
+| --- | --- | --- | --- |
+| `solve` | Compile a scenario from plain language and run the loop | both | `--description`/`-d`, `--task-file`, `--iterations`/`--gens`, `--task-prompt`, `--family`, `--output`, `--json` |
+| `run` | Run the generation loop for a scenario | both | `--scenario`, `--iterations`/`--gens`, `--run-id`, `--serve`, `--port`, `--preset`, `--json` |
+| `resume` | Continue a previously started run | Python | `--scenario`, `--gens`, run id argument |
+| `replay` | Print replay JSON for a generation | both | `--generation` |
+| `show` | Render a finished run's artifacts | both | `--best`, `--generation`, `--json` |
+| `watch` | Stream live status until a run finishes | both | `--interval`, `--json` |
+| `list` | List recent runs | both | `--json` |
+| `status` | Report the state of a run | both | run id argument, `--json` |
+| `benchmark` | Repeated one-generation trials with aggregate stats | both | `--scenario`, `--runs` |
+| `runtime-sessions` | Inspect recorded runtime sessions | both | varies (see `--help`) |
+
+## Evaluation
+
+| Command | Description | Runtime | Key flags |
+| --- | --- | --- | --- |
+| `judge` | One-shot evaluation against a rubric | both | `--task-prompt`/`-p`, `--output`/`-o`, `--rubric`/`-r`, `--provider`, `--model`, `--timeout`, `--json` |
+| `improve` | Multi-round improvement loop | both | `--task-prompt`/`-p`, `--rubric`/`-r`, `--output`/`-o`, `--rounds`/`-n`, `--threshold`/`-t`, `--provider`, `--json` |
+| `repl` | Direct REPL-loop session | both | (interactive) |
+| `ab-test` | Compare a baseline against a variant | Python | `--scenario`, `--baseline` |
+
+## Plain-language
+
+| Command | Description | Runtime | Key flags |
+| --- | --- | --- | --- |
+| `simulate` | Plain-language simulation with sweeps | both | `--description`/`-d`, `--variables`, `--sweep`, `--runs`, `--max-steps`, `--replay`, `--compare-left`, `--compare-right`, `--export`, `--format`, `--save-as`, `--json` |
+| `investigate` | Plain-language investigation | both | `--description`/`-d`, `--max-steps`, `--hypotheses`, `--mode`, `--browser-url`, `--save-as`, `--json` |
+| `analyze` | Compare runs, simulations, investigations, missions | both | varies (see `--help`) |
+
+## Missions
+
+| Command | Description | Runtime | Key flags |
+| --- | --- | --- | --- |
+| `mission` | Manage multi-step task missions | both (richer on TS) | subcommands (see `--help`) |
+| `campaign` | Manage multi-mission campaigns | both (richer on TS) | subcommands (see `--help`) |
+
+## Background queue
+
+| Command | Description | Runtime | Key flags |
+| --- | --- | --- | --- |
+| `queue add` | Add a task to the background queue | both | `--spec`/`-s`, `--task-prompt`/`--prompt`/`-p`, `--rubric`/`-r`, `--browser-url`, `--rounds`/`-n`, `--threshold`/`-t`, `--min-rounds`, `--priority`, `--provider`, `--json` |
+| `queue status` | Show pending queue depth | both | `--json` |
+| `worker` | Run the background queue worker | both | `--poll-interval`, `--concurrency`, `--max-empty-polls`, `--model`, `--once`, `--json` |
+
+## Auth and discovery
+
+| Command | Description | Runtime | Key flags |
+| --- | --- | --- | --- |
+| `login` | Store provider credentials | both | (interactive) |
+| `whoami` | Show current auth status and provider | both | |
+| `logout` | Clear stored provider credentials | both | |
+| `providers` | List known providers with auth status (JSON) | both | |
+| `models` | List available models for authed providers (JSON) | both | |
+| `capabilities` | Show commands, aliases, per-runtime support | both | `--json` |
+| `init` | Scaffold project config and agent guidance | both | |
+| `agent` | Run or dev-serve local `.autoctx/agents` handlers | both | varies (see `--help`) |
+
+## Export, import, and training
+
+| Command | Description | Runtime | Key flags |
+| --- | --- | --- | --- |
+| `export` | Export a strategy package for a scenario or run | both | `--run-id`/`--scenario`, `--format` (`strategy`/`pi-package`), `--output`, `--json` |
+| `export-training-data` | Export runs as JSONL training data | both | `--run-id`, `--scenario`, `--all-runs` |
+| `import-package` | Import a strategy package from a file | both | path argument, `--scenario`, `--conflict` (`overwrite`/`merge`/`skip`) |
+| `train` | Train a distilled model from a curated dataset | both | `--scenario`, `--data`, `--time-budget`, `--max-experiments`, `--memory-limit`, `--backend`, `--agent-provider`, `--agent-model`, `--json` |
+| `scenario create` | Create or scaffold a scenario | both | varies (see `--help`) |
+
+## Serve, MCP, and TUI
+
+| Command | Description | Runtime | Key flags |
+| --- | --- | --- | --- |
+| `serve http` | Start the HTTP API server | both | `--port`, `--json` |
+| `serve mcp` | Start the MCP server | both | varies (see `--help`) |
+| `mcp-serve` | Start the MCP server on stdio | both | |
+| `tui` | Start the interactive server for a terminal UI client | both | `--port` |
+
+## Control plane (TypeScript only)
+
+| Command | Description | Runtime | Key flags |
+| --- | --- | --- | --- |
+| `candidate` | Register, list, show, lineage, rollback artifacts | TypeScript | subcommands (see `--help`) |
+| `eval` | Attach and list EvalRuns on artifacts | TypeScript | subcommands (see `--help`) |
+| `promotion` | Decide, apply, history for promotions | TypeScript | subcommands (see `--help`) |
+| `harness` | Create and gate evidence-backed proposals | TypeScript | subcommands (see `--help`) |
+| `registry` | Repair, validate, migrate the registry | TypeScript | subcommands (see `--help`) |
+| `emit-pr` | Generate a promotion PR or dry-run bundle | TypeScript | varies (see `--help`) |
+
+## Production traces and probes
+
+| Command | Description | Runtime | Key flags |
+| --- | --- | --- | --- |
+| `production-traces` | Ingest, list, show, stats, build-dataset, export, policy, and prune production traces | both | subcommands (see `--help`) |
+| `instrument` | Scan a repo for LLM clients and propose wrappers | both | varies (see `--help`) |
+| `trace-findings` | Extract structured findings from a trace JSON file | both | varies (see `--help`) |
+| `probes check` | Run contract probes against observed harness state | both | `--suite`, `--json` |
+
+## Utility and Python-only
+
+| Command | Description | Runtime | Key flags |
+| --- | --- | --- | --- |
+| `version` | Show the version | both | |
+| `ecosystem` | Run a multi-cycle ecosystem loop | Python | `--scenario`, `--cycles`, `--gens-per-cycle` |
+| `wait` | Wait on a monitor condition | Python | condition id argument, `--timeout`, `--json` |
+| `trigger-distillation` | Trigger a distillation job | Python | varies (see `--help`) |
+
+## Related
+
+- [CLI Overview](/docs/cli): invocation model and parity buckets.
+- [Providers](/docs/providers): the provider selection these commands share.

--- a/apps/docs/content/docs/cli/reference.mdx
+++ b/apps/docs/content/docs/cli/reference.mdx
@@ -83,10 +83,12 @@ A few commands marked "both" have a deeper implementation on one runtime. `missi
 
 | Command | Description | Runtime | Key flags |
 | --- | --- | --- | --- |
-| `serve http` | Start the HTTP API server | both | `--port`, `--json` |
-| `serve mcp` | Start the MCP server | both | varies (see `--help`) |
+| `serve http` | Start the HTTP API server | both | `--host` (default `127.0.0.1`), `--port`, `--json` |
+| `serve mcp` | Start the MCP server over stdio | both | varies (see `--help`) |
 | `mcp-serve` | Start the MCP server on stdio | both | |
 | `tui` | Start the interactive server for a terminal UI client | both | `--port` |
+
+The bare `autoctx serve` (with `--host` and `--port`) is the legacy equivalent of `autoctx serve http`.
 
 ## Control plane (TypeScript only)
 

--- a/apps/docs/content/docs/cli/reference.mdx
+++ b/apps/docs/content/docs/cli/reference.mdx
@@ -31,7 +31,7 @@ A few commands marked "both" have a deeper implementation on one runtime. `missi
 | `judge` | One-shot evaluation against a rubric | both | `--task-prompt`/`-p`, `--output`/`-o`, `--rubric`/`-r`, `--provider`, `--model`, `--timeout`, `--json` |
 | `improve` | Multi-round improvement loop | both | `--task-prompt`/`-p`, `--rubric`/`-r`, `--output`/`-o`, `--rounds`/`-n`, `--threshold`/`-t`, `--provider`, `--json` |
 | `repl` | Direct REPL-loop session | both | (interactive) |
-| `ab-test` | Compare a baseline against a variant | Python | `--scenario`, `--baseline` |
+| `ab-test` | Paired A/B test comparing two configurations | Python | `--scenario`, `--baseline`, `--treatment`, `--runs`, `--gens`, `--seed` |
 
 ## Plain-language
 

--- a/apps/docs/content/docs/cli/solve-run.mdx
+++ b/apps/docs/content/docs/cli/solve-run.mdx
@@ -1,0 +1,157 @@
+---
+title: Solve & Run
+description: Create and run scenarios, then inspect the results.
+---
+
+The core working loop of autoctx is: turn a goal into a scenario, run it, and inspect what happened. `solve` and `run` are the two ways to start work, and `show`, `watch`, `list`, and `status` let you follow and review it.
+
+## solve
+
+`solve` takes a plain-language description, compiles it into a scenario, and runs the improvement loop on it. It is the fastest path from an idea to a result.
+
+<Tabs items={['Python','TypeScript']}>
+<Tab value="Python">
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx solve \
+  "build an orbital transfer optimizer" \
+  --iterations 3
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx solve \
+  "build an orbital transfer optimizer" \
+  --iterations 3
+```
+
+</Tab>
+</Tabs>
+
+The description can be a positional argument, the `--description` / `-d` flag, or loaded from a file with `--task-file` (mutually exclusive with `--description`, convenient for long prompts). Other useful flags:
+
+- `--gens` / `--generations` and `--iterations`: how many generations to run (1 to 50; `--iterations` is the plain-language alias).
+- `--timeout`: provider timeout override in seconds.
+- `--generation-time-budget`: soft per-generation time budget in seconds (0 = unlimited).
+- `--family`: force a specific scenario family, bypassing the keyword classifier.
+- `--task-prompt`: supply the verbatim task prompt for the agent, bypassing the LLM scenario designer. Use this to preserve long, detail-laden prompts the designer might otherwise truncate.
+- `--output`: write the solved package to a JSON file.
+- `--json`: structured output.
+
+## run
+
+`run` executes the generation loop for a scenario that already exists (for example `grid_ctf`), rather than compiling one from a description.
+
+<Tabs items={['Python','TypeScript']}>
+<Tab value="Python">
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx run \
+  --scenario grid_ctf \
+  --iterations 3
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx run \
+  --scenario grid_ctf \
+  --iterations 3
+```
+
+</Tab>
+</Tabs>
+
+The scenario can be passed positionally (`autoctx run grid_ctf`) or via `--scenario`. When neither is given, it defaults to `grid_ctf`. Flags:
+
+- `--gens` and `--iterations`: number of generations (`--iterations` is the plain-language alias for `--gens`).
+- `--run-id`: assign or resume a specific run id.
+- `--serve`: start the interactive API and WebSocket server alongside the loop.
+- `--port`: server port, only used with `--serve` (default 8000).
+- `--preset`: apply a named configuration preset.
+- `--json`: structured output. Note that `--json` cannot be combined with `--serve`.
+
+## resume
+
+<Callout type="info">
+`resume` is a Python-only command. It is not available in the npm (TypeScript) package.
+</Callout>
+
+`resume` continues a previously started run by its id:
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx resume <run-id> --gens 1
+```
+
+## replay
+
+`replay` prints the replay JSON for a single generation of a run, so you can inspect exactly what was produced:
+
+```bash
+autoctx replay <run-id> --generation 1
+```
+
+## show
+
+`show` renders a finished run's artifacts: run metadata plus selected generations.
+
+```bash
+# Show only the best-scoring generation
+autoctx show <run-id> --best
+
+# Show a specific generation
+autoctx show <run-id> --generation 2
+
+# Structured output
+autoctx show <run-id> --json
+```
+
+## watch
+
+`watch` follows an in-flight run, streaming live status updates until it finishes.
+
+```bash
+autoctx watch <run-id> --interval 2
+```
+
+`--interval` sets the poll interval in seconds (default 2.0). With `--json`, `watch` emits one JSONL row per poll, which is handy for piping progress into another process.
+
+## list
+
+`list` shows recent runs:
+
+```bash
+autoctx list
+autoctx list --json
+```
+
+## status
+
+`status` reports the current state of a run by id:
+
+```bash
+autoctx status <run-id>
+autoctx status <run-id> --json
+```
+
+<Callout type="info">
+`status` is overloaded: with a run id it reports run state, and `autoctx queue status` reports the background queue depth. See [Background Queue](/docs/cli/queue-worker).
+</Callout>
+
+## benchmark
+
+`benchmark` runs repeated one-generation trials for quick benchmarking and aggregates the results:
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx benchmark --scenario grid_ctf --runs 3
+```
+
+`--runs` sets how many trials to run (default 3). The scenario defaults to `grid_ctf`.
+
+## Related
+
+- [The self-improving loop](/docs/concepts/the-loop): what a generation actually does.
+- [Runs, traces, and artifacts](/docs/concepts/runs-traces-artifacts): what `show` and `replay` surface.

--- a/apps/docs/content/docs/cli/solve-run.mdx
+++ b/apps/docs/content/docs/cli/solve-run.mdx
@@ -9,26 +9,11 @@ The core working loop of autoctx is: turn a goal into a scenario, run it, and in
 
 `solve` takes a plain-language description, compiles it into a scenario, and runs the improvement loop on it. It is the fastest path from an idea to a result.
 
-<Tabs items={['Python','TypeScript']}>
-<Tab value="Python">
-
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=pi autoctx solve \
   "build an orbital transfer optimizer" \
   --iterations 3
 ```
-
-</Tab>
-<Tab value="TypeScript">
-
-```bash
-AUTOCONTEXT_AGENT_PROVIDER=pi autoctx solve \
-  "build an orbital transfer optimizer" \
-  --iterations 3
-```
-
-</Tab>
-</Tabs>
 
 The description can be a positional argument, the `--description` / `-d` flag, or loaded from a file with `--task-file` (mutually exclusive with `--description`, convenient for long prompts). Other useful flags:
 
@@ -44,26 +29,11 @@ The description can be a positional argument, the `--description` / `-d` flag, o
 
 `run` executes the generation loop for a scenario that already exists (for example `grid_ctf`), rather than compiling one from a description.
 
-<Tabs items={['Python','TypeScript']}>
-<Tab value="Python">
-
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=pi autoctx run \
   --scenario grid_ctf \
   --iterations 3
 ```
-
-</Tab>
-<Tab value="TypeScript">
-
-```bash
-AUTOCONTEXT_AGENT_PROVIDER=pi autoctx run \
-  --scenario grid_ctf \
-  --iterations 3
-```
-
-</Tab>
-</Tabs>
 
 The scenario can be passed positionally (`autoctx run grid_ctf`) or via `--scenario`. When neither is given, it defaults to `grid_ctf`. Flags:
 

--- a/apps/docs/content/docs/concepts/evaluation.mdx
+++ b/apps/docs/content/docs/concepts/evaluation.mdx
@@ -1,0 +1,29 @@
+---
+title: Evaluation
+description: How autocontext scores work, with rubrics and tournaments.
+---
+
+Every generation has to be scored before the loop can decide whether to advance. autocontext uses two evaluation methods depending on the kind of scenario: a judge against a rubric for agent-task scenarios, and Elo-based tournament scoring for game scenarios. The score is what the [backpressure gate](/docs/concepts/the-loop) acts on.
+
+## Rubric and judge for agent-task scenarios
+
+Agent-task scenarios are prompt-centric: the output is a candidate response that needs to be assessed for quality. These are evaluated by an LLM judge against a rubric. The judge reads the task, the candidate output, and the rubric, then produces a score. autocontext samples the judge and uses a tolerant parser to extract the score reliably, so a single malformed response does not derail evaluation.
+
+This is the path used when you frame work as a task or an agent-task scenario, and it is what powers the `autoctx judge` and `autoctx improve` commands.
+
+## Elo and tournaments for game scenarios
+
+Game scenarios (such as `grid_ctf` and `othello`) have stable rules and head-to-head matches rather than a single gradable output. These are scored by playing tournament matches and tracking Elo ratings. A new strategy is good if it wins against the field, and Elo progression is what the loop uses to gate whether a generation advances.
+
+## The judge provider
+
+The judge runs on a configurable LLM provider. By default, `judge_provider=auto` inherits the provider from the first configured agent role, falling back to Anthropic if none is configured. This keeps the judge consistent with the models running the rest of the loop unless you deliberately point it elsewhere (for example, to evaluate with a different or independent model).
+
+<Callout type="info">
+Setting the judge to a different provider than the agents is a common way to reduce shared-model bias in evaluation. The judge provider, model, sample count, and temperature are all configurable.
+</Callout>
+
+## Related
+
+- [Evaluation CLI commands](/docs/cli/evaluation-cmds): running `judge` and `improve` from the command line.
+- [Per-role and judge providers](/docs/providers/per-role-and-judge): configuring which model evaluates and how provider inheritance works.

--- a/apps/docs/content/docs/concepts/index.mdx
+++ b/apps/docs/content/docs/concepts/index.mdx
@@ -1,0 +1,41 @@
+---
+title: The Self-Improving Loop
+description: How autocontext turns a goal into compounding knowledge.
+---
+
+autocontext is a recursive self-improving harness. You give it a goal, it runs that goal as a concrete execution, evaluates the result, curates what is worth keeping, and feeds that curated knowledge back into the next run. Each pass starts from everything the last one learned rather than from scratch, so results compound over time.
+
+## The cycle
+
+The whole system is one loop. A goal is framed as a scenario or task, executed as a run, scored by an evaluator, and distilled into curated knowledge. The next run inherits that knowledge, so the starting point keeps improving.
+
+```mermaid
+flowchart LR
+  goal[Goal] --> frame[Scenario or Task]
+  frame --> run[Run]
+  run --> eval[Evaluation]
+  eval --> curate[Curated Knowledge]
+  curate -. inherited by next run .-> run
+```
+
+The knowledge written at the end of one run (playbooks, hints, and lessons) is persisted per scenario and loaded back in at the start of the next run. That feedback edge is what makes re-running the same goal tend to do better, not just differently.
+
+## The five roles
+
+Within a run, the work is divided across five LLM agent roles that collaborate each generation:
+
+- **Competitor** proposes strategies (the candidate work for the generation).
+- **Analyst** explains what happened (findings, root causes, recommendations).
+- **Coach** updates the playbook and hints carried forward.
+- **Architect** proposes tooling improvements.
+- **Curator** gates which knowledge is allowed to persist.
+
+These roles, and how a run advances generation by generation through a backpressure gate, are covered in [The Generation Loop](/docs/concepts/the-loop).
+
+## Where to go next
+
+- [Scenarios, Tasks, Missions, Campaigns](/docs/concepts/scenarios-tasks): the four ways you frame work.
+- [The Generation Loop](/docs/concepts/the-loop): the five roles and how a run advances.
+- [Knowledge](/docs/concepts/knowledge): what persists across runs and how it is curated.
+- [Runs, Traces, Artifacts](/docs/concepts/runs-traces-artifacts): the outputs a run produces and how to read them.
+- [Evaluation](/docs/concepts/evaluation): how work is scored, with rubrics and tournaments.

--- a/apps/docs/content/docs/concepts/knowledge.mdx
+++ b/apps/docs/content/docs/concepts/knowledge.mdx
@@ -1,0 +1,36 @@
+---
+title: Knowledge
+description: What persists across runs and how it is curated.
+---
+
+Knowledge is the part of autocontext that compounds. While a run's artifacts are per-run and disposable, knowledge is persisted state that should carry forward across runs: playbooks, hints, lessons, and analysis. It is stored per scenario, so each scenario accumulates its own body of learned strategy.
+
+## Where knowledge lives
+
+Knowledge is written under the knowledge root (default `knowledge/`, override with `AUTOCONTEXT_KNOWLEDGE_ROOT`), in a per-scenario directory:
+
+- `playbook.md`: the accumulated strategy the next run inherits. It is versioned with rollback support.
+- `hints.md`: targeted advice from the coach, carried forward across runs.
+- `lessons.json`: consolidated, structured lessons distilled from past runs. This is JSON, not markdown.
+- `tools/`: tooling the architect generates for the scenario (older versions move to an `_archive/` subdirectory).
+- `snapshots/<run_id>/`: a cross-run snapshot of the knowledge as it stood at the end of a run, used for cross-run inheritance.
+- `reports/<run_id>.md`: the human-readable session report for a completed run.
+- `analysis/`, `progress_reports/`, and `weakness_reports/`: per-generation and per-run analysis written during the loop.
+
+<Callout type="info">
+`lessons.json` is structured JSON, not a markdown file. The playbook and hints are markdown so they read cleanly as prompt context, but lessons are stored as data so they can be consolidated and filtered programmatically.
+</Callout>
+
+## How knowledge is curated
+
+Not everything a run produces becomes durable knowledge. During each generation, the analyst and coach extract patterns from the run, and the curator gates which of those patterns are allowed to persist (see [The Generation Loop](/docs/concepts/the-loop)). The curator accepts, rejects, or merges proposed playbook and lesson updates, and only changes on an advancing generation are kept. This is what keeps persisted knowledge high-signal rather than an accumulation of every attempt.
+
+## Consolidation and decay
+
+Across many runs, raw knowledge would grow without bound, so autocontext consolidates it. Cross-run compaction and lesson consolidation distill repeated observations into fewer, stronger entries, and stale or low-value hints decay out over time rather than accumulating forever. The result is a body of knowledge that stays compact and applicable instead of bloating as runs pile up.
+
+Optionally, knowledge can also be exported: a distillation step can produce a portable skill package, and a local model snapshot can be trained from accumulated runs.
+
+## Knowledge in the prompt
+
+Persisted knowledge is not just stored, it is loaded back into the agents. At the start of each run, the applicable playbook, hints, and lessons for the scenario are assembled into the context the roles see, alongside the scenario or task inputs. That assembly is what turns yesterday's curated lessons into today's starting advantage.

--- a/apps/docs/content/docs/concepts/meta.json
+++ b/apps/docs/content/docs/concepts/meta.json
@@ -1,0 +1,11 @@
+{
+  "title": "Core Concepts",
+  "pages": [
+    "index",
+    "scenarios-tasks",
+    "the-loop",
+    "knowledge",
+    "runs-traces-artifacts",
+    "evaluation"
+  ]
+}

--- a/apps/docs/content/docs/concepts/runs-traces-artifacts.mdx
+++ b/apps/docs/content/docs/concepts/runs-traces-artifacts.mdx
@@ -1,0 +1,47 @@
+---
+title: Runs, Traces, Artifacts
+description: The outputs a run produces and how to read them.
+---
+
+A run is the fundamental runtime unit in autocontext: a concrete execution instance of a scenario or task. Everything the system does at runtime happens inside a run. This page covers what a run writes to disk, the trace that records what it did, and how to tell transient run output apart from the knowledge that persists.
+
+## What a run produces
+
+A run writes its output under the runs root (default `runs/`, override with `AUTOCONTEXT_RUNS_ROOT`), in a per-run directory keyed by run id. Each pass of the loop writes its artifacts to a per-generation directory:
+
+- `runs/<run_id>/generations/gen_<N>/`: the artifacts produced by generation `N`, one directory per generation.
+
+These are the transient outputs of a run: candidate strategies, scored results, replays, and per-generation records. They are useful for inspection and debugging, but they are not the part that compounds.
+
+## The trace
+
+Every run also records an append-only trace: the ground-truth record of each action, LLM call, and decision, in order. The trace is the authoritative log of what actually happened during a run, and it is what replay and analysis read from.
+
+Rather than reading a raw file at a fixed path, inspect the trace through the CLI and the runtime-session readers:
+
+```bash
+autoctx show <run-id>              # inspect what a run did
+autoctx show <run-id> --best       # focus on the best generation
+autoctx replay <run-id>            # replay a run's events
+```
+
+<Callout type="info">
+Treat the trace as an append-only event log inspected through `autoctx show` and `autoctx replay`, not as a single fixed file you parse yourself. The trace is observational: it lets you replay what happened, not deterministically re-execute it.
+</Callout>
+
+## The session report
+
+When a run completes, autocontext writes a human-readable session report at:
+
+- `knowledge/<scenario>/reports/<run_id>.md`
+
+Note that this report lives under the knowledge root, not the runs root, because it is a durable per-run summary kept alongside the scenario's accumulated knowledge.
+
+## Transient output versus persisted knowledge
+
+The key distinction is between two roots:
+
+- **`runs/`** holds per-run output. The run directory is per-run and disposable. You can delete old run directories without losing what the system learned.
+- **`knowledge/`** holds what compounds across runs (playbooks, hints, lessons, and snapshots). This is the part the next run inherits.
+
+Both roots default to relative directories and are configurable: set `AUTOCONTEXT_RUNS_ROOT` and `AUTOCONTEXT_KNOWLEDGE_ROOT` to relocate them (for example, to a persistent volume on a shared host). For what lives under the knowledge root and how it is curated, see [Knowledge](/docs/concepts/knowledge).

--- a/apps/docs/content/docs/concepts/scenarios-tasks.mdx
+++ b/apps/docs/content/docs/concepts/scenarios-tasks.mdx
@@ -1,0 +1,34 @@
+---
+title: Scenarios, Tasks, Missions, Campaigns
+description: The four ways you frame work for autocontext.
+---
+
+autocontext uses four user-facing nouns to describe what you want it to do. They differ in how the work is scoped, how it is evaluated, and how long it runs. Underneath, the runtime turns any of them into one or more runs (see [Runs, Traces, Artifacts](/docs/concepts/runs-traces-artifacts)).
+
+## Scenario
+
+A scenario is a reusable environment, simulation, or evaluation context with stable rules and scoring. It is the most established concept in autocontext: implemented across the Python and TypeScript packages, the CLI, MCP, and the API. Built-in game scenarios include `grid_ctf` and `othello`, and you can also author agent-task scenarios or generate custom ones from a natural-language description.
+
+Because a scenario carries stable rules and a scoring method, it is what knowledge accumulates against. Playbooks, hints, and lessons are stored per scenario under `knowledge/<scenario>/`.
+
+## Task
+
+A task is a user-authored unit of work, a prompt-centric objective that can be evaluated directly or embedded inside another surface. Where a scenario is an environment, a task is closer to a single prompt with an expected outcome that a judge can score.
+
+<Callout type="info">
+The name `task` is overloaded in the codebase: there is the user-facing task concept described here, an internal `AgentTask`/`AgentTaskSpec` type, and a background evaluation job in the task queue. In docs and product copy, `task` means the prompt-centric objective.
+</Callout>
+
+## Mission
+
+A mission is a long-running goal advanced step by step until a verifier says it is complete. Unlike a single run, a mission is expected to take many steps, and a runtime verifier decides when the goal has actually been met. Missions are a first-class control-plane concept in the TypeScript runtime today (with `autoctx mission create` and `autoctx mission run`), and are still being generalized into the Python package.
+
+## Campaign
+
+A campaign is a planned grouping of missions, runs, and scenarios used to coordinate broader work over time. Campaigns provide the richest orchestration layer, and that layer is more developed in the TypeScript runtime today: partial support exists through the TypeScript CLI, API, and MCP surfaces, but there is not yet a Python package campaign workflow.
+
+## solve is an operation, not a primitive
+
+It is tempting to treat `solve` as a fifth noun, but it is not. `solve` is a workflow operation: it creates or selects a scenario or task, launches a run, and exports the resulting knowledge. In other words, `solve` is a convenient verb wrapping the run lifecycle, not a peer concept alongside scenario, task, mission, and campaign.
+
+The same is true of `run` at the surface level: the CLI and MCP keep the verb, but the underlying noun is a run, the concrete execution instance described in [Runs, Traces, Artifacts](/docs/concepts/runs-traces-artifacts).

--- a/apps/docs/content/docs/concepts/the-loop.mdx
+++ b/apps/docs/content/docs/concepts/the-loop.mdx
@@ -1,0 +1,45 @@
+---
+title: The Generation Loop
+description: The five roles and how a run advances generation by generation.
+---
+
+A run advances in discrete passes called generations. Each generation loads the scenario plus the knowledge persisted from earlier runs, orchestrates the agent roles to produce and analyze candidate work, scores it, and then decides whether the run should advance, retry, or roll back. The knowledge persisted from earlier runs is what makes each generation start ahead of the last.
+
+## A generation, step by step
+
+```mermaid
+flowchart TD
+  load[Load scenario + persisted knowledge] --> roles[Run the agent roles]
+  roles --> score[Score the generation]
+  score --> gate[Backpressure gate]
+  gate -->|advance| persist[Persist + carry knowledge forward]
+  gate -->|retry| roles
+  gate -->|rollback| restore[Restore prior playbook]
+  persist --> curate[Curator quality gate]
+```
+
+Each generation loads the scenario and accumulated knowledge, runs the competitor first, then the analyst, coach, and architect (in parallel), scores the result, applies the backpressure gate, and lets the curator decide what knowledge is allowed to persist. Lessons are periodically consolidated across generations.
+
+## The five roles
+
+- **Competitor** proposes strategies. It produces the candidate work for the generation (a JSON strategy, or executable code when code strategies are enabled).
+- **Analyst** explains what happened. It produces a markdown analysis with findings, root causes, and recommendations.
+- **Coach** updates the playbook and the hints carried into the next generation.
+- **Architect** proposes tooling improvements, and can persist generated tools for the scenario.
+- **Curator** is the quality gate. It decides which playbook updates and lessons are good enough to keep, and it periodically consolidates lessons.
+
+The competitor runs first because the other roles react to what it produced. The analyst, coach, and architect then run together, and the curator gates the result.
+
+## The backpressure gate
+
+After a generation is scored, a backpressure gate decides how the run proceeds. It has three outcomes:
+
+- **advance**: the generation improved enough, so the run moves forward and the playbook update persists.
+- **retry**: the result was not a clear improvement, so the generation is attempted again rather than locked in.
+- **rollback**: the result regressed, so the run restores a prior state instead of carrying a bad change forward.
+
+Playbook updates only persist on `advance`, which keeps regressions from polluting the knowledge that future runs inherit.
+
+## The curator quality gate
+
+The backpressure gate decides whether a generation advances. The curator decides what knowledge survives. It acts as a quality gate over playbook updates and lessons, accepting, rejecting, or merging proposed changes, and consolidating lessons over time. This is the mechanism that keeps persisted [knowledge](/docs/concepts/knowledge) high-signal instead of letting every generation's output accumulate.

--- a/apps/docs/content/docs/faq.mdx
+++ b/apps/docs/content/docs/faq.mdx
@@ -1,0 +1,20 @@
+---
+title: FAQ
+description: Common questions about installing and using autocontext.
+---
+
+## Do I need an API key?
+
+No. With the Pi runtime, a CLI runtime (claude-cli, codex, hermes), or a local provider (ollama, vllm, mlx), you authenticate through that tool, not through autocontext. The default `deterministic` provider is fully offline and needs no credentials at all. See [providers](/docs/providers) for the full list and how to pick one.
+
+## Python or TypeScript?
+
+Both. Each package exposes the same `autoctx` CLI, and the two are at parity for most surfaces. Python is the primary package, and the control-plane commands are TypeScript-only. See [the CLI overview](/docs/cli) for which commands live where.
+
+## Where do my results go?
+
+Each run writes to `runs/<run_id>/`, which holds the trace, report, generations, and artifacts for that run. Learned knowledge that survives across runs persists under `knowledge/<scenario>/`. See [runs, traces, and artifacts](/docs/concepts/runs-traces-artifacts) for the full layout.
+
+## How is this different from a prompt loop?
+
+autocontext evaluates against real scoring rather than self-assessment, persists curated knowledge across runs so later runs inherit what earlier ones learned, and splits the work across five specialized roles instead of a single repeated prompt. See [the self-improving loop](/docs/concepts) for how those pieces fit together.

--- a/apps/docs/content/docs/faq.mdx
+++ b/apps/docs/content/docs/faq.mdx
@@ -5,7 +5,7 @@ description: Common questions about installing and using autocontext.
 
 ## Do I need an API key?
 
-No. With the Pi runtime, a CLI runtime (claude-cli, codex, hermes), or a local provider (ollama, vllm, mlx), you authenticate through that tool, not through autocontext. The default `deterministic` provider is fully offline and needs no credentials at all. See [providers](/docs/providers) for the full list and how to pick one.
+Not always. API providers like Anthropic and OpenAI need a key. With the Pi runtime, a CLI runtime (claude-cli, codex, hermes), or a local provider (ollama, vllm, mlx), you authenticate through that tool, not through autocontext. The `deterministic` provider is fully offline and needs nothing. See [providers](/docs/providers) for the full list and how to pick one.
 
 ## Python or TypeScript?
 

--- a/apps/docs/content/docs/faq.mdx
+++ b/apps/docs/content/docs/faq.mdx
@@ -13,7 +13,7 @@ Both. Each package exposes the same `autoctx` CLI, and the two are at parity for
 
 ## Where do my results go?
 
-Each run writes to `runs/<run_id>/`, which holds the trace, report, generations, and artifacts for that run. Learned knowledge that survives across runs persists under `knowledge/<scenario>/`. See [runs, traces, and artifacts](/docs/concepts/runs-traces-artifacts) for the full layout.
+Each run writes per-generation artifacts to `runs/<run_id>/` (under `generations/gen_<N>/`). Learned knowledge that survives across runs, including the human-readable session report at `reports/<run_id>.md`, persists under `knowledge/<scenario>/`. The run's event trace is not a fixed top-level file; inspect it with `autoctx show`/`autoctx replay`. See [runs, traces, and artifacts](/docs/concepts/runs-traces-artifacts) for the full layout.
 
 ## How is this different from a prompt loop?
 

--- a/apps/docs/content/docs/get-started/installation.mdx
+++ b/apps/docs/content/docs/get-started/installation.mdx
@@ -1,0 +1,47 @@
+---
+title: Installation
+description: Install the autocontext CLI for Python or TypeScript.
+---
+
+autocontext ships a Python package and a TypeScript package. Both expose the same `autoctx` binary, so pick whichever fits your stack.
+
+## Install the CLI
+
+<Tabs items={['Python', 'TypeScript']}>
+<Tab value="Python">
+```bash
+uv tool install autocontext==0.5.0
+```
+
+This requires Python 3.11 or newer. If you prefer pip, `pip install autocontext` works too.
+</Tab>
+<Tab value="TypeScript">
+```bash
+bun add -g autoctx@0.5.0
+```
+
+If you prefer npm, `npm i -g autoctx` works too.
+</Tab>
+</Tabs>
+
+Both packages install the same `autoctx` command, so the rest of these docs apply no matter which one you chose. Confirm the install with:
+
+```bash
+autoctx --help
+```
+
+## Provider credentials
+
+autocontext runs your task through an agent provider, and how you authenticate depends on which provider you pick.
+
+- The Pi runtime is the zero-config path: install Pi, and it handles its own auth. There is no API key to plumb through autocontext.
+- API providers (Anthropic, OpenAI, and others) need a key set in the matching environment variable, for example `ANTHROPIC_API_KEY`.
+- The `deterministic` provider runs fully offline and needs no credentials at all, which is handy for a first smoke test.
+
+<Callout type="info">
+Without any configuration, autocontext targets the `anthropic` provider, which needs `ANTHROPIC_API_KEY`. Set `AUTOCONTEXT_AGENT_PROVIDER` explicitly to choose a different runtime. See [providers](/docs/providers) for the full list and how to pick one.
+</Callout>
+
+## Next step
+
+With the CLI installed, head to [the quickstart](/docs/get-started/quickstart) to run your first solve.

--- a/apps/docs/content/docs/get-started/meta.json
+++ b/apps/docs/content/docs/get-started/meta.json
@@ -1,0 +1,1 @@
+{ "title": "Get Started", "pages": ["installation", "quickstart", "your-first-solve"] }

--- a/apps/docs/content/docs/get-started/quickstart.mdx
+++ b/apps/docs/content/docs/get-started/quickstart.mdx
@@ -1,0 +1,44 @@
+---
+title: Quickstart
+description: Run your first solve in about 30 seconds.
+---
+
+Once the [CLI is installed](/docs/get-started/installation), a single `autoctx solve` command points autocontext at a goal in plain language and iterates against real evaluation.
+
+## The 30-second solve
+
+The Pi runtime is the recommended zero-config path: install Pi, and it handles its own auth with no API key to set. Run a first solve against a customer-support goal:
+
+<Tabs items={['Python', 'TypeScript']}>
+<Tab value="Python">
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi \
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
+```
+</Tab>
+<Tab value="TypeScript">
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi bunx autoctx solve \
+  "improve customer-support replies for billing disputes" --iterations 5 --json
+```
+</Tab>
+</Tabs>
+
+autocontext attempts the goal, scores the result, keeps what worked, and writes everything to a run directory you can inspect afterward.
+
+## Using an API provider
+
+To run against an API provider instead, set the provider and its key in the same command:
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=anthropic ANTHROPIC_API_KEY=sk-ant-... \
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
+```
+
+<Callout type="info">
+Without configuration, autocontext targets the `anthropic` provider, which needs a key, so set `AUTOCONTEXT_AGENT_PROVIDER` explicitly. Use `pi` for a zero-config local run, or `deterministic` for a fully offline smoke test with no credentials.
+</Callout>
+
+## Next step
+
+Want to understand the output and how re-running improves results? Continue to [your first solve](/docs/get-started/your-first-solve).

--- a/apps/docs/content/docs/get-started/your-first-solve.mdx
+++ b/apps/docs/content/docs/get-started/your-first-solve.mdx
@@ -43,37 +43,17 @@ That directory also holds `tools/` (helpers generated along the way) and `snapsh
 
 ## Inspect the results
 
-List recent runs to find a run id, then look at a specific one. `autoctx list` is shared across both runtimes, but the per-run inspect commands differ between them.
+The inspect commands share the same names on both runtimes. List recent runs to find a run id, then look at a specific one:
 
 ```bash
-autoctx list
+autoctx list                       # recent runs
+autoctx show <run-id> --best       # best generation for a run
+autoctx watch <run-id>             # follow a run until it finishes
+autoctx status <run-id>            # generation status
 ```
-
-To look at a single run:
-
-<Tabs items={['Python', 'TypeScript']}>
-<Tab value="Python">
-```bash
-# Show generation-level status for a run
-autoctx status <run-id>
-
-# Machine-readable output
-autoctx status <run-id> --json
-```
-</Tab>
-<Tab value="TypeScript">
-```bash
-# Show the best generation for a run
-autoctx show <run-id> --best
-
-# Follow a run until it finishes
-autoctx watch <run-id>
-```
-</Tab>
-</Tabs>
 
 <Callout type="info">
-The inspect surface differs by runtime: the Python CLI exposes `autoctx status <run-id>`, while the TypeScript CLI adds `autoctx show <run-id> --best` and `autoctx watch <run-id>`. Most commands accept `--json` for machine-readable output.
+Most of these commands accept `--json` for machine-readable output, for example `autoctx list --json` or `autoctx show <run-id> --best --json`.
 </Callout>
 
 ## Why re-running improves results

--- a/apps/docs/content/docs/get-started/your-first-solve.mdx
+++ b/apps/docs/content/docs/get-started/your-first-solve.mdx
@@ -26,20 +26,26 @@ AUTOCONTEXT_AGENT_PROVIDER=pi bunx autoctx solve \
 
 ## What a run produces
 
-Each solve writes a self-contained directory at `runs/<run_id>/`. The pieces you will use most:
+autocontext writes to two roots. Both default to relative directories and can be relocated with environment variables:
 
-- `trace.jsonl`: an append-only event log, one JSON object per line. This is the ground truth for what happened during the run, in order.
-- `report.md`: a human-readable summary of the run, good for a quick read.
-- `generations/`: per-iteration records, one entry for each pass the loop made.
-- `artifacts/`: the concrete outputs the run produced.
+- `runs/` holds per-run output (override with `AUTOCONTEXT_RUNS_ROOT`).
+- `knowledge/` holds the knowledge that compounds across runs (override with `AUTOCONTEXT_KNOWLEDGE_ROOT`).
 
-Knowledge that survives across runs lives separately, under `knowledge/<scenario>/`:
+Under `runs/<run_id>/`, each pass of the loop writes its artifacts to a per-generation directory:
+
+- `generations/gen_<N>/`: the artifacts produced by generation `N`, one directory per iteration.
+
+The compounding knowledge lives separately, per scenario, under `knowledge/<scenario>/`:
 
 - `playbook.md`: the accumulated strategy the next run inherits.
 - `hints.md`: targeted advice carried forward for the next attempt.
-- `lessons.md`: consolidated lessons distilled from past runs.
+- `lessons.json`: consolidated, structured lessons distilled from past runs.
+- `snapshots/<run_id>/`: a cross-run snapshot of the knowledge as it stood at the end of each run.
+- `reports/<run_id>.md`: the human-readable session report for a completed run.
 
-That directory also holds `tools/` (helpers generated along the way) and `snapshots/` (cross-run state). The run directory is per-run and disposable, while the knowledge directory is the part that compounds.
+The run directory is per-run and disposable, while the knowledge directory is the part that compounds.
+
+Every run also records an append-only trace: the ground-truth record of each action, LLM call, and decision, in order. Rather than reading a raw file, inspect it through the CLI with `autoctx show <run-id>` and `autoctx replay`, and through the runtime-session readers.
 
 ## Inspect the results
 

--- a/apps/docs/content/docs/get-started/your-first-solve.mdx
+++ b/apps/docs/content/docs/get-started/your-first-solve.mdx
@@ -1,0 +1,85 @@
+---
+title: Your First Solve
+description: Run a solve and understand the output it produces.
+---
+
+This walkthrough runs a solve, then explains the files it produces and how to inspect them. It assumes the [CLI is installed](/docs/get-started/installation).
+
+## Run a solve
+
+Using the zero-config Pi runtime:
+
+<Tabs items={['Python', 'TypeScript']}>
+<Tab value="Python">
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi \
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
+```
+</Tab>
+<Tab value="TypeScript">
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi bunx autoctx solve \
+  "improve customer-support replies for billing disputes" --iterations 5 --json
+```
+</Tab>
+</Tabs>
+
+## What a run produces
+
+Each solve writes a self-contained directory at `runs/<run_id>/`. The pieces you will use most:
+
+- `trace.jsonl`: an append-only event log, one JSON object per line. This is the ground truth for what happened during the run, in order.
+- `report.md`: a human-readable summary of the run, good for a quick read.
+- `generations/`: per-iteration records, one entry for each pass the loop made.
+- `artifacts/`: the concrete outputs the run produced.
+
+Knowledge that survives across runs lives separately, under `knowledge/<scenario>/`:
+
+- `playbook.md`: the accumulated strategy the next run inherits.
+- `hints.md`: targeted advice carried forward for the next attempt.
+- `lessons.md`: consolidated lessons distilled from past runs.
+
+That directory also holds `tools/` (helpers generated along the way) and `snapshots/` (cross-run state). The run directory is per-run and disposable, while the knowledge directory is the part that compounds.
+
+## Inspect the results
+
+List recent runs to find a run id, then look at a specific one. `autoctx list` is shared across both runtimes, but the per-run inspect commands differ between them.
+
+```bash
+autoctx list
+```
+
+To look at a single run:
+
+<Tabs items={['Python', 'TypeScript']}>
+<Tab value="Python">
+```bash
+# Show generation-level status for a run
+autoctx status <run-id>
+
+# Machine-readable output
+autoctx status <run-id> --json
+```
+</Tab>
+<Tab value="TypeScript">
+```bash
+# Show the best generation for a run
+autoctx show <run-id> --best
+
+# Follow a run until it finishes
+autoctx watch <run-id>
+```
+</Tab>
+</Tabs>
+
+<Callout type="info">
+The inspect surface differs by runtime: the Python CLI exposes `autoctx status <run-id>`, while the TypeScript CLI adds `autoctx show <run-id> --best` and `autoctx watch <run-id>`. Most commands accept `--json` for machine-readable output.
+</Callout>
+
+## Why re-running improves results
+
+Run the same solve again and it tends to do better, not just differently. That is because knowledge persists across runs: the playbook, hints, and lessons written to `knowledge/<scenario>/` are inherited by the next run, so each pass starts from everything the last one learned rather than from scratch.
+
+## Next step
+
+For the deeper model behind runs, knowledge, and the loop, read [core concepts](/docs/concepts).

--- a/apps/docs/content/docs/guides/distillation-mlx.mdx
+++ b/apps/docs/content/docs/guides/distillation-mlx.mdx
@@ -5,14 +5,14 @@ description: Train a distilled local model on Apple Silicon.
 
 ## Overview
 
-autocontext's `autoctx train` command uses [MLX](https://github.com/ml-explore/mlx) to fine-tune local models from exported run data. With `--backend mlx`, training distills a local model from the JSONL data your runs produced, and the resulting checkpoint becomes a [snapshot](/docs/concepts) that `MLXProvider` can load for local inference.
+autocontext's `autoctx train` command uses [MLX](https://github.com/ml-explore/mlx) to fine-tune local models from exported run data. With `--backend mlx`, training distills a local model from the JSONL data your runs produced, and the resulting checkpoint becomes a [snapshot](/docs/concepts/knowledge) that `MLXProvider` can load for local inference.
 
 MLX requires direct access to Apple's Metal GPU framework, which means training must run on the macOS host, not inside a Docker sandbox.
 
 Docker containers on macOS run inside a Linux VM and cannot access Metal. The MLX Python package may install on Linux aarch64, but training cannot complete without a Metal-capable Apple Silicon host. Host-side Python environments also cannot be executed directly from the sandbox when they point to macOS-native binaries.
 
 <Callout type="info">
-  See [the train command](/docs/cli/export-import) for exporting run data and invoking training, and [local providers](/docs/providers/local) for serving the resulting checkpoint.
+  See [export and train commands](/docs/cli/export-import) for exporting run data and invoking training, and [local providers](/docs/providers/local) for serving the resulting checkpoint.
 </Callout>
 
 ## Prerequisites

--- a/apps/docs/content/docs/guides/distillation-mlx.mdx
+++ b/apps/docs/content/docs/guides/distillation-mlx.mdx
@@ -1,0 +1,305 @@
+---
+title: Distillation on MLX
+description: Train a distilled local model on Apple Silicon.
+---
+
+## Overview
+
+autocontext's `autoctx train` command uses [MLX](https://github.com/ml-explore/mlx) to fine-tune local models from exported run data. With `--backend mlx`, training distills a local model from the JSONL data your runs produced, and the resulting checkpoint becomes a [snapshot](/docs/concepts) that `MLXProvider` can load for local inference.
+
+MLX requires direct access to Apple's Metal GPU framework, which means training must run on the macOS host, not inside a Docker sandbox.
+
+Docker containers on macOS run inside a Linux VM and cannot access Metal. The MLX Python package may install on Linux aarch64, but training cannot complete without a Metal-capable Apple Silicon host. Host-side Python environments also cannot be executed directly from the sandbox when they point to macOS-native binaries.
+
+<Callout type="info">
+  See [the train command](/docs/cli/export-import) for exporting run data and invoking training, and [local providers](/docs/providers/local) for serving the resulting checkpoint.
+</Callout>
+
+## Prerequisites
+
+| Component | Version | Install |
+|-----------|---------|---------|
+| Apple Silicon Mac | M1/M2/M3/M4 | - |
+| macOS | Tahoe (26.x) or later | - |
+| Homebrew | Latest | [brew.sh](https://brew.sh) |
+| Python | 3.12+ | `brew install python@3.12` |
+| uv | 0.10+ | `brew install uv` |
+
+The package requires Python 3.11+, but Homebrew Python 3.12 is the safest host setup for MLX on Apple Silicon.
+
+## Installation
+
+### 1. Install Python and uv
+
+```bash
+brew install python@3.12
+brew install uv
+```
+
+### 2. Sync the MLX dependency group
+
+From the `autocontext/` directory:
+
+```bash
+cd <project-root>/autocontext
+uv sync --group dev --extra mlx
+```
+
+This installs the MLX-specific extras:
+
+- `mlx>=0.30.0`
+- `rustbpe>=0.1.0`
+- `tiktoken>=0.11.0`
+- `safetensors>=0.4.0`
+
+## Running training
+
+Export JSONL data from completed runs:
+
+```bash
+cd <project-root>/autocontext
+uv run autoctx export-training-data \
+  --scenario grid_ctf \
+  --all-runs \
+  --output training/grid_ctf.jsonl
+```
+
+Run training on the host:
+
+```bash
+cd <project-root>/autocontext
+uv run autoctx train \
+  --scenario grid_ctf \
+  --data /absolute/path/to/training/grid_ctf.jsonl \
+  --time-budget 300
+```
+
+Use absolute paths for `--data`. The CLI resolves relative paths from the current working directory, which may differ from the location that originally produced the training data.
+
+The training loop writes its workspace under `runs/train_<scenario>/` and produces a checkpoint bundle that `MLXProvider` can load for local inference.
+
+## Automating host training for sandboxed agents
+
+For sandboxed agents, especially OpenClaw agents running in Docker, the cleanest low-risk approach is a file-based host-training bridge.
+
+### Why a file bridge
+
+- the sandbox cannot access Metal directly
+- you do not need to expose a network service
+- you do not need to grant broad host exec permissions to the sandbox
+- the agent can request training asynchronously and poll for results through the shared workspace
+
+### How it works
+
+1. The agent writes `request-*.json` into a watched directory.
+2. A host-side `launchd` agent notices the file and runs a watcher script.
+3. The watcher script invokes `uv run autoctx train` on the host.
+4. The watcher writes `<request>-result.json` back to the same directory.
+5. The agent polls for the result file and then loads the produced local artifact.
+
+## Request format
+
+The agent writes a request file such as `request-123.json`:
+
+```json
+{
+  "scenario": "grid_ctf",
+  "data": "/absolute/path/to/training-data.jsonl",
+  "time_budget": 60
+}
+```
+
+## Result format
+
+Successful run:
+
+```json
+{
+  "status": "success",
+  "scenario": "grid_ctf",
+  "timestamp": "2026-03-12T02:49:33Z"
+}
+```
+
+Failure:
+
+```json
+{
+  "status": "error",
+  "exit_code": 1,
+  "scenario": "grid_ctf",
+  "timestamp": "2026-03-12T02:49:33Z"
+}
+```
+
+## Reference watcher script
+
+Save as `~/.openclaw/scripts/autocontext-train-watcher.sh`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+REQUEST_DIR="$HOME/.openclaw/workspace/autocontext/runs/train-requests"
+AUTOCTX_DIR="$HOME/.openclaw/workspace/autocontext/autocontext"
+LOG="/tmp/autocontext-train-watcher.log"
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) watcher triggered" >> "$LOG"
+
+for req in "$REQUEST_DIR"/request-*.json; do
+  [ -f "$req" ] || continue
+  [[ "$req" == *-result.json ]] && continue
+  [ -s "$req" ] || { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) skipping empty file: $req" >> "$LOG"; continue; }
+
+  BASENAME="$(basename "$req" .json)"
+  RESULT_FILE="$REQUEST_DIR/${BASENAME}-result.json"
+
+  [ -f "$RESULT_FILE" ] && continue
+
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) processing $req" >> "$LOG"
+
+  SCENARIO=$(python3.12 -c "import json,sys; print(json.load(open(sys.argv[1]))['scenario'])" "$req" 2>/dev/null || echo "")
+  DATA_PATH=$(python3.12 -c "import json,sys; print(json.load(open(sys.argv[1]))['data'])" "$req" 2>/dev/null || echo "")
+  TIME_BUDGET=$(python3.12 -c "import json,sys; print(json.load(open(sys.argv[1])).get('time_budget', 60))" "$req" 2>/dev/null || echo "60")
+
+  if [ -z "$SCENARIO" ] || [ -z "$DATA_PATH" ]; then
+    echo "{\"status\":\"error\",\"message\":\"missing scenario or data in request\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$RESULT_FILE"
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) error: missing fields in $req" >> "$LOG"
+    continue
+  fi
+
+  cd "$AUTOCTX_DIR"
+  if /opt/homebrew/bin/uv run autoctx train --scenario "$SCENARIO" --data "$DATA_PATH" --time-budget "$TIME_BUDGET" >> "$LOG" 2>&1; then
+    echo "{\"status\":\"success\",\"scenario\":\"$SCENARIO\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$RESULT_FILE"
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) training complete for $SCENARIO" >> "$LOG"
+  else
+    EXIT_CODE=$?
+    echo "{\"status\":\"error\",\"exit_code\":$EXIT_CODE,\"scenario\":\"$SCENARIO\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$RESULT_FILE"
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) training failed ($EXIT_CODE) for $SCENARIO" >> "$LOG"
+  fi
+done
+```
+
+Make it executable:
+
+```bash
+chmod 755 ~/.openclaw/scripts/autocontext-train-watcher.sh
+```
+
+## Reference `launchd` plist
+
+Save as `~/Library/LaunchAgents/com.autocontext.train-watcher.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.autocontext.train-watcher</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/cirdan/.openclaw/scripts/autocontext-train-watcher.sh</string>
+  </array>
+  <key>WatchPaths</key>
+  <array>
+    <string>/Users/cirdan/.openclaw/workspace/autocontext/runs/train-requests</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/tmp/autocontext-train-watcher-stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/autocontext-train-watcher-stderr.log</string>
+</dict>
+</plist>
+```
+
+Update the example paths to match your home directory and shared workspace path.
+
+Load the agent:
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.autocontext.train-watcher.plist
+launchctl list com.autocontext.train-watcher
+```
+
+## Bridge test
+
+Write a request:
+
+```bash
+echo '{"scenario": "grid_ctf", "data": "/absolute/path/to/training-data.jsonl", "time_budget": 60}' > ~/.openclaw/workspace/autocontext/runs/train-requests/request-test.json
+```
+
+Check logs and result:
+
+```bash
+cat /tmp/autocontext-train-watcher.log
+cat ~/.openclaw/workspace/autocontext/runs/train-requests/request-test-result.json
+```
+
+Clean up:
+
+```bash
+rm ~/.openclaw/workspace/autocontext/runs/train-requests/request-test*.json
+```
+
+## Alternative approaches
+
+### Gateway exec
+
+OpenClaw's host-exec gateway is cleaner in principle, but today it routes all exec traffic to the host rather than only the training command. That is too broad for Slack-style sandboxed agents and makes normal sandbox behavior awkward.
+
+### HTTP bridge
+
+A localhost HTTP bridge is possible, but it adds a service boundary and local networking complexity without giving much over the file-based trigger model.
+
+## Troubleshooting
+
+### `MLX is required`
+
+You are either running inside Docker or you have not synced the MLX extra on the host:
+
+```bash
+uv sync --group dev --extra mlx
+```
+
+### Python version errors
+
+Install Homebrew Python and verify it:
+
+```bash
+brew install python@3.12
+python3.12 --version
+```
+
+### Metal runtime failures
+
+MLX requires Apple Silicon and a Metal-capable macOS host. Intel Macs are not supported.
+
+### Watcher does not trigger
+
+Check:
+
+```bash
+launchctl list com.autocontext.train-watcher
+```
+
+Also verify that:
+
+- the watched directory exists
+- request files match `request-*.json`
+- the script is executable
+
+### Permission errors on workspace files
+
+If the sandbox created the exported data with restrictive permissions:
+
+```bash
+chmod -R u+rw ~/.openclaw/workspace/autocontext/runs/
+```

--- a/apps/docs/content/docs/guides/fixtures.mdx
+++ b/apps/docs/content/docs/guides/fixtures.mdx
@@ -1,0 +1,96 @@
+---
+title: Fixture Loader
+description: Load and cache evaluation fixtures.
+---
+
+autocontext can pre-fetch external reference data ("authoritative ground truth") before generation 1 starts, so downstream agents see the right canonical values up front instead of inferring or hallucinating them.
+
+This is different from:
+
+- `bootstrap/` which captures the **local** environment snapshot.
+- `analytics/regression_fixtures.py` which synthesizes fixtures **from friction**.
+
+The fixture loader fetches from an external URL or local path, checksum-verifies, caches, and threads a rendered summary into the agent prompts.
+
+## Quick start
+
+1. Enable the feature flag:
+
+   ```bash
+   export AUTOCONTEXT_FIXTURE_LOADER_ENABLED=true
+   ```
+
+2. Create a manifest at `autocontext/knowledge/<scenario>/fixtures.json`:
+
+   ```json
+   {
+     "entries": [
+       {
+         "key": "challenge_data",
+         "source": "https://example.com/challenge.txt",
+         "expected_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+       },
+       {
+         "key": "local_vectors",
+         "source": "/absolute/path/to/test_vectors.json"
+       }
+     ]
+   }
+   ```
+
+3. Run autocontext as usual. At gen 1 the loader will fetch each entry, store it under `autocontext/knowledge/.fixture-cache/<scenario>/<key>.bin` with a `<key>.provenance.json` sidecar, and inject a `## Available fixtures` block into agent prompts.
+
+## Manifest format
+
+| Field             | Required | Notes                                                                                                                                                                    |
+| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `key`             | yes      | Safe identifier: `^[A-Za-z0-9_][A-Za-z0-9_.\-]*$`. Path traversal is rejected.                                                                                           |
+| `source`          | yes      | `http(s)://` URL, `file://` URL, or absolute local path.                                                                                                                 |
+| `expected_sha256` | no       | 64-char hex digest. If present, every fetch and every cache read is verified against it; mismatch raises `FixtureChecksumError` (fetch) or invalidates the cache (read). |
+
+Missing manifest is a graceful no-op: no error, no event. Same for an empty `entries` list.
+
+## Cache semantics
+
+- **Cache hit + checksum match**: no network call, no fetcher invocation.
+- **Cache hit + cached `.bin` corrupted (sha mismatch vs provenance)**: cache treated as missing, full refetch.
+- **Cache hit + manifest source changed**: refetch (the source URL is part of the freshness check even when no `expected_sha256` is provided).
+- **Cache hit + manifest `expected_sha256` changed and old payload matches the new value**: still treated as fresh (your manifest pinned the new hash to the old bytes, which is presumably what you meant).
+- **Fetched body fails `expected_sha256`**: raises `FixtureChecksumError`; cache is not updated.
+- **Fetcher cannot retrieve the source**: raises `FixtureFetchError`.
+
+## How agents see it
+
+`stage_preflight.py` calls `render_fixtures(fixtures)` and assigns the result to `ctx.fixtures_section`. The prompt-budget pipeline (`prompts/context_budget.py`) gives the `fixtures` component an 800-token cap and trims it after `environment_snapshot` if the budget tightens. `prompts/templates.py` injects the rendered block between the environment snapshot and the playbook, so it appears in the competitor / analyst / coach / architect prompts.
+
+For programmatic access, agents can read `ctx.fixtures[key].bytes_` directly.
+
+## Programmatic API
+
+```python
+from autocontext.loop.fixture_loader import (
+    FixtureManifest,
+    FixtureCache,
+    UrlFetcher,
+    load_fixtures,
+    load_scenario_fixtures,
+    render_fixtures,
+)
+```
+
+- `FixtureManifest.from_json(path)`: parse a manifest file; missing path gives empty.
+- `load_fixtures(manifest, *, fetcher, cache, scenario)`: low-level orchestration.
+- `load_scenario_fixtures(scenario, *, knowledge_root, cache_root, fetcher=None)`: convenience that reads `<knowledge_root>/<scenario>/fixtures.json` and uses `UrlFetcher` by default.
+- `render_fixtures(fixtures)`: emit the `## Available fixtures` prompt block.
+
+## Settings
+
+| Setting                  | Default | Description                                   |
+| ------------------------ | ------- | --------------------------------------------- |
+| `fixture_loader_enabled` | `False` | Master switch; the loader is silent when off. |
+
+The cache directory is fixed at `.fixture-cache` under the knowledge root.
+
+<Callout type="info">
+  Fixtures are part of the [knowledge system](/docs/concepts/knowledge) that threads context into every agent prompt.
+</Callout>

--- a/apps/docs/content/docs/guides/fixtures.mdx
+++ b/apps/docs/content/docs/guides/fixtures.mdx
@@ -3,6 +3,8 @@ title: Fixture Loader
 description: Load and cache evaluation fixtures.
 ---
 
+## Overview
+
 autocontext can pre-fetch external reference data ("authoritative ground truth") before generation 1 starts, so downstream agents see the right canonical values up front instead of inferring or hallucinating them.
 
 This is different from:

--- a/apps/docs/content/docs/guides/index.mdx
+++ b/apps/docs/content/docs/guides/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Guides
+description: Operational guides for running autocontext in production.
+---
+
+These guides cover the operational concerns of running autocontext in production: where models execute, how to keep a long-lived server, loading fixtures, and capturing real traffic.
+
+- [Distillation on MLX](/docs/guides/distillation-mlx): train a distilled model locally with the MLX backend.
+- [Sandbox Modes](/docs/guides/sandbox): choose where strategies execute (local, remote, or reserved modes).
+- [Persistent Host](/docs/guides/persistent-host): run a long-lived `autoctx serve` host for the dashboard and API.
+- [Fixture Loader](/docs/guides/fixtures): seed runs and knowledge from fixtures for testing and demos.
+- [Production Traces](/docs/guides/production-traces): ingest, inspect, and build datasets from real production traffic.

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Guides",
+  "pages": ["distillation-mlx", "sandbox", "persistent-host", "fixtures", "production-traces"]
+}

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -1,4 +1,11 @@
 {
   "title": "Guides",
-  "pages": ["distillation-mlx", "sandbox", "persistent-host", "fixtures", "production-traces"]
+  "pages": [
+    "index",
+    "distillation-mlx",
+    "sandbox",
+    "persistent-host",
+    "fixtures",
+    "production-traces"
+  ]
 }

--- a/apps/docs/content/docs/guides/persistent-host.mdx
+++ b/apps/docs/content/docs/guides/persistent-host.mdx
@@ -1,0 +1,151 @@
+---
+title: Persistent Host
+description: Run autocontext serve and worker as durable services.
+---
+
+Use this shape when you want autocontext to keep accepting queued work while a server stays online.
+
+Run the HTTP API and queue worker as separate long-lived processes against the same durable workspace:
+
+```bash
+export AUTOCONTEXT_DB_PATH=/srv/autoctx/runs/autocontext.sqlite3
+export AUTOCONTEXT_RUNS_ROOT=/srv/autoctx/runs
+export AUTOCONTEXT_KNOWLEDGE_ROOT=/srv/autoctx/knowledge
+
+uv run autoctx serve --host 0.0.0.0 --port 8000
+uv run autoctx worker --poll-interval 5 --concurrency 2
+```
+
+For the TypeScript package, the equivalent worker surface is:
+
+```bash
+autoctx serve --host 0.0.0.0 --port 8000
+autoctx worker --poll-interval 5 --concurrency 2
+```
+
+`autoctx queue` and MCP `queue_task` calls write into the task queue. `autoctx worker` wraps the existing `TaskRunner`, polls that queue, processes tasks in priority order, and persists task results back into the configured store.
+
+If the selected provider/runtime is stateful and persistent, for example persistent Pi RPC, worker concurrency is forced to `1`. Use non-persistent provider instances or a hosted storage/runtime adapter when you need true parallel task execution.
+
+## Durable state
+
+Keep these paths on persistent storage:
+
+- `runs/`: run records, event streams, task queue SQLite DB, and per-run artifacts
+- `knowledge/`: playbooks, hints, custom scenarios, and reusable context
+- `skills/` and `.claude/skills/`: optional exported skills when those surfaces are enabled
+
+SQLite is the current open-source queue store. Treat the DB path as a single-writer operational boundary unless you explicitly deploy with a storage adapter that provides stronger multi-worker semantics. A Postgres-backed queue can fit the same `serve + worker` shape, but should be introduced behind the storage abstraction rather than by changing task-runner behavior.
+
+## Operational notes
+
+Use `--once` for cron, smoke tests, or CI:
+
+```bash
+uv run autoctx worker --once --concurrency 4 --json
+```
+
+Use `--max-empty-polls` for bounded workers that should exit after the queue drains:
+
+```bash
+uv run autoctx worker --poll-interval 1 --max-empty-polls 3
+```
+
+On a service manager such as systemd, run `serve` and `worker` as separate units with the same environment file. Restarting the worker should not require restarting the API process as long as both use the same durable paths.
+
+### systemd sketch
+
+Use one environment file for both units:
+
+```ini
+# /etc/autoctx/autoctx.env
+AUTOCONTEXT_DB_PATH=/srv/autoctx/runs/autocontext.sqlite3
+AUTOCONTEXT_RUNS_ROOT=/srv/autoctx/runs
+AUTOCONTEXT_KNOWLEDGE_ROOT=/srv/autoctx/knowledge
+AUTOCONTEXT_AGENT_PROVIDER=pi
+AUTOCONTEXT_PI_COMMAND=pi
+```
+
+```ini
+# /etc/systemd/system/autoctx-serve.service
+[Unit]
+Description=Autocontext HTTP API
+After=network-online.target
+
+[Service]
+WorkingDirectory=/srv/autoctx/app/autocontext
+EnvironmentFile=/etc/autoctx/autoctx.env
+ExecStart=/usr/bin/uv run autoctx serve --host 0.0.0.0 --port 8000
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```ini
+# /etc/systemd/system/autoctx-worker.service
+[Unit]
+Description=Autocontext queue worker
+After=network-online.target autoctx-serve.service
+
+[Service]
+WorkingDirectory=/srv/autoctx/app/autocontext
+EnvironmentFile=/etc/autoctx/autoctx.env
+ExecStart=/usr/bin/uv run autoctx worker --poll-interval 5 --concurrency 2
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Container sketch
+
+Keep the same image for API and worker, but run separate processes and mount the same durable volume:
+
+```yaml
+services:
+  autoctx-serve:
+    image: ghcr.io/your-org/autoctx:latest
+    command: ["uv", "run", "autoctx", "serve", "--host", "0.0.0.0", "--port", "8000"]
+    env_file: .env.autoctx
+    volumes:
+      - autoctx-state:/srv/autoctx
+    ports:
+      - "8000:8000"
+
+  autoctx-worker:
+    image: ghcr.io/your-org/autoctx:latest
+    command: ["uv", "run", "autoctx", "worker", "--poll-interval", "5", "--concurrency", "2"]
+    env_file: .env.autoctx
+    volumes:
+      - autoctx-state:/srv/autoctx
+
+volumes:
+  autoctx-state:
+```
+
+The image build, reverse proxy, auth, TLS, and secret distribution are deployment-specific. Do not bake provider API keys into images.
+
+## Storage adapter contract
+
+The OSS worker now depends on a narrow task queue contract instead of SQLite inheritance:
+
+- Python: `autocontext.execution.TaskQueueStore` / `TaskQueueEnqueueStore`
+- TypeScript: `TaskQueueWorkerStore` / `TaskQueueEnqueueStore`, with methods that may return values directly or as promises.
+
+Adapters must provide atomic task claim, task lookup, completion, failure, and enqueue semantics. SQLite is the bundled implementation. A hosted Postgres adapter can add leases, heartbeats, retries, and multi-worker coordination behind that contract without changing `TaskRunner`.
+
+What should stay outside the OSS contract is the hosted control plane: tenant scheduling, billing, policy UI, fleet routing, secret brokering, and managed retention/audit workflows.
+
+## Sandbox boundary
+
+The worker uses the same evaluator/executor settings as the rest of autocontext. Use Monty when you need in-process interpreter guardrails, PrimeIntellect or SSH when you need an external execution host, and reserve Gondolin for the optional microVM backend once it is wired. `AUTOCONTEXT_EXECUTOR_MODE=gondolin` is intentionally fail-closed today so deployments do not silently fall back to local execution when they expected a VM isolation boundary.
+
+For future Gondolin work, implement the public backend contracts rather than changing task-runner behavior:
+
+- Python: `autocontext.execution.executors.gondolin_contract.GondolinBackend`
+- TypeScript: `GondolinBackend` and `createDefaultGondolinSandboxPolicy` from `autoctx`
+
+<Callout type="info">
+  See [sandbox modes](/docs/guides/sandbox) for the executor settings the worker inherits, and [the queue and worker CLI](/docs/cli/queue-worker) for the full command surface.
+</Callout>

--- a/apps/docs/content/docs/guides/persistent-host.mdx
+++ b/apps/docs/content/docs/guides/persistent-host.mdx
@@ -3,6 +3,8 @@ title: Persistent Host
 description: Run autocontext serve and worker as durable services.
 ---
 
+## Overview
+
 Use this shape when you want autocontext to keep accepting queued work while a server stays online.
 
 Run the HTTP API and queue worker as separate long-lived processes against the same durable workspace:

--- a/apps/docs/content/docs/guides/production-traces.mdx
+++ b/apps/docs/content/docs/guides/production-traces.mdx
@@ -11,6 +11,10 @@ The TypeScript package (`autoctx`) ships three commands for this:
 - `autoctx instrument`: scan a repo for LLM clients and propose or apply wrappers that emit traces.
 - `autoctx trace-findings`: extract structured findings from a single trace.
 
+<Callout type="warn">
+  `production-traces`, `instrument`, and `trace-findings` are TypeScript CLI commands (the npm `autoctx` build). They are not top-level Python commands. On the Python runtime, the findings equivalent is the nested `autoctx analytics trace-findings` (with different flags); there is no `autoctx production-traces` or `autoctx instrument` on Python. Run `autoctx capabilities --json` to confirm the support level for your install.
+</Callout>
+
 <Callout type="info">
   All three commands print their own help. Run `autoctx production-traces --help`, `autoctx instrument --help`, or `autoctx trace-findings --help` for the authoritative flag list.
 </Callout>

--- a/apps/docs/content/docs/guides/production-traces.mdx
+++ b/apps/docs/content/docs/guides/production-traces.mdx
@@ -1,0 +1,153 @@
+---
+title: Production Traces
+description: Ingest real traces and build datasets from them.
+---
+
+Production traces let you capture what your real LLM clients actually did in production, curate and redact those records locally, and turn them into evaluation datasets and structured findings. This closes the loop between live agent behavior and autocontext's improvement workflow.
+
+The TypeScript package (`autoctx`) ships three commands for this:
+
+- `autoctx production-traces`: ingest, curate, redact, and export the trace store.
+- `autoctx instrument`: scan a repo for LLM clients and propose or apply wrappers that emit traces.
+- `autoctx trace-findings`: extract structured findings from a single trace.
+
+<Callout type="info">
+  All three commands print their own help. Run `autoctx production-traces --help`, `autoctx instrument --help`, or `autoctx trace-findings --help` for the authoritative flag list.
+</Callout>
+
+## What a ProductionTrace is
+
+A `ProductionTrace` is the schema-versioned record autocontext stores for one captured LLM interaction. Each trace carries:
+
+- `schemaVersion` and a stable `traceId`
+- `source` of the capture and `provider` / `model` that served the call
+- optional `session` identifier and `env` context (the environment the call ran in)
+- the `messages` and `toolCalls` exchanged
+- an optional `outcome`, plus `timing` and `usage` info
+- `feedbackRefs`, `links`, and `redactions` markers
+- optional `routing` (the model-routing decision) and free-form `metadata`
+
+Traces live under `.autocontext/production-traces/` in your repo. Incoming batches land in `incoming/`, validated traces move to `ingested/`, and the redaction policy plus install-salt are scaffolded alongside them. The local store view is unredacted; redaction is applied on export.
+
+A `PublicTrace` is the redacted, exportable view of a trace. `autoctx trace-findings` reads either a `PublicTrace` JSON file or a stored trace looked up by id.
+
+## `autoctx production-traces`
+
+Ingest, curate, redact, and export production LLM traces. The command dispatches to subcommands; pass the subcommand after the `production-traces` keyword:
+
+```bash
+autoctx production-traces <subcommand> [flags]
+autoctx production-traces <subcommand> --help
+```
+
+### Subcommands
+
+| Subcommand | Purpose |
+| ------------- | ------------------------------------------------------------------------ |
+| `init`        | Scaffold `.autocontext/production-traces/` and generate install-salt. |
+| `ingest`      | Validate and move `incoming/` batches to `ingested/` (shared lock). |
+| `list`        | List stored traces (local view, no redaction). |
+| `show`        | Inspect a single trace (add `--as-exported` to preview redaction). |
+| `stats`       | Aggregate counts by env / app / provider / outcome / cluster. |
+| `build-dataset` | Generate an evaluation dataset from curated traces. |
+| `datasets`    | List or show generated datasets. |
+| `export`      | Export traces outbound with redaction applied. |
+| `policy`      | Show or set the redaction-mode policy. |
+| `rotate-salt` | Rotate install-salt (break-glass; requires `--force`). |
+| `prune`       | Enforce retention policy out-of-band. |
+
+### Typical flow
+
+```bash
+# 1. Scaffold the store and generate install-salt.
+autoctx production-traces init
+
+# 2. Drop captured batches into incoming/, then validate and move them.
+autoctx production-traces ingest
+
+# 3. Inspect what you have.
+autoctx production-traces list
+autoctx production-traces stats
+autoctx production-traces show <trace-id> --as-exported
+
+# 4. Turn curated traces into an evaluation dataset.
+autoctx production-traces build-dataset
+
+# 5. Export outbound with redaction applied.
+autoctx production-traces export
+```
+
+`show --as-exported` previews exactly what redaction will strip before you export. Use `policy` to inspect or change the redaction mode that `export` and the preview apply.
+
+## `autoctx instrument`
+
+Scan a repo for LLM clients and propose or apply autocontext wrappers that emit production traces. The default mode is a dry run that composes patches without touching your files:
+
+```bash
+autoctx instrument [--dry-run | --apply [--branch <name>] [--commit <msg>]]
+                   [--exclude <glob>]... [--exclude-from <file>]
+                   [--enhanced] [--max-file-bytes <N>]
+                   [--fail-if-empty] [--output json|table|pretty]
+                   [--force]
+```
+
+Modes are mutually exclusive; the default is `--dry-run`:
+
+- `--dry-run`: compose patches and a session directory; do NOT mutate files.
+- `--apply`: write patches into the working tree (requires a clean tree or `--force`).
+- `--apply --branch <name>`: branch off HEAD, apply, and commit (`--commit <msg>` optional).
+
+Filters:
+
+- `--exclude <glob>`: repeatable; adds gitignore-style exclude patterns.
+- `--exclude-from <file>`: read additional excludes from a file (gitignore syntax).
+- `--max-file-bytes <N>`: skip files over N bytes (default 1048576 = 1 MiB).
+
+Safety and observability:
+
+- `--fail-if-empty`: exit 12 when zero detector plugins are registered.
+- `--force`: bypass the clean-tree preflight (prints a prominent stderr warning).
+- `--enhanced`: force LLM enhancement of the PR-body narrative. Without a provider wired or without an API key, enhancement silently falls back to the deterministic default templates, so `plan.json` stays byte-identical whether enhancement is on or off.
+- `--output json|table|pretty`: format for the summary printed to stdout (default: `pretty`).
+
+```bash
+# Preview the wrappers instrument would add.
+autoctx instrument --dry-run
+
+# Apply on a fresh branch with a commit message.
+autoctx instrument --apply --branch add-autoctx-traces --commit "instrument LLM clients"
+```
+
+<Callout type="warn">
+  `--apply` refuses to run against a dirty working tree unless you pass `--force`. Prefer `--apply --branch <name>` so the changes land on their own branch.
+</Callout>
+
+## `autoctx trace-findings`
+
+Extract structured findings from a single trace:
+
+```bash
+autoctx trace-findings --trace <path> [--json]
+autoctx trace-findings --trace-id <id> [--json]
+autoctx trace-findings --help
+```
+
+Options:
+
+- `--trace <path>`: path to a `PublicTrace` JSON file.
+- `--trace-id <id>`: look up a stored `ProductionTrace` from the local `.autocontext/production-traces/ingested/` store.
+- `--json`: emit the `TraceFindingReport` as JSON instead of Markdown.
+
+Exactly one of `--trace` and `--trace-id` is required. By default the command prints a Markdown report with `Summary`, `Findings`, and `Failure Motifs` sections; `--json` emits the `TraceFindingReport` JSON matching `TraceFindingReportSchema`.
+
+```bash
+# Findings from a standalone PublicTrace file.
+autoctx trace-findings --trace ./trace.json
+
+# Findings from a stored trace, as JSON.
+autoctx trace-findings --trace-id <id> --json
+```
+
+<Callout type="info">
+  See [agent integration](/docs/agents) for how trace ingestion fits with other capture surfaces, and the [SDK](/docs/sdk) for emitting traces from your own code.
+</Callout>

--- a/apps/docs/content/docs/guides/sandbox.mdx
+++ b/apps/docs/content/docs/guides/sandbox.mdx
@@ -1,0 +1,62 @@
+---
+title: Sandbox Modes
+description: How autocontext isolates agent execution.
+---
+
+autocontext supports three shipped execution modes for game scenarios, plus judge-based evaluation for agent tasks:
+
+- `local` executor: runs strategies in a process pool with timeout controls, and applies memory limits in the subprocess path.
+- `primeintellect` executor: runs strategies remotely via PrimeIntellect sandbox lifecycle (create/wait/execute/delete).
+- `monty` executor: runs strategies in a pydantic-monty interpreter sandbox with external function callbacks and configurable timeout/call limits.
+- **Agent task evaluation**: Agent task scenarios bypass match execution entirely. `JudgeExecutor` delegates to `AgentTaskInterface.evaluate_output()`, which may use `LLMJudge` for LLM-based scoring against a rubric.
+
+## Gondolin boundary
+
+Gondolin is reserved as an optional microVM sandbox backend for deployments that need stronger isolation, secret policy, and egress policy than the local/Monty paths provide. It is not a hosted scheduler or background-worker control plane by itself.
+
+`AUTOCONTEXT_EXECUTOR_MODE=gondolin` is intentionally fail-closed until a real backend adapter is configured. This prevents a deployment that expected a VM boundary from silently running tasks locally.
+
+Use the current modes this way:
+
+- Use `monty` when you want interpreter-level containment for Python evaluation with low operational overhead.
+- Use `local` for trusted local development and fast iteration.
+- Use `primeintellect` or `ssh` when you want execution off the current host.
+- Use Gondolin only after the adapter is wired for VM lifecycle, mounted artifacts, secret injection, and network/egress policy.
+
+The public OSS contract for a future Gondolin adapter is intentionally narrow:
+
+- Python: implement `GondolinBackend` from `autocontext.execution.executors.gondolin_contract` behind the existing `ExecutionEngine` boundary.
+- TypeScript: implement `GondolinBackend` from `autoctx` and start from `createDefaultGondolinSandboxPolicy()`.
+
+The contract carries policy and secret references, not secret values. Hosted fleet orchestration, tenant scheduling, policy UI, billing, and managed audit retention remain deployment concerns outside this OSS boundary.
+
+## Relevant environment variables
+
+- `AUTOCONTEXT_EXECUTOR_MODE` (`local`, `primeintellect`, `monty`, `ssh`; `gondolin` is reserved/fail-closed)
+- `AUTOCONTEXT_PRIMEINTELLECT_API_BASE`
+- `AUTOCONTEXT_PRIMEINTELLECT_API_KEY`
+- `AUTOCONTEXT_PRIMEINTELLECT_DOCKER_IMAGE`
+- `AUTOCONTEXT_PRIMEINTELLECT_CPU_CORES`
+- `AUTOCONTEXT_PRIMEINTELLECT_MEMORY_GB`
+- `AUTOCONTEXT_PRIMEINTELLECT_DISK_SIZE_GB`
+- `AUTOCONTEXT_PRIMEINTELLECT_TIMEOUT_MINUTES`
+- `AUTOCONTEXT_PRIMEINTELLECT_WAIT_ATTEMPTS`
+- `AUTOCONTEXT_PRIMEINTELLECT_MAX_RETRIES`
+- `AUTOCONTEXT_PRIMEINTELLECT_BACKOFF_SECONDS`
+- `AUTOCONTEXT_ALLOW_PRIMEINTELLECT_FALLBACK`
+- `AUTOCONTEXT_LOCAL_SANDBOX_HARDENED`
+- `AUTOCONTEXT_MONTY_MAX_EXECUTION_TIME_SECONDS`
+- `AUTOCONTEXT_MONTY_MAX_EXTERNAL_CALLS`
+- `AUTOCONTEXT_JUDGE_MODEL`
+- `AUTOCONTEXT_JUDGE_SAMPLES`
+- `AUTOCONTEXT_JUDGE_TEMPERATURE`
+
+## Recovery behavior
+
+- PrimeIntellect preflight probe retries according to control-plane backoff.
+- PrimeIntellect match execution retries with backoff around full sandbox lifecycle operations.
+- If remote execution remains unavailable, fallback replay/result payloads are generated and captured through normal recovery markers.
+
+<Callout type="info">
+  See [providers](/docs/providers) for selecting the agent runtime, and [the persistent host guide](/docs/guides/persistent-host) for running a durable worker with these same executor settings.
+</Callout>

--- a/apps/docs/content/docs/guides/sandbox.mdx
+++ b/apps/docs/content/docs/guides/sandbox.mdx
@@ -8,6 +8,7 @@ autocontext supports three shipped execution modes for game scenarios, plus judg
 - `local` executor: runs strategies in a process pool with timeout controls, and applies memory limits in the subprocess path.
 - `primeintellect` executor: runs strategies remotely via PrimeIntellect sandbox lifecycle (create/wait/execute/delete).
 - `monty` executor: runs strategies in a pydantic-monty interpreter sandbox with external function callbacks and configurable timeout/call limits.
+- `ssh` executor: also selectable via `AUTOCONTEXT_EXECUTOR_MODE=ssh`, runs strategies on an external execution host over SSH.
 - **Agent task evaluation**: Agent task scenarios bypass match execution entirely. `JudgeExecutor` delegates to `AgentTaskInterface.evaluate_output()`, which may use `LLMJudge` for LLM-based scoring against a rubric.
 
 ## Gondolin boundary

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -1,0 +1,49 @@
+---
+title: Introduction
+description: autocontext is a recursive self-improving harness that helps agents succeed on any task.
+---
+
+## What autocontext is
+
+autocontext is a recursive self-improving harness. You point it at a goal in plain language, and it iterates against real evaluation: it keeps what worked, discards what did not, and produces a structured trace plus artifacts, playbooks, datasets, and (optionally) a distilled local model that the next agent inherits. Because that knowledge persists, repeated runs get better, not just different.
+
+## The mental model
+
+A loop of five specialized roles (competitor, analyst, coach, architect, and curator) runs your task against real evaluation. The competitor attempts the goal, the analyst scores the result, the coach turns failures into concrete advice, the architect shapes strategy, and the curator decides what is worth keeping. Knowledge that works persists across runs in a playbook that the next run inherits, so each pass starts from everything the last one learned.
+
+## Who these docs serve
+
+These docs are organized into three layered tracks, depending on how you want to use autocontext:
+
+- [The CLI](/docs/cli) is for terminal practitioners who want to run autocontext directly from the command line.
+- [Agent integration](/docs/agents) is for wiring autocontext into Claude Code, Pi, Hermes, or any other MCP client.
+- [The SDK](/docs/sdk) is for embedding autocontext in your own Python or TypeScript code.
+
+All three share the same [core concepts](/docs/concepts), so start there if you want the foundation before diving into a track.
+
+## Try it in 30 seconds
+
+The default provider is `deterministic` and runs fully offline, so every runnable example sets `AUTOCONTEXT_AGENT_PROVIDER` to pick a real runtime. Here is a first run against a customer-support goal:
+
+<Tabs items={['Python', 'TypeScript']}>
+<Tab value="Python">
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi AUTOCONTEXT_PI_COMMAND=pi \
+uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
+```
+</Tab>
+<Tab value="TypeScript">
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi bunx autoctx solve \
+  "improve customer-support replies for billing disputes" --iterations 5 --json
+```
+</Tab>
+</Tabs>
+
+<Callout type="info">
+autocontext ships a Python package and a TypeScript package, both exposing the same `autoctx` CLI, so you can pick whichever fits your stack.
+</Callout>
+
+## Next step
+
+Ready to install and run your first loop? Head to [the quickstart](/docs/get-started/quickstart).

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -23,12 +23,12 @@ All three share the same [core concepts](/docs/concepts), so start there if you 
 
 ## Try it in 30 seconds
 
-The default provider is `deterministic` and runs fully offline, so every runnable example sets `AUTOCONTEXT_AGENT_PROVIDER` to pick a real runtime. Here is a first run against a customer-support goal:
+autocontext supports many providers. The `deterministic` provider runs fully offline with no credentials, and the Pi runtime is the recommended zero-config path (it handles its own auth). Every runnable example sets `AUTOCONTEXT_AGENT_PROVIDER` to pick the runtime explicitly. Here is a first run against a customer-support goal:
 
 <Tabs items={['Python', 'TypeScript']}>
 <Tab value="Python">
 ```bash
-AUTOCONTEXT_AGENT_PROVIDER=pi AUTOCONTEXT_PI_COMMAND=pi \
+AUTOCONTEXT_AGENT_PROVIDER=pi \
 uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
 </Tab>

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,0 +1,15 @@
+{
+  "title": "autocontext",
+  "pages": [
+    "index",
+    "get-started",
+    "concepts",
+    "cli",
+    "providers",
+    "agents",
+    "sdk",
+    "guides",
+    "reference",
+    "faq"
+  ]
+}

--- a/apps/docs/content/docs/providers/api-providers.mdx
+++ b/apps/docs/content/docs/providers/api-providers.mdx
@@ -1,0 +1,66 @@
+---
+title: API Providers
+description: Hosted model APIs that need an API key.
+---
+
+Hosted API providers run the loop against a remote model service. They are the fastest way to good results, and they require an API key on the autocontext side.
+
+## `anthropic`
+
+The default provider. It reads `ANTHROPIC_API_KEY` (or the compatibility alias `AUTOCONTEXT_ANTHROPIC_API_KEY`) and raises an error if neither is set.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=anthropic \
+ANTHROPIC_API_KEY=sk-ant-... \
+autoctx solve "summarize this codebase"
+```
+
+## `openai`
+
+Targets the OpenAI API and reads `OPENAI_API_KEY`. The default model is `gpt-4o`.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=openai \
+OPENAI_API_KEY=sk-... \
+autoctx solve "summarize this codebase"
+```
+
+## `openai-compatible`
+
+Targets any service that exposes an OpenAI-shaped chat-completions API. You provide the key and the base URL. This is the single enum value that covers every other vendor.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=openai-compatible \
+AUTOCONTEXT_AGENT_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai \
+AUTOCONTEXT_AGENT_API_KEY=... \
+autoctx solve "summarize this codebase"
+```
+
+The relevant settings are `agent_base_url` (`AUTOCONTEXT_AGENT_BASE_URL`), `agent_api_key` (`AUTOCONTEXT_AGENT_API_KEY`), and `agent_default_model` (`AUTOCONTEXT_AGENT_DEFAULT_MODEL`, default `gpt-4o`).
+
+<Callout type="info">
+Gemini, Mistral, Groq, OpenRouter, and Azure OpenAI are not separate provider values. There is no `gemini` or `azure` enum. You reach all of them through `openai-compatible` by setting `AUTOCONTEXT_AGENT_BASE_URL` to their OpenAI-compatible endpoint and `AUTOCONTEXT_AGENT_API_KEY` to your key. Do not expect a dedicated provider value for them.
+</Callout>
+
+## Credential reference
+
+| Provider | Key env var | Endpoint env var |
+| --- | --- | --- |
+| `anthropic` | `ANTHROPIC_API_KEY` (or `AUTOCONTEXT_ANTHROPIC_API_KEY`) | (built in) |
+| `openai` | `OPENAI_API_KEY` | (built in) |
+| `openai-compatible` | `AUTOCONTEXT_AGENT_API_KEY` | `AUTOCONTEXT_AGENT_BASE_URL` |
+
+## `agent_sdk`
+
+There is also an `agent_sdk` provider that runs the agent through the Anthropic Agent SDK rather than the plain messages API. It is selected the same way (`AUTOCONTEXT_AGENT_PROVIDER=agent_sdk`) and is useful when you want SDK-style tool execution. Most users should start with `anthropic`, `openai`, or `openai-compatible`.
+
+## A full solve example
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=anthropic \
+ANTHROPIC_API_KEY=sk-ant-... \
+autoctx solve "draft a migration plan for the auth module" \
+  --output plan.md
+```
+
+To run the loop fully on your own machine with no API key, see [Local & Offline](/docs/providers/local). To drive autocontext with a coding-agent CLI instead, see [CLI Runtimes](/docs/providers/cli-runtimes).

--- a/apps/docs/content/docs/providers/cli-runtimes.mdx
+++ b/apps/docs/content/docs/providers/cli-runtimes.mdx
@@ -1,0 +1,70 @@
+---
+title: CLI Runtimes
+description: Drive autocontext with your existing coding-agent CLI.
+---
+
+CLI runtimes let autocontext drive a coding-agent CLI that you already have installed. Instead of calling a model API directly, autocontext shells out to the tool for each agent turn. The tool runs the model, executes its own tools, and returns the result.
+
+<Callout type="info">
+All CLI runtimes inherit authentication from the local tool. There is no autocontext API key to set for `claude-cli`, `codex`, or `hermes`. If the CLI works on its own (you have logged in or set its native env vars), autocontext can use it.
+</Callout>
+
+## `claude-cli`
+
+Drives the Claude CLI. autocontext invokes it with `--permission-mode` and a model alias.
+
+| Setting | Env var | Default |
+| --- | --- | --- |
+| `claude_model` | `AUTOCONTEXT_CLAUDE_MODEL` | `sonnet` |
+| `claude_timeout` | `AUTOCONTEXT_CLAUDE_TIMEOUT` | `600` |
+| `claude_permission_mode` | `AUTOCONTEXT_CLAUDE_PERMISSION_MODE` | `bypassPermissions` |
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=claude-cli \
+AUTOCONTEXT_CLAUDE_MODEL=sonnet \
+autoctx solve "add a test for the cache layer"
+```
+
+The permission mode controls how much the underlying CLI is allowed to do without prompting. The default `bypassPermissions` keeps non-interactive runs from stalling on confirmation prompts.
+
+## `codex`
+
+Drives the Codex CLI. autocontext passes a model and an approval mode.
+
+| Setting | Env var | Default |
+| --- | --- | --- |
+| `codex_model` | `AUTOCONTEXT_CODEX_MODEL` | `o4-mini` |
+| `codex_timeout` | `AUTOCONTEXT_CODEX_TIMEOUT` | `120` |
+| `codex_approval_mode` | `AUTOCONTEXT_CODEX_APPROVAL_MODE` | `full-auto` |
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=codex \
+AUTOCONTEXT_CODEX_MODEL=o4-mini \
+autoctx solve "add a test for the cache layer"
+```
+
+The approval mode mirrors Codex's own approval flag. The default `full-auto` lets the loop run unattended.
+
+## `hermes`
+
+Drives the Hermes CLI. Hermes can run in an isolated git worktree and preload toolsets and skills, which makes it well suited to multi-step agent work that touches the filesystem.
+
+| Setting | Env var | Default |
+| --- | --- | --- |
+| `hermes_command` | `AUTOCONTEXT_HERMES_COMMAND` | `hermes` |
+| `hermes_model` | `AUTOCONTEXT_HERMES_MODEL` | (empty) |
+| `hermes_timeout` | `AUTOCONTEXT_HERMES_TIMEOUT` | `120` |
+| `hermes_worktree` | `AUTOCONTEXT_HERMES_WORKTREE` | `false` |
+| `hermes_toolsets` | `AUTOCONTEXT_HERMES_TOOLSETS` | (empty) |
+| `hermes_skills` | `AUTOCONTEXT_HERMES_SKILLS` | (empty) |
+| `hermes_base_url` | `AUTOCONTEXT_HERMES_BASE_URL` | (empty) |
+| `hermes_api_key` | `AUTOCONTEXT_HERMES_API_KEY` | (empty) |
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=hermes \
+AUTOCONTEXT_HERMES_WORKTREE=true \
+AUTOCONTEXT_HERMES_TOOLSETS=web,terminal \
+autoctx solve "open a PR that fixes the failing test"
+```
+
+`hermes_api_key` and `hermes_base_url` are optional. They configure the model endpoint Hermes itself uses, and `hermes_base_url` takes precedence over the provider when both are set. They are not an autocontext credential: Hermes still owns its own authentication.

--- a/apps/docs/content/docs/providers/index.mdx
+++ b/apps/docs/content/docs/providers/index.mdx
@@ -1,0 +1,56 @@
+---
+title: Providers Overview
+description: Choose how autocontext runs your agent.
+---
+
+autocontext does not hardcode a model vendor. Every run dispatches to an agent provider that you select with a single environment variable, `AUTOCONTEXT_AGENT_PROVIDER`. The provider decides where the agent roles (competitor, analyst, coach, architect, translator, curator) actually run: a hosted API, a local server, an MLX checkpoint on your machine, or an existing coding-agent CLI you already have installed.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx solve "summarize this repo"
+```
+
+## Provider values
+
+`AUTOCONTEXT_AGENT_PROVIDER` accepts one of the following values:
+
+| Value | Family | Page |
+| --- | --- | --- |
+| `anthropic` | Hosted API | [API Providers](/docs/providers/api-providers) |
+| `openai` | Hosted API | [API Providers](/docs/providers/api-providers) |
+| `openai-compatible` | Hosted API | [API Providers](/docs/providers/api-providers) |
+| `ollama` | Local server | [Local & Offline](/docs/providers/local) |
+| `vllm` | Local server | [Local & Offline](/docs/providers/local) |
+| `mlx` | Local model | [Local & Offline](/docs/providers/local) |
+| `deterministic` | Offline dev | [Local & Offline](/docs/providers/local) |
+| `pi` | Local runtime | [Pi Runtime](/docs/providers/pi) |
+| `pi-rpc` | Local runtime | [Pi Runtime](/docs/providers/pi) |
+| `claude-cli` | CLI runtime | [CLI Runtimes](/docs/providers/cli-runtimes) |
+| `codex` | CLI runtime | [CLI Runtimes](/docs/providers/cli-runtimes) |
+| `hermes` | CLI runtime | [CLI Runtimes](/docs/providers/cli-runtimes) |
+| `agent_sdk` | SDK runtime | [API Providers](/docs/providers/api-providers) |
+
+These are the only accepted values. Vendors like Gemini, Mistral, Groq, OpenRouter, and Azure are not separate enum values: you reach them through `openai-compatible` by pointing `AUTOCONTEXT_AGENT_BASE_URL` at their OpenAI-compatible endpoint.
+
+## The real default
+
+The code-level default is `anthropic`. If you run autocontext without setting `AUTOCONTEXT_AGENT_PROVIDER`, it targets the Anthropic API and requires a key (`ANTHROPIC_API_KEY` or `AUTOCONTEXT_ANTHROPIC_API_KEY`). It will raise an error if no key is present.
+
+<Callout type="info">
+The `.env.example` template suggests `AUTOCONTEXT_AGENT_PROVIDER=deterministic`, but that is a template convenience, not the code default. `deterministic` is the offline, no-credential option for development and testing. For a real zero-config local run, `pi` is the recommended path, since the Pi CLI handles its own authentication.
+</Callout>
+
+## Choosing a provider
+
+| Provider family | Credential | When to use |
+| --- | --- | --- |
+| `anthropic`, `openai` | API key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) | Hosted frontier models, fastest to get good results |
+| `openai-compatible` | API key plus `AUTOCONTEXT_AGENT_BASE_URL` | Any OpenAI-shaped endpoint (Gemini, Mistral, Groq, OpenRouter, Azure, a gateway) |
+| `ollama`, `vllm` | None (local server URL) | Self-hosted open models on your own hardware |
+| `mlx` | None (`AUTOCONTEXT_MLX_MODEL_PATH`) | A distilled or local MLX checkpoint on Apple silicon |
+| `deterministic` | None | Offline development, CI, plumbing tests with no model calls |
+| `pi`, `pi-rpc` | None (Pi CLI auth) | Recommended zero-config local runtime |
+| `claude-cli`, `codex`, `hermes` | None (the CLI's own auth) | Drive autocontext with a coding-agent CLI you already use |
+
+## Beyond a single provider
+
+You are not limited to one model for the whole loop. You can assign different models, providers, keys, and base URLs to individual roles, and you can control the judge that scores each generation. See [Per-Role Models & Judge](/docs/providers/per-role-and-judge).

--- a/apps/docs/content/docs/providers/local.mdx
+++ b/apps/docs/content/docs/providers/local.mdx
@@ -1,0 +1,60 @@
+---
+title: Local & Offline
+description: Run fully on your machine with no API key.
+---
+
+These providers run the loop without any hosted API. Use them to keep data on your machine, work offline, or develop autocontext itself without spending tokens.
+
+## `ollama`
+
+Targets a local [Ollama](https://ollama.com) server through its OpenAI-compatible API. autocontext defaults the base URL to `http://localhost:11434/v1`, so a stock Ollama install needs no further configuration. The default model is `llama3.1`.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=ollama \
+autoctx solve "explain this function"
+```
+
+Override the endpoint or model with `AUTOCONTEXT_AGENT_BASE_URL` and `AUTOCONTEXT_AGENT_DEFAULT_MODEL` if your server is elsewhere.
+
+## `vllm`
+
+Targets a local [vLLM](https://docs.vllm.ai) OpenAI-compatible server. The default base URL is `http://localhost:8000/v1`. No real key is required (autocontext sends a placeholder), so just point it at your server.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=vllm \
+AUTOCONTEXT_AGENT_DEFAULT_MODEL=my-served-model \
+autoctx solve "explain this function"
+```
+
+## `mlx`
+
+Runs a local MLX model on Apple silicon. You must give it a checkpoint directory through `AUTOCONTEXT_MLX_MODEL_PATH`, or it raises an error.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=mlx \
+AUTOCONTEXT_MLX_MODEL_PATH=/path/to/mlx-checkpoint \
+autoctx solve "explain this function"
+```
+
+Two sampling settings are available:
+
+| Setting | Env var | Default |
+| --- | --- | --- |
+| `mlx_model_path` | `AUTOCONTEXT_MLX_MODEL_PATH` | (required) |
+| `mlx_temperature` | `AUTOCONTEXT_MLX_TEMPERATURE` | `0.8` |
+| `mlx_max_tokens` | `AUTOCONTEXT_MLX_MAX_TOKENS` | `512` |
+
+An MLX checkpoint can come from distilling your own accumulated runs into a local model. See [the distillation guide](/docs/guides/distillation-mlx) for how to produce one.
+
+## `deterministic`
+
+The offline development provider. It returns fixed, scripted responses with no model call and no credentials, which makes it ideal for CI, plumbing tests, and exercising the loop's mechanics without spending tokens.
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=deterministic \
+autoctx run grid_ctf --iterations 1
+```
+
+<Callout type="info">
+`deterministic` is the offline, no-credential option, not the production default. The code-level default provider is `anthropic` (which needs a key). For a real zero-config local model, prefer the [Pi runtime](/docs/providers/pi).
+</Callout>

--- a/apps/docs/content/docs/providers/meta.json
+++ b/apps/docs/content/docs/providers/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Providers",
+  "pages": ["index", "pi", "api-providers", "local", "cli-runtimes", "per-role-and-judge"]
+}

--- a/apps/docs/content/docs/providers/per-role-and-judge.mdx
+++ b/apps/docs/content/docs/providers/per-role-and-judge.mdx
@@ -1,0 +1,88 @@
+---
+title: Per-Role Models & Judge
+description: Assign different models to roles and control the judge.
+---
+
+A single run uses several agent roles: competitor, analyst, coach, architect, translator, and curator. By default they all share the provider you set with `AUTOCONTEXT_AGENT_PROVIDER`, but you can give each role its own model, and the four core roles can even use a different provider, key, and endpoint.
+
+## Per-role models
+
+Every role has a model environment variable. These set the model name passed to whatever provider that role uses.
+
+| Role | Env var |
+| --- | --- |
+| Competitor | `AUTOCONTEXT_MODEL_COMPETITOR` |
+| Analyst | `AUTOCONTEXT_MODEL_ANALYST` |
+| Coach | `AUTOCONTEXT_MODEL_COACH` |
+| Architect | `AUTOCONTEXT_MODEL_ARCHITECT` |
+| Translator | `AUTOCONTEXT_MODEL_TRANSLATOR` |
+| Curator | `AUTOCONTEXT_MODEL_CURATOR` |
+
+A common pattern is a cheaper model for the high-volume competitor and a stronger model for the coach and architect:
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=anthropic \
+AUTOCONTEXT_MODEL_COMPETITOR=claude-sonnet-4-5-20250929 \
+AUTOCONTEXT_MODEL_COACH=claude-opus-4-6 \
+AUTOCONTEXT_MODEL_ARCHITECT=claude-opus-4-6 \
+autoctx run grid_ctf --iterations 3
+```
+
+## Per-role provider, key, and base URL overrides
+
+The four core roles (competitor, analyst, coach, architect) can each override the provider, API key, and base URL independently. This lets you run different roles against entirely different backends in the same loop.
+
+| Role | Provider | API key | Base URL |
+| --- | --- | --- | --- |
+| Competitor | `AUTOCONTEXT_COMPETITOR_PROVIDER` | `AUTOCONTEXT_COMPETITOR_API_KEY` | `AUTOCONTEXT_COMPETITOR_BASE_URL` |
+| Analyst | `AUTOCONTEXT_ANALYST_PROVIDER` | `AUTOCONTEXT_ANALYST_API_KEY` | `AUTOCONTEXT_ANALYST_BASE_URL` |
+| Coach | `AUTOCONTEXT_COACH_PROVIDER` | `AUTOCONTEXT_COACH_API_KEY` | `AUTOCONTEXT_COACH_BASE_URL` |
+| Architect | `AUTOCONTEXT_ARCHITECT_PROVIDER` | `AUTOCONTEXT_ARCHITECT_API_KEY` | `AUTOCONTEXT_ARCHITECT_BASE_URL` |
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=openai \
+OPENAI_API_KEY=sk-... \
+AUTOCONTEXT_ARCHITECT_PROVIDER=anthropic \
+AUTOCONTEXT_ARCHITECT_API_KEY=sk-ant-... \
+autoctx run grid_ctf --iterations 3
+```
+
+Here the loop runs on OpenAI, but the architect role runs on Anthropic.
+
+## The judge
+
+The judge scores each generation. It has its own provider settings:
+
+| Setting | Env var | Default |
+| --- | --- | --- |
+| `judge_provider` | `AUTOCONTEXT_JUDGE_PROVIDER` | `auto` |
+| `judge_model` | `AUTOCONTEXT_JUDGE_MODEL` | `claude-sonnet-4-20250514` |
+| `judge_api_key` | `AUTOCONTEXT_JUDGE_API_KEY` | (empty) |
+| `judge_base_url` | `AUTOCONTEXT_JUDGE_BASE_URL` | (empty) |
+
+### Auto-inheritance
+
+With the default `judge_provider=auto`, the judge does not pick a provider blindly. It inherits from the first configured role provider in this priority order:
+
+1. competitor
+2. architect
+3. analyst
+4. coach
+5. the global `agent_provider`
+
+If the first configured provider it finds in that order is a CLI runtime (`claude-cli`, `codex`, `pi`, or `pi-rpc`), the judge uses it too, so a subscription-tier setup with only local CLI auth does not fall back to an API that needs a key. For any other provider, the judge falls back to `anthropic`.
+
+<Callout type="info">
+Auto-inheritance only carries over the CLI runtime providers. If your effective provider is a hosted API like `openai`, the `auto` judge still resolves to `anthropic` rather than inheriting OpenAI. Set `AUTOCONTEXT_JUDGE_PROVIDER` explicitly if you want the judge on a specific backend.
+</Callout>
+
+To pin the judge regardless of the loop's provider:
+
+```bash
+AUTOCONTEXT_JUDGE_PROVIDER=openai \
+AUTOCONTEXT_JUDGE_MODEL=gpt-4o \
+OPENAI_API_KEY=sk-... \
+autoctx judge --task task.json --output out.json
+```
+
+For how scoring fits into the loop, see [evaluation concepts](/docs/concepts/evaluation).

--- a/apps/docs/content/docs/providers/per-role-and-judge.mdx
+++ b/apps/docs/content/docs/providers/per-role-and-judge.mdx
@@ -5,6 +5,10 @@ description: Assign different models to roles and control the judge.
 
 A single run uses several agent roles: competitor, analyst, coach, architect, translator, and curator. By default they all share the provider you set with `AUTOCONTEXT_AGENT_PROVIDER`, but you can give each role its own model, and the four core roles can even use a different provider, key, and endpoint.
 
+<Callout type="info">
+The concepts pages describe five conceptual roles (competitor, analyst, coach, architect, curator). The translator is an internal helper role that extracts structured strategy from competitor output, which is why a separate `AUTOCONTEXT_MODEL_TRANSLATOR` variable exists alongside the five.
+</Callout>
+
 ## Per-role models
 
 Every role has a model environment variable. These set the model name passed to whatever provider that role uses.

--- a/apps/docs/content/docs/providers/pi.mdx
+++ b/apps/docs/content/docs/providers/pi.mdx
@@ -1,0 +1,68 @@
+---
+title: Pi Runtime
+description: The recommended zero-config local runtime.
+---
+
+Pi is the recommended way to run autocontext without configuring API keys. It is a local coding-agent CLI, and when you select a Pi provider, autocontext shells out to the `pi` binary and lets Pi handle its own authentication. There is no autocontext API key to set.
+
+autocontext exposes two Pi providers that differ only in how they talk to the binary.
+
+## `pi` versus `pi-rpc`
+
+The `pi` provider runs Pi in one-shot mode. For each agent call it invokes `pi --print`, passes the prompt, and reads a single completion back. Every call is an independent process.
+
+The `pi-rpc` provider runs Pi in RPC mode with `pi --mode rpc`. This speaks JSONL over the subprocess's stdin and stdout, so a single Pi process can serve multiple turns.
+
+<Callout type="info">
+`pi-rpc` is a subprocess speaking JSONL over stdin and stdout. It is not an HTTP server, and it does not open a network port. If you are looking for an HTTP endpoint, you want `openai-compatible` instead.
+</Callout>
+
+## Configuration
+
+Both Pi providers read the same `pi_*` settings. Each setting maps to an environment variable of the form `AUTOCONTEXT_<FIELD>`.
+
+| Setting | Env var | Default | Notes |
+| --- | --- | --- | --- |
+| `pi_command` | `AUTOCONTEXT_PI_COMMAND` | `pi` | Path to the Pi binary |
+| `pi_timeout` | `AUTOCONTEXT_PI_TIMEOUT` | `300` | Per-call execution timeout in seconds |
+| `pi_workspace` | `AUTOCONTEXT_PI_WORKSPACE` | (empty) | Workspace directory for Pi |
+| `pi_model` | `AUTOCONTEXT_PI_MODEL` | (empty) | Optional Pi model override |
+| `pi_no_context_files` | `AUTOCONTEXT_PI_NO_CONTEXT_FILES` | `false` | Skip Pi's own context files |
+
+The `pi-rpc` provider adds two RPC-only settings:
+
+| Setting | Env var | Default | Notes |
+| --- | --- | --- | --- |
+| `pi_rpc_session_persistence` | `AUTOCONTEXT_PI_RPC_SESSION_PERSISTENCE` | `true` | Reuse a session across turns |
+| `pi_rpc_persistent` | `AUTOCONTEXT_PI_RPC_PERSISTENT` | `false` | Keep one persistent RPC process for the whole run |
+
+<Callout type="info">
+`pi_rpc_session_persistence` and `pi_rpc_persistent` only apply to `pi-rpc`. The one-shot `pi` provider ignores them, since each call is already its own process.
+</Callout>
+
+## Example invocations
+
+One-shot Pi, the simplest zero-config path:
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi autoctx solve "write a haiku about caching"
+```
+
+RPC mode, reusing a single Pi process across turns:
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi-rpc \
+AUTOCONTEXT_PI_RPC_PERSISTENT=true \
+autoctx run grid_ctf --iterations 1
+```
+
+Point at a non-default Pi binary and raise the timeout:
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=pi \
+AUTOCONTEXT_PI_COMMAND=/opt/pi/bin/pi \
+AUTOCONTEXT_PI_TIMEOUT=600 \
+autoctx solve "refactor the parser"
+```
+
+Because Pi owns its credentials, this is the fastest way to get a real model running the loop without managing any autocontext-side keys.

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -15,7 +15,7 @@ For how these variables map onto provider selection, see [providers](/docs/provi
 | `AUTOCONTEXT_EXECUTOR_MODE` | `local` | Where strategies are executed (`local`, `primeintellect`, `monty`, `ssh`). `gondolin` is reserved and fail-closed. |
 
 <Callout type="warn">
-`.env.example` ships `AUTOCONTEXT_AGENT_PROVIDER=deterministic` so the offline demo runs without credentials, but the code default when the variable is unset is `anthropic`. Set the variable explicitly to avoid surprises, and see [providers](/docs/providers) for the full list of accepted values (`deterministic`, `anthropic`, `agent_sdk`, `pi`, `pi-rpc`, `openai`, `ollama`, `vllm`).
+`.env.example` ships `AUTOCONTEXT_AGENT_PROVIDER=deterministic` so the offline demo runs without credentials, but the code default when the variable is unset is `anthropic`. Set the variable explicitly to avoid surprises, and see [providers](/docs/providers) for the full list of accepted values: `deterministic`, `anthropic`, `agent_sdk`, `openai`, `openai-compatible`, `ollama`, `vllm`, `mlx`, `claude-cli`, `codex`, `pi`, `pi-rpc`, `hermes`.
 </Callout>
 
 ## Paths

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -1,0 +1,125 @@
+---
+title: Environment Variables
+description: Every AUTOCONTEXT_* variable and its default.
+---
+
+autocontext is configured entirely through environment variables. They are loaded into the Pydantic `AppSettings` object at startup, so any of them can be set in your shell, a `.env` file, or your deployment platform. The tables below are generated from the repository's `.env.example` and group the variables by concern. Each row lists the variable name, the default shipped in `.env.example`, and a one-line purpose.
+
+For how these variables map onto provider selection, see [providers](/docs/providers).
+
+## Core runtime
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AUTOCONTEXT_AGENT_PROVIDER` | `deterministic` | Selects the agent provider that drives the loop. |
+| `AUTOCONTEXT_EXECUTOR_MODE` | `local` | Where strategies are executed (`local`, `primeintellect`, `monty`). |
+
+<Callout type="warn">
+`.env.example` ships `AUTOCONTEXT_AGENT_PROVIDER=deterministic` so the offline demo runs without credentials, but the code default when the variable is unset is `anthropic`. Set the variable explicitly to avoid surprises, and see [providers](/docs/providers) for the full list of accepted values (`deterministic`, `anthropic`, `agent_sdk`, `pi`, `pi-rpc`, `openai`, `ollama`, `vllm`).
+</Callout>
+
+## Paths
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AUTOCONTEXT_DB_PATH` | `runs/autocontext.sqlite3` | SQLite database file for runs, generations, matches, and the task queue. |
+| `AUTOCONTEXT_RUNS_ROOT` | `runs` | Root directory for run artifacts and generation outputs. |
+| `AUTOCONTEXT_KNOWLEDGE_ROOT` | `knowledge` | Root directory for per-scenario playbooks, analysis, tools, and snapshots. |
+| `AUTOCONTEXT_SKILLS_ROOT` | `skills` | Root directory for generated operational skill notes. |
+| `AUTOCONTEXT_CLAUDE_SKILLS_PATH` | `.claude/skills` | Location where skill notes are synced for Claude Code. |
+| `AUTOCONTEXT_EVENT_STREAM_PATH` | `runs/events.ndjson` | Newline-delimited JSON event stream for the loop. |
+
+## Model selection (by role)
+
+Each agent role can run on a different model. See [agents](/docs/concepts) for what each role does.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AUTOCONTEXT_MODEL_COMPETITOR` | `claude-sonnet-4-5-20250929` | Model for the competitor role (produces strategies). |
+| `AUTOCONTEXT_MODEL_ANALYST` | `claude-sonnet-4-5-20250929` | Model for the analyst role (produces analysis). |
+| `AUTOCONTEXT_MODEL_COACH` | `claude-opus-4-6` | Model for the coach role (updates the playbook). |
+| `AUTOCONTEXT_MODEL_ARCHITECT` | `claude-opus-4-6` | Model for the architect role (proposes tooling). |
+| `AUTOCONTEXT_MODEL_TRANSLATOR` | `claude-sonnet-4-5-20250929` | Model for the translator role (extracts structured strategy). |
+| `AUTOCONTEXT_MODEL_CURATOR` | `claude-opus-4-6` | Model for the curator role (quality gate and lesson consolidation). |
+
+## Credentials
+
+Prefer provider-native variables such as `ANTHROPIC_API_KEY`. The `AUTOCONTEXT_ANTHROPIC_API_KEY` form remains a compatibility alias.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `ANTHROPIC_API_KEY` | (empty) | Anthropic API key (preferred provider-native form). |
+| `AUTOCONTEXT_ANTHROPIC_API_KEY` | (empty) | Compatibility alias for the Anthropic API key. |
+| `AUTOCONTEXT_COMPETITOR_API_KEY` | (empty) | Optional role-scoped API key for the competitor. |
+| `AUTOCONTEXT_COMPETITOR_BASE_URL` | (empty) | Optional role-scoped base URL for the competitor. |
+| `AUTOCONTEXT_ANALYST_API_KEY` | (empty) | Optional role-scoped API key for the analyst. |
+| `AUTOCONTEXT_ANALYST_BASE_URL` | (empty) | Optional role-scoped base URL for the analyst. |
+| `AUTOCONTEXT_COACH_API_KEY` | (empty) | Optional role-scoped API key for the coach. |
+| `AUTOCONTEXT_COACH_BASE_URL` | (empty) | Optional role-scoped base URL for the coach. |
+| `AUTOCONTEXT_ARCHITECT_API_KEY` | (empty) | Optional role-scoped API key for the architect. |
+| `AUTOCONTEXT_ARCHITECT_BASE_URL` | (empty) | Optional role-scoped base URL for the architect. |
+
+## Execution and loop tuning
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AUTOCONTEXT_DEFAULT_GENERATIONS` | `1` | Default number of generations per run when not specified. |
+| `AUTOCONTEXT_SEED_BASE` | `1000` | Base seed for deterministic match generation. |
+| `AUTOCONTEXT_MATCHES_PER_GENERATION` | `3` | Number of tournament matches run each generation. |
+| `AUTOCONTEXT_ARCHITECT_EVERY_N_GENS` | `3` | How often the architect role runs (every N generations). |
+| `AUTOCONTEXT_BACKPRESSURE_MIN_DELTA` | `0.005` | Minimum score improvement for the backpressure gate to advance. |
+| `AUTOCONTEXT_MAX_RETRIES` | `2` | Maximum retries for transient agent or execution failures. |
+| `AUTOCONTEXT_RETRY_BACKOFF_SECONDS` | `0.25` | Backoff delay between retries, in seconds. |
+| `AUTOCONTEXT_HARNESS_PROFILE` | `standard` | Harness profile controlling context and tool budgets. |
+| `AUTOCONTEXT_LEAN_CONTEXT_BUDGET_TOKENS` | `32000` | Token budget for visible context in lean harness mode. |
+| `AUTOCONTEXT_LEAN_HIDDEN_CONTEXT_BUDGET_TOKENS` | `0` | Token budget for hidden context in lean harness mode. |
+| `AUTOCONTEXT_LEAN_TOOL_ALLOWLIST` | `read,bash,edit,write` | Tools permitted in lean harness mode. |
+| `AUTOCONTEXT_PI_RPC_PERSISTENT` | `false` | Keep the Pi RPC session persistent across calls. |
+| `AUTOCONTEXT_EXTENSIONS` | (empty) | Comma-separated list of extensions to load. |
+| `AUTOCONTEXT_EXTENSION_FAIL_FAST` | `false` | Abort startup if an extension fails to load. |
+
+## PrimeIntellect
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AUTOCONTEXT_PRIMEINTELLECT_API_BASE` | `https://api.primeintellect.ai` | Base URL for the PrimeIntellect API. |
+| `AUTOCONTEXT_PRIMEINTELLECT_API_KEY` | (empty) | API key for PrimeIntellect remote sandboxes. |
+| `AUTOCONTEXT_PRIMEINTELLECT_DOCKER_IMAGE` | `python:3.11-slim` | Docker image used for the remote sandbox. |
+| `AUTOCONTEXT_PRIMEINTELLECT_CPU_CORES` | `1.0` | CPU cores allocated to the remote sandbox. |
+| `AUTOCONTEXT_PRIMEINTELLECT_MEMORY_GB` | `2.0` | Memory (GB) allocated to the remote sandbox. |
+| `AUTOCONTEXT_PRIMEINTELLECT_DISK_SIZE_GB` | `5.0` | Disk size (GB) allocated to the remote sandbox. |
+| `AUTOCONTEXT_PRIMEINTELLECT_TIMEOUT_MINUTES` | `30` | Timeout (minutes) for a remote sandbox run. |
+| `AUTOCONTEXT_PRIMEINTELLECT_WAIT_ATTEMPTS` | `60` | Number of polling attempts while the sandbox provisions. |
+| `AUTOCONTEXT_PRIMEINTELLECT_MAX_RETRIES` | `2` | Maximum retries for PrimeIntellect operations. |
+| `AUTOCONTEXT_PRIMEINTELLECT_BACKOFF_SECONDS` | `0.75` | Backoff delay between PrimeIntellect retries, in seconds. |
+| `AUTOCONTEXT_ALLOW_PRIMEINTELLECT_FALLBACK` | `true` | Allow falling back to local execution if PrimeIntellect is unavailable. |
+
+## Sandbox
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AUTOCONTEXT_LOCAL_SANDBOX_HARDENED` | `true` | Run the local sandbox with hardened isolation. |
+
+## Browser exploration
+
+Browser exploration ships disabled with secure defaults; enable it deliberately.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AUTOCONTEXT_BROWSER_ENABLED` | `false` | Master switch for browser exploration. |
+| `AUTOCONTEXT_BROWSER_BACKEND` | `chrome-cdp` | Browser backend driver. |
+| `AUTOCONTEXT_BROWSER_PROFILE_MODE` | `ephemeral` | Browser profile lifetime (`ephemeral` discards state). |
+| `AUTOCONTEXT_BROWSER_ALLOWED_DOMAINS` | (empty) | Allowlist of domains the browser may visit. |
+| `AUTOCONTEXT_BROWSER_ALLOW_AUTH` | `false` | Permit authenticated browser sessions. |
+| `AUTOCONTEXT_BROWSER_ALLOW_UPLOADS` | `false` | Permit file uploads from the browser. |
+| `AUTOCONTEXT_BROWSER_ALLOW_DOWNLOADS` | `false` | Permit file downloads from the browser. |
+| `AUTOCONTEXT_BROWSER_CAPTURE_SCREENSHOTS` | `true` | Capture screenshots during browser exploration. |
+| `AUTOCONTEXT_BROWSER_HEADLESS` | `true` | Run the browser in headless mode. |
+| `AUTOCONTEXT_BROWSER_DEBUGGER_URL` | `http://127.0.0.1:9222` | Chrome DevTools Protocol debugger endpoint. |
+| `AUTOCONTEXT_BROWSER_PREFERRED_TARGET_URL` | (empty) | Preferred initial target URL for the browser. |
+| `AUTOCONTEXT_BROWSER_DOWNLOADS_ROOT` | (empty) | Directory for browser downloads (when enabled). |
+| `AUTOCONTEXT_BROWSER_UPLOADS_ROOT` | (empty) | Directory browser uploads are sourced from (when enabled). |
+
+<Callout type="info">
+This catalog covers the variables shipped in `.env.example`. autocontext recognizes additional `AUTOCONTEXT_*` variables for the curator, RLM, judge, Pi, and notification subsystems that are documented inline in `config/settings.py`; the ones above are the ones surfaced for first-time setup.
+</Callout>

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -12,7 +12,7 @@ For how these variables map onto provider selection, see [providers](/docs/provi
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `AUTOCONTEXT_AGENT_PROVIDER` | `deterministic` | Selects the agent provider that drives the loop. |
-| `AUTOCONTEXT_EXECUTOR_MODE` | `local` | Where strategies are executed (`local`, `primeintellect`, `monty`). |
+| `AUTOCONTEXT_EXECUTOR_MODE` | `local` | Where strategies are executed (`local`, `primeintellect`, `monty`, `ssh`). `gondolin` is reserved and fail-closed. |
 
 <Callout type="warn">
 `.env.example` ships `AUTOCONTEXT_AGENT_PROVIDER=deterministic` so the offline demo runs without credentials, but the code default when the variable is unset is `anthropic`. Set the variable explicitly to avoid surprises, and see [providers](/docs/providers) for the full list of accepted values (`deterministic`, `anthropic`, `agent_sdk`, `pi`, `pi-rpc`, `openai`, `ollama`, `vllm`).

--- a/apps/docs/content/docs/reference/glossary.mdx
+++ b/apps/docs/content/docs/reference/glossary.mdx
@@ -9,8 +9,8 @@ A one-line definition for each core term, with a link to its fuller treatment.
 | --- | --- |
 | [Scenario](/docs/concepts/scenarios-tasks) | A pluggable problem definition: either a game scenario (with match rules) or an agent-task scenario (evaluated by a judge). |
 | [Task](/docs/concepts/scenarios-tasks) | A prompt-centric unit of work framed as an agent task, scored by a judge against a rubric. |
-| [Mission](/docs/sdk) | A single verifier-driven objective the runtime pursues to completion through repeated verified steps. |
-| [Campaign](/docs/sdk) | A coordinator over multiple missions, with budgets, priorities, and dependencies between them. |
+| [Mission](/docs/concepts/scenarios-tasks) | A single verifier-driven objective the runtime pursues to completion through repeated verified steps. |
+| [Campaign](/docs/concepts/scenarios-tasks) | A coordinator over multiple missions, with budgets, priorities, and dependencies between them. |
 | [Run](/docs/concepts/runs-traces-artifacts) | One execution of a scenario across one or more generations, persisted to SQLite and the artifact store. |
 | [Generation](/docs/concepts/the-loop) | A single pass of the loop: agents act, matches are scored, and the backpressure gate decides advance, retry, or rollback. |
 | [Trace](/docs/concepts/runs-traces-artifacts) | A recorded, redactable record of what happened during execution, used for replay, datasets, and inspection. |
@@ -24,7 +24,7 @@ A one-line definition for each core term, with a link to its fuller treatment.
 | [Coach](/docs/concepts) | The agent role that updates the accumulated playbook and writes competitor hints. |
 | [Architect](/docs/concepts) | The agent role that proposes and persists tooling improvements for a scenario. |
 | [Curator](/docs/concepts) | The agent role that acts as the quality gate for playbook updates and consolidates lessons. |
-| [Judge](/docs/concepts/evaluation) | The LLM evaluator that scores agent-task outputs against a rubric, using multi-sample sampling and tolerant parsing. |
+| [Judge](/docs/concepts/evaluation) | The LLM evaluator that scores agent-task outputs against a rubric, using multi-sample voting and tolerant parsing. |
 | [Elo](/docs/concepts/evaluation) | The rating system used to score game scenarios through tournament matches between strategies. |
 | [Distillation](/docs/concepts/knowledge) | Compressing what a scenario learned into a portable, exportable form (a skill package or trained policy). |
 | [Snapshot](/docs/concepts/runs-traces-artifacts) | A per-run capture of knowledge that later runs inherit, enabling cross-run improvement. |

--- a/apps/docs/content/docs/reference/glossary.mdx
+++ b/apps/docs/content/docs/reference/glossary.mdx
@@ -1,0 +1,32 @@
+---
+title: Glossary
+description: autocontext terms in one place.
+---
+
+A one-line definition for each core term, with a link to its fuller treatment.
+
+| Term | Definition |
+| --- | --- |
+| [Scenario](/docs/concepts/scenarios-tasks) | A pluggable problem definition: either a game scenario (with match rules) or an agent-task scenario (evaluated by a judge). |
+| [Task](/docs/concepts/scenarios-tasks) | A prompt-centric unit of work framed as an agent task, scored by a judge against a rubric. |
+| [Mission](/docs/sdk) | A single verifier-driven objective the runtime pursues to completion through repeated verified steps. |
+| [Campaign](/docs/sdk) | A coordinator over multiple missions, with budgets, priorities, and dependencies between them. |
+| [Run](/docs/concepts/runs-traces-artifacts) | One execution of a scenario across one or more generations, persisted to SQLite and the artifact store. |
+| [Generation](/docs/concepts/the-loop) | A single pass of the loop: agents act, matches are scored, and the backpressure gate decides advance, retry, or rollback. |
+| [Trace](/docs/concepts/runs-traces-artifacts) | A recorded, redactable record of what happened during execution, used for replay, datasets, and inspection. |
+| [Artifact](/docs/concepts/runs-traces-artifacts) | A durable output of a run (playbook, generated tool, snapshot, or published package) stored on the filesystem. |
+| [Knowledge](/docs/concepts/knowledge) | Everything that persists across runs: playbooks, hints, lessons, analysis, tools, and snapshots. |
+| [Playbook](/docs/concepts/knowledge) | The versioned, accumulated strategy document for a scenario, updated by the coach and gated by the curator. |
+| [Hints](/docs/concepts/knowledge) | Coach-authored competitor hints that persist across restarts and steer the next generation's strategy. |
+| [Lessons](/docs/concepts/knowledge) | Distilled, consolidated takeaways the curator periodically merges into durable knowledge. |
+| [Competitor](/docs/concepts) | The agent role that produces a candidate strategy (JSON or executable code). |
+| [Analyst](/docs/concepts) | The agent role that produces markdown analysis: findings, root causes, and recommendations. |
+| [Coach](/docs/concepts) | The agent role that updates the accumulated playbook and writes competitor hints. |
+| [Architect](/docs/concepts) | The agent role that proposes and persists tooling improvements for a scenario. |
+| [Curator](/docs/concepts) | The agent role that acts as the quality gate for playbook updates and consolidates lessons. |
+| [Judge](/docs/concepts/evaluation) | The LLM evaluator that scores agent-task outputs against a rubric, using multi-sample sampling and tolerant parsing. |
+| [Elo](/docs/concepts/evaluation) | The rating system used to score game scenarios through tournament matches between strategies. |
+| [Distillation](/docs/concepts/knowledge) | Compressing what a scenario learned into a portable, exportable form (a skill package or trained policy). |
+| [Snapshot](/docs/concepts/runs-traces-artifacts) | A per-run capture of knowledge that later runs inherit, enabling cross-run improvement. |
+| [Provider](/docs/providers) | The pluggable LLM backend that powers agent roles (Anthropic, Agent SDK, OpenAI-compatible, Pi, deterministic). |
+| [MCP](/docs/agents/mcp) | The Model Context Protocol server autocontext exposes so agents can drive the loop, read knowledge, and manage runs. |

--- a/apps/docs/content/docs/reference/mcp-tools.mdx
+++ b/apps/docs/content/docs/reference/mcp-tools.mdx
@@ -1,0 +1,289 @@
+---
+title: MCP Tools
+description: The full catalog of MCP tools on both runtimes.
+---
+
+autocontext ships an MCP server on both runtimes so agents can drive the loop, read knowledge, and manage runs without shelling out. The Python server (`uv run autoctx mcp-serve`) registers the largest surface: **72 distinct public tools**, all under the `autocontext_` prefix. The TypeScript server (`autoctx mcp-serve` in the `ts` package) exposes a parallel, mission- and campaign-oriented surface of **76 distinct tools** (the three solve tools are each registered under both a bare name and an `autocontext_`-prefixed alias, so 79 registrations cover 76 unique tools).
+
+The tables below are generated from the server source. For setup and how to wire the server into Claude Code or another MCP client, see [the MCP server guide](/docs/agents/mcp).
+
+## Python tools
+
+Grouped by family. All names carry the `autocontext_` prefix.
+
+### Solve, evaluate, improve, status
+
+| Tool | Purpose |
+| --- | --- |
+| `autocontext_solve_scenario` | Submit a new problem for on-demand solving (autocontext creates a scenario for it). |
+| `autocontext_solve_status` | Check status of a solve-on-demand job. |
+| `autocontext_solve_result` | Get the skill package result of a completed solve job. |
+| `autocontext_evaluate_strategy` | Evaluate a candidate strategy against a scenario via tournament matches. |
+| `autocontext_evaluate_output` | One-shot evaluation of an output against a saved agent task spec. |
+| `autocontext_validate_strategy` | Validate a strategy JSON string against scenario constraints. |
+| `autocontext_validate_strategy_against_harness` | Validate a strategy against scenario constraints and harness validators. |
+| `autocontext_generate_output` | Generate an initial output for an agent task. |
+| `autocontext_run_improvement_loop` | Run the multi-step improvement loop for an agent task. |
+| `autocontext_queue_improvement_run` | Queue an agent task for background improvement-loop processing. |
+| `autocontext_get_best_output` | Get the highest-scoring output for a task across all completed runs. |
+| `autocontext_run_status` | Get generation-level metrics for a run. |
+
+### Scenario discovery
+
+| Tool | Purpose |
+| --- | --- |
+| `autocontext_list_scenarios` | List available game scenarios with a rules preview. |
+| `autocontext_describe_scenario` | Get full scenario description: rules, strategy interface, evaluation criteria. |
+| `autocontext_skill_discover` | Discover available scenarios, optionally filtered by natural language query. |
+| `autocontext_skill_select` | Recommend the best scenario for a problem description. |
+| `autocontext_skill_scenario_capabilities` | Return per-scenario capabilities: evaluation mode, harness, playbook, best scores. |
+| `autocontext_skill_scenario_artifacts` | Return all artifacts associated with a scenario. |
+| `autocontext_search_strategies` | Search solved scenarios by natural language query. |
+| `autocontext_list_solved` | List scenarios with solved strategies, including best scores and run counts. |
+
+### Knowledge readers
+
+| Tool | Purpose |
+| --- | --- |
+| `autocontext_read_playbook` | Read the current strategy playbook for a scenario. |
+| `autocontext_read_hints` | Read persisted coach hints for a scenario. |
+| `autocontext_read_analysis` | Read analysis for a specific generation. |
+| `autocontext_read_skills` | Read operational lessons from SKILL.md for a scenario. |
+| `autocontext_read_tools` | Read architect-generated tools for a scenario. |
+| `autocontext_read_trajectory` | Read the score trajectory table for a run. |
+
+### Runs and runtime sessions
+
+| Tool | Purpose |
+| --- | --- |
+| `autocontext_list_runs` | List recent runs. |
+| `autocontext_run_match` | Execute a single match and return the result. |
+| `autocontext_run_tournament` | Run N matches and return aggregate stats. |
+| `autocontext_run_replay` | Read replay JSON for a specific generation. |
+| `autocontext_list_runtime_sessions` | List recorded runtime-session event logs. |
+| `autocontext_get_runtime_session` | Read a runtime-session event log by session id or run id. |
+| `autocontext_get_runtime_session_timeline` | Read an operator-facing runtime-session timeline. |
+| `autocontext_env_snapshot` | Return the environment snapshot collected at run start for a scenario. |
+
+### Sandbox
+
+| Tool | Purpose |
+| --- | --- |
+| `autocontext_sandbox_create` | Create an isolated sandbox for external play. |
+| `autocontext_sandbox_run` | Run generation(s) in a sandbox. |
+| `autocontext_sandbox_status` | Get sandbox status. |
+| `autocontext_sandbox_playbook` | Read the sandbox playbook. |
+| `autocontext_sandbox_list` | List active sandboxes. |
+| `autocontext_sandbox_destroy` | Destroy a sandbox and clean up its data. |
+
+### Monitors
+
+| Tool | Purpose |
+| --- | --- |
+| `autocontext_create_monitor_tool` | Create a new monitor condition to watch for events. |
+| `autocontext_list_monitors_tool` | List active monitor conditions. |
+| `autocontext_delete_monitor_tool` | Deactivate a monitor condition. |
+| `autocontext_list_monitor_alerts_tool` | List monitor alerts with optional filters. |
+| `autocontext_wait_for_monitor_tool` | Wait for a monitor condition to fire; blocks until alert or timeout. |
+
+### Agent tasks
+
+| Tool | Purpose |
+| --- | --- |
+| `autocontext_create_agent_task` | Create and save an agent task spec for evaluation. |
+| `autocontext_get_agent_task` | Get the full agent task spec by name. |
+| `autocontext_list_agent_tasks` | List all saved agent task specs. |
+| `autocontext_delete_agent_task` | Delete an agent task spec. |
+| `autocontext_export_agent_task_skill` | Export a portable skill package for an agent task with best outputs and lessons. |
+| `autocontext_get_queue_status` | Get task queue status: pending, running, recent completed/failed. |
+| `autocontext_get_task_result` | Get the result of a specific queued task by ID. |
+
+### Evidence
+
+| Tool | Purpose |
+| --- | --- |
+| `autocontext_evidence_list` | Return the evidence workspace manifest for a scenario. |
+| `autocontext_evidence_artifact` | Return a specific evidence artifact by ID, with optional excerpting. |
+
+### Export and import
+
+| Tool | Purpose |
+| --- | --- |
+| `autocontext_export_skill` | Export a portable skill package (playbook, lessons, strategy) for a solved scenario. |
+| `autocontext_export_package` | Export a versioned, portable strategy package for a scenario. |
+| `autocontext_import_package` | Import a strategy package into scenario knowledge. |
+| `autocontext_publish_artifact` | Publish an artifact (harness, policy, or distilled model). |
+| `autocontext_fetch_artifact` | Fetch a published artifact by its ID. |
+| `autocontext_list_artifacts` | List published artifacts with optional scenario and type filters. |
+
+### Distillation
+
+| Tool | Purpose |
+| --- | --- |
+| `autocontext_trigger_distillation` | Trigger a distillation workflow for a scenario. |
+| `autocontext_distill_status` | Check status of distillation workflows, optionally filtered by scenario. |
+| `autocontext_get_distill_job` | Get details of a specific distillation job by ID. |
+| `autocontext_update_distill_job` | Update a distillation job status (training metrics passed as a JSON string). |
+
+### Feedback
+
+| Tool | Purpose |
+| --- | --- |
+| `autocontext_record_feedback` | Record human feedback on an agent task output (score 0.0-1.0). |
+| `autocontext_get_feedback` | Get recent human feedback for a scenario. |
+
+### Skill and capability surface
+
+| Tool | Purpose |
+| --- | --- |
+| `autocontext_capabilities` | Return capability metadata for this autocontext instance. |
+| `autocontext_skill_advertise` | Return a full capability advertisement: version, runtime health, scenarios, artifact counts. |
+| `autocontext_skill_manifest` | Get the ClawHub skill manifest for this instance. |
+| `autocontext_skill_runtime_health` | Return runtime health: executor mode, provider, harness mode, available models. |
+| `autocontext_skill_discover_artifacts` | Find published artifacts with optional scenario and type filters. |
+| `autocontext_skill_evaluate` | Full validate-plus-evaluate workflow for a strategy. |
+
+## TypeScript tools
+
+The TypeScript server centers on missions and campaigns, plus a production-traces data plane. Tool names here are unprefixed unless noted.
+
+### Solve
+
+| Tool | Purpose |
+| --- | --- |
+| `solve_scenario` (alias `autocontext_solve_scenario`) | Submit a problem for on-demand solving; returns a job_id for polling. |
+| `solve_status` (alias `autocontext_solve_status`) | Check status of a solve-on-demand job. |
+| `solve_result` (alias `autocontext_solve_result`) | Get the exported skill package result of a completed solve-on-demand job. |
+
+### Missions
+
+| Tool | Purpose |
+| --- | --- |
+| `create_mission` | Create a new verifier-driven mission. |
+| `mission_status` | Get the current status and summary for a mission. |
+| `mission_result` | Get the full mission result payload, including steps and verifications. |
+| `mission_artifacts` | Inspect durable checkpoint artifacts for a mission. |
+| `pause_mission` | Pause an active mission. |
+| `resume_mission` | Resume a paused mission. |
+| `cancel_mission` | Cancel a mission. |
+
+### Campaigns
+
+| Tool | Purpose |
+| --- | --- |
+| `create_campaign` | Create a new campaign to coordinate multiple missions. |
+| `campaign_status` | Get campaign details with progress and mission list. |
+| `campaign_progress` | Get campaign progress with completion percentage and budget usage. |
+| `list_campaigns` | List all campaigns, optionally filtered by status. |
+| `add_campaign_mission` | Add a mission to a campaign with optional priority and dependencies. |
+| `pause_campaign` | Pause an active campaign. |
+| `resume_campaign` | Resume a paused campaign. |
+| `cancel_campaign` | Cancel a campaign. |
+
+### Core control
+
+| Tool | Purpose |
+| --- | --- |
+| `evaluate_output` | One-shot evaluation of output against a rubric. |
+| `run_improvement_loop` | Run a multi-round improvement loop on agent output. |
+| `run_repl_session` | Run a direct REPL-loop session for agent-task generation or revision. |
+| `queue_task` | Add a task to the background runner queue. |
+| `get_queue_status` | Get the task queue status summary. |
+| `get_task_result` | Get the result of a queued task by ID. |
+| `capabilities` | Return capability metadata for this autocontext instance. |
+| `instrument` | Scan a repo for LLM clients and propose or apply autocontext wrappers. |
+
+### Scenarios
+
+| Tool | Purpose |
+| --- | --- |
+| `list_scenarios` | List available scenarios with metadata. |
+| `get_scenario` | Get detailed information about a scenario. |
+| `revise_scenario` | Revise a scenario spec from user feedback and return the updated spec. |
+| `validate_strategy` | Validate a strategy JSON against a scenario's constraints. |
+| `run_match` | Execute a single match for a scenario. |
+| `run_tournament` | Run N matches with Elo scoring. |
+
+### Runs
+
+| Tool | Purpose |
+| --- | --- |
+| `list_runs` | List recent runs with optional filters. |
+| `get_run_status` | Get run progress, scores, and generation details. |
+| `get_generation_detail` | Get detailed results for a specific generation. |
+| `get_playbook` | Read the accumulated playbook for a scenario. |
+| `run_scenario` | Kick off a scenario run with configuration options. |
+| `run_replay` | Read replay JSON for a specific generation. |
+
+### Runtime sessions
+
+| Tool | Purpose |
+| --- | --- |
+| `list_runtime_sessions` | List recent runtime-session event logs. |
+| `get_runtime_session` | Read a runtime-session event log by session id or run id. |
+| `get_runtime_session_timeline` | Read an operator-facing runtime-session timeline. |
+
+### Knowledge readers
+
+| Tool | Purpose |
+| --- | --- |
+| `read_trajectory` | Read the score trajectory for a run as markdown. |
+| `read_hints` | Read competitor hints for a scenario. |
+| `read_analysis` | Read the analyst output for a specific generation. |
+| `read_tools` | Read architect-generated tools for a scenario. |
+| `read_skills` | Read skill notes for a scenario. |
+| `export_skill` | Export a portable skill package with markdown for agent install. |
+| `list_solved` | List scenarios with exported knowledge or completed runs. |
+| `search_strategies` | Search past strategies by keyword. |
+
+### Agent task packages
+
+| Tool | Purpose |
+| --- | --- |
+| `create_agent_task` | Create a named agent task spec for evaluation. |
+| `list_agent_tasks` | List created agent task specs. |
+| `get_agent_task` | Get a specific agent task spec by name. |
+| `generate_output` | Generate an initial agent output for a task prompt. |
+| `export_package` | Export a versioned strategy package for a scenario. |
+| `import_package` | Import a strategy package into scenario knowledge. |
+
+### Sandbox
+
+| Tool | Purpose |
+| --- | --- |
+| `sandbox_create` | Create an isolated sandbox for scenario execution. |
+| `sandbox_run` | Run generation(s) in a sandbox. |
+| `sandbox_status` | Get sandbox status. |
+| `sandbox_playbook` | Read the current playbook for a sandbox. |
+| `sandbox_list` | List active sandboxes. |
+| `sandbox_destroy` | Destroy a sandbox and clean up its data. |
+
+### Feedback and replay
+
+| Tool | Purpose |
+| --- | --- |
+| `record_feedback` | Record human feedback for a scenario evaluation. |
+| `get_feedback` | Retrieve human feedback for a scenario. |
+| `run_replay` | Read replay JSON for a specific generation. |
+
+### Production traces
+
+| Tool | Purpose |
+| --- | --- |
+| `production_traces_init` | Scaffold the production-traces workspace and generate the install salt (idempotent). |
+| `production_traces_ingest` | Validate and move incoming trace batches into the ingested store. |
+| `production_traces_list` | List locally-stored traces (no redaction applied). |
+| `production_traces_show` | Inspect a single trace by traceId, optionally previewing redaction. |
+| `production_traces_stats` | Aggregate counts across ingested traces, grouped by a field. |
+| `production_traces_build_dataset` | Build an evaluation dataset from curated traces. |
+| `production_traces_datasets_list` | List dataset manifests. |
+| `production_traces_datasets_show` | Render a specific dataset's manifest. |
+| `production_traces_export` | Emit traces with redaction applied at the export boundary. |
+| `production_traces_policy_show` | Print the current redaction policy. |
+| `production_traces_policy_set` | Change the redaction mode. |
+| `production_traces_rotate_salt` | Rotate the install salt (break-glass; requires force). |
+| `production_traces_prune` | Enforce the retention policy out-of-band. |
+
+<Callout type="info">
+Tool names are read directly from the MCP server registrations. The Python and TypeScript surfaces overlap by intent but are not identical: the Python server carries the distillation, evidence, monitor, and skill-advertisement families, while the TypeScript server carries the mission, campaign, and production-traces families.
+</Callout>

--- a/apps/docs/content/docs/reference/mcp-tools.mdx
+++ b/apps/docs/content/docs/reference/mcp-tools.mdx
@@ -3,13 +3,17 @@ title: MCP Tools
 description: The full catalog of MCP tools on both runtimes.
 ---
 
-autocontext ships an MCP server on both runtimes so agents can drive the loop, read knowledge, and manage runs without shelling out. The Python server (`uv run autoctx mcp-serve`) registers the largest surface: **72 distinct public tools**, all under the `autocontext_` prefix. The TypeScript server (`autoctx mcp-serve` in the `ts` package) exposes a parallel, mission- and campaign-oriented surface of **76 distinct tools** (the three solve tools are each registered under both a bare name and an `autocontext_`-prefixed alias, so 79 registrations cover 76 unique tools).
+autocontext ships an MCP server on both runtimes so agents can drive the loop, read knowledge, and manage runs without shelling out. The Python server (`uv run autoctx mcp-serve`) registers the largest surface: **72 distinct public tools**, primarily under the `autocontext_` prefix. Six of those tools (the three solve tools plus the three runtime-session readers) also register unprefixed aliases for parity with the TypeScript names, so MCP clients may discover them under both the prefixed and bare names. The TypeScript server (`autoctx mcp-serve` in the `ts` package) exposes a parallel, mission- and campaign-oriented surface of **76 distinct tools** (the three solve tools are each registered under both a bare name and an `autocontext_`-prefixed alias, so 79 registrations cover 76 unique tools).
 
 The tables below are generated from the server source. For setup and how to wire the server into Claude Code or another MCP client, see [the MCP server guide](/docs/agents/mcp).
 
 ## Python tools
 
-Grouped by family. All names carry the `autocontext_` prefix.
+Grouped by family. Names carry the `autocontext_` prefix.
+
+<Callout type="info">
+Six Python tools also register unprefixed aliases for parity with the TypeScript tool names (verified in `mcp/server.py`): `solve_scenario`, `solve_status`, `solve_result`, `list_runtime_sessions`, `get_runtime_session`, and `get_runtime_session_timeline`. Each of these is reachable under both its `autocontext_`-prefixed name and its bare name, so MCP clients may discover both forms.
+</Callout>
 
 ### Solve, evaluate, improve, status
 

--- a/apps/docs/content/docs/reference/mcp-tools.mdx
+++ b/apps/docs/content/docs/reference/mcp-tools.mdx
@@ -258,13 +258,12 @@ The TypeScript server centers on missions and campaigns, plus a production-trace
 | `sandbox_list` | List active sandboxes. |
 | `sandbox_destroy` | Destroy a sandbox and clean up its data. |
 
-### Feedback and replay
+### Feedback
 
 | Tool | Purpose |
 | --- | --- |
 | `record_feedback` | Record human feedback for a scenario evaluation. |
 | `get_feedback` | Retrieve human feedback for a scenario. |
-| `run_replay` | Read replay JSON for a specific generation. |
 
 ### Production traces
 

--- a/apps/docs/content/docs/reference/meta.json
+++ b/apps/docs/content/docs/reference/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Reference",
+  "pages": ["environment-variables", "mcp-tools", "glossary"]
+}

--- a/apps/docs/content/docs/sdk/extensions.mdx
+++ b/apps/docs/content/docs/sdk/extensions.mdx
@@ -39,7 +39,7 @@ Set `AUTOCONTEXT_EXTENSION_FAIL_FAST=true` when hook failures should stop the ru
 An extension module may expose `register(api)`, `configure(api)`, or `setup(api)`. References may also target a callable directly with `module:function`.
 
 ```python
-from autocontext.extensions import HookEvents, HookResult
+from autocontext import HookEvents, HookResult
 
 
 def register(api):

--- a/apps/docs/content/docs/sdk/extensions.mdx
+++ b/apps/docs/content/docs/sdk/extensions.mdx
@@ -1,0 +1,83 @@
+---
+title: Extension Hooks
+description: Hook into autocontext lifecycle events.
+---
+
+autocontext exposes small Python and TypeScript extension hook buses for Pi-shaped runtime customization. They are intentionally narrow: extensions receive structured events at stable runtime boundaries and may mutate the event payload, block the operation, or record side metadata.
+
+Both packages export the same core types from their package roots:
+
+- `ExtensionAPI`: the object passed to your extension's setup function, used to register handlers.
+- `HookBus`: the bus that dispatches events to registered handlers in order.
+- `HookEvents`: the catalog of built-in event names.
+- `HookResult`: the explicit return type for replacing, merging, or blocking on an event.
+
+```python
+from autocontext import ExtensionAPI, HookBus, HookEvents, HookResult
+```
+
+## Loading extensions
+
+Load extensions with the `AUTOCONTEXT_EXTENSIONS` environment variable, a comma-separated list of module paths:
+
+```bash
+AUTOCONTEXT_EXTENSIONS=my_project.autoctx_hooks,./local_hooks.py \
+uv run autoctx run --scenario grid_ctf --gens 3
+```
+
+For the TypeScript package, point `AUTOCONTEXT_EXTENSIONS` at JavaScript/ESM modules or `module:callable` targets:
+
+```bash
+AUTOCONTEXT_EXTENSIONS=./local-hooks.mjs \
+bunx autoctx run --scenario grid_ctf --gens 3
+```
+
+Set `AUTOCONTEXT_EXTENSION_FAIL_FAST=true` when hook failures should stop the run. By default, hook handler exceptions are recorded on the event and the run continues.
+
+## Extension shape
+
+An extension module may expose `register(api)`, `configure(api)`, or `setup(api)`. References may also target a callable directly with `module:function`.
+
+```python
+from autocontext.extensions import HookEvents, HookResult
+
+
+def register(api):
+    @api.on(HookEvents.CONTEXT)
+    def add_competitor_context(event):
+        roles = dict(event.payload["roles"])
+        roles["competitor"] += "\nPrefer concise, testable strategies."
+        return HookResult(payload={"roles": roles})
+```
+
+Handlers may mutate `event.payload` in place, return a `dict` to merge into the payload, or return `HookResult` for explicit replacement or blocking:
+
+```python
+return HookResult(block=True, reason="extension policy rejected this artifact")
+```
+
+## Built-in events
+
+| Event | Payload |
+| --- | --- |
+| `run_start` | `run_id`, `scenario`, `target_generations`, `loaded_extensions` |
+| `run_end` | `run_id`, `scenario`, `status`, summary metrics, optional `error` |
+| `generation_start` | `run_id`, `scenario`, `generation` |
+| `generation_end` | `run_id`, `scenario`, `generation`, `status`, metrics, optional `error` |
+| `context_components` | Prompt assembly inputs before prompt construction |
+| `before_compaction` | Semantic compaction components before compaction |
+| `after_compaction` | Semantic compaction inputs and compacted components |
+| `context` | Final role prompts as `roles.competitor`, `roles.analyst`, `roles.coach`, `roles.architect` |
+| `before_provider_request` | Provider, role, model, prompt or messages, token and temperature settings |
+| `after_provider_response` | Provider, role, request, text, usage, metadata |
+| `before_judge` | Judge prompt, model, temperature, sample and retry metadata |
+| `after_judge` | Judge request and raw `response_text` before parsing |
+| `artifact_write` | Path, format, content or payload, append/buffered metadata |
+
+<Callout>
+`artifact_write` hooks may rewrite `path`, but ArtifactStore writes must stay inside the original managed root (`runs`, `knowledge`, `skills`, or `.claude/skills`).
+</Callout>
+
+## Design notes
+
+The hook bus follows the same spirit as Pi extensions: small contracts, ordered handlers, branch and run-safe payloads, and no hidden prompt parsing. autocontext keeps its full control plane by default; use hooks for local policy, observability, context shaping, and Pi-like harness adaptation.

--- a/apps/docs/content/docs/sdk/extensions.mdx
+++ b/apps/docs/content/docs/sdk/extensions.mdx
@@ -67,7 +67,7 @@ return HookResult(block=True, reason="extension policy rejected this artifact")
 | `context_components` | Prompt assembly inputs before prompt construction |
 | `before_compaction` | Semantic compaction components before compaction |
 | `after_compaction` | Semantic compaction inputs and compacted components |
-| `context` | Final role prompts as `roles.competitor`, `roles.analyst`, `roles.coach`, `roles.architect` |
+| `context` | Final role prompts as `roles.competitor`, `roles.analyst`, `roles.coach`, `roles.architect` (the prompt-producing roles only; translator and curator are not part of this payload) |
 | `before_provider_request` | Provider, role, model, prompt or messages, token and temperature settings |
 | `after_provider_response` | Provider, role, request, text, usage, metadata |
 | `before_judge` | Judge prompt, model, temperature, sample and retry metadata |

--- a/apps/docs/content/docs/sdk/index.mdx
+++ b/apps/docs/content/docs/sdk/index.mdx
@@ -1,0 +1,35 @@
+---
+title: SDK Overview
+description: Embed autocontext in your own Python or TypeScript code.
+---
+
+The CLI and MCP server cover most workflows, but sometimes you want autocontext as a library: a function call inside your own service, a step in a pipeline, or a building block in a larger agent. autocontext ships two packages for that, one for Python and one for TypeScript.
+
+## When to embed vs use the CLI
+
+Reach for the SDK when you need:
+
+- Typed, in-process results instead of parsing CLI JSON.
+- To wire autocontext into an existing service, worker, or notebook.
+- Fine-grained control over individual pieces (judge, improvement loop, storage) rather than the whole generation loop.
+
+Stick with the [CLI](/docs/cli) or [agent integration](/docs/agents) when you want the full control plane, want another agent to drive autocontext over a shell or MCP, or just want to run a scenario end to end without writing code.
+
+<Callout>
+The SDK and CLI share the same underlying tool layer, so results are consistent across both. The SDK simply returns typed objects instead of dicts on stdout.
+</Callout>
+
+## The two packages
+
+| Package | Install | Best at |
+| --- | --- | --- |
+| Python (`autocontext`) | `pip install autocontext` / `uv add autocontext` | The high-level `AutoContext` client: discover scenarios, evaluate strategies, search solved knowledge, export skills. |
+| TypeScript (`autoctx`) | `npm install autoctx` | Composable building blocks: the improvement loop, judge, executor, storage, config, prompts, and scoring primitives. |
+
+The Python package gives you one stable, ergonomic class. The TypeScript package gives you a wider surface of lower-level primitives you can assemble yourself.
+
+## Where to go next
+
+- [Python SDK](/docs/sdk/python): the `AutoContext` class, every method, and a minimal end-to-end example.
+- [TypeScript SDK](/docs/sdk/typescript): the key exports from `autoctx`, grouped by concern.
+- [Extension Hooks](/docs/sdk/extensions): hook into autocontext lifecycle events from either language.

--- a/apps/docs/content/docs/sdk/meta.json
+++ b/apps/docs/content/docs/sdk/meta.json
@@ -1,0 +1,1 @@
+{ "title": "SDK", "pages": ["index", "python", "typescript", "extensions"] }

--- a/apps/docs/content/docs/sdk/python.mdx
+++ b/apps/docs/content/docs/sdk/python.mdx
@@ -1,0 +1,176 @@
+---
+title: Python SDK
+description: The AutoContext class and how to use it.
+---
+
+The Python package exposes a single high-level client, `AutoContext`, that wraps the same tool layer used by the CLI and MCP server and returns typed result models instead of raw dicts.
+
+```python
+from autocontext import AutoContext
+```
+
+## Constructing the client
+
+`AutoContext` takes only keyword arguments, all optional:
+
+```python
+AutoContext(
+    *,
+    settings: AppSettings | None = None,
+    db_path: str | Path | None = None,
+    knowledge_root: str | Path | None = None,
+    skills_root: str | Path | None = None,
+    claude_skills_path: str | Path | None = None,
+    **overrides,
+)
+```
+
+- `settings`: a pre-built `AppSettings` instance. When provided, every other argument is ignored.
+- `db_path`, `knowledge_root`, `skills_root`, `claude_skills_path`: convenience path overrides that map to the matching `AppSettings` fields.
+- `**overrides`: any additional `AppSettings` field overrides (for example `matches_per_generation=5`).
+
+With no arguments it loads settings from `AUTOCONTEXT_*` environment variables.
+
+```python
+client = AutoContext(db_path="runs/autocontext.sqlite3")
+```
+
+## Typed result models
+
+Several methods return Pydantic models from `autocontext.sdk_models` rather than dicts:
+
+- `ValidateResult`: `valid: bool`, `reason: str`.
+- `EvaluateResult`: `scores: list[float]`, `mean_score: float`, `best_score: float`, `matches: int`, `error: str | None`.
+- `MatchResult`: `score: float`, `winner: str`, `summary: str`, `metrics: dict`, `replay: list | None`, `error: str | None`.
+- `SearchResult`: `scenario_name: str`, `display_name: str`, `description: str`, `relevance: float`, `best_score: float`, `best_elo: float`, `match_reason: str`.
+
+<Callout>
+`evaluate`, `match`, and `validate` never raise on a bad strategy. They populate the `error` (or `reason`) field on the result instead, so you can branch on it cleanly.
+</Callout>
+
+## Methods
+
+### `list_scenarios()`
+
+Return available scenarios, each as a dict with a name and rules preview.
+
+```python
+for s in client.list_scenarios():
+    print(s["name"])
+```
+
+Returns `list[dict[str, str]]`.
+
+### `describe_scenario(name)`
+
+Return the full description of a scenario: rules, strategy interface, and evaluation criteria.
+
+```python
+info = client.describe_scenario("grid_ctf")
+print(info["rules"])
+```
+
+Returns `dict[str, str]`.
+
+### `validate(scenario, strategy)`
+
+Validate a strategy dict against a scenario's constraints without running a match.
+
+```python
+result = client.validate("grid_ctf", {"aggression": 0.5})
+if not result.valid:
+    print(result.reason)
+```
+
+Returns `ValidateResult`.
+
+### `evaluate(scenario, strategy, matches=3, seed_base=42)`
+
+Run `matches` tournament games and return aggregate scores. The strategy is validated first; agent-task scenarios (which use judge evaluation) populate the `error` field instead.
+
+```python
+result = client.evaluate("grid_ctf", {"aggression": 0.5}, matches=5)
+print(result.mean_score, result.best_score)
+```
+
+Returns `EvaluateResult`.
+
+### `match(scenario, strategy, seed=42)`
+
+Execute a single match and return the result, including a replay when the scenario provides one.
+
+```python
+result = client.match("grid_ctf", {"aggression": 0.5}, seed=7)
+print(result.winner, result.score)
+```
+
+Returns `MatchResult`.
+
+### `search(query, top_k=5)`
+
+Search solved scenarios by natural-language query, ranked by relevance.
+
+```python
+for hit in client.search("capture the flag on a grid", top_k=3):
+    print(hit.scenario_name, hit.relevance)
+```
+
+Returns `list[SearchResult]`.
+
+### `export_skill(scenario)`
+
+Export a portable skill package (markdown plus JSON) for a solved scenario.
+
+```python
+pkg = client.export_skill("grid_ctf")
+```
+
+Returns `dict[str, Any]`.
+
+### `export_package(scenario)`
+
+Export a versioned, portable strategy package for a solved scenario.
+
+```python
+pkg = client.export_package("grid_ctf")
+```
+
+Returns `dict[str, Any]`.
+
+### `list_artifacts(scenario=None, artifact_type=None)`
+
+List published artifacts, optionally filtered by scenario or by artifact type.
+
+```python
+artifacts = client.list_artifacts(scenario="grid_ctf")
+```
+
+Returns `list[dict[str, Any]]`.
+
+## End-to-end example
+
+```python
+from autocontext import AutoContext
+
+client = AutoContext(db_path="runs/autocontext.sqlite3")
+
+# Discover what is available.
+for scenario in client.list_scenarios():
+    print(scenario["name"])
+
+# Evaluate a strategy over five matches.
+result = client.evaluate("grid_ctf", {"aggression": 0.5}, matches=5)
+if result.error:
+    print("evaluation failed:", result.error)
+else:
+    print(f"mean={result.mean_score:.3f} best={result.best_score:.3f}")
+
+# Search solved knowledge.
+for hit in client.search("grid capture the flag", top_k=3):
+    print(f"{hit.scenario_name}: {hit.relevance:.2f}")
+```
+
+## See also
+
+- [Extension Hooks](/docs/sdk/extensions): `ExtensionAPI`, `HookBus`, `HookEvents`, and `HookResult`, also exported from the `autocontext` package.
+- [Providers](/docs/providers): configure the LLM provider via `AUTOCONTEXT_*` settings that `AutoContext` reads.

--- a/apps/docs/content/docs/sdk/typescript.mdx
+++ b/apps/docs/content/docs/sdk/typescript.mdx
@@ -1,0 +1,154 @@
+---
+title: TypeScript SDK
+description: Programmatic building blocks from the autoctx package.
+---
+
+The TypeScript package is published as `autoctx` on npm. Unlike the Python package, which centers on one high-level client, `autoctx` exposes a wide surface of composable primitives you assemble yourself.
+
+```bash
+npm install autoctx
+```
+
+```typescript
+import { ImprovementLoop, JudgeExecutor } from "autoctx";
+```
+
+All exports come from the package root unless noted. The package is ESM-only and targets Node.js 18 or later.
+
+## Improvement loop
+
+`ImprovementLoop` drives a multi-round evaluate-then-revise loop over an agent task, with parse-failure resilience and plateau detection.
+
+```typescript
+import { ImprovementLoop, isImproved, isParseFailure } from "autoctx";
+import type { ImprovementLoopOpts } from "autoctx";
+
+const loop = new ImprovementLoop({
+  task,                 // an AgentTaskInterface
+  maxRounds: 5,
+  qualityThreshold: 0.9,
+  minRounds: 1,
+});
+
+const result = await loop.run({
+  initialOutput: "first draft",
+  state: {},
+  referenceContext: "authoritative context",
+  requiredConcepts: ["idempotency", "retries"],
+});
+
+console.log(result.bestScore, result.bestOutput);
+```
+
+- `ImprovementLoopOpts`: the constructor options (`task`, plus optional `maxRounds`, `qualityThreshold`, `minRounds`, `maxScoreDelta`, `capScoreJumps`, `dimensionThreshold`, `timeBudget`).
+- `isImproved(...)`: predicate for whether a round improved on the prior best.
+- `isParseFailure(...)`: predicate for whether a judge result was a parse failure rather than a genuine low score.
+
+## Evaluation
+
+`JudgeExecutor` evaluates a single agent output by delegating to an `AgentTaskInterface`, running context preparation and validation first.
+
+```typescript
+import { JudgeExecutor } from "autoctx";
+
+const judge = new JudgeExecutor(task); // task: AgentTaskInterface
+const result = await judge.execute(agentOutput, state, {
+  referenceContext: "...",
+  requiredConcepts: ["..."],
+});
+
+console.log(result.score, result.reasoning);
+```
+
+## Execution
+
+- `ExecutionSupervisor`: orchestrates an execution engine over an `ExecutionInput`, returning an `ExecutionOutput`.
+- `LocalExecutor`: a local execution engine for use with the supervisor.
+
+```typescript
+import { ExecutionSupervisor, LocalExecutor } from "autoctx";
+```
+
+## Storage
+
+`SQLiteStore` is the structured-data store for runs, generations, matches, feedback, and the task queue.
+
+```typescript
+import { SQLiteStore } from "autoctx";
+
+const store = new SQLiteStore("./autocontext.db");
+```
+
+## Config
+
+```typescript
+import { AppSettingsSchema, loadSettings, applyPreset, PRESETS } from "autoctx";
+
+const settings = loadSettings();          // read AUTOCONTEXT_* env vars
+const quick = applyPreset("quick");       // overrides for a named preset
+const presetNames = [...PRESETS.keys()];  // e.g. "quick", "standard"
+```
+
+- `loadSettings()`: build an `AppSettings` from the environment.
+- `applyPreset(name)`: return the field overrides for a named preset.
+- `PRESETS`: a `Map` of preset name to override object.
+- `AppSettingsSchema`: the zod schema backing `AppSettings`.
+
+## Prompts
+
+```typescript
+import { buildPromptBundle, estimateTokens, ContextBudget } from "autoctx";
+
+const tokens = estimateTokens("some prompt text");
+const budget = new ContextBudget(100_000);
+const bundle = buildPromptBundle(promptContext);
+```
+
+- `buildPromptBundle(ctx)`: assemble role prompts from a `PromptContext` into a `PromptBundle`.
+- `estimateTokens(text)`: a fast token-count estimate.
+- `ContextBudget`: enforce a token budget across prompt components.
+
+## Scoring
+
+```typescript
+import { expectedScore, updateElo } from "autoctx";
+
+const expected = expectedScore(1500, 1480);
+const next = updateElo(1500, 1480, 1.0); // playerRating, opponentRating, actualScore
+```
+
+- `expectedScore(playerRating, opponentRating)`: the expected Elo score.
+- `updateElo(playerRating, opponentRating, actualScore, kFactor = 24)`: the updated rating.
+
+## Validation
+
+`StrategyValidator` validates strategy dicts against a scenario before execution.
+
+```typescript
+import { StrategyValidator } from "autoctx";
+```
+
+## Experimental agent-handler surface
+
+The package also exposes an experimental `autoctx/agent-runtime` subpath for local programmable handlers placed in `.autoctx/agents/*.ts`. It uses the bundled `tsx` loader for `.ts`, `.tsx`, and `.mts` files on Node 18 or later. This is an open-source local authoring surface, not a hosted deployment layer.
+
+```typescript
+import type { AutoctxAgentContext } from "autoctx/agent-runtime";
+
+export const triggers = { webhook: true };
+
+export default async function supportAgent(
+  { init, payload }: AutoctxAgentContext<{ message: string }>,
+) {
+  const runtime = await init();
+  const session = await runtime.session("default");
+  return session.prompt(payload.message, { role: "support-triager" });
+}
+```
+
+See [`examples/agent-runtime`](https://github.com/greyhaven-ai/autocontext/tree/main/examples/agent-runtime) for a complete, runnable handler.
+
+## See also
+
+- [Extension Hooks](/docs/sdk/extensions): `ExtensionAPI`, `HookBus`, `HookEvents`, and `HookResult` are exported from `autoctx` as well.
+- [Python SDK](/docs/sdk/python): the higher-level `AutoContext` client for the Python package.

--- a/apps/docs/content/docs/sdk/typescript.mdx
+++ b/apps/docs/content/docs/sdk/typescript.mdx
@@ -44,6 +44,8 @@ console.log(result.bestScore, result.bestOutput);
 - `isImproved(...)`: predicate for whether a round improved on the prior best.
 - `isParseFailure(...)`: predicate for whether a judge result was a parse failure rather than a genuine low score.
 
+Here `task` is an `AgentTaskInterface` (an exported type), typically a scenario you load or implement that knows how to evaluate output. In the snippets on this page it is supplied by the caller.
+
 ## Evaluation
 
 `JudgeExecutor` evaluates a single agent output by delegating to an `AgentTaskInterface`, running context preparation and validation first.
@@ -147,6 +149,35 @@ export default async function supportAgent(
 ```
 
 See [`examples/agent-runtime`](https://github.com/greyhaven-ai/autocontext/tree/main/examples/agent-runtime) for a complete, runnable handler.
+
+## Putting it together
+
+The primitives compose into a small revise-until-good flow: open a store, wrap a task in a `JudgeExecutor` to check a single output, then hand the same task to an `ImprovementLoop` to drive multiple rounds. The `task` is an `AgentTaskInterface` supplied by the caller (a scenario you load or implement).
+
+```typescript
+import { SQLiteStore, JudgeExecutor, ImprovementLoop } from "autoctx";
+import type { AgentTaskInterface } from "autoctx";
+
+async function refine(task: AgentTaskInterface, draft: string) {
+  const store = new SQLiteStore("./autocontext.db");
+
+  // One-off check of the starting draft.
+  const judge = new JudgeExecutor(task);
+  const baseline = await judge.execute(draft, {});
+
+  // Iterate until it clears the quality threshold (or rounds run out).
+  const loop = new ImprovementLoop({ task, maxRounds: 5, qualityThreshold: 0.9 });
+  const result = await loop.run({ initialOutput: draft, state: {} });
+
+  console.log({
+    baselineScore: baseline.score,
+    bestScore: result.bestScore,
+    improved: result.bestScore > baseline.score,
+  });
+
+  return result.bestOutput;
+}
+```
 
 ## See also
 


### PR DESCRIPTION
## Summary

Adds a comprehensive, Fumadocs-ready developer documentation tree under `apps/docs/content/docs/` so developers can understand how to use autocontext across all three surfaces (CLI, agent integration, SDK). This is **content only**: the Next.js + Fumadocs application and any marketing-site linking are intentionally deferred (the MDX + per-folder `meta.json` layout drops into a Fumadocs `content/docs` source with no restructuring).

**44 pages across 8 sections**, plus a landing page, FAQ, and a verification log:

- **get-started** — installation (Python + TypeScript), quickstart, your-first-solve
- **concepts** — the self-improving loop, scenarios/tasks/missions/campaigns, the five roles, knowledge, runs/traces/artifacts, evaluation
- **cli** — solve/run, evaluation commands, plain-language workflows, missions/campaigns, queue/worker, auth, export/import, full command reference
- **providers** — overview, Pi runtime, API providers, local/offline, CLI runtimes, per-role models and judge
- **agents** — MCP server, Claude Code, Pi skill, Hermes
- **sdk** — Python (`AutoContext`), TypeScript building blocks, extension hooks
- **guides** — distillation on MLX, sandbox modes, persistent host, fixtures, production traces
- **reference** — environment variables, MCP tools catalog, glossary

## How it was built

Authored task-by-task with a fresh agent per section and a two-stage review (spec compliance, then quality) after each. Every command, flag, env var, provider value, MCP tool name, and SDK signature was verified against the repo source (not the stale installed `autoctx` binary). A final whole-site pass reconciled cross-section contradictions.

## Verification

- 44 `.mdx` pages, all with valid `title`/`description` frontmatter
- Zero em dashes (house style); "autocontext" lowercase in prose
- Every section has a valid `meta.json` listing all sibling pages (no orphans)
- All 37+ internal `/docs/...` links resolve
- Facts traced to source: CLI (`cli.py`, `cli_*.py`, `ts/src/cli/`), providers (`llm_client.py`, `registry.py`, `settings.py`, `.env.example`), MCP tools (`mcp/`, `ts/src/mcp/`), SDK (`sdk.py`, `ts/src/index.ts`, `extensions/hooks.py`), guides (faithful rewrites of `docs/*.md`)
- See `apps/docs/content/docs/VERIFICATION.md` for the per-section log

## Notes

- Corrections surfaced during authoring and baked in: default provider is `anthropic` (not `deterministic`, which is the `.env.example` template suggestion); `queue add` uses `--rounds` (not `--max-rounds`); run-inspection commands (`show`/`watch`) exist on both runtimes; the session report lives under `knowledge/<scenario>/reports/`, not `runs/`.
- Deferred (not in this PR): the Next.js + Fumadocs app, theming/search/deploy, marketing-site linking, auto-generated API reference, versioned docs.