### PR TITLE
fix(hermes): finish AC-708 advisor wrap-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- AC-708 Hermes advisor checkpoints preserve MLX/CUDA provenance through `autoctx hermes recommend --advisor`, and local-training docs now point at the shipped `train-advisor` / `recommend` flow.
+
 ## [pi-v0.8.0] - 2026-06-20
 
 ### Changed

--- a/autocontext/src/autocontext/cli_hermes.py
+++ b/autocontext/src/autocontext/cli_hermes.py
@@ -369,7 +369,7 @@ def register_hermes_command(
             Path | None,
             typer.Option(
                 "--advisor",
-                help="Trained advisor checkpoint (AC-708 slice 2a; produced by train-advisor --logistic --checkpoint)",
+                help="Trained advisor checkpoint produced by train-advisor --logistic/--mlx/--cuda --checkpoint",
             ),
         ] = None,
         output: Annotated[

--- a/autocontext/src/autocontext/cli_hermes_runners.py
+++ b/autocontext/src/autocontext/cli_hermes_runners.py
@@ -513,6 +513,7 @@ def run_hermes_train_advisor_command(
         # `training_device` and thread it into save_cuda_advisor;
         # PR #996 review (P2): the device must come from training,
         # not from torch.cuda.is_available() at save time.
+        training_device: str | None = None
         if logistic:
             trained = train_logistic(examples)
             advisor_kind = "logistic_regression"
@@ -541,7 +542,7 @@ def run_hermes_train_advisor_command(
         }
         if backend_label is not None:
             payload["backend"] = backend_label
-        if cuda:
+        if training_device is not None:
             payload["device"] = training_device
         if checkpoint is not None:
             saver(trained, checkpoint)
@@ -582,12 +583,11 @@ def run_hermes_recommend_command(
 ) -> None:
     """Emit read-only recommendations from an advisor (AC-709).
 
-    Backend selection (AC-708 slice 2a):
+    Backend selection (AC-708):
     * ``--baseline-from <jsonl>``: train a majority-class baseline
       on the fly from AC-705 export data.
-    * ``--advisor <checkpoint>``: load a trained advisor (e.g. the
-      logistic-regression checkpoint produced by
-      ``autoctx hermes train-advisor --logistic --checkpoint ...``).
+    * ``--advisor <checkpoint>``: load a trained advisor produced by
+      ``autoctx hermes train-advisor --logistic|--mlx|--cuda --checkpoint ...``.
     Exactly one must be passed.
     """
 
@@ -657,7 +657,7 @@ def run_hermes_recommend_command(
                 console.print(f"[red]{err}[/red]")
             raise typer.Exit(code=1) from err
         advisor = trained
-        advisor_kind = "logistic_regression"
+        advisor_kind = trained.checkpoint_kind
         summary_extra = {"labels": list(trained.labels)}
 
     resolved_home = _resolve_hermes_home(home)

--- a/autocontext/src/autocontext/hermes/dataset_export.py
+++ b/autocontext/src/autocontext/hermes/dataset_export.py
@@ -52,9 +52,9 @@ Each JSONL row:
       }
     }
 
-The schema is intentionally flat and feature-engineered so it can
-feed `autoctx train --backend mlx|cuda` via a one-step adapter (the
-adapter is a follow-up; this slice ships the dataset shape).
+The schema is intentionally flat and feature-engineered so it can feed
+`autoctx hermes train-advisor --baseline|--logistic|--mlx|--cuda`
+without a bespoke adapter.
 """
 
 from __future__ import annotations

--- a/autocontext/src/autocontext/hermes/references.py
+++ b/autocontext/src/autocontext/hermes/references.py
@@ -220,18 +220,19 @@ How autocontext-exported datasets feed local MLX or CUDA training. Use
 this when the user asks "can I train a model from my Hermes data" or
 when an agent needs to scope training expectations.
 
-> **Command availability.** `autoctx hermes export-dataset` (AC-705)
-> ships on a follow-up PR in the Hermes-integration cluster.
-> `autoctx train` is shipped today. Run `autoctx hermes --help` and
-> `autoctx train --help` to confirm what is installed locally before
-> recommending the end-to-end flow below.
+> **Command availability.** `autoctx hermes export-dataset`,
+> `autoctx hermes train-advisor`, and `autoctx hermes recommend` ship
+> together in the Hermes-integration path. Run `autoctx hermes --help`
+> to confirm what is installed locally before recommending the flow
+> below. `autoctx train` is for Autocontext scenario datasets, not
+> Hermes curator-advisor checkpoints.
 
 ## Scope (read this first)
 
-`autoctx train` produces **narrow advisor classifiers**, not full
-agent replacements. The expected use is: should this curator decision
-have been made? Should this skill be active vs archived? Was this
-consolidation good?
+`autoctx hermes train-advisor` produces **narrow advisor classifiers**,
+not full agent replacements. The expected use is: should this Curator
+decision have been made? Should this skill be archived, consolidated,
+pruned, or left alone?
 
 **Small personal Hermes homes will not produce frontier-quality
 models.** The size and diversity of the dataset matter more than the
@@ -243,9 +244,9 @@ shadow-evaluation loop instead of training.
 1. Export a labeled dataset:
 
    ```bash
-   autoctx hermes export-dataset \
-       --kind curator-decisions \
-       --home ~/.hermes \
+   autoctx hermes export-dataset \\
+       --kind curator-decisions \\
+       --home ~/.hermes \\
        --output training/hermes-curator-decisions.jsonl
    ```
 
@@ -258,42 +259,52 @@ shadow-evaluation loop instead of training.
    Each row is a flat feature vector + label + confidence. See the
    AC-705 module docstring for the canonical schema.
 
-3. (Future) Train an advisor model:
+3. Train an advisor model:
 
    ```bash
-   autoctx train --backend mlx --dataset training/hermes-curator-decisions.jsonl
-   autoctx train --backend cuda --dataset training/hermes-curator-decisions.jsonl
+   autoctx hermes train-advisor \\
+       --data training/hermes-curator-decisions.jsonl \\
+       --logistic \\
+       --checkpoint training/hermes-advisor.json \\
+       --json
    ```
 
-   The training pipeline adapter for this dataset shape is a follow-up
-   (AC-708); for now the dataset shape ships and an external trainer
-   can consume the JSONL directly.
+   Use `--baseline` first for a floor. Use `--mlx` on Apple Silicon or
+   `--cuda` on PyTorch/CUDA hosts when the optional extra is installed.
 
-4. (Future) Surface advisor predictions back to Hermes Curator as
-   **read-only recommendations** (AC-709). Curator stays the mutation
-   owner.
+4. Surface advisor predictions back to Hermes Curator as **read-only**
+   recommendations. Curator stays the mutation owner.
+
+   ```bash
+   autoctx hermes recommend \\
+       --home ~/.hermes \\
+       --advisor training/hermes-advisor.json \\
+       --output training/hermes-recommendations.jsonl \\
+       --json
+   ```
 
 ## Backend selection
 
+- **baseline**: majority-class floor; no checkpoint needed.
+- **logistic**: pure-Python fallback; works in plain CI and small homes.
 - **MLX**: Apple Silicon laptops with plenty of RAM. Quick iteration.
-- **CUDA**: x86 + NVIDIA. Faster wall-clock for the same dataset.
+- **CUDA**: NVIDIA hosts with PyTorch; falls back to CPU torch when CUDA
+  is unavailable.
 
-Both backends produce models in the same on-disk format that the
-advisor surface (AC-709) will consume.
+All trained backends produce JSON checkpoints that `autoctx hermes
+recommend --advisor` can consume.
 
 ## What the advisor predicts
 
-Per the AC-708 design, the initial advisor tasks are:
+Per the shipped AC-708/AC-709 path, the initial advisor predicts Curator
+actions from exported decision rows:
 
-- classify whether a skill is `active` / `stale` / `prunable` /
-  `pinned` / `patch-worthy`,
-- recommend likely umbrella consolidation targets,
-- rank candidate skills for a task/session summary,
-- detect low-confidence Curator actions (so an operator can review
-  before the decision is durable).
+- `added`, `archived`, `consolidated`, or `pruned` labels,
+- confidence and per-label metrics from the local training run,
+- protected-skill status for pinned, bundled, and hub-owned skills.
 
-None of these mutate Hermes state. They are evidence + scores;
-Curator decides what to do with them.
+None of these mutate Hermes state. They are evidence + scores; Curator
+and the operator decide what to do with them.
 """
 
 _REFERENCES: dict[str, str] = {

--- a/autocontext/src/autocontext/hermes/skill.py
+++ b/autocontext/src/autocontext/hermes/skill.py
@@ -159,7 +159,15 @@ uv run autoctx train --scenario grid_ctf --data training/grid_ctf.jsonl --backen
 
 Use MLX on Apple Silicon hosts. Use CUDA on Linux GPU hosts with a CUDA-enabled PyTorch install. Do not run host-GPU training inside a sandbox unless the user has already provided a host bridge or direct GPU access.
 
-For Hermes Curator artifacts, start with read-only inspection and dataset design before training. Curator reports are decision traces; they are best suited for advisor/ranker/classifier training, not full autonomous skill mutation.
+For Hermes Curator artifacts, train a narrow read-only advisor from exported decision rows:
+
+```bash
+uv run autoctx hermes export-dataset --kind curator-decisions --home ~/.hermes --output training/hermes-curator-decisions.jsonl --json
+uv run autoctx hermes train-advisor --data training/hermes-curator-decisions.jsonl --logistic --checkpoint training/hermes-advisor.json --json
+uv run autoctx hermes recommend --home ~/.hermes --advisor training/hermes-advisor.json --output training/hermes-recommendations.jsonl --json
+```
+
+Use `--baseline` first for the majority-class floor. Use `--mlx` on Apple Silicon or `--cuda` on PyTorch/CUDA hosts when the optional extra is installed. Curator reports are decision traces; they are best suited for advisor/ranker/classifier training, not full autonomous skill mutation.
 
 ## MCP Workflow When Configured
 

--- a/autocontext/src/autocontext/hermes/trained_advisor.py
+++ b/autocontext/src/autocontext/hermes/trained_advisor.py
@@ -118,6 +118,7 @@ class LogisticRegressionAdvisor:
     seed: int = 0
     epochs: int = 0
     learning_rate: float = 0.0
+    checkpoint_kind: str = _CHECKPOINT_KIND
     label_counts: dict[str, int] = field(default_factory=dict)
 
     def predict(self, features: SkillFeatures) -> str:
@@ -302,6 +303,7 @@ def load_advisor(path: Path) -> LogisticRegressionAdvisor:
         seed=int(payload.get("seed", 0)),
         epochs=int(payload.get("epochs", 0)),
         learning_rate=float(payload.get("learning_rate", 0.0)),
+        checkpoint_kind=str(kind),
         label_counts=dict(payload.get("label_counts", {})),
     )
 

--- a/autocontext/tests/test_hermes_trained_advisor.py
+++ b/autocontext/tests/test_hermes_trained_advisor.py
@@ -273,6 +273,7 @@ def test_load_advisor_accepts_mlx_kind(tmp_path: Path) -> None:
     loaded = load_advisor(path)
     assert isinstance(loaded, LogisticRegressionAdvisor)
     assert loaded.labels == ("consolidated", "pruned")
+    assert loaded.checkpoint_kind == "mlx_logistic_regression"
 
 
 def test_load_advisor_rejects_missing_file(tmp_path: Path) -> None:
@@ -470,9 +471,64 @@ def test_cli_recommend_consumes_trained_checkpoint(tmp_path: Path) -> None:
     assert rows[0]["predicted_action"] == "consolidated"
 
 
-def test_cli_train_advisor_requires_one_of_baseline_or_logistic(tmp_path: Path) -> None:
-    """Passing neither --baseline nor --logistic must fail loudly so
-    the operator picks a backend deliberately."""
+def test_cli_recommend_reports_loaded_checkpoint_kind(tmp_path: Path) -> None:
+    """Recommendation summaries should preserve MLX/CUDA checkpoint provenance."""
+    from typer.testing import CliRunner
+
+    from autocontext.cli import app
+
+    advisor = train_logistic(_separable_dataset())
+    checkpoint = tmp_path / "mlx-advisor.json"
+    save_advisor(advisor, checkpoint)
+    payload = json.loads(checkpoint.read_text(encoding="utf-8"))
+    payload["kind"] = "mlx_logistic_regression"
+    payload["backend"] = "mlx"
+    checkpoint.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    home = tmp_path / "hermes"
+    skills_dir = home / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "hot-skill").mkdir()
+    (skills_dir / "hot-skill" / "SKILL.md").write_text(
+        "---\nname: hot-skill\ndescription: test\n---\n# hot-skill\n",
+        encoding="utf-8",
+    )
+    (skills_dir / ".usage.json").write_text(
+        json.dumps(
+            {
+                "hot-skill": {
+                    "state": "active",
+                    "pinned": False,
+                    "use_count": 25,
+                    "view_count": 0,
+                    "patch_count": 0,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    recs_out = tmp_path / "recs.jsonl"
+    result = CliRunner().invoke(
+        app,
+        [
+            "hermes",
+            "recommend",
+            "--home",
+            str(home),
+            "--advisor",
+            str(checkpoint),
+            "--output",
+            str(recs_out),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["advisor_kind"] == "mlx_logistic_regression"
+
+
+def test_cli_train_advisor_requires_one_backend_flag(tmp_path: Path) -> None:
+    """Passing neither backend flag must fail loudly so the operator picks one."""
     from typer.testing import CliRunner
 
     from autocontext.cli import app

--- a/docs/hermes-positioning.md
+++ b/docs/hermes-positioning.md
@@ -24,7 +24,7 @@ training pipelines can consume.
 | Session and trajectory data               | Hermes writes        | autocontext imports (with explicit redaction)                                               |
 | Evaluation against a rubric               | Out of scope         | `autoctx judge` / `autoctx improve`                                                         |
 | Replay / artifact storage                 | Per-Hermes-run logs  | Durable `Run` / `Artifact` / `Knowledge` model (see [concept-model.md](./concept-model.md)) |
-| Local MLX / CUDA training                 | Out of scope         | `autoctx train` (advisory, narrow)                                                          |
+| Local MLX / CUDA training                 | Out of scope         | `autoctx hermes train-advisor` (advisory, narrow)                                           |
 | Exporting reusable skills                 | Out of scope         | `autoctx hermes export-skill`                                                               |
 
 ## Default operator flow
@@ -141,9 +141,9 @@ operator commands with their own consent surfaces.
 
 ## Local MLX / CUDA training
 
-`autoctx train` produces narrow advisor models from local datasets
-(see [agent-integration.md](../autocontext/docs/agent-integration.md)
-for the command flags). The training path is intentionally scoped:
+`autoctx hermes train-advisor` produces narrow advisor models from
+`autoctx hermes export-dataset --kind curator-decisions` JSONL. The
+training path is intentionally scoped:
 
 - Datasets are derived from curator decisions, traces, and rubric
   outcomes that the operator already has on disk.
@@ -155,10 +155,8 @@ for the command flags). The training path is intentionally scoped:
   operator's actual workflow, not to claim benchmark performance
   improvements.
 
-The advisor output is exposed as **read-only recommendations** to
-Hermes Curator: Curator still owns the mutation. (See AC-708 / AC-709
-for the in-flight training and recommendation surface; not yet
-shipped.)
+The advisor output is exposed as **read-only recommendations** via
+`autoctx hermes recommend --advisor`: Curator still owns the mutation.
 
 ## Why autocontext does not replace Curator
 
@@ -186,26 +184,23 @@ export-dataset --kind curator-decisions` (AC-705), `autoctx hermes
 ingest-trajectories --redact standard|strict|off` (AC-706 slice 1),
   `autoctx hermes ingest-sessions --redact standard|strict|off`
   (AC-706 slice 2, read-only SQLite + schema drift + WAL/SHM
-  independence), `autoctx hermes train-advisor --baseline` (AC-708
-  slice 1, data + evaluation contract with majority-class baseline
-  and insufficient-data floor), `autoctx hermes recommend
---baseline-from <jsonl>` (AC-709, read-only recommendation surface
-  with protected-skill filter and audit mode), `autoctx hermes
-validate-skill --json` (AC-711, static content rubric over the
-  rendered SKILL.md with six behaviors and three negative
-  regression tests; see
-  [hermes-skill-validation.md](./hermes-skill-validation.md)),
-  the rendered Hermes-format SKILL.md, the committed
-  `skills/autocontext/` distribution snapshot with CI sync
-  invariant (AC-712, see
-  [hermes-skill-distribution.md](./hermes-skill-distribution.md)
-  for install / update / versioning), the integration surface
-  order decision (CLI-first / MCP-optional / native runtime /
-  plugin / gateway).
-- In flight: AC-708 slice 2 (logistic-regression / MLX / CUDA
-  trained advisor), AC-707 follow-up implementation (only if
-  revisited per spike doc), upstream Hermes / agentskills.io
-  submission (AC-712 follow-up).
+  independence), `autoctx hermes train-advisor --baseline|--logistic|--mlx|--cuda`
+  (AC-708, baseline plus trained logistic/MLX/CUDA advisor checkpoints),
+  `autoctx hermes recommend --baseline-from <jsonl>|--advisor <checkpoint>`
+  (AC-709, read-only recommendation surface with protected-skill filter
+  and audit mode), `autoctx hermes validate-skill --json` (AC-711,
+  static content rubric over the rendered SKILL.md with six behaviors
+  and three negative regression tests; see
+  [hermes-skill-validation.md](./hermes-skill-validation.md)), the
+  rendered Hermes-format SKILL.md, the committed `skills/autocontext/`
+  distribution snapshot with CI sync invariant (AC-712, see
+  [hermes-skill-distribution.md](./hermes-skill-distribution.md) for
+  install / update / versioning), the integration surface order
+  decision (CLI-first / MCP-optional / native runtime / plugin /
+  gateway).
+- In flight: AC-707 follow-up implementation (only if revisited per
+  spike doc), upstream Hermes / agentskills.io submission (AC-712
+  follow-up).
 - Out of scope (today): autocontext writing to `~/.hermes/skills/`,
   autocontext replacing Curator's pruning / consolidation /
   gating workflow, frontier-scale training from a single operator's

--- a/skills/autocontext/SKILL.md
+++ b/skills/autocontext/SKILL.md
@@ -145,7 +145,15 @@ uv run autoctx train --scenario grid_ctf --data training/grid_ctf.jsonl --backen
 
 Use MLX on Apple Silicon hosts. Use CUDA on Linux GPU hosts with a CUDA-enabled PyTorch install. Do not run host-GPU training inside a sandbox unless the user has already provided a host bridge or direct GPU access.
 
-For Hermes Curator artifacts, start with read-only inspection and dataset design before training. Curator reports are decision traces; they are best suited for advisor/ranker/classifier training, not full autonomous skill mutation.
+For Hermes Curator artifacts, train a narrow read-only advisor from exported decision rows:
+
+```bash
+uv run autoctx hermes export-dataset --kind curator-decisions --home ~/.hermes --output training/hermes-curator-decisions.jsonl --json
+uv run autoctx hermes train-advisor --data training/hermes-curator-decisions.jsonl --logistic --checkpoint training/hermes-advisor.json --json
+uv run autoctx hermes recommend --home ~/.hermes --advisor training/hermes-advisor.json --output training/hermes-recommendations.jsonl --json
+```
+
+Use `--baseline` first for the majority-class floor. Use `--mlx` on Apple Silicon or `--cuda` on PyTorch/CUDA hosts when the optional extra is installed. Curator reports are decision traces; they are best suited for advisor/ranker/classifier training, not full autonomous skill mutation.
 
 ## MCP Workflow When Configured
 

--- a/skills/autocontext/references/local-training.md
+++ b/skills/autocontext/references/local-training.md
@@ -4,18 +4,19 @@ How autocontext-exported datasets feed local MLX or CUDA training. Use
 this when the user asks "can I train a model from my Hermes data" or
 when an agent needs to scope training expectations.
 
-> **Command availability.** `autoctx hermes export-dataset` (AC-705)
-> ships on a follow-up PR in the Hermes-integration cluster.
-> `autoctx train` is shipped today. Run `autoctx hermes --help` and
-> `autoctx train --help` to confirm what is installed locally before
-> recommending the end-to-end flow below.
+> **Command availability.** `autoctx hermes export-dataset`,
+> `autoctx hermes train-advisor`, and `autoctx hermes recommend` ship
+> together in the Hermes-integration path. Run `autoctx hermes --help`
+> to confirm what is installed locally before recommending the flow
+> below. `autoctx train` is for Autocontext scenario datasets, not
+> Hermes curator-advisor checkpoints.
 
 ## Scope (read this first)
 
-`autoctx train` produces **narrow advisor classifiers**, not full
-agent replacements. The expected use is: should this curator decision
-have been made? Should this skill be active vs archived? Was this
-consolidation good?
+`autoctx hermes train-advisor` produces **narrow advisor classifiers**,
+not full agent replacements. The expected use is: should this Curator
+decision have been made? Should this skill be archived, consolidated,
+pruned, or left alone?
 
 **Small personal Hermes homes will not produce frontier-quality
 models.** The size and diversity of the dataset matter more than the
@@ -27,7 +28,10 @@ shadow-evaluation loop instead of training.
 1. Export a labeled dataset:
 
    ```bash
-   autoctx hermes export-dataset        --kind curator-decisions        --home ~/.hermes        --output training/hermes-curator-decisions.jsonl
+   autoctx hermes export-dataset \
+       --kind curator-decisions \
+       --home ~/.hermes \
+       --output training/hermes-curator-decisions.jsonl
    ```
 
 2. Inspect the dataset shape:
@@ -39,39 +43,49 @@ shadow-evaluation loop instead of training.
    Each row is a flat feature vector + label + confidence. See the
    AC-705 module docstring for the canonical schema.
 
-3. (Future) Train an advisor model:
+3. Train an advisor model:
 
    ```bash
-   autoctx train --backend mlx --dataset training/hermes-curator-decisions.jsonl
-   autoctx train --backend cuda --dataset training/hermes-curator-decisions.jsonl
+   autoctx hermes train-advisor \
+       --data training/hermes-curator-decisions.jsonl \
+       --logistic \
+       --checkpoint training/hermes-advisor.json \
+       --json
    ```
 
-   The training pipeline adapter for this dataset shape is a follow-up
-   (AC-708); for now the dataset shape ships and an external trainer
-   can consume the JSONL directly.
+   Use `--baseline` first for a floor. Use `--mlx` on Apple Silicon or
+   `--cuda` on PyTorch/CUDA hosts when the optional extra is installed.
 
-4. (Future) Surface advisor predictions back to Hermes Curator as
-   **read-only recommendations** (AC-709). Curator stays the mutation
-   owner.
+4. Surface advisor predictions back to Hermes Curator as **read-only**
+   recommendations. Curator stays the mutation owner.
+
+   ```bash
+   autoctx hermes recommend \
+       --home ~/.hermes \
+       --advisor training/hermes-advisor.json \
+       --output training/hermes-recommendations.jsonl \
+       --json
+   ```
 
 ## Backend selection
 
+- **baseline**: majority-class floor; no checkpoint needed.
+- **logistic**: pure-Python fallback; works in plain CI and small homes.
 - **MLX**: Apple Silicon laptops with plenty of RAM. Quick iteration.
-- **CUDA**: x86 + NVIDIA. Faster wall-clock for the same dataset.
+- **CUDA**: NVIDIA hosts with PyTorch; falls back to CPU torch when CUDA
+  is unavailable.
 
-Both backends produce models in the same on-disk format that the
-advisor surface (AC-709) will consume.
+All trained backends produce JSON checkpoints that `autoctx hermes
+recommend --advisor` can consume.
 
 ## What the advisor predicts
 
-Per the AC-708 design, the initial advisor tasks are:
+Per the shipped AC-708/AC-709 path, the initial advisor predicts Curator
+actions from exported decision rows:
 
-- classify whether a skill is `active` / `stale` / `prunable` /
-  `pinned` / `patch-worthy`,
-- recommend likely umbrella consolidation targets,
-- rank candidate skills for a task/session summary,
-- detect low-confidence Curator actions (so an operator can review
-  before the decision is durable).
+- `added`, `archived`, `consolidated`, or `pruned` labels,
+- confidence and per-label metrics from the local training run,
+- protected-skill status for pinned, bundled, and hub-owned skills.
 
-None of these mutate Hermes state. They are evidence + scores;
-Curator decides what to do with them.
+None of these mutate Hermes state. They are evidence + scores; Curator
+and the operator decide what to do with them.


### PR DESCRIPTION
## Summary

- Preserve trained advisor checkpoint provenance when `autoctx hermes recommend --advisor` consumes MLX/CUDA checkpoints.
- Update the rendered Hermes skill, local-training reference, dataset exporter notes, and positioning docs to the shipped `train-advisor` + `recommend` path.
- Add a regression test for loading/reporting MLX checkpoint kind through the recommendation CLI.

## Hermes research basis

Verified against Hermes Agent docs/source that Curator owns live `~/.hermes/skills` mutation, tracks usage in `.usage.json`, writes reports under `~/.hermes/logs/curator/<timestamp>/`, protects pinned/bundled/hub skills, and archives rather than auto-deletes. This keeps Autocontext in the read-only advisor/evaluation/export role.

## Tests

- `/Users/jayscambler/Repositories/autocontext/autocontext/autocontext/.venv/bin/python -m pytest autocontext/tests/test_hermes_advisor.py autocontext/tests/test_hermes_dataset_export.py autocontext/tests/test_hermes_recommendations.py autocontext/tests/test_hermes_references.py autocontext/tests/test_hermes_skill_distribution.py autocontext/tests/test_hermes_trained_advisor.py -q`
- `cd autocontext && .venv/bin/python -m ruff check src tests/test_hermes_trained_advisor.py`
- `cd autocontext && .venv/bin/python -m mypy src`
- LSP diagnostics on edited Python files: 0 errors

Linear: AC-708
