### PR TITLE
AC-827 derive lesson curation from markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - AC-824 campaign mode reports define shared Python/TypeScript multi-branch campaign identity, branch budgets, eval lanes, evidence sharing, terminal states, and recommendations.
 - AC-825 goal run reports define a shared Python/TypeScript outer supervisor artifact for continue-until-verified execution, resume tokens, budgets, action cadence, verifier state, and durable stop/continuation decisions.
 - AC-826 playbook approval gates stage curator playbook updates as pending artifacts, expose approve/reject/read APIs, and keep approved playbooks in prompts until human approval.
+- AC-827 lesson lifecycle curation now derives from live playbook/SKILL markdown, mutates markdown for delete/stale/dead-end actions, and retires `lessons.json` as a prompt or curation source of truth.
 
 ## [pi-v0.2.6] - 2026-06-16
 

--- a/autocontext/src/autocontext/knowledge/lessons.py
+++ b/autocontext/src/autocontext/knowledge/lessons.py
@@ -1,7 +1,8 @@
-"""AC-236: Schema- and state-aware lesson applicability.
+"""Deprecated AC-236 structured lesson compatibility types.
 
-Defines structured lessons with applicability metadata, a JSON-backed
-LessonStore, and filtering/invalidation operations.
+AC-827 moved prompt loading and lifecycle curation to live playbook/SKILL
+markdown. ``LessonStore`` remains for old callers/tests, but new code should
+not use ``lessons.json`` as a lesson source of truth.
 """
 
 from __future__ import annotations
@@ -77,7 +78,7 @@ class Lesson(BaseModel):
 
 
 class LessonStore:
-    """JSON-backed store for structured lessons with applicability metadata."""
+    """Deprecated JSON-backed store for structured lesson metadata."""
 
     def __init__(self, knowledge_root: Path, skills_root: Path) -> None:
         self.knowledge_root = knowledge_root

--- a/autocontext/src/autocontext/knowledge/lifecycle.py
+++ b/autocontext/src/autocontext/knowledge/lifecycle.py
@@ -1,32 +1,119 @@
-"""Pure lesson-lifecycle assembly and curation ops (Cowork 2c).
-
-Backed by the structured LessonStore (lessons.json) and the dead_ends.md
-registry. "pending" is a status on the lesson itself (meta.approval_status),
-not a separate store, so the whole lifecycle reads one store.
-"""
+"""Lesson lifecycle derived from live playbook/SKILL markdown primitives."""
 
 from __future__ import annotations
 
 import hashlib
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
-from autocontext.knowledge.lessons import Lesson, LessonStore
 from autocontext.storage.artifacts import ArtifactStore
 
 STALENESS_WINDOW = 10
+LESSONS_START = "<!-- LESSONS_START -->"
+LESSONS_END = "<!-- LESSONS_END -->"
+STALE_MARKER = "<!-- autocontext:lesson-status=stale -->"
 
 
-def _lesson_view(lesson: Lesson, status: str, source: str = "curator") -> dict[str, Any]:
+@dataclass(frozen=True)
+class _DerivedLesson:
+    id: str
+    text: str
+    status: Literal["active", "stale"]
+    source: str
+
+
+def _normalize_text(text: str) -> str:
+    stripped = text.replace(STALE_MARKER, "").strip()
+    if stripped.startswith("- "):
+        stripped = stripped[2:].strip()
+    return " ".join(stripped.split())
+
+
+def _lesson_id(text: str) -> str:
+    return "lesson_" + hashlib.sha256(_normalize_text(text).encode("utf-8")).hexdigest()[:12]
+
+
+def _parse_lesson_line(line: str) -> tuple[str, bool] | None:
+    stripped = line.strip()
+    if not stripped.startswith("-"):
+        return None
+    text = _normalize_text(stripped[1:].strip())
+    if not text:
+        return None
+    return text, STALE_MARKER in stripped
+
+
+def _playbook_block(content: str) -> tuple[int, int, str] | None:
+    start = content.find(LESSONS_START)
+    end = content.find(LESSONS_END)
+    if start == -1 or end == -1 or end <= start:
+        return None
+    block_start = start + len(LESSONS_START)
+    return block_start, end, content[block_start:end]
+
+
+def _playbook_lessons(artifacts: ArtifactStore, scenario: str) -> list[_DerivedLesson]:
+    content = artifacts.read_playbook(scenario)
+    block = _playbook_block(content)
+    if block is None:
+        return []
+    lessons: list[_DerivedLesson] = []
+    for line in block[2].splitlines():
+        parsed = _parse_lesson_line(line)
+        if parsed is None:
+            continue
+        text, stale = parsed
+        lessons.append(
+            _DerivedLesson(
+                id=_lesson_id(text),
+                text=text,
+                status="stale" if stale else "active",
+                source=f"knowledge/{scenario}/playbook.md",
+            )
+        )
+    return lessons
+
+
+def _skill_lessons(artifacts: ArtifactStore, scenario: str) -> list[_DerivedLesson]:
+    lessons: list[_DerivedLesson] = []
+    for line in artifacts.read_skill_lessons_raw(scenario):
+        parsed = _parse_lesson_line(line)
+        if parsed is None:
+            continue
+        text, stale = parsed
+        lessons.append(
+            _DerivedLesson(
+                id=_lesson_id(text),
+                text=text,
+                status="stale" if stale else "active",
+                source=f"skills/{scenario.replace('_', '-')}-ops/SKILL.md",
+            )
+        )
+    return lessons
+
+
+def _derived_lessons(artifacts: ArtifactStore, scenario: str) -> list[_DerivedLesson]:
+    seen: set[str] = set()
+    result: list[_DerivedLesson] = []
+    for lesson in [*_playbook_lessons(artifacts, scenario), *_skill_lessons(artifacts, scenario)]:
+        if lesson.id in seen:
+            continue
+        seen.add(lesson.id)
+        result.append(lesson)
+    return result
+
+
+def _lesson_view(lesson: _DerivedLesson, current_generation: int) -> dict[str, Any]:
     return {
         "id": lesson.id,
         "text": lesson.text,
-        "status": status,
-        "generation": lesson.meta.generation,
-        "createdAt": lesson.meta.created_at,
-        "bestScore": lesson.meta.best_score,
-        "lastValidatedGen": lesson.meta.last_validated_gen,
-        "supersededBy": lesson.meta.superseded_by or None,
-        "source": source,
+        "status": lesson.status,
+        "generation": 0,
+        "createdAt": "",
+        "bestScore": None,
+        "lastValidatedGen": current_generation if lesson.status == "active" else None,
+        "supersededBy": None,
+        "source": lesson.source,
     }
 
 
@@ -36,7 +123,7 @@ def _dead_end_views(dead_ends_md: str) -> list[dict[str, Any]]:
         text = block.strip()
         if not text:
             continue
-        did = "deadend_" + hashlib.sha1(text.encode("utf-8")).hexdigest()[:8]
+        did = "deadend_" + hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
         views.append(
             {
                 "id": did,
@@ -47,7 +134,7 @@ def _dead_end_views(dead_ends_md: str) -> list[dict[str, Any]]:
                 "bestScore": None,
                 "lastValidatedGen": None,
                 "supersededBy": None,
-                "source": "curator",
+                "source": "knowledge/dead_ends.md",
             }
         )
     return views
@@ -56,27 +143,22 @@ def _dead_end_views(dead_ends_md: str) -> list[dict[str, Any]]:
 def build_lifecycle(
     *,
     artifacts: ArtifactStore,
-    lesson_store: LessonStore,
     scenario: str,
     current_generation: int,
+    lesson_store: object | None = None,
     staleness_window: int = STALENESS_WINDOW,
 ) -> dict[str, Any]:
-    pending: list[dict[str, Any]] = []
+    del lesson_store, staleness_window
     active: list[dict[str, Any]] = []
     stale: list[dict[str, Any]] = []
-    for lesson in lesson_store.read_lessons(scenario):
-        if lesson.is_pending():
-            pending.append(_lesson_view(lesson, "pending"))
-            continue
-        if lesson.is_superseded():
-            continue
-        if lesson.is_stale(current_generation, staleness_window):
-            stale.append(_lesson_view(lesson, "stale"))
+    for lesson in _derived_lessons(artifacts, scenario):
+        if lesson.status == "stale":
+            stale.append(_lesson_view(lesson, current_generation))
         else:
-            active.append(_lesson_view(lesson, "active"))
+            active.append(_lesson_view(lesson, current_generation))
     return {
         "scenario": scenario,
-        "pending": pending,
+        "pending": [],
         "active": active,
         "stale": stale,
         "deadEnd": _dead_end_views(artifacts.read_dead_ends(scenario)),
@@ -85,59 +167,165 @@ def build_lifecycle(
 
 def approve_lesson(
     *,
-    lesson_store: LessonStore,
+    artifacts: ArtifactStore,
     scenario: str,
     lesson_id: str,
     current_generation: int,
+    lesson_store: object | None = None,
 ) -> str | None:
-    """Approve a pending lesson: flip it to active. Returns None if not pending."""
-    lessons = lesson_store.read_lessons(scenario)
-    target = next((les for les in lessons if les.id == lesson_id and les.is_pending()), None)
-    if target is None:
-        return None
-    target.meta.approval_status = "active"
-    # Never lower the validation generation: approving must not make a lesson stale
-    # (current_generation can be 0 when derived from an otherwise-empty store).
-    target.meta.last_validated_gen = max(current_generation, target.meta.generation, target.meta.last_validated_gen)
-    lesson_store.write_lessons(scenario, lessons)
-    return "active"
+    del lesson_store, current_generation
+    found, _text = _set_lesson_stale(artifacts, scenario, lesson_id, stale=False)
+    return "active" if found else None
 
 
-def reject_lesson(*, lesson_store: LessonStore, scenario: str, lesson_id: str) -> bool:
-    """Reject a PENDING lesson: remove it from the store. Returns False if the id is
-    not a pending lesson. Deleting an already-active lesson is a separate, explicit
-    action (curate "delete")."""
-    lessons = lesson_store.read_lessons(scenario)
-    target = next((les for les in lessons if les.id == lesson_id and les.is_pending()), None)
-    if target is None:
-        return False
-    lesson_store.write_lessons(scenario, [les for les in lessons if les.id != lesson_id])
-    return True
+def reject_lesson(
+    *,
+    artifacts: ArtifactStore,
+    scenario: str,
+    lesson_id: str,
+    lesson_store: object | None = None,
+) -> bool:
+    del lesson_store
+    found, _text = _remove_lesson(artifacts, scenario, lesson_id)
+    return found
 
 
 def curate_lesson(
     *,
     artifacts: ArtifactStore,
-    lesson_store: LessonStore,
     scenario: str,
     lesson_id: str,
     action: str,
     current_generation: int,
+    lesson_store: object | None = None,
 ) -> str | None:
-    """Manually mark an active lesson stale, move it to dead-end, or delete it."""
-    lessons = lesson_store.read_lessons(scenario)
-    target = next((les for les in lessons if les.id == lesson_id), None)
-    if target is None:
-        return None
+    del lesson_store, current_generation
     if action == "delete":
-        lesson_store.write_lessons(scenario, [les for les in lessons if les.id != lesson_id])
-        return "deleted"
+        found, _text = _remove_lesson(artifacts, scenario, lesson_id)
+        return "deleted" if found else None
     if action == "stale":
-        target.meta.last_validated_gen = -1
-        lesson_store.write_lessons(scenario, lessons)
-        return "stale"
+        found, _text = _set_lesson_stale(artifacts, scenario, lesson_id, stale=True)
+        return "stale" if found else None
     if action == "deadEnd":
-        artifacts.append_dead_end(scenario, target.text)
-        lesson_store.write_lessons(scenario, [les for les in lessons if les.id != lesson_id])
+        found, text = _remove_lesson(artifacts, scenario, lesson_id)
+        if not found or text is None:
+            return None
+        artifacts.append_dead_end(scenario, text)
         return "deadEnd"
     return None
+
+
+def _remove_lesson(artifacts: ArtifactStore, scenario: str, lesson_id: str) -> tuple[bool, str | None]:
+    found_playbook, text = _rewrite_playbook_lessons(artifacts, scenario, lesson_id, mode="remove")
+    found_skill, skill_text = _rewrite_skill_lessons(artifacts, scenario, lesson_id, mode="remove")
+    return found_playbook or found_skill, text or skill_text
+
+
+def _set_lesson_stale(
+    artifacts: ArtifactStore,
+    scenario: str,
+    lesson_id: str,
+    *,
+    stale: bool,
+) -> tuple[bool, str | None]:
+    mode: Literal["stale", "active"] = "stale" if stale else "active"
+    found_playbook, text = _rewrite_playbook_lessons(artifacts, scenario, lesson_id, mode=mode)
+    found_skill, skill_text = _rewrite_skill_lessons(artifacts, scenario, lesson_id, mode=mode)
+    return found_playbook or found_skill, text or skill_text
+
+
+def _rewrite_playbook_lessons(
+    artifacts: ArtifactStore,
+    scenario: str,
+    lesson_id: str,
+    *,
+    mode: Literal["remove", "stale", "active"],
+) -> tuple[bool, str | None]:
+    content = artifacts.read_playbook(scenario)
+    block = _playbook_block(content)
+    if block is None:
+        return False, None
+    start, end, body = block
+    found = False
+    changed = False
+    target_text: str | None = None
+    next_lines: list[str] = []
+    for line in body.splitlines():
+        parsed = _parse_lesson_line(line)
+        if parsed is None:
+            next_lines.append(line)
+            continue
+        text, is_stale = parsed
+        if _lesson_id(text) != lesson_id:
+            next_lines.append(line)
+            continue
+        found = True
+        target_text = target_text or text
+        if mode == "remove":
+            changed = True
+            continue
+        if mode == "active" and not is_stale:
+            next_lines.append(line)
+            continue
+        if mode == "stale" and is_stale:
+            next_lines.append(line)
+            continue
+        changed = True
+        bullet = f"- {text}"
+        if mode == "stale":
+            bullet = f"{bullet} {STALE_MARKER}"
+        next_lines.append(bullet)
+    if not found:
+        return False, None
+    if not changed:
+        return True, target_text
+    new_body = "\n".join(next_lines).strip()
+    prefix = content[:start].rstrip()
+    suffix = content[end:].lstrip()
+    new_content = f"{prefix}\n{new_body}\n{suffix}" if new_body else f"{prefix}\n{suffix}"
+    artifacts.write_playbook(scenario, new_content)
+    return True, target_text
+
+
+def _rewrite_skill_lessons(
+    artifacts: ArtifactStore,
+    scenario: str,
+    lesson_id: str,
+    *,
+    mode: Literal["remove", "stale", "active"],
+) -> tuple[bool, str | None]:
+    lines = artifacts.read_skill_lessons_raw(scenario)
+    if not lines:
+        return False, None
+    found = False
+    changed = False
+    target_text: str | None = None
+    next_lines: list[str] = []
+    for line in lines:
+        parsed = _parse_lesson_line(line)
+        if parsed is None:
+            next_lines.append(line)
+            continue
+        text, is_stale = parsed
+        if _lesson_id(text) != lesson_id:
+            next_lines.append(line)
+            continue
+        found = True
+        target_text = target_text or text
+        if mode == "remove":
+            changed = True
+            continue
+        if mode == "active" and not is_stale:
+            next_lines.append(line)
+            continue
+        if mode == "stale" and is_stale:
+            next_lines.append(line)
+            continue
+        changed = True
+        bullet = f"- {text}"
+        if mode == "stale":
+            bullet = f"{bullet} {STALE_MARKER}"
+        next_lines.append(bullet)
+    if changed:
+        artifacts.replace_skill_lessons(scenario, next_lines)
+    return found, target_text

--- a/autocontext/src/autocontext/loop/stage_helpers/freshness.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/freshness.py
@@ -37,34 +37,7 @@ def _load_fresh_skill_context(
     *,
     artifacts: ArtifactStore,
 ) -> tuple[str, str]:
-    lessons = artifacts.lesson_store.read_lessons(ctx.scenario_name)
-    if not lessons:
-        return artifacts.read_skills(ctx.scenario_name), ""
-
-    records: list[tuple[str, EvidenceFreshness]] = []
-    for lesson in lessons:
-        if lesson.is_pending():
-            # Pending lessons await human approval and must never enter prompts.
-            continue
-        records.append(
-            (
-                lesson.text.strip(),
-                EvidenceFreshness(
-                    item_id=lesson.id or lesson.text.strip(),
-                    support_count=1,
-                    last_validated_gen=max(lesson.meta.last_validated_gen, 0),
-                    confidence=max(0.0, min(1.0, lesson.meta.best_score)),
-                    created_at_gen=max(lesson.meta.generation, 0),
-                ),
-            )
-        )
-
-    items = [item for _, item in records]
-    active, _ = apply_freshness_decay(items, ctx.generation, _freshness_policy(ctx))
-    active_ids = {item.item_id for item in active}
-    active_text = "\n".join(text for text, item in records if item.item_id in active_ids).strip()
-    warnings = detect_stale_context(items, ctx.generation, _freshness_policy(ctx))
-    return active_text, _format_freshness_warning_block("Lesson", warnings)
+    return artifacts.read_skills(ctx.scenario_name), ""
 
 
 def _load_fresh_hint_context(

--- a/autocontext/src/autocontext/loop/stage_helpers/persistence_helpers.py
+++ b/autocontext/src/autocontext/loop/stage_helpers/persistence_helpers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from autocontext.agents.feedback_loops import AnalystRating
@@ -14,7 +13,6 @@ from autocontext.analytics.credit_assignment import (
     compute_change_vector,
 )
 from autocontext.knowledge.dead_end_manager import DeadEndEntry, consolidate_dead_ends
-from autocontext.knowledge.lessons import ApplicabilityMeta
 from autocontext.knowledge.progress import build_progress_snapshot
 from autocontext.loop.stage_helpers.context_loaders import _current_tool_names
 from autocontext.loop.stage_types import GenerationContext
@@ -199,8 +197,6 @@ def _persist_skill_note(
 
     if gate_decision == "advance":
         if ctx.require_playbook_approval:
-            if playbook_result == "pending":
-                _stage_pending_skill_lessons(ctx, artifacts=artifacts)
             return
         skill_lessons = outputs.coach_lessons
     else:
@@ -229,26 +225,6 @@ def _persist_skill_note(
             score=tournament.best_score,
         )
         artifacts.append_dead_end(ctx.scenario_name, entry.to_markdown())
-
-
-def _stage_pending_skill_lessons(ctx: GenerationContext, *, artifacts: ArtifactStore) -> None:
-    outputs = ctx.outputs
-    tournament = ctx.tournament
-    assert outputs is not None and tournament is not None
-    for line in outputs.coach_lessons.strip().splitlines():
-        text = line.strip()
-        if not text or text == "No new lessons.":
-            continue
-        artifacts.lesson_store.add_lesson(
-            ctx.scenario_name,
-            text if text.startswith("- ") else f"- {text}",
-            ApplicabilityMeta(
-                created_at=datetime.now(UTC).isoformat(),
-                generation=ctx.generation,
-                best_score=tournament.best_score,
-                approval_status="pending",
-            ),
-        )
 
 
 def _run_curator_consolidation(

--- a/autocontext/src/autocontext/server/knowledge_api.py
+++ b/autocontext/src/autocontext/server/knowledge_api.py
@@ -149,9 +149,8 @@ def _validate_scenario(scenario_name: str) -> str:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
-def _lesson_stores() -> tuple[Any, Any]:
-    ctx = _get_ctx()
-    return ctx.artifacts, ctx.artifacts.lesson_store
+def _artifacts() -> Any:
+    return _get_ctx().artifacts
 
 
 @router.get("/{scenario_name}/lifecycle")
@@ -160,26 +159,24 @@ def lesson_lifecycle(scenario_name: str) -> dict[str, Any]:
     from autocontext.knowledge.lifecycle import build_lifecycle
 
     scenario_name = _validate_scenario(scenario_name)
-    artifacts, store = _lesson_stores()
     return build_lifecycle(
-        artifacts=artifacts,
-        lesson_store=store,
+        artifacts=_artifacts(),
         scenario=scenario_name,
-        current_generation=store.current_generation(scenario_name),
+        current_generation=0,
     )
 
 
 @router.get("/{scenario_name}/playbook/pending")
 def pending_playbook_route(scenario_name: str) -> dict[str, Any]:
     scenario_name = _validate_scenario(scenario_name)
-    artifacts, _store = _lesson_stores()
+    artifacts = _artifacts()
     return cast(dict[str, Any], artifacts.read_pending_playbook(scenario_name))
 
 
 @router.post("/{scenario_name}/playbook/approve")
 def approve_playbook_route(scenario_name: str) -> dict[str, Any]:
     scenario_name = _validate_scenario(scenario_name)
-    artifacts, _store = _lesson_stores()
+    artifacts = _artifacts()
     result = cast(dict[str, Any], artifacts.approve_pending_playbook(scenario_name))
     if not result.get("ok"):
         raise HTTPException(status_code=404, detail="pending playbook not found")
@@ -189,7 +186,7 @@ def approve_playbook_route(scenario_name: str) -> dict[str, Any]:
 @router.post("/{scenario_name}/playbook/reject")
 def reject_playbook_route(scenario_name: str) -> dict[str, Any]:
     scenario_name = _validate_scenario(scenario_name)
-    artifacts, _store = _lesson_stores()
+    artifacts = _artifacts()
     result = cast(dict[str, Any], artifacts.reject_pending_playbook(scenario_name))
     if not result.get("ok"):
         raise HTTPException(status_code=404, detail="pending playbook not found")
@@ -198,16 +195,15 @@ def reject_playbook_route(scenario_name: str) -> dict[str, Any]:
 
 @router.post("/{scenario_name}/lessons/{lesson_id}/approve")
 def approve_lesson_route(scenario_name: str, lesson_id: str) -> dict[str, Any]:
-    """Approve a pending lesson (move it to active). 404 if the id is not pending."""
+    """Validate an existing live lesson. 404 if the derived id is missing."""
     from autocontext.knowledge.lifecycle import approve_lesson
 
     scenario_name = _validate_scenario(scenario_name)
-    _artifacts, store = _lesson_stores()
     status = approve_lesson(
-        lesson_store=store,
+        artifacts=_artifacts(),
         scenario=scenario_name,
         lesson_id=lesson_id,
-        current_generation=store.current_generation(scenario_name),
+        current_generation=0,
     )
     if status is None:
         raise HTTPException(status_code=404, detail="lesson not found")
@@ -216,12 +212,11 @@ def approve_lesson_route(scenario_name: str, lesson_id: str) -> dict[str, Any]:
 
 @router.post("/{scenario_name}/lessons/{lesson_id}/reject")
 def reject_lesson_route(scenario_name: str, lesson_id: str) -> dict[str, Any]:
-    """Reject a lesson (remove from pending and from active if present). 404 if not found."""
+    """Reject a lesson by removing its markdown bullet. 404 if not found."""
     from autocontext.knowledge.lifecycle import reject_lesson
 
     scenario_name = _validate_scenario(scenario_name)
-    _artifacts, store = _lesson_stores()
-    ok = reject_lesson(lesson_store=store, scenario=scenario_name, lesson_id=lesson_id)
+    ok = reject_lesson(artifacts=_artifacts(), scenario=scenario_name, lesson_id=lesson_id)
     if not ok:
         raise HTTPException(status_code=404, detail="lesson not found")
     return {"ok": True}
@@ -233,14 +228,12 @@ def curate_lesson_route(scenario_name: str, lesson_id: str, body: CurateRequest)
     from autocontext.knowledge.lifecycle import curate_lesson
 
     scenario_name = _validate_scenario(scenario_name)
-    artifacts, store = _lesson_stores()
     status = curate_lesson(
-        artifacts=artifacts,
-        lesson_store=store,
+        artifacts=_artifacts(),
         scenario=scenario_name,
         lesson_id=lesson_id,
         action=body.action,
-        current_generation=store.current_generation(scenario_name),
+        current_generation=0,
     )
     if status is None:
         raise HTTPException(status_code=404, detail="lesson not found")

--- a/autocontext/src/autocontext/storage/artifacts.py
+++ b/autocontext/src/autocontext/storage/artifacts.py
@@ -228,17 +228,6 @@ class ArtifactStore(PlaybookApprovalMethods, ArtifactGenerationPersistenceMethod
         reads the full SKILL.md (with bundled resources) on its own.
         """
         scenario = normalize_scenario_name_segment(scenario_name)
