### PR TITLE
feat(server): engine user-auth verification + enforcement (verify + enforce slice)

### DIFF
--- a/docs/websocket-protocol-contract.json
+++ b/docs/websocket-protocol-contract.json
@@ -98,6 +98,10 @@
     {
       "type": "whoami",
       "reason": "TypeScript TUI provider-auth workflow"
+    },
+    {
+      "type": "authenticate",
+      "reason": "TypeScript desktop token-based auth handshake"
     }
   ],
   "python_only_server_messages": [],

--- a/ts/bun.lock
+++ b/ts/bun.lock
@@ -4,27 +4,57 @@
     "": {
       "name": "autoctx",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@types/diff": "^7.0.2",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "better-sqlite3": "^11.0.0",
+        "diff": "^9.0.0",
+        "ignore": "5.3.2",
         "ink": "^5.1.0",
         "ink-text-input": "^6.0.0",
+        "jose": "^6.2.3",
+        "openai": "^4",
         "react": "^18.3.1",
         "secure-exec": "^0.1.0",
+        "tree-sitter": "0.21.1",
+        "tree-sitter-javascript": "0.21.4",
+        "tree-sitter-python": "0.21.0",
+        "tree-sitter-typescript": "0.21.2",
+        "tsx": "^4.21.0",
+        "ulid": "^3.0.2",
         "ws": "^8.18.0",
         "zod": "^3.24.0",
       },
       "devDependencies": {
+        "@apidevtools/json-schema-ref-parser": "^15.3.5",
         "@types/better-sqlite3": "^7.6.0",
         "@types/react": "^18.3.0",
         "@types/ws": "^8.5.13",
-        "tsx": "^4.21.0",
+        "fast-check": "^4.7.0",
+        "json-schema-to-typescript": "^15.0.4",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0",
       },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": "^0.32",
+        "openai": "^4",
+      },
+      "optionalPeers": [
+        "@anthropic-ai/sdk",
+        "openai",
+      ],
     },
   },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.1.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.90.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg=="],
