### PR TITLE
feat(providers): MLXLMProvider serves base + LoRA adapter (recursive loop serving gap)

### DIFF
--- a/autocontext/src/autocontext/agents/llm_client.py
+++ b/autocontext/src/autocontext/agents/llm_client.py
@@ -199,10 +199,17 @@ class MLXLMClient(LanguageModelClient):
         adapter_path: str | None = None,
         temperature: float = 0.8,
         max_tokens: int = 512,
+        score_conditioned: bool = False,
     ) -> None:
         from autocontext.providers.mlx_lm_provider import MLXLMProvider
 
-        self._provider = MLXLMProvider(model, adapter_path=adapter_path, temperature=temperature, max_tokens=max_tokens)
+        self._provider = MLXLMProvider(
+            model,
+            adapter_path=adapter_path,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            score_conditioned=score_conditioned,
+        )
 
     def generate(
         self,

--- a/autocontext/src/autocontext/agents/llm_client.py
+++ b/autocontext/src/autocontext/agents/llm_client.py
@@ -185,6 +185,66 @@ class MLXClient(LanguageModelClient):
         )
 
 
+class MLXLMClient(LanguageModelClient):
+    """LanguageModelClient over a local mlx-lm model (optionally base + LoRA adapter).
+
+    The serving counterpart to the mlxlm / opd / trl training backends, so a harness-trained
+    adapter can drive an agent role.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        adapter_path: str | None = None,
+        temperature: float = 0.8,
+        max_tokens: int = 512,
+    ) -> None:
+        from autocontext.providers.mlx_lm_provider import MLXLMProvider
+
+        self._provider = MLXLMProvider(model, adapter_path=adapter_path, temperature=temperature, max_tokens=max_tokens)
+
+    def generate(
+        self,
+        *,
+        model: str,
+        prompt: str,
+        max_tokens: int,
+        temperature: float,
+        role: str = "",
+    ) -> ModelResponse:
+        del model, role
+        started = time.perf_counter()
+        try:
+            result = self._provider.complete("", prompt, temperature=temperature, max_tokens=max_tokens)
+        except ProviderError as exc:
+            raise RuntimeError(str(exc)) from exc
+        elapsed = int((time.perf_counter() - started) * 1000)
+        usage = RoleUsage(
+            input_tokens=result.usage.get("input_tokens", 0),
+            output_tokens=result.usage.get("output_tokens", 0),
+            latency_ms=elapsed,
+            model=result.model or self._provider.default_model(),
+        )
+        return ModelResponse(text=result.text, usage=usage)
+
+    def generate_multiturn(
+        self,
+        *,
+        model: str,
+        system: str,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+        temperature: float,
+        role: str = "",
+    ) -> ModelResponse:
+        del role
+        user_parts = [m["content"] for m in messages if m["role"] == "user"]
+        combined = "\n\n".join(user_parts)
+        prompt = f"{system}\n\n{combined}" if system else combined
+        return self.generate(model=model, prompt=prompt, max_tokens=max_tokens, temperature=temperature)
+
+
 class DeferredMLXClient(LanguageModelClient):
     """Placeholder agent client for ``AUTOCONTEXT_AGENT_PROVIDER=mlx`` with no model path.
 

--- a/autocontext/src/autocontext/providers/mlx_lm_provider.py
+++ b/autocontext/src/autocontext/providers/mlx_lm_provider.py
@@ -49,12 +49,17 @@ class MLXLMProvider(LLMProvider):
         adapter_path: str | None = None,
         temperature: float = 0.8,
         max_tokens: int = 512,
+        score_conditioned: bool = False,
         _loaded: tuple[Any, Any] | None = None,
     ) -> None:
         self._model_id = model
         self._adapter_path = adapter_path
         self._temperature = temperature
         self._max_tokens = max_tokens
+        # Score-conditioned mlxlm adapters were trained + assessed with a top-bucket quality
+        # directive in the prompt (registry data_stats records the flag); reapply it at serving
+        # time so the served prompt matches the contract the adapter passed assessment under.
+        self._score_conditioned = score_conditioned
         if _loaded is not None:  # test/injection seam: skip the mlx-lm load
             self._model, self._tokenizer = _loaded
             return
@@ -80,7 +85,7 @@ class MLXLMProvider(LLMProvider):
 
         effective_temp = temperature if temperature > 0 else self._temperature
         effective_max = min(max_tokens, self._max_tokens) if max_tokens != 4096 else self._max_tokens
