### PR TITLE
AC-683: Surface trace findings and gate decisions

### DIFF
--- a/autocontext/src/autocontext/analytics/__init__.py
+++ b/autocontext/src/autocontext/analytics/__init__.py
@@ -1,5 +1,19 @@
 """Aggregate analytics for cross-run facets, signal extraction, and pattern clustering."""
 
 from autocontext.analytics.runtime_session_run_trace import runtime_session_log_to_run_trace
+from autocontext.analytics.trace_gate_operator_view import (
+    TraceGateAnalysisState,
+    TraceGateOperatorState,
+    TraceGateOperatorView,
+    build_trace_gate_operator_view,
+    render_trace_gate_operator_view_lines,
+)
 
-__all__ = ["runtime_session_log_to_run_trace"]
+__all__ = [
+    "TraceGateAnalysisState",
+    "TraceGateOperatorState",
+    "TraceGateOperatorView",
+    "build_trace_gate_operator_view",
+    "render_trace_gate_operator_view_lines",
+    "runtime_session_log_to_run_trace",
+]

--- a/autocontext/src/autocontext/analytics/trace_gate_operator_view.py
+++ b/autocontext/src/autocontext/analytics/trace_gate_operator_view.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal, TypeAlias
+
+from autocontext.analytics.cross_runtime_trace_findings import (
+    CrossRuntimeFailureMotif,
+    CrossRuntimeTraceFinding,
+    CrossRuntimeTraceFindingReport,
+)
+
+TraceGateOperatorState: TypeAlias = Literal[
+    "missing_report",
+    "incomplete_analysis",
+    "no_findings",
+    "ready",
+]
+TraceGateAnalysisState: TypeAlias = Literal["complete", "incomplete"]
+TraceEvidenceLink: TypeAlias = dict[str, str]
+TraceGateOperatorView: TypeAlias = dict[str, Any]
+
+
+def build_trace_gate_operator_view(
+    *,
+    run_id: str,
+    report: CrossRuntimeTraceFindingReport | Mapping[str, Any] | None,
+    proposals: Sequence[Mapping[str, Any]] | None = None,
+    analysis_state: TraceGateAnalysisState = "complete",
+) -> TraceGateOperatorView:
+    parsed_report = _parse_report(report)
+    parsed_proposals = list(proposals or [])
+    state = _resolve_state(parsed_report, parsed_proposals, analysis_state)
+    linked_proposal_ids = _proposal_ids_by_finding(parsed_proposals)
+    return {
+        "schema_version": "1",
+        "run_id": run_id,
+        "state": state,
+        "summary": _summary_for_state(state, parsed_report),
+        "report": _summarize_report(parsed_report) if parsed_report is not None else None,
+        "findings": [
+            _finding_view(finding, linked_proposal_ids)
+            for finding in (parsed_report.findings if parsed_report is not None else [])
+        ],
+        "failure_modes": [
+            _failure_mode_view(motif) for motif in (parsed_report.failure_motifs if parsed_report is not None else [])
+        ],
+        "proposals": [_proposal_view(proposal) for proposal in parsed_proposals],
+        "gate_decisions": [decision for proposal in parsed_proposals for decision in _decision_views(proposal)],
+    }
+
+
+def render_trace_gate_operator_view_lines(view: Mapping[str, Any]) -> list[str]:
+    lines = [f"Trace gates for {view['run_id']} — {view['state']}", _read_str(view.get("summary"))]
+    findings = _read_list(view.get("findings"))
+    lines.append("Findings:")
+    if findings:
+        for finding in findings:
+            evidence = _format_evidence_labels(_read_list(finding.get("evidence_refs")))
+            proposal_text = _format_list(_read_str_list(finding.get("linked_proposal_ids")))
+            lines.append(
+                f"- [{finding['severity']}/{finding['category']}] {finding['title']} "
+                f"evidence={evidence} proposals={proposal_text}"
+            )
+    else:
+        lines.append("- none")
+
+    modes = _read_list(view.get("failure_modes"))
+    lines.append("Recurring failure modes:")
+    if modes:
+        for mode in modes:
+            evidence = _format_evidence_labels(_read_list(mode.get("representative_evidence_refs")))
+            lines.append(f"- {mode['category']} x{mode['occurrence_count']} evidence={evidence}")
+    else:
+        lines.append("- none")
+
+    proposal_views = _read_list(view.get("proposals"))
+    lines.append("Proposals:")
+    if proposal_views:
+        for proposal in proposal_views:
+            lines.append(
+                f"- {proposal['proposal_id']} {proposal['status']} target={proposal['target_surface']} "
+                f"patches={proposal['patch_count']} — {proposal['summary']}"
+            )
+    else:
+        lines.append("- none")
+
+    decisions = _read_list(view.get("gate_decisions"))
+    lines.append("Gate decisions:")
+    if decisions:
+        for decision in decisions:
+            validation_mode = _read_str(decision.get("validation_mode")) or "unknown"
+            lines.append(f"- {decision['proposal_id']} {decision['status']} {validation_mode} — {decision['reason']}")
+    else:
+        lines.append("- none")
+    return lines
+
+
+def _parse_report(
+    report: CrossRuntimeTraceFindingReport | Mapping[str, Any] | None,
+) -> CrossRuntimeTraceFindingReport | None:
+    if report is None:
+        return None
+    if isinstance(report, CrossRuntimeTraceFindingReport):
+        return report
+    return CrossRuntimeTraceFindingReport.model_validate(report)
+
+
+def _resolve_state(
+    report: CrossRuntimeTraceFindingReport | None,
+    proposals: Sequence[Mapping[str, Any]],
+    analysis_state: TraceGateAnalysisState,
+) -> TraceGateOperatorState:
+    if analysis_state == "incomplete":
+        return "incomplete_analysis"
+    if report is None:
+        return "missing_report"
+    if not report.findings and not proposals:
+        return "no_findings"
+    return "ready"
+
+
+def _summary_for_state(
+    state: TraceGateOperatorState,
+    report: CrossRuntimeTraceFindingReport | None,
+) -> str:
+    if state == "incomplete_analysis":
+        return "Trace analysis is still running; findings and gate decisions may be incomplete."
+    if state == "missing_report":
+        return "No trace finding report is available for this run yet."
+    if state == "no_findings":
+        return report.summary if report is not None else "No findings or proposals are available for this run."
+    return report.summary if report is not None else "Trace findings and gate decisions are ready."
+
+
+def _summarize_report(report: CrossRuntimeTraceFindingReport) -> dict[str, str | int]:
+    return {
+        "report_id": report.report_id,
+        "trace_id": report.trace_id,
+        "source_harness": report.source_harness,
+        "created_at": report.created_at,
+        "finding_count": len(report.findings),
+        "failure_mode_count": len(report.failure_motifs),
+    }
+
+
+def _finding_view(
+    finding: CrossRuntimeTraceFinding,
+    linked_proposal_ids: Mapping[str, list[str]],
+) -> dict[str, Any]:
+    evidence_refs = [_trace_message_evidence_link(index) for index in finding.evidence_message_indexes]
+    return {
+        "finding_id": finding.finding_id,
+        "category": finding.category,
+        "severity": finding.severity,
+        "title": finding.title,
+        "description": finding.description,
+        "evidence_count": len(evidence_refs),
+        "evidence_refs": evidence_refs,
+        "linked_proposal_ids": linked_proposal_ids.get(finding.finding_id, []),
+    }
+
+
+def _failure_mode_view(motif: CrossRuntimeFailureMotif) -> dict[str, Any]:
+    return {
+        "motif_id": motif.motif_id,
+        "category": motif.category,
+        "occurrence_count": motif.occurrence_count,
+        "description": motif.description,
+        "representative_evidence_refs": [_trace_message_evidence_link(index) for index in motif.evidence_message_indexes],
+    }
+
+
+def _proposal_view(proposal: Mapping[str, Any]) -> dict[str, Any]:
+    proposed_edit = _read_mapping(_read_key(proposal, "proposedEdit", "proposed_edit"))
+    decision = _read_mapping(proposal.get("decision"))
+    return {
+        "proposal_id": _read_str(proposal.get("id")),
+        "status": _read_str(proposal.get("status")),
+        "target_surface": _read_str(_read_key(proposal, "targetSurface", "target_surface")),
+        "summary": _read_str(proposed_edit.get("summary")),
+        "finding_ids": _read_str_list(_read_key(proposal, "findingIds", "finding_ids")),
+        "patch_count": len(_read_list(proposed_edit.get("patches"))),
+        "rollback_criteria": _read_str_list(_read_key(proposal, "rollbackCriteria", "rollback_criteria")),
+        "gate_status": _read_str(decision.get("status")),
+        "gate_reason": _read_str(decision.get("reason")),
+    }
+
+
+def _decision_views(proposal: Mapping[str, Any]) -> list[dict[str, Any]]:
+    decision = _read_mapping(proposal.get("decision"))
+    if not decision:
+        return []
+    validation = _read_mapping(decision.get("validation"))
+    evidence_refs = [
+        _artifact_evidence_link(ref) for ref in _read_str_list(_read_key(validation, "evidenceRefs", "evidence_refs"))
+    ]
+    return [
+        {
+            "proposal_id": _read_str(proposal.get("id")),
+            "status": _read_str(decision.get("status")),
+            "reason": _read_str(decision.get("reason")),
+            "validation_mode": _read_str(validation.get("mode")),
+            "suite_id": _read_str(_read_key(validation, "suiteId", "suite_id")),
+            "decided_at": _read_str(_read_key(decision, "decidedAt", "decided_at")),
+            "evidence_refs": evidence_refs,
+        }
+    ]
+
+
+def _proposal_ids_by_finding(proposals: Sequence[Mapping[str, Any]]) -> dict[str, list[str]]:
+    ids: dict[str, list[str]] = {}
+    for proposal in proposals:
+        proposal_id = _read_str(proposal.get("id"))
+        for finding_id in _read_str_list(_read_key(proposal, "findingIds", "finding_ids")):
+            ids.setdefault(finding_id, []).append(proposal_id)
+    return ids
+
+
+def _trace_message_evidence_link(index: int) -> TraceEvidenceLink:
+    return {
+        "kind": "trace_message",
+        "ref": f"msg:{index}",
+        "label": f"msg #{index}",
+        "href": f"#msg-{index}",
+    }
+
+
+def _artifact_evidence_link(ref: str) -> TraceEvidenceLink:
+    return {
+        "kind": "artifact",
+        "ref": ref,
+        "label": _artifact_label(ref),
+        "href": ref,
+    }
+
+
+def _artifact_label(ref: str) -> str:
+    return next((part for part in reversed(ref.replace("\\", "/").split("/")) if part), ref)
+
+
+def _format_evidence_labels(refs: Sequence[Mapping[str, Any]]) -> str:
+    labels = [_read_str(ref.get("label")) for ref in refs if _read_str(ref.get("label"))]
+    return ", ".join(labels) if labels else "none"
+
+
+def _format_list(items: Sequence[str]) -> str:
+    return ", ".join(items) if items else "none"
+
+
+def _read_key(mapping: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in mapping:
+            return mapping[key]
+    return None
+
+
+def _read_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _read_list(value: Any) -> list[Mapping[str, Any]]:
+    return [item for item in value if isinstance(item, Mapping)] if isinstance(value, list) else []
+
+
+def _read_str_list(value: Any) -> list[str]:
+    return [item for item in value if isinstance(item, str)] if isinstance(value, list) else []
+
+
+def _read_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""

--- a/autocontext/src/autocontext/control_plane/harness_change_proposal.py
+++ b/autocontext/src/autocontext/control_plane/harness_change_proposal.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any, cast
+
+_SCHEMA_VERSION_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+_ULID_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
+_SUITE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_DATE_TIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
+
+
+class InvalidHarnessChangeProposalError(Exception):
+    """Raised when persisted proposal JSON does not match the shared contract."""
+
+
+def validate_harness_change_proposal(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a HarnessChangeProposal JSON object before trusting gate decisions."""
+    proposal = _expect_mapping(payload, "HarnessChangeProposal")
+    _require_keys(
+        proposal,
+        {
+            "schemaVersion",
+            "id",
+            "status",
+            "findingIds",
+            "targetSurface",
+            "proposedEdit",
+            "expectedImpact",
+            "rollbackCriteria",
+            "provenance",
+        },
+        "HarnessChangeProposal",
+    )
+    _reject_extra(
+        proposal,
+        {
+            "schemaVersion",
+            "id",
+            "status",
+            "findingIds",
+            "targetSurface",
+            "proposedEdit",
+            "expectedImpact",
+            "rollbackCriteria",
+            "provenance",
+            "decision",
+        },
+        "HarnessChangeProposal",
+    )
+    _expect_pattern(proposal["schemaVersion"], _SCHEMA_VERSION_RE, "schemaVersion")
+    _expect_pattern(proposal["id"], _ULID_RE, "id")
+    status = _expect_literal(proposal["status"], {"proposed", "accepted", "rejected", "inconclusive"}, "status")
+    _expect_non_empty_str_list(proposal["findingIds"], "findingIds")
+    _expect_literal(
+        proposal["targetSurface"],
+        {
+            "prompt",
+            "tool-schema",
+            "tool-affordance-policy",
+            "compaction-policy",
+            "verifier-rubric",
+            "retry-policy",
+            "playbook",
+        },
+        "targetSurface",
+    )
+    _validate_proposed_edit(proposal["proposedEdit"])
+    _validate_expected_impact(proposal["expectedImpact"])
+    _expect_non_empty_str_list(proposal["rollbackCriteria"], "rollbackCriteria")
+    _validate_provenance(proposal["provenance"])
+
+    if status == "proposed":
+        if "decision" in proposal:
+            _fail("proposed HarnessChangeProposal must not include decision")
+    else:
+        if "decision" not in proposal:
+            _fail(f"{status} HarnessChangeProposal requires decision")
+        _validate_decision(proposal["decision"], status)
+    return dict(proposal)
+
+
+def _validate_proposed_edit(value: Any) -> None:
+    edit = _expect_mapping(value, "proposedEdit")
+    _require_keys(edit, {"summary", "patches"}, "proposedEdit")
+    _reject_extra(edit, {"summary", "patches"}, "proposedEdit")
+    _expect_non_empty_str(edit["summary"], "proposedEdit.summary")
+    patches = _expect_non_empty_sequence(edit["patches"], "proposedEdit.patches")
+    for index, patch in enumerate(patches):
+        patch_map = _expect_mapping(patch, f"proposedEdit.patches[{index}]")
+        _require_keys(patch_map, {"filePath", "operation", "unifiedDiff"}, f"proposedEdit.patches[{index}]")
+        _reject_extra(
+            patch_map,
+            {"filePath", "operation", "unifiedDiff", "afterContent"},
+            f"proposedEdit.patches[{index}]",
+        )
+        _expect_non_empty_str(patch_map["filePath"], f"proposedEdit.patches[{index}].filePath")
+        _expect_literal(patch_map["operation"], {"create", "modify", "delete"}, f"proposedEdit.patches[{index}].operation")
+        _expect_str(patch_map["unifiedDiff"], f"proposedEdit.patches[{index}].unifiedDiff")
+        if "afterContent" in patch_map:
+            _expect_str(patch_map["afterContent"], f"proposedEdit.patches[{index}].afterContent")
+
+
+def _validate_expected_impact(value: Any) -> None:
+    impact = _expect_mapping(value, "expectedImpact")
+    _reject_extra(
+        impact,
+        {"qualityDelta", "costDelta", "latencyDelta", "riskReduction", "notes"},
+        "expectedImpact",
+    )
+    if "qualityDelta" in impact:
+        _expect_number(impact["qualityDelta"], "expectedImpact.qualityDelta")
+    if "costDelta" in impact:
+        _validate_cost_metric(impact["costDelta"], "expectedImpact.costDelta")
+    if "latencyDelta" in impact:
+        _validate_latency_metric(impact["latencyDelta"], "expectedImpact.latencyDelta")
+    if "riskReduction" in impact:
+        _expect_non_empty_str(impact["riskReduction"], "expectedImpact.riskReduction")
+    if "notes" in impact:
+        _expect_str_list(impact["notes"], "expectedImpact.notes")
+
+
+def _validate_provenance(value: Any) -> None:
+    provenance = _expect_mapping(value, "provenance")
+    _require_keys(provenance, {"authorType", "authorId", "parentArtifactIds", "createdAt"}, "provenance")
+    _reject_extra(provenance, {"authorType", "authorId", "agentRole", "parentArtifactIds", "createdAt"}, "provenance")
+    _expect_literal(provenance["authorType"], {"autocontext-run", "human", "external-agent"}, "provenance.authorType")
+    _expect_non_empty_str(provenance["authorId"], "provenance.authorId")
+    if "agentRole" in provenance:
+        _expect_str(provenance["agentRole"], "provenance.agentRole")
+    for index, artifact_id in enumerate(_expect_sequence(provenance["parentArtifactIds"], "provenance.parentArtifactIds")):
+        _expect_pattern(artifact_id, _ULID_RE, f"provenance.parentArtifactIds[{index}]")
+    _expect_date_time(provenance["createdAt"], "provenance.createdAt")
+
+
+def _validate_decision(value: Any, proposal_status: str) -> None:
+    decision = _expect_mapping(value, "decision")
+    _require_keys(
+        decision,
+        {"status", "reason", "validation", "promotionDecision", "candidateArtifactId", "candidateEvalRunId", "decidedAt"},
+        "decision",
+    )
+    _reject_extra(
+        decision,
+        {
+            "status",
+            "reason",
+            "validation",
+            "promotionDecision",
+            "candidateArtifactId",
+            "candidateEvalRunId",
+            "baselineArtifactId",
+            "baselineEvalRunId",
+            "decidedAt",
+        },
+        "decision",
+    )
+    decision_status = _expect_literal(decision["status"], {"accepted", "rejected", "inconclusive"}, "decision.status")
+    if decision_status != proposal_status:
+        _fail("HarnessChangeProposal decision.status must match status")
+    _expect_non_empty_str(decision["reason"], "decision.reason")
+    validation = _validate_validation(decision["validation"])
+    _validate_promotion_decision(decision["promotionDecision"])
+    _expect_pattern(decision["candidateArtifactId"], _ULID_RE, "decision.candidateArtifactId")
+    _expect_non_empty_str(decision["candidateEvalRunId"], "decision.candidateEvalRunId")
+    if "baselineArtifactId" in decision:
+        _expect_pattern(decision["baselineArtifactId"], _ULID_RE, "decision.baselineArtifactId")
+    if "baselineEvalRunId" in decision:
+        _expect_non_empty_str(decision["baselineEvalRunId"], "decision.baselineEvalRunId")
+    _expect_date_time(decision["decidedAt"], "decision.decidedAt")
+    if proposal_status in {"accepted", "rejected"}:
+        if validation["mode"] not in {"heldout", "fresh"}:
+            _fail("accepted/rejected HarnessChangeProposal requires heldout or fresh validation")
+        if not validation["evidenceRefs"]:
+            _fail("accepted/rejected HarnessChangeProposal requires validation evidenceRefs")
+        if "baselineArtifactId" not in decision or "baselineEvalRunId" not in decision:
+            _fail("accepted/rejected HarnessChangeProposal requires baseline artifact and eval refs")
+
+
+def _validate_validation(value: Any) -> Mapping[str, Any]:
+    validation = _expect_mapping(value, "decision.validation")
+    _require_keys(validation, {"mode", "suiteId", "evidenceRefs"}, "decision.validation")
+    _reject_extra(validation, {"mode", "suiteId", "evidenceRefs"}, "decision.validation")
+    _expect_literal(validation["mode"], {"dev", "heldout", "fresh"}, "decision.validation.mode")
+    _expect_pattern(validation["suiteId"], _SUITE_ID_RE, "decision.validation.suiteId")
+    _expect_str_list(validation["evidenceRefs"], "decision.validation.evidenceRefs", require_non_empty_items=True)
+    return validation
+
+
+def _validate_promotion_decision(value: Any) -> None:
+    decision = _expect_mapping(value, "decision.promotionDecision")
+    _require_keys(
+        decision,
+        {"schemaVersion", "pass", "recommendedTargetState", "deltas", "confidence", "thresholds", "reasoning", "evaluatedAt"},
+        "decision.promotionDecision",
+    )
+    _reject_extra(
+        decision,
+        {
+            "schemaVersion",
+            "pass",
+            "recommendedTargetState",
+            "deltas",
+            "confidence",
+            "thresholds",
+            "ablationVerification",
+            "reasoning",
+            "evaluatedAt",
+        },
+        "decision.promotionDecision",
+    )
+    _expect_pattern(decision["schemaVersion"], _SCHEMA_VERSION_RE, "decision.promotionDecision.schemaVersion")
+    _expect_bool(decision["pass"], "decision.promotionDecision.pass")
+    _expect_literal(
+        decision["recommendedTargetState"],
+        {"shadow", "canary", "active", "disabled"},
+        "decision.promotionDecision.recommendedTargetState",
+    )
+    _validate_promotion_deltas(decision["deltas"])
+    confidence = _expect_number(decision["confidence"], "decision.promotionDecision.confidence")
+    if not 0 <= confidence <= 1:
+        _fail("decision.promotionDecision.confidence must be between 0 and 1")
+    _validate_thresholds(decision["thresholds"])
+    if "ablationVerification" in decision:
+        _validate_ablation_verification(decision["ablationVerification"])
+    _expect_str(decision["reasoning"], "decision.promotionDecision.reasoning")
+    _expect_date_time(decision["evaluatedAt"], "decision.promotionDecision.evaluatedAt")
+
+
+def _validate_promotion_deltas(value: Any) -> None:
+    deltas = _expect_mapping(value, "decision.promotionDecision.deltas")
+    _require_keys(deltas, {"quality", "cost", "latency", "safety"}, "decision.promotionDecision.deltas")
+    _reject_extra(deltas, {"quality", "cost", "latency", "safety", "humanFeedback"}, "decision.promotionDecision.deltas")
+    _validate_quality_delta(deltas["quality"])
+    _validate_metric_delta(deltas["cost"], _validate_cost_metric, "decision.promotionDecision.deltas.cost")
+    _validate_metric_delta(deltas["latency"], _validate_latency_metric, "decision.promotionDecision.deltas.latency")
+    _validate_safety_delta(deltas["safety"])
+    if "humanFeedback" in deltas:
+        feedback = _expect_mapping(deltas["humanFeedback"], "decision.promotionDecision.deltas.humanFeedback")
+        _require_keys(feedback, {"delta", "passed"}, "decision.promotionDecision.deltas.humanFeedback")
+        _reject_extra(feedback, {"delta", "passed"}, "decision.promotionDecision.deltas.humanFeedback")
+        _expect_number(feedback["delta"], "decision.promotionDecision.deltas.humanFeedback.delta")
+        _expect_bool(feedback["passed"], "decision.promotionDecision.deltas.humanFeedback.passed")
+
+
+def _validate_quality_delta(value: Any) -> None:
+    quality = _expect_mapping(value, "decision.promotionDecision.deltas.quality")
+    _require_keys(quality, {"baseline", "candidate", "delta", "passed"}, "decision.promotionDecision.deltas.quality")
+    _reject_extra(quality, {"baseline", "candidate", "delta", "passed"}, "decision.promotionDecision.deltas.quality")
+    _expect_number(quality["baseline"], "decision.promotionDecision.deltas.quality.baseline")
+    _expect_number(quality["candidate"], "decision.promotionDecision.deltas.quality.candidate")
+    _expect_number(quality["delta"], "decision.promotionDecision.deltas.quality.delta")
+    _expect_bool(quality["passed"], "decision.promotionDecision.deltas.quality.passed")
+
+
+def _validate_metric_delta(value: Any, metric_validator: Any, path: str) -> None:
+    delta = _expect_mapping(value, path)
+    _require_keys(delta, {"baseline", "candidate", "delta", "passed"}, path)
+    _reject_extra(delta, {"baseline", "candidate", "delta", "passed"}, path)
+    metric_validator(delta["baseline"], f"{path}.baseline")
+    metric_validator(delta["candidate"], f"{path}.candidate")
+    metric_validator(delta["delta"], f"{path}.delta")
+    _expect_bool(delta["passed"], f"{path}.passed")
+
+
+def _validate_safety_delta(value: Any) -> None:
+    safety = _expect_mapping(value, "decision.promotionDecision.deltas.safety")
+    _require_keys(safety, {"regressions", "passed"}, "decision.promotionDecision.deltas.safety")
+    _reject_extra(safety, {"regressions", "passed"}, "decision.promotionDecision.deltas.safety")
+    regression_path = "decision.promotionDecision.deltas.safety.regressions"
+    for index, regression in enumerate(_expect_sequence(safety["regressions"], regression_path)):
+        item_path = f"{regression_path}[{index}]"
+        regression_map = _expect_mapping(regression, item_path)
+        _require_keys(regression_map, {"id", "severity", "description"}, item_path)
+        _reject_extra(
+            regression_map,
+            {"id", "severity", "description", "exampleRef"},
+            item_path,
+        )
+        _expect_non_empty_str(regression_map["id"], f"{item_path}.id")
+        _expect_literal(
+            regression_map["severity"],
+            {"info", "minor", "major", "critical"},
+            f"{item_path}.severity",
+        )
+        _expect_str(regression_map["description"], f"{item_path}.description")
+        if "exampleRef" in regression_map:
+            _expect_str(regression_map["exampleRef"], f"{item_path}.exampleRef")
+    _expect_bool(safety["passed"], "decision.promotionDecision.deltas.safety.passed")
+
+
+def _validate_thresholds(value: Any) -> None:
+    thresholds = _expect_mapping(value, "decision.promotionDecision.thresholds")
+    _require_keys(
+        thresholds,
+        {
+            "qualityMinDelta",
+            "costMaxRelativeIncrease",
+            "latencyMaxRelativeIncrease",
+            "strongConfidenceMin",
+            "moderateConfidenceMin",
+            "strongQualityMultiplier",
+        },
+        "decision.promotionDecision.thresholds",
+    )
+    _reject_extra(
+        thresholds,
+        {
+            "qualityMinDelta",
+            "costMaxRelativeIncrease",
+            "latencyMaxRelativeIncrease",
+            "humanFeedbackMinDelta",
+            "strongConfidenceMin",
+            "moderateConfidenceMin",
+            "strongQualityMultiplier",
+        },
+        "decision.promotionDecision.thresholds",
+    )
+    for field in thresholds:
+        _expect_number(thresholds[field], f"decision.promotionDecision.thresholds.{field}")
+
+
+def _validate_ablation_verification(value: Any) -> None:
+    ablation = _expect_mapping(value, "decision.promotionDecision.ablationVerification")
+    _require_keys(
+        ablation,
+        {"required", "status", "requiredTargets", "coveredTargets", "missingTargets"},
+        "decision.promotionDecision.ablationVerification",
+    )
+    _reject_extra(
+        ablation,
+        {"required", "status", "requiredTargets", "coveredTargets", "missingTargets", "reason"},
+        "decision.promotionDecision.ablationVerification",
+    )
+    _expect_bool(ablation["required"], "decision.promotionDecision.ablationVerification.required")
+    _expect_literal(
+        ablation["status"],
+        {"not-required", "missing", "incomplete", "failed", "passed"},
+        "decision.promotionDecision.ablationVerification.status",
+    )
+    ablation_path = "decision.promotionDecision.ablationVerification"
+    for field in ("requiredTargets", "coveredTargets", "missingTargets"):
+        target_path = f"{ablation_path}.{field}"
+        for index, target in enumerate(_expect_sequence(ablation[field], target_path)):
+            _expect_literal(
+                target,
+                {"strategy", "harness"},
+                f"{target_path}[{index}]",
+            )
+    if "reason" in ablation:
+        _expect_non_empty_str(ablation["reason"], "decision.promotionDecision.ablationVerification.reason")
+
+
+def _validate_cost_metric(value: Any, path: str) -> None:
+    metric = _expect_mapping(value, path)
+    _require_keys(metric, {"tokensIn", "tokensOut"}, path)
+    _reject_extra(metric, {"tokensIn", "tokensOut", "usd"}, path)
+    _expect_number(metric["tokensIn"], f"{path}.tokensIn")
+    _expect_number(metric["tokensOut"], f"{path}.tokensOut")
+    if "usd" in metric:
+        _expect_number(metric["usd"], f"{path}.usd")
+
+
+def _validate_latency_metric(value: Any, path: str) -> None:
+    metric = _expect_mapping(value, path)
+    _require_keys(metric, {"p50Ms", "p95Ms", "p99Ms"}, path)
+    _reject_extra(metric, {"p50Ms", "p95Ms", "p99Ms"}, path)
+    _expect_number(metric["p50Ms"], f"{path}.p50Ms")
+    _expect_number(metric["p95Ms"], f"{path}.p95Ms")
+    _expect_number(metric["p99Ms"], f"{path}.p99Ms")
+
+
+def _expect_mapping(value: Any, path: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        _fail(f"{path} must be an object")
+    return cast(Mapping[str, Any], value)
+
+
+def _expect_sequence(value: Any, path: str) -> Sequence[Any]:
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        _fail(f"{path} must be an array")
+    return cast(Sequence[Any], value)
+
+
+def _expect_non_empty_sequence(value: Any, path: str) -> Sequence[Any]:
+    sequence = _expect_sequence(value, path)
+    if not sequence:
+        _fail(f"{path} must contain at least one item")
+    return sequence
+
+
+def _expect_str(value: Any, path: str) -> str:
+    if not isinstance(value, str):
+        _fail(f"{path} must be a string")
+    return cast(str, value)
+
+
+def _expect_non_empty_str(value: Any, path: str) -> str:
+    text = _expect_str(value, path)
+    if not text:
+        _fail(f"{path} must not be empty")
+    return text
+
+
+def _expect_bool(value: Any, path: str) -> bool:
+    if not isinstance(value, bool):
+        _fail(f"{path} must be a boolean")
+    return cast(bool, value)
+
+
+def _expect_number(value: Any, path: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        _fail(f"{path} must be a number")
+    return float(value)
+
+
+def _expect_literal(value: Any, allowed: set[str], path: str) -> str:
+    if not isinstance(value, str) or value not in allowed:
+        _fail(f"{path} must be one of {', '.join(sorted(allowed))}")
+    return cast(str, value)
+
+
+def _expect_pattern(value: Any, pattern: re.Pattern[str], path: str) -> str:
+    text = _expect_str(value, path)
+    if not pattern.fullmatch(text):
+        _fail(f"{path} has invalid format")
+    return text
+
+
+def _expect_date_time(value: Any, path: str) -> str:
+    text = _expect_pattern(value, _DATE_TIME_RE, path)
+    try:
+        datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        _fail(f"{path} must be a valid date-time")
+    return text
+
+
+def _expect_str_list(value: Any, path: str, *, require_non_empty_items: bool = True) -> list[str]:
+    items = _expect_sequence(value, path)
+    strings: list[str] = []
+    for index, item in enumerate(items):
+        strings.append(
+            _expect_non_empty_str(item, f"{path}[{index}]") if require_non_empty_items else _expect_str(item, f"{path}[{index}]")
+        )
+    return strings
+
+
+def _expect_non_empty_str_list(value: Any, path: str) -> list[str]:
+    strings = _expect_str_list(value, path)
+    if not strings:
+        _fail(f"{path} must contain at least one item")
+    return strings
+
+
+def _require_keys(mapping: Mapping[str, Any], required: set[str], path: str) -> None:
+    missing = sorted(required - set(mapping))
+    if missing:
+        _fail(f"{path} missing required field(s): {', '.join(missing)}")
+
+
+def _reject_extra(mapping: Mapping[str, Any], allowed: set[str], path: str) -> None:
+    extra = sorted(set(mapping) - allowed)
+    if extra:
+        _fail(f"{path} has unexpected field(s): {', '.join(extra)}")
+
+
+def _fail(message: str) -> None:
+    raise InvalidHarnessChangeProposalError(message)

--- a/autocontext/src/autocontext/server/cockpit_api.py
+++ b/autocontext/src/autocontext/server/cockpit_api.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import logging
+from json import JSONDecodeError
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from autocontext.analytics.artifact_rendering import render_scenario_curation_html, scenario_curation_view_from_artifacts
 from autocontext.consultation.runner import ConsultationRunner
@@ -20,6 +21,7 @@ from autocontext.providers.registry import create_provider
 from autocontext.providers.retry import RetryProvider
 from autocontext.server.background_session_api import background_session_router
 from autocontext.server.changelog import build_changelog
+from autocontext.server.trace_gate_review_api import build_run_trace_gate_review
 from autocontext.server.writeup import generate_writeup, generate_writeup_html
 from autocontext.session.runtime_events import RuntimeSessionEventStore
 from autocontext.session.runtime_session_ids import runtime_session_id_for_run
@@ -98,8 +100,6 @@ def _runtime_session_discovery(
 
 def _runtime_session_not_found(message: str, session_id: str) -> HTTPException:
     return HTTPException(status_code=404, detail={"detail": message, "session_id": session_id})
-
-
 
 
 class NotebookUpdateBody(BaseModel):
@@ -226,7 +226,6 @@ def cockpit_delete_notebook(session_id: str, request: Request) -> dict[str, str]
     return {"status": "deleted", "session_id": session_id}
 
 
-
 # ---------------------------------------------------------------------------
 # Runtime-session endpoints (provider runtime observability)
 # ---------------------------------------------------------------------------
@@ -321,10 +320,23 @@ def get_run_runtime_session(run_id: str, request: Request) -> dict[str, Any]:
     finally:
         runtime_store.close()
 
-
 # ---------------------------------------------------------------------------
 # Run endpoints (read-only)
 # ---------------------------------------------------------------------------
+
+
+@cockpit_router.get("/runs/{run_id}/trace-gates")
+def get_run_trace_gate_review(run_id: str, request: Request) -> dict[str, Any]:
+    """Read trace findings, proposals, and gate decisions for operator review."""
+    settings = getattr(request.app.state, "app_settings", None)
+    if settings is None:
+        raise HTTPException(status_code=500, detail="Application settings are not configured")
+    try:
+        return build_run_trace_gate_review(runs_root=settings.runs_root, run_id=run_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except (OSError, JSONDecodeError, ValidationError) as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @cockpit_router.get("/runs")

--- a/autocontext/src/autocontext/server/cockpit_api.py
+++ b/autocontext/src/autocontext/server/cockpit_api.py
@@ -21,7 +21,7 @@ from autocontext.providers.registry import create_provider
 from autocontext.providers.retry import RetryProvider
 from autocontext.server.background_session_api import background_session_router
 from autocontext.server.changelog import build_changelog
-from autocontext.server.trace_gate_review_api import build_run_trace_gate_review
+from autocontext.server.trace_gate_review_api import InvalidHarnessChangeProposalError, build_run_trace_gate_review
 from autocontext.server.writeup import generate_writeup, generate_writeup_html
 from autocontext.session.runtime_events import RuntimeSessionEventStore
 from autocontext.session.runtime_session_ids import runtime_session_id_for_run
@@ -335,7 +335,7 @@ def get_run_trace_gate_review(run_id: str, request: Request) -> dict[str, Any]:
         return build_run_trace_gate_review(runs_root=settings.runs_root, run_id=run_id)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    except (OSError, JSONDecodeError, ValidationError) as exc:
+    except (OSError, JSONDecodeError, ValidationError, InvalidHarnessChangeProposalError) as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 

--- a/autocontext/src/autocontext/server/trace_gate_review_api.py
+++ b/autocontext/src/autocontext/server/trace_gate_review_api.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from autocontext.analytics.cross_runtime_trace_findings import CrossRuntimeTraceFindingReport
+from autocontext.analytics.trace_gate_operator_view import build_trace_gate_operator_view
+from autocontext.storage.run_paths import resolve_run_root
+
+
+def build_run_trace_gate_review(*, runs_root: Path, run_id: str) -> dict[str, Any]:
+    """Read the operator-facing trace-finding/proposal/gate view for a run."""
+    run_root = resolve_run_root(runs_root, run_id)
+    return build_trace_gate_operator_view(
+        run_id=run_id.strip(),
+        report=_load_latest_trace_finding_report(run_root),
+        proposals=_load_harness_change_proposals(run_root),
+    )
+
+
+def _load_latest_trace_finding_report(run_root: Path) -> CrossRuntimeTraceFindingReport | None:
+    candidates = [
+        *_json_files(run_root / "trace-findings"),
+        *_json_files(run_root / "trace_findings"),
+        run_root / "trace-finding-report.json",
+        run_root / "trace_finding_report.json",
+    ]
+    existing = [path for path in candidates if path.exists()]
+    if not existing:
+        return None
+    existing.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    payload = json.loads(existing[0].read_text(encoding="utf-8"))
+    return CrossRuntimeTraceFindingReport.model_validate(payload)
+
+
+def _load_harness_change_proposals(run_root: Path) -> list[dict[str, Any]]:
+    proposals: list[dict[str, Any]] = []
+    for path in [*_json_files(run_root / "harness-proposals"), *_json_files(run_root / "harness_proposals")]:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            proposals.append(payload)
+    return proposals
+
+
+def _json_files(directory: Path) -> list[Path]:
+    if not directory.exists():
+        return []
+    return sorted(path for path in directory.glob("*.json") if path.is_file())

--- a/autocontext/src/autocontext/server/trace_gate_review_api.py
+++ b/autocontext/src/autocontext/server/trace_gate_review_api.py
@@ -6,6 +6,10 @@ from typing import Any
 
 from autocontext.analytics.cross_runtime_trace_findings import CrossRuntimeTraceFindingReport
 from autocontext.analytics.trace_gate_operator_view import build_trace_gate_operator_view
+from autocontext.control_plane.harness_change_proposal import (
+    InvalidHarnessChangeProposalError,
+    validate_harness_change_proposal,
+)
 from autocontext.storage.run_paths import resolve_run_root
 
 
@@ -38,8 +42,12 @@ def _load_harness_change_proposals(run_root: Path) -> list[dict[str, Any]]:
     proposals: list[dict[str, Any]] = []
     for path in [*_json_files(run_root / "harness-proposals"), *_json_files(run_root / "harness_proposals")]:
         payload = json.loads(path.read_text(encoding="utf-8"))
-        if isinstance(payload, dict):
-            proposals.append(payload)
+        if not isinstance(payload, dict):
+            raise InvalidHarnessChangeProposalError(f"Invalid HarnessChangeProposal at {path}: expected object")
+        try:
+            proposals.append(validate_harness_change_proposal(payload))
+        except InvalidHarnessChangeProposalError as exc:
+            raise InvalidHarnessChangeProposalError(f"Invalid HarnessChangeProposal at {path}: {exc}") from exc
     return proposals
 
 

--- a/autocontext/tests/test_trace_gate_operator_view.py
+++ b/autocontext/tests/test_trace_gate_operator_view.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from autocontext.analytics.cross_runtime_trace_findings import CrossRuntimeTraceFindingReport  # type: ignore[import-untyped]
+from autocontext.analytics.trace_gate_operator_view import (  # type: ignore[import-untyped]
+    build_trace_gate_operator_view,
+    render_trace_gate_operator_view_lines,
+)
+
+_REPORT_DATA = {
+    "reportId": "report-run-123",
+    "traceId": "trace-run-123",
+    "sourceHarness": "autocontext",
+    "createdAt": "2026-06-01T12:00:00.000Z",
+    "summary": "2 finding(s) across 1 category.",
+    "metadata": {},
+    "findings": [
+        {
+            "findingId": "finding-tool-1",
+            "category": "tool_call_failure",
+            "severity": "high",
+            "title": "Patch tool failed twice",
+            "description": "patch hunk did not apply",
+            "evidenceMessageIndexes": [1, 3],
+        },
+        {
+            "findingId": "finding-score-1",
+            "category": "low_outcome_score",
+            "severity": "medium",
+            "title": "Outcome stayed below threshold",
+            "description": "score=0.32",
+            "evidenceMessageIndexes": [],
+        },
+    ],
+    "failureMotifs": [
+        {
+            "motifId": "motif-tool",
+            "category": "tool_call_failure",
+            "occurrenceCount": 2,
+            "evidenceMessageIndexes": [1, 3],
+            "description": "patch tool failures repeated",
+        },
+    ],
+}
+
+
+def _proposal(suffix: str, status: str, reason: str = "") -> dict[str, object]:
+    return {
+        "schemaVersion": "1.0",
+        "id": f"01HX0000000000000000000{suffix}",
+        "status": status,
+        "findingIds": ["finding-tool-1"],
+        "targetSurface": "verifier-rubric" if suffix == "683" else "prompt",
+        "proposedEdit": {
+            "summary": f"{status} proposal for trace finding",
+            "patches": [
+                {
+                    "filePath": "agents/grid_ctf/prompts/competitor.txt",
+                    "operation": "modify",
+                    "unifiedDiff": "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new\n",
+                }
+            ],
+        },
+        "expectedImpact": {"qualityDelta": 0.08, "riskReduction": "fewer repeat tool failures"},
+        "rollbackCriteria": ["heldout score regresses"],
+        "provenance": {
+            "authorType": "autocontext-run",
+            "authorId": "run-123",
+            "parentArtifactIds": [],
+            "createdAt": "2026-06-01T12:05:00.000Z",
+        },
+        **(
+            {}
+            if status == "proposed"
+            else {
+                "decision": {
+                    "status": status,
+                    "reason": reason,
+                    "validation": {
+                        "mode": "dev" if status == "inconclusive" else "heldout",
+                        "suiteId": "heldout-suite",
+                        "evidenceRefs": [] if status == "inconclusive" else [f"runs/run-123/{status}.json"],
+                    },
+                    "decidedAt": "2026-06-01T12:10:00.000Z",
+                }
+            }
+        ),
+    }
+
+
+def test_build_trace_gate_operator_view_surfaces_findings_proposals_and_gates() -> None:
+    report = CrossRuntimeTraceFindingReport.model_validate(_REPORT_DATA)
+    view = build_trace_gate_operator_view(
+        run_id="run-123",
+        report=report,
+        proposals=[
+            _proposal("681", "accepted", "Accepted on heldout validation."),
+            _proposal("682", "rejected", "Rejected on heldout validation."),
+            _proposal("683", "inconclusive", "Dev-only validation is not enough."),
+        ],
+    )
+
+    assert view["schema_version"] == "1"
+    assert view["run_id"] == "run-123"
+    assert view["state"] == "ready"
+    assert view["report"] == {
+        "report_id": "report-run-123",
+        "trace_id": "trace-run-123",
+        "source_harness": "autocontext",
+        "created_at": "2026-06-01T12:00:00.000Z",
+        "finding_count": 2,
+        "failure_mode_count": 1,
+    }
+    assert view["findings"][0]["linked_proposal_ids"] == [
+        "01HX0000000000000000000681",
+        "01HX0000000000000000000682",
+        "01HX0000000000000000000683",
+    ]
+    assert view["findings"][0]["evidence_refs"] == [
+        {"kind": "trace_message", "ref": "msg:1", "label": "msg #1", "href": "#msg-1"},
+        {"kind": "trace_message", "ref": "msg:3", "label": "msg #3", "href": "#msg-3"},
+    ]
+    assert [item["status"] for item in view["gate_decisions"]] == ["accepted", "rejected", "inconclusive"]
+    assert view["gate_decisions"][0]["evidence_refs"] == [
+        {
+            "kind": "artifact",
+            "ref": "runs/run-123/accepted.json",
+            "label": "accepted.json",
+            "href": "runs/run-123/accepted.json",
+        }
+    ]
+
+
+def test_render_trace_gate_operator_view_lines_is_tui_safe() -> None:
+    view = build_trace_gate_operator_view(
+        run_id="run-123",
+        report=CrossRuntimeTraceFindingReport.model_validate(_REPORT_DATA),
+        proposals=[_proposal("681", "accepted", "Accepted on heldout validation.")],
+    )
+
+    assert render_trace_gate_operator_view_lines(view) == [
+        "Trace gates for run-123 — ready",
+        "2 finding(s) across 1 category.",
+        "Findings:",
+        "- [high/tool_call_failure] Patch tool failed twice evidence=msg #1, msg #3 proposals=01HX0000000000000000000681",
+        "- [medium/low_outcome_score] Outcome stayed below threshold evidence=none proposals=none",
+        "Recurring failure modes:",
+        "- tool_call_failure x2 evidence=msg #1, msg #3",
+        "Proposals:",
+        "- 01HX0000000000000000000681 accepted target=prompt patches=1 — accepted proposal for trace finding",
+        "Gate decisions:",
+        "- 01HX0000000000000000000681 accepted heldout — Accepted on heldout validation.",
+    ]
+
+
+def test_trace_gate_operator_view_handles_missing_incomplete_and_no_findings() -> None:
+    assert build_trace_gate_operator_view(run_id="run-123", report=None)["state"] == "missing_report"
+    assert (
+        build_trace_gate_operator_view(run_id="run-123", report=None, analysis_state="incomplete")["state"]
+        == "incomplete_analysis"
+    )
+    no_findings = CrossRuntimeTraceFindingReport.model_validate(
+        {**_REPORT_DATA, "findings": [], "failureMotifs": [], "summary": "No notable findings."}
+    )
+    assert build_trace_gate_operator_view(run_id="run-123", report=no_findings, proposals=[])["state"] == "no_findings"

--- a/autocontext/tests/test_trace_gate_operator_view.py
+++ b/autocontext/tests/test_trace_gate_operator_view.py
@@ -80,6 +80,42 @@ def _proposal(suffix: str, status: str, reason: str = "") -> dict[str, object]:
                         "suiteId": "heldout-suite",
                         "evidenceRefs": [] if status == "inconclusive" else [f"runs/run-123/{status}.json"],
                     },
+                    "promotionDecision": {
+                        "schemaVersion": "1.0",
+                        "pass": status == "accepted",
+                        "recommendedTargetState": "canary" if status == "accepted" else "disabled",
+                        "deltas": {
+                            "quality": {"baseline": 0.6, "candidate": 0.72, "delta": 0.12, "passed": True},
+                            "cost": {
+                                "baseline": {"tokensIn": 100, "tokensOut": 50},
+                                "candidate": {"tokensIn": 110, "tokensOut": 55},
+                                "delta": {"tokensIn": 10, "tokensOut": 5},
+                                "passed": True,
+                            },
+                            "latency": {
+                                "baseline": {"p50Ms": 10, "p95Ms": 20, "p99Ms": 30},
+                                "candidate": {"p50Ms": 11, "p95Ms": 21, "p99Ms": 31},
+                                "delta": {"p50Ms": 1, "p95Ms": 1, "p99Ms": 1},
+                                "passed": True,
+                            },
+                            "safety": {"regressions": [], "passed": True},
+                        },
+                        "confidence": 0.9,
+                        "thresholds": {
+                            "qualityMinDelta": 0.05,
+                            "costMaxRelativeIncrease": 0.2,
+                            "latencyMaxRelativeIncrease": 0.2,
+                            "strongConfidenceMin": 0.9,
+                            "moderateConfidenceMin": 0.7,
+                            "strongQualityMultiplier": 2,
+                        },
+                        "reasoning": reason,
+                        "evaluatedAt": "2026-06-01T12:10:00.000Z",
+                    },
+                    "candidateArtifactId": "01HX0000000000000000000001",
+                    "candidateEvalRunId": f"candidate-{status}",
+                    "baselineArtifactId": "01HX0000000000000000000002",
+                    "baselineEvalRunId": f"baseline-{status}",
                     "decidedAt": "2026-06-01T12:10:00.000Z",
                 }
             }

--- a/autocontext/tests/test_trace_gate_review_api.py
+++ b/autocontext/tests/test_trace_gate_review_api.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from autocontext.server.cockpit_api import cockpit_router  # type: ignore[import-untyped]
+from autocontext.storage.sqlite_store import SQLiteStore  # type: ignore[import-untyped]
+
+
+def _build_cockpit_env(tmp_path: Path) -> dict[str, Any]:
+    from autocontext.config.settings import AppSettings  # type: ignore[import-untyped]
+
+    db_path = tmp_path / "autocontext.db"
+    store = SQLiteStore(db_path)
+    store.migrate(Path(__file__).resolve().parents[1] / "migrations")
+    settings = AppSettings(
+        db_path=db_path,
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+    )
+    settings.runs_root.mkdir(parents=True, exist_ok=True)
+    settings.knowledge_root.mkdir(parents=True, exist_ok=True)
+
+    app = FastAPI()
+    app.state.store = store
+    app.state.app_settings = settings
+    app.include_router(cockpit_router)
+    return {"client": TestClient(app), "settings": settings, "store": store}
+
+
+def _write_report(settings: Any, run_id: str) -> None:
+    report_dir = settings.runs_root / run_id / "trace-findings"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "reportId": "report-run-123",
+                "traceId": "trace-run-123",
+                "sourceHarness": "autocontext",
+                "createdAt": "2026-06-01T12:00:00.000Z",
+                "summary": "1 finding(s) across 1 category.",
+                "metadata": {},
+                "findings": [
+                    {
+                        "findingId": "finding-tool-1",
+                        "category": "tool_call_failure",
+                        "severity": "high",
+                        "title": "Patch tool failed twice",
+                        "description": "patch hunk did not apply",
+                        "evidenceMessageIndexes": [1, 3],
+                    }
+                ],
+                "failureMotifs": [
+                    {
+                        "motifId": "motif-tool",
+                        "category": "tool_call_failure",
+                        "occurrenceCount": 2,
+                        "evidenceMessageIndexes": [1, 3],
+                        "description": "patch tool failures repeated",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_proposal(settings: Any, run_id: str) -> None:
+    proposal_dir = settings.runs_root / run_id / "harness-proposals"
+    proposal_dir.mkdir(parents=True, exist_ok=True)
+    (proposal_dir / "01HX0000000000000000000683.json").write_text(
+        json.dumps(
+            {
+                "id": "01HX0000000000000000000683",
+                "status": "accepted",
+                "findingIds": ["finding-tool-1"],
+                "targetSurface": "prompt",
+                "proposedEdit": {
+                    "summary": "accepted proposal for trace finding",
+                    "patches": [{"filePath": "prompt.txt", "operation": "modify", "unifiedDiff": "--- a\n+++ b\n"}],
+                },
+                "rollbackCriteria": ["heldout score regresses"],
+                "decision": {
+                    "status": "accepted",
+                    "reason": "Accepted on heldout validation.",
+                    "validation": {
+                        "mode": "heldout",
+                        "suiteId": "heldout-suite",
+                        "evidenceRefs": ["runs/run-123/accepted.json"],
+                    },
+                    "decidedAt": "2026-06-01T12:10:00.000Z",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_cockpit_trace_gate_review_reads_report_and_gate_decisions(tmp_path: Path) -> None:
+    cockpit_env = _build_cockpit_env(tmp_path)
+    _write_report(cockpit_env["settings"], "run-123")
+    _write_proposal(cockpit_env["settings"], "run-123")
+
+    response = cockpit_env["client"].get("/api/cockpit/runs/run-123/trace-gates")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "ready"
+    assert body["findings"][0]["linked_proposal_ids"] == ["01HX0000000000000000000683"]
+    assert body["gate_decisions"][0]["status"] == "accepted"
+    assert body["gate_decisions"][0]["evidence_refs"] == [
+        {
+            "kind": "artifact",
+            "ref": "runs/run-123/accepted.json",
+            "label": "accepted.json",
+            "href": "runs/run-123/accepted.json",
+        }
+    ]
+
+
+def test_cockpit_trace_gate_review_handles_missing_and_invalid_run_ids(tmp_path: Path) -> None:
+    cockpit_env = _build_cockpit_env(tmp_path)
+    missing = cockpit_env["client"].get("/api/cockpit/runs/run-404/trace-gates")
+    assert missing.status_code == 200
+    assert missing.json()["state"] == "missing_report"
+
+    invalid = cockpit_env["client"].get("/api/cockpit/runs/%20/trace-gates")
+    assert invalid.status_code == 422
+    assert "run_id is required" in invalid.json()["detail"]

--- a/autocontext/tests/test_trace_gate_review_api.py
+++ b/autocontext/tests/test_trace_gate_review_api.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -69,33 +71,79 @@ def _write_report(settings: Any, run_id: str) -> None:
     )
 
 
-def _write_proposal(settings: Any, run_id: str) -> None:
+def _valid_proposal_payload() -> dict[str, Any]:
+    return {
+        "schemaVersion": "1.0",
+        "id": "01HX0000000000000000000683",
+        "status": "accepted",
+        "findingIds": ["finding-tool-1"],
+        "targetSurface": "prompt",
+        "proposedEdit": {
+            "summary": "accepted proposal for trace finding",
+            "patches": [{"filePath": "prompt.txt", "operation": "modify", "unifiedDiff": "--- a\n+++ b\n"}],
+        },
+        "expectedImpact": {"qualityDelta": 0.08, "riskReduction": "fewer repeat tool failures"},
+        "rollbackCriteria": ["heldout score regresses"],
+        "provenance": {
+            "authorType": "autocontext-run",
+            "authorId": "run-123",
+            "parentArtifactIds": [],
+            "createdAt": "2026-06-01T12:05:00.000Z",
+        },
+        "decision": {
+            "status": "accepted",
+            "reason": "Accepted on heldout validation.",
+            "validation": {
+                "mode": "heldout",
+                "suiteId": "heldout-suite",
+                "evidenceRefs": ["runs/run-123/accepted.json"],
+            },
+            "promotionDecision": {
+                "schemaVersion": "1.0",
+                "pass": True,
+                "recommendedTargetState": "canary",
+                "deltas": {
+                    "quality": {"baseline": 0.6, "candidate": 0.72, "delta": 0.12, "passed": True},
+                    "cost": {
+                        "baseline": {"tokensIn": 100, "tokensOut": 50},
+                        "candidate": {"tokensIn": 110, "tokensOut": 55},
+                        "delta": {"tokensIn": 10, "tokensOut": 5},
+                        "passed": True,
+                    },
+                    "latency": {
+                        "baseline": {"p50Ms": 10, "p95Ms": 20, "p99Ms": 30},
+                        "candidate": {"p50Ms": 11, "p95Ms": 21, "p99Ms": 31},
+                        "delta": {"p50Ms": 1, "p95Ms": 1, "p99Ms": 1},
+                        "passed": True,
+                    },
+                    "safety": {"regressions": [], "passed": True},
+                },
+                "confidence": 0.9,
+                "thresholds": {
+                    "qualityMinDelta": 0.05,
+                    "costMaxRelativeIncrease": 0.2,
+                    "latencyMaxRelativeIncrease": 0.2,
+                    "strongConfidenceMin": 0.9,
+                    "moderateConfidenceMin": 0.7,
+                    "strongQualityMultiplier": 2,
+                },
+                "reasoning": "Accepted on heldout validation.",
+                "evaluatedAt": "2026-06-01T12:10:00.000Z",
+            },
+            "candidateArtifactId": "01HX0000000000000000000001",
+            "candidateEvalRunId": "candidate-accepted",
+            "baselineArtifactId": "01HX0000000000000000000002",
+            "baselineEvalRunId": "baseline-accepted",
+            "decidedAt": "2026-06-01T12:10:00.000Z",
+        },
+    }
+
+
+def _write_proposal(settings: Any, run_id: str, payload: dict[str, Any] | None = None) -> None:
     proposal_dir = settings.runs_root / run_id / "harness-proposals"
     proposal_dir.mkdir(parents=True, exist_ok=True)
     (proposal_dir / "01HX0000000000000000000683.json").write_text(
-        json.dumps(
-            {
-                "id": "01HX0000000000000000000683",
-                "status": "accepted",
-                "findingIds": ["finding-tool-1"],
-                "targetSurface": "prompt",
-                "proposedEdit": {
-                    "summary": "accepted proposal for trace finding",
-                    "patches": [{"filePath": "prompt.txt", "operation": "modify", "unifiedDiff": "--- a\n+++ b\n"}],
-                },
-                "rollbackCriteria": ["heldout score regresses"],
-                "decision": {
-                    "status": "accepted",
-                    "reason": "Accepted on heldout validation.",
-                    "validation": {
-                        "mode": "heldout",
-                        "suiteId": "heldout-suite",
-                        "evidenceRefs": ["runs/run-123/accepted.json"],
-                    },
-                    "decidedAt": "2026-06-01T12:10:00.000Z",
-                },
-            }
-        ),
+        json.dumps(payload or _valid_proposal_payload()),
         encoding="utf-8",
     )
 
@@ -120,6 +168,49 @@ def test_cockpit_trace_gate_review_reads_report_and_gate_decisions(tmp_path: Pat
             "href": "runs/run-123/accepted.json",
         }
     ]
+
+
+def test_cockpit_trace_gate_review_rejects_invalid_proposal_json(tmp_path: Path) -> None:
+    cockpit_env = _build_cockpit_env(tmp_path)
+    _write_report(cockpit_env["settings"], "run-123")
+    invalid_payload = _valid_proposal_payload()
+    del invalid_payload["decision"]["promotionDecision"]
+    _write_proposal(cockpit_env["settings"], "run-123", invalid_payload)
+
+    response = cockpit_env["client"].get("/api/cockpit/runs/run-123/trace-gates")
+
+    assert response.status_code == 500
+    assert "Invalid HarnessChangeProposal" in response.json()["detail"]
+    assert "promotionDecision" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    ("field_path", "expected_detail"),
+    [
+        (("provenance", "createdAt"), "provenance.createdAt"),
+        (("decision", "decidedAt"), "decision.decidedAt"),
+        (("decision", "promotionDecision", "evaluatedAt"), "decision.promotionDecision.evaluatedAt"),
+    ],
+)
+def test_cockpit_trace_gate_review_rejects_non_schema_timestamps(
+    tmp_path: Path,
+    field_path: tuple[str, ...],
+    expected_detail: str,
+) -> None:
+    cockpit_env = _build_cockpit_env(tmp_path)
+    _write_report(cockpit_env["settings"], "run-123")
+    invalid_payload = deepcopy(_valid_proposal_payload())
+    target: dict[str, Any] = invalid_payload
+    for key in field_path[:-1]:
+        target = target[key]
+    target[field_path[-1]] = "not-a-date"
+    _write_proposal(cockpit_env["settings"], "run-123", invalid_payload)
+
+    response = cockpit_env["client"].get("/api/cockpit/runs/run-123/trace-gates")
+
+    assert response.status_code == 500
+    assert "Invalid HarnessChangeProposal" in response.json()["detail"]
+    assert expected_detail in response.json()["detail"]
 
 
 def test_cockpit_trace_gate_review_handles_missing_and_invalid_run_ids(tmp_path: Path) -> None:

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -72,6 +72,12 @@ autoctx trace-findings --help                        # Usage
 `PublicTraceSchema`. Loading by stored trace id (`--trace-id <id>` against
 the ProductionTrace store) is a follow-up slice.
 
+### Operator trace-gate review (AC-683)
+
+Cockpit and the terminal UI consume the same trace-finding report and harness-change proposal contracts instead of a TUI-only shape. The read model is available at `GET /api/cockpit/runs/:run_id/trace-gates` in both runtimes and in the TUI via `/findings <run-id>` or `/trace-gates <run-id>`.
+
+The view surfaces findings with trace-message evidence refs, recurring failure modes with occurrence counts, proposed harness/context changes with target surfaces, gate decisions (`accepted`, `rejected`, `inconclusive`) with reasons, evidence artifact refs, and graceful `missing_report`, `incomplete_analysis`, and `no_findings` states.
+
 ## Repository Traffic
 
 For GitHub-hosted repo traffic, use the repository Traffic view:

--- a/ts/src/analytics/trace-gate-operator-view.ts
+++ b/ts/src/analytics/trace-gate-operator-view.ts
@@ -1,0 +1,303 @@
+import {
+  TraceFindingReportSchema,
+  type FailureMotif,
+  type TraceFinding,
+  type TraceFindingReport,
+} from "./trace-findings.js";
+import type { HarnessChangeProposal } from "../control-plane/contract/types.js";
+
+export type TraceGateOperatorState =
+  | "missing_report"
+  | "incomplete_analysis"
+  | "no_findings"
+  | "ready";
+export type TraceGateAnalysisState = "complete" | "incomplete";
+export type TraceEvidenceLinkKind = "trace_message" | "artifact";
+
+export interface TraceEvidenceLink {
+  readonly kind: TraceEvidenceLinkKind;
+  readonly ref: string;
+  readonly label: string;
+  readonly href: string;
+}
+
+export interface TraceGateReportSummary {
+  readonly report_id: string;
+  readonly trace_id: string;
+  readonly source_harness: string;
+  readonly created_at: string;
+  readonly finding_count: number;
+  readonly failure_mode_count: number;
+}
+
+export interface TraceGateFindingView {
+  readonly finding_id: string;
+  readonly category: string;
+  readonly severity: string;
+  readonly title: string;
+  readonly description: string;
+  readonly evidence_count: number;
+  readonly evidence_refs: readonly TraceEvidenceLink[];
+  readonly linked_proposal_ids: readonly string[];
+}
+
+export interface TraceGateFailureModeView {
+  readonly motif_id: string;
+  readonly category: string;
+  readonly occurrence_count: number;
+  readonly description: string;
+  readonly representative_evidence_refs: readonly TraceEvidenceLink[];
+}
+
+export interface TraceGateProposalView {
+  readonly proposal_id: string;
+  readonly status: string;
+  readonly target_surface: string;
+  readonly summary: string;
+  readonly finding_ids: readonly string[];
+  readonly patch_count: number;
+  readonly rollback_criteria: readonly string[];
+  readonly gate_status: string;
+  readonly gate_reason: string;
+}
+
+export interface TraceGateDecisionView {
+  readonly proposal_id: string;
+  readonly status: string;
+  readonly reason: string;
+  readonly validation_mode: string;
+  readonly suite_id: string;
+  readonly decided_at: string;
+  readonly evidence_refs: readonly TraceEvidenceLink[];
+}
+
+export interface TraceGateOperatorView {
+  readonly schema_version: "1";
+  readonly run_id: string;
+  readonly state: TraceGateOperatorState;
+  readonly summary: string;
+  readonly report: TraceGateReportSummary | null;
+  readonly findings: readonly TraceGateFindingView[];
+  readonly failure_modes: readonly TraceGateFailureModeView[];
+  readonly proposals: readonly TraceGateProposalView[];
+  readonly gate_decisions: readonly TraceGateDecisionView[];
+}
+
+export interface BuildTraceGateOperatorViewInput {
+  readonly run_id: string;
+  readonly report?: TraceFindingReport | null;
+  readonly proposals?: readonly HarnessChangeProposal[];
+  readonly analysis_state?: TraceGateAnalysisState;
+}
+
+export function buildTraceGateOperatorView(
+  input: BuildTraceGateOperatorViewInput,
+): TraceGateOperatorView {
+  const proposals = input.proposals ?? [];
+  const report = input.report ? TraceFindingReportSchema.parse(input.report) : null;
+  const state = resolveState(report, proposals, input.analysis_state ?? "complete");
+  const linkedProposalIds = proposalIdsByFinding(proposals);
+  return {
+    schema_version: "1",
+    run_id: input.run_id,
+    state,
+    summary: summaryForState(state, report),
+    report: report ? summarizeReport(report) : null,
+    findings: report?.findings.map((finding) => findingView(finding, linkedProposalIds)) ?? [],
+    failure_modes: report?.failureMotifs.map(failureModeView) ?? [],
+    proposals: proposals.map(proposalView),
+    gate_decisions: proposals.flatMap((proposal) => decisionView(proposal)),
+  };
+}
+
+export function renderTraceGateOperatorViewLines(view: TraceGateOperatorView): string[] {
+  const lines = [`Trace gates for ${view.run_id} — ${view.state}`, view.summary];
+  lines.push("Findings:");
+  if (view.findings.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const finding of view.findings) {
+      lines.push(
+        `- [${finding.severity}/${finding.category}] ${finding.title} evidence=${formatEvidenceLabels(finding.evidence_refs)} proposals=${formatList(finding.linked_proposal_ids)}`,
+      );
+    }
+  }
+
+  lines.push("Recurring failure modes:");
+  if (view.failure_modes.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const mode of view.failure_modes) {
+      lines.push(
+        `- ${mode.category} x${mode.occurrence_count} evidence=${formatEvidenceLabels(mode.representative_evidence_refs)}`,
+      );
+    }
+  }
+
+  lines.push("Proposals:");
+  if (view.proposals.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const proposal of view.proposals) {
+      lines.push(
+        `- ${proposal.proposal_id} ${proposal.status} target=${proposal.target_surface} patches=${proposal.patch_count} — ${proposal.summary}`,
+      );
+    }
+  }
+
+  lines.push("Gate decisions:");
+  if (view.gate_decisions.length === 0) {
+    lines.push("- none");
+  } else {
+    for (const decision of view.gate_decisions) {
+      lines.push(
+        `- ${decision.proposal_id} ${decision.status} ${decision.validation_mode || "unknown"} — ${decision.reason}`,
+      );
+    }
+  }
+  return lines;
+}
+
+function resolveState(
+  report: TraceFindingReport | null,
+  proposals: readonly HarnessChangeProposal[],
+  analysisState: TraceGateAnalysisState,
+): TraceGateOperatorState {
+  if (analysisState === "incomplete") {
+    return "incomplete_analysis";
+  }
+  if (!report) {
+    return "missing_report";
+  }
+  if (report.findings.length === 0 && proposals.length === 0) {
+    return "no_findings";
+  }
+  return "ready";
+}
+
+function summaryForState(state: TraceGateOperatorState, report: TraceFindingReport | null): string {
+  switch (state) {
+    case "incomplete_analysis":
+      return "Trace analysis is still running; findings and gate decisions may be incomplete.";
+    case "missing_report":
+      return "No trace finding report is available for this run yet.";
+    case "no_findings":
+      return report?.summary ?? "No findings or proposals are available for this run.";
+    case "ready":
+      return report?.summary ?? "Trace findings and gate decisions are ready.";
+  }
+}
+
+function summarizeReport(report: TraceFindingReport): TraceGateReportSummary {
+  return {
+    report_id: report.reportId,
+    trace_id: report.traceId,
+    source_harness: report.sourceHarness,
+    created_at: report.createdAt,
+    finding_count: report.findings.length,
+    failure_mode_count: report.failureMotifs.length,
+  };
+}
+
+function findingView(
+  finding: TraceFinding,
+  linkedProposalIds: ReadonlyMap<string, readonly string[]>,
+): TraceGateFindingView {
+  const evidenceRefs = finding.evidenceMessageIndexes.map(traceMessageEvidenceLink);
+  return {
+    finding_id: finding.findingId,
+    category: finding.category,
+    severity: finding.severity,
+    title: finding.title,
+    description: finding.description,
+    evidence_count: evidenceRefs.length,
+    evidence_refs: evidenceRefs,
+    linked_proposal_ids: linkedProposalIds.get(finding.findingId) ?? [],
+  };
+}
+
+function failureModeView(motif: FailureMotif): TraceGateFailureModeView {
+  return {
+    motif_id: motif.motifId,
+    category: motif.category,
+    occurrence_count: motif.occurrenceCount,
+    description: motif.description,
+    representative_evidence_refs: motif.evidenceMessageIndexes.map(traceMessageEvidenceLink),
+  };
+}
+
+function proposalView(proposal: HarnessChangeProposal): TraceGateProposalView {
+  return {
+    proposal_id: proposal.id,
+    status: proposal.status,
+    target_surface: proposal.targetSurface,
+    summary: proposal.proposedEdit.summary,
+    finding_ids: proposal.findingIds,
+    patch_count: proposal.proposedEdit.patches.length,
+    rollback_criteria: proposal.rollbackCriteria,
+    gate_status: proposal.decision?.status ?? "",
+    gate_reason: proposal.decision?.reason ?? "",
+  };
+}
+
+function decisionView(proposal: HarnessChangeProposal): TraceGateDecisionView[] {
+  if (!proposal.decision) {
+    return [];
+  }
+  return [
+    {
+      proposal_id: proposal.id,
+      status: proposal.decision.status,
+      reason: proposal.decision.reason,
+      validation_mode: proposal.decision.validation.mode,
+      suite_id: proposal.decision.validation.suiteId,
+      decided_at: proposal.decision.decidedAt,
+      evidence_refs: proposal.decision.validation.evidenceRefs.map(artifactEvidenceLink),
+    },
+  ];
+}
+
+function proposalIdsByFinding(
+  proposals: readonly HarnessChangeProposal[],
+): ReadonlyMap<string, readonly string[]> {
+  const ids = new Map<string, string[]>();
+  for (const proposal of proposals) {
+    for (const findingId of proposal.findingIds) {
+      const existing = ids.get(findingId) ?? [];
+      existing.push(proposal.id);
+      ids.set(findingId, existing);
+    }
+  }
+  return ids;
+}
+
+function traceMessageEvidenceLink(index: number): TraceEvidenceLink {
+  return {
+    kind: "trace_message",
+    ref: `msg:${index}`,
+    label: `msg #${index}`,
+    href: `#msg-${index}`,
+  };
+}
+
+function artifactEvidenceLink(ref: string): TraceEvidenceLink {
+  return {
+    kind: "artifact",
+    ref,
+    label: artifactLabel(ref),
+    href: ref,
+  };
+}
+
+function artifactLabel(ref: string): string {
+  const parts = ref.split(/[\\/]/).filter(Boolean);
+  return parts.at(-1) ?? ref;
+}
+
+function formatEvidenceLabels(refs: readonly TraceEvidenceLink[]): string {
+  return refs.length === 0 ? "none" : refs.map((ref) => ref.label).join(", ");
+}
+
+function formatList(items: readonly string[]): string {
+  return items.length === 0 ? "none" : items.join(", ");
+}

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -623,6 +623,23 @@ export type { TraceEventInit } from "./analytics/run-trace.js";
 export { runtimeSessionLogToRunTrace } from "./analytics/runtime-session-run-trace.js";
 export type { RuntimeSessionRunTraceOpts } from "./analytics/runtime-session-run-trace.js";
 export {
+  buildTraceGateOperatorView,
+  renderTraceGateOperatorViewLines,
+} from "./analytics/trace-gate-operator-view.js";
+export type {
+  BuildTraceGateOperatorViewInput,
+  TraceEvidenceLink,
+  TraceEvidenceLinkKind,
+  TraceGateAnalysisState,
+  TraceGateDecisionView,
+  TraceGateFailureModeView,
+  TraceGateFindingView,
+  TraceGateOperatorState,
+  TraceGateOperatorView,
+  TraceGateProposalView,
+  TraceGateReportSummary,
+} from "./analytics/trace-gate-operator-view.js";
+export {
   TRACE_FINDING_CATEGORIES,
   TraceFindingCategorySchema,
   TraceFindingSchema,

--- a/ts/src/server/http-api-parity.ts
+++ b/ts/src/server/http-api-parity.ts
@@ -51,25 +51,6 @@ function both(
   };
 }
 
-function pythonOnly(
-  domain: string,
-  method: HttpApiMethod,
-  path: string,
-  source: string,
-  notes: string,
-): HttpApiParityEntry {
-  return {
-    domain,
-    method,
-    path,
-    python: { support: "supported", source },
-    typescript: { support: "unsupported" },
-    status: "typescript_gap",
-    issue: "AC-627",
-    notes,
-  };
-}
-
 function typescriptOnly(
   domain: string,
   method: HttpApiMethod,
@@ -311,6 +292,7 @@ export const HTTP_API_PARITY_ROUTES: readonly HttpApiParityEntry[] = [
   both("cockpit", "GET", "/api/cockpit/runs/:run_id/status", PY_COCKPIT_API),
   both("cockpit", "GET", "/api/cockpit/runs/:run_id/changelog", PY_COCKPIT_API),
   both("cockpit", "GET", "/api/cockpit/runs/:run_id/context-selection", PY_COCKPIT_API),
+  both("cockpit", "GET", "/api/cockpit/runs/:run_id/trace-gates", PY_COCKPIT_API),
   both("cockpit", "GET", "/api/cockpit/runs/:run_id/compare/:gen_a/:gen_b", PY_COCKPIT_API),
   both("cockpit", "GET", "/api/cockpit/runs/:run_id/resume", PY_COCKPIT_API),
   both("cockpit", "GET", "/api/cockpit/writeup/:run_id", PY_COCKPIT_API),
@@ -382,22 +364,6 @@ export const HTTP_API_PARITY_ROUTES: readonly HttpApiParityEntry[] = [
   ),
   both("openclaw", "GET", "/api/openclaw/skill/manifest", PY_OPENCLAW_API),
 ];
-
-function pythonOnlyRoutes(
-  domain: string,
-  source: string,
-  routes: Array<[HttpApiMethod, string]>,
-): HttpApiParityEntry[] {
-  return routes.map(([method, path]) =>
-    pythonOnly(
-      domain,
-      method,
-      path,
-      source,
-      `${domain} HTTP routes are mounted by the Python FastAPI app and are not yet ported to TypeScript.`,
-    ),
-  );
-}
 
 export function buildHttpApiParityMatrix(): HttpApiParityMatrix {
   const summary: Record<HttpApiParityStatus, number> = {

--- a/ts/src/server/trace-gate-review-api.ts
+++ b/ts/src/server/trace-gate-review-api.ts
@@ -1,0 +1,129 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import {
+  buildTraceGateOperatorView,
+  type TraceGateOperatorView,
+} from "../analytics/trace-gate-operator-view.js";
+import { TraceFindingReportSchema, type TraceFindingReport } from "../analytics/trace-findings.js";
+import type { HarnessChangeProposal } from "../control-plane/contract/types.js";
+import { validateHarnessChangeProposal } from "../control-plane/contract/validators.js";
+import type { CockpitApiResponse } from "./cockpit-api.js";
+
+export interface TraceGateReviewApiRoutes {
+  getByRunId(runId: string): CockpitApiResponse;
+}
+
+export interface BuildTraceGateReviewApiRoutesOptions {
+  runsRoot: string;
+  loadReport?: (runId: string) => TraceFindingReport | null;
+  loadProposals?: (runId: string) => readonly HarnessChangeProposal[];
+}
+
+export function buildTraceGateReviewApiRoutes(
+  opts: BuildTraceGateReviewApiRoutesOptions,
+): TraceGateReviewApiRoutes {
+  return {
+    getByRunId(runId) {
+      let cleanRunId: string;
+      try {
+        cleanRunId = validateRunId(opts.runsRoot, runId);
+      } catch (error) {
+        return { status: 422, body: { detail: errorMessage(error) } };
+      }
+
+      try {
+        const view = buildTraceGateOperatorView({
+          run_id: cleanRunId,
+          report: opts.loadReport
+            ? opts.loadReport(cleanRunId)
+            : loadLatestTraceFindingReport(opts.runsRoot, cleanRunId),
+          proposals: opts.loadProposals
+            ? opts.loadProposals(cleanRunId)
+            : loadHarnessChangeProposals(opts.runsRoot, cleanRunId),
+        });
+        return { status: 200, body: view };
+      } catch (error) {
+        return { status: 500, body: { detail: errorMessage(error) } };
+      }
+    },
+  };
+}
+
+export function loadLatestTraceFindingReport(
+  runsRoot: string,
+  runId: string,
+): TraceFindingReport | null {
+  const runRoot = resolveRunRoot(runsRoot, runId);
+  const candidates = [
+    ...reportFilesInDir(join(runRoot, "trace-findings")),
+    ...reportFilesInDir(join(runRoot, "trace_findings")),
+    join(runRoot, "trace-finding-report.json"),
+    join(runRoot, "trace_finding_report.json"),
+  ]
+    .filter((path) => existsSync(path))
+    .sort((left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs);
+  const first = candidates[0];
+  return first ? TraceFindingReportSchema.parse(readJson(first)) : null;
+}
+
+export function loadHarnessChangeProposals(
+  runsRoot: string,
+  runId: string,
+): HarnessChangeProposal[] {
+  const runRoot = resolveRunRoot(runsRoot, runId);
+  return [join(runRoot, "harness-proposals"), join(runRoot, "harness_proposals")]
+    .flatMap(jsonFilesInDir)
+    .map((path) => readHarnessChangeProposal(path));
+}
+
+function validateRunId(runsRoot: string, runId: string): string {
+  const cleanRunId = runId.trim();
+  resolveRunRoot(runsRoot, cleanRunId);
+  return cleanRunId;
+}
+
+function resolveRunRoot(runsRoot: string, runId: string): string {
+  const cleanRunId = runId.trim();
+  if (!cleanRunId) {
+    throw new Error("run_id is required");
+  }
+  const root = resolve(runsRoot);
+  const candidate = resolve(root, cleanRunId);
+  if (candidate === root || !candidate.startsWith(`${root}/`)) {
+    throw new Error(`run_id escapes runs root: '${runId}'`);
+  }
+  return candidate;
+}
+
+function readHarnessChangeProposal(path: string): HarnessChangeProposal {
+  const payload = readJson(path);
+  const validation = validateHarnessChangeProposal(payload);
+  if (!validation.valid) {
+    throw new Error(`Invalid HarnessChangeProposal at ${path}: ${validation.errors.join("; ")}`);
+  }
+  return payload as HarnessChangeProposal;
+}
+
+function reportFilesInDir(dir: string): string[] {
+  return jsonFilesInDir(dir).filter((path) => !path.endsWith(".tmp"));
+}
+
+function jsonFilesInDir(dir: string): string[] {
+  if (!existsSync(dir)) {
+    return [];
+  }
+  return readdirSync(dir)
+    .filter((entry) => entry.endsWith(".json"))
+    .map((entry) => join(dir, entry));
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export type { TraceGateOperatorView };

--- a/ts/src/server/trace-gate-review-api.ts
+++ b/ts/src/server/trace-gate-review-api.ts
@@ -1,5 +1,5 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
 import {
   buildTraceGateOperatorView,
@@ -90,10 +90,23 @@ function resolveRunRoot(runsRoot: string, runId: string): string {
   }
   const root = resolve(runsRoot);
   const candidate = resolve(root, cleanRunId);
-  if (candidate === root || !candidate.startsWith(`${root}/`)) {
+  if (!isContainedSubpath(root, candidate)) {
     throw new Error(`run_id escapes runs root: '${runId}'`);
   }
+  if (existsSync(root) && existsSync(candidate)) {
+    const realRoot = realpathSync(root);
+    const realCandidate = realpathSync(candidate);
+    if (!isContainedSubpath(realRoot, realCandidate)) {
+      throw new Error(`run_id escapes runs root: '${runId}'`);
+    }
+    return realCandidate;
+  }
   return candidate;
+}
+
+function isContainedSubpath(root: string, candidate: string): boolean {
+  const relativePath = relative(root, candidate);
+  return relativePath !== "" && !relativePath.startsWith("..") && !isAbsolute(relativePath);
 }
 
 function readHarnessChangeProposal(path: string): HarnessChangeProposal {

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -47,6 +47,7 @@ import { buildOpenClawApiRoutes } from "./openclaw-api.js";
 import { buildBackgroundSessionApiRoutes } from "./background-session-api.js";
 import { buildRuntimeSessionApiRoutes } from "./runtime-session-api.js";
 import { buildSimulationApiRoutes } from "./simulation-api.js";
+import { buildTraceGateReviewApiRoutes } from "./trace-gate-review-api.js";
 import { renderDashboardHtml } from "./simulation-dashboard.js";
 import { buildSessionBootstrapMessages, buildStateMessage } from "./websocket-session-bootstrap.js";
 import { parseClientMessage } from "./protocol.js";
@@ -220,6 +221,9 @@ export class InteractiveServer {
     const runtimeSessionApi = buildRuntimeSessionApiRoutes({
       openStore: () => new RuntimeSessionEventStore(this.#runManager.getDbPath()),
     });
+    const traceGateReviewApi = buildTraceGateReviewApiRoutes({
+      runsRoot: this.#runManager.getRunsRoot(),
+    });
     const hubApi = buildHubApiRoutes({
       runsRoot: this.#runManager.getRunsRoot(),
       knowledgeRoot: this.#runManager.getKnowledgeRoot(),
@@ -293,6 +297,7 @@ export class InteractiveServer {
           openclaw: "/api/openclaw",
           cockpit: "/api/cockpit",
           context_selection: "/api/cockpit/runs/:run_id/context-selection",
+          trace_gates: "/api/cockpit/runs/:run_id/trace-gates",
           background_sessions: {
             list: "/api/cockpit/background-sessions",
             show: "/api/cockpit/background-sessions/:session_id",
@@ -630,6 +635,14 @@ export class InteractiveServer {
     if (method === "GET" && cockpitRunRuntimeSessionMatch) {
       const [, rawRunId] = cockpitRunRuntimeSessionMatch;
       const response = runtimeSessionApi.getByRunId(decodeURIComponent(rawRunId!));
+      json(response.status, response.body);
+      return;
+    }
+
+    const cockpitTraceGateReviewMatch = url.match(/^\/api\/cockpit\/runs\/([^/]+)\/trace-gates$/);
+    if (method === "GET" && cockpitTraceGateReviewMatch) {
+      const [, rawRunId] = cockpitTraceGateReviewMatch;
+      const response = traceGateReviewApi.getByRunId(decodeURIComponent(rawRunId!));
       json(response.status, response.body);
       return;
     }

--- a/ts/src/tui/commands.ts
+++ b/ts/src/tui/commands.ts
@@ -1,9 +1,7 @@
+import type { TraceGateOperatorView } from "../analytics/trace-gate-operator-view.js";
 import type { RunManager } from "../server/run-manager.js";
 import type { TuiActivitySettings } from "./activity-summary.js";
-import {
-  resetTuiActivitySettings,
-  saveTuiActivitySettings,
-} from "./activity-settings-store.js";
+import { resetTuiActivitySettings, saveTuiActivitySettings } from "./activity-settings-store.js";
 import {
   handleTuiLogin,
   handleTuiLogout,
@@ -87,9 +85,8 @@ async function loadTuiRuntimeSessionTimeline(
 ): Promise<string[]> {
   const { RuntimeSessionEventStore } = await import("../session/runtime-events.js");
   const { runtimeSessionIdForRun } = await import("../session/runtime-session-ids.js");
-  const { executeRuntimeSessionsCommandWorkflow } = await import(
-    "../cli/runtime-session-command-workflow.js"
-  );
+  const { executeRuntimeSessionsCommandWorkflow } =
+    await import("../cli/runtime-session-command-workflow.js");
   const store = new RuntimeSessionEventStore(manager.getDbPath());
   try {
     return executeRuntimeSessionsCommandWorkflow({
@@ -105,6 +102,24 @@ async function loadTuiRuntimeSessionTimeline(
   }
 }
 
+async function renderTuiTraceGates(manager: RunManager, runId: string): Promise<string[]> {
+  const { buildTraceGateReviewApiRoutes } = await import("../server/trace-gate-review-api.js");
+  const { renderTraceGateOperatorViewLines } =
+    await import("../analytics/trace-gate-operator-view.js");
+  const response = buildTraceGateReviewApiRoutes({
+    runsRoot: manager.getRunsRoot(),
+  }).getByRunId(runId);
+  if (response.status >= 400) {
+    const body = response.body as { detail?: unknown };
+    return [
+      typeof body.detail === "string"
+        ? body.detail
+        : `trace gate review failed: ${response.status}`,
+    ];
+  }
+  return renderTraceGateOperatorViewLines(response.body as TraceGateOperatorView);
+}
+
 export function formatCommandHelp(): string[] {
   return formatTuiCommandHelp();
 }
@@ -117,83 +132,89 @@ export async function handleInteractiveTuiCommand(args: {
   activitySettings?: TuiActivitySettings;
 }): Promise<HandleInteractiveTuiCommandResult> {
   const { manager, configDir, pendingLogin } = args;
-  return executeTuiInteractiveCommandWorkflow({
-    raw: args.raw,
-    pendingLogin,
-    activitySettings: args.activitySettings,
-  }, {
-    pendingLogin: {
-      login(provider, apiKey, model, baseUrl) {
-        return handleTuiLogin(configDir, provider, apiKey, model, baseUrl);
+  return executeTuiInteractiveCommandWorkflow(
+    {
+      raw: args.raw,
+      pendingLogin,
+      activitySettings: args.activitySettings,
+    },
+    {
+      pendingLogin: {
+        login(provider, apiKey, model, baseUrl) {
+          return handleTuiLogin(configDir, provider, apiKey, model, baseUrl);
+        },
+        selectProvider(provider) {
+          return applyProviderSelection(manager, configDir, provider);
+        },
       },
-      selectProvider(provider) {
-        return applyProviderSelection(manager, configDir, provider);
+      activity: {
+        reset() {
+          return resetTuiActivitySettings(configDir);
+        },
+        save(settings) {
+          saveTuiActivitySettings(configDir, settings);
+        },
+      },
+      operator: manager,
+      solve: manager,
+      startRun: manager,
+      readActiveRunId() {
+        return manager.getState().runId;
+      },
+      runInspection: {
+        renderStatus(runId) {
+          return renderTuiRunStatus(manager, runId);
+        },
+        renderShow(runId, best) {
+          return renderTuiRunShow(manager, runId, best);
+        },
+        renderTimeline(runId) {
+          return loadTuiRuntimeSessionTimeline(manager, runId);
+        },
+        renderTraceGates(runId) {
+          return renderTuiTraceGates(manager, runId);
+        },
+      },
+      chat: manager,
+      authStatus: {
+        selectProvider(provider) {
+          return applyProviderSelection(manager, configDir, provider);
+        },
+        readWhoami(preferredProvider) {
+          return handleTuiWhoami(configDir, preferredProvider);
+        },
+        getActiveProvider() {
+          return manager.getActiveProviderType() ?? undefined;
+        },
+      },
+      authLogout: {
+        logout(provider) {
+          handleTuiLogout(configDir, provider);
+        },
+        clearActiveProvider() {
+          manager.clearActiveProvider();
+        },
+        getActiveProvider() {
+          return manager.getActiveProviderType() ?? undefined;
+        },
+        selectProvider(preferredProvider) {
+          return applyProviderSelection(manager, configDir, preferredProvider);
+        },
+        readWhoami(preferredProvider) {
+          return handleTuiWhoami(configDir, preferredProvider);
+        },
+      },
+      authLogin: {
+        providerRequiresKey(provider) {
+          return getKnownProvider(provider)?.requiresKey ?? true;
+        },
+        login(provider, apiKey, model, baseUrl) {
+          return handleTuiLogin(configDir, provider, apiKey, model, baseUrl);
+        },
+        selectProvider(provider) {
+          return applyProviderSelection(manager, configDir, provider);
+        },
       },
     },
-    activity: {
-      reset() {
-        return resetTuiActivitySettings(configDir);
-      },
-      save(settings) {
-        saveTuiActivitySettings(configDir, settings);
-      },
-    },
-    operator: manager,
-    solve: manager,
-    startRun: manager,
-    readActiveRunId() {
-      return manager.getState().runId;
-    },
-    runInspection: {
-      renderStatus(runId) {
-        return renderTuiRunStatus(manager, runId);
-      },
-      renderShow(runId, best) {
-        return renderTuiRunShow(manager, runId, best);
-      },
-      renderTimeline(runId) {
-        return loadTuiRuntimeSessionTimeline(manager, runId);
-      },
-    },
-    chat: manager,
-    authStatus: {
-      selectProvider(provider) {
-        return applyProviderSelection(manager, configDir, provider);
-      },
-      readWhoami(preferredProvider) {
-        return handleTuiWhoami(configDir, preferredProvider);
-      },
-      getActiveProvider() {
-        return manager.getActiveProviderType() ?? undefined;
-      },
-    },
-    authLogout: {
-      logout(provider) {
-        handleTuiLogout(configDir, provider);
-      },
-      clearActiveProvider() {
-        manager.clearActiveProvider();
-      },
-      getActiveProvider() {
-        return manager.getActiveProviderType() ?? undefined;
-      },
-      selectProvider(preferredProvider) {
-        return applyProviderSelection(manager, configDir, preferredProvider);
-      },
-      readWhoami(preferredProvider) {
-        return handleTuiWhoami(configDir, preferredProvider);
-      },
-    },
-    authLogin: {
-      providerRequiresKey(provider) {
-        return getKnownProvider(provider)?.requiresKey ?? true;
-      },
-      login(provider, apiKey, model, baseUrl) {
-        return handleTuiLogin(configDir, provider, apiKey, model, baseUrl);
-      },
-      selectProvider(provider) {
-        return applyProviderSelection(manager, configDir, provider);
-      },
-    },
-  });
+  );
 }

--- a/ts/src/tui/meta-command.ts
+++ b/ts/src/tui/meta-command.ts
@@ -65,6 +65,7 @@ export function formatTuiCommandHelp(): string[] {
     "/show <run-id> --best",
     "/watch <run-id>",
     "/timeline <run-id>",
+    "/findings <run-id> (alias: /trace-gates <run-id>)",
     TUI_ACTIVITY_USAGE,
     "/pause or /resume",
     "/hint <text>",

--- a/ts/src/tui/run-command.ts
+++ b/ts/src/tui/run-command.ts
@@ -7,7 +7,13 @@ export type TuiRunCommandTarget =
       readonly kind: "missing";
     };
 
-type TuiRunInspectionCommandName = "status" | "show" | "watch" | "timeline";
+type TuiRunInspectionCommandName =
+  | "status"
+  | "show"
+  | "watch"
+  | "timeline"
+  | "findings"
+  | "trace-gates";
 type TuiActiveRunIdSource = string | null | undefined | (() => string | null | undefined);
 
 const TUI_RUN_INSPECTION_USAGES: Record<TuiRunInspectionCommandName, string> = {
@@ -15,6 +21,8 @@ const TUI_RUN_INSPECTION_USAGES: Record<TuiRunInspectionCommandName, string> = {
   show: "/show <run-id> [--best]",
   watch: "/watch <run-id>",
   timeline: "/timeline <run-id>",
+  findings: "/findings <run-id>",
+  "trace-gates": "/trace-gates <run-id>",
 };
 
 export type TuiRunInspectionCommandPlan =
@@ -41,12 +49,17 @@ export type TuiRunInspectionCommandPlan =
   | {
       readonly kind: "timeline";
       readonly runId: string;
+    }
+  | {
+      readonly kind: "findings";
+      readonly runId: string;
     };
 
 export interface TuiRunInspectionCommandEffects {
   renderStatus(runId: string): Promise<string[]>;
   renderShow(runId: string, best: boolean): Promise<string[]>;
   renderTimeline(runId: string): Promise<string[]>;
+  renderTraceGates(runId: string): Promise<string[]>;
 }
 
 export interface TuiRunInspectionCommandExecutionResult {
@@ -147,7 +160,7 @@ export function planTuiRunInspectionCommand(
     };
   }
   return {
-    kind: command,
+    kind: command === "trace-gates" ? "findings" : command,
     runId: target.runId,
   };
 }
@@ -175,6 +188,8 @@ export async function executeTuiRunInspectionCommandPlan(
         };
       case "timeline":
         return { logLines: await effects.renderTimeline(plan.runId) };
+      case "findings":
+        return { logLines: await effects.renderTraceGates(plan.runId) };
     }
   } catch (err) {
     return { logLines: [err instanceof Error ? err.message : String(err)] };
@@ -182,7 +197,7 @@ export async function executeTuiRunInspectionCommandPlan(
 }
 
 function readTuiRunInspectionCommandName(raw: string): TuiRunInspectionCommandName | null {
-  const match = raw.trim().match(/^\/(status|show|watch|timeline)(?:\s|$)/);
+  const match = raw.trim().match(/^\/(status|show|watch|timeline|findings|trace-gates)(?:\s|$)/);
   return match ? (match[1] as TuiRunInspectionCommandName) : null;
 }
 

--- a/ts/tests/trace-gate-operator-view.test.ts
+++ b/ts/tests/trace-gate-operator-view.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTraceGateOperatorView,
+  renderTraceGateOperatorViewLines,
+} from "../src/analytics/trace-gate-operator-view.js";
+import type { TraceFindingReport } from "../src/analytics/trace-findings.js";
+import type { HarnessChangeProposal } from "../src/control-plane/contract/types.js";
+
+const report: TraceFindingReport = {
+  reportId: "report-run-123",
+  traceId: "trace-run-123",
+  sourceHarness: "autocontext",
+  createdAt: "2026-06-01T12:00:00.000Z",
+  summary: "2 finding(s) across 1 category.",
+  metadata: {},
+  findings: [
+    {
+      findingId: "finding-tool-1",
+      category: "tool_call_failure",
+      severity: "high",
+      title: "Patch tool failed twice",
+      description: "patch hunk did not apply",
+      evidenceMessageIndexes: [1, 3],
+    },
+    {
+      findingId: "finding-score-1",
+      category: "low_outcome_score",
+      severity: "medium",
+      title: "Outcome stayed below threshold",
+      description: "score=0.32",
+      evidenceMessageIndexes: [],
+    },
+  ],
+  failureMotifs: [
+    {
+      motifId: "motif-tool",
+      category: "tool_call_failure",
+      occurrenceCount: 2,
+      evidenceMessageIndexes: [1, 3],
+      description: "patch tool failures repeated",
+    },
+  ],
+};
+
+function proposal(
+  suffix: string,
+  status: "accepted" | "rejected" | "inconclusive" | "proposed",
+  reason = "",
+): HarnessChangeProposal {
+  return {
+    schemaVersion: "1.0" as HarnessChangeProposal["schemaVersion"],
+    id: `01HX0000000000000000000${suffix}` as HarnessChangeProposal["id"],
+    status,
+    findingIds: ["finding-tool-1"],
+    targetSurface: suffix === "683" ? "verifier-rubric" : "prompt",
+    proposedEdit: {
+      summary: `${status} proposal for trace finding`,
+      patches: [
+        {
+          filePath: "agents/grid_ctf/prompts/competitor.txt",
+          operation: "modify",
+          unifiedDiff: "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new\n",
+        },
+      ],
+    },
+    expectedImpact: { qualityDelta: 0.08, riskReduction: "fewer repeat tool failures" },
+    rollbackCriteria: ["heldout score regresses"],
+    provenance: {
+      authorType: "autocontext-run",
+      authorId: "run-123",
+      parentArtifactIds: [],
+      createdAt: "2026-06-01T12:05:00.000Z",
+    },
+    ...(status === "proposed"
+      ? {}
+      : {
+          decision: {
+            status,
+            reason,
+            validation: {
+              mode: status === "inconclusive" ? "dev" : "heldout",
+              suiteId: "heldout-suite" as never,
+              evidenceRefs: status === "inconclusive" ? [] : [`runs/run-123/${status}.json`],
+            },
+            promotionDecision: {
+              schemaVersion: "1.0" as HarnessChangeProposal["schemaVersion"],
+              pass: status === "accepted",
+              recommendedTargetState: status === "accepted" ? "canary" : "disabled",
+              deltas: {
+                quality: { baseline: 0.6, candidate: 0.72, delta: 0.12, passed: true },
+                cost: {
+                  baseline: { tokensIn: 100, tokensOut: 50 },
+                  candidate: { tokensIn: 110, tokensOut: 55 },
+                  delta: { tokensIn: 10, tokensOut: 5 },
+                  passed: true,
+                },
+                latency: {
+                  baseline: { p50Ms: 10, p95Ms: 20, p99Ms: 30 },
+                  candidate: { p50Ms: 11, p95Ms: 21, p99Ms: 31 },
+                  delta: { p50Ms: 1, p95Ms: 1, p99Ms: 1 },
+                  passed: true,
+                },
+                safety: { regressions: [], passed: true },
+              },
+              confidence: 0.9,
+              thresholds: {
+                qualityMinDelta: 0.05,
+                costMaxRelativeIncrease: 0.2,
+                latencyMaxRelativeIncrease: 0.2,
+                strongConfidenceMin: 0.9,
+                moderateConfidenceMin: 0.7,
+                strongQualityMultiplier: 2,
+              },
+              reasoning: reason,
+              evaluatedAt: "2026-06-01T12:10:00.000Z",
+            },
+            candidateArtifactId: "01HX0000000000000000000001" as never,
+            candidateEvalRunId: `candidate-${status}`,
+            baselineArtifactId: "01HX0000000000000000000002" as never,
+            baselineEvalRunId: `baseline-${status}`,
+            decidedAt: "2026-06-01T12:10:00.000Z",
+          },
+        }),
+  };
+}
+
+describe("trace gate operator view", () => {
+  it("surfaces findings, recurring failure modes, proposals, gate decisions, and evidence links", () => {
+    const view = buildTraceGateOperatorView({
+      run_id: "run-123",
+      report,
+      proposals: [
+        proposal("681", "accepted", "Accepted on heldout validation."),
+        proposal("682", "rejected", "Rejected on heldout validation."),
+        proposal("683", "inconclusive", "Dev-only validation is not enough."),
+      ],
+    });
+
+    expect(view).toMatchObject({
+      schema_version: "1",
+      run_id: "run-123",
+      state: "ready",
+      report: {
+        report_id: "report-run-123",
+        trace_id: "trace-run-123",
+        finding_count: 2,
+        failure_mode_count: 1,
+      },
+    });
+    expect(view.findings[0]).toMatchObject({
+      finding_id: "finding-tool-1",
+      evidence_count: 2,
+      linked_proposal_ids: [
+        "01HX0000000000000000000681",
+        "01HX0000000000000000000682",
+        "01HX0000000000000000000683",
+      ],
+      evidence_refs: [
+        { kind: "trace_message", ref: "msg:1", label: "msg #1", href: "#msg-1" },
+        { kind: "trace_message", ref: "msg:3", label: "msg #3", href: "#msg-3" },
+      ],
+    });
+    expect(view.failure_modes).toEqual([
+      {
+        motif_id: "motif-tool",
+        category: "tool_call_failure",
+        occurrence_count: 2,
+        description: "patch tool failures repeated",
+        representative_evidence_refs: [
+          { kind: "trace_message", ref: "msg:1", label: "msg #1", href: "#msg-1" },
+          { kind: "trace_message", ref: "msg:3", label: "msg #3", href: "#msg-3" },
+        ],
+      },
+    ]);
+    expect(view.proposals.map((item) => [item.status, item.target_surface])).toEqual([
+      ["accepted", "prompt"],
+      ["rejected", "prompt"],
+      ["inconclusive", "verifier-rubric"],
+    ]);
+    expect(view.gate_decisions.map((decision) => decision.status)).toEqual([
+      "accepted",
+      "rejected",
+      "inconclusive",
+    ]);
+    expect(view.gate_decisions[0]?.evidence_refs).toEqual([
+      {
+        kind: "artifact",
+        ref: "runs/run-123/accepted.json",
+        label: "accepted.json",
+        href: "runs/run-123/accepted.json",
+      },
+    ]);
+  });
+
+  it("renders TUI-safe lines without raw JSON for operator inspection", () => {
+    const view = buildTraceGateOperatorView({
+      run_id: "run-123",
+      report,
+      proposals: [proposal("681", "accepted", "Accepted on heldout validation.")],
+    });
+
+    expect(renderTraceGateOperatorViewLines(view)).toEqual([
+      "Trace gates for run-123 — ready",
+      "2 finding(s) across 1 category.",
+      "Findings:",
+      "- [high/tool_call_failure] Patch tool failed twice evidence=msg #1, msg #3 proposals=01HX0000000000000000000681",
+      "- [medium/low_outcome_score] Outcome stayed below threshold evidence=none proposals=none",
+      "Recurring failure modes:",
+      "- tool_call_failure x2 evidence=msg #1, msg #3",
+      "Proposals:",
+      "- 01HX0000000000000000000681 accepted target=prompt patches=1 — accepted proposal for trace finding",
+      "Gate decisions:",
+      "- 01HX0000000000000000000681 accepted heldout — Accepted on heldout validation.",
+    ]);
+  });
+
+  it("handles missing, incomplete, and no-finding states gracefully", () => {
+    expect(buildTraceGateOperatorView({ run_id: "run-123", report: null }).state).toBe(
+      "missing_report",
+    );
+    expect(
+      buildTraceGateOperatorView({ run_id: "run-123", report: null, analysis_state: "incomplete" })
+        .state,
+    ).toBe("incomplete_analysis");
+    expect(
+      buildTraceGateOperatorView({
+        run_id: "run-123",
+        report: { ...report, findings: [], failureMotifs: [], summary: "No notable findings." },
+        proposals: [],
+      }).state,
+    ).toBe("no_findings");
+  });
+});

--- a/ts/tests/trace-gate-review-api.test.ts
+++ b/ts/tests/trace-gate-review-api.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTraceGateReviewApiRoutes } from "../src/server/trace-gate-review-api.js";
+import type { TraceFindingReport } from "../src/analytics/trace-findings.js";
+
+const report: TraceFindingReport = {
+  reportId: "report-run-123",
+  traceId: "trace-run-123",
+  sourceHarness: "autocontext",
+  createdAt: "2026-06-01T12:00:00.000Z",
+  summary: "No notable findings.",
+  metadata: {},
+  findings: [],
+  failureMotifs: [],
+};
+
+describe("trace gate review API routes", () => {
+  it("returns the operator view for a run from injected report and proposal loaders", () => {
+    const api = buildTraceGateReviewApiRoutes({
+      runsRoot: "/tmp/runs",
+      loadReport: (runId) => (runId === "run-123" ? report : null),
+      loadProposals: () => [],
+    });
+
+    expect(api.getByRunId("run-123")).toMatchObject({
+      status: 200,
+      body: {
+        run_id: "run-123",
+        state: "no_findings",
+        report: { report_id: "report-run-123" },
+      },
+    });
+  });
+
+  it("handles missing reports and invalid run ids without throwing raw errors", () => {
+    const api = buildTraceGateReviewApiRoutes({
+      runsRoot: "/tmp/runs",
+      loadReport: () => null,
+      loadProposals: () => [],
+    });
+
+    expect(api.getByRunId("run-404")).toMatchObject({
+      status: 200,
+      body: {
+        run_id: "run-404",
+        state: "missing_report",
+        findings: [],
+        gate_decisions: [],
+      },
+    });
+    expect(api.getByRunId("../escape")).toMatchObject({
+      status: 422,
+      body: { detail: "run_id escapes runs root: '../escape'" },
+    });
+  });
+});

--- a/ts/tests/trace-gate-review-api.test.ts
+++ b/ts/tests/trace-gate-review-api.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { buildTraceGateReviewApiRoutes } from "../src/server/trace-gate-review-api.js";
@@ -30,6 +34,75 @@ describe("trace gate review API routes", () => {
         report: { report_id: "report-run-123" },
       },
     });
+  });
+
+  it("rejects symlinked run directories that resolve outside runs root", () => {
+    const root = mkdtempSync(join(tmpdir(), "trace-gate-runs-"));
+    const outside = mkdtempSync(join(tmpdir(), "trace-gate-outside-"));
+    try {
+      writeFileSync(join(outside, "trace-finding-report.json"), JSON.stringify(report));
+      symlinkSync(outside, join(root, "link"), "dir");
+      const api = buildTraceGateReviewApiRoutes({ runsRoot: root });
+
+      expect(api.getByRunId("link")).toMatchObject({
+        status: 422,
+        body: { detail: "run_id escapes runs root: 'link'" },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects invalid proposal files instead of surfacing trusted gate decisions", () => {
+    const root = mkdtempSync(join(tmpdir(), "trace-gate-runs-"));
+    try {
+      const runRoot = join(root, "run-123");
+      mkdirSync(join(runRoot, "harness-proposals"), { recursive: true });
+      writeFileSync(join(runRoot, "trace-finding-report.json"), JSON.stringify(report));
+      writeFileSync(
+        join(runRoot, "harness-proposals", "invalid.json"),
+        JSON.stringify({
+          schemaVersion: "1.0",
+          id: "01HX0000000000000000000683",
+          status: "accepted",
+          findingIds: ["finding-tool-1"],
+          targetSurface: "prompt",
+          proposedEdit: {
+            summary: "accepted proposal for trace finding",
+            patches: [
+              { filePath: "prompt.txt", operation: "modify", unifiedDiff: "--- a\n+++ b\n" },
+            ],
+          },
+          expectedImpact: { qualityDelta: 0.08, riskReduction: "fewer repeat tool failures" },
+          rollbackCriteria: ["heldout score regresses"],
+          provenance: {
+            authorType: "autocontext-run",
+            authorId: "run-123",
+            parentArtifactIds: [],
+            createdAt: "2026-06-01T12:05:00.000Z",
+          },
+          decision: {
+            status: "accepted",
+            reason: "Missing promotion-grade fields.",
+            validation: {
+              mode: "heldout",
+              suiteId: "heldout-suite",
+              evidenceRefs: ["accepted.json"],
+            },
+            decidedAt: "2026-06-01T12:10:00.000Z",
+          },
+        }),
+      );
+      const api = buildTraceGateReviewApiRoutes({ runsRoot: root });
+
+      expect(api.getByRunId("run-123")).toMatchObject({
+        status: 500,
+        body: { detail: expect.stringContaining("Invalid HarnessChangeProposal") },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("handles missing reports and invalid run ids without throwing raw errors", () => {

--- a/ts/tests/tui-command-help.test.ts
+++ b/ts/tests/tui-command-help.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -27,7 +27,9 @@ describe("TUI command help", () => {
     expect(help).toContain("/show <run-id> --best");
     expect(help).toContain("/watch <run-id>");
     expect(help).toContain("/timeline <run-id>");
-    expect(help).toContain("/activity [status|reset|<all|runtime|prompts|commands|children|errors> [quiet|normal|verbose]]");
+    expect(help).toContain(
+      "/activity [status|reset|<all|runtime|prompts|commands|children|errors> [quiet|normal|verbose]]",
+    );
   });
 
   it("turns /solve plain language into scenario creation and a run", async () => {
@@ -107,6 +109,52 @@ describe("TUI command help", () => {
     );
   });
 
+  it("renders the active run trace findings and gate decisions", async () => {
+    const runsRoot = mkdtempSync(join(tmpdir(), "tui-trace-gates-"));
+    const reportDir = join(runsRoot, "run-123", "trace-findings");
+    mkdirSync(reportDir, { recursive: true });
+    writeFileSync(
+      join(reportDir, "latest.json"),
+      JSON.stringify({
+        reportId: "report-run-123",
+        traceId: "trace-run-123",
+        sourceHarness: "autocontext",
+        createdAt: "2026-06-01T12:00:00.000Z",
+        summary: "1 finding(s) across 1 category.",
+        metadata: {},
+        findings: [
+          {
+            findingId: "finding-tool-1",
+            category: "tool_call_failure",
+            severity: "high",
+            title: "Patch tool failed twice",
+            description: "patch hunk did not apply",
+            evidenceMessageIndexes: [1, 3],
+          },
+        ],
+        failureMotifs: [],
+      }),
+    );
+    const manager = {
+      getState: vi.fn(() => ({ runId: "run-123" })),
+      getRunsRoot: vi.fn(() => runsRoot),
+    };
+
+    const result = await handleInteractiveTuiCommand({
+      manager: manager as never,
+      configDir: ".",
+      raw: "/findings",
+      pendingLogin: null,
+    });
+
+    expect(result.logLines).toEqual(
+      expect.arrayContaining([
+        "Trace gates for run-123 — ready",
+        "- [high/tool_call_failure] Patch tool failed twice evidence=msg #1, msg #3 proposals=none",
+      ]),
+    );
+  });
+
   it("updates live activity feed focus and verbosity", async () => {
     const manager = {};
     const configDir = mkdtempSync(join(tmpdir(), "tui-activity-command-"));
@@ -153,13 +201,17 @@ describe("TUI command help", () => {
     const settingsPath = join(configDir, TUI_SETTINGS_FILE);
     writeFileSync(
       settingsPath,
-      `${JSON.stringify({
-        activity: {
-          filter: "commands",
-          verbosity: "quiet",
+      `${JSON.stringify(
+        {
+          activity: {
+            filter: "commands",
+            verbosity: "quiet",
+          },
+          updatedAt: "2026-04-10T00:00:00.000Z",
         },
-        updatedAt: "2026-04-10T00:00:00.000Z",
-      }, null, 2)}\n`,
+        null,
+        2,
+      )}\n`,
       "utf-8",
     );
     const before = readFileSync(settingsPath, "utf-8");
@@ -183,13 +235,17 @@ describe("TUI command help", () => {
     const settingsPath = join(configDir, TUI_SETTINGS_FILE);
     writeFileSync(
       settingsPath,
-      `${JSON.stringify({
-        activity: {
-          filter: "runtime",
-          verbosity: "verbose",
+      `${JSON.stringify(
+        {
+          activity: {
+            filter: "runtime",
+            verbosity: "verbose",
+          },
+          updatedAt: "2026-04-10T00:00:00.000Z",
         },
-        updatedAt: "2026-04-10T00:00:00.000Z",
-      }, null, 2)}\n`,
+        null,
+        2,
+      )}\n`,
       "utf-8",
     );
     const before = readFileSync(settingsPath, "utf-8");

--- a/ts/tests/tui-run-command.test.ts
+++ b/ts/tests/tui-run-command.test.ts
@@ -65,10 +65,18 @@ describe("TUI run inspection command planner", () => {
     });
   });
 
-  it("plans runtime timeline commands with the same target rules", () => {
+  it("plans runtime timeline and trace-finding commands with the same target rules", () => {
     expect(planTuiRunInspectionCommand("/timeline", "run-active")).toEqual({
       kind: "timeline",
       runId: "run-active",
+    });
+    expect(planTuiRunInspectionCommand("/findings", "run-active")).toEqual({
+      kind: "findings",
+      runId: "run-active",
+    });
+    expect(planTuiRunInspectionCommand("/trace-gates run-123", "run-active")).toEqual({
+      kind: "findings",
+      runId: "run-123",
     });
   });
 
@@ -76,6 +84,10 @@ describe("TUI run inspection command planner", () => {
     expect(planTuiRunInspectionCommand("/timeline", null)).toEqual({
       kind: "usage",
       usageLine: "usage: /timeline <run-id>",
+    });
+    expect(planTuiRunInspectionCommand("/findings", null)).toEqual({
+      kind: "usage",
+      usageLine: "usage: /findings <run-id>",
     });
     expect(planTuiRunInspectionCommand("/show", "")).toEqual({
       kind: "usage",
@@ -95,10 +107,12 @@ describe("TUI run inspection command planner", () => {
   it("does not read active run state for non-run-inspection commands", () => {
     let readCount = 0;
 
-    expect(planTuiRunInspectionCommand("/login anthropic", () => {
-      readCount += 1;
-      return "run-active";
-    })).toEqual({
+    expect(
+      planTuiRunInspectionCommand("/login anthropic", () => {
+        readCount += 1;
+        return "run-active";
+      }),
+    ).toEqual({
       kind: "unhandled",
     });
     expect(readCount).toBe(0);
@@ -111,25 +125,37 @@ describe("TUI run inspection command executor", () => {
       renderStatus: vi.fn(async () => ["status line"]),
       renderShow: vi.fn(async () => ["show line"]),
       renderTimeline: vi.fn(),
+      renderTraceGates: vi.fn(),
     };
 
-    await expect(executeTuiRunInspectionCommandPlan({
-      kind: "status",
-      runId: "run-123",
-    }, effects)).resolves.toEqual({
+    await expect(
+      executeTuiRunInspectionCommandPlan(
+        {
+          kind: "status",
+          runId: "run-123",
+        },
+        effects,
+      ),
+    ).resolves.toEqual({
       logLines: ["status line"],
     });
-    await expect(executeTuiRunInspectionCommandPlan({
-      kind: "show",
-      runId: "run-123",
-      best: true,
-    }, effects)).resolves.toEqual({
+    await expect(
+      executeTuiRunInspectionCommandPlan(
+        {
+          kind: "show",
+          runId: "run-123",
+          best: true,
+        },
+        effects,
+      ),
+    ).resolves.toEqual({
       logLines: ["show line"],
     });
 
     expect(effects.renderStatus).toHaveBeenCalledWith("run-123");
     expect(effects.renderShow).toHaveBeenCalledWith("run-123", true);
     expect(effects.renderTimeline).not.toHaveBeenCalled();
+    expect(effects.renderTraceGates).not.toHaveBeenCalled();
   });
 
   it("prepends the watching line while reusing status rendering", async () => {
@@ -137,35 +163,60 @@ describe("TUI run inspection command executor", () => {
       renderStatus: vi.fn(async () => ["status line"]),
       renderShow: vi.fn(),
       renderTimeline: vi.fn(),
+      renderTraceGates: vi.fn(),
     };
 
-    await expect(executeTuiRunInspectionCommandPlan({
-      kind: "watch",
-      runId: "run-123",
-    }, effects)).resolves.toEqual({
+    await expect(
+      executeTuiRunInspectionCommandPlan(
+        {
+          kind: "watch",
+          runId: "run-123",
+        },
+        effects,
+      ),
+    ).resolves.toEqual({
       logLines: ["watching run-123", "status line"],
     });
 
     expect(effects.renderStatus).toHaveBeenCalledWith("run-123");
     expect(effects.renderShow).not.toHaveBeenCalled();
     expect(effects.renderTimeline).not.toHaveBeenCalled();
+    expect(effects.renderTraceGates).not.toHaveBeenCalled();
   });
 
-  it("routes timeline plans through the timeline renderer", async () => {
+  it("routes timeline and trace-finding plans through dedicated renderers", async () => {
     const effects = {
       renderStatus: vi.fn(),
       renderShow: vi.fn(),
       renderTimeline: vi.fn(async () => ["timeline line"]),
+      renderTraceGates: vi.fn(async () => ["trace gate line"]),
     };
 
-    await expect(executeTuiRunInspectionCommandPlan({
-      kind: "timeline",
-      runId: "run-123",
-    }, effects)).resolves.toEqual({
+    await expect(
+      executeTuiRunInspectionCommandPlan(
+        {
+          kind: "timeline",
+          runId: "run-123",
+        },
+        effects,
+      ),
+    ).resolves.toEqual({
       logLines: ["timeline line"],
+    });
+    await expect(
+      executeTuiRunInspectionCommandPlan(
+        {
+          kind: "findings",
+          runId: "run-123",
+        },
+        effects,
+      ),
+    ).resolves.toEqual({
+      logLines: ["trace gate line"],
     });
 
     expect(effects.renderTimeline).toHaveBeenCalledWith("run-123");
+    expect(effects.renderTraceGates).toHaveBeenCalledWith("run-123");
     expect(effects.renderStatus).not.toHaveBeenCalled();
     expect(effects.renderShow).not.toHaveBeenCalled();
   });
@@ -175,19 +226,28 @@ describe("TUI run inspection command executor", () => {
       renderStatus: vi.fn(),
       renderShow: vi.fn(),
       renderTimeline: vi.fn(),
+      renderTraceGates: vi.fn(),
     };
 
-    await expect(executeTuiRunInspectionCommandPlan({
-      kind: "usage",
-      usageLine: "usage: /status <run-id>",
-    }, effects)).resolves.toEqual({
+    await expect(
+      executeTuiRunInspectionCommandPlan(
+        {
+          kind: "usage",
+          usageLine: "usage: /status <run-id>",
+        },
+        effects,
+      ),
+    ).resolves.toEqual({
       logLines: ["usage: /status <run-id>"],
     });
-    await expect(executeTuiRunInspectionCommandPlan({ kind: "unhandled" }, effects)).resolves.toBeNull();
+    await expect(
+      executeTuiRunInspectionCommandPlan({ kind: "unhandled" }, effects),
+    ).resolves.toBeNull();
 
     expect(effects.renderStatus).not.toHaveBeenCalled();
     expect(effects.renderShow).not.toHaveBeenCalled();
     expect(effects.renderTimeline).not.toHaveBeenCalled();
+    expect(effects.renderTraceGates).not.toHaveBeenCalled();
   });
 
   it("maps render failures to log lines", async () => {
@@ -197,12 +257,18 @@ describe("TUI run inspection command executor", () => {
       }),
       renderShow: vi.fn(),
       renderTimeline: vi.fn(),
+      renderTraceGates: vi.fn(),
     };
 
-    await expect(executeTuiRunInspectionCommandPlan({
-      kind: "status",
-      runId: "missing",
-    }, effects)).resolves.toEqual({
+    await expect(
+      executeTuiRunInspectionCommandPlan(
+        {
+          kind: "status",
+          runId: "missing",
+        },
+        effects,
+      ),
+    ).resolves.toEqual({
       logLines: ["run 'missing' not found"],
     });
   });
@@ -254,11 +320,16 @@ describe("TUI start run command executor", () => {
       startRun: vi.fn(async () => "run-123"),
     };
 
-    await expect(executeTuiStartRunCommandPlan({
-      kind: "start",
-      scenario: "support_triage",
-      iterations: 3,
-    }, effects)).resolves.toEqual({
+    await expect(
+      executeTuiStartRunCommandPlan(
+        {
+          kind: "start",
+          scenario: "support_triage",
+          iterations: 3,
+        },
+        effects,
+      ),
+    ).resolves.toEqual({
       logLines: ["accepted run run-123"],
     });
     expect(effects.startRun).toHaveBeenCalledWith("support_triage", 3);
@@ -280,11 +351,16 @@ describe("TUI start run command executor", () => {
       }),
     };
 
-    await expect(executeTuiStartRunCommandPlan({
-      kind: "start",
-      scenario: "missing",
-      iterations: 5,
-    }, effects)).resolves.toEqual({
+    await expect(
+      executeTuiStartRunCommandPlan(
+        {
+          kind: "start",
+          scenario: "missing",
+          iterations: 5,
+        },
+        effects,
+      ),
+    ).resolves.toEqual({
       logLines: ["scenario not found"],
     });
   });


### PR DESCRIPTION
## Summary
- Reapplies AC-683 after revert #1073 so it can receive human review before merging.
- Adds shared Python/TypeScript trace-gate operator read models, Cockpit route, and TUI /findings + /trace-gates commands.
- Fixes reviewer findings from #1072:
  - Python now validates persisted HarnessChangeProposal JSON before trusting proposals/gate decisions.
  - TypeScript run-root containment now checks real paths for existing run directories and rejects symlinks escaping runsRoot.

## Regression coverage
- Python invalid accepted/rejected proposal JSON returns an invalid-proposal error instead of gate decisions.
- TypeScript symlinked run directory outside runsRoot returns 422 and does not read the outside report.

## Tests
- git diff --check origin/main...HEAD
- git diff --check 59ce2a125fd7698ccb7dc5485f99daf518649cee...HEAD
- cd autocontext/autocontext && uv run pytest tests/test_trace_gate_operator_view.py tests/test_trace_gate_review_api.py tests/test_module_size_limits.py -q
- cd autocontext/autocontext && uv run ruff check src/autocontext/control_plane/harness_change_proposal.py src/autocontext/analytics/trace_gate_operator_view.py src/autocontext/server/trace_gate_review_api.py src/autocontext/server/cockpit_api.py tests/test_trace_gate_operator_view.py tests/test_trace_gate_review_api.py
- cd autocontext/autocontext && uv run mypy src/autocontext/control_plane/harness_change_proposal.py src/autocontext/analytics/trace_gate_operator_view.py src/autocontext/server/trace_gate_review_api.py src/autocontext/server/cockpit_api.py
- cd autocontext/ts && npx vitest run tests/trace-gate-operator-view.test.ts tests/trace-gate-review-api.test.ts tests/tui-run-command.test.ts --reporter=verbose
- cd autocontext/ts && npx vitest run tests/tui-command-help.test.ts -t "trace findings" --reporter=verbose
- cd autocontext/ts && npm run lint -- --pretty false

Linear: AC-683