### PR TITLE
AC-807 Document Fetch conformance helpers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - [Core/control package split](core-control-package-split.md)
 - [Generic edge runtime compatibility spike](edge-runtime-compatibility.md)
 - [Generated Fetch packaging guide](generated-fetch-packaging.md)
+- [Fetch conformance guide](fetch-conformance.md)
 - [Flue-inspired runtime decisions](flue-influences.md)
 - [Scenario parity matrix — Python & TypeScript](scenario-parity-matrix.md)
 - [Browser exploration contract](browser-exploration-contract.md)

--- a/docs/edge-runtime-compatibility.md
+++ b/docs/edge-runtime-compatibility.md
@@ -136,8 +136,9 @@ manifest as standalone JSON for external/provider hosts, while
 `renderAgentAppFetchHostCapabilityManifestSchema()` expose the matching
 provider-neutral validation schema. See
 [`generated-fetch-packaging.md`](generated-fetch-packaging.md) for a generic
-Fetch/ESM packaging walkthrough. Provider wrappers remain external to that
-generated source.
+Fetch/ESM packaging walkthrough, and [`fetch-conformance.md`](fetch-conformance.md)
+for runner-agnostic checks host wrappers can use before exposing generated
+handlers. Provider wrappers remain external to that generated source.
 
 ### Explicit Environment And Runtime Capabilities
 
@@ -237,7 +238,9 @@ destructive for that store instance.
 The suite covers read-your-writes behavior, byte cloning, deterministic
 workspace listings, recursive root removal, fail-closed shell execution,
 session append idempotency by `eventId`, replay ordering by per-session
-`sequence`, metadata/payload cloning, and child-session linkage visibility.
+`sequence`, metadata/payload cloning, and child-session linkage visibility. See
+[`fetch-conformance.md`](fetch-conformance.md) for runner-agnostic case and
+one-shot runner examples.
 
 ### Fetch Invocation Conformance
 
@@ -247,7 +250,9 @@ suite validates `GET /manifest`, `GET /agents`, `POST /agents/:agent/invoke`,
 stable success/error envelopes, missing-agent behavior, invalid JSON, body-size
 limits, no handler loading during manifest reads, and explicit env/workspace /
 runtime capability wiring. The helper is runner-agnostic and does not add any
-provider deployment or storage binding.
+provider deployment or storage binding. See
+[`fetch-conformance.md`](fetch-conformance.md) for wrapper setup guidance and
+common failure modes.
 
 ## Reference Runtime Findings
 

