### PR TITLE
release: cut v0.6.0 — AC-697 + AC-728 + mission Python parity + cross-runtime audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-02
+
+Two ticket series closed end-to-end in this release:
+
+- **AC-697 — shared canonical CLI contract.** All `intentional_gap` entries in `docs/cli-contract.json` are closed. `autoctx capabilities` is contract-driven on both runtimes. Every contracted command has matching Typer / registry registration. Includes the mission Python parity sub-plan (5 slices: store + types → MissionManager + verifiers + planner → control-plane workflows → CLI subcommands → lifecycle subcommands + README).
+- **AC-728 — contract-probe library + CLI parity.** Python parity sub-plan (7 slices) brings the 4 base + 3 advanced probes, suite runner + Pydantic schema, `autoctx probes check`, `autoctx probes extract`, and the missing-observation audit close-out. Both runtimes share the same probe shapes, failure-kind enums, strict wire format (RegExp + ISO-8601 + strict primitives + null rejection), CLI surface, and trace-extractor orphan-rejection contract.
+
+Cross-runtime mission checkpoint contract is unified: collision-free wall-clock-nanosecond filenames, camelCase + snake_case loader interop, atomic restore with no orphan rows, and an `AsyncContextError` guard for sync-from-async callers.
+
+A new cross-runtime parity audit (`test_cli_contract_parity.py` + `cli-contract-parity.test.ts`) pins the reverse direction (every observed top-level command/group is contracted, aliased, or explicitly allowlisted) plus cross-runtime id invariants (unique, well-formed, no runtime-specific prefix, no per-runtime path divergence).
+
 ### Added
 
 - AC-728 Python parity slice 1: four base contract probes. Mirrors `ts/src/control-plane/contract-probes/index.ts` at the PR #957 shape (`probeDirectoryContract` / `probeTerminalContract` / `probeServiceContract` / `probeArtifactContract`) as pure Python functions in a new `autocontext.control_plane.contract_probes` package. Inputs / outputs / failures are Pydantic v2 frozen models (`extra="forbid"`, `arbitrary_types_allowed=True` so compiled `re.Pattern[str]` regex objects can ride through unchanged). Same failure-kind enums as the TS surface: directory (`unexpected-file`, `missing-file`), terminal (`unexpected-exit-code`, `missing-stdout-pattern`, `forbidden-stdout-pattern`, `missing-stderr-pattern`, `forbidden-stderr-pattern`), service (`missing-endpoint`, `unexpected-endpoint`, `wrong-interface` with port + protocol normalization so `tcp` is the default), artifact (`missing-substring`, `forbidden-substring`, `wrong-line-ending`, `invalid-json`, `missing-json-field` with dotted-path JSON field lookup and the same early-return shape on JSON parse failure). The slice-1 audit invariant (every observation field is non-optional so the silent-pass shape cannot arise) is pinned by a parametrised `test_expectation_against_minimum_observation_always_fails_loudly` that mirrors the TS close-out audit (PR #1000). 25 new Python tests covering the per-probe pass / fail surfaces and the missing-observation pinning property. `ruff` + `mypy` clean; module is 407 lines (under the 800-line guard).

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autocontext"
-version = "0.5.1"
+version = "0.6.0"
 description = "autocontext control plane for iterative strategy evolution."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/autocontext/src/autocontext/__init__.py
+++ b/autocontext/src/autocontext/__init__.py
@@ -5,4 +5,4 @@ from autocontext.sdk import AutoContext
 
 __all__ = ["AutoContext", "ExtensionAPI", "HookBus", "HookEvents", "HookResult", "__version__"]
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/autocontext/uv.lock
+++ b/autocontext/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "autocontext"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoctx",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bump both packages from 0.5.1 to 0.6.0 and convert the accumulated `[Unreleased]` CHANGELOG block to a tagged `[0.6.0] - 2026-06-02` section.

### Source changes

- `autocontext/pyproject.toml`: 0.5.1 → 0.6.0
- `autocontext/src/autocontext/__init__.py`: `__version__` 0.5.0 → 0.6.0 (the source attribute had drifted behind pyproject; aligned here)
- `ts/package.json`: 0.5.1 → 0.6.0
- `CHANGELOG.md`: new `[Unreleased]` placeholder; existing unreleased block renamed `[0.6.0] - 2026-06-02` with a short top-of-section summary

### What this release covers

- **AC-697 closed end-to-end**: `intentional_gap` entries in `docs/cli-contract.json` all reach `yes`. `autoctx capabilities` is contract-driven on both runtimes. Mission Python parity shipped via a 5-slice sub-plan (`autoctx mission create / run / status / list / artifacts / pause / resume / cancel`).
- **AC-728 closed end-to-end**: contract-probe library + suite runner + `autoctx probes check` + `autoctx probes extract` shipped on Python in a 7-slice sub-plan. Both runtimes share probe shapes, failure-kind enums, strict wire format, and trace-extractor orphan-rejection.
- **Cross-runtime mission checkpoint contract unified**: collision-free wall-clock-nanosecond filenames, camelCase + snake_case loader interop, atomic restore with no orphan rows, and `AsyncContextError` guard for sync-from-async callers.
- **New cross-runtime parity audit** pins reverse direction (every observed command is contracted, aliased, or explicitly allowlisted) plus cross-runtime id invariants.

## Test plan

- [x] `uv run pytest tests/test_cli_contract.py tests/test_cli_contract_parity.py` (23 passed)
- [x] Python `__version__` reports `0.6.0`
- [x] `ts/package.json` reports 0.6.0
- [ ] CI: green
- [ ] After merge: tag `v0.6.0` on the merge commit

## Tag

Tag `v0.6.0` will be created in a follow-up step after CI confirms the release commit ships clean.