### PR TITLE
AC-805 add Fetch manifest JSON schema

### DIFF
--- a/docs/edge-runtime-compatibility.md
+++ b/docs/edge-runtime-compatibility.md
@@ -131,8 +131,11 @@ resolves a named factory from a static module map without ambient module lookup.
 with static handler/runtime module maps, an embedded host capability manifest,
 and a `createAgentAppFetchEntrypoint()` factory that accepts explicit host
 capabilities. `renderAgentAppFetchHostCapabilityManifest()` can also emit that
-manifest as standalone JSON for external/provider hosts. Provider wrappers remain
-external to that generated source.
+manifest as standalone JSON for external/provider hosts, while
+`agentAppFetchHostCapabilityManifestSchema` and
+`renderAgentAppFetchHostCapabilityManifestSchema()` expose the matching
+provider-neutral validation schema. Provider wrappers remain external to that
+generated source.
 
 ### Explicit Environment And Runtime Capabilities
 
@@ -151,8 +154,8 @@ accepted host capability keys (`env`, `runtime`, `runtimeFactory`,
 `eventStore`, `sessionEventStore`, `eventSink`, and `maxBodyBytes`) plus
 unsupported defaults: runtime filesystem discovery, ambient environment capture,
 local shell execution, provider deployment config, and hosted orchestration.
-Provider hosts can use the manifest to validate their wrapper wiring without
-adding provider code to the generic adapter.
+Provider hosts can use the manifest plus its JSON Schema to validate their
+wrapper wiring without adding provider code to the generic adapter.
 
 ### Workspace And Grants
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -216,8 +216,10 @@ source does not read ambient env or add provider deployment wrappers:
 import {
   planAgentAppFetchCatalog,
   planAgentAppFetchRuntimeFactories,
+  agentAppFetchHostCapabilityManifestSchema,
   renderAgentAppFetchEntrypointTemplate,
   renderAgentAppFetchHostCapabilityManifest,
+  renderAgentAppFetchHostCapabilityManifestSchema,
 } from "autoctx/control-plane/agent-app-fetch";
 
 const plan = planAgentAppFetchCatalog({ entries });
@@ -228,6 +230,9 @@ const source = renderAgentAppFetchEntrypointTemplate(plan, {
   runtimeFactoryPlan,
 });
 const manifestJson = renderAgentAppFetchHostCapabilityManifest(plan);
