### PR TITLE
AC-835 Training pipeline larger CUDA model plans

### DIFF
--- a/autocontext/docs/mlx-training.md
+++ b/autocontext/docs/mlx-training.md
@@ -249,6 +249,16 @@ uv run autoctx train --backend trl --trl-mode grpo \
   --scenario antichain_diverse \
   --base-model Qwen/Qwen2.5-1.5B-Instruct \
   --grpo-beta 0.0
+
+# Larger CUDA/QLoRA RLVR profile (defaults stay small; this is opt-in)
+uv run autoctx train --scale-profile cuda_qlora_7b_rlvr \
+  --scenario antichain_diverse \
+  --data /absolute/path/to/training/antichain.jsonl
+
+# Sharded GKD/distillation profile for larger student/base runs
+uv run autoctx train --scale-profile cuda_sharded_32b_distill \
+  --scenario antichain_diverse \
+  --data /absolute/path/to/training/antichain.jsonl
 ```
 
 Notes:
@@ -265,7 +275,17 @@ Notes:
   result above (that case study predates this default). Negative values are rejected.
 - Models are HuggingFace repo ids (e.g. `Qwen/Qwen2.5-1.5B-Instruct`), not the MLX 4-bit
   community repos. `--base-model` is the student; `--teacher-model` (gkd) must share the
-  student's tokenizer. LoRA (PEFT) is applied automatically.
+  student's tokenizer. LoRA (PEFT) is applied automatically. API/hosted teachers are supported
+  for build-time trace collection via `trace_collector.collect()`; token-level GKD/OPD still
+  requires local/open-weights teacher logits.
+- `--scale-profile cuda_qlora_7b_rlvr` selects TRL GRPO with `Qwen/Qwen2.5-7B-Instruct`,
+  NF4 QLoRA loading, and 24 GB target VRAM metadata. `cuda_sharded_32b_distill` selects
+  TRL GKD with a 32B student, 72B teacher, NF4 loading, and a generated DeepSpeed ZeRO-3
+  config for multi-GPU runs. Override individual knobs (`--base-model`, `--device-count`,
+  `--sharding-strategy`, etc.) when your host differs.
+- `--base-model-quantization nf4` enables 4-bit QLoRA model loading for TRL. `--device-count`
+  above 1 sets `device_map=auto`; `--sharding-strategy fsdp` passes `fsdp=full_shard`, and
+  `--sharding-strategy deepspeed_zero3` writes a `deepspeed_zero3.json` config in the output dir.
 - `--time-budget` is enforced via a training callback that stops at the next step boundary.
 
 ### Token-pressure diagnostics (optional)

--- a/autocontext/src/autocontext/cli_train.py
+++ b/autocontext/src/autocontext/cli_train.py
@@ -17,6 +17,7 @@ from rich.table import Table  # type: ignore[import-not-found]
 from autocontext.training.autoresearch.opd_pressure import normalize_opd_pressure_mode
 from autocontext.training.autoresearch.r1_pipeline import run_r1_pipeline
 from autocontext.training.autoresearch.sequence_format import BASE_VOCAB_SIZE
+from autocontext.training.model_defaults import get_model_scale_profile, list_model_scale_profiles
 from autocontext.training.runner import TrainingConfig, TrainingResult
 
 logger = logging.getLogger(__name__)
@@ -72,7 +73,28 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
         data: str = typer.Option("training_data.jsonl", "--data", help="Path to JSONL training data"),
         time_budget: int = typer.Option(300, "--time-budget", help="Training time budget in seconds"),
         max_experiments: int = typer.Option(0, "--max-experiments", help="Max iterations (0 = unlimited)"),
-        memory_limit: int = typer.Option(16384, "--memory-limit", help="Peak memory cap in MB"),
+        memory_limit: int = typer.Option(16384, "--memory-limit", help="Global peak memory cap in MB"),
+        scale_profile: str = typer.Option(
+            "",
+            "--scale-profile",
+            help=f"Opt-in larger-model profile: {', '.join(list_model_scale_profiles())}",
+        ),
+        device_count: int = typer.Option(1, "--device-count", help="Planned accelerator count for scaled training"),
+        sharding_strategy: str = typer.Option(
+            "none", "--sharding-strategy", help="Scaled training sharding: none | fsdp | deepspeed_zero3"
+        ),
+        per_device_memory_limit: int = typer.Option(
+            0, "--per-device-memory-limit", help="Per-device memory cap in MB (0 = global cap)"
+        ),
+        base_model_parameters: int = typer.Option(
+            0, "--base-model-parameters", help="Base/student parameter count for registry metadata"
+        ),
+        base_model_quantization: str = typer.Option(
+            "", "--base-model-quantization", help="Base/student quantization label, e.g. nf4, int4, bf16"
+        ),
+        deployment_target_vram: int = typer.Option(
+            0, "--deployment-target-vram", help="Deployment target VRAM cap in MB for registry gating"
+        ),
         backend: str = typer.Option(
             "mlx",
             "--backend",
@@ -169,8 +191,52 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             raise typer.BadParameter(f"--vocab-size must be >= 256 (the byte-level BPE base), got {vocab_size}")
         if trl_mode not in ("gkd", "grpo"):
             raise typer.BadParameter(f"--trl-mode must be gkd|grpo, got {trl_mode!r}")
+        if scale_profile:
+            try:
+                profile = get_model_scale_profile(scale_profile)
+            except ValueError as exc:
+                raise typer.BadParameter(str(exc)) from exc
+            backend = profile.get("backend", backend) if backend == "mlx" else backend
+            trl_mode = profile.get("trl_mode", trl_mode) if trl_mode == "gkd" else trl_mode
+            memory_limit = profile.get("memory_limit_mb", memory_limit) if memory_limit == 16384 else memory_limit
+            base_model = profile.get("base_model", base_model) if not base_model else base_model
+            teacher_model = profile.get("teacher_model", teacher_model) if not teacher_model else teacher_model
+            device_count = profile.get("device_count", device_count) if device_count == 1 else device_count
+            if sharding_strategy == "none":
+                sharding_strategy = profile.get("sharding_strategy", sharding_strategy)
+            per_device_memory_limit = (
+                profile.get("per_device_memory_limit_mb", per_device_memory_limit)
+                if per_device_memory_limit == 0
+                else per_device_memory_limit
+            )
+            base_model_parameters = (
+                profile.get("base_model_parameter_count", base_model_parameters)
+                if base_model_parameters == 0
+                else base_model_parameters
+            )
+            base_model_quantization = (
+                profile.get("base_model_quantization", base_model_quantization)
+                if not base_model_quantization
+                else base_model_quantization
+            )
+            deployment_target_vram = (
+                profile.get("deployment_target_vram_mb", deployment_target_vram)
+                if deployment_target_vram == 0
+                else deployment_target_vram
+            )
+
         if backend not in ("mlx", "cuda", "mlxlm", "grpo", "opd", "trl"):
             raise typer.BadParameter(f"--backend must be mlx|cuda|mlxlm|grpo|opd|trl, got {backend!r}")
+        if device_count < 1:
+            raise typer.BadParameter(f"--device-count must be >= 1, got {device_count}")
+        if sharding_strategy not in ("none", "fsdp", "deepspeed_zero3"):
+            raise typer.BadParameter("--sharding-strategy must be none|fsdp|deepspeed_zero3")
+        if per_device_memory_limit < 0:
+            raise typer.BadParameter("--per-device-memory-limit must be >= 0")
+        if base_model_parameters < 0:
+            raise typer.BadParameter("--base-model-parameters must be >= 0")
+        if deployment_target_vram < 0:
+            raise typer.BadParameter("--deployment-target-vram must be >= 0")
         try:
             opd_pressure_mode = normalize_opd_pressure_mode(opd_pressure_mode)
         except ValueError as exc:
@@ -194,6 +260,12 @@ def register_train_command(app: typer.Typer, console: Console) -> None:
             time_budget=time_budget,
             max_experiments=max_experiments,
             memory_limit_mb=memory_limit,
+            device_count=device_count,
+            sharding_strategy=sharding_strategy,
+            per_device_memory_limit_mb=per_device_memory_limit,
+            base_model_parameter_count=base_model_parameters,
+            base_model_quantization=base_model_quantization,
+            deployment_target_vram_mb=deployment_target_vram,
             backend=backend,
             train_steps=train_steps,
             learning_rate=learning_rate,

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -32,7 +32,7 @@ from autocontext.training.autoresearch.model import (  # noqa: F401
 from autocontext.training.autoresearch.opd_pressure import OPD_PRESSURE_MODE_CODES, normalize_opd_pressure_mode
 from autocontext.training.autoresearch.prepare import BASE_VOCAB_SIZE
 from autocontext.training.autoresearch.sequence_format import NUM_QUALITY_BUCKETS
-from autocontext.training.model_defaults import get_model_scale_profile, list_model_scale_profiles
+from autocontext.training.model_defaults import get_model_scale_profile
 
 logger = logging.getLogger(__name__)
 
@@ -685,17 +685,10 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--time-budget", type=int, default=300)
     parser.add_argument("--memory-limit", type=int, default=16384)
-    parser.add_argument(
-        "--scale-profile",
-        default="",
-        help=f"opt-in larger-model profile: {', '.join(list_model_scale_profiles())}",
-    )
+    parser.add_argument("--scale-profile", default="", help="opt-in larger-model profile")
     parser.add_argument("--device-count", type=int, default=1, help="trl backend: planned accelerator count")
     parser.add_argument(
-        "--sharding-strategy",
-        choices=("none", "fsdp", "deepspeed_zero3"),
-        default="none",
-        help="trl backend: sharded training strategy",
+        "--sharding-strategy", choices=("none", "fsdp", "deepspeed_zero3"), default="none", help="trl backend sharding"
     )
     parser.add_argument("--per-device-memory-limit", type=int, default=0, help="trl backend: per-device memory cap in MB")
     parser.add_argument("--base-model-quantization", default="", help="trl backend: QLoRA quantization (nf4/int4/4bit)")

--- a/autocontext/src/autocontext/training/autoresearch/train.py
+++ b/autocontext/src/autocontext/training/autoresearch/train.py
@@ -32,6 +32,7 @@ from autocontext.training.autoresearch.model import (  # noqa: F401
 from autocontext.training.autoresearch.opd_pressure import OPD_PRESSURE_MODE_CODES, normalize_opd_pressure_mode
 from autocontext.training.autoresearch.prepare import BASE_VOCAB_SIZE
 from autocontext.training.autoresearch.sequence_format import NUM_QUALITY_BUCKETS
+from autocontext.training.model_defaults import get_model_scale_profile, list_model_scale_profiles
 
 logger = logging.getLogger(__name__)
 
@@ -430,6 +431,12 @@ def run_training(
     output_dir: Path,
     time_budget: int,
     memory_limit_mb: int,
+    scale_profile: str = "",
+    device_count: int = 1,
+    sharding_strategy: str = "none",
+    per_device_memory_limit_mb: int = 0,
+    base_model_quantization: str = "",
+    deployment_target_vram_mb: int = 0,
     train_steps: int = 0,  # 0 = backend default (see _default_train_steps)
     batch_size: int = 4,
     learning_rate: float = 0.0,  # 0 = backend default (see _default_learning_rate)
@@ -461,6 +468,23 @@ def run_training(
     collect_samples_path: Path | None = None,
     backend: str = "mlx",
 ) -> dict[str, Any]:
+    if scale_profile:
+        profile = get_model_scale_profile(scale_profile)
+        backend = profile.get("backend", backend) if backend == "mlx" else backend
+        trl_mode = profile.get("trl_mode", trl_mode) if trl_mode == "gkd" else trl_mode
+        memory_limit_mb = profile.get("memory_limit_mb", memory_limit_mb) if memory_limit_mb == 16384 else memory_limit_mb
+        base_model = profile.get("base_model", base_model) if not base_model else base_model
+        teacher_model = profile.get("teacher_model", teacher_model) if not teacher_model else teacher_model
+        device_count = profile.get("device_count", device_count) if device_count == 1 else device_count
+        if sharding_strategy == "none":
+            sharding_strategy = profile.get("sharding_strategy", sharding_strategy)
+        if per_device_memory_limit_mb == 0:
+            per_device_memory_limit_mb = profile.get("per_device_memory_limit_mb", per_device_memory_limit_mb)
+        if base_model_quantization == "":
+            base_model_quantization = profile.get("base_model_quantization", base_model_quantization)
+        if deployment_target_vram_mb == 0:
+            deployment_target_vram_mb = profile.get("deployment_target_vram_mb", deployment_target_vram_mb)
+
     # Reject out-of-range curation before any work (select_top_fraction would clamp to one record).
     if not 0.0 < elite_fraction <= 1.0:
         raise ValueError(f"elite_fraction must be in (0, 1], got {elite_fraction}")
@@ -471,6 +495,12 @@ def run_training(
     # base vocab into the tokenizer (special-token ids would collide with / fall below the byte base).
     if vocab_size < 256:
         raise ValueError(f"vocab_size must be >= 256 (the byte-level BPE base), got {vocab_size}")
+    if device_count < 1:
+        raise ValueError(f"device_count must be >= 1, got {device_count}")
+    if sharding_strategy not in ("none", "fsdp", "deepspeed_zero3"):
+        raise ValueError("sharding_strategy must be none|fsdp|deepspeed_zero3")
+    if per_device_memory_limit_mb < 0 or deployment_target_vram_mb < 0:
+        raise ValueError("memory limits must be >= 0")
 
     normalized_backend = backend.strip().lower()
     opd_pressure_mode = normalize_opd_pressure_mode(opd_pressure_mode)
@@ -608,6 +638,11 @@ def run_training(
             grpo_beta=grpo_beta,
             time_budget=time_budget,
             memory_limit_mb=memory_limit_mb,
+            device_count=device_count,
+            sharding_strategy=sharding_strategy,
+            per_device_memory_limit_mb=per_device_memory_limit_mb,
+            base_model_quantization=base_model_quantization,
+            deployment_target_vram_mb=deployment_target_vram_mb,
             opd_diagnostics=opd_diagnostics,
             opd_diagnostics_debug_tokens=opd_diagnostics_debug_tokens,
         )
@@ -650,6 +685,21 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--time-budget", type=int, default=300)
     parser.add_argument("--memory-limit", type=int, default=16384)
+    parser.add_argument(
+        "--scale-profile",
+        default="",
+        help=f"opt-in larger-model profile: {', '.join(list_model_scale_profiles())}",
+    )
+    parser.add_argument("--device-count", type=int, default=1, help="trl backend: planned accelerator count")
+    parser.add_argument(
+        "--sharding-strategy",
+        choices=("none", "fsdp", "deepspeed_zero3"),
+        default="none",
+        help="trl backend: sharded training strategy",
+    )
+    parser.add_argument("--per-device-memory-limit", type=int, default=0, help="trl backend: per-device memory cap in MB")
+    parser.add_argument("--base-model-quantization", default="", help="trl backend: QLoRA quantization (nf4/int4/4bit)")
+    parser.add_argument("--deployment-target-vram", type=int, default=0, help="artifact metadata: deployment VRAM cap in MB")
     parser.add_argument("--train-steps", type=int, default=0, help="0 = backend default (8 from-scratch, 100 adapters)")
     parser.add_argument("--batch-size", type=int, default=4)
     parser.add_argument(
@@ -686,6 +736,12 @@ def main(argv: list[str] | None = None) -> int:
             output_dir=Path(args.output_dir),
             time_budget=args.time_budget,
             memory_limit_mb=args.memory_limit,
+            scale_profile=args.scale_profile,
+            device_count=args.device_count,
+            sharding_strategy=args.sharding_strategy,
+            per_device_memory_limit_mb=args.per_device_memory_limit,
+            base_model_quantization=args.base_model_quantization,
+            deployment_target_vram_mb=args.deployment_target_vram,
             train_steps=args.train_steps,
             batch_size=args.batch_size,
             learning_rate=args.learning_rate,

--- a/autocontext/src/autocontext/training/autoresearch/trl_backend.py
+++ b/autocontext/src/autocontext/training/autoresearch/trl_backend.py
@@ -17,6 +17,7 @@ pure config / dataset / reward seams). The trainer-instantiating runner imports
 
 from __future__ import annotations
 
+import json
 import time
 from importlib import import_module
 from pathlib import Path
@@ -41,6 +42,8 @@ __all__ = [
     "build_chat_dataset_rows",
     "build_gkd_config_kwargs",
     "build_grpo_config_kwargs",
+    "build_model_load_kwargs",
+    "build_parallel_training_kwargs",
     "build_prompt_dataset_rows",
     "make_reward_func",
     "make_time_budget_callback",
@@ -63,6 +66,80 @@ def _import_gkd() -> tuple[Any, Any]:
     return GKDConfig, GKDTrainer
 
 
+def build_model_load_kwargs(
+    *,
+    base_model_quantization: str = "",
+    device_count: int = 1,
+    bitsandbytes_config_cls: Any | None = None,
+) -> dict[str, Any]:
+    """Kwargs for loading larger HF models, including QLoRA 4-bit bases."""
+    quantization = base_model_quantization.strip().lower()
+    kwargs: dict[str, Any] = {}
+    if device_count > 1:
+        kwargs["device_map"] = "auto"
+    if quantization in {"", "none"}:
+        return kwargs
+    if quantization not in {"nf4", "int4", "4bit"}:
+        raise ValueError("base_model_quantization must be empty|none|nf4|int4|4bit")
+    config_cls = bitsandbytes_config_cls
+    if config_cls is None:
+        config_cls = import_module("transformers").BitsAndBytesConfig
+    kwargs["device_map"] = "auto"
+    kwargs["quantization_config"] = config_cls(
+        load_in_4bit=True,
+        bnb_4bit_quant_type="nf4" if quantization == "nf4" else "fp4",
+        bnb_4bit_use_double_quant=True,
+        bnb_4bit_compute_dtype="bfloat16",
+    )
+    return kwargs
+
+
+def build_parallel_training_kwargs(
+    *,
+    output_dir: Path,
+    device_count: int = 1,
+    sharding_strategy: str = "none",
+    per_device_memory_limit_mb: int = 0,
+) -> dict[str, Any]:
+    """Kwargs for HuggingFace/TRL sharded training arguments."""
+    strategy = sharding_strategy.strip().lower()
+    if device_count < 1:
+        raise ValueError("device_count must be >= 1")
+    if strategy == "none":
+        return {}
+    if strategy == "fsdp":
+        return {"fsdp": "full_shard"}
+    if strategy == "deepspeed_zero3":
+        config_path = output_dir / "deepspeed_zero3.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            json.dumps(
+                {
+                    "bf16": {"enabled": "auto"},
+                    "fp16": {"enabled": "auto"},
+                    "train_micro_batch_size_per_gpu": "auto",
+                    "gradient_accumulation_steps": "auto",
+                    "zero_optimization": {
+                        "stage": 3,
+                        "overlap_comm": True,
+                        "contiguous_gradients": True,
+                        "reduce_bucket_size": "auto",
+                        "stage3_prefetch_bucket_size": "auto",
+                        "stage3_param_persistence_threshold": "auto",
+                    },
+                    "autocontext": {
+                        "device_count": device_count,
+                        "per_device_memory_limit_mb": per_device_memory_limit_mb,
+                    },
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        return {"deepspeed": str(config_path)}
+    raise ValueError("sharding_strategy must be none|fsdp|deepspeed_zero3")
+
+
 def build_gkd_config_kwargs(
     *,
     output_dir: str,
@@ -76,6 +153,7 @@ def build_gkd_config_kwargs(
     max_steps: int = -1,
     per_device_train_batch_size: int = 1,
     seed: int = 0,
+    **parallel_kwargs: Any,
 ) -> dict[str, Any]:
     """Kwargs for ``trl.experimental.gkd.GKDConfig`` (on-policy distillation).
 
@@ -96,6 +174,7 @@ def build_gkd_config_kwargs(
         "max_steps": max_steps,
         "per_device_train_batch_size": per_device_train_batch_size,
         "seed": seed,
+        **parallel_kwargs,
     }
 
 
@@ -119,6 +198,7 @@ def build_grpo_config_kwargs(
     max_steps: int = -1,
     per_device_train_batch_size: int = 8,
     seed: int = 0,
+    **parallel_kwargs: Any,
 ) -> dict[str, Any]:
     """Kwargs for ``trl.GRPOConfig`` (RLVR). ``beta`` is the reference-policy KL penalty.
 
@@ -144,6 +224,7 @@ def build_grpo_config_kwargs(
         "max_steps": max_steps,
         "per_device_train_batch_size": per_device_train_batch_size,
         "seed": seed,
+        **parallel_kwargs,
     }
 
 
@@ -307,6 +388,11 @@ def run_trl_training(
     register_import: str | None = None,
     time_budget: int = 3600,
     memory_limit_mb: int = 16384,  # noqa: ARG001 - backend-signature parity
+    device_count: int = 1,
+    sharding_strategy: str = "none",
+    per_device_memory_limit_mb: int = 0,
+    base_model_quantization: str = "",
+    deployment_target_vram_mb: int = 0,  # noqa: ARG001 - recorded by runner/registry; serving gate uses metadata
 ) -> dict[str, float]:
     """Run TRL ``gkd`` (on-policy distillation) or ``grpo`` (RLVR) and return summary metrics.
 
@@ -338,6 +424,17 @@ def run_trl_training(
 
     output_dir.mkdir(parents=True, exist_ok=True)
     peft_config = LoraConfig(**_LORA)
+    model_load_kwargs = build_model_load_kwargs(
+        base_model_quantization=base_model_quantization,
+        device_count=device_count,
+    )
+    teacher_load_kwargs = {"device_map": "auto"} if device_count > 1 else {}
+    parallel_kwargs = build_parallel_training_kwargs(
+        output_dir=output_dir,
+        device_count=device_count,
+        sharding_strategy=sharding_strategy,
+        per_device_memory_limit_mb=per_device_memory_limit_mb,
+    )
     tokenizer = AutoTokenizer.from_pretrained(student_model)
     started = time.monotonic()
     callbacks = [make_time_budget_callback(float(time_budget))]
@@ -353,8 +450,8 @@ def run_trl_training(
         # per-token JSD compares logits, and same-family models can have different PADDED
         # vocab (e.g. Qwen2.5 1.5B=151936 vs 7B=152064) while their tokenizers look equal.
         # Catch it here with a clear message instead of a cryptic tensor-shape error in the loss.
-        student_lm = AutoModelForCausalLM.from_pretrained(student_model)
-        teacher_lm = AutoModelForCausalLM.from_pretrained(teacher_model)
+        student_lm = AutoModelForCausalLM.from_pretrained(student_model, **model_load_kwargs)
+        teacher_lm = AutoModelForCausalLM.from_pretrained(teacher_model, **teacher_load_kwargs)
         s_vocab = getattr(student_lm.config, "vocab_size", None)
         t_vocab = getattr(teacher_lm.config, "vocab_size", None)
         if isinstance(s_vocab, int) and isinstance(t_vocab, int):
@@ -367,6 +464,7 @@ def run_trl_training(
             learning_rate=learning_rate,
             max_steps=max_steps,
             seed=seed,
+            **parallel_kwargs,
         )
         if batch_size > 0:
             gkd_kwargs["per_device_train_batch_size"] = batch_size
@@ -391,12 +489,14 @@ def run_trl_training(
             seed=seed,
             max_completion_length=max_completion_length,
             beta=grpo_beta,
+            **parallel_kwargs,
         )
         if batch_size > 0:
             grpo_kwargs["per_device_train_batch_size"] = batch_size
         args = GRPOConfig(**build_grpo_config_kwargs(**grpo_kwargs))
+        student_lm = AutoModelForCausalLM.from_pretrained(student_model, **model_load_kwargs)
         trainer = GRPOTrainer(
-            model=student_model,
+            model=student_lm,
             args=args,
             reward_funcs=make_reward_func(scenario),
             train_dataset=dataset,

--- a/autocontext/src/autocontext/training/model_defaults.py
+++ b/autocontext/src/autocontext/training/model_defaults.py
@@ -9,6 +9,8 @@ one the training subprocess trains against (a mismatch would serve the adapter o
 
 from __future__ import annotations
 
+from typing import Any
+
 # mlx-lm LoRA SFT (mlxlm backend).
 MLXLM_DEFAULT_BASE_MODEL = "mlx-community/Qwen2.5-0.5B-Instruct-4bit"
 
@@ -18,3 +20,45 @@ GRPO_DEFAULT_BASE_MODEL = "mlx-community/Qwen2.5-1.5B-Instruct-4bit"
 # mlx-lm on-policy distillation (opd backend): student is the trained model, teacher is frozen.
 OPD_DEFAULT_STUDENT_MODEL = "mlx-community/Qwen2.5-1.5B-Instruct-4bit"
 OPD_DEFAULT_TEACHER_MODEL = "mlx-community/Qwen2.5-3B-Instruct-4bit"
+
+# Opt-in larger CUDA/TRL profiles. Defaults stay local/small; profiles make the larger
+# student/base plan one flag instead of a pile of fragile knobs.
+MODEL_SCALE_PROFILES: dict[str, dict[str, Any]] = {
+    "cuda_qlora_7b_rlvr": {
+        "backend": "trl",
+        "trl_mode": "grpo",
+        "base_model": "Qwen/Qwen2.5-7B-Instruct",
+        "teacher_model": "Qwen/Qwen2.5-14B-Instruct",
+        "base_model_parameter_count": 7_000_000_000,
+        "base_model_quantization": "nf4",
+        "memory_limit_mb": 24_576,
+        "device_count": 1,
+        "sharding_strategy": "none",
+        "per_device_memory_limit_mb": 24_576,
+        "deployment_target_vram_mb": 24_576,
+    },
+    "cuda_sharded_32b_distill": {
+        "backend": "trl",
+        "trl_mode": "gkd",
+        "base_model": "Qwen/Qwen2.5-32B-Instruct",
+        "teacher_model": "Qwen/Qwen2.5-72B-Instruct",
+        "base_model_parameter_count": 32_000_000_000,
+        "base_model_quantization": "nf4",
+        "memory_limit_mb": 98_304,
+        "device_count": 4,
+        "sharding_strategy": "deepspeed_zero3",
+        "per_device_memory_limit_mb": 24_576,
+        "deployment_target_vram_mb": 24_576,
+    },
+}
+
+
+def list_model_scale_profiles() -> list[str]:
+    return sorted(MODEL_SCALE_PROFILES)
+
+
+def get_model_scale_profile(name: str) -> dict[str, Any]:
+    try:
+        return dict(MODEL_SCALE_PROFILES[name])
+    except KeyError as exc:
+        raise ValueError(f"unknown model scale profile {name!r}; expected one of {list_model_scale_profiles()}") from exc

--- a/autocontext/src/autocontext/training/model_registry.py
+++ b/autocontext/src/autocontext/training/model_registry.py
@@ -133,10 +133,7 @@ class ModelRegistry:
         return DistilledModelRecord.from_dict(read_json(path))
 
     def list_all(self) -> list[DistilledModelRecord]:
-        return [
-            DistilledModelRecord.from_dict(read_json(p))
-            for p in sorted(self._dir.glob("*.json"))
-        ]
+        return [DistilledModelRecord.from_dict(read_json(p)) for p in sorted(self._dir.glob("*.json"))]
 
     def list_for_scenario(self, scenario: str) -> list[DistilledModelRecord]:
         return [r for r in self.list_all() if r.scenario == scenario]
@@ -170,12 +167,25 @@ class ModelRegistry:
         self.register(rec)
 
 
+def _fits_deployment_target(record: DistilledModelRecord, deployment_target_vram_mb: int) -> bool:
+    if deployment_target_vram_mb <= 0:
+        return True
+    scale = record.metadata.get("training_scale") if isinstance(record.metadata, dict) else None
+    required = scale.get("deployment_target_vram_mb", 0) if isinstance(scale, dict) else 0
+    try:
+        required_vram = int(required or 0)
+    except (TypeError, ValueError):
+        return False
+    return required_vram <= 0 or required_vram <= deployment_target_vram_mb
+
+
 def resolve_model(
     registry: ModelRegistry,
     scenario: str,
     backend: str,
     runtime_type: str = "provider",
     manual_override: str | None = None,
+    deployment_target_vram_mb: int = 0,
 ) -> DistilledModelRecord | None:
     """Resolve the active model for a scenario/backend/runtime combination.
 
@@ -199,6 +209,7 @@ def resolve_model(
             rec.backend == backend
             and rec.activation_state == "active"
             and (not rec.runtime_types or runtime_type in rec.runtime_types)
+            and _fits_deployment_target(rec, deployment_target_vram_mb)
         ):
             return rec
 
@@ -227,7 +238,7 @@ def publish_training_output(
         version=1,
         scenario=completion.scenario,
         compatible_scenarios=[completion.scenario],
-        tags=[completion.backend, *( [completion.scenario_family] if completion.scenario_family else [] )],
+        tags=[completion.backend, *([completion.scenario_family] if completion.scenario_family else [])],
         provenance=ArtifactProvenance(
             run_id=completion.run_id,
             generation=0,

--- a/autocontext/src/autocontext/training/runner.py
+++ b/autocontext/src/autocontext/training/runner.py
@@ -29,6 +29,7 @@ from autocontext.training.model_registry import (
     TrainingCompletionOutput,
     publish_training_output,
 )
+from autocontext.training.scale import training_scale_metadata_from_config
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,12 @@ class TrainingConfig:
     time_budget: int = 300
     max_experiments: int = 0
     memory_limit_mb: int = 16384
+    device_count: int = 1
+    sharding_strategy: str = "none"
+    per_device_memory_limit_mb: int = 0
+    base_model_parameter_count: int = 0
+    base_model_quantization: str = ""
+    deployment_target_vram_mb: int = 0
     backend: str = "mlx"
     train_steps: int = 0  # 0 = backend default (8 from-scratch mlx/cuda, 100 pretrained-adapter backends)
     learning_rate: float = 0.0  # 0 = backend default (1e-3 from-scratch, 1e-4 mlxlm, 1e-5 opd/grpo/trl)
@@ -416,6 +423,14 @@ class TrainingRunner:
             command += ["--train-steps", str(self.config.train_steps)]
         if self.config.learning_rate > 0:
             command += ["--learning-rate", str(self.config.learning_rate)]
+        if self.config.device_count != 1:
+            command += ["--device-count", str(self.config.device_count)]
+        if self.config.sharding_strategy != "none":
+            command += ["--sharding-strategy", self.config.sharding_strategy]
+        if self.config.per_device_memory_limit_mb != 0:
+            command += ["--per-device-memory-limit", str(self.config.per_device_memory_limit_mb)]
+        if self.config.deployment_target_vram_mb != 0:
+            command += ["--deployment-target-vram", str(self.config.deployment_target_vram_mb)]
         if self.config.val_select:
             command.append("--val-select")
         if self.config.elite_fraction != 1.0:
@@ -436,6 +451,8 @@ class TrainingRunner:
             command += ["--vocab-size", str(self.config.vocab_size)]
         if self.config.base_model:
             command += ["--base-model", self.config.base_model]
+        if self.config.base_model_quantization:
+            command += ["--base-model-quantization", self.config.base_model_quantization]
         if self.config.teacher_model:
             command += ["--teacher-model", self.config.teacher_model]
         if self.config.trl_mode != "gkd":
@@ -692,6 +709,7 @@ class TrainingRunner:
                 # effective default when no explicit --base-model was given, since the
                 # subprocess applies that same default (an empty value is unservable).
                 "base_model": self.config.base_model or self._backend.default_base_model(),
+                "training_scale": training_scale_metadata_from_config(self.config),
                 "score_conditioned": self.config.score_conditioned,
                 "opd_diagnostics": diagnostics_written,
                 "opd_pressure_mode": self.config.opd_pressure_mode,

--- a/autocontext/src/autocontext/training/scale.py
+++ b/autocontext/src/autocontext/training/scale.py
@@ -1,0 +1,60 @@
+"""Training scale metadata for larger-model pipeline planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+_VALID_SHARDING = frozenset({"none", "fsdp", "deepspeed_zero3"})
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingScaleProfile:
+    """Hardware/model scale intent recorded with trained artifacts."""
+
+    device_count: int = 1
+    sharding_strategy: str = "none"
+    memory_limit_mb: int = 16384
+    per_device_memory_limit_mb: int = 0
+    base_model_parameter_count: int = 0
+    base_model_quantization: str = ""
+    deployment_target_vram_mb: int = 0
+
+    def __post_init__(self) -> None:
+        if self.device_count < 1:
+            raise ValueError("device_count must be >= 1")
+        if self.sharding_strategy not in _VALID_SHARDING:
+            raise ValueError(f"sharding_strategy must be one of {sorted(_VALID_SHARDING)}")
+        for field_name in (
+            "memory_limit_mb",
+            "per_device_memory_limit_mb",
+            "base_model_parameter_count",
+            "deployment_target_vram_mb",
+        ):
+            if getattr(self, field_name) < 0:
+                raise ValueError(f"{field_name} must be >= 0")
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "device_count": self.device_count,
+            "sharding_strategy": self.sharding_strategy,
+            "memory_limit_mb": self.memory_limit_mb,
+            "per_device_memory_limit_mb": self.per_device_memory_limit_mb or self.memory_limit_mb,
+            "base_model_parameter_count": self.base_model_parameter_count,
+            "base_model_quantization": self.base_model_quantization,
+            "deployment_target_vram_mb": self.deployment_target_vram_mb,
+        }
+
+
+def training_scale_metadata_from_config(config: Any) -> dict[str, Any]:
+    """Return registry-safe scale metadata from a training config object."""
+    profile = TrainingScaleProfile(
+        device_count=int(getattr(config, "device_count", 1)),
+        sharding_strategy=str(getattr(config, "sharding_strategy", "none")),
+        memory_limit_mb=int(getattr(config, "memory_limit_mb", 16384)),
+        per_device_memory_limit_mb=int(getattr(config, "per_device_memory_limit_mb", 0)),
+        base_model_parameter_count=int(getattr(config, "base_model_parameter_count", 0)),
+        base_model_quantization=str(getattr(config, "base_model_quantization", "")),
+        deployment_target_vram_mb=int(getattr(config, "deployment_target_vram_mb", 0)),
+    )
+    return profile.to_metadata()

--- a/autocontext/tests/test_model_registry.py
+++ b/autocontext/tests/test_model_registry.py
@@ -195,7 +195,9 @@ class TestResolveModel:
         registry.register(_record(artifact_id="a1", scenario="grid_ctf", activation_state="active"))
 
         result = resolve_model(
-            registry, scenario="grid_ctf", backend="mlx",
+            registry,
+            scenario="grid_ctf",
+            backend="mlx",
             manual_override="a-override",
         )
         assert result is not None
@@ -220,6 +222,38 @@ class TestResolveModel:
         result = resolve_model(registry, scenario="grid_ctf", backend="cuda")
         assert result is not None
         assert result.artifact_id == "cuda-1"
+
+    def test_filters_by_deployment_target_vram(self, tmp_path: Path) -> None:
+        from autocontext.training.model_registry import ModelRegistry, resolve_model
+
+        registry = ModelRegistry(tmp_path)
+        registry.register(
+            _record(
+                artifact_id="a-large",
+                scenario="grid_ctf",
+                backend="cuda",
+                activation_state="active",
+                metadata={"training_scale": {"deployment_target_vram_mb": 24_576}},
+            )
+        )
+        registry.register(
+            _record(
+                artifact_id="b-small",
+                scenario="grid_ctf",
+                backend="cuda",
+                activation_state="active",
+                metadata={"training_scale": {"deployment_target_vram_mb": 16_384}},
+            )
+        )
+
+        result = resolve_model(
+            registry,
+            scenario="grid_ctf",
+            backend="cuda",
+            deployment_target_vram_mb=16_384,
+        )
+        assert result is not None
+        assert result.artifact_id == "b-small"
 
 
 # ===========================================================================

--- a/autocontext/tests/test_training_runner.py
+++ b/autocontext/tests/test_training_runner.py
@@ -13,6 +13,7 @@ import pytest
 from typer.testing import CliRunner
 
 from autocontext.config.settings import AppSettings
+from autocontext.training.model_defaults import get_model_scale_profile, list_model_scale_profiles
 from autocontext.training.runner import (
     ExperimentOutcome,
     ExperimentResult,
@@ -20,6 +21,7 @@ from autocontext.training.runner import (
     TrainingResult,
     TrainingRunner,
 )
+from autocontext.training.scale import training_scale_metadata_from_config
 
 # ---------------------------------------------------------------------------
 # TrainingConfig
@@ -35,6 +37,12 @@ class TestTrainingConfig:
         assert cfg.max_experiments == 0
         assert cfg.memory_limit_mb == 16384
         assert cfg.backend == "mlx"
+        assert cfg.device_count == 1
+        assert cfg.sharding_strategy == "none"
+        assert cfg.per_device_memory_limit_mb == 0
+        assert cfg.base_model_parameter_count == 0
+        assert cfg.base_model_quantization == ""
+        assert cfg.deployment_target_vram_mb == 0
         assert cfg.agent_provider == "anthropic"
         assert cfg.agent_model == ""
         assert cfg.val_select is False
@@ -55,6 +63,39 @@ class TestTrainingConfig:
         assert cfg.max_experiments == 50
         assert cfg.memory_limit_mb == 8192
         assert cfg.backend == "cuda"
+
+    def test_known_large_model_profiles_are_opt_in(self) -> None:
+        assert "cuda_qlora_7b_rlvr" in list_model_scale_profiles()
+        profile = get_model_scale_profile("cuda_sharded_32b_distill")
+        assert profile["backend"] == "trl"
+        assert profile["trl_mode"] == "gkd"
+        assert profile["base_model_parameter_count"] == 32_000_000_000
+        assert profile["base_model_quantization"] == "nf4"
+        assert profile["memory_limit_mb"] == 98_304
+        assert profile["sharding_strategy"] == "deepspeed_zero3"
+
+    def test_training_scale_metadata_records_larger_model_hardware_plan(self) -> None:
+        cfg = TrainingConfig(
+            scenario="arc_agi_3",
+            data_path=Path("train.jsonl"),
+            memory_limit_mb=65_536,
+            device_count=4,
+            sharding_strategy="fsdp",
+            per_device_memory_limit_mb=16_384,
+            base_model_parameter_count=32_000_000_000,
+            base_model_quantization="nf4",
+            deployment_target_vram_mb=16_384,
+        )
+
+        assert training_scale_metadata_from_config(cfg) == {
+            "device_count": 4,
+            "sharding_strategy": "fsdp",
+            "memory_limit_mb": 65_536,
+            "per_device_memory_limit_mb": 16_384,
+            "base_model_parameter_count": 32_000_000_000,
+            "base_model_quantization": "nf4",
+            "deployment_target_vram_mb": 16_384,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -324,6 +365,30 @@ class TestConstraints:
         command = mock_run.call_args.args[0]
         seed_index = command.index("--seed")
         assert command[seed_index + 1] == "7"
+
+    def test_experiment_subprocess_passes_scale_plan_flags(self, tmp_path: Path) -> None:
+        cfg = TrainingConfig(
+            scenario="grid_ctf",
+            data_path=tmp_path / "data.jsonl",
+            backend="trl",
+            device_count=4,
+            sharding_strategy="fsdp",
+            per_device_memory_limit_mb=16_384,
+            base_model_quantization="nf4",
+            deployment_target_vram_mb=16_384,
+        )
+        (tmp_path / "data.jsonl").write_text("{}\n")
+        runner = TrainingRunner(cfg, work_dir=tmp_path / "workspace")
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("autocontext.training.runner.subprocess.run", return_value=completed) as mock_run:
+            runner._run_experiment_subprocess(0)
+
+        command = mock_run.call_args.args[0]
+        assert command[command.index("--device-count") + 1] == "4"
+        assert command[command.index("--sharding-strategy") + 1] == "fsdp"
+        assert command[command.index("--per-device-memory-limit") + 1] == "16384"
+        assert command[command.index("--base-model-quantization") + 1] == "nf4"
+        assert command[command.index("--deployment-target-vram") + 1] == "16384"
 
     def test_experiment_subprocess_passes_max_completion_length_when_overridden(self, tmp_path: Path) -> None:
         """A GRPO completion-length override must reach the subprocess (so the public `autoctx train`
@@ -678,6 +743,8 @@ class TestTrainingLoop:
         assert registry_record["backend"] == "mlx"
         assert registry_record["runtime_types"] == ["provider", "pi"]
         assert registry_record["training_metrics"]["token_pressure_positive_ratio"] == 0.75
+        assert registry_record["metadata"]["training_scale"]["device_count"] == 1
+        assert registry_record["metadata"]["training_scale"]["memory_limit_mb"] == 16384
         assert registry_record["metadata"]["opd_diagnostics"] is True
         assert registry_record["metadata"]["opd_diagnostics_path"] == str(checkpoint_path / "token_pressure_diagnostics.json")
 
@@ -846,6 +913,18 @@ class TestTrainCLI:
                     "50",
                     "--memory-limit",
                     "8192",
+                    "--device-count",
+                    "4",
+                    "--sharding-strategy",
+                    "fsdp",
+                    "--per-device-memory-limit",
+                    "2048",
+                    "--base-model-parameters",
+                    "7000000000",
+                    "--base-model-quantization",
+                    "nf4",
+                    "--deployment-target-vram",
+                    "16384",
                     "--backend",
                     "cuda",
                     "--agent-provider",
@@ -862,9 +941,40 @@ class TestTrainCLI:
             assert call_cfg.time_budget == 600
             assert call_cfg.max_experiments == 50
             assert call_cfg.memory_limit_mb == 8192
+            assert call_cfg.device_count == 4
+            assert call_cfg.sharding_strategy == "fsdp"
+            assert call_cfg.per_device_memory_limit_mb == 2048
+            assert call_cfg.base_model_parameter_count == 7_000_000_000
+            assert call_cfg.base_model_quantization == "nf4"
+            assert call_cfg.deployment_target_vram_mb == 16384
             assert call_cfg.backend == "cuda"
             assert call_cfg.agent_provider == "deterministic"
             assert call_cfg.agent_model == "custom-model"
+
+    def test_scale_profile_reaches_config(self) -> None:
+        from autocontext.cli import app
+
+        runner = CliRunner()
+        with patch("autocontext.cli_train._run_training") as mock_run:
+            mock_run.return_value = TrainingResult(
+                scenario="grid_ctf",
+                total_experiments=1,
+                kept_count=1,
+                discarded_count=0,
+                best_score=0.5,
+                best_experiment_index=0,
+                checkpoint_path=Path("/tmp/best"),
+                results=[],
+            )
+            result = runner.invoke(app, ["train", "--scenario", "grid_ctf", "--scale-profile", "cuda_qlora_7b_rlvr"])
+            assert result.exit_code == 0, result.output
+            call_cfg = mock_run.call_args[0][0]
+            assert call_cfg.backend == "trl"
+            assert call_cfg.trl_mode == "grpo"
+            assert call_cfg.base_model == "Qwen/Qwen2.5-7B-Instruct"
+            assert call_cfg.memory_limit_mb == 24_576
+            assert call_cfg.base_model_quantization == "nf4"
+            assert call_cfg.deployment_target_vram_mb == 24_576
 
     def test_loss_weight_options_reach_config(self) -> None:
         from autocontext.cli import app

--- a/autocontext/tests/test_trl_backend.py
+++ b/autocontext/tests/test_trl_backend.py
@@ -127,8 +127,80 @@ def test_config_kwargs_thread_seed_for_reproducible_repeats() -> None:
     assert build_grpo_config_kwargs(output_dir="/o", seed=5)["seed"] == 5
 
 
-def test_run_training_forwards_seed_to_trl_backend(monkeypatch, tmp_path) -> None:
-    """The PUBLIC runner path must forward seed: run_training(backend='trl', seed=N) -> run_trl_training(seed=N).
+def test_quantized_model_load_kwargs_enable_qlora_without_importing_transformers() -> None:
+    from autocontext.training.autoresearch.trl_backend import build_model_load_kwargs
+
+    class BitsAndBytesConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    kwargs = build_model_load_kwargs(
+        base_model_quantization="nf4",
+        device_count=4,
+        bitsandbytes_config_cls=BitsAndBytesConfig,
+    )
+
+    assert kwargs["device_map"] == "auto"
+    assert kwargs["quantization_config"].kwargs == {
+        "load_in_4bit": True,
+        "bnb_4bit_quant_type": "nf4",
+        "bnb_4bit_use_double_quant": True,
+        "bnb_4bit_compute_dtype": "bfloat16",
+    }
+
+
+def test_parallel_training_kwargs_write_sharded_training_configs(tmp_path: Any) -> None:
+    import json
+
+    from autocontext.training.autoresearch.trl_backend import build_parallel_training_kwargs
+
+    fsdp = build_parallel_training_kwargs(output_dir=tmp_path, device_count=4, sharding_strategy="fsdp")
+    assert fsdp == {"fsdp": "full_shard"}
+
+    deepspeed = build_parallel_training_kwargs(
+        output_dir=tmp_path,
+        device_count=8,
+        sharding_strategy="deepspeed_zero3",
+        per_device_memory_limit_mb=24_576,
+    )
+    path = tmp_path / "deepspeed_zero3.json"
+    assert deepspeed == {"deepspeed": str(path)}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["zero_optimization"]["stage"] == 3
+    assert data["autocontext"]["device_count"] == 8
+    assert data["autocontext"]["per_device_memory_limit_mb"] == 24_576
+
+
+def test_run_training_scale_profile_reaches_trl_backend(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    import autocontext.training.autoresearch.train as train_mod
+    import autocontext.training.autoresearch.trl_backend as trl_mod
+
+    captured: dict = {}
+    monkeypatch.setattr(train_mod, "_preflight_backend_deps", lambda backend: None)
+    monkeypatch.setattr(
+        trl_mod,
+        "run_trl_training",
+        lambda **kw: captured.update(kw) or {"avg_score": 0.0, "valid_rate": 1.0},
+    )
+
+    train_mod.run_training(
+        scenario_name="grid_ctf",
+        data_path=tmp_path / "d.jsonl",
+        output_dir=tmp_path / "o",
+        time_budget=10,
+        memory_limit_mb=1024,
+        scale_profile="cuda_sharded_32b_distill",
+    )
+
+    assert captured["mode"] == "gkd"
+    assert captured["student_model"] == "Qwen/Qwen2.5-32B-Instruct"
+    assert captured["base_model_quantization"] == "nf4"
+    assert captured["device_count"] == 4
+    assert captured["sharding_strategy"] == "deepspeed_zero3"
+
+
+def test_run_training_forwards_scale_plan_to_trl_backend(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    """The PUBLIC runner path must forward seed + larger-model knobs to TRL.
     (CI-safe: preflight + the trl runner are patched, so no torch/trl needed.)"""
     import autocontext.training.autoresearch.train as train_mod
     import autocontext.training.autoresearch.trl_backend as trl_mod
@@ -149,8 +221,18 @@ def test_run_training_forwards_seed_to_trl_backend(monkeypatch, tmp_path) -> Non
         memory_limit_mb=1024,
         backend="trl",
         seed=7,
+        device_count=4,
+        sharding_strategy="fsdp",
+        per_device_memory_limit_mb=16_384,
+        base_model_quantization="nf4",
+        deployment_target_vram_mb=16_384,
     )
     assert captured["seed"] == 7
+    assert captured["device_count"] == 4
+    assert captured["sharding_strategy"] == "fsdp"
+    assert captured["per_device_memory_limit_mb"] == 16_384
+    assert captured["base_model_quantization"] == "nf4"
+    assert captured["deployment_target_vram_mb"] == 16_384
 
 
 # ---------------------------------------------------------------------------
@@ -233,7 +315,7 @@ def test_reward_func_scores_against_per_instance_answer() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_import_gkd_prefers_experimental_then_falls_back(monkeypatch) -> None:
+def test_import_gkd_prefers_experimental_then_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
     """The GKD class resolver tries trl.experimental.gkd first, then top-level trl, so the
     GKD arm survives TRL's cross-version layout differences (stubbed; no real trl)."""
     import sys

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -1266,7 +1266,13 @@ async function cmdStatus(dbPath: string): Promise<void> {
   const runtimeSession = await loadRuntimeSessionSummaryForRun(dbPath, runId);
   const progressReport = await loadProgressReportForRun(run);
   console.log(
-    renderRunStatus(run, store.getGenerations(runId), !!values.json, runtimeSession, progressReport),
+    renderRunStatus(
+      run,
+      store.getGenerations(runId),
+      !!values.json,
+      runtimeSession,
+      progressReport,
+    ),
   );
   store.close();
 }
@@ -1655,7 +1661,12 @@ async function loadProgressReportForRun(run: { run_id: string; scenario: string 
   const { loadSettings } = await import("../config/index.js");
   const { parseRunProgressReport } = await import("../analytics/progress-report.js");
   const settings = loadSettings();
-  const path = join(resolve(settings.knowledgeRoot), run.scenario, "progress_reports", `${run.run_id}.json`);
+  const path = join(
+    resolve(settings.knowledgeRoot),
+    run.scenario,
+    "progress_reports",
+    `${run.run_id}.json`,
+  );
   if (!existsSync(path)) return null;
   try {
     return parseRunProgressReport(JSON.parse(readFileSync(path, "utf-8")) as unknown);
@@ -3338,10 +3349,19 @@ async function cmdTrain(): Promise<void> {
       backend: { type: "string", default: "cuda" },
       mode: { type: "string", default: "from_scratch" },
       "base-model": { type: "string" },
+      "teacher-model": { type: "string" },
+      "scale-profile": { type: "string" },
+      "memory-limit": { type: "string" },
       output: { type: "string", short: "o" },
       "opd-diagnostics": { type: "boolean" },
       "opd-diagnostics-debug-tokens": { type: "boolean" },
       "opd-pressure-mode": { type: "string" },
+      "device-count": { type: "string" },
+      "sharding-strategy": { type: "string" },
+      "per-device-memory-limit": { type: "string" },
+      "base-model-parameters": { type: "string" },
+      "base-model-quantization": { type: "string" },
+      "deployment-target-vram": { type: "string" },
       json: { type: "boolean" },
       help: { type: "boolean", short: "h" },
     },

--- a/ts/src/cli/index.ts
+++ b/ts/src/cli/index.ts
@@ -3339,36 +3339,17 @@ async function cmdContextSelection(): Promise<void> {
 
 async function cmdTrain(): Promise<void> {
   const { parseArgs } = await import("node:util");
+  const {
+    executeTrainCommandWorkflow,
+    planTrainCommand,
+    renderTrainSuccess,
+    TRAIN_COMMAND_PARSE_OPTIONS,
+    TRAIN_HELP_TEXT,
+  } = await import("./train-command-workflow.js");
   const { values } = parseArgs({
     args: process.argv.slice(3),
-    options: {
-      scenario: { type: "string", short: "s" },
-      family: { type: "string" },
-      dataset: { type: "string", short: "d" },
-      "held-out": { type: "string" },
-      backend: { type: "string", default: "cuda" },
-      mode: { type: "string", default: "from_scratch" },
-      "base-model": { type: "string" },
-      "teacher-model": { type: "string" },
-      "scale-profile": { type: "string" },
-      "memory-limit": { type: "string" },
-      output: { type: "string", short: "o" },
-      "opd-diagnostics": { type: "boolean" },
-      "opd-diagnostics-debug-tokens": { type: "boolean" },
-      "opd-pressure-mode": { type: "string" },
-      "device-count": { type: "string" },
-      "sharding-strategy": { type: "string" },
-      "per-device-memory-limit": { type: "string" },
-      "base-model-parameters": { type: "string" },
-      "base-model-quantization": { type: "string" },
-      "deployment-target-vram": { type: "string" },
-      json: { type: "boolean" },
-      help: { type: "boolean", short: "h" },
-    },
+    options: TRAIN_COMMAND_PARSE_OPTIONS,
   });
-
-  const { executeTrainCommandWorkflow, planTrainCommand, renderTrainSuccess, TRAIN_HELP_TEXT } =
-    await import("./train-command-workflow.js");
 
   if (values.help) {
     console.log(TRAIN_HELP_TEXT);

--- a/ts/src/cli/train-command-workflow.ts
+++ b/ts/src/cli/train-command-workflow.ts
@@ -1,3 +1,5 @@
+import { getModelScaleProfile, listModelScaleProfiles } from "../training/model-defaults.js";
+
 export const TRAIN_HELP_TEXT = `autoctx train — train a distilled model from curated dataset
 
 Usage: autoctx train --scenario <name> --dataset <path> [options]
