### PR TITLE
AC-822 add run utilization report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - AC-820 scenario environment contracts now document and expose reset, rollout, verification, scoring, replay, evidence, and cleanup hooks across Python and TypeScript.
 - AC-821 run progress reports add Python/TypeScript parity for best-score-over-time curves, milestone timing, pass@k summaries, and branch lineage inspection references.
+- AC-822 run utilization reports add shared Python/TypeScript runner, token, verifier idle, model wait, and eval-throughput telemetry for single- and multi-branch runs.
 
 ## [pi-v0.2.6] - 2026-06-16
 

--- a/autocontext/src/autocontext/analytics/__init__.py
+++ b/autocontext/src/autocontext/analytics/__init__.py
@@ -1,6 +1,7 @@
 """Aggregate analytics for cross-run facets, signal extraction, and pattern clustering."""
 
 from autocontext.analytics.progress_report import RunProgressReport, build_run_progress_report
+from autocontext.analytics.run_utilization_report import RunUtilizationReport, build_run_utilization_report
 from autocontext.analytics.runtime_session_run_trace import runtime_session_log_to_run_trace
 from autocontext.analytics.trace_gate_operator_view import (
     TraceGateAnalysisState,
@@ -12,10 +13,12 @@ from autocontext.analytics.trace_gate_operator_view import (
 
 __all__ = [
     "RunProgressReport",
+    "RunUtilizationReport",
     "TraceGateAnalysisState",
     "TraceGateOperatorState",
     "TraceGateOperatorView",
     "build_run_progress_report",
+    "build_run_utilization_report",
     "build_trace_gate_operator_view",
     "render_trace_gate_operator_view_lines",
     "runtime_session_log_to_run_trace",

--- a/autocontext/src/autocontext/analytics/run_utilization_report.py
+++ b/autocontext/src/autocontext/analytics/run_utilization_report.py
@@ -1,0 +1,487 @@
+"""Runner and token utilization report for parallel autoresearch runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class UtilizationWindow:
+    started_at: str | None
+    completed_at: str | None
+    duration_seconds: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "duration_seconds": self.duration_seconds,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> UtilizationWindow:
+        _exact(data, {"started_at", "completed_at", "duration_seconds"})
+        return cls(
+            started_at=_nullable_string(data.get("started_at"), "started_at"),
+            completed_at=_nullable_string(data.get("completed_at"), "completed_at"),
+            duration_seconds=_nullable_number(data.get("duration_seconds"), "duration_seconds"),
+        )
+
+
+@dataclass(frozen=True)
+class BranchUtilization:
+    branch_count: int | None
+    max_parallel_branches: int | None
+    runner_capacity_seconds: float | None
+    active_runner_seconds: float | None
+    idle_runner_seconds: float | None
+    mean_runner_utilization: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "branch_count": self.branch_count,
+            "max_parallel_branches": self.max_parallel_branches,
+            "runner_capacity_seconds": self.runner_capacity_seconds,
+            "active_runner_seconds": self.active_runner_seconds,
+            "idle_runner_seconds": self.idle_runner_seconds,
+            "mean_runner_utilization": self.mean_runner_utilization,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BranchUtilization:
+        _exact(
+            data,
+            {
+                "branch_count",
+                "max_parallel_branches",
+                "runner_capacity_seconds",
+                "active_runner_seconds",
+                "idle_runner_seconds",
+                "mean_runner_utilization",
+            },
+        )
+        return cls(
+            branch_count=_nullable_int(data.get("branch_count"), "branch_count"),
+            max_parallel_branches=_nullable_int(data.get("max_parallel_branches"), "max_parallel_branches"),
+            runner_capacity_seconds=_nullable_number(data.get("runner_capacity_seconds"), "runner_capacity_seconds"),
+            active_runner_seconds=_nullable_number(data.get("active_runner_seconds"), "active_runner_seconds"),
+            idle_runner_seconds=_nullable_number(data.get("idle_runner_seconds"), "idle_runner_seconds"),
+            mean_runner_utilization=_nullable_number(data.get("mean_runner_utilization"), "mean_runner_utilization"),
+        )
+
+
+@dataclass(frozen=True)
+class TokenUtilization:
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    model_active_seconds: float | None
+    model_wait_seconds: float | None
+    mean_token_utilization: float | None
+    token_throughput_per_second: float | None
+    tokens_to_success: int | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.total_tokens,
+            "model_active_seconds": self.model_active_seconds,
+            "model_wait_seconds": self.model_wait_seconds,
+            "mean_token_utilization": self.mean_token_utilization,
+            "token_throughput_per_second": self.token_throughput_per_second,
+            "tokens_to_success": self.tokens_to_success,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TokenUtilization:
+        _exact(
+            data,
+            {
+                "input_tokens",
+                "output_tokens",
+                "total_tokens",
+                "model_active_seconds",
+                "model_wait_seconds",
+                "mean_token_utilization",
+                "token_throughput_per_second",
+                "tokens_to_success",
+            },
+        )
+        return cls(
+            input_tokens=_required_int(data.get("input_tokens"), "input_tokens"),
+            output_tokens=_required_int(data.get("output_tokens"), "output_tokens"),
+            total_tokens=_required_int(data.get("total_tokens"), "total_tokens"),
+            model_active_seconds=_nullable_number(data.get("model_active_seconds"), "model_active_seconds"),
+            model_wait_seconds=_nullable_number(data.get("model_wait_seconds"), "model_wait_seconds"),
+            mean_token_utilization=_nullable_number(data.get("mean_token_utilization"), "mean_token_utilization"),
+            token_throughput_per_second=_nullable_number(
+                data.get("token_throughput_per_second"),
+                "token_throughput_per_second",
+            ),
+            tokens_to_success=_nullable_int(data.get("tokens_to_success"), "tokens_to_success"),
+        )
+
+
+@dataclass(frozen=True)
+class EvaluationUtilization:
+    eval_count: int
+    eval_active_seconds: float | None
+    verifier_active_seconds: float | None
+    verifier_idle_seconds: float | None
+    eval_throughput_per_second: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "eval_count": self.eval_count,
+            "eval_active_seconds": self.eval_active_seconds,
+            "verifier_active_seconds": self.verifier_active_seconds,
+            "verifier_idle_seconds": self.verifier_idle_seconds,
+            "eval_throughput_per_second": self.eval_throughput_per_second,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EvaluationUtilization:
+        _exact(
+            data,
+            {
+                "eval_count",
+                "eval_active_seconds",
+                "verifier_active_seconds",
+                "verifier_idle_seconds",
+                "eval_throughput_per_second",
+            },
+        )
+        return cls(
+            eval_count=_required_int(data.get("eval_count"), "eval_count"),
+            eval_active_seconds=_nullable_number(data.get("eval_active_seconds"), "eval_active_seconds"),
+            verifier_active_seconds=_nullable_number(data.get("verifier_active_seconds"), "verifier_active_seconds"),
+            verifier_idle_seconds=_nullable_number(data.get("verifier_idle_seconds"), "verifier_idle_seconds"),
+            eval_throughput_per_second=_nullable_number(
+                data.get("eval_throughput_per_second"),
+                "eval_throughput_per_second",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class RunUtilizationReport:
+    run_id: str
+    generated_at: str
+    window: UtilizationWindow
+    branch_utilization: BranchUtilization
+    token_utilization: TokenUtilization
+    evaluation_utilization: EvaluationUtilization
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "run_id": self.run_id,
+            "generated_at": self.generated_at,
+            "window": self.window.to_dict(),
+            "branch_utilization": self.branch_utilization.to_dict(),
+            "token_utilization": self.token_utilization.to_dict(),
+            "evaluation_utilization": self.evaluation_utilization.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunUtilizationReport:
+        _exact(
+            data,
+            {
+                "schema_version",
+                "run_id",
+                "generated_at",
+                "window",
+                "branch_utilization",
+                "token_utilization",
+                "evaluation_utilization",
+            },
+        )
+        if data.get("schema_version") != 1:
+            raise ValueError("schema_version must be 1")
+        return cls(
+            run_id=_required_string(data.get("run_id"), "run_id"),
+            generated_at=_required_string(data.get("generated_at"), "generated_at"),
+            window=UtilizationWindow.from_dict(_record(data.get("window"), "window")),
+            branch_utilization=BranchUtilization.from_dict(
+                _record(data.get("branch_utilization"), "branch_utilization")
+            ),
+            token_utilization=TokenUtilization.from_dict(_record(data.get("token_utilization"), "token_utilization")),
+            evaluation_utilization=EvaluationUtilization.from_dict(
+                _record(data.get("evaluation_utilization"), "evaluation_utilization")
+            ),
+        )
+
+
+def build_run_utilization_report(
+    *,
+    run_id: str,
+    events: list[dict[str, Any]],
+    role_usage: list[dict[str, Any]],
+    generated_at: str | None = None,
+) -> RunUtilizationReport:
+    normalized_events = [_normalize_event(event) for event in events]
+    normalized_usage = [_normalize_usage(row) for row in role_usage]
+    started_at, completed_at, duration = _window(normalized_events, normalized_usage)
+    branches = _branch_ids(normalized_events, normalized_usage)
+    max_parallel = _max_parallel_branches(normalized_events, completed_at) if branches else None
+    capacity = _round(duration * max_parallel) if duration is not None and max_parallel else None
+    eval_events = [event for event in normalized_events if event.get("event_type") in _EVAL_FINISHED]
+    eval_active = _sum_duration(normalized_events, _EVAL_ACTIVE)
+    explicit_runner_active = _sum_duration(normalized_events, _RUNNER_ACTIVE)
+    active_runner = explicit_runner_active if explicit_runner_active is not None else eval_active
+    verifier_active = _sum_duration(normalized_events, _VERIFIER_ACTIVE)
+    input_tokens = sum(_int(row.get("input_tokens")) for row in normalized_usage)
+    output_tokens = sum(_int(row.get("output_tokens")) for row in normalized_usage)
+    total_tokens = input_tokens + output_tokens
+    model_active = _sum_usage_seconds(normalized_usage, "latency_ms", scale=1000.0)
+    model_wait = _sum_usage_seconds(normalized_usage, "model_wait_seconds")
+
+    return RunUtilizationReport.from_dict(
+        {
+            "schema_version": 1,
+            "run_id": run_id,
+            "generated_at": generated_at or datetime.now().astimezone().isoformat(),
+            "window": {
+                "started_at": started_at,
+                "completed_at": completed_at,
+                "duration_seconds": duration,
+            },
+            "branch_utilization": {
+                "branch_count": len(branches) if branches else None,
+                "max_parallel_branches": max_parallel,
+                "runner_capacity_seconds": capacity,
+                "active_runner_seconds": active_runner,
+                "idle_runner_seconds": _diff_or_none(capacity, active_runner),
+                "mean_runner_utilization": _ratio(active_runner, capacity),
+            },
+            "token_utilization": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "total_tokens": total_tokens,
+                "model_active_seconds": model_active,
+                "model_wait_seconds": model_wait,
+                "mean_token_utilization": _ratio(model_active, capacity),
+                "token_throughput_per_second": _ratio(total_tokens, model_active),
+                "tokens_to_success": _tokens_to_success(normalized_events, normalized_usage),
+            },
+            "evaluation_utilization": {
+                "eval_count": len(eval_events),
+                "eval_active_seconds": eval_active,
+                "verifier_active_seconds": verifier_active,
+                "verifier_idle_seconds": _diff_or_none(capacity, verifier_active),
+                "eval_throughput_per_second": _ratio(len(eval_events), duration),
+            },
+        }
+    )
+
+
+_RUNNER_ACTIVE = {"runner_active", "worker_active"}
+_EVAL_FINISHED = {"evaluation_finished", "eval_finished"}
+_EVAL_ACTIVE = {"evaluation_finished", "eval_finished", "evaluation_active"}
+_VERIFIER_ACTIVE = {"verifier_finished", "verification_finished", "verifier_active"}
+
+
+def _normalize_event(event: dict[str, Any]) -> dict[str, Any]:
+    raw_payload = event.get("payload")
+    payload = raw_payload if isinstance(raw_payload, dict) else {}
+    score_value = event.get("score") if event.get("score") is not None else payload.get("score")
+    verifier_passed = event.get("verifier_passed")
+    return {
+        **event,
+        "event_type": _string(event.get("event_type") or event.get("event")),
+        "timestamp": _string(event.get("timestamp") or event.get("ts")),
+        "branch_id": _string(event.get("branch_id") or payload.get("branch_id") or payload.get("worker_id")),
+        "duration_seconds": _float_or_none(event.get("duration_seconds") or payload.get("duration_seconds")),
+        "score": _float_or_none(score_value),
+        "verifier_passed": verifier_passed if isinstance(verifier_passed, bool) else payload.get("verifier_passed"),
+        "outcome": _string(event.get("outcome") or payload.get("outcome")),
+    }
+
+
+def _normalize_usage(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **row,
+        "timestamp": _string(row.get("timestamp") or row.get("ts")),
+        "branch_id": _string(row.get("branch_id") or row.get("worker_id")),
+        "input_tokens": _int(row.get("input_tokens")),
+        "output_tokens": _int(row.get("output_tokens")),
+        "latency_ms": _float_or_none(row.get("latency_ms")),
+        "model_wait_seconds": _float_or_none(row.get("model_wait_seconds")),
+    }
+
+
+def _window(events: list[dict[str, Any]], usage: list[dict[str, Any]]) -> tuple[str | None, str | None, float | None]:
+    values = [stamp for item in [*events, *usage] if (stamp := _parse_time(_string(item.get("timestamp"))))]
+    if not values:
+        return None, None, None
+    start = min(values)
+    end = max(values)
+    return _format_time(start), _format_time(end), _round((end - start).total_seconds())
+
+
+def _branch_ids(events: list[dict[str, Any]], usage: list[dict[str, Any]]) -> set[str]:
+    return {branch for item in [*events, *usage] if (branch := _string(item.get("branch_id")))}
+
+
+def _max_parallel_branches(events: list[dict[str, Any]], completed_at: str | None) -> int | None:
+    starts: dict[str, datetime] = {}
+    finishes: dict[str, datetime] = {}
+    for event in events:
+        branch = _string(event.get("branch_id"))
+        timestamp = _parse_time(_string(event.get("timestamp")))
+        if not branch or timestamp is None:
+            continue
+        if event.get("event_type") == "branch_started":
+            starts[branch] = timestamp
+        if event.get("event_type") == "branch_finished":
+            finishes[branch] = timestamp
+    fallback_end = _parse_time(completed_at or "")
+    points: list[tuple[datetime, int]] = []
+    for branch, start in starts.items():
+        if start is None:
+            continue
+        end = finishes.get(branch) or fallback_end
+        points.append((start, 1))
+        if end is not None:
+            points.append((end, -1))
+    if not points:
+        return len(_branch_ids(events, [])) or None
+    current = 0
+    max_seen = 0
+    for _, delta in sorted(points, key=lambda item: (item[0], item[1])):
+        current += delta
+        max_seen = max(max_seen, current)
+    return max_seen or None
+
+
+def _sum_duration(events: list[dict[str, Any]], event_types: set[str]) -> float | None:
+    values: list[float] = []
+    for event in events:
+        value = _float_or_none(event.get("duration_seconds"))
+        if event.get("event_type") in event_types and value is not None:
+            values.append(value)
+    return _round(sum(values)) if values else None
+
+
+def _sum_usage_seconds(rows: list[dict[str, Any]], key: str, *, scale: float = 1.0) -> float | None:
+    values: list[float] = []
+    for row in rows:
+        value = _float_or_none(row.get(key))
+        if value is not None:
+            values.append(value)
+    return _round(sum(values) / scale) if values else None
+
+
+def _tokens_to_success(events: list[dict[str, Any]], usage: list[dict[str, Any]]) -> int | None:
+    success_times: list[datetime] = []
+    for event in events:
+        timestamp = _parse_time(_string(event.get("timestamp")))
+        if _is_success(event) and timestamp is not None:
+            success_times.append(timestamp)
+    if not success_times:
+        return None
+    first_success = min(success_times)
+    total = 0
+    for row in usage:
+        timestamp = _parse_time(_string(row.get("timestamp")))
+        if timestamp is not None and timestamp <= first_success:
+            total += _int(row.get("input_tokens")) + _int(row.get("output_tokens"))
+    return total
+
+
+def _is_success(event: dict[str, Any]) -> bool:
+    return event.get("verifier_passed") is True or _string(event.get("outcome")) == "success"
+
+
+def _diff_or_none(left: float | None, right: float | None) -> float | None:
+    return _round(max(0.0, left - right)) if left is not None and right is not None else None
+
+
+def _ratio(numerator: float | int | None, denominator: float | int | None) -> float | None:
+    if numerator is None or denominator is None or denominator == 0:
+        return None
+    return _round(float(numerator) / float(denominator))
+
+
+def _round(value: float) -> float:
+    return round(value, 6)
+
+
+def _parse_time(value: str) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _format_time(value: datetime) -> str:
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def _record(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _exact(data: dict[str, Any], allowed: set[str]) -> None:
+    extra = sorted(set(data) - allowed)
+    if extra:
+        raise ValueError(f"unexpected field(s): {', '.join(extra)}")
+
+
+def _required_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _nullable_string(value: Any, label: str) -> str | None:
+    if value is None:
+        return None
+    return _required_string(value, label)
+
+
+def _required_int(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{label} must be an integer")
+    return value
+
+
+def _nullable_int(value: Any, label: str) -> int | None:
+    if value is None:
+        return None
+    return _required_int(value, label)
+
+
+def _nullable_number(value: Any, label: str) -> float | None:
+    if value is None:
+        return None
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError(f"{label} must be a number or null")
+    return float(value)
+
+
+def _string(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _int(value: Any) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _float_or_none(value: Any) -> float | None:
+    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+__all__ = [
+    "BranchUtilization",
+    "EvaluationUtilization",
+    "RunUtilizationReport",
+    "TokenUtilization",
+    "UtilizationWindow",
+    "build_run_utilization_report",
+]

--- a/autocontext/src/autocontext/analytics/run_utilization_report.py
+++ b/autocontext/src/autocontext/analytics/run_utilization_report.py
@@ -111,9 +111,9 @@ class TokenUtilization:
             },
         )
         return cls(
-            input_tokens=_required_int(data.get("input_tokens"), "input_tokens"),
-            output_tokens=_required_int(data.get("output_tokens"), "output_tokens"),
-            total_tokens=_required_int(data.get("total_tokens"), "total_tokens"),
+            input_tokens=_required_nonnegative_int(data.get("input_tokens"), "input_tokens"),
+            output_tokens=_required_nonnegative_int(data.get("output_tokens"), "output_tokens"),
+            total_tokens=_required_nonnegative_int(data.get("total_tokens"), "total_tokens"),
             model_active_seconds=_nullable_number(data.get("model_active_seconds"), "model_active_seconds"),
             model_wait_seconds=_nullable_number(data.get("model_wait_seconds"), "model_wait_seconds"),
             mean_token_utilization=_nullable_number(data.get("mean_token_utilization"), "mean_token_utilization"),
@@ -121,7 +121,7 @@ class TokenUtilization:
                 data.get("token_throughput_per_second"),
                 "token_throughput_per_second",
             ),
-            tokens_to_success=_nullable_int(data.get("tokens_to_success"), "tokens_to_success"),
+            tokens_to_success=_nullable_nonnegative_int(data.get("tokens_to_success"), "tokens_to_success"),
         )
 
 
@@ -155,7 +155,7 @@ class EvaluationUtilization:
             },
         )
         return cls(
-            eval_count=_required_int(data.get("eval_count"), "eval_count"),
+            eval_count=_required_nonnegative_int(data.get("eval_count"), "eval_count"),
             eval_active_seconds=_nullable_number(data.get("eval_active_seconds"), "eval_active_seconds"),
             verifier_active_seconds=_nullable_number(data.get("verifier_active_seconds"), "verifier_active_seconds"),
             verifier_idle_seconds=_nullable_number(data.get("verifier_idle_seconds"), "verifier_idle_seconds"),
@@ -206,9 +206,7 @@ class RunUtilizationReport:
             run_id=_required_string(data.get("run_id"), "run_id"),
             generated_at=_required_string(data.get("generated_at"), "generated_at"),
             window=UtilizationWindow.from_dict(_record(data.get("window"), "window")),
-            branch_utilization=BranchUtilization.from_dict(
-                _record(data.get("branch_utilization"), "branch_utilization")
-            ),
+            branch_utilization=BranchUtilization.from_dict(_record(data.get("branch_utilization"), "branch_utilization")),
             token_utilization=TokenUtilization.from_dict(_record(data.get("token_utilization"), "token_utilization")),
             evaluation_utilization=EvaluationUtilization.from_dict(
                 _record(data.get("evaluation_utilization"), "evaluation_utilization")
@@ -428,6 +426,9 @@ def _record(value: Any, label: str) -> dict[str, Any]:
 
 
 def _exact(data: dict[str, Any], allowed: set[str]) -> None:
+    missing = sorted(allowed - set(data))
+    if missing:
+        raise ValueError(f"missing field(s): {', '.join(missing)}")
     extra = sorted(set(data) - allowed)
     if extra:
         raise ValueError(f"unexpected field(s): {', '.join(extra)}")
@@ -457,6 +458,19 @@ def _nullable_int(value: Any, label: str) -> int | None:
     return _required_int(value, label)
 
 
+def _required_nonnegative_int(value: Any, label: str) -> int:
+    result = _required_int(value, label)
+    if result < 0:
+        raise ValueError(f"{label} must be a non-negative integer")
+    return result
+
+
+def _nullable_nonnegative_int(value: Any, label: str) -> int | None:
+    if value is None:
+        return None
+    return _required_nonnegative_int(value, label)
+
+
 def _nullable_number(value: Any, label: str) -> float | None:
     if value is None:
         return None
@@ -470,7 +484,7 @@ def _string(value: Any) -> str:
 
 
 def _int(value: Any) -> int:
-    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
 
 
 def _float_or_none(value: Any) -> float | None:

--- a/autocontext/tests/test_run_utilization_report.py
+++ b/autocontext/tests/test_run_utilization_report.py
@@ -38,13 +38,64 @@ def test_run_utilization_report_rejects_schema_invalid_data() -> None:
     from autocontext.analytics.run_utilization_report import RunUtilizationReport
 
     expected = _cases()[1]["expected_report"]
+    missing_duration = {
+        **expected,
+        "window": {k: v for k, v in expected["window"].items() if k != "duration_seconds"},
+    }
+    missing_model_wait = {
+        **expected,
+        "token_utilization": {k: v for k, v in expected["token_utilization"].items() if k != "model_wait_seconds"},
+    }
+    negative_tokens = {
+        **expected,
+        "token_utilization": {**expected["token_utilization"], "input_tokens": -1},
+    }
+    negative_eval_count = {
+        **expected,
+        "evaluation_utilization": {**expected["evaluation_utilization"], "eval_count": -1},
+    }
     for payload in [
         {**expected, "surprise": True},
         {**expected, "run_id": ""},
         {**expected, "generated_at": ""},
+        missing_duration,
+        missing_model_wait,
+        negative_tokens,
+        negative_eval_count,
     ]:
         try:
             RunUtilizationReport.from_dict(payload)
         except ValueError:
             continue
         raise AssertionError("schema-invalid utilization report was accepted")
+
+
+def test_build_run_utilization_report_never_emits_negative_token_counts() -> None:
+    from autocontext.analytics.run_utilization_report import build_run_utilization_report
+
+    report = build_run_utilization_report(
+        run_id="negative-token-run",
+        generated_at="2026-06-16T12:00:00Z",
+        events=[
+            {
+                "event_type": "evaluation_finished",
+                "timestamp": "2026-06-16T12:00:01Z",
+                "branch_id": "branch-a",
+                "duration_seconds": 1,
+                "verifier_passed": True,
+            }
+        ],
+        role_usage=[
+            {
+                "timestamp": "2026-06-16T12:00:00Z",
+                "branch_id": "branch-a",
+                "input_tokens": -10,
+                "output_tokens": -5,
+            }
+        ],
+    )
+
+    assert report.token_utilization.input_tokens == 0
+    assert report.token_utilization.output_tokens == 0
+    assert report.token_utilization.total_tokens == 0
+    assert report.token_utilization.tokens_to_success == 0

--- a/autocontext/tests/test_run_utilization_report.py
+++ b/autocontext/tests/test_run_utilization_report.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_PATH = ROOT / "docs" / "run-utilization-report-parity-fixture.json"
+
+
+def _cases() -> list[dict[str, Any]]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))["cases"]
+
+
+def test_build_run_utilization_report_matches_shared_fixture() -> None:
+    from autocontext.analytics.run_utilization_report import build_run_utilization_report
+
+    for case in _cases():
+        report = build_run_utilization_report(
+            run_id=case["run_id"],
+            events=case["events"],
+            role_usage=case["role_usage"],
+            generated_at=case["generated_at"],
+        )
+
+        assert report.to_dict() == case["expected_report"]
+
+
+def test_run_utilization_report_round_trips_from_shared_json() -> None:
+    from autocontext.analytics.run_utilization_report import RunUtilizationReport
+
+    for case in _cases():
+        expected = case["expected_report"]
+        assert RunUtilizationReport.from_dict(expected).to_dict() == expected
+
+
+def test_run_utilization_report_rejects_schema_invalid_data() -> None:
+    from autocontext.analytics.run_utilization_report import RunUtilizationReport
+
+    expected = _cases()[1]["expected_report"]
+    for payload in [
+        {**expected, "surprise": True},
+        {**expected, "run_id": ""},
+        {**expected, "generated_at": ""},
+    ]:
+        try:
+            RunUtilizationReport.from_dict(payload)
+        except ValueError:
+            continue
+        raise AssertionError("schema-invalid utilization report was accepted")

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - [Scenario parity matrix — Python & TypeScript](scenario-parity-matrix.md)
 - [Scenario environment contract](scenario-environment-contract.md)
 - [Run progress report](run-progress-report.md)
+- [Run utilization report](run-utilization-report.md)
 - [Browser exploration contract](browser-exploration-contract.md)
 - [OpenTelemetry bridge](opentelemetry-bridge.md)
 - [Background session domain and parity contract](background-session-domain.md)

--- a/docs/run-utilization-report-parity-fixture.json
+++ b/docs/run-utilization-report-parity-fixture.json
@@ -1,0 +1,330 @@
+{
+  "cases": [
+    {
+      "name": "missing-telemetry",
+      "run_id": "run-utilization-missing",
+      "generated_at": "2026-01-01T00:10:00Z",
+      "events": [],
+      "role_usage": [],
+      "expected_report": {
+        "schema_version": 1,
+        "run_id": "run-utilization-missing",
+        "generated_at": "2026-01-01T00:10:00Z",
+        "window": {
+          "started_at": null,
+          "completed_at": null,
+          "duration_seconds": null
+        },
+        "branch_utilization": {
+          "branch_count": null,
+          "max_parallel_branches": null,
+          "runner_capacity_seconds": null,
+          "active_runner_seconds": null,
+          "idle_runner_seconds": null,
+          "mean_runner_utilization": null
+        },
+        "token_utilization": {
+          "input_tokens": 0,
+          "output_tokens": 0,
+          "total_tokens": 0,
+          "model_active_seconds": null,
+          "model_wait_seconds": null,
+          "mean_token_utilization": null,
+          "token_throughput_per_second": null,
+          "tokens_to_success": null
+        },
+        "evaluation_utilization": {
+          "eval_count": 0,
+          "eval_active_seconds": null,
+          "verifier_active_seconds": null,
+          "verifier_idle_seconds": null,
+          "eval_throughput_per_second": null
+        }
+      }
+    },
+    {
+      "name": "single-branch",
+      "run_id": "run-utilization-single",
+      "generated_at": "2026-01-01T00:03:00Z",
+      "events": [
+        {
+          "event_id": "b1-start",
+          "event_type": "branch_started",
+          "timestamp": "2026-01-01T00:00:00Z",
+          "branch_id": "branch-1"
+        },
+        {
+          "event_id": "b1-active",
+          "event_type": "runner_active",
+          "timestamp": "2026-01-01T00:00:10Z",
+          "branch_id": "branch-1",
+          "duration_seconds": 40.0
+        },
+        {
+          "event_id": "b1-eval",
+          "event_type": "evaluation_finished",
+          "timestamp": "2026-01-01T00:00:40Z",
+          "branch_id": "branch-1",
+          "duration_seconds": 30.0
+        },
+        {
+          "event_id": "b1-verifier",
+          "event_type": "verifier_finished",
+          "timestamp": "2026-01-01T00:00:50Z",
+          "branch_id": "branch-1",
+          "duration_seconds": 10.0
+        },
+        {
+          "event_id": "b1-success",
+          "event_type": "candidate_scored",
+          "timestamp": "2026-01-01T00:01:00Z",
+          "branch_id": "branch-1",
+          "score": 0.82,
+          "verifier_passed": true
+        },
+        {
+          "event_id": "b1-finish",
+          "event_type": "branch_finished",
+          "timestamp": "2026-01-01T00:02:00Z",
+          "branch_id": "branch-1"
+        }
+      ],
+      "role_usage": [
+        {
+          "timestamp": "2026-01-01T00:00:20Z",
+          "branch_id": "branch-1",
+          "input_tokens": 100,
+          "output_tokens": 50,
+          "latency_ms": 10000,
+          "model_wait_seconds": 3.0
+        },
+        {
+          "timestamp": "2026-01-01T00:00:55Z",
+          "branch_id": "branch-1",
+          "input_tokens": 150,
+          "output_tokens": 70,
+          "latency_ms": 20000,
+          "model_wait_seconds": 7.0
+        }
+      ],
+      "expected_report": {
+        "schema_version": 1,
+        "run_id": "run-utilization-single",
+        "generated_at": "2026-01-01T00:03:00Z",
+        "window": {
+          "started_at": "2026-01-01T00:00:00Z",
+          "completed_at": "2026-01-01T00:02:00Z",
+          "duration_seconds": 120.0
+        },
+        "branch_utilization": {
+          "branch_count": 1,
+          "max_parallel_branches": 1,
+          "runner_capacity_seconds": 120.0,
+          "active_runner_seconds": 40.0,
+          "idle_runner_seconds": 80.0,
+          "mean_runner_utilization": 0.333333
+        },
+        "token_utilization": {
+          "input_tokens": 250,
+          "output_tokens": 120,
+          "total_tokens": 370,
+          "model_active_seconds": 30.0,
+          "model_wait_seconds": 10.0,
+          "mean_token_utilization": 0.25,
+          "token_throughput_per_second": 12.333333,
+          "tokens_to_success": 370
+        },
+        "evaluation_utilization": {
+          "eval_count": 1,
+          "eval_active_seconds": 30.0,
+          "verifier_active_seconds": 10.0,
+          "verifier_idle_seconds": 110.0,
+          "eval_throughput_per_second": 0.008333
+        }
+      }
+    },
+    {
+      "name": "multi-branch",
+      "run_id": "run-utilization-multi",
+      "generated_at": "2026-01-01T00:03:00Z",
+      "events": [
+        {
+          "event_id": "a-start",
+          "event_type": "branch_started",
+          "timestamp": "2026-01-01T00:00:00Z",
+          "branch_id": "branch-a"
+        },
+        {
+          "event_id": "b-start",
+          "event_type": "branch_started",
+          "timestamp": "2026-01-01T00:00:00Z",
+          "branch_id": "branch-b"
+        },
+        {
+          "event_id": "c-start",
+          "event_type": "branch_started",
+          "timestamp": "2026-01-01T00:00:30Z",
+          "branch_id": "branch-c"
+        },
+        {
+          "event_id": "a-active",
+          "event_type": "runner_active",
+          "timestamp": "2026-01-01T00:00:10Z",
+          "branch_id": "branch-a",
+          "duration_seconds": 60.0
+        },
+        {
+          "event_id": "b-active",
+          "event_type": "runner_active",
+          "timestamp": "2026-01-01T00:00:20Z",
+          "branch_id": "branch-b",
+          "duration_seconds": 50.0
+        },
+        {
+          "event_id": "c-active",
+          "event_type": "runner_active",
+          "timestamp": "2026-01-01T00:00:50Z",
+          "branch_id": "branch-c",
+          "duration_seconds": 40.0
+        },
+        {
+          "event_id": "a-eval",
+          "event_type": "evaluation_finished",
+          "timestamp": "2026-01-01T00:00:50Z",
+          "branch_id": "branch-a",
+          "duration_seconds": 40.0
+        },
+        {
+          "event_id": "b-eval",
+          "event_type": "evaluation_finished",
+          "timestamp": "2026-01-01T00:01:00Z",
+          "branch_id": "branch-b",
+          "duration_seconds": 30.0
+        },
+        {
+          "event_id": "c-eval",
+          "event_type": "evaluation_finished",
+          "timestamp": "2026-01-01T00:01:20Z",
+          "branch_id": "branch-c",
+          "duration_seconds": 20.0
+        },
+        {
+          "event_id": "a-verifier",
+          "event_type": "verifier_finished",
+          "timestamp": "2026-01-01T00:01:00Z",
+          "branch_id": "branch-a",
+          "duration_seconds": 10.0
+        },
+        {
+          "event_id": "b-verifier",
+          "event_type": "verifier_finished",
+          "timestamp": "2026-01-01T00:01:10Z",
+          "branch_id": "branch-b",
+          "duration_seconds": 10.0
+        },
+        {
+          "event_id": "c-verifier",
+          "event_type": "verifier_finished",
+          "timestamp": "2026-01-01T00:01:25Z",
+          "branch_id": "branch-c",
+          "duration_seconds": 5.0
+        },
+        {
+          "event_id": "b-success",
+          "event_type": "candidate_scored",
+          "timestamp": "2026-01-01T00:01:10Z",
+          "branch_id": "branch-b",
+          "score": 0.85,
+          "verifier_passed": true
+        },
+        {
+          "event_id": "a-finish",
+          "event_type": "branch_finished",
+          "timestamp": "2026-01-01T00:02:00Z",
+          "branch_id": "branch-a"
+        },
+        {
+          "event_id": "b-finish",
+          "event_type": "branch_finished",
+          "timestamp": "2026-01-01T00:02:00Z",
+          "branch_id": "branch-b"
+        },
+        {
+          "event_id": "c-finish",
+          "event_type": "branch_finished",
+          "timestamp": "2026-01-01T00:02:00Z",
+          "branch_id": "branch-c"
+        }
+      ],
+      "role_usage": [
+        {
+          "timestamp": "2026-01-01T00:00:20Z",
+          "branch_id": "branch-a",
+          "input_tokens": 200,
+          "output_tokens": 100,
+          "latency_ms": 20000,
+          "model_wait_seconds": 8.0
+        },
+        {
+          "timestamp": "2026-01-01T00:00:50Z",
+          "branch_id": "branch-b",
+          "input_tokens": 120,
+          "output_tokens": 80,
+          "latency_ms": 10000,
+          "model_wait_seconds": 5.0
+        },
+        {
+          "timestamp": "2026-01-01T00:01:05Z",
+          "branch_id": "branch-b",
+          "input_tokens": 180,
+          "output_tokens": 120,
+          "latency_ms": 20000,
+          "model_wait_seconds": 4.0
+        },
+        {
+          "timestamp": "2026-01-01T00:01:30Z",
+          "branch_id": "branch-c",
+          "input_tokens": 100,
+          "output_tokens": 50,
+          "latency_ms": 10000,
+          "model_wait_seconds": 2.0
+        }
+      ],
+      "expected_report": {
+        "schema_version": 1,
+        "run_id": "run-utilization-multi",
+        "generated_at": "2026-01-01T00:03:00Z",
+        "window": {
+          "started_at": "2026-01-01T00:00:00Z",
+          "completed_at": "2026-01-01T00:02:00Z",
+          "duration_seconds": 120.0
+        },
+        "branch_utilization": {
+          "branch_count": 3,
+          "max_parallel_branches": 3,
+          "runner_capacity_seconds": 360.0,
+          "active_runner_seconds": 150.0,
+          "idle_runner_seconds": 210.0,
+          "mean_runner_utilization": 0.416667
+        },
+        "token_utilization": {
+          "input_tokens": 600,
+          "output_tokens": 350,
+          "total_tokens": 950,
+          "model_active_seconds": 60.0,
+          "model_wait_seconds": 19.0,
+          "mean_token_utilization": 0.166667,
+          "token_throughput_per_second": 15.833333,
+          "tokens_to_success": 800
+        },
+        "evaluation_utilization": {
+          "eval_count": 3,
+          "eval_active_seconds": 90.0,
+          "verifier_active_seconds": 25.0,
+          "verifier_idle_seconds": 335.0,
+          "eval_throughput_per_second": 0.025
+        }
+      }
+    }
+  ]
+}

--- a/docs/run-utilization-report.json
+++ b/docs/run-utilization-report.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/greyhaven-ai/autocontext/docs/run-utilization-report.json",
+  "title": "RunUtilizationReport",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "generated_at",
+    "window",
+    "branch_utilization",
+    "token_utilization",
+    "evaluation_utilization"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "run_id": { "type": "string", "minLength": 1 },
+    "generated_at": { "type": "string", "minLength": 1 },
+    "window": { "$ref": "#/$defs/window" },
+    "branch_utilization": { "$ref": "#/$defs/branchUtilization" },
+    "token_utilization": { "$ref": "#/$defs/tokenUtilization" },
+    "evaluation_utilization": { "$ref": "#/$defs/evaluationUtilization" }
+  },
+  "$defs": {
+    "nullableString": { "type": ["string", "null"] },
+    "nullableNumber": { "type": ["number", "null"] },
+    "nullableInteger": { "type": ["integer", "null"] },
+    "window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["started_at", "completed_at", "duration_seconds"],
+      "properties": {
+        "started_at": { "$ref": "#/$defs/nullableString" },
+        "completed_at": { "$ref": "#/$defs/nullableString" },
+        "duration_seconds": { "$ref": "#/$defs/nullableNumber" }
+      }
+    },
+    "branchUtilization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "branch_count",
+        "max_parallel_branches",
+        "runner_capacity_seconds",
+        "active_runner_seconds",
+        "idle_runner_seconds",
+        "mean_runner_utilization"
+      ],
+      "properties": {
+        "branch_count": { "$ref": "#/$defs/nullableInteger" },
+        "max_parallel_branches": { "$ref": "#/$defs/nullableInteger" },
+        "runner_capacity_seconds": { "$ref": "#/$defs/nullableNumber" },
+        "active_runner_seconds": { "$ref": "#/$defs/nullableNumber" },
+        "idle_runner_seconds": { "$ref": "#/$defs/nullableNumber" },
+        "mean_runner_utilization": { "$ref": "#/$defs/nullableNumber" }
+      }
+    },
+    "tokenUtilization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "model_active_seconds",
+        "model_wait_seconds",
+        "mean_token_utilization",
+        "token_throughput_per_second",
+        "tokens_to_success"
+      ],
+      "properties": {
+        "input_tokens": { "type": "integer", "minimum": 0 },
+        "output_tokens": { "type": "integer", "minimum": 0 },
+        "total_tokens": { "type": "integer", "minimum": 0 },
+        "model_active_seconds": { "$ref": "#/$defs/nullableNumber" },
+        "model_wait_seconds": { "$ref": "#/$defs/nullableNumber" },
+        "mean_token_utilization": { "$ref": "#/$defs/nullableNumber" },
+        "token_throughput_per_second": { "$ref": "#/$defs/nullableNumber" },
+        "tokens_to_success": { "$ref": "#/$defs/nullableInteger" }
+      }
+    },
+    "evaluationUtilization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eval_count",
+        "eval_active_seconds",
+        "verifier_active_seconds",
+        "verifier_idle_seconds",
+        "eval_throughput_per_second"
+      ],
+      "properties": {
+        "eval_count": { "type": "integer", "minimum": 0 },
+        "eval_active_seconds": { "$ref": "#/$defs/nullableNumber" },
+        "verifier_active_seconds": { "$ref": "#/$defs/nullableNumber" },
+        "verifier_idle_seconds": { "$ref": "#/$defs/nullableNumber" },
+        "eval_throughput_per_second": { "$ref": "#/$defs/nullableNumber" }
+      }
+    }
+  }
+}

--- a/docs/run-utilization-report.json
+++ b/docs/run-utilization-report.json
@@ -77,7 +77,7 @@
         "model_wait_seconds": { "$ref": "#/$defs/nullableNumber" },
         "mean_token_utilization": { "$ref": "#/$defs/nullableNumber" },
         "token_throughput_per_second": { "$ref": "#/$defs/nullableNumber" },
-        "tokens_to_success": { "$ref": "#/$defs/nullableInteger" }
+        "tokens_to_success": { "type": ["integer", "null"], "minimum": 0 }
       }
     },
     "evaluationUtilization": {

--- a/docs/run-utilization-report.md
+++ b/docs/run-utilization-report.md
@@ -1,0 +1,21 @@
+# Run Utilization Report
+
+AC-822 adds a descriptive report for parallel autoresearch runs. It does not gate runs.
+
+## Window semantics
+
+`window.started_at` and `window.completed_at` are the earliest and latest known telemetry timestamps from run events and role usage rows. `duration_seconds` is null when no telemetry has timestamps.
+
+## Metrics
+
+- `mean_runner_utilization`: `active_runner_seconds / runner_capacity_seconds`.
+- `runner_capacity_seconds`: `window.duration_seconds * max_parallel_branches`.
+- `mean_token_utilization`: `model_active_seconds / runner_capacity_seconds`.
+- `token_throughput_per_second`: `total_tokens / model_active_seconds`.
+- `tokens_to_success`: tokens from role usage rows at or before the first success event.
+- `verifier_idle_seconds`: `runner_capacity_seconds - verifier_active_seconds`.
+- `eval_throughput_per_second`: completed evaluations per window second.
+
+Unknown telemetry is represented as `null`; token counts degrade to `0`.
+
+Shared schema: [`run-utilization-report.json`](run-utilization-report.json). Parity fixture: [`run-utilization-report-parity-fixture.json`](run-utilization-report-parity-fixture.json).

--- a/ts/src/analytics/run-utilization-report.ts
+++ b/ts/src/analytics/run-utilization-report.ts
@@ -1,0 +1,427 @@
+export interface RunUtilizationEventInput {
+  event_id?: string;
+  event_type?: string;
+  event?: string;
+  timestamp?: string;
+  ts?: string;
+  branch_id?: string;
+  worker_id?: string;
+  duration_seconds?: number;
+  score?: number;
+  verifier_passed?: boolean;
+  outcome?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface RunUtilizationRoleUsageInput {
+  timestamp?: string;
+  ts?: string;
+  branch_id?: string;
+  worker_id?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  latency_ms?: number;
+  model_wait_seconds?: number;
+}
+
+export interface UtilizationWindow {
+  started_at: string | null;
+  completed_at: string | null;
+  duration_seconds: number | null;
+}
+
+export interface BranchUtilization {
+  branch_count: number | null;
+  max_parallel_branches: number | null;
+  runner_capacity_seconds: number | null;
+  active_runner_seconds: number | null;
+  idle_runner_seconds: number | null;
+  mean_runner_utilization: number | null;
+}
+
+export interface TokenUtilization {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  model_active_seconds: number | null;
+  model_wait_seconds: number | null;
+  mean_token_utilization: number | null;
+  token_throughput_per_second: number | null;
+  tokens_to_success: number | null;
+}
+
+export interface EvaluationUtilization {
+  eval_count: number;
+  eval_active_seconds: number | null;
+  verifier_active_seconds: number | null;
+  verifier_idle_seconds: number | null;
+  eval_throughput_per_second: number | null;
+}
+
+export interface RunUtilizationReport {
+  schema_version: 1;
+  run_id: string;
+  generated_at: string;
+  window: UtilizationWindow;
+  branch_utilization: BranchUtilization;
+  token_utilization: TokenUtilization;
+  evaluation_utilization: EvaluationUtilization;
+}
+
+export interface BuildRunUtilizationReportInput {
+  runId: string;
+  events: RunUtilizationEventInput[];
+  roleUsage: RunUtilizationRoleUsageInput[];
+  generatedAt?: string;
+}
+
+interface NormalizedUtilizationEvent {
+  eventType: string;
+  timestamp: string;
+  branchId: string;
+  durationSeconds: number | null;
+  score: number | null;
+  verifierPassed: boolean | null;
+  outcome: string;
+}
+
+interface NormalizedRoleUsage {
+  timestamp: string;
+  branchId: string;
+  inputTokens: number;
+  outputTokens: number;
+  latencyMs: number | null;
+  modelWaitSeconds: number | null;
+}
+
+const RUNNER_ACTIVE = new Set(["runner_active", "worker_active"]);
+const EVAL_FINISHED = new Set(["evaluation_finished", "eval_finished"]);
+const EVAL_ACTIVE = new Set(["evaluation_finished", "eval_finished", "evaluation_active"]);
+const VERIFIER_ACTIVE = new Set(["verifier_finished", "verification_finished", "verifier_active"]);
+
+export function buildRunUtilizationReport(input: BuildRunUtilizationReportInput): RunUtilizationReport {
+  const events = input.events.map(normalizeEvent);
+  const roleUsage = input.roleUsage.map(normalizeUsage);
+  const window = utilizationWindow(events, roleUsage);
+  const branches = branchIds(events, roleUsage);
+  const maxParallel = branches.size ? maxParallelBranches(events, window.completed_at) : null;
+  const capacity = window.duration_seconds !== null && maxParallel ? round(window.duration_seconds * maxParallel) : null;
+  const evalEvents = events.filter((event) => EVAL_FINISHED.has(event.eventType));
+  const evalActive = sumDuration(events, EVAL_ACTIVE);
+  const explicitRunnerActive = sumDuration(events, RUNNER_ACTIVE);
+  const activeRunner = explicitRunnerActive ?? evalActive;
+  const verifierActive = sumDuration(events, VERIFIER_ACTIVE);
+  const inputTokens = roleUsage.reduce((total, row) => total + row.inputTokens, 0);
+  const outputTokens = roleUsage.reduce((total, row) => total + row.outputTokens, 0);
+  const totalTokens = inputTokens + outputTokens;
+  const modelActive = sumUsageSeconds(roleUsage, "latencyMs", 1000);
+  const modelWait = sumUsageSeconds(roleUsage, "modelWaitSeconds", 1);
+
+  return parseRunUtilizationReport({
+    schema_version: 1,
+    run_id: input.runId,
+    generated_at: input.generatedAt ?? new Date().toISOString(),
+    window,
+    branch_utilization: {
+      branch_count: branches.size || null,
+      max_parallel_branches: maxParallel,
+      runner_capacity_seconds: capacity,
+      active_runner_seconds: activeRunner,
+      idle_runner_seconds: diffOrNull(capacity, activeRunner),
+      mean_runner_utilization: ratio(activeRunner, capacity),
+    },
+    token_utilization: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      total_tokens: totalTokens,
+      model_active_seconds: modelActive,
+      model_wait_seconds: modelWait,
+      mean_token_utilization: ratio(modelActive, capacity),
+      token_throughput_per_second: ratio(totalTokens, modelActive),
+      tokens_to_success: tokensToSuccess(events, roleUsage),
+    },
+    evaluation_utilization: {
+      eval_count: evalEvents.length,
+      eval_active_seconds: evalActive,
+      verifier_active_seconds: verifierActive,
+      verifier_idle_seconds: diffOrNull(capacity, verifierActive),
+      eval_throughput_per_second: ratio(evalEvents.length, window.duration_seconds),
+    },
+  });
+}
+
+export function parseRunUtilizationReport(value: unknown): RunUtilizationReport {
+  const report = record(value, "utilization report");
+  exact(report, [
+    "schema_version",
+    "run_id",
+    "generated_at",
+    "window",
+    "branch_utilization",
+    "token_utilization",
+    "evaluation_utilization",
+  ]);
+  if (report.schema_version !== 1) throw new Error("schema_version must be 1");
+  return {
+    schema_version: 1,
+    run_id: string(report.run_id, "run_id"),
+    generated_at: string(report.generated_at, "generated_at"),
+    window: parseWindow(report.window),
+    branch_utilization: parseBranchUtilization(report.branch_utilization),
+    token_utilization: parseTokenUtilization(report.token_utilization),
+    evaluation_utilization: parseEvaluationUtilization(report.evaluation_utilization),
+  };
+}
+
+function parseWindow(value: unknown): UtilizationWindow {
+  const item = record(value, "window");
+  exact(item, ["started_at", "completed_at", "duration_seconds"]);
+  return {
+    started_at: nullableString(item.started_at, "started_at"),
+    completed_at: nullableString(item.completed_at, "completed_at"),
+    duration_seconds: nullableNumber(item.duration_seconds, "duration_seconds"),
+  };
+}
+
+function parseBranchUtilization(value: unknown): BranchUtilization {
+  const item = record(value, "branch utilization");
+  exact(item, [
+    "branch_count",
+    "max_parallel_branches",
+    "runner_capacity_seconds",
+    "active_runner_seconds",
+    "idle_runner_seconds",
+    "mean_runner_utilization",
+  ]);
+  return {
+    branch_count: nullableInteger(item.branch_count, "branch_count"),
+    max_parallel_branches: nullableInteger(item.max_parallel_branches, "max_parallel_branches"),
+    runner_capacity_seconds: nullableNumber(item.runner_capacity_seconds, "runner_capacity_seconds"),
+    active_runner_seconds: nullableNumber(item.active_runner_seconds, "active_runner_seconds"),
+    idle_runner_seconds: nullableNumber(item.idle_runner_seconds, "idle_runner_seconds"),
+    mean_runner_utilization: nullableNumber(item.mean_runner_utilization, "mean_runner_utilization"),
+  };
+}
+
+function parseTokenUtilization(value: unknown): TokenUtilization {
+  const item = record(value, "token utilization");
+  exact(item, [
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "model_active_seconds",
+    "model_wait_seconds",
+    "mean_token_utilization",
+    "token_throughput_per_second",
+    "tokens_to_success",
+  ]);
+  return {
+    input_tokens: integer(item.input_tokens, "input_tokens"),
+    output_tokens: integer(item.output_tokens, "output_tokens"),
+    total_tokens: integer(item.total_tokens, "total_tokens"),
+    model_active_seconds: nullableNumber(item.model_active_seconds, "model_active_seconds"),
+    model_wait_seconds: nullableNumber(item.model_wait_seconds, "model_wait_seconds"),
+    mean_token_utilization: nullableNumber(item.mean_token_utilization, "mean_token_utilization"),
+    token_throughput_per_second: nullableNumber(
+      item.token_throughput_per_second,
+      "token_throughput_per_second",
+    ),
+    tokens_to_success: nullableInteger(item.tokens_to_success, "tokens_to_success"),
+  };
+}
+
+function parseEvaluationUtilization(value: unknown): EvaluationUtilization {
+  const item = record(value, "evaluation utilization");
+  exact(item, [
+    "eval_count",
+    "eval_active_seconds",
+    "verifier_active_seconds",
+    "verifier_idle_seconds",
+    "eval_throughput_per_second",
+  ]);
+  return {
+    eval_count: integer(item.eval_count, "eval_count"),
+    eval_active_seconds: nullableNumber(item.eval_active_seconds, "eval_active_seconds"),
+    verifier_active_seconds: nullableNumber(item.verifier_active_seconds, "verifier_active_seconds"),
+    verifier_idle_seconds: nullableNumber(item.verifier_idle_seconds, "verifier_idle_seconds"),
+    eval_throughput_per_second: nullableNumber(
+      item.eval_throughput_per_second,
+      "eval_throughput_per_second",
+    ),
+  };
+}
+
+function normalizeEvent(event: RunUtilizationEventInput): NormalizedUtilizationEvent {
+  const payload = event.payload ?? {};
+  const score = event.score ?? maybeNumber(payload.score);
+  const verifierPassed = event.verifier_passed ?? maybeBoolean(payload.verifier_passed) ?? null;
+  return {
+    eventType: event.event_type ?? event.event ?? "",
+    timestamp: event.timestamp ?? event.ts ?? "",
+    branchId: event.branch_id ?? maybeString(payload.branch_id) ?? event.worker_id ?? maybeString(payload.worker_id) ?? "",
+    durationSeconds: event.duration_seconds ?? maybeNumber(payload.duration_seconds) ?? null,
+    score: score ?? null,
+    verifierPassed,
+    outcome: event.outcome ?? maybeString(payload.outcome) ?? "",
+  };
+}
+
+function normalizeUsage(row: RunUtilizationRoleUsageInput): NormalizedRoleUsage {
+  return {
+    timestamp: row.timestamp ?? row.ts ?? "",
+    branchId: row.branch_id ?? row.worker_id ?? "",
+    inputTokens: integerOrZero(row.input_tokens),
+    outputTokens: integerOrZero(row.output_tokens),
+    latencyMs: maybeNumber(row.latency_ms) ?? null,
+    modelWaitSeconds: maybeNumber(row.model_wait_seconds) ?? null,
+  };
+}
+
+function utilizationWindow(events: NormalizedUtilizationEvent[], usage: NormalizedRoleUsage[]): UtilizationWindow {
+  const stamps = [...events.map((event) => event.timestamp), ...usage.map((row) => row.timestamp)]
+    .map(parseTime)
+    .filter((stamp): stamp is number => stamp !== null);
+  if (!stamps.length) return { started_at: null, completed_at: null, duration_seconds: null };
+  const start = Math.min(...stamps);
+  const end = Math.max(...stamps);
+  return {
+    started_at: formatTime(start),
+    completed_at: formatTime(end),
+    duration_seconds: round((end - start) / 1000),
+  };
+}
+
+function branchIds(events: NormalizedUtilizationEvent[], usage: NormalizedRoleUsage[]): Set<string> {
+  return new Set(
+    [...events.map((event) => event.branchId), ...usage.map((row) => row.branchId)].filter(Boolean),
+  );
+}
+
+function maxParallelBranches(events: NormalizedUtilizationEvent[], completedAt: string | null): number | null {
+  const starts = new Map<string, number>();
+  const finishes = new Map<string, number>();
+  for (const event of events) {
+    const timestamp = parseTime(event.timestamp);
+    if (!event.branchId || timestamp === null) continue;
+    if (event.eventType === "branch_started") starts.set(event.branchId, timestamp);
+    if (event.eventType === "branch_finished") finishes.set(event.branchId, timestamp);
+  }
+  const fallbackEnd = completedAt ? parseTime(completedAt) : null;
+  const points: Array<[number, number]> = [];
+  for (const [branch, start] of starts) {
+    points.push([start, 1]);
+    const end = finishes.get(branch) ?? fallbackEnd;
+    if (end !== null) points.push([end, -1]);
+  }
+  if (!points.length) return branchIds(events, [] as NormalizedRoleUsage[]).size || null;
+  let current = 0;
+  let maxSeen = 0;
+  for (const [, delta] of points.sort((left, right) => left[0] - right[0] || left[1] - right[1])) {
+    current += delta;
+    maxSeen = Math.max(maxSeen, current);
+  }
+  return maxSeen || null;
+}
+
+function sumDuration(events: NormalizedUtilizationEvent[], eventTypes: Set<string>): number | null {
+  const total = events
+    .filter((event) => eventTypes.has(event.eventType) && event.durationSeconds !== null)
+    .reduce((sum, event) => sum + (event.durationSeconds ?? 0), 0);
+  return total > 0 ? round(total) : null;
+}
+
+function sumUsageSeconds(rows: NormalizedRoleUsage[], key: "latencyMs" | "modelWaitSeconds", scale: number): number | null {
+  const values = rows.map((row) => row[key]).filter((value): value is number => value !== null);
+  return values.length ? round(values.reduce((sum, value) => sum + value, 0) / scale) : null;
+}
+
+function tokensToSuccess(events: NormalizedUtilizationEvent[], usage: NormalizedRoleUsage[]): number | null {
+  const successTimes = events
+    .filter((event) => event.verifierPassed === true || event.outcome === "success")
+    .map((event) => parseTime(event.timestamp))
+    .filter((stamp): stamp is number => stamp !== null);
+  if (!successTimes.length) return null;
+  const firstSuccess = Math.min(...successTimes);
+  return usage
+    .filter((row) => {
+      const timestamp = parseTime(row.timestamp);
+      return timestamp !== null && timestamp <= firstSuccess;
+    })
+    .reduce((total, row) => total + row.inputTokens + row.outputTokens, 0);
+}
+
+function diffOrNull(left: number | null, right: number | null): number | null {
+  return left !== null && right !== null ? round(Math.max(0, left - right)) : null;
+}
+
+function ratio(numerator: number | null, denominator: number | null): number | null {
+  if (numerator === null || denominator === null || denominator === 0) return null;
+  return round(numerator / denominator);
+}
+
+function round(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function parseTime(value: string): number | null {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function formatTime(timestamp: number): string {
+  return new Date(timestamp).toISOString().replace(/\.000Z$/, "Z");
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function exact(item: Record<string, unknown>, allowed: string[]): void {
+  const allowedSet = new Set(allowed);
+  const extra = Object.keys(item).filter((key) => !allowedSet.has(key));
+  if (extra.length) throw new Error(`unexpected field(s): ${extra.sort().join(", ")}`);
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a string`);
+  return value;
+}
+
+function nullableString(value: unknown, label: string): string | null {
+  return value === null || value === undefined ? null : string(value, label);
+}
+
+function number(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${label} must be a number`);
+  return value;
+}
+
+function nullableNumber(value: unknown, label: string): number | null {
+  return value === null || value === undefined ? null : number(value, label);
+}
+
+function integer(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) throw new Error(`${label} must be an integer`);
+  return value;
+}
+
+function nullableInteger(value: unknown, label: string): number | null {
+  return value === null || value === undefined ? null : integer(value, label);
+}
+
+function integerOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isInteger(value) ? value : 0;
+}
+
+function maybeString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length ? value : undefined;
+}
+
+function maybeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function maybeBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}

--- a/ts/src/analytics/run-utilization-report.ts
+++ b/ts/src/analytics/run-utilization-report.ts
@@ -99,13 +99,18 @@ const EVAL_FINISHED = new Set(["evaluation_finished", "eval_finished"]);
 const EVAL_ACTIVE = new Set(["evaluation_finished", "eval_finished", "evaluation_active"]);
 const VERIFIER_ACTIVE = new Set(["verifier_finished", "verification_finished", "verifier_active"]);
 
-export function buildRunUtilizationReport(input: BuildRunUtilizationReportInput): RunUtilizationReport {
+export function buildRunUtilizationReport(
+  input: BuildRunUtilizationReportInput,
+): RunUtilizationReport {
   const events = input.events.map(normalizeEvent);
   const roleUsage = input.roleUsage.map(normalizeUsage);
   const window = utilizationWindow(events, roleUsage);
   const branches = branchIds(events, roleUsage);
   const maxParallel = branches.size ? maxParallelBranches(events, window.completed_at) : null;
-  const capacity = window.duration_seconds !== null && maxParallel ? round(window.duration_seconds * maxParallel) : null;
+  const capacity =
+    window.duration_seconds !== null && maxParallel
+      ? round(window.duration_seconds * maxParallel)
+      : null;
   const evalEvents = events.filter((event) => EVAL_FINISHED.has(event.eventType));
   const evalActive = sumDuration(events, EVAL_ACTIVE);
   const explicitRunnerActive = sumDuration(events, RUNNER_ACTIVE);
@@ -196,10 +201,16 @@ function parseBranchUtilization(value: unknown): BranchUtilization {
   return {
     branch_count: nullableInteger(item.branch_count, "branch_count"),
     max_parallel_branches: nullableInteger(item.max_parallel_branches, "max_parallel_branches"),
-    runner_capacity_seconds: nullableNumber(item.runner_capacity_seconds, "runner_capacity_seconds"),
+    runner_capacity_seconds: nullableNumber(
+      item.runner_capacity_seconds,
+      "runner_capacity_seconds",
+    ),
     active_runner_seconds: nullableNumber(item.active_runner_seconds, "active_runner_seconds"),
     idle_runner_seconds: nullableNumber(item.idle_runner_seconds, "idle_runner_seconds"),
-    mean_runner_utilization: nullableNumber(item.mean_runner_utilization, "mean_runner_utilization"),
+    mean_runner_utilization: nullableNumber(
+      item.mean_runner_utilization,
+      "mean_runner_utilization",
+    ),
   };
 }
 
@@ -216,9 +227,9 @@ function parseTokenUtilization(value: unknown): TokenUtilization {
     "tokens_to_success",
   ]);
   return {
-    input_tokens: integer(item.input_tokens, "input_tokens"),
-    output_tokens: integer(item.output_tokens, "output_tokens"),
-    total_tokens: integer(item.total_tokens, "total_tokens"),
+    input_tokens: nonNegativeInteger(item.input_tokens, "input_tokens"),
+    output_tokens: nonNegativeInteger(item.output_tokens, "output_tokens"),
+    total_tokens: nonNegativeInteger(item.total_tokens, "total_tokens"),
     model_active_seconds: nullableNumber(item.model_active_seconds, "model_active_seconds"),
     model_wait_seconds: nullableNumber(item.model_wait_seconds, "model_wait_seconds"),
     mean_token_utilization: nullableNumber(item.mean_token_utilization, "mean_token_utilization"),
@@ -226,7 +237,7 @@ function parseTokenUtilization(value: unknown): TokenUtilization {
       item.token_throughput_per_second,
       "token_throughput_per_second",
     ),
-    tokens_to_success: nullableInteger(item.tokens_to_success, "tokens_to_success"),
+    tokens_to_success: nullableNonNegativeInteger(item.tokens_to_success, "tokens_to_success"),
   };
 }
 
@@ -240,9 +251,12 @@ function parseEvaluationUtilization(value: unknown): EvaluationUtilization {
     "eval_throughput_per_second",
   ]);
   return {
-    eval_count: integer(item.eval_count, "eval_count"),
+    eval_count: nonNegativeInteger(item.eval_count, "eval_count"),
     eval_active_seconds: nullableNumber(item.eval_active_seconds, "eval_active_seconds"),
-    verifier_active_seconds: nullableNumber(item.verifier_active_seconds, "verifier_active_seconds"),
+    verifier_active_seconds: nullableNumber(
+      item.verifier_active_seconds,
+      "verifier_active_seconds",
+    ),
     verifier_idle_seconds: nullableNumber(item.verifier_idle_seconds, "verifier_idle_seconds"),
     eval_throughput_per_second: nullableNumber(
       item.eval_throughput_per_second,
@@ -258,7 +272,12 @@ function normalizeEvent(event: RunUtilizationEventInput): NormalizedUtilizationE
   return {
     eventType: event.event_type ?? event.event ?? "",
     timestamp: event.timestamp ?? event.ts ?? "",
-    branchId: event.branch_id ?? maybeString(payload.branch_id) ?? event.worker_id ?? maybeString(payload.worker_id) ?? "",
+    branchId:
+      event.branch_id ??
+      maybeString(payload.branch_id) ??
+      event.worker_id ??
+      maybeString(payload.worker_id) ??
+      "",
     durationSeconds: event.duration_seconds ?? maybeNumber(payload.duration_seconds) ?? null,
     score: score ?? null,
     verifierPassed,
@@ -277,7 +296,10 @@ function normalizeUsage(row: RunUtilizationRoleUsageInput): NormalizedRoleUsage 
   };
 }
 
-function utilizationWindow(events: NormalizedUtilizationEvent[], usage: NormalizedRoleUsage[]): UtilizationWindow {
+function utilizationWindow(
+  events: NormalizedUtilizationEvent[],
+  usage: NormalizedRoleUsage[],
+): UtilizationWindow {
   const stamps = [...events.map((event) => event.timestamp), ...usage.map((row) => row.timestamp)]
     .map(parseTime)
     .filter((stamp): stamp is number => stamp !== null);
@@ -291,13 +313,19 @@ function utilizationWindow(events: NormalizedUtilizationEvent[], usage: Normaliz
   };
 }
 
-function branchIds(events: NormalizedUtilizationEvent[], usage: NormalizedRoleUsage[]): Set<string> {
+function branchIds(
+  events: NormalizedUtilizationEvent[],
+  usage: NormalizedRoleUsage[],
+): Set<string> {
   return new Set(
     [...events.map((event) => event.branchId), ...usage.map((row) => row.branchId)].filter(Boolean),
   );
 }
 
-function maxParallelBranches(events: NormalizedUtilizationEvent[], completedAt: string | null): number | null {
+function maxParallelBranches(
+  events: NormalizedUtilizationEvent[],
+  completedAt: string | null,
+): number | null {
   const starts = new Map<string, number>();
   const finishes = new Map<string, number>();
   for (const event of events) {
@@ -330,12 +358,19 @@ function sumDuration(events: NormalizedUtilizationEvent[], eventTypes: Set<strin
   return total > 0 ? round(total) : null;
 }
 
-function sumUsageSeconds(rows: NormalizedRoleUsage[], key: "latencyMs" | "modelWaitSeconds", scale: number): number | null {
+function sumUsageSeconds(
+  rows: NormalizedRoleUsage[],
+  key: "latencyMs" | "modelWaitSeconds",
+  scale: number,
+): number | null {
   const values = rows.map((row) => row[key]).filter((value): value is number => value !== null);
   return values.length ? round(values.reduce((sum, value) => sum + value, 0) / scale) : null;
 }
 
-function tokensToSuccess(events: NormalizedUtilizationEvent[], usage: NormalizedRoleUsage[]): number | null {
+function tokensToSuccess(
+  events: NormalizedUtilizationEvent[],
+  usage: NormalizedRoleUsage[],
+): number | null {
   const successTimes = events
     .filter((event) => event.verifierPassed === true || event.outcome === "success")
     .map((event) => parseTime(event.timestamp))
@@ -373,13 +408,17 @@ function formatTime(timestamp: number): string {
 }
 
 function record(value: unknown, label: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error(`${label} must be an object`);
   return value as Record<string, unknown>;
 }
 
 function exact(item: Record<string, unknown>, allowed: string[]): void {
   const allowedSet = new Set(allowed);
-  const extra = Object.keys(item).filter((key) => !allowedSet.has(key));
+  const keys = Object.keys(item);
+  const missing = allowed.filter((key) => !keys.includes(key));
+  if (missing.length) throw new Error(`missing field(s): ${missing.sort().join(", ")}`);
+  const extra = keys.filter((key) => !allowedSet.has(key));
   if (extra.length) throw new Error(`unexpected field(s): ${extra.sort().join(", ")}`);
 }
 
@@ -389,29 +428,41 @@ function string(value: unknown, label: string): string {
 }
 
 function nullableString(value: unknown, label: string): string | null {
-  return value === null || value === undefined ? null : string(value, label);
+  return value === null ? null : string(value, label);
 }
 
 function number(value: unknown, label: string): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${label} must be a number`);
+  if (typeof value !== "number" || !Number.isFinite(value))
+    throw new Error(`${label} must be a number`);
   return value;
 }
 
 function nullableNumber(value: unknown, label: string): number | null {
-  return value === null || value === undefined ? null : number(value, label);
+  return value === null ? null : number(value, label);
 }
 
 function integer(value: unknown, label: string): number {
-  if (typeof value !== "number" || !Number.isInteger(value)) throw new Error(`${label} must be an integer`);
+  if (typeof value !== "number" || !Number.isInteger(value))
+    throw new Error(`${label} must be an integer`);
   return value;
 }
 
 function nullableInteger(value: unknown, label: string): number | null {
-  return value === null || value === undefined ? null : integer(value, label);
+  return value === null ? null : integer(value, label);
+}
+
+function nonNegativeInteger(value: unknown, label: string): number {
+  const result = integer(value, label);
+  if (result < 0) throw new Error(`${label} must be a non-negative integer`);
+  return result;
+}
+
+function nullableNonNegativeInteger(value: unknown, label: string): number | null {
+  return value === null ? null : nonNegativeInteger(value, label);
 }
 
 function integerOrZero(value: unknown): number {
-  return typeof value === "number" && Number.isInteger(value) ? value : 0;
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : 0;
 }
 
 function maybeString(value: unknown): string | undefined {

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -674,6 +674,20 @@ export type {
   RunProgressEventStreamRow,
   RunProgressReport,
 } from "./analytics/progress-report.js";
+export {
+  buildRunUtilizationReport,
+  parseRunUtilizationReport,
+} from "./analytics/run-utilization-report.js";
+export type {
+  BranchUtilization,
+  BuildRunUtilizationReportInput,
+  EvaluationUtilization,
+  RunUtilizationEventInput,
+  RunUtilizationReport,
+  RunUtilizationRoleUsageInput,
+  TokenUtilization,
+  UtilizationWindow,
+} from "./analytics/run-utilization-report.js";
 export { runtimeSessionLogToRunTrace } from "./analytics/runtime-session-run-trace.js";
 export type { RuntimeSessionRunTraceOpts } from "./analytics/runtime-session-run-trace.js";
 export {

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -43,6 +43,7 @@ describe("package root exports", () => {
     expect(pkg.validateExternalEvalBoundaryPolicy).toBeDefined();
     expect(pkg.buildExternalEvalDiagnosticReport).toBeDefined();
     expect(pkg.buildExternalEvalImprovementSignals).toBeDefined();
+    expect(pkg.buildRunUtilizationReport).toBeDefined();
     expect(pkg.buildOperationalMemoryPackFromDiagnostics).toBeDefined();
     expect(pkg.resolveBrowserSessionConfig).toBeDefined();
     expect(pkg.evaluateBrowserActionPolicy).toBeDefined();

--- a/ts/tests/run-utilization-report.test.ts
+++ b/ts/tests/run-utilization-report.test.ts
@@ -11,7 +11,10 @@ import {
 } from "../src/analytics/run-utilization-report.js";
 
 const reportSchema = JSON.parse(
-  readFileSync(join(import.meta.dirname, "..", "..", "docs", "run-utilization-report.json"), "utf-8"),
+  readFileSync(
+    join(import.meta.dirname, "..", "..", "docs", "run-utilization-report.json"),
+    "utf-8",
+  ),
 ) as { required?: string[] };
 
 const fixture = JSON.parse(
@@ -30,6 +33,12 @@ const fixture = JSON.parse(
   }>;
 };
 
+function withoutKey(item: object, key: string): Record<string, unknown> {
+  const copy = { ...(item as Record<string, unknown>) };
+  delete copy[key];
+  return copy;
+}
+
 describe("run utilization report", () => {
   it("matches the shared Python/TypeScript parity fixture", () => {
     for (const item of fixture.cases) {
@@ -44,13 +53,68 @@ describe("run utilization report", () => {
     }
   });
 
-  it("parses durable report JSON and rejects extra fields", () => {
+  it("parses durable report JSON and rejects schema-invalid data", () => {
     const report = fixture.cases[1]!.expected_report;
 
     expect(parseRunUtilizationReport(report)).toEqual(report);
     expect(reportSchema.required).toContain("token_utilization");
     expect(reportSchema.required).toContain("evaluation_utilization");
-    expect(() => parseRunUtilizationReport({ ...report, surprise: true })).toThrow(/unexpected field/);
+    expect(() => parseRunUtilizationReport({ ...report, surprise: true })).toThrow(
+      /unexpected field/,
+    );
     expect(() => parseRunUtilizationReport({ ...report, run_id: "" })).toThrow(/run_id/);
+    expect(() =>
+      parseRunUtilizationReport({
+        ...report,
+        window: withoutKey(report.window, "duration_seconds"),
+      }),
+    ).toThrow(/missing field/);
+    expect(() =>
+      parseRunUtilizationReport({
+        ...report,
+        token_utilization: withoutKey(report.token_utilization, "model_wait_seconds"),
+      }),
+    ).toThrow(/missing field/);
+    expect(() =>
+      parseRunUtilizationReport({
+        ...report,
+        token_utilization: { ...report.token_utilization, input_tokens: -1 },
+      }),
+    ).toThrow(/input_tokens/);
+    expect(() =>
+      parseRunUtilizationReport({
+        ...report,
+        evaluation_utilization: { ...report.evaluation_utilization, eval_count: -1 },
+      }),
+    ).toThrow(/eval_count/);
+  });
+
+  it("does not emit negative token counts from malformed usage telemetry", () => {
+    const report = buildRunUtilizationReport({
+      runId: "negative-token-run",
+      generatedAt: "2026-06-16T12:00:00Z",
+      events: [
+        {
+          event_type: "evaluation_finished",
+          timestamp: "2026-06-16T12:00:01Z",
+          branch_id: "branch-a",
+          duration_seconds: 1,
+          verifier_passed: true,
+        },
+      ],
+      roleUsage: [
+        {
+          timestamp: "2026-06-16T12:00:00Z",
+          branch_id: "branch-a",
+          input_tokens: -10,
+          output_tokens: -5,
+        },
+      ],
+    });
+
+    expect(report.token_utilization.input_tokens).toBe(0);
+    expect(report.token_utilization.output_tokens).toBe(0);
+    expect(report.token_utilization.total_tokens).toBe(0);
+    expect(report.token_utilization.tokens_to_success).toBe(0);
   });
 });

--- a/ts/tests/run-utilization-report.test.ts
+++ b/ts/tests/run-utilization-report.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRunUtilizationReport,
+  parseRunUtilizationReport,
+  type RunUtilizationEventInput,
+  type RunUtilizationReport,
+  type RunUtilizationRoleUsageInput,
+} from "../src/analytics/run-utilization-report.js";
+
+const reportSchema = JSON.parse(
+  readFileSync(join(import.meta.dirname, "..", "..", "docs", "run-utilization-report.json"), "utf-8"),
+) as { required?: string[] };
+
+const fixture = JSON.parse(
+  readFileSync(
+    join(import.meta.dirname, "..", "..", "docs", "run-utilization-report-parity-fixture.json"),
+    "utf-8",
+  ),
+) as {
+  cases: Array<{
+    name: string;
+    run_id: string;
+    generated_at: string;
+    events: RunUtilizationEventInput[];
+    role_usage: RunUtilizationRoleUsageInput[];
+    expected_report: RunUtilizationReport;
+  }>;
+};
+
+describe("run utilization report", () => {
+  it("matches the shared Python/TypeScript parity fixture", () => {
+    for (const item of fixture.cases) {
+      expect(
+        buildRunUtilizationReport({
+          runId: item.run_id,
+          generatedAt: item.generated_at,
+          events: item.events,
+          roleUsage: item.role_usage,
+        }),
+      ).toEqual(item.expected_report);
+    }
+  });
+
+  it("parses durable report JSON and rejects extra fields", () => {
+    const report = fixture.cases[1]!.expected_report;
+
+    expect(parseRunUtilizationReport(report)).toEqual(report);
+    expect(reportSchema.required).toContain("token_utilization");
+    expect(reportSchema.required).toContain("evaluation_utilization");
+    expect(() => parseRunUtilizationReport({ ...report, surprise: true })).toThrow(/unexpected field/);
+    expect(() => parseRunUtilizationReport({ ...report, run_id: "" })).toThrow(/run_id/);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared Python/TypeScript run utilization report contract for AC-822
- compute runner utilization, token utilization, tokens-to-success, model wait, verifier idle time, and eval throughput
- add parity fixture/schema/docs covering missing telemetry, single-branch, and multi-branch runs

## Tests
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m pytest tests/test_run_utilization_report.py tests/test_package_boundaries.py tests/test_module_size_limits.py -q`
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m ruff check src/autocontext/analytics/run_utilization_report.py src/autocontext/analytics/__init__.py tests/test_run_utilization_report.py`
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m mypy src/autocontext/analytics/run_utilization_report.py src/autocontext/analytics/__init__.py`
- `cd ts && npm test -- run-utilization-report.test.ts package-export-catalogs.test.ts`
- `cd ts && npm run lint`
- `cd ts && npm run build`

Resolves AC-822.
