### PR TITLE
AC-848, AC-849: fix agent-task guardrail split and CI-gate schema sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         run: npx vitest run tests/package-topology.test.ts tests/package-boundaries.test.ts
       - name: Python/TS schema sync drift check
         working-directory: ts
-        run: uv run --project ../autocontext -- npm run check:schemas
+        run: uv run --frozen --project ../autocontext -- npm run check:schemas
 
   smoke:
     needs: [lint, test, package-boundaries]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
       - name: TypeScript package boundary checks
         working-directory: ts
         run: npx vitest run tests/package-topology.test.ts tests/package-boundaries.test.ts
+      - name: Python/TS schema sync drift check
+        working-directory: ts
+        run: uv run --project ../autocontext -- npm run check:schemas
 
   smoke:
     needs: [lint, test, package-boundaries]

--- a/autocontext/pyproject.toml
+++ b/autocontext/pyproject.toml
@@ -46,6 +46,7 @@ all = ["autocontext[mcp,agent-sdk,monty,openai,browser,primeintellect]"]
 
 [dependency-groups]
 dev = [
+  "datamodel-code-generator>=0.56.0,<0.57.0",
   "httpx>=0.28.1",
   "hypothesis>=6.151.12",
   "mypy>=1.16.0",

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -42,6 +42,11 @@ from autocontext.cli_worker import register_worker_command
 from autocontext.config import load_settings
 from autocontext.config.presets import VALID_PRESET_NAMES
 from autocontext.config.settings import AppSettings
+from autocontext.execution.agent_task_completion import (
+    TaskConfig,
+    build_evaluator_guardrail_payload,
+    compute_effective_met_threshold,
+)
 from autocontext.execution.improvement_loop import ImprovementLoop
 from autocontext.extensions import active_hook_bus
 from autocontext.loop.generation_runner import GenerationRunner
@@ -114,8 +119,6 @@ def _artifacts_from_settings(settings: AppSettings) -> ArtifactStore:
         settings,
         enable_buffered_writes=True,
     )
-
-
 
 
 def _write_json_stdout(payload: object) -> None:
