### PR TITLE
AC-823 add negative result ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - AC-820 scenario environment contracts now document and expose reset, rollout, verification, scoring, replay, evidence, and cleanup hooks across Python and TypeScript.
 - AC-821 run progress reports add Python/TypeScript parity for best-score-over-time curves, milestone timing, pass@k summaries, and branch lineage inspection references.
 - AC-822 run utilization reports add shared Python/TypeScript runner, token, verifier idle, model wait, and eval-throughput telemetry for single- and multi-branch runs.
+- AC-823 negative result ledgers preserve failed/pruned/rejected branch evidence, branch lineage, score deltas, and caution-vs-hard-ban prompt lessons across Python and TypeScript.
 
 ## [pi-v0.2.6] - 2026-06-16
 

--- a/autocontext/src/autocontext/analytics/__init__.py
+++ b/autocontext/src/autocontext/analytics/__init__.py
@@ -1,5 +1,6 @@
 """Aggregate analytics for cross-run facets, signal extraction, and pattern clustering."""
 
+from autocontext.analytics.negative_result_ledger import NegativeResultLedger, build_negative_result_ledger
 from autocontext.analytics.progress_report import RunProgressReport, build_run_progress_report
 from autocontext.analytics.run_utilization_report import RunUtilizationReport, build_run_utilization_report
 from autocontext.analytics.runtime_session_run_trace import runtime_session_log_to_run_trace
