### PR TITLE
AC-824 add campaign mode report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - AC-821 run progress reports add Python/TypeScript parity for best-score-over-time curves, milestone timing, pass@k summaries, and branch lineage inspection references.
 - AC-822 run utilization reports add shared Python/TypeScript runner, token, verifier idle, model wait, and eval-throughput telemetry for single- and multi-branch runs.
 - AC-823 negative result ledgers preserve failed/pruned/rejected branch evidence, branch lineage, score deltas, and caution-vs-hard-ban prompt lessons across Python and TypeScript.
+- AC-824 campaign mode reports define shared Python/TypeScript multi-branch campaign identity, branch budgets, eval lanes, evidence sharing, terminal states, and recommendations.
 
 ## [pi-v0.2.6] - 2026-06-16
 

--- a/autocontext/src/autocontext/analytics/__init__.py
+++ b/autocontext/src/autocontext/analytics/__init__.py
@@ -1,5 +1,6 @@
 """Aggregate analytics for cross-run facets, signal extraction, and pattern clustering."""
 
+from autocontext.analytics.campaign_mode_report import CampaignModeReport, build_campaign_mode_report
 from autocontext.analytics.negative_result_ledger import NegativeResultLedger, build_negative_result_ledger
 from autocontext.analytics.progress_report import RunProgressReport, build_run_progress_report
 from autocontext.analytics.run_utilization_report import RunUtilizationReport, build_run_utilization_report
