### PR TITLE
AC-762 implement Node agent app build target MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ pi install npm:pi-autocontext@0.2.5
 | `train`            | `autoctx train --scenario <name> --data <jsonl>`       | Distill stable exported data into a cheaper local runtime                              |
 | `context-selection` | `bunx autoctx context-selection --run-id <run-id> --json` (TypeScript CLI) | Inspect persisted prompt context budget, cache, diagnostics, and selection telemetry   |
 | `runtime-sessions` | `bunx autoctx runtime-sessions timeline --run-id <run-id>` (TypeScript CLI) | Inspect persisted provider prompts, messages, child-task events, and operator-facing timelines from runtime-backed runs; also exposed through Python and TypeScript MCP/cockpit HTTP, the TypeScript TUI `/timeline` plus persisted filterable and resettable `/activity` live feed, and `/ws/events` updates |
-| `agent`            | `bunx autoctx agent run support --id ticket-123 --payload '{"message":"..."}' --json` (TypeScript CLI) | Invoke experimental `.autoctx/agents` handlers locally, or run `autoctx agent dev` for `/manifest` and `/agents/<name>/invoke` routes |
+| `agent`            | `bunx autoctx agent run support --id ticket-123 --payload '{"message":"..."}' --json` (TypeScript CLI) | Invoke experimental `.autoctx/agents` handlers locally, run `autoctx agent dev`, or generate the self-hosted Node target with `autoctx agent build --target node` |
 | `hermes`           | `uv run autoctx hermes inspect --json` (Python)        | Inspect Hermes v0.12 skill usage and Curator reports, or export the Hermes skill       |
 | `replay`           | `autoctx replay <run_id> --generation N`               | Inspect what happened before deciding what knowledge should persist                    |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - **`analyze`** — interpret and compare outputs from all surfaces
 - **`context-selection`** — inspect persisted prompt context telemetry for run budget/cache tuning
 - **`mission`** — real-world goal execution with adaptive planning and campaigns
-- **`agent`** — TypeScript local runner/dev server for experimental `.autoctx/agents` handlers
+- **`agent`** — TypeScript local runner/dev server and self-hosted Node build target for experimental `.autoctx/agents` handlers
 - **`train`** — distill curated datasets into scenario-local models
 - **`hermes`** — read-only Hermes v0.12 skill/Curator inspection plus Hermes skill export
 

--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -107,6 +107,9 @@ runtime-session recording through the same umbrella-owned event contracts used
 by local execution until those contracts are extracted into `@autocontext/core`.
 It may generate a minimal server entrypoint and package manifest, but should not
 invent a second handler API or bypass the runtime workspace/session contracts.
+The umbrella CLI dispatch is `autoctx agent build --target node`, which
+materializes a self-hosted Node package exposing `GET /manifest` and
+`POST /agents/<agent>/invoke` with the same wire shape as `autoctx agent dev`.
 
 The MVP is approved only as a packaging/control-plane layer around existing
 contracts:

--- a/ts/README.md
+++ b/ts/README.md
@@ -95,9 +95,15 @@ const result = await invokeAutoctxAgent(agent, {
 });
 ```
 
-For local iteration, the npm CLI can invoke the same handlers by name or expose
-a tiny dev server. Env file loading is explicit: pass `--env FILE`; values
-already set in the shell win over values in that file.
+For local iteration, the npm CLI can invoke the same handlers by name, expose
+a tiny dev server, or materialize the approved self-hosted Node build target.
+Env file loading is explicit: pass `--env FILE` to local run/dev, or set
+`AUTOCTX_ENV_FILE` for a generated Node server; values already set in the shell
+win over values in that file. Generated packages use a local `file:` dependency
+on the currently installed `autoctx`, so source builds do not reinstall an older
+npm release that lacks the Node-target subpath. Runtime-backed generated servers
+accept `AUTOCTX_RUNTIME_MODULE` as a bare package specifier, relative/absolute
+file path, or URL.
 
 ```bash
 autoctx agent run support \
@@ -107,6 +113,9 @@ autoctx agent run support \
   --json
 
 autoctx agent dev --port 3583 --env .env.local
+
+autoctx agent build --target node --out .autoctx/build/node
+cd .autoctx/build/node && npm install && AUTOCTX_ENV_FILE=.env.local npm start
 
 curl http://127.0.0.1:3583/manifest
 curl -X POST http://127.0.0.1:3583/agents/support/invoke \

--- a/ts/package.json
+++ b/ts/package.json
@@ -69,6 +69,10 @@
       "import": "./dist/control-plane/external-evals/index.js",
       "types": "./dist/control-plane/external-evals/index.d.ts"
     },
