### PR TITLE
feat(self-improve): generalize ReST-EM loop to mlxlm backend + agent-task scenarios

### DIFF
--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -387,8 +387,12 @@ self-training analogue of rejection-sampling fine-tuning, lifted from a single f
 an iterated one.
 
 Sampling uses a positive temperature so the collected constructions are diverse
-(greedy decoding would collect identical samples and stall the loop). Sample
-collection is MLX-only for now, so the loop drives the `mlx` backend.
+(greedy decoding would collect identical samples and stall the loop). The loop drives
+the SFT backends that collect assessment samples: `mlx` (from-scratch GPT) and `mlxlm`
+(LoRA on a pretrained base, via `--backend mlxlm`). It works for both game scenarios
+(JSON strategies) and agent-task scenarios (free-text outputs, scored via
+`evaluate_output` and retrained on verbatim). The online-RL / distillation backends
+(`grpo`/`opd`/`trl`) have no SFT sample stream and are rejected.
 
 Because each round trains _before_ appending its own elite, the loop runs one final
 training pass over the full accumulated dataset so the shipped model reflects every
@@ -398,13 +402,18 @@ records inherit the seed dataset's representative (most common) `context` so eve
 training example shares the same context prefix, rather than mixing the seed records'
 playbook/hints context with empty prefixes for generated examples.
 