@@ -13,12 +14,14 @@ from autocontext.analytics.trace_gate_operator_view import (
 )
 
 __all__ = [
+    "CampaignModeReport",
     "NegativeResultLedger",
     "RunProgressReport",
     "RunUtilizationReport",
     "TraceGateAnalysisState",
     "TraceGateOperatorState",
     "TraceGateOperatorView",
+    "build_campaign_mode_report",
     "build_negative_result_ledger",
     "build_run_progress_report",
     "build_run_utilization_report",

--- a/autocontext/src/autocontext/analytics/campaign_mode_report.py
+++ b/autocontext/src/autocontext/analytics/campaign_mode_report.py
@@ -1,0 +1,277 @@
+"""Shared campaign-mode report for multi-branch runs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field
+
+CampaignTerminalState = Literal["active", "completed", "failed", "budget_exhausted", "canceled"]
+BranchTerminalState = Literal["pending", "running", "continued", "pruned", "succeeded", "failed", "budget_exhausted", "canceled"]
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        return cls.model_validate(data)
+
+
+class CampaignBranchBudget(_StrictModel):
+    max_tokens: int | None = Field(default=None, ge=0)
+    max_seconds: float | None = Field(default=None, ge=0)
+    max_evaluations: int | None = Field(default=None, ge=0)
+
+
+class CampaignBranchUsage(_StrictModel):
+    input_tokens: int = Field(ge=0)
+    output_tokens: int = Field(ge=0)
+    total_tokens: int = Field(ge=0)
+    evaluations: int = Field(ge=0)
+    runner_seconds: float = Field(ge=0)
+
+
+class CampaignEvalLane(_StrictModel):
+    lane_id: str = Field(min_length=1)
+    label: str = Field(min_length=1)
+    verifier_contract_ref: str = Field(min_length=1)
+    seeds: list[str]
+    holdout_refs: list[str]
+    weight: float = Field(ge=0)
+
+
+class CampaignBranch(_StrictModel):
+    branch_id: str = Field(min_length=1)
+    parent_branch_id: str | None
+    hypothesis_node_id: str | None
+    objective: str = Field(min_length=1)
+    budget: CampaignBranchBudget
+    usage: CampaignBranchUsage
+    terminal_state: BranchTerminalState
+    score: float | None
+    verifier_passed: bool | None
+    terminal_reason: str = Field(min_length=1)
+
+
+class CampaignBranchLineageEdge(_StrictModel):
+    parent_branch_id: str = Field(min_length=1)
+    child_branch_id: str = Field(min_length=1)
+
+
+class CampaignEvidenceReference(_StrictModel):
+    uri: str = Field(min_length=1)
+    summary: str = Field(min_length=1)
+
+
+class CampaignEvidenceShareItem(_StrictModel):
+    share_id: str = Field(min_length=1)
+    from_branch_id: str = Field(min_length=1)
+    to_branch_ids: list[str]
+    summary: str = Field(min_length=1)
+    included: bool
+    evidence_refs: list[CampaignEvidenceReference]
+
+
+class CampaignEvidencePolicy(_StrictModel):
+    max_shared_items: int = Field(default=2, ge=0)
+    max_summary_chars: int = Field(default=240, ge=1)
+
+
+class CampaignEvidenceSharing(_StrictModel):
+    policy: CampaignEvidencePolicy
+    items: list[CampaignEvidenceShareItem]
+
+
+class CampaignBranchSummary(_StrictModel):
+    branch_count: int = Field(ge=0)
+    succeeded: int = Field(ge=0)
+    failed: int = Field(ge=0)
+    pruned: int = Field(ge=0)
+    budget_exhausted: int = Field(ge=0)
+    running: int = Field(ge=0)
+
+
+class CampaignRecommendation(_StrictModel):
+    branch_id: str = Field(min_length=1)
+    score: float | None
+    reason: str = Field(min_length=1)
+
+
+class CampaignLinkedReports(_StrictModel):
+    progress_report_uri: str | None
+    utilization_report_uri: str | None
+    negative_result_ledger_uri: str | None
+
+
+class CampaignModeReport(_StrictModel):
+    schema_version: Literal[1] = 1
+    campaign_id: str = Field(min_length=1)
+    run_id: str = Field(min_length=1)
+    scenario_name: str = Field(min_length=1)
+    generated_at: str = Field(min_length=1)
+    terminal_state: CampaignTerminalState
+    branch_budget_defaults: CampaignBranchBudget
+    eval_lanes: list[CampaignEvalLane]
+    branches: list[CampaignBranch]
+    branch_lineage: list[CampaignBranchLineageEdge]
+    evidence_sharing: CampaignEvidenceSharing
+    branch_summary: CampaignBranchSummary
+    final_recommendation: CampaignRecommendation | None
+    linked_reports: CampaignLinkedReports
+
+    def to_markdown(self) -> str:
+        recommendation = (
+            f"- Recommendation: {self.final_recommendation.branch_id} "
+            f"(score={self.final_recommendation.score}) — {self.final_recommendation.reason}"
+            if self.final_recommendation
+            else "- Recommendation: none"
+        )
+        return "\n".join(
+            [
+                f"# Campaign Mode Report: {self.campaign_id}",
+                f"- Run: {self.run_id}",
+                f"- Scenario: {self.scenario_name}",
+                f"- Terminal state: {self.terminal_state}",
+                f"- Branches: {self.branch_summary.branch_count}",
+                recommendation,
+                "",
+                "## Shared Evidence",
+                render_campaign_evidence_share(self) or "- None",
+                "",
+            ]
+        )
+
+
+def build_campaign_mode_report(
+    *,
+    campaign_id: str,
+    run_id: str,
+    scenario_name: str,
+    terminal_state: CampaignTerminalState,
+    branch_budget_defaults: dict[str, Any],
+    eval_lanes: list[dict[str, Any]],
+    branches: list[dict[str, Any]],
+    shared_evidence: list[dict[str, Any]],
+    linked_reports: dict[str, Any],
+    evidence_policy: dict[str, Any] | None = None,
+    generated_at: str | None = None,
+) -> CampaignModeReport:
+    defaults = CampaignBranchBudget.from_dict(branch_budget_defaults).to_dict()
+    branch_models = [_branch_from_dict(branch, defaults) for branch in branches]
+    policy = CampaignEvidencePolicy.from_dict(evidence_policy or {}).to_dict()
+    return CampaignModeReport(
+        campaign_id=campaign_id,
+        run_id=run_id,
+        scenario_name=scenario_name,
+        generated_at=generated_at or datetime.now().astimezone().isoformat(),
+        terminal_state=terminal_state,
+        branch_budget_defaults=CampaignBranchBudget.from_dict(defaults),
+        eval_lanes=[CampaignEvalLane.from_dict(lane) for lane in eval_lanes],
+        branches=branch_models,
+        branch_lineage=_branch_lineage(branch_models),
+        evidence_sharing=CampaignEvidenceSharing(
+            policy=CampaignEvidencePolicy.from_dict(policy),
+            items=_evidence_items(shared_evidence, CampaignEvidencePolicy.from_dict(policy)),
+        ),
+        branch_summary=_branch_summary(branch_models),
+        final_recommendation=_recommendation(branch_models),
+        linked_reports=CampaignLinkedReports.from_dict(linked_reports),
+    )
+
+
+def render_campaign_evidence_share(report: CampaignModeReport) -> str:
+    lines: list[str] = []
+    for item in report.evidence_sharing.items:
+        if not item.included:
+            continue
+        evidence = "; ".join(ref.summary for ref in item.evidence_refs[:2])
+        targets = ", ".join(item.to_branch_ids) or "all branches"
+        lines.append(f"- {item.share_id}: {item.from_branch_id} -> {targets}: {item.summary}; evidence: {evidence}")
+    return "\n".join(lines)
+
+
+def _branch_from_dict(data: dict[str, Any], defaults: dict[str, Any]) -> CampaignBranch:
+    merged = {**data, "budget": data.get("budget") or defaults}
+    return CampaignBranch.from_dict(merged)
+
+
+def _branch_lineage(branches: list[CampaignBranch]) -> list[CampaignBranchLineageEdge]:
+    return [
+        CampaignBranchLineageEdge(parent_branch_id=branch.parent_branch_id, child_branch_id=branch.branch_id)
+        for branch in branches
+        if branch.parent_branch_id
+    ]
+
+
+def _branch_summary(branches: list[CampaignBranch]) -> CampaignBranchSummary:
+    active = {"pending", "running", "continued"}
+    return CampaignBranchSummary(
+        branch_count=len(branches),
+        succeeded=sum(1 for branch in branches if branch.terminal_state == "succeeded"),
+        failed=sum(1 for branch in branches if branch.terminal_state == "failed"),
+        pruned=sum(1 for branch in branches if branch.terminal_state == "pruned"),
+        budget_exhausted=sum(1 for branch in branches if branch.terminal_state == "budget_exhausted"),
+        running=sum(1 for branch in branches if branch.terminal_state in active),
+    )
+
+
+def _recommendation(branches: list[CampaignBranch]) -> CampaignRecommendation | None:
+    eligible = [branch for branch in branches if branch.score is not None and branch.verifier_passed is True]
+    if not eligible:
+        eligible = [branch for branch in branches if branch.score is not None]
+    if not eligible:
+        return None
+    best = max(eligible, key=lambda branch: branch.score if branch.score is not None else float("-inf"))
+    return CampaignRecommendation(branch_id=best.branch_id, score=best.score, reason=best.terminal_reason)
+
+
+def _evidence_items(
+    items: list[dict[str, Any]],
+    policy: CampaignEvidencePolicy,
+) -> list[CampaignEvidenceShareItem]:
+    result: list[CampaignEvidenceShareItem] = []
+    for index, item in enumerate(items):
+        included = bool(item.get("evidence_refs")) and index < policy.max_shared_items
+        result.append(
+            CampaignEvidenceShareItem.from_dict(
+                {
+                    "share_id": item.get("share_id"),
+                    "from_branch_id": item.get("from_branch_id"),
+                    "to_branch_ids": item.get("to_branch_ids", []),
+                    "summary": _truncate(str(item.get("summary", "")), policy.max_summary_chars),
+                    "included": included,
+                    "evidence_refs": item.get("evidence_refs", []),
+                }
+            )
+        )
+    return result
+
+
+def _truncate(value: str, max_chars: int) -> str:
+    return value if len(value) <= max_chars else value[: max_chars - 1].rstrip() + "…"
+
+
+__all__ = [
+    "BranchTerminalState",
+    "CampaignBranch",
+    "CampaignBranchBudget",
+    "CampaignBranchLineageEdge",
+    "CampaignBranchSummary",
+    "CampaignBranchUsage",
+    "CampaignEvalLane",
+    "CampaignEvidencePolicy",
+    "CampaignEvidenceReference",
+    "CampaignEvidenceShareItem",
+    "CampaignEvidenceSharing",
+    "CampaignLinkedReports",
+    "CampaignModeReport",
+    "CampaignRecommendation",
+    "CampaignTerminalState",
+    "build_campaign_mode_report",
+    "render_campaign_evidence_share",
+]

--- a/autocontext/src/autocontext/analytics/campaign_mode_report.py
+++ b/autocontext/src/autocontext/analytics/campaign_mode_report.py
@@ -23,9 +23,9 @@ class _StrictModel(BaseModel):
 
 
 class CampaignBranchBudget(_StrictModel):
-    max_tokens: int | None = Field(default=None, ge=0)
-    max_seconds: float | None = Field(default=None, ge=0)
-    max_evaluations: int | None = Field(default=None, ge=0)
+    max_tokens: int | None = Field(ge=0)
+    max_seconds: float | None = Field(ge=0)
+    max_evaluations: int | None = Field(ge=0)
 
 
 class CampaignBranchUsage(_StrictModel):
@@ -78,8 +78,8 @@ class CampaignEvidenceShareItem(_StrictModel):
 
 
 class CampaignEvidencePolicy(_StrictModel):
-    max_shared_items: int = Field(default=2, ge=0)
-    max_summary_chars: int = Field(default=240, ge=1)
+    max_shared_items: int = Field(ge=0)
+    max_summary_chars: int = Field(ge=1)
 
 
 class CampaignEvidenceSharing(_StrictModel):
@@ -109,7 +109,7 @@ class CampaignLinkedReports(_StrictModel):
 
 
 class CampaignModeReport(_StrictModel):
-    schema_version: Literal[1] = 1
+    schema_version: Literal[1]
     campaign_id: str = Field(min_length=1)
     run_id: str = Field(min_length=1)
     scenario_name: str = Field(min_length=1)
@@ -163,8 +163,9 @@ def build_campaign_mode_report(
 ) -> CampaignModeReport:
     defaults = CampaignBranchBudget.from_dict(branch_budget_defaults).to_dict()
     branch_models = [_branch_from_dict(branch, defaults) for branch in branches]
-    policy = CampaignEvidencePolicy.from_dict(evidence_policy or {}).to_dict()
+    policy = _evidence_policy_from_builder_input(evidence_policy)
     return CampaignModeReport(
+        schema_version=1,
         campaign_id=campaign_id,
         run_id=run_id,
         scenario_name=scenario_name,
@@ -175,8 +176,8 @@ def build_campaign_mode_report(
         branches=branch_models,
         branch_lineage=_branch_lineage(branch_models),
         evidence_sharing=CampaignEvidenceSharing(
-            policy=CampaignEvidencePolicy.from_dict(policy),
-            items=_evidence_items(shared_evidence, CampaignEvidencePolicy.from_dict(policy)),
+            policy=policy,
+            items=_evidence_items(shared_evidence, policy),
         ),
         branch_summary=_branch_summary(branch_models),
         final_recommendation=_recommendation(branch_models),
@@ -198,6 +199,12 @@ def render_campaign_evidence_share(report: CampaignModeReport) -> str:
 def _branch_from_dict(data: dict[str, Any], defaults: dict[str, Any]) -> CampaignBranch:
     merged = {**data, "budget": data.get("budget") or defaults}
     return CampaignBranch.from_dict(merged)
+
+
+def _evidence_policy_from_builder_input(data: dict[str, Any] | None) -> CampaignEvidencePolicy:
+    if data is None:
+        return CampaignEvidencePolicy(max_shared_items=2, max_summary_chars=240)
+    return CampaignEvidencePolicy.from_dict(data)
 
 
 def _branch_lineage(branches: list[CampaignBranch]) -> list[CampaignBranchLineageEdge]:
@@ -235,8 +242,11 @@ def _evidence_items(
     policy: CampaignEvidencePolicy,
 ) -> list[CampaignEvidenceShareItem]:
     result: list[CampaignEvidenceShareItem] = []
-    for index, item in enumerate(items):
-        included = bool(item.get("evidence_refs")) and index < policy.max_shared_items
+    included_count = 0
+    for item in items:
+        included = bool(item.get("evidence_refs")) and included_count < policy.max_shared_items
+        if included:
+            included_count += 1
         result.append(
             CampaignEvidenceShareItem.from_dict(
                 {

--- a/autocontext/src/autocontext/storage/campaign_mode_report_store.py
+++ b/autocontext/src/autocontext/storage/campaign_mode_report_store.py
@@ -1,0 +1,50 @@
+"""File helpers for campaign-mode reports."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Protocol
+
+from autocontext.analytics.campaign_mode_report import CampaignModeReport
+from autocontext.storage.scenario_paths import normalize_scenario_name_segment
+from autocontext.util.json_io import read_json, write_json
+
+
+class DictSerializable(Protocol):
+    def to_dict(self) -> dict[str, Any]: ...
+
+
+def campaign_mode_report_path(knowledge_root: Path, scenario_name: str, run_id: str) -> Path:
+    return knowledge_root / normalize_scenario_name_segment(scenario_name) / "campaign_mode_reports" / f"{run_id}.json"
+
+
+def write_campaign_mode_report(knowledge_root: Path, scenario_name: str, run_id: str, report: DictSerializable) -> Path:
+    path = campaign_mode_report_path(knowledge_root, scenario_name, run_id)
+    write_json(path, report.to_dict())
+    return path
+
+
+def read_campaign_mode_report(knowledge_root: Path, scenario_name: str, run_id: str) -> CampaignModeReport | None:
+    path = campaign_mode_report_path(knowledge_root, scenario_name, run_id)
+    return CampaignModeReport.from_dict(read_json(path)) if path.exists() else None
+
+
+def read_latest_campaign_mode_reports_markdown(
+    knowledge_root: Path,
+    scenario_name: str,
+    *,
+    max_reports: int = 2,
+) -> str:
+    root = knowledge_root / normalize_scenario_name_segment(scenario_name) / "campaign_mode_reports"
+    if not root.exists():
+        return ""
+    paths = sorted(root.glob("*.json"), key=lambda path: path.stat().st_mtime, reverse=True)[:max_reports]
+    return "\n\n".join(CampaignModeReport.from_dict(read_json(path)).to_markdown() for path in paths)
+
+
+__all__ = [
+    "campaign_mode_report_path",
+    "read_campaign_mode_report",
+    "read_latest_campaign_mode_reports_markdown",
+    "write_campaign_mode_report",
+]

--- a/autocontext/src/autocontext/storage/campaign_mode_report_store.py
+++ b/autocontext/src/autocontext/storage/campaign_mode_report_store.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Protocol
 
 from autocontext.analytics.campaign_mode_report import CampaignModeReport
@@ -15,7 +15,25 @@ class DictSerializable(Protocol):
 
 
 def campaign_mode_report_path(knowledge_root: Path, scenario_name: str, run_id: str) -> Path:
-    return knowledge_root / normalize_scenario_name_segment(scenario_name) / "campaign_mode_reports" / f"{run_id}.json"
+    return (
+        knowledge_root
+        / normalize_scenario_name_segment(scenario_name)
+        / "campaign_mode_reports"
+        / f"{_normalize_path_segment(run_id, 'run_id')}.json"
+    )
+
+
+def _normalize_path_segment(value: str, label: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{label} is required")
+    if "/" in normalized or "\\" in normalized:
+        raise ValueError(f"{label} must be a single path segment: {value!r}")
+    for path_cls in (PurePosixPath, PureWindowsPath):
+        candidate = path_cls(normalized)
+        if candidate.is_absolute() or len(candidate.parts) != 1 or candidate.parts[0] in {".", ".."}:
+            raise ValueError(f"{label} must be a single path segment: {value!r}")
+    return normalized
 
 
 def write_campaign_mode_report(knowledge_root: Path, scenario_name: str, run_id: str, report: DictSerializable) -> Path:

--- a/autocontext/tests/test_campaign_mode_report.py
+++ b/autocontext/tests/test_campaign_mode_report.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_PATH = ROOT / "docs" / "campaign-mode-report-parity-fixture.json"
+
+
+def _cases() -> list[dict[str, Any]]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))["cases"]
+
+
+def test_build_campaign_mode_report_matches_shared_fixture() -> None:
+    from autocontext.analytics.campaign_mode_report import build_campaign_mode_report
+
+    for case in _cases():
+        report = build_campaign_mode_report(
+            campaign_id=case["campaign_id"],
+            run_id=case["run_id"],
+            scenario_name=case["scenario_name"],
+            generated_at=case["generated_at"],
+            terminal_state=case["terminal_state"],
+            branch_budget_defaults=case["branch_budget_defaults"],
+            eval_lanes=case["eval_lanes"],
+            branches=case["branches"],
+            shared_evidence=case["shared_evidence"],
+            linked_reports=case["linked_reports"],
+            evidence_policy=case.get("evidence_policy"),
+        )
+
+        assert report.to_dict() == case["expected_report"]
+
+
+def test_campaign_mode_report_round_trips_shared_json() -> None:
+    from autocontext.analytics.campaign_mode_report import CampaignModeReport
+
+    for case in _cases():
+        expected = case["expected_report"]
+        assert CampaignModeReport.from_dict(expected).to_dict() == expected
+
+
+def test_campaign_mode_report_renders_only_included_evidence() -> None:
+    from autocontext.analytics.campaign_mode_report import CampaignModeReport, render_campaign_evidence_share
+
+    report = CampaignModeReport.from_dict(_cases()[1]["expected_report"])
+
+    rendered = render_campaign_evidence_share(report)
+
+    assert "share-safe-1" in rendered
+    assert "share-risky-1" not in rendered
+    assert "Safe branch passed both eval lanes" in rendered
+
+
+def test_campaign_mode_report_file_store_persists_report(tmp_path: Path) -> None:
+    from autocontext.analytics.campaign_mode_report import CampaignModeReport
+    from autocontext.storage.campaign_mode_report_store import (
+        read_campaign_mode_report,
+        read_latest_campaign_mode_reports_markdown,
+        write_campaign_mode_report,
+    )
+
+    report = CampaignModeReport.from_dict(_cases()[1]["expected_report"])
+
+    write_campaign_mode_report(tmp_path / "knowledge", "grid_ctf", report.run_id, report)
+
+    restored = read_campaign_mode_report(tmp_path / "knowledge", "grid_ctf", report.run_id)
+    assert isinstance(restored, CampaignModeReport)
+    assert restored.to_dict() == report.to_dict()
+    assert "Campaign Mode Report" in read_latest_campaign_mode_reports_markdown(tmp_path / "knowledge", "grid_ctf")
+
+
+def test_campaign_mode_report_rejects_schema_invalid_data() -> None:
+    from autocontext.analytics.campaign_mode_report import CampaignModeReport
+
+    expected = _cases()[1]["expected_report"]
+    bad_branch = {**expected["branches"][0], "terminal_state": "unknown"}
+    missing_budget = {k: v for k, v in expected["branches"][0].items() if k != "budget"}
+    negative_budget = {
+        **expected["branch_budget_defaults"],
+        "max_tokens": -1,
+    }
+
+    for payload in [
+        {**expected, "surprise": True},
+        {**expected, "campaign_id": ""},
+        {**expected, "branches": [bad_branch]},
+        {**expected, "branches": [missing_budget]},
+        {**expected, "branch_budget_defaults": negative_budget},
+    ]:
+        try:
+            CampaignModeReport.from_dict(payload)
+        except ValueError:
+            continue
+        raise AssertionError("schema-invalid campaign mode report was accepted")

