### PR TITLE
refactor(protocol): drop deprecated require_lesson_approval alias (AC-828)

### DIFF
--- a/autocontext/src/autocontext/server/app.py
+++ b/autocontext/src/autocontext/server/app.py
@@ -341,7 +341,7 @@ def create_app(
                                     rid = run_manager.start_run(
                                         scenario,
                                         generations,
-                                        require_playbook_approval=start_cmd.effective_require_playbook_approval,
+                                        require_playbook_approval=start_cmd.require_playbook_approval,
                                     )
                                     await websocket.send_json(
                                         RunAcceptedMsg(run_id=rid, scenario=scenario, generations=generations).model_dump()

--- a/autocontext/src/autocontext/server/protocol.py
+++ b/autocontext/src/autocontext/server/protocol.py
@@ -246,11 +246,6 @@ class StartRunCmd(BaseModel):
     scenario: str
     generations: int = Field(gt=0)
     require_playbook_approval: bool = False
-    require_lesson_approval: bool = False
-
-    @property
-    def effective_require_playbook_approval(self) -> bool:
-        return self.require_playbook_approval or self.require_lesson_approval
 
 
 class ListScenariosCmd(BaseModel):

--- a/autocontext/tests/test_playbook_approval_protocol.py
+++ b/autocontext/tests/test_playbook_approval_protocol.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 
 def test_start_run_protocol_accepts_playbook_approval_flag() -> None:
     from autocontext.server.protocol import StartRunCmd, parse_client_message
@@ -7,14 +9,21 @@ def test_start_run_protocol_accepts_playbook_approval_flag() -> None:
     cmd = parse_client_message({"type": "start_run", "scenario": "grid_ctf", "generations": 1, "require_playbook_approval": True})
 
     assert isinstance(cmd, StartRunCmd)
-    assert cmd.effective_require_playbook_approval is True
+    assert cmd.require_playbook_approval is True
 
 
-def test_start_run_protocol_accepts_deprecated_lesson_approval_alias() -> None:
+def test_start_run_protocol_defaults_playbook_approval_off() -> None:
     from autocontext.server.protocol import StartRunCmd, parse_client_message
 
-    cmd = parse_client_message({"type": "start_run", "scenario": "grid_ctf", "generations": 1, "require_lesson_approval": True})
+    cmd = parse_client_message({"type": "start_run", "scenario": "grid_ctf", "generations": 1})
 
     assert isinstance(cmd, StartRunCmd)
     assert cmd.require_playbook_approval is False
-    assert cmd.effective_require_playbook_approval is True
+
+
+def test_start_run_protocol_rejects_removed_lesson_approval_alias() -> None:
+    """The deprecated require_lesson_approval alias was removed; extra=forbid rejects it."""
+    from autocontext.server.protocol import parse_client_message
+
+    with pytest.raises(ValueError):
+        parse_client_message({"type": "start_run", "scenario": "grid_ctf", "generations": 1, "require_lesson_approval": True})

--- a/docs/playbook-approval-gate.md
+++ b/docs/playbook-approval-gate.md
@@ -17,4 +17,4 @@ When `require_playbook_approval` is false, curator-approved playbooks are writte
 
 The lesson lifecycle `pending` bucket is now always empty; lesson curation is derived from approved playbook/SKILL markdown, not a structured pending lesson store.
 
-The wire flag `require_lesson_approval` is accepted as a deprecated alias for one compatibility window; new clients should send `require_playbook_approval`.
+Clients enable the hold gate with the wire flag `require_playbook_approval`. (An earlier `require_lesson_approval` alias was removed; `start_run` now rejects it.)

--- a/protocol/autocontext-protocol.json
+++ b/protocol/autocontext-protocol.json
@@ -797,11 +797,6 @@
             "default": false,
             "title": "Require Playbook Approval",
             "type": "boolean"
-          },
-          "require_lesson_approval": {
-            "default": false,
-            "title": "Require Lesson Approval",
-            "type": "boolean"
           }
         },
         "required": [

--- a/scripts/generate_protocol.py
+++ b/scripts/generate_protocol.py
@@ -117,7 +117,10 @@ def _json_schema_to_zod_type(prop: dict[str, Any], defs: dict[str, Any]) -> str:
         if "properties" in prop:
             # Inline object
             inner = _build_object_fields(prop, defs)
-            return "z.object({" + ", ".join(f"{k}: {v}" for k, v in inner.items()) + "})"
+            obj = "z.object({" + ", ".join(f"{k}: {v}" for k, v in inner.items()) + "})"
+            # Honor additionalProperties: false (Pydantic extra="forbid") so the
+            # generated schema rejects unknown keys, matching the server schema.
+            return obj + ".strict()" if additional is False else obj
         return "z.record(z.unknown())"
 
     return "z.unknown()"
@@ -167,7 +170,9 @@ def _generate_zod_schema(
     lines = [f"export const {model_name}Schema = z.object({{"]
     for field_name, zod_type in fields.items():
         lines.append(f"  {field_name}: {zod_type},")
-    lines.append("});")
+    # Honor additionalProperties: false (Pydantic extra="forbid") so the generated
+    # schema rejects unknown keys, matching the server schema (which uses .strict()).
+    lines.append("}).strict();" if model_schema.get("additionalProperties") is False else "});")
     return "\n".join(lines)
 
 

--- a/ts/src/server/interactive-control-command-workflow.ts
+++ b/ts/src/server/interactive-control-command-workflow.ts
@@ -57,8 +57,7 @@ export async function executeInteractiveControlCommand(opts: {
         opts.command.scenario,
         opts.command.generations,
         {
-          requirePlaybookApproval:
-            opts.command.require_playbook_approval || opts.command.require_lesson_approval,
+          requirePlaybookApproval: opts.command.require_playbook_approval,
         },
       );
       return [

--- a/ts/src/server/protocol.ts
+++ b/ts/src/server/protocol.ts
@@ -240,7 +240,6 @@ export const StartRunCmdSchema = protocolObject({
   scenario: z.string(),
   generations: z.number().int().positive(),
   require_playbook_approval: z.boolean().default(false),
-  require_lesson_approval: z.boolean().default(false),
 });
 
 export const ListScenariosCmdSchema = protocolObject({

--- a/ts/src/tui/protocol.generated.ts
+++ b/ts/src/tui/protocol.generated.ts
@@ -11,56 +11,56 @@ export const ExecutorResourcesSchema = z.object({
   memory_gb: z.number().int(),
   disk_gb: z.number().int(),
   timeout_minutes: z.number().int(),
-});
+}).strict();
 
 export const ExecutorInfoSchema = z.object({
   mode: z.string(),
   available: z.boolean(),
   description: z.string(),
   resources: ExecutorResourcesSchema.optional().nullable(),
-});
+}).strict();
 
 export const ScenarioInfoSchema = z.object({
   name: z.string(),
   description: z.string(),
-});
+}).strict();
 
 export const ScoringComponentSchema = z.object({
   name: z.string(),
   description: z.string(),
   weight: z.number(),
-});
+}).strict();
 
 export const StrategyParamSchema = z.object({
   name: z.string(),
   description: z.string(),
-});
+}).strict();
 
 // --- Server -> Client messages ---
 
 export const HelloMsgSchema = z.object({
   type: z.literal("hello"),
   protocol_version: z.number().int().optional(),
-});
+}).strict();
 
 export const EventMsgSchema = z.object({
   type: z.literal("event"),
   event: z.string(),
   payload: z.record(z.unknown()),
-});
+}).strict();
 
 export const StateMsgSchema = z.object({
   type: z.literal("state"),
   paused: z.boolean(),
   generation: z.number().int().optional(),
   phase: z.string().optional(),
-});
+}).strict();
 
 export const ChatResponseMsgSchema = z.object({
   type: z.literal("chat_response"),
   role: z.string(),
   text: z.string(),
-});
+}).strict();
 
 export const EnvironmentsMsgSchema = z.object({
   type: z.literal("environments"),
@@ -68,30 +68,30 @@ export const EnvironmentsMsgSchema = z.object({
   executors: z.array(ExecutorInfoSchema),
   current_executor: z.string(),
   agent_provider: z.string(),
-});
+}).strict();
 
 export const RunAcceptedMsgSchema = z.object({
   type: z.literal("run_accepted"),
   run_id: z.string(),
   scenario: z.string(),
   generations: z.number().int(),
-});
+}).strict();
 
 export const AckMsgSchema = z.object({
   type: z.literal("ack"),
   action: z.string(),
   decision: z.string().optional().nullable(),
-});
+}).strict();
 
 export const ErrorMsgSchema = z.object({
   type: z.literal("error"),
   message: z.string(),
-});
+}).strict();
 
 export const ScenarioGeneratingMsgSchema = z.object({
   type: z.literal("scenario_generating"),
   name: z.string(),
-});
+}).strict();
 
 export const ScenarioPreviewMsgSchema = z.object({
   type: z.literal("scenario_preview"),
@@ -102,19 +102,19 @@ export const ScenarioPreviewMsgSchema = z.object({
   scoring_components: z.array(ScoringComponentSchema),
   constraints: z.array(z.string()),
   win_threshold: z.number(),
-});
+}).strict();
 
 export const ScenarioReadyMsgSchema = z.object({
   type: z.literal("scenario_ready"),
   name: z.string(),
   test_scores: z.array(z.number()),
-});
+}).strict();
 
 export const ScenarioErrorMsgSchema = z.object({
   type: z.literal("scenario_error"),
   message: z.string(),
   stage: z.string(),
-});
+}).strict();
 
 export const MonitorAlertMsgSchema = z.object({
   type: z.literal("monitor_alert"),
@@ -124,7 +124,7 @@ export const MonitorAlertMsgSchema = z.object({
   condition_type: z.string(),
   scope: z.string(),
   detail: z.string(),
-});
+}).strict();
 
 export const ServerMessageSchema = z.discriminatedUnion("type", [HelloMsgSchema, EventMsgSchema, StateMsgSchema, ChatResponseMsgSchema, EnvironmentsMsgSchema, RunAcceptedMsgSchema, AckMsgSchema, ErrorMsgSchema, ScenarioGeneratingMsgSchema, ScenarioPreviewMsgSchema, ScenarioReadyMsgSchema, ScenarioErrorMsgSchema, MonitorAlertMsgSchema]);
 
