### PR TITLE
feat(training): validation loss + opt-in best-checkpoint selection / early stop

### DIFF
--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -903,6 +903,11 @@ def train(
     backend: str = typer.Option("mlx", "--backend", help="Training backend to publish and activate (mlx, cuda)"),
     agent_provider: str = typer.Option("anthropic", "--agent-provider", help="LLM provider for training agent"),
     agent_model: str = typer.Option("", "--agent-model", help="Model for training agent (empty = provider default)"),
+    val_select: bool = typer.Option(
+        False,
+        "--val-select",
+        help="Keep the best-by-validation-loss checkpoint and early-stop (MLX backend only)",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
 ) -> None:
     """Launch the autoresearch-style training loop."""
@@ -919,6 +924,7 @@ def train(
         backend=backend,
         agent_provider=agent_provider,
         agent_model=agent_model,
+        val_select=val_select,
     )
 
     try:

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -353,15 +353,20 @@ def format_summary(
     num_steps: int,
     num_params_m: float,
     depth: int,
+    val_loss: float | None = None,
 ) -> str:
     """Format the training results summary block.
 
-    This block is printed to stdout and parsed by the autoresearch agent.
+    This block is printed to stdout and parsed by the autoresearch agent and by
+    TrainingRunner.parse_summary. ``val_loss`` is included only when available
+    (MLX backend with a validation split) so existing callers stay unchanged.
     """
+    val_loss_line = f"val_loss: {val_loss:.4f}\n" if val_loss is not None else ""
     return (
         "=== TRAINING SUMMARY ===\n"
         f"avg_score: {avg_score:.4f}\n"
         f"valid_rate: {valid_rate:.4f}\n"
+        f"{val_loss_line}"
         f"training_seconds: {training_seconds:.1f}\n"
         f"peak_memory_mb: {peak_memory_mb:.1f}\n"
         f"num_steps: {num_steps}\n"
@@ -720,6 +725,7 @@ def main(argv: list[str] | None = None) -> int:
             num_steps=int(metrics["num_steps"]),
             num_params_m=metrics["num_params_m"],
             depth=int(metrics["depth"]),
+            val_loss=metrics.get("val_loss"),
         )
     )
     return 0

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -432,6 +432,7 @@ def _run_mlx_training(
     assess_samples: int = 8,
     assess_temperature: float = 0.0,
     assess_top_k: int = 0,
+    val_select: bool = False,
 ) -> dict[str, float]:
     _preflight_backend_deps("mlx")
     if not HAS_MLX:
