### PR TITLE
fix(trl-grpo): raise GRPO max_completion_length 256→512 (truncation zeroed all rewards)

### DIFF
--- a/autocontext/src/autocontext/cli_train.py
+++ b/autocontext/src/autocontext/cli_train.py
@@ -87,6 +87,9 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
         ),
         trl_mode: str = typer.Option("gkd", "--trl-mode", help="trl backend: gkd (on-policy distillation) | grpo (RLVR)"),
         seed: int = typer.Option(0, "--seed", help="trl backend: training seed (for seeded repeats / error bars)"),
+        max_completion_length: int = typer.Option(
+            512, "--max-completion-length", help="trl grpo: generation cap (256 truncates reasoning -> 0 reward / no gradient)"
+        ),
         agent_provider: str = typer.Option("anthropic", "--agent-provider", help="LLM provider for training agent"),
         agent_model: str = typer.Option("", "--agent-model", help="Model for training agent (empty = provider default)"),
         val_select: bool = typer.Option(
@@ -150,6 +153,8 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             raise typer.BadParameter(f"--backend must be mlx|cuda|mlxlm|grpo|opd|trl, got {backend!r}")
         if train_steps < 0:
             raise typer.BadParameter(f"--train-steps must be >= 0 (0 = backend default), got {train_steps}")
+        if max_completion_length < 1:
+            raise typer.BadParameter(f"--max-completion-length must be a positive integer, got {max_completion_length}")
         if learning_rate < 0:
             raise typer.BadParameter(f"--learning-rate must be >= 0 (0 = backend default), got {learning_rate}")
 
@@ -179,6 +184,7 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             teacher_model=teacher_model,
             trl_mode=trl_mode,
             seed=seed,
+            max_completion_length=max_completion_length,
             fine_tune_type=fine_tune_type,
             num_layers=num_layers,
         )

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -396,6 +396,7 @@ def run_training(
     teacher_model: str = "",  # opd backend: distillation teacher (empty = backend default)
     trl_mode: str = "gkd",  # trl backend: gkd (on-policy distillation) | grpo (RLVR)
     seed: int = 0,  # trl backend: training seed (for seeded repeats / error bars)
+    max_completion_length: int = 512,  # trl grpo: generation cap (>= task answer length; 256 truncates reasoning)
     fine_tune_type: str = "lora",
     num_layers: int = 8,
     collect_samples_path: Path | None = None,
@@ -534,6 +535,7 @@ def run_training(
             max_steps=train_steps if train_steps > 0 else -1,  # generic --train-steps -> TRL step cap
             batch_size=batch_size,
             seed=seed,
+            max_completion_length=max_completion_length,
             time_budget=time_budget,
             memory_limit_mb=memory_limit_mb,
         )
@@ -548,6 +550,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--backend", choices=("mlx", "cuda", "mlxlm", "grpo", "opd", "trl"), default="mlx")
     parser.add_argument("--trl-mode", choices=("gkd", "grpo"), default="gkd", help="trl backend: gkd | grpo")
     parser.add_argument("--seed", type=int, default=0, help="trl backend: training seed (seeded repeats)")
+    parser.add_argument(
+        "--max-completion-length", type=int, default=512, help="trl grpo: generation cap (256 truncates reasoning -> 0 reward)"
+    )
     parser.add_argument("--time-budget", type=int, default=300)
     parser.add_argument("--memory-limit", type=int, default=16384)
     parser.add_argument("--train-steps", type=int, default=0, help="0 = backend default (8 from-scratch, 100 adapters)")
@@ -605,6 +610,7 @@ def main(argv: list[str] | None = None) -> int:
             teacher_model=args.teacher_model,
             trl_mode=args.trl_mode,
             seed=args.seed,
+            max_completion_length=args.max_completion_length,
             fine_tune_type=args.fine_tune_type,
             num_layers=args.num_layers,
             backend=args.backend,

--- a/autocontext/src/autocontext/training/autoresearch/trl_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/trl_backend.py
@@ -102,7 +102,10 @@ def build_grpo_config_kwargs(
     output_dir: str,
     learning_rate: float = 1e-5,
     num_generations: int = 8,
-    max_completion_length: int = 256,
+    # 512, not 256: reasoning tasks (e.g. GSM8K) need room for step-by-step work + the final
+    # answer. At 256 every completion truncates before the answer, the verifier scores them all
+    # 0, reward variance is 0, and GRPO gets no gradient -- RLVR silently learns nothing.
+    max_completion_length: int = 512,
     beta: float = 0.0,
     temperature: float = 1.0,
     num_train_epochs: float = 1.0,
@@ -204,6 +207,7 @@ def run_trl_training(
     max_steps: int = -1,
     batch_size: int = 0,
     seed: int = 0,
+    max_completion_length: int = 512,  # grpo: generation cap (>= task answer length; see build_grpo_config_kwargs)
     register_import: str | None = None,
     time_budget: int = 3600,
     memory_limit_mb: int = 16384,  # noqa: ARG001 - backend-signature parity
@@ -280,7 +284,11 @@ def run_trl_training(
 
         dataset = Dataset.from_list(build_prompt_dataset_rows(scenario, n_prompts))
         grpo_kwargs: dict[str, Any] = dict(
-            output_dir=str(output_dir), learning_rate=learning_rate, max_steps=max_steps, seed=seed
+            output_dir=str(output_dir),
+            learning_rate=learning_rate,
+            max_steps=max_steps,
+            seed=seed,
+            max_completion_length=max_completion_length,
         )
         if batch_size > 0:
             grpo_kwargs["per_device_train_batch_size"] = batch_size

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -73,6 +73,7 @@ class TrainingConfig:
     teacher_model: str = ""  # opd backend: distillation teacher (empty = backend default)
     trl_mode: str = "gkd"  # trl backend: gkd (on-policy distillation) | grpo (RLVR)
     seed: int = 0  # trl backend: training seed (for seeded repeats)
+    max_completion_length: int = 512  # trl grpo: generation cap (256 truncates reasoning -> 0 reward / no gradient)
     fine_tune_type: str = "lora"  # mlxlm backend: lora | dora | full
     num_layers: int = 8  # mlxlm backend: number of layers to fine-tune
 
@@ -437,6 +438,8 @@ class TrainingRunner:
             command += ["--trl-mode", self.config.trl_mode]
         if self.config.seed != 0:
             command += ["--seed", str(self.config.seed)]
+        if self.config.max_completion_length != 512:
+            command += ["--max-completion-length", str(self.config.max_completion_length)]
         if self.config.fine_tune_type != "lora":
             command += ["--fine-tune-type", self.config.fine_tune_type]
         if self.config.num_layers != 8:

--- a/autocontext/tests/test_training_runner.py
+++ b/autocontext/tests/test_training_runner.py
@@ -324,6 +324,26 @@ class TestConstraints:
         seed_index = command.index("--seed")
         assert command[seed_index + 1] == "7"
 
+    def test_experiment_subprocess_passes_max_completion_length_when_overridden(self, tmp_path: Path) -> None:
+        """A GRPO completion-length override must reach the subprocess (so the public `autoctx train`
+        path can avoid the 256-token truncation that zeroes GSM8K-style rewards); the default 512 is
+        omitted to keep the command minimal."""
+        cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl", backend="trl", max_completion_length=768)
+        (tmp_path / "data.jsonl").write_text("{}\n")
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run:
+            runner._run_experiment_subprocess(0)
+        command = mock_run.call_args.args[0]
+        assert command[command.index("--max-completion-length") + 1] == "768"
+
+        # default (512) stays off the command line
+        cfg2 = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl", backend="trl")
+        runner2 = TrainingRunner(cfg2, work_dir=tmp_path / "ws2")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run2:
+            runner2._run_experiment_subprocess(0)
+        assert "--max-completion-length" not in mock_run2.call_args.args[0]
+
     def test_experiment_subprocess_omits_loss_weight_flags_when_uniform(self, tmp_path: Path) -> None:
         cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl")
         (tmp_path / "data.jsonl").write_text("{}\n")

--- a/autocontext/tests/test_trl_backend.py
+++ b/autocontext/tests/test_trl_backend.py
@@ -63,6 +63,16 @@ def test_grpo_config_kwargs_have_generation_and_kl_fields() -> None:
     assert "max_prompt_length" not in cfg
 
 
+def test_grpo_completion_length_defaults_long_enough_for_reasoning() -> None:
+    """Regression: a 256-token cap truncates GSM8K completions before the answer, so every
+    verifier reward is 0 and GRPO gets no gradient (RLVR silently learns nothing). The default
+    must leave room for step-by-step reasoning + the final answer, and stay overridable."""
+    from autocontext.training.autoresearch.trl_backend import build_grpo_config_kwargs
+
+    assert build_grpo_config_kwargs(output_dir="/o")["max_completion_length"] >= 512
+    assert build_grpo_config_kwargs(output_dir="/o", max_completion_length=1024)["max_completion_length"] == 1024
+
+
 def test_config_kwargs_thread_max_steps_and_batch_size() -> None:
     """--train-steps / --batch-size must reach TRL, not be silently dropped."""
     from autocontext.training.autoresearch.trl_backend import build_gkd_config_kwargs, build_grpo_config_kwargs


### PR DESCRIPTION
## What

Discovered **live** while watching a GSM8K GRPO run on Modal: the GRPO arm was learning nothing, and the metrics showed why —
```
completions/mean_length: 256   completions/clipped_ratio: 1   mean_terminated_length: 0
reward: 0   reward_std: 0   frac_reward_zero_std: 1   loss: 0   grad_norm: 0
```
Every completion was clipped at the 256-token cap before reaching its final `Answer: N`, so the exact-integer verifier scored **all** completions 0. Zero reward variance → zero advantage → no gradient. RLVR silently no-ops on any task whose correct output exceeds 256 tokens (i.e. all step-by-step reasoning).

Root cause: `build_grpo_config_kwargs` defaulted `max_completion_length=256` and `run_trl_training` never threaded it.

## Fix
- Default `max_completion_length` → **512** (room for reasoning + the answer), with a comment explaining the failure mode.
- `run_trl_training` now exposes `max_completion_length` so callers can raise it further for longer tasks.

## Why it matters beyond this run

This likely explains the case study's **"GRPO flat at matched compute"** on GSM8K — that may have been this same truncation artifact rather than genuine RLVR failure. Worth re-checking the GRPO comparison with the fix before treating "RLVR doesn't help here" as established.

Tests: GRPO config default ≥ 512 and overridable (CI-safe, no torch/trl).