### PR TITLE
AC-801 add Fetch host capability manifest

### DIFF
--- a/docs/core-control-package-split.md
+++ b/docs/core-control-package-split.md
@@ -136,10 +136,10 @@ handler/server boundary. The TypeScript control-plane Fetch adapter lives at
 wire shape without becoming a provider-specific deployment target. Its
 build-time catalog planner turns explicit `.autoctx/agents` entries into static
 module maps so edge-compatible bundles do not scan a filesystem at request time,
-and its generic entrypoint template wires those maps into a Fetch factory for
-host-created capabilities. Its workspace-store contract gives Fetch hosts a
-provider-neutral artifact
-persistence seam behind the existing runtime workspace API, while its session
+and its generic entrypoint template wires those maps plus a host capability
+manifest into a Fetch factory for host-created capabilities. Its workspace-store
+contract gives Fetch hosts a provider-neutral artifact persistence seam behind
+the existing runtime workspace API, while its session
 event-store contract gives hosts a provider-neutral append/replay seam for
 explicit runtime-session capabilities.
 Cloudflare Workers/Durable Objects may be reference environments. The spike

--- a/docs/edge-runtime-compatibility.md
+++ b/docs/edge-runtime-compatibility.md
@@ -27,10 +27,10 @@ the existing `GET /manifest` and `POST /agents/:agent/invoke` shape using a
 static handler catalog or module map. It also includes a build-time catalog
 planner that turns explicit `.autoctx/agents` entries into bundler-visible
 module maps, so generated bundles do not need runtime filesystem discovery.
-The same subpath now exposes a generated Fetch entrypoint template plus
-provider-neutral workspace-store and runtime-session event-store contracts for
-explicit host-created capabilities. These helpers are not deployment targets and
-do not add provider-specific build output.
+The same subpath now exposes a generated Fetch entrypoint template, a host
+capability manifest, and provider-neutral workspace-store/runtime-session
+event-store contracts for explicit host-created capabilities. These helpers are
+not deployment targets and do not add provider-specific build output.
 
 Recommended follow-up after the generic adapter seams:
 
@@ -124,9 +124,11 @@ provider-neutral `planAgentAppFetchCatalog()` and
 `createAgentAppFetchCatalogFromModuleMap()` helpers keep source-project
 scanning out of the edge request path and let bundlers see which handler modules
 must be included. `renderAgentAppFetchEntrypointTemplate()` can then emit a
-generic ESM entrypoint with a static module map and a
-`createAgentAppFetchEntrypoint()` factory that accepts explicit host
-capabilities. Provider wrappers remain external to that generated source.
+generic ESM entrypoint with a static module map, an embedded host capability
+manifest, and a `createAgentAppFetchEntrypoint()` factory that accepts explicit
+host capabilities. `renderAgentAppFetchHostCapabilityManifest()` can also emit
+that manifest as standalone JSON for external/provider hosts. Provider wrappers
+remain external to that generated source.
 
 ### Explicit Environment And Runtime Capabilities
 
@@ -134,6 +136,14 @@ The adapter should receive env as a plain object from trusted host code. It must
 not read `process.env`, parse `.env` files, or bake secrets into generated
 artifacts. Runtime factories should be host-created capabilities, not ambient
 module lookups, unless a bundler-safe module map is supplied explicitly.
+
+The Fetch host capability manifest is machine-readable and lists the accepted
+host capability keys (`env`, `runtime`, `workspace`, `workspaceStore`,
+`commands`, `tools`, `eventStore`, `sessionEventStore`, `eventSink`, and
+`maxBodyBytes`) plus unsupported defaults: runtime filesystem discovery,
+ambient environment capture, local shell execution, provider deployment config,
+and hosted orchestration. Provider hosts can use the manifest to validate their
+wrapper wiring without adding provider code to the generic adapter.
 
 ### Workspace And Grants
 

--- a/docs/edge-runtime-compatibility.md
+++ b/docs/edge-runtime-compatibility.md
@@ -23,8 +23,8 @@ generic adapter seams are proven.
 
 The first OSS adapter seam is the TypeScript control-plane Fetch helper at
 `autoctx/control-plane/agent-app-fetch`. It handles `Request` -> `Response` for
