### PR TITLE
feat(trl-grpo): expose KL penalty (--grpo-beta) + default it nonzero (prevents RLVR overfitting)

### DIFF
--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -235,9 +235,16 @@ uv run autoctx train --backend trl --trl-mode gkd \
   --teacher-model Qwen/Qwen2.5-3B-Instruct
 
 # RLVR (GRPO) -- the cross-platform counterpart of `grpo`
+# Applies a reference-policy KL penalty of --grpo-beta 0.04 by default (see notes).
 uv run autoctx train --backend trl --trl-mode grpo \
   --scenario antichain_diverse \
   --base-model Qwen/Qwen2.5-1.5B-Instruct
+
+# KL-free / R1-Zero-style GRPO (reproduces the original "GRPO stayed flat" baseline)
+uv run autoctx train --backend trl --trl-mode grpo \
+  --scenario antichain_diverse \
+  --base-model Qwen/Qwen2.5-1.5B-Instruct \
+  --grpo-beta 0.0
 ```
 
 Notes:
@@ -245,6 +252,13 @@ Notes:
 - `--trl-mode gkd` uses TRL's `GKDTrainer` (on-policy distillation; `lmbda=1.0` fully
   on-policy, `beta=1.0` reverse KL). `--trl-mode grpo` uses `GRPOTrainer` and reuses the
   **same** scenario-verifier reward as the MLX `grpo` backend (`score_completions`).
+- `--grpo-beta` sets the GRPO reference-policy KL penalty and **defaults to `0.04`** (the
+  DeepSeekMath GRPO value), not TRL's `0.0`. A small-model / short-run RLVR job with no KL
+  penalty drifts off the base distribution and overfits the train prompts (observed directly:
+  train reward climbed while held-out accuracy fell), so a nonzero anchor is the safer default
+  for the typical autocontext loop. Pass `--grpo-beta 0.0` for the KL-free / R1-Zero-style
+  regime at scale -- this reproduces the original KL-free run behind the "GRPO stayed flat"
+  result above (that case study predates this default). Negative values are rejected.
 - Models are HuggingFace repo ids (e.g. `Qwen/Qwen2.5-1.5B-Instruct`), not the MLX 4-bit
   community repos. `--base-model` is the student; `--teacher-model` (gkd) must share the
   student's tokenizer. LoRA (PEFT) is applied automatically.

--- a/autocontext/src/autocontext/cli_train.py
+++ b/autocontext/src/autocontext/cli_train.py
@@ -90,6 +90,9 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
         max_completion_length: int = typer.Option(
             512, "--max-completion-length", help="trl grpo: generation cap (256 truncates reasoning -> 0 reward / no gradient)"
         ),
+        grpo_beta: float = typer.Option(
+            0.04, "--grpo-beta", help="trl grpo: KL penalty toward base policy (0.0 = KL-free; nonzero prevents overfitting)"
+        ),
         agent_provider: str = typer.Option("anthropic", "--agent-provider", help="LLM provider for training agent"),
         agent_model: str = typer.Option("", "--agent-model", help="Model for training agent (empty = provider default)"),
         val_select: bool = typer.Option(
@@ -155,6 +158,8 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             raise typer.BadParameter(f"--train-steps must be >= 0 (0 = backend default), got {train_steps}")
         if max_completion_length < 1:
             raise typer.BadParameter(f"--max-completion-length must be a positive integer, got {max_completion_length}")
+        if grpo_beta < 0:
+            raise typer.BadParameter(f"--grpo-beta must be >= 0 (0 = KL-free), got {grpo_beta}")
         if learning_rate < 0:
             raise typer.BadParameter(f"--learning-rate must be >= 0 (0 = backend default), got {learning_rate}")
 
@@ -185,6 +190,7 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             trl_mode=trl_mode,
             seed=seed,
             max_completion_length=max_completion_length,
+            grpo_beta=grpo_beta,
             fine_tune_type=fine_tune_type,
             num_layers=num_layers,
         )

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -397,6 +397,7 @@ def run_training(
     trl_mode: str = "gkd",  # trl backend: gkd (on-policy distillation) | grpo (RLVR)
     seed: int = 0,  # trl backend: training seed (for seeded repeats / error bars)
     max_completion_length: int = 512,  # trl grpo: generation cap (>= task answer length; 256 truncates reasoning)
+    grpo_beta: float = 0.04,  # trl grpo: KL penalty toward base policy (0.0 = KL-free; nonzero prevents overfitting)
     fine_tune_type: str = "lora",
     num_layers: int = 8,
     collect_samples_path: Path | None = None,
@@ -536,6 +537,7 @@ def run_training(
             batch_size=batch_size,
             seed=seed,
             max_completion_length=max_completion_length,
+            grpo_beta=grpo_beta,
             time_budget=time_budget,
             memory_limit_mb=memory_limit_mb,
         )
@@ -552,6 +554,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--seed", type=int, default=0, help="trl backend: training seed (seeded repeats)")
     parser.add_argument(
         "--max-completion-length", type=int, default=512, help="trl grpo: generation cap (256 truncates reasoning -> 0 reward)"
+    )
+    parser.add_argument(
+        "--grpo-beta",
+        type=float,
+        default=0.04,
+        help="trl grpo: KL penalty toward base policy (0.0 = KL-free; nonzero prevents overfitting)",
     )
     parser.add_argument("--time-budget", type=int, default=300)
     parser.add_argument("--memory-limit", type=int, default=16384)
@@ -611,6 +619,7 @@ def main(argv: list[str] | None = None) -> int:
             trl_mode=args.trl_mode,
             seed=args.seed,
             max_completion_length=args.max_completion_length,
+            grpo_beta=args.grpo_beta,
             fine_tune_type=args.fine_tune_type,
             num_layers=args.num_layers,
             backend=args.backend,

--- a/autocontext/src/autocontext/training/autoresearch/trl_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/trl_backend.py
@@ -106,14 +106,19 @@ def build_grpo_config_kwargs(
     # answer. At 256 every completion truncates before the answer, the verifier scores them all
     # 0, reward variance is 0, and GRPO gets no gradient -- RLVR silently learns nothing.
     max_completion_length: int = 512,
-    beta: float = 0.0,
+    # KL penalty toward the reference policy. TRL's default is 0.0 (no KL), which lets a
+    # small-model / short-run RLVR job drift off the base distribution and OVERFIT the train
+    # prompts -- observed directly: train reward climbed while held-out accuracy fell. 0.04
+    # (the DeepSeekMath GRPO value) anchors the policy and is the safer default for the typical
+    # autocontext loop; set 0.0 for the KL-free / R1-Zero-style regime at scale.
+    beta: float = 0.04,
     temperature: float = 1.0,
     num_train_epochs: float = 1.0,
     max_steps: int = -1,
     per_device_train_batch_size: int = 8,
     seed: int = 0,
 ) -> dict[str, Any]:
-    """Kwargs for ``trl.GRPOConfig`` (RLVR). ``beta=0.0`` follows TRL's KL-free default.
+    """Kwargs for ``trl.GRPOConfig`` (RLVR). ``beta`` is the reference-policy KL penalty.
 
     Only widely-stable GRPOConfig fields are passed (e.g. ``max_prompt_length`` is omitted
     -- some TRL versions reject it; the default prompt handling is fine). ``max_steps`` (>0
@@ -217,6 +222,7 @@ def run_trl_training(
     batch_size: int = 0,
     seed: int = 0,
     max_completion_length: int = 512,  # grpo: generation cap (>= task answer length; see build_grpo_config_kwargs)
+    grpo_beta: float = 0.04,  # grpo: KL penalty toward the base policy (0.0 = KL-free; nonzero prevents overfitting)
     register_import: str | None = None,
     time_budget: int = 3600,
     memory_limit_mb: int = 16384,  # noqa: ARG001 - backend-signature parity
@@ -298,6 +304,7 @@ def run_trl_training(
             max_steps=max_steps,
             seed=seed,
             max_completion_length=max_completion_length,
+            beta=grpo_beta,
         )
         if batch_size > 0:
             grpo_kwargs["per_device_train_batch_size"] = batch_size

--- a/autocontext/src/autocontext/training/autoresearch/trl_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/trl_backend.py
@@ -123,7 +123,14 @@ def build_grpo_config_kwargs(
     Only widely-stable GRPOConfig fields are passed (e.g. ``max_prompt_length`` is omitted
     -- some TRL versions reject it; the default prompt handling is fine). ``max_steps`` (>0
     caps total optimizer steps) and ``per_device_train_batch_size`` thread the generic controls.
+
+    ``beta`` must be ``>= 0``: it is a KL *penalty*, so a negative value would reward the policy
+    for drifting off the reference -- the opposite of regularization. The CLI guards this, but so
+    does this lower-level entrypoint because harnesses call ``run_trl_training`` / ``run_training``
+    (which route here) directly. ``beta == 0`` is the valid KL-free / R1-Zero-style opt-out.
     """
+    if beta < 0:
+        raise ValueError(f"GRPO beta (reference-policy KL penalty) must be >= 0; got {beta!r}")
     return {
         "output_dir": output_dir,
         "learning_rate": learning_rate,

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -74,6 +74,7 @@ class TrainingConfig:
     trl_mode: str = "gkd"  # trl backend: gkd (on-policy distillation) | grpo (RLVR)
     seed: int = 0  # trl backend: training seed (for seeded repeats)
     max_completion_length: int = 512  # trl grpo: generation cap (256 truncates reasoning -> 0 reward / no gradient)
+    grpo_beta: float = 0.04  # trl grpo: KL penalty toward base policy (0.0 = KL-free; nonzero prevents overfitting)
     fine_tune_type: str = "lora"  # mlxlm backend: lora | dora | full
     num_layers: int = 8  # mlxlm backend: number of layers to fine-tune
 
@@ -440,6 +441,8 @@ class TrainingRunner:
             command += ["--seed", str(self.config.seed)]
         if self.config.max_completion_length != 512:
             command += ["--max-completion-length", str(self.config.max_completion_length)]
+        if self.config.grpo_beta != 0.04:
+            command += ["--grpo-beta", str(self.config.grpo_beta)]
         if self.config.fine_tune_type != "lora":
             command += ["--fine-tune-type", self.config.fine_tune_type]
         if self.config.num_layers != 8:

--- a/autocontext/tests/test_training_runner.py
+++ b/autocontext/tests/test_training_runner.py
@@ -344,6 +344,25 @@ class TestConstraints:
             runner2._run_experiment_subprocess(0)
         assert "--max-completion-length" not in mock_run2.call_args.args[0]
 
+    def test_experiment_subprocess_passes_grpo_beta_when_overridden(self, tmp_path: Path) -> None:
+        """The GRPO KL penalty must reach the subprocess so `autoctx train` can avoid the beta=0
+        overfitting; the default 0.04 is omitted to keep the command minimal."""
+        cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl", backend="trl", grpo_beta=0.0)
+        (tmp_path / "data.jsonl").write_text("{}\n")
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run:
+            runner._run_experiment_subprocess(0)
+        command = mock_run.call_args.args[0]
+        assert command[command.index("--grpo-beta") + 1] == "0.0"
+
+        # default (0.04) stays off the command line
+        cfg2 = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl", backend="trl")
+        runner2 = TrainingRunner(cfg2, work_dir=tmp_path / "ws2g")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run2:
+            runner2._run_experiment_subprocess(0)
+        assert "--grpo-beta" not in mock_run2.call_args.args[0]
+
     def test_experiment_subprocess_omits_loss_weight_flags_when_uniform(self, tmp_path: Path) -> None:
         cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl")
         (tmp_path / "data.jsonl").write_text("{}\n")

--- a/autocontext/tests/test_trl_backend.py
+++ b/autocontext/tests/test_trl_backend.py
@@ -57,7 +57,7 @@ def test_grpo_config_kwargs_have_generation_and_kl_fields() -> None:
 
     cfg = build_grpo_config_kwargs(output_dir="/tmp/out", num_generations=6)
     assert cfg["num_generations"] == 6
-    assert cfg["beta"] == 0.0  # TRL KL-free default
+    assert cfg["beta"] > 0  # KL penalty on by default (not TRL's KL-free 0.0; see overfitting regression)
     assert "max_completion_length" in cfg
     # max_prompt_length is intentionally NOT passed (some TRL versions reject it).
     assert "max_prompt_length" not in cfg
@@ -71,6 +71,17 @@ def test_grpo_completion_length_defaults_long_enough_for_reasoning() -> None:
 
     assert build_grpo_config_kwargs(output_dir="/o")["max_completion_length"] >= 512
     assert build_grpo_config_kwargs(output_dir="/o", max_completion_length=1024)["max_completion_length"] == 1024
+
+
+def test_grpo_beta_defaults_nonzero_to_prevent_overfitting() -> None:
+    """Regression: beta=0 (no KL penalty) lets small-model RLVR drift off the base distribution
+    and overfit the train prompts (train reward up, held-out down). The default must apply a KL
+    anchor, stay overridable, and still allow the KL-free regime (beta=0)."""
+    from autocontext.training.autoresearch.trl_backend import build_grpo_config_kwargs
+
+    assert build_grpo_config_kwargs(output_dir="/o")["beta"] > 0  # KL anchor on by default
+    assert build_grpo_config_kwargs(output_dir="/o", beta=0.1)["beta"] == 0.1
+    assert build_grpo_config_kwargs(output_dir="/o", beta=0.0)["beta"] == 0.0  # KL-free still possible
 
 
 def test_config_kwargs_thread_max_steps_and_batch_size() -> None:

--- a/autocontext/tests/test_trl_backend.py
+++ b/autocontext/tests/test_trl_backend.py
@@ -84,6 +84,18 @@ def test_grpo_beta_defaults_nonzero_to_prevent_overfitting() -> None:
     assert build_grpo_config_kwargs(output_dir="/o", beta=0.0)["beta"] == 0.0  # KL-free still possible
 
 
+def test_grpo_beta_rejects_negative_in_lower_level_api() -> None:
+    """beta is a KL *penalty*; a negative value rewards drift off the reference -- the opposite
+    of regularization. The CLI guards this, but harnesses call run_trl_training / run_training
+    (which route through build_grpo_config_kwargs) directly, so the invariant lives here too."""
+    import pytest
+
+    from autocontext.training.autoresearch.trl_backend import build_grpo_config_kwargs
+
+    with pytest.raises(ValueError, match="must be >= 0"):
+        build_grpo_config_kwargs(output_dir="/tmp/out", beta=-0.1)
+
+
 def test_config_kwargs_thread_max_steps_and_batch_size() -> None:
     """--train-steps / --batch-size must reach TRL, not be silently dropped."""
     from autocontext.training.autoresearch.trl_backend import build_gkd_config_kwargs, build_grpo_config_kwargs


### PR DESCRIPTION
## What

Loop hardening motivated directly by the GSM8K self-improvement study (Linear AC-787). With the three GRPO bugs fixed, RLVR was finally *functional* — and it **regressed** held-out accuracy (0.63 → 0.58). The diagnosis was unambiguous: **train reward climbed (0.65 → 0.74) while held-out fell**, i.e. the policy overfit the train prompts because `beta=0` (no KL penalty) let it drift off the base distribution.

`beta` existed only in `build_grpo_config_kwargs` (default `0.0`) and was **never threaded through `run_trl_training` or the CLI**, so every GRPO run was silently forced KL-free.

## Change

- **Default `beta` → 0.04** (the DeepSeekMath GRPO value): a KL anchor that prevents the overfitting we measured. `beta=0` still selects the KL-free / R1-Zero-style regime for scale.
- **Exposed end to end:** `--grpo-beta` on `autoctx train` → `TrainingConfig` → runner subprocess → `train.py` → `run_trl_training` → `GRPOConfig`, mirroring the `--max-completion-length` wiring (#1067). The Modal harness calls `run_trl_training` directly, so it now gets the KL anchor by default too.

## Tests
Build default `beta` nonzero + overridable + `0` still allowed; runner forwards `--grpo-beta` when overridden, omits the `0.04` default; updated the stale `beta == 0.0` assertion. ruff + mypy clean.

## Why it matters
This is the single change that turns "RLVR overfits in our stack" into "RLVR is usable in our stack," and it's exactly the next experiment AC-787 recommends (GRPO + KL). A future GRPO retest now runs with regularization by default.