### PR TITLE
AC-763 document edge runtime compatibility spike

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 ## Architecture And Parity
 
 - [Core/control package split](core-control-package-split.md)
+- [Generic edge runtime compatibility spike](edge-runtime-compatibility.md)
 - [Flue-inspired runtime decisions](flue-influences.md)
 - [Scenario parity matrix — Python & TypeScript](scenario-parity-matrix.md)
 - [Browser exploration contract](browser-exploration-contract.md)

--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -68,9 +68,11 @@ level while remaining Apache-2.0 in this repo.
 
 ## Agent App Build Targets
 
-autocontext should treat `build --target node|cloudflare` deployment targets as
-control-plane packaging around stable runtime contracts, not as new runtime
-contracts themselves. The machine-readable target boundary lives in
+autocontext should treat generated agent app targets as control-plane packaging
+around stable runtime contracts, not as new runtime contracts themselves. The
+only current CLI build target is `node`; generic edge-runtime compatibility is a
+spike until the Node target proves which seams are reusable. The
+machine-readable target boundary lives in
 [`packages/package-topology.json`](../packages/package-topology.json) under
 `agentApps`.
 
@@ -88,9 +90,9 @@ Ownership:
   interfaces, runtime-session event contracts, and the dependencies needed by
   those contracts.
 - Build and deploy workflows belong in the Apache control-plane artifact. This
-  includes target selection, bundle planning, generated server/worker templates,
-  target-specific adapters, packaging checks, and operator-facing CLI/API
-  commands.
+  includes target selection, bundle planning, generated server or Fetch adapter
+  templates, target-specific adapters, packaging checks, and operator-facing
+  CLI/API commands.
 - The umbrella `autoctx` CLI may dispatch build commands while package splitting
   is in progress, but it should delegate to the control-plane implementation.
 - Hosted fleet orchestration is out of scope for this Apache repo. Multi-tenant
@@ -126,24 +128,27 @@ contracts:
 - keep deployment, service hosting, process supervision, and remote secret
   management out of scope.
 
-### Cloudflare Target Spike
+### Generic Edge Runtime Compatibility Spike
 
-The Cloudflare target should stay a spike until the Node target proves the
-handler/server boundary. The spike can explore Workers for request routing and
-Durable Objects for session/event persistence, but it should report contract
-gaps before adding a production build path.
+The edge-runtime question should stay a spike until the Node target proves the
+handler/server boundary. Cloudflare Workers/Durable Objects may be reference
+environments, but the spike must report generic portability constraints before
+any provider-specific build path is added. The detailed spike lives in
+[`edge-runtime-compatibility.md`](./edge-runtime-compatibility.md).
 
 The spike should answer:
 
-- how a Worker bundle loads or embeds agent handlers without depending on
-  Node-only dynamic import behavior;
-- how Durable Objects map onto runtime-session ids, append/replay semantics, and
-  child-session links;
+- whether the Node `GET /manifest` and `POST /agents/<agent>/invoke` wire shape
+  can be reused through a standards-based Fetch handler;
+- how edge bundles load or embed agent handlers without depending on Node-only
+  dynamic import or runtime filesystem discovery behavior;
+- how edge-native storage maps onto runtime-session ids, append/replay
+  semantics, and child-session links;
 - how tool grants are represented when local process execution and filesystem
   access are unavailable;
-- which runtime workspace adapters are valid in an edge environment;
-- which pieces must remain target adapters in the control-plane package instead
-  of leaking into core.
+- which runtime workspace adapters are valid in constrained edge environments;
+- which pieces must remain generic target adapters in the control-plane package
+  instead of leaking into core or becoming provider-specific OSS commitments.
 
 ### Risks
 
@@ -153,12 +158,13 @@ The spike should answer:
 - Environment variables: build targets must preserve explicit env loading and
   redaction semantics. They must not capture the full host environment or bake
   secrets into generated artifacts.
-- Session persistence: Node can start with local SQLite/file stores, while
-  Cloudflare needs a Durable Object or other edge-native event store. Replay
+- Session persistence: Node can start with local SQLite/file stores, while edge
+  runtimes need an adapter around a runtime-native or remote event store. Replay
   semantics must stay compatible before sessions move between targets.
 - Sandbox providers: local shell grants, filesystem adapters, and subprocess