+    "./control-plane/agent-app-node": {
+      "import": "./dist/control-plane/agent-app-node/index.js",
+      "types": "./dist/control-plane/agent-app-node/index.d.ts"
+    },
     "./production-traces": {
       "types": "./dist/production-traces/sdk/index.d.ts",
       "import": "./dist/production-traces/sdk/index.js",

--- a/ts/src/cli/agent-command-workflow.ts
+++ b/ts/src/cli/agent-command-workflow.ts
@@ -16,6 +16,7 @@ export const AGENT_COMMAND_HELP_TEXT = `autoctx agent — Run local programmable
 Usage:
   autoctx agent run <agent> --id <id> [--payload JSON] [--env FILE] [--json]
   autoctx agent dev [--port 3583] [--host 127.0.0.1] [--env FILE] [--json]
+  autoctx agent build --target node [--out .autoctx/build/node] [--json]
 
 Options:
   --id <id>             Invocation/session id for agent run
@@ -28,15 +29,18 @@ Options:
   --base-url <url>      Base URL override for compatible providers
   --port <port>         Dev server port (default: 3583)
   --host <host>         Dev server host (default: 127.0.0.1)
+  --target <target>     Agent app build target (MVP: node)
+  --out <dir>           Output directory for agent app build artifacts
   --json                Output machine-readable JSON
 
-Dev server routes:
+Dev/build server routes:
   GET  /manifest
   POST /agents/<agent>/invoke
 
 Examples:
   autoctx agent run support --id ticket-123 --payload '{"message":"Please triage this."}' --env .env.local --json
-  autoctx agent dev --port 3583 --env .env.local`;
+  autoctx agent dev --port 3583 --env .env.local
+  autoctx agent build --target node --out .autoctx/build/node`;
 
 export interface AutoctxAgentCommandValues {
   id?: string;
@@ -50,6 +54,8 @@ export interface AutoctxAgentCommandValues {
   model?: string;
   "api-key"?: string;
   "base-url"?: string;
+  target?: string;
+  out?: string;
 }
 
 export interface AutoctxAgentRunCommandPlan {
@@ -79,9 +85,18 @@ export interface AutoctxAgentDevCommandPlan {
   baseUrl?: string;
 }
 
+export interface AutoctxAgentBuildCommandPlan {
+  action: "build";
+  target: "node";
+  outDir?: string;
+  cwd?: string;
+  json: boolean;
+}
+
 export type AutoctxAgentCommandPlan =
   | AutoctxAgentRunCommandPlan
-  | AutoctxAgentDevCommandPlan;
+  | AutoctxAgentDevCommandPlan
+  | AutoctxAgentBuildCommandPlan;
 
 export interface AutoctxAgentCommandResult {
   stdout: string;
@@ -123,6 +138,11 @@ export interface ExecuteAutoctxAgentRunCommandWorkflowOptions {
   cwd: string;
   processEnv?: Record<string, string | undefined>;
   createRuntime?: AutoctxAgentRuntimeFactory;
+}
+
+export interface ExecuteAutoctxAgentBuildCommandWorkflowOptions {
+  plan: AutoctxAgentBuildCommandPlan;
+  cwd: string;
 }
 
 export interface AutoctxAgentDevServerOptions {
@@ -179,7 +199,23 @@ export function planAutoctxAgentCommand(
       baseUrl: normalizeOptionalString(values["base-url"]),
     };
   }
-  throw new Error("agent requires a subcommand: run or dev");
+  if (action === "build") {
+    if (name || extra.length > 0) {
+      throw new Error(`Unexpected agent build arguments: ${[name, ...extra].filter(Boolean).join(" ")}`);
+    }
+    const target = normalizeOptionalString(values.target) ?? "node";
+    if (target !== "node") {
+      throw new Error("agent build currently only supports --target node");
+    }
+    return {
+      action: "build",
+      target,
+      outDir: normalizeOptionalString(values.out),
+      cwd: normalizeOptionalString(values.cwd),
+      json: !!values.json,
+    };
+  }
+  throw new Error("agent requires a subcommand: run, dev, or build");
 }
 
 export function loadAutoctxAgentEnvFile(
@@ -237,6 +273,41 @@ export async function executeAutoctxAgentRunCommandWorkflow(
     await closeRuntimeHandle(runtimeHandle);
     await workspace.cleanup();
   }
+}
+
+export async function executeAutoctxAgentBuildCommandWorkflow(
+  options: ExecuteAutoctxAgentBuildCommandWorkflowOptions,
+): Promise<AutoctxAgentCommandResult> {
+  const { buildNodeAgentAppTarget } = await import("../control-plane/agent-app-node/index.js");
+  const root = path.resolve(options.cwd, options.plan.cwd ?? ".");
+  const result = await buildNodeAgentAppTarget({
+    cwd: root,
+    outDir: options.plan.outDir,
+  });
+  if (options.plan.json) {
+    return {
+      stdout: JSON.stringify({
+        ok: true,
+        target: result.target,
+        outputDir: result.outputDir,
+        files: result.files.map((file) => file.relativePath),
+        routes: result.routes,
+      }, null, 2),
+      stderr: "",
+      exitCode: 0,
+    };
+  }
+  return {
+    stdout: [
+      `Generated AutoContext Node agent app at ${result.outputDir}`,
+      "Routes:",
+      ...result.routes.map((route) => `  ${route}`),
+      "Files:",
+      ...result.files.map((file) => `  ${file.relativePath}`),
+    ].join("\n"),
+    stderr: "",
+    exitCode: 0,
+  };
 }
 
 export function renderAutoctxAgentCommandError(

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -395,6 +395,8 @@ async function cmdAgent(): Promise<void> {
       model: { type: "string" },
       "api-key": { type: "string" },
       "base-url": { type: "string" },
+      target: { type: "string" },
+      out: { type: "string" },
       help: { type: "boolean", short: "h" },
     },
   });
@@ -402,6 +404,7 @@ async function cmdAgent(): Promise<void> {
   const {
     AGENT_COMMAND_HELP_TEXT,
     createAutoctxAgentDevServer,
+    executeAutoctxAgentBuildCommandWorkflow,
     executeAutoctxAgentRunCommandWorkflow,
     planAutoctxAgentCommand,
     renderAutoctxAgentCommandError,
@@ -427,6 +430,21 @@ async function cmdAgent(): Promise<void> {
         cwd: process.cwd(),
         processEnv: process.env,
         createRuntime: createAutoctxAgentCliRuntime,
+      });
+      if (result.stderr) process.stderr.write(result.stderr + "\n");
+      if (result.stdout) process.stdout.write(result.stdout + "\n");
+      process.exit(result.exitCode);
+    } catch (error) {
+      console.error(renderAutoctxAgentCommandError(error, plan.json));
+      process.exit(1);
+    }
+  }
+
+  if (plan.action === "build") {
+    try {
+      const result = await executeAutoctxAgentBuildCommandWorkflow({
+        plan,
+        cwd: process.cwd(),
       });
       if (result.stderr) process.stderr.write(result.stderr + "\n");
       if (result.stdout) process.stdout.write(result.stdout + "\n");

--- a/ts/src/control-plane/agent-app-node/index.ts
+++ b/ts/src/control-plane/agent-app-node/index.ts
@@ -1,0 +1,736 @@
+import { existsSync, promises as fs, readFileSync } from "node:fs";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  discoverAutoctxAgents,
+  invokeAutoctxAgent,
+  loadAutoctxAgent,
+} from "../../agent-runtime/index.js";
+import type { AgentRuntime } from "../../runtimes/base.js";
+import {
+  createLocalWorkspaceEnv,
+  type RuntimeWorkspaceEnv,
+} from "../../runtimes/workspace-env.js";
+import type { RuntimeSessionEventStore } from "../../session/runtime-events.js";
+import type { RuntimeSessionEventSink } from "../../session/runtime-session-notifications.js";
+
+export type NodeAgentAppBuildTarget = "node";
+
+export interface NodeAgentAppBuildOptions {
+  cwd: string;
+  outDir?: string;
+  packageName?: string;
+  autoctxDependency?: string;
+}
+
+export interface NodeAgentAppBuildFile {
+  relativePath: string;
+  absolutePath: string;
+  content: string;
+}
+
+export interface NodeAgentAppBuildPlan {
+  target: NodeAgentAppBuildTarget;
+  projectRoot: string;
+  outputDir: string;
+  handlerDir: ".autoctx/agents";
+  routes: readonly ["GET /manifest", "POST /agents/:agent/invoke"];
+  files: NodeAgentAppBuildFile[];
+}
+
+export interface NodeAgentAppBuildResult extends NodeAgentAppBuildPlan {
+  writtenFiles: string[];
+}
+
+export interface NodeAgentRuntimeContracts {
+  discoverAutoctxAgents: typeof discoverAutoctxAgents;
+  loadAutoctxAgent: typeof loadAutoctxAgent;
+  invokeAutoctxAgent: typeof invokeAutoctxAgent;
+}
+
+export type NodeAgentAppRuntimeHandle =
+  | AgentRuntime
+  | { runtime: AgentRuntime; close?: () => void | Promise<void> };
+
+export interface NodeAgentAppRuntimeFactoryPlan {
+  agentName: string;
+  id: string;
+  env: Readonly<Record<string, string>>;
+}
+
+export type NodeAgentAppRuntimeFactory = (
+  plan: NodeAgentAppRuntimeFactoryPlan,
+) => NodeAgentAppRuntimeHandle | undefined | Promise<NodeAgentAppRuntimeHandle | undefined>;
+
+export interface NodeAgentAppServerOptions {
+  projectRoot: string | URL;
+  env?: Record<string, string | undefined>;
+  envFile?: string;
+  processEnv?: Record<string, string | undefined>;
+  workspace?: RuntimeWorkspaceEnv;
+  runtime?: AgentRuntime;
+  createRuntime?: NodeAgentAppRuntimeFactory;
+  agentRuntime?: NodeAgentRuntimeContracts;
+  eventStore?: RuntimeSessionEventStore;
+  eventSink?: RuntimeSessionEventSink;
+  sessionDbPath?: string;
+}
+
+export interface StartNodeAgentAppServerOptions extends Partial<NodeAgentAppServerOptions> {
+  projectRoot?: string | URL;
+  host?: string;
+  port?: number;
+  runtimeModule?: string;
+  stdout?: Pick<NodeJS.WriteStream, "write">;
+}
+
+interface NodeAgentAppSuccessEnvelope {
+  ok: true;
+  agent: string;
+  id: string;
+  result: unknown;
+}
+
+interface NodeAgentAppErrorEnvelope {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+const NODE_AGENT_ROUTES = ["GET /manifest", "POST /agents/:agent/invoke"] as const;
+const DEFAULT_NODE_AGENT_OUTPUT_DIR = ".autoctx/build/node";
+const AUTOCTX_PACKAGE_NAME = "autoctx";
+const DEFAULT_AGENT_RUNTIME: NodeAgentRuntimeContracts = {
+  discoverAutoctxAgents,
+  loadAutoctxAgent,
+  invokeAutoctxAgent,
+};
+
+export function planNodeAgentAppBuildTarget(
+  options: NodeAgentAppBuildOptions,
+): NodeAgentAppBuildPlan {
+  const projectRoot = path.resolve(options.cwd);
+  const outputDir = path.resolve(projectRoot, options.outDir ?? DEFAULT_NODE_AGENT_OUTPUT_DIR);
+  const packageName = normalizePackageName(options.packageName, projectRoot);
+  const files = [
+    nodeAgentBuildFile(outputDir, "package.json", renderNodeAgentPackageJson({
+      packageName,
+      autoctxDependency: options.autoctxDependency ?? defaultAutoctxDependency(),
+    })),
+    nodeAgentBuildFile(
+      outputDir,
+      "server.mjs",
+      renderNodeAgentServerEntrypoint(projectRootUrlSpecifier(outputDir, projectRoot)),
+    ),
+    nodeAgentBuildFile(outputDir, "README.md", renderNodeAgentReadme()),
+    nodeAgentBuildFile(outputDir, ".gitignore", "node_modules\n.env\n*.sqlite\n*.sqlite-*\n"),
+  ];
+  return {
+    target: "node",
+    projectRoot,
+    outputDir,
+    handlerDir: ".autoctx/agents",
+    routes: NODE_AGENT_ROUTES,
+    files,
+  };
+}
+
+export async function buildNodeAgentAppTarget(
+  options: NodeAgentAppBuildOptions,
+): Promise<NodeAgentAppBuildResult> {
+  const plan = planNodeAgentAppBuildTarget(options);
+  const writtenFiles: string[] = [];
+  for (const file of plan.files) {
+    await fs.mkdir(path.dirname(file.absolutePath), { recursive: true });
+    await fs.writeFile(file.absolutePath, file.content, "utf-8");
+    writtenFiles.push(file.absolutePath);
+  }
+  return { ...plan, writtenFiles };
+}
+
+export function renderNodeAgentServerEntrypoint(projectRootSpecifier = "../../.."): string {
+  return `#!/usr/bin/env node
+import * as agentRuntime from "autoctx/agent-runtime";
+import { startNodeAgentAppServer } from "autoctx/control-plane/agent-app-node";
+
+await startNodeAgentAppServer({
+  projectRoot: new URL(${JSON.stringify(projectRootSpecifier)}, import.meta.url),
+  agentRuntime,
+});
+`;
+}
+
+export async function createNodeAgentAppServer(
+  options: NodeAgentAppServerOptions,
+): Promise<Server> {
+  const projectRoot = resolveProjectRoot(options.projectRoot);
+  const workspace = options.workspace ?? createLocalWorkspaceEnv({ root: projectRoot });
+  const eventStore = options.eventStore ?? await createEventStore(projectRoot, options.sessionDbPath);
+  const agentRuntime = options.agentRuntime ?? DEFAULT_AGENT_RUNTIME;
+  const env = await resolveExplicitEnv(projectRoot, options);
+  const ownedWorkspace = options.workspace ? undefined : workspace;
+  const ownedEventStore = options.eventStore ? undefined : eventStore;
+  const server = createServer((request, response) => {
+    void handleNodeAgentAppRequest(request, response, {
+      ...options,
+      projectRoot,
+      workspace,
+      eventStore,
+      agentRuntime,
+      env,
+    });
+  });
+  server.once("close", () => {
+    void ownedWorkspace?.cleanup();
+    ownedEventStore?.close();
+  });
+  return server;
+}
+
+export async function startNodeAgentAppServer(
+  options: StartNodeAgentAppServerOptions = {},
+): Promise<Server> {
+  const port = options.port ?? parsePort(process.env.AUTOCTX_AGENT_PORT ?? process.env.PORT ?? "3583");
+  const host = options.host ?? process.env.AUTOCTX_AGENT_HOST ?? process.env.HOST ?? "127.0.0.1";
+  const projectRoot = resolveProjectRoot(options.projectRoot ?? process.cwd());
+  const runtimeModule = options.runtimeModule ?? process.env.AUTOCTX_RUNTIME_MODULE;
+  const createRuntime = options.createRuntime ?? (runtimeModule
+    ? await loadNodeAgentAppRuntimeFactory(runtimeModule, projectRoot)
+    : undefined);
+  const server = await createNodeAgentAppServer({
+    projectRoot,
+    env: options.env,
+    envFile: options.envFile ?? process.env.AUTOCTX_ENV_FILE,
+    processEnv: options.processEnv ?? process.env,
+    workspace: options.workspace,
+    runtime: options.runtime,
+    createRuntime,
+    eventStore: options.eventStore,
+    eventSink: options.eventSink,
+    sessionDbPath: options.sessionDbPath ?? process.env.AUTOCTX_SESSION_DB,
+    agentRuntime: options.agentRuntime,
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => resolve());
+  });
+  const address = server.address();
+  const actualPort = typeof address === "object" && address ? address.port : port;
+  const message = JSON.stringify({
+    ok: true,
+    target: "node",
+    url: `http://${host}:${actualPort}`,
+    manifest: `http://${host}:${actualPort}/manifest`,
+  });
+  (options.stdout ?? process.stdout).write(`${message}\n`);
+  return server;
+}
+
+export async function loadNodeAgentAppEnvFile(
+  envPath: string,
+  processEnv: Record<string, string | undefined> = {},
+): Promise<Record<string, string>> {
+  const parsed = parseEnvFile(await fs.readFile(envPath, "utf-8"));
+  const merged: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    const shellValue = processEnv[key];
+    merged[key] = shellValue === undefined ? value : shellValue;
+  }
+  return merged;
+}
+
+function defaultAutoctxDependency(): string {
+  return `file:${toPosixPath(resolveAutoctxPackageRoot())}`;
+}
+
+function resolveAutoctxPackageRoot(): string {
+  let current = path.dirname(fileURLToPath(import.meta.url));
+  while (true) {
+    const packageJsonPath = path.join(current, "package.json");
+    if (existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { name?: unknown };
+      if (packageJson.name === AUTOCTX_PACKAGE_NAME) return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error("Unable to locate the installed autoctx package root for Node agent app generation");
+}
+
+function projectRootUrlSpecifier(outputDir: string, projectRoot: string): string {
+  const relative = path.relative(outputDir, projectRoot).split(path.sep).join("/");
+  return relative || ".";
+}
+
+function nodeAgentBuildFile(
+  outputDir: string,
+  relativePath: string,
+  content: string,
+): NodeAgentAppBuildFile {
+  return {
+    relativePath,
+    absolutePath: path.join(outputDir, relativePath),
+    content,
+  };
+}
+
+function renderNodeAgentPackageJson(options: {
+  packageName: string;
+  autoctxDependency: string;
+}): string {
+  return `${JSON.stringify({
+    name: options.packageName,
+    private: true,
+    type: "module",
+    scripts: {
+      start: "node server.mjs",
+    },
+    dependencies: {
+      autoctx: options.autoctxDependency,
+    },
+  }, null, 2)}\n`;
+}
+
+function renderNodeAgentReadme(): string {
+  return [
+    "# AutoContext Node Agent App",
+    "",
+    "Generated by `autoctx agent build --target node`.",
+    "",
+    "This is a self-hosted Node wrapper around handlers in `.autoctx/agents`.",
+    "It exposes the same HTTP shape as local `autoctx agent dev`:",
+    "",
+    "- `GET /manifest`",
+    "- `POST /agents/<agent>/invoke`",
+    "",
+    "Runtime-backed handlers can receive host-created runtime capabilities via `AUTOCTX_RUNTIME_MODULE` (bare package specifier, relative/absolute file path, or URL).",
+    "The generated package uses a local `file:` dependency on the currently installed `autoctx` so it does not reinstall a stale npm release before this target is published.",
+    "Explicit handler env can be loaded with `AUTOCTX_ENV_FILE` (resolved from the source project root); the generated server does not capture the full host environment.",
+    "Runtime-session events can be persisted with `AUTOCTX_SESSION_DB`.",
+    "",
+    "Boundary reference: docs/core-control-package-split.md#agent-app-build-targets",
+    "",
+  ].join("\n");
+}
+
+async function handleNodeAgentAppRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  options: NodeAgentAppServerOptions & {
+    projectRoot: string;
+    workspace: RuntimeWorkspaceEnv;
+    agentRuntime: NodeAgentRuntimeContracts;
+    env: Record<string, string>;
+  },
+): Promise<void> {
+  try {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (request.method === "GET" && (url.pathname === "/manifest" || url.pathname === "/agents")) {
+      await writeJson(response, 200, await buildManifest(options.projectRoot, options.agentRuntime));
+      return;
+    }
+
+    const match = /^\/agents\/([^/]+)\/invoke$/.exec(url.pathname);
+    if (request.method === "POST" && match) {
+      const body = await readJsonBody(request);
+      const agentName = decodeURIComponent(match[1]!);
+      const id = readOptionalString(body.id) ?? "default";
+      const payload = "payload" in body ? body.payload : {};
+      const envelope = await invokeNodeAgentAppHandler({
+        ...options,
+        agentName,
+        id,
+        payload,
+      });
+      await writeJson(response, 200, envelope);
+      return;
+    }
+
+    await writeJson(response, 404, {
+      ok: false,
+      error: {
+        code: "AUTOCTX_AGENT_NOT_FOUND",
+        message: `No Node agent app route for ${request.method ?? "GET"} ${url.pathname}`,
+      },
+    });
+  } catch (error) {
+    await writeJson(response, 500, renderNodeAgentAppError(error));
+  }
+}
+
+async function invokeNodeAgentAppHandler(
+  options: NodeAgentAppServerOptions & {
+    projectRoot: string;
+    workspace: RuntimeWorkspaceEnv;
+    agentRuntime: NodeAgentRuntimeContracts;
+    env: Record<string, string>;
+    agentName: string;
+    id: string;
+    payload: unknown;
+  },
+): Promise<NodeAgentAppSuccessEnvelope> {
+  let runtimeHandle: NormalizedRuntimeHandle | undefined;
+  try {
+    const entry = await resolveAgentEntry(options.projectRoot, options.agentName, options.agentRuntime);
+    const loaded = await options.agentRuntime.loadAutoctxAgent<unknown, unknown>(entry);
+    runtimeHandle = createLazyRuntimeHandle(options.createRuntime, {
+      agentName: loaded.name,
+      id: options.id,
+      env: options.env,
+    });
+    const result = await options.agentRuntime.invokeAutoctxAgent(loaded, {
+      id: options.id,
+      payload: options.payload,
+      env: options.env,
+      workspace: options.workspace,
+      runtime: runtimeHandle?.runtime ?? options.runtime,
+      eventStore: options.eventStore,
+      eventSink: options.eventSink,
+    });
+    return {
+      ok: true,
+      agent: loaded.name,
+      id: options.id,
+      result,
+    };
+  } finally {
+    await closeRuntimeHandle(runtimeHandle);
+  }
+}
+
+async function buildManifest(
+  projectRoot: string,
+  agentRuntime: NodeAgentRuntimeContracts,
+): Promise<{
+  ok: true;
+  target: "node";
+  agents: Array<{
+    name: string;
+    relativePath: string;
+    extension: string;
+    triggers?: Record<string, unknown>;
+  }>;
+}> {
+  const entries = await agentRuntime.discoverAutoctxAgents({ cwd: projectRoot });
+  const agents = [];
+  for (const entry of entries) {
+    const loaded = await agentRuntime.loadAutoctxAgent(entry);
+    agents.push({
+      name: entry.name,
+      relativePath: entry.relativePath,
+      extension: entry.extension,
+      triggers: loaded.triggers,
+    });
+  }
+  return { ok: true, target: "node", agents };
+}
+
+async function resolveAgentEntry(
+  projectRoot: string,
+  agentName: string,
+  agentRuntime: NodeAgentRuntimeContracts,
+) {
+  const agents = await agentRuntime.discoverAutoctxAgents({ cwd: projectRoot });
+  const entry = agents.find((agent) => agent.name === agentName);
+  if (entry) return entry;
+  const available = agents.map((agent) => agent.name).join(", ");
+  throw new Error(
+    available
+      ? `AutoContext agent not found: ${agentName}. Available: ${available}`
+      : `AutoContext agent not found: ${agentName}. No handlers found under .autoctx/agents`,
+  );
+}
+
+async function resolveExplicitEnv(
+  projectRoot: string,
+  options: NodeAgentAppServerOptions,
+): Promise<Record<string, string>> {
+  const envPath = normalizeOptionalString(options.envFile);
+  const fileEnv = envPath
+    ? await loadNodeAgentAppEnvFile(path.resolve(projectRoot, envPath), options.processEnv ?? {})
+    : {};
+  return {
+    ...fileEnv,
+    ...definedStringRecord(options.env ?? {}),
+  };
+}
+
+function definedStringRecord(values: Record<string, string | undefined>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined) result[key] = value;
+  }
+  return result;
+}
+
+async function createEventStore(
+  projectRoot: string,
+  sessionDbPath: string | undefined,
+): Promise<RuntimeSessionEventStore | undefined> {
+  const normalized = normalizeOptionalString(sessionDbPath);
+  if (!normalized) return undefined;
+  const { RuntimeSessionEventStore } = await import("../../session/runtime-events.js");
+  return new RuntimeSessionEventStore(path.resolve(projectRoot, normalized));
+}
+
+function parseEnvFile(content: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const normalized = line.startsWith("export ") ? line.slice("export ".length).trim() : line;
+    const equals = normalized.indexOf("=");
+    if (equals <= 0) continue;
+    const key = normalized.slice(0, equals).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    env[key] = parseEnvValue(normalized.slice(equals + 1).trim());
+  }
+  return env;
+}
+
+function parseEnvValue(value: string): string {
+  if (
+    (value.startsWith("\"") && value.endsWith("\"")) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1).replace(/\\n/g, "\n").replace(/\\"/g, "\"");
+  }
+  const commentStart = value.search(/\s#/);
+  return (commentStart === -1 ? value : value.slice(0, commentStart)).trim();
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.byteLength;
+    if (total > 1_000_000) {
+      throw new Error("Request body is too large");
+    }
+    chunks.push(buffer);
+  }
+  if (chunks.length === 0) return {};
+  const text = Buffer.concat(chunks).toString("utf-8");
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (!isRecord(parsed)) {
+      throw new Error("body must be a JSON object");
+    }
+    return parsed;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Request body must be valid JSON: ${message}`);
+  }
+}
+
+function renderNodeAgentAppError(error: unknown): NodeAgentAppErrorEnvelope {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    ok: false,
+    error: {
+      code: "AUTOCTX_NODE_AGENT_APP_ERROR",
+      message,
+    },
+  };
+}
+
+async function writeJson(
+  response: ServerResponse,
+  statusCode: number,
+  body: unknown,
+): Promise<void> {
+  response.writeHead(statusCode, {
+    "content-type": "application/json; charset=utf-8",
+  });
+  response.end(`${JSON.stringify(body, null, 2)}\n`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizePackageName(packageName: string | undefined, projectRoot: string): string {
+  const normalized = normalizeOptionalString(packageName);
+  if (normalized) return normalized;
+  const base = path.basename(projectRoot).toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${base || "autoctx"}-agent-app`;
+}
+
+function resolveProjectRoot(projectRoot: string | URL): string {
+  if (projectRoot instanceof URL) return path.resolve(fileURLToPath(projectRoot));
+  return path.resolve(projectRoot);
+}
+
+function parsePort(raw: string): number {
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error("AUTOCTX_AGENT_PORT must be a TCP port between 1 and 65535");
+  }
+  return parsed;
+}
+
+type NormalizedRuntimeHandle = { runtime: AgentRuntime; close?: () => void | Promise<void> };
+
+function normalizeRuntimeHandle(
+  handle: NodeAgentAppRuntimeHandle | undefined,
+): NormalizedRuntimeHandle | undefined {
+  if (!handle) return undefined;
+  if ("runtime" in handle) return handle;
+  return { runtime: handle, close: handle.close?.bind(handle) };
+}
+
+function createLazyRuntimeHandle(
+  factory: NodeAgentAppRuntimeFactory | undefined,
+  plan: NodeAgentAppRuntimeFactoryPlan,
+): NormalizedRuntimeHandle | undefined {
+  if (!factory) return undefined;
+  const runtime = new LazyNodeAgentAppRuntime(factory, plan);
+  return {
+    runtime,
+    close: () => runtime.closeResolvedRuntime(),
+  };
+}
+
+class LazyNodeAgentAppRuntime implements AgentRuntime {
+  readonly #factory: NodeAgentAppRuntimeFactory;
+  readonly #plan: NodeAgentAppRuntimeFactoryPlan;
+  #handlePromise?: Promise<NormalizedRuntimeHandle | undefined>;
+  #handle?: NormalizedRuntimeHandle;
+  #closed = false;
+
+  constructor(factory: NodeAgentAppRuntimeFactory, plan: NodeAgentAppRuntimeFactoryPlan) {
+    this.#factory = factory;
+    this.#plan = plan;
+  }
+
+  get name(): string {
+    return this.#handle?.runtime.name ?? "autoctx-node-agent-app-runtime";
+  }
+
+  get supportsConcurrentRequests(): boolean | undefined {
+    return this.#handle?.runtime.supportsConcurrentRequests;
+  }
+
+  async generate(opts: {
+    prompt: string;
+    system?: string;
+    schema?: Record<string, unknown>;
+  }) {
+    return await (await this.#resolveRuntime()).generate(opts);
+  }
+
+  async revise(opts: {
+    prompt: string;
+    previousOutput: string;
+    feedback: string;
+    system?: string;
+  }) {
+    return await (await this.#resolveRuntime()).revise(opts);
+  }
+
+  close(): void {
+    this.#closed = true;
+    void this.closeResolvedRuntime();
+  }
+
+  async closeResolvedRuntime(): Promise<void> {
+    this.#closed = true;
+    if (!this.#handlePromise) return;
+    let handle: NormalizedRuntimeHandle | undefined;
+    try {
+      handle = await this.#handlePromise;
+    } catch {
+      return;
+    }
+    await closeRuntimeHandle(handle);
+  }
+
+  async #resolveRuntime(): Promise<AgentRuntime> {
+    if (this.#closed) {
+      throw new Error("AutoContext Node agent app runtime is closed");
+    }
+    const handle = await this.#resolveHandle();
+    if (!handle) {
+      throw new Error("AutoContext Node agent app runtime is not configured");
+    }
+    return handle.runtime;
+  }
+
+  async #resolveHandle(): Promise<NormalizedRuntimeHandle | undefined> {
+    if (!this.#handlePromise) {
+      this.#handlePromise = Promise.resolve(this.#factory(this.#plan)).then((handle) => {
+        const normalized = normalizeRuntimeHandle(handle);
+        this.#handle = normalized;
+        return normalized;
+      });
+    }
+    return await this.#handlePromise;
+  }
+}
+
+async function closeRuntimeHandle(handle: NormalizedRuntimeHandle | undefined): Promise<void> {
+  if (!handle?.close) return;
+  await handle.close();
+}
+
+export async function loadNodeAgentAppRuntimeFactory(
+  moduleSpecifier: string,
+  projectRoot = process.cwd(),
+): Promise<NodeAgentAppRuntimeFactory> {
+  const imported = await import(runtimeModuleUrl(moduleSpecifier, projectRoot));
+  const factory = readRuntimeFactory(imported);
+  if (!factory) {
+    throw new Error(
+      "AUTOCTX_RUNTIME_MODULE must export createAutoctxAgentRuntime, createRuntime, or a default function",
+    );
+  }
+  return factory;
+}
+
+function runtimeModuleUrl(moduleSpecifier: string, projectRoot: string): string {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(moduleSpecifier)) return moduleSpecifier;
+  if (isFileLikeModuleSpecifier(moduleSpecifier)) {
+    return pathToFileURL(path.resolve(projectRoot, moduleSpecifier)).href;
+  }
+  return resolveBareModuleUrl(moduleSpecifier, projectRoot) ?? moduleSpecifier;
+}
+
+function isFileLikeModuleSpecifier(moduleSpecifier: string): boolean {
+  return moduleSpecifier.startsWith(".") || path.isAbsolute(moduleSpecifier);
+}
+
+function resolveBareModuleUrl(moduleSpecifier: string, projectRoot: string): string | undefined {
+  try {
+    const requireFromProject = createRequire(path.join(projectRoot, "package.json"));
+    return pathToFileURL(requireFromProject.resolve(moduleSpecifier)).href;
+  } catch {
+    return undefined;
+  }
+}
+
+function toPosixPath(value: string): string {
+  return value.split(path.sep).join("/");
+}
+
+function readRuntimeFactory(imported: Record<string, unknown>): NodeAgentAppRuntimeFactory | undefined {
+  const candidate = imported.createAutoctxAgentRuntime ?? imported.createRuntime ?? imported.default;
+  return typeof candidate === "function" ? candidate as NodeAgentAppRuntimeFactory : undefined;
+}

