### PR TITLE
feat(training): add experimental OPD pressure modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- AC-794 OPD training adds an experimental `--opd-pressure-mode` flag (`full_kl`, `sample_positive`, `sample_positive_reverse_negative`) with Python/TypeScript CLI parity, pressure-mode summaries, masked-loss metrics, and OPD-only validation.
+
 ### Fixed
 
 - AC-637 TypeScript role routing now matches Python `role_routing=auto` semantics for role aliases, tier model selection, explicit provider overrides, and local-route unsupported capability reporting.

--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -211,6 +211,10 @@ Notes:
 - The teacher only needs to be at least as capable as the student; it need not be huge.
 - The run stops at the next iteration boundary once `--time-budget` is reached (model
   loading counts against the budget), so it cannot overrun indefinitely.
+- `--opd-pressure-mode` defaults to `full_kl` (existing full-distribution reverse KL).
+  Experimental modes `sample_positive` and `sample_positive_reverse_negative` are OPD-only:
+  the former trains only on sampled tokens where the teacher is more confident than the
+  student, while the latter also pushes down student-overconfident sampled tokens.
 - For cross-platform / larger runs (Linux, NVIDIA, multi-GPU), use the `trl` backend below;
   this `opd` backend is the local Apple-Silicon path.
 
@@ -278,7 +282,9 @@ than the teacher on its own sampled token. High shock-spike counts mark large di
 Raw token text is omitted by default. Pass `--opd-diagnostics-debug-tokens` only for local
 debugging when the sampled text is safe to persist. The runner summary also includes
 `token_pressure_positive_ratio`, `token_pressure_negative_ratio`, and
-`token_pressure_shock_spike_count` when diagnostics are enabled.
+`token_pressure_shock_spike_count` when diagnostics are enabled. OPD runs also report the
+selected `opd_pressure_mode`, `opd_positive_token_fraction`, `opd_negative_token_fraction`,
+and `opd_mean_masked_loss`.
 
 ### Tokenizer vocabulary size (optional)
 

--- a/autocontext/src/autocontext/cli_train.py
+++ b/autocontext/src/autocontext/cli_train.py
@@ -14,6 +14,7 @@ import typer  # type: ignore[import-not-found]
 from rich.console import Console  # type: ignore[import-not-found]
 from rich.table import Table  # type: ignore[import-not-found]
 
+from autocontext.training.autoresearch.opd_pressure import normalize_opd_pressure_mode
 from autocontext.training.autoresearch.r1_pipeline import run_r1_pipeline
 from autocontext.training.autoresearch.sequence_format import BASE_VOCAB_SIZE
 from autocontext.training.runner import TrainingConfig, TrainingResult
@@ -104,6 +105,11 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             "--opd-diagnostics-debug-tokens",
             help="include raw sampled token text in diagnostics (off by default)",
         ),
+        opd_pressure_mode: str = typer.Option(
+            "full_kl",
+            "--opd-pressure-mode",
+            help="opd backend pressure mode: full_kl, sample_positive, sample_positive_reverse_negative",
+        ),
         agent_provider: str = typer.Option("anthropic", "--agent-provider", help="LLM provider for training agent"),
         agent_model: str = typer.Option("", "--agent-model", help="Model for training agent (empty = provider default)"),
         val_select: bool = typer.Option(
@@ -165,6 +171,12 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             raise typer.BadParameter(f"--trl-mode must be gkd|grpo, got {trl_mode!r}")
         if backend not in ("mlx", "cuda", "mlxlm", "grpo", "opd", "trl"):
             raise typer.BadParameter(f"--backend must be mlx|cuda|mlxlm|grpo|opd|trl, got {backend!r}")
+        try:
+            opd_pressure_mode = normalize_opd_pressure_mode(opd_pressure_mode)
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        if backend != "opd" and opd_pressure_mode != "full_kl":
+            raise typer.BadParameter("--opd-pressure-mode only supports --backend opd")
         if train_steps < 0:
             raise typer.BadParameter(f"--train-steps must be >= 0 (0 = backend default), got {train_steps}")
         if max_completion_length < 1:
@@ -204,6 +216,7 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             grpo_beta=grpo_beta,
             opd_diagnostics=opd_diagnostics,
             opd_diagnostics_debug_tokens=opd_diagnostics_debug_tokens,
+            opd_pressure_mode=opd_pressure_mode,
             fine_tune_type=fine_tune_type,
             num_layers=num_layers,
         )