--- a/autocontext/tests/test_campaign_mode_report.py
+++ b/autocontext/tests/test_campaign_mode_report.py
@@ -53,6 +53,42 @@ def test_campaign_mode_report_renders_only_included_evidence() -> None:
     assert "Safe branch passed both eval lanes" in rendered
 
 
+def test_campaign_mode_report_counts_only_evidence_backed_items_against_share_budget() -> None:
+    from autocontext.analytics.campaign_mode_report import build_campaign_mode_report
+
+    case = _cases()[0]
+    report = build_campaign_mode_report(
+        campaign_id=case["campaign_id"],
+        run_id=case["run_id"],
+        scenario_name=case["scenario_name"],
+        generated_at=case["generated_at"],
+        terminal_state=case["terminal_state"],
+        branch_budget_defaults=case["branch_budget_defaults"],
+        eval_lanes=case["eval_lanes"],
+        branches=case["branches"],
+        shared_evidence=[
+            {
+                "share_id": "without-evidence",
+                "from_branch_id": "branch-1",
+                "to_branch_ids": [],
+                "summary": "No artifact reference yet.",
+                "evidence_refs": [],
+            },
+            {
+                "share_id": "with-evidence",
+                "from_branch_id": "branch-1",
+                "to_branch_ids": [],
+                "summary": "This one should fit the prompt budget.",
+                "evidence_refs": [{"uri": "artifact://runs/run-1/eval.json", "summary": "passed"}],
+            },
+        ],
+        linked_reports=case["linked_reports"],
+        evidence_policy={"max_shared_items": 1, "max_summary_chars": 240},
+    )
+
+    assert [item.included for item in report.evidence_sharing.items] == [False, True]
+
+
 def test_campaign_mode_report_file_store_persists_report(tmp_path: Path) -> None:
     from autocontext.analytics.campaign_mode_report import CampaignModeReport
     from autocontext.storage.campaign_mode_report_store import (
@@ -71,6 +107,23 @@ def test_campaign_mode_report_file_store_persists_report(tmp_path: Path) -> None
     assert "Campaign Mode Report" in read_latest_campaign_mode_reports_markdown(tmp_path / "knowledge", "grid_ctf")
 
 
+def test_campaign_mode_report_file_store_rejects_path_traversal(tmp_path: Path) -> None:
+    from autocontext.analytics.campaign_mode_report import CampaignModeReport
+    from autocontext.storage.campaign_mode_report_store import write_campaign_mode_report
+
+    report = CampaignModeReport.from_dict(_cases()[0]["expected_report"])
+    knowledge_root = tmp_path / "knowledge"
+
+    try:
+        write_campaign_mode_report(knowledge_root, "grid_ctf", "../../../outside", report)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("path-traversing run_id was accepted")
+
+    assert not (tmp_path / "outside.json").exists()
+
+
 def test_campaign_mode_report_rejects_schema_invalid_data() -> None:
     from autocontext.analytics.campaign_mode_report import CampaignModeReport
 
@@ -81,13 +134,24 @@ def test_campaign_mode_report_rejects_schema_invalid_data() -> None:
         **expected["branch_budget_defaults"],
         "max_tokens": -1,
     }
+    missing_default_budget_field = {k: v for k, v in expected["branch_budget_defaults"].items() if k != "max_seconds"}
+    missing_branch_budget_field = {k: v for k, v in expected["branches"][0]["budget"].items() if k != "max_seconds"}
+    missing_schema_version = {k: v for k, v in expected.items() if k != "schema_version"}
+    missing_policy_field = {
+        **expected["evidence_sharing"],
+        "policy": {"max_shared_items": expected["evidence_sharing"]["policy"]["max_shared_items"]},
+    }
 
     for payload in [
+        missing_schema_version,
         {**expected, "surprise": True},
         {**expected, "campaign_id": ""},
         {**expected, "branches": [bad_branch]},
         {**expected, "branches": [missing_budget]},
+        {**expected, "branches": [{**expected["branches"][0], "budget": missing_branch_budget_field}]},
         {**expected, "branch_budget_defaults": negative_budget},
+        {**expected, "branch_budget_defaults": missing_default_budget_field},
+        {**expected, "evidence_sharing": missing_policy_field},
     ]:
         try:
             CampaignModeReport.from_dict(payload)

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - [Run progress report](run-progress-report.md)
 - [Run utilization report](run-utilization-report.md)
 - [Negative result ledger](negative-result-ledger.md)
+- [Campaign mode report](campaign-mode-report.md)
 - [Browser exploration contract](browser-exploration-contract.md)
 - [OpenTelemetry bridge](opentelemetry-bridge.md)
 - [Background session domain and parity contract](background-session-domain.md)

