### PR TITLE
AC-819 prepare pi-autocontext 0.2.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [pi-v0.2.6] - 2026-06-16
+
+### Changed
+
+- Pi `pi-autocontext` package metadata is bumped to `0.2.6`, and its `autoctx` dependency now requires the published `^0.7.0` line.
+
 ## [0.7.0] - 2026-06-16
 
 ### Added
@@ -514,7 +520,8 @@ A new cross-runtime parity audit (`test_cli_contract_parity.py` + `cli-contract-
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
-[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.7.0...HEAD
+[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/pi-v0.2.6...HEAD
+[pi-v0.2.6]: https://github.com/greyhaven-ai/autocontext/compare/v0.7.0...pi-v0.2.6
 [0.7.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.6.0...py-v0.7.0
 [0.6.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.5.0...py-v0.6.0
 [0.5.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.4.9...py-v0.5.0

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ If you already work inside a coding agent, you can wire autocontext in once and 
 **Pi** ships an autocontext skill out of the box. Install the published Pi package and Pi loads natural-language wrappers over live tools such as `autocontext_solve_scenario`, `autocontext_evaluate_output`, `autocontext_run_improvement_loop`, `autocontext_run_status`, and `autocontext_list_scenarios`.
 
 ```bash
-pi install npm:pi-autocontext@0.2.5
+pi install npm:pi-autocontext@0.2.6
 ```
 
-Pi is on a separate package line: `pi-autocontext@0.2.5` currently depends on `autoctx@^0.5.1`. Use it for the current Pi tools/skills, and use `autocontext==0.7.0` or `autoctx@0.7.0` directly when you need the 0.7 runtime features until the next Pi extension release updates its bundled TypeScript dependency.
+Pi is on a separate package line: `pi-autocontext@0.2.6` now depends on `autoctx@^0.7.0`, matching the current Python and TypeScript 0.7 runtime line.
 
 Then you just ask:
 
@@ -244,10 +244,10 @@ uv tool install autocontext==0.7.0
 bun add -g autoctx@0.7.0
 
 # Pi extension
-pi install npm:pi-autocontext@0.2.5
+pi install npm:pi-autocontext@0.2.6
 ```
 
-> The PyPI package is `autocontext`. The CLI entrypoint is `autoctx`. The npm packages are `autoctx` and `pi-autocontext` (note: an unrelated package on npm uses the name `autocontext`; that is not this project). `pi-autocontext@0.2.5` currently depends on `autoctx@^0.5.1`; it remains the current Pi extension package, but it does not bundle `autoctx@0.7.0` until the next Pi package release.
+> The PyPI package is `autocontext`. The CLI entrypoint is `autoctx`. The npm packages are `autoctx` and `pi-autocontext` (note: an unrelated package on npm uses the name `autocontext`; that is not this project). `pi-autocontext@0.2.6` depends on `autoctx@^0.7.0`, matching the current TypeScript runtime line.
 
 ## Surfaces
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -5,16 +5,16 @@ autocontext extension for [Pi coding agent](https://github.com/earendil-works/pi
 ## Install
 
 ```bash
-pi install npm:pi-autocontext@0.2.5
+pi install npm:pi-autocontext@0.2.6
 ```
 
-Current package note: `pi-autocontext@0.2.5` is on a separate Pi extension line and currently depends on `autoctx@^0.5.1`. Use it for Pi tools/skills, and install `autocontext==0.6.0` or `autoctx@0.6.0` directly when you need 0.6 runtime features until the next Pi extension release updates its bundled TypeScript dependency.
+Current package note: `pi-autocontext@0.2.6` is on a separate Pi extension line and depends on `autoctx@^0.7.0`, matching the current Python and TypeScript 0.7 runtime line.
 
 Or add to your project's `.pi/settings.json`:
 
 ```json
 {
-  "packages": ["npm:pi-autocontext@0.2.5"]
+  "packages": ["npm:pi-autocontext@0.2.6"]
 }
 ```
 

--- a/pi/package-lock.json
+++ b/pi/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "pi-autocontext",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-autocontext",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
-        "autoctx": "^0.5.1"
+        "autoctx": "^0.7.0"
       },
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.74.0",
@@ -2583,9 +2583,9 @@
       }
     },
     "node_modules/autoctx": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/autoctx/-/autoctx-0.5.1.tgz",
-      "integrity": "sha512-8YByczMJASyrJpuw55inyMEmg5qRDO67nPQ6oDeF1bR3Wc8PH9ChYYmfOaDYu3fvFMwXa4uOz0svSGxINhSkSw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/autoctx/-/autoctx-0.7.0.tgz",
+      "integrity": "sha512-bo+tBT3rWGYfrOcDIFPq1E7/Bag6yx518tKnsUS39yplAs15AC2P1XG3GEfhhJdsC35J6ROoPefNIdq835AaiQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",

--- a/pi/package.json
+++ b/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-autocontext",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "autocontext extension for Pi coding agent — iterative strategy generation, LLM judging, and evaluation tools",
   "type": "module",
   "keywords": [
@@ -27,7 +27,7 @@
     "typebox": "*"
   },
   "dependencies": {
-    "autoctx": "^0.5.1"
+    "autoctx": "^0.7.0"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.74.0",

--- a/pi/tests/extension.test.ts
+++ b/pi/tests/extension.test.ts
@@ -356,7 +356,7 @@ describe("Package manifest", () => {
 
   it("depends on the current autoctx toolkit line", () => {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-    expect(pkg.dependencies.autoctx).toBe("^0.5.1");
+    expect(pkg.dependencies.autoctx).toBe("^0.7.0");
   });
 });
 


### PR DESCRIPTION
## Summary

- bump `pi-autocontext` to 0.2.6
- update its bundled `autoctx` dependency to `^0.7.0`
- refresh Pi install docs, root README Pi references, lockfile, and manifest pinning test

## Validation

- `cd pi && env npm_config_min_release_age=0 npm_config_before= npm ci --ignore-scripts`
- `cd pi && npm run lint`
- `cd pi && npm test`
- `cd pi && npm run build`
- `cd pi && npm pack --dry-run`

Linear: AC-819
