### PR TITLE
AC-815 Add Fetch adapter troubleshooting guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - [Fetch host capability manifest examples](fetch-host-capability-manifest.md)
 - [Generated Fetch packaging guide](generated-fetch-packaging.md)
 - [Fetch conformance guide](fetch-conformance.md)
+- [Fetch adapter troubleshooting guide](fetch-troubleshooting.md)
 - [Flue-inspired runtime decisions](flue-influences.md)
 - [Scenario parity matrix — Python & TypeScript](scenario-parity-matrix.md)
 - [Browser exploration contract](browser-exploration-contract.md)

--- a/docs/fetch-api-reference.md
+++ b/docs/fetch-api-reference.md
@@ -142,9 +142,10 @@ cases; one-shot runners execute the same cases without assuming a test runner.
 | `runAgentAppFetchInvocationConformance`                | One-shot invocation wrapper runner.  |
 
 See [`fetch-conformance.md`](fetch-conformance.md) for case details, failure
-modes, and runner examples, and
-`ts/examples/fetch-conformance-host-wrapper.ts` for a typed executable wrapper
-example.
+modes, and runner examples,
+[`fetch-troubleshooting.md`](fetch-troubleshooting.md) for common host wiring
+failures, and `ts/examples/fetch-conformance-host-wrapper.ts` for a typed
+executable wrapper example.
 
 ## Generated Entrypoint Contract
 
@@ -183,4 +184,6 @@ The Fetch adapter remains a generic OSS seam:
 
 For packaging guidance, see
 [`generated-fetch-packaging.md`](generated-fetch-packaging.md). For wrapper and
-store verification, see [`fetch-conformance.md`](fetch-conformance.md).
+store verification, see [`fetch-conformance.md`](fetch-conformance.md). For
+common host wiring failures, see
+[`fetch-troubleshooting.md`](fetch-troubleshooting.md).

--- a/docs/fetch-conformance.md
+++ b/docs/fetch-conformance.md
@@ -7,7 +7,9 @@ a generated `fetch` handler. See the
 surface. The helpers are framework-agnostic: each case is an async function with
 a stable name, and each one-shot runner executes the same cases without assuming
 a test framework. See `ts/examples/fetch-conformance-host-wrapper.ts` for a
-minimal executable host-wrapper example.
+minimal executable host-wrapper example and
+[`fetch-troubleshooting.md`](fetch-troubleshooting.md) for common host wiring
+failures.
 
 ## Runner-Agnostic Usage
 
@@ -140,7 +142,9 @@ entrypoint or wrapper:
 
 ## Failure Modes
 
-Common conformance failures usually indicate a contract mismatch:
+Common conformance failures usually indicate a contract mismatch. For a shorter
+symptom-to-fix checklist, see
+[`fetch-troubleshooting.md`](fetch-troubleshooting.md).
 
 | Failure                                            | Likely cause                                            | Expected fix                                                        |
 | -------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------- |

