### PR TITLE
AC-800 add Fetch entrypoint template

### DIFF
--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -135,8 +135,10 @@ handler/server boundary. The TypeScript control-plane Fetch adapter lives at
 `autoctx/control-plane/agent-app-fetch` and reuses the Node manifest/invoke
 wire shape without becoming a provider-specific deployment target. Its
 build-time catalog planner turns explicit `.autoctx/agents` entries into static
-module maps so edge-compatible bundles do not scan a filesystem at request time.
-Its workspace-store contract gives Fetch hosts a provider-neutral artifact
+module maps so edge-compatible bundles do not scan a filesystem at request time,
+and its generic entrypoint template wires those maps into a Fetch factory for
+host-created capabilities. Its workspace-store contract gives Fetch hosts a
+provider-neutral artifact
 persistence seam behind the existing runtime workspace API, while its session
 event-store contract gives hosts a provider-neutral append/replay seam for
 explicit runtime-session capabilities.

--- a/docs/edge-runtime-compatibility.md
+++ b/docs/edge-runtime-compatibility.md
@@ -27,10 +27,10 @@ the existing `GET /manifest` and `POST /agents/:agent/invoke` shape using a
 static handler catalog or module map. It also includes a build-time catalog
 planner that turns explicit `.autoctx/agents` entries into bundler-visible
 module maps, so generated bundles do not need runtime filesystem discovery.
-The same subpath now exposes provider-neutral workspace-store and
-runtime-session event-store contracts for explicit host-created storage
-capabilities. These helpers are not deployment targets and do not add
-provider-specific build output.
+The same subpath now exposes a generated Fetch entrypoint template plus
+provider-neutral workspace-store and runtime-session event-store contracts for
+explicit host-created capabilities. These helpers are not deployment targets and
+do not add provider-specific build output.
 
 Recommended follow-up after the generic adapter seams:
 
@@ -123,7 +123,10 @@ workflow, but the runtime adapter receives a static list or module map. The
 provider-neutral `planAgentAppFetchCatalog()` and
 `createAgentAppFetchCatalogFromModuleMap()` helpers keep source-project
 scanning out of the edge request path and let bundlers see which handler modules
-must be included.
+must be included. `renderAgentAppFetchEntrypointTemplate()` can then emit a
+generic ESM entrypoint with a static module map and a
+`createAgentAppFetchEntrypoint()` factory that accepts explicit host
+capabilities. Provider wrappers remain external to that generated source.
 
 ### Explicit Environment And Runtime Capabilities
 
@@ -222,7 +225,8 @@ they should not create provider-specific OSS deployment workflows by default.
 
 - Maintain the generic Fetch request adapter that reuses the Node
   manifest/invoke envelope without advertising a provider deployment target.
-- Maintain the build-time handler manifest/module-map planner.
+- Maintain the build-time handler manifest/module-map planner and generic
+  generated Fetch entrypoint template.
 - Maintain the provider-neutral workspace-store contract for explicit
   host-supplied Fetch artifact capabilities.
 - Maintain the provider-neutral session event-store contract for explicit

--- a/ts/README.md
+++ b/ts/README.md
@@ -175,8 +175,9 @@ export default {
 ```
 
 Build tooling can also precompute a bundler-visible module map and turn it into
-the same Fetch catalog. The planner accepts explicit `.autoctx/agents` entries
-from a build step; it does not discover files from the request path:
+the same Fetch catalog or a generic generated Fetch entrypoint. The planner
+accepts explicit `.autoctx/agents` entries from a build step; it does not
+discover files from the request path:
 
 ```ts
 import {
@@ -202,6 +203,22 @@ const catalog = createAgentAppFetchCatalogFromModuleMap(plan, {
 });
 
 export default { fetch: createAgentAppFetchHandler({ catalog }) };
+```
+
+For generated Fetch bundles, `renderAgentAppFetchEntrypointTemplate()` emits an
+ESM entrypoint with a static module map plus a `createAgentAppFetchEntrypoint()`
+factory. Host code can pass explicit capabilities such as `env`, `runtime`,
+`workspaceStore`, or `sessionEventStore`; the generated source does not read
+ambient env or add provider deployment wrappers:
+
+```ts
+import {
+  planAgentAppFetchCatalog,
+  renderAgentAppFetchEntrypointTemplate,
+} from "autoctx/control-plane/agent-app-fetch";
+
+const plan = planAgentAppFetchCatalog({ entries });
+const source = renderAgentAppFetchEntrypointTemplate(plan);
 ```
 
 Runtime-backed Fetch handlers can receive an explicit edge-safe session event

--- a/ts/src/control-plane/agent-app-fetch/entrypoint-template.ts
+++ b/ts/src/control-plane/agent-app-fetch/entrypoint-template.ts
@@ -1,0 +1,61 @@
+import type { AgentAppFetchCatalogPlan } from "./catalog-planner.js";
+
+export interface RenderAgentAppFetchEntrypointTemplateOptions {
+  packageSpecifier?: string;
+}
+
+const DEFAULT_AGENT_APP_FETCH_PACKAGE_SPECIFIER = "autoctx/control-plane/agent-app-fetch";
+
+export function renderAgentAppFetchEntrypointTemplate(
+  plan: AgentAppFetchCatalogPlan,
+  options: RenderAgentAppFetchEntrypointTemplateOptions = {},
+): string {
+  const packageSpecifier = options.packageSpecifier ?? DEFAULT_AGENT_APP_FETCH_PACKAGE_SPECIFIER;
+  const moduleMapEntries = plan.entries.map(
+    (entry) =>
+      `  ${renderObjectKey(entry.name)}: () => import(${JSON.stringify(entry.importSpecifier)}),`,
+  );
+  const imports = [
+    "createAgentAppFetchCatalogFromModuleMap",
+    "createAgentAppFetchHandler",
+  ].join(", ");
+  return [
+    `import { ${imports} } from ${JSON.stringify(packageSpecifier)};`,
+    "",
+    `export const agentAppFetchCatalogPlan = ${JSON.stringify(plan, null, 2)};`,
+    "",
+    "export const agentAppFetchModuleMap = {",
+    ...moduleMapEntries,
+    "};",
+    "",
+    "export const agentAppFetchCatalog = createAgentAppFetchCatalogFromModuleMap(",
+    "  agentAppFetchCatalogPlan,",
+    "  agentAppFetchModuleMap,",
+    ");",
+    "",
+    "export function createAgentAppFetchEntrypoint(hostCapabilities = {}) {",
+    "  return createAgentAppFetchHandler({",
+    "    catalog: agentAppFetchCatalog,",
+    "    env: hostCapabilities.env,",
+    "    workspace: hostCapabilities.workspace,",
+    "    workspaceStore: hostCapabilities.workspaceStore,",
+    "    runtime: hostCapabilities.runtime,",
+    "    commands: hostCapabilities.commands,",
+    "    tools: hostCapabilities.tools,",
+    "    eventStore: hostCapabilities.eventStore,",
+    "    sessionEventStore: hostCapabilities.sessionEventStore,",
+    "    eventSink: hostCapabilities.eventSink,",
+    "    maxBodyBytes: hostCapabilities.maxBodyBytes,",
+    "  });",
+    "}",
+    "",
+    "export const fetch = createAgentAppFetchEntrypoint();",
+    "",
+    "export default { fetch };",
+    "",
+  ].join("\n");
+}
+
+function renderObjectKey(value: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/u.test(value) ? value : JSON.stringify(value);
+}

--- a/ts/src/control-plane/agent-app-fetch/index.ts
+++ b/ts/src/control-plane/agent-app-fetch/index.ts
@@ -90,6 +90,7 @@ export interface AgentAppFetchManifest {
 }
 
 export * from "./catalog-planner.js";
+export * from "./entrypoint-template.js";
 export * from "./session-event-store.js";
 export * from "./workspace-store.js";
 

--- a/ts/tests/agent-app-fetch-entrypoint-template.test.ts
+++ b/ts/tests/agent-app-fetch-entrypoint-template.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  planAgentAppFetchCatalog,
+  renderAgentAppFetchEntrypointTemplate,
+} from "../src/control-plane/agent-app-fetch/index.js";
+
+describe("agent app Fetch entrypoint template", () => {
+  it("renders a generated Fetch entrypoint with explicit host hooks", () => {
+    const plan = planAgentAppFetchCatalog({
+      entries: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          triggers: { webhook: true },
+        },
+        {
+          name: "audit.worker",
+          relativePath: ".autoctx/agents/audit.worker.ts",
+          extension: ".ts",
+        },
+      ],
+      moduleSpecifier: (entry) => `./${entry.relativePath}`,
+    });
+
+    const source = renderAgentAppFetchEntrypointTemplate(plan);
+
+    expect(source).toContain("autoctx/control-plane/agent-app-fetch");
+    expect(source).toContain("createAgentAppFetchCatalogFromModuleMap");
+    expect(source).toContain("createAgentAppFetchHandler");
+    expect(source).toContain('support: () => import("./.autoctx/agents/support.mjs")');
+    expect(source).toContain(
+      '"audit.worker": () => import("./.autoctx/agents/audit.worker.ts")',
+    );
+    expect(source).toContain("export function createAgentAppFetchEntrypoint");
+    expect(source).toContain("hostCapabilities.env");
+    expect(source).toContain("hostCapabilities.runtime");
+    expect(source).toContain("hostCapabilities.workspaceStore");
+    expect(source).toContain("hostCapabilities.sessionEventStore");
+    expect(source).toContain("hostCapabilities.commands");
+    expect(source).toContain("hostCapabilities.tools");
+    expect(source).toContain("hostCapabilities.eventSink");
+    expect(source).toContain("export const fetch = createAgentAppFetchEntrypoint();");
+    expect(source).toContain("export default { fetch };");
+  });
+
+  it("allows package specifier customization without changing generated capability names", () => {
+    const plan = planAgentAppFetchCatalog({
+      entries: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+        },
+      ],
+    });
+
+    const source = renderAgentAppFetchEntrypointTemplate(plan, {
+      packageSpecifier: "@autocontext/control-plane/agent-app-fetch",
+    });
+
+    expect(source).toContain('from "@autocontext/control-plane/agent-app-fetch"');
+    expect(source).toContain("workspaceStore: hostCapabilities.workspaceStore");
+    expect(source).toContain("sessionEventStore: hostCapabilities.sessionEventStore");
+  });
+
+  it("keeps template and generated output provider-neutral", () => {
+    const templateSource = readFileSync(
+      join(
+        import.meta.dirname,
+        "..",
+        "src",
+        "control-plane",
+        "agent-app-fetch",
+        "entrypoint-template.ts",
+      ),
+      "utf-8",
+    );
+    const generatedSource = renderAgentAppFetchEntrypointTemplate(
+      planAgentAppFetchCatalog({
+        entries: [
+          {
+            name: "support",
+            relativePath: ".autoctx/agents/support.mjs",
+            extension: ".mjs",
+          },
+        ],
+      }),
+    );
+
+    for (const source of [templateSource, generatedSource]) {
+      expect(source).not.toContain('"node:');
+      expect(source).not.toContain("'node:");
+      expect(source).not.toContain("process.env");
+      expect(source).not.toContain("discoverAutoctxAgents");
+      expect(source).not.toContain("fs.readdir");
+      expect(source).not.toMatch(
+        /wrangler|cloudflare|vercel|deno deploy|durable object|r2 bucket|s3/i,
+      );
+    }
+  });
+});

--- a/ts/tests/tsconfig.json
+++ b/ts/tests/tsconfig.json
@@ -8,11 +8,13 @@
   "include": [
     "agent-app-fetch-adapter.test.ts",
     "agent-app-fetch-catalog-planner.test.ts",
+    "agent-app-fetch-entrypoint-template.test.ts",
     "agent-app-fetch-session-event-store.test.ts",
     "agent-app-fetch-workspace-store.test.ts",
     "background-session-*.test.ts",
     "sandbox-adapter-contracts.test.ts",
     "../src/control-plane/agent-app-fetch/index.ts",
+    "../src/control-plane/agent-app-fetch/entrypoint-template.ts",
     "../src/control-plane/agent-app-fetch/workspace-store.ts",
     "../src/execution/sandbox-adapter-contracts.ts",
     "../src/session/background-session-*.ts",


### PR DESCRIPTION
## Summary

- Add `renderAgentAppFetchEntrypointTemplate()` for provider-neutral generated Fetch app entrypoints.
- Render a static module map plus `createAgentAppFetchEntrypoint(hostCapabilities)` so host code can pass explicit env/runtime/workspace/session/tool capabilities.
- Keep generated output free of runtime filesystem discovery, ambient env capture, provider deployment code, and hosted orchestration.
- Document the new generated entrypoint seam in the TypeScript README and edge-runtime boundary docs.

## Boundary

This is a generic ESM template under `autoctx/control-plane/agent-app-fetch`. It does not add a provider target, deployment config, storage binding, tenant scheduling, secret brokering, billing, or hosted fleet behavior.

## Verification

- `npx vitest run tests/agent-app-fetch-entrypoint-template.test.ts tests/agent-app-fetch-catalog-planner.test.ts tests/agent-app-fetch-adapter.test.ts tests/agent-app-fetch-workspace-store.test.ts tests/agent-app-fetch-session-event-store.test.ts tests/package-topology.test.ts --reporter=verbose`
- `npx vitest run tests/package-export-catalogs.test.ts -t "Fetch adapter" --reporter=verbose`
- `npx vitest run tests/package-boundaries.test.ts tests/package-topology.test.ts --reporter=verbose`
- `npx tsc -p tests/tsconfig.json --noEmit --pretty false`
- `npm run lint -- --pretty false`
- `npm run build`
- `git diff --check origin/main...HEAD && git diff --check`

Fixes AC-800