-        structured_lessons = self.lesson_store.read_lessons(scenario)
-        if structured_lessons:
-            current_generation = self.lesson_store.current_generation(scenario)
-            applicable = self.lesson_store.get_applicable_lessons(
-                scenario,
-                current_generation=current_generation,
-            )
-            if applicable:
-                return "\n".join(lesson.text.strip() for lesson in applicable).strip()
-            return ""
-
         skill_path = self._skill_dir(scenario) / "SKILL.md"
         if not skill_path.exists():
             return ""
@@ -249,9 +238,12 @@ class ArtifactStore(PlaybookApprovalMethods, ArtifactGenerationPersistenceMethod
             return ""
         after = content[start + len(marker):]
         next_heading = after.find("\n## ")
-        if next_heading != -1:
-            return after[:next_heading].strip()
-        return after.strip()
+        section = after[:next_heading] if next_heading != -1 else after
+        active_lines = [
+            line for line in section.splitlines()
+            if "<!-- autocontext:lesson-status=stale -->" not in line
+        ]
+        return "\n".join(active_lines).strip()
 
     def write_hints(self, scenario_name: str, content: str) -> None:
         """Persist coach hints so they survive run restarts."""

--- a/autocontext/src/autocontext/storage/playbook_approval.py
+++ b/autocontext/src/autocontext/storage/playbook_approval.py
@@ -72,21 +72,17 @@ class PlaybookApprovalMethods:
 
     def approve_pending_playbook(self: PlaybookApprovalHost, scenario_name: str) -> dict[str, Any]:
         pending = read_pending_playbook(self.knowledge_root, scenario_name)
-        result = approve_pending_playbook(self.knowledge_root, scenario_name, self.write_playbook, self.lesson_store)
+        result = approve_pending_playbook(self.knowledge_root, scenario_name, self.write_playbook)
         if result["ok"]:
             generation = int((pending.get("provenance") or {}).get("generation", 0))
-            lessons = [
-                lesson.text
-                for lesson in self.lesson_store.read_lessons(scenario_name)
-                if lesson.meta.generation == generation and lesson.meta.approval_status == "active"
-            ]
+            lessons = _extract_lesson_bullets(str(pending.get("content") or ""))
             if lessons:
                 self.persist_skill_note(scenario_name, generation, "advance", "\n".join(lessons))
             self._append_mutation(scenario_name, mutation_type="playbook_approved", payload={}, description="Playbook approved")
         return result
 
     def reject_pending_playbook(self: PlaybookApprovalHost, scenario_name: str) -> dict[str, Any]:
-        result = reject_pending_playbook(self.knowledge_root, scenario_name, self.lesson_store)
+        result = reject_pending_playbook(self.knowledge_root, scenario_name)
         if result["ok"]:
             self._append_mutation(scenario_name, mutation_type="playbook_rejected", payload={}, description="Playbook rejected")
         return result
@@ -152,15 +148,11 @@ def approve_pending_playbook(
     knowledge_root: Path,
     scenario_name: str,
     write_live_playbook: Callable[[str, str], None],
-    lesson_store: LessonApprovalStore | None = None,
 ) -> dict[str, Any]:
     pending = read_pending_playbook(knowledge_root, scenario_name)
     if not pending["has_pending"]:
         return {"ok": False, "status": "missing"}
-    provenance = pending["provenance"] or {}
     write_live_playbook(scenario_name, str(pending["content"]))
-    if lesson_store is not None:
-        _approve_lessons(lesson_store, scenario_name, int(provenance.get("generation", -1)))
     _clear_pending(resolve_scenario_root(knowledge_root, scenario_name))
     return {"ok": True, "status": "approved"}
 
@@ -168,37 +160,23 @@ def approve_pending_playbook(
 def reject_pending_playbook(
     knowledge_root: Path,
     scenario_name: str,
-    lesson_store: LessonApprovalStore | None = None,
 ) -> dict[str, Any]:
     pending = read_pending_playbook(knowledge_root, scenario_name)
     if not pending["has_pending"]:
         return {"ok": False, "status": "missing"}
-    provenance = pending["provenance"] or {}
-    if lesson_store is not None:
-        _drop_lessons(lesson_store, scenario_name, int(provenance.get("generation", -1)))
     _clear_pending(resolve_scenario_root(knowledge_root, scenario_name))
     return {"ok": True, "status": "rejected"}
 
 
-def _approve_lessons(lesson_store: LessonApprovalStore, scenario_name: str, generation: int) -> None:
-    lessons = lesson_store.read_lessons(scenario_name)
-    changed = False
-    for lesson in lessons:
-        if lesson.meta.approval_status == "pending" and lesson.meta.generation == generation:
-            lesson.meta.approval_status = "active"
-            lesson.meta.last_validated_gen = max(lesson.meta.last_validated_gen, generation)
-            changed = True
-    if changed:
-        lesson_store.write_lessons(scenario_name, lessons)
-
-
-def _drop_lessons(lesson_store: LessonApprovalStore, scenario_name: str, generation: int) -> None:
-    lessons = lesson_store.read_lessons(scenario_name)
-    kept = [
-        lesson for lesson in lessons if not (lesson.meta.approval_status == "pending" and lesson.meta.generation == generation)
-    ]
-    if len(kept) != len(lessons):
-        lesson_store.write_lessons(scenario_name, kept)
+def _extract_lesson_bullets(content: str) -> list[str]:
+    start_marker = "<!-- LESSONS_START -->"
+    end_marker = "<!-- LESSONS_END -->"
+    start = content.find(start_marker)
+    end = content.find(end_marker)
+    if start == -1 or end == -1 or end <= start:
+        return []
+    block = content[start + len(start_marker):end]
+    return [line.strip() for line in block.splitlines() if line.strip().startswith("-")]
 
 
 def _clear_pending(scenario_dir: Path) -> None:

--- a/autocontext/src/autocontext/storage/playbook_approval.py
+++ b/autocontext/src/autocontext/storage/playbook_approval.py
@@ -51,6 +51,14 @@ class PlaybookApprovalMethods:
         if not require_playbook_approval:
             self.write_playbook(scenario_name, content)
             return "live"
+        if read_pending_playbook(self.knowledge_root, scenario_name)["has_pending"]:
+            self._append_mutation(
+                scenario_name,
+                mutation_type="playbook_awaiting_approval",
+                payload={"generation": generation, "source_run_id": source_run_id},
+                description="Playbook update skipped while prior update awaits approval",
+            )
+            return "awaiting_approval"
         result = stage_pending_playbook(
             self.knowledge_root,
             scenario_name,

--- a/autocontext/src/autocontext/storage/playbook_approval.py
+++ b/autocontext/src/autocontext/storage/playbook_approval.py
@@ -50,6 +50,14 @@ class PlaybookApprovalMethods:
     ) -> str:
         if not require_playbook_approval:
             self.write_playbook(scenario_name, content)
+            if read_pending_playbook(self.knowledge_root, scenario_name)["has_pending"]:
+                reject_pending_playbook(self.knowledge_root, scenario_name)
+                self._append_mutation(
+                    scenario_name,
+                    mutation_type="playbook_pending_superseded",
+                    payload={"generation": generation, "source_run_id": source_run_id},
+                    description="Pending playbook cleared by live auto-mode update",
+                )
             return "live"
         if read_pending_playbook(self.knowledge_root, scenario_name)["has_pending"]:
             self._append_mutation(

--- a/autocontext/tests/test_knowledge_lifecycle_api.py
+++ b/autocontext/tests/test_knowledge_lifecycle_api.py
@@ -4,17 +4,13 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from autocontext.knowledge.lessons import ApplicabilityMeta, Lesson
-
 
 @pytest.fixture
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     import autocontext.server.knowledge_api as api
 
-    # Point the engine's knowledge/skills roots at tmp_path via the real AUTOCONTEXT_* env vars.
     monkeypatch.setenv("AUTOCONTEXT_KNOWLEDGE_ROOT", str(tmp_path / "knowledge"))
     monkeypatch.setenv("AUTOCONTEXT_SKILLS_ROOT", str(tmp_path / "skills"))
-    # Reset the module-level lazy singletons so they re-read the patched settings.
     api._ctx = None
     api._solve_mgr = None
     app = FastAPI()
@@ -22,54 +18,68 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     return TestClient(app)
 
 
+def _playbook(*lessons: str) -> str:
+    bullets = "\n".join(f"- {lesson}" for lesson in lessons)
+    return f"intro\n<!-- LESSONS_START -->\n{bullets}\n<!-- LESSONS_END -->\noutro"
+
+
 def _seed(client: TestClient) -> None:
     import autocontext.server.knowledge_api as api
 
     ctx = api._get_ctx()
-    ctx.artifacts.lesson_store.write_lessons(
-        "scn",
-        [
-            Lesson(id="a", text="fresh", meta=ApplicabilityMeta(created_at="", generation=1, best_score=0.5)),
-            Lesson(
-                id="p",
-                text="held",
-                meta=ApplicabilityMeta(created_at="", generation=1, best_score=0.5, approval_status="pending"),
-            ),
-        ],
-    )
+    ctx.artifacts.write_playbook("scn", _playbook("fresh", "held"))
 
 
-def test_lifecycle_endpoint(client: TestClient) -> None:
+def test_lifecycle_endpoint_derives_from_playbook(client: TestClient) -> None:
     _seed(client)
     resp = client.get("/api/knowledge/scn/lifecycle")
     assert resp.status_code == 200
     body = resp.json()
-    assert {les["text"] for les in body["active"]} == {"fresh"}
-    assert {les["text"] for les in body["pending"]} == {"held"}
+    assert {les["text"] for les in body["active"]} == {"fresh", "held"}
+    assert body["pending"] == []
 
 
-def test_approve_endpoint(client: TestClient) -> None:
+def test_approve_endpoint_is_noop_for_live_lesson(client: TestClient) -> None:
     _seed(client)
-    resp = client.post("/api/knowledge/scn/lessons/p/approve")
+    lesson_id = client.get("/api/knowledge/scn/lifecycle").json()["active"][0]["id"]
+    resp = client.post(f"/api/knowledge/scn/lessons/{lesson_id}/approve")
     assert resp.status_code == 200
     assert resp.json() == {"ok": True, "status": "active"}
-    after = client.get("/api/knowledge/scn/lifecycle").json()
-    assert {les["text"] for les in after["active"]} == {"fresh", "held"}
-    assert after["pending"] == []
 
 
-def test_reject_endpoint(client: TestClient) -> None:
+def test_reject_endpoint_removes_live_lesson(client: TestClient) -> None:
     _seed(client)
-    resp = client.post("/api/knowledge/scn/lessons/p/reject")
+    lesson = next(
+        les for les in client.get("/api/knowledge/scn/lifecycle").json()["active"] if les["text"] == "held"
+    )
+    resp = client.post(f"/api/knowledge/scn/lessons/{lesson['id']}/reject")
     assert resp.status_code == 200 and resp.json()["ok"] is True
-    assert client.get("/api/knowledge/scn/lifecycle").json()["pending"] == []
+    after = client.get("/api/knowledge/scn/lifecycle").json()
+    assert {les["text"] for les in after["active"]} == {"fresh"}
 
 
 def test_curate_delete_endpoint(client: TestClient) -> None:
     _seed(client)
-    resp = client.post("/api/knowledge/scn/lessons/a/curate", json={"action": "delete"})
+    lesson_id = client.get("/api/knowledge/scn/lifecycle").json()["active"][0]["id"]
+    resp = client.post(f"/api/knowledge/scn/lessons/{lesson_id}/curate", json={"action": "delete"})
     assert resp.status_code == 200 and resp.json() == {"ok": True, "status": "deleted"}
-    assert client.get("/api/knowledge/scn/lifecycle").json()["active"] == []
+
+
+def test_curate_stale_endpoint(client: TestClient) -> None:
+    _seed(client)
+    lesson_id = client.get("/api/knowledge/scn/lifecycle").json()["active"][0]["id"]
+    resp = client.post(f"/api/knowledge/scn/lessons/{lesson_id}/curate", json={"action": "stale"})
+    assert resp.status_code == 200 and resp.json() == {"ok": True, "status": "stale"}
+    after = client.get("/api/knowledge/scn/lifecycle").json()
+    assert after["stale"]
+
+
+def test_curate_dead_end_endpoint(client: TestClient) -> None:
+    _seed(client)
+    lesson_id = client.get("/api/knowledge/scn/lifecycle").json()["active"][0]["id"]
+    resp = client.post(f"/api/knowledge/scn/lessons/{lesson_id}/curate", json={"action": "deadEnd"})
+    assert resp.status_code == 200 and resp.json() == {"ok": True, "status": "deadEnd"}
+    assert client.get("/api/knowledge/scn/lifecycle").json()["deadEnd"]
 
 
 def test_curate_missing_is_404(client: TestClient) -> None:
@@ -79,7 +89,6 @@ def test_curate_missing_is_404(client: TestClient) -> None:
 
 
 def test_path_traversal_rejected(client: TestClient, tmp_path: Path) -> None:
-    # %2E%2E decodes to ".." — must be rejected, not write files above knowledge_root.
     resp = client.post("/api/knowledge/%2E%2E/lessons/p/approve")
     assert resp.status_code != 200
     assert not (tmp_path / "pending_lessons.json").exists()

--- a/autocontext/tests/test_lesson_applicability.py
+++ b/autocontext/tests/test_lesson_applicability.py
@@ -790,12 +790,13 @@ class TestArtifactStoreLessonIntegration:
         lessons = artifact_store.lesson_store.read_lessons("grid_ctf")
         assert len(lessons) == 1
 
-    def test_read_skills_prefers_applicable_structured_lessons(self, artifact_store) -> None:
+    def test_read_skills_ignores_structured_lessons_shadow(self, artifact_store) -> None:
         from autocontext.knowledge.lessons import ApplicabilityMeta
 
+        artifact_store.persist_skill_note("grid_ctf", 4, "advance", "- markdown source")
         artifact_store.lesson_store.add_lesson(
             "grid_ctf",
-            "- still valid",
+            "- structured shadow",
             ApplicabilityMeta(
                 created_at="2026-03-13T10:00:00Z",
                 generation=4,
@@ -803,17 +804,7 @@ class TestArtifactStoreLessonIntegration:
                 last_validated_gen=4,
             ),
         )
-        artifact_store.lesson_store.add_lesson(
-            "grid_ctf",
-            "- invalidated by schema change",
-            ApplicabilityMeta(
-                created_at="2026-03-13T11:00:00Z",
-                generation=4,
-                best_score=0.72,
-                last_validated_gen=-1,
-            ),
-        )
 
         skills = artifact_store.read_skills("grid_ctf")
-        assert "- still valid" in skills
-        assert "- invalidated by schema change" not in skills
+        assert "- markdown source" in skills
+        assert "- structured shadow" not in skills

--- a/autocontext/tests/test_lesson_lifecycle.py
+++ b/autocontext/tests/test_lesson_lifecycle.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from autocontext.knowledge.lessons import ApplicabilityMeta, Lesson, LessonStore
 from autocontext.knowledge.lifecycle import (
     approve_lesson,
     build_lifecycle,
@@ -10,139 +9,125 @@ from autocontext.knowledge.lifecycle import (
 from autocontext.storage.artifacts import ArtifactStore
 
 
-def _meta(gen: int, approval_status: str = "active") -> ApplicabilityMeta:
-    return ApplicabilityMeta(created_at="", generation=gen, best_score=0.5, approval_status=approval_status)
-
-
-def _stores(tmp_path: Path) -> tuple[ArtifactStore, LessonStore]:
-    artifacts = ArtifactStore(
+def _store(tmp_path: Path) -> ArtifactStore:
+    return ArtifactStore(
         runs_root=tmp_path / "runs",
         knowledge_root=tmp_path / "knowledge",
         skills_root=tmp_path / "skills",
         claude_skills_path=tmp_path / "claude_skills",
     )
-    return artifacts, artifacts.lesson_store
 
 
-def test_build_lifecycle_buckets(tmp_path: Path) -> None:
-    artifacts, store = _stores(tmp_path)
-    store.write_lessons(
-        "scn",
-        [
-            Lesson(id="a", text="fresh", meta=_meta(20)),
-            Lesson(id="b", text="old", meta=_meta(2)),
-            Lesson(id="p", text="held", meta=_meta(20, approval_status="pending")),
-        ],
-    )
+def _playbook(*lessons: str) -> str:
+    bullets = "\n".join(f"- {lesson}" for lesson in lessons)
+    return f"intro\n<!-- LESSONS_START -->\n{bullets}\n<!-- LESSONS_END -->\noutro"
+
+
+def test_build_lifecycle_derives_from_playbook_and_skill_markdown(tmp_path: Path) -> None:
+    artifacts = _store(tmp_path)
+    artifacts.write_playbook("scn", _playbook("fresh", "shared"))
+    artifacts.persist_skill_note("scn", 0, "advance", "- shared\n- skill only")
     artifacts.append_dead_end("scn", "tried Y, lost")
-    view = build_lifecycle(artifacts=artifacts, lesson_store=store, scenario="scn", current_generation=20)
-    assert [v["text"] for v in view["active"]] == ["fresh"]
-    assert [v["text"] for v in view["stale"]] == ["old"]
-    assert [v["text"] for v in view["pending"]] == ["held"]
-    assert view["deadEnd"] and "tried Y" in view["deadEnd"][0]["text"]
-    assert view["deadEnd"][0]["id"].startswith("deadend_")
 
+    view = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=20)
 
-def test_approve_flips_pending_to_active(tmp_path: Path) -> None:
-    _artifacts, store = _stores(tmp_path)
-    store.write_lessons("scn", [Lesson(id="p", text="held", meta=_meta(5, approval_status="pending"))])
-    assert approve_lesson(lesson_store=store, scenario="scn", lesson_id="p", current_generation=9) == "active"
-    lesson = store.read_lessons("scn")[0]
-    assert lesson.meta.approval_status == "active"
-    assert lesson.meta.last_validated_gen == 9
-    # idempotent: now active, not pending -> None
-    assert approve_lesson(lesson_store=store, scenario="scn", lesson_id="p", current_generation=9) is None
-
-
-def test_approve_non_pending_is_none(tmp_path: Path) -> None:
-    _artifacts, store = _stores(tmp_path)
-    store.write_lessons("scn", [Lesson(id="a", text="already active", meta=_meta(5))])
-    assert approve_lesson(lesson_store=store, scenario="scn", lesson_id="a", current_generation=9) is None
-
-
-def test_approve_does_not_lower_validation_generation(tmp_path: Path) -> None:
-    # Approving must never make a lesson stale: a gen-20 pending lesson approved
-    # with a lower current_generation (e.g. 0 from an otherwise-empty store) keeps
-    # its validation generation and stays active.
-    artifacts, store = _stores(tmp_path)
-    meta = ApplicabilityMeta(created_at="", generation=20, best_score=0.5, approval_status="pending")
-    meta.last_validated_gen = 20
-    store.write_lessons("scn", [Lesson(id="p", text="held", meta=meta)])
-    assert approve_lesson(lesson_store=store, scenario="scn", lesson_id="p", current_generation=0) == "active"
-    assert store.read_lessons("scn")[0].meta.last_validated_gen == 20
-    view = build_lifecycle(artifacts=artifacts, lesson_store=store, scenario="scn", current_generation=20)
-    assert [v["text"] for v in view["active"]] == ["held"]
+    assert [v["text"] for v in view["active"]] == ["fresh", "shared", "skill only"]
+    assert view["pending"] == []
     assert view["stale"] == []
+    assert view["deadEnd"] and "tried Y" in view["deadEnd"][0]["text"]
+    assert view["active"][0]["id"].startswith("lesson_")
+    assert view["active"][0]["source"].endswith("playbook.md")
 
 
-def test_reject_removes_pending_only(tmp_path: Path) -> None:
-    _artifacts, store = _stores(tmp_path)
-    store.write_lessons("scn", [Lesson(id="x", text="held", meta=_meta(5, approval_status="pending"))])
-    assert reject_lesson(lesson_store=store, scenario="scn", lesson_id="x") is True
-    assert store.read_lessons("scn") == []
-    assert reject_lesson(lesson_store=store, scenario="scn", lesson_id="x") is False
+def test_read_skills_ignores_structured_lesson_store(tmp_path: Path) -> None:
+    from autocontext.knowledge.lessons import ApplicabilityMeta
+
+    artifacts = _store(tmp_path)
+    artifacts.persist_skill_note("scn", 0, "advance", "- markdown lesson")
+    artifacts.lesson_store.add_lesson(
+        "scn",
+        "- stale structured shadow",
+        ApplicabilityMeta(created_at="", generation=1, best_score=0.1),
+    )
+
+    skills = artifacts.read_skills("scn")
+
+    assert "markdown lesson" in skills
+    assert "stale structured shadow" not in skills
 
 
-def test_reject_does_not_delete_active(tmp_path: Path) -> None:
-    # reject only removes pending lessons; deleting an active lesson must go through
-    # the explicit curate "delete" action.
-    _artifacts, store = _stores(tmp_path)
-    store.write_lessons("scn", [Lesson(id="a", text="active one", meta=_meta(5))])
-    assert reject_lesson(lesson_store=store, scenario="scn", lesson_id="a") is False
-    assert [v.text for v in store.read_lessons("scn")] == ["active one"]
+def test_approve_is_noop_for_derived_live_lesson(tmp_path: Path) -> None:
+    artifacts = _store(tmp_path)
+    artifacts.write_playbook("scn", _playbook("already live"))
+    [lesson] = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=1)["active"]
+
+    assert approve_lesson(artifacts=artifacts, scenario="scn", lesson_id=lesson["id"], current_generation=1) == "active"
+    assert artifacts._playbook_store("scn").version_count("playbook.md") == 0
+    assert approve_lesson(artifacts=artifacts, scenario="scn", lesson_id="missing", current_generation=1) is None
 
 
-def test_curate_actions(tmp_path: Path) -> None:
-    artifacts, store = _stores(tmp_path)
-    store.write_lessons("scn", [Lesson(id="x", text="lesson", meta=_meta(5))])
+def test_reject_and_delete_remove_markdown_lesson_and_version_playbook(tmp_path: Path) -> None:
+    artifacts = _store(tmp_path)
+    artifacts.write_playbook("scn", _playbook("remove me", "keep me"))
+    active = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=1)["active"]
+    [target] = [v for v in active if v["text"] == "remove me"]
+
+    assert reject_lesson(artifacts=artifacts, scenario="scn", lesson_id=target["id"]) is True
+
+    assert "remove me" not in artifacts.read_playbook("scn")
+    assert "keep me" in artifacts.read_playbook("scn")
+    assert artifacts._playbook_store("scn").version_count("playbook.md") == 1
+    assert reject_lesson(artifacts=artifacts, scenario="scn", lesson_id=target["id"]) is False
+
+
+def test_curate_stale_annotates_without_deleting_or_prompting(tmp_path: Path) -> None:
+    artifacts = _store(tmp_path)
+    artifacts.write_playbook("scn", _playbook("stale me"))
+    artifacts.persist_skill_note("scn", 0, "advance", "- stale me")
+    [lesson] = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=1)["active"]
+
     assert (
         curate_lesson(
-            artifacts=artifacts, lesson_store=store, scenario="scn", lesson_id="x", action="stale", current_generation=9
+            artifacts=artifacts,
+            scenario="scn",
+            lesson_id=lesson["id"],
+            action="stale",
+            current_generation=9,
         )
         == "stale"
     )
-    assert store.read_lessons("scn")[0].meta.last_validated_gen == -1
 
-    store.write_lessons("scn", [Lesson(id="y", text="dead lesson", meta=_meta(5))])
+    view = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=9)
+    assert view["active"] == []
+    assert [v["text"] for v in view["stale"]] == ["stale me"]
+    assert "stale me" in artifacts.read_playbook("scn")
+    assert "stale me" not in artifacts.read_skills("scn")
+
+
+def test_curate_dead_end_moves_markdown_lesson(tmp_path: Path) -> None:
+    artifacts = _store(tmp_path)
+    artifacts.write_playbook("scn", _playbook("dead lesson"))
+    [lesson] = build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=1)["active"]
+
     assert (
         curate_lesson(
-            artifacts=artifacts, lesson_store=store, scenario="scn", lesson_id="y", action="deadEnd", current_generation=9
+            artifacts=artifacts,
+            scenario="scn",
+            lesson_id=lesson["id"],
+            action="deadEnd",
+            current_generation=9,
         )
         == "deadEnd"
     )