@@ -10,10 +12,15 @@ Options:
   --backend <name>         Training backend: cuda, mlx (default: cuda)
   --mode <mode>            from_scratch, adapter_finetune, full_finetune
   --base-model <id>        Base model for adapter/full fine-tune
+  --teacher-model <id>     Teacher model for TRL distillation
+  --scale-profile <name>   Opt-in larger-model profile: ${listModelScaleProfiles().join(", ")}
+  --memory-limit <mb>      Global training memory budget in MB
   -o, --output <dir>       Output directory
   --opd-diagnostics        Write OPD/GKD token-pressure diagnostics
   --opd-diagnostics-debug-tokens  Include raw sampled token text in diagnostics
   --opd-pressure-mode <mode>  OPD pressure mode: full_kl, sample_positive, sample_positive_reverse_negative
+  --device-count <n>       Planned accelerator count for scaled training
+  --sharding-strategy <s>  Sharding strategy: none, fsdp, deepspeed_zero3
   --json                   Output as JSON
   -h, --help               Show this help
 
@@ -22,12 +29,24 @@ Notes:
   For end-to-end local training, prefer the Python package's \`autoctx train\` command.`;
 
 export type OpdPressureMode = "full_kl" | "sample_positive" | "sample_positive_reverse_negative";
+export type TrainingShardingStrategy = "none" | "fsdp" | "deepspeed_zero3";
 
 const OPD_PRESSURE_MODES = [
   "full_kl",
   "sample_positive",
   "sample_positive_reverse_negative",
 ] as const;
