### PR TITLE
test(cli): cross-runtime parity audit (reverse-direction + id invariants)

### DIFF
--- a/autocontext/tests/test_cli_contract_parity.py
+++ b/autocontext/tests/test_cli_contract_parity.py
@@ -1,0 +1,193 @@
+"""Cross-runtime CLI parity audit (Python side).
+
+The forward direction (contract -> Typer registration) is already
+covered by ``tests/test_cli_contract.py``. The audit below adds the
+REVERSE direction plus cross-runtime invariants so accidental drift
+surfaces immediately.
+
+What this pins:
+
+1. **Reverse direction**: every top-level Typer command observed on
+   the live ``autocontext.cli.app`` is either contracted, listed
+   as a contracted alias, or named in
+   ``UNCONTRACTED_TOP_LEVEL_ALLOWLIST``. Adding a new top-level
+   command without a contract entry (or allowlist line) fails the
+   test, so the operator is forced to either advertise it in the
+   contract or document why it stays uncontracted.
+
+2. **Alias registration**: every contracted alias path must
+   correspond to an observed top-level Typer command. Pins that
+   the legacy invocations (`autoctx mcp-serve`,
+   `autoctx new-scenario`) still work after future refactors.
+
+3. **Cross-runtime path equality**: a command id with both
+   ``python.yes`` and ``typescript.yes`` must declare the SAME
+   canonical ``path``. The contract is a single source of truth so
+   this is trivially true per-entry, but the assertion documents
+   the invariant and traps a hand-edit that introduces a per-
+   runtime path divergence.
+
+4. **Cross-runtime id uniqueness**: command ids are unique within
+   the contract; the assertion is a sanity backstop for the
+   above.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autocontext.cli_contract import (
+    Contract,
+    RuntimeStatus,
+    iter_python_command_paths,
+    load_contract,
+)
+
+
+def _contract_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "docs" / "cli-contract.json"
+
+
+@pytest.fixture(scope="module")
+def contract() -> Contract:
+    return load_contract(_contract_path())
+
+
+# Top-level Typer commands that are intentionally NOT advertised in
+# docs/cli-contract.json. Reasons range from "operator-internal"
+# (``worker``, ``import-package``) to "advanced surface tracked in a
+# future contract slice" (``investigate``, ``simulate``, ``train``).
+# Adding a new top-level command should land either in the contract
+# or on this list; nothing should slip through silently.
+UNCONTRACTED_TOP_LEVEL_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "ab-test",
+        "benchmark",
+        "ecosystem",
+        "export-training-data",
+        "import-package",
+        "investigate",
+        "resume",
+        "simulate",
+        "train",
+        "tui",
+        "wait",
+        "worker",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Reverse direction: observed -> contract / alias / allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_every_observed_top_level_command_is_accounted_for(
+    contract: Contract,
+) -> None:
+    """Every top-level Typer command on the live ``app`` must be in
+    the contract, in a contracted alias list, or on the explicit
+    ``UNCONTRACTED_TOP_LEVEL_ALLOWLIST``.
+
+    A new command shipped without a contract entry surfaces here so
+    the operator either adds it to the contract or documents why it
+    stays uncontracted via the allowlist.
+    """
+    from autocontext.cli import app
+
+    observed = {p[0] for p in iter_python_command_paths(app) if len(p) == 1}
+    contracted_top_level = {c.path[0] for c in contract.commands if len(c.path) == 1}
+    contracted_aliases = {a for c in contract.commands for a in c.aliases}
+    accounted_for = contracted_top_level | contracted_aliases | UNCONTRACTED_TOP_LEVEL_ALLOWLIST
+
+    leaked = observed - accounted_for
+    assert not leaked, (
+        "Top-level Typer commands shipped without a contract entry or "
+        "allowlist line: "
+        f"{sorted(leaked)}. Either add them to docs/cli-contract.json "
+        "or to UNCONTRACTED_TOP_LEVEL_ALLOWLIST in this test."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Forward direction sanity: contract entries / aliases must be live
+# ---------------------------------------------------------------------------
+
+
+def test_every_contracted_alias_path_is_registered_in_typer(
+    contract: Contract,
+) -> None:
+    """Every contracted alias must still resolve to a registered
+    top-level Typer command. Catches the case where a future
+    refactor drops a legacy alias without updating the contract."""
+    from autocontext.cli import app
+
+    observed_top_level = {p[0] for p in iter_python_command_paths(app) if len(p) == 1}
+    for cmd in contract.commands:
+        for alias in cmd.aliases:
+            assert alias in observed_top_level, (
+                f"contracted alias {alias!r} on {cmd.id!r} is no longer registered as a top-level Typer command"
+            )
+
+
+def test_allowlist_is_minimal(contract: Contract) -> None:
+    """Defensive: an entry on
+    ``UNCONTRACTED_TOP_LEVEL_ALLOWLIST`` that ALSO appears in the
+    contract is dead weight and confuses future readers. Reject the
+    duplication so the allowlist stays the "explicitly uncontracted"
+    set."""
+    contracted_top_level = {c.path[0] for c in contract.commands if len(c.path) == 1}
+    contracted_aliases = {a for c in contract.commands for a in c.aliases}
+    contracted = contracted_top_level | contracted_aliases
+    redundant = UNCONTRACTED_TOP_LEVEL_ALLOWLIST & contracted
+    assert not redundant, f"Allowlist entries that are ALSO in the contract: {sorted(redundant)}. Remove them from the allowlist."
+
+
+# ---------------------------------------------------------------------------
+# Cross-runtime invariants
+# ---------------------------------------------------------------------------
+
+
+def test_no_per_runtime_path_divergence(contract: Contract) -> None:
+    """A command id with python.yes AND typescript.yes must have the
+    same ``path`` field. The contract is a single source of truth
+    (one ``path`` per ``id``) so this is trivially true today;
+    pinning the invariant catches a future hand-edit that
+    introduces a per-runtime path divergence."""
+    for cmd in contract.commands:
+        if cmd.runtime_support.python.status is RuntimeStatus.YES and cmd.runtime_support.typescript.status is RuntimeStatus.YES:
+            # No per-runtime path override is allowed by the schema;
+            # the existence of `cmd.path` as a single field is what
+            # guarantees parity. Surface the invariant explicitly so
+            # a future schema change that adds per-runtime paths is
+            # caught here.
+            assert cmd.path, f"command {cmd.id!r} has an empty path"
+
+
+def test_no_command_id_uses_a_runtime_specific_prefix(contract: Contract) -> None:
+    """A command id should be runtime-agnostic. `python.X` /
+    `typescript.X` / `ts.X` / `py.X` prefixes would defeat the
+    purpose of a shared contract."""
+    forbidden = ("python.", "py.", "typescript.", "ts.")
+    for cmd in contract.commands:
+        for prefix in forbidden:
+            assert not cmd.id.startswith(prefix), (
+                f"command id {cmd.id!r} uses a runtime-specific prefix; the contract is single-sourced across runtimes"
+            )
+
+
+def test_command_ids_are_unique_and_well_formed(contract: Contract) -> None:
+    """Command ids are dot-separated semantic identifiers (e.g.
+    ``run.list`` signals "list within the Run family" even though
+    the canonical CLI path is just ``["list"]``). Pin that ids are
+    non-empty, unique, and contain only alphanumeric / dot / dash /
+    underscore characters."""
+    seen_ids: set[str] = set()
+    for cmd in contract.commands:
+        assert cmd.id, "empty command id"
+        assert cmd.id not in seen_ids, f"duplicate command id {cmd.id!r}"
+        seen_ids.add(cmd.id)
+        for ch in cmd.id:
+            assert ch.isalnum() or ch in (".", "-", "_"), f"command id {cmd.id!r} contains illegal character {ch!r}"

--- a/autocontext/tests/test_cli_contract_parity.py
+++ b/autocontext/tests/test_cli_contract_parity.py
@@ -64,11 +64,14 @@ def contract() -> Contract:
 UNCONTRACTED_TOP_LEVEL_ALLOWLIST: frozenset[str] = frozenset(
     {
         "ab-test",
+        "analytics",
         "benchmark",
         "ecosystem",
         "export-training-data",
+        "hermes",
         "import-package",
         "investigate",
+        "probes",
         "resume",
         "simulate",
         "train",
@@ -84,12 +87,35 @@ UNCONTRACTED_TOP_LEVEL_ALLOWLIST: frozenset[str] = frozenset(
 # ---------------------------------------------------------------------------
 
 
+def _observed_top_level_names(app: object) -> set[str]:
+    """PR #1021 review (P2): combine ``iter_python_command_paths``
+    output with ``app.registered_groups`` so visible Typer GROUPS
+    (like ``analytics``, ``hermes``, ``probes``, ``scenario``) are
+    surfaced even when they don't set ``invoke_without_command=True``.
+    ``iter_python_command_paths`` only emits a group prefix when the
+    group itself is invokable; a public group whose only purpose is
+    to hold subcommands would otherwise slip past the reverse-
+    direction audit even though it appears in ``autoctx --help``.
+    """
+    iter_paths: set[str] = {
+        p[0]
+        for p in iter_python_command_paths(app)  # type: ignore[arg-type]
+        if len(p) == 1
+    }
+    group_names: set[str] = {
+        g.name
+        for g in app.registered_groups  # type: ignore[attr-defined]
+        if g.name is not None
+    }
+    return iter_paths | group_names
+
+
 def test_every_observed_top_level_command_is_accounted_for(
     contract: Contract,
 ) -> None:
-    """Every top-level Typer command on the live ``app`` must be in
-    the contract, in a contracted alias list, or on the explicit
-    ``UNCONTRACTED_TOP_LEVEL_ALLOWLIST``.
+    """Every top-level Typer command OR group on the live ``app``
+    must be in the contract, in a contracted alias list, or on the
+    explicit ``UNCONTRACTED_TOP_LEVEL_ALLOWLIST``.
 
     A new command shipped without a contract entry surfaces here so
     the operator either adds it to the contract or documents why it
@@ -97,15 +123,19 @@ def test_every_observed_top_level_command_is_accounted_for(
     """
     from autocontext.cli import app
 
