### PR TITLE
fix(trl,opd): make the distillation backends actually run on GPU (first-run fixes)

### DIFF
--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -181,14 +181,14 @@ the student roll out, and steps the student to match the teacher's per-token dis
 uv run autoctx train --backend opd \
   --scenario antichain_diverse \
   --base-model mlx-community/Qwen2.5-1.5B-Instruct-4bit \
-  --teacher-model mlx-community/Qwen2.5-7B-Instruct-4bit \
+  --teacher-model mlx-community/Qwen2.5-3B-Instruct-4bit \
   --num-layers 8
 ```
 
 Notes:
 
 - `--base-model` is the **student** and `--teacher-model` is the teacher (default:
-  `mlx-community/Qwen2.5-7B-Instruct-4bit`); both empty fall back to same-family Qwen2.5
+  `mlx-community/Qwen2.5-3B-Instruct-4bit`); both empty fall back to same-family Qwen2.5
   defaults. Teacher and student **must share a tokenizer** (the run aborts with a clear
   error on a vocab mismatch), so keep them in one model family.
 - The teacher only needs to be at least as capable as the student; it need not be huge.
@@ -211,7 +211,7 @@ uv pip install trl peft
 uv run autoctx train --backend trl --trl-mode gkd \
   --scenario antichain_diverse \
   --base-model Qwen/Qwen2.5-1.5B-Instruct \
-  --teacher-model Qwen/Qwen2.5-7B-Instruct
+  --teacher-model Qwen/Qwen2.5-3B-Instruct
 
 # RLVR (GRPO) -- the cross-platform counterpart of `grpo`
 uv run autoctx train --backend trl --trl-mode grpo \

--- a/autocontext/src/autocontext/training/autoresearch/on_policy_distill.py
+++ b/autocontext/src/autocontext/training/autoresearch/on_policy_distill.py
@@ -42,6 +42,7 @@ __all__ = [
     "distill_loss",
     "distill_over_prompts",
     "distill_update_step",
+    "_model_logit_vocab",
     "on_policy_distill_step",
     "reverse_kl_per_token",
     "run_on_policy_distillation",
@@ -51,6 +52,16 @@ __all__ = [
 
 def _log_softmax(logits: mx.array, axis: int = -1) -> mx.array:
     return logits - mx.logsumexp(logits, axis=axis, keepdims=True)
+
+
+def _model_logit_vocab(model: Any) -> int:
+    """The model's output logit vocab size, via a 1-token forward.
+
+    This is the exact dimension :func:`reverse_kl_per_token` compares, so it catches
+    padded-vocab mismatches (e.g. Qwen2.5 1.5B=151936 vs 7B=152064) that ``tokenizer.vocab_size``
+    misses; reading logits is also robust across mlx_lm architectures vs a config attr.
+    """
+    return int(model(mx.array([[0]])).shape[-1])
 
 
 def reverse_kl_per_token(
@@ -277,17 +288,16 @@ def run_on_policy_distillation(
     scenario = SCENARIO_REGISTRY[scenario_name]()
 
     started = time.monotonic()  # spans model loads + the loop, so loads count against time_budget
-    loaded_teacher = load(teacher_model)
-    teacher, teacher_tok = loaded_teacher[0], loaded_teacher[1]
+    teacher = load(teacher_model)[0]
     teacher.freeze()
     loaded_student = load(student_model)
     student, tokenizer = loaded_student[0], loaded_student[1]
     student.freeze()
-    # Reject a tokenizer mismatch before training (else an opaque logit-shape error later).
-    student_vocab = getattr(tokenizer, "vocab_size", None)
-    teacher_vocab = getattr(teacher_tok, "vocab_size", None)
-    if isinstance(student_vocab, int) and isinstance(teacher_vocab, int):
-        assert_vocab_compatible(student_vocab, teacher_vocab)
+    # Reject a vocab mismatch before training, comparing the MODELS' LOGIT vocab (what
+    # reverse_kl_per_token actually compares) -- NOT tokenizer.vocab_size, which can match
+    # while the padded logit dims differ (e.g. Qwen2.5 1.5B=151936 vs 7B=152064) and would
+    # otherwise crash deep in the loss with an opaque tensor-shape error.
+    assert_vocab_compatible(_model_logit_vocab(student), _model_logit_vocab(teacher))
     linear_to_lora_layers(student, num_layers, _LORA_PARAMETERS)
 
     rows = build_prompt_rows(scenario, n_prompts)

--- a/autocontext/src/autocontext/training/autoresearch/on_policy_distill.py
+++ b/autocontext/src/autocontext/training/autoresearch/on_policy_distill.py
@@ -27,10 +27,12 @@ from autocontext.training.autoresearch.distill_common import assert_vocab_compat
 
 _EPS = 1e-8
 
-# Both models must share a tokenizer, so default teacher/student are the same family
-# (Qwen2.5). The student is the capable RLVR-grade base; the teacher is larger.
+# Teacher and student must share the LOGIT vocab dimension (reverse_kl_per_token compares
+# logits over vocab). Qwen2.5 0.5B/1.5B/3B share vocab 151936, but 7B+ use 152064, so the
+# default teacher is 3B (NOT 7B) -- a 7B teacher with a 1.5B student fails on a vocab shape
+# mismatch. 3B still gives a real teacher>student capability gap for distillation.
 DEFAULT_STUDENT_MODEL = "mlx-community/Qwen2.5-1.5B-Instruct-4bit"
-DEFAULT_TEACHER_MODEL = "mlx-community/Qwen2.5-7B-Instruct-4bit"
+DEFAULT_TEACHER_MODEL = "mlx-community/Qwen2.5-3B-Instruct-4bit"
 _LORA_PARAMETERS = {"rank": 8, "dropout": 0.0, "scale": 20.0}
 
 __all__ = [

--- a/autocontext/src/autocontext/training/autoresearch/trl_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/trl_backend.py
@@ -26,7 +26,9 @@ from autocontext.training.autoresearch.grpo_backend import build_prompt_rows, sc
 # Cross-platform HF model ids (not the MLX 4-bit community repos). Teacher/student must
 # share a tokenizer; defaults are the same Qwen2.5 family.
 DEFAULT_STUDENT_MODEL = "Qwen/Qwen2.5-1.5B-Instruct"
-DEFAULT_TEACHER_MODEL = "Qwen/Qwen2.5-7B-Instruct"
+# Teacher must share the student's LOGIT vocab dim for GKD: Qwen2.5 0.5B/1.5B/3B = 151936,
+# but 7B+ = 152064, so 3B (not 7B) is the vocab-compatible teacher for the 1.5B student.
+DEFAULT_TEACHER_MODEL = "Qwen/Qwen2.5-3B-Instruct"
 SUPPORTED_MODES = ("gkd", "grpo")
 # PEFT LoRA config passed to the TRL trainers (kwargs for peft.LoraConfig).
 _LORA = {"r": 8, "lora_alpha": 16, "lora_dropout": 0.0, "task_type": "CAUSAL_LM"}
@@ -99,7 +101,6 @@ def build_grpo_config_kwargs(
     learning_rate: float = 1e-5,
     num_generations: int = 8,
     max_completion_length: int = 256,
-    max_prompt_length: int = 512,
     beta: float = 0.0,
     temperature: float = 1.0,
     num_train_epochs: float = 1.0,
@@ -108,15 +109,15 @@ def build_grpo_config_kwargs(
 ) -> dict[str, Any]:
     """Kwargs for ``trl.GRPOConfig`` (RLVR). ``beta=0.0`` follows TRL's KL-free default.
 
-    ``max_steps`` (>0 caps total optimizer steps) and ``per_device_train_batch_size`` are
-    threaded from the generic train controls.
+    Only widely-stable GRPOConfig fields are passed (e.g. ``max_prompt_length`` is omitted
+    -- some TRL versions reject it; the default prompt handling is fine). ``max_steps`` (>0
+    caps total optimizer steps) and ``per_device_train_batch_size`` thread the generic controls.
     """
     return {
         "output_dir": output_dir,
         "learning_rate": learning_rate,
         "num_generations": num_generations,
         "max_completion_length": max_completion_length,
-        "max_prompt_length": max_prompt_length,
         "beta": beta,
         "temperature": temperature,
         "num_train_epochs": num_train_epochs,
@@ -126,8 +127,23 @@ def build_grpo_config_kwargs(
 
 
 def build_chat_dataset_rows(scenario: Any, n_prompts: int) -> list[dict[str, Any]]:
-    """GKD dataset rows: ``{"messages": [{"role": "user", "content": prompt}]}`` per prompt."""
-    return [{"messages": [{"role": "user", "content": row["prompt"]}]} for row in build_prompt_rows(scenario, n_prompts)]
+    """GKD dataset rows: a user turn plus a placeholder assistant turn.
+
+    TRL's ``DataCollatorForChatML`` splits each row into prompt (``messages[:-1]``) and a
+    target turn (the last message), so a single user-only message makes ``messages[:-1]``
+    empty and the collator raises ``IndexError`` building the prompt. On-policy GKD
+    (``lmbda=1.0``) resamples the completion from the student, so the assistant content is a
+    throwaway placeholder; it only has to give the collator a prompt/target boundary.
+    """
+    return [
+        {
+            "messages": [
+                {"role": "user", "content": row["prompt"]},
+                {"role": "assistant", "content": "(on-policy: resampled from the student)"},
+            ]
+        }
+        for row in build_prompt_rows(scenario, n_prompts)
+    ]
 
 
 def build_prompt_dataset_rows(scenario: Any, n_prompts: int) -> list[dict[str, str]]:
@@ -224,8 +240,14 @@ def run_trl_training(
     if mode == "gkd":
         gkd_config_cls, gkd_trainer_cls = _import_gkd()
 
-        teacher_tok = AutoTokenizer.from_pretrained(teacher_model)
-        s_vocab, t_vocab = getattr(tokenizer, "vocab_size", None), getattr(teacher_tok, "vocab_size", None)
+        # Compare the MODELS' logit vocab (config.vocab_size), not the tokenizer's: GKD's
+        # per-token JSD compares logits, and same-family models can have different PADDED
+        # vocab (e.g. Qwen2.5 1.5B=151936 vs 7B=152064) while their tokenizers look equal.
+        # Catch it here with a clear message instead of a cryptic tensor-shape error in the loss.
+        student_lm = AutoModelForCausalLM.from_pretrained(student_model)
+        teacher_lm = AutoModelForCausalLM.from_pretrained(teacher_model)
+        s_vocab = getattr(student_lm.config, "vocab_size", None)
+        t_vocab = getattr(teacher_lm.config, "vocab_size", None)
         if isinstance(s_vocab, int) and isinstance(t_vocab, int):
             assert_vocab_compatible(s_vocab, t_vocab)
         dataset = Dataset.from_list(build_chat_dataset_rows(scenario, n_prompts))
@@ -236,8 +258,8 @@ def run_trl_training(
             gkd_kwargs["per_device_train_batch_size"] = batch_size
         args = gkd_config_cls(**build_gkd_config_kwargs(**gkd_kwargs))
         trainer = gkd_trainer_cls(
-            model=AutoModelForCausalLM.from_pretrained(student_model),
-            teacher_model=AutoModelForCausalLM.from_pretrained(teacher_model),
+            model=student_lm,
+            teacher_model=teacher_lm,
             args=args,
             processing_class=tokenizer,
             train_dataset=dataset,

--- a/autocontext/tests/test_on_policy_distill.py
+++ b/autocontext/tests/test_on_policy_distill.py
@@ -255,3 +255,15 @@ def test_assert_vocab_compatible_guards_tokenizer_mismatch() -> None:
     assert_vocab_compatible(151936, 151936)  # equal vocab: fine
     with pytest.raises(ValueError, match="tokenizer"):
         assert_vocab_compatible(151936, 32000)  # mismatched vocab -> clear error, not a shape crash
+
+
+def test_model_logit_vocab_reads_output_dim_not_tokenizer() -> None:
+    """The guard must compare the MODEL's logit vocab (what reverse_kl compares), so a
+    padded-vocab mismatch is caught up front rather than crashing in the loss."""
+    from autocontext.training.autoresearch.on_policy_distill import _model_logit_vocab
+
+    assert _model_logit_vocab(_TinyLM(vocab=151936, dim=4)) == 151936
+    # two models with different logit vocab -> the guard rejects the pair
+    s, t = _model_logit_vocab(_TinyLM(vocab=151936, dim=4)), _model_logit_vocab(_TinyLM(vocab=152064, dim=4))
+    with pytest.raises(ValueError, match="tokenizer"):
+        assert_vocab_compatible(s, t)

--- a/autocontext/tests/test_trl_backend.py
+++ b/autocontext/tests/test_trl_backend.py
@@ -58,7 +58,9 @@ def test_grpo_config_kwargs_have_generation_and_kl_fields() -> None:
     cfg = build_grpo_config_kwargs(output_dir="/tmp/out", num_generations=6)
     assert cfg["num_generations"] == 6
     assert cfg["beta"] == 0.0  # TRL KL-free default
-    assert "max_completion_length" in cfg and "max_prompt_length" in cfg
+    assert "max_completion_length" in cfg
+    # max_prompt_length is intentionally NOT passed (some TRL versions reject it).
+    assert "max_prompt_length" not in cfg
 
 
 def test_config_kwargs_thread_max_steps_and_batch_size() -> None:
@@ -86,6 +88,10 @@ def test_chat_dataset_rows_are_messages_for_gkd() -> None:
     assert len(rows) == 3
     assert all(r["messages"][0]["role"] == "user" for r in rows)
     assert all(isinstance(r["messages"][0]["content"], str) and r["messages"][0]["content"] for r in rows)
+    # GKD's ChatML collator splits messages[:-1] as the prompt, so a target (assistant) turn
+    # is required or it raises IndexError on a user-only row.
+    assert all(r["messages"][-1]["role"] == "assistant" for r in rows)
+    assert all(len(r["messages"]) == 2 for r in rows)
 
 
 def test_prompt_dataset_rows_have_prompt_and_answer_for_grpo() -> None:


### PR DESCRIPTION
## What

The first real GPU validation run of the `trl` backend (Modal / A100, distilling Qwen2.5-3B → 1.5B on the antichain task) surfaced and fixed **5 bugs that only appear when the code actually executes** — the kind no amount of CI without a GPU/torch can catch. The trl backend now runs **both arms (GKD + GRPO) end-to-end**.

1. **GKD dataset format** — `build_chat_dataset_rows` emitted user-only ChatML rows; TRL's `DataCollatorForChatML` splits `messages[:-1]` as the prompt and raised `IndexError` on a single-turn row. Added a placeholder assistant turn (on-policy GKD resamples it).
2. **Vocab guard checked the wrong thing** — the GKD check compared `tokenizer.vocab_size` (which matched), missing that same-family models differ in **padded logit vocab** (Qwen2.5 1.5B = 151936 vs 7B = 152064) → cryptic tensor-shape `RuntimeError` deep in the JSD loss. Now compares the **models'** `config.vocab_size` and fails fast with the clear message.
3. **Broken default teacher** — `DEFAULT_TEACHER_MODEL` was Qwen2.5-7B (152064), vocab-incompatible with the 1.5B student default (151936) → guaranteed failure. Changed to **3B (151936)** in **both** the `trl` and `opd` backends; 3B is vocab-compatible *and* has a real teacher>student gap. Docs updated.
4. **GRPO config field** — `build_grpo_config_kwargs` passed `max_prompt_length`, which this TRL version's `GRPOConfig` rejects (`TypeError`). Dropped it (default prompt handling is fine).

(A 5th — `cli-contract.json` packaging in the Modal image — is in the consumer-repo harness, not this diff.)

## Tests

`test_trl_backend.py` updated to pin the new contracts (user+assistant GKD rows, no `max_prompt_length`). All green; ruff + mypy clean.

## Validation context

End-to-end run completed (exit 0). On the antichain task the 3B teacher ≈ the 1.5B student (the task has a strategy ceiling ~0.47 that capability doesn't move), so the headroom gate correctly flagged it as a non-discriminating task and neither arm showed a lift at 60 steps — an honest null on an ill-suited task, not a method failure. Measuring the efficiency claim needs a task with real teacher>student headroom (e.g. math reasoning); these fixes make that run possible.