### PR TITLE
feat(recursive-loop): serve trained mlxlm/opd adapters via the scenario-bound resolver

### DIFF
--- a/autocontext/src/autocontext/agents/scenario_bound_clients.py
+++ b/autocontext/src/autocontext/agents/scenario_bound_clients.py
@@ -31,7 +31,8 @@ logger = logging.getLogger(__name__)
 # (from-scratch GPT / full fine-tunes), vs. backends whose checkpoint is a LoRA
 # adapter that must be loaded on top of its base model via MLXLMClient.
 _FULL_CHECKPOINT_BACKENDS = {"mlx"}
-_ADAPTER_BACKENDS = {"mlxlm", "opd"}
+# mlx-lm LoRA adapter backends served as base + adapter via MLXLMClient.
+_ADAPTER_BACKENDS = {"mlxlm", "opd", "grpo"}
 
 
 @dataclass(frozen=True)
@@ -87,7 +88,7 @@ def _resolve_local_record(settings: AppSettings, scenario_name: str) -> Distille
     except Exception:
         logger.debug("agents.scenario_bound_clients: could not open model registry", exc_info=True)
         return None
-    for backend in ("opd", "mlxlm", "mlx"):
+    for backend in ("opd", "mlxlm", "grpo", "mlx"):
         try:
             record = resolve_model(registry, scenario=scenario_name, backend=backend, runtime_type="provider")
         except Exception:

--- a/autocontext/src/autocontext/agents/scenario_bound_clients.py
+++ b/autocontext/src/autocontext/agents/scenario_bound_clients.py
@@ -9,33 +9,152 @@ they reuse its routed-client cache and client wrapping.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from autocontext.agents.llm_client import LanguageModelClient, build_client_from_settings
+from autocontext.agents.llm_client import (
+    LanguageModelClient,
+    MLXClient,
+    MLXLMClient,
+    build_client_from_settings,
+)
 from autocontext.agents.role_runtime_overrides import settings_for_budgeted_role_call
 
 if TYPE_CHECKING:
     from autocontext.agents.orchestrator import AgentOrchestrator
+    from autocontext.config import AppSettings
+    from autocontext.training.model_registry import DistilledModelRecord
 
 logger = logging.getLogger(__name__)
 
