### PR TITLE
docs: refresh README for 0.6 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 - **CLI contract parity** aligns the Python and TypeScript `autoctx` command surfaces around the shared canonical contract, including capabilities, mission lifecycle commands, queue commands, scenario creation, serve/MCP paths, show/watch, status behavior, and aliases.
 - **Contract probes** add terminal, directory, service, artifact, cleanup, media, and distributed probe families, plus `autoctx probes check` and `autoctx probes extract` for harness verification.
 - **Mission checkpoints** now share a cross-runtime checkpoint contract with collision-free filenames, camelCase/snake_case loader interop, atomic restore behavior, and async-boundary guards.
+<!-- autocontext-whats-new:end -->
 
 ## On main (unreleased)
 
 - **Training pipeline work** adds opt-in teacher-reasoning distillation, sampling controls, MLX-LM fine-tuning, score-conditioned generation, reward-weighted loss, and self-improving local-training loops. These features are on `main` and in [CHANGELOG.md](CHANGELOG.md), but they are not included in the pinned `0.6.0` packages yet.
-<!-- autocontext-whats-new:end -->
 
 ## Choose Your Package
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,20 @@
 
 <!-- autocontext-readme-hero:end -->
 
-Autocontext is a harness. You point it at a goal in plain language. It iterates against real evaluation, keeps what worked, throws out what didn't, and produces a structured trace of the work plus the artifacts, playbooks, datasets, and (optionally) a distilled local model that the next agent inherits. Repeated runs get better, not just different.
+autocontext is a harness. You point it at a goal in plain language. It iterates against real evaluation, keeps what worked, throws out what didn't, and produces a structured trace of the work plus the artifacts, playbooks, datasets, and (optionally) a distilled local model that the next agent inherits. Repeated runs get better, not just different.
+
+**Documentation:** [autocontext.ai/docs](https://autocontext.ai/docs) · [quickstart](https://autocontext.ai/docs/get-started/quickstart) · [CLI reference](https://autocontext.ai/docs/cli/reference) · [changelog](https://autocontext.ai/docs/changelog)
 
 ## Try It In 30 Seconds
 
 The fastest path uses our **Pi runtime**, a local coding agent that handles its own auth. No API key plumbing, no provider config: install Pi, install autocontext, point one at the other.
 
 ```bash
-uv tool install autocontext==0.5.0
+uv tool install autocontext==0.6.0
 
 AUTOCONTEXT_AGENT_PROVIDER=pi \
 AUTOCONTEXT_PI_COMMAND=pi \
-uv run autoctx solve \
+autoctx solve \
   "improve customer-support replies for billing disputes" \
   --iterations 3
 ```
@@ -36,7 +38,7 @@ Pi runs locally as a subprocess and emits live traces back into the harness. For
 Prefer TypeScript? Same surface, same command:
 
 ```bash
-bun add -g autoctx@0.5.0
+bun add -g autoctx@0.6.0
 AUTOCONTEXT_AGENT_PROVIDER=pi bunx autoctx solve \
   "improve customer-support replies for billing disputes" \
   --iterations 5 --json
@@ -47,10 +49,10 @@ Already on Anthropic, OpenAI, Gemini, Mistral, Groq, OpenRouter, Azure, Claude C
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=anthropic \
 ANTHROPIC_API_KEY=sk-ant-... \
-uv run autoctx solve "..." --iterations 3
+autoctx solve "..." --iterations 3
 ```
 
-See [`.env.example`](.env.example) for every provider's variables. Prefer to clone and run a starter? [`examples/README.md`](examples/README.md) has copy-paste recipes for Python CLI, Claude Code MCP, Python SDK, TypeScript library usage, and the experimental TypeScript agent handler surface.
+See [`.env.example`](.env.example) for every provider's variables, or use the live provider guide at [autocontext.ai/docs/providers](https://autocontext.ai/docs/providers). Prefer to clone and run a starter? [`examples/README.md`](examples/README.md) has copy-paste recipes for Python CLI, Claude Code MCP, Python SDK, TypeScript library usage, and the experimental TypeScript agent handler surface.
 
 ## Or Just Talk To Your Agent
 
@@ -59,7 +61,7 @@ If you already work inside a coding agent, you can wire autocontext in once and 
 **Pi** ships an autocontext skill out of the box. Install the published Pi package and Pi loads natural-language wrappers over live tools such as `autocontext_solve_scenario`, `autocontext_evaluate_output`, `autocontext_run_improvement_loop`, `autocontext_run_status`, and `autocontext_list_scenarios`.
 
 ```bash
-pi install npm:pi-autocontext
+pi install npm:pi-autocontext@0.2.5
 ```
 
 Then you just ask:
@@ -89,14 +91,14 @@ After that, Python MCP exposes prefixed tools such as `autocontext_solve_scenari
 ```bash
 cd autocontext
 uv run autoctx hermes export-skill --output ~/.hermes/skills/autocontext/SKILL.md --json
-# Add progressive-disclosure reference files alongside SKILL.md (AC-702)
+# Add progressive-disclosure reference files alongside SKILL.md
 uv run autoctx hermes export-skill \
     --output ~/.hermes/skills/autocontext/SKILL.md \
     --with-references --json
 uv run autoctx hermes inspect --json
 ```
 
-Full integration guide: [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md).
+Full integration guide: [autocontext.ai/docs/agents](https://autocontext.ai/docs/agents) and [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md).
 
 ## What You Get Back
 
@@ -171,11 +173,11 @@ Inside each run, five roles cooperate:
 
 Strategies are evaluated through scenario execution, staged validation, and gating. Weak changes are rolled back. Successful changes accumulate as reusable knowledge that future runs (and future agents) inherit automatically.
 
-The full vocabulary (Scenario, Task, Mission, Campaign, Run, Verifier, Knowledge, Artifact, Budget, Policy) lives in [docs/concept-model.md](docs/concept-model.md).
+The full vocabulary (Scenario, Task, Mission, Campaign, Run, Verifier, Knowledge, Artifact, Budget, Policy) lives in the [concept docs](https://autocontext.ai/docs/concepts) and [docs/concept-model.md](docs/concept-model.md).
 
 ## Capture What's Happening In Production
 
-Autocontext can sit alongside your live application and record what your agents do, then turn that into training data. Wrap your existing Anthropic or OpenAI client once:
+autocontext can sit alongside your live application and record what your agents do, then turn that into training data. Wrap your existing Anthropic or OpenAI client once:
 
 ```python
 from anthropic import Anthropic
@@ -209,12 +211,12 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 ```
 
 <!-- autocontext-whats-new:start -->
-## What's New in 0.5.0
+## What's New in 0.6.0
 
-- **Plain-language CLI continuity** lets Python and TypeScript callers use positional goals/scenarios, `--iterations`, and run-scoped exports while preserving the existing flag forms.
-- **Hermes Agent integration** adds read-only Hermes v0.12 inspection plus an exportable CLI-first `autocontext` skill for Hermes agents.
-- **Packaged CLI startup** no longer crashes when installed without banner assets.
-- **Release alignment** bumps Python `autocontext` and npm `autoctx` to `0.5.0`, with `pi-autocontext` moving to `0.2.4` on its own lower-numbered line.
+- **CLI contract parity** aligns the Python and TypeScript `autoctx` command surfaces around the shared canonical contract, including capabilities, mission lifecycle commands, queue commands, scenario creation, serve/MCP paths, show/watch, status behavior, and aliases.
+- **Contract probes** add terminal, directory, service, artifact, cleanup, media, and distributed probe families, plus `autoctx probes check` and `autoctx probes extract` for harness verification.
+- **Mission checkpoints** now share a cross-runtime checkpoint contract with collision-free filenames, camelCase/snake_case loader interop, atomic restore behavior, and async-boundary guards.
+- **Training pipeline work** on `main` adds opt-in teacher-reasoning distillation, sampling controls, MLX-LM fine-tuning, score-conditioned generation, reward-weighted loss, and self-improving local-training loops. See [CHANGELOG.md](CHANGELOG.md) and [autocontext.ai/docs/changelog](https://autocontext.ai/docs/changelog).
 <!-- autocontext-whats-new:end -->
 
 ## Choose Your Package
@@ -229,14 +231,14 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 
 ```bash
 # Python: library or CLI tool
-uv pip install autocontext==0.5.0
-uv tool install autocontext==0.5.0
+uv pip install autocontext==0.6.0
+uv tool install autocontext==0.6.0
 
 # TypeScript
-bun add -g autoctx@0.5.0
+bun add -g autoctx@0.6.0
 
 # Pi extension
-pi install npm:pi-autocontext
+pi install npm:pi-autocontext@0.2.5
 ```
 
 > The PyPI package is `autocontext`. The CLI entrypoint is `autoctx`. The npm packages are `autoctx` and `pi-autocontext` (note: an unrelated package on npm uses the name `autocontext`; that is not this project).
@@ -297,7 +299,7 @@ A deterministic offline provider exists for the test suite. Configuration matrix
 No. It's a harness for improving real agent behavior on real work. Benchmarks (the 11 scenario families) are one of many surfaces; you can also point it at production tasks, missions, or simulations.
 
 **How is this different from DSPy, Inspect, TextGrad, or a prompt optimizer?**
-Those tools optimize prompts. Autocontext takes a goal in plain language, generates the scenario, runs a multi-role loop with verifier-driven gating, and produces transferable artifacts (playbooks, datasets, distilled models) that the next run inherits. Prompt optimization is a special case.
+Those tools optimize prompts. autocontext takes a goal in plain language, generates the scenario, runs a multi-role loop with verifier-driven gating, and produces transferable artifacts (playbooks, datasets, distilled models) that the next run inherits. Prompt optimization is a special case.
 
 **Do I need API keys?**
 No. The Pi runtime runs locally and handles its own auth. Anthropic, OpenAI, Gemini, Mistral, Groq, OpenRouter, Azure, MLX, and Claude/Codex CLI are all opt-in via env vars.
@@ -310,13 +312,13 @@ Yes. Wire `autoctx mcp-serve` (or `bunx autoctx mcp-serve`) into Claude Code, Cu
 
 ## Where To Look Next
 
+- Live documentation: [autocontext.ai/docs](https://autocontext.ai/docs)
 - Canonical vocabulary and object model: [docs/concept-model.md](docs/concept-model.md)
-- Docs overview: [docs/README.md](docs/README.md)
 - Python package guide: [autocontext/README.md](autocontext/README.md)
 - TypeScript package guide: [ts/README.md](ts/README.md)
 - Copy-paste examples: [examples/README.md](examples/README.md)
 - External agent integration: [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md)
-- Recent changes: [CHANGELOG.md](CHANGELOG.md)
+- Recent changes: [CHANGELOG.md](CHANGELOG.md) and [autocontext.ai/docs/changelog](https://autocontext.ai/docs/changelog)
 - Contributor setup: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Repo layout for coding agents: [AGENTS.md](AGENTS.md)
 - Sandboxed agents that need to trigger MLX training on the host: [autocontext/docs/mlx-training.md](autocontext/docs/mlx-training.md)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ If you already work inside a coding agent, you can wire autocontext in once and 
 pi install npm:pi-autocontext@0.2.5
 ```
 
+Pi is on a separate package line: `pi-autocontext@0.2.5` currently depends on `autoctx@^0.5.1`. Use it for the current Pi tools/skills, and use `autocontext==0.6.0` or `autoctx@0.6.0` directly when you need the 0.6 runtime features until the next Pi extension release updates its bundled TypeScript dependency.
+
 Then you just ask:
 
 > "Solve: improve customer-support replies for billing disputes."
@@ -216,7 +218,10 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 - **CLI contract parity** aligns the Python and TypeScript `autoctx` command surfaces around the shared canonical contract, including capabilities, mission lifecycle commands, queue commands, scenario creation, serve/MCP paths, show/watch, status behavior, and aliases.
 - **Contract probes** add terminal, directory, service, artifact, cleanup, media, and distributed probe families, plus `autoctx probes check` and `autoctx probes extract` for harness verification.
 - **Mission checkpoints** now share a cross-runtime checkpoint contract with collision-free filenames, camelCase/snake_case loader interop, atomic restore behavior, and async-boundary guards.
-- **Training pipeline work** on `main` adds opt-in teacher-reasoning distillation, sampling controls, MLX-LM fine-tuning, score-conditioned generation, reward-weighted loss, and self-improving local-training loops. See [CHANGELOG.md](CHANGELOG.md) and [autocontext.ai/docs/changelog](https://autocontext.ai/docs/changelog).
+
+## On main (unreleased)
+
+- **Training pipeline work** adds opt-in teacher-reasoning distillation, sampling controls, MLX-LM fine-tuning, score-conditioned generation, reward-weighted loss, and self-improving local-training loops. These features are on `main` and in [CHANGELOG.md](CHANGELOG.md), but they are not included in the pinned `0.6.0` packages yet.
 <!-- autocontext-whats-new:end -->
 
 ## Choose Your Package
@@ -241,7 +246,7 @@ bun add -g autoctx@0.6.0
 pi install npm:pi-autocontext@0.2.5
 ```
 
-> The PyPI package is `autocontext`. The CLI entrypoint is `autoctx`. The npm packages are `autoctx` and `pi-autocontext` (note: an unrelated package on npm uses the name `autocontext`; that is not this project).
+> The PyPI package is `autocontext`. The CLI entrypoint is `autoctx`. The npm packages are `autoctx` and `pi-autocontext` (note: an unrelated package on npm uses the name `autocontext`; that is not this project). `pi-autocontext@0.2.5` currently depends on `autoctx@^0.5.1`; it remains the current Pi extension package, but it does not bundle `autoctx@0.6.0` until the next Pi package release.
 
 ## Surfaces
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -10,7 +10,7 @@ The intended use is to hand the harness a real task in plain language, let it so
 pip install autocontext
 ```
 
-The current PyPI release line is `autocontext==0.5.0`.
+The current PyPI release line is `autocontext==0.6.0`.
 The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
 
 ## Working Directory
@@ -35,7 +35,7 @@ The Python package is the full control-plane surface in this repo. It currently 
 - plain-language investigation via `autoctx investigate`
 - local training workflows via `autoctx export-training-data` and `autoctx train`
 - scenario creation and materialization via `autoctx new-scenario`
-- Hermes Agent integration helpers via `autoctx hermes inspect` and `autoctx hermes export-skill` (with optional `--with-references` for progressive-disclosure reference files; AC-702)
+- Hermes Agent integration helpers via `autoctx hermes inspect` and `autoctx hermes export-skill` (with optional `--with-references` for progressive-disclosure reference files)
 - HTTP API and MCP server surfaces via `autoctx serve` and `autoctx mcp-serve`, including runtime-session log and timeline readers for provider-backed runs
 
 Some newer operator-facing surfaces are currently TypeScript-first:
@@ -242,7 +242,7 @@ uv run autoctx solve "improve customer-support replies for billing disputes" --i
 
 ## Contract Probes
 
-`uv run autoctx probes check --suite <path>` runs the AC-728 contract-probe suite against observed harness state and reports per-probe pass/fail. It exits 0 on a full pass and 1 on any failure or any load / parse error. Default output is human-readable; pass `--json` to emit a structured `ContractProbeSuiteResult` payload (`{passed, results: [{kind, label?, passed, failures: [{kind, message, ...}]}]}`) that downstream tools can consume. On load / parse / validation failure, the typer wrapper writes the actionable error to stderr so `--json` consumers can safely parse stdout.
+`uv run autoctx probes check --suite <path>` runs the contract-probe suite against observed harness state and reports per-probe pass/fail. It exits 0 on a full pass and 1 on any failure or any load / parse error. Default output is human-readable; pass `--json` to emit a structured `ContractProbeSuiteResult` payload (`{passed, results: [{kind, label?, passed, failures: [{kind, message, ...}]}]}`) that downstream tools can consume. On load / parse / validation failure, the typer wrapper writes the actionable error to stderr so `--json` consumers can safely parse stdout.
 
 The suite file is a JSON document validated by `ContractProbeSuiteSchema`. Every nested model is strict: unknown keys (for example a typo like `requiredStdoutPattern` missing the trailing `s`) fail validation rather than silently disappearing. Required observation fields (`presentFiles`, `observed`, `entries`, `ranks`) must be present and primitives are not coerced (`"exitCode": "0"` rejects). Optional expectation fields accept omission but not explicit `null`.
 
@@ -468,7 +468,7 @@ autocontext exposes:
 
 ## OpenAI integration
 
-Autocontext ships a zero-configuration OpenAI instrumentation path that
+autocontext ships a zero-configuration OpenAI instrumentation path that
 automatically wraps your existing `OpenAI(...)` calls and emits structured
 traces to a sink of your choice.
 
@@ -582,7 +582,7 @@ For the TypeScript equivalent, see `ts/src/integrations/openai/STABILITY.md`.
 
 ## Anthropic integration
 
-Autocontext ships a zero-configuration Anthropic instrumentation path that
+autocontext ships a zero-configuration Anthropic instrumentation path that
 automatically wraps your existing `Anthropic(...)` calls and emits structured
 traces to a sink of your choice.
 

--- a/autocontext/assets/whats_new.txt
+++ b/autocontext/assets/whats_new.txt
@@ -1,4 +1,3 @@
-**Plain-language CLI continuity** lets Python and TypeScript callers use positional goals/scenarios, `--iterations`, and run-scoped exports while preserving the existing flag forms.
-**Hermes Agent integration** adds read-only Hermes v0.12 inspection plus an exportable CLI-first `autocontext` skill for Hermes agents.
-**Packaged CLI startup** no longer crashes when installed without banner assets.
-**Release alignment** bumps Python `autocontext` and npm `autoctx` to `0.5.0`, with `pi-autocontext` moving to `0.2.4` on its own lower-numbered line.
+**CLI contract parity** aligns the Python and TypeScript `autoctx` command surfaces around the shared canonical contract, including capabilities, mission lifecycle commands, queue commands, scenario creation, serve/MCP paths, show/watch, status behavior, and aliases.
+**Contract probes** add terminal, directory, service, artifact, cleanup, media, and distributed probe families, plus `autoctx probes check` and `autoctx probes extract` for harness verification.
+**Mission checkpoints** now share a cross-runtime checkpoint contract with collision-free filenames, camelCase/snake_case loader interop, atomic restore behavior, and async-boundary guards.

--- a/autocontext/src/autocontext/banner.py
+++ b/autocontext/src/autocontext/banner.py
@@ -16,14 +16,13 @@ from pathlib import Path
 from xml.sax.saxutils import escape as xml_escape
 
 TAGLINE = (
-    "a recursive self-improving harness designed to help your agents "
-    "(and future iterations of those agents) succeed on any task"
+    "a recursive self-improving harness designed to help your agents (and future iterations of those agents) succeed on any task"
 )
 SYNC_BLOCK_START = "<!-- autocontext-readme-hero:start -->"
 SYNC_BLOCK_END = "<!-- autocontext-readme-hero:end -->"
 WHATS_NEW_BLOCK_START = "<!-- autocontext-whats-new:start -->"
 WHATS_NEW_BLOCK_END = "<!-- autocontext-whats-new:end -->"
-README_WHATS_NEW_HEADING = "What's New in 0.5.0"
+README_WHATS_NEW_HEADING = "What's New in 0.6.0"
 FALLBACK_BANNER_ART = "autocontext"
 README_BADGES = (
     (
@@ -75,12 +74,7 @@ def get_banner_svg_path() -> Path:
 
 def _read_packaged_asset(name: str) -> str | None:
     try:
-        return (
-            resources.files("autocontext")
-            .joinpath("assets")
-            .joinpath(name)
-            .read_text(encoding="utf-8")
-        )
+        return resources.files("autocontext").joinpath("assets").joinpath(name).read_text(encoding="utf-8")
     except (FileNotFoundError, ModuleNotFoundError, OSError):
         return None
 
@@ -105,11 +99,7 @@ def load_whats_new() -> tuple[str, ...]:
     content = _read_packaged_asset("whats_new.txt") or _read_source_asset("whats_new.txt")
     if content is None:
         return ()
-    return tuple(
-        line.strip()
-        for line in content.splitlines()
-        if line.strip()
-    )
+    return tuple(line.strip() for line in content.splitlines() if line.strip())
 
 
 def render_banner_svg() -> str:
@@ -127,15 +117,10 @@ def render_banner_svg() -> str:
     text_nodes = []
     for index, line in enumerate(lines):
         y = padding_y + font_size + index * line_height
-        text_nodes.append(
-            f'  <text x="{padding_x}" y="{y}" xml:space="preserve">{xml_escape(line)}</text>'
-        )
+        text_nodes.append(f'  <text x="{padding_x}" y="{y}" xml:space="preserve">{xml_escape(line)}</text>')
 
     joined = "\n".join(text_nodes)
-    font_family = (
-        "ui-monospace, SFMono-Regular, SF Mono, Menlo, Monaco, Consolas, "
-        "Liberation Mono, monospace"
-    )
+    font_family = "ui-monospace, SFMono-Regular, SF Mono, Menlo, Monaco, Consolas, Liberation Mono, monospace"
     return (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
@@ -211,19 +196,12 @@ def render_readme_banner_block() -> str:
 def render_readme_whats_new_block() -> str:
     """Render the synced README What's New section."""
     whats_new = "\n".join(f"- {item}" for item in load_whats_new())
-    return (
-        f"{WHATS_NEW_BLOCK_START}\n"
-        f"## {README_WHATS_NEW_HEADING}\n\n"
-        f"{whats_new}\n"
-        f"{WHATS_NEW_BLOCK_END}"
-    )
+    return f"{WHATS_NEW_BLOCK_START}\n## {README_WHATS_NEW_HEADING}\n\n{whats_new}\n{WHATS_NEW_BLOCK_END}"
 
 
 def render_dashboard_banner_block() -> str:
     """Render the synced dashboard hero block."""
-    whats_new = "\n".join(
-        f"          <li>{html_escape(item)}</li>" for item in load_whats_new()
-    )
+    whats_new = "\n".join(f"          <li>{html_escape(item)}</li>" for item in load_whats_new())
     return (
         f"{SYNC_BLOCK_START}\n"
         '    <section class="hero">\n'

--- a/pi/README.md
+++ b/pi/README.md
@@ -1,18 +1,20 @@
 # pi-autocontext
 
-Autocontext extension for [Pi coding agent](https://github.com/earendil-works/pi) — iterative strategy generation, LLM judging, and evaluation tools.
+autocontext extension for [Pi coding agent](https://github.com/earendil-works/pi) — iterative strategy generation, LLM judging, and evaluation tools.
 
 ## Install
 
 ```bash
-pi install npm:pi-autocontext
+pi install npm:pi-autocontext@0.2.5
 ```
+
+Current package note: `pi-autocontext@0.2.5` is on a separate Pi extension line and currently depends on `autoctx@^0.5.1`. Use it for Pi tools/skills, and install `autocontext==0.6.0` or `autoctx@0.6.0` directly when you need 0.6 runtime features until the next Pi extension release updates its bundled TypeScript dependency.
 
 Or add to your project's `.pi/settings.json`:
 
 ```json
 {
-  "packages": ["npm:pi-autocontext"]
+  "packages": ["npm:pi-autocontext@0.2.5"]
 }
 ```
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -147,7 +147,7 @@ export function register(api) {
 npm install autoctx
 ```
 
-The current npm release line is `autoctx@0.5.0`.
+The current npm release line is `autoctx@0.6.0`.
 Important: use `autoctx`, not `autocontext`.
 `autocontext` on npm is a different package and not this project.
 
@@ -293,7 +293,7 @@ autoctx analyze --id deploy_sim --type simulation
 autoctx analyze --left sim_a --right sim_b --type simulation
 autoctx trace-findings --trace ./trace.json          # Markdown report
 autoctx trace-findings --trace ./trace.json --json   # TraceFindingReport JSON
-autoctx probes check --suite ./suite.json            # AC-728 contract probes (see Contract Probes below)
+autoctx probes check --suite ./suite.json            # contract probes (see Contract Probes below)
 autoctx probes check --suite ./suite.json --json     # structured ContractProbeSuiteResult
 autoctx probes extract --trace ./trace.json          # synthesize a probe suite from a harness trace
 autoctx probes extract --trace ./trace.json --output ./suite.json
@@ -324,7 +324,7 @@ Stateful persistent providers, including persistent Pi RPC, run with effective w
 
 ## Contract Probes
 
-`autoctx probes check --suite <path>` runs the AC-728 contract-probe suite against observed harness state and reports per-probe pass/fail. It exits 0 on a full pass and 1 on any failure or any load / parse error. Default output is human-readable; pass `--json` to emit a structured `ContractProbeSuiteResult` payload that downstream tools can consume.
+`autoctx probes check --suite <path>` runs the contract-probe suite against observed harness state and reports per-probe pass/fail. It exits 0 on a full pass and 1 on any failure or any load / parse error. Default output is human-readable; pass `--json` to emit a structured `ContractProbeSuiteResult` payload that downstream tools can consume.
 
 The suite file is a JSON document validated by `ContractProbeSuiteSchema`. Every nested object is strict: unknown keys (e.g. a typo like `requiredStdoutPattern` missing the trailing `s`) fail validation rather than silently disappearing. Every declared expectation requires the matching observation; an `expected*` field without its observation fails as `missing-observation` rather than silently passing.
 
@@ -403,7 +403,7 @@ The `results` field is a discriminated union by `kind`, so TypeScript callers ca
 
 For workflows that record a run and then verify it (rather than hand-authoring a suite), `autoctx probes extract --trace <path>` synthesizes a runnable probe suite from a harness-trace JSON file. The trace bundles both `observations` (what actually happened) and optional `expectations` (what the operator declared should have happened); the extractor joins them.
 
-Coverage: all seven AC-728 probe kinds (terminal, directory, service, artifact, cleanup, media, distributed). Orphan expectations (declared without a matching observation) fail validation at parse time rather than silently producing a vacuously-passing suite.
+Coverage: all seven probe kinds (terminal, directory, service, artifact, cleanup, media, distributed). Orphan expectations (declared without a matching observation) fail validation at parse time rather than silently producing a vacuously-passing suite.
 
 Minimal trace example:
 
@@ -794,7 +794,7 @@ The TypeScript package includes the current 0.4.x operator-facing surfaces:
 - `investigate`
 - `analyze`
 - `context-selection`
-- `trace-findings` — extract structured findings (`TraceFindingReport`) from a `PublicTrace` JSON file (AC-679)
+- `trace-findings` — extract structured findings (`TraceFindingReport`) from a `PublicTrace` JSON file
 - `mission`
 - `train` as a validation plus executor-hook surface
 
@@ -829,7 +829,7 @@ These workflows require infrastructure not available in the npm package:
 
 ## OpenAI integration
 
-Autocontext ships a zero-configuration OpenAI instrumentation path that
+autocontext ships a zero-configuration OpenAI instrumentation path that
 automatically wraps your existing `new OpenAI(...)` calls and emits structured
 traces to a sink of your choice.
 
@@ -945,7 +945,7 @@ For the Python equivalent, see
 
 ## Anthropic integration
 
-Autocontext ships a zero-configuration Anthropic instrumentation path that
+autocontext ships a zero-configuration Anthropic instrumentation path that
 automatically wraps your existing `new Anthropic(...)` calls and emits structured
 traces to a sink of your choice.
 


### PR DESCRIPTION
## Summary
- update root install snippets to current Python/TypeScript runtime versions (`autocontext`/`autoctx` 0.6.0)
- update linked package guides so `autocontext/README.md` and `ts/README.md` also advertise the 0.6.0 release line
- add canonical live docs links for quickstart, CLI reference, providers, agents, and changelog
- keep 0.6.0 highlights limited to released CLI/probe/checkpoint work, and move current training/distillation work into an explicit “On main (unreleased)” section
- document that `pi-autocontext@0.2.5` is on a separate package line and currently depends on `autoctx@^0.5.1`
- normalize visible brand copy and remove internal planning IDs from the touched README files

## Validation
- checked local README links resolve across root, Python, TypeScript, and Pi README files
- checked no leftover `autocontext==0.5.0`, `autoctx@0.5.0`, `0.2.4`, `AC-`, or uppercase `Autocontext` references in touched README files
- checked root README includes the unreleased-training disclaimer and Pi compatibility note
- ran `git diff --check`

Docs-only update; no package code changed.