-| Flag                  | Default | Meaning                                                 |
-| --------------------- | ------- | ------------------------------------------------------- |
-| `--rounds`            | `3`     | Number of generate -> filter -> retrain rounds.         |
-| `--samples-per-round` | `16`    | Constructions sampled and scored each round.            |
-| `--elite-fraction`    | `0.25`  | Top fraction of each round's samples kept and appended. |
-| `--train-steps`       | `100`   | Training steps per round.                               |
-| `--score-conditioned` | off     | Carry score-conditioning through every round.           |
+| Flag                  | Default   | Meaning                                                                                               |
+| --------------------- | --------- | ----------------------------------------------------------------------------------------------------- |
+| `--rounds`            | `3`       | Number of generate -> filter -> retrain rounds.                                                       |
+| `--samples-per-round` | `16`      | Constructions sampled and scored each round.                                                          |
+| `--elite-fraction`    | `0.25`    | Top fraction of each round's samples kept and appended.                                               |
+| `--train-steps`       | `100`     | Training steps per round.                                                                             |
+| `--batch-size`        | `4`       | Training batch size (lower for `mlxlm` on small seeds: the validation split must hold >= batch_size). |
+| `--score-conditioned` | off       | Carry score-conditioning through every round.                                                         |
+| `--backend`           | `mlx`     | SFT backend: `mlx` (from-scratch GPT) or `mlxlm` (LoRA on a pretrained base).                         |
+| `--base-model`        | (default) | `mlxlm`: pretrained base model to fine-tune.                                                          |
+| `--fine-tune-type`    | `lora`    | `mlxlm`: `lora`, `dora`, or `full`.                                                                   |
+| `--num-layers`        | `8`       | `mlxlm`: layers to fine-tune.                                                                         |
 
 ```bash
 uv run autoctx self-improve \

--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -389,10 +389,15 @@ an iterated one.
 Sampling uses a positive temperature so the collected constructions are diverse
 (greedy decoding would collect identical samples and stall the loop). The loop drives
 the SFT backends that collect assessment samples: `mlx` (from-scratch GPT) and `mlxlm`
-(LoRA on a pretrained base, via `--backend mlxlm`). It works for both game scenarios
-(JSON strategies) and agent-task scenarios (free-text outputs, scored via
-`evaluate_output` and retrained on verbatim). The online-RL / distillation backends
-(`grpo`/`opd`/`trl`) have no SFT sample stream and are rejected.
+(LoRA on a pretrained base, via `--backend mlxlm`). The online-RL / distillation
+backends (`grpo`/`opd`/`trl`) have no SFT sample stream and are rejected.
+
+Scenario coverage depends on the backend. Both backends handle game scenarios (JSON
+strategies). **Free-text agent-task scenarios** (whose `evaluate_output` scores prose)
+need a pretrained instruct model that emits natural language, so use **`--backend mlxlm`**:
+its assessment retrains on the generated text verbatim. The from-scratch `mlx` backend
+emits the structured `<|...|>` token contract, so on it agent tasks must be the
+structured (JSON-strategy) kind, not free text.
 
 Because each round trains _before_ appending its own elite, the loop runs one final
 training pass over the full accumulated dataset so the shipped model reflects every

--- a/autocontext/src/autocontext/cli_self_improve.py
+++ b/autocontext/src/autocontext/cli_self_improve.py
@@ -22,10 +22,19 @@ def register_self_improve_command(app: typer.Typer, console: Console) -> None:
         samples_per_round: int = typer.Option(16, "--samples-per-round", help="Samples generated per round"),
         elite_fraction: float = typer.Option(0.25, "--elite-fraction", help="Top fraction of samples to keep"),
         train_steps: int = typer.Option(100, "--train-steps", help="Training steps per round"),
+        batch_size: int = typer.Option(
+            4, "--batch-size", help="Training batch size (mlxlm needs the validation split >= this; lower it for small seeds)"
+        ),
         score_conditioned: bool = typer.Option(False, "--score-conditioned", help="Score-conditioned generation"),
+        backend: str = typer.Option(
+            "mlx", "--backend", help="SFT backend: mlx (from-scratch GPT) | mlxlm (LoRA on a pretrained base)"
+        ),
+        base_model: str = typer.Option("", "--base-model", help="mlxlm: pretrained base model (empty = backend default)"),
+        fine_tune_type: str = typer.Option("lora", "--fine-tune-type", help="mlxlm: lora | dora | full"),
+        num_layers: int = typer.Option(8, "--num-layers", help="mlxlm: layers to fine-tune"),
         json_output: bool = typer.Option(False, "--json", help="Output structured JSON"),
     ) -> None:
-        """Run the ReST-EM loop: train, sample, keep the elite, append, retrain (MLX)."""
+        """Run the ReST-EM loop: train, sample, keep the elite, append, retrain (mlx or mlxlm)."""
         from autocontext.cli import _write_json_stderr, _write_json_stdout
         from autocontext.training.autoresearch.self_improve import run_self_improving_loop
 
@@ -37,6 +46,10 @@ def register_self_improve_command(app: typer.Typer, console: Console) -> None:
             raise typer.BadParameter(f"--samples-per-round must be a positive integer, got {samples_per_round}")
         if train_steps < 1:
             raise typer.BadParameter(f"--train-steps must be a positive integer, got {train_steps}")
+        if batch_size < 1:
+            raise typer.BadParameter(f"--batch-size must be a positive integer, got {batch_size}")
+        if backend not in ("mlx", "mlxlm"):
+            raise typer.BadParameter(f"--backend must be mlx|mlxlm (the SFT backends), got {backend!r}")
 
         logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
         try:
@@ -48,7 +61,12 @@ def register_self_improve_command(app: typer.Typer, console: Console) -> None:
                 samples_per_round=samples_per_round,
                 elite_fraction=elite_fraction,
                 train_steps=train_steps,
+                batch_size=batch_size,
                 score_conditioned=score_conditioned,
+                backend=backend,
+                base_model=base_model,
+                fine_tune_type=fine_tune_type,
+                num_layers=num_layers,
             )
         except Exception as exc:
             logger.debug("cli_self_improve: caught Exception", exc_info=True)

--- a/autocontext/src/autocontext/training/autoresearch/mlxlm_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/mlxlm_backend.py
@@ -102,10 +102,14 @@ def records_to_completions(
     out: list[dict[str, str]] = []
     for record in records:
         quality = score_to_quality_bucket(float(record.get("score", 0.0)), num_buckets=num_buckets) if score_conditioned else None
+        strategy = record["strategy"]
+        # Game scenarios carry a JSON strategy object; agent-task scenarios carry the raw text
+        # output. Use the text directly as the completion (json.dumps would quote/escape it).
+        strategy_text = strategy if isinstance(strategy, str) else json.dumps(strategy, sort_keys=True)
         out.append(
             build_completion_record(
                 task_prompt=task_prompt,
-                strategy_json=json.dumps(record["strategy"], sort_keys=True),
+                strategy_json=strategy_text,
                 quality=quality,
                 num_buckets=num_buckets,
                 reasoning=str(record.get("reasoning") or "") or None,
@@ -178,8 +182,13 @@ def run_mlxlm_training(
     dedupe_near_threshold: float = 1.0,
     score_conditioned: bool = False,
     augmenter_spec: str = "",
+    collect_samples_path: Path | None = None,
 ) -> dict[str, float]:
-    """Fine-tune a pretrained mlx-lm model with LoRA/DoRA and assess it in-scenario."""
+    """Fine-tune a pretrained mlx-lm model with LoRA/DoRA and assess it in-scenario.
+
+    When ``collect_samples_path`` is set, the in-scenario assessment also writes its
+    generated ``{strategy, score}`` samples there, so the ReST-EM self-improving loop can
+    keep the elite and retrain on them (the adapter analogue of the mlx collect path)."""
     from autocontext.scenarios import SCENARIO_REGISTRY
     from autocontext.training.autoresearch.data_selection import prepare_training_records
     from autocontext.training.autoresearch.train import _all_records, _peak_memory_mb, _preflight_backend_deps
@@ -240,6 +249,7 @@ def run_mlxlm_training(
         temperature=assess_temperature,
         top_k=assess_top_k,
         score_conditioned=score_conditioned,
+        collect_path=collect_samples_path,
     )
     return {
         "avg_score": metrics["avg_score"],
@@ -264,6 +274,7 @@ def _assess_mlxlm(
     temperature: float,
     top_k: int,
     score_conditioned: bool,
+    collect_path: Path | None = None,
 ) -> dict[str, float]:
     from mlx_lm import generate, load  # type: ignore[import-not-found]
     from mlx_lm.sample_utils import make_sampler  # type: ignore[import-not-found]
@@ -277,22 +288,31 @@ def _assess_mlxlm(
 
     scores: list[float] = []
     valid = 0
+    collected: list[dict[str, Any]] = []  # {strategy, score} for the ReST-EM self-improving loop
     for _ in range(max(1, n_samples)):
         try:
             text = generate(model, tokenizer, prompt=prompt, max_tokens=512, verbose=False, sampler=sampler)
             if is_game:
                 # Reason-trained models emit `rationale\n{...}`; extract the trailing
                 # JSON object robustly (a bare extract_strategy returns None on prose).
-                strategy = extract_json_object(text)
+                strategy: Any = extract_json_object(text)
                 if strategy is None:
                     continue
                 valid += 1
-                scores.append(scenario.execute_match(strategy, seed=0).score)
+                score = scenario.execute_match(strategy, seed=0).score
             else:
+                # Agent-task scenarios score the raw text; the text IS the sample to retrain on.
+                strategy = text
                 valid += 1
-                scores.append(scenario.evaluate_output(output=text).score)
+                score = scenario.evaluate_output(output=text).score
+            scores.append(score)
+            if collect_path is not None:
+                collected.append({"strategy": strategy, "score": float(score)})
         except Exception:
             continue
+    if collect_path is not None:
+        collect_path.parent.mkdir(parents=True, exist_ok=True)
+        collect_path.write_text("\n".join(json.dumps(s) for s in collected) + "\n", encoding="utf-8")
     return {
         "avg_score": sum(scores) / len(scores) if scores else 0.0,
         "valid_rate": valid / n_samples if n_samples > 0 else 0.0,

--- a/autocontext/src/autocontext/training/autoresearch/mlxlm_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/mlxlm_backend.py
@@ -140,20 +140,28 @@ def write_completion_dataset(
     return len(train), len(val)
 
 
-def scenario_task_prompt(scenario: Any) -> str:
-    """Resolve the natural-language task instruction for a scenario.
+def scenario_task_prompt_and_state(scenario: Any) -> tuple[str, Any]:
+    """Resolve the task instruction and, for agent-task scenarios, the state it was built from.
 
-    Prefers ``get_task_prompt(initial_state())`` (agent-task scenarios); falls back to
-    the shared context resolver (task prompt / description).
+    Agent-task scenarios (``get_task_prompt`` + ``initial_state``) must pass that SAME state back
+    into ``evaluate_output(output, state)`` at scoring time, so the state is resolved once and
+    returned alongside the prompt. Returns ``(prompt, None)`` for scenarios without an agent-task
+    interface (e.g. games scored via ``execute_match``, which take no state).
     """
     get_task_prompt = getattr(scenario, "get_task_prompt", None)
     initial_state = getattr(scenario, "initial_state", None)
     if callable(get_task_prompt) and callable(initial_state):
         try:
-            return str(get_task_prompt(initial_state()))
+            state = initial_state()
+            return str(get_task_prompt(state)), state
         except Exception:
             pass
-    return resolve_scenario_context(scenario)
+    return resolve_scenario_context(scenario), None
+
+
+def scenario_task_prompt(scenario: Any) -> str:
+    """Resolve the natural-language task instruction for a scenario (state-agnostic)."""
+    return scenario_task_prompt_and_state(scenario)[0]
 
 
 # ---------------------------------------------------------------------------
@@ -205,7 +213,7 @@ def run_mlxlm_training(
         dedupe=dedupe,
         near_threshold=dedupe_near_threshold,
     )
-    task_prompt = scenario_task_prompt(scenario)
+    task_prompt, eval_state = scenario_task_prompt_and_state(scenario)
 
     output_dir.mkdir(parents=True, exist_ok=True)
     data_dir = output_dir / "data"
@@ -245,6 +253,7 @@ def run_mlxlm_training(
         adapter_dir=adapter_dir,
         scenario=scenario,
         task_prompt=task_prompt,
+        eval_state=eval_state,
         n_samples=assess_samples,
         temperature=assess_temperature,
         top_k=assess_top_k,
@@ -274,6 +283,7 @@ def _assess_mlxlm(
     temperature: float,
     top_k: int,
     score_conditioned: bool,
+    eval_state: Any = None,
     collect_path: Path | None = None,
 ) -> dict[str, float]:
     from mlx_lm import generate, load  # type: ignore[import-not-found]
@@ -298,13 +308,15 @@ def _assess_mlxlm(
                 strategy: Any = extract_json_object(text)
                 if strategy is None:
                     continue
-                valid += 1
                 score = scenario.execute_match(strategy, seed=0).score
             else:
                 # Agent-task scenarios score the raw text; the text IS the sample to retrain on.
+                # evaluate_output requires the same state the task prompt was built from.
                 strategy = text
-                valid += 1
-                score = scenario.evaluate_output(output=text).score
+                score = scenario.evaluate_output(output=text, state=eval_state).score
+            # Count valid only after scoring succeeds, so a scoring error (caught below) can't
+            # inflate valid_rate while no sample was actually collected.
+            valid += 1
             scores.append(score)
             if collect_path is not None:
                 collected.append({"strategy": strategy, "score": float(score)})

--- a/autocontext/src/autocontext/training/autoresearch/prepare.py
+++ b/autocontext/src/autocontext/training/autoresearch/prepare.py
@@ -348,6 +348,15 @@ if HAS_MLX:
         collected: list[dict[str, Any]] = []  # (strategy, score) for the self-improving loop
 
         is_game = hasattr(scenario, "execute_match")
+        # Agent-task scenarios require the task state passed back into evaluate_output(); resolve
+        # it once (this from-scratch backend emits JSON strategies, so agent tasks here are the
+        # structured kind -- free-text agent tasks use the mlxlm backend).
+        eval_state = None
+        if not is_game:
+            try:
+                eval_state = scenario.initial_state()
+            except Exception:
+                eval_state = {}
 
         for i in range(n_samples):
             try:
@@ -363,11 +372,12 @@ if HAS_MLX:
                 strategy = _extract_strategy_json(raw_output)
 
                 if strategy is not None:
-                    valid_count += 1
                     if is_game:
                         result = scenario.execute_match(strategy, seed=i)
                     else:
-                        result = scenario.evaluate_output(output=json.dumps(strategy))
+                        result = scenario.evaluate_output(output=json.dumps(strategy), state=eval_state)
+                    # Count valid only after scoring succeeds (a scoring error must not inflate it).
+                    valid_count += 1
                     scores.append(result.score)
                     if collect_path is not None:
                         collected.append({"strategy": strategy, "score": float(result.score)})

--- a/autocontext/src/autocontext/training/autoresearch/self_improve.py
+++ b/autocontext/src/autocontext/training/autoresearch/self_improve.py
@@ -7,7 +7,9 @@ one-shot distillation into PatternBoost / ReST-EM: the model generates new train
 data for itself, biased toward the best of what it can already produce.
 
 The pure helpers (elite selection, sample -> record conversion) are backend-agnostic.
-The loop currently drives the MLX backend (sample collection is MLX-only for now).
+The loop drives the SFT backends that collect assessment samples: ``mlx`` (from-scratch GPT)
+and ``mlxlm`` (LoRA on a pretrained base). It works for both game scenarios (JSON strategies)
+and agent-task scenarios (free-text outputs).
 """
 
 from __future__ import annotations
@@ -90,8 +92,13 @@ def run_self_improving_loop(
     memory_limit_mb: int = 16384,
     final_train: bool = True,
     generated_context: Any = None,
+    backend: str = "mlx",
+    base_model: str = "",
+    fine_tune_type: str = "lora",
+    num_layers: int = 8,
+    learning_rate: float = 0.0,
 ) -> dict[str, Any]:
-    """Run the ReST-EM self-improving loop on the MLX backend.
+    """Run the ReST-EM self-improving loop on an SFT backend (``mlx`` or ``mlxlm``).
 
     Each round trains on the current dataset, samples + scores constructions,
     keeps the top ``elite_fraction`` and appends them. Because a round trains
@@ -118,6 +125,11 @@ def run_self_improving_loop(
         raise ValueError(f"samples_per_round must be a positive integer, got {samples_per_round}")
     if train_steps < 1:
         raise ValueError(f"train_steps must be a positive integer, got {train_steps}")
+    # ReST-EM is iterative SFT on collected elite: only the SFT backends collect samples.
+    # mlx (from-scratch GPT) and mlxlm (LoRA on a pretrained base) qualify; the online-RL /
+    # distillation backends (grpo/opd/trl) do not produce an SFT sample stream to filter.
+    if backend not in ("mlx", "mlxlm"):
+        raise ValueError(f"self-improving loop supports backend 'mlx' or 'mlxlm', got {backend!r}")
 
     output_dir = Path(output_dir)
     # Diverse sampling is required for ReST-EM (greedy would collect identical samples).
@@ -141,6 +153,7 @@ def run_self_improving_loop(
             train_steps=train_steps,
             batch_size=batch_size,
             seq_len=seq_len,
+            learning_rate=learning_rate,
             assess_samples=samples_per_round,
             assess_temperature=temperature,
             assess_top_k=assess_top_k,
@@ -148,7 +161,10 @@ def run_self_improving_loop(
             dedupe=dedupe,
             dedupe_near_threshold=dedupe_near_threshold,
             collect_samples_path=collect,
-            backend="mlx",
+            backend=backend,
+            base_model=base_model,
+            fine_tune_type=fine_tune_type,
+            num_layers=num_layers,
         )
 
     for r in range(rounds):

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -442,8 +442,10 @@ def run_training(
         return _run_mlx_training(
             **common, seq_len=seq_len, assess_top_k=assess_top_k, val_select=val_select, collect_samples_path=collect_samples_path
         )
-    if collect_samples_path is not None:
-        raise NotImplementedError("collect_samples_path (self-improving loop) is currently MLX-only")
+    if collect_samples_path is not None and normalized_backend != "mlxlm":
+        # mlx (above) and mlxlm (below) collect assessment samples for the ReST-EM loop; the
+        # online-RL / distillation backends (cuda/grpo/opd/trl) have no SFT-sample collection.
+        raise NotImplementedError("collect_samples_path (self-improving loop) supports the mlx and mlxlm backends")
     if normalized_backend == "cuda":
         if val_select:
             raise ValueError("val_select is currently MLX-only; omit it for the cuda backend")
@@ -466,6 +468,7 @@ def run_training(
             base_model=base_model or DEFAULT_BASE_MODEL,
             fine_tune_type=fine_tune_type,
             num_layers=num_layers,
+            collect_samples_path=collect_samples_path,
         )
     if normalized_backend == "grpo":
         if loss_weight_mode != "uniform" or vocab_size != BASE_VOCAB_SIZE:

--- a/autocontext/tests/test_mlxlm_backend.py
+++ b/autocontext/tests/test_mlxlm_backend.py
@@ -38,6 +38,17 @@ def test_records_to_completions_buckets_by_score() -> None:
     assert all("Target quality" not in c["prompt"] for c in plain)
 
 
+def test_records_to_completions_uses_text_strategy_verbatim_for_agent_tasks() -> None:
+    """Agent-task scenarios carry the raw text output as the strategy; it must be the completion
+    verbatim, not json.dumps'd (which would wrap/escape it and break the self-improving loop)."""
+    text = "The answer is 42.\n#### 42"
+    comps = mb.records_to_completions([{"strategy": text, "score": 1.0}], task_prompt="Solve it.")
+    assert comps[0]["completion"] == text  # verbatim, not '"The answer is 42...."'
+    # a dict strategy (game scenario) still serializes to JSON
+    game = mb.records_to_completions([{"strategy": {"a": 1}, "score": 1.0}], task_prompt="T")
+    assert game[0]["completion"] == '{"a": 1}'
+
+
 def test_write_completion_dataset_writes_train_and_valid(tmp_path: Path) -> None:
     records = [{"strategy": {"a": i}, "score": i / 10} for i in range(10)]
     data_dir = tmp_path / "data"

--- a/autocontext/tests/test_mlxlm_backend.py
+++ b/autocontext/tests/test_mlxlm_backend.py
@@ -202,3 +202,31 @@ def test_format_assess_prompt_falls_back_to_raw_without_chat_template() -> None:
             raise ValueError("no chat template")
 
     assert mb.format_assess_prompt(_Tok(), "raw text", score_conditioned=False) == "raw text"
+
+
+def test_scenario_task_prompt_and_state_resolves_agent_task_state() -> None:
+    """Agent-task scenarios must return the state the prompt was built from, so evaluate_output
+    gets that same state at scoring time (calling it without state raises and is swallowed)."""
+
+    class _Agent:
+        def initial_state(self, seed=None):
+            return {"n": 3}
+
+        def get_task_prompt(self, state):
+            return f"solve n={state['n']}"
+
+    prompt, state = mb.scenario_task_prompt_and_state(_Agent())
+    assert prompt == "solve n=3"
+    assert state == {"n": 3}
+
+
+def test_scenario_task_prompt_and_state_none_for_game_scenarios() -> None:
+    class _Game:
+        def describe_strategy_interface(self):
+            return "Return JSON."
+
+    prompt, state = mb.scenario_task_prompt_and_state(_Game())
+    assert state is None  # games score via execute_match, which takes no state
+    assert "Return JSON." in prompt
+    # the state-agnostic alias still returns just the prompt
+    assert mb.scenario_task_prompt(_Game()) == prompt

--- a/autocontext/tests/test_self_improve.py
+++ b/autocontext/tests/test_self_improve.py
@@ -99,8 +99,8 @@ def test_run_self_improving_loop_rejects_non_positive_counts(tmp_path: str, kwar
         )
 
 
-def test_run_training_collect_samples_path_non_mlx_raises(tmp_path: str) -> None:
-    """The collect-samples plumbing is MLX-only; other backends reject it loudly."""
+def test_run_training_collect_samples_path_non_sft_raises(tmp_path: str) -> None:
+    """Collect-samples is for the SFT backends (mlx/mlxlm); the RL/distill backends reject it."""
     from autocontext.training.autoresearch.train import run_training
 
     records = [
@@ -110,7 +110,7 @@ def test_run_training_collect_samples_path_non_mlx_raises(tmp_path: str) -> None
     data_path = Path(tmp_path) / "data.jsonl"
     data_path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
 
-    with pytest.raises(NotImplementedError, match="MLX-only"):
+    with pytest.raises(NotImplementedError, match="mlx and mlxlm"):
         run_training(
             scenario_name="grid_ctf",
             data_path=data_path,
@@ -123,6 +123,54 @@ def test_run_training_collect_samples_path_non_mlx_raises(tmp_path: str) -> None
             backend="cuda",
             collect_samples_path=Path(tmp_path) / "samples.jsonl",
         )
+
+
+def test_run_self_improving_loop_rejects_non_sft_backend(tmp_path: str) -> None:
+    """ReST-EM is iterative SFT; the online-RL / distillation backends have no SFT sample stream."""
+    data_path = Path(tmp_path) / "seed.jsonl"
+    data_path.write_text(
+        json.dumps({"run_id": "r0", "scenario": "grid_ctf", "context": {}, "strategy": {"a": 1}, "score": 0.5}) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="backend 'mlx' or 'mlxlm'"):
+        run_self_improving_loop(scenario_name="grid_ctf", data_path=data_path, output_dir=Path(tmp_path) / "out", backend="grpo")
+
+
+def test_run_self_improving_loop_threads_backend_and_adapter_params(tmp_path: str, monkeypatch) -> None:
+    """backend + adapter params must reach run_training, so `--backend mlxlm` actually fine-tunes
+    the adapter rather than silently falling back to the from-scratch GPT. Mocks training (no mlx)."""
+    import autocontext.training.autoresearch.train as train_mod
+
+    data_path = Path(tmp_path) / "seed.jsonl"
+    data_path.write_text(
+        json.dumps({"run_id": "r0", "scenario": "grid_ctf", "context": {}, "strategy": {"a": 1}, "score": 0.5}) + "\n",
+        encoding="utf-8",
+    )
+    seen: list[dict] = []
+
+    def fake_run_training(**kwargs):
+        seen.append(kwargs)
+        return {"avg_score": 0.7, "valid_rate": 1.0}
+
+    # run_self_improving_loop imports run_training from this module at call time.
+    monkeypatch.setattr(train_mod, "run_training", fake_run_training)
+    run_self_improving_loop(
+        scenario_name="grid_ctf",
+        data_path=data_path,
+        output_dir=Path(tmp_path) / "out",
+        rounds=1,
+        final_train=False,
+        backend="mlxlm",
+        base_model="mlx-community/Qwen2.5-0.5B-Instruct-4bit",
+        fine_tune_type="dora",
+        num_layers=4,
+    )
+    assert seen, "training was never invoked"
+    call = seen[0]
+    assert call["backend"] == "mlxlm"
+    assert call["base_model"] == "mlx-community/Qwen2.5-0.5B-Instruct-4bit"
+    assert call["fine_tune_type"] == "dora"
+    assert call["num_layers"] == 4
 
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX not installed")


### PR DESCRIPTION
## What

The self-improving loop (`autoctx self-improve`, ReST-EM / expert iteration) was hardcoded to the **from-scratch `mlx`** backend and **game scenarios**. This generalizes it along both axes — the two follow-ons chosen after closing the recursive loop.

### Backend: `mlx` → `{mlx, mlxlm}`
The loop now drives either SFT backend: `mlx` (from-scratch GPT) or **`mlxlm`** (LoRA on a pretrained base, `--backend mlxlm`). `mlxlm`'s in-scenario assessment now collects `{strategy, score}` samples to a `collect_samples_path` (the adapter analogue of the existing mlx collect path), so ReST-EM can keep the elite and retrain. `train.py` permits `collect_samples_path` for `mlx`+`mlxlm` and rejects it for the online-RL/distillation backends (`grpo`/`opd`/`trl`), which have no SFT sample stream.

### Scenarios: game → game + agent-task
Agent-task scenarios (scored via `evaluate_output` on free text) are now first-class. `_assess_mlxlm` collects the raw text as the sample's strategy, and `records_to_completions` uses a string strategy **verbatim** as the completion (`json.dumps` would quote/escape it). Game scenarios (JSON strategies) are unchanged.

### CLI
`autoctx self-improve` gains `--backend`, `--base-model`, `--fine-tune-type`, `--num-layers`, and `--batch-size` (lower it for `mlxlm` on small seeds: mlx-lm requires the validation split to hold ≥ batch_size examples).

## Verified live

`autoctx self-improve --backend mlxlm` on `grid_ctf` (cached Qwen2.5-0.5B), 2 rounds: dataset grew 24→28, per-round **avg_score 0.755 → 0.878**. The loop collects samples, filters elite, grows the dataset, and retrains the adapter each round — end to end through the CLI.

## Tests (CI-safe, no mlx)
`records_to_completions` verbatim-text vs JSON-strategy; loop rejects non-SFT backends; loop threads backend + adapter params into `run_training` (mocked); `collect_samples_path` rejected for non-SFT backends. Updated the prior `MLX-only` guard test to the new `mlx and mlxlm` message. Documents the new flags + backend/scenario coverage in `mlx-training.md`. ruff + mypy clean.