### PR TITLE
AC-825 add goal run report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - AC-822 run utilization reports add shared Python/TypeScript runner, token, verifier idle, model wait, and eval-throughput telemetry for single- and multi-branch runs.
 - AC-823 negative result ledgers preserve failed/pruned/rejected branch evidence, branch lineage, score deltas, and caution-vs-hard-ban prompt lessons across Python and TypeScript.
 - AC-824 campaign mode reports define shared Python/TypeScript multi-branch campaign identity, branch budgets, eval lanes, evidence sharing, terminal states, and recommendations.
+- AC-825 goal run reports define a shared Python/TypeScript outer supervisor artifact for continue-until-verified execution, resume tokens, budgets, action cadence, verifier state, and durable stop/continuation decisions.
 
 ## [pi-v0.2.6] - 2026-06-16
 

--- a/autocontext/src/autocontext/analytics/__init__.py
+++ b/autocontext/src/autocontext/analytics/__init__.py
@@ -1,6 +1,7 @@
 """Aggregate analytics for cross-run facets, signal extraction, and pattern clustering."""
 
 from autocontext.analytics.campaign_mode_report import CampaignModeReport, build_campaign_mode_report
+from autocontext.analytics.goal_run_report import GoalRunReport, build_goal_run_report
 from autocontext.analytics.negative_result_ledger import NegativeResultLedger, build_negative_result_ledger
 from autocontext.analytics.progress_report import RunProgressReport, build_run_progress_report
 from autocontext.analytics.run_utilization_report import RunUtilizationReport, build_run_utilization_report