@@ -132,56 +132,56 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [HelloMsgSchema,
 
 export const PauseCmdSchema = z.object({
   type: z.literal("pause"),
-});
+}).strict();
 
 export const ResumeCmdSchema = z.object({
   type: z.literal("resume"),
-});
+}).strict();
 
 export const InjectHintCmdSchema = z.object({
   type: z.literal("inject_hint"),
   text: z.string().min(1),
-});
+}).strict();
 
 export const OverrideGateCmdSchema = z.object({
   type: z.literal("override_gate"),
   decision: z.enum(["advance", "retry", "rollback"]),
-});
+}).strict();
 
 export const ChatAgentCmdSchema = z.object({
   type: z.literal("chat_agent"),
   role: z.string(),
   message: z.string().min(1),
-});
+}).strict();
 
 export const StartRunCmdSchema = z.object({
   type: z.literal("start_run"),
   scenario: z.string(),
   generations: z.number().int().gt(0),
   require_playbook_approval: z.boolean().optional(),
-});
+}).strict();
 
 export const ListScenariosCmdSchema = z.object({
   type: z.literal("list_scenarios"),
-});
+}).strict();
 
 export const CreateScenarioCmdSchema = z.object({
   type: z.literal("create_scenario"),
   description: z.string().min(1),
-});
+}).strict();
 
 export const ConfirmScenarioCmdSchema = z.object({
   type: z.literal("confirm_scenario"),
-});
+}).strict();
 
 export const ReviseScenarioCmdSchema = z.object({
   type: z.literal("revise_scenario"),
   feedback: z.string().min(1),
-});
+}).strict();
 
 export const CancelScenarioCmdSchema = z.object({
   type: z.literal("cancel_scenario"),
-});
+}).strict();
 
 export const ClientMessageSchema = z.discriminatedUnion("type", [PauseCmdSchema, ResumeCmdSchema, InjectHintCmdSchema, OverrideGateCmdSchema, ChatAgentCmdSchema, StartRunCmdSchema, ListScenariosCmdSchema, CreateScenarioCmdSchema, ConfirmScenarioCmdSchema, ReviseScenarioCmdSchema, CancelScenarioCmdSchema]);
 