-  runtimes do not automatically exist in Workers. Target adapters must degrade
-  explicitly or require remote tools rather than silently broadening authority.
+  runtimes do not automatically exist in constrained edge runtimes. Target
+  adapters must degrade explicitly or require remote tools rather than silently
+  broadening authority.
 - Product boundary: hosted scheduling, policy rollout, tenant isolation,
   observability cockpit features, and managed deployment are not open-source
   build-target responsibilities.

--- a/docs/edge-runtime-compatibility.md
+++ b/docs/edge-runtime-compatibility.md
@@ -1,0 +1,204 @@
+# Generic Edge Runtime Compatibility Spike
+
+AC-763 records the portability questions for generated agent apps after the
+Node target MVP in AC-762. The goal is to identify generic contracts that make
+agent apps portable across constrained Fetch/ESM runtimes. It is not approval to
+ship a provider-specific target in the OSS repo.
+
+Cloudflare Workers/Durable Objects may be reference environments, alongside
+Deno Deploy, Vercel Edge, and other Fetch-compatible runtimes, but provider
+names are used only to expose portability constraints. Provider deployment
+manifests, hosted tenant routing, managed secrets, fleet scheduling, billing,
+and hosted observability remain outside this Apache-2.0 repository.
+
+Boundary reference: [Agent App Build Targets](./core-control-package-split.md#agent-app-build-targets).
+
+## Result
+
+The AC-762 manifest/invoke wire shape can be reused in an edge runtime if the
+Node-specific server shell is replaced by a standards-based Fetch adapter and
+handler discovery is moved to a build-time manifest or explicit module map.
+The current Node target should remain the only emitted build target until those
+generic adapter seams are proven.
+
+Recommended OSS follow-up, if this spike is accepted:
+
+1. Add a TypeScript control-plane helper that handles `Request` -> `Response`
+   for the existing `GET /manifest` and `POST /agents/:agent/invoke` shape.
+2. Add a build-time handler manifest/module-map contract so edge bundles do not
+   need runtime filesystem discovery.
+3. Add or document edge-safe workspace and session event-store adapters behind
+   the existing runtime/session contracts.
+4. Keep provider-specific deployment templates and hosted orchestration in a
+   separate product/repository unless they are deliberately opened later.
+
+## Reusable Invocation Shape
+
+The Node agent app currently exposes:
+
+- `GET /manifest` or `GET /agents`
+- `POST /agents/<agent>/invoke`
+
+The invoke body is a JSON object with optional `id` and optional `payload`; the
+success envelope is:
+
+```json
+{
+  "ok": true,
+  "agent": "support",
+  "id": "ticket-123",
+  "result": {}
+}
+```
+
+That shape is transport-neutral. A Fetch adapter can preserve it by parsing the
+URL path and JSON body from `Request`, then returning a JSON `Response`. The
+handler API does not need to change if the adapter can still supply the same
+AutoContext invocation context: `id`, `payload`, explicit `env`, workspace,
+runtime, event store/sink, command grants, and tool grants.
+
+## Node Assumptions That Do Not Hold At The Edge
+
+| Area | AC-762 Node target assumption | Edge compatibility concern |
+| --- | --- | --- |
+| HTTP | Uses `node:http` `IncomingMessage`/`ServerResponse` and a long-lived `Server`. | Edge runtimes expose `fetch(request, env, ctx)` or equivalent `Request`/`Response` APIs. |
+| Handler discovery | Reads `.autoctx/agents` with `node:fs` at runtime. | Edge bundles usually cannot scan a deployment filesystem; discovery needs a manifest produced at build time. |
+| Handler loading | Dynamically imports file paths and bare modules from local disk. | Edge bundlers require static or bundler-known dynamic imports; native Node resolution is unavailable. |
+| Workspace | Defaults to `createLocalWorkspaceEnv()`, which can read/write files and run local command grants. | Edge workspaces must be in-memory, remote object-backed, or explicitly unavailable; shell execution must not be emulated. |
+| Session persistence | Can lazy-import the local SQLite runtime-session store when `AUTOCTX_SESSION_DB` is set. | Edge persistence needs an append/replay event-log adapter backed by runtime storage, not native SQLite. |
+| Environment | Reads selected process env values and optional `.env` files from the source project root. | Edge env must be explicit bindings/config passed by the host; the adapter must not capture deployment-wide ambient env. |
+| Runtime factory | Loads `AUTOCTX_RUNTIME_MODULE` as URL, file path, or bare package from `node_modules`. | Runtime factories must be bundled or passed as explicit host-created capabilities; provider SDKs must be edge-compatible. |
+| Dependencies | The generated package can install `autoctx` and Node dependencies. | Edge bundles must avoid native addons, Node-only modules, and optional dependencies that bundlers cannot tree-shake. |
+| Lifecycle | A Node process owns server startup/shutdown and resource cleanup. | Edge invocations may be short-lived; cleanup must be scoped to requests or runtime-provided wait hooks. |
+
+## Minimum Generic Edge Adapter Contract
+
+A generic edge adapter should stay in the TypeScript control-plane boundary until
+its reusable contracts are extracted into `@autocontext/core`.
+
+### Fetch Transport
+
+The adapter should accept a standards-based request and context:
+
+```ts
+type EdgeAgentAppFetch = (
+  request: Request,
+  context: EdgeAgentAppContext,
+) => Promise<Response> | Response;
+```
+
+The transport layer owns:
+
+- route matching for `GET /manifest`, `GET /agents`, and
+  `POST /agents/:agent/invoke`;
+- JSON parsing with an explicit body-size limit;
+- JSON response serialization and stable error envelopes;
+- request cancellation through `AbortSignal` where the runtime supplies one;
+- no dependency on `node:http`, `Buffer`, process globals, or local ports.
+
+### Handler Catalog And Loader
+
+Edge runtimes should not discover handlers from the filesystem at request time.
+The build step should provide a catalog similar to:
+
+```ts
+interface EdgeAgentCatalogEntry {
+  name: string;
+  relativePath: string;
+  extension: string;
+  triggers?: Record<string, unknown>;
+  load(): Promise<AutoctxLoadedAgent>;
+}
+```
+
+The catalog can be generated from `.autoctx/agents` by the control-plane build
+workflow, but the runtime adapter receives a static list or module map. This
+keeps source-project scanning out of the edge request path and lets bundlers see
+which handler modules must be included.
+
+### Explicit Environment And Runtime Capabilities
+
+The adapter should receive env as a plain object from trusted host code. It must
+not read `process.env`, parse `.env` files, or bake secrets into generated
+artifacts. Runtime factories should be host-created capabilities, not ambient
+module lookups, unless a bundler-safe module map is supplied explicitly.
+
+### Workspace And Grants
+
+The existing `RuntimeWorkspaceEnv`, `RuntimeCommandGrant`, and
+`RuntimeToolGrant` concepts can carry over, but edge adapters need stricter
+capability choices:
+
+- in-memory workspace for pure handlers;
+- remote/object-backed workspace for explicit persisted artifacts;
+- no-op or denied filesystem methods when persistence was not granted;
+- no local shell command grants;
+- remote tool grants only when the host explicitly supplies them;
+- grant lifecycle events should keep the existing redaction and truncation
+  semantics.
+
+The adapter must fail closed or return an explicit unsupported-capability error
+when a handler asks for local filesystem or shell authority that does not exist.
+
+### Runtime-Session Event Log
+
+The existing runtime-session store shape is append/replay oriented and can be
+mapped to edge storage if an adapter provides:
+
+- append event by runtime-session id;
+- read session metadata and timeline by id;
+- list or query sessions where the runtime supports it;
+- deterministic child-session linkage fields;
+- idempotent writes or retry-safe event ids;
+- documented consistency/concurrency behavior.
+
+Durable Objects, Deno KV, Vercel KV, S3/R2-like object stores, and hosted event
+logs are possible storage implementations, but OSS should define only the
+adapter contract unless a provider-neutral implementation is added.
+
+## Reference Runtime Findings
+
+| Runtime family | Useful reference | Main constraints |
+| --- | --- | --- |
+| Cloudflare Workers + Durable Objects | Fetch routing and per-object session/event coordination. | No Node server, no local filesystem, bundler restrictions, Durable Object namespace provisioning is provider deployment code. |
+| Deno Deploy | Standards-first Fetch/ESM runtime. | Different module resolution, explicit permissions model, no Node native addons. |
+| Vercel Edge | Fetch-like function surface integrated with a deployment platform. | Limited Node API support, platform-specific env and storage adapters. |
+| Generic Fetch/ESM | Lowest common denominator for an OSS adapter contract. | Requires static/bundler-known handler modules and explicit capabilities. |
+
+Provider-specific details should feed constraints back into the generic adapter;
+they should not create provider-specific OSS deployment workflows by default.
+
+## Follow-Up Split
+
+### OSS Core Contract Changes Only If Needed
+
+- Extract public handler/catalog types when `autoctx/agent-runtime` moves into
+  the planned `@autocontext/core` surface.
+- Keep runtime-session event contracts provider-neutral and storage-agnostic.
+- Add capability vocabulary only when multiple runtimes need the same concept.
+
+### TypeScript Control-Plane / OSS Adapter Work
+
+- Add a Fetch request adapter that reuses the Node manifest/invoke envelope.
+- Add a build-time handler manifest/module-map planner.
+- Add tests proving pure local handlers can run through the Fetch adapter with
+  in-memory workspace/env and without Node-only globals.
+- Document unsupported shell/filesystem capability behavior.
+
+### Provider-Specific Or Proprietary Work
+
+- Cloudflare `wrangler` config, Durable Object bindings, namespace provisioning,
+  queues, alarms, and deployment scripts.
+- Vercel/Deno deployment manifests and platform-specific secret wiring.
+- Hosted tenant scheduling, hosted warm pools, provider image/cache economics,
+  billing, organization policy rollout, hosted observability cockpit, or remote
+  secret brokering.
+
+## Decision
+
+Do not add `autoctx agent build --target cloudflare` or any provider-specific
+edge target from this spike. The next OSS implementation slice, if prioritized,
+should be a generic Fetch adapter and static handler catalog in the TypeScript
+control-plane boundary. Provider-specific deployment can depend on that adapter
+from outside the OSS repo or from a future explicitly approved open provider
+package.

--- a/packages/package-topology.json
+++ b/packages/package-topology.json
@@ -45,10 +45,10 @@
         "owner": "@autocontext/control-plane",
         "runtime": "load local agent handlers through autoctx/agent-runtime until the surface is extracted into @autocontext/core"
       },