@@ -12,11 +13,13 @@ from autocontext.analytics.trace_gate_operator_view import (
 )
 
 __all__ = [
+    "NegativeResultLedger",
     "RunProgressReport",
     "RunUtilizationReport",
     "TraceGateAnalysisState",
     "TraceGateOperatorState",
     "TraceGateOperatorView",
+    "build_negative_result_ledger",
     "build_run_progress_report",
     "build_run_utilization_report",
     "build_trace_gate_operator_view",

--- a/autocontext/src/autocontext/analytics/negative_result_ledger.py
+++ b/autocontext/src/autocontext/analytics/negative_result_ledger.py
@@ -1,0 +1,299 @@
+"""Negative branch results as reusable run evidence."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field
+
+FailureKind = Literal[
+    "verification_failed",
+    "score_regression",
+    "pruned",
+    "refused",
+    "dead_end",
+    "timeout",
+    "harness_error",
+    "unsafe_action",
+]
+NegativeResultDisposition = Literal["caution", "hard_ban", "noise"]
+
+_NEGATIVE_EVENTS = {
+    "branch_failed",
+    "branch_pruned",
+    "branch_rejected",
+    "candidate_rejected",
+    "evaluation_failed",
+    "gate_rollback",
+    "harness_refused",
+}
+_EVENT_FAILURE_KIND: dict[str, FailureKind] = {
+    "branch_pruned": "pruned",
+    "branch_rejected": "dead_end",
+    "candidate_rejected": "verification_failed",
+    "evaluation_failed": "verification_failed",
+    "gate_rollback": "score_regression",
+    "harness_refused": "refused",
+}
+_FAILURE_KINDS: set[str] = {
+    "verification_failed",
+    "score_regression",
+    "pruned",
+    "refused",
+    "dead_end",
+    "timeout",
+    "harness_error",
+    "unsafe_action",
+}
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        return cls.model_validate(data)
+
+
+class NegativeEvidenceReference(_StrictModel):
+    uri: str = Field(min_length=1)
+    summary: str = Field(min_length=1)
+
+
+class NegativeBranchLineageEdge(_StrictModel):
+    parent_branch_id: str = Field(min_length=1)
+    child_branch_id: str = Field(min_length=1)
+    event_id: str | None
+
+
+class NegativeResultEntry(_StrictModel):
+    result_id: str = Field(min_length=1)
+    branch_id: str = Field(min_length=1)
+    hypothesis_node_id: str | None
+    occurred_at: str = Field(min_length=1)
+    failure_kind: FailureKind
+    disposition: NegativeResultDisposition
+    reason: str = Field(min_length=1)
+    score_delta: float | None
+    evaluated_seeds: list[str]
+    evaluated_probes: list[str]
+    branch_lineage: list[NegativeBranchLineageEdge]
+    evidence_refs: list[NegativeEvidenceReference]
+    generation_index: int | None = Field(default=None, ge=0)
+
+
+class FailureModeSummary(_StrictModel):
+    failure_kind: FailureKind
+    disposition: NegativeResultDisposition
+    count: int = Field(ge=0)
+    result_ids: list[str]
+
+
+class NegativeResultLedger(_StrictModel):
+    schema_version: Literal[1] = 1
+    run_id: str = Field(min_length=1)
+    generated_at: str = Field(min_length=1)
+    entries: list[NegativeResultEntry]
+    failure_mode_summary: list[FailureModeSummary]
+
+    def to_markdown(self) -> str:
+        lessons = render_negative_result_lessons(self)
+        summary_lines = [
+            f"- {item.failure_kind}/{item.disposition}: {item.count} ({', '.join(item.result_ids)})"
+            for item in self.failure_mode_summary
+        ]
+        return "\n".join(
+            [
+                f"# Negative Result Ledger: {self.run_id}",
+                "",
+                "## Failure Modes",
+                *(summary_lines or ["- None"]),
+                "",
+                "## Prompt Lessons",
+                lessons or "- None",
+                "",
+            ]
+        )
+
+
+def build_negative_result_ledger(
+    *,
+    run_id: str,
+    events: list[dict[str, Any]],
+    generated_at: str | None = None,
+) -> NegativeResultLedger:
+    entries = [_entry for event in events if (_entry := _entry_from_event(event)) is not None]
+    return NegativeResultLedger(
+        run_id=run_id,
+        generated_at=generated_at or datetime.now().astimezone().isoformat(),
+        entries=entries,
+        failure_mode_summary=_failure_mode_summary(entries),
+    )
+
+
+def render_negative_result_lessons(ledger: NegativeResultLedger, *, max_entries: int = 4) -> str:
+    """Compact, evidence-backed prompt lessons; noise is intentionally omitted."""
+
+    entries = [entry for entry in ledger.entries if entry.disposition != "noise" and entry.evidence_refs]
+    rank = {"hard_ban": 0, "caution": 1, "noise": 2}
+    lines: list[str] = []
+    for entry in sorted(entries, key=lambda item: (rank[item.disposition], item.result_id))[:max_entries]:
+        evidence = "; ".join(ref.summary for ref in entry.evidence_refs[:2])
+        delta = f", delta={entry.score_delta:g}" if entry.score_delta is not None else ""
+        if entry.disposition == "hard_ban":
+            prefix = "Hard ban"
+            suffix = "do not repeat without new evidence"
+        else:
+            prefix = "Caution"
+            suffix = "not a ban; explore only with differentiating evidence"
+        lines.append(
+            f"- {prefix}: {entry.failure_kind} on {entry.branch_id} "
+            f"({entry.result_id}{delta}) — {entry.reason}; evidence: {evidence}; {suffix}."
+        )
+    return "\n".join(lines)
+
+
+def _entry_from_event(event: dict[str, Any]) -> NegativeResultEntry | None:
+    raw_payload = event.get("payload")
+    payload: dict[str, Any] = raw_payload if isinstance(raw_payload, dict) else {}
+    event_type = _string(event.get("event_type") or event.get("event"))
+    failure_kind = _failure_kind(payload, event_type)
+    if failure_kind is None and event_type not in _NEGATIVE_EVENTS:
+        return None
+    branch_id = _string(event.get("branch_id") or payload.get("branch_id"))
+    if not branch_id:
+        return None
+    event_id = _string(event.get("event_id")) or (f"seq-{event.get('seq')}" if event.get("seq") is not None else "")
+    result_id = _string(payload.get("result_id")) or event_id or f"negative-{len(branch_id)}"
+    score_delta = _score_delta(payload)
+    return NegativeResultEntry(
+        result_id=result_id,
+        branch_id=branch_id,
+        hypothesis_node_id=_string_or_none(payload.get("hypothesis_node_id") or event.get("hypothesis_node_id")),
+        occurred_at=_string(event.get("timestamp") or event.get("ts")) or datetime.now().astimezone().isoformat(),
+        failure_kind=failure_kind or _EVENT_FAILURE_KIND.get(event_type, "dead_end"),
+        disposition=_disposition(payload.get("disposition")),
+        reason=_string(payload.get("reason") or event.get("reason")) or "Negative branch result recorded.",
+        score_delta=score_delta,
+        evaluated_seeds=_string_list(payload.get("evaluated_seeds") or payload.get("seeds")),
+        evaluated_probes=_string_list(payload.get("evaluated_probes") or payload.get("probes")),
+        branch_lineage=_branch_lineage(event, payload, event_id, branch_id),
+        evidence_refs=_evidence_refs(payload),
+        generation_index=_int_or_none(payload.get("generation_index") or event.get("generation_index")),
+    )
+
+
+def _failure_mode_summary(entries: list[NegativeResultEntry]) -> list[FailureModeSummary]:
+    groups: dict[tuple[FailureKind, NegativeResultDisposition], list[str]] = {}
+    for entry in entries:
+        groups.setdefault((entry.failure_kind, entry.disposition), []).append(entry.result_id)
+    return [
+        FailureModeSummary(failure_kind=kind, disposition=disposition, count=len(ids), result_ids=ids)
+        for (kind, disposition), ids in sorted(groups.items())
+    ]
+
+
+def _failure_kind(payload: dict[str, Any], event_type: str) -> FailureKind | None:
+    value = _string(payload.get("failure_kind"))
+    if value in _FAILURE_KINDS:
+        return value  # type: ignore[return-value]
+    return _EVENT_FAILURE_KIND.get(event_type)
+
+
+def _disposition(value: Any) -> NegativeResultDisposition:
+    raw = _string(value)
+    if raw in {"caution", "hard_ban", "noise"}:
+        return raw  # type: ignore[return-value]
+    return "caution"
+
+
+def _score_delta(payload: dict[str, Any]) -> float | None:
+    explicit = _float_or_none(payload.get("score_delta"))
+    if explicit is not None:
+        return round(explicit, 6)
+    score = _float_or_none(payload.get("score"))
+    baseline = _float_or_none(payload.get("baseline_score"))
+    return round(score - baseline, 6) if score is not None and baseline is not None else None
+
+
+def _branch_lineage(
+    event: dict[str, Any],
+    payload: dict[str, Any],
+    event_id: str,
+    branch_id: str,
+) -> list[NegativeBranchLineageEdge]:
+    raw = payload.get("branch_lineage")
+    if isinstance(raw, list):
+        edges = [_edge_from_dict(edge) for edge in raw if isinstance(edge, dict)]
+        return [edge for edge in edges if edge is not None]
+    parent = _string(event.get("parent_branch_id") or payload.get("parent_branch_id"))
+    if not parent:
+        return []
+    return [NegativeBranchLineageEdge(parent_branch_id=parent, child_branch_id=branch_id, event_id=event_id or None)]
+
+
+def _edge_from_dict(edge: dict[str, Any]) -> NegativeBranchLineageEdge | None:
+    parent = _string(edge.get("parent_branch_id"))
+    child = _string(edge.get("child_branch_id"))
+    if not parent or not child:
+        return None
+    return NegativeBranchLineageEdge(
+        parent_branch_id=parent,
+        child_branch_id=child,
+        event_id=_string_or_none(edge.get("event_id")),
+    )
+
+
+def _evidence_refs(payload: dict[str, Any]) -> list[NegativeEvidenceReference]:
+    refs = payload.get("evidence_refs")
+    if isinstance(refs, list):
+        return [ref for item in refs if (ref := _evidence_ref(item)) is not None]
+    uri = _string(payload.get("evidence_uri"))
+    summary = _string(payload.get("evidence_summary"))
+    return [NegativeEvidenceReference(uri=uri, summary=summary)] if uri and summary else []
+
+
+def _evidence_ref(value: Any) -> NegativeEvidenceReference | None:
+    if not isinstance(value, dict):
+        return None
+    uri = _string(value.get("uri"))
+    summary = _string(value.get("summary"))
+    return NegativeEvidenceReference(uri=uri, summary=summary) if uri and summary else None
+
+
+def _string_list(value: Any) -> list[str]:
+    return [item for item in value if isinstance(item, str) and item] if isinstance(value, list) else []
+
+
+def _string_or_none(value: Any) -> str | None:
+    result = _string(value)
+    return result or None
+
+
+def _string(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _int_or_none(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _float_or_none(value: Any) -> float | None:
+    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+__all__ = [
+    "FailureKind",
+    "FailureModeSummary",
+    "NegativeBranchLineageEdge",
+    "NegativeEvidenceReference",
+    "NegativeResultDisposition",
+    "NegativeResultEntry",
+    "NegativeResultLedger",
+    "build_negative_result_ledger",
+    "render_negative_result_lessons",
+]

--- a/autocontext/src/autocontext/storage/negative_result_ledger_store.py
+++ b/autocontext/src/autocontext/storage/negative_result_ledger_store.py
@@ -1,0 +1,50 @@
+"""File helpers for negative result ledger run artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Protocol
+
+from autocontext.analytics.negative_result_ledger import NegativeResultLedger
+from autocontext.storage.scenario_paths import normalize_scenario_name_segment
+from autocontext.util.json_io import read_json, write_json
+
+
+class DictSerializable(Protocol):
+    def to_dict(self) -> dict[str, Any]: ...
+
+
+def negative_result_ledger_path(knowledge_root: Path, scenario_name: str, run_id: str) -> Path:
+    return knowledge_root / normalize_scenario_name_segment(scenario_name) / "negative_result_ledgers" / f"{run_id}.json"
+
+
+def write_negative_result_ledger(knowledge_root: Path, scenario_name: str, run_id: str, ledger: DictSerializable) -> Path:
+    path = negative_result_ledger_path(knowledge_root, scenario_name, run_id)
+    write_json(path, ledger.to_dict())
+    return path
+
+
+def read_negative_result_ledger(knowledge_root: Path, scenario_name: str, run_id: str) -> NegativeResultLedger | None:
+    path = negative_result_ledger_path(knowledge_root, scenario_name, run_id)
+    return NegativeResultLedger.from_dict(read_json(path)) if path.exists() else None
+
+
+def read_latest_negative_result_ledgers_markdown(
+    knowledge_root: Path,
+    scenario_name: str,
+    *,
+    max_ledgers: int = 2,
+) -> str:
+    root = knowledge_root / normalize_scenario_name_segment(scenario_name) / "negative_result_ledgers"
+    if not root.exists():
+        return ""
+    paths = sorted(root.glob("*.json"), key=lambda path: path.stat().st_mtime, reverse=True)[:max_ledgers]
+    return "\n\n".join(NegativeResultLedger.from_dict(read_json(path)).to_markdown() for path in paths)
+
+
+__all__ = [
+    "negative_result_ledger_path",
+    "read_latest_negative_result_ledgers_markdown",
+    "read_negative_result_ledger",
+    "write_negative_result_ledger",
+]

--- a/autocontext/tests/test_negative_result_ledger.py
+++ b/autocontext/tests/test_negative_result_ledger.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_PATH = ROOT / "docs" / "negative-result-ledger-parity-fixture.json"
+
+
+def _cases() -> list[dict[str, Any]]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))["cases"]
+
+
+def test_build_negative_result_ledger_matches_shared_fixture() -> None:
+    from autocontext.analytics.negative_result_ledger import build_negative_result_ledger
+
+    for case in _cases():
+        ledger = build_negative_result_ledger(
+            run_id=case["run_id"],
+            events=case["events"],
+            generated_at=case["generated_at"],
+        )
+
+        assert ledger.to_dict() == case["expected_ledger"]
+
+
+def test_negative_result_ledger_round_trips_shared_json() -> None:
+    from autocontext.analytics.negative_result_ledger import NegativeResultLedger
+
+    for case in _cases():
+        expected = case["expected_ledger"]
+        assert NegativeResultLedger.from_dict(expected).to_dict() == expected
+
+
+def test_negative_result_lessons_distinguish_noise_caution_and_hard_bans() -> None:
+    from autocontext.analytics.negative_result_ledger import NegativeResultLedger, render_negative_result_lessons
+
+    caution = NegativeResultLedger.from_dict(_cases()[0]["expected_ledger"])
+    noise = NegativeResultLedger.from_dict(_cases()[1]["expected_ledger"])
+    hard_ban = NegativeResultLedger.from_dict(_cases()[2]["expected_ledger"])
+
+    caution_text = render_negative_result_lessons(caution)
+    assert "Caution:" in caution_text
+    assert "not a ban" in caution_text
+    assert "Replay diverged at turn 6" in caution_text
+
+    assert render_negative_result_lessons(noise) == ""
+
+    hard_ban_text = render_negative_result_lessons(hard_ban)
+    assert "Hard ban:" in hard_ban_text
+    assert "unsafe_action" in hard_ban_text
+    assert "evt-hard-1" in hard_ban_text
+    assert "evt-hard-2" in hard_ban_text
+
+
+def test_file_store_persists_negative_result_ledger(tmp_path: Path) -> None:
+    from autocontext.analytics.negative_result_ledger import NegativeResultLedger
+    from autocontext.storage.negative_result_ledger_store import (
+        read_latest_negative_result_ledgers_markdown,
+        read_negative_result_ledger,
+        write_negative_result_ledger,
+    )
+
+    expected = _cases()[2]["expected_ledger"]
+    ledger = NegativeResultLedger.from_dict(expected)
+
+    write_negative_result_ledger(tmp_path / "knowledge", "grid_ctf", ledger.run_id, ledger)
+
+    restored = read_negative_result_ledger(tmp_path / "knowledge", "grid_ctf", ledger.run_id)
+    assert isinstance(restored, NegativeResultLedger)
+    assert restored.to_dict() == expected
+    assert "Hard ban:" in read_latest_negative_result_ledgers_markdown(tmp_path / "knowledge", "grid_ctf")
+
+
+def test_negative_result_ledger_rejects_schema_invalid_data() -> None:
+    from autocontext.analytics.negative_result_ledger import NegativeResultLedger
+
+    expected = _cases()[0]["expected_ledger"]
+    bad_entry = {**expected["entries"][0], "disposition": "maybe"}
+    missing_branch = {k: v for k, v in expected["entries"][0].items() if k != "branch_id"}
+    negative_generation = {**expected["entries"][0], "generation_index": -1}
+
+    for payload in [
+        {**expected, "surprise": True},
+        {**expected, "run_id": ""},
+        {**expected, "entries": [bad_entry]},
+        {**expected, "entries": [missing_branch]},
+        {**expected, "entries": [negative_generation]},
+    ]:
+        try:
+            NegativeResultLedger.from_dict(payload)
+        except ValueError:
+            continue
+        raise AssertionError("schema-invalid negative-result ledger was accepted")

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - [Scenario environment contract](scenario-environment-contract.md)
 - [Run progress report](run-progress-report.md)
 - [Run utilization report](run-utilization-report.md)
