### PR TITLE
feat(providers): mirror role routing in TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- AC-637 TypeScript role routing now matches Python `role_routing=auto` semantics for role aliases, tier model selection, explicit provider overrides, and local-route unsupported capability reporting.
 - AC-708 Hermes advisor checkpoints preserve MLX/CUDA provenance through `autoctx hermes recommend --advisor`, and local-training docs now point at the shipped `train-advisor` / `recommend` flow.
 
 ## [pi-v0.8.0] - 2026-06-20

--- a/autocontext/tests/test_role_routing_contract.py
+++ b/autocontext/tests/test_role_routing_contract.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+
+def _contract() -> dict[str, Any]:
+    contract_path = Path(__file__).resolve().parents[2] / "docs" / "role-routing-contract.json"
+    payload = json.loads(contract_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError("role-routing contract must be a JSON object")
+    return cast(dict[str, Any], payload)
+
+
+def test_python_role_router_constants_match_shared_contract() -> None:
+    from autocontext.agents import role_router
+    from autocontext.agents.role_router import ProviderClass
+
+    contract = _contract()
+
+    assert [provider_class.value for provider_class in ProviderClass] == contract["provider_classes"]
+    assert {
+        role: [provider_class.value for provider_class in preferences]
+        for role, preferences in role_router.DEFAULT_ROUTING_TABLE.items()
+    } == contract["default_routing_table"]
+    assert sorted(role_router._LOCAL_ELIGIBLE_ROLES) == sorted(contract["local_eligible_roles"])  # noqa: SLF001
+    assert {
+        provider_class.value: cost
+        for provider_class, cost in role_router._COST_TABLE.items()  # noqa: SLF001
+    } == contract["cost_per_1k_tokens"]
+    assert {
+        provider: provider_class.value
+        for provider, provider_class in role_router._EXPLICIT_PROVIDER_CLASS.items()  # noqa: SLF001
+    } == contract["explicit_provider_classes"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ This directory is the maintainer-facing landing page for repository docs. Use it
 - [Flue-inspired runtime decisions](flue-influences.md)
 - [Scenario parity matrix — Python & TypeScript](scenario-parity-matrix.md)
 - [Scenario environment contract](scenario-environment-contract.md)
+- [Role routing contract](role-routing-contract.json)
 - [Run progress report](run-progress-report.md)
 - [Run utilization report](run-utilization-report.md)
 - [Negative result ledger](negative-result-ledger.md)

--- a/docs/app-settings-contract.json
+++ b/docs/app-settings-contract.json
@@ -1192,6 +1192,15 @@
       ]
     },
     {
+      "python": "mlx_model_path",
+      "typescript": "mlxModelPath",
+      "type": "string",
+      "default": "",
+      "env": [
+        "AUTOCONTEXT_MLX_MODEL_PATH"
+      ]
+    },
+    {
       "python": "monitor_enabled",
       "typescript": "monitorEnabled",
       "type": "boolean",
@@ -1678,6 +1687,19 @@
       ]
     },
     {
+      "python": "role_routing",
+      "typescript": "roleRouting",
+      "type": "enum",
+      "default": "off",
+      "env": [
+        "AUTOCONTEXT_ROLE_ROUTING"
+      ],
+      "values": [
+        "off",
+        "auto"
+      ]
+    },
+    {
       "python": "runs_root",
       "typescript": "runsRoot",
       "type": "path",
@@ -1833,6 +1855,33 @@
       "default": 5,
       "env": [
         "AUTOCONTEXT_STAGNATION_ROLLBACK_THRESHOLD"
+      ]
+    },
+    {
+      "python": "tier_haiku_model",
+      "typescript": "tierHaikuModel",
+      "type": "string",
+      "default": "claude-haiku-4-5-20251001",
+      "env": [
+        "AUTOCONTEXT_TIER_HAIKU_MODEL"
+      ]
+    },
+    {
+      "python": "tier_sonnet_model",
+      "typescript": "tierSonnetModel",
+      "type": "string",
+      "default": "claude-sonnet-4-5-20250929",
+      "env": [
+        "AUTOCONTEXT_TIER_SONNET_MODEL"
+      ]
+    },
+    {
+      "python": "tier_opus_model",
+      "typescript": "tierOpusModel",
+      "type": "string",
+      "default": "claude-opus-4-6",
+      "env": [
+        "AUTOCONTEXT_TIER_OPUS_MODEL"
       ]
     },
     {

--- a/docs/role-routing-contract.json
+++ b/docs/role-routing-contract.json
@@ -1,0 +1,53 @@
+{
+  "version": 1,
+  "contract": "role provider routing classes, preferences, and model tier mapping shared by Python and TypeScript",
+  "mode_values": ["off", "auto"],
+  "provider_classes": ["frontier", "mid_tier", "fast", "local", "code_policy"],
+  "cost_per_1k_tokens": {
+    "frontier": 0.015,
+    "mid_tier": 0.003,
+    "fast": 0.001,
+    "local": 0.0
+  },
+  "default_routing_table": {
+    "competitor": ["frontier", "local"],
+    "analyst": ["mid_tier", "local"],
+    "coach": ["mid_tier", "local"],
+    "architect": ["frontier"],
+    "curator": ["fast"],
+    "translator": ["fast", "local"]
+  },
+  "local_eligible_roles": ["competitor", "analyst", "coach", "translator"],
+  "explicit_provider_classes": {
+    "anthropic": "frontier",
+    "mlx": "local",
+    "openclaw": "frontier",
+    "deterministic": "fast",
+    "agent_sdk": "frontier",
+    "openai": "mid_tier",
+    "openai-compatible": "mid_tier",
+    "ollama": "mid_tier",
+    "vllm": "mid_tier"
+  },
+  "class_model_fields": {
+    "frontier": { "python": "tier_opus_model", "typescript": "tierOpusModel" },
+    "mid_tier": { "python": "tier_sonnet_model", "typescript": "tierSonnetModel" },
+    "fast": { "python": "tier_haiku_model", "typescript": "tierHaikuModel" },
+    "local": { "python": "mlx_model_path", "typescript": "mlxModelPath" }
+  },
+  "role_model_fields": {
+    "competitor": { "python": "model_competitor", "typescript": "modelCompetitor" },
+    "analyst": { "python": "model_analyst", "typescript": "modelAnalyst" },
+    "coach": { "python": "model_coach", "typescript": "modelCoach" },
+    "architect": { "python": "model_architect", "typescript": "modelArchitect" },
+    "curator": { "python": "model_curator", "typescript": "modelCurator" },
+    "translator": { "python": "model_translator", "typescript": "modelTranslator" }
+  },
+  "precedence": [
+    "explicit per-role provider override",
+    "default provider and role model when role routing is off",
+    "auto routing table with available local artifacts preferred for eligible roles",
+    "first API-backed provider class in the role routing table",
+    "mid-tier fallback for unknown roles"
+  ]
+}

--- a/ts/src/config/app-settings-schema.ts
+++ b/ts/src/config/app-settings-schema.ts
@@ -30,6 +30,11 @@ export const AppSettingsSchema = z.object({
   modelTranslator: z.string().default("claude-sonnet-4-5-20250929"),
   modelCurator: z.string().default("claude-opus-4-6"),
   modelSkeptic: z.string().default("claude-opus-4-6"),
+  tierHaikuModel: z.string().default("claude-haiku-4-5-20251001"),
+  tierSonnetModel: z.string().default("claude-sonnet-4-5-20250929"),
+  tierOpusModel: z.string().default("claude-opus-4-6"),
+  mlxModelPath: z.string().default(""),
+  roleRouting: z.enum(["off", "auto"]).default("off"),
 
   // Loop tuning
   architectEveryNGens: z.number().int().min(1).default(3),

--- a/ts/src/providers/index.ts
+++ b/ts/src/providers/index.ts
@@ -30,3 +30,21 @@ export {
   type RoleProviderBundle,
   type RoleProviderSettings,
 } from "./role-provider-bundle.js";
+
+export {
+  DEFAULT_ROLE_ROUTING_TABLE,
+  EXPLICIT_PROVIDER_CLASS,
+  LOCAL_ELIGIBLE_ROLES,
+  PROVIDER_CLASSES,
+  PROVIDER_CLASS_COST_PER_1K_TOKENS,
+  ROLE_ROUTING_MODES,
+  ROUTED_GENERATION_ROLES,
+  estimateRoleRoutingCost,
+  routeRoleProvider,
+  type ProviderClass,
+  type RoleRoutingContext,
+  type RoleRoutingCostEstimate,
+  type RoleRoutingMode,
+  type RoleRoutingSettings,
+  type RoutedProviderConfig,
+} from "./role-routing.js";

--- a/ts/src/providers/role-provider-bundle.ts
+++ b/ts/src/providers/role-provider-bundle.ts
@@ -1,6 +1,6 @@
 import { mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import type { LLMProvider } from "../types/index.js";
+import { ProviderError, type LLMProvider } from "../types/index.js";
 import { createProvider, type CreateProviderOpts } from "./provider-factory.js";
 import { resolveProviderConfig, type ProviderConfig } from "./provider-config-resolution.js";
 import {
@@ -11,11 +11,20 @@ import {
 import { RuntimeSession } from "../session/runtime-session.js";
 import { RuntimeSessionEventStore } from "../session/runtime-events.js";
 import type { RuntimeSessionEventSink } from "../session/runtime-session-notifications.js";
+import {
+  ROUTED_GENERATION_ROLES,
+  routeRoleProvider,
+  type GenerationRole,
+  type RoleRoutingContext,
+  type RoleRoutingSettings,
+  type RoutedProviderConfig,
+} from "./role-routing.js";
 
-export type GenerationRole = "competitor" | "analyst" | "coach" | "architect" | "curator";
+export type { GenerationRole } from "./role-routing.js";
 
-export interface RoleProviderSettings {
+export interface RoleProviderSettings extends RoleRoutingSettings {
   agentProvider: string;
+  roleRouting?: string;
   competitorProvider?: string;
   analystProvider?: string;
   coachProvider?: string;
@@ -33,6 +42,11 @@ export interface RoleProviderSettings {
   modelCoach?: string;
   modelArchitect?: string;
   modelCurator?: string;
+  modelTranslator?: string;
+  tierOpusModel?: string;
+  tierSonnetModel?: string;
+  tierHaikuModel?: string;
+  mlxModelPath?: string;
   claudeModel?: string;
   claudeFallbackModel?: string;
   claudeTools?: string | null;
@@ -70,6 +84,7 @@ export interface ProviderRuntimeSessionOpts {
 
 export interface ProviderCompositionOpts {
   runtimeSession?: ProviderRuntimeSessionOpts;
+  routingContext?: RoleRoutingContext;
 }
 
 export interface RoleProviderBundle {
@@ -77,6 +92,7 @@ export interface RoleProviderBundle {
   defaultConfig: ProviderConfig;
   roleProviders: Partial<Record<GenerationRole, LLMProvider>>;
   roleModels: Partial<Record<GenerationRole, string>>;
+  roleRoutes?: Partial<Record<GenerationRole, RoutedProviderConfig>>;
   runtimeSession?: RuntimeSession;
   close?: () => void;
 }
@@ -180,6 +196,76 @@ function resolveRoleConfig(
   );
 }
 
+function roleConfigInputForRole(
+  role: GenerationRole,
+  settings: RoleProviderSettings,
+): RoleConfigInput {
+  switch (role) {
+    case "competitor":
+      return {
+        providerType: settings.competitorProvider,
+        model: settings.modelCompetitor,
+        apiKey: settings.competitorApiKey,
+        baseUrl: settings.competitorBaseUrl,
+      };
+    case "analyst":
+      return {
+        providerType: settings.analystProvider,
+        model: settings.modelAnalyst,
+        apiKey: settings.analystApiKey,
+        baseUrl: settings.analystBaseUrl,
+      };
+    case "coach":
+      return {
+        providerType: settings.coachProvider,
+        model: settings.modelCoach,
+        apiKey: settings.coachApiKey,
+        baseUrl: settings.coachBaseUrl,
+      };
+    case "architect":
+      return {
+        providerType: settings.architectProvider,
+        model: settings.modelArchitect,
+        apiKey: settings.architectApiKey,
+        baseUrl: settings.architectBaseUrl,
+      };
+    case "curator":
+      return {
+        model: settings.modelCurator,
+      };
+    case "translator":
+      return {
+        model: settings.modelTranslator,
+      };
+  }
+}
+
+function assertRoutedProviderIsExecutable(
+  role: GenerationRole,
+  routed: RoutedProviderConfig,
+): void {
+  if (routed.executableInTypeScript) {
+    return;
+  }
+  throw new ProviderError(
+    `${routed.unsupportedReason ?? "TypeScript provider runtime does not support routed provider"} for role ${JSON.stringify(role)}.`,
+  );
+}
+
+function resolveRoutedRoleConfig(
+  defaultConfig: ProviderConfig,
+  overrides: Partial<ProviderConfig>,
+  roleConfig: RoleConfigInput,
+  routed: RoutedProviderConfig,
+): ProviderConfig {
+  return resolveRoleConfig(defaultConfig, overrides, {
+    providerType: routed.providerType,
+    model: routed.model,
+    apiKey: roleConfig.apiKey,
+    baseUrl: roleConfig.baseUrl,
+  });
+}
+
 export function createConfiguredProvider(
   overrides: Partial<ProviderConfig> = {},
   settings: Partial<RoleProviderSettings> = {},
@@ -212,71 +298,78 @@ export function buildRoleProviderBundle(
   overrides: Partial<ProviderConfig> = {},
   opts: ProviderCompositionOpts = {},
 ): RoleProviderBundle {
-  const runtimeSession = createRuntimeSessionProvider(settings, opts.runtimeSession);
   const defaultConfig = resolveProviderConfig({
     ...overrides,
     providerType: overrides.providerType ?? settings.agentProvider,
   });
+  const roleRoutes = Object.fromEntries(
+    ROUTED_GENERATION_ROLES.map((role) => [
+      role,
+      routeRoleProvider(settings, role, opts.routingContext),
+    ]),
+  ) as Record<GenerationRole, RoutedProviderConfig>;
+  for (const role of ROUTED_GENERATION_ROLES) {
+    assertRoutedProviderIsExecutable(role, roleRoutes[role]);
+  }
+
+  const roleConfigs: Record<GenerationRole, ProviderConfig> = {
+    competitor: resolveRoutedRoleConfig(
+      defaultConfig,
+      overrides,
+      roleConfigInputForRole("competitor", settings),
+      roleRoutes.competitor,
+    ),
+    analyst: resolveRoutedRoleConfig(
+      defaultConfig,
+      overrides,
+      roleConfigInputForRole("analyst", settings),
+      roleRoutes.analyst,
+    ),
+    coach: resolveRoutedRoleConfig(
+      defaultConfig,
+      overrides,
+      roleConfigInputForRole("coach", settings),
+      roleRoutes.coach,
+    ),
+    architect: resolveRoutedRoleConfig(
+      defaultConfig,
+      overrides,
+      roleConfigInputForRole("architect", settings),
+      roleRoutes.architect,
+    ),
+    curator: resolveRoutedRoleConfig(
+      defaultConfig,
+      overrides,
+      roleConfigInputForRole("curator", settings),
+      roleRoutes.curator,
+    ),
+    translator: resolveRoutedRoleConfig(
+      defaultConfig,
+      overrides,
+      roleConfigInputForRole("translator", settings),
+      roleRoutes.translator,
+    ),
+  };
+
+  const runtimeSession = createRuntimeSessionProvider(settings, opts.runtimeSession);
   const defaultProvider = createProvider(
     withRuntimeSession(defaultConfig, settings, runtimeSession, "default"),
   );
-
-  const roleConfigs: Record<GenerationRole, ProviderConfig> = {
-    competitor: resolveRoleConfig(defaultConfig, overrides, {
-      providerType: settings.competitorProvider,
-      model: settings.modelCompetitor,
-      apiKey: settings.competitorApiKey,
-      baseUrl: settings.competitorBaseUrl,
-    }),
-    analyst: resolveRoleConfig(defaultConfig, overrides, {
-      providerType: settings.analystProvider,
-      model: settings.modelAnalyst,
-      apiKey: settings.analystApiKey,
-      baseUrl: settings.analystBaseUrl,
-    }),
-    coach: resolveRoleConfig(defaultConfig, overrides, {
-      providerType: settings.coachProvider,
-      model: settings.modelCoach,
-      apiKey: settings.coachApiKey,
-      baseUrl: settings.coachBaseUrl,
-    }),
-    architect: resolveRoleConfig(defaultConfig, overrides, {
-      providerType: settings.architectProvider,
-      model: settings.modelArchitect,
-      apiKey: settings.architectApiKey,
-      baseUrl: settings.architectBaseUrl,
-    }),
-    curator: resolveRoleConfig(defaultConfig, overrides, {
-      model: settings.modelCurator,
-    }),
-  };
-
-  const roleProviders: Partial<Record<GenerationRole, LLMProvider>> = {
-    competitor: createProvider(
-      withRuntimeSession(roleConfigs.competitor, settings, runtimeSession, "competitor"),
-    ),
-    analyst: createProvider(
-      withRuntimeSession(roleConfigs.analyst, settings, runtimeSession, "analyst"),
-    ),
-    coach: createProvider(withRuntimeSession(roleConfigs.coach, settings, runtimeSession, "coach")),
-    architect: createProvider(
-      withRuntimeSession(roleConfigs.architect, settings, runtimeSession, "architect"),
-    ),
-    curator: createProvider(
-      withRuntimeSession(roleConfigs.curator, settings, runtimeSession, "curator"),
-    ),
-  };
+  const roleProviders = Object.fromEntries(
+    ROUTED_GENERATION_ROLES.map((role) => [
+      role,
+      createProvider(withRuntimeSession(roleConfigs[role], settings, runtimeSession, role)),
+    ]),
+  ) as Partial<Record<GenerationRole, LLMProvider>>;
+  const roleModels = Object.fromEntries(
+    ROUTED_GENERATION_ROLES.map((role) => [role, roleConfigs[role].model]),
+  ) as Partial<Record<GenerationRole, string>>;
   const bundle: RoleProviderBundle = {
     defaultProvider,
     defaultConfig,
     roleProviders,
-    roleModels: {
-      competitor: roleConfigs.competitor.model,
-      analyst: roleConfigs.analyst.model,
-      coach: roleConfigs.coach.model,
-      architect: roleConfigs.architect.model,
-      curator: roleConfigs.curator.model,
-    },
+    roleModels,
+    roleRoutes,
     runtimeSession: runtimeSession?.session,
   };
   let closed = false;
@@ -310,8 +403,8 @@ function createRuntimeSessionProvider(
   const resolvedDbPath = resolve(dbPath);
   mkdirSync(dirname(resolvedDbPath), { recursive: true });
   const eventStore = new RuntimeSessionEventStore(resolvedDbPath);
-  const workspace = opts.workspace
-    ?? createLocalWorkspaceEnv({ root: opts.workspaceRoot ?? process.cwd() });
+  const workspace =
+    opts.workspace ?? createLocalWorkspaceEnv({ root: opts.workspaceRoot ?? process.cwd() });
   const session = RuntimeSession.create({
     sessionId: opts.sessionId,
     goal: opts.goal,

--- a/ts/src/providers/role-provider-bundle.ts
+++ b/ts/src/providers/role-provider-bundle.ts
@@ -158,6 +158,19 @@ function withRuntimeSession(
   };
 }
 
+function withRoutedRuntimeModel(
+  config: ProviderConfig,
+  opts: CreateProviderOpts,
+): CreateProviderOpts {
+  if (config.providerType === "claude-cli") {
+    return { ...opts, claudeModel: config.model };
+  }
+  if (config.providerType === "codex") {
+    return { ...opts, codexModel: config.model };
+  }
+  return opts;
+}
+
 interface RoleConfigInput {
   providerType?: string;
   model?: string;
@@ -358,7 +371,12 @@ export function buildRoleProviderBundle(
   const roleProviders = Object.fromEntries(
     ROUTED_GENERATION_ROLES.map((role) => [
       role,
-      createProvider(withRuntimeSession(roleConfigs[role], settings, runtimeSession, role)),
+      createProvider(
+        withRoutedRuntimeModel(
+          roleConfigs[role],
+          withRuntimeSession(roleConfigs[role], settings, runtimeSession, role),
+        ),
+      ),
     ]),
   ) as Partial<Record<GenerationRole, LLMProvider>>;
   const roleModels = Object.fromEntries(

--- a/ts/src/providers/role-routing.ts
+++ b/ts/src/providers/role-routing.ts
@@ -1,0 +1,250 @@
+import { SUPPORTED_PROVIDER_TYPES } from "./supported-provider-types.js";
+
+export const PROVIDER_CLASSES = ["frontier", "mid_tier", "fast", "local", "code_policy"] as const;
+
+export type ProviderClass = (typeof PROVIDER_CLASSES)[number];
+
+export const ROUTED_GENERATION_ROLES = [
+  "competitor",
+  "analyst",
+  "coach",
+  "architect",
+  "curator",
+  "translator",
+] as const;
+
+export type GenerationRole = (typeof ROUTED_GENERATION_ROLES)[number];
+
+export const ROLE_ROUTING_MODES = ["off", "auto"] as const;
+
+export type RoleRoutingMode = (typeof ROLE_ROUTING_MODES)[number];
+
+export const PROVIDER_CLASS_COST_PER_1K_TOKENS: Partial<Record<ProviderClass, number>> = {
+  frontier: 0.015,
+  mid_tier: 0.003,
+  fast: 0.001,
+  local: 0.0,
+};
+
+export const DEFAULT_ROLE_ROUTING_TABLE = {
+  competitor: ["frontier", "local"],
+  analyst: ["mid_tier", "local"],
+  coach: ["mid_tier", "local"],
+  architect: ["frontier"],
+  curator: ["fast"],
+  translator: ["fast", "local"],
+} as const satisfies Record<GenerationRole, readonly ProviderClass[]>;
+
+export const LOCAL_ELIGIBLE_ROLES = [
+  "competitor",
+  "analyst",
+  "coach",
+  "translator",
+] as const satisfies readonly GenerationRole[];
+
+export const EXPLICIT_PROVIDER_CLASS: Record<string, ProviderClass> = {
+  anthropic: "frontier",
+  mlx: "local",
+  openclaw: "frontier",
+  deterministic: "fast",
+  agent_sdk: "frontier",
+  openai: "mid_tier",
+  "openai-compatible": "mid_tier",
+  ollama: "mid_tier",
+  vllm: "mid_tier",
+};
+
+const DEFAULT_ROLE_MODELS: Record<GenerationRole, string> = {
+  competitor: "claude-sonnet-4-5-20250929",
+  analyst: "claude-sonnet-4-5-20250929",
+  coach: "claude-opus-4-6",
+  architect: "claude-opus-4-6",
+  curator: "claude-opus-4-6",
+  translator: "claude-sonnet-4-5-20250929",
+};
+
+export interface RoleRoutingSettings {
+  agentProvider: string;
+  roleRouting?: string;
+  competitorProvider?: string;
+  analystProvider?: string;
+  coachProvider?: string;
+  architectProvider?: string;
+  modelCompetitor?: string;
+  modelAnalyst?: string;
+  modelCoach?: string;
+  modelArchitect?: string;
+  modelCurator?: string;
+  modelTranslator?: string;
+  tierOpusModel?: string;
+  tierSonnetModel?: string;
+  tierHaikuModel?: string;
+  mlxModelPath?: string;
+}
+
+export interface RoleRoutingContext {
+  availableLocalModels?: readonly string[];
+}
+
+export interface RoutedProviderConfig {
+  role: string;
+  providerType: string;
+  providerClass: ProviderClass;
+  model: string;
+  estimatedCostPer1kTokens: number;
+  executableInTypeScript: boolean;
+  unsupportedReason?: string;
+}
+
+export interface RoleRoutingCostEstimate {
+  roles: Partial<Record<GenerationRole, RoutedProviderConfig>>;
+  totalPer1kTokens: number;
+  allFrontierPer1kTokens: number;
+  savingsVsAllFrontier: number;
+}
+
+function clean(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeProvider(providerType: string | undefined): string {
+  return (clean(providerType) ?? "anthropic").toLowerCase();
+}
+
+function roleSpecificProvider(role: string, settings: RoleRoutingSettings): string | undefined {
+  switch (role) {
+    case "competitor":
+      return clean(settings.competitorProvider);
+    case "analyst":
+      return clean(settings.analystProvider);
+    case "coach":
+      return clean(settings.coachProvider);
+    case "architect":
+      return clean(settings.architectProvider);
+    default:
+      return undefined;
+  }
+}
+
+function roleSpecificModel(role: string, settings: RoleRoutingSettings): string {
+  switch (role) {
+    case "competitor":
+      return clean(settings.modelCompetitor) ?? DEFAULT_ROLE_MODELS.competitor;
+    case "analyst":
+      return clean(settings.modelAnalyst) ?? DEFAULT_ROLE_MODELS.analyst;
+    case "coach":
+      return clean(settings.modelCoach) ?? DEFAULT_ROLE_MODELS.coach;
+    case "architect":
+      return clean(settings.modelArchitect) ?? DEFAULT_ROLE_MODELS.architect;
+    case "curator":
+      return clean(settings.modelCurator) ?? DEFAULT_ROLE_MODELS.curator;
+    case "translator":
+      return clean(settings.modelTranslator) ?? DEFAULT_ROLE_MODELS.translator;
+    default:
+      return clean(settings.tierSonnetModel) ?? "claude-sonnet-4-5-20250929";
+  }
+}
+
+function tierModel(providerClass: ProviderClass, settings: RoleRoutingSettings): string {
+  switch (providerClass) {
+    case "frontier":
+      return clean(settings.tierOpusModel) ?? "claude-opus-4-6";
+    case "mid_tier":
+    case "code_policy":
+      return clean(settings.tierSonnetModel) ?? "claude-sonnet-4-5-20250929";
+    case "fast":
+      return clean(settings.tierHaikuModel) ?? "claude-haiku-4-5-20251001";
+    case "local":
+      return clean(settings.mlxModelPath) ?? "local";
+  }
+}
+
+function executableInTypeScript(providerType: string): boolean {
+  return (SUPPORTED_PROVIDER_TYPES as readonly string[]).includes(providerType);
+}
+
+function routedConfig(
+  role: string,
+  providerType: string,
+  providerClass: ProviderClass,
+  model: string,
+): RoutedProviderConfig {
+  const executable = executableInTypeScript(providerType);
+  return {
+    role,
+    providerType,
+    providerClass,
+    model,
+    estimatedCostPer1kTokens: PROVIDER_CLASS_COST_PER_1K_TOKENS[providerClass] ?? 0.003,
+    executableInTypeScript: executable,
+    unsupportedReason: executable
+      ? undefined
+      : "TypeScript provider runtime does not support routed provider",
+  };
+}
+
+export function routeRoleProvider(
+  settings: RoleRoutingSettings,
+  role: string,
+  context: RoleRoutingContext = {},
+): RoutedProviderConfig {
+  const explicitProvider = roleSpecificProvider(role, settings);
+  if (explicitProvider) {
+    const providerType = normalizeProvider(explicitProvider);
+    const providerClass = EXPLICIT_PROVIDER_CLASS[providerType] ?? "frontier";
+    const model = providerClass === "local"
+      ? tierModel("local", settings)
+      : roleSpecificModel(role, settings);
+    return routedConfig(role, providerType, providerClass, model);
+  }
+
+  const providerType = normalizeProvider(settings.agentProvider);
+  const providerClass = EXPLICIT_PROVIDER_CLASS[providerType] ?? "mid_tier";
+
+  if (settings.roleRouting !== "auto") {
+    const model = providerClass === "local"
+      ? tierModel("local", settings)
+      : roleSpecificModel(role, settings);
+    return routedConfig(role, providerType, providerClass, model);
+  }
+
+  const preferences = DEFAULT_ROLE_ROUTING_TABLE[role as GenerationRole] ?? ["mid_tier"];
+  const hasLocal = Boolean(context.availableLocalModels?.length);
+  const localModel = clean(context.availableLocalModels?.[0]) ?? clean(settings.mlxModelPath);
+  if (
+    hasLocal &&
+    localModel &&
+    (LOCAL_ELIGIBLE_ROLES as readonly string[]).includes(role) &&
+    preferences.some((preference) => preference === "local")
+  ) {
+    return routedConfig(role, "mlx", "local", localModel);
+  }
+
+  return routedConfig(role, providerType, preferences[0], tierModel(preferences[0], settings));
+}
+
+export function estimateRoleRoutingCost(
+  settings: RoleRoutingSettings,
+  context: RoleRoutingContext = {},
+): RoleRoutingCostEstimate {
+  const roles: Partial<Record<GenerationRole, RoutedProviderConfig>> = {};
+  let totalPer1kTokens = 0;
+
+  for (const role of ROUTED_GENERATION_ROLES) {
+    const routed = routeRoleProvider(settings, role, context);
+    roles[role] = routed;
+    totalPer1kTokens += routed.estimatedCostPer1kTokens;
+  }
+
+  const allFrontierPer1kTokens =
+    ROUTED_GENERATION_ROLES.length * (PROVIDER_CLASS_COST_PER_1K_TOKENS.frontier ?? 0);
+  const savingsVsAllFrontier = Math.max(0, allFrontierPer1kTokens - totalPer1kTokens);
+
+  return {
+    roles,
+    totalPer1kTokens,
+    allFrontierPer1kTokens,
+    savingsVsAllFrontier,
+  };
+}

--- a/ts/tests/role-routing-contract.test.ts
+++ b/ts/tests/role-routing-contract.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_ROLE_ROUTING_TABLE,
+  EXPLICIT_PROVIDER_CLASS,
+  LOCAL_ELIGIBLE_ROLES,
+  PROVIDER_CLASSES,
+  PROVIDER_CLASS_COST_PER_1K_TOKENS,
+  ROLE_ROUTING_MODES,
+  buildRoleProviderBundle,
+  estimateRoleRoutingCost,
+  routeRoleProvider,
+  type RoleRoutingSettings,
+} from "../src/providers/index.js";
+
+type RoleRoutingContract = {
+  cost_per_1k_tokens: Record<string, number>;
+  default_routing_table: Record<string, string[]>;
+  explicit_provider_classes: Record<string, string>;
+  local_eligible_roles: string[];
+  mode_values: string[];
+  provider_classes: string[];
+};
+
+const CONTRACT = JSON.parse(
+  readFileSync(
+    join(import.meta.dirname, "..", "..", "docs", "role-routing-contract.json"),
+    "utf-8",
+  ),
+) as RoleRoutingContract;
+
+function baseSettings(overrides: Partial<RoleRoutingSettings> = {}): RoleRoutingSettings {
+  return {
+    agentProvider: "deterministic",
+    roleRouting: "auto",
+    modelCompetitor: "competitor-role-model",
+    modelAnalyst: "analyst-role-model",
+    modelCoach: "coach-role-model",
+    modelArchitect: "architect-role-model",
+    modelCurator: "curator-role-model",
+    modelTranslator: "translator-role-model",
+    tierOpusModel: "opus-tier-model",
+    tierSonnetModel: "sonnet-tier-model",
+    tierHaikuModel: "haiku-tier-model",
+    mlxModelPath: "/models/default-local",
+    ...overrides,
+  };
+}
+
+describe("shared role routing contract", () => {
+  it("keeps TypeScript routing constants aligned with the shared contract", () => {
+    expect(PROVIDER_CLASSES).toEqual(CONTRACT.provider_classes);
+    expect(ROLE_ROUTING_MODES).toEqual(CONTRACT.mode_values);
+    expect(DEFAULT_ROLE_ROUTING_TABLE).toEqual(CONTRACT.default_routing_table);
+    expect(LOCAL_ELIGIBLE_ROLES).toEqual(CONTRACT.local_eligible_roles);
+    expect(PROVIDER_CLASS_COST_PER_1K_TOKENS).toEqual(CONTRACT.cost_per_1k_tokens);
+    expect(EXPLICIT_PROVIDER_CLASS).toEqual(CONTRACT.explicit_provider_classes);
+  });
+
+  it("uses the default provider and configured role model when role routing is off", () => {
+    const routed = routeRoleProvider(baseSettings({ roleRouting: "off" }), "competitor");
+
+    expect(routed).toMatchObject({
+      providerType: "deterministic",
+      providerClass: "fast",
+      model: "competitor-role-model",
+      estimatedCostPer1kTokens: 0.001,
+    });
+  });
+
+  it("lets explicit per-role provider overrides win over auto routing", () => {
+    const routed = routeRoleProvider(baseSettings({ competitorProvider: "ollama" }), "competitor");
+
+    expect(routed).toMatchObject({
+      providerType: "ollama",
+      providerClass: "mid_tier",
+      model: "competitor-role-model",
+    });
+    expect(routeRoleProvider(baseSettings({ competitorProvider: "mlx" }), "competitor"))
+      .toMatchObject({
+        providerType: "mlx",
+        providerClass: "local",
+        model: "/models/default-local",
+        executableInTypeScript: false,
+      });
+  });
+
+  it("routes auto mode through Python-compatible tier preferences", () => {
+    expect(routeRoleProvider(baseSettings(), "competitor")).toMatchObject({
+      providerClass: "frontier",
+      model: "opus-tier-model",
+    });
+    expect(routeRoleProvider(baseSettings(), "analyst")).toMatchObject({
+      providerClass: "mid_tier",
+      model: "sonnet-tier-model",
+    });
+    expect(routeRoleProvider(baseSettings(), "translator")).toMatchObject({
+      providerClass: "fast",
+      model: "haiku-tier-model",
+    });
+    expect(routeRoleProvider(baseSettings(), "curator")).toMatchObject({
+      providerClass: "fast",
+      model: "haiku-tier-model",
+    });
+  });
+
+  it("prefers available local artifacts for eligible roles and leaves frontier roles alone", () => {
+    const context = { availableLocalModels: ["/models/distilled-grid-ctf"] };
+
+    expect(routeRoleProvider(baseSettings(), "analyst", context)).toMatchObject({
+      providerType: "mlx",
+      providerClass: "local",
+      model: "/models/distilled-grid-ctf",
+      estimatedCostPer1kTokens: 0.0,
+      executableInTypeScript: false,
+    });
+    expect(routeRoleProvider(baseSettings(), "architect", context)).toMatchObject({
+      providerType: "deterministic",
+      providerClass: "frontier",
+      model: "opus-tier-model",
+      executableInTypeScript: true,
+    });
+  });
+
+  it("keeps Python's mid-tier fallback for unknown role names", () => {
+    const routed = routeRoleProvider(baseSettings(), "unknown_role");
+
+    expect(routed).toMatchObject({
+      providerType: "deterministic",
+      providerClass: "mid_tier",
+      model: "sonnet-tier-model",
+    });
+  });
+
+  it("estimates one generation cycle with the same role set as Python", () => {
+    const estimate = estimateRoleRoutingCost(baseSettings());
+
+    expect(Object.keys(estimate.roles).sort()).toEqual(
+      Object.keys(CONTRACT.default_routing_table).sort(),
+    );
+    expect(estimate.totalPer1kTokens).toBeGreaterThan(0);
+    expect(estimate.savingsVsAllFrontier).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("role-routed provider bundles", () => {
+  it("applies auto role routing to generated providers and models", () => {
+    const bundle = buildRoleProviderBundle(baseSettings());
+
+    expect(bundle.roleModels.competitor).toBe("opus-tier-model");
+    expect(bundle.roleModels.analyst).toBe("sonnet-tier-model");
+    expect(bundle.roleModels.translator).toBe("haiku-tier-model");
+    expect(bundle.roleProviders.translator?.name).toBe("deterministic");
+    expect(bundle.roleRoutes?.competitor).toMatchObject({ providerClass: "frontier" });
+    bundle.close?.();
+  });
+
+  it("keeps explicit role providers as the highest-priority route", () => {
+    const bundle = buildRoleProviderBundle(baseSettings({ competitorProvider: "deterministic" }));
+
+    expect(bundle.roleModels.competitor).toBe("competitor-role-model");
+    expect(bundle.roleRoutes?.competitor).toMatchObject({
+      providerType: "deterministic",
+      providerClass: "fast",
+    });
+    bundle.close?.();
+  });
+
+  it("surfaces Python-local routes explicitly when TypeScript cannot execute them", () => {
+    expect(() =>
+      buildRoleProviderBundle(
+        baseSettings(),
+        {},
+        { routingContext: { availableLocalModels: ["/models/distilled-grid-ctf"] } },
+      ),
+    ).toThrow("TypeScript provider runtime does not support routed provider");
+  });
+});

--- a/ts/tests/role-routing-contract.test.ts
+++ b/ts/tests/role-routing-contract.test.ts
@@ -12,7 +12,7 @@ import {
   buildRoleProviderBundle,
   estimateRoleRoutingCost,
   routeRoleProvider,
-  type RoleRoutingSettings,
+  type RoleProviderSettings,
 } from "../src/providers/index.js";
 
 type RoleRoutingContract = {
@@ -31,7 +31,7 @@ const CONTRACT = JSON.parse(
   ),
 ) as RoleRoutingContract;
 
-function baseSettings(overrides: Partial<RoleRoutingSettings> = {}): RoleRoutingSettings {
+function baseSettings(overrides: Partial<RoleProviderSettings> = {}): RoleProviderSettings {
   return {
     agentProvider: "deterministic",
     roleRouting: "auto",
@@ -166,6 +166,26 @@ describe("role-routed provider bundles", () => {
       providerClass: "fast",
     });
     bundle.close?.();
+  });
+
+  it("uses routed tier models as CLI runtime defaults for role providers", () => {
+    const claudeBundle = buildRoleProviderBundle(baseSettings({
+      agentProvider: "claude-cli",
+      claudeModel: "sonnet-cli",
+    }));
+    expect(claudeBundle.defaultProvider.defaultModel()).toBe("sonnet-cli");
+    expect(claudeBundle.roleModels.competitor).toBe("opus-tier-model");
+    expect(claudeBundle.roleProviders.competitor?.defaultModel()).toBe("opus-tier-model");
+    claudeBundle.close?.();
+
+    const codexBundle = buildRoleProviderBundle(baseSettings({
+      agentProvider: "codex",
+      codexModel: "codex-global",
+    }));
+    expect(codexBundle.defaultProvider.defaultModel()).toBe("codex-global");
+    expect(codexBundle.roleModels.analyst).toBe("sonnet-tier-model");
+    expect(codexBundle.roleProviders.analyst?.defaultModel()).toBe("sonnet-tier-model");
+    codexBundle.close?.();
   });
 
   it("surfaces Python-local routes explicitly when TypeScript cannot execute them", () => {


### PR DESCRIPTION
## Summary
- add a shared role routing contract for Python/TypeScript provider classes, role preferences, and tier model fields
- implement TypeScript `roleRouting` / `routeRoleProvider` parity with Python `role_routing=auto`, including explicit provider precedence and local-route unsupported capability reporting
- thread routed role configs through the TypeScript role provider bundle while preserving runtime-session provider recording

## Tests
- `/Users/jayscambler/Repositories/autocontext/autocontext/autocontext/.venv/bin/python -m pytest autocontext/tests/test_role_routing_contract.py autocontext/tests/test_app_settings_contract.py`
- `cd ts && npm test -- role-routing-contract.test.ts app-settings-contract.test.ts role-provider-bundle-workflow.test.ts`
- `cd ts && npm test -- provider-routing.test.ts runtime-session-provider-bundle.test.ts run-manager-provider-session.test.ts subscription-cli-runtime-provider.test.ts pi-runtime.test.ts`
- `cd ts && npm run lint`
- `cd autocontext && .venv/bin/python -m ruff check tests/test_role_routing_contract.py src/autocontext/py.typed`
- `cd autocontext && .venv/bin/python -m mypy src tests/test_role_routing_contract.py`