+# Backends whose checkpoint is a standalone model served directly by MLXClient
+# (from-scratch GPT / full fine-tunes), vs. backends whose checkpoint is a LoRA
+# adapter that must be loaded on top of its base model via MLXLMClient.
+_FULL_CHECKPOINT_BACKENDS = {"mlx"}
+_ADAPTER_BACKENDS = {"mlxlm", "opd"}
+
+
+@dataclass(frozen=True)
+class LocalClientPlan:
+    """How to rebuild a served client from a trained registry record.
+
+    ``kind`` selects the client class; ``model`` is the checkpoint path (full) or the
+    base model id (adapter); ``adapter_path`` and ``score_conditioned`` apply to adapters.
+    """
+
+    kind: str  # "mlx" | "mlxlm"
+    model: str
+    adapter_path: str | None
+    score_conditioned: bool
+
+
+def plan_local_client(record: DistilledModelRecord) -> LocalClientPlan | None:
+    """Decide which local client serves a trained record (pure; no model loading).
+
+    Full-checkpoint backends (``mlx``) serve their checkpoint directly. Adapter backends
+    (``mlxlm`` / ``opd``) need the base model they trained against (recorded in metadata at
+    publish time) and the score-conditioning flag so inference re-applies the quality prefix.
+    Returns ``None`` for an unknown backend or an adapter record missing its base model, so
+    the caller falls back to the default client rather than serving something broken.
+    """
+    backend = (record.backend or "").lower()
+    if backend in _ADAPTER_BACKENDS:
+        base_model = str(record.metadata.get("base_model") or "")
+        if not base_model:
+            logger.debug("agents.scenario_bound_clients: adapter record %s has no base_model", record.artifact_id)
+            return None
+        return LocalClientPlan(
+            kind="mlxlm",
+            model=base_model,
+            adapter_path=record.checkpoint_path,
+            score_conditioned=bool(record.metadata.get("score_conditioned")),
+        )
+    if backend in _FULL_CHECKPOINT_BACKENDS:
+        return LocalClientPlan(kind="mlx", model=record.checkpoint_path, adapter_path=None, score_conditioned=False)
+    return None
+
+
+def _resolve_local_record(settings: AppSettings, scenario_name: str) -> DistilledModelRecord | None:
+    """Active provider-runtime record the harness trained for this scenario, capable first.
+
+    Adapter backends (instruct fine-tunes) are preferred over the from-scratch GPT when both
+    are active for the scenario. Returns ``None`` on any registry error or no active model.
+    """
+    from autocontext.training.model_registry import ModelRegistry, resolve_model
+
+    try:
+        registry = ModelRegistry(settings.knowledge_root)
+    except Exception:
+        logger.debug("agents.scenario_bound_clients: could not open model registry", exc_info=True)
+        return None
+    for backend in ("opd", "mlxlm", "mlx"):
+        try:
+            record = resolve_model(registry, scenario=scenario_name, backend=backend, runtime_type="provider")
+        except Exception:
+            logger.debug("agents.scenario_bound_clients: resolve_model failed for backend %s", backend, exc_info=True)
+            record = None
+        if record is not None:
+            return record
+    return None
+
+
+def _build_planned_client(plan: LocalClientPlan, settings: AppSettings) -> LanguageModelClient:
+    """Construct the MLX/MLXLM client described by ``plan`` (loads the model)."""
+    if plan.kind == "mlxlm":
+        return MLXLMClient(
+            plan.model,
+            adapter_path=plan.adapter_path,
+            temperature=settings.mlx_temperature,
+            max_tokens=settings.mlx_max_tokens,
+            score_conditioned=plan.score_conditioned,
+        )
+    return MLXClient(
+        model_path=plan.model,
+        temperature=settings.mlx_temperature,
+        max_tokens=settings.mlx_max_tokens,
+    )
+
 
 def scenario_bound_mlx_client(orch: AgentOrchestrator, role: str, *, scenario_name: str) -> LanguageModelClient | None:
-    """Build the MLX agent client resolved from the registry for this scenario (recursive loop).
+    """Build the local agent client resolved from the registry for this scenario (recursive loop).
 