+- [Negative result ledger](negative-result-ledger.md)
 - [Browser exploration contract](browser-exploration-contract.md)
 - [OpenTelemetry bridge](opentelemetry-bridge.md)
 - [Background session domain and parity contract](background-session-domain.md)

--- a/docs/negative-result-ledger-parity-fixture.json
+++ b/docs/negative-result-ledger-parity-fixture.json
@@ -1,0 +1,253 @@
+{
+  "cases": [
+    {
+      "name": "failed-branch-caution",
+      "run_id": "run-negative-failed",
+      "generated_at": "2026-06-16T13:00:00Z",
+      "events": [
+        {
+          "event": "branch_pruned",
+          "ts": "2026-06-16T12:05:00Z",
+          "seq": 4,
+          "payload": {
+            "result_id": "neg-1",
+            "branch_id": "branch-beta",
+            "parent_branch_id": "branch-root",
+            "hypothesis_node_id": "node-beta",
+            "failure_kind": "verification_failed",
+            "disposition": "caution",
+            "reason": "Replay verifier rejected the branch after a state mismatch.",
+            "score_delta": -0.18,
+            "evaluated_seeds": ["seed-7"],
+            "evaluated_probes": ["replay-grid-ctf"],
+            "evidence_refs": [
+              {
+                "uri": "runs/run-negative-failed/evidence/replay.json",
+                "summary": "Replay diverged at turn 6."
+              }
+            ]
+          }
+        }
+      ],
+      "expected_ledger": {
+        "schema_version": 1,
+        "run_id": "run-negative-failed",
+        "generated_at": "2026-06-16T13:00:00Z",
+        "entries": [
+          {
+            "result_id": "neg-1",
+            "branch_id": "branch-beta",
+            "hypothesis_node_id": "node-beta",
+            "generation_index": null,
+            "occurred_at": "2026-06-16T12:05:00Z",
+            "failure_kind": "verification_failed",
+            "disposition": "caution",
+            "reason": "Replay verifier rejected the branch after a state mismatch.",
+            "score_delta": -0.18,
+            "evaluated_seeds": ["seed-7"],
+            "evaluated_probes": ["replay-grid-ctf"],
+            "branch_lineage": [
+              {
+                "parent_branch_id": "branch-root",
+                "child_branch_id": "branch-beta",
+                "event_id": "seq-4"
+              }
+            ],
+            "evidence_refs": [
+              {
+                "uri": "runs/run-negative-failed/evidence/replay.json",
+                "summary": "Replay diverged at turn 6."
+              }
+            ]
+          }
+        ],
+        "failure_mode_summary": [
+          {
+            "failure_kind": "verification_failed",
+            "disposition": "caution",
+            "count": 1,
+            "result_ids": ["neg-1"]
+          }
+        ]
+      }
+    },
+    {
+      "name": "one-off-noise",
+      "run_id": "run-negative-noise",
+      "generated_at": "2026-06-16T13:10:00Z",
+      "events": [
+        {
+          "event_type": "branch_failed",
+          "timestamp": "2026-06-16T13:06:00Z",
+          "event_id": "evt-noise",
+          "branch_id": "branch-flaky",
+          "payload": {
+            "failure_kind": "timeout",
+            "disposition": "noise",
+            "reason": "One runner timed out while the replay succeeded on retry.",
+            "evidence_refs": [
+              {
+                "uri": "runs/run-negative-noise/logs/timeout.txt",
+                "summary": "Transient worker timeout."
+              }
+            ]
+          }
+        }
+      ],
+      "expected_ledger": {
+        "schema_version": 1,
+        "run_id": "run-negative-noise",
+        "generated_at": "2026-06-16T13:10:00Z",
+        "entries": [
+          {
+            "result_id": "evt-noise",
+            "branch_id": "branch-flaky",
+            "hypothesis_node_id": null,
+            "generation_index": null,
+            "occurred_at": "2026-06-16T13:06:00Z",
+            "failure_kind": "timeout",
+            "disposition": "noise",
+            "reason": "One runner timed out while the replay succeeded on retry.",
+            "score_delta": null,
+            "evaluated_seeds": [],
+            "evaluated_probes": [],
+            "branch_lineage": [],
+            "evidence_refs": [
+              {
+                "uri": "runs/run-negative-noise/logs/timeout.txt",
+                "summary": "Transient worker timeout."
+              }
+            ]
+          }
+        ],
+        "failure_mode_summary": [
+          {
+            "failure_kind": "timeout",
+            "disposition": "noise",
+            "count": 1,
+            "result_ids": ["evt-noise"]
+          }
+        ]
+      }
+    },
+    {
+      "name": "reproducible-hard-contraindication",
+      "run_id": "run-negative-hard-ban",
+      "generated_at": "2026-06-16T13:20:00Z",
+      "events": [
+        {
+          "event_id": "evt-hard-1",
+          "event_type": "branch_rejected",
+          "timestamp": "2026-06-16T13:15:00Z",
+          "branch_id": "branch-red",
+          "parent_branch_id": "branch-root",
+          "payload": {
+            "hypothesis_node_id": "node-red",
+            "failure_kind": "unsafe_action",
+            "disposition": "hard_ban",
+            "reason": "The branch requires an action outside the scenario contract.",
+            "score": 0.12,
+            "baseline_score": 0.64,
+            "evaluated_seeds": ["seed-1", "seed-2"],
+            "evaluated_probes": ["contract-probe"],
+            "evidence_refs": [
+              {
+                "uri": "runs/run-negative-hard-ban/evidence/contract-probe.json",
+                "summary": "Contract probe rejected the action."
+              }
+            ]
+          }
+        },
+        {
+          "event_id": "evt-hard-2",
+          "event_type": "branch_rejected",
+          "timestamp": "2026-06-16T13:18:00Z",
+          "branch_id": "branch-red-retry",
+          "parent_branch_id": "branch-red",
+          "payload": {
+            "hypothesis_node_id": "node-red-retry",
+            "failure_kind": "unsafe_action",
+            "disposition": "hard_ban",
+            "reason": "Retry reproduced the same contract violation.",
+            "score_delta": -0.49,
+            "evaluated_seeds": ["seed-3"],
+            "evaluated_probes": ["contract-probe"],
+            "evidence_refs": [
+              {
+                "uri": "runs/run-negative-hard-ban/evidence/retry.json",
+                "summary": "Retry reproduced the violation."
+              }
+            ]
+          }
+        }
+      ],
+      "expected_ledger": {
+        "schema_version": 1,
+        "run_id": "run-negative-hard-ban",
+        "generated_at": "2026-06-16T13:20:00Z",
+        "entries": [
+          {
+            "result_id": "evt-hard-1",
+            "branch_id": "branch-red",
+            "hypothesis_node_id": "node-red",
+            "generation_index": null,
+            "occurred_at": "2026-06-16T13:15:00Z",
+            "failure_kind": "unsafe_action",
+            "disposition": "hard_ban",
+            "reason": "The branch requires an action outside the scenario contract.",
+            "score_delta": -0.52,
+            "evaluated_seeds": ["seed-1", "seed-2"],
+            "evaluated_probes": ["contract-probe"],
+            "branch_lineage": [
+              {
+                "parent_branch_id": "branch-root",
+                "child_branch_id": "branch-red",
+                "event_id": "evt-hard-1"
+              }
+            ],
+            "evidence_refs": [
+              {
+                "uri": "runs/run-negative-hard-ban/evidence/contract-probe.json",
+                "summary": "Contract probe rejected the action."
+              }
+            ]
+          },
+          {
+            "result_id": "evt-hard-2",
+            "branch_id": "branch-red-retry",
+            "hypothesis_node_id": "node-red-retry",
+            "generation_index": null,
+            "occurred_at": "2026-06-16T13:18:00Z",
+            "failure_kind": "unsafe_action",
+            "disposition": "hard_ban",
+            "reason": "Retry reproduced the same contract violation.",
+            "score_delta": -0.49,
+            "evaluated_seeds": ["seed-3"],
+            "evaluated_probes": ["contract-probe"],
+            "branch_lineage": [
+              {
+                "parent_branch_id": "branch-red",
+                "child_branch_id": "branch-red-retry",
+                "event_id": "evt-hard-2"
+              }
+            ],
+            "evidence_refs": [
+              {
+                "uri": "runs/run-negative-hard-ban/evidence/retry.json",
+                "summary": "Retry reproduced the violation."
+              }
+            ]
+          }
+        ],
+        "failure_mode_summary": [
+          {
+            "failure_kind": "unsafe_action",
+            "disposition": "hard_ban",
+            "count": 2,
+            "result_ids": ["evt-hard-1", "evt-hard-2"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/negative-result-ledger.json
+++ b/docs/negative-result-ledger.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/greyhaven-ai/autocontext/docs/negative-result-ledger.json",
+  "title": "NegativeResultLedger",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "run_id", "generated_at", "entries", "failure_mode_summary"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "run_id": { "type": "string", "minLength": 1 },
+    "generated_at": { "type": "string", "minLength": 1 },
+    "entries": { "type": "array", "items": { "$ref": "#/$defs/entry" } },
+    "failure_mode_summary": { "type": "array", "items": { "$ref": "#/$defs/failureModeSummary" } }
+  },
+  "$defs": {
+    "failureKind": {
+      "enum": [
+        "verification_failed",
+        "score_regression",
+        "pruned",
+        "refused",
+        "dead_end",
+        "timeout",
+        "harness_error",
+        "unsafe_action"
+      ]
+    },
+    "disposition": { "enum": ["caution", "hard_ban", "noise"] },
+    "nullableString": { "type": ["string", "null"] },
+    "nullableNumber": { "type": ["number", "null"] },
+    "nullableNonNegativeInteger": { "type": ["integer", "null"], "minimum": 0 },
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uri", "summary"],
+      "properties": {
+        "uri": { "type": "string", "minLength": 1 },
+        "summary": { "type": "string", "minLength": 1 }
+      }
+    },
+    "branchLineageEdge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["parent_branch_id", "child_branch_id", "event_id"],
+      "properties": {
+        "parent_branch_id": { "type": "string", "minLength": 1 },
+        "child_branch_id": { "type": "string", "minLength": 1 },
+        "event_id": { "$ref": "#/$defs/nullableString" }
+      }
+    },
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "result_id",
+        "branch_id",
+        "hypothesis_node_id",
+        "generation_index",
+        "occurred_at",
+        "failure_kind",
+        "disposition",
+        "reason",
+        "score_delta",
+        "evaluated_seeds",
+        "evaluated_probes",
+        "branch_lineage",
+        "evidence_refs"
+      ],
+      "properties": {
+        "result_id": { "type": "string", "minLength": 1 },
+        "branch_id": { "type": "string", "minLength": 1 },
+        "hypothesis_node_id": { "$ref": "#/$defs/nullableString" },
+        "generation_index": { "$ref": "#/$defs/nullableNonNegativeInteger" },
+        "occurred_at": { "type": "string", "minLength": 1 },
+        "failure_kind": { "$ref": "#/$defs/failureKind" },
+        "disposition": { "$ref": "#/$defs/disposition" },
+        "reason": { "type": "string", "minLength": 1 },
+        "score_delta": { "$ref": "#/$defs/nullableNumber" },
+        "evaluated_seeds": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "evaluated_probes": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "branch_lineage": { "type": "array", "items": { "$ref": "#/$defs/branchLineageEdge" } },
+        "evidence_refs": { "type": "array", "items": { "$ref": "#/$defs/evidenceRef" } }
+      }
+    },
+    "failureModeSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["failure_kind", "disposition", "count", "result_ids"],
+      "properties": {
+        "failure_kind": { "$ref": "#/$defs/failureKind" },
+        "disposition": { "$ref": "#/$defs/disposition" },
+        "count": { "type": "integer", "minimum": 0 },
+        "result_ids": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+      }
+    }
+  }
+}

