### PR TITLE
refactor(training): consolidate autoresearch sequence-format contract (DDD seam + DRY)

### DIFF
--- a/autocontext/src/autocontext/training/autoresearch/cuda.py
+++ b/autocontext/src/autocontext/training/autoresearch/cuda.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import time
 from pathlib import Path
 from typing import Any
 
 from autocontext.training.autoresearch.prepare import save_tokenizer_json
+from autocontext.training.autoresearch.sequence_format import (
+    TrainingExample,
+    build_generation_prompt,
+    extract_strategy,
+    generation_logit_mask_values,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -129,43 +134,6 @@ def _save_torch_checkpoint_bundle(
     )
 
 
-def _resolve_scenario_name(scenario: Any) -> str:
-    value = getattr(scenario, "name", None)
-    if isinstance(value, str) and value.strip():
-        return value
-    scenario_name = str(scenario.__class__.__name__)
-    return scenario_name.lower()
-
-
-def _resolve_scenario_context(scenario: Any) -> str:
-    task_prompt = getattr(scenario, "get_task_prompt", None)
-    if callable(task_prompt):
-        try:
-            prompt = task_prompt()
-        except TypeError:
-            prompt = None
-        if isinstance(prompt, str):
-            return prompt
-
-    description = getattr(scenario, "description", None)
-    if isinstance(description, str):
-        return description
-    return ""
-
-
-def _extract_strategy_json(text: str) -> dict[str, Any] | None:
-    match = re.search(r"<\|strategy\|>(.*?)(?:<\||$)", text, re.DOTALL)
-    if match:
-        try:
-            return json.loads(match.group(1))  # type: ignore[no-any-return]
-        except json.JSONDecodeError:
-            return None
-    try:
-        return json.loads(text)  # type: ignore[no-any-return]
-    except json.JSONDecodeError:
-        return None
-
-
 def _generate_torch_strategy_text(
     *,
     model: Any,
@@ -178,9 +146,7 @@ def _generate_torch_strategy_text(
     temperature: float = 0.0,
     top_k: int = 0,
 ) -> str:
-    from autocontext.training.autoresearch.prepare import generation_logit_mask_values
-
-    prompt = f"<|scenario|>{_resolve_scenario_name(scenario)}<|context|>{_resolve_scenario_context(scenario)}<|strategy|>"
+    prompt = build_generation_prompt(scenario)
     token_ids = list(tokenizer.encode(prompt))
     seq_len = int(model.cfg.seq_len)
     vocab_size = int(getattr(model.cfg, "vocab_size", 0))
@@ -249,7 +215,7 @@ def _assess_torch_strategy_quality(
                 temperature=temperature,
                 top_k=top_k,
             )
-            strategy = _extract_strategy_json(raw_output)
+            strategy = extract_strategy(raw_output)
             if strategy is None:
                 continue
             valid_count += 1
@@ -293,9 +259,9 @@ def run_cuda_training(
     from autocontext.training.autoresearch.train import ModelConfig, _all_records, _build_corpus, _peak_memory_mb
 
     try:
-        from prepare import format_example, train_tokenizer  # type: ignore[import-not-found]
+        from prepare import train_tokenizer  # type: ignore[import-not-found]
     except ImportError:
-        from autocontext.training.autoresearch.prepare import format_example, train_tokenizer
+        from autocontext.training.autoresearch.prepare import train_tokenizer
 
     if scenario_name not in SCENARIO_REGISTRY:
         raise ValueError(f"unknown scenario: {scenario_name}")
@@ -308,16 +274,7 @@ def run_cuda_training(
 
     token_ids: list[int] = []
     for record in records:
-        token_ids.extend(
-            tokenizer.encode(
-                format_example(
-                    scenario=str(record["scenario"]),
-                    context=json.dumps(record.get("context", {}), sort_keys=True),
-                    strategy_json=json.dumps(record["strategy"], sort_keys=True),
-                    score=float(record["score"]),
-                )
-            )
-        )
+        token_ids.extend(tokenizer.encode(TrainingExample.from_record(record).to_sequence()))
 
     batches = _create_torch_dataloader(
         token_ids,

--- a/autocontext/src/autocontext/training/autoresearch/prepare.py
+++ b/autocontext/src/autocontext/training/autoresearch/prepare.py
@@ -15,48 +15,41 @@ from __future__ import annotations
 import base64
 import json
 import logging
-import re
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, cast
 
 from autocontext.training import HAS_MLX
 
+# The sequence-format contract is owned by sequence_format (pure domain module).
+# Re-exported here for backward compatibility: existing callers / tests import these
+# names from prepare. New code should import from sequence_format directly.
+from autocontext.training.autoresearch.sequence_format import (  # noqa: F401
+    _BPE_PAT,
+    BASE_VOCAB_SIZE,
+    SPECIAL_TOKEN_STRINGS,
+    TrainingExample,
+    build_generation_prompt,
+    build_special_tokens,
+    decodable_vocab_size,
+    format_example,
+    generation_logit_mask_values,
+    total_vocab_size,
+)
+from autocontext.training.autoresearch.sequence_format import (
+    extract_strategy as _extract_strategy_json,  # noqa: F401
+)
+from autocontext.training.autoresearch.sequence_format import (
+    resolve_scenario_context as _resolve_scenario_context,  # noqa: F401
+)
+from autocontext.training.autoresearch.sequence_format import (
+    resolve_scenario_name as _resolve_scenario_name,  # noqa: F401
+)
+
 logger = logging.getLogger(__name__)
 
 if HAS_MLX:
     import mlx.core as mx  # type: ignore[import-not-found]
-
-
-BASE_VOCAB_SIZE = 8192
-SPECIAL_TOKEN_STRINGS = (
-    "<|scenario|>",
-    "<|context|>",
-    "<|strategy|>",
-    "<|score|>",
-    "<|end|>",
-)
-
-_BPE_PAT = (
-    r"(?i:'s|'t|'re|'ve|'m|'ll|'d)"
-    r"|[^\r\n\p{L}\p{N}]?\p{L}+"
-    r"|\p{N}{1,3}"
-    r"| ?[^\s\p{L}\p{N}]+[\r\n]*"
-    r"|\s*[\r\n]+"
-    r"|\s+"
-)
-
-
-def build_special_tokens(base_vocab_size: int) -> dict[str, int]:
-    """Map the autoresearch special tokens above the base tokenizer range."""
-
-    return {token: base_vocab_size + offset for offset, token in enumerate(SPECIAL_TOKEN_STRINGS)}
-
-
-def total_vocab_size(base_vocab_size: int) -> int:
-    """Return the embedding/output vocab size including special tokens."""
-
-    return base_vocab_size + len(SPECIAL_TOKEN_STRINGS)
 
 
 def serialize_tokenizer(tokenizer: Any) -> dict[str, Any]:
@@ -83,69 +76,6 @@ def save_tokenizer_json(tokenizer: Any, path: Path) -> None:
     """Persist tokenizer metadata in the format expected by MLXProvider."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(serialize_tokenizer(tokenizer), indent=2, sort_keys=True), encoding="utf-8")
-
-
-def _extract_strategy_json(text: str) -> dict[str, Any] | None:
-    """Extract JSON strategy from model output text."""
-    match = re.search(r"<\|strategy\|>(.*?)(?:<\||$)", text, re.DOTALL)
-    if match:
-        try:
-            return json.loads(match.group(1))  # type: ignore[no-any-return]
-        except json.JSONDecodeError:
-            return None
-    # Try parsing the whole text as JSON
-    try:
-        return json.loads(text)  # type: ignore[no-any-return]
-    except json.JSONDecodeError:
-        return None
-
-
-def decodable_vocab_size(tokenizer: Any) -> int:
-    """Number of real, decodable BPE base tokens the tokenizer learned.
-
-    On small corpora the BPE trainer learns fewer than ``base_vocab_size`` merges,
-    leaving a gap of ids in ``[n_learned, base_vocab_size)`` that the underlying
-    tiktoken encoding cannot decode (``decode`` raises ``KeyError``). Sampling must
-    not emit ids in that gap. Returns ``max(rank) + 1`` over the mergeable ranks,
-    falling back to ``base_vocab_size`` when the ranks are unavailable.
-    """
-    enc = getattr(tokenizer, "_encoding", None)
-    ranks = getattr(enc, "_mergeable_ranks", None)
-    if isinstance(ranks, dict) and ranks:
-        return int(max(ranks.values())) + 1
-    base = getattr(tokenizer, "base_vocab_size", None)
-    return int(base) if base else BASE_VOCAB_SIZE
-
-
-def generation_logit_mask_values(
-    tokenizer: Any,
-    vocab_size: int,
-    *,
-    block_structural_specials: bool = True,
-) -> list[float]:
-    """Additive logit-mask values (0.0 = allowed, -1e9 = blocked).
-
-    Always blocks the phantom-id gap ``[decodable_vocab_size, base_vocab_size)``
-    that the tokenizer cannot decode, so neither training-time assessment nor
-    ``MLXProvider`` inference can sample an id that later crashes ``decode``.
-
-    When ``block_structural_specials`` is true (training assessment) it also blocks
-    the ``<|scenario|>`` / ``<|context|>`` / ``<|strategy|>`` tokens so a generated
-    body cannot restart the header. Providers doing general completion pass
-    ``False`` to leave all (decodable) special tokens available.
-    """
-    base = int(getattr(tokenizer, "base_vocab_size", BASE_VOCAB_SIZE))
-    n_base = decodable_vocab_size(tokenizer)
-    mask = [0.0] * vocab_size
-    for i in range(max(0, n_base), min(base, vocab_size)):
-        mask[i] = -1e9
-    if block_structural_specials:
-        specials = build_special_tokens(base)
-        for name in ("<|scenario|>", "<|context|>", "<|strategy|>"):
-            sid = specials.get(name)
-            if sid is not None and 0 <= sid < vocab_size:
-                mask[sid] = -1e9
-    return mask
 
 
 # ---------------------------------------------------------------------------
@@ -195,21 +125,6 @@ def load_jsonl(
 # ---------------------------------------------------------------------------
 # 2. Input formatting (no MLX dependency)
 # ---------------------------------------------------------------------------
-
-
-def format_example(
-    *,
-    scenario: str,
-    context: str,
-    strategy_json: str,
-    score: float,
-) -> str:
-    """Format a single training example in the standard input format.
-
-    Format:
-        <|scenario|>{scenario}<|context|>{context}<|strategy|>{strategy_json}<|score|>{score}<|end|>
-    """
-    return f"<|scenario|>{scenario}<|context|>{context}<|strategy|>{strategy_json}<|score|>{score}<|end|>"
 
 
 def extract_best_opponent(records: list[dict[str, Any]]) -> dict[str, Any]:
@@ -440,7 +355,7 @@ if HAS_MLX:
             # Test doubles may not expose a sampling surface; fall back to the tokenizer stub.
             return cast(str, tokenizer.decode([seed] * 32))
 
-        prompt = f"<|scenario|>{_resolve_scenario_name(scenario)}<|context|>{_resolve_scenario_context(scenario)}<|strategy|>"
+        prompt = build_generation_prompt(scenario)
         token_ids = list(tokenizer.encode(prompt))
         seq_len = int(model.cfg.seq_len)
         vocab_size = int(getattr(model.cfg, "vocab_size", total_vocab_size(BASE_VOCAB_SIZE)))
@@ -468,25 +383,3 @@ if HAS_MLX:
                 break
 
         return cast(str, tokenizer.decode(token_ids))
-
-    def _resolve_scenario_name(scenario: Any) -> str:
-        value = getattr(scenario, "name", None)
-        if isinstance(value, str) and value.strip():
-            return value
-        scenario_name = cast(str, scenario.__class__.__name__)
-        return scenario_name.lower()
-
-    def _resolve_scenario_context(scenario: Any) -> str:
-        task_prompt = getattr(scenario, "get_task_prompt", None)
-        if callable(task_prompt):
-            try:
-                prompt = task_prompt()
-            except TypeError:
-                prompt = None
-            if isinstance(prompt, str):
-                return prompt
-
-        description = getattr(scenario, "description", None)
-        if isinstance(description, str):
-            return description
-        return ""

--- a/autocontext/src/autocontext/training/autoresearch/sequence_format.py
+++ b/autocontext/src/autocontext/training/autoresearch/sequence_format.py
@@ -1,0 +1,223 @@
+"""Canonical sequence-format contract for autoresearch training (pure domain).
+
+This is the single source of truth for how a training record becomes a token
+sequence, how special tokens are laid out, how a generation prompt is built, how
+a generated strategy is parsed back out, and the decodable/structural logit mask.
+
+It is pure: no MLX, no torch, no import of ``prepare``/``train``/``cuda`` (so it can
+be reused by every backend and by ``MLXProvider`` without import cycles). ``prepare``
+re-exports these names for backward compatibility; ``cuda`` and the providers consume
+them directly instead of duplicating the format.
+
+Frontier note: keeping the format in one value object (``TrainingExample``) is what
+lets later work move a quality/return control token into the sequence (Decision
+Transformer / Quark style) by editing exactly one place.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Vocab + special-token layout
+# ---------------------------------------------------------------------------
+
+BASE_VOCAB_SIZE = 8192
+
+SPECIAL_TOKEN_STRINGS = (
+    "<|scenario|>",
+    "<|context|>",
+    "<|strategy|>",
+    "<|score|>",
+    "<|end|>",
+)
+
+# rustbpe / tiktoken split pattern (GPT-style). Part of the tokenizer contract.
+_BPE_PAT = (
+    r"(?i:'s|'t|'re|'ve|'m|'ll|'d)"
+    r"|[^\r\n\p{L}\p{N}]?\p{L}+"
+    r"|\p{N}{1,3}"
+    r"| ?[^\s\p{L}\p{N}]+[\r\n]*"
+    r"|\s*[\r\n]+"
+    r"|\s+"
+)
+
+_STRATEGY_RE = re.compile(r"<\|strategy\|>(.*?)(?:<\||$)", re.DOTALL)
+
+
+def build_special_tokens(base_vocab_size: int) -> dict[str, int]:
+    """Map the autoresearch special tokens above the base tokenizer range."""
+    return {token: base_vocab_size + offset for offset, token in enumerate(SPECIAL_TOKEN_STRINGS)}
+
+
+def total_vocab_size(base_vocab_size: int) -> int:
+    """Return the embedding/output vocab size including special tokens."""
+    return base_vocab_size + len(SPECIAL_TOKEN_STRINGS)
+
+
+def decodable_vocab_size(tokenizer: Any) -> int:
+    """Number of real, decodable BPE base tokens the tokenizer learned.
+
+    On small corpora the BPE trainer learns fewer than ``base_vocab_size`` merges,
+    leaving a gap of ids in ``[n_learned, base_vocab_size)`` that the underlying
+    tiktoken encoding cannot decode (``decode`` raises ``KeyError``). Sampling must
+    not emit ids in that gap. Returns ``max(rank) + 1`` over the mergeable ranks,
+    falling back to ``base_vocab_size`` when the ranks are unavailable.
+    """
+    enc = getattr(tokenizer, "_encoding", None)
+    ranks = getattr(enc, "_mergeable_ranks", None)
+    if isinstance(ranks, dict) and ranks:
+        return int(max(ranks.values())) + 1
+    base = getattr(tokenizer, "base_vocab_size", None)
+    return int(base) if base else BASE_VOCAB_SIZE
+
+
+def generation_logit_mask_values(
+    tokenizer: Any,
+    vocab_size: int,
+    *,
+    block_structural_specials: bool = True,
+) -> list[float]:
+    """Additive logit-mask values (0.0 = allowed, -1e9 = blocked).
+
+    Always blocks the phantom-id gap ``[decodable_vocab_size, base_vocab_size)``
+    that the tokenizer cannot decode, so neither training-time assessment nor
+    ``MLXProvider`` inference can sample an id that later crashes ``decode``.
+
+    When ``block_structural_specials`` is true (training assessment) it also blocks
+    the ``<|scenario|>`` / ``<|context|>`` / ``<|strategy|>`` tokens so a generated
+    body cannot restart the header. Providers doing general completion pass
+    ``False`` to leave all (decodable) special tokens available.
+    """
+    base = int(getattr(tokenizer, "base_vocab_size", BASE_VOCAB_SIZE))
+    n_base = decodable_vocab_size(tokenizer)
+    mask = [0.0] * vocab_size
+    for i in range(max(0, n_base), min(base, vocab_size)):
+        mask[i] = -1e9
+    if block_structural_specials:
+        specials = build_special_tokens(base)
+        for name in ("<|scenario|>", "<|context|>", "<|strategy|>"):
+            sid = specials.get(name)
+            if sid is not None and 0 <= sid < vocab_size:
+                mask[sid] = -1e9
+    return mask
+
+
+# ---------------------------------------------------------------------------
+# Scenario resolution (pure; previously duplicated in prepare + cuda)
+# ---------------------------------------------------------------------------
+
+
+def resolve_scenario_name(scenario: Any) -> str:
+    """Resolve a scenario's stable name (its ``name`` attr, else lowercased class)."""
+    value = getattr(scenario, "name", None)
+    if isinstance(value, str) and value.strip():
+        return value
+    return str(scenario.__class__.__name__).lower()
+
+
+def resolve_scenario_context(scenario: Any) -> str:
+    """Resolve the context string for a scenario (task prompt, else description)."""
+    task_prompt = getattr(scenario, "get_task_prompt", None)
+    if callable(task_prompt):
+        try:
+            prompt = task_prompt()
+        except TypeError:
+            prompt = None
+        if isinstance(prompt, str):
+            return prompt
+    description = getattr(scenario, "description", None)
+    if isinstance(description, str):
+        return description
+    return ""
+
+
+# Backward-compatible private aliases (prepare/cuda historically used underscored names).
+_resolve_scenario_name = resolve_scenario_name
+_resolve_scenario_context = resolve_scenario_context
+
+
+# ---------------------------------------------------------------------------
+# Example formatting + parsing (the format itself)
+# ---------------------------------------------------------------------------
+
+
+def format_example(
+    *,
+    scenario: str,
+    context: str,
+    strategy_json: str,
+    score: float,
+) -> str:
+    """Format a single training example in the standard input format.
+
+    Format:
+        <|scenario|>{scenario}<|context|>{context}<|strategy|>{strategy_json}<|score|>{score}<|end|>
+    """
+    return f"<|scenario|>{scenario}<|context|>{context}<|strategy|>{strategy_json}<|score|>{score}<|end|>"
+
+
+def build_generation_prompt(scenario: Any) -> str:
+    """Build the generation prompt for a scenario (header up to ``<|strategy|>``).
+
+    Single source for both the MLX and CUDA generators (and any provider) so the
+    prompt prefix stays in lockstep with :func:`format_example`.
+    """
+    return f"<|scenario|>{resolve_scenario_name(scenario)}<|context|>{resolve_scenario_context(scenario)}<|strategy|>"
+
+
+def extract_strategy(text: str) -> dict[str, Any] | None:
+    """Extract the JSON strategy object from model output text.
+
+    Prefers the span after ``<|strategy|>`` up to the next special token; falls back
+    to parsing the whole text as JSON. Returns ``None`` if nothing parses.
+    """
+    match = _STRATEGY_RE.search(text)
+    if match:
+        try:
+            result = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            return None
+        return result if isinstance(result, dict) else None
+    try:
+        result = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return result if isinstance(result, dict) else None
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingExample:
+    """A training record reduced to the fields that define its token sequence.
+
+    ``from_record`` is the single place that maps a raw JSONL/record dict onto the
+    sequence fields (canonical JSON serialization of context/strategy, float score),
+    so producers (``_build_corpus``, the MLX/CUDA tokenize loops) no longer repeat
+    that mapping. ``to_sequence`` is the single place that lays the fields out.
+    """
+
+    scenario: str
+    context: str
+    strategy_json: str
+    score: float
+
+    @classmethod
+    def from_record(cls, record: Mapping[str, Any]) -> TrainingExample:
+        return cls(
+            scenario=str(record["scenario"]),
+            context=json.dumps(record.get("context", {}), sort_keys=True),
+            strategy_json=json.dumps(record["strategy"], sort_keys=True),
+            score=float(record["score"]),
+        )
+
+    def to_sequence(self) -> str:
+        return format_example(
+            scenario=self.scenario,
+            context=self.context,
+            strategy_json=self.strategy_json,
+            score=self.score,
+        )

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -402,20 +402,11 @@ def _all_records(data_path: Path) -> list[dict[str, Any]]:
 
 def _build_corpus(records: list[dict[str, Any]]) -> str:
     try:
-        from prepare import format_example  # type: ignore[import-not-found]
+        from prepare import TrainingExample  # type: ignore[import-not-found]
     except ImportError:
-        from autocontext.training.autoresearch.prepare import format_example
+        from autocontext.training.autoresearch.prepare import TrainingExample
 
-    examples = [
-        format_example(
-            scenario=str(record["scenario"]),
-            context=json.dumps(record.get("context", {}), sort_keys=True),
-            strategy_json=json.dumps(record["strategy"], sort_keys=True),
-            score=float(record["score"]),
-        )
-        for record in records
-    ]
-    return "\n".join(examples)
+    return "\n".join(TrainingExample.from_record(record).to_sequence() for record in records)
 
 
 def _run_mlx_training(
@@ -445,16 +436,15 @@ def _run_mlx_training(
 
     try:
         from prepare import (  # type: ignore[import-not-found]
+            TrainingExample,
             assess_strategy_quality,
             create_dataloader,
-            format_example,
             train_tokenizer,
         )
     except ImportError:
         from autocontext.training.autoresearch.prepare import (
             assess_strategy_quality,
             create_dataloader,
-            format_example,
             train_tokenizer,
         )
 
@@ -469,16 +459,7 @@ def _run_mlx_training(
 
     token_ids: list[int] = []
     for record in records:
-        token_ids.extend(
-            tokenizer.encode(
-                format_example(
-                    scenario=str(record["scenario"]),
-                    context=json.dumps(record.get("context", {}), sort_keys=True),
-                    strategy_json=json.dumps(record["strategy"], sort_keys=True),
-                    score=float(record["score"]),
-                )
-            )
-        )
+        token_ids.extend(tokenizer.encode(TrainingExample.from_record(record).to_sequence()))
 
     batches = list(create_dataloader(token_ids, seq_len=seq_len, batch_size=batch_size))
     if not batches:

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -443,6 +443,7 @@ def _run_mlx_training(
         )
     except ImportError:
         from autocontext.training.autoresearch.prepare import (
+            TrainingExample,
             assess_strategy_quality,
             create_dataloader,
             train_tokenizer,

--- a/autocontext/tests/test_sequence_format.py
+++ b/autocontext/tests/test_sequence_format.py
@@ -1,0 +1,132 @@
+"""Contract tests for the autoresearch sequence-format domain (PR1).
+
+These pin the training-data sequence format byte-for-byte (golden master) so the
+DDD consolidation that moves the contract into ``sequence_format`` and removes the
+``cuda.py`` duplication cannot change observable behavior. They also cover the new
+single-source ``build_generation_prompt`` and ``TrainingExample`` value object.
+"""
+
+from __future__ import annotations
+
+import json
+
+# ---------------------------------------------------------------------------
+# Golden master: the format must remain byte-identical (imported via the public
+# prepare surface, which re-exports the contract for backward compatibility).
+# ---------------------------------------------------------------------------
+
+
+def test_format_example_is_byte_stable_via_prepare() -> None:
+    from autocontext.training.autoresearch.prepare import format_example
+
+    out = format_example(scenario="grid_ctf", context="ctx", strategy_json='{"a": 1}', score=0.5)
+    assert out == '<|scenario|>grid_ctf<|context|>ctx<|strategy|>{"a": 1}<|score|>0.5<|end|>'
+
+
+def test_extract_strategy_round_trips_via_prepare() -> None:
+    from autocontext.training.autoresearch.prepare import _extract_strategy_json
+
+    assert _extract_strategy_json('<|strategy|>{"a": 1}<|score|>0.5<|end|>') == {"a": 1}
+    assert _extract_strategy_json('<|strategy|>{"a": 1}') == {"a": 1}
+    assert _extract_strategy_json("not json at all") is None
+
+
+def test_special_tokens_and_vocab_via_prepare() -> None:
+    from autocontext.training.autoresearch.prepare import (
+        BASE_VOCAB_SIZE,
+        SPECIAL_TOKEN_STRINGS,
+        build_special_tokens,
+        total_vocab_size,
+    )
+
+    specials = build_special_tokens(BASE_VOCAB_SIZE)
+    assert specials == {
+        "<|scenario|>": BASE_VOCAB_SIZE + 0,
+        "<|context|>": BASE_VOCAB_SIZE + 1,
+        "<|strategy|>": BASE_VOCAB_SIZE + 2,
+        "<|score|>": BASE_VOCAB_SIZE + 3,
+        "<|end|>": BASE_VOCAB_SIZE + 4,
+    }
+    assert total_vocab_size(BASE_VOCAB_SIZE) == BASE_VOCAB_SIZE + len(SPECIAL_TOKEN_STRINGS)
+
+
+def test_generation_logit_mask_values_via_prepare_unchanged() -> None:
+    from autocontext.training.autoresearch.prepare import generation_logit_mask_values, total_vocab_size
+
+    class _Enc:
+        _mergeable_ranks = {bytes([i]): i for i in range(4)}
+
+    class _Tok:
+        _encoding = _Enc()
+        base_vocab_size = 16
+
+    vocab = total_vocab_size(16)
+    mask = generation_logit_mask_values(_Tok(), vocab, block_structural_specials=True)
+    assert mask[0] == 0.0 and mask[3] == 0.0
+    assert mask[4] == -1e9 and mask[15] == -1e9  # phantom gap
+    assert mask[16] == -1e9  # <|scenario|> blocked
+    assert mask[19] == 0.0 and mask[20] == 0.0  # score/end allowed
+
+
+# ---------------------------------------------------------------------------
+# New single-source contract API (sequence_format).
+# ---------------------------------------------------------------------------
+
+
+def test_build_generation_prompt_single_source() -> None:
+    from autocontext.training.autoresearch.sequence_format import build_generation_prompt
+
+    class _Scn:
+        name = "capset"
+        description = "build a set"
+
+    assert build_generation_prompt(_Scn()) == "<|scenario|>capset<|context|>build a set<|strategy|>"
+
+
+def test_build_generation_prompt_falls_back_to_classname() -> None:
+    from autocontext.training.autoresearch.sequence_format import build_generation_prompt
+
+    class WidgetTask:  # no name attr, no description
+        pass
+
+    # name falls back to lowercased class name; context falls back to "" when no description
+    assert build_generation_prompt(WidgetTask()) == "<|scenario|>widgettask<|context|><|strategy|>"
+
+
+def test_training_example_to_sequence_matches_format_example() -> None:
+    from autocontext.training.autoresearch.sequence_format import TrainingExample, format_example
+
+    record = {
+        "run_id": "r1",
+        "scenario": "grid_ctf",
+        "context": {"playbook": "p"},
+        "strategy": {"a": 1, "b": 2},
+        "score": 0.75,
+    }
+    ex = TrainingExample.from_record(record)
+    expected = format_example(
+        scenario="grid_ctf",
+        context=json.dumps({"playbook": "p"}, sort_keys=True),
+        strategy_json=json.dumps({"a": 1, "b": 2}, sort_keys=True),
+        score=0.75,
+    )
+    assert ex.to_sequence() == expected
+
+
+def test_training_example_defaults_missing_context() -> None:
+    from autocontext.training.autoresearch.sequence_format import TrainingExample
+
+    ex = TrainingExample.from_record({"scenario": "s", "strategy": {"x": 1}, "score": 1.0})
+    assert ex.context == json.dumps({}, sort_keys=True)
+
+
+def test_cuda_uses_shared_contract_no_duplicate_definitions() -> None:
+    """cuda.py must not redefine the parser/resolvers; it consumes sequence_format."""
+    import inspect
+
+    from autocontext.training.autoresearch import cuda
+
+    src = inspect.getsource(cuda)
+    assert "def _extract_strategy_json" not in src
+    assert "def _resolve_scenario_name" not in src
+    assert "def _resolve_scenario_context" not in src

--- a/autocontext/tests/test_train_mlx.py
+++ b/autocontext/tests/test_train_mlx.py
@@ -3,6 +3,7 @@
 All tests are skipped when MLX is not installed (CI-safe).
 Note: mx.eval() is MLX's lazy evaluation trigger, not Python's eval().
 """
+
 from __future__ import annotations
 
 import pytest
@@ -97,6 +98,50 @@ def test_summary_block_format() -> None:
     assert "num_params_M" in summary
     assert "depth" in summary
     assert "0.75" in summary or "0.7500" in summary
+
+
+def test_run_training_mlx_end_to_end_smoke(tmp_path: str) -> None:
+    """run_training(backend='mlx') runs the full pipeline via the package import path.
+
+    Regression guard (PR #1027 review): _run_mlx_training's tokenization loop uses
+    TrainingExample, which must be importable in BOTH the script-local and the
+    package (autocontext.training.autoresearch.prepare) fallback import branches.
+    Normal package/CLI execution takes the fallback branch; a missing import there
+    raised UnboundLocalError. Existing tests never ran the full loop, so this pins it.
+    """
+    import json
+    from pathlib import Path
+
+    from autocontext.training.autoresearch.train import run_training
+
+    records = [
+        {
+            "run_id": f"r{i % 2}",
+            "scenario": "grid_ctf",
+            "context": {"playbook": "p"},
+            "strategy": {"aggression": 0.5, "defense": 0.3},
+            "score": 0.5 + 0.01 * i,
+        }
+        for i in range(6)
+    ]
+    data_path = Path(tmp_path) / "data.jsonl"
+    data_path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+
+    metrics = run_training(
+        scenario_name="grid_ctf",
+        data_path=data_path,
+        output_dir=Path(tmp_path) / "out",
+        time_budget=30,
+        memory_limit_mb=4096,
+        train_steps=1,
+        batch_size=1,
+        seq_len=16,
+        assess_samples=1,
+        backend="mlx",
+    )
+    assert "avg_score" in metrics and "valid_rate" in metrics
+    # the inference bundle should have been written without error
+    assert (Path(tmp_path) / "out" / "model.safetensors").exists()
 
 
 def test_checkpoint_save_load(tmp_path: str) -> None:


### PR DESCRIPTION
First PR in a sequence improving the autoresearch data -> training/finetuning pipeline. This one is a **pure refactor** (no behavior change) that establishes a single source of truth for the sequence-format contract, so subsequent PRs (completion-only loss, score-conditioning, dedup/filtering, pretrained finetune, self-improving loop) are localized and safe.

## Problem
The training-data format contract was spread across `prepare.py` with **duplicated** copies in `cuda.py` (`_extract_strategy_json`, `_resolve_scenario_name`, `_resolve_scenario_context`, and the inline `<|scenario|>...<|strategy|>` prompt), and the record->sequence mapping (json-dump context/strategy, float score, `format_example`) was repeated in three loops (`_build_corpus`, the MLX tokenize loop, the CUDA tokenize loop). Changing the format safely was therefore error-prone.

## Change
- New pure `training/autoresearch/sequence_format.py` domain module owns: special-token layout, `build_special_tokens`/`total_vocab_size`/`decodable_vocab_size`, `generation_logit_mask_values`, scenario resolution, `format_example`, `build_generation_prompt`, `extract_strategy`, and a `TrainingExample` value object (`from_record` -> `to_sequence`). No MLX/torch import, no import cycle.
- `prepare.py` re-exports the contract names for backward compatibility; existing imports and tests are unchanged. Its own definitions are deleted (now imported).
- `cuda.py` deletes its three duplicated functions + inline prompt and consumes the shared helpers.
- `train.py` and `cuda.py` build the corpus + token stream via `TrainingExample.from_record(record).to_sequence()`.

Net **-169 lines** in the touched files.

## Tests
- New `test_sequence_format.py`: golden-master pins of `format_example`, `extract_strategy`, special tokens, vocab sizes, and the logit mask (byte-for-byte, imported via the public `prepare` surface so they hold across the move), plus `build_generation_prompt` and `TrainingExample`, plus an assertion that `cuda.py` no longer redefines the parser/resolvers.
- All affected autoresearch/provider/training tests pass; ruff + mypy clean.

TS parity: N/A (TS training is orchestration only; no token format/generation).