### PR TITLE
AC-786: Document background execution trust boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Yes. Wire `autoctx mcp-serve` (or `bunx autoctx mcp-serve`) into Claude Code, Cu
 - Recursive loop closed end to end on local MLX (train -> auto-serve -> improve): [autocontext/docs/case-study-recursive-loop.md](autocontext/docs/case-study-recursive-loop.md)
 - Sandbox and executor notes: [autocontext/docs/sandbox.md](autocontext/docs/sandbox.md)
 - Persistent host worker: [autocontext/docs/persistent-host.md](autocontext/docs/persistent-host.md)
+- Background execution trust boundaries: [docs/background-execution-trust-boundaries.md](docs/background-execution-trust-boundaries.md)
 - License: [LICENSE](LICENSE)
 
 ## Acknowledgments

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -155,7 +155,7 @@ Run a persistent queue worker beside the API server:
 uv run autoctx worker --poll-interval 5 --concurrency 2
 ```
 
-Stateful persistent providers, such as persistent Pi RPC, run with effective concurrency `1` so one long-lived runtime cannot mix events across tasks.
+Stateful persistent providers, such as persistent Pi RPC, run with effective concurrency `1` so one long-lived runtime cannot mix events across tasks. The persistent-host worker is a single-tenant/trusted-org deployment shape; review [persistent-host trust guidance](docs/persistent-host.md#trust-and-credential-boundary) and the repo-level [background execution trust boundaries](../docs/background-execution-trust-boundaries.md) before exposing it beyond a trusted network or adding SCM/sandbox credentials.
 
 Start the MCP server:
 

--- a/autocontext/docs/persistent-host.md
+++ b/autocontext/docs/persistent-host.md
@@ -24,6 +24,14 @@ autoctx worker --poll-interval 5 --concurrency 2
 
 If the selected provider/runtime is stateful and persistent, for example persistent Pi RPC, worker concurrency is forced to `1`. Use non-persistent provider instances or a hosted storage/runtime adapter when you need true parallel task execution.
 
+## Trust and Credential Boundary
+
+This persistent-host shape is single-tenant or trusted-org infrastructure. Treat the API process, worker process, SQLite DB, runs root, knowledge root, mounted repository, service account, and environment file as one trust boundary. It is suitable for a developer machine, a CI worker, or one trusted organization; it is not a hosted multi-tenant SaaS control plane.
+
+If `autoctx serve` binds beyond loopback, put it behind TLS, authentication, and authorization before exposing it to other users. Provider keys, SCM credentials, sandbox API keys, and webhook secrets may be supplied through the host environment for this single-tenant shape, but they must not be baked into images or written into prompts, runtime-session timelines, background-session summaries, lifecycle hook payloads, or outcome metadata.
+
+Shared GitHub App credentials or bot tokens for branch/PR workflows are acceptable only inside one tenant or trusted organization with explicit admin consent. Cross-customer hosted PR creation requires a product adapter with per-tenant GitHub App installations or user OAuth tokens, scoped credential brokering, audit, and revocation. See [Background execution trust boundaries and credential model](../../docs/background-execution-trust-boundaries.md) before claiming hosted or multi-tenant safety.
+
 ## Durable State
 
 Keep these paths on persistent storage:
@@ -121,7 +129,7 @@ volumes:
   autoctx-state:
 ```
 
-The image build, reverse proxy, auth, TLS, and secret distribution are deployment-specific. Do not bake provider API keys into images.
+The image build, reverse proxy, auth, TLS, and secret distribution are deployment-specific. Do not bake provider API keys, SCM tokens, GitHub App private keys, webhook secrets, or sandbox API keys into images.
 
 ## Storage Adapter Contract
 

--- a/autocontext/docs/sandbox.md
+++ b/autocontext/docs/sandbox.md
@@ -25,13 +25,13 @@ The public OSS contract for a future Gondolin adapter is intentionally narrow:
 - Python: implement `GondolinBackend` from `autocontext.execution.executors.gondolin_contract` behind the existing `ExecutionEngine` boundary.
 - TypeScript: implement `GondolinBackend` from `autoctx` and start from `createDefaultGondolinSandboxPolicy()`.
 
