### PR TITLE
AC-810 Tighten Fetch adapter API reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 
 - [Core/control package split](core-control-package-split.md)
 - [Generic edge runtime compatibility spike](edge-runtime-compatibility.md)
+- [Fetch adapter API reference](fetch-api-reference.md)
 - [Generated Fetch packaging guide](generated-fetch-packaging.md)
 - [Fetch conformance guide](fetch-conformance.md)
 - [Flue-inspired runtime decisions](flue-influences.md)

--- a/docs/edge-runtime-compatibility.md
+++ b/docs/edge-runtime-compatibility.md
@@ -135,10 +135,12 @@ manifest as standalone JSON for external/provider hosts, while
 `agentAppFetchHostCapabilityManifestSchema` and
 `renderAgentAppFetchHostCapabilityManifestSchema()` expose the matching
 provider-neutral validation schema. See
-[`generated-fetch-packaging.md`](generated-fetch-packaging.md) for a generic
-Fetch/ESM packaging walkthrough, and [`fetch-conformance.md`](fetch-conformance.md)
-for runner-agnostic checks host wrappers can use before exposing generated
-handlers. Provider wrappers remain external to that generated source.
+[`fetch-api-reference.md`](fetch-api-reference.md) for the exported Fetch API
+surface, [`generated-fetch-packaging.md`](generated-fetch-packaging.md) for a
+generic Fetch/ESM packaging walkthrough, and
+[`fetch-conformance.md`](fetch-conformance.md) for runner-agnostic checks host
+wrappers can use before exposing generated handlers. Provider wrappers remain
+external to that generated source.
 
 ### Explicit Environment And Runtime Capabilities
 

--- a/docs/edge-runtime-compatibility.md
+++ b/docs/edge-runtime-compatibility.md
@@ -155,9 +155,10 @@ of the statically bundled factories.
 The Fetch host capability manifest is machine-readable and lists the supported
 routes (`GET /manifest`, `GET /agents`, and `POST /agents/:agent/invoke`), the
 accepted host capability keys (`env`, `runtime`, `runtimeFactory`,
-`runtimeFactoryName`, `workspace`, `workspaceStore`, `commands`, `tools`,
-`eventStore`, `sessionEventStore`, `eventSink`, and `maxBodyBytes`) plus
-unsupported defaults: runtime filesystem discovery, ambient environment capture,
+`runtimeFactoryName`, `runtimeFactoryPlan`, `runtimeFactoryModuleMap`,
+`workspace`, `workspaceStore`, `commands`, `tools`, `eventStore`,
+`sessionEventStore`, `eventSink`, and `maxBodyBytes`) plus unsupported defaults:
+runtime filesystem discovery, ambient environment capture,
 local shell execution, provider deployment config, and hosted orchestration.
 Provider hosts can use the manifest plus its JSON Schema to validate their
 wrapper wiring without adding provider code to the generic adapter.

