### PR TITLE
fix(training): GRPO reward function must accept mlx-lm-lora's runtime kwargs

### DIFF
--- a/autocontext/src/autocontext/training/autoresearch/grpo_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/grpo_backend.py
@@ -176,8 +176,11 @@ def render_reward_module(scenario_name: str, *, reward_name: str = REWARD_NAME, 
         f"{registration}"
         f"_SCENARIO = SCENARIO_REGISTRY[{scenario_name!r}]()\n\n\n"
         f"@register_reward_function({reward_name!r})\n"
-        "def _autocontext_verifier_reward(prompts, completions, answers, types=None):\n"
-        "    return score_completions(_SCENARIO, completions)\n"
+        # **kwargs (not a fixed answers/types signature): mlx-lm-lora's trainer calls the
+        # reward with answer= (singular) at runtime, despite the documented `answers`
+        # type alias; only `completions` is needed, so absorb the rest defensively.
+        "def _autocontext_verifier_reward(prompts=None, completions=None, **kwargs):\n"
+        "    return score_completions(_SCENARIO, completions or [])\n"
     )
 
 

--- a/autocontext/tests/test_grpo_backend.py
+++ b/autocontext/tests/test_grpo_backend.py
@@ -186,6 +186,31 @@ def test_render_reward_module_emits_compilable_registration() -> None:
     assert "capset_n4" in src
     assert "score_completions" in src
     assert "from capset_scenario import register; register(4)" in src
+    # **kwargs signature (not a fixed answers/types): mlx-lm-lora calls with answer=
+    # (singular) at runtime, so the reward must absorb arbitrary kwargs.
+    assert "**kwargs" in src
+
+
+def test_generated_reward_tolerates_trainer_kwargs() -> None:
+    """Reproduces the runtime call mlx-lm-lora actually makes: reward(prompts=, completions=,
+    answer=, types=). A fixed `answers` signature raised TypeError; this pins the fix."""
+    import importlib.util
+
+    if importlib.util.find_spec("mlx_lm_lora") is None:
+        import pytest
+
+        pytest.skip("mlx-lm-lora not installed")
+
+    from mlx_lm_lora.trainer.grpo_reward_functions import REWARD_REGISTRY
+
+    from autocontext.training.autoresearch.grpo_backend import render_reward_module
+
+    ns: dict = {}
+    exec(compile(render_reward_module("grid_ctf"), "<reward>", "exec"), ns)  # noqa: S102
+    fn = REWARD_REGISTRY["autocontext_verifier"]
+    # the exact runtime call shape (answer singular, types) must not raise
+    out = fn(prompts=["p"], completions=["not json"], answer=[""], types=None)
+    assert out == [0.0]
 
 
 def test_build_prompt_rows_shape() -> None:


### PR DESCRIPTION
## What

Follow-up fix to #1042. An **end-to-end smoke against the real `mlx-lm-lora`** (which the unit tests didn't exercise) revealed the GRPO backend's generated reward function crashed on **every** run:

```
TypeError: _autocontext_verifier_reward() got an unexpected keyword argument 'answer'
```

`mlx-lm-lora`'s trainer calls the reward function with `answer=` (**singular**) at runtime — despite the documented `(prompts, completions, answers, types)` type alias the original signature was based on. So the merged GRPO backend doesn't actually train without this fix.

## Fix

The reward only needs `completions`, so it now uses `**kwargs` and absorbs the rest (`answer`/`answers`/`types`) defensively — immune to the trainer's exact kwarg naming.

## Verification

- **Smoke now passes end-to-end**: GSPO trains on grid_ctf (0.5B, 3 iters), reward fn called with the real kwargs, LoRA adapter produced, in-scenario assessment runs, full metrics dict returned (`avg_score`/`valid_rate`/`peak_memory_mb`/`num_steps`/`num_params_m`/`depth`/`variant`). `avg_score=0.0` is expected at that toy scale — this validates the plumbing.
- New `test_generated_reward_tolerates_trainer_kwargs` reproduces the exact runtime call `reward(prompts=, completions=, answer=, types=)`; plus a `**kwargs` structural guard. 14 tests; ruff + mypy clean.