### PR TITLE
fix(server): guard get_environment_info for agent-task scenarios

### DIFF
--- a/autocontext/src/autocontext/server/run_manager.py
+++ b/autocontext/src/autocontext/server/run_manager.py
@@ -39,10 +39,20 @@ class RunManager:
         for name in sorted(SCENARIO_REGISTRY.keys()):
             scenario_cls = SCENARIO_REGISTRY[name]
             instance = scenario_cls()
-            scenarios.append({
-                "name": name,
-                "description": instance.describe_rules(),
-            })
+            # Dual-interface registry: game scenarios expose describe_rules(),
+            # agent-task scenarios expose describe_task(). Guard for both.
+            if hasattr(instance, "describe_rules"):
+                description = instance.describe_rules()
+            elif hasattr(instance, "describe_task"):
+                description = instance.describe_task()
+            else:
+                description = name
+            scenarios.append(
+                {
+                    "name": name,
+                    "description": description,
+                }
+            )
 
         pi_configured = bool(self.settings.primeintellect_api_key)
         executors: list[dict[str, Any]] = [


### PR DESCRIPTION
## Problem

`RunManager.get_environment_info()` unconditionally calls `instance.describe_rules()` on every registered scenario. Game scenarios expose `describe_rules()`, but agent-task scenarios (e.g. `TemplateAgentTask`) only expose `describe_task()`. The unguarded call raises `AttributeError`.

This fires on the `/ws/interactive` connect path (`server/app.py` sends environment info right after the `hello` handshake), so the WebSocket connection closes immediately after `hello` whenever an agent-task scenario is registered. Any cockpit client is then unable to receive `environments`, `list_scenarios` results, or proceed with a run.

## Fix

Guard the description lookup with the documented dual-interface pattern (CLAUDE.md: "Code accessing the registry uses hasattr/getattr guards for the dual-interface pattern"): prefer `describe_rules()`, fall back to `describe_task()`, then to the scenario name.

## How it was found

Surfaced while building an external WebSocket client against the interactive server: the connection always dropped right after `hello`. The traceback pointed at `run_manager.py` `get_environment_info` calling `describe_rules()` on a `TemplateAgentTask`.

## Verification

- `tests/test_server_health.py` passes.
- With the fix, an interactive client completes the full protocol against `autoctx tui`: `hello` -> `environments` -> `list_scenarios` -> `start_run` -> `run_accepted` -> `override_gate` -> `ack` (deterministic provider).