--- a/ts/src/tui/protocol.generated.ts
+++ b/ts/src/tui/protocol.generated.ts
@@ -159,7 +159,6 @@ export const StartRunCmdSchema = z.object({
   scenario: z.string(),
   generations: z.number().int().gt(0),
   require_playbook_approval: z.boolean().optional(),
-  require_lesson_approval: z.boolean().optional(),
 });
 
 export const ListScenariosCmdSchema = z.object({

--- a/ts/tests/playbook-approval-gate.test.ts
+++ b/ts/tests/playbook-approval-gate.test.ts
@@ -16,7 +16,7 @@ function store(dir: string): ArtifactStore {
 }
 
 describe("playbook approval gate", () => {
-  it("accepts playbook approval flag and deprecated lesson alias", () => {
+  it("accepts the playbook approval flag and rejects the removed lesson alias", () => {
     expect(
       StartRunCmdSchema.parse({
         type: "start_run",
@@ -25,14 +25,15 @@ describe("playbook approval gate", () => {
         require_playbook_approval: true,
       }).require_playbook_approval,
     ).toBe(true);
-    expect(
+    // The deprecated require_lesson_approval alias was removed; the strict schema rejects it.
+    expect(() =>
       StartRunCmdSchema.parse({
         type: "start_run",
         scenario: "grid_ctf",
         generations: 1,
         require_lesson_approval: true,
-      }).require_lesson_approval,
-    ).toBe(true);
+      }),
+    ).toThrow();
   });
 
   it("defaults off and writes playbooks live", () => {
@@ -79,7 +80,10 @@ describe("playbook approval gate", () => {
 
       expect(artifacts.readPlaybook("grid_ctf")).toBe("auto new\n");
       expect(artifacts.readPendingPlaybook("grid_ctf").hasPending).toBe(false);
-      expect(artifacts.approvePendingPlaybook("grid_ctf")).toEqual({ ok: false, status: "missing" });
+      expect(artifacts.approvePendingPlaybook("grid_ctf")).toEqual({
+        ok: false,
+        status: "missing",
+      });
       expect(artifacts.readPlaybook("grid_ctf")).toBe("auto new\n");
     } finally {
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
Removes the `require_lesson_approval` compatibility alias on `start_run`. It was kept for one window so the in-flight autowork toggle wouldn't break; autowork now sends the canonical `require_playbook_approval` (autowork #24, merged), so the alias is dead weight.

## Changes
- **`protocol.py`** `StartRunCmd`: remove `require_lesson_approval` + the `effective_require_playbook_approval` shim. With `extra="forbid"`, sending the old field is now rejected at parse time instead of silently aliased.
- **`app.py`**: read `start_cmd.require_playbook_approval` directly.
- **`ts/src/server/protocol.ts`**: drop the alias from the `start_run` schema (`.strict()` rejects it); `interactive-control-command-workflow.ts` reads the field directly.
- **Regenerated** `ts/src/tui/protocol.generated.ts` + `protocol/autocontext-protocol.json` via `scripts/generate_protocol.py`.
- **Tests**: assert the canonical flag parses, defaults off, and the removed alias is now rejected (Python `extra=forbid` + TS `.strict()`).

## Pre-flight (per AC-828)
Confirmed the only client, autowork, sends `require_playbook_approval` and no longer sends the old field. A small autowork follow-up drops the now-pointless alias mirror from its vendored `protocol.ts`.

## Verification
Python protocol/app/websocket/parity/approval-gate suites green; `tsc` clean. Pre-existing `isolated-vm`/`better-sqlite3` native-binding test failures are unrelated (reproduce on `main`).

Closes AC-828.