### PR TITLE
test(packages): lock strategy import purity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - AC-708 Hermes advisor checkpoints preserve MLX/CUDA provenance through `autoctx hermes recommend --advisor`, and local-training docs now point at the shipped `train-advisor` / `recommend` flow.
+- AC-638 strategy package imports now have a shared Python/TypeScript side-effect contract and smoke tests proving module imports do not create runtime files.
 
 ## [pi-v0.8.0] - 2026-06-20
 

--- a/autocontext/tests/test_strategy_package_import_contract.py
+++ b/autocontext/tests/test_strategy_package_import_contract.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any, cast
+
+
+def _contract_modules() -> list[dict[str, Any]]:
+    contract_path = Path(__file__).resolve().parents[2] / "docs" / "strategy-package-import-contract.json"
+    payload = json.loads(contract_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError("strategy-package import contract must be a JSON object")
+    modules = payload.get("modules")
+    if not isinstance(modules, list):
+        raise AssertionError("strategy-package import contract must declare modules")
+    return cast(list[dict[str, Any]], modules)
+
+
+def _snapshot_directory(path: Path) -> list[str]:
+    return sorted(str(child.relative_to(path)) for child in path.rglob("*"))
+
+
+def test_strategy_package_import_contract_declares_python_imports_pure() -> None:
+    modules = [entry for entry in _contract_modules() if entry["runtime"] == "python"]
+    assert modules
+    for entry in modules:
+        assert entry["import_time_filesystem_writes"] is False
+        assert "Call" in str(entry["runtime_setup"])
+
+
+def test_strategy_package_imports_do_not_create_runtime_files(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.chdir(tmp_path)
+    for entry in _contract_modules():
+        if entry["runtime"] != "python":
+            continue
+        before = _snapshot_directory(tmp_path)
+        importlib.import_module(str(entry["module"]))
+        assert _snapshot_directory(tmp_path) == before

--- a/autocontext/tests/test_strategy_package_import_contract.py
+++ b/autocontext/tests/test_strategy_package_import_contract.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-import importlib
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any, cast
 
@@ -29,11 +31,22 @@ def test_strategy_package_import_contract_declares_python_imports_pure() -> None
         assert "Call" in str(entry["runtime_setup"])
 
 
-def test_strategy_package_imports_do_not_create_runtime_files(tmp_path: Path, monkeypatch: Any) -> None:
-    monkeypatch.chdir(tmp_path)
+def test_strategy_package_imports_do_not_create_runtime_files(tmp_path: Path) -> None:
+    src_path = str(Path(__file__).resolve().parents[1] / "src")
+    env = {
+        **os.environ,
+        "PYTHONPATH": f"{src_path}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+    }
     for entry in _contract_modules():
         if entry["runtime"] != "python":
             continue
-        before = _snapshot_directory(tmp_path)
-        importlib.import_module(str(entry["module"]))
-        assert _snapshot_directory(tmp_path) == before
+        module_cwd = tmp_path / str(entry["module"]).replace(".", "_")
+        module_cwd.mkdir()
+        before = _snapshot_directory(module_cwd)
+        subprocess.run(
+            [sys.executable, "-c", f"import importlib; importlib.import_module({str(entry['module'])!r})"],
+            cwd=module_cwd,
+            env=env,
+            check=True,
+        )
+        assert _snapshot_directory(module_cwd) == before

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 ## Architecture And Parity
 
 - [Core/control package split](core-control-package-split.md)
+- [Strategy package import side-effect contract](strategy-package-import-contract.json)
 - [Generic edge runtime compatibility spike](edge-runtime-compatibility.md)
 - [Fetch adapter API reference](fetch-api-reference.md)
 - [Fetch host capability manifest examples](fetch-host-capability-manifest.md)

--- a/docs/strategy-package-import-contract.json
+++ b/docs/strategy-package-import-contract.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "contract": "strategy package module imports are pure",
+  "modules": [
+    {
+      "runtime": "python",
+      "module": "autocontext.knowledge",
+      "import_time_filesystem_writes": false,
+      "runtime_setup": "Call package import/export services explicitly."
+    },
+    {
+      "runtime": "python",
+      "module": "autocontext.knowledge.package",
+      "import_time_filesystem_writes": false,
+      "runtime_setup": "Call import_strategy_package(...) or export_strategy_package(...) with explicit stores."
+    },
+    {
+      "runtime": "typescript",
+      "module": "src/knowledge/index.js",
+      "import_time_filesystem_writes": false,
+      "runtime_setup": "Call package import/export services explicitly."
+    },
+    {
+      "runtime": "typescript",
+      "module": "src/knowledge/package.js",
+      "import_time_filesystem_writes": false,
+      "runtime_setup": "Call importStrategyPackage(...) or exportStrategyPackage(...) with explicit stores."
+    }
+  ]
+}

--- a/ts/tests/package-import-side-effects.test.ts
+++ b/ts/tests/package-import-side-effects.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+type ImportContractModule = {
+  import_time_filesystem_writes: boolean;
+  module: string;
+  runtime: "python" | "typescript";
+  runtime_setup: string;
+};
+
+const CONTRACT = JSON.parse(
+  readFileSync(
+    join(import.meta.dirname, "..", "..", "docs", "strategy-package-import-contract.json"),
+    "utf-8",
+  ),
+) as { modules: ImportContractModule[] };
+
+const TYPESCRIPT_IMPORTS: Record<string, () => Promise<unknown>> = {
+  "src/knowledge/index.js": () => import("../src/knowledge/index.js"),
+  "src/knowledge/package.js": () => import("../src/knowledge/package.js"),
+};
+
+function snapshotDirectory(dir: string): string[] {
+  return readdirSync(dir, { recursive: true })
+    .map((entry) => String(entry))
+    .sort();
+}
+
+describe("strategy package import contract", () => {
+  let dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    dirs = [];
+  });
+
+  it("declares TypeScript strategy-package imports as filesystem-pure", () => {
+    const modules = CONTRACT.modules.filter((entry) => entry.runtime === "typescript");
+    expect(modules).not.toHaveLength(0);
+    for (const entry of modules) {
+      expect(entry.import_time_filesystem_writes, entry.module).toBe(false);
+      expect(entry.runtime_setup, entry.module).toContain("Call");
+    }
+  });
+
+  it("imports strategy-package modules without creating runtime files", async () => {
+    for (const entry of CONTRACT.modules.filter((item) => item.runtime === "typescript")) {
+      const importModule = TYPESCRIPT_IMPORTS[entry.module];
+      expect(importModule, entry.module).toBeDefined();
+
+      const dir = mkdtempSync(join(tmpdir(), "ac-package-import-"));
+      dirs.push(dir);
+      const previousCwd = process.cwd();
+      try {
+        process.chdir(dir);
+        const before = snapshotDirectory(dir);
+        await importModule();
+        expect(snapshotDirectory(dir), entry.module).toEqual(before);
+      } finally {
+        process.chdir(previousCwd);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add a shared `docs/strategy-package-import-contract.json` declaring Python/TypeScript strategy-package imports as filesystem-pure.
- Add Python and TypeScript smoke tests proving the documented modules can be imported from an empty cwd without creating runtime files.
- Link the contract from the docs overview and note AC-638 in the changelog.

## Tests

- `/Users/jayscambler/Repositories/autocontext/autocontext/autocontext/.venv/bin/python -m pytest autocontext/tests/test_strategy_package_import_contract.py -q`
- `cd autocontext && .venv/bin/python -m ruff check tests/test_strategy_package_import_contract.py`
- `cd autocontext && .venv/bin/python -m mypy src`
- `cd ts && npm test -- tests/package-import-side-effects.test.ts`
- `cd ts && npm run lint`
- LSP diagnostics on edited Python/TypeScript test files: 0 errors

Linear: AC-638
