### PR TITLE
AC-791 add Fetch session event-store contract

### DIFF
--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -136,6 +136,8 @@ handler/server boundary. The TypeScript control-plane Fetch adapter lives at
 wire shape without becoming a provider-specific deployment target. Its
 build-time catalog planner turns explicit `.autoctx/agents` entries into static
 module maps so edge-compatible bundles do not scan a filesystem at request time.
+Its session event-store contract gives Fetch hosts a provider-neutral append/replay
+seam for explicit runtime-session capabilities.
 Cloudflare Workers/Durable Objects may be reference environments. The spike
 must report generic portability constraints before adding any provider-specific build path.
 The detailed spike lives in

--- a/docs/edge-runtime-compatibility.md
+++ b/docs/edge-runtime-compatibility.md
@@ -149,19 +149,33 @@ when a handler asks for local filesystem or shell authority that does not exist.
 
 ### Runtime-Session Event Log
 
-The existing runtime-session store shape is append/replay oriented and can be
-mapped to edge storage if an adapter provides:
+The TypeScript Fetch adapter exposes a provider-neutral
+`AgentAppFetchSessionEventStore` contract for runtime-backed generated agent
+apps. The contract accepts append batches keyed by runtime-session id and replays
+a JSON snapshot with session metadata plus a per-session ordered timeline. The
+in-memory reference implementation is useful for tests and pure handlers; host
+code owns any durable storage binding.
 
-- append event by runtime-session id;
+The generic contract requires:
+
+- append batches by runtime-session id;
 - read session metadata and timeline by id;
-- list or query sessions where the runtime supports it;
+- optional list/query methods where the runtime supports them;
 - deterministic child-session linkage fields;
-- idempotent writes or retry-safe event ids;
-- documented consistency/concurrency behavior.
+- idempotent writes by `eventId`;
+- replay ordered by per-session `sequence`;
+- read-your-writes behavior after an append resolves.
+
+Concurrency remains a storage-adapter responsibility. Generic Fetch hosts should
+prefer one writer per runtime-session id or a storage primitive that serializes
+append batches. If an implementation accepts concurrent appends, it must either
+preserve supplied sequence numbers without collision or deterministically assign
+the next open per-session sequence while keeping `eventId` idempotency.
 
 Durable Objects, Deno KV, Vercel KV, S3/R2-like object stores, and hosted event
-logs are possible storage implementations, but OSS should define only the
-adapter contract unless a provider-neutral implementation is added.
+logs are possible storage implementations, but OSS defines only the generic
+adapter contract plus an in-memory reference. Provider bindings and deployment
+manifests remain outside this OSS adapter.
 
 ## Reference Runtime Findings
 
@@ -189,6 +203,8 @@ they should not create provider-specific OSS deployment workflows by default.
 - Maintain the generic Fetch request adapter that reuses the Node
   manifest/invoke envelope without advertising a provider deployment target.
 - Maintain the build-time handler manifest/module-map planner.
+- Maintain the provider-neutral session event-store contract for explicit
+  host-supplied Fetch runtime capabilities.
 - Add tests proving pure local handlers can run through generated catalogs with
   in-memory workspace/env and without Node-only server globals.
 - Document unsupported shell/filesystem capability behavior.

