### PR TITLE
AC-788 Add generic Fetch adapter for generated agent apps

### DIFF
--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -130,10 +130,12 @@ contracts:
 
 ### Generic Edge Runtime Compatibility Spike
 
-The edge-runtime question should stay a spike until the Node target proves the
-handler/server boundary. Cloudflare Workers/Durable Objects may be reference
-environments, but the spike must report generic portability constraints before
-any provider-specific build path is added. The detailed spike lives in
+The edge-runtime question should stay generic until the Node target proves the
+handler/server boundary. The TypeScript control-plane Fetch adapter lives at
+`autoctx/control-plane/agent-app-fetch` and reuses the Node manifest/invoke
+wire shape without becoming a provider-specific deployment target. Cloudflare Workers/Durable Objects may be reference environments, but the spike must report
+generic portability constraints before any provider-specific build path is
+added. The detailed spike lives in
 [`edge-runtime-compatibility.md`](./edge-runtime-compatibility.md).
 
 The spike should answer:

--- a/docs/edge-runtime-compatibility.md
+++ b/docs/edge-runtime-compatibility.md
@@ -21,15 +21,19 @@ handler discovery is moved to a build-time manifest or explicit module map.
 The current Node target should remain the only emitted build target until those
 generic adapter seams are proven.
 
-Recommended OSS follow-up, if this spike is accepted:
+The first OSS adapter seam is the TypeScript control-plane Fetch helper at
+`autoctx/control-plane/agent-app-fetch`. It handles `Request` -> `Response` for
+the existing `GET /manifest` and `POST /agents/:agent/invoke` shape using a
+static handler catalog or module map. This helper is not a deployment target and
+does not add provider-specific build output.
 
-1. Add a TypeScript control-plane helper that handles `Request` -> `Response`
-   for the existing `GET /manifest` and `POST /agents/:agent/invoke` shape.
-2. Add a build-time handler manifest/module-map contract so edge bundles do not
-   need runtime filesystem discovery.
-3. Add or document edge-safe workspace and session event-store adapters behind
+Recommended follow-up after the generic adapter seam:
+
+1. Add a build-time handler manifest/module-map planner so generated edge
+   bundles do not need runtime filesystem discovery.
+2. Add or document edge-safe workspace and session event-store adapters behind
    the existing runtime/session contracts.
-4. Keep provider-specific deployment templates and hosted orchestration in a
+3. Keep provider-specific deployment templates and hosted orchestration in a
    separate product/repository unless they are deliberately opened later.
 
 ## Reusable Invocation Shape
@@ -179,10 +183,11 @@ they should not create provider-specific OSS deployment workflows by default.
 
 ### TypeScript Control-Plane / OSS Adapter Work
 
-- Add a Fetch request adapter that reuses the Node manifest/invoke envelope.
+- Maintain the generic Fetch request adapter that reuses the Node
+  manifest/invoke envelope without advertising a provider deployment target.
 - Add a build-time handler manifest/module-map planner.
-- Add tests proving pure local handlers can run through the Fetch adapter with
-  in-memory workspace/env and without Node-only globals.
+- Add tests proving pure local handlers can run through generated catalogs with
+  in-memory workspace/env and without Node-only server globals.
 - Document unsupported shell/filesystem capability behavior.
 
 ### Provider-Specific Or Proprietary Work
@@ -197,8 +202,7 @@ they should not create provider-specific OSS deployment workflows by default.
 ## Decision
 
 Do not add `autoctx agent build --target cloudflare` or any provider-specific
-edge target from this spike. The next OSS implementation slice, if prioritized,
-should be a generic Fetch adapter and static handler catalog in the TypeScript
-control-plane boundary. Provider-specific deployment can depend on that adapter
-from outside the OSS repo or from a future explicitly approved open provider
-package.
+edge target from this spike. The OSS implementation surface is a generic Fetch
+adapter and static handler catalog in the TypeScript control-plane boundary.
+Provider-specific deployment can depend on that adapter from outside the OSS
+repo or from a future explicitly approved open provider package.

--- a/ts/README.md
+++ b/ts/README.md
@@ -123,6 +123,42 @@ curl -X POST http://127.0.0.1:3583/agents/support/invoke \
   -d '{"id":"ticket-123","payload":{"message":"Please triage this ticket."}}'
 ```
 
+Generic Fetch/ESM hosts can reuse the same manifest/invoke wire shape through
+the control-plane adapter at `autoctx/control-plane/agent-app-fetch`. The
+adapter takes an explicit static catalog or module map; it does not scan the
+filesystem at request time and does not imply a Cloudflare, Vercel, or Deno
+build target.
+
+```ts
+import {
+  createAgentAppFetchHandler,
+  createStaticAgentAppCatalog,
+} from "autoctx/control-plane/agent-app-fetch";
+
+const hostProvidedEnv = { SUPPORT_TOKEN: "host-injected-token" };
+
+const fetchAgentApp = createAgentAppFetchHandler({
+  env: { SUPPORT_TOKEN: hostProvidedEnv.SUPPORT_TOKEN },
+  catalog: createStaticAgentAppCatalog([
+    {
+      name: "support",
+      relativePath: ".autoctx/agents/support.ts",
+      extension: ".ts",
+      triggers: { webhook: true },
+      handler: async (ctx) => ({ id: ctx.id, payload: ctx.payload }),
+    },
+  ]),
+});
+
+export default { fetch: fetchAgentApp };
+```
+
+See [`docs/edge-runtime-compatibility.md`](../docs/edge-runtime-compatibility.md)
+and [`docs/core-control-package-split.md#agent-app-build-targets`](../docs/core-control-package-split.md#agent-app-build-targets)
+for the OSS/proprietary boundary: provider deployment manifests, hosted secrets,
+fleet scheduling, billing, and tenant orchestration stay outside this OSS
+adapter.
+
 The TypeScript package includes mirrored deterministic semantic prompt
 compaction for long-lived playbooks, trajectories, and session reports.
 Standalone npm runs compact prompt context before the coarse budget fallback,

--- a/ts/package.json
+++ b/ts/package.json
@@ -73,6 +73,10 @@
       "import": "./dist/control-plane/agent-app-node/index.js",
       "types": "./dist/control-plane/agent-app-node/index.d.ts"
     },