--- a/docs/campaign-mode-report-parity-fixture.json
+++ b/docs/campaign-mode-report-parity-fixture.json
@@ -1,0 +1,415 @@
+{
+  "cases": [
+    {
+      "name": "single-branch-completed",
+      "campaign_id": "campaign-single",
+      "run_id": "run-campaign-single",
+      "scenario_name": "grid_ctf",
+      "generated_at": "2026-06-16T14:00:00Z",
+      "terminal_state": "completed",
+      "branch_budget_defaults": {
+        "max_tokens": 1000,
+        "max_seconds": 120,
+        "max_evaluations": 3
+      },
+      "eval_lanes": [
+        {
+          "lane_id": "lane-smoke",
+          "label": "smoke verifier",
+          "verifier_contract_ref": "scenario://grid_ctf/verifier",
+          "seeds": ["seed-1"],
+          "holdout_refs": [],
+          "weight": 1
+        }
+      ],
+      "branches": [
+        {
+          "branch_id": "branch-main",
+          "parent_branch_id": null,
+          "hypothesis_node_id": "node-main",
+          "objective": "Solve with baseline strategy",
+          "budget": {
+            "max_tokens": 1000,
+            "max_seconds": 120,
+            "max_evaluations": 3
+          },
+          "usage": {
+            "input_tokens": 300,
+            "output_tokens": 120,
+            "total_tokens": 420,
+            "evaluations": 1,
+            "runner_seconds": 45
+          },
+          "terminal_state": "succeeded",
+          "score": 0.82,
+          "verifier_passed": true,
+          "terminal_reason": "Passed smoke verifier."
+        }
+      ],
+      "shared_evidence": [],
+      "linked_reports": {
+        "progress_report_uri": "knowledge/grid_ctf/progress_reports/run-campaign-single.json",
+        "utilization_report_uri": "knowledge/grid_ctf/utilization_reports/run-campaign-single.json",
+        "negative_result_ledger_uri": null
+      },
+      "expected_report": {
+        "schema_version": 1,
+        "campaign_id": "campaign-single",
+        "run_id": "run-campaign-single",
+        "scenario_name": "grid_ctf",
+        "generated_at": "2026-06-16T14:00:00Z",
+        "terminal_state": "completed",
+        "branch_budget_defaults": {
+          "max_tokens": 1000,
+          "max_seconds": 120,
+          "max_evaluations": 3
+        },
+        "eval_lanes": [
+          {
+            "lane_id": "lane-smoke",
+            "label": "smoke verifier",
+            "verifier_contract_ref": "scenario://grid_ctf/verifier",
+            "seeds": ["seed-1"],
+            "holdout_refs": [],
+            "weight": 1
+          }
+        ],
+        "branches": [
+          {
+            "branch_id": "branch-main",
+            "parent_branch_id": null,
+            "hypothesis_node_id": "node-main",
+            "objective": "Solve with baseline strategy",
+            "budget": {
+              "max_tokens": 1000,
+              "max_seconds": 120,
+              "max_evaluations": 3
+            },
+            "usage": {
+              "input_tokens": 300,
+              "output_tokens": 120,
+              "total_tokens": 420,
+              "evaluations": 1,
+              "runner_seconds": 45
+            },
+            "terminal_state": "succeeded",
+            "score": 0.82,
+            "verifier_passed": true,
+            "terminal_reason": "Passed smoke verifier."
+          }
+        ],
+        "branch_lineage": [],
+        "evidence_sharing": {
+          "policy": {
+            "max_shared_items": 2,
+            "max_summary_chars": 240
+          },
+          "items": []
+        },
+        "branch_summary": {
+          "branch_count": 1,
+          "succeeded": 1,
+          "failed": 0,
+          "pruned": 0,
+          "budget_exhausted": 0,
+          "running": 0
+        },
+        "final_recommendation": {
+          "branch_id": "branch-main",
+          "score": 0.82,
+          "reason": "Passed smoke verifier."
+        },
+        "linked_reports": {
+          "progress_report_uri": "knowledge/grid_ctf/progress_reports/run-campaign-single.json",
+          "utilization_report_uri": "knowledge/grid_ctf/utilization_reports/run-campaign-single.json",
+          "negative_result_ledger_uri": null
+        }
+      }
+    },
+    {
+      "name": "multi-branch-budgeted",
+      "campaign_id": "campaign-multi",
+      "run_id": "run-campaign-multi",
+      "scenario_name": "grid_ctf",
+      "generated_at": "2026-06-16T14:30:00Z",
+      "terminal_state": "completed",
+      "branch_budget_defaults": {
+        "max_tokens": 800,
+        "max_seconds": 90,
+        "max_evaluations": 2
+      },
+      "evidence_policy": {
+        "max_shared_items": 1,
+        "max_summary_chars": 72
+      },
+      "eval_lanes": [
+        {
+          "lane_id": "lane-seed",
+          "label": "seed replay",
+          "verifier_contract_ref": "scenario://grid_ctf/replay",
+          "seeds": ["seed-1", "seed-2"],
+          "holdout_refs": [],
+          "weight": 0.6
+        },
+        {
+          "lane_id": "lane-holdout",
+          "label": "holdout probe",
+          "verifier_contract_ref": "scenario://grid_ctf/holdout",
+          "seeds": [],
+          "holdout_refs": ["holdout-a"],
+          "weight": 0.4
+        }
+      ],
+      "branches": [
+        {
+          "branch_id": "branch-root",
+          "parent_branch_id": null,
+          "hypothesis_node_id": "node-root",
+          "objective": "Baseline capture-first plan",
+          "usage": {
+            "input_tokens": 260,
+            "output_tokens": 140,
+            "total_tokens": 400,
+            "evaluations": 2,
+            "runner_seconds": 50
+          },
+          "terminal_state": "pruned",
+          "score": 0.51,
+          "verifier_passed": false,
+          "terminal_reason": "Holdout probe regressed."
+        },
+        {
+          "branch_id": "branch-safe",
+          "parent_branch_id": "branch-root",
+          "hypothesis_node_id": "node-safe",
+          "objective": "Preserve defense while probing",
+          "budget": {
+            "max_tokens": 900,
+            "max_seconds": 90,
+            "max_evaluations": 2
+          },
+          "usage": {
+            "input_tokens": 380,
+            "output_tokens": 170,
+            "total_tokens": 550,
+            "evaluations": 2,
+            "runner_seconds": 62
+          },
+          "terminal_state": "succeeded",
+          "score": 0.88,
+          "verifier_passed": true,
+          "terminal_reason": "Best holdout score with verifier pass."
+        },
+        {
+          "branch_id": "branch-risky",
+          "parent_branch_id": "branch-root",
+          "hypothesis_node_id": "node-risky",
+          "objective": "Aggressive rush",
+          "usage": {
+            "input_tokens": 420,
+            "output_tokens": 240,
+            "total_tokens": 660,
+            "evaluations": 2,
+            "runner_seconds": 88
+          },
+          "terminal_state": "budget_exhausted",
+          "score": 0.42,
+          "verifier_passed": false,
+          "terminal_reason": "Token budget exhausted before verifier recovery."
+        }
+      ],
+      "shared_evidence": [
+        {
+          "share_id": "share-safe-1",
+          "from_branch_id": "branch-safe",
+          "to_branch_ids": ["branch-root", "branch-risky"],
+          "summary": "Defense-preserving probes recovered flag control and should seed retries.",
+          "evidence_refs": [
+            {
+              "uri": "runs/run-campaign-multi/evidence/safe.json",
+              "summary": "Safe branch passed both eval lanes."
+            }
+          ]
+        },
+        {
+          "share_id": "share-risky-1",
+          "from_branch_id": "branch-risky",
+          "to_branch_ids": ["branch-root"],
+          "summary": "Aggressive rush repeatedly overran the token budget.",
+          "evidence_refs": [
+            {
+              "uri": "runs/run-campaign-multi/evidence/risky.json",
+              "summary": "Risky branch exhausted budget."
+            }
+          ]
+        }
+      ],
+      "linked_reports": {
+        "progress_report_uri": "knowledge/grid_ctf/progress_reports/run-campaign-multi.json",
+        "utilization_report_uri": "knowledge/grid_ctf/utilization_reports/run-campaign-multi.json",
+        "negative_result_ledger_uri": "knowledge/grid_ctf/negative_result_ledgers/run-campaign-multi.json"
+      },
+      "expected_report": {
+        "schema_version": 1,
+        "campaign_id": "campaign-multi",
+        "run_id": "run-campaign-multi",
+        "scenario_name": "grid_ctf",
+        "generated_at": "2026-06-16T14:30:00Z",
+        "terminal_state": "completed",
+        "branch_budget_defaults": {
+          "max_tokens": 800,
+          "max_seconds": 90,
+          "max_evaluations": 2
+        },
+        "eval_lanes": [
+          {
+            "lane_id": "lane-seed",
+            "label": "seed replay",
+            "verifier_contract_ref": "scenario://grid_ctf/replay",
+            "seeds": ["seed-1", "seed-2"],
+            "holdout_refs": [],
+            "weight": 0.6
+          },
+          {
+            "lane_id": "lane-holdout",
+            "label": "holdout probe",
+            "verifier_contract_ref": "scenario://grid_ctf/holdout",
+            "seeds": [],
+            "holdout_refs": ["holdout-a"],
+            "weight": 0.4
+          }
+        ],
+        "branches": [
+          {
+            "branch_id": "branch-root",
+            "parent_branch_id": null,
+            "hypothesis_node_id": "node-root",
+            "objective": "Baseline capture-first plan",
+            "budget": {
+              "max_tokens": 800,
+              "max_seconds": 90,
+              "max_evaluations": 2
+            },
+            "usage": {
+              "input_tokens": 260,
+              "output_tokens": 140,
+              "total_tokens": 400,
+              "evaluations": 2,
+              "runner_seconds": 50
+            },
+            "terminal_state": "pruned",
+            "score": 0.51,
+            "verifier_passed": false,
+            "terminal_reason": "Holdout probe regressed."
+          },
+          {
+            "branch_id": "branch-safe",
+            "parent_branch_id": "branch-root",
+            "hypothesis_node_id": "node-safe",
+            "objective": "Preserve defense while probing",
+            "budget": {
+              "max_tokens": 900,
+              "max_seconds": 90,
+              "max_evaluations": 2
+            },
+            "usage": {
+              "input_tokens": 380,
+              "output_tokens": 170,
+              "total_tokens": 550,
+              "evaluations": 2,
+              "runner_seconds": 62
+            },
+            "terminal_state": "succeeded",
+            "score": 0.88,
+            "verifier_passed": true,
+            "terminal_reason": "Best holdout score with verifier pass."
+          },
+          {
+            "branch_id": "branch-risky",
+            "parent_branch_id": "branch-root",
+            "hypothesis_node_id": "node-risky",
+            "objective": "Aggressive rush",
+            "budget": {
+              "max_tokens": 800,
+              "max_seconds": 90,
+              "max_evaluations": 2
+            },
+            "usage": {
+              "input_tokens": 420,
+              "output_tokens": 240,
+              "total_tokens": 660,
+              "evaluations": 2,
+              "runner_seconds": 88
+            },
+            "terminal_state": "budget_exhausted",
+            "score": 0.42,
+            "verifier_passed": false,
+            "terminal_reason": "Token budget exhausted before verifier recovery."
+          }
+        ],
+        "branch_lineage": [
+          {
+            "parent_branch_id": "branch-root",
+            "child_branch_id": "branch-safe"
+          },
+          {
+            "parent_branch_id": "branch-root",
+            "child_branch_id": "branch-risky"
+          }
+        ],
+        "evidence_sharing": {
+          "policy": {
+            "max_shared_items": 1,
+            "max_summary_chars": 72
+          },
+          "items": [
+            {
+              "share_id": "share-safe-1",
+              "from_branch_id": "branch-safe",
+              "to_branch_ids": ["branch-root", "branch-risky"],
+              "summary": "Defense-preserving probes recovered flag control and should seed retrie…",
+              "included": true,
+              "evidence_refs": [
+                {
+                  "uri": "runs/run-campaign-multi/evidence/safe.json",
+                  "summary": "Safe branch passed both eval lanes."
+                }
+              ]
+            },
+            {
+              "share_id": "share-risky-1",
+              "from_branch_id": "branch-risky",
+              "to_branch_ids": ["branch-root"],
+              "summary": "Aggressive rush repeatedly overran the token budget.",
+              "included": false,
+              "evidence_refs": [
+                {
+                  "uri": "runs/run-campaign-multi/evidence/risky.json",
+                  "summary": "Risky branch exhausted budget."
+                }
+              ]
+            }
+          ]
+        },
+        "branch_summary": {
+          "branch_count": 3,
+          "succeeded": 1,
+          "failed": 0,
+          "pruned": 1,
+          "budget_exhausted": 1,
+          "running": 0
+        },
+        "final_recommendation": {
+          "branch_id": "branch-safe",
+          "score": 0.88,
+          "reason": "Best holdout score with verifier pass."
+        },
+        "linked_reports": {
+          "progress_report_uri": "knowledge/grid_ctf/progress_reports/run-campaign-multi.json",
+          "utilization_report_uri": "knowledge/grid_ctf/utilization_reports/run-campaign-multi.json",
+          "negative_result_ledger_uri": "knowledge/grid_ctf/negative_result_ledgers/run-campaign-multi.json"
+        }
+      }
+    }
+  ]
+}

