### PR TITLE
Fix Python optional integration dependencies

### DIFF
--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -12,6 +12,7 @@ pip install autocontext
 
 The current PyPI release line is `autocontext==0.8.0`.
 The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
+Optional integrations use extras: `autocontext[browser]` for Chrome CDP capture and `autocontext[primeintellect]` for PrimeIntellect sandboxes.
 
 ## Working Directory
 
@@ -411,7 +412,7 @@ Common settings:
 - `AUTOCONTEXT_BROWSER_ALLOW_DOWNLOADS` and `AUTOCONTEXT_BROWSER_DOWNLOADS_ROOT`
 
 Browser exploration defaults to a secure disabled posture and uses the shared contract described in [../docs/browser-exploration-contract.md](../docs/browser-exploration-contract.md).
-The Python package includes a thin Chrome CDP backend that attaches to an existing debugger endpoint, enforces the browser allowlist, and stores browser evidence under run-local roots.
+Install `autocontext[browser]` before using the thin Chrome CDP backend; it attaches to an existing debugger endpoint, enforces the browser allowlist, and stores browser evidence under run-local roots.
 
 `AUTOCONTEXT_HARNESS_PROFILE=lean` resolves a Pi-shaped runtime profile: prompt context is capped by `AUTOCONTEXT_LEAN_CONTEXT_BUDGET_TOKENS`, hidden/implicit context defaults to zero, and generated tool context is replaced by the lean allowlist before agent execution. `AUTOCONTEXT_PI_RPC_PERSISTENT=true` opts Pi RPC into a long-lived subprocess; one-shot Pi RPC remains the default.
 

--- a/autocontext/docs/sandbox.md
+++ b/autocontext/docs/sandbox.md
@@ -17,7 +17,7 @@ Use the current modes this way:
 
 - Use `monty` when you want interpreter-level containment for Python evaluation with low operational overhead.
 - Use `local` for trusted local development and fast iteration.