+    "./control-plane/agent-app-fetch": {
+      "import": "./dist/control-plane/agent-app-fetch/index.js",
+      "types": "./dist/control-plane/agent-app-fetch/index.d.ts"
+    },
     "./production-traces": {
       "types": "./dist/production-traces/sdk/index.d.ts",
       "import": "./dist/production-traces/sdk/index.js",

--- a/ts/src/control-plane/agent-app-fetch/index.ts
+++ b/ts/src/control-plane/agent-app-fetch/index.ts
@@ -426,7 +426,8 @@ class EdgeInMemoryWorkspaceEnv implements RuntimeWorkspaceEnv {
 
   constructor(state: EdgeMemoryState, cwd: string, tools?: readonly RuntimeToolGrant[]) {
     this.#state = state;
-    this.cwd = cwd;
+    this.cwd = normalizeVirtualPath(cwd, "/");
+    ensureDir(this.#state, this.cwd);
     this.tools = tools;
   }
 
@@ -439,13 +440,17 @@ class EdgeInMemoryWorkspaceEnv implements RuntimeWorkspaceEnv {
   }
 
   scope(options: RuntimeScopeOptions = {}): Promise<RuntimeWorkspaceEnv> {
-    return Promise.resolve(
-      new EdgeInMemoryWorkspaceEnv(
-        this.#state,
-        normalizeVirtualPath(options.cwd ?? this.cwd, this.cwd),
-        options.tools ?? this.tools,
-      ),
-    );
+    try {
+      return Promise.resolve(
+        new EdgeInMemoryWorkspaceEnv(
+          this.#state,
+          normalizeVirtualPath(options.cwd ?? this.cwd, this.cwd),
+          options.tools ?? this.tools,
+        ),
+      );
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   async readFile(filePath: string): Promise<string> {
@@ -459,13 +464,12 @@ class EdgeInMemoryWorkspaceEnv implements RuntimeWorkspaceEnv {
   }
 
   writeFile(filePath: string, content: string | Uint8Array): Promise<void> {
-    const resolved = this.resolvePath(filePath);
-    ensureDir(this.#state, parentDir(resolved));
-    this.#state.files.set(resolved, {
-      content: typeof content === "string" ? new TextEncoder().encode(content) : content.slice(),
-      mtime: new Date(),
-    });
-    return Promise.resolve();
+    try {
+      writeEdgeMemoryFile(this.#state, this.resolvePath(filePath), content);
+      return Promise.resolve();
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   stat(filePath: string): Promise<RuntimeFileStat> {
@@ -513,9 +517,27 @@ class EdgeInMemoryWorkspaceEnv implements RuntimeWorkspaceEnv {
     return Promise.resolve(this.#state.files.has(resolved) || this.#state.dirs.has(resolved));
   }
 
-  mkdir(dirPath: string, _options: { recursive?: boolean } = {}): Promise<void> {
-    ensureDir(this.#state, this.resolvePath(dirPath));
-    return Promise.resolve();
+  mkdir(dirPath: string, options: { recursive?: boolean } = {}): Promise<void> {
+    const resolved = this.resolvePath(dirPath);
+    const parent = parentDir(resolved);
+    if (this.#state.files.has(resolved)) {
+      return Promise.reject(new Error(`File exists: ${resolved}`));
+    }
+    if (this.#state.dirs.has(resolved)) {
+      return options.recursive
+        ? Promise.resolve()
+        : Promise.reject(new Error(`Directory exists: ${resolved}`));
+    }
+    if (!options.recursive && !this.#state.dirs.has(parent)) {
+      return Promise.reject(new Error(`Parent directory not found: ${parent}`));
+    }
+    try {
+      ensureDir(this.#state, options.recursive ? resolved : parent);
+      this.#state.dirs.set(resolved, new Date());
+      return Promise.resolve();
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   rm(filePath: string, options: { recursive?: boolean; force?: boolean } = {}): Promise<void> {
@@ -567,15 +589,8 @@ async function readJsonRequestBody(
   request: Request,
   maxBodyBytes: number,
 ): Promise<Record<string, unknown>> {
-  const text = await request.text();
+  const text = await readLimitedRequestText(request, maxBodyBytes);
   if (!text.trim()) return {};
-  if (new TextEncoder().encode(text).byteLength > maxBodyBytes) {
-    throw new AgentAppFetchRequestError(
-      413,
-      "AUTOCTX_AGENT_APP_REQUEST_TOO_LARGE",
-      "Request body is too large",
-    );
-  }
   try {
     const parsed: unknown = JSON.parse(text);
     if (!isRecord(parsed)) {
@@ -590,6 +605,70 @@ async function readJsonRequestBody(
       `Request body must be valid JSON: ${message}`,
     );
   }
+}
+
+async function readLimitedRequestText(request: Request, maxBodyBytes: number): Promise<string> {
+  const advertisedLength = readContentLength(request.headers.get("content-length"));
+  if (advertisedLength !== undefined && advertisedLength > maxBodyBytes) {
+    throw requestTooLargeError();
+  }
+  if (!request.body) return "";
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBodyBytes) {
+        await cancelRequestReader(reader);
+        throw requestTooLargeError();
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return decodeRequestChunks(chunks, totalBytes);
+}
+
+async function cancelRequestReader(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<void> {
+  try {
+    await reader.cancel("Request body is too large");
+  } catch {
+    // The adapter already knows the request is too large; ignore cancellation races.
+  }
+}
+
+function decodeRequestChunks(chunks: Uint8Array[], totalBytes: number): string {
+  if (chunks.length === 0) return "";
+  if (chunks.length === 1) return new TextDecoder().decode(chunks[0]);
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function readContentLength(value: string | null): number | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) return undefined;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
+}
+
+function requestTooLargeError(): AgentAppFetchRequestError {
+  return new AgentAppFetchRequestError(
+    413,
+    "AUTOCTX_AGENT_APP_REQUEST_TOO_LARGE",
+    "Request body is too large",
+  );
 }
 
 function jsonResponse(status: number, body: unknown): Response {
@@ -617,12 +696,30 @@ function createEdgeMemoryState(): EdgeMemoryState {
   return { files: new Map(), dirs: new Map([["/", new Date()]]) };
 }
 
+function writeEdgeMemoryFile(
+  state: EdgeMemoryState,
+  resolved: string,
+  content: string | Uint8Array,
+): void {
+  if (state.dirs.has(resolved)) {
+    throw new Error(`Is a directory: ${resolved}`);
+  }
+  ensureDir(state, parentDir(resolved));
+  state.files.set(resolved, {
+    content: typeof content === "string" ? new TextEncoder().encode(content) : content.slice(),
+    mtime: new Date(),
+  });
+}
+
 function ensureDir(state: EdgeMemoryState, dirPath: string): void {
   let current = "/";
   state.dirs.set(current, state.dirs.get(current) ?? new Date());
   for (const segment of dirPath.split("/")) {
     if (!segment) continue;
     current = current === "/" ? `/${segment}` : `${current}/${segment}`;
+    if (state.files.has(current)) {
+      throw new Error(`Not a directory: ${current}`);
+    }
     state.dirs.set(current, state.dirs.get(current) ?? new Date());
   }
 }

--- a/ts/src/control-plane/agent-app-fetch/index.ts
+++ b/ts/src/control-plane/agent-app-fetch/index.ts
@@ -1,0 +1,684 @@
+import { agentOutputMetadata } from "../../runtimes/agent-output-metadata.js";
+import type { AgentOutput, AgentRuntime } from "../../runtimes/base.js";
+import type {
+  AutoctxAgentContext,
+  AutoctxAgentDescriptor,
+  AutoctxAgentEnv,
+  AutoctxAgentHandler,
+  AutoctxAgentInitOptions,
+  AutoctxAgentPromptOptions,
+  AutoctxAgentRuntime,
+  AutoctxAgentSession,
+  AutoctxAgentSessionOptions,
+  AutoctxLoadedAgent,
+  MaybePromise,
+} from "../../agent-runtime/index.js";
+import type {
+  RuntimeCommandGrant,
+  RuntimeExecOptions,
+  RuntimeExecResult,
+  RuntimeFileStat,
+  RuntimeScopeOptions,
+  RuntimeToolGrant,
+  RuntimeWorkspaceEnv,
+} from "../../runtimes/workspace-env.js";
+import type { RuntimeSession, RuntimeSessionPromptResult } from "../../session/runtime-session.js";
+import type { RuntimeSessionEventStore } from "../../session/runtime-events.js";
+import type { RuntimeSessionEventSink } from "../../session/runtime-session-notifications.js";
+
+export type AgentAppFetchTarget = "fetch";
+export type AgentAppFetchAgentExtension = ".ts" | ".tsx" | ".mts" | ".js" | ".mjs";
+
+export interface AgentAppFetchCatalogEntry<Payload = unknown, Result = unknown> {
+  name: string;
+  relativePath: string;
+  extension: AgentAppFetchAgentExtension | string;
+  triggers?: Record<string, unknown>;
+  handler?: AutoctxAgentHandler<Payload, Result>;
+  load?: () => MaybePromise<AutoctxLoadedAgent<Payload, Result>>;
+}
+
+export interface StaticAgentAppCatalogEntry<Payload = unknown, Result = unknown> {
+  name: string;
+  relativePath: string;
+  extension: AgentAppFetchAgentExtension | string;
+  triggers?: Record<string, unknown>;
+  handler: AutoctxAgentHandler<Payload, Result>;
+}
+
+export interface AgentAppFetchHandlerOptions<Payload = unknown, Result = unknown> {
+  catalog: readonly AgentAppFetchCatalogEntry<Payload, Result>[];
+  env?: Record<string, string | undefined>;
+  workspace?: RuntimeWorkspaceEnv;
+  runtime?: AgentRuntime;
+  commands?: RuntimeCommandGrant[];
+  tools?: RuntimeToolGrant[];
+  eventStore?: RuntimeSessionEventStore;
+  eventSink?: RuntimeSessionEventSink;
+  maxBodyBytes?: number;
+}
+
+export interface AgentAppFetchSuccessEnvelope {
+  ok: true;
+  agent: string;
+  id: string;
+  result: unknown;
+}
+
+export interface AgentAppFetchErrorEnvelope {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+export interface AgentAppFetchManifest {
+  ok: true;
+  target: AgentAppFetchTarget;
+  agents: Array<{
+    name: string;
+    relativePath: string;
+    extension: string;
+    triggers?: Record<string, unknown>;
+  }>;
+}
+
+type EdgeMemoryState = {
+  files: Map<string, EdgeMemoryFile>;
+  dirs: Map<string, Date>;
+};
+
+type EdgeMemoryFile = {
+  content: Uint8Array;
+  mtime: Date;
+};
+
+type FetchAgentContextOptions<Payload> = AgentAppFetchHandlerOptions<Payload> & {
+  agent: AutoctxLoadedAgent<Payload>;
+  id: string;
+  payload: Payload;
+  env: AutoctxAgentEnv;
+  workspace: RuntimeWorkspaceEnv;
+};
+
+const DEFAULT_MAX_BODY_BYTES = 1_000_000;
+const JSON_HEADERS = { "content-type": "application/json; charset=utf-8" };
+
+export function createStaticAgentAppCatalog<Payload = unknown, Result = unknown>(
+  entries: readonly StaticAgentAppCatalogEntry<Payload, Result>[],
+): AgentAppFetchCatalogEntry<Payload, Result>[] {
+  return entries.map((entry) => ({ ...entry }));
+}
+
+export function createAgentAppFetchHandler<Payload = unknown, Result = unknown>(
+  options: AgentAppFetchHandlerOptions<Payload, Result>,
+): (request: Request) => Promise<Response> {
+  const catalog = [...options.catalog];
+  const env = definedStringRecord(options.env ?? {});
+  return async (request) =>
+    handleAgentAppFetchRequest(request, {
+      ...options,
+      catalog,
+      env,
+      workspace: options.workspace ?? createEdgeInMemoryWorkspaceEnv(),
+    });
+}
+
+export async function handleAgentAppFetchRequest<Payload = unknown, Result = unknown>(
+  request: Request,
+  options: AgentAppFetchHandlerOptions<Payload, Result> & {
+    env: AutoctxAgentEnv;
+    workspace: RuntimeWorkspaceEnv;
+  },
+): Promise<Response> {
+  try {
+    const url = new URL(request.url);
+    if (request.method === "GET" && (url.pathname === "/manifest" || url.pathname === "/agents")) {
+      return jsonResponse(200, buildManifest(options.catalog));
+    }
+
+    const match = /^\/agents\/([^/]+)\/invoke$/.exec(url.pathname);
+    if (request.method === "POST" && match) {
+      const agentName = decodeURIComponent(match[1]!);
+      const entry = resolveCatalogEntry(options.catalog, agentName);
+      if (!entry) return jsonResponse(404, renderAgentNotFound(agentName, options.catalog));
+      const body = await readJsonRequestBody(
+        request,
+        options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
+      );
+      const loaded = await loadCatalogEntry(entry);
+      const id = readOptionalString(body.id) ?? "default";
+      const payload = ("payload" in body ? body.payload : {}) as Payload;
+      const result = await loaded.handler(
+        createFetchAgentContext({
+          ...options,
+          agent: loaded,
+          id,
+          payload,
+        }),
+      );
+      return jsonResponse(200, {
+        ok: true,
+        agent: loaded.name,
+        id,
+        result,
+      } satisfies AgentAppFetchSuccessEnvelope);
+    }
+
+    return jsonResponse(404, {
+      ok: false,
+      error: {
+        code: "AUTOCTX_AGENT_NOT_FOUND",
+        message: `No Fetch agent app route for ${request.method} ${url.pathname}`,
+      },
+    } satisfies AgentAppFetchErrorEnvelope);
+  } catch (error) {
+    if (error instanceof AgentAppFetchRequestError) {
+      return jsonResponse(error.statusCode, {
+        ok: false,
+        error: {
+          code: error.code,
+          message: error.message,
+        },
+      } satisfies AgentAppFetchErrorEnvelope);
+    }
+    return jsonResponse(500, {
+      ok: false,
+      error: {
+        code: "AUTOCTX_AGENT_APP_ERROR",
+        message: error instanceof Error ? error.message : String(error),
+      },
+    } satisfies AgentAppFetchErrorEnvelope);
+  }
+}
+
+export function createEdgeInMemoryWorkspaceEnv(
+  options: { cwd?: string } = {},
+): RuntimeWorkspaceEnv {
+  return new EdgeInMemoryWorkspaceEnv(
+    createEdgeMemoryState(),
+    normalizeVirtualPath(options.cwd ?? "/", "/"),
+  );
+}
+
+function buildManifest<Payload, Result>(
+  catalog: readonly AgentAppFetchCatalogEntry<Payload, Result>[],
+): AgentAppFetchManifest {
+  return {
+    ok: true,
+    target: "fetch",
+    agents: catalog.map((entry) => ({
+      name: entry.name,
+      relativePath: entry.relativePath,
+      extension: entry.extension,
+      triggers: cloneRecord(entry.triggers),
+    })),
+  };
+}
+
+function resolveCatalogEntry<Payload, Result>(
+  catalog: readonly AgentAppFetchCatalogEntry<Payload, Result>[],
+  agentName: string,
+): AgentAppFetchCatalogEntry<Payload, Result> | undefined {
+  return catalog.find((entry) => entry.name === agentName);
+}
+
+function renderAgentNotFound<Payload, Result>(
+  agentName: string,
+  catalog: readonly AgentAppFetchCatalogEntry<Payload, Result>[],
+): AgentAppFetchErrorEnvelope {
+  const available = catalog.map((entry) => entry.name).join(", ");
+  return {
+    ok: false,
+    error: {
+      code: "AUTOCTX_AGENT_NOT_FOUND",
+      message: available
+        ? `AutoContext agent not found: ${agentName}. Available: ${available}`
+        : `AutoContext agent not found: ${agentName}. No handlers registered in the static catalog`,
+    },
+  };
+}
+
+async function loadCatalogEntry<Payload, Result>(
+  entry: AgentAppFetchCatalogEntry<Payload, Result>,
+): Promise<AutoctxLoadedAgent<Payload, Result>> {
+  if (entry.handler) {
+    return {
+      name: entry.name,
+      relativePath: entry.relativePath,
+      handler: entry.handler,
+      triggers: entry.triggers,
+    };
+  }
+  if (!entry.load) {
+    throw new Error(`AutoContext agent '${entry.name}' must provide a handler or load function`);
+  }
+  const loaded = await entry.load();
+  return {
+    ...loaded,
+    name: loaded.name || entry.name,
+    relativePath: loaded.relativePath ?? entry.relativePath,
+    triggers: loaded.triggers ?? entry.triggers,
+  };
+}
+
+function createFetchAgentContext<Payload>(
+  options: FetchAgentContextOptions<Payload>,
+): AutoctxAgentContext<Payload> {
+  const agent: AutoctxAgentDescriptor = {
+    name: options.agent.name,
+    path: options.agent.path,
+    relativePath: options.agent.relativePath,
+  };
+  return {
+    id: options.id,
+    payload: options.payload,
+    env: Object.freeze({ ...options.env }),
+    workspace: options.workspace,
+    agent,
+    init: async (initOptions: AutoctxAgentInitOptions = {}) =>
+      new FetchRuntimeBackedAutoctxAgent({
+        agent,
+        workspace: options.workspace,
+        runtime: initOptions.runtime ?? options.runtime,
+        cwd: initOptions.cwd,
+        commands: [...(options.commands ?? []), ...(initOptions.commands ?? [])],
+        tools: [...(options.tools ?? []), ...(initOptions.tools ?? [])],
+        eventStore: initOptions.eventStore ?? options.eventStore,
+        eventSink: initOptions.eventSink ?? options.eventSink,
+        metadata: initOptions.metadata,
+        goal: initOptions.goal,
+      }),
+  };
+}
+
+class FetchRuntimeBackedAutoctxAgent implements AutoctxAgentRuntime {
+  readonly #agent: AutoctxAgentDescriptor;
+  readonly #workspace: RuntimeWorkspaceEnv;
+  readonly #runtime?: AgentRuntime;
+  readonly #goal?: string;
+  readonly #cwd?: string;
+  readonly #commands: RuntimeCommandGrant[];
+  readonly #tools: RuntimeToolGrant[];
+  readonly #eventStore?: RuntimeSessionEventStore;
+  readonly #eventSink?: RuntimeSessionEventSink;
+  readonly #metadata?: Record<string, unknown>;
+  readonly #sessions = new Map<string, AutoctxAgentSession>();
+
+  constructor(options: {
+    agent: AutoctxAgentDescriptor;
+    workspace: RuntimeWorkspaceEnv;
+    runtime?: AgentRuntime;
+    goal?: string;
+    cwd?: string;
+    commands?: RuntimeCommandGrant[];
+    tools?: RuntimeToolGrant[];
+    eventStore?: RuntimeSessionEventStore;
+    eventSink?: RuntimeSessionEventSink;
+    metadata?: Record<string, unknown>;
+  }) {
+    this.#agent = options.agent;
+    this.#workspace = options.workspace;
+    this.#runtime = options.runtime;
+    this.#goal = options.goal;
+    this.#cwd = options.cwd;
+    this.#commands = options.commands ?? [];
+    this.#tools = options.tools ?? [];
+    this.#eventStore = options.eventStore;
+    this.#eventSink = options.eventSink;
+    this.#metadata = options.metadata;
+  }
+
+  async session(
+    sessionKey = "default",
+    options: AutoctxAgentSessionOptions = {},
+  ): Promise<AutoctxAgentSession> {
+    const cacheKey = options.sessionId ?? sessionKey;
+    const existing = this.#sessions.get(cacheKey);
+    if (existing) return existing;
+    const { RuntimeSession } = await import("../../session/runtime-session.js");
+    const session = RuntimeSession.create({
+      sessionId: options.sessionId ?? autoctxAgentSessionId(this.#agent.name, sessionKey),
+      goal: options.goal ?? this.#goal ?? `AutoContext agent ${this.#agent.name}`,
+      workspace: this.#workspace,
+      eventStore: options.eventStore ?? this.#eventStore,
+      eventSink: options.eventSink ?? this.#eventSink,
+      metadata: {
+        ...(this.#metadata ?? {}),
+        ...(options.metadata ?? {}),
+        agentName: this.#agent.name,
+        agentPath: this.#agent.path,
+        agentSessionKey: sessionKey,
+        experimentalAgentRuntime: true,
+      },
+    });
+    const handle = new FetchRuntimeBackedAutoctxAgentSession({
+      session,
+      runtime: this.#runtime,
+      cwd: options.cwd ?? this.#cwd,
+      commands: [...this.#commands, ...(options.commands ?? [])],
+      tools: [...this.#tools, ...(options.tools ?? [])],
+    });
+    this.#sessions.set(cacheKey, handle);
+    return handle;
+  }
+
+  close(): void {
+    this.#runtime?.close?.();
+  }
+}
+
+class FetchRuntimeBackedAutoctxAgentSession implements AutoctxAgentSession {
+  readonly session: RuntimeSession;
+  readonly #runtime?: AgentRuntime;
+  readonly #cwd?: string;
+  readonly #commands: RuntimeCommandGrant[];
+  readonly #tools: RuntimeToolGrant[];
+
+  constructor(options: {
+    session: RuntimeSession;
+    runtime?: AgentRuntime;
+    cwd?: string;
+    commands?: RuntimeCommandGrant[];
+    tools?: RuntimeToolGrant[];
+  }) {
+    this.session = options.session;
+    this.#runtime = options.runtime;
+    this.#cwd = options.cwd;
+    this.#commands = options.commands ?? [];
+    this.#tools = options.tools ?? [];
+  }
+
+  async prompt(
+    prompt: string,
+    options: AutoctxAgentPromptOptions = {},
+  ): Promise<RuntimeSessionPromptResult> {
+    const runtime = options.runtime ?? this.#runtime;
+    if (!runtime) {
+      throw new Error("AutoContext agent session prompt requires an AgentRuntime");
+    }
+    return this.session.submitPrompt({
+      prompt,
+      role: options.role,
+      cwd: options.cwd ?? this.#cwd,
+      commands: [...this.#commands, ...(options.commands ?? [])],
+      tools: [...this.#tools, ...(options.tools ?? [])],
+      handler: async () => {
+        const output = await runtime.generate({
+          prompt,
+          system: options.system,
+          schema: options.schema,
+        });
+        return {
+          text: output.text,
+          metadata: agentPromptMetadata(runtime, output, this.session.sessionId),
+        };
+      },
+    });
+  }
+}
+
+class EdgeInMemoryWorkspaceEnv implements RuntimeWorkspaceEnv {
+  readonly #state: EdgeMemoryState;
+  readonly cwd: string;
+  readonly tools?: readonly RuntimeToolGrant[];
+
+  constructor(state: EdgeMemoryState, cwd: string, tools?: readonly RuntimeToolGrant[]) {
+    this.#state = state;
+    this.cwd = cwd;
+    this.tools = tools;
+  }
+
+  exec(_command: string, _options: RuntimeExecOptions = {}): Promise<RuntimeExecResult> {
+    return Promise.reject(
+      new Error(
+        "Runtime command execution is unavailable in the generic Fetch agent app workspace",
+      ),
+    );
+  }
+
+  scope(options: RuntimeScopeOptions = {}): Promise<RuntimeWorkspaceEnv> {
+    return Promise.resolve(
+      new EdgeInMemoryWorkspaceEnv(
+        this.#state,
+        normalizeVirtualPath(options.cwd ?? this.cwd, this.cwd),
+        options.tools ?? this.tools,
+      ),
+    );
+  }
+
+  async readFile(filePath: string): Promise<string> {
+    return new TextDecoder().decode(await this.readFileBytes(filePath));
+  }
+
+  readFileBytes(filePath: string): Promise<Uint8Array> {
+    const file = this.#state.files.get(this.resolvePath(filePath));
+    if (!file) return Promise.reject(new Error(`File not found: ${filePath}`));
+    return Promise.resolve(file.content.slice());
+  }
+
+  writeFile(filePath: string, content: string | Uint8Array): Promise<void> {
+    const resolved = this.resolvePath(filePath);
+    ensureDir(this.#state, parentDir(resolved));
+    this.#state.files.set(resolved, {
+      content: typeof content === "string" ? new TextEncoder().encode(content) : content.slice(),
+      mtime: new Date(),
+    });
+    return Promise.resolve();
+  }
+
+  stat(filePath: string): Promise<RuntimeFileStat> {
+    const resolved = this.resolvePath(filePath);
+    const file = this.#state.files.get(resolved);
+    if (file) {
+      return Promise.resolve({
+        isFile: true,
+        isDirectory: false,
+        isSymbolicLink: false,
+        size: file.content.byteLength,
+        mtime: file.mtime,
+      });
+    }
+    const dirMtime = this.#state.dirs.get(resolved);
+    if (dirMtime) {
+      return Promise.resolve({
+        isFile: false,
+        isDirectory: true,
+        isSymbolicLink: false,
+        size: 0,
+        mtime: dirMtime,
+      });
+    }
+    return Promise.reject(new Error(`Path not found: ${filePath}`));
+  }
+
+  readdir(dirPath: string): Promise<string[]> {
+    const dir = this.resolvePath(dirPath);
+    if (!this.#state.dirs.has(dir)) {
+      return Promise.reject(new Error(`Directory not found: ${dirPath}`));
+    }
+    const names = new Set<string>();
+    for (const path of this.#state.files.keys()) {
+      if (parentDir(path) === dir) names.add(baseName(path));
+    }
+    for (const path of this.#state.dirs.keys()) {
+      if (path !== dir && parentDir(path) === dir) names.add(baseName(path));
+    }
+    return Promise.resolve([...names].sort((left, right) => left.localeCompare(right)));
+  }
+
+  exists(filePath: string): Promise<boolean> {
+    const resolved = this.resolvePath(filePath);
+    return Promise.resolve(this.#state.files.has(resolved) || this.#state.dirs.has(resolved));
+  }
+
+  mkdir(dirPath: string, _options: { recursive?: boolean } = {}): Promise<void> {
+    ensureDir(this.#state, this.resolvePath(dirPath));
+    return Promise.resolve();
+  }
+
+  rm(filePath: string, options: { recursive?: boolean; force?: boolean } = {}): Promise<void> {
+    const resolved = this.resolvePath(filePath);
+    if (this.#state.files.delete(resolved)) return Promise.resolve();
+    if (this.#state.dirs.has(resolved)) {
+      const hasChildren = [...this.#state.files.keys(), ...this.#state.dirs.keys()].some(
+        (path) => path !== resolved && path.startsWith(`${resolved}/`),
+      );
+      if (hasChildren && !options.recursive) {
+        return Promise.reject(new Error(`Directory not empty: ${filePath}`));
+      }
+      for (const path of [...this.#state.files.keys()]) {
+        if (path.startsWith(`${resolved}/`)) this.#state.files.delete(path);
+      }
+      for (const path of [...this.#state.dirs.keys()]) {
+        if (path !== "/" && (path === resolved || path.startsWith(`${resolved}/`))) {
+          this.#state.dirs.delete(path);
+        }
+      }
+      return Promise.resolve();
+    }
+    return options.force
+      ? Promise.resolve()
+      : Promise.reject(new Error(`Path not found: ${filePath}`));
+  }
+
+  resolvePath(filePath: string): string {
+    return normalizeVirtualPath(filePath, this.cwd);
+  }
+
+  async cleanup(): Promise<void> {
+    // Caller owns the request lifecycle; the in-memory workspace has no ambient resources.
+  }
+}
+
+class AgentAppFetchRequestError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+
+  constructor(statusCode: number, code: string, message: string) {
+    super(message);
+    this.statusCode = statusCode;
+    this.code = code;
+  }
+}
+
+async function readJsonRequestBody(
+  request: Request,
+  maxBodyBytes: number,
+): Promise<Record<string, unknown>> {
+  const text = await request.text();
+  if (!text.trim()) return {};
+  if (new TextEncoder().encode(text).byteLength > maxBodyBytes) {
+    throw new AgentAppFetchRequestError(
+      413,
+      "AUTOCTX_AGENT_APP_REQUEST_TOO_LARGE",
+      "Request body is too large",
+    );
+  }
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (!isRecord(parsed)) {
+      throw new Error("body must be a JSON object");
+    }
+    return parsed;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new AgentAppFetchRequestError(
+      400,
+      "AUTOCTX_AGENT_APP_BAD_REQUEST",
+      `Request body must be valid JSON: ${message}`,
+    );
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(`${JSON.stringify(body, null, 2)}\n`, {
+    status,
+    headers: JSON_HEADERS,
+  });
+}
+
+function definedStringRecord(values: Record<string, string | undefined>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined) result[key] = value;
+  }
+  return result;
+}
+
+function cloneRecord(
+  value: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return value ? { ...value } : undefined;
+}
+
+function createEdgeMemoryState(): EdgeMemoryState {
+  return { files: new Map(), dirs: new Map([["/", new Date()]]) };
+}
+
+function ensureDir(state: EdgeMemoryState, dirPath: string): void {
+  let current = "/";
+  state.dirs.set(current, state.dirs.get(current) ?? new Date());
+  for (const segment of dirPath.split("/")) {
+    if (!segment) continue;
+    current = current === "/" ? `/${segment}` : `${current}/${segment}`;
+    state.dirs.set(current, state.dirs.get(current) ?? new Date());
+  }
+}
+
+function normalizeVirtualPath(filePath: string, cwd: string): string {
+  const base = filePath.startsWith("/") ? filePath : `${cwd.replace(/\/$/, "")}/${filePath}`;
+  const parts: string[] = [];
+  for (const segment of base.split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      parts.pop();
+      continue;
+    }
+    parts.push(segment);
+  }
+  return `/${parts.join("/")}`;
+}
+
+function parentDir(filePath: string): string {
+  if (filePath === "/") return "/";
+  const index = filePath.lastIndexOf("/");
+  return index <= 0 ? "/" : filePath.slice(0, index);
+}
+
+function baseName(filePath: string): string {
+  const index = filePath.lastIndexOf("/");
+  return index === -1 ? filePath : filePath.slice(index + 1);
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function autoctxAgentSessionId(agentName: string, sessionKey: string): string {
+  return `agent:${safeSessionSegment(agentName)}:${safeSessionSegment(sessionKey)}`;
+}
+
+function safeSessionSegment(value: string): string {
+  const normalized = value
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || "default";
+}
+
+function agentPromptMetadata(
+  runtime: AgentRuntime,
+  output: AgentOutput,
+  runtimeSessionId: string,
+): Record<string, unknown> {
+  return {
+    ...agentOutputMetadata(runtime.name, output, { runtimeSessionId }),
+    experimentalAgentRuntime: true,
+  };
+}

--- a/ts/tests/agent-app-fetch-adapter.test.ts
+++ b/ts/tests/agent-app-fetch-adapter.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import type { AutoctxAgentContext, AutoctxAgentHandler } from "../src/agent-runtime/index.js";
 import {
   createAgentAppFetchHandler,
+  createEdgeInMemoryWorkspaceEnv,
   createStaticAgentAppCatalog,
 } from "../src/control-plane/agent-app-fetch/index.js";
 import {
@@ -140,6 +141,79 @@ describe("generic agent app Fetch adapter", () => {
         existedBefore: false,
       },
     });
+  });
+
+  it("keeps the edge in-memory workspace file and directory state coherent", async () => {
+    const workspace = createEdgeInMemoryWorkspaceEnv();
+
+    await workspace.writeFile("/a", "file");
+
+    await expect(workspace.writeFile("/a/b.txt", "child")).rejects.toThrow(
+      "Not a directory: /a",
+    );
+    await expect(workspace.readdir("/a")).rejects.toThrow("Directory not found: /a");
+    await expect(workspace.mkdir("/a")).rejects.toThrow("File exists: /a");
+    await expect(workspace.mkdir("/a/child", { recursive: true })).rejects.toThrow(
+      "Not a directory: /a",
+    );
+    await expect(workspace.mkdir("/missing/child")).rejects.toThrow(
+      "Parent directory not found: /missing",
+    );
+    await expect(workspace.exists("/missing")).resolves.toBe(false);
+
+    await workspace.mkdir("/missing/child", { recursive: true });
+
+    await expect(workspace.stat("/missing/child")).resolves.toMatchObject({
+      isDirectory: true,
+      isFile: false,
+    });
+  });
+
+  it("rejects streaming request bodies as soon as the byte limit is exceeded", async () => {
+    let pullCount = 0;
+    let canceled = false;
+    const chunk = new Uint8Array(1024 * 1024);
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        controller.enqueue(chunk);
+        if (pullCount >= 5) controller.close();
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    const handler = createAgentAppFetchHandler({
+      maxBodyBytes: 1,
+      catalog: createStaticAgentAppCatalog([
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          handler: async () => ({ ok: true }),
+        },
+      ]),
+    });
+
+    const response = await handler(
+      new Request("https://agent-app.test/agents/support/invoke", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: stream,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" }),
+    );
+
+    expect(response.status).toBe(413);
+    expect(await jsonBody(response)).toEqual({
+      ok: false,
+      error: {
+        code: "AUTOCTX_AGENT_APP_REQUEST_TOO_LARGE",
+        message: "Request body is too large",
+      },
+    });
+    expect(canceled).toBe(true);
+    expect(pullCount).toBeLessThan(5);
   });
 
   it("supports runtime-backed handlers through explicit runtime and event-store capabilities", async () => {

--- a/ts/tests/agent-app-fetch-adapter.test.ts
+++ b/ts/tests/agent-app-fetch-adapter.test.ts
@@ -1,0 +1,257 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { AutoctxAgentContext, AutoctxAgentHandler } from "../src/agent-runtime/index.js";
+import {
+  createAgentAppFetchHandler,
+  createStaticAgentAppCatalog,
+} from "../src/control-plane/agent-app-fetch/index.js";
+import {
+  RuntimeSessionEventLog,
+  type RuntimeSessionEventStore,
+} from "../src/session/runtime-events.js";
+
+async function jsonBody(response: Response): Promise<unknown> {
+  return await response.json();
+}
+
+function request(path: string, init?: RequestInit): Request {
+  return new Request(`https://agent-app.test${path}`, init);
+}
+
+describe("generic agent app Fetch adapter", () => {
+  it("keeps the adapter source free of Node server, filesystem, and provider deployment imports", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "src", "control-plane", "agent-app-fetch", "index.ts"),
+      "utf-8",
+    );
+
+    expect(source).not.toContain('"node:');
+    expect(source).not.toContain("'node:");
+    expect(source).not.toContain("process.env");
+    expect(source).not.toMatch(/wrangler|durable object namespace|cloudflare build/i);
+  });
+
+  it("serves the manifest from a static catalog without loading handler modules", async () => {
+    let loadCalls = 0;
+    const handler = createAgentAppFetchHandler({
+      catalog: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          triggers: { webhook: true },
+          load: async () => {
+            loadCalls += 1;
+            return {
+              name: "support",
+              relativePath: ".autoctx/agents/support.mjs",
+              handler: async () => ({ ok: true }),
+            };
+          },
+        },
+      ],
+    });
+
+    const response = await handler(request("/manifest"));
+
+    expect(response.status).toBe(200);
+    expect(await jsonBody(response)).toEqual({
+      ok: true,
+      target: "fetch",
+      agents: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          triggers: { webhook: true },
+        },
+      ],
+    });
+    expect(loadCalls).toBe(0);
+  });
+
+  it("invokes static handlers with explicit env and an in-memory workspace", async () => {
+    const supportHandler: AutoctxAgentHandler<{ message: string }> = async (ctx) => {
+      const existedBefore = await ctx.workspace.exists("scratch/result.txt");
+      await ctx.workspace.writeFile("scratch/result.txt", ctx.payload.message);
+      return {
+        id: ctx.id,
+        message: await ctx.workspace.readFile("scratch/result.txt"),
+        cwd: ctx.workspace.cwd,
+        existedBefore,
+        token: ctx.env.SUPPORT_TOKEN,
+        leaked: ctx.env.SECRET_TOKEN,
+      };
+    };
+    const handler = createAgentAppFetchHandler({
+      env: {
+        SUPPORT_TOKEN: "explicit-token",
+        SECRET_TOKEN: undefined,
+      },
+      catalog: createStaticAgentAppCatalog([
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          triggers: { webhook: true },
+          handler: supportHandler,
+        },
+      ]),
+    });
+
+    const response = await handler(
+      request("/agents/support/invoke", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "ticket-123", payload: { message: "please triage" } }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await jsonBody(response)).toEqual({
+      ok: true,
+      agent: "support",
+      id: "ticket-123",
+      result: {
+        id: "ticket-123",
+        message: "please triage",
+        cwd: "/",
+        existedBefore: false,
+        token: "explicit-token",
+      },
+    });
+
+    const secondResponse = await handler(
+      request("/agents/support/invoke", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "ticket-456", payload: { message: "second request" } }),
+      }),
+    );
+
+    expect(await jsonBody(secondResponse)).toMatchObject({
+      ok: true,
+      id: "ticket-456",
+      result: {
+        message: "second request",
+        existedBefore: false,
+      },
+    });
+  });
+
+  it("supports runtime-backed handlers through explicit runtime and event-store capabilities", async () => {
+    const savedLogs = new Map<string, RuntimeSessionEventLog>();
+    const store = {
+      save: (log: RuntimeSessionEventLog) => {
+        savedLogs.set(log.sessionId, RuntimeSessionEventLog.fromJSON(log.toJSON()));
+      },
+      load: (sessionId: string) => savedLogs.get(sessionId) ?? null,
+      list: () => [...savedLogs.values()],
+      listChildren: () => [],
+      close: () => {},
+    } as unknown as RuntimeSessionEventStore;
+    const handler = createAgentAppFetchHandler({
+      eventStore: store,
+      runtime: {
+        name: "edge-test-runtime",
+        generate: async ({ prompt }) => ({ text: `edge:${prompt}` }),
+        revise: async () => ({ text: "unused" }),
+      },
+      catalog: createStaticAgentAppCatalog([
+        {
+          name: "prompted",
+          relativePath: ".autoctx/agents/prompted.mjs",
+          extension: ".mjs",
+          handler: async (ctx: AutoctxAgentContext<{ prompt: string }>) => {
+            const runtime = await ctx.init();
+            const session = await runtime.session("default");
+            const reply = await session.prompt(ctx.payload.prompt);
+            return { text: reply.text, sessionId: reply.sessionId };
+          },
+        },
+      ]),
+    });
+
+    const response = await handler(
+      request("/agents/prompted/invoke", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "run-1", payload: { prompt: "hello" } }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await jsonBody(response)).toMatchObject({
+      ok: true,
+      agent: "prompted",
+      id: "run-1",
+      result: { text: "edge:hello", sessionId: "agent:prompted:default" },
+    });
+    const log = savedLogs.get("agent:prompted:default");
+    expect(log?.metadata).toMatchObject({
+      agentName: "prompted",
+      experimentalAgentRuntime: true,
+    });
+    expect(log?.events.map((event) => event.eventType)).toEqual([
+      "prompt_submitted",
+      "assistant_message",
+    ]);
+  });
+
+  it("returns stable JSON error envelopes for missing agents, invalid JSON, and handler errors", async () => {
+    const handler = createAgentAppFetchHandler({
+      catalog: createStaticAgentAppCatalog([
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          handler: async () => {
+            throw new Error("handler exploded");
+          },
+        },
+      ]),
+    });
+
+    const missing = await handler(request("/agents/missing/invoke", { method: "POST" }));
+    expect(missing.status).toBe(404);
+    expect(await jsonBody(missing)).toEqual({
+      ok: false,
+      error: {
+        code: "AUTOCTX_AGENT_NOT_FOUND",
+        message: "AutoContext agent not found: missing. Available: support",
+      },
+    });
+
+    const invalidJson = await handler(
+      request("/agents/support/invoke", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{not-json",
+      }),
+    );
+    expect(invalidJson.status).toBe(400);
+    expect(await jsonBody(invalidJson)).toMatchObject({
+      ok: false,
+      error: { code: "AUTOCTX_AGENT_APP_BAD_REQUEST" },
+    });
+
+    const exploded = await handler(
+      request("/agents/support/invoke", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ payload: {} }),
+      }),
+    );
+    expect(exploded.status).toBe(500);
+    expect(await jsonBody(exploded)).toEqual({
+      ok: false,
+      error: {
+        code: "AUTOCTX_AGENT_APP_ERROR",
+        message: "handler exploded",
+      },
+    });
+  });
+});

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -138,4 +138,15 @@ describe("package root exports", () => {
       types: "./dist/control-plane/agent-app-node/index.d.ts",
     });
   });
+
+  it("publishes the generic agent app Fetch adapter subpath", () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(import.meta.dirname, "..", "package.json"), "utf-8"),
+    ) as { exports?: Record<string, { import?: string; types?: string }> };
+
+    expect(packageJson.exports?.["./control-plane/agent-app-fetch"]).toEqual({
+      import: "./dist/control-plane/agent-app-fetch/index.js",
+      types: "./dist/control-plane/agent-app-fetch/index.d.ts",
+    });
+  });
 });

--- a/ts/tests/tsconfig.json
+++ b/ts/tests/tsconfig.json
@@ -6,8 +6,10 @@
     "allowImportingTsExtensions": true
   },
   "include": [
+    "agent-app-fetch-adapter.test.ts",
     "background-session-*.test.ts",
     "sandbox-adapter-contracts.test.ts",
+    "../src/control-plane/agent-app-fetch/index.ts",
     "../src/execution/sandbox-adapter-contracts.ts",
     "../src/session/background-session-*.ts",
     "../src/server/background-session-api.ts",


### PR DESCRIPTION
## Summary
- add `autoctx/control-plane/agent-app-fetch` with a generic `Request` -> `Response` adapter for generated agent apps
- reuse the existing manifest/invoke wire shape with explicit env, static catalogs/loaders, and default in-memory workspace behavior
- document the OSS/proprietary boundary and export the new subpath from the TypeScript package

## Boundary notes
- no provider-specific build target, deployment manifest, hosted orchestration, or secret brokering added
- adapter source is guarded against Node server/filesystem/provider deployment imports
- runtime/workspace capabilities are caller-supplied; shell execution fails closed in the default Fetch workspace

## Verification
- `npx vitest run tests/agent-app-fetch-adapter.test.ts tests/package-topology.test.ts tests/agent-command-workflow.test.ts tests/package-export-catalogs.test.ts -t "generic agent app Fetch|package topology|agent command workflow|Fetch adapter" --reporter=verbose`
- `npm run lint -- --pretty false`
- `npx tsc -p tests/tsconfig.json --noEmit --pretty false`
- `npm run build`
- `node --input-type=module -e "const m = await import('autoctx/control-plane/agent-app-fetch'); console.log(typeof m.createAgentAppFetchHandler, typeof m.createStaticAgentAppCatalog);"`
- `git diff --check origin/main...HEAD && git diff --check`

## Diagnostics
- LSP diagnostics were clean for touched TS files.
- `lens_diagnostics mode=full` still reports pre-existing project-wide Python/Pi errors outside this slice; no touched Fetch adapter files were implicated.
