### PR TITLE
feat(training): completion-only loss + document-boundary packing (no tail drop)

### DIFF
--- a/autocontext/src/autocontext/training/autoresearch/cuda.py
+++ b/autocontext/src/autocontext/training/autoresearch/cuda.py
@@ -12,6 +12,8 @@ from autocontext.training.autoresearch.prepare import save_tokenizer_json
 from autocontext.training.autoresearch.sequence_format import (
     TrainingExample,
     build_generation_prompt,
+    build_masked_example,
+    build_special_tokens,
     extract_strategy,
     generation_logit_mask_values,
 )
@@ -33,27 +35,39 @@ def require_torch_cuda() -> Any:
     return torch
 
 
-def _create_torch_dataloader(
-    token_ids: list[int],
+def _create_torch_masked_dataloader(
+    sequences: list[list[int]],
     *,
     torch_module: Any,
     device: Any,
     seq_len: int,
     batch_size: int,
-) -> list[tuple[Any, Any]]:
-    stride = seq_len + 1
-    total_seqs = len(token_ids) // stride
-    usable_seqs = (total_seqs // batch_size) * batch_size
-    total_tokens = usable_seqs * stride
-    if total_tokens == 0:
-        return []
+    pad_token_id: int,
+    strategy_token_id: int,
+) -> list[tuple[Any, Any, Any]]:
+    """Per-example, completion-masked torch batches (mirrors prepare.iter_masked_batches).
 
-    data = torch_module.tensor(token_ids[:total_tokens], dtype=torch_module.long, device=device)
-    data = data.reshape(usable_seqs, stride)
-    batches: list[tuple[Any, Any]] = []
-    for batch_start in range(0, usable_seqs, batch_size):
-        batch = data[batch_start : batch_start + batch_size]
-        batches.append((batch[:, :seq_len], batch[:, 1 : seq_len + 1]))
+    No cross-example packing (document boundaries respected), no tail dropped, and a
+    completion-only loss mask (prompt + padding zeroed). Returns ``(x, y, mask)`` tuples.
+    """
+    built: list[tuple[list[int], list[int], list[int]]] = []
+    for tokens in sequences:
+        example = build_masked_example(
+            tokens,
+            seq_len=seq_len,
+            pad_token_id=pad_token_id,
+            strategy_token_id=strategy_token_id,
+        )
+        if example is not None:
+            built.append(example)
+
+    batches: list[tuple[Any, Any, Any]] = []
+    for start in range(0, len(built), batch_size):
+        chunk = built[start : start + batch_size]
+        x = torch_module.tensor([c[0] for c in chunk], dtype=torch_module.long, device=device)
+        y = torch_module.tensor([c[1] for c in chunk], dtype=torch_module.long, device=device)
+        mask = torch_module.tensor([c[2] for c in chunk], dtype=torch_module.float32, device=device)
+        batches.append((x, y, mask))
     return batches
 
 
@@ -272,16 +286,18 @@ def run_cuda_training(
     corpus_path.write_text(_build_corpus(records), encoding="utf-8")
     tokenizer = train_tokenizer(corpus_path)
 
-    token_ids: list[int] = []
-    for record in records:
-        token_ids.extend(tokenizer.encode(TrainingExample.from_record(record).to_sequence()))
-
-    batches = _create_torch_dataloader(
-        token_ids,
+    sequences = [tokenizer.encode(TrainingExample.from_record(record).to_sequence()) for record in records]
+    base_vocab = int(getattr(tokenizer, "base_vocab_size", 8192))
+    strategy_token_id = build_special_tokens(base_vocab)["<|strategy|>"]
+    pad_token_id = getattr(tokenizer, "end_token_id", 0) or 0
+    batches = _create_torch_masked_dataloader(
+        sequences,
         torch_module=torch_module,
         device=device,
         seq_len=seq_len,
         batch_size=batch_size,
+        pad_token_id=pad_token_id,
+        strategy_token_id=strategy_token_id,
     )
     if not batches:
         raise ValueError("not enough tokenized training data for a single batch")
@@ -301,13 +317,16 @@ def run_cuda_training(
     for step in range(train_steps):
         if time.perf_counter() >= deadline:
             break
-        x, y = batches[step % len(batches)]
+        x, y, loss_mask = batches[step % len(batches)]
         optimizer.zero_grad(set_to_none=True)
         logits = model(x)
-        loss = torch_module.nn.functional.cross_entropy(
+        per_token = torch_module.nn.functional.cross_entropy(
             logits.reshape(-1, cfg.vocab_size),
             y.reshape(-1),
+            reduction="none",
         )
+        mask_flat = loss_mask.reshape(-1)
+        loss = (per_token * mask_flat).sum() / mask_flat.sum().clamp(min=1.0)
         loss.backward()
         optimizer.step()
         steps_completed += 1

--- a/autocontext/src/autocontext/training/autoresearch/prepare.py
+++ b/autocontext/src/autocontext/training/autoresearch/prepare.py
@@ -30,7 +30,9 @@ from autocontext.training.autoresearch.sequence_format import (  # noqa: F401
     SPECIAL_TOKEN_STRINGS,
     TrainingExample,
     build_generation_prompt,
+    build_masked_example,
     build_special_tokens,
+    completion_loss_mask,
     decodable_vocab_size,
     format_example,
     generation_logit_mask_values,
@@ -239,6 +241,40 @@ if HAS_MLX:
             x = batch[:, :seq_len]
             y = batch[:, 1 : seq_len + 1]
             yield x, y
+
+    def iter_masked_batches(
+        sequences: list[list[int]],
+        *,
+        seq_len: int,
+        batch_size: int,
+        pad_token_id: int,
+        strategy_token_id: int,
+    ) -> Iterator[tuple[Any, Any, Any]]:
+        """Yield ``(x, y, loss_mask)`` batches of per-example, completion-masked sequences.
+
+        Each example is encoded independently (no cross-example packing, so the model
+        never predicts across a document boundary), right-truncated to keep the
+        completion when it exceeds ``seq_len + 1``, padded to ``seq_len``, and its loss
+        mask zeroes both the prompt tokens (completion-only loss) and the padding.
+        No batch is dropped: the final partial batch is yielded as-is.
+        """
+        built: list[tuple[list[int], list[int], list[int]]] = []
+        for tokens in sequences:
+            example = build_masked_example(
+                tokens,
+                seq_len=seq_len,
+                pad_token_id=pad_token_id,
+                strategy_token_id=strategy_token_id,
+            )
+            if example is not None:
+                built.append(example)
+
+        for start in range(0, len(built), batch_size):
+            chunk = built[start : start + batch_size]
+            xs = mx.array([c[0] for c in chunk], dtype=mx.int32)
+            ys = mx.array([c[1] for c in chunk], dtype=mx.int32)
+            ms = mx.array([c[2] for c in chunk], dtype=mx.float32)
+            yield xs, ys, ms
 
     # -----------------------------------------------------------------------
     # 5. Assessment oracle

--- a/autocontext/src/autocontext/training/autoresearch/sequence_format.py
+++ b/autocontext/src/autocontext/training/autoresearch/sequence_format.py
@@ -190,6 +190,61 @@ def extract_strategy(text: str) -> dict[str, Any] | None:
     return result if isinstance(result, dict) else None
 
 
+def completion_loss_mask(token_ids: list[int], *, strategy_token_id: int) -> list[int]:
+    """Per-target loss mask for completion-only training (1 = train, 0 = ignore).
+
+    For next-token prediction the target sequence is ``token_ids[1:]`` (aligned to
+    inputs ``token_ids[:-1]``), so the mask has length ``len(token_ids) - 1``. Loss
+    is enabled only for targets that fall *after* the ``<|strategy|>`` token (the
+    completion the model must learn to generate); the scenario/context prompt that
+    precedes it is masked out. This is the standard completion-only / "loss over
+    completions" objective used in instruction tuning.
+
+    If the strategy token is absent (unexpected/legacy), all positions are trained
+    (all-ones) so no example is silently dropped.
+    """
+    n = len(token_ids)
+    if n <= 1:
+        return []
+    try:
+        strategy_index = token_ids.index(strategy_token_id)
+    except ValueError:
+        return [1] * (n - 1)
+    # input j predicts token_ids[j+1]; it is a completion target iff j+1 > strategy_index
+    return [1 if (j + 1) > strategy_index else 0 for j in range(n - 1)]
+
+
+def build_masked_example(
+    tokens: list[int],
+    *,
+    seq_len: int,
+    pad_token_id: int,
+    strategy_token_id: int,
+) -> tuple[list[int], list[int], list[int]] | None:
+    """Build a padded ``(input_ids, target_ids, loss_mask)`` triple for one example.
+
+    Pure and backend-agnostic (the MLX and torch dataloaders both wrap this). The
+    example is right-truncated to ``seq_len + 1`` tokens when too long (keeping the
+    tail so the completion survives), then split into next-token ``input``/``target``
+    of length ``seq_len`` and padded with ``pad_token_id``. The loss mask is the
+    completion-only mask with padding positions zeroed. Returns ``None`` for
+    sequences too short to form a single (input, target) pair.
+    """
+    if len(tokens) < 2:
+        return None
+    if len(tokens) > seq_len + 1:
+        tokens = tokens[-(seq_len + 1) :]
+    mask = completion_loss_mask(tokens, strategy_token_id=strategy_token_id)
+    input_ids = tokens[:-1]
+    target_ids = tokens[1:]
+    pad = seq_len - len(input_ids)
+    if pad > 0:
+        input_ids = input_ids + [pad_token_id] * pad
+        target_ids = target_ids + [pad_token_id] * pad
+        mask = mask + [0] * pad
+    return input_ids, target_ids, mask
+
+
 @dataclass(frozen=True, slots=True)
 class TrainingExample:
     """A training record reduced to the fields that define its token sequence.

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -188,14 +188,23 @@ if HAS_MLX:
             h = self.norm(h)
             return self.head(h)
 
-    def compute_loss(model: GPTModel, x: Any, y: Any) -> Any:
-        """Cross-entropy loss for next-token prediction."""
+    def compute_loss(model: GPTModel, x: Any, y: Any, loss_mask: Any = None) -> Any:
+        """Cross-entropy loss for next-token prediction.
+
+        When ``loss_mask`` is provided (same shape as ``y``, 1.0 = train / 0.0 =
+        ignore) the loss is averaged over only the unmasked positions, giving the
+        completion-only objective. With ``loss_mask=None`` it averages over all
+        positions (legacy behavior; keeps existing callers byte-identical).
+        """
         logits = model(x)
-        # Reshape for cross entropy: [batch*seq, vocab]
         batch, seq_len, vocab = logits.shape
         logits_flat = logits.reshape(-1, vocab)
         targets_flat = y.reshape(-1)
-        return mx.mean(nn.losses.cross_entropy(logits_flat, targets_flat))
+        per_token = nn.losses.cross_entropy(logits_flat, targets_flat)
+        if loss_mask is None:
+            return mx.mean(per_token)
+        mask_flat = loss_mask.reshape(-1)
+        return (per_token * mask_flat).sum() / mx.maximum(mask_flat.sum(), 1.0)
 
     def save_checkpoint(model: GPTModel, path: Path) -> None:
         """Save model weights to safetensors format."""
@@ -438,14 +447,16 @@ def _run_mlx_training(
         from prepare import (  # type: ignore[import-not-found]
             TrainingExample,
             assess_strategy_quality,
-            create_dataloader,
+            build_special_tokens,
+            iter_masked_batches,
             train_tokenizer,
         )
     except ImportError:
         from autocontext.training.autoresearch.prepare import (
             TrainingExample,
             assess_strategy_quality,
-            create_dataloader,
+            build_special_tokens,
+            iter_masked_batches,
             train_tokenizer,
         )
 
@@ -458,11 +469,22 @@ def _run_mlx_training(
     corpus_path.write_text(_build_corpus(records), encoding="utf-8")
     tokenizer = train_tokenizer(corpus_path)
 
-    token_ids: list[int] = []
-    for record in records:
-        token_ids.extend(tokenizer.encode(TrainingExample.from_record(record).to_sequence()))
-
-    batches = list(create_dataloader(token_ids, seq_len=seq_len, batch_size=batch_size))
+    # Per-example, completion-masked sequences: loss is computed only on the strategy
+    # completion (tokens after <|strategy|>), examples do not pack across document
+    # boundaries, and no tail is dropped.
+    sequences = [tokenizer.encode(TrainingExample.from_record(record).to_sequence()) for record in records]
+    base_vocab = int(getattr(tokenizer, "base_vocab_size", BASE_VOCAB_SIZE))
+    strategy_token_id = build_special_tokens(base_vocab)["<|strategy|>"]
+    pad_token_id = getattr(tokenizer, "end_token_id", 0) or 0
+    batches = list(
+        iter_masked_batches(
+            sequences,
+            seq_len=seq_len,
+            batch_size=batch_size,
+            pad_token_id=pad_token_id,
+            strategy_token_id=strategy_token_id,
+        )
+    )
     if not batches:
         raise ValueError("not enough tokenized training data for a single batch")
 
@@ -477,8 +499,8 @@ def _run_mlx_training(
     for step in range(train_steps):
         if time.perf_counter() >= deadline:
             break
-        x, y = batches[step % len(batches)]
-        loss, grads = loss_and_grad(model, x, y)
+        x, y, loss_mask = batches[step % len(batches)]
+        loss, grads = loss_and_grad(model, x, y, loss_mask)
         optimizer.update(model, grads)
         mx.eval(model.parameters(), optimizer.state, loss)  # noqa: S307
         steps_completed += 1

--- a/autocontext/tests/test_sequence_format.py
+++ b/autocontext/tests/test_sequence_format.py
@@ -120,6 +120,62 @@ def test_training_example_defaults_missing_context() -> None:
     assert ex.context == json.dumps({}, sort_keys=True)
 
 
+def test_completion_loss_mask_trains_only_after_strategy() -> None:
+    from autocontext.training.autoresearch.sequence_format import completion_loss_mask
+
+    # tokens: [A, <strat>, B, C] with strategy id = 99
+    # targets (token_ids[1:]) = [<strat>, B, C]; only B, C are completion targets
+    mask = completion_loss_mask([5, 99, 7, 8], strategy_token_id=99)
+    assert mask == [0, 1, 1]
+
+
+def test_completion_loss_mask_all_ones_when_strategy_absent() -> None:
+    from autocontext.training.autoresearch.sequence_format import completion_loss_mask
+
+    assert completion_loss_mask([1, 2, 3, 4], strategy_token_id=99) == [1, 1, 1]
+
+
+def test_completion_loss_mask_short_sequences() -> None:
+    from autocontext.training.autoresearch.sequence_format import completion_loss_mask
+
+    assert completion_loss_mask([], strategy_token_id=99) == []
+    assert completion_loss_mask([99], strategy_token_id=99) == []
+
+
+def test_build_masked_example_no_pad() -> None:
+    from autocontext.training.autoresearch.sequence_format import build_masked_example
+
+    # tokens [A, <strat>=99, B, C], seq_len 3 -> exactly fills, no padding
+    x, y, mask = build_masked_example([5, 99, 7, 8], seq_len=3, pad_token_id=0, strategy_token_id=99)
+    assert x == [5, 99, 7]
+    assert y == [99, 7, 8]
+    assert mask == [0, 1, 1]  # train only on completion targets
+
+
+def test_build_masked_example_pads_and_masks_padding() -> None:
+    from autocontext.training.autoresearch.sequence_format import build_masked_example
+
+    x, y, mask = build_masked_example([5, 99, 7], seq_len=4, pad_token_id=0, strategy_token_id=99)
+    assert x == [5, 99, 0, 0]
+    assert y == [99, 7, 0, 0]
+    assert mask == [0, 1, 0, 0]  # prompt (0) + completion (1) + padding (0,0)
+
+
+def test_build_masked_example_truncates_keeping_tail() -> None:
+    from autocontext.training.autoresearch.sequence_format import build_masked_example
+
+    # 6 tokens, seq_len 3 -> keep last seq_len+1 = 4 tokens
+    x, y, mask = build_masked_example([1, 2, 3, 99, 5, 6], seq_len=3, pad_token_id=0, strategy_token_id=99)
+    assert len(x) == 3 and len(y) == 3 and len(mask) == 3
+    assert x == [3, 99, 5] and y == [99, 5, 6]
+
+
+def test_build_masked_example_too_short_returns_none() -> None:
+    from autocontext.training.autoresearch.sequence_format import build_masked_example
+
+    assert build_masked_example([7], seq_len=4, pad_token_id=0, strategy_token_id=99) is None
+
+
 def test_cuda_uses_shared_contract_no_duplicate_definitions() -> None:
     """cuda.py must not redefine the parser/resolvers; it consumes sequence_format."""
     import inspect

--- a/autocontext/tests/test_train_mlx.py
+++ b/autocontext/tests/test_train_mlx.py
@@ -100,6 +100,54 @@ def test_summary_block_format() -> None:
     assert "0.75" in summary or "0.7500" in summary
 
 
+def test_iter_masked_batches_shapes_mask_and_no_tail_drop() -> None:
+    """iter_masked_batches yields (x, y, mask) per-example, pads, and drops no example."""
+    from autocontext.training.autoresearch.prepare import iter_masked_batches
+
+    strat = 99
+    # 3 examples -> with batch_size 2 we expect 2 batches (sizes 2 and 1): nothing dropped
+    sequences = [
+        [1, strat, 2, 3],
+        [4, strat, 5],
+        [6, strat, 7, 8, 9],
+    ]
+    batches = list(iter_masked_batches(sequences, seq_len=4, batch_size=2, pad_token_id=0, strategy_token_id=strat))
+    assert len(batches) == 2
+    x0, y0, m0 = batches[0]
+    assert x0.shape == (2, 4) and y0.shape == (2, 4) and m0.shape == (2, 4)
+    assert batches[1][0].shape[0] == 1  # last partial batch kept, not dropped
+    # mask is 0 on the prompt token(s) before the strategy token, 1 after
+    import mlx.core as mx  # type: ignore[import-not-found]
+
+    assert m0[0].tolist() == [0.0, 1.0, 1.0, 0.0]  # [prompt, comp, comp, pad]
+    assert mx.sum(m0).item() > 0
+
+
+def test_compute_loss_mask_ignores_masked_positions() -> None:
+    """Masked compute_loss equals the loss over only the unmasked positions."""
+    import mlx.core as mx  # type: ignore[import-not-found]
+
+    from autocontext.training.autoresearch.train import GPTModel, ModelConfig, compute_loss
+
+    cfg = ModelConfig()
+    model = GPTModel(cfg)
+    x = mx.zeros((1, 4), dtype=mx.int32)
+    y = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+
+    # all-ones mask must equal the unmasked mean loss
+    ones = mx.ones((1, 4), dtype=mx.float32)
+    masked_all = compute_loss(model, x, y, ones)
+    unmasked = compute_loss(model, x, y)
+    mx.eval(masked_all, unmasked)  # noqa: S307
+    assert abs(masked_all.item() - unmasked.item()) < 1e-4
+
+    # masking out 3 of 4 positions changes the value (only one target counts)
+    partial = mx.array([[0.0, 1.0, 0.0, 0.0]], dtype=mx.float32)
+    masked_partial = compute_loss(model, x, y, partial)
+    mx.eval(masked_partial)  # noqa: S307
+    assert masked_partial.item() >= 0.0
+
+
 def test_run_training_mlx_end_to_end_smoke(tmp_path: str) -> None:
     """run_training(backend='mlx') runs the full pipeline via the package import path.
 


### PR DESCRIPTION
PR2 of the data->training pipeline series (builds on the #1027 sequence-format seam). Replaces the flat cross-document token packing with per-example, completion-masked batching.

## Problem
The old path concatenated all examples into one token stream, then `create_dataloader` (a) **dropped the tail** (`usable_seqs = (total_seqs // batch_size) * batch_size`), (b) **packed across example boundaries** with no separator (the model learned to predict across unrelated examples), and `compute_loss` trained on **every token** including the scenario/context prompt.

## Change (frontier-aligned)
- **Completion-only loss** (cf. TRL `DataCollatorForCompletionOnlyLM`): loss is computed only on targets after `<|strategy|>`; the prompt is masked out.
- **Document-boundary packing, no tail drop** (cf. Llama/OLMo): one example per row, right-truncated keeping the tail so the completion survives, padded to `seq_len`; the final partial batch is kept.
- Pure, backend-agnostic core in `sequence_format`: `completion_loss_mask` + `build_masked_example`, reused by both the MLX loader (`prepare.iter_masked_batches`) and the CUDA loader (`_create_torch_masked_dataloader`).
- `compute_loss` gains an optional `loss_mask` (averages over unmasked positions). `loss_mask=None` preserves the legacy all-token mean, so existing callers/tests are byte-identical.

## Tests
- Pure: `completion_loss_mask` (train only after `<|strategy|>`, all-ones fallback, short seqs) and `build_masked_example` (pad+mask padding, truncate-keeping-tail, too-short -> None).
- MLX: `iter_masked_batches` shapes + mask layout + **no tail drop** (3 examples, batch_size 2 -> 2 batches, last size 1); masked `compute_loss` (all-ones mask == legacy mean; partial mask differs).
- The existing end-to-end `run_training(backend="mlx")` smoke exercises the new path end to end.
- ruff + mypy clean; all affected autoresearch/training tests pass.

TS parity: N/A (TS training is orchestration only).