### PR TITLE
AC-846 Trim public README verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,204 +19,74 @@
 
 <!-- autocontext-readme-hero:end -->
 
-autocontext is a harness. You point it at a goal in plain language. It iterates against real evaluation, keeps what worked, throws out what didn't, and produces a structured trace of the work plus the artifacts, playbooks, datasets, and (optionally) a distilled local model that the next agent inherits. Repeated runs get better, not just different.
+autocontext is a harness for agent improvement. Give it a goal, it runs the task against evaluation, keeps the useful lessons, discards dead ends, and leaves traces, reports, playbooks, datasets, and optional local-model training artifacts for the next run.
 
-**Documentation:** [autocontext.ai/docs](https://autocontext.ai/docs) · [quickstart](https://autocontext.ai/docs/get-started/quickstart) · [CLI reference](https://autocontext.ai/docs/cli/reference) · [changelog](https://autocontext.ai/docs/changelog)
+**Docs:** [autocontext.ai/docs](https://autocontext.ai/docs) · [quickstart](https://autocontext.ai/docs/get-started/quickstart) · [CLI reference](https://autocontext.ai/docs/cli/reference) · [changelog](https://autocontext.ai/docs/changelog)
 
-## Try It In 30 Seconds
+## Install
 
-The fastest path uses our **Pi runtime**, a local coding agent that handles its own auth. No API key plumbing, no provider config: install Pi, install autocontext, point one at the other.
+| Surface             | Command                               |
+| ------------------- | ------------------------------------- |
+| Python CLI          | `uv tool install autocontext==0.10.0` |
+| Python library/dev  | `uv pip install autocontext==0.10.0`  |
+| TypeScript/Node CLI | `bun add -g autoctx@0.10.0`           |
+| Pi extension        | `pi install npm:pi-autocontext@0.8.0` |
+
+The PyPI package is `autocontext`; the CLI is `autoctx`. The npm package is `autoctx` (not the unrelated `autocontext` npm package). Provider variables live in [`.env.example`](.env.example).
+
+## 30-Second Run
+
+Pi is the lowest-friction provider because it uses your local agent auth:
 
 ```bash
-uv tool install autocontext==0.10.0
-
 AUTOCONTEXT_AGENT_PROVIDER=pi \
 AUTOCONTEXT_PI_COMMAND=pi \
-autoctx solve \
-  "improve customer-support replies for billing disputes" \
-  --iterations 3
+autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
 
-Pi runs locally as a subprocess and emits live traces back into the harness. For a hosted Pi, set `AUTOCONTEXT_AGENT_PROVIDER=pi-rpc` and `AUTOCONTEXT_PI_RPC_ENDPOINT` instead.
+Use `AUTOCONTEXT_AGENT_PROVIDER=anthropic`, `openai-compatible`, `claude-cli`, `codex`, `pi-rpc`, or another provider when you need that runtime. See [agent integration](autocontext/docs/agent-integration.md) for the full matrix.
 
-Prefer TypeScript? Same surface, same command:
+## Agent Entry Points
 
-```bash
-bun add -g autoctx@0.10.0
-AUTOCONTEXT_AGENT_PROVIDER=pi bunx autoctx solve \
-  "improve customer-support replies for billing disputes" \
-  --iterations 5 --json
-```
+- **Pi:** install `pi-autocontext`, then ask Pi to solve, judge, improve, list, or inspect runs through the packaged skill.
+- **MCP clients:** run `autoctx mcp-serve` or `bunx autoctx mcp-serve` and expose the tools to Claude Code, Cursor, or another MCP client.
+- **Hermes:** export the CLI-first skill with `uv run autoctx hermes export-skill --with-references --json`.
 
-Already on Anthropic, OpenAI, Gemini, Mistral, Groq, OpenRouter, Azure, Claude CLI, Codex CLI, or MLX? Set `AUTOCONTEXT_AGENT_PROVIDER` and the matching credential env var:
+Full setup: [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md).
 
-```bash
-AUTOCONTEXT_AGENT_PROVIDER=anthropic \
-ANTHROPIC_API_KEY=sk-ant-... \
-autoctx solve "..." --iterations 3
-```
+## What A Run Leaves Behind
 
-See [`.env.example`](.env.example) for every provider's variables, or use the live provider guide at [autocontext.ai/docs/providers](https://autocontext.ai/docs/providers). Prefer to clone and run a starter? [`examples/README.md`](examples/README.md) has copy-paste recipes for Python CLI, Claude Code MCP, Python SDK, TypeScript library usage, and the experimental TypeScript agent handler surface.
-
-## Or Just Talk To Your Agent
-
-If you already work inside a coding agent, you can wire autocontext in once and give the agent a natural-language entry point. Hermes and other terminal-capable agents should start with the CLI-backed skill; MCP remains available for clients that want a tool-catalog protocol.
-
-**Pi** ships an autocontext skill out of the box. Install the published Pi package and Pi loads natural-language wrappers over live tools such as `autocontext_solve_scenario`, `autocontext_evaluate_output`, `autocontext_run_improvement_loop`, `autocontext_run_status`, and `autocontext_list_scenarios`.
-
-```bash
-pi install npm:pi-autocontext@0.8.0
-```
-
-Pi is on a separate package line: `pi-autocontext@0.8.0` depends on `autoctx@^0.8.0`. A follow-up Pi release can move it to a newer `autoctx` line after the core npm package is live.
-
-Then you just ask:
-
-> "Solve: improve customer-support replies for billing disputes."
->
-> "Judge this output against this rubric and improve it until it scores 0.85."
-
-**Claude Code** (and any other MCP client) gets the same surface by adding one entry to `.claude/settings.json`:
-
-```json
-{
-  "mcpServers": {
-    "autocontext": {
-      "command": "uv",
-      "args": ["run", "--directory", "/path/to/autocontext", "autoctx", "mcp-serve"],
-      "env": { "AUTOCONTEXT_AGENT_PROVIDER": "pi", "AUTOCONTEXT_PI_COMMAND": "pi" }
-    }
-  }
-}
-```
-
-After that, Python MCP exposes prefixed tools such as `autocontext_solve_scenario`, `autocontext_evaluate_output`, `autocontext_run_improvement_loop`, `autocontext_run_status`, `autocontext_list_scenarios`, `autocontext_export_skill`, and `autocontext_search_strategies`. It also exposes runtime-session readers as `autocontext_list_runtime_sessions`, `autocontext_get_runtime_session`, and `autocontext_get_runtime_session_timeline`, with unprefixed aliases for parity with TypeScript MCP; Python runtime-backed `run` and `solve` role calls populate those logs automatically. The TypeScript package exposes the same capabilities with its documented tool names via `bunx autoctx mcp-serve`.
-
-**Hermes Agent** can load a CLI-first skill and inspect Hermes Curator state without MCP:
-
-```bash
-cd autocontext
-uv run autoctx hermes export-skill --output ~/.hermes/skills/autocontext/SKILL.md --json
-# Add progressive-disclosure reference files alongside SKILL.md
-uv run autoctx hermes export-skill \
-    --output ~/.hermes/skills/autocontext/SKILL.md \
-    --with-references --json
-uv run autoctx hermes inspect --json
-```
-
-Full integration guide: [autocontext.ai/docs/agents](https://autocontext.ai/docs/agents) and [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md).
-
-## What You Get Back
-
-Every run leaves a structured record on disk. Replay it, diff it, export it, feed it back into training.
-
-```
+```text
 runs/<run_id>/
-├── trace.jsonl              # every prompt, tool call, and outcome, in order
-├── generations/
-│   ├── gen_1/
-│   │   ├── strategy.json    # what the competitor proposed
-│   │   ├── analysis.md      # what the analyst observed
-│   │   └── score.json       # how it was evaluated
-│   └── gen_2/ ...
-├── report.md                # human-readable summary of the whole run
-└── artifacts/               # files, configs, packages the run produced
+├── trace.jsonl
+├── generations/<n>/{strategy.json,analysis.md,score.json}
+├── report.md
+└── artifacts/
 
 knowledge/<scenario>/
-├── playbook.md              # accumulated lessons that carried forward
-├── hints.md                 # competitor hints that survived the curator
-└── tools/                   # any helper tools the architect generated
+├── playbook.md
+├── hints.md
+└── tools/
 ```
 
-A `playbook.md` is plain markdown the next run reads as context:
+Everything is filesystem-first: inspect it, diff it, replay it, export it, or feed it into training.
 
-```markdown
-<!-- PLAYBOOK_START -->
+## Core Surfaces
 
-## Billing dispute replies
+| Surface       | Command                                                 | Use it for                                              |
+| ------------- | ------------------------------------------------------- | ------------------------------------------------------- |
+| `solve`       | `autoctx solve "..." --iterations 3`                    | Start from a plain-language goal                        |
+| `run`         | `autoctx run <scenario> --iterations 3`                 | Improve a saved scenario                                |
+| `simulate`    | `autoctx simulate -d "..."`                             | Model/replay/compare system behavior                    |
+| `investigate` | `autoctx investigate -d "..."`                          | Evidence-driven diagnosis                               |
+| `mission`     | `autoctx mission create --name "..." --goal "..."`      | Verifier-driven multi-step goals                        |
+| `train`       | `uv run autoctx train --scenario <name> --data <jsonl>` | Distill stable behavior into a cheaper runtime (Python) |
+| `mcp-serve`   | `autoctx mcp-serve`                                     | Give an agent the autocontext tool surface              |
 
-- Always restate the disputed charge in the first sentence; refunds requested without
-  explicit confirmation cause loops.
-- "Pending" charges are not yet billable. Don't promise a refund until status flips
-  to `posted`. Verified gen_4, regressed in gen_7 when omitted.
-- Empathy + specific next step beats empathy alone. Escalation rate dropped from
-0.31 to 0.12 once the second sentence named the next-step owner.
-<!-- PLAYBOOK_END -->
-```
-
-A `trace.jsonl` line is one event:
-
-```json
-{
-  "ts": "2026-04-28T17:42:11Z",
-  "gen": 4,
-  "role": "competitor",
-  "event": "strategy_proposed",
-  "score": 0.78,
-  "tokens_in": 1840,
-  "tokens_out": 612,
-  "strategy_id": "s_4f2a"
-}
-```
-
-Inspect, replay, or compare any of it:
-
-```bash
-uv run autoctx list
-uv run autoctx status <run_id>
-uv run autoctx replay <run_id> --generation 2
-```
-
-## How It Works
-
-Inside each run, five roles cooperate:
-
-- **competitor** proposes a strategy or artifact for the task
-- **analyst** explains what happened and why
-- **coach** turns that analysis into playbook updates and future hints
-- **architect** proposes tools or harness changes when the loop is stuck
-- **curator** gates what knowledge is allowed to persist across runs
-
-Strategies are evaluated through scenario execution, staged validation, and gating. Weak changes are rolled back. Successful changes accumulate as reusable knowledge that future runs (and future agents) inherit automatically.
-
-The full vocabulary (Scenario, Task, Mission, Campaign, Run, Verifier, Knowledge, Artifact, Budget, Policy) lives in the [concept docs](https://autocontext.ai/docs/concepts) and [docs/concept-model.md](docs/concept-model.md).
-
-## Capture What's Happening In Production
-
-autocontext can sit alongside your live application and record what your agents do, then turn that into training data. Wrap your existing Anthropic or OpenAI client once:
-
-```python
-from anthropic import Anthropic
-from autocontext.production_traces import instrument_client
-
-client = instrument_client(Anthropic(), app="billing-bot", env="prod")
-# use `client` exactly like before; calls are captured to JSONL with content blocks,
-# cache-aware usage, and Anthropic-native outcome taxonomy.
-```
-
-```ts
-import Anthropic from "@anthropic-ai/sdk";
-import { instrumentClient } from "autoctx/production-traces";
-
-const client = instrumentClient(new Anthropic(), { app: "billing-bot", env: "prod" });
-```
-
-Then build scoped datasets from the captured traces:
-
-```bash
-uv run autoctx build-dataset \
-  --app billing-bot --provider anthropic \
-  --env prod --outcome success \
-  --output training/billing.jsonl
-```
-
-And distill them into a smaller local model with MLX (Apple Silicon) or CUDA (Linux GPUs):
-
-```bash
-uv run autoctx train --scenario support_triage --data training/billing.jsonl --time-budget 300
-```
+Python owns the full control-plane package; TypeScript owns several operator-facing surfaces, the TUI, and Node runtime adapters. Start with [autocontext/README.md](autocontext/README.md) or [ts/README.md](ts/README.md).
 
 <!-- autocontext-whats-new:start -->
+
 ## What's New in 0.10.0
 
 - **Scaled training plans** add default-off CUDA/TRL profiles for 7B QLoRA RLVR and sharded 32B/72B distillation across Python and TypeScript.
@@ -224,119 +94,21 @@ uv run autoctx train --scenario support_triage --data training/billing.jsonl --t
 - **TypeScript CLI parity** makes `--scale-profile` preserve profile backend/base/mode and documents every scale-related train flag.
 <!-- autocontext-whats-new:end -->
 
-## Choose Your Package
-
-| If you want to...                                               | Start here                                                                     |
-| --------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Run the full multi-generation control plane (Python)            | [autocontext/README.md](autocontext/README.md)                                 |
-| Run from Node, or operate missions, simulations, investigations | [ts/README.md](ts/README.md)                                                   |
-| Install the Pi extension package                                | [pi/README.md](pi/README.md)                                                   |
-| Wire an external coding agent into autocontext over MCP         | [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md) |
-| Grab copy-paste integration snippets                            | [examples/README.md](examples/README.md)                                       |
-
-```bash
-# Python: library or CLI tool
-uv pip install autocontext==0.10.0
-uv tool install autocontext==0.10.0
-
-# TypeScript
-bun add -g autoctx@0.10.0
-
-# Pi extension
-pi install npm:pi-autocontext@0.8.0
-```
-
-> The PyPI package is `autocontext`. The CLI entrypoint is `autoctx`. The npm packages are `autoctx` and `pi-autocontext` (note: an unrelated package on npm uses the name `autocontext`; that is not this project). `pi-autocontext@0.8.0` still depends on `autoctx@^0.8.0`; a follow-up Pi release can move it to a newer `autoctx` line after the core npm package is live.
-
-## Surfaces
-
-| Surface            | Command                                                | When to use it                                                                         |
-| ------------------ | ------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `solve`            | `autoctx solve "..." --iterations 3`                   | Hand the harness a goal in plain language; it generates the scenario and runs the loop |
-| `run`              | `autoctx run <scenario> --iterations 3`                | Improve behavior inside a saved scenario across generations                            |
-| `simulate`         | `autoctx simulate -d "..."`                            | Model a system, sweep parameters, replay, compare                                      |
-| `investigate`      | `autoctx investigate -d "..."`                         | Evidence-driven diagnosis, either synthetic harness or live iterative LLM session      |
-| `analyze`          | `autoctx analyze --id <id> --type <kind>`              | Inspect or compare runs, simulations, investigations, or missions after the fact       |
-| `mission`          | `autoctx mission create --name "..." --goal "..."`     | Verifier-driven goal advanced step by step until done                                  |
-| `campaign`         | `bunx autoctx campaign ...` (TypeScript)               | Coordinate multiple missions with budgets, dependencies, progress aggregation          |
-| `worker`           | `autoctx worker --poll-interval 5`                     | Process queued tasks on a persistent host beside `autoctx serve`                       |
-| `export`           | `autoctx export <run-id>`                              | Share solved knowledge as JSON, skills, or Pi-local package directories                |
-| `train`            | `autoctx train --scenario <name> --data <jsonl>`       | Distill stable exported data into a cheaper local runtime                              |
-| `context-selection` | `bunx autoctx context-selection --run-id <run-id> --json` (TypeScript CLI) | Inspect persisted prompt context budget, cache, diagnostics, and selection telemetry   |
-| `runtime-sessions` | `bunx autoctx runtime-sessions timeline --run-id <run-id>` (TypeScript CLI) | Inspect persisted provider prompts, messages, child-task events, and operator-facing timelines from runtime-backed runs; also exposed through Python and TypeScript MCP/cockpit HTTP, the TypeScript TUI `/timeline` plus persisted filterable and resettable `/activity` live feed, and `/ws/events` updates |
-| `agent`            | `bunx autoctx agent run support --id ticket-123 --payload '{"message":"..."}' --json` (TypeScript CLI) | Invoke experimental `.autoctx/agents` handlers locally, run `autoctx agent dev`, or generate the self-hosted Node target with `autoctx agent build --target node` |
-| `hermes`           | `uv run autoctx hermes inspect --json` (Python)        | Inspect Hermes v0.12 skill usage and Curator reports, or export the Hermes skill       |
-| `replay`           | `autoctx replay <run_id> --generation N`               | Inspect what happened before deciding what knowledge should persist                    |
-
 ## Scenario Families
 
-All 11 families execute in both Python and TypeScript. TypeScript uses V8 isolate codegen; Python uses subprocess executors.
+The shipped families cover games, agent tasks, simulations, artifact editing, investigations, workflows, negotiation, schema evolution, tool fragility, operator loops, and coordination. Python and TypeScript share the family vocabulary; see [docs/scenario-parity-matrix.md](docs/scenario-parity-matrix.md) for parity details.
 
-| Family             | Evaluation              | What it tests                                                           |
-| ------------------ | ----------------------- | ----------------------------------------------------------------------- |
-| `game`             | Tournament with Elo     | Turn-based strategy (grid_ctf, othello)                                 |
-| `agent_task`       | LLM judge               | Prompt-centric tasks with optional improvement loops                    |
-| `simulation`       | Trace evaluation        | Action-trace scenarios with mock environments and fault injection       |
-| `artifact_editing` | Artifact validation     | File, config, and schema modification with diff tracking                |
-| `investigation`    | Evidence chains         | Diagnosis accuracy with red herring detection                           |
-| `workflow`         | Workflow evaluation     | Transactional flows with compensation, retry, and side-effect tracking  |
-| `negotiation`      | Negotiation evaluation  | Hidden preferences, BATNA constraints, and opponent modeling            |
-| `schema_evolution` | Schema adaptation       | Mid-run state changes where agents must detect stale context            |
-| `tool_fragility`   | Drift adaptation        | APIs that drift, requiring agents to adapt to changed tool behavior     |
-| `operator_loop`    | Judgment evaluation     | Escalation and clarification judgment in operator-in-the-loop workflows |
-| `coordination`     | Coordination evaluation | Multi-agent partial context, handoff, merge, and duplication detection  |
+## Package Guides
 
-## Providers, Runtimes, Executors
-
-**LLM providers**: Anthropic (with `instrument_client` capture), OpenAI-compatible (vLLM, Ollama, Hermes), Gemini, Mistral, Groq, OpenRouter, Azure OpenAI, MLX (Apple Silicon), CUDA (Linux GPUs), Pi (CLI and RPC).
-
-**Agent runtimes**: Claude CLI, Codex CLI, Hermes CLI, Direct API, Pi variants, plus branch-aware session and persistent Pi RPC for local agent loops.
-
-**Executors**: Local subprocess, SSH remote, Monty (`pydantic-monty` sandbox), PrimeIntellect remote sandbox. Gondolin is reserved as an optional fail-closed microVM backend until its adapter is wired.
-
-**Harness profiles and hooks**: The Python control plane supports a Pi-shaped lean profile that caps prompt context during generation and exports a minimal tool-affordance allowlist for agent surfaces that enforce tool gating. Semantic prompt compactions are recorded as Pi-shaped JSONL entries under each run; the TypeScript package now includes a mirrored deterministic prompt compactor plus `ArtifactStore` ledger read/write/latest APIs for standalone npm runs. Python and TypeScript runs can load `AUTOCONTEXT_EXTENSIONS`; Python extensions are Python modules, while TypeScript extensions are JavaScript/ESM modules that register hooks around context assembly, semantic compaction, provider calls, judge calls, artifact writes, and run lifecycle events.
-
-A deterministic offline provider exists for the test suite. Configuration matrix: [`.env.example`](.env.example) and [docs/concept-model.md](docs/concept-model.md).
-
-## FAQ
-
-**Is autocontext a benchmark?**
-No. It's a harness for improving real agent behavior on real work. Benchmarks (the 11 scenario families) are one of many surfaces; you can also point it at production tasks, missions, or simulations.
-
-**How is this different from DSPy, Inspect, TextGrad, or a prompt optimizer?**
-Those tools optimize prompts. autocontext takes a goal in plain language, generates the scenario, runs a multi-role loop with verifier-driven gating, and produces transferable artifacts (playbooks, datasets, distilled models) that the next run inherits. Prompt optimization is a special case.
-
-**Do I need API keys?**
-No. The Pi runtime runs locally and handles its own auth. Anthropic, OpenAI, Gemini, Mistral, Groq, OpenRouter, Azure, MLX, and Claude/Codex CLI are all opt-in via env vars.
-
-**Where does the knowledge live?**
-On your filesystem. Runs go to `runs/`, accumulated knowledge to `knowledge/`. Indexed metadata is in SQLite. Everything is inspectable, diffable, and portable.
-
-**Can my coding agent drive autocontext directly?**
-Yes. Wire `autoctx mcp-serve` (or `bunx autoctx mcp-serve`) into Claude Code, Cursor, or Pi as an MCP server, and the agent gets natural-language access to `solve`, `judge`, `improve`, `status`, `export_skill`, and the rest. See [Or Just Talk To Your Agent](#or-just-talk-to-your-agent).
-
-## Where To Look Next
-
-- Live documentation: [autocontext.ai/docs](https://autocontext.ai/docs)
-- Canonical vocabulary and object model: [docs/concept-model.md](docs/concept-model.md)
-- Python package guide: [autocontext/README.md](autocontext/README.md)
-- TypeScript package guide: [ts/README.md](ts/README.md)
-- Copy-paste examples: [examples/README.md](examples/README.md)
-- External agent integration: [autocontext/docs/agent-integration.md](autocontext/docs/agent-integration.md)
-- Recent changes: [CHANGELOG.md](CHANGELOG.md) and [autocontext.ai/docs/changelog](https://autocontext.ai/docs/changelog)
-- Contributor setup: [CONTRIBUTING.md](CONTRIBUTING.md)
-- Repo layout for coding agents: [AGENTS.md](AGENTS.md)
-- Local + cross-platform model training (MLX and TRL backends): [autocontext/docs/mlx-training.md](autocontext/docs/mlx-training.md)
-- Validated training result (on-policy distillation vs RLVR on GSM8K): [autocontext/docs/case-study-on-policy-distillation.md](autocontext/docs/case-study-on-policy-distillation.md)
-- Recursive loop closed end to end on local MLX (train -> auto-serve -> improve): [autocontext/docs/case-study-recursive-loop.md](autocontext/docs/case-study-recursive-loop.md)
-- Sandbox and executor notes: [autocontext/docs/sandbox.md](autocontext/docs/sandbox.md)
-- Persistent host worker: [autocontext/docs/persistent-host.md](autocontext/docs/persistent-host.md)
-- Background execution trust boundaries: [docs/background-execution-trust-boundaries.md](docs/background-execution-trust-boundaries.md)
-- License: [LICENSE](LICENSE)
-
-## Acknowledgments
-
-Thanks to [George](https://github.com/GeorgeH87) for generously donating the `autocontext` name on PyPI.
+| Need                                          | Go here                                        |
+| --------------------------------------------- | ---------------------------------------------- |
+| Python CLI/library, MCP, HTTP, training       | [autocontext/README.md](autocontext/README.md) |
+| Node CLI, TUI, missions, Fetch/agent adapters | [ts/README.md](ts/README.md)                   |
+| Pi package                                    | [pi/README.md](pi/README.md)                   |
+| Copy-paste examples                           | [examples/README.md](examples/README.md)       |
+| Concepts and docs index                       | [docs/README.md](docs/README.md)               |
+| Contributor setup                             | [CONTRIBUTING.md](CONTRIBUTING.md)             |
+| Repo guide for agents                         | [AGENTS.md](AGENTS.md)                         |
 
 ## Project Signals
 
@@ -344,3 +116,7 @@ Thanks to [George](https://github.com/GeorgeH87) for generously donating the `au
 [![PyPI downloads](https://img.shields.io/pypi/dm/autocontext?logo=pypi&label=PyPI%20downloads)](https://pypi.org/project/autocontext/)
 
 [![Star History Chart](https://api.star-history.com/svg?repos=greyhaven-ai/autocontext&type=Date)](https://www.star-history.com/#greyhaven-ai/autocontext&Date)
+
+## Acknowledgments
+
+Thanks to [George](https://github.com/GeorgeH87) for generously donating the `autocontext` name on PyPI.

--- a/autocontext/README.md
+++ b/autocontext/README.md
@@ -1,74 +1,40 @@
-# autocontext
+# autocontext Python package
 
-autocontext is the Python control-plane package for running scenarios, carrying forward validated knowledge, exporting artifacts, and distilling stable behavior into cheaper runtimes over time.
+This package is the Python control plane for autocontext: scenario runs, `solve`, simulations, investigations, MCP/HTTP surfaces, persistent knowledge, training-data export, and local training hooks.
 
-The intended use is to hand the harness a real task in plain language, let it solve or simulate the problem mostly hands-off, and then inspect the resulting traces, reports, playbooks, datasets, and optional distilled model.
+Use it when you want the full harness in Python, a CLI installed with `uv`/`pip`, or the MCP/HTTP server that coding agents can call.
 
 ## Install
 
 ```bash
 pip install autocontext
+# or, for an isolated CLI tool:
+uv tool install autocontext
 ```
 
-The current PyPI release line is `autocontext==0.10.0`.
-The PyPI package name is now `autocontext`. The CLI entrypoint remains `autoctx`.
-Optional integrations use extras: `autocontext[browser]` for Chrome CDP capture and `autocontext[primeintellect]` for PrimeIntellect sandboxes.
+Optional extras:
 
-## Working Directory
+```bash
+pip install 'autocontext[browser]'          # Chrome/CDP capture
+pip install 'autocontext[primeintellect]'   # PrimeIntellect sandbox backend
+pip install 'autocontext[mcp]'              # MCP server dependencies
+```
 
-Run the commands in this README from the `autocontext/` directory. The Python package, CLI entrypoint, tests, and migrations all live here.
+The CLI entrypoint is `autoctx`. Provider env vars are listed in the repo-level [`.env.example`](../.env.example).
 
-## What It Does
-
-- Runs iterative generation loops against game scenarios and agent-task scenarios
-- Adds a first-class `simulate` surface for modeled-world exploration, replay, compare, and export
-- Persists playbooks, hints, tools, reports, and snapshots across runs
-- Supports staged validation, harness synthesis, and harness-aware routing
-- Exports training data and runs autoresearch-style local training loops
-- Exposes evaluation, validation, artifact, runtime-session, and discovery operations over MCP and HTTP
-
-## Surface Summary
-
-The Python package is the full control-plane surface in this repo. It currently includes:
-
-- generation-loop execution via `autoctx run`
-- plain-language simulation via `autoctx simulate`
-- plain-language investigation via `autoctx investigate`
-- local training workflows via `autoctx export-training-data` and `autoctx train`
-- scenario creation and materialization via `autoctx new-scenario`
-- Hermes Agent integration helpers via `autoctx hermes inspect` and `autoctx hermes export-skill` (with optional `--with-references` for progressive-disclosure reference files)
-- HTTP API and MCP server surfaces via `autoctx serve` and `autoctx mcp-serve`, including runtime-session log and timeline readers for provider-backed runs
-
-Some newer operator-facing surfaces are currently TypeScript-first:
-
-- `autoctx analyze`
-- the interactive terminal UI via `npx autoctx tui`
-
-`campaign` currently lives in that same bucket: it has partial TypeScript CLI/API/MCP support, but the Python package does not expose a campaign control-plane workflow yet.
-
-## Quick Start
-
-From the repo root:
+## Run from a checkout
 
 ```bash
 cd autocontext
 uv venv
 source .venv/bin/activate
 uv sync --group dev
-```
 
-Use the repo-level `.env.example` as the reference for available `AUTOCONTEXT_*` settings and supported provider-native credential aliases such as `ANTHROPIC_API_KEY`.
-
-`operator-in-the-loop` is a runnable scenario family for escalation and clarification experiments. Use it when you want executable operator-loop simulations, judgment evaluation, and live-agent escalation workflow testing.
-
-Run a deterministic local scenario:
-
-```bash
 AUTOCONTEXT_AGENT_PROVIDER=deterministic \
 uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
 
-Run with Anthropic:
+Use a real provider by changing `AUTOCONTEXT_AGENT_PROVIDER` and setting its credential:
 
 ```bash
 AUTOCONTEXT_AGENT_PROVIDER=anthropic \
@@ -76,634 +42,121 @@ ANTHROPIC_API_KEY=... \
 uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
 ```
 
-`ANTHROPIC_API_KEY` is the preferred Anthropic credential env var. `AUTOCONTEXT_ANTHROPIC_API_KEY` remains supported as a compatibility alias.
-
-Run with Claude CLI (`claude -p` via a local authenticated Claude Code runtime):
+Pi and local CLI providers avoid API-key plumbing when those tools are already authenticated:
 
 ```bash
-AUTOCONTEXT_AGENT_PROVIDER=claude-cli \
-AUTOCONTEXT_CLAUDE_MODEL=sonnet \
-AUTOCONTEXT_CLAUDE_TIMEOUT=300 \
-uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
+AUTOCONTEXT_AGENT_PROVIDER=pi AUTOCONTEXT_PI_COMMAND=pi uv run autoctx solve "..." --iterations 3
+AUTOCONTEXT_AGENT_PROVIDER=claude-cli AUTOCONTEXT_CLAUDE_MODEL=sonnet uv run autoctx solve "..." --iterations 3
+AUTOCONTEXT_AGENT_PROVIDER=codex AUTOCONTEXT_CODEX_MODEL=o4-mini uv run autoctx solve "..." --iterations 3
 ```
 
-For longer live prompts, `autoctx solve`, `autoctx judge`, and `autoctx improve` all accept `--timeout <seconds>`. `autoctx solve` also accepts `--generation-time-budget <seconds>` to cap per-generation solve runtime. You can still use provider env vars such as `AUTOCONTEXT_CLAUDE_TIMEOUT`, `AUTOCONTEXT_CLAUDE_MAX_RETRIES`, `AUTOCONTEXT_CLAUDE_MAX_TOTAL_SECONDS`, or `AUTOCONTEXT_PI_TIMEOUT`.
+## Common commands
 
-Run with Codex CLI (`codex exec` via a local authenticated Codex runtime):
+| Command                                                                                | Purpose                                                |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `uv run autoctx solve "..." --iterations 3`                                            | Generate and run a scenario from a plain-language goal |
+| `uv run autoctx run <scenario> --iterations 3`                                         | Improve an existing scenario                           |
+| `uv run autoctx simulate --description "..."`                                          | Create/replay/compare modeled-world simulations        |
+| `uv run autoctx investigate --description "..."`                                       | Run synthetic or iterative investigations              |
+| `uv run autoctx list` / `status <run_id>` / `show <run_id>`                            | Inspect runs                                           |
+| `uv run autoctx replay <run_id> --generation 1`                                        | Replay a generation before accepting knowledge         |
+| `uv run autoctx queue add --task-prompt "..." --rubric "..."`                          | Queue evaluation/improvement work                      |
+| `uv run autoctx serve --host 127.0.0.1 --port 8000`                                    | Start the local HTTP API                               |
+| `uv run autoctx worker --poll-interval 5 --concurrency 2`                              | Process queued tasks beside the API server             |
+| `uv run autoctx mcp-serve`                                                             | Expose the MCP tool surface                            |
+| `uv run autoctx export-training-data --scenario <name> --all-runs --output data.jsonl` | Build a training corpus                                |
+| `uv run autoctx train --scenario <name> --data data.jsonl --time-budget 300`           | Run the local training hook                            |
+| `uv run autoctx hermes inspect --json`                                                 | Inspect Hermes Curator state                           |
 
-```bash
-AUTOCONTEXT_AGENT_PROVIDER=codex \
-AUTOCONTEXT_CODEX_MODEL=o4-mini \
-uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
-```
+Saved custom scenarios under `knowledge/_custom_scenarios/` can be rerun and benchmarked by name after their `spec.json` is persisted.
 
-Run with Pi CLI (local Pi agent runtime):
-
-```bash
-AUTOCONTEXT_AGENT_PROVIDER=pi \
-AUTOCONTEXT_PI_COMMAND=pi \
-uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
-```
-
-`autoctx simulate` now follows the effective architect-role runtime surface, so `AUTOCONTEXT_ARCHITECT_PROVIDER`, other role-routing overrides, and per-call `--provider <name>` overrides all apply to live simulation generation.
-
-`autoctx investigate` now ships as a first-class Python CLI surface as well. It uses the architect runtime for investigation-spec synthesis and the analyst runtime for hypothesis generation, so role-routing overrides apply there too. The default `--mode synthetic` creates and executes a compact investigation harness. `--mode iterative` runs a live multi-step LLM investigation, emits `events.ndjson` rows, and writes Pi-shaped compaction ledger entries under `runs/<investigation_id>/` when context budget pressure triggers compaction. When browser exploration is enabled, `--browser-url <url>` captures a policy-checked snapshot and folds that evidence into the investigation prompts and report artifacts.
-
-Run with Pi RPC (local Pi subprocess using `pi --mode rpc` JSONL):
-
-```bash
-AUTOCONTEXT_AGENT_PROVIDER=pi-rpc \
-AUTOCONTEXT_PI_COMMAND=pi \
-uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
-```
-
-For deterministic evals where Pi should ignore repo-local `AGENTS.md` / `CLAUDE.md`, add:
-
-```bash
-AUTOCONTEXT_PI_NO_CONTEXT_FILES=true
-```
-
-For Pi-shaped harness runs with a tighter prompt budget and exported tool-affordance metadata, add:
-
-```bash
-AUTOCONTEXT_HARNESS_PROFILE=lean
-AUTOCONTEXT_LEAN_CONTEXT_BUDGET_TOKENS=32000
-AUTOCONTEXT_LEAN_TOOL_ALLOWLIST=read,bash,edit,write
-AUTOCONTEXT_PI_RPC_PERSISTENT=true
-```
-
-Run with Hermes (via OpenAI-compatible gateway):
-
-```bash
-AUTOCONTEXT_AGENT_PROVIDER=openai-compatible \
-AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1 \
-AUTOCONTEXT_AGENT_API_KEY=no-key \
-AUTOCONTEXT_AGENT_DEFAULT_MODEL=hermes-3-llama-3.1-8b \
-uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
-```
-
-Start the API server:
-
-```bash
-uv run autoctx serve --host 127.0.0.1 --port 8000
-```
-
-Inspect `http://127.0.0.1:8000/` for the API index after the server starts. Browser-based GUI clients calling the HTTP API cross-origin are allowed via CORS for local app origins by default (the cowork desktop webview and dev servers); set `AUTOCONTEXT_CORS_ORIGINS` to a comma-separated origin list for remote or custom GUI deployments. For an interactive terminal UI, use the TypeScript package: `npx autoctx tui`.
-
-Run a persistent queue worker beside the API server:
-
-```bash
-uv run autoctx worker --poll-interval 5 --concurrency 2
-```
-
-Stateful persistent providers, such as persistent Pi RPC, run with effective concurrency `1` so one long-lived runtime cannot mix events across tasks. The persistent-host worker is a single-tenant/trusted-org deployment shape; review [persistent-host trust guidance](docs/persistent-host.md#trust-and-credential-boundary) and the repo-level [background execution trust boundaries](../docs/background-execution-trust-boundaries.md) before exposing it beyond a trusted network or adding SCM/sandbox credentials.
-
-Start the MCP server:
+## HTTP, MCP, and agents
 
 ```bash
 uv sync --group dev --extra mcp
 uv run autoctx mcp-serve
 ```
 
-Python runtime-backed `run` and `solve` role calls automatically append provider prompts and responses to the run-scoped runtime-session log. Runtime-session logs created by the TypeScript runtime-session provider bundle can be read from Python too when both packages point at the same `AUTOCONTEXT_DB_PATH`. Python command grants mirror the TypeScript runtime grant vocabulary for command lifecycle events: trusted env values stay out of prompt text, local command wrappers inherit only explicitly allowlisted host env, start/end/error payloads redact against the effective grant env, and child tasks inherit only grants whose scope policy allows it. The Python cockpit API exposes `GET /api/cockpit/runtime-sessions`, `GET /api/cockpit/runtime-sessions/{session_id}`, `GET /api/cockpit/runtime-sessions/{session_id}/timeline`, `GET /api/cockpit/runs/{run_id}/runtime-session`, and `GET /api/cockpit/runs/{run_id}/runtime-session/timeline`. The Python MCP server exposes the same read model through `autocontext_list_runtime_sessions`, `autocontext_get_runtime_session`, and `autocontext_get_runtime_session_timeline`, plus unprefixed aliases.
+Python runtime-backed `run` and `solve` calls append provider prompts/responses to run-scoped runtime-session logs. The same logs are readable through the cockpit HTTP API and MCP tools.
 
-## Main CLI Commands
+Detailed setup moved out of this README:
+
+- External agents and provider routing: [docs/agent-integration.md](docs/agent-integration.md)
+- Persistent worker trust boundaries: [docs/persistent-host.md](docs/persistent-host.md)
+- Sandbox/executor notes: [docs/sandbox.md](docs/sandbox.md)
+- Extension hooks: [docs/extensions.md](docs/extensions.md)
+
+## Contract probes
+
+Contract probes turn observed harness traces into executable checks:
 
 ```bash
-uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
-uv run autoctx simulate --description "simulate deploying a web service with rollback"
-uv run autoctx simulate --description "simulate deploying a web service with rollback" --provider claude-cli
-uv run autoctx investigate --description "why did conversion drop after Tuesday's release"
-uv run autoctx investigate --description "debug the outage timeline" --mode iterative
-uv run autoctx investigate --description "checkout is failing in prod" --browser-url https://status.example.com
-uv run autoctx queue add --task-prompt "Write a 1-line fact about primes" --rubric "correct" --threshold 0.8 --rounds 2
-uv run autoctx queue --spec support_triage --browser-url https://status.example.com
-uv run autoctx worker --poll-interval 5 --concurrency 2
-uv run autoctx simulate --replay deploy_sim --variables threshold=0.9
-uv run autoctx list
-uv run autoctx status <run_id>
-uv run autoctx show <run_id> --best
-uv run autoctx show <run_id> --generation 2 --json
-uv run autoctx watch <run_id> --interval 2
-uv run autoctx replay <run_id> --generation 1
-uv run autoctx run support_triage --iterations 3
-uv run autoctx benchmark --scenario support_triage --runs 5
-uv run autoctx new-scenario --template prompt-optimization --name support_triage
-uv run autoctx export-training-data --scenario support_triage --all-runs --output training/support_triage.jsonl
-uv run autoctx train --scenario support_triage --data training/support_triage.jsonl --time-budget 300
-uv run autoctx hermes inspect --json
-uv run autoctx hermes export-skill --output ~/.hermes/skills/autocontext/SKILL.md --json
-uv run autoctx hermes export-skill --output ~/.hermes/skills/autocontext/SKILL.md --with-references --json
-uv run autoctx analytics context-selection --run-id <run_id> --json
-uv run autoctx analytics trace-findings --trace-id <trace_id> --kind writeup --json
-uv run autoctx analytics trace-findings --trace-id <trace_id> --kind weakness
-uv run autoctx serve --host 127.0.0.1 --port 8000
-uv run autoctx mcp-serve
 uv run autoctx probes check --suite contract-probes.json
 uv run autoctx probes check --suite contract-probes.json --json
-uv run autoctx probes extract --trace harness-trace.json
 uv run autoctx probes extract --trace harness-trace.json --output contract-probes.json
-uv run autoctx mission create --name "Ship login" --goal "Implement OAuth"
-uv run autoctx mission run --id <mission_id> --max-iterations 3 --json
-uv run autoctx mission status --id <mission_id> --json
-uv run autoctx mission list --status active --json
-uv run autoctx mission pause --id <mission_id>
-uv run autoctx mission resume --id <mission_id>
-uv run autoctx mission cancel --id <mission_id>
-uv run autoctx mission artifacts --id <mission_id> --json
-uv run autoctx wait <condition_id> --json
 ```
 
-Saved custom scenarios under `knowledge/_custom_scenarios/` can be rerun and benchmarked by name once their `spec.json` has been persisted, so the `new-scenario` / `solve` workflow lines up with the named `run` and `benchmark` surfaces.
+Probe suites are strict JSON: unknown keys fail validation and required observation fields must be present. Pipe stdin with `--suite -` when another tool generates the suite.
 
-Trace-finding reports read persisted `RunTrace` files from `knowledge/analytics/traces/`.
-Use the filename without `.json` as `--trace-id` (for example
-`trace-run-123` from `knowledge/analytics/traces/trace-run-123.json`), or run
-`uv run autoctx analytics rebuild-traces --run-id <run_id> --json` to rebuild
-trace artifacts from an events stream first. `--kind writeup` emits the full
-summary/findings/motifs/recovery-path shape; `--kind weakness` emits
-recommendations, weakness findings, motifs, and recovery analysis.
+## Production traces
 
-Useful variants:
+Wrap an existing Anthropic/OpenAI client once, then persist emitted traces through a sink:
 
-```bash
-AUTOCONTEXT_AGENT_PROVIDER=anthropic ANTHROPIC_API_KEY=... \
-uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
+```python
+from anthropic import Anthropic
+from autocontext.integrations.anthropic import FileSink, instrument_client
 
-AUTOCONTEXT_AGENT_PROVIDER=anthropic \
-ANTHROPIC_API_KEY=sk-ant-primary \
-AUTOCONTEXT_COMPETITOR_PROVIDER=openai-compatible \
-AUTOCONTEXT_COMPETITOR_API_KEY=sk-role \
-AUTOCONTEXT_COMPETITOR_BASE_URL=http://localhost:8000/v1 \
-uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
-
-AUTOCONTEXT_AGENT_PROVIDER=deterministic AUTOCONTEXT_RLM_ENABLED=true \
-uv run autoctx solve "improve customer-support replies for billing disputes" --iterations 3
+sink = FileSink("./traces/anthropic.jsonl")
+client = instrument_client(
+    Anthropic(),
+    sink=sink,
+    app_id="billing-bot",
+    environment_tag="prod",
+)
 ```
 
-## Contract Probes
+For lower-level emit APIs, use `autocontext.production_traces.build_trace`
+and `write_jsonl`. Architecture notes are in
+[../docs/analytics.md](../docs/analytics.md) and
+[../docs/opentelemetry-bridge.md](../docs/opentelemetry-bridge.md).
 
-`uv run autoctx probes check --suite <path>` runs the contract-probe suite against observed harness state and reports per-probe pass/fail. It exits 0 on a full pass and 1 on any failure or any load / parse error. Default output is human-readable; pass `--json` to emit a structured `ContractProbeSuiteResult` payload (`{passed, results: [{kind, label?, passed, failures: [{kind, message, ...}]}]}`) that downstream tools can consume. On load / parse / validation failure, the typer wrapper writes the actionable error to stderr so `--json` consumers can safely parse stdout.
-
-The suite file is a JSON document validated by `ContractProbeSuiteSchema`. Every nested model is strict: unknown keys (for example a typo like `requiredStdoutPattern` missing the trailing `s`) fail validation rather than silently disappearing. Required observation fields (`presentFiles`, `observed`, `entries`, `ranks`) must be present and primitives are not coerced (`"exitCode": "0"` rejects). Optional expectation fields accept omission but not explicit `null`.
-
-Stdin form lets the canonical pipe pattern stay cross-platform:
-
-```bash
-uv run autoctx probes check --suite contract-probes.json --json
-cat contract-probes.json | uv run autoctx probes check --suite -
-```
-
-Minimal suite example:
-
-```json
-{
-  "schema_version": 1,
-  "probes": [
-    {
-      "kind": "terminal",
-      "label": "solve-cli",
-      "inputs": {
-        "exitCode": 0,
-        "stdout": "solution.txt written",
-        "stderr": "",
-        "requiredStdoutPatterns": ["solution\\.txt"]
-      }
-    },
-    {
-      "kind": "directory",
-      "label": "final-workdir",
-      "inputs": {
-        "presentFiles": ["solution.txt"],
-        "requiredFiles": ["solution.txt"],
-        "allowedFiles": ["solution.txt"]
-      }
-    }
-  ]
-}
-```
-
-The seven probe kinds (`directory`, `terminal`, `service`, `artifact`, `cleanup`, `media`, `distributed`) each verify a different facet of observed harness state. RegExp values accept a bare pattern string or `{"source": ..., "flags": ...}`; ISO-8601 strings parse to `datetime`. Every declared expectation must carry a corresponding observation; missing observations fail with kind `missing-observation` rather than silently passing.
-
-### Synthesizing a suite from a harness trace
-
-`uv run autoctx probes extract --trace <path>` reads a harness-trace JSON envelope that bundles two halves:
-
-- `observations`: what actually happened in a recorded run (terminal exit code / stdout / stderr; the workdir's present files; observed service endpoints; emitted artifacts and their content).
-- `expectations`: what the operator declared should have happened (expected exit code, required / allowed files, required endpoints, per-artifact JSON-field / substring / line-ending expectations).
-
-The extractor joins them into a runnable `ContractProbeSuite` that `autoctx probes check` can execute. Per-artifact expectations join observations by `path`; observations without a matching expectation are still encoded as no-op artifact probes (path + content only, no assertions). Orphan expectations (declared without a matching observation) fail validation at parse time rather than producing a vacuously-passing suite.
-
-Pipe form: `autoctx probes extract --trace t.json | autoctx probes check --suite -` works cross-platform; the typer wrapper writes parse / validation errors to stderr so JSON consumers can parse stdout cleanly. `--output <path>` writes the suite to a file (parent directories are created); omit it to emit to stdout.
-
-Slice 5 covers the four base probe kinds (`terminal`, `directory`, `service`, `artifact`); cleanup / media / distributed extraction lands in a follow-up slice. Minimal trace example:
-
-```json
-{
-  "schema_version": 1,
-  "label": "solve-cli",
-  "observations": {
-    "terminal": { "exitCode": 0, "stdout": "solution.txt written", "stderr": "" },
-    "workdir": { "presentFiles": ["solution.txt"] },
-    "artifacts": [{ "path": "solution.txt", "content": "answer\n" }]
-  },
-  "expectations": {
-    "terminal": { "requiredStdoutPatterns": ["solution\\.txt"] },
-    "directory": { "requiredFiles": ["solution.txt"], "allowedFiles": ["solution.txt"] },
-    "artifacts": [{ "path": "solution.txt", "requiredSubstrings": ["answer"] }]
-  }
-}
-```
-
-## Missions
-
-`uv run autoctx mission ...` manages long-running, verifier-driven missions. A mission bundles a goal, a budget, a status that follows the state-machine table (active / paused / blocked / completed / failed / canceled / budget_exhausted / verifier_failed), and an optional verifier that gates completion. Two flavours land:
-
-- Generic missions advance via a subgoal-stepping loop; the fallback verifier passes once every subgoal reaches a terminal state.
-- Code missions register a `CodeMissionSpec` whose `test_command` (and optional `lint_command` / `build_command`) is wrapped in a `CommandVerifier` (composite when multiple commands are supplied). A code mission rejected by its verifier is downgraded from `active` to `failed` when the run loop returns.
-
-Every subcommand emits human-readable text by default and a structured JSON payload under `--json`. Errors route to stderr so JSON consumers can safely parse stdout on failure paths. State persists under `settings.db_path`; each `create` / `run` / `pause` / `resume` / `cancel` action writes a fresh checkpoint under `<settings.runs_root>/missions/<mission_id>/checkpoints/`. The checkpoint filename embeds nanosecond resolution + an 8-char uuid suffix so concurrent writes never collide; loaders accept both Python-shaped (snake_case) and TS-shaped (camelCase) checkpoints so a shared `AUTOCONTEXT_DB_PATH` can resume from either runtime.
-
-Minimal end-to-end (generic mission):
-
-```bash
-uv run autoctx mission create --name "Ship login" --goal "Implement OAuth" --json
-# -> {"id": "mission-abc12345", "status": "active", ...}
-uv run autoctx mission run --id mission-abc12345 --max-iterations 3 --json
-# -> {"id": "...", "finalStatus": "active", "stepsExecuted": 3, "verifierPassed": false, ...}
-uv run autoctx mission status --id mission-abc12345 --json
-uv run autoctx mission pause --id mission-abc12345 --json
-uv run autoctx mission cancel --id mission-abc12345 --json
-uv run autoctx mission artifacts --id mission-abc12345 --json
-```
-
-Code mission example:
-
-```bash
-uv run autoctx mission create \
-  --type code \
-  --name "Fix login" \
-  --goal "Tests pass" \
-  --repo-path . \
-  --test-command "pytest -x" \
-  --lint-command "ruff check src" \
-  --max-steps 5 \
-  --json
-uv run autoctx mission run --id <mission_id> --max-iterations 5 --json
-```
-
-Status transitions are enforced by the slice-2 transition table. Only `completed` is truly terminal (self-loop only). `canceled` can be reopened via `resume` (e.g. an operator who changes their mind), so a `mission cancel` followed by `mission resume` returns the mission to `active`. `paused -> completed` rejects because the verifier must observe a live mission. An invalid transition surfaces a clear error and does not mutate state. Async verifiers and async step executors are supported; the CLI is a sync entry point so they cannot be combined with a running event loop (calling from inside an active loop raises `AsyncContextError` before any state mutation).
-
-## Training Workflow
-
-Export JSONL training data from completed runs:
+## Training
 
 ```bash
 uv run autoctx export-training-data \
-  --scenario support_triage \
-  --all-runs \
+  --scenario support_triage --all-runs \
   --output training/support_triage.jsonl
-```
-
-Launch the autoresearch-style training loop:
-
-```bash
-uv sync --group dev --extra mlx
 uv run autoctx train \
   --scenario support_triage \
   --data training/support_triage.jsonl \
   --time-budget 300
 ```
 
-MLX training is host-only. It must run on an Apple Silicon macOS machine with Metal access. It will not run correctly inside a Docker sandbox on macOS.
+For MLX/CUDA setup and case studies, use:
 
-If you only want to inspect generated training data first, export without training and open the JSONL directly.
+- [docs/mlx-training.md](docs/mlx-training.md)
+- [docs/case-study-recursive-loop.md](docs/case-study-recursive-loop.md)
+- [case study: on-policy distillation](docs/case-study-on-policy-distillation.md)
 
-For host setup details and OpenClaw automation via a file-based watcher bridge, see [docs/mlx-training.md](docs/mlx-training.md).
-
-## Configuration
-
-Configuration is loaded from `AUTOCONTEXT_*` environment variables in `src/autocontext/config/settings.py`.
-
-Common settings:
-
-- `AUTOCONTEXT_AGENT_PROVIDER`
-- `AUTOCONTEXT_EXECUTOR_MODE`
-- `AUTOCONTEXT_MODEL_COMPETITOR`
-- `AUTOCONTEXT_MATCHES_PER_GENERATION`
-- `AUTOCONTEXT_MAX_RETRIES`
-- `AUTOCONTEXT_JUDGE_PROVIDER`
-- `AUTOCONTEXT_PI_TIMEOUT` (defaults to 300 seconds for Pi-backed live runs)
-- `AUTOCONTEXT_HARNESS_PROFILE` (`standard` or `lean`)
-- `AUTOCONTEXT_LEAN_CONTEXT_BUDGET_TOKENS`
-- `AUTOCONTEXT_LEAN_HIDDEN_CONTEXT_BUDGET_TOKENS`
-- `AUTOCONTEXT_LEAN_TOOL_ALLOWLIST`
-- `AUTOCONTEXT_PI_RPC_PERSISTENT`
-- `AUTOCONTEXT_EXTENSIONS`
-- `AUTOCONTEXT_EXTENSION_FAIL_FAST`
-- `AUTOCONTEXT_RLM_ENABLED`
-- `AUTOCONTEXT_SIMPLICITY_MODE` (`off`, `guide`, or experimental guide-only `enforce`)
-- `AUTOCONTEXT_HARNESS_PREFLIGHT_ENABLED`
-- `AUTOCONTEXT_STAGED_VALIDATION_ENABLED`
-- `AUTOCONTEXT_BROWSER_ENABLED`
-- `AUTOCONTEXT_BROWSER_ALLOWED_DOMAINS`
-- `AUTOCONTEXT_BROWSER_PROFILE_MODE`
-- `AUTOCONTEXT_BROWSER_ALLOW_AUTH`
-- `AUTOCONTEXT_BROWSER_ALLOW_DOWNLOADS` and `AUTOCONTEXT_BROWSER_DOWNLOADS_ROOT`
-
-Browser exploration defaults to a secure disabled posture and uses the shared contract described in [../docs/browser-exploration-contract.md](../docs/browser-exploration-contract.md).
-Install `autocontext[browser]` before using the thin Chrome CDP backend; it attaches to an existing debugger endpoint, enforces the browser allowlist, and stores browser evidence under run-local roots.
-
-`AUTOCONTEXT_HARNESS_PROFILE=lean` resolves a Pi-shaped runtime profile: prompt context is capped by `AUTOCONTEXT_LEAN_CONTEXT_BUDGET_TOKENS`, hidden/implicit context defaults to zero, and generated tool context is replaced by the lean allowlist before agent execution. `AUTOCONTEXT_PI_RPC_PERSISTENT=true` opts Pi RPC into a long-lived subprocess; one-shot Pi RPC remains the default.
-
-`AUTOCONTEXT_EXTENSIONS` loads comma-separated extension modules that register Pi-shaped runtime hooks for context transforms, provider requests/responses, judge calls, artifact writes, and run/generation lifecycle events. Python runs load Python modules or `.py` files; TypeScript runs load JavaScript/ESM modules. See [docs/extensions.md](docs/extensions.md).
-
-Semantic prompt compactions are also persisted as Pi-shaped JSONL entries at
-`runs/<run_id>/compactions.jsonl`, including `summary`, `firstKeptEntryId`,
-`tokensBefore`, and component details for runtime snapshots and resumption.
-
-Solved strategy packages can also be exported as Pi-local package directories:
-
-```bash
-uv run autoctx export <run_id> --format pi-package --output grid-ctf-pi-package
-```
-
-The directory contains `package.json`, a Pi skill, a prompt file, and the original `autocontext.package.json` strategy payload for re-import.
-
-See the repo-level [.env.example](../.env.example) for a working starting point.
-
-## Repository Structure
+## Repository layout
 
 ```text
 autocontext/
-  src/autocontext/   Python package
-  tests/             Pytest suite
-  docs/              Package-specific documentation
-  migrations/        SQLite migrations
-ts/                  TypeScript package
-infra/               Docker, Fly.io, bootstrap scripts
+├── src/autocontext/       # Python package
+├── tests/                 # pytest suite
+├── docs/                  # package-specific docs
+├── demo_data/             # small bundled examples
+├── migrations/            # SQLite migrations
+└── pyproject.toml
 ```
 
-## Validation and Development
+## Development
 
 ```bash
-uv run ruff check src tests
+uv run ruff check .
 uv run mypy src
 uv run pytest
 ```
 
-If you change protocol messages, regenerate the derived protocol artifacts from the repo root:
-
-```bash
-cd ..
-uv run --directory autocontext python scripts/generate_protocol.py
-```
-
-## OpenClaw / ClawHub
-
-autocontext exposes:
-
-- artifact contracts for harnesses, policies, and distilled models
-- REST and MCP operations for evaluate, validate, publish, import, and discover
-- ClawHub skill manifests and scenario discovery metadata
-- an adapter layer for running OpenClaw agents inside the harness
-
-## OpenAI integration
-
-autocontext ships a zero-configuration OpenAI instrumentation path that
-automatically wraps your existing `OpenAI(...)` calls and emits structured
-traces to a sink of your choice.
-
-### 1. Register detectors
-
-Create `.autoctx.instrument.config.mjs` at the root of your repo:
-
-```js
-// .autoctx.instrument.config.mjs
-import { registerDetectorPlugin } from "autoctx/control-plane/instrument";
-import { plugin as openaiPythonPlugin } from "autoctx/detectors/openai-python";
-
-registerDetectorPlugin(openaiPythonPlugin);
-```
-
-### 2. Run instrument
-
-Preview changes without touching any files:
-
-```bash
-autoctx instrument --dry-run
-```
-
-Apply changes on a new branch for review:
-
-```bash
-autoctx instrument --apply --branch autoctx/instrument
-```
-
-### 3. Review the PR
-
-The instrument command opens a branch. Open the PR and review the diff — you
-will see your `OpenAI(...)` calls wrapped with `instrument_client(...)`.
-Edit the generated TODO comment to point at your `FileSink`:
-
-```python
-# Before (generated):
-client = instrument_client(OpenAI(), sink=None)  # TODO: pass your TraceSink here
-
-# After (your edit):
-from autocontext.integrations.openai import instrument_client, FileSink
-sink = FileSink("./traces/openai.jsonl")
-client = instrument_client(OpenAI(), sink=sink)
-```
-
-Merge the PR.
-
-### 4. Customer code emits traces
-
-Your code is unchanged beyond the wrap. Every `chat.completions.create` call
-now emits a JSONL trace line to your sink:
-
-```python
-import openai
-from autocontext.integrations.openai import instrument_client, FileSink, autocontext_session
-
-sink = FileSink("./traces/openai.jsonl")
-client = instrument_client(openai.OpenAI(), sink=sink)
-
-with autocontext_session({"userId": "u_123"}):
-    response = client.chat.completions.create(
-        model="gpt-4o",
-        messages=[{"role": "user", "content": "Hello!"}],
-    )
-    print(response.choices[0].message.content)
-
-sink.close()
-```
-
-Emitted trace line (pretty-printed for readability):
-
-```jsonl
-{
-  "schemaVersion": "1.0",
-  "traceId": "...",
-  "sessionContext": {
-    "userId": "u_123"
-  },
-  "request": {
-    "model": "gpt-4o",
-    "messages": [
-      {
-        "role": "user",
-        "content": "Hello!"
-      }
-    ]
-  },
-  "response": {
-    "id": "...",
-    "choices": [
-      {
-        "message": {
-          "role": "assistant",
-          "content": "Hi! How can I help?"
-        },
-        "finish_reason": "stop"
-      }
-    ],
-    "usage": {
-      "prompt_tokens": 9,
-      "completion_tokens": 7,
-      "total_tokens": 16
-    }
-  },
-  "durationMs": 342,
-  "errorReason": null
-}
-```
-
-For the TypeScript equivalent, see `ts/src/integrations/openai/STABILITY.md`.
-
-## Anthropic integration
-
-autocontext ships a zero-configuration Anthropic instrumentation path that
-automatically wraps your existing `Anthropic(...)` calls and emits structured
-traces to a sink of your choice.
-
-### 1. Register detectors
-
-Create `.autoctx.instrument.config.mjs` at the root of your repo:
-
-```js
-// .autoctx.instrument.config.mjs
-import { registerDetectorPlugin } from "autoctx/control-plane/instrument";
-import { plugin as anthropicPythonPlugin } from "autoctx/detectors/anthropic-python";
-
-registerDetectorPlugin(anthropicPythonPlugin);
-```
-
-### 2. Run instrument
-
-Preview changes without touching any files:
-
-```bash
-autoctx instrument --dry-run
-```
-
-Apply changes on a new branch for review:
-
-```bash
-autoctx instrument --apply --branch autoctx/instrument
-```
-
-### 3. Review the PR
-
-The instrument command opens a branch. Open the PR and review the diff — you
-will see your `Anthropic(...)` calls wrapped with `instrument_client(...)`.
-Edit the generated TODO comment to point at your `FileSink`:
-
-```python
-# Before (generated):
-client = instrument_client(Anthropic(), sink=None)  # TODO: pass your TraceSink here
-
-# After (your edit):
-from autocontext.integrations.anthropic import instrument_client, FileSink
-sink = FileSink("./traces/anthropic.jsonl")
-client = instrument_client(Anthropic(), sink=sink)
-```
-
-Merge the PR.
-
-### 4. Customer code emits traces
-
-Your code is unchanged beyond the wrap. Every `messages.create` call now emits
-a JSONL trace line to your sink:
-
-```python
-import anthropic
-from autocontext.integrations.anthropic import instrument_client, FileSink, autocontext_session
-
-sink = FileSink("./traces/anthropic.jsonl")
-client = instrument_client(anthropic.Anthropic(), sink=sink)
-
-with autocontext_session({"userId": "u_123"}):
-    response = client.messages.create(
-        model="claude-opus-4-7-20251101",
-        max_tokens=256,
-        messages=[{"role": "user", "content": "Hello!"}],
-    )
-    print(response.content[0].text)
-
-sink.close()
-```
-
-Emitted trace line (pretty-printed for readability):
-
-```jsonl
-{
-  "schemaVersion": "1.0",
-  "traceId": "...",
-  "sessionContext": {
-    "userId": "u_123"
-  },
-  "request": {
-    "model": "claude-opus-4-7-20251101",
-    "messages": [
-      {
-        "role": "user",
-        "content": "Hello!"
-      }
-    ]
-  },
-  "response": {
-    "id": "...",
-    "content": [
-      {
-        "type": "text",
-        "text": "Hi! How can I help?"
-      }
-    ],
-    "stop_reason": "end_turn",
-    "usage": {
-      "input_tokens": 9,
-      "output_tokens": 7
-    }
-  },
-  "durationMs": 342,
-  "errorReason": null
-}
-```
-
-For the TypeScript equivalent, see `ts/src/integrations/anthropic/STABILITY.md`.
-
-## Additional Docs
-
-- [Canonical concept model](../docs/concept-model.md)
-- [Agent integration guide](docs/agent-integration.md) — CLI-first integration for external agents, MCP fallback, JSON output reference
-- [Sandbox modes](docs/sandbox.md)
-- [Persistent host worker](docs/persistent-host.md)
-- [MLX host training](docs/mlx-training.md)
-- [Case study: recursive loop closed on local MLX](docs/case-study-recursive-loop.md)
-- [TypeScript package guide](../ts/README.md) — `analyze`, mission control, and interactive TUI surfaces
-- [Demo data notes](demo_data/README.md)
-- [Copy-paste examples](../examples/README.md)
-- [Change history](../CHANGELOG.md)
-- [Repository overview](../README.md)
+Keep this README concise. Add deep reference prose to `docs/` or the repo-level
+docs index instead.

--- a/ts/README.md
+++ b/ts/README.md
@@ -1,372 +1,18 @@
-# autoctx — autocontext TypeScript Package
+# autoctx — TypeScript package
 
-`autoctx` is the Node/TypeScript package for autocontext. It provides the operator-facing CLI, simulation, investigation, analysis, mission, and trace surfaces for Node environments:
+`autoctx` is the Node/TypeScript package for autocontext. It ships the operator-facing CLI, TUI, simulations, investigations, analysis, missions, MCP server, runtime/session primitives, production-trace SDK, and experimental agent-handler surface.
 
-The intended use is to point the harness at a real task, simulation, investigation, or mission, let it produce a rich execution history, and then use the returned traces, reports, datasets, packages, and artifacts to improve or operationalize that workflow.
-
-Need the canonical product/runtime vocabulary first? Start with [docs/concept-model.md](../docs/concept-model.md).
-
-- **Scenario execution**: run generation loops with tournament scoring and Elo progression
-- **Simulation surface**: plain-language simulations with sweeps, replay, compare, and export
-- **Investigation surface**: evidence-driven diagnosis with hypotheses and confidence scoring
-- **Analysis surface**: interpret and compare runs, simulations, investigations, and missions
-- **Mission surface**: adaptive execution, mission artifacts, and verifier-driven control plane
-- **Knowledge system**: versioned playbooks, score trajectories, session reports, dead-end tracking
-- **Interactive server**: HTTP API, WebSocket control plane, bundled Ink TUI
-- **MCP control plane**: 40+ tools covering scenarios, runs, knowledge, evaluation, feedback, solve, sandbox, and export
-- **Provider routing**: Anthropic, OpenAI-compatible, Gemini, Mistral, Groq, OpenRouter, Azure OpenAI, Ollama, vLLM, Hermes, Pi, Pi-RPC, deterministic
-- **Evaluation**: one-shot judging, multi-round improvement loops, REPL-loop sessions
-- **Package management**: strategy package export/import, training data export
-- **Training hook surface**: dataset validation and executor-backed `train` entry point
-- **Runtime workspace/session primitives**: workspace-scoped filesystem/shell contracts, scoped command/tool grants with redacted lifecycle events, runtime session event logs, child-task lineage helpers, a runtime-session facade, and AgentRuntime session recording
-- **Experimental agent handler surface** at `autoctx/agent-runtime`: discover and invoke `.autoctx/agents/*.ts` handlers backed by runtime sessions
-- **Production-traces emit SDK** at `autoctx/production-traces` — customer-facing emit APIs mirroring the Python SDK (A2-II-a)
-
-Runtime command grants are host-created capability handles, not prompt text.
-Trusted env values are injected only into the grant handler or local child
-process. Local grant wrappers do not inherit `process.env`; callers must opt in
-with an explicit `inheritEnv` allowlist. Runtime-session logs record
-`start`/`end`/`error` events with command name, args summary, exit code, and
-redaction metadata; they redact values from the exact env supplied to the
-grant. Prompt-scoped grants last only for that runtime call. Child tasks receive
-grants only when the caller passes grants to `runChildTask()` or when an
-already-granted workspace contains grants whose policy allows child-task
-inheritance.
-
-TypeScript callers can also adapt remote streamable-HTTP MCP servers into
-scoped runtime tool grants with `connectMcpRuntimeTools()`. The trusted host
-code owns the MCP URL and headers, discovered tool names are normalized with
-collision suffixes, input schemas are preserved, and tool results are converted
-to model-safe text while keeping structured content available to callers:
-
-```ts
-import { createInMemoryWorkspaceEnv } from "autoctx";
-import { connectMcpRuntimeTools } from "autoctx/runtimes/mcp";
-
-const mcpTools = await connectMcpRuntimeTools({
-  url: "https://mcp.example.com/rpc",
-  headers: { Authorization: `Bearer ${process.env.MCP_TOKEN ?? ""}` },
-  namePrefix: "docs",
-});
-
-const workspace = await createInMemoryWorkspaceEnv({ cwd: "/repo" }).scope({
-  tools: mcpTools.tools,
-});
-
-const result = await workspace.tools?.[0]?.execute?.({ q: "runtime sessions" });
-await mcpTools.close();
-```
-
-The package also includes an experimental programmable-agent authoring surface
-at `autoctx/agent-runtime`. It discovers handlers from `.autoctx/agents` only
-and avoids colliding with `.autoctx/skills`, scenario directories, or hosted
-deployment concerns. The invoker supplies payload, env, workspace, and an
-`AgentRuntime`; env values are available to trusted handler code but are not
-automatically inserted into prompts. The package uses its bundled `tsx` loader
-for `.ts`, `.tsx`, and `.mts` agent files on Node 18+.
-
-```ts
-// .autoctx/agents/support.ts
-import type { AutoctxAgentContext } from "autoctx/agent-runtime";
-
-type Payload = { threadId?: string; message: string };
-
-export const triggers = { webhook: true };
-
-export default async function ({ id, init, payload }: AutoctxAgentContext<Payload>) {
-  const runtime = await init();
-  const session = await runtime.session(payload.threadId ?? id ?? "default");
-  return session.prompt(payload.message, { role: "support-triager" });
-}
-```
-
-```ts
-import { discoverAutoctxAgents, invokeAutoctxAgent, loadAutoctxAgent } from "autoctx/agent-runtime";
-import { createInMemoryWorkspaceEnv } from "autoctx";
-
-const [entry] = await discoverAutoctxAgents({ cwd: process.cwd() });
-const agent = await loadAutoctxAgent(entry);
-
-const result = await invokeAutoctxAgent(agent, {
-  payload: { threadId: "ticket-123", message: "Please triage this ticket." },
-  env: { SUPPORT_TOKEN: process.env.SUPPORT_TOKEN },
-  runtime: myAgentRuntime,
-  workspace: createInMemoryWorkspaceEnv({ cwd: "/repo" }),
-});
-```
-
-For local iteration, the npm CLI can invoke the same handlers by name, expose
-a tiny dev server, or materialize the approved self-hosted Node build target.
-Env file loading is explicit: pass `--env FILE` to local run/dev, or set
-`AUTOCTX_ENV_FILE` for a generated Node server; values already set in the shell
-win over values in that file. Generated packages use a local `file:` dependency
-on the currently installed `autoctx`, so source builds do not reinstall an older
-npm release that lacks the Node-target subpath. Runtime-backed generated servers
-accept `AUTOCTX_RUNTIME_MODULE` as a bare package specifier, relative/absolute
-file path, or URL.
-
-```bash
-autoctx agent run support \
-  --id ticket-123 \
-  --payload '{"threadId":"ticket-123","message":"Please triage this ticket."}' \
-  --env .env.local \
-  --json
-
-autoctx agent dev --port 3583 --env .env.local
-
-autoctx agent build --target node --out .autoctx/build/node
-cd .autoctx/build/node && npm install && AUTOCTX_ENV_FILE=.env.local npm start
-
-curl http://127.0.0.1:3583/manifest
-curl -X POST http://127.0.0.1:3583/agents/support/invoke \
-  -H 'content-type: application/json' \
-  -d '{"id":"ticket-123","payload":{"message":"Please triage this ticket."}}'
-```
-
-Generic Fetch/ESM hosts can reuse the same manifest/invoke wire shape through
-the control-plane adapter at `autoctx/control-plane/agent-app-fetch`. The
-adapter takes an explicit static catalog or module map; it does not scan the
-filesystem at request time and does not imply a Cloudflare, Vercel, or Deno
-build target.
-
-```ts
-import {
-  createAgentAppFetchHandler,
-  createStaticAgentAppCatalog,
-} from "autoctx/control-plane/agent-app-fetch";
-
-const hostProvidedEnv = { SUPPORT_TOKEN: "host-injected-token" };
-
-const fetchAgentApp = createAgentAppFetchHandler({
-  env: { SUPPORT_TOKEN: hostProvidedEnv.SUPPORT_TOKEN },
-  catalog: createStaticAgentAppCatalog([
-    {
-      name: "support",
-      relativePath: ".autoctx/agents/support.ts",
-      extension: ".ts",
-      triggers: { webhook: true },
-      handler: async (ctx) => ({ id: ctx.id, payload: ctx.payload }),
-    },
-  ]),
-});
-
-export default { fetch: fetchAgentApp };
-```
-
-Fetch hosts can pass an explicit workspace store when handler artifacts should
-survive beyond a single invocation. The default Fetch workspace is request-local
-memory; the store seam is provider-neutral and keeps shell execution unavailable
-unless a separate host-created capability is supplied:
-
-```ts
-import {
-  createAgentAppFetchHandler,
-  createInMemoryAgentAppFetchWorkspaceStore,
-} from "autoctx/control-plane/agent-app-fetch";
-
-const workspaceStore = createInMemoryAgentAppFetchWorkspaceStore();
-
-export default {
-  fetch: createAgentAppFetchHandler({
-    catalog, // a static or module-map catalog supplied by host build code
-    workspaceStore,
-  }),
-};
-```
-
-Build tooling can also precompute a bundler-visible module map and turn it into
-the same Fetch catalog or a generic generated Fetch entrypoint. The planner
-accepts explicit `.autoctx/agents` entries from a build step; it does not
-discover files from the request path:
-
-```ts
-import {
-  createAgentAppFetchCatalogFromModuleMap,
-  createAgentAppFetchHandler,
-  planAgentAppFetchCatalog,
-} from "autoctx/control-plane/agent-app-fetch";
-
-const plan = planAgentAppFetchCatalog({
-  entries: [
-    {
-      name: "support",
-      relativePath: ".autoctx/agents/support.ts",
-      extension: ".ts",
-      triggers: { webhook: true },
-    },
-  ],
-  moduleSpecifier: (entry) => `./${entry.relativePath}`,
-});
-
-const catalog = createAgentAppFetchCatalogFromModuleMap(plan, {
-  support: () => import("./.autoctx/agents/support.ts"),
-});
-
-export default { fetch: createAgentAppFetchHandler({ catalog }) };
-```
-
-For generated Fetch bundles, `renderAgentAppFetchEntrypointTemplate()` emits an
-ESM entrypoint with a static module map, a machine-readable host capability
-manifest, and a `createAgentAppFetchEntrypoint()` factory. Host code can pass
-explicit capabilities such as `env`, `runtime`, `runtimeFactory`,
-`runtimeFactoryName`, `workspaceStore`, or `sessionEventStore`; the generated
-source does not read ambient env or add provider deployment wrappers:
-
-```ts
-import {
-  planAgentAppFetchCatalog,
-  planAgentAppFetchRuntimeFactories,
-  agentAppFetchHostCapabilityManifestSchema,
-  renderAgentAppFetchEntrypointTemplate,
-  renderAgentAppFetchHostCapabilityManifest,
-  renderAgentAppFetchHostCapabilityManifestSchema,
-} from "autoctx/control-plane/agent-app-fetch";
-
-const plan = planAgentAppFetchCatalog({ entries });
-const runtimeFactoryPlan = planAgentAppFetchRuntimeFactories({
-  entries: runtimeEntries,
-});
-const source = renderAgentAppFetchEntrypointTemplate(plan, {
-  runtimeFactoryPlan,
-});
-const manifestJson = renderAgentAppFetchHostCapabilityManifest(plan);
-const manifestSchemaJson = renderAgentAppFetchHostCapabilityManifestSchema();
-// or import agentAppFetchHostCapabilityManifestSchema directly for validators.
-void agentAppFetchHostCapabilityManifestSchema;
-```
-
-The manifest lists the supported Fetch routes (`GET /manifest`, `GET /agents`,
-and `POST /agents/:agent/invoke`), generated agents, accepted host capability
-keys, and unsupported defaults such as runtime filesystem discovery, ambient
-environment capture, and local shell execution. A generated entrypoint can use a
-host-supplied `runtimeFactory` directly or resolve `runtimeFactoryName` through
-the bundled, static runtime factory module map. Provider wrappers can consume the
-manifest JSON and `agentAppFetchHostCapabilityManifestSchema` when validating
-host capability wiring, but provider-specific deployment remains outside this
-package. See [`docs/fetch-api-reference.md`](../docs/fetch-api-reference.md) for
-the exported API surface,
-[`docs/fetch-host-capability-manifest.md`](../docs/fetch-host-capability-manifest.md)
-for manifest validation examples,
-[`docs/generated-fetch-packaging.md`](../docs/generated-fetch-packaging.md),
-[`docs/fetch-troubleshooting.md`](../docs/fetch-troubleshooting.md),
-[`examples/generated-fetch-packaging.ts`](examples/generated-fetch-packaging.ts),
-and [`examples/generated-fetch-runtime-factory-packaging.ts`](examples/generated-fetch-runtime-factory-packaging.ts)
-for generic Fetch/ESM packaging examples and common host wiring fixes.
-
-Runtime-backed Fetch handlers can receive an explicit edge-safe session event
-store. The store appends idempotently by `eventId`, replays by per-session
-sequence, and is host-owned; provider-specific storage adapters belong outside
-this generic package:
-
-```ts
-import {
-  createAgentAppFetchHandler,
-  createInMemoryAgentAppFetchSessionEventStore,
-} from "autoctx/control-plane/agent-app-fetch";
-
-const sessionEventStore = createInMemoryAgentAppFetchSessionEventStore();
-
-export default {
-  fetch: createAgentAppFetchHandler({ catalog, runtime, sessionEventStore }),
-};
-```
-
-Host-owned workspace/session store adapters can run the framework-agnostic Fetch
-store conformance helpers from `autoctx/control-plane/agent-app-fetch`. Each
-case expects a fresh isolated store from `createStore`; the workspace root
-removal case is destructive for that store instance.
-
-```ts
-import {
-  createAgentAppFetchSessionEventStoreConformanceCases,
-  createAgentAppFetchWorkspaceStoreConformanceCases,
-} from "autoctx/control-plane/agent-app-fetch";
-import { describe, it } from "vitest";
-
-describe("host Fetch stores", () => {
-  for (const testCase of createAgentAppFetchWorkspaceStoreConformanceCases({
-    createStore: createHostWorkspaceStore,
-  })) {
-    it(testCase.name, testCase.run);
-  }
-
-  for (const testCase of createAgentAppFetchSessionEventStoreConformanceCases({
-    createStore: createHostSessionEventStore,
-  })) {
-    it(testCase.name, testCase.run);
-  }
-});
-```
-
-Fetch wrappers can also run invocation conformance cases against any factory that
-accepts generic Fetch handler options. The suite verifies the manifest aliases,
-agent invocation envelope, error envelopes, body limits, explicit
-env/workspace/runtime capability wiring, and runtime factory precedence/laziness
-without depending on a provider runtime.
-
-```ts
-import { createAgentAppFetchInvocationConformanceCases } from "autoctx/control-plane/agent-app-fetch";
-import { describe, it } from "vitest";
-
-describe("host Fetch invocation", () => {
-  for (const testCase of createAgentAppFetchInvocationConformanceCases({
-    createHandler: createHostFetchHandler,
-  })) {
-    it(testCase.name, testCase.run);
-  }
-});
-```
-
-See [`docs/fetch-conformance.md`](../docs/fetch-conformance.md) for the full
-runner-agnostic conformance guide,
-[`docs/fetch-troubleshooting.md`](../docs/fetch-troubleshooting.md) for common
-host wiring failures, and
-[`examples/fetch-conformance-host-wrapper.ts`](examples/fetch-conformance-host-wrapper.ts)
-for a typed executable wrapper example. See
-[`docs/edge-runtime-compatibility.md`](../docs/edge-runtime-compatibility.md) and
-[`docs/core-control-package-split.md#agent-app-build-targets`](../docs/core-control-package-split.md#agent-app-build-targets)
-for the OSS/proprietary boundary: provider deployment manifests, hosted secrets,
-fleet scheduling, billing, and tenant orchestration stay outside this OSS
-adapter.
-
-The TypeScript package includes mirrored deterministic semantic prompt
-compaction for long-lived playbooks, trajectories, and session reports.
-Standalone npm runs compact prompt context before the coarse budget fallback,
-then record Pi-shaped entries via the `ArtifactStore` ledger contract:
-`appendCompactionEntries()`, `readCompactionEntries()`, and
-`latestCompactionEntryId()` persist/read `runs/<run_id>/compactions.jsonl` plus
-the `compactions.latest` sidecar for cheap latest-entry lookups.
-
-The TypeScript runtime also mirrors the Python extension hook bus for
-standalone npm runs. Set `AUTOCONTEXT_EXTENSIONS` to a comma-separated list of
-JavaScript/ESM modules or `module:callable` targets, and set
-`AUTOCONTEXT_EXTENSION_FAIL_FAST=true` when hook errors should stop the run.
-Extensions receive ordered Pi-shaped events for run lifecycle, context
-assembly, semantic compaction, provider calls, judge calls, and artifact
-writes:
-
-```js
-export function register(api) {
-  api.on("context", (event) => ({
-    roles: {
-      ...event.payload.roles,
-      competitor: `${event.payload.roles.competitor}\nPrefer concise, testable strategies.`,
-    },
-  }));
-}
-```
+Use the Python package when you need the full Python control plane or local MLX/CUDA training implementation. Use this package when you need Node, npm, the TUI, Fetch/agent adapters, or TypeScript library APIs.
 
 ## Install
 
 ```bash
-npm install autoctx
+bun add -g autoctx
+# or
+npm install -g autoctx
 ```
 
-The current npm release line is `autoctx@0.10.0`.
-Important: use `autoctx`, not `autocontext`.
-`autocontext` on npm is a different package and not this project.
-
-From source:
+From a checkout:
 
 ```bash
 cd ts
@@ -374,914 +20,165 @@ npm install
 npm run build
 ```
 
-## Emit SDK: `autoctx/production-traces`
+## Quick start
 
-Customer applications can emit production traces directly from their
-TypeScript code using the `autoctx/production-traces` subpath. This is the
-TS mirror of the Python `autocontext.production_traces` emit module;
-customers using both languages get one mental model, enforced at the byte
-level by cross-runtime property tests.
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=deterministic autoctx solve "improve customer-support replies" --iterations 3
+```
+
+Use a real provider by setting `AUTOCONTEXT_AGENT_PROVIDER` and its credential:
+
+```bash
+AUTOCONTEXT_AGENT_PROVIDER=anthropic ANTHROPIC_API_KEY=... autoctx solve "..." --iterations 3
+AUTOCONTEXT_AGENT_PROVIDER=openai-compatible AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8000/v1 AUTOCONTEXT_AGENT_API_KEY=... autoctx solve "..." --iterations 3
+AUTOCONTEXT_AGENT_PROVIDER=pi AUTOCONTEXT_PI_COMMAND=pi autoctx solve "..." --iterations 3
+```
+
+Provider routing details live in [../autocontext/docs/agent-integration.md](../autocontext/docs/agent-integration.md).
+
+## CLI surfaces
+
+| Command                                                | Purpose                                                      |
+| ------------------------------------------------------ | ------------------------------------------------------------ |
+| `autoctx solve "..." --iterations 3`                   | Generate and run a scenario from a plain-language goal       |
+| `autoctx run <scenario> --iterations 3`                | Run a saved scenario                                         |
+| `autoctx simulate -d "..."`                            | Build/replay/compare simulations                             |
+| `autoctx investigate -d "..."`                         | Evidence-driven diagnosis                                    |
+| `autoctx analyze --id <id> --type <kind>`              | Inspect runs, simulations, investigations, or missions       |
+| `autoctx mission create --name "..." --goal "..."`     | Create verifier-driven goals                                 |
+| `autoctx mission run --id <id> --max-iterations 3`     | Execute a mission                                            |
+| `autoctx queue add --task-prompt "..." --rubric "..."` | Add evaluation/improvement work                              |
+| `autoctx runtime-sessions timeline --run-id <run_id>`  | Inspect provider/tool/child-task timelines                   |
+| `autoctx mcp-serve`                                    | Expose MCP tools                                             |
+| `autoctx tui`                                          | Start the terminal UI                                        |
+| `autoctx train --scenario <name> --dataset <jsonl>`    | Validate training input and call an injected training runner |
+| `autoctx agent run <name> --payload '{...}'`           | Invoke experimental `.autoctx/agents` handlers               |
+
+`train` is a validation/executor-hook surface in TypeScript; end-to-end MLX/CUDA training lives in the Python package unless your application injects a real `TrainingRunner`.
+
+## MCP and control plane
+
+```bash
+autoctx mcp-serve
+```
+
+The MCP server exposes scenario/run/knowledge/evaluation/feedback/solve/sandbox/export tools. Python and TypeScript share the same high-level vocabulary; parity details are tracked in [../docs/scenario-parity-matrix.md](../docs/scenario-parity-matrix.md).
+
+## Library usage
 
 ```ts
-import {
-  buildTrace,
-  writeJsonl,
-  TraceBatch,
-  hashUserId,
-  loadInstallSalt,
-} from "autoctx/production-traces";
+import { createProvider, LLMJudge } from "autoctx";
 
-// 1) Hash personally-identifying identifiers with the install salt.
-const salt = (await loadInstallSalt(process.cwd())) ?? "";
-const userIdHash = hashUserId(session.user.id, salt);
-
-// 2) Build and validate a ProductionTrace. Throws ValidationError on
-//    invalid input with per-field detail.
-const trace = buildTrace({
-  provider: "openai",
-  model: "gpt-4o-mini",
-  messages: [{ role: "user", content: prompt, timestamp: new Date().toISOString() }],
-  timing: {
-    startedAt: "2026-04-17T12:00:00.000Z",
-    endedAt: "2026-04-17T12:00:01.250Z",
-    latencyMs: 1250,
-  },
-  usage: { tokensIn: 42, tokensOut: 88 },
-  env: { environmentTag: "production", appId: "my-app" },
-  session: { userIdHash },
-});
-
-// 3) Persist: one file per call, or batch across many calls.
-writeJsonl(trace);
-
-const batch = new TraceBatch();
-for (const event of stream) batch.add(buildTrace(/* ... */));
-batch.flush(); // writes accumulated traces as one file
-```
-
-Both ESM and CommonJS consumers are supported via the `"exports"` map:
-
-```ts
-// ESM
-import { buildTrace } from "autoctx/production-traces";
-
-// CJS
-const { buildTrace } = require("autoctx/production-traces");
-```
-
-### Zero telemetry
-
-**Traces go where you put them.** The SDK itself emits zero telemetry
-about its own usage. No analytics, no phone-home, no opt-out toggle
-needed. CI script `check:no-telemetry` greps the SDK source plus every
-transitive dep for suspicious network patterns on every PR.
-
-### Enterprise-discipline guarantees
-
-- **Bundle size**: ~48 kB gzipped at ship, enforced in CI at a
-  100 kB ceiling. Tree-shakable via `"sideEffects"` discipline.
-- **License compatibility**: every dep in the SDK's transitive closure
-  carries an MIT / Apache-2.0 / BSD / ISC / 0BSD license, enforced by
-  `check:license-compatibility`.
-- **No install scripts**: `autoctx` declares no `preinstall`,
-  `install`, or `postinstall` lifecycle hooks. Safe to deploy with
-  `npm install --ignore-scripts`.
-- **Dual ESM + CJS**: both `import` and `require()` work via the
-  `package.json` `"exports"` map.
-- **Cross-runtime parity**: TS `buildTrace` and Python `build_trace`
-  produce byte-identical canonical JSON, enforced at 50 property runs
-  plus 7 committed fixtures.
-
-See [`src/production-traces/sdk/STABILITY.md`](src/production-traces/sdk/STABILITY.md)
-for the API-stability commitment and
-[`src/production-traces/sdk/BUDGET.md`](src/production-traces/sdk/BUDGET.md)
-for the bundle-size budget details.
-
-## CLI Commands
-
-The package ships a full `autoctx` CLI with commands including:
-
-```bash
-# Project setup and discovery
-autoctx init
-autoctx capabilities
-autoctx login
-autoctx whoami
-autoctx logout
-autoctx providers
-autoctx models
-
-# Scenario execution
-autoctx solve "improve customer-support replies for billing disputes" --iterations 3 --json
-autoctx run support_triage --iterations 3 --json
-autoctx run --scenario support_triage --iterations 3 --json
-autoctx list --json
-autoctx runtime-sessions list --limit 10
-autoctx runtime-sessions show --run-id <run-id> --json
-autoctx runtime-sessions timeline --run-id <run-id> --json
-autoctx context-selection --run-id <run-id> --json
-autoctx agent run support --id ticket-123 --payload '{"message":"Please triage this."}' --env .env.local --json
-autoctx agent dev --port 3583 --env .env.local
-autoctx status <run-id>
-autoctx show <run-id> --best
-autoctx watch <run-id>
-autoctx replay --run-id <id> --generation 1
-autoctx benchmark --scenario support_triage --runs 5
-
-# Package management
-autoctx export <run-id> --output pkg.json
-autoctx export-training-data --run-id <id> --output data.jsonl
-autoctx import-package --file pkg.json
-autoctx new-scenario --description "Test summarization quality"
-autoctx new-scenario --template prompt-optimization --name support_triage
-
-# Interactive, simulations, and missions
-autoctx tui [--port 8000]
-autoctx serve [--port 8000] [--json] # HTTP API
-autoctx worker [--poll-interval 5] [--concurrency 2]
-autoctx mcp-serve                     # MCP server on stdio
-autoctx simulate -d "simulate deploying a web service with rollback"
-autoctx simulate -d "simulate escalation thresholds" --sweep max_escalations=1:5:1
-autoctx investigate -d "why did conversion drop after Tuesday's release"
-autoctx investigate -d "checkout is failing" --browser-url https://status.example.com
-autoctx analyze --id deploy_sim --type simulation
-autoctx analyze --left sim_a --right sim_b --type simulation
-autoctx trace-findings --trace ./trace.json          # Markdown report
-autoctx trace-findings --trace ./trace.json --json   # TraceFindingReport JSON
-autoctx probes check --suite ./suite.json            # contract probes (see Contract Probes below)
-autoctx probes check --suite ./suite.json --json     # structured ContractProbeSuiteResult
-autoctx probes extract --trace ./trace.json          # synthesize a probe suite from a harness trace
-autoctx probes extract --trace ./trace.json --output ./suite.json
-autoctx mission create --name "Ship login" --goal "Implement OAuth"
-autoctx mission create --type code --name "Fix login" --goal "Tests pass" --repo-path . --test-command "npm test"
-autoctx mission run --id <mission-id> --max-iterations 3
-autoctx mission status --id <mission-id>
-autoctx mission artifacts --id <mission-id>
-autoctx train --scenario support_triage --dataset data.jsonl --backend cuda
-
-# Evaluation
-autoctx judge -p <prompt> -o <output> -r <rubric>
-autoctx judge --scenario my_saved_task -o <output>
-autoctx improve -p <prompt> -r <rubric> [-n rounds]
-autoctx improve -p <prompt> -o <output> -r <rubric> [-n rounds]
-autoctx improve --scenario my_saved_task [-o <output>]
-autoctx repl --scenario my_saved_task
-
-# Task queue
-autoctx queue add -s <spec> [--priority N] [--browser-url https://status.example.com]
-autoctx queue -s <spec> [...]   # legacy alias; prefer `queue add`
-autoctx queue status [--json]
-autoctx worker --poll-interval 5 --concurrency 2
-autoctx status <run-id>
-```
-
-Stateful persistent providers, including persistent Pi RPC, run with effective worker concurrency `1` to keep long-lived runtime sessions isolated. The worker/API shape is single-tenant or trusted-org infrastructure, not a hosted multi-tenant control plane; review the repo-level [background execution trust boundaries](../docs/background-execution-trust-boundaries.md) before exposing it beyond a trusted network or adding SCM/sandbox credentials.
-
-## Contract Probes
-
-`autoctx probes check --suite <path>` runs the contract-probe suite against observed harness state and reports per-probe pass/fail. It exits 0 on a full pass and 1 on any failure or any load / parse error. Default output is human-readable; pass `--json` to emit a structured `ContractProbeSuiteResult` payload that downstream tools can consume.
-
-The suite file is a JSON document validated by `ContractProbeSuiteSchema`. Every nested object is strict: unknown keys (e.g. a typo like `requiredStdoutPattern` missing the trailing `s`) fail validation rather than silently disappearing. Every declared expectation requires the matching observation; an `expected*` field without its observation fails as `missing-observation` rather than silently passing.
-
-Minimal suite example:
-
-```json
-{
-  "schema_version": 1,
-  "probes": [
-    {
-      "kind": "directory",
-      "label": "final-workdir",
-      "inputs": {
-        "presentFiles": ["solution.txt"],
-        "requiredFiles": ["solution.txt"],
-        "allowedFiles": ["solution.txt"],
-        "ignoredPatterns": ["^trace\\."]
-      }
-    },
-    {
-      "kind": "terminal",
-      "label": "after-build",
-      "inputs": {
-        "exitCode": 0,
-        "stdout": "All checks passed.\n",
-        "stderr": "",
-        "expectedExitCode": 0,
-        "requiredStdoutPatterns": ["checks passed"]
-      }
-    },
-    {
-      "kind": "cleanup",
-      "inputs": {
-        "entries": [
-          { "path": "solution.txt" },
-          { "path": "stale.lock", "mtime": "2026-05-21T10:00:00Z" }
-        ],
-        "now": "2026-05-21T12:00:00Z",
-        "maxLockfileAgeMs": 300000
-      }
-    }
-  ]
-}
-```
-
-Seven probe kinds are supported: `directory`, `terminal`, `service`, `artifact`, `cleanup`, `media`, `distributed`. Each invocation accepts an optional `label` string (caller-supplied attribution; surfaced in the report) and a `kind`-specific `inputs` object. Wire-format notes:
-
-- RegExp values may be a bare pattern string (`"^trace\\."`) or `{ "source": "^trace\\.", "flags": "i" }`. Invalid regexes (e.g. `"[unclosed"`) fail validation cleanly via Zod.
-- Date values are ISO-8601 strings. Malformed dates fail validation cleanly via Zod.
-
-`--json` payload shape:
-
-```json
-{
-  "passed": false,
-  "results": [
-    {
-      "kind": "cleanup",
-      "label": "after-build",
-      "passed": false,
-      "failures": [
-        {
-          "kind": "stale-lockfile",
-          "path": "stale.lock",
-          "message": "stale.lock is a lockfile older than 300000ms"
-        }
-      ]
-    }
-  ]
-}
-```
-
-The `results` field is a discriminated union by `kind`, so TypeScript callers can switch on `kind` and access each probe's typed failure fields (`path`, `rank`, `key`, `endpoint`, etc.) without casting. The library API (`runContractProbeSuite`, `loadContractProbeSuite`, `ContractProbeSuiteSchema`) is exported from the package root for programmatic use.
-
-### Synthesizing a suite from a harness trace
-
-For workflows that record a run and then verify it (rather than hand-authoring a suite), `autoctx probes extract --trace <path>` synthesizes a runnable probe suite from a harness-trace JSON file. The trace bundles both `observations` (what actually happened) and optional `expectations` (what the operator declared should have happened); the extractor joins them.
-
-Coverage: all seven probe kinds (terminal, directory, service, artifact, cleanup, media, distributed). Orphan expectations (declared without a matching observation) fail validation at parse time rather than silently producing a vacuously-passing suite.
-
-Minimal trace example:
-
-```json
-{
-  "schema_version": 1,
-  "label": "smoke-run-2026-05-22",
-  "observations": {
-    "terminal": { "exitCode": 0, "stdout": "All checks passed.\n", "stderr": "" },
-    "workdir": { "presentFiles": ["solution.txt", "trace.log"] },
-    "services": [{ "host": "127.0.0.1", "port": 8080, "protocol": "tcp" }],
-    "artifacts": [{ "path": "manifest.json", "content": "{\"name\":\"x\"}" }],
-    "cleanup": {
-      "entries": [
-        { "path": "solution.txt" },
-        { "path": "stale.lock", "mtime": "2026-05-21T10:00:00Z" }
-      ]
-    },
-    "media": [{ "path": "rendered.png", "width": 256, "height": 128, "byteSize": 4096 }],
-    "distributed": {
-      "worldSize": 1,
-      "ranks": [{ "rank": 0, "steps": 100, "observations": { "loss": "0.1" } }]
-    }
-  },
-  "expectations": {
-    "terminal": { "expectedExitCode": 0, "requiredStdoutPatterns": ["checks passed"] },
-    "directory": {
-      "requiredFiles": ["solution.txt"],
-      "allowedFiles": ["solution.txt"],
-      "ignoredPatterns": ["^trace\\."]
-    },
-    "services": { "required": [{ "host": "127.0.0.1", "port": 8080, "protocol": "tcp" }] },
-    "artifacts": [{ "path": "manifest.json", "requiredJsonFields": ["name"] }],
-    "cleanup": { "now": "2026-05-21T12:00:00Z", "maxLockfileAgeMs": 300000 },
-    "media": [{ "path": "rendered.png", "expectedWidth": 256, "expectedHeight": 128 }],
-    "distributed": { "expectedWorldSize": 1, "mustMatchAcrossRanks": ["loss"] }
-  }
-}
-```
-
-Piping `extract` into `check` round-trips a trace to a pass/fail report:
-
-```bash
-autoctx probes extract --trace trace.json | autoctx probes check --suite -
-autoctx probes extract --trace trace.json --output suite.json
-autoctx probes check --suite suite.json --json
-```
-
-## Provider Configuration
-
-Configure the agent provider via environment variables:
-
-```bash
-# Anthropic (default)
-ANTHROPIC_API_KEY=sk-ant-... autoctx run support_triage --json
-
-# OpenAI-compatible
-AUTOCONTEXT_AGENT_PROVIDER=openai-compatible \
-AUTOCONTEXT_AGENT_API_KEY=sk-... \
-AUTOCONTEXT_AGENT_BASE_URL=https://api.openai.com/v1 \
-autoctx run support_triage --json
-
-# Role-scoped override: competitor uses a separate gateway/key
-AUTOCONTEXT_AGENT_PROVIDER=anthropic \
-ANTHROPIC_API_KEY=sk-ant-primary \
-AUTOCONTEXT_COMPETITOR_PROVIDER=openai-compatible \
-AUTOCONTEXT_COMPETITOR_API_KEY=sk-role \
-AUTOCONTEXT_COMPETITOR_BASE_URL=http://localhost:8000/v1 \
-autoctx run support_triage --json
-
-# Ollama (local)
-AUTOCONTEXT_AGENT_PROVIDER=ollama autoctx run support_triage --json
-
-# Hermes (via OpenAI-compatible gateway)
-AUTOCONTEXT_AGENT_PROVIDER=openai-compatible \
-AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1 \
-AUTOCONTEXT_AGENT_DEFAULT_MODEL=hermes-3-llama-3.1-8b \
-autoctx run support_triage --json
-
-# Hermes shortcut provider (same gateway path, Hermes defaults)
-AUTOCONTEXT_AGENT_PROVIDER=hermes \
-AUTOCONTEXT_AGENT_BASE_URL=http://localhost:8080/v1 \
-autoctx run support_triage --json
-
-# Claude CLI (local authenticated Claude Code runtime)
-AUTOCONTEXT_AGENT_PROVIDER=claude-cli \
-AUTOCONTEXT_CLAUDE_MODEL=sonnet \
-autoctx run support_triage --json
-
-# Codex CLI (local authenticated Codex runtime)
-AUTOCONTEXT_AGENT_PROVIDER=codex \
-AUTOCONTEXT_CODEX_MODEL=o4-mini \
-autoctx run support_triage --json
-
-# Pi CLI
-AUTOCONTEXT_AGENT_PROVIDER=pi autoctx run support_triage --json
-
-# Pi RPC with one long-lived subprocess
-AUTOCONTEXT_AGENT_PROVIDER=pi-rpc \
-AUTOCONTEXT_PI_RPC_PERSISTENT=true \
-autoctx run support_triage --json
-
-# Deterministic (CI/testing)
-AUTOCONTEXT_AGENT_PROVIDER=deterministic autoctx run support_triage --json
-```
-
-`ANTHROPIC_API_KEY` is the preferred Anthropic credential env var. `AUTOCONTEXT_ANTHROPIC_API_KEY` remains supported as a compatibility alias.
-
-Supported providers: `anthropic`, `openai`, `openai-compatible`, `gemini`, `mistral`, `groq`, `openrouter`, `azure-openai`, `ollama`, `vllm`, `hermes`, `claude-cli`, `codex`, `pi`, `pi-rpc`, `deterministic`.
-
-Programmatic callers can pass `runtimeSession`, `runtimeSessionRole`,
-`runtimeSessionCwd`, and `runtimeSessionCommands` to `createProvider()` for
-CLI-backed providers (`claude-cli`, `codex`, `pi`, `pi-rpc`). Those options
-wrap the underlying `AgentRuntime` at the provider bridge so provider
-completions are recorded in the `RuntimeSession` event log.
-`autoctx run` also creates a run-scoped runtime session automatically for
-CLI-backed providers and persists it in the configured SQLite database. Use
-`autoctx runtime-sessions list` and `autoctx runtime-sessions show
---run-id <run-id> --json` to inspect those recorded provider prompts,
-messages, and child-task events. Use `autoctx runtime-sessions timeline
---run-id <run-id> --json` when operators need a grouped prompt/response and
-child-task timeline instead of the raw event log. `autoctx status <run-id> --json`,
-`autoctx show <run-id> --json`, and `autoctx watch <run-id> --json` include a
-`runtime_session` summary when that persisted log exists. HTTP clients can read
-the same data from `GET /api/cockpit/runtime-sessions`,
-`GET /api/cockpit/runtime-sessions/:session_id`, and
-`GET /api/cockpit/runs/:run_id/runtime-session`; timeline views are available
-at `GET /api/cockpit/runtime-sessions/:session_id/timeline` and
-`GET /api/cockpit/runs/:run_id/runtime-session/timeline`. Cockpit run list, status, and
-resume responses also include `runtime_session` (a summary or `null`) plus
-`runtime_session_url` for direct log discovery. The interactive server emits
-live runtime updates on `/ws/events` as `runtime_session_event` envelopes on the
-`runtime_session` channel; each payload includes the current session summary and
-the appended event.
-
-Inside `autoctx tui`, operators can run `/timeline <run-id>` to render the same
-runtime-session timeline in the recent-activity pane. If a run is active,
-`/timeline` uses that active run id. The TUI recent-activity feed also
-summarizes live runtime-session prompt, assistant, shell, tool, and child-task
-events as they arrive. Use
-`/activity [status|reset|<all|runtime|prompts|commands|children|errors> [quiet|normal|verbose]]`
-to focus that live feed and tune how much detail each runtime event includes.
-Those activity settings are saved in the resolved autoctx config directory and
-reloaded when the TUI starts again; `/activity reset` clears the saved
-preference and returns the feed to `all normal`. On startup, Recent Activity
-logs the loaded activity setting before the command help. Bare `/activity` and
-`/activity status` report the current setting without rewriting the saved
-preference.
-
-`autoctx simulate` and `autoctx investigate` require a configured provider for spec generation. If you want synthetic placeholder behavior for CI/testing, select the deterministic provider explicitly instead of relying on implicit fallback.
-
-Key environment variables:
-
-| Variable                                                             | Purpose                                                     |
-| -------------------------------------------------------------------- | ----------------------------------------------------------- |
-| `AUTOCONTEXT_AGENT_PROVIDER`                                         | Agent provider selection                                    |
-| `AUTOCONTEXT_AGENT_API_KEY`                                          | Global API key override (or use provider-specific env vars) |
-| `AUTOCONTEXT_AGENT_BASE_URL`                                         | Global base URL override for compatible providers           |
-| `AUTOCONTEXT_AGENT_DEFAULT_MODEL`                                    | Override default model                                      |
-| `AUTOCONTEXT_COMPETITOR_API_KEY` / `AUTOCONTEXT_COMPETITOR_BASE_URL` | Optional competitor-specific credential/endpoint override   |
-| `AUTOCONTEXT_ANALYST_API_KEY` / `AUTOCONTEXT_ANALYST_BASE_URL`       | Optional analyst-specific credential/endpoint override      |
-| `AUTOCONTEXT_COACH_API_KEY` / `AUTOCONTEXT_COACH_BASE_URL`           | Optional coach-specific credential/endpoint override        |
-| `AUTOCONTEXT_ARCHITECT_API_KEY` / `AUTOCONTEXT_ARCHITECT_BASE_URL`   | Optional architect-specific credential/endpoint override    |
-| `AUTOCONTEXT_CLAUDE_MODEL`                                           | Claude CLI model alias override                             |
-| `AUTOCONTEXT_CODEX_MODEL`                                            | Codex CLI model override                                    |
-| `AUTOCONTEXT_PI_RPC_PERSISTENT`                                      | Reuse one Pi RPC subprocess across provider calls           |
-| `AUTOCONTEXT_CONFIG_DIR`                                             | Override where `login` / `whoami` read saved credentials    |
-| `AUTOCONTEXT_DB_PATH`                                                | SQLite database path                                        |
-
-Credential resolution order is:
-
-1. Environment variables
-2. CLI flags
-3. Project config (`.autoctx.json`)
-4. Credential store (`~/.config/autoctx/credentials.json`)
-
-## Project Defaults
-
-`autoctx init` scaffolds a `.autoctx.json` file in your project. When present, the CLI uses it for:
-
-- Default provider selection
-- Default model preference
-- Default scenario for `run`, `benchmark`, and `export`
-- Project `runs/` and `knowledge/` roots
-- The default SQLite database location under the configured `runs_dir`
-
-`autoctx init` also writes an `AGENTS.md` block with the recommended local autocontext workflow.
-
-`autoctx capabilities` returns structured JSON describing commands, providers, scenarios, the canonical concept model, and project-specific state such as the current project config, active runs, and knowledge directory summary.
-
-`autoctx login` can prompt interactively for provider credentials. `autoctx login --provider ollama` validates that a local Ollama server is reachable before persisting the connection details, and `autoctx logout` clears the stored credentials.
-
-`autoctx replay` writes the selected generation and available generations to `stderr` before printing the replay JSON payload. `autoctx export-training-data` writes progress updates to `stderr` while keeping JSONL records on `stdout`.
-
-Saved custom scenarios under `knowledge/_custom_scenarios/` can be reused directly from the TS CLI. Saved parametric scenarios can now be targeted by name in `run` and `benchmark`, while saved agent-task scenarios remain directly usable in `judge`, `improve`, `repl`, and `queue` without retyping their prompt and rubric.
-
-## Control-Plane Strategy Identity
-
-`autoctx candidate register` records deterministic strategy identity metadata for
-each candidate artifact. The identity includes a canonical strategy fingerprint,
-per-file component fingerprints, parent strategy fingerprints, and an exact or
-near duplicate assessment when the candidate matches an existing strategy surface
-for the same scenario and actuator. Environments do not split this identity
-surface: a repeated strategy in staging is still a duplicate of the same
-scenario/actuator strategy from production.
-
-```bash
-autoctx candidate register \
-  --scenario grid_ctf \
-  --actuator prompt-patch \
-  --payload ./payload \
-  --output json
-```
-
-`autoctx candidate show <artifact-id> --output json` returns the full
-`strategyIdentity` block. `autoctx candidate list --output json` includes compact
-`strategyFingerprint` and `duplicateKind` fields for automation.
-
-If a newly registered candidate is an exact or near duplicate of a disabled or
-already-quarantined strategy, the artifact also records `strategyQuarantine`.
-Promotion decisions reject quarantined strategies as non-promotion evidence, and
-`autoctx candidate list --output json` includes `quarantineReason` for quick
-triage. Operational memory can also skip findings tied to quarantined strategy
-fingerprints before they are rendered back into agent context. Older artifacts
-without `strategyIdentity` can still seed exact duplicate/quarantine checks via
-their content-addressed `payloadHash`.
-
-## Control-Plane Eval Tracks
-
-`autoctx eval attach` accepts `--track verified|experimental` for attached
-EvalRuns. Verified runs are promotion-grade evidence; experimental runs remain
-inspectable but are rejected by promotion decisions by default.
-
-```bash
-autoctx eval attach <artifact-id> \
-  --suite prod-eval \
-  --metrics metrics.json \
-  --dataset-provenance dataset.json \
-  --track experimental \
-  --output json
-```
-
-`autoctx eval list <artifact-id> --output json` includes the effective track for
-each EvalRun. Legacy clean EvalRuns without an explicit track are reported as
-`verified`; non-clean integrity still blocks ingestion and promotion evidence.
-
-For accepted strategy or harness changes, promotion can also require explicit
-ablation evidence. Attach an ablation verification object to the EvalRun:
-
-```json
-{
-  "status": "passed",
-  "targets": ["strategy", "harness"],
-  "verifiedAt": "2026-05-13T12:00:00.000Z",
-  "evidenceRefs": ["runs/ablation/run_1.json"]
-}
-```
-
-```bash
-autoctx eval attach <artifact-id> \
-  --suite prod-eval \
-  --metrics metrics.json \
-  --dataset-provenance dataset.json \
-  --ablation-verification ablation.json
-```
-
-Ablation checks are opt in at decision time:
-
-```bash
-autoctx promotion decide <artifact-id> \
-  --baseline auto \
-  --require-ablation \
-  --ablation-targets strategy,harness \
-  --output json
-```
-
-When enabled, the PromotionDecision includes an `ablationVerification`
-assessment and fails if the latest candidate EvalRun is missing evidence, has a
-`failed` or `incomplete` status, or does not cover every required target.
-
-## Control-Plane Harness Proposals
-
-`autoctx harness proposal create` records evidence-backed harness/context change
-proposals before they can affect the loop. A proposal carries finding lineage,
-the target surface, concrete patches, expected impact, rollback criteria, and
-provenance.
-
-```bash
-autoctx harness proposal create \
-  --finding finding-1 \
-  --surface prompt \
-  --summary "tighten verifier-facing prompt" \
-  --patches patches.json \
-  --expected-impact impact.json \
-  --rollback "revert if heldout quality drops" \
-  --output json
-```
-
-`autoctx harness proposal decide` gates a proposal against the candidate
-artifact's EvalRun evidence for the requested suite. `heldout` and `fresh`
-validation can accept or reject the proposal when compared with matching-suite
-baseline evidence; `dev` or missing-baseline validation stays `inconclusive`.
-Promotion-grade decisions must also include at least one `--evidence-ref`;
-omitting evidence refs keeps the durable proposal decision `inconclusive`.
-
-```bash
-autoctx harness proposal decide <proposal-id> \
-  --candidate <artifact-id> \
-  --baseline <artifact-id>|auto|none \
-  --validation heldout \
-  --suite prod-heldout \
-  --evidence-ref runs/heldout/candidate.json \
-  --output json
-```
-
-Use `autoctx harness proposal list --output json` for a compact review queue and
-`autoctx harness proposal show <proposal-id> --output json` for the full durable
-record under `.autocontext/harness-proposals/`.
-
-## MCP Tools (40+)
-
-`mcp-serve` starts the MCP server on stdio with tools across these families:
-
-| Family        | Tools                                                                                                                                  |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Scenarios     | list_scenarios, get_scenario, validate_strategy, run_match, run_tournament, run_scenario                                               |
-| Runs          | list_runs, get_run_status, get_generation_detail, list_runtime_sessions, get_runtime_session, get_runtime_session_timeline, run_replay |
-| Knowledge     | get_playbook, read_trajectory, read_hints, read_analysis, read_tools, read_skills                                                      |
-| Evaluation    | evaluate_output, run_improvement_loop, run_repl_session, generate_output                                                               |
-| Task queue    | queue_task, get_queue_status, get_task_result                                                                                          |
-| Export/Search | export_skill, export_package, import_package, list_solved, search_strategies                                                           |
-| Feedback      | record_feedback, get_feedback                                                                                                          |
-| Solve         | solve_scenario, solve_status, solve_result                                                                                             |
-| Sandbox       | sandbox_create, sandbox_run, sandbox_status, sandbox_playbook, sandbox_list, sandbox_destroy                                           |
-| Agent tasks   | create_agent_task, list_agent_tasks, get_agent_task                                                                                    |
-| Missions      | create_mission, mission_status, mission_result, mission_artifacts, pause_mission, resume_mission, cancel_mission                       |
-| Discovery     | capabilities                                                                                                                           |
-
-`create_mission` and `autoctx mission create` both support a code-mission variant with `type=code` plus `repo_path` / `test_command` (and optional `lint_command` / `build_command`) so mission success is tied to external checks instead of model self-report.
-
-### Claude Code integration
-
-```json
-{
-  "mcpServers": {
-    "autocontext": {
-      "command": "npx",
-      "args": ["autoctx", "mcp-serve"],
-      "env": {
-        "ANTHROPIC_API_KEY": "sk-ant-..."
-      }
-    }
-  }
-}
-```
-
-## Library Usage
-
-```ts
-import { createProvider, LLMJudge, ImprovementLoop, SimpleAgentTask } from "autoctx";
-
-// One-shot evaluation
 const provider = createProvider({
   providerType: "anthropic",
   apiKey: process.env.ANTHROPIC_API_KEY ?? "",
 });
-const judge = new LLMJudge({ provider, rubric: "Score clarity and correctness." });
+
+const judge = new LLMJudge({
+  provider,
+  model: provider.defaultModel(),
+  rubric: "Score clarity and correctness.",
+});
+
 const result = await judge.evaluate({
   taskPrompt: "Explain binary search.",
   agentOutput: "Binary search halves the search space each step.",
 });
-
-// Multi-round improvement
-const task = new SimpleAgentTask(
-  "Draft a support reply for a billing dispute.",
-  "Score accuracy, policy compliance, and tone.",
-  provider,
-);
-const loop = new ImprovementLoop({ task, maxRounds: 3, qualityThreshold: 0.9 });
-const improved = await loop.run({
-  initialOutput: "We can help with that billing issue.",
-  state: {},
-});
 ```
 
-## TS / Python Scope
-
-The TypeScript package includes the current 0.4.x operator-facing surfaces:
-
-- `simulate`
-- `investigate`
-- `analyze`
-- `context-selection`
-- `trace-findings` — extract structured findings (`TraceFindingReport`) from a `PublicTrace` JSON file
-- `mission`
-- `train` as a validation plus executor-hook surface
-
-`campaign` now ships as a first-class TypeScript CLI/API/MCP workflow for multi-mission coordination.
-
-`context-selection` reads persisted per-run context-selection artifacts and
-renders the same budget, semantic compaction cache, diagnostics, and selected
-context telemetry cards exposed through Cockpit HTTP.
-
-For end-to-end local MLX/CUDA training, the Python package is still the canonical out-of-the-box runtime.
-
-## Browser Exploration Contract
-
-The TypeScript package exposes the shared browser exploration contract and policy helpers from the package root. Browser exploration is disabled by default and configured through `AUTOCONTEXT_BROWSER_*` settings such as `AUTOCONTEXT_BROWSER_ENABLED`, `AUTOCONTEXT_BROWSER_ALLOWED_DOMAINS`, and `AUTOCONTEXT_BROWSER_PROFILE_MODE`.
-
-Use `resolveBrowserSessionConfig(...)`, `evaluateBrowserActionPolicy(...)`, and the `validateBrowser*` helpers when integrating a browser backend or agent harness.
-
-When browser exploration is enabled, the TS CLI can capture a policy-gated Chrome DevTools Protocol snapshot and attach it as evidence for `autoctx investigate --browser-url <url>`. Queued agent tasks can also store `--browser-url`; the runner resolves it through an injected browser-context service so enterprise deployments can keep browser access disabled by default, domain-scoped, and audit-artifact backed.
-
-## Python-Only Commands
-
-These workflows require infrastructure not available in the npm package:
-
-- `ecosystem` — Multi-provider cycling
-- `ab-test` — Requires ecosystem runner
-- `resume` / `wait` — Run recovery infrastructure
-- `hermes inspect` / `hermes export-skill` — Hermes v0.12 Curator inspection and Hermes skill export
-- `trigger-distillation` — Training pipeline
-- Monitor conditions — Monitoring engine
-
-`train` is exposed in the TS CLI as a validation plus executor-hook surface, but the npm package does not bundle a real MLX/CUDA trainer. For end-to-end local training, use the Python package (`pip install autocontext`) or inject a real `TrainingRunner` executor from code.
-
-## OpenAI integration
-
-autocontext ships a zero-configuration OpenAI instrumentation path that
-automatically wraps your existing `new OpenAI(...)` calls and emits structured
-traces to a sink of your choice.
-
-### 1. Register detectors
-
-Create `.autoctx.instrument.config.mjs` at the root of your repo:
-
-```js
-// .autoctx.instrument.config.mjs
-import { registerDetectorPlugin } from "autoctx/control-plane/instrument";
-import { plugin as openaiTsPlugin } from "autoctx/detectors/openai-ts";
-
-registerDetectorPlugin(openaiTsPlugin);
-```
-
-### 2. Run instrument
-
-Preview changes without touching any files:
-
-```bash
-autoctx instrument --dry-run
-```
-
-Apply changes on a new branch for review:
-
-```bash
-autoctx instrument --apply --branch autoctx/instrument
-```
-
-### 3. Review the PR
-
-The instrument command opens a branch. Open the PR and review the diff — you
-will see your `new OpenAI(...)` calls wrapped with `instrumentClient(...)`.
-Edit the generated TODO comment to point at your `FileSink`:
+Prefer package subpath exports for specialized surfaces:
 
 ```ts
-// Before (generated):
-const client = instrumentClient(new OpenAI(), { sink: /* TODO: pass your TraceSink here */ });
-
-// After (your edit):
-import { FileSink } from "autoctx/integrations/openai";
-const sink = new FileSink("./traces/openai.jsonl");
-const client = instrumentClient(new OpenAI(), { sink });
+import { buildTrace } from "autoctx/production-traces";
+import { instrumentClient } from "autoctx/integrations/anthropic";
+import type { AutoctxAgentContext } from "autoctx/agent-runtime";
+import { connectMcpRuntimeTools } from "autoctx/runtimes/mcp";
 ```
 
-Merge the PR.
-
-### 4. Customer code emits traces
-
-Your code is unchanged beyond the wrap. Every `chat.completions.create` call
-now emits a JSONL trace line to your sink:
-
-```ts
-import OpenAI from "openai";
-import { instrumentClient, FileSink, autocontextSession } from "autoctx/integrations/openai";
-
-const sink = new FileSink("./traces/openai.jsonl");
-const client = instrumentClient(new OpenAI(), { sink });
-
-await autocontextSession({ userId: "u_123" }, async () => {
-  const res = await client.chat.completions.create({
-    model: "gpt-4o",
-    messages: [{ role: "user", content: "Hello!" }],
-  });
-  console.log(res.choices[0].message.content);
-});
-
-await sink.close();
-```
-
-Emitted trace line (pretty-printed for readability):
-
-```jsonl
-{
-  "schemaVersion": "1.0",
-  "traceId": "...",
-  "sessionContext": {
-    "userId": "u_123"
-  },
-  "request": {
-    "model": "gpt-4o",
-    "messages": [
-      {
-        "role": "user",
-        "content": "Hello!"
-      }
-    ]
-  },
-  "response": {
-    "id": "...",
-    "choices": [
-      {
-        "message": {
-          "role": "assistant",
-          "content": "Hi! How can I help?"
-        },
-        "finish_reason": "stop"
-      }
-    ],
-    "usage": {
-      "prompt_tokens": 9,
-      "completion_tokens": 7,
-      "total_tokens": 16
-    }
-  },
-  "durationMs": 342,
-  "errorReason": null
-}
-```
-
-For the Python equivalent, see
-`autocontext/src/autocontext/integrations/openai/STABILITY.md`.
-
-## Anthropic integration
-
-autocontext ships a zero-configuration Anthropic instrumentation path that
-automatically wraps your existing `new Anthropic(...)` calls and emits structured
-traces to a sink of your choice.
-
-### 1. Register detectors
-
-Create `.autoctx.instrument.config.mjs` at the root of your repo:
-
-```js
-// .autoctx.instrument.config.mjs
-import { registerDetectorPlugin } from "autoctx/control-plane/instrument";
-import { plugin as anthropicTsPlugin } from "autoctx/detectors/anthropic-ts";
-
-registerDetectorPlugin(anthropicTsPlugin);
-```
-
-### 2. Run instrument
-
-Preview changes without touching any files:
-
-```bash
-autoctx instrument --dry-run
-```
-
-Apply changes on a new branch for review:
-
-```bash
-autoctx instrument --apply --branch autoctx/instrument
-```
-
-### 3. Review the PR
-
-The instrument command opens a branch. Open the PR and review the diff — you
-will see your `new Anthropic(...)` calls wrapped with `instrumentClient(...)`.
-Edit the generated TODO comment to point at your `FileSink`:
-
-```ts
-// Before (generated):
-const client = instrumentClient(new Anthropic(), { sink: /* TODO: pass your TraceSink here */ });
-
-// After (your edit):
-import { FileSink } from "autoctx/integrations/anthropic";
-const sink = new FileSink("./traces/anthropic.jsonl");
-const client = instrumentClient(new Anthropic(), { sink });
-```
-
-Merge the PR.
-
-### 4. Customer code emits traces
-
-Your code is unchanged beyond the wrap. Every `messages.create` call now emits
-a JSONL trace line to your sink:
+## Production traces
 
 ```ts
 import Anthropic from "@anthropic-ai/sdk";
-import { instrumentClient, FileSink, autocontextSession } from "autoctx/integrations/anthropic";
+import { FileSink, instrumentClient } from "autoctx/integrations/anthropic";
 
 const sink = new FileSink("./traces/anthropic.jsonl");
-const client = instrumentClient(new Anthropic(), { sink });
-
-await autocontextSession({ userId: "u_123" }, async () => {
-  const res = await client.messages.create({
-    model: "claude-opus-4-7-20251101",
-    max_tokens: 256,
-    messages: [{ role: "user", content: "Hello!" }],
-  });
-  console.log(res.content[0].type === "text" ? res.content[0].text : "");
+const client = instrumentClient(new Anthropic(), {
+  sink,
+  appId: "billing-bot",
+  environmentTag: "prod",
 });
-
-await sink.close();
 ```
 
-Emitted trace line (pretty-printed for readability):
+The SDK captures provider-native content blocks, cache-aware usage, outcome
+taxonomy, and dataset/retention helpers. Deeper notes live in
+[../docs/analytics.md](../docs/analytics.md),
+[../docs/opentelemetry-bridge.md](../docs/opentelemetry-bridge.md), and the
+source under `src/production-traces/`.
 
-```jsonl
-{
-  "schemaVersion": "1.0",
-  "traceId": "...",
-  "sessionContext": {
-    "userId": "u_123"
-  },
-  "request": {
-    "model": "claude-opus-4-7-20251101",
-    "messages": [
-      {
-        "role": "user",
-        "content": "Hello!"
-      }
-    ]
-  },
-  "response": {
-    "id": "...",
-    "content": [
-      {
-        "type": "text",
-        "text": "Hi! How can I help?"
-      }
-    ],
-    "stop_reason": "end_turn",
-    "usage": {
-      "input_tokens": 9,
-      "output_tokens": 7
-    }
-  },
-  "durationMs": 342,
-  "errorReason": null
+## Agent handlers
+
+The experimental `autoctx/agent-runtime` subpath discovers handlers only from
+`.autoctx/agents` and invokes them with explicit `payload`, `env`, `workspace`,
+and `AgentRuntime` capabilities.
+
+```ts
+// .autoctx/agents/support.ts
+import type { AutoctxAgentContext } from "autoctx/agent-runtime";
+
+export default async function ({ init, payload }: AutoctxAgentContext<{ message: string }>) {
+  const runtime = await init();
+  const session = await runtime.session("support");
+  return session.prompt(payload.message, { role: "support-triager" });
 }
 ```
 
-For the Python equivalent, see
-`autocontext/src/autocontext/integrations/anthropic/STABILITY.md`.
+```bash
+autoctx agent run support --payload '{"message":"triage this ticket"}' --json
+autoctx agent dev --port 3583
+autoctx agent build --target node --out .autoctx/build/node
+```
+
+Examples:
+[../examples/README.md](../examples/README.md#experimental-typescript-agent-handler).
+
+## Fetch/edge adapters
+
+Generic Fetch/ESM hosts can use static catalogs and explicit host capabilities;
+the package does not imply Cloudflare/Vercel/Deno deployment wrappers.
+
+Reference docs moved out of this README:
+
+- [../docs/fetch-api-reference.md](../docs/fetch-api-reference.md)
+- [../docs/fetch-host-capability-manifest.md](../docs/fetch-host-capability-manifest.md)
+- [../docs/generated-fetch-packaging.md](../docs/generated-fetch-packaging.md)
+- [../docs/fetch-conformance.md](../docs/fetch-conformance.md)
+- [../docs/fetch-troubleshooting.md](../docs/fetch-troubleshooting.md)
+- [../docs/edge-runtime-compatibility.md](../docs/edge-runtime-compatibility.md)
+
+## Contract probes
+
+```bash
+autoctx probes check --suite contract-probes.json
+autoctx probes check --suite contract-probes.json --json
+autoctx probes extract --trace harness-trace.json --output contract-probes.json
+```
+
+Use probes to turn observed harness behavior into strict executable checks.
+
+## Project defaults
+
+`autoctx` searches upward for `.autoctxrc.json`, `.autoctxrc`, or
+`autoctx.config.json`. Explicit CLI flags win over config files. Env file
+loading for agent handlers is explicit: pass `--env FILE` or set
+`AUTOCTX_ENV_FILE` for generated Node servers.
 
 ## Development
 
 ```bash
-cd ts
-npm install
-npm test              # vitest
-npm run lint          # tsc --noEmit
-npm run build         # tsc (outputs to dist/)
-npm run check:a2-ii-a-all  # enterprise discipline checks for the SDK subpath
+npm run build
+npm run lint
+npm test
 ```
+
+Keep this README as the package entry point. Put long reference material in
+`../docs/`, `examples/`, or source-level API docs.


### PR DESCRIPTION
## Summary
- Trim root, Python, and TypeScript READMEs down to concise entry points
- Keep release/version sync markers and install snippets intact
- Link deep reference material to existing docs instead of duplicating it

## Checks
- `python3 scripts/sync_release_surfaces.py --check`
- `git diff --check`
- `UV_EXCLUDE_NEWER=2026-04-10T14:55:41Z uv run --locked --directory autocontext pytest tests/test_release_surface_manifest.py`
- `npm --prefix ts run lint`
