### PR TITLE
AC-816 dedupe bundle-size checks

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@types/diff": "^7.0.2",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "better-sqlite3": "^11.0.0",
@@ -1021,12 +1020,6 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true
-    },
-    "node_modules/@types/diff": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
-      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
-      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/ts/package.json
+++ b/ts/package.json
@@ -198,7 +198,6 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.90.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@types/diff": "^7.0.2",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "better-sqlite3": "^11.0.0",

--- a/ts/scripts/bundle-size-check.mjs
+++ b/ts/scripts/bundle-size-check.mjs
@@ -1,0 +1,135 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+export const NODE_BUILTINS = [
+  "node:crypto",
+  "node:fs",
+  "node:fs/promises",
+  "node:path",
+  "node:url",
+  "node:os",
+  "node:zlib",
+  "node:child_process",
+  "node:stream",
+  "node:util",
+];
+
+export const NODE_BUILTINS_WITH_ASYNC = ["node:async_hooks", ...NODE_BUILTINS];
+
+export function runDistGzipCheck({ distFile, label, budgetKb }) {
+  const file = join(ROOT, distFile);
+  if (!existsSync(file)) {
+    console.log("SKIP — dist not built yet. Run `npm run build` first.");
+    process.exit(0);
+  }
+
+  const gz = gzipSync(readFileSync(file));
+  const kb = (gz.length / 1024).toFixed(1);
+
+  if (gz.length / 1024 > budgetKb) {
+    console.error(`FAIL — ${label}: ${kb} KB gzipped exceeds budget of ${budgetKb} KB.`);
+    process.exit(1);
+  }
+
+  console.log(`OK — ${label}: ${kb} KB gzipped (under ${budgetKb} KB budget).`);
+}
+
+export async function runEsbuildBundleCheck({
+  entry,
+  budgetBytes,
+  tmpPrefix,
+  consoleHeader = "",
+  reportTitle,
+  reportSeparator,
+  reportFile,
+  external = [],
+  failureDetail = "",
+}) {
+  const args = new Set(process.argv.slice(2));
+  const wantReport = args.has("--report");
+  const wantJson = args.has("--json");
+
+  const tmp = mkdtempSync(join(tmpdir(), tmpPrefix));
+  const outFile = join(tmp, "bundle.js");
+  let metafile;
+
+  try {
+    const { build } = await import("esbuild");
+    const result = await build({
+      entryPoints: [join(ROOT, entry)],
+      bundle: true,
+      platform: "neutral",
+      target: "es2022",
+      format: "esm",
+      minify: true,
+      treeShaking: true,
+      outfile: outFile,
+      metafile: true,
+      logLevel: "silent",
+      external,
+      mainFields: ["module", "main"],
+      conditions: ["import", "default"],
+    });
+    metafile = result.metafile;
+  } catch (err) {
+    console.error("[bundle-size] esbuild failed:", err);
+    process.exit(2);
+  }
+
+  const raw = readFileSync(outFile);
+  const gzipped = gzipSync(raw);
+  rmSync(tmp, { recursive: true, force: true });
+
+  const rawBytes = raw.byteLength;
+  const gzipBytes = gzipped.byteLength;
+  const headroom = budgetBytes - gzipBytes;
+  const overBudget = gzipBytes > budgetBytes;
+
+  if (wantJson) {
+    process.stdout.write(
+      JSON.stringify({ budgetBytes, rawBytes, gzipBytes, headroom, overBudget }) + "\n",
+    );
+  } else {
+    if (consoleHeader) console.log(`[bundle-size] ${consoleHeader}`);
+    console.log(`[bundle-size] raw:      ${rawBytes.toLocaleString()} bytes`);
+    console.log(`[bundle-size] gzipped:  ${gzipBytes.toLocaleString()} bytes`);
+    console.log(`[bundle-size] budget:   ${budgetBytes.toLocaleString()} bytes`);
+    console.log(`[bundle-size] headroom: ${headroom.toLocaleString()} bytes`);
+  }
+
+  if (wantReport) {
+    const topModules = Object.entries(metafile.inputs)
+      .map(([path, info]) => ({ path, bytes: info.bytes }))
+      .sort((a, b) => b.bytes - a.bytes)
+      .slice(0, 20);
+    const lines = [
+      reportTitle,
+      reportSeparator,
+      `raw:      ${rawBytes.toLocaleString()} bytes`,
+      `gzipped:  ${gzipBytes.toLocaleString()} bytes`,
+      `budget:   ${budgetBytes.toLocaleString()} bytes`,
+      `headroom: ${headroom.toLocaleString()} bytes`,
+      "",
+      "top module contributors (raw):",
+      ...topModules.map((m) => `  ${String(m.bytes).padStart(8)}  ${m.path}`),
+      "",
+    ].join("\n");
+    writeFileSync(join(ROOT, reportFile), lines, "utf-8");
+    console.log(`[bundle-size] wrote ${reportFile}`);
+  }
+
+  if (overBudget) {
+    console.error(
+      `[bundle-size] FAIL — ${gzipBytes - budgetBytes} bytes over the ${budgetBytes}-byte budget.${failureDetail}`,
+    );
+    process.exit(1);
+  }
+
+  if (!wantJson) console.log("[bundle-size] OK — within budget.");
+}

