### PR TITLE
feat(engine): opt-in require_lesson_approval flag (stage new lessons as pending)

### DIFF
--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -1060,7 +1060,9 @@ class GenerationRunner:
             gate_decision_history,
         )
 
-    def run(self, scenario_name: str, generations: int, run_id: str | None = None) -> RunSummary:
+    def run(
+        self, scenario_name: str, generations: int, run_id: str | None = None, require_lesson_approval: bool = False
+    ) -> RunSummary:
         scenario = self._scenario(scenario_name)
         active_run_id = run_id or f"run_{uuid.uuid4().hex[:12]}"
         run_start_time = time.monotonic()
@@ -1210,6 +1212,7 @@ class GenerationRunner:
                         scenario=scenario,
                         generation=generation,
                         settings=self.settings,
+                        require_lesson_approval=require_lesson_approval,
                         hook_bus=self.hook_bus,
                         previous_best=previous_best,
                         challenger_elo=challenger_elo,

--- a/autocontext/src/autocontext/loop/stage_helpers/persistence_helpers.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/persistence_helpers.py
@@ -13,6 +13,7 @@ from autocontext.analytics.credit_assignment import (
     compute_change_vector,
 )
 from autocontext.knowledge.dead_end_manager import DeadEndEntry, consolidate_dead_ends
+from autocontext.knowledge.lessons import ApplicabilityMeta
 from autocontext.knowledge.progress import build_progress_snapshot
 from autocontext.loop.stage_helpers.context_loaders import _current_tool_names
 from autocontext.loop.stage_types import GenerationContext
@@ -222,6 +223,39 @@ def _persist_skill_note(
             score=tournament.best_score,
         )
         artifacts.append_dead_end(ctx.scenario_name, entry.to_markdown())
