### PR TITLE
AC-820 add scenario environment contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- AC-820 scenario environment contracts now document and expose reset, rollout, verification, scoring, replay, evidence, and cleanup hooks across Python and TypeScript.
+
 ## [pi-v0.2.6] - 2026-06-16
 
 ### Changed

--- a/autocontext/src/autocontext/scenarios/environment_contract.py
+++ b/autocontext/src/autocontext/scenarios/environment_contract.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, get_args
+
+ScenarioEnvironmentHookKind = Literal[
+    "setup",
+    "reset",
+    "rollout",
+    "verification",
+    "scoring",
+    "replay",
+    "evidence",
+    "cleanup",
+]
+
+HOOK_KINDS = tuple(get_args(ScenarioEnvironmentHookKind))
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioEnvironmentHook:
+    """One callable or reported stage in a scenario environment lifecycle."""
+
+    kind: ScenarioEnvironmentHookKind
+    label: str
+    description: str
+    required: bool = True
+    inputs: list[str] = field(default_factory=list)
+    emits: list[str] = field(default_factory=list)
+    evidence_refs: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.kind not in HOOK_KINDS:
+            raise ValueError(f"unknown scenario environment hook kind: {self.kind}")
+
+    @classmethod
+    def model_validate(cls, data: dict[str, Any]) -> ScenarioEnvironmentHook:
+        _reject_extra(data, {"kind", "label", "description", "required", "inputs", "emits", "evidence_refs"})
+        return cls(
+            kind=data["kind"],
+            label=str(data["label"]),
+            description=str(data["description"]),
+            required=bool(data.get("required", True)),
+            inputs=_list_of_str(data.get("inputs", [])),
+            emits=_list_of_str(data.get("emits", [])),
+            evidence_refs=_list_of_str(data.get("evidence_refs", [])),
+        )
+
+    def model_dump(self, mode: str = "python") -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "label": self.label,
+            "description": self.description,
+            "required": self.required,
+            "inputs": list(self.inputs),
+            "emits": list(self.emits),
+            "evidence_refs": list(self.evidence_refs),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioEnvironmentHooks:
+    """Resettable, verifiable lifecycle hooks expected from serious scenarios."""
+
+    setup: list[ScenarioEnvironmentHook]
+    reset: list[ScenarioEnvironmentHook]
+    rollout: list[ScenarioEnvironmentHook]
+    verification: list[ScenarioEnvironmentHook]
+    scoring: list[ScenarioEnvironmentHook]
+    replay: list[ScenarioEnvironmentHook]
+    evidence: list[ScenarioEnvironmentHook]
+    cleanup: list[ScenarioEnvironmentHook]
+
+    @classmethod
+    def model_validate(cls, data: dict[str, Any]) -> ScenarioEnvironmentHooks:
+        _reject_extra(data, set(HOOK_KINDS))
+        return cls(**{kind: _hooks(data[kind]) for kind in HOOK_KINDS})
+
+    def model_dump(self, mode: str = "python") -> dict[str, Any]:
+        return {kind: [hook.model_dump(mode=mode) for hook in getattr(self, kind)] for kind in HOOK_KINDS}
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioEnvironmentContract:
+    """Portable scenario environment contract shared by Python and TypeScript."""
+
+    scenario_name: str
+    scenario_family: str
+    hooks: ScenarioEnvironmentHooks
+    schema_version: Literal[1] = 1
+
+    @classmethod
+    def model_validate(cls, data: dict[str, Any]) -> ScenarioEnvironmentContract:
+        _reject_extra(data, {"schema_version", "scenario_name", "scenario_family", "hooks"})
+        if data.get("schema_version") != 1:
+            raise ValueError("scenario environment contract schema_version must be 1")
+        hooks = data["hooks"]
+        if not isinstance(hooks, dict):
+            raise TypeError("hooks must be an object")
+        return cls(
+            scenario_name=str(data["scenario_name"]),
+            scenario_family=str(data["scenario_family"]),
+            hooks=ScenarioEnvironmentHooks.model_validate(hooks),
+            schema_version=1,
+        )
+
+    def model_dump(self, mode: str = "python") -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "scenario_name": self.scenario_name,
+            "scenario_family": self.scenario_family,
+            "hooks": self.hooks.model_dump(mode=mode),
+        }
+
+
+def _reject_extra(data: dict[str, Any], allowed: set[str]) -> None:
+    extra = set(data) - allowed
+    if extra:
+        raise ValueError(f"unexpected scenario environment contract field(s): {', '.join(sorted(extra))}")
+
+
+def _list_of_str(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        raise TypeError("expected list")
+    return [str(item) for item in value]
+
+
+def _hooks(value: Any) -> list[ScenarioEnvironmentHook]:
+    if not isinstance(value, list):
+        raise TypeError("hook group must be a list")
+    return [ScenarioEnvironmentHook.model_validate(item) for item in value]
+
+
+def _hook(
+    kind: ScenarioEnvironmentHookKind,
+    label: str,
+    description: str,
+    *,
+    inputs: list[str] | None = None,
+    emits: list[str] | None = None,
+    evidence_refs: list[str] | None = None,
+) -> ScenarioEnvironmentHook:
+    return ScenarioEnvironmentHook(
+        kind=kind,
+        label=label,
+        description=description,
+        inputs=inputs or [],
+        emits=emits or [],
+        evidence_refs=evidence_refs or [],
+    )
+
+
+def _contract(
+    scenario_name: str,
+    scenario_family: str,
+    hooks: dict[str, list[ScenarioEnvironmentHook]],
+) -> ScenarioEnvironmentContract:
+    return ScenarioEnvironmentContract(
+        scenario_name=scenario_name,
+        scenario_family=scenario_family,
+        hooks=ScenarioEnvironmentHooks(**{kind: hooks[kind] for kind in HOOK_KINDS}),
+    )
+
+
+def scenario_environment_contract_for_game(scenario: Any, *, scenario_family: str = "game") -> ScenarioEnvironmentContract:
+    """Describe the existing game ScenarioInterface as a resettable harness."""
+
+    return _contract(
+        str(getattr(scenario, "name", scenario.__class__.__name__)),
+        scenario_family,
+        {
+            "setup": [
+                _hook(
+                    "setup",
+                    "seeded initial state",
+                    "initial_state(seed) creates the deterministic harness state.",
+                    inputs=["seed"],
+                    emits=["state"],
+                )
+            ],
+            "reset": [
+                _hook(
+                    "reset",
+                    "repeatable reset",
+                    "Calling initial_state(seed) again restores a clean state for replay.",
+                    inputs=["seed"],
+                    emits=["state"],
+                )
+            ],
+            "rollout": [
+                _hook(
+                    "rollout",
+                    "strategy rollout",
+                    "validate_actions and step execute a candidate strategy in the harness.",
+                    inputs=["state", "strategy"],
+                    emits=["next_state"],
+                )
+            ],
+            "verification": [
+                _hook(
+                    "verification",
+                    "action and terminal checks",
+                    "validate_actions, is_terminal, and get_result reject invalid or incomplete runs.",
+                    inputs=["state", "strategy"],
+                    emits=["validation_errors", "terminal_state"],
+                    evidence_refs=["Result.validation_errors"],
+                )
+            ],
+            "scoring": [
+                _hook(
+                    "scoring",
+                    "scalar result score",
+                    "get_result emits the scalar score consumed by tournaments and reports.",
+                    inputs=["terminal_state"],
+                    emits=["scalar_score"],
+                )
+            ],
+            "replay": [
+                _hook(
+                    "replay",
+                    "replay timeline",
+                    "Result.replay and replay_to_narrative preserve the run trace for inspection.",
+                    inputs=["result.replay"],
+                    emits=["replay_timeline"],
+                )
+            ],
+            "evidence": [
+                _hook(
+                    "evidence",
+                    "metrics and validation evidence",
+                    "Result.summary, Result.metrics, and validation errors explain the score.",
+                    inputs=["result"],
+                    emits=["summary", "metrics", "validation_errors"],
+                )
+            ],
+            "cleanup": [
+                _hook(
+                    "cleanup",
+                    "in-memory cleanup",
+                    "Default game scenarios do not retain external resources between seeded runs.",
+                    emits=["no_external_state"],
+                )
+            ],
+        },
+    )
+
+
+def agent_task_template_environment_contract(template_name: str) -> ScenarioEnvironmentContract:
+    """Default contract for judge-backed agent-task templates."""
+
+    return _contract(
+        template_name,
+        "agent_task",
+        {
+            "setup": [
+                _hook(
+                    "setup",
+                    "template task load",
+                    "Load task prompt, rubric, optional sample input, and reference context.",
+                    emits=["task_prompt", "judge_rubric"],
+                )
+            ],
+            "reset": [
+                _hook(
+                    "reset",
+                    "seeded task state",
+                    "initial_state(seed) creates a clean task state for another attempt.",
+                    inputs=["seed"],
+                    emits=["state"],
+                )
+            ],
+            "rollout": [
+                _hook(
+                    "rollout",
+                    "agent output attempt",
+                    "The candidate model produces one output for the task prompt.",
+                    inputs=["task_prompt"],
+                    emits=["agent_output"],
+                )
+            ],
+            "verification": [
+                _hook(
+                    "verification",
+                    "judge rubric check",
+                    "LLM judge evaluates the output against the rubric and guardrails.",
+                    inputs=["agent_output", "judge_rubric"],
+                    emits=["judge_result"],
+                    evidence_refs=["AgentTaskResult.reasoning"],
+                )
+            ],
+            "scoring": [
+                _hook(
+                    "scoring",
+                    "judge scalar score",
+                    "AgentTaskResult.score is the scalar quality score.",
+                    inputs=["judge_result"],
+                    emits=["scalar_score"],
+                )
+            ],
+            "replay": [
+                _hook(
+                    "replay",
+                    "attempt transcript",
+                    "Prompt, output, and judge feedback are enough to replay the attempt.",
+                    inputs=["task_prompt", "agent_output", "judge_result"],
+                    emits=["attempt_transcript"],
+                )
+            ],
+            "evidence": [
+                _hook(
+                    "evidence",
+                    "judge feedback evidence",
+                    "Judge reasoning and dimension scores explain why the output passed or failed.",
+                    inputs=["judge_result"],
+                    emits=["judge_reasoning", "dimension_scores"],
+                )
+            ],
+            "cleanup": [
+                _hook(
+                    "cleanup",
+                    "stateless template cleanup",
+                    "Template-backed tasks keep no external mutable state by default.",
+                    emits=["no_external_state"],
+                )
+            ],
+        },
+    )
+
+
+__all__ = [
+    "HOOK_KINDS",
+    "ScenarioEnvironmentContract",
+    "ScenarioEnvironmentHook",
+    "ScenarioEnvironmentHookKind",
+    "ScenarioEnvironmentHooks",
+    "agent_task_template_environment_contract",
+    "scenario_environment_contract_for_game",
+]

--- a/autocontext/src/autocontext/scenarios/environment_contract.py
+++ b/autocontext/src/autocontext/scenarios/environment_contract.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Literal, get_args
+from typing import Any, Literal, cast, get_args
 
 ScenarioEnvironmentHookKind = Literal[
     "setup",
@@ -15,6 +15,7 @@ ScenarioEnvironmentHookKind = Literal[
 ]
 
 HOOK_KINDS = tuple(get_args(ScenarioEnvironmentHookKind))
+HOOK_FIELDS = {"kind", "label", "description", "required", "inputs", "emits", "evidence_refs"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,16 +35,27 @@ class ScenarioEnvironmentHook:
             raise ValueError(f"unknown scenario environment hook kind: {self.kind}")
 
     @classmethod
-    def model_validate(cls, data: dict[str, Any]) -> ScenarioEnvironmentHook:
-        _reject_extra(data, {"kind", "label", "description", "required", "inputs", "emits", "evidence_refs"})
+    def model_validate(
+        cls,
+        data: dict[str, Any],
+        *,
+        expected_kind: ScenarioEnvironmentHookKind | None = None,
+    ) -> ScenarioEnvironmentHook:
+        if not isinstance(data, dict):
+            raise TypeError("hook must be an object")
+        _require_fields(data, HOOK_FIELDS, "scenario environment hook")
+        _reject_extra(data, HOOK_FIELDS)
+        required = data["required"]
+        if not isinstance(required, bool):
+            raise TypeError("required must be boolean")
         return cls(
-            kind=data["kind"],
-            label=str(data["label"]),
-            description=str(data["description"]),
-            required=bool(data.get("required", True)),
-            inputs=_list_of_str(data.get("inputs", [])),
-            emits=_list_of_str(data.get("emits", [])),
-            evidence_refs=_list_of_str(data.get("evidence_refs", [])),
+            kind=_hook_kind(data["kind"], expected_kind),
+            label=_non_empty_str(data["label"], "label"),
+            description=_non_empty_str(data["description"], "description"),
+            required=required,
+            inputs=_list_of_str(data["inputs"], "inputs"),
+            emits=_list_of_str(data["emits"], "emits"),
+            evidence_refs=_list_of_str(data["evidence_refs"], "evidence_refs"),
         )
 
     def model_dump(self, mode: str = "python") -> dict[str, Any]:
@@ -73,8 +85,11 @@ class ScenarioEnvironmentHooks:
 
     @classmethod
     def model_validate(cls, data: dict[str, Any]) -> ScenarioEnvironmentHooks:
+        if not isinstance(data, dict):
+            raise TypeError("hooks must be an object")
+        _require_fields(data, set(HOOK_KINDS), "scenario environment hooks")
         _reject_extra(data, set(HOOK_KINDS))
-        return cls(**{kind: _hooks(data[kind]) for kind in HOOK_KINDS})
+        return cls(**{kind: _hooks(data[kind], kind) for kind in HOOK_KINDS})
 
     def model_dump(self, mode: str = "python") -> dict[str, Any]:
         return {kind: [hook.model_dump(mode=mode) for hook in getattr(self, kind)] for kind in HOOK_KINDS}
@@ -91,16 +106,16 @@ class ScenarioEnvironmentContract:
 
     @classmethod
     def model_validate(cls, data: dict[str, Any]) -> ScenarioEnvironmentContract:
+        if not isinstance(data, dict):
+            raise TypeError("scenario environment contract must be an object")
+        _require_fields(data, {"schema_version", "scenario_name", "scenario_family", "hooks"}, "scenario environment contract")
         _reject_extra(data, {"schema_version", "scenario_name", "scenario_family", "hooks"})
-        if data.get("schema_version") != 1:
+        if data["schema_version"] != 1 or isinstance(data["schema_version"], bool):
             raise ValueError("scenario environment contract schema_version must be 1")
-        hooks = data["hooks"]
-        if not isinstance(hooks, dict):
-            raise TypeError("hooks must be an object")
         return cls(
-            scenario_name=str(data["scenario_name"]),
-            scenario_family=str(data["scenario_family"]),
-            hooks=ScenarioEnvironmentHooks.model_validate(hooks),
+            scenario_name=_non_empty_str(data["scenario_name"], "scenario_name"),
+            scenario_family=_non_empty_str(data["scenario_family"], "scenario_family"),
+            hooks=ScenarioEnvironmentHooks.model_validate(data["hooks"]),
             schema_version=1,
         )
 
@@ -113,22 +128,45 @@ class ScenarioEnvironmentContract:
         }
 
 
+def _require_fields(data: dict[str, Any], required: set[str], label: str) -> None:
+    missing = required - set(data)
+    if missing:
+        raise ValueError(f"missing {label} field(s): {', '.join(sorted(missing))}")
+
+
 def _reject_extra(data: dict[str, Any], allowed: set[str]) -> None:
     extra = set(data) - allowed
     if extra:
         raise ValueError(f"unexpected scenario environment contract field(s): {', '.join(sorted(extra))}")
 
 
-def _list_of_str(value: Any) -> list[str]:
-    if not isinstance(value, list):
-        raise TypeError("expected list")
-    return [str(item) for item in value]
+def _non_empty_str(value: Any, label: str) -> str:
+    if not isinstance(value, str) or value == "":
+        raise TypeError(f"{label} must be a non-empty string")
+    return value
 
 
-def _hooks(value: Any) -> list[ScenarioEnvironmentHook]:
+def _hook_kind(value: Any, expected_kind: ScenarioEnvironmentHookKind | None) -> ScenarioEnvironmentHookKind:
+    if value not in HOOK_KINDS:
+        raise ValueError(f"unknown scenario environment hook kind: {value}")
+    kind = cast(ScenarioEnvironmentHookKind, value)
+    if expected_kind is not None and kind != expected_kind:
+        raise ValueError(f"expected {expected_kind} hook")
+    return kind
+
+
+def _list_of_str(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise TypeError(f"{label} must be a string list")
+    return list(value)
+
+
+def _hooks(value: Any, expected_kind: ScenarioEnvironmentHookKind) -> list[ScenarioEnvironmentHook]:
     if not isinstance(value, list):
         raise TypeError("hook group must be a list")
-    return [ScenarioEnvironmentHook.model_validate(item) for item in value]
+    if not value:
+        raise ValueError("hook group must be non-empty")
+    return [ScenarioEnvironmentHook.model_validate(item, expected_kind=expected_kind) for item in value]
 
 
 def _hook(

--- a/autocontext/src/autocontext/scenarios/templates/__init__.py
+++ b/autocontext/src/autocontext/scenarios/templates/__init__.py
@@ -6,13 +6,14 @@ from pathlib import Path
 from typing import Any
 
 import yaml  # type: ignore[import-untyped]
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from autocontext.config import load_settings
 from autocontext.execution.judge import LLMJudge
 from autocontext.providers.registry import get_provider
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
 from autocontext.scenarios.custom.agent_task_spec import AgentTaskSpec
+from autocontext.scenarios.environment_contract import ScenarioEnvironmentContract
 from autocontext.scenarios.families import get_family_marker
 
 TEMPLATE_DIR = Path(__file__).parent
@@ -50,6 +51,16 @@ class TemplateSpec(BaseModel):
     revision_prompt: str | None = None
     sample_input: str | None = None
     rubric_dimensions: list[RubricDimension] | None = None
+    environment_contract: ScenarioEnvironmentContract | None = None
+
+    @field_validator("environment_contract", mode="before")
+    @classmethod
+    def _validate_environment_contract(cls, value: Any) -> ScenarioEnvironmentContract | None:
+        if value is None or isinstance(value, ScenarioEnvironmentContract):
+            return value
+        if not isinstance(value, dict):
+            raise TypeError("environment_contract must be an object")
+        return ScenarioEnvironmentContract.model_validate(value)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TemplateSpec:

--- a/autocontext/src/autocontext/scenarios/templates/content-generation/spec.yaml
+++ b/autocontext/src/autocontext/scenarios/templates/content-generation/spec.yaml
@@ -55,3 +55,80 @@ rubric_dimensions:
   - name: keyword_integration
     description: Are target keywords naturally integrated?
     weight: 0.15
+environment_contract:
+  schema_version: 1
+  scenario_name: content-generation
+  scenario_family: agent_task
+  hooks:
+    setup:
+      - kind: setup
+        label: template task load
+        description: >-
+          Load prompt, rubric, optional sample input, and reference context.
+        required: true
+        inputs: []
+        emits: [task_prompt, judge_rubric]
+        evidence_refs: []
+    reset:
+      - kind: reset
+        label: seeded task state
+        description: >-
+          initial_state(seed) creates a clean task state for another attempt.
+        required: true
+        inputs: [seed]
+        emits: [state]
+        evidence_refs: []
+    rollout:
+      - kind: rollout
+        label: agent output attempt
+        description: >-
+          The candidate model produces one output for the task prompt.
+        required: true
+        inputs: [task_prompt]
+        emits: [agent_output]
+        evidence_refs: []
+    verification:
+      - kind: verification
+        label: judge rubric check
+        description: >-
+          LLM judge evaluates the output against the rubric and guardrails.
+        required: true
+        inputs: [agent_output, judge_rubric]
+        emits: [judge_result]
+        evidence_refs: [AgentTaskResult.reasoning]
+    scoring:
+      - kind: scoring
+        label: judge scalar score
+        description: AgentTaskResult.score is the scalar quality score.
+        required: true
+        inputs: [judge_result]
+        emits: [scalar_score]
+        evidence_refs: []
+    replay:
+      - kind: replay
+        label: attempt transcript
+        description: >-
+          Prompt, output, and judge feedback are enough to replay the attempt.
+        required: true
+        inputs: [task_prompt, agent_output, judge_result]
+        emits: [attempt_transcript]
+        evidence_refs: []
+    evidence:
+      - kind: evidence
+        label: judge feedback evidence
+        description: >-
+          Judge reasoning and dimension scores explain why the output passed or
+          failed.
+        required: true
+        inputs: [judge_result]
+        emits: [judge_reasoning, dimension_scores]
+        evidence_refs: []
+    cleanup:
+      - kind: cleanup
+        label: stateless template cleanup
+        description: >-
+          Template-backed tasks keep no external mutable state by default.
+        required: true
+        inputs: []
+        emits: [no_external_state]
+        evidence_refs: []

--- a/autocontext/tests/test_scenario_environment_contract.py
+++ b/autocontext/tests/test_scenario_environment_contract.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import json
 import sys
+from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, get_args
@@ -37,6 +39,9 @@ def test_docs_schema_matches_python_hook_vocabulary() -> None:
     assert schema["required"] == ["schema_version", "scenario_name", "scenario_family", "hooks"]
     assert schema["properties"]["hooks"]["required"] == HOOK_KINDS
     assert schema["$defs"]["hookKind"]["enum"] == list(get_args(module.ScenarioEnvironmentHookKind))
+    for kind in HOOK_KINDS:
+        assert schema["properties"]["hooks"]["properties"][kind]["$ref"] == f"#/$defs/{kind}HookList"
+        assert schema["$defs"][f"{kind}Hook"]["allOf"][1]["properties"]["kind"]["const"] == kind
 
 
 def test_game_scenario_reports_uniform_environment_contract() -> None:
@@ -57,19 +62,39 @@ def test_game_scenario_reports_uniform_environment_contract() -> None:
 
 
 def test_template_exposes_environment_contract() -> None:
-    spec_yaml = (
-        ROOT
-        / "autocontext"
-        / "src"
-        / "autocontext"
-        / "scenarios"
-        / "templates"
-        / "content-generation"
-        / "spec.yaml"
-    ).read_text()
+    templates = importlib.import_module("autocontext.scenarios.templates")
+    spec = templates.TemplateLoader().get_template("content-generation")
 
-    assert "environment_contract:" in spec_yaml
-    assert "scenario_family: agent_task" in spec_yaml
-    assert "kind: verification" in spec_yaml
-    assert "judge_reasoning" in spec_yaml
-    assert "dimension_scores" in spec_yaml
+    assert spec.environment_contract is not None
+    assert spec.environment_contract.scenario_family == "agent_task"
+    assert spec.environment_contract.hooks.verification[0].kind == "verification"
+    assert spec.environment_contract.hooks.evidence[0].emits == ["judge_reasoning", "dimension_scores"]
+
+
+def test_python_contract_rejects_schema_invalid_data() -> None:
+    module = _contract_module()
+    valid = module.agent_task_template_environment_contract("content-generation").model_dump(mode="json")
+    invalid_contracts = []
+
+    missing_required = deepcopy(valid)
+    del missing_required["hooks"]["setup"][0]["required"]
+    invalid_contracts.append(missing_required)
+
+    empty_group = deepcopy(valid)
+    empty_group["hooks"]["setup"] = []
+    invalid_contracts.append(empty_group)
+
+    wrong_kind = deepcopy(valid)
+    wrong_kind["hooks"]["setup"][0]["kind"] = "cleanup"
+    invalid_contracts.append(wrong_kind)
+
+    coerced_list_item = deepcopy(valid)
+    coerced_list_item["hooks"]["setup"][0]["emits"] = [123]
+    invalid_contracts.append(coerced_list_item)
+
+    for contract in invalid_contracts:
+        try:
+            module.ScenarioEnvironmentContract.model_validate(contract)
+        except (KeyError, TypeError, ValueError):
+            continue
+        raise AssertionError("schema-invalid environment contract was accepted")

--- a/autocontext/tests/test_scenario_environment_contract.py
+++ b/autocontext/tests/test_scenario_environment_contract.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, get_args
+
+ROOT = Path(__file__).parents[2]
+MODULE_PATH = ROOT / "autocontext" / "src" / "autocontext" / "scenarios" / "environment_contract.py"
+HOOK_KINDS = [
+    "setup",
+    "reset",
+    "rollout",
+    "verification",
+    "scoring",
+    "replay",
+    "evidence",
+    "cleanup",
+]
+
+
+def _contract_module() -> Any:
+    spec = importlib.util.spec_from_file_location("environment_contract", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_docs_schema_matches_python_hook_vocabulary() -> None:
+    module = _contract_module()
+    schema = json.loads((ROOT / "docs" / "scenario-environment-contract.json").read_text())
+
+    assert schema["required"] == ["schema_version", "scenario_name", "scenario_family", "hooks"]
+    assert schema["properties"]["hooks"]["required"] == HOOK_KINDS
+    assert schema["$defs"]["hookKind"]["enum"] == list(get_args(module.ScenarioEnvironmentHookKind))
+
+
+def test_game_scenario_reports_uniform_environment_contract() -> None:
+    module = _contract_module()
+    contract = module.scenario_environment_contract_for_game(SimpleNamespace(name="grid_ctf"))
+
+    assert contract.scenario_name == "grid_ctf"
+    assert contract.scenario_family == "game"
+    assert [hook.kind for hook in contract.hooks.reset]
+    assert [hook.kind for hook in contract.hooks.rollout]
+    assert [hook.kind for hook in contract.hooks.verification]
+    assert contract.hooks.scoring[0].emits == ["scalar_score"]
+    assert contract.hooks.replay[0].emits == ["replay_timeline"]
+
+    dumped = contract.model_dump(mode="json")
+    reparsed = module.ScenarioEnvironmentContract.model_validate(dumped)
+    assert reparsed.model_dump(mode="json") == dumped
+
+
+def test_template_exposes_environment_contract() -> None:
+    spec_yaml = (
+        ROOT
+        / "autocontext"
+        / "src"
+        / "autocontext"
+        / "scenarios"
+        / "templates"
+        / "content-generation"
+        / "spec.yaml"
+    ).read_text()
+
+    assert "environment_contract:" in spec_yaml
+    assert "scenario_family: agent_task" in spec_yaml
+    assert "kind: verification" in spec_yaml
+    assert "judge_reasoning" in spec_yaml
+    assert "dimension_scores" in spec_yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - [Fetch adapter troubleshooting guide](fetch-troubleshooting.md)
 - [Flue-inspired runtime decisions](flue-influences.md)
 - [Scenario parity matrix — Python & TypeScript](scenario-parity-matrix.md)
+- [Scenario environment contract](scenario-environment-contract.md)
 - [Browser exploration contract](browser-exploration-contract.md)
 - [OpenTelemetry bridge](opentelemetry-bridge.md)
 - [Background session domain and parity contract](background-session-domain.md)

--- a/docs/scenario-environment-contract.json
+++ b/docs/scenario-environment-contract.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/greyhaven-ai/autocontext/docs/scenario-environment-contract.json",
+  "title": "ScenarioEnvironmentContract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "scenario_name", "scenario_family", "hooks"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "scenario_name": { "type": "string", "minLength": 1 },
+    "scenario_family": { "type": "string", "minLength": 1 },
+    "hooks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "setup",
+        "reset",
+        "rollout",
+        "verification",
+        "scoring",
+        "replay",
+        "evidence",
+        "cleanup"
+      ],
+      "properties": {
+        "setup": { "$ref": "#/$defs/hookList" },
+        "reset": { "$ref": "#/$defs/hookList" },
+        "rollout": { "$ref": "#/$defs/hookList" },
+        "verification": { "$ref": "#/$defs/hookList" },
+        "scoring": { "$ref": "#/$defs/hookList" },
+        "replay": { "$ref": "#/$defs/hookList" },
+        "evidence": { "$ref": "#/$defs/hookList" },
+        "cleanup": { "$ref": "#/$defs/hookList" }
+      }
+    }
+  },
+  "$defs": {
+    "hookKind": {
+      "type": "string",
+      "enum": [
+        "setup",
+        "reset",
+        "rollout",
+        "verification",
+        "scoring",
+        "replay",
+        "evidence",
+        "cleanup"
+      ]
+    },
+    "hookList": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/hook" }
+    },
+    "hook": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "label", "description", "required", "inputs", "emits", "evidence_refs"],
+      "properties": {
+        "kind": { "$ref": "#/$defs/hookKind" },
+        "label": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "required": { "type": "boolean" },
+        "inputs": { "type": "array", "items": { "type": "string" } },
+        "emits": { "type": "array", "items": { "type": "string" } },
+        "evidence_refs": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/docs/scenario-environment-contract.json
+++ b/docs/scenario-environment-contract.json
@@ -23,14 +23,14 @@
         "cleanup"
       ],
       "properties": {
-        "setup": { "$ref": "#/$defs/hookList" },
-        "reset": { "$ref": "#/$defs/hookList" },
-        "rollout": { "$ref": "#/$defs/hookList" },
-        "verification": { "$ref": "#/$defs/hookList" },
-        "scoring": { "$ref": "#/$defs/hookList" },
-        "replay": { "$ref": "#/$defs/hookList" },
-        "evidence": { "$ref": "#/$defs/hookList" },
-        "cleanup": { "$ref": "#/$defs/hookList" }
+        "setup": { "$ref": "#/$defs/setupHookList" },
+        "reset": { "$ref": "#/$defs/resetHookList" },
+        "rollout": { "$ref": "#/$defs/rolloutHookList" },
+        "verification": { "$ref": "#/$defs/verificationHookList" },
+        "scoring": { "$ref": "#/$defs/scoringHookList" },
+        "replay": { "$ref": "#/$defs/replayHookList" },
+        "evidence": { "$ref": "#/$defs/evidenceHookList" },
+        "cleanup": { "$ref": "#/$defs/cleanupHookList" }
       }
     }
   },
