### PR TITLE
feat(server): add /api/runs/{id}/candidate endpoint

### DIFF
--- a/autocontext/src/autocontext/server/app.py
+++ b/autocontext/src/autocontext/server/app.py
@@ -154,6 +154,11 @@ def create_app(
     def run_status(run_id: str) -> list[dict[str, Any]]:
         return store.run_status(run_id)
 
+    @application.get("/api/runs/{run_id}/candidate")
+    def candidate(run_id: str) -> dict[str, Any]:
+        """The latest generation's agent outputs — the live candidate the loop is producing."""
+        return store.get_latest_agent_outputs(run_id)
+
     @application.get("/api/runs/{run_id}/replay/{generation}")
     def replay(run_id: str, generation: int) -> dict[str, Any]:
         replay_path = _read_replay_file(run_id, generation)

--- a/autocontext/src/autocontext/storage/agent_output_queries.py
+++ b/autocontext/src/autocontext/storage/agent_output_queries.py
@@ -1,0 +1,36 @@
+"""SQLite query helpers for agent outputs.
+
+Extracted from ``sqlite_store.py`` to keep that module under its size cap. These are pure
+functions over a ``sqlite3.Connection`` (whose ``row_factory`` the caller sets), so they
+stay easy to test and reuse without growing the store module.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+
+def latest_agent_outputs(conn: sqlite3.Connection, run_id: str) -> dict[str, Any]:
+    """Every agent's output text for the most recent generation of a run.
+
+    Shape: ``{"generation": int | None, "outputs": [{"role": str, "content": str}, ...]}``.
+    Used by the cowork GUI to show the live candidate the loop is producing.
+    """
+    head = conn.execute(
+        "SELECT MAX(generation_index) AS g FROM agent_outputs WHERE run_id = ?",
+        (run_id,),
+    ).fetchone()
+    generation = head["g"] if head and head["g"] is not None else None
+    if generation is None:
+        return {"generation": None, "outputs": []}
+    rows = conn.execute(
+        """
+        SELECT role, content
+        FROM agent_outputs
+        WHERE run_id = ? AND generation_index = ?
+        ORDER BY rowid
+        """,
+        (run_id, generation),
+    ).fetchall()
+    return {"generation": generation, "outputs": [dict(r) for r in rows]}

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -314,6 +314,31 @@ class SQLiteStore:
             ).fetchall()
             return [dict(r) for r in rows]
 
+    def get_latest_agent_outputs(self, run_id: str) -> dict[str, Any]:
+        """Return every agent's output text for the most recent generation of a run.
+
+        Shape: {"generation": int | None, "outputs": [{"role": str, "content": str}, ...]}.
+        Used by the cowork GUI to show the live candidate the loop is producing.
+        """
+        with self.connect() as conn:
+            head = conn.execute(
+                "SELECT MAX(generation_index) AS g FROM agent_outputs WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+            generation = head["g"] if head and head["g"] is not None else None
+            if generation is None:
+                return {"generation": None, "outputs": []}
+            rows = conn.execute(
+                """
+                SELECT role, content
+                FROM agent_outputs
+                WHERE run_id = ? AND generation_index = ?
+                ORDER BY rowid
+                """,
+                (run_id, generation),
+            ).fetchall()
+            return {"generation": generation, "outputs": [dict(r) for r in rows]}
+
     def append_agent_role_metric(
         self,
         run_id: str,

--- a/autocontext/src/autocontext/storage/sqlite_store.py
+++ b/autocontext/src/autocontext/storage/sqlite_store.py
@@ -317,27 +317,13 @@ class SQLiteStore:
     def get_latest_agent_outputs(self, run_id: str) -> dict[str, Any]:
         """Return every agent's output text for the most recent generation of a run.
 
-        Shape: {"generation": int | None, "outputs": [{"role": str, "content": str}, ...]}.
-        Used by the cowork GUI to show the live candidate the loop is producing.
+        Delegates to ``agent_output_queries.latest_agent_outputs`` (extracted to keep this
+        module under its size cap). Used by the cowork GUI to show the live candidate.
         """
+        from autocontext.storage.agent_output_queries import latest_agent_outputs
+
         with self.connect() as conn:
-            head = conn.execute(
-                "SELECT MAX(generation_index) AS g FROM agent_outputs WHERE run_id = ?",
-                (run_id,),
-            ).fetchone()
-            generation = head["g"] if head and head["g"] is not None else None
-            if generation is None:
-                return {"generation": None, "outputs": []}
-            rows = conn.execute(
-                """
-                SELECT role, content
-                FROM agent_outputs
-                WHERE run_id = ? AND generation_index = ?
-                ORDER BY rowid
-                """,
-                (run_id, generation),
-            ).fetchall()
-            return {"generation": generation, "outputs": [dict(r) for r in rows]}
+            return latest_agent_outputs(conn, run_id)
 
     def append_agent_role_metric(
         self,


### PR DESCRIPTION
Adds `GET /api/runs/{run_id}/candidate`, returning the most recent generation's agent output text (competitor strategy, analyst findings, coach playbook) as `{ generation, outputs: [{role, content}] }`. Backed by a new `SQLiteStore.get_latest_agent_outputs`.

Motivated by the cowork operator GUI, which shows the live candidate the loop is producing so a non-technical user can see the actual work, not just a score. Additive, read-only; no behavior change to the loop.