--- a/docs/fetch-api-reference.md
+++ b/docs/fetch-api-reference.md
@@ -1,0 +1,180 @@
+# Fetch Adapter API Reference
+
+AutoContext's public Fetch/ESM adapter lives at
+`autoctx/control-plane/agent-app-fetch`. It exposes the same agent-app manifest
+and invocation wire shape as the TypeScript control-plane Node target while
+remaining a generic `Request` to `Response` seam. Host code owns runtime,
+workspace, storage, command, tool, and environment capabilities and passes them
+explicitly.
+
+## Import Path
+
+```ts
+import {
+  createAgentAppFetchHandler,
+  planAgentAppFetchCatalog,
+  renderAgentAppFetchEntrypointTemplate,
+} from "autoctx/control-plane/agent-app-fetch";
+```
+
+The subpath is the supported package boundary for Fetch helpers. Importing from
+source files is not required for generated handlers, conformance cases, or host
+capability manifests.
+
+## Handler Surface
+
+Use `createAgentAppFetchHandler(options)` when host code already has a static
+catalog and wants a `Request` to `Response` handler. The lower-level
+`handleAgentAppFetchRequest()` is exported for wrappers that need to prepare the
+resolved environment/workspace before dispatching a single request.
+
+Core handler types and helpers:
+
+| API                            | Purpose                                                                       |
+| ------------------------------ | ----------------------------------------------------------------------------- |
+| `AgentAppFetchHandlerOptions`  | Options accepted by the handler and wrapper conformance helpers.              |
+| `AgentAppFetchCatalogEntry`    | Static or lazily loaded agent handler catalog entry.                          |
+| `createStaticAgentAppCatalog`  | Clones already-loaded handler entries into a Fetch catalog.                   |
+| `createAgentAppFetchHandler`   | Builds the generic Fetch handler from a catalog plus explicit capabilities.   |
+| `handleAgentAppFetchRequest`   | Dispatches one request when a wrapper has already normalized options.         |
+| `AgentAppFetchManifest`        | Manifest envelope returned by `GET /manifest` and `GET /agents`.              |
+| `AgentAppFetchSuccessEnvelope` | Successful invocation envelope returned by `POST /agents/:agent/invoke`.      |
+| `AgentAppFetchErrorEnvelope`   | Stable error envelope for missing agents, invalid bodies, and handler errors. |
+
+Supported routes are:
+
+- `GET /manifest`
+- `GET /agents`
+- `POST /agents/:agent/invoke`
+
+Accepted host-created capability keys are `env`, `runtime`, `runtimeFactory`,
+`runtimeFactoryName`, `runtimeFactoryPlan`, `runtimeFactoryModuleMap`,
+`workspace`, `workspaceStore`, `commands`, `tools`, `eventStore`,
+`sessionEventStore`, `eventSink`, and `maxBodyBytes`.
+
+## Catalog And Entrypoint Planning
+
+Build tooling should provide explicit catalog entries. The runtime handler does
+not discover files.
+
+| API                                       | Purpose                                                                                |
+| ----------------------------------------- | -------------------------------------------------------------------------------------- |
+| `planAgentAppFetchCatalog`                | Validates and normalizes explicit `.autoctx/agents` entries into a deterministic plan. |
+| `createAgentAppFetchCatalogFromModuleMap` | Turns a plan plus a static module map into lazy catalog entries.                       |
+| `renderAgentAppFetchModuleMapEntrypoint`  | Emits a small ESM module-map entrypoint that directly creates `fetch`.                 |
+| `renderAgentAppFetchEntrypointTemplate`   | Emits the generated Fetch entrypoint template with manifest and factory exports.       |
+| `AGENT_APP_FETCH_ROUTES`                  | Canonical route list used by catalog plans and manifests.                              |
+
+`renderAgentAppFetchEntrypointTemplate()` is the preferred packaging helper for
+generated Fetch bundles because it emits the catalog plan, static module map,
+host capability manifest, and `createAgentAppFetchEntrypoint()` factory in one
+ESM source string.
+
+## Runtime Factory Helpers
+
+Runtime factories let generated entrypoints bundle a static set of runtime
+factory modules while preserving explicit host capability precedence.
+
+| API                                              | Purpose                                                                                  |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `planAgentAppFetchRuntimeFactories`              | Validates and normalizes explicit `.autoctx/runtimes` entries into a deterministic plan. |
+| `createAgentAppFetchRuntimeFactoryFromModuleMap` | Resolves a named runtime factory from a static module map.                               |
+| `createAgentAppFetchLazyRuntime`                 | Wraps a runtime factory so the runtime is created only on first prompt/revise use.       |
+
+Precedence is fixed: direct `runtime` wins over `runtimeFactory`, and direct
+`runtimeFactory` wins over `runtimeFactoryName`. Named factories should be
+selected from `runtimeFactoryPlan` plus `runtimeFactoryModuleMap`, never from an
+ambient module lookup.
+
+## Host Capability Manifest
+
+Generated packages can emit a manifest and schema so host wrappers can validate
+which capabilities the generic Fetch handler accepts.
+
+| API                                               | Purpose                                                                       |
+| ------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `createAgentAppFetchHostCapabilityManifest`       | Builds the machine-readable manifest from a catalog plan.                     |
+| `renderAgentAppFetchHostCapabilityManifest`       | Serializes the manifest as pretty JSON with a trailing newline.               |
+| `agentAppFetchHostCapabilityManifestSchema`       | JSON Schema object for the manifest contract.                                 |
+| `renderAgentAppFetchHostCapabilityManifestSchema` | Serializes the schema as pretty JSON with a trailing newline.                 |
+| `AGENT_APP_FETCH_ACCEPTED_HOST_CAPABILITIES`      | Canonical accepted capability key list.                                       |
+| `AGENT_APP_FETCH_UNSUPPORTED_DEFAULTS`            | Canonical list of defaults intentionally not provided by the generic adapter. |
+
+The unsupported-default list documents that the generated handler does not add
+runtime filesystem discovery, ambient environment capture, local shell
+execution, host deployment configuration, or commercial orchestration behavior.
+
+## Workspace And Session Stores
+
+The Fetch adapter exports provider-neutral store contracts and in-memory
+references for tests, examples, and pure handlers.
+
+| API                                            | Purpose                                                                    |
+| ---------------------------------------------- | -------------------------------------------------------------------------- |
+| `AgentAppFetchWorkspaceStore`                  | Virtual workspace store contract for files, directories, and metadata.     |
+| `createAgentAppFetchWorkspaceEnv`              | Adapts a workspace store to the shared runtime workspace surface.          |
+| `createInMemoryAgentAppFetchWorkspaceStore`    | In-memory reference workspace store.                                       |
+| `createEdgeInMemoryWorkspaceEnv`               | Convenience in-memory workspace environment for Fetch-compatible runtimes. |
+| `AgentAppFetchSessionEventStore`               | Runtime-session event-store contract with idempotent append and replay.    |
+| `createAgentAppFetchSessionEventStoreBridge`   | Bridges a session event store into the runtime event-store adapter shape.  |
+| `createInMemoryAgentAppFetchSessionEventStore` | In-memory reference session event store.                                   |
+
+The in-memory references are useful defaults but do not imply persistence across
+requests. Hosts that need persistence should pass `workspaceStore` and
+`sessionEventStore` explicitly.
+
+## Conformance Helpers
+
+Conformance helpers are framework-agnostic. Case factories return named async
+cases; one-shot runners execute the same cases without assuming a test runner.
+
+| API                                                    | Purpose                              |
+| ------------------------------------------------------ | ------------------------------------ |
+| `createAgentAppFetchWorkspaceStoreConformanceCases`    | Workspace store case factory.        |
+| `runAgentAppFetchWorkspaceStoreConformance`            | One-shot workspace store runner.     |
+| `createAgentAppFetchSessionEventStoreConformanceCases` | Session event-store case factory.    |
+| `runAgentAppFetchSessionEventStoreConformance`         | One-shot session event-store runner. |
+| `createAgentAppFetchInvocationConformanceCases`        | Invocation wrapper case factory.     |
+| `runAgentAppFetchInvocationConformance`                | One-shot invocation wrapper runner.  |
+
+See [`fetch-conformance.md`](fetch-conformance.md) for case details, failure
+modes, and runner examples.
+
+## Generated Entrypoint Contract
+
+A source string emitted by `renderAgentAppFetchEntrypointTemplate()` exports:
+
+- `agentAppFetchCatalogPlan`
+- `agentAppFetchModuleMap`
+- `agentAppFetchCatalog`
+- `agentAppFetchRuntimeFactoryPlan` when runtime factories are planned
+- `agentAppFetchRuntimeFactoryModuleMap` when runtime factories are planned
+- `agentAppFetchHostCapabilityManifest`
+- `createAgentAppFetchEntrypoint(hostCapabilities?)`
+- `fetch`
+- a default object containing `fetch`
+
+`createAgentAppFetchEntrypoint()` forwards host-created capabilities to
+`createAgentAppFetchHandler()`. When the generated source includes runtime
+factory entries, it can resolve `runtimeFactoryName` through the static runtime
+factory module map lazily. Direct `runtime` and `runtimeFactory` capabilities
+still take precedence over named factory selection.
+
+## Boundary Guarantees
+
+The Fetch adapter remains a generic OSS seam:
+
+- handler and runtime catalogs are explicit build-step inputs;
+- request handling uses static catalogs/module maps and no request-time file
+  discovery;
+- environment data is passed through `env` rather than captured ambiently;
+- runtime factories are host-created capabilities or selected from static module
+  maps;
+- shell execution is unavailable unless a host deliberately supplies safe
+  command grants;
+- host deployment descriptors, fleet policy, storage bindings, and commercial
+  orchestration stay outside this package.
+
+For packaging guidance, see
+[`generated-fetch-packaging.md`](generated-fetch-packaging.md). For wrapper and
+store verification, see [`fetch-conformance.md`](fetch-conformance.md).

