### PR TITLE
fix(grpo): make RLVR work on free-text reasoning tasks (GSM8K — non-termination + JSON-only reward)

### DIFF
--- a/autocontext/src/autocontext/training/autoresearch/grpo_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/grpo_backend.py
@@ -49,33 +49,50 @@ _DAPO_EPSILON_HIGH = 0.28  # DAPO clip-higher default
 # ---------------------------------------------------------------------------
 # Reward adapter (the core: model completions -> scalar verifier rewards)
 # ---------------------------------------------------------------------------
-def score_completions(scenario: Any, completions: list[str], *, answers: list[str] | None = None, seed: int = 0) -> list[float]:
+def _completion_text(completion: Any) -> str:
+    """Normalize a TRL completion to text. Conversational prompts yield message-list completions
+    (``[{"role": "assistant", "content": ...}]``); plain prompts yield strings."""
+    if isinstance(completion, str):
+        return completion
+    if isinstance(completion, list) and completion:
+        last = completion[-1]
+        return str(last.get("content", "")) if isinstance(last, dict) else str(last)
+    return str(completion)
+
+
+def score_completions(scenario: Any, completions: list[Any], *, answers: list[str] | None = None, seed: int = 0) -> list[float]:
     """Score each completion with the scenario verifier; the GRPO reward function.
 
-    Robust to reason-then-construct output (extracts the JSON construction via the
-    shared ``extract_json_object``). Game scenarios are scored by ``execute_match``,
-    agent-task scenarios by ``evaluate_output``. Unparseable output or a throwing
-    verifier scores 0.0 (never propagates, so one bad rollout can't kill training).
+    Game scenarios (``execute_match``) expect a JSON construction, so the completion's trailing
+    JSON object is extracted (reason-then-construct robust) and a non-dict scores 0.0.
 
-    When ``answers`` is given (aligned to ``completions``), each completion is verified
-    against ITS OWN instance state (decoded from the answer field that
-    :func:`build_prompt_rows` wrote), so prompt-diverse GRPO scores each rollout against
-    the instance it was sampled for. Without it, a single resolved state is used.
+    Agent-task scenarios (``evaluate_output``) are scored hybrid: if the completion contains a JSON
+    construction it is passed as canonical JSON (back-compat for JSON-construction agent tasks), but
+    if there is NO JSON the RAW text is passed -- GSM8K-style answers are free text, and the old
+    extract-JSON-or-zero path silently scored every correct free-text answer 0 (the bug that zeroed
+    GRPO reward on reasoning tasks). A throwing verifier scores 0.0.
+
+    Accepts string OR conversational (message-list) completions. When ``answers`` is given (aligned
+    to ``completions``), each is verified against ITS OWN instance state (decoded from the answer
+    field :func:`build_prompt_rows` wrote); otherwise a single resolved state is used.
     """
     is_game = hasattr(scenario, "execute_match")
     shared_state = {} if is_game else _resolve_state(scenario, seed)
     scores: list[float] = []
     for i, completion in enumerate(completions):
-        strategy = extract_json_object(completion)
-        if not isinstance(strategy, dict):
-            scores.append(0.0)
-            continue
+        text = _completion_text(completion)
         state = _decode_answer_state(answers[i]) if answers and i < len(answers) else shared_state
         try:
             if is_game:
+                strategy = extract_json_object(text)
+                if not isinstance(strategy, dict):
+                    scores.append(0.0)
+                    continue
                 scores.append(float(scenario.execute_match(strategy, seed=seed).score))
             else:
-                scores.append(float(scenario.evaluate_output(output=json.dumps(strategy), state=state).score))
+                strategy = extract_json_object(text)
+                output = json.dumps(strategy) if isinstance(strategy, dict) else text  # JSON if present, else raw text
+                scores.append(float(scenario.evaluate_output(output=output, state=state).score))
         except Exception:
             scores.append(0.0)
     return scores