--- a/ts/tests/agent-app-node-build-target.test.ts
+++ b/ts/tests/agent-app-node-build-target.test.ts
@@ -1,0 +1,259 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  buildNodeAgentAppTarget,
+  createNodeAgentAppServer,
+  loadNodeAgentAppRuntimeFactory,
+  planNodeAgentAppBuildTarget,
+} from "../src/control-plane/agent-app-node/index.js";
+import {
+  RuntimeSessionEventLog,
+  type RuntimeSessionEventStore,
+} from "../src/session/runtime-events.js";
+
+async function listen(server: Awaited<ReturnType<typeof createNodeAgentAppServer>>): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("missing server address");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server: Awaited<ReturnType<typeof createNodeAgentAppServer>>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function resolveFileDependency(packageDir: string, dependency: string): string {
+  if (!dependency.startsWith("file:")) throw new Error(`expected file dependency: ${dependency}`);
+  const target = dependency.slice("file:".length);
+  return isAbsolute(target) ? target : resolve(packageDir, target);
+}
+
+describe("Node agent app build target", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "autoctx-node-agent-build-"));
+    mkdirSync(join(root, ".autoctx", "agents"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("plans a control-plane Node build without reading host env or changing the handler API", () => {
+    const plan = planNodeAgentAppBuildTarget({ cwd: root });
+
+    expect(plan.target).toBe("node");
+    expect(plan.outputDir).toBe(join(root, ".autoctx", "build", "node"));
+    expect(plan.handlerDir).toBe(".autoctx/agents");
+    expect(plan.routes).toEqual(["GET /manifest", "POST /agents/:agent/invoke"]);
+    expect(plan.files.map((file) => file.relativePath).sort()).toEqual([
+      ".gitignore",
+      "README.md",
+      "package.json",
+      "server.mjs",
+    ]);
+    expect(plan.files.find((file) => file.relativePath === "server.mjs")?.content).toContain(
+      "autoctx/control-plane/agent-app-node",
+    );
+    expect(plan.files.find((file) => file.relativePath === "server.mjs")?.content).toContain(
+      "autoctx/agent-runtime",
+    );
+    expect(plan.files.find((file) => file.relativePath === "server.mjs")?.content).not.toContain(
+      process.env.PATH ?? "__PATH_NOT_SET__",
+    );
+  });
+
+  it("materializes a minimal self-hosted Node package", async () => {
+    const result = await buildNodeAgentAppTarget({ cwd: root, outDir: "dist-agent" });
+
+    expect(result.target).toBe("node");
+    expect(result.outputDir).toBe(join(root, "dist-agent"));
+    expect(existsSync(join(root, "dist-agent", "server.mjs"))).toBe(true);
+    const packageDir = join(root, "dist-agent");
+    const packageJson = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf-8")) as {
+      type: string;
+      scripts: { start: string };
+      dependencies: { autoctx: string };
+    };
+    expect(packageJson).toMatchObject({
+      type: "module",
+      scripts: { start: "node server.mjs" },
+    });
+    expect(packageJson.dependencies.autoctx).toMatch(/^file:/);
+    expect(
+      JSON.parse(
+        readFileSync(join(resolveFileDependency(packageDir, packageJson.dependencies.autoctx), "package.json"), "utf-8"),
+      ),
+    ).toMatchObject({
+      name: "autoctx",
+      exports: {
+        "./control-plane/agent-app-node": expect.any(Object),
+      },
+    });
+    expect(readFileSync(join(root, "dist-agent", "server.mjs"), "utf-8")).toContain(
+      'projectRoot: new URL("..", import.meta.url)',
+    );
+    expect(readFileSync(join(root, "dist-agent", "README.md"), "utf-8")).toContain(
+      "docs/core-control-package-split.md#agent-app-build-targets",
+    );
+  });
+
+  it("loads runtime factories from bare packages installed in the generated app root", async () => {
+    mkdirSync(join(root, "node_modules", "runtime-factory"), { recursive: true });
+    writeFileSync(
+      join(root, "node_modules", "runtime-factory", "package.json"),
+      JSON.stringify({ name: "runtime-factory", type: "module", main: "index.mjs" }),
+    );
+    writeFileSync(
+      join(root, "node_modules", "runtime-factory", "index.mjs"),
+      [
+        "export default function createRuntime(plan) {",
+        "  return {",
+        "    name: `bare-runtime:${plan.agentName}:${plan.id}`,",
+        "    async generate() { return { text: plan.env.RUNTIME_TOKEN ?? 'missing' }; },",
+        "    async revise() { return { text: 'unused' }; }",
+        "  };",
+        "}",
+      ].join("\n"),
+    );
+
+    const factory = await loadNodeAgentAppRuntimeFactory("runtime-factory", root);
+    const runtime = await factory({
+      agentName: "support",
+      id: "ticket-123",
+      env: { RUNTIME_TOKEN: "token-from-env" },
+    });
+    if (!runtime || "runtime" in runtime) {
+      throw new Error("expected direct AgentRuntime handle");
+    }
+
+    expect(runtime.name).toBe("bare-runtime:support:ticket-123");
+    await expect(runtime.generate({ prompt: "hello" })).resolves.toEqual({ text: "token-from-env" });
+  });
+
+  it("serves pure local handlers through the generated Node server shape", async () => {
+    writeFileSync(
+      join(root, ".autoctx", "agents", "support.mjs"),
+      [
+        "export const triggers = { webhook: true };",
+        "export default async function (ctx) {",
+        "  return { id: ctx.id, message: ctx.payload.message, token: ctx.env.SUPPORT_TOKEN, leaked: ctx.env.SECRET_TOKEN };",
+        "}",
+      ].join("\n"),
+    );
+    writeFileSync(join(root, ".env.local"), "SUPPORT_TOKEN=file-token\n");
+    let createRuntimeCalls = 0;
+
+    const server = await createNodeAgentAppServer({
+      projectRoot: root,
+      envFile: ".env.local",
+      processEnv: {
+        SUPPORT_TOKEN: "shell-token",
+        SECRET_TOKEN: "must-not-be-captured",
+      },
+      createRuntime: () => {
+        createRuntimeCalls += 1;
+        throw new Error("runtime should be lazy for local handlers");
+      },
+    });
+    const baseUrl = await listen(server);
+    try {
+      const manifest = await fetch(`${baseUrl}/manifest`);
+      expect(manifest.status).toBe(200);
+      expect(await manifest.json()).toMatchObject({
+        ok: true,
+        agents: [{ name: "support", relativePath: ".autoctx/agents/support.mjs", triggers: { webhook: true } }],
+      });
+
+      const invocation = await fetch(`${baseUrl}/agents/support/invoke`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "ticket-123", payload: { message: "please triage" } }),
+      });
+      expect(invocation.status).toBe(200);
+      expect(await invocation.json()).toEqual({
+        ok: true,
+        agent: "support",
+        id: "ticket-123",
+        result: {
+          id: "ticket-123",
+          message: "please triage",
+          token: "shell-token",
+        },
+      });
+      expect(createRuntimeCalls).toBe(0);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("invokes runtime-backed handlers and records runtime-session events through the store contract", async () => {
+    writeFileSync(
+      join(root, ".autoctx", "agents", "prompted.mjs"),
+      [
+        "export default async function (ctx) {",
+        "  const runtime = await ctx.init();",
+        "  const session = await runtime.session('default');",
+        "  const response = await session.prompt(ctx.payload.prompt);",
+        "  return { text: response.text, sessionId: response.sessionId };",
+        "}",
+      ].join("\n"),
+    );
+    const savedLogs = new Map<string, RuntimeSessionEventLog>();
+    const store = {
+      save: (log: RuntimeSessionEventLog) => {
+        savedLogs.set(log.sessionId, RuntimeSessionEventLog.fromJSON(log.toJSON()));
+      },
+      load: (sessionId: string) => savedLogs.get(sessionId) ?? null,
+      list: () => [...savedLogs.values()],
+      listChildren: () => [],
+      close: () => {},
+    } as unknown as RuntimeSessionEventStore;
+
+    const server = await createNodeAgentAppServer({
+      projectRoot: root,
+      eventStore: store,
+      createRuntime: () => ({
+        name: "fake-node-target-runtime",
+        generate: async ({ prompt }) => ({ text: `echo:${prompt}` }),
+        revise: async () => ({ text: "unused" }),
+      }),
+    });
+    const baseUrl = await listen(server);
+    try {
+      const invocation = await fetch(`${baseUrl}/agents/prompted/invoke`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "run-1", payload: { prompt: "hello" } }),
+      });
+      expect(invocation.status).toBe(200);
+      expect(await invocation.json()).toMatchObject({
+        ok: true,
+        agent: "prompted",
+        id: "run-1",
+        result: { text: "echo:hello", sessionId: "agent:prompted:default" },
+      });
+
+      const log = savedLogs.get("agent:prompted:default");
+      expect(log?.metadata).toMatchObject({
+        agentName: "prompted",
+        experimentalAgentRuntime: true,
+      });
+      expect(log?.events.map((event) => event.eventType)).toEqual([
+        "prompt_submitted",
+        "assistant_message",
+      ]);
+    } finally {
+      await close(server);
+    }
+  });
+});

