### PR TITLE
AC-795 add token-pressure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - AC-825 goal run reports define a shared Python/TypeScript outer supervisor artifact for continue-until-verified execution, resume tokens, budgets, action cadence, verifier state, and durable stop/continuation decisions.
 - AC-826 playbook approval gates stage curator playbook updates as pending artifacts, expose approve/reject/read APIs, and keep approved playbooks in prompts until human approval.
 - AC-827 lesson lifecycle curation now derives from live playbook/SKILL markdown, mutates markdown for delete/stale/dead-end actions, and retires `lessons.json` as a prompt or curation source of truth.
+- AC-795 OPD/GKD training adds opt-in token-pressure diagnostics with parity helpers, summary metrics, and no raw token text unless debug persistence is explicitly enabled.
 
 ## [pi-v0.2.6] - 2026-06-16
 

--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -264,6 +264,21 @@ Notes:
   student's tokenizer. LoRA (PEFT) is applied automatically.
 - `--time-budget` is enforced via a training callback that stops at the next step boundary.
 
+### Token-pressure diagnostics (optional)
+
+`--opd-diagnostics` (or `AUTOCONTEXT_OPD_DIAGNOSTICS=1`) writes
+`token_pressure_diagnostics.json` for `opd` and TRL `gkd` runs. The report summarizes
+teacher-vs-student token logprob margins, positive/negative pressure ratios, position
+hotspots, response lengths, and shock-spike counts for A/B comparisons without changing
+training updates. A positive margin means the teacher assigned the sampled token a higher
+log-probability than the student did; a negative margin means the student was more confident
+than the teacher on its own sampled token. High shock-spike counts mark large disagreements.
+
+Raw token text is omitted by default. Pass `--opd-diagnostics-debug-tokens` only for local
+debugging when the sampled text is safe to persist. The runner summary also includes
+`token_pressure_positive_ratio`, `token_pressure_negative_ratio`, and
+`token_pressure_shock_spike_count` when diagnostics are enabled.
+
 ### Tokenizer vocabulary size (optional)
 
 `--vocab-size` (default 8192) sets the BPE tokenizer's target vocab for the from-scratch

--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -267,10 +267,11 @@ Notes:
 ### Token-pressure diagnostics (optional)
 
 `--opd-diagnostics` (or `AUTOCONTEXT_OPD_DIAGNOSTICS=1`) writes
-`token_pressure_diagnostics.json` for `opd` and TRL `gkd` runs. The report summarizes
-teacher-vs-student token logprob margins, positive/negative pressure ratios, position
-hotspots, response lengths, and shock-spike counts for A/B comparisons without changing
-training updates. A positive margin means the teacher assigned the sampled token a higher
+`token_pressure_diagnostics.json` for `opd` and TRL `gkd` runs when budget remains after
+training. Diagnostics sample at most 8 prompts / 64 new tokens so the post-training check stays
+bounded. The report summarizes teacher-vs-student token logprob margins, positive/negative
+pressure ratios, position hotspots, response lengths, and shock-spike counts for A/B comparisons
+without changing training updates. A positive margin means the teacher assigned the sampled token a higher
 log-probability than the student did; a negative margin means the student was more confident
 than the teacher on its own sampled token. High shock-spike counts mark large disagreements.
 

--- a/autocontext/src/autocontext/cli_train.py
+++ b/autocontext/src/autocontext/cli_train.py
@@ -10,9 +10,9 @@ import logging
 from pathlib import Path
 from typing import Any
 
-import typer
-from rich.console import Console
-from rich.table import Table
+import typer  # type: ignore[import-not-found]
+from rich.console import Console  # type: ignore[import-not-found]
+from rich.table import Table  # type: ignore[import-not-found]
 
 from autocontext.training.autoresearch.r1_pipeline import run_r1_pipeline
 from autocontext.training.autoresearch.sequence_format import BASE_VOCAB_SIZE
@@ -92,6 +92,17 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
         ),
         grpo_beta: float = typer.Option(
             0.04, "--grpo-beta", help="trl grpo: KL penalty toward base policy (0.0 = KL-free; nonzero prevents overfitting)"
+        ),
+        opd_diagnostics: bool = typer.Option(
+            False,
+            "--opd-diagnostics",
+            envvar="AUTOCONTEXT_OPD_DIAGNOSTICS",
+            help="write OPD/GKD token-pressure diagnostics",
+        ),
+        opd_diagnostics_debug_tokens: bool = typer.Option(
+            False,
+            "--opd-diagnostics-debug-tokens",
+            help="include raw sampled token text in diagnostics (off by default)",
         ),
         agent_provider: str = typer.Option("anthropic", "--agent-provider", help="LLM provider for training agent"),
         agent_model: str = typer.Option("", "--agent-model", help="Model for training agent (empty = provider default)"),
@@ -191,6 +202,8 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             seed=seed,
             max_completion_length=max_completion_length,
             grpo_beta=grpo_beta,
+            opd_diagnostics=opd_diagnostics,
+            opd_diagnostics_debug_tokens=opd_diagnostics_debug_tokens,
             fine_tune_type=fine_tune_type,
             num_layers=num_layers,
         )
@@ -210,6 +223,14 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             raise typer.Exit(code=1) from exc
 
         if json_output:
+            best_metrics = next(
+                (
+                    item.summary_metrics
+                    for item in result.results
+                    if item.experiment_index == result.best_experiment_index
+                ),
+                {},
+            )
             _write_json_stdout(
                 {
                     "scenario": result.scenario,
@@ -219,6 +240,7 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
                     "best_score": result.best_score,
                     "checkpoint_path": str(result.checkpoint_path) if result.checkpoint_path else None,
                     "published_model_id": result.published_model_id,
+                    "training_metrics": best_metrics,
                 }
             )
             return

--- a/autocontext/src/autocontext/training/autoresearch/on_policy_distill.py
+++ b/autocontext/src/autocontext/training/autoresearch/on_policy_distill.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 
 import json
 import time
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
-import mlx.core as mx
-import mlx.nn as nn
+import mlx.core as mx  # type: ignore[import-not-found]
+import mlx.nn as nn  # type: ignore[import-not-found]
 
 # Re-exported from the pure (mlx-free) shared module so the cross-platform trl backend can
 # use it without importing this mlx-scoped module; kept importable here for back-compat.