@@ -48,12 +48,11 @@
         "cleanup"
       ]
     },
-    "hookList": {
+    "stringList": {
       "type": "array",
-      "minItems": 1,
-      "items": { "$ref": "#/$defs/hook" }
+      "items": { "type": "string" }
     },
-    "hook": {
+    "hookBase": {
       "type": "object",
       "additionalProperties": false,
       "required": ["kind", "label", "description", "required", "inputs", "emits", "evidence_refs"],
@@ -62,10 +61,66 @@
         "label": { "type": "string", "minLength": 1 },
         "description": { "type": "string", "minLength": 1 },
         "required": { "type": "boolean" },
-        "inputs": { "type": "array", "items": { "type": "string" } },
-        "emits": { "type": "array", "items": { "type": "string" } },
-        "evidence_refs": { "type": "array", "items": { "type": "string" } }
+        "inputs": { "$ref": "#/$defs/stringList" },
+        "emits": { "$ref": "#/$defs/stringList" },
+        "evidence_refs": { "$ref": "#/$defs/stringList" }
       }
+    },
+    "setupHookList": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/setupHook" } },
+    "setupHook": {
+      "allOf": [
+        { "$ref": "#/$defs/hookBase" },
+        { "type": "object", "properties": { "kind": { "const": "setup" } } }
+      ]
+    },
+    "resetHookList": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/resetHook" } },
+    "resetHook": {
+      "allOf": [
+        { "$ref": "#/$defs/hookBase" },
+        { "type": "object", "properties": { "kind": { "const": "reset" } } }
+      ]
+    },
+    "rolloutHookList": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/rolloutHook" } },
+    "rolloutHook": {
+      "allOf": [
+        { "$ref": "#/$defs/hookBase" },
+        { "type": "object", "properties": { "kind": { "const": "rollout" } } }
+      ]
+    },
+    "verificationHookList": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/verificationHook" } },
+    "verificationHook": {
+      "allOf": [
+        { "$ref": "#/$defs/hookBase" },
+        { "type": "object", "properties": { "kind": { "const": "verification" } } }
+      ]
+    },
+    "scoringHookList": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/scoringHook" } },
+    "scoringHook": {
+      "allOf": [
+        { "$ref": "#/$defs/hookBase" },
+        { "type": "object", "properties": { "kind": { "const": "scoring" } } }
+      ]
+    },
+    "replayHookList": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/replayHook" } },
+    "replayHook": {
+      "allOf": [
+        { "$ref": "#/$defs/hookBase" },
+        { "type": "object", "properties": { "kind": { "const": "replay" } } }
+      ]
+    },
+    "evidenceHookList": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/evidenceHook" } },
+    "evidenceHook": {
+      "allOf": [
+        { "$ref": "#/$defs/hookBase" },
+        { "type": "object", "properties": { "kind": { "const": "evidence" } } }
+      ]
+    },
+    "cleanupHookList": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/cleanupHook" } },
+    "cleanupHook": {
+      "allOf": [
+        { "$ref": "#/$defs/hookBase" },
+        { "type": "object", "properties": { "kind": { "const": "cleanup" } } }
+      ]
     }
   }
 }

--- a/docs/scenario-environment-contract.md
+++ b/docs/scenario-environment-contract.md
@@ -1,0 +1,42 @@
+# Scenario Environment Contract
+
+AC-820 promotes reset and verification from optional harness details to the public scenario boundary. The contract is ENPIRE-inspired but robotics-free: a serious Autocontext scenario should say how it resets, runs a candidate, verifies the result, scores it, preserves replay/evidence, and cleans up.
+
+Canonical JSON shape: [`scenario-environment-contract.json`](scenario-environment-contract.json).
+
+## Required lifecycle hooks
+
+| Hook | Autocontext meaning |
+| --- | --- |
+| `setup` | Create or load the deterministic scenario environment. |
+| `reset` | Return to a clean seeded state before each attempt. |
+| `rollout` | Run the candidate strategy/output/action trace. |
+| `verification` | Check validity with validators, probes, rubrics, or guardrails. |
+| `scoring` | Emit the scalar score used by search and reports. |
+| `replay` | Preserve enough timeline/transcript to replay the attempt. |
+| `evidence` | Attach score explanations, metrics, validation errors, or judge feedback. |
+| `cleanup` | Remove or declare any mutable resources after the attempt. |
+
+Contract probes map into the `verification` hook. If a scenario synthesizes a terminal, directory, artifact, service, cleanup, media, or distributed probe suite, its hook should list that suite under `evidence_refs` and emit `validation_errors` or equivalent failures.
+
+## Minimal example
+
+```json
+{
+  "schema_version": 1,
+  "scenario_name": "grid_ctf",
+  "scenario_family": "game",
+  "hooks": {
+    "setup": [{ "kind": "setup", "label": "seeded initial state", "description": "initial_state(seed)", "required": true, "inputs": ["seed"], "emits": ["state"], "evidence_refs": [] }],
+    "reset": [{ "kind": "reset", "label": "repeatable reset", "description": "initial_state(seed) again", "required": true, "inputs": ["seed"], "emits": ["state"], "evidence_refs": [] }],
+    "rollout": [{ "kind": "rollout", "label": "strategy rollout", "description": "validate_actions + step", "required": true, "inputs": ["state", "strategy"], "emits": ["next_state"], "evidence_refs": [] }],
+    "verification": [{ "kind": "verification", "label": "action checks", "description": "validation errors fail the run", "required": true, "inputs": ["state", "strategy"], "emits": ["validation_errors"], "evidence_refs": ["Result.validation_errors"] }],
+    "scoring": [{ "kind": "scoring", "label": "scalar score", "description": "get_result().score", "required": true, "inputs": ["terminal_state"], "emits": ["scalar_score"], "evidence_refs": [] }],
+    "replay": [{ "kind": "replay", "label": "timeline", "description": "Result.replay", "required": true, "inputs": ["result.replay"], "emits": ["replay_timeline"], "evidence_refs": [] }],
+    "evidence": [{ "kind": "evidence", "label": "metrics", "description": "summary, metrics, validation errors", "required": true, "inputs": ["result"], "emits": ["summary", "metrics"], "evidence_refs": [] }],
+    "cleanup": [{ "kind": "cleanup", "label": "stateless cleanup", "description": "no external resources", "required": true, "inputs": [], "emits": ["no_external_state"], "evidence_refs": [] }]
+  }
+}
+```
+
+Python and TypeScript mirror this durable wire shape; runtime internals may differ, but persisted contracts must keep these keys and hook names stable.

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -530,6 +530,10 @@ export type {
   ExecutionLimits,
   ScoringDimension,
   LegalAction,
+  ScenarioEnvironmentContract,
+  ScenarioEnvironmentHook,
+  ScenarioEnvironmentHookKind,
+  ScenarioEnvironmentHooks,
 } from "./scenarios/index.js";
 export {
   AgentTaskSpecSchema,
@@ -555,6 +559,10 @@ export {
   ReplayEnvelopeSchema,
   ExecutionLimitsSchema,
   GridCtfScenario,
+  SCENARIO_ENVIRONMENT_HOOK_KINDS,
+  ScenarioEnvironmentContractSchema,
+  agentTaskTemplateEnvironmentContract,
+  scenarioEnvironmentContractForGame,
   SCENARIO_REGISTRY,
   isGameScenario,
   isAgentTask,

--- a/ts/src/scenarios/environment-contract.ts
+++ b/ts/src/scenarios/environment-contract.ts
@@ -1,0 +1,271 @@
+import type { ScenarioInterface } from "./game-interface.js";
+
+export const SCENARIO_ENVIRONMENT_HOOK_KINDS = [
+  "setup",
+  "reset",
+  "rollout",
+  "verification",
+  "scoring",
+  "replay",
+  "evidence",
+  "cleanup",
+] as const;
+
+export type ScenarioEnvironmentHookKind = (typeof SCENARIO_ENVIRONMENT_HOOK_KINDS)[number];
+
+export interface ScenarioEnvironmentHook {
+  kind: ScenarioEnvironmentHookKind;
+  label: string;
+  description: string;
+  required: boolean;
+  inputs: string[];
+  emits: string[];
+  evidence_refs: string[];
+}
+
+export type ScenarioEnvironmentHooks = Record<
+  ScenarioEnvironmentHookKind,
+  ScenarioEnvironmentHook[]
+>;
+
+export interface ScenarioEnvironmentContract {
+  schema_version: 1;
+  scenario_name: string;
+  scenario_family: string;
+  hooks: ScenarioEnvironmentHooks;
+}
+
+export const ScenarioEnvironmentContractSchema = {
+  parse(value: unknown): ScenarioEnvironmentContract {
+    const contract = asRecord(value, "contract");
+    rejectExtra(contract, ["schema_version", "scenario_name", "scenario_family", "hooks"]);
+    if (contract.schema_version !== 1) throw new Error("schema_version must be 1");
+    const hooks = asRecord(contract.hooks, "hooks");
+    rejectExtra(hooks, [...SCENARIO_ENVIRONMENT_HOOK_KINDS]);
+    return {
+      schema_version: 1,
+      scenario_name: asString(contract.scenario_name, "scenario_name"),
+      scenario_family: asString(contract.scenario_family, "scenario_family"),
+      hooks: Object.fromEntries(
+        SCENARIO_ENVIRONMENT_HOOK_KINDS.map((kind) => [kind, parseHooks(hooks[kind], kind)]),
+      ) as ScenarioEnvironmentHooks,
+    };
+  },
+} as const;
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a string`);
+  return value;
+}
+
+function stringList(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new Error(`${label} must be a string array`);
+  }
+  return [...value];
+}
+
+function rejectExtra(record: Record<string, unknown>, allowed: readonly string[]): void {
+  const allowedSet = new Set(allowed);
+  const extra = Object.keys(record).filter((key) => !allowedSet.has(key));
+  if (extra.length > 0) throw new Error(`unexpected field(s): ${extra.sort().join(", ")}`);
+}
+
+function parseHooks(value: unknown, kind: ScenarioEnvironmentHookKind): ScenarioEnvironmentHook[] {
+  if (!Array.isArray(value) || value.length === 0)
+    throw new Error(`${kind} hooks must be a non-empty array`);
+  return value.map((item) => parseHook(item, kind));
+}
+
+function parseHook(
+  value: unknown,
+  expectedKind: ScenarioEnvironmentHookKind,
+): ScenarioEnvironmentHook {
+  const hookValue = asRecord(value, expectedKind);
+  rejectExtra(hookValue, [
+    "kind",
+    "label",
+    "description",
+    "required",
+    "inputs",
+    "emits",
+    "evidence_refs",
+  ]);
+  if (hookValue.kind !== expectedKind) throw new Error(`expected ${expectedKind} hook`);
+  if (typeof hookValue.required !== "boolean") throw new Error("required must be boolean");
+  return {
+    kind: expectedKind,
+    label: asString(hookValue.label, "label"),
+    description: asString(hookValue.description, "description"),
+    required: hookValue.required,
+    inputs: stringList(hookValue.inputs, "inputs"),
+    emits: stringList(hookValue.emits, "emits"),
+    evidence_refs: stringList(hookValue.evidence_refs, "evidence_refs"),
+  };
+}
+
+function hook(
+  kind: ScenarioEnvironmentHookKind,
+  label: string,
+  description: string,
+  opts: Partial<Pick<ScenarioEnvironmentHook, "inputs" | "emits" | "evidence_refs">> = {},
+): ScenarioEnvironmentHook {
+  return {
+    kind,
+    label,
+    description,
+    required: true,
+    inputs: opts.inputs ?? [],
+    emits: opts.emits ?? [],
+    evidence_refs: opts.evidence_refs ?? [],
+  };
+}
+
+export function agentTaskTemplateEnvironmentContract(templateName: string): ScenarioEnvironmentContract {
+  return {
+    schema_version: 1,
+    scenario_name: templateName,
+    scenario_family: "agent_task",
+    hooks: {
+      setup: [hook("setup", "template task load", "Load prompt and rubric.", {
+        emits: ["task_prompt", "judge_rubric"],
+      })],
+      reset: [hook("reset", "seeded task state", "Create clean task state.", {
+        inputs: ["seed"],
+        emits: ["state"],
+      })],
+      rollout: [hook("rollout", "agent output attempt", "Produce one task output.", {
+        inputs: ["task_prompt"],
+        emits: ["agent_output"],
+      })],
+      verification: [hook("verification", "judge rubric check", "Judge the output.", {
+        inputs: ["agent_output", "judge_rubric"],
+        emits: ["judge_result"],
+        evidence_refs: ["AgentTaskResult.reasoning"],
+      })],
+      scoring: [hook("scoring", "judge scalar score", "Emit scalar score.", {
+        inputs: ["judge_result"],
+        emits: ["scalar_score"],
+      })],
+      replay: [hook("replay", "attempt transcript", "Keep prompt, output, and feedback.", {
+        inputs: ["task_prompt", "agent_output", "judge_result"],
+        emits: ["attempt_transcript"],
+      })],
+      evidence: [hook("evidence", "judge feedback evidence", "Keep judge reasoning and dimensions.", {
+        inputs: ["judge_result"],
+        emits: ["judge_reasoning", "dimension_scores"],
+      })],
+      cleanup: [hook("cleanup", "stateless template cleanup", "No external mutable state.", {
+        emits: ["no_external_state"],
+      })],
+    },
+  };
+}
+
+export function scenarioEnvironmentContractForGame(
+  scenario: Pick<ScenarioInterface, "name">,
+  scenarioFamily = "game",
+): ScenarioEnvironmentContract {
+  return {
+    schema_version: 1,
+    scenario_name: scenario.name,
+    scenario_family: scenarioFamily,
+    hooks: {
+      setup: [
+        hook(
+          "setup",
+          "seeded initial state",
+          "initialState(seed) creates the deterministic harness state.",
+          {
+            inputs: ["seed"],
+            emits: ["state"],
+          },
+        ),
+      ],
+      reset: [
+        hook(
+          "reset",
+          "repeatable reset",
+          "Calling initialState(seed) again restores a clean state for replay.",
+          {
+            inputs: ["seed"],
+            emits: ["state"],
+          },
+        ),
+      ],
+      rollout: [
+        hook(
+          "rollout",
+          "strategy rollout",
+          "validateActions and step execute a candidate strategy in the harness.",
+          {
+            inputs: ["state", "strategy"],
+            emits: ["next_state"],
+          },
+        ),
+      ],
+      verification: [
+        hook(
+          "verification",
+          "action and terminal checks",
+          "validateActions, isTerminal, and getResult reject invalid or incomplete runs.",
+          {
+            inputs: ["state", "strategy"],
+            emits: ["validation_errors", "terminal_state"],
+            evidence_refs: ["Result.validationErrors"],
+          },
+        ),
+      ],
+      scoring: [
+        hook(
+          "scoring",
+          "scalar result score",
+          "getResult emits the scalar score consumed by tournaments and reports.",
+          {
+            inputs: ["terminal_state"],
+            emits: ["scalar_score"],
+          },
+        ),
+      ],
+      replay: [
+        hook(
+          "replay",
+          "replay timeline",
+          "Result.replay and replayToNarrative preserve the run trace for inspection.",
+          {
+            inputs: ["result.replay"],
+            emits: ["replay_timeline"],
+          },
+        ),
+      ],
+      evidence: [
+        hook(
+          "evidence",
+          "metrics and validation evidence",
+          "Result.summary, Result.metrics, and validation errors explain the score.",
+          {
+            inputs: ["result"],
+            emits: ["summary", "metrics", "validation_errors"],
+          },
+        ),
+      ],
+      cleanup: [
+        hook(
+          "cleanup",
+          "in-memory cleanup",
+          "Default game scenarios do not retain external resources between seeded runs.",
+          {
+            emits: ["no_external_state"],
+          },
+        ),
+      ],
+    },
+  };
+}

--- a/ts/src/scenarios/index.ts
+++ b/ts/src/scenarios/index.ts
@@ -60,6 +60,18 @@ export type { WorkflowCreatorOpts, WorkflowScenarioHandle } from "./workflow-cre
 export type { WorkflowSpec, WorkflowStepSpec } from "./workflow-spec.js";
 export { WorkflowSpecSchema, WorkflowStepSpecSchema, parseRawWorkflowSpec } from "./workflow-spec.js";
 export { getScenarioTypeMarker, SCENARIO_TYPE_MARKERS } from "./families.js";
+export {
+  SCENARIO_ENVIRONMENT_HOOK_KINDS,
+  ScenarioEnvironmentContractSchema,
+  agentTaskTemplateEnvironmentContract,
+  scenarioEnvironmentContractForGame,
+} from "./environment-contract.js";
+export type {
+  ScenarioEnvironmentContract,
+  ScenarioEnvironmentHook,
+  ScenarioEnvironmentHookKind,
+  ScenarioEnvironmentHooks,
+} from "./environment-contract.js";
 
 // Game scenario interface + Grid CTF (AC-343)
 export type {

--- a/ts/src/scenarios/templates/index.ts
+++ b/ts/src/scenarios/templates/index.ts
@@ -9,6 +9,9 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { agentTaskTemplateEnvironmentContract } from "../environment-contract.js";
+import type { ScenarioEnvironmentContract } from "../environment-contract.js";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -33,6 +36,7 @@ export interface TemplateSpec {
   referenceContext?: string;
   requiredConcepts?: string[];
   rubricDimensions?: RubricDimension[];
+  environmentContract?: ScenarioEnvironmentContract;
 }
 
 // ---------------------------------------------------------------------------
@@ -53,6 +57,7 @@ const BUILTIN_TEMPLATES: readonly TemplateSpec[] = [
     qualityThreshold: 0.85,
     revisionPrompt:
       "Review the judge feedback and improve your article. Focus on the lowest-scoring dimensions. Strengthen factual claims with specific examples, improve transitions between sections, and ensure keywords are naturally integrated.",
+    environmentContract: agentTaskTemplateEnvironmentContract("content-generation"),
     rubricDimensions: [
       { name: "readability", description: "Is the content clear and accessible to the target audience?", weight: 0.25 },
       { name: "engagement", description: "Does the content capture and maintain reader interest?", weight: 0.2 },
@@ -112,6 +117,9 @@ function cloneTemplateSpec(spec: TemplateSpec): TemplateSpec {
     rubricDimensions: spec.rubricDimensions
       ? spec.rubricDimensions.map((dimension) => ({ ...dimension }))
       : undefined,
+    environmentContract: spec.environmentContract
+      ? JSON.parse(JSON.stringify(spec.environmentContract)) as ScenarioEnvironmentContract
+      : undefined,
   };
 }
 
@@ -130,7 +138,7 @@ export class TemplateLoader {
     if (templateDir) {
       this.templates = new Map<string, TemplateSpec>();
       try {
-        const files = readdirSync(templateDir).filter((f) => f.endsWith(".json")).sort();
+        const files = readdirSync(templateDir).filter((f: string) => f.endsWith(".json")).sort();
         for (const file of files) {
           try {
             const raw = readFileSync(join(templateDir, file), "utf-8");

--- a/ts/tests/scenario-environment-contract.test.ts
+++ b/ts/tests/scenario-environment-contract.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import Ajv2020 from "ajv/dist/2020.js";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -17,9 +18,16 @@ const CONTRACT_SCHEMA = JSON.parse(
   ),
 ) as {
   required: string[];
-  properties: { hooks: { required: string[] } };
-  $defs: { hookKind: { enum: string[] } };
+  properties: { hooks: { required: string[]; properties: Record<string, { $ref: string }> } };
+  $defs: Record<
+    string,
+    { enum?: string[]; allOf?: [unknown, { properties: { kind: { const: string } } }] }
+  >;
 };
+
+function cloneContract<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
 
 describe("ScenarioEnvironmentContract", () => {
   it("keeps the docs schema aligned with the TypeScript hook vocabulary", () => {
@@ -30,7 +38,13 @@ describe("ScenarioEnvironmentContract", () => {
       "hooks",
     ]);
     expect(CONTRACT_SCHEMA.properties.hooks.required).toEqual([...SCENARIO_ENVIRONMENT_HOOK_KINDS]);
-    expect(CONTRACT_SCHEMA.$defs.hookKind.enum).toEqual([...SCENARIO_ENVIRONMENT_HOOK_KINDS]);
+    expect(CONTRACT_SCHEMA.$defs.hookKind?.enum).toEqual([...SCENARIO_ENVIRONMENT_HOOK_KINDS]);
+    for (const kind of SCENARIO_ENVIRONMENT_HOOK_KINDS) {
+      expect(CONTRACT_SCHEMA.properties.hooks.properties[kind]?.$ref).toBe(
+        `#/$defs/${kind}HookList`,
+      );
+      expect(CONTRACT_SCHEMA.$defs[`${kind}Hook`]?.allOf?.[1].properties.kind.const).toBe(kind);
+    }
   });
 
   it("reports a uniform environment contract for game scenarios", () => {
@@ -45,6 +59,17 @@ describe("ScenarioEnvironmentContract", () => {
     expect(contract.hooks.replay[0]?.emits).toEqual(["replay_timeline"]);
 
     expect(ScenarioEnvironmentContractSchema.parse(contract)).toEqual(contract);
+  });
+
+  it("rejects hook kinds in the wrong schema group", () => {
+    const validate = new Ajv2020({ allErrors: true, strict: true }).compile(CONTRACT_SCHEMA);
+    const contract = scenarioEnvironmentContractForGame(new GridCtfScenario());
+    const invalid = cloneContract(contract);
+    invalid.hooks.setup[0]!.kind = "cleanup";
+
+    expect(validate(contract)).toBe(true);
+    expect(validate(invalid)).toBe(false);
+    expect(() => ScenarioEnvironmentContractSchema.parse(invalid)).toThrow(/expected setup hook/);
   });
 
   it("exposes the environment contract on a scenario template", () => {

--- a/ts/tests/scenario-environment-contract.test.ts
+++ b/ts/tests/scenario-environment-contract.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  GridCtfScenario,
+  SCENARIO_ENVIRONMENT_HOOK_KINDS,
+  ScenarioEnvironmentContractSchema,
+  TemplateLoader,
+  scenarioEnvironmentContractForGame,
+} from "../src/scenarios/index.js";
+
+const CONTRACT_SCHEMA = JSON.parse(
+  readFileSync(
+    join(import.meta.dirname, "..", "..", "docs", "scenario-environment-contract.json"),
+    "utf-8",
+  ),
+) as {
+  required: string[];
+  properties: { hooks: { required: string[] } };
+  $defs: { hookKind: { enum: string[] } };
+};
+
+describe("ScenarioEnvironmentContract", () => {
+  it("keeps the docs schema aligned with the TypeScript hook vocabulary", () => {
+    expect(CONTRACT_SCHEMA.required).toEqual([
+      "schema_version",
+      "scenario_name",
+      "scenario_family",
+      "hooks",
+    ]);
+    expect(CONTRACT_SCHEMA.properties.hooks.required).toEqual([...SCENARIO_ENVIRONMENT_HOOK_KINDS]);
+    expect(CONTRACT_SCHEMA.$defs.hookKind.enum).toEqual([...SCENARIO_ENVIRONMENT_HOOK_KINDS]);
+  });
+
+  it("reports a uniform environment contract for game scenarios", () => {
+    const contract = scenarioEnvironmentContractForGame(new GridCtfScenario());
+
+    expect(contract.scenario_name).toBe("grid_ctf");
+    expect(contract.scenario_family).toBe("game");
+    expect(contract.hooks.reset.length).toBeGreaterThan(0);
+    expect(contract.hooks.rollout.length).toBeGreaterThan(0);
+    expect(contract.hooks.verification.length).toBeGreaterThan(0);
+    expect(contract.hooks.scoring[0]?.emits).toEqual(["scalar_score"]);
+    expect(contract.hooks.replay[0]?.emits).toEqual(["replay_timeline"]);
+
+    expect(ScenarioEnvironmentContractSchema.parse(contract)).toEqual(contract);
+  });
+
+  it("exposes the environment contract on a scenario template", () => {
+    const spec = new TemplateLoader().getTemplate("content-generation");
+
+    expect(spec.environmentContract?.scenario_family).toBe("agent_task");
+    expect(spec.environmentContract?.hooks.verification[0]?.kind).toBe("verification");
+    expect(spec.environmentContract?.hooks.evidence[0]?.emits).toEqual([
+      "judge_reasoning",
+      "dimension_scores",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- add shared Python/TypeScript scenario environment contract shapes for setup/reset/rollout/verification/scoring/replay/evidence/cleanup
- expose game and agent-task-template contract builders, plus TS package-root exports
- document the ENPIRE-inspired mapping and add the contract to the content-generation template

## Validation

- `cd autocontext && PYTHONPATH=src ../../autocontext/autocontext/.venv/bin/pytest tests/test_scenario_environment_contract.py -q`
- `cd autocontext && ../../autocontext/autocontext/.venv/bin/ruff check src/autocontext/scenarios/environment_contract.py tests/test_scenario_environment_contract.py`
- `cd autocontext && PYTHONPATH=src ../../autocontext/autocontext/.venv/bin/mypy src/autocontext/scenarios/environment_contract.py`
- `cd autocontext && PYTHONPATH=src ../../autocontext/autocontext/.venv/bin/pytest tests/test_package_boundaries.py tests/test_package_topology.py -q`
- `cd ts && npm test -- --run tests/scenario-environment-contract.test.ts`
- `cd ts && npm run build`
- `cd ts && npm test -- --run tests/package-boundaries.test.ts tests/package-topology.test.ts tests/package-export-catalogs.test.ts`

Linear: AC-820
