### PR TITLE
feat(ts-engine): wire lesson lifecycle REST routes (Python parity)

### DIFF
--- a/ts/src/server/http-api-parity.ts
+++ b/ts/src/server/http-api-parity.ts
@@ -130,6 +130,30 @@ export const HTTP_API_PARITY_ROUTES: readonly HttpApiParityEntry[] = [
     "/api/knowledge/:scenario/playbook/reject",
     "autocontext/src/autocontext/server/knowledge_api.py",
   ),
+  both(
+    "knowledge",
+    "GET",
+    "/api/knowledge/:scenario/lifecycle",
+    "autocontext/src/autocontext/server/knowledge_api.py",
+  ),
+  both(
+    "knowledge",
+    "POST",
+    "/api/knowledge/:scenario/lessons/:lesson_id/approve",
+    "autocontext/src/autocontext/server/knowledge_api.py",
+  ),
+  both(
+    "knowledge",
+    "POST",
+    "/api/knowledge/:scenario/lessons/:lesson_id/reject",
+    "autocontext/src/autocontext/server/knowledge_api.py",
+  ),
+  both(
+    "knowledge",
+    "POST",
+    "/api/knowledge/:scenario/lessons/:lesson_id/curate",
+    "autocontext/src/autocontext/server/knowledge_api.py",
+  ),
   typescriptOnly(
     "knowledge",
     "GET",

--- a/ts/src/server/knowledge-api.ts
+++ b/ts/src/server/knowledge-api.ts
@@ -3,6 +3,12 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { ArtifactStore } from "../knowledge/artifact-store.js";
 import {
+  approveLesson as approveLessonLifecycle,
+  buildLifecycle,
+  curateLesson as curateLessonLifecycle,
+  rejectLesson as rejectLessonLifecycle,
+} from "../knowledge/lesson-lifecycle.js";
+import {
   exportStrategyPackage,
   importStrategyPackage,
   type ConflictPolicy,
@@ -32,6 +38,14 @@ export interface KnowledgeApiRoutes {
   pendingPlaybook(scenarioName: string): KnowledgeApiResponse;
   approvePendingPlaybook(scenarioName: string): KnowledgeApiResponse;
   rejectPendingPlaybook(scenarioName: string): KnowledgeApiResponse;
+  lessonLifecycle(scenarioName: string): KnowledgeApiResponse;
+  approveLesson(scenarioName: string, lessonId: string): KnowledgeApiResponse;
+  rejectLesson(scenarioName: string, lessonId: string): KnowledgeApiResponse;
+  curateLesson(
+    scenarioName: string,
+    lessonId: string,
+    body: Record<string, unknown>,
+  ): KnowledgeApiResponse;
 }
 
 export function buildKnowledgeApiRoutes(opts: {
@@ -150,7 +164,74 @@ export function buildKnowledgeApiRoutes(opts: {
           ? { status: 200, body: result }
           : { status: 404, body: { detail: "pending playbook not found" } };
       }),
+    lessonLifecycle: (scenarioName) => {
+      if (!resolveKnowledgeScenarioDir(opts.knowledgeRoot, scenarioName)) {
+        return invalidScenario(scenarioName);
+      }
+      return {
+        status: 200,
+        body: buildLifecycle({
+          knowledgeRoot: opts.knowledgeRoot,
+          skillsRoot: opts.skillsRoot,
+          scenario: scenarioName,
+          currentGeneration: 0,
+        }),
+      };
+    },
+    approveLesson: (scenarioName, lessonId) => {
+      if (!resolveKnowledgeScenarioDir(opts.knowledgeRoot, scenarioName)) {
+        return invalidScenario(scenarioName);
+      }
+      const status = approveLessonLifecycle({
+        knowledgeRoot: opts.knowledgeRoot,
+        skillsRoot: opts.skillsRoot,
+        scenario: scenarioName,
+        lessonId,
+        currentGeneration: 0,
+      });
+      return status === null
+        ? { status: 404, body: { detail: "lesson not found" } }
+        : { status: 200, body: { ok: true, status } };
+    },
+    rejectLesson: (scenarioName, lessonId) => {
+      if (!resolveKnowledgeScenarioDir(opts.knowledgeRoot, scenarioName)) {
+        return invalidScenario(scenarioName);
+      }
+      const ok = rejectLessonLifecycle({
+        knowledgeRoot: opts.knowledgeRoot,
+        skillsRoot: opts.skillsRoot,
+        scenario: scenarioName,
+        lessonId,
+      });
+      return ok
+        ? { status: 200, body: { ok: true } }
+        : { status: 404, body: { detail: "lesson not found" } };
+    },
+    curateLesson: (scenarioName, lessonId, body) => {
+      if (!resolveKnowledgeScenarioDir(opts.knowledgeRoot, scenarioName)) {
+        return invalidScenario(scenarioName);
+      }
+      const action = typeof body.action === "string" ? body.action : "";
+      if (action !== "stale" && action !== "deadEnd" && action !== "delete") {
+        return { status: 422, body: { detail: "action must be one of stale, deadEnd, delete" } };
+      }
+      const status = curateLessonLifecycle({
+        knowledgeRoot: opts.knowledgeRoot,
+        skillsRoot: opts.skillsRoot,
+        scenario: scenarioName,
+        lessonId,
+        action,
+        currentGeneration: 0,
+      });
+      return status === null
+        ? { status: 404, body: { detail: "lesson not found" } }
+        : { status: 200, body: { ok: true, status } };
+    },
   };
+}
+
+function invalidScenario(scenarioName: string): KnowledgeApiResponse {
+  return { status: 422, body: { error: `Invalid scenario '${scenarioName}'` } };
 }
 
 function withPlaybookApproval(

--- a/ts/src/server/ws-server.ts
+++ b/ts/src/server/ws-server.ts
@@ -289,6 +289,7 @@ export class InteractiveServer {
             search: "/api/knowledge/search",
             solve: "/api/knowledge/solve",
             playbook: "/api/knowledge/playbook/:scenario",
+            lifecycle: "/api/knowledge/:scenario/lifecycle",
           },
           campaigns: "/api/campaigns",
           missions: "/api/missions",
@@ -948,6 +949,33 @@ export class InteractiveServer {
     if (method === "POST" && rejectPlaybookMatch) {
       const [, rawScenario] = rejectPlaybookMatch;
       const response = knowledgeApi.rejectPendingPlaybook(decodeURIComponent(rawScenario!));
+      json(response.status, response.body);
+      return;
+    }
+
+    // GET /api/knowledge/:scenario/lifecycle
+    const lessonLifecycleMatch = url.match(/^\/api\/knowledge\/([^/]+)\/lifecycle$/);
+    if (method === "GET" && lessonLifecycleMatch) {
+      const [, rawScenario] = lessonLifecycleMatch;
+      const response = knowledgeApi.lessonLifecycle(decodeURIComponent(rawScenario!));
+      json(response.status, response.body);
+      return;
+    }
+
+    // POST /api/knowledge/:scenario/lessons/:lessonId/(approve|reject|curate)
+    const lessonActionMatch = url.match(
+      /^\/api\/knowledge\/([^/]+)\/lessons\/([^/]+)\/(approve|reject|curate)$/,
+    );
+    if (method === "POST" && lessonActionMatch) {
+      const [, rawScenario, rawLessonId, action] = lessonActionMatch;
+      const scenario = decodeURIComponent(rawScenario!);
+      const lessonId = decodeURIComponent(rawLessonId!);
+      const response =
+        action === "approve"
+          ? knowledgeApi.approveLesson(scenario, lessonId)
+          : action === "reject"
+            ? knowledgeApi.rejectLesson(scenario, lessonId)
+            : knowledgeApi.curateLesson(scenario, lessonId, await this.#readJsonBody(req));
       json(response.status, response.body);
       return;
     }

--- a/ts/tests/lesson-lifecycle-routes.test.ts
+++ b/ts/tests/lesson-lifecycle-routes.test.ts
@@ -1,0 +1,130 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { ArtifactStore } from "../src/knowledge/artifact-store.js";
+import { buildKnowledgeApiRoutes, type KnowledgeApiRoutes } from "../src/server/knowledge-api.js";
+
+function root(): string {
+  return mkdtempSync(join(tmpdir(), "lesson-lifecycle-routes-"));
+}
+
+function routesFor(dir: string): KnowledgeApiRoutes {
+  return buildKnowledgeApiRoutes({
+    runsRoot: join(dir, "runs"),
+    knowledgeRoot: join(dir, "knowledge"),
+    skillsRoot: join(dir, "skills"),
+    openStore: () => {
+      throw new Error("store unused");
+    },
+    getSolveManager: () => ({
+      submit: () => "job",
+      getStatus: () => ({}),
+      getResult: () => null,
+    }),
+  });
+}
+
+/** Write a playbook whose LESSONS block carries the given bullets. */
+function seedLessons(dir: string, scenario: string, bullets: string[]): void {
+  const artifacts = new ArtifactStore({
+    runsRoot: join(dir, "runs"),
+    knowledgeRoot: join(dir, "knowledge"),
+  });
+  const block = ["<!-- LESSONS_START -->", ...bullets.map((b) => `- ${b}`), "<!-- LESSONS_END -->"];
+  artifacts.writePlaybook(scenario, `Strategy.\n\n${block.join("\n")}\n`);
+}
+
+describe("lesson lifecycle routes", () => {
+  it("lessonLifecycle derives active lessons from the playbook markdown", () => {
+    const dir = root();
+    try {
+      seedLessons(dir, "grid_ctf", ["use X", "use Y"]);
+      const res = routesFor(dir).lessonLifecycle("grid_ctf");
+      expect(res.status).toBe(200);
+      const body = res.body as { active: Array<{ id: string; text: string }>; pending: unknown[] };
+      expect(body.pending).toEqual([]);
+      expect(body.active.map((l) => l.text).sort()).toEqual(["use X", "use Y"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("approveLesson validates a live lesson and 404s an unknown id", () => {
+    const dir = root();
+    try {
+      seedLessons(dir, "grid_ctf", ["use X"]);
+      const routes = routesFor(dir);
+      const id = (routes.lessonLifecycle("grid_ctf").body as { active: Array<{ id: string }> })
+        .active[0]!.id;
+      expect(routes.approveLesson("grid_ctf", id)).toEqual({
+        status: 200,
+        body: { ok: true, status: "active" },
+      });
+      expect(routes.approveLesson("grid_ctf", "nope").status).toBe(404);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejectLesson removes the bullet from the playbook", () => {
+    const dir = root();
+    try {
+      seedLessons(dir, "grid_ctf", ["use X", "use Y"]);
+      const routes = routesFor(dir);
+      const id = (
+        routes.lessonLifecycle("grid_ctf").body as { active: Array<{ id: string; text: string }> }
+      ).active.find((l) => l.text === "use X")!.id;
+      expect(routes.rejectLesson("grid_ctf", id)).toEqual({ status: 200, body: { ok: true } });
+      const after = routes.lessonLifecycle("grid_ctf").body as { active: Array<{ text: string }> };
+      expect(after.active.map((l) => l.text)).toEqual(["use Y"]);
+      expect(routes.rejectLesson("grid_ctf", id).status).toBe(404);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("curateLesson marks stale / moves to dead-end and rejects an invalid action", () => {
+    const dir = root();
+    try {
+      seedLessons(dir, "grid_ctf", ["use X", "use Y"]);
+      const routes = routesFor(dir);
+      const lessons = (
+        routes.lessonLifecycle("grid_ctf").body as { active: Array<{ id: string; text: string }> }
+      ).active;
+      const xId = lessons.find((l) => l.text === "use X")!.id;
+      const yId = lessons.find((l) => l.text === "use Y")!.id;
+
+      expect(routes.curateLesson("grid_ctf", xId, { action: "stale" })).toEqual({
+        status: 200,
+        body: { ok: true, status: "stale" },
+      });
+      expect(routes.curateLesson("grid_ctf", yId, { action: "deadEnd" })).toEqual({
+        status: 200,
+        body: { ok: true, status: "deadEnd" },
+      });
+
+      const lc = routes.lessonLifecycle("grid_ctf").body as {
+        active: unknown[];
+        stale: Array<{ text: string }>;
+        deadEnd: Array<{ text: string }>;
+      };
+      expect(lc.stale.map((l) => l.text)).toEqual(["use X"]);
+      expect(lc.deadEnd.map((l) => l.text)).toEqual(["use Y"]);
+
+      expect(routes.curateLesson("grid_ctf", xId, { action: "bogus" }).status).toBe(422);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("422s an invalid scenario id", () => {
+    const dir = root();
+    try {
+      expect(routesFor(dir).lessonLifecycle("../escape").status).toBe(422);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes the last TS-engine gap from the AC-826 lesson-architecture rework: the TS server never exposed the **lesson lifecycle** HTTP routes the Python engine has.

## Context
The TS engine already had:
- the markdown-derived lifecycle logic (`lesson-lifecycle.ts`: `buildLifecycle`/`approveLesson`/`rejectLesson`/`curateLesson`) — parity with #1118, and
- the playbook hold-gate HTTP routes (`/playbook/pending|approve|reject`) — parity with #1117.

But the **lesson** lifecycle was never wired to HTTP, so a client (e.g. the autowork knowledge board) hitting the TS engine got 404s where the Python engine answers.

## Changes
- **`knowledge-api.ts`** — add `lessonLifecycle` / `approveLesson` / `rejectLesson` / `curateLesson` route methods over the existing lifecycle module, mirroring the Python `knowledge_api` contract (200 `{ok,status}`, 404 `lesson not found`, 422 invalid scenario/action).
- **`ws-server.ts`** — `GET /api/knowledge/:scenario/lifecycle` and `POST /api/knowledge/:scenario/lessons/:id/(approve|reject|curate)`; add `lifecycle` to the knowledge route-discovery map.
- **`http-api-parity.ts`** — declare the four routes as `both()`-supported (they were Python-only and untracked in the parity matrix).
- **tests** — `lesson-lifecycle-routes.test.ts`: derive/approve/reject/curate + the 404 (unknown id) and 422 (invalid scenario/action) paths.

## Verification
`npm run lint` (tsc) clean; new test 5/5. The repo's `isolated-vm`/`better-sqlite3` native-binding test failures are pre-existing on this machine (they reproduce on `main` with these changes stashed) and unrelated — CI has the native bindings.

Relates to AC-826 (TS parity) and closes the deferred "TS REST routes" follow-up.