--- a/docs/negative-result-ledger.md
+++ b/docs/negative-result-ledger.md
@@ -1,0 +1,23 @@
+# Negative Result Ledger
+
+AC-823 adds a durable ledger for failed, pruned, rejected, or refused branches. It keeps negative evidence inspectable instead of collapsing it into `dead_ends.md` prose.
+
+## Contract
+
+Schema: [`negative-result-ledger.json`](negative-result-ledger.json)  
+Parity fixture: [`negative-result-ledger-parity-fixture.json`](negative-result-ledger-parity-fixture.json)
+
+A ledger contains:
+
+- `entries`: negative branch examples with `failure_kind`, `disposition`, `score_delta`, evaluated seeds/probes, branch lineage, and evidence references.
+- `failure_mode_summary`: grouped counts by `failure_kind` and `disposition`, with the source `result_ids` preserved.
+
+## Disposition semantics
+
+- `caution`: evidence-backed warning. Prompt injection says it is **not a ban** and should only constrain retries with no differentiating evidence.
+- `hard_ban`: reproducible contraindication. Prompt injection says do not repeat without new evidence.
+- `noise`: one-off or flaky result. It remains inspectable but is omitted from prompt lessons so exploration does not collapse.
+
+## OSS boundary
+
+The contract is public and file-based. Hosted aggregation, tenant-level suppression, fleet-wide policy, and commercial scheduling remain deployment concerns.