--- a/ts/tests/agent-command-workflow.test.ts
+++ b/ts/tests/agent-command-workflow.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   AGENT_COMMAND_HELP_TEXT,
   createAutoctxAgentDevServer,
+  executeAutoctxAgentBuildCommandWorkflow,
   executeAutoctxAgentRunCommandWorkflow,
   loadAutoctxAgentEnvFile,
   planAutoctxAgentCommand,
@@ -24,11 +25,13 @@ describe("agent command workflow", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it("exposes stable help text for run and dev", () => {
+  it("exposes stable help text for run, dev, and build", () => {
     expect(AGENT_COMMAND_HELP_TEXT).toContain("autoctx agent run <agent>");
     expect(AGENT_COMMAND_HELP_TEXT).toContain("autoctx agent dev");
+    expect(AGENT_COMMAND_HELP_TEXT).toContain("autoctx agent build --target node");
     expect(AGENT_COMMAND_HELP_TEXT).toContain("--payload");
     expect(AGENT_COMMAND_HELP_TEXT).toContain("--env");
+    expect(AGENT_COMMAND_HELP_TEXT).toContain("--out");
     expect(AGENT_COMMAND_HELP_TEXT).toContain("--json");
   });
 
@@ -82,6 +85,30 @@ describe("agent command workflow", () => {
     });
   });
 
+  it("plans the Node build target without accepting hosted targets", () => {
+    expect(
+      planAutoctxAgentCommand(
+        {
+          target: "node",
+          out: "dist-agent",
+          cwd: "apps/support",
+          json: true,
+        },
+        ["build"],
+      ),
+    ).toEqual({
+      action: "build",
+      target: "node",
+      outDir: "dist-agent",
+      cwd: "apps/support",
+      json: true,
+    });
+
+    expect(() => planAutoctxAgentCommand({ target: "cloudflare" }, ["build"])).toThrow(
+      "only supports --target node",
+    );
+  });
+
   it("rejects malformed JSON payloads with an actionable message", () => {
     expect(() =>
       planAutoctxAgentCommand({ payload: "{bad" }, ["run", "support"]),
@@ -107,6 +134,26 @@ describe("agent command workflow", () => {
       SUPPORT_TOKEN: "shell-token",
       QUOTED: "file value",
       EMPTY: "",
+    });
+  });
+
+  it("executes the Node build workflow and reports generated files", async () => {
+    const result = await executeAutoctxAgentBuildCommandWorkflow({
+      cwd: root,
+      plan: {
+        action: "build",
+        target: "node",
+        outDir: "dist-agent",
+        json: true,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      target: "node",
+      files: ["package.json", "server.mjs", "README.md", ".gitignore"],
+      routes: ["GET /manifest", "POST /agents/:agent/invoke"],
     });
   });
 

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -127,4 +127,15 @@ describe("package root exports", () => {
       types: "./dist/agent-runtime/index.d.ts",
     });
   });
+
+  it("publishes the Node agent app control-plane build target subpath", () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(import.meta.dirname, "..", "package.json"), "utf-8"),
+    ) as { exports?: Record<string, { import?: string; types?: string }> };
+
+    expect(packageJson.exports?.["./control-plane/agent-app-node"]).toEqual({
+      import: "./dist/control-plane/agent-app-node/index.js",
+      types: "./dist/control-plane/agent-app-node/index.d.ts",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds the TypeScript control-plane Node agent app build target at `autoctx agent build --target node`.
- Generates a minimal self-hosted Node package (`server.mjs`, `package.json`, README, `.gitignore`) that loads `.autoctx/agents` through `autoctx/agent-runtime`.
- Exposes the same `GET /manifest` and `POST /agents/<agent>/invoke` HTTP shape as local `autoctx agent dev`, with explicit env loading and runtime-session event-store wiring.
- Publishes `autoctx/control-plane/agent-app-node` and updates docs for the Node build target boundary.

## Boundary notes
- Stays in the TypeScript control-plane / umbrella CLI boundary.
- Does not add hosted deployment, fleet orchestration, remote provisioning, secret brokering, scheduling, billing, or tenant policy code.
- Keeps runtime-backed handlers behind host-created runtime capabilities and explicit env injection.

## Verification
- `npx vitest run tests/agent-app-node-build-target.test.ts tests/agent-command-workflow.test.ts tests/package-export-catalogs.test.ts -t "Node agent app|agent command workflow" --reporter=verbose`
- `npx vitest run tests/cli-help.test.ts tests/agent-command-workflow.test.ts --reporter=verbose`
- `npm run lint -- --pretty false`
- `npx tsc -p tests/tsconfig.json --noEmit --pretty false`
- `npm run build`
- `git diff --check origin/main...HEAD && git diff --check`

Linear: AC-762