--- a/docs/fetch-conformance.md
+++ b/docs/fetch-conformance.md
@@ -2,9 +2,11 @@
 
 AutoContext's generic Fetch adapter exposes conformance helpers so a host can
 prove its wrapper and storage adapters preserve the OSS contract before exposing
-a generated `fetch` handler. The helpers are framework-agnostic: each case is an
-async function with a stable name, and each one-shot runner executes the same
-cases without assuming a test framework.
+a generated `fetch` handler. See the
+[`Fetch adapter API reference`](fetch-api-reference.md) for the exported helper
+surface. The helpers are framework-agnostic: each case is an async function with
+a stable name, and each one-shot runner executes the same cases without assuming
+a test framework.
 
 ## Runner-Agnostic Usage
 
@@ -139,17 +141,17 @@ entrypoint or wrapper:
 
 Common conformance failures usually indicate a contract mismatch:
 
-| Failure | Likely cause | Expected fix |
-| --- | --- | --- |
-| Mutating a written byte array changes later reads. | Store retained caller-owned buffers. | Clone bytes on write and read. |
-| Directory listing order changes between runs. | Backend iteration order leaked into the contract. | Sort path names lexicographically before returning them. |
-| Removing `/` deletes the root entry itself. | Recursive cleanup treated root like a normal directory. | Preserve `/` and remove only its children. |
-| Manifest requests load agent modules. | Wrapper discovers or imports handlers at request time. | Use a static catalog or module map supplied by the build step. |
-| Invocation ignores sentinel workspace calls. | Wrapper replaced the supplied `workspaceStore`. | Thread host-created stores through to the agent context. |
-| Session replay duplicates events. | Store appends without `eventId` idempotency. | Treat duplicate event ids as already persisted. |
-| Runtime prompts fail in invocation cases. | Wrapper did not pass the explicit runtime capability. | Forward the provided runtime or selected runtime factory. |
-| Named factory loads before invocation. | Wrapper eagerly called the factory module map. | Wrap factories with lazy runtime creation. |
-| Named factory overrides direct capabilities. | Wrapper ignored runtime precedence. | Prefer `runtime`, then `runtimeFactory`, then `runtimeFactoryName`. |
+| Failure                                            | Likely cause                                            | Expected fix                                                        |
+| -------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------- |
+| Mutating a written byte array changes later reads. | Store retained caller-owned buffers.                    | Clone bytes on write and read.                                      |
+| Directory listing order changes between runs.      | Backend iteration order leaked into the contract.       | Sort path names lexicographically before returning them.            |
+| Removing `/` deletes the root entry itself.        | Recursive cleanup treated root like a normal directory. | Preserve `/` and remove only its children.                          |
+| Manifest requests load agent modules.              | Wrapper discovers or imports handlers at request time.  | Use a static catalog or module map supplied by the build step.      |
+| Invocation ignores sentinel workspace calls.       | Wrapper replaced the supplied `workspaceStore`.         | Thread host-created stores through to the agent context.            |
+| Session replay duplicates events.                  | Store appends without `eventId` idempotency.            | Treat duplicate event ids as already persisted.                     |
+| Runtime prompts fail in invocation cases.          | Wrapper did not pass the explicit runtime capability.   | Forward the provided runtime or selected runtime factory.           |
+| Named factory loads before invocation.             | Wrapper eagerly called the factory module map.          | Wrap factories with lazy runtime creation.                          |
+| Named factory overrides direct capabilities.       | Wrapper ignored runtime precedence.                     | Prefer `runtime`, then `runtimeFactory`, then `runtimeFactoryName`. |
 
 These helpers intentionally stop at the generic Fetch/ESM seam. Durable storage
 adapters, deployment descriptors, scheduling policy, secrets handling, and