@@ -41,6 +42,7 @@ __all__ = [
     "DEFAULT_TEACHER_MODEL",
     "assert_vocab_compatible",
     "distill_loss",
+    "collect_token_pressure_for_prompts",
     "distill_over_prompts",
     "distill_update_step",
     "_model_logit_vocab",
@@ -186,6 +188,65 @@ def on_policy_distill_step(
     return distill_update_step(student_model, teacher_model, optimizer, full_ids, completion_mask, temperature=kl_temperature)
 
 
+def collect_token_pressure_for_prompts(
+    student_model: Any,
+    teacher_model: Any,
+    prompts: list[mx.array],
+    *,
+    max_tokens: int,
+    sample_temperature: float = 1.0,
+    include_token_text: bool = False,
+    tokenizer: Any | None = None,
+    backend: str = "opd",
+    mode: str = "opd",
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Collect teacher-vs-student sampled-token pressure without updating weights."""
+    token_pressure = import_module("autocontext.training.autoresearch.token_pressure")
+    mx.random.seed(seed)
+    observations: list[Any] = []
+    response_lengths: list[int] = []
+    for prompt_ids in prompts:
+        full_ids, completion_mask = sample_completion(
+            student_model,
+            prompt_ids,
+            max_tokens=max_tokens,
+            temperature=sample_temperature,
+        )
+        full_ids = mx.stop_gradient(full_ids)
+        student_logp = _log_softmax(student_model(full_ids), axis=-1)
+        teacher_logp = _log_softmax(mx.stop_gradient(teacher_model(full_ids)), axis=-1)
+        student_entropy = -mx.sum(mx.exp(student_logp) * student_logp, axis=-1)
+        for row in range(int(full_ids.shape[0])):
+            ids = [int(token) for token in full_ids[row].tolist()]
+            mask = [float(value) for value in completion_mask[row].tolist()]
+            response_lengths.append(sum(1 for value in mask if value > 0))
+            for position, active in enumerate(mask):
+                if active <= 0 or position + 1 >= len(ids):
+                    continue
+                token_id = ids[position + 1]
+                token_text = tokenizer.decode([token_id]) if include_token_text and tokenizer is not None else None
+                observations.append(
+                    token_pressure.TokenPressureObservation(
+                        position=position,
+                        student_logprob=float(student_logp[row, position, token_id]),
+                        teacher_logprob=float(teacher_logp[row, position, token_id]),
+                        student_entropy=float(student_entropy[row, position]),
+                        token_text=token_text,
+                    )
+                )
+    return dict(
+        token_pressure.build_token_pressure_report(
+            observations,
+            backend=backend,
+            mode=mode,
+            seed=seed,
+            response_lengths=response_lengths,
+            include_token_text=include_token_text,
+        )
+    )
+
+
 def distill_over_prompts(
     student_model: Any,
     teacher_model: Any,
@@ -260,6 +321,9 @@ def run_on_policy_distillation(
     register_import: str | None = None,
     time_budget: int = 3600,
     memory_limit_mb: int = 16384,
+    seed: int = 0,
+    opd_diagnostics: bool = False,
+    opd_diagnostics_debug_tokens: bool = False,
 ) -> dict[str, float]:
     """Distill a teacher into a LoRA student IN-PROCESS via on-policy reverse-KL, then assess.
 
@@ -269,10 +333,10 @@ def run_on_policy_distillation(
     tokenizer (default: same Qwen2.5 family). ``register_import`` registers a consumer-repo
     scenario in this process before lookup. Returns backend-standard summary metrics.
     """
-    import mlx.optimizers as optim
-    from mlx.utils import tree_flatten
-    from mlx_lm import load
-    from mlx_lm.tuner.utils import linear_to_lora_layers
+    import mlx.optimizers as optim  # type: ignore[import-not-found]
+    from mlx.utils import tree_flatten  # type: ignore[import-not-found]
+    from mlx_lm import load  # type: ignore[import-not-found]
+    from mlx_lm.tuner.utils import linear_to_lora_layers  # type: ignore[import-not-found]
 
     from autocontext.scenarios import SCENARIO_REGISTRY
     from autocontext.training.autoresearch.grpo_backend import build_prompt_rows
@@ -305,6 +369,8 @@ def run_on_policy_distillation(
     prompts = _tokenize_prompts(tokenizer, rows)
     optimizer = optim.Adam(learning_rate=learning_rate)
 
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pressure_report: dict[str, Any] | None = None
     loop_budget = max(0.0, float(time_budget) - (time.monotonic() - started))
     loop = distill_over_prompts(
         student,
@@ -318,7 +384,22 @@ def run_on_policy_distillation(
         time_budget=loop_budget,
     )
 
-    output_dir.mkdir(parents=True, exist_ok=True)
+    if opd_diagnostics:
+        token_pressure = import_module("autocontext.training.autoresearch.token_pressure")
+        pressure_report = collect_token_pressure_for_prompts(
+            student,
+            teacher,
+            prompts,
+            max_tokens=max_tokens,
+            sample_temperature=sample_temperature,
+            include_token_text=opd_diagnostics_debug_tokens,
+            tokenizer=tokenizer,
+            backend="opd",
+            mode="opd",
+            seed=seed,
+        )
+        token_pressure.write_token_pressure_report(output_dir / "token_pressure_diagnostics.json", pressure_report)
+
     adapter_dir = output_dir / "adapters"
     adapter_dir.mkdir(parents=True, exist_ok=True)
     adapter_weights = dict(tree_flatten(student.trainable_parameters()))
@@ -338,7 +419,7 @@ def run_on_policy_distillation(
         top_k=0,
         score_conditioned=False,
     )
-    return {
+    result = {
         "avg_score": metrics["avg_score"],
         "valid_rate": metrics["valid_rate"],
         "val_loss": float("nan"),
@@ -351,3 +432,12 @@ def run_on_policy_distillation(
         "num_params_m": 0.0,
         "depth": 0.0,
     }
+    if pressure_report is not None:
+        result.update(
+            {
+                "token_pressure_positive_ratio": float(pressure_report["positive_pressure_ratio"]),
+                "token_pressure_negative_ratio": float(pressure_report["negative_pressure_ratio"]),
+                "token_pressure_shock_spike_count": float(pressure_report["shock_spike_count"]),
+            }
+        )
+    return result

--- a/autocontext/src/autocontext/training/autoresearch/on_policy_distill.py
+++ b/autocontext/src/autocontext/training/autoresearch/on_policy_distill.py
@@ -386,19 +386,25 @@ def run_on_policy_distillation(
 
     if opd_diagnostics:
         token_pressure = import_module("autocontext.training.autoresearch.token_pressure")
-        pressure_report = collect_token_pressure_for_prompts(
-            student,
-            teacher,
+        diag_prompts, diag_tokens = token_pressure.bounded_diagnostic_inputs(
             prompts,
-            max_tokens=max_tokens,
-            sample_temperature=sample_temperature,
-            include_token_text=opd_diagnostics_debug_tokens,
-            tokenizer=tokenizer,
-            backend="opd",
-            mode="opd",
-            seed=seed,
+            max_tokens,
+            remaining_seconds=float(time_budget) - (time.monotonic() - started),
         )
-        token_pressure.write_token_pressure_report(output_dir / "token_pressure_diagnostics.json", pressure_report)
+        if diag_prompts:
+            pressure_report = collect_token_pressure_for_prompts(
+                student,
+                teacher,
+                diag_prompts,
+                max_tokens=diag_tokens,
+                sample_temperature=sample_temperature,
+                include_token_text=opd_diagnostics_debug_tokens,
+                tokenizer=tokenizer,
+                backend="opd",
+                mode="opd",
+                seed=seed,
+            )
+            token_pressure.write_token_pressure_report(output_dir / "token_pressure_diagnostics.json", pressure_report)
 
     adapter_dir = output_dir / "adapters"
     adapter_dir.mkdir(parents=True, exist_ok=True)

--- a/autocontext/src/autocontext/training/autoresearch/token_pressure.py
+++ b/autocontext/src/autocontext/training/autoresearch/token_pressure.py
@@ -10,6 +10,9 @@ from pathlib import Path
 from statistics import fmean
 from typing import Any
 
+DEFAULT_DIAGNOSTIC_MAX_PROMPTS = 8
+DEFAULT_DIAGNOSTIC_MAX_TOKENS = 64
+
 
 @dataclass(frozen=True, slots=True)
 class TokenPressureObservation:
@@ -67,6 +70,19 @@ def write_token_pressure_report(path: Path, report: dict[str, Any]) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return path
+
+
+def bounded_diagnostic_inputs(
+    items: Sequence[Any],
+    max_tokens: int,
+    *,
+    remaining_seconds: float,
+    max_prompts: int = DEFAULT_DIAGNOSTIC_MAX_PROMPTS,
+    max_diagnostic_tokens: int = DEFAULT_DIAGNOSTIC_MAX_TOKENS,
+) -> tuple[list[Any], int]:
+    if remaining_seconds <= 0.0 or max_tokens <= 0:
+        return [], 0
+    return list(items)[:max_prompts], min(max_tokens, max_diagnostic_tokens)
 
 
 def compare_token_pressure_reports(reports: list[dict[str, Any]]) -> dict[str, Any]:
@@ -141,7 +157,10 @@ def _max_run(reports: list[dict[str, Any]], key: str) -> str | None:
 
 
 __all__ = [
+    "DEFAULT_DIAGNOSTIC_MAX_PROMPTS",
+    "DEFAULT_DIAGNOSTIC_MAX_TOKENS",
     "TokenPressureObservation",
+    "bounded_diagnostic_inputs",
     "build_token_pressure_report",
     "compare_token_pressure_reports",
     "write_token_pressure_report",

--- a/autocontext/src/autocontext/training/autoresearch/token_pressure.py
+++ b/autocontext/src/autocontext/training/autoresearch/token_pressure.py
@@ -1,0 +1,148 @@
+"""Token-pressure diagnostics for OPD/GKD teacher signals."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import fmean
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class TokenPressureObservation:
+    position: int
+    student_logprob: float
+    teacher_logprob: float
+    student_entropy: float | None = None
+    token_text: str | None = None
+
+    @property
+    def margin(self) -> float:
+        return self.teacher_logprob - self.student_logprob
+
+
+def build_token_pressure_report(
+    observations: list[TokenPressureObservation],
+    *,
+    backend: str,
+    mode: str,
+    seed: int = 0,
+    run_id: str = "",
+    response_lengths: list[int] | None = None,
+    shock_threshold: float = 2.0,
+    include_token_text: bool = False,
+) -> dict[str, Any]:
+    margins = [obs.margin for obs in observations]
+    positive = [m for m in margins if m > 0]
+    negative = [m for m in margins if m < 0]
+    shocks = [obs for obs in observations if abs(obs.margin) >= shock_threshold]
+    total = len(observations)
+    return {
+        "schema_version": 1,
+        "run_id": run_id,
+        "backend": backend,
+        "mode": mode,
+        "seed": seed,
+        "token_count": total,
+        "positive_pressure_ratio": _ratio(len(positive), total),
+        "negative_pressure_ratio": _ratio(len(negative), total),
+        "neutral_pressure_ratio": _ratio(total - len(positive) - len(negative), total),
+        "mean_positive_margin": fmean(positive) if positive else None,
+        "mean_negative_margin": fmean(negative) if negative else None,
+        "mean_margin": fmean(margins) if margins else None,
+        "mean_student_entropy": _mean([obs.student_entropy for obs in observations]),
+        "mean_response_length": fmean(response_lengths) if response_lengths else None,
+        "position_pressure": _position_pressure(observations),
+        "shock_threshold": shock_threshold,
+        "shock_spike_count": len(shocks),
+        "shock_spikes": [_shock(obs, include_token_text=include_token_text) for obs in shocks],
+        "raw_token_text_persisted": include_token_text,
+    }
+
+
+def write_token_pressure_report(path: Path, report: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def compare_token_pressure_reports(reports: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "run_count": len(reports),
+        "mean_positive_pressure_ratio": _mean(_numbers(reports, "positive_pressure_ratio")),
+        "mean_negative_pressure_ratio": _mean(_numbers(reports, "negative_pressure_ratio")),
+        "highest_positive_pressure_run_id": _max_run(reports, "positive_pressure_ratio"),
+        "highest_shock_run_id": _max_run(reports, "shock_spike_count"),
+        "runs": [
+            {
+                "run_id": str(report.get("run_id", "")),
+                "positive_pressure_ratio": report.get("positive_pressure_ratio"),
+                "negative_pressure_ratio": report.get("negative_pressure_ratio"),
+                "shock_spike_count": report.get("shock_spike_count", 0),
+            }
+            for report in reports
+        ],
+    }
+
+
+def _position_pressure(observations: list[TokenPressureObservation]) -> list[dict[str, Any]]:
+    by_position: dict[int, list[TokenPressureObservation]] = defaultdict(list)
+    for obs in observations:
+        by_position[obs.position].append(obs)
+    rows: list[dict[str, Any]] = []
+    for position, items in sorted(by_position.items()):
+        margins = [obs.margin for obs in items]
+        rows.append(
+            {
+                "position": position,
+                "count": len(items),
+                "positive_pressure_ratio": _ratio(sum(1 for margin in margins if margin > 0), len(items)),
+                "negative_pressure_ratio": _ratio(sum(1 for margin in margins if margin < 0), len(items)),
+                "mean_margin": fmean(margins),
+                "mean_student_entropy": _mean([obs.student_entropy for obs in items]),
+            }
+        )
+    return rows
+
+
+def _shock(obs: TokenPressureObservation, *, include_token_text: bool) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "position": obs.position,
+        "margin": obs.margin,
+        "direction": "positive" if obs.margin > 0 else "negative",
+    }
+    if include_token_text:
+        item["token_text"] = obs.token_text or ""
+    return item
+
+
+def _ratio(count: int, total: int) -> float:
+    return 0.0 if total == 0 else count / total
+
+
+def _mean(values: Sequence[float | int | None]) -> float | None:
+    numeric = [float(value) for value in values if value is not None]
+    return fmean(numeric) if numeric else None
+
+
+def _numbers(reports: list[dict[str, Any]], key: str) -> list[float]:
+    return [float(report[key]) for report in reports if isinstance(report.get(key), int | float)]
+
+
+def _max_run(reports: list[dict[str, Any]], key: str) -> str | None:
+    if not reports:
+        return None
+    winner = max(reports, key=lambda report: float(report.get(key) or 0.0))
+    return str(winner.get("run_id", ""))
+
+
+__all__ = [
+    "TokenPressureObservation",
+    "build_token_pressure_report",
+    "compare_token_pressure_reports",
+    "write_token_pressure_report",
+]

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import logging
+import os
 import sys
 import time
 from pathlib import Path
@@ -57,6 +58,9 @@ def format_summary(
     depth: int,
     val_loss: float | None = None,
     num_records: float | None = None,
+    token_pressure_positive_ratio: float | None = None,
+    token_pressure_negative_ratio: float | None = None,
+    token_pressure_shock_spike_count: float | None = None,
 ) -> str:
     """Format the training results summary block.
 
@@ -66,12 +70,33 @@ def format_summary(
     """
     val_loss_line = f"val_loss: {val_loss:.4f}\n" if val_loss is not None else ""
     num_records_line = f"num_records: {int(num_records)}\n" if num_records is not None else ""
+    pressure_lines = "".join(
+        line
+        for line in (
+            (
+                f"token_pressure_positive_ratio: {token_pressure_positive_ratio:.4f}\n"
+                if token_pressure_positive_ratio is not None
+                else ""
+            ),
+            (
+                f"token_pressure_negative_ratio: {token_pressure_negative_ratio:.4f}\n"
+                if token_pressure_negative_ratio is not None
+                else ""
+            ),
+            (
+                f"token_pressure_shock_spike_count: {int(token_pressure_shock_spike_count)}\n"
+                if token_pressure_shock_spike_count is not None
+                else ""
+            ),
+        )
+    )
     return (
         "=== TRAINING SUMMARY ===\n"
         f"avg_score: {avg_score:.4f}\n"
         f"valid_rate: {valid_rate:.4f}\n"
         f"{val_loss_line}"
         f"{num_records_line}"
+        f"{pressure_lines}"
         f"training_seconds: {training_seconds:.1f}\n"
         f"peak_memory_mb: {peak_memory_mb:.1f}\n"
         f"num_steps: {num_steps}\n"
@@ -236,7 +261,7 @@ def _run_mlx_training(
         seq_len=seq_len,
         vocab_size=int(tokenizer.vocab_size),
     )
-    model = GPTModel(cfg)
+    model: Any = GPTModel(cfg)
     optimizer = optim.AdamW(learning_rate=learning_rate)
     loss_and_grad = nn.value_and_grad(model, compute_loss)
 
@@ -369,6 +394,10 @@ def _default_learning_rate(backend: str) -> float:
     return {"mlx": 1e-3, "cuda": 1e-3, "mlxlm": 1e-4}.get(backend, 1e-5)
 
 
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def run_training(
     *,
     scenario_name: str,
@@ -398,6 +427,8 @@ def run_training(
     seed: int = 0,  # trl backend: training seed (for seeded repeats / error bars)
     max_completion_length: int = 512,  # trl grpo: generation cap (>= task answer length; 256 truncates reasoning)
     grpo_beta: float = 0.04,  # trl grpo: KL penalty toward base policy (0.0 = KL-free; nonzero prevents overfitting)
+    opd_diagnostics: bool | None = None,
+    opd_diagnostics_debug_tokens: bool = False,
     fine_tune_type: str = "lora",
     num_layers: int = 8,
     collect_samples_path: Path | None = None,
@@ -415,6 +446,8 @@ def run_training(
         raise ValueError(f"vocab_size must be >= 256 (the byte-level BPE base), got {vocab_size}")
 
     normalized_backend = backend.strip().lower()
+    if opd_diagnostics is None:
+        opd_diagnostics = _env_truthy("AUTOCONTEXT_OPD_DIAGNOSTICS")
     if train_steps <= 0:  # resolve the unset sentinel to a backend-appropriate step count
         train_steps = _default_train_steps(normalized_backend)
     if learning_rate <= 0:  # likewise: a from-scratch LR diverges a LoRA adapter
@@ -515,8 +548,11 @@ def run_training(
             num_layers=num_layers,
             assess_samples=assess_samples,
             assess_temperature=assess_temperature,
+            seed=seed,
             time_budget=time_budget,
             memory_limit_mb=memory_limit_mb,
+            opd_diagnostics=opd_diagnostics,
+            opd_diagnostics_debug_tokens=opd_diagnostics_debug_tokens,
         )
     if normalized_backend == "trl":
         if loss_weight_mode != "uniform" or vocab_size != BASE_VOCAB_SIZE:
@@ -540,6 +576,8 @@ def run_training(
             grpo_beta=grpo_beta,
             time_budget=time_budget,
             memory_limit_mb=memory_limit_mb,
+            opd_diagnostics=opd_diagnostics,
+            opd_diagnostics_debug_tokens=opd_diagnostics_debug_tokens,
         )
     raise ValueError("unsupported training backend: expected 'mlx', 'cuda', 'mlxlm', 'grpo', 'opd', or 'trl'")
 
@@ -560,6 +598,17 @@ def _build_parser() -> argparse.ArgumentParser:
         type=float,
         default=0.04,
         help="trl grpo: KL penalty toward base policy (0.0 = KL-free; nonzero prevents overfitting)",
+    )
+    parser.add_argument(
+        "--opd-diagnostics",
+        action="store_true",
+        default=None,
+        help="write OPD/GKD token-pressure diagnostics (or set AUTOCONTEXT_OPD_DIAGNOSTICS=1)",
+    )
+    parser.add_argument(
+        "--opd-diagnostics-debug-tokens",
+        action="store_true",
+        help="include raw sampled token text in diagnostics (off by default)",
     )
     parser.add_argument("--time-budget", type=int, default=300)
     parser.add_argument("--memory-limit", type=int, default=16384)
@@ -620,6 +669,8 @@ def main(argv: list[str] | None = None) -> int:
             seed=args.seed,
             max_completion_length=args.max_completion_length,
             grpo_beta=args.grpo_beta,
+            opd_diagnostics=args.opd_diagnostics,
+            opd_diagnostics_debug_tokens=args.opd_diagnostics_debug_tokens,
             fine_tune_type=args.fine_tune_type,
             num_layers=args.num_layers,
             backend=args.backend,
@@ -640,6 +691,9 @@ def main(argv: list[str] | None = None) -> int:
             depth=int(metrics["depth"]),
             val_loss=metrics.get("val_loss"),
             num_records=metrics.get("num_records"),
+            token_pressure_positive_ratio=metrics.get("token_pressure_positive_ratio"),
+            token_pressure_negative_ratio=metrics.get("token_pressure_negative_ratio"),
+            token_pressure_shock_spike_count=metrics.get("token_pressure_shock_spike_count"),
         )
     )
     return 0

--- a/autocontext/src/autocontext/training/autoresearch/trl_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/trl_backend.py
@@ -18,6 +18,7 @@ pure config / dataset / reward seams). The trainer-instantiating runner imports
 from __future__ import annotations
 
 import time
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -43,6 +44,7 @@ __all__ = [
     "build_prompt_dataset_rows",
     "make_reward_func",
     "make_time_budget_callback",
+    "collect_hf_token_pressure",
     "run_trl_training",
 ]
 
@@ -55,9 +57,9 @@ def _import_gkd() -> tuple[Any, Any]:
     works regardless of the resolved TRL version instead of failing on import mid-run.
     """
     try:
-        from trl.experimental.gkd import GKDConfig, GKDTrainer
+        from trl.experimental.gkd import GKDConfig, GKDTrainer  # type: ignore[import-not-found]
     except ImportError:
-        from trl import GKDConfig, GKDTrainer
+        from trl import GKDConfig, GKDTrainer  # type: ignore[import-not-found]
     return GKDConfig, GKDTrainer
 
 
@@ -195,13 +197,75 @@ def make_reward_func(scenario: Any) -> Any:
     return _reward
 
 
+def collect_hf_token_pressure(
+    *,
+    student_lm: Any,
+    teacher_lm: Any,
+    tokenizer: Any,
+    prompt_rows: list[dict[str, str]],
+    max_new_tokens: int,
+    include_token_text: bool = False,
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Collect GKD sampled-token pressure without running optimizer steps."""
+    import torch  # type: ignore[import-not-found]
+
+    token_pressure = import_module("autocontext.training.autoresearch.token_pressure")
+    torch.manual_seed(seed)
+    observations: list[Any] = []
+    response_lengths: list[int] = []
+    device = getattr(student_lm, "device", None)
+    teacher_device = getattr(teacher_lm, "device", device)
+    for row in prompt_rows:
+        encoded = tokenizer(row["prompt"], return_tensors="pt")
+        if device is not None:
+            encoded = encoded.to(device)
+        with torch.no_grad():
+            generated = student_lm.generate(
+                **encoded,
+                max_new_tokens=max_new_tokens,
+                do_sample=False,
+                pad_token_id=getattr(tokenizer, "eos_token_id", None),
+            )
+            student_logits = student_lm(generated).logits
+            teacher_logits = teacher_lm(generated.to(teacher_device)).logits.to(student_logits.device)
+            student_logp = torch.log_softmax(student_logits, dim=-1)
+            teacher_logp = torch.log_softmax(teacher_logits, dim=-1)
+            entropy = -(student_logp.exp() * student_logp).sum(dim=-1)
+        prompt_len = int(encoded["input_ids"].shape[1])
+        total_len = int(generated.shape[1])
+        response_lengths.append(max(total_len - prompt_len, 0))
+        for position in range(max(prompt_len - 1, 0), max(total_len - 1, 0)):
+            token_id = int(generated[0, position + 1].item())
+            token_text = tokenizer.decode([token_id]) if include_token_text else None
+            observations.append(
+                token_pressure.TokenPressureObservation(
+                    position=position,
+                    student_logprob=float(student_logp[0, position, token_id].item()),
+                    teacher_logprob=float(teacher_logp[0, position, token_id].item()),
+                    student_entropy=float(entropy[0, position].item()),
+                    token_text=token_text,
+                )
+            )
+    return dict(
+        token_pressure.build_token_pressure_report(
+            observations,
+            backend="trl",
+            mode="gkd",
+            seed=seed,
+            response_lengths=response_lengths,
+            include_token_text=include_token_text,
+        )
+    )
+
+
 def make_time_budget_callback(time_budget: float) -> Any:
     """A ``transformers.TrainerCallback`` that stops training once ``time_budget`` (s) elapses.
 
     TRL/transformers loops run to ``num_train_epochs``/``max_steps`` with no wall-clock cap,
     so this enforces the budget at step boundaries (transformers imported lazily so the
     module stays importable without it)."""
-    from transformers import TrainerCallback
+    from transformers import TrainerCallback  # type: ignore[import-not-found]
 
     class _TimeBudgetCallback(TrainerCallback):  # type: ignore[misc, valid-type]
         def __init__(self, budget: float) -> None:
@@ -230,6 +294,8 @@ def run_trl_training(
     seed: int = 0,
     max_completion_length: int = 512,  # grpo: generation cap (>= task answer length; see build_grpo_config_kwargs)
     grpo_beta: float = 0.04,  # grpo: KL penalty toward the base policy (0.0 = KL-free; nonzero prevents overfitting)
+    opd_diagnostics: bool = False,
+    opd_diagnostics_debug_tokens: bool = False,
     register_import: str | None = None,
     time_budget: int = 3600,
     memory_limit_mb: int = 16384,  # noqa: ARG001 - backend-signature parity
@@ -245,9 +311,9 @@ def run_trl_training(
     if mode not in SUPPORTED_MODES:
         raise ValueError(f"trl mode must be one of {SUPPORTED_MODES}, got {mode!r}")
 
-    from datasets import Dataset
-    from peft import LoraConfig
-    from transformers import AutoModelForCausalLM, AutoTokenizer
+    from datasets import Dataset  # type: ignore[import-not-found]
+    from peft import LoraConfig  # type: ignore[import-not-found]
+    from transformers import AutoModelForCausalLM, AutoTokenizer  # type: ignore[import-not-found]
 
     from autocontext.scenarios import SCENARIO_REGISTRY
     from autocontext.training.autoresearch.distill_common import assert_vocab_compatible, build_trl_metrics
@@ -268,6 +334,10 @@ def run_trl_training(
     started = time.monotonic()
     callbacks = [make_time_budget_callback(float(time_budget))]
 
+    pressure_report: dict[str, Any] | None = None
+    student_lm: Any = None
+    teacher_lm: Any = None
+    prompt_rows: list[dict[str, str]] = []
     if mode == "gkd":
         gkd_config_cls, gkd_trainer_cls = _import_gkd()
 
@@ -281,7 +351,18 @@ def run_trl_training(
         t_vocab = getattr(teacher_lm.config, "vocab_size", None)
         if isinstance(s_vocab, int) and isinstance(t_vocab, int):
             assert_vocab_compatible(s_vocab, t_vocab)
-        dataset = Dataset.from_list(build_chat_dataset_rows(scenario, n_prompts))
+        prompt_rows = build_prompt_rows(scenario, n_prompts)
+        dataset = Dataset.from_list(
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": row["prompt"]},
+                        {"role": "assistant", "content": "(on-policy: resampled from the student)"},
+                    ]
+                }
+                for row in prompt_rows
+            ]
+        )
         gkd_kwargs: dict[str, Any] = dict(
             output_dir=str(output_dir),
             teacher_model=teacher_model,
@@ -302,7 +383,7 @@ def run_trl_training(
             callbacks=callbacks,
         )
     else:  # grpo
-        from trl import GRPOConfig, GRPOTrainer
+        from trl import GRPOConfig, GRPOTrainer  # type: ignore[import-not-found]
 
         dataset = Dataset.from_list(build_prompt_dataset_rows(scenario, n_prompts))
         grpo_kwargs: dict[str, Any] = dict(
@@ -328,13 +409,34 @@ def run_trl_training(
 
     train_output = trainer.train()
     trainer.save_model(str(output_dir))
+    if mode == "gkd" and opd_diagnostics:
+        token_pressure = import_module("autocontext.training.autoresearch.token_pressure")
+        pressure_report = collect_hf_token_pressure(
+            student_lm=student_lm,
+            teacher_lm=teacher_lm,
+            tokenizer=tokenizer,
+            prompt_rows=prompt_rows,
+            max_new_tokens=max_completion_length,
+            include_token_text=opd_diagnostics_debug_tokens,
+            seed=seed,
+        )
+        token_pressure.write_token_pressure_report(output_dir / "token_pressure_diagnostics.json", pressure_report)
     training_loss = float(getattr(train_output, "training_loss", float("nan")))
     num_steps = float(getattr(getattr(trainer, "state", None), "global_step", 0) or 0)
     # build_trl_metrics gives a FINITE avg_score (negative training loss) so the training
     # runner's keep/discard comparison selects this checkpoint instead of discarding on NaN.
-    return build_trl_metrics(
+    result = build_trl_metrics(
         training_loss=training_loss,
         num_steps=num_steps,
         training_seconds=time.monotonic() - started,
         peak_memory_mb=_peak_memory_mb(),
     )
+    if pressure_report is not None:
+        result.update(
+            {
+                "token_pressure_positive_ratio": float(pressure_report["positive_pressure_ratio"]),
+                "token_pressure_negative_ratio": float(pressure_report["negative_pressure_ratio"]),
+                "token_pressure_shock_spike_count": float(pressure_report["shock_spike_count"]),
+            }
+        )
+    return result

--- a/autocontext/src/autocontext/training/autoresearch/trl_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/trl_backend.py
@@ -197,6 +197,14 @@ def make_reward_func(scenario: Any) -> Any:
     return _reward
 
 
+def _gkd_diagnostic_prompt_text(tokenizer: Any, row: dict[str, str]) -> str:
+    messages = [{"role": "user", "content": row["prompt"]}]
+    apply_chat_template = getattr(tokenizer, "apply_chat_template", None)
+    if callable(apply_chat_template):
+        return str(apply_chat_template(messages, tokenize=False, add_generation_prompt=True))
+    return row["prompt"]
+
+
 def collect_hf_token_pressure(
     *,
     student_lm: Any,
@@ -217,7 +225,7 @@ def collect_hf_token_pressure(
     device = getattr(student_lm, "device", None)
     teacher_device = getattr(teacher_lm, "device", device)
     for row in prompt_rows:
-        encoded = tokenizer(row["prompt"], return_tensors="pt")
+        encoded = tokenizer(_gkd_diagnostic_prompt_text(tokenizer, row), return_tensors="pt")
         if device is not None:
             encoded = encoded.to(device)
         with torch.no_grad():
@@ -352,17 +360,7 @@ def run_trl_training(
         if isinstance(s_vocab, int) and isinstance(t_vocab, int):
             assert_vocab_compatible(s_vocab, t_vocab)
         prompt_rows = build_prompt_rows(scenario, n_prompts)
-        dataset = Dataset.from_list(
-            [
-                {
-                    "messages": [
-                        {"role": "user", "content": row["prompt"]},
-                        {"role": "assistant", "content": "(on-policy: resampled from the student)"},
-                    ]
-                }
-                for row in prompt_rows
-            ]
-        )
+        dataset = Dataset.from_list(build_chat_dataset_rows(scenario, n_prompts))
         gkd_kwargs: dict[str, Any] = dict(
             output_dir=str(output_dir),
             teacher_model=teacher_model,
@@ -411,16 +409,22 @@ def run_trl_training(
     trainer.save_model(str(output_dir))
     if mode == "gkd" and opd_diagnostics:
         token_pressure = import_module("autocontext.training.autoresearch.token_pressure")
-        pressure_report = collect_hf_token_pressure(
-            student_lm=student_lm,
-            teacher_lm=teacher_lm,
-            tokenizer=tokenizer,
-            prompt_rows=prompt_rows,
-            max_new_tokens=max_completion_length,
-            include_token_text=opd_diagnostics_debug_tokens,
-            seed=seed,
+        diag_rows, diag_tokens = token_pressure.bounded_diagnostic_inputs(
+            prompt_rows,
+            max_completion_length,
+            remaining_seconds=float(time_budget) - (time.monotonic() - started),
         )
-        token_pressure.write_token_pressure_report(output_dir / "token_pressure_diagnostics.json", pressure_report)
+        if diag_rows:
+            pressure_report = collect_hf_token_pressure(
+                student_lm=student_lm,
+                teacher_lm=teacher_lm,
+                tokenizer=tokenizer,
+                prompt_rows=diag_rows,
+                max_new_tokens=diag_tokens,
+                include_token_text=opd_diagnostics_debug_tokens,
+                seed=seed,
+            )
+            token_pressure.write_token_pressure_report(output_dir / "token_pressure_diagnostics.json", pressure_report)
     training_loss = float(getattr(train_output, "training_loss", float("nan")))
     num_steps = float(getattr(getattr(trainer, "state", None), "global_step", 0) or 0)
     # build_trl_metrics gives a FINITE avg_score (negative training loss) so the training

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -662,6 +662,7 @@ class TrainingRunner:
             if key in best_result.summary_metrics:
                 training_metrics[key] = best_result.summary_metrics[key]
 
+        diagnostics_written = "token_pressure_positive_ratio" in best_result.summary_metrics
         completion = TrainingCompletionOutput(
             run_id=self._training_run_id(),
             checkpoint_path=str(best_result.checkpoint_path),
@@ -686,10 +687,10 @@ class TrainingRunner:
                 # subprocess applies that same default (an empty value is unservable).
                 "base_model": self.config.base_model or self._backend.default_base_model(),
                 "score_conditioned": self.config.score_conditioned,
-                "opd_diagnostics": self.config.opd_diagnostics,
+                "opd_diagnostics": diagnostics_written,
                 "opd_diagnostics_path": (
                     str(best_result.checkpoint_path / "token_pressure_diagnostics.json")
-                    if self.config.opd_diagnostics and best_result.checkpoint_path is not None
+                    if diagnostics_written and best_result.checkpoint_path is not None
                     else ""
                 ),
             },

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -75,6 +75,8 @@ class TrainingConfig:
     seed: int = 0  # trl backend: training seed (for seeded repeats)
     max_completion_length: int = 512  # trl grpo: generation cap (256 truncates reasoning -> 0 reward / no gradient)
     grpo_beta: float = 0.04  # trl grpo: KL penalty toward base policy (0.0 = KL-free; nonzero prevents overfitting)
+    opd_diagnostics: bool = False  # OPD/GKD token-pressure report; no training-update changes
+    opd_diagnostics_debug_tokens: bool = False  # include sampled token text in diagnostics (off by default)
     fine_tune_type: str = "lora"  # mlxlm backend: lora | dora | full
     num_layers: int = 8  # mlxlm backend: number of layers to fine-tune
 
@@ -443,6 +445,10 @@ class TrainingRunner:
             command += ["--max-completion-length", str(self.config.max_completion_length)]
         if self.config.grpo_beta != 0.04:
             command += ["--grpo-beta", str(self.config.grpo_beta)]
+        if self.config.opd_diagnostics:
+            command.append("--opd-diagnostics")
+        if self.config.opd_diagnostics_debug_tokens:
+            command.append("--opd-diagnostics-debug-tokens")
         if self.config.fine_tune_type != "lora":
             command += ["--fine-tune-type", self.config.fine_tune_type]
         if self.config.num_layers != 8:
@@ -639,6 +645,23 @@ class TrainingRunner:
 
         settings = load_settings()
         registry = ModelRegistry(settings.knowledge_root)
+        training_metrics = {
+            "avg_score": best_result.avg_score,
+            "valid_rate": best_result.valid_rate,
+            "val_loss": best_result.summary_metrics.get("val_loss", float("nan")),
+            "peak_memory_mb": best_result.peak_memory_mb,
+            "training_seconds": best_result.training_seconds,
+            "num_steps": best_result.summary_metrics.get("num_steps", 0.0),
+            "depth": best_result.summary_metrics.get("depth", 0.0),
+        }
+        for key in (
+            "token_pressure_positive_ratio",
+            "token_pressure_negative_ratio",
+            "token_pressure_shock_spike_count",
+        ):
+            if key in best_result.summary_metrics:
+                training_metrics[key] = best_result.summary_metrics[key]
+
         completion = TrainingCompletionOutput(
             run_id=self._training_run_id(),
             checkpoint_path=str(best_result.checkpoint_path),
@@ -647,15 +670,7 @@ class TrainingRunner:
             scenario_family=self._scenario_family_name(),
             parameter_count=max(int(num_params_m * 1_000_000), 1),
             architecture="autoresearch_gpt",
-            training_metrics={
-                "avg_score": best_result.avg_score,
-                "valid_rate": best_result.valid_rate,
-                "val_loss": best_result.summary_metrics.get("val_loss", float("nan")),
-                "peak_memory_mb": best_result.peak_memory_mb,
-                "training_seconds": best_result.training_seconds,
-                "num_steps": best_result.summary_metrics.get("num_steps", 0.0),
-                "depth": best_result.summary_metrics.get("depth", 0.0),
-            },
+            training_metrics=training_metrics,
             data_stats=self._data_stats(best_result),
             runtime_types=self._backend.supported_runtime_types(),
             metadata={
@@ -671,6 +686,12 @@ class TrainingRunner:
                 # subprocess applies that same default (an empty value is unservable).
                 "base_model": self.config.base_model or self._backend.default_base_model(),
                 "score_conditioned": self.config.score_conditioned,
+                "opd_diagnostics": self.config.opd_diagnostics,
+                "opd_diagnostics_path": (
+                    str(best_result.checkpoint_path / "token_pressure_diagnostics.json")
+                    if self.config.opd_diagnostics and best_result.checkpoint_path is not None
+                    else ""
+                ),
             },
         )
         record = publish_training_output(

--- a/autocontext/tests/test_on_policy_distill.py
+++ b/autocontext/tests/test_on_policy_distill.py
@@ -8,6 +8,7 @@ with hand-computed values and the frozen-teacher gradient contract (pure mlx, no
 from __future__ import annotations
 
 import math
+from typing import Any
 
 import pytest
 
@@ -19,6 +20,7 @@ optim = pytest.importorskip("mlx.optimizers")
 
 from autocontext.training.autoresearch.on_policy_distill import (  # noqa: E402
     assert_vocab_compatible,
+    collect_token_pressure_for_prompts,
     distill_loss,
     distill_over_prompts,
     distill_update_step,
@@ -36,7 +38,7 @@ class _TinyLM(nn.Module):
         self.embed = nn.Embedding(vocab, dim)
         self.out = nn.Linear(dim, vocab)
 
-    def __call__(self, ids: mx.array) -> mx.array:
+    def __call__(self, ids: Any) -> Any:
         return self.out(self.embed(ids))
 
 
@@ -47,7 +49,7 @@ class _ConstLM:
         self.vocab = vocab
         self.hot = hot
 
-    def __call__(self, ids: mx.array) -> mx.array:
+    def __call__(self, ids: Any) -> Any:
         b, t = ids.shape
         onehot = (mx.arange(self.vocab) == self.hot).astype(mx.float32) * 10.0
         return mx.broadcast_to(onehot, (b, t, self.vocab))
@@ -181,6 +183,25 @@ def test_on_policy_distill_step_runs_and_changes_student() -> None:
 
     assert math.isfinite(loss)
     assert before != after  # the step updated the student's parameters
+
+
+def test_collect_token_pressure_does_not_update_student_weights() -> None:
+    mx.random.seed(17)
+    student = _TinyLM(vocab=6, dim=4)
+    teacher = _TinyLM(vocab=6, dim=4)
+    prompts = [mx.array([[1, 2]])]
+    before = float(mx.sum(mx.abs(student.out.weight)))
+
+    report = collect_token_pressure_for_prompts(
+        student,
+        teacher,
+        prompts,
+        max_tokens=2,
+        sample_temperature=0.0,
+    )
+
+    assert report["token_count"] == 2
+    assert float(mx.sum(mx.abs(student.out.weight))) == before
 
 
 def test_distill_over_prompts_runs_all_iters_and_trains() -> None:

--- a/autocontext/tests/test_opd_diagnostics_routing.py
+++ b/autocontext/tests/test_opd_diagnostics_routing.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _summary() -> dict[str, float]:
+    return {
+        "avg_score": 0.4,
+        "valid_rate": 1.0,
+        "training_seconds": 0.0,
+        "peak_memory_mb": 0.0,
+        "num_steps": 0.0,
+        "num_params_m": 0.0,
+        "depth": 0.0,
+    }
+
+
+def test_run_training_forwards_opd_diagnostics_to_opd_backend(monkeypatch, tmp_path):
+    train_mod = importlib.import_module("autocontext.training.autoresearch.train")
+    captured: dict = {}
+    stub = types.ModuleType("autocontext.training.autoresearch.on_policy_distill")
+    stub.__dict__["run_on_policy_distillation"] = lambda **kw: captured.update(kw) or _summary()
+    monkeypatch.setitem(sys.modules, stub.__name__, stub)
+    monkeypatch.setattr(train_mod, "_preflight_backend_deps", lambda backend: None)
+
+    train_mod.run_training(
+        scenario_name="grid_ctf",
+        data_path=tmp_path / "d.jsonl",
+        output_dir=tmp_path / "o",
+        time_budget=10,
+        memory_limit_mb=1024,
+        backend="opd",
+        opd_diagnostics=True,
+        opd_diagnostics_debug_tokens=True,
+    )
+
+    assert captured["opd_diagnostics"] is True
+    assert captured["opd_diagnostics_debug_tokens"] is True
+
+
+def test_run_training_uses_opd_diagnostics_env_mirror(monkeypatch, tmp_path):
+    train_mod = importlib.import_module("autocontext.training.autoresearch.train")
+    captured: dict = {}
+    stub = types.ModuleType("autocontext.training.autoresearch.on_policy_distill")
+    stub.__dict__["run_on_policy_distillation"] = lambda **kw: captured.update(kw) or _summary()
+    monkeypatch.setitem(sys.modules, stub.__name__, stub)
+    monkeypatch.setattr(train_mod, "_preflight_backend_deps", lambda backend: None)
+    monkeypatch.setenv("AUTOCONTEXT_OPD_DIAGNOSTICS", "true")
+
+    train_mod.run_training(
+        scenario_name="grid_ctf",
+        data_path=tmp_path / "d.jsonl",
+        output_dir=tmp_path / "o",
+        time_budget=10,
+        memory_limit_mb=1024,
+        backend="opd",
+    )
+
+    assert captured["opd_diagnostics"] is True
+
+
+def test_run_training_forwards_opd_diagnostics_to_trl_gkd(monkeypatch, tmp_path):
+    train_mod = importlib.import_module("autocontext.training.autoresearch.train")
+    trl_mod = importlib.import_module("autocontext.training.autoresearch.trl_backend")
+    captured: dict = {}
+    monkeypatch.setattr(train_mod, "_preflight_backend_deps", lambda backend: None)
+    monkeypatch.setattr(
+        trl_mod,
+        "run_trl_training",
+        lambda **kw: captured.update(kw) or {"avg_score": 0.0, "valid_rate": 1.0},
+    )
+
+    train_mod.run_training(
+        scenario_name="grid_ctf",
+        data_path=tmp_path / "d.jsonl",
+        output_dir=tmp_path / "o",
+        time_budget=10,
+        memory_limit_mb=1024,
+        backend="trl",
+        trl_mode="gkd",
+        opd_diagnostics=True,
+    )
+
+    assert captured["opd_diagnostics"] is True

--- a/autocontext/tests/test_token_pressure_diagnostics.py
+++ b/autocontext/tests/test_token_pressure_diagnostics.py
@@ -83,6 +83,20 @@ def test_token_pressure_report_debug_tokens_are_explicit_opt_in() -> None:
     assert report["shock_spikes"][0]["token_text"] == "debug-token"
 
 
+def test_bounded_diagnostic_inputs_caps_prompt_and_token_budget() -> None:
+    token_pressure = _token_pressure()
+
+    prompts, max_tokens = token_pressure.bounded_diagnostic_inputs(
+        list(range(20)),
+        512,
+        remaining_seconds=1.0,
+    )
+
+    assert prompts == list(range(8))
+    assert max_tokens == 64
+    assert token_pressure.bounded_diagnostic_inputs([1, 2], 512, remaining_seconds=0.0) == ([], 0)
+
+
 def test_compare_token_pressure_reports_orders_runs_for_ab_comparison() -> None:
     token_pressure = _token_pressure()
     comparison = token_pressure.compare_token_pressure_reports(

--- a/autocontext/tests/test_token_pressure_diagnostics.py
+++ b/autocontext/tests/test_token_pressure_diagnostics.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _token_pressure() -> Any:
+    return importlib.import_module("autocontext.training.autoresearch.token_pressure")
+
+
+def test_token_pressure_report_summarizes_margins_without_token_text(tmp_path: Path) -> None:
+    token_pressure = _token_pressure()
+    report = token_pressure.build_token_pressure_report(
+        [
+            token_pressure.TokenPressureObservation(
+                position=0,
+                student_logprob=-2.0,
+                teacher_logprob=-1.0,
+                student_entropy=0.7,
+                token_text="secret",
+            ),
+            token_pressure.TokenPressureObservation(
+                position=1,
+                student_logprob=-0.1,
+                teacher_logprob=-1.1,
+                student_entropy=0.2,
+                token_text="token",
+            ),
+            token_pressure.TokenPressureObservation(
+                position=1,
+                student_logprob=-4.0,
+                teacher_logprob=-0.5,
+                student_entropy=0.3,
+                token_text="spike",
+            ),
+        ],
+        backend="opd",
+        mode="opd",
+        seed=7,
+        response_lengths=[2, 3],
+        shock_threshold=2.0,
+    )
+
+    assert report["schema_version"] == 1
+    assert report["backend"] == "opd"
+    assert report["mode"] == "opd"
+    assert report["seed"] == 7
+    assert report["token_count"] == 3
+    assert report["positive_pressure_ratio"] == 2 / 3
+    assert report["negative_pressure_ratio"] == 1 / 3
+    assert report["mean_positive_margin"] == 2.25
+    assert report["mean_negative_margin"] == -1.0
+    assert report["mean_response_length"] == 2.5
+    assert report["shock_spike_count"] == 1
+    assert report["position_pressure"][1]["count"] == 2
+    assert report["raw_token_text_persisted"] is False
+    assert "secret" not in json.dumps(report)
+
+    path = token_pressure.write_token_pressure_report(tmp_path / "pressure.json", report)
+    assert json.loads(path.read_text(encoding="utf-8"))["token_count"] == 3
+
+
+def test_token_pressure_report_debug_tokens_are_explicit_opt_in() -> None:
+    token_pressure = _token_pressure()
+    report = token_pressure.build_token_pressure_report(
+        [
+            token_pressure.TokenPressureObservation(
+                position=0,
+                student_logprob=-5.0,
+                teacher_logprob=-1.0,
+                token_text="debug-token",
+            )
+        ],
+        backend="trl",
+        mode="gkd",
+        include_token_text=True,
+        shock_threshold=1.0,
+    )
+
+    assert report["raw_token_text_persisted"] is True
+    assert report["shock_spikes"][0]["token_text"] == "debug-token"
+
+
+def test_compare_token_pressure_reports_orders_runs_for_ab_comparison() -> None:
+    token_pressure = _token_pressure()
+    comparison = token_pressure.compare_token_pressure_reports(
+        [
+            {"run_id": "neg", "positive_pressure_ratio": 0.25, "negative_pressure_ratio": 0.75, "shock_spike_count": 3},
+            {"run_id": "pos", "positive_pressure_ratio": 0.75, "negative_pressure_ratio": 0.25, "shock_spike_count": 1},
+        ]
+    )
+
+    assert comparison["run_count"] == 2
+    assert comparison["mean_positive_pressure_ratio"] == 0.5
+    assert comparison["highest_positive_pressure_run_id"] == "pos"
+    assert comparison["highest_shock_run_id"] == "neg"

--- a/autocontext/tests/test_train_summary.py
+++ b/autocontext/tests/test_train_summary.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import importlib
+
+
+def _train_module():
+    return importlib.import_module("autocontext.training.autoresearch.train")
+
+
+def _runner_module():
+    return importlib.import_module("autocontext.training.runner")
+
 
 def test_format_summary_no_mlx() -> None:
     """format_summary works even without MLX installed."""
-    from autocontext.training.autoresearch.train import format_summary
-
-    result = format_summary(
+    result = _train_module().format_summary(
         avg_score=0.85,
         valid_rate=0.99,
         training_seconds=60.0,
@@ -19,15 +27,11 @@ def test_format_summary_no_mlx() -> None:
     assert "avg_score: 0.8500" in result
     assert "valid_rate: 0.9900" in result
     assert "depth: 4" in result
-    # val_loss omitted when not provided (keeps existing callers unchanged)
     assert "val_loss" not in result
 
 
 def test_format_summary_includes_val_loss_when_provided() -> None:
-    """When val_loss is provided it is emitted so the runner/CLI can surface it."""
-    from autocontext.training.autoresearch.train import format_summary
-
-    result = format_summary(
+    result = _train_module().format_summary(
         avg_score=0.85,
         valid_rate=0.99,
         training_seconds=60.0,
@@ -41,11 +45,9 @@ def test_format_summary_includes_val_loss_when_provided() -> None:
 
 
 def test_parse_summary_picks_up_val_loss() -> None:
-    """TrainingRunner.parse_summary surfaces the val_loss line from the block."""
-    from autocontext.training.autoresearch.train import format_summary
-    from autocontext.training.runner import TrainingRunner
-
-    block = format_summary(
+    train = _train_module()
+    runner_mod = _runner_module()
+    block = train.format_summary(
         avg_score=0.5,
         valid_rate=1.0,
         training_seconds=1.0,
@@ -55,30 +57,43 @@ def test_parse_summary_picks_up_val_loss() -> None:
         depth=4,
         val_loss=0.789,
     )
-    runner = TrainingRunner.__new__(TrainingRunner)  # parse_summary is pure; skip __init__
-    parsed = TrainingRunner.parse_summary(runner, block)
+    runner = runner_mod.TrainingRunner.__new__(runner_mod.TrainingRunner)
+    parsed = runner_mod.TrainingRunner.parse_summary(runner, block)
     assert parsed is not None
     assert parsed["val_loss"] == 0.789
 
 
-def test_default_train_steps_distinguishes_from_scratch_vs_adapter() -> None:
-    """A from-scratch GPT converges in a few steps; pretrained-adapter backends need far more,
-    so the unset (<=0) sentinel must resolve to different defaults per backend family."""
-    from autocontext.training.autoresearch.train import _default_train_steps
+def test_format_summary_includes_token_pressure_metrics_when_provided() -> None:
+    result = _train_module().format_summary(
+        avg_score=0.5,
+        valid_rate=1.0,
+        training_seconds=1.0,
+        peak_memory_mb=10.0,
+        num_steps=3,
+        num_params_m=0.1,
+        depth=4,
+        token_pressure_positive_ratio=0.75,
+        token_pressure_negative_ratio=0.25,
+        token_pressure_shock_spike_count=2,
+    )
 
-    assert _default_train_steps("mlx") == 8
-    assert _default_train_steps("cuda") == 8
+    assert "token_pressure_positive_ratio: 0.7500" in result
+    assert "token_pressure_negative_ratio: 0.2500" in result
+    assert "token_pressure_shock_spike_count: 2" in result
+
+
+def test_default_train_steps_distinguishes_from_scratch_vs_adapter() -> None:
+    train = _train_module()
+    assert train._default_train_steps("mlx") == 8
+    assert train._default_train_steps("cuda") == 8
     for adapter in ("mlxlm", "opd", "grpo", "trl"):
-        assert _default_train_steps(adapter) == 100, adapter
+        assert train._default_train_steps(adapter) == 100, adapter
 
 
 def test_default_learning_rate_per_backend() -> None:
-    """A from-scratch LR (1e-3) diverges a LoRA adapter; each adapter backend resolves to the
-    rate its own entry point is tuned for when --learning-rate is left unset."""
-    from autocontext.training.autoresearch.train import _default_learning_rate
-
-    assert _default_learning_rate("mlx") == 1e-3
-    assert _default_learning_rate("cuda") == 1e-3
-    assert _default_learning_rate("mlxlm") == 1e-4
+    train = _train_module()
+    assert train._default_learning_rate("mlx") == 1e-3
+    assert train._default_learning_rate("cuda") == 1e-3
+    assert train._default_learning_rate("mlxlm") == 1e-4
     for rlvr in ("opd", "grpo", "trl"):
-        assert _default_learning_rate(rlvr) == 1e-5, rlvr
+        assert train._default_learning_rate(rlvr) == 1e-5, rlvr

--- a/autocontext/tests/test_training_runner.py
+++ b/autocontext/tests/test_training_runner.py
@@ -654,11 +654,49 @@ class TestTrainingLoop:
         assert registry_record["backend"] == "mlx"
         assert registry_record["runtime_types"] == ["provider", "pi"]
         assert registry_record["training_metrics"]["token_pressure_positive_ratio"] == 0.75
+        assert registry_record["metadata"]["opd_diagnostics"] is True
+        assert registry_record["metadata"]["opd_diagnostics_path"] == str(checkpoint_path / "token_pressure_diagnostics.json")
 
         artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
         assert artifact["artifact_type"] == "distilled_model"
         assert artifact["scenario"] == "grid_ctf"
         assert artifact["checkpoint_path"] == str(checkpoint_path)
+
+    def test_build_training_result_does_not_publish_missing_diagnostics_path(self, tmp_path: Path) -> None:
+        cfg = TrainingConfig(
+            scenario="grid_ctf",
+            data_path=tmp_path / "data.jsonl",
+            max_experiments=1,
+            opd_diagnostics=True,
+        )
+        (tmp_path / "data.jsonl").write_text("{}\n", encoding="utf-8")
+        checkpoint_path = tmp_path / "workspace" / "checkpoints" / "exp_0"
+        checkpoint_path.mkdir(parents=True, exist_ok=True)
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+        settings = AppSettings(
+            knowledge_root=tmp_path / "knowledge",
+            runs_root=tmp_path / "runs",
+            skills_root=tmp_path / "skills",
+            claude_skills_path=tmp_path / ".claude" / "skills",
+        )
+        best = ExperimentResult(
+            experiment_index=0,
+            avg_score=0.75,
+            valid_rate=1.0,
+            peak_memory_mb=1024.0,
+            training_seconds=12.0,
+            outcome=ExperimentOutcome.KEPT,
+            checkpoint_path=checkpoint_path,
+            summary_metrics={"num_params_M": 1.25},
+        )
+
+        with patch("autocontext.training.runner.load_settings", return_value=settings):
+            result = runner.build_training_result([best])
+
+        registry_path = settings.knowledge_root / "model_registry" / f"{result.published_model_id}.json"
+        registry_record = json.loads(registry_path.read_text(encoding="utf-8"))
+        assert registry_record["metadata"]["opd_diagnostics"] is False
+        assert registry_record["metadata"]["opd_diagnostics_path"] == ""
 
     def test_build_training_result_respects_selected_backend(self, tmp_path: Path) -> None:
         cfg = TrainingConfig(

--- a/autocontext/tests/test_training_runner.py
+++ b/autocontext/tests/test_training_runner.py
@@ -6,6 +6,7 @@ import json
 import subprocess
 import textwrap
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -344,6 +345,23 @@ class TestConstraints:
             runner2._run_experiment_subprocess(0)
         assert "--max-completion-length" not in mock_run2.call_args.args[0]
 
+    def test_experiment_subprocess_passes_opd_diagnostics_flags(self, tmp_path: Path) -> None:
+        cfg = TrainingConfig(
+            scenario="grid_ctf",
+            data_path=tmp_path / "data.jsonl",
+            backend="opd",
+            opd_diagnostics=True,
+            opd_diagnostics_debug_tokens=True,
+        )
+        (tmp_path / "data.jsonl").write_text("{}\n")
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run:
+            runner._run_experiment_subprocess(0)
+        command = mock_run.call_args.args[0]
+        assert "--opd-diagnostics" in command
+        assert "--opd-diagnostics-debug-tokens" in command
+
     def test_experiment_subprocess_passes_grpo_beta_when_overridden(self, tmp_path: Path) -> None:
         """The GRPO KL penalty must reach the subprocess so `autoctx train` can avoid the beta=0
         overfitting; the default 0.04 is omitted to keep the command minimal."""
@@ -614,7 +632,12 @@ class TestTrainingLoop:
             training_seconds=12.0,
             outcome=ExperimentOutcome.KEPT,
             checkpoint_path=checkpoint_path,
-            summary_metrics={"num_params_M": 1.25, "num_steps": 8.0, "depth": 4.0},
+            summary_metrics={
+                "num_params_M": 1.25,
+                "num_steps": 8.0,
+                "depth": 4.0,
+                "token_pressure_positive_ratio": 0.75,
+            },
         )
 
         with patch("autocontext.training.runner.load_settings", return_value=settings):
@@ -630,6 +653,7 @@ class TestTrainingLoop:
         registry_record = json.loads(registry_path.read_text(encoding="utf-8"))
         assert registry_record["backend"] == "mlx"
         assert registry_record["runtime_types"] == ["provider", "pi"]
+        assert registry_record["training_metrics"]["token_pressure_positive_ratio"] == 0.75
 
         artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
         assert artifact["artifact_type"] == "distilled_model"
@@ -719,7 +743,7 @@ class TestTrainingLoop:
             "autocontext.training.runner.load_settings",
             return_value=AppSettings(model_competitor="fallback-competitor"),
         ):
-            updated = runner._propose_train_py(client, experiment_index=1, consecutive_discards=0)
+            updated = runner._propose_train_py(cast(Any, client), experiment_index=1, consecutive_discards=0)
 
         assert client.model == "fallback-competitor"
         assert "updated" in updated
@@ -930,7 +954,7 @@ class TestValSelectSubprocess:
 class TestCurationSubprocess:
     """Elite/dedup curation flags must reach the train.py subprocess."""
 
-    def _capture_command(self, tmp_path: Path, **config_kwargs: object) -> list[str]:
+    def _capture_command(self, tmp_path: Path, **config_kwargs: Any) -> list[str]:
         cfg = TrainingConfig(
             scenario="grid_ctf",
             data_path=tmp_path / "data.jsonl",

--- a/autocontext/tests/test_trl_backend.py
+++ b/autocontext/tests/test_trl_backend.py
@@ -4,6 +4,8 @@ runner imports them lazily)."""
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
@@ -21,14 +23,22 @@ class _TargetScenario(AgentTaskInterface):
     def get_task_prompt(self, state: dict | None = None) -> str:
         return f'return JSON {{"x": N}} with N={(state or {}).get("target")}'
 
-    def evaluate_output(self, output: str, state: dict | None = None, **kwargs: object) -> AgentTaskResult:
+    def evaluate_output(
+        self,
+        output: str,
+        state: dict,
+        reference_context: str | None = None,
+        required_concepts: list[str] | None = None,
+        calibration_examples: list[dict] | None = None,
+        pinned_dimensions: list[str] | None = None,
+    ) -> AgentTaskResult:
         import json
 
         try:
             x = json.loads(output).get("x")
         except Exception:
             x = None
-        return AgentTaskResult(score=1.0 if x == (state or {}).get("target") else 0.0, reasoning="")
+        return AgentTaskResult(score=1.0 if x == state.get("target") else 0.0, reasoning="")
 
     def get_rubric(self) -> str:
         return "1 if x == target else 0"
@@ -161,6 +171,29 @@ def test_chat_dataset_rows_are_messages_for_gkd() -> None:
     assert all(len(r["messages"]) == 2 for r in rows)
 
 
+def test_gkd_diagnostics_use_chat_template_prompt_surface() -> None:
+    from autocontext.training.autoresearch.trl_backend import _gkd_diagnostic_prompt_text
+
+    class Tokenizer:
+        def __init__(self) -> None:
+            self.calls: list[tuple[list[dict[str, str]], bool, bool]] = []
+
+        def apply_chat_template(
+            self,
+            messages: list[dict[str, str]],
+            *,
+            tokenize: bool,
+            add_generation_prompt: bool,
+        ) -> str:
+            self.calls.append((messages, tokenize, add_generation_prompt))
+            return "CHAT:" + messages[0]["content"]
+
+    tokenizer = Tokenizer()
+
+    assert _gkd_diagnostic_prompt_text(tokenizer, {"prompt": "solve it"}) == "CHAT:solve it"
+    assert tokenizer.calls == [([{"role": "user", "content": "solve it"}], False, True)]
+
+
 def test_prompt_dataset_rows_have_prompt_and_answer_for_grpo() -> None:
     from autocontext.training.autoresearch.trl_backend import build_prompt_dataset_rows
 
@@ -249,7 +282,8 @@ def test_vocab_helper_is_in_a_pure_mlx_free_module() -> None:
     # Block mlx the way a non-Mac host would: find_spec returns None / import raises.
     blocked = {name: None for name in list(sys.modules) if name == "mlx" or name.startswith("mlx.")}
     saved = {k: sys.modules.get(k) for k in blocked}
-    sys.modules.update(blocked)
+    modules = cast(dict[str, Any], sys.modules)
+    modules.update(blocked)
     try:
         import importlib
 
@@ -261,9 +295,9 @@ def test_vocab_helper_is_in_a_pure_mlx_free_module() -> None:
     finally:
         for k, v in saved.items():
             if v is None:
-                sys.modules.pop(k, None)
+                modules.pop(k, None)
             else:
-                sys.modules[k] = v
+                modules[k] = v
 
 
 def test_build_trl_metrics_gives_finite_keep_discard_score() -> None:
@@ -289,13 +323,11 @@ def test_build_trl_metrics_gives_finite_keep_discard_score() -> None:
 
 
 def test_time_budget_callback_stops_when_exceeded() -> None:
-    pytest.importorskip("transformers")
-    from transformers import TrainerControl
-
+    transformers = pytest.importorskip("transformers")
     from autocontext.training.autoresearch.trl_backend import make_time_budget_callback
 
     cb = make_time_budget_callback(0.0)  # already exhausted
-    control = TrainerControl()
+    control = transformers.TrainerControl()
     cb.on_step_end(args=None, state=None, control=control)
     assert control.should_training_stop is True
 

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -183,13 +183,6 @@ interface SavedAgentTaskScenario {
   qualityThreshold?: number;
 }
 
-function mergeUniqueStrings(primary?: string[], secondary?: string[]): string[] | undefined {
-  const merged = [...(primary ?? []), ...(secondary ?? [])]
-    .map((value) => value.trim())
-    .filter(Boolean);
-  return merged.length > 0 ? [...new Set(merged)] : undefined;
-}
-
 async function loadSavedAgentTaskScenario(name: string): Promise<SavedAgentTaskScenario | null> {
   const { loadSettings } = await import("../config/index.js");
   const { resolveCustomJudgeScenario, renderAgentTaskPrompt } =
@@ -3346,6 +3339,8 @@ async function cmdTrain(): Promise<void> {
       mode: { type: "string", default: "from_scratch" },
       "base-model": { type: "string" },
       output: { type: "string", short: "o" },
+      "opd-diagnostics": { type: "boolean" },
+      "opd-diagnostics-debug-tokens": { type: "boolean" },
       json: { type: "boolean" },
       help: { type: "boolean", short: "h" },
     },

--- a/ts/src/cli/train-command-workflow.ts
+++ b/ts/src/cli/train-command-workflow.ts
@@ -12,6 +12,7 @@ Options:
   --base-model <id>        Base model for adapter/full fine-tune
   -o, --output <dir>       Output directory
   --opd-diagnostics        Write OPD/GKD token-pressure diagnostics
+  --opd-diagnostics-debug-tokens  Include raw sampled token text in diagnostics
   --json                   Output as JSON
   -h, --help               Show this help
 

--- a/ts/src/cli/train-command-workflow.ts
+++ b/ts/src/cli/train-command-workflow.ts
@@ -11,6 +11,7 @@ Options:
   --mode <mode>            from_scratch, adapter_finetune, full_finetune
   --base-model <id>        Base model for adapter/full fine-tune
   -o, --output <dir>       Output directory
+  --opd-diagnostics        Write OPD/GKD token-pressure diagnostics
   --json                   Output as JSON
   -h, --help               Show this help
 
@@ -27,6 +28,8 @@ export interface TrainCommandValues {
   mode?: string;
   "base-model"?: string;
   output?: string;
+  "opd-diagnostics"?: boolean;
+  "opd-diagnostics-debug-tokens"?: boolean;
   json?: boolean;
 }
 
@@ -39,6 +42,8 @@ export interface TrainCommandPlan {
   backend: string;
   trainingMode: "from_scratch" | "adapter_finetune" | "full_finetune";
   baseModel?: string;
+  opdDiagnostics: boolean;
+  opdDiagnosticsDebugTokens: boolean;
   json: boolean;
 }
 
@@ -63,6 +68,8 @@ export function planTrainCommand(
       | "adapter_finetune"
       | "full_finetune",
     baseModel: values["base-model"],
+    opdDiagnostics: !!values["opd-diagnostics"],
+    opdDiagnosticsDebugTokens: !!values["opd-diagnostics-debug-tokens"],
     json: !!values.json,
   };
 }
@@ -80,6 +87,8 @@ export async function executeTrainCommandWorkflow<TResult extends { status?: str
       backend: string;
       trainingMode: "from_scratch" | "adapter_finetune" | "full_finetune";
       baseModel?: string;
+      opdDiagnostics?: boolean;
+      opdDiagnosticsDebugTokens?: boolean;
     }): Promise<TResult>;
   };
 }): Promise<TResult> {
@@ -98,6 +107,8 @@ export async function executeTrainCommandWorkflow<TResult extends { status?: str
     backend: opts.plan.backend,
     trainingMode: opts.plan.trainingMode,
     baseModel: opts.plan.baseModel,
+    opdDiagnostics: opts.plan.opdDiagnostics,
+    opdDiagnosticsDebugTokens: opts.plan.opdDiagnosticsDebugTokens,
   });
 }
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -951,6 +951,16 @@ export {
   TrainingRunner,
 } from "./training/backends.js";
 export type { TrainingConfig, TrainingResult, PublishedArtifact } from "./training/backends.js";
+export {
+  buildTokenPressureReport,
+  compareTokenPressureReports,
+} from "./training/token-pressure-diagnostics.js";
+export type {
+  TokenPressureObservation,
+  TokenPressurePositionSummary,
+  TokenPressureReport,
+  TokenPressureSpike,
+} from "./training/token-pressure-diagnostics.js";
 export { ACTIVATION_STATES, ModelRegistry, PromotionEngine } from "./training/promotion.js";
 export type {
   ActivationState,

--- a/ts/src/training/token-pressure-diagnostics.ts
+++ b/ts/src/training/token-pressure-diagnostics.ts
@@ -1,0 +1,176 @@
+export interface TokenPressureObservation {
+  position: number;
+  studentLogprob: number;
+  teacherLogprob: number;
+  studentEntropy?: number;
+  tokenText?: string;
+}
+
+export interface TokenPressurePositionSummary {
+  position: number;
+  count: number;
+  positivePressureRatio: number;
+  negativePressureRatio: number;
+  meanMargin: number;
+  meanStudentEntropy: number | null;
+}
+
+export interface TokenPressureSpike {
+  position: number;
+  margin: number;
+  direction: "positive" | "negative";
+  tokenText?: string;
+}
+
+export interface TokenPressureReport {
+  schemaVersion: 1;
+  runId: string;
+  backend: string;
+  mode: string;
+  seed: number;
+  tokenCount: number;
+  positivePressureRatio: number;
+  negativePressureRatio: number;
+  neutralPressureRatio: number;
+  meanPositiveMargin: number | null;
+  meanNegativeMargin: number | null;
+  meanMargin: number | null;
+  meanStudentEntropy: number | null;
+  meanResponseLength: number | null;
+  positionPressure: TokenPressurePositionSummary[];
+  shockThreshold: number;
+  shockSpikeCount: number;
+  shockSpikes: TokenPressureSpike[];
+  rawTokenTextPersisted: boolean;
+}
+
+export function buildTokenPressureReport(
+  observations: TokenPressureObservation[],
+  opts: {
+    backend: string;
+    mode: string;
+    seed?: number;
+    runId?: string;
+    responseLengths?: number[];
+    shockThreshold?: number;
+    includeTokenText?: boolean;
+  },
+): TokenPressureReport {
+  const margins = observations.map((obs) => obs.teacherLogprob - obs.studentLogprob);
+  const positive = margins.filter((margin) => margin > 0);
+  const negative = margins.filter((margin) => margin < 0);
+  const shockThreshold = opts.shockThreshold ?? 2;
+  const includeTokenText = opts.includeTokenText ?? false;
+  const shocks = observations.filter(
+    (obs) => Math.abs(obs.teacherLogprob - obs.studentLogprob) >= shockThreshold,
+  );
+  return {
+    schemaVersion: 1,
+    runId: opts.runId ?? "",
+    backend: opts.backend,
+    mode: opts.mode,
+    seed: opts.seed ?? 0,
+    tokenCount: observations.length,
+    positivePressureRatio: ratio(positive.length, observations.length),
+    negativePressureRatio: ratio(negative.length, observations.length),
+    neutralPressureRatio: ratio(
+      observations.length - positive.length - negative.length,
+      observations.length,
+    ),
+    meanPositiveMargin: mean(positive),
+    meanNegativeMargin: mean(negative),
+    meanMargin: mean(margins),
+    meanStudentEntropy: mean(observations.map((obs) => obs.studentEntropy)),
+    meanResponseLength: mean(opts.responseLengths ?? []),
+    positionPressure: positionPressure(observations),
+    shockThreshold,
+    shockSpikeCount: shocks.length,
+    shockSpikes: shocks.map((obs) => shock(obs, includeTokenText)),
+    rawTokenTextPersisted: includeTokenText,
+  };
+}
+
+export function compareTokenPressureReports(
+  reports: Array<
+    Pick<
+      TokenPressureReport,
+      "runId" | "positivePressureRatio" | "negativePressureRatio" | "shockSpikeCount"
+    >
+  >,
+): {
+  schemaVersion: 1;
+  runCount: number;
+  meanPositivePressureRatio: number | null;
+  meanNegativePressureRatio: number | null;
+  highestPositivePressureRunId: string | null;
+  highestShockRunId: string | null;
+  runs: Array<
+    Pick<
+      TokenPressureReport,
+      "runId" | "positivePressureRatio" | "negativePressureRatio" | "shockSpikeCount"
+    >
+  >;
+} {
+  return {
+    schemaVersion: 1,
+    runCount: reports.length,
+    meanPositivePressureRatio: mean(reports.map((report) => report.positivePressureRatio)),
+    meanNegativePressureRatio: mean(reports.map((report) => report.negativePressureRatio)),
+    highestPositivePressureRunId: maxRun(reports, "positivePressureRatio"),
+    highestShockRunId: maxRun(reports, "shockSpikeCount"),
+    runs: reports,
+  };
+}
+
+function positionPressure(
+  observations: TokenPressureObservation[],
+): TokenPressurePositionSummary[] {
+  const byPosition = new Map<number, TokenPressureObservation[]>();
+  for (const obs of observations) {
+    byPosition.set(obs.position, [...(byPosition.get(obs.position) ?? []), obs]);
+  }
+  return [...byPosition.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([position, items]) => {
+      const margins = items.map((obs) => obs.teacherLogprob - obs.studentLogprob);
+      return {
+        position,
+        count: items.length,
+        positivePressureRatio: ratio(margins.filter((margin) => margin > 0).length, items.length),
+        negativePressureRatio: ratio(margins.filter((margin) => margin < 0).length, items.length),
+        meanMargin: mean(margins) ?? 0,
+        meanStudentEntropy: mean(items.map((obs) => obs.studentEntropy)),
+      };
+    });
+}
+
+function shock(obs: TokenPressureObservation, includeTokenText: boolean): TokenPressureSpike {
+  const margin = obs.teacherLogprob - obs.studentLogprob;
+  return {
+    position: obs.position,
+    margin,
+    direction: margin > 0 ? "positive" : "negative",
+    ...(includeTokenText ? { tokenText: obs.tokenText ?? "" } : {}),
+  };
+}
+
+function ratio(count: number, total: number): number {
+  return total === 0 ? 0 : count / total;
+}
+
+function mean(values: Array<number | undefined>): number | null {
+  const numeric = values.filter(
+    (value): value is number => typeof value === "number" && Number.isFinite(value),
+  );
+  return numeric.length === 0
+    ? null
+    : numeric.reduce((sum, value) => sum + value, 0) / numeric.length;
+}
+
+function maxRun(reports: Array<Record<string, unknown>>, key: string): string | null {
+  if (reports.length === 0) return null;
+  const winner = reports.reduce((best, report) =>
+    Number(report[key] ?? 0) > Number(best[key] ?? 0) ? report : best,
+  );
+  return String(winner.runId ?? "");
+}

--- a/ts/src/training/training-checkpoint-workflow.ts
+++ b/ts/src/training/training-checkpoint-workflow.ts
@@ -58,6 +58,8 @@ export function writeTrainingManifest(
       maxEpochs: config.maxEpochs ?? 3,
       batchSize: config.batchSize ?? 4,
       learningRate: config.learningRate ?? 5e-5,
+      opdDiagnostics: config.opdDiagnostics ?? false,
+      opdDiagnosticsDebugTokens: config.opdDiagnosticsDebugTokens ?? false,
       startedAt: new Date().toISOString(),
     }, null, 2),
     "utf-8",

--- a/ts/src/training/training-types.ts
+++ b/ts/src/training/training-types.ts
@@ -14,6 +14,8 @@ export interface TrainingConfig {
   maxEpochs?: number;
   batchSize?: number;
   learningRate?: number;
+  opdDiagnostics?: boolean;
+  opdDiagnosticsDebugTokens?: boolean;
 }
 
 export interface PublishedArtifact {

--- a/ts/tests/package-export-catalogs.test.ts
+++ b/ts/tests/package-export-catalogs.test.ts
@@ -47,6 +47,7 @@ describe("package root exports", () => {
     expect(pkg.buildNegativeResultLedger).toBeDefined();
     expect(pkg.buildCampaignModeReport).toBeDefined();
     expect(pkg.buildGoalRunReport).toBeDefined();
+    expect(pkg.buildTokenPressureReport).toBeDefined();
     expect(pkg.stagePendingPlaybook).toBeDefined();
     expect(pkg.buildOperationalMemoryPackFromDiagnostics).toBeDefined();
     expect(pkg.resolveBrowserSessionConfig).toBeDefined();

--- a/ts/tests/token-pressure-diagnostics.test.ts
+++ b/ts/tests/token-pressure-diagnostics.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTokenPressureReport,
+  compareTokenPressureReports,
+  type TokenPressureObservation,
+} from "../src/training/token-pressure-diagnostics.js";
+
+describe("token pressure diagnostics", () => {
+  it("summarizes teacher/student pressure without raw token text by default", () => {
+    const observations: TokenPressureObservation[] = [
+      {
+        position: 0,
+        studentLogprob: -2,
+        teacherLogprob: -1,
+        studentEntropy: 0.7,
+        tokenText: "secret",
+      },
+      { position: 1, studentLogprob: -0.1, teacherLogprob: -1.1, studentEntropy: 0.2 },
+      {
+        position: 1,
+        studentLogprob: -4,
+        teacherLogprob: -0.5,
+        studentEntropy: 0.3,
+        tokenText: "spike",
+      },
+    ];
+
+    const report = buildTokenPressureReport(observations, {
+      backend: "trl",
+      mode: "gkd",
+      seed: 7,
+      responseLengths: [2, 3],
+      shockThreshold: 2,
+    });
+
+    expect(report.tokenCount).toBe(3);
+    expect(report.positivePressureRatio).toBe(2 / 3);
+    expect(report.negativePressureRatio).toBe(1 / 3);
+    expect(report.meanPositiveMargin).toBe(2.25);
+    expect(report.meanNegativeMargin).toBe(-1);
+    expect(report.meanResponseLength).toBe(2.5);
+    expect(report.shockSpikeCount).toBe(1);
+    expect(report.positionPressure[1].count).toBe(2);
+    expect(report.rawTokenTextPersisted).toBe(false);
+    expect(JSON.stringify(report)).not.toContain("secret");
+  });
+
+  it("only persists debug token text by explicit opt-in", () => {
+    const report = buildTokenPressureReport(
+      [{ position: 0, studentLogprob: -5, teacherLogprob: -1, tokenText: "debug-token" }],
+      { backend: "opd", mode: "opd", includeTokenText: true, shockThreshold: 1 },
+    );
+
+    expect(report.rawTokenTextPersisted).toBe(true);
+    expect(report.shockSpikes[0].tokenText).toBe("debug-token");
+  });
+
+  it("compares diagnostic runs for A/B pressure checks", () => {
+    const comparison = compareTokenPressureReports([
+      {
+        runId: "neg",
+        positivePressureRatio: 0.25,
+        negativePressureRatio: 0.75,
+        shockSpikeCount: 3,
+      },
+      {
+        runId: "pos",
+        positivePressureRatio: 0.75,
+        negativePressureRatio: 0.25,
+        shockSpikeCount: 1,
+      },
+    ]);
+
+    expect(comparison.runCount).toBe(2);
+    expect(comparison.meanPositivePressureRatio).toBe(0.5);
+    expect(comparison.highestPositivePressureRunId).toBe("pos");
+    expect(comparison.highestShockRunId).toBe("neg");
+  });
+});

--- a/ts/tests/train-command-workflow.test.ts
+++ b/ts/tests/train-command-workflow.test.ts
@@ -16,6 +16,7 @@ describe("train command workflow", () => {
     expect(TRAIN_HELP_TEXT).toContain("--dataset");
     expect(TRAIN_HELP_TEXT).toContain("--backend");
     expect(TRAIN_HELP_TEXT).toContain("--opd-diagnostics");
+    expect(TRAIN_HELP_TEXT).toContain("--opd-diagnostics-debug-tokens");
   });
 
   it("requires scenario and dataset", () => {
@@ -51,6 +52,7 @@ describe("train command workflow", () => {
           "base-model": "qwen",
           output: "artifacts",
           "opd-diagnostics": true,
+          "opd-diagnostics-debug-tokens": true,
           json: true,
         },
         "/tmp/runs",
@@ -66,7 +68,7 @@ describe("train command workflow", () => {
       trainingMode: "adapter_finetune",
       baseModel: "qwen",
       opdDiagnostics: true,
-      opdDiagnosticsDebugTokens: false,
+      opdDiagnosticsDebugTokens: true,
       json: true,
     });
   });

--- a/ts/tests/train-command-workflow.test.ts
+++ b/ts/tests/train-command-workflow.test.ts
@@ -15,6 +15,7 @@ describe("train command workflow", () => {
     expect(TRAIN_HELP_TEXT).toContain("--scenario");
     expect(TRAIN_HELP_TEXT).toContain("--dataset");
     expect(TRAIN_HELP_TEXT).toContain("--backend");
+    expect(TRAIN_HELP_TEXT).toContain("--opd-diagnostics");
   });
 
   it("requires scenario and dataset", () => {
@@ -49,6 +50,7 @@ describe("train command workflow", () => {
           mode: "adapter_finetune",
           "base-model": "qwen",
           output: "artifacts",
+          "opd-diagnostics": true,
           json: true,
         },
         "/tmp/runs",
@@ -63,6 +65,8 @@ describe("train command workflow", () => {
       backend: "mlx",
       trainingMode: "adapter_finetune",
       baseModel: "qwen",
+      opdDiagnostics: true,
+      opdDiagnosticsDebugTokens: false,
       json: true,
     });
   });
@@ -79,6 +83,8 @@ describe("train command workflow", () => {
           backend: "cuda",
           trainingMode: "from_scratch",
           baseModel: undefined,
+          opdDiagnostics: false,
+          opdDiagnosticsDebugTokens: false,
           json: false,
         },
         createRunner: () => ({
@@ -110,6 +116,8 @@ describe("train command workflow", () => {
         backend: "cuda",
         trainingMode: "from_scratch",
         baseModel: undefined,
+        opdDiagnostics: true,
+        opdDiagnosticsDebugTokens: true,
         json: false,
       },
       createRunner: () => ({
@@ -127,6 +135,8 @@ describe("train command workflow", () => {
       backend: "cuda",
       trainingMode: "from_scratch",
       baseModel: undefined,
+      opdDiagnostics: true,
+      opdDiagnosticsDebugTokens: true,
     });
     expect(result).toMatchObject({ status: "completed", backend: "cuda" });
   });
@@ -139,11 +149,13 @@ describe("train command workflow", () => {
         checkpointDir: "/tmp/checkpoint",
         durationMs: 1234,
       }),
-    ).toEqual([
-      "Training completed: artifact-1",
-      "  Backend: cuda",
-      "  Checkpoint: /tmp/checkpoint",
-      "  Duration: 1.2s",
-    ].join("\n"));
+    ).toEqual(
+      [
+        "Training completed: artifact-1",
+        "  Backend: cuda",
+        "  Checkpoint: /tmp/checkpoint",
+        "  Duration: 1.2s",
+      ].join("\n"),
+    );
   });
 });

--- a/ts/tests/training-checkpoint-workflow.test.ts
+++ b/ts/tests/training-checkpoint-workflow.test.ts
@@ -47,6 +47,7 @@ describe("training checkpoint workflow", () => {
       backend: "cuda",
       trainingMode: "adapter_finetune",
       baseModel: "Qwen/Qwen3-0.6B",
+      opdDiagnostics: true,
     };
 
     const checkpointDir = ensureCheckpointDir(config.outputDir, new StubBackend("cuda"), config.scenario);
@@ -57,6 +58,7 @@ describe("training checkpoint workflow", () => {
       scenario: "grid_ctf",
       datasetSize: 2,
       heldOutSize: 1,
+      opdDiagnostics: true,
     });
 
     const executorResult = await defaultExecutor(config, checkpointDir);


### PR DESCRIPTION
## Summary
- add Python OPD/GKD token-pressure diagnostics report helpers and opt-in persistence
- thread `--opd-diagnostics` / `AUTOCONTEXT_OPD_DIAGNOSTICS` through train CLI, runner, OPD, and TRL GKD
- add TypeScript parity helpers/types and train workflow flags

## Testing
- `python -m ruff check ...`
- `PYTHONPATH=src python -m mypy ...`
- `PYTHONPATH=src python -m pytest tests/test_on_policy_distill.py tests/test_trl_backend.py tests/test_train_summary.py tests/test_opd_diagnostics_routing.py tests/test_token_pressure_diagnostics.py tests/test_training_runner.py tests/test_module_size_limits.py tests/test_package_boundaries.py -q`
- `npm test -- token-pressure-diagnostics.test.ts train-command-workflow.test.ts training-checkpoint-workflow.test.ts package-export-catalogs.test.ts`
- `npm run lint`
- `npm run build`
- `git diff --check`

Linear: AC-795