--- a/docs/campaign-mode-report.json
+++ b/docs/campaign-mode-report.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/greyhaven-ai/autocontext/docs/campaign-mode-report.json",
+  "title": "CampaignModeReport",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "campaign_id",
+    "run_id",
+    "scenario_name",
+    "generated_at",
+    "terminal_state",
+    "branch_budget_defaults",
+    "eval_lanes",
+    "branches",
+    "branch_lineage",
+    "evidence_sharing",
+    "branch_summary",
+    "final_recommendation",
+    "linked_reports"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "campaign_id": { "type": "string", "minLength": 1 },
+    "run_id": { "type": "string", "minLength": 1 },
+    "scenario_name": { "type": "string", "minLength": 1 },
+    "generated_at": { "type": "string", "minLength": 1 },
+    "terminal_state": { "$ref": "#/$defs/campaignTerminalState" },
+    "branch_budget_defaults": { "$ref": "#/$defs/branchBudget" },
+    "eval_lanes": { "type": "array", "items": { "$ref": "#/$defs/evalLane" } },
+    "branches": { "type": "array", "items": { "$ref": "#/$defs/branch" } },
+    "branch_lineage": { "type": "array", "items": { "$ref": "#/$defs/lineageEdge" } },
+    "evidence_sharing": { "$ref": "#/$defs/evidenceSharing" },
+    "branch_summary": { "$ref": "#/$defs/branchSummary" },
+    "final_recommendation": { "oneOf": [{ "$ref": "#/$defs/recommendation" }, { "type": "null" }] },
+    "linked_reports": { "$ref": "#/$defs/linkedReports" }
+  },
+  "$defs": {
+    "campaignTerminalState": { "enum": ["active", "completed", "failed", "budget_exhausted", "canceled"] },
+    "branchTerminalState": {
+      "enum": ["pending", "running", "continued", "pruned", "succeeded", "failed", "budget_exhausted", "canceled"]
+    },
+    "nullableString": { "type": ["string", "null"] },
+    "nullableNumber": { "type": ["number", "null"] },
+    "nullableNonNegativeInteger": { "type": ["integer", "null"], "minimum": 0 },
+    "nullableNonNegativeNumber": { "type": ["number", "null"], "minimum": 0 },
+    "branchBudget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_tokens", "max_seconds", "max_evaluations"],
+      "properties": {
+        "max_tokens": { "$ref": "#/$defs/nullableNonNegativeInteger" },
+        "max_seconds": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "max_evaluations": { "$ref": "#/$defs/nullableNonNegativeInteger" }
+      }
+    },
+    "branchUsage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input_tokens", "output_tokens", "total_tokens", "evaluations", "runner_seconds"],
+      "properties": {
+        "input_tokens": { "type": "integer", "minimum": 0 },
+        "output_tokens": { "type": "integer", "minimum": 0 },
+        "total_tokens": { "type": "integer", "minimum": 0 },
+        "evaluations": { "type": "integer", "minimum": 0 },
+        "runner_seconds": { "type": "number", "minimum": 0 }
+      }
+    },
+    "evalLane": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["lane_id", "label", "verifier_contract_ref", "seeds", "holdout_refs", "weight"],
+      "properties": {
+        "lane_id": { "type": "string", "minLength": 1 },
+        "label": { "type": "string", "minLength": 1 },
+        "verifier_contract_ref": { "type": "string", "minLength": 1 },
+        "seeds": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "holdout_refs": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "weight": { "type": "number", "minimum": 0 }
+      }
+    },
+    "branch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "branch_id",
+        "parent_branch_id",
+        "hypothesis_node_id",
+        "objective",
+        "budget",
+        "usage",
+        "terminal_state",
+        "score",
+        "verifier_passed",
+        "terminal_reason"
+      ],
+      "properties": {
+        "branch_id": { "type": "string", "minLength": 1 },
+        "parent_branch_id": { "$ref": "#/$defs/nullableString" },
+        "hypothesis_node_id": { "$ref": "#/$defs/nullableString" },
+        "objective": { "type": "string", "minLength": 1 },
+        "budget": { "$ref": "#/$defs/branchBudget" },
+        "usage": { "$ref": "#/$defs/branchUsage" },
+        "terminal_state": { "$ref": "#/$defs/branchTerminalState" },
+        "score": { "$ref": "#/$defs/nullableNumber" },
+        "verifier_passed": { "type": ["boolean", "null"] },
+        "terminal_reason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "lineageEdge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["parent_branch_id", "child_branch_id"],
+      "properties": {
+        "parent_branch_id": { "type": "string", "minLength": 1 },
+        "child_branch_id": { "type": "string", "minLength": 1 }
+      }
+    },
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uri", "summary"],
+      "properties": {
+        "uri": { "type": "string", "minLength": 1 },
+        "summary": { "type": "string", "minLength": 1 }
+      }
+    },
+    "evidenceShareItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["share_id", "from_branch_id", "to_branch_ids", "summary", "included", "evidence_refs"],
+      "properties": {
+        "share_id": { "type": "string", "minLength": 1 },
+        "from_branch_id": { "type": "string", "minLength": 1 },
+        "to_branch_ids": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "summary": { "type": "string", "minLength": 1 },
+        "included": { "type": "boolean" },
+        "evidence_refs": { "type": "array", "items": { "$ref": "#/$defs/evidenceRef" } }
+      }
+    },
+    "evidencePolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_shared_items", "max_summary_chars"],
+      "properties": {
+        "max_shared_items": { "type": "integer", "minimum": 0 },
+        "max_summary_chars": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "evidenceSharing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy", "items"],
+      "properties": {
+        "policy": { "$ref": "#/$defs/evidencePolicy" },
+        "items": { "type": "array", "items": { "$ref": "#/$defs/evidenceShareItem" } }
+      }
+    },
+    "branchSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["branch_count", "succeeded", "failed", "pruned", "budget_exhausted", "running"],
+      "properties": {
+        "branch_count": { "type": "integer", "minimum": 0 },
+        "succeeded": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "pruned": { "type": "integer", "minimum": 0 },
+        "budget_exhausted": { "type": "integer", "minimum": 0 },
+        "running": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "recommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["branch_id", "score", "reason"],
+      "properties": {
+        "branch_id": { "type": "string", "minLength": 1 },
+        "score": { "$ref": "#/$defs/nullableNumber" },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "linkedReports": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["progress_report_uri", "utilization_report_uri", "negative_result_ledger_uri"],
+      "properties": {
+        "progress_report_uri": { "$ref": "#/$defs/nullableString" },
+        "utilization_report_uri": { "$ref": "#/$defs/nullableString" },
+        "negative_result_ledger_uri": { "$ref": "#/$defs/nullableString" }
+      }
+    }
+  }
+}

--- a/docs/campaign-mode-report.md
+++ b/docs/campaign-mode-report.md
@@ -4,7 +4,7 @@ AC-824 defines campaign mode as a shared Python/TypeScript artifact for multi-br
 
 ## Contract
 
-Schema: [`campaign-mode-report.json`](campaign-mode-report.json)  
+Schema: [`campaign-mode-report.json`](campaign-mode-report.json)
 Parity fixture: [`campaign-mode-report-parity-fixture.json`](campaign-mode-report-parity-fixture.json)
 
 A report captures:

--- a/docs/campaign-mode-report.md
+++ b/docs/campaign-mode-report.md
@@ -1,0 +1,32 @@
+# Campaign Mode Report
+
+AC-824 defines campaign mode as a shared Python/TypeScript artifact for multi-branch runs. It makes the hypothesis tree operator-visible without adding hosted scheduling or proprietary orchestration.
+
+## Contract
+
+Schema: [`campaign-mode-report.json`](campaign-mode-report.json)  
+Parity fixture: [`campaign-mode-report-parity-fixture.json`](campaign-mode-report-parity-fixture.json)
+
+A report captures:
+
+- campaign and run identity
+- branch budgets and usage
+- comparable eval lanes with verifier contract references, seeds, and holdouts
+- branch lineage and terminal states
+- compact, evidence-backed cross-branch sharing with an item/summary budget
+- links to progress, utilization, and negative-result artifacts
+- final recommendation for the best evidence-backed branch
+
+## Terminal states
+
+Campaign states: `active`, `completed`, `failed`, `budget_exhausted`, `canceled`.
+
+Branch states: `pending`, `running`, `continued`, `pruned`, `succeeded`, `failed`, `budget_exhausted`, `canceled`.
+
+## Evidence sharing
+
+`evidence_sharing.policy` caps how much cross-branch evidence may enter prompt context. Items outside the cap remain inspectable with `included: false` but should not be injected into prompts.
+
+## OSS boundary
+
+The artifact contract, builders, parsers, and file helpers are public. Hosted tenant scheduling, fleet routing, budget billing, warm pools, and proprietary campaign dashboards remain out of scope.