--- a/docs/generated-fetch-packaging.md
+++ b/docs/generated-fetch-packaging.md
@@ -6,9 +6,10 @@ host still creates and passes runtime, workspace, storage, and grant
 capabilities explicitly.
 
 The same pattern is implemented as a typed repository example in
-`ts/examples/generated-fetch-packaging.ts`. After packaging, use the
-[`Fetch conformance guide`](fetch-conformance.md) to verify host-owned wrappers
-and stores before exposing the generated handler.
+`ts/examples/generated-fetch-packaging.ts`. See the
+[`Fetch adapter API reference`](fetch-api-reference.md) for the exported helper
+surface. After packaging, use the [`Fetch conformance guide`](fetch-conformance.md)
+to verify host-owned wrappers and stores before exposing the generated handler.
 
 ## Inputs
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -243,7 +243,8 @@ host-supplied `runtimeFactory` directly or resolve `runtimeFactoryName` through
 the bundled, static runtime factory module map. Provider wrappers can consume the
 manifest JSON and `agentAppFetchHostCapabilityManifestSchema` when validating
 host capability wiring, but provider-specific deployment remains outside this
-package. See [`docs/generated-fetch-packaging.md`](../docs/generated-fetch-packaging.md)
+package. See [`docs/fetch-api-reference.md`](../docs/fetch-api-reference.md) for
+the exported API surface, [`docs/generated-fetch-packaging.md`](../docs/generated-fetch-packaging.md)
 and [`examples/generated-fetch-packaging.ts`](examples/generated-fetch-packaging.ts)
 for a generic Fetch/ESM packaging example.
 

