### PR TITLE
Bump pi-autocontext to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [pi-v0.8.0] - 2026-06-20
+
+### Changed
+
+- Pi `pi-autocontext` package metadata is bumped to `0.8.0`, and its `autoctx` dependency now requires the published `^0.8.0` line.
+
 ## [0.8.0] - 2026-06-20
 
 ### Added
@@ -538,7 +544,8 @@ A new cross-runtime parity audit (`test_cli_contract_parity.py` + `cli-contract-
 - FastAPI dashboard with WebSocket events.
 - CLI via Typer (Python) and `parseArgs` (TypeScript).
 
-[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.8.0...HEAD
+[Unreleased]: https://github.com/greyhaven-ai/autocontext/compare/pi-v0.8.0...HEAD
+[pi-v0.8.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.8.0...pi-v0.8.0
 [0.8.0]: https://github.com/greyhaven-ai/autocontext/compare/pi-v0.2.6...py-v0.8.0
 [pi-v0.2.6]: https://github.com/greyhaven-ai/autocontext/compare/v0.7.0...pi-v0.2.6
 [0.7.0]: https://github.com/greyhaven-ai/autocontext/compare/py-v0.6.0...py-v0.7.0

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ If you already work inside a coding agent, you can wire autocontext in once and 
 **Pi** ships an autocontext skill out of the box. Install the published Pi package and Pi loads natural-language wrappers over live tools such as `autocontext_solve_scenario`, `autocontext_evaluate_output`, `autocontext_run_improvement_loop`, `autocontext_run_status`, and `autocontext_list_scenarios`.
 
 ```bash
-pi install npm:pi-autocontext@0.2.6
+pi install npm:pi-autocontext@0.8.0
 ```
 
-Pi is on a separate package line: `pi-autocontext@0.2.6` depends on `autoctx@^0.7.0`. A follow-up Pi release can move it to `autoctx@^0.8.0` after the core npm package is live.
+Pi is on a separate package line: `pi-autocontext@0.8.0` depends on `autoctx@^0.8.0`, matching the current Python and TypeScript 0.8 runtime line.
 
 Then you just ask:
 
@@ -244,10 +244,10 @@ uv tool install autocontext==0.8.0
 bun add -g autoctx@0.8.0
 
 # Pi extension
-pi install npm:pi-autocontext@0.2.6
+pi install npm:pi-autocontext@0.8.0
 ```
 
-> The PyPI package is `autocontext`. The CLI entrypoint is `autoctx`. The npm packages are `autoctx` and `pi-autocontext` (note: an unrelated package on npm uses the name `autocontext`; that is not this project). `pi-autocontext@0.2.6` still depends on `autoctx@^0.7.0`; a follow-up Pi release can move it to `autoctx@^0.8.0` after the core npm package is live.
+> The PyPI package is `autocontext`. The CLI entrypoint is `autoctx`. The npm packages are `autoctx` and `pi-autocontext` (note: an unrelated package on npm uses the name `autocontext`; that is not this project). `pi-autocontext@0.8.0` depends on `autoctx@^0.8.0`, matching the current TypeScript runtime line.
 
 ## Surfaces
 

--- a/pi/README.md
+++ b/pi/README.md
@@ -5,16 +5,16 @@ autocontext extension for [Pi coding agent](https://github.com/earendil-works/pi
 ## Install
 
 ```bash
-pi install npm:pi-autocontext@0.2.6
+pi install npm:pi-autocontext@0.8.0
 ```
 
-Current package note: `pi-autocontext@0.2.6` is on a separate Pi extension line and depends on `autoctx@^0.7.0`. A follow-up Pi release can move it to `autoctx@^0.8.0` after the core npm package is live.
+Current package note: `pi-autocontext@0.8.0` is on a separate Pi extension line and depends on `autoctx@^0.8.0`, matching the current Python and TypeScript 0.8 runtime line.
 
 Or add to your project's `.pi/settings.json`:
 
 ```json
 {
-  "packages": ["npm:pi-autocontext@0.2.6"]
+  "packages": ["npm:pi-autocontext@0.8.0"]
 }
 ```
 

--- a/pi/package-lock.json
+++ b/pi/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "pi-autocontext",
-  "version": "0.2.6",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-autocontext",
-      "version": "0.2.6",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "autoctx": "^0.7.0"
+        "autoctx": "^0.8.0"
       },
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.74.0",
@@ -2214,12 +2214,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/diff": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
-      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2583,14 +2577,13 @@
       }
     },
     "node_modules/autoctx": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/autoctx/-/autoctx-0.7.0.tgz",
-      "integrity": "sha512-bo+tBT3rWGYfrOcDIFPq1E7/Bag6yx518tKnsUS39yplAs15AC2P1XG3GEfhhJdsC35J6ROoPefNIdq835AaiQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/autoctx/-/autoctx-0.8.0.tgz",
+      "integrity": "sha512-dkQTX180Sq1NJbYCGVWt3aEdJKPk2PW0SAzhamk3crpUS0fWxcjTdZLE9TWJne2bMdyCgNiAzA5K+INXN5zmkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@types/diff": "^7.0.2",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "better-sqlite3": "^11.0.0",

--- a/pi/package.json
+++ b/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-autocontext",
-  "version": "0.2.6",
+  "version": "0.8.0",
   "description": "autocontext extension for Pi coding agent — iterative strategy generation, LLM judging, and evaluation tools",
   "type": "module",
   "keywords": [
@@ -21,13 +21,13 @@
   },
   "homepage": "https://github.com/greyhaven-ai/autocontext/tree/main/pi",
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*",
     "typebox": "*"
   },
   "dependencies": {
-    "autoctx": "^0.7.0"
+    "autoctx": "^0.8.0"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.74.0",

--- a/pi/tests/extension.test.ts
+++ b/pi/tests/extension.test.ts
@@ -356,7 +356,7 @@ describe("Package manifest", () => {
 
   it("depends on the current autoctx toolkit line", () => {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-    expect(pkg.dependencies.autoctx).toBe("^0.7.0");
+    expect(pkg.dependencies.autoctx).toBe("^0.8.0");
   });
 });
 


### PR DESCRIPTION
## Summary

- Bump `pi-autocontext` package metadata to `0.8.0`.
- Update its `autoctx` dependency and lockfile to the published `^0.8.0` toolkit line.
- Refresh root/Pi install docs and package-manifest test expectations.

## Validation

- `cd pi && npm install --package-lock-only --ignore-scripts --min-release-age=0`
- `cd pi && npm ci --ignore-scripts`
- `cd pi && npm run lint`
- `cd pi && npm test`
- `cd pi && npm run build`
- `cd pi && npm pack --dry-run`

`autoctx@0.8.0` is published before this bump.