-    observed = {p[0] for p in iter_python_command_paths(app) if len(p) == 1}
+    observed = _observed_top_level_names(app)
     contracted_top_level = {c.path[0] for c in contract.commands if len(c.path) == 1}
     contracted_aliases = {a for c in contract.commands for a in c.aliases}
-    accounted_for = contracted_top_level | contracted_aliases | UNCONTRACTED_TOP_LEVEL_ALLOWLIST
+    # Multi-token contract entries (e.g. `scenario.create`) anchor
+    # their top-level token; that token IS the visible Typer group
+    # name and must count as contracted.
+    contracted_parents = {c.path[0] for c in contract.commands if len(c.path) >= 2}
+    accounted_for = contracted_top_level | contracted_parents | contracted_aliases | UNCONTRACTED_TOP_LEVEL_ALLOWLIST
 
     leaked = observed - accounted_for
     assert not leaked, (
-        "Top-level Typer commands shipped without a contract entry or "
-        "allowlist line: "
+        "Top-level Typer commands/groups shipped without a contract "
+        "entry or allowlist line: "
         f"{sorted(leaked)}. Either add them to docs/cli-contract.json "
         "or to UNCONTRACTED_TOP_LEVEL_ALLOWLIST in this test."
     )
@@ -120,14 +150,15 @@ def test_every_contracted_alias_path_is_registered_in_typer(
     contract: Contract,
 ) -> None:
     """Every contracted alias must still resolve to a registered
-    top-level Typer command. Catches the case where a future
-    refactor drops a legacy alias without updating the contract."""
+    top-level Typer command OR group. Catches the case where a
+    future refactor drops a legacy alias without updating the
+    contract."""
     from autocontext.cli import app
 
-    observed_top_level = {p[0] for p in iter_python_command_paths(app) if len(p) == 1}
+    observed = _observed_top_level_names(app)
     for cmd in contract.commands:
         for alias in cmd.aliases:
-            assert alias in observed_top_level, (
+            assert alias in observed, (
                 f"contracted alias {alias!r} on {cmd.id!r} is no longer registered as a top-level Typer command"
             )
 

--- a/ts/tests/cli-contract-parity.test.ts
+++ b/ts/tests/cli-contract-parity.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Cross-runtime CLI parity audit (TypeScript side).
+ *
+ * The forward direction (contract -> command-registry registration) is
+ * covered by `cli-contract-ac697.test.ts`. The audit below adds the
+ * REVERSE direction plus cross-runtime invariants so accidental drift
+ * surfaces immediately.
+ *
+ * What this pins:
+ *
+ * 1. **Reverse direction**: every visible command in
+ *    `visibleSupportedCommandNames()` is either contracted, a
+ *    contracted alias, OR named in
+ *    `UNCONTRACTED_TOP_LEVEL_ALLOWLIST`. Adding a new top-level
+ *    command without a contract entry (or an allowlist line) fails
+ *    the test, so the operator is forced to either advertise it in
+ *    the contract or document why it stays uncontracted.
+ *
+ * 2. **Alias registration**: every contracted alias must still
+ *    resolve to a registered TS command name. Pins that the legacy
+ *    invocations (`autoctx mcp-serve`, `autoctx new-scenario`) still
+ *    work after future refactors.
+ *
+ * 3. **Cross-runtime invariants**: command ids are unique, well-
+ *    formed, and runtime-agnostic (no `python.X` / `ts.X` prefix).
+ *    The contract is a single source of truth across runtimes; these
+ *    assertions trap a hand-edit that introduces a runtime-specific
+ *    id.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import { loadContract } from "../src/cli/cli-contract.js";
+import { visibleSupportedCommandNames } from "../src/cli/command-registry.js";
+
+const CONTRACT_PATH = resolve(import.meta.dirname, "..", "..", "docs", "cli-contract.json");
+
+/**
+ * Top-level visible TS commands that are intentionally NOT advertised
+ * in docs/cli-contract.json. The TS surface ships a richer set of
+ * non-paved-road commands today; this allowlist documents the
+ * "uncontracted by design" set so a new top-level command can't slip
+ * through silently.
+ */
+const UNCONTRACTED_TOP_LEVEL_ALLOWLIST = new Set<string>([
+  "agent",
+  "analyze",
+  "benchmark",
+  "campaign",
+  "candidate",
+  "context-selection",
+  "emit-pr",
+  "eval",
+  "export-training-data",
+  "harness",
+  "import-package",
+  "init",
+  "instrument",
+  "investigate",
+  "login",
+  "logout",
+  "models",
+  "probes",
+  "production-traces",
+  "promotion",
+  "providers",
+  "registry",
+  "repl",
+  "runtime-sessions",
+  "simulate",
+  "trace-findings",
+  "train",
+  "tui",
+  "version",
+  "whoami",
+  "worker",
+]);
+
+// ---------------------------------------------------------------------------
+// Reverse direction: observed -> contract / alias / allowlist
+// ---------------------------------------------------------------------------
+
+describe("AC-697 cross-runtime parity audit (TypeScript side)", () => {
+  it("every observed top-level command is contracted, aliased, or on the explicit allowlist", () => {
+    const contract = loadContract(CONTRACT_PATH);
+    const observed = new Set(visibleSupportedCommandNames());
+
+    const contractedTopLevel = new Set<string>();
+    for (const cmd of contract.commands) {
+      if (cmd.path.length >= 1) {
+        contractedTopLevel.add(cmd.path[0]);
+      }
+    }
+    const contractedAliases = new Set<string>();
+    for (const cmd of contract.commands) {
+      for (const alias of cmd.aliases) {
+        contractedAliases.add(alias);
+      }
+    }
+    const accountedFor = new Set<string>([
+      ...contractedTopLevel,
+      ...contractedAliases,
+      ...UNCONTRACTED_TOP_LEVEL_ALLOWLIST,
+    ]);
+
+    const leaked: string[] = [];
+    for (const name of observed) {
+      if (!accountedFor.has(name)) {
+        leaked.push(name);
+      }
+    }
+    leaked.sort();
+    expect(
+      leaked,
+      `Top-level TS commands shipped without a contract entry or allowlist line: ${JSON.stringify(
+        leaked,
+      )}. Either add them to docs/cli-contract.json or to UNCONTRACTED_TOP_LEVEL_ALLOWLIST in this test.`,
+    ).toEqual([]);
+  });
+
+  it("every contracted alias resolves to a registered TS command name", () => {
+    const contract = loadContract(CONTRACT_PATH);
+    const observed = new Set(visibleSupportedCommandNames());
+    for (const cmd of contract.commands) {
+      for (const alias of cmd.aliases) {
+        expect(
+          observed.has(alias),
+          `contracted alias ${JSON.stringify(alias)} on ${JSON.stringify(
+            cmd.id,
+          )} is no longer a registered TS command`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("allowlist is minimal (no entries also present in the contract)", () => {
+    const contract = loadContract(CONTRACT_PATH);
+    const contractedTopLevel = new Set<string>();
+    for (const cmd of contract.commands) {
+      if (cmd.path.length >= 1) {
+        contractedTopLevel.add(cmd.path[0]);
+      }
+    }
+    const contractedAliases = new Set<string>();
+    for (const cmd of contract.commands) {
+      for (const alias of cmd.aliases) {
+        contractedAliases.add(alias);
+      }
+    }
+    const contracted = new Set<string>([...contractedTopLevel, ...contractedAliases]);
+
+    const redundant: string[] = [];
+    for (const name of UNCONTRACTED_TOP_LEVEL_ALLOWLIST) {
+      if (contracted.has(name)) {
+        redundant.push(name);
+      }
+    }
+    expect(
+      redundant.sort(),
+      `Allowlist entries that are ALSO in the contract: ${JSON.stringify(
+        redundant,
+      )}. Remove them from the allowlist.`,
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-runtime invariants
+// ---------------------------------------------------------------------------
+
+describe("AC-697 cross-runtime parity audit — id invariants", () => {
+  it("command ids are unique and well-formed", () => {
+    const contract = loadContract(CONTRACT_PATH);
+    const seen = new Set<string>();
+    for (const cmd of contract.commands) {
+      expect(cmd.id, "empty command id").toBeTruthy();
+      expect(seen.has(cmd.id), `duplicate command id ${JSON.stringify(cmd.id)}`).toBe(false);
+      seen.add(cmd.id);
+      for (const ch of cmd.id) {
+        const isAllowed = /[a-z0-9._-]/i.test(ch);
+        expect(
+          isAllowed,
+          `command id ${JSON.stringify(cmd.id)} contains illegal character ${JSON.stringify(ch)}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("no command id uses a runtime-specific prefix", () => {
+    const contract = loadContract(CONTRACT_PATH);
+    const forbidden = ["python.", "py.", "typescript.", "ts."];
+    for (const cmd of contract.commands) {
+      for (const prefix of forbidden) {
+        expect(
+          cmd.id.startsWith(prefix),
+          `command id ${JSON.stringify(cmd.id)} uses a runtime-specific prefix; the contract is single-sourced across runtimes`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("no per-runtime path divergence on commands claimed yes by both", () => {
+    const contract = loadContract(CONTRACT_PATH);
+    for (const cmd of contract.commands) {
+      if (
+        cmd.runtime_support.python.status === "yes" &&
+        cmd.runtime_support.typescript.status === "yes"
+      ) {
+        // No per-runtime path override is allowed by the schema; the
+        // existence of `cmd.path` as a single field is what guarantees
+        // parity. Surface the invariant explicitly so a future schema
+        // change that introduces per-runtime paths trips this assert.
+        expect(cmd.path.length, `command ${JSON.stringify(cmd.id)} has empty path`).toBeGreaterThan(
+          0,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The forward direction (contract → Typer/registry) was already pinned by the existing AC-697 contract tests. This PR adds the reverse direction plus cross-runtime invariants so accidental drift surfaces immediately.

Both runtimes get a new `cli-contract-parity` test file with the same shape:

- **Reverse direction**: every top-level command observed on the live app must be in the contract, in a contracted alias list, or named in an explicit `UNCONTRACTED_TOP_LEVEL_ALLOWLIST`. A new top-level command shipped without a contract entry fails the test, forcing either advertisement in the contract or documentation in the allowlist.
- **Alias registration**: every contracted alias path still resolves to a registered top-level command.
- **Allowlist hygiene**: rejects entries that are both allowlisted and contracted.
- **Cross-runtime invariants**: ids unique + well-formed, no runtime-specific prefix, no per-runtime path divergence on commands claimed `yes` by both.

## Allowlists

- Python (12): `ab-test`, `benchmark`, `ecosystem`, `export-training-data`, `import-package`, `investigate`, `resume`, `simulate`, `train`, `tui`, `wait`, `worker`.
- TS (30): includes the richer non-paved-road surface — `agent` / `analyze` / `campaign` / `candidate` / `emit-pr` / `eval` / `harness` / `instrument` / `probes` / `production-traces` / `promotion` / `registry` / `trace-findings`, plus operator-internal pieces (`login` / `logout` / `providers` / `whoami` / `version` / `repl` / `init` / `runtime-sessions` / `models`).

## Test plan

- [x] `uv run pytest tests/test_cli_contract_parity.py` (6 passed) + `tests/test_cli_contract.py` (17 passed) = 23 total
- [x] `npx vitest run tests/cli-contract-parity.test.ts` (6 passed)
- [x] `uv run ruff check` clean
- [x] `bun run lint` (`tsc --noEmit`) clean
- [ ] CI: green