-The contract carries policy and secret references, not secret values. Hosted fleet orchestration, tenant scheduling, policy UI, billing, and managed audit retention remain deployment concerns outside this OSS boundary.
+The contract carries policy and secret references, not secret values. Hosted fleet orchestration, tenant scheduling, policy UI, billing, and managed audit retention remain deployment concerns outside this OSS boundary. A deployment is not multi-tenant safe merely because it uses a remote sandbox; it also needs tenant-aware credential brokering, per-tenant filesystem/network isolation, egress policy, audit, retention, and abuse controls. See [Background execution trust boundaries and credential model](../../docs/background-execution-trust-boundaries.md).
 
 ## Relevant Environment Variables
 
 - `AUTOCONTEXT_EXECUTOR_MODE` (`local`, `primeintellect`, `monty`, `ssh`; `gondolin` is reserved/fail-closed)
 - `AUTOCONTEXT_PRIMEINTELLECT_API_BASE`
-- `AUTOCONTEXT_PRIMEINTELLECT_API_KEY`
+- `AUTOCONTEXT_PRIMEINTELLECT_API_KEY` (deployment secret; never store in prompts, traces, runtime-session events, background-session summaries, lifecycle hook payloads, or artifact metadata)
 - `AUTOCONTEXT_PRIMEINTELLECT_DOCKER_IMAGE`
 - `AUTOCONTEXT_PRIMEINTELLECT_CPU_CORES`
 - `AUTOCONTEXT_PRIMEINTELLECT_MEMORY_GB`

--- a/autocontext/src/autocontext/session/background_session_read_model.py
+++ b/autocontext/src/autocontext/session/background_session_read_model.py
@@ -15,6 +15,39 @@ TaskQueueRowLike: TypeAlias = Mapping[str, Any]
 RunRowLike: TypeAlias = Mapping[str, Any]
 ArtifactLike: TypeAlias = Mapping[str, Any]
 