--- a/ts/tests/agent-app-fetch-api-reference-docs.test.ts
+++ b/ts/tests/agent-app-fetch-api-reference-docs.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(import.meta.dirname, "..", "..");
+const apiReferencePath = join(repoRoot, "docs", "fetch-api-reference.md");
+const docsIndexPath = join(repoRoot, "docs", "README.md");
+const edgeDocPath = join(repoRoot, "docs", "edge-runtime-compatibility.md");
+const packagingDocPath = join(repoRoot, "docs", "generated-fetch-packaging.md");
+const conformanceDocPath = join(repoRoot, "docs", "fetch-conformance.md");
+const tsReadmePath = join(repoRoot, "ts", "README.md");
+
+const REQUIRED_SECTIONS = [
+  "# Fetch Adapter API Reference",
+  "## Import Path",
+  "## Handler Surface",
+  "## Catalog And Entrypoint Planning",
+  "## Runtime Factory Helpers",
+  "## Host Capability Manifest",
+  "## Workspace And Session Stores",
+  "## Conformance Helpers",
+  "## Generated Entrypoint Contract",
+  "## Boundary Guarantees",
+] as const;
+
+const REQUIRED_API_NAMES = [
+  "createAgentAppFetchHandler",
+  "handleAgentAppFetchRequest",
+  "createStaticAgentAppCatalog",
+  "AgentAppFetchHandlerOptions",
+  "AgentAppFetchCatalogEntry",
+  "AgentAppFetchManifest",
+  "AgentAppFetchSuccessEnvelope",
+  "AgentAppFetchErrorEnvelope",
+  "planAgentAppFetchCatalog",
+  "createAgentAppFetchCatalogFromModuleMap",
+  "renderAgentAppFetchModuleMapEntrypoint",
+  "renderAgentAppFetchEntrypointTemplate",
+  "planAgentAppFetchRuntimeFactories",
+  "createAgentAppFetchRuntimeFactoryFromModuleMap",
+  "createAgentAppFetchLazyRuntime",
+  "createAgentAppFetchHostCapabilityManifest",
+  "renderAgentAppFetchHostCapabilityManifest",
+  "renderAgentAppFetchHostCapabilityManifestSchema",
+  "agentAppFetchHostCapabilityManifestSchema",
+  "AGENT_APP_FETCH_ACCEPTED_HOST_CAPABILITIES",
+  "AGENT_APP_FETCH_UNSUPPORTED_DEFAULTS",
+  "createAgentAppFetchWorkspaceEnv",
+  "createInMemoryAgentAppFetchWorkspaceStore",
+  "createEdgeInMemoryWorkspaceEnv",
+  "AgentAppFetchWorkspaceStore",
+  "createAgentAppFetchSessionEventStoreBridge",
+  "createInMemoryAgentAppFetchSessionEventStore",
+  "AgentAppFetchSessionEventStore",
+  "createAgentAppFetchWorkspaceStoreConformanceCases",
+  "runAgentAppFetchWorkspaceStoreConformance",
+  "createAgentAppFetchSessionEventStoreConformanceCases",
+  "runAgentAppFetchSessionEventStoreConformance",
+  "createAgentAppFetchInvocationConformanceCases",
+  "runAgentAppFetchInvocationConformance",
+] as const;
+
+const REQUIRED_HOST_CAPABILITY_NAMES = [
+  "env",
+  "runtime",
+  "runtimeFactory",
+  "runtimeFactoryName",
+  "runtimeFactoryPlan",
+  "runtimeFactoryModuleMap",
+  "workspace",
+  "workspaceStore",
+  "commands",
+  "tools",
+  "eventStore",
+  "sessionEventStore",
+  "eventSink",
+  "maxBodyBytes",
+] as const;
+
+const PROVIDER_OR_HOSTED_BOUNDARY_TERMS =
+  /wrangler|cloudflare|vercel|deno deploy|durable object|r2 bucket|s3|tenant|billing|secret broker|warm pool|hosted orchestration/i;
+
+describe("Fetch adapter API reference documentation", () => {
+  it("documents the public Fetch adapter API surface", () => {
+    const doc = readFileSync(apiReferencePath, "utf-8");
+
+    for (const section of REQUIRED_SECTIONS) {
+      expect(doc).toContain(section);
+    }
+    for (const apiName of REQUIRED_API_NAMES) {
+      expect(doc).toContain(apiName);
+    }
+  });
+
+  it("documents the generic Fetch routes and accepted host capability keys", () => {
+    const doc = readFileSync(apiReferencePath, "utf-8");
+
+    expect(doc).toContain("GET /manifest");
+    expect(doc).toContain("GET /agents");
+    expect(doc).toContain("POST /agents/:agent/invoke");
+    for (const capability of REQUIRED_HOST_CAPABILITY_NAMES) {
+      expect(doc).toContain(`\`${capability}\``);
+    }
+  });
+
+  it("links the API reference from related Fetch docs", () => {
+    for (const path of [
+      docsIndexPath,
+      edgeDocPath,
+      packagingDocPath,
+      conformanceDocPath,
+      tsReadmePath,
+    ]) {
+      expect(readFileSync(path, "utf-8")).toContain("fetch-api-reference.md");
+    }
+  });
+
+  it("keeps the API reference generic and provider-neutral", () => {
+    const doc = readFileSync(apiReferencePath, "utf-8");
+
+    expect(doc).not.toContain("process.env");
+    expect(doc).not.toContain("discoverAutoctxAgents");
+    expect(doc).not.toContain("fs.readdir");
+    expect(doc).not.toMatch(PROVIDER_OR_HOSTED_BOUNDARY_TERMS);
+  });
+});