-      "cloudflare": {
+      "edge": {
         "phase": "spike",
         "owner": "@autocontext/control-plane",
-        "runtime": "prototype Worker and Durable Object session persistence after Node target contracts stabilize"
+        "runtime": "inventory generic Fetch/ESM runtime portability gaps before any provider-specific build target is added"
       }
     }
   },

--- a/ts/tests/package-topology.test.ts
+++ b/ts/tests/package-topology.test.ts
@@ -129,7 +129,7 @@ describe("package topology", () => {
           phase: "mvp",
           owner: "@autocontext/control-plane",
         },
-        cloudflare: {
+        edge: {
           phase: "spike",
           owner: "@autocontext/control-plane",
         },
@@ -164,7 +164,9 @@ describe("package topology", () => {
     expect(doc).toContain("autoctx/agent-runtime");
     expect(doc).toContain("importing missing core package");
     expect(doc).toContain("Node Target MVP");
-    expect(doc).toContain("Cloudflare Target Spike");
+    expect(doc).toContain("Generic Edge Runtime Compatibility Spike");
+    expect(doc).toContain("Cloudflare Workers/Durable Objects may be reference");
+    expect(doc).toContain("provider-specific build path");
     expect(doc).toContain("Hosted fleet orchestration");
     expect(doc).toContain("Bundling");
     expect(doc).toContain("Environment variables");


### PR DESCRIPTION
## Summary
- Re-scope the agent app topology from a provider-specific Cloudflare spike to a generic edge-runtime compatibility spike.
- Add `docs/edge-runtime-compatibility.md` with Node assumption inventory, Fetch adapter contract gaps, edge storage/workspace/tool-grant constraints, and provider-boundary follow-ups.
- Update core/control package split docs and package topology tests to preserve the OSS/proprietary boundary and keep provider-specific deployment out of OSS.

## Verification
- `npx vitest run tests/package-topology.test.ts --reporter=verbose`
- `npx vitest run tests/package-topology.test.ts tests/package-boundaries.test.ts tests/agent-command-workflow.test.ts --reporter=verbose`
- `npm run lint -- --pretty false`
- `npx tsc -p tests/tsconfig.json --noEmit --pretty false`
- `git diff --check origin/main...HEAD && git diff --check`

Linear: AC-763