### PR TITLE
AC-817 prepare 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-16
+
 ### Added
 
 - Recursive loop: the MLX agent provider auto-resolves the model the harness trained. When `AUTOCONTEXT_AGENT_PROVIDER=mlx` and no explicit `AUTOCONTEXT_MLX_MODEL_PATH` is set, `build_client_from_settings` now looks up the active MLX model in the model registry for the scenario (training auto-activates published models), so a run uses the local model a prior run produced and activated. Mirrors the existing `pi` handoff resolution. An explicit `AUTOCONTEXT_MLX_MODEL_PATH` still takes precedence; only `mlx`-backend full checkpoints (servable by `MLXProvider`) are resolved; a clear error is raised when neither a path nor an active model is available.
@@ -512,7 +514,9 @@ A new cross-runtime parity audit (`test_cli_contract_parity.py` + `cli-contract-
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
-[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.5.0...HEAD
+[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.7.0...HEAD
+[0.7.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.6.0...py-v0.7.0
+[0.6.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.5.0...py-v0.6.0
 [0.5.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.9...py-v0.5.0
 [0.4.9]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.8...py-v0.4.9
 [0.4.8]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.7...py-v0.4.8

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ autocontext is a harness. You point it at a goal in plain language. It iterates 
 The fastest path uses our **Pi runtime**, a local coding agent that handles its own auth. No API key plumbing, no provider config: install Pi, install autocontext, point one at the other.
 
 ```bash
-uv tool install autocontext==0.6.0
+uv tool install autocontext==0.7.0
 
 AUTOCONTEXT_AGENT_PROVIDER=pi \
 AUTOCONTEXT_PI_COMMAND=pi \
@@ -42,7 +42,7 @@ Pi runs locally as a subprocess and emits live traces back into the harness. For
 Prefer TypeScript? Same surface, same command:
 
 ```bash
-bun add -g autoctx@0.6.0
+bun add -g autoctx@0.7.0
 AUTOCONTEXT_AGENT_PROVIDER=pi bunx autoctx solve \
   "improve customer-support replies for billing disputes" \
   --iterations 5 --json
@@ -68,7 +68,7 @@ If you already work inside a coding agent, you can wire autocontext in once and 
 pi install npm:pi-autocontext@0.2.5
 ```
 
-Pi is on a separate package line: `pi-autocontext@0.2.5` currently depends on `autoctx@^0.5.1`. Use it for the current Pi tools/skills, and use `autocontext==0.6.0` or `autoctx@0.6.0` directly when you need the 0.6 runtime features until the next Pi extension release updates its bundled TypeScript dependency.
+Pi is on a separate package line: `pi-autocontext@0.2.5` currently depends on `autoctx@^0.5.1`. Use it for the current Pi tools/skills, and use `autocontext==0.7.0` or `autoctx@0.7.0` directly when you need the 0.7 runtime features until the next Pi extension release updates its bundled TypeScript dependency.
 
 Then you just ask:
 
@@ -217,16 +217,13 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 ```
 
 <!-- autocontext-whats-new:start -->
-## What's New in 0.6.0
+## What's New in 0.7.0
 
-- **CLI contract parity** aligns the Python and TypeScript `autoctx` command surfaces around the shared canonical contract, including capabilities, mission lifecycle commands, queue commands, scenario creation, serve/MCP paths, show/watch, status behavior, and aliases.
-- **Contract probes** add terminal, directory, service, artifact, cleanup, media, and distributed probe families, plus `autoctx probes check` and `autoctx probes extract` for harness verification.
-- **Mission checkpoints** now share a cross-runtime checkpoint contract with collision-free filenames, camelCase/snake_case loader interop, atomic restore behavior, and async-boundary guards.
+- **Agent app/runtime foundations** add OSS contracts for child background sessions, sandbox adapters, session outcomes, and trust boundaries while keeping hosted orchestration out of the public package.
+- **TypeScript agent app packaging** adds Node and Fetch/edge build targets, capability manifests, runtime factories, conformance checks, examples, and troubleshooting docs.
+- **Training/runtime improvements** include TRL/OPD/R1 backend work, GRPO fixes, MLX serving handoff improvements, trace-gate review fixes, and local server read/write endpoints.
+- **Experimental simplicity mode** adds opt-in guide-only minimal-output prompt guidance across Python CLI solve/improve and shared app settings.
 <!-- autocontext-whats-new:end -->
-
-## On main (unreleased)
-
-- **Training pipeline work** adds opt-in teacher-reasoning distillation, sampling controls, MLX-LM fine-tuning, score-conditioned generation, reward-weighted loss, and self-improving local-training loops. These features are on `main` and in [CHANGELOG.md](CHANGELOG.md), but they are not included in the pinned `0.6.0` packages yet.
 
 ## Choose Your Package
 
@@ -240,17 +237,17 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 
 ```bash
 # Python: library or CLI tool
-uv pip install autocontext==0.6.0
-uv tool install autocontext==0.6.0
+uv pip install autocontext==0.7.0
+uv tool install autocontext==0.7.0
 
 # TypeScript
-bun add -g autoctx@0.6.0
+bun add -g autoctx@0.7.0
 
 # Pi extension
 pi install npm:pi-autocontext@0.2.5
 ```
 
-> The PyPI package is `autocontext`. The CLI entrypoint is `autoctx`. The npm packages are `autoctx` and `pi-autocontext` (note: an unrelated package on npm uses the name `autocontext`; that is not this project). `pi-autocontext@0.2.5` currently depends on `autoctx@^0.5.1`; it remains the current Pi extension package, but it does not bundle `autoctx@0.6.0` until the next Pi package release.
+> The PyPI package is `autocontext`. The CLI entrypoint is `autoctx`. The npm packages are `autoctx` and `pi-autocontext` (note: an unrelated package on npm uses the name `autocontext`; that is not this project). `pi-autocontext@0.2.5` currently depends on `autoctx@^0.5.1`; it remains the current Pi extension package, but it does not bundle `autoctx@0.7.0` until the next Pi package release.
 
 ## Surfaces
 

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -10,7 +10,7 @@ The intended use is to hand the harness a real task in plain language, let it so
 pip install autocontext
 ```
 
-The current PyPI release line is `autocontext==0.6.0`.
+The current PyPI release line is `autocontext==0.7.0`.
 The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
 
 ## Working Directory

--- a/autocontext/assets/whats_new.txt
+++ b/autocontext/assets/whats_new.txt
@@ -1,3 +1,4 @@
-**CLI contract parity** aligns the Python and TypeScript `autoctx` command surfaces around the shared canonical contract, including capabilities, mission lifecycle commands, queue commands, scenario creation, serve/MCP paths, show/watch, status behavior, and aliases.
-**Contract probes** add terminal, directory, service, artifact, cleanup, media, and distributed probe families, plus `autoctx probes check` and `autoctx probes extract` for harness verification.
-**Mission checkpoints** now share a cross-runtime checkpoint contract with collision-free filenames, camelCase/snake_case loader interop, atomic restore behavior, and async-boundary guards.
+**Agent app/runtime foundations** add OSS contracts for child background sessions, sandbox adapters, session outcomes, and trust boundaries while keeping hosted orchestration out of the public package.
+**TypeScript agent app packaging** adds Node and Fetch/edge build targets, capability manifests, runtime factories, conformance checks, examples, and troubleshooting docs.
+**Training/runtime improvements** include TRL/OPD/R1 backend work, GRPO fixes, MLX serving handoff improvements, trace-gate review fixes, and local server read/write endpoints.
+**Experimental simplicity mode** adds opt-in guide-only minimal-output prompt guidance across Python CLI solve/improve and shared app settings.

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autocontext"
-version = "0.6.0"
+version = "0.7.0"
 description = "autocontext control plane for iterative strategy evolution."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/autocontext/src/autocontext/__init__.py
+++ b/autocontext/src/autocontext/__init__.py
@@ -5,4 +5,4 @@ from autocontext.sdk import AutoContext
 
 __all__ = ["AutoContext", "ExtensionAPI", "HookBus", "HookEvents", "HookResult", "__version__"]
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/autocontext/src/autocontext/banner.py
+++ b/autocontext/src/autocontext/banner.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from html import escape as html_escape
-from importlib import resources
+from importlib import import_module, resources
 from pathlib import Path
 from xml.sax.saxutils import escape as xml_escape
 
@@ -22,7 +22,7 @@ SYNC_BLOCK_START = "<!-- autocontext-readme-hero:start -->"
 SYNC_BLOCK_END = "<!-- autocontext-readme-hero:end -->"
 WHATS_NEW_BLOCK_START = "<!-- autocontext-whats-new:start -->"
 WHATS_NEW_BLOCK_END = "<!-- autocontext-whats-new:end -->"
-README_WHATS_NEW_HEADING = "What's New in 0.6.0"
+README_WHATS_NEW_HEADING = "What's New in 0.7.0"
 FALLBACK_BANNER_ART = "autocontext"
 README_WORDMARK_DARK_PATH = "autocontext/assets/autocontext-wordmark-dark.svg"
 README_WORDMARK_LIGHT_PATH = "autocontext/assets/autocontext-wordmark.svg"
@@ -143,12 +143,15 @@ def banner_plain() -> str:
 
 def print_banner_rich() -> None:
     """Print the banner with Rich styling to the terminal."""
-    from rich.console import Console
-    from rich.panel import Panel
-    from rich.text import Text
+    try:
+        Console = import_module("rich.console").Console
+        Panel = import_module("rich.panel").Panel
+        Text = import_module("rich.text").Text
+    except ImportError:
+        print(banner_plain())
+        return
 
-    from autocontext import __version__
-
+    version = getattr(import_module("autocontext"), "__version__", "unknown")
     console = Console(stderr=True)
 
     art = Text(load_banner_art())
@@ -170,7 +173,7 @@ def print_banner_rich() -> None:
 
         panel = Panel(
             lines,
-            title=f"[bold]What's new in v{__version__}[/bold]",
+            title=f"[bold]What's new in v{version}[/bold]",
             title_align="left",
             border_style="dim",
             padding=(0, 1),

--- a/autocontext/uv.lock
+++ b/autocontext/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "autocontext"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/ts/README.md
+++ b/ts/README.md
@@ -362,7 +362,7 @@ export function register(api) {
 npm install autoctx
 ```
 
-The current npm release line is `autoctx@0.6.0`.
+The current npm release line is `autoctx@0.7.0`.
 Important: use `autoctx`, not `autocontext`.
 `autocontext` on npm is a different package and not this project.
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoctx",
-  "version": "0.5.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoctx",
-      "version": "0.5.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoctx",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "autocontext — always-on agent evaluation harness",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- bump Python `autocontext` and TypeScript `autoctx` package metadata to 0.7.0
- move current changelog entries under the 0.7.0 release header and refresh compare links
- update public README install pins and release highlights
- leave `pi-autocontext` on its existing 0.2.5 line

## Validation

- `cd autocontext && uv build`
- `cd autocontext && uv run ruff check src tests`
- `cd autocontext && uv run mypy src/autocontext/config/settings.py src/autocontext/simplicity.py`
- `cd autocontext && uv run pytest tests/test_app_settings_contract.py tests/test_simplicity_mode.py tests/test_package_topology.py tests/test_package_boundaries.py -q`
- `cd ts && npm ci --no-audit`
- `cd ts && npm run build`
- `cd ts && npm test -- --run tests/app-settings-contract.test.ts tests/package-boundaries.test.ts tests/agent-app-fetch-invocation-conformance.test.ts`
- `cd ts && npm pack --dry-run`

Note: full local `npm test` is not the CI gate and still has pre-existing non-release failures in stale CLI/status, type-assertion budget, runtime-child-task event ordering, and a package-boundaries timeout under full-suite load.

Linear: AC-817
