### PR TITLE
AC-844 Shrink repeated test setup

### DIFF
--- a/autocontext/tests/test_generation_stages.py
+++ b/autocontext/tests/test_generation_stages.py
@@ -180,58 +180,49 @@ def _make_ctx(settings: AppSettings | None = None, scenario: MagicMock | None = 
     )
 
 
+def _make_knowledge_stage_mocks(**artifact_reads: object) -> tuple[MagicMock, MagicMock]:
+    artifacts = MagicMock()
+    defaults: dict[str, object] = {
+        "read_playbook": "",
+        "read_tool_context": "",
+        "read_skills": "",
+        "read_mutation_replay": "",
+        "read_latest_weakness_reports_markdown": "",
+        "read_latest_progress_reports_markdown": "",
+        "read_latest_session_reports": "",
+        "read_latest_advance_analysis": "",
+        "read_progress": None,
+    }
+    defaults.update(artifact_reads)
+    for reader, value in defaults.items():
+        getattr(artifacts, reader).return_value = value
+
+    trajectory = MagicMock()
+    trajectory.build_trajectory.return_value = ""
+    trajectory.build_strategy_registry.return_value = ""
+    trajectory.build_experiment_log.return_value = ""
+    return artifacts, trajectory
+
+
 # ---------- TestStageKnowledgeSetup ----------
 
 
 class TestStageKnowledgeSetup:
     def test_populates_prompts(self) -> None:
-        artifacts = MagicMock()
-        artifacts.read_playbook.return_value = "Playbook content"
-        artifacts.read_tool_context.return_value = ""
-        artifacts.read_skills.return_value = ""
-        artifacts.read_mutation_replay.return_value = ""
-        artifacts.read_latest_weakness_reports_markdown.return_value = ""
-        artifacts.read_latest_progress_reports_markdown.return_value = ""
-        artifacts.read_latest_advance_analysis.return_value = ""
-        artifacts.read_progress.return_value = None
-        trajectory = MagicMock()
-        trajectory.build_trajectory.return_value = ""
-        trajectory.build_strategy_registry.return_value = ""
+        artifacts, trajectory = _make_knowledge_stage_mocks(read_playbook="Playbook content")
         ctx = _make_ctx()
         result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
         assert result.prompts is not None
         assert result.prompts.competitor  # non-empty
 
     def test_sets_strategy_interface(self) -> None:
-        artifacts = MagicMock()
-        artifacts.read_playbook.return_value = ""
-        artifacts.read_tool_context.return_value = ""
-        artifacts.read_skills.return_value = ""
-        artifacts.read_mutation_replay.return_value = ""
-        artifacts.read_latest_weakness_reports_markdown.return_value = ""
-        artifacts.read_latest_progress_reports_markdown.return_value = ""
-        artifacts.read_latest_advance_analysis.return_value = ""
-        artifacts.read_progress.return_value = None
-        trajectory = MagicMock()
-        trajectory.build_trajectory.return_value = ""
-        trajectory.build_strategy_registry.return_value = ""
+        artifacts, trajectory = _make_knowledge_stage_mocks()
         ctx = _make_ctx()
         result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
         assert result.strategy_interface == '{"aggression": float}'
 
     def test_lean_harness_profile_caps_prompt_budget(self) -> None:
