### PR TITLE
fix(trl): version-robust GKD import (experimental -> top-level fallback)

### DIFF
--- a/autocontext/src/autocontext/training/autoresearch/trl_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/trl_backend.py
@@ -45,6 +45,20 @@ __all__ = [
 ]
 
 
+def _import_gkd() -> tuple[Any, Any]:
+    """Resolve ``(GKDConfig, GKDTrainer)`` across TRL layouts.
+
+    Recent TRL moved GKD under ``trl.experimental.gkd``; older releases expose it at the
+    top level. Try the experimental path first, fall back to the top level, so the GKD arm
+    works regardless of the resolved TRL version instead of failing on import mid-run.
+    """
+    try:
+        from trl.experimental.gkd import GKDConfig, GKDTrainer
+    except ImportError:
+        from trl import GKDConfig, GKDTrainer
+    return GKDConfig, GKDTrainer
+
+
 def build_gkd_config_kwargs(
     *,
     output_dir: str,
@@ -208,7 +222,7 @@ def run_trl_training(
     callbacks = [make_time_budget_callback(float(time_budget))]
 
     if mode == "gkd":
-        from trl.experimental.gkd import GKDConfig, GKDTrainer
+        gkd_config_cls, gkd_trainer_cls = _import_gkd()
 
         teacher_tok = AutoTokenizer.from_pretrained(teacher_model)
         s_vocab, t_vocab = getattr(tokenizer, "vocab_size", None), getattr(teacher_tok, "vocab_size", None)
@@ -220,8 +234,8 @@ def run_trl_training(
         )
         if batch_size > 0:
             gkd_kwargs["per_device_train_batch_size"] = batch_size
-        args = GKDConfig(**build_gkd_config_kwargs(**gkd_kwargs))
-        trainer = GKDTrainer(
+        args = gkd_config_cls(**build_gkd_config_kwargs(**gkd_kwargs))
+        trainer = gkd_trainer_cls(
             model=AutoModelForCausalLM.from_pretrained(student_model),
             teacher_model=AutoModelForCausalLM.from_pretrained(teacher_model),
             args=args,

--- a/autocontext/tests/test_trl_backend.py
+++ b/autocontext/tests/test_trl_backend.py
@@ -117,8 +117,37 @@ def test_reward_func_scores_against_per_instance_answer() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Mode validation (runs before any heavy import)
+# Mode validation + GKD import resolution (run before any heavy import)
 # ---------------------------------------------------------------------------
+
+
+def test_import_gkd_prefers_experimental_then_falls_back(monkeypatch) -> None:
+    """The GKD class resolver tries trl.experimental.gkd first, then top-level trl, so the
+    GKD arm survives TRL's cross-version layout differences (stubbed; no real trl)."""
+    import sys
+    import types
+
+    from autocontext.training.autoresearch import trl_backend
+
+    # Branch 1: experimental layout present -> use it.
+    trl = types.ModuleType("trl")
+    exp = types.ModuleType("trl.experimental")
+    gkd = types.ModuleType("trl.experimental.gkd")
+    gkd.GKDConfig, gkd.GKDTrainer = "EXP_CFG", "EXP_TR"  # type: ignore[attr-defined]
+    trl.experimental = exp  # type: ignore[attr-defined]
+    exp.gkd = gkd  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "trl", trl)
+    monkeypatch.setitem(sys.modules, "trl.experimental", exp)
+    monkeypatch.setitem(sys.modules, "trl.experimental.gkd", gkd)
+    assert trl_backend._import_gkd() == ("EXP_CFG", "EXP_TR")
+
+    # Branch 2: only top-level GKD (no experimental submodule) -> fall back.
+    trl_top = types.ModuleType("trl")
+    trl_top.GKDConfig, trl_top.GKDTrainer = "TOP_CFG", "TOP_TR"  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "trl", trl_top)
+    monkeypatch.delitem(sys.modules, "trl.experimental.gkd", raising=False)
+    monkeypatch.delitem(sys.modules, "trl.experimental", raising=False)
+    assert trl_backend._import_gkd() == ("TOP_CFG", "TOP_TR")
 
 
 def test_run_trl_training_rejects_unknown_mode() -> None:


### PR DESCRIPTION
## What

The `trl` backend imported `GKDConfig`/`GKDTrainer` only from `trl.experimental.gkd`. Recent TRL keeps GKD there, but older releases expose it at the top level (`trl.GKDTrainer`), so the **GKD arm would fail on import** depending on which TRL version resolves — a guaranteed mid-run break right when someone runs the cross-platform validation on real hardware.

`_import_gkd()` tries the experimental path first and falls back to top-level, so the GKD arm works across TRL layouts instead of being pinned to one.

## Tests

TDD, CI-safe (no real `trl`): `test_import_gkd_prefers_experimental_then_falls_back` stubs `sys.modules` to cover both branches — experimental present (used) and experimental absent / top-level present (fallback).

Prompted by writing the GPU validation harness (`validate_trl_modal.py` in the consumer repo): this is the one cross-version risk that would otherwise surface only once the run reaches the GKD arm.