### PR TITLE
feat(trl): thread seed into GKD/GRPO configs for reproducible runs

### DIFF
--- a/autocontext/src/autocontext/cli_train.py
+++ b/autocontext/src/autocontext/cli_train.py
@@ -78,6 +78,7 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             help="Training backend: mlx, cuda, mlxlm, grpo, opd, trl (cross-platform GKD/GRPO via TRL)",
         ),
         trl_mode: str = typer.Option("gkd", "--trl-mode", help="trl backend: gkd (on-policy distillation) | grpo (RLVR)"),
+        seed: int = typer.Option(0, "--seed", help="trl backend: training seed (for seeded repeats / error bars)"),
         agent_provider: str = typer.Option("anthropic", "--agent-provider", help="LLM provider for training agent"),
         agent_model: str = typer.Option("", "--agent-model", help="Model for training agent (empty = provider default)"),
         val_select: bool = typer.Option(
@@ -161,6 +162,7 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             base_model=base_model,
             teacher_model=teacher_model,
             trl_mode=trl_mode,
+            seed=seed,
             fine_tune_type=fine_tune_type,
             num_layers=num_layers,
         )

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -376,6 +376,7 @@ def run_training(
     base_model: str = "",
     teacher_model: str = "",  # opd backend: distillation teacher (empty = backend default)
     trl_mode: str = "gkd",  # trl backend: gkd (on-policy distillation) | grpo (RLVR)
+    seed: int = 0,  # trl backend: training seed (for seeded repeats / error bars)
     fine_tune_type: str = "lora",
     num_layers: int = 8,
     collect_samples_path: Path | None = None,
@@ -506,6 +507,7 @@ def run_training(
             learning_rate=learning_rate,
             max_steps=train_steps if train_steps > 0 else -1,  # generic --train-steps -> TRL step cap
             batch_size=batch_size,
+            seed=seed,
             time_budget=time_budget,
             memory_limit_mb=memory_limit_mb,
         )
@@ -519,6 +521,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--output-dir", required=True)
     parser.add_argument("--backend", choices=("mlx", "cuda", "mlxlm", "grpo", "opd", "trl"), default="mlx")
     parser.add_argument("--trl-mode", choices=("gkd", "grpo"), default="gkd", help="trl backend: gkd | grpo")
+    parser.add_argument("--seed", type=int, default=0, help="trl backend: training seed (seeded repeats)")
     parser.add_argument("--time-budget", type=int, default=300)
     parser.add_argument("--memory-limit", type=int, default=16384)
     parser.add_argument("--train-steps", type=int, default=8)
@@ -573,6 +576,7 @@ def main(argv: list[str] | None = None) -> int:
             base_model=args.base_model,
             teacher_model=args.teacher_model,
             trl_mode=args.trl_mode,
+            seed=args.seed,
             fine_tune_type=args.fine_tune_type,
             num_layers=args.num_layers,
             backend=args.backend,

--- a/autocontext/src/autocontext/training/autoresearch/trl_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/trl_backend.py
@@ -73,6 +73,7 @@ def build_gkd_config_kwargs(
     num_train_epochs: float = 1.0,
     max_steps: int = -1,
     per_device_train_batch_size: int = 1,
+    seed: int = 0,
 ) -> dict[str, Any]:
     """Kwargs for ``trl.experimental.gkd.GKDConfig`` (on-policy distillation).
 
@@ -92,6 +93,7 @@ def build_gkd_config_kwargs(
         "num_train_epochs": num_train_epochs,
         "max_steps": max_steps,
         "per_device_train_batch_size": per_device_train_batch_size,
+        "seed": seed,
     }
 
 
@@ -106,6 +108,7 @@ def build_grpo_config_kwargs(
     num_train_epochs: float = 1.0,
     max_steps: int = -1,
     per_device_train_batch_size: int = 8,
+    seed: int = 0,
 ) -> dict[str, Any]:
     """Kwargs for ``trl.GRPOConfig`` (RLVR). ``beta=0.0`` follows TRL's KL-free default.
 
@@ -123,6 +126,7 @@ def build_grpo_config_kwargs(
         "num_train_epochs": num_train_epochs,
         "max_steps": max_steps,
         "per_device_train_batch_size": per_device_train_batch_size,
+        "seed": seed,
     }
 
 
@@ -199,6 +203,7 @@ def run_trl_training(
     learning_rate: float = 1e-5,
     max_steps: int = -1,
     batch_size: int = 0,
+    seed: int = 0,
     register_import: str | None = None,
     time_budget: int = 3600,
     memory_limit_mb: int = 16384,  # noqa: ARG001 - backend-signature parity
@@ -252,7 +257,11 @@ def run_trl_training(
             assert_vocab_compatible(s_vocab, t_vocab)
         dataset = Dataset.from_list(build_chat_dataset_rows(scenario, n_prompts))
         gkd_kwargs: dict[str, Any] = dict(
-            output_dir=str(output_dir), teacher_model=teacher_model, learning_rate=learning_rate, max_steps=max_steps
+            output_dir=str(output_dir),
+            teacher_model=teacher_model,
+            learning_rate=learning_rate,
+            max_steps=max_steps,
+            seed=seed,
         )
         if batch_size > 0:
             gkd_kwargs["per_device_train_batch_size"] = batch_size
@@ -270,7 +279,9 @@ def run_trl_training(
         from trl import GRPOConfig, GRPOTrainer
 
         dataset = Dataset.from_list(build_prompt_dataset_rows(scenario, n_prompts))
-        grpo_kwargs: dict[str, Any] = dict(output_dir=str(output_dir), learning_rate=learning_rate, max_steps=max_steps)
+        grpo_kwargs: dict[str, Any] = dict(
+            output_dir=str(output_dir), learning_rate=learning_rate, max_steps=max_steps, seed=seed
+        )
         if batch_size > 0:
             grpo_kwargs["per_device_train_batch_size"] = batch_size
         args = GRPOConfig(**build_grpo_config_kwargs(**grpo_kwargs))

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -70,6 +70,7 @@ class TrainingConfig:
     base_model: str = ""  # mlxlm backend: pretrained base model (empty = backend default)
     teacher_model: str = ""  # opd backend: distillation teacher (empty = backend default)
     trl_mode: str = "gkd"  # trl backend: gkd (on-policy distillation) | grpo (RLVR)
+    seed: int = 0  # trl backend: training seed (for seeded repeats)
     fine_tune_type: str = "lora"  # mlxlm backend: lora | dora | full
     num_layers: int = 8  # mlxlm backend: number of layers to fine-tune
 
@@ -428,6 +429,8 @@ class TrainingRunner:
             command += ["--teacher-model", self.config.teacher_model]
         if self.config.trl_mode != "gkd":
             command += ["--trl-mode", self.config.trl_mode]
+        if self.config.seed != 0:
+            command += ["--seed", str(self.config.seed)]
         if self.config.fine_tune_type != "lora":
             command += ["--fine-tune-type", self.config.fine_tune_type]
         if self.config.num_layers != 8:

--- a/autocontext/tests/test_training_runner.py
+++ b/autocontext/tests/test_training_runner.py
@@ -309,6 +309,21 @@ class TestConstraints:
         temp_index = command.index("--loss-weight-temperature")
         assert command[temp_index + 1] == "0.5"
 
+    def test_experiment_subprocess_passes_seed_flag(self, tmp_path: Path) -> None:
+        """The trl seed must flow CLI -> TrainingConfig -> subprocess command (else seeded
+        repeats via `autoctx train` can't differ)."""
+        cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl", backend="trl", seed=7)
+        (tmp_path / "data.jsonl").write_text("{}\n")
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run:
+            runner._run_experiment_subprocess(0)
+
+        command = mock_run.call_args.args[0]
+        seed_index = command.index("--seed")
+        assert command[seed_index + 1] == "7"
+
     def test_experiment_subprocess_omits_loss_weight_flags_when_uniform(self, tmp_path: Path) -> None:
         cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl")
         (tmp_path / "data.jsonl").write_text("{}\n")

--- a/autocontext/tests/test_trl_backend.py
+++ b/autocontext/tests/test_trl_backend.py
@@ -84,6 +84,32 @@ def test_config_kwargs_thread_seed_for_reproducible_repeats() -> None:
     assert build_grpo_config_kwargs(output_dir="/o", seed=5)["seed"] == 5
 
 
+def test_run_training_forwards_seed_to_trl_backend(monkeypatch, tmp_path) -> None:
+    """The PUBLIC runner path must forward seed: run_training(backend='trl', seed=N) -> run_trl_training(seed=N).
+    (CI-safe: preflight + the trl runner are patched, so no torch/trl needed.)"""
+    import autocontext.training.autoresearch.train as train_mod
+    import autocontext.training.autoresearch.trl_backend as trl_mod
+
+    captured: dict = {}
+    monkeypatch.setattr(train_mod, "_preflight_backend_deps", lambda backend: None)
+    monkeypatch.setattr(
+        trl_mod,
+        "run_trl_training",
+        lambda **kw: captured.update(kw) or {"avg_score": 0.0, "valid_rate": 1.0},
+    )
+
+    train_mod.run_training(
+        scenario_name="grid_ctf",
+        data_path=tmp_path / "d.jsonl",
+        output_dir=tmp_path / "o",
+        time_budget=10,
+        memory_limit_mb=1024,
+        backend="trl",
+        seed=7,
+    )
+    assert captured["seed"] == 7
+
+
 # ---------------------------------------------------------------------------
 # Dataset row builders
 # ---------------------------------------------------------------------------

--- a/autocontext/tests/test_trl_backend.py
+++ b/autocontext/tests/test_trl_backend.py
@@ -76,6 +76,14 @@ def test_config_kwargs_thread_max_steps_and_batch_size() -> None:
     assert grpo["per_device_train_batch_size"] == 2
 
 
+def test_config_kwargs_thread_seed_for_reproducible_repeats() -> None:
+    """A seed must reach TrainingArguments so seeded repeats actually differ (error bars)."""
+    from autocontext.training.autoresearch.trl_backend import build_gkd_config_kwargs, build_grpo_config_kwargs
+
+    assert build_gkd_config_kwargs(output_dir="/o", teacher_model="T", seed=3)["seed"] == 3
+    assert build_grpo_config_kwargs(output_dir="/o", seed=5)["seed"] == 5
+
+
 # ---------------------------------------------------------------------------
 # Dataset row builders
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
TRL's `TrainingArguments.seed` defaults to a fixed value, so repeated training runs are identical. This threads a `seed` through `run_trl_training` -> `build_gkd_config_kwargs`/`build_grpo_config_kwargs` -> `TrainingArguments`, so seeded repeats actually differ — needed to put error bars on the GSM8K validation result (the +6pt GKD lift was a single run). Small, tested (ruff + mypy + pytest green).