-        prompt = format_mlxlm_prompt(self._tokenizer, system_prompt, user_prompt)
+        prompt = format_mlxlm_prompt(self._tokenizer, system_prompt, self._quality_prefixed(user_prompt))
         try:
             text = generate(
                 self._model,
@@ -94,6 +99,18 @@ class MLXLMProvider(LLMProvider):
             logger.debug("providers.mlx_lm_provider: caught Exception", exc_info=True)
             raise ProviderError(f"MLX-LM generation error: {exc}") from exc
         return CompletionResult(text=text, model=model or self._model_id)
+
+    def _quality_prefixed(self, user_prompt: str) -> str:
+        """Prepend the top-bucket quality directive for score-conditioned adapters.
+
+        Reuses the training backend's exact ``_quality_prefix`` text (the same prefix
+        ``_assess_mlxlm`` applied), so the served prompt matches the assessed one.
+        """
+        if not self._score_conditioned:
+            return user_prompt
+        from autocontext.training.autoresearch.mlxlm_backend import NUM_QUALITY_BUCKETS, _quality_prefix
+
+        return _quality_prefix(NUM_QUALITY_BUCKETS - 1, NUM_QUALITY_BUCKETS) + user_prompt
 
     def default_model(self) -> str:
         return self._model_id

--- a/autocontext/src/autocontext/providers/mlx_lm_provider.py
+++ b/autocontext/src/autocontext/providers/mlx_lm_provider.py
@@ -1,0 +1,99 @@
+"""MLXLMProvider -- serve an mlx-lm model (optionally base + LoRA adapter) as a provider.
+
+This is the serving counterpart to the `mlxlm` / `opd` / `trl` training backends, which emit
+mlx-lm models plus LoRA adapter directories (loaded via ``mlx_lm.load(base, adapter_path=...)``).
+``MLXProvider`` only serves the from-scratch autoresearch GPT; this provider serves the capable
+pretrained-instruct fine-tunes so a harness-trained adapter can be the agent (the recursive
+loop for capable models). Mirrors the load+generate path already used by ``_assess_mlxlm``.
+
+All mlx-lm imports are lazy/guarded so this module imports without MLX (Linux/CI); only
+constructing/running the provider needs mlx-lm (Apple Silicon).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from pathlib import Path
+from typing import Any
+
+from autocontext.providers.base import CompletionResult, LLMProvider, ProviderError
+
+logger = logging.getLogger(__name__)
+
+HAS_MLXLM = importlib.util.find_spec("mlx_lm") is not None
+
+
+def format_mlxlm_prompt(tokenizer: Any, system_prompt: str, user_prompt: str) -> str:
+    """Render a chat prompt for an mlx-lm instruct model via its chat template.
+
+    System and user text are combined into a single user turn (the agent roles pass a
+    system + user prompt); ``add_generation_prompt`` leaves the model positioned to answer.
+    """
+    content = f"{system_prompt}\n\n{user_prompt}" if system_prompt else user_prompt
+    rendered = tokenizer.apply_chat_template(
+        [{"role": "user", "content": content}],
+        add_generation_prompt=True,
+        tokenize=False,
+    )
+    return str(rendered)
+
+
+class MLXLMProvider(LLMProvider):
+    """Provider over a local mlx-lm model, optionally with a LoRA adapter."""
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        adapter_path: str | None = None,
+        temperature: float = 0.8,
+        max_tokens: int = 512,
+        _loaded: tuple[Any, Any] | None = None,
+    ) -> None:
+        self._model_id = model
+        self._adapter_path = adapter_path
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+        if _loaded is not None:  # test/injection seam: skip the mlx-lm load
+            self._model, self._tokenizer = _loaded
+            return
+        if adapter_path is not None and not Path(adapter_path).exists():
+            raise ProviderError(f"adapter path does not exist: {adapter_path}")
+        if not HAS_MLXLM:
+            raise ProviderError("mlx-lm is required for MLXLMProvider; install with: uv pip install mlx-lm")
+        from mlx_lm import load
+
+        loaded = load(model, adapter_path=adapter_path) if adapter_path else load(model)
+        self._model, self._tokenizer = loaded[0], loaded[1]
+
+    def complete(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str | None = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+    ) -> CompletionResult:
+        from mlx_lm import generate
+        from mlx_lm.sample_utils import make_sampler
+
+        effective_temp = temperature if temperature > 0 else self._temperature
+        effective_max = min(max_tokens, self._max_tokens) if max_tokens != 4096 else self._max_tokens
+        prompt = format_mlxlm_prompt(self._tokenizer, system_prompt, user_prompt)
+        try:
+            text = generate(
+                self._model,
+                self._tokenizer,
+                prompt=prompt,
+                max_tokens=effective_max,
+                sampler=make_sampler(temp=max(float(effective_temp), 0.0)),
+                verbose=False,
+            )
+        except Exception as exc:
+            logger.debug("providers.mlx_lm_provider: caught Exception", exc_info=True)
+            raise ProviderError(f"MLX-LM generation error: {exc}") from exc
+        return CompletionResult(text=text, model=model or self._model_id)
+
+    def default_model(self) -> str:
+        return self._model_id

--- a/autocontext/tests/test_mlx_lm_provider.py
+++ b/autocontext/tests/test_mlx_lm_provider.py
@@ -44,3 +44,15 @@ def test_missing_adapter_path_raises_before_any_mlx_load() -> None:
 def test_injection_seam_skips_load_and_exposes_model_id() -> None:
     provider = MLXLMProvider("Org/Model-1.5B", adapter_path=None, _loaded=(object(), _StubTokenizer()))
     assert provider.default_model() == "Org/Model-1.5B"
+
+
+def test_score_conditioned_reapplies_top_bucket_quality_directive() -> None:
+    """A score-conditioned adapter must be served with the same top-bucket quality prefix it
+    was assessed under, else the prompt contract differs and generation can regress."""
+    conditioned = MLXLMProvider("M", score_conditioned=True, _loaded=(object(), _StubTokenizer()))
+    prefixed = conditioned._quality_prefixed("do the task")
+    assert prefixed.startswith("Target quality:")
+    assert prefixed.endswith("do the task")
+
+    plain = MLXLMProvider("M", score_conditioned=False, _loaded=(object(), _StubTokenizer()))
+    assert plain._quality_prefixed("do the task") == "do the task"

--- a/autocontext/tests/test_mlx_lm_provider.py
+++ b/autocontext/tests/test_mlx_lm_provider.py
@@ -1,0 +1,46 @@
+"""MLXLMProvider serving seams (CI-safe: the mlx-lm load/generate is gated, so these cover
+the non-MLX logic -- chat-prompt assembly, adapter-path validation, and the injection seam)."""
+
+from __future__ import annotations
+
+import pytest
+
+from autocontext.providers.base import ProviderError
+from autocontext.providers.mlx_lm_provider import MLXLMProvider, format_mlxlm_prompt
+
+
+class _StubTokenizer:
+    """Records the messages passed to apply_chat_template and echoes a rendered string."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def apply_chat_template(self, messages, *, add_generation_prompt, tokenize):
+        self.calls.append({"messages": messages, "add_generation_prompt": add_generation_prompt, "tokenize": tokenize})
+        return f"<RENDERED:{messages[0]['content']}>"
+
+
+def test_format_prompt_combines_system_and_user_into_one_user_turn() -> None:
+    tok = _StubTokenizer()
+    out = format_mlxlm_prompt(tok, "be terse", "solve x")
+    assert out == "<RENDERED:be terse\n\nsolve x>"
+    call = tok.calls[-1]
+    assert call["messages"] == [{"role": "user", "content": "be terse\n\nsolve x"}]
+    assert call["add_generation_prompt"] is True and call["tokenize"] is False
+
+
+def test_format_prompt_user_only_when_no_system() -> None:
+    tok = _StubTokenizer()
+    format_mlxlm_prompt(tok, "", "just the user part")
+    assert tok.calls[-1]["messages"][0]["content"] == "just the user part"
+
+
+def test_missing_adapter_path_raises_before_any_mlx_load() -> None:
+    # The adapter-existence check runs before the gated mlx-lm import, so this is CI-safe.
+    with pytest.raises(ProviderError, match="adapter path does not exist"):
+        MLXLMProvider("Qwen/Qwen2.5-1.5B-Instruct", adapter_path="/no/such/adapter/dir")
+
+
+def test_injection_seam_skips_load_and_exposes_model_id() -> None:
+    provider = MLXLMProvider("Org/Model-1.5B", adapter_path=None, _loaded=(object(), _StubTokenizer()))
+    assert provider.default_model() == "Org/Model-1.5B"


### PR DESCRIPTION
## What

Closes the **serving** half of the recursive loop for *capable* models. `MLXProvider` only serves the from-scratch autoresearch GPT; the `mlxlm` / `opd` / `trl` backends emit **mlx-lm** models plus LoRA adapter dirs, loaded via `mlx_lm.load(base, adapter_path=...)`. New **`MLXLMProvider`** serves those (a fine-tuned Qwen2.5 etc.), mirroring the proven `_assess_mlxlm` load + `mlx_lm.generate` path, with:

- `format_mlxlm_prompt` — chat-template prompt assembly (system + user → one user turn).
- `MLXLMProvider(model, adapter_path=..., ...)` — lazy/guarded mlx-lm load; serves base or base+adapter.
- `MLXLMClient` — the `LanguageModelClient` wrapper (parallels `MLXClient`).

## Tests

mlx-lm load/generate is gated (Apple-Silicon only), so the CI-safe tests cover the non-MLX logic: chat-prompt assembly (system+user and user-only), adapter-path validation (raises before any mlx import), and the `_loaded` injection seam. ruff + mypy + module-size clean.

## Scope / follow-up

This PR is the serving *capability*. Wiring it into agent selection — resolving an active `mlxlm`/`opd` registry record to `MLXLMClient(base, adapter)` — needs the **base model recorded in the registry** (`DistilledModelRecord` has no `base_model` today), so that's the next PR. After that, a fine-tuned adapter the harness trained can be the agent (the full loop for capable models), and a local end-to-end demo validates it.