--- a/ts/scripts/check-detector-anthropic-python-bundle-size.mjs
+++ b/ts/scripts/check-detector-anthropic-python-bundle-size.mjs
@@ -1,28 +1,7 @@
-/**
- * Bundle-size budget check for autoctx/detectors/anthropic-python.
- * Budget: 15 KB gzipped. Run: node scripts/check-detector-anthropic-python-bundle-size.mjs
- */
-import { gzipSync } from "node:zlib";
-import { readFileSync, existsSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { runDistGzipCheck } from "./bundle-size-check.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const distFile = join(__dirname, "..", "dist", "control-plane", "instrument", "detectors", "anthropic-python", "index.js");
-
-if (!existsSync(distFile)) {
-  console.log("SKIP — dist not built yet. Run `npm run build` first.");
-  process.exit(0);
-}
-
-const raw = readFileSync(distFile);
-const gz = gzipSync(raw);
-const kb = (gz.length / 1024).toFixed(1);
-const budget = 15;
-
-if (gz.length / 1024 > budget) {
-  console.error(`FAIL — detector-anthropic-python: ${kb} KB gzipped exceeds budget of ${budget} KB.`);
-  process.exit(1);
-} else {
-  console.log(`OK — detector-anthropic-python: ${kb} KB gzipped (under ${budget} KB budget).`);
-}
+runDistGzipCheck({
+  distFile: "dist/control-plane/instrument/detectors/anthropic-python/index.js",
+  label: "detector-anthropic-python",
+  budgetKb: 15,
+});

--- a/ts/scripts/check-detector-anthropic-ts-bundle-size.mjs
+++ b/ts/scripts/check-detector-anthropic-ts-bundle-size.mjs
@@ -1,28 +1,7 @@
-/**
- * Bundle-size budget check for autoctx/detectors/anthropic-ts.
- * Budget: 15 KB gzipped. Run: node scripts/check-detector-anthropic-ts-bundle-size.mjs
- */
-import { gzipSync } from "node:zlib";
-import { readFileSync, existsSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { runDistGzipCheck } from "./bundle-size-check.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const distFile = join(__dirname, "..", "dist", "control-plane", "instrument", "detectors", "anthropic-ts", "index.js");
-
-if (!existsSync(distFile)) {
-  console.log("SKIP — dist not built yet. Run `npm run build` first.");
-  process.exit(0);
-}
-
-const raw = readFileSync(distFile);
-const gz = gzipSync(raw);
-const kb = (gz.length / 1024).toFixed(1);
-const budget = 15;
-
-if (gz.length / 1024 > budget) {
-  console.error(`FAIL — detector-anthropic-ts: ${kb} KB gzipped exceeds budget of ${budget} KB.`);
-  process.exit(1);
-} else {
-  console.log(`OK — detector-anthropic-ts: ${kb} KB gzipped (under ${budget} KB budget).`);
-}
+runDistGzipCheck({
+  distFile: "dist/control-plane/instrument/detectors/anthropic-ts/index.js",
+  label: "detector-anthropic-ts",
+  budgetKb: 15,
+});

--- a/ts/scripts/check-detector-openai-python-bundle-size.mjs
+++ b/ts/scripts/check-detector-openai-python-bundle-size.mjs
@@ -1,28 +1,7 @@
-/**
- * Bundle-size budget check for autoctx/detectors/openai-python.
- * Budget: 15 KB gzipped. Run: node scripts/check-detector-openai-python-bundle-size.mjs
- */
-import { gzipSync } from "node:zlib";
-import { readFileSync, existsSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { runDistGzipCheck } from "./bundle-size-check.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const distFile = join(__dirname, "..", "dist", "control-plane", "instrument", "detectors", "openai-python", "index.js");
-
-if (!existsSync(distFile)) {
-  console.log("SKIP — dist not built yet. Run `npm run build` first.");
-  process.exit(0);
-}
-
-const raw = readFileSync(distFile);
-const gz = gzipSync(raw);
-const kb = (gz.length / 1024).toFixed(1);
-const budget = 15;
-
-if (gz.length / 1024 > budget) {
-  console.error(`FAIL — detector-openai-python: ${kb} KB gzipped exceeds budget of ${budget} KB.`);
-  process.exit(1);
-} else {
-  console.log(`OK — detector-openai-python: ${kb} KB gzipped (under ${budget} KB budget).`);
-}
+runDistGzipCheck({
+  distFile: "dist/control-plane/instrument/detectors/openai-python/index.js",
+  label: "detector-openai-python",
+  budgetKb: 15,
+});

--- a/ts/scripts/check-detector-openai-ts-bundle-size.mjs
+++ b/ts/scripts/check-detector-openai-ts-bundle-size.mjs
@@ -1,28 +1,7 @@
-/**
- * Bundle-size budget check for autoctx/detectors/openai-ts.
- * Budget: 15 KB gzipped. Run: node scripts/check-detector-openai-ts-bundle-size.mjs
- */
-import { gzipSync } from "node:zlib";
-import { readFileSync, existsSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { runDistGzipCheck } from "./bundle-size-check.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const distFile = join(__dirname, "..", "dist", "control-plane", "instrument", "detectors", "openai-ts", "index.js");
-
-if (!existsSync(distFile)) {
-  console.log("SKIP — dist not built yet. Run `npm run build` first.");
-  process.exit(0);
-}
-
-const raw = readFileSync(distFile);
-const gz = gzipSync(raw);
-const kb = (gz.length / 1024).toFixed(1);
-const budget = 15;
-
-if (gz.length / 1024 > budget) {
-  console.error(`FAIL — detector-openai-ts: ${kb} KB gzipped exceeds budget of ${budget} KB.`);
-  process.exit(1);
-} else {
-  console.log(`OK — detector-openai-ts: ${kb} KB gzipped (under ${budget} KB budget).`);
-}
+runDistGzipCheck({
+  distFile: "dist/control-plane/instrument/detectors/openai-ts/index.js",
+  label: "detector-openai-ts",
+  budgetKb: 15,
+});

--- a/ts/scripts/check-integrations-anthropic-bundle-size.mjs
+++ b/ts/scripts/check-integrations-anthropic-bundle-size.mjs
@@ -1,141 +1,25 @@
 #!/usr/bin/env node
-/**
- * Bundle-size budget check for `autoctx/integrations/anthropic`.
- *
- * Bundles the subpath entry via esbuild for a browser-ish target with
- * tree-shaking + minification, gzips with zlib default compression, and
- * asserts the result is ≤ BUDGET_BYTES (40 kB gzipped).
- *
- * Runs in CI on PRs touching `integrations/anthropic/**`, `package.json`, or
- * this script itself.
- *
- * Flags:
- *   --report    write `bundle-integrations-anthropic-report.txt` with sizes.
- *   --json      emit a JSON summary on stdout for tooling.
- *
- * Exit 1 on over-budget. Budget bumps are PR decisions.
- */
-import { build } from "esbuild";
-import { gzipSync } from "node:zlib";
-import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { tmpdir } from "node:os";
+/** Bundle-size budget check for `autoctx/integrations/anthropic`. */
+import { NODE_BUILTINS_WITH_ASYNC, runEsbuildBundleCheck } from "./bundle-size-check.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = resolve(__dirname, "..");
-
-const BUDGET_BYTES = 40_960; // 40 kB gzipped ceiling (spec §6.1).
-
-const ENTRY = join(ROOT, "src", "integrations", "anthropic", "index.ts");
-
-const args = new Set(process.argv.slice(2));
-const wantReport = args.has("--report");
-const wantJson = args.has("--json");
-
-const tmp = mkdtempSync(join(tmpdir(), "autoctx-integrations-anthropic-bundle-"));
-const outFile = join(tmp, "bundle.js");
-
-const NODE_BUILTINS = [
-  "node:async_hooks",
-  "node:crypto",
-  "node:fs",
-  "node:fs/promises",
-  "node:path",
-  "node:url",
-  "node:os",
-  "node:zlib",
-  "node:child_process",
-  "node:stream",
-  "node:util",
-];
-
-let metafile;
-try {
-  const result = await build({
-    entryPoints: [ENTRY],
-    bundle: true,
-    platform: "neutral",
-    target: "es2022",
-    format: "esm",
-    minify: true,
-    treeShaking: true,
-    outfile: outFile,
-    metafile: true,
-    logLevel: "silent",
-    // @anthropic-ai/sdk is a peer dep; ajv/ajv-formats/ulid are runtime deps
-    // bundled into autoctx/production-traces and thus always present.
-    external: [
-      ...NODE_BUILTINS,
-      "@anthropic-ai/sdk",
-      "ajv",
-      "ajv/dist/2020.js",
-      "ajv-formats",
-      "ulid",
-    ],
-    mainFields: ["module", "main"],
-    conditions: ["import", "default"],
-  });
-  metafile = result.metafile;
-} catch (err) {
-  console.error("[bundle-size] esbuild failed:", err);
-  process.exit(2);
-}
-
-const raw = readFileSync(outFile);
-const gzipped = gzipSync(raw);
-rmSync(tmp, { recursive: true, force: true });
-
-const rawBytes = raw.byteLength;
-const gzipBytes = gzipped.byteLength;
-const headroom = BUDGET_BYTES - gzipBytes;
-const overBudget = gzipBytes > BUDGET_BYTES;
-
-if (wantJson) {
-  process.stdout.write(
-    JSON.stringify({ budgetBytes: BUDGET_BYTES, rawBytes, gzipBytes, headroom, overBudget }) + "\n",
-  );
-} else {
-  console.log(`[bundle-size] autoctx/integrations/anthropic`);
-  console.log(`[bundle-size] raw:      ${rawBytes.toLocaleString()} bytes`);
-  console.log(`[bundle-size] gzipped:  ${gzipBytes.toLocaleString()} bytes`);
-  console.log(`[bundle-size] budget:   ${BUDGET_BYTES.toLocaleString()} bytes`);
-  console.log(`[bundle-size] headroom: ${headroom.toLocaleString()} bytes`);
-}
-
-if (wantReport) {
-  const topModules = Object.entries(metafile.inputs)
-    .map(([path, info]) => ({ path, bytes: info.bytes }))
-    .sort((a, b) => b.bytes - a.bytes)
-    .slice(0, 20);
-  const lines = [
-    `autoctx/integrations/anthropic bundle report`,
-    `---------------------------------------------`,
-    `raw:      ${rawBytes.toLocaleString()} bytes`,
-    `gzipped:  ${gzipBytes.toLocaleString()} bytes`,
-    `budget:   ${BUDGET_BYTES.toLocaleString()} bytes`,
-    `headroom: ${headroom.toLocaleString()} bytes`,
-    ``,
-    `top module contributors (raw):`,
-    ...topModules.map((m) => `  ${String(m.bytes).padStart(8)}  ${m.path}`),
-    ``,
-  ].join("\n");
-  writeFileSync(
-    join(ROOT, "bundle-integrations-anthropic-report.txt"),
-    lines,
-    "utf-8",
-  );
-  console.log(`[bundle-size] wrote bundle-integrations-anthropic-report.txt`);
-}
-
-if (overBudget) {
-  console.error(
-    `[bundle-size] FAIL — ${gzipBytes - BUDGET_BYTES} bytes over the ${BUDGET_BYTES}-byte budget.\n` +
-      `  Re-run with --report to see the top contributors, or bump BUDGET_BYTES in\n` +
-      `  scripts/check-integrations-anthropic-bundle-size.mjs if the addition is\n` +
-      `  intentional and justified in the PR description.`,
-  );
-  process.exit(1);
-}
-
-if (!wantJson) console.log(`[bundle-size] OK — within budget.`);
+await runEsbuildBundleCheck({
+  entry: "src/integrations/anthropic/index.ts",
+  budgetBytes: 40_960,
+  tmpPrefix: "autoctx-integrations-anthropic-bundle-",
+  consoleHeader: "autoctx/integrations/anthropic",
+  reportTitle: "autoctx/integrations/anthropic bundle report",
+  reportSeparator: "---------------------------------------------",
+  reportFile: "bundle-integrations-anthropic-report.txt",
+  external: [
+    ...NODE_BUILTINS_WITH_ASYNC,
+    "@anthropic-ai/sdk",
+    "ajv",
+    "ajv/dist/2020.js",
+    "ajv-formats",
+    "ulid",
+  ],
+  failureDetail:
+    "\n  Re-run with --report to see the top contributors, or bump BUDGET_BYTES in\n" +
+    "  scripts/check-integrations-anthropic-bundle-size.mjs if the addition is\n" +
+    "  intentional and justified in the PR description.",
+});

--- a/ts/scripts/check-integrations-openai-bundle-size.mjs
+++ b/ts/scripts/check-integrations-openai-bundle-size.mjs
@@ -1,130 +1,25 @@
 #!/usr/bin/env node
-/**
- * Bundle-size budget check for `autoctx/integrations/openai`.
- *
- * Bundles the subpath entry via esbuild for a browser-ish target with
- * tree-shaking + minification, gzips with zlib default compression, and
- * asserts the result is ≤ BUDGET_BYTES (40 kB gzipped).
- *
- * Runs in CI on PRs touching `integrations/openai/**`, `package.json`, or
- * this script itself.
- *
- * Flags:
- *   --report    write `bundle-integrations-openai-report.txt` with sizes.
- *   --json      emit a JSON summary on stdout for tooling.
- *
- * Exit 1 on over-budget. Budget bumps are PR decisions.
- */
-import { build } from "esbuild";
-import { gzipSync } from "node:zlib";
-import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { tmpdir } from "node:os";
+/** Bundle-size budget check for `autoctx/integrations/openai`. */
+import { NODE_BUILTINS_WITH_ASYNC, runEsbuildBundleCheck } from "./bundle-size-check.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = resolve(__dirname, "..");
-
-const BUDGET_BYTES = 40_960; // 40 kB gzipped ceiling (spec §6.1).
-
-const ENTRY = join(ROOT, "src", "integrations", "openai", "index.ts");
-
-const args = new Set(process.argv.slice(2));
-const wantReport = args.has("--report");
-const wantJson = args.has("--json");
-
-const tmp = mkdtempSync(join(tmpdir(), "autoctx-integrations-openai-bundle-"));
-const outFile = join(tmp, "bundle.js");
-
-const NODE_BUILTINS = [
-  "node:async_hooks",
-  "node:crypto",
-  "node:fs",
-  "node:fs/promises",
-  "node:path",
-  "node:url",
-  "node:os",
-  "node:zlib",
-  "node:child_process",
-  "node:stream",
-  "node:util",
-];
-
-let metafile;
-try {
-  const result = await build({
-    entryPoints: [ENTRY],
-    bundle: true,
-    platform: "neutral",
-    target: "es2022",
-    format: "esm",
-    minify: true,
-    treeShaking: true,
-    outfile: outFile,
-    metafile: true,
-    logLevel: "silent",
-    // openai is a peer dep; ajv/ajv-formats/ulid are runtime deps already
-    // bundled into autoctx/production-traces and thus always present.
-    external: [...NODE_BUILTINS, "openai", "ajv", "ajv/dist/2020.js", "ajv-formats", "ulid"],
-    mainFields: ["module", "main"],
-    conditions: ["import", "default"],
-  });
-  metafile = result.metafile;
-} catch (err) {
-  console.error("[bundle-size] esbuild failed:", err);
-  process.exit(2);
-}
-
-const raw = readFileSync(outFile);
-const gzipped = gzipSync(raw);
-rmSync(tmp, { recursive: true, force: true });
-
-const rawBytes = raw.byteLength;
-const gzipBytes = gzipped.byteLength;
-const headroom = BUDGET_BYTES - gzipBytes;
-const overBudget = gzipBytes > BUDGET_BYTES;
-
-if (wantJson) {
-  process.stdout.write(
-    JSON.stringify({ budgetBytes: BUDGET_BYTES, rawBytes, gzipBytes, headroom, overBudget }) + "\n",
-  );
-} else {
-  console.log(`[bundle-size] autoctx/integrations/openai`);
-  console.log(`[bundle-size] raw:      ${rawBytes.toLocaleString()} bytes`);
-  console.log(`[bundle-size] gzipped:  ${gzipBytes.toLocaleString()} bytes`);
-  console.log(`[bundle-size] budget:   ${BUDGET_BYTES.toLocaleString()} bytes`);
-  console.log(`[bundle-size] headroom: ${headroom.toLocaleString()} bytes`);
-}
-
-if (wantReport) {
-  const topModules = Object.entries(metafile.inputs)
-    .map(([path, info]) => ({ path, bytes: info.bytes }))
-    .sort((a, b) => b.bytes - a.bytes)
-    .slice(0, 20);
-  const lines = [
-    `autoctx/integrations/openai bundle report`,
-    `------------------------------------------`,
-    `raw:      ${rawBytes.toLocaleString()} bytes`,
-    `gzipped:  ${gzipBytes.toLocaleString()} bytes`,
-    `budget:   ${BUDGET_BYTES.toLocaleString()} bytes`,
-    `headroom: ${headroom.toLocaleString()} bytes`,
-    ``,
-    `top module contributors (raw):`,
-    ...topModules.map((m) => `  ${String(m.bytes).padStart(8)}  ${m.path}`),
-    ``,
-  ].join("\n");
-  writeFileSync(join(ROOT, "bundle-integrations-openai-report.txt"), lines, "utf-8");
-  console.log(`[bundle-size] wrote bundle-integrations-openai-report.txt`);
-}
-
-if (overBudget) {
-  console.error(
-    `[bundle-size] FAIL — ${gzipBytes - BUDGET_BYTES} bytes over the ${BUDGET_BYTES}-byte budget.\n` +
-      `  Re-run with --report to see the top contributors, or bump BUDGET_BYTES in\n` +
-      `  scripts/check-integrations-openai-bundle-size.mjs if the addition is\n` +
-      `  intentional and justified in the PR description.`,
-  );
-  process.exit(1);
-}
-
-if (!wantJson) console.log(`[bundle-size] OK — within budget.`);
+await runEsbuildBundleCheck({
+  entry: "src/integrations/openai/index.ts",
+  budgetBytes: 40_960,
+  tmpPrefix: "autoctx-integrations-openai-bundle-",
+  consoleHeader: "autoctx/integrations/openai",
+  reportTitle: "autoctx/integrations/openai bundle report",
+  reportSeparator: "------------------------------------------",
+  reportFile: "bundle-integrations-openai-report.txt",
+  external: [
+    ...NODE_BUILTINS_WITH_ASYNC,
+    "openai",
+    "ajv",
+    "ajv/dist/2020.js",
+    "ajv-formats",
+    "ulid",
+  ],
+  failureDetail:
+    "\n  Re-run with --report to see the top contributors, or bump BUDGET_BYTES in\n" +
+    "  scripts/check-integrations-openai-bundle-size.mjs if the addition is\n" +
+    "  intentional and justified in the PR description.",
+});

--- a/ts/scripts/check-integrations-shared-bundle-size.mjs
+++ b/ts/scripts/check-integrations-shared-bundle-size.mjs
@@ -1,118 +1,14 @@
 #!/usr/bin/env node
-/**
- * Bundle-size budget check for `autoctx/integrations/_shared`.
- *
- * Bundles the shared subpath entry (TraceSink / FileSink / autocontextSession)
- * via esbuild with tree-shaking + minification, gzips, and asserts the result
- * is ≤ BUDGET_BYTES.
- *
- * Clone of check-integrations-openai-bundle-size.mjs with path + budget changes.
- */
-import { build } from "esbuild";
-import { gzipSync } from "node:zlib";
-import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { tmpdir } from "node:os";
+/** Bundle-size budget check for `autoctx/integrations/_shared`. */
+import { NODE_BUILTINS_WITH_ASYNC, runEsbuildBundleCheck } from "./bundle-size-check.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = resolve(__dirname, "..");
-
-const BUDGET_BYTES = 15_360; // 15 kB gzipped ceiling.
-
-const ENTRY = join(ROOT, "src", "integrations", "_shared", "index.ts");
-
-const args = new Set(process.argv.slice(2));
-const wantReport = args.has("--report");
-const wantJson = args.has("--json");
-
-const tmp = mkdtempSync(join(tmpdir(), "autoctx-integrations-shared-bundle-"));
-const outFile = join(tmp, "bundle.js");
-
-const NODE_BUILTINS = [
-  "node:async_hooks",
-  "node:crypto",
-  "node:fs",
-  "node:fs/promises",
-  "node:path",
-  "node:url",
-  "node:os",
-  "node:zlib",
-  "node:child_process",
-  "node:stream",
-  "node:util",
-];
-
-let metafile;
-try {
-  const result = await build({
-    entryPoints: [ENTRY],
-    bundle: true,
-    platform: "neutral",
-    target: "es2022",
-    format: "esm",
-    minify: true,
-    treeShaking: true,
-    outfile: outFile,
-    metafile: true,
-    logLevel: "silent",
-    external: [...NODE_BUILTINS],
-    mainFields: ["module", "main"],
-    conditions: ["import", "default"],
-  });
-  metafile = result.metafile;
-} catch (err) {
-  console.error("[bundle-size] esbuild failed:", err);
-  process.exit(2);
-}
-
-const raw = readFileSync(outFile);
-const gzipped = gzipSync(raw);
-rmSync(tmp, { recursive: true, force: true });
-
-const rawBytes = raw.byteLength;
-const gzipBytes = gzipped.byteLength;
-const headroom = BUDGET_BYTES - gzipBytes;
-const overBudget = gzipBytes > BUDGET_BYTES;
-
-if (wantJson) {
-  process.stdout.write(
-    JSON.stringify({ budgetBytes: BUDGET_BYTES, rawBytes, gzipBytes, headroom, overBudget }) + "\n",
-  );
-} else {
-  console.log(`[bundle-size] autoctx/integrations/_shared`);
-  console.log(`[bundle-size] raw:      ${rawBytes.toLocaleString()} bytes`);
-  console.log(`[bundle-size] gzipped:  ${gzipBytes.toLocaleString()} bytes`);
-  console.log(`[bundle-size] budget:   ${BUDGET_BYTES.toLocaleString()} bytes`);
-  console.log(`[bundle-size] headroom: ${headroom.toLocaleString()} bytes`);
-}
-
-if (wantReport) {
-  const topModules = Object.entries(metafile.inputs)
-    .map(([path, info]) => ({ path, bytes: info.bytes }))
-    .sort((a, b) => b.bytes - a.bytes)
-    .slice(0, 20);
-  const lines = [
-    `autoctx/integrations/_shared bundle report`,
-    `------------------------------------------`,
-    `raw:      ${rawBytes.toLocaleString()} bytes`,
-    `gzipped:  ${gzipBytes.toLocaleString()} bytes`,
-    `budget:   ${BUDGET_BYTES.toLocaleString()} bytes`,
-    `headroom: ${headroom.toLocaleString()} bytes`,
-    ``,
-    `top module contributors (raw):`,
-    ...topModules.map((m) => `  ${String(m.bytes).padStart(8)}  ${m.path}`),
-    ``,
-  ].join("\n");
-  writeFileSync(join(ROOT, "bundle-integrations-shared-report.txt"), lines, "utf-8");
-  console.log(`[bundle-size] wrote bundle-integrations-shared-report.txt`);
-}
-
-if (overBudget) {
-  console.error(
-    `[bundle-size] FAIL — ${gzipBytes - BUDGET_BYTES} bytes over the ${BUDGET_BYTES}-byte budget.`,
-  );
-  process.exit(1);
-}
-
-if (!wantJson) console.log(`[bundle-size] OK — within budget.`);
+await runEsbuildBundleCheck({
+  entry: "src/integrations/_shared/index.ts",
+  budgetBytes: 15_360,
+  tmpPrefix: "autoctx-integrations-shared-bundle-",
+  consoleHeader: "autoctx/integrations/_shared",
+  reportTitle: "autoctx/integrations/_shared bundle report",
+  reportSeparator: "------------------------------------------",
+  reportFile: "bundle-integrations-shared-report.txt",
+  external: NODE_BUILTINS_WITH_ASYNC,
+});

--- a/ts/scripts/check-production-traces-sdk-bundle-size.mjs
+++ b/ts/scripts/check-production-traces-sdk-bundle-size.mjs
@@ -1,134 +1,17 @@
 #!/usr/bin/env node
-/**
- * Bundle-size budget check for `autoctx/production-traces`.
- *
- * Bundles the subpath entry via esbuild for a browser-ish target with
- * tree-shaking + minification, gzips with zlib default compression, and
- * asserts the result is ≤ BUDGET_BYTES (100 kB).
- *
- * Runs in CI on PRs touching `production-traces/**`, `package.json`, or
- * this script itself.
- *
- * Flags:
- *   --report    write `bundle-report.txt` with raw/gzipped sizes and top
- *               module contributors.
- *   --json      emit a JSON summary on stdout for tooling.
- *
- * Exit 1 on over-budget with an actionable diff. Budget bumps are PR
- * decisions — edit BUDGET_BYTES with a justification in the PR body.
- */
-import { build } from "esbuild";
-import { gzipSync } from "node:zlib";
-import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { tmpdir } from "node:os";
+/** Bundle-size budget check for `autoctx/production-traces`. */
+import { NODE_BUILTINS, runEsbuildBundleCheck } from "./bundle-size-check.mjs";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = resolve(__dirname, "..");
-
-const BUDGET_BYTES = 102_400; // 100 kB gzipped ceiling (spec §6.1).
-
-const ENTRY = join(ROOT, "src", "production-traces", "sdk", "index.ts");
-
-const args = new Set(process.argv.slice(2));
-const wantReport = args.has("--report");
-const wantJson = args.has("--json");
-
-const tmp = mkdtempSync(join(tmpdir(), "autoctx-sdk-bundle-"));
-const outFile = join(tmp, "bundle.js");
-
-// We measure the SDK *code footprint*: the SDK source plus bundled runtime
-// deps (ajv, ajv-formats, ulid). Node built-ins (`node:crypto`, `node:fs`,
-// etc.) are external — customers bring their own platform polyfills on
-// non-Node runtimes (Cloudflare Workers, Deno, Bun, browser), and
-// bundling the Node types would (a) fail to bundle and (b) over-count
-// against the budget.
-const NODE_BUILTINS = [
-  "node:crypto",
-  "node:fs",
-  "node:fs/promises",
-  "node:path",
-  "node:url",
-  "node:os",
-  "node:zlib",
-  "node:child_process",
-  "node:stream",
-  "node:util",
-];
-
-let metafile;
-try {
-  const result = await build({
-    entryPoints: [ENTRY],
-    bundle: true,
-    platform: "neutral",
-    target: "es2022",
-    format: "esm",
-    minify: true,
-    treeShaking: true,
-    outfile: outFile,
-    metafile: true,
-    logLevel: "silent",
-    external: NODE_BUILTINS,
-    mainFields: ["module", "main"],
-    conditions: ["import", "default"],
-  });
-  metafile = result.metafile;
-} catch (err) {
-  console.error("[bundle-size] esbuild failed:", err);
-  process.exit(2);
-}
-
-const raw = readFileSync(outFile);
-const gzipped = gzipSync(raw);
-rmSync(tmp, { recursive: true, force: true });
-
-const rawBytes = raw.byteLength;
-const gzipBytes = gzipped.byteLength;
-const headroom = BUDGET_BYTES - gzipBytes;
-const overBudget = gzipBytes > BUDGET_BYTES;
-
-if (wantJson) {
-  process.stdout.write(
-    JSON.stringify({ budgetBytes: BUDGET_BYTES, rawBytes, gzipBytes, headroom, overBudget }) + "\n",
-  );
-} else {
-  console.log(`[bundle-size] raw:      ${rawBytes.toLocaleString()} bytes`);
-  console.log(`[bundle-size] gzipped:  ${gzipBytes.toLocaleString()} bytes`);
-  console.log(`[bundle-size] budget:   ${BUDGET_BYTES.toLocaleString()} bytes`);
-  console.log(`[bundle-size] headroom: ${headroom.toLocaleString()} bytes`);
-}
-
-if (wantReport) {
-  const topModules = Object.entries(metafile.inputs)
-    .map(([path, info]) => ({ path, bytes: info.bytes }))
-    .sort((a, b) => b.bytes - a.bytes)
-    .slice(0, 20);
-  const lines = [
-    `autoctx/production-traces bundle report`,
-    `---------------------------------------`,
-    `raw:      ${rawBytes.toLocaleString()} bytes`,
-    `gzipped:  ${gzipBytes.toLocaleString()} bytes`,
-    `budget:   ${BUDGET_BYTES.toLocaleString()} bytes`,
-    `headroom: ${headroom.toLocaleString()} bytes`,
-    ``,
-    `top module contributors (raw):`,
-    ...topModules.map((m) => `  ${String(m.bytes).padStart(8)}  ${m.path}`),
-    ``,
-  ].join("\n");
-  writeFileSync(join(ROOT, "bundle-report.txt"), lines, "utf-8");
-  console.log(`[bundle-size] wrote bundle-report.txt`);
-}
-
-if (overBudget) {
-  console.error(
-    `[bundle-size] FAIL — ${gzipBytes - BUDGET_BYTES} bytes over the ${BUDGET_BYTES}-byte budget.\n` +
-      `  Re-run with --report to see the top contributors, or bump BUDGET_BYTES in\n` +
-      `  scripts/check-production-traces-sdk-bundle-size.mjs if the addition is\n` +
-      `  intentional and justified in the PR description.`,
-  );
-  process.exit(1);
-}
-
-if (!wantJson) console.log(`[bundle-size] OK — within budget.`);
+await runEsbuildBundleCheck({
+  entry: "src/production-traces/sdk/index.ts",
+  budgetBytes: 102_400,
+  tmpPrefix: "autoctx-sdk-bundle-",
+  reportTitle: "autoctx/production-traces bundle report",
+  reportSeparator: "---------------------------------------",
+  reportFile: "bundle-report.txt",
+  external: NODE_BUILTINS,
+  failureDetail:
+    "\n  Re-run with --report to see the top contributors, or bump BUDGET_BYTES in\n" +
+    "  scripts/check-production-traces-sdk-bundle-size.mjs if the addition is\n" +
+    "  intentional and justified in the PR description.",
+});


### PR DESCRIPTION
## Summary

- Add one shared bundle-size check helper and keep existing check script filenames as thin wrappers.
- Preserve bundle budgets, report filenames, JSON output, and existing command entrypoints.
- Remove redundant `@types/diff`; `diff@9.0.0` ships its own types.

Linear: AC-816

## Validation

- `cd ts && npm run lint`
- `cd ts && node scripts/check-production-traces-sdk-bundle-size.mjs --json`
- `cd ts && node scripts/check-integrations-openai-bundle-size.mjs --json`
- `cd ts && node scripts/check-integrations-anthropic-bundle-size.mjs --json`
- `cd ts && node scripts/check-integrations-shared-bundle-size.mjs --json`
- `cd ts && node scripts/check-detector-openai-ts-bundle-size.mjs`
- `cd ts && node scripts/check-detector-openai-python-bundle-size.mjs`
- `cd ts && node scripts/check-detector-anthropic-ts-bundle-size.mjs`
- `cd ts && node scripts/check-detector-anthropic-python-bundle-size.mjs`
- `cd ts && npx vitest run tests/control-plane/actuators/_shared/content-revert-rollback.test.ts tests/control-plane/actuators/_shared/unified-diff-emitter.test.ts tests/control-plane/actuators/fine-tuned-model/fine-tuned-model.test.ts tests/control-plane/actuators/model-routing/applicator.test.ts tests/control-plane/actuators/prompt-patch/prompt-patch.test.ts tests/control-plane/actuators/routing-rule/routing-rule.test.ts tests/control-plane/actuators/tool-policy/tool-policy.test.ts tests/package-boundaries.test.ts tests/scripts/check-license-compatibility.test.ts`

## Note

Full `npm test` was attempted locally and is blocked by local native module ABI mismatch (`isolated-vm` / `better-sqlite3` built for a different Node module version than active Node 23.11.0). Targeted checks for this change pass.