+
+    "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@15.3.6", "", { "dependencies": { "js-yaml": "^4.2.0" }, "peerDependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-oPFDSviRrreUmCZn09LCD4S9QQa6j7zfEwBM1pkGa/kXY0O4sXsEXn4emLP/Tt6tik2+BtgwKk2eldAeOWZ2Rw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -87,6 +117,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@jsdevtools/ono": ["@jsdevtools/ono@7.1.3", "", {}, "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -154,9 +186,17 @@
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
+    "@types/diff": ["@types/diff@7.0.2", "", {}, "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/lodash": ["@types/lodash@4.17.24", "", {}, "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="],
+
+    "@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
@@ -178,7 +218,11 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -192,11 +236,15 @@
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
     "asn1.js": ["asn1.js@4.10.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw=="],
 
     "assert": ["assert@2.1.0", "", { "dependencies": { "call-bind": "^1.0.2", "is-nan": "^1.3.2", "object-is": "^1.1.5", "object.assign": "^4.1.4", "util": "^0.12.5" } }, "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
@@ -264,6 +312,8 @@
 
     "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "console-browserify": ["console-browserify@1.2.0", "", {}, "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="],
@@ -310,11 +360,15 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "des.js": ["des.js@1.1.0", "", { "dependencies": { "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "diffie-hellman": ["diffie-hellman@5.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "miller-rabin": "^4.0.0", "randombytes": "^2.0.0" } }, "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg=="],
 
@@ -342,6 +396,8 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
     "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": "bin/esbuild" }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
@@ -353,6 +409,8 @@
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
@@ -370,6 +428,8 @@
 
     "express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
+    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
@@ -383,6 +443,12 @@
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
+
+    "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
+
+    "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -418,7 +484,7 @@
 
     "hash.js": ["hash.js@1.1.7", "", { "dependencies": { "inherits": "^2.0.3", "minimalistic-assert": "^1.0.1" } }, "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA=="],
 
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "hmac-drbg": ["hmac-drbg@1.0.1", "", { "dependencies": { "hash.js": "^1.0.3", "minimalistic-assert": "^1.0.0", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="],
 
@@ -428,9 +494,13 @@
 
     "https-browserify": ["https-browserify@1.0.0", "", {}, "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="],
 
+    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
+
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
 
@@ -452,9 +522,13 @@
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
 
     "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-in-ci": ["is-in-ci@1.0.0", "", { "bin": "cli.js" }, "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg=="],
 
@@ -474,9 +548,15 @@
 
     "isomorphic-timers-promises": ["isomorphic-timers-promises@1.0.1", "", {}, "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ=="],
 
-    "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-to-typescript": ["json-schema-to-typescript@15.0.4", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "^11.5.5", "@types/json-schema": "^7.0.15", "@types/lodash": "^4.17.7", "is-glob": "^4.0.3", "js-yaml": "^4.1.0", "lodash": "^4.17.21", "minimist": "^1.2.8", "prettier": "^3.2.5", "tinyglobby": "^0.2.9" }, "bin": { "json2ts": "dist/src/cli.js" } }, "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -485,6 +565,8 @@
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": "cli.js" }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
@@ -530,6 +612,12 @@
 
     "node-abi": ["node-abi@3.87.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ=="],
 
+    "node-addon-api": ["node-addon-api@8.8.0", "", {}, "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "node-stdlib-browser": ["node-stdlib-browser@1.3.1", "", { "dependencies": { "assert": "^2.0.0", "browser-resolve": "^2.0.0", "browserify-zlib": "^0.2.0", "buffer": "^5.7.1", "console-browserify": "^1.1.0", "constants-browserify": "^1.0.0", "create-require": "^1.1.1", "crypto-browserify": "^3.12.1", "domain-browser": "4.22.0", "events": "^3.0.0", "https-browserify": "^1.0.0", "isomorphic-timers-promises": "^1.0.1", "os-browserify": "^0.3.0", "path-browserify": "^1.0.1", "pkg-dir": "^5.0.0", "process": "^0.11.10", "punycode": "^1.4.1", "querystring-es3": "^0.2.1", "readable-stream": "^3.6.0", "stream-browserify": "^3.0.0", "stream-http": "^3.2.0", "string_decoder": "^1.0.0", "timers-browserify": "^2.0.4", "tty-browserify": "0.0.1", "url": "^0.11.4", "util": "^0.12.4", "vm-browserify": "^1.0.1" } }, "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw=="],
@@ -549,6 +637,8 @@
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA=="],
 
     "os-browserify": ["os-browserify@0.3.0", "", {}, "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A=="],
 
@@ -596,6 +686,8 @@
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": "bin.js" }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
+    "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
+
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
@@ -607,6 +699,8 @@
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
+
+    "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
     "pyodide": ["pyodide@0.28.3", "", { "dependencies": { "ws": "^8.5.0" } }, "sha512-rtCsyTU55oNGpLzSVuAd55ZvruJDEX8o6keSdWKN9jPeBVSNlynaKFG7eRqkiIgU7i2M6HEgYtm0atCEQX3u4A=="],
 
@@ -746,7 +840,17 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "tree-sitter": ["tree-sitter@0.21.1", "", { "dependencies": { "node-addon-api": "^8.0.0", "node-gyp-build": "^4.8.0" } }, "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ=="],
+
+    "tree-sitter-javascript": ["tree-sitter-javascript@0.21.4", "", { "dependencies": { "node-addon-api": "^8.0.0", "node-gyp-build": "^4.8.1" }, "peerDependencies": { "tree-sitter": "^0.21.1" } }, "sha512-Lrk8yahebwrwc1sWJE9xPcz1OnnqiEV7Dh5fbN6EN3wNAdu9r06HpTqLqDwUUbnG4EB46Sfk+FJFAOldfoKLOw=="],
+
+    "tree-sitter-python": ["tree-sitter-python@0.21.0", "", { "dependencies": { "node-addon-api": "^7.1.0", "node-gyp-build": "^4.8.0" }, "peerDependencies": { "tree-sitter": "^0.21.0" } }, "sha512-IUKx7JcTVbByUx1iHGFS/QsIjx7pqwTMHL9bl/NGyhyyydbfNrpruo2C7W6V4KZrbkkCOlX8QVrCoGOFW5qecg=="],
+
+    "tree-sitter-typescript": ["tree-sitter-typescript@0.21.2", "", { "dependencies": { "node-addon-api": "^8.0.0", "node-gyp-build": "^4.8.1" }, "peerDependencies": { "tree-sitter": "^0.21.0" } }, "sha512-/RyNK41ZpkA8PuPZimR6pGLvNR1p0ibRUJwwQn4qAjyyLEIQD/BNlwS3NSxWtGsAWZe9gZ44VK1mWx2+eQVldg=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
@@ -764,7 +868,9 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "ulid": ["ulid@3.0.2", "", { "bin": { "ulid": "dist/cli.js" } }, "sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w=="],
+
+    "undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -784,9 +890,11 @@
 
     "vm-browserify": ["vm-browserify@1.1.2", "", {}, "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="],
 
-    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+    "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
-    "whatwg-url": ["whatwg-url@15.1.0", "", { "dependencies": { "tr46": "^6.0.0", "webidl-conversions": "^8.0.0" } }, "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g=="],
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -812,6 +920,16 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
+    "@modelcontextprotocol/sdk/jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+
+    "@secure-exec/core/whatwg-url": ["whatwg-url@15.1.0", "", { "dependencies": { "tr46": "^6.0.0", "webidl-conversions": "^8.0.0" } }, "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g=="],
+
+    "@types/better-sqlite3/@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
+
+    "@types/node-fetch/@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
+
+    "@types/ws/@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
+
     "asn1.js/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
@@ -825,6 +943,16 @@
     "diffie-hellman/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
     "elliptic/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "get-intrinsic/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "is-core-module/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "is-regex/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "json-schema-to-typescript/@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@11.9.3", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ=="],
 
     "miller-rabin/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
@@ -840,22 +968,34 @@
 
     "to-buffer/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
-    "tr46/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+    "tree-sitter-python/node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "vite/@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
+
+    "@secure-exec/core/whatwg-url/tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
+    "@secure-exec/core/whatwg-url/webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "@types/better-sqlite3/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@types/node-fetch/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "browserify-sign/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "browserify-sign/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "ripemd160/hash-base/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
-    "browserify-sign/readable-stream/string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+    "vite/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
-    "ripemd160/hash-base/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+    "@secure-exec/core/whatwg-url/tr46/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "ripemd160/hash-base/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "ripemd160/hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
-
-    "ripemd160/hash-base/readable-stream/string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
   }
 }

--- a/ts/package.json
+++ b/ts/package.json
@@ -198,6 +198,7 @@
     "ignore": "5.3.2",
     "ink": "^5.1.0",
     "ink-text-input": "^6.0.0",
+    "jose": "^6.2.3",
     "openai": "^4",
     "react": "^18.3.1",
     "secure-exec": "^0.1.0",

--- a/ts/src/server/protocol.ts
+++ b/ts/src/server/protocol.ts
@@ -25,10 +25,7 @@ export const PYTHON_SHARED_SERVER_MESSAGE_TYPES = [
   "monitor_alert",
 ] as const;
 
-export const TYPESCRIPT_ONLY_SERVER_MESSAGE_TYPES = [
-  "auth_status",
-  "mission_progress",
-] as const;
+export const TYPESCRIPT_ONLY_SERVER_MESSAGE_TYPES = ["auth_status", "mission_progress"] as const;
 
 export const SERVER_MESSAGE_TYPES = [
   ...PYTHON_SHARED_SERVER_MESSAGE_TYPES,
@@ -54,6 +51,7 @@ export const TYPESCRIPT_ONLY_CLIENT_MESSAGE_TYPES = [
   "logout",
   "switch_provider",
   "whoami",
+  "authenticate",
 ] as const;
 
 export const CLIENT_MESSAGE_TYPES = [
@@ -205,10 +203,14 @@ export const AuthStatusMsgSchema = protocolObject({
   provider: z.string(),
   authenticated: z.boolean(),
   model: z.string().optional(),
-  configuredProviders: z.array(protocolObject({
-    provider: z.string(),
-    hasApiKey: z.boolean(),
-  })).optional(),
+  configuredProviders: z
+    .array(
+      protocolObject({
+        provider: z.string(),
+        hasApiKey: z.boolean(),
+      }),
+    )
+    .optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -285,6 +287,11 @@ export const WhoamiCmdSchema = protocolObject({
   type: z.literal("whoami"),
 });
 
+export const AuthenticateCmdSchema = protocolObject({
+  type: z.literal("authenticate"),
+  token: z.string().min(1),
+});
+
 // ---------------------------------------------------------------------------
 // Discriminated unions
 // ---------------------------------------------------------------------------
@@ -323,6 +330,7 @@ export const ClientMessageSchema = z.discriminatedUnion("type", [
   LogoutCmdSchema,
   SwitchProviderCmdSchema,
   WhoamiCmdSchema,
+  AuthenticateCmdSchema,
 ]);
 
 export type ServerMessage = z.infer<typeof ServerMessageSchema>;

--- a/ts/src/server/user-auth/README.md
+++ b/ts/src/server/user-auth/README.md
@@ -1,0 +1,20 @@
+# Engine user auth
+
+The engine can verify a user identity JWT that the desktop client attaches, and enforce it on run-affecting operations. It is issuer-agnostic (verifies any JWT against a configured JWKS URL), so it works with a company IdP directly without any autocontext-specific adapter.
+
+## Configuration
+
+- `AUTOCONTEXT_AUTH_JWKS_URL`: the IdP JWKS endpoint.
+- `AUTOCONTEXT_AUTH_ISSUER`: the expected token issuer.
+- `AUTOCONTEXT_AUTH_AUDIENCE`: optional expected audience.
+
+Auth is DISABLED (no enforcement, the default local-mode behavior) unless both the JWKS URL and issuer are set.
+
+## When enabled
+
+- **WebSocket**: the client sends `{ "type": "authenticate", "token": "..." }`; run-affecting commands (start_run, create_scenario, and similar) require a verified session. Read-only and provider-auth commands (list_scenarios, whoami, switch_provider) are always open.
+- **HTTP**: mutating requests (POST/PUT/PATCH/DELETE) require an `Authorization: Bearer <token>` header; GET is open.
+
+## Notes
+
+Gating is binary (verified or not); role/group-based permissions (RBAC) and run audit are follow-on work. The token is verified with `jose` against the JWKS (signature, issuer, audience, expiry).

--- a/ts/src/server/user-auth/config.ts
+++ b/ts/src/server/user-auth/config.ts
@@ -1,0 +1,19 @@
+export interface UserAuthConfig {
+  jwksUrl: string;
+  issuer: string;
+  audience?: string;
+}
+
+/**
+ * Build user-auth config from env. Returns null (auth disabled, the default
+ * local-mode behavior) unless both the JWKS URL and issuer are set.
+ */
+export function userAuthConfigFromEnv(
+  env: Record<string, string | undefined>,
+): UserAuthConfig | null {
+  const jwksUrl = env.AUTOCONTEXT_AUTH_JWKS_URL?.trim();
+  const issuer = env.AUTOCONTEXT_AUTH_ISSUER?.trim();
+  if (!jwksUrl || !issuer) return null;
+  const audience = env.AUTOCONTEXT_AUTH_AUDIENCE?.trim() || undefined;
+  return { jwksUrl, issuer, audience };
+}

--- a/ts/src/server/user-auth/enforcement.ts
+++ b/ts/src/server/user-auth/enforcement.ts
@@ -1,0 +1,24 @@
+/**
+ * Commands allowed before/without authentication: the auth handshake itself,
+ * read-only listing, and the provider-auth (LLM/API-key) setup commands, which
+ * are a separate concern from user identity.
+ */
+const AUTH_FREE_COMMANDS = new Set<string>([
+  "authenticate",
+  "list_scenarios",
+  "whoami",
+  "login",
+  "logout",
+  "switch_provider",
+]);
+
+/** Whether a ws command requires a verified identity (when auth is enabled). */
+export function commandRequiresAuth(type: string): boolean {
+  return !AUTH_FREE_COMMANDS.has(type);
+}
+
+/** Whether an HTTP method is mutating and requires a verified identity. */
+export function httpRequiresAuth(method: string): boolean {
+  const m = method.toUpperCase();
+  return m !== "GET" && m !== "HEAD" && m !== "OPTIONS";
+}

--- a/ts/src/server/user-auth/token-verifier.ts
+++ b/ts/src/server/user-auth/token-verifier.ts
@@ -1,0 +1,60 @@
+import {
+  createLocalJWKSet,
+  createRemoteJWKSet,
+  jwtVerify,
+  type JSONWebKeySet,
+  type JWTPayload,
+} from "jose";
+import type { UserAuthConfig } from "./config.js";
+
+export interface VerifiedIdentity {
+  subject: string;
+  email?: string;
+  groups: string[];
+}
+
+export interface TokenVerifier {
+  verify(token: string): Promise<VerifiedIdentity>;
+}
+
+/** Pure claim extraction: groups from `groups`, else `roles`, else []. */
+export function identityFromClaims(payload: JWTPayload): VerifiedIdentity {
+  const raw = (payload.groups ?? payload.roles) as unknown;
+  const groups = Array.isArray(raw) ? raw.map(String) : [];
+  return {
+    subject: String(payload.sub ?? ""),
+    email: typeof payload.email === "string" ? payload.email : undefined,
+    groups,
+  };
+}
+
+type KeyResolver = ReturnType<typeof createLocalJWKSet>;
+
+function verifierFromResolver(
+  keys: KeyResolver,
+  opts: { issuer: string; audience?: string },
+): TokenVerifier {
+  return {
+    async verify(token: string): Promise<VerifiedIdentity> {
+      const { payload } = await jwtVerify(token, keys, {
+        issuer: opts.issuer,
+        audience: opts.audience,
+      });
+      return identityFromClaims(payload);
+    },
+  };
+}
+
+/** Verifier backed by a remote JWKS endpoint (production). */
+export function createJwksVerifier(config: UserAuthConfig): TokenVerifier {
+  const jwks = createRemoteJWKSet(new URL(config.jwksUrl)) as KeyResolver;
+  return verifierFromResolver(jwks, { issuer: config.issuer, audience: config.audience });
+}
+
+/** Verifier backed by an in-memory JWKS (tests / injected). */
+export function createVerifierWithKeySet(
+  jwks: JSONWebKeySet,
+  opts: { issuer: string; audience?: string },
+): TokenVerifier {
+  return verifierFromResolver(createLocalJWKSet(jwks), opts);
+}

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -272,7 +272,7 @@ export class InteractiveServer {
     );
     res.setHeader("Vary", "Origin");
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
 
     if (method === "OPTIONS") {
       res.writeHead(204);

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -61,11 +61,25 @@ import { SQLiteStore } from "../storage/index.js";
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import { SolveManager } from "../knowledge/solver.js";
 import type { LLMProvider } from "../types/index.js";
+import { userAuthConfigFromEnv } from "./user-auth/config.js";
+import {
+  createJwksVerifier,
+  type TokenVerifier,
+  type VerifiedIdentity,
+} from "./user-auth/token-verifier.js";
+import { commandRequiresAuth, httpRequiresAuth } from "./user-auth/enforcement.js";
 
 export interface InteractiveServerOpts {
   runManager: RunManager;
   port?: number;
   host?: string;
+  /**
+   * Optional injected token verifier. When provided, it overrides the
+   * env-derived verifier (used by tests). When omitted, the server derives a
+   * verifier from `userAuthConfigFromEnv(process.env)`; if that returns null,
+   * user-auth enforcement is disabled (today's local-mode behavior).
+   */
+  userVerifier?: TokenVerifier;
 }
 
 export class PortInUseError extends Error {
@@ -97,9 +111,17 @@ export class InteractiveServer {
   #httpServer: HttpServer | null = null;
   #wsServer: WebSocketServer | null = null;
   #boundPort = 0;
+  readonly #userVerifier: TokenVerifier | null;
+  readonly #identities = new Map<WebSocket, VerifiedIdentity>();
 
   constructor(opts: InteractiveServerOpts) {
     this.#runManager = opts.runManager;
+    if (opts.userVerifier) {
+      this.#userVerifier = opts.userVerifier;
+    } else {
+      const userAuthConfig = userAuthConfigFromEnv(process.env);
+      this.#userVerifier = userAuthConfig ? createJwksVerifier(userAuthConfig) : null;
+    }
     this.#missionEvents = new MissionEventEmitter();
     this.#missionManager = new MissionManager(this.#runManager.getDbPath(), {
       events: this.#missionEvents,
@@ -256,6 +278,28 @@ export class InteractiveServer {
       res.writeHead(204);
       res.end();
       return;
+    }
+
+    // User-auth gate for mutating HTTP methods (only when configured). OPTIONS
+    // is naturally exempt (handled above; httpRequiresAuth("OPTIONS") is false).
+    // When the verifier is null, this is skipped entirely (today's behavior).
+    if (this.#userVerifier !== null && httpRequiresAuth(method)) {
+      const authorization = req.headers.authorization ?? "";
+      const match = /^Bearer (.+)$/.exec(authorization);
+      let authenticated = false;
+      if (match) {
+        try {
+          await this.#userVerifier.verify(match[1]!);
+          authenticated = true;
+        } catch {
+          authenticated = false;
+        }
+      }
+      if (!authenticated) {
+        res.writeHead(401, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "authentication required" }));
+        return;
+      }
     }
 
     const json = (status: number, body: unknown) => {
@@ -1332,6 +1376,7 @@ export class InteractiveServer {
       this.#runManager.unsubscribeEvents(eventCallback);
       this.#runManager.unsubscribeState(stateCallback);
       unsubscribeMissionProgress();
+      this.#identities.delete(ws);
     });
   }
 
@@ -1380,7 +1425,29 @@ export class InteractiveServer {
   }
 
   async #handleClientMessage(ws: WebSocket, msg: ClientMessage): Promise<void> {
+    // User-auth gate (only when configured). When disabled, this is skipped
+    // entirely and behavior is byte-for-byte today's local-mode behavior.
+    if (this.#userVerifier !== null && commandRequiresAuth(msg.type) && !this.#identities.has(ws)) {
+      this.#send(ws, buildClientErrorMessage(new Error("authentication required"), msg));
+      return;
+    }
+
     switch (msg.type) {
+      case "authenticate": {
+        if (this.#userVerifier === null) {
+          // Auth disabled: no-op accept so clients can probe uniformly.
+          this.#send(ws, { type: "ack", action: "authenticate" });
+          return;
+        }
+        try {
+          const identity = await this.#userVerifier.verify(msg.token);
+          this.#identities.set(ws, identity);
+          this.#send(ws, { type: "ack", action: "authenticate" });
+        } catch (err) {
+          this.#send(ws, buildClientErrorMessage(err, msg));
+        }
+        return;
+      }
       case "pause":
       case "resume":
       case "inject_hint":

--- a/ts/tests/user-auth-config.test.ts
+++ b/ts/tests/user-auth-config.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { userAuthConfigFromEnv } from "../src/server/user-auth/config.js";
+
+describe("userAuthConfigFromEnv", () => {
+  it("returns a config when jwks url + issuer are present", () => {
+    const cfg = userAuthConfigFromEnv({
+      AUTOCONTEXT_AUTH_JWKS_URL: "https://idp.co/jwks",
+      AUTOCONTEXT_AUTH_ISSUER: "https://idp.co",
+      AUTOCONTEXT_AUTH_AUDIENCE: "autoctx",
+    });
+    expect(cfg).toEqual({
+      jwksUrl: "https://idp.co/jwks",
+      issuer: "https://idp.co",
+      audience: "autoctx",
+    });
+  });
+  it("audience is optional", () => {
+    const cfg = userAuthConfigFromEnv({
+      AUTOCONTEXT_AUTH_JWKS_URL: "https://idp.co/jwks",
+      AUTOCONTEXT_AUTH_ISSUER: "https://idp.co",
+    });
+    expect(cfg).toEqual({
+      jwksUrl: "https://idp.co/jwks",
+      issuer: "https://idp.co",
+      audience: undefined,
+    });
+  });
+  it("returns null when disabled (missing jwks or issuer)", () => {
+    expect(userAuthConfigFromEnv({})).toBeNull();
+    expect(userAuthConfigFromEnv({ AUTOCONTEXT_AUTH_JWKS_URL: "https://idp.co/jwks" })).toBeNull();
+    expect(userAuthConfigFromEnv({ AUTOCONTEXT_AUTH_ISSUER: "https://idp.co" })).toBeNull();
+  });
+});

--- a/ts/tests/user-auth-enforcement-integration.test.ts
+++ b/ts/tests/user-auth-enforcement-integration.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Integration tests for SP5 Task 5: user-auth enforcement wired into the
+ * interactive WebSocket server. Mirrors the real-server harness in
+ * tests/server-protocol.test.ts but injects a stub TokenVerifier.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import type { TokenVerifier, VerifiedIdentity } from "../src/server/user-auth/token-verifier.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "ac-user-auth-"));
+}
+
+/** Stub verifier: accepts only the token "good". */
+const stubVerifier: TokenVerifier = {
+  async verify(token: string): Promise<VerifiedIdentity> {
+    if (token !== "good") {
+      throw new Error("invalid token");
+    }
+    return { subject: "u1", email: undefined, groups: [] };
+  },
+};
+
+interface BufferedSocket {
+  send: (payload: Record<string, unknown>) => void;
+  collect: () => Record<string, unknown>[];
+  until: (
+    predicate: (messages: Record<string, unknown>[]) => boolean,
+    timeoutMs?: number,
+  ) => Promise<void>;
+  close: () => void;
+}
+
+async function openSocket(url: string): Promise<BufferedSocket> {
+  const { WebSocket } = await import("ws");
+  const ws = new WebSocket(url);
+  const received: Record<string, unknown>[] = [];
+
+  ws.on("message", (data) => {
+    received.push(JSON.parse(data.toString()) as Record<string, unknown>);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", () => resolve());
+    ws.once("error", (err) => reject(err));
+  });
+
+  return {
+    send(payload) {
+      ws.send(JSON.stringify(payload));
+    },
+    collect() {
+      return received;
+    },
+    async until(predicate, timeoutMs = 5000) {
+      const started = Date.now();
+      while (!predicate(received)) {
+        if (Date.now() - started > timeoutMs) {
+          throw new Error("Timed out waiting for condition");
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    },
+    close() {
+      ws.close();
+    },
+  };
+}
+
+function hasAuthRequiredError(messages: Record<string, unknown>[]): boolean {
+  return messages.some(
+    (msg) =>
+      msg.type === "error" &&
+      typeof msg.message === "string" &&
+      msg.message.includes("authentication required"),
+  );
+}
+
+describe("user-auth enforcement (ws integration)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = makeTempDir();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function makeServer(opts: { withVerifier: boolean }) {
+    const { RunManager, InteractiveServer } = await import("../src/server/index.js");
+    const mgr = new RunManager({
+      dbPath: join(dir, "test.db"),
+      migrationsDir: join(__dirname, "..", "migrations"),
+      runsRoot: join(dir, "runs"),
+      knowledgeRoot: join(dir, "knowledge"),
+      providerType: "deterministic",
+    });
+    const server = new InteractiveServer({
+      runManager: mgr,
+      port: 0,
+      ...(opts.withVerifier ? { userVerifier: stubVerifier } : {}),
+    });
+    await server.start();
+    return server;
+  }
+
+  it("rejects a command sent before authenticate when auth is enabled", async () => {
+    const server = await makeServer({ withVerifier: true });
+    const socket = await openSocket(server.url);
+    try {
+      socket.send({ type: "start_run", scenario: "x", generations: 1 });
+      await socket.until((messages) => hasAuthRequiredError(messages));
+      expect(hasAuthRequiredError(socket.collect())).toBe(true);
+    } finally {
+      socket.close();
+      await server.stop();
+    }
+  }, 15000);
+
+  it("passes the gate after authenticate when auth is enabled", async () => {
+    const server = await makeServer({ withVerifier: true });
+    const socket = await openSocket(server.url);
+    try {
+      socket.send({ type: "authenticate", token: "good" });
+      // Expect a non-error success (ack).
+      await socket.until((messages) =>
+        messages.some((msg) => msg.type === "ack" && msg.action === "authenticate"),
+      );
+      expect(hasAuthRequiredError(socket.collect())).toBe(false);
+
+      const sawAckAt = socket.collect().length;
+      socket.send({ type: "start_run", scenario: "x", generations: 1 });
+      // Wait for the server to respond to start_run (any message past the ack).
+      await socket.until((messages) => messages.length > sawAckAt);
+      // The auth gate must NOT have blocked it (other engine errors are fine).
+      expect(hasAuthRequiredError(socket.collect())).toBe(false);
+    } finally {
+      socket.close();
+      await server.stop();
+    }
+  }, 15000);
+
+  it("does not gate commands when no verifier is configured", async () => {
+    const server = await makeServer({ withVerifier: false });
+    const socket = await openSocket(server.url);
+    try {
+      socket.send({ type: "start_run", scenario: "x", generations: 1 });
+      // Wait for any server response to the command.
+      await socket.until((messages) =>
+        messages.some(
+          (msg) => msg.type === "run_accepted" || msg.type === "error" || msg.type === "event",
+        ),
+      );
+      expect(hasAuthRequiredError(socket.collect())).toBe(false);
+    } finally {
+      socket.close();
+      await server.stop();
+    }
+  }, 15000);
+});

--- a/ts/tests/user-auth-enforcement-integration.test.ts
+++ b/ts/tests/user-auth-enforcement-integration.test.ts
@@ -166,3 +166,82 @@ describe("user-auth enforcement (ws integration)", () => {
     }
   }, 15000);
 });
+
+describe("user-auth enforcement (HTTP integration)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = makeTempDir();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function makeServer(opts: { withVerifier: boolean }) {
+    const { RunManager, InteractiveServer } = await import("../src/server/index.js");
+    const mgr = new RunManager({
+      dbPath: join(dir, "test.db"),
+      migrationsDir: join(__dirname, "..", "migrations"),
+      runsRoot: join(dir, "runs"),
+      knowledgeRoot: join(dir, "knowledge"),
+      providerType: "deterministic",
+    });
+    const server = new InteractiveServer({
+      runManager: mgr,
+      port: 0,
+      ...(opts.withVerifier ? { userVerifier: stubVerifier } : {}),
+    });
+    await server.start();
+    return server;
+  }
+
+  // A real mutating route the server serves: PUT /api/notebooks/:sessionId.
+  const mutatingRoute = (server: { port: number }) =>
+    `http://localhost:${server.port}/api/notebooks/test-session`;
+
+  it("returns 401 for a mutating request without Authorization when auth is enabled", async () => {
+    const server = await makeServer({ withVerifier: true });
+    try {
+      const res = await fetch(mutatingRoute(server), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("authentication required");
+    } finally {
+      await server.stop();
+    }
+  }, 15000);
+
+  it("does not return 401 for a mutating request with a valid Bearer token", async () => {
+    const server = await makeServer({ withVerifier: true });
+    try {
+      const res = await fetch(mutatingRoute(server), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer good" },
+        body: JSON.stringify({}),
+      });
+      // The auth gate passed; any other status from the route is acceptable.
+      expect(res.status).not.toBe(401);
+    } finally {
+      await server.stop();
+    }
+  }, 15000);
+
+  it("does not gate mutating HTTP requests when no verifier is configured", async () => {
+    const server = await makeServer({ withVerifier: false });
+    try {
+      const res = await fetch(mutatingRoute(server), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      // Today's behavior: no auth gate, so not a gate-level 401.
+      expect(res.status).not.toBe(401);
+    } finally {
+      await server.stop();
+    }
+  }, 15000);
+});

--- a/ts/tests/user-auth-enforcement.test.ts
+++ b/ts/tests/user-auth-enforcement.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { commandRequiresAuth, httpRequiresAuth } from "../src/server/user-auth/enforcement.js";
+
+describe("commandRequiresAuth", () => {
+  it("gates run-affecting commands", () => {
+    for (const t of [
+      "start_run",
+      "create_scenario",
+      "confirm_scenario",
+      "revise_scenario",
+      "cancel_scenario",
+      "override_gate",
+      "inject_hint",
+      "pause",
+      "resume",
+      "chat_agent",
+    ]) {
+      expect(commandRequiresAuth(t)).toBe(true);
+    }
+  });
+  it("allows handshake / read-only / provider-auth pre-auth", () => {
+    for (const t of [
+      "authenticate",
+      "list_scenarios",
+      "whoami",
+      "login",
+      "logout",
+      "switch_provider",
+    ]) {
+      expect(commandRequiresAuth(t)).toBe(false);
+    }
+  });
+});
+
+describe("httpRequiresAuth", () => {
+  it("gates mutating methods, allows GET/HEAD/OPTIONS", () => {
+    for (const m of ["POST", "PUT", "PATCH", "DELETE"]) expect(httpRequiresAuth(m)).toBe(true);
+    for (const m of ["GET", "HEAD", "OPTIONS"]) expect(httpRequiresAuth(m)).toBe(false);
+  });
+});

--- a/ts/tests/user-auth-protocol.test.ts
+++ b/ts/tests/user-auth-protocol.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { parseClientMessage } from "../src/server/protocol.js";
+
+describe("authenticate command", () => {
+  it("parses a valid authenticate frame", () => {
+    expect(parseClientMessage({ type: "authenticate", token: "abc" })).toEqual({
+      type: "authenticate",
+      token: "abc",
+    });
+  });
+  it("rejects a blank token", () => {
+    expect(() => parseClientMessage({ type: "authenticate", token: "" })).toThrow();
+  });
+});

--- a/ts/tests/user-auth-verifier.test.ts
+++ b/ts/tests/user-auth-verifier.test.ts
@@ -44,6 +44,31 @@ describe("identityFromClaims", () => {
       groups: [],
     });
   });
+  it("defends against malformed claims", () => {
+    // non-array groups/roles -> []
+    expect(identityFromClaims({ sub: "u", groups: "admin" as unknown as string[] })).toEqual({
+      subject: "u",
+      email: undefined,
+      groups: [],
+    });
+    expect(identityFromClaims({ sub: "u", roles: 42 as unknown as string[] })).toEqual({
+      subject: "u",
+      email: undefined,
+      groups: [],
+    });
+    // non-string email -> undefined
+    expect(identityFromClaims({ sub: "u", email: 42 as unknown as string })).toEqual({
+      subject: "u",
+      email: undefined,
+      groups: [],
+    });
+    // array of non-strings -> stringified
+    expect(identityFromClaims({ sub: "u", groups: [1, 2] as unknown as string[] })).toEqual({
+      subject: "u",
+      email: undefined,
+      groups: ["1", "2"],
+    });
+  });
 });
 
 describe("verifier", () => {

--- a/ts/tests/user-auth-verifier.test.ts
+++ b/ts/tests/user-auth-verifier.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { SignJWT, exportJWK, generateKeyPair } from "jose";
+import {
+  createVerifierWithKeySet,
+  identityFromClaims,
+} from "../src/server/user-auth/token-verifier.js";
+
+async function setup() {
+  const { publicKey, privateKey } = await generateKeyPair("RS256");
+  const jwk = await exportJWK(publicKey);
+  jwk.kid = "test";
+  jwk.alg = "RS256";
+  return { privateKey, jwks: { keys: [jwk] } };
+}
+
+function sign(
+  privateKey: CryptoKey,
+  claims: Record<string, unknown>,
+  opts: { iss: string; aud?: string; exp?: string },
+) {
+  let b = new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256", kid: "test" })
+    .setIssuer(opts.iss)
+    .setIssuedAt();
+  if (opts.aud) b = b.setAudience(opts.aud);
+  return b.setExpirationTime(opts.exp ?? "5m").sign(privateKey);
+}
+
+describe("identityFromClaims", () => {
+  it("extracts subject, email, groups (groups then roles, default [])", () => {
+    expect(identityFromClaims({ sub: "u1", email: "u1@x.co", groups: ["a"] })).toEqual({
+      subject: "u1",
+      email: "u1@x.co",
+      groups: ["a"],
+    });
+    expect(identityFromClaims({ sub: "u2", roles: ["r"] })).toEqual({
+      subject: "u2",
+      email: undefined,
+      groups: ["r"],
+    });
+    expect(identityFromClaims({ sub: "u3" })).toEqual({
+      subject: "u3",
+      email: undefined,
+      groups: [],
+    });
+  });
+});
+
+describe("verifier", () => {
+  it("accepts a validly signed token", async () => {
+    const { privateKey, jwks } = await setup();
+    const v = createVerifierWithKeySet(jwks, { issuer: "https://idp.co", audience: "autoctx" });
+    const token = await sign(
+      privateKey,
+      { sub: "u1", email: "u1@x.co", groups: ["eng"] },
+      { iss: "https://idp.co", aud: "autoctx" },
+    );
+    expect(await v.verify(token)).toEqual({ subject: "u1", email: "u1@x.co", groups: ["eng"] });
+  });
+  it("rejects a wrong issuer", async () => {
+    const { privateKey, jwks } = await setup();
+    const v = createVerifierWithKeySet(jwks, { issuer: "https://idp.co", audience: "autoctx" });
+    const token = await sign(privateKey, { sub: "u1" }, { iss: "https://evil.co", aud: "autoctx" });
+    await expect(v.verify(token)).rejects.toThrow();
+  });
+  it("rejects a wrong audience", async () => {
+    const { privateKey, jwks } = await setup();
+    const v = createVerifierWithKeySet(jwks, { issuer: "https://idp.co", audience: "autoctx" });
+    const token = await sign(privateKey, { sub: "u1" }, { iss: "https://idp.co", aud: "other" });
+    await expect(v.verify(token)).rejects.toThrow();
+  });
+  it("rejects an expired token", async () => {
+    const { privateKey, jwks } = await setup();
+    const v = createVerifierWithKeySet(jwks, { issuer: "https://idp.co", audience: "autoctx" });
+    const token = await sign(
+      privateKey,
+      { sub: "u1" },
+      { iss: "https://idp.co", aud: "autoctx", exp: "-1m" },
+    );
+    await expect(v.verify(token)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds user-identity auth to the engine: the server verifies a user JWT that a client attaches and enforces it on run-affecting operations, but ONLY when auth is configured. Disabled by default, so existing local-mode behavior is unchanged. This is the engine side of an enterprise-auth effort (the desktop client attaches the token; this is its first real consumer). Issuer-agnostic: verifies any JWT against a configured JWKS URL, so it works against a company IdP directly.

Scope is intentionally **verify + enforce only** (a binary authenticated-or-not gate). Role/group RBAC, run audit, and a gateway-trust (`X-Forwarded-User`) variant are explicit follow-on slices.

## What's included

- **`ts/src/server/user-auth/`** (new module):
  - `config.ts`: `userAuthConfigFromEnv(env)` reads `AUTOCONTEXT_AUTH_JWKS_URL` / `AUTOCONTEXT_AUTH_ISSUER` / `AUTOCONTEXT_AUTH_AUDIENCE`. Returns `null` (auth disabled) unless the JWKS URL + issuer are both set.
  - `token-verifier.ts`: a `jose`-based `TokenVerifier` (`createRemoteJWKSet` + `jwtVerify` checking issuer/audience/expiry) plus a pure `identityFromClaims` (subject/email/groups, groups from `groups` then `roles`, defaulting to `[]`, defensive against malformed claims). A local-JWKS factory is exposed for tests.
  - `enforcement.ts`: pure `commandRequiresAuth(type)` (allowlist: handshake + read-only + provider-auth commands are open; run-affecting commands are gated, fail-closed) and `httpRequiresAuth(method)` (mutating methods gated, GET/HEAD/OPTIONS open).
- **`protocol.ts`**: adds the `authenticate` client command (`{ type, token }`) to the strict union (+ the shared contract manifest), classified as a TypeScript-only client message.
- **`ws-server.ts`**: an injectable `TokenVerifier` (from env by default), per-connection identity map (cleaned up on close), the `authenticate` handler, and config-gated enforcement on both the ws command path and the HTTP `Authorization: Bearer` path (401 on mutating routes without a valid token). CORS now allows the `Authorization` header.
- A `user-auth/README.md` documenting the env vars and behavior.

## Safety: disabled path is byte-for-byte unchanged

When `AUTOCONTEXT_AUTH_*` is not configured, `userAuthConfigFromEnv` returns `null`, the verifier is `null`, and both the ws and HTTP gates short-circuit (`=== null`). The `authenticate` frame is a no-op ack. Today's local-mode behavior is preserved; the 27 pre-existing protocol/contract tests pass unchanged.

## Verification

- 47 tests pass across 7 files (17 new user-auth + the existing protocol/contract suites). The verifier tests use real RS256 crypto (signature + issuer + audience + expiry rejection); ws and HTTP gates have integration tests against a real server with an injected stub verifier.
- `bunx tsc --noEmit` clean; `bunx prettier --check` clean.
- No token is logged anywhere; the HTTP 401 body carries no secret.

## Notes for review

- **Not auto-merged**: opened for team review of a shared repo.
- **Release coordination**: this lands in `autoctx`; a consuming desktop client only enforces auth once a new `autoctx` version is published and the client pins it. No behavior change for existing consumers until then (disabled by default).
- Out of scope (follow-ons): RBAC granularity, run audit, gateway-trust, and the client-side wiring (already shipped separately).

Built TDD, task-by-task, each with spec-compliance + code-quality review plus a final holistic review.