--- a/ts/src/analytics/campaign-mode-report.ts
+++ b/ts/src/analytics/campaign-mode-report.ts
@@ -401,11 +401,16 @@ function evidenceItems(
   items: CampaignEvidenceShareItemInput[],
   policy: CampaignEvidencePolicy,
 ): CampaignEvidenceShareItem[] {
-  return items.map((item, index) => parseEvidenceItem({
-    ...item,
-    summary: truncate(item.summary, policy.max_summary_chars),
-    included: item.evidence_refs.length > 0 && index < policy.max_shared_items,
-  }));
+  let includedCount = 0;
+  return items.map((item) => {
+    const included = item.evidence_refs.length > 0 && includedCount < policy.max_shared_items;
+    if (included) includedCount += 1;
+    return parseEvidenceItem({
+      ...item,
+      summary: truncate(item.summary, policy.max_summary_chars),
+      included,
+    });
+  });
 }
 
 function truncate(value: string, maxChars: number): string {

--- a/ts/src/analytics/campaign-mode-report.ts
+++ b/ts/src/analytics/campaign-mode-report.ts
@@ -1,0 +1,506 @@
+export const CAMPAIGN_TERMINAL_STATES = [
+  "active",
+  "completed",
+  "failed",
+  "budget_exhausted",
+  "canceled",
+] as const;
+export const BRANCH_TERMINAL_STATES = [
+  "pending",
+  "running",
+  "continued",
+  "pruned",
+  "succeeded",
+  "failed",
+  "budget_exhausted",
+  "canceled",
+] as const;
+
+export type CampaignTerminalState = (typeof CAMPAIGN_TERMINAL_STATES)[number];
+export type BranchTerminalState = (typeof BRANCH_TERMINAL_STATES)[number];
+
+export interface CampaignBranchBudget {
+  max_tokens: number | null;
+  max_seconds: number | null;
+  max_evaluations: number | null;
+}
+
+export interface CampaignBranchUsage {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  evaluations: number;
+  runner_seconds: number;
+}
+
+export interface CampaignEvalLane {
+  lane_id: string;
+  label: string;
+  verifier_contract_ref: string;
+  seeds: string[];
+  holdout_refs: string[];
+  weight: number;
+}
+
+export interface CampaignBranch {
+  branch_id: string;
+  parent_branch_id: string | null;
+  hypothesis_node_id: string | null;
+  objective: string;
+  budget: CampaignBranchBudget;
+  usage: CampaignBranchUsage;
+  terminal_state: BranchTerminalState;
+  score: number | null;
+  verifier_passed: boolean | null;
+  terminal_reason: string;
+}
+
+export interface CampaignBranchLineageEdge {
+  parent_branch_id: string;
+  child_branch_id: string;
+}
+
+export interface CampaignEvidenceReference {
+  uri: string;
+  summary: string;
+}
+
+export interface CampaignEvidenceShareItemInput {
+  share_id: string;
+  from_branch_id: string;
+  to_branch_ids: string[];
+  summary: string;
+  evidence_refs: CampaignEvidenceReference[];
+}
+
+export interface CampaignEvidenceShareItem extends CampaignEvidenceShareItemInput {
+  included: boolean;
+}
+
+export interface CampaignEvidencePolicy {
+  max_shared_items: number;
+  max_summary_chars: number;
+}
+
+export interface CampaignEvidenceSharing {
+  policy: CampaignEvidencePolicy;
+  items: CampaignEvidenceShareItem[];
+}
+
+export interface CampaignBranchSummary {
+  branch_count: number;
+  succeeded: number;
+  failed: number;
+  pruned: number;
+  budget_exhausted: number;
+  running: number;
+}
+
+export interface CampaignRecommendation {
+  branch_id: string;
+  score: number | null;
+  reason: string;
+}
+
+export interface CampaignLinkedReports {
+  progress_report_uri: string | null;
+  utilization_report_uri: string | null;
+  negative_result_ledger_uri: string | null;
+}
+
+export interface CampaignModeReport {
+  schema_version: 1;
+  campaign_id: string;
+  run_id: string;
+  scenario_name: string;
+  generated_at: string;
+  terminal_state: CampaignTerminalState;
+  branch_budget_defaults: CampaignBranchBudget;
+  eval_lanes: CampaignEvalLane[];
+  branches: CampaignBranch[];
+  branch_lineage: CampaignBranchLineageEdge[];
+  evidence_sharing: CampaignEvidenceSharing;
+  branch_summary: CampaignBranchSummary;
+  final_recommendation: CampaignRecommendation | null;
+  linked_reports: CampaignLinkedReports;
+}
+
+export interface BuildCampaignModeReportInput {
+  campaign_id: string;
+  run_id: string;
+  scenario_name: string;
+  generated_at?: string;
+  terminal_state: CampaignTerminalState;
+  branch_budget_defaults: CampaignBranchBudget;
+  eval_lanes: CampaignEvalLane[];
+  branches: Array<Omit<CampaignBranch, "budget"> & { budget?: CampaignBranchBudget }>;
+  shared_evidence: CampaignEvidenceShareItemInput[];
+  linked_reports: CampaignLinkedReports;
+  evidence_policy?: CampaignEvidencePolicy;
+}
+
+const CAMPAIGN_TERMINAL_STATE_SET = new Set<string>(CAMPAIGN_TERMINAL_STATES);
+const BRANCH_TERMINAL_STATE_SET = new Set<string>(BRANCH_TERMINAL_STATES);
+
+export function buildCampaignModeReport(input: BuildCampaignModeReportInput): CampaignModeReport {
+  const defaults = parseBudget(input.branch_budget_defaults);
+  const branches = input.branches.map((branch) => parseBranch({ ...branch, budget: branch.budget ?? defaults }));
+  const policy = parseEvidencePolicy(input.evidence_policy ?? { max_shared_items: 2, max_summary_chars: 240 });
+  return parseCampaignModeReport({
+    schema_version: 1,
+    campaign_id: input.campaign_id,
+    run_id: input.run_id,
+    scenario_name: input.scenario_name,
+    generated_at: input.generated_at ?? new Date().toISOString(),
+    terminal_state: input.terminal_state,
+    branch_budget_defaults: defaults,
+    eval_lanes: input.eval_lanes,
+    branches,
+    branch_lineage: branchLineage(branches),
+    evidence_sharing: { policy, items: evidenceItems(input.shared_evidence, policy) },
+    branch_summary: branchSummary(branches),
+    final_recommendation: recommendation(branches),
+    linked_reports: input.linked_reports,
+  });
+}
+
+export function parseCampaignModeReport(value: unknown): CampaignModeReport {
+  const report = record(value, "campaign mode report");
+  exact(report, [
+    "schema_version",
+    "campaign_id",
+    "run_id",
+    "scenario_name",
+    "generated_at",
+    "terminal_state",
+    "branch_budget_defaults",
+    "eval_lanes",
+    "branches",
+    "branch_lineage",
+    "evidence_sharing",
+    "branch_summary",
+    "final_recommendation",
+    "linked_reports",
+  ]);
+  if (report.schema_version !== 1) throw new Error("schema_version must be 1");
+  return {
+    schema_version: 1,
+    campaign_id: string(report.campaign_id, "campaign_id"),
+    run_id: string(report.run_id, "run_id"),
+    scenario_name: string(report.scenario_name, "scenario_name"),
+    generated_at: string(report.generated_at, "generated_at"),
+    terminal_state: campaignTerminalState(report.terminal_state),
+    branch_budget_defaults: parseBudget(report.branch_budget_defaults),
+    eval_lanes: array(report.eval_lanes, "eval_lanes").map(parseEvalLane),
+    branches: array(report.branches, "branches").map(parseBranch),
+    branch_lineage: array(report.branch_lineage, "branch_lineage").map(parseLineage),
+    evidence_sharing: parseEvidenceSharing(report.evidence_sharing),
+    branch_summary: parseBranchSummary(report.branch_summary),
+    final_recommendation: report.final_recommendation === null ? null : parseRecommendation(report.final_recommendation),
+    linked_reports: parseLinkedReports(report.linked_reports),
+  };
+}
+
+export function renderCampaignEvidenceShare(report: CampaignModeReport): string {
+  return report.evidence_sharing.items
+    .filter((item) => item.included)
+    .map((item) => {
+      const targets = item.to_branch_ids.length ? item.to_branch_ids.join(", ") : "all branches";
+      const evidence = item.evidence_refs.slice(0, 2).map((ref) => ref.summary).join("; ");
+      return `- ${item.share_id}: ${item.from_branch_id} -> ${targets}: ${item.summary}; evidence: ${evidence}`;
+    })
+    .join("\n");
+}
+
+export function campaignModeReportToMarkdown(report: CampaignModeReport): string {
+  const recommendation = report.final_recommendation
+    ? `- Recommendation: ${report.final_recommendation.branch_id} (score=${report.final_recommendation.score}) — ${report.final_recommendation.reason}`
+    : "- Recommendation: none";
+  return [
+    `# Campaign Mode Report: ${report.campaign_id}`,
+    `- Run: ${report.run_id}`,
+    `- Scenario: ${report.scenario_name}`,
+    `- Terminal state: ${report.terminal_state}`,
+    `- Branches: ${report.branch_summary.branch_count}`,
+    recommendation,
+    "",
+    "## Shared Evidence",
+    renderCampaignEvidenceShare(report) || "- None",
+    "",
+  ].join("\n");
+}
+
+function parseBudget(value: unknown): CampaignBranchBudget {
+  const item = record(value, "branch budget");
+  exact(item, ["max_tokens", "max_seconds", "max_evaluations"]);
+  return {
+    max_tokens: nullableNonNegativeInteger(item.max_tokens, "max_tokens"),
+    max_seconds: nullableNonNegativeNumber(item.max_seconds, "max_seconds"),
+    max_evaluations: nullableNonNegativeInteger(item.max_evaluations, "max_evaluations"),
+  };
+}
+
+function parseUsage(value: unknown): CampaignBranchUsage {
+  const item = record(value, "branch usage");
+  exact(item, ["input_tokens", "output_tokens", "total_tokens", "evaluations", "runner_seconds"]);
+  return {
+    input_tokens: nonNegativeInteger(item.input_tokens, "input_tokens"),
+    output_tokens: nonNegativeInteger(item.output_tokens, "output_tokens"),
+    total_tokens: nonNegativeInteger(item.total_tokens, "total_tokens"),
+    evaluations: nonNegativeInteger(item.evaluations, "evaluations"),
+    runner_seconds: nonNegativeNumber(item.runner_seconds, "runner_seconds"),
+  };
+}
+
+function parseEvalLane(value: unknown): CampaignEvalLane {
+  const item = record(value, "eval lane");
+  exact(item, ["lane_id", "label", "verifier_contract_ref", "seeds", "holdout_refs", "weight"]);
+  return {
+    lane_id: string(item.lane_id, "lane_id"),
+    label: string(item.label, "label"),
+    verifier_contract_ref: string(item.verifier_contract_ref, "verifier_contract_ref"),
+    seeds: stringArray(item.seeds, "seeds"),
+    holdout_refs: stringArray(item.holdout_refs, "holdout_refs"),
+    weight: nonNegativeNumber(item.weight, "weight"),
+  };
+}
+
+function parseBranch(value: unknown): CampaignBranch {
+  const item = record(value, "campaign branch");
+  exact(item, [
+    "branch_id",
+    "parent_branch_id",
+    "hypothesis_node_id",
+    "objective",
+    "budget",
+    "usage",
+    "terminal_state",
+    "score",
+    "verifier_passed",
+    "terminal_reason",
+  ]);
+  return {
+    branch_id: string(item.branch_id, "branch_id"),
+    parent_branch_id: nullableString(item.parent_branch_id, "parent_branch_id"),
+    hypothesis_node_id: nullableString(item.hypothesis_node_id, "hypothesis_node_id"),
+    objective: string(item.objective, "objective"),
+    budget: parseBudget(item.budget),
+    usage: parseUsage(item.usage),
+    terminal_state: branchTerminalState(item.terminal_state),
+    score: nullableNumber(item.score, "score"),
+    verifier_passed: nullableBoolean(item.verifier_passed, "verifier_passed"),
+    terminal_reason: string(item.terminal_reason, "terminal_reason"),
+  };
+}
+
+function parseLineage(value: unknown): CampaignBranchLineageEdge {
+  const item = record(value, "branch lineage edge");
+  exact(item, ["parent_branch_id", "child_branch_id"]);
+  return {
+    parent_branch_id: string(item.parent_branch_id, "parent_branch_id"),
+    child_branch_id: string(item.child_branch_id, "child_branch_id"),
+  };
+}
+
+function parseEvidenceReference(value: unknown): CampaignEvidenceReference {
+  const item = record(value, "evidence reference");
+  exact(item, ["uri", "summary"]);
+  return { uri: string(item.uri, "uri"), summary: string(item.summary, "summary") };
+}
+
+function parseEvidenceItem(value: unknown): CampaignEvidenceShareItem {
+  const item = record(value, "evidence share item");
+  exact(item, ["share_id", "from_branch_id", "to_branch_ids", "summary", "included", "evidence_refs"]);
+  return {
+    share_id: string(item.share_id, "share_id"),
+    from_branch_id: string(item.from_branch_id, "from_branch_id"),
+    to_branch_ids: stringArray(item.to_branch_ids, "to_branch_ids"),
+    summary: string(item.summary, "summary"),
+    included: boolean(item.included, "included"),
+    evidence_refs: array(item.evidence_refs, "evidence_refs").map(parseEvidenceReference),
+  };
+}
+
+function parseEvidencePolicy(value: unknown): CampaignEvidencePolicy {
+  const item = record(value, "evidence policy");
+  exact(item, ["max_shared_items", "max_summary_chars"]);
+  return {
+    max_shared_items: nonNegativeInteger(item.max_shared_items, "max_shared_items"),
+    max_summary_chars: positiveInteger(item.max_summary_chars, "max_summary_chars"),
+  };
+}
+
+function parseEvidenceSharing(value: unknown): CampaignEvidenceSharing {
+  const item = record(value, "evidence sharing");
+  exact(item, ["policy", "items"]);
+  return {
+    policy: parseEvidencePolicy(item.policy),
+    items: array(item.items, "items").map(parseEvidenceItem),
+  };
+}
+
+function parseBranchSummary(value: unknown): CampaignBranchSummary {
+  const item = record(value, "branch summary");
+  exact(item, ["branch_count", "succeeded", "failed", "pruned", "budget_exhausted", "running"]);
+  return {
+    branch_count: nonNegativeInteger(item.branch_count, "branch_count"),
+    succeeded: nonNegativeInteger(item.succeeded, "succeeded"),
+    failed: nonNegativeInteger(item.failed, "failed"),
+    pruned: nonNegativeInteger(item.pruned, "pruned"),
+    budget_exhausted: nonNegativeInteger(item.budget_exhausted, "budget_exhausted"),
+    running: nonNegativeInteger(item.running, "running"),
+  };
+}
+
+function parseRecommendation(value: unknown): CampaignRecommendation {
+  const item = record(value, "final recommendation");
+  exact(item, ["branch_id", "score", "reason"]);
+  return {
+    branch_id: string(item.branch_id, "branch_id"),
+    score: nullableNumber(item.score, "score"),
+    reason: string(item.reason, "reason"),
+  };
+}
+
+function parseLinkedReports(value: unknown): CampaignLinkedReports {
+  const item = record(value, "linked reports");
+  exact(item, ["progress_report_uri", "utilization_report_uri", "negative_result_ledger_uri"]);
+  return {
+    progress_report_uri: nullableString(item.progress_report_uri, "progress_report_uri"),
+    utilization_report_uri: nullableString(item.utilization_report_uri, "utilization_report_uri"),
+    negative_result_ledger_uri: nullableString(item.negative_result_ledger_uri, "negative_result_ledger_uri"),
+  };
+}
+
+function branchLineage(branches: CampaignBranch[]): CampaignBranchLineageEdge[] {
+  return branches.flatMap((branch) =>
+    branch.parent_branch_id ? [{ parent_branch_id: branch.parent_branch_id, child_branch_id: branch.branch_id }] : [],
+  );
+}
+
+function branchSummary(branches: CampaignBranch[]): CampaignBranchSummary {
+  const active = new Set<BranchTerminalState>(["pending", "running", "continued"]);
+  return {
+    branch_count: branches.length,
+    succeeded: branches.filter((branch) => branch.terminal_state === "succeeded").length,
+    failed: branches.filter((branch) => branch.terminal_state === "failed").length,
+    pruned: branches.filter((branch) => branch.terminal_state === "pruned").length,
+    budget_exhausted: branches.filter((branch) => branch.terminal_state === "budget_exhausted").length,
+    running: branches.filter((branch) => active.has(branch.terminal_state)).length,
+  };
+}
+
+function recommendation(branches: CampaignBranch[]): CampaignRecommendation | null {
+  let eligible = branches.filter((branch) => branch.score !== null && branch.verifier_passed === true);
+  if (!eligible.length) eligible = branches.filter((branch) => branch.score !== null);
+  const best = eligible.sort((left, right) => (right.score ?? -Infinity) - (left.score ?? -Infinity))[0];
+  return best ? { branch_id: best.branch_id, score: best.score, reason: best.terminal_reason } : null;
+}
+
+function evidenceItems(
+  items: CampaignEvidenceShareItemInput[],
+  policy: CampaignEvidencePolicy,
+): CampaignEvidenceShareItem[] {
+  return items.map((item, index) => parseEvidenceItem({
+    ...item,
+    summary: truncate(item.summary, policy.max_summary_chars),
+    included: item.evidence_refs.length > 0 && index < policy.max_shared_items,
+  }));
+}
+
+function truncate(value: string, maxChars: number): string {
+  return value.length <= maxChars ? value : value.slice(0, maxChars - 1).trimEnd() + "…";
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function exact(item: Record<string, unknown>, allowed: string[]): void {
+  const allowedSet = new Set(allowed);
+  const keys = Object.keys(item);
+  const missing = allowed.filter((key) => !keys.includes(key));
+  if (missing.length) throw new Error(`missing field(s): ${missing.sort().join(", ")}`);
+  const extra = keys.filter((key) => !allowedSet.has(key));
+  if (extra.length) throw new Error(`unexpected field(s): ${extra.sort().join(", ")}`);
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a string`);
+  return value;
+}
+
+function nullableString(value: unknown, label: string): string | null {
+  return value === null ? null : string(value, label);
+}
+
+function number(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${label} must be a number`);
+  return value;
+}
+
+function nullableNumber(value: unknown, label: string): number | null {
+  return value === null ? null : number(value, label);
+}
+
+function nonNegativeNumber(value: unknown, label: string): number {
+  const result = number(value, label);
+  if (result < 0) throw new Error(`${label} must be non-negative`);
+  return result;
+}
+
+function nullableNonNegativeNumber(value: unknown, label: string): number | null {
+  return value === null ? null : nonNegativeNumber(value, label);
+}
+
+function integer(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) throw new Error(`${label} must be an integer`);
+  return value;
+}
+
+function nonNegativeInteger(value: unknown, label: string): number {
+  const result = integer(value, label);
+  if (result < 0) throw new Error(`${label} must be a non-negative integer`);
+  return result;
+}
+
+function nullableNonNegativeInteger(value: unknown, label: string): number | null {
+  return value === null ? null : nonNegativeInteger(value, label);
+}
+
+function positiveInteger(value: unknown, label: string): number {
+  const result = integer(value, label);
+  if (result < 1) throw new Error(`${label} must be a positive integer`);
+  return result;
+}
+
+function boolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${label} must be a boolean`);
+  return value;
+}
+
+function nullableBoolean(value: unknown, label: string): boolean | null {
+  return value === null ? null : boolean(value, label);
+}
+
+function array(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value;
+}
+
+function stringArray(value: unknown, label: string): string[] {
+  return array(value, label).map((item) => string(item, label));
+}
+
+function campaignTerminalState(value: unknown): CampaignTerminalState {
+  const result = string(value, "terminal_state");
+  if (!CAMPAIGN_TERMINAL_STATE_SET.has(result)) throw new Error("terminal_state must be a campaign terminal state");
+  return result as CampaignTerminalState;
+}
+
+function branchTerminalState(value: unknown): BranchTerminalState {
+  const result = string(value, "terminal_state");
+  if (!BRANCH_TERMINAL_STATE_SET.has(result)) throw new Error("terminal_state must be a branch terminal state");
+  return result as BranchTerminalState;
+}

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -655,6 +655,39 @@ export type {
 // Analytics / Traces
 export { ActorRef, TraceEvent, RunTrace } from "./analytics/run-trace.js";
 export {
+  BRANCH_TERMINAL_STATES,
+  CAMPAIGN_TERMINAL_STATES,
+  buildCampaignModeReport,
+  campaignModeReportToMarkdown,
+  parseCampaignModeReport,
+  renderCampaignEvidenceShare,
+} from "./analytics/campaign-mode-report.js";
+export type {
+  BranchTerminalState,
+  BuildCampaignModeReportInput,
+  CampaignBranch,
+  CampaignBranchBudget,
+  CampaignBranchLineageEdge,
+  CampaignBranchSummary,
+  CampaignBranchUsage,
+  CampaignEvalLane,
+  CampaignEvidencePolicy,
+  CampaignEvidenceReference,
+  CampaignEvidenceShareItem,
+  CampaignEvidenceShareItemInput,
+  CampaignEvidenceSharing,
+  CampaignLinkedReports,
+  CampaignModeReport,
+  CampaignRecommendation,
+  CampaignTerminalState,
+} from "./analytics/campaign-mode-report.js";
+export {
+  campaignModeReportPath,
+  readCampaignModeReport,
+  readLatestCampaignModeReportsMarkdown,
+  writeCampaignModeReport,
+} from "./knowledge/campaign-mode-report-store.js";
+export {
   FAILURE_KINDS,
   NEGATIVE_RESULT_DISPOSITIONS,
   buildNegativeResultLedger,

--- a/ts/src/knowledge/campaign-mode-report-store.ts
+++ b/ts/src/knowledge/campaign-mode-report-store.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import {
   campaignModeReportToMarkdown,
   parseCampaignModeReport,
@@ -11,7 +11,27 @@ export function campaignModeReportPath(
   scenarioName: string,
   runId: string,
 ): string {
-  return join(knowledgeRoot, scenarioName, "campaign_mode_reports", `${runId}.json`);
+  return join(
+    knowledgeRoot,
+    pathSegment(scenarioName, "scenarioName"),
+    "campaign_mode_reports",
+    `${pathSegment(runId, "runId")}.json`,
+  );
+}
+
+function pathSegment(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${label} is required`);
+  if (
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.includes("/") ||
+    normalized.includes("\\") ||
+    basename(normalized) !== normalized
+  ) {
+    throw new Error(`${label} must be a single path segment`);
+  }
+  return normalized;
 }
 
 export function writeCampaignModeReport(
@@ -42,7 +62,7 @@ export function readLatestCampaignModeReportsMarkdown(
   scenarioName: string,
   opts: { maxReports?: number } = {},
 ): string {
-  const dir = join(knowledgeRoot, scenarioName, "campaign_mode_reports");
+  const dir = join(knowledgeRoot, pathSegment(scenarioName, "scenarioName"), "campaign_mode_reports");
   if (!existsSync(dir)) return "";
   return readdirSync(dir)
     .filter((name: string) => name.endsWith(".json"))

--- a/ts/src/knowledge/campaign-mode-report-store.ts
+++ b/ts/src/knowledge/campaign-mode-report-store.ts
@@ -1,0 +1,58 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  campaignModeReportToMarkdown,
+  parseCampaignModeReport,
+  type CampaignModeReport,
+} from "../analytics/campaign-mode-report.js";
+
+export function campaignModeReportPath(
+  knowledgeRoot: string,
+  scenarioName: string,
+  runId: string,
+): string {
+  return join(knowledgeRoot, scenarioName, "campaign_mode_reports", `${runId}.json`);
+}
+
+export function writeCampaignModeReport(
+  knowledgeRoot: string,
+  scenarioName: string,
+  runId: string,
+  report: CampaignModeReport,
+): string {
+  const path = campaignModeReportPath(knowledgeRoot, scenarioName, runId);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(report, null, 2) + "\n", "utf-8");
+  return path;
+}
+
+export function readCampaignModeReport(
+  knowledgeRoot: string,
+  scenarioName: string,
+  runId: string,
+): CampaignModeReport | null {
+  const path = campaignModeReportPath(knowledgeRoot, scenarioName, runId);
+  return existsSync(path)
+    ? parseCampaignModeReport(JSON.parse(readFileSync(path, "utf-8")) as unknown)
+    : null;
+}
+
+export function readLatestCampaignModeReportsMarkdown(
+  knowledgeRoot: string,
+  scenarioName: string,
+  opts: { maxReports?: number } = {},
+): string {
+  const dir = join(knowledgeRoot, scenarioName, "campaign_mode_reports");
+  if (!existsSync(dir)) return "";
+  return readdirSync(dir)
+    .filter((name: string) => name.endsWith(".json"))
+    .map((name: string) => join(dir, name))
+    .sort((left: string, right: string) => statSync(right).mtimeMs - statSync(left).mtimeMs)
+    .slice(0, opts.maxReports ?? 2)
+    .map((path: string) =>
+      campaignModeReportToMarkdown(
+        parseCampaignModeReport(JSON.parse(readFileSync(path, "utf-8")) as unknown),
+      ),
+    )
+    .join("\n\n");
+}

