### PR TITLE
fix(mission): TS checkpoint parity backport from AC-697 Python slice 3 review

### DIFF
--- a/ts/src/mission/checkpoint.ts
+++ b/ts/src/mission/checkpoint.ts
@@ -62,13 +62,20 @@ export function saveCheckpoint(
     budgetUsage,
   };
 
-  // PR #1016 review (P3) backport: two saves landing in the same
-  // millisecond overwrote each other because the filename was only
-  // `<missionId>-<ms>.json`. Use nanosecond resolution plus an
-  // 8-char uuid suffix so the path is unique even on fast hardware
-  // and across concurrent writers. Newest-first ordering still
-  // works because the ns prefix sorts lexicographically.
-  const filename = `${missionId}-${process.hrtime.bigint().toString()}-${randomUUID().slice(0, 8)}.json`;
+  // PR #1016 review (P3) + PR #1020 review (P2) backport: two saves
+  // landing in the same millisecond used to overwrite each other.
+  // The first attempt switched to `process.hrtime.bigint()` ns but
+  // that counter is monotonic since process start (not Unix time),
+  // so after a reboot a newer checkpoint can sort before an older
+  // one and downstream artifact / analysis readers that pick
+  // newest-by-filename would surface stale state. Use wall-clock
+  // nanoseconds via `Date.now() * 1e6 + (hrtime % 1e6)` so the
+  // prefix is Unix-time-based and survives reboots; the lower 6
+  // digits come from hrtime's sub-ms resolution so two saves inside
+  // the same ms still differ. The 8-char uuid suffix is the final
+  // tiebreaker for fully-concurrent writers.
+  const wallClockNanos = BigInt(Date.now()) * 1_000_000n + (process.hrtime.bigint() % 1_000_000n);
+  const filename = `${missionId}-${wallClockNanos.toString()}-${randomUUID().slice(0, 8)}.json`;
   const path = join(checkpointDir, filename);
   writeFileSync(path, JSON.stringify(checkpoint, null, 2), "utf-8");
   return path;
@@ -125,42 +132,60 @@ export function loadCheckpoint(store: MissionStore, checkpointPath: string): str
   const mission = raw.mission;
   const restoredId = mission.id as string;
 
-  // Re-create the mission
-  const missionId = store.createMission({
-    name: mission.name as string,
-    goal: mission.goal as string,
-    budget: normaliseBudget(mission.budget),
-    metadata: (mission.metadata as Record<string, unknown>) ?? {},
-  });
-
-  // The store generates a new ID — we need to update it to the original.
-  // For checkpoint restore, we use the original ID by directly updating.
   const db = (
     store as unknown as {
       db: {
-        prepare: (sql: string) => { run: (...args: unknown[]) => void };
+        prepare: (sql: string) => {
+          run: (...args: unknown[]) => void;
+          get: (...args: unknown[]) => unknown;
+        };
         transaction: <T extends (...args: unknown[]) => unknown>(fn: T) => T;
       };
     }
   ).db;
 