-    assert store.read_lessons("scn") == []
+
+    assert "dead lesson" not in artifacts.read_playbook("scn")
     assert "dead lesson" in artifacts.read_dead_ends("scn")
-
-    store.write_lessons("scn", [Lesson(id="z", text="gone", meta=_meta(5))])
-    assert (
-        curate_lesson(
-            artifacts=artifacts, lesson_store=store, scenario="scn", lesson_id="z", action="delete", current_generation=9
-        )
-        == "deleted"
-    )
-    assert store.read_lessons("scn") == []
-
-    assert (
-        curate_lesson(
-            artifacts=artifacts, lesson_store=store, scenario="scn", lesson_id="missing", action="delete", current_generation=9
-        )
-        is None
-    )
+    assert build_lifecycle(artifacts=artifacts, scenario="scn", current_generation=9)["active"] == []
 
 
-def test_pending_excluded_from_prompt_skills(tmp_path: Path) -> None:
-    # Unapproved (pending) lessons must never enter prompt/skill loading, even though
-    # /lifecycle surfaces them under "pending".
-    artifacts, store = _stores(tmp_path)
-    store.write_lessons(
-        "scn",
-        [
-            Lesson(id="a", text="approved lesson", meta=_meta(20)),
-            Lesson(id="p", text="UNAPPROVED secret", meta=_meta(20, approval_status="pending")),
-        ],
-    )
-    applicable = store.get_applicable_lessons("scn", current_generation=20)
-    assert [v.text for v in applicable] == ["approved lesson"]
-    skills_text = artifacts.read_skills("scn")
-    assert "approved lesson" in skills_text
-    assert "UNAPPROVED secret" not in skills_text
+def test_curate_missing_or_unknown_action_returns_none(tmp_path: Path) -> None:
+    artifacts = _store(tmp_path)
+    artifacts.write_playbook("scn", _playbook("keep"))
+
+    assert curate_lesson(artifacts=artifacts, scenario="scn", lesson_id="missing", action="delete", current_generation=1) is None
+    assert curate_lesson(artifacts=artifacts, scenario="scn", lesson_id="missing", action="bad", current_generation=1) is None

