### PR TITLE
fix(cli-train): drive adapter backends end-to-end (--train-steps wiring + per-backend defaults)

### DIFF
--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -95,12 +95,14 @@ tokenizer with a natural-language prompt/completion and completion-only loss
 
 Install the extra: `uv sync --group dev --extra mlxlm`.
 
-| Flag               | Default                                    | Effect                                                           |
-| ------------------ | ------------------------------------------ | ---------------------------------------------------------------- |
-| `--backend mlxlm`  | `mlx`                                      | Select the pretrained-finetune backend.                          |
-| `--base-model`     | `mlx-community/Qwen2.5-0.5B-Instruct-4bit` | Pretrained mlx-lm model (HF repo or local path).                 |
-| `--fine-tune-type` | `lora`                                     | `lora`, `dora` (weight-decomposed, usually stronger), or `full`. |
-| `--num-layers`     | `8`                                        | Number of layers to fine-tune (fewer = less memory).             |
+| Flag               | Default                                    | Effect                                                                              |
+| ------------------ | ------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `--backend mlxlm`  | `mlx`                                      | Select the pretrained-finetune backend.                                             |
+| `--base-model`     | `mlx-community/Qwen2.5-0.5B-Instruct-4bit` | Pretrained mlx-lm model (HF repo or local path).                                    |
+| `--fine-tune-type` | `lora`                                     | `lora`, `dora` (weight-decomposed, usually stronger), or `full`.                    |
+| `--num-layers`     | `8`                                        | Number of layers to fine-tune (fewer = less memory).                                |
+| `--train-steps`    | `0` (= 100 for adapter backends)           | Training steps. `0` resolves per backend: 8 from-scratch, 100 adapters.             |
+| `--learning-rate`  | `0` (= 1e-4 for `mlxlm`)                   | `0` resolves per backend: 1e-3 from-scratch, 1e-4 `mlxlm`, 1e-5 `opd`/`grpo`/`trl`. |
 
 ```bash
 uv run autoctx train --backend mlxlm \

--- a/autocontext/src/autocontext/cli_train.py
+++ b/autocontext/src/autocontext/cli_train.py
@@ -77,6 +77,9 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             "--backend",
             help="Training backend: mlx, cuda, mlxlm, grpo, opd, trl (cross-platform GKD/GRPO via TRL)",
         ),
+        train_steps: int = typer.Option(
+            0, "--train-steps", help="Training steps (0 = backend default: 8 from-scratch mlx/cuda, 100 adapter backends)"
+        ),
         trl_mode: str = typer.Option("gkd", "--trl-mode", help="trl backend: gkd (on-policy distillation) | grpo (RLVR)"),
         seed: int = typer.Option(0, "--seed", help="trl backend: training seed (for seeded repeats / error bars)"),
         agent_provider: str = typer.Option("anthropic", "--agent-provider", help="LLM provider for training agent"),
@@ -138,6 +141,10 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             raise typer.BadParameter(f"--vocab-size must be >= 256 (the byte-level BPE base), got {vocab_size}")
         if trl_mode not in ("gkd", "grpo"):
             raise typer.BadParameter(f"--trl-mode must be gkd|grpo, got {trl_mode!r}")
+        if backend not in ("mlx", "cuda", "mlxlm", "grpo", "opd", "trl"):
+            raise typer.BadParameter(f"--backend must be mlx|cuda|mlxlm|grpo|opd|trl, got {backend!r}")
+        if train_steps < 0:
+            raise typer.BadParameter(f"--train-steps must be >= 0 (0 = backend default), got {train_steps}")
 
         logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 
@@ -148,6 +155,7 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             max_experiments=max_experiments,
             memory_limit_mb=memory_limit,
             backend=backend,
+            train_steps=train_steps,
             agent_provider=agent_provider,
             agent_model=agent_model,
             val_select=val_select,

--- a/autocontext/src/autocontext/cli_train.py
+++ b/autocontext/src/autocontext/cli_train.py
@@ -80,6 +80,11 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
         train_steps: int = typer.Option(
             0, "--train-steps", help="Training steps (0 = backend default: 8 from-scratch mlx/cuda, 100 adapter backends)"
         ),
+        learning_rate: float = typer.Option(
+            0.0,
+            "--learning-rate",
+            help="Learning rate (0 = backend default: 1e-3 from-scratch, 1e-4 mlxlm, 1e-5 opd/grpo/trl)",
+        ),
         trl_mode: str = typer.Option("gkd", "--trl-mode", help="trl backend: gkd (on-policy distillation) | grpo (RLVR)"),
         seed: int = typer.Option(0, "--seed", help="trl backend: training seed (for seeded repeats / error bars)"),
         agent_provider: str = typer.Option("anthropic", "--agent-provider", help="LLM provider for training agent"),
@@ -145,6 +150,8 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             raise typer.BadParameter(f"--backend must be mlx|cuda|mlxlm|grpo|opd|trl, got {backend!r}")
         if train_steps < 0:
             raise typer.BadParameter(f"--train-steps must be >= 0 (0 = backend default), got {train_steps}")
+        if learning_rate < 0:
+            raise typer.BadParameter(f"--learning-rate must be >= 0 (0 = backend default), got {learning_rate}")
 
         logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 
@@ -156,6 +163,7 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             memory_limit_mb=memory_limit,
             backend=backend,
             train_steps=train_steps,
+            learning_rate=learning_rate,
             agent_provider=agent_provider,
             agent_model=agent_model,
             val_select=val_select,

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -350,6 +350,25 @@ def _preflight_backend_deps(backend: str) -> None:
         raise RuntimeError(f"{lead}; missing: {', '.join(missing)}. Install with: {install}")
 
 
+def _default_train_steps(backend: str) -> int:
+    """Resolve ``--train-steps`` when left unset (<= 0).
+
+    The from-scratch GPT backends (mlx/cuda) converge in a handful of steps; the
+    pretrained-adapter backends (mlxlm LoRA / opd distillation / grpo+trl RLVR) need far more
+    to move a strong prior, so the old global default of 8 silently undertrained them (an
+    8-step LoRA learns almost nothing). Users still override explicitly with --train-steps."""
+    return 8 if backend in ("mlx", "cuda") else 100
+
+
+def _default_learning_rate(backend: str) -> float:
+    """Resolve ``--learning-rate`` when left unset (<= 0).
+
+    The from-scratch GPT backends train at 1e-3; that rate is ~10x too high for a LoRA adapter
+    and diverges it to garbage tokens, so each pretrained-adapter backend gets the rate its own
+    entry point is tuned for (mlxlm LoRA 1e-4; opd/grpo/trl RLVR+distillation 1e-5)."""
+    return {"mlx": 1e-3, "cuda": 1e-3, "mlxlm": 1e-4}.get(backend, 1e-5)
+
+
 def run_training(
     *,
     scenario_name: str,
@@ -357,9 +376,9 @@ def run_training(
     output_dir: Path,
     time_budget: int,
     memory_limit_mb: int,
-    train_steps: int = 8,
+    train_steps: int = 0,  # 0 = backend default (see _default_train_steps)
     batch_size: int = 4,
-    learning_rate: float = 1e-3,
+    learning_rate: float = 0.0,  # 0 = backend default (see _default_learning_rate)
     seq_len: int = 128,
     assess_samples: int = 8,
     assess_temperature: float = 0.0,
@@ -394,6 +413,10 @@ def run_training(
         raise ValueError(f"vocab_size must be >= 256 (the byte-level BPE base), got {vocab_size}")
 
     normalized_backend = backend.strip().lower()
+    if train_steps <= 0:  # resolve the unset sentinel to a backend-appropriate step count
+        train_steps = _default_train_steps(normalized_backend)
+    if learning_rate <= 0:  # likewise: a from-scratch LR diverges a LoRA adapter
+        learning_rate = _default_learning_rate(normalized_backend)
     # Shared args; backend extras added per dispatch (each entry runs its own dep preflight).
     common: dict[str, Any] = dict(
         scenario_name=scenario_name,
@@ -524,9 +547,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--seed", type=int, default=0, help="trl backend: training seed (seeded repeats)")
     parser.add_argument("--time-budget", type=int, default=300)
     parser.add_argument("--memory-limit", type=int, default=16384)
-    parser.add_argument("--train-steps", type=int, default=8)
+    parser.add_argument("--train-steps", type=int, default=0, help="0 = backend default (8 from-scratch, 100 adapters)")
     parser.add_argument("--batch-size", type=int, default=4)
-    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument(
+        "--learning-rate", type=float, default=0.0, help="0 = backend default (1e-3 from-scratch, 1e-4 mlxlm, 1e-5 opd/grpo/trl)"
+    )
     parser.add_argument("--seq-len", type=int, default=128)
     parser.add_argument("--assess-samples", type=int, default=8)
     parser.add_argument("--assess-temperature", type=float, default=0.0, help="assessment sampling temp (<=0 greedy)")

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -56,6 +56,7 @@ class TrainingConfig:
     max_experiments: int = 0
     memory_limit_mb: int = 16384
     backend: str = "mlx"
+    train_steps: int = 0  # 0 = backend default (8 from-scratch mlx/cuda, 100 pretrained-adapter backends)
     agent_provider: str = "anthropic"
     agent_model: str = ""
     val_select: bool = False  # keep best-by-validation-loss checkpoint + early stop (MLX only)
@@ -405,6 +406,8 @@ class TrainingRunner:
             "--backend",
             self.config.backend,
         ]
+        if self.config.train_steps > 0:
+            command += ["--train-steps", str(self.config.train_steps)]
         if self.config.val_select:
             command.append("--val-select")
         if self.config.elite_fraction != 1.0:

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -57,6 +57,7 @@ class TrainingConfig:
     memory_limit_mb: int = 16384
     backend: str = "mlx"
     train_steps: int = 0  # 0 = backend default (8 from-scratch mlx/cuda, 100 pretrained-adapter backends)
+    learning_rate: float = 0.0  # 0 = backend default (1e-3 from-scratch, 1e-4 mlxlm, 1e-5 opd/grpo/trl)
     agent_provider: str = "anthropic"
     agent_model: str = ""
     val_select: bool = False  # keep best-by-validation-loss checkpoint + early stop (MLX only)
@@ -408,6 +409,8 @@ class TrainingRunner:
         ]
         if self.config.train_steps > 0:
             command += ["--train-steps", str(self.config.train_steps)]
+        if self.config.learning_rate > 0:
+            command += ["--learning-rate", str(self.config.learning_rate)]
         if self.config.val_select:
             command.append("--val-select")
         if self.config.elite_fraction != 1.0:

--- a/autocontext/tests/test_train_summary.py
+++ b/autocontext/tests/test_train_summary.py
@@ -59,3 +59,26 @@ def test_parse_summary_picks_up_val_loss() -> None:
     parsed = TrainingRunner.parse_summary(runner, block)
     assert parsed is not None
     assert parsed["val_loss"] == 0.789
+
+
+def test_default_train_steps_distinguishes_from_scratch_vs_adapter() -> None:
+    """A from-scratch GPT converges in a few steps; pretrained-adapter backends need far more,
+    so the unset (<=0) sentinel must resolve to different defaults per backend family."""
+    from autocontext.training.autoresearch.train import _default_train_steps
+
+    assert _default_train_steps("mlx") == 8
+    assert _default_train_steps("cuda") == 8
+    for adapter in ("mlxlm", "opd", "grpo", "trl"):
+        assert _default_train_steps(adapter) == 100, adapter
+
+
+def test_default_learning_rate_per_backend() -> None:
+    """A from-scratch LR (1e-3) diverges a LoRA adapter; each adapter backend resolves to the
+    rate its own entry point is tuned for when --learning-rate is left unset."""
+    from autocontext.training.autoresearch.train import _default_learning_rate
+
+    assert _default_learning_rate("mlx") == 1e-3
+    assert _default_learning_rate("cuda") == 1e-3
+    assert _default_learning_rate("mlxlm") == 1e-4
+    for rlvr in ("opd", "grpo", "trl"):
+        assert _default_learning_rate(rlvr) == 1e-5, rlvr

--- a/autocontext/tests/test_training_runner.py
+++ b/autocontext/tests/test_training_runner.py
@@ -336,6 +336,32 @@ class TestConstraints:
         command = mock_run.call_args.args[0]
         assert "--loss-weight-by-score" not in command  # uniform default stays off the command line
 
+    def test_experiment_subprocess_passes_train_steps_when_set(self, tmp_path: Path) -> None:
+        """--train-steps must flow CLI -> TrainingConfig -> subprocess, else `autoctx train
+        --backend mlxlm --train-steps 80` silently trains the adapter for the 8-step default."""
+        cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl", backend="mlxlm", train_steps=80)
+        (tmp_path / "data.jsonl").write_text("{}\n")
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run:
+            runner._run_experiment_subprocess(0)
+
+        command = mock_run.call_args.args[0]
+        assert command[command.index("--train-steps") + 1] == "80"
+
+    def test_experiment_subprocess_omits_train_steps_when_unset(self, tmp_path: Path) -> None:
+        cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl")  # train_steps=0
+        (tmp_path / "data.jsonl").write_text("{}\n")
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run:
+            runner._run_experiment_subprocess(0)
+
+        # Unset stays off the command line so train.py applies its per-backend default.
+        assert "--train-steps" not in mock_run.call_args.args[0]
+
     def test_convergence_nudge_after_consecutive_discards(self, tmp_path: Path) -> None:
         cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl")
         (tmp_path / "data.jsonl").write_text("{}\n")

--- a/autocontext/tests/test_training_runner.py
+++ b/autocontext/tests/test_training_runner.py
@@ -362,6 +362,31 @@ class TestConstraints:
         # Unset stays off the command line so train.py applies its per-backend default.
         assert "--train-steps" not in mock_run.call_args.args[0]
 
+    def test_experiment_subprocess_passes_learning_rate_when_set(self, tmp_path: Path) -> None:
+        """--learning-rate must flow CLI -> TrainingConfig -> subprocess (the documented flag);
+        else `autoctx train --backend mlxlm --learning-rate 1e-4` can't override the default."""
+        cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl", backend="mlxlm", learning_rate=1e-4)
+        (tmp_path / "data.jsonl").write_text("{}\n")
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run:
+            runner._run_experiment_subprocess(0)
+
+        command = mock_run.call_args.args[0]
+        assert command[command.index("--learning-rate") + 1] == "0.0001"
+
+    def test_experiment_subprocess_omits_learning_rate_when_unset(self, tmp_path: Path) -> None:
+        cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl")  # learning_rate=0.0
+        (tmp_path / "data.jsonl").write_text("{}\n")
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run:
+            runner._run_experiment_subprocess(0)
+
+        assert "--learning-rate" not in mock_run.call_args.args[0]
+
     def test_convergence_nudge_after_consecutive_discards(self, tmp_path: Path) -> None:
         cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl")
         (tmp_path / "data.jsonl").write_text("{}\n")


### PR DESCRIPTION
## What

Make the recursive loop fully drivable from the CLI for the **pretrained-adapter backends** (`mlxlm`/`opd`/`grpo`/`trl`). The CLI, runner, and `train.py` were already wired to *accept* these backends — but two from-scratch-tuned defaults silently broke them when driven through `autoctx train`:

### 1. `--train-steps` was never forwarded
`TrainingConfig` had no `train_steps` field and the runner never passed `--train-steps` to the subprocess, so every backend trained at `train.py`'s 8-step default. An 8-step LoRA learns essentially nothing. Now:
- `TrainingConfig.train_steps` (default `0` = unset), forwarded by the runner only when `> 0`.
- `train.py` resolves the `0` sentinel per backend via `_default_train_steps`: **8** for from-scratch (mlx/cuda), **100** for adapter backends.
- CLI exposes `--train-steps`.

### 2. `learning_rate=1e-3` diverged LoRA adapters
`train.py`'s default LR is tuned for the from-scratch GPT; it is ~10x too high for a LoRA adapter and **diverged it to garbage tokens** (in-training assessment `avg_score=0`). Now `train.py` resolves an unset (`0`) LR per backend via `_default_learning_rate`: **1e-3** from-scratch, **1e-4** `mlxlm`, **1e-5** `opd`/`grpo`/`trl` — each backend's own tuned rate.

Also: the CLI validates `--backend` against the known set and rejects negative `--train-steps`.

## Verified live

`train.py --backend mlxlm --train-steps 80` on `grid_ctf` (cached Qwen2.5-0.5B):
- **before** (1e-3 default): assessment `avg_score=0.0`, `valid_rate=0.0` — adapter emits `!!!!` garbage.
- **after** (resolved 1e-4): assessment `avg_score=0.8654`, `valid_rate=1.0`, 80 steps, 20s.

## Tests
Runner forwards `--train-steps` when set / omits when unset; `_default_train_steps` and `_default_learning_rate` resolution per backend. Full training-backend + runner + CLI regression green; ruff + mypy clean. Documents the resolved defaults in `mlx-training.md`.

## Note
Both bugs are the same class the recursive-loop demo work keeps surfacing: a from-scratch-tuned default silently breaking the pretrained-adapter path. The sentinel-default pattern (`0` = per-backend default) keeps existing mlx/cuda behavior byte-identical while making the adapter backends correct out of the box.