--- a/ts/README.md
+++ b/ts/README.md
@@ -183,6 +183,24 @@ const catalog = createAgentAppFetchCatalogFromModuleMap(plan, {
 export default { fetch: createAgentAppFetchHandler({ catalog }) };
 ```
 
+Runtime-backed Fetch handlers can receive an explicit edge-safe session event
+store. The store appends idempotently by `eventId`, replays by per-session
+sequence, and is host-owned; provider-specific storage adapters belong outside
+this generic package:
+
+```ts
+import {
+  createAgentAppFetchHandler,
+  createInMemoryAgentAppFetchSessionEventStore,
+} from "autoctx/control-plane/agent-app-fetch";
+
+const sessionEventStore = createInMemoryAgentAppFetchSessionEventStore();
+
+export default {
+  fetch: createAgentAppFetchHandler({ catalog, runtime, sessionEventStore }),
+};
+```
+
 See [`docs/edge-runtime-compatibility.md`](../docs/edge-runtime-compatibility.md)
 and [`docs/core-control-package-split.md#agent-app-build-targets`](../docs/core-control-package-split.md#agent-app-build-targets)
 for the OSS/proprietary boundary: provider deployment manifests, hosted secrets,

--- a/ts/src/control-plane/agent-app-fetch/index.ts
+++ b/ts/src/control-plane/agent-app-fetch/index.ts
@@ -25,6 +25,8 @@ import type {
 import type { RuntimeSession, RuntimeSessionPromptResult } from "../../session/runtime-session.js";
 import type { RuntimeSessionEventStore } from "../../session/runtime-events.js";
 import type { RuntimeSessionEventSink } from "../../session/runtime-session-notifications.js";
+import { createAgentAppFetchSessionEventStoreBridge } from "./session-event-store.js";
+import type { AgentAppFetchSessionEventStore } from "./session-event-store.js";
 
 export type AgentAppFetchTarget = "fetch";
 export type AgentAppFetchAgentExtension = ".ts" | ".tsx" | ".mts" | ".js" | ".mjs";
@@ -54,6 +56,7 @@ export interface AgentAppFetchHandlerOptions<Payload = unknown, Result = unknown
   commands?: RuntimeCommandGrant[];
   tools?: RuntimeToolGrant[];
   eventStore?: RuntimeSessionEventStore;
+  sessionEventStore?: AgentAppFetchSessionEventStore;
   eventSink?: RuntimeSessionEventSink;
   maxBodyBytes?: number;
 }
@@ -84,21 +87,8 @@ export interface AgentAppFetchManifest {
   }>;
 }
 
-export {
-  createAgentAppFetchCatalogFromModuleMap,
-  planAgentAppFetchCatalog,
-  renderAgentAppFetchModuleMapEntrypoint,
-} from "./catalog-planner.js";
-export type {
-  AgentAppFetchCatalogPlan,
-  AgentAppFetchCatalogPlanEntry,
-  AgentAppFetchCatalogPlanOptions,
-  AgentAppFetchCatalogSourceEntry,
-  AgentAppFetchModuleLoader,
-  AgentAppFetchModuleMap,
-  AgentAppFetchRoute,
-  RenderAgentAppFetchModuleMapEntrypointOptions,
-} from "./catalog-planner.js";
+export * from "./catalog-planner.js";
+export * from "./session-event-store.js";
 
 type EdgeMemoryState = {
   files: Map<string, EdgeMemoryFile>;
@@ -148,32 +138,46 @@ export async function handleAgentAppFetchRequest<Payload = unknown, Result = unk
     workspace: RuntimeWorkspaceEnv;
   },
 ): Promise<Response> {
+  const sessionEventBridge = options.sessionEventStore
+    ? createAgentAppFetchSessionEventStoreBridge(options.sessionEventStore)
+    : undefined;
+  const effectiveEventStore = (options.eventStore ?? sessionEventBridge?.eventStore) as
+    | RuntimeSessionEventStore
+    | undefined;
+  const effectiveOptions = {
+    ...options,
+    eventStore: effectiveEventStore,
+  };
+
   try {
     const url = new URL(request.url);
     if (request.method === "GET" && (url.pathname === "/manifest" || url.pathname === "/agents")) {
-      return jsonResponse(200, buildManifest(options.catalog));
+      return jsonResponse(200, buildManifest(effectiveOptions.catalog));
     }
 
     const match = /^\/agents\/([^/]+)\/invoke$/.exec(url.pathname);
     if (request.method === "POST" && match) {
       const agentName = decodeURIComponent(match[1]!);
-      const entry = resolveCatalogEntry(options.catalog, agentName);
-      if (!entry) return jsonResponse(404, renderAgentNotFound(agentName, options.catalog));
+      const entry = resolveCatalogEntry(effectiveOptions.catalog, agentName);
+      if (!entry) {
+        return jsonResponse(404, renderAgentNotFound(agentName, effectiveOptions.catalog));
+      }
       const body = await readJsonRequestBody(
         request,
-        options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
+        effectiveOptions.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
       );
       const loaded = await loadCatalogEntry(entry);
       const id = readOptionalString(body.id) ?? "default";
       const payload = ("payload" in body ? body.payload : {}) as Payload;
       const result = await loaded.handler(
         createFetchAgentContext({
-          ...options,
+          ...effectiveOptions,
           agent: loaded,
           id,
           payload,
         }),
       );
+      await sessionEventBridge?.flush();
       return jsonResponse(200, {
         ok: true,
         agent: loaded.name,
@@ -190,6 +194,17 @@ export async function handleAgentAppFetchRequest<Payload = unknown, Result = unk
       },
     } satisfies AgentAppFetchErrorEnvelope);
   } catch (error) {
+    try {
+      await sessionEventBridge?.flush();
+    } catch (flushError) {
+      return jsonResponse(500, {
+        ok: false,
+        error: {
+          code: "AUTOCTX_AGENT_APP_SESSION_EVENT_STORE_ERROR",
+          message: flushError instanceof Error ? flushError.message : String(flushError),
+        },
+      } satisfies AgentAppFetchErrorEnvelope);
+    }
     if (error instanceof AgentAppFetchRequestError) {
       return jsonResponse(error.statusCode, {
         ok: false,

--- a/ts/src/control-plane/agent-app-fetch/session-event-store.ts
+++ b/ts/src/control-plane/agent-app-fetch/session-event-store.ts
@@ -48,11 +48,29 @@ export interface AgentAppFetchRuntimeSessionEventLogLike {
   toJSON(): AgentAppFetchSessionEventLogSnapshot | Record<string, unknown>;
 }
 
+export type AgentAppFetchRuntimeSessionEventLogSubscriber = (
+  event: AgentAppFetchSessionEventRecord,
+  log: AgentAppFetchRuntimeSessionReadableEventLog,
+) => void;
+
+export interface AgentAppFetchRuntimeSessionReadableEventLog extends AgentAppFetchRuntimeSessionEventLogLike {
+  readonly sessionId: string;
+  readonly parentSessionId: string;
+  readonly taskId: string;
+  readonly workerId: string;
+  readonly events: AgentAppFetchSessionEventRecord[];
+  readonly createdAt: string;
+  updatedAt: string;
+  metadata: Record<string, unknown>;
+  append(eventType: string, payload?: Record<string, unknown>): AgentAppFetchSessionEventRecord;
+  subscribe(callback: AgentAppFetchRuntimeSessionEventLogSubscriber): () => void;
+}
+
 export interface AgentAppFetchRuntimeSessionEventStoreAdapter {
   save(log: AgentAppFetchRuntimeSessionEventLogLike): void;
-  load(sessionId: string): null;
-  list(options?: { limit?: number }): [];
-  listChildren(parentSessionId: string): [];
+  load(sessionId: string): AgentAppFetchRuntimeSessionReadableEventLog | null;
+  list(options?: { limit?: number }): AgentAppFetchRuntimeSessionReadableEventLog[];
+  listChildren(parentSessionId: string): AgentAppFetchRuntimeSessionReadableEventLog[];
   close(): void;
 }
 
@@ -72,29 +90,45 @@ const AGENT_APP_FETCH_SESSION_EVENT_STORE_CAPABILITIES = {
 export function createAgentAppFetchSessionEventStoreBridge(
   store: AgentAppFetchSessionEventStore,
 ): AgentAppFetchSessionEventStoreBridge {
+  const snapshots = new Map<string, AgentAppFetchSessionEventLogSnapshot>();
   const pending = new Map<string, AgentAppFetchSessionEventLogSnapshot>();
+  const updateSnapshot = (snapshot: AgentAppFetchSessionEventLogSnapshot) => {
+    const normalized = normalizeSnapshot(snapshot);
+    snapshots.set(normalized.sessionId, normalized);
+    pending.set(normalized.sessionId, normalized);
+  };
+  const readSnapshot = (sessionId: string) => snapshots.get(sessionId);
+  const toBridgeLog = (snapshot: AgentAppFetchSessionEventLogSnapshot | undefined) =>
+    snapshot ? new BridgeRuntimeSessionEventLog(snapshot, updateSnapshot) : null;
+
   return {
     eventStore: {
       save(log) {
-        const snapshot = normalizeSnapshot(log.toJSON());
-        pending.set(snapshot.sessionId, snapshot);
+        updateSnapshot(normalizeSnapshot(log.toJSON()));
       },
-      load() {
-        return null;
+      load(sessionId) {
+        return toBridgeLog(readSnapshot(sessionId));
       },
-      list() {
-        return [];
+      list(options = {}) {
+        const limit = positiveLimit(options.limit);
+        return [...snapshots.values()]
+          .sort((left, right) => compareSessionsForList(left, right))
+          .slice(0, limit)
+          .map((snapshot) => new BridgeRuntimeSessionEventLog(snapshot, updateSnapshot));
       },
-      listChildren() {
-        return [];
+      listChildren(parentSessionId) {
+        return [...snapshots.values()]
+          .filter((snapshot) => snapshot.parentSessionId === parentSessionId)
+          .sort(compareChildSessionsForList)
+          .map((snapshot) => new BridgeRuntimeSessionEventLog(snapshot, updateSnapshot));
       },
       close() {},
     },
     async flush() {
-      const snapshots = [...pending.values()].sort((left, right) =>
+      const flushSnapshots = [...pending.values()].sort((left, right) =>
         left.sessionId.localeCompare(right.sessionId),
       );
-      for (const snapshot of snapshots) {
+      for (const snapshot of flushSnapshots) {
         await store.append(snapshot);
         pending.delete(snapshot.sessionId);
       }
@@ -104,6 +138,80 @@ export function createAgentAppFetchSessionEventStoreBridge(
 
 export function createInMemoryAgentAppFetchSessionEventStore(): AgentAppFetchSessionEventStore {
   return new InMemoryAgentAppFetchSessionEventStore();
+}
+
+class BridgeRuntimeSessionEventLog implements AgentAppFetchRuntimeSessionReadableEventLog {
+  readonly sessionId: string;
+  readonly parentSessionId: string;
+  readonly taskId: string;
+  readonly workerId: string;
+  readonly events: AgentAppFetchSessionEventRecord[];
+  readonly createdAt: string;
+  updatedAt: string;
+  metadata: Record<string, unknown>;
+  readonly #onChange: (snapshot: AgentAppFetchSessionEventLogSnapshot) => void;
+  readonly #subscribers: AgentAppFetchRuntimeSessionEventLogSubscriber[] = [];
+
+  constructor(
+    snapshot: AgentAppFetchSessionEventLogSnapshot,
+    onChange: (snapshot: AgentAppFetchSessionEventLogSnapshot) => void,
+  ) {
+    const clone = cloneSnapshot(snapshot);
+    this.sessionId = clone.sessionId;
+    this.parentSessionId = clone.parentSessionId;
+    this.taskId = clone.taskId;
+    this.workerId = clone.workerId;
+    this.metadata = clone.metadata;
+    this.events = clone.events;
+    this.createdAt = clone.createdAt;
+    this.updatedAt = clone.updatedAt;
+    this.#onChange = onChange;
+  }
+
+  append(
+    eventType: string,
+    payload: Record<string, unknown> = {},
+  ): AgentAppFetchSessionEventRecord {
+    const event: AgentAppFetchSessionEventRecord = {
+      eventId: createEdgeSafeEventId(),
+      sessionId: this.sessionId,
+      sequence: this.events.length,
+      eventType,
+      timestamp: new Date().toISOString(),
+      payload: cloneJsonRecord(payload),
+      parentSessionId: this.parentSessionId,
+      taskId: this.taskId,
+      workerId: this.workerId,
+    };
+    this.events.push(event);
+    this.updatedAt = event.timestamp;
+    this.#onChange(this.toJSON());
+    for (const subscriber of [...this.#subscribers]) {
+      subscriber(event, this);
+    }
+    return event;
+  }
+
+  subscribe(callback: AgentAppFetchRuntimeSessionEventLogSubscriber): () => void {
+    this.#subscribers.push(callback);
+    return () => {
+      const index = this.#subscribers.indexOf(callback);
+      if (index !== -1) this.#subscribers.splice(index, 1);
+    };
+  }
+
+  toJSON(): AgentAppFetchSessionEventLogSnapshot {
+    return cloneSnapshot({
+      sessionId: this.sessionId,
+      parentSessionId: this.parentSessionId,
+      taskId: this.taskId,
+      workerId: this.workerId,
+      metadata: this.metadata,
+      events: this.events,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    });
+  }
 }
 
 class InMemoryAgentAppFetchSessionEventStore implements AgentAppFetchSessionEventStore {
@@ -162,11 +270,7 @@ class InMemoryAgentAppFetchSessionEventStore implements AgentAppFetchSessionEven
   async listChildren(parentSessionId: string): Promise<AgentAppFetchSessionEventLogSnapshot[]> {
     return [...this.#snapshots.values()]
       .filter((snapshot) => snapshot.parentSessionId === parentSessionId)
-      .sort(
-        (left, right) =>
-          left.createdAt.localeCompare(right.createdAt) ||
-          left.sessionId.localeCompare(right.sessionId),
-      )
+      .sort(compareChildSessionsForList)
       .map(cloneSnapshot);
   }
 
@@ -193,7 +297,7 @@ function normalizeSnapshot(
     parentSessionId,
     taskId,
     workerId,
-    metadata: cloneRecord(value.metadata),
+    metadata: cloneJsonRecord(value.metadata),
     events: events.sort(compareEvents),
     createdAt,
     updatedAt,
@@ -209,7 +313,7 @@ function mergeSnapshot(
     parentSessionId: incoming.parentSessionId || existing.parentSessionId,
     taskId: incoming.taskId || existing.taskId,
     workerId: incoming.workerId || existing.workerId,
-    metadata: { ...existing.metadata, ...incoming.metadata },
+    metadata: cloneJsonRecord({ ...existing.metadata, ...incoming.metadata }),
     events: existing.events.map(cloneEvent),
     createdAt: existing.createdAt || incoming.createdAt,
     updatedAt: maxTimestamp(existing.updatedAt, incoming.updatedAt),
@@ -228,7 +332,7 @@ function normalizeEvent(
     sequence: readNumber(value.sequence),
     eventType: readString(value.eventType),
     timestamp: readString(value.timestamp),
-    payload: cloneRecord(value.payload),
+    payload: cloneJsonRecord(value.payload),
     parentSessionId: readString(value.parentSessionId),
     taskId: readString(value.taskId),
     workerId: readString(value.workerId),
@@ -240,7 +344,7 @@ function cloneSnapshot(
 ): AgentAppFetchSessionEventLogSnapshot {
   return {
     ...snapshot,
-    metadata: { ...snapshot.metadata },
+    metadata: cloneJsonRecord(snapshot.metadata),
     events: snapshot.events.map(cloneEvent),
   };
 }
@@ -248,12 +352,34 @@ function cloneSnapshot(
 function cloneEvent(event: AgentAppFetchSessionEventRecord): AgentAppFetchSessionEventRecord {
   return {
     ...event,
-    payload: { ...event.payload },
+    payload: cloneJsonRecord(event.payload),
   };
 }
 
-function cloneRecord(value: unknown): Record<string, unknown> {
-  return isRecord(value) ? { ...value } : {};
+function cloneJsonRecord(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) return {};
+  return cloneJsonValue(value) as Record<string, unknown>;
+}
+
+function cloneJsonValue(value: unknown): unknown {
+  if (value === null) return null;
+  if (typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      const cloned = cloneJsonValue(item);
+      return cloned === undefined ? null : cloned;
+    });
+  }
+  if (isRecord(value)) {
+    const record: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      const cloned = cloneJsonValue(entry);
+      if (cloned !== undefined) record[key] = cloned;
+    }
+    return record;
+  }
+  return undefined;
 }
 
 function readString(value: unknown): string {
@@ -293,6 +419,15 @@ function compareEvents(
   );
 }
 
+function compareChildSessionsForList(
+  left: AgentAppFetchSessionEventLogSnapshot,
+  right: AgentAppFetchSessionEventLogSnapshot,
+): number {
+  return (
+    left.createdAt.localeCompare(right.createdAt) || left.sessionId.localeCompare(right.sessionId)
+  );
+}
+
 function compareSessionsForList(
   left: AgentAppFetchSessionEventLogSnapshot,
   right: AgentAppFetchSessionEventLogSnapshot,
@@ -312,4 +447,10 @@ function nextOpenSequence(usedSequences: ReadonlySet<number>, start = 0): number
     sequence += 1;
   }
   return sequence;
+}
+
+function createEdgeSafeEventId(): string {
+  const randomUUID = globalThis.crypto?.randomUUID?.();
+  if (randomUUID) return randomUUID.slice(0, 12);
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
 }

--- a/ts/src/control-plane/agent-app-fetch/session-event-store.ts
+++ b/ts/src/control-plane/agent-app-fetch/session-event-store.ts
@@ -1,0 +1,315 @@
+export interface AgentAppFetchSessionEventRecord {
+  eventId: string;
+  sessionId: string;
+  sequence: number;
+  eventType: string;
+  timestamp: string;
+  payload: Record<string, unknown>;
+  parentSessionId: string;
+  taskId: string;
+  workerId: string;
+}
+
+export interface AgentAppFetchSessionEventLogSnapshot {
+  sessionId: string;
+  parentSessionId: string;
+  taskId: string;
+  workerId: string;
+  metadata: Record<string, unknown>;
+  events: AgentAppFetchSessionEventRecord[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AgentAppFetchSessionEventStoreAppendResult {
+  appended: number;
+  duplicateEventIds: string[];
+  nextSequence: number;
+}
+
+export interface AgentAppFetchSessionEventStoreCapabilities {
+  ordering: "per_session_sequence";
+  idempotency: "event_id";
+  consistency: "read_your_writes_after_append";
+}
+
+export interface AgentAppFetchSessionEventStore {
+  readonly capabilities: AgentAppFetchSessionEventStoreCapabilities;
+  append(
+    snapshot: AgentAppFetchSessionEventLogSnapshot,
+  ): MaybePromise<AgentAppFetchSessionEventStoreAppendResult>;
+  load(sessionId: string): MaybePromise<AgentAppFetchSessionEventLogSnapshot | null>;
+  list?(options?: { limit?: number }): MaybePromise<AgentAppFetchSessionEventLogSnapshot[]>;
+  listChildren?(parentSessionId: string): MaybePromise<AgentAppFetchSessionEventLogSnapshot[]>;
+  close?(): MaybePromise<void>;
+}
+
+export interface AgentAppFetchRuntimeSessionEventLogLike {
+  toJSON(): AgentAppFetchSessionEventLogSnapshot | Record<string, unknown>;
+}
+
+export interface AgentAppFetchRuntimeSessionEventStoreAdapter {
+  save(log: AgentAppFetchRuntimeSessionEventLogLike): void;
+  load(sessionId: string): null;
+  list(options?: { limit?: number }): [];
+  listChildren(parentSessionId: string): [];
+  close(): void;
+}
+
+export interface AgentAppFetchSessionEventStoreBridge {
+  eventStore: AgentAppFetchRuntimeSessionEventStoreAdapter;
+  flush(): Promise<void>;
+}
+
+type MaybePromise<T> = T | Promise<T>;
+
+const AGENT_APP_FETCH_SESSION_EVENT_STORE_CAPABILITIES = {
+  ordering: "per_session_sequence",
+  idempotency: "event_id",
+  consistency: "read_your_writes_after_append",
+} as const satisfies AgentAppFetchSessionEventStoreCapabilities;
+
+export function createAgentAppFetchSessionEventStoreBridge(
+  store: AgentAppFetchSessionEventStore,
+): AgentAppFetchSessionEventStoreBridge {
+  const pending = new Map<string, AgentAppFetchSessionEventLogSnapshot>();
+  return {
+    eventStore: {
+      save(log) {
+        const snapshot = normalizeSnapshot(log.toJSON());
+        pending.set(snapshot.sessionId, snapshot);
+      },
+      load() {
+        return null;
+      },
+      list() {
+        return [];
+      },
+      listChildren() {
+        return [];
+      },
+      close() {},
+    },
+    async flush() {
+      const snapshots = [...pending.values()].sort((left, right) =>
+        left.sessionId.localeCompare(right.sessionId),
+      );
+      for (const snapshot of snapshots) {
+        await store.append(snapshot);
+        pending.delete(snapshot.sessionId);
+      }
+    },
+  };
+}
+
+export function createInMemoryAgentAppFetchSessionEventStore(): AgentAppFetchSessionEventStore {
+  return new InMemoryAgentAppFetchSessionEventStore();
+}
+
+class InMemoryAgentAppFetchSessionEventStore implements AgentAppFetchSessionEventStore {
+  readonly capabilities = AGENT_APP_FETCH_SESSION_EVENT_STORE_CAPABILITIES;
+  readonly #snapshots = new Map<string, AgentAppFetchSessionEventLogSnapshot>();
+
+  async append(
+    snapshot: AgentAppFetchSessionEventLogSnapshot,
+  ): Promise<AgentAppFetchSessionEventStoreAppendResult> {
+    const incoming = normalizeSnapshot(snapshot);
+    const existing = this.#snapshots.get(incoming.sessionId);
+    const merged = existing
+      ? mergeSnapshot(existing, incoming)
+      : normalizeSnapshot({ ...incoming, events: [] });
+    const eventIds = new Set(merged.events.map((event) => event.eventId));
+    const usedSequences = new Set(merged.events.map((event) => event.sequence));
+    const duplicateEventIds: string[] = [];
+    let appended = 0;
+    let nextSequence = nextOpenSequence(usedSequences);
+
+    for (const incomingEvent of incoming.events) {
+      const event = normalizeEvent(incomingEvent, incoming.sessionId);
+      if (eventIds.has(event.eventId)) {
+        duplicateEventIds.push(event.eventId);
+        continue;
+      }
+      if (usedSequences.has(event.sequence)) {
+        event.sequence = nextSequence;
+      }
+      merged.events.push(event);
+      eventIds.add(event.eventId);
+      usedSequences.add(event.sequence);
+      appended += 1;
+      nextSequence = nextOpenSequence(usedSequences, event.sequence + 1);
+    }
+
+    merged.events.sort(compareEvents);
+    merged.updatedAt = maxTimestamp(merged.updatedAt, incoming.updatedAt);
+    this.#snapshots.set(merged.sessionId, cloneSnapshot(merged));
+    return { appended, duplicateEventIds, nextSequence };
+  }
+
+  async load(sessionId: string): Promise<AgentAppFetchSessionEventLogSnapshot | null> {
+    const snapshot = this.#snapshots.get(sessionId);
+    return snapshot ? cloneSnapshot(snapshot) : null;
+  }
+
+  async list(options: { limit?: number } = {}): Promise<AgentAppFetchSessionEventLogSnapshot[]> {
+    const limit = positiveLimit(options.limit);
+    return [...this.#snapshots.values()]
+      .sort((left, right) => compareSessionsForList(left, right))
+      .slice(0, limit)
+      .map(cloneSnapshot);
+  }
+
+  async listChildren(parentSessionId: string): Promise<AgentAppFetchSessionEventLogSnapshot[]> {
+    return [...this.#snapshots.values()]
+      .filter((snapshot) => snapshot.parentSessionId === parentSessionId)
+      .sort(
+        (left, right) =>
+          left.createdAt.localeCompare(right.createdAt) ||
+          left.sessionId.localeCompare(right.sessionId),
+      )
+      .map(cloneSnapshot);
+  }
+
+  close(): void {
+    this.#snapshots.clear();
+  }
+}
+
+function normalizeSnapshot(
+  value: AgentAppFetchSessionEventLogSnapshot | Record<string, unknown>,
+): AgentAppFetchSessionEventLogSnapshot {
+  const sessionId = readString(value.sessionId);
+  if (!sessionId) throw new Error("Agent app Fetch session event snapshots require sessionId");
+  const parentSessionId = readString(value.parentSessionId);
+  const taskId = readString(value.taskId);
+  const workerId = readString(value.workerId);
+  const events = Array.isArray(value.events)
+    ? value.events.filter(isRecord).map((event) => normalizeEvent(event, sessionId))
+    : [];
+  const createdAt = readString(value.createdAt) || firstTimestamp(events);
+  const updatedAt = readString(value.updatedAt) || lastTimestamp(events) || createdAt;
+  return {
+    sessionId,
+    parentSessionId,
+    taskId,
+    workerId,
+    metadata: cloneRecord(value.metadata),
+    events: events.sort(compareEvents),
+    createdAt,
+    updatedAt,
+  };
+}
+
+function mergeSnapshot(
+  existing: AgentAppFetchSessionEventLogSnapshot,
+  incoming: AgentAppFetchSessionEventLogSnapshot,
+): AgentAppFetchSessionEventLogSnapshot {
+  return {
+    sessionId: existing.sessionId,
+    parentSessionId: incoming.parentSessionId || existing.parentSessionId,
+    taskId: incoming.taskId || existing.taskId,
+    workerId: incoming.workerId || existing.workerId,
+    metadata: { ...existing.metadata, ...incoming.metadata },
+    events: existing.events.map(cloneEvent),
+    createdAt: existing.createdAt || incoming.createdAt,
+    updatedAt: maxTimestamp(existing.updatedAt, incoming.updatedAt),
+  };
+}
+
+function normalizeEvent(
+  value: AgentAppFetchSessionEventRecord | Record<string, unknown>,
+  fallbackSessionId: string,
+): AgentAppFetchSessionEventRecord {
+  const eventId = readString(value.eventId);
+  if (!eventId) throw new Error("Agent app Fetch session events require eventId");
+  return {
+    eventId,
+    sessionId: readString(value.sessionId) || fallbackSessionId,
+    sequence: readNumber(value.sequence),
+    eventType: readString(value.eventType),
+    timestamp: readString(value.timestamp),
+    payload: cloneRecord(value.payload),
+    parentSessionId: readString(value.parentSessionId),
+    taskId: readString(value.taskId),
+    workerId: readString(value.workerId),
+  };
+}
+
+function cloneSnapshot(
+  snapshot: AgentAppFetchSessionEventLogSnapshot,
+): AgentAppFetchSessionEventLogSnapshot {
+  return {
+    ...snapshot,
+    metadata: { ...snapshot.metadata },
+    events: snapshot.events.map(cloneEvent),
+  };
+}
+
+function cloneEvent(event: AgentAppFetchSessionEventRecord): AgentAppFetchSessionEventRecord {
+  return {
+    ...event,
+    payload: { ...event.payload },
+  };
+}
+
+function cloneRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? { ...value } : {};
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function readNumber(value: unknown): number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function firstTimestamp(events: readonly AgentAppFetchSessionEventRecord[]): string {
+  return events[0]?.timestamp ?? new Date(0).toISOString();
+}
+
+function lastTimestamp(events: readonly AgentAppFetchSessionEventRecord[]): string {
+  return events.at(-1)?.timestamp ?? "";
+}
+
+function maxTimestamp(left: string, right: string): string {
+  if (!left) return right;
+  if (!right) return left;
+  return left > right ? left : right;
+}
+
+function compareEvents(
+  left: AgentAppFetchSessionEventRecord,
+  right: AgentAppFetchSessionEventRecord,
+): number {
+  return (
+    left.sequence - right.sequence ||
+    left.timestamp.localeCompare(right.timestamp) ||
+    left.eventId.localeCompare(right.eventId)
+  );
+}
+
+function compareSessionsForList(
+  left: AgentAppFetchSessionEventLogSnapshot,
+  right: AgentAppFetchSessionEventLogSnapshot,
+): number {
+  const leftTime = left.updatedAt || left.createdAt;
+  const rightTime = right.updatedAt || right.createdAt;
+  return rightTime.localeCompare(leftTime) || left.sessionId.localeCompare(right.sessionId);
+}
+
+function positiveLimit(value: unknown): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : 50;
+}
+
+function nextOpenSequence(usedSequences: ReadonlySet<number>, start = 0): number {
+  let sequence = start;
+  while (usedSequences.has(sequence)) {
+    sequence += 1;
+  }
+  return sequence;
+}

--- a/ts/tests/agent-app-fetch-session-event-store.test.ts
+++ b/ts/tests/agent-app-fetch-session-event-store.test.ts
@@ -1,0 +1,150 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { AutoctxAgentContext } from "../src/agent-runtime/index.js";
+import {
+  createAgentAppFetchHandler,
+  createInMemoryAgentAppFetchSessionEventStore,
+  createStaticAgentAppCatalog,
+} from "../src/control-plane/agent-app-fetch/index.js";
+
+async function jsonBody(response: Response): Promise<unknown> {
+  return await response.json();
+}
+
+function request(path: string, init?: RequestInit): Request {
+  return new Request(`https://agent-app.test${path}`, init);
+}
+
+describe("agent app Fetch session event-store contract", () => {
+  it("records and replays runtime-session events through an explicit edge-safe store", async () => {
+    const sessionEventStore = createInMemoryAgentAppFetchSessionEventStore();
+    const handler = createAgentAppFetchHandler({
+      sessionEventStore,
+      runtime: {
+        name: "edge-test-runtime",
+        generate: async ({ prompt }) => ({ text: `edge:${prompt}` }),
+        revise: async () => ({ text: "unused" }),
+      },
+      catalog: createStaticAgentAppCatalog([
+        {
+          name: "prompted",
+          relativePath: ".autoctx/agents/prompted.mjs",
+          extension: ".mjs",
+          handler: async (ctx: AutoctxAgentContext<{ prompt: string }>) => {
+            const runtime = await ctx.init();
+            const session = await runtime.session("default");
+            const reply = await session.prompt(ctx.payload.prompt);
+            return { text: reply.text, sessionId: reply.sessionId };
+          },
+        },
+      ]),
+    });
+
+    const response = await handler(
+      request("/agents/prompted/invoke", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "edge-run-1", payload: { prompt: "hello" } }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await jsonBody(response)).toEqual({
+      ok: true,
+      agent: "prompted",
+      id: "edge-run-1",
+      result: {
+        text: "edge:hello",
+        sessionId: "agent:prompted:default",
+      },
+    });
+
+    const replayed = await sessionEventStore.load("agent:prompted:default");
+
+    expect(replayed).toMatchObject({
+      sessionId: "agent:prompted:default",
+      metadata: {
+        agentName: "prompted",
+        agentSessionKey: "default",
+        experimentalAgentRuntime: true,
+      },
+    });
+    expect(replayed?.events.map((event) => event.eventType)).toEqual([
+      "prompt_submitted",
+      "assistant_message",
+    ]);
+    expect(replayed?.events.map((event) => event.sequence)).toEqual([0, 1]);
+    expect(replayed?.events[1]?.payload).toMatchObject({ text: "edge:hello" });
+  });
+
+  it("appends idempotently and replays events in per-session sequence order", async () => {
+    const sessionEventStore = createInMemoryAgentAppFetchSessionEventStore();
+    const event = {
+      eventId: "evt-1",
+      sessionId: "session-1",
+      sequence: 0,
+      eventType: "prompt_submitted",
+      timestamp: "2026-06-13T00:00:00.000Z",
+      payload: { prompt: "hello" },
+      parentSessionId: "",
+      taskId: "",
+      workerId: "",
+    };
+
+    const first = await sessionEventStore.append({
+      sessionId: "session-1",
+      parentSessionId: "",
+      taskId: "",
+      workerId: "",
+      metadata: { goal: "test" },
+      createdAt: "2026-06-13T00:00:00.000Z",
+      updatedAt: "2026-06-13T00:00:00.000Z",
+      events: [event],
+    });
+    const duplicate = await sessionEventStore.append({
+      sessionId: "session-1",
+      parentSessionId: "",
+      taskId: "",
+      workerId: "",
+      metadata: { goal: "test" },
+      createdAt: "2026-06-13T00:00:00.000Z",
+      updatedAt: "2026-06-13T00:00:00.000Z",
+      events: [event],
+    });
+
+    expect(first).toEqual({ appended: 1, duplicateEventIds: [], nextSequence: 1 });
+    expect(duplicate).toEqual({ appended: 0, duplicateEventIds: ["evt-1"], nextSequence: 1 });
+    await expect(sessionEventStore.load("session-1")).resolves.toMatchObject({
+      sessionId: "session-1",
+      events: [event],
+    });
+  });
+
+  it("documents edge consistency semantics without provider-specific storage imports", () => {
+    const sessionEventStore = createInMemoryAgentAppFetchSessionEventStore();
+    const source = readFileSync(
+      join(
+        import.meta.dirname,
+        "..",
+        "src",
+        "control-plane",
+        "agent-app-fetch",
+        "session-event-store.ts",
+      ),
+      "utf-8",
+    );
+
+    expect(sessionEventStore.capabilities).toEqual({
+      ordering: "per_session_sequence",
+      idempotency: "event_id",
+      consistency: "read_your_writes_after_append",
+    });
+    expect(source).not.toContain('"node:');
+    expect(source).not.toContain("'node:");
+    expect(source).not.toContain("better-sqlite3");
+    expect(source).not.toMatch(/wrangler|cloudflare|vercel|deno deploy|durable object/i);
+  });
+});

--- a/ts/tests/agent-app-fetch-session-event-store.test.ts
+++ b/ts/tests/agent-app-fetch-session-event-store.test.ts
@@ -80,6 +80,59 @@ describe("agent app Fetch session event-store contract", () => {
     expect(replayed?.events[1]?.payload).toMatchObject({ text: "edge:hello" });
   });
 
+  it("exposes in-request child logs through the Fetch bridge before flush", async () => {
+    const sessionEventStore = createInMemoryAgentAppFetchSessionEventStore();
+    const handler = createAgentAppFetchHandler({
+      sessionEventStore,
+      catalog: createStaticAgentAppCatalog([
+        {
+          name: "delegating",
+          relativePath: ".autoctx/agents/delegating.mjs",
+          extension: ".mjs",
+          handler: async (ctx: AutoctxAgentContext) => {
+            const runtime = await ctx.init();
+            const session = await runtime.session("default");
+            await session.session.runChildTask({
+              taskId: "child-1",
+              role: "worker",
+              prompt: "inspect child state",
+              handler: async () => ({ text: "child-complete" }),
+            });
+            const childLogs = session.session.listChildLogs();
+            return {
+              parentSessionId: session.session.sessionId,
+              childCount: childLogs.length,
+              childEventTypes: childLogs[0]?.events.map((event) => event.eventType) ?? [],
+            };
+          },
+        },
+      ]),
+    });
+
+    const response = await handler(
+      request("/agents/delegating/invoke", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "edge-run-child", payload: {} }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await jsonBody(response)).toEqual({
+      ok: true,
+      agent: "delegating",
+      id: "edge-run-child",
+      result: {
+        parentSessionId: "agent:delegating:default",
+        childCount: 1,
+        childEventTypes: ["prompt_submitted", "assistant_message"],
+      },
+    });
+    await expect(sessionEventStore.listChildren!("agent:delegating:default")).resolves.toHaveLength(
+      1,
+    );
+  });
+
   it("appends idempotently and replays events in per-session sequence order", async () => {
     const sessionEventStore = createInMemoryAgentAppFetchSessionEventStore();
     const event = {
@@ -120,6 +173,51 @@ describe("agent app Fetch session event-store contract", () => {
     await expect(sessionEventStore.load("session-1")).resolves.toMatchObject({
       sessionId: "session-1",
       events: [event],
+    });
+  });
+
+  it("deep-clones JSON metadata and payload snapshots on append and load", async () => {
+    const sessionEventStore = createInMemoryAgentAppFetchSessionEventStore();
+    const event = {
+      eventId: "evt-nested",
+      sessionId: "session-nested",
+      sequence: 0,
+      eventType: "assistant_message",
+      timestamp: "2026-06-13T00:00:00.000Z",
+      payload: { nested: { text: "original" } },
+      parentSessionId: "",
+      taskId: "",
+      workerId: "",
+    };
+    const metadata = { nested: { owner: "original" } };
+
+    await sessionEventStore.append({
+      sessionId: "session-nested",
+      parentSessionId: "",
+      taskId: "",
+      workerId: "",
+      metadata,
+      createdAt: "2026-06-13T00:00:00.000Z",
+      updatedAt: "2026-06-13T00:00:00.000Z",
+      events: [event],
+    });
+    metadata.nested.owner = "mutated after append";
+    event.payload.nested.text = "mutated after append";
+
+    const loaded = await sessionEventStore.load("session-nested");
+    expect(loaded?.metadata).toEqual({ nested: { owner: "original" } });
+    expect(loaded?.events[0]?.payload).toEqual({ nested: { text: "original" } });
+
+    (loaded!.metadata.nested as { owner: string }).owner = "mutated after load";
+    (loaded!.events[0]!.payload.nested as { text: string }).text = "mutated after load";
+
+    await expect(sessionEventStore.load("session-nested")).resolves.toMatchObject({
+      metadata: { nested: { owner: "original" } },
+      events: [
+        {
+          payload: { nested: { text: "original" } },
+        },
+      ],
     });
   });
 

--- a/ts/tests/tsconfig.json
+++ b/ts/tests/tsconfig.json
@@ -8,6 +8,7 @@
   "include": [
     "agent-app-fetch-adapter.test.ts",
     "agent-app-fetch-catalog-planner.test.ts",
+    "agent-app-fetch-session-event-store.test.ts",
     "background-session-*.test.ts",
     "sandbox-adapter-contracts.test.ts",
     "../src/control-plane/agent-app-fetch/index.ts",


### PR DESCRIPTION
## Summary
- add a provider-neutral `AgentAppFetchSessionEventStore` append/replay contract for runtime-backed generated Fetch agent apps
- add an in-memory reference store plus a request bridge that flushes RuntimeSession logs through explicit host-supplied session event storage
- document idempotency, per-session ordering, read-your-writes behavior, and provider boundary constraints

## Tests
- `npx vitest run tests/agent-app-fetch-session-event-store.test.ts tests/agent-app-fetch-adapter.test.ts tests/agent-app-fetch-catalog-planner.test.ts tests/package-topology.test.ts --reporter=verbose`
- `npx vitest run tests/package-export-catalogs.test.ts -t "Fetch adapter" --reporter=verbose`
- `npx vitest run tests/package-boundaries.test.ts tests/package-topology.test.ts --reporter=verbose`
- `npm run lint -- --pretty false`
- `npx tsc -p tests/tsconfig.json --noEmit --pretty false`
- `npm run build`
- `git diff --check origin/main...HEAD && git diff --check`

## Boundary
- no Durable Objects/KV/R2/S3/Vercel/Deno/Wrangler deployment target or provider-specific storage implementation added
- no hosted scheduling, secret brokering, tenant policy, billing, warming, or fleet orchestration added
- Fetch hosts receive explicit runtime/session capabilities; no runtime filesystem discovery added

Linear: AC-791