### PR TITLE
AC-790 add Fetch handler catalog planner

### DIFF
--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -133,9 +133,12 @@ contracts:
 The edge-runtime question should stay generic until the Node target proves the
 handler/server boundary. The TypeScript control-plane Fetch adapter lives at
 `autoctx/control-plane/agent-app-fetch` and reuses the Node manifest/invoke
-wire shape without becoming a provider-specific deployment target. Cloudflare Workers/Durable Objects may be reference environments, but the spike must report
-generic portability constraints before any provider-specific build path is
-added. The detailed spike lives in
+wire shape without becoming a provider-specific deployment target. Its
+build-time catalog planner turns explicit `.autoctx/agents` entries into static
+module maps so edge-compatible bundles do not scan a filesystem at request time.
+Cloudflare Workers/Durable Objects may be reference environments. The spike
+must report generic portability constraints before adding any provider-specific build path.
+The detailed spike lives in
 [`edge-runtime-compatibility.md`](./edge-runtime-compatibility.md).
 
 The spike should answer:

--- a/docs/edge-runtime-compatibility.md
+++ b/docs/edge-runtime-compatibility.md
@@ -24,16 +24,17 @@ generic adapter seams are proven.
 The first OSS adapter seam is the TypeScript control-plane Fetch helper at
 `autoctx/control-plane/agent-app-fetch`. It handles `Request` -> `Response` for
 the existing `GET /manifest` and `POST /agents/:agent/invoke` shape using a
-static handler catalog or module map. This helper is not a deployment target and
-does not add provider-specific build output.
+static handler catalog or module map. It also includes a build-time catalog
+planner that turns explicit `.autoctx/agents` entries into bundler-visible
+module maps, so generated bundles do not need runtime filesystem discovery.
+This helper is not a deployment target and does not add provider-specific build
+output.
 
 Recommended follow-up after the generic adapter seam:
 
-1. Add a build-time handler manifest/module-map planner so generated edge
-   bundles do not need runtime filesystem discovery.
-2. Add or document edge-safe workspace and session event-store adapters behind
+1. Add or document edge-safe workspace and session event-store adapters behind
    the existing runtime/session contracts.
-3. Keep provider-specific deployment templates and hosted orchestration in a
+2. Keep provider-specific deployment templates and hosted orchestration in a
    separate product/repository unless they are deliberately opened later.
 
 ## Reusable Invocation Shape