--- a/docs/fetch-troubleshooting.md
+++ b/docs/fetch-troubleshooting.md
@@ -1,0 +1,99 @@
+# Fetch Adapter Troubleshooting
+
+Use this guide when a generic Fetch/ESM host wires a generated AutoContext
+entrypoint but manifest, invocation, store, or runtime-factory behavior is not
+what the host expected. The fix is usually to pass the explicit host capability
+through unchanged, then run the conformance case that covers it.
+
+## Runtime Factory Selection Fails
+
+Symptom: `runtimeFactoryName` is set, but invocation fails before the agent
+prompt runs.
+
+Check that the handler receives all three named-factory capabilities together:
+
+- `runtimeFactoryName`
+- `runtimeFactoryPlan`
+- `runtimeFactoryModuleMap`
+
+`runtimeFactoryName` is only a selector. The plan names the allowed factories,
+and the module map resolves the selected factory from a static bundler-visible
+map. Do not resolve named factories from ambient state or request-time discovery.
+
+## Direct Runtime Capability Wins Unexpectedly
+
+Symptom: a bundled named factory exists, but prompts use a different runtime.
+
+The precedence is intentional:
+
+1. direct `runtime`
+2. direct `runtimeFactory`
+3. selected `runtimeFactoryName`
+
+Remove the direct `runtime` or `runtimeFactory` capability if the host wants the
+named bundled factory to run. Keep this order in wrappers too; it is covered by
+`createAgentAppFetchInvocationConformanceCases`.
+
+## Wrapper Drops Host Stores
+
+Symptom: an agent reads or writes a workspace file during one request, but host
+store telemetry shows no calls, or session events do not persist.
+
+Forward the exact supplied stores:
+
+- `workspaceStore` for virtual workspace files and directories;
+- `sessionEventStore` for runtime-session event append/replay.
+
+Do not replace them with hidden request-local stores in wrapper code. Run
+`createAgentAppFetchWorkspaceStoreConformanceCases`,
+`createAgentAppFetchSessionEventStoreConformanceCases`, and
+`createAgentAppFetchInvocationConformanceCases` against the wrapper. The
+invocation suite includes sentinel store checks that fail when a wrapper drops
+`workspaceStore`.
+
+## Manifest Or Schema Drift
+
+Symptom: a host accepts a generated package, but its routes or accepted
+capability keys differ from the Fetch adapter contract.
+
+Validate the manifest JSON with `agentAppFetchHostCapabilityManifestSchema` and
+compare accepted capabilities against the generated artifact. The manifest should
+advertise `GET /manifest`, `GET /agents`, and `POST /agents/:agent/invoke`, plus
+canonical accepted capability keys including `runtimeFactoryPlan` and
+`runtimeFactoryModuleMap`.
+
+If validation fails, regenerate the manifest from the same catalog plan that
+produced the entrypoint. Do not hand-edit generated manifest files.
+
+## Named Factory Loads Too Early
+
+Symptom: factory module load counters change during handler creation or manifest
+requests.
+
+Named factories should load lazily on first runtime prompt/revise use, not while
+creating the handler and not during `GET /manifest` or `GET /agents`. Keep the
+runtime factory module map static, but call the selected factory only through the
+lazy runtime wrapper. The invocation conformance suite checks this behavior.
+
+## Provider Assumptions Leak Into Generic Fetch
+
+Symptom: a generated Fetch package needs a platform binding, deployment file, or
+ambient module lookup before it can answer generic `Request` objects.
+
+Move that code into host-owned adapter code. The generated Fetch entrypoint
+should stay provider-neutral: static catalogs and module maps in, explicit host
+capabilities in, `Request` to `Response` out. Storage adapters, routing policy,
+secrets, and deployment descriptors belong outside the generated generic Fetch
+artifact.
+
+## Quick Checks
+
+- Read [`fetch-api-reference.md`](fetch-api-reference.md) for accepted host
+  capability keys and route shapes.
+- Validate generated manifests with `agentAppFetchHostCapabilityManifestSchema`.
+- Run [`fetch-conformance.md`](fetch-conformance.md) suites before exposing a
+  wrapper.
+- Use `ts/examples/fetch-conformance-host-wrapper.ts` as the smallest executable
+  conformance wiring example.
+- If runtime factory behavior is confusing, test direct `runtime`, direct
+  `runtimeFactory`, then `runtimeFactoryName` separately.

--- a/docs/generated-fetch-packaging.md
+++ b/docs/generated-fetch-packaging.md
@@ -12,7 +12,8 @@ shown in `ts/examples/generated-fetch-runtime-factory-packaging.ts`. See the
 surface and [`Fetch host capability manifest examples`](fetch-host-capability-manifest.md)
 for manifest validation. After packaging, use the
 [`Fetch conformance guide`](fetch-conformance.md) to verify host-owned wrappers
-and stores before exposing the generated handler.
+and stores before exposing the generated handler. If host wiring fails, see
+[`Fetch adapter troubleshooting`](fetch-troubleshooting.md).
 
 ## Inputs
 
@@ -113,4 +114,5 @@ host wiring before exposing the generated `fetch` handler. See
 [`fetch-host-capability-manifest.md`](fetch-host-capability-manifest.md) for a
 provider-neutral validation example, then use [`fetch-conformance.md`](fetch-conformance.md)
 to run the workspace store, session event-store, and invocation checks against
-host-created capabilities.
+host-created capabilities. Use [`fetch-troubleshooting.md`](fetch-troubleshooting.md)
+for common runtime-factory, manifest, and wrapper wiring failures.