-        artifacts = MagicMock()
-        artifacts.read_playbook.return_value = ""
-        artifacts.read_tool_context.return_value = ""
-        artifacts.read_skills.return_value = ""
-        artifacts.read_mutation_replay.return_value = ""
-        artifacts.read_latest_weakness_reports_markdown.return_value = ""
-        artifacts.read_latest_progress_reports_markdown.return_value = ""
-        artifacts.read_latest_advance_analysis.return_value = ""
-        artifacts.read_progress.return_value = None
-        trajectory = MagicMock()
-        trajectory.build_trajectory.return_value = ""
-        trajectory.build_strategy_registry.return_value = ""
+        artifacts, trajectory = _make_knowledge_stage_mocks()
         trajectory.build_experiment_log.return_value = ""
         settings = AppSettings(
             agent_provider="deterministic",
@@ -262,19 +253,7 @@ class TestStageKnowledgeSetup:
         assert captured["context_budget_tokens"] == 16_000
 
     def test_lean_harness_profile_enforces_tool_allowlist(self) -> None:
-        artifacts = MagicMock()
-        artifacts.read_playbook.return_value = ""
-        artifacts.read_tool_context.return_value = "Generated helper source"
-        artifacts.read_skills.return_value = ""
-        artifacts.read_mutation_replay.return_value = ""
-        artifacts.read_latest_weakness_reports_markdown.return_value = ""
-        artifacts.read_latest_progress_reports_markdown.return_value = ""
-        artifacts.read_latest_advance_analysis.return_value = ""
-        artifacts.read_progress.return_value = None
-        trajectory = MagicMock()
-        trajectory.build_trajectory.return_value = ""
-        trajectory.build_strategy_registry.return_value = ""
-        trajectory.build_experiment_log.return_value = ""
+        artifacts, trajectory = _make_knowledge_stage_mocks(read_tool_context="Generated helper source")
         settings = AppSettings(
             agent_provider="deterministic",
             harness_profile=HarnessProfile.LEAN,
@@ -304,19 +283,9 @@ class TestStageKnowledgeSetup:
         artifacts.read_tool_context.assert_not_called()
 
     def test_includes_mutation_replay_in_prompt_context(self) -> None:
-        artifacts = MagicMock()
-        artifacts.read_playbook.return_value = ""
-        artifacts.read_tool_context.return_value = ""
-        artifacts.read_skills.return_value = ""
-        artifacts.read_mutation_replay.return_value = "Context mutations since last checkpoint:\n- gen 2: playbook_updated"
-        artifacts.read_latest_weakness_reports_markdown.return_value = ""
-        artifacts.read_latest_progress_reports_markdown.return_value = ""
-        artifacts.read_latest_advance_analysis.return_value = ""
-        artifacts.read_progress.return_value = None
-        trajectory = MagicMock()
-        trajectory.build_trajectory.return_value = ""
-        trajectory.build_strategy_registry.return_value = ""
-        trajectory.build_experiment_log.return_value = ""
+        artifacts, trajectory = _make_knowledge_stage_mocks(
+            read_mutation_replay="Context mutations since last checkpoint:\n- gen 2: playbook_updated"
+        )
         ctx = _make_ctx()
 
         result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
@@ -325,21 +294,11 @@ class TestStageKnowledgeSetup:
         assert "Context mutations since last checkpoint" in result.prompts.competitor
 
     def test_includes_recent_weakness_reports_in_prompt_context(self) -> None:
-        artifacts = MagicMock()
-        artifacts.read_playbook.return_value = ""
-        artifacts.read_tool_context.return_value = ""
-        artifacts.read_skills.return_value = ""
-        artifacts.read_mutation_replay.return_value = ""
-        artifacts.read_latest_weakness_reports_markdown.return_value = (
-            "# Weakness Report: run_1\n## [HIGH] dead_end_pattern\nRepeated rollbacks detected"
+        artifacts, trajectory = _make_knowledge_stage_mocks(
+            read_latest_weakness_reports_markdown=(
+                "# Weakness Report: run_1\n## [HIGH] dead_end_pattern\nRepeated rollbacks detected"
+            )
         )
-        artifacts.read_latest_progress_reports_markdown.return_value = ""
-        artifacts.read_latest_advance_analysis.return_value = ""
-        artifacts.read_progress.return_value = None
-        trajectory = MagicMock()
-        trajectory.build_trajectory.return_value = ""
-        trajectory.build_strategy_registry.return_value = ""
-        trajectory.build_experiment_log.return_value = ""
         ctx = _make_ctx()
 
         result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
@@ -349,21 +308,9 @@ class TestStageKnowledgeSetup:
         assert "dead_end_pattern" in result.prompts.competitor
 
     def test_includes_recent_progress_reports_in_prompt_context(self) -> None:
-        artifacts = MagicMock()
-        artifacts.read_playbook.return_value = ""
-        artifacts.read_tool_context.return_value = ""
-        artifacts.read_skills.return_value = ""
-        artifacts.read_mutation_replay.return_value = ""
-        artifacts.read_latest_weakness_reports_markdown.return_value = ""
-        artifacts.read_latest_progress_reports_markdown.return_value = (
-            "# Progress Report: run_2\n- Total cost: $0.0240\n- Tokens per advance: 3,400"
+        artifacts, trajectory = _make_knowledge_stage_mocks(
+            read_latest_progress_reports_markdown=("# Progress Report: run_2\n- Total cost: $0.0240\n- Tokens per advance: 3,400")
         )
-        artifacts.read_latest_advance_analysis.return_value = ""
-        artifacts.read_progress.return_value = None
-        trajectory = MagicMock()
-        trajectory.build_trajectory.return_value = ""
-        trajectory.build_strategy_registry.return_value = ""
-        trajectory.build_experiment_log.return_value = ""
         ctx = _make_ctx()
 
         result = stage_knowledge_setup(ctx, artifacts=artifacts, trajectory_builder=trajectory)
@@ -399,18 +346,7 @@ class TestStageKnowledgeSetup:
 
     def test_skips_session_reports_when_disabled(self) -> None:
         settings = AppSettings(agent_provider="deterministic", session_reports_enabled=False)
-        artifacts = MagicMock()
-        artifacts.read_playbook.return_value = ""
-        artifacts.read_tool_context.return_value = ""
-        artifacts.read_skills.return_value = ""
-        artifacts.read_mutation_replay.return_value = ""
-        artifacts.read_latest_weakness_reports_markdown.return_value = ""
-        artifacts.read_latest_progress_reports_markdown.return_value = ""
-        artifacts.read_latest_advance_analysis.return_value = ""
-        artifacts.read_progress.return_value = None
-        trajectory = MagicMock()
-        trajectory.build_trajectory.return_value = ""
-        trajectory.build_strategy_registry.return_value = ""
+        artifacts, trajectory = _make_knowledge_stage_mocks()
         trajectory.build_experiment_log.return_value = ""
         ctx = _make_ctx(settings=settings)
 
@@ -505,18 +441,7 @@ class TestStageKnowledgeSetup:
         assert "Try aggression <= 0.4 next generation" not in result.prompts.analyst
 
     def test_includes_environment_snapshot_in_prompt_context(self) -> None:
-        artifacts = MagicMock()
-        artifacts.read_playbook.return_value = ""
-        artifacts.read_tool_context.return_value = ""
-        artifacts.read_skills.return_value = ""
-        artifacts.read_mutation_replay.return_value = ""
-        artifacts.read_latest_weakness_reports_markdown.return_value = ""
-        artifacts.read_latest_progress_reports_markdown.return_value = ""
-        artifacts.read_latest_advance_analysis.return_value = ""
-        artifacts.read_progress.return_value = None
-        trajectory = MagicMock()
-        trajectory.build_trajectory.return_value = ""
-        trajectory.build_strategy_registry.return_value = ""
+        artifacts, trajectory = _make_knowledge_stage_mocks()
         trajectory.build_experiment_log.return_value = ""
         ctx = _make_ctx()
         ctx.environment_snapshot = "## Environment\nPython 3.13 | macOS"
@@ -625,12 +550,7 @@ class TestStageKnowledgeSetup:
             >= result.semantic_compaction_benchmark["budget_only_variant"]["signal_lines_preserved"]
         )
         assert result.semantic_compaction_benchmark["evidence_cache_lookups"] == 1
-        report_path = (
-            artifacts.knowledge_root
-            / "test_scenario"
-            / "semantic_compaction_reports"
-            / "run_test_gen_1.json"
-        )
+        report_path = artifacts.knowledge_root / "test_scenario" / "semantic_compaction_reports" / "run_test_gen_1.json"
         assert report_path.exists()
         persisted = json.loads(report_path.read_text(encoding="utf-8"))
         assert persisted["context_budget_tokens"] == 180

--- a/autocontext/tests/test_knowledge_solver.py
+++ b/autocontext/tests/test_knowledge_solver.py
@@ -89,6 +89,15 @@ class _StubProvider:
         return "test-model"
 
 
+def _solve_settings(tmp_path: Path, **overrides: object) -> AppSettings:
+    values: dict[str, object] = {
+        "knowledge_root": tmp_path / "knowledge",
+        "db_path": tmp_path / "runs.sqlite3",
+    }
+    values.update(overrides)
+    return AppSettings(**values)
+
+
 class _SolveAgentTask(AgentTaskInterface):
     name = "solve_agent_task_fixture"
 
@@ -873,9 +882,8 @@ class TestSolveLLMFn:
             SolveScenarioExecutor,
         )
 
-        settings = AppSettings(
-            knowledge_root=tmp_path / "knowledge",
-            db_path=tmp_path / "runs.sqlite3",
+        settings = _solve_settings(
+            tmp_path,
             agent_provider="pi",
             pi_timeout=300.0,
         )
@@ -917,9 +925,8 @@ class TestSolveLLMFn:
     ) -> None:
         from autocontext.knowledge.solver import SolveScenarioExecutor
 
-        settings = AppSettings(
-            knowledge_root=tmp_path / "knowledge",
-            db_path=tmp_path / "runs.sqlite3",
+        settings = _solve_settings(
+            tmp_path,
             agent_provider="pi",
             pi_timeout=900.0,
             generation_time_budget_seconds=420,
@@ -962,9 +969,8 @@ class TestSolveLLMFn:
     ) -> None:
         from autocontext.knowledge.solver import SolveScenarioExecutor
 
-        settings = AppSettings(
-            knowledge_root=tmp_path / "knowledge",
-            db_path=tmp_path / "runs.sqlite3",
+        settings = _solve_settings(
+            tmp_path,
             agent_provider="deterministic",
             competitor_provider="pi-rpc",
             pi_timeout=900.0,
@@ -1015,9 +1021,8 @@ class TestSolveLLMFn:
             SolveScenarioExecutor,
         )
 
-        settings = AppSettings(
-            knowledge_root=tmp_path / "knowledge",
-            db_path=tmp_path / "runs.sqlite3",
+        settings = _solve_settings(
+            tmp_path,
             agent_provider="pi",
             pi_timeout=300.0,
         )
@@ -1073,9 +1078,8 @@ class TestSolveLLMFn:
     ) -> None:
         from autocontext.knowledge.solver import SolveScenarioExecutor
 
-        settings = AppSettings(
-            knowledge_root=tmp_path / "knowledge",
-            db_path=tmp_path / "runs.sqlite3",
+        settings = _solve_settings(
+            tmp_path,
             agent_provider="pi",
             pi_timeout=900.0,
             generation_time_budget_seconds=420,
@@ -1129,9 +1133,8 @@ class TestSolveScenarioExecutor:
     def test_runs_agent_task_scenarios_through_task_loop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from autocontext.knowledge.solver import SolveScenarioExecutor
 
-        settings = AppSettings(
-            knowledge_root=tmp_path / "knowledge",
-            db_path=tmp_path / "runs.sqlite3",
+        settings = _solve_settings(
+            tmp_path,
         )
         scenario_name = "solve_agent_task_execution"
         previous = SCENARIO_REGISTRY.get(scenario_name)
@@ -1172,9 +1175,8 @@ class TestSolveScenarioExecutor:
         from autocontext.extensions import HookBus, HookEvents
         from autocontext.knowledge.solver import SolveScenarioExecutor
 
-        settings = AppSettings(
-            knowledge_root=tmp_path / "knowledge",
-            db_path=tmp_path / "runs.sqlite3",
+        settings = _solve_settings(
+            tmp_path,
         )
         scenario_name = "solve_agent_task_run_end_rounds"
         previous = SCENARIO_REGISTRY.get(scenario_name)
@@ -1234,9 +1236,8 @@ class TestSolveScenarioExecutor:
     def test_runs_artifact_editing_scenarios_through_task_loop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from autocontext.knowledge.solver import SolveScenarioExecutor
 
-        settings = AppSettings(
-            knowledge_root=tmp_path / "knowledge",
-            db_path=tmp_path / "runs.sqlite3",
+        settings = _solve_settings(
+            tmp_path,
         )
         scenario_name = "solve_artifact_editing_execution"
         previous = SCENARIO_REGISTRY.get(scenario_name)
@@ -1289,9 +1290,8 @@ class TestSolveScenarioExecutor:
         from autocontext.knowledge.solver import SolveScenarioExecutor
 
         clock = {"now": 0.0}
-        settings = AppSettings(
-            knowledge_root=tmp_path / "knowledge",
-            db_path=tmp_path / "runs.sqlite3",
+        settings = _solve_settings(
+            tmp_path,
             generation_time_budget_seconds=1,
         )
         scenario_name = "solve_budget_exhausting_execution"
@@ -1360,9 +1360,8 @@ def register(api):
         )
         monkeypatch.setenv("SOLVE_HOOK_EVENTS", str(events_path))
 
-        settings = AppSettings(
-            knowledge_root=tmp_path / "knowledge",
-            db_path=tmp_path / "runs.sqlite3",
+        settings = _solve_settings(
+            tmp_path,
             extensions=str(extension_path),
             extension_fail_fast=True,
         )
@@ -1424,10 +1423,7 @@ def register(api):
             else:
                 SCENARIO_REGISTRY[scenario_name] = previous
 
-        event_names = [
-            json.loads(line)["name"]
-            for line in events_path.read_text(encoding="utf-8").splitlines()
-        ]
+        event_names = [json.loads(line)["name"] for line in events_path.read_text(encoding="utf-8").splitlines()]
 
         assert job.status == "completed"
         assert job.family_name == "agent_task"
@@ -1449,9 +1445,8 @@ def register(api):
             SolveScenarioBuildResult,
         )
 
-        settings = AppSettings(
-            knowledge_root=tmp_path / "knowledge",
-            db_path=tmp_path / "runs.sqlite3",
+        settings = _solve_settings(
+            tmp_path,
         )
         manager = SolveManager(settings)
         created = SolveScenarioBuildResult(

--- a/ts/tests/http-api.test.ts
+++ b/ts/tests/http-api.test.ts
@@ -241,6 +241,24 @@ async function createTestServer(dir: string) {
   return { server, mgr, baseUrl: `http://localhost:${server.port}` };
 }
 
+let dir: string;
+let server: Awaited<ReturnType<typeof createTestServer>>["server"] | undefined;
+let mgr: Awaited<ReturnType<typeof createTestServer>>["mgr"];
+let baseUrl: string;
+
+beforeEach(async () => {
+  dir = makeTempDir();
+  const testServer = await createTestServer(dir);
+  server = testServer.server;
+  mgr = testServer.mgr;
+  baseUrl = testServer.baseUrl;
+});
+
+afterEach(async () => {
+  await server?.stop();
+  rmSync(dir, { recursive: true, force: true });
+});
+
 async function persistRuntimeSession(dir: string): Promise<void> {
   const {
     RuntimeSessionEventLog,
@@ -327,22 +345,6 @@ function persistContextSelectionDecision(dir: string): void {
 // ---------------------------------------------------------------------------
 
 describe("HTTP API — health", () => {
-  let dir: string;
-  let server: Awaited<ReturnType<typeof createTestServer>>["server"];
-  let baseUrl: string;
-
-  beforeEach(async () => {
-    dir = makeTempDir();
-    const s = await createTestServer(dir);
-    server = s.server;
-    baseUrl = s.baseUrl;
-  });
-
-  afterEach(async () => {
-    await server.stop();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
   it("GET /health returns ok", async () => {
     const { status, body } = await fetchJson(`${baseUrl}/health`);
     expect(status).toBe(200);
@@ -471,22 +473,6 @@ describe("HTTP API — health", () => {
 // ---------------------------------------------------------------------------
 
 describe("HTTP API — runs", () => {
-  let dir: string;
-  let server: Awaited<ReturnType<typeof createTestServer>>["server"];
-  let baseUrl: string;
-
-  beforeEach(async () => {
-    dir = makeTempDir();
-    const s = await createTestServer(dir);
-    server = s.server;
-    baseUrl = s.baseUrl;
-  });
-
-  afterEach(async () => {
-    await server.stop();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
   it("GET /api/runs returns run list", async () => {
     const { status, body } = await fetchJson(`${baseUrl}/api/runs`);
     expect(status).toBe(200);
@@ -528,22 +514,6 @@ describe("HTTP API — runs", () => {
 // ---------------------------------------------------------------------------
 
 describe("HTTP API — notebooks", () => {
-  let dir: string;
-  let server: Awaited<ReturnType<typeof createTestServer>>["server"];
-  let baseUrl: string;
-
-  beforeEach(async () => {
-    dir = makeTempDir();
-    const s = await createTestServer(dir);
-    server = s.server;
-    baseUrl = s.baseUrl;
-  });
-
-  afterEach(async () => {
-    await server.stop();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
   it("GET /api/notebooks lists notebooks", async () => {
     const { status, body } = await fetchJson(`${baseUrl}/api/notebooks`);
     expect(status).toBe(200);
@@ -657,24 +627,6 @@ describe("HTTP API — notebooks", () => {
 // ---------------------------------------------------------------------------
 
 describe("HTTP API — monitors", () => {
-  let dir: string;
-  let server: Awaited<ReturnType<typeof createTestServer>>["server"];
-  let mgr: Awaited<ReturnType<typeof createTestServer>>["mgr"];
-  let baseUrl: string;
-
-  beforeEach(async () => {
-    dir = makeTempDir();
-    const s = await createTestServer(dir);
-    server = s.server;
-    mgr = s.mgr;
-    baseUrl = s.baseUrl;
-  });
-
-  afterEach(async () => {
-    await server.stop();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
   it("POST /api/monitors creates a monitor condition", async () => {
     const { status, body } = await postJson(`${baseUrl}/api/monitors`, {
       name: "Score floor",
@@ -833,22 +785,6 @@ describe("HTTP API — monitors", () => {
 // ---------------------------------------------------------------------------
 
 describe("HTTP API — cockpit", () => {
-  let dir: string;
-  let server: Awaited<ReturnType<typeof createTestServer>>["server"];
-  let baseUrl: string;
-
-  beforeEach(async () => {
-    dir = makeTempDir();
-    const s = await createTestServer(dir);
-    server = s.server;
-    baseUrl = s.baseUrl;
-  });
-
-  afterEach(async () => {
-    await server.stop();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
   it("mirrors notebook CRUD under /api/cockpit/notebooks", async () => {
     const created = await putJson(`${baseUrl}/api/cockpit/notebooks/test-run-1`, {
       scenario_name: "grid_ctf",
@@ -1259,22 +1195,6 @@ describe("HTTP API — cockpit", () => {
 // ---------------------------------------------------------------------------
 
 describe("HTTP API — research hub", () => {
-  let dir: string;
-  let server: Awaited<ReturnType<typeof createTestServer>>["server"];
-  let baseUrl: string;
-
-  beforeEach(async () => {
-    dir = makeTempDir();
-    const s = await createTestServer(dir);
-    server = s.server;
-    baseUrl = s.baseUrl;
-  });
-
-  afterEach(async () => {
-    await server.stop();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
   it("upserts, lists, fetches, and heartbeats hub sessions", async () => {
     const created = await putJson(`${baseUrl}/api/hub/sessions/session-1`, {
       scenario_name: "grid_ctf",
@@ -1441,22 +1361,6 @@ describe("HTTP API — research hub", () => {
 // ---------------------------------------------------------------------------
 
 describe("HTTP API — OpenClaw", () => {
-  let dir: string;
-  let server: Awaited<ReturnType<typeof createTestServer>>["server"];
-  let baseUrl: string;
-
-  beforeEach(async () => {
-    dir = makeTempDir();
-    const s = await createTestServer(dir);
-    server = s.server;
-    baseUrl = s.baseUrl;
-  });
-
-  afterEach(async () => {
-    await server.stop();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
   it("POST /api/openclaw/evaluate scores a built-in game strategy", async () => {
     const { status, body } = await postJson(`${baseUrl}/api/openclaw/evaluate`, {
       scenario_name: "grid_ctf",
@@ -1709,22 +1613,6 @@ describe("HTTP API — OpenClaw", () => {
 // ---------------------------------------------------------------------------
 
 describe("HTTP API — knowledge", () => {
-  let dir: string;
-  let server: Awaited<ReturnType<typeof createTestServer>>["server"];
-  let baseUrl: string;
-
-  beforeEach(async () => {
-    dir = makeTempDir();
-    const s = await createTestServer(dir);
-    server = s.server;
-    baseUrl = s.baseUrl;
-  });
-
-  afterEach(async () => {
-    await server.stop();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
   it("GET /api/knowledge/playbook/:scenario returns playbook", async () => {
     const { status, body } = await fetchJson(`${baseUrl}/api/knowledge/playbook/grid_ctf`);
     expect(status).toBe(200);
@@ -1856,24 +1744,6 @@ describe("HTTP API — knowledge", () => {
 // ---------------------------------------------------------------------------
 
 describe("HTTP API — dashboard event stream", () => {
-  let dir: string;
-  let server: Awaited<ReturnType<typeof createTestServer>>["server"];
-  let mgr: Awaited<ReturnType<typeof createTestServer>>["mgr"];
-  let baseUrl: string;
-
-  beforeEach(async () => {
-    dir = makeTempDir();
-    const s = await createTestServer(dir);
-    server = s.server;
-    mgr = s.mgr;
-    baseUrl = s.baseUrl;
-  });
-
-  afterEach(async () => {
-    await server.stop();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
   it("streams live events over /ws/events for the dashboard", async () => {
     const { WebSocket } = await import("ws");
     const wsUrl = baseUrl.replace(/^http/, "ws") + "/ws/events";


### PR DESCRIPTION
## Summary

- centralize repeated HTTP API test server setup/cleanup in `ts/tests/http-api.test.ts`
- add a small knowledge-stage mock builder for repeated `test_generation_stages.py` setup
- add a shared solve settings builder for repeated `test_knowledge_solver.py` settings setup

Net: 215 fewer test lines with no behavior changes.

## Tests

- `/Users/jayscambler/Repositories/autocontext/autocontext/autocontext/.venv/bin/python -m pytest autocontext/tests/test_generation_stages.py autocontext/tests/test_knowledge_solver.py`
- `cd ts && npm run lint`
- `cd ts && npm test -- tests/http-api.test.ts --run` *(blocked locally by known Node 23 `isolated-vm` native-build issue: no native build for darwin arm64 abi=131)*

## Notes

Admin merge held for green CI and explicit approval.