--- a/docs/fetch-conformance.md
+++ b/docs/fetch-conformance.md
@@ -1,0 +1,148 @@
+# Fetch Conformance
+
+AutoContext's generic Fetch adapter exposes conformance helpers so a host can
+prove its wrapper and storage adapters preserve the OSS contract before exposing
+a generated `fetch` handler. The helpers are framework-agnostic: each case is an
+async function with a stable name, and each one-shot runner executes the same
+cases without assuming a test framework.
+
+## Runner-Agnostic Usage
+
+Use the case factories when you want your test runner to report each case
+individually:
+
+```ts
+import {
+  createAgentAppFetchInvocationConformanceCases,
+  createAgentAppFetchSessionEventStoreConformanceCases,
+  createAgentAppFetchWorkspaceStoreConformanceCases,
+} from "autoctx/control-plane/agent-app-fetch";
+import { describe, it } from "vitest";
+
+describe("host Fetch workspace store", () => {
+  for (const testCase of createAgentAppFetchWorkspaceStoreConformanceCases({
+    createStore: createHostWorkspaceStore,
+  })) {
+    it(testCase.name, testCase.run);
+  }
+});
+
+describe("host Fetch session event store", () => {
+  for (const testCase of createAgentAppFetchSessionEventStoreConformanceCases({
+    createStore: createHostSessionEventStore,
+  })) {
+    it(testCase.name, testCase.run);
+  }
+});
+
+describe("host Fetch invocation wrapper", () => {
+  for (const testCase of createAgentAppFetchInvocationConformanceCases({
+    createHandler: createHostFetchHandler,
+  })) {
+    it(testCase.name, testCase.run);
+  }
+});
+```
+
+Use one-shot runners when your harness has a single async setup step:
+
+```ts
+import {
+  runAgentAppFetchInvocationConformance,
+  runAgentAppFetchSessionEventStoreConformance,
+  runAgentAppFetchWorkspaceStoreConformance,
+} from "autoctx/control-plane/agent-app-fetch";
+
+await runAgentAppFetchWorkspaceStoreConformance({
+  createStore: createHostWorkspaceStore,
+});
+await runAgentAppFetchSessionEventStoreConformance({
+  createStore: createHostSessionEventStore,
+});
+await runAgentAppFetchInvocationConformance({
+  createHandler: createHostFetchHandler,
+});
+```
+
+## Workspace Store Conformance
+
+`createAgentAppFetchWorkspaceStoreConformanceCases()` and
+`runAgentAppFetchWorkspaceStoreConformance()` validate a host-owned
+`AgentAppFetchWorkspaceStore` implementation. Each case calls `createStore()`
+for a fresh isolated instance. The root-removal case recursively removes `/`, so
+that store instance must not be shared with other tests.
+
+The workspace cases verify:
+
+- read-your-writes behavior after each write resolves;
+- byte cloning on write and read boundaries;
+- lexicographic directory listings;
+- recursive root removal that preserves `/` while clearing entries;
+- fail-closed shell execution through `createAgentAppFetchWorkspaceEnv()`.
+
+## Session Event-Store Conformance
+
+`createAgentAppFetchSessionEventStoreConformanceCases()` and
+`runAgentAppFetchSessionEventStoreConformance()` validate a host-owned
+`AgentAppFetchSessionEventStore` implementation. The store should close any
+request-scoped resources through its optional `close()` method when a case
+finishes.
+
+The session event-store cases verify:
+
+- append idempotency by `eventId`;
+- replay ordering by per-session `sequence`;
+- cloning of session metadata and event payloads at append and load boundaries;
+- preservation of parent and child runtime-session links.
+
+## Invocation Conformance
+
+`createAgentAppFetchInvocationConformanceCases()` and
+`runAgentAppFetchInvocationConformance()` validate a host-owned Fetch wrapper
+that accepts the generic `AgentAppFetchHandlerOptions` shape. The wrapper may
+call `createAgentAppFetchHandler()` internally or adapt the options to an
+equivalent `Request` to `Response` handler.
+
+The invocation cases verify:
+
+- `GET /manifest` and `GET /agents` return the static catalog without loading
+  handler modules;
+- `POST /agents/:agent/invoke` preserves the success envelope and request id;
+- explicit `env`, `workspaceStore`, and `runtime` capabilities are wired into
+  the agent context;
+- missing agents, invalid JSON, and over-limit bodies return stable error
+  envelopes;
+- the supplied workspace store is used rather than a hidden request-local store.
+
+## Host Guarantees
+
+A conforming host should provide only explicit capabilities to the generated
+entrypoint or wrapper:
+
+- create fresh stores for conformance cases and isolate destructive cases;
+- pass plain `env` data from trusted host code instead of reading ambient
+  deployment state inside the generated handler;
+- pass `runtime`, `runtimeFactory`, or `runtimeFactoryName` as host-created
+  capabilities;
+- pass `workspaceStore` and `sessionEventStore` when persistence is required;
+- keep handler and runtime catalogs static and bundler-visible;
+- keep command and tool grants absent unless the host deliberately supplies safe
+  grants.
+
+## Failure Modes
+
+Common conformance failures usually indicate a contract mismatch:
+
+| Failure | Likely cause | Expected fix |
+| --- | --- | --- |
+| Mutating a written byte array changes later reads. | Store retained caller-owned buffers. | Clone bytes on write and read. |
+| Directory listing order changes between runs. | Backend iteration order leaked into the contract. | Sort path names lexicographically before returning them. |
+| Removing `/` deletes the root entry itself. | Recursive cleanup treated root like a normal directory. | Preserve `/` and remove only its children. |
+| Manifest requests load agent modules. | Wrapper discovers or imports handlers at request time. | Use a static catalog or module map supplied by the build step. |
+| Invocation ignores sentinel workspace calls. | Wrapper replaced the supplied `workspaceStore`. | Thread host-created stores through to the agent context. |
+| Session replay duplicates events. | Store appends without `eventId` idempotency. | Treat duplicate event ids as already persisted. |
+| Runtime prompts fail in invocation cases. | Wrapper did not pass the explicit runtime capability. | Forward the provided runtime or selected runtime factory. |
+
+These helpers intentionally stop at the generic Fetch/ESM seam. Durable storage
+adapters, deployment descriptors, scheduling policy, secrets handling, and
+commercial orchestration stay outside this OSS conformance package.