+REDACTED_TRIGGER_VALUE = "[redacted]"
+_SENSITIVE_TRIGGER_KEY_WORDS = frozenset(
+    {
+        "auth",
+        "apikey",
+        "authorization",
+        "bearer",
+        "credential",
+        "credentials",
+        "password",
+        "passwd",
+        "privatekey",
+        "secret",
+        "token",
+    }
+)
+_COMPOUND_SENSITIVE_TRIGGER_KEY_WORDS = (
+    ("api", "key"),
+    ("private", "key"),
+    ("access", "token"),
+    ("refresh", "token"),
+)
+_SECRET_VALUE_MARKERS = (
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "ghr_",
+    "github_pat_",
+    "sk-",
+    "bearer ",
+)
+
 
 def build_background_session_summary(
     *,
@@ -114,8 +147,59 @@ def _sanitize_record(record: Mapping[str, Any]) -> dict[str, str | int | bool]:
     clean: dict[str, str | int | bool] = {}
     for key, value in record.items():
         if isinstance(key, str) and isinstance(value, str | int | bool):
-            clean[key] = value
+            clean[key] = REDACTED_TRIGGER_VALUE if _is_sensitive_trigger_entry(key, value) else value
     return clean
+
+
+def _is_sensitive_trigger_entry(key: str, value: str | int | bool) -> bool:
+    return _is_sensitive_trigger_key(key) or (isinstance(value, str) and _looks_like_secret_value(value))
+
+
+def _is_sensitive_trigger_key(key: str) -> bool:
+    words = _trigger_key_words(key)
+    if any(word in _SENSITIVE_TRIGGER_KEY_WORDS for word in words):
+        return True
+    return any(_contains_word_sequence(words, sequence) for sequence in _COMPOUND_SENSITIVE_TRIGGER_KEY_WORDS)
+
+
+def _trigger_key_words(key: str) -> list[str]:
+    words: list[str] = []
+    current: list[str] = []
+    previous = ""
+    for character in key:
+        if not character.isalnum():
+            _append_trigger_key_word(words, current)
+        elif current and character.isupper() and (previous.islower() or previous.isdigit()):
+            _append_trigger_key_word(words, current)
+            current.append(character)
+        else:
+            current.append(character)
+        previous = character
+    _append_trigger_key_word(words, current)
+    return words
+
+
+def _append_trigger_key_word(words: list[str], current: list[str]) -> None:
+    if current:
+        words.append("".join(current).lower())
+        current.clear()
+
+
+def _contains_word_sequence(words: Sequence[str], sequence: Sequence[str]) -> bool:
+    if len(sequence) > len(words):
+        return False
+    end = len(words) - len(sequence) + 1
+    for index in range(end):
+        if list(words[index : index + len(sequence)]) == list(sequence):
+            return True
+    return False
+
+
+def _looks_like_secret_value(value: str) -> bool:
+    lower_value = value.lower()
+    return any(marker in lower_value for marker in _SECRET_VALUE_MARKERS) or (
+        "-----begin " in lower_value and "private key-----" in lower_value
+    )
 
 
 def _normalize_status(raw: str, *, has_runtime_session: bool) -> BackgroundSessionStatus:

--- a/autocontext/tests/test_background_session_api.py
+++ b/autocontext/tests/test_background_session_api.py
@@ -26,7 +26,18 @@ def _make_store(tmp_path: Path) -> SQLiteStore:
 def _persist_background_sessions(db_path: Path) -> None:
     app_store = SQLiteStore(db_path)
     app_store.create_run("test-run-1", "grid_ctf", 1, "local")
-    app_store.enqueue_task("task-1", "autoctx run grid_ctf")
+    app_store.enqueue_task(
+        "task-1",
+        "autoctx run grid_ctf",
+        config={
+            "trigger": {
+                "type": "github_webhook",
+                "actor": "octocat",
+                "token": "ghp_SECRET_VALUE",
+                "apiKey": "sk-SECRET_VALUE",
+            }
+        },
+    )
     app_store.complete_task("task-1", 1.0, "ok", 1, True)
     app_store.enqueue_task("queued-1", "autoctx run queued")
 
@@ -165,6 +176,12 @@ def test_cockpit_reads_background_session_detail(cockpit_env: dict[str, Any]) ->
     assert body["summary"]["session_id"] == "run:test-run-1:runtime"
     assert body["summary"]["status"] == "completed"
     assert body["child_sessions"][0]["session_id"] == "task:run:test-run-1:runtime:child-1"
+    assert body["trigger"] == {
+        "type": "github_webhook",
+        "actor": "octocat",
+        "token": "[redacted]",
+        "apiKey": "[redacted]",
+    }
     assert body["normalized_events"] == [
         {
             "event_id": body["normalized_events"][0]["event_id"],

--- a/autocontext/tests/test_background_session_read_model.py
+++ b/autocontext/tests/test_background_session_read_model.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
-from autocontext.session.background_session_read_model import (
+from autocontext.session.background_session_read_model import (  # type: ignore[import-untyped]
     background_session_url,
     build_background_session_detail,
     build_background_session_summary,
@@ -177,6 +178,46 @@ def test_background_session_detail_sanitizes_artifacts_and_child_summaries() -> 
     assert detail["child_sessions"][0]["parent_session_id"] == "run:run-123:runtime"
     assert detail["child_sessions"][0]["status"] == "completed"
     assert detail["trigger"] == {"type": "manual", "actor": "operator"}
+    assert "SECRET_VALUE" not in str(detail)
+
+
+def test_background_session_detail_redacts_sensitive_trigger_metadata() -> None:
+    detail = build_background_session_detail(
+        task=_task(
+            config_json=json.dumps(
+                {
+                    "trigger": {
+                        "type": "github_webhook",
+                        "actor": "octocat",
+                        "retry": 2,
+                        "dry_run": False,
+                        "token": "ghp_SECRET_VALUE",
+                        "github_token": "ghp_SECRET_VALUE",
+                        "apiKey": "sk-SECRET_VALUE",
+                        "clientSecret": "SECRET_VALUE",
+                        "Authorization": "Bearer SECRET_VALUE",
+                        "password": "SECRET_VALUE",
+                        "private_key": "-----BEGIN PRIVATE KEY-----SECRET_VALUE",
+                        "headers": {"authorization": "Bearer SECRET_VALUE"},
+                    }
+                }
+            )
+        )
+    )
+
+    assert detail["trigger"] == {
+        "type": "github_webhook",
+        "actor": "octocat",
+        "retry": 2,
+        "dry_run": False,
+        "token": "[redacted]",
+        "github_token": "[redacted]",
+        "apiKey": "[redacted]",
+        "clientSecret": "[redacted]",
+        "Authorization": "[redacted]",
+        "password": "[redacted]",
+        "private_key": "[redacted]",
+    }
     assert "SECRET_VALUE" not in str(detail)
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - [Browser exploration contract](browser-exploration-contract.md)
 - [OpenTelemetry bridge](opentelemetry-bridge.md)
 - [Background session domain and parity contract](background-session-domain.md)
+- [Background execution trust boundaries and credential model](background-execution-trust-boundaries.md)
 
 ## Execution Surfaces (0.3.0)
 

--- a/docs/background-execution-trust-boundaries.md
+++ b/docs/background-execution-trust-boundaries.md
@@ -1,0 +1,103 @@
+# Background Execution Trust Boundaries and Credential Model
+
+This document records the security model for background execution before the hosted product surface grows beyond the current persistent-host worker. It is intentionally candid: the Apache-2.0 repository provides local and self-hosted contracts, not a hosted multi-tenant control plane.
+
+## Scope and non-goals
+
+The open-source repository owns:
+
+- local/self-hosted `serve + worker` deployment guidance;
+- background-session read models, lifecycle hook contracts, normalized event vocabulary, and outcome schemas;
+- adapter interfaces that can carry policy names, secret references, and artifact references without embedding secret values.
+
+The hosted/proprietary product or deployment adapter owns:
+
+- tenant scheduling, organization policy UI, billing, and hosted audit retention;
+- credential brokering for SCM, sandbox providers, OAuth, and GitHub App installations;
+- managed sandbox fleets, prebuild/warming orchestration, egress policy, and fleet routing;
+- hosted cockpit UX and websocket fan-out with tenant-aware authorization.
+
+The OSS package must not claim multi-tenant safety unless the blockers in this document are satisfied by a concrete deployment.
+
+## Deployment safety matrix
+
+| Deployment shape | Trust classification | Safe for | Not safe for | Notes |
+| --- | --- | --- | --- | --- |
+| Developer laptop or CI job running one `autoctx` process | Single-tenant local | One operator or one CI trust boundary | Untrusted users, public web access | Provider keys and repo credentials come from that operator's environment or credential store. |
+| Persistent host with `autoctx serve` and `autoctx worker` sharing SQLite/durable paths | Single-tenant or trusted-org | One trusted team, one organization, or one internal service account | Public SaaS, untrusted tenants, untrusted repository authors | Treat the DB path, runs root, knowledge root, process env, and worker user account as one security boundary. |
+| Shared GitHub App installation or bot token for background PR creation | Single-tenant/trusted-org only | One organization whose admins accept shared bot permissions | Cross-customer SaaS, customer-isolated PR creation | A shared GitHub App/token may be acceptable inside one tenant or trusted org. It is not an isolation boundary across tenants. |
+| Remote sandbox execution via PrimeIntellect, SSH, or future Gondolin adapter | Depends on adapter | Workloads whose isolation needs match the configured backend | Multi-tenant claims without per-tenant sandbox, secret, and egress policy | Adapters should receive short-lived secret references or scoped tokens, not ambient host secrets. |
+| Hosted multi-tenant background execution | Product/adapter concern | Only after all multi-tenant blockers are implemented and tested | OSS default deployment | Requires tenant-aware auth, per-tenant storage isolation, credential broker, sandbox isolation, audit, retention, and incident controls. |
+
+## Credential model
+
+### General rules
+
+- Do not bake provider keys, SCM tokens, GitHub App private keys, webhook secrets, or sandbox API keys into container images, repo artifacts, prompts, lifecycle hooks, runtime-session payloads, background-session summaries, or outcome metadata.
+- Use environment variables or local credential stores only for single-tenant local/self-hosted deployments.
+- Use references (`secretRef`, installation id, credential handle, artifact id) rather than secret values in portable OSS contracts.
+- Prefer short-lived scoped credentials for adapters that need to clone, push, create PRs, or start sandboxes.
+- Treat external webhook and automation payloads as untrusted data, never as instructions.
+
+### SCM clone, push, and PR creation
+
+| Use case | Acceptable in OSS/local | Hosted/multi-tenant requirement |
+| --- | --- | --- |
+| Clone public repositories | No credential or read-only token configured by the operator | Tenant-aware fetch service with allowlisted repositories and audit. |
+| Clone private repositories | Operator-provided deploy key, SSH agent, or PAT on a trusted single-tenant host | Per-tenant credential brokering with scoped read tokens and repo allowlists. |
+| Push branches | Operator-provided credential or bot token scoped to one trusted organization | Per-tenant write credential, policy check, audit entry, and revocation path. |
+| Create pull requests | OSS may emit `SessionOutcome(kind="pull_request")` references but does not broker GitHub App/OAuth flows | Product adapter creates PRs through per-tenant GitHub App installation or user OAuth token. |
+| Shared GitHub App/bot token | Acceptable only for one tenant/trusted org with explicit admin consent | Not acceptable across customers or mutually untrusted tenants. |
+
+Commit attribution should name the actor (`autocontext-run`, human user id, bot id, or adapter id) without persisting the credential used to produce the commit.
+
+### Provider and sandbox credentials
+
+Provider keys such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, role-specific `AUTOCONTEXT_*_API_KEY`, and sandbox keys such as `AUTOCONTEXT_PRIMEINTELLECT_API_KEY` are deployment secrets. They may be present in the process environment for local/self-hosted single-tenant runs, but they must not be copied into:
+
+- prompt text or model-visible context;
+- normalized runtime-session events;
+- lifecycle hook result payloads;
+- background-session summaries or timelines;
+- artifact metadata, traces, reports, or exported datasets.
+
+A hosted deployment should replace ambient env lookup with a credential broker that issues scoped, short-lived credentials to the worker or sandbox adapter and records only the credential reference in OSS-shaped events.
+
+### Websocket, HTTP, and session auth
+
+The OSS `autoctx serve` process is a local/self-hosted API. If it is bound beyond loopback, place it behind TLS, authentication, and authorization appropriate for a trusted single tenant. Hosted cockpit websockets and session APIs require tenant-aware identity, session membership checks, rate limiting, and audit logging; those are product concerns and are not provided by the OSS worker contract.
+
+## Redaction expectations
+
+The background-session surfaces must be safe to show in operator dashboards without secret values:
+
+- `BackgroundSessionSummary` and `BackgroundSessionDetail.summary` may include ids, statuses, counts, titles, result URLs, timestamps, and sanitized scalar metadata; they must not include raw prompts, stdout, stderr, full webhook payloads, env maps, or secret values.
+- Normalized runtime-session timelines should redact common secret-bearing keys (`authorization`, `cookie`, `api_key`, `token`, `secret`, `password`, provider-specific key names) before rendering.
+- Lifecycle hook events may record hook name, phase, status, timeout, cwd/argv shape, and redaction metadata; they must not copy ambient process env or hook-provided secret values into event payloads.
+- Session outcomes may store stable refs such as branch, commit SHA, PR URL, report path, trace id, dataset id, and verification result id; outcome metadata must remain sanitized and JSON-scalar.
+- Raw runtime logs and artifacts may contain more evidence than summaries. Hosted deployments must protect raw reads with tenant-aware authorization and retention policy.
+
+## Multi-tenant support blockers
+
+Do not describe a deployment as multi-tenant safe until it has all of the following:
+
+1. tenant-aware authentication and authorization for HTTP, websocket, MCP, and worker control paths;
+2. storage isolation for runs, queue rows, runtime-session logs, artifacts, and knowledge roots, with migration tests;
+3. per-tenant credential brokering with scoped, revocable, auditable tokens;
+4. sandbox isolation for filesystem, process, network, egress, and mounted secrets;
+5. SCM policy that prevents one tenant's repository credential or GitHub App installation from acting on another tenant's repository;
+6. webhook signature verification, replay protection, idempotency, and tenant routing before enqueue;
+7. secret redaction tests for summaries, timelines, lifecycle hooks, outcomes, traces, reports, and exported datasets;
+8. audit logs for credential use, worker claims, sandbox lifecycle, PR creation, and administrator actions;
+9. retention/deletion policy for tenant data and artifacts;
+10. abuse controls: rate limits, quotas, cancellation, and incident-response runbooks.
+
+Until those blockers are implemented by a product/adapter layer, the OSS background-session contracts should be documented as portable single-tenant/trusted-org building blocks.
+
+## Review checklist for future background execution PRs
+
+- Does the PR add secret values to a public JSON contract, runtime event, timeline, artifact, or docs example?
+- Does it imply hosted multi-tenant safety without naming the required adapter/product controls?
+- Does it distinguish shared single-tenant GitHub App credentials from per-tenant credential brokering?
+- Does it keep lifecycle hook env explicit and avoid inheriting ambient process secrets?
+- Does it add or preserve tests for redaction and malformed credential-bearing payloads?

--- a/docs/background-session-domain.md
+++ b/docs/background-session-domain.md
@@ -6,6 +6,8 @@ This document is the Layer-0 domain model for the Open-Inspect-inspired backgrou
 
 Autocontext should borrow background-execution primitives only where they make recursive harness runs unattended, inspectable, replayable, and portable. The open repository owns stable contracts, local/self-hosted behavior, and read models. A separate proprietary product may own hosted scheduling, tenant isolation, credential brokering, billing, managed sandbox fleets, and hosted cockpit UX.
 
+The detailed security model lives in [Background execution trust boundaries and credential model](background-execution-trust-boundaries.md). In short: OSS background-session contracts are single-tenant/trusted-org building blocks, not a hosted multi-tenant safety claim.
+
 ## Bounded contexts
 
 | Context                       | Open-source responsibility                                                                                              | Proprietary/hosted responsibility                                                      |
@@ -91,6 +93,13 @@ The OSS lifecycle slice defines adapter-neutral setup/start hooks only:
 | `start` | `fail_session`         | Required runtime-start boundary when configured. Failures/timeouts are strict and should fail the session unless explicitly configured otherwise.   |
 
 Hook definitions are pure contracts: command argv, optional cwd, timeout, failure policy, and explicit env. Executors receive deterministic `AUTOCTX_*` context variables (`AUTOCTX_BACKGROUND_SESSION_ID`, `AUTOCTX_SESSION_ID`, `AUTOCTX_RUN_ID`, `AUTOCTX_TASK_ID`, `AUTOCTX_WORKER_ID`, `AUTOCTX_HOOK_NAME`) plus hook-provided env. Implementations must not copy ambient process secrets into hook env or normalized lifecycle events. Hosted secret brokering, repo image prebuilds, warming fleets, and sandbox routing remain proprietary/product concerns.
+
+## Trust-boundary invariants
+
+- `BackgroundSessionSummary`, `BackgroundSessionDetail`, normalized timelines, lifecycle events, and outcome metadata must carry ids, refs, counts, status, timestamps, and sanitized scalar metadata rather than secret values.
+- Hosted credential brokering for SCM, GitHub App/OAuth PR creation, sandbox auth, and websocket/session auth is a product/adapter concern, not a core OSS default.
+- Shared GitHub App credentials or bot tokens are acceptable only inside one tenant or trusted organization with explicit admin consent; they are not safe across mutually untrusted tenants.
+- Multi-tenant support claims are blocked until tenant-aware auth, storage isolation, credential brokering, sandbox isolation, SCM policy, webhook verification, audit, retention, and abuse controls are implemented by the hosting layer.
 
 ## Current open API surface
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -320,7 +320,7 @@ autoctx worker --poll-interval 5 --concurrency 2
 autoctx status <run-id>
 ```
 
-Stateful persistent providers, including persistent Pi RPC, run with effective worker concurrency `1` to keep long-lived runtime sessions isolated.
+Stateful persistent providers, including persistent Pi RPC, run with effective worker concurrency `1` to keep long-lived runtime sessions isolated. The worker/API shape is single-tenant or trusted-org infrastructure, not a hosted multi-tenant control plane; review the repo-level [background execution trust boundaries](../docs/background-execution-trust-boundaries.md) before exposing it beyond a trusted network or adding SCM/sandbox credentials.
 
 ## Contract Probes
 
@@ -766,7 +766,7 @@ record under `.autocontext/harness-proposals/`.
 import { createProvider, LLMJudge, ImprovementLoop, SimpleAgentTask } from "autoctx";
 
 // One-shot evaluation
-const provider = createProvider({ providerType: "anthropic", apiKey: "sk-ant-..." });
+const provider = createProvider({ providerType: "anthropic", apiKey: process.env.ANTHROPIC_API_KEY ?? "" });
 const judge = new LLMJudge({ provider, rubric: "Score clarity and correctness." });
 const result = await judge.evaluate({
   taskPrompt: "Explain binary search.",

--- a/ts/src/session/background-session-read-model.ts
+++ b/ts/src/session/background-session-read-model.ts
@@ -79,6 +79,34 @@ type NormalizedBackgroundSessionSource = {
   childSessions: RuntimeSessionEventLog[];
 };
 
+const REDACTED_TRIGGER_VALUE = "[redacted]";
+const SENSITIVE_TRIGGER_KEY_WORDS = new Set([
+  "auth",
+  "authorization",
+  "bearer",
+  "credential",
+  "credentials",
+  "password",
+  "passwd",
+  "secret",
+  "token",
+]);
+const COMPOUND_SENSITIVE_TRIGGER_KEY_WORDS = [
+  ["api", "key"],
+  ["private", "key"],
+  ["access", "token"],
+  ["refresh", "token"],
+] as const;
+const SECRET_VALUE_PATTERNS = [
+  /gh[pousr]_[A-Za-z0-9_]+/,
+  /github_pat_[A-Za-z0-9_]+/,
+  /\bsk-[A-Za-z0-9_-]{6,}\b/,
+  /\bbearer\s+[A-Za-z0-9._~+/=-]+/i,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+] as const;
+const CAMEL_CASE_BOUNDARY_PATTERN = /([a-z0-9])([A-Z])/g;
+const TRIGGER_KEY_WORD_PATTERN = /[^A-Za-z0-9]+/;
+
 export function buildBackgroundSessionSummary(
   source: BackgroundSessionSource,
 ): BackgroundSessionSummary {
@@ -225,11 +253,59 @@ function parseRecordJson(json: string): Record<string, unknown> {
 function sanitizeRecord(record: Record<string, unknown>): Record<string, unknown> {
   const clean: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {
-    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-      clean[key] = value;
+    if (isScalarTriggerValue(value)) {
+      clean[key] = isSensitiveTriggerEntry(key, value) ? REDACTED_TRIGGER_VALUE : value;
     }
   }
   return clean;
+}
+
+function isScalarTriggerValue(value: unknown): value is string | number | boolean {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+function isSensitiveTriggerEntry(key: string, value: string | number | boolean): boolean {
+  return isSensitiveTriggerKey(key) || (typeof value === "string" && looksLikeSecretValue(value));
+}
+
+function isSensitiveTriggerKey(key: string): boolean {
+  const words = triggerKeyWords(key);
+  if (words.some((word) => SENSITIVE_TRIGGER_KEY_WORDS.has(word))) {
+    return true;
+  }
+  return COMPOUND_SENSITIVE_TRIGGER_KEY_WORDS.some((sequence) => containsWordSequence(words, sequence));
+}
+
+function triggerKeyWords(key: string): string[] {
+  return key
+    .replace(CAMEL_CASE_BOUNDARY_PATTERN, "$1 $2")
+    .split(TRIGGER_KEY_WORD_PATTERN)
+    .filter(Boolean)
+    .map((word) => word.toLowerCase());
+}
+
+function containsWordSequence(words: readonly string[], sequence: readonly string[]): boolean {
+  if (sequence.length > words.length) {
+    return false;
+  }
+  const lastStart = words.length - sequence.length;
+  for (let index = 0; index <= lastStart; index += 1) {
+    let matches = true;
+    for (let offset = 0; offset < sequence.length; offset += 1) {
+      if (words[index + offset] !== sequence[offset]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function looksLikeSecretValue(value: string): boolean {
+  return SECRET_VALUE_PATTERNS.some((pattern) => pattern.test(value));
 }
 
 function readMetadataString(

--- a/ts/tests/background-session-api.test.ts
+++ b/ts/tests/background-session-api.test.ts
@@ -162,8 +162,18 @@ describe("background session HTTP API routes", () => {
   it("reads a detail view with child summaries and normalized events", () => {
     const load = vi.fn((sessionId: string) => createLog(sessionId));
     const listChildren = vi.fn(() => [createChildLog()]);
+    const task = createTask("task-abc", "running", "autoctx run support_triage");
+    task.config_json = JSON.stringify({
+      trigger: {
+        type: "github_webhook",
+        actor: "octocat",
+        token: "ghp_SECRET_VALUE",
+        apiKey: "sk-SECRET_VALUE",
+      },
+    });
     const api = buildBackgroundSessionApiRoutes({
       openStore: () => ({ list: vi.fn(), load, listChildren }),
+      openSourceStore: () => ({ getTask: vi.fn(() => task) }),
     });
 
     const response = api.getBySessionId("run:abc:runtime");
@@ -178,6 +188,12 @@ describe("background session HTTP API routes", () => {
         status: "completed",
       }),
     ]);
+    expect(body.trigger).toEqual({
+      type: "github_webhook",
+      actor: "octocat",
+      token: "[redacted]",
+      apiKey: "[redacted]",
+    });
     expect(body.normalized_events).toEqual([
       expect.objectContaining({ event: "prompt_started", source_event_type: "prompt_submitted" }),
     ]);

--- a/ts/tests/background-session-read-model.test.ts
+++ b/ts/tests/background-session-read-model.test.ts
@@ -193,6 +193,44 @@ describe("background session read model", () => {
     expect(JSON.stringify(detail)).not.toContain("SECRET_VALUE");
   });
 
+  it("redacts sensitive trigger metadata from detail views", () => {
+    const detail = buildBackgroundSessionDetail({
+      task: createTask({
+        config_json: JSON.stringify({
+          trigger: {
+            type: "github_webhook",
+            actor: "octocat",
+            retry: 2,
+            dry_run: false,
+            token: "ghp_SECRET_VALUE",
+            github_token: "ghp_SECRET_VALUE",
+            apiKey: "sk-SECRET_VALUE",
+            clientSecret: "SECRET_VALUE",
+            Authorization: "Bearer SECRET_VALUE",
+            password: "SECRET_VALUE",
+            private_key: "-----BEGIN PRIVATE KEY-----SECRET_VALUE",
+            headers: { authorization: "Bearer SECRET_VALUE" },
+          },
+        }),
+      }),
+    });
+
+    expect(detail.trigger).toEqual({
+      type: "github_webhook",
+      actor: "octocat",
+      retry: 2,
+      dry_run: false,
+      token: "[redacted]",
+      github_token: "[redacted]",
+      apiKey: "[redacted]",
+      clientSecret: "[redacted]",
+      Authorization: "[redacted]",
+      password: "[redacted]",
+      private_key: "[redacted]",
+    });
+    expect(JSON.stringify(detail)).not.toContain("SECRET_VALUE");
+  });
+
   it("uses shared URL helpers for encoded background and runtime session links", () => {
     expect(backgroundSessionUrl("run:run-123:runtime")).toBe(
       "/api/cockpit/background-sessions/run%3Arun-123%3Aruntime",


### PR DESCRIPTION
## Summary
- Add a public trust-boundary and credential-model guide for background execution.
- Clarify single-tenant/trusted-org versus hosted multi-tenant safety claims.
- Document credential patterns for SCM, PR creation, sandbox auth, websocket/session auth, and repository secrets.
- Update persistent-host, sandbox, background-session, Python README, TypeScript README, and docs index links.

## Key points
- Hosted credential brokering remains a product/adapter concern, not a core OSS default.
- Shared GitHub App/bot credentials are acceptable only inside one tenant/trusted org, not across untrusted tenants.
- Background-session summaries, timelines, lifecycle events, and outcome metadata must use ids/refs/sanitized metadata rather than secret values.
- Multi-tenant support claims are blocked on authz, storage isolation, credential brokering, sandbox isolation, webhook verification, audit, retention, and abuse controls.

## Checks
- git diff --check origin/main...HEAD
- Verified referenced docs paths exist
- rg spot-check for multi-tenant/GitHub App/credential/secret coverage

Linear: AC-786