--- a/ts/src/analytics/negative-result-ledger.ts
+++ b/ts/src/analytics/negative-result-ledger.ts
@@ -1,0 +1,425 @@
+export const FAILURE_KINDS = [
+  "verification_failed",
+  "score_regression",
+  "pruned",
+  "refused",
+  "dead_end",
+  "timeout",
+  "harness_error",
+  "unsafe_action",
+] as const;
+
+export const NEGATIVE_RESULT_DISPOSITIONS = ["caution", "hard_ban", "noise"] as const;
+
+export type FailureKind = (typeof FAILURE_KINDS)[number];
+export type NegativeResultDisposition = (typeof NEGATIVE_RESULT_DISPOSITIONS)[number];
+
+export interface NegativeResultEventInput {
+  event_id?: string;
+  event_type?: string;
+  event?: string;
+  timestamp?: string;
+  ts?: string;
+  seq?: number;
+  branch_id?: string;
+  parent_branch_id?: string;
+  hypothesis_node_id?: string;
+  generation_index?: number;
+  reason?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface NegativeEvidenceReference {
+  uri: string;
+  summary: string;
+}
+
+export interface NegativeBranchLineageEdge {
+  parent_branch_id: string;
+  child_branch_id: string;
+  event_id: string | null;
+}
+
+export interface NegativeResultEntry {
+  result_id: string;
+  branch_id: string;
+  hypothesis_node_id: string | null;
+  generation_index: number | null;
+  occurred_at: string;
+  failure_kind: FailureKind;
+  disposition: NegativeResultDisposition;
+  reason: string;
+  score_delta: number | null;
+  evaluated_seeds: string[];
+  evaluated_probes: string[];
+  branch_lineage: NegativeBranchLineageEdge[];
+  evidence_refs: NegativeEvidenceReference[];
+}
+
+export interface FailureModeSummary {
+  failure_kind: FailureKind;
+  disposition: NegativeResultDisposition;
+  count: number;
+  result_ids: string[];
+}
+
+export interface NegativeResultLedger {
+  schema_version: 1;
+  run_id: string;
+  generated_at: string;
+  entries: NegativeResultEntry[];
+  failure_mode_summary: FailureModeSummary[];
+}
+
+export interface BuildNegativeResultLedgerInput {
+  runId: string;
+  events: NegativeResultEventInput[];
+  generatedAt?: string;
+}
+
+const NEGATIVE_EVENTS = new Set([
+  "branch_failed",
+  "branch_pruned",
+  "branch_rejected",
+  "candidate_rejected",
+  "evaluation_failed",
+  "gate_rollback",
+  "harness_refused",
+]);
+const EVENT_FAILURE_KIND: Record<string, FailureKind> = {
+  branch_pruned: "pruned",
+  branch_rejected: "dead_end",
+  candidate_rejected: "verification_failed",
+  evaluation_failed: "verification_failed",
+  gate_rollback: "score_regression",
+  harness_refused: "refused",
+};
+const FAILURE_KIND_SET = new Set<string>(FAILURE_KINDS);
+const DISPOSITION_SET = new Set<string>(NEGATIVE_RESULT_DISPOSITIONS);
+
+export function buildNegativeResultLedger(
+  input: BuildNegativeResultLedgerInput,
+): NegativeResultLedger {
+  const entries = input.events.flatMap((event) => {
+    const entry = entryFromEvent(event);
+    return entry ? [entry] : [];
+  });
+  return parseNegativeResultLedger({
+    schema_version: 1,
+    run_id: input.runId,
+    generated_at: input.generatedAt ?? new Date().toISOString(),
+    entries,
+    failure_mode_summary: failureModeSummary(entries),
+  });
+}
+
+export function parseNegativeResultLedger(value: unknown): NegativeResultLedger {
+  const ledger = record(value, "negative result ledger");
+  exact(ledger, ["schema_version", "run_id", "generated_at", "entries", "failure_mode_summary"]);
+  if (ledger.schema_version !== 1) throw new Error("schema_version must be 1");
+  return {
+    schema_version: 1,
+    run_id: string(ledger.run_id, "run_id"),
+    generated_at: string(ledger.generated_at, "generated_at"),
+    entries: array(ledger.entries, "entries").map(parseEntry),
+    failure_mode_summary: array(ledger.failure_mode_summary, "failure_mode_summary").map(
+      parseFailureModeSummary,
+    ),
+  };
+}
+
+export function renderNegativeResultLessons(
+  ledger: NegativeResultLedger,
+  opts: { maxEntries?: number } = {},
+): string {
+  const rank: Record<NegativeResultDisposition, number> = { hard_ban: 0, caution: 1, noise: 2 };
+  return ledger.entries
+    .filter((entry) => entry.disposition !== "noise" && entry.evidence_refs.length > 0)
+    .sort((left, right) => rank[left.disposition] - rank[right.disposition] || left.result_id.localeCompare(right.result_id))
+    .slice(0, opts.maxEntries ?? 4)
+    .map((entry) => {
+      const evidence = entry.evidence_refs.slice(0, 2).map((ref) => ref.summary).join("; ");
+      const delta = entry.score_delta === null ? "" : `, delta=${entry.score_delta}`;
+      const prefix = entry.disposition === "hard_ban" ? "Hard ban" : "Caution";
+      const suffix = entry.disposition === "hard_ban"
+        ? "do not repeat without new evidence"
+        : "not a ban; explore only with differentiating evidence";
+      return `- ${prefix}: ${entry.failure_kind} on ${entry.branch_id} (${entry.result_id}${delta}) — ${entry.reason}; evidence: ${evidence}; ${suffix}.`;
+    })
+    .join("\n");
+}
+
+export function negativeResultLedgerToMarkdown(ledger: NegativeResultLedger): string {
+  const summary = ledger.failure_mode_summary.map(
+    (item) => `- ${item.failure_kind}/${item.disposition}: ${item.count} (${item.result_ids.join(", ")})`,
+  );
+  return [
+    `# Negative Result Ledger: ${ledger.run_id}`,
+    "",
+    "## Failure Modes",
+    ...(summary.length ? summary : ["- None"]),
+    "",
+    "## Prompt Lessons",
+    renderNegativeResultLessons(ledger) || "- None",
+    "",
+  ].join("\n");
+}
+
+function parseEntry(value: unknown): NegativeResultEntry {
+  const item = record(value, "negative result entry");
+  exact(item, [
+    "result_id",
+    "branch_id",
+    "hypothesis_node_id",
+    "generation_index",
+    "occurred_at",
+    "failure_kind",
+    "disposition",
+    "reason",
+    "score_delta",
+    "evaluated_seeds",
+    "evaluated_probes",
+    "branch_lineage",
+    "evidence_refs",
+  ]);
+  return {
+    result_id: string(item.result_id, "result_id"),
+    branch_id: string(item.branch_id, "branch_id"),
+    hypothesis_node_id: nullableString(item.hypothesis_node_id, "hypothesis_node_id"),
+    generation_index: nullableNonNegativeInteger(item.generation_index, "generation_index"),
+    occurred_at: string(item.occurred_at, "occurred_at"),
+    failure_kind: failureKind(item.failure_kind),
+    disposition: disposition(item.disposition),
+    reason: string(item.reason, "reason"),
+    score_delta: nullableNumber(item.score_delta, "score_delta"),
+    evaluated_seeds: array(item.evaluated_seeds, "evaluated_seeds").map((seed) => string(seed, "seed")),
+    evaluated_probes: array(item.evaluated_probes, "evaluated_probes").map((probe) => string(probe, "probe")),
+    branch_lineage: array(item.branch_lineage, "branch_lineage").map(parseLineageEdge),
+    evidence_refs: array(item.evidence_refs, "evidence_refs").map(parseEvidenceReference),
+  };
+}
+
+function parseLineageEdge(value: unknown): NegativeBranchLineageEdge {
+  const item = record(value, "branch lineage edge");
+  exact(item, ["parent_branch_id", "child_branch_id", "event_id"]);
+  return {
+    parent_branch_id: string(item.parent_branch_id, "parent_branch_id"),
+    child_branch_id: string(item.child_branch_id, "child_branch_id"),
+    event_id: nullableString(item.event_id, "event_id"),
+  };
+}
+
+function parseEvidenceReference(value: unknown): NegativeEvidenceReference {
+  const item = record(value, "evidence reference");
+  exact(item, ["uri", "summary"]);
+  return {
+    uri: string(item.uri, "uri"),
+    summary: string(item.summary, "summary"),
+  };
+}
+
+function parseFailureModeSummary(value: unknown): FailureModeSummary {
+  const item = record(value, "failure mode summary");
+  exact(item, ["failure_kind", "disposition", "count", "result_ids"]);
+  return {
+    failure_kind: failureKind(item.failure_kind),
+    disposition: disposition(item.disposition),
+    count: nonNegativeInteger(item.count, "count"),
+    result_ids: array(item.result_ids, "result_ids").map((id) => string(id, "result_id")),
+  };
+}
+
+function entryFromEvent(event: NegativeResultEventInput): NegativeResultEntry | null {
+  const payload = event.payload ?? {};
+  const eventType = event.event_type ?? event.event ?? "";
+  const kind = eventFailureKind(payload, eventType);
+  const isNegativeEvent = kind !== null || NEGATIVE_EVENTS.has(eventType);
+  if (isNegativeEvent === false) return null;
+  const branchId = event.branch_id ?? maybeString(payload.branch_id) ?? "";
+  if (branchId.length === 0) return null;
+  const eventId = event.event_id ?? (event.seq !== undefined ? `seq-${event.seq}` : "");
+  const fallbackResultId = eventId || `negative-${branchId.length}`;
+  const resultId = maybeString(payload.result_id) ?? fallbackResultId;
+  return {
+    result_id: resultId,
+    branch_id: branchId,
+    hypothesis_node_id: maybeString(payload.hypothesis_node_id) ?? event.hypothesis_node_id ?? null,
+    generation_index: nonNegativeIntegerOrNull(payload.generation_index ?? event.generation_index),
+    occurred_at: event.timestamp ?? event.ts ?? new Date().toISOString(),
+    failure_kind: kind ?? EVENT_FAILURE_KIND[eventType] ?? "dead_end",
+    disposition: eventDisposition(payload.disposition),
+    reason: maybeString(payload.reason) ?? event.reason ?? "Negative branch result recorded.",
+    score_delta: scoreDelta(payload),
+    evaluated_seeds: stringArray(payload.evaluated_seeds ?? payload.seeds),
+    evaluated_probes: stringArray(payload.evaluated_probes ?? payload.probes),
+    branch_lineage: branchLineage(event, payload, eventId, branchId),
+    evidence_refs: evidenceRefs(payload),
+  };
+}
+
+function failureModeSummary(entries: NegativeResultEntry[]): FailureModeSummary[] {
+  const groups = new Map<string, FailureModeSummary>();
+  for (const entry of entries) {
+    const key = `${entry.failure_kind}:${entry.disposition}`;
+    const existing = groups.get(key) ?? {
+      failure_kind: entry.failure_kind,
+      disposition: entry.disposition,
+      count: 0,
+      result_ids: [],
+    };
+    existing.count += 1;
+    existing.result_ids.push(entry.result_id);
+    groups.set(key, existing);
+  }
+  return [...groups.values()].sort((left, right) =>
+    `${left.failure_kind}:${left.disposition}`.localeCompare(`${right.failure_kind}:${right.disposition}`),
+  );
+}
+
+function eventFailureKind(payload: Record<string, unknown>, eventType: string): FailureKind | null {
+  const value = maybeString(payload.failure_kind);
+  if (value && FAILURE_KIND_SET.has(value)) return value as FailureKind;
+  return EVENT_FAILURE_KIND[eventType] ?? null;
+}
+
+function eventDisposition(value: unknown): NegativeResultDisposition {
+  const result = maybeString(value);
+  return result && DISPOSITION_SET.has(result) ? result as NegativeResultDisposition : "caution";
+}
+
+function scoreDelta(payload: Record<string, unknown>): number | null {
+  const explicit = maybeNumber(payload.score_delta);
+  if (explicit !== undefined) return round(explicit);
+  const score = maybeNumber(payload.score);
+  const baseline = maybeNumber(payload.baseline_score);
+  return score !== undefined && baseline !== undefined ? round(score - baseline) : null;
+}
+
+function branchLineage(
+  event: NegativeResultEventInput,
+  payload: Record<string, unknown>,
+  eventId: string,
+  branchId: string,
+): NegativeBranchLineageEdge[] {
+  if (Array.isArray(payload.branch_lineage)) {
+    return payload.branch_lineage.flatMap((edge) => {
+      const parsed = lineageEdgeFromRecord(edge);
+      return parsed ? [parsed] : [];
+    });
+  }
+  const parent = event.parent_branch_id ?? maybeString(payload.parent_branch_id);
+  return parent ? [{ parent_branch_id: parent, child_branch_id: branchId, event_id: eventId || null }] : [];
+}
+
+function lineageEdgeFromRecord(value: unknown): NegativeBranchLineageEdge | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const item = value as Record<string, unknown>;
+  const parent = maybeString(item.parent_branch_id);
+  const child = maybeString(item.child_branch_id);
+  if (!parent || !child) return null;
+  return { parent_branch_id: parent, child_branch_id: child, event_id: maybeString(item.event_id) ?? null };
+}
+
+function evidenceRefs(payload: Record<string, unknown>): NegativeEvidenceReference[] {
+  if (Array.isArray(payload.evidence_refs)) {
+    return payload.evidence_refs.flatMap((item) => {
+      const parsed = evidenceRefFromRecord(item);
+      return parsed ? [parsed] : [];
+    });
+  }
+  const uri = maybeString(payload.evidence_uri);
+  const summary = maybeString(payload.evidence_summary);
+  return uri && summary ? [{ uri, summary }] : [];
+}
+
+function evidenceRefFromRecord(value: unknown): NegativeEvidenceReference | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const item = value as Record<string, unknown>;
+  const uri = maybeString(item.uri);
+  const summary = maybeString(item.summary);
+  return uri && summary ? { uri, summary } : null;
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function exact(item: Record<string, unknown>, allowed: string[]): void {
+  const allowedSet = new Set(allowed);
+  const keys = Object.keys(item);
+  const missing = allowed.filter((key) => !keys.includes(key));
+  if (missing.length) throw new Error(`missing field(s): ${missing.sort().join(", ")}`);
+  const extra = keys.filter((key) => !allowedSet.has(key));
+  if (extra.length) throw new Error(`unexpected field(s): ${extra.sort().join(", ")}`);
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a string`);
+  return value;
+}
+
+function nullableString(value: unknown, label: string): string | null {
+  return value === null ? null : string(value, label);
+}
+
+function number(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${label} must be a number`);
+  return value;
+}
+
+function nullableNumber(value: unknown, label: string): number | null {
+  return value === null ? null : number(value, label);
+}
+
+function integer(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) throw new Error(`${label} must be an integer`);
+  return value;
+}
+
+function nonNegativeInteger(value: unknown, label: string): number {
+  const result = integer(value, label);
+  if (result < 0) throw new Error(`${label} must be a non-negative integer`);
+  return result;
+}
+
+function nullableNonNegativeInteger(value: unknown, label: string): number | null {
+  return value === null ? null : nonNegativeInteger(value, label);
+}
+
+function failureKind(value: unknown): FailureKind {
+  const result = string(value, "failure_kind");
+  if (!FAILURE_KIND_SET.has(result)) throw new Error("failure_kind must be known");
+  return result as FailureKind;
+}
+
+function disposition(value: unknown): NegativeResultDisposition {
+  const result = string(value, "disposition");
+  if (!DISPOSITION_SET.has(result)) throw new Error("disposition must be caution, hard_ban, or noise");
+  return result as NegativeResultDisposition;
+}
+
+function array(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value;
+}
+
+function maybeString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function maybeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function nonNegativeIntegerOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string" && item.length > 0) : [];
+}
+
+function round(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -654,6 +654,31 @@ export type {
 
 // Analytics / Traces
 export { ActorRef, TraceEvent, RunTrace } from "./analytics/run-trace.js";
+export {
+  FAILURE_KINDS,
+  NEGATIVE_RESULT_DISPOSITIONS,
+  buildNegativeResultLedger,
+  negativeResultLedgerToMarkdown,
+  parseNegativeResultLedger,
+  renderNegativeResultLessons,
+} from "./analytics/negative-result-ledger.js";
+export type {
+  BuildNegativeResultLedgerInput,
+  FailureKind,
+  FailureModeSummary,
+  NegativeBranchLineageEdge,
+  NegativeEvidenceReference,
+  NegativeResultDisposition,
+  NegativeResultEntry,
+  NegativeResultEventInput,
+  NegativeResultLedger,
+} from "./analytics/negative-result-ledger.js";
+export {
+  negativeResultLedgerPath,
+  readLatestNegativeResultLedgersMarkdown,
+  readNegativeResultLedger,
+  writeNegativeResultLedger,
+} from "./knowledge/negative-result-ledger-store.js";
 export type { TraceEventInit } from "./analytics/run-trace.js";
 export {
   PROGRESS_MILESTONE_NAMES,

--- a/ts/src/knowledge/negative-result-ledger-store.ts
+++ b/ts/src/knowledge/negative-result-ledger-store.ts
@@ -1,0 +1,58 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  negativeResultLedgerToMarkdown,
+  parseNegativeResultLedger,
+  type NegativeResultLedger,
+} from "../analytics/negative-result-ledger.js";
+
+export function negativeResultLedgerPath(
+  knowledgeRoot: string,
+  scenarioName: string,
+  runId: string,
+): string {
+  return join(knowledgeRoot, scenarioName, "negative_result_ledgers", `${runId}.json`);
+}
+
+export function writeNegativeResultLedger(
+  knowledgeRoot: string,
+  scenarioName: string,
+  runId: string,
+  ledger: NegativeResultLedger,
+): string {
+  const path = negativeResultLedgerPath(knowledgeRoot, scenarioName, runId);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(ledger, null, 2) + "\n", "utf-8");
+  return path;
+}
+
+export function readNegativeResultLedger(
+  knowledgeRoot: string,
+  scenarioName: string,
+  runId: string,
+): NegativeResultLedger | null {
+  const path = negativeResultLedgerPath(knowledgeRoot, scenarioName, runId);
+  return existsSync(path)
+    ? parseNegativeResultLedger(JSON.parse(readFileSync(path, "utf-8")) as unknown)
+    : null;
+}
+
+export function readLatestNegativeResultLedgersMarkdown(
+  knowledgeRoot: string,
+  scenarioName: string,
+  opts: { maxLedgers?: number } = {},
+): string {
+  const dir = join(knowledgeRoot, scenarioName, "negative_result_ledgers");
+  if (!existsSync(dir)) return "";
+  return readdirSync(dir)
+    .filter((name: string) => name.endsWith(".json"))
+    .map((name: string) => join(dir, name))
+    .sort((left: string, right: string) => statSync(right).mtimeMs - statSync(left).mtimeMs)
+    .slice(0, opts.maxLedgers ?? 2)
+    .map((path: string) =>
+      negativeResultLedgerToMarkdown(
+        parseNegativeResultLedger(JSON.parse(readFileSync(path, "utf-8")) as unknown),
+      ),
+    )
+    .join("\n\n");
+}

--- a/ts/tests/negative-result-ledger.test.ts
+++ b/ts/tests/negative-result-ledger.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildNegativeResultLedger,
+  parseNegativeResultLedger,
+  renderNegativeResultLessons,
+  type NegativeResultEventInput,
+  type NegativeResultLedger,
+} from "../src/analytics/negative-result-ledger.js";
+import {
+  readLatestNegativeResultLedgersMarkdown,
+  readNegativeResultLedger,
+  writeNegativeResultLedger,
+} from "../src/knowledge/negative-result-ledger-store.js";
+
+const fixture = JSON.parse(
+  readFileSync(
+    join(import.meta.dirname, "..", "..", "docs", "negative-result-ledger-parity-fixture.json"),
+    "utf-8",
+  ),
+) as {
+  cases: Array<{
+    name: string;
+    run_id: string;
+    generated_at: string;
+    events: NegativeResultEventInput[];
+    expected_ledger: NegativeResultLedger;
+  }>;
+};
+
+describe("negative result ledger", () => {
+  it("matches the shared Python/TypeScript parity fixture", () => {
+    for (const item of fixture.cases) {
+      expect(
+        buildNegativeResultLedger({
+          runId: item.run_id,
+          generatedAt: item.generated_at,
+          events: item.events,
+        }),
+      ).toEqual(item.expected_ledger);
+    }
+  });
+
+  it("persists negative result ledgers through the artifact store", () => {
+    const root = mkdtempSync(join(tmpdir(), "negative-ledger-"));
+    try {
+      const knowledgeRoot = join(root, "knowledge");
+      const ledger = parseNegativeResultLedger(fixture.cases[2]!.expected_ledger);
+
+      writeNegativeResultLedger(knowledgeRoot, "grid_ctf", ledger.run_id, ledger);
+
+      expect(readNegativeResultLedger(knowledgeRoot, "grid_ctf", ledger.run_id)).toEqual(ledger);
+      expect(readLatestNegativeResultLedgersMarkdown(knowledgeRoot, "grid_ctf")).toContain(
+        "Hard ban:",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("parses durable ledger JSON and rejects schema-invalid data", () => {
+    const ledger = fixture.cases[0]!.expected_ledger;
+    const entry = ledger.entries[0]!;
+
+    expect(parseNegativeResultLedger(ledger)).toEqual(ledger);
+    expect(() => parseNegativeResultLedger({ ...ledger, surprise: true })).toThrow(
+      /unexpected field/,
+    );
+    expect(() => parseNegativeResultLedger({ ...ledger, run_id: "" })).toThrow(/run_id/);
+    expect(() =>
+      parseNegativeResultLedger({ ...ledger, entries: [{ ...entry, disposition: "maybe" }] }),
+    ).toThrow(/disposition/);
+    const { branch_id: _branchId, ...missingBranch } = entry;
+    expect(() => parseNegativeResultLedger({ ...ledger, entries: [missingBranch] })).toThrow(
+      /missing field/,
+    );
+    expect(() =>
+      parseNegativeResultLedger({ ...ledger, entries: [{ ...entry, generation_index: -1 }] }),
+    ).toThrow(/generation_index/);
+  });
+
+  it("distinguishes cautionary lessons, noise, and hard bans", () => {
+    const caution = parseNegativeResultLedger(fixture.cases[0]!.expected_ledger);
+    const noise = parseNegativeResultLedger(fixture.cases[1]!.expected_ledger);
+    const hardBan = parseNegativeResultLedger(fixture.cases[2]!.expected_ledger);
+
+    expect(renderNegativeResultLessons(caution)).toContain("Caution:");
+    expect(renderNegativeResultLessons(caution)).toContain("not a ban");
+    expect(renderNegativeResultLessons(noise)).toBe("");
+    expect(renderNegativeResultLessons(hardBan)).toContain("Hard ban:");
+    expect(renderNegativeResultLessons(hardBan)).toContain("evt-hard-1");
+    expect(renderNegativeResultLessons(hardBan)).toContain("evt-hard-2");
+  });
+});

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -44,6 +44,7 @@ describe("package root exports", () => {
     expect(pkg.buildExternalEvalDiagnosticReport).toBeDefined();
     expect(pkg.buildExternalEvalImprovementSignals).toBeDefined();
     expect(pkg.buildRunUtilizationReport).toBeDefined();
+    expect(pkg.buildNegativeResultLedger).toBeDefined();
     expect(pkg.buildOperationalMemoryPackFromDiagnostics).toBeDefined();
     expect(pkg.resolveBrowserSessionConfig).toBeDefined();
     expect(pkg.evaluateBrowserActionPolicy).toBeDefined();


### PR DESCRIPTION
## Summary
- add shared Python/TypeScript negative result ledger contract for AC-823
- preserve failed/pruned/rejected branch evidence, branch lineage, score deltas, seeds/probes, and grouped failure modes
- add compact prompt lessons that distinguish caution, hard bans, and one-off noise
- add file helpers plus schema/docs/parity fixture for persisted ledger artifacts

## Tests
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m pytest tests/test_negative_result_ledger.py tests/test_package_boundaries.py tests/test_module_size_limits.py -q`
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m ruff check src/autocontext/analytics/negative_result_ledger.py src/autocontext/analytics/__init__.py src/autocontext/storage/negative_result_ledger_store.py tests/test_negative_result_ledger.py`
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m mypy src/autocontext/analytics/negative_result_ledger.py src/autocontext/analytics/__init__.py src/autocontext/storage/negative_result_ledger_store.py`
- `cd ts && npm test -- negative-result-ledger.test.ts package-export-catalogs.test.ts`
- `cd ts && npm run lint`
- `cd ts && npm run build`

Resolves AC-823.