--- a/docs/generated-fetch-packaging.md
+++ b/docs/generated-fetch-packaging.md
@@ -6,7 +6,9 @@ host still creates and passes runtime, workspace, storage, and grant
 capabilities explicitly.
 
 The same pattern is implemented as a typed repository example in
-`ts/examples/generated-fetch-packaging.ts`.
+`ts/examples/generated-fetch-packaging.ts`. After packaging, use the
+[`Fetch conformance guide`](fetch-conformance.md) to verify host-owned wrappers
+and stores before exposing the generated handler.
 
 ## Inputs
 
@@ -102,4 +104,6 @@ factory selection.
   explicitly supplies safe command grants.
 
 Use the manifest plus `agentAppFetchHostCapabilityManifestSchema` to validate
-host wiring before exposing the generated `fetch` handler.
+host wiring before exposing the generated `fetch` handler. Use
+[`fetch-conformance.md`](fetch-conformance.md) to run the workspace store,
+session event-store, and invocation checks against host-created capabilities.

--- a/ts/README.md
+++ b/ts/README.md
@@ -312,8 +312,10 @@ describe("host Fetch invocation", () => {
 });
 ```
 
-See [`docs/edge-runtime-compatibility.md`](../docs/edge-runtime-compatibility.md)
-and [`docs/core-control-package-split.md#agent-app-build-targets`](../docs/core-control-package-split.md#agent-app-build-targets)
+See [`docs/fetch-conformance.md`](../docs/fetch-conformance.md) for the full
+runner-agnostic conformance guide. See
+[`docs/edge-runtime-compatibility.md`](../docs/edge-runtime-compatibility.md) and
+[`docs/core-control-package-split.md#agent-app-build-targets`](../docs/core-control-package-split.md#agent-app-build-targets)
 for the OSS/proprietary boundary: provider deployment manifests, hosted secrets,
 fleet scheduling, billing, and tenant orchestration stay outside this OSS
 adapter.

--- a/ts/tests/agent-app-fetch-conformance-docs.test.ts
+++ b/ts/tests/agent-app-fetch-conformance-docs.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(import.meta.dirname, "..", "..");
+const conformanceDocPath = join(repoRoot, "docs", "fetch-conformance.md");
+const edgeDocPath = join(repoRoot, "docs", "edge-runtime-compatibility.md");
+const packagingDocPath = join(repoRoot, "docs", "generated-fetch-packaging.md");
+const tsReadmePath = join(repoRoot, "ts", "README.md");
+
+const HELPER_NAMES = [
+  "createAgentAppFetchWorkspaceStoreConformanceCases",
+  "runAgentAppFetchWorkspaceStoreConformance",
+  "createAgentAppFetchSessionEventStoreConformanceCases",
+  "runAgentAppFetchSessionEventStoreConformance",
+  "createAgentAppFetchInvocationConformanceCases",
+  "runAgentAppFetchInvocationConformance",
+] as const;
+
+const PROVIDER_OR_HOSTED_BOUNDARY_TERMS =
+  /wrangler|cloudflare|vercel|deno deploy|durable object|r2 bucket|s3|tenant|billing|secret broker|warm pool|hosted orchestration/i;
+
+describe("Fetch conformance documentation", () => {
+  it("documents workspace, session, and invocation conformance helpers", () => {
+    const doc = readFileSync(conformanceDocPath, "utf-8");
+
+    expect(doc).toContain("# Fetch Conformance");
+    expect(doc).toContain("## Workspace Store Conformance");
+    expect(doc).toContain("## Session Event-Store Conformance");
+    expect(doc).toContain("## Invocation Conformance");
+    expect(doc).toContain("## Host Guarantees");
+    expect(doc).toContain("## Failure Modes");
+    for (const helperName of HELPER_NAMES) {
+      expect(doc).toContain(helperName);
+    }
+  });
+
+  it("shows runner-agnostic case usage and one-shot runners", () => {
+    const doc = readFileSync(conformanceDocPath, "utf-8");
+
+    expect(doc).toContain(
+      "for (const testCase of createAgentAppFetchWorkspaceStoreConformanceCases",
+    );
+    expect(doc).toContain("it(testCase.name, testCase.run)");
+    expect(doc).toContain("await runAgentAppFetchWorkspaceStoreConformance");
+    expect(doc).toContain("await runAgentAppFetchSessionEventStoreConformance");
+    expect(doc).toContain("await runAgentAppFetchInvocationConformance");
+    expect(doc).toContain("createHandler: createHostFetchHandler");
+  });
+
+  it("links the conformance guide from related Fetch docs", () => {
+    for (const path of [edgeDocPath, packagingDocPath, tsReadmePath]) {
+      expect(readFileSync(path, "utf-8")).toContain("fetch-conformance.md");
+    }
+  });
+
+  it("keeps the conformance docs generic and provider-neutral", () => {
+    const doc = readFileSync(conformanceDocPath, "utf-8");
+
+    expect(doc).not.toContain("process.env");
+    expect(doc).not.toContain("discoverAutoctxAgents");
+    expect(doc).not.toContain("fs.readdir");
+    expect(doc).not.toMatch(PROVIDER_OR_HOSTED_BOUNDARY_TERMS);
+  });
+});

--- a/ts/tests/tsconfig.json
+++ b/ts/tests/tsconfig.json
@@ -9,6 +9,7 @@
     "agent-app-fetch-adapter.test.ts",
     "agent-app-fetch-capability-manifest.test.ts",
     "agent-app-fetch-catalog-planner.test.ts",
+    "agent-app-fetch-conformance-docs.test.ts",
     "agent-app-fetch-entrypoint-template.test.ts",
     "agent-app-fetch-invocation-conformance.test.ts",
     "agent-app-fetch-packaging-docs.test.ts",


### PR DESCRIPTION
## Summary

- Add a provider-neutral Fetch conformance guide covering workspace store, session event-store, and invocation helper suites.
- Document runner-agnostic case usage plus one-shot runner helpers for host test harnesses.
- Link the guide from edge compatibility docs, generated Fetch packaging docs, docs index, and the TypeScript README.
- Add docs smoke tests that enforce helper coverage, related links, and generic Fetch/ESM boundaries.

## Boundaries

- Generic Fetch/ESM documentation only.
- No provider SDKs, deployment config, storage bindings, tenant scheduling, hosted orchestration, billing, secret brokering, runtime filesystem discovery, or ambient environment lookup.
- Host-created capabilities remain explicit.

## Verification

- `cd ts && npx vitest run tests/agent-app-fetch-conformance-docs.test.ts --reporter=verbose`
- `cd ts && npx vitest run tests/agent-app-fetch-conformance-docs.test.ts tests/agent-app-fetch-store-conformance.test.ts tests/agent-app-fetch-invocation-conformance.test.ts tests/package-boundaries.test.ts tests/package-topology.test.ts --reporter=verbose`
- `cd ts && npx vitest run tests/package-export-catalogs.test.ts -t "Fetch adapter" --reporter=verbose`
- `cd ts && npx tsc -p tests/tsconfig.json --noEmit --pretty false`
- `cd ts && npm run lint -- --pretty false`
- `cd ts && npm run build`
- `cd ts && node --input-type=module -e "const mod = await import('./dist/control-plane/agent-app-fetch/index.js'); if (typeof mod.createAgentAppFetchInvocationConformanceCases !== 'function' || typeof mod.runAgentAppFetchWorkspaceStoreConformance !== 'function') throw new Error('missing Fetch conformance exports'); console.log('fetch conformance exports ok');"`
- `git diff --check origin/main...HEAD && git diff --check`

Closes AC-807