-- Use `primeintellect` or `ssh` when you want execution off the current host.
+- Use `primeintellect` or `ssh` when you want execution off the current host; PrimeIntellect requires `pip install 'autocontext[primeintellect]'`.
 - Use Gondolin only after the adapter is wired for VM lifecycle, mounted artifacts, secret injection, and network/egress policy.
 
 The public OSS contract for a future Gondolin adapter is intentionally narrow:

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -24,18 +24,17 @@ classifiers = [
 dependencies = [
   "anthropic>=0.66.0",
   "fastapi>=0.116.1",
-  "httpx>=0.28.1",
-  "prime-sandboxes>=0.2.14",
   "pydantic>=2.11.0",
   "python-ulid>=3.0.0",
   "pyyaml>=6.0.2",
   "rich>=13.9.4",
   "typer>=0.16.0",
   "uvicorn>=0.35.0",
-  "websockets>=16.0",
 ]
 
 [project.optional-dependencies]
+browser = ["httpx>=0.28.1", "websockets>=16.0"]
+primeintellect = ["prime-sandboxes>=0.2.14"]
 mcp = ["mcp>=1.0.0"]
 agent-sdk = ["claude-agent-sdk>=0.1.0"]
 monty = ["pydantic-monty>=0.0.7"]
@@ -43,17 +42,20 @@ mlx = ["mlx>=0.30.0", "rustbpe>=0.1.0", "tiktoken>=0.11.0", "safetensors>=0.4.0"
 mlxlm = ["mlx-lm>=0.20.0"]
 cuda = ["torch>=2.0.0"]
 openai = ["openai>=1.0.0"]
-all = ["autocontext[mcp,agent-sdk,monty,openai]"]
+all = ["autocontext[mcp,agent-sdk,monty,openai,browser,primeintellect]"]
 
 [dependency-groups]
 dev = [
+  "httpx>=0.28.1",
   "hypothesis>=6.151.12",
   "mypy>=1.16.0",
   "openai>=1.0.0,<2.0",
+  "prime-sandboxes>=0.2.14",
   "pytest>=8.4.0",
   "pytest-asyncio>=1.3.0",
   "pytest-cov>=6.0.0",
   "ruff>=0.12.0",
+  "websockets>=16.0",
 ]
 
 [project.scripts]

--- a/autocontext/src/autocontext/__init__.py
+++ b/autocontext/src/autocontext/__init__.py
@@ -1,8 +1,19 @@
 """autocontext control plane package."""
 
+# pyright: reportUnsupportedDunderAll=false
+
+from typing import Any
+
 from autocontext.extensions import ExtensionAPI, HookBus, HookEvents, HookResult
-from autocontext.sdk import AutoContext
 
 __all__ = ["AutoContext", "ExtensionAPI", "HookBus", "HookEvents", "HookResult", "__version__"]
 
 __version__ = "0.8.0"
+
+
+def __getattr__(name: str) -> Any:
+    if name == "AutoContext":
+        from autocontext.sdk import AutoContext
+
+        return AutoContext
+    raise AttributeError(name)

--- a/autocontext/src/autocontext/execution/executors/__init__.py
+++ b/autocontext/src/autocontext/execution/executors/__init__.py
@@ -1,3 +1,9 @@
+# pyright: reportUnsupportedDunderAll=false
+
+from __future__ import annotations
+
+from typing import Any
+
 from .base import ExecutionEngine
 from .gondolin_contract import (
     GondolinBackend,
@@ -8,7 +14,6 @@ from .gondolin_contract import (
 )
 from .local import LocalExecutor
 from .monty import MontyExecutor
-from .primeintellect import PrimeIntellectExecutor
 
 __all__ = [
     "ExecutionEngine",
@@ -21,3 +26,11 @@ __all__ = [
     "MontyExecutor",
     "PrimeIntellectExecutor",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "PrimeIntellectExecutor":
+        from .primeintellect import PrimeIntellectExecutor
+
+        return PrimeIntellectExecutor
+    raise AttributeError(name)

--- a/autocontext/src/autocontext/integrations/browser/__init__.py
+++ b/autocontext/src/autocontext/integrations/browser/__init__.py
@@ -1,75 +1,50 @@
 """Browser exploration contract, settings, and policy helpers."""
 
-from autocontext.integrations.browser.chrome_cdp import ChromeCdpSession, ChromeCdpTransport
-from autocontext.integrations.browser.chrome_cdp_discovery import (
-    ChromeCdpDiscoveryError,
-    ChromeCdpTarget,
-    ChromeCdpTargetDiscovery,
-    ChromeCdpTargetDiscoveryPort,
-    select_chrome_cdp_target,
-)
-from autocontext.integrations.browser.chrome_cdp_runtime import ChromeCdpRuntime
-from autocontext.integrations.browser.chrome_cdp_transport import (
-    ChromeCdpTransportError,
-    ChromeCdpWebSocketTransport,
-)
-from autocontext.integrations.browser.context_capture import (
-    CapturedBrowserContext,
-    capture_browser_context,
-    render_captured_browser_context,
-)
-from autocontext.integrations.browser.evidence import BrowserArtifactPaths, BrowserEvidenceStore
-from autocontext.integrations.browser.factory import (
-    ConfiguredBrowserRuntime,
-    browser_runtime_from_settings,
-)
-from autocontext.integrations.browser.policy import (
-    BrowserPolicyDecision,
-    build_default_browser_session_config,
-    evaluate_browser_action_policy,
-    normalize_browser_allowed_domains,
-    resolve_browser_session_config,
-)
-from autocontext.integrations.browser.validate import (
-    validate_browser_action,
-    validate_browser_action_dict,
-    validate_browser_audit_event,
-    validate_browser_audit_event_dict,
-    validate_browser_session_config,
-    validate_browser_session_config_dict,
-    validate_browser_snapshot,
-    validate_browser_snapshot_dict,
-)
+# pyright: reportUnsupportedDunderAll=false
 
-__all__ = [
-    "BrowserArtifactPaths",
-    "BrowserEvidenceStore",
-    "ConfiguredBrowserRuntime",
-    "ChromeCdpDiscoveryError",
-    "ChromeCdpSession",
-    "ChromeCdpTransport",
-    "ChromeCdpRuntime",
-    "ChromeCdpTarget",
-    "ChromeCdpTargetDiscovery",
-    "ChromeCdpTargetDiscoveryPort",
-    "ChromeCdpTransportError",
-    "ChromeCdpWebSocketTransport",
-    "CapturedBrowserContext",
-    "BrowserPolicyDecision",
-    "browser_runtime_from_settings",
-    "build_default_browser_session_config",
-    "capture_browser_context",
-    "evaluate_browser_action_policy",
-    "normalize_browser_allowed_domains",
-    "render_captured_browser_context",
-    "resolve_browser_session_config",
-    "select_chrome_cdp_target",
-    "validate_browser_action",
-    "validate_browser_action_dict",
-    "validate_browser_audit_event",
-    "validate_browser_audit_event_dict",
-    "validate_browser_session_config",
-    "validate_browser_session_config_dict",
-    "validate_browser_snapshot",
-    "validate_browser_snapshot_dict",
-]
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_EXPORTS = {
+    "BrowserArtifactPaths": "autocontext.integrations.browser.evidence",
+    "BrowserEvidenceStore": "autocontext.integrations.browser.evidence",
+    "ConfiguredBrowserRuntime": "autocontext.integrations.browser.factory",
+    "ChromeCdpDiscoveryError": "autocontext.integrations.browser.chrome_cdp_discovery",
+    "ChromeCdpSession": "autocontext.integrations.browser.chrome_cdp",
+    "ChromeCdpTransport": "autocontext.integrations.browser.chrome_cdp",
+    "ChromeCdpRuntime": "autocontext.integrations.browser.chrome_cdp_runtime",
+    "ChromeCdpTarget": "autocontext.integrations.browser.chrome_cdp_discovery",
+    "ChromeCdpTargetDiscovery": "autocontext.integrations.browser.chrome_cdp_discovery",
+    "ChromeCdpTargetDiscoveryPort": "autocontext.integrations.browser.chrome_cdp_discovery",
+    "ChromeCdpTransportError": "autocontext.integrations.browser.chrome_cdp_transport",
+    "ChromeCdpWebSocketTransport": "autocontext.integrations.browser.chrome_cdp_transport",
+    "CapturedBrowserContext": "autocontext.integrations.browser.context_capture",
+    "BrowserPolicyDecision": "autocontext.integrations.browser.policy",
+    "browser_runtime_from_settings": "autocontext.integrations.browser.factory",
+    "build_default_browser_session_config": "autocontext.integrations.browser.policy",
+    "capture_browser_context": "autocontext.integrations.browser.context_capture",
+    "evaluate_browser_action_policy": "autocontext.integrations.browser.policy",
+    "normalize_browser_allowed_domains": "autocontext.integrations.browser.policy",
+    "render_captured_browser_context": "autocontext.integrations.browser.context_capture",
+    "resolve_browser_session_config": "autocontext.integrations.browser.policy",
+    "select_chrome_cdp_target": "autocontext.integrations.browser.chrome_cdp_discovery",
+    "validate_browser_action": "autocontext.integrations.browser.validate",
+    "validate_browser_action_dict": "autocontext.integrations.browser.validate",
+    "validate_browser_audit_event": "autocontext.integrations.browser.validate",
+    "validate_browser_audit_event_dict": "autocontext.integrations.browser.validate",
+    "validate_browser_session_config": "autocontext.integrations.browser.validate",
+    "validate_browser_session_config_dict": "autocontext.integrations.browser.validate",
+    "validate_browser_snapshot": "autocontext.integrations.browser.validate",
+    "validate_browser_snapshot_dict": "autocontext.integrations.browser.validate",
+}
+
+__all__ = sorted(_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(name)
+    return getattr(import_module(module_name), name)

--- a/autocontext/src/autocontext/integrations/browser/chrome_cdp_discovery.py
+++ b/autocontext/src/autocontext/integrations/browser/chrome_cdp_discovery.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Protocol, TypeAlias, runtime_checkable
-
-import httpx
+from importlib import import_module
+from typing import Any, Protocol, TypeAlias, cast, runtime_checkable
 
 from autocontext.integrations.browser.contract.models import BrowserSessionConfig
 from autocontext.integrations.browser.policy import evaluate_browser_action_policy
@@ -102,7 +101,15 @@ def select_chrome_cdp_target(
 
 
 async def _fetch_json(url: str) -> object:
-    async with httpx.AsyncClient() as client:
+    try:
+        httpx = import_module("httpx")
+    except ImportError as exc:
+        raise ChromeCdpDiscoveryError(
+            "Chrome CDP target discovery requires the optional httpx dependency. "
+            "Install it with `pip install 'autocontext[browser]'`."
+        ) from exc
+    async_client = cast(Any, httpx).AsyncClient
+    async with async_client() as client:
         response = await client.get(url)
     response.raise_for_status()
     return response.json()

--- a/autocontext/src/autocontext/integrations/browser/chrome_cdp_transport.py
+++ b/autocontext/src/autocontext/integrations/browser/chrome_cdp_transport.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+from importlib import import_module
 from typing import Any, cast
-
-from websockets.asyncio.client import connect
 
 
 class ChromeCdpTransportError(RuntimeError):
@@ -40,7 +39,7 @@ class ChromeCdpWebSocketTransport:
             if self._websocket is not None:
                 return
             self._closing = False
-            self._websocket = await connect(
+            self._websocket = await _connect_websocket(
                 self.websocket_url,
                 open_timeout=self.connect_timeout,
                 max_size=None,
@@ -130,6 +129,18 @@ class ChromeCdpWebSocketTransport:
         except json.JSONDecodeError:
             return None
         return None
+
+
+async def _connect_websocket(websocket_url: str, *, open_timeout: float, max_size: int | None) -> Any:
+    try:
+        websockets_client = import_module("websockets.asyncio.client")
+    except ImportError as exc:
+        raise ChromeCdpTransportError(
+            "Chrome CDP websocket transport requires the optional websockets dependency. "
+            "Install it with `pip install 'autocontext[browser]'`."
+        ) from exc
+    connect = cast(Any, websockets_client).connect
+    return await connect(websocket_url, open_timeout=open_timeout, max_size=max_size)
 
 
 def _error_message(error: dict[str, Any]) -> str:

--- a/autocontext/src/autocontext/integrations/primeintellect/__init__.py
+++ b/autocontext/src/autocontext/integrations/primeintellect/__init__.py
@@ -1,3 +1,15 @@
-from .client import PrimeIntellectClient
+# pyright: reportUnsupportedDunderAll=false
+
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = ["PrimeIntellectClient"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "PrimeIntellectClient":
+        from .client import PrimeIntellectClient
+
+        return PrimeIntellectClient
+    raise AttributeError(name)

--- a/autocontext/src/autocontext/integrations/primeintellect/client.py
+++ b/autocontext/src/autocontext/integrations/primeintellect/client.py
@@ -14,6 +14,10 @@ AsyncSandboxClient: Any | None = None
 CreateSandboxRequest: Any | None = None
 
 
+class MissingPrimeIntellectExtraError(RuntimeError):
+    """Raised when the PrimeIntellect optional extra is not installed."""
+
+
 class _CreateSandboxRequestFallback:
     def __init__(self, **kwargs: Any) -> None:
         self.__dict__.update(kwargs)
@@ -26,7 +30,7 @@ def _prime_sandboxes_sdk() -> tuple[Any, Any]:
         from prime_sandboxes import AsyncSandboxClient as client_cls
         from prime_sandboxes import CreateSandboxRequest as request_cls
     except ImportError as exc:
-        raise RuntimeError(
+        raise MissingPrimeIntellectExtraError(
             "PrimeIntellect execution requires the optional prime-sandboxes SDK. "
             "Install it with `pip install 'autocontext[primeintellect]'`."
         ) from exc
@@ -81,6 +85,8 @@ class PrimeIntellectClient:
                         network_access=network_access,
                     )
                 )
+            except MissingPrimeIntellectExtraError:
+                raise
             except Exception:
                 logger.debug("integrations.primeintellect.client: caught Exception", exc_info=True)
                 attempt += 1

--- a/autocontext/src/autocontext/integrations/primeintellect/client.py
+++ b/autocontext/src/autocontext/integrations/primeintellect/client.py
@@ -8,9 +8,29 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
-from prime_sandboxes import AsyncSandboxClient, CreateSandboxRequest
-
 logger = logging.getLogger(__name__)
+
+AsyncSandboxClient: Any | None = None
+CreateSandboxRequest: Any | None = None
+
+
+class _CreateSandboxRequestFallback:
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
+
+def _prime_sandboxes_sdk() -> tuple[Any, Any]:
+    if AsyncSandboxClient is not None:
+        return AsyncSandboxClient, CreateSandboxRequest or _CreateSandboxRequestFallback
+    try:
+        from prime_sandboxes import AsyncSandboxClient as client_cls
+        from prime_sandboxes import CreateSandboxRequest as request_cls
+    except ImportError as exc:
+        raise RuntimeError(
+            "PrimeIntellect execution requires the optional prime-sandboxes SDK. "
+            "Install it with `pip install 'autocontext[primeintellect]'`."
+        ) from exc
+    return client_cls, request_cls
 
 
 @dataclass(slots=True)
@@ -71,7 +91,8 @@ class PrimeIntellectClient:
                 time.sleep(backoff_seconds * attempt)
 
     async def _probe(self) -> None:
-        async with AsyncSandboxClient(api_key=self.api_key) as client:
+        sandbox_client_cls, _ = _prime_sandboxes_sdk()
+        async with sandbox_client_cls(api_key=self.api_key) as client:
             await client.list(per_page=1, exclude_terminated=True)
 
     async def _execute_strategy_once(
@@ -84,9 +105,10 @@ class PrimeIntellectClient:
         max_memory_mb: int,
         network_access: bool,
     ) -> dict[str, Any]:
+        sandbox_client_cls, create_sandbox_request = _prime_sandboxes_sdk()
         sandbox_id: str | None = None
-        async with AsyncSandboxClient(api_key=self.api_key) as client:
-            request = CreateSandboxRequest(
+        async with sandbox_client_cls(api_key=self.api_key) as client:
+            request = create_sandbox_request(
                 name=f"autocontext-{scenario_name}-{seed}",
                 docker_image=self.docker_image,
                 cpu_cores=self.cpu_cores,

--- a/autocontext/src/autocontext/loop/generation_runner.py
+++ b/autocontext/src/autocontext/loop/generation_runner.py
@@ -40,13 +40,12 @@ from autocontext.analytics.taxonomy import FacetTaxonomy
 from autocontext.analytics.trace_reporter import ReportStore, TraceReporter
 from autocontext.config import AppSettings
 from autocontext.execution import ExecutionSupervisor
-from autocontext.execution.executors import LocalExecutor, PrimeIntellectExecutor
+from autocontext.execution.executors import LocalExecutor
 from autocontext.extensions import HookBus
 from autocontext.harness.meta_optimizer import MetaOptimizer
 from autocontext.harness.pipeline.gate import BackpressureGate
 from autocontext.harness.pipeline.trend_gate import TrendAwareGate
 from autocontext.harness.scoring.backends import get_backend
-from autocontext.integrations.primeintellect import PrimeIntellectClient
 from autocontext.knowledge.mutation_log import MutationEntry
 from autocontext.knowledge.normalized_metrics import generate_run_progress_report
 from autocontext.knowledge.report import generate_session_report
@@ -113,8 +112,11 @@ class GenerationRunner:
             )
         else:
             self.gate = BackpressureGate(min_delta=settings.backpressure_min_delta)
-        self.remote: PrimeIntellectClient | None = None
+        self.remote: Any | None = None
         if settings.executor_mode == "primeintellect":
+            from autocontext.execution.executors.primeintellect import PrimeIntellectExecutor
+            from autocontext.integrations.primeintellect.client import PrimeIntellectClient
+
             if not settings.primeintellect_api_key:
                 raise ValueError("AUTOCONTEXT_PRIMEINTELLECT_API_KEY is required for primeintellect executor mode")
             self.remote = PrimeIntellectClient(
@@ -1188,7 +1190,7 @@ class GenerationRunner:
 
                     warm_fn = None
                     if self.settings.executor_mode == "primeintellect" and self.remote is not None:
-                        def _warm(ctx_arg: object, _gen: int = generation) -> dict:
+                        def _warm(ctx_arg: object, _gen: int = generation) -> Any:
                             assert self.remote is not None
                             return self.remote.warm_provision(
                                 environment_name=f"{scenario_name}-gen-{_gen}",

--- a/autocontext/tests/test_optional_integration_dependencies.py
+++ b/autocontext/tests/test_optional_integration_dependencies.py
@@ -78,6 +78,30 @@ assert 'autocontext[primeintellect]' in result['error']
     )
 
 
+def test_primeintellect_execute_strategy_preserves_missing_extra_guidance() -> None:
+    _run_python_with_blocked_imports(
+        ["prime_sandboxes"],
+        """
+from autocontext.integrations.primeintellect.client import PrimeIntellectClient
+
+try:
+    PrimeIntellectClient(api_key='test-key').execute_strategy(
+        scenario_name='grid_ctf',
+        strategy={'aggression': 0.6, 'defense': 0.4, 'path_bias': 0.5},
+        seed=123,
+        timeout_seconds=10.0,
+        max_memory_mb=512,
+        network_access=False,
+        max_retries=0,
+    )
+except RuntimeError as exc:
+    assert 'autocontext[primeintellect]' in str(exc)
+else:
+    raise AssertionError('missing prime-sandboxes was swallowed by fallback')
+""",
+    )
+
+
 def test_browser_feature_reports_missing_extra() -> None:
     _run_python_with_blocked_imports(
         ["httpx", "websockets"],

--- a/autocontext/tests/test_optional_integration_dependencies.py
+++ b/autocontext/tests/test_optional_integration_dependencies.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PACKAGE_ROOT / "src"
+
+
+def _run_python_with_blocked_imports(blocked: list[str], script: str) -> None:
+    blocker = "\n".join(
+        [
+            "import importlib.abc",
+            "import sys",
+            f"BLOCKED = {blocked!r}",
+            "class _Blocker(importlib.abc.MetaPathFinder):",
+            "    def find_spec(self, fullname, path=None, target=None):",
+            "        if any(fullname == name or fullname.startswith(name + '.') for name in BLOCKED):",
+            "            raise ModuleNotFoundError(f'No module named {fullname!r}', name=fullname)",
+            "        return None",
+            "for name in list(sys.modules):",
+            "    if any(name == blocked or name.startswith(blocked + '.') for blocked in BLOCKED):",
+            "        sys.modules.pop(name, None)",
+            "sys.meta_path.insert(0, _Blocker())",
+        ]
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{SRC_ROOT}{os.pathsep}{env.get('PYTHONPATH', '')}".rstrip(os.pathsep)
+    result = subprocess.run(
+        [sys.executable, "-c", blocker + "\n" + script],
+        cwd=PACKAGE_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_core_runner_import_does_not_require_primeintellect_sdk() -> None:
+    _run_python_with_blocked_imports(
+        ["prime_sandboxes"],
+        """
+import importlib
+for module_name in [
+    'autocontext',
+    'autocontext.execution.executors',
+    'autocontext.loop.generation_runner',
+    'autocontext.integrations.primeintellect',
+]:
+    importlib.import_module(module_name)
+""",
+    )
+
+
+def test_browser_facade_import_does_not_require_cdp_dependencies() -> None:
+    _run_python_with_blocked_imports(
+        ["httpx", "websockets"],
+        """
+import importlib
+importlib.import_module('autocontext.integrations.browser')
+""",
+    )
+
+
+def test_primeintellect_feature_reports_missing_extra() -> None:
+    _run_python_with_blocked_imports(
+        ["prime_sandboxes"],
+        """
+from autocontext.integrations.primeintellect.client import PrimeIntellectClient
+
+result = PrimeIntellectClient(api_key='test-key').warm_provision('smoke')
+assert result['status'] == 'failed'
+assert 'autocontext[primeintellect]' in result['error']
+""",
+    )
+
+
+def test_browser_feature_reports_missing_extra() -> None:
+    _run_python_with_blocked_imports(
+        ["httpx", "websockets"],
+        """
+import asyncio
+from autocontext.integrations.browser.chrome_cdp_discovery import ChromeCdpDiscoveryError, ChromeCdpTargetDiscovery
+from autocontext.integrations.browser.chrome_cdp_transport import ChromeCdpTransportError, ChromeCdpWebSocketTransport
+
+async def main():
+    try:
+        await ChromeCdpTargetDiscovery('http://127.0.0.1:9222').list_targets()
+    except ChromeCdpDiscoveryError as exc:
+        assert 'autocontext[browser]' in str(exc)
+    else:
+        raise AssertionError('missing httpx did not fail with install guidance')
+
+    try:
+        await ChromeCdpWebSocketTransport('ws://127.0.0.1:9222/devtools/page/1').connect()
+    except ChromeCdpTransportError as exc:
+        assert 'autocontext[browser]' in str(exc)
+    else:
+        raise AssertionError('missing websockets did not fail with install guidance')
+
+asyncio.run(main())
+""",
+    )

--- a/autocontext/uv.lock
+++ b/autocontext/uv.lock
@@ -80,15 +80,12 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "fastapi" },
-    { name = "httpx" },
-    { name = "prime-sandboxes" },
     { name = "pydantic" },
     { name = "python-ulid" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "typer" },
     { name = "uvicorn" },
-    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -97,9 +94,16 @@ agent-sdk = [
 ]
 all = [
     { name = "claude-agent-sdk" },
+    { name = "httpx" },
     { name = "mcp" },
     { name = "openai" },
+    { name = "prime-sandboxes" },
     { name = "pydantic-monty" },
+    { name = "websockets" },
+]
+browser = [
+    { name = "httpx" },
+    { name = "websockets" },
 ]
 cuda = [
     { name = "torch" },
@@ -123,31 +127,37 @@ monty = [
 openai = [
     { name = "openai" },
 ]
+primeintellect = [
+    { name = "prime-sandboxes" },
+]
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "hypothesis" },
     { name = "mypy" },
     { name = "openai" },
+    { name = "prime-sandboxes" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "websockets" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.66.0" },
-    { name = "autocontext", extras = ["mcp", "agent-sdk", "monty", "openai"], marker = "extra == 'all'" },
+    { name = "autocontext", extras = ["mcp", "agent-sdk", "monty", "openai", "browser", "primeintellect"], marker = "extra == 'all'" },
     { name = "claude-agent-sdk", marker = "extra == 'agent-sdk'", specifier = ">=0.1.0" },
     { name = "fastapi", specifier = ">=0.116.1" },
-    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx", marker = "extra == 'browser'", specifier = ">=0.28.1" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "mlx", marker = "extra == 'mlx'", specifier = ">=0.30.0" },
     { name = "mlx-lm", marker = "extra == 'mlxlm'", specifier = ">=0.20.0" },
     { name = "numpy", marker = "extra == 'mlx'", specifier = ">=1.24.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
-    { name = "prime-sandboxes", specifier = ">=0.2.14" },
+    { name = "prime-sandboxes", marker = "extra == 'primeintellect'", specifier = ">=0.2.14" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pydantic-monty", marker = "extra == 'monty'", specifier = ">=0.0.7" },
     { name = "python-ulid", specifier = ">=3.0.0" },
@@ -159,19 +169,22 @@ requires-dist = [
     { name = "torch", marker = "extra == 'cuda'", specifier = ">=2.0.0" },
     { name = "typer", specifier = ">=0.16.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },
-    { name = "websockets", specifier = ">=16.0" },
+    { name = "websockets", marker = "extra == 'browser'", specifier = ">=16.0" },
 ]
-provides-extras = ["mcp", "agent-sdk", "monty", "mlx", "mlxlm", "cuda", "openai", "all"]
+provides-extras = ["browser", "primeintellect", "mcp", "agent-sdk", "monty", "mlx", "mlxlm", "cuda", "openai", "all"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "hypothesis", specifier = ">=6.151.12" },
     { name = "mypy", specifier = ">=1.16.0" },
     { name = "openai", specifier = ">=1.0.0,<2.0" },
+    { name = "prime-sandboxes", specifier = ">=0.2.14" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.12.0" },
+    { name = "websockets", specifier = ">=16.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- move Python `prime-sandboxes`, `httpx`, and `websockets` from base install into `primeintellect` / `browser` extras
- lazy-load PrimeIntellect and Chrome CDP dependencies at feature-use boundaries with install guidance
- add subprocess smoke tests that block optional modules and prove core/facade imports stay clean
- document the new optional extras

## Tests

- `autocontext/.venv/bin/python -m pytest autocontext/tests/test_optional_integration_dependencies.py autocontext/tests/test_primeintellect_client.py autocontext/tests/test_browser_discovery.py autocontext/tests/test_browser_transport.py autocontext/tests/test_browser_settings.py autocontext/tests/test_browser_context_capture.py -q`
- `cd autocontext && .venv/bin/python -m ruff check src tests`
- `cd autocontext && .venv/bin/python -m mypy src`
- `cd autocontext && UV_EXCLUDE_NEWER=2026-04-10T14:55:41Z uv lock --check`
- `autocontext/.venv/bin/python -m pytest autocontext/tests -m "not live" -q` (passed; first 300s attempt timed out at 82%, rerun with 600s completed)

## Notes

- Kept optional integration deps in the dev dependency group so CI's existing optional integration tests still run under `uv sync --locked --group dev`.
- Preserved unrelated local `.claude/` settings in stash `cleanup: preserve local Claude settings before AC-818`.