@@ -116,9 +117,11 @@ interface EdgeAgentCatalogEntry {
 ```
 
 The catalog can be generated from `.autoctx/agents` by the control-plane build
-workflow, but the runtime adapter receives a static list or module map. This
-keeps source-project scanning out of the edge request path and lets bundlers see
-which handler modules must be included.
+workflow, but the runtime adapter receives a static list or module map. The
+provider-neutral `planAgentAppFetchCatalog()` and
+`createAgentAppFetchCatalogFromModuleMap()` helpers keep source-project
+scanning out of the edge request path and let bundlers see which handler modules
+must be included.
 
 ### Explicit Environment And Runtime Capabilities
 
@@ -185,7 +188,7 @@ they should not create provider-specific OSS deployment workflows by default.
 
 - Maintain the generic Fetch request adapter that reuses the Node
   manifest/invoke envelope without advertising a provider deployment target.
-- Add a build-time handler manifest/module-map planner.
+- Maintain the build-time handler manifest/module-map planner.
 - Add tests proving pure local handlers can run through generated catalogs with
   in-memory workspace/env and without Node-only server globals.
 - Document unsupported shell/filesystem capability behavior.

--- a/ts/README.md
+++ b/ts/README.md
@@ -153,6 +153,36 @@ const fetchAgentApp = createAgentAppFetchHandler({
 export default { fetch: fetchAgentApp };
 ```
 
+Build tooling can also precompute a bundler-visible module map and turn it into
+the same Fetch catalog. The planner accepts explicit `.autoctx/agents` entries
+from a build step; it does not discover files from the request path:
+
+```ts
+import {
+  createAgentAppFetchCatalogFromModuleMap,
+  createAgentAppFetchHandler,
+  planAgentAppFetchCatalog,
+} from "autoctx/control-plane/agent-app-fetch";
+
+const plan = planAgentAppFetchCatalog({
+  entries: [
+    {
+      name: "support",
+      relativePath: ".autoctx/agents/support.ts",
+      extension: ".ts",
+      triggers: { webhook: true },
+    },
+  ],
+  moduleSpecifier: (entry) => `./${entry.relativePath}`,
+});
+
+const catalog = createAgentAppFetchCatalogFromModuleMap(plan, {
+  support: () => import("./.autoctx/agents/support.ts"),
+});
+
+export default { fetch: createAgentAppFetchHandler({ catalog }) };
+```
+
 See [`docs/edge-runtime-compatibility.md`](../docs/edge-runtime-compatibility.md)
 and [`docs/core-control-package-split.md#agent-app-build-targets`](../docs/core-control-package-split.md#agent-app-build-targets)
 for the OSS/proprietary boundary: provider deployment manifests, hosted secrets,

--- a/ts/src/control-plane/agent-app-fetch/catalog-planner.ts
+++ b/ts/src/control-plane/agent-app-fetch/catalog-planner.ts
@@ -1,0 +1,234 @@
+import type { AutoctxAgentHandler, AutoctxLoadedAgent, MaybePromise } from "../../agent-runtime/index.js";
+import type {
+  AgentAppFetchAgentExtension,
+  AgentAppFetchCatalogEntry,
+  AgentAppFetchTarget,
+} from "./index.js";
+
+export interface AgentAppFetchCatalogSourceEntry {
+  name: string;
+  relativePath: string;
+  extension: AgentAppFetchAgentExtension | string;
+  triggers?: Record<string, unknown>;
+  importSpecifier?: string;
+}
+
+export interface AgentAppFetchCatalogPlanEntry extends AgentAppFetchCatalogSourceEntry {
+  importSpecifier: string;
+}
+
+export interface AgentAppFetchCatalogPlanOptions {
+  entries: readonly AgentAppFetchCatalogSourceEntry[];
+  handlerDir?: string;
+  moduleSpecifier?: (entry: AgentAppFetchCatalogSourceEntry) => string;
+}
+
+export interface AgentAppFetchCatalogPlan {
+  target: AgentAppFetchTarget;
+  handlerDir: string;
+  routes: AgentAppFetchRoute[];
+  entries: AgentAppFetchCatalogPlanEntry[];
+}
+
+export type AgentAppFetchRoute = "GET /manifest" | "POST /agents/:agent/invoke";
+export type AgentAppFetchModuleLoader = () => MaybePromise<unknown>;
+export type AgentAppFetchModuleMap = Record<string, AgentAppFetchModuleLoader>;
+
+export interface RenderAgentAppFetchModuleMapEntrypointOptions {
+  packageSpecifier?: string;
+}
+
+const DEFAULT_AGENT_APP_FETCH_HANDLER_DIR = ".autoctx/agents";
+const AGENT_APP_FETCH_ROUTES: AgentAppFetchRoute[] = [
+  "GET /manifest",
+  "POST /agents/:agent/invoke",
+];
+
+export function planAgentAppFetchCatalog(
+  options: AgentAppFetchCatalogPlanOptions,
+): AgentAppFetchCatalogPlan {
+  const handlerDir = normalizeCatalogPath(
+    options.handlerDir ?? DEFAULT_AGENT_APP_FETCH_HANDLER_DIR,
+    "handler directory",
+  );
+  const seenNames = new Set<string>();
+  const entries = options.entries.map((entry) => {
+    const name = normalizeAgentName(entry.name);
+    if (seenNames.has(name)) {
+      throw new Error(`Duplicate AutoContext agent name: ${name}`);
+    }
+    seenNames.add(name);
+    const relativePath = normalizeCatalogPath(entry.relativePath, "agent relative path");
+    if (!relativePath.startsWith(`${handlerDir}/`)) {
+      throw new Error(`Agent app Fetch catalog entries must be under ${handlerDir}`);
+    }
+    if (relativePath.endsWith(".d.ts")) {
+      throw new Error("Declaration files cannot be agent app handlers");
+    }
+    const extension = normalizeExtension(entry.extension);
+    const normalizedEntry: AgentAppFetchCatalogSourceEntry = {
+      name,
+      relativePath,
+      extension,
+    };
+    if (entry.importSpecifier !== undefined) {
+      normalizedEntry.importSpecifier = entry.importSpecifier;
+    }
+    const triggers = cloneRecord(entry.triggers);
+    if (triggers) normalizedEntry.triggers = triggers;
+    return {
+      ...normalizedEntry,
+      importSpecifier:
+        options.moduleSpecifier?.(normalizedEntry) ?? entry.importSpecifier ?? `./${relativePath}`,
+    };
+  });
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+  return {
+    target: "fetch",
+    handlerDir,
+    routes: [...AGENT_APP_FETCH_ROUTES],
+    entries,
+  };
+}
+
+export function createAgentAppFetchCatalogFromModuleMap<Payload = unknown, Result = unknown>(
+  planOrEntries: AgentAppFetchCatalogPlan | readonly AgentAppFetchCatalogPlanEntry[],
+  moduleMap: AgentAppFetchModuleMap,
+): AgentAppFetchCatalogEntry<Payload, Result>[] {
+  const entries: readonly AgentAppFetchCatalogPlanEntry[] = isAgentAppFetchCatalogPlan(
+    planOrEntries,
+  )
+    ? planOrEntries.entries
+    : planOrEntries;
+  return entries.map((entry) => ({
+    name: entry.name,
+    relativePath: entry.relativePath,
+    extension: entry.extension,
+    triggers: cloneRecord(entry.triggers),
+    load: async () => loadAgentAppFetchModuleEntry<Payload, Result>(entry, moduleMap),
+  }));
+}
+
+export function renderAgentAppFetchModuleMapEntrypoint(
+  plan: AgentAppFetchCatalogPlan,
+  options: RenderAgentAppFetchModuleMapEntrypointOptions = {},
+): string {
+  const packageSpecifier = options.packageSpecifier ?? "autoctx/control-plane/agent-app-fetch";
+  const moduleMapEntries = plan.entries.map(
+    (entry) =>
+      `  ${renderObjectKey(entry.name)}: () => import(${JSON.stringify(entry.importSpecifier)}),`,
+  );
+  return [
+    `import { createAgentAppFetchCatalogFromModuleMap, createAgentAppFetchHandler } from ${JSON.stringify(packageSpecifier)};`,
+    "",
+    `export const agentAppFetchCatalogPlan = ${JSON.stringify(plan, null, 2)};`,
+    "",
+    "export const agentAppFetchModuleMap = {",
+    ...moduleMapEntries,
+    "};",
+    "",
+    "export const agentAppFetchCatalog = createAgentAppFetchCatalogFromModuleMap(",
+    "  agentAppFetchCatalogPlan,",
+    "  agentAppFetchModuleMap,",
+    ");",
+    "",
+    "export const fetch = createAgentAppFetchHandler({ catalog: agentAppFetchCatalog });",
+    "",
+    "export default { fetch };",
+    "",
+  ].join("\n");
+}
+
+function normalizeCatalogPath(value: string, label: string): string {
+  const trimmed = value
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^\.\/+/u, "");
+  if (!trimmed) throw new Error(`AutoContext ${label} must be non-empty`);
+  if (trimmed.startsWith("/")) throw new Error(`AutoContext ${label} must be relative`);
+  const parts: string[] = [];
+  for (const segment of trimmed.split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      throw new Error(`AutoContext ${label} cannot contain parent directory segments`);
+    }
+    parts.push(segment);
+  }
+  if (parts.length === 0) throw new Error(`AutoContext ${label} must be non-empty`);
+  return parts.join("/");
+}
+
+function normalizeAgentName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed || !/^[A-Za-z0-9._-]+$/u.test(trimmed)) {
+    throw new Error("AutoContext agent names must be non-empty path-safe identifiers");
+  }
+  return trimmed;
+}
+
+function normalizeExtension(extension: string): string {
+  const trimmed = extension.trim();
+  if (!trimmed.startsWith(".") || trimmed.includes("/")) {
+    throw new Error(
+      "AutoContext agent extensions must start with '.' and contain no path segments",
+    );
+  }
+  return trimmed;
+}
+
+function isAgentAppFetchCatalogPlan(
+  value: AgentAppFetchCatalogPlan | readonly AgentAppFetchCatalogPlanEntry[],
+): value is AgentAppFetchCatalogPlan {
+  return !Array.isArray(value);
+}
+
+async function loadAgentAppFetchModuleEntry<Payload, Result>(
+  entry: AgentAppFetchCatalogPlanEntry,
+  moduleMap: AgentAppFetchModuleMap,
+): Promise<AutoctxLoadedAgent<Payload, Result>> {
+  const loadModule = moduleMap[entry.name];
+  if (!loadModule) {
+    throw new Error(`Missing module loader for AutoContext agent: ${entry.name}`);
+  }
+  const imported = unwrapAgentAppFetchModule(await loadModule());
+  if (!isAutoctxAgentHandler<Payload, Result>(imported.default)) {
+    throw new Error(
+      `AutoContext agent '${entry.name}' module must export a default handler function`,
+    );
+  }
+  return {
+    name: entry.name,
+    relativePath: entry.relativePath,
+    handler: imported.default,
+    triggers: readOptionalRecord(imported.triggers) ?? entry.triggers,
+  };
+}
+
+function unwrapAgentAppFetchModule(value: unknown): Record<string, unknown> {
+  const moduleRecord = isRecord(value) ? value : { default: value };
+  const nestedDefault = readOptionalRecord(moduleRecord.default);
+  if (nestedDefault && isAutoctxAgentHandler(nestedDefault.default)) return nestedDefault;
+  return moduleRecord;
+}
+
+function cloneRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? { ...value } : undefined;
+}
+
+function readOptionalRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? { ...value } : undefined;
+}
+
+function isAutoctxAgentHandler<Payload, Result>(
+  value: unknown,
+): value is AutoctxAgentHandler<Payload, Result> {
+  return typeof value === "function";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function renderObjectKey(value: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/u.test(value) ? value : JSON.stringify(value);
+}

--- a/ts/src/control-plane/agent-app-fetch/index.ts
+++ b/ts/src/control-plane/agent-app-fetch/index.ts
@@ -84,6 +84,22 @@ export interface AgentAppFetchManifest {
   }>;
 }
 
