### PR TITLE
fix(py-publish): bundle docs/cli-contract.json into sdist + wheel

### DIFF
--- a/autocontext/hatch_build.py
+++ b/autocontext/hatch_build.py
@@ -1,0 +1,51 @@
+"""Build hook that bundles ``docs/cli-contract.json`` into the wheel.
+
+The contract lives at the repo root (``docs/cli-contract.json``) so the
+TypeScript and Python sides share a single source of truth. To ship it
+inside the wheel, slice 5 of AC-697 originally used a static
+``force-include`` rule pointing at ``../docs/cli-contract.json``.
+
+That works for ``uv build`` invoked directly from the source tree, but
+the publish-python workflow runs ``uv build`` which builds the wheel
+from the freshly produced sdist. Inside the extracted sdist there is no
+parent ``docs/`` directory, so the static rule resolves to a missing
+file and the build fails.
+
+This hook resolves the contract from whichever location actually exists
+(repo tree during dev builds, in-sdist copy during release builds),
+stages it under ``build/`` next to the hook, and registers an absolute
+``force_include`` entry for the wheel.
+
+The sibling ``[tool.hatch.build.targets.sdist.force-include]`` rule in
+``pyproject.toml`` is what places the file at ``docs/cli-contract.json``
+inside the sdist so the wheel-from-sdist branch finds it here.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CliContractBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "cli-contract"
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        if self.target_name != "wheel":
+            return
+        root = Path(self.root)
+        candidates = [
+            root.parent / "docs" / "cli-contract.json",
+            root / "docs" / "cli-contract.json",
+        ]
+        source = next((p for p in candidates if p.is_file()), None)
+        if source is None:
+            tried = ", ".join(str(c) for c in candidates)
+            raise FileNotFoundError(f"cli-contract.json not found; looked in: {tried}")
+        staged = root / "build" / "_cli_contract" / "cli_contract.json"
+        staged.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, staged)
+        force_include = build_data.setdefault("force_include", {})
+        force_include[str(staged)] = "autocontext/cli_contract.json"

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -67,15 +67,23 @@ Documentation = "https://github.com/greyhaven-ai/autocontext/tree/main/autoconte
 [tool.hatch.build]
 exclude = [".claude", ".claude/**"]
 
+[tool.hatch.build.targets.sdist.force-include]
+# Bundle the canonical CLI contract into the sdist so the
+# wheel-from-sdist branch of `uv build` (publish-python.yml) can find
+# it. The dev tree reaches into ../docs/ directly via hatch_build.py.
+"../docs/cli-contract.json" = "docs/cli-contract.json"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/autocontext"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "assets" = "autocontext/assets"
-# AC-697 slice 5 packaging fix: ship docs/cli-contract.json inside the
-# wheel so `autoctx capabilities` works after `pip install` without
-# the surrounding repo.
-"../docs/cli-contract.json" = "autocontext/cli_contract.json"
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+# Stages docs/cli-contract.json into the wheel as
+# autocontext/cli_contract.json from whichever location actually exists
+# (parent docs/ in dev, in-sdist docs/ during release builds).
+path = "hatch_build.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

- Fixes the `publish-python` workflow which failed on tag `py-v0.6.0` at the wheel-from-sdist step with `FileNotFoundError: Forced include not found: .../docs/cli-contract.json`.
- Root cause: PR #1000 (AC-697 slice 5) added a static `[tool.hatch.build.targets.wheel.force-include]` entry pointing at `../docs/cli-contract.json`. That works for a direct `uv build` from the source tree but breaks the wheel-from-sdist branch of `uv build` (which is what publish-python uses), because the sdist tarball has no parent `docs/` directory.
- Fix is two-part:
  1. `targets.sdist.force-include` bundles the contract at `docs/cli-contract.json` inside the sdist.
  2. `hatch_build.py` resolves the contract from either location (parent `docs/` for dev builds, in-sdist `docs/` for release builds), stages it under `build/`, and registers it as a wheel `force_include`.

Verified locally: `uv build` from `autocontext/` now produces both artifacts and the wheel contains `autocontext/cli_contract.json` (10 KB).

## Test plan

- [x] `uv build` produces sdist + wheel without errors
- [x] sdist tarball contains `autocontext-0.6.0/docs/cli-contract.json`
- [x] wheel contains `autocontext/cli_contract.json`
- [ ] CI green on this PR
- [ ] After merge, retag `py-v0.6.0` at the fix commit and confirm publish-python succeeds