-    Returns ``None`` when no active model is resolvable, so the caller falls back to the
-    default client. ``build_client_from_settings`` does the registry-aware path resolution.
+    An explicit ``AUTOCONTEXT_MLX_MODEL_PATH`` still wins (served as a full checkpoint). Otherwise
+    the active trained record is resolved and routed by backend: ``mlx`` checkpoints serve directly,
+    while ``mlxlm`` / ``opd`` adapters rebuild ``MLXLMClient(base, adapter, score_conditioned=...)``.
+    Returns ``None`` when nothing is resolvable, so the caller falls back to the default client.
     """
-    key = ("mlx", None, scenario_name, role)
+    key: tuple[str, str | None, str, str]
+    if orch.settings.mlx_model_path:
+        key = ("mlx", None, scenario_name, role)
+        cached = orch._routed_clients.get(key)
+        if cached is not None:
+            return cached
+        try:
+            client = build_client_from_settings(orch.settings, scenario_name=scenario_name)
+        except Exception:
+            logger.debug("agents.scenario_bound_clients: explicit mlx path build failed", exc_info=True)
+            return None
+        client = orch._wrap_client(client, provider_name=f"mlx:{role}")
+        orch._routed_clients[key] = client
+        return client
+
+    record = _resolve_local_record(orch.settings, scenario_name)
+    if record is None:
+        return None
+    plan = plan_local_client(record)
+    if plan is None:
+        return None
+
+    key = (plan.kind, plan.adapter_path, scenario_name, role)
     cached = orch._routed_clients.get(key)
     if cached is not None:
         return cached
     try:
-        client = build_client_from_settings(orch.settings, scenario_name=scenario_name)
+        client = _build_planned_client(plan, orch.settings)
     except Exception:
-        logger.debug("agents.scenario_bound_clients: no active mlx model for scenario", exc_info=True)
+        logger.debug("agents.scenario_bound_clients: planned client build failed", exc_info=True)
         return None
-    client = orch._wrap_client(client, provider_name=f"mlx:{role}")
+    client = orch._wrap_client(client, provider_name=f"{plan.kind}:{role}")
     orch._routed_clients[key] = client
     return client
 

--- a/autocontext/src/autocontext/training/autoresearch/grpo_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/grpo_backend.py
@@ -25,11 +25,13 @@ import json
 from typing import Any
 
 from autocontext.training.autoresearch.sequence_format import extract_json_object
+from autocontext.training.model_defaults import GRPO_DEFAULT_BASE_MODEL
 
 HAS_MLX_LM_LORA = importlib.util.find_spec("mlx_lm_lora") is not None
 
 # Capable instruct base by default (small bases hit the RLVR capability ceiling).
-DEFAULT_BASE_MODEL = "mlx-community/Qwen2.5-1.5B-Instruct-4bit"
+# Sourced from the mlx-free shared module so backends.py can report it without importing mlx.
+DEFAULT_BASE_MODEL = GRPO_DEFAULT_BASE_MODEL
 DEFAULT_VARIANT = "gspo"
 REWARD_NAME = "autocontext_verifier"
 

--- a/autocontext/src/autocontext/training/autoresearch/mlxlm_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/mlxlm_backend.py
@@ -31,11 +31,13 @@ from autocontext.training.autoresearch.sequence_format import (
     resolve_scenario_context,
     score_to_quality_bucket,
 )
+from autocontext.training.model_defaults import MLXLM_DEFAULT_BASE_MODEL
 
 HAS_MLXLM = importlib.util.find_spec("mlx_lm") is not None
 
 # Small instruct base with a 4-bit MLX conversion (QLoRA-friendly). Overridable.
-DEFAULT_BASE_MODEL = "mlx-community/Qwen2.5-0.5B-Instruct-4bit"
+# Sourced from the mlx-free shared module so backends.py can report it without importing mlx.
+DEFAULT_BASE_MODEL = MLXLM_DEFAULT_BASE_MODEL
 
 
 # ---------------------------------------------------------------------------

--- a/autocontext/src/autocontext/training/autoresearch/on_policy_distill.py
+++ b/autocontext/src/autocontext/training/autoresearch/on_policy_distill.py
@@ -24,6 +24,7 @@ import mlx.nn as nn
 # Re-exported from the pure (mlx-free) shared module so the cross-platform trl backend can
 # use it without importing this mlx-scoped module; kept importable here for back-compat.
 from autocontext.training.autoresearch.distill_common import assert_vocab_compatible
+from autocontext.training.model_defaults import OPD_DEFAULT_STUDENT_MODEL, OPD_DEFAULT_TEACHER_MODEL
 
 _EPS = 1e-8
 
@@ -31,8 +32,8 @@ _EPS = 1e-8
 # logits over vocab). Qwen2.5 0.5B/1.5B/3B share vocab 151936, but 7B+ use 152064, so the
 # default teacher is 3B (NOT 7B) -- a 7B teacher with a 1.5B student fails on a vocab shape
 # mismatch. 3B still gives a real teacher>student capability gap for distillation.
-DEFAULT_STUDENT_MODEL = "mlx-community/Qwen2.5-1.5B-Instruct-4bit"
-DEFAULT_TEACHER_MODEL = "mlx-community/Qwen2.5-3B-Instruct-4bit"
+DEFAULT_STUDENT_MODEL = OPD_DEFAULT_STUDENT_MODEL
+DEFAULT_TEACHER_MODEL = OPD_DEFAULT_TEACHER_MODEL
 _LORA_PARAMETERS = {"rank": 8, "dropout": 0.0, "scale": 20.0}
 
 __all__ = [

--- a/autocontext/src/autocontext/training/backends.py
+++ b/autocontext/src/autocontext/training/backends.py
@@ -143,9 +143,9 @@ class MLXLMBackend(TrainingBackend):
         return ["provider", "checkpoint"]
 
     def default_base_model(self) -> str:
-        from autocontext.training.autoresearch.mlxlm_backend import DEFAULT_BASE_MODEL
+        from autocontext.training.model_defaults import MLXLM_DEFAULT_BASE_MODEL
 
-        return DEFAULT_BASE_MODEL
+        return MLXLM_DEFAULT_BASE_MODEL
 
 
 class GRPOBackend(TrainingBackend):
@@ -174,9 +174,9 @@ class GRPOBackend(TrainingBackend):
         return ["provider", "checkpoint"]
 
     def default_base_model(self) -> str:
-        from autocontext.training.autoresearch.grpo_backend import DEFAULT_BASE_MODEL
+        from autocontext.training.model_defaults import GRPO_DEFAULT_BASE_MODEL
 
-        return DEFAULT_BASE_MODEL
+        return GRPO_DEFAULT_BASE_MODEL
 
 
 class OnPolicyDistillBackend(TrainingBackend):
@@ -205,9 +205,9 @@ class OnPolicyDistillBackend(TrainingBackend):
         return ["provider", "checkpoint"]
 
     def default_base_model(self) -> str:
-        from autocontext.training.autoresearch.on_policy_distill import DEFAULT_STUDENT_MODEL
+        from autocontext.training.model_defaults import OPD_DEFAULT_STUDENT_MODEL
 
-        return DEFAULT_STUDENT_MODEL
+        return OPD_DEFAULT_STUDENT_MODEL
 
 
 class TRLBackend(TrainingBackend):

--- a/autocontext/src/autocontext/training/backends.py
+++ b/autocontext/src/autocontext/training/backends.py
@@ -51,6 +51,16 @@ class TrainingBackend(ABC):
         """Runtime types this backend can serve."""
         return ["provider"]
 
+    def default_base_model(self) -> str:
+        """Effective base/student model when no explicit ``--base-model`` is given.
+
+        From-scratch / standalone-checkpoint backends train no adapter and need no base, so
+        they return ``""``. Adapter backends (LoRA on a pretrained base) return the model the
+        subprocess actually defaults to, so the runner can persist the *effective* base on the
+        published record (an adapter is unservable without it). See ``_publish_best_model``.
+        """
+        return ""
+
 
 class MLXBackend(TrainingBackend):
     """Apple Silicon MLX backend."""
@@ -129,7 +139,13 @@ class MLXLMBackend(TrainingBackend):
         return Path("models") / scenario / "mlxlm"
 
     def supported_runtime_types(self) -> list[str]:
-        return ["checkpoint"]  # LoRA adapter bundle
+        # LoRA adapter bundle, but mlx-lm can serve it as an agent provider (base + adapter).
+        return ["provider", "checkpoint"]
+
+    def default_base_model(self) -> str:
+        from autocontext.training.autoresearch.mlxlm_backend import DEFAULT_BASE_MODEL
+
+        return DEFAULT_BASE_MODEL
 
 
 class GRPOBackend(TrainingBackend):
@@ -154,7 +170,13 @@ class GRPOBackend(TrainingBackend):
         return Path("models") / scenario / "grpo"
 
     def supported_runtime_types(self) -> list[str]:
-        return ["checkpoint"]  # LoRA adapter bundle
+        # LoRA adapter bundle, but mlx-lm can serve it as an agent provider (base + adapter).
+        return ["provider", "checkpoint"]
+
+    def default_base_model(self) -> str:
+        from autocontext.training.autoresearch.grpo_backend import DEFAULT_BASE_MODEL
+
+        return DEFAULT_BASE_MODEL
 
 
 class OnPolicyDistillBackend(TrainingBackend):
@@ -179,7 +201,13 @@ class OnPolicyDistillBackend(TrainingBackend):
         return Path("models") / scenario / "opd"
 
     def supported_runtime_types(self) -> list[str]:
-        return ["checkpoint"]  # LoRA adapter bundle
+        # LoRA adapter bundle, but mlx-lm can serve it as an agent provider (base + adapter).
+        return ["provider", "checkpoint"]
+
+    def default_base_model(self) -> str:
+        from autocontext.training.autoresearch.on_policy_distill import DEFAULT_STUDENT_MODEL
+
+        return DEFAULT_STUDENT_MODEL
 
 
 class TRLBackend(TrainingBackend):

--- a/autocontext/src/autocontext/training/model_defaults.py
+++ b/autocontext/src/autocontext/training/model_defaults.py
@@ -1,0 +1,20 @@
+"""Default base/student/teacher model ids for the adapter training backends.
+
+Kept in a dependency-free module (no ``mlx`` / ``torch`` imports) so the lightweight
+``backends.py`` can report a backend's *effective* default base model without importing the
+heavy backend implementation. This is the single source of truth: the autoresearch backend
+modules re-export these, so the model the runner records on a published adapter is exactly the
+one the training subprocess trains against (a mismatch would serve the adapter on the wrong base).
+"""
+
+from __future__ import annotations
+
+# mlx-lm LoRA SFT (mlxlm backend).
+MLXLM_DEFAULT_BASE_MODEL = "mlx-community/Qwen2.5-0.5B-Instruct-4bit"
+
+# mlx-lm-lora RLVR (grpo backend).
+GRPO_DEFAULT_BASE_MODEL = "mlx-community/Qwen2.5-1.5B-Instruct-4bit"
+
+# mlx-lm on-policy distillation (opd backend): student is the trained model, teacher is frozen.
+OPD_DEFAULT_STUDENT_MODEL = "mlx-community/Qwen2.5-1.5B-Instruct-4bit"
+OPD_DEFAULT_TEACHER_MODEL = "mlx-community/Qwen2.5-3B-Instruct-4bit"

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -650,6 +650,13 @@ class TrainingRunner:
                 "backend_metadata": self._backend.metadata(),
                 "experiment_index": best_result.experiment_index,
                 "work_dir": str(self.work_dir),
+                # Serving bridge: an adapter checkpoint (mlxlm/opd) is useless without
+                # the base model it was trained against, and a score-conditioned model
+                # must be prompted with the quality prefix at inference. Record both so
+                # the scenario-bound resolver can rebuild the right client (see
+                # scenario_bound_clients.plan_local_client).
+                "base_model": self.config.base_model,
+                "score_conditioned": self.config.score_conditioned,
             },
         )
         record = publish_training_output(

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -654,8 +654,10 @@ class TrainingRunner:
                 # the base model it was trained against, and a score-conditioned model
                 # must be prompted with the quality prefix at inference. Record both so
                 # the scenario-bound resolver can rebuild the right client (see
-                # scenario_bound_clients.plan_local_client).
-                "base_model": self.config.base_model,
+                # scenario_bound_clients.plan_local_client). Fall back to the backend's
+                # effective default when no explicit --base-model was given, since the
+                # subprocess applies that same default (an empty value is unservable).
+                "base_model": self.config.base_model or self._backend.default_base_model(),
                 "score_conditioned": self.config.score_conditioned,
             },
         )

--- a/autocontext/tests/test_on_policy_distill_backend.py
+++ b/autocontext/tests/test_on_policy_distill_backend.py
@@ -17,7 +17,9 @@ def test_opd_backend_metadata() -> None:
 
     backend = default_backend_registry().get("opd")
     assert backend is not None
-    assert backend.supported_runtime_types() == ["checkpoint"]  # LoRA adapter bundle
+    # LoRA adapter bundle that mlx-lm can also serve as an agent provider (base + adapter).
+    assert backend.supported_runtime_types() == ["provider", "checkpoint"]
+    assert backend.default_base_model()  # effective student/base recorded for serving
     assert "opd" in str(backend.default_checkpoint_dir("grid_ctf"))
 
 

--- a/autocontext/tests/test_recursive_loop_bridge.py
+++ b/autocontext/tests/test_recursive_loop_bridge.py
@@ -13,6 +13,7 @@ from autocontext.agents.scenario_bound_clients import (
     plan_local_client,
 )
 from autocontext.config.settings import AppSettings
+from autocontext.training.backends import default_backend_registry
 from autocontext.training.model_registry import (
     DistilledModelRecord,
     ModelRegistry,
@@ -36,7 +37,19 @@ def _record(*, backend: str, checkpoint: str = "/ckpt", metadata: dict | None = 
     )
 
 
-def _register_active(root, *, artifact_id: str, backend: str, checkpoint: str, metadata: dict | None = None) -> None:
+def _register_active(
+    root,
+    *,
+    artifact_id: str,
+    backend: str,
+    checkpoint: str,
+    metadata: dict | None = None,
+    runtime_types: list[str] | None = None,
+) -> None:
+    # Default to the *real* runtime slots the backend advertises, so the test exercises the
+    # actual runner publish shape rather than a hand-picked ["provider"] that masks slot bugs.
+    if runtime_types is None:
+        runtime_types = default_backend_registry().get(backend).supported_runtime_types()
     reg = ModelRegistry(root)
     reg.register(
         DistilledModelRecord(
@@ -45,7 +58,7 @@ def _register_active(root, *, artifact_id: str, backend: str, checkpoint: str, m
             scenario_family="game",
             backend=backend,
             checkpoint_path=checkpoint,
-            runtime_types=["provider"],
+            runtime_types=runtime_types,
             activation_state="candidate",
             training_metrics={},
             provenance={},
@@ -131,7 +144,8 @@ def test_published_adapter_record_routes_to_mlxlm(tmp_path) -> None:
         backend="opd",
         scenario="grid_ctf",
         scenario_family="game",
-        runtime_types=["provider"],
+        # Real runner shape: the backend's advertised slots, not a hand-picked ["provider"].
+        runtime_types=default_backend_registry().get("opd").supported_runtime_types(),
         metadata={"base_model": "Qwen/Qwen2.5-3B", "score_conditioned": True},
     )
     record = publish_training_output(completion, registry, artifacts_root=None, auto_activate=True)
@@ -145,3 +159,49 @@ def test_published_adapter_record_routes_to_mlxlm(tmp_path) -> None:
     assert plan.model == "Qwen/Qwen2.5-3B"
     assert plan.adapter_path == "/adapters/lora"
     assert plan.score_conditioned is True
+
+
+# --- regression: the two ways the runner path was unservable --------------------------------
+
+
+def test_adapter_backends_advertise_provider_serving() -> None:
+    """[P1] An adapter published with the backend's own runtime slots must be resolvable as a
+    provider. Adapter backends advertised only ["checkpoint"], so resolve_model(provider) missed
+    every real runner record while ["provider"]-only tests passed."""
+    registry = default_backend_registry()
+    for name in ("mlxlm", "opd", "grpo"):
+        assert "provider" in registry.get(name).supported_runtime_types(), name
+
+
+def test_adapter_backends_expose_effective_default_base_model() -> None:
+    """[P2] A default `autoctx train --backend opd/mlxlm` leaves config.base_model empty and the
+    subprocess applies the backend default; that effective base must be recordable, else the
+    published adapter is unservable even with the runtime-slot fixed."""
+    registry = default_backend_registry()
+    for name in ("mlxlm", "opd", "grpo"):
+        assert registry.get(name).default_base_model(), name
+    # From-scratch backends train no adapter and need no base.
+    assert default_backend_registry().get("mlx").default_base_model() == ""
+
+
+def test_default_train_publish_is_servable(tmp_path) -> None:
+    """[P1+P2] End-to-end of the *default* CLI path: no --base-model override, backend-advertised
+    runtime slots, effective default base recorded -> the record resolves and routes to MLXLMClient."""
+    backend = default_backend_registry().get("opd")
+    effective_base = backend.default_base_model()  # what runner records when config.base_model == ""
+    _register_active(
+        tmp_path,
+        artifact_id="m1",
+        backend="opd",
+        checkpoint="/adapters/lora",
+        metadata={"base_model": effective_base, "score_conditioned": False},
+        # runtime_types defaults to backend.supported_runtime_types() inside the helper
+    )
+    settings = AppSettings(agent_provider="mlx", mlx_model_path="", knowledge_root=tmp_path)
+
+    record = _resolve_local_record(settings, "grid_ctf")
+    assert record is not None, "default-trained adapter must resolve as a provider"
+    plan = plan_local_client(record)
+    assert plan is not None and plan.kind == "mlxlm"
+    assert plan.model == effective_base and plan.model != ""
+    assert plan.adapter_path == "/adapters/lora"

--- a/autocontext/tests/test_recursive_loop_bridge.py
+++ b/autocontext/tests/test_recursive_loop_bridge.py
@@ -1,0 +1,147 @@
+"""Recursive-loop serving bridge: a trained adapter is served by the right local client.
+
+Closes the last wiring step of the loop for capable models. CI-safe (JSON-file registry,
+no MLX load, no training): exercises the pure routing decision (``plan_local_client``), the
+record resolution preference, and the publish -> route round-trip that the runner relies on.
+"""
+
+from __future__ import annotations
+
+from autocontext.agents.scenario_bound_clients import (
+    LocalClientPlan,
+    _resolve_local_record,
+    plan_local_client,
+)
+from autocontext.config.settings import AppSettings
+from autocontext.training.model_registry import (
+    DistilledModelRecord,
+    ModelRegistry,
+    TrainingCompletionOutput,
+    publish_training_output,
+)
+
+
+def _record(*, backend: str, checkpoint: str = "/ckpt", metadata: dict | None = None) -> DistilledModelRecord:
+    return DistilledModelRecord(
+        artifact_id="a1",
+        scenario="grid_ctf",
+        scenario_family="game",
+        backend=backend,
+        checkpoint_path=checkpoint,
+        runtime_types=["provider"],
+        activation_state="active",
+        training_metrics={},
+        provenance={},
+        metadata=metadata or {},
+    )
+
+
+def _register_active(root, *, artifact_id: str, backend: str, checkpoint: str, metadata: dict | None = None) -> None:
+    reg = ModelRegistry(root)
+    reg.register(
+        DistilledModelRecord(
+            artifact_id=artifact_id,
+            scenario="grid_ctf",
+            scenario_family="game",
+            backend=backend,
+            checkpoint_path=checkpoint,
+            runtime_types=["provider"],
+            activation_state="candidate",
+            training_metrics={},
+            provenance={},
+            metadata=metadata or {},
+        )
+    )
+    reg.activate(artifact_id)
+
+
+# --- plan_local_client: the pure routing decision -------------------------------------------
+
+
+def test_mlx_full_checkpoint_serves_directly() -> None:
+    plan = plan_local_client(_record(backend="mlx", checkpoint="/trained/gpt"))
+    assert plan == LocalClientPlan(kind="mlx", model="/trained/gpt", adapter_path=None, score_conditioned=False)
+
+
+def test_mlxlm_adapter_routes_to_base_plus_adapter() -> None:
+    plan = plan_local_client(_record(backend="mlxlm", checkpoint="/adapters/lora", metadata={"base_model": "Qwen/Qwen2.5-1.5B"}))
+    assert plan == LocalClientPlan(
+        kind="mlxlm", model="Qwen/Qwen2.5-1.5B", adapter_path="/adapters/lora", score_conditioned=False
+    )
+
+
+def test_opd_adapter_routes_like_mlxlm() -> None:
+    plan = plan_local_client(_record(backend="opd", checkpoint="/adapters/opd", metadata={"base_model": "Qwen/Qwen2.5-3B"}))
+    assert plan is not None
+    assert plan.kind == "mlxlm"
+    assert plan.model == "Qwen/Qwen2.5-3B"
+    assert plan.adapter_path == "/adapters/opd"
+
+
+def test_score_conditioned_flag_is_carried_for_serving() -> None:
+    plan = plan_local_client(_record(backend="opd", metadata={"base_model": "Qwen/Qwen2.5-3B", "score_conditioned": True}))
+    assert plan is not None and plan.score_conditioned is True
+
+
+def test_adapter_without_base_model_is_unservable() -> None:
+    # An adapter is useless without the base it was trained against -> fall back, not crash.
+    assert plan_local_client(_record(backend="mlxlm", metadata={})) is None
+
+
+def test_unknown_backend_falls_back() -> None:
+    assert plan_local_client(_record(backend="something-else")) is None
+
+
+# --- _resolve_local_record: which active model wins -----------------------------------------
+
+
+def test_resolves_active_record_for_scenario(tmp_path) -> None:
+    _register_active(
+        tmp_path, artifact_id="m1", backend="mlxlm", checkpoint="/lora", metadata={"base_model": "Qwen/Qwen2.5-1.5B"}
+    )
+    settings = AppSettings(agent_provider="mlx", mlx_model_path="", knowledge_root=tmp_path)
+    record = _resolve_local_record(settings, "grid_ctf")
+    assert record is not None and record.backend == "mlxlm"
+
+
+def test_adapter_backend_preferred_over_from_scratch_gpt(tmp_path) -> None:
+    # Both active for the scenario: the capable instruct fine-tune wins over the from-scratch GPT.
+    _register_active(tmp_path, artifact_id="gpt", backend="mlx", checkpoint="/gpt")
+    _register_active(tmp_path, artifact_id="ad", backend="opd", checkpoint="/lora", metadata={"base_model": "Qwen/Qwen2.5-3B"})
+    settings = AppSettings(agent_provider="mlx", mlx_model_path="", knowledge_root=tmp_path)
+    record = _resolve_local_record(settings, "grid_ctf")
+    assert record is not None and record.backend == "opd"
+
+
+def test_no_active_model_resolves_to_none(tmp_path) -> None:
+    settings = AppSettings(agent_provider="mlx", mlx_model_path="", knowledge_root=tmp_path)
+    assert _resolve_local_record(settings, "grid_ctf") is None
+
+
+# --- publish -> route round-trip: what the runner actually wires up --------------------------
+
+
+def test_published_adapter_record_routes_to_mlxlm(tmp_path) -> None:
+    """The runner records base_model + score_conditioned in completion.metadata; publishing must
+    surface them on the record so the resolver can rebuild MLXLMClient(base, adapter, ...)."""
+    registry = ModelRegistry(tmp_path)
+    completion = TrainingCompletionOutput(
+        run_id="r1",
+        checkpoint_path="/adapters/lora",
+        backend="opd",
+        scenario="grid_ctf",
+        scenario_family="game",
+        runtime_types=["provider"],
+        metadata={"base_model": "Qwen/Qwen2.5-3B", "score_conditioned": True},
+    )
+    record = publish_training_output(completion, registry, artifacts_root=None, auto_activate=True)
+
+    assert record.metadata.get("base_model") == "Qwen/Qwen2.5-3B"
+    assert record.metadata.get("score_conditioned") is True
+
+    plan = plan_local_client(record)
+    assert plan is not None
+    assert plan.kind == "mlxlm"
+    assert plan.model == "Qwen/Qwen2.5-3B"
+    assert plan.adapter_path == "/adapters/lora"
+    assert plan.score_conditioned is True


### PR DESCRIPTION
## What

Closes the last wiring step of the recursive loop for **capable models**. Until now the loop could only auto-serve from-scratch `mlx` GPT checkpoints (#1055). This routes an active `mlxlm`/`opd` LoRA adapter the harness trained and auto-activated back into the next run's agent role via `MLXLMClient` (#1058's serving capability).

The two halves wired here:

1. **Publish carries what serving needs.** `runner._publish_best_model` now records `base_model` and `score_conditioned` on the published registry record (through `completion.metadata`). An adapter checkpoint is useless without the base it was trained against, and a score-conditioned model must be re-prompted with the quality prefix at inference.

2. **The resolver routes by backend.** `scenario_bound_clients` gains a pure `plan_local_client(record)` decision:
   - `mlx` full checkpoint → `MLXClient(checkpoint)` (unchanged)
   - `mlxlm` / `opd` adapter → `MLXLMClient(base, adapter_path, score_conditioned=...)`
   - adapter missing its `base_model`, or unknown backend → `None` (fall back to the default client rather than serve something broken)

   The active record is resolved capable-backend-first (`opd` → `mlxlm` → `mlx`), so an instruct fine-tune wins over the from-scratch GPT when both are active for a scenario. An explicit `AUTOCONTEXT_MLX_MODEL_PATH` still takes precedence.

## Tests

CI-safe (JSON-file registry, no MLX load, no training): the routing decision for each backend, the score-conditioned flag carry-through, the unservable-adapter / unknown-backend fallbacks, the resolution preference, and a `publish_training_output` → `plan_local_client` round-trip that mirrors exactly what the runner wires up.

Full local sweep green: new bridge suite + `test_mlx_agent_resolution` + `test_scenario_routing` + `test_model_registry` + `test_model_router_integration` + `test_module_size_limits`; ruff + mypy clean.