--- a/ts/tests/agent-app-fetch-api-reference-docs.test.ts
+++ b/ts/tests/agent-app-fetch-api-reference-docs.test.ts
@@ -104,6 +104,14 @@ describe("Fetch adapter API reference documentation", () => {
     }
   });
 
+  it("keeps the linked edge capability list in sync with accepted host keys", () => {
+    const edgeDoc = readFileSync(edgeDocPath, "utf-8");
+
+    for (const capability of REQUIRED_HOST_CAPABILITY_NAMES) {
+      expect(edgeDoc).toContain(`\`${capability}\``);
+    }
+  });
+
   it("links the API reference from related Fetch docs", () => {
     for (const path of [
       docsIndexPath,

--- a/ts/tests/tsconfig.json
+++ b/ts/tests/tsconfig.json
@@ -7,6 +7,7 @@
   },
   "include": [
     "agent-app-fetch-adapter.test.ts",
+    "agent-app-fetch-api-reference-docs.test.ts",
     "agent-app-fetch-capability-manifest.test.ts",
     "agent-app-fetch-catalog-planner.test.ts",
     "agent-app-fetch-conformance-docs.test.ts",


### PR DESCRIPTION
## Summary

- Add `docs/fetch-api-reference.md` covering the public `autoctx/control-plane/agent-app-fetch` API surface.
- Document handler, catalog/entrypoint planning, runtime factory, manifest/schema, workspace/session store, conformance, and generated entrypoint helper groups.
- Add docs drift tests to keep required API names, route names, host capability keys, links, and provider-neutral boundaries covered.
- Link the API reference from related Fetch docs and the TypeScript README.

## Boundaries

- Generic Fetch/ESM only.
- No provider SDKs, deployment configuration, storage bindings, hosted orchestration, tenant scheduling, billing, secret brokering, warming behavior, ambient env/module lookup, or request-time filesystem discovery.
- Runtime factories remain explicit host-created capabilities or selected from static module maps.

## Verification

- `cd ts && npx vitest run tests/agent-app-fetch-api-reference-docs.test.ts --reporter=verbose` (red before docs existed; green after implementation)
- `cd ts && npx vitest run tests/agent-app-fetch-api-reference-docs.test.ts tests/agent-app-fetch-conformance-docs.test.ts tests/agent-app-fetch-packaging-docs.test.ts --reporter=verbose`
- `cd ts && npx vitest run tests/agent-app-fetch-*.test.ts --reporter=verbose`
- `cd ts && npx vitest run tests/package-export-catalogs.test.ts -t "Fetch adapter" --reporter=verbose`
- `cd ts && npx vitest run tests/package-boundaries.test.ts tests/package-topology.test.ts --reporter=verbose --testTimeout=30000`
  - Local note: these package-build boundary cases run near Vitest's default 5s per-test budget in this environment.
- `cd ts && npx tsc -p tests/tsconfig.json --noEmit --pretty false`
- `cd ts && npm run lint -- --pretty false`
- `cd ts && npm run build`
- `cd ts && node --input-type=module - <<'EOF' ... Fetch API reference export smoke ... EOF`
- `git diff --check origin/main...HEAD && git diff --check`

Closes AC-810