+export {
+  createAgentAppFetchCatalogFromModuleMap,
+  planAgentAppFetchCatalog,
+  renderAgentAppFetchModuleMapEntrypoint,
+} from "./catalog-planner.js";
+export type {
+  AgentAppFetchCatalogPlan,
+  AgentAppFetchCatalogPlanEntry,
+  AgentAppFetchCatalogPlanOptions,
+  AgentAppFetchCatalogSourceEntry,
+  AgentAppFetchModuleLoader,
+  AgentAppFetchModuleMap,
+  AgentAppFetchRoute,
+  RenderAgentAppFetchModuleMapEntrypointOptions,
+} from "./catalog-planner.js";
+
 type EdgeMemoryState = {
   files: Map<string, EdgeMemoryFile>;
   dirs: Map<string, Date>;

--- a/ts/tests/agent-app-fetch-catalog-planner.test.ts
+++ b/ts/tests/agent-app-fetch-catalog-planner.test.ts
@@ -1,0 +1,196 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { AutoctxAgentHandler } from "../src/agent-runtime/index.js";
+import {
+  createAgentAppFetchCatalogFromModuleMap,
+  createAgentAppFetchHandler,
+  planAgentAppFetchCatalog,
+  renderAgentAppFetchModuleMapEntrypoint,
+} from "../src/control-plane/agent-app-fetch/index.js";
+
+async function jsonBody(response: Response): Promise<unknown> {
+  return await response.json();
+}
+
+function request(path: string, init?: RequestInit): Request {
+  return new Request(`https://agent-app.test${path}`, init);
+}
+
+describe("agent app Fetch catalog planner", () => {
+  it("plans a deterministic static catalog and bundler-visible module map from explicit handler entries", () => {
+    const plan = planAgentAppFetchCatalog({
+      entries: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          triggers: { webhook: true },
+        },
+        {
+          name: "audit",
+          relativePath: ".autoctx/agents/audit.ts",
+          extension: ".ts",
+        },
+      ],
+      moduleSpecifier: (entry) => `../${entry.relativePath}`,
+    });
+
+    expect(plan).toEqual({
+      target: "fetch",
+      handlerDir: ".autoctx/agents",
+      routes: ["GET /manifest", "POST /agents/:agent/invoke"],
+      entries: [
+        {
+          name: "audit",
+          relativePath: ".autoctx/agents/audit.ts",
+          extension: ".ts",
+          importSpecifier: "../.autoctx/agents/audit.ts",
+        },
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          importSpecifier: "../.autoctx/agents/support.mjs",
+          triggers: { webhook: true },
+        },
+      ],
+    });
+  });
+
+  it("turns a planned module map into a Fetch catalog without loading handlers for the manifest", async () => {
+    let loadCalls = 0;
+    const supportHandler: AutoctxAgentHandler<{ message: string }> = async (ctx) => ({
+      id: ctx.id,
+      message: ctx.payload.message,
+      token: ctx.env.SUPPORT_TOKEN,
+    });
+    const plan = planAgentAppFetchCatalog({
+      entries: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          triggers: { webhook: true },
+        },
+      ],
+    });
+    const catalog = createAgentAppFetchCatalogFromModuleMap(plan, {
+      support: async () => {
+        loadCalls += 1;
+        return { default: supportHandler };
+      },
+    });
+    const handler = createAgentAppFetchHandler({
+      env: { SUPPORT_TOKEN: "explicit-token" },
+      catalog,
+    });
+
+    const manifest = await handler(request("/manifest"));
+
+    expect(manifest.status).toBe(200);
+    expect(await jsonBody(manifest)).toEqual({
+      ok: true,
+      target: "fetch",
+      agents: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          triggers: { webhook: true },
+        },
+      ],
+    });
+    expect(loadCalls).toBe(0);
+
+    const invocation = await handler(
+      request("/agents/support/invoke", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "ticket-123", payload: { message: "please triage" } }),
+      }),
+    );
+
+    expect(invocation.status).toBe(200);
+    expect(await jsonBody(invocation)).toEqual({
+      ok: true,
+      agent: "support",
+      id: "ticket-123",
+      result: {
+        id: "ticket-123",
+        message: "please triage",
+        token: "explicit-token",
+      },
+    });
+    expect(loadCalls).toBe(1);
+  });
+
+  it("renders a provider-neutral ESM module-map entrypoint for generated Fetch hosts", () => {
+    const plan = planAgentAppFetchCatalog({
+      entries: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+        },
+      ],
+      moduleSpecifier: (entry) => `./${entry.relativePath}`,
+    });
+
+    const source = renderAgentAppFetchModuleMapEntrypoint(plan);
+
+    expect(source).toContain("autoctx/control-plane/agent-app-fetch");
+    expect(source).toContain("createAgentAppFetchCatalogFromModuleMap");
+    expect(source).toContain("createAgentAppFetchHandler");
+    expect(source).toContain('support: () => import("./.autoctx/agents/support.mjs")');
+    expect(source).not.toContain("node:");
+    expect(source).not.toContain("process.env");
+    expect(source).not.toMatch(/wrangler|cloudflare|vercel|deno deploy|durable object/i);
+  });
+
+  it("rejects duplicate, non-agent, and declaration-file entries before rendering module maps", () => {
+    expect(() =>
+      planAgentAppFetchCatalog({
+        entries: [
+          { name: "support", relativePath: ".autoctx/agents/support.mjs", extension: ".mjs" },
+          { name: "support", relativePath: ".autoctx/agents/support.ts", extension: ".ts" },
+        ],
+      }),
+    ).toThrow("Duplicate AutoContext agent name: support");
+
+    expect(() =>
+      planAgentAppFetchCatalog({
+        entries: [{ name: "skill", relativePath: ".autoctx/skills/skill.mjs", extension: ".mjs" }],
+      }),
+    ).toThrow("Agent app Fetch catalog entries must be under .autoctx/agents");
+
+    expect(() =>
+      planAgentAppFetchCatalog({
+        entries: [{ name: "types", relativePath: ".autoctx/agents/types.d.ts", extension: ".ts" }],
+      }),
+    ).toThrow("Declaration files cannot be agent app handlers");
+  });
+
+  it("keeps the catalog planner source free of runtime filesystem discovery and provider deployment imports", () => {
+    const source = readFileSync(
+      join(
+        import.meta.dirname,
+        "..",
+        "src",
+        "control-plane",
+        "agent-app-fetch",
+        "catalog-planner.ts",
+      ),
+      "utf-8",
+    );
+
+    expect(source).not.toContain('"node:');
+    expect(source).not.toContain("'node:");
+    expect(source).not.toContain("discoverAutoctxAgents");
+    expect(source).not.toContain("fs.readdir");
+    expect(source).not.toContain("process.env");
+    expect(source).not.toMatch(/wrangler|cloudflare build|durable object namespace/i);
+  });
+});