+
+
+def _stage_pending_lessons(ctx: GenerationContext, *, artifacts: ArtifactStore) -> None:
+    """When require_lesson_approval is set, stage this generation's proposed lessons
+    into lessons.json as ``pending`` (held for human approval, excluded from prompts).
+
+    Opt-in and inert by default: a no-op unless ``ctx.require_lesson_approval`` is True,
+    so behavior is unchanged for every run that does not request it.
+    """
+    if not getattr(ctx, "require_lesson_approval", False):
+        return
+    if ctx.gate_decision != "advance" or ctx.outputs is None:
+        return
+    raw_block = getattr(ctx.outputs, "coach_lessons", None) or ""
+    proposed = [line for line in raw_block.splitlines() if line.strip()]
+    if not proposed:
+        return
+
+    store = artifacts.lesson_store
+    seen = {les.text for les in store.read_lessons(ctx.scenario_name)}
+    for raw in proposed:
+        stripped = raw.strip()
+        text = stripped[2:].strip() if stripped.startswith("- ") else stripped
+        if not text or text in seen:
+            continue
+        meta = ApplicabilityMeta(
+            created_at="",
+            generation=ctx.generation,
+            best_score=ctx.previous_best,
+            approval_status="pending",
+        )
+        store.add_lesson(ctx.scenario_name, text, meta)
+        seen.add(text)
 
 
 def _run_curator_consolidation(

--- a/autocontext/src/autocontext/loop/stage_types.py
+++ b/autocontext/src/autocontext/loop/stage_types.py
@@ -89,6 +89,8 @@ class GenerationContext:
     skeptic_review: SkepticReview | None = None
     applied_competitor_hints: str = ""
     challenger_uncertainty: float | None = None
+    # Opt-in per-run gate: stage newly proposed lessons as pending instead of applying them.
+    require_lesson_approval: bool = False
 
 
 @dataclass(slots=True)

--- a/autocontext/src/autocontext/loop/stages.py
+++ b/autocontext/src/autocontext/loop/stages.py
@@ -101,6 +101,7 @@ from autocontext.loop.stage_helpers.persistence_helpers import (
     _persist_skill_note,
     _revise_strategy_for_validity_failure,
     _run_curator_consolidation,
+    _stage_pending_lessons,
 )
 from autocontext.loop.stage_helpers.semantic_benchmark import (
     materialize_evidence_manifests,
@@ -1309,6 +1310,7 @@ def stage_persistence(
 
     # 5. Write skill note + dead-end tracking
     _persist_skill_note(ctx, artifacts=artifacts)
+    _stage_pending_lessons(ctx, artifacts=artifacts)
 
     # 6. Curator lesson consolidation
     existing_lessons_check = artifacts.read_skill_lessons_raw(scenario_name)

--- a/autocontext/src/autocontext/server/app.py
+++ b/autocontext/src/autocontext/server/app.py
@@ -331,14 +331,20 @@ def create_app(
                                 response = await asyncio.to_thread(controller.submit_chat, role, message)
                                 await websocket.send_json(ChatResponseMsg(role=role, text=response).model_dump())
 
-                        case StartRunCmd(scenario=scenario, generations=generations):
+                        case StartRunCmd(
+                            scenario=scenario,
+                            generations=generations,
+                            require_lesson_approval=require_lesson_approval,
+                        ):
                             if run_manager is None:
                                 await websocket.send_json(ErrorMsg(message="Run manager not available.").model_dump())
                             elif run_manager.is_active:
                                 await websocket.send_json(ErrorMsg(message="A run is already active.").model_dump())
                             else:
                                 try:
-                                    rid = run_manager.start_run(scenario, generations)
+                                    rid = run_manager.start_run(
+                                        scenario, generations, require_lesson_approval=require_lesson_approval
+                                    )
                                     await websocket.send_json(
                                         RunAcceptedMsg(run_id=rid, scenario=scenario, generations=generations).model_dump()
                                     )

--- a/autocontext/src/autocontext/server/protocol.py
+++ b/autocontext/src/autocontext/server/protocol.py
@@ -245,6 +245,9 @@ class StartRunCmd(BaseModel):
     type: Literal["start_run"] = "start_run"
     scenario: str
     generations: int = Field(gt=0)
+    # Opt-in (default off): stage newly proposed lessons as pending (held for human
+    # approval, excluded from prompts) instead of applying them. Inert unless set.
+    require_lesson_approval: bool = False
 
 
 class ListScenariosCmd(BaseModel):

--- a/autocontext/src/autocontext/server/run_manager.py
+++ b/autocontext/src/autocontext/server/run_manager.py
@@ -82,7 +82,9 @@ class RunManager:
             "agent_provider": self.settings.agent_provider,
         }
 
-    def start_run(self, scenario: str, generations: int, run_id: str | None = None) -> str:
+    def start_run(
+        self, scenario: str, generations: int, run_id: str | None = None, require_lesson_approval: bool = False
+    ) -> str:
         if self._active:
             raise RuntimeError("A run is already active. Wait for it to finish or stop it.")
         if scenario not in SCENARIO_REGISTRY:
@@ -99,7 +101,12 @@ class RunManager:
 
         def _target() -> None:
             try:
-                summary = runner.run(scenario_name=scenario, generations=generations, run_id=actual_run_id)
+                summary = runner.run(
+                    scenario_name=scenario,
+                    generations=generations,
+                    run_id=actual_run_id,
+                    require_lesson_approval=require_lesson_approval,
+                )
                 logger.info("Run %s completed: best_score=%.4f", summary.run_id, summary.best_score)
             except Exception:
                 logger.exception("Run %s failed", actual_run_id)

--- a/autocontext/tests/test_require_lesson_approval.py
+++ b/autocontext/tests/test_require_lesson_approval.py
@@ -1,0 +1,67 @@
+import inspect
+from pathlib import Path
+
+from autocontext.loop.generation_runner import GenerationRunner
+from autocontext.loop.stage_helpers.persistence_helpers import _stage_pending_lessons
+from autocontext.loop.stage_types import GenerationContext
+from autocontext.server.protocol import StartRunCmd
+from autocontext.server.run_manager import RunManager
+from autocontext.storage.artifacts import ArtifactStore
+
+
+def test_start_run_cmd_flag_defaults_false() -> None:
+    assert StartRunCmd(scenario="grid_ctf", generations=3).require_lesson_approval is False
+    cmd = StartRunCmd(scenario="grid_ctf", generations=3, require_lesson_approval=True)
+    assert cmd.require_lesson_approval is True
+
+
+def test_threading_params_present() -> None:
+    assert "require_lesson_approval" in inspect.signature(RunManager.start_run).parameters
+    assert "require_lesson_approval" in inspect.signature(GenerationRunner.run).parameters
+    assert "require_lesson_approval" in GenerationContext.__dataclass_fields__
+
+
+class _Outputs:
+    def __init__(self, lessons: str) -> None:
+        self.coach_lessons = lessons
+
+
+class _Ctx:
+    def __init__(self, flag: bool, lessons: str) -> None:
+        self.scenario_name = "scn"
+        self.generation = 7
+        self.previous_best = 0.5
+        self.gate_decision = "advance"
+        self.require_lesson_approval = flag
+        self.outputs = _Outputs(lessons)
+
+
+def _artifacts(tmp_path: Path) -> ArtifactStore:
+    return ArtifactStore(
+        runs_root=tmp_path / "runs",
+        knowledge_root=tmp_path / "knowledge",
+        skills_root=tmp_path / "skills",
+        claude_skills_path=tmp_path / "claude_skills",
+    )
+
+
+def test_flag_off_is_noop(tmp_path: Path) -> None:
+    art = _artifacts(tmp_path)
+    _stage_pending_lessons(_Ctx(False, "- avoid X\nuse Y"), artifacts=art)
+    assert art.lesson_store.read_lessons("scn") == []
+
+
+def test_flag_on_stages_pending(tmp_path: Path) -> None:
+    art = _artifacts(tmp_path)
+    _stage_pending_lessons(_Ctx(True, "- avoid X\nuse Y"), artifacts=art)
+    lessons = art.lesson_store.read_lessons("scn")
+    assert sorted(v.text for v in lessons) == ["avoid X", "use Y"]
+    assert all(v.meta.approval_status == "pending" for v in lessons)
+
+
+def test_flag_on_skips_non_advance(tmp_path: Path) -> None:
+    art = _artifacts(tmp_path)
+    ctx = _Ctx(True, "x")
+    ctx.gate_decision = "retry"
+    _stage_pending_lessons(ctx, artifacts=art)
+    assert art.lesson_store.read_lessons("scn") == []

--- a/protocol/autocontext-protocol.json
+++ b/protocol/autocontext-protocol.json
@@ -792,6 +792,11 @@
             "exclusiveMinimum": 0,
             "title": "Generations",
             "type": "integer"
+          },
+          "require_lesson_approval": {
+            "default": false,
+            "title": "Require Lesson Approval",
+            "type": "boolean"
           }
         },
         "required": [

--- a/ts/src/tui/protocol.generated.ts
+++ b/ts/src/tui/protocol.generated.ts
@@ -158,6 +158,7 @@ export const StartRunCmdSchema = z.object({
   type: z.literal("start_run"),
   scenario: z.string(),
   generations: z.number().int().gt(0),
+  require_lesson_approval: z.boolean().optional(),
 });
 
 export const ListScenariosCmdSchema = z.object({


### PR DESCRIPTION
A per-run, **default-off** flag that lets the desktop app gate lesson application without affecting anyone else.

## What it does
- `StartRunCmd.require_lesson_approval: bool = False`. When **off** (the default, and the only state for CLI / other WS clients), behavior is byte-for-byte unchanged — the flag adds no new work.
- When **on**, newly proposed lessons each generation are written to `lessons.json` as `approval_status="pending"` (held for human approval) instead of applied. Pending lessons are already excluded from prompts (`is_applicable`) and surfaced under `pending` in the lifecycle API, where they can be approved/rejected.
- Threads `start_run` → `RunManager.start_run` → `GenerationRunner.run` → `GenerationContext`; the gated feed (`_stage_pending_lessons`) in `stage_persistence` is a **no-op unless the flag is set**.

## Inert by design
- Default false everywhere; only the desktop app opts in (when an operator picks "Approve" mode).
- No global setting, no change to existing code paths. Reuses the already-merged 2c primitives (`approval_status`, pending exclusion, approve/reject).
- The one intended, scoped effect: a scenario an operator chose to gate keeps its pending lessons held even in a later CLI run (pending = not yet approved). Scenarios never gated are never touched.

## Tests
`tests/test_require_lesson_approval.py`: flag defaults false; threading params present; flag-on stages pending; flag-off is a no-op; non-advance skipped. ruff + mypy clean; protocol parity + module-size tests pass. Protocol artifacts regenerated.

Backs the autowork operator "Lesson approval: Auto / Approve" choice (the autowork board PR + a follow-up mode control).