--- a/ts/README.md
+++ b/ts/README.md
@@ -248,9 +248,10 @@ the exported API surface,
 [`docs/fetch-host-capability-manifest.md`](../docs/fetch-host-capability-manifest.md)
 for manifest validation examples,
 [`docs/generated-fetch-packaging.md`](../docs/generated-fetch-packaging.md),
+[`docs/fetch-troubleshooting.md`](../docs/fetch-troubleshooting.md),
 [`examples/generated-fetch-packaging.ts`](examples/generated-fetch-packaging.ts),
 and [`examples/generated-fetch-runtime-factory-packaging.ts`](examples/generated-fetch-runtime-factory-packaging.ts)
-for generic Fetch/ESM packaging examples.
+for generic Fetch/ESM packaging examples and common host wiring fixes.
 
 Runtime-backed Fetch handlers can receive an explicit edge-safe session event
 store. The store appends idempotently by `eventId`, replays by per-session
@@ -317,7 +318,9 @@ describe("host Fetch invocation", () => {
 ```
 
 See [`docs/fetch-conformance.md`](../docs/fetch-conformance.md) for the full
-runner-agnostic conformance guide and
+runner-agnostic conformance guide,
+[`docs/fetch-troubleshooting.md`](../docs/fetch-troubleshooting.md) for common
+host wiring failures, and
 [`examples/fetch-conformance-host-wrapper.ts`](examples/fetch-conformance-host-wrapper.ts)
 for a typed executable wrapper example. See
 [`docs/edge-runtime-compatibility.md`](../docs/edge-runtime-compatibility.md) and

--- a/ts/tests/agent-app-fetch-troubleshooting-docs.test.ts
+++ b/ts/tests/agent-app-fetch-troubleshooting-docs.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = join(import.meta.dirname, "..", "..");
 const troubleshootingDocPath = join(repoRoot, "docs", "fetch-troubleshooting.md");
+const docsIndexPath = join(repoRoot, "docs", "README.md");
 const apiReferencePath = join(repoRoot, "docs", "fetch-api-reference.md");
 const conformanceDocPath = join(repoRoot, "docs", "fetch-conformance.md");
 const packagingDocPath = join(repoRoot, "docs", "generated-fetch-packaging.md");
@@ -52,7 +53,13 @@ describe("Fetch troubleshooting documentation", () => {
   });
 
   it("links the troubleshooting guide from related Fetch docs", () => {
-    for (const path of [apiReferencePath, conformanceDocPath, packagingDocPath, tsReadmePath]) {
+    for (const path of [
+      docsIndexPath,
+      apiReferencePath,
+      conformanceDocPath,
+      packagingDocPath,
+      tsReadmePath,
+    ]) {
       expect(readFileSync(path, "utf-8")).toContain("fetch-troubleshooting.md");
     }
   });

--- a/ts/tests/agent-app-fetch-troubleshooting-docs.test.ts
+++ b/ts/tests/agent-app-fetch-troubleshooting-docs.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(import.meta.dirname, "..", "..");
+const troubleshootingDocPath = join(repoRoot, "docs", "fetch-troubleshooting.md");
+const apiReferencePath = join(repoRoot, "docs", "fetch-api-reference.md");
+const conformanceDocPath = join(repoRoot, "docs", "fetch-conformance.md");
+const packagingDocPath = join(repoRoot, "docs", "generated-fetch-packaging.md");
+const tsReadmePath = join(repoRoot, "ts", "README.md");
+
+const REQUIRED_SECTIONS = [
+  "# Fetch Adapter Troubleshooting",
+  "## Runtime Factory Selection Fails",
+  "## Direct Runtime Capability Wins Unexpectedly",
+  "## Wrapper Drops Host Stores",
+  "## Manifest Or Schema Drift",
+  "## Named Factory Loads Too Early",
+  "## Provider Assumptions Leak Into Generic Fetch",
+  "## Quick Checks",
+] as const;
+
+const REQUIRED_TERMS = [
+  "runtimeFactoryName",
+  "runtimeFactoryPlan",
+  "runtimeFactoryModuleMap",
+  "runtime",
+  "runtimeFactory",
+  "workspaceStore",
+  "sessionEventStore",
+  "agentAppFetchHostCapabilityManifestSchema",
+  "createAgentAppFetchInvocationConformanceCases",
+  "createAgentAppFetchWorkspaceStoreConformanceCases",
+  "createAgentAppFetchSessionEventStoreConformanceCases",
+  "fetch-conformance.md",
+] as const;
+
+const PROVIDER_OR_HOSTED_BOUNDARY_TERMS =
+  /wrangler|cloudflare|vercel|deno deploy|durable object|r2 bucket|s3|tenant|billing|secret broker|warm pool|hosted orchestration/i;
+
+describe("Fetch troubleshooting documentation", () => {
+  it("documents common generic Fetch host wiring failures", () => {
+    const doc = readFileSync(troubleshootingDocPath, "utf-8");
+
+    for (const section of REQUIRED_SECTIONS) {
+      expect(doc).toContain(section);
+    }
+    for (const term of REQUIRED_TERMS) {
+      expect(doc).toContain(term);
+    }
+  });
+
+  it("links the troubleshooting guide from related Fetch docs", () => {
+    for (const path of [apiReferencePath, conformanceDocPath, packagingDocPath, tsReadmePath]) {
+      expect(readFileSync(path, "utf-8")).toContain("fetch-troubleshooting.md");
+    }
+  });
+
+  it("keeps troubleshooting guidance generic and provider-neutral", () => {
+    const doc = readFileSync(troubleshootingDocPath, "utf-8");
+
+    expect(doc).not.toContain("process.env");
+    expect(doc).not.toContain("discoverAutoctxAgents");
+    expect(doc).not.toContain("fs.readdir");
+    expect(doc).not.toMatch(PROVIDER_OR_HOSTED_BOUNDARY_TERMS);
+  });
+});

--- a/ts/tests/tsconfig.json
+++ b/ts/tests/tsconfig.json
@@ -21,6 +21,7 @@
     "agent-app-fetch-runtime-factory-packaging-example.test.ts",
     "agent-app-fetch-session-event-store.test.ts",
     "agent-app-fetch-store-conformance.test.ts",
+    "agent-app-fetch-troubleshooting-docs.test.ts",
     "agent-app-fetch-workspace-store.test.ts",
     "background-session-*.test.ts",
     "sandbox-adapter-contracts.test.ts",


### PR DESCRIPTION
## Summary

- Add `docs/fetch-troubleshooting.md`, a provider-neutral symptom-to-fix guide for generic Fetch host wiring failures.
- Cover runtime-factory selector requirements, direct runtime precedence, dropped host stores, manifest/schema drift, eager named-factory loading, and generic Fetch boundary leaks.
- Link the guide from the Fetch API reference, conformance guide, generated packaging guide, and TypeScript README.
- Add regression tests for content, links, and provider-neutral boundaries.

## Note

AC-814 already exists for a separate simplicity-mode issue, so this slice is AC-815.

## Boundaries

- Docs/tests only.
- Generic Fetch/ESM only.
- No provider SDKs, deployment configuration, storage bindings, hosted orchestration, fleet scheduling, tenant policy, billing, secret brokering, warming behavior, ambient env/module lookup, or runtime filesystem discovery.

## Verification

- `cd ts && npx vitest run tests/agent-app-fetch-troubleshooting-docs.test.ts --reporter=verbose` (red before docs/links existed; green after implementation)
- `cd ts && npx vitest run tests/agent-app-fetch-troubleshooting-docs.test.ts tests/agent-app-fetch-api-reference-docs.test.ts tests/agent-app-fetch-conformance-docs.test.ts tests/agent-app-fetch-packaging-docs.test.ts --reporter=verbose`
- `cd ts && npx vitest run tests/agent-app-fetch-*.test.ts --reporter=verbose`
- `cd ts && npx vitest run tests/package-export-catalogs.test.ts -t "Fetch adapter" --reporter=verbose`
- `cd ts && npx vitest run tests/package-boundaries.test.ts tests/package-topology.test.ts --reporter=verbose --testTimeout=30000`
- `cd ts && npx tsc -p tests/tsconfig.json --noEmit --pretty false`
- `cd ts && npm run lint -- --pretty false`
- `cd ts && npm run build`
- `git diff --check origin/main...HEAD && git diff --check`

Closes AC-815
