### PR TITLE
feat(server): add PUT /api/knowledge/{scenario} write endpoint

### DIFF
--- a/autocontext/src/autocontext/server/app.py
+++ b/autocontext/src/autocontext/server/app.py
@@ -203,6 +203,12 @@ def create_app(
             if isinstance(value, str):
                 (base / fname).write_text(value, encoding="utf-8")
                 written.append(fname)
+        if "hints.md" in written:
+            # ArtifactStore.read_hints prefers structured hint_state.json over
+            # flat hints.md. The operator's edit overwrites hint state, so drop
+            # the structured snapshot; readers fall back to the flat file and
+            # read_hint_manager lazily rebuilds structure from it.
+            (base / "hint_state.json").unlink(missing_ok=True)
         return {"scenario": scenario, "written": written}
 
     @application.get("/api/runs/{run_id}/replay/{generation}")

--- a/autocontext/src/autocontext/server/app.py
+++ b/autocontext/src/autocontext/server/app.py
@@ -186,6 +186,25 @@ def create_app(
             "deadEnds": _read("dead_ends.md"),
         }
 
+    @application.put("/api/knowledge/{scenario}")
+    def update_knowledge(scenario: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """Overwrite a scenario's knowledge files (operator curation of what persists)."""
+        if not scenario or len(scenario) > 128 or not scenario.replace("_", "").replace("-", "").isalnum():
+            raise HTTPException(status_code=400, detail="invalid scenario id")
+        base = (app_settings.knowledge_root / scenario).resolve()
+        root = app_settings.knowledge_root.resolve()
+        if base != root and root not in base.parents:
+            raise HTTPException(status_code=400, detail="invalid scenario path")
+        base.mkdir(parents=True, exist_ok=True)
+        files = {"playbook": "playbook.md", "hints": "hints.md", "deadEnds": "dead_ends.md"}
+        written: list[str] = []
+        for key, fname in files.items():
+            value = payload.get(key)
+            if isinstance(value, str):
+                (base / fname).write_text(value, encoding="utf-8")
+                written.append(fname)
+        return {"scenario": scenario, "written": written}
+
     @application.get("/api/runs/{run_id}/replay/{generation}")
     def replay(run_id: str, generation: int) -> dict[str, Any]:
         replay_path = _read_replay_file(run_id, generation)

--- a/autocontext/tests/test_knowledge_endpoint.py
+++ b/autocontext/tests/test_knowledge_endpoint.py
@@ -1,0 +1,49 @@
+"""Tests for the /api/knowledge/{scenario} read + write endpoints."""
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from autocontext.server.app import create_app
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("AUTOCONTEXT_KNOWLEDGE_ROOT", str(tmp_path / "knowledge"))
+    monkeypatch.setenv("AUTOCONTEXT_DB_PATH", str(tmp_path / "runs.sqlite3"))
+    monkeypatch.setenv("AUTOCONTEXT_AGENT_PROVIDER", "deterministic")
+    return TestClient(create_app())
+
+
+def test_put_writes_knowledge_files_and_get_round_trips(client: TestClient, tmp_path: Path) -> None:
+    payload = {"playbook": "## Plan", "hints": "- keep the flag", "deadEnds": "- brute force"}
+    response = client.put("/api/knowledge/grid_ctf", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["scenario"] == "grid_ctf"
+    assert sorted(body["written"]) == ["dead_ends.md", "hints.md", "playbook.md"]
+
+    base = tmp_path / "knowledge" / "grid_ctf"
+    assert (base / "playbook.md").read_text(encoding="utf-8") == "## Plan"
+    assert (base / "dead_ends.md").read_text(encoding="utf-8") == "- brute force"
+
+    got = client.get("/api/knowledge/grid_ctf").json()
+    assert got["playbook"] == "## Plan"
+    assert got["hints"] == "- keep the flag"
+    assert got["deadEnds"] == "- brute force"
+
+
+def test_put_writes_only_provided_string_fields(client: TestClient, tmp_path: Path) -> None:
+    response = client.put("/api/knowledge/grid_ctf", json={"hints": "- only hints", "playbook": 42})
+    assert response.status_code == 200
+    assert response.json()["written"] == ["hints.md"]
+    base = tmp_path / "knowledge" / "grid_ctf"
+    assert (base / "hints.md").exists()
+    assert not (base / "playbook.md").exists()
+
+
+def test_put_rejects_invalid_scenario_ids(client: TestClient) -> None:
+    assert client.put("/api/knowledge/bad!name", json={"hints": "x"}).status_code == 400
+    assert client.put("/api/knowledge/dots..dots", json={"hints": "x"}).status_code == 400
+    assert client.put(f"/api/knowledge/{'a' * 129}", json={"hints": "x"}).status_code == 400

--- a/autocontext/tests/test_knowledge_endpoint.py
+++ b/autocontext/tests/test_knowledge_endpoint.py
@@ -43,6 +43,51 @@ def test_put_writes_only_provided_string_fields(client: TestClient, tmp_path: Pa
     assert not (base / "playbook.md").exists()
 
 
+def test_put_hints_overrides_structured_hint_state(client: TestClient, tmp_path: Path) -> None:
+    # ArtifactStore.read_hints prefers hint_state.json over hints.md, so an
+    # edit that only wrote hints.md would be silently ignored by the loop
+    # (reviewer P2 on PR #1059). Seed structured state, then PUT new hints.
+    from autocontext.knowledge.hint_volume import HintManager, HintVolumePolicy
+    from autocontext.storage.artifacts import ArtifactStore
+
+    knowledge_root = tmp_path / "knowledge"
+    store = ArtifactStore(
+        runs_root=tmp_path / "runs",
+        knowledge_root=knowledge_root,
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / "claude_skills",
+    )
+    manager = HintManager.from_hint_text("- old structured hint", policy=HintVolumePolicy())
+    store.write_hint_manager("grid_ctf", manager)
+    assert (knowledge_root / "grid_ctf" / "hint_state.json").exists()
+    assert "old structured hint" in store.read_hints("grid_ctf")
+
+    response = client.put("/api/knowledge/grid_ctf", json={"hints": "- edited hint"})
+    assert response.status_code == 200
+
+    assert not (knowledge_root / "grid_ctf" / "hint_state.json").exists()
+    assert store.read_hints("grid_ctf") == "- edited hint"
+
+
+def test_put_without_hints_preserves_hint_state(client: TestClient, tmp_path: Path) -> None:
+    from autocontext.knowledge.hint_volume import HintManager, HintVolumePolicy
+    from autocontext.storage.artifacts import ArtifactStore
+
+    knowledge_root = tmp_path / "knowledge"
+    store = ArtifactStore(
+        runs_root=tmp_path / "runs",
+        knowledge_root=knowledge_root,
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / "claude_skills",
+    )
+    store.write_hint_manager("grid_ctf", HintManager.from_hint_text("- keep me", policy=HintVolumePolicy()))
+
+    response = client.put("/api/knowledge/grid_ctf", json={"playbook": "## Plan only"})
+    assert response.status_code == 200
+    assert (knowledge_root / "grid_ctf" / "hint_state.json").exists()
+    assert "keep me" in store.read_hints("grid_ctf")
+
+
 def test_put_rejects_invalid_scenario_ids(client: TestClient) -> None:
     assert client.put("/api/knowledge/bad!name", json={"hints": "x"}).status_code == 400
     assert client.put("/api/knowledge/dots..dots", json={"hints": "x"}).status_code == 400


### PR DESCRIPTION
## Summary

Companion to the read endpoint merged in #1056. The cowork GUI's knowledge editor ("Save changes") and document-to-knowledge flow need to write curated knowledge back to the engine.

`PUT /api/knowledge/{scenario}` overwrites a scenario's `playbook.md` / `hints.md` / `dead_ends.md` from a `{playbook, hints, deadEnds}` JSON payload:

- Writes only the fields provided as strings (partial updates are fine; non-string values are ignored).
- Returns `{scenario, written: [...]}` listing which files were written.
- Same scenario-id validation (length, alphanumeric with `_`/`-`) and resolve-under-`knowledge_root` path guard as the GET.

## Tests

`tests/test_knowledge_endpoint.py` (the GET shipped untested in #1056; these exercise both directions):
- PUT writes all three files and the GET round-trips them.
- PUT with a partial payload writes only the provided string fields.
- Invalid scenario ids (`bad!name`, `dots..dots`, 129 chars) are rejected with 400.

Checks in a clean worktree off `main`: new tests + `test_server_health.py` pass, `ruff` clean, `mypy` clean.