+const manifestSchemaJson = renderAgentAppFetchHostCapabilityManifestSchema();
+// or import agentAppFetchHostCapabilityManifestSchema directly for validators.
+void agentAppFetchHostCapabilityManifestSchema;
 ```
 
 The manifest lists the supported Fetch routes (`GET /manifest`, `GET /agents`,
@@ -236,8 +241,9 @@ keys, and unsupported defaults such as runtime filesystem discovery, ambient
 environment capture, and local shell execution. A generated entrypoint can use a
 host-supplied `runtimeFactory` directly or resolve `runtimeFactoryName` through
 the bundled, static runtime factory module map. Provider wrappers can consume the
-manifest when wiring host capabilities, but provider-specific deployment remains
-outside this package.
+manifest JSON and `agentAppFetchHostCapabilityManifestSchema` when validating
+host capability wiring, but provider-specific deployment remains outside this
+package.
 
 Runtime-backed Fetch handlers can receive an explicit edge-safe session event
 store. The store appends idempotently by `eventId`, replays by per-session

--- a/ts/src/control-plane/agent-app-fetch/capability-manifest.ts
+++ b/ts/src/control-plane/agent-app-fetch/capability-manifest.ts
@@ -1,3 +1,4 @@
+import { AGENT_APP_FETCH_ROUTES } from "./catalog-planner.js";
 import type { AgentAppFetchCatalogPlan, AgentAppFetchRoute } from "./catalog-planner.js";
 
 export type AgentAppFetchHostCapabilityName =
@@ -37,7 +38,7 @@ export interface AgentAppFetchHostCapabilityManifest {
   unsupportedDefaults: AgentAppFetchUnsupportedDefault[];
 }
 
-const ACCEPTED_HOST_CAPABILITIES: readonly AgentAppFetchHostCapabilityName[] = [
+export const AGENT_APP_FETCH_ACCEPTED_HOST_CAPABILITIES = [
   "env",
   "runtime",
   "runtimeFactory",
@@ -50,15 +51,79 @@ const ACCEPTED_HOST_CAPABILITIES: readonly AgentAppFetchHostCapabilityName[] = [
   "sessionEventStore",
   "eventSink",
   "maxBodyBytes",
-];
+] as const satisfies readonly AgentAppFetchHostCapabilityName[];
 
-const UNSUPPORTED_DEFAULTS: readonly AgentAppFetchUnsupportedDefault[] = [
+export const AGENT_APP_FETCH_UNSUPPORTED_DEFAULTS = [
   "runtime_filesystem_discovery",
   "ambient_environment_capture",
   "local_shell_execution",
   "provider_deployment_configuration",
   "hosted_orchestration",
-];
+] as const satisfies readonly AgentAppFetchUnsupportedDefault[];
+
+export const agentAppFetchHostCapabilityManifestSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  $id: "https://autocontext.dev/schemas/agent-app-fetch-host-capability-manifest.schema.json",
+  title: "AutoContext Fetch host capability manifest",
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "target",
+    "routes",
+    "agents",
+    "acceptedHostCapabilities",
+    "requiredHostCapabilities",
+    "unsupportedDefaults",
+  ],
+  properties: {
+    target: { const: "fetch" },
+    routes: {
+      type: "array",
+      items: { enum: [...AGENT_APP_FETCH_ROUTES] },
+      minItems: AGENT_APP_FETCH_ROUTES.length,
+      maxItems: AGENT_APP_FETCH_ROUTES.length,
+      uniqueItems: true,
+    },
+    agents: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["name", "relativePath", "extension"],
+        properties: {
+          name: { type: "string", pattern: "^[A-Za-z0-9._-]+$" },
+          relativePath: {
+            type: "string",
+            pattern: "^(?!/)(?!.*\\\\)(?!.*(?:^|/)\\.\\.(?:/|$)).+$",
+          },
+          extension: { type: "string", pattern: "^\\.[^/\\\\]+$" },
+          triggers: { type: "object" },
+        },
+      },
+    },
+    acceptedHostCapabilities: {
+      type: "array",
+      items: { enum: [...AGENT_APP_FETCH_ACCEPTED_HOST_CAPABILITIES] },
+      minItems: AGENT_APP_FETCH_ACCEPTED_HOST_CAPABILITIES.length,
+      maxItems: AGENT_APP_FETCH_ACCEPTED_HOST_CAPABILITIES.length,
+      uniqueItems: true,
+    },
+    requiredHostCapabilities: {
+      type: "array",
+      items: { enum: [...AGENT_APP_FETCH_ACCEPTED_HOST_CAPABILITIES] },
+      minItems: 0,
+      maxItems: 0,
+      uniqueItems: true,
+    },
+    unsupportedDefaults: {
+      type: "array",
+      items: { enum: [...AGENT_APP_FETCH_UNSUPPORTED_DEFAULTS] },
+      minItems: AGENT_APP_FETCH_UNSUPPORTED_DEFAULTS.length,
+      maxItems: AGENT_APP_FETCH_UNSUPPORTED_DEFAULTS.length,
+      uniqueItems: true,
+    },
+  },
+} as const;
 
 export function createAgentAppFetchHostCapabilityManifest(
   plan: AgentAppFetchCatalogPlan,
@@ -76,14 +141,18 @@ export function createAgentAppFetchHostCapabilityManifest(
       if (triggers) agent.triggers = triggers;
       return agent;
     }),
-    acceptedHostCapabilities: [...ACCEPTED_HOST_CAPABILITIES],
+    acceptedHostCapabilities: [...AGENT_APP_FETCH_ACCEPTED_HOST_CAPABILITIES],
     requiredHostCapabilities: [],
-    unsupportedDefaults: [...UNSUPPORTED_DEFAULTS],
+    unsupportedDefaults: [...AGENT_APP_FETCH_UNSUPPORTED_DEFAULTS],
   };
 }
 
 export function renderAgentAppFetchHostCapabilityManifest(plan: AgentAppFetchCatalogPlan): string {
   return `${JSON.stringify(createAgentAppFetchHostCapabilityManifest(plan), null, 2)}\n`;
+}
+
+export function renderAgentAppFetchHostCapabilityManifestSchema(): string {
+  return `${JSON.stringify(agentAppFetchHostCapabilityManifestSchema, null, 2)}\n`;
 }
 
 function cloneRecord(value: unknown): Record<string, unknown> | undefined {

--- a/ts/src/control-plane/agent-app-fetch/catalog-planner.ts
+++ b/ts/src/control-plane/agent-app-fetch/catalog-planner.ts
@@ -43,7 +43,7 @@ export interface RenderAgentAppFetchModuleMapEntrypointOptions {
 }
 
 const DEFAULT_AGENT_APP_FETCH_HANDLER_DIR = ".autoctx/agents";
-const AGENT_APP_FETCH_ROUTES: AgentAppFetchRoute[] = [
+export const AGENT_APP_FETCH_ROUTES: readonly AgentAppFetchRoute[] = [
   "GET /manifest",
   "GET /agents",
   "POST /agents/:agent/invoke",

--- a/ts/tests/agent-app-fetch-capability-manifest.test.ts
+++ b/ts/tests/agent-app-fetch-capability-manifest.test.ts
@@ -1,13 +1,16 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import Ajv, { type ValidateFunction } from "ajv";
 import { describe, expect, it } from "vitest";
 
 import {
+  agentAppFetchHostCapabilityManifestSchema,
   createAgentAppFetchHostCapabilityManifest,
   planAgentAppFetchCatalog,
   renderAgentAppFetchEntrypointTemplate,
   renderAgentAppFetchHostCapabilityManifest,
+  renderAgentAppFetchHostCapabilityManifestSchema,
 } from "../src/control-plane/agent-app-fetch/index.js";
 
 describe("agent app Fetch host capability manifest", () => {
@@ -106,6 +109,73 @@ describe("agent app Fetch host capability manifest", () => {
     });
   });
 
+  it("validates rendered manifests against a provider-neutral JSON schema", () => {
+    const plan = planAgentAppFetchCatalog({
+      entries: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+          triggers: { webhook: true },
+        },
+      ],
+    });
+    const validate = compileManifestSchema();
+    const renderedManifest = JSON.parse(renderAgentAppFetchHostCapabilityManifest(plan));
+    const renderedSchema = JSON.parse(renderAgentAppFetchHostCapabilityManifestSchema());
+
+    expect(validate(renderedManifest)).toBe(true);
+    expect(renderedSchema).toEqual(agentAppFetchHostCapabilityManifestSchema);
+  });
+
+  it("rejects Fetch manifest drift through the JSON schema", () => {
+    const plan = planAgentAppFetchCatalog({
+      entries: [
+        {
+          name: "support",
+          relativePath: ".autoctx/agents/support.mjs",
+          extension: ".mjs",
+        },
+      ],
+    });
+    const manifest = createAgentAppFetchHostCapabilityManifest(plan);
+    const validate = compileManifestSchema();
+
+    expect(
+      validate({
+        ...manifest,
+        acceptedHostCapabilities: [...manifest.acceptedHostCapabilities, "providerBinding"],
+      }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...manifest,
+        routes: [...manifest.routes, "POST /deploy"],
+      }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...manifest,
+        routes: manifest.routes.slice(1),
+      }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...manifest,
+        agents: [{ ...manifest.agents[0], relativePath: "/absolute/agent.mjs" }],
+      }),
+    ).toBe(false);
+    const { unsupportedDefaults, ...missingRequiredSection } = manifest;
+    void unsupportedDefaults;
+    expect(validate(missingRequiredSection)).toBe(false);
+    expect(
+      validate({
+        ...manifest,
+        hostedDeployment: true,
+      }),
+    ).toBe(false);
+  });
+
   it("exports the manifest from generated Fetch entrypoints", () => {
     const plan = planAgentAppFetchCatalog({
       entries: [
@@ -164,3 +234,8 @@ describe("agent app Fetch host capability manifest", () => {
     }
   });
 });
+
+function compileManifestSchema(): ValidateFunction {
+  const ajv = new Ajv({ allErrors: true, strict: true });
+  return ajv.compile(agentAppFetchHostCapabilityManifestSchema);
+}


### PR DESCRIPTION
## Summary

- add a provider-neutral JSON Schema for `AgentAppFetchHostCapabilityManifest`
- export schema constants/render helper through `autoctx/control-plane/agent-app-fetch`
- add Ajv-backed regressions proving rendered manifests validate and schema rejects drift
- update Fetch/edge docs for schema-based host validation

## Boundaries

- no provider SDKs, deployment config, durable bindings, tenant scheduling, hosted orchestration, billing, secret brokering, ambient env lookup, or request-time filesystem discovery
- schema only describes the generic Fetch host capability manifest contract

## Verification

- `cd ts && npx vitest run tests/agent-app-fetch-*.test.ts --reporter=verbose`
- `cd ts && npx vitest run tests/package-export-catalogs.test.ts -t "Fetch adapter" tests/package-boundaries.test.ts tests/package-topology.test.ts --reporter=verbose --testTimeout=20000`
- `cd ts && npx vitest run tests/package-boundaries.test.ts tests/package-topology.test.ts --reporter=verbose --testTimeout=20000`
- `cd ts && npx tsc -p tests/tsconfig.json --noEmit --pretty false`
- `cd ts && npm run lint -- --pretty false`
- `cd ts && npm run build`
- `cd ts && node -e "import('./dist/control-plane/agent-app-fetch/index.js').then((m) => { for (const name of ['agentAppFetchHostCapabilityManifestSchema','renderAgentAppFetchHostCapabilityManifestSchema']) { if (m[name] === undefined) throw new Error(name + ' missing'); } const schema = JSON.parse(m.renderAgentAppFetchHostCapabilityManifestSchema()); if (schema.properties.target.const !== 'fetch') throw new Error('schema target mismatch'); console.log('fetch manifest schema dist exports ok'); })"`
- `git diff --check origin/main...HEAD && git diff --check`

Closes AC-805
