### PR TITLE
feat(training): data selection - elite top-k + dedup (record curation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - autoresearch generation sampling controls. `assess_strategy_quality` and the local-training generator (`prepare._generate_strategy_text`) now accept `temperature`, `top_k`, and a per-sample seed, threaded through `run_training` / `_run_mlx_training` and exposed as `--assess-temperature` / `--assess-top-k` on the train CLI. The default is `temperature=0.0` (greedy and deterministic, byte-identical to prior behavior), so diverse assessment is opt-in: pass a positive temperature to draw varied samples and let the oracle measure generation diversity. The CUDA backend (`run_cuda_training`) threads the same controls through its torch generator for parity.
+- autoresearch training-data pipeline improvements (all opt-in; defaults reproduce prior behavior):
+  - Completion-only loss + document-boundary packing: loss is computed only on the strategy completion (tokens after `<|strategy|>`), examples are batched per-document with no cross-example contamination, and the final partial batch is no longer dropped.
+  - Held-out validation: `autoctx train` reports a `val_loss`, and `--val-select` keeps the best-by-validation-loss checkpoint and early-stops (MLX backend only).
+  - Record curation: `--elite-fraction <0-1]` trains on only the top fraction of records by score, `--dedupe` drops duplicate constructions (keeping the highest-scoring representative), and `--dedupe-near-threshold <0-1]` additionally removes near-duplicates by character-shingle similarity. Out-of-range values are rejected before training; the published model artifact records the curation settings plus raw and curated record counts. See `docs/mlx-training.md`.
 
 ### Fixed
 

--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -8,13 +8,13 @@ Docker containers on macOS run inside a Linux VM and cannot access Metal. The ML
 
 ## Prerequisites
 
-| Component | Version | Install |
-|-----------|---------|---------|
-| Apple Silicon Mac | M1/M2/M3/M4 | - |
-| macOS | Tahoe (26.x) or later | - |
-| Homebrew | Latest | [brew.sh](https://brew.sh) |
-| Python | 3.12+ | `brew install python@3.12` |
-| uv | 0.10+ | `brew install uv` |
+| Component         | Version               | Install                    |
+| ----------------- | --------------------- | -------------------------- |
+| Apple Silicon Mac | M1/M2/M3/M4           | -                          |
+| macOS             | Tahoe (26.x) or later | -                          |
+| Homebrew          | Latest                | [brew.sh](https://brew.sh) |
+| Python            | 3.12+                 | `brew install python@3.12` |
+| uv                | 0.10+                 | `brew install uv`          |
 
 The package requires Python 3.11+, but Homebrew Python 3.12 is the safest host setup for MLX on Apple Silicon.
 
@@ -68,6 +68,34 @@ uv run autoctx train \
 Use absolute paths for `--data`. The CLI resolves relative paths from the current working directory, which may differ from the location that originally produced the training data.
 
 The training loop writes its workspace under `runs/train_<scenario>/` and produces a checkpoint bundle that `MLXProvider` can load for local inference.
+
+### Record curation (optional)
+
+These flags curate the training records before tokenization (defaults are a no-op,
+so omitting them reproduces the previous behavior). Curation is applied to the
+training split only; the held-out validation split is untouched.
+
+| Flag                      | Default | Range    | Effect                                                                                                                                                                       |
+| ------------------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--elite-fraction`        | `1.0`   | `(0, 1]` | Train on only the top fraction of records by score (e.g. `0.25` keeps the best quarter). Rejection-sampling fine-tuning: imitate the best of the distribution, not its mean. |
+| `--dedupe`                | off     | flag     | Drop duplicate constructions (exact by canonical strategy JSON), keeping the highest-scoring representative.                                                                 |
+| `--dedupe-near-threshold` | `1.0`   | `(0, 1]` | With `--dedupe`, also drop near-duplicates at/above this character-shingle Jaccard similarity. `1.0` = exact only; e.g. `0.9` removes near-identical strategies.             |
+
+Out-of-range values are rejected before training starts. Example (train on the
+best 20% with exact + near deduplication, and keep the best-by-validation-loss
+checkpoint):
+
+```bash
+uv run autoctx train \
+  --scenario grid_ctf \
+  --data /absolute/path/to/training/grid_ctf.jsonl \
+  --elite-fraction 0.2 \
+  --dedupe --dedupe-near-threshold 0.9 \
+  --val-select
+```
+
+The published model artifact records the curation settings plus the raw and
+curated record counts (`data_stats`) so a trained model's data split is reproducible.
 
 ## Automating Host Training for Sandboxed Agents
 
@@ -282,6 +310,7 @@ launchctl list com.autocontext.train-watcher
 ```
 
 Also verify that:
+
 - the watched directory exists
 - request files match `request-*.json`
 - the script is executable

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -908,6 +908,17 @@ def train(
         "--val-select",
         help="Keep the best-by-validation-loss checkpoint and early-stop (MLX backend only)",
     ),
+    elite_fraction: float = typer.Option(
+        1.0, "--elite-fraction", help="Train on only the top fraction of records by score (1.0 = all)"
+    ),
+    dedupe: bool = typer.Option(
+        False, "--dedupe", help="Drop duplicate constructions, keeping the highest-scoring representative"
+    ),
+    dedupe_near_threshold: float = typer.Option(
+        1.0,
+        "--dedupe-near-threshold",
+        help="With --dedupe, also drop near-duplicates at/above this similarity (1.0 = exact only)",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
 ) -> None:
     """Launch the autoresearch-style training loop."""
@@ -925,6 +936,9 @@ def train(
         agent_provider=agent_provider,
         agent_model=agent_model,
         val_select=val_select,
+        elite_fraction=elite_fraction,
+        dedupe=dedupe,
+        dedupe_near_threshold=dedupe_near_threshold,
     )
 
     try:

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -924,6 +924,12 @@ def train(
     """Launch the autoresearch-style training loop."""
     from autocontext.training.runner import TrainingConfig
 
+    # Fail fast on out-of-range curation values before any workspace/subprocess setup.
+    if not 0.0 < elite_fraction <= 1.0:
+        raise typer.BadParameter(f"--elite-fraction must be in (0, 1], got {elite_fraction}")
+    if not 0.0 < dedupe_near_threshold <= 1.0:
+        raise typer.BadParameter(f"--dedupe-near-threshold must be in (0, 1], got {dedupe_near_threshold}")
+
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 
     config = TrainingConfig(

--- a/autocontext/src/autocontext/training/autoresearch/cuda.py
+++ b/autocontext/src/autocontext/training/autoresearch/cuda.py
@@ -262,7 +262,11 @@ def run_cuda_training(
     assess_samples: int = 8,
     assess_temperature: float = 0.0,
     assess_top_k: int = 0,
+    elite_fraction: float = 1.0,
+    dedupe: bool = False,
+    dedupe_near_threshold: float = 1.0,
 ) -> dict[str, float]:
+    from autocontext.training.autoresearch.data_selection import curate_records
     from autocontext.training.autoresearch.train import _preflight_backend_deps
 
     _preflight_backend_deps("cuda")
@@ -280,7 +284,12 @@ def run_cuda_training(
     if scenario_name not in SCENARIO_REGISTRY:
         raise ValueError(f"unknown scenario: {scenario_name}")
 
-    records = _all_records(data_path)
+    records = curate_records(
+        _all_records(data_path),
+        elite_fraction=elite_fraction,
+        dedupe=dedupe,
+        near_threshold=dedupe_near_threshold,
+    )
     output_dir.mkdir(parents=True, exist_ok=True)
     corpus_path = output_dir / "corpus.txt"
     corpus_path.write_text(_build_corpus(records), encoding="utf-8")

--- a/autocontext/src/autocontext/training/autoresearch/cuda.py
+++ b/autocontext/src/autocontext/training/autoresearch/cuda.py
@@ -366,6 +366,7 @@ def run_cuda_training(
         "training_seconds": time.perf_counter() - started,
         "peak_memory_mb": min(peak_memory_mb, float(memory_limit_mb)),
         "num_steps": float(steps_completed),
+        "num_records": float(len(records)),  # records used after curation
         "num_params_m": _count_torch_params_million(model),
         "depth": float(cfg.depth),
     }

--- a/autocontext/src/autocontext/training/autoresearch/data_selection.py
+++ b/autocontext/src/autocontext/training/autoresearch/data_selection.py
@@ -1,0 +1,112 @@
+"""Training-data curation for autoresearch (pure domain, no MLX/torch).
+
+Two record-level transforms applied before tokenization:
+
+- ``dedupe_records`` removes duplicate constructions. Identical strategies inflate
+  the effective dataset and bias the model toward whatever was sampled most often;
+  near-duplicates do the same more subtly. Keeps the highest-scoring representative.
+- ``select_top_fraction`` keeps only the highest-scoring fraction of records
+  (elite filtering). Training the generator on the best constructions is the core
+  move of rejection-sampling fine-tuning / ReST / expert iteration: imitate the
+  top of the distribution rather than its mean.
+
+``curate_records`` composes them (dedupe first, then elite filter). All functions
+are pure and operate on the JSONL record dicts (``strategy`` + ``score`` fields).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Sequence
+from typing import Any
+
+
+def _strategy_key(record: dict[str, Any]) -> str:
+    """Canonical, order-insensitive string for a record's strategy."""
+    return json.dumps(record.get("strategy"), sort_keys=True)
+
+
+def _score(record: dict[str, Any]) -> float:
+    try:
+        return float(record.get("score", 0.0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _shingles(text: str, size: int = 4) -> set[str]:
+    """Character n-gram shingles for cheap near-duplicate detection."""
+    if len(text) <= size:
+        return {text}
+    return {text[i : i + size] for i in range(len(text) - size + 1)}
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union else 0.0
+
+
+def dedupe_records(records: Sequence[dict[str, Any]], *, near_threshold: float = 1.0) -> list[dict[str, Any]]:
+    """Remove duplicate constructions, keeping the highest-scoring representative.
+
+    ``near_threshold == 1.0`` (default) removes only exact duplicates (identical
+    canonical strategy JSON). ``near_threshold < 1.0`` additionally drops records
+    whose strategy shingle-Jaccard similarity to an already-kept record is at least
+    the threshold. Order of survivors follows descending score so the strongest
+    representative of each group is the one retained.
+    """
+    # Sort by score desc so the first record seen for any (near-)duplicate group is
+    # the best one; ties keep original order (stable sort).
+    ordered = sorted(records, key=_score, reverse=True)
+
+    kept: list[dict[str, Any]] = []
+    seen_keys: set[str] = set()
+    kept_shingles: list[set[str]] = []
+    do_near = near_threshold < 1.0
+    for record in ordered:
+        key = _strategy_key(record)
+        if key in seen_keys:
+            continue
+        if do_near:
+            shingles = _shingles(key)
+            if any(_jaccard(shingles, ks) >= near_threshold for ks in kept_shingles):
+                continue
+            kept_shingles.append(shingles)
+        seen_keys.add(key)
+        kept.append(record)
+    return kept
+
+
+def select_top_fraction(records: Sequence[dict[str, Any]], fraction: float) -> list[dict[str, Any]]:
+    """Keep the highest-scoring ``fraction`` of records (at least one).
+
+    ``fraction >= 1.0`` returns all records unchanged (preserving order); otherwise
+    the top ``ceil(n * fraction)`` records by score are returned, highest first.
+    """
+    if fraction >= 1.0:
+        return list(records)
+    n = len(records)
+    if n == 0:
+        return []
+    keep = max(1, math.ceil(n * max(fraction, 0.0)))
+    return sorted(records, key=_score, reverse=True)[:keep]
+
+
+def curate_records(
+    records: Sequence[dict[str, Any]],
+    *,
+    elite_fraction: float = 1.0,
+    dedupe: bool = False,
+    near_threshold: float = 1.0,
+) -> list[dict[str, Any]]:
+    """Dedupe (optional) then elite-filter. No-op when both are at their defaults."""
+    out: list[dict[str, Any]] = list(records)
+    if dedupe:
+        out = dedupe_records(out, near_threshold=near_threshold)
+    out = select_top_fraction(out, elite_fraction)
+    return out

--- a/autocontext/src/autocontext/training/autoresearch/data_selection.py
+++ b/autocontext/src/autocontext/training/autoresearch/data_selection.py
@@ -59,7 +59,12 @@ def dedupe_records(records: Sequence[dict[str, Any]], *, near_threshold: float =
     whose strategy shingle-Jaccard similarity to an already-kept record is at least
     the threshold. Order of survivors follows descending score so the strongest
     representative of each group is the one retained.
+
+    Raises ``ValueError`` for ``near_threshold`` outside ``(0, 1]`` (a threshold of
+    0 would collapse all records to a single representative).
     """
+    if not 0.0 < near_threshold <= 1.0:
+        raise ValueError(f"near_threshold must be in (0, 1], got {near_threshold}")
     # Sort by score desc so the first record seen for any (near-)duplicate group is
     # the best one; ties keep original order (stable sort).
     ordered = sorted(records, key=_score, reverse=True)
@@ -85,15 +90,20 @@ def dedupe_records(records: Sequence[dict[str, Any]], *, near_threshold: float =
 def select_top_fraction(records: Sequence[dict[str, Any]], fraction: float) -> list[dict[str, Any]]:
     """Keep the highest-scoring ``fraction`` of records (at least one).
 
-    ``fraction >= 1.0`` returns all records unchanged (preserving order); otherwise
+    ``fraction == 1.0`` returns all records unchanged (preserving order); otherwise
     the top ``ceil(n * fraction)`` records by score are returned, highest first.
+
+    Raises ``ValueError`` for ``fraction`` outside ``(0, 1]`` rather than clamping
+    (a clamped fraction would silently collapse the dataset to its single top record).
     """
-    if fraction >= 1.0:
+    if not 0.0 < fraction <= 1.0:
+        raise ValueError(f"fraction must be in (0, 1], got {fraction}")
+    if fraction == 1.0:
         return list(records)
     n = len(records)
     if n == 0:
         return []
-    keep = max(1, math.ceil(n * max(fraction, 0.0)))
+    keep = max(1, math.ceil(n * fraction))
     return sorted(records, key=_score, reverse=True)[:keep]
 
 

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from autocontext.training import HAS_MLX
+from autocontext.training.autoresearch.data_selection import curate_records
 from autocontext.training.autoresearch.prepare import BASE_VOCAB_SIZE, save_tokenizer_json, total_vocab_size
 
 logger = logging.getLogger(__name__)
@@ -438,6 +439,9 @@ def _run_mlx_training(
     assess_temperature: float = 0.0,
     assess_top_k: int = 0,
     val_select: bool = False,
+    elite_fraction: float = 1.0,
+    dedupe: bool = False,
+    dedupe_near_threshold: float = 1.0,
 ) -> dict[str, float]:
     _preflight_backend_deps("mlx")
     if not HAS_MLX:
@@ -480,6 +484,15 @@ def _run_mlx_training(
         train_records, val_records = list(val_records), []
     if not train_records:
         raise ValueError(f"no training records found in {data_path}")
+
+    # Curate the TRAIN split only (val stays held out untouched): dedupe duplicate
+    # constructions and keep the highest-scoring elite fraction.
+    train_records = curate_records(
+        train_records,
+        elite_fraction=elite_fraction,
+        dedupe=dedupe,
+        near_threshold=dedupe_near_threshold,
+    )
 
     output_dir.mkdir(parents=True, exist_ok=True)
     corpus_path = output_dir / "corpus.txt"
@@ -617,6 +630,9 @@ def run_training(
     assess_temperature: float = 0.0,
     assess_top_k: int = 0,
     val_select: bool = False,
+    elite_fraction: float = 1.0,
+    dedupe: bool = False,
+    dedupe_near_threshold: float = 1.0,
     backend: str = "mlx",
 ) -> dict[str, float]:
     normalized_backend = backend.strip().lower()
@@ -638,6 +654,9 @@ def run_training(
             assess_temperature=assess_temperature,
             assess_top_k=assess_top_k,
             val_select=val_select,
+            elite_fraction=elite_fraction,
+            dedupe=dedupe,
+            dedupe_near_threshold=dedupe_near_threshold,
         )
     if normalized_backend == "cuda":
         if val_select:
@@ -659,6 +678,9 @@ def run_training(
             assess_samples=assess_samples,
             assess_temperature=assess_temperature,
             assess_top_k=assess_top_k,
+            elite_fraction=elite_fraction,
+            dedupe=dedupe,
+            dedupe_near_threshold=dedupe_near_threshold,
         )
     raise ValueError("unsupported training backend: expected 'mlx' or 'cuda'")
 
@@ -688,6 +710,23 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="keep the best-by-validation-loss checkpoint and early-stop (MLX backend only)",
     )
+    parser.add_argument(
+        "--elite-fraction",
+        type=float,
+        default=1.0,
+        help="train on only the top fraction of records by score (1.0 = all)",
+    )
+    parser.add_argument(
+        "--dedupe",
+        action="store_true",
+        help="drop duplicate constructions, keeping the highest-scoring representative",
+    )
+    parser.add_argument(
+        "--dedupe-near-threshold",
+        type=float,
+        default=1.0,
+        help="with --dedupe, also drop near-duplicates at/above this shingle-Jaccard similarity (1.0 = exact only)",
+    )
     return parser
 
 
@@ -709,6 +748,9 @@ def main(argv: list[str] | None = None) -> int:
             assess_temperature=args.assess_temperature,
             assess_top_k=args.assess_top_k,
             val_select=args.val_select,
+            elite_fraction=args.elite_fraction,
+            dedupe=args.dedupe,
+            dedupe_near_threshold=args.dedupe_near_threshold,
             backend=args.backend,
         )
     except Exception as exc:

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -355,19 +355,22 @@ def format_summary(
     num_params_m: float,
     depth: int,
     val_loss: float | None = None,
+    num_records: float | None = None,
 ) -> str:
     """Format the training results summary block.
 
     This block is printed to stdout and parsed by the autoresearch agent and by
-    TrainingRunner.parse_summary. ``val_loss`` is included only when available
-    (MLX backend with a validation split) so existing callers stay unchanged.
+    TrainingRunner.parse_summary. ``val_loss`` and ``num_records`` are included only
+    when available so existing callers stay unchanged.
     """
     val_loss_line = f"val_loss: {val_loss:.4f}\n" if val_loss is not None else ""
+    num_records_line = f"num_records: {int(num_records)}\n" if num_records is not None else ""
     return (
         "=== TRAINING SUMMARY ===\n"
         f"avg_score: {avg_score:.4f}\n"
         f"valid_rate: {valid_rate:.4f}\n"
         f"{val_loss_line}"
+        f"{num_records_line}"
         f"training_seconds: {training_seconds:.1f}\n"
         f"peak_memory_mb: {peak_memory_mb:.1f}\n"
         f"num_steps: {num_steps}\n"
@@ -588,6 +591,7 @@ def _run_mlx_training(
         "training_seconds": time.perf_counter() - started,
         "peak_memory_mb": min(_peak_memory_mb(), float(memory_limit_mb)),
         "num_steps": float(steps_completed),
+        "num_records": float(len(train_records)),  # records used after curation
         "num_params_m": _count_params_million(model.parameters()),
         "depth": float(cfg.depth),
     }
@@ -635,6 +639,13 @@ def run_training(
     dedupe_near_threshold: float = 1.0,
     backend: str = "mlx",
 ) -> dict[str, float]:
+    # Reject out-of-range curation values before any training work: select_top_fraction
+    # otherwise clamps and silently collapses the dataset to the single top record.
+    if not 0.0 < elite_fraction <= 1.0:
+        raise ValueError(f"elite_fraction must be in (0, 1], got {elite_fraction}")
+    if not 0.0 < dedupe_near_threshold <= 1.0:
+        raise ValueError(f"dedupe_near_threshold must be in (0, 1], got {dedupe_near_threshold}")
+
     normalized_backend = backend.strip().lower()
     # Dependency preflight runs inside each backend entry (_run_mlx_training /
     # run_cuda_training) so routing/dispatch stays importable and unit-testable
@@ -768,6 +779,7 @@ def main(argv: list[str] | None = None) -> int:
             num_params_m=metrics["num_params_m"],
             depth=int(metrics["depth"]),
             val_loss=metrics.get("val_loss"),
+            num_records=metrics.get("num_records"),
         )
     )
     return 0

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -59,6 +59,9 @@ class TrainingConfig:
     agent_provider: str = "anthropic"
     agent_model: str = ""
     val_select: bool = False  # keep best-by-validation-loss checkpoint + early stop (MLX only)
+    elite_fraction: float = 1.0  # train on only the top fraction of records by score (1.0 = all)
+    dedupe: bool = False  # drop duplicate constructions, keeping the highest-scoring representative
+    dedupe_near_threshold: float = 1.0  # with dedupe, also drop near-dups at/above this similarity
 
 
 @dataclass(slots=True)
@@ -372,6 +375,12 @@ class TrainingRunner:
         ]
         if self.config.val_select:
             command.append("--val-select")
+        if self.config.elite_fraction != 1.0:
+            command += ["--elite-fraction", str(self.config.elite_fraction)]
+        if self.config.dedupe:
+            command.append("--dedupe")
+        if self.config.dedupe_near_threshold != 1.0:
+            command += ["--dedupe-near-threshold", str(self.config.dedupe_near_threshold)]
         return subprocess.run(
             command,
             cwd=self.work_dir,

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -539,13 +539,22 @@ class TrainingRunner:
             logger.debug("training.runner: caught Exception", exc_info=True)
             return ""
 
-    def _data_stats(self) -> dict[str, float | str]:
-        stats: dict[str, float | str] = {"data_path": str(self.config.data_path)}
+    def _data_stats(self, best_result: ExperimentResult | None = None) -> dict[str, float | str]:
+        # Record the curation settings (with the raw + curated record counts) so a
+        # published model carries enough provenance to reproduce the training split.
+        stats: dict[str, float | str] = {
+            "data_path": str(self.config.data_path),
+            "elite_fraction": float(self.config.elite_fraction),
+            "dedupe": 1.0 if self.config.dedupe else 0.0,
+            "dedupe_near_threshold": float(self.config.dedupe_near_threshold),
+        }
         try:
             line_count = sum(1 for _ in self.config.data_path.open(encoding="utf-8"))
             stats["records"] = float(line_count)
         except OSError:
             logger.debug("training.runner: suppressed OSError", exc_info=True)
+        if best_result is not None and "num_records" in best_result.summary_metrics:
+            stats["curated_records"] = float(best_result.summary_metrics["num_records"])
         return stats
 
     def _checkpoint_dir(self, experiment_index: int) -> Path:
@@ -576,7 +585,7 @@ class TrainingRunner:
                 "num_steps": best_result.summary_metrics.get("num_steps", 0.0),
                 "depth": best_result.summary_metrics.get("depth", 0.0),
             },
-            data_stats=self._data_stats(),
+            data_stats=self._data_stats(best_result),
             runtime_types=self._backend.supported_runtime_types(),
             metadata={
                 "backend_metadata": self._backend.metadata(),

--- a/autocontext/tests/test_data_selection.py
+++ b/autocontext/tests/test_data_selection.py
@@ -1,0 +1,85 @@
+"""Tests for autoresearch training-data curation (pure; no MLX required)."""
+
+from __future__ import annotations
+
+from autocontext.training.autoresearch.data_selection import (
+    curate_records,
+    dedupe_records,
+    select_top_fraction,
+)
+
+
+def _rec(strategy: dict, score: float, run_id: str = "r0") -> dict:
+    return {"run_id": run_id, "scenario": "s", "context": {}, "strategy": strategy, "score": score}
+
+
+def test_select_top_fraction_keeps_highest_scoring() -> None:
+    records = [_rec({"a": i}, score=i / 10) for i in range(10)]  # scores 0.0..0.9
+    top = select_top_fraction(records, 0.3)  # ceil(10*0.3)=3
+    assert len(top) == 3
+    assert sorted(r["score"] for r in top) == [0.7, 0.8, 0.9]
+
+
+def test_select_top_fraction_full_is_noop_preserving_order() -> None:
+    records = [_rec({"a": 1}, 0.1), _rec({"a": 2}, 0.9)]
+    assert select_top_fraction(records, 1.0) == records
+
+
+def test_select_top_fraction_keeps_at_least_one() -> None:
+    records = [_rec({"a": i}, i) for i in range(5)]
+    assert len(select_top_fraction(records, 0.0)) == 1
+
+
+def test_dedupe_exact_keeps_highest_score() -> None:
+    records = [
+        _rec({"points": [1, 2, 3]}, score=0.4),
+        _rec({"points": [1, 2, 3]}, score=0.9),  # exact dup, higher score
+        _rec({"points": [4, 5, 6]}, score=0.5),
+    ]
+    deduped = dedupe_records(records)
+    assert len(deduped) == 2
+    by_key = {tuple(r["strategy"]["points"]): r["score"] for r in deduped}
+    assert by_key[(1, 2, 3)] == 0.9  # kept the higher-scoring representative
+    assert by_key[(4, 5, 6)] == 0.5
+
+
+def test_dedupe_key_is_order_insensitive_for_json() -> None:
+    # same dict, different key insertion order -> same canonical key -> deduped
+    records = [_rec({"a": 1, "b": 2}, 0.5), _rec({"b": 2, "a": 1}, 0.6)]
+    assert len(dedupe_records(records)) == 1
+
+
+def test_dedupe_near_threshold_removes_near_duplicates() -> None:
+    # two nearly-identical strategies (differ in the last word) + one distinct
+    base = {"plan": "the quick brown fox jumps over the lazy dog near the river bank"}
+    near = {"plan": "the quick brown fox jumps over the lazy dog near the river bend"}
+    distinct = {"plan": "completely unrelated content about mathematics numbers 12345"}
+    records = [_rec(base, 0.5), _rec(near, 0.7), _rec(distinct, 0.6)]
+
+    exact_only = dedupe_records(records, near_threshold=1.0)
+    assert len(exact_only) == 3  # all distinct exactly
+
+    near_deduped = dedupe_records(records, near_threshold=0.6)
+    # base/near collapse to one (the higher-scoring near, 0.7); distinct remains
+    assert len(near_deduped) == 2
+    assert any(r["strategy"] == distinct for r in near_deduped)
+    collapsed = [r for r in near_deduped if r["strategy"] != distinct]
+    assert collapsed[0]["score"] == 0.7
+
+
+def test_curate_composes_dedupe_then_elite() -> None:
+    records = [
+        _rec({"points": [1]}, 0.2),
+        _rec({"points": [1]}, 0.3),  # dup of above
+        _rec({"points": [2]}, 0.9),
+        _rec({"points": [3]}, 0.5),
+    ]
+    out = curate_records(records, elite_fraction=0.5, dedupe=True)
+    # dedupe -> 3 unique ([1]=0.3, [2]=0.9, [3]=0.5); elite 0.5 -> ceil(3*0.5)=2 best
+    assert len(out) == 2
+    assert sorted(r["score"] for r in out) == [0.5, 0.9]
+
+
+def test_curate_default_is_noop() -> None:
+    records = [_rec({"a": 1}, 0.1), _rec({"a": 1}, 0.2)]
+    assert curate_records(records) == records

--- a/autocontext/tests/test_data_selection.py
+++ b/autocontext/tests/test_data_selection.py
@@ -27,7 +27,26 @@ def test_select_top_fraction_full_is_noop_preserving_order() -> None:
 
 def test_select_top_fraction_keeps_at_least_one() -> None:
     records = [_rec({"a": i}, i) for i in range(5)]
-    assert len(select_top_fraction(records, 0.0)) == 1
+    # a valid tiny fraction still keeps at least one record
+    assert len(select_top_fraction(records, 0.01)) == 1
+
+
+def test_select_top_fraction_rejects_out_of_range() -> None:
+    import pytest
+
+    records = [_rec({"a": i}, i) for i in range(5)]
+    for bad in (0.0, -1.0, 1.5):
+        with pytest.raises(ValueError, match="fraction"):
+            select_top_fraction(records, bad)
+
+
+def test_dedupe_rejects_out_of_range_threshold() -> None:
+    import pytest
+
+    records = [_rec({"a": 1}, 0.5)]
+    for bad in (0.0, -0.1, 1.5):
+        with pytest.raises(ValueError, match="near_threshold"):
+            dedupe_records(records, near_threshold=bad)
 
 
 def test_dedupe_exact_keeps_highest_score() -> None:

--- a/autocontext/tests/test_train_cuda.py
+++ b/autocontext/tests/test_train_cuda.py
@@ -79,6 +79,30 @@ def test_run_training_rejects_val_select_on_cuda(tmp_path: Path) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"elite_fraction": 1.5}, "elite_fraction"),
+        ({"elite_fraction": 0.0}, "elite_fraction"),
+        ({"elite_fraction": -1.0}, "elite_fraction"),
+        ({"dedupe_near_threshold": 0.0}, "dedupe_near_threshold"),
+        ({"dedupe_near_threshold": 1.5}, "dedupe_near_threshold"),
+    ],
+)
+def test_run_training_rejects_out_of_range_curation(tmp_path: Path, kwargs: dict, match: str) -> None:
+    # Validation happens before backend dispatch, so this holds without MLX/torch.
+    with pytest.raises(ValueError, match=match):
+        train_module.run_training(
+            scenario_name="grid_ctf",
+            data_path=tmp_path / "training.jsonl",
+            output_dir=tmp_path / "out",
+            time_budget=1,
+            memory_limit_mb=1024,
+            backend="mlx",
+            **kwargs,
+        )
+
+
 def test_run_training_rejects_unknown_backend(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="unsupported training backend"):
         train_module.run_training(

--- a/autocontext/tests/test_training_runner.py
+++ b/autocontext/tests/test_training_runner.py
@@ -681,3 +681,36 @@ class TestValSelectSubprocess:
     def test_no_val_select_omits_flag(self, tmp_path: Path) -> None:
         command = self._capture_command(tmp_path, val_select=False)
         assert "--val-select" not in command
+
+
+class TestCurationSubprocess:
+    """Elite/dedup curation flags must reach the train.py subprocess."""
+
+    def _capture_command(self, tmp_path: Path, **config_kwargs: object) -> list[str]:
+        cfg = TrainingConfig(
+            scenario="grid_ctf",
+            data_path=tmp_path / "data.jsonl",
+            **config_kwargs,
+        )
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+        fake = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=fake) as mock_run:
+            runner._run_experiment_subprocess(0)
+        return list(mock_run.call_args.args[0])
+
+    def test_defaults_omit_curation_flags(self, tmp_path: Path) -> None:
+        command = self._capture_command(tmp_path)
+        assert "--elite-fraction" not in command
+        assert "--dedupe" not in command
+        assert "--dedupe-near-threshold" not in command
+
+    def test_elite_fraction_appended(self, tmp_path: Path) -> None:
+        command = self._capture_command(tmp_path, elite_fraction=0.25)
+        assert "--elite-fraction" in command
+        assert command[command.index("--elite-fraction") + 1] == "0.25"
+
+    def test_dedupe_flags_appended(self, tmp_path: Path) -> None:
+        command = self._capture_command(tmp_path, dedupe=True, dedupe_near_threshold=0.8)
+        assert "--dedupe" in command
+        assert "--dedupe-near-threshold" in command
+        assert command[command.index("--dedupe-near-threshold") + 1] == "0.8"

--- a/autocontext/tests/test_training_runner.py
+++ b/autocontext/tests/test_training_runner.py
@@ -714,3 +714,34 @@ class TestCurationSubprocess:
         assert "--dedupe" in command
         assert "--dedupe-near-threshold" in command
         assert command[command.index("--dedupe-near-threshold") + 1] == "0.8"
+
+
+class TestDataStatsProvenance:
+    """Published data_stats records the curation settings + raw/curated counts."""
+
+    def test_data_stats_includes_curation_settings_and_counts(self, tmp_path: Path) -> None:
+        data_path = tmp_path / "data.jsonl"
+        data_path.write_text("{}\n{}\n{}\n{}\n", encoding="utf-8")  # 4 raw records
+        cfg = TrainingConfig(
+            scenario="grid_ctf",
+            data_path=data_path,
+            elite_fraction=0.5,
+            dedupe=True,
+            dedupe_near_threshold=0.9,
+        )
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+        best = ExperimentResult(
+            experiment_index=0,
+            avg_score=0.5,
+            valid_rate=1.0,
+            peak_memory_mb=1.0,
+            training_seconds=1.0,
+            outcome=ExperimentOutcome.KEPT,
+            summary_metrics={"num_records": 2.0},  # curated count from the subprocess summary
+        )
+        stats = runner._data_stats(best)
+        assert stats["elite_fraction"] == 0.5
+        assert stats["dedupe"] == 1.0
+        assert stats["dedupe_near_threshold"] == 0.9
+        assert stats["records"] == 4.0  # raw JSONL line count
+        assert stats["curated_records"] == 2.0  # records actually used after curation


### PR DESCRIPTION
PR3 of the data->training pipeline series (builds on #1027/#1028/#1029).

## Problem
`_all_records` trained on every record with no curation: identical / near-identical constructions inflate the effective dataset and bias the generator toward over-sampled outputs, and the model imitates the *mean* of the data rather than its best.

## Change
New pure `data_selection` module:
- `dedupe_records` — exact dedup by canonical strategy JSON, optional near-dup removal via character-shingle Jaccard, keeping the highest-scoring representative.
- `select_top_fraction` — keep the highest-scoring elite fraction (rejection-sampling fine-tuning / ReST: imitate the top of the distribution).
- `curate_records` — dedupe then elite-filter; no-op at defaults.

Applied to the **train split only** (val stays held out) in both MLX and CUDA backends, and **plumbed end to end** (the lesson from earlier reviews): `run_training` params → both backends → `train.py` flags (`--elite-fraction` / `--dedupe` / `--dedupe-near-threshold`) → `TrainingConfig` fields → `autoctx train` options → `_run_experiment_subprocess` argv. Defaults are a no-op so existing behavior is unchanged.

## Tests
- Pure: top-k selection, exact + near dedup (highest-score representative), composition, no-op default.
- Runner: subprocess argv contains the curation flags **only when set** (and omits them at defaults).
- ruff + mypy clean; affected suites pass.

Frontier alignment: ReST / RFT elite filtering + duplicate removal. TS parity: N/A.