-  // PR #1016 review (P2) backport: wrap the multi-row restore in a
-  // single SQLite transaction via better-sqlite3's
-  // ``db.transaction`` helper. A row failure (FK violation, UNIQUE
-  // duplicate, etc.) rolls back the partial restore so the operator
-  // can retry without first cleaning up the half-loaded mission row.
+  // PR #1020 review (P2): refuse to restore over an existing
+  // mission row. The previous behaviour was to let SQLite raise on
+  // the INSERT, but a friendlier message helps the operator
+  // distinguish "shared db with the original mission still in it"
+  // from a more subtle FK / UNIQUE failure deeper in the restore.
+  const existing = db.prepare("SELECT id FROM missions WHERE id = ?").get(restoredId) as
+    | { id: string }
+    | undefined;
+  if (existing !== undefined) {
+    throw new Error(`Cannot restore checkpoint: mission ${restoredId} already exists`);
+  }
+
+  // PR #1016 review (P2) backport + PR #1020 review (P2): wrap the
+  // FULL restore (mission insert + child rows) in a single SQLite
+  // transaction via better-sqlite3's ``db.transaction`` helper. The
+  // previous shape called ``store.createMission()`` BEFORE the
+  // transaction, so a later child-row failure rolled back only the
+  // child inserts and left an orphan mission row with a freshly
+  // generated id (not the original) committed. The fix inserts the
+  // mission row directly via SQL inside the transaction so a
+  // rollback returns the DB to its prior state with no orphan.
+  const missionRecord = mission as Record<string, unknown>;
+  const budgetDict = normaliseBudget(mission.budget);
+  const budgetBlob = budgetDict ? JSON.stringify(budgetDict) : null;
+  const metadataBlob = JSON.stringify(
+    (mission.metadata as Record<string, unknown> | undefined) ?? {},
+  );
+
   const restoreAll = db.transaction((): void => {
-    const missionRecord = mission as Record<string, unknown>;
-    const createdAtOverride = pickField<string>(missionRecord, "createdAt", "created_at");
     db.prepare(
-      "UPDATE missions SET id = ?, status = ?, created_at = COALESCE(?, created_at), updated_at = ?, completed_at = ? WHERE id = ?",
+      "INSERT INTO missions (id, name, goal, status, budget, metadata, created_at, updated_at, completed_at) " +
+        "VALUES (?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?)",
     ).run(
       restoredId,
+      mission.name as string,
+      mission.goal as string,
       mission.status as string,
-      createdAtOverride ?? null,
+      budgetBlob,
+      metadataBlob,
+      pickField<string>(missionRecord, "createdAt", "created_at") ?? null,
       pickField<string>(missionRecord, "updatedAt", "updated_at") ?? null,
       pickField<string>(missionRecord, "completedAt", "completed_at") ?? null,
-      missionId,
     );
 
     for (const step of raw.steps) {

--- a/ts/src/mission/checkpoint.ts
+++ b/ts/src/mission/checkpoint.ts
@@ -4,6 +4,22 @@
  * Checkpoints capture the full mission state as a JSON snapshot:
  * mission metadata, steps, subgoals, verifications, and budget usage.
  * Designed for restart-safe resume behavior.
+ *
+ * AC-697 Python parity PR #1016 review backports:
+ *
+ *   - `saveCheckpoint` filenames embed `process.hrtime.bigint()` ns
+ *     resolution plus a short uuid suffix so two saves in the same
+ *     millisecond no longer overwrite each other. Newest-first
+ *     lexicographic sorting still works because the ns prefix
+ *     orders.
+ *   - `loadCheckpoint` accepts both camelCase (TS-shaped) and
+ *     snake_case (Python-shaped) timestamp / budget keys so a
+ *     shared `AUTOCONTEXT_DB_PATH` resumes cleanly from either
+ *     runtime's checkpoints.
+ *   - `loadCheckpoint` runs the multi-row restore inside a single
+ *     SQLite transaction. A row failure rolls back the partial
+ *     restore so the operator can retry without first cleaning up
+ *     the half-loaded mission row.
  */
 
 import { mkdirSync, writeFileSync, readFileSync } from "node:fs";
@@ -21,7 +37,11 @@ export interface MissionCheckpoint {
   budgetUsage: { stepsUsed: number; maxSteps?: number; maxCostUsd?: number; exhausted: boolean };
 }
 
-export function saveCheckpoint(store: MissionStore, missionId: string, checkpointDir: string): string {
+export function saveCheckpoint(
+  store: MissionStore,
+  missionId: string,
+  checkpointDir: string,
+): string {
   mkdirSync(checkpointDir, { recursive: true });
 
   const mission = store.getMission(missionId);
@@ -42,72 +62,157 @@ export function saveCheckpoint(store: MissionStore, missionId: string, checkpoin
     budgetUsage,
   };
 
-  const filename = `${missionId}-${Date.now()}.json`;
+  // PR #1016 review (P3) backport: two saves landing in the same
+  // millisecond overwrote each other because the filename was only
+  // `<missionId>-<ms>.json`. Use nanosecond resolution plus an
+  // 8-char uuid suffix so the path is unique even on fast hardware
+  // and across concurrent writers. Newest-first ordering still
+  // works because the ns prefix sorts lexicographically.
+  const filename = `${missionId}-${process.hrtime.bigint().toString()}-${randomUUID().slice(0, 8)}.json`;
   const path = join(checkpointDir, filename);
   writeFileSync(path, JSON.stringify(checkpoint, null, 2), "utf-8");
   return path;
 }
 
+/** PR #1016 review (P2) backport: a TS-shaped checkpoint stores
+ * fields in camelCase (`createdAt` / `maxSteps` / ...) while a
+ * Python-shaped checkpoint stores them in snake_case (`created_at`
+ * / `max_steps` / ...). The loader accepts either shape so a
+ * shared `AUTOCONTEXT_DB_PATH` resumes from either runtime's
+ * checkpoints without dropping budget caps or provenance.
+ */
+function pickField<T = unknown>(
+  payload: Record<string, unknown>,
+  ...keys: string[]
+): T | undefined {
+  for (const key of keys) {
+    const value = payload[key];
+    if (value !== undefined && value !== null) {
+      return value as T;
+    }
+  }
+  return undefined;
+}
+
+interface BudgetPayload {
+  maxSteps?: number;
+  maxCostUsd?: number;
+  maxDurationMinutes?: number;
+}
+
+function normaliseBudget(payload: unknown): BudgetPayload | undefined {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+  const source = payload as Record<string, unknown>;
+  const out: BudgetPayload = {};
+  const mapping: Array<[keyof BudgetPayload, string[]]> = [
+    ["maxSteps", ["maxSteps", "max_steps"]],
+    ["maxCostUsd", ["maxCostUsd", "max_cost_usd"]],
+    ["maxDurationMinutes", ["maxDurationMinutes", "max_duration_minutes"]],
+  ];
+  for (const [target, candidates] of mapping) {
+    const value = pickField<number>(source, ...candidates);
+    if (typeof value === "number") {
+      out[target] = value;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 export function loadCheckpoint(store: MissionStore, checkpointPath: string): string {
   const raw = JSON.parse(readFileSync(checkpointPath, "utf-8")) as MissionCheckpoint;
   const mission = raw.mission;
+  const restoredId = mission.id as string;
 
   // Re-create the mission
   const missionId = store.createMission({
     name: mission.name as string,
     goal: mission.goal as string,
-    budget: mission.budget as { maxSteps?: number; maxCostUsd?: number; maxDurationMinutes?: number } | undefined,
+    budget: normaliseBudget(mission.budget),
     metadata: (mission.metadata as Record<string, unknown>) ?? {},
   });
 
-  // The store generates a new ID — we need to update it to the original
-  // For checkpoint restore, we use the original ID by directly updating
-  const db = (store as unknown as { db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } }).db;
-  db.prepare("UPDATE missions SET id = ?, status = ?, updated_at = ?, completed_at = ? WHERE id = ?").run(
-    mission.id as string,
-    mission.status as string,
-    (mission.updatedAt as string) ?? null,
-    (mission.completedAt as string) ?? null,
-    missionId,
-  );
+  // The store generates a new ID — we need to update it to the original.
+  // For checkpoint restore, we use the original ID by directly updating.
+  const db = (
+    store as unknown as {
+      db: {
+        prepare: (sql: string) => { run: (...args: unknown[]) => void };
+        transaction: <T extends (...args: unknown[]) => unknown>(fn: T) => T;
+      };
+    }
+  ).db;
 
-  const restoredId = mission.id as string;
-
-  // Restore steps
-  for (const step of raw.steps) {
+  // PR #1016 review (P2) backport: wrap the multi-row restore in a
+  // single SQLite transaction via better-sqlite3's
+  // ``db.transaction`` helper. A row failure (FK violation, UNIQUE
+  // duplicate, etc.) rolls back the partial restore so the operator
+  // can retry without first cleaning up the half-loaded mission row.
+  const restoreAll = db.transaction((): void => {
+    const missionRecord = mission as Record<string, unknown>;
+    const createdAtOverride = pickField<string>(missionRecord, "createdAt", "created_at");
     db.prepare(
-      "INSERT INTO mission_steps (id, mission_id, description, status, result, created_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      "UPDATE missions SET id = ?, status = ?, created_at = COALESCE(?, created_at), updated_at = ?, completed_at = ? WHERE id = ?",
     ).run(
-      step.id, restoredId, step.description, step.status,
-      step.result ?? null, step.createdAt, step.completedAt ?? null,
+      restoredId,
+      mission.status as string,
+      createdAtOverride ?? null,
+      pickField<string>(missionRecord, "updatedAt", "updated_at") ?? null,
+      pickField<string>(missionRecord, "completedAt", "completed_at") ?? null,
+      missionId,
     );
-  }
 
-  // Restore subgoals
-  for (const sg of raw.subgoals) {
-    db.prepare(
-      "INSERT INTO mission_subgoals (id, mission_id, description, priority, status, created_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-    ).run(
-      sg.id, restoredId, sg.description, sg.priority, sg.status,
-      sg.createdAt, sg.completedAt ?? null,
-    );
-  }
+    for (const step of raw.steps) {
+      const stepRecord = step as Record<string, unknown>;
+      db.prepare(
+        "INSERT INTO mission_steps (id, mission_id, description, status, result, created_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run(
+        stepRecord.id,
+        restoredId,
+        stepRecord.description,
+        stepRecord.status,
+        stepRecord.result ?? null,
+        pickField<string>(stepRecord, "createdAt", "created_at"),
+        pickField<string>(stepRecord, "completedAt", "completed_at") ?? null,
+      );
+    }
 
-  // Restore verifications
-  for (const v of raw.verifications) {
-    const verificationId = typeof v.id === "string" && v.id.length > 0
-      ? v.id
-      : `verify-restored-${randomUUID().slice(0, 8)}`;
-    db.prepare(
-      "INSERT INTO mission_verifications (id, mission_id, passed, reason, suggestions, metadata, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-    ).run(
-      verificationId, restoredId,
-      v.passed ? 1 : 0, v.reason,
-      JSON.stringify(v.suggestions ?? []),
-      JSON.stringify(v.metadata ?? {}),
-      v.createdAt,
-    );
-  }
+    for (const sg of raw.subgoals) {
+      const subgoalRecord = sg as Record<string, unknown>;
+      db.prepare(
+        "INSERT INTO mission_subgoals (id, mission_id, description, priority, status, created_at, completed_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run(
+        subgoalRecord.id,
+        restoredId,
+        subgoalRecord.description,
+        subgoalRecord.priority,
+        subgoalRecord.status,
+        pickField<string>(subgoalRecord, "createdAt", "created_at"),
+        pickField<string>(subgoalRecord, "completedAt", "completed_at") ?? null,
+      );
+    }
+
+    for (const v of raw.verifications) {
+      const verificationRecord = v as Record<string, unknown>;
+      const verificationId =
+        typeof verificationRecord.id === "string" && verificationRecord.id.length > 0
+          ? verificationRecord.id
+          : `verify-restored-${randomUUID().slice(0, 8)}`;
+      db.prepare(
+        "INSERT INTO mission_verifications (id, mission_id, passed, reason, suggestions, metadata, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run(
+        verificationId,
+        restoredId,
+        verificationRecord.passed ? 1 : 0,
+        verificationRecord.reason,
+        JSON.stringify(verificationRecord.suggestions ?? []),
+        JSON.stringify(verificationRecord.metadata ?? {}),
+        pickField<string>(verificationRecord, "createdAt", "created_at"),
+      );
+    }
+  });
+  restoreAll();
 
   return restoredId;
 }

--- a/ts/tests/mission-checkpoints.test.ts
+++ b/ts/tests/mission-checkpoints.test.ts
@@ -50,8 +50,12 @@ describe("MissionSpec", () => {
 
 describe("Subgoals", () => {
   let dir: string;
-  beforeEach(() => { dir = makeTempDir(); });
-  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+  beforeEach(() => {
+    dir = makeTempDir();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
 
   it("store creates and retrieves subgoals", async () => {
     const { MissionStore } = await import("../src/mission/store.js");
@@ -135,8 +139,12 @@ describe("Subgoals", () => {
 
 describe("Mission checkpoints", () => {
   let dir: string;
-  beforeEach(() => { dir = makeTempDir(); });
-  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+  beforeEach(() => {
+    dir = makeTempDir();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
 
   it("saveCheckpoint writes a JSON snapshot to disk", async () => {
     const { MissionStore } = await import("../src/mission/store.js");
@@ -239,6 +247,162 @@ describe("Mission checkpoints", () => {
     expect(data.budgetUsage.maxSteps).toBe(10);
     store.close();
   });
+
+  // -------------------------------------------------------------------------
+  // AC-697 Python parity PR #1016 review backports
+  // -------------------------------------------------------------------------
+
+  it("saveCheckpoint produces collision-free filenames for back-to-back writes", async () => {
+    /**
+     * PR #1016 review (P3) backport: the previous filename pattern
+     * `<missionId>-<Date.now()>.json` collided when two saves landed
+     * in the same millisecond and silently overwrote each other.
+     * The new `<missionId>-<ns>-<uuid8>.json` shape stays unique
+     * even in a tight loop.
+     */
+    const { MissionStore } = await import("../src/mission/store.js");
+    const { saveCheckpoint } = await import("../src/mission/checkpoint.js");
+    const store = new MissionStore(join(dir, "collide.db"));
+    const mId = store.createMission({ name: "Collide", goal: "g" });
+    const checkpointDir = join(dir, "checkpoints");
+    const paths = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      paths.add(saveCheckpoint(store, mId, checkpointDir));
+    }
+    expect(paths.size).toBe(10);
+    for (const path of paths) {
+      expect(existsSync(path)).toBe(true);
+    }
+    store.close();
+  });
+
+  it("loadCheckpoint accepts Python-shaped snake_case keys", async () => {
+    /**
+     * PR #1016 review (P2) backport: a Python-shaped checkpoint
+     * stores fields in snake_case (`created_at`, `budget.max_steps`,
+     * ...). Before this fix the TS loader only read camelCase, so
+     * Python -> TS resume dropped budget caps and timestamps. The
+     * loader now accepts either shape.
+     */
+    const { MissionStore } = await import("../src/mission/store.js");
+    const { loadCheckpoint } = await import("../src/mission/checkpoint.js");
+    const { writeFileSync } = await import("node:fs");
+
+    const pythonShapedCheckpoint = {
+      version: 1,
+      checkpointedAt: "2026-06-02T00:00:00Z",
+      mission: {
+        id: "mission-pysnake",
+        name: "py-shaped",
+        goal: "g",
+        status: "active",
+        budget: { max_steps: 9, max_cost_usd: 4.25 },
+        metadata: { missionType: "code" },
+        created_at: "2026-06-02T01:00:00Z",
+        updated_at: "2026-06-02T02:00:00Z",
+        completed_at: null,
+      },
+      steps: [
+        {
+          id: "step-1",
+          mission_id: "mission-pysnake",
+          description: "did a",
+          status: "completed",
+          result: null,
+          created_at: "2026-06-02T03:00:00Z",
+          completed_at: "2026-06-02T03:01:00Z",
+        },
+      ],
+      subgoals: [],
+      verifications: [],
+      budgetUsage: { steps_used: 1, exhausted: false },
+    };
+    const checkpointPath = join(dir, "py-shaped.json");
+    writeFileSync(checkpointPath, JSON.stringify(pythonShapedCheckpoint), "utf-8");
+
+    const store = new MissionStore(join(dir, "py-resume.db"));
+    const restoredId = loadCheckpoint(store, checkpointPath);
+    expect(restoredId).toBe("mission-pysnake");
+    const mission = store.getMission(restoredId);
+    expect(mission!.budget).toEqual({ maxSteps: 9, maxCostUsd: 4.25 });
+    expect(mission!.createdAt).toBe("2026-06-02T01:00:00Z");
+    expect(mission!.updatedAt).toBe("2026-06-02T02:00:00Z");
+    expect(store.getSteps(restoredId)[0].createdAt).toBe("2026-06-02T03:00:00Z");
+    store.close();
+  });
+
+  it("loadCheckpoint rolls back the partial restore on duplicate child rows", async () => {
+    /**
+     * PR #1016 review (P2) backport: the previous loader inserted
+     * rows one at a time without a transaction, so a later FK /
+     * UNIQUE failure left a partial mission + first step behind and
+     * a retry choked on the already-existing mission row. The
+     * better-sqlite3 `db.transaction` wrapper rolls back every
+     * insert on failure so the operator can retry.
+     */
+    const { MissionStore } = await import("../src/mission/store.js");
+    const { loadCheckpoint } = await import("../src/mission/checkpoint.js");
+    const { writeFileSync } = await import("node:fs");
+
+    const duplicateStepId = "step-dup";
+    const payload = {
+      version: 1,
+      checkpointedAt: "2026-06-02T00:00:00Z",
+      mission: {
+        id: "mission-rb",
+        name: "rb",
+        goal: "g",
+        status: "active",
+        budget: null,
+        metadata: {},
+        createdAt: "2026-06-02T00:00:00Z",
+        updatedAt: null,
+        completedAt: null,
+      },
+      steps: [
+        {
+          id: duplicateStepId,
+          description: "first",
+          status: "completed",
+          result: null,
+          createdAt: "2026-06-02T00:01:00Z",
+          completedAt: null,
+        },
+        // Duplicate id triggers UNIQUE constraint failure on the
+        // second insert; the rollback should drop the mission row
+        // AND the first step.
+        {
+          id: duplicateStepId,
+          description: "second",
+          status: "completed",
+          result: null,
+          createdAt: "2026-06-02T00:02:00Z",
+          completedAt: null,
+        },
+      ],
+      subgoals: [],
+      verifications: [],
+      budgetUsage: { stepsUsed: 2, exhausted: false },
+    };
+    const checkpointPath = join(dir, "rb.json");
+    writeFileSync(checkpointPath, JSON.stringify(payload), "utf-8");
+
+    const store = new MissionStore(join(dir, "rb.db"));
+    expect(() => loadCheckpoint(store, checkpointPath)).toThrow(/UNIQUE/i);
+
+    // Mission row was rolled back.
+    expect(store.getMission("mission-rb")).toBeNull();
+    // First step was rolled back too.
+    expect(store.getSteps("mission-rb")).toEqual([]);
+
+    // Retry succeeds after the operator dedupes the steps.
+    payload.steps[1].id = "step-dup-2";
+    writeFileSync(checkpointPath, JSON.stringify(payload), "utf-8");
+    const restoredId = loadCheckpoint(store, checkpointPath);
+    expect(restoredId).toBe("mission-rb");
+    expect(store.getSteps(restoredId)).toHaveLength(2);
+    store.close();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -247,8 +411,12 @@ describe("Mission checkpoints", () => {
 
 describe("Budget usage", () => {
   let dir: string;
-  beforeEach(() => { dir = makeTempDir(); });
-  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+  beforeEach(() => {
+    dir = makeTempDir();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
 
   it("getBudgetUsage returns steps used vs budget", async () => {
     const { MissionStore } = await import("../src/mission/store.js");

--- a/ts/tests/mission-checkpoints.test.ts
+++ b/ts/tests/mission-checkpoints.test.ts
@@ -390,10 +390,16 @@ describe("Mission checkpoints", () => {
     const store = new MissionStore(join(dir, "rb.db"));
     expect(() => loadCheckpoint(store, checkpointPath)).toThrow(/UNIQUE/i);
 
-    // Mission row was rolled back.
+    // PR #1020 review (P2): the previous shape created the mission
+    // row via `store.createMission()` BEFORE the transaction, so a
+    // child-row failure left an orphan mission row with a
+    // freshly-generated id (not the original) committed. Inserting
+    // the mission row INSIDE the transaction means the rollback
+    // returns the DB to its prior empty state: no row with the
+    // original id, and no row with a fresh id either.
     expect(store.getMission("mission-rb")).toBeNull();
-    // First step was rolled back too.
     expect(store.getSteps("mission-rb")).toEqual([]);
+    expect(store.listMissions()).toEqual([]);
 
     // Retry succeeds after the operator dedupes the steps.
     payload.steps[1].id = "step-dup-2";
@@ -401,6 +407,38 @@ describe("Mission checkpoints", () => {
     const restoredId = loadCheckpoint(store, checkpointPath);
     expect(restoredId).toBe("mission-rb");
     expect(store.getSteps(restoredId)).toHaveLength(2);
+    store.close();
+  });
+
+  it("saveCheckpoint filenames embed a wall-clock unix-ns prefix that survives a reboot", async () => {
+    /**
+     * PR #1020 review (P2): the first backport used
+     * `process.hrtime.bigint()`, which is a monotonic counter since
+     * process start (not Unix time). After a reboot a newer
+     * checkpoint could sort before an older one, so downstream
+     * artifact / analysis readers that pick "newest by filename"
+     * would surface stale state. The fixed shape uses wall-clock
+     * nanoseconds via `Date.now() * 1e6 + (hrtime % 1e6)` so the
+     * prefix is reboot-stable and lexicographic sort matches Unix
+     * chronological order.
+     */
+    const { MissionStore } = await import("../src/mission/store.js");
+    const { saveCheckpoint } = await import("../src/mission/checkpoint.js");
+    const store = new MissionStore(join(dir, "wallclock.db"));
+    const mId = store.createMission({ name: "WallClock", goal: "g" });
+    const checkpointDir = join(dir, "checkpoints");
+    const path = saveCheckpoint(store, mId, checkpointDir);
+    const filename = path.split("/").pop()!;
+    // Filename shape: `<mid>-<ns>-<uuid8>.json`.
+    const match = filename.match(/^mission-[0-9a-f]+-(\d+)-[0-9a-f]+\.json$/);
+    expect(match).not.toBeNull();
+    const ns = BigInt(match![1]);
+    const nowMs = BigInt(Date.now());
+    // The ns prefix is wall-clock-ns, so dividing by 1e6 must
+    // land within a few milliseconds of `Date.now()`.
+    const filenameMs = ns / 1_000_000n;
+    expect(filenameMs).toBeGreaterThanOrEqual(nowMs - 1_000n);
+    expect(filenameMs).toBeLessThanOrEqual(nowMs + 1_000n);
     store.close();
   });
 });


### PR DESCRIPTION
## Summary

Three of the four PR #1016 review fixes existed on the TS side too. Backport them so both runtimes share the same checkpoint contract.

- **P3 (filename collision)**: `<missionId>-<Date.now()>.json` overwrote itself on millisecond ties; the new `<missionId>-<process.hrtime.bigint()>-<uuid8>.json` shape stays unique even on fast hardware and across concurrent writers. Newest-first lexicographic sort still works.
- **P2 (camelCase + snake_case loader)**: TS read only camelCase, so a Python-shaped checkpoint dropped budget caps and regenerated timestamps on resume. New `pickField(...)` + `normaliseBudget` helpers accept either shape across mission/step/subgoal/verification rows. The mission UPDATE now coalesces an explicit `createdAt`/`created_at` override too.
- **P2 (atomic restore)**: a `better-sqlite3 db.transaction(...)` wrapper rolls back the partial restore on any insert failure so the operator can retry.

The fourth PR #1016 issue (async-in-running-loop) does not apply to TS: `await` works natively inside async contexts.

## Test plan

- [x] `npx vitest run tests/mission-checkpoints.test.ts` (17 passed: 14 prior + 3 new)
- [x] `bun run lint` (`tsc --noEmit`) clean
- [ ] CI: green