### PR TITLE
AC-847 Adopt parity-last coding practice

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@
 
 ## Surfaces Touched
 
+- [ ] Parity decision: cross-runtime parity is user-visible and required now, or explicitly deferred below
 - [ ] Python package
 - [ ] TypeScript package
 - [ ] TUI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ cd ts
 npm install
 ```
 
+## Parity-Last Changes
+
+Implement one runtime first unless cross-runtime parity is user-visible in the same release. If parity is deferred, say where and why in the PR.
+
 ## Common Checks
 
 Python:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ npm test
 - The Python package name and CLI are `autocontext` / `autoctx`.
 - Environment variables use the `AUTOCONTEXT_` prefix.
 - Prefer targeted tests for touched modules before running full suites.
+- Use parity-last changes: implement one runtime first unless cross-runtime parity is user-visible in the same release. Note deferred parity in the PR.
 - Keep protocol changes in sync with `scripts/generate_protocol.py`.
 - Avoid rewriting historical plan docs unless the change is user-facing or release-facing.
 

--- a/autocontext/tests/test_contributor_guidance.py
+++ b/autocontext/tests/test_contributor_guidance.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_repo_file(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_parity_last_guidance_is_documented_for_people_and_agents() -> None:
+    for path in ("CONTRIBUTING.md", "AGENTS.md"):
+        text = _read_repo_file(path)
+        assert "parity-last" in text.lower()
+        assert "one runtime first" in text.lower()
+        assert "user-visible" in text.lower()
+
+
+def test_pr_template_requires_parity_decision() -> None:
+    text = _read_repo_file(".github/PULL_REQUEST_TEMPLATE.md")
+
+    assert "Parity decision" in text
+    assert "required now" in text
+    assert "deferred" in text


### PR DESCRIPTION
## Summary
- document parity-last contribution guidance for humans and agents
- add a PR template checkbox requiring a parity decision
- add a small pytest guard for the guidance/template text

## Surfaces Touched

- [x] Parity decision: docs-only contributor process change; no runtime parity required
- [ ] Python package
- [ ] TypeScript package
- [ ] TUI
- [x] Docs or examples
- [ ] CI or release metadata

## Verification

- [x] `cd autocontext && .venv/bin/python -m pytest tests/test_contributor_guidance.py -q`
- [x] `cd autocontext && .venv/bin/python -m pytest tests/test_contributor_guidance.py tests/test_module_size_limits.py -q`
- [x] `cd autocontext && .venv/bin/python -m ruff check tests/test_contributor_guidance.py`
- [x] `git diff --check`

## Docs And Release Impact

- [ ] no user-facing docs changes needed
- [x] updated relevant README/docs/examples
- [ ] updated `CHANGELOG.md`
- [ ] updated version metadata if this is part of a release

## Notes

- AC-847 cleanup only; package behavior unchanged.