-the existing `GET /manifest` and `POST /agents/:agent/invoke` shape using a
-static handler catalog or module map. It also includes a build-time catalog
+the existing `GET /manifest` / `GET /agents` manifest aliases and
+`POST /agents/:agent/invoke` shape using a static handler catalog or module map. It also includes a build-time catalog
 planner that turns explicit `.autoctx/agents` entries into bundler-visible
 module maps, so generated bundles do not need runtime filesystem discovery.
 The same subpath now exposes a generated Fetch entrypoint template, a host
@@ -137,8 +137,9 @@ not read `process.env`, parse `.env` files, or bake secrets into generated
 artifacts. Runtime factories should be host-created capabilities, not ambient
 module lookups, unless a bundler-safe module map is supplied explicitly.
 
-The Fetch host capability manifest is machine-readable and lists the accepted
-host capability keys (`env`, `runtime`, `workspace`, `workspaceStore`,
+The Fetch host capability manifest is machine-readable and lists the supported
+routes (`GET /manifest`, `GET /agents`, and `POST /agents/:agent/invoke`), the
+accepted host capability keys (`env`, `runtime`, `workspace`, `workspaceStore`,
 `commands`, `tools`, `eventStore`, `sessionEventStore`, `eventSink`, and
 `maxBodyBytes`) plus unsupported defaults: runtime filesystem discovery,
 ambient environment capture, local shell execution, provider deployment config,

--- a/ts/README.md
+++ b/ts/README.md
@@ -206,20 +206,28 @@ export default { fetch: createAgentAppFetchHandler({ catalog }) };
 ```
 
 For generated Fetch bundles, `renderAgentAppFetchEntrypointTemplate()` emits an
-ESM entrypoint with a static module map plus a `createAgentAppFetchEntrypoint()`
-factory. Host code can pass explicit capabilities such as `env`, `runtime`,
-`workspaceStore`, or `sessionEventStore`; the generated source does not read
-ambient env or add provider deployment wrappers:
+ESM entrypoint with a static module map, a machine-readable host capability
+manifest, and a `createAgentAppFetchEntrypoint()` factory. Host code can pass
+explicit capabilities such as `env`, `runtime`, `workspaceStore`, or
+`sessionEventStore`; the generated source does not read ambient env or add
+provider deployment wrappers:
 
 ```ts
 import {
   planAgentAppFetchCatalog,
   renderAgentAppFetchEntrypointTemplate,
+  renderAgentAppFetchHostCapabilityManifest,
 } from "autoctx/control-plane/agent-app-fetch";
 
 const plan = planAgentAppFetchCatalog({ entries });
 const source = renderAgentAppFetchEntrypointTemplate(plan);
+const manifestJson = renderAgentAppFetchHostCapabilityManifest(plan);
 ```
+
+The manifest lists routes, generated agents, accepted host capability keys, and
+unsupported defaults such as runtime filesystem discovery, ambient environment
+capture, and local shell execution. Provider wrappers can consume it when wiring
+host capabilities, but provider-specific deployment remains outside this package.
 
 Runtime-backed Fetch handlers can receive an explicit edge-safe session event
 store. The store appends idempotently by `eventId`, replays by per-session

--- a/ts/README.md
+++ b/ts/README.md
@@ -224,10 +224,12 @@ const source = renderAgentAppFetchEntrypointTemplate(plan);
 const manifestJson = renderAgentAppFetchHostCapabilityManifest(plan);
 ```
 
-The manifest lists routes, generated agents, accepted host capability keys, and
-unsupported defaults such as runtime filesystem discovery, ambient environment
-capture, and local shell execution. Provider wrappers can consume it when wiring
-host capabilities, but provider-specific deployment remains outside this package.
+The manifest lists the supported Fetch routes (`GET /manifest`, `GET /agents`,
+and `POST /agents/:agent/invoke`), generated agents, accepted host capability
+keys, and unsupported defaults such as runtime filesystem discovery, ambient
+environment capture, and local shell execution. Provider wrappers can consume it
+when wiring host capabilities, but provider-specific deployment remains outside
+this package.
 
 Runtime-backed Fetch handlers can receive an explicit edge-safe session event
 store. The store appends idempotently by `eventId`, replays by per-session

--- a/ts/src/control-plane/agent-app-fetch/capability-manifest.ts
+++ b/ts/src/control-plane/agent-app-fetch/capability-manifest.ts
@@ -1,0 +1,91 @@
+import type { AgentAppFetchCatalogPlan, AgentAppFetchRoute } from "./catalog-planner.js";
+
+export type AgentAppFetchHostCapabilityName =
+  | "env"
+  | "runtime"
+  | "workspace"
+  | "workspaceStore"
+  | "commands"
+  | "tools"
+  | "eventStore"
+  | "sessionEventStore"
+  | "eventSink"
+  | "maxBodyBytes";
+
+export type AgentAppFetchUnsupportedDefault =
+  | "runtime_filesystem_discovery"
+  | "ambient_environment_capture"
+  | "local_shell_execution"
+  | "provider_deployment_configuration"
+  | "hosted_orchestration";
+
+export interface AgentAppFetchHostCapabilityManifestAgent {
+  name: string;
+  relativePath: string;
+  extension: string;
+  triggers?: Record<string, unknown>;
+}
+
+export interface AgentAppFetchHostCapabilityManifest {
+  target: AgentAppFetchCatalogPlan["target"];
+  routes: AgentAppFetchRoute[];
+  agents: AgentAppFetchHostCapabilityManifestAgent[];
+  acceptedHostCapabilities: AgentAppFetchHostCapabilityName[];
+  requiredHostCapabilities: AgentAppFetchHostCapabilityName[];
+  unsupportedDefaults: AgentAppFetchUnsupportedDefault[];
+}
+
+const ACCEPTED_HOST_CAPABILITIES: readonly AgentAppFetchHostCapabilityName[] = [
+  "env",
+  "runtime",
+  "workspace",
+  "workspaceStore",
+  "commands",
+  "tools",
+  "eventStore",
+  "sessionEventStore",
+  "eventSink",
+  "maxBodyBytes",
+];
+
+const UNSUPPORTED_DEFAULTS: readonly AgentAppFetchUnsupportedDefault[] = [
+  "runtime_filesystem_discovery",
+  "ambient_environment_capture",
+  "local_shell_execution",
+  "provider_deployment_configuration",
+  "hosted_orchestration",
+];
+
+export function createAgentAppFetchHostCapabilityManifest(
+  plan: AgentAppFetchCatalogPlan,
+): AgentAppFetchHostCapabilityManifest {
+  return {
+    target: plan.target,
+    routes: [...plan.routes],
+    agents: plan.entries.map((entry) => {
+      const agent: AgentAppFetchHostCapabilityManifestAgent = {
+        name: entry.name,
+        relativePath: entry.relativePath,
+        extension: entry.extension,
+      };
+      const triggers = cloneRecord(entry.triggers);
+      if (triggers) agent.triggers = triggers;
+      return agent;
+    }),
+    acceptedHostCapabilities: [...ACCEPTED_HOST_CAPABILITIES],
+    requiredHostCapabilities: [],
+    unsupportedDefaults: [...UNSUPPORTED_DEFAULTS],
+  };
+}
+
+export function renderAgentAppFetchHostCapabilityManifest(plan: AgentAppFetchCatalogPlan): string {
+  return `${JSON.stringify(createAgentAppFetchHostCapabilityManifest(plan), null, 2)}\n`;
+}
+
+function cloneRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? { ...value } : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/ts/src/control-plane/agent-app-fetch/catalog-planner.ts
+++ b/ts/src/control-plane/agent-app-fetch/catalog-planner.ts
@@ -1,4 +1,8 @@
-import type { AutoctxAgentHandler, AutoctxLoadedAgent, MaybePromise } from "../../agent-runtime/index.js";
+import type {
+  AutoctxAgentHandler,
+  AutoctxLoadedAgent,
+  MaybePromise,
+} from "../../agent-runtime/index.js";
 import type {
   AgentAppFetchAgentExtension,
   AgentAppFetchCatalogEntry,
@@ -30,7 +34,7 @@ export interface AgentAppFetchCatalogPlan {
   entries: AgentAppFetchCatalogPlanEntry[];
 }
 
-export type AgentAppFetchRoute = "GET /manifest" | "POST /agents/:agent/invoke";
+export type AgentAppFetchRoute = "GET /manifest" | "GET /agents" | "POST /agents/:agent/invoke";
 export type AgentAppFetchModuleLoader = () => MaybePromise<unknown>;
 export type AgentAppFetchModuleMap = Record<string, AgentAppFetchModuleLoader>;
 
@@ -41,6 +45,7 @@ export interface RenderAgentAppFetchModuleMapEntrypointOptions {
 const DEFAULT_AGENT_APP_FETCH_HANDLER_DIR = ".autoctx/agents";
 const AGENT_APP_FETCH_ROUTES: AgentAppFetchRoute[] = [
   "GET /manifest",
+  "GET /agents",
   "POST /agents/:agent/invoke",
 ];
 

--- a/ts/src/control-plane/agent-app-fetch/entrypoint-template.ts
+++ b/ts/src/control-plane/agent-app-fetch/entrypoint-template.ts
@@ -1,3 +1,4 @@
+import { createAgentAppFetchHostCapabilityManifest } from "./capability-manifest.js";
 import type { AgentAppFetchCatalogPlan } from "./catalog-planner.js";
 
 export interface RenderAgentAppFetchEntrypointTemplateOptions {
@@ -11,18 +12,21 @@ export function renderAgentAppFetchEntrypointTemplate(
   options: RenderAgentAppFetchEntrypointTemplateOptions = {},
 ): string {
   const packageSpecifier = options.packageSpecifier ?? DEFAULT_AGENT_APP_FETCH_PACKAGE_SPECIFIER;
+  const hostCapabilityManifest = createAgentAppFetchHostCapabilityManifest(plan);
+  const renderedHostCapabilityManifest = JSON.stringify(hostCapabilityManifest, null, 2);
   const moduleMapEntries = plan.entries.map(
     (entry) =>
       `  ${renderObjectKey(entry.name)}: () => import(${JSON.stringify(entry.importSpecifier)}),`,
   );
-  const imports = [
-    "createAgentAppFetchCatalogFromModuleMap",
-    "createAgentAppFetchHandler",
-  ].join(", ");
+  const imports = ["createAgentAppFetchCatalogFromModuleMap", "createAgentAppFetchHandler"].join(
+    ", ",
+  );
   return [
     `import { ${imports} } from ${JSON.stringify(packageSpecifier)};`,
     "",
     `export const agentAppFetchCatalogPlan = ${JSON.stringify(plan, null, 2)};`,
+    "",
+    `export const agentAppFetchHostCapabilityManifest = ${renderedHostCapabilityManifest};`,
     "",
     "export const agentAppFetchModuleMap = {",
     ...moduleMapEntries,

--- a/ts/src/control-plane/agent-app-fetch/index.ts
+++ b/ts/src/control-plane/agent-app-fetch/index.ts
@@ -89,6 +89,7 @@ export interface AgentAppFetchManifest {
   }>;
 }
 
+export * from "./capability-manifest.js";
 export * from "./catalog-planner.js";
 export * from "./entrypoint-template.js";
 export * from "./session-event-store.js";

--- a/ts/tests/agent-app-fetch-capability-manifest.test.ts
+++ b/ts/tests/agent-app-fetch-capability-manifest.test.ts
@@ -1,0 +1,161 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createAgentAppFetchHostCapabilityManifest,
+  planAgentAppFetchCatalog,
+  renderAgentAppFetchEntrypointTemplate,
+  renderAgentAppFetchHostCapabilityManifest,
+} from "../src/control-plane/agent-app-fetch/index.js";
+
+describe("agent app Fetch host capability manifest", () => {
+  it("builds a deterministic provider-neutral manifest from a catalog plan", () => {
+    const plan = planAgentAppFetchCatalog({
+      entries: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          triggers: { webhook: true },
+        },
+        {
+          name: "audit",
+          relativePath: ".autoctx/agents/audit.ts",
+          extension: ".ts",
+        },
+      ],
+    });
+
+    expect(createAgentAppFetchHostCapabilityManifest(plan)).toEqual({
+      target: "fetch",
+      routes: ["GET /manifest", "POST /agents/:agent/invoke"],
+      agents: [
+        {
+          name: "audit",
+          relativePath: ".autoctx/agents/audit.ts",
+          extension: ".ts",
+        },
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          triggers: { webhook: true },
+        },
+      ],
+      acceptedHostCapabilities: [
+        "env",
+        "runtime",
+        "workspace",
+        "workspaceStore",
+        "commands",
+        "tools",
+        "eventStore",
+        "sessionEventStore",
+        "eventSink",
+        "maxBodyBytes",
+      ],
+      requiredHostCapabilities: [],
+      unsupportedDefaults: [
+        "runtime_filesystem_discovery",
+        "ambient_environment_capture",
+        "local_shell_execution",
+        "provider_deployment_configuration",
+        "hosted_orchestration",
+      ],
+    });
+  });
+
+  it("renders stable JSON for external hosts", () => {
+    const plan = planAgentAppFetchCatalog({
+      entries: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+        },
+      ],
+    });
+
+    const rendered = renderAgentAppFetchHostCapabilityManifest(plan);
+
+    expect(rendered).toBe(
+      `${JSON.stringify(createAgentAppFetchHostCapabilityManifest(plan), null, 2)}\n`,
+    );
+    expect(JSON.parse(rendered)).toMatchObject({
+      target: "fetch",
+      acceptedHostCapabilities: expect.arrayContaining([
+        "env",
+        "runtime",
+        "workspaceStore",
+        "sessionEventStore",
+        "commands",
+        "tools",
+        "eventSink",
+      ]),
+      unsupportedDefaults: expect.arrayContaining([
+        "runtime_filesystem_discovery",
+        "ambient_environment_capture",
+        "local_shell_execution",
+      ]),
+    });
+  });
+
+  it("exports the manifest from generated Fetch entrypoints", () => {
+    const plan = planAgentAppFetchCatalog({
+      entries: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+        },
+      ],
+    });
+
+    const source = renderAgentAppFetchEntrypointTemplate(plan);
+
+    expect(source).toContain("export const agentAppFetchHostCapabilityManifest = {");
+    expect(source).toContain('"acceptedHostCapabilities"');
+    expect(source).toContain('"unsupportedDefaults"');
+    expect(source).toContain('"runtime_filesystem_discovery"');
+    expect(source).toContain('"ambient_environment_capture"');
+    expect(source).toContain('"local_shell_execution"');
+  });
+
+  it("keeps manifest helpers and generated output free of provider deployment code", () => {
+    const manifestSource = readFileSync(
+      join(
+        import.meta.dirname,
+        "..",
+        "src",
+        "control-plane",
+        "agent-app-fetch",
+        "capability-manifest.ts",
+      ),
+      "utf-8",
+    );
+    const generatedSource = renderAgentAppFetchEntrypointTemplate(
+      planAgentAppFetchCatalog({
+        entries: [
+          {
+            name: "support",
+            relativePath: ".autoctx/agents/support.mjs",
+            extension: ".mjs",
+          },
+        ],
+      }),
+    );
+
+    for (const source of [manifestSource, generatedSource]) {
+      expect(source).not.toContain('"node:');
+      expect(source).not.toContain("'node:");
+      expect(source).not.toContain("process.env");
+      expect(source).not.toContain("discoverAutoctxAgents");
+      expect(source).not.toContain("fs.readdir");
+      expect(source).not.toMatch(
+        /wrangler|cloudflare|vercel|deno deploy|durable object|r2 bucket|s3/i,
+      );
+    }
+  });
+});