@@ -244,11 +247,7 @@ def _run_agent_task(
     loop = ImprovementLoop(
         task=task,
         max_rounds=max_rounds,
-        metadata=(
-            simplicity_mode_metadata(settings.simplicity_mode)
-            if settings.simplicity_mode != "off"
-            else None
-        ),
+        metadata=(simplicity_mode_metadata(settings.simplicity_mode) if settings.simplicity_mode != "off" else None),
     )
     active_run_id = run_id or f"task_{uuid.uuid4().hex[:12]}"
     sqlite.create_run(
@@ -289,6 +288,29 @@ def _run_agent_task(
         )
         raise
 
+    # AC-848: apply the same guardrail-adjusted effective_met_threshold that
+    # execution/task_runner.py::_process_task applies, via the shared
+    # agent_task_completion helpers, so the two execution paths cannot drift.
+    # There is no queued objective_verification config for a direct scenario
+    # run, so only the evaluator guardrail (judge_samples / bias probes) can
+    # veto here.
+    guardrail_config = TaskConfig(
+        judge_samples=settings.judge_samples,
+        judge_temperature=settings.judge_temperature,
+        judge_disagreement_threshold=settings.judge_disagreement_threshold,
+        judge_bias_probes_enabled=settings.judge_bias_probes_enabled,
+    )
+    evaluator_guardrail = build_evaluator_guardrail_payload(
+        task,
+        result.best_output,
+        guardrail_config,
+    )
+    effective_met_threshold = compute_effective_met_threshold(
+        result.met_threshold,
+        None,
+        evaluator_guardrail,
+    )
+
     sqlite.append_agent_output(active_run_id, 1, "competitor", result.best_output)
     sqlite.upsert_generation(
         active_run_id,
@@ -309,7 +331,7 @@ def _run_agent_task(
         best_score=result.best_score,
         best_output=result.best_output,
         total_rounds=result.total_rounds,
-        met_threshold=result.met_threshold,
+        met_threshold=effective_met_threshold,
         termination_reason=result.termination_reason,
         optimizer_metadata=getattr(result, "metadata", {}) or None,
     )
@@ -856,10 +878,6 @@ def mcp_serve() -> None:
     run_server()
 
 
-
-
-
-
 @app.command()
 def simulate(
     description: str = typer.Option("", "--description", "-d", help="Plain-language description of what to simulate"),
@@ -1038,8 +1056,6 @@ def investigate(
         write_json_stderr=_write_json_stderr,
         check_json_exit=_check_json_exit,
     )
-
-
 
 
 @app.command()

--- a/autocontext/src/autocontext/cli.py
+++ b/autocontext/src/autocontext/cli.py
@@ -300,15 +300,28 @@ def _run_agent_task(
         judge_disagreement_threshold=settings.judge_disagreement_threshold,
         judge_bias_probes_enabled=settings.judge_bias_probes_enabled,
     )
-    evaluator_guardrail = build_evaluator_guardrail_payload(
-        task,
-        result.best_output,
-        guardrail_config,
-    )
+    # The guardrail re-runs the live judge, so it must run inside the same
+    # hook-bus context as the loop's judge calls (above), and it must see the
+    # same prepared/validated ``state`` the loop ran against -- not a fresh
+    # ``task.initial_state()`` that would drop any injected context.
+    with active_hook_bus(hook_bus):
+        evaluator_guardrail = build_evaluator_guardrail_payload(
+            task,
+            result.best_output,
+            guardrail_config,
+            state=state,
+        )
     effective_met_threshold = compute_effective_met_threshold(
         result.met_threshold,
         None,
         evaluator_guardrail,
+    )
+    # When a guardrail vetoes a loop that met the threshold, the persisted
+    # termination_reason/gate_decision must not still claim "threshold_met".
+    # Mirror the ``"threshold_met" if effective else "max_rounds"`` derivation
+    # in execution/task_runner.py::_run_task_multi_generation.
+    effective_termination_reason = (
+        "max_rounds" if result.met_threshold and not effective_met_threshold else result.termination_reason
     )
 
     sqlite.append_agent_output(active_run_id, 1, "competitor", result.best_output)
@@ -320,7 +333,7 @@ def _run_agent_task(
         elo=0.0,
         wins=0,
         losses=0,
-        gate_decision=result.termination_reason,
+        gate_decision=effective_termination_reason,
         status="completed",
         duration_seconds=(result.duration_ms / 1000.0) if result.duration_ms is not None else None,
     )
@@ -332,7 +345,7 @@ def _run_agent_task(
         best_output=result.best_output,
         total_rounds=result.total_rounds,
         met_threshold=effective_met_threshold,
-        termination_reason=result.termination_reason,
+        termination_reason=effective_termination_reason,
         optimizer_metadata=getattr(result, "metadata", {}) or None,
     )
 

--- a/autocontext/src/autocontext/execution/agent_task_completion.py
+++ b/autocontext/src/autocontext/execution/agent_task_completion.py
@@ -1,0 +1,205 @@
+"""Shared payload/guardrail/threshold assembly for agent-task completion.
+
+Both the queued-task runner (``execution/task_runner.py``) and the direct
+CLI agent-task path (``cli.py::_run_agent_task``) run an ``ImprovementLoop``
+and then have to decide whether the result actually clears the quality bar
+once objective and evaluator guardrails are taken into account. This module
+is the single place that assembly happens (AC-848) so the two call sites
+cannot drift apart.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from autocontext.execution.objective_verification import (
+    ObjectiveVerificationConfig,
+    run_objective_verification,
+)
+from autocontext.execution.rubric_calibration import run_judge_calibration
+from autocontext.execution.verification_dataset import enrich_objective_payload
+from autocontext.harness.pipeline.objective_guardrail import (
+    evaluate_objective_guardrail,
+    resolve_objective_guardrail_policy,
+)
+from autocontext.simplicity import normalize_simplicity_mode
+
+if TYPE_CHECKING:
+    from autocontext.execution.task_queue_store import TaskQueueStore
+    from autocontext.providers.base import LLMProvider
+    from autocontext.scenarios.agent_task import AgentTaskInterface
+
+
+@dataclass(slots=True)
+class TaskConfig:
+    """Configuration for a queued task run."""
+
+    generations: int = 1
+    max_rounds: int = 5
+    quality_threshold: float = 0.9
+    min_rounds: int = 1
+    reference_context: str | None = None
+    browser_url: str | None = None
+    required_concepts: list[str] | None = None
+    calibration_examples: list[dict] | None = None
+    initial_output: str | None = None
+    rubric: str | None = None
+    task_prompt: str | None = None
+    revision_prompt: str | None = None
+    objective_verification: dict[str, Any] | None = None
+    judge_samples: int = 1
+    judge_temperature: float = 0.0
+    judge_disagreement_threshold: float = 0.15
+    judge_bias_probes_enabled: bool = False
+    simplicity_mode: str = "off"
+
+    @classmethod
+    def from_json(cls, data: str | None) -> TaskConfig:
+        if not data:
+            return cls()
+        parsed = json.loads(data)
+        return cls(
+            generations=parsed.get("generations", 1),
+            max_rounds=parsed.get("max_rounds", 5),
+            quality_threshold=parsed.get("quality_threshold", 0.9),
+            min_rounds=parsed.get("min_rounds", 1),
+            reference_context=parsed.get("reference_context"),
+            browser_url=parsed.get("browser_url"),
+            required_concepts=parsed.get("required_concepts"),
+            calibration_examples=parsed.get("calibration_examples"),
+            initial_output=parsed.get("initial_output"),
+            rubric=parsed.get("rubric"),
+            task_prompt=parsed.get("task_prompt"),
+            revision_prompt=parsed.get("revision_prompt"),
+            objective_verification=parsed.get("objective_verification"),
+            judge_samples=parsed.get("judge_samples", 1),
+            judge_temperature=parsed.get("judge_temperature", 0.0),
+            judge_disagreement_threshold=parsed.get("judge_disagreement_threshold", 0.15),
+            judge_bias_probes_enabled=parsed.get("judge_bias_probes_enabled", False),
+            simplicity_mode=normalize_simplicity_mode(parsed.get("simplicity_mode")),
+        )
+
+
+def build_objective_payload(
+    output: str,
+    rubric_score: float,
+    config: TaskConfig,
+    *,
+    run_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Run optional objective verification for a task result."""
+    if not config.objective_verification:
+        return None
+    verification_config = ObjectiveVerificationConfig.from_dict(config.objective_verification)
+    if not verification_config.ground_truth:
+        dataset_id = config.objective_verification.get("dataset_id")
+        if dataset_id:
+            msg = f"Queued task objective_verification references dataset '{dataset_id}' but was not resolved before execution"
+            raise ValueError(msg)
+        return None
+    payload = run_objective_verification(
+        output=output,
+        rubric_score=rubric_score,
+        config=verification_config,
+    )
+    return enrich_objective_payload(
+        payload,
+        run_id=run_id,
+        created_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    )
+
+
+def build_objective_revision_feedback(
+    output: str,
+    rubric_score: float,
+    config: TaskConfig,
+) -> str | None:
+    """Build optional oracle-derived revision context for the next loop round."""
+    payload = build_objective_payload(output, rubric_score, config)
+    if not payload:
+        return None
+    revision_feedback = payload.get("revision_feedback")
+    if not isinstance(revision_feedback, dict):
+        return None
+    context = revision_feedback.get("revision_prompt_context")
+    if not isinstance(context, str) or not context.strip():
+        return None
+    return context
+
+
+def build_objective_guardrail_payload(
+    objective_payload: dict[str, Any] | None,
+    config: TaskConfig,
+) -> dict[str, Any] | None:
+    """Build optional binding guardrail results from an objective payload."""
+    if objective_payload is None or not config.objective_verification:
+        return None
+    policy = resolve_objective_guardrail_policy(config.objective_verification)
+    result = evaluate_objective_guardrail(objective_payload, policy)
+    return result.to_dict() if result is not None else None
+
+
+def build_evaluator_guardrail_payload(
+    task: AgentTaskInterface,
+    output: str,
+    config: TaskConfig,
+    *,
+    reference_context: str | None = None,
+) -> dict[str, Any] | None:
+    """Run live evaluator guardrails on the best output when enabled."""
+    if config.judge_samples <= 1 and not config.judge_bias_probes_enabled:
+        return None
+    evaluation = task.evaluate_output(
+        output,
+        task.initial_state(),
+        reference_context=reference_context,
+        required_concepts=config.required_concepts,
+        calibration_examples=config.calibration_examples,
+    )
+    return evaluation.evaluator_guardrail
+
+
+def build_rubric_calibration_payload(
+    *,
+    store: TaskQueueStore,
+    spec_name: str,
+    task_prompt: str,
+    rubric: str,
+    provider: LLMProvider,
+    model: str,
+    reference_context: str | None = None,
+    required_concepts: list[str] | None = None,
+) -> dict[str, Any] | None:
+    """Run live rubric calibration against stored human feedback anchors."""
+    calibration_examples = store.get_calibration_examples(spec_name, limit=5)
+    report = run_judge_calibration(
+        domain=spec_name,
+        task_prompt=task_prompt,
+        rubric=rubric,
+        provider=provider,
+        model=model or provider.default_model(),
+        calibration_examples=calibration_examples,
+        reference_context=reference_context,
+        required_concepts=required_concepts,
+    )
+    return report.to_dict() if report is not None else None
+
+
+def compute_effective_met_threshold(
+    met_threshold: bool,
+    objective_guardrail: dict[str, Any] | None,
+    evaluator_guardrail: dict[str, Any] | None,
+) -> bool:
+    """Apply guardrail-adjusted gating to a raw met_threshold result.
+
+    A guardrail that did not run (``None``) never vetoes; a guardrail that
+    ran must have ``passed`` for the threshold to hold.
+    """
+    return (
+        met_threshold
+        and (objective_guardrail is None or bool(objective_guardrail.get("passed")))
+        and (evaluator_guardrail is None or bool(evaluator_guardrail.get("passed")))
+    )

--- a/autocontext/src/autocontext/execution/agent_task_completion.py
+++ b/autocontext/src/autocontext/execution/agent_task_completion.py
@@ -148,13 +148,20 @@ def build_evaluator_guardrail_payload(
     config: TaskConfig,
     *,
     reference_context: str | None = None,
+    state: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
-    """Run live evaluator guardrails on the best output when enabled."""
+    """Run live evaluator guardrails on the best output when enabled.
+
+    ``state`` should be the same prepared/validated state the
+    ``ImprovementLoop`` ran against so the guardrail re-evaluates the best
+    output under identical context. When omitted it falls back to a fresh
+    ``task.initial_state()``.
+    """
     if config.judge_samples <= 1 and not config.judge_bias_probes_enabled:
         return None
     evaluation = task.evaluate_output(
         output,
-        task.initial_state(),
+        task.initial_state() if state is None else state,
         reference_context=reference_context,
         required_concepts=config.required_concepts,
         calibration_examples=config.calibration_examples,

--- a/autocontext/src/autocontext/execution/task_runner.py
+++ b/autocontext/src/autocontext/execution/task_runner.py
@@ -13,13 +13,21 @@ import signal
 import time
 import traceback
 import uuid
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from autocontext.notifications.base import Notifier
 
 from autocontext.config.settings import AppSettings
+from autocontext.execution.agent_task_completion import (
+    TaskConfig,
+    build_evaluator_guardrail_payload,
+    build_objective_guardrail_payload,
+    build_objective_payload,
+    build_objective_revision_feedback,
+    build_rubric_calibration_payload,
+    compute_effective_met_threshold,
+)
 from autocontext.execution.agent_task_evolution import (
     AgentTaskEvolutionRunner,
     AgentTaskGenerationEvaluation,
@@ -28,80 +36,20 @@ from autocontext.execution.agent_task_evolution import (
 from autocontext.execution.evaluator_guardrail import evaluate_evaluator_guardrail
 from autocontext.execution.improvement_loop import ImprovementLoop, ImprovementResult
 from autocontext.execution.judge import LLMJudge
-from autocontext.execution.objective_verification import (
-    ObjectiveVerificationConfig,
-    run_objective_verification,
-)
 from autocontext.execution.queued_task_browser_context import (
     QueuedTaskBrowserContextService,
     create_queued_task_browser_context_service,
 )
-from autocontext.execution.rubric_calibration import run_judge_calibration
 from autocontext.execution.simple_agent_task_workflow import (
     generate_simple_agent_task_output,
     revise_simple_agent_task_output,
 )
 from autocontext.execution.task_queue_store import TaskQueueEnqueueStore, TaskQueueStore
-from autocontext.execution.verification_dataset import enrich_objective_payload
-from autocontext.harness.pipeline.objective_guardrail import (
-    evaluate_objective_guardrail,
-    resolve_objective_guardrail_policy,
-)
 from autocontext.providers.base import LLMProvider
 from autocontext.scenarios.agent_task import AgentTaskInterface, AgentTaskResult
 from autocontext.simplicity import normalize_simplicity_mode
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(slots=True)
-class TaskConfig:
-    """Configuration for a queued task run."""
-
-    generations: int = 1
-    max_rounds: int = 5
-    quality_threshold: float = 0.9
-    min_rounds: int = 1
-    reference_context: str | None = None
-    browser_url: str | None = None
-    required_concepts: list[str] | None = None
-    calibration_examples: list[dict] | None = None
-    initial_output: str | None = None
-    rubric: str | None = None
-    task_prompt: str | None = None
-    revision_prompt: str | None = None
-    objective_verification: dict[str, Any] | None = None
-    judge_samples: int = 1
-    judge_temperature: float = 0.0
-    judge_disagreement_threshold: float = 0.15
-    judge_bias_probes_enabled: bool = False
-    simplicity_mode: str = "off"
-
-    @classmethod
-    def from_json(cls, data: str | None) -> TaskConfig:
-        if not data:
-            return cls()
-        parsed = json.loads(data)
-        return cls(
-            generations=parsed.get("generations", 1),
-            max_rounds=parsed.get("max_rounds", 5),
-            quality_threshold=parsed.get("quality_threshold", 0.9),
-            min_rounds=parsed.get("min_rounds", 1),
-            reference_context=parsed.get("reference_context"),
-            browser_url=parsed.get("browser_url"),
-            required_concepts=parsed.get("required_concepts"),
-            calibration_examples=parsed.get("calibration_examples"),
-            initial_output=parsed.get("initial_output"),
-            rubric=parsed.get("rubric"),
-            task_prompt=parsed.get("task_prompt"),
-            revision_prompt=parsed.get("revision_prompt"),
-            objective_verification=parsed.get("objective_verification"),
-            judge_samples=parsed.get("judge_samples", 1),
-            judge_temperature=parsed.get("judge_temperature", 0.0),
-            judge_disagreement_threshold=parsed.get("judge_disagreement_threshold", 0.15),
-            judge_bias_probes_enabled=parsed.get("judge_bias_probes_enabled", False),
-            simplicity_mode=normalize_simplicity_mode(parsed.get("simplicity_mode")),
-        )
 
 
 def _serialize_result(
@@ -114,13 +62,15 @@ def _serialize_result(
     """Serialize an ImprovementResult to JSON."""
     rounds = []
     for r in result.rounds:
-        rounds.append({
-            "round_number": r.round_number,
-            "score": r.score,
-            "reasoning": r.reasoning,
-            "dimension_scores": r.dimension_scores,
-            "is_revision": r.is_revision,
-        })
+        rounds.append(
+            {
+                "round_number": r.round_number,
+                "score": r.score,
+                "reasoning": r.reasoning,
+                "dimension_scores": r.dimension_scores,
+                "is_revision": r.is_revision,
+            }
+        )
     data: dict[str, Any] = {
         "rounds": rounds,
         "best_score": result.best_score,
@@ -180,18 +130,9 @@ def _serialize_evolution_result(
             "best_round": result.best_round,
             "total_rounds": result.total_rounds,
             "met_threshold": result.met_threshold,
-            **(
-                {"pareto_frontier": result.pareto_frontier}
-                if result.pareto_frontier else {}
-            ),
-            **(
-                {"actionable_side_info": result.actionable_side_info}
-                if result.actionable_side_info else {}
-            ),
-            **(
-                {"optimizer_metadata": result.metadata}
-                if result.metadata else {}
-            ),
+            **({"pareto_frontier": result.pareto_frontier} if result.pareto_frontier else {}),
+            **({"actionable_side_info": result.actionable_side_info} if result.actionable_side_info else {}),
+            **({"optimizer_metadata": result.metadata} if result.metadata else {}),
         }
         for idx, result in enumerate(generation_results)
     ]
@@ -203,9 +144,7 @@ def _serialize_evolution_result(
         "rounds": final_rounds,
         "best_score": trajectory.metadata.get("best_score", trajectory.final_score),
         "met_threshold": (
-            met_threshold
-            if met_threshold is not None
-            else any(result.met_threshold for result in generation_results)
+            met_threshold if met_threshold is not None else any(result.met_threshold for result in generation_results)
         ),
         "total_rounds": sum(result.total_rounds for result in generation_results),
     }
@@ -226,114 +165,6 @@ def _serialize_evolution_result(
         if final_result.metadata:
             data["optimizer_metadata"] = final_result.metadata
     return json.dumps(data)
-
-
-def _build_objective_payload(
-    output: str,
-    rubric_score: float,
-    config: TaskConfig,
-    *,
-    run_id: str | None = None,
-) -> dict[str, Any] | None:
-    """Run optional objective verification for a task result."""
-    if not config.objective_verification:
-        return None
-    verification_config = ObjectiveVerificationConfig.from_dict(config.objective_verification)
-    if not verification_config.ground_truth:
-        dataset_id = config.objective_verification.get("dataset_id")
-        if dataset_id:
-            msg = (
-                "Queued task objective_verification references dataset "
-                f"'{dataset_id}' but was not resolved before execution"
-            )
-            raise ValueError(msg)
-        return None
-    payload = run_objective_verification(
-        output=output,
-        rubric_score=rubric_score,
-        config=verification_config,
-    )
-    return enrich_objective_payload(
-        payload,
-        run_id=run_id,
-        created_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-    )
-
-
-def _build_objective_revision_feedback(
-    output: str,
-    rubric_score: float,
-    config: TaskConfig,
-) -> str | None:
-    """Build optional oracle-derived revision context for the next loop round."""
-    payload = _build_objective_payload(output, rubric_score, config)
-    if not payload:
-        return None
-    revision_feedback = payload.get("revision_feedback")
-    if not isinstance(revision_feedback, dict):
-        return None
-    context = revision_feedback.get("revision_prompt_context")
-    if not isinstance(context, str) or not context.strip():
-        return None
-    return context
-
-
-def _build_objective_guardrail_payload(
-    objective_payload: dict[str, Any] | None,
-    config: TaskConfig,
-) -> dict[str, Any] | None:
-    """Build optional binding guardrail results from an objective payload."""
-    if objective_payload is None or not config.objective_verification:
-        return None
-    policy = resolve_objective_guardrail_policy(config.objective_verification)
-    result = evaluate_objective_guardrail(objective_payload, policy)
-    return result.to_dict() if result is not None else None
-
-
-def _build_evaluator_guardrail_payload(
-    task: AgentTaskInterface,
-    output: str,
-    config: TaskConfig,
-    *,
-    reference_context: str | None = None,
-) -> dict[str, Any] | None:
-    """Run live evaluator guardrails on the best output when enabled."""
-    if config.judge_samples <= 1 and not config.judge_bias_probes_enabled:
-        return None
-    evaluation = task.evaluate_output(
-        output,
-        task.initial_state(),
-        reference_context=reference_context,
-        required_concepts=config.required_concepts,
-        calibration_examples=config.calibration_examples,
-    )
-    return evaluation.evaluator_guardrail
-
-
-def _build_rubric_calibration_payload(
-    *,
-    store: TaskQueueStore,
-    spec_name: str,
-    task_prompt: str,
-    rubric: str,
-    provider: LLMProvider,
-    model: str,
-    reference_context: str | None = None,
-    required_concepts: list[str] | None = None,
-) -> dict[str, Any] | None:
-    """Run live rubric calibration against stored human feedback anchors."""
-    calibration_examples = store.get_calibration_examples(spec_name, limit=5)
-    report = run_judge_calibration(
-        domain=spec_name,
-        task_prompt=task_prompt,
-        rubric=rubric,
-        provider=provider,
-        model=model or provider.default_model(),
-        calibration_examples=calibration_examples,
-        reference_context=reference_context,
-        required_concepts=required_concepts,
-    )
-    return report.to_dict() if report is not None else None
 
 
 class SimpleAgentTask(AgentTaskInterface):
@@ -418,11 +249,7 @@ class SimpleAgentTask(AgentTaskInterface):
             reasoning=judge_result.reasoning,
             dimension_scores=judge_result.dimension_scores,
             internal_retries=judge_result.internal_retries,
-            evaluator_guardrail=(
-                evaluator_guardrail.to_dict()
-                if evaluator_guardrail is not None
-                else None
-            ),
+            evaluator_guardrail=(evaluator_guardrail.to_dict() if evaluator_guardrail is not None else None),
         )
 
     def generate_output(self, state: dict) -> str:
@@ -448,11 +275,7 @@ class SimpleAgentTask(AgentTaskInterface):
             revision_prompt=self._revision_prompt,
             reference_context=state.get("reference_context"),
             required_concepts=state.get("required_concepts"),
-            objective_feedback=(
-                objective_feedback
-                if isinstance(objective_feedback, str)
-                else None
-            ),
+            objective_feedback=(objective_feedback if isinstance(objective_feedback, str) else None),
             simplicity_mode=self._simplicity_mode,
         )
 
@@ -499,7 +322,8 @@ class TaskRunner:
 
         logger.info(
             "task runner started (poll_interval=%.1fs, concurrency=%d)",
-            self.poll_interval, self.concurrency,
+            self.poll_interval,
+            self.concurrency,
         )
 
         while not self._shutdown:
@@ -597,10 +421,12 @@ class TaskRunner:
             initial_output = config.initial_output
             if not initial_output:
                 logger.info("generating initial output for task %s", task_id)
-                initial_output = agent_task.generate_output({
-                    "reference_context": reference_context,
-                    "required_concepts": config.required_concepts,
-                })
+                initial_output = agent_task.generate_output(
+                    {
+                        "reference_context": reference_context,
+                        "required_concepts": config.required_concepts,
+                    }
+                )
             if config.generations > 1:
                 result = self._run_task_multi_generation(
                     task_id=task_id,
@@ -622,8 +448,8 @@ class TaskRunner:
                     "required_concepts": config.required_concepts,
                 }
                 if config.objective_verification:
-                    loop_state["revision_feedback_callback"] = (
-                        lambda current_output, judge_result: _build_objective_revision_feedback(
+                    loop_state["revision_feedback_callback"] = lambda current_output, judge_result: (
+                        build_objective_revision_feedback(
                             current_output,
                             judge_result.score,
                             config,
@@ -637,29 +463,29 @@ class TaskRunner:
                     required_concepts=config.required_concepts,
                     calibration_examples=config.calibration_examples,
                 )
-                objective_payload = _build_objective_payload(
+                objective_payload = build_objective_payload(
                     result.best_output,
                     result.best_score,
                     config,
                     run_id=task_id,
                 )
-                objective_guardrail = _build_objective_guardrail_payload(
+                objective_guardrail = build_objective_guardrail_payload(
                     objective_payload,
                     config,
                 )
-                evaluator_guardrail = _build_evaluator_guardrail_payload(
+                evaluator_guardrail = build_evaluator_guardrail_payload(
                     agent_task,
                     result.best_output,
                     config,
                     reference_context=reference_context,
                 )
-                effective_met_threshold = result.met_threshold and (
-                    objective_guardrail is None or bool(objective_guardrail.get("passed"))
-                ) and (
-                    evaluator_guardrail is None or bool(evaluator_guardrail.get("passed"))
+                effective_met_threshold = compute_effective_met_threshold(
+                    result.met_threshold,
+                    objective_guardrail,
+                    evaluator_guardrail,
                 )
                 result.met_threshold = effective_met_threshold
-                rubric_calibration = _build_rubric_calibration_payload(
+                rubric_calibration = build_rubric_calibration_payload(
                     store=self.store,
                     spec_name=spec_name,
                     task_prompt=agent_task.get_task_prompt({}),
@@ -687,7 +513,10 @@ class TaskRunner:
 
             logger.info(
                 "task %s completed: score=%.2f rounds=%d threshold_met=%s",
-                task_id, result.best_score, result.total_rounds, result.met_threshold,
+                task_id,
+                result.best_score,
+                result.total_rounds,
+                result.met_threshold,
             )
 
             self._emit_completion_event(task_id, spec_name, result)
@@ -731,12 +560,10 @@ class TaskRunner:
                 "required_concepts": config.required_concepts,
             }
             if config.objective_verification:
-                loop_state["revision_feedback_callback"] = (
-                    lambda current_output, judge_result: _build_objective_revision_feedback(
-                        current_output,
-                        judge_result.score,
-                        config,
-                    )
+                loop_state["revision_feedback_callback"] = lambda current_output, judge_result: build_objective_revision_feedback(
+                    current_output,
+                    judge_result.score,
+                    config,
                 )
             loop_result = loop.run(
                 initial_output=output,
@@ -777,28 +604,28 @@ class TaskRunner:
         met_threshold = any(result.met_threshold for result in ordered_results)
         best_score = state.best_score
         best_output = state.best_output
-        objective_payload = _build_objective_payload(
+        objective_payload = build_objective_payload(
             best_output,
             best_score,
             config,
             run_id=task_id,
         )
-        objective_guardrail = _build_objective_guardrail_payload(
+        objective_guardrail = build_objective_guardrail_payload(
             objective_payload,
             config,
         )
-        evaluator_guardrail = _build_evaluator_guardrail_payload(
+        evaluator_guardrail = build_evaluator_guardrail_payload(
             agent_task,
             best_output,
             config,
             reference_context=reference_context,
         )
-        effective_met_threshold = met_threshold and (
-            objective_guardrail is None or bool(objective_guardrail.get("passed"))
-        ) and (
-            evaluator_guardrail is None or bool(evaluator_guardrail.get("passed"))
+        effective_met_threshold = compute_effective_met_threshold(
+            met_threshold,
+            objective_guardrail,
+            evaluator_guardrail,
         )
-        rubric_calibration = _build_rubric_calibration_payload(
+        rubric_calibration = build_rubric_calibration_payload(
             store=self.store,
             spec_name=spec_name,
             task_prompt=agent_task.get_task_prompt({}),
@@ -857,9 +684,7 @@ class TaskRunner:
             reference_context=config.reference_context,
         )
 
-    def _emit_completion_event(
-        self, task_id: str, spec_name: str, result: ImprovementResult
-    ) -> None:
+    def _emit_completion_event(self, task_id: str, spec_name: str, result: ImprovementResult) -> None:
         if not self.notifier:
             return
         try:
@@ -926,11 +751,7 @@ def create_task_runner_from_settings(
     concurrency: int = 1,
 ) -> TaskRunner:
     """Build a task runner from app settings with optional browser enrichment."""
-    browser_context_service = (
-        create_queued_task_browser_context_service(settings)
-        if settings.browser_enabled
-        else None
-    )
+    browser_context_service = create_queued_task_browser_context_service(settings) if settings.browser_enabled else None
     return TaskRunner(
         store=store,
         provider=provider,

--- a/autocontext/tests/test_cli_agent_task.py
+++ b/autocontext/tests/test_cli_agent_task.py
@@ -1,4 +1,5 @@
 """Tests for AC-231: direct agent-task execution support in the Python CLI."""
+
 from __future__ import annotations
 
 import dataclasses
@@ -260,6 +261,60 @@ class TestAgentTaskServeRejection:
             result = runner.invoke(app, ["run", "--serve", "--scenario", "mock_task"])
 
         assert result.exit_code == 2
+
+
+class _EvaluatorGuardrailFailTask(_MockAgentTask):
+    """Task whose judge reports a failed evaluator guardrail (AC-848).
+
+    Mirrors what execution/task_runner.py::_process_task sees when
+    ``config.judge_bias_probes_enabled`` (or ``judge_samples > 1``) triggers
+    a live evaluator guardrail check on the best output.
+    """
+
+    def evaluate_output(
+        self,
+        output: str,
+        state: dict,
+        reference_context: str | None = None,
+        required_concepts: list[str] | None = None,
+        calibration_examples: list[dict] | None = None,
+        pinned_dimensions: list[str] | None = None,
+    ) -> AgentTaskResult:
+        return AgentTaskResult(
+            score=0.95,
+            reasoning="judge liked it",
+            dimension_scores={"quality": 0.95},
+            evaluator_guardrail={
+                "passed": False,
+                "reason": "judge disagreement exceeded threshold",
+                "violations": ["judge disagreement exceeded threshold"],
+            },
+        )
+
+
+class TestAgentTaskGuardrailParity:
+    """AC-848: CLI path must apply the same guardrail-adjusted
+    effective_met_threshold as execution/task_runner.py::_process_task."""
+
+    def test_evaluator_guardrail_forces_met_threshold_false(self, tmp_path: Path) -> None:
+        settings = _settings(tmp_path).model_copy(update={"judge_bias_probes_enabled": True})
+        loop_result = _FakeLoopResult()
+        loop_result.met_threshold = True
+        with (
+            patch("autocontext.cli.SCENARIO_REGISTRY", {"mock_task": _EvaluatorGuardrailFailTask}),
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._resolve_agent_task_runtime", return_value=(_FakeProvider(), "runtime-model")),
+            patch("autocontext.cli.ImprovementLoop") as mock_loop,
+        ):
+            mock_loop.return_value.run.return_value = loop_result
+            result = runner.invoke(app, ["run", "--json", "--scenario", "mock_task", "--run-id", "task-guardrail-001"])
+
+        assert result.exit_code == 0, result.stderr
+        data = json.loads(result.stdout.strip())
+        # The loop itself reported met_threshold=True, but the evaluator
+        # guardrail failed, so the effective (guardrail-adjusted) result
+        # must be False -- the same gate execution/task_runner.py applies.
+        assert data["met_threshold"] is False
 
 
 class TestAgentTaskRunSummary:

--- a/autocontext/tests/test_cli_agent_task.py
+++ b/autocontext/tests/test_cli_agent_task.py
@@ -292,6 +292,37 @@ class _EvaluatorGuardrailFailTask(_MockAgentTask):
         )
 
 
+class _PreparedStateGuardrailTask(_ContextTask):
+    """Guardrail evaluation must receive the prepared context state (AC-848).
+
+    ``_ContextTask.prepare_context`` injects ``prepared=True``; a guardrail
+    evaluated against the raw ``initial_state()`` would not see it. This task
+    passes the guardrail only when the prepared state reaches it, so the test
+    distinguishes prepared-state wiring from an ``initial_state()`` fallback.
+    """
+
+    def evaluate_output(
+        self,
+        output: str,
+        state: dict,
+        reference_context: str | None = None,
+        required_concepts: list[str] | None = None,
+        calibration_examples: list[dict] | None = None,
+        pinned_dimensions: list[str] | None = None,
+    ) -> AgentTaskResult:
+        prepared = bool(state.get("prepared"))
+        return AgentTaskResult(
+            score=0.95,
+            reasoning="checked state",
+            dimension_scores={"quality": 0.95},
+            evaluator_guardrail={
+                "passed": prepared,
+                "reason": "prepared context present" if prepared else "guardrail saw stale initial state",
+                "violations": [] if prepared else ["guardrail saw stale initial state"],
+            },
+        )
+
+
 class TestAgentTaskGuardrailParity:
     """AC-848: CLI path must apply the same guardrail-adjusted
     effective_met_threshold as execution/task_runner.py::_process_task."""
@@ -315,6 +346,62 @@ class TestAgentTaskGuardrailParity:
         # guardrail failed, so the effective (guardrail-adjusted) result
         # must be False -- the same gate execution/task_runner.py applies.
         assert data["met_threshold"] is False
+
+    def test_guardrail_veto_does_not_persist_threshold_met(self, tmp_path: Path) -> None:
+        """A veto that flips met_threshold True->False must not leave the
+        termination_reason/gate_decision claiming "threshold_met" (mirrors the
+        ``"threshold_met" if effective else "max_rounds"`` derivation in
+        execution/task_runner.py::_run_task_multi_generation)."""
+        settings = _settings(tmp_path).model_copy(update={"judge_bias_probes_enabled": True})
+        loop_result = _FakeLoopResult()
+        loop_result.met_threshold = True
+        loop_result.termination_reason = "threshold_met"
+        with (
+            patch("autocontext.cli.SCENARIO_REGISTRY", {"mock_task": _EvaluatorGuardrailFailTask}),
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._resolve_agent_task_runtime", return_value=(_FakeProvider(), "runtime-model")),
+            patch("autocontext.cli.ImprovementLoop") as mock_loop,
+        ):
+            mock_loop.return_value.run.return_value = loop_result
+            result = runner.invoke(app, ["run", "--json", "--scenario", "mock_task", "--run-id", "task-guardrail-veto-001"])
+
+        assert result.exit_code == 0, result.stderr
+        data = json.loads(result.stdout.strip())
+        assert data["met_threshold"] is False
+        # Coherent termination: not still "threshold_met".
+        assert data["termination_reason"] != "threshold_met"
+        assert data["termination_reason"] == "max_rounds"
+
+        # The persisted gate_decision must match the coherent termination.
+        store = SQLiteStore(settings.db_path)
+        with store.connect() as conn:
+            gen_row = conn.execute(
+                "SELECT gate_decision FROM generations WHERE run_id = ? AND generation_index = 1",
+                ("task-guardrail-veto-001",),
+            ).fetchone()
+        assert gen_row is not None
+        assert gen_row["gate_decision"] == "max_rounds"
+
+    def test_guardrail_receives_prepared_state_not_initial_state(self, tmp_path: Path) -> None:
+        """The evaluator guardrail must re-evaluate against the same prepared
+        state the ImprovementLoop used, not a fresh ``task.initial_state()``."""
+        settings = _settings(tmp_path).model_copy(update={"judge_bias_probes_enabled": True})
+        loop_result = _FakeLoopResult()
+        loop_result.met_threshold = True
+        with (
+            patch("autocontext.cli.SCENARIO_REGISTRY", {"mock_task": _PreparedStateGuardrailTask}),
+            patch("autocontext.cli.load_settings", return_value=settings),
+            patch("autocontext.cli._resolve_agent_task_runtime", return_value=(_FakeProvider(), "runtime-model")),
+            patch("autocontext.cli.ImprovementLoop") as mock_loop,
+        ):
+            mock_loop.return_value.run.return_value = loop_result
+            result = runner.invoke(app, ["run", "--json", "--scenario", "mock_task", "--run-id", "task-guardrail-prep-001"])
+
+        assert result.exit_code == 0, result.stderr
+        data = json.loads(result.stdout.strip())
+        # The guardrail only passes when it received the prepared state; a
+        # fallback to initial_state() would veto and flip this to False.
+        assert data["met_threshold"] is True
 
 
 class TestAgentTaskRunSummary:

--- a/autocontext/uv.lock
+++ b/autocontext/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 2
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [options]
 exclude-newer = "2026-04-10T14:55:41Z"
@@ -62,6 +66,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload_time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload_time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload_time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload_time = "2025-10-20T03:33:33.021Z" },
 ]
 
 [[package]]
@@ -133,6 +146,7 @@ primeintellect = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "datamodel-code-generator" },
     { name = "httpx" },
     { name = "hypothesis" },
     { name = "mypy" },
@@ -175,6 +189,7 @@ provides-extras = ["browser", "primeintellect", "mcp", "agent-sdk", "monty", "ml
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "datamodel-code-generator", specifier = ">=0.56.0,<0.57.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "hypothesis", specifier = ">=6.151.12" },
     { name = "mypy", specifier = ">=1.16.0" },
@@ -185,6 +200,43 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.12.0" },
     { name = "websockets", specifier = ">=16.0" },
+]
+
+[[package]]
+name = "black"
+version = "26.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload_time = "2026-03-12T03:36:03.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/57/5f11c92861f9c92eb9dddf515530bc2d06db843e44bdcf1c83c1427824bc/black-26.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff", size = 1851987, upload_time = "2026-03-12T03:40:06.248Z" },
+    { url = "https://files.pythonhosted.org/packages/54/aa/340a1463660bf6831f9e39646bf774086dbd8ca7fc3cded9d59bbdf4ad0a/black-26.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c", size = 1689499, upload_time = "2026-03-12T03:40:07.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/b726c93d717d72733da031d2de10b92c9fa4c8d0c67e8a8a372076579279/black-26.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5", size = 1754369, upload_time = "2026-03-12T03:40:09.279Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/09/61e91881ca291f150cfc9eb7ba19473c2e59df28859a11a88248b5cbbc4d/black-26.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:5e9d0d86df21f2e1677cc4bd090cd0e446278bcbbe49bf3659c308c3e402843e", size = 1413613, upload_time = "2026-03-12T03:40:10.943Z" },
+    { url = "https://files.pythonhosted.org/packages/16/73/544f23891b22e7efe4d8f812371ab85b57f6a01b2fc45e3ba2e52ba985b8/black-26.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:9a5e9f45e5d5e1c5b5c29b3bd4265dcc90e8b92cf4534520896ed77f791f4da5", size = 1219719, upload_time = "2026-03-12T03:40:12.597Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload_time = "2026-03-12T03:40:13.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload_time = "2026-03-12T03:40:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload_time = "2026-03-12T03:40:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload_time = "2026-03-12T03:40:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload_time = "2026-03-12T03:40:20.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload_time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload_time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload_time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload_time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload_time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload_time = "2026-03-12T03:40:30.964Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload_time = "2026-03-12T03:40:32.346Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload_time = "2026-03-12T03:40:33.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload_time = "2026-03-12T03:40:35.442Z" },
+    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload_time = "2026-03-12T03:40:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload_time = "2026-03-12T03:36:01.668Z" },
 ]
 
 [[package]]
@@ -641,6 +693,26 @@ nvtx = [
 ]
 
 [[package]]
+name = "datamodel-code-generator"
+version = "0.56.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "black" },
+    { name = "genson" },
+    { name = "inflect" },
+    { name = "isort" },
+    { name = "jinja2" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tomli", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/7d/7fc2bb3d8946ca45851da3f23497a2c6e252e92558ccbd89d609cf1e13d4/datamodel_code_generator-0.56.0.tar.gz", hash = "sha256:e7c003fb5421b890aabe12f66ae65b57198b04cfe1da7c40810798020835b3a8", size = 837708, upload_time = "2026-04-04T09:46:19.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/3a/7f169ffc7a2d69a4f9158b1ac083f685b7f4a1a8a1db5d1e4abbb4e741b7/datamodel_code_generator-0.56.0-py3-none-any.whl", hash = "sha256:a0559683fbe90cdf2ce9b6637e3adae3e3a8056a8d0516df581d486e2834ead2", size = 256545, upload_time = "2026-04-04T09:46:17.582Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -690,6 +762,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload_time = "2026-03-27T19:11:14.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload_time = "2026-03-27T19:11:13.595Z" },
+]
+
+[[package]]
+name = "genson"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cf/2303c8ad276dcf5ee2ad6cf69c4338fd86ef0f471a5207b069adf7a393cf/genson-1.3.0.tar.gz", hash = "sha256:e02db9ac2e3fd29e65b5286f7135762e2cd8a986537c075b06fc5f1517308e37", size = 34919, upload_time = "2024-05-15T22:08:49.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/5c/e226de133afd8bb267ec27eead9ae3d784b95b39a287ed404caab39a5f50/genson-1.3.0-py3-none-any.whl", hash = "sha256:468feccd00274cc7e4c09e84b08704270ba8d95232aa280f65b986139cec67f7", size = 21470, upload_time = "2024-05-15T22:08:47.056Z" },
 ]
 
 [[package]]
@@ -824,12 +905,34 @@ wheels = [
 ]
 
 [[package]]
+name = "inflect"
+version = "7.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload_time = "2024-12-28T17:11:18.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload_time = "2024-12-28T17:11:15.931Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload_time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload_time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload_time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload_time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]
@@ -1213,6 +1316,15 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload_time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload_time = "2026-04-09T15:01:32.21Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1565,6 +1677,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload_time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload_time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload_time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload_time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -1940,6 +2061,40 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/40/7e/0d6c82b5ccc71e7c833aed43d9e8468e1f2ff0be1b3f657a6fcafbb8433d/python_ulid-3.1.0.tar.gz", hash = "sha256:ff0410a598bc5f6b01b602851a3296ede6f91389f913a5d5f8c496003836f636", size = 93175, upload_time = "2025-08-18T16:09:26.305Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/a0/4ed6632b70a52de845df056654162acdebaf97c20e3212c559ac43e7216e/python_ulid-3.1.0-py3-none-any.whl", hash = "sha256:e2cdc979c8c877029b4b7a38a6fba3bc4578e4f109a308419ff4d3ccf0a46619", size = 11577, upload_time = "2025-08-18T16:09:25.047Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload_time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload_time = "2026-01-30T01:02:57.882Z" },
+    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload_time = "2026-01-30T01:02:59.912Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload_time = "2026-01-30T01:03:01.471Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload_time = "2026-01-30T01:03:04.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload_time = "2026-01-30T01:03:05.412Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload_time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload_time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload_time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload_time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload_time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload_time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload_time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload_time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload_time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload_time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload_time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload_time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload_time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload_time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload_time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload_time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload_time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload_time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload_time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload_time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload_time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]
@@ -2718,6 +2873,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload_time = "2026-01-20T16:01:07.278Z" },
     { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload_time = "2026-01-20T16:16:31.528Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload_time = "2026-01-20T16:01:14.236Z" },
+]
+
+[[package]]
+name = "typeguard"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/e8/66e25efcc18542d58706ce4e50415710593721aae26e794ab1dec34fb66f/typeguard-4.5.1.tar.gz", hash = "sha256:f6f8ecbbc819c9bc749983cc67c02391e16a9b43b8b27f15dc70ed7c4a007274", size = 80121, upload_time = "2026-02-19T16:09:03.392Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl", hash = "sha256:44d2bf329d49a244110a090b55f5f91aa82d9a9834ebfd30bcc73651e4a8cc40", size = 36745, upload_time = "2026-02-19T16:09:01.6Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Fixes the one behavioral bug from the code-quality sweep and closes the CI parity gap.

- AC-848: the CLI agent-task path (`_run_agent_task` in cli.py) never applied the guardrail-adjusted `effective_met_threshold` that `task_runner.py` applies, so the two execution paths behaved differently for the same task. The shared payload/guardrail/threshold assembly now lives in `execution/agent_task_completion.py` and both paths use it. TDD regression test included (drives the real `run --json` command).
- AC-849: the three Python/TS schema sync scripts (production traces, browser contract, instrument) existed but were never run in CI; the 18 shared JSON schemas were identical only by discipline. They now run in the package-boundaries job via `npm run check:schemas` under `uv run --frozen`. This surfaced that the sync scripts silently depended on `datamodel-codegen`, which was undeclared anywhere; it is now a pinned dev dependency (locked against ci.yml's UV_EXCLUDE_NEWER cutoff so resolution is deterministic).

## Testing
- New regression test asserts the CLI path applies the same guardrail-adjusted threshold as the task runner; 231 tests green across the covering suites; ruff and mypy clean.
- All three schema checks exit 0 on a clean tree; perturbation test verified the failure path (drift correctly fails, restore verified byte-identical).
- Reviewed per-task (spec + quality) plus a whole-branch final review.

Part 1 of 4 of the quality sweep. AC-850/851 (Python refactors) stack on this PR.