### PR TITLE
AC-783 Represent background sub-tasks as child runtime sessions

### DIFF
--- a/autocontext/src/autocontext/server/background_session_api.py
+++ b/autocontext/src/autocontext/server/background_session_api.py
@@ -118,8 +118,7 @@ def list_background_sessions(request: Request, limit: int = 50) -> dict[str, Any
         task_index = {str(task["id"]): task for task in tasks if isinstance(task.get("id"), str)}
         runtime_task_ids = {runtime_session.task_id for runtime_session in runtime_sessions if runtime_session.task_id}
         summaries = [
-            _background_session_summary(runtime_store, runtime_session, store, task_index)
-            for runtime_session in runtime_sessions
+            _background_session_summary(runtime_store, runtime_session, store, task_index) for runtime_session in runtime_sessions
         ]
         summaries.extend(
             build_background_session_summary(task=task)
@@ -143,14 +142,15 @@ def get_background_session(session_id: str, request: Request) -> dict[str, Any]:
         log = read_runtime_session_by_id(runtime_store, clean_session_id)
         if log is not None:
             task = _task_for_runtime_session(store, log)
+            child_sessions = runtime_store.list_children(log.session_id)
             return {
                 **build_background_session_detail(
                     runtime_session=log,
                     task=task,
                     run=_run_for_runtime_session(store, log, task),
-                    child_sessions=runtime_store.list_children(log.session_id),
+                    child_sessions=child_sessions,
                 ),
-                "normalized_events": normalize_background_session_timeline(log),
+                "normalized_events": normalize_background_session_timeline(log, child_logs=child_sessions),
             }
         task_id = _task_id_from_background_session_id(clean_session_id)
         task = store.get_task(task_id) if task_id else None

--- a/autocontext/src/autocontext/session/__init__.py
+++ b/autocontext/src/autocontext/session/__init__.py
@@ -90,7 +90,9 @@ from autocontext.session.runtime_events import (
 )
 from autocontext.session.runtime_grant_events import create_runtime_session_grant_event_sink
 from autocontext.session.runtime_session import (
+    DEFAULT_CHILD_TASK_MAX_CONCURRENT,
     DEFAULT_CHILD_TASK_MAX_DEPTH,
+    RuntimeChildSessionCancellation,
     RuntimeChildTaskHandlerInput,
     RuntimeChildTaskHandlerOutput,
     RuntimeChildTaskResult,
@@ -154,6 +156,7 @@ __all__ = [
     "NormalizedSessionEvent",
     "NormalizedSessionEventName",
     "NormalizedSessionEventStatus",
+    "DEFAULT_CHILD_TASK_MAX_CONCURRENT",
     "DEFAULT_CHILD_TASK_MAX_DEPTH",
     "RUNTIME_CONTEXT_LAYER_KEYS",
     "RUNTIME_CONTEXT_LAYERS",
@@ -162,6 +165,7 @@ __all__ = [
     "SessionOutcomeKind",
     "SessionOutcomeMetadataValue",
     "SessionOutcomeStatus",
+    "RuntimeChildSessionCancellation",
     "RuntimeChildTaskHandlerInput",
     "RuntimeChildTaskHandlerOutput",
     "RuntimeChildTaskResult",

--- a/autocontext/src/autocontext/session/background_session_events.py
+++ b/autocontext/src/autocontext/session/background_session_events.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal, TypeAlias
 
 from autocontext.session.runtime_events import RuntimeSessionEvent, RuntimeSessionEventLog
@@ -23,8 +23,18 @@ NormalizedSessionEventSummaryValue: TypeAlias = str | int | float | bool
 NormalizedSessionEvent: TypeAlias = dict[str, Any]
 
 
-def normalize_background_session_timeline(log: RuntimeSessionEventLog) -> list[NormalizedSessionEvent]:
-    return [normalize_runtime_session_event(event) for event in sorted(log.events, key=lambda event: event.sequence)]
+def normalize_background_session_timeline(
+    log: RuntimeSessionEventLog,
+    *,
+    child_logs: Sequence[RuntimeSessionEventLog] | None = None,
+) -> list[NormalizedSessionEvent]:
+    events = [normalize_runtime_session_event(event) for event in sorted(log.events, key=lambda event: event.sequence)]
+    for child_log in child_logs or []:
+        events.extend(
+            _with_child_lineage(normalize_runtime_session_event(event), child_log)
+            for event in sorted(child_log.events, key=lambda event: event.sequence)
+        )
+    return sorted(events, key=lambda event: (str(event["ts"]), str(event["session_id"]), int(event["sequence"])))
 
 
 def normalize_runtime_session_event(event: RuntimeSessionEvent) -> NormalizedSessionEvent:
@@ -40,7 +50,7 @@ def normalize_runtime_session_event(event: RuntimeSessionEvent) -> NormalizedSes
         return _base_event(
             event,
             normalized_event="runtime_event",
-            status="failed" if _has_failure_payload(event.payload) else "completed",
+            status=_runtime_action_status(event.payload, "completed"),
             title="Assistant message",
             payload_summary=_pick_payload(event.payload, {"request_id": "requestId", "role": "role"}),
         )
@@ -72,12 +82,15 @@ def normalize_runtime_session_event(event: RuntimeSessionEvent) -> NormalizedSes
             ),
         )
     if event.event_type == "child_task_completed":
+        canceled = _is_canceled_payload(event.payload)
         failed = event.payload.get("isError") is True
+        status: NormalizedSessionEventStatus = "canceled" if canceled else "failed" if failed else "completed"
+        title = "Child session canceled" if canceled else "Child session failed" if failed else "Child session completed"
         return _base_event(
             event,
             normalized_event="session_status",
-            status="failed" if failed else "completed",
-            title="Child session failed" if failed else "Child session completed",
+            status=status,
+            title=title,
             payload_summary=_pick_payload(event.payload, {"task_id": "taskId"}),
         )
     return _base_event(
@@ -189,6 +202,24 @@ def _base_event(
     }
 
 
+def _with_child_lineage(
+    event: NormalizedSessionEvent,
+    child_log: RuntimeSessionEventLog,
+) -> NormalizedSessionEvent:
+    payload_summary = dict(event["payload_summary"])
+    payload_summary.update(
+        _sanitize_summary(
+            {
+                "child_session_id": child_log.session_id,
+                "parent_session_id": child_log.parent_session_id,
+                "task_id": child_log.task_id,
+                "worker_id": child_log.worker_id,
+            }
+        )
+    )
+    return {**event, "payload_summary": payload_summary}
+
+
 def _pick_payload(
     payload: Mapping[str, Any],
     mapping: Mapping[str, str],
@@ -213,11 +244,17 @@ def _runtime_action_status(
     payload: Mapping[str, Any],
     default_status: NormalizedSessionEventStatus,
 ) -> NormalizedSessionEventStatus:
+    if _is_canceled_payload(payload):
+        return "canceled"
     if _has_failure_payload(payload):
         return "failed"
     if _has_completed_payload(payload):
         return "completed"
     return default_status
+
+
+def _is_canceled_payload(payload: Mapping[str, Any]) -> bool:
+    return _read_phase(payload) in {"canceled", "cancelled"} or _read_status(payload) in {"canceled", "cancelled"}
 
 
 def _has_failure_payload(payload: Mapping[str, Any]) -> bool:
@@ -237,6 +274,10 @@ def _has_completed_payload(payload: Mapping[str, Any]) -> bool:
 
 def _read_phase(payload: Mapping[str, Any]) -> str:
     return _read_non_empty_string(payload.get("phase")).lower().replace("-", "_")
+
+
+def _read_status(payload: Mapping[str, Any]) -> str:
+    return _read_non_empty_string(payload.get("status")).lower().replace("-", "_")
 
 
 def _read_non_empty_string(value: Any) -> str:

--- a/autocontext/src/autocontext/session/background_session_read_model.py
+++ b/autocontext/src/autocontext/session/background_session_read_model.py
@@ -8,13 +8,22 @@ from urllib.parse import quote
 from autocontext.session.runtime_events import RuntimeSessionEventLog
 
 BackgroundSessionStatus: TypeAlias = Literal["queued", "running", "completed", "failed", "canceled", "skipped", "unknown"]
-BackgroundSessionSummary: TypeAlias = dict[str, str | int]
+BackgroundSessionSummary: TypeAlias = dict[str, Any]
 BackgroundSessionArtifact: TypeAlias = dict[str, str]
 BackgroundSessionDetail: TypeAlias = dict[str, Any]
 TaskQueueRowLike: TypeAlias = Mapping[str, Any]
 RunRowLike: TypeAlias = Mapping[str, Any]
 ArtifactLike: TypeAlias = Mapping[str, Any]
 
+_CHILD_STATUS_KEYS: tuple[BackgroundSessionStatus, ...] = (
+    "queued",
+    "running",
+    "completed",
+    "failed",
+    "canceled",
+    "skipped",
+    "unknown",
+)
 REDACTED_TRIGGER_VALUE = "[redacted]"
 _SENSITIVE_TRIGGER_KEY_WORDS = frozenset(
     {
@@ -57,17 +66,12 @@ def build_background_session_summary(
     artifacts: Sequence[ArtifactLike] | None = None,
     child_sessions: Sequence[RuntimeSessionEventLog] | None = None,
 ) -> BackgroundSessionSummary:
-    artifacts = artifacts or []
-    child_sessions = child_sessions or []
+    artifacts = list(artifacts) if artifacts is not None else _runtime_session_artifacts(runtime_session)
+    child_sessions = list(child_sessions or [])
     session_id = runtime_session.session_id if runtime_session else _task_session_id(task)
-    created_at = (
-        runtime_session.created_at if runtime_session else _task_str(task, "created_at") or _run_str(run, "created_at")
-    )
+    created_at = runtime_session.created_at if runtime_session else _task_str(task, "created_at") or _run_str(run, "created_at")
     updated_at = _updated_at(runtime_session, task, run)
-    status = _normalize_status(
-        _metadata_str(runtime_session, "status") or _task_str(task, "status") or _run_str(run, "status"),
-        has_runtime_session=runtime_session is not None,
-    )
+    status = _read_background_session_status(runtime_session, task, run)
 
     return {
         "session_id": session_id,
@@ -80,6 +84,7 @@ def build_background_session_summary(
         "event_count": len(runtime_session.events) if runtime_session else 0,
         "artifact_count": len(artifacts),
         "child_session_count": len(child_sessions),
+        "child_status_counts": _child_status_counts(child_sessions),
         "created_at": created_at,
         "updated_at": updated_at,
         "result_url": background_session_url(session_id),
@@ -95,16 +100,19 @@ def build_background_session_detail(
     artifacts: Sequence[ArtifactLike] | None = None,
     child_sessions: Sequence[RuntimeSessionEventLog] | None = None,
 ) -> BackgroundSessionDetail:
+    child_sessions = list(child_sessions or [])
+    own_artifacts = list(artifacts) if artifacts is not None else _runtime_session_artifacts(runtime_session)
+    detail_artifacts = [*own_artifacts, *_child_runtime_session_artifacts(child_sessions)]
     return {
         "summary": build_background_session_summary(
             runtime_session=runtime_session,
             task=task,
             run=run,
-            artifacts=artifacts,
+            artifacts=detail_artifacts,
             child_sessions=child_sessions,
         ),
-        "artifacts": [_sanitize_artifact(artifact) for artifact in (artifacts or [])],
-        "child_sessions": [build_background_session_summary(runtime_session=child) for child in (child_sessions or [])],
+        "artifacts": [_sanitize_artifact(artifact) for artifact in detail_artifacts],
+        "child_sessions": [build_background_session_summary(runtime_session=child) for child in child_sessions],
         "trigger": _read_trigger(task),
     }
 
@@ -125,6 +133,30 @@ def _sanitize_artifact(artifact: ArtifactLike) -> BackgroundSessionArtifact:
         "path": _read_str(artifact.get("path")),
         "url": _read_str(artifact.get("url")),
     }
+
+
+def _runtime_session_artifacts(runtime_session: RuntimeSessionEventLog | None) -> list[ArtifactLike]:
+    if runtime_session is None:
+        return []
+    artifacts = [*_artifact_records(runtime_session.metadata.get("artifacts"))]
+    for event in runtime_session.events:
+        metadata = event.payload.get("metadata")
+        if isinstance(metadata, Mapping):
+            artifacts.extend(_artifact_records(metadata.get("artifacts")))
+    return artifacts
+
+
+def _child_runtime_session_artifacts(child_sessions: Sequence[RuntimeSessionEventLog]) -> list[ArtifactLike]:
+    artifacts: list[ArtifactLike] = []
+    for child in child_sessions:
+        artifacts.extend(_runtime_session_artifacts(child))
+    return artifacts
+
+
+def _artifact_records(value: Any) -> list[ArtifactLike]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, Mapping)]
 
 
 def _read_trigger(task: TaskQueueRowLike | None) -> dict[str, str | int | bool] | None:
@@ -200,6 +232,38 @@ def _looks_like_secret_value(value: str) -> bool:
     return any(marker in lower_value for marker in _SECRET_VALUE_MARKERS) or (
         "-----begin " in lower_value and "private key-----" in lower_value
     )
+
+
+def _read_background_session_status(
+    runtime_session: RuntimeSessionEventLog | None,
+    task: TaskQueueRowLike | None,
+    run: RunRowLike | None,
+) -> BackgroundSessionStatus:
+    raw_status = _metadata_str(runtime_session, "status") or _task_str(task, "status") or _run_str(run, "status")
+    status = _normalize_status(raw_status, has_runtime_session=runtime_session is not None)
+    if runtime_session is not None and runtime_session.parent_session_id and status == "running" and not raw_status:
+        return _infer_child_runtime_session_status(runtime_session)
+    return status
+
+
+def _child_status_counts(child_sessions: Sequence[RuntimeSessionEventLog]) -> dict[BackgroundSessionStatus, int]:
+    counts: dict[BackgroundSessionStatus, int] = {}
+    for status in _CHILD_STATUS_KEYS:
+        counts[status] = 0
+    for child in child_sessions:
+        counts[_read_background_session_status(child, None, None)] += 1
+    return counts
+
+
+def _infer_child_runtime_session_status(runtime_session: RuntimeSessionEventLog) -> BackgroundSessionStatus:
+    for event in sorted(runtime_session.events, key=lambda item: item.sequence, reverse=True):
+        if event.event_type == "assistant_message":
+            phase = _read_str(event.payload.get("phase")).lower().replace("-", "_")
+            status = _read_str(event.payload.get("status")).lower().replace("-", "_")
+            if phase in {"canceled", "cancelled"} or status in {"canceled", "cancelled"}:
+                return "canceled"
+            return "failed" if event.payload.get("isError") is True else "completed"
+    return "running"
 
 
 def _normalize_status(raw: str, *, has_runtime_session: bool) -> BackgroundSessionStatus:

--- a/autocontext/src/autocontext/session/runtime_child_session_controls.py
+++ b/autocontext/src/autocontext/session/runtime_child_session_controls.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from autocontext.session.runtime_events import (
+    RuntimeSessionEvent,
+    RuntimeSessionEventLog,
+    RuntimeSessionEventStore,
+    RuntimeSessionEventType,
+)
+
+DEFAULT_CHILD_TASK_MAX_CONCURRENT = 8
+
+
+@dataclass(frozen=True)
+class RuntimeChildSessionCancellation:
+    child_session_id: str
+    parent_session_id: str
+    task_id: str
+    worker_id: str
+    status: str
+    reason: str
+    child_session_log: RuntimeSessionEventLog
+
+
+def observe_runtime_session_log(
+    log: RuntimeSessionEventLog,
+    event_store: RuntimeSessionEventStore | None,
+    event_sink: Any,
+) -> None:
+    if event_store is None and event_sink is None:
+        return
+
+    def on_event(event: RuntimeSessionEvent, current_log: RuntimeSessionEventLog) -> None:
+        if event_store is not None:
+            event_store.save(current_log)
+        if event_sink is not None:
+            try:
+                event_sink.on_runtime_session_event(event, current_log)
+            except Exception:
+                pass
+
+    log.subscribe(on_event)
+
+
+def json_safe_record(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    if value is None:
+        return {}
+    return {str(key): _json_safe_value(item) for key, item in value.items()}
+
+
+def _json_safe_value(value: Any) -> Any:
+    try:
+        return json.loads(json.dumps(value, allow_nan=False))
+    except (TypeError, ValueError):
+        if isinstance(value, Mapping):
+            return {str(key): _json_safe_value(item) for key, item in value.items()}
+        if isinstance(value, list | tuple):
+            return [_json_safe_value(item) for item in value]
+        return str(value)
+
+
+def normalize_depth(value: int, name: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        msg = f"{name} must be a non-negative integer"
+        raise ValueError(msg)
+    return value
+
+
+def normalize_positive_int(value: int, name: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        msg = f"{name} must be a positive integer"
+        raise ValueError(msg)
+    return value
+
+
+def child_task_coordinator_lineage(
+    *,
+    task_id: str,
+    child_session_id: str,
+    parent_session_id: str,
+    role: str,
+    cwd: str,
+    depth: int,
+    max_depth: int,
+) -> dict[str, Any]:
+    return {
+        "taskId": task_id,
+        "childSessionId": child_session_id,
+        "parentSessionId": parent_session_id,
+        "role": role,
+        "cwd": cwd,
+        "depth": depth,
+        "maxDepth": max_depth,
+    }
+
+
+def active_child_session_ids(log: RuntimeSessionEventLog) -> set[str]:
+    active: set[str] = set()
+    for event in log.events:
+        if event.event_type == RuntimeSessionEventType.CHILD_TASK_STARTED:
+            child_session_id = _read_str(event.payload.get("childSessionId"))
+            if child_session_id:
+                active.add(child_session_id)
+        elif event.event_type == RuntimeSessionEventType.CHILD_TASK_COMPLETED:
+            child_session_id = _read_str(event.payload.get("childSessionId"))
+            if child_session_id:
+                active.discard(child_session_id)
+    return active
+
+
+def cancel_child_session_for_parent(
+    *,
+    parent_log: RuntimeSessionEventLog,
+    event_store: RuntimeSessionEventStore,
+    child_session_id: str,
+    reason: str,
+) -> RuntimeChildSessionCancellation:
+    clean_child_session_id = child_session_id.strip()
+    if not clean_child_session_id:
+        msg = "child_session_id is required"
+        raise ValueError(msg)
+    child_log = event_store.load(clean_child_session_id)
+    if child_log is None:
+        raise KeyError(f"Child session '{clean_child_session_id}' not found")
+    if child_log.parent_session_id != parent_log.session_id:
+        msg = f"Child session '{clean_child_session_id}' does not belong to parent '{parent_log.session_id}'"
+        raise ValueError(msg)
+    clean_reason = reason.strip() or "canceled"
+    child_log.metadata["status"] = "canceled"
+    child_log.append(
+        RuntimeSessionEventType.ASSISTANT_MESSAGE,
+        {"text": "", "error": clean_reason, "isError": True, "phase": "canceled", "status": "canceled"},
+    )
+    parent_log.append(
+        RuntimeSessionEventType.CHILD_TASK_COMPLETED,
+        {
+            "taskId": child_log.task_id,
+            "childSessionId": child_log.session_id,
+            "workerId": child_log.worker_id,
+            "result": "",
+            "error": clean_reason,
+            "isError": True,
+            "phase": "canceled",
+            "status": "canceled",
+        },
+    )
+    event_store.save(parent_log)
+    event_store.save(child_log)
+    return RuntimeChildSessionCancellation(
+        child_session_id=child_log.session_id,
+        parent_session_id=parent_log.session_id,
+        task_id=child_log.task_id,
+        worker_id=child_log.worker_id,
+        status="canceled",
+        reason=clean_reason,
+        child_session_log=child_log,
+    )
+
+
+def load_canceled_child_log(
+    event_store: RuntimeSessionEventStore | None,
+    child_log: RuntimeSessionEventLog,
+) -> RuntimeSessionEventLog | None:
+    persisted = event_store.load(child_log.session_id) if event_store is not None else None
+    for candidate in (persisted, child_log):
+        if candidate is not None and is_canceled_child_log(candidate):
+            return candidate
+    return None
+
+
+def is_canceled_child_log(log: RuntimeSessionEventLog) -> bool:
+    if _is_canceled_value(log.metadata.get("status")):
+        return True
+    return any(
+        event.event_type == RuntimeSessionEventType.ASSISTANT_MESSAGE
+        and (_is_canceled_value(event.payload.get("phase")) or _is_canceled_value(event.payload.get("status")))
+        for event in log.events
+    )
+
+
+def canceled_child_reason(log: RuntimeSessionEventLog) -> str:
+    for event in reversed(log.events):
+        if event.event_type != RuntimeSessionEventType.ASSISTANT_MESSAGE:
+            continue
+        if not (_is_canceled_value(event.payload.get("phase")) or _is_canceled_value(event.payload.get("status"))):
+            continue
+        return _read_str(event.payload.get("error")) or "canceled"
+    return "canceled"
+
+
+def _is_canceled_value(value: Any) -> bool:
+    normalized = _read_str(value).lower().replace("-", "_")
+    return normalized in {"canceled", "cancelled"}
+
+
+def _read_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""

--- a/autocontext/src/autocontext/session/runtime_session.py
+++ b/autocontext/src/autocontext/session/runtime_session.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import uuid
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -10,6 +9,19 @@ from typing import Any, Protocol, Self
 
 from autocontext.runtimes.workspace_env import RuntimeCommandGrant, RuntimeWorkspaceEnv
 from autocontext.session.coordinator import Coordinator
+from autocontext.session.runtime_child_session_controls import (
+    DEFAULT_CHILD_TASK_MAX_CONCURRENT,
+    RuntimeChildSessionCancellation,
+    active_child_session_ids,
+    cancel_child_session_for_parent,
+    canceled_child_reason,
+    child_task_coordinator_lineage,
+    json_safe_record,
+    load_canceled_child_log,
+    normalize_depth,
+    normalize_positive_int,
+    observe_runtime_session_log,
+)
 from autocontext.session.runtime_events import (
     RuntimeSessionEvent,
     RuntimeSessionEventLog,
@@ -128,6 +140,7 @@ class RuntimeSession:
         event_sink: RuntimeSessionEventSink | None = None,
         depth: int = 0,
         max_depth: int = DEFAULT_CHILD_TASK_MAX_DEPTH,
+        max_concurrent_child_tasks: int = DEFAULT_CHILD_TASK_MAX_CONCURRENT,
     ) -> None:
         self.goal = goal
         self.log = log
@@ -135,9 +148,13 @@ class RuntimeSession:
         self.workspace = workspace
         self._event_store = event_store
         self._event_sink = event_sink
-        self._depth = _normalize_depth(depth, "depth")
-        self._max_depth = _normalize_depth(max_depth, "max_depth")
-        _observe_runtime_session_log(self.log, self._event_store, self._event_sink)
+        self._depth = normalize_depth(depth, "depth")
+        self._max_depth = normalize_depth(max_depth, "max_depth")
+        self._max_concurrent_child_tasks = normalize_positive_int(
+            max_concurrent_child_tasks,
+            "max_concurrent_child_tasks",
+        )
+        observe_runtime_session_log(self.log, self._event_store, self._event_sink)
 
     @classmethod
     def create(
@@ -151,11 +168,12 @@ class RuntimeSession:
         workspace: RuntimeWorkspaceEnv | None = None,
         depth: int = 0,
         max_depth: int = DEFAULT_CHILD_TASK_MAX_DEPTH,
+        max_concurrent_child_tasks: int = DEFAULT_CHILD_TASK_MAX_CONCURRENT,
     ) -> Self:
         clean_session_id = session_id or f"runtime:{uuid.uuid4().hex[:12]}"
         log = RuntimeSessionEventLog.create(
             session_id=clean_session_id,
-            metadata={**_json_safe_record(metadata), "goal": goal},
+            metadata={**json_safe_record(metadata), "goal": goal},
         )
         return cls(
             goal=goal,
@@ -166,6 +184,7 @@ class RuntimeSession:
             event_sink=event_sink,
             depth=depth,
             max_depth=max_depth,
+            max_concurrent_child_tasks=max_concurrent_child_tasks,
         )
 
     @classmethod
@@ -178,6 +197,7 @@ class RuntimeSession:
         workspace: RuntimeWorkspaceEnv | None = None,
         depth: int = 0,
         max_depth: int = DEFAULT_CHILD_TASK_MAX_DEPTH,
+        max_concurrent_child_tasks: int = DEFAULT_CHILD_TASK_MAX_CONCURRENT,
     ) -> Self | None:
         log = event_store.load(session_id)
         if log is None:
@@ -192,6 +212,7 @@ class RuntimeSession:
             event_sink=event_sink,
             depth=depth,
             max_depth=max_depth,
+            max_concurrent_child_tasks=max_concurrent_child_tasks,
         )
 
     @property
@@ -252,7 +273,7 @@ class RuntimeSession:
                     "requestId": request_id,
                     "promptEventId": prompt_event.event_id,
                     "text": output.text,
-                    "metadata": _json_safe_record(output.metadata),
+                    "metadata": json_safe_record(output.metadata),
                     "role": role,
                     "cwd": resolved_cwd,
                 },
@@ -296,10 +317,27 @@ class RuntimeSession:
             event_sink=self._event_sink,
             depth=self._depth,
             max_depth=self._max_depth,
+            max_concurrent_child_tasks=self._max_concurrent_child_tasks,
         ).run(prompt=prompt, role=role, handler=handler, task_id=task_id, cwd=cwd, commands=commands)
 
     def list_child_logs(self) -> list[RuntimeSessionEventLog]:
         return self._event_store.list_children(self.session_id) if self._event_store is not None else []
+
+    def cancel_child_session(
+        self,
+        *,
+        child_session_id: str,
+        reason: str = "canceled",
+    ) -> RuntimeChildSessionCancellation:
+        if self._event_store is None:
+            msg = "event_store is required to cancel child sessions"
+            raise ValueError(msg)
+        return cancel_child_session_for_parent(
+            parent_log=self.log,
+            event_store=self._event_store,
+            child_session_id=child_session_id,
+            reason=reason,
+        )
 
     def record_compaction(self, compaction: RuntimeSessionCompactionInput) -> None:
         if not compaction.entries:
@@ -344,14 +382,19 @@ class RuntimeChildTaskRunner:
         event_sink: RuntimeSessionEventSink | None = None,
         depth: int = 0,
         max_depth: int = DEFAULT_CHILD_TASK_MAX_DEPTH,
+        max_concurrent_child_tasks: int = DEFAULT_CHILD_TASK_MAX_CONCURRENT,
     ) -> None:
         self._coordinator = coordinator
         self._parent_log = parent_log
         self._workspace = workspace
         self._event_store = event_store
         self._event_sink = event_sink
-        self._depth = _normalize_depth(depth, "depth")
-        self._max_depth = _normalize_depth(max_depth, "max_depth")
+        self._depth = normalize_depth(depth, "depth")
+        self._max_depth = normalize_depth(max_depth, "max_depth")
+        self._max_concurrent_child_tasks = normalize_positive_int(
+            max_concurrent_child_tasks,
+            "max_concurrent_child_tasks",
+        )
 
     def run(
         self,
@@ -366,8 +409,10 @@ class RuntimeChildTaskRunner:
         clean_task_id = task_id or uuid.uuid4().hex[:12]
         worker = self._coordinator.delegate(prompt, role)
         child_depth = self._depth + 1
-        child_cwd = self._workspace.resolve_path(cwd) if self._workspace is not None and cwd else (
-            self._workspace.cwd if self._workspace is not None else cwd
+        child_cwd = (
+            self._workspace.resolve_path(cwd)
+            if self._workspace is not None and cwd
+            else (self._workspace.cwd if self._workspace is not None else cwd)
         )
         child_session_id = f"task:{self._parent_log.session_id}:{clean_task_id}:{worker.worker_id}"
         child_log = RuntimeSessionEventLog.create(
@@ -380,9 +425,11 @@ class RuntimeChildTaskRunner:
                 "cwd": child_cwd,
                 "depth": child_depth,
                 "maxDepth": self._max_depth,
+                "status": "running",
             },
         )
-        _observe_runtime_session_log(child_log, self._event_store, self._event_sink)
+        observe_runtime_session_log(child_log, self._event_store, self._event_sink)
+        active_child_count = len(active_child_session_ids(self._parent_log))
         child_workspace = (
             self._workspace.scope(
                 cwd=cwd or None,
@@ -401,7 +448,7 @@ class RuntimeChildTaskRunner:
             else None
         )
         child_cwd = child_workspace.cwd if child_workspace is not None else child_cwd
-        coordinator_lineage = _child_task_coordinator_lineage(
+        coordinator_lineage = child_task_coordinator_lineage(
             task_id=clean_task_id,
             child_session_id=child_session_id,
             parent_session_id=self._parent_log.session_id,
@@ -446,6 +493,17 @@ class RuntimeChildTaskRunner:
                 child_log=child_log,
                 message=f"Maximum child task depth ({self._max_depth}) exceeded",
             )
+        if active_child_count >= self._max_concurrent_child_tasks:
+            return self._fail_child_task(
+                task_id=clean_task_id,
+                child_session_id=child_session_id,
+                worker_id=worker.worker_id,
+                role=role,
+                cwd=child_cwd,
+                depth=child_depth,
+                child_log=child_log,
+                message=f"Maximum concurrent child sessions ({self._max_concurrent_child_tasks}) exceeded",
+            )
 
         try:
             output = _normalize_child_output(
@@ -465,11 +523,23 @@ class RuntimeChildTaskRunner:
                     )
                 )
             )
+            canceled_child_log = load_canceled_child_log(self._event_store, child_log)
+            if canceled_child_log is not None:
+                return self._canceled_result(
+                    task_id=clean_task_id,
+                    child_session_id=child_session_id,
+                    worker_id=worker.worker_id,
+                    role=role,
+                    cwd=child_cwd,
+                    depth=child_depth,
+                    child_log=canceled_child_log,
+                )
+            child_log.metadata["status"] = "completed"
             child_log.append(
                 RuntimeSessionEventType.ASSISTANT_MESSAGE,
                 {
                     "text": output.text,
-                    "metadata": _json_safe_record(output.metadata),
+                    "metadata": json_safe_record(output.metadata),
                     "depth": child_depth,
                     "maxDepth": self._max_depth,
                 },
@@ -508,6 +578,17 @@ class RuntimeChildTaskRunner:
             self._persist(child_log)
             return result
         except Exception as exc:
+            canceled_child_log = load_canceled_child_log(self._event_store, child_log)
+            if canceled_child_log is not None:
+                return self._canceled_result(
+                    task_id=clean_task_id,
+                    child_session_id=child_session_id,
+                    worker_id=worker.worker_id,
+                    role=role,
+                    cwd=child_cwd,
+                    depth=child_depth,
+                    child_log=canceled_child_log,
+                )
             return self._fail_child_task(
                 task_id=clean_task_id,
                 child_session_id=child_session_id,
@@ -531,11 +612,12 @@ class RuntimeChildTaskRunner:
         child_log: RuntimeSessionEventLog,
         message: str,
     ) -> RuntimeChildTaskResult:
+        child_log.metadata["status"] = "failed"
         self._coordinator.fail_worker(
             worker_id,
             message,
             {
-                **_child_task_coordinator_lineage(
+                **child_task_coordinator_lineage(
                     task_id=task_id,
                     child_session_id=child_session_id,
                     parent_session_id=self._parent_log.session_id,
@@ -587,6 +669,41 @@ class RuntimeChildTaskRunner:
         self._persist(child_log)
         return result
 
+    def _canceled_result(
+        self,
+        *,
+        task_id: str,
+        child_session_id: str,
+        worker_id: str,
+        role: str,
+        cwd: str,
+        depth: int,
+        child_log: RuntimeSessionEventLog,
+    ) -> RuntimeChildTaskResult:
+        reason = canceled_child_reason(child_log)
+        details = child_task_coordinator_lineage(
+            task_id=task_id,
+            child_session_id=child_session_id,
+            parent_session_id=self._parent_log.session_id,
+            role=role,
+            cwd=cwd,
+            depth=depth,
+            max_depth=self._max_depth,
+        ) | {"isError": True, "phase": "canceled", "status": "canceled"}
+        self._coordinator.fail_worker(worker_id, reason, details)
+        return self._result(
+            task_id=task_id,
+            child_session_id=child_session_id,
+            worker_id=worker_id,
+            role=role,
+            cwd=cwd,
+            text="",
+            is_error=True,
+            error=reason,
+            depth=depth,
+            child_log=child_log,
+        )
+
     def _result(
         self,
         *,
@@ -623,26 +740,6 @@ class RuntimeChildTaskRunner:
         self._event_store.save(child_log)
 
 
-def _observe_runtime_session_log(
-    log: RuntimeSessionEventLog,
-    event_store: RuntimeSessionEventStore | None,
-    event_sink: RuntimeSessionEventSink | None,
-) -> None:
-    if event_store is None and event_sink is None:
-        return
-
-    def on_event(event: RuntimeSessionEvent, current_log: RuntimeSessionEventLog) -> None:
-        if event_store is not None:
-            event_store.save(current_log)
-        if event_sink is not None:
-            try:
-                event_sink.on_runtime_session_event(event, current_log)
-            except Exception:
-                pass
-
-    log.subscribe(on_event)
-
-
 def _normalize_prompt_output(output: RuntimeSessionPromptHandlerOutput | str) -> RuntimeSessionPromptHandlerOutput:
     if isinstance(output, RuntimeSessionPromptHandlerOutput):
         return output
@@ -655,50 +752,8 @@ def _normalize_child_output(output: RuntimeChildTaskHandlerOutput | str) -> Runt
     return RuntimeChildTaskHandlerOutput(text=output)
 
 
-def _child_task_coordinator_lineage(
-    *,
-    task_id: str,
-    child_session_id: str,
-    parent_session_id: str,
-    role: str,
-    cwd: str,
-    depth: int,
-    max_depth: int,
-) -> dict[str, Any]:
-    return {
-        "taskId": task_id,
-        "childSessionId": child_session_id,
-        "parentSessionId": parent_session_id,
-        "role": role,
-        "cwd": cwd,
-        "depth": depth,
-        "maxDepth": max_depth,
-    }
-
-
-def _json_safe_record(value: Mapping[str, Any] | None) -> dict[str, Any]:
-    if value is None:
-        return {}
-    return {str(key): _json_safe_value(item) for key, item in value.items()}
-
-
-def _json_safe_value(value: Any) -> Any:
-    try:
-        return json.loads(json.dumps(value, allow_nan=False))
-    except (TypeError, ValueError):
-        if isinstance(value, Mapping):
-            return {str(key): _json_safe_value(item) for key, item in value.items()}
-        if isinstance(value, list | tuple):
-            return [_json_safe_value(item) for item in value]
-        return str(value)
-
-
 def _compaction_payload(compaction: RuntimeSessionCompactionInput) -> dict[str, Any]:
-    entry_ids = [
-        entry_id
-        for entry in compaction.entries
-        if (entry_id := _read_str(entry.get("id")))
-    ]
+    entry_ids = [entry_id for entry in compaction.entries if (entry_id := _read_str(entry.get("id")))]
     components = sorted(
         {
             component
@@ -726,19 +781,12 @@ def _compaction_payload(compaction: RuntimeSessionCompactionInput) -> dict[str, 
         payload["generation"] = compaction.generation
     if compaction.promoted_knowledge_id:
         payload["promotedKnowledgeId"] = compaction.promoted_knowledge_id
-    return _json_safe_record(payload)
+    return json_safe_record(payload)
 
 
 def _preview_text(value: str, max_length: int = 500) -> str:
     normalized = " ".join(value.split()).strip()
     return f"{normalized[: max_length - 3]}..." if len(normalized) > max_length else normalized
-
-
-def _normalize_depth(value: int, name: str) -> int:
-    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
-        msg = f"{name} must be a non-negative integer"
-        raise ValueError(msg)
-    return value
 
 
 def _read_str(value: Any) -> str:

--- a/autocontext/tests/test_background_session_api.py
+++ b/autocontext/tests/test_background_session_api.py
@@ -17,6 +17,20 @@ from autocontext.storage.sqlite_store import SQLiteStore  # type: ignore[import-
 MIGRATIONS_DIR = Path(__file__).resolve().parents[1] / "migrations"
 
 
+def _child_status_counts(**overrides: int) -> dict[str, int]:
+    counts = {
+        "queued": 0,
+        "running": 0,
+        "completed": 0,
+        "failed": 0,
+        "canceled": 0,
+        "skipped": 0,
+        "unknown": 0,
+    }
+    counts.update(overrides)
+    return counts
+
+
 def _make_store(tmp_path: Path) -> SQLiteStore:
     store = SQLiteStore(tmp_path / "test.db")
     store.migrate(MIGRATIONS_DIR)
@@ -75,10 +89,46 @@ def _persist_background_sessions(db_path: Path) -> None:
             "parentSessionId": "run:test-run-1:runtime",
             "taskId": "child-1",
             "workerId": "worker-child",
-            "metadata": {"goal": "Inspect failing test", "runId": "test-run-1", "status": "completed"},
+            "metadata": {
+                "goal": "Inspect failing test",
+                "runId": "test-run-1",
+                "status": "completed",
+                "artifacts": [
+                    {
+                        "artifact_id": "child-report",
+                        "kind": "report",
+                        "label": "Child report",
+                        "path": "runs/test-run-1/child-report.md",
+                        "token": "SECRET_VALUE",
+                    }
+                ],
+            },
             "createdAt": "2026-06-01T00:00:03.000Z",
             "updatedAt": "2026-06-01T00:00:04.000Z",
-            "events": [],
+            "events": [
+                {
+                    "eventId": "child-prompt",
+                    "sessionId": "task:run:test-run-1:runtime:child-1",
+                    "sequence": 0,
+                    "eventType": RuntimeSessionEventType.PROMPT_SUBMITTED.value,
+                    "timestamp": "2026-06-01T00:00:03.500Z",
+                    "payload": {"role": "analyst", "prompt": "SECRET_VALUE"},
+                    "parentSessionId": "run:test-run-1:runtime",
+                    "taskId": "child-1",
+                    "workerId": "worker-child",
+                },
+                {
+                    "eventId": "child-answer",
+                    "sessionId": "task:run:test-run-1:runtime:child-1",
+                    "sequence": 1,
+                    "eventType": RuntimeSessionEventType.ASSISTANT_MESSAGE.value,
+                    "timestamp": "2026-06-01T00:00:04.000Z",
+                    "payload": {"role": "analyst", "text": "SECRET_VALUE"},
+                    "parentSessionId": "run:test-run-1:runtime",
+                    "taskId": "child-1",
+                    "workerId": "worker-child",
+                },
+            ],
         }
     )
     store = RuntimeSessionEventStore(db_path)
@@ -123,9 +173,10 @@ def test_cockpit_lists_background_sessions(cockpit_env: dict[str, Any]) -> None:
         "parent_session_id": "run:test-run-1:runtime",
         "status": "completed",
         "goal": "Inspect failing test",
-        "event_count": 0,
-        "artifact_count": 0,
+        "event_count": 2,
+        "artifact_count": 1,
         "child_session_count": 0,
+        "child_status_counts": _child_status_counts(),
         "created_at": "2026-06-01T00:00:03.000Z",
         "updated_at": "2026-06-01T00:00:04.000Z",
         "result_url": "/api/cockpit/background-sessions/task%3Arun%3Atest-run-1%3Aruntime%3Achild-1",
@@ -142,6 +193,7 @@ def test_cockpit_lists_background_sessions(cockpit_env: dict[str, Any]) -> None:
         "event_count": 1,
         "artifact_count": 0,
         "child_session_count": 1,
+        "child_status_counts": _child_status_counts(completed=1),
         "created_at": "2026-06-01T00:00:00.000Z",
         "updated_at": "2026-06-01T00:00:02.000Z",
         "result_url": "/api/cockpit/background-sessions/run%3Atest-run-1%3Aruntime",
@@ -158,6 +210,7 @@ def test_cockpit_lists_background_sessions(cockpit_env: dict[str, Any]) -> None:
         "event_count": 0,
         "artifact_count": 0,
         "child_session_count": 0,
+        "child_status_counts": _child_status_counts(),
         "created_at": "",
         "updated_at": "",
         "result_url": "/api/cockpit/background-sessions/task%3Aqueued-1",
@@ -176,6 +229,16 @@ def test_cockpit_reads_background_session_detail(cockpit_env: dict[str, Any]) ->
     assert body["summary"]["session_id"] == "run:test-run-1:runtime"
     assert body["summary"]["status"] == "completed"
     assert body["child_sessions"][0]["session_id"] == "task:run:test-run-1:runtime:child-1"
+    assert body["summary"]["child_status_counts"] == _child_status_counts(completed=1)
+    assert body["artifacts"] == [
+        {
+            "artifact_id": "child-report",
+            "kind": "report",
+            "label": "Child report",
+            "path": "runs/test-run-1/child-report.md",
+            "url": "",
+        }
+    ]
     assert body["trigger"] == {
         "type": "github_webhook",
         "actor": "octocat",
@@ -193,7 +256,41 @@ def test_cockpit_reads_background_session_detail(cockpit_env: dict[str, Any]) ->
             "status": "running",
             "title": "Prompt started",
             "payload_summary": {"request_id": "req-1", "role": "competitor"},
-        }
+        },
+        {
+            "event_id": "child-prompt",
+            "session_id": "task:run:test-run-1:runtime:child-1",
+            "sequence": 0,
+            "ts": "2026-06-01T00:00:03.500Z",
+            "event": "prompt_started",
+            "source_event_type": "prompt_submitted",
+            "status": "running",
+            "title": "Prompt started",
+            "payload_summary": {
+                "role": "analyst",
+                "child_session_id": "task:run:test-run-1:runtime:child-1",
+                "parent_session_id": "run:test-run-1:runtime",
+                "task_id": "child-1",
+                "worker_id": "worker-child",
+            },
+        },
+        {
+            "event_id": "child-answer",
+            "session_id": "task:run:test-run-1:runtime:child-1",
+            "sequence": 1,
+            "ts": "2026-06-01T00:00:04.000Z",
+            "event": "runtime_event",
+            "source_event_type": "assistant_message",
+            "status": "completed",
+            "title": "Assistant message",
+            "payload_summary": {
+                "role": "analyst",
+                "child_session_id": "task:run:test-run-1:runtime:child-1",
+                "parent_session_id": "run:test-run-1:runtime",
+                "task_id": "child-1",
+                "worker_id": "worker-child",
+            },
+        },
     ]
     assert "SECRET_VALUE" not in str(body)
 

--- a/autocontext/tests/test_background_session_events.py
+++ b/autocontext/tests/test_background_session_events.py
@@ -133,6 +133,71 @@ def test_background_session_events_match_typescript_contract_without_raw_payload
     assert "SECRET_VALUE" not in str(events)
 
 
+def test_parent_background_session_timeline_includes_child_session_events() -> None:
+    child = RuntimeSessionEventLog.from_dict(
+        {
+            "sessionId": "task:run:run-123:runtime:child-1",
+            "parentSessionId": "run:run-123:runtime",
+            "taskId": "child-1",
+            "workerId": "worker-child",
+            "metadata": {"goal": "Inspect failing test", "status": "failed"},
+            "createdAt": "2026-06-01T00:00:31.000Z",
+            "updatedAt": "2026-06-01T00:00:36.000Z",
+            "events": [
+                {
+                    "eventId": "child-prompt",
+                    "sessionId": "task:run:run-123:runtime:child-1",
+                    "sequence": 0,
+                    "eventType": RuntimeSessionEventType.PROMPT_SUBMITTED.value,
+                    "timestamp": "2026-06-01T00:00:35.000Z",
+                    "payload": {"role": "analyst", "prompt": "SECRET_VALUE"},
+                    "parentSessionId": "run:run-123:runtime",
+                    "taskId": "child-1",
+                    "workerId": "worker-child",
+                },
+                {
+                    "eventId": "child-answer",
+                    "sessionId": "task:run:run-123:runtime:child-1",
+                    "sequence": 1,
+                    "eventType": RuntimeSessionEventType.ASSISTANT_MESSAGE.value,
+                    "timestamp": "2026-06-01T00:00:36.000Z",
+                    "payload": {"role": "analyst", "isError": True, "error": "SECRET_VALUE"},
+                    "parentSessionId": "run:run-123:runtime",
+                    "taskId": "child-1",
+                    "workerId": "worker-child",
+                },
+            ],
+        }
+    )
+
+    events = normalize_background_session_timeline(_runtime_log(), child_logs=[child])
+
+    assert [event["event_id"] for event in events] == [
+        "event-1",
+        "event-2",
+        "event-3",
+        "child-prompt",
+        "child-answer",
+        "event-4",
+    ]
+    assert events[3]["payload_summary"] == {
+        "role": "analyst",
+        "child_session_id": "task:run:run-123:runtime:child-1",
+        "parent_session_id": "run:run-123:runtime",
+        "task_id": "child-1",
+        "worker_id": "worker-child",
+    }
+    assert events[4]["status"] == "failed"
+    assert events[4]["payload_summary"] == {
+        "role": "analyst",
+        "child_session_id": "task:run:run-123:runtime:child-1",
+        "parent_session_id": "run:run-123:runtime",
+        "task_id": "child-1",
+        "worker_id": "worker-child",
+    }
+    assert "SECRET_VALUE" not in str(events)
+
+
 def test_failed_runtime_payloads_from_assistants_and_grants_are_marked_failed() -> None:
     log = RuntimeSessionEventLog.from_dict(
         {
@@ -161,9 +226,20 @@ def test_failed_runtime_payloads_from_assistants_and_grants_are_marked_failed() 
                     "workerId": "worker-1",
                 },
                 {
-                    "eventId": "tool-failed",
+                    "eventId": "assistant-canceled",
                     "sessionId": "run:failed-runtime:runtime",
                     "sequence": 1,
+                    "eventType": RuntimeSessionEventType.ASSISTANT_MESSAGE.value,
+                    "timestamp": "2026-06-01T01:00:01.500Z",
+                    "payload": {"phase": "canceled", "isError": True, "error": "SECRET_VALUE"},
+                    "parentSessionId": "",
+                    "taskId": "task-failed",
+                    "workerId": "worker-1",
+                },
+                {
+                    "eventId": "tool-failed",
+                    "sessionId": "run:failed-runtime:runtime",
+                    "sequence": 2,
                     "eventType": RuntimeSessionEventType.TOOL_CALL.value,
                     "timestamp": "2026-06-01T01:00:02.000Z",
                     "payload": {"tool": "workspace.write", "phase": "error", "error": "SECRET_VALUE"},
@@ -174,7 +250,7 @@ def test_failed_runtime_payloads_from_assistants_and_grants_are_marked_failed() 
                 {
                     "eventId": "shell-failed",
                     "sessionId": "run:failed-runtime:runtime",
-                    "sequence": 2,
+                    "sequence": 3,
                     "eventType": RuntimeSessionEventType.SHELL_COMMAND.value,
                     "timestamp": "2026-06-01T01:00:03.000Z",
                     "payload": {
@@ -187,6 +263,17 @@ def test_failed_runtime_payloads_from_assistants_and_grants_are_marked_failed() 
                     "taskId": "task-failed",
                     "workerId": "worker-1",
                 },
+                {
+                    "eventId": "child-canceled",
+                    "sessionId": "run:failed-runtime:runtime",
+                    "sequence": 4,
+                    "eventType": RuntimeSessionEventType.CHILD_TASK_COMPLETED.value,
+                    "timestamp": "2026-06-01T01:00:04.000Z",
+                    "payload": {"taskId": "child-1", "phase": "canceled", "isError": True, "error": "SECRET_VALUE"},
+                    "parentSessionId": "",
+                    "taskId": "task-failed",
+                    "workerId": "worker-1",
+                },
             ],
         }
     )
@@ -195,8 +282,10 @@ def test_failed_runtime_payloads_from_assistants_and_grants_are_marked_failed() 
 
     assert [(event["event_id"], event["status"], event["payload_summary"]) for event in events] == [
         ("assistant-failed", "failed", {"request_id": "req-failed", "role": "competitor"}),
+        ("assistant-canceled", "canceled", {}),
         ("tool-failed", "failed", {"tool": "workspace.write"}),
         ("shell-failed", "failed", {"command": "npm test", "cwd": "/workspace"}),
+        ("child-canceled", "canceled", {"task_id": "child-1"}),
     ]
     assert "SECRET_VALUE" not in str(events)
 

--- a/autocontext/tests/test_background_session_read_model.py
+++ b/autocontext/tests/test_background_session_read_model.py
@@ -64,12 +64,39 @@ def _child_log() -> RuntimeSessionEventLog:
             "parentSessionId": "run:run-123:runtime",
             "taskId": "child-1",
             "workerId": "worker-child",
-            "metadata": {"goal": "Inspect failing test", "runId": "run-123", "status": "completed"},
+            "metadata": {
+                "goal": "Inspect failing test",
+                "runId": "run-123",
+                "status": "completed",
+                "artifacts": [
+                    {
+                        "artifact_id": "child-report",
+                        "kind": "report",
+                        "label": "Child report",
+                        "path": "runs/run-123/child-report.md",
+                        "token": "SECRET_VALUE",
+                    }
+                ],
+            },
             "createdAt": "2026-06-01T00:00:30.000Z",
             "updatedAt": "2026-06-01T00:00:45.000Z",
             "events": [],
         }
     )
+
+
+def _child_status_counts(**overrides: int) -> dict[str, int]:
+    counts = {
+        "queued": 0,
+        "running": 0,
+        "completed": 0,
+        "failed": 0,
+        "canceled": 0,
+        "skipped": 0,
+        "unknown": 0,
+    }
+    counts.update(overrides)
+    return counts
 
 
 def _task(**overrides: Any) -> dict[str, Any]:
@@ -117,6 +144,7 @@ def test_background_session_summary_matches_typescript_contract_without_raw_payl
         "event_count": 2,
         "artifact_count": 2,
         "child_session_count": 1,
+        "child_status_counts": _child_status_counts(completed=1),
         "created_at": "2026-06-01T00:00:00.000Z",
         "updated_at": "2026-06-01T00:01:00.000Z",
         "result_url": "/api/cockpit/background-sessions/run%3Arun-123%3Aruntime",
@@ -141,6 +169,7 @@ def test_background_session_summary_represents_queued_work_without_runtime_sessi
         "event_count": 0,
         "artifact_count": 0,
         "child_session_count": 0,
+        "child_status_counts": _child_status_counts(),
         "created_at": "2026-06-01T00:00:00.000Z",
         "updated_at": "2026-06-01T00:00:10.000Z",
         "result_url": "/api/cockpit/background-sessions/task%3Aqueued-1",
@@ -165,6 +194,8 @@ def test_background_session_detail_sanitizes_artifacts_and_child_summaries() -> 
     )
 
     assert detail["summary"]["session_id"] == "run:run-123:runtime"
+    assert detail["summary"]["artifact_count"] == 2
+    assert detail["summary"]["child_status_counts"] == _child_status_counts(completed=1)
     assert detail["artifacts"] == [
         {
             "artifact_id": "pr-1",
@@ -172,11 +203,19 @@ def test_background_session_detail_sanitizes_artifacts_and_child_summaries() -> 
             "label": "Review changes",
             "path": "",
             "url": "https://github.example/pr/1",
-        }
+        },
+        {
+            "artifact_id": "child-report",
+            "kind": "report",
+            "label": "Child report",
+            "path": "runs/run-123/child-report.md",
+            "url": "",
+        },
     ]
     assert detail["child_sessions"][0]["session_id"] == "task:run:run-123:runtime:child-1"
     assert detail["child_sessions"][0]["parent_session_id"] == "run:run-123:runtime"
     assert detail["child_sessions"][0]["status"] == "completed"
+    assert detail["child_sessions"][0]["artifact_count"] == 1
     assert detail["trigger"] == {"type": "manual", "actor": "operator"}
     assert "SECRET_VALUE" not in str(detail)
 

--- a/autocontext/tests/test_runtime_child_session_controls.py
+++ b/autocontext/tests/test_runtime_child_session_controls.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+from autocontext.session import RuntimeChildTaskHandlerOutput, RuntimeSession  # type: ignore[import-untyped]
+from autocontext.session.runtime_events import (  # type: ignore[import-untyped]
+    RuntimeSessionEventLog,
+    RuntimeSessionEventStore,
+    RuntimeSessionEventType,
+)
+
+
+def test_runtime_session_child_task_concurrency_limit_is_recorded(tmp_path: Path) -> None:
+    store = RuntimeSessionEventStore(tmp_path / "runtime-events.db")
+    try:
+        session = cast(Any, RuntimeSession).create(
+            session_id="run:abc:runtime",
+            goal="autoctx run support_triage",
+            event_store=store,
+            max_concurrent_child_tasks=1,
+        )
+        session.log.append(
+            RuntimeSessionEventType.CHILD_TASK_STARTED,
+            {"taskId": "active", "childSessionId": "child-active", "workerId": "worker-active"},
+        )
+        session.save()
+        called = False
+
+        def handler(_input: Any) -> RuntimeChildTaskHandlerOutput:
+            nonlocal called
+            called = True
+            return RuntimeChildTaskHandlerOutput(text="should not run")
+
+        result = session.run_child_task(
+            prompt="Queue one more",
+            role="analyst",
+            task_id="queued",
+            handler=handler,
+        )
+
+        assert called is False
+        assert result.is_error is True
+        assert result.error == "Maximum concurrent child sessions (1) exceeded"
+        parent = store.load("run:abc:runtime")
+        child = store.load(result.child_session_id)
+        assert parent is not None
+        assert child is not None
+        assert parent.events[-1].event_type == RuntimeSessionEventType.CHILD_TASK_COMPLETED
+        assert parent.events[-1].payload["isError"] is True
+        assert parent.events[-1].payload["error"] == "Maximum concurrent child sessions (1) exceeded"
+        assert child.metadata["status"] == "failed"
+        assert child.events[-1].payload["isError"] is True
+    finally:
+        store.close()
+
+
+def test_runtime_session_does_not_overwrite_child_sessions_canceled_during_handler(tmp_path: Path) -> None:
+    store = RuntimeSessionEventStore(tmp_path / "runtime-events.db")
+    try:
+        session = RuntimeSession.create(
+            session_id="run:abc:runtime",
+            goal="autoctx run support_triage",
+            event_store=store,
+        )
+
+        def handler(input: Any) -> RuntimeChildTaskHandlerOutput:
+            cast(Any, session).cancel_child_session(
+                child_session_id=input.child_session_id,
+                reason="operator requested",
+            )
+            return RuntimeChildTaskHandlerOutput(text="late success")
+
+        result = session.run_child_task(
+            prompt="Do child work",
+            role="analyst",
+            task_id="child",
+            handler=handler,
+        )
+
+        assert result.child_session_id.startswith("task:run:abc:runtime:child:")
+        assert result.is_error is True
+        assert result.error == "operator requested"
+        assert result.text == ""
+        parent = store.load("run:abc:runtime")
+        canceled_child = store.load(result.child_session_id)
+        assert parent is not None
+        assert canceled_child is not None
+        completions = [
+            event
+            for event in parent.events
+            if event.event_type == RuntimeSessionEventType.CHILD_TASK_COMPLETED
+            and event.payload.get("childSessionId") == result.child_session_id
+        ]
+        assert len(completions) == 1
+        assert completions[0].payload["phase"] == "canceled"
+        assert completions[0].payload["status"] == "canceled"
+        assert completions[0].payload["error"] == "operator requested"
+        assert canceled_child.metadata["status"] == "canceled"
+        assert session.coordinator.active_workers == []
+        assert "late success" not in str(canceled_child.to_dict())
+    finally:
+        store.close()
+
+
+def test_runtime_session_can_cancel_active_child_session(tmp_path: Path) -> None:
+    store = RuntimeSessionEventStore(tmp_path / "runtime-events.db")
+    try:
+        session = RuntimeSession.create(
+            session_id="run:abc:runtime",
+            goal="autoctx run support_triage",
+            event_store=store,
+        )
+        child = RuntimeSessionEventLog.create(
+            session_id="task:run:abc:runtime:child:worker-1",
+            parent_session_id="run:abc:runtime",
+            task_id="child",
+            worker_id="worker-1",
+            metadata={"goal": "child work", "status": "running"},
+        )
+        child.append(RuntimeSessionEventType.PROMPT_SUBMITTED, {"prompt": "SECRET_VALUE", "role": "analyst"})
+        store.save(child)
+        session.log.append(
+            RuntimeSessionEventType.CHILD_TASK_STARTED,
+            {
+                "taskId": "child",
+                "childSessionId": child.session_id,
+                "workerId": "worker-1",
+                "role": "analyst",
+            },
+        )
+        session.save()
+
+        cancellation = cast(Any, session).cancel_child_session(
+            child_session_id=child.session_id,
+            reason="operator requested",
+        )
+
+        assert cancellation.child_session_id == child.session_id
+        assert cancellation.status == "canceled"
+        assert cancellation.reason == "operator requested"
+        parent = store.load("run:abc:runtime")
+        canceled_child = store.load(child.session_id)
+        assert parent is not None
+        assert canceled_child is not None
+        assert canceled_child.metadata["status"] == "canceled"
+        assert canceled_child.events[-1].event_type == RuntimeSessionEventType.ASSISTANT_MESSAGE
+        assert canceled_child.events[-1].payload == {
+            "text": "",
+            "error": "operator requested",
+            "isError": True,
+            "phase": "canceled",
+            "status": "canceled",
+        }
+        assert parent.events[-1].event_type == RuntimeSessionEventType.CHILD_TASK_COMPLETED
+        assert parent.events[-1].payload == {
+            "taskId": "child",
+            "childSessionId": child.session_id,
+            "workerId": "worker-1",
+            "result": "",
+            "error": "operator requested",
+            "isError": True,
+            "phase": "canceled",
+            "status": "canceled",
+        }
+    finally:
+        store.close()

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -387,6 +387,8 @@ export {
   readRuntimeSessionTimelineByRunId,
 } from "./session/runtime-session-timeline.js";
 export type {
+  RuntimeChildSessionCancellation,
+  RuntimeSessionCancelChildSessionOpts,
   RuntimeSessionCreateOpts,
   RuntimeSessionCompactionEntry,
   RuntimeSessionLoadOpts,
@@ -472,6 +474,7 @@ export type {
   RuntimeSessionEventSink,
 } from "./session/runtime-session-notifications.js";
 export {
+  DEFAULT_CHILD_TASK_MAX_CONCURRENT,
   DEFAULT_CHILD_TASK_MAX_DEPTH,
   RuntimeChildTaskRunner,
   createAgentRuntimeChildTaskHandler,

--- a/ts/src/server/background-session-api.ts
+++ b/ts/src/server/background-session-api.ts
@@ -46,7 +46,12 @@ export function buildBackgroundSessionApiRoutes(opts: {
         const runtimeTaskIds = new Set(runtimeSessions.map((log) => log.taskId).filter(Boolean));
         const summaries = [
           ...runtimeSessions.map((runtimeSession) =>
-            summarizeBackgroundSessionFromStore(runtimeStore, sourceStore, taskIndex, runtimeSession),
+            summarizeBackgroundSessionFromStore(
+              runtimeStore,
+              sourceStore,
+              taskIndex,
+              runtimeSession,
+            ),
           ),
           ...[...taskIndex.values()]
             .filter((task) => !runtimeTaskIds.has(task.id))
@@ -73,12 +78,14 @@ export function buildBackgroundSessionApiRoutes(opts: {
             status: 200,
             body: {
               ...buildBackgroundSessionDetail({ runtimeSession, task, run, childSessions }),
-              normalized_events: normalizeBackgroundSessionTimeline(runtimeSession),
+              normalized_events: normalizeBackgroundSessionTimeline(runtimeSession, {
+                childLogs: childSessions,
+              }),
             },
           };
         }
         const taskId = taskIdFromSessionId(cleanSessionId);
-        const task = taskId ? sourceStore?.getTask?.(taskId) ?? null : null;
+        const task = taskId ? (sourceStore?.getTask?.(taskId) ?? null) : null;
         if (task) {
           return {
             status: 200,
@@ -123,7 +130,9 @@ function taskForRuntimeSession(
   if (!runtimeSession.taskId) {
     return null;
   }
-  return taskIndex?.get(runtimeSession.taskId) ?? sourceStore?.getTask?.(runtimeSession.taskId) ?? null;
+  return (
+    taskIndex?.get(runtimeSession.taskId) ?? sourceStore?.getTask?.(runtimeSession.taskId) ?? null
+  );
 }
 
 function runForRuntimeSession(
@@ -132,7 +141,7 @@ function runForRuntimeSession(
   task: TaskQueueRow | null,
 ): RunRow | null {
   const runId = readString(runtimeSession.metadata.runId) || readRunIdFromTask(task);
-  return runId ? sourceStore?.getRun?.(runId) ?? null : null;
+  return runId ? (sourceStore?.getRun?.(runId) ?? null) : null;
 }
 
 function readRunIdFromTask(task: TaskQueueRow | null): string {

--- a/ts/src/session/background-session-events.ts
+++ b/ts/src/session/background-session-events.ts
@@ -73,10 +73,23 @@ export interface SessionStatusEventInput {
 
 export function normalizeBackgroundSessionTimeline(
   log: RuntimeSessionEventLog,
+  opts: { childLogs?: readonly RuntimeSessionEventLog[] } = {},
 ): NormalizedSessionEvent[] {
-  return [...log.events]
+  const events = [...log.events]
     .sort((left, right) => left.sequence - right.sequence)
     .map(normalizeRuntimeSessionEvent);
+  for (const childLog of opts.childLogs ?? []) {
+    events.push(
+      ...[...childLog.events]
+        .sort((left, right) => left.sequence - right.sequence)
+        .map((event) => withChildLineage(normalizeRuntimeSessionEvent(event), childLog)),
+    );
+  }
+  return events.sort((left, right) =>
+    `${left.ts}\u0000${left.session_id}\u0000${left.sequence}`.localeCompare(
+      `${right.ts}\u0000${right.session_id}\u0000${right.sequence}`,
+    ),
+  );
 }
 
 export function normalizeRuntimeSessionEvent(event: RuntimeSessionEvent): NormalizedSessionEvent {
@@ -94,7 +107,7 @@ export function normalizeRuntimeSessionEvent(event: RuntimeSessionEvent): Normal
     case "assistant_message":
       return baseEvent(event, {
         normalizedEvent: "runtime_event",
-        status: hasFailurePayload(event.payload) ? "failed" : "completed",
+        status: runtimeActionStatus(event.payload, "completed"),
         title: "Assistant message",
         payloadSummary: pickPayload(event.payload, {
           request_id: "requestId",
@@ -134,11 +147,12 @@ export function normalizeRuntimeSessionEvent(event: RuntimeSessionEvent): Normal
         }),
       });
     case "child_task_completed": {
+      const canceled = isCanceledPayload(event.payload);
       const failed = readBoolean(event.payload.isError);
       return baseEvent(event, {
         normalizedEvent: "session_status",
-        status: failed ? "failed" : "completed",
-        title: failed ? "Child session failed" : "Child session completed",
+        status: canceled ? "canceled" : failed ? "failed" : "completed",
+        title: canceled ? "Child session canceled" : failed ? "Child session failed" : "Child session completed",
         payloadSummary: pickPayload(event.payload, {
           task_id: "taskId",
         }),
@@ -245,6 +259,24 @@ function baseEvent(
   };
 }
 
+function withChildLineage(
+  event: NormalizedSessionEvent,
+  childLog: RuntimeSessionEventLog,
+): NormalizedSessionEvent {
+  return {
+    ...event,
+    payload_summary: {
+      ...event.payload_summary,
+      ...sanitizeSummary({
+        child_session_id: childLog.sessionId,
+        parent_session_id: childLog.parentSessionId,
+        task_id: childLog.taskId,
+        worker_id: childLog.workerId,
+      }),
+    },
+  };
+}
+
 function pickPayload(
   payload: Record<string, unknown>,
   mapping: Record<string, string>,
@@ -275,6 +307,9 @@ function runtimeActionStatus(
   payload: Record<string, unknown>,
   defaultStatus: NormalizedSessionEventStatus,
 ): NormalizedSessionEventStatus {
+  if (isCanceledPayload(payload)) {
+    return "canceled";
+  }
   if (hasFailurePayload(payload)) {
     return "failed";
   }
@@ -282,6 +317,12 @@ function runtimeActionStatus(
     return "completed";
   }
   return defaultStatus;
+}
+
+function isCanceledPayload(payload: Record<string, unknown>): boolean {
+  return [readPhase(payload), readStatus(payload)].some(
+    (value) => value === "canceled" || value === "cancelled",
+  );
 }
 
 function hasFailurePayload(payload: Record<string, unknown>): boolean {
@@ -304,6 +345,10 @@ function hasCompletedPayload(payload: Record<string, unknown>): boolean {
 
 function readPhase(payload: Record<string, unknown>): string {
   return readNonEmptyString(payload.phase).toLowerCase().replace(/-/g, "_");
+}
+
+function readStatus(payload: Record<string, unknown>): string {
+  return readNonEmptyString(payload.status).toLowerCase().replace(/-/g, "_");
 }
 
 function readNonEmptyString(value: unknown): string {

--- a/ts/src/session/background-session-read-model.ts
+++ b/ts/src/session/background-session-read-model.ts
@@ -50,6 +50,7 @@ export interface BackgroundSessionSummary {
   readonly event_count: number;
   readonly artifact_count: number;
   readonly child_session_count: number;
+  readonly child_status_counts: Record<BackgroundSessionStatus, number>;
   readonly created_at: string;
   readonly updated_at: string;
   readonly result_url: string;
@@ -79,6 +80,15 @@ type NormalizedBackgroundSessionSource = {
   childSessions: RuntimeSessionEventLog[];
 };
 
+const CHILD_STATUS_KEYS: readonly BackgroundSessionStatus[] = [
+  "queued",
+  "running",
+  "completed",
+  "failed",
+  "canceled",
+  "skipped",
+  "unknown",
+];
 const REDACTED_TRIGGER_VALUE = "[redacted]";
 const SENSITIVE_TRIGGER_KEY_WORDS = new Set([
   "auth",
@@ -117,7 +127,10 @@ export function buildBackgroundSessionSummary(
   return {
     session_id: sessionId,
     runtime_session_id: runtimeSessionId,
-    run_id: readMetadataString(normalized.runtimeSession?.metadata, "runId") || normalized.run?.run_id || "",
+    run_id:
+      readMetadataString(normalized.runtimeSession?.metadata, "runId") ||
+      normalized.run?.run_id ||
+      "",
     task_id: readTaskId(normalized),
     parent_session_id: normalized.runtimeSession?.parentSessionId ?? "",
     status: readBackgroundSessionStatus(normalized),
@@ -125,6 +138,7 @@ export function buildBackgroundSessionSummary(
     event_count: normalized.runtimeSession?.events.length ?? 0,
     artifact_count: normalized.artifacts.length,
     child_session_count: normalized.childSessions.length,
+    child_status_counts: childStatusCounts(normalized.childSessions),
     created_at: readCreatedAt(normalized),
     updated_at: readUpdatedAt(normalized),
     result_url: backgroundSessionUrl(sessionId),
@@ -135,13 +149,18 @@ export function buildBackgroundSessionSummary(
 export function buildBackgroundSessionDetail(
   source: BackgroundSessionSource,
 ): BackgroundSessionDetail {
+  const normalized = normalizeSource(source);
+  const detailArtifacts = [
+    ...normalized.artifacts,
+    ...normalized.childSessions.flatMap(runtimeSessionArtifacts),
+  ];
   return {
-    summary: buildBackgroundSessionSummary(source),
-    artifacts: (source.artifacts ?? []).map(sanitizeArtifact),
-    child_sessions: (source.childSessions ?? []).map((runtimeSession) =>
+    summary: buildBackgroundSessionSummary({ ...source, artifacts: detailArtifacts }),
+    artifacts: detailArtifacts.map(sanitizeArtifact),
+    child_sessions: normalized.childSessions.map((runtimeSession) =>
       buildBackgroundSessionSummary({ runtimeSession }),
     ),
-    trigger: readTrigger(source.task),
+    trigger: readTrigger(normalized.task),
   };
 }
 
@@ -164,7 +183,7 @@ function normalizeSource(source: BackgroundSessionSource): NormalizedBackgroundS
     runtimeSession: source.runtimeSession ?? null,
     task: source.task ?? null,
     run: source.run ?? null,
-    artifacts: source.artifacts ?? [],
+    artifacts: source.artifacts ?? runtimeSessionArtifacts(source.runtimeSession ?? null),
     childSessions: source.childSessions ?? [],
   };
 }
@@ -180,13 +199,16 @@ function readTaskId(source: NormalizedBackgroundSessionSource): string {
 function readBackgroundSessionStatus(
   source: NormalizedBackgroundSessionSource,
 ): BackgroundSessionStatus {
-  return normalizeStatus(
+  const rawStatus =
     readMetadataString(source.runtimeSession?.metadata, "status") ||
-      source.task?.status ||
-      source.run?.status ||
-      "",
-    Boolean(source.runtimeSession),
-  );
+    source.task?.status ||
+    source.run?.status ||
+    "";
+  const status = normalizeStatus(rawStatus, Boolean(source.runtimeSession));
+  if (source.runtimeSession?.parentSessionId && status === "running" && !rawStatus) {
+    return inferChildRuntimeSessionStatus(source.runtimeSession);
+  }
+  return status;
 }
 
 function readGoal(source: NormalizedBackgroundSessionSource): string {
@@ -199,7 +221,9 @@ function readGoal(source: NormalizedBackgroundSessionSource): string {
 }
 
 function readCreatedAt(source: NormalizedBackgroundSessionSource): string {
-  return source.runtimeSession?.createdAt || source.task?.created_at || source.run?.created_at || "";
+  return (
+    source.runtimeSession?.createdAt || source.task?.created_at || source.run?.created_at || ""
+  );
 }
 
 function readUpdatedAt(source: NormalizedBackgroundSessionSource): string {
@@ -220,6 +244,65 @@ function sanitizeArtifact(artifact: BackgroundSessionArtifactInput): BackgroundS
     path: artifact.path ?? "",
     url: artifact.url ?? "",
   };
+}
+
+function runtimeSessionArtifacts(
+  runtimeSession: RuntimeSessionEventLog | null | undefined,
+): BackgroundSessionArtifactInput[] {
+  if (!runtimeSession) return [];
+  const artifacts = [...artifactRecords(runtimeSession.metadata.artifacts)];
+  for (const event of runtimeSession.events) {
+    const metadata = event.payload.metadata;
+    if (isRecord(metadata)) {
+      artifacts.push(...artifactRecords(metadata.artifacts));
+    }
+  }
+  return artifacts;
+}
+
+function artifactRecords(value: unknown): BackgroundSessionArtifactInput[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isRecord).map((record) => ({
+    artifact_id: readString(record.artifact_id),
+    kind: readString(record.kind) || "file",
+    label: readString(record.label),
+    path: readString(record.path),
+    url: readString(record.url),
+  }));
+}
+
+function childStatusCounts(
+  childSessions: RuntimeSessionEventLog[],
+): Record<BackgroundSessionStatus, number> {
+  const counts = Object.fromEntries(CHILD_STATUS_KEYS.map((status) => [status, 0])) as Record<
+    BackgroundSessionStatus,
+    number
+  >;
+  for (const child of childSessions) {
+    counts[readBackgroundSessionStatus(normalizeSource({ runtimeSession: child }))] += 1;
+  }
+  return counts;
+}
+
+function inferChildRuntimeSessionStatus(
+  runtimeSession: RuntimeSessionEventLog,
+): BackgroundSessionStatus {
+  const events = [...runtimeSession.events].sort((left, right) => right.sequence - left.sequence);
+  for (const event of events) {
+    if (event.eventType !== "assistant_message") continue;
+    const phase = readString(event.payload.phase).toLowerCase().replace(/-/g, "_");
+    const status = readString(event.payload.status).toLowerCase().replace(/-/g, "_");
+    if (
+      phase === "canceled" ||
+      phase === "cancelled" ||
+      status === "canceled" ||
+      status === "cancelled"
+    ) {
+      return "canceled";
+    }
+    return event.payload.isError === true ? "failed" : "completed";
+  }
+  return "running";
 }
 
 function readTrigger(task: TaskQueueRow | null | undefined): Record<string, unknown> | null {
@@ -273,7 +356,9 @@ function isSensitiveTriggerKey(key: string): boolean {
   if (words.some((word) => SENSITIVE_TRIGGER_KEY_WORDS.has(word))) {
     return true;
   }
-  return COMPOUND_SENSITIVE_TRIGGER_KEY_WORDS.some((sequence) => containsWordSequence(words, sequence));
+  return COMPOUND_SENSITIVE_TRIGGER_KEY_WORDS.some((sequence) =>
+    containsWordSequence(words, sequence),
+  );
 }
 
 function triggerKeyWords(key: string): string[] {
@@ -306,6 +391,10 @@ function containsWordSequence(words: readonly string[], sequence: readonly strin
 
 function looksLikeSecretValue(value: string): boolean {
   return SECRET_VALUE_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }
 
 function readMetadataString(

--- a/ts/src/session/runtime-child-tasks.ts
+++ b/ts/src/session/runtime-child-tasks.ts
@@ -2,10 +2,10 @@ import { randomUUID } from "node:crypto";
 import { agentOutputMetadata } from "../runtimes/agent-output-metadata.js";
 import type { AgentRuntime } from "../runtimes/base.js";
 import type { RuntimeCommandGrant, RuntimeWorkspaceEnv } from "../runtimes/workspace-env.js";
-import { Coordinator } from "./coordinator.js";
+import type { Coordinator } from "./coordinator.js";
 import {
   RuntimeSessionEventLog,
-  RuntimeSessionEventStore,
+  type RuntimeSessionEventStore,
   RuntimeSessionEventType,
 } from "./runtime-events.js";
 import { createRuntimeSessionGrantEventSink } from "./runtime-grant-events.js";
@@ -13,6 +13,7 @@ import { jsonSafeRecord } from "./runtime-json.js";
 import type { RuntimeSessionEventSink } from "./runtime-session-notifications.js";
 
 export const DEFAULT_CHILD_TASK_MAX_DEPTH = 4;
+export const DEFAULT_CHILD_TASK_MAX_CONCURRENT = 8;
 
 export interface RuntimeChildTaskHandlerInput {
   taskId: string;
@@ -45,6 +46,7 @@ export interface RuntimeChildTaskRunnerOpts {
   eventSink?: RuntimeSessionEventSink;
   depth?: number;
   maxDepth?: number;
+  maxConcurrentChildTasks?: number;
 }
 
 export interface RuntimeChildTaskRunOpts {
@@ -101,6 +103,7 @@ export class RuntimeChildTaskRunner {
   private readonly eventSink?: RuntimeSessionEventSink;
   private readonly depth: number;
   private readonly maxDepth: number;
+  private readonly maxConcurrentChildTasks: number;
 
   constructor(opts: RuntimeChildTaskRunnerOpts) {
     this.coordinator = opts.coordinator;
@@ -110,10 +113,15 @@ export class RuntimeChildTaskRunner {
     this.eventSink = opts.eventSink;
     this.depth = normalizeDepth(opts.depth ?? 0, "depth");
     this.maxDepth = normalizeDepth(opts.maxDepth ?? DEFAULT_CHILD_TASK_MAX_DEPTH, "maxDepth");
+    this.maxConcurrentChildTasks = normalizePositiveInteger(
+      opts.maxConcurrentChildTasks ?? DEFAULT_CHILD_TASK_MAX_CONCURRENT,
+      "maxConcurrentChildTasks",
+    );
   }
 
   async run(opts: RuntimeChildTaskRunOpts): Promise<RuntimeChildTaskResult> {
     const taskId = opts.taskId ?? randomUUID().slice(0, 12);
+    const activeChildCount = activeChildSessionIds(this.parentLog).size;
     const worker = this.coordinator.delegate(opts.prompt, opts.role);
     const childDepth = this.depth + 1;
     const childCwd = opts.cwd ? this.workspace.resolvePath(opts.cwd) : this.workspace.cwd;
@@ -128,30 +136,48 @@ export class RuntimeChildTaskRunner {
         cwd: childCwd,
         depth: childDepth,
         maxDepth: this.maxDepth,
+        status: "running",
       },
     });
     this.observeChildLog(childLog);
-    const childWorkspace = await this.workspace.scope({
-      cwd: opts.cwd,
-      commands: opts.commands,
-      grantInheritance: "child_task",
-      grantEventSink: createRuntimeSessionGrantEventSink(childLog, {
-        taskId,
-        childSessionId,
-        workerId: worker.workerId,
-      }),
-    });
     const coordinatorLineage = childTaskCoordinatorLineage({
       taskId,
       childSessionId,
       parentSessionId: this.parentLog.sessionId,
       role: opts.role,
-      cwd: childWorkspace.cwd,
+      cwd: childCwd,
       depth: childDepth,
       maxDepth: this.maxDepth,
     });
-    this.coordinator.startWorker(worker.workerId, coordinatorLineage);
 
+    if (this.depth >= this.maxDepth) {
+      this.coordinator.startWorker(worker.workerId, coordinatorLineage);
+      return this.failChildTask({
+        taskId,
+        childSessionId,
+        workerId: worker.workerId,
+        role: opts.role,
+        cwd: childCwd,
+        depth: childDepth,
+        childLog,
+        message: `Maximum child task depth (${this.maxDepth}) exceeded`,
+      });
+    }
+    if (activeChildCount >= this.maxConcurrentChildTasks) {
+      this.coordinator.startWorker(worker.workerId, coordinatorLineage);
+      return this.failChildTask({
+        taskId,
+        childSessionId,
+        workerId: worker.workerId,
+        role: opts.role,
+        cwd: childCwd,
+        depth: childDepth,
+        childLog,
+        message: `Maximum concurrent child sessions (${this.maxConcurrentChildTasks}) exceeded`,
+      });
+    }
+
+    this.coordinator.startWorker(worker.workerId, coordinatorLineage);
     this.parentLog.append(RuntimeSessionEventType.CHILD_TASK_STARTED, {
       taskId,
       childSessionId,
@@ -161,6 +187,45 @@ export class RuntimeChildTaskRunner {
       depth: childDepth,
       maxDepth: this.maxDepth,
     });
+    this.persist(childLog);
+
+    let childWorkspace: RuntimeWorkspaceEnv;
+    try {
+      childWorkspace = await this.workspace.scope({
+        cwd: opts.cwd,
+        commands: opts.commands,
+        grantInheritance: "child_task",
+        grantEventSink: createRuntimeSessionGrantEventSink(childLog, {
+          taskId,
+          childSessionId,
+          workerId: worker.workerId,
+        }),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return this.failChildTask({
+        taskId,
+        childSessionId,
+        workerId: worker.workerId,
+        role: opts.role,
+        cwd: childCwd,
+        depth: childDepth,
+        childLog,
+        message,
+      });
+    }
+    const canceledAfterScope = this.canceledChildLog(childLog);
+    if (canceledAfterScope) {
+      return this.canceledResult({
+        taskId,
+        childSessionId,
+        workerId: worker.workerId,
+        role: opts.role,
+        cwd: childWorkspace.cwd,
+        depth: childDepth,
+        childLog: canceledAfterScope,
+      });
+    }
     childLog.append(RuntimeSessionEventType.PROMPT_SUBMITTED, {
       prompt: opts.prompt,
       role: opts.role,
@@ -168,19 +233,6 @@ export class RuntimeChildTaskRunner {
       depth: childDepth,
       maxDepth: this.maxDepth,
     });
-
-    if (this.depth >= this.maxDepth) {
-      return this.failChildTask({
-        taskId,
-        childSessionId,
-        workerId: worker.workerId,
-        role: opts.role,
-        cwd: childWorkspace.cwd,
-        depth: childDepth,
-        childLog,
-        message: `Maximum child task depth (${this.maxDepth}) exceeded`,
-      });
-    }
 
     try {
       const output = await opts.handler({
@@ -196,7 +248,20 @@ export class RuntimeChildTaskRunner {
         workspace: childWorkspace,
         sessionLog: childLog,
       });
+      const canceledAfterHandler = this.canceledChildLog(childLog);
+      if (canceledAfterHandler) {
+        return this.canceledResult({
+          taskId,
+          childSessionId,
+          workerId: worker.workerId,
+          role: opts.role,
+          cwd: childWorkspace.cwd,
+          depth: childDepth,
+          childLog: canceledAfterHandler,
+        });
+      }
       const text = output.text;
+      childLog.metadata.status = "completed";
       childLog.append(RuntimeSessionEventType.ASSISTANT_MESSAGE, {
         text,
         metadata: jsonSafeRecord(output.metadata),
@@ -234,6 +299,18 @@ export class RuntimeChildTaskRunner {
       this.persist(childLog);
       return result;
     } catch (error) {
+      const canceledAfterError = this.canceledChildLog(childLog);
+      if (canceledAfterError) {
+        return this.canceledResult({
+          taskId,
+          childSessionId,
+          workerId: worker.workerId,
+          role: opts.role,
+          cwd: childWorkspace.cwd,
+          depth: childDepth,
+          childLog: canceledAfterError,
+        });
+      }
       const message = error instanceof Error ? error.message : String(error);
       return this.failChildTask({
         taskId,
@@ -258,6 +335,7 @@ export class RuntimeChildTaskRunner {
     childLog: RuntimeSessionEventLog;
     message: string;
   }): RuntimeChildTaskResult {
+    opts.childLog.metadata.status = "failed";
     this.coordinator.failWorker(opts.workerId, opts.message, {
       ...childTaskCoordinatorLineage({
         taskId: opts.taskId,
@@ -303,6 +381,52 @@ export class RuntimeChildTaskRunner {
     });
     this.persist(opts.childLog);
     return result;
+  }
+
+  private canceledResult(opts: {
+    taskId: string;
+    childSessionId: string;
+    workerId: string;
+    role: string;
+    cwd: string;
+    depth: number;
+    childLog: RuntimeSessionEventLog;
+  }): RuntimeChildTaskResult {
+    const reason = canceledChildReason(opts.childLog);
+    this.coordinator.failWorker(opts.workerId, reason, {
+      ...childTaskCoordinatorLineage({
+        taskId: opts.taskId,
+        childSessionId: opts.childSessionId,
+        parentSessionId: this.parentLog.sessionId,
+        role: opts.role,
+        cwd: opts.cwd,
+        depth: opts.depth,
+        maxDepth: this.maxDepth,
+      }),
+      isError: true,
+      phase: "canceled",
+      status: "canceled",
+    });
+    return this.result({
+      taskId: opts.taskId,
+      childSessionId: opts.childSessionId,
+      workerId: opts.workerId,
+      role: opts.role,
+      cwd: opts.cwd,
+      text: "",
+      isError: true,
+      error: reason,
+      depth: opts.depth,
+      childLog: opts.childLog,
+    });
+  }
+
+  private canceledChildLog(childLog: RuntimeSessionEventLog): RuntimeSessionEventLog | null {
+    const persisted = this.eventStore?.load(childLog.sessionId) ?? null;
+    for (const candidate of [persisted, childLog]) {
+      if (candidate && isCanceledChildLog(candidate)) return candidate;
+    }
+    return null;
   }
 
   private result(opts: {
@@ -383,4 +507,52 @@ function normalizeDepth(value: number, name: string): number {
     throw new Error(`${name} must be a non-negative integer`);
   }
   return value;
+}
+
+function normalizePositiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function activeChildSessionIds(log: RuntimeSessionEventLog): Set<string> {
+  const active = new Set<string>();
+  for (const event of log.events) {
+    if (event.eventType === RuntimeSessionEventType.CHILD_TASK_STARTED) {
+      const childSessionId = readString(event.payload.childSessionId);
+      if (childSessionId) active.add(childSessionId);
+    } else if (event.eventType === RuntimeSessionEventType.CHILD_TASK_COMPLETED) {
+      const childSessionId = readString(event.payload.childSessionId);
+      if (childSessionId) active.delete(childSessionId);
+    }
+  }
+  return active;
+}
+
+function isCanceledChildLog(log: RuntimeSessionEventLog): boolean {
+  if (isCanceledValue(log.metadata.status)) return true;
+  return log.events.some(
+    (event) =>
+      event.eventType === RuntimeSessionEventType.ASSISTANT_MESSAGE &&
+      (isCanceledValue(event.payload.phase) || isCanceledValue(event.payload.status)),
+  );
+}
+
+function canceledChildReason(log: RuntimeSessionEventLog): string {
+  for (const event of [...log.events].reverse()) {
+    if (event.eventType !== RuntimeSessionEventType.ASSISTANT_MESSAGE) continue;
+    if (!isCanceledValue(event.payload.phase) && !isCanceledValue(event.payload.status)) continue;
+    return readString(event.payload.error) || "canceled";
+  }
+  return "canceled";
+}
+
+function isCanceledValue(value: unknown): boolean {
+  const normalized = readString(value).toLowerCase().replace(/-/g, "_");
+  return normalized === "canceled" || normalized === "cancelled";
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }

--- a/ts/src/session/runtime-session.ts
+++ b/ts/src/session/runtime-session.ts
@@ -6,13 +6,14 @@ import type {
 } from "../runtimes/workspace-env.js";
 import { Coordinator } from "./coordinator.js";
 import {
+  DEFAULT_CHILD_TASK_MAX_CONCURRENT,
   RuntimeChildTaskRunner,
   type RuntimeChildTaskResult,
   type RuntimeChildTaskRunOpts,
 } from "./runtime-child-tasks.js";
 import {
   RuntimeSessionEventLog,
-  RuntimeSessionEventStore,
+  type RuntimeSessionEventStore,
   RuntimeSessionEventType,
 } from "./runtime-events.js";
 import { jsonSafeRecord } from "./runtime-json.js";
@@ -28,6 +29,7 @@ export interface RuntimeSessionCreateOpts {
   metadata?: Record<string, unknown>;
   depth?: number;
   maxDepth?: number;
+  maxConcurrentChildTasks?: number;
 }
 
 export interface RuntimeSessionLoadOpts {
@@ -37,6 +39,22 @@ export interface RuntimeSessionLoadOpts {
   eventSink?: RuntimeSessionEventSink;
   depth?: number;
   maxDepth?: number;
+  maxConcurrentChildTasks?: number;
+}
+
+export interface RuntimeChildSessionCancellation {
+  childSessionId: string;
+  parentSessionId: string;
+  taskId: string;
+  workerId: string;
+  status: "canceled";
+  reason: string;
+  childSessionLog: RuntimeSessionEventLog;
+}
+
+export interface RuntimeSessionCancelChildSessionOpts {
+  childSessionId: string;
+  reason?: string;
 }
 
 export interface RuntimeSessionPromptHandlerInput {
@@ -104,6 +122,7 @@ interface RuntimeSessionConstructorOpts {
   eventSink?: RuntimeSessionEventSink;
   depth?: number;
   maxDepth?: number;
+  maxConcurrentChildTasks?: number;
 }
 
 export class RuntimeSession {
@@ -116,6 +135,7 @@ export class RuntimeSession {
   private readonly eventSink?: RuntimeSessionEventSink;
   private readonly depth?: number;
   private readonly maxDepth?: number;
+  private readonly maxConcurrentChildTasks: number;
 
   private constructor(opts: RuntimeSessionConstructorOpts) {
     this.goal = opts.goal;
@@ -126,6 +146,10 @@ export class RuntimeSession {
     this.eventSink = opts.eventSink;
     this.depth = opts.depth;
     this.maxDepth = opts.maxDepth;
+    this.maxConcurrentChildTasks = normalizePositiveInteger(
+      opts.maxConcurrentChildTasks ?? DEFAULT_CHILD_TASK_MAX_CONCURRENT,
+      "maxConcurrentChildTasks",
+    );
     observeRuntimeSessionLog(this.log, this.eventStore, this.eventSink);
   }
 
@@ -142,6 +166,7 @@ export class RuntimeSession {
       eventSink: opts.eventSink,
       depth: opts.depth,
       maxDepth: opts.maxDepth,
+      maxConcurrentChildTasks: opts.maxConcurrentChildTasks,
     });
   }
 
@@ -158,6 +183,7 @@ export class RuntimeSession {
       eventSink: opts.eventSink,
       depth: opts.depth,
       maxDepth: opts.maxDepth,
+      maxConcurrentChildTasks: opts.maxConcurrentChildTasks,
     });
   }
 
@@ -243,6 +269,53 @@ export class RuntimeSession {
     return this.eventStore?.listChildren(this.sessionId) ?? [];
   }
 
+  cancelChildSession(opts: RuntimeSessionCancelChildSessionOpts): RuntimeChildSessionCancellation {
+    if (!this.eventStore) {
+      throw new Error("eventStore is required to cancel child sessions");
+    }
+    const childSessionId = opts.childSessionId.trim();
+    if (!childSessionId) {
+      throw new Error("childSessionId is required");
+    }
+    const childLog = this.eventStore.load(childSessionId);
+    if (!childLog) {
+      throw new Error(`Child session '${childSessionId}' not found`);
+    }
+    if (childLog.parentSessionId !== this.sessionId) {
+      throw new Error(`Child session '${childSessionId}' does not belong to parent '${this.sessionId}'`);
+    }
+    const reason = opts.reason?.trim() || "canceled";
+    childLog.metadata.status = "canceled";
+    childLog.append(RuntimeSessionEventType.ASSISTANT_MESSAGE, {
+      text: "",
+      error: reason,
+      isError: true,
+      phase: "canceled",
+      status: "canceled",
+    });
+    this.log.append(RuntimeSessionEventType.CHILD_TASK_COMPLETED, {
+      taskId: childLog.taskId,
+      childSessionId: childLog.sessionId,
+      workerId: childLog.workerId,
+      result: "",
+      error: reason,
+      isError: true,
+      phase: "canceled",
+      status: "canceled",
+    });
+    this.save();
+    this.eventStore.save(childLog);
+    return {
+      childSessionId: childLog.sessionId,
+      parentSessionId: this.sessionId,
+      taskId: childLog.taskId,
+      workerId: childLog.workerId,
+      status: "canceled",
+      reason,
+      childSessionLog: childLog,
+    };
+  }
+
   recordCompaction(opts: RuntimeSessionRecordCompactionOpts): void {
     if (opts.entries.length === 0) return;
     this.log.append(RuntimeSessionEventType.COMPACTION, compactionPayload(opts));
@@ -262,6 +335,7 @@ export class RuntimeSession {
       eventSink: this.eventSink,
       depth: this.depth,
       maxDepth: this.maxDepth,
+      maxConcurrentChildTasks: this.maxConcurrentChildTasks,
     });
   }
 
@@ -290,6 +364,13 @@ function readString(value: unknown): string {
 
 function readNumber(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function normalizePositiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
 }
 
 function compactionPayload(opts: RuntimeSessionRecordCompactionOpts): Record<string, unknown> {

--- a/ts/tests/background-session-api.test.ts
+++ b/ts/tests/background-session-api.test.ts
@@ -36,7 +36,11 @@ function createLog(
   });
 }
 
-function createTask(id: string, status: string, specName = "autoctx run support_triage"): TaskQueueRow {
+function createTask(
+  id: string,
+  status: string,
+  specName = "autoctx run support_triage",
+): TaskQueueRow {
   return {
     id,
     spec_name: specName,
@@ -54,6 +58,21 @@ function createTask(id: string, status: string, specName = "autoctx run support_
     error: null,
     created_at: `2026-04-10T00:00:${id === "queued-1" ? "03" : "01"}.000Z`,
     updated_at: `2026-04-10T00:00:${id === "queued-1" ? "03" : "04"}.000Z`,
+  };
+}
+
+function childStatusCounts(
+  overrides: Partial<Record<string, number>> = {},
+): Record<string, number> {
+  return {
+    queued: 0,
+    running: 0,
+    completed: 0,
+    failed: 0,
+    canceled: 0,
+    skipped: 0,
+    unknown: 0,
+    ...overrides,
   };
 }
 
@@ -76,10 +95,46 @@ function createChildLog(): RuntimeSessionEventLog {
     parentSessionId: "run:abc:runtime",
     taskId: "child-1",
     workerId: "worker-child",
-    metadata: { goal: "Inspect failing test", runId: "abc", status: "completed" },
+    metadata: {
+      goal: "Inspect failing test",
+      runId: "abc",
+      status: "completed",
+      artifacts: [
+        {
+          artifact_id: "child-report",
+          kind: "report",
+          label: "Child report",
+          path: "runs/abc/child-report.md",
+          token: "SECRET_VALUE",
+        },
+      ],
+    },
     createdAt: "2026-04-10T00:00:03.000Z",
     updatedAt: "2026-04-10T00:00:04.000Z",
-    events: [],
+    events: [
+      {
+        eventId: "child-prompt",
+        sessionId: "task:run:abc:runtime:child-1",
+        sequence: 0,
+        eventType: RuntimeSessionEventType.PROMPT_SUBMITTED,
+        timestamp: "2026-04-10T00:00:03.500Z",
+        payload: { role: "analyst", prompt: "SECRET_VALUE" },
+        parentSessionId: "run:abc:runtime",
+        taskId: "child-1",
+        workerId: "worker-child",
+      },
+      {
+        eventId: "child-answer",
+        sessionId: "task:run:abc:runtime:child-1",
+        sequence: 1,
+        eventType: RuntimeSessionEventType.ASSISTANT_MESSAGE,
+        timestamp: "2026-04-10T00:00:04.000Z",
+        payload: { role: "analyst", text: "SECRET_VALUE" },
+        parentSessionId: "run:abc:runtime",
+        taskId: "child-1",
+        workerId: "worker-child",
+      },
+    ],
   });
 }
 
@@ -108,6 +163,7 @@ describe("background session HTTP API routes", () => {
           status: "running",
           event_count: 1,
           child_session_count: 1,
+          child_status_counts: childStatusCounts({ completed: 1 }),
         }),
       ],
     });
@@ -181,12 +237,26 @@ describe("background session HTTP API routes", () => {
 
     expect(response.status).toBe(200);
     expect(load).toHaveBeenCalledWith("run:abc:runtime");
-    expect(body.summary).toMatchObject({ session_id: "run:abc:runtime" });
+    expect(body.summary).toMatchObject({
+      session_id: "run:abc:runtime",
+      child_status_counts: childStatusCounts({ completed: 1 }),
+      artifact_count: 1,
+    });
     expect(body.child_sessions).toEqual([
       expect.objectContaining({
         session_id: "task:run:abc:runtime:child-1",
         status: "completed",
+        artifact_count: 1,
       }),
+    ]);
+    expect(body.artifacts).toEqual([
+      {
+        artifact_id: "child-report",
+        kind: "report",
+        label: "Child report",
+        path: "runs/abc/child-report.md",
+        url: "",
+      },
     ]);
     expect(body.trigger).toEqual({
       type: "github_webhook",
@@ -196,6 +266,31 @@ describe("background session HTTP API routes", () => {
     });
     expect(body.normalized_events).toEqual([
       expect.objectContaining({ event: "prompt_started", source_event_type: "prompt_submitted" }),
+      expect.objectContaining({
+        event_id: "child-prompt",
+        session_id: "task:run:abc:runtime:child-1",
+        event: "prompt_started",
+        payload_summary: {
+          role: "analyst",
+          child_session_id: "task:run:abc:runtime:child-1",
+          parent_session_id: "run:abc:runtime",
+          task_id: "child-1",
+          worker_id: "worker-child",
+        },
+      }),
+      expect.objectContaining({
+        event_id: "child-answer",
+        session_id: "task:run:abc:runtime:child-1",
+        event: "runtime_event",
+        status: "completed",
+        payload_summary: {
+          role: "analyst",
+          child_session_id: "task:run:abc:runtime:child-1",
+          parent_session_id: "run:abc:runtime",
+          task_id: "child-1",
+          worker_id: "worker-child",
+        },
+      }),
     ]);
     expect(JSON.stringify(body)).not.toContain("SECRET_VALUE");
   });

--- a/ts/tests/background-session-events.test.ts
+++ b/ts/tests/background-session-events.test.ts
@@ -131,6 +131,69 @@ describe("background session normalized events", () => {
     expect(JSON.stringify(events)).not.toContain("SECRET_VALUE");
   });
 
+  it("includes child session events in parent timeline summaries", () => {
+    const child = RuntimeSessionEventLog.fromJSON({
+      sessionId: "task:run:run-123:runtime:child-1",
+      parentSessionId: "run:run-123:runtime",
+      taskId: "child-1",
+      workerId: "worker-child",
+      metadata: { goal: "Inspect failing test", status: "failed" },
+      createdAt: "2026-06-01T00:00:31.000Z",
+      updatedAt: "2026-06-01T00:00:36.000Z",
+      events: [
+        {
+          eventId: "child-prompt",
+          sessionId: "task:run:run-123:runtime:child-1",
+          sequence: 0,
+          eventType: RuntimeSessionEventType.PROMPT_SUBMITTED,
+          timestamp: "2026-06-01T00:00:35.000Z",
+          payload: { role: "analyst", prompt: "SECRET_VALUE" },
+          parentSessionId: "run:run-123:runtime",
+          taskId: "child-1",
+          workerId: "worker-child",
+        },
+        {
+          eventId: "child-answer",
+          sessionId: "task:run:run-123:runtime:child-1",
+          sequence: 1,
+          eventType: RuntimeSessionEventType.ASSISTANT_MESSAGE,
+          timestamp: "2026-06-01T00:00:36.000Z",
+          payload: { role: "analyst", isError: true, error: "SECRET_VALUE" },
+          parentSessionId: "run:run-123:runtime",
+          taskId: "child-1",
+          workerId: "worker-child",
+        },
+      ],
+    });
+
+    const events = normalizeBackgroundSessionTimeline(createRuntimeLog(), { childLogs: [child] });
+
+    expect(events.map((event) => event.event_id)).toEqual([
+      "event-1",
+      "event-2",
+      "event-3",
+      "child-prompt",
+      "child-answer",
+      "event-4",
+    ]);
+    expect(events[3].payload_summary).toEqual({
+      role: "analyst",
+      child_session_id: "task:run:run-123:runtime:child-1",
+      parent_session_id: "run:run-123:runtime",
+      task_id: "child-1",
+      worker_id: "worker-child",
+    });
+    expect(events[4].status).toBe("failed");
+    expect(events[4].payload_summary).toEqual({
+      role: "analyst",
+      child_session_id: "task:run:run-123:runtime:child-1",
+      parent_session_id: "run:run-123:runtime",
+      task_id: "child-1",
+      worker_id: "worker-child",
+    });
+    expect(JSON.stringify(events)).not.toContain("SECRET_VALUE");
+  });
+
   it("marks failed runtime payloads from assistants and grants as failed", () => {
     const log = RuntimeSessionEventLog.fromJSON({
       sessionId: "run:failed-runtime:runtime",
@@ -147,7 +210,23 @@ describe("background session normalized events", () => {
           sequence: 0,
           eventType: RuntimeSessionEventType.ASSISTANT_MESSAGE,
           timestamp: "2026-06-01T01:00:01.000Z",
-          payload: { requestId: "req-failed", role: "competitor", isError: true, error: "SECRET_VALUE" },
+          payload: {
+            requestId: "req-failed",
+            role: "competitor",
+            isError: true,
+            error: "SECRET_VALUE",
+          },
+          parentSessionId: "",
+          taskId: "task-failed",
+          workerId: "worker-1",
+        },
+        {
+          eventId: "assistant-canceled",
+          sessionId: "run:failed-runtime:runtime",
+          sequence: 1,
+          eventType: RuntimeSessionEventType.ASSISTANT_MESSAGE,
+          timestamp: "2026-06-01T01:00:01.500Z",
+          payload: { phase: "canceled", isError: true, error: "SECRET_VALUE" },
           parentSessionId: "",
           taskId: "task-failed",
           workerId: "worker-1",
@@ -155,7 +234,7 @@ describe("background session normalized events", () => {
         {
           eventId: "tool-failed",
           sessionId: "run:failed-runtime:runtime",
-          sequence: 1,
+          sequence: 2,
           eventType: RuntimeSessionEventType.TOOL_CALL,
           timestamp: "2026-06-01T01:00:02.000Z",
           payload: { tool: "workspace.write", phase: "error", error: "SECRET_VALUE" },
@@ -166,10 +245,26 @@ describe("background session normalized events", () => {
         {
           eventId: "shell-failed",
           sessionId: "run:failed-runtime:runtime",
-          sequence: 2,
+          sequence: 3,
           eventType: RuntimeSessionEventType.SHELL_COMMAND,
           timestamp: "2026-06-01T01:00:03.000Z",
-          payload: { command: "npm test", cwd: "/workspace", phase: "error", error: "SECRET_VALUE" },
+          payload: {
+            command: "npm test",
+            cwd: "/workspace",
+            phase: "error",
+            error: "SECRET_VALUE",
+          },
+          parentSessionId: "",
+          taskId: "task-failed",
+          workerId: "worker-1",
+        },
+        {
+          eventId: "child-canceled",
+          sessionId: "run:failed-runtime:runtime",
+          sequence: 4,
+          eventType: RuntimeSessionEventType.CHILD_TASK_COMPLETED,
+          timestamp: "2026-06-01T01:00:04.000Z",
+          payload: { taskId: "child-1", phase: "canceled", isError: true, error: "SECRET_VALUE" },
           parentSessionId: "",
           taskId: "task-failed",
           workerId: "worker-1",
@@ -181,8 +276,10 @@ describe("background session normalized events", () => {
 
     expect(events.map((event) => [event.event_id, event.status, event.payload_summary])).toEqual([
       ["assistant-failed", "failed", { request_id: "req-failed", role: "competitor" }],
+      ["assistant-canceled", "canceled", {}],
       ["tool-failed", "failed", { tool: "workspace.write" }],
       ["shell-failed", "failed", { command: "npm test", cwd: "/workspace" }],
+      ["child-canceled", "canceled", { task_id: "child-1" }],
     ]);
     expect(JSON.stringify(events)).not.toContain("SECRET_VALUE");
   });

--- a/ts/tests/background-session-read-model.test.ts
+++ b/ts/tests/background-session-read-model.test.ts
@@ -58,11 +58,39 @@ function createChildLog(): RuntimeSessionEventLog {
     parentSessionId: "run:run-123:runtime",
     taskId: "child-1",
     workerId: "worker-child",
-    metadata: { goal: "Inspect failing test", runId: "run-123", status: "completed" },
+    metadata: {
+      goal: "Inspect failing test",
+      runId: "run-123",
+      status: "completed",
+      artifacts: [
+        {
+          artifact_id: "child-report",
+          kind: "report",
+          label: "Child report",
+          path: "runs/run-123/child-report.md",
+          token: "SECRET_VALUE",
+        },
+      ],
+    },
     createdAt: "2026-06-01T00:00:30.000Z",
     updatedAt: "2026-06-01T00:00:45.000Z",
     events: [],
   });
+}
+
+function childStatusCounts(
+  overrides: Partial<Record<string, number>> = {},
+): Record<string, number> {
+  return {
+    queued: 0,
+    running: 0,
+    completed: 0,
+    failed: 0,
+    canceled: 0,
+    skipped: 0,
+    unknown: 0,
+    ...overrides,
+  };
 }
 
 function createTask(overrides: Partial<TaskQueueRow> = {}): TaskQueueRow {
@@ -120,6 +148,7 @@ describe("background session read model", () => {
       event_count: 2,
       artifact_count: 2,
       child_session_count: 1,
+      child_status_counts: childStatusCounts({ completed: 1 }),
       created_at: "2026-06-01T00:00:00.000Z",
       updated_at: "2026-06-01T00:01:00.000Z",
       result_url: "/api/cockpit/background-sessions/run%3Arun-123%3Aruntime",
@@ -149,6 +178,7 @@ describe("background session read model", () => {
       event_count: 0,
       artifact_count: 0,
       child_session_count: 0,
+      child_status_counts: childStatusCounts(),
       created_at: "2026-06-01T00:00:00.000Z",
       updated_at: "2026-06-01T00:00:10.000Z",
       result_url: "/api/cockpit/background-sessions/task%3Aqueued-1",
@@ -172,7 +202,11 @@ describe("background session read model", () => {
       childSessions: [createChildLog()],
     });
 
-    expect(detail.summary.session_id).toBe("run:run-123:runtime");
+    expect(detail.summary).toMatchObject({
+      session_id: "run:run-123:runtime",
+      artifact_count: 2,
+      child_status_counts: childStatusCounts({ completed: 1 }),
+    });
     expect(detail.artifacts).toEqual([
       {
         artifact_id: "pr-1",
@@ -181,12 +215,20 @@ describe("background session read model", () => {
         path: "",
         url: "https://github.example/pr/1",
       },
+      {
+        artifact_id: "child-report",
+        kind: "report",
+        label: "Child report",
+        path: "runs/run-123/child-report.md",
+        url: "",
+      },
     ]);
     expect(detail.child_sessions).toEqual([
       expect.objectContaining({
         session_id: "task:run:run-123:runtime:child-1",
         parent_session_id: "run:run-123:runtime",
         status: "completed",
+        artifact_count: 1,
       }),
     ]);
     expect(detail.trigger).toEqual({ type: "manual", actor: "operator" });

--- a/ts/tests/runtime-child-session-controls.test.ts
+++ b/ts/tests/runtime-child-session-controls.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from "vitest";
+
+import { createInMemoryWorkspaceEnv } from "../src/runtimes/workspace-env.js";
+import { RuntimeSession } from "../src/session/runtime-session.js";
+import {
+  RuntimeSessionEventLog,
+  type RuntimeSessionEventStore,
+  RuntimeSessionEventType,
+} from "../src/session/runtime-events.js";
+
+function createEventStore(): RuntimeSessionEventStore & { close(): void } {
+  const logs = new Map<string, RuntimeSessionEventLog>();
+  return {
+    save(log: RuntimeSessionEventLog): void {
+      logs.set(log.sessionId, log);
+    },
+    load(sessionId: string): RuntimeSessionEventLog | null {
+      return logs.get(sessionId) ?? null;
+    },
+    listChildren(parentSessionId: string): RuntimeSessionEventLog[] {
+      return Array.from(logs.values()).filter((log) => log.parentSessionId === parentSessionId);
+    },
+    close(): void {},
+  } as unknown as RuntimeSessionEventStore & { close(): void };
+}
+
+function last<T>(items: readonly T[]): T | undefined {
+  return items[items.length - 1];
+}
+
+describe("runtime child session controls", () => {
+  it("reserves child-session slots before async workspace setup", async () => {
+    const workspace = createInMemoryWorkspaceEnv({ cwd: "/workspace" });
+    const eventStore = createEventStore();
+    const session = RuntimeSession.create({
+      sessionId: "runtime-parent",
+      goal: "ship auth",
+      workspace,
+      eventStore,
+      maxConcurrentChildTasks: 1,
+    });
+    const startedTasks: string[] = [];
+
+    const [first, second] = await Promise.all([
+      session.runChildTask({
+        taskId: "first",
+        prompt: "First child",
+        role: "analyst",
+        handler: (input) => {
+          startedTasks.push(input.taskId);
+          return { text: "first complete" };
+        },
+      }),
+      session.runChildTask({
+        taskId: "second",
+        prompt: "Second child",
+        role: "analyst",
+        handler: (input) => {
+          startedTasks.push(input.taskId);
+          return { text: "second complete" };
+        },
+      }),
+    ]);
+
+    expect(startedTasks).toEqual(["first"]);
+    expect(first).toMatchObject({ taskId: "first", isError: false, text: "first complete" });
+    expect(second).toMatchObject({
+      taskId: "second",
+      isError: true,
+      error: "Maximum concurrent child sessions (1) exceeded",
+    });
+    const parent = eventStore.load("runtime-parent");
+    const startedEvents = (parent?.events ?? []).filter(
+      (event) => event.eventType === RuntimeSessionEventType.CHILD_TASK_STARTED,
+    );
+    expect(startedEvents.map((event) => event.payload.taskId)).toEqual(["first"]);
+
+    eventStore.close();
+  });
+
+  it("records max-concurrent child task guardrail failures through the facade", async () => {
+    const workspace = createInMemoryWorkspaceEnv({ cwd: "/workspace" });
+    const eventStore = createEventStore();
+    const session = RuntimeSession.create({
+      sessionId: "runtime-parent",
+      goal: "ship auth",
+      workspace,
+      eventStore,
+      maxConcurrentChildTasks: 1,
+    });
+    session.log.append(RuntimeSessionEventType.CHILD_TASK_STARTED, {
+      taskId: "active",
+      childSessionId: "child-active",
+      workerId: "worker-active",
+    });
+    session.save();
+    let called = false;
+
+    const result = await session.runChildTask({
+      taskId: "queued",
+      prompt: "Queue one more",
+      role: "analyst",
+      handler: () => {
+        called = true;
+        return { text: "should not run" };
+      },
+    });
+
+    expect(called).toBe(false);
+    expect(result).toMatchObject({
+      isError: true,
+      error: "Maximum concurrent child sessions (1) exceeded",
+    });
+    const parent = eventStore.load("runtime-parent");
+    const child = eventStore.load(result.childSessionId);
+    expect(last(parent?.events ?? [])?.eventType).toBe(
+      RuntimeSessionEventType.CHILD_TASK_COMPLETED,
+    );
+    expect(last(parent?.events ?? [])?.payload).toMatchObject({
+      isError: true,
+      error: "Maximum concurrent child sessions (1) exceeded",
+    });
+    expect(child?.metadata.status).toBe("failed");
+    expect(last(child?.events ?? [])?.payload.isError).toBe(true);
+
+    eventStore.close();
+  });
+
+  it("does not overwrite child sessions canceled while their handler is in flight", async () => {
+    const workspace = createInMemoryWorkspaceEnv({ cwd: "/workspace" });
+    const eventStore = createEventStore();
+    const session = RuntimeSession.create({
+      sessionId: "runtime-parent",
+      goal: "ship auth",
+      workspace,
+      eventStore,
+    });
+
+    const result = await session.runChildTask({
+      taskId: "child",
+      prompt: "Do child work",
+      role: "analyst",
+      handler: (input) => {
+        session.cancelChildSession({
+          childSessionId: input.childSessionId,
+          reason: "operator requested",
+        });
+        return { text: "late success" };
+      },
+    });
+
+    expect(result.childSessionId).toMatch(/^task:runtime-parent:child:/);
+    expect(result).toMatchObject({
+      isError: true,
+      error: "operator requested",
+      text: "",
+    });
+    const parent = eventStore.load("runtime-parent");
+    const canceledChild = eventStore.load(result.childSessionId);
+    const completions = (parent?.events ?? []).filter(
+      (event) =>
+        event.eventType === RuntimeSessionEventType.CHILD_TASK_COMPLETED &&
+        event.payload.childSessionId === result.childSessionId,
+    );
+    expect(completions).toHaveLength(1);
+    expect(completions[0]?.payload).toMatchObject({
+      phase: "canceled",
+      status: "canceled",
+      error: "operator requested",
+    });
+    expect(canceledChild?.metadata.status).toBe("canceled");
+    expect(session.coordinator.activeWorkers).toEqual([]);
+    expect(JSON.stringify(canceledChild?.toJSON())).not.toContain("late success");
+
+    eventStore.close();
+  });
+
+  it("cancels active child sessions through the facade", () => {
+    const workspace = createInMemoryWorkspaceEnv({ cwd: "/workspace" });
+    const eventStore = createEventStore();
+    const session = RuntimeSession.create({
+      sessionId: "runtime-parent",
+      goal: "ship auth",
+      workspace,
+      eventStore,
+    });
+    const child = RuntimeSessionEventLog.create({
+      sessionId: "task:runtime-parent:child:worker-1",
+      parentSessionId: "runtime-parent",
+      taskId: "child",
+      workerId: "worker-1",
+      metadata: { goal: "child work", status: "running" },
+    });
+    child.append(RuntimeSessionEventType.PROMPT_SUBMITTED, {
+      prompt: "SECRET_VALUE",
+      role: "analyst",
+    });
+    eventStore.save(child);
+    session.log.append(RuntimeSessionEventType.CHILD_TASK_STARTED, {
+      taskId: "child",
+      childSessionId: child.sessionId,
+      workerId: "worker-1",
+      role: "analyst",
+    });
+    session.save();
+
+    const cancellation = session.cancelChildSession({
+      childSessionId: child.sessionId,
+      reason: "operator requested",
+    });
+
+    expect(cancellation).toMatchObject({
+      childSessionId: child.sessionId,
+      status: "canceled",
+      reason: "operator requested",
+    });
+    const parent = eventStore.load("runtime-parent");
+    const canceledChild = eventStore.load(child.sessionId);
+    expect(canceledChild?.metadata.status).toBe("canceled");
+    expect(last(canceledChild?.events ?? [])?.eventType).toBe(
+      RuntimeSessionEventType.ASSISTANT_MESSAGE,
+    );
+    expect(last(canceledChild?.events ?? [])?.payload).toEqual({
+      text: "",
+      error: "operator requested",
+      isError: true,
+      phase: "canceled",
+      status: "canceled",
+    });
+    expect(last(parent?.events ?? [])?.eventType).toBe(
+      RuntimeSessionEventType.CHILD_TASK_COMPLETED,
+    );
+    expect(last(parent?.events ?? [])?.payload).toEqual({
+      taskId: "child",
+      childSessionId: child.sessionId,
+      workerId: "worker-1",
+      result: "",
+      error: "operator requested",
+      isError: true,
+      phase: "canceled",
+      status: "canceled",
+    });
+
+    eventStore.close();
+  });
+});


### PR DESCRIPTION
## Summary
- aggregate child runtime-session status counts, artifacts, and timeline events into parent background-session read models in Python and TypeScript
- add runtime facade controls for max concurrent child sessions and child-session cancellation with persisted status transitions
- keep normalized event payloads sanitized while preserving child lineage across parent/child timelines

## Tests
- UV_EXCLUDE_NEWER=2026-04-10T14:55:41Z uv run pytest tests/test_background_session_read_model.py tests/test_background_session_events.py tests/test_background_session_api.py tests/test_runtime_child_session_controls.py -q
- UV_EXCLUDE_NEWER=2026-04-10T14:55:41Z uv run ruff check src/autocontext/session/runtime_session.py src/autocontext/session/__init__.py src/autocontext/session/background_session_read_model.py src/autocontext/session/background_session_events.py src/autocontext/server/background_session_api.py tests/test_background_session_read_model.py tests/test_background_session_events.py tests/test_background_session_api.py tests/test_runtime_child_session_controls.py
- UV_EXCLUDE_NEWER=2026-04-10T14:55:41Z uv run mypy src/autocontext/session/runtime_session.py src/autocontext/session/__init__.py src/autocontext/session/background_session_read_model.py src/autocontext/session/background_session_events.py src/autocontext/server/background_session_api.py tests/test_background_session_read_model.py tests/test_background_session_events.py tests/test_background_session_api.py tests/test_runtime_child_session_controls.py
- npx vitest run tests/background-session-read-model.test.ts tests/background-session-events.test.ts tests/background-session-api.test.ts tests/runtime-child-session-controls.test.ts --reporter=verbose
- npm run lint -- --pretty false
- git diff --check origin/main...HEAD && git diff --check

Linear: AC-783