### PR TITLE
AC-843 Single-source release/version copy

### DIFF
--- a/autocontext/tests/test_release_surface_manifest.py
+++ b/autocontext/tests/test_release_surface_manifest.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "sync_release_surfaces.py"
+
+
+def _load_sync_module() -> Any:
+    spec = importlib.util.spec_from_file_location("sync_release_surfaces", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_release_manifest_syncs_public_surfaces() -> None:
+    sync = _load_sync_module()
+    manifest = sync.load_release_manifest()
+    issues = sync.check_release_surfaces(manifest)
+
+    assert issues == []
+
+
+def test_release_manifest_renders_whats_new_asset() -> None:
+    sync = _load_sync_module()
+    manifest = sync.ReleaseManifest(
+        core_version="1.2.3",
+        pi_version="0.8.0",
+        pi_autoctx_dependency="^0.8.0",
+        whats_new=("**One** thing.", "**Two** thing."),
+    )
+
+    assert sync.render_whats_new_asset(manifest) == "**One** thing.\n**Two** thing.\n"
+    assert sync.render_whats_new_heading(manifest) == "What's New in 1.2.3"

--- a/autocontext/tests/test_release_surface_manifest.py
+++ b/autocontext/tests/test_release_surface_manifest.py
@@ -37,3 +37,38 @@ def test_release_manifest_renders_whats_new_asset() -> None:
 
     assert sync.render_whats_new_asset(manifest) == "**One** thing.\n**Two** thing.\n"
     assert sync.render_whats_new_heading(manifest) == "What's New in 1.2.3"
+
+
+def test_pi_version_syncs_install_snippets() -> None:
+    sync = _load_sync_module()
+    manifest = sync.ReleaseManifest(
+        core_version="0.10.0",
+        pi_version="0.9.0",
+        pi_autoctx_dependency="^0.9.0",
+        whats_new=("**One** thing.",),
+    )
+
+    root = sync.sync_root_readme((REPO_ROOT / "README.md").read_text(encoding="utf-8"), manifest)
+    pi_readme = sync.sync_pi_readme((REPO_ROOT / "pi" / "README.md").read_text(encoding="utf-8"), manifest)
+
+    assert "pi install npm:pi-autocontext@0.9.0" in root
+    assert "pi install npm:pi-autocontext@0.9.0" in pi_readme
+    assert '"npm:pi-autocontext@0.9.0"' in pi_readme
+    assert "pi-autocontext@0.8.0" not in root
+    assert "pi-autocontext@0.8.0" not in pi_readme
+
+
+def test_release_manifest_checks_package_version_files() -> None:
+    sync = _load_sync_module()
+    manifest = sync.ReleaseManifest(
+        core_version="9.9.9",
+        pi_version="0.9.0",
+        pi_autoctx_dependency="^0.9.0",
+        whats_new=("**One** thing.",),
+    )
+
+    issues = sync.check_release_surfaces(manifest)
+
+    assert "autocontext/src/autocontext/__init__.py version 0.10.0 != manifest 9.9.9" in issues
+    assert "pi/package.json version 0.8.0 != manifest 0.9.0" in issues
+    assert "pi/package.json autoctx dependency ^0.8.0 != manifest ^0.9.0" in issues

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -10,12 +10,19 @@ Use this checklist when preparing a tagged release such as `py-v0.4.9`, `ts-v0.4
 
 ## 2. Sync Version Metadata
 
-Update every version surface that should ship together:
+Update package versions that should ship together:
 
 - `autocontext/pyproject.toml`
 - `autocontext/src/autocontext/__init__.py`
 - `ts/package.json`
 - `pi/package.json`
+
+Then update `docs/release-manifest.json` and sync public release copy:
+
+```bash
+python scripts/sync_release_surfaces.py
+python scripts/sync_release_surfaces.py --check
+```
 
 If one package is intentionally not being released, note that clearly in the PR.
 
@@ -73,6 +80,7 @@ npm pack --dry-run
 - Confirm `.github/workflows/publish-python.yml`, `.github/workflows/publish-ts.yml`, and `.github/workflows/publish-pi-autocontext.yml` still match the intended publish surfaces.
 - Treat `.github/workflows/publish-python.yml`, `.github/workflows/publish-ts.yml`, and `.github/workflows/publish-pi-autocontext.yml` as the supported release workflows. Do not add a parallel publish path without updating the trusted publisher configuration first.
 - Confirm release notes in `CHANGELOG.md` reflect the tagged version.
+- Confirm `python scripts/sync_release_surfaces.py --check` passes.
 - Confirm any install commands in the READMEs still match the package names and binaries.
 
 ## 6. Publish

--- a/docs/release-manifest.json
+++ b/docs/release-manifest.json
@@ -1,0 +1,10 @@
+{
+  "core_version": "0.10.0",
+  "pi_version": "0.8.0",
+  "pi_autoctx_dependency": "^0.8.0",
+  "whats_new": [
+    "**Scaled training plans** add default-off CUDA/TRL profiles for 7B QLoRA RLVR and sharded 32B/72B distillation across Python and TypeScript.",
+    "**Training scale metadata** records device count, sharding, memory budgets, quantization, parameter count, and deployment VRAM for registry gating.",
+    "**TypeScript CLI parity** makes `--scale-profile` preserve profile backend/base/mode and documents every scale-related train flag."
+  ]
+}

--- a/scripts/sync_release_surfaces.py
+++ b/scripts/sync_release_surfaces.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Sync release/version copy from docs/release-manifest.json."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "docs" / "release-manifest.json"
+WHATS_NEW_BLOCK_START = "<!-- autocontext-whats-new:start -->"
+WHATS_NEW_BLOCK_END = "<!-- autocontext-whats-new:end -->"
+_VERSION_RE = r"\d+\.\d+\.\d+"
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseManifest:
+    core_version: str
+    pi_version: str
+    pi_autoctx_dependency: str
+    whats_new: tuple[str, ...]
+
+
+def load_release_manifest(path: Path = MANIFEST_PATH) -> ReleaseManifest:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return ReleaseManifest(
+        core_version=str(data["core_version"]),
+        pi_version=str(data["pi_version"]),
+        pi_autoctx_dependency=str(data["pi_autoctx_dependency"]),
+        whats_new=tuple(str(item) for item in data["whats_new"]),
+    )
+
+
+def render_whats_new_asset(manifest: ReleaseManifest) -> str:
+    return "\n".join(manifest.whats_new) + "\n"
+
+
+def render_whats_new_heading(manifest: ReleaseManifest) -> str:
+    return f"What's New in {manifest.core_version}"
+
+
+def render_readme_whats_new_block(manifest: ReleaseManifest) -> str:
+    items = "\n".join(f"- {item}" for item in manifest.whats_new)
+    return f"{WHATS_NEW_BLOCK_START}\n## {render_whats_new_heading(manifest)}\n\n{items}\n{WHATS_NEW_BLOCK_END}"
+
+
+def render_pi_release_note(manifest: ReleaseManifest, prefix: str = "Pi is on a separate package line") -> str:
+    return (
+        f"{prefix}: `pi-autocontext@{manifest.pi_version}` depends on "
+        f"`autoctx@{manifest.pi_autoctx_dependency}`. A follow-up Pi release can move it to a newer "
+        "`autoctx` line after the core npm package is live."
+    )
+
+
+def _replace_block(text: str, start: str, end: str, replacement: str) -> str:
+    pattern = re.compile(rf"{re.escape(start)}.*?{re.escape(end)}", re.DOTALL)
+    if not pattern.search(text):
+        raise ValueError(f"sync markers not found for {start}")
+    return pattern.sub(replacement, text, count=1)
+
+
+def _replace_versions(text: str, manifest: ReleaseManifest) -> str:
+    text = re.sub(rf"autocontext=={_VERSION_RE}", f"autocontext=={manifest.core_version}", text)
+    return re.sub(rf"autoctx@{_VERSION_RE}", f"autoctx@{manifest.core_version}", text)
+
+
+def _replace_root_pi_notes(text: str, manifest: ReleaseManifest) -> str:
+    separate_note = re.compile(
+        r"Pi is on a separate package line: `pi-autocontext@[^`]+` depends on `autoctx@[^`]+`\. "
+        r"A follow-up Pi release can move it to a newer `autoctx` line after the core npm package is live\."
+    )
+    text = separate_note.sub(render_pi_release_note(manifest), text)
+    blockquote_note = re.compile(
+        r"`pi-autocontext@[^`]+` still depends on `autoctx@[^`]+`; "
+        r"a follow-up Pi release can move it to a newer `autoctx` line after the core npm package is live\."
+    )
+    return blockquote_note.sub(
+        f"`pi-autocontext@{manifest.pi_version}` still depends on `autoctx@{manifest.pi_autoctx_dependency}`; "
+        "a follow-up Pi release can move it to a newer `autoctx` line after the core npm package is live.",
+        text,
+    )
+
+
+def sync_root_readme(text: str, manifest: ReleaseManifest) -> str:
+    text = _replace_versions(text, manifest)
+    text = _replace_root_pi_notes(text, manifest)
+    return _replace_block(text, WHATS_NEW_BLOCK_START, WHATS_NEW_BLOCK_END, render_readme_whats_new_block(manifest))
+
+
+def sync_python_readme(text: str, manifest: ReleaseManifest) -> str:
+    return re.sub(rf"autocontext=={_VERSION_RE}", f"autocontext=={manifest.core_version}", text)
+
+
+def sync_ts_readme(text: str, manifest: ReleaseManifest) -> str:
+    return re.sub(rf"autoctx@{_VERSION_RE}", f"autoctx@{manifest.core_version}", text)
+
+
+def render_pi_package_note(manifest: ReleaseManifest) -> str:
+    return (
+        f"Current package note: `pi-autocontext@{manifest.pi_version}` is on a separate Pi extension line "
+        f"and depends on `autoctx@{manifest.pi_autoctx_dependency}`. A follow-up Pi release can move it "
+        "to a newer `autoctx` line after the core npm package is live."
+    )
+
+
+def sync_pi_readme(text: str, manifest: ReleaseManifest) -> str:
+    note = re.compile(
+        r"Current package note: `pi-autocontext@[^`]+` is on a separate Pi extension line and "
+        r"depends on `autoctx@[^`]+`\. A follow-up Pi release can move it to a newer `autoctx` line "
+        r"after the core npm package is live\."
+    )
+    return note.sub(render_pi_package_note(manifest), text)
+
+
+def sync_banner_py(text: str, manifest: ReleaseManifest) -> str:
+    return re.sub(
+        r"README_WHATS_NEW_HEADING = \"[^\"]+\"",
+        f'README_WHATS_NEW_HEADING = "{render_whats_new_heading(manifest)}"',
+        text,
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _read_toml(path: Path) -> dict[str, Any]:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def planned_release_surface_updates(manifest: ReleaseManifest) -> dict[Path, str]:
+    return {
+        REPO_ROOT / "README.md": sync_root_readme((REPO_ROOT / "README.md").read_text(encoding="utf-8"), manifest),
+        REPO_ROOT / "autocontext" / "README.md": sync_python_readme(
+            (REPO_ROOT / "autocontext" / "README.md").read_text(encoding="utf-8"), manifest
+        ),
+        REPO_ROOT / "ts" / "README.md": sync_ts_readme((REPO_ROOT / "ts" / "README.md").read_text(encoding="utf-8"), manifest),
+        REPO_ROOT / "pi" / "README.md": sync_pi_readme((REPO_ROOT / "pi" / "README.md").read_text(encoding="utf-8"), manifest),
+        REPO_ROOT / "autocontext" / "assets" / "whats_new.txt": render_whats_new_asset(manifest),
+        REPO_ROOT / "autocontext" / "src" / "autocontext" / "banner.py": sync_banner_py(
+            (REPO_ROOT / "autocontext" / "src" / "autocontext" / "banner.py").read_text(encoding="utf-8"), manifest
+        ),
+    }
+
+
+def check_release_surfaces(manifest: ReleaseManifest) -> list[str]:
+    issues: list[str] = []
+    pyproject_version = _read_toml(REPO_ROOT / "autocontext" / "pyproject.toml")["project"]["version"]
+    package_version = _read_json(REPO_ROOT / "ts" / "package.json")["version"]
+    if pyproject_version != manifest.core_version:
+        issues.append(f"autocontext/pyproject.toml version {pyproject_version} != manifest {manifest.core_version}")
+    if package_version != manifest.core_version:
+        issues.append(f"ts/package.json version {package_version} != manifest {manifest.core_version}")
+    for path, expected in planned_release_surface_updates(manifest).items():
+        if path.read_text(encoding="utf-8") != expected:
+            issues.append(f"{path.relative_to(REPO_ROOT)} is not synced with docs/release-manifest.json")
+    return issues
+
+
+def write_release_surfaces(manifest: ReleaseManifest) -> None:
+    for path, expected in planned_release_surface_updates(manifest).items():
+        if path.read_text(encoding="utf-8") != expected:
+            path.write_text(expected, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail if public release surfaces are stale")
+    args = parser.parse_args()
+    manifest = load_release_manifest()
+    if args.check:
+        issues = check_release_surfaces(manifest)
+        for issue in issues:
+            print(issue)
+        return 1 if issues else 0
+    write_release_surfaces(manifest)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_release_surfaces.py
+++ b/scripts/sync_release_surfaces.py
@@ -9,7 +9,7 @@ import re
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = REPO_ROOT / "docs" / "release-manifest.json"
@@ -49,7 +49,9 @@ def render_readme_whats_new_block(manifest: ReleaseManifest) -> str:
     return f"{WHATS_NEW_BLOCK_START}\n## {render_whats_new_heading(manifest)}\n\n{items}\n{WHATS_NEW_BLOCK_END}"
 
 
-def render_pi_release_note(manifest: ReleaseManifest, prefix: str = "Pi is on a separate package line") -> str:
+def render_pi_release_note(
+    manifest: ReleaseManifest, prefix: str = "Pi is on a separate package line"
+) -> str:
     return (
         f"{prefix}: `pi-autocontext@{manifest.pi_version}` depends on "
         f"`autoctx@{manifest.pi_autoctx_dependency}`. A follow-up Pi release can move it to a newer "
@@ -65,8 +67,13 @@ def _replace_block(text: str, start: str, end: str, replacement: str) -> str:
 
 
 def _replace_versions(text: str, manifest: ReleaseManifest) -> str:
-    text = re.sub(rf"autocontext=={_VERSION_RE}", f"autocontext=={manifest.core_version}", text)
-    return re.sub(rf"autoctx@{_VERSION_RE}", f"autoctx@{manifest.core_version}", text)
+    text = re.sub(
+        rf"autocontext=={_VERSION_RE}", f"autocontext=={manifest.core_version}", text
+    )
+    text = re.sub(rf"autoctx@{_VERSION_RE}", f"autoctx@{manifest.core_version}", text)
+    return re.sub(
+        rf"pi-autocontext@{_VERSION_RE}", f"pi-autocontext@{manifest.pi_version}", text
+    )
 
 
 def _replace_root_pi_notes(text: str, manifest: ReleaseManifest) -> str:
@@ -89,11 +96,18 @@ def _replace_root_pi_notes(text: str, manifest: ReleaseManifest) -> str:
 def sync_root_readme(text: str, manifest: ReleaseManifest) -> str:
     text = _replace_versions(text, manifest)
     text = _replace_root_pi_notes(text, manifest)
-    return _replace_block(text, WHATS_NEW_BLOCK_START, WHATS_NEW_BLOCK_END, render_readme_whats_new_block(manifest))
+    return _replace_block(
+        text,
+        WHATS_NEW_BLOCK_START,
+        WHATS_NEW_BLOCK_END,
+        render_readme_whats_new_block(manifest),
+    )
 
 
 def sync_python_readme(text: str, manifest: ReleaseManifest) -> str:
-    return re.sub(rf"autocontext=={_VERSION_RE}", f"autocontext=={manifest.core_version}", text)
+    return re.sub(
+        rf"autocontext=={_VERSION_RE}", f"autocontext=={manifest.core_version}", text
+    )
 
 
 def sync_ts_readme(text: str, manifest: ReleaseManifest) -> str:
@@ -114,7 +128,7 @@ def sync_pi_readme(text: str, manifest: ReleaseManifest) -> str:
         r"depends on `autoctx@[^`]+`\. A follow-up Pi release can move it to a newer `autoctx` line "
         r"after the core npm package is live\."
     )
-    return note.sub(render_pi_package_note(manifest), text)
+    return note.sub(render_pi_package_note(manifest), _replace_versions(text, manifest))
 
 
 def sync_banner_py(text: str, manifest: ReleaseManifest) -> str:
@@ -126,39 +140,85 @@ def sync_banner_py(text: str, manifest: ReleaseManifest) -> str:
 
 
 def _read_json(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return cast(dict[str, Any], data)
 
 
 def _read_toml(path: Path) -> dict[str, Any]:
-    return tomllib.loads(path.read_text(encoding="utf-8"))
+    return cast(dict[str, Any], tomllib.loads(path.read_text(encoding="utf-8")))
+
+
+def _read_python_init_version(path: Path) -> str:
+    match = re.search(r'^__version__ = "([^"]+)"$', path.read_text(encoding="utf-8"), re.MULTILINE)
+    if match is None:
+        raise ValueError(f"{path} does not define __version__")
+    return match.group(1)
 
 
 def planned_release_surface_updates(manifest: ReleaseManifest) -> dict[Path, str]:
     return {
-        REPO_ROOT / "README.md": sync_root_readme((REPO_ROOT / "README.md").read_text(encoding="utf-8"), manifest),
-        REPO_ROOT / "autocontext" / "README.md": sync_python_readme(
-            (REPO_ROOT / "autocontext" / "README.md").read_text(encoding="utf-8"), manifest
+        REPO_ROOT / "README.md": sync_root_readme(
+            (REPO_ROOT / "README.md").read_text(encoding="utf-8"), manifest
         ),
-        REPO_ROOT / "ts" / "README.md": sync_ts_readme((REPO_ROOT / "ts" / "README.md").read_text(encoding="utf-8"), manifest),
-        REPO_ROOT / "pi" / "README.md": sync_pi_readme((REPO_ROOT / "pi" / "README.md").read_text(encoding="utf-8"), manifest),
-        REPO_ROOT / "autocontext" / "assets" / "whats_new.txt": render_whats_new_asset(manifest),
+        REPO_ROOT / "autocontext" / "README.md": sync_python_readme(
+            (REPO_ROOT / "autocontext" / "README.md").read_text(encoding="utf-8"),
+            manifest,
+        ),
+        REPO_ROOT / "ts" / "README.md": sync_ts_readme(
+            (REPO_ROOT / "ts" / "README.md").read_text(encoding="utf-8"), manifest
+        ),
+        REPO_ROOT / "pi" / "README.md": sync_pi_readme(
+            (REPO_ROOT / "pi" / "README.md").read_text(encoding="utf-8"), manifest
+        ),
+        REPO_ROOT / "autocontext" / "assets" / "whats_new.txt": render_whats_new_asset(
+            manifest
+        ),
         REPO_ROOT / "autocontext" / "src" / "autocontext" / "banner.py": sync_banner_py(
-            (REPO_ROOT / "autocontext" / "src" / "autocontext" / "banner.py").read_text(encoding="utf-8"), manifest
+            (REPO_ROOT / "autocontext" / "src" / "autocontext" / "banner.py").read_text(
+                encoding="utf-8"
+            ),
+            manifest,
         ),
     }
 
 
 def check_release_surfaces(manifest: ReleaseManifest) -> list[str]:
     issues: list[str] = []
-    pyproject_version = _read_toml(REPO_ROOT / "autocontext" / "pyproject.toml")["project"]["version"]
-    package_version = _read_json(REPO_ROOT / "ts" / "package.json")["version"]
+    pyproject = _read_toml(REPO_ROOT / "autocontext" / "pyproject.toml")
+    pyproject_version = str(cast(dict[str, Any], pyproject["project"])["version"])
+    python_init_version = _read_python_init_version(
+        REPO_ROOT / "autocontext" / "src" / "autocontext" / "__init__.py"
+    )
+    package_version = str(_read_json(REPO_ROOT / "ts" / "package.json")["version"])
+    pi_package = _read_json(REPO_ROOT / "pi" / "package.json")
+    pi_version = str(pi_package["version"])
+    pi_dependencies = cast(dict[str, Any], pi_package["dependencies"])
+    pi_autoctx_dependency = str(pi_dependencies["autoctx"])
     if pyproject_version != manifest.core_version:
-        issues.append(f"autocontext/pyproject.toml version {pyproject_version} != manifest {manifest.core_version}")
+        issues.append(
+            f"autocontext/pyproject.toml version {pyproject_version} != manifest {manifest.core_version}"
+        )
+    if python_init_version != manifest.core_version:
+        issues.append(
+            f"autocontext/src/autocontext/__init__.py version {python_init_version} != manifest {manifest.core_version}"
+        )
     if package_version != manifest.core_version:
-        issues.append(f"ts/package.json version {package_version} != manifest {manifest.core_version}")
+        issues.append(
+            f"ts/package.json version {package_version} != manifest {manifest.core_version}"
+        )
+    if pi_version != manifest.pi_version:
+        issues.append(f"pi/package.json version {pi_version} != manifest {manifest.pi_version}")
+    if pi_autoctx_dependency != manifest.pi_autoctx_dependency:
+        issues.append(
+            f"pi/package.json autoctx dependency {pi_autoctx_dependency} != manifest {manifest.pi_autoctx_dependency}"
+        )
     for path, expected in planned_release_surface_updates(manifest).items():
         if path.read_text(encoding="utf-8") != expected:
-            issues.append(f"{path.relative_to(REPO_ROOT)} is not synced with docs/release-manifest.json")
+            issues.append(
+                f"{path.relative_to(REPO_ROOT)} is not synced with docs/release-manifest.json"
+            )
     return issues
 
 
@@ -170,7 +230,9 @@ def write_release_surfaces(manifest: ReleaseManifest) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--check", action="store_true", help="fail if public release surfaces are stale")
+    parser.add_argument(
+        "--check", action="store_true", help="fail if public release surfaces are stale"
+    )
     args = parser.parse_args()
     manifest = load_release_manifest()
     if args.check:


### PR DESCRIPTION
## Summary
- Add `docs/release-manifest.json` as the source for public release/version copy
- Add `scripts/sync_release_surfaces.py` with sync and `--check` modes
- Add a pytest guard that keeps README/package release surfaces synced
- Update the release checklist to use the manifest sync step

## Validation
- `cd autocontext && .venv/bin/python -m pytest tests/test_release_surface_manifest.py tests/test_module_size_limits.py -q`
- `cd autocontext && .venv/bin/python -m ruff check ../scripts/sync_release_surfaces.py tests/test_release_surface_manifest.py`
- `python3 scripts/sync_release_surfaces.py --check`
- `git diff --check`

## Notes
- This only changes release/docs automation; package runtime behavior is unchanged.