--- a/ts/tests/agent-app-fetch-capability-manifest.test.ts
+++ b/ts/tests/agent-app-fetch-capability-manifest.test.ts
@@ -30,7 +30,7 @@ describe("agent app Fetch host capability manifest", () => {
 
     expect(createAgentAppFetchHostCapabilityManifest(plan)).toEqual({
       target: "fetch",
-      routes: ["GET /manifest", "POST /agents/:agent/invoke"],
+      routes: ["GET /manifest", "GET /agents", "POST /agents/:agent/invoke"],
       agents: [
         {
           name: "audit",
@@ -116,6 +116,7 @@ describe("agent app Fetch host capability manifest", () => {
     const source = renderAgentAppFetchEntrypointTemplate(plan);
 
     expect(source).toContain("export const agentAppFetchHostCapabilityManifest = {");
+    expect(source).toContain('"GET /agents"');
     expect(source).toContain('"acceptedHostCapabilities"');
     expect(source).toContain('"unsupportedDefaults"');
     expect(source).toContain('"runtime_filesystem_discovery"');

--- a/ts/tests/agent-app-fetch-catalog-planner.test.ts
+++ b/ts/tests/agent-app-fetch-catalog-planner.test.ts
@@ -41,7 +41,7 @@ describe("agent app Fetch catalog planner", () => {
     expect(plan).toEqual({
       target: "fetch",
       handlerDir: ".autoctx/agents",
-      routes: ["GET /manifest", "POST /agents/:agent/invoke"],
+      routes: ["GET /manifest", "GET /agents", "POST /agents/:agent/invoke"],
       entries: [
         {
           name: "audit",

--- a/ts/tests/tsconfig.json
+++ b/ts/tests/tsconfig.json
@@ -7,6 +7,7 @@
   },
   "include": [
     "agent-app-fetch-adapter.test.ts",
+    "agent-app-fetch-capability-manifest.test.ts",
     "agent-app-fetch-catalog-planner.test.ts",
     "agent-app-fetch-entrypoint-template.test.ts",
     "agent-app-fetch-session-event-store.test.ts",
@@ -14,6 +15,7 @@
     "background-session-*.test.ts",
     "sandbox-adapter-contracts.test.ts",
     "../src/control-plane/agent-app-fetch/index.ts",
+    "../src/control-plane/agent-app-fetch/capability-manifest.ts",
     "../src/control-plane/agent-app-fetch/entrypoint-template.ts",
     "../src/control-plane/agent-app-fetch/workspace-store.ts",
     "../src/execution/sandbox-adapter-contracts.ts",


### PR DESCRIPTION
## Summary

- Add `createAgentAppFetchHostCapabilityManifest()` and `renderAgentAppFetchHostCapabilityManifest()` for generated Fetch host wiring.
- Include deterministic routes, agents, accepted host capability keys, required capabilities, and unsupported defaults.
- Embed `agentAppFetchHostCapabilityManifest` in generated Fetch entrypoint templates.
- Document how external/provider hosts can consume the manifest without adding provider deployment code to OSS.

## Boundary

This stays in the generic Fetch control-plane seam. It does not add a provider target, deployment config, storage binding, tenant scheduling, secret brokering, billing, or hosted fleet behavior.

## Verification

- `npx vitest run tests/agent-app-fetch-capability-manifest.test.ts tests/agent-app-fetch-entrypoint-template.test.ts tests/agent-app-fetch-catalog-planner.test.ts tests/agent-app-fetch-adapter.test.ts tests/agent-app-fetch-workspace-store.test.ts tests/agent-app-fetch-session-event-store.test.ts tests/package-topology.test.ts --reporter=verbose`
- `npx vitest run tests/package-export-catalogs.test.ts -t "Fetch adapter" --reporter=verbose`
- `npx vitest run tests/package-boundaries.test.ts tests/package-topology.test.ts --reporter=verbose`
- `npx tsc -p tests/tsconfig.json --noEmit --pretty false`
- `npm run lint -- --pretty false`
- `npm run build`
- `git diff --check origin/main...HEAD && git diff --check`

Fixes AC-801