@@ -224,11 +237,7 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
 
         if json_output:
             best_metrics = next(
-                (
-                    item.summary_metrics
-                    for item in result.results
-                    if item.experiment_index == result.best_experiment_index
-                ),
+                (item.summary_metrics for item in result.results if item.experiment_index == result.best_experiment_index),
                 {},
             )
             _write_json_stdout(

--- a/autocontext/src/autocontext/training/autoresearch/on_policy_distill.py
+++ b/autocontext/src/autocontext/training/autoresearch/on_policy_distill.py
@@ -25,6 +25,7 @@ import mlx.nn as nn  # type: ignore[import-not-found]
 # Re-exported from the pure (mlx-free) shared module so the cross-platform trl backend can
 # use it without importing this mlx-scoped module; kept importable here for back-compat.
 from autocontext.training.autoresearch.distill_common import assert_vocab_compatible
+from autocontext.training.autoresearch.opd_pressure import normalize_opd_pressure_mode
 from autocontext.training.model_defaults import OPD_DEFAULT_STUDENT_MODEL, OPD_DEFAULT_TEACHER_MODEL
 
 _EPS = 1e-8
@@ -95,6 +96,79 @@ def reverse_kl_per_token(
     return mx.sum(masked) / mx.maximum(denom, _EPS)
 
 
+def _sampled_token_logprobs(logp: mx.array, full_ids: mx.array) -> mx.array:
+    targets = full_ids[:, 1:]
+    return mx.squeeze(mx.take_along_axis(logp[:, :-1, :], targets[:, :, None], axis=-1), axis=-1)
+
+
+def _sampled_token_pressure_loss(
+    student_logits: mx.array,
+    teacher_logits: mx.array,
+    full_ids: mx.array,
+    completion_mask: mx.array,
+    *,
+    mode: str,
+    temperature: float = 1.0,
+) -> mx.array:
+    teacher_logits = mx.stop_gradient(teacher_logits)
+    inv_t = 1.0 / temperature
+    student_logp = _log_softmax(student_logits * inv_t, axis=-1)
+    teacher_logp = _log_softmax(teacher_logits * inv_t, axis=-1)
+    margin = _sampled_token_logprobs(teacher_logp, full_ids) - _sampled_token_logprobs(student_logp, full_ids)
+    mask = completion_mask[:, :-1]
+    if mode == "sample_positive":
+        selected = (margin > 0.0).astype(mx.float32) * mask
+        per_token = mx.maximum(margin, 0.0)
+    else:
+        selected = ((margin > 0.0) | (margin < 0.0)).astype(mx.float32) * mask
+        per_token = mx.abs(margin)
+    return mx.sum(per_token * selected) / mx.maximum(mx.sum(selected), _EPS)
+
+
+def _sampled_token_pressure_metrics(
+    student_logits: mx.array,
+    teacher_logits: mx.array,
+    full_ids: mx.array,
+    completion_mask: mx.array,
+    *,
+    mode: str,
+    masked_loss: float | None = None,
+) -> dict[str, float]:
+    student_logp = _log_softmax(student_logits, axis=-1)
+    teacher_logp = _log_softmax(mx.stop_gradient(teacher_logits), axis=-1)
+    margin = _sampled_token_logprobs(teacher_logp, full_ids) - _sampled_token_logprobs(student_logp, full_ids)
+    mask = completion_mask[:, :-1]
+    total = float(mx.sum(mask))
+    if total <= 0.0:
+        return {
+            "opd_positive_token_fraction": 0.0,
+            "opd_negative_token_fraction": 0.0,
+            "opd_mean_masked_loss": float(masked_loss or 0.0),
+        }
+    positive_fraction = float(mx.sum((margin > 0.0).astype(mx.float32) * mask)) / total
+    negative_fraction = float(mx.sum((margin < 0.0).astype(mx.float32) * mask)) / total
+    if mode == "full_kl":
+        return {
+            "opd_positive_token_fraction": positive_fraction,
+            "opd_negative_token_fraction": negative_fraction,
+            "opd_mean_masked_loss": float(masked_loss or 0.0),
+        }
+    if mode == "sample_positive":
+        selected = (margin > 0.0).astype(mx.float32) * mask
+        per_token = mx.maximum(margin, 0.0)
+    else:
+        selected = ((margin > 0.0) | (margin < 0.0)).astype(mx.float32) * mask
+        per_token = mx.abs(margin)
+    selected_count = float(mx.sum(selected))
+    return {
+        "opd_positive_token_fraction": positive_fraction,
+        "opd_negative_token_fraction": negative_fraction,
+        "opd_mean_masked_loss": (
+            float(mx.sum(per_token * selected) / mx.maximum(mx.sum(selected), _EPS)) if selected_count > 0.0 else 0.0
+        ),
+    }
+
+
 def distill_loss(
     student_model: Any,
     teacher_model: Any,
@@ -102,6 +176,7 @@ def distill_loss(
     completion_mask: mx.array,
     *,
     temperature: float = 1.0,
+    opd_pressure_mode: str = "full_kl",
 ) -> mx.array:
     """Reverse-KL distillation loss over ``full_ids`` (one forward per model).
 
@@ -109,9 +184,19 @@ def distill_loss(
     positions whose next-token distribution should match the teacher's. Differentiable in
     the student; the teacher is frozen inside :func:`reverse_kl_per_token`.
     """
+    opd_pressure_mode = normalize_opd_pressure_mode(opd_pressure_mode)
     student_logits = student_model(full_ids)
     teacher_logits = teacher_model(full_ids)
-    return reverse_kl_per_token(student_logits, teacher_logits, completion_mask, temperature=temperature)
+    if opd_pressure_mode == "full_kl":
+        return reverse_kl_per_token(student_logits, teacher_logits, completion_mask, temperature=temperature)
+    return _sampled_token_pressure_loss(
+        student_logits,
+        teacher_logits,
+        full_ids,
+        completion_mask,
+        mode=opd_pressure_mode,
+        temperature=temperature,
+    )
 
 
 def distill_update_step(
@@ -122,11 +207,19 @@ def distill_update_step(
     completion_mask: mx.array,
     *,
     temperature: float = 1.0,
+    opd_pressure_mode: str = "full_kl",
 ) -> float:
     """One gradient step minimizing the reverse-KL distillation loss on a FIXED batch."""
 
     def loss_fn(model: Any) -> mx.array:
-        return distill_loss(model, teacher_model, full_ids, completion_mask, temperature=temperature)
+        return distill_loss(
+            model,
+            teacher_model,
+            full_ids,
+            completion_mask,
+            temperature=temperature,
+            opd_pressure_mode=opd_pressure_mode,
+        )
 
     loss, grads = nn.value_and_grad(student_model, loss_fn)(student_model)
     optimizer.update(student_model, grads)
@@ -175,6 +268,7 @@ def on_policy_distill_step(
     max_tokens: int,
     sample_temperature: float = 1.0,
     kl_temperature: float = 1.0,
+    opd_pressure_mode: str = "full_kl",
 ) -> float:
     """One on-policy distillation step: student rolls out, then a reverse-KL update.
 
@@ -185,7 +279,53 @@ def on_policy_distill_step(
         student_model, prompt_ids, max_tokens=max_tokens, temperature=sample_temperature
     )
     full_ids = mx.stop_gradient(full_ids)
-    return distill_update_step(student_model, teacher_model, optimizer, full_ids, completion_mask, temperature=kl_temperature)
+    return distill_update_step(
+        student_model,
+        teacher_model,
+        optimizer,
+        full_ids,
+        completion_mask,
+        temperature=kl_temperature,
+        opd_pressure_mode=opd_pressure_mode,
+    )
+
+
+def _on_policy_distill_step_with_metrics(
+    student_model: Any,
+    teacher_model: Any,
+    optimizer: Any,
+    prompt_ids: mx.array,
+    *,
+    max_tokens: int,
+    sample_temperature: float = 1.0,
+    kl_temperature: float = 1.0,
+    opd_pressure_mode: str = "full_kl",
+) -> tuple[float, dict[str, float]]:
+    full_ids, completion_mask = sample_completion(
+        student_model,
+        prompt_ids,
+        max_tokens=max_tokens,
+        temperature=sample_temperature,
+    )
+    full_ids = mx.stop_gradient(full_ids)
+    loss = distill_update_step(
+        student_model,
+        teacher_model,
+        optimizer,
+        full_ids,
+        completion_mask,
+        temperature=kl_temperature,
+        opd_pressure_mode=opd_pressure_mode,
+    )
+    stats = _sampled_token_pressure_metrics(
+        student_model(full_ids),
+        teacher_model(full_ids),
+        full_ids,
+        completion_mask,
+        mode=opd_pressure_mode,
+        masked_loss=loss,
+    )
+    return loss, stats
 
 
 def collect_token_pressure_for_prompts(
@@ -258,7 +398,8 @@ def distill_over_prompts(
     sample_temperature: float = 1.0,
     kl_temperature: float = 1.0,
     time_budget: float | None = None,
-) -> dict[str, float]:
+    opd_pressure_mode: str = "full_kl",
+) -> dict[str, Any]:
     """Run up to ``iters`` on-policy distillation steps, cycling through ``prompts``.
 
     Each ``prompts`` entry is a ``[1, P]`` token array. ``time_budget`` (seconds), if set,
@@ -266,31 +407,51 @@ def distill_over_prompts(
     overrun indefinitely on expensive rollouts. Returns ``num_steps`` plus the ``final_loss``
     and ``mean_loss`` over the run (the training loop body of the backend).
     """
+    opd_pressure_mode = normalize_opd_pressure_mode(opd_pressure_mode)
+    empty_result: dict[str, Any] = {
+        "num_steps": 0.0,
+        "final_loss": 0.0,
+        "mean_loss": 0.0,
+        "opd_pressure_mode": opd_pressure_mode,
+        "opd_positive_token_fraction": 0.0,
+        "opd_negative_token_fraction": 0.0,
+        "opd_mean_masked_loss": 0.0,
+    }
     if not prompts:
-        return {"num_steps": 0.0, "final_loss": 0.0, "mean_loss": 0.0}
+        return empty_result
     losses: list[float] = []
+    pressure_totals = {
+        "opd_positive_token_fraction": 0.0,
+        "opd_negative_token_fraction": 0.0,
+        "opd_mean_masked_loss": 0.0,
+    }
     started = time.monotonic()
     for step in range(iters):
         if time_budget is not None and (time.monotonic() - started) >= time_budget:
             break
         prompt_ids = prompts[step % len(prompts)]
-        losses.append(
-            on_policy_distill_step(
-                student_model,
-                teacher_model,
-                optimizer,
-                prompt_ids,
-                max_tokens=max_tokens,
-                sample_temperature=sample_temperature,
-                kl_temperature=kl_temperature,
-            )
+        loss, pressure_stats = _on_policy_distill_step_with_metrics(
+            student_model,
+            teacher_model,
+            optimizer,
+            prompt_ids,
+            max_tokens=max_tokens,
+            sample_temperature=sample_temperature,
+            kl_temperature=kl_temperature,
+            opd_pressure_mode=opd_pressure_mode,
         )
+        losses.append(loss)
+        for key in pressure_totals:
+            pressure_totals[key] += pressure_stats[key]
     if not losses:
-        return {"num_steps": 0.0, "final_loss": 0.0, "mean_loss": 0.0}
+        return empty_result
+    steps = float(len(losses))
     return {
-        "num_steps": float(len(losses)),
+        "num_steps": steps,
         "final_loss": losses[-1],
         "mean_loss": sum(losses) / len(losses),
+        "opd_pressure_mode": opd_pressure_mode,
+        **{key: value / steps for key, value in pressure_totals.items()},
     }
 
 
@@ -324,7 +485,8 @@ def run_on_policy_distillation(
     seed: int = 0,
     opd_diagnostics: bool = False,
     opd_diagnostics_debug_tokens: bool = False,
-) -> dict[str, float]:
+    opd_pressure_mode: str = "full_kl",
+) -> dict[str, Any]:
     """Distill a teacher into a LoRA student IN-PROCESS via on-policy reverse-KL, then assess.
 
     There is no distillation CLI to shell out to (mlx-lm-lora has no GKD mode), so this runs
@@ -344,6 +506,7 @@ def run_on_policy_distillation(
     from autocontext.training.autoresearch.train import _peak_memory_mb, _preflight_backend_deps
 
     _preflight_backend_deps("mlxlm")  # needs mlx-lm (load + tuner)
+    opd_pressure_mode = normalize_opd_pressure_mode(opd_pressure_mode)
     teacher_model = teacher_model or DEFAULT_TEACHER_MODEL
     student_model = student_model or DEFAULT_STUDENT_MODEL
     if register_import:
@@ -382,6 +545,7 @@ def run_on_policy_distillation(
         sample_temperature=sample_temperature,
         kl_temperature=kl_temperature,
         time_budget=loop_budget,
+        opd_pressure_mode=opd_pressure_mode,
     )
 
     if opd_diagnostics:
@@ -434,6 +598,10 @@ def run_on_policy_distillation(
         "num_steps": loop["num_steps"],
         "final_loss": loop["final_loss"],
         "mean_loss": loop["mean_loss"],
+        "opd_pressure_mode": loop["opd_pressure_mode"],
+        "opd_positive_token_fraction": loop["opd_positive_token_fraction"],
+        "opd_negative_token_fraction": loop["opd_negative_token_fraction"],
+        "opd_mean_masked_loss": loop["opd_mean_masked_loss"],
         "num_records": float(len(prompts)),
         "num_params_m": 0.0,
         "depth": 0.0,

--- a/autocontext/src/autocontext/training/autoresearch/opd_pressure.py
+++ b/autocontext/src/autocontext/training/autoresearch/opd_pressure.py
@@ -1,0 +1,49 @@
+"""Small helpers for experimental OPD pressure modes."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Final
+
+OPD_PRESSURE_MODES: Final = ("full_kl", "sample_positive", "sample_positive_reverse_negative")
+OPD_PRESSURE_MODE_CODES: Final[dict[str, float]] = {
+    "full_kl": 0.0,
+    "sample_positive": 1.0,
+    "sample_positive_reverse_negative": 2.0,
+}
+
+
+def normalize_opd_pressure_mode(mode: str) -> str:
+    normalized = mode.strip().lower()
+    if normalized not in OPD_PRESSURE_MODE_CODES:
+        expected = "|".join(OPD_PRESSURE_MODES)
+        raise ValueError(f"opd_pressure_mode must be one of {expected}, got {mode!r}")
+    return normalized
+
+
+def selected_sample_mask(margins: Sequence[float], mode: str) -> list[bool]:
+    normalized = normalize_opd_pressure_mode(mode)
+    if normalized == "sample_positive":
+        return [margin > 0.0 for margin in margins]
+    if normalized == "sample_positive_reverse_negative":
+        return [margin != 0.0 for margin in margins]
+    return [True for _ in margins]
+
+
+def sampled_token_pressure_summary(margins: Sequence[float], mode: str) -> dict[str, float]:
+    normalized = normalize_opd_pressure_mode(mode)
+    total = len(margins)
+    if total == 0:
+        return {
+            "opd_positive_token_fraction": 0.0,
+            "opd_negative_token_fraction": 0.0,
+            "opd_mean_masked_loss": 0.0,
+        }
+
+    mask = selected_sample_mask(margins, normalized)
+    losses = [abs(margin) for margin, selected in zip(margins, mask, strict=True) if selected]
+    return {
+        "opd_positive_token_fraction": sum(1 for margin in margins if margin > 0.0) / total,
+        "opd_negative_token_fraction": sum(1 for margin in margins if margin < 0.0) / total,
+        "opd_mean_masked_loss": sum(losses) / len(losses) if losses else 0.0,
+    }

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -29,6 +29,7 @@ from autocontext.training.autoresearch.model import (  # noqa: F401
     save_checkpoint,
     save_inference_bundle,
 )
+from autocontext.training.autoresearch.opd_pressure import OPD_PRESSURE_MODE_CODES, normalize_opd_pressure_mode
 from autocontext.training.autoresearch.prepare import BASE_VOCAB_SIZE
 from autocontext.training.autoresearch.sequence_format import NUM_QUALITY_BUCKETS
 
@@ -61,6 +62,10 @@ def format_summary(
     token_pressure_positive_ratio: float | None = None,
     token_pressure_negative_ratio: float | None = None,
     token_pressure_shock_spike_count: float | None = None,
+    opd_pressure_mode: str | None = None,
+    opd_positive_token_fraction: float | None = None,
+    opd_negative_token_fraction: float | None = None,
+    opd_mean_masked_loss: float | None = None,
 ) -> str:
     """Format the training results summary block.
 
@@ -88,6 +93,18 @@ def format_summary(
                 if token_pressure_shock_spike_count is not None
                 else ""
             ),
+            f"opd_pressure_mode: {opd_pressure_mode}\n" if opd_pressure_mode is not None else "",
+            (
+                f"opd_positive_token_fraction: {opd_positive_token_fraction:.4f}\n"
+                if opd_positive_token_fraction is not None
+                else ""
+            ),
+            (
+                f"opd_negative_token_fraction: {opd_negative_token_fraction:.4f}\n"
+                if opd_negative_token_fraction is not None
+                else ""
+            ),
+            f"opd_mean_masked_loss: {opd_mean_masked_loss:.4f}\n" if opd_mean_masked_loss is not None else "",
         )
     )
     return (
@@ -438,11 +455,12 @@ def run_training(
     grpo_beta: float = 0.04,  # trl grpo: KL penalty toward base policy (0.0 = KL-free; nonzero prevents overfitting)
     opd_diagnostics: bool | None = None,
     opd_diagnostics_debug_tokens: bool = False,
+    opd_pressure_mode: str = "full_kl",
     fine_tune_type: str = "lora",
     num_layers: int = 8,
     collect_samples_path: Path | None = None,
     backend: str = "mlx",
-) -> dict[str, float]:
+) -> dict[str, Any]:
     # Reject out-of-range curation before any work (select_top_fraction would clamp to one record).
     if not 0.0 < elite_fraction <= 1.0:
         raise ValueError(f"elite_fraction must be in (0, 1], got {elite_fraction}")
@@ -455,6 +473,9 @@ def run_training(
         raise ValueError(f"vocab_size must be >= 256 (the byte-level BPE base), got {vocab_size}")
 
     normalized_backend = backend.strip().lower()
+    opd_pressure_mode = normalize_opd_pressure_mode(opd_pressure_mode)
+    if normalized_backend != "opd" and opd_pressure_mode != "full_kl":
+        raise NotImplementedError("--opd-pressure-mode only supports the opd backend")
     if opd_diagnostics is None:
         opd_diagnostics = _env_truthy("AUTOCONTEXT_OPD_DIAGNOSTICS")
     if train_steps <= 0:  # resolve the unset sentinel to a backend-appropriate step count
@@ -562,6 +583,7 @@ def run_training(
             memory_limit_mb=memory_limit_mb,
             opd_diagnostics=opd_diagnostics,
             opd_diagnostics_debug_tokens=opd_diagnostics_debug_tokens,
+            opd_pressure_mode=opd_pressure_mode,
         )
     if normalized_backend == "trl":
         if loss_weight_mode != "uniform" or vocab_size != BASE_VOCAB_SIZE:
@@ -619,6 +641,12 @@ def _build_parser() -> argparse.ArgumentParser:
         "--opd-diagnostics-debug-tokens",
         action="store_true",
         help="include raw sampled token text in diagnostics (off by default)",
+    )
+    parser.add_argument(
+        "--opd-pressure-mode",
+        choices=tuple(OPD_PRESSURE_MODE_CODES),
+        default="full_kl",
+        help="experimental opd backend pressure mode (default: full_kl)",
     )
     parser.add_argument("--time-budget", type=int, default=300)
     parser.add_argument("--memory-limit", type=int, default=16384)
@@ -683,6 +711,7 @@ def main(argv: list[str] | None = None) -> int:
             grpo_beta=args.grpo_beta,
             opd_diagnostics=args.opd_diagnostics,
             opd_diagnostics_debug_tokens=args.opd_diagnostics_debug_tokens,
+            opd_pressure_mode=args.opd_pressure_mode,
             fine_tune_type=args.fine_tune_type,
             num_layers=args.num_layers,
             backend=args.backend,
@@ -706,6 +735,10 @@ def main(argv: list[str] | None = None) -> int:
             token_pressure_positive_ratio=metrics.get("token_pressure_positive_ratio"),
             token_pressure_negative_ratio=metrics.get("token_pressure_negative_ratio"),
             token_pressure_shock_spike_count=metrics.get("token_pressure_shock_spike_count"),
+            opd_pressure_mode=str(metrics.get("opd_pressure_mode")) if "opd_pressure_mode" in metrics else None,
+            opd_positive_token_fraction=metrics.get("opd_positive_token_fraction"),
+            opd_negative_token_fraction=metrics.get("opd_negative_token_fraction"),
+            opd_mean_masked_loss=metrics.get("opd_mean_masked_loss"),
         )
     )
     return 0

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -77,6 +77,7 @@ class TrainingConfig:
     grpo_beta: float = 0.04  # trl grpo: KL penalty toward base policy (0.0 = KL-free; nonzero prevents overfitting)
     opd_diagnostics: bool = False  # OPD/GKD token-pressure report; no training-update changes
     opd_diagnostics_debug_tokens: bool = False  # include sampled token text in diagnostics (off by default)
+    opd_pressure_mode: str = "full_kl"  # opd backend: full_kl | sample_positive | sample_positive_reverse_negative
     fine_tune_type: str = "lora"  # mlxlm backend: lora | dora | full
     num_layers: int = 8  # mlxlm backend: number of layers to fine-tune
 
@@ -449,6 +450,8 @@ class TrainingRunner:
             command.append("--opd-diagnostics")
         if self.config.opd_diagnostics_debug_tokens:
             command.append("--opd-diagnostics-debug-tokens")
+        if self.config.opd_pressure_mode != "full_kl":
+            command += ["--opd-pressure-mode", self.config.opd_pressure_mode]
         if self.config.fine_tune_type != "lora":
             command += ["--fine-tune-type", self.config.fine_tune_type]
         if self.config.num_layers != 8:
@@ -658,6 +661,9 @@ class TrainingRunner:
             "token_pressure_positive_ratio",
             "token_pressure_negative_ratio",
             "token_pressure_shock_spike_count",
+            "opd_positive_token_fraction",
+            "opd_negative_token_fraction",
+            "opd_mean_masked_loss",
         ):
             if key in best_result.summary_metrics:
                 training_metrics[key] = best_result.summary_metrics[key]
@@ -688,6 +694,7 @@ class TrainingRunner:
                 "base_model": self.config.base_model or self._backend.default_base_model(),
                 "score_conditioned": self.config.score_conditioned,
                 "opd_diagnostics": diagnostics_written,
+                "opd_pressure_mode": self.config.opd_pressure_mode,
                 "opd_diagnostics_path": (
                     str(best_result.checkpoint_path / "token_pressure_diagnostics.json")
                     if diagnostics_written and best_result.checkpoint_path is not None

--- a/autocontext/tests/test_opd_pressure_modes.py
+++ b/autocontext/tests/test_opd_pressure_modes.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from autocontext.training.autoresearch.opd_pressure import (
+    OPD_PRESSURE_MODE_CODES,
+    normalize_opd_pressure_mode,
+    sampled_token_pressure_summary,
+    selected_sample_mask,
+)
+
+
+def test_positive_mode_selects_only_teacher_advantaged_tokens() -> None:
+    margins = [0.4, -0.2, 0.0, 1.1]
+
+    assert selected_sample_mask(margins, "sample_positive") == [True, False, False, True]
+    assert sampled_token_pressure_summary(margins, "sample_positive") == {
+        "opd_positive_token_fraction": 0.5,
+        "opd_negative_token_fraction": 0.25,
+        "opd_mean_masked_loss": 0.75,
+    }
+
+
+def test_positive_mode_all_negative_batch_has_zero_masked_loss() -> None:
+    summary = sampled_token_pressure_summary([-0.5, -0.25], "sample_positive")
+
+    assert summary["opd_positive_token_fraction"] == 0.0
+    assert summary["opd_negative_token_fraction"] == 1.0
+    assert summary["opd_mean_masked_loss"] == 0.0
+
+
+def test_positive_mode_all_positive_batch_keeps_every_token() -> None:
+    summary = sampled_token_pressure_summary([0.25, 0.75], "sample_positive")
+
+    assert selected_sample_mask([0.25, 0.75], "sample_positive") == [True, True]
+    assert summary["opd_positive_token_fraction"] == 1.0
+    assert summary["opd_negative_token_fraction"] == 0.0
+    assert summary["opd_mean_masked_loss"] == 0.5
+
+
+def test_reverse_negative_mode_keeps_both_pressure_directions() -> None:
+    margins = [0.4, -0.2, 0.0]
+
+    summary = sampled_token_pressure_summary(margins, "sample_positive_reverse_negative")
+
+    assert selected_sample_mask(margins, "sample_positive_reverse_negative") == [True, True, False]
+    assert summary["opd_mean_masked_loss"] == pytest.approx(0.3)
+
+
+def test_run_training_forwards_pressure_mode_to_opd_backend(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    train = importlib.import_module("autocontext.training.autoresearch.train")
+    fake_opd = types.ModuleType("autocontext.training.autoresearch.on_policy_distill")
+    captured: dict[str, Any] = {}
+
+    def fake_run_on_policy_distillation(**kwargs: Any) -> dict[str, float]:
+        captured.update(kwargs)
+        return {
+            "avg_score": 0.0,
+            "valid_rate": 0.0,
+            "training_seconds": 0.0,
+            "peak_memory_mb": 0.0,
+            "num_steps": 1.0,
+            "num_params_m": 0.0,
+            "depth": 0.0,
+        }
+
+    fake_opd.run_on_policy_distillation = fake_run_on_policy_distillation  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "autocontext.training.autoresearch.on_policy_distill", fake_opd)
+    monkeypatch.setattr(train, "_preflight_backend_deps", lambda _backend: None)
+
+    train.run_training(
+        scenario_name="gsm8k",
+        data_path=tmp_path / "data.jsonl",
+        output_dir=tmp_path / "out",
+        time_budget=1,
+        memory_limit_mb=1024,
+        backend="opd",
+        opd_pressure_mode="sample_positive",
+    )
+
+    assert captured["opd_pressure_mode"] == "sample_positive"
+
+
+def test_run_training_rejects_pressure_mode_for_incompatible_backends(tmp_path: Path) -> None:
+    train = importlib.import_module("autocontext.training.autoresearch.train")
+
+    with pytest.raises(NotImplementedError, match="--opd-pressure-mode"):
+        train.run_training(
+            scenario_name="gsm8k",
+            data_path=tmp_path / "data.jsonl",
+            output_dir=tmp_path / "out",
+            time_budget=1,
+            memory_limit_mb=1024,
+            backend="mlx",
+            opd_pressure_mode="sample_positive",
+        )
+
+
+def test_pressure_mode_normalization_and_codes_are_stable() -> None:
+    assert normalize_opd_pressure_mode(" Sample_Positive ") == "sample_positive"
+    assert OPD_PRESSURE_MODE_CODES == {
+        "full_kl": 0.0,
+        "sample_positive": 1.0,
+        "sample_positive_reverse_negative": 2.0,
+    }
+    with pytest.raises(ValueError, match=r"full_kl\|sample_positive\|sample_positive_reverse_negative"):
+        normalize_opd_pressure_mode("invented")

--- a/autocontext/tests/test_train_summary.py
+++ b/autocontext/tests/test_train_summary.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
+from types import ModuleType
+from typing import Any
 
 
-def _train_module():
+def _train_module() -> ModuleType:
     return importlib.import_module("autocontext.training.autoresearch.train")
 
 
-def _runner_module():
+def _runner_module() -> ModuleType:
     return importlib.import_module("autocontext.training.runner")
 
 
@@ -82,6 +85,27 @@ def test_format_summary_includes_token_pressure_metrics_when_provided() -> None:
     assert "token_pressure_shock_spike_count: 2" in result
 
 
+def test_format_summary_includes_opd_pressure_mode_metrics_when_provided() -> None:
+    result = _train_module().format_summary(
+        avg_score=0.5,
+        valid_rate=1.0,
+        training_seconds=1.0,
+        peak_memory_mb=10.0,
+        num_steps=3,
+        num_params_m=0.1,
+        depth=4,
+        opd_pressure_mode="sample_positive",
+        opd_positive_token_fraction=0.75,
+        opd_negative_token_fraction=0.25,
+        opd_mean_masked_loss=0.125,
+    )
+
+    assert "opd_pressure_mode: sample_positive" in result
+    assert "opd_positive_token_fraction: 0.7500" in result
+    assert "opd_negative_token_fraction: 0.2500" in result
+    assert "opd_mean_masked_loss: 0.1250" in result
+
+
 def test_default_train_steps_distinguishes_from_scratch_vs_adapter() -> None:
     train = _train_module()
     assert train._default_train_steps("mlx") == 8
@@ -115,12 +139,12 @@ def test_train_parser_accepts_trl_prompt_count() -> None:
     assert args.n_prompts == 384
 
 
-def test_trl_backend_receives_prompt_count(monkeypatch, tmp_path) -> None:
+def test_trl_backend_receives_prompt_count(monkeypatch: Any, tmp_path: Path) -> None:
     train = _train_module()
     trl_backend = importlib.import_module("autocontext.training.autoresearch.trl_backend")
-    captured = {}
+    captured: dict[str, Any] = {}
 
-    def fake_run_trl_training(**kwargs):
+    def fake_run_trl_training(**kwargs: Any) -> dict[str, float]:
         captured.update(kwargs)
         return {
             "avg_score": 0.0,

--- a/autocontext/tests/test_training_runner.py
+++ b/autocontext/tests/test_training_runner.py
@@ -362,6 +362,30 @@ class TestConstraints:
         assert "--opd-diagnostics" in command
         assert "--opd-diagnostics-debug-tokens" in command
 
+    def test_experiment_subprocess_passes_opd_pressure_mode_when_overridden(self, tmp_path: Path) -> None:
+        cfg = TrainingConfig(
+            scenario="grid_ctf",
+            data_path=tmp_path / "data.jsonl",
+            backend="opd",
+            opd_pressure_mode="sample_positive",
+        )
+        (tmp_path / "data.jsonl").write_text("{}\n")
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run:
+            runner._run_experiment_subprocess(0)
+        command = mock_run.call_args.args[0]
+        assert command[command.index("--opd-pressure-mode") + 1] == "sample_positive"
+
+    def test_experiment_subprocess_omits_default_opd_pressure_mode(self, tmp_path: Path) -> None:
+        cfg = TrainingConfig(scenario="grid_ctf", data_path=tmp_path / "data.jsonl", backend="opd")
+        (tmp_path / "data.jsonl").write_text("{}\n")
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run:
+            runner._run_experiment_subprocess(0)
+        assert "--opd-pressure-mode" not in mock_run.call_args.args[0]
+
     def test_experiment_subprocess_passes_grpo_beta_when_overridden(self, tmp_path: Path) -> None:
         """The GRPO KL penalty must reach the subprocess so `autoctx train` can avoid the beta=0
         overfitting; the default 0.04 is omitted to keep the command minimal."""
@@ -913,6 +937,37 @@ class TestTrainCLI:
             result = runner.invoke(app, ["train", "--scenario", "grid_ctf", "--vocab-size", "4096"])
             assert result.exit_code == 0, result.output
             assert mock_run.call_args[0][0].vocab_size == 4096
+
+    def test_opd_pressure_mode_option_reaches_config(self) -> None:
+        from autocontext.cli import app
+
+        runner = CliRunner()
+        with patch("autocontext.cli_train._run_training") as mock_run:
+            mock_run.return_value = TrainingResult(
+                scenario="grid_ctf",
+                total_experiments=1,
+                kept_count=1,
+                discarded_count=0,
+                best_score=0.5,
+                best_experiment_index=0,
+                checkpoint_path=Path("/tmp/best"),
+                results=[],
+            )
+            result = runner.invoke(
+                app,
+                ["train", "--scenario", "grid_ctf", "--backend", "opd", "--opd-pressure-mode", "sample_positive"],
+            )
+            assert result.exit_code == 0, result.output
+            assert mock_run.call_args[0][0].opd_pressure_mode == "sample_positive"
+
+    def test_opd_pressure_mode_rejects_non_opd_backend(self) -> None:
+        from autocontext.cli import app
+
+        runner = CliRunner()
+        with patch("autocontext.cli_train._run_training") as mock_run:
+            result = runner.invoke(app, ["train", "--backend", "mlx", "--opd-pressure-mode", "sample_positive"])
+        assert result.exit_code != 0
+        mock_run.assert_not_called()
 
     def test_too_small_vocab_size_rejected(self) -> None:
         from autocontext.cli import app

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -3341,6 +3341,7 @@ async function cmdTrain(): Promise<void> {
       output: { type: "string", short: "o" },
       "opd-diagnostics": { type: "boolean" },
       "opd-diagnostics-debug-tokens": { type: "boolean" },
+      "opd-pressure-mode": { type: "string" },
       json: { type: "boolean" },
       help: { type: "boolean", short: "h" },
     },

--- a/ts/src/cli/train-command-workflow.ts
+++ b/ts/src/cli/train-command-workflow.ts
@@ -13,12 +13,31 @@ Options:
   -o, --output <dir>       Output directory
   --opd-diagnostics        Write OPD/GKD token-pressure diagnostics
   --opd-diagnostics-debug-tokens  Include raw sampled token text in diagnostics
+  --opd-pressure-mode <mode>  OPD pressure mode: full_kl, sample_positive, sample_positive_reverse_negative
   --json                   Output as JSON
   -h, --help               Show this help
 
 Notes:
   The TypeScript package requires an injected training executor for real MLX/CUDA training.
   For end-to-end local training, prefer the Python package's \`autoctx train\` command.`;
+
+export type OpdPressureMode = "full_kl" | "sample_positive" | "sample_positive_reverse_negative";
+
+const OPD_PRESSURE_MODES = [
+  "full_kl",
+  "sample_positive",
+  "sample_positive_reverse_negative",
+] as const;
+
+function normalizeOpdPressureMode(value: string | undefined): OpdPressureMode {
+  const mode = value ?? "full_kl";
+  if (!OPD_PRESSURE_MODES.includes(mode as OpdPressureMode)) {
+    throw new Error(
+      "--opd-pressure-mode must be full_kl|sample_positive|sample_positive_reverse_negative",
+    );
+  }
+  return mode as OpdPressureMode;
+}
 
 export interface TrainCommandValues {
   scenario?: string;
@@ -31,6 +50,7 @@ export interface TrainCommandValues {
   output?: string;
   "opd-diagnostics"?: boolean;
   "opd-diagnostics-debug-tokens"?: boolean;
+  "opd-pressure-mode"?: string;
   json?: boolean;
 }
 
@@ -45,6 +65,7 @@ export interface TrainCommandPlan {
   baseModel?: string;
   opdDiagnostics: boolean;
   opdDiagnosticsDebugTokens: boolean;
+  opdPressureMode: OpdPressureMode;
   json: boolean;
 }
 
@@ -57,13 +78,19 @@ export function planTrainCommand(
     throw new Error("Error: --scenario and --dataset are required. Run 'autoctx train --help'.");
   }
 
+  const backend = values.backend ?? "cuda";
+  const opdPressureMode = normalizeOpdPressureMode(values["opd-pressure-mode"]);
+  if (backend !== "opd" && opdPressureMode !== "full_kl") {
+    throw new Error("--opd-pressure-mode only supports --backend opd");
+  }
+
   return {
     scenario: values.scenario,
     family: values.family ?? "agent_task",
     datasetPath: resolvePath(values.dataset),
     heldOutPath: values["held-out"] ? resolvePath(values["held-out"]) : undefined,
     outputDir: values.output ? resolvePath(values.output) : resolvePath(runsRoot),
-    backend: values.backend ?? "cuda",
+    backend,
     trainingMode: (values.mode ?? "from_scratch") as
       | "from_scratch"
       | "adapter_finetune"
@@ -71,6 +98,7 @@ export function planTrainCommand(
     baseModel: values["base-model"],
     opdDiagnostics: !!values["opd-diagnostics"],
     opdDiagnosticsDebugTokens: !!values["opd-diagnostics-debug-tokens"],
+    opdPressureMode,
     json: !!values.json,
   };
 }
@@ -90,6 +118,7 @@ export async function executeTrainCommandWorkflow<TResult extends { status?: str
       baseModel?: string;
       opdDiagnostics?: boolean;
       opdDiagnosticsDebugTokens?: boolean;
+      opdPressureMode?: OpdPressureMode;
     }): Promise<TResult>;
   };
 }): Promise<TResult> {
@@ -110,6 +139,7 @@ export async function executeTrainCommandWorkflow<TResult extends { status?: str
     baseModel: opts.plan.baseModel,
     opdDiagnostics: opts.plan.opdDiagnostics,
     opdDiagnosticsDebugTokens: opts.plan.opdDiagnosticsDebugTokens,
+    opdPressureMode: opts.plan.opdPressureMode,
   });
 }
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -972,7 +972,7 @@ export {
   defaultBackendRegistry,
   TrainingRunner,
 } from "./training/backends.js";