@@ -15,6 +16,7 @@ from autocontext.analytics.trace_gate_operator_view import (
 
 __all__ = [
     "CampaignModeReport",
+    "GoalRunReport",
     "NegativeResultLedger",
     "RunProgressReport",
     "RunUtilizationReport",
@@ -22,6 +24,7 @@ __all__ = [
     "TraceGateOperatorState",
     "TraceGateOperatorView",
     "build_campaign_mode_report",
+    "build_goal_run_report",
     "build_negative_result_ledger",
     "build_run_progress_report",
     "build_run_utilization_report",

--- a/autocontext/src/autocontext/analytics/goal_run_report.py
+++ b/autocontext/src/autocontext/analytics/goal_run_report.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 GoalRunStatus = Literal[
     "continued",
@@ -74,6 +74,12 @@ class GoalVerifierState(_StrictModel):
     summary: str = Field(min_length=1)
     evidence_refs: list[GoalEvidenceRef]
 
+    @model_validator(mode="after")
+    def verified_or_failed(self) -> Self:
+        if self.verified and self.verifier_failed:
+            raise ValueError("verified and verifier_failed are mutually exclusive")
+        return self
+
 
 class GoalSupervisorDecision(_StrictModel):
     decision_id: str = Field(min_length=1)
@@ -83,6 +89,16 @@ class GoalSupervisorDecision(_StrictModel):
     stop_reason: GoalStopReason | None
     rationale: str = Field(min_length=1)
     evidence_refs: list[GoalEvidenceRef]
+
+    @model_validator(mode="after")
+    def decision_matches_shape(self) -> Self:
+        if self.decision_kind == "continue":
+            if self.status != "continued" or self.next_action_kind is None or self.stop_reason is not None:
+                raise ValueError("continue decisions require continued status, next action, and no stop reason")
+            return self
+        if self.status == "continued" or self.next_action_kind is not None or self.stop_reason != self.status:
+            raise ValueError("stop decisions require terminal status, no next action, and matching stop reason")
+        return self
 
 
 class GoalRunReport(_StrictModel):
@@ -100,6 +116,12 @@ class GoalRunReport(_StrictModel):
     actions: list[GoalActionRecord]
     verifier_state: GoalVerifierState
     decision: GoalSupervisorDecision
+
+    @model_validator(mode="after")
+    def status_matches_decision(self) -> Self:
+        if self.status != self.decision.status:
+            raise ValueError("status must match decision.status")
+        return self
 
     def to_markdown(self) -> str:
         decision = self.decision

--- a/autocontext/src/autocontext/analytics/goal_run_report.py
+++ b/autocontext/src/autocontext/analytics/goal_run_report.py
@@ -1,0 +1,250 @@
+"""Shared goal-run supervisor report for continue-until-verified execution."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field
+
+GoalRunStatus = Literal[
+    "continued",
+    "verified_complete",
+    "blocked",
+    "budget_exhausted",
+    "verifier_failed",
+    "no_progress",
+    "canceled",
+]
+GoalActionKind = Literal["run", "solve", "improve", "mission", "campaign"]
+GoalActionStatus = Literal["planned", "running", "completed", "failed", "canceled"]
+GoalDecisionKind = Literal["continue", "stop"]
+GoalStopReason = Literal["verified_complete", "blocked", "budget_exhausted", "verifier_failed", "no_progress", "canceled"]
+
+
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump(mode="json")
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        return cls.model_validate(data)
+
+
+class GoalEvidenceRef(_StrictModel):
+    uri: str = Field(min_length=1)
+    summary: str = Field(min_length=1)
+
+
+class GoalBudget(_StrictModel):
+    max_iterations: int | None = Field(ge=0)
+    max_actions: int | None = Field(ge=0)
+    max_seconds: float | None = Field(ge=0)
+    max_tokens: int | None = Field(ge=0)
+    max_no_progress_iterations: int | None = Field(ge=0)
+
+
+class GoalUsage(_StrictModel):
+    iterations: int = Field(ge=0)
+    actions: int = Field(ge=0)
+    elapsed_seconds: float = Field(ge=0)
+    tokens: int = Field(ge=0)
+    no_progress_count: int = Field(ge=0)
+
+
+class GoalActionRecord(_StrictModel):
+    action_id: str = Field(min_length=1)
+    action_kind: GoalActionKind
+    status: GoalActionStatus
+    started_at: str | None
+    completed_at: str | None
+    inner_run_ref: str | None
+    summary: str = Field(min_length=1)
+    evidence_refs: list[GoalEvidenceRef]
+    negative_result_ledger_uri: str | None
+
+
+class GoalVerifierState(_StrictModel):
+    verifier_ref: str = Field(min_length=1)
+    verified: bool
+    verifier_failed: bool
+    confidence: float | None
+    summary: str = Field(min_length=1)
+    evidence_refs: list[GoalEvidenceRef]
+
+
+class GoalSupervisorDecision(_StrictModel):
+    decision_id: str = Field(min_length=1)
+    decision_kind: GoalDecisionKind
+    status: GoalRunStatus
+    next_action_kind: GoalActionKind | None
+    stop_reason: GoalStopReason | None
+    rationale: str = Field(min_length=1)
+    evidence_refs: list[GoalEvidenceRef]
+
+
+class GoalRunReport(_StrictModel):
+    schema_version: Literal[1]
+    goal_id: str = Field(min_length=1)
+    goal_run_id: str = Field(min_length=1)
+    scenario_name: str = Field(min_length=1)
+    objective: str = Field(min_length=1)
+    generated_at: str = Field(min_length=1)
+    resume_token: str = Field(min_length=1)
+    status: GoalRunStatus
+    verifier_ref: str = Field(min_length=1)
+    budget: GoalBudget
+    usage: GoalUsage
+    actions: list[GoalActionRecord]
+    verifier_state: GoalVerifierState
+    decision: GoalSupervisorDecision
+
+    def to_markdown(self) -> str:
+        decision = self.decision
+        next_action = decision.next_action_kind or "none"
+        return "\n".join(
+            [
+                f"# Goal Run Report: {self.goal_run_id}",
+                f"- Goal: {self.goal_id}",
+                f"- Scenario: {self.scenario_name}",
+                f"- Status: {self.status}",
+                f"- Decision: {decision.decision_kind}",
+                f"- Next action: {next_action}",
+                f"- Rationale: {decision.rationale}",
+                "",
+            ]
+        )
+
+
+def build_goal_run_report(
+    *,
+    goal_id: str,
+    goal_run_id: str,
+    scenario_name: str,
+    objective: str,
+    verifier_ref: str,
+    budget: dict[str, Any],
+    usage: dict[str, Any],
+    actions: list[dict[str, Any]],
+    verifier_state: dict[str, Any],
+    next_action_kind: GoalActionKind | None = None,
+    blocked_reason: str | None = None,
+    requested_cancel: bool = False,
+    decision_id: str | None = None,
+    generated_at: str | None = None,
+    resume_token: str | None = None,
+) -> GoalRunReport:
+    budget_model = GoalBudget.from_dict(budget)
+    usage_model = GoalUsage.from_dict(usage)
+    verifier_model = GoalVerifierState.from_dict(verifier_state)
+    action_models = [GoalActionRecord.from_dict(action) for action in actions]
+    decision = _decide_goal_run(
+        budget=budget_model,
+        usage=usage_model,
+        verifier_state=verifier_model,
+        next_action_kind=next_action_kind,
+        blocked_reason=blocked_reason,
+        requested_cancel=requested_cancel,
+        decision_id=decision_id or f"{goal_run_id}:decision:{usage_model.iterations}",
+    )
+    return GoalRunReport(
+        schema_version=1,
+        goal_id=goal_id,
+        goal_run_id=goal_run_id,
+        scenario_name=scenario_name,
+        objective=objective,
+        generated_at=generated_at or datetime.now().astimezone().isoformat(),
+        resume_token=resume_token or f"{goal_run_id}:{usage_model.iterations}",
+        status=decision.status,
+        verifier_ref=verifier_ref,
+        budget=budget_model,
+        usage=usage_model,
+        actions=action_models,
+        verifier_state=verifier_model,
+        decision=decision,
+    )
+
+
+def _decide_goal_run(
+    *,
+    budget: GoalBudget,
+    usage: GoalUsage,
+    verifier_state: GoalVerifierState,
+    next_action_kind: GoalActionKind | None,
+    blocked_reason: str | None,
+    requested_cancel: bool,
+    decision_id: str,
+) -> GoalSupervisorDecision:
+    evidence_refs = verifier_state.evidence_refs
+    if requested_cancel:
+        return _stop_decision(decision_id, "canceled", "Goal canceled by operator.", evidence_refs)
+    if verifier_state.verifier_failed:
+        return _stop_decision(decision_id, "verifier_failed", "Verifier failed before goal completion.", evidence_refs)
+    if verifier_state.verified:
+        return _stop_decision(decision_id, "verified_complete", "Verifier confirmed the goal is complete.", evidence_refs)
+    if blocked_reason:
+        return _stop_decision(decision_id, "blocked", blocked_reason, evidence_refs)
+    if _budget_exhausted(budget, usage):
+        return _stop_decision(decision_id, "budget_exhausted", "Goal budget exhausted before verification.", evidence_refs)
+    if _no_progress_exhausted(budget, usage):
+        return _stop_decision(decision_id, "no_progress", "No-progress limit reached with evidence.", evidence_refs)
+    return GoalSupervisorDecision(
+        decision_id=decision_id,
+        decision_kind="continue",
+        status="continued",
+        next_action_kind=next_action_kind or "mission",
+        stop_reason=None,
+        rationale=f"Verifier incomplete; continue with {next_action_kind or 'mission'} checkpoint.",
+        evidence_refs=evidence_refs,
+    )
+
+
+def _stop_decision(
+    decision_id: str,
+    reason: GoalStopReason,
+    rationale: str,
+    evidence_refs: list[GoalEvidenceRef],
+) -> GoalSupervisorDecision:
+    return GoalSupervisorDecision(
+        decision_id=decision_id,
+        decision_kind="stop",
+        status=reason,
+        next_action_kind=None,
+        stop_reason=reason,
+        rationale=rationale,
+        evidence_refs=evidence_refs,
+    )
+
+
+def _budget_exhausted(budget: GoalBudget, usage: GoalUsage) -> bool:
+    return any(
+        [
+            budget.max_iterations is not None and usage.iterations >= budget.max_iterations,
+            budget.max_actions is not None and usage.actions >= budget.max_actions,
+            budget.max_seconds is not None and usage.elapsed_seconds >= budget.max_seconds,
+            budget.max_tokens is not None and usage.tokens >= budget.max_tokens,
+        ]
+    )
+
+
+def _no_progress_exhausted(budget: GoalBudget, usage: GoalUsage) -> bool:
+    return budget.max_no_progress_iterations is not None and usage.no_progress_count >= budget.max_no_progress_iterations
+
+
+__all__ = [
+    "GoalActionKind",
+    "GoalActionRecord",
+    "GoalActionStatus",
+    "GoalBudget",
+    "GoalDecisionKind",
+    "GoalEvidenceRef",
+    "GoalRunReport",
+    "GoalRunStatus",
+    "GoalStopReason",
+    "GoalSupervisorDecision",
+    "GoalUsage",
+    "GoalVerifierState",
+    "build_goal_run_report",
+]

--- a/autocontext/src/autocontext/storage/goal_run_report_store.py
+++ b/autocontext/src/autocontext/storage/goal_run_report_store.py
@@ -25,7 +25,13 @@ def _path_segment(value: str, label: str) -> str:
         raise ValueError(f"{label} must be a single path segment: {value!r}")
     for path_cls in (PurePosixPath, PureWindowsPath):
         candidate = path_cls(normalized)
-        if candidate.is_absolute() or len(candidate.parts) != 1 or candidate.parts[0] in {".", ".."}:
+        if (
+            candidate.drive
+            or candidate.root
+            or candidate.is_absolute()
+            or len(candidate.parts) != 1
+            or candidate.parts[0] in {".", ".."}
+        ):
             raise ValueError(f"{label} must be a single path segment: {value!r}")
     return normalized
 

--- a/autocontext/src/autocontext/storage/goal_run_report_store.py
+++ b/autocontext/src/autocontext/storage/goal_run_report_store.py
@@ -1,0 +1,48 @@
+"""File helpers for goal-run reports."""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, Protocol
+
+from autocontext.analytics.goal_run_report import GoalRunReport
+from autocontext.util.json_io import read_json, write_json
+
+
+class DictSerializable(Protocol):
+    def to_dict(self) -> dict[str, Any]: ...
+
+
+def goal_run_report_path(knowledge_root: Path, goal_id: str, goal_run_id: str) -> Path:
+    return knowledge_root / "goal_runs" / _path_segment(goal_id, "goal_id") / f"{_path_segment(goal_run_id, 'goal_run_id')}.json"
+
+
+def _path_segment(value: str, label: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{label} is required")
+    if "/" in normalized or "\\" in normalized:
+        raise ValueError(f"{label} must be a single path segment: {value!r}")
+    for path_cls in (PurePosixPath, PureWindowsPath):
+        candidate = path_cls(normalized)
+        if candidate.is_absolute() or len(candidate.parts) != 1 or candidate.parts[0] in {".", ".."}:
+            raise ValueError(f"{label} must be a single path segment: {value!r}")
+    return normalized
+
+
+def write_goal_run_report(knowledge_root: Path, goal_id: str, goal_run_id: str, report: DictSerializable) -> Path:
+    path = goal_run_report_path(knowledge_root, goal_id, goal_run_id)
+    write_json(path, report.to_dict())
+    return path
+
+
+def read_goal_run_report(knowledge_root: Path, goal_id: str, goal_run_id: str) -> GoalRunReport | None:
+    path = goal_run_report_path(knowledge_root, goal_id, goal_run_id)
+    return GoalRunReport.from_dict(read_json(path)) if path.exists() else None
+
+
+__all__ = [
+    "goal_run_report_path",
+    "read_goal_run_report",
+    "write_goal_run_report",
+]

--- a/autocontext/tests/test_goal_run_report.py
+++ b/autocontext/tests/test_goal_run_report.py
@@ -80,7 +80,12 @@ def test_goal_run_report_file_store_rejects_path_traversal(tmp_path: Path) -> No
 
     report = GoalRunReport.from_dict(_cases()[0]["expected_report"])
 
-    for goal_id, goal_run_id in [("../../../outside", report.goal_run_id), (report.goal_id, "../../../outside")]:
+    for goal_id, goal_run_id in [
+        ("../../../outside", report.goal_run_id),
+        (report.goal_id, "../../../outside"),
+        ("C:foo", report.goal_run_id),
+        (report.goal_id, "C:foo"),
+    ]:
         try:
             write_goal_run_report(tmp_path / "knowledge", goal_id, goal_run_id, report)
         except ValueError:
@@ -112,3 +117,30 @@ def test_goal_run_report_rejects_schema_invalid_data() -> None:
         except ValueError:
             continue
         raise AssertionError("schema-invalid goal run report was accepted")
+
+
+def test_goal_run_report_rejects_inconsistent_decisions_and_verifier_state() -> None:
+    from autocontext.analytics.goal_run_report import GoalRunReport, build_goal_run_report
+
+    continued = _cases()[0]["expected_report"]
+    terminal = _cases()[1]["expected_report"]
+
+    for payload in [
+        {**continued, "status": "verified_complete"},
+        {**continued, "decision": {**continued["decision"], "next_action_kind": None}},
+        {**terminal, "decision": {**terminal["decision"], "next_action_kind": "mission"}},
+        {**terminal, "decision": {**terminal["decision"], "stop_reason": "blocked"}},
+        {**terminal, "verifier_state": {**terminal["verifier_state"], "verifier_failed": True}},
+    ]:
+        try:
+            GoalRunReport.from_dict(payload)
+        except ValueError:
+            continue
+        raise AssertionError("inconsistent goal run report was accepted")
+
+    bad_input = {**_cases()[1], "verifier_state": {**_cases()[1]["verifier_state"], "verifier_failed": True}}
+    try:
+        build_goal_run_report(**_build_args(bad_input))
+    except ValueError:
+        return
+    raise AssertionError("conflicting verifier booleans were accepted")

--- a/autocontext/tests/test_goal_run_report.py
+++ b/autocontext/tests/test_goal_run_report.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_PATH = ROOT / "docs" / "goal-run-report-parity-fixture.json"
+
+
+def _cases() -> list[dict[str, Any]]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))["cases"]
+
+
+def _build_args(case: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "goal_id": case["goal_id"],
+        "goal_run_id": case["goal_run_id"],
+        "scenario_name": case["scenario_name"],
+        "objective": case["objective"],
+        "verifier_ref": case["verifier_ref"],
+        "generated_at": case["generated_at"],
+        "resume_token": case["resume_token"],
+        "budget": case["budget"],
+        "usage": case["usage"],
+        "actions": case["actions"],
+        "verifier_state": case["verifier_state"],
+        "next_action_kind": case.get("next_action_kind"),
+        "blocked_reason": case.get("blocked_reason"),
+        "requested_cancel": case.get("requested_cancel", False),
+        "decision_id": case["decision_id"],
+    }
+
+
+def test_build_goal_run_report_matches_shared_fixture() -> None:
+    from autocontext.analytics.goal_run_report import build_goal_run_report
+
+    for case in _cases():
+        assert build_goal_run_report(**_build_args(case)).to_dict() == case["expected_report"]
+
+
+def test_goal_run_report_round_trips_shared_json() -> None:
+    from autocontext.analytics.goal_run_report import GoalRunReport
+
+    for case in _cases():
+        expected = case["expected_report"]
+        assert GoalRunReport.from_dict(expected).to_dict() == expected
+
+
+def test_goal_run_report_covers_terminal_and_continued_statuses() -> None:
+    statuses = {case["expected_report"]["status"] for case in _cases()}
+
+    assert statuses == {
+        "continued",
+        "verified_complete",
+        "blocked",
+        "budget_exhausted",
+        "verifier_failed",
+        "no_progress",
+        "canceled",
+    }
+
+
+def test_goal_run_report_persists_for_resume(tmp_path: Path) -> None:
+    from autocontext.analytics.goal_run_report import GoalRunReport
+    from autocontext.storage.goal_run_report_store import read_goal_run_report, write_goal_run_report
+
+    report = GoalRunReport.from_dict(_cases()[0]["expected_report"])
+    write_goal_run_report(tmp_path / "knowledge", report.goal_id, report.goal_run_id, report)
+
+    restored = read_goal_run_report(tmp_path / "knowledge", report.goal_id, report.goal_run_id)
+    assert isinstance(restored, GoalRunReport)
+    assert restored.resume_token == "goal-run-1:1"
+    assert restored.to_dict() == report.to_dict()
+
+
+def test_goal_run_report_file_store_rejects_path_traversal(tmp_path: Path) -> None:
+    from autocontext.analytics.goal_run_report import GoalRunReport
+    from autocontext.storage.goal_run_report_store import write_goal_run_report
+
+    report = GoalRunReport.from_dict(_cases()[0]["expected_report"])
+
+    for goal_id, goal_run_id in [("../../../outside", report.goal_run_id), (report.goal_id, "../../../outside")]:
+        try:
+            write_goal_run_report(tmp_path / "knowledge", goal_id, goal_run_id, report)
+        except ValueError:
+            continue
+        raise AssertionError("path-traversing goal identifier was accepted")
+
+    assert not (tmp_path / "outside.json").exists()
+
+
+def test_goal_run_report_rejects_schema_invalid_data() -> None:
+    from autocontext.analytics.goal_run_report import GoalRunReport
+
+    expected = _cases()[0]["expected_report"]
+    missing_budget_field = {key: value for key, value in expected["budget"].items() if key != "max_iterations"}
+    bad_action = {**expected["actions"][0], "action_kind": "unknown"}
+    bad_status = {**expected, "status": "active"}
+
+    for payload in [
+        {key: value for key, value in expected.items() if key != "schema_version"},
+        {**expected, "surprise": True},
+        {**expected, "goal_id": ""},
+        {**expected, "budget": missing_budget_field},
+        {**expected, "usage": {**expected["usage"], "iterations": -1}},
+        {**expected, "actions": [bad_action]},
+        bad_status,
+    ]:
+        try:
+            GoalRunReport.from_dict(payload)
+        except ValueError:
+            continue
+        raise AssertionError("schema-invalid goal run report was accepted")

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - [Run utilization report](run-utilization-report.md)
 - [Negative result ledger](negative-result-ledger.md)
 - [Campaign mode report](campaign-mode-report.md)
+- [Goal run report](goal-run-report.md)
 - [Browser exploration contract](browser-exploration-contract.md)
 - [OpenTelemetry bridge](opentelemetry-bridge.md)
 - [Background session domain and parity contract](background-session-domain.md)

--- a/docs/goal-run-report-parity-fixture.json
+++ b/docs/goal-run-report-parity-fixture.json
@@ -1,0 +1,646 @@
+{
+  "cases": [
+    {
+      "name": "continued",
+      "goal_id": "goal-cap-set",
+      "goal_run_id": "goal-run-1",
+      "scenario_name": "cap_set",
+      "objective": "Find and verify a stronger cap-set construction.",
+      "generated_at": "2026-06-17T20:00:00Z",
+      "resume_token": "goal-run-1:1",
+      "verifier_ref": "scenario://cap_set/verifier",
+      "budget": {
+        "max_iterations": 4,
+        "max_actions": 8,
+        "max_seconds": null,
+        "max_tokens": null,
+        "max_no_progress_iterations": 2
+      },
+      "usage": {
+        "iterations": 1,
+        "actions": 1,
+        "elapsed_seconds": 12.5,
+        "tokens": 2048,
+        "no_progress_count": 0
+      },
+      "actions": [
+        {
+          "action_id": "action-1",
+          "action_kind": "run",
+          "status": "completed",
+          "started_at": "2026-06-17T19:59:00Z",
+          "completed_at": "2026-06-17T19:59:30Z",
+          "inner_run_ref": "run://cap-set/1",
+          "summary": "Initial run found a promising but unverified branch.",
+          "evidence_refs": [
+            {
+              "uri": "artifact://runs/run-1/progress.json",
+              "summary": "best score improved to 0.62"
+            }
+          ],
+          "negative_result_ledger_uri": null
+        }
+      ],
+      "verifier_state": {
+        "verifier_ref": "scenario://cap_set/verifier",
+        "verified": false,
+        "verifier_failed": false,
+        "confidence": 0.61,
+        "summary": "Incomplete: best construction has not passed holdout probes.",
+        "evidence_refs": [
+          {
+            "uri": "artifact://runs/run-1/verification.json",
+            "summary": "holdout failed"
+          }
+        ]
+      },
+      "next_action_kind": "mission",
+      "decision_id": "decision-continued",
+      "expected_report": {
+        "schema_version": 1,
+        "goal_id": "goal-cap-set",
+        "goal_run_id": "goal-run-1",
+        "scenario_name": "cap_set",
+        "objective": "Find and verify a stronger cap-set construction.",
+        "generated_at": "2026-06-17T20:00:00Z",
+        "resume_token": "goal-run-1:1",
+        "status": "continued",
+        "verifier_ref": "scenario://cap_set/verifier",
+        "budget": {
+          "max_iterations": 4,
+          "max_actions": 8,
+          "max_seconds": null,
+          "max_tokens": null,
+          "max_no_progress_iterations": 2
+        },
+        "usage": {
+          "iterations": 1,
+          "actions": 1,
+          "elapsed_seconds": 12.5,
+          "tokens": 2048,
+          "no_progress_count": 0
+        },
+        "actions": [
+          {
+            "action_id": "action-1",
+            "action_kind": "run",
+            "status": "completed",
+            "started_at": "2026-06-17T19:59:00Z",
+            "completed_at": "2026-06-17T19:59:30Z",
+            "inner_run_ref": "run://cap-set/1",
+            "summary": "Initial run found a promising but unverified branch.",
+            "evidence_refs": [
+              {
+                "uri": "artifact://runs/run-1/progress.json",
+                "summary": "best score improved to 0.62"
+              }
+            ],
+            "negative_result_ledger_uri": null
+          }
+        ],
+        "verifier_state": {
+          "verifier_ref": "scenario://cap_set/verifier",
+          "verified": false,
+          "verifier_failed": false,
+          "confidence": 0.61,
+          "summary": "Incomplete: best construction has not passed holdout probes.",
+          "evidence_refs": [
+            {
+              "uri": "artifact://runs/run-1/verification.json",
+              "summary": "holdout failed"
+            }
+          ]
+        },
+        "decision": {
+          "decision_id": "decision-continued",
+          "decision_kind": "continue",
+          "status": "continued",
+          "next_action_kind": "mission",
+          "stop_reason": null,
+          "rationale": "Verifier incomplete; continue with mission checkpoint.",
+          "evidence_refs": [
+            {
+              "uri": "artifact://runs/run-1/verification.json",
+              "summary": "holdout failed"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "verified_complete",
+      "goal_id": "goal-cap-set",
+      "goal_run_id": "goal-run-verified",
+      "scenario_name": "cap_set",
+      "objective": "Find and verify a stronger cap-set construction.",
+      "generated_at": "2026-06-17T20:01:00Z",
+      "resume_token": "goal-run-verified:2",
+      "verifier_ref": "scenario://cap_set/verifier",
+      "budget": {
+        "max_iterations": 4,
+        "max_actions": 8,
+        "max_seconds": null,
+        "max_tokens": null,
+        "max_no_progress_iterations": 2
+      },
+      "usage": {
+        "iterations": 2,
+        "actions": 2,
+        "elapsed_seconds": 20.0,
+        "tokens": 4096,
+        "no_progress_count": 0
+      },
+      "actions": [],
+      "verifier_state": {
+        "verifier_ref": "scenario://cap_set/verifier",
+        "verified": true,
+        "verifier_failed": false,
+        "confidence": 0.98,
+        "summary": "Holdout verifier passed.",
+        "evidence_refs": [
+          {
+            "uri": "artifact://runs/run-2/verification.json",
+            "summary": "holdout passed"
+          }
+        ]
+      },
+      "next_action_kind": "mission",
+      "decision_id": "decision-verified",
+      "expected_report": {
+        "schema_version": 1,
+        "goal_id": "goal-cap-set",
+        "goal_run_id": "goal-run-verified",
+        "scenario_name": "cap_set",
+        "objective": "Find and verify a stronger cap-set construction.",
+        "generated_at": "2026-06-17T20:01:00Z",
+        "resume_token": "goal-run-verified:2",
+        "status": "verified_complete",
+        "verifier_ref": "scenario://cap_set/verifier",
+        "budget": {
+          "max_iterations": 4,
+          "max_actions": 8,
+          "max_seconds": null,
+          "max_tokens": null,
+          "max_no_progress_iterations": 2
+        },
+        "usage": {
+          "iterations": 2,
+          "actions": 2,
+          "elapsed_seconds": 20.0,
+          "tokens": 4096,
+          "no_progress_count": 0
+        },
+        "actions": [],
+        "verifier_state": {
+          "verifier_ref": "scenario://cap_set/verifier",
+          "verified": true,
+          "verifier_failed": false,
+          "confidence": 0.98,
+          "summary": "Holdout verifier passed.",
+          "evidence_refs": [
+            {
+              "uri": "artifact://runs/run-2/verification.json",
+              "summary": "holdout passed"
+            }
+          ]
+        },
+        "decision": {
+          "decision_id": "decision-verified",
+          "decision_kind": "stop",
+          "status": "verified_complete",
+          "next_action_kind": null,
+          "stop_reason": "verified_complete",
+          "rationale": "Verifier confirmed the goal is complete.",
+          "evidence_refs": [
+            {
+              "uri": "artifact://runs/run-2/verification.json",
+              "summary": "holdout passed"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "blocked",
+      "goal_id": "goal-cap-set",
+      "goal_run_id": "goal-run-blocked",
+      "scenario_name": "cap_set",
+      "objective": "Find and verify a stronger cap-set construction.",
+      "generated_at": "2026-06-17T20:02:00Z",
+      "resume_token": "goal-run-blocked:2",
+      "verifier_ref": "scenario://cap_set/verifier",
+      "budget": {
+        "max_iterations": 4,
+        "max_actions": 8,
+        "max_seconds": null,
+        "max_tokens": null,
+        "max_no_progress_iterations": 2
+      },
+      "usage": {
+        "iterations": 2,
+        "actions": 2,
+        "elapsed_seconds": 21.0,
+        "tokens": 4096,
+        "no_progress_count": 0
+      },
+      "actions": [],
+      "verifier_state": {
+        "verifier_ref": "scenario://cap_set/verifier",
+        "verified": false,
+        "verifier_failed": false,
+        "confidence": null,
+        "summary": "Verifier needs human approval before continuing.",
+        "evidence_refs": []
+      },
+      "next_action_kind": "mission",
+      "blocked_reason": "Waiting for human approval.",
+      "decision_id": "decision-blocked",
+      "expected_report": {
+        "schema_version": 1,
+        "goal_id": "goal-cap-set",
+        "goal_run_id": "goal-run-blocked",
+        "scenario_name": "cap_set",
+        "objective": "Find and verify a stronger cap-set construction.",
+        "generated_at": "2026-06-17T20:02:00Z",
+        "resume_token": "goal-run-blocked:2",
+        "status": "blocked",
+        "verifier_ref": "scenario://cap_set/verifier",
+        "budget": {
+          "max_iterations": 4,
+          "max_actions": 8,
+          "max_seconds": null,
+          "max_tokens": null,
+          "max_no_progress_iterations": 2
+        },
+        "usage": {
+          "iterations": 2,
+          "actions": 2,
+          "elapsed_seconds": 21.0,
+          "tokens": 4096,
+          "no_progress_count": 0
+        },
+        "actions": [],
+        "verifier_state": {
+          "verifier_ref": "scenario://cap_set/verifier",
+          "verified": false,
+          "verifier_failed": false,
+          "confidence": null,
+          "summary": "Verifier needs human approval before continuing.",
+          "evidence_refs": []
+        },
+        "decision": {
+          "decision_id": "decision-blocked",
+          "decision_kind": "stop",
+          "status": "blocked",
+          "next_action_kind": null,
+          "stop_reason": "blocked",
+          "rationale": "Waiting for human approval.",
+          "evidence_refs": []
+        }
+      }
+    },
+    {
+      "name": "budget_exhausted",
+      "goal_id": "goal-cap-set",
+      "goal_run_id": "goal-run-budget",
+      "scenario_name": "cap_set",
+      "objective": "Find and verify a stronger cap-set construction.",
+      "generated_at": "2026-06-17T20:03:00Z",
+      "resume_token": "goal-run-budget:4",
+      "verifier_ref": "scenario://cap_set/verifier",
+      "budget": {
+        "max_iterations": 4,
+        "max_actions": 8,
+        "max_seconds": null,
+        "max_tokens": null,
+        "max_no_progress_iterations": 2
+      },
+      "usage": {
+        "iterations": 4,
+        "actions": 5,
+        "elapsed_seconds": 42.0,
+        "tokens": 8192,
+        "no_progress_count": 1
+      },
+      "actions": [],
+      "verifier_state": {
+        "verifier_ref": "scenario://cap_set/verifier",
+        "verified": false,
+        "verifier_failed": false,
+        "confidence": 0.5,
+        "summary": "Verifier incomplete at final checkpoint.",
+        "evidence_refs": []
+      },
+      "next_action_kind": "mission",
+      "decision_id": "decision-budget",
+      "expected_report": {
+        "schema_version": 1,
+        "goal_id": "goal-cap-set",
+        "goal_run_id": "goal-run-budget",
+        "scenario_name": "cap_set",
+        "objective": "Find and verify a stronger cap-set construction.",
+        "generated_at": "2026-06-17T20:03:00Z",
+        "resume_token": "goal-run-budget:4",
+        "status": "budget_exhausted",
+        "verifier_ref": "scenario://cap_set/verifier",
+        "budget": {
+          "max_iterations": 4,
+          "max_actions": 8,
+          "max_seconds": null,
+          "max_tokens": null,
+          "max_no_progress_iterations": 2
+        },
+        "usage": {
+          "iterations": 4,
+          "actions": 5,
+          "elapsed_seconds": 42.0,
+          "tokens": 8192,
+          "no_progress_count": 1
+        },
+        "actions": [],
+        "verifier_state": {
+          "verifier_ref": "scenario://cap_set/verifier",
+          "verified": false,
+          "verifier_failed": false,
+          "confidence": 0.5,
+          "summary": "Verifier incomplete at final checkpoint.",
+          "evidence_refs": []
+        },
+        "decision": {
+          "decision_id": "decision-budget",
+          "decision_kind": "stop",
+          "status": "budget_exhausted",
+          "next_action_kind": null,
+          "stop_reason": "budget_exhausted",
+          "rationale": "Goal budget exhausted before verification.",
+          "evidence_refs": []
+        }
+      }
+    },
+    {
+      "name": "verifier_failed",
+      "goal_id": "goal-cap-set",
+      "goal_run_id": "goal-run-verifier-failed",
+      "scenario_name": "cap_set",
+      "objective": "Find and verify a stronger cap-set construction.",
+      "generated_at": "2026-06-17T20:04:00Z",
+      "resume_token": "goal-run-verifier-failed:2",
+      "verifier_ref": "scenario://cap_set/verifier",
+      "budget": {
+        "max_iterations": 4,
+        "max_actions": 8,
+        "max_seconds": null,
+        "max_tokens": null,
+        "max_no_progress_iterations": 2
+      },
+      "usage": {
+        "iterations": 2,
+        "actions": 2,
+        "elapsed_seconds": 24.0,
+        "tokens": 4096,
+        "no_progress_count": 0
+      },
+      "actions": [],
+      "verifier_state": {
+        "verifier_ref": "scenario://cap_set/verifier",
+        "verified": false,
+        "verifier_failed": true,
+        "confidence": null,
+        "summary": "Verifier harness crashed with invalid state.",
+        "evidence_refs": [
+          {
+            "uri": "artifact://runs/run-2/verifier-error.txt",
+            "summary": "harness error"
+          }
+        ]
+      },
+      "next_action_kind": "mission",
+      "decision_id": "decision-verifier-failed",
+      "expected_report": {
+        "schema_version": 1,
+        "goal_id": "goal-cap-set",
+        "goal_run_id": "goal-run-verifier-failed",
+        "scenario_name": "cap_set",
+        "objective": "Find and verify a stronger cap-set construction.",
+        "generated_at": "2026-06-17T20:04:00Z",
+        "resume_token": "goal-run-verifier-failed:2",
+        "status": "verifier_failed",
+        "verifier_ref": "scenario://cap_set/verifier",
+        "budget": {
+          "max_iterations": 4,
+          "max_actions": 8,
+          "max_seconds": null,
+          "max_tokens": null,
+          "max_no_progress_iterations": 2
+        },
+        "usage": {
+          "iterations": 2,
+          "actions": 2,
+          "elapsed_seconds": 24.0,
+          "tokens": 4096,
+          "no_progress_count": 0
+        },
+        "actions": [],
+        "verifier_state": {
+          "verifier_ref": "scenario://cap_set/verifier",
+          "verified": false,
+          "verifier_failed": true,
+          "confidence": null,
+          "summary": "Verifier harness crashed with invalid state.",
+          "evidence_refs": [
+            {
+              "uri": "artifact://runs/run-2/verifier-error.txt",
+              "summary": "harness error"
+            }
+          ]
+        },
+        "decision": {
+          "decision_id": "decision-verifier-failed",
+          "decision_kind": "stop",
+          "status": "verifier_failed",
+          "next_action_kind": null,
+          "stop_reason": "verifier_failed",
+          "rationale": "Verifier failed before goal completion.",
+          "evidence_refs": [
+            {
+              "uri": "artifact://runs/run-2/verifier-error.txt",
+              "summary": "harness error"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "no_progress",
+      "goal_id": "goal-cap-set",
+      "goal_run_id": "goal-run-no-progress",
+      "scenario_name": "cap_set",
+      "objective": "Find and verify a stronger cap-set construction.",
+      "generated_at": "2026-06-17T20:05:00Z",
+      "resume_token": "goal-run-no-progress:3",
+      "verifier_ref": "scenario://cap_set/verifier",
+      "budget": {
+        "max_iterations": 4,
+        "max_actions": 8,
+        "max_seconds": null,
+        "max_tokens": null,
+        "max_no_progress_iterations": 2
+      },
+      "usage": {
+        "iterations": 3,
+        "actions": 3,
+        "elapsed_seconds": 32.0,
+        "tokens": 6144,
+        "no_progress_count": 2
+      },
+      "actions": [],
+      "verifier_state": {
+        "verifier_ref": "scenario://cap_set/verifier",
+        "verified": false,
+        "verifier_failed": false,
+        "confidence": 0.2,
+        "summary": "Two checkpoints produced no new evidence.",
+        "evidence_refs": [
+          {
+            "uri": "artifact://runs/run-3/negative-ledger.json",
+            "summary": "repeated no-progress branches"
+          }
+        ]
+      },
+      "next_action_kind": "mission",
+      "decision_id": "decision-no-progress",
+      "expected_report": {
+        "schema_version": 1,
+        "goal_id": "goal-cap-set",
+        "goal_run_id": "goal-run-no-progress",
+        "scenario_name": "cap_set",
+        "objective": "Find and verify a stronger cap-set construction.",
+        "generated_at": "2026-06-17T20:05:00Z",
+        "resume_token": "goal-run-no-progress:3",
+        "status": "no_progress",
+        "verifier_ref": "scenario://cap_set/verifier",
+        "budget": {
+          "max_iterations": 4,
+          "max_actions": 8,
+          "max_seconds": null,
+          "max_tokens": null,
+          "max_no_progress_iterations": 2
+        },
+        "usage": {
+          "iterations": 3,
+          "actions": 3,
+          "elapsed_seconds": 32.0,
+          "tokens": 6144,
+          "no_progress_count": 2
+        },
+        "actions": [],
+        "verifier_state": {
+          "verifier_ref": "scenario://cap_set/verifier",
+          "verified": false,
+          "verifier_failed": false,
+          "confidence": 0.2,
+          "summary": "Two checkpoints produced no new evidence.",
+          "evidence_refs": [
+            {
+              "uri": "artifact://runs/run-3/negative-ledger.json",
+              "summary": "repeated no-progress branches"
+            }
+          ]
+        },
+        "decision": {
+          "decision_id": "decision-no-progress",
+          "decision_kind": "stop",
+          "status": "no_progress",
+          "next_action_kind": null,
+          "stop_reason": "no_progress",
+          "rationale": "No-progress limit reached with evidence.",
+          "evidence_refs": [
+            {
+              "uri": "artifact://runs/run-3/negative-ledger.json",
+              "summary": "repeated no-progress branches"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "canceled",
+      "goal_id": "goal-cap-set",
+      "goal_run_id": "goal-run-canceled",
+      "scenario_name": "cap_set",
+      "objective": "Find and verify a stronger cap-set construction.",
+      "generated_at": "2026-06-17T20:06:00Z",
+      "resume_token": "goal-run-canceled:2",
+      "verifier_ref": "scenario://cap_set/verifier",
+      "budget": {
+        "max_iterations": 4,
+        "max_actions": 8,
+        "max_seconds": null,
+        "max_tokens": null,
+        "max_no_progress_iterations": 2
+      },
+      "usage": {
+        "iterations": 2,
+        "actions": 2,
+        "elapsed_seconds": 25.0,
+        "tokens": 4096,
+        "no_progress_count": 0
+      },
+      "actions": [],
+      "verifier_state": {
+        "verifier_ref": "scenario://cap_set/verifier",
+        "verified": false,
+        "verifier_failed": false,
+        "confidence": 0.4,
+        "summary": "Canceled before next checkpoint.",
+        "evidence_refs": []
+      },
+      "next_action_kind": "mission",
+      "requested_cancel": true,
+      "decision_id": "decision-canceled",
+      "expected_report": {
+        "schema_version": 1,
+        "goal_id": "goal-cap-set",
+        "goal_run_id": "goal-run-canceled",
+        "scenario_name": "cap_set",
+        "objective": "Find and verify a stronger cap-set construction.",
+        "generated_at": "2026-06-17T20:06:00Z",
+        "resume_token": "goal-run-canceled:2",
+        "status": "canceled",
+        "verifier_ref": "scenario://cap_set/verifier",
+        "budget": {
+          "max_iterations": 4,
+          "max_actions": 8,
+          "max_seconds": null,
+          "max_tokens": null,
+          "max_no_progress_iterations": 2
+        },
+        "usage": {
+          "iterations": 2,
+          "actions": 2,
+          "elapsed_seconds": 25.0,
+          "tokens": 4096,
+          "no_progress_count": 0
+        },
+        "actions": [],
+        "verifier_state": {
+          "verifier_ref": "scenario://cap_set/verifier",
+          "verified": false,
+          "verifier_failed": false,
+          "confidence": 0.4,
+          "summary": "Canceled before next checkpoint.",
+          "evidence_refs": []
+        },
+        "decision": {
+          "decision_id": "decision-canceled",
+          "decision_kind": "stop",
+          "status": "canceled",
+          "next_action_kind": null,
+          "stop_reason": "canceled",
+          "rationale": "Goal canceled by operator.",
+          "evidence_refs": []
+        }
+      }
+    }
+  ]
+}

--- a/docs/goal-run-report.json
+++ b/docs/goal-run-report.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/greyhaven-ai/autocontext/docs/goal-run-report.json",
+  "title": "GoalRunReport",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "goal_id",
+    "goal_run_id",
+    "scenario_name",
+    "objective",
+    "generated_at",
+    "resume_token",
+    "status",
+    "verifier_ref",
+    "budget",
+    "usage",
+    "actions",
+    "verifier_state",
+    "decision"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "goal_id": { "type": "string", "minLength": 1 },
+    "goal_run_id": { "type": "string", "minLength": 1 },
+    "scenario_name": { "type": "string", "minLength": 1 },
+    "objective": { "type": "string", "minLength": 1 },
+    "generated_at": { "type": "string", "minLength": 1 },
+    "resume_token": { "type": "string", "minLength": 1 },
+    "status": { "$ref": "#/$defs/goalRunStatus" },
+    "verifier_ref": { "type": "string", "minLength": 1 },
+    "budget": { "$ref": "#/$defs/budget" },
+    "usage": { "$ref": "#/$defs/usage" },
+    "actions": { "type": "array", "items": { "$ref": "#/$defs/action" } },
+    "verifier_state": { "$ref": "#/$defs/verifierState" },
+    "decision": { "$ref": "#/$defs/decision" }
+  },
+  "$defs": {
+    "goalRunStatus": {
+      "enum": [
+        "continued",
+        "verified_complete",
+        "blocked",
+        "budget_exhausted",
+        "verifier_failed",
+        "no_progress",
+        "canceled"
+      ]
+    },
+    "actionKind": { "enum": ["run", "solve", "improve", "mission", "campaign"] },
+    "actionStatus": { "enum": ["planned", "running", "completed", "failed", "canceled"] },
+    "stopReason": {
+      "enum": ["verified_complete", "blocked", "budget_exhausted", "verifier_failed", "no_progress", "canceled"]
+    },
+    "decisionKind": { "enum": ["continue", "stop"] },
+    "nullableString": { "type": ["string", "null"] },
+    "nullableNumber": { "type": ["number", "null"] },
+    "nullableNonNegativeInteger": { "type": ["integer", "null"], "minimum": 0 },
+    "nullableNonNegativeNumber": { "type": ["number", "null"], "minimum": 0 },
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uri", "summary"],
+      "properties": {
+        "uri": { "type": "string", "minLength": 1 },
+        "summary": { "type": "string", "minLength": 1 }
+      }
+    },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_iterations", "max_actions", "max_seconds", "max_tokens", "max_no_progress_iterations"],
+      "properties": {
+        "max_iterations": { "$ref": "#/$defs/nullableNonNegativeInteger" },
+        "max_actions": { "$ref": "#/$defs/nullableNonNegativeInteger" },
+        "max_seconds": { "$ref": "#/$defs/nullableNonNegativeNumber" },
+        "max_tokens": { "$ref": "#/$defs/nullableNonNegativeInteger" },
+        "max_no_progress_iterations": { "$ref": "#/$defs/nullableNonNegativeInteger" }
+      }
+    },
+    "usage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["iterations", "actions", "elapsed_seconds", "tokens", "no_progress_count"],
+      "properties": {
+        "iterations": { "type": "integer", "minimum": 0 },
+        "actions": { "type": "integer", "minimum": 0 },
+        "elapsed_seconds": { "type": "number", "minimum": 0 },
+        "tokens": { "type": "integer", "minimum": 0 },
+        "no_progress_count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action_id",
+        "action_kind",
+        "status",
+        "started_at",
+        "completed_at",
+        "inner_run_ref",
+        "summary",
+        "evidence_refs",
+        "negative_result_ledger_uri"
+      ],
+      "properties": {
+        "action_id": { "type": "string", "minLength": 1 },
+        "action_kind": { "$ref": "#/$defs/actionKind" },
+        "status": { "$ref": "#/$defs/actionStatus" },
+        "started_at": { "$ref": "#/$defs/nullableString" },
+        "completed_at": { "$ref": "#/$defs/nullableString" },
+        "inner_run_ref": { "$ref": "#/$defs/nullableString" },
+        "summary": { "type": "string", "minLength": 1 },
+        "evidence_refs": { "type": "array", "items": { "$ref": "#/$defs/evidenceRef" } },
+        "negative_result_ledger_uri": { "$ref": "#/$defs/nullableString" }
+      }
+    },
+    "verifierState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verifier_ref", "verified", "verifier_failed", "confidence", "summary", "evidence_refs"],
+      "properties": {
+        "verifier_ref": { "type": "string", "minLength": 1 },
+        "verified": { "type": "boolean" },
+        "verifier_failed": { "type": "boolean" },
+        "confidence": { "$ref": "#/$defs/nullableNumber" },
+        "summary": { "type": "string", "minLength": 1 },
+        "evidence_refs": { "type": "array", "items": { "$ref": "#/$defs/evidenceRef" } }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision_id",
+        "decision_kind",
+        "status",
+        "next_action_kind",
+        "stop_reason",
+        "rationale",
+        "evidence_refs"
+      ],
+      "properties": {
+        "decision_id": { "type": "string", "minLength": 1 },
+        "decision_kind": { "$ref": "#/$defs/decisionKind" },
+        "status": { "$ref": "#/$defs/goalRunStatus" },
+        "next_action_kind": { "oneOf": [{ "$ref": "#/$defs/actionKind" }, { "type": "null" }] },
+        "stop_reason": { "oneOf": [{ "$ref": "#/$defs/stopReason" }, { "type": "null" }] },
+        "rationale": { "type": "string", "minLength": 1 },
+        "evidence_refs": { "type": "array", "items": { "$ref": "#/$defs/evidenceRef" } }
+      }
+    }
+  }
+}

--- a/docs/goal-run-report.json
+++ b/docs/goal-run-report.json
@@ -36,6 +36,113 @@
     "verifier_state": { "$ref": "#/$defs/verifierState" },
     "decision": { "$ref": "#/$defs/decision" }
   },
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "status": { "const": "continued" },
+        "decision": {
+          "type": "object",
+          "properties": {
+            "decision_kind": { "const": "continue" },
+            "status": { "const": "continued" },
+            "next_action_kind": { "$ref": "#/$defs/actionKind" },
+            "stop_reason": { "const": null }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "status": { "const": "verified_complete" },
+        "decision": {
+          "type": "object",
+          "properties": {
+            "decision_kind": { "const": "stop" },
+            "status": { "const": "verified_complete" },
+            "next_action_kind": { "const": null },
+            "stop_reason": { "const": "verified_complete" }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "status": { "const": "blocked" },
+        "decision": {
+          "type": "object",
+          "properties": {
+            "decision_kind": { "const": "stop" },
+            "status": { "const": "blocked" },
+            "next_action_kind": { "const": null },
+            "stop_reason": { "const": "blocked" }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "status": { "const": "budget_exhausted" },
+        "decision": {
+          "type": "object",
+          "properties": {
+            "decision_kind": { "const": "stop" },
+            "status": { "const": "budget_exhausted" },
+            "next_action_kind": { "const": null },
+            "stop_reason": { "const": "budget_exhausted" }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "status": { "const": "verifier_failed" },
+        "decision": {
+          "type": "object",
+          "properties": {
+            "decision_kind": { "const": "stop" },
+            "status": { "const": "verifier_failed" },
+            "next_action_kind": { "const": null },
+            "stop_reason": { "const": "verifier_failed" }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "status": { "const": "no_progress" },
+        "decision": {
+          "type": "object",
+          "properties": {
+            "decision_kind": { "const": "stop" },
+            "status": { "const": "no_progress" },
+            "next_action_kind": { "const": null },
+            "stop_reason": { "const": "no_progress" }
+          }
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "status": { "const": "canceled" },
+        "decision": {
+          "type": "object",
+          "properties": {
+            "decision_kind": { "const": "stop" },
+            "status": { "const": "canceled" },
+            "next_action_kind": { "const": null },
+            "stop_reason": { "const": "canceled" }
+          }
+        }
+      }
+    }
+  ],
   "$defs": {
     "goalRunStatus": {
       "enum": [
@@ -51,7 +158,14 @@
     "actionKind": { "enum": ["run", "solve", "improve", "mission", "campaign"] },
     "actionStatus": { "enum": ["planned", "running", "completed", "failed", "canceled"] },
     "stopReason": {
-      "enum": ["verified_complete", "blocked", "budget_exhausted", "verifier_failed", "no_progress", "canceled"]
+      "enum": [
+        "verified_complete",
+        "blocked",
+        "budget_exhausted",
+        "verifier_failed",
+        "no_progress",
+        "canceled"
+      ]
     },
     "decisionKind": { "enum": ["continue", "stop"] },
     "nullableString": { "type": ["string", "null"] },
@@ -70,7 +184,13 @@
     "budget": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["max_iterations", "max_actions", "max_seconds", "max_tokens", "max_no_progress_iterations"],
+      "required": [
+        "max_iterations",
+        "max_actions",
+        "max_seconds",
+        "max_tokens",
+        "max_no_progress_iterations"
+      ],
       "properties": {
         "max_iterations": { "$ref": "#/$defs/nullableNonNegativeInteger" },
         "max_actions": { "$ref": "#/$defs/nullableNonNegativeInteger" },
@@ -120,7 +240,14 @@
     "verifierState": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["verifier_ref", "verified", "verifier_failed", "confidence", "summary", "evidence_refs"],
+      "required": [
+        "verifier_ref",
+        "verified",
+        "verifier_failed",
+        "confidence",
+        "summary",
+        "evidence_refs"
+      ],
       "properties": {
         "verifier_ref": { "type": "string", "minLength": 1 },
         "verified": { "type": "boolean" },
@@ -128,6 +255,14 @@
         "confidence": { "$ref": "#/$defs/nullableNumber" },
         "summary": { "type": "string", "minLength": 1 },
         "evidence_refs": { "type": "array", "items": { "$ref": "#/$defs/evidenceRef" } }
+      },
+      "not": {
+        "type": "object",
+        "required": ["verified", "verifier_failed"],
+        "properties": {
+          "verified": { "const": true },
+          "verifier_failed": { "const": true }
+        }
       }
     },
     "decision": {

--- a/docs/goal-run-report.md
+++ b/docs/goal-run-report.md
@@ -1,0 +1,27 @@
+# Goal Run Report
+
+AC-825 defines an outer goal loop as a shared Python/TypeScript artifact for continue-until-verified execution. Inner loop limits are checkpoint/cadence controls; goal completion is decided by verification or an explicit terminal condition.
+
+## Contract
+
+Schema: [`goal-run-report.json`](goal-run-report.json)
+Parity fixture: [`goal-run-report-parity-fixture.json`](goal-run-report-parity-fixture.json)
+
+A report captures:
+
+- goal and goal-run identity
+- verifier reference and latest verifier state
+- budget and usage counters, including no-progress tracking
+- invoked inner-loop actions: `run`, `solve`, `improve`, `mission`, and `campaign`
+- durable continuation or stop rationale
+- resume token for process-restart recovery
+
+## Statuses
+
+Goal statuses: `continued`, `verified_complete`, `blocked`, `budget_exhausted`, `verifier_failed`, `no_progress`, and `canceled`.
+
+`continued` means the supervisor should invoke the recorded `next_action_kind`. Terminal states record `stop_reason` and should not schedule another inner action without a new goal-run decision.
+
+## OSS boundary
+
+The shared contract, builder, parser, and file helpers are public. Hosted fleet routing, tenant scheduling, billing, warm pools, and proprietary dashboards remain out of scope.

--- a/ts/src/analytics/goal-run-report.ts
+++ b/ts/src/analytics/goal-run-report.ts
@@ -1,0 +1,435 @@
+export const GOAL_RUN_STATUSES = [
+  "continued",
+  "verified_complete",
+  "blocked",
+  "budget_exhausted",
+  "verifier_failed",
+  "no_progress",
+  "canceled",
+] as const;
+export const GOAL_ACTION_KINDS = ["run", "solve", "improve", "mission", "campaign"] as const;
+export const GOAL_ACTION_STATUSES = ["planned", "running", "completed", "failed", "canceled"] as const;
+
+export type GoalRunStatus = (typeof GOAL_RUN_STATUSES)[number];
+export type GoalActionKind = (typeof GOAL_ACTION_KINDS)[number];
+export type GoalActionStatus = (typeof GOAL_ACTION_STATUSES)[number];
+export type GoalDecisionKind = "continue" | "stop";
+export type GoalStopReason = Exclude<GoalRunStatus, "continued">;
+
+export interface GoalEvidenceRef {
+  uri: string;
+  summary: string;
+}
+
+export interface GoalBudget {
+  max_iterations: number | null;
+  max_actions: number | null;
+  max_seconds: number | null;
+  max_tokens: number | null;
+  max_no_progress_iterations: number | null;
+}
+
+export interface GoalUsage {
+  iterations: number;
+  actions: number;
+  elapsed_seconds: number;
+  tokens: number;
+  no_progress_count: number;
+}
+
+export interface GoalActionRecord {
+  action_id: string;
+  action_kind: GoalActionKind;
+  status: GoalActionStatus;
+  started_at: string | null;
+  completed_at: string | null;
+  inner_run_ref: string | null;
+  summary: string;
+  evidence_refs: GoalEvidenceRef[];
+  negative_result_ledger_uri: string | null;
+}
+
+export interface GoalVerifierState {
+  verifier_ref: string;
+  verified: boolean;
+  verifier_failed: boolean;
+  confidence: number | null;
+  summary: string;
+  evidence_refs: GoalEvidenceRef[];
+}
+
+export interface GoalSupervisorDecision {
+  decision_id: string;
+  decision_kind: GoalDecisionKind;
+  status: GoalRunStatus;
+  next_action_kind: GoalActionKind | null;
+  stop_reason: GoalStopReason | null;
+  rationale: string;
+  evidence_refs: GoalEvidenceRef[];
+}
+
+export interface GoalRunReport {
+  schema_version: 1;
+  goal_id: string;
+  goal_run_id: string;
+  scenario_name: string;
+  objective: string;
+  generated_at: string;
+  resume_token: string;
+  status: GoalRunStatus;
+  verifier_ref: string;
+  budget: GoalBudget;
+  usage: GoalUsage;
+  actions: GoalActionRecord[];
+  verifier_state: GoalVerifierState;
+  decision: GoalSupervisorDecision;
+}
+
+export interface BuildGoalRunReportInput {
+  goal_id: string;
+  goal_run_id: string;
+  scenario_name: string;
+  objective: string;
+  verifier_ref: string;
+  budget: GoalBudget;
+  usage: GoalUsage;
+  actions: GoalActionRecord[];
+  verifier_state: GoalVerifierState;
+  next_action_kind?: GoalActionKind | null;
+  blocked_reason?: string | null;
+  requested_cancel?: boolean;
+  decision_id?: string;
+  generated_at?: string;
+  resume_token?: string;
+}
+
+const GOAL_RUN_STATUS_SET = new Set<string>(GOAL_RUN_STATUSES);
+const GOAL_ACTION_KIND_SET = new Set<string>(GOAL_ACTION_KINDS);
+const GOAL_ACTION_STATUS_SET = new Set<string>(GOAL_ACTION_STATUSES);
+
+export function buildGoalRunReport(input: BuildGoalRunReportInput): GoalRunReport {
+  const budget = parseBudget(input.budget);
+  const usage = parseUsage(input.usage);
+  const verifierState = parseVerifierState(input.verifier_state);
+  const decision = decideGoalRun({
+    budget,
+    usage,
+    verifierState,
+    nextActionKind: input.next_action_kind ?? null,
+    blockedReason: input.blocked_reason ?? null,
+    requestedCancel: input.requested_cancel ?? false,
+    decisionId: input.decision_id ?? `${input.goal_run_id}:decision:${usage.iterations}`,
+  });
+  return parseGoalRunReport({
+    schema_version: 1,
+    goal_id: input.goal_id,
+    goal_run_id: input.goal_run_id,
+    scenario_name: input.scenario_name,
+    objective: input.objective,
+    generated_at: input.generated_at ?? new Date().toISOString(),
+    resume_token: input.resume_token ?? `${input.goal_run_id}:${usage.iterations}`,
+    status: decision.status,
+    verifier_ref: input.verifier_ref,
+    budget,
+    usage,
+    actions: input.actions,
+    verifier_state: verifierState,
+    decision,
+  });
+}
+
+export function parseGoalRunReport(value: unknown): GoalRunReport {
+  const report = record(value, "goal run report");
+  exact(report, [
+    "schema_version",
+    "goal_id",
+    "goal_run_id",
+    "scenario_name",
+    "objective",
+    "generated_at",
+    "resume_token",
+    "status",
+    "verifier_ref",
+    "budget",
+    "usage",
+    "actions",
+    "verifier_state",
+    "decision",
+  ]);
+  if (report.schema_version !== 1) throw new Error("schema_version must be 1");
+  return {
+    schema_version: 1,
+    goal_id: string(report.goal_id, "goal_id"),
+    goal_run_id: string(report.goal_run_id, "goal_run_id"),
+    scenario_name: string(report.scenario_name, "scenario_name"),
+    objective: string(report.objective, "objective"),
+    generated_at: string(report.generated_at, "generated_at"),
+    resume_token: string(report.resume_token, "resume_token"),
+    status: goalRunStatus(report.status),
+    verifier_ref: string(report.verifier_ref, "verifier_ref"),
+    budget: parseBudget(report.budget),
+    usage: parseUsage(report.usage),
+    actions: array(report.actions, "actions").map(parseAction),
+    verifier_state: parseVerifierState(report.verifier_state),
+    decision: parseDecision(report.decision),
+  };
+}
+
+export function goalRunReportToMarkdown(report: GoalRunReport): string {
+  return [
+    `# Goal Run Report: ${report.goal_run_id}`,
+    `- Goal: ${report.goal_id}`,
+    `- Scenario: ${report.scenario_name}`,
+    `- Status: ${report.status}`,
+    `- Decision: ${report.decision.decision_kind}`,
+    `- Next action: ${report.decision.next_action_kind ?? "none"}`,
+    `- Rationale: ${report.decision.rationale}`,
+    "",
+  ].join("\n");
+}
+
+function decideGoalRun(input: {
+  budget: GoalBudget;
+  usage: GoalUsage;
+  verifierState: GoalVerifierState;
+  nextActionKind: GoalActionKind | null;
+  blockedReason: string | null;
+  requestedCancel: boolean;
+  decisionId: string;
+}): GoalSupervisorDecision {
+  const evidenceRefs = input.verifierState.evidence_refs;
+  if (input.requestedCancel) return stopDecision(input.decisionId, "canceled", "Goal canceled by operator.", evidenceRefs);
+  if (input.verifierState.verifier_failed)
+    return stopDecision(input.decisionId, "verifier_failed", "Verifier failed before goal completion.", evidenceRefs);
+  if (input.verifierState.verified)
+    return stopDecision(input.decisionId, "verified_complete", "Verifier confirmed the goal is complete.", evidenceRefs);
+  if (input.blockedReason) return stopDecision(input.decisionId, "blocked", input.blockedReason, evidenceRefs);
+  if (budgetExhausted(input.budget, input.usage))
+    return stopDecision(input.decisionId, "budget_exhausted", "Goal budget exhausted before verification.", evidenceRefs);
+  if (noProgressExhausted(input.budget, input.usage))
+    return stopDecision(input.decisionId, "no_progress", "No-progress limit reached with evidence.", evidenceRefs);
+  const nextActionKind = input.nextActionKind ?? "mission";
+  return {
+    decision_id: input.decisionId,
+    decision_kind: "continue",
+    status: "continued",
+    next_action_kind: nextActionKind,
+    stop_reason: null,
+    rationale: `Verifier incomplete; continue with ${nextActionKind} checkpoint.`,
+    evidence_refs: evidenceRefs,
+  };
+}
+
+function stopDecision(
+  decisionId: string,
+  reason: GoalStopReason,
+  rationale: string,
+  evidenceRefs: GoalEvidenceRef[],
+): GoalSupervisorDecision {
+  return {
+    decision_id: decisionId,
+    decision_kind: "stop",
+    status: reason,
+    next_action_kind: null,
+    stop_reason: reason,
+    rationale,
+    evidence_refs: evidenceRefs,
+  };
+}
+
+function budgetExhausted(budget: GoalBudget, usage: GoalUsage): boolean {
+  return (
+    (budget.max_iterations !== null && usage.iterations >= budget.max_iterations) ||
+    (budget.max_actions !== null && usage.actions >= budget.max_actions) ||
+    (budget.max_seconds !== null && usage.elapsed_seconds >= budget.max_seconds) ||
+    (budget.max_tokens !== null && usage.tokens >= budget.max_tokens)
+  );
+}
+
+function noProgressExhausted(budget: GoalBudget, usage: GoalUsage): boolean {
+  return budget.max_no_progress_iterations !== null && usage.no_progress_count >= budget.max_no_progress_iterations;
+}
+
+function parseBudget(value: unknown): GoalBudget {
+  const item = record(value, "goal budget");
+  exact(item, ["max_iterations", "max_actions", "max_seconds", "max_tokens", "max_no_progress_iterations"]);
+  return {
+    max_iterations: nullableNonNegativeInteger(item.max_iterations, "max_iterations"),
+    max_actions: nullableNonNegativeInteger(item.max_actions, "max_actions"),
+    max_seconds: nullableNonNegativeNumber(item.max_seconds, "max_seconds"),
+    max_tokens: nullableNonNegativeInteger(item.max_tokens, "max_tokens"),
+    max_no_progress_iterations: nullableNonNegativeInteger(
+      item.max_no_progress_iterations,
+      "max_no_progress_iterations",
+    ),
+  };
+}
+
+function parseUsage(value: unknown): GoalUsage {
+  const item = record(value, "goal usage");
+  exact(item, ["iterations", "actions", "elapsed_seconds", "tokens", "no_progress_count"]);
+  return {
+    iterations: nonNegativeInteger(item.iterations, "iterations"),
+    actions: nonNegativeInteger(item.actions, "actions"),
+    elapsed_seconds: nonNegativeNumber(item.elapsed_seconds, "elapsed_seconds"),
+    tokens: nonNegativeInteger(item.tokens, "tokens"),
+    no_progress_count: nonNegativeInteger(item.no_progress_count, "no_progress_count"),
+  };
+}
+
+function parseAction(value: unknown): GoalActionRecord {
+  const item = record(value, "goal action");
+  exact(item, [
+    "action_id",
+    "action_kind",
+    "status",
+    "started_at",
+    "completed_at",
+    "inner_run_ref",
+    "summary",
+    "evidence_refs",
+    "negative_result_ledger_uri",
+  ]);
+  return {
+    action_id: string(item.action_id, "action_id"),
+    action_kind: goalActionKind(item.action_kind),
+    status: goalActionStatus(item.status),
+    started_at: nullableString(item.started_at, "started_at"),
+    completed_at: nullableString(item.completed_at, "completed_at"),
+    inner_run_ref: nullableString(item.inner_run_ref, "inner_run_ref"),
+    summary: string(item.summary, "summary"),
+    evidence_refs: array(item.evidence_refs, "evidence_refs").map(parseEvidenceRef),
+    negative_result_ledger_uri: nullableString(item.negative_result_ledger_uri, "negative_result_ledger_uri"),
+  };
+}
+
+function parseVerifierState(value: unknown): GoalVerifierState {
+  const item = record(value, "goal verifier state");
+  exact(item, ["verifier_ref", "verified", "verifier_failed", "confidence", "summary", "evidence_refs"]);
+  return {
+    verifier_ref: string(item.verifier_ref, "verifier_ref"),
+    verified: boolean(item.verified, "verified"),
+    verifier_failed: boolean(item.verifier_failed, "verifier_failed"),
+    confidence: nullableNumber(item.confidence, "confidence"),
+    summary: string(item.summary, "summary"),
+    evidence_refs: array(item.evidence_refs, "evidence_refs").map(parseEvidenceRef),
+  };
+}
+
+function parseDecision(value: unknown): GoalSupervisorDecision {
+  const item = record(value, "goal decision");
+  exact(item, ["decision_id", "decision_kind", "status", "next_action_kind", "stop_reason", "rationale", "evidence_refs"]);
+  const status = goalRunStatus(item.status);
+  return {
+    decision_id: string(item.decision_id, "decision_id"),
+    decision_kind: goalDecisionKind(item.decision_kind),
+    status,
+    next_action_kind: item.next_action_kind === null ? null : goalActionKind(item.next_action_kind),
+    stop_reason: item.stop_reason === null ? null : goalStopReason(item.stop_reason),
+    rationale: string(item.rationale, "rationale"),
+    evidence_refs: array(item.evidence_refs, "evidence_refs").map(parseEvidenceRef),
+  };
+}
+
+function parseEvidenceRef(value: unknown): GoalEvidenceRef {
+  const item = record(value, "goal evidence ref");
+  exact(item, ["uri", "summary"]);
+  return { uri: string(item.uri, "uri"), summary: string(item.summary, "summary") };
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function exact(item: Record<string, unknown>, allowed: string[]): void {
+  const allowedSet = new Set(allowed);
+  const keys = Object.keys(item);
+  const missing = allowed.filter((key) => !keys.includes(key));
+  if (missing.length) throw new Error(`missing field(s): ${missing.sort().join(", ")}`);
+  const extra = keys.filter((key) => !allowedSet.has(key));
+  if (extra.length) throw new Error(`unexpected field(s): ${extra.sort().join(", ")}`);
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a string`);
+  return value;
+}
+
+function nullableString(value: unknown, label: string): string | null {
+  return value === null ? null : string(value, label);
+}
+
+function number(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${label} must be a number`);
+  return value;
+}
+
+function nullableNumber(value: unknown, label: string): number | null {
+  return value === null ? null : number(value, label);
+}
+
+function nonNegativeNumber(value: unknown, label: string): number {
+  const result = number(value, label);
+  if (result < 0) throw new Error(`${label} must be non-negative`);
+  return result;
+}
+
+function nullableNonNegativeNumber(value: unknown, label: string): number | null {
+  return value === null ? null : nonNegativeNumber(value, label);
+}
+
+function integer(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) throw new Error(`${label} must be an integer`);
+  return value;
+}
+
+function nonNegativeInteger(value: unknown, label: string): number {
+  const result = integer(value, label);
+  if (result < 0) throw new Error(`${label} must be a non-negative integer`);
+  return result;
+}
+
+function nullableNonNegativeInteger(value: unknown, label: string): number | null {
+  return value === null ? null : nonNegativeInteger(value, label);
+}
+
+function boolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${label} must be a boolean`);
+  return value;
+}
+
+function array(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value;
+}
+
+function goalRunStatus(value: unknown): GoalRunStatus {
+  const result = string(value, "status");
+  if (!GOAL_RUN_STATUS_SET.has(result)) throw new Error("status must be a goal run status");
+  return result as GoalRunStatus;
+}
+
+function goalActionKind(value: unknown): GoalActionKind {
+  const result = string(value, "action_kind");
+  if (!GOAL_ACTION_KIND_SET.has(result)) throw new Error("action_kind must be a goal action kind");
+  return result as GoalActionKind;
+}
+
+function goalActionStatus(value: unknown): GoalActionStatus {
+  const result = string(value, "action status");
+  if (!GOAL_ACTION_STATUS_SET.has(result)) throw new Error("status must be a goal action status");
+  return result as GoalActionStatus;
+}
+
+function goalDecisionKind(value: unknown): GoalDecisionKind {
+  const result = string(value, "decision_kind");
+  if (result !== "continue" && result !== "stop") throw new Error("decision_kind must be continue or stop");
+  return result;
+}
+
+function goalStopReason(value: unknown): GoalStopReason {
+  const result = goalRunStatus(value);
+  if (result === "continued") throw new Error("stop_reason must be terminal");
+  return result;
+}

--- a/ts/src/analytics/goal-run-report.ts
+++ b/ts/src/analytics/goal-run-report.ts
@@ -8,7 +8,13 @@ export const GOAL_RUN_STATUSES = [
   "canceled",
 ] as const;
 export const GOAL_ACTION_KINDS = ["run", "solve", "improve", "mission", "campaign"] as const;
-export const GOAL_ACTION_STATUSES = ["planned", "running", "completed", "failed", "canceled"] as const;
+export const GOAL_ACTION_STATUSES = [
+  "planned",
+  "running",
+  "completed",
+  "failed",
+  "canceled",
+] as const;
 
 export type GoalRunStatus = (typeof GOAL_RUN_STATUSES)[number];
 export type GoalActionKind = (typeof GOAL_ACTION_KINDS)[number];
@@ -157,6 +163,9 @@ export function parseGoalRunReport(value: unknown): GoalRunReport {
     "decision",
   ]);
   if (report.schema_version !== 1) throw new Error("schema_version must be 1");
+  const status = goalRunStatus(report.status);
+  const decision = parseDecision(report.decision);
+  if (status !== decision.status) throw new Error("status must match decision.status");
   return {
     schema_version: 1,
     goal_id: string(report.goal_id, "goal_id"),
@@ -165,13 +174,13 @@ export function parseGoalRunReport(value: unknown): GoalRunReport {
     objective: string(report.objective, "objective"),
     generated_at: string(report.generated_at, "generated_at"),
     resume_token: string(report.resume_token, "resume_token"),
-    status: goalRunStatus(report.status),
+    status,
     verifier_ref: string(report.verifier_ref, "verifier_ref"),
     budget: parseBudget(report.budget),
     usage: parseUsage(report.usage),
     actions: array(report.actions, "actions").map(parseAction),
     verifier_state: parseVerifierState(report.verifier_state),
-    decision: parseDecision(report.decision),
+    decision,
   };
 }
 
@@ -198,16 +207,38 @@ function decideGoalRun(input: {
   decisionId: string;
 }): GoalSupervisorDecision {
   const evidenceRefs = input.verifierState.evidence_refs;
-  if (input.requestedCancel) return stopDecision(input.decisionId, "canceled", "Goal canceled by operator.", evidenceRefs);
+  if (input.requestedCancel)
+    return stopDecision(input.decisionId, "canceled", "Goal canceled by operator.", evidenceRefs);
   if (input.verifierState.verifier_failed)
-    return stopDecision(input.decisionId, "verifier_failed", "Verifier failed before goal completion.", evidenceRefs);
+    return stopDecision(
+      input.decisionId,
+      "verifier_failed",
+      "Verifier failed before goal completion.",
+      evidenceRefs,
+    );
   if (input.verifierState.verified)
-    return stopDecision(input.decisionId, "verified_complete", "Verifier confirmed the goal is complete.", evidenceRefs);
-  if (input.blockedReason) return stopDecision(input.decisionId, "blocked", input.blockedReason, evidenceRefs);
+    return stopDecision(
+      input.decisionId,
+      "verified_complete",
+      "Verifier confirmed the goal is complete.",
+      evidenceRefs,
+    );
+  if (input.blockedReason)
+    return stopDecision(input.decisionId, "blocked", input.blockedReason, evidenceRefs);
   if (budgetExhausted(input.budget, input.usage))
-    return stopDecision(input.decisionId, "budget_exhausted", "Goal budget exhausted before verification.", evidenceRefs);
+    return stopDecision(
+      input.decisionId,
+      "budget_exhausted",
+      "Goal budget exhausted before verification.",
+      evidenceRefs,
+    );
   if (noProgressExhausted(input.budget, input.usage))
-    return stopDecision(input.decisionId, "no_progress", "No-progress limit reached with evidence.", evidenceRefs);
+    return stopDecision(
+      input.decisionId,
+      "no_progress",
+      "No-progress limit reached with evidence.",
+      evidenceRefs,
+    );
   const nextActionKind = input.nextActionKind ?? "mission";
   return {
     decision_id: input.decisionId,
@@ -247,12 +278,21 @@ function budgetExhausted(budget: GoalBudget, usage: GoalUsage): boolean {
 }
 
 function noProgressExhausted(budget: GoalBudget, usage: GoalUsage): boolean {
-  return budget.max_no_progress_iterations !== null && usage.no_progress_count >= budget.max_no_progress_iterations;
+  return (
+    budget.max_no_progress_iterations !== null &&
+    usage.no_progress_count >= budget.max_no_progress_iterations
+  );
 }
 
 function parseBudget(value: unknown): GoalBudget {
   const item = record(value, "goal budget");
-  exact(item, ["max_iterations", "max_actions", "max_seconds", "max_tokens", "max_no_progress_iterations"]);
+  exact(item, [
+    "max_iterations",
+    "max_actions",
+    "max_seconds",
+    "max_tokens",
+    "max_no_progress_iterations",
+  ]);
   return {
     max_iterations: nullableNonNegativeInteger(item.max_iterations, "max_iterations"),
     max_actions: nullableNonNegativeInteger(item.max_actions, "max_actions"),
@@ -299,17 +339,30 @@ function parseAction(value: unknown): GoalActionRecord {
     inner_run_ref: nullableString(item.inner_run_ref, "inner_run_ref"),
     summary: string(item.summary, "summary"),
     evidence_refs: array(item.evidence_refs, "evidence_refs").map(parseEvidenceRef),
-    negative_result_ledger_uri: nullableString(item.negative_result_ledger_uri, "negative_result_ledger_uri"),
+    negative_result_ledger_uri: nullableString(
+      item.negative_result_ledger_uri,
+      "negative_result_ledger_uri",
+    ),
   };
 }
 
 function parseVerifierState(value: unknown): GoalVerifierState {
   const item = record(value, "goal verifier state");
-  exact(item, ["verifier_ref", "verified", "verifier_failed", "confidence", "summary", "evidence_refs"]);
+  exact(item, [
+    "verifier_ref",
+    "verified",
+    "verifier_failed",
+    "confidence",
+    "summary",
+    "evidence_refs",
+  ]);
+  const verified = boolean(item.verified, "verified");
+  const verifierFailed = boolean(item.verifier_failed, "verifier_failed");
+  if (verified && verifierFailed) throw new Error("verified and verifier_failed are mutually exclusive");
   return {
     verifier_ref: string(item.verifier_ref, "verifier_ref"),
-    verified: boolean(item.verified, "verified"),
-    verifier_failed: boolean(item.verifier_failed, "verifier_failed"),
+    verified,
+    verifier_failed: verifierFailed,
     confidence: nullableNumber(item.confidence, "confidence"),
     summary: string(item.summary, "summary"),
     evidence_refs: array(item.evidence_refs, "evidence_refs").map(parseEvidenceRef),
@@ -318,14 +371,32 @@ function parseVerifierState(value: unknown): GoalVerifierState {
 
 function parseDecision(value: unknown): GoalSupervisorDecision {
   const item = record(value, "goal decision");
-  exact(item, ["decision_id", "decision_kind", "status", "next_action_kind", "stop_reason", "rationale", "evidence_refs"]);
+  exact(item, [
+    "decision_id",
+    "decision_kind",
+    "status",
+    "next_action_kind",
+    "stop_reason",
+    "rationale",
+    "evidence_refs",
+  ]);
   const status = goalRunStatus(item.status);
+  const decisionKind = goalDecisionKind(item.decision_kind);
+  const nextActionKind = item.next_action_kind === null ? null : goalActionKind(item.next_action_kind);
+  const stopReason = item.stop_reason === null ? null : goalStopReason(item.stop_reason);
+  if (decisionKind === "continue") {
+    if (status !== "continued" || nextActionKind === null || stopReason !== null) {
+      throw new Error("continue decisions require continued status, next action, and no stop reason");
+    }
+  } else if (status === "continued" || nextActionKind !== null || stopReason !== status) {
+    throw new Error("stop decisions require terminal status, no next action, and matching stop reason");
+  }
   return {
     decision_id: string(item.decision_id, "decision_id"),
-    decision_kind: goalDecisionKind(item.decision_kind),
+    decision_kind: decisionKind,
     status,
-    next_action_kind: item.next_action_kind === null ? null : goalActionKind(item.next_action_kind),
-    stop_reason: item.stop_reason === null ? null : goalStopReason(item.stop_reason),
+    next_action_kind: nextActionKind,
+    stop_reason: stopReason,
     rationale: string(item.rationale, "rationale"),
     evidence_refs: array(item.evidence_refs, "evidence_refs").map(parseEvidenceRef),
   };
@@ -338,7 +409,8 @@ function parseEvidenceRef(value: unknown): GoalEvidenceRef {
 }
 
 function record(value: unknown, label: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error(`${label} must be an object`);
   return value as Record<string, unknown>;
 }
 
@@ -361,7 +433,8 @@ function nullableString(value: unknown, label: string): string | null {
 }
 
 function number(value: unknown, label: string): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${label} must be a number`);
+  if (typeof value !== "number" || !Number.isFinite(value))
+    throw new Error(`${label} must be a number`);
   return value;
 }
 
@@ -380,7 +453,8 @@ function nullableNonNegativeNumber(value: unknown, label: string): number | null
 }
 
 function integer(value: unknown, label: string): number {
-  if (typeof value !== "number" || !Number.isInteger(value)) throw new Error(`${label} must be an integer`);
+  if (typeof value !== "number" || !Number.isInteger(value))
+    throw new Error(`${label} must be an integer`);
   return value;
 }
 
@@ -424,7 +498,8 @@ function goalActionStatus(value: unknown): GoalActionStatus {
 
 function goalDecisionKind(value: unknown): GoalDecisionKind {
   const result = string(value, "decision_kind");
-  if (result !== "continue" && result !== "stop") throw new Error("decision_kind must be continue or stop");
+  if (result !== "continue" && result !== "stop")
+    throw new Error("decision_kind must be continue or stop");
   return result;
 }
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -688,6 +688,34 @@ export {
   writeCampaignModeReport,
 } from "./knowledge/campaign-mode-report-store.js";
 export {
+  GOAL_ACTION_KINDS,
+  GOAL_ACTION_STATUSES,
+  GOAL_RUN_STATUSES,
+  buildGoalRunReport,
+  goalRunReportToMarkdown,
+  parseGoalRunReport,
+} from "./analytics/goal-run-report.js";
+export type {
+  BuildGoalRunReportInput,
+  GoalActionKind,
+  GoalActionRecord,
+  GoalActionStatus,
+  GoalBudget,
+  GoalDecisionKind,
+  GoalEvidenceRef,
+  GoalRunReport,
+  GoalRunStatus,
+  GoalStopReason,
+  GoalSupervisorDecision,
+  GoalUsage,
+  GoalVerifierState,
+} from "./analytics/goal-run-report.js";
+export {
+  goalRunReportPath,
+  readGoalRunReport,
+  writeGoalRunReport,
+} from "./knowledge/goal-run-report-store.js";
+export {
   FAILURE_KINDS,
   NEGATIVE_RESULT_DISPOSITIONS,
   buildNegativeResultLedger,

--- a/ts/src/knowledge/goal-run-report-store.ts
+++ b/ts/src/knowledge/goal-run-report-store.ts
@@ -1,8 +1,12 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { basename, dirname, join } from "node:path";
+import { dirname, join, posix, win32 } from "node:path";
 import { parseGoalRunReport, type GoalRunReport } from "../analytics/goal-run-report.js";
 
-export function goalRunReportPath(knowledgeRoot: string, goalId: string, goalRunId: string): string {
+export function goalRunReportPath(
+  knowledgeRoot: string,
+  goalId: string,
+  goalRunId: string,
+): string {
   return join(
     knowledgeRoot,
     "goal_runs",
@@ -19,7 +23,10 @@ function pathSegment(value: string, label: string): string {
     normalized === ".." ||
     normalized.includes("/") ||
     normalized.includes("\\") ||
-    basename(normalized) !== normalized
+    posix.isAbsolute(normalized) ||
+    win32.isAbsolute(normalized) ||
+    posix.basename(normalized) !== normalized ||
+    win32.basename(normalized) !== normalized
   ) {
     throw new Error(`${label} must be a single path segment`);
   }
@@ -38,7 +45,13 @@ export function writeGoalRunReport(
   return path;
 }
 
-export function readGoalRunReport(knowledgeRoot: string, goalId: string, goalRunId: string): GoalRunReport | null {
+export function readGoalRunReport(
+  knowledgeRoot: string,
+  goalId: string,
+  goalRunId: string,
+): GoalRunReport | null {
   const path = goalRunReportPath(knowledgeRoot, goalId, goalRunId);
-  return existsSync(path) ? parseGoalRunReport(JSON.parse(readFileSync(path, "utf-8")) as unknown) : null;
+  return existsSync(path)
+    ? parseGoalRunReport(JSON.parse(readFileSync(path, "utf-8")) as unknown)
+    : null;
 }

--- a/ts/src/knowledge/goal-run-report-store.ts
+++ b/ts/src/knowledge/goal-run-report-store.ts
@@ -1,0 +1,44 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { parseGoalRunReport, type GoalRunReport } from "../analytics/goal-run-report.js";
+
+export function goalRunReportPath(knowledgeRoot: string, goalId: string, goalRunId: string): string {
+  return join(
+    knowledgeRoot,
+    "goal_runs",
+    pathSegment(goalId, "goalId"),
+    `${pathSegment(goalRunId, "goalRunId")}.json`,
+  );
+}
+
+function pathSegment(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`${label} is required`);
+  if (
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.includes("/") ||
+    normalized.includes("\\") ||
+    basename(normalized) !== normalized
+  ) {
+    throw new Error(`${label} must be a single path segment`);
+  }
+  return normalized;
+}
+
+export function writeGoalRunReport(
+  knowledgeRoot: string,
+  goalId: string,
+  goalRunId: string,
+  report: GoalRunReport,
+): string {
+  const path = goalRunReportPath(knowledgeRoot, goalId, goalRunId);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(report, null, 2) + "\n", "utf-8");
+  return path;
+}
+
+export function readGoalRunReport(knowledgeRoot: string, goalId: string, goalRunId: string): GoalRunReport | null {
+  const path = goalRunReportPath(knowledgeRoot, goalId, goalRunId);
+  return existsSync(path) ? parseGoalRunReport(JSON.parse(readFileSync(path, "utf-8")) as unknown) : null;
+}

--- a/ts/tests/goal-run-report.test.ts
+++ b/ts/tests/goal-run-report.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import Ajv2020 from "ajv/dist/2020.js";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -9,13 +10,13 @@ import {
   type BuildGoalRunReportInput,
   type GoalRunReport,
 } from "../src/analytics/goal-run-report.js";
-import {
-  readGoalRunReport,
-  writeGoalRunReport,
-} from "../src/knowledge/goal-run-report-store.js";
+import { readGoalRunReport, writeGoalRunReport } from "../src/knowledge/goal-run-report-store.js";
 
 const fixture = JSON.parse(
-  readFileSync(join(import.meta.dirname, "..", "..", "docs", "goal-run-report-parity-fixture.json"), "utf-8"),
+  readFileSync(
+    join(import.meta.dirname, "..", "..", "docs", "goal-run-report-parity-fixture.json"),
+    "utf-8",
+  ),
 ) as {
   cases: Array<
     BuildGoalRunReportInput & {
@@ -24,6 +25,9 @@ const fixture = JSON.parse(
     }
   >;
 };
+const schema = JSON.parse(
+  readFileSync(join(import.meta.dirname, "..", "..", "docs", "goal-run-report.json"), "utf-8"),
+) as unknown;
 
 describe("goal run report", () => {
   it("matches the shared Python/TypeScript parity fixture", () => {
@@ -39,12 +43,17 @@ describe("goal run report", () => {
     expect(parseGoalRunReport(report)).toEqual(report);
     expect(() => parseGoalRunReport({ ...report, surprise: true })).toThrow(/unexpected field/);
     expect(() => parseGoalRunReport({ ...report, goal_id: "" })).toThrow(/goal_id/);
-    expect(() => parseGoalRunReport({ ...report, budget: missingBudgetField })).toThrow(/missing field/);
+    expect(() => parseGoalRunReport({ ...report, budget: missingBudgetField })).toThrow(
+      /missing field/,
+    );
     expect(() =>
       parseGoalRunReport({ ...report, usage: { ...report.usage, iterations: -1 } }),
     ).toThrow(/iterations/);
     expect(() =>
-      parseGoalRunReport({ ...report, actions: [{ ...report.actions[0]!, action_kind: "unknown" }] }),
+      parseGoalRunReport({
+        ...report,
+        actions: [{ ...report.actions[0]!, action_kind: "unknown" }],
+      }),
     ).toThrow(/action_kind/);
     expect(() => parseGoalRunReport({ ...report, status: "active" })).toThrow(/status/);
   });
@@ -77,16 +86,65 @@ describe("goal run report", () => {
     }
   });
 
+  it("rejects inconsistent decisions and conflicting verifier states", () => {
+    const continued = fixture.cases[0]!.expected_report;
+    const terminal = fixture.cases[1]!.expected_report;
+
+    for (const payload of [
+      { ...continued, status: "verified_complete" },
+      { ...continued, decision: { ...continued.decision, next_action_kind: null } },
+      { ...terminal, decision: { ...terminal.decision, next_action_kind: "mission" } },
+      { ...terminal, decision: { ...terminal.decision, stop_reason: "blocked" } },
+      { ...terminal, verifier_state: { ...terminal.verifier_state, verifier_failed: true } },
+    ]) {
+      expect(() => parseGoalRunReport(payload)).toThrow();
+    }
+
+    expect(() =>
+      buildGoalRunReport({
+        ...fixture.cases[1]!,
+        verifier_state: { ...fixture.cases[1]!.verifier_state, verifier_failed: true },
+      }),
+    ).toThrow(/verified/);
+  });
+
+  it("schema rejects inconsistent durable decisions", () => {
+    const validate = new Ajv2020({ allErrors: true, strict: true }).compile(schema);
+    const continued = fixture.cases[0]!.expected_report;
+    const terminal = fixture.cases[1]!.expected_report;
+
+    for (const item of fixture.cases) expect(validate(item.expected_report)).toBe(true);
+    expect(validate({ ...continued, status: "verified_complete" })).toBe(false);
+    expect(validate({ ...continued, decision: { ...continued.decision, next_action_kind: null } })).toBe(
+      false,
+    );
+    expect(validate({ ...terminal, decision: { ...terminal.decision, next_action_kind: "mission" } })).toBe(
+      false,
+    );
+    expect(validate({ ...terminal, decision: { ...terminal.decision, stop_reason: "blocked" } })).toBe(
+      false,
+    );
+    expect(validate({ ...terminal, verifier_state: { ...terminal.verifier_state, verifier_failed: true } })).toBe(
+      false,
+    );
+  });
+
   it("rejects path traversal through file helper identifiers", () => {
     const root = mkdtempSync(join(tmpdir(), "goal-run-"));
     try {
       const report = parseGoalRunReport(fixture.cases[0]!.expected_report);
       const knowledgeRoot = join(root, "knowledge");
 
-      expect(() => writeGoalRunReport(knowledgeRoot, "../../../outside", report.goal_run_id, report)).toThrow(
+      expect(() =>
+        writeGoalRunReport(knowledgeRoot, "../../../outside", report.goal_run_id, report),
+      ).toThrow(/goalId/);
+      expect(() =>
+        writeGoalRunReport(knowledgeRoot, report.goal_id, "../../../outside", report),
+      ).toThrow(/goalRunId/);
+      expect(() => writeGoalRunReport(knowledgeRoot, "C:foo", report.goal_run_id, report)).toThrow(
         /goalId/,
       );
-      expect(() => writeGoalRunReport(knowledgeRoot, report.goal_id, "../../../outside", report)).toThrow(
+      expect(() => writeGoalRunReport(knowledgeRoot, report.goal_id, "C:foo", report)).toThrow(
         /goalRunId/,
       );
       expect(existsSync(join(root, "outside.json"))).toBe(false);

--- a/ts/tests/goal-run-report.test.ts
+++ b/ts/tests/goal-run-report.test.ts
@@ -1,0 +1,97 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGoalRunReport,
+  parseGoalRunReport,
+  type BuildGoalRunReportInput,
+  type GoalRunReport,
+} from "../src/analytics/goal-run-report.js";
+import {
+  readGoalRunReport,
+  writeGoalRunReport,
+} from "../src/knowledge/goal-run-report-store.js";
+
+const fixture = JSON.parse(
+  readFileSync(join(import.meta.dirname, "..", "..", "docs", "goal-run-report-parity-fixture.json"), "utf-8"),
+) as {
+  cases: Array<
+    BuildGoalRunReportInput & {
+      name: string;
+      expected_report: GoalRunReport;
+    }
+  >;
+};
+
+describe("goal run report", () => {
+  it("matches the shared Python/TypeScript parity fixture", () => {
+    for (const item of fixture.cases) {
+      expect(buildGoalRunReport(item)).toEqual(item.expected_report);
+    }
+  });
+
+  it("parses durable report JSON and rejects schema-invalid data", () => {
+    const report = fixture.cases[0]!.expected_report;
+    const { max_iterations: _maxIterations, ...missingBudgetField } = report.budget;
+
+    expect(parseGoalRunReport(report)).toEqual(report);
+    expect(() => parseGoalRunReport({ ...report, surprise: true })).toThrow(/unexpected field/);
+    expect(() => parseGoalRunReport({ ...report, goal_id: "" })).toThrow(/goal_id/);
+    expect(() => parseGoalRunReport({ ...report, budget: missingBudgetField })).toThrow(/missing field/);
+    expect(() =>
+      parseGoalRunReport({ ...report, usage: { ...report.usage, iterations: -1 } }),
+    ).toThrow(/iterations/);
+    expect(() =>
+      parseGoalRunReport({ ...report, actions: [{ ...report.actions[0]!, action_kind: "unknown" }] }),
+    ).toThrow(/action_kind/);
+    expect(() => parseGoalRunReport({ ...report, status: "active" })).toThrow(/status/);
+  });
+
+  it("covers terminal and continued statuses", () => {
+    expect(new Set(fixture.cases.map((item) => item.expected_report.status))).toEqual(
+      new Set([
+        "continued",
+        "verified_complete",
+        "blocked",
+        "budget_exhausted",
+        "verifier_failed",
+        "no_progress",
+        "canceled",
+      ]),
+    );
+  });
+
+  it("persists goal run reports for resume", () => {
+    const root = mkdtempSync(join(tmpdir(), "goal-run-"));
+    try {
+      const report = parseGoalRunReport(fixture.cases[0]!.expected_report);
+      const knowledgeRoot = join(root, "knowledge");
+
+      writeGoalRunReport(knowledgeRoot, report.goal_id, report.goal_run_id, report);
+
+      expect(readGoalRunReport(knowledgeRoot, report.goal_id, report.goal_run_id)).toEqual(report);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects path traversal through file helper identifiers", () => {
+    const root = mkdtempSync(join(tmpdir(), "goal-run-"));
+    try {
+      const report = parseGoalRunReport(fixture.cases[0]!.expected_report);
+      const knowledgeRoot = join(root, "knowledge");
+
+      expect(() => writeGoalRunReport(knowledgeRoot, "../../../outside", report.goal_run_id, report)).toThrow(
+        /goalId/,
+      );
+      expect(() => writeGoalRunReport(knowledgeRoot, report.goal_id, "../../../outside", report)).toThrow(
+        /goalRunId/,
+      );
+      expect(existsSync(join(root, "outside.json"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -46,6 +46,7 @@ describe("package root exports", () => {
     expect(pkg.buildRunUtilizationReport).toBeDefined();
     expect(pkg.buildNegativeResultLedger).toBeDefined();
     expect(pkg.buildCampaignModeReport).toBeDefined();
+    expect(pkg.buildGoalRunReport).toBeDefined();
     expect(pkg.buildOperationalMemoryPackFromDiagnostics).toBeDefined();
     expect(pkg.resolveBrowserSessionConfig).toBeDefined();
     expect(pkg.evaluateBrowserActionPolicy).toBeDefined();


### PR DESCRIPTION
## Summary
- add shared Python/TypeScript `GoalRunReport` contract for AC-825 outer goal supervision
- model continue-vs-stop decisions, verifier state, budgets/usages, inner-loop action cadence, negative-result links, resume tokens, and terminal status vocabulary
- add file helpers plus schema/docs/parity fixture covering continued, verified, blocked, budget exhausted, verifier failed, no-progress, and canceled states

## Tests
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m pytest tests/test_goal_run_report.py tests/test_package_boundaries.py tests/test_module_size_limits.py -q`
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m ruff check src/autocontext/analytics/goal_run_report.py src/autocontext/analytics/__init__.py src/autocontext/storage/goal_run_report_store.py tests/test_goal_run_report.py`
- `cd autocontext && PYTHONPATH=src ../../autocontext-ac820/autocontext/.venv/bin/python -m mypy src/autocontext/analytics/goal_run_report.py src/autocontext/analytics/__init__.py src/autocontext/storage/goal_run_report_store.py`
- `cd ts && npm test -- goal-run-report.test.ts package-export-catalogs.test.ts`
- `cd ts && npm run lint`
- `cd ts && npm run build`
- `git diff --check`

Resolves AC-825.