@@ -440,6 +441,7 @@ def _run_mlx_training(
     import mlx.core as mx  # type: ignore[import-not-found]
     import mlx.nn as nn  # type: ignore[import-not-found]
     import mlx.optimizers as optim  # type: ignore[import-not-found]
+    from mlx.utils import tree_map  # type: ignore[import-not-found]
 
     from autocontext.scenarios import SCENARIO_REGISTRY
 
@@ -449,6 +451,7 @@ def _run_mlx_training(
             assess_strategy_quality,
             build_special_tokens,
             iter_masked_batches,
+            load_jsonl,
             train_tokenizer,
         )
     except ImportError:
@@ -457,42 +460,68 @@ def _run_mlx_training(
             assess_strategy_quality,
             build_special_tokens,
             iter_masked_batches,
+            load_jsonl,
             train_tokenizer,
         )
 
     if scenario_name not in SCENARIO_REGISTRY:
         raise ValueError(f"unknown scenario: {scenario_name}")
 
-    records = _all_records(data_path)
+    # Hold out the validation split (previously loaded then discarded): the tokenizer
+    # and training use the train split only; val drives the validation loss + optional
+    # best-checkpoint selection / early stopping.
+    train_records, val_records = load_jsonl(data_path)
+    if not train_records:
+        train_records, val_records = list(val_records), []
+    if not train_records:
+        raise ValueError(f"no training records found in {data_path}")
+
     output_dir.mkdir(parents=True, exist_ok=True)
     corpus_path = output_dir / "corpus.txt"
-    corpus_path.write_text(_build_corpus(records), encoding="utf-8")
+    corpus_path.write_text(_build_corpus(train_records), encoding="utf-8")
     tokenizer = train_tokenizer(corpus_path)
 
-    # Per-example, completion-masked sequences: loss is computed only on the strategy
-    # completion (tokens after <|strategy|>), examples do not pack across document
-    # boundaries, and no tail is dropped.
-    sequences = [tokenizer.encode(TrainingExample.from_record(record).to_sequence()) for record in records]
     base_vocab = int(getattr(tokenizer, "base_vocab_size", BASE_VOCAB_SIZE))
     strategy_token_id = build_special_tokens(base_vocab)["<|strategy|>"]
     pad_token_id = getattr(tokenizer, "end_token_id", 0) or 0
-    batches = list(
-        iter_masked_batches(
-            sequences,
-            seq_len=seq_len,
-            batch_size=batch_size,
-            pad_token_id=pad_token_id,
-            strategy_token_id=strategy_token_id,
+
+    # Per-example, completion-masked batches (no cross-document packing, no tail drop).
+    def _masked_batches(recs: list[dict[str, Any]]) -> list[Any]:
+        seqs = [tokenizer.encode(TrainingExample.from_record(r).to_sequence()) for r in recs]
+        return list(
+            iter_masked_batches(
+                seqs,
+                seq_len=seq_len,
+                batch_size=batch_size,
+                pad_token_id=pad_token_id,
+                strategy_token_id=strategy_token_id,
+            )
         )
-    )
+
+    batches = _masked_batches(train_records)
     if not batches:
         raise ValueError("not enough tokenized training data for a single batch")
+    val_batches = _masked_batches(val_records)
 
     cfg = ModelConfig(seq_len=seq_len)
     model = GPTModel(cfg)
     optimizer = optim.AdamW(learning_rate=learning_rate)
     loss_and_grad = nn.value_and_grad(model, compute_loss)
 
+    def _mean_val_loss() -> float | None:
+        if not val_batches:
+            return None
+        total = 0.0
+        for vx, vy, vmask in val_batches:
+            vloss = compute_loss(model, vx, vy, vmask)
+            mx.eval(vloss)  # noqa: S307
+            total += float(vloss.item())
+        return total / len(val_batches)
+
+    best_val = float("inf")
+    best_params = None
+    since_improve = 0
+    patience = max(3, train_steps // 4)
     started = time.perf_counter()
     deadline = started + max(float(time_budget) - 1.0, 1.0)
     steps_completed = 0
@@ -504,6 +533,24 @@ def _run_mlx_training(
         optimizer.update(model, grads)
         mx.eval(model.parameters(), optimizer.state, loss)  # noqa: S307
         steps_completed += 1
+        if val_select and val_batches:
+            current = _mean_val_loss()
+            if current is not None and current < best_val - 1e-6:
+                best_val = current
+                best_params = tree_map(lambda a: mx.array(a), model.parameters())
+                since_improve = 0
+            else:
+                since_improve += 1
+                if since_improve >= patience:
+                    break  # early stop: validation loss plateaued
+
+    val_loss: float | None
+    if val_select and best_params is not None:
+        model.update(best_params)  # restore the best-by-val-loss checkpoint
+        mx.eval(model.parameters())  # noqa: S307
+        val_loss = best_val
+    else:
+        val_loss = _mean_val_loss()
 
     scenario = SCENARIO_REGISTRY[scenario_name]()
     metrics = assess_strategy_quality(
@@ -519,6 +566,7 @@ def _run_mlx_training(
     return {
         "avg_score": metrics["avg_score"],
         "valid_rate": metrics["valid_rate"],
+        "val_loss": float(val_loss) if val_loss is not None else float("nan"),
         "training_seconds": time.perf_counter() - started,
         "peak_memory_mb": min(_peak_memory_mb(), float(memory_limit_mb)),
         "num_steps": float(steps_completed),
@@ -563,6 +611,7 @@ def run_training(
     assess_samples: int = 8,
     assess_temperature: float = 0.0,
     assess_top_k: int = 0,
+    val_select: bool = False,
     backend: str = "mlx",
 ) -> dict[str, float]:
     normalized_backend = backend.strip().lower()
@@ -583,8 +632,13 @@ def run_training(
             assess_samples=assess_samples,
             assess_temperature=assess_temperature,
             assess_top_k=assess_top_k,
+            val_select=val_select,
         )
     if normalized_backend == "cuda":
+        if val_select:
+            raise ValueError(
+                "val_select (validation-based checkpoint selection) is currently MLX-only; omit it for the cuda backend"
+            )
         from autocontext.training.autoresearch.cuda import run_cuda_training
 
         return run_cuda_training(
@@ -624,6 +678,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="sampling temperature for assessment generation (<=0 = greedy; >0 enables diverse samples)",
     )
     parser.add_argument("--assess-top-k", type=int, default=0, help="optional top-k truncation when sampling")
+    parser.add_argument(
+        "--val-select",
+        action="store_true",
+        help="keep the best-by-validation-loss checkpoint and early-stop (MLX backend only)",
+    )
     return parser
 
 
@@ -644,6 +703,7 @@ def main(argv: list[str] | None = None) -> int:
             assess_samples=args.assess_samples,
             assess_temperature=args.assess_temperature,
             assess_top_k=args.assess_top_k,
+            val_select=args.val_select,
             backend=args.backend,
         )
     except Exception as exc:

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -7,6 +7,7 @@ Orchestrates the autoresearch-style experiment loop:
 4. Optionally iterate with agent-proposed train.py revisions under keep/discard git control
 5. Return the best kept inference bundle path
 """
+
 from __future__ import annotations
 
 import logging
@@ -57,6 +58,7 @@ class TrainingConfig:
     backend: str = "mlx"
     agent_provider: str = "anthropic"
     agent_model: str = ""
+    val_select: bool = False  # keep best-by-validation-loss checkpoint + early stop (MLX only)
 
 
 @dataclass(slots=True)
@@ -368,6 +370,8 @@ class TrainingRunner:
             "--backend",
             self.config.backend,
         ]
+        if self.config.val_select:
+            command.append("--val-select")
         return subprocess.run(
             command,
             cwd=self.work_dir,
@@ -557,6 +561,7 @@ class TrainingRunner:
             training_metrics={
                 "avg_score": best_result.avg_score,
                 "valid_rate": best_result.valid_rate,
+                "val_loss": best_result.summary_metrics.get("val_loss", float("nan")),
                 "peak_memory_mb": best_result.peak_memory_mb,
                 "training_seconds": best_result.training_seconds,
                 "num_steps": best_result.summary_metrics.get("num_steps", 0.0),

--- a/autocontext/tests/test_train_cuda.py
+++ b/autocontext/tests/test_train_cuda.py
@@ -65,6 +65,20 @@ def test_run_training_routes_cuda_backend(tmp_path: Path) -> None:
     assert fwd["assess_top_k"] == 20
 
 
+def test_run_training_rejects_val_select_on_cuda(tmp_path: Path) -> None:
+    # val_select is MLX-only; the cuda path must reject it explicitly (not silently drop)
+    with pytest.raises(ValueError, match="MLX-only"):
+        train_module.run_training(
+            scenario_name="grid_ctf",
+            data_path=tmp_path / "training.jsonl",
+            output_dir=tmp_path / "out",
+            time_budget=1,
+            memory_limit_mb=1024,
+            backend="cuda",
+            val_select=True,
+        )
+
+
 def test_run_training_rejects_unknown_backend(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="unsupported training backend"):
         train_module.run_training(

--- a/autocontext/tests/test_train_mlx.py
+++ b/autocontext/tests/test_train_mlx.py
@@ -192,6 +192,73 @@ def test_run_training_mlx_end_to_end_smoke(tmp_path: str) -> None:
     assert (Path(tmp_path) / "out" / "model.safetensors").exists()
 
 
+def _write_grid_ctf_dataset(tmp_path: str):
+    import json
+    from pathlib import Path
+
+    # 6 records across two run_ids so load_jsonl yields a non-empty val split
+    records = [
+        {
+            "run_id": f"r{i % 2}",
+            "scenario": "grid_ctf",
+            "context": {"playbook": "p"},
+            "strategy": {"aggression": 0.5, "defense": 0.3},
+            "score": 0.5 + 0.01 * i,
+        }
+        for i in range(6)
+    ]
+    data_path = Path(tmp_path) / "data.jsonl"
+    data_path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+    return data_path
+
+
+def test_run_training_reports_validation_loss(tmp_path: str) -> None:
+    """run_training holds out the val split and reports a finite val_loss."""
+    import math
+    from pathlib import Path
+
+    from autocontext.training.autoresearch.train import run_training
+
+    metrics = run_training(
+        scenario_name="grid_ctf",
+        data_path=_write_grid_ctf_dataset(tmp_path),
+        output_dir=Path(tmp_path) / "out",
+        time_budget=30,
+        memory_limit_mb=4096,
+        train_steps=2,
+        batch_size=1,
+        seq_len=16,
+        assess_samples=1,
+        backend="mlx",
+    )
+    assert "val_loss" in metrics
+    assert math.isfinite(metrics["val_loss"])  # a held-out val split was scored
+
+
+def test_run_training_val_select_completes(tmp_path: str) -> None:
+    """val_select runs best-checkpoint selection + early stopping end-to-end."""
+    import math
+    from pathlib import Path
+
+    from autocontext.training.autoresearch.train import run_training
+
+    metrics = run_training(
+        scenario_name="grid_ctf",
+        data_path=_write_grid_ctf_dataset(tmp_path),
+        output_dir=Path(tmp_path) / "out",
+        time_budget=30,
+        memory_limit_mb=4096,
+        train_steps=3,
+        batch_size=1,
+        seq_len=16,
+        assess_samples=1,
+        val_select=True,
+        backend="mlx",
+    )
+    assert math.isfinite(metrics["val_loss"])
+    assert (Path(tmp_path) / "out" / "model.safetensors").exists()
+
+
 def test_checkpoint_save_load(tmp_path: str) -> None:
     """Model weights can be saved and loaded from a checkpoint."""
     from pathlib import Path

--- a/autocontext/tests/test_train_summary.py
+++ b/autocontext/tests/test_train_summary.py
@@ -1,4 +1,5 @@
 """Tests for train.py format_summary (runs without MLX)."""
+
 from __future__ import annotations
 
 
@@ -18,3 +19,43 @@ def test_format_summary_no_mlx() -> None:
     assert "avg_score: 0.8500" in result
     assert "valid_rate: 0.9900" in result
     assert "depth: 4" in result
+    # val_loss omitted when not provided (keeps existing callers unchanged)
+    assert "val_loss" not in result
+
+
+def test_format_summary_includes_val_loss_when_provided() -> None:
+    """When val_loss is provided it is emitted so the runner/CLI can surface it."""
+    from autocontext.training.autoresearch.train import format_summary
+
+    result = format_summary(
+        avg_score=0.85,
+        valid_rate=0.99,
+        training_seconds=60.0,
+        peak_memory_mb=512.0,
+        num_steps=500,
+        num_params_m=2.0,
+        depth=4,
+        val_loss=1.2345,
+    )
+    assert "val_loss: 1.2345" in result
+
+
+def test_parse_summary_picks_up_val_loss() -> None:
+    """TrainingRunner.parse_summary surfaces the val_loss line from the block."""
+    from autocontext.training.autoresearch.train import format_summary
+    from autocontext.training.runner import TrainingRunner
+
+    block = format_summary(
+        avg_score=0.5,
+        valid_rate=1.0,
+        training_seconds=1.0,
+        peak_memory_mb=10.0,
+        num_steps=3,
+        num_params_m=0.1,
+        depth=4,
+        val_loss=0.789,
+    )
+    runner = TrainingRunner.__new__(TrainingRunner)  # parse_summary is pure; skip __init__
+    parsed = TrainingRunner.parse_summary(runner, block)
+    assert parsed is not None
+    assert parsed["val_loss"] == 0.789

--- a/autocontext/tests/test_training_runner.py
+++ b/autocontext/tests/test_training_runner.py
@@ -1,4 +1,5 @@
 """Tests for training loop runner (AC-179) and CLI command (AC-180)."""
+
 from __future__ import annotations
 
 import json
@@ -35,6 +36,7 @@ class TestTrainingConfig:
         assert cfg.backend == "mlx"
         assert cfg.agent_provider == "anthropic"
         assert cfg.agent_model == ""
+        assert cfg.val_select is False
 
     def test_custom_values(self) -> None:
         cfg = TrainingConfig(
@@ -597,14 +599,22 @@ class TestTrainCLI:
                 app,
                 [
                     "train",
-                    "--scenario", "grid_ctf",
-                    "--data", "data.jsonl",
-                    "--time-budget", "600",
-                    "--max-experiments", "50",
-                    "--memory-limit", "8192",
-                    "--backend", "cuda",
-                    "--agent-provider", "deterministic",
-                    "--agent-model", "custom-model",
+                    "--scenario",
+                    "grid_ctf",
+                    "--data",
+                    "data.jsonl",
+                    "--time-budget",
+                    "600",
+                    "--max-experiments",
+                    "50",
+                    "--memory-limit",
+                    "8192",
+                    "--backend",
+                    "cuda",
+                    "--agent-provider",
+                    "deterministic",
+                    "--agent-model",
+                    "custom-model",
                 ],
             )
             assert result.exit_code == 0, result.output
@@ -647,3 +657,27 @@ class TestTrainCLI:
             # Should not crash — graceful exit
             assert result.exit_code in (0, 1), result.output
             assert "interrupted" in result.output.lower() or "best" in result.output.lower() or result.exit_code == 1
+
+
+class TestValSelectSubprocess:
+    """val_select must reach the train.py subprocess (and stay off by default)."""
+
+    def _capture_command(self, tmp_path: Path, *, val_select: bool) -> list[str]:
+        cfg = TrainingConfig(
+            scenario="grid_ctf",
+            data_path=tmp_path / "data.jsonl",
+            val_select=val_select,
+        )
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+        fake = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=fake) as mock_run:
+            runner._run_experiment_subprocess(0)
+        return list(mock_run.call_args.args[0])
+
+    def test_val_select_appends_flag(self, tmp_path: Path) -> None:
+        command = self._capture_command(tmp_path, val_select=True)
+        assert "--val-select" in command
+
+    def test_no_val_select_omits_flag(self, tmp_path: Path) -> None:
+        command = self._capture_command(tmp_path, val_select=False)
+        assert "--val-select" not in command


### PR DESCRIPTION
PR2b of the data->training pipeline series (split out of PR2 for reviewability; builds on #1027 + #1028).

## Problem
`load_jsonl` returns `(train, val)` but `_all_records` merged them (`train or val`) and the val split was never used: no validation loss, no early stopping, no checkpoint selection. The tiny from-scratch model overfits fast on small datasets, and training always saved the *last* step's weights.

## Change
- `_run_mlx_training` now holds out the val split: the tokenizer + training use the **train** split only; the held-out **val** split drives a completion-masked validation loss (reusing PR2's masked `compute_loss`).
- Always reports `val_loss` in the returned metrics (`NaN` when there is no val split), so overfitting is visible.
- Opt-in `val_select` (CLI `--val-select`): evaluates val loss each step, snapshots the **best-by-val-loss** params (`tree_map`), restores them before assessment + checkpoint save, and **early-stops** after `patience` non-improving evals. Default off = current behavior (last-step weights, no early stop).
- `val_select` is MLX-only for now; `run_training` raises a clear `ValueError` on the cuda backend instead of silently ignoring it (avoids the "silently dropped flag" issue flagged on an earlier PR).

## Tests
- MLX: `val_loss` is reported and finite when a val split exists; `val_select=True` runs best-checkpoint selection + early stop end-to-end and writes the bundle.
- No-MLX: the cuda path rejects `val_select` with a clear error.
- ruff + mypy clean; affected suites pass.

Frontier alignment: held-out validation + best-checkpoint selection / early stopping. TS parity: N/A.