-export type { TrainingConfig, TrainingResult, PublishedArtifact } from "./training/backends.js";
+export type { OpdPressureMode, TrainingConfig, TrainingResult, PublishedArtifact } from "./training/backends.js";
 export {
   buildTokenPressureReport,
   compareTokenPressureReports,

--- a/ts/src/training/backends.ts
+++ b/ts/src/training/backends.ts
@@ -22,7 +22,7 @@ import { defaultExecutor } from "./training-runner-workflow.js";
 import { executeTrainingRunWorkflow } from "./training-run-execution-workflow.js";
 import type { TrainingExecutor } from "./training-types.js";
 import { ModelRegistry, PromotionEngine, type ModelRecord } from "./promotion.js";
-import type { PublishedArtifact, TrainingConfig, TrainingResult } from "./training-types.js";
+import type { TrainingConfig, TrainingResult } from "./training-types.js";
 
 export {
   BackendRegistry,
@@ -35,7 +35,7 @@ export {
   TRLBackend,
   TrainingBackend,
 };
-export type { PublishedArtifact, TrainingConfig, TrainingResult } from "./training-types.js";
+export type { OpdPressureMode, PublishedArtifact, TrainingConfig, TrainingResult } from "./training-types.js";
 export type { TrainingExecutor } from "./training-types.js";
 
 export class TrainingRunner {

--- a/ts/src/training/training-checkpoint-workflow.ts
+++ b/ts/src/training/training-checkpoint-workflow.ts
@@ -2,24 +2,25 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { ModelRecord } from "./promotion.js";
-import type {
-  PublishedArtifact,
-  TrainingConfig,
-  TrainingExecutor,
-} from "./training-types.js";
+import type { PublishedArtifact, TrainingConfig, TrainingExecutor } from "./training-types.js";
 import type { TrainingBackend } from "./training-backend-core.js";
 
 export const defaultExecutor: TrainingExecutor = async (config, checkpointDir) => {
   writeFileSync(
     join(checkpointDir, "checkpoint_info.json"),
-    JSON.stringify({
-      backend: config.backend,
-      trainingMode: config.trainingMode,
-      baseModel: config.baseModel,
-      status: "trained",
-      note: "Default executor — replace with real PyTorch/MLX training for production use",
-      timestamp: new Date().toISOString(),
-    }, null, 2),
+    JSON.stringify(
+      {
+        backend: config.backend,
+        trainingMode: config.trainingMode,
+        baseModel: config.baseModel,
+        opdPressureMode: config.opdPressureMode ?? "full_kl",
+        status: "trained",
+        note: "Default executor — replace with real PyTorch/MLX training for production use",
+        timestamp: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
     "utf-8",
   );
   return { success: true, metrics: { epochs: config.maxEpochs ?? 3 } };
@@ -45,23 +46,28 @@ export function writeTrainingManifest(
 ): void {
   writeFileSync(
     join(checkpointDir, "training_manifest.json"),
-    JSON.stringify({
-      scenario: config.scenario,
-      family: config.family,
-      backend: config.backend,
-      trainingMode: config.trainingMode,
-      baseModel: config.baseModel ?? null,
-      adapterType: config.adapterType ?? null,
-      datasetPath: config.datasetPath,
-      datasetSize,
-      heldOutSize,
-      maxEpochs: config.maxEpochs ?? 3,
-      batchSize: config.batchSize ?? 4,
-      learningRate: config.learningRate ?? 5e-5,
-      opdDiagnostics: config.opdDiagnostics ?? false,
-      opdDiagnosticsDebugTokens: config.opdDiagnosticsDebugTokens ?? false,
-      startedAt: new Date().toISOString(),
-    }, null, 2),
+    JSON.stringify(
+      {
+        scenario: config.scenario,
+        family: config.family,
+        backend: config.backend,
+        trainingMode: config.trainingMode,
+        baseModel: config.baseModel ?? null,
+        adapterType: config.adapterType ?? null,
+        datasetPath: config.datasetPath,
+        datasetSize,
+        heldOutSize,
+        maxEpochs: config.maxEpochs ?? 3,
+        batchSize: config.batchSize ?? 4,
+        learningRate: config.learningRate ?? 5e-5,
+        opdDiagnostics: config.opdDiagnostics ?? false,
+        opdDiagnosticsDebugTokens: config.opdDiagnosticsDebugTokens ?? false,
+        opdPressureMode: config.opdPressureMode ?? "full_kl",
+        startedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
     "utf-8",
   );
 }
@@ -88,11 +94,20 @@ export function publishTrainingArtifact(opts: {
     heldOutSize: opts.heldOutSize,
     trainedAt: new Date().toISOString(),
     metrics: opts.metrics,
+    opdPressureMode: opts.config.opdPressureMode ?? "full_kl",
     activationState: opts.record.activationState,
     promotionHistory: [...opts.record.promotionHistory],
   };
 
-  writeFileSync(join(opts.checkpointDir, "artifact.json"), JSON.stringify(artifact, null, 2), "utf-8");
-  writeFileSync(join(opts.checkpointDir, "promotion_state.json"), JSON.stringify(opts.record, null, 2), "utf-8");
+  writeFileSync(
+    join(opts.checkpointDir, "artifact.json"),
+    JSON.stringify(artifact, null, 2),
+    "utf-8",
+  );
+  writeFileSync(
+    join(opts.checkpointDir, "promotion_state.json"),
+    JSON.stringify(opts.record, null, 2),
+    "utf-8",
+  );
   return artifact;
 }

--- a/ts/src/training/training-config-workflow.ts
+++ b/ts/src/training/training-config-workflow.ts
@@ -24,9 +24,18 @@ export function resolveTrainingConfig(config: TrainingConfig): {
   }
 
   const datasetSize = countJsonlRecords(config.datasetPath);
-  const heldOutSize = config.heldOutPath && existsSync(config.heldOutPath)
-    ? countJsonlRecords(config.heldOutPath)
-    : 0;
+  const heldOutSize =
+    config.heldOutPath && existsSync(config.heldOutPath)
+      ? countJsonlRecords(config.heldOutPath)
+      : 0;
+  if (config.backend !== "opd" && config.opdPressureMode && config.opdPressureMode !== "full_kl") {
+    return {
+      resolvedConfig: config,
+      datasetSize,
+      heldOutSize,
+      error: "--opd-pressure-mode only supports the opd backend",
+    };
+  }
 
   const selector = new ModelStrategySelector();
   const strategy = selector.select({
@@ -41,6 +50,7 @@ export function resolveTrainingConfig(config: TrainingConfig): {
     trainingMode: strategy.trainingMode,
     baseModel: strategy.baseModel,
     adapterType: config.adapterType ?? strategy.adapterType,
+    opdPressureMode: config.opdPressureMode ?? "full_kl",
   };
 
   if (resolvedConfig.trainingMode !== "from_scratch" && !resolvedConfig.baseModel) {

--- a/ts/src/training/training-types.ts
+++ b/ts/src/training/training-types.ts
@@ -1,6 +1,8 @@
 import type { ActivationState, PromotionEvent } from "./promotion.js";
 import type { TrainingMode } from "./model-strategy.js";
 
+export type OpdPressureMode = "full_kl" | "sample_positive" | "sample_positive_reverse_negative";
+
 export interface TrainingConfig {
   scenario: string;
   family: string;
@@ -16,6 +18,7 @@ export interface TrainingConfig {
   learningRate?: number;
   opdDiagnostics?: boolean;
   opdDiagnosticsDebugTokens?: boolean;
+  opdPressureMode?: OpdPressureMode;
 }
 
 export interface PublishedArtifact {
@@ -31,6 +34,7 @@ export interface PublishedArtifact {
   heldOutSize: number;
   trainedAt: string;
   metrics?: Record<string, number>;
+  opdPressureMode?: OpdPressureMode;
   activationState: ActivationState;
   promotionHistory: PromotionEvent[];
 }

--- a/ts/tests/train-command-workflow.test.ts
+++ b/ts/tests/train-command-workflow.test.ts
@@ -17,6 +17,7 @@ describe("train command workflow", () => {
     expect(TRAIN_HELP_TEXT).toContain("--backend");
     expect(TRAIN_HELP_TEXT).toContain("--opd-diagnostics");
     expect(TRAIN_HELP_TEXT).toContain("--opd-diagnostics-debug-tokens");
+    expect(TRAIN_HELP_TEXT).toContain("--opd-pressure-mode");
   });
 
   it("requires scenario and dataset", () => {
@@ -47,12 +48,13 @@ describe("train command workflow", () => {
           family: "agent_task",
           dataset: "train.jsonl",
           "held-out": "heldout.jsonl",
-          backend: "mlx",
+          backend: "opd",
           mode: "adapter_finetune",
           "base-model": "qwen",
           output: "artifacts",
           "opd-diagnostics": true,
           "opd-diagnostics-debug-tokens": true,
+          "opd-pressure-mode": "sample_positive",
           json: true,
         },
         "/tmp/runs",
@@ -64,13 +66,29 @@ describe("train command workflow", () => {
       datasetPath: "/abs/train.jsonl",
       heldOutPath: "/abs/heldout.jsonl",
       outputDir: "/abs/artifacts",
-      backend: "mlx",
+      backend: "opd",
       trainingMode: "adapter_finetune",
       baseModel: "qwen",
       opdDiagnostics: true,
       opdDiagnosticsDebugTokens: true,
+      opdPressureMode: "sample_positive",
       json: true,
     });
+  });
+
+  it("rejects non-default OPD pressure modes for non-OPD backends", () => {
+    expect(() =>
+      planTrainCommand(
+        {
+          scenario: "grid_ctf",
+          dataset: "train.jsonl",
+          backend: "cuda",
+          "opd-pressure-mode": "sample_positive",
+        },
+        "/tmp/runs",
+        (value: string) => `/abs/${value}`,
+      ),
+    ).toThrow("--opd-pressure-mode only supports --backend opd");
   });
 
   it("fails clearly when only the synthetic executor is available", async () => {
@@ -87,6 +105,7 @@ describe("train command workflow", () => {
           baseModel: undefined,
           opdDiagnostics: false,
           opdDiagnosticsDebugTokens: false,
+          opdPressureMode: "full_kl",
           json: false,
         },
         createRunner: () => ({
@@ -115,11 +134,12 @@ describe("train command workflow", () => {
         datasetPath: "/abs/train.jsonl",
         heldOutPath: "/abs/heldout.jsonl",
         outputDir: "/tmp/runs",
-        backend: "cuda",
+        backend: "opd",
         trainingMode: "from_scratch",
         baseModel: undefined,
         opdDiagnostics: true,
         opdDiagnosticsDebugTokens: true,
+        opdPressureMode: "sample_positive_reverse_negative",
         json: false,
       },
       createRunner: () => ({
@@ -134,11 +154,12 @@ describe("train command workflow", () => {
       datasetPath: "/abs/train.jsonl",
       heldOutPath: "/abs/heldout.jsonl",
       outputDir: "/tmp/runs",
-      backend: "cuda",
+      backend: "opd",
       trainingMode: "from_scratch",
       baseModel: undefined,
       opdDiagnostics: true,
       opdDiagnosticsDebugTokens: true,
+      opdPressureMode: "sample_positive_reverse_negative",
     });
     expect(result).toMatchObject({ status: "completed", backend: "cuda" });
   });

--- a/ts/tests/training-checkpoint-workflow.test.ts
+++ b/ts/tests/training-checkpoint-workflow.test.ts
@@ -44,13 +44,14 @@ describe("training checkpoint workflow", () => {
       family: "agent_task",
       datasetPath: join(dir, "train.jsonl"),
       outputDir: join(dir, "output"),
-      backend: "cuda",
+      backend: "opd",
       trainingMode: "adapter_finetune",
       baseModel: "Qwen/Qwen3-0.6B",
       opdDiagnostics: true,
+      opdPressureMode: "sample_positive",
     };
 
-    const checkpointDir = ensureCheckpointDir(config.outputDir, new StubBackend("cuda"), config.scenario);
+    const checkpointDir = ensureCheckpointDir(config.outputDir, new StubBackend("opd"), config.scenario);
     expect(existsSync(checkpointDir)).toBe(true);
 
     writeTrainingManifest(checkpointDir, config, 2, 1);
@@ -59,6 +60,7 @@ describe("training checkpoint workflow", () => {
       datasetSize: 2,
       heldOutSize: 1,
       opdDiagnostics: true,
+      opdPressureMode: "sample_positive",
     });
 
     const executorResult = await defaultExecutor(config, checkpointDir);
@@ -88,6 +90,7 @@ describe("training checkpoint workflow", () => {
       activationState: "candidate",
       datasetSize: 2,
       heldOutSize: 1,
+      opdPressureMode: "sample_positive",
     });
     expect(existsSync(join(checkpointDir, "artifact.json"))).toBe(true);
     expect(existsSync(join(checkpointDir, "promotion_state.json"))).toBe(true);


### PR DESCRIPTION
## Summary

- Adds OPD pressure mode vocabulary and validation for `full_kl`, `sample_positive`, and `sample_positive_reverse_negative`.
- Threads `--opd-pressure-mode` through Python/TypeScript train CLI planning, subprocess execution, summaries, manifests, artifacts, and registry metadata.
- Adds pressure-mode metrics: selected mode, positive/negative sampled-token fractions, and mean masked loss.
- Documents the experimental OPD-only modes.

## Tests

- `autocontext/.venv/bin/python -m pytest autocontext/tests/test_opd_pressure_modes.py autocontext/tests/test_train_summary.py autocontext/tests/test_training_runner.py autocontext/tests/test_module_size_limits.py autocontext/tests/test_package_boundaries.py -q`
- `cd autocontext && ../autocontext/.venv/bin/python -m ruff check src/autocontext/training/autoresearch/opd_pressure.py src/autocontext/training/autoresearch/on_policy_distill.py src/autocontext/training/autoresearch/train.py src/autocontext/training/runner.py src/autocontext/cli_train.py tests/test_opd_pressure_modes.py tests/test_train_summary.py tests/test_training_runner.py`
- `cd autocontext && ../autocontext/.venv/bin/python -m mypy src/autocontext/training/autoresearch/opd_pressure.py src/autocontext/training/autoresearch/on_policy_distill.py src/autocontext/training/autoresearch/train.py src/autocontext/training/runner.py src/autocontext/cli_train.py tests/test_opd_pressure_modes.py tests/test_train_summary.py tests/test_training_runner.py`
- `cd ts && npm test -- tests/train-command-workflow.test.ts tests/training-checkpoint-workflow.test.ts tests/training-config-workflow.test.ts`
- `cd ts && npm run lint`

## Notes

- `autocontext/tests/test_on_policy_distill.py` skips locally because MLX is not installed in this venv.
- `ts/tests/package-export-catalogs.test.ts` has one local environment failure from `isolated-vm` lacking a native build for Node 23/darwin-arm64; unrelated to this change.