+
+function parseOptionalNumber(value: number | string | undefined, name: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${name} must be >= 0`);
+  }
+  return parsed;
+}
 
 function normalizeOpdPressureMode(value: string | undefined): OpdPressureMode {
   const mode = value ?? "full_kl";
@@ -47,10 +66,19 @@ export interface TrainCommandValues {
   backend?: string;
   mode?: string;
   "base-model"?: string;
+  "teacher-model"?: string;
+  "scale-profile"?: string;
+  "memory-limit"?: number | string;
   output?: string;
   "opd-diagnostics"?: boolean;
   "opd-diagnostics-debug-tokens"?: boolean;
   "opd-pressure-mode"?: string;
+  "device-count"?: number | string;
+  "sharding-strategy"?: string;
+  "per-device-memory-limit"?: number | string;
+  "base-model-parameters"?: number | string;
+  "base-model-quantization"?: string;
+  "deployment-target-vram"?: number | string;
   json?: boolean;
 }
 
@@ -63,9 +91,18 @@ export interface TrainCommandPlan {
   backend: string;
   trainingMode: "from_scratch" | "adapter_finetune" | "full_finetune";
   baseModel?: string;
+  teacherModel?: string;
+  trlMode?: "gkd" | "grpo";
   opdDiagnostics: boolean;
   opdDiagnosticsDebugTokens: boolean;
   opdPressureMode: OpdPressureMode;
+  memoryLimitMb?: number;
+  deviceCount?: number;
+  shardingStrategy?: TrainingShardingStrategy;
+  perDeviceMemoryLimitMb?: number;
+  baseModelParameterCount?: number;
+  baseModelQuantization?: string;
+  deploymentTargetVramMb?: number;
   json: boolean;
 }
 
@@ -78,8 +115,24 @@ export function planTrainCommand(
     throw new Error("Error: --scenario and --dataset are required. Run 'autoctx train --help'.");
   }
 
-  const backend = values.backend ?? "cuda";
+  const profile = values["scale-profile"]
+    ? getModelScaleProfile(values["scale-profile"])
+    : undefined;
+  const backend = values.backend ?? profile?.backend ?? "cuda";
   const opdPressureMode = normalizeOpdPressureMode(values["opd-pressure-mode"]);
+  const shardingStrategy = (values["sharding-strategy"] ??
+    profile?.shardingStrategy ??
+    "none") as TrainingShardingStrategy;
+  const memoryLimitMb =
+    parseOptionalNumber(values["memory-limit"], "--memory-limit") ?? profile?.memoryLimitMb;
+  const deviceCount =
+    parseOptionalNumber(values["device-count"], "--device-count") ?? profile?.deviceCount;
+  if (deviceCount !== undefined && deviceCount < 1) {
+    throw new Error("--device-count must be >= 1");
+  }
+  if (!["none", "fsdp", "deepspeed_zero3"].includes(shardingStrategy)) {
+    throw new Error("--sharding-strategy must be none|fsdp|deepspeed_zero3");
+  }
   if (backend !== "opd" && opdPressureMode !== "full_kl") {
     throw new Error("--opd-pressure-mode only supports --backend opd");
   }
@@ -95,10 +148,25 @@ export function planTrainCommand(
       | "from_scratch"
       | "adapter_finetune"
       | "full_finetune",
-    baseModel: values["base-model"],
+    baseModel: values["base-model"] ?? profile?.baseModel,
+    teacherModel: values["teacher-model"] ?? profile?.teacherModel,
+    trlMode: profile?.trlMode,
     opdDiagnostics: !!values["opd-diagnostics"],
     opdDiagnosticsDebugTokens: !!values["opd-diagnostics-debug-tokens"],
     opdPressureMode,
+    memoryLimitMb,
+    deviceCount,
+    shardingStrategy,
+    perDeviceMemoryLimitMb:
+      parseOptionalNumber(values["per-device-memory-limit"], "--per-device-memory-limit") ??
+      profile?.perDeviceMemoryLimitMb,
+    baseModelParameterCount:
+      parseOptionalNumber(values["base-model-parameters"], "--base-model-parameters") ??
+      profile?.baseModelParameterCount,
+    baseModelQuantization: values["base-model-quantization"] ?? profile?.baseModelQuantization,
+    deploymentTargetVramMb:
+      parseOptionalNumber(values["deployment-target-vram"], "--deployment-target-vram") ??
+      profile?.deploymentTargetVramMb,
     json: !!values.json,
   };
 }
@@ -116,9 +184,18 @@ export async function executeTrainCommandWorkflow<TResult extends { status?: str
       backend: string;
       trainingMode: "from_scratch" | "adapter_finetune" | "full_finetune";
       baseModel?: string;
+      teacherModel?: string;
+      trlMode?: "gkd" | "grpo";
       opdDiagnostics?: boolean;
       opdDiagnosticsDebugTokens?: boolean;
       opdPressureMode?: OpdPressureMode;
+      memoryLimitMb?: number;
+      deviceCount?: number;
+      shardingStrategy?: TrainingShardingStrategy;
+      perDeviceMemoryLimitMb?: number;
+      baseModelParameterCount?: number;
+      baseModelQuantization?: string;
+      deploymentTargetVramMb?: number;
     }): Promise<TResult>;
   };
 }): Promise<TResult> {
@@ -137,9 +214,18 @@ export async function executeTrainCommandWorkflow<TResult extends { status?: str
     backend: opts.plan.backend,
     trainingMode: opts.plan.trainingMode,
     baseModel: opts.plan.baseModel,
+    teacherModel: opts.plan.teacherModel,
+    trlMode: opts.plan.trlMode,
     opdDiagnostics: opts.plan.opdDiagnostics,
     opdDiagnosticsDebugTokens: opts.plan.opdDiagnosticsDebugTokens,
     opdPressureMode: opts.plan.opdPressureMode,
+    memoryLimitMb: opts.plan.memoryLimitMb,
+    deviceCount: opts.plan.deviceCount,
+    shardingStrategy: opts.plan.shardingStrategy,
+    perDeviceMemoryLimitMb: opts.plan.perDeviceMemoryLimitMb,
+    baseModelParameterCount: opts.plan.baseModelParameterCount,
+    baseModelQuantization: opts.plan.baseModelQuantization,
+    deploymentTargetVramMb: opts.plan.deploymentTargetVramMb,
   });
 }
 

--- a/ts/src/cli/train-command-workflow.ts
+++ b/ts/src/cli/train-command-workflow.ts
@@ -21,6 +21,10 @@ Options:
   --opd-pressure-mode <mode>  OPD pressure mode: full_kl, sample_positive, sample_positive_reverse_negative
   --device-count <n>       Planned accelerator count for scaled training
   --sharding-strategy <s>  Sharding strategy: none, fsdp, deepspeed_zero3
+  --per-device-memory-limit <mb>  Per-device memory cap for scaled training
+  --base-model-parameters <n>  Base/student parameter count for registry metadata
+  --base-model-quantization <q>  Base/student quantization label, e.g. nf4
+  --deployment-target-vram <mb>  Deployment target VRAM cap for registry gating
   --json                   Output as JSON
   -h, --help               Show this help
 
@@ -30,6 +34,31 @@ Notes:
 
 export type OpdPressureMode = "full_kl" | "sample_positive" | "sample_positive_reverse_negative";
 export type TrainingShardingStrategy = "none" | "fsdp" | "deepspeed_zero3";
+
+export const TRAIN_COMMAND_PARSE_OPTIONS = {
+  scenario: { type: "string", short: "s" },
+  family: { type: "string" },
+  dataset: { type: "string", short: "d" },
+  "held-out": { type: "string" },
+  backend: { type: "string" },
+  mode: { type: "string" },
+  "base-model": { type: "string" },
+  "teacher-model": { type: "string" },
+  "scale-profile": { type: "string" },
+  "memory-limit": { type: "string" },
+  output: { type: "string", short: "o" },
+  "opd-diagnostics": { type: "boolean" },
+  "opd-diagnostics-debug-tokens": { type: "boolean" },
+  "opd-pressure-mode": { type: "string" },
+  "device-count": { type: "string" },
+  "sharding-strategy": { type: "string" },
+  "per-device-memory-limit": { type: "string" },
+  "base-model-parameters": { type: "string" },
+  "base-model-quantization": { type: "string" },
+  "deployment-target-vram": { type: "string" },
+  json: { type: "boolean" },
+  help: { type: "boolean", short: "h" },
+} as const;
 
 const OPD_PRESSURE_MODES = [
   "full_kl",
@@ -144,7 +173,7 @@ export function planTrainCommand(
     heldOutPath: values["held-out"] ? resolvePath(values["held-out"]) : undefined,
     outputDir: values.output ? resolvePath(values.output) : resolvePath(runsRoot),
     backend,
-    trainingMode: (values.mode ?? "from_scratch") as
+    trainingMode: (values.mode ?? profile?.trainingMode ?? "from_scratch") as
       | "from_scratch"
       | "adapter_finetune"
       | "full_finetune",

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -989,7 +989,24 @@ export {
   defaultBackendRegistry,
   TrainingRunner,
 } from "./training/backends.js";
-export type { OpdPressureMode, TrainingConfig, TrainingResult, PublishedArtifact } from "./training/backends.js";
+export {
+  getModelScaleProfile,
+  listModelScaleProfiles,
+  MODEL_SCALE_PROFILES,
+} from "./training/model-defaults.js";
+export {
+  resolveTrainingScaleMetadata,
+  validateTrainingScaleMetadata,
+} from "./training/training-scale.js";
+export type {
+  OpdPressureMode,
+  PublishedArtifact,
+  TrainingConfig,
+  TrainingResult,
+  TrainingScaleMetadata,
+  TrainingShardingStrategy,
+} from "./training/backends.js";
+export type { ModelScaleProfile } from "./training/model-defaults.js";
 export {
   buildTokenPressureReport,
   compareTokenPressureReports,

--- a/ts/src/training/backends.ts
+++ b/ts/src/training/backends.ts
@@ -35,7 +35,14 @@ export {
   TRLBackend,
   TrainingBackend,
 };
-export type { OpdPressureMode, PublishedArtifact, TrainingConfig, TrainingResult } from "./training-types.js";
+export type {
+  OpdPressureMode,
+  PublishedArtifact,
+  TrainingConfig,
+  TrainingResult,
+  TrainingScaleMetadata,
+  TrainingShardingStrategy,
+} from "./training-types.js";
 export type { TrainingExecutor } from "./training-types.js";
 
 export class TrainingRunner {

--- a/ts/src/training/model-defaults.ts
+++ b/ts/src/training/model-defaults.ts
@@ -1,0 +1,56 @@
+export type ModelScaleProfile = {
+  backend: "trl";
+  trlMode: "gkd" | "grpo";
+  baseModel: string;
+  teacherModel: string;
+  baseModelParameterCount: number;
+  baseModelQuantization: string;
+  memoryLimitMb: number;
+  deviceCount: number;
+  shardingStrategy: "none" | "fsdp" | "deepspeed_zero3";
+  perDeviceMemoryLimitMb: number;
+  deploymentTargetVramMb: number;
+};
+
+export const MODEL_SCALE_PROFILES: Record<string, ModelScaleProfile> = {
+  cuda_qlora_7b_rlvr: {
+    backend: "trl",
+    trlMode: "grpo",
+    baseModel: "Qwen/Qwen2.5-7B-Instruct",
+    teacherModel: "Qwen/Qwen2.5-14B-Instruct",
+    baseModelParameterCount: 7_000_000_000,
+    baseModelQuantization: "nf4",
+    memoryLimitMb: 24_576,
+    deviceCount: 1,
+    shardingStrategy: "none",
+    perDeviceMemoryLimitMb: 24_576,
+    deploymentTargetVramMb: 24_576,
+  },
+  cuda_sharded_32b_distill: {
+    backend: "trl",
+    trlMode: "gkd",
+    baseModel: "Qwen/Qwen2.5-32B-Instruct",
+    teacherModel: "Qwen/Qwen2.5-72B-Instruct",
+    baseModelParameterCount: 32_000_000_000,
+    baseModelQuantization: "nf4",
+    memoryLimitMb: 98_304,
+    deviceCount: 4,
+    shardingStrategy: "deepspeed_zero3",
+    perDeviceMemoryLimitMb: 24_576,
+    deploymentTargetVramMb: 24_576,
+  },
+};
+
+export function listModelScaleProfiles(): string[] {
+  return Object.keys(MODEL_SCALE_PROFILES).sort();
+}
+
+export function getModelScaleProfile(name: string): ModelScaleProfile {
+  const profile = MODEL_SCALE_PROFILES[name];
+  if (!profile) {
+    throw new Error(
+      `unknown model scale profile ${name}; expected one of ${listModelScaleProfiles().join(", ")}`,
+    );
+  }
+  return { ...profile };
+}

--- a/ts/src/training/model-defaults.ts
+++ b/ts/src/training/model-defaults.ts
@@ -1,5 +1,6 @@
 export type ModelScaleProfile = {
   backend: "trl";
+  trainingMode: "adapter_finetune";
   trlMode: "gkd" | "grpo";
   baseModel: string;
   teacherModel: string;
@@ -15,6 +16,7 @@ export type ModelScaleProfile = {
 export const MODEL_SCALE_PROFILES: Record<string, ModelScaleProfile> = {
   cuda_qlora_7b_rlvr: {
     backend: "trl",
+    trainingMode: "adapter_finetune",
     trlMode: "grpo",
     baseModel: "Qwen/Qwen2.5-7B-Instruct",
     teacherModel: "Qwen/Qwen2.5-14B-Instruct",
@@ -28,6 +30,7 @@ export const MODEL_SCALE_PROFILES: Record<string, ModelScaleProfile> = {
   },
   cuda_sharded_32b_distill: {
     backend: "trl",
+    trainingMode: "adapter_finetune",
     trlMode: "gkd",
     baseModel: "Qwen/Qwen2.5-32B-Instruct",
     teacherModel: "Qwen/Qwen2.5-72B-Instruct",

--- a/ts/src/training/model-strategy-recommendations.ts
+++ b/ts/src/training/model-strategy-recommendations.ts
@@ -77,6 +77,8 @@ export const DEFAULT_RECOMMENDATIONS: Record<string, FamilyRecommendation> = {
 
 export const KNOWN_BASE_MODELS: Record<string, { parameterCount: number; supportedBackends: string[] }> = {
   "Qwen/Qwen3-0.6B": { parameterCount: 600_000_000, supportedBackends: ["cuda", "mlx"] },
+  "Qwen/Qwen2.5-7B-Instruct": { parameterCount: 7_000_000_000, supportedBackends: ["trl"] },
+  "Qwen/Qwen2.5-32B-Instruct": { parameterCount: 32_000_000_000, supportedBackends: ["trl"] },
   "meta-llama/Llama-3.2-1B": { parameterCount: 1_000_000_000, supportedBackends: ["cuda"] },
   "microsoft/phi-4-mini": { parameterCount: 3_800_000_000, supportedBackends: ["cuda"] },
 };

--- a/ts/src/training/promotion-registry-workflow.ts
+++ b/ts/src/training/promotion-registry-workflow.ts
@@ -1,8 +1,5 @@
-import type {
-  ActivationState,
-  ModelRecord,
-  PromotionEvent,
-} from "./promotion-types.js";
+import type { TrainingScaleMetadata } from "./training-scale-types.js";
+import type { ActivationState, ModelRecord, PromotionEvent } from "./promotion-types.js";
 
 export function generateModelId(): string {
   return `model_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
@@ -14,6 +11,7 @@ export function createModelRecord(opts: {
   family: string;
   backend: string;
   checkpointDir: string;
+  trainingScale?: TrainingScaleMetadata;
   activationState?: ActivationState;
 }): ModelRecord {
   return {
@@ -22,6 +20,7 @@ export function createModelRecord(opts: {
     family: opts.family,
     backend: opts.backend,
     checkpointDir: opts.checkpointDir,
+    trainingScale: opts.trainingScale,
     activationState: opts.activationState ?? "candidate",
     promotionHistory: [],
     registeredAt: new Date().toISOString(),
@@ -50,13 +49,26 @@ export function listModelRecordsForScenario(
   return [...records].filter((record) => record.scenario === scenario);
 }
 
+function fitsDeploymentTarget(record: ModelRecord, deploymentTargetVramMb?: number): boolean {
+  if (!deploymentTargetVramMb || deploymentTargetVramMb <= 0) {
+    return true;
+  }
+  const required = record.trainingScale?.deploymentTargetVramMb ?? 0;
+  return required <= 0 || required <= deploymentTargetVramMb;
+}
+
 export function resolveActiveModelRecord(
   records: Iterable<ModelRecord>,
   scenario: string,
+  opts?: { deploymentTargetVramMb?: number },
 ): ModelRecord | null {
-  return listModelRecordsForScenario(records, scenario).find(
-    (record) => record.activationState === "active",
-  ) ?? null;
+  return (
+    listModelRecordsForScenario(records, scenario).find(
+      (record) =>
+        record.activationState === "active" &&
+        fitsDeploymentTarget(record, opts?.deploymentTargetVramMb),
+    ) ?? null
+  );
 }
 
 export function applyModelStateTransition(opts: {
@@ -75,25 +87,29 @@ export function applyModelStateTransition(opts: {
   if (opts.targetState === "active") {
     for (const candidate of opts.records.values()) {
       if (
-        candidate.scenario === record.scenario
-        && candidate.activationState === "active"
-        && candidate.artifactId !== opts.artifactId
+        candidate.scenario === record.scenario &&
+        candidate.activationState === "active" &&
+        candidate.artifactId !== opts.artifactId
       ) {
         candidate.activationState = "disabled";
-        candidate.promotionHistory.push(buildPromotionEvent({
-          from: "active",
-          to: "disabled",
-          reason: `Displaced by ${opts.artifactId}`,
-        }));
+        candidate.promotionHistory.push(
+          buildPromotionEvent({
+            from: "active",
+            to: "disabled",
+            reason: `Displaced by ${opts.artifactId}`,
+          }),
+        );
       }
     }
   }
 
   record.activationState = opts.targetState;
-  record.promotionHistory.push(buildPromotionEvent({
-    from: fromState,
-    to: opts.targetState,
-    reason: opts.reason ?? `State changed to ${opts.targetState}`,
-    evidence: opts.evidence,
-  }));
+  record.promotionHistory.push(
+    buildPromotionEvent({
+      from: fromState,
+      to: opts.targetState,
+      reason: opts.reason ?? `State changed to ${opts.targetState}`,
+      evidence: opts.evidence,
+    }),
+  );
 }

--- a/ts/src/training/promotion-types.ts
+++ b/ts/src/training/promotion-types.ts
@@ -1,3 +1,5 @@
+import type { TrainingScaleMetadata } from "./training-scale-types.js";
+
 export type ActivationState = "candidate" | "shadow" | "active" | "disabled" | "deprecated";
 
 export const ACTIVATION_STATES: readonly ActivationState[] = [
@@ -22,6 +24,7 @@ export interface ModelRecord {
   family: string;
   backend: string;
   checkpointDir: string;
+  trainingScale?: TrainingScaleMetadata;
   activationState: ActivationState;
   promotionHistory: PromotionEvent[];
   registeredAt: string;
@@ -56,7 +59,10 @@ export interface PromotionThresholds {
   regressionThreshold: number;
 }
 
-export type ShadowExecutor = (artifactId: string, scenario: string) => Promise<{
+export type ShadowExecutor = (
+  artifactId: string,
+  scenario: string,
+) => Promise<{
   score: number;
   parseFailureRate: number;
   validationFailureRate: number;

--- a/ts/src/training/promotion.ts
+++ b/ts/src/training/promotion.ts
@@ -23,6 +23,7 @@ import {
   evaluatePromotionCheck,
   normalizePromotionThresholds,
 } from "./promotion-engine-workflow.js";
+import type { TrainingScaleMetadata } from "./training-scale-types.js";
 import type {
   ActivationState,
   ModelRecord,
@@ -33,9 +34,7 @@ import type {
   ShadowRunOpts,
 } from "./promotion-types.js";
 
-export {
-  ACTIVATION_STATES,
-} from "./promotion-types.js";
+export { ACTIVATION_STATES } from "./promotion-types.js";
 export type {
   ActivationState,
   ModelRecord,
@@ -55,6 +54,7 @@ export class ModelRegistry {
     family: string;
     backend: string;
     checkpointDir: string;
+    trainingScale?: TrainingScaleMetadata;
     activationState?: ActivationState;
   }): string {
     const record = createModelRecord(opts);
@@ -70,8 +70,8 @@ export class ModelRegistry {
     return listModelRecordsForScenario(this.records.values(), scenario);
   }
 
-  resolveActive(scenario: string): ModelRecord | null {
-    return resolveActiveModelRecord(this.records.values(), scenario);
+  resolveActive(scenario: string, opts?: { deploymentTargetVramMb?: number }): ModelRecord | null {
+    return resolveActiveModelRecord(this.records.values(), scenario, opts);
   }
 
   setState(
@@ -97,7 +97,10 @@ export class PromotionEngine {
   private thresholds: PromotionThresholds;
   private shadowExecutor?: ShadowExecutor;
 
-  constructor(opts?: { thresholds?: Partial<PromotionThresholds>; shadowExecutor?: ShadowExecutor }) {
+  constructor(opts?: {
+    thresholds?: Partial<PromotionThresholds>;
+    shadowExecutor?: ShadowExecutor;
+  }) {
     this.thresholds = normalizePromotionThresholds(opts?.thresholds);
     this.shadowExecutor = opts?.shadowExecutor;
   }

--- a/ts/src/training/training-checkpoint-workflow.ts
+++ b/ts/src/training/training-checkpoint-workflow.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import type { ModelRecord } from "./promotion.js";
+import { resolveTrainingScaleMetadata } from "./training-scale.js";
 import type { PublishedArtifact, TrainingConfig, TrainingExecutor } from "./training-types.js";
 import type { TrainingBackend } from "./training-backend-core.js";
 
@@ -13,7 +14,10 @@ export const defaultExecutor: TrainingExecutor = async (config, checkpointDir) =
         backend: config.backend,
         trainingMode: config.trainingMode,
         baseModel: config.baseModel,
+        teacherModel: config.teacherModel,
+        trlMode: config.trlMode,
         opdPressureMode: config.opdPressureMode ?? "full_kl",
+        trainingScale: resolveTrainingScaleMetadata(config),
         status: "trained",
         note: "Default executor — replace with real PyTorch/MLX training for production use",
         timestamp: new Date().toISOString(),
@@ -53,6 +57,8 @@ export function writeTrainingManifest(
         backend: config.backend,
         trainingMode: config.trainingMode,
         baseModel: config.baseModel ?? null,
+        teacherModel: config.teacherModel ?? null,
+        trlMode: config.trlMode ?? null,
         adapterType: config.adapterType ?? null,
         datasetPath: config.datasetPath,
         datasetSize,
@@ -63,6 +69,7 @@ export function writeTrainingManifest(
         opdDiagnostics: config.opdDiagnostics ?? false,
         opdDiagnosticsDebugTokens: config.opdDiagnosticsDebugTokens ?? false,
         opdPressureMode: config.opdPressureMode ?? "full_kl",
+        trainingScale: resolveTrainingScaleMetadata(config),
         startedAt: new Date().toISOString(),
       },
       null,
@@ -88,6 +95,8 @@ export function publishTrainingArtifact(opts: {
     backend: opts.config.backend,
     trainingMode: opts.config.trainingMode,
     baseModel: opts.config.baseModel,
+    teacherModel: opts.config.teacherModel,
+    trlMode: opts.config.trlMode,
     adapterType: opts.config.adapterType,
     checkpointDir: opts.checkpointDir,
     datasetSize: opts.datasetSize,
@@ -95,6 +104,7 @@ export function publishTrainingArtifact(opts: {
     trainedAt: new Date().toISOString(),
     metrics: opts.metrics,
     opdPressureMode: opts.config.opdPressureMode ?? "full_kl",
+    trainingScale: resolveTrainingScaleMetadata(opts.config),
     activationState: opts.record.activationState,
     promotionHistory: [...opts.record.promotionHistory],
   };

--- a/ts/src/training/training-config-workflow.ts
+++ b/ts/src/training/training-config-workflow.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 
 import { ModelStrategySelector } from "./model-strategy.js";
+import { resolveTrainingScaleMetadata, validateTrainingScaleMetadata } from "./training-scale.js";
 import type { TrainingConfig } from "./training-types.js";
 
 export function countJsonlRecords(path: string): number {
@@ -28,6 +29,16 @@ export function resolveTrainingConfig(config: TrainingConfig): {
     config.heldOutPath && existsSync(config.heldOutPath)
       ? countJsonlRecords(config.heldOutPath)
       : 0;
+  const scaleError = validateTrainingScaleMetadata(resolveTrainingScaleMetadata(config));
+  if (scaleError) {
+    return {
+      resolvedConfig: config,
+      datasetSize,
+      heldOutSize,
+      error: scaleError,
+    };
+  }
+
   if (config.backend !== "opd" && config.opdPressureMode && config.opdPressureMode !== "full_kl") {
     return {
       resolvedConfig: config,

--- a/ts/src/training/training-promotion-workflow.ts
+++ b/ts/src/training/training-promotion-workflow.ts
@@ -1,9 +1,6 @@
-import {
-  type ModelRecord,
-  ModelRegistry,
-  PromotionEngine,
-} from "./promotion.js";
+import type { ModelRecord, ModelRegistry, PromotionEngine } from "./promotion.js";
 import { readMetric } from "./training-metric-utils.js";
+import { resolveTrainingScaleMetadata } from "./training-scale.js";
 import type { TrainingConfig } from "./training-types.js";
 
 export function registerPromotionCandidate(
@@ -16,6 +13,7 @@ export function registerPromotionCandidate(
     family: config.family,
     backend: config.backend,
     checkpointDir,
+    trainingScale: resolveTrainingScaleMetadata(config),
     activationState: "candidate",
   });
 
@@ -40,7 +38,8 @@ export function evaluatePromotionState(
       heldOutScore,
       incumbentScore,
       parseFailureRate: readMetric(metrics, "parseFailureRate", "parse_failure_rate") ?? 0,
-      validationFailureRate: readMetric(metrics, "validationFailureRate", "validation_failure_rate") ?? 0,
+      validationFailureRate:
+        readMetric(metrics, "validationFailureRate", "validation_failure_rate") ?? 0,
     });
     if (decision.targetState !== "candidate") {
       promotionRegistry.setState(artifactId, decision.targetState, {

--- a/ts/src/training/training-scale-types.ts
+++ b/ts/src/training/training-scale-types.ts
@@ -1,0 +1,11 @@
+export type TrainingShardingStrategy = "none" | "fsdp" | "deepspeed_zero3";
+
+export interface TrainingScaleMetadata {
+  deviceCount: number;
+  shardingStrategy: TrainingShardingStrategy;
+  memoryLimitMb: number;
+  perDeviceMemoryLimitMb: number;
+  baseModelParameterCount: number;
+  baseModelQuantization: string;
+  deploymentTargetVramMb: number;
+}

--- a/ts/src/training/training-scale.ts
+++ b/ts/src/training/training-scale.ts
@@ -1,0 +1,34 @@
+import type { TrainingScaleMetadata } from "./training-scale-types.js";
+import type { TrainingConfig } from "./training-types.js";
+
+export function resolveTrainingScaleMetadata(config: TrainingConfig): TrainingScaleMetadata {
+  return {
+    deviceCount: config.deviceCount ?? 1,
+    shardingStrategy: config.shardingStrategy ?? "none",
+    memoryLimitMb: config.memoryLimitMb ?? 16_384,
+    perDeviceMemoryLimitMb: config.perDeviceMemoryLimitMb ?? config.memoryLimitMb ?? 16_384,
+    baseModelParameterCount: config.baseModelParameterCount ?? 0,
+    baseModelQuantization: config.baseModelQuantization ?? "",
+    deploymentTargetVramMb: config.deploymentTargetVramMb ?? 0,
+  };
+}
+
+export function validateTrainingScaleMetadata(scale: TrainingScaleMetadata): string | null {
+  if (scale.deviceCount < 1) {
+    return "deviceCount must be >= 1";
+  }
+  if (!["none", "fsdp", "deepspeed_zero3"].includes(scale.shardingStrategy)) {
+    return "shardingStrategy must be none|fsdp|deepspeed_zero3";
+  }
+  for (const [key, value] of Object.entries({
+    memoryLimitMb: scale.memoryLimitMb,
+    perDeviceMemoryLimitMb: scale.perDeviceMemoryLimitMb,
+    baseModelParameterCount: scale.baseModelParameterCount,
+    deploymentTargetVramMb: scale.deploymentTargetVramMb,
+  })) {
+    if (value < 0) {
+      return `${key} must be >= 0`;
+    }
+  }
+  return null;
+}

--- a/ts/src/training/training-types.ts
+++ b/ts/src/training/training-types.ts
@@ -1,7 +1,9 @@
-import type { ActivationState, PromotionEvent } from "./promotion.js";
+import type { ActivationState, PromotionEvent } from "./promotion-types.js";
 import type { TrainingMode } from "./model-strategy.js";
+import type { TrainingScaleMetadata, TrainingShardingStrategy } from "./training-scale-types.js";
 
 export type OpdPressureMode = "full_kl" | "sample_positive" | "sample_positive_reverse_negative";
+export type { TrainingScaleMetadata, TrainingShardingStrategy } from "./training-scale-types.js";
 
 export interface TrainingConfig {
   scenario: string;
@@ -12,7 +14,16 @@ export interface TrainingConfig {
   backend: string;
   trainingMode: TrainingMode;
   baseModel?: string;
+  teacherModel?: string;
+  trlMode?: "gkd" | "grpo";
   adapterType?: string;
+  deviceCount?: number;
+  shardingStrategy?: TrainingShardingStrategy;
+  memoryLimitMb?: number;
+  perDeviceMemoryLimitMb?: number;
+  baseModelParameterCount?: number;
+  baseModelQuantization?: string;
+  deploymentTargetVramMb?: number;
   maxEpochs?: number;
   batchSize?: number;
   learningRate?: number;
@@ -28,6 +39,8 @@ export interface PublishedArtifact {
   backend: string;
   trainingMode: TrainingMode;
   baseModel?: string;
+  teacherModel?: string;
+  trlMode?: "gkd" | "grpo";
   adapterType?: string;
   checkpointDir: string;
   datasetSize: number;
@@ -35,6 +48,7 @@ export interface PublishedArtifact {
   trainedAt: string;
   metrics?: Record<string, number>;
   opdPressureMode?: OpdPressureMode;
+  trainingScale?: TrainingScaleMetadata;
   activationState: ActivationState;
   promotionHistory: PromotionEvent[];
 }

--- a/ts/tests/promotion-registry-workflow.test.ts
+++ b/ts/tests/promotion-registry-workflow.test.ts
@@ -18,6 +18,7 @@ function makeRecord(overrides?: Partial<ModelRecord>): ModelRecord {
     backend: overrides?.backend ?? "cuda",
     checkpointDir: overrides?.checkpointDir ?? "/tmp/checkpoint",
     activationState: overrides?.activationState ?? "candidate",
+    trainingScale: overrides?.trainingScale,
     promotionHistory: overrides?.promotionHistory ?? [],
     registeredAt: overrides?.registeredAt ?? "2026-03-27T10:00:00Z",
   };
@@ -58,12 +59,46 @@ describe("promotion registry workflow", () => {
       makeRecord({ artifactId: "model_3", scenario: "othello", activationState: "active" }),
     ];
 
-    expect(listModelRecordsForScenario(records, "grid_ctf").map((record) => record.artifactId)).toEqual([
-      "model_1",
-      "model_2",
-    ]);
+    expect(
+      listModelRecordsForScenario(records, "grid_ctf").map((record) => record.artifactId),
+    ).toEqual(["model_1", "model_2"]);
     expect(resolveActiveModelRecord(records, "grid_ctf")?.artifactId).toBe("model_2");
     expect(resolveActiveModelRecord(records, "unknown")).toBeNull();
+  });
+
+  it("resolves an active model that fits the deployment VRAM target", () => {
+    const records = [
+      makeRecord({
+        artifactId: "model_large",
+        activationState: "active",
+        trainingScale: {
+          deviceCount: 4,
+          shardingStrategy: "deepspeed_zero3",
+          memoryLimitMb: 98_304,
+          perDeviceMemoryLimitMb: 24_576,
+          baseModelParameterCount: 32_000_000_000,
+          baseModelQuantization: "nf4",
+          deploymentTargetVramMb: 24_576,
+        },
+      }),
+      makeRecord({
+        artifactId: "model_small",
+        activationState: "active",
+        trainingScale: {
+          deviceCount: 1,
+          shardingStrategy: "none",
+          memoryLimitMb: 16_384,
+          perDeviceMemoryLimitMb: 16_384,
+          baseModelParameterCount: 7_000_000_000,
+          baseModelQuantization: "nf4",
+          deploymentTargetVramMb: 16_384,
+        },
+      }),
+    ];
+
+    expect(
+      resolveActiveModelRecord(records, "grid_ctf", { deploymentTargetVramMb: 16_384 })?.artifactId,
+    ).toBe("model_small");
   });
 
   it("applies state transitions and displaces existing active models for the scenario", () => {

--- a/ts/tests/train-command-workflow.test.ts
+++ b/ts/tests/train-command-workflow.test.ts
@@ -18,6 +18,9 @@ describe("train command workflow", () => {
     expect(TRAIN_HELP_TEXT).toContain("--opd-diagnostics");
     expect(TRAIN_HELP_TEXT).toContain("--opd-diagnostics-debug-tokens");
     expect(TRAIN_HELP_TEXT).toContain("--opd-pressure-mode");
+    expect(TRAIN_HELP_TEXT).toContain("--device-count");
+    expect(TRAIN_HELP_TEXT).toContain("--sharding-strategy");
+    expect(TRAIN_HELP_TEXT).toContain("--scale-profile");
   });
 
   it("requires scenario and dataset", () => {
@@ -55,6 +58,12 @@ describe("train command workflow", () => {
           "opd-diagnostics": true,
           "opd-diagnostics-debug-tokens": true,
           "opd-pressure-mode": "sample_positive",
+          "device-count": 4,
+          "sharding-strategy": "fsdp",
+          "per-device-memory-limit": 16_384,
+          "base-model-parameters": 32_000_000_000,
+          "base-model-quantization": "nf4",
+          "deployment-target-vram": 16_384,
           json: true,
         },
         "/tmp/runs",
@@ -72,7 +81,38 @@ describe("train command workflow", () => {
       opdDiagnostics: true,
       opdDiagnosticsDebugTokens: true,
       opdPressureMode: "sample_positive",
+      memoryLimitMb: undefined,
+      deviceCount: 4,
+      shardingStrategy: "fsdp",
+      perDeviceMemoryLimitMb: 16_384,
+      baseModelParameterCount: 32_000_000_000,
+      baseModelQuantization: "nf4",
+      deploymentTargetVramMb: 16_384,
       json: true,
+    });
+  });
+
+  it("applies larger-model scale profiles", () => {
+    expect(
+      planTrainCommand(
+        {
+          scenario: "grid_ctf",
+          dataset: "train.jsonl",
+          "scale-profile": "cuda_sharded_32b_distill",
+        },
+        "/tmp/runs",
+        (value: string) => `/abs/${value}`,
+      ),
+    ).toMatchObject({
+      backend: "trl",
+      baseModel: "Qwen/Qwen2.5-32B-Instruct",
+      teacherModel: "Qwen/Qwen2.5-72B-Instruct",
+      trlMode: "gkd",
+      deviceCount: 4,
+      shardingStrategy: "deepspeed_zero3",
+      baseModelQuantization: "nf4",
+      memoryLimitMb: 98_304,
+      deploymentTargetVramMb: 24_576,
     });
   });
 
@@ -137,9 +177,14 @@ describe("train command workflow", () => {
         backend: "opd",
         trainingMode: "from_scratch",
         baseModel: undefined,
+        teacherModel: "Qwen/Qwen2.5-14B-Instruct",
+        trlMode: "grpo",
         opdDiagnostics: true,
         opdDiagnosticsDebugTokens: true,
         opdPressureMode: "sample_positive_reverse_negative",
+        deviceCount: 2,
+        shardingStrategy: "deepspeed_zero3",
+        deploymentTargetVramMb: 24_576,
         json: false,
       },
       createRunner: () => ({
@@ -157,9 +202,15 @@ describe("train command workflow", () => {
       backend: "opd",
       trainingMode: "from_scratch",
       baseModel: undefined,
+      teacherModel: "Qwen/Qwen2.5-14B-Instruct",
+      trlMode: "grpo",
       opdDiagnostics: true,
       opdDiagnosticsDebugTokens: true,
       opdPressureMode: "sample_positive_reverse_negative",
+      memoryLimitMb: undefined,
+      deviceCount: 2,
+      shardingStrategy: "deepspeed_zero3",
+      deploymentTargetVramMb: 24_576,
     });
     expect(result).toMatchObject({ status: "completed", backend: "cuda" });
   });

--- a/ts/tests/train-command-workflow.test.ts
+++ b/ts/tests/train-command-workflow.test.ts
@@ -1,7 +1,9 @@
+import { parseArgs } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 
 import {
   executeTrainCommandWorkflow,
+  TRAIN_COMMAND_PARSE_OPTIONS,
   TRAIN_HELP_TEXT,
   planTrainCommand,
   renderTrainSuccess,
@@ -20,6 +22,10 @@ describe("train command workflow", () => {
     expect(TRAIN_HELP_TEXT).toContain("--opd-pressure-mode");
     expect(TRAIN_HELP_TEXT).toContain("--device-count");
     expect(TRAIN_HELP_TEXT).toContain("--sharding-strategy");
+    expect(TRAIN_HELP_TEXT).toContain("--per-device-memory-limit");
+    expect(TRAIN_HELP_TEXT).toContain("--base-model-parameters");
+    expect(TRAIN_HELP_TEXT).toContain("--base-model-quantization");
+    expect(TRAIN_HELP_TEXT).toContain("--deployment-target-vram");
     expect(TRAIN_HELP_TEXT).toContain("--scale-profile");
   });
 
@@ -105,6 +111,7 @@ describe("train command workflow", () => {
       ),
     ).toMatchObject({
       backend: "trl",
+      trainingMode: "adapter_finetune",
       baseModel: "Qwen/Qwen2.5-32B-Instruct",
       teacherModel: "Qwen/Qwen2.5-72B-Instruct",
       trlMode: "gkd",
@@ -113,6 +120,24 @@ describe("train command workflow", () => {
       baseModelQuantization: "nf4",
       memoryLimitMb: 98_304,
       deploymentTargetVramMb: 24_576,
+    });
+  });
+
+  it("keeps scale-profile defaults through the real parseArgs path", () => {
+    const { values } = parseArgs({
+      args: ["--scenario", "grid_ctf", "--dataset", "train.jsonl", "--scale-profile", "cuda_qlora_7b_rlvr"],
+      options: TRAIN_COMMAND_PARSE_OPTIONS,
+    });
+
+    const plan = planTrainCommand(values, "/tmp/runs", (value: string) => `/abs/${value}`);
+
+    expect(values.backend).toBeUndefined();
+    expect(values.mode).toBeUndefined();
+    expect(plan).toMatchObject({
+      backend: "trl",
+      trainingMode: "adapter_finetune",
+      baseModel: "Qwen/Qwen2.5-7B-Instruct",
+      trlMode: "grpo",
     });
   });
 

--- a/ts/tests/training-config-workflow.test.ts
+++ b/ts/tests/training-config-workflow.test.ts
@@ -7,6 +7,7 @@ import {
   countJsonlRecords,
   resolveTrainingConfig,
 } from "../src/training/training-config-workflow.js";
+import { resolveTrainingScaleMetadata } from "../src/training/training-scale.js";
 import type { TrainingConfig } from "../src/training/training-types.js";
 
 describe("training config workflow", () => {
@@ -41,6 +42,26 @@ describe("training config workflow", () => {
     expect(resolution.heldOutSize).toBe(1);
     expect(resolution.resolvedConfig.baseModel).toBeTruthy();
     expect(resolution.resolvedConfig.adapterType).toBeTruthy();
+    expect(resolveTrainingScaleMetadata(resolution.resolvedConfig)).toMatchObject({
+      deviceCount: 1,
+      shardingStrategy: "none",
+      memoryLimitMb: 16_384,
+    });
+  });
+
+  it("rejects invalid training scale fields", () => {
+    const config: TrainingConfig = {
+      scenario: "bad-scale",
+      family: "agent_task",
+      datasetPath: join(dir, "train.jsonl"),
+      outputDir: join(dir, "output"),
+      backend: "cuda",
+      trainingMode: "adapter_finetune",
+      deviceCount: 0,
+    };
+    writeFileSync(config.datasetPath, '{"a":1}\n', "utf-8");
+
+    expect(resolveTrainingConfig(config).error).toBe("deviceCount must be >= 1");
   });
 
   it("returns stable errors for missing datasets and invalid base models", () => {

--- a/ts/tests/training-config-workflow.test.ts
+++ b/ts/tests/training-config-workflow.test.ts
@@ -49,6 +49,25 @@ describe("training config workflow", () => {
     });
   });
 
+  it("preserves profile base models when resolving adapter training", () => {
+    const config: TrainingConfig = {
+      scenario: "grid_ctf",
+      family: "agent_task",
+      datasetPath: join(dir, "train.jsonl"),
+      outputDir: join(dir, "output"),
+      backend: "trl",
+      trainingMode: "adapter_finetune",
+      baseModel: "Qwen/Qwen2.5-7B-Instruct",
+    };
+    writeFileSync(config.datasetPath, '{"a":1}\n', "utf-8");
+
+    const resolution = resolveTrainingConfig(config);
+
+    expect(resolution.error).toBeUndefined();
+    expect(resolution.resolvedConfig.trainingMode).toBe("adapter_finetune");
+    expect(resolution.resolvedConfig.baseModel).toBe("Qwen/Qwen2.5-7B-Instruct");
+  });
+
   it("rejects invalid training scale fields", () => {
     const config: TrainingConfig = {
       scenario: "bad-scale",

--- a/ts/tests/training-run-execution-workflow.test.ts
+++ b/ts/tests/training-run-execution-workflow.test.ts
@@ -46,14 +46,28 @@ describe("training run execution workflow", () => {
       outputDir: join(dir, "output"),
       backend: "cuda",
       trainingMode: "adapter_finetune",
+      memoryLimitMb: 65_536,
+      deviceCount: 4,
+      shardingStrategy: "fsdp",
+      perDeviceMemoryLimitMb: 16_384,
+      baseModelParameterCount: 32_000_000_000,
+      baseModelQuantization: "nf4",
+      deploymentTargetVramMb: 16_384,
     };
-    writeFileSync(config.datasetPath, '{"conversations":[{"from":"human","value":"hi"}]}\n', "utf-8");
+    writeFileSync(
+      config.datasetPath,
+      '{"conversations":[{"from":"human","value":"hi"}]}\n',
+      "utf-8",
+    );
 
     const result = await executeTrainingRunWorkflow({
       start: 0,
       config,
       registry,
-      executor: async () => ({ success: true, metrics: { heldOutScore: 0.95, incumbentScore: 1.0 } }),
+      executor: async () => ({
+        success: true,
+        metrics: { heldOutScore: 0.95, incumbentScore: 1.0 },
+      }),
       promotionRegistry: new ModelRegistry(),
       promotionEngine: new PromotionEngine(),
     });
@@ -61,9 +75,72 @@ describe("training run execution workflow", () => {
     expect(result.status).toBe("completed");
     expect(result.artifact?.activationState).toBe("shadow");
     expect(existsSync(join(result.checkpointDir!, "training_manifest.json"))).toBe(true);
-    expect(JSON.parse(readFileSync(join(result.checkpointDir!, "artifact.json"), "utf-8"))).toMatchObject({
+    const manifest = JSON.parse(
+      readFileSync(join(result.checkpointDir!, "training_manifest.json"), "utf-8"),
+    );
+    expect(manifest.trainingScale).toMatchObject({
+      deviceCount: 4,
+      shardingStrategy: "fsdp",
+      perDeviceMemoryLimitMb: 16_384,
+      baseModelParameterCount: 32_000_000_000,
+      baseModelQuantization: "nf4",
+      deploymentTargetVramMb: 16_384,
+    });
+
+    const artifact = JSON.parse(
+      readFileSync(join(result.checkpointDir!, "artifact.json"), "utf-8"),
+    );
+    expect(artifact).toMatchObject({
       scenario: "workflow_success",
       backend: "cuda",
+      trainingScale: {
+        deviceCount: 4,
+        shardingStrategy: "fsdp",
+      },
+    });
+    expect(result.artifact?.trainingScale?.deploymentTargetVramMb).toBe(16_384);
+    expect(result.artifact?.trainingScale?.baseModelQuantization).toBe("nf4");
+  });
+
+  it("stores training scale metadata on promotion records", async () => {
+    const registry = new BackendRegistry();
+    registry.register(new StubBackend("cuda", true));
+    const promotionRegistry = new ModelRegistry();
+    const config: TrainingConfig = {
+      scenario: "scale_record",
+      family: "agent_task",
+      datasetPath: join(dir, "train.jsonl"),
+      outputDir: join(dir, "output"),
+      backend: "cuda",
+      trainingMode: "adapter_finetune",
+      deviceCount: 2,
+      shardingStrategy: "deepspeed_zero3",
+      deploymentTargetVramMb: 24_576,
+    };
+    writeFileSync(
+      config.datasetPath,
+      '{"conversations":[{"from":"human","value":"hi"}]}\n',
+      "utf-8",
+    );
+
+    const result = await executeTrainingRunWorkflow({
+      start: 0,
+      config,
+      registry,
+      executor: async () => ({
+        success: true,
+        metrics: { heldOutScore: 0.95, incumbentScore: 1.0 },
+      }),
+      promotionRegistry,
+      promotionEngine: new PromotionEngine(),
+    });
+
+    expect(result.status).toBe("completed");
+    const record = promotionRegistry.get(result.artifact!.artifactId);
+    expect(record?.trainingScale).toMatchObject({
+      deviceCount: 2,
+      shardingStrategy: "deepspeed_zero3",
+      deploymentTargetVramMb: 24_576,
     });
   });
 
@@ -98,7 +175,11 @@ describe("training run execution workflow", () => {
       backend: "cuda",
       trainingMode: "adapter_finetune",
     };
-    writeFileSync(config.datasetPath, '{"conversations":[{"from":"human","value":"hi"}]}\n', "utf-8");
+    writeFileSync(
+      config.datasetPath,
+      '{"conversations":[{"from":"human","value":"hi"}]}\n',
+      "utf-8",
+    );
 
     const executorFailure = await executeTrainingRunWorkflow({
       start: 0,


### PR DESCRIPTION
## Summary
- add training-scale metadata contracts across Python and TypeScript, including device count, sharding, quantization, memory, and deployment VRAM
- wire TRL CUDA training for larger models with opt-in scale profiles, QLoRA load kwargs, FSDP/DeepSpeed ZeRO-3 config, and registry metadata
- add hardware-aware model resolution gates and docs for CUDA/QLoRA/sharded distill/RLVR flows

## Testing
- `cd autocontext && .venv/bin/python -m pytest tests/test_training_runner.py tests/test_trl_backend.py tests/test_model_registry.py -q`
- `cd autocontext && .venv/bin/python -m ruff check src/autocontext/training/scale.py src/autocontext/training/runner.py src/autocontext/cli_train.py src/autocontext/training/model_defaults.py src/autocontext/training/model_registry.py src/autocontext/training/autoresearch/train.py src/autocontext/training/autoresearch/trl_backend.py tests/test_training_runner.py tests/test_trl_backend.py tests/test_model_registry.py`
- `cd ts && npm test -- --run tests/promotion-registry-workflow.test.ts tests/train-command-workflow.test.ts tests/training-config-workflow.test.ts tests/training-run-execution-workflow.test.ts`
- `cd ts && npm run lint`

Known local environment issue: `ts/tests/package-export-catalogs.test.ts` and `ts/tests/training-backend.test.ts` fail locally before exercising this change because `isolated-vm` has no native build for local Node 23 (`No native build was found for platform=darwin arch=arm64 runtime=node abi=131`).

Closes AC-835.