--- a/ts/tests/campaign-mode-report.test.ts
+++ b/ts/tests/campaign-mode-report.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -43,7 +43,9 @@ describe("campaign mode report", () => {
     const { budget: _budget, ...missingBudget } = branch;
 
     expect(parseCampaignModeReport(report)).toEqual(report);
-    expect(() => parseCampaignModeReport({ ...report, surprise: true })).toThrow(/unexpected field/);
+    expect(() => parseCampaignModeReport({ ...report, surprise: true })).toThrow(
+      /unexpected field/,
+    );
     expect(() => parseCampaignModeReport({ ...report, campaign_id: "" })).toThrow(/campaign_id/);
     expect(() =>
       parseCampaignModeReport({ ...report, branches: [{ ...branch, terminal_state: "unknown" }] }),
@@ -69,6 +71,35 @@ describe("campaign mode report", () => {
     expect(rendered).toContain("Safe branch passed both eval lanes");
   });
 
+  it("counts only evidence-backed items against the share budget", () => {
+    const item = fixture.cases[0]!;
+    const report = buildCampaignModeReport({
+      ...item,
+      shared_evidence: [
+        {
+          share_id: "without-evidence",
+          from_branch_id: "branch-1",
+          to_branch_ids: [],
+          summary: "No artifact reference yet.",
+          evidence_refs: [],
+        },
+        {
+          share_id: "with-evidence",
+          from_branch_id: "branch-1",
+          to_branch_ids: [],
+          summary: "This one should fit the prompt budget.",
+          evidence_refs: [{ uri: "artifact://runs/run-1/eval.json", summary: "passed" }],
+        },
+      ],
+      evidence_policy: { max_shared_items: 1, max_summary_chars: 240 },
+    });
+
+    expect(report.evidence_sharing.items.map((evidence) => evidence.included)).toEqual([
+      false,
+      true,
+    ]);
+  });
+
   it("persists campaign mode reports through file helpers", () => {
     const root = mkdtempSync(join(tmpdir(), "campaign-mode-"));
     try {
@@ -81,6 +112,24 @@ describe("campaign mode report", () => {
       expect(readLatestCampaignModeReportsMarkdown(knowledgeRoot, "grid_ctf")).toContain(
         "Campaign Mode Report",
       );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects path traversal through file helper identifiers", () => {
+    const root = mkdtempSync(join(tmpdir(), "campaign-mode-"));
+    try {
+      const knowledgeRoot = join(root, "knowledge");
+      const report = parseCampaignModeReport(fixture.cases[0]!.expected_report);
+
+      expect(() =>
+        writeCampaignModeReport(knowledgeRoot, "grid_ctf", "../../../outside", report),
+      ).toThrow(/runId/);
+      expect(() =>
+        writeCampaignModeReport(knowledgeRoot, "../outside", report.run_id, report),
+      ).toThrow(/scenarioName/);
+      expect(existsSync(join(root, "outside.json"))).toBe(false);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/ts/tests/campaign-mode-report.test.ts
+++ b/ts/tests/campaign-mode-report.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCampaignModeReport,
+  parseCampaignModeReport,
+  renderCampaignEvidenceShare,
+  type CampaignModeReport,
+  type BuildCampaignModeReportInput,
+} from "../src/analytics/campaign-mode-report.js";
+import {
+  readCampaignModeReport,
+  readLatestCampaignModeReportsMarkdown,
+  writeCampaignModeReport,
+} from "../src/knowledge/campaign-mode-report-store.js";
+
+const fixture = JSON.parse(
+  readFileSync(
+    join(import.meta.dirname, "..", "..", "docs", "campaign-mode-report-parity-fixture.json"),
+    "utf-8",
+  ),
+) as {
+  cases: Array<
+    BuildCampaignModeReportInput & {
+      name: string;
+      expected_report: CampaignModeReport;
+    }
+  >;
+};
+
+describe("campaign mode report", () => {
+  it("matches the shared Python/TypeScript parity fixture", () => {
+    for (const item of fixture.cases) {
+      expect(buildCampaignModeReport(item)).toEqual(item.expected_report);
+    }
+  });
+
+  it("parses durable report JSON and rejects schema-invalid data", () => {
+    const report = fixture.cases[1]!.expected_report;
+    const branch = report.branches[0]!;
+    const { budget: _budget, ...missingBudget } = branch;
+
+    expect(parseCampaignModeReport(report)).toEqual(report);
+    expect(() => parseCampaignModeReport({ ...report, surprise: true })).toThrow(/unexpected field/);
+    expect(() => parseCampaignModeReport({ ...report, campaign_id: "" })).toThrow(/campaign_id/);
+    expect(() =>
+      parseCampaignModeReport({ ...report, branches: [{ ...branch, terminal_state: "unknown" }] }),
+    ).toThrow(/terminal_state/);
+    expect(() => parseCampaignModeReport({ ...report, branches: [missingBudget] })).toThrow(
+      /missing field/,
+    );
+    expect(() =>
+      parseCampaignModeReport({
+        ...report,
+        branch_budget_defaults: { ...report.branch_budget_defaults, max_tokens: -1 },
+      }),
+    ).toThrow(/max_tokens/);
+  });
+
+  it("renders only budget-included shared evidence", () => {
+    const report = parseCampaignModeReport(fixture.cases[1]!.expected_report);
+
+    const rendered = renderCampaignEvidenceShare(report);
+
+    expect(rendered).toContain("share-safe-1");
+    expect(rendered).not.toContain("share-risky-1");
+    expect(rendered).toContain("Safe branch passed both eval lanes");
+  });
+
+  it("persists campaign mode reports through file helpers", () => {
+    const root = mkdtempSync(join(tmpdir(), "campaign-mode-"));
+    try {
+      const knowledgeRoot = join(root, "knowledge");
+      const report = parseCampaignModeReport(fixture.cases[1]!.expected_report);
+
+      writeCampaignModeReport(knowledgeRoot, "grid_ctf", report.run_id, report);
+
+      expect(readCampaignModeReport(knowledgeRoot, "grid_ctf", report.run_id)).toEqual(report);
+      expect(readLatestCampaignModeReportsMarkdown(knowledgeRoot, "grid_ctf")).toContain(
+        "Campaign Mode Report",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -45,6 +45,7 @@ describe("package root exports", () => {
     expect(pkg.buildExternalEvalImprovementSignals).toBeDefined();
     expect(pkg.buildRunUtilizationReport).toBeDefined();
     expect(pkg.buildNegativeResultLedger).toBeDefined();
+    expect(pkg.buildCampaignModeReport).toBeDefined();
     expect(pkg.buildOperationalMemoryPackFromDiagnostics).toBeDefined();
     expect(pkg.resolveBrowserSessionConfig).toBeDefined();
     expect(pkg.evaluateBrowserActionPolicy).toBeDefined();


### PR DESCRIPTION
## Summary
- add shared Python/TypeScript campaign mode report contract for AC-824
- model campaign identity, branch budgets/usages, eval lanes, branch lineage, evidence sharing budgets, terminal states, linked reports, and final recommendations
- add file helpers plus schema/docs/parity fixture for durable campaign artifacts

## Tests
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m pytest tests/test_campaign_mode_report.py tests/test_package_boundaries.py tests/test_module_size_limits.py -q`
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m ruff check src/autocontext/analytics/campaign_mode_report.py src/autocontext/analytics/__init__.py src/autocontext/storage/campaign_mode_report_store.py tests/test_campaign_mode_report.py`
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m mypy src/autocontext/analytics/campaign_mode_report.py src/autocontext/analytics/__init__.py src/autocontext/storage/campaign_mode_report_store.py`
- `cd ts && npm test -- campaign-mode-report.test.ts package-export-catalogs.test.ts`
- `cd ts && npm run lint`
- `cd ts && npm run build`

Resolves AC-824.