--- a/autocontext/src/autocontext/training/autoresearch/trl_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/trl_backend.py
@@ -153,10 +153,19 @@ def build_chat_dataset_rows(scenario: Any, n_prompts: int) -> list[dict[str, Any
     ]
 
 
-def build_prompt_dataset_rows(scenario: Any, n_prompts: int) -> list[dict[str, str]]:
-    """GRPO dataset rows: ``{"prompt", "answer"}`` (TRL passes the extra ``answer`` column
-    to the reward function as a kwarg). This is exactly what :func:`build_prompt_rows` emits."""
-    return build_prompt_rows(scenario, n_prompts)
+def build_prompt_dataset_rows(scenario: Any, n_prompts: int) -> list[dict[str, Any]]:
+    """GRPO dataset rows: ``{"prompt": [chat messages], "answer"}``.
+
+    The prompt is **conversational** (a one-message user turn), NOT a raw string: TRL applies
+    the model's chat template to conversational prompts before generation, so an instruct model
+    answers in chat mode and emits EOS after its answer. A raw-string prompt skips the template,
+    the instruct model never stops, and every completion runs to ``max_completion_length``
+    (``clipped_ratio=1``) without a parseable answer -> reward 0 -> no gradient. ``answer`` carries
+    the per-instance state for the reward (TRL passes extra columns through as kwargs)."""
+    return [
+        {"prompt": [{"role": "user", "content": row["prompt"]}], "answer": row["answer"]}
+        for row in build_prompt_rows(scenario, n_prompts)
+    ]
 
 
 def make_reward_func(scenario: Any) -> Any:

--- a/autocontext/tests/test_grpo_backend.py
+++ b/autocontext/tests/test_grpo_backend.py
@@ -90,6 +90,40 @@ def test_score_completions_is_robust_to_verifier_errors() -> None:
     assert score_completions(_Boom(), ['{"points": [1]}']) == [0.0]
 
 
+class _FreeTextScenario:
+    """Free-text agent task (GSM8K-style): scores the RAW completion, no JSON. The old
+    extract-JSON-or-zero path scored every correct free-text answer 0 -> GRPO got no reward."""
+
+    name = "freetext"
+    description = "free text"
+
+    def initial_state(self, seed=None):
+        return {"gold": 42}
+
+    def get_task_prompt(self, state=None):
+        return "What is the answer?"
+
+    def evaluate_output(self, output, state, **kwargs):
+        return AgentTaskResult(score=1.0 if "Answer: 42" in output else 0.0, reasoning="")
+
+
+def test_score_completions_scores_free_text_agent_task_without_json() -> None:
+    """GSM8K-style: the raw free-text completion must reach evaluate_output (no JSON extraction),
+    else every correct reasoning answer scores 0 and GRPO never learns."""
+    from autocontext.training.autoresearch.grpo_backend import score_completions
+
+    comps = ["Let me think step by step... so the total is 42.\nAnswer: 42", "I think it is 7.\nAnswer: 7"]
+    assert score_completions(_FreeTextScenario(), comps, answers=['{"gold": 42}', '{"gold": 42}']) == [1.0, 0.0]
+
+
+def test_score_completions_accepts_conversational_completions() -> None:
+    """TRL conversational prompts yield message-list completions; the reward must read their text."""
+    from autocontext.training.autoresearch.grpo_backend import score_completions
+
+    comps = [[{"role": "assistant", "content": "work...\nAnswer: 42"}]]
+    assert score_completions(_FreeTextScenario(), comps, answers=['{"gold": 42}']) == [1.0]
+
+
 # ---------------------------------------------------------------------------
 # grpo_cli_args: variant -> mlx-lm-lora flag mapping
 # ---------------------------------------------------------------------------

--- a/autocontext/tests/test_trl_backend.py
+++ b/autocontext/tests/test_trl_backend.py
@@ -144,6 +144,12 @@ def test_prompt_dataset_rows_have_prompt_and_answer_for_grpo() -> None:
     rows = build_prompt_dataset_rows(_TargetScenario(), 3)
     assert len(rows) == 3
     assert all("prompt" in r and "answer" in r for r in rows)
+    # prompts are CONVERSATIONAL (message list), so TRL applies the chat template before
+    # generation -> the instruct model answers in chat mode and stops at EOS (a raw-string
+    # prompt skips the template, the model never stops, and every completion truncates).
+    for r in rows:
+        assert isinstance(r["prompt"], list)
+        assert r["prompt"][0]["role"] == "user" and isinstance(r["prompt"][0]["content"], str)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Watching a GSM8K GRPO run live exposed **two more bugs** that made RLVR a silent no-op (every reward 0, no gradient), on top of the completion-length issue fixed in #1067. With #1067, completions stopped truncating *for length* — but the metrics still showed `clipped_ratio: 1`, `mean_terminated_length: 0`, `reward: 0`:

1. **No chat template on GRPO prompts.** `build_prompt_dataset_rows` emitted a raw-string `prompt`, so TRL skipped the chat template. The instruct model never entered chat mode, never emitted EOS, and every completion ran to `max_completion_length` without a parseable answer. Now it emits **conversational** prompts (`[{role: user, content}]`) so TRL applies the chat template → completions terminate at EOS.

2. **Reward required JSON.** `score_completions` ran `extract_json_object` on every completion and scored a non-dict 0 — so a correct free-text GSM8K answer ("…Answer: 42") scored **0**. It's now **hybrid** for agent tasks: pass the extracted JSON when present (back-compat for JSON-construction agent tasks), else the **raw text**; and it accepts conversational (message-list) completions.

Both are the same game-vs-agent-task split already fixed in the mlxlm assessment path (#1064): games → JSON via `execute_match`; agent tasks → raw text via `evaluate_output`.

## Why it matters

RLVR (GRPO) is the most promising verifier-driven self-improvement path on math, but across two Modal runs it was a flat artifact — first from truncation (#1067), then from these two issues. Together with #1067 these make GRPO actually capable of earning reward on reasoning tasks, so a future run can finally test RLVR fairly.

## Tests (CI-safe, no torch/trl)
Free-text agent-task scoring without JSON; conversational (message-list) completion handling; conversational prompt rows. Existing JSON-construction agent-task + game tests still pass (back-compat preserved). ruff + mypy clean.