--- a/autocontext/tests/test_playbook_approval_gate.py
+++ b/autocontext/tests/test_playbook_approval_gate.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 
 def _store(tmp_path: Path):
     from autocontext.storage.artifacts import ArtifactStore
@@ -74,18 +72,18 @@ def test_approve_pending_playbook_promotes_and_syncs_lessons_to_skill(tmp_path: 
     assert store.lesson_store.read_lessons("grid_ctf") == []
 
 
-def test_pending_playbook_cannot_be_overwritten_before_review(tmp_path: Path) -> None:
+def test_pending_playbook_skips_new_staging_without_failing_run(tmp_path: Path) -> None:
     store = _store(tmp_path)
     store.write_playbook("grid_ctf", "approved playbook")
     store.persist_generation(**_persist_args(), require_playbook_approval=True)
     args = _persist_args() | {"generation_index": 3, "coach_playbook": "new pending playbook"}
 
-    with pytest.raises(ValueError, match="pending playbook already exists"):
-        store.persist_generation(**args, require_playbook_approval=True)
+    assert store.persist_generation(**args, require_playbook_approval=True) == "awaiting_approval"
 
     pending = store.read_pending_playbook("grid_ctf")
     assert pending["content"] == _pending_playbook().strip() + "\n"
     assert pending["provenance"]["generation"] == 2
+    assert "new pending playbook" not in pending["content"]
 
 
 def test_pending_skill_lessons_do_not_reach_skill_prompt_until_approval(tmp_path: Path) -> None:

--- a/autocontext/tests/test_playbook_approval_gate.py
+++ b/autocontext/tests/test_playbook_approval_gate.py
@@ -16,6 +16,10 @@ def _store(tmp_path: Path):
     )
 
 
+def _pending_playbook() -> str:
+    return "intro\n<!-- LESSONS_START -->\n- approved pending lesson\n<!-- LESSONS_END -->\noutro"
+
+
 def _persist_args() -> dict[str, object]:
     return {
         "run_id": "run-approval",
@@ -26,7 +30,7 @@ def _persist_args() -> dict[str, object]:
         "coach_md": "coach",
         "architect_md": "architect",
         "scenario_name": "grid_ctf",
-        "coach_playbook": "pending playbook",
+        "coach_playbook": _pending_playbook(),
     }
 
 
@@ -36,7 +40,7 @@ def test_playbook_approval_default_off_writes_live(tmp_path: Path) -> None:
 
     store.persist_generation(**_persist_args())
 
-    assert store.read_playbook("grid_ctf") == "pending playbook\n"
+    assert store.read_playbook("grid_ctf") == _pending_playbook().strip() + "\n"
     assert store.read_pending_playbook("grid_ctf")["has_pending"] is False
 
 
@@ -50,32 +54,24 @@ def test_playbook_approval_stages_pending_without_touching_live(tmp_path: Path) 
     assert store.read_playbook("grid_ctf") == "approved playbook\n"
     pending = store.read_pending_playbook("grid_ctf")
     assert pending["has_pending"] is True
-    assert pending["content"] == "pending playbook\n"
+    assert pending["content"] == _pending_playbook().strip() + "\n"
     assert "-approved playbook" in pending["diff"]
-    assert "+pending playbook" in pending["diff"]
+    assert "+intro" in pending["diff"]
     assert pending["provenance"]["source_run_id"] == "run-approval"
     assert pending["provenance"]["generation"] == 2
 
 
-def test_approve_pending_playbook_promotes_and_activates_same_generation_lessons(tmp_path: Path) -> None:
-    from autocontext.knowledge.lessons import ApplicabilityMeta
-
+def test_approve_pending_playbook_promotes_and_syncs_lessons_to_skill(tmp_path: Path) -> None:
     store = _store(tmp_path)
     store.write_playbook("grid_ctf", "approved playbook")
-    store.lesson_store.add_lesson(
-        "grid_ctf",
-        "held lesson",
-        ApplicabilityMeta(created_at="", generation=2, best_score=0.7, approval_status="pending"),
-    )
     store.persist_generation(**_persist_args(), require_playbook_approval=True)
 
     assert store.approve_pending_playbook("grid_ctf") == {"ok": True, "status": "approved"}
 
-    assert store.read_playbook("grid_ctf") == "pending playbook\n"
+    assert store.read_playbook("grid_ctf") == _pending_playbook().strip() + "\n"
     assert store.read_pending_playbook("grid_ctf")["has_pending"] is False
-    lessons = store.lesson_store.read_lessons("grid_ctf")
-    assert [lesson.text for lesson in lessons] == ["held lesson"]
-    assert lessons[0].meta.approval_status == "active"
+    assert "approved pending lesson" in store.read_skills("grid_ctf")
+    assert store.lesson_store.read_lessons("grid_ctf") == []
 
 
 def test_pending_playbook_cannot_be_overwritten_before_review(tmp_path: Path) -> None:
@@ -88,7 +84,7 @@ def test_pending_playbook_cannot_be_overwritten_before_review(tmp_path: Path) ->
         store.persist_generation(**args, require_playbook_approval=True)
 
     pending = store.read_pending_playbook("grid_ctf")
-    assert pending["content"] == "pending playbook\n"
+    assert pending["content"] == _pending_playbook().strip() + "\n"
     assert pending["provenance"]["generation"] == 2
 
 
@@ -123,7 +119,7 @@ def test_pending_skill_lessons_do_not_reach_skill_prompt_until_approval(tmp_path
         strategy={},
         analysis_markdown="",
         coach_markdown="",
-        coach_playbook="pending playbook",
+        coach_playbook=_pending_playbook(),
         coach_lessons="- unapproved lesson",
         coach_competitor_hints="",
         architect_markdown="",
@@ -135,30 +131,22 @@ def test_pending_skill_lessons_do_not_reach_skill_prompt_until_approval(tmp_path
     _persist_skill_note(ctx, artifacts=store, playbook_result=playbook_result)
 
     assert "unapproved lesson" not in store.read_skills("grid_ctf")
-    [lesson] = store.lesson_store.read_lessons("grid_ctf")
-    assert lesson.text == "- unapproved lesson"
-    assert lesson.meta.approval_status == "pending"
+    assert store.lesson_store.read_lessons("grid_ctf") == []
 
     store.approve_pending_playbook("grid_ctf")
 
-    assert "unapproved lesson" in store.read_skills("grid_ctf")
-    assert store.lesson_store.read_lessons("grid_ctf")[0].meta.approval_status == "active"
+    assert "approved pending lesson" in store.read_skills("grid_ctf")
+    assert "unapproved lesson" not in store.read_skills("grid_ctf")
 
 
-def test_reject_pending_playbook_discards_and_drops_same_generation_lessons(tmp_path: Path) -> None:
-    from autocontext.knowledge.lessons import ApplicabilityMeta
-
+def test_reject_pending_playbook_discards_without_touching_skill_or_lesson_store(tmp_path: Path) -> None:
     store = _store(tmp_path)
     store.write_playbook("grid_ctf", "approved playbook")
-    store.lesson_store.add_lesson(
-        "grid_ctf",
-        "held lesson",
-        ApplicabilityMeta(created_at="", generation=2, best_score=0.7, approval_status="pending"),
-    )
     store.persist_generation(**_persist_args(), require_playbook_approval=True)
 
     assert store.reject_pending_playbook("grid_ctf") == {"ok": True, "status": "rejected"}
 
     assert store.read_playbook("grid_ctf") == "approved playbook\n"
     assert store.read_pending_playbook("grid_ctf")["has_pending"] is False
+    assert store.read_skills("grid_ctf") == ""
     assert store.lesson_store.read_lessons("grid_ctf") == []

--- a/autocontext/tests/test_playbook_approval_gate.py
+++ b/autocontext/tests/test_playbook_approval_gate.py
@@ -42,6 +42,20 @@ def test_playbook_approval_default_off_writes_live(tmp_path: Path) -> None:
     assert store.read_pending_playbook("grid_ctf")["has_pending"] is False
 
 
+def test_auto_mode_supersedes_stale_pending_approval(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.write_playbook("grid_ctf", "approved playbook")
+    store.persist_generation(**_persist_args(), require_playbook_approval=True)
+    args = _persist_args() | {"generation_index": 3, "coach_playbook": "auto new"}
+
+    assert store.persist_generation(**args) == "live"
+
+    assert store.read_playbook("grid_ctf") == "auto new\n"
+    assert store.read_pending_playbook("grid_ctf")["has_pending"] is False
+    assert store.approve_pending_playbook("grid_ctf") == {"ok": False, "status": "missing"}
+    assert store.read_playbook("grid_ctf") == "auto new\n"
+
+
 def test_playbook_approval_stages_pending_without_touching_live(tmp_path: Path) -> None:
     store = _store(tmp_path)
     store.write_playbook("grid_ctf", "approved playbook")

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - [Campaign mode report](campaign-mode-report.md)
 - [Goal run report](goal-run-report.md)
 - [Playbook approval gate](playbook-approval-gate.md)
+- [Derived lesson curation](derived-lesson-curation.md)
 - [Browser exploration contract](browser-exploration-contract.md)
 - [OpenTelemetry bridge](opentelemetry-bridge.md)
 - [Background session domain and parity contract](background-session-domain.md)

--- a/docs/derived-lesson-curation.md
+++ b/docs/derived-lesson-curation.md
@@ -1,0 +1,32 @@
+# Derived lesson curation
+
+AC-827 makes the live markdown artifacts the lesson source of truth.
+
+## Source of truth
+
+Lessons are derived from:
+
+- `knowledge/<scenario>/playbook.md` between `<!-- LESSONS_START -->` and `<!-- LESSONS_END -->`
+- `skills/<scenario>-ops/SKILL.md` under `## Operational Lessons` when a lesson exists only in the skill
+
+`lessons.json` is no longer read by prompt loading or lifecycle curation. The old `LessonStore` remains as a deprecated compatibility type, but new code should not write lesson text there.
+
+## Lifecycle actions
+
+`GET /api/knowledge/{scenario}/lifecycle` returns a derived view with stable hash ids and buckets:
+
+- `active`: live markdown bullets
+- `stale`: live markdown bullets annotated with `<!-- autocontext:lesson-status=stale -->`
+- `pending`: always empty; playbook approval is handled by the playbook pending artifact
+- `deadEnd`: entries from `dead_ends.md`
+
+Actions mutate markdown, not a parallel store:
+
+- `approve`: no-op validation for an existing live lesson; removes the stale marker if present
+- `reject` / `curate:delete`: remove the bullet from playbook/SKILL markdown
+- `curate:stale`: add the stale marker without deleting the bullet
+- `curate:deadEnd`: append the lesson text to `dead_ends.md` and remove the bullet
+
+## AC-236 metadata decision
+
+The optional AC-236 applicability sidecar is intentionally dropped for now. The curator's consolidation and the explicit stale marker cover the current operator workflow without creating a second authoritative lesson schema.

--- a/docs/playbook-approval-gate.md
+++ b/docs/playbook-approval-gate.md
@@ -12,7 +12,9 @@ When `require_playbook_approval` is false, curator-approved playbooks are writte
 ## API
 
 - `GET /api/knowledge/{scenario}/playbook/pending` returns pending content, diff, and provenance.
-- `POST /api/knowledge/{scenario}/playbook/approve` promotes pending content to `playbook.md`, clears pending files, and activates same-generation pending lessons.
-- `POST /api/knowledge/{scenario}/playbook/reject` clears pending files and drops same-generation pending lessons.
+- `POST /api/knowledge/{scenario}/playbook/approve` promotes pending content to `playbook.md` and clears pending files. Python also syncs lesson bullets from the approved pending playbook into `SKILL.md`.
+- `POST /api/knowledge/{scenario}/playbook/reject` clears pending files without changing the approved playbook or skill lessons.
+
+The lesson lifecycle `pending` bucket is now always empty; lesson curation is derived from approved playbook/SKILL markdown, not a structured pending lesson store.
 
 The wire flag `require_lesson_approval` is accepted as a deprecated alias for one compatibility window; new clients should send `require_playbook_approval`.

--- a/docs/playbook-approval-gate.md
+++ b/docs/playbook-approval-gate.md
@@ -2,7 +2,7 @@
 
 AC-826 makes the optional human hold gate operate on the artifact that drives the next prompt: `playbook.md`.
 
-When `require_playbook_approval` is false, curator-approved playbooks are written live as before. When it is true, the engine writes:
+When `require_playbook_approval` is false, curator-approved playbooks are written live as before and any stale `playbook.pending.*` proposal is cleared. When it is true, the engine writes:
 
 - `knowledge/<scenario>/playbook.pending.md`
 - `knowledge/<scenario>/playbook.pending.json`

--- a/ts/src/knowledge/artifact-store.ts
+++ b/ts/src/knowledge/artifact-store.ts
@@ -15,7 +15,6 @@ import {
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { HookEvents, type HookBus } from "../extensions/index.js";
-import { LessonStore } from "./lessons.js";
 import { PlaybookManager, EMPTY_PLAYBOOK_SENTINEL } from "./playbook.js";
 import {
   approvePendingPlaybook,
@@ -227,23 +226,12 @@ export class ArtifactStore {
     return readPendingPlaybook(this.knowledgeRoot, scenarioName);
   }
 
-  approvePendingPlaybook(
-    scenarioName: string,
-    lessonStore = new LessonStore(this.knowledgeRoot),
-  ): { ok: boolean; status: "approved" | "missing" } {
-    return approvePendingPlaybook(
-      this.knowledgeRoot,
-      scenarioName,
-      this.writePlaybook.bind(this),
-      lessonStore,
-    );
+  approvePendingPlaybook(scenarioName: string): { ok: boolean; status: "approved" | "missing" } {
+    return approvePendingPlaybook(this.knowledgeRoot, scenarioName, this.writePlaybook.bind(this));
   }
 
-  rejectPendingPlaybook(
-    scenarioName: string,
-    lessonStore = new LessonStore(this.knowledgeRoot),
-  ): { ok: boolean; status: "rejected" | "missing" } {
-    return rejectPendingPlaybook(this.knowledgeRoot, scenarioName, lessonStore);
+  rejectPendingPlaybook(scenarioName: string): { ok: boolean; status: "rejected" | "missing" } {
+    return rejectPendingPlaybook(this.knowledgeRoot, scenarioName);
   }
 
   readDeadEnds(scenarioName: string): string {

--- a/ts/src/knowledge/artifact-store.ts
+++ b/ts/src/knowledge/artifact-store.ts
@@ -210,11 +210,12 @@ export class ArtifactStore {
       generation: number;
       curatorDecision: string;
     },
-  ): "live" | "pending" {
+  ): "live" | "pending" | "awaiting_approval" {
     if (!opts.requireApproval) {
       this.writePlaybook(scenarioName, content);
       return "live";
     }
+    if (this.readPendingPlaybook(scenarioName).hasPending) return "awaiting_approval";
     return stagePendingPlaybook(this.knowledgeRoot, scenarioName, content, {
       sourceRunId: opts.sourceRunId,
       generation: opts.generation,

--- a/ts/src/knowledge/artifact-store.ts
+++ b/ts/src/knowledge/artifact-store.ts
@@ -213,6 +213,9 @@ export class ArtifactStore {
   ): "live" | "pending" | "awaiting_approval" {
     if (!opts.requireApproval) {
       this.writePlaybook(scenarioName, content);
+      if (this.readPendingPlaybook(scenarioName).hasPending) {
+        rejectPendingPlaybook(this.knowledgeRoot, scenarioName);
+      }
       return "live";
     }
     if (this.readPendingPlaybook(scenarioName).hasPending) return "awaiting_approval";

--- a/ts/src/knowledge/lesson-lifecycle.ts
+++ b/ts/src/knowledge/lesson-lifecycle.ts
@@ -1,15 +1,13 @@
-/** Pure lesson-lifecycle assembly + curation ops (Cowork 2c, mirrors Python).
- *
- * Backed by the structured LessonStore (lessons.json) and the ArtifactStore
- * dead_ends.md registry. "pending" is a status on the lesson itself
- * (meta.approvalStatus), not a separate store, so the lifecycle reads one store.
- */
+/** Lesson lifecycle derived from live playbook markdown primitives. */
 import { createHash } from "node:crypto";
-import { type Lesson, LessonStore, isPending, isStale, isSuperseded } from "./lessons.js";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { ArtifactStore } from "./artifact-store.js";
+import { PLAYBOOK_MARKERS } from "./playbook.js";
 import { normalizeScenarioSegment } from "./scenario-paths.js";
 
 export const STALENESS_WINDOW = 10;
+export const STALE_MARKER = "<!-- autocontext:lesson-status=stale -->";
 
 export interface LessonView {
   id: string;
@@ -20,45 +18,7 @@ export interface LessonView {
   bestScore: number | null;
   lastValidatedGen: number | null;
   supersededBy: string | null;
-  source: "curator" | "human";
-}
-
-function lessonView(l: Lesson, status: LessonView["status"]): LessonView {
-  return {
-    id: l.id,
-    text: l.text,
-    status,
-    generation: l.meta.generation,
-    createdAt: l.meta.createdAt,
-    bestScore: l.meta.bestScore,
-    lastValidatedGen: l.meta.lastValidatedGen,
-    supersededBy: l.meta.supersededBy || null,
-    source: "curator",
-  };
-}
-
-function deadEndStore(knowledgeRoot: string): ArtifactStore {
-  // Dead ends only need knowledgeRoot; runsRoot is unused for read/append.
-  return new ArtifactStore({ runsRoot: knowledgeRoot, knowledgeRoot });
-}
-
-function deadEndViews(md: string): LessonView[] {
-  // ArtifactStore.appendDeadEnd writes "### Dead End\n\n{entry}\n" sections.
-  return md
-    .split("### Dead End")
-    .map((block) => block.trim())
-    .filter((block) => block.length > 0)
-    .map((text) => ({
-      id: "deadend_" + createHash("sha1").update(text).digest("hex").slice(0, 8),
-      text,
-      status: "deadEnd" as const,
-      generation: 0,
-      createdAt: "",
-      bestScore: null,
-      lastValidatedGen: null,
-      supersededBy: null,
-      source: "curator" as const,
-    }));
+  source: string;
 }
 
 export interface LifecycleView {
@@ -69,33 +29,148 @@ export interface LifecycleView {
   deadEnd: LessonView[];
 }
 
+type DerivedLesson = {
+  id: string;
+  text: string;
+  status: "active" | "stale";
+  source: string;
+};
+
+type RewriteMode = "remove" | "stale" | "active";
+
+function normalizeText(text: string): string {
+  let stripped = text.replace(STALE_MARKER, "").trim();
+  if (stripped.startsWith("- ")) stripped = stripped.slice(2).trim();
+  return stripped.split(/\s+/).filter(Boolean).join(" ");
+}
+
+function lessonId(text: string): string {
+  return "lesson_" + createHash("sha256").update(normalizeText(text)).digest("hex").slice(0, 12);
+}
+
+function parseLessonLine(line: string): { text: string; stale: boolean } | null {
+  const stripped = line.trim();
+  if (!stripped.startsWith("-")) return null;
+  const text = normalizeText(stripped.slice(1));
+  return text ? { text, stale: stripped.includes(STALE_MARKER) } : null;
+}
+
+function playbookBlock(content: string): { start: number; end: number; body: string } | null {
+  const startMarker = PLAYBOOK_MARKERS.LESSONS_START;
+  const endMarker = PLAYBOOK_MARKERS.LESSONS_END;
+  const markerStart = content.indexOf(startMarker);
+  const end = content.indexOf(endMarker);
+  if (markerStart === -1 || end === -1 || end <= markerStart) return null;
+  const start = markerStart + startMarker.length;
+  return { start, end, body: content.slice(start, end) };
+}
+
+function playbookLessons(artifacts: ArtifactStore, scenario: string): DerivedLesson[] {
+  const block = playbookBlock(artifacts.readPlaybook(scenario));
+  if (!block) return [];
+  return block.body
+    .split("\n")
+    .map(parseLessonLine)
+    .filter((item): item is { text: string; stale: boolean } => item !== null)
+    .map((item) => ({
+      id: lessonId(item.text),
+      text: item.text,
+      status: item.stale ? "stale" : "active",
+      source: `knowledge/${scenario}/playbook.md`,
+    }));
+}
+
+function skillLessons(skillsRoot: string | undefined, scenario: string): DerivedLesson[] {
+  if (!skillsRoot) return [];
+  const skillPath = join(skillsRoot, `${scenario.replace(/_/g, "-")}-ops`, "SKILL.md");
+  if (!existsSync(skillPath)) return [];
+  const content = readFileSync(skillPath, "utf-8");
+  const marker = "## Operational Lessons";
+  const start = content.indexOf(marker);
+  if (start === -1) return [];
+  const after = content.slice(start + marker.length);
+  const nextHeading = after.indexOf("\n## ");
+  const section = nextHeading === -1 ? after : after.slice(0, nextHeading);
+  return section
+    .split("\n")
+    .map(parseLessonLine)
+    .filter((item): item is { text: string; stale: boolean } => item !== null)
+    .map((item) => ({
+      id: lessonId(item.text),
+      text: item.text,
+      status: item.stale ? "stale" : "active",
+      source: `skills/${scenario.replace(/_/g, "-")}-ops/SKILL.md`,
+    }));
+}
+
+function derivedLessons(
+  artifacts: ArtifactStore,
+  scenario: string,
+  skillsRoot: string | undefined,
+): DerivedLesson[] {
+  const seen = new Set<string>();
+  const result: DerivedLesson[] = [];
+  for (const lesson of [...playbookLessons(artifacts, scenario), ...skillLessons(skillsRoot, scenario)]) {
+    if (seen.has(lesson.id)) continue;
+    seen.add(lesson.id);
+    result.push(lesson);
+  }
+  return result;
+}
+
+function lessonView(lesson: DerivedLesson, currentGeneration: number): LessonView {
+  return {
+    id: lesson.id,
+    text: lesson.text,
+    status: lesson.status,
+    generation: 0,
+    createdAt: "",
+    bestScore: null,
+    lastValidatedGen: lesson.status === "active" ? currentGeneration : null,
+    supersededBy: null,
+    source: lesson.source,
+  };
+}
+
+function deadEndViews(md: string): LessonView[] {
+  return md
+    .split("### Dead End")
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0)
+    .map((text) => ({
+      id: "deadend_" + createHash("sha256").update(text).digest("hex").slice(0, 8),
+      text,
+      status: "deadEnd" as const,
+      generation: 0,
+      createdAt: "",
+      bestScore: null,
+      lastValidatedGen: null,
+      supersededBy: null,
+      source: "knowledge/dead_ends.md",
+    }));
+}
+
 export function buildLifecycle(opts: {
   knowledgeRoot: string;
   scenario: string;
   currentGeneration: number;
   stalenessWindow?: number;
+  skillsRoot?: string;
 }): LifecycleView {
+  void opts.stalenessWindow;
   const scenario = normalizeScenarioSegment(opts.scenario);
-  const window = opts.stalenessWindow ?? STALENESS_WINDOW;
-  const store = new LessonStore(opts.knowledgeRoot);
-  const pending: LessonView[] = [];
+  const artifacts = new ArtifactStore({ runsRoot: opts.knowledgeRoot, knowledgeRoot: opts.knowledgeRoot });
   const active: LessonView[] = [];
   const stale: LessonView[] = [];
-  for (const l of store.readLessons(scenario)) {
-    if (isPending(l)) {
-      pending.push(lessonView(l, "pending"));
-      continue;
-    }
-    if (isSuperseded(l)) continue;
-    if (isStale(l, opts.currentGeneration, window)) stale.push(lessonView(l, "stale"));
-    else active.push(lessonView(l, "active"));
+  for (const lesson of derivedLessons(artifacts, scenario, opts.skillsRoot)) {
+    (lesson.status === "stale" ? stale : active).push(lessonView(lesson, opts.currentGeneration));
   }
   return {
     scenario,
-    pending,
+    pending: [],
     active,
     stale,
-    deadEnd: deadEndViews(deadEndStore(opts.knowledgeRoot).readDeadEnds(scenario)),
+    deadEnd: deadEndViews(artifacts.readDeadEnds(scenario)),
   };
 }
 
@@ -105,20 +180,9 @@ export function approveLesson(opts: {
   lessonId: string;
   currentGeneration: number;
 }): string | null {
-  const scenario = normalizeScenarioSegment(opts.scenario);
-  const store = new LessonStore(opts.knowledgeRoot);
-  const lessons = store.readLessons(scenario);
-  const target = lessons.find((l) => l.id === opts.lessonId && isPending(l));
-  if (!target) return null;
-  target.meta.approvalStatus = "active";
-  // Never lower the validation generation: approving must not make a lesson stale.
-  target.meta.lastValidatedGen = Math.max(
-    opts.currentGeneration,
-    target.meta.generation,
-    target.meta.lastValidatedGen,
-  );
-  store.writeLessons(scenario, lessons);
-  return "active";
+  void opts.currentGeneration;
+  const result = setLessonStale(opts.knowledgeRoot, opts.scenario, opts.lessonId, false);
+  return result.found ? "active" : null;
 }
 
 export function rejectLesson(opts: {
@@ -126,18 +190,7 @@ export function rejectLesson(opts: {
   scenario: string;
   lessonId: string;
 }): boolean {
-  // Reject only removes pending lessons; deleting an active lesson is the explicit
-  // curate "delete" action.
-  const scenario = normalizeScenarioSegment(opts.scenario);
-  const store = new LessonStore(opts.knowledgeRoot);
-  const lessons = store.readLessons(scenario);
-  const target = lessons.find((l) => l.id === opts.lessonId && isPending(l));
-  if (!target) return false;
-  store.writeLessons(
-    scenario,
-    lessons.filter((l) => l.id !== opts.lessonId),
-  );
-  return true;
+  return removeLesson(opts.knowledgeRoot, opts.scenario, opts.lessonId).found;
 }
 
 export function curateLesson(opts: {
@@ -147,30 +200,82 @@ export function curateLesson(opts: {
   action: "stale" | "deadEnd" | "delete";
   currentGeneration: number;
 }): string | null {
-  const scenario = normalizeScenarioSegment(opts.scenario);
-  const store = new LessonStore(opts.knowledgeRoot);
-  const lessons = store.readLessons(scenario);
-  const target = lessons.find((l) => l.id === opts.lessonId);
-  if (!target) return null;
+  void opts.currentGeneration;
   if (opts.action === "delete") {
-    store.writeLessons(
-      scenario,
-      lessons.filter((l) => l.id !== opts.lessonId),
-    );
-    return "deleted";
+    return removeLesson(opts.knowledgeRoot, opts.scenario, opts.lessonId).found ? "deleted" : null;
   }
   if (opts.action === "stale") {
-    target.meta.lastValidatedGen = -1;
-    store.writeLessons(scenario, lessons);
-    return "stale";
+    return setLessonStale(opts.knowledgeRoot, opts.scenario, opts.lessonId, true).found ? "stale" : null;
   }
-  // deadEnd: append via the shared ArtifactStore registry (single format), remove from active.
-  deadEndStore(opts.knowledgeRoot).appendDeadEnd(scenario, target.text);
-  store.writeLessons(
-    scenario,
-    lessons.filter((l) => l.id !== opts.lessonId),
-  );
+  const result = removeLesson(opts.knowledgeRoot, opts.scenario, opts.lessonId);
+  if (!result.found || !result.text) return null;
+  new ArtifactStore({ runsRoot: opts.knowledgeRoot, knowledgeRoot: opts.knowledgeRoot })
+    .appendDeadEnd(normalizeScenarioSegment(opts.scenario), result.text);
   return "deadEnd";
+}
+
+function removeLesson(
+  knowledgeRoot: string,
+  scenarioName: string,
+  id: string,
+): { found: boolean; text: string | null } {
+  return rewritePlaybookLesson(knowledgeRoot, scenarioName, id, "remove");
+}
+
+function setLessonStale(
+  knowledgeRoot: string,
+  scenarioName: string,
+  id: string,
+  stale: boolean,
+): { found: boolean; text: string | null } {
+  return rewritePlaybookLesson(knowledgeRoot, scenarioName, id, stale ? "stale" : "active");
+}
+
+function rewritePlaybookLesson(
+  knowledgeRoot: string,
+  scenarioName: string,
+  id: string,
+  mode: RewriteMode,
+): { found: boolean; text: string | null } {
+  const scenario = normalizeScenarioSegment(scenarioName);
+  const artifacts = new ArtifactStore({ runsRoot: knowledgeRoot, knowledgeRoot });
+  const content = artifacts.readPlaybook(scenario);
+  const block = playbookBlock(content);
+  if (!block) return { found: false, text: null };
+  let found = false;
+  let changed = false;
+  let targetText: string | null = null;
+  const lines: string[] = [];
+  for (const line of block.body.split("\n")) {
+    const parsed = parseLessonLine(line);
+    if (!parsed || lessonId(parsed.text) !== id) {
+      lines.push(line);
+      continue;
+    }
+    found = true;
+    targetText ??= parsed.text;
+    if (mode === "remove") {
+      changed = true;
+      continue;
+    }
+    if (mode === "active" && !parsed.stale) {
+      lines.push(line);
+      continue;
+    }
+    if (mode === "stale" && parsed.stale) {
+      lines.push(line);
+      continue;
+    }
+    changed = true;
+    lines.push(`- ${parsed.text}${mode === "stale" ? ` ${STALE_MARKER}` : ""}`);
+  }
+  if (!found) return { found: false, text: null };
+  if (!changed) return { found: true, text: targetText };
+  const body = lines.join("\n").trim();
+  const prefix = content.slice(0, block.start).trimEnd();
+  const suffix = content.slice(block.end).trimStart();
+  artifacts.writePlaybook(scenario, body ? `${prefix}\n${body}\n${suffix}` : `${prefix}\n${suffix}`);
+  return { found, text: targetText };
 }
 
 export { LessonStore, makeMeta } from "./lessons.js";

--- a/ts/src/knowledge/lesson-lifecycle.ts
+++ b/ts/src/knowledge/lesson-lifecycle.ts
@@ -1,6 +1,6 @@
 /** Lesson lifecycle derived from live playbook markdown primitives. */
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { ArtifactStore } from "./artifact-store.js";
 import { PLAYBOOK_MARKERS } from "./playbook.js";
@@ -110,7 +110,10 @@ function derivedLessons(
 ): DerivedLesson[] {
   const seen = new Set<string>();
   const result: DerivedLesson[] = [];
-  for (const lesson of [...playbookLessons(artifacts, scenario), ...skillLessons(skillsRoot, scenario)]) {
+  for (const lesson of [
+    ...playbookLessons(artifacts, scenario),
+    ...skillLessons(skillsRoot, scenario),
+  ]) {
     if (seen.has(lesson.id)) continue;
     seen.add(lesson.id);
     result.push(lesson);
@@ -159,7 +162,10 @@ export function buildLifecycle(opts: {
 }): LifecycleView {
   void opts.stalenessWindow;
   const scenario = normalizeScenarioSegment(opts.scenario);
-  const artifacts = new ArtifactStore({ runsRoot: opts.knowledgeRoot, knowledgeRoot: opts.knowledgeRoot });
+  const artifacts = new ArtifactStore({
+    runsRoot: opts.knowledgeRoot,
+    knowledgeRoot: opts.knowledgeRoot,
+  });
   const active: LessonView[] = [];
   const stale: LessonView[] = [];
   for (const lesson of derivedLessons(artifacts, scenario, opts.skillsRoot)) {
@@ -176,25 +182,34 @@ export function buildLifecycle(opts: {
 
 export function approveLesson(opts: {
   knowledgeRoot: string;
+  skillsRoot?: string;
   scenario: string;
   lessonId: string;
   currentGeneration: number;
 }): string | null {
   void opts.currentGeneration;
-  const result = setLessonStale(opts.knowledgeRoot, opts.scenario, opts.lessonId, false);
+  const result = setLessonStale(
+    opts.knowledgeRoot,
+    opts.skillsRoot,
+    opts.scenario,
+    opts.lessonId,
+    false,
+  );
   return result.found ? "active" : null;
 }
 
 export function rejectLesson(opts: {
   knowledgeRoot: string;
+  skillsRoot?: string;
   scenario: string;
   lessonId: string;
 }): boolean {
-  return removeLesson(opts.knowledgeRoot, opts.scenario, opts.lessonId).found;
+  return removeLesson(opts.knowledgeRoot, opts.skillsRoot, opts.scenario, opts.lessonId).found;
 }
 
 export function curateLesson(opts: {
   knowledgeRoot: string;
+  skillsRoot?: string;
   scenario: string;
   lessonId: string;
   action: "stale" | "deadEnd" | "delete";
@@ -202,33 +217,47 @@ export function curateLesson(opts: {
 }): string | null {
   void opts.currentGeneration;
   if (opts.action === "delete") {
-    return removeLesson(opts.knowledgeRoot, opts.scenario, opts.lessonId).found ? "deleted" : null;
+    return removeLesson(opts.knowledgeRoot, opts.skillsRoot, opts.scenario, opts.lessonId).found
+      ? "deleted"
+      : null;
   }
   if (opts.action === "stale") {
-    return setLessonStale(opts.knowledgeRoot, opts.scenario, opts.lessonId, true).found ? "stale" : null;
+    return setLessonStale(opts.knowledgeRoot, opts.skillsRoot, opts.scenario, opts.lessonId, true)
+      .found
+      ? "stale"
+      : null;
   }
-  const result = removeLesson(opts.knowledgeRoot, opts.scenario, opts.lessonId);
+  const result = removeLesson(opts.knowledgeRoot, opts.skillsRoot, opts.scenario, opts.lessonId);
   if (!result.found || !result.text) return null;
-  new ArtifactStore({ runsRoot: opts.knowledgeRoot, knowledgeRoot: opts.knowledgeRoot })
-    .appendDeadEnd(normalizeScenarioSegment(opts.scenario), result.text);
+  new ArtifactStore({
+    runsRoot: opts.knowledgeRoot,
+    knowledgeRoot: opts.knowledgeRoot,
+  }).appendDeadEnd(normalizeScenarioSegment(opts.scenario), result.text);
   return "deadEnd";
 }
 
 function removeLesson(
   knowledgeRoot: string,
+  skillsRoot: string | undefined,
   scenarioName: string,
   id: string,
 ): { found: boolean; text: string | null } {
-  return rewritePlaybookLesson(knowledgeRoot, scenarioName, id, "remove");
+  const playbook = rewritePlaybookLesson(knowledgeRoot, scenarioName, id, "remove");
+  const skill = rewriteSkillLesson(skillsRoot, scenarioName, id, "remove");
+  return { found: playbook.found || skill.found, text: playbook.text ?? skill.text };
 }
 
 function setLessonStale(
   knowledgeRoot: string,
+  skillsRoot: string | undefined,
   scenarioName: string,
   id: string,
   stale: boolean,
 ): { found: boolean; text: string | null } {
-  return rewritePlaybookLesson(knowledgeRoot, scenarioName, id, stale ? "stale" : "active");
+  const mode = stale ? "stale" : "active";
+  const playbook = rewritePlaybookLesson(knowledgeRoot, scenarioName, id, mode);
+  const skill = rewriteSkillLesson(skillsRoot, scenarioName, id, mode);
+  return { found: playbook.found || skill.found, text: playbook.text ?? skill.text };
 }
 
 function rewritePlaybookLesson(
@@ -242,11 +271,58 @@ function rewritePlaybookLesson(
   const content = artifacts.readPlaybook(scenario);
   const block = playbookBlock(content);
   if (!block) return { found: false, text: null };
+  const rewritten = rewriteLessonLines(block.body, id, mode);
+  if (!rewritten.found) return rewritten;
+  if (!rewritten.changed) return { found: true, text: rewritten.text };
+  const body = rewritten.lines.join("\n").trim();
+  const prefix = content.slice(0, block.start).trimEnd();
+  const suffix = content.slice(block.end).trimStart();
+  artifacts.writePlaybook(
+    scenario,
+    body ? `${prefix}\n${body}\n${suffix}` : `${prefix}\n${suffix}`,
+  );
+  return { found: true, text: rewritten.text };
+}
+
+function rewriteSkillLesson(
+  skillsRoot: string | undefined,
+  scenarioName: string,
+  id: string,
+  mode: RewriteMode,
+): { found: boolean; text: string | null } {
+  if (!skillsRoot) return { found: false, text: null };
+  const scenario = normalizeScenarioSegment(scenarioName);
+  const path = join(skillsRoot, `${scenario.replace(/_/g, "-")}-ops`, "SKILL.md");
+  if (!existsSync(path)) return { found: false, text: null };
+  const content = readFileSync(path, "utf-8");
+  const marker = "## Operational Lessons";
+  const markerStart = content.indexOf(marker);
+  if (markerStart === -1) return { found: false, text: null };
+  const start = markerStart + marker.length;
+  const after = content.slice(start);
+  const nextHeading = after.indexOf("\n## ");
+  const end = nextHeading === -1 ? content.length : start + nextHeading;
+  const rewritten = rewriteLessonLines(content.slice(start, end), id, mode);
+  if (!rewritten.found) return rewritten;
+  if (rewritten.changed) {
+    const body = rewritten.lines.join("\n").trim();
+    const prefix = content.slice(0, start).trimEnd();
+    const suffix = content.slice(end).trimStart();
+    writeFileSync(path, body ? `${prefix}\n${body}\n${suffix}` : `${prefix}\n${suffix}`, "utf-8");
+  }
+  return { found: true, text: rewritten.text };
+}
+
+function rewriteLessonLines(
+  body: string,
+  id: string,
+  mode: RewriteMode,
+): { found: boolean; changed: boolean; text: string | null; lines: string[] } {
   let found = false;
   let changed = false;
   let targetText: string | null = null;
   const lines: string[] = [];
-  for (const line of block.body.split("\n")) {
+  for (const line of body.split("\n")) {
     const parsed = parseLessonLine(line);
     if (!parsed || lessonId(parsed.text) !== id) {
       lines.push(line);
@@ -269,13 +345,7 @@ function rewritePlaybookLesson(
     changed = true;
     lines.push(`- ${parsed.text}${mode === "stale" ? ` ${STALE_MARKER}` : ""}`);
   }
-  if (!found) return { found: false, text: null };
-  if (!changed) return { found: true, text: targetText };
-  const body = lines.join("\n").trim();
-  const prefix = content.slice(0, block.start).trimEnd();
-  const suffix = content.slice(block.end).trimStart();
-  artifacts.writePlaybook(scenario, body ? `${prefix}\n${body}\n${suffix}` : `${prefix}\n${suffix}`);
-  return { found, text: targetText };
+  return { found, changed, text: targetText, lines };
 }
 
 export { LessonStore, makeMeta } from "./lessons.js";

--- a/ts/src/knowledge/lessons.ts
+++ b/ts/src/knowledge/lessons.ts
@@ -1,4 +1,4 @@
-/** Structured lessons with applicability metadata (Cowork 2c, mirrors Python LessonStore). */
+/** Deprecated structured lessons compatibility types; live curation derives from markdown. */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";

--- a/ts/src/knowledge/playbook-approval.ts
+++ b/ts/src/knowledge/playbook-approval.ts
@@ -1,6 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { LessonStore, Lesson } from "./lessons.js";
 import { resolveScenarioRoot } from "./scenario-paths.js";
 
 export interface PendingPlaybookProvenance {
@@ -84,12 +83,10 @@ export function approvePendingPlaybook(
   knowledgeRoot: string,
   scenarioName: string,
   writeLivePlaybook: (scenarioName: string, content: string) => void,
-  lessonStore?: LessonStore,
 ): { ok: boolean; status: "approved" | "missing" } {
   const pending = readPendingPlaybook(knowledgeRoot, scenarioName);
   if (!pending.hasPending || pending.provenance === null) return { ok: false, status: "missing" };
   writeLivePlaybook(scenarioName, pending.content);
-  approveLessons(lessonStore, scenarioName, pending.provenance.generation);
   clearPending(resolveScenarioRoot(knowledgeRoot, scenarioName));
   return { ok: true, status: "approved" };
 }
@@ -97,45 +94,11 @@ export function approvePendingPlaybook(
 export function rejectPendingPlaybook(
   knowledgeRoot: string,
   scenarioName: string,
-  lessonStore?: LessonStore,
 ): { ok: boolean; status: "rejected" | "missing" } {
   const pending = readPendingPlaybook(knowledgeRoot, scenarioName);
   if (!pending.hasPending || pending.provenance === null) return { ok: false, status: "missing" };
-  dropLessons(lessonStore, scenarioName, pending.provenance.generation);
   clearPending(resolveScenarioRoot(knowledgeRoot, scenarioName));
   return { ok: true, status: "rejected" };
-}
-
-function approveLessons(
-  lessonStore: LessonStore | undefined,
-  scenarioName: string,
-  generation: number,
-): void {
-  if (!lessonStore) return;
-  const lessons = lessonStore.readLessons(scenarioName);
-  let changed = false;
-  for (const lesson of lessons) {
-    if (lesson.meta.approvalStatus === "pending" && lesson.meta.generation === generation) {
-      lesson.meta.approvalStatus = "active";
-      lesson.meta.lastValidatedGen = Math.max(lesson.meta.lastValidatedGen, generation);
-      changed = true;
-    }
-  }
-  if (changed) lessonStore.writeLessons(scenarioName, lessons);
-}
-
-function dropLessons(
-  lessonStore: LessonStore | undefined,
-  scenarioName: string,
-  generation: number,
-): void {
-  if (!lessonStore) return;
-  const lessons = lessonStore.readLessons(scenarioName);
-  const kept = lessons.filter(
-    (lesson: Lesson) =>
-      !(lesson.meta.approvalStatus === "pending" && lesson.meta.generation === generation),
-  );
-  if (kept.length !== lessons.length) lessonStore.writeLessons(scenarioName, kept);
 }
 
 function clearPending(scenarioDir: string): void {

--- a/ts/tests/lesson-lifecycle.test.ts
+++ b/ts/tests/lesson-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { ArtifactStore } from "../src/knowledge/artifact-store.js";
@@ -19,134 +19,132 @@ async function mods() {
   };
 }
 
-function seedDeadEnd(scenario: string, entry: string): void {
-  new ArtifactStore({ runsRoot: dir, knowledgeRoot: dir }).appendDeadEnd(scenario, entry);
+function store(): ArtifactStore {
+  return new ArtifactStore({ runsRoot: dir, knowledgeRoot: dir });
 }
 
-describe("lesson lifecycle (single store)", () => {
-  it("buildLifecycle buckets active/stale/pending and reads ### Dead End sections", async () => {
-    const { buildLifecycle, LessonStore, makeMeta } = await mods();
-    const store = new LessonStore(dir);
-    store.writeLessons("scn", [
-      {
-        id: "a",
-        text: "fresh",
-        meta: makeMeta({ generation: 20, bestScore: 0.5, lastValidatedGen: 20 }),
-      },
-      {
-        id: "b",
-        text: "old",
-        meta: makeMeta({ generation: 2, bestScore: 0.5, lastValidatedGen: 2 }),
-      },
-      {
-        id: "p",
-        text: "held",
-        meta: makeMeta({ generation: 20, bestScore: 0, approvalStatus: "pending" }),
-      },
-    ]);
-    seedDeadEnd("scn", "tried Y, lost");
+function playbook(...lessons: string[]): string {
+  return [
+    "intro",
+    "<!-- LESSONS_START -->",
+    ...lessons.map((lesson) => `- ${lesson}`),
+    "<!-- LESSONS_END -->",
+    "outro",
+  ].join("\n");
+}
 
-    const view = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 20 });
-    expect(view.active.map((l: { text: string }) => l.text)).toEqual(["fresh"]);
-    expect(view.stale.map((l: { text: string }) => l.text)).toEqual(["old"]);
-    expect(view.pending.map((l: { text: string }) => l.text)).toEqual(["held"]);
-    expect(view.deadEnd.length).toBe(1);
+describe("lesson lifecycle (derived markdown view)", () => {
+  it("buildLifecycle derives active lessons from playbook/SKILL and reads dead ends", async () => {
+    const { buildLifecycle } = await mods();
+    const artifacts = store();
+    artifacts.writePlaybook("scn", playbook("fresh", "shared"));
+    const skillDir = join(dir, "skills", "scn-ops");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      "# Skill\n\n## Operational Lessons\n\n- shared\n- skill only\n",
+      "utf-8",
+    );
+    artifacts.appendDeadEnd("scn", "tried Y, lost");
+
+    const view = buildLifecycle({
+      knowledgeRoot: dir,
+      skillsRoot: join(dir, "skills"),
+      scenario: "scn",
+      currentGeneration: 20,
+    });
+
+    expect(view.active.map((l: { text: string }) => l.text)).toEqual(["fresh", "shared", "skill only"]);
+    expect(view.pending).toEqual([]);
+    expect(view.stale).toEqual([]);
     expect(view.deadEnd[0].text).toContain("tried Y");
+    expect(view.active[0].id).toMatch(/^lesson_/);
+    expect(view.active[0].source).toMatch(/playbook\.md$/);
   });
 
-  it("approve flips pending to active; idempotent; never lowers validation generation", async () => {
-    const { approveLesson, LessonStore, makeMeta } = await mods();
-    const store = new LessonStore(dir);
-    store.writeLessons("scn", [
-      {
-        id: "p",
-        text: "held",
-        meta: makeMeta({
-          generation: 20,
-          bestScore: 0,
-          lastValidatedGen: 20,
-          approvalStatus: "pending",
-        }),
-      },
-    ]);
+  it("approve is a no-op for a live derived lesson", async () => {
+    const { approveLesson, buildLifecycle } = await mods();
+    const artifacts = store();
+    artifacts.writePlaybook("scn", playbook("already live"));
+    const [lesson] = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 1 }).active;
+
     expect(
-      approveLesson({ knowledgeRoot: dir, scenario: "scn", lessonId: "p", currentGeneration: 0 }),
+      approveLesson({ knowledgeRoot: dir, scenario: "scn", lessonId: lesson.id, currentGeneration: 0 }),
     ).toBe("active");
-    const lesson = store.readLessons("scn")[0];
-    expect(lesson.meta.approvalStatus).toBe("active");
-    expect(lesson.meta.lastValidatedGen).toBe(20);
     expect(
-      approveLesson({ knowledgeRoot: dir, scenario: "scn", lessonId: "p", currentGeneration: 9 }),
+      approveLesson({ knowledgeRoot: dir, scenario: "scn", lessonId: "missing", currentGeneration: 9 }),
     ).toBeNull();
   });
 
-  it("reject removes pending only; does not delete an active lesson", async () => {
-    const { rejectLesson, LessonStore, makeMeta } = await mods();
-    const store = new LessonStore(dir);
-    store.writeLessons("scn", [
-      {
-        id: "x",
-        text: "held",
-        meta: makeMeta({ generation: 5, bestScore: 0, approvalStatus: "pending" }),
-      },
-      { id: "a", text: "active one", meta: makeMeta({ generation: 5, bestScore: 0 }) },
-    ]);
-    expect(rejectLesson({ knowledgeRoot: dir, scenario: "scn", lessonId: "x" })).toBe(true);
-    expect(rejectLesson({ knowledgeRoot: dir, scenario: "scn", lessonId: "a" })).toBe(false);
-    expect(store.readLessons("scn").map((l) => l.text)).toEqual(["active one"]);
+  it("reject removes a live markdown lesson", async () => {
+    const { rejectLesson, buildLifecycle } = await mods();
+    const artifacts = store();
+    artifacts.writePlaybook("scn", playbook("held", "keep"));
+    const lesson = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 1 })
+      .active.find((l: { text: string }) => l.text === "held")!;
+
+    expect(rejectLesson({ knowledgeRoot: dir, scenario: "scn", lessonId: lesson.id })).toBe(true);
+    expect(artifacts.readPlaybook("scn")).not.toContain("held");
+    expect(artifacts.readPlaybook("scn")).toContain("keep");
   });
 
-  it("curate deadEnd uses the shared registry format and is read back by buildLifecycle", async () => {
-    const { curateLesson, buildLifecycle, LessonStore, makeMeta } = await mods();
-    const store = new LessonStore(dir);
-    store.writeLessons("scn", [
-      { id: "d", text: "dead me", meta: makeMeta({ generation: 5, bestScore: 0 }) },
-    ]);
+  it("curate deadEnd moves the markdown lesson into the shared registry", async () => {
+    const { curateLesson, buildLifecycle } = await mods();
+    const artifacts = store();
+    artifacts.writePlaybook("scn", playbook("dead me"));
+    const [lesson] = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 9 }).active;
+
     expect(
       curateLesson({
         knowledgeRoot: dir,
         scenario: "scn",
-        lessonId: "d",
+        lessonId: lesson.id,
         action: "deadEnd",
         currentGeneration: 9,
       }),
     ).toBe("deadEnd");
-    expect(store.readLessons("scn")).toEqual([]);
-    const view = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 9 });
-    expect(view.deadEnd.some((v: { text: string }) => v.text.includes("dead me"))).toBe(true);
+    expect(artifacts.readPlaybook("scn")).not.toContain("dead me");
+    expect(buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 9 }).deadEnd[0].text)
+      .toContain("dead me");
   });
 
-  it("curate marks stale / deletes; null on missing", async () => {
-    const { curateLesson, LessonStore, makeMeta } = await mods();
-    const store = new LessonStore(dir);
-    store.writeLessons("scn", [
-      { id: "s", text: "stale me", meta: makeMeta({ generation: 5, bestScore: 0 }) },
-    ]);
+  it("curate stale annotates without deleting and excludes stale from active", async () => {
+    const { curateLesson, buildLifecycle } = await mods();
+    const artifacts = store();
+    artifacts.writePlaybook("scn", playbook("stale me"));
+    const [lesson] = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 9 }).active;
+
     expect(
       curateLesson({
         knowledgeRoot: dir,
         scenario: "scn",
-        lessonId: "s",
+        lessonId: lesson.id,
         action: "stale",
         currentGeneration: 9,
       }),
     ).toBe("stale");
-    expect(store.readLessons("scn")[0].meta.lastValidatedGen).toBe(-1);
+    const view = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 9 });
+    expect(view.active).toEqual([]);
+    expect(view.stale.map((l: { text: string }) => l.text)).toEqual(["stale me"]);
+    expect(artifacts.readPlaybook("scn")).toContain("stale me");
+  });
 
-    store.writeLessons("scn", [
-      { id: "z", text: "gone", meta: makeMeta({ generation: 5, bestScore: 0 }) },
-    ]);
+  it("deletes and returns null on missing", async () => {
+    const { curateLesson, buildLifecycle } = await mods();
+    const artifacts = store();
+    artifacts.writePlaybook("scn", playbook("gone"));
+    const [lesson] = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 9 }).active;
+
     expect(
       curateLesson({
         knowledgeRoot: dir,
         scenario: "scn",
-        lessonId: "z",
+        lessonId: lesson.id,
         action: "delete",
         currentGeneration: 9,
       }),
     ).toBe("deleted");
-    expect(store.readLessons("scn")).toEqual([]);
-
+    expect(artifacts.readPlaybook("scn")).not.toContain("gone");
     expect(
       curateLesson({
         knowledgeRoot: dir,
@@ -158,28 +156,21 @@ describe("lesson lifecycle (single store)", () => {
     ).toBeNull();
   });
 
-  it("pending lessons are excluded from applicability", async () => {
-    const { makeMeta } = await mods();
-    const { isApplicable } = await import("../src/knowledge/lessons.js");
-    const pending = {
-      id: "p",
-      text: "UNAPPROVED",
-      meta: makeMeta({ generation: 20, bestScore: 0, approvalStatus: "pending" }),
-    };
-    const active = {
-      id: "a",
-      text: "approved",
-      meta: makeMeta({ generation: 20, bestScore: 0, lastValidatedGen: 20 }),
-    };
-    expect(isApplicable(pending, 20, 10)).toBe(false);
-    expect(isApplicable(active, 20, 10)).toBe(true);
+  it("structured LessonStore no longer feeds lifecycle or prompt paths", async () => {
+    const { buildLifecycle, LessonStore, makeMeta } = await mods();
+    const lessonStore = new LessonStore(dir);
+    lessonStore.writeLessons("scn", [
+      { id: "x", text: "structured shadow", meta: makeMeta({ generation: 1, bestScore: 0 }) },
+    ]);
+
+    expect(buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 1 }).active).toEqual([]);
   });
 
   it("rejects path-traversal scenario names and writes nothing outside the root", async () => {
     const { LessonStore, makeMeta } = await mods();
-    const store = new LessonStore(join(dir, "knowledge"));
+    const lessonStore = new LessonStore(join(dir, "knowledge"));
     expect(() =>
-      store.writeLessons("../outside", [
+      lessonStore.writeLessons("../outside", [
         { id: "x", text: "escape", meta: makeMeta({ generation: 1, bestScore: 0 }) },
       ]),
     ).toThrow();

--- a/ts/tests/lesson-lifecycle.test.ts
+++ b/ts/tests/lesson-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { ArtifactStore } from "../src/knowledge/artifact-store.js";
@@ -54,7 +54,11 @@ describe("lesson lifecycle (derived markdown view)", () => {
       currentGeneration: 20,
     });
 
-    expect(view.active.map((l: { text: string }) => l.text)).toEqual(["fresh", "shared", "skill only"]);
+    expect(view.active.map((l: { text: string }) => l.text)).toEqual([
+      "fresh",
+      "shared",
+      "skill only",
+    ]);
     expect(view.pending).toEqual([]);
     expect(view.stale).toEqual([]);
     expect(view.deadEnd[0].text).toContain("tried Y");
@@ -62,17 +66,95 @@ describe("lesson lifecycle (derived markdown view)", () => {
     expect(view.active[0].source).toMatch(/playbook\.md$/);
   });
 
+  it("curates skill-only lessons listed in the derived view", async () => {
+    const { buildLifecycle, curateLesson, rejectLesson } = await mods();
+    const skillDir = join(dir, "skills", "scn-ops");
+    const skillPath = join(skillDir, "SKILL.md");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(skillPath, "# Skill\n\n## Operational Lessons\n\n- skill only\n", "utf-8");
+    const lesson = buildLifecycle({
+      knowledgeRoot: dir,
+      skillsRoot: join(dir, "skills"),
+      scenario: "scn",
+      currentGeneration: 1,
+    }).active.find((item: { text: string }) => item.text === "skill only")!;
+
+    expect(
+      curateLesson({
+        knowledgeRoot: dir,
+        skillsRoot: join(dir, "skills"),
+        scenario: "scn",
+        lessonId: lesson.id,
+        action: "stale",
+        currentGeneration: 1,
+      }),
+    ).toBe("stale");
+    expect(readFileSync(skillPath, "utf-8")).toContain("autocontext:lesson-status=stale");
+    expect(
+      buildLifecycle({
+        knowledgeRoot: dir,
+        skillsRoot: join(dir, "skills"),
+        scenario: "scn",
+        currentGeneration: 1,
+      }).stale.map((item: { text: string }) => item.text),
+    ).toEqual(["skill only"]);
+
+    expect(
+      curateLesson({
+        knowledgeRoot: dir,
+        skillsRoot: join(dir, "skills"),
+        scenario: "scn",
+        lessonId: lesson.id,
+        action: "deadEnd",
+        currentGeneration: 1,
+      }),
+    ).toBe("deadEnd");
+    expect(readFileSync(skillPath, "utf-8")).not.toContain("skill only");
+    expect(store().readDeadEnds("scn")).toContain("skill only");
+
+    writeFileSync(skillPath, "# Skill\n\n## Operational Lessons\n\n- reject me\n", "utf-8");
+    const rejectId = buildLifecycle({
+      knowledgeRoot: dir,
+      skillsRoot: join(dir, "skills"),
+      scenario: "scn",
+      currentGeneration: 1,
+    }).active[0].id;
+    expect(
+      rejectLesson({
+        knowledgeRoot: dir,
+        skillsRoot: join(dir, "skills"),
+        scenario: "scn",
+        lessonId: rejectId,
+      }),
+    ).toBe(true);
+    expect(readFileSync(skillPath, "utf-8")).not.toContain("reject me");
+  });
+
   it("approve is a no-op for a live derived lesson", async () => {
     const { approveLesson, buildLifecycle } = await mods();
     const artifacts = store();
     artifacts.writePlaybook("scn", playbook("already live"));
-    const [lesson] = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 1 }).active;
+    const [lesson] = buildLifecycle({
+      knowledgeRoot: dir,
+      scenario: "scn",
+      currentGeneration: 1,
+    }).active;
 
     expect(
-      approveLesson({ knowledgeRoot: dir, scenario: "scn", lessonId: lesson.id, currentGeneration: 0 }),
+      approveLesson({
+        knowledgeRoot: dir,
+        scenario: "scn",
+        lessonId: lesson.id,
+        currentGeneration: 0,
+      }),
     ).toBe("active");
     expect(
-      approveLesson({ knowledgeRoot: dir, scenario: "scn", lessonId: "missing", currentGeneration: 9 }),
+      approveLesson({
+        knowledgeRoot: dir,
+        scenario: "scn",
+        lessonId: "missing",
+        currentGeneration: 9,
+      }),
     ).toBeNull();
   });
 
@@ -80,8 +162,11 @@ describe("lesson lifecycle (derived markdown view)", () => {
     const { rejectLesson, buildLifecycle } = await mods();
     const artifacts = store();
     artifacts.writePlaybook("scn", playbook("held", "keep"));
-    const lesson = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 1 })
-      .active.find((l: { text: string }) => l.text === "held")!;
+    const lesson = buildLifecycle({
+      knowledgeRoot: dir,
+      scenario: "scn",
+      currentGeneration: 1,
+    }).active.find((l: { text: string }) => l.text === "held")!;
 
     expect(rejectLesson({ knowledgeRoot: dir, scenario: "scn", lessonId: lesson.id })).toBe(true);
     expect(artifacts.readPlaybook("scn")).not.toContain("held");
@@ -92,7 +177,11 @@ describe("lesson lifecycle (derived markdown view)", () => {
     const { curateLesson, buildLifecycle } = await mods();
     const artifacts = store();
     artifacts.writePlaybook("scn", playbook("dead me"));
-    const [lesson] = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 9 }).active;
+    const [lesson] = buildLifecycle({
+      knowledgeRoot: dir,
+      scenario: "scn",
+      currentGeneration: 9,
+    }).active;
 
     expect(
       curateLesson({
@@ -104,15 +193,20 @@ describe("lesson lifecycle (derived markdown view)", () => {
       }),
     ).toBe("deadEnd");
     expect(artifacts.readPlaybook("scn")).not.toContain("dead me");
-    expect(buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 9 }).deadEnd[0].text)
-      .toContain("dead me");
+    expect(
+      buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 9 }).deadEnd[0].text,
+    ).toContain("dead me");
   });
 
   it("curate stale annotates without deleting and excludes stale from active", async () => {
     const { curateLesson, buildLifecycle } = await mods();
     const artifacts = store();
     artifacts.writePlaybook("scn", playbook("stale me"));
-    const [lesson] = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 9 }).active;
+    const [lesson] = buildLifecycle({
+      knowledgeRoot: dir,
+      scenario: "scn",
+      currentGeneration: 9,
+    }).active;
 
     expect(
       curateLesson({
@@ -133,7 +227,11 @@ describe("lesson lifecycle (derived markdown view)", () => {
     const { curateLesson, buildLifecycle } = await mods();
     const artifacts = store();
     artifacts.writePlaybook("scn", playbook("gone"));
-    const [lesson] = buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 9 }).active;
+    const [lesson] = buildLifecycle({
+      knowledgeRoot: dir,
+      scenario: "scn",
+      currentGeneration: 9,
+    }).active;
 
     expect(
       curateLesson({
@@ -163,7 +261,9 @@ describe("lesson lifecycle (derived markdown view)", () => {
       { id: "x", text: "structured shadow", meta: makeMeta({ generation: 1, bestScore: 0 }) },
     ]);
 
-    expect(buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 1 }).active).toEqual([]);
+    expect(
+      buildLifecycle({ knowledgeRoot: dir, scenario: "scn", currentGeneration: 1 }).active,
+    ).toEqual([]);
   });
 
   it("rejects path-traversal scenario names and writes nothing outside the root", async () => {

--- a/ts/tests/playbook-approval-gate.test.ts
+++ b/ts/tests/playbook-approval-gate.test.ts
@@ -56,7 +56,7 @@ describe("playbook approval gate", () => {
     }
   });
 
-  it("refuses to overwrite an unresolved pending playbook", () => {
+  it("skips new staging while an unresolved pending playbook exists", () => {
     const dir = root();
     try {
       const artifacts = store(dir);
@@ -68,14 +68,14 @@ describe("playbook approval gate", () => {
         curatorDecision: "advance",
       });
 
-      expect(() =>
+      expect(
         artifacts.writeOrStagePlaybook("grid_ctf", "new pending playbook", {
           requireApproval: true,
           sourceRunId: "run-approval",
           generation: 3,
           curatorDecision: "advance",
         }),
-      ).toThrow(/pending playbook already exists/);
+      ).toBe("awaiting_approval");
       expect(artifacts.readPendingPlaybook("grid_ctf").content).toBe("pending playbook\n");
       expect(artifacts.readPendingPlaybook("grid_ctf").provenance?.generation).toBe(2);
     } finally {
@@ -166,7 +166,11 @@ describe("playbook approval gate", () => {
       }
       async complete(opts: { userPrompt: string }) {
         if (opts.userPrompt.startsWith("Describe your strategy")) {
-          return { text: JSON.stringify({ aggression: 0.6, defense: 0.55, path_bias: 0.5 }), model: "m", usage: {} };
+          return {
+            text: JSON.stringify({ aggression: 0.6, defense: 0.55, path_bias: 0.5 }),
+            model: "m",
+            usage: {},
+          };
         }
         if (opts.userPrompt.startsWith("You are a curator consolidating")) {
           return {
@@ -200,9 +204,9 @@ describe("playbook approval gate", () => {
       await runner.run("approval-consolidation", 1);
       storeDb.close();
 
-      expect(readFileSync(join(dir, "knowledge", "grid_ctf", "playbook.md"), "utf-8")).not.toContain(
-        "consolidated leak",
-      );
+      expect(
+        readFileSync(join(dir, "knowledge", "grid_ctf", "playbook.md"), "utf-8"),
+      ).not.toContain("consolidated leak");
       expect(artifacts.readPendingPlaybook("grid_ctf").hasPending).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/ts/tests/playbook-approval-gate.test.ts
+++ b/ts/tests/playbook-approval-gate.test.ts
@@ -4,7 +4,6 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { ArtifactStore } from "../src/knowledge/artifact-store.js";
-import { LessonStore, makeMeta } from "../src/knowledge/lessons.js";
 import { buildKnowledgeApiRoutes } from "../src/server/knowledge-api.js";
 import { StartRunCmdSchema } from "../src/server/protocol.js";
 
@@ -111,17 +110,11 @@ describe("playbook approval gate", () => {
     }
   });
 
-  it("approves or rejects pending playbooks with same-generation lessons", () => {
+  it("approves or rejects pending playbooks without structured lesson side effects", () => {
     const dir = root();
     try {
       const artifacts = store(dir);
-      const lessons = new LessonStore(join(dir, "knowledge"));
       artifacts.writePlaybook("grid_ctf", "approved playbook");
-      lessons.addLesson(
-        "grid_ctf",
-        "held lesson",
-        makeMeta({ generation: 2, bestScore: 0.7, approvalStatus: "pending" }),
-      );
       artifacts.writeOrStagePlaybook("grid_ctf", "pending playbook", {
         requireApproval: true,
         sourceRunId: "run-approval",
@@ -129,12 +122,11 @@ describe("playbook approval gate", () => {
         curatorDecision: "advance",
       });
 
-      expect(artifacts.approvePendingPlaybook("grid_ctf", lessons)).toEqual({
+      expect(artifacts.approvePendingPlaybook("grid_ctf")).toEqual({
         ok: true,
         status: "approved",
       });
       expect(artifacts.readPlaybook("grid_ctf")).toBe("pending playbook\n");
-      expect(lessons.readLessons("grid_ctf")[0]!.meta.approvalStatus).toBe("active");
 
       artifacts.writeOrStagePlaybook("grid_ctf", "rejected playbook", {
         requireApproval: true,
@@ -142,18 +134,12 @@ describe("playbook approval gate", () => {
         generation: 3,
         curatorDecision: "advance",
       });
-      lessons.addLesson(
-        "grid_ctf",
-        "rejected lesson",
-        makeMeta({ generation: 3, bestScore: 0.8, approvalStatus: "pending" }),
-      );
 
-      expect(artifacts.rejectPendingPlaybook("grid_ctf", lessons)).toEqual({
+      expect(artifacts.rejectPendingPlaybook("grid_ctf")).toEqual({
         ok: true,
         status: "rejected",
       });
       expect(artifacts.readPlaybook("grid_ctf")).toBe("pending playbook\n");
-      expect(lessons.readLessons("grid_ctf").map((lesson) => lesson.text)).toEqual(["held lesson"]);
       expect(existsSync(join(dir, "knowledge", "grid_ctf", "playbook.pending.md"))).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/ts/tests/playbook-approval-gate.test.ts
+++ b/ts/tests/playbook-approval-gate.test.ts
@@ -56,6 +56,36 @@ describe("playbook approval gate", () => {
     }
   });
 
+  it("auto mode supersedes stale pending approvals", () => {
+    const dir = root();
+    try {
+      const artifacts = store(dir);
+      artifacts.writePlaybook("grid_ctf", "approved playbook");
+      artifacts.writeOrStagePlaybook("grid_ctf", "pending old", {
+        requireApproval: true,
+        sourceRunId: "run-approval",
+        generation: 2,
+        curatorDecision: "advance",
+      });
+
+      expect(
+        artifacts.writeOrStagePlaybook("grid_ctf", "auto new", {
+          requireApproval: false,
+          sourceRunId: "run-auto",
+          generation: 3,
+          curatorDecision: "advance",
+        }),
+      ).toBe("live");
+
+      expect(artifacts.readPlaybook("grid_ctf")).toBe("auto new\n");
+      expect(artifacts.readPendingPlaybook("grid_ctf").hasPending).toBe(false);
+      expect(artifacts.approvePendingPlaybook("grid_ctf")).toEqual({ ok: false, status: "missing" });
+      expect(artifacts.readPlaybook("grid_ctf")).toBe("auto new\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("skips new staging while an unresolved pending playbook exists", () => {
     const dir = root();
     try {


### PR DESCRIPTION
## Summary

- Re-point lesson lifecycle views/actions at live playbook/SKILL markdown instead of `lessons.json`.
- Make lifecycle curation mutate markdown for delete/stale/dead-end actions, with stable hash ids and an explicit stale marker.
- Keep AC-826 approval at the playbook gate: pending playbooks sync lessons into `SKILL.md` only after approval, without structured pending lessons.
- Document the AC-236 sidecar decision: no thin applicability index for now; curator consolidation + stale markers cover the workflow.

## Tests

- `PYTHONPATH=src ../../autocontext/autocontext/.venv/bin/python -m pytest tests/test_lesson_lifecycle.py tests/test_knowledge_lifecycle_api.py tests/test_playbook_approval_gate.py tests/test_playbook_approval_protocol.py tests/test_lesson_applicability.py tests/test_knowledge_api.py tests/test_knowledge_endpoint.py tests/test_protocol.py tests/test_protocol_parity.py tests/test_websocket_protocol_contract.py tests/test_package_boundaries.py tests/test_module_size_limits.py -q`
- `PYTHONPATH=src ../../autocontext/autocontext/.venv/bin/python -m ruff check src/autocontext/knowledge/lifecycle.py src/autocontext/storage/artifacts.py src/autocontext/storage/playbook_approval.py src/autocontext/loop/stage_helpers/persistence_helpers.py src/autocontext/loop/stage_helpers/freshness.py src/autocontext/server/knowledge_api.py src/autocontext/knowledge/lessons.py tests/test_lesson_lifecycle.py tests/test_knowledge_lifecycle_api.py tests/test_playbook_approval_gate.py tests/test_lesson_applicability.py`
- `PYTHONPATH=src ../../autocontext/autocontext/.venv/bin/python -m mypy src/autocontext/knowledge/lifecycle.py src/autocontext/storage/artifacts.py src/autocontext/storage/playbook_approval.py src/autocontext/loop/stage_helpers/persistence_helpers.py src/autocontext/loop/stage_helpers/freshness.py src/autocontext/server/knowledge_api.py src/autocontext/knowledge/lessons.py`
- `npm test -- lesson-lifecycle.test.ts playbook-approval-gate.test.ts knowledge-api-workflow.test.ts run-start-workflow.test.ts server-protocol.test.ts websocket-protocol-contract.test.ts package-export-catalogs.test.ts`
- `npm run lint`
- `npm run build`

Closes AC-827
