### PR TITLE
feat(ts): export server subpaths (protocol, ws-server, run-manager)

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -37,6 +37,18 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./server/protocol": {
+      "import": "./dist/server/protocol.js",
+      "types": "./dist/server/protocol.d.ts"
+    },
+    "./server/ws-server": {
+      "import": "./dist/server/ws-server.js",
+      "types": "./dist/server/ws-server.d.ts"
+    },
+    "./server/run-manager": {
+      "import": "./dist/server/run-manager.js",
+      "types": "./dist/server/run-manager.d.ts"
+    },
     "./control-plane/runtime": {
       "import": "./dist/control-plane/runtime/index.js",
       "types": "./dist/control-plane/runtime/index.d.ts"


### PR DESCRIPTION
Adds three subpath exports to the `autoctx` package so external TypeScript clients can import the interactive-server surface:

- `autoctx/server/protocol` — the typed protocol contract (`ServerMessage`/`ClientMessage`, `PROTOCOL_VERSION`, `parseServerMessage`/`parseClientMessage`). Pure (zod only, no native deps), so it is safe to import for types from non-Node runtimes.
- `autoctx/server/ws-server` — `InteractiveServer` (for embedders that run the control plane in-process under Node).
- `autoctx/server/run-manager` — `RunManager`.

Additive only; no behavior change. Motivated by an external GUI client that consumes the protocol types to talk to the interactive WebSocket server.