### PR TITLE
AC-821 add run progress reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - AC-820 scenario environment contracts now document and expose reset, rollout, verification, scoring, replay, evidence, and cleanup hooks across Python and TypeScript.
+- AC-821 run progress reports add Python/TypeScript parity for best-score-over-time curves, milestone timing, pass@k summaries, and branch lineage inspection references.
 
 ## [pi-v0.2.6] - 2026-06-16
 

--- a/autocontext/src/autocontext/analytics/__init__.py
+++ b/autocontext/src/autocontext/analytics/__init__.py
@@ -1,5 +1,6 @@
 """Aggregate analytics for cross-run facets, signal extraction, and pattern clustering."""
 
+from autocontext.analytics.progress_report import RunProgressReport, build_run_progress_report
 from autocontext.analytics.runtime_session_run_trace import runtime_session_log_to_run_trace
 from autocontext.analytics.trace_gate_operator_view import (
     TraceGateAnalysisState,
@@ -10,9 +11,11 @@ from autocontext.analytics.trace_gate_operator_view import (
 )
 
 __all__ = [
+    "RunProgressReport",
     "TraceGateAnalysisState",
     "TraceGateOperatorState",
     "TraceGateOperatorView",
+    "build_run_progress_report",
     "build_trace_gate_operator_view",
     "render_trace_gate_operator_view_lines",
     "runtime_session_log_to_run_trace",

--- a/autocontext/src/autocontext/analytics/progress_report.py
+++ b/autocontext/src/autocontext/analytics/progress_report.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -25,12 +25,19 @@ MILESTONE_NAMES: tuple[ProgressMilestoneName, ...] = (
 class _StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True)
 
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        return cls.model_validate(data)
+
 
 class ProgressPoint(_StrictModel):
     """One scored candidate on the best-score-over-time curve."""
 
-    event_id: str
-    timestamp: str
+    event_id: str = Field(min_length=1)
+    timestamp: str = Field(min_length=1)
     elapsed_seconds: float
     generation_index: int | None = None
     hypothesis_node_id: str | None = None
@@ -68,9 +75,9 @@ class PassAtKSummary(_StrictModel):
 class BranchLineageEdge(_StrictModel):
     """Parent/child hypothesis edge included in the inspection artifact."""
 
-    parent_hypothesis_node_id: str
-    child_hypothesis_node_id: str
-    event_id: str
+    parent_hypothesis_node_id: str = Field(min_length=1)
+    child_hypothesis_node_id: str = Field(min_length=1)
+    event_id: str = Field(min_length=1)
     generation_index: int | None = None
 
 
@@ -78,13 +85,39 @@ class RunProgressReport(_StrictModel):
     """Durable progress report shared by Python and TypeScript."""
 
     schema_version: Literal[1] = 1
-    run_id: str
-    generated_at: str
+    run_id: str = Field(min_length=1)
+    generated_at: str = Field(min_length=1)
     threshold: float
     progress_points: list[ProgressPoint]
     milestones: list[MilestoneTiming]
     pass_at_k: list[PassAtKSummary]
     branch_lineage: list[BranchLineageEdge]
+
+    def to_markdown(self) -> str:
+        best_score = max((point.best_score for point in self.progress_points), default=None)
+        pass_lines = [
+            f"- pass@{summary.k}: {'pass' if summary.passed else 'miss'} "
+            f"({summary.successes}/{summary.trials_considered}, best={summary.best_score})"
+            for summary in self.pass_at_k
+        ]
+        milestone_lines = [
+            f"- {milestone.name}: {milestone.elapsed_seconds:.3f}s"
+            for milestone in self.milestones
+            if milestone.reached and milestone.elapsed_seconds is not None
+        ]
+        parts = [
+            f"# Progress Report: {self.run_id}",
+            f"- Best score: {best_score}",
+            f"- Threshold: {self.threshold}",
+            "",
+            "## Milestones",
+            *(milestone_lines or ["- None reached"]),
+            "",
+            "## Pass@k",
+            *(pass_lines or ["- No trials"]),
+            "",
+        ]
+        return "\n".join(parts)
 
 
 def build_run_progress_report(

--- a/autocontext/src/autocontext/analytics/progress_report.py
+++ b/autocontext/src/autocontext/analytics/progress_report.py
@@ -1,0 +1,321 @@
+"""Run progress curves, milestones, pass@k, and branch lineage reports."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ProgressMilestoneName = Literal[
+    "first_valid_candidate",
+    "first_passing_verifier",
+    "first_advancement",
+    "threshold_success",
+]
+
+MILESTONE_NAMES: tuple[ProgressMilestoneName, ...] = (
+    "first_valid_candidate",
+    "first_passing_verifier",
+    "first_advancement",
+    "threshold_success",
+)
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+class ProgressPoint(_StrictModel):
+    """One scored candidate on the best-score-over-time curve."""
+
+    event_id: str
+    timestamp: str
+    elapsed_seconds: float
+    generation_index: int | None = None
+    hypothesis_node_id: str | None = None
+    candidate_id: str | None = None
+    score: float
+    best_score: float
+    improved: bool
+    milestone_names: list[ProgressMilestoneName] = Field(default_factory=list)
+
+
+class MilestoneTiming(_StrictModel):
+    """Time to a named operator-facing progress milestone."""
+
+    name: ProgressMilestoneName
+    reached: bool
+    event_id: str | None = None
+    timestamp: str | None = None
+    elapsed_seconds: float | None = None
+    generation_index: int | None = None
+    hypothesis_node_id: str | None = None
+    score: float | None = None
+
+
+class PassAtKSummary(_StrictModel):
+    """Observed pass@k / best-of-k summary for the first k candidates."""
+
+    k: int
+    trials_considered: int
+    successes: int
+    passed: bool
+    best_score: float | None
+    threshold: float
+
+
+class BranchLineageEdge(_StrictModel):
+    """Parent/child hypothesis edge included in the inspection artifact."""
+
+    parent_hypothesis_node_id: str
+    child_hypothesis_node_id: str
+    event_id: str
+    generation_index: int | None = None
+
+
+class RunProgressReport(_StrictModel):
+    """Durable progress report shared by Python and TypeScript."""
+
+    schema_version: Literal[1] = 1
+    run_id: str
+    generated_at: str
+    threshold: float
+    progress_points: list[ProgressPoint]
+    milestones: list[MilestoneTiming]
+    pass_at_k: list[PassAtKSummary]
+    branch_lineage: list[BranchLineageEdge]
+
+
+def build_run_progress_report(
+    *,
+    run_id: str,
+    events: list[dict[str, Any]],
+    threshold: float,
+    pass_at_k_values: list[int] | None = None,
+    generated_at: str | None = None,
+) -> RunProgressReport:
+    """Build a progress report from tree-search or campaign events."""
+
+    ordered = sorted((_normalize_event(event) for event in events), key=_event_sort_key)
+    start = _start_time(ordered, generated_at)
+    scored = [event for event in ordered if _score(event) is not None]
+    milestones_by_name = _milestones(ordered, scored, threshold, start)
+
+    return RunProgressReport(
+        run_id=run_id,
+        generated_at=generated_at or datetime.now().astimezone().isoformat(),
+        threshold=threshold,
+        progress_points=_progress_points(scored, milestones_by_name, start),
+        milestones=[milestones_by_name[name] for name in MILESTONE_NAMES],
+        pass_at_k=_pass_at_k(scored, threshold, pass_at_k_values if pass_at_k_values is not None else [1, 5, 10]),
+        branch_lineage=_branch_lineage(ordered),
+    )
+
+
+def progress_report_reference(report: RunProgressReport) -> dict[str, Any]:
+    """Small inspection-safe pointer to a full progress report."""
+
+    best_score = max((point.best_score for point in report.progress_points), default=None)
+    return {
+        "run_id": report.run_id,
+        "threshold": report.threshold,
+        "best_score": best_score,
+        "milestones_reached": sum(1 for milestone in report.milestones if milestone.reached),
+        "pass_at_k": [summary.model_dump(mode="json") for summary in report.pass_at_k],
+    }
+
+
+def _normalize_event(event: dict[str, Any]) -> dict[str, Any]:
+    payload = event.get("payload")
+    if not isinstance(payload, dict):
+        return event
+    event_id = event.get("event_id") or (f"seq-{event.get('seq')}" if event.get("seq") is not None else "")
+    return {
+        "event_id": event_id,
+        "event_type": event.get("event"),
+        "timestamp": event.get("ts") or event.get("timestamp"),
+        "generation_index": payload.get("generation_index") or payload.get("generation"),
+        "hypothesis_node_id": payload.get("hypothesis_node_id") or payload.get("node_id") or payload.get("child_id"),
+        "parent_hypothesis_node_id": payload.get("parent_hypothesis_node_id") or payload.get("parent_id"),
+        "candidate_id": payload.get("candidate_id") or payload.get("match_index"),
+        "score": payload.get("score") if payload.get("score") is not None else payload.get("best_score"),
+        "verifier_passed": payload.get("verifier_passed"),
+        "gate_decision": payload.get("gate_decision") or payload.get("decision"),
+    }
+
+
+def _event_sort_key(event: dict[str, Any]) -> tuple[str, str]:
+    return (_string(event.get("timestamp")), _string(event.get("event_id")))
+
+
+def _start_time(events: list[dict[str, Any]], generated_at: str | None) -> datetime:
+    timestamps = [_parse_time(_string(event.get("timestamp"))) for event in events if event.get("timestamp")]
+    if timestamps:
+        return min(timestamps)
+    if generated_at:
+        return _parse_time(generated_at)
+    return datetime.now().astimezone()
+
+
+def _milestones(
+    events: list[dict[str, Any]],
+    scored: list[dict[str, Any]],
+    threshold: float,
+    start: datetime,
+) -> dict[ProgressMilestoneName, MilestoneTiming]:
+    return {
+        "first_valid_candidate": _milestone("first_valid_candidate", _first(scored), start),
+        "first_passing_verifier": _milestone(
+            "first_passing_verifier",
+            _first(event for event in scored if event.get("verifier_passed") is True),
+            start,
+        ),
+        "first_advancement": _milestone(
+            "first_advancement",
+            _first(event for event in events if _string(event.get("gate_decision") or event.get("decision")) == "advance"),
+            start,
+        ),
+        "threshold_success": _milestone(
+            "threshold_success",
+            _first(event for event in scored if (_score(event) or 0.0) >= threshold),
+            start,
+        ),
+    }
+
+
+def _milestone(name: ProgressMilestoneName, event: dict[str, Any] | None, start: datetime) -> MilestoneTiming:
+    if event is None:
+        return MilestoneTiming(name=name, reached=False)
+    timestamp = _string(event.get("timestamp"))
+    return MilestoneTiming(
+        name=name,
+        reached=True,
+        event_id=_string(event.get("event_id")),
+        timestamp=timestamp,
+        elapsed_seconds=_elapsed_seconds(timestamp, start),
+        generation_index=_int_or_none(event.get("generation_index")),
+        hypothesis_node_id=_str_or_none(event.get("hypothesis_node_id")),
+        score=_score(event),
+    )
+
+
+def _progress_points(
+    scored: list[dict[str, Any]],
+    milestones_by_name: dict[ProgressMilestoneName, MilestoneTiming],
+    start: datetime,
+) -> list[ProgressPoint]:
+    point_milestones: dict[str, list[ProgressMilestoneName]] = {}
+    for milestone in milestones_by_name.values():
+        if milestone.event_id:
+            point_milestones.setdefault(milestone.event_id, []).append(milestone.name)
+
+    points: list[ProgressPoint] = []
+    best = float("-inf")
+    for event in scored:
+        score = _score(event)
+        if score is None:
+            continue
+        improved = score > best
+        if improved:
+            best = score
+        timestamp = _string(event.get("timestamp"))
+        points.append(
+            ProgressPoint(
+                event_id=_string(event.get("event_id")),
+                timestamp=timestamp,
+                elapsed_seconds=_elapsed_seconds(timestamp, start),
+                generation_index=_int_or_none(event.get("generation_index")),
+                hypothesis_node_id=_str_or_none(event.get("hypothesis_node_id")),
+                candidate_id=_str_or_none(event.get("candidate_id")),
+                score=score,
+                best_score=best,
+                improved=improved,
+                milestone_names=point_milestones.get(_string(event.get("event_id")), []),
+            )
+        )
+    return points
+
+
+def _pass_at_k(scored: list[dict[str, Any]], threshold: float, values: list[int]) -> list[PassAtKSummary]:
+    scores = [_score(event) for event in scored]
+    numeric_scores = [score for score in scores if score is not None]
+    summaries: list[PassAtKSummary] = []
+    for k in values:
+        if k <= 0:
+            continue
+        window = numeric_scores[:k]
+        successes = sum(1 for score in window if score >= threshold)
+        summaries.append(
+            PassAtKSummary(
+                k=k,
+                trials_considered=len(window),
+                successes=successes,
+                passed=successes > 0,
+                best_score=max(window) if window else None,
+                threshold=threshold,
+            )
+        )
+    return summaries
+
+
+def _branch_lineage(events: list[dict[str, Any]]) -> list[BranchLineageEdge]:
+    seen: set[tuple[str, str]] = set()
+    edges: list[BranchLineageEdge] = []
+    for event in events:
+        parent = _str_or_none(event.get("parent_hypothesis_node_id"))
+        child = _str_or_none(event.get("hypothesis_node_id"))
+        if not parent or not child or parent == child or (parent, child) in seen:
+            continue
+        seen.add((parent, child))
+        edges.append(
+            BranchLineageEdge(
+                parent_hypothesis_node_id=parent,
+                child_hypothesis_node_id=child,
+                event_id=_string(event.get("event_id")),
+                generation_index=_int_or_none(event.get("generation_index")),
+            )
+        )
+    return edges
+
+
+def _first(events: Any) -> dict[str, Any] | None:
+    return next(iter(events), None)
+
+
+def _score(event: dict[str, Any]) -> float | None:
+    value = event.get("score")
+    return float(value) if isinstance(value, int | float) and not isinstance(value, bool) else None
+
+
+def _elapsed_seconds(timestamp: str, start: datetime) -> float:
+    return (_parse_time(timestamp) - start).total_seconds()
+
+
+def _parse_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _string(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _str_or_none(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _int_or_none(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+__all__ = [
+    "BranchLineageEdge",
+    "MILESTONE_NAMES",
+    "MilestoneTiming",
+    "PassAtKSummary",
+    "ProgressMilestoneName",
+    "ProgressPoint",
+    "RunProgressReport",
+    "build_run_progress_report",
+    "progress_report_reference",
+]

--- a/autocontext/src/autocontext/analytics/timeline_inspector.py
+++ b/autocontext/src/autocontext/analytics/timeline_inspector.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from autocontext.analytics.progress_report import RunProgressReport, progress_report_reference
 from autocontext.analytics.run_trace import RunTrace, TraceEvent
 
 # Severity ordering for filtering
@@ -69,6 +70,7 @@ class RunInspection(BaseModel):
     recovery_count: int
     retry_count: int
     causal_depth: int
+    progress_report: dict[str, Any] | None = None
 
 
 class GenerationInspection(BaseModel):
@@ -175,7 +177,7 @@ class TimelineBuilder:
 class StateInspector:
     """Main inspection API for run and generation state."""
 
-    def inspect_run(self, trace: RunTrace) -> RunInspection:
+    def inspect_run(self, trace: RunTrace, progress_report: RunProgressReport | None = None) -> RunInspection:
         events = trace.events
         cat_counts: Counter[str] = Counter(e.category for e in events)
         stage_counts: Counter[str] = Counter(e.stage for e in events)
@@ -195,6 +197,7 @@ class StateInspector:
             recovery_count=recovery_count,
             retry_count=retry_count,
             causal_depth=causal_depth,
+            progress_report=progress_report_reference(progress_report) if progress_report is not None else None,
         )
 
     def inspect_generation(

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -1052,41 +1052,41 @@ class ArtifactStore(ArtifactWriteMethods):
 
     def read_progress_report(self, scenario_name: str, run_id: str) -> object | None:
         """Read a RunProgressReport, or None if missing."""
-        from autocontext.knowledge.normalized_metrics import RunProgressReport
-
         path = self._progress_report_dir(scenario_name) / f"{run_id}.json"
         if not path.exists():
             return None
-        data = read_json(path)
-        return RunProgressReport.from_dict(data)
+        return self._load_progress_report(read_json(path))
+
+    def _load_progress_report(self, data: dict[str, Any]) -> object:
+        if data.get("schema_version") == 1 and "progress_points" in data:
+            from autocontext.analytics.progress_report import RunProgressReport as CurveReport
+            return CurveReport.from_dict(data)
+        from autocontext.knowledge.normalized_metrics import RunProgressReport as NormalizedReport
+        return NormalizedReport.from_dict(data)
 
     def read_latest_progress_reports(
         self, scenario_name: str, max_reports: int = 2,
     ) -> list[object]:
         """Read most recent progress reports for a scenario."""
-        from autocontext.knowledge.normalized_metrics import RunProgressReport
-
         pr_dir = self._progress_report_dir(scenario_name)
         if not pr_dir.exists():
             return []
         files = sorted(pr_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
         reports: list[object] = []
         for path in files[:max_reports]:
-            data = read_json(path)
-            reports.append(RunProgressReport.from_dict(data))
+            reports.append(self._load_progress_report(read_json(path)))
         return reports
 
     def read_latest_progress_reports_markdown(self, scenario_name: str, max_reports: int = 2) -> str:
         """Read recent progress reports and concatenate them as markdown."""
-        from autocontext.knowledge.normalized_metrics import RunProgressReport
-
         reports = self.read_latest_progress_reports(scenario_name, max_reports=max_reports)
         if not reports:
             return ""
         parts: list[str] = []
         for report in reports:
-            if isinstance(report, RunProgressReport):
-                parts.append(report.to_markdown())
+            to_markdown = getattr(report, "to_markdown", None)
+            if callable(to_markdown) and isinstance(markdown := to_markdown(), str):
+                parts.append(markdown)
         return "\n\n".join(parts)
 
     # --- Weakness reports (AC-196) -------------------------------------------
@@ -1131,8 +1131,8 @@ class ArtifactStore(ArtifactWriteMethods):
         markdown_parts: list[str] = []
         for report in reports:
             to_markdown = getattr(report, "to_markdown", None)
-            if callable(to_markdown):
-                markdown_parts.append(to_markdown())
+            if callable(to_markdown) and isinstance(markdown := to_markdown(), str):
+                markdown_parts.append(markdown)
         return "\n\n".join(markdown_parts)
 
     def _deserialize_weakness_report(self, data: dict[str, Any]) -> object:

--- a/autocontext/tests/test_progress_report.py
+++ b/autocontext/tests/test_progress_report.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_PATH = ROOT / "docs" / "run-progress-report-parity-fixture.json"
+
+
+def _fixture() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_build_run_progress_report_matches_shared_fixture() -> None:
+    from autocontext.analytics.progress_report import build_run_progress_report
+
+    fixture = _fixture()
+    report = build_run_progress_report(
+        run_id=fixture["run_id"],
+        events=fixture["events"],
+        threshold=fixture["threshold"],
+        pass_at_k_values=fixture["pass_at_k_values"],
+        generated_at=fixture["generated_at"],
+    )
+
+    assert report.model_dump(mode="json") == fixture["expected_report"]
+
+
+def test_run_progress_report_round_trips_from_shared_json() -> None:
+    from autocontext.analytics.progress_report import RunProgressReport
+
+    expected = _fixture()["expected_report"]
+    assert RunProgressReport.model_validate(expected).model_dump(mode="json") == expected
+
+
+def test_run_progress_report_rejects_extra_fields() -> None:
+    from autocontext.analytics.progress_report import RunProgressReport
+
+    payload = {**_fixture()["expected_report"], "surprise": True}
+    try:
+        RunProgressReport.model_validate(payload)
+    except ValueError:
+        return
+    raise AssertionError("schema-invalid progress report was accepted")
+
+
+def test_run_inspection_can_reference_progress_report() -> None:
+    from autocontext.analytics.progress_report import RunProgressReport
+    from autocontext.analytics.run_trace import ActorRef, RunTrace, TraceEvent
+    from autocontext.analytics.timeline_inspector import StateInspector
+
+    trace = RunTrace(
+        trace_id="trace-progress",
+        run_id="run-progress-1",
+        generation_index=None,
+        schema_version="1.0.0",
+        events=[
+            TraceEvent(
+                event_id="e1",
+                run_id="run-progress-1",
+                generation_index=1,
+                sequence_number=1,
+                timestamp="2026-01-01T00:00:20Z",
+                category="checkpoint",
+                event_type="candidate_scored",
+                actor=ActorRef(actor_type="system", actor_id="progress", actor_name="Progress"),
+                resources=[],
+                summary="candidate scored",
+                detail={},
+                parent_event_id=None,
+                cause_event_ids=[],
+                evidence_ids=[],
+                severity="info",
+                stage="gate",
+                outcome="success",
+                duration_ms=None,
+            )
+        ],
+        causal_edges=[],
+        created_at="2026-01-01T00:00:00Z",
+        metadata={},
+    )
+    report = RunProgressReport.model_validate(_fixture()["expected_report"])
+
+    inspection = StateInspector().inspect_run(trace, progress_report=report)
+
+    assert inspection.progress_report is not None
+    assert inspection.progress_report["run_id"] == "run-progress-1"
+    assert inspection.progress_report["best_score"] == 0.83
+    assert inspection.progress_report["pass_at_k"][-1]["passed"] is True

--- a/autocontext/tests/test_progress_report.py
+++ b/autocontext/tests/test_progress_report.py
@@ -34,15 +34,46 @@ def test_run_progress_report_round_trips_from_shared_json() -> None:
     assert RunProgressReport.model_validate(expected).model_dump(mode="json") == expected
 
 
-def test_run_progress_report_rejects_extra_fields() -> None:
+def test_run_progress_report_rejects_schema_invalid_data() -> None:
     from autocontext.analytics.progress_report import RunProgressReport
 
-    payload = {**_fixture()["expected_report"], "surprise": True}
-    try:
-        RunProgressReport.model_validate(payload)
-    except ValueError:
-        return
-    raise AssertionError("schema-invalid progress report was accepted")
+    for payload in [
+        {**_fixture()["expected_report"], "surprise": True},
+        {**_fixture()["expected_report"], "run_id": ""},
+        {**_fixture()["expected_report"], "generated_at": ""},
+    ]:
+        try:
+            RunProgressReport.model_validate(payload)
+        except ValueError:
+            continue
+        raise AssertionError("schema-invalid progress report was accepted")
+
+
+def test_run_progress_report_uses_artifact_store_round_trip(tmp_path: Path) -> None:
+    from autocontext.analytics.progress_report import RunProgressReport, build_run_progress_report
+    from autocontext.storage.artifacts import ArtifactStore
+
+    fixture = _fixture()
+    report = build_run_progress_report(
+        run_id=fixture["run_id"],
+        events=fixture["events"],
+        threshold=fixture["threshold"],
+        pass_at_k_values=fixture["pass_at_k_values"],
+        generated_at=fixture["generated_at"],
+    )
+    store = ArtifactStore(
+        tmp_path / "runs",
+        tmp_path / "knowledge",
+        tmp_path / "skills",
+        tmp_path / "claude-skills",
+    )
+
+    store.write_progress_report("grid_ctf", fixture["run_id"], report)
+    loaded = store.read_progress_report("grid_ctf", fixture["run_id"])
+
+    assert isinstance(loaded, RunProgressReport)
+    assert loaded.to_dict() == fixture["expected_report"]
+    assert "pass@4" in store.read_latest_progress_reports_markdown("grid_ctf")
 
 
 def test_run_inspection_can_reference_progress_report() -> None:

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - [Flue-inspired runtime decisions](flue-influences.md)
 - [Scenario parity matrix — Python & TypeScript](scenario-parity-matrix.md)
 - [Scenario environment contract](scenario-environment-contract.md)
+- [Run progress report](run-progress-report.md)
 - [Browser exploration contract](browser-exploration-contract.md)
 - [OpenTelemetry bridge](opentelemetry-bridge.md)
 - [Background session domain and parity contract](background-session-domain.md)

--- a/docs/run-progress-report-parity-fixture.json
+++ b/docs/run-progress-report-parity-fixture.json
@@ -1,0 +1,203 @@
+{
+  "schema_version": 1,
+  "run_id": "run-progress-1",
+  "threshold": 0.8,
+  "generated_at": "2026-01-01T00:02:00Z",
+  "pass_at_k_values": [1, 2, 4],
+  "events": [
+    {
+      "event_id": "run-started",
+      "event_type": "run_started",
+      "timestamp": "2026-01-01T00:00:00Z"
+    },
+    {
+      "event_id": "candidate-1",
+      "event_type": "candidate_scored",
+      "timestamp": "2026-01-01T00:00:20Z",
+      "generation_index": 1,
+      "hypothesis_node_id": "h-root",
+      "candidate_id": "c-1",
+      "score": 0.45,
+      "verifier_passed": false
+    },
+    {
+      "event_id": "candidate-2",
+      "event_type": "candidate_scored",
+      "timestamp": "2026-01-01T00:00:40Z",
+      "generation_index": 2,
+      "hypothesis_node_id": "h-child-a",
+      "parent_hypothesis_node_id": "h-root",
+      "candidate_id": "c-2",
+      "score": 0.72,
+      "verifier_passed": true
+    },
+    {
+      "event_id": "candidate-2b",
+      "event_type": "candidate_scored",
+      "timestamp": "2026-01-01T00:00:50Z",
+      "generation_index": 2,
+      "hypothesis_node_id": "h-child-a",
+      "parent_hypothesis_node_id": "h-root",
+      "candidate_id": "c-2b",
+      "score": 0.6,
+      "verifier_passed": false
+    },
+    {
+      "event_id": "candidate-3",
+      "event_type": "candidate_scored",
+      "timestamp": "2026-01-01T00:01:10Z",
+      "generation_index": 3,
+      "hypothesis_node_id": "h-child-b",
+      "parent_hypothesis_node_id": "h-child-a",
+      "candidate_id": "c-3",
+      "score": 0.83,
+      "verifier_passed": true
+    },
+    {
+      "event_id": "gate-3",
+      "event_type": "gate_decided",
+      "timestamp": "2026-01-01T00:01:15Z",
+      "generation_index": 3,
+      "hypothesis_node_id": "h-child-b",
+      "gate_decision": "advance"
+    }
+  ],
+  "expected_report": {
+    "schema_version": 1,
+    "run_id": "run-progress-1",
+    "generated_at": "2026-01-01T00:02:00Z",
+    "threshold": 0.8,
+    "progress_points": [
+      {
+        "event_id": "candidate-1",
+        "timestamp": "2026-01-01T00:00:20Z",
+        "elapsed_seconds": 20.0,
+        "generation_index": 1,
+        "hypothesis_node_id": "h-root",
+        "candidate_id": "c-1",
+        "score": 0.45,
+        "best_score": 0.45,
+        "improved": true,
+        "milestone_names": ["first_valid_candidate"]
+      },
+      {
+        "event_id": "candidate-2",
+        "timestamp": "2026-01-01T00:00:40Z",
+        "elapsed_seconds": 40.0,
+        "generation_index": 2,
+        "hypothesis_node_id": "h-child-a",
+        "candidate_id": "c-2",
+        "score": 0.72,
+        "best_score": 0.72,
+        "improved": true,
+        "milestone_names": ["first_passing_verifier"]
+      },
+      {
+        "event_id": "candidate-2b",
+        "timestamp": "2026-01-01T00:00:50Z",
+        "elapsed_seconds": 50.0,
+        "generation_index": 2,
+        "hypothesis_node_id": "h-child-a",
+        "candidate_id": "c-2b",
+        "score": 0.6,
+        "best_score": 0.72,
+        "improved": false,
+        "milestone_names": []
+      },
+      {
+        "event_id": "candidate-3",
+        "timestamp": "2026-01-01T00:01:10Z",
+        "elapsed_seconds": 70.0,
+        "generation_index": 3,
+        "hypothesis_node_id": "h-child-b",
+        "candidate_id": "c-3",
+        "score": 0.83,
+        "best_score": 0.83,
+        "improved": true,
+        "milestone_names": ["threshold_success"]
+      }
+    ],
+    "milestones": [
+      {
+        "name": "first_valid_candidate",
+        "reached": true,
+        "event_id": "candidate-1",
+        "timestamp": "2026-01-01T00:00:20Z",
+        "elapsed_seconds": 20.0,
+        "generation_index": 1,
+        "hypothesis_node_id": "h-root",
+        "score": 0.45
+      },
+      {
+        "name": "first_passing_verifier",
+        "reached": true,
+        "event_id": "candidate-2",
+        "timestamp": "2026-01-01T00:00:40Z",
+        "elapsed_seconds": 40.0,
+        "generation_index": 2,
+        "hypothesis_node_id": "h-child-a",
+        "score": 0.72
+      },
+      {
+        "name": "first_advancement",
+        "reached": true,
+        "event_id": "gate-3",
+        "timestamp": "2026-01-01T00:01:15Z",
+        "elapsed_seconds": 75.0,
+        "generation_index": 3,
+        "hypothesis_node_id": "h-child-b",
+        "score": null
+      },
+      {
+        "name": "threshold_success",
+        "reached": true,
+        "event_id": "candidate-3",
+        "timestamp": "2026-01-01T00:01:10Z",
+        "elapsed_seconds": 70.0,
+        "generation_index": 3,
+        "hypothesis_node_id": "h-child-b",
+        "score": 0.83
+      }
+    ],
+    "pass_at_k": [
+      {
+        "k": 1,
+        "trials_considered": 1,
+        "successes": 0,
+        "passed": false,
+        "best_score": 0.45,
+        "threshold": 0.8
+      },
+      {
+        "k": 2,
+        "trials_considered": 2,
+        "successes": 0,
+        "passed": false,
+        "best_score": 0.72,
+        "threshold": 0.8
+      },
+      {
+        "k": 4,
+        "trials_considered": 4,
+        "successes": 1,
+        "passed": true,
+        "best_score": 0.83,
+        "threshold": 0.8
+      }
+    ],
+    "branch_lineage": [
+      {
+        "parent_hypothesis_node_id": "h-root",
+        "child_hypothesis_node_id": "h-child-a",
+        "event_id": "candidate-2",
+        "generation_index": 2
+      },
+      {
+        "parent_hypothesis_node_id": "h-child-a",
+        "child_hypothesis_node_id": "h-child-b",
+        "event_id": "candidate-3",
+        "generation_index": 3
+      }
+    ]
+  }
+}

--- a/docs/run-progress-report.json
+++ b/docs/run-progress-report.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/greyhaven-ai/autocontext/docs/run-progress-report.json",
+  "title": "RunProgressReport",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "generated_at",
+    "threshold",
+    "progress_points",
+    "milestones",
+    "pass_at_k",
+    "branch_lineage"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "run_id": { "type": "string", "minLength": 1 },
+    "generated_at": { "type": "string", "minLength": 1 },
+    "threshold": { "type": "number" },
+    "progress_points": { "type": "array", "items": { "$ref": "#/$defs/progressPoint" } },
+    "milestones": { "type": "array", "items": { "$ref": "#/$defs/milestoneTiming" } },
+    "pass_at_k": { "type": "array", "items": { "$ref": "#/$defs/passAtKSummary" } },
+    "branch_lineage": { "type": "array", "items": { "$ref": "#/$defs/branchLineageEdge" } }
+  },
+  "$defs": {
+    "milestoneName": {
+      "type": "string",
+      "enum": [
+        "first_valid_candidate",
+        "first_passing_verifier",
+        "first_advancement",
+        "threshold_success"
+      ]
+    },
+    "nullableString": { "type": ["string", "null"] },
+    "nullableNumber": { "type": ["number", "null"] },
+    "nullableInteger": { "type": ["integer", "null"] },
+    "progressPoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_id",
+        "timestamp",
+        "elapsed_seconds",
+        "generation_index",
+        "hypothesis_node_id",
+        "candidate_id",
+        "score",
+        "best_score",
+        "improved",
+        "milestone_names"
+      ],
+      "properties": {
+        "event_id": { "type": "string", "minLength": 1 },
+        "timestamp": { "type": "string", "minLength": 1 },
+        "elapsed_seconds": { "type": "number" },
+        "generation_index": { "$ref": "#/$defs/nullableInteger" },
+        "hypothesis_node_id": { "$ref": "#/$defs/nullableString" },
+        "candidate_id": { "$ref": "#/$defs/nullableString" },
+        "score": { "type": "number" },
+        "best_score": { "type": "number" },
+        "improved": { "type": "boolean" },
+        "milestone_names": { "type": "array", "items": { "$ref": "#/$defs/milestoneName" } }
+      }
+    },
+    "milestoneTiming": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "reached",
+        "event_id",
+        "timestamp",
+        "elapsed_seconds",
+        "generation_index",
+        "hypothesis_node_id",
+        "score"
+      ],
+      "properties": {
+        "name": { "$ref": "#/$defs/milestoneName" },
+        "reached": { "type": "boolean" },
+        "event_id": { "$ref": "#/$defs/nullableString" },
+        "timestamp": { "$ref": "#/$defs/nullableString" },
+        "elapsed_seconds": { "$ref": "#/$defs/nullableNumber" },
+        "generation_index": { "$ref": "#/$defs/nullableInteger" },
+        "hypothesis_node_id": { "$ref": "#/$defs/nullableString" },
+        "score": { "$ref": "#/$defs/nullableNumber" }
+      }
+    },
+    "passAtKSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["k", "trials_considered", "successes", "passed", "best_score", "threshold"],
+      "properties": {
+        "k": { "type": "integer", "minimum": 1 },
+        "trials_considered": { "type": "integer", "minimum": 0 },
+        "successes": { "type": "integer", "minimum": 0 },
+        "passed": { "type": "boolean" },
+        "best_score": { "$ref": "#/$defs/nullableNumber" },
+        "threshold": { "type": "number" }
+      }
+    },
+    "branchLineageEdge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "parent_hypothesis_node_id",
+        "child_hypothesis_node_id",
+        "event_id",
+        "generation_index"
+      ],
+      "properties": {
+        "parent_hypothesis_node_id": { "type": "string", "minLength": 1 },
+        "child_hypothesis_node_id": { "type": "string", "minLength": 1 },
+        "event_id": { "type": "string", "minLength": 1 },
+        "generation_index": { "$ref": "#/$defs/nullableInteger" }
+      }
+    }
+  }
+}

--- a/docs/run-progress-report.md
+++ b/docs/run-progress-report.md
@@ -1,0 +1,12 @@
+# Run Progress Report
+
+Canonical JSON shape: [`run-progress-report.json`](run-progress-report.json).
+
+The report turns tree-search or campaign events into operator-facing progress:
+
+- `progress_points` — best score over wall-clock time, with the generation and hypothesis node that caused each score.
+- `milestones` — time to first valid candidate, first passing verifier, first advancement, and threshold success.
+- `pass_at_k` — observed pass@k / best-of-k summaries for configured k values.
+- `branch_lineage` — parent/child hypothesis edges for inspection artifacts.
+
+Python and TypeScript parity is exercised by [`run-progress-report-parity-fixture.json`](run-progress-report-parity-fixture.json).

--- a/ts/src/analytics/progress-report.ts
+++ b/ts/src/analytics/progress-report.ts
@@ -1,0 +1,392 @@
+export const PROGRESS_MILESTONE_NAMES = [
+  "first_valid_candidate",
+  "first_passing_verifier",
+  "first_advancement",
+  "threshold_success",
+] as const;
+
+export type ProgressMilestoneName = (typeof PROGRESS_MILESTONE_NAMES)[number];
+
+export interface RunProgressEvent {
+  event_id: string;
+  event_type: string;
+  timestamp: string;
+  generation_index?: number;
+  hypothesis_node_id?: string;
+  parent_hypothesis_node_id?: string;
+  candidate_id?: string;
+  score?: number;
+  verifier_passed?: boolean;
+  gate_decision?: string;
+  decision?: string;
+}
+
+export interface RunProgressEventStreamRow {
+  event?: string;
+  ts?: string;
+  seq?: number;
+  payload?: Record<string, unknown>;
+}
+
+export type RunProgressEventInput = RunProgressEvent | RunProgressEventStreamRow;
+
+export interface ProgressPoint {
+  event_id: string;
+  timestamp: string;
+  elapsed_seconds: number;
+  generation_index: number | null;
+  hypothesis_node_id: string | null;
+  candidate_id: string | null;
+  score: number;
+  best_score: number;
+  improved: boolean;
+  milestone_names: ProgressMilestoneName[];
+}
+
+export interface MilestoneTiming {
+  name: ProgressMilestoneName;
+  reached: boolean;
+  event_id: string | null;
+  timestamp: string | null;
+  elapsed_seconds: number | null;
+  generation_index: number | null;
+  hypothesis_node_id: string | null;
+  score: number | null;
+}
+
+export interface PassAtKSummary {
+  k: number;
+  trials_considered: number;
+  successes: number;
+  passed: boolean;
+  best_score: number | null;
+  threshold: number;
+}
+
+export interface BranchLineageEdge {
+  parent_hypothesis_node_id: string;
+  child_hypothesis_node_id: string;
+  event_id: string;
+  generation_index: number | null;
+}
+
+export interface RunProgressReport {
+  schema_version: 1;
+  run_id: string;
+  generated_at: string;
+  threshold: number;
+  progress_points: ProgressPoint[];
+  milestones: MilestoneTiming[];
+  pass_at_k: PassAtKSummary[];
+  branch_lineage: BranchLineageEdge[];
+}
+
+export interface BuildRunProgressReportInput {
+  runId: string;
+  events: RunProgressEventInput[];
+  threshold: number;
+  passAtKValues?: number[];
+  generatedAt?: string;
+}
+
+export interface ProgressReportReference {
+  run_id: string;
+  threshold: number;
+  best_score: number | null;
+  milestones_reached: number;
+  pass_at_k: PassAtKSummary[];
+}
+
+export function buildRunProgressReport(input: BuildRunProgressReportInput): RunProgressReport {
+  const events = input.events.map(normalizeEvent).sort(eventSort);
+  const start = startTime(events, input.generatedAt);
+  const scored = events.filter((event) => scoreOf(event) !== null);
+  const milestones = milestoneMap(events, scored, input.threshold, start);
+  return parseRunProgressReport({
+    schema_version: 1,
+    run_id: input.runId,
+    generated_at: input.generatedAt ?? new Date().toISOString(),
+    threshold: input.threshold,
+    progress_points: progressPoints(scored, milestones, start),
+    milestones: PROGRESS_MILESTONE_NAMES.map((name) => milestones[name]),
+    pass_at_k: passAtK(scored, input.threshold, input.passAtKValues ?? [1, 5, 10]),
+    branch_lineage: branchLineage(events),
+  });
+}
+
+export function parseRunProgressReport(value: unknown): RunProgressReport {
+  const report = record(value, "progress report");
+  exact(report, ["schema_version", "run_id", "generated_at", "threshold", "progress_points", "milestones", "pass_at_k", "branch_lineage"]);
+  if (report.schema_version !== 1) throw new Error("schema_version must be 1");
+  return {
+    schema_version: 1,
+    run_id: string(report.run_id, "run_id"),
+    generated_at: string(report.generated_at, "generated_at"),
+    threshold: number(report.threshold, "threshold"),
+    progress_points: array(report.progress_points, "progress_points").map(parseProgressPoint),
+    milestones: array(report.milestones, "milestones").map(parseMilestone),
+    pass_at_k: array(report.pass_at_k, "pass_at_k").map(parsePassAtK),
+    branch_lineage: array(report.branch_lineage, "branch_lineage").map(parseLineageEdge),
+  };
+}
+
+export function progressReportReference(report: RunProgressReport): ProgressReportReference {
+  return {
+    run_id: report.run_id,
+    threshold: report.threshold,
+    best_score: report.progress_points.reduce<number | null>(
+      (best, point) => (best === null || point.best_score > best ? point.best_score : best),
+      null,
+    ),
+    milestones_reached: report.milestones.filter((milestone) => milestone.reached).length,
+    pass_at_k: report.pass_at_k.map((summary) => ({ ...summary })),
+  };
+}
+
+function normalizeEvent(event: RunProgressEventInput): RunProgressEvent {
+  if (!("payload" in event) || !event.payload) return event as RunProgressEvent;
+  const payload = event.payload;
+  return {
+    event_id: maybeString((event as RunProgressEvent).event_id) ?? (event.seq !== undefined ? `seq-${event.seq}` : ""),
+    event_type: event.event ?? "",
+    timestamp: event.ts ?? (event as RunProgressEvent).timestamp ?? "",
+    generation_index: maybeNumber(payload.generation_index) ?? maybeNumber(payload.generation),
+    hypothesis_node_id:
+      maybeString(payload.hypothesis_node_id) ?? maybeString(payload.node_id) ?? maybeString(payload.child_id),
+    parent_hypothesis_node_id: maybeString(payload.parent_hypothesis_node_id) ?? maybeString(payload.parent_id),
+    candidate_id: maybeString(payload.candidate_id),
+    score: maybeNumber(payload.score) ?? maybeNumber(payload.best_score),
+    verifier_passed: maybeBoolean(payload.verifier_passed),
+    gate_decision: maybeString(payload.gate_decision) ?? maybeString(payload.decision),
+  };
+}
+
+function eventSort(a: RunProgressEvent, b: RunProgressEvent): number {
+  return a.timestamp.localeCompare(b.timestamp) || a.event_id.localeCompare(b.event_id);
+}
+
+function startTime(events: RunProgressEvent[], generatedAt?: string): number {
+  const timestamps = events.map((event) => Date.parse(event.timestamp)).filter(Number.isFinite);
+  if (timestamps.length > 0) return Math.min(...timestamps);
+  return generatedAt ? Date.parse(generatedAt) : Date.now();
+}
+
+function milestoneMap(
+  events: RunProgressEvent[],
+  scored: RunProgressEvent[],
+  threshold: number,
+  start: number,
+): Record<ProgressMilestoneName, MilestoneTiming> {
+  return {
+    first_valid_candidate: milestone("first_valid_candidate", scored[0], start),
+    first_passing_verifier: milestone("first_passing_verifier", scored.find((event) => event.verifier_passed), start),
+    first_advancement: milestone(
+      "first_advancement",
+      events.find((event) => (event.gate_decision ?? event.decision) === "advance"),
+      start,
+    ),
+    threshold_success: milestone(
+      "threshold_success",
+      scored.find((event) => (scoreOf(event) ?? 0) >= threshold),
+      start,
+    ),
+  };
+}
+
+function milestone(name: ProgressMilestoneName, event: RunProgressEvent | undefined, start: number): MilestoneTiming {
+  if (!event) return { name, reached: false, event_id: null, timestamp: null, elapsed_seconds: null, generation_index: null, hypothesis_node_id: null, score: null };
+  return {
+    name,
+    reached: true,
+    event_id: event.event_id,
+    timestamp: event.timestamp,
+    elapsed_seconds: elapsedSeconds(event.timestamp, start),
+    generation_index: event.generation_index ?? null,
+    hypothesis_node_id: event.hypothesis_node_id ?? null,
+    score: scoreOf(event),
+  };
+}
+
+function progressPoints(
+  scored: RunProgressEvent[],
+  milestones: Record<ProgressMilestoneName, MilestoneTiming>,
+  start: number,
+): ProgressPoint[] {
+  const pointMilestones = new Map<string, ProgressMilestoneName[]>();
+  for (const item of Object.values(milestones)) {
+    if (!item.event_id) continue;
+    pointMilestones.set(item.event_id, [...(pointMilestones.get(item.event_id) ?? []), item.name]);
+  }
+
+  let best = Number.NEGATIVE_INFINITY;
+  return scored.map((event) => {
+    const score = scoreOf(event) ?? 0;
+    const improved = score > best;
+    if (improved) best = score;
+    return {
+      event_id: event.event_id,
+      timestamp: event.timestamp,
+      elapsed_seconds: elapsedSeconds(event.timestamp, start),
+      generation_index: event.generation_index ?? null,
+      hypothesis_node_id: event.hypothesis_node_id ?? null,
+      candidate_id: event.candidate_id ?? null,
+      score,
+      best_score: best,
+      improved,
+      milestone_names: pointMilestones.get(event.event_id) ?? [],
+    };
+  });
+}
+
+function passAtK(scored: RunProgressEvent[], threshold: number, values: number[]): PassAtKSummary[] {
+  const scores = scored.map(scoreOf).filter((score): score is number => score !== null);
+  return values.filter((k) => k > 0).map((k) => {
+    const window = scores.slice(0, k);
+    const successes = window.filter((score) => score >= threshold).length;
+    return { k, trials_considered: window.length, successes, passed: successes > 0, best_score: window.length ? Math.max(...window) : null, threshold };
+  });
+}
+
+function branchLineage(events: RunProgressEvent[]): BranchLineageEdge[] {
+  const seen = new Set<string>();
+  const edges: BranchLineageEdge[] = [];
+  for (const event of events) {
+    const parent = event.parent_hypothesis_node_id;
+    const child = event.hypothesis_node_id;
+    if (!parent || !child || parent === child) continue;
+    const key = `${parent}\u0000${child}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    edges.push({ parent_hypothesis_node_id: parent, child_hypothesis_node_id: child, event_id: event.event_id, generation_index: event.generation_index ?? null });
+  }
+  return edges;
+}
+
+function parseProgressPoint(value: unknown): ProgressPoint {
+  const item = record(value, "progress point");
+  exact(item, ["event_id", "timestamp", "elapsed_seconds", "generation_index", "hypothesis_node_id", "candidate_id", "score", "best_score", "improved", "milestone_names"]);
+  return {
+    event_id: string(item.event_id, "event_id"),
+    timestamp: string(item.timestamp, "timestamp"),
+    elapsed_seconds: number(item.elapsed_seconds, "elapsed_seconds"),
+    generation_index: nullableInteger(item.generation_index, "generation_index"),
+    hypothesis_node_id: nullableString(item.hypothesis_node_id, "hypothesis_node_id"),
+    candidate_id: nullableString(item.candidate_id, "candidate_id"),
+    score: number(item.score, "score"),
+    best_score: number(item.best_score, "best_score"),
+    improved: boolean(item.improved, "improved"),
+    milestone_names: array(item.milestone_names, "milestone_names").map(milestoneName),
+  };
+}
+
+function parseMilestone(value: unknown): MilestoneTiming {
+  const item = record(value, "milestone");
+  exact(item, ["name", "reached", "event_id", "timestamp", "elapsed_seconds", "generation_index", "hypothesis_node_id", "score"]);
+  return {
+    name: milestoneName(item.name),
+    reached: boolean(item.reached, "reached"),
+    event_id: nullableString(item.event_id, "event_id"),
+    timestamp: nullableString(item.timestamp, "timestamp"),
+    elapsed_seconds: nullableNumber(item.elapsed_seconds, "elapsed_seconds"),
+    generation_index: nullableInteger(item.generation_index, "generation_index"),
+    hypothesis_node_id: nullableString(item.hypothesis_node_id, "hypothesis_node_id"),
+    score: nullableNumber(item.score, "score"),
+  };
+}
+
+function parsePassAtK(value: unknown): PassAtKSummary {
+  const item = record(value, "pass_at_k");
+  exact(item, ["k", "trials_considered", "successes", "passed", "best_score", "threshold"]);
+  return {
+    k: integer(item.k, "k"),
+    trials_considered: integer(item.trials_considered, "trials_considered"),
+    successes: integer(item.successes, "successes"),
+    passed: boolean(item.passed, "passed"),
+    best_score: nullableNumber(item.best_score, "best_score"),
+    threshold: number(item.threshold, "threshold"),
+  };
+}
+
+function parseLineageEdge(value: unknown): BranchLineageEdge {
+  const item = record(value, "branch lineage edge");
+  exact(item, ["parent_hypothesis_node_id", "child_hypothesis_node_id", "event_id", "generation_index"]);
+  return {
+    parent_hypothesis_node_id: string(item.parent_hypothesis_node_id, "parent_hypothesis_node_id"),
+    child_hypothesis_node_id: string(item.child_hypothesis_node_id, "child_hypothesis_node_id"),
+    event_id: string(item.event_id, "event_id"),
+    generation_index: nullableInteger(item.generation_index, "generation_index"),
+  };
+}
+
+function scoreOf(event: RunProgressEvent): number | null {
+  return typeof event.score === "number" && Number.isFinite(event.score) ? event.score : null;
+}
+
+function elapsedSeconds(timestamp: string, start: number): number {
+  return (Date.parse(timestamp) - start) / 1000;
+}
+
+function milestoneName(value: unknown): ProgressMilestoneName {
+  if (typeof value !== "string" || !PROGRESS_MILESTONE_NAMES.includes(value as ProgressMilestoneName)) throw new Error("unknown milestone name");
+  return value as ProgressMilestoneName;
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function exact(item: Record<string, unknown>, allowed: readonly string[]): void {
+  const allowedSet = new Set(allowed);
+  const extra = Object.keys(item).filter((key) => !allowedSet.has(key));
+  if (extra.length) throw new Error(`unexpected field(s): ${extra.sort().join(", ")}`);
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a string`);
+  return value;
+}
+
+function nullableString(value: unknown, label: string): string | null {
+  return value === null || value === undefined ? null : string(value, label);
+}
+
+function number(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${label} must be a number`);
+  return value;
+}
+
+function nullableNumber(value: unknown, label: string): number | null {
+  return value === null || value === undefined ? null : number(value, label);
+}
+
+function integer(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) throw new Error(`${label} must be an integer`);
+  return value;
+}
+
+function nullableInteger(value: unknown, label: string): number | null {
+  return value === null || value === undefined ? null : integer(value, label);
+}
+
+function boolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${label} must be boolean`);
+  return value;
+}
+
+function array(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value;
+}
+
+function maybeString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length ? value : undefined;
+}
+
+function maybeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function maybeBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -1271,7 +1271,10 @@ async function cmdStatus(dbPath: string): Promise<void> {
     process.exit(1);
   }
   const runtimeSession = await loadRuntimeSessionSummaryForRun(dbPath, runId);
-  console.log(renderRunStatus(run, store.getGenerations(runId), !!values.json, runtimeSession));
+  const progressReport = await loadProgressReportForRun(run);
+  console.log(
+    renderRunStatus(run, store.getGenerations(runId), !!values.json, runtimeSession, progressReport),
+  );
   store.close();
 }
 
@@ -1622,10 +1625,11 @@ async function cmdWatch(dbPath: string): Promise<void> {
       }
       const generations = store.getGenerations(runId);
       const runtimeSession = await loadRuntimeSessionSummaryForRun(dbPath, runId);
+      const progressReport = await loadProgressReportForRun(run);
       console.log(
         values.json
-          ? renderRunStatusJsonLine(run, generations, runtimeSession)
-          : renderRunStatus(run, generations, false, runtimeSession),
+          ? renderRunStatusJsonLine(run, generations, runtimeSession, progressReport)
+          : renderRunStatus(run, generations, false, runtimeSession, progressReport),
       );
       if (run.status !== "running") {
         return;
@@ -1650,6 +1654,20 @@ async function loadRuntimeSessionSummaryForRun(dbPath: string, runId: string) {
     return log ? summarizeRuntimeSession(log) : null;
   } finally {
     eventStore.close();
+  }
+}
+
+async function loadProgressReportForRun(run: { run_id: string; scenario: string }) {
+  const { existsSync, readFileSync } = await import("node:fs");
+  const { loadSettings } = await import("../config/index.js");
+  const { parseRunProgressReport } = await import("../analytics/progress-report.js");
+  const settings = loadSettings();
+  const path = join(resolve(settings.knowledgeRoot), run.scenario, "progress_reports", `${run.run_id}.json`);
+  if (!existsSync(path)) return null;
+  try {
+    return parseRunProgressReport(JSON.parse(readFileSync(path, "utf-8")) as unknown);
+  } catch {
+    return null;
   }
 }
 

--- a/ts/src/cli/run-inspection-command-workflow.ts
+++ b/ts/src/cli/run-inspection-command-workflow.ts
@@ -116,8 +116,9 @@ export function renderRunStatusJsonLine(
   run: RunInspectionRun,
   generations: RunInspectionGeneration[],
   runtimeSession?: RuntimeSessionSummary | null,
+  progressReport?: RunProgressReport | null,
 ): string {
-  return JSON.stringify(runStatusPayload(run, generations, runtimeSession));
+  return JSON.stringify(runStatusPayload(run, generations, runtimeSession, progressReport));
 }
 
 export function renderRunShow(

--- a/ts/src/cli/run-inspection-command-workflow.ts
+++ b/ts/src/cli/run-inspection-command-workflow.ts
@@ -1,3 +1,4 @@
+import { progressReportReference, type RunProgressReport } from "../analytics/progress-report.js";
 import type { RuntimeSessionSummary } from "../session/runtime-session-read-model.js";
 
 export const RUN_STATUS_HELP_TEXT = `autoctx status — show queue status or a run status
@@ -92,9 +93,10 @@ export function renderRunStatus(
   generations: RunInspectionGeneration[],
   json: boolean,
   runtimeSession?: RuntimeSessionSummary | null,
+  progressReport?: RunProgressReport | null,
 ): string {
   if (json) {
-    return JSON.stringify(runStatusPayload(run, generations, runtimeSession), null, 2);
+    return JSON.stringify(runStatusPayload(run, generations, runtimeSession, progressReport), null, 2);
   }
 
   const latest = latestGeneration(generations);
@@ -105,6 +107,7 @@ export function renderRunStatus(
     `  Generations: ${generations.length}/${run.target_generations}`,
     latest ? `  Latest best score: ${formatScore(latest.best_score)} (generation ${latest.generation_index})` : null,
     latest ? `  Latest gate: ${latest.gate_decision}` : null,
+    progressReport ? `  ${renderProgressReportReference(progressReport)}` : null,
     runtimeSession ? `  Runtime session: ${runtimeSession.session_id}` : null,
   ].filter((line): line is string => line !== null).join("\n");
 }
@@ -172,15 +175,18 @@ function runStatusPayload(
   run: RunInspectionRun,
   generations: RunInspectionGeneration[],
   runtimeSession?: RuntimeSessionSummary | null,
+  progressReport?: RunProgressReport | null,
 ): {
   run: RunInspectionRun;
   latest_generation: RunInspectionGeneration | null;
   runtime_session: RuntimeSessionSummary | null;
+  progress_report: ReturnType<typeof progressReportReference> | null;
 } {
   return {
     run,
     latest_generation: latestGeneration(generations),
     runtime_session: runtimeSession ?? null,
+    progress_report: progressReport ? progressReportReference(progressReport) : null,
   };
 }
 
@@ -190,6 +196,20 @@ function bestGeneration(generations: RunInspectionGeneration[]): RunInspectionGe
       !best || generation.best_score > best.best_score ? generation : best,
     null,
   );
+}
+
+function renderProgressReportReference(report: RunProgressReport): string {
+  const reference = progressReportReference(report);
+  const latestPassAtK = reference.pass_at_k.at(-1);
+  return [
+    `Progress best score: ${formatNullableScore(reference.best_score)}`,
+    `(threshold ${formatScore(reference.threshold)},`,
+    latestPassAtK ? `pass@${latestPassAtK.k}: ${latestPassAtK.passed ? "pass" : "miss"})` : "pass@k: n/a)",
+  ].join(" ");
+}
+
+function formatNullableScore(score: number | null): string {
+  return score === null ? "n/a" : formatScore(score);
 }
 
 function formatScore(score: number): string {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -655,6 +655,25 @@ export type {
 // Analytics / Traces
 export { ActorRef, TraceEvent, RunTrace } from "./analytics/run-trace.js";
 export type { TraceEventInit } from "./analytics/run-trace.js";
+export {
+  PROGRESS_MILESTONE_NAMES,
+  buildRunProgressReport,
+  parseRunProgressReport,
+  progressReportReference,
+} from "./analytics/progress-report.js";
+export type {
+  BranchLineageEdge,
+  BuildRunProgressReportInput,
+  MilestoneTiming,
+  PassAtKSummary,
+  ProgressMilestoneName,
+  ProgressPoint,
+  ProgressReportReference,
+  RunProgressEvent,
+  RunProgressEventInput,
+  RunProgressEventStreamRow,
+  RunProgressReport,
+} from "./analytics/progress-report.js";
 export { runtimeSessionLogToRunTrace } from "./analytics/runtime-session-run-trace.js";
 export type { RuntimeSessionRunTraceOpts } from "./analytics/runtime-session-run-trace.js";
 export {

--- a/ts/tests/cli-dx.test.ts
+++ b/ts/tests/cli-dx.test.ts
@@ -697,6 +697,71 @@ describe("runtime session run inspection", () => {
     }
   });
 
+  it("status and watch include the latest persisted progress report", async () => {
+    const dir = makeTempDir();
+    try {
+      const dbPath = join(dir, "runs", "autocontext.sqlite3");
+      const knowledgeRoot = join(dir, "knowledge");
+      mkdirSync(join(dir, "runs"), { recursive: true });
+      mkdirSync(join(knowledgeRoot, "grid_ctf", "progress_reports"), { recursive: true });
+
+      const { SQLiteStore } = await import("../src/storage/index.js");
+      const { buildRunProgressReport } = await import("../src/analytics/progress-report.js");
+
+      const store = new SQLiteStore(dbPath);
+      store.migrate(join(import.meta.dirname, "..", "migrations"));
+      store.createRun("run-123", "grid_ctf", 1, "local", "codex");
+      store.upsertGeneration("run-123", 1, {
+        meanScore: 0.5,
+        bestScore: 0.83,
+        elo: 1010,
+        wins: 2,
+        losses: 1,
+        gateDecision: "advance",
+        status: "completed",
+      });
+      store.updateRunStatus("run-123", "completed");
+      store.close();
+
+      const progressReport = buildRunProgressReport({
+        runId: "run-123",
+        threshold: 0.8,
+        generatedAt: "2026-01-01T00:00:30Z",
+        passAtKValues: [1],
+        events: [
+          {
+            event_id: "candidate-1",
+            event_type: "candidate_scored",
+            timestamp: "2026-01-01T00:00:10Z",
+            generation_index: 1,
+            hypothesis_node_id: "h-1",
+            score: 0.83,
+            verifier_passed: true,
+          },
+        ],
+      });
+      writeFileSync(
+        join(knowledgeRoot, "grid_ctf", "progress_reports", "run-123.json"),
+        JSON.stringify(progressReport, null, 2),
+        "utf-8",
+      );
+
+      for (const command of ["status", "watch"] as const) {
+        const { stdout, exitCode } = runCli([command, "run-123", "--json"], {
+          env: { AUTOCONTEXT_DB_PATH: dbPath, AUTOCONTEXT_KNOWLEDGE_ROOT: knowledgeRoot },
+        });
+        expect(exitCode).toBe(0);
+        expect(JSON.parse(stdout).progress_report).toMatchObject({
+          run_id: "run-123",
+          best_score: 0.83,
+          milestones_reached: 3,
+        });
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("runtime-sessions show can resolve the run-scoped session by run id", async () => {
     const dir = makeTempDir();
     try {

--- a/ts/tests/progress-report.test.ts
+++ b/ts/tests/progress-report.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRunProgressReport,
+  parseRunProgressReport,
+  type RunProgressEvent,
+  type RunProgressReport,
+} from "../src/analytics/progress-report.js";
+import { renderRunStatus } from "../src/cli/run-inspection-command-workflow.js";
+
+const reportSchema = JSON.parse(
+  readFileSync(join(import.meta.dirname, "..", "..", "docs", "run-progress-report.json"), "utf-8"),
+) as Record<string, unknown>;
+
+const fixture = JSON.parse(
+  readFileSync(join(import.meta.dirname, "..", "..", "docs", "run-progress-report-parity-fixture.json"), "utf-8"),
+) as {
+  run_id: string;
+  threshold: number;
+  generated_at: string;
+  pass_at_k_values: number[];
+  events: RunProgressEvent[];
+  expected_report: RunProgressReport;
+};
+
+const run = {
+  run_id: "run-progress-1",
+  scenario: "grid_ctf",
+  target_generations: 3,
+  executor_mode: "local",
+  status: "completed",
+  agent_provider: "deterministic",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:02:00Z",
+};
+
+describe("run progress report", () => {
+  it("matches the shared Python/TypeScript parity fixture", () => {
+    const report = buildRunProgressReport({
+      runId: fixture.run_id,
+      events: fixture.events,
+      threshold: fixture.threshold,
+      passAtKValues: fixture.pass_at_k_values,
+      generatedAt: fixture.generated_at,
+    });
+
+    expect(report).toEqual(fixture.expected_report);
+  });
+
+  it("parses and documents the durable report JSON shape", () => {
+    expect(parseRunProgressReport(fixture.expected_report)).toEqual(fixture.expected_report);
+    expect(reportSchema.required).toContain("progress_points");
+    expect(reportSchema.required).toContain("pass_at_k");
+  });
+
+  it("rejects schema-invalid extra fields", () => {
+    expect(() => parseRunProgressReport({ ...fixture.expected_report, surprise: true })).toThrow(
+      /unexpected field/,
+    );
+  });
+
+  it("lets run inspection reference progress curves and pass@k", () => {
+    const rendered = renderRunStatus(run, [], false, null, fixture.expected_report);
+    const payload = JSON.parse(renderRunStatus(run, [], true, null, fixture.expected_report));
+
+    expect(rendered).toContain("Progress best score: 0.830");
+    expect(rendered).toContain("pass@4: pass");
+    expect(payload.progress_report.best_score).toBe(0.83);
+    expect(payload.progress_report.pass_at_k.at(-1)?.passed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a durable run progress report contract for best-score-over-time curves, milestone timing, pass@k, and branch lineage.
- Implements mirrored Python and TypeScript report builders/parsers with a shared parity fixture.
- Lets existing run inspection/status surfaces reference progress report summaries.

## Stack

Stacked on AC-820 / PR #1108 because it follows the scenario environment contract slice. Retarget to `main` after AC-820 merges.

## Validation

- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m pytest tests/test_progress_report.py tests/test_timeline_inspector.py -q`
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m ruff check src/autocontext/analytics/progress_report.py src/autocontext/analytics/timeline_inspector.py src/autocontext/analytics/__init__.py tests/test_progress_report.py`
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m mypy src/autocontext/analytics/progress_report.py src/autocontext/analytics/timeline_inspector.py`
- `cd ts && npm test -- progress-report.test.ts run-inspection-command-workflow.test.ts`
- `cd ts && npm run lint`
- `cd ts && npm run build`