--- a/ts/tests/tsconfig.json
+++ b/ts/tests/tsconfig.json
@@ -7,6 +7,7 @@
   },
   "include": [
     "agent-app-fetch-adapter.test.ts",
+    "agent-app-fetch-catalog-planner.test.ts",
     "background-session-*.test.ts",
     "sandbox-adapter-contracts.test.ts",
     "../src/control-plane/agent-app-fetch/index.ts",


### PR DESCRIPTION
## Summary
- add a provider-neutral Fetch handler catalog planner that turns explicit `.autoctx/agents` entries into deterministic static catalog plans and bundler-visible module maps
- add module-map catalog loading and generated Fetch entrypoint rendering on `autoctx/control-plane/agent-app-fetch`
- document the build-time planner in the TypeScript README and edge-runtime boundary docs

## Tests
- `npx vitest run tests/agent-app-fetch-catalog-planner.test.ts tests/agent-app-fetch-adapter.test.ts tests/package-topology.test.ts --reporter=verbose`
- `npx vitest run tests/package-export-catalogs.test.ts -t "Fetch adapter" --reporter=verbose`
- `npm run lint -- --pretty false`
- `npx tsc -p tests/tsconfig.json --noEmit --pretty false`
- `npm run build`
- `git diff --check origin/main...HEAD && git diff --check`

## Boundary
- no provider-specific deployment target, Wrangler/Vercel/Deno config, hosted secret brokering, scheduling, or fleet orchestration added
- planner relies on explicit build-step inputs instead of runtime filesystem discovery in Fetch hosts

Linear: AC-790