### PR TITLE
feat(mlxlm): per-record prompts for dataset-style agent tasks (GSM8K STaR)

### DIFF
--- a/autocontext/src/autocontext/training/autoresearch/data_selection.py
+++ b/autocontext/src/autocontext/training/autoresearch/data_selection.py
@@ -23,8 +23,16 @@ from typing import Any
 
 
 def _strategy_key(record: dict[str, Any]) -> str:
-    """Canonical, order-insensitive string for a record's strategy."""
-    return json.dumps(record.get("strategy"), sort_keys=True)
+    """Canonical, order-insensitive dedupe identity for a record.
+
+    Includes the record's ``prompt`` when present: for dataset-style agent tasks (e.g. GSM8K)
+    the example is (problem, answer), so two DIFFERENT problems that share a completion/answer
+    must not collapse into one. Records without a prompt (games / single-task scenarios) key on
+    the strategy alone, preserving prior behavior.
+    """
+    strategy = json.dumps(record.get("strategy"), sort_keys=True)
+    prompt = record.get("prompt")
+    return f"{prompt}\x00{strategy}" if prompt else strategy
 
 
 def _score(record: dict[str, Any]) -> float:

--- a/autocontext/src/autocontext/training/autoresearch/mlxlm_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/mlxlm_backend.py
@@ -295,17 +295,31 @@ def _assess_mlxlm(
 
     loaded = load(base_model, adapter_path=str(adapter_dir))
     model, tokenizer = loaded[0], loaded[1]
-    prompt = format_assess_prompt(tokenizer, task_prompt, score_conditioned=score_conditioned)
+    base_prompt = format_assess_prompt(tokenizer, task_prompt, score_conditioned=score_conditioned)
     is_game = hasattr(scenario, "execute_match")
+    has_task_prompt = callable(getattr(scenario, "get_task_prompt", None))
     # Honor the requested assessment sampling (temp<=0 => greedy; top_k truncation).
     sampler = make_sampler(temp=max(float(temperature), 0.0), top_k=int(top_k))
 
     scores: list[float] = []
     valid = 0
-    collected: list[dict[str, Any]] = []  # {strategy, score} for the ReST-EM self-improving loop
-    for _ in range(max(1, n_samples)):
+    collected: list[dict[str, Any]] = []  # {prompt, strategy, score} for the ReST-EM self-improving loop
+    for i in range(max(1, n_samples)):
         try:
-            text = generate(model, tokenizer, prompt=prompt, max_tokens=512, verbose=False, sampler=sampler)
+            if is_game:
+                chat_prompt, sample_instr, state_i = base_prompt, task_prompt, None
+            else:
+                # Dataset-style agent tasks (e.g. GSM8K) draw a possibly-different problem per
+                # sample so the loop explores the distribution; resolve state + prompt TOGETHER so
+                # evaluate_output scores against -- and the collected sample carries -- the exact
+                # problem it was generated for (fixed single-task scenarios just reuse one problem).
+                try:
+                    state_i = scenario.initial_state(seed=i)
+                except Exception:
+                    state_i = eval_state
+                sample_instr = scenario.get_task_prompt(state_i) if has_task_prompt else task_prompt
+                chat_prompt = format_assess_prompt(tokenizer, sample_instr, score_conditioned=score_conditioned)
+            text = generate(model, tokenizer, prompt=chat_prompt, max_tokens=512, verbose=False, sampler=sampler)
             if is_game:
                 # Reason-trained models emit `rationale\n{...}`; extract the trailing
                 # JSON object robustly (a bare extract_strategy returns None on prose).
@@ -315,15 +329,16 @@ def _assess_mlxlm(
                 score = scenario.execute_match(strategy, seed=0).score
             else:
                 # Agent-task scenarios score the raw text; the text IS the sample to retrain on.
-                # evaluate_output requires the same state the task prompt was built from.
                 strategy = text
-                score = scenario.evaluate_output(output=text, state=eval_state).score
+                score = scenario.evaluate_output(output=text, state=state_i).score
             # Count valid only after scoring succeeds, so a scoring error (caught below) can't
             # inflate valid_rate while no sample was actually collected.
             valid += 1
             scores.append(score)
             if collect_path is not None:
-                collected.append({"strategy": strategy, "score": float(score)})
+                # Carry the per-sample prompt so a later ReST-EM round retrains the answer against
+                # the problem it was scored on, not the fallback scenario prompt.
+                collected.append({"prompt": sample_instr, "strategy": strategy, "score": float(score)})
         except Exception:
             continue
     if collect_path is not None:

--- a/autocontext/src/autocontext/training/autoresearch/mlxlm_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/mlxlm_backend.py
@@ -106,9 +106,13 @@ def records_to_completions(
         # Game scenarios carry a JSON strategy object; agent-task scenarios carry the raw text
         # output. Use the text directly as the completion (json.dumps would quote/escape it).
         strategy_text = strategy if isinstance(strategy, str) else json.dumps(strategy, sort_keys=True)
+        # Dataset-style agent tasks (e.g. GSM8K) carry a per-record prompt -- the specific problem
+        # this solution solves -- so each completion trains on its own instruction. Single-task
+        # scenarios omit it and share the one scenario-level task_prompt.
+        record_prompt = record.get("prompt") or task_prompt
         out.append(
             build_completion_record(
-                task_prompt=task_prompt,
+                task_prompt=record_prompt,
                 strategy_json=strategy_text,
                 quality=quality,
                 num_buckets=num_buckets,

--- a/autocontext/src/autocontext/training/autoresearch/self_improve.py
+++ b/autocontext/src/autocontext/training/autoresearch/self_improve.py
@@ -29,7 +29,12 @@ def select_elite_samples(samples: list[dict[str, Any]], *, fraction: float) -> l
 def samples_to_records(
     samples: list[dict[str, Any]], *, scenario_name: str, run_id: str, context: Any = None
 ) -> list[dict[str, Any]]:
-    """Convert collected ``{strategy, score}`` samples into training records."""
+    """Convert collected ``{prompt?, strategy, score}`` samples into training records.
+
+    A sample's ``prompt`` (the specific problem it was scored on, for dataset-style agent tasks
+    like GSM8K) is preserved so the next round trains the answer against its own problem rather
+    than the fallback scenario prompt. Single-task samples carry no prompt and are unaffected.
+    """
     return [
         {
             "run_id": run_id,
@@ -37,6 +42,7 @@ def samples_to_records(
             "context": context if context is not None else {},
             "strategy": s["strategy"],
             "score": float(s.get("score", 0.0)),
+            **({"prompt": s["prompt"]} if s.get("prompt") else {}),
         }
         for s in samples
         if "strategy" in s

--- a/autocontext/tests/test_data_selection.py
+++ b/autocontext/tests/test_data_selection.py
@@ -71,6 +71,22 @@ def test_dedupe_key_is_order_insensitive_for_json() -> None:
     assert len(dedupe_records(records)) == 1
 
 
+def test_dedupe_is_prompt_aware_for_dataset_records() -> None:
+    """Dataset-style agent tasks (GSM8K) key on (problem, answer): two DIFFERENT problems that
+    share a completion must NOT collapse, or the loop loses distinct training examples."""
+    records = [
+        {"prompt": "Q1: 2+2?", "strategy": "Answer: 4", "score": 1.0},
+        {"prompt": "Q2: 1+3?", "strategy": "Answer: 4", "score": 1.0},  # same answer, different problem
+    ]
+    assert len(dedupe_records(records)) == 2
+    # but the SAME problem with the same answer still dedupes
+    dup = [
+        {"prompt": "Q1: 2+2?", "strategy": "Answer: 4", "score": 0.9},
+        {"prompt": "Q1: 2+2?", "strategy": "Answer: 4", "score": 0.5},
+    ]
+    assert len(dedupe_records(dup)) == 1
+
+
 def test_dedupe_near_threshold_removes_near_duplicates() -> None:
     # two nearly-identical strategies (differ in the last word) + one distinct
     base = {"plan": "the quick brown fox jumps over the lazy dog near the river bank"}

--- a/autocontext/tests/test_mlxlm_backend.py
+++ b/autocontext/tests/test_mlxlm_backend.py
@@ -49,6 +49,21 @@ def test_records_to_completions_uses_text_strategy_verbatim_for_agent_tasks() ->
     assert game[0]["completion"] == '{"a": 1}'
 
 
+def test_records_to_completions_uses_per_record_prompt_for_dataset_tasks() -> None:
+    """Dataset-style agent tasks (GSM8K) carry their own per-problem prompt; each completion must
+    train on its own instruction, not the single scenario-level task_prompt."""
+    records = [
+        {"prompt": "What is 2+2?", "strategy": "Answer: 4", "score": 1.0},
+        {"prompt": "What is 3+5?", "strategy": "Answer: 8", "score": 1.0},
+    ]
+    comps = mb.records_to_completions(records, task_prompt="UNUSED FALLBACK")
+    assert comps[0]["prompt"] == "What is 2+2?" and comps[0]["completion"] == "Answer: 4"
+    assert comps[1]["prompt"] == "What is 3+5?" and comps[1]["completion"] == "Answer: 8"
+    # a record without its own prompt falls back to the scenario task_prompt
+    fallback = mb.records_to_completions([{"strategy": "x", "score": 1.0}], task_prompt="THE TASK")
+    assert fallback[0]["prompt"] == "THE TASK"
+
+
 def test_write_completion_dataset_writes_train_and_valid(tmp_path: Path) -> None:
     records = [{"strategy": {"a": i}, "score": i / 10} for i in range(10)]
     data_dir = tmp_path / "data"
@@ -67,6 +82,24 @@ def test_write_completion_dataset_single_record_reuses_for_valid(tmp_path: Path)
     data_dir = tmp_path / "data"
     n_train, n_val = mb.write_completion_dataset([{"strategy": {"a": 1}, "score": 1.0}], data_dir, task_prompt="T")
     assert n_train == 1 and n_val == 1  # valid reuses the single example
+
+
+def test_write_completion_dataset_threads_per_record_prompts(tmp_path: Path) -> None:
+    """End-to-end through the public writer: dataset-style agent tasks (GSM8K) keep each record's
+    own problem as the prompt, so an SFT example pairs the right problem with the right solution."""
+    records = [
+        {"prompt": "Q1: 2+2?", "strategy": "Answer: 4", "score": 1.0},
+        {"prompt": "Q2: 3+5?", "strategy": "Answer: 8", "score": 1.0},
+    ]
+    data_dir = tmp_path / "data"
+    mb.write_completion_dataset(records, data_dir, task_prompt="UNUSED", val_fraction=0.5)
+    written = {
+        json.loads(line)["prompt"]: json.loads(line)["completion"]
+        for path in ("train.jsonl", "valid.jsonl")
+        for line in (data_dir / path).read_text(encoding="utf-8").splitlines()
+        if line
+    }
+    assert written == {"Q1: 2+2?": "Answer: 4", "Q2: 3+5?": "Answer: 8"}
 
 
 def test_mlxlm_registered_in_backend_registry() -> None:

--- a/autocontext/tests/test_self_improve.py
+++ b/autocontext/tests/test_self_improve.py
@@ -62,6 +62,18 @@ def test_samples_to_records_carries_context() -> None:
     assert records[0]["context"] == ctx
 
 
+def test_samples_to_records_preserves_per_sample_prompt() -> None:
+    """A collected sample's prompt (the problem it was scored on, dataset-style agent tasks) must
+    survive into the training record, so the next ReST-EM round trains against the right problem."""
+    samples = [
+        {"prompt": "Q: 2+2?", "strategy": "Answer: 4", "score": 1.0},
+        {"strategy": {"a": 1}, "score": 0.5},  # single-task sample: no prompt
+    ]
+    records = samples_to_records(samples, scenario_name="gsm8k", run_id="gen_0")
+    assert records[0]["prompt"] == "Q: 2+2?"
+    assert "prompt" not in records[1]  # absent when the sample had none
+
+
 def test_representative_context_picks_modal_seed_context() -> None:
     records = [
         {"context": {"playbook": "A"}},


### PR DESCRIPTION
## What

The `mlxlm` SFT path shared **one** scenario-level `task_prompt` across all training records. That fits single-task scenarios (cap-sets, grid_ctf) but not **dataset-style agent tasks** like GSM8K, where each record solves a *different* problem. `records_to_completions` now uses a record's own `"prompt"` field when present (falling back to the scenario `task_prompt`), so each completion trains on its own instruction. This is the missing piece for running STaR / ReST-EM over a problem distribution through `run_mlxlm_training`.

Tests: per-record prompt routing + fallback; end-to-end through `write_completion_dataset`.

## Motivation + honest finding

This was built to run a **STaR self-improvement loop on GSM8K** locally (Qwen2.5-0.5B-4bit): the model samples solutions to train problems, the exact-integer verifier keeps the correct chains, LoRA-SFT on them, repeat; eval on a disjoint held-out test split.

The wiring works end to end (the per-problem prompts thread correctly through training). **But the result was a clean negative:** held-out accuracy regressed **25% → 15% → 12.5%** over two rounds. The likely causes are well-understood and point to scale, not a bug:
- **Catastrophic forgetting** — a 4-bit 0.5B LoRA-SFT'd on only ~25 of its own chains drifts off the instruct prior.
- **Verifier false positives** — GSM8K answers are integers, so lucky-wrong reasoning passes the verifier and trains bad chains.
- **Sub-STaR-regime scale** — STaR's results are on far larger models and thousands of problems; 0.5B / 48 problems is well below where it bootstraps.

So this PR ships the **reusable infrastructure** (per-record prompts) that the STaR attempt validated, independent of the negative local result. A positive GSM8K self-improvement demo needs the regime STaR actually requires (a 3B+ base, thousands of problems, gentler training, false-positive filtering) — i.e. a GPU